### PR TITLE
Drop redundant std::move on rvalue-ref lambda return in CPUBlas ukernel caches

### DIFF
--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -1159,7 +1159,7 @@ struct Brgemm : public KernelCache <BrgemmKey, GemmHelper> {
           c10::CppTypeToScalarType<scalar_t_c>::value,
           add_C);
       (*v).brg.generate();
-      return std::move(v);
+      return v;
     });
     if (get_current() != value) {
 #if defined(ONEDNN_UKERNEL_1)
@@ -1230,7 +1230,7 @@ struct Pack : public KernelCache <PackKey, pack_t> {
       if (could_pack(dt_in)) {
         (*p).generate();
       }
-      return std::move(p);
+      return p;
     });
     if (could_pack(dt_in)) {
       (*pack).execute(in, out);


### PR DESCRIPTION
`v`/`p` are `auto&&` (rvalue-ref) locals, so C++20 implicit move (P1825)
already moves them on return; the explicit `std::move` is redundant. Only built
under `ONEDNN_UKERNEL_1/2`, so it escaped `-Wredundant-move` in default CI.

Prepared with an AI agent (Claude Code); reviewed by the author.
