### PR TITLE
[CD] Content-address the manywheel/almalinux builder image so PRs test their own .ci/docker

### DIFF
--- a/.github/actions/binary-docker-build/action.yml
+++ b/.github/actions/binary-docker-build/action.yml
@@ -42,6 +42,16 @@ runs:
           --use \
           "${buildkit_addr}"
 
+    # Same-repo PRs publish the content-addressed image to ECR via OIDC -- the
+    # PR-safe path CI's docker-builds uses. PRs get no environment secrets (so
+    # DOCKER_TOKEN is unavailable), but id-token works on same-repo PRs. Skipped
+    # on fork PRs (no OIDC) and on push (Docker Hub path handles its own login).
+    - name: Login to ECR
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      uses: pytorch/pytorch/.github/actions/ecr-login@main
+      with:
+        aws-role-to-assume: arn:aws:iam::308535385114:role/arc
+
     - name: Build (and, on push, publish) via remote BuildKit
       env:
         REMOTE_BUILDKIT: "1"
@@ -63,27 +73,41 @@ runs:
         GIT_COMMIT_SHA=${GITHUB_SHA:-$(git rev-parse HEAD)}
         CI_FOLDER_SHA=$(git rev-parse HEAD:.ci/docker)
 
-        # Same tag set the local-daemon path publishes: branch / commit /
-        # .ci/docker-hash tags are always produced; the floating ${prefix} tag is
-        # only published from main so a release-branch rebuild can't clobber the
-        # image main CI consumes.
-        PREFIX="docker.io/pytorch/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_PREFIX}"
-        TAGS=(
-          -t "${PREFIX}-${GIT_BRANCH_NAME}"
-          -t "${PREFIX}-${GIT_COMMIT_SHA}"
-          -t "${PREFIX}-${CI_FOLDER_SHA}"
-        )
-        if [[ "${GIT_BRANCH_NAME}" == "main" ]]; then
-          TAGS+=(-t "${PREFIX}")
-        fi
+        # Registry + tag set depend on the event:
+        #  - pull_request: publish ONLY the content-addressed image to ECR,
+        #    mirroring the Docker Hub repo layout -- pytorch/<image-name>:
+        #    <variant>-<.ci/docker hash> (e.g. pytorch/manylinux2_28-builder:
+        #    cuda13.0-<hash>, pytorch/almalinux-builder:<variant>-<hash>). The
+        #    image name IS the ECR repo. The ciflow/binaries test run consumes
+        #    it. Auth is via the ecr-login OIDC step above (no docker login
+        #    here). Keeps per-PR images off the public Docker Hub repo and off
+        #    the floating tag -- the same PR-safe path CI's docker-builds uses.
+        #  - push (main / release / rc tags): publish to Docker Hub as before --
+        #    branch / commit / .ci/docker-hash tags, plus the floating <prefix>
+        #    tag only from main so a release-branch rebuild can't clobber it.
+        if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+          PREFIX="308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_PREFIX}"
+          TAGS=(-t "${PREFIX}-${CI_FOLDER_SHA}")
+        else
+          PREFIX="docker.io/pytorch/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_PREFIX}"
+          TAGS=(
+            -t "${PREFIX}-${GIT_BRANCH_NAME}"
+            -t "${PREFIX}-${GIT_COMMIT_SHA}"
+            -t "${PREFIX}-${CI_FOLDER_SHA}"
+          )
+          if [[ "${GIT_BRANCH_NAME}" == "main" ]]; then
+            TAGS+=(-t "${PREFIX}")
+          fi
 
-        # WITH_PUSH gates publishing (build.sh pushes when it is true; PRs just
-        # validate the build). Log in only when we are going to push.
-        set +x
-        if [[ "${WITH_PUSH:-false}" == "true" ]]; then
-          echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_ID}" --password-stdin
+          # WITH_PUSH gates publishing (build.sh pushes when it is true; fork
+          # PRs have no credentials and stay build-only). The PR path logs in via
+          # the ecr-login step; log in to Docker Hub only on the push path.
+          set +x
+          if [[ "${WITH_PUSH:-false}" == "true" ]]; then
+            echo "${DOCKER_TOKEN}" | docker login docker.io -u "${DOCKER_ID}" --password-stdin
+          fi
+          set -x
         fi
