### PR TITLE
flex_gemm: accept explicit QUACK configs

### DIFF
--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -430,6 +430,37 @@ class TestFlexGemmRuntimeHelpers(TestCase):
                 explicit_config=swap_config,
             )
 
+    def test_multi_cta_local_reduce_rejects_full_tile_group(self):
+        """Reject full-tile groups until GroupedLocalReduce owns two-CTA stores."""
+        from torch._inductor.kernel.flex_gemm.constraints import (
+            max_flex_gemm_local_reduce_group_for_configs,
+            validate_flex_gemm_local_reduce_config,
+        )
+        from torch._vendor.quack.gemm_config import GemmConfig
+
+        configs = (
+            GemmConfig(
+                tile_m=128,
+                tile_n=256,
+                pingpong=False,
+                cluster_m=2,
+                device_capacity=10,
+            ),
+            GemmConfig(
+                tile_m=256,
+                tile_n=512,
+                pingpong=False,
+                cluster_m=2,
+                device_capacity=10,
+            ),
+        )
+        for config in configs:
+            self.assertTrue(validate_flex_gemm_local_reduce_config(config, 128, 1))
+            self.assertFalse(
+                validate_flex_gemm_local_reduce_config(config, config.tile_n, 1)
+            )
+        self.assertEqual(max_flex_gemm_local_reduce_group_for_configs(configs, 1), 256)
+
     def test_precompile_metadata_counts_symbolic_skip(self):
         import sympy
 

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -2032,13 +2032,6 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
             a.shape[1],
         )
 
-
-
-
-
-
-
-
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
@@ -3562,10 +3555,6 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         )
         self.assertLocalReduceAuxCode(code, group, callbacks=True)
         self.assertIn("cluster_n', 1", code)
-
-
-
-
 
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
@@ -5865,6 +5854,7 @@ class TestFlexGemmFastMathDevice(FlexGemmTestCase):
         self.assertIn("fastmath=True", code)
         self.assertNotIn("cute.math.erf", code)
 
+
 instantiate_device_type_tests(TestFlexGemmFastMathDevice, globals(), only_for="cuda")
 
 
@@ -6157,6 +6147,7 @@ class TestFlexGemmExplicitConfigDevice(FlexGemmTestCase):
             self.assertIn(f"FlexGemmLocalReduceGeometry(group={group}, axis=0)", code)
             self.assertIn("FlexGemmLocalReduceCallbacks(", code)
         self.assertIn(f"config_key={config_key!r}", code)
