### PR TITLE
Make torch.get_device_module() not eagerly trigger device ruintime initialization

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5082,7 +5082,7 @@ with torch.cuda.graph(g):
         VISIBLE_DEVICES = (
             "HIP_VISIBLE_DEVICES" if TEST_WITH_ROCM else "CUDA_VISIBLE_DEVICES"
         )
-        test_script = f"import os; import torch;os.environ['{VISIBLE_DEVICES}']='32';print(torch.cuda.device_count());print(torch.get_device_module().device_count())"
+        test_script = f"import os; import torch;os.environ['{VISIBLE_DEVICES}']='32';torch.get_device_module().device_count();print(torch.cuda.device_count())"
         rc = check_output(test_script)
         self.assertEqual(rc, "0")
         if not TEST_WITH_ROCM:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5082,7 +5082,7 @@ with torch.cuda.graph(g):
         VISIBLE_DEVICES = (
             "HIP_VISIBLE_DEVICES" if TEST_WITH_ROCM else "CUDA_VISIBLE_DEVICES"
         )
-        test_script = f"import os; import torch;os.environ['{VISIBLE_DEVICES}']='32';print(torch.cuda.device_count())"
+        test_script = f"import os; import torch;os.environ['{VISIBLE_DEVICES}']='32';print(torch.cuda.device_count());print(torch.get_device_module().device_count())"
         rc = check_output(test_script)
         self.assertEqual(rc, "0")
         if not TEST_WITH_ROCM:

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -3485,8 +3485,9 @@ def get_device_module(device: "torch.device | str | None" = None) -> _ModuleType
     elif isinstance(device, str):
         device_module_name = torch.device(device).type
     elif device is None:
-        # Using default accelerator type. If no accelerator is available, it automatically returns CPU device.
-        device_module_name = torch._C._get_accelerator().type
+        # Use the current accelerator's type, falling back to CPU when none is available.
+        acc = torch._C._accelerator_getAccelerator()
+        device_module_name = acc.type if acc is not None else "cpu"
     else:
         raise RuntimeError(
             f"Invalid value of device '{device}', expect torch.device, str, or None"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190751

# Motivation
Fix https://github.com/pytorch/pytorch/issues/190708
The root cause is that `torch._C._get_accelerator` will eagerly trigger device runtime initialization in https://github.com/pytorch/pytorch/blob/801c3e6b41427fde03004f2afa4691919d4ee005/torch/csrc/Module.cpp#L3217

Use `torch._C._accelerator_getAccelerator` instead which is determined at the build time, see https://github.com/pytorch/pytorch/blob/801c3e6b41427fde03004f2afa4691919d4ee005/aten/src/ATen/DeviceAccelerator.cpp#L36