### PR TITLE
[c10d] Fix bfloat16 NCCL PREMUL_SUM factor being read as zero

### DIFF
--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -197,9 +197,6 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
         # Premul Sum
         if torch.cuda.nccl.version() >= (2, 11, 1):
-            # bfloat16 exercises the host-scalar path that silently zeroed the
-            # reduction when the factor was passed as a 4-byte float; the
-            # tensor factor covers the device-scalar path.
             for dtype in torch.half, torch.float, torch.double, torch.bfloat16:
                 for factor in (
                     3.0,

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -197,7 +197,10 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
         # Premul Sum
         if torch.cuda.nccl.version() >= (2, 11, 1):
-            for dtype in torch.half, torch.float, torch.double:
+            # bfloat16 exercises the host-scalar path that silently zeroed the
+            # reduction when the factor was passed as a 4-byte float; the
+            # tensor factor covers the device-scalar path.
+            for dtype in torch.half, torch.float, torch.double, torch.bfloat16:
                 for factor in (
                     3.0,
                     torch.tensor([5.0], device=local_device_id, dtype=dtype),

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -115,7 +115,12 @@ ncclRedOpRAII getNcclReduceOp(
         case ncclFloat:
           return unpackPreMulSum<float, ncclFloat>(reduceOp, comm);
         case ncclBfloat16:
-          return unpackPreMulSum<float, ncclBfloat16>(reduceOp, comm);
+          // The scalar type must match the reduction datatype: NCCL reads
+          // ncclTypeSize(dataType) bytes from the factor. Using float here
+          // made NCCL read the low 2 bytes of a 4-byte float (zero for any
+          // power-of-two host scalar such as FSDP2's 1/factor), silently
+          // zeroing the reduction, and rejected bfloat16 device factors.
+          return unpackPreMulSum<at::BFloat16, ncclBfloat16>(reduceOp, comm);
         case ncclDouble:
           return unpackPreMulSum<double, ncclDouble>(reduceOp, comm);
         default:


### PR DESCRIPTION

Fixes #190745.

## Summary

`getNcclReduceOp` dispatched bfloat16 `PreMulSum` through `unpackPreMulSum<float, ncclBfloat16>`. NCCL reads `ncclTypeSize(dataType)` = 2 bytes from the scalar factor, but it was stored as a 4-byte `float`. For a little-endian float whose low 2 bytes are zero (every power of two, including the `1/factor` FSDP2 passes for a custom `gradient_divide_factor`), NCCL received a bfloat16 zero and silently produced all-zero gradients; a bfloat16 device factor was also rejected because `const_data_ptr<float>` requires a float tensor. Use `at::BFloat16` so the scalar is the correct width for both residences.

## Change

- `torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp`: `unpackPreMulSum<float, ncclBfloat16>` -> `unpackPreMulSum<at::BFloat16, ncclBfloat16>`.
- `test/distributed/test_c10d_ops_nccl.py`: extend the PreMulSum dtype loop in `test_allreduce_ops` from `half, float, double` to include `bfloat16` (host scalar 3.0 and device tensor 5.0). The host-scalar case returns 0 before the fix and the correct value after.

## Verification

CI (the NCCL multi-GPU distributed test jobs); the author has no local CUDA/NCCL build, so this is verification-pending on those jobs. Happy to attach a 2-GPU run before merge.

```
python test/distributed/test_c10d_ops_nccl.py -k test_allreduce_ops
```

*This PR was authored with assistance from Claude; the fix was human-reviewed.*