-        set -x
 
         # build.sh reads REMOTE_BUILDKIT and buildx-pushes the passed -t tags.
         run_build() {

--- a/.github/actions/binary-docker-build/action.yml
+++ b/.github/actions/binary-docker-build/action.yml
@@ -42,12 +42,12 @@ runs:
           --use \
           "${buildkit_addr}"
 
-    # Same-repo PRs publish the content-addressed image to ECR via OIDC -- the
-    # PR-safe path CI's docker-builds uses. PRs get no environment secrets (so
-    # DOCKER_TOKEN is unavailable), but id-token works on same-repo PRs. Skipped
-    # on fork PRs (no OIDC) and on push (Docker Hub path handles its own login).
+    # ciflow/docker publishes the content-addressed image to ECR via OIDC -- the
+    # same PR-safe path CI's docker-builds uses. The label pushes this tag into
+    # the base repo, so OIDC works even for fork SHAs. Other refs (main / release
+    # / v* -> Docker Hub) handle their own docker login in the build step.
     - name: Login to ECR
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      if: startsWith(github.ref, 'refs/tags/ciflow/docker/')
       uses: pytorch/pytorch/.github/actions/ecr-login@main
       with:
         aws-role-to-assume: arn:aws:iam::308535385114:role/arc
@@ -73,19 +73,19 @@ runs:
         GIT_COMMIT_SHA=${GITHUB_SHA:-$(git rev-parse HEAD)}
         CI_FOLDER_SHA=$(git rev-parse HEAD:.ci/docker)
 
-        # Registry + tag set depend on the event:
-        #  - pull_request: publish ONLY the content-addressed image to ECR,
+        # Registry + tag set depend on the ref:
+        #  - ciflow/docker tag: publish ONLY the content-addressed image to ECR,
         #    mirroring the Docker Hub repo layout -- pytorch/<image-name>:
         #    <variant>-<.ci/docker hash> (e.g. pytorch/manylinux2_28-builder:
         #    cuda13.0-<hash>, pytorch/almalinux-builder:<variant>-<hash>). The
         #    image name IS the ECR repo. The ciflow/binaries test run consumes
         #    it. Auth is via the ecr-login OIDC step above (no docker login
         #    here). Keeps per-PR images off the public Docker Hub repo and off
-        #    the floating tag -- the same PR-safe path CI's docker-builds uses.
+        #    the floating tag -- the same path CI's docker-builds uses.
         #  - push (main / release / rc tags): publish to Docker Hub as before --
         #    branch / commit / .ci/docker-hash tags, plus the floating <prefix>
         #    tag only from main so a release-branch rebuild can't clobber it.
-        if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+        if [[ "${GITHUB_REF:-}" == refs/tags/ciflow/docker/* ]]; then
           PREFIX="308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_PREFIX}"
           TAGS=(-t "${PREFIX}-${CI_FOLDER_SHA}")
         else

--- a/.github/actions/binary-docker-build/action.yml
+++ b/.github/actions/binary-docker-build/action.yml
@@ -25,9 +25,7 @@ runs:
     - name: Checkout PyTorch
       uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
 
-    # Build on a remote BuildKit builder (OSDC/ARC has no host docker daemon)
-    # and push straight to the registry. The referenced <docker-build-dir>/build.sh
-    # honors REMOTE_BUILDKIT (see .ci/docker/build.sh).
+    # Build on a remote BuildKit builder (OSDC/ARC has no host docker daemon); build.sh honors REMOTE_BUILDKIT
     - name: Set up Docker Buildx (remote, no bootstrap)
       shell: bash
       run: |
@@ -42,10 +40,7 @@ runs:
           --use \
           "${buildkit_addr}"
 
-    # ciflow/docker publishes the content-addressed image to ECR via OIDC -- the
-    # same PR-safe path CI's docker-builds uses. The label pushes this tag into
-    # the base repo, so OIDC works even for fork SHAs. Other refs (main / release
-    # / v* -> Docker Hub) handle their own docker login in the build step.
+    # ciflow/docker publishes to ECR via OIDC (works for fork SHAs too); other refs use Docker Hub
     - name: Login to ECR
       if: startsWith(github.ref, 'refs/tags/ciflow/docker/')
       uses: pytorch/pytorch/.github/actions/ecr-login@main
@@ -73,18 +68,7 @@ runs:
         GIT_COMMIT_SHA=${GITHUB_SHA:-$(git rev-parse HEAD)}
         CI_FOLDER_SHA=$(git rev-parse HEAD:.ci/docker)
 
-        # Registry + tag set depend on the ref:
-        #  - ciflow/docker tag: publish ONLY the content-addressed image to ECR,
-        #    mirroring the Docker Hub repo layout -- pytorch/<image-name>:
-        #    <variant>-<.ci/docker hash> (e.g. pytorch/manylinux2_28-builder:
-        #    cuda13.0-<hash>, pytorch/almalinux-builder:<variant>-<hash>). The
-        #    image name IS the ECR repo. The ciflow/binaries test run consumes
-        #    it. Auth is via the ecr-login OIDC step above (no docker login
-        #    here). Keeps per-PR images off the public Docker Hub repo and off
-        #    the floating tag -- the same path CI's docker-builds uses.
-        #  - push (main / release / rc tags): publish to Docker Hub as before --
-        #    branch / commit / .ci/docker-hash tags, plus the floating <prefix>
-        #    tag only from main so a release-branch rebuild can't clobber it.
+        # ciflow/docker -> ECR content-addressed tag (<variant>-<.ci/docker hash>); else Docker Hub branch/commit/hash tags (+ floating from main)
         if [[ "${GITHUB_REF:-}" == refs/tags/ciflow/docker/* ]]; then
           PREFIX="308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_PREFIX}"
           TAGS=(-t "${PREFIX}-${CI_FOLDER_SHA}")
@@ -99,9 +83,7 @@ runs:
             TAGS+=(-t "${PREFIX}")
           fi
 
-          # WITH_PUSH gates publishing (build.sh pushes when it is true; fork
-          # PRs have no credentials and stay build-only). The PR path logs in via
-          # the ecr-login step; log in to Docker Hub only on the push path.
+          # WITH_PUSH gates publishing; log in to Docker Hub only on the push path (ECR uses the ecr-login step)
           set +x
           if [[ "${WITH_PUSH:-false}" == "true" ]]; then
             echo "${DOCKER_TOKEN}" | docker login docker.io -u "${DOCKER_ID}" --password-stdin
@@ -114,10 +96,7 @@ runs:
           ".ci/docker/${DOCKER_BUILD_DIR}/build.sh" "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_PREFIX}" "${TAGS[@]}"
         }
 
-        # The autoscaled BuildKit pool may be cold / at capacity at start, where
-        # buildx's ~20s connect (gRPC default) fails before scale-up. Retry
-        # connection failures (not build errors) so a capacity-limited build waits
-        # for a free pod instead of hard-failing -- still within the job timeout.
+        # Retry connection failures (not build errors): the autoscaled BuildKit pool may be cold at start
         attempts="${REMOTE_BUILDKIT_CONNECT_ATTEMPTS:-360}"
         delay="${REMOTE_BUILDKIT_CONNECT_DELAY:-15}"
         for attempt in $(seq 1 "${attempts}"); do

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -189,6 +189,9 @@
 "ciflow/docker":
 - .ci/docker/**
 - .github/workflows/docker-builds.yml
+- .github/workflows/build-manywheel-images.yml
+- .github/workflows/build-almalinux-images.yml
+- .github/actions/binary-docker-build/**
 - .lintrunner.toml
 
 "ciflow/torchtitan":

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -78,6 +78,12 @@ name: !{{ build_environment }}
 {%- set pin_docker_image = "s390x" not in build_environment %}
 {%- if pin_docker_image %}
   {%- set docker_image_suffix = "${{ needs.get-docker-tag.outputs.docker_image_suffix }}" %}
+  {#- Registry host prefix (with trailing slash) for the builder image. Blank
+      (-> Docker Hub) on nightly/release; on ciflow/binaries PR test runs
+      get-docker-tag sets it to the ECR host so build/test pull the
+      content-addressed image the PR just published. A skipped get-docker-tag
+      reads blank, preserving the Docker Hub floating tag. -#}
+  {%- set docker_registry_host = "${{ needs.get-docker-tag.outputs.docker_registry_host }}" %}
   {#- get-docker-tag only runs on tag pushes, so jobs that need it must tolerate
       it being skipped (a skipped need skips dependents by default). !failure()
       keeps the real build->test ordering; a skipped get-docker-tag is not a
@@ -85,6 +91,7 @@ name: !{{ build_environment }}
   {%- set owner_if = "${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}" %}
 {%- else %}
   {%- set docker_image_suffix = "" %}
+  {%- set docker_registry_host = "" %}
   {%- set owner_if = "${{ github.repository_owner == 'pytorch' }}" %}
 {%- endif %}
 
@@ -139,20 +146,31 @@ jobs:
       check_experiments: lf
 {%- if pin_docker_image %}
 
-  # Computes the manylinux builder image tag suffix at runtime. On release
-  # candidate tag pushes (v1.2.3-rc4) it resolves to "-<.ci/docker tree hash>",
-  # pinning the build/test/upload jobs to the reproducible image published by
-  # binary-docker-build; otherwise it is empty (main's floating tag). ciflow/*
-  # tags keep the floating tag. Done in a shared job so the value can feed the
-  # job-level `container:` directives, which are resolved before any step runs.
+  # Computes the manylinux builder image tag suffix + registry host at runtime,
+  # feeding the job-level `container:` directives (resolved before any step runs):
+  #   - release-candidate tag (v1.2.3-rc4): suffix = "-<.ci/docker tree hash>",
+  #     host = "" -> the reproducible image binary-docker-build pinned on Docker
+  #     Hub.
+  #   - ciflow/binaries PR test: the PR builds its own .ci/docker and
+  #     binary-docker-build pushes the content-addressed image to ECR, so
+  #     suffix = "-<hash>" and host = the ECR host. Because build-manywheel-images
+  #     runs in parallel on the same PR, this job WAITS (polls ECR) until those
+  #     images are pushed before the build/test jobs start pulling them.
+  #   - otherwise (nightly branch, etc.): skipped; outputs read blank -> Docker
+  #     Hub floating tag, unchanged.
   get-docker-tag:
-    # Only runs on tag pushes (release candidates); on branch/PR runs it is
-    # skipped and its output reads as blank, so the floating tag is used.
+    # Runs on tag pushes only (release candidates + ciflow/binaries). On branch
+    # (nightly) runs it is skipped and its outputs read blank, so the floating
+    # Docker Hub tag is used.
     if: ${{ github.repository_owner == 'pytorch' && github.ref_type == 'tag' }}
     name: get-docker-tag
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       docker_image_suffix: ${{ steps.calc.outputs.docker_image_suffix }}
+      docker_registry_host: ${{ steps.calc.outputs.docker_registry_host }}
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -161,18 +179,65 @@ jobs:
           fetch-depth: 1
           submodules: false
           show-progress: false
-      - name: Calculate docker image suffix
+      - name: Calculate docker image suffix and registry host
         id: calc
         env:
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
+          GITHUB_REF: ${{ github.ref }}
         shell: bash
         run: |
+          set -euo pipefail
           suffix=""
-          if [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" == v* ]]; then
+          registry_host=""
+          if [[ "${GITHUB_REF}" == refs/tags/ciflow/binaries/* ]]; then
+            # PR test run: the content-addressed image lives in ECR.
+            suffix="-$(git rev-parse HEAD:.ci/docker)"
+            registry_host="308535385114.dkr.ecr.us-east-1.amazonaws.com/"
+          elif [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" == v* ]]; then
+            # Release candidate: pin the Docker Hub image.
             suffix="-$(git rev-parse HEAD:.ci/docker)"
           fi
           echo "docker_image_suffix=${suffix}" >> "${GITHUB_OUTPUT}"
+          echo "docker_registry_host=${registry_host}" >> "${GITHUB_OUTPUT}"
+      # ciflow/binaries only: the builder images are pushed to ECR by
+      # build-manywheel-images / build-almalinux-images, which run concurrently
+      # on the same PR. Log in (read-only) and wait for the content-addressed
+      # tags to appear before the build/test jobs try to pull them.
+      - name: Login to ECR
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        uses: pytorch/pytorch/.github/actions/ecr-login@main
+{%- if ns.groups %}
+      - name: Wait for content-addressed builder image in ECR
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        env:
+          DOCKER_IMAGE_SUFFIX: ${{ steps.calc.outputs.docker_image_suffix }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Drop the leading dash: "-<hash>" -> "<hash>".
+          tree_hash="${DOCKER_IMAGE_SUFFIX#-}"
+          # build-manywheel-images builds and pushes all variants together, so
+          # wait on a single representative image as the readiness signal.
+          repo="pytorch/!{{ ns.groups[0]['configs'][0]['container_image'] }}"
+          tag="!{{ ns.groups[0]['configs'][0]['container_image_tag_prefix'] }}-${tree_hash}"
+          echo "Waiting for ${repo}:${tag} to be pushed to ECR by build-manywheel-images..."
+          # Poll every 5 min, up to 60 min.
+          deadline=$(( SECONDS + 60 * 60 ))
+          until aws ecr describe-images \
+              --region us-east-1 \
+              --repository-name "${repo}" \
+              --image-ids imageTag="${tag}" >/dev/null 2>&1; do
+            if (( SECONDS > deadline )); then
+              echo "ERROR: timed out (60 min) waiting for ${repo}:${tag} in ECR." >&2
+              echo "Is build-manywheel-images / build-almalinux-images still running or did it fail?" >&2
+              exit 1
+            fi
+            echo "  not in ECR yet (build-manywheel-images still running); retrying in 5 min..."
+            sleep 300
+          done
+          echo "Found ${repo}:${tag}"
+{%- endif %}
 {%- endif %}
 
 {#- One inline build job per (gpu_arch_type, desired_cuda) group. Each loops
@@ -206,14 +271,14 @@ jobs:
     runs-on: "!{{ runner_prefix }}!{{ build_runs_on }}"
     timeout-minutes: !{{ timeout_minutes }}
     container:
-      image: pytorch/!{{ first['container_image'] }}:!{{ first['container_image_tag_prefix'] }}!{{ docker_image_suffix }}
+      image: !{{ docker_registry_host }}pytorch/!{{ first['container_image'] }}:!{{ first['container_image_tag_prefix'] }}!{{ docker_image_suffix }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: !{{ first['package_type'] }}
       DESIRED_CUDA: !{{ desired_cuda }}
       GPU_ARCH_VERSION: "!{{ first['gpu_arch_version'] | default('') }}"
       GPU_ARCH_TYPE: !{{ arch_type }}
-      DOCKER_IMAGE: pytorch/!{{ first['container_image'] }}:!{{ first['container_image_tag_prefix'] }}!{{ docker_image_suffix }}
+      DOCKER_IMAGE: !{{ docker_registry_host }}pytorch/!{{ first['container_image'] }}:!{{ first['container_image_tag_prefix'] }}!{{ docker_image_suffix }}
       SKIP_ALL_TESTS: 1
       DESIRED_PYTHONS: "!{{ group | map(attribute='python_version') | join(' ') }}"
       BUILD_NAME_PREFIX: "manywheel-py"
@@ -295,7 +360,10 @@ jobs:
       GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
-      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}!{{ docker_image_suffix }}
+      # ROCm/XPU are excluded from the content-addressed ECR path: their test
+      # runners have no ECR pull credentials, so they stay on the Docker Hub
+      # image (this matrix only carries rocm/xpu; cpu/cuda build inline above).
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       runner_prefix: "!{{ runner_prefix }}"
       runs_on: !{{ build_runs_on }}
@@ -351,6 +419,7 @@ jobs:
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
       DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}!{{ docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "!{{ docker_registry_host }}"
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       build_name: ${{ matrix.build_name }}
       build_environment: !{{ build_environment }}
@@ -389,7 +458,9 @@ jobs:
       GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
-      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}!{{ docker_image_suffix }}
+      # ROCm test runners have no ECR pull credentials, so ROCm stays on the
+      # Docker Hub image (excluded from the content-addressed ECR path).
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       build_name: ${{ matrix.build_name }}
 {%- endif %}
@@ -419,7 +490,9 @@ jobs:
       DESIRED_CUDA: ${{ matrix.desired_cuda }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
-      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}!{{ docker_image_suffix }}
+      # XPU test runners have no ECR pull credentials, so XPU stays on the
+      # Docker Hub image (excluded from the content-addressed ECR path).
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       build_name: ${{ matrix.build_name }}
 {%- endif %}

--- a/.github/workflows/_binary-test-linux.yml
+++ b/.github/workflows/_binary-test-linux.yml
@@ -70,6 +70,15 @@ on:
       DOCKER_IMAGE_TAG_PREFIX:
         required: true
         type: string
+      DOCKER_IMAGE_REGISTRY_HOST:
+        required: false
+        default: ""
+        type: string
+        description: |
+          Registry host prefix (with trailing slash) prepended to the
+          pytorch/<image> path, e.g.
+          "308535385114.dkr.ecr.us-east-1.amazonaws.com/". Empty (default)
+          means Docker Hub, preserving the historical nightly/release behavior.
       DESIRED_PYTHON:
         required: false
         type: string
@@ -92,7 +101,7 @@ jobs:
     runs-on: ${{ inputs.runner_prefix }}${{ inputs.runs_on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     container:
-      image: ${{ inputs.use_container_directive && format('pytorch/{0}:{1}', inputs.DOCKER_IMAGE, inputs.DOCKER_IMAGE_TAG_PREFIX) || '' }}
+      image: ${{ inputs.use_container_directive && format('{0}pytorch/{1}:{2}', inputs.DOCKER_IMAGE_REGISTRY_HOST, inputs.DOCKER_IMAGE, inputs.DOCKER_IMAGE_TAG_PREFIX) || '' }}
       options: ${{ inputs.use_container_directive && inputs.GPU_ARCH_TYPE == 'cuda' && '--gpus all -e NVIDIA_DRIVER_CAPABILITIES=compute,utility,video' || ' ' }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
@@ -100,7 +109,7 @@ jobs:
       DESIRED_CUDA: ${{ inputs.DESIRED_CUDA }}
       GPU_ARCH_VERSION: ${{ inputs.GPU_ARCH_VERSION }}
       GPU_ARCH_TYPE: ${{ inputs.GPU_ARCH_TYPE }}
-      DOCKER_IMAGE: pytorch/${{ inputs.DOCKER_IMAGE }}:${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
+      DOCKER_IMAGE: ${{ inputs.DOCKER_IMAGE_REGISTRY_HOST }}pytorch/${{ inputs.DOCKER_IMAGE }}:${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
       SKIP_ALL_TESTS: 1
       LIBTORCH_CONFIG: ${{ inputs.LIBTORCH_CONFIG }}
       LIBTORCH_VARIANT: ${{ inputs.LIBTORCH_VARIANT }}

--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -43,9 +43,8 @@ jobs:
       matrix:
         tag: ["cuda12.6", "cuda13.0", "cuda13.2", "rocm7.1", "rocm7.2", "cpu"]
     steps:
-      # TESTING ONLY -- REVERT TO @main BEFORE MERGE (pinned to PR branch to test its own action)
       - name: Build docker image
-        uses: pytorch/pytorch/.github/actions/binary-docker-build@atalman/cd-docker-content-addressed
+        uses: pytorch/pytorch/.github/actions/binary-docker-build@main
         with:
           docker-image-name: almalinux-builder
           custom-tag-prefix: ${{ matrix.tag }}

--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -23,7 +23,11 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v')) }}
+  # Publish on protected-ref pushes (main / release / release-candidate tags ->
+  # Docker Hub) and on same-repo PRs (-> ECR pytorch/almalinux-builder, for
+  # ciflow/binaries test runs). Fork PRs have no push credentials, so they stay
+  # build-only. The registry + tag set is chosen per-event in binary-docker-build.
+  WITH_PUSH: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v'))) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
@@ -32,6 +36,13 @@ concurrency:
 jobs:
   build-docker:
     if: github.repository_owner == 'pytorch'
+    # id-token: write lets the same-repo PR path assume the ECR push role via
+    # OIDC and publish the content-addressed builder image to ECR -- the same
+    # PR-safe mechanism CI's docker-builds uses (PRs get no environment secrets,
+    # so DOCKER_TOKEN is unavailable, but OIDC works).
+    permissions:
+      id-token: write
+      contents: read
     environment: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v')) && 'docker-build') || '' }}
     runs-on: "mt-${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
     container:
@@ -41,8 +52,15 @@ jobs:
       matrix:
         tag: ["cuda12.6", "cuda13.0", "cuda13.2", "rocm7.1", "rocm7.2", "cpu"]
     steps:
+      # TESTING ONLY -- REVERT TO @main BEFORE MERGE.
+      # Local (`./`) composite actions don't resolve on the OSDC/ARC
+      # container-hook runners: the runner resolves the action on the host
+      # (/home/runner/_work) while `container:` steps check out to /__w, so it
+      # errors with "Can't find action.yml". `uses:` can't take an expression,
+      # so to exercise this PR's binary-docker-build change we temporarily pin
+      # the action to this PR branch (a downloadable remote ref).
       - name: Build docker image
-        uses: pytorch/pytorch/.github/actions/binary-docker-build@main
+        uses: pytorch/pytorch/.github/actions/binary-docker-build@atalman/cd-docker-content-addressed
         with:
           docker-image-name: almalinux-builder
           custom-tag-prefix: ${{ matrix.tag }}

--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -11,9 +11,7 @@ on:
       # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
       # Release candidate tags look like: v1.11.0-rc1
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-      # ciflow/docker builds and pushes the content-addressed image to ECR so a
-      # PR can test its own .ci/docker changes (a maintainer applies the label,
-      # which pushes this tag into the base repo -> full OIDC even for fork SHAs).
+      # ciflow/docker: build + push the content-addressed image to ECR for PR testing
       - ciflow/docker/*
     paths:
       - .ci/docker/**
@@ -22,10 +20,7 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  # Publish on protected-ref pushes (main / release / release-candidate tags ->
-  # Docker Hub) and on ciflow/docker tag pushes (-> ECR pytorch/almalinux-builder,
-  # for content-addressed PR testing). The registry + tag set is chosen per-ref
-  # in binary-docker-build.
+  # Publish to Docker Hub on main/release/v*, to ECR on ciflow/docker (chosen per-ref in binary-docker-build)
   WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/ciflow/docker/')) }}
 
 concurrency:
@@ -35,10 +30,7 @@ concurrency:
 jobs:
   build-docker:
     if: github.repository_owner == 'pytorch'
-    # id-token: write lets the same-repo PR path assume the ECR push role via
-    # OIDC and publish the content-addressed builder image to ECR -- the same
-    # PR-safe mechanism CI's docker-builds uses (PRs get no environment secrets,
-    # so DOCKER_TOKEN is unavailable, but OIDC works).
+    # id-token: write lets the ciflow/docker path assume the ECR push role via OIDC
     permissions:
       id-token: write
       contents: read
@@ -51,13 +43,7 @@ jobs:
       matrix:
         tag: ["cuda12.6", "cuda13.0", "cuda13.2", "rocm7.1", "rocm7.2", "cpu"]
     steps:
-      # TESTING ONLY -- REVERT TO @main BEFORE MERGE.
-      # Local (`./`) composite actions don't resolve on the OSDC/ARC
-      # container-hook runners: the runner resolves the action on the host
-      # (/home/runner/_work) while `container:` steps check out to /__w, so it
-      # errors with "Can't find action.yml". `uses:` can't take an expression,
-      # so to exercise this PR's binary-docker-build change we temporarily pin
-      # the action to this PR branch (a downloadable remote ref).
+      # TESTING ONLY -- REVERT TO @main BEFORE MERGE (pinned to PR branch to test its own action)
       - name: Build docker image
         uses: pytorch/pytorch/.github/actions/binary-docker-build@atalman/cd-docker-content-addressed
         with:

--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -11,11 +11,10 @@ on:
       # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
       # Release candidate tags look like: v1.11.0-rc1
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-    paths:
-      - .ci/docker/**
-      - .github/workflows/build-almalinux-images.yml
-      - .github/actions/binary-docker-build/**
-  pull_request:
+      # ciflow/docker builds and pushes the content-addressed image to ECR so a
+      # PR can test its own .ci/docker changes (a maintainer applies the label,
+      # which pushes this tag into the base repo -> full OIDC even for fork SHAs).
+      - ciflow/docker/*
     paths:
       - .ci/docker/**
       - .github/workflows/build-almalinux-images.yml
@@ -24,10 +23,10 @@ on:
 env:
   DOCKER_BUILDKIT: 1
   # Publish on protected-ref pushes (main / release / release-candidate tags ->
-  # Docker Hub) and on same-repo PRs (-> ECR pytorch/almalinux-builder, for
-  # ciflow/binaries test runs). Fork PRs have no push credentials, so they stay
-  # build-only. The registry + tag set is chosen per-event in binary-docker-build.
-  WITH_PUSH: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v'))) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+  # Docker Hub) and on ciflow/docker tag pushes (-> ECR pytorch/almalinux-builder,
+  # for content-addressed PR testing). The registry + tag set is chosen per-ref
+  # in binary-docker-build.
+  WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/ciflow/docker/')) }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -23,7 +23,11 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v')) }}
+  # Publish on protected-ref pushes (main / release / release-candidate tags ->
+  # Docker Hub) and on same-repo PRs (-> ECR pytorch/<image-name>, for
+  # ciflow/binaries test runs). Fork PRs have no push credentials, so they stay
+  # build-only. The registry + tag set is chosen per-event in binary-docker-build.
+  WITH_PUSH: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v'))) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
@@ -50,6 +54,14 @@ jobs:
   build:
     if: github.repository_owner == 'pytorch'
     needs: select-runner
+    # id-token: write lets the same-repo PR path assume the ECR push role via
+    # OIDC and publish the content-addressed builder image to ECR (repo
+    # pytorch/<image-name>) -- the same PR-safe mechanism CI's docker-builds
+    # uses (PRs get no environment secrets, so DOCKER_TOKEN is unavailable, but
+    # OIDC works).
+    permissions:
+      id-token: write
+      contents: read
     environment: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v')) && 'docker-build') || '' }}
     runs-on: ${{ matrix.runner }}
     container:
@@ -73,8 +85,15 @@ jobs:
         ]
     name: ${{ matrix.name }}:${{ matrix.tag }}
     steps:
+      # TESTING ONLY -- REVERT TO @main BEFORE MERGE.
+      # Local (`./`) composite actions don't resolve on the OSDC/ARC
+      # container-hook runners: the runner resolves the action on the host
+      # (/home/runner/_work) while `container:` steps check out to /__w, so it
+      # errors with "Can't find action.yml". `uses:` can't take an expression,
+      # so to exercise this PR's binary-docker-build change we temporarily pin
+      # the action to this PR branch (a downloadable remote ref).
       - name: Build docker image
-        uses: pytorch/pytorch/.github/actions/binary-docker-build@main
+        uses: pytorch/pytorch/.github/actions/binary-docker-build@atalman/cd-docker-content-addressed
         with:
           docker-image-name: ${{ matrix.name }}
           custom-tag-prefix: ${{ matrix.tag }}

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -11,11 +11,10 @@ on:
       # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
       # Release candidate tags look like: v1.11.0-rc1
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-    paths:
-      - .ci/docker/**
-      - .github/workflows/build-manywheel-images.yml
-      - .github/actions/binary-docker-build/**
-  pull_request:
+      # ciflow/docker builds and pushes the content-addressed image to ECR so a
+      # PR can test its own .ci/docker changes (a maintainer applies the label,
+      # which pushes this tag into the base repo -> full OIDC even for fork SHAs).
+      - ciflow/docker/*
     paths:
       - .ci/docker/**
       - .github/workflows/build-manywheel-images.yml
@@ -24,10 +23,10 @@ on:
 env:
   DOCKER_BUILDKIT: 1
   # Publish on protected-ref pushes (main / release / release-candidate tags ->
-  # Docker Hub) and on same-repo PRs (-> ECR pytorch/<image-name>, for
-  # ciflow/binaries test runs). Fork PRs have no push credentials, so they stay
-  # build-only. The registry + tag set is chosen per-event in binary-docker-build.
-  WITH_PUSH: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v'))) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+  # Docker Hub) and on ciflow/docker tag pushes (-> ECR pytorch/<image-name>,
+  # for content-addressed PR testing). The registry + tag set is chosen per-ref
+  # in binary-docker-build.
+  WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/ciflow/docker/')) }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -75,9 +75,8 @@ jobs:
         ]
     name: ${{ matrix.name }}:${{ matrix.tag }}
     steps:
-      # TESTING ONLY -- REVERT TO @main BEFORE MERGE (pinned to PR branch to test its own action)
       - name: Build docker image
-        uses: pytorch/pytorch/.github/actions/binary-docker-build@atalman/cd-docker-content-addressed
+        uses: pytorch/pytorch/.github/actions/binary-docker-build@main
         with:
           docker-image-name: ${{ matrix.name }}
           custom-tag-prefix: ${{ matrix.tag }}

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -11,9 +11,7 @@ on:
       # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
       # Release candidate tags look like: v1.11.0-rc1
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-      # ciflow/docker builds and pushes the content-addressed image to ECR so a
-      # PR can test its own .ci/docker changes (a maintainer applies the label,
-      # which pushes this tag into the base repo -> full OIDC even for fork SHAs).
+      # ciflow/docker: build + push the content-addressed image to ECR for PR testing
       - ciflow/docker/*
     paths:
       - .ci/docker/**
@@ -22,10 +20,7 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  # Publish on protected-ref pushes (main / release / release-candidate tags ->
-  # Docker Hub) and on ciflow/docker tag pushes (-> ECR pytorch/<image-name>,
-  # for content-addressed PR testing). The registry + tag set is chosen per-ref
-  # in binary-docker-build.
+  # Publish to Docker Hub on main/release/v*, to ECR on ciflow/docker (chosen per-ref in binary-docker-build)
   WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/ciflow/docker/')) }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
@@ -53,11 +48,7 @@ jobs:
   build:
     if: github.repository_owner == 'pytorch'
     needs: select-runner
-    # id-token: write lets the same-repo PR path assume the ECR push role via
-    # OIDC and publish the content-addressed builder image to ECR (repo
-    # pytorch/<image-name>) -- the same PR-safe mechanism CI's docker-builds
-    # uses (PRs get no environment secrets, so DOCKER_TOKEN is unavailable, but
-    # OIDC works).
+    # id-token: write lets the ciflow/docker path assume the ECR push role via OIDC
     permissions:
       id-token: write
       contents: read
@@ -84,13 +75,7 @@ jobs:
         ]
     name: ${{ matrix.name }}:${{ matrix.tag }}
     steps:
-      # TESTING ONLY -- REVERT TO @main BEFORE MERGE.
-      # Local (`./`) composite actions don't resolve on the OSDC/ARC
-      # container-hook runners: the runner resolves the action on the host
-      # (/home/runner/_work) while `container:` steps check out to /__w, so it
-      # errors with "Can't find action.yml". `uses:` can't take an expression,
-      # so to exercise this PR's binary-docker-build change we temporarily pin
-      # the action to this PR branch (a downloadable remote ref).
+      # TESTING ONLY -- REVERT TO @main BEFORE MERGE (pinned to PR branch to test its own action)
       - name: Build docker image
         uses: pytorch/pytorch/.github/actions/binary-docker-build@atalman/cd-docker-content-addressed
         with:

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -49,20 +49,31 @@ jobs:
       curr_ref_type: ${{ github.ref_type }}
       check_experiments: lf
 
-  # Computes the manylinux builder image tag suffix at runtime. On release
-  # candidate tag pushes (v1.2.3-rc4) it resolves to "-<.ci/docker tree hash>",
-  # pinning the build/test/upload jobs to the reproducible image published by
-  # binary-docker-build; otherwise it is empty (main's floating tag). ciflow/*
-  # tags keep the floating tag. Done in a shared job so the value can feed the
-  # job-level `container:` directives, which are resolved before any step runs.
+  # Computes the manylinux builder image tag suffix + registry host at runtime,
+  # feeding the job-level `container:` directives (resolved before any step runs):
+  #   - release-candidate tag (v1.2.3-rc4): suffix = "-<.ci/docker tree hash>",
+  #     host = "" -> the reproducible image binary-docker-build pinned on Docker
+  #     Hub.
+  #   - ciflow/binaries PR test: the PR builds its own .ci/docker and
+  #     binary-docker-build pushes the content-addressed image to ECR, so
+  #     suffix = "-<hash>" and host = the ECR host. Because build-manywheel-images
+  #     runs in parallel on the same PR, this job WAITS (polls ECR) until those
+  #     images are pushed before the build/test jobs start pulling them.
+  #   - otherwise (nightly branch, etc.): skipped; outputs read blank -> Docker
+  #     Hub floating tag, unchanged.
   get-docker-tag:
-    # Only runs on tag pushes (release candidates); on branch/PR runs it is
-    # skipped and its output reads as blank, so the floating tag is used.
+    # Runs on tag pushes only (release candidates + ciflow/binaries). On branch
+    # (nightly) runs it is skipped and its outputs read blank, so the floating
+    # Docker Hub tag is used.
     if: ${{ github.repository_owner == 'pytorch' && github.ref_type == 'tag' }}
     name: get-docker-tag
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       docker_image_suffix: ${{ steps.calc.outputs.docker_image_suffix }}
+      docker_registry_host: ${{ steps.calc.outputs.docker_registry_host }}
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -71,18 +82,63 @@ jobs:
           fetch-depth: 1
           submodules: false
           show-progress: false
-      - name: Calculate docker image suffix
+      - name: Calculate docker image suffix and registry host
         id: calc
         env:
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
+          GITHUB_REF: ${{ github.ref }}
         shell: bash
         run: |
+          set -euo pipefail
           suffix=""
-          if [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" == v* ]]; then
+          registry_host=""
+          if [[ "${GITHUB_REF}" == refs/tags/ciflow/binaries/* ]]; then
+            # PR test run: the content-addressed image lives in ECR.
+            suffix="-$(git rev-parse HEAD:.ci/docker)"
+            registry_host="308535385114.dkr.ecr.us-east-1.amazonaws.com/"
+          elif [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" == v* ]]; then
+            # Release candidate: pin the Docker Hub image.
             suffix="-$(git rev-parse HEAD:.ci/docker)"
           fi
           echo "docker_image_suffix=${suffix}" >> "${GITHUB_OUTPUT}"
+          echo "docker_registry_host=${registry_host}" >> "${GITHUB_OUTPUT}"
+      # ciflow/binaries only: the builder images are pushed to ECR by
+      # build-manywheel-images / build-almalinux-images, which run concurrently
+      # on the same PR. Log in (read-only) and wait for the content-addressed
+      # tags to appear before the build/test jobs try to pull them.
+      - name: Login to ECR
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        uses: pytorch/pytorch/.github/actions/ecr-login@main
+      - name: Wait for content-addressed builder image in ECR
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        env:
+          DOCKER_IMAGE_SUFFIX: ${{ steps.calc.outputs.docker_image_suffix }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Drop the leading dash: "-<hash>" -> "<hash>".
+          tree_hash="${DOCKER_IMAGE_SUFFIX#-}"
+          # build-manywheel-images builds and pushes all variants together, so
+          # wait on a single representative image as the readiness signal.
+          repo="pytorch/manylinux2_28_aarch64-builder"
+          tag="cpu-aarch64-${tree_hash}"
+          echo "Waiting for ${repo}:${tag} to be pushed to ECR by build-manywheel-images..."
+          # Poll every 5 min, up to 60 min.
+          deadline=$(( SECONDS + 60 * 60 ))
+          until aws ecr describe-images \
+              --region us-east-1 \
+              --repository-name "${repo}" \
+              --image-ids imageTag="${tag}" >/dev/null 2>&1; do
+            if (( SECONDS > deadline )); then
+              echo "ERROR: timed out (60 min) waiting for ${repo}:${tag} in ECR." >&2
+              echo "Is build-manywheel-images / build-almalinux-images still running or did it fail?" >&2
+              exit 1
+            fi
+            echo "  not in ECR yet (build-manywheel-images still running); retrying in 5 min..."
+            sleep 300
+          done
+          echo "Found ${repo}:${tag}"
 
   manywheel-cpu-aarch64-build:
     name: manywheel-cpu-aarch64-build
@@ -91,14 +147,14 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
     timeout-minutes: 420
     container:
-      image: pytorch/manylinux2_28_aarch64-builder:cpu-aarch64${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28_aarch64-builder:cpu-aarch64${{ needs.get-docker-tag.outputs.docker_image_suffix }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: manywheel
       DESIRED_CUDA: cpu
       GPU_ARCH_VERSION: ""
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinux2_28_aarch64-builder:cpu-aarch64${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28_aarch64-builder:cpu-aarch64${{ needs.get-docker-tag.outputs.docker_image_suffix }}
       SKIP_ALL_TESTS: 1
       DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
@@ -179,14 +235,14 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
     timeout-minutes: 420
     container:
-      image: pytorch/manylinuxaarch64-builder:cuda12.6${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinuxaarch64-builder:cuda12.6${{ needs.get-docker-tag.outputs.docker_image_suffix }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: manywheel
       DESIRED_CUDA: cu126
       GPU_ARCH_VERSION: "12.6-aarch64"
       GPU_ARCH_TYPE: cuda-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cuda12.6${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinuxaarch64-builder:cuda12.6${{ needs.get-docker-tag.outputs.docker_image_suffix }}
       SKIP_ALL_TESTS: 1
       DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
@@ -268,14 +324,14 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
     timeout-minutes: 420
     container:
-      image: pytorch/manylinuxaarch64-builder:cuda13.0${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinuxaarch64-builder:cuda13.0${{ needs.get-docker-tag.outputs.docker_image_suffix }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: manywheel
       DESIRED_CUDA: cu130
       GPU_ARCH_VERSION: "13.0-aarch64"
       GPU_ARCH_TYPE: cuda-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cuda13.0${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinuxaarch64-builder:cuda13.0${{ needs.get-docker-tag.outputs.docker_image_suffix }}
       SKIP_ALL_TESTS: 1
       DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
@@ -357,14 +413,14 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
     timeout-minutes: 420
     container:
-      image: pytorch/manylinuxaarch64-builder:cuda13.2${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinuxaarch64-builder:cuda13.2${{ needs.get-docker-tag.outputs.docker_image_suffix }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: manywheel
       DESIRED_CUDA: cu132
       GPU_ARCH_VERSION: "13.2-aarch64"
       GPU_ARCH_TYPE: cuda-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cuda13.2${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinuxaarch64-builder:cuda13.2${{ needs.get-docker-tag.outputs.docker_image_suffix }}
       SKIP_ALL_TESTS: 1
       DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
@@ -712,6 +768,7 @@ jobs:
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
       DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "${{ needs.get-docker-tag.outputs.docker_registry_host }}"
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       build_name: ${{ matrix.build_name }}
       build_environment: linux-aarch64-binary-manywheel

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -50,20 +50,31 @@ jobs:
       curr_ref_type: ${{ github.ref_type }}
       check_experiments: lf
 
-  # Computes the manylinux builder image tag suffix at runtime. On release
-  # candidate tag pushes (v1.2.3-rc4) it resolves to "-<.ci/docker tree hash>",
-  # pinning the build/test/upload jobs to the reproducible image published by
-  # binary-docker-build; otherwise it is empty (main's floating tag). ciflow/*
-  # tags keep the floating tag. Done in a shared job so the value can feed the
-  # job-level `container:` directives, which are resolved before any step runs.
+  # Computes the manylinux builder image tag suffix + registry host at runtime,
+  # feeding the job-level `container:` directives (resolved before any step runs):
+  #   - release-candidate tag (v1.2.3-rc4): suffix = "-<.ci/docker tree hash>",
+  #     host = "" -> the reproducible image binary-docker-build pinned on Docker
+  #     Hub.
+  #   - ciflow/binaries PR test: the PR builds its own .ci/docker and
+  #     binary-docker-build pushes the content-addressed image to ECR, so
+  #     suffix = "-<hash>" and host = the ECR host. Because build-manywheel-images
+  #     runs in parallel on the same PR, this job WAITS (polls ECR) until those
+  #     images are pushed before the build/test jobs start pulling them.
+  #   - otherwise (nightly branch, etc.): skipped; outputs read blank -> Docker
+  #     Hub floating tag, unchanged.
   get-docker-tag:
-    # Only runs on tag pushes (release candidates); on branch/PR runs it is
-    # skipped and its output reads as blank, so the floating tag is used.
+    # Runs on tag pushes only (release candidates + ciflow/binaries). On branch
+    # (nightly) runs it is skipped and its outputs read blank, so the floating
+    # Docker Hub tag is used.
     if: ${{ github.repository_owner == 'pytorch' && github.ref_type == 'tag' }}
     name: get-docker-tag
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       docker_image_suffix: ${{ steps.calc.outputs.docker_image_suffix }}
+      docker_registry_host: ${{ steps.calc.outputs.docker_registry_host }}
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -72,18 +83,63 @@ jobs:
           fetch-depth: 1
           submodules: false
           show-progress: false
-      - name: Calculate docker image suffix
+      - name: Calculate docker image suffix and registry host
         id: calc
         env:
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
+          GITHUB_REF: ${{ github.ref }}
         shell: bash
         run: |
+          set -euo pipefail
           suffix=""
-          if [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" == v* ]]; then
+          registry_host=""
+          if [[ "${GITHUB_REF}" == refs/tags/ciflow/binaries/* ]]; then
+            # PR test run: the content-addressed image lives in ECR.
+            suffix="-$(git rev-parse HEAD:.ci/docker)"
+            registry_host="308535385114.dkr.ecr.us-east-1.amazonaws.com/"
+          elif [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" == v* ]]; then
+            # Release candidate: pin the Docker Hub image.
             suffix="-$(git rev-parse HEAD:.ci/docker)"
           fi
           echo "docker_image_suffix=${suffix}" >> "${GITHUB_OUTPUT}"
+          echo "docker_registry_host=${registry_host}" >> "${GITHUB_OUTPUT}"
+      # ciflow/binaries only: the builder images are pushed to ECR by
+      # build-manywheel-images / build-almalinux-images, which run concurrently
+      # on the same PR. Log in (read-only) and wait for the content-addressed
+      # tags to appear before the build/test jobs try to pull them.
+      - name: Login to ECR
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        uses: pytorch/pytorch/.github/actions/ecr-login@main
+      - name: Wait for content-addressed builder image in ECR
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        env:
+          DOCKER_IMAGE_SUFFIX: ${{ steps.calc.outputs.docker_image_suffix }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Drop the leading dash: "-<hash>" -> "<hash>".
+          tree_hash="${DOCKER_IMAGE_SUFFIX#-}"
+          # build-manywheel-images builds and pushes all variants together, so
+          # wait on a single representative image as the readiness signal.
+          repo="pytorch/manylinux2_28-builder"
+          tag="cpu-${tree_hash}"
+          echo "Waiting for ${repo}:${tag} to be pushed to ECR by build-manywheel-images..."
+          # Poll every 5 min, up to 60 min.
+          deadline=$(( SECONDS + 60 * 60 ))
+          until aws ecr describe-images \
+              --region us-east-1 \
+              --repository-name "${repo}" \
+              --image-ids imageTag="${tag}" >/dev/null 2>&1; do
+            if (( SECONDS > deadline )); then
+              echo "ERROR: timed out (60 min) waiting for ${repo}:${tag} in ECR." >&2
+              echo "Is build-manywheel-images / build-almalinux-images still running or did it fail?" >&2
+              exit 1
+            fi
+            echo "  not in ECR yet (build-manywheel-images still running); retrying in 5 min..."
+            sleep 300
+          done
+          echo "Found ${repo}:${tag}"
 
   manywheel-cpu-build:
     name: manywheel-cpu-build
@@ -92,14 +148,14 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
     timeout-minutes: 280
     container:
-      image: pytorch/manylinux2_28-builder:cpu${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:cpu${{ needs.get-docker-tag.outputs.docker_image_suffix }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: manywheel
       DESIRED_CUDA: cpu
       GPU_ARCH_VERSION: ""
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux2_28-builder:cpu${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:cpu${{ needs.get-docker-tag.outputs.docker_image_suffix }}
       SKIP_ALL_TESTS: 1
       DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
@@ -180,14 +236,14 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
     timeout-minutes: 280
     container:
-      image: pytorch/manylinux2_28-builder:cuda12.6${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:cuda12.6${{ needs.get-docker-tag.outputs.docker_image_suffix }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: manywheel
       DESIRED_CUDA: cu126
       GPU_ARCH_VERSION: "12.6"
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux2_28-builder:cuda12.6${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:cuda12.6${{ needs.get-docker-tag.outputs.docker_image_suffix }}
       SKIP_ALL_TESTS: 1
       DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
@@ -269,14 +325,14 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
     timeout-minutes: 280
     container:
-      image: pytorch/manylinux2_28-builder:cuda13.0${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:cuda13.0${{ needs.get-docker-tag.outputs.docker_image_suffix }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: manywheel
       DESIRED_CUDA: cu130
       GPU_ARCH_VERSION: "13.0"
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux2_28-builder:cuda13.0${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:cuda13.0${{ needs.get-docker-tag.outputs.docker_image_suffix }}
       SKIP_ALL_TESTS: 1
       DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
@@ -358,14 +414,14 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
     timeout-minutes: 280
     container:
-      image: pytorch/manylinux2_28-builder:cuda13.2${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:cuda13.2${{ needs.get-docker-tag.outputs.docker_image_suffix }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: manywheel
       DESIRED_CUDA: cu132
       GPU_ARCH_VERSION: "13.2"
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux2_28-builder:cuda13.2${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:cuda13.2${{ needs.get-docker-tag.outputs.docker_image_suffix }}
       SKIP_ALL_TESTS: 1
       DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
@@ -672,7 +728,10 @@ jobs:
       GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
-      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      # ROCm/XPU are excluded from the content-addressed ECR path: their test
+      # runners have no ECR pull credentials, so they stay on the Docker Hub
+      # image (this matrix only carries rocm/xpu; cpu/cuda build inline above).
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runs_on: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}
@@ -958,6 +1017,7 @@ jobs:
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
       DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "${{ needs.get-docker-tag.outputs.docker_registry_host }}"
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       build_name: ${{ matrix.build_name }}
       build_environment: linux-binary-manywheel
@@ -1096,7 +1156,9 @@ jobs:
       GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
-      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      # ROCm test runners have no ECR pull credentials, so ROCm stays on the
+      # Docker Hub image (excluded from the content-addressed ECR path).
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       build_name: ${{ matrix.build_name }}
 
@@ -1163,7 +1225,9 @@ jobs:
       DESIRED_CUDA: ${{ matrix.desired_cuda }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
-      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      # XPU test runners have no ECR pull credentials, so XPU stays on the
+      # Docker Hub image (excluded from the content-addressed ECR path).
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       build_name: ${{ matrix.build_name }}
 

--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -120,6 +120,9 @@ jobs:
       GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
+      # ROCm/XPU are excluded from the content-addressed ECR path: their test
+      # runners have no ECR pull credentials, so they stay on the Docker Hub
+      # image (this matrix only carries rocm/xpu; cpu/cuda build inline above).
       DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       runner_prefix: ""
@@ -198,6 +201,7 @@ jobs:
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
       DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
+      DOCKER_IMAGE_REGISTRY_HOST: ""
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       build_name: ${{ matrix.build_name }}
       build_environment: linux-s390x-binary-manywheel


### PR DESCRIPTION
## Summary

Make `ciflow/binaries` builds test the `.ci/docker` builder image the PR itself produces, instead of the stale Docker Hub floating tag. Uses the same **ECR + OIDC** mechanism CI's `docker-builds` uses. **Nightly and release builds are unchanged (Docker Hub).**

## Producer -- publish the PR image to ECR (`ciflow/docker`)

- `build-manywheel-images.yml` / `build-almalinux-images.yml` trigger on `ciflow/docker` (like `docker-builds.yml`). A maintainer applying the label pushes the tag into the base repo, so the ECR push runs in base-repo context with full OIDC (`role/arc`) -- even for fork-originated SHAs.
- `binary-docker-build`: on `refs/tags/ciflow/docker/*`, publish the content-addressed image
  `308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/<image>:<variant>-<.ci/docker tree hash>`.
  `main` / `release` / `v*` still publish to Docker Hub.

## Consumer -- pull the PR image and wait (`ciflow/binaries`, cpu/cuda)

- `get-docker-tag` (in the generated `linux_binary_build_workflow.yml.j2`): on `ciflow/binaries`, resolve the tag suffix + ECR host, then poll ECR until the image is published (build runs concurrently) -- every 5 min, up to 60 min.
- New optional `DOCKER_IMAGE_REGISTRY_HOST` input on `_binary-test-linux`, defaulting to `""` so nightly/release stay `docker.io/pytorch/<image>` byte-for-byte.
- **ROCm/XPU are excluded** and stay on the Docker Hub image (their test runners have no ECR pull credentials).

## Dependency

Requires the `arc` OIDC role to have ECR write on the builder repos (`pytorch/manylinux*-builder`, `pytorch/almalinux-builder`) -- granted in **pytorch-gha-infra#1308**.

cc @huydhn @pytorch/pytorch-dev-infra