### PR TITLE
Drop contiguous-copy workarounds in antialias and bicubic upsample2d

### DIFF
--- a/aten/src/ATen/native/cuda/UpSample.cuh
+++ b/aten/src/ATen/native/cuda/UpSample.cuh
@@ -349,7 +349,8 @@ template <typename scalar_t, typename accscalar_t>
 __device__ __forceinline__ accscalar_t interpolate_aa_single_dim(
     const scalar_t* src,
     const scalar_t* weights,
-    int size) {
+    int size,
+    int64_t stride) {
   accscalar_t t = static_cast<accscalar_t>(*src);
   accscalar_t wts = static_cast<accscalar_t>(weights[0]);
   accscalar_t output = t * wts;
@@ -357,7 +358,7 @@ __device__ __forceinline__ accscalar_t interpolate_aa_single_dim(
   int j = 1;
   for (; j < size; j++) {
     wts = static_cast<accscalar_t>(weights[j]);
-    t = static_cast<accscalar_t>(*(src + j));
+    t = static_cast<accscalar_t>(src[j * stride]);
     output += t * wts;
   }
   return output;

--- a/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu
@@ -334,7 +334,8 @@ static void upsample_bicubic2d_backward_out_cuda_template(
   int input_height = input_size[2];
   int input_width = input_size[3];
 
-  Tensor grad_output = grad_output_.contiguous();
+  // Strided accessors handle any memory format; no contiguous copy needed.
+  const Tensor& grad_output = grad_output_;
 
   grad_input.zero_();
 

--- a/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
@@ -653,11 +653,11 @@ __global__ void upsample_gen2d_aa_out_frame(
       buffer1 = &(idata[n][c][ymin + y][xmin]);
       buffer2[y] = static_cast<scalar_t>(
           upsample_antialias::interpolate_aa_single_dim<scalar_t, accscalar_t>(
-              buffer1, wx, xsize));
+              buffer1, wx, xsize, idata.stride(3)));
     }
     odata[n][c][output_y][output_x] = static_cast<scalar_t>(
         upsample_antialias::interpolate_aa_single_dim<scalar_t, accscalar_t>(
-            buffer2, wy, ysize));
+            buffer2, wy, ysize, 1));
   }
 }
 
@@ -780,11 +780,8 @@ static void upsample_gen2d_aa_out_cuda_template(
   TensorArg input_arg{input_, "input_", 1}, output_arg{output, "output", 2};
   checkAllSameGPU("upsample_gen2d_aa_out_cuda", {input_arg, output_arg});
 
-  // TODO: remove this when the cuda kernel is updated to support the channels_last memory format.
-  // This is a temporary hack to prevent a silence correctness issue when calling this kernel
-  // with tensors in channels_last format.
-  auto output_c = output.is_contiguous() ? output : at::empty(output.sizes(), output.options());
-  auto input = input_.contiguous();
+  // Strided accessors handle any memory format; no contiguous copy needed.
+  const Tensor& input = input_;
 
   int output_height = output_size[0];
   int output_width = output_size[1];
@@ -806,7 +803,7 @@ static void upsample_gen2d_aa_out_cuda_template(
         using accscalar_t = at::acc_type<scalar_t, true>;
 
         auto idata = input.packed_accessor64<const scalar_t, 4>();
-        auto odata = output_c.template packed_accessor64<scalar_t, 4>();
+        auto odata = output.packed_accessor64<scalar_t, 4>();
 
         const accscalar_t height_scale = area_pixel_compute_scale<accscalar_t>(
             input_height, output_height, align_corners, scales_h);
@@ -855,10 +852,6 @@ static void upsample_gen2d_aa_out_cuda_template(
                stream>>>(height_scale, width_scale, idata, odata, interp_filter);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
-
-  if (!output.is_contiguous()) {
-      output.copy_(output_c);
-  }
 }
 
 // In the code below interp_filter_t distinguishes between bilinear and bicubic interpolations
@@ -886,7 +879,8 @@ static void upsample_gen2d_aa_backward_out_cuda_template(
   int input_height = input_size[2];
   int input_width = input_size[3];
 
-  Tensor grad_output = grad_output_.contiguous();
+  // Strided accessors handle any memory format; no contiguous copy needed.
+  const Tensor& grad_output = grad_output_;
 
   grad_input.zero_();
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10502,6 +10502,28 @@ class TestNNDeviceType(NNTestCase):
         t_out = F.interpolate(t_in, size=(2, 2), mode="bicubic", align_corners=False, antialias=True)
         self.assertEqual(expected_out, t_out)
 
+    @onlyCUDA
+    @parametrize_test("mode, antialias", [("bilinear", True), ("bicubic", True), ("bicubic", False)])
+    def test_upsampling2d_channels_last_consistency(self, device, mode, antialias):
+        # The changed CUDA kernels must produce identical forward output and input
+        # grad for channels_last and contiguous inputs, up- and downsampling.
+        torch.manual_seed(0)
+        x = torch.randn(2, 5, 16, 16, device=device)
+        for out_size in [(8, 10), (25, 23)]:
+            kwargs = dict(size=out_size, mode=mode, align_corners=False, antialias=antialias)
+            x_cl = x.clone().contiguous(memory_format=torch.channels_last).requires_grad_()
+            x_co = x.clone().requires_grad_()
+            out_cl = F.interpolate(x_cl, **kwargs)
+            out_co = F.interpolate(x_co, **kwargs)
+            self.assertEqual(out_cl, out_co)
+            self.assertTrue(out_cl.is_contiguous(memory_format=torch.channels_last))
+
+            grad = torch.randn(2, 5, *out_size, device=device)
+            out_cl.backward(grad.contiguous(memory_format=torch.channels_last))
+            out_co.backward(grad.contiguous())
+            self.assertEqual(x_cl.grad, x_co.grad)
+            self.assertTrue(x_cl.grad.is_contiguous(memory_format=torch.channels_last))
+
     @onlyCPU
     @parametrize_test("memory_format", [torch.contiguous_format, torch.channels_last])
     def test_upsamplingLanczos2d_aa_correctness(self, device, memory_format):


### PR DESCRIPTION
Several CUDA upsample2d paths forced input/grad_output to contiguous and copied
the result back, though their kernels already index through strided
PackedTensorAccessors. The only path that genuinely couldn't take a channels_last
tensor was the antialias forward, which walked width through a raw pointer
assuming stride-1: give `interpolate_aa_single_dim` a width stride so it reads
along the accessor stride, then drop the contiguous+copy-back from the aa
forward/backward and the bicubic2d backward. Behavior (values and memory format)
is unchanged; channels_last inputs skip the extra round-trip.

Authored with the help of an AI assistant.