+
 
 instantiate_device_type_tests(
     TestFlexGemmExplicitConfigDevice, globals(), only_for="cuda"

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -3780,6 +3780,56 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @unittest.skipIf(SM120OrLater, "SM100 config required")
+    def test_mm_tuned_local_reduce_supports_max_autotune(self):
+        """Keep mutable local-reduce outputs out of deferred template selection."""
+        from torch._inductor import config as inductor_config
+
+        m, n, group = 256, 512, 512
+
+        def epilogue_fn(acc):
+            partials = acc.float().view(m, -1, group).sum(-1)
+            return acc.relu(), partials
+
+        def fn(a, b):
+            actual, partials = flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "tuned": True},
+            )
+            return actual, partials.sum(-1)
+
+        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
+        with inductor_config.patch(max_autotune=True):
+            (actual, reduced), (code,) = run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        expected, expected_partials = epilogue_fn(a @ b)
+        high_precision_expected, high_precision_partials = epilogue_fn(
+            a.double() @ b.double()
+        )
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            expected,
+            high_precision_expected,
+            a.shape[1],
+        )
+        torch.testing.assert_close(
+            reduced,
+            high_precision_partials.float().sum(-1),
+            atol=1e-3,
+            rtol=1e-3,
+        )
+        self.assertFlexGemmGeneratedCode(code)
+        self.assertIn("('tile_m', 256)", code)
+        self.assertIn("('tile_n', 512)", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
     @parametrize(
         "case",
         (

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -3655,7 +3655,11 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         (
             ("local_n_g32_tile64", 1, 32, 128, 64, 2, 2),
             ("local_n_g16_tile160", 1, 16, 128, 160, 2, 2),
+            ("local_n_g32_tile192", 1, 32, 128, 192, 2, 1),
             ("local_n_g32_tile224", 1, 32, 256, 224, 2, 2),
+            ("local_n_g32_tile256", 1, 32, 128, 256, 2, 2),
+            ("local_n_g64_tile_m128", 1, 64, 128, 256, 2, 1),
+            ("local_n_g128_tile_m128", 1, 128, 128, 256, 2, 1),
             ("local_m_g128_tile160", 0, 128, 128, 160, 1, 1),
             ("local_m_g64_tile_m256", 0, 64, 256, 256, 2, 1),
             ("local_m_g128_tile_m256", 0, 128, 256, 256, 2, 1),

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 import contextlib
+import dataclasses
 import importlib
 import math
 import sys
@@ -361,6 +362,10 @@ class TestFlexGemmRuntimeHelpers(TestCase):
                 flex_gemm_heuristics.explicit_gemm_config_key(
                     {**config, "cluster_m": True}, device
                 )
+            with self.assertRaisesRegex(NotImplementedError, "not supported"):
+                flex_gemm_heuristics.explicit_gemm_config_key(
+                    {**config, "use_tma_gather": True}, device
+                )
             with self.assertRaisesRegex(
                 NotImplementedError, "targets SM90.*uses SM100"
             ):
@@ -369,18 +374,13 @@ class TestFlexGemmRuntimeHelpers(TestCase):
                 )
 
         swap_config_key = flex_gemm_heuristics.gemm_config_key(
-            GemmConfig(
-                tile_m=128,
-                tile_n=192,
-                pingpong=False,
-                is_dynamic_persistent=True,
-                cluster_m=2,
-                swap_ab=True,
-                device_capacity=10,
-            )
+            dataclasses.replace(supported, swap_ab=True)
         )
-        with self.assertRaisesRegex(
-            NotImplementedError, "incompatible with local reduction"
+        with (
+            mock.patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+            self.assertRaisesRegex(
+                NotImplementedError, "incompatible with local reduction"
+            ),
         ):
             flex_gemm_config_keys_for_local_reduce(
                 device,
@@ -5665,12 +5665,6 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
                 lambda acc: acc.relu(),
                 {"backend": "QUACK", "split_k": 2},
                 "unsupported FlexGEMM kernel options",
-            ),
-            (
-                "invalid_tuned_option",
-                lambda acc: acc.relu(),
-                {"backend": "QUACK", "tuned": 1},
-                "tuned kernel option must be bool",
             ),
             (
                 "invalid_fast_math_option",

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -3607,6 +3607,49 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize("group", (64, 128))
+    def test_mm_tuple_aux_local_n_reduce_supports_clustered_tile_m256(self, group):
+        from torch._vendor.quack.gemm_config import GemmConfig
+
+        m = n = 256
+
+        def epilogue_fn(acc):
+            x = acc.float().view(m, -1, group)
+            return acc.relu(), x.sum(-1)
+
+        config = dataclasses.asdict(
+            GemmConfig(
+                tile_m=256,
+                tile_n=256,
+                pingpong=False,
+                cluster_m=2,
+                cluster_n=1,
+                device_capacity=10,
+            )
+        )
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "config": config},
+            )
+
+        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
+        (actual, aux), (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        self.assertLocalReduceAuxMatches(actual, aux, a, b, epilogue_fn)
+        self.assertLocalReduceAuxCode(code, group, callbacks=True)
+        self.assertIn("('tile_m', 256)", code)
+        self.assertIn("('cluster_m', 2)", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
     @parametrize(
         "case",
         (

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -3830,6 +3830,55 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @unittest.skipIf(SM120OrLater, "SM100 config required")
+    def test_mm_full_tile_local_reduce_checks_actual_n_warp_layout(self):
+        """Reject a host-approved full-N group when the kernel layout splits N."""
+        from torch._vendor.quack.gemm_config import GemmConfig
+
+        m = n = group = 256
+
+        def epilogue_fn(acc):
+            partials = acc.float().view(m, -1, group).sum(-1)
+            return acc.relu(), partials
+
+        config = dataclasses.asdict(
+            GemmConfig(
+                tile_m=128,
+                tile_n=256,
+                pingpong=False,
+                is_dynamic_persistent=True,
+                cluster_m=2,
+                cluster_n=1,
+                device_capacity=10,
+            )
+        )
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "config": config},
+            )
+
+        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
+        with (
+            mock.patch(
+                "torch._inductor.kernel.flex_gemm.lowering."
+                "validate_flex_gemm_local_reduce_config",
+                return_value=True,
+            ),
+            self.assertRaisesRegex(
+                Exception,
+                "full-N GroupedLocalReduce requires one epilogue N-warp partition",
+            ),
+        ):
+            torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
     @parametrize(
         "case",
         (

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -315,6 +315,82 @@ class TestFlexGemmRuntimeHelpers(TestCase):
                     torch.device("cuda")
                 )
 
+    def test_explicit_dense_config_requires_complete_supported_schema(self):
+        from torch._inductor.heuristics.template import (
+            flex_gemm as flex_gemm_heuristics,
+        )
+        from torch._inductor.kernel.flex_gemm.constraints import (
+            FlexGemmLocalReduceGeometry,
+        )
+        from torch._inductor.kernel.flex_gemm.lowering import (
+            flex_gemm_config_keys_for_local_reduce,
+        )
+        from torch._vendor.quack.gemm_config import GemmConfig
+
+        supported = GemmConfig(
+            tile_m=128,
+            tile_n=192,
+            pingpong=False,
+            is_dynamic_persistent=True,
+            cluster_m=2,
+            device_capacity=10,
+        )
+        config = dict(flex_gemm_heuristics.gemm_config_key(supported))
+        device = torch.device("cuda")
+        with (
+            mock.patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+            mock.patch(
+                "torch._vendor.quack.gemm_config.get_all_configs",
+                return_value=[supported],
+            ),
+        ):
+            self.assertEqual(
+                flex_gemm_heuristics.explicit_gemm_config_key(config, device),
+                flex_gemm_heuristics.gemm_config_key(supported),
+            )
+            with self.assertRaisesRegex(NotImplementedError, "missing=.*tile_n"):
+                flex_gemm_heuristics.explicit_gemm_config_key(
+                    {name: value for name, value in config.items() if name != "tile_n"},
+                    device,
+                )
+            with self.assertRaisesRegex(NotImplementedError, "unexpected=.*stages"):
+                flex_gemm_heuristics.explicit_gemm_config_key(
+                    {**config, "stages": 4}, device
+                )
+            with self.assertRaisesRegex(NotImplementedError, "not supported"):
+                flex_gemm_heuristics.explicit_gemm_config_key(
+                    {**config, "cluster_m": True}, device
+                )
+            with self.assertRaisesRegex(
+                NotImplementedError, "targets SM90.*uses SM100"
+            ):
+                flex_gemm_heuristics.explicit_gemm_config_key(
+                    {**config, "device_capacity": 9}, device
+                )
+
+        swap_config_key = flex_gemm_heuristics.gemm_config_key(
+            GemmConfig(
+                tile_m=128,
+                tile_n=192,
+                pingpong=False,
+                is_dynamic_persistent=True,
+                cluster_m=2,
+                swap_ab=True,
+                device_capacity=10,
+            )
+        )
+        with self.assertRaisesRegex(
+            NotImplementedError, "incompatible with local reduction"
+        ):
+            flex_gemm_config_keys_for_local_reduce(
+                device,
+                128,
+                128,
+                (FlexGemmLocalReduceGeometry(group=16, axis=1),),
+                tuned=False,
+                explicit_config_key=swap_config_key,
+            )
+
     def test_precompile_metadata_counts_symbolic_skip(self):
         import sympy
 
@@ -1962,6 +2038,47 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         self.assertIn("cute.math.tanh", code)
         self.assertIn("fastmath=True", code)
         self.assertNotIn("cute.math.erf", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_explicit_config_matches_reference(self):
+        from torch._inductor.heuristics.template.flex_gemm import (
+            candidate_gemm_configs_for_device,
+            gemm_config_key,
+        )
+
+        def epilogue_fn(acc):
+            return (acc + 1).relu()
+
+        config = next(
+            config
+            for config in candidate_gemm_configs_for_device(torch.device("cuda"))
+            if config.swap_ab
+        )
+        config_key = gemm_config_key(config)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "config": dict(config_key)},
+            )
+
+        a = torch.randn(128, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            epilogue_fn(a @ b),
+            epilogue_fn(a.double() @ b.double()),
+            a.shape[1],
+        )
+        self.assertFlexGemmGeneratedCode(code)
+        self.assertIn(f"config_key={config_key!r}", code)
 
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
@@ -5550,10 +5667,34 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
                 "unsupported FlexGEMM kernel options",
             ),
             (
+                "invalid_tuned_option",
+                lambda acc: acc.relu(),
+                {"backend": "QUACK", "tuned": 1},
+                "tuned kernel option must be bool",
+            ),
+            (
                 "invalid_fast_math_option",
                 lambda acc: acc.relu(),
                 {"backend": "QUACK", "fast_math": 1},
                 "fast_math kernel option must be bool",
+            ),
+            (
+                "invalid_config_option",
+                lambda acc: acc.relu(),
+                {"backend": "QUACK", "config": None},
+                "config kernel option must be a dict",
+            ),
+            (
+                "incomplete_config_option",
+                lambda acc: acc.relu(),
+                {"backend": "QUACK", "config": {"tile_m": 128}},
+                "explicit QUACK config must specify exactly",
+            ),
+            (
+                "config_and_tuned",
+                lambda acc: acc.relu(),
+                {"backend": "QUACK", "config": {}, "tuned": True},
+                "config and tuned kernel options are mutually exclusive",
             ),
         ),
         name_fn=lambda case: case[0],

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -316,7 +316,7 @@ class TestFlexGemmRuntimeHelpers(TestCase):
                     torch.device("cuda")
                 )
 
-    def test_explicit_dense_config_requires_complete_supported_schema(self):
+    def test_explicit_dense_config_supports_partial_constraints(self):
         from torch._inductor.heuristics.template import (
             flex_gemm as flex_gemm_heuristics,
         )
@@ -326,6 +326,7 @@ class TestFlexGemmRuntimeHelpers(TestCase):
         from torch._inductor.kernel.flex_gemm.lowering import (
             flex_gemm_config_keys_for_local_reduce,
         )
+        from torch._inductor.virtualized import V
         from torch._vendor.quack.gemm_config import GemmConfig
 
         supported = GemmConfig(
@@ -336,48 +337,86 @@ class TestFlexGemmRuntimeHelpers(TestCase):
             cluster_m=2,
             device_capacity=10,
         )
+        alternative = dataclasses.replace(supported, tile_n=256, cluster_m=1)
         config = dict(flex_gemm_heuristics.gemm_config_key(supported))
         device = torch.device("cuda")
+        fake_graph = SimpleNamespace(
+            sizevars=SimpleNamespace(guard_or_false=lambda expr: bool(expr))
+        )
         with (
             mock.patch("torch.cuda.get_device_capability", return_value=(10, 0)),
             mock.patch(
                 "torch._vendor.quack.gemm_config.get_all_configs",
-                return_value=[supported],
+                return_value=[supported, alternative],
             ),
+            V.set_graph_handler(fake_graph),
         ):
             self.assertEqual(
-                flex_gemm_heuristics.explicit_gemm_config_key(config, device),
-                flex_gemm_heuristics.gemm_config_key(supported),
+                flex_gemm_heuristics.explicit_gemm_configs_for_device(config, device),
+                (supported,),
             )
-            with self.assertRaisesRegex(NotImplementedError, "missing=.*tile_n"):
-                flex_gemm_heuristics.explicit_gemm_config_key(
-                    {name: value for name, value in config.items() if name != "tile_n"},
+            self.assertEqual(
+                flex_gemm_heuristics.explicit_gemm_configs_for_device(
+                    {"tile_m": 128}, device
+                ),
+                (supported, alternative),
+            )
+            self.assertEqual(
+                flex_gemm_config_keys_for_local_reduce(
                     device,
-                )
-            with self.assertRaisesRegex(NotImplementedError, "unexpected=.*stages"):
-                flex_gemm_heuristics.explicit_gemm_config_key(
+                    128,
+                    128,
+                    (),
+                    tuned=False,
+                    explicit_config={"tile_m": 128},
+                ),
+                (flex_gemm_heuristics.gemm_config_key(supported),),
+            )
+            self.assertEqual(
+                flex_gemm_config_keys_for_local_reduce(
+                    device,
+                    128,
+                    128,
+                    (),
+                    tuned=True,
+                    explicit_config={"tile_m": 128},
+                ),
+                tuple(
+                    flex_gemm_heuristics.gemm_config_key(candidate)
+                    for candidate in (supported, alternative)
+                ),
+            )
+            with self.assertRaisesRegex(NotImplementedError, "unexpected.*stages"):
+                flex_gemm_heuristics.explicit_gemm_configs_for_device(
                     {**config, "stages": 4}, device
                 )
             with self.assertRaisesRegex(NotImplementedError, "not supported"):
-                flex_gemm_heuristics.explicit_gemm_config_key(
+                flex_gemm_heuristics.explicit_gemm_configs_for_device(
                     {**config, "cluster_m": True}, device
                 )
             with self.assertRaisesRegex(NotImplementedError, "not supported"):
-                flex_gemm_heuristics.explicit_gemm_config_key(
+                flex_gemm_heuristics.explicit_gemm_configs_for_device(
                     {**config, "use_tma_gather": True}, device
                 )
             with self.assertRaisesRegex(
                 NotImplementedError, "targets SM90.*uses SM100"
             ):
-                flex_gemm_heuristics.explicit_gemm_config_key(
+                flex_gemm_heuristics.explicit_gemm_configs_for_device(
                     {**config, "device_capacity": 9}, device
                 )
 
-        swap_config_key = flex_gemm_heuristics.gemm_config_key(
-            dataclasses.replace(supported, swap_ab=True)
+        swap_config = dict(
+            flex_gemm_heuristics.gemm_config_key(
+                dataclasses.replace(supported, swap_ab=True)
+            )
         )
         with (
             mock.patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+            mock.patch(
+                "torch._vendor.quack.gemm_config.get_all_configs",
+                return_value=[dataclasses.replace(supported, swap_ab=True)],
+            ),
+            V.set_graph_handler(fake_graph),
             self.assertRaisesRegex(
                 NotImplementedError, "incompatible with local reduction"
             ),
@@ -388,7 +427,7 @@ class TestFlexGemmRuntimeHelpers(TestCase):
                 128,
                 (FlexGemmLocalReduceGeometry(group=16, axis=1),),
                 tuned=False,
-                explicit_config_key=swap_config_key,
+                explicit_config=swap_config,
             )
 
     def test_precompile_metadata_counts_symbolic_skip(self):
@@ -2079,6 +2118,55 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         )
         self.assertFlexGemmGeneratedCode(code)
         self.assertIn(f"config_key={config_key!r}", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize("tuned", (False, True))
+    def test_mm_partial_config_matches_reference(self, tuned):
+        from torch._inductor.heuristics.template.flex_gemm import (
+            candidate_gemm_configs_for_device,
+        )
+
+        def epilogue_fn(acc):
+            return (acc + 1).relu()
+
+        config = next(
+            config
+            for config in candidate_gemm_configs_for_device(torch.device("cuda"))
+            if config.swap_ab
+        )
+        pinned = {
+            name: getattr(config, name)
+            for name in ("tile_m", "tile_n", "cluster_m", "cluster_n", "swap_ab")
+        }
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={
+                    "backend": "QUACK",
+                    "config": pinned,
+                    "tuned": tuned,
+                },
+            )
+
+        a = torch.randn(128, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            epilogue_fn(a @ b),
+            epilogue_fn(a.double() @ b.double()),
+            a.shape[1],
+        )
+        self.assertFlexGemmGeneratedCode(code)
+        for item in pinned.items():
+            self.assertIn(repr(item), code)
 
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
@@ -5791,16 +5879,10 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
                 "config kernel option must be a dict",
             ),
             (
-                "incomplete_config_option",
+                "unknown_config_field",
                 lambda acc: acc.relu(),
-                {"backend": "QUACK", "config": {"tile_m": 128}},
-                "explicit QUACK config must specify exactly",
-            ),
-            (
-                "config_and_tuned",
-                lambda acc: acc.relu(),
-                {"backend": "QUACK", "config": {}, "tuned": True},
-                "config and tuned kernel options are mutually exclusive",
+                {"backend": "QUACK", "config": {"stages": 4}},
+                "unexpected GemmConfig fields",
             ),
         ),
         name_fn=lambda case: case[0],

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -3653,6 +3653,71 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @parametrize(
         "case",
         (
+            ("local_n_g32_tile64", 1, 32, 128, 64, 2, 2),
+            ("local_n_g16_tile160", 1, 16, 128, 160, 2, 2),
+            ("local_n_g32_tile224", 1, 32, 256, 224, 2, 2),
+            ("local_m_g128_tile160", 0, 128, 128, 160, 1, 1),
+            ("local_m_g64_tile_m256", 0, 64, 256, 256, 2, 1),
+            ("local_m_g128_tile_m256", 0, 128, 256, 256, 2, 1),
+        ),
+        name_fn=lambda case: case[0],
+    )
+    def test_mm_tuple_aux_local_reduce_supports_expanded_configs(self, case):
+        from torch._vendor.quack.gemm_config import GemmConfig
+
+        _, axis, group, tile_m, tile_n, cluster_m, cluster_n = case
+        m = max(tile_m, group, 256)
+        n = max(tile_n, group if axis == 1 else 256)
+
+        def epilogue_fn(acc):
+            if axis == 1:
+                partial = acc.float().view(m, -1, group).sum(-1)
+            else:
+                partial = acc.float().view(-1, group, n).sum(1)
+            return acc.relu(), partial
+
+        config = dataclasses.asdict(
+            GemmConfig(
+                tile_m=tile_m,
+                tile_n=tile_n,
+                pingpong=False,
+                cluster_m=cluster_m,
+                cluster_n=cluster_n,
+                device_capacity=10,
+            )
+        )
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "config": config},
+            )
+
+        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
+        (actual, aux), (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        self.assertLocalReduceAuxMatches(actual, aux, a, b, epilogue_fn)
+        if axis == 1:
+            self.assertLocalReduceAuxCode(code, group, callbacks=group > 32)
+        else:
+            self.assertIn(f"FlexGemmLocalReduceGeometry(group={group}, axis=0)", code)
+            self.assertIn("FlexGemmLocalReduceCallbacks(", code)
+        self.assertIn(f"('tile_m', {tile_m})", code)
+        self.assertIn(f"('tile_n', {tile_n})", code)
+        self.assertIn(f"('cluster_m', {cluster_m})", code)
+        self.assertIn(f"('cluster_n', {cluster_n})", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize(
+        "case",
+        (
             (
                 "variance_like",
                 lambda x: ((x - x.mean(-1, keepdim=True)).square()).mean(-1) * 0.5
@@ -3732,7 +3797,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
             config
             for config in candidates
             if config.tile_m == 128
-            and config.tile_n == 128
+            and config.tile_n in (128, 160, 224)
             and config.cluster_m > 1
             and validate_flex_gemm_local_reduce_config(config, 16, 1)
         ]

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -16,8 +16,7 @@ from torch._higher_order_ops.flex_gemm import _SUPPORTED_FLEX_GEMM_OP_NAMES
 from torch._inductor.ops_handler import ReductionType
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_cuda import SM100OrLater, SM120OrLater, TEST_CUDA
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_cuda import SM100OrLater, TEST_CUDA
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -431,8 +430,8 @@ class TestFlexGemmRuntimeHelpers(TestCase):
                 explicit_config=swap_config,
             )
 
-    def test_multi_cta_local_reduce_rejects_full_tile_group(self):
-        """Reject full-tile groups until GroupedLocalReduce owns two-CTA stores."""
+    def test_multi_cta_local_reduce_full_tile_follows_n_warp_topology(self):
+        """Allow full-N groups only when one epilogue warp partition owns N."""
         from torch._inductor.kernel.flex_gemm.constraints import (
             max_flex_gemm_local_reduce_group_for_configs,
             validate_flex_gemm_local_reduce_config,
@@ -455,32 +454,23 @@ class TestFlexGemmRuntimeHelpers(TestCase):
                 device_capacity=10,
             ),
         )
-        for config in configs:
-            self.assertTrue(validate_flex_gemm_local_reduce_config(config, 128, 1))
-            self.assertFalse(
-                validate_flex_gemm_local_reduce_config(config, config.tile_n, 1)
-            )
-        self.assertEqual(max_flex_gemm_local_reduce_group_for_configs(configs, 1), 256)
-
-    def test_expanded_local_reduce_configs_are_sm100_only(self):
-        from torch._inductor.kernel.flex_gemm.constraints import (
-            validate_flex_gemm_local_reduce_config,
+        split_n_warp, single_n_warp = configs
+        self.assertTrue(validate_flex_gemm_local_reduce_config(split_n_warp, 128, 1))
+        self.assertFalse(
+            validate_flex_gemm_local_reduce_config(split_n_warp, split_n_warp.tile_n, 1)
         )
-        from torch._vendor.quack.gemm_config import GemmConfig
-
-        for device_capacity in (9, 12):
-            single_cta = GemmConfig(
-                tile_m=128,
-                tile_n=256,
-                pingpong=False,
-                cluster_m=1,
-                device_capacity=device_capacity,
+        self.assertTrue(validate_flex_gemm_local_reduce_config(single_n_warp, 128, 1))
+        self.assertTrue(
+            validate_flex_gemm_local_reduce_config(
+                single_n_warp, single_n_warp.tile_n, 1
             )
-            clustered = dataclasses.replace(single_cta, tile_m=256, cluster_m=2)
-
-            self.assertTrue(validate_flex_gemm_local_reduce_config(single_cta, 64, 1))
-            self.assertTrue(validate_flex_gemm_local_reduce_config(single_cta, 256, 1))
-            self.assertFalse(validate_flex_gemm_local_reduce_config(clustered, 64, 0))
+        )
+        self.assertFalse(
+            validate_flex_gemm_local_reduce_config(
+                single_n_warp, single_n_warp.tile_m, 0
+            )
+        )
+        self.assertEqual(max_flex_gemm_local_reduce_group_for_configs(configs, 1), 512)
 
     def test_precompile_metadata_counts_symbolic_skip(self):
         import sympy
@@ -514,26 +504,10 @@ class TestFlexGemmRuntimeHelpers(TestCase):
 
 
 class FlexGemmTestCase(TestCase):
-    def makeTensor(self, *shape, device="cuda", dtype=torch.bfloat16):
+    def makeTensor(self, *shape, dtype=torch.bfloat16):
         return torch.testing.make_tensor(
-            *shape, device=device, dtype=dtype, low=-0.1, high=0.1
+            *shape, device="cuda", dtype=dtype, low=-0.1, high=0.1
         )
-
-    def assertFlexGemmGeneratedCode(self, code, *checks):
-        file_check = (
-            FileCheck()
-            .check("from torch._inductor.kernel.flex_gemm.runtime import (")
-            .check("FlexGemmRuntimeLocalReducePlan")
-            .check("gemm_epilogue as flex_gemm_epilogue")
-            .check("flex_gemm_epilogue(")
-        )
-        for check in checks:
-            file_check = file_check.check(check)
-        file_check = (
-            file_check.check("stream=stream").check("config_key=").check_not("tuned=")
-        )
-        file_check = file_check.check_not("epilogue_source=")
-        file_check.check_not("from quack").check_not("import quack").run(code)
 
     def swapAndNonSwapConfigKeys(self, device):
         """Return one swap_ab and one non-swap candidate config key for ``device``."""
@@ -573,13 +547,11 @@ class FlexGemmTestCase(TestCase):
             actual_error.item(),
             eager_error.item() + rounding_atol,
             msg=(
-                lambda msg: (
-                    f"{msg}\nactual error {actual_error.item()} exceeded low precision eager "
-                    f"error {eager_error.item()} with fp32_accumulation_eps="
-                    f"{fp32_accumulation_eps}, result_rounding_eps="
-                    f"{result_rounding_eps}, output_scale={output_scale}, "
-                    f"and atol={rounding_atol}"
-                )
+                lambda msg: f"{msg}\nactual error {actual_error.item()} exceeded low precision eager "
+                f"error {eager_error.item()} with fp32_accumulation_eps="
+                f"{fp32_accumulation_eps}, result_rounding_eps="
+                f"{result_rounding_eps}, output_scale={output_scale}, "
+                f"and atol={rounding_atol}"
             ),
         )
 
@@ -1775,6 +1747,22 @@ class TestFlexGemmRuntime(FlexGemmTestCase):
 
 @instantiate_parametrized_tests
 class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
+    def assertFlexGemmGeneratedCode(self, code, *checks):
+        file_check = (
+            FileCheck()
+            .check("from torch._inductor.kernel.flex_gemm.runtime import (")
+            .check("FlexGemmRuntimeLocalReducePlan")
+            .check("gemm_epilogue as flex_gemm_epilogue")
+            .check("flex_gemm_epilogue(")
+        )
+        for check in checks:
+            file_check = file_check.check(check)
+        file_check = (
+            file_check.check("stream=stream").check("config_key=").check_not("tuned=")
+        )
+        file_check = file_check.check_not("epilogue_source=")
+        file_check.check_not("from quack").check_not("import quack").run(code)
+
     def test_supported_op_names_match_dense_scope(self):
         self.assertEqual(_SUPPORTED_FLEX_GEMM_OP_NAMES, "mm/addmm/bmm/baddbmm")
 
@@ -1947,6 +1935,280 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
             epilogue_fn(a.double() @ b.double()),
             a.shape[1],
         )
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fast_math_kernel_option_controls_cutedsl_math(self):
+        def epilogue_fn(acc):
+            magnitude = acc.abs() + 1.0
+            return (
+                torch.tanh(acc)
+                + torch.sigmoid(acc)
+                + torch.exp(-acc.abs())
+                + torch.log1p(acc.abs())
+                + torch.sqrt(magnitude)
+                + torch.rsqrt(magnitude)
+            )
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64)
+        b = self.makeTensor(64, 128)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        for op_name in ("tanh", "exp2", "log", "sqrt", "rsqrt"):
+            self.assertIn(f"cute.math.{op_name}", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("fastmath=True", precise_code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fast_math_sigmoid_uses_tanh_decomposition(self):
+        def epilogue_fn(acc):
+            return torch.sigmoid(acc)
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64)
+        b = self.makeTensor(64, 128)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        self.assertIn("cute.math.tanh", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("cute.math.exp2", fast_code)
+        self.assertIn("cute.math.exp2", precise_code)
+        self.assertNotIn("cute.math.tanh", precise_code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fast_math_silu_uses_tanh_decomposition(self):
+        def epilogue_fn(acc):
+            return torch.nn.functional.silu(acc)
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64)
+        b = self.makeTensor(64, 128)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        self.assertIn("cute.math.tanh", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("cute.math.exp2", fast_code)
+        self.assertIn("cute.math.exp2", precise_code)
+        self.assertNotIn("cute.math.tanh", precise_code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fast_math_gelu_none_uses_tanh_decomposition(self):
+        def epilogue_fn(acc):
+            return torch.nn.functional.gelu(acc, approximate="none")
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64)
+        b = self.makeTensor(64, 128)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(
+            fast_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        self.assertIn("cute.math.tanh", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("cute.math.erf", fast_code)
+        self.assertIn("cute.math.erf", precise_code)
+        self.assertNotIn("cute.math.tanh", precise_code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fast_math_gelu_tanh_preserves_requested_approximation(self):
+        def epilogue_fn(acc):
+            return torch.nn.functional.gelu(acc, approximate="tanh")
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "fast_math": True},
+            )
+
+        a = self.makeTensor(128, 64)
+        b = self.makeTensor(64, 128)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(actual.double(), expected, atol=0.02, rtol=0.002)
+        self.assertIn("cute.math.tanh", code)
+        self.assertIn("fastmath=True", code)
+        self.assertNotIn("cute.math.erf", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_explicit_config_matches_reference(self):
+        from torch._inductor.heuristics.template.flex_gemm import (
+            candidate_gemm_configs_for_device,
+            gemm_config_key,
+        )
+
+        def epilogue_fn(acc):
+            return (acc + 1).relu()
+
+        config = next(
+            config
+            for config in candidate_gemm_configs_for_device(torch.device("cuda"))
+            if config.swap_ab
+        )
+        config_key = gemm_config_key(config)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "config": dict(config_key)},
+            )
+
+        a = torch.randn(128, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            epilogue_fn(a @ b),
+            epilogue_fn(a.double() @ b.double()),
+            a.shape[1],
+        )
+        self.assertFlexGemmGeneratedCode(code)
+        self.assertIn(f"config_key={config_key!r}", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize("tuned", (False, True))
+    def test_mm_partial_config_matches_reference(self, tuned):
+        from torch._inductor.heuristics.template.flex_gemm import (
+            candidate_gemm_configs_for_device,
+        )
+
+        def epilogue_fn(acc):
+            return (acc + 1).relu()
+
+        config = next(
+            config
+            for config in candidate_gemm_configs_for_device(torch.device("cuda"))
+            if config.swap_ab
+        )
+        pinned = {
+            name: getattr(config, name)
+            for name in ("tile_m", "tile_n", "cluster_m", "cluster_n", "swap_ab")
+        }
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={
+                    "backend": "QUACK",
+                    "config": pinned,
+                    "tuned": tuned,
+                },
+            )
+
+        a = torch.randn(128, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            epilogue_fn(a @ b),
+            epilogue_fn(a.double() @ b.double()),
+            a.shape[1],
+        )
+        self.assertFlexGemmGeneratedCode(code)
+        for item in pinned.items():
+            self.assertIn(repr(item), code)
 
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
@@ -3475,14 +3737,127 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize("group", (64, 128))
+    def test_mm_tuple_aux_local_n_reduce_supports_clustered_tile_m256(self, group):
+        from torch._vendor.quack.gemm_config import GemmConfig
+
+        m = n = 256
+
+        def epilogue_fn(acc):
+            x = acc.float().view(m, -1, group)
+            return acc.relu(), x.sum(-1)
+
+        config = dataclasses.asdict(
+            GemmConfig(
+                tile_m=256,
+                tile_n=256,
+                pingpong=False,
+                cluster_m=2,
+                cluster_n=1,
+                device_capacity=10,
+            )
+        )
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "config": config},
+            )
+
+        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
+        (actual, aux), (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        self.assertLocalReduceAuxMatches(actual, aux, a, b, epilogue_fn)
+        self.assertLocalReduceAuxCode(code, group, callbacks=True)
+        self.assertIn("('tile_m', 256)", code)
+        self.assertIn("('cluster_m', 2)", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize(
+        "case",
+        (
+            ("local_n_g32_tile64", 1, 32, 128, 64, 2, 2),
+            ("local_n_g16_tile160", 1, 16, 128, 160, 2, 2),
+            ("local_n_g32_tile192", 1, 32, 128, 192, 2, 1),
+            ("local_n_g32_tile224", 1, 32, 256, 224, 2, 2),
+            ("local_n_g32_tile256", 1, 32, 128, 256, 2, 2),
+            ("local_n_g64_tile_m128", 1, 64, 128, 256, 2, 1),
+            ("local_n_g128_tile_m128", 1, 128, 128, 256, 2, 1),
+            ("local_n_full_tile256_tile_m256", 1, 256, 256, 256, 2, 1),
+            ("local_n_full_tile512_tile_m256", 1, 512, 256, 512, 2, 1),
+            ("local_m_g128_tile160", 0, 128, 128, 160, 1, 1),
+            ("local_m_g64_tile_m256", 0, 64, 256, 256, 2, 1),
+            ("local_m_g128_tile_m256", 0, 128, 256, 256, 2, 1),
+        ),
+        name_fn=lambda case: case[0],
+    )
+    def test_mm_tuple_aux_local_reduce_supports_expanded_configs(self, case):
+        from torch._vendor.quack.gemm_config import GemmConfig
+
+        _, axis, group, tile_m, tile_n, cluster_m, cluster_n = case
+        m = max(tile_m, group, 256)
+        n = max(tile_n, group if axis == 1 else 256)
+
+        def epilogue_fn(acc):
+            if axis == 1:
+                partial = acc.float().view(m, -1, group).sum(-1)
+            else:
+                partial = acc.float().view(-1, group, n).sum(1)
+            return acc.relu(), partial
+
+        config = dataclasses.asdict(
+            GemmConfig(
+                tile_m=tile_m,
+                tile_n=tile_n,
+                pingpong=False,
+                cluster_m=cluster_m,
+                cluster_n=cluster_n,
+                device_capacity=10,
+            )
+        )
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "config": config},
+            )
+
+        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
+        (actual, aux), (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        self.assertLocalReduceAuxMatches(actual, aux, a, b, epilogue_fn)
+        if axis == 1:
+            self.assertLocalReduceAuxCode(code, group, callbacks=group > 32)
+        else:
+            self.assertIn(f"FlexGemmLocalReduceGeometry(group={group}, axis=0)", code)
+            self.assertIn("FlexGemmLocalReduceCallbacks(", code)
+        self.assertIn(f"('tile_m', {tile_m})", code)
+        self.assertIn(f"('tile_n', {tile_n})", code)
+        self.assertIn(f"('cluster_m', {cluster_m})", code)
+        self.assertIn(f"('cluster_n', {cluster_n})", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
     @parametrize(
         "case",
         (
             (
                 "variance_like",
-                lambda x: (
-                    ((x - x.mean(-1, keepdim=True)).square()).mean(-1) * 0.5 + 1.0
-                ),
+                lambda x: ((x - x.mean(-1, keepdim=True)).square()).mean(-1) * 0.5
+                + 1.0,
                 " / 4.0",
                 False,
             ),
@@ -4718,6 +5093,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
             ("fragment_group_tuned", 128, 32, True),
             ("multi_chunk_large_group", 256, 128, False),
             ("tile_n_group", 256, 256, False),
+            ("wide_m_tile_n_group", 512, 512, False),
         ),
         name_fn=lambda case: case[0],
     )
@@ -4784,8 +5160,8 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
     def test_mm_coda_rmsnorm_rewrite_rejects_group_above_config_limit(self):
-        m, k, n, p = 64, 32, 512, 48
-        group = 512
+        m, k, n, p = 64, 32, 1024, 48
+        group = 1024
         eps = 1e-5
 
         def fn(a, b1, gamma, b2):
@@ -4819,7 +5195,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
 
         with self.assertRaisesRegex(
             Exception,
-            "requested group=512, max supported group=256 for axis=1",
+            "requested group=1024, max supported group=512 for axis=1",
         ):
             torch.compile(fn, backend="inductor", fullgraph=True)(a, b1, gamma, b2)
 
@@ -5597,384 +5973,6 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
                 kernel_options={"backend": "CUTLASS"},
             )
 
-
-@skipIfNoCuteDSL
-@unittest.skipIf(not SM100OrLater, "SM100+ required")
-class TestFlexGemmFastMathDevice(FlexGemmTestCase):
-    def test_mm_fast_math_kernel_option_controls_cutedsl_math(self, device):
-        def epilogue_fn(acc):
-            magnitude = acc.abs() + 1.0
-            return (
-                torch.tanh(acc)
-                + torch.sigmoid(acc)
-                + torch.exp(-acc.abs())
-                + torch.log1p(acc.abs())
-                + torch.sqrt(magnitude)
-                + torch.rsqrt(magnitude)
-            )
-
-        def compile_with_fast_math(a, b, fast_math):
-            def fn(a, b):
-                return flex_gemm(
-                    torch.mm,
-                    (a, b),
-                    epilogue_fn,
-                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
-                )
-
-            torch._dynamo.reset()
-            return run_and_get_code(
-                torch.compile(fn, backend="inductor", fullgraph=True), a, b
-            )
-
-        a = self.makeTensor(128, 64, device=device)
-        b = self.makeTensor(64, 128, device=device)
-        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
-        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
-        expected = epilogue_fn(a.double() @ b.double())
-
-        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
-        torch.testing.assert_close(
-            precise_result.double(), expected, atol=0.02, rtol=0.002
-        )
-        for op_name in ("tanh", "exp2", "log", "sqrt", "rsqrt"):
-            self.assertIn(f"cute.math.{op_name}", fast_code)
-        self.assertIn("fastmath=True", fast_code)
-        self.assertNotIn("fastmath=True", precise_code)
-
-    def test_mm_fast_math_sigmoid_uses_tanh_decomposition(self, device):
-        def epilogue_fn(acc):
-            return torch.sigmoid(acc)
-
-        def compile_with_fast_math(a, b, fast_math):
-            def fn(a, b):
-                return flex_gemm(
-                    torch.mm,
-                    (a, b),
-                    epilogue_fn,
-                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
-                )
-
-            torch._dynamo.reset()
-            return run_and_get_code(
-                torch.compile(fn, backend="inductor", fullgraph=True), a, b
-            )
-
-        a = self.makeTensor(128, 64, device=device)
-        b = self.makeTensor(64, 128, device=device)
-        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
-        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
-        expected = epilogue_fn(a.double() @ b.double())
-
-        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
-        torch.testing.assert_close(
-            precise_result.double(), expected, atol=0.02, rtol=0.002
-        )
-        self.assertIn("cute.math.tanh", fast_code)
-        self.assertIn("fastmath=True", fast_code)
-        self.assertNotIn("cute.math.exp2", fast_code)
-        self.assertIn("cute.math.exp2", precise_code)
-        self.assertNotIn("cute.math.tanh", precise_code)
-
-    def test_mm_fast_math_silu_uses_tanh_decomposition(self, device):
-        def epilogue_fn(acc):
-            return torch.nn.functional.silu(acc)
-
-        def compile_with_fast_math(a, b, fast_math):
-            def fn(a, b):
-                return flex_gemm(
-                    torch.mm,
-                    (a, b),
-                    epilogue_fn,
-                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
-                )
-
-            torch._dynamo.reset()
-            return run_and_get_code(
-                torch.compile(fn, backend="inductor", fullgraph=True), a, b
-            )
-
-        a = self.makeTensor(128, 64, device=device)
-        b = self.makeTensor(64, 128, device=device)
-        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
-        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
-        expected = epilogue_fn(a.double() @ b.double())
-
-        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
-        torch.testing.assert_close(
-            precise_result.double(), expected, atol=0.02, rtol=0.002
-        )
-        self.assertIn("cute.math.tanh", fast_code)
-        self.assertIn("fastmath=True", fast_code)
-        self.assertNotIn("cute.math.exp2", fast_code)
-        self.assertIn("cute.math.exp2", precise_code)
-        self.assertNotIn("cute.math.tanh", precise_code)
-
-    def test_mm_fast_math_gelu_none_uses_tanh_decomposition(self, device):
-        def epilogue_fn(acc):
-            return torch.nn.functional.gelu(acc, approximate="none")
-
-        def compile_with_fast_math(a, b, fast_math):
-            def fn(a, b):
-                return flex_gemm(
-                    torch.mm,
-                    (a, b),
-                    epilogue_fn,
-                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
-                )
-
-            torch._dynamo.reset()
-            return run_and_get_code(
-                torch.compile(fn, backend="inductor", fullgraph=True), a, b
-            )
-
-        a = self.makeTensor(128, 64, device=device)
-        b = self.makeTensor(64, 128, device=device)
-        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
-        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
-        expected = epilogue_fn(a.double() @ b.double())
-
-        torch.testing.assert_close(
-            fast_result.double(), expected, atol=0.02, rtol=0.002
-        )
-        torch.testing.assert_close(
-            precise_result.double(), expected, atol=0.02, rtol=0.002
-        )
-        self.assertIn("cute.math.tanh", fast_code)
-        self.assertIn("fastmath=True", fast_code)
-        self.assertNotIn("cute.math.erf", fast_code)
-        self.assertIn("cute.math.erf", precise_code)
-        self.assertNotIn("cute.math.tanh", precise_code)
-
-    def test_mm_fast_math_gelu_tanh_preserves_requested_approximation(self, device):
-        def epilogue_fn(acc):
-            return torch.nn.functional.gelu(acc, approximate="tanh")
-
-        def fn(a, b):
-            return flex_gemm(
-                torch.mm,
-                (a, b),
-                epilogue_fn,
-                kernel_options={"backend": "QUACK", "fast_math": True},
-            )
-
-        a = self.makeTensor(128, 64, device=device)
-        b = self.makeTensor(64, 128, device=device)
-        actual, (code,) = run_and_get_code(
-            torch.compile(fn, backend="inductor", fullgraph=True), a, b
-        )
-        expected = epilogue_fn(a.double() @ b.double())
-
-        torch.testing.assert_close(actual.double(), expected, atol=0.02, rtol=0.002)
-        self.assertIn("cute.math.tanh", code)
-        self.assertIn("fastmath=True", code)
-        self.assertNotIn("cute.math.erf", code)
-
-
-instantiate_device_type_tests(TestFlexGemmFastMathDevice, globals(), only_for="cuda")
-
-
-@skipIfNoCuteDSL
-@unittest.skipIf(not SM100OrLater, "SM100+ required")
-class TestFlexGemmExplicitConfigDevice(FlexGemmTestCase):
-    def test_mm_explicit_config_matches_reference(self, device):
-        from torch._inductor.heuristics.template.flex_gemm import (
-            candidate_gemm_configs_for_device,
-            gemm_config_key,
-        )
-
-        def epilogue_fn(acc):
-            return (acc + 1).relu()
-
-        config = next(
-            config
-            for config in candidate_gemm_configs_for_device(device)
-            if config.swap_ab
-        )
-        config_key = gemm_config_key(config)
-
-        def fn(a, b):
-            return flex_gemm(
-                torch.mm,
-                (a, b),
-                epilogue_fn,
-                kernel_options={"backend": "QUACK", "config": dict(config_key)},
-            )
-
-        a = torch.randn(128, 64, device=device, dtype=torch.bfloat16)
-        b = torch.randn(64, 128, device=device, dtype=torch.bfloat16)
-        actual, (code,) = run_and_get_code(
-            torch.compile(fn, backend="inductor", fullgraph=True), a, b
-        )
-        self.assertMatchesLowPrecisionEager(
-            actual,
-            epilogue_fn(a @ b),
-            epilogue_fn(a.double() @ b.double()),
-            a.shape[1],
-        )
-        self.assertFlexGemmGeneratedCode(code)
-        self.assertIn(f"config_key={config_key!r}", code)
-
-    @parametrize("tuned", (False, True))
-    def test_mm_partial_config_matches_reference(self, device, tuned):
-        from torch._inductor.heuristics.template.flex_gemm import (
-            candidate_gemm_configs_for_device,
-        )
-
-        def epilogue_fn(acc):
-            return (acc + 1).relu()
-
-        config = next(
-            config
-            for config in candidate_gemm_configs_for_device(device)
-            if config.swap_ab
-        )
-        pinned = {
-            name: getattr(config, name)
-            for name in ("tile_m", "tile_n", "cluster_m", "cluster_n", "swap_ab")
-        }
-
-        def fn(a, b):
-            return flex_gemm(
-                torch.mm,
-                (a, b),
-                epilogue_fn,
-                kernel_options={
-                    "backend": "QUACK",
-                    "config": pinned,
-                    "tuned": tuned,
-                },
-            )
-
-        a = torch.randn(128, 64, device=device, dtype=torch.bfloat16)
-        b = torch.randn(64, 128, device=device, dtype=torch.bfloat16)
-        actual, (code,) = run_and_get_code(
-            torch.compile(fn, backend="inductor", fullgraph=True), a, b
-        )
-        self.assertMatchesLowPrecisionEager(
-            actual,
-            epilogue_fn(a @ b),
-            epilogue_fn(a.double() @ b.double()),
-            a.shape[1],
-        )
-        self.assertFlexGemmGeneratedCode(code)
-        for item in pinned.items():
-            self.assertIn(repr(item), code)
-
-    @unittest.skipIf(SM120OrLater, "SM100 config required")
-    @parametrize("group", (64, 128))
-    def test_mm_tuple_aux_local_n_reduce_supports_clustered_tile_m256(
-        self, device, group
-    ):
-        from torch._vendor.quack.gemm_config import GemmConfig
-
-        m = n = 256
-
-        def epilogue_fn(acc):
-            x = acc.float().view(m, -1, group)
-            return acc.relu(), x.sum(-1)
-
-        config = dataclasses.asdict(
-            GemmConfig(
-                tile_m=256,
-                tile_n=256,
-                pingpong=False,
-                cluster_m=2,
-                cluster_n=1,
-                device_capacity=10,
-            )
-        )
-
-        def fn(a, b):
-            return flex_gemm(
-                torch.mm,
-                (a, b),
-                epilogue_fn,
-                kernel_options={"backend": "QUACK", "config": config},
-            )
-
-        a = torch.randn(m, 64, device=device, dtype=torch.bfloat16)
-        b = torch.randn(64, n, device=device, dtype=torch.bfloat16)
-        (actual, aux), (code,) = run_and_get_code(
-            torch.compile(fn, backend="inductor", fullgraph=True), a, b
-        )
-
-        self.assertLocalReduceAuxMatches(actual, aux, a, b, epilogue_fn)
-        self.assertLocalReduceAuxCode(code, group, callbacks=True)
-        self.assertIn("('tile_m', 256)", code)
-        self.assertIn("('cluster_m', 2)", code)
-
-    @unittest.skipIf(SM120OrLater, "SM100 config required")
-    @parametrize(
-        "case",
-        (
-            ("local_n_g32_tile64", 1, 32, 128, 64, 2, 2),
-            ("local_n_g16_tile160", 1, 16, 128, 160, 2, 2),
-            ("local_n_g32_tile192", 1, 32, 128, 192, 2, 1),
-            ("local_n_g32_tile224", 1, 32, 256, 224, 2, 2),
-            ("local_n_g32_tile256", 1, 32, 128, 256, 2, 2),
-            ("local_n_g64_tile_m128", 1, 64, 128, 256, 2, 1),
-            ("local_n_g128_tile_m128", 1, 128, 128, 256, 2, 1),
-            ("local_m_g128_tile160", 0, 128, 128, 160, 1, 1),
-            ("local_m_g64_tile_m256", 0, 64, 256, 256, 2, 1),
-            ("local_m_g128_tile_m256", 0, 128, 256, 256, 2, 1),
-        ),
-        name_fn=lambda case: case[0],
-    )
-    def test_mm_tuple_aux_local_reduce_supports_expanded_configs(self, device, case):
-        from torch._vendor.quack.gemm_config import GemmConfig
-
-        _, axis, group, tile_m, tile_n, cluster_m, cluster_n = case
-        m = max(tile_m, group, 256)
-        n = max(tile_n, group if axis == 1 else 256)
-
-        def epilogue_fn(acc):
-            if axis == 1:
-                partial = acc.float().view(m, -1, group).sum(-1)
-            else:
-                partial = acc.float().view(-1, group, n).sum(1)
-            return acc.relu(), partial
-
-        config = dataclasses.asdict(
-            GemmConfig(
-                tile_m=tile_m,
-                tile_n=tile_n,
-                pingpong=False,
-                cluster_m=cluster_m,
-                cluster_n=cluster_n,
-                device_capacity=10,
-            )
-        )
-
-        def fn(a, b):
-            return flex_gemm(
-                torch.mm,
-                (a, b),
-                epilogue_fn,
-                kernel_options={"backend": "QUACK", "config": config},
-            )
-
-        a = torch.randn(m, 64, device=device, dtype=torch.bfloat16)
-        b = torch.randn(64, n, device=device, dtype=torch.bfloat16)
-        (actual, aux), (code,) = run_and_get_code(
-            torch.compile(fn, backend="inductor", fullgraph=True), a, b
-        )
-
-        self.assertLocalReduceAuxMatches(actual, aux, a, b, epilogue_fn)
-        if axis == 1:
-            self.assertLocalReduceAuxCode(code, group, callbacks=group > 32)
-        else:
-            self.assertIn(f"FlexGemmLocalReduceGeometry(group={group}, axis=0)", code)
-            self.assertIn("FlexGemmLocalReduceCallbacks(", code)
-        self.assertIn(f"('tile_m', {tile_m})", code)
-        self.assertIn(f"('tile_n', {tile_n})", code)
-        self.assertIn(f"('cluster_m', {cluster_m})", code)
-        self.assertIn(f"('cluster_n', {cluster_n})", code)
-
-
-instantiate_device_type_tests(
-    TestFlexGemmExplicitConfigDevice, globals(), only_for="cuda"
-)
 
 if __name__ == "__main__":
     run_tests()

--- a/tools/vendoring/quack/flex_gemm_patches/0011-flex-gemm-local-reduce-layout-assert.patch
+++ b/tools/vendoring/quack/flex_gemm_patches/0011-flex-gemm-local-reduce-layout-assert.patch
@@ -1,0 +1,27 @@
+diff --git a/epi_ops.py b/epi_ops.py
+index 96a3c37854b..2bfa2b0da29 100644
+--- a/epi_ops.py
++++ b/epi_ops.py
+@@ -1269,9 +1269,21 @@ class GroupedLocalReduce(VecReduce):
+             tile = tile_N if const_expr(axis == 1) else tile_M
+             assert group != 0 and group <= tile
+             assert tile % group == 0
++            tiled_copy = (
++                ctx.tiled_copy_t2r
++                if ctx.tiled_copy_t2r is not None
++                else ctx.tiled_copy_r2s
++            )
++            if const_expr(gemm.arch == 100 and axis == 1 and group == tile_N):
++                _, warp_layout_MN = _get_lane_warp_layouts(
++                    tiled_copy, ctx.tiled_copy_t2r is None
++                )
++                warps_in_N = const_expr(cute.size(warp_layout_MN, mode=[1]))
++                assert warps_in_N == 1, (
++                    "full-N GroupedLocalReduce requires one epilogue N-warp partition"
++                )
+             if const_expr(param.feeds_main):
+                 assert axis == 0
+-                tiled_copy = ctx.tiled_copy_t2r if ctx.tiled_copy_t2r is not None else ctx.tiled_copy_r2s
+                 lane_layout_MN, _ = _get_lane_warp_layouts(
+                     tiled_copy, ctx.tiled_copy_t2r is None
+                 )

--- a/tools/vendoring/quack/flex_gemm_patches/series
+++ b/tools/vendoring/quack/flex_gemm_patches/series
@@ -13,3 +13,4 @@
 0008-flex-gemm-local-reduce-feed-main.patch
 0009-flex-gemm-fragment-group-32.patch
 0010-flex-gemm-scalar-epilogue-args.patch
+0011-flex-gemm-local-reduce-layout-assert.patch

--- a/torch/_inductor/heuristics/template/flex_gemm.py
+++ b/torch/_inductor/heuristics/template/flex_gemm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import fields
 from functools import cache
-from typing import Any, TypeAlias
+from typing import Any, TYPE_CHECKING, TypeAlias
 
 import sympy
 
@@ -11,6 +11,9 @@ import torch
 import torch._vendor.quack.gemm_config as quack_gemm_config
 from torch.utils._ordered_set import OrderedSet
 
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 GemmConfigKey: TypeAlias = tuple[tuple[str, Any], ...]
 
@@ -28,39 +31,46 @@ def gemm_config_from_key(config_key: GemmConfigKey) -> quack_gemm_config.GemmCon
     return quack_gemm_config.GemmConfig(**dict(config_key))
 
 
-def explicit_gemm_config_key(
+def explicit_gemm_configs_for_device(
     config: dict[str, Any], device: torch.device
-) -> GemmConfigKey:
-    """Validate and canonicalize a user-selected QuACK GEMM config.
+) -> tuple[quack_gemm_config.GemmConfig, ...]:
+    """Return device configs matching every explicitly pinned field.
 
     Exact type matching prevents bool/int aliases from selecting a different key.
     """
     field_names = tuple(field.name for field in fields(quack_gemm_config.GemmConfig))
-    missing = [name for name in field_names if name not in config]
     unexpected = [name for name in config if name not in field_names]
-    if missing or unexpected:
+    if unexpected:
         raise NotImplementedError(
-            "FlexGEMM explicit QUACK config must specify exactly the GemmConfig "
-            f"fields; missing={missing}, unexpected={unexpected}"
+            "FlexGEMM explicit QUACK config contains unexpected GemmConfig fields: "
+            f"{unexpected}"
         )
 
-    requested = quack_gemm_config.GemmConfig(**config)
     candidates = candidate_gemm_configs_for_device(device)
     expected_device_capacity = candidates[0].device_capacity
-    if requested.device_capacity != expected_device_capacity:
+    requested_device_capacity = config.get("device_capacity")
+    if (
+        type(requested_device_capacity) is type(expected_device_capacity)
+        and requested_device_capacity != expected_device_capacity
+    ):
         raise NotImplementedError(
-            f"FlexGEMM explicit QUACK config targets SM{requested.device_capacity}0, "
+            f"FlexGEMM explicit QUACK config targets SM{requested_device_capacity}0, "
             f"but {device} uses SM{expected_device_capacity}0 configs"
         )
-    for candidate in candidates:
+    matches = tuple(
+        candidate
+        for candidate in candidates
         if all(
-            type(getattr(requested, name)) is type(getattr(candidate, name))
-            and getattr(requested, name) == getattr(candidate, name)
-            for name in field_names
-        ):
-            return gemm_config_key(candidate)
+            type(value) is type(getattr(candidate, name))
+            and value == getattr(candidate, name)
+            for name, value in config.items()
+        )
+    )
+    if matches:
+        return matches
     raise NotImplementedError(
-        f"FlexGEMM explicit QUACK config is not supported on {device}: {requested}"
+        f"FlexGEMM explicit QUACK config constraints are not supported on {device}: "
+        f"{config}"
     )
 
 
@@ -200,9 +210,14 @@ def candidate_gemm_configs_for_device(device: torch.device):
     return configs
 
 
-def default_gemm_config_key(device: torch.device, m, n) -> GemmConfigKey:
+def default_gemm_config_key(
+    device: torch.device,
+    m,
+    n,
+    configs: Sequence[quack_gemm_config.GemmConfig] | None = None,
+) -> GemmConfigKey:
     """Return the untuned default QuACK config key for generated code."""
-    configs = candidate_gemm_configs_for_device(device)
+    configs = candidate_gemm_configs_for_device(device) if configs is None else configs
     config_keys = OrderedSet([gemm_config_key(config) for config in configs])
     default_key, skinny_key, large_rect_key, large_key = (
         dense_gemm_config_priority_keys()[:4]

--- a/torch/_inductor/heuristics/template/flex_gemm.py
+++ b/torch/_inductor/heuristics/template/flex_gemm.py
@@ -28,6 +28,42 @@ def gemm_config_from_key(config_key: GemmConfigKey) -> quack_gemm_config.GemmCon
     return quack_gemm_config.GemmConfig(**dict(config_key))
 
 
+def explicit_gemm_config_key(
+    config: dict[str, Any], device: torch.device
+) -> GemmConfigKey:
+    """Validate and canonicalize a user-selected QuACK GEMM config.
+
+    Exact type matching prevents bool/int aliases from selecting a different key.
+    """
+    field_names = tuple(field.name for field in fields(quack_gemm_config.GemmConfig))
+    missing = [name for name in field_names if name not in config]
+    unexpected = [name for name in config if name not in field_names]
+    if missing or unexpected:
+        raise NotImplementedError(
+            "FlexGEMM explicit QUACK config must specify exactly the GemmConfig "
+            f"fields; missing={missing}, unexpected={unexpected}"
+        )
+
+    requested = quack_gemm_config.GemmConfig(**config)
+    candidates = candidate_gemm_configs_for_device(device)
+    expected_device_capacity = candidates[0].device_capacity
+    if requested.device_capacity != expected_device_capacity:
+        raise NotImplementedError(
+            f"FlexGEMM explicit QUACK config targets SM{requested.device_capacity}0, "
+            f"but {device} uses SM{expected_device_capacity}0 configs"
+        )
+    for candidate in candidates:
+        if all(
+            type(getattr(requested, name)) is type(getattr(candidate, name))
+            and getattr(requested, name) == getattr(candidate, name)
+            for name in field_names
+        ):
+            return gemm_config_key(candidate)
+    raise NotImplementedError(
+        f"FlexGEMM explicit QUACK config is not supported on {device}: {requested}"
+    )
+
+
 @cache
 def dense_gemm_config_priority_keys() -> tuple[GemmConfigKey, ...]:
     """Return the measured dense FlexGEMM QuACK preference order."""

--- a/torch/_inductor/kernel/flex_gemm/constraints.py
+++ b/torch/_inductor/kernel/flex_gemm/constraints.py
@@ -317,21 +317,17 @@ def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -
     one 32-value epilogue fragment need no cross-fragment combine. Some SM100
     two-CTA layouts expose only 16 contiguous N values, reducing that local limit.
 
-    Non-SM100 devices retain the conservative single-CTA families because the
-    expanded fragment and clustered layouts have only been validated on SM100.
-
     Axis-0 groups and larger axis-1 groups use ``GroupedLocalReduce``'s physical
     callback path, which combines epilogue fragments inside one CTA and directly
-    stores one value per
-    ``(row, group)``; it has no explicit two-CTA ownership or cluster-reduction
-    protocol. The validated two-CTA families therefore support only strict
-    subgroups of the selected tile. A full-tile group produces incorrect values
-    because CTA-local state is finalized as though it had one complete owner.
+    stores one value per ``(row, group)``. For two-CTA ``tile_m=128`` kernels, each
+    CTA has a 64-row epilogue tile whose warps are split 2x2 across M and N. An
+    axis-1 group spanning the full N tile therefore crosses N-warp ownership that
+    the temporal fragment combine does not stitch; strict subgroups remain valid.
 
-    Full-tile support needs either a one-CTA fallback or a real two-CTA contract:
-    CTA-rank-aware row ownership, proof that one CTA has the complete N reduction
-    (or DSM exchange of partials), cluster synchronization, and exactly one final
-    store for each logical output group.
+    Two-CTA ``tile_m=256`` kernels instead have a 128-row epilogue tile with a 4x1
+    warp layout, so one N-warp partition owns each row's full N tile. Their axis-1
+    temporal fragment combine supports a full-tile group without cross-CTA state.
+    Axis-0 full groups still exceed the per-CTA M tile and remain unsupported.
     """
     match axis:
         case 0:
@@ -342,26 +338,6 @@ def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -
             return False
     if group <= 0 or config.swap_ab:
         return False
-    if config.device_capacity != 10:
-        if config.tile_n < 128 or config.tile_n % 64 != 0 or tile % group != 0:
-            return False
-        fragment_width = LOCAL_REDUCE_FRAGMENT_WIDTH
-        if (
-            axis == 1
-            and config.tile_m == 128
-            and config.tile_n == 128
-            and config.cluster_m > 1
-        ):
-            fragment_width //= 2
-        if group <= LOCAL_REDUCE_FRAGMENT_WIDTH:
-            return fragment_width % group == 0 and group < tile
-        return (
-            group % LOCAL_REDUCE_FRAGMENT_WIDTH == 0
-            and group <= tile
-            and config.tile_m == 128
-            and config.cluster_m == 1
-            and config.cluster_n == 1
-        )
     if config.tile_n % LOCAL_REDUCE_FRAGMENT_WIDTH != 0 or tile % group != 0:
         return False
 
@@ -381,13 +357,18 @@ def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -
         return False
 
     is_single_cta_layout = config.tile_m == 128 and config.cluster_m == 1
-    is_validated_two_cta_layout = (config.tile_m == 256 and config.cluster_m == 2) or (
+    is_wide_m_two_cta_layout = config.tile_m == 256 and config.cluster_m == 2
+    is_split_n_warp_two_cta_layout = (
         axis == 1
         and config.tile_m == 128
         and config.tile_n == 256
         and config.cluster_m == 2
     )
-    return is_single_cta_layout or (is_validated_two_cta_layout and group < tile)
+    if is_single_cta_layout:
+        return True
+    if is_wide_m_two_cta_layout:
+        return axis == 1 or group < tile
+    return is_split_n_warp_two_cta_layout and group < tile
 
 
 def flex_gemm_local_reduce_candidate_groups(config: Any, axis: int) -> tuple[int, ...]:

--- a/torch/_inductor/kernel/flex_gemm/constraints.py
+++ b/torch/_inductor/kernel/flex_gemm/constraints.py
@@ -310,15 +310,25 @@ def validate_local_reduce_no_c_alpha_beta(
 
 
 def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -> bool:
-    """Return whether a QuACK config can keep grouped reductions inside one CTA.
+    """Return whether a QuACK config has a validated grouped-reduction layout.
 
-    This host gate covers tile and cluster fields available on ``GemmConfig``.
-    SM100 two-CTA configs with tile_m=128 and tile_n in {128, 160, 224}
-    expose only 16 contiguous N values per epilogue fragment; other accepted
-    configs expose the full 32-wide fragment.
-    Lane/warp ownership is derived later from QuACK's tiled-copy layout, where
-    ``GroupedLocalReduce`` asserts the remaining lane-count, divisibility, and
-    stride invariants. Forced-config tests cover the accepted SM100 extremes.
+    This matches ``GemmConfig`` fields against layout families covered by forced
+    kernel tests; tile divisibility alone is not sufficient. Axis-1 groups within
+    one 32-value epilogue fragment need no cross-fragment combine. Some SM100
+    two-CTA layouts expose only 16 contiguous N values, reducing that local limit.
+
+    Axis-0 groups and larger axis-1 groups use ``GroupedLocalReduce``'s physical
+    callback path, which combines epilogue fragments inside one CTA and directly
+    stores one value per
+    ``(row, group)``; it has no explicit two-CTA ownership or cluster-reduction
+    protocol. The validated two-CTA families therefore support only strict
+    subgroups of the selected tile. A full-tile group produces incorrect values
+    because CTA-local state is finalized as though it had one complete owner.
+
+    Full-tile support needs either a one-CTA fallback or a real two-CTA contract:
+    CTA-rank-aware row ownership, proof that one CTA has the complete N reduction
+    (or DSM exchange of partials), cluster synchronization, and exactly one final
+    store for each logical output group.
     """
     match axis:
         case 0:
@@ -329,37 +339,32 @@ def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -
             return False
     if group <= 0 or config.swap_ab:
         return False
-    if config.tile_n % LOCAL_REDUCE_FRAGMENT_WIDTH != 0:
+    if config.tile_n % LOCAL_REDUCE_FRAGMENT_WIDTH != 0 or tile % group != 0:
         return False
-    if tile % group != 0:
-        return False
+
     fragment_width = LOCAL_REDUCE_FRAGMENT_WIDTH
-    if (
+    has_half_n_fragment = (
         axis == 1
         and config.tile_m == 128
         and config.tile_n in (128, 160, 224)
         and config.cluster_m > 1
-    ):
+    )
+    if has_half_n_fragment:
         fragment_width //= 2
-    match group:
-        case _ if group <= LOCAL_REDUCE_FRAGMENT_WIDTH:
-            return fragment_width % group == 0 and group < tile
-        case _:
-            return (
-                group % LOCAL_REDUCE_FRAGMENT_WIDTH == 0
-                and group <= tile
-                and config.cluster_n == 1
-                and (
-                    (config.tile_m == 128 and config.cluster_m == 1)
-                    or (config.tile_m == 256 and config.cluster_m == 2)
-                    or (
-                        axis == 1
-                        and config.tile_m == 128
-                        and config.tile_n == 256
-                        and config.cluster_m == 2
-                    )
-                )
-            )
+    if group <= LOCAL_REDUCE_FRAGMENT_WIDTH:
+        return fragment_width % group == 0 and group < tile
+
+    if group % LOCAL_REDUCE_FRAGMENT_WIDTH != 0 or config.cluster_n != 1:
+        return False
+
+    is_single_cta_layout = config.tile_m == 128 and config.cluster_m == 1
+    is_validated_two_cta_layout = (config.tile_m == 256 and config.cluster_m == 2) or (
+        axis == 1
+        and config.tile_m == 128
+        and config.tile_n == 256
+        and config.cluster_m == 2
+    )
+    return is_single_cta_layout or (is_validated_two_cta_layout and group < tile)
 
 
 def flex_gemm_local_reduce_candidate_groups(config: Any, axis: int) -> tuple[int, ...]:

--- a/torch/_inductor/kernel/flex_gemm/constraints.py
+++ b/torch/_inductor/kernel/flex_gemm/constraints.py
@@ -352,6 +352,12 @@ def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -
                 and (
                     (config.tile_m == 128 and config.cluster_m == 1)
                     or (config.tile_m == 256 and config.cluster_m == 2)
+                    or (
+                        axis == 1
+                        and config.tile_m == 128
+                        and config.tile_n == 256
+                        and config.cluster_m == 2
+                    )
                 )
             )
 

--- a/torch/_inductor/kernel/flex_gemm/constraints.py
+++ b/torch/_inductor/kernel/flex_gemm/constraints.py
@@ -313,8 +313,9 @@ def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -
     """Return whether a QuACK config can keep grouped reductions inside one CTA.
 
     This host gate covers tile and cluster fields available on ``GemmConfig``.
-    SM100 128x128 two-CTA configs expose only 16 contiguous N values per
-    epilogue fragment; other accepted configs expose the full 32-wide fragment.
+    SM100 two-CTA configs with tile_m=128 and tile_n in {128, 160, 224}
+    expose only 16 contiguous N values per epilogue fragment; other accepted
+    configs expose the full 32-wide fragment.
     Lane/warp ownership is derived later from QuACK's tiled-copy layout, where
     ``GroupedLocalReduce`` asserts the remaining lane-count, divisibility, and
     stride invariants. Forced-config tests cover the accepted SM100 extremes.
@@ -328,7 +329,7 @@ def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -
             return False
     if group <= 0 or config.swap_ab:
         return False
-    if config.tile_n < 128 or config.tile_n % 64 != 0:
+    if config.tile_n % LOCAL_REDUCE_FRAGMENT_WIDTH != 0:
         return False
     if tile % group != 0:
         return False
@@ -336,7 +337,7 @@ def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -
     if (
         axis == 1
         and config.tile_m == 128
-        and config.tile_n == 128
+        and config.tile_n in (128, 160, 224)
         and config.cluster_m > 1
     ):
         fragment_width //= 2
@@ -350,7 +351,7 @@ def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -
                 and config.cluster_n == 1
                 and (
                     (config.tile_m == 128 and config.cluster_m == 1)
-                    or (axis == 1 and config.tile_m == 256 and config.cluster_m == 2)
+                    or (config.tile_m == 256 and config.cluster_m == 2)
                 )
             )
 

--- a/torch/_inductor/kernel/flex_gemm/constraints.py
+++ b/torch/_inductor/kernel/flex_gemm/constraints.py
@@ -347,9 +347,11 @@ def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -
             return (
                 group % LOCAL_REDUCE_FRAGMENT_WIDTH == 0
                 and group <= tile
-                and config.tile_m == 128
-                and config.cluster_m == 1
                 and config.cluster_n == 1
+                and (
+                    (config.tile_m == 128 and config.cluster_m == 1)
+                    or (axis == 1 and config.tile_m == 256 and config.cluster_m == 2)
+                )
             )
 
 

--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -295,8 +295,6 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
         raise NotImplementedError(
             f"unsupported FlexGEMM kernel options: {sorted(unsupported_options)}"
         )
-    if not isinstance(tuned, bool):
-        raise NotImplementedError("FlexGEMM tuned kernel option must be bool")
     if not isinstance(fast_math, bool):
         raise NotImplementedError("FlexGEMM fast_math kernel option must be bool")
     if "config" in kernel_options and not isinstance(explicit_config, dict):

--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -461,6 +461,7 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
         input_nodes,
         layout,
         input_gen_fns=input_gen_fns or None,
+        **({"return_multi_template": False} if mutated_input_nodes else {}),
     )
     return flex_gemm_ordered_outputs(
         result,

--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -189,6 +189,7 @@ def flex_gemm_config_keys_for_local_reduce(
     n: int,
     local_reduce_geometries: tuple[Any, ...],
     tuned: bool,
+    explicit_config_key: tuple[tuple[str, Any], ...] | None = None,
 ) -> tuple[tuple[Any, ...], ...]:
     """Select QuACK config keys after applying grouped-layout config constraints.
 
@@ -204,6 +205,18 @@ def flex_gemm_config_keys_for_local_reduce(
         gemm_config_from_key,
         gemm_config_key,
     )
+
+    if explicit_config_key is not None:
+        config = gemm_config_from_key(explicit_config_key)
+        for geometry in local_reduce_geometries:
+            if not validate_flex_gemm_local_reduce_config(
+                config, geometry.group, geometry.axis
+            ):
+                raise NotImplementedError(
+                    "FlexGEMM explicit QUACK config is incompatible with local "
+                    f"reduction group={geometry.group}, axis={geometry.axis}"
+                )
+        return (explicit_config_key,)
 
     if not tuned:
         default_key = default_gemm_config_key(device, m, n)
@@ -274,15 +287,24 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
         )
     tuned = kernel_options.get("tuned", False)
     fast_math = kernel_options.get("fast_math", False)
+    explicit_config = kernel_options.get("config")
     unsupported_options = OrderedSet(kernel_options) - OrderedSet(
-        ["backend", "tuned", "fast_math"]
+        ["backend", "tuned", "fast_math", "config"]
     )
     if unsupported_options:
         raise NotImplementedError(
             f"unsupported FlexGEMM kernel options: {sorted(unsupported_options)}"
         )
+    if not isinstance(tuned, bool):
+        raise NotImplementedError("FlexGEMM tuned kernel option must be bool")
     if not isinstance(fast_math, bool):
         raise NotImplementedError("FlexGEMM fast_math kernel option must be bool")
+    if "config" in kernel_options and not isinstance(explicit_config, dict):
+        raise NotImplementedError("FlexGEMM config kernel option must be a dict")
+    if explicit_config is not None and tuned:
+        raise NotImplementedError(
+            "FlexGEMM config and tuned kernel options are mutually exclusive"
+        )
 
     from torch._inductor.kernel.flex_gemm.epilogue import (
         analyze_flex_gemm_epilogue,
@@ -398,12 +420,20 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
         epilogue_arg_placeholders,
         fast_math=fast_math,
     )
+    explicit_config_key = None
+    if explicit_config is not None:
+        from torch._inductor.heuristics.template.flex_gemm import (
+            explicit_gemm_config_key,
+        )
+
+        explicit_config_key = explicit_gemm_config_key(explicit_config, layout.device)
     quack_config_keys = flex_gemm_config_keys_for_local_reduce(
         layout.device,
         gemm_args[mat1_index].get_size()[-2],
         gemm_args[mat2_index].get_size()[-1],
         epilogue_analysis.required_geometries,
         tuned,
+        explicit_config_key,
     )
     epilogue_arg_indices = tuple(
         range(

--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -189,7 +189,7 @@ def flex_gemm_config_keys_for_local_reduce(
     n: int,
     local_reduce_geometries: tuple[Any, ...],
     tuned: bool,
-    explicit_config_key: tuple[tuple[str, Any], ...] | None = None,
+    explicit_config: dict[str, Any] | None = None,
 ) -> tuple[tuple[Any, ...], ...]:
     """Select QuACK config keys after applying grouped-layout config constraints.
 
@@ -197,29 +197,25 @@ def flex_gemm_config_keys_for_local_reduce(
     a runtime local-reduce plan or a plan-less grouped TensorSSA fragment
     reshape in the generated epilogue: swap_ab reorients the accumulator
     fragment and non-divisible tiles split groups across fragments, so either
-    would silently regroup the wrong elements.
+    would silently regroup the wrong elements. Explicit config fields constrain
+    the candidate set; untuned selection fills omitted fields from the normal
+    default, while tuned selection benchmarks the matches.
     """
     from torch._inductor.heuristics.template.flex_gemm import (
         candidate_gemm_configs_for_device,
         default_gemm_config_key,
+        explicit_gemm_configs_for_device,
         gemm_config_from_key,
         gemm_config_key,
     )
 
-    if explicit_config_key is not None:
-        config = gemm_config_from_key(explicit_config_key)
-        for geometry in local_reduce_geometries:
-            if not validate_flex_gemm_local_reduce_config(
-                config, geometry.group, geometry.axis
-            ):
-                raise NotImplementedError(
-                    "FlexGEMM explicit QUACK config is incompatible with local "
-                    f"reduction group={geometry.group}, axis={geometry.axis}"
-                )
-        return (explicit_config_key,)
-
+    candidate_configs = (
+        candidate_gemm_configs_for_device(device)
+        if explicit_config is None
+        else explicit_gemm_configs_for_device(explicit_config, device)
+    )
     if not tuned:
-        default_key = default_gemm_config_key(device, m, n)
+        default_key = default_gemm_config_key(device, m, n, candidate_configs)
         if all(
             validate_flex_gemm_local_reduce_config(
                 gemm_config_from_key(default_key), geometry.group, geometry.axis
@@ -228,7 +224,6 @@ def flex_gemm_config_keys_for_local_reduce(
         ):
             return (default_key,)
 
-    candidate_configs = candidate_gemm_configs_for_device(device)
     configs = candidate_configs
     for geometry in local_reduce_geometries:
         configs = tuple(
@@ -239,6 +234,11 @@ def flex_gemm_config_keys_for_local_reduce(
             )
         )
         if not configs:
+            if explicit_config is not None:
+                raise NotImplementedError(
+                    "FlexGEMM explicit QUACK config constraints are incompatible "
+                    f"with local reduction group={geometry.group}, axis={geometry.axis}"
+                )
             raise NotImplementedError(
                 flex_gemm_local_reduce_config_error(
                     candidate_configs,
@@ -299,10 +299,6 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
         raise NotImplementedError("FlexGEMM fast_math kernel option must be bool")
     if "config" in kernel_options and not isinstance(explicit_config, dict):
         raise NotImplementedError("FlexGEMM config kernel option must be a dict")
-    if explicit_config is not None and tuned:
-        raise NotImplementedError(
-            "FlexGEMM config and tuned kernel options are mutually exclusive"
-        )
 
     from torch._inductor.kernel.flex_gemm.epilogue import (
         analyze_flex_gemm_epilogue,
@@ -418,20 +414,13 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
         epilogue_arg_placeholders,
         fast_math=fast_math,
     )
-    explicit_config_key = None
-    if explicit_config is not None:
-        from torch._inductor.heuristics.template.flex_gemm import (
-            explicit_gemm_config_key,
-        )
-
-        explicit_config_key = explicit_gemm_config_key(explicit_config, layout.device)
     quack_config_keys = flex_gemm_config_keys_for_local_reduce(
         layout.device,
         gemm_args[mat1_index].get_size()[-2],
         gemm_args[mat2_index].get_size()[-1],
         epilogue_analysis.required_geometries,
         tuned,
-        explicit_config_key,
+        explicit_config,
     )
     epilogue_arg_indices = tuple(
         range(

--- a/torch/_vendor/quack/epi_ops.py
+++ b/torch/_vendor/quack/epi_ops.py
@@ -1269,9 +1269,21 @@ class GroupedLocalReduce(VecReduce):
             tile = tile_N if const_expr(axis == 1) else tile_M
             assert group != 0 and group <= tile
             assert tile % group == 0
+            tiled_copy = (
+                ctx.tiled_copy_t2r
+                if ctx.tiled_copy_t2r is not None
+                else ctx.tiled_copy_r2s
+            )
+            if const_expr(gemm.arch == 100 and axis == 1 and group == tile_N):
+                _, warp_layout_MN = _get_lane_warp_layouts(
+                    tiled_copy, ctx.tiled_copy_t2r is None
+                )
+                warps_in_N = const_expr(cute.size(warp_layout_MN, mode=[1]))
+                assert warps_in_N == 1, (
+                    "full-N GroupedLocalReduce requires one epilogue N-warp partition"
+                )
             if const_expr(param.feeds_main):
                 assert axis == 0
-                tiled_copy = ctx.tiled_copy_t2r if ctx.tiled_copy_t2r is not None else ctx.tiled_copy_r2s
                 lane_layout_MN, _ = _get_lane_warp_layouts(
                     tiled_copy, ctx.tiled_copy_t2r is None
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190793
* #190158
* #188739
* __->__ #190752
* #190710

Does what it says on the can -> enables users to pass in the direct config they want and plumb to quack; 

-- Agent --
Allow QUACK FlexGEMM callers to replay an autotuned GemmConfig through
kernel_options["config"] without benchmarking the candidate set again.

Require the complete serialized GemmConfig schema, canonicalize it through
the vendored QUACK dataclass and existing GemmConfigKey flow, and reject
configs unsupported by the current device. Explicit configs are mutually
exclusive with tuned=True and still pass local-reduction safety filters.

Add schema, exact-type, device, geometry, generated-code, and numerical
coverage for forced non-default configs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo