### PR TITLE
swap_tensors: allow observational weakrefs, block identity-container weakrefs

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10976,9 +10976,59 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
                 with self.assertRaisesRegex(RuntimeError, "AccumulateGrad node that was poisoned by swap_tensors"):
                     out.sum().backward()
 
-            _wr = weakref.ref(t1)
-            with self.assertRaisesRegex(RuntimeError, "has weakref"):
-                torch.utils.swap_tensors(t1, t2)
+            # A weakref no longer blocks the swap. It keeps pointing at the
+            # same object (identity is preserved) and observes the new content.
+            wr = weakref.ref(t1)
+            t2_id = id(t2)
+            torch.utils.swap_tensors(t1, t2)
+            self.assertIs(wr(), t1)
+            self.assertEqual(id(t2), t2_id)
+
+
+    def test_swap_allows_weakref(self):
+        from torch.utils.weak import TensorWeakRef
+
+        # A plain weakref only observes live state and does not block the swap:
+        # it keeps pointing at the same object (identity preserved) and sees the
+        # swapped-in content.
+        t1 = torch.zeros(4, 4)
+        t2 = torch.ones(4, 4)
+        wr1 = weakref.ref(t1)
+        wr2 = weakref.ref(t2)
+        torch.utils.swap_tensors(t1, t2)
+        self.assertIs(wr1(), t1)
+        self.assertIs(wr2(), t2)
+        self.assertEqual(t1, torch.ones(4, 4))
+        self.assertEqual(t2, torch.zeros(4, 4))
+
+        # Dynamo's guard weakref type on a parameter (the issue's repro) wraps a
+        # plain weakref.ref, so it is allowed too.
+        p = torch.nn.Parameter(torch.zeros(4, 4))
+        tw = TensorWeakRef(p)
+        torch.utils.swap_tensors(p, torch.nn.Parameter(torch.ones(4, 4)))
+        self.assertEqual(p, torch.ones(4, 4))
+        self.assertIs(tw(), p)
+        self.assertEqual(tw(), torch.ones(4, 4))
+
+    def test_swap_blocked_by_weak_id_dict(self):
+        # A tensor that is a key in an identity-keyed weak container carries a
+        # weakref.ref subclass (WeakIdRef). Swapping would silently corrupt that
+        # mapping (content changes behind a stable identity), so it is rejected.
+        # This is the mechanism behind nn.Module._apply raising "Couldn't swap"
+        # when a module is converted mid fake-tensor tracing (e.g. export).
+        from torch.utils.weak import WeakIdKeyDictionary
+
+        t1 = torch.zeros(4, 4)
+        t2 = torch.ones(4, 4)
+        d = WeakIdKeyDictionary()
+        d[t1] = 1
+        with self.assertRaisesRegex(RuntimeError, "has weakref"):
+            torch.utils.swap_tensors(t1, t2)
+        # Symmetric: a structural weakref on t2 also blocks.
+        t3 = torch.zeros(4, 4)
+        d[t2] = 2
+        with self.assertRaisesRegex(RuntimeError, "has weakref"):
+            torch.utils.swap_tensors(t3, t2)
 
 
     @unittest.skipIf(TEST_WITH_TORCHDYNAMO, "Dynamo adds weakrefs")

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -40,10 +40,19 @@ def swap_tensors(t1, t2):
 
     This will not work if t1 and t2 have different slots.
     """
-    # Ensure there are no weakrefs
-    if weakref.getweakrefs(t1):
+
+    # A tensor that is a key/value in an identity-keyed weak container (e.g.
+    # WeakIdKeyDictionary via WeakIdRef, or a WeakValueDictionary via KeyedRef)
+    # cannot be swapped: the swap changes the content behind a stable identity
+    # and silently corrupts the mapping. Such containers use weakref.ref
+    # subclasses. A plain weakref.ref only observes live state (e.g. Dynamo's
+    # TENSOR_MATCH guard, which re-reads metadata each check) and is safe.
+    def has_structural_weakref(t):
+        return any(type(r) is not weakref.ref for r in weakref.getweakrefs(t))
+
+    if has_structural_weakref(t1):
         raise RuntimeError("Cannot swap t1 because it has weakref associated with it")
-    if weakref.getweakrefs(t2):
+    if has_structural_weakref(t2):
         raise RuntimeError("Cannot swap t2 because it has weakref associated with it")
     t1_slots = set(copyreg._slotnames(t1.__class__))  # type: ignore[attr-defined]
     t2_slots = set(copyreg._slotnames(t2.__class__))  # type: ignore[attr-defined]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190739

Fixes #186796.

torch.utils.swap_tensors rejected either operand that carried any Python
weakref. Dynamo installs TENSOR_MATCH guards holding a
torch.utils.weak.TensorWeakRef on every traced parameter; while a compiled
artifact is live (e.g. mid-forward, when a diffusers group-offloading onload
hook runs) those weakrefs are present, so the swap raised and blocked
offloading that relies on it (required for TorchAO subclass tensors).

Rather than remove the check entirely, distinguish two kinds of weakref:

- Observational (a plain weakref.ref, e.g. Dynamo's guard, which re-reads
  live metadata each check): safe to swap under. swap_tensors preserves
  object identity and swaps content, so an observer sees the swapped-in
  content -- exactly what every strong-reference holder already sees. For a
  guard this is fail-safe: unchanged metadata reuses the graph on the new
  data; changed metadata fails the guard and recompiles.

- Structural (a weakref.ref subclass such as WeakIdRef or KeyedRef, used as
  the key/value of an identity-keyed weak container like WeakIdKeyDictionary
  or a WeakValueDictionary): swapping changes content behind a stable
  identity and silently corrupts the mapping, so it stays rejected.

This is why removing the check outright is wrong: during non-strict export a
parameter is a FakeTensor carrying WeakIdRef/KeyedRef from the fake-tensor
memo. Removing the check lets nn.Module._apply (a mid-trace .to()/.half())
swap the fake param, corrupting the memo and producing a silently broken
exported graph instead of the current fail-fast "Couldn't swap" error. The
structural/observational split keeps that guardrail while unblocking the
Dynamo case.

Alternatives: PR #186801 made TensorWeakRef a weakref.ref subclass and
allow-listed it; that was reverted (BC-breaking public-class change, and
"unnecessary"). This change touches neither TensorWeakRef nor weak.py and
block-lists the structural subclasses instead, so it needs no public-API
change. Blanket removal is tracked in #190604 but regresses
test/export/test_export.py::TestExport::test_exception.

Test Plan:

```
python test/test_torch.py -k test_swap
python test/export/test_export.py -k test_exception
python test/dynamo/test_repros.py -k swap_tensors_subclass_not_blocked_by_metaconverter_refcycle
lintrunner -a torch/utils/__init__.py test/test_torch.py
```

test_swap_blocked_by_weak_id_dict fails on the blanket-removal version and
passes here; test_swap_allows_weakref covers the plain-weakref and
TensorWeakRef cases.

Draft: opened to run CI comparing this against the blanket-removal approach.

This change was authored with the assistance of an AI coding assistant
(Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98