### PR TITLE
Save forward RNG outputs when the memory-budget partitioner forces recompute

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -66,6 +66,7 @@ from torch._functorch.partitioners import (
     _extract_fwd_bwd_modules,
     _extract_fwd_bwd_outputs,
     _extract_graph_with_inputs_outputs,
+    is_rng_op,
 )
 from torch._higher_order_ops.out_dtype import out_dtype
 from torch._inductor.codecache import compiled_fx_graph_hash
@@ -7265,14 +7266,14 @@ def forward(self, primals_1, tangents_1):
         # so the producer op does not appear in the backward graph.
         self.assertNotIn("topk", bw_graph["gm"].code)
 
-    def _assert_dropout_fw_bw_mask_consistency(self, memory_budget):
+    def _assert_dropout_fw_bw_mask_consistency(self, memory_budget, device="cpu"):
         """Partitioner-forced recompute must not redraw dropout randomness in
         the backward (#190717): the gradient must match the mask the forward
         applied, derived here from the compiled forward's own output.
         """
         # The tests sharing this helper differ only in config, so recompile
         torch._dynamo.reset()
-        w = torch.arange(1.0, 26.0).view(5, 5)
+        w = torch.arange(1.0, 26.0, device=device).view(5, 5)
 
         def f(x):
             return F.dropout(x @ w, 0.5, True)
@@ -7280,7 +7281,7 @@ def forward(self, primals_1, tangents_1):
         with torch._functorch.config.patch(activation_memory_budget=memory_budget):
             compiled = torch.compile(f)
             torch.manual_seed(42)
-            x = torch.ones(2, 5, requires_grad=True)
+            x = torch.ones(2, 5, device=device, requires_grad=True)
             out = compiled(x)
             out.sum().backward()
         # x @ w is strictly positive, so the forward output reveals the mask
@@ -7296,7 +7297,17 @@ def forward(self, primals_1, tangents_1):
     def test_min_cut_partitioner_rng_budget_one_dropout_mask_consistency(self):
         self._assert_dropout_fw_bw_mask_consistency(memory_budget=1.0)
 
-    def _assert_rng_mlp_eager_parity(self, memory_budget):
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    def test_min_cut_partitioner_rng_budget_zero_dropout_mask_consistency_cuda(self):
+        self._assert_dropout_fw_bw_mask_consistency(memory_budget=0.0, device="cuda")
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    def test_min_cut_partitioner_rng_budget_one_dropout_mask_consistency_cuda(self):
+        self._assert_dropout_fw_bw_mask_consistency(memory_budget=1.0, device="cuda")
+
+    def _assert_rng_mlp_eager_parity(self, memory_budget, device="cpu"):
         """With fallback_random, compiled fw+bw must exactly match eager even
         when the memory budget forces recompute of everything else (#190717).
         """
@@ -7312,10 +7323,8 @@ def forward(self, primals_1, tangents_1):
 
         def run(fn, seed):
             torch.manual_seed(seed)
-            args = [
-                torch.rand(64, 64, dtype=torch.float64, requires_grad=True)
-                for _ in range(3)
-            ]
+            kwargs = {"dtype": torch.float64, "device": device}
+            args = [torch.rand(64, 64, **kwargs, requires_grad=True) for _ in range(3)]
             out = fn(*args)
             out.sum().backward()
             return out, args
@@ -7343,11 +7352,80 @@ def forward(self, primals_1, tangents_1):
         self._assert_rng_mlp_eager_parity(memory_budget=0.005)
 
     @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_half_eager_parity(self):
+        self._assert_rng_mlp_eager_parity(memory_budget=0.5)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    def test_min_cut_partitioner_rng_budget_zero_eager_parity_cuda(self):
+        self._assert_rng_mlp_eager_parity(memory_budget=0.0, device="cuda")
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    def test_min_cut_partitioner_rng_budget_knapsack_eager_parity_cuda(self):
+        self._assert_rng_mlp_eager_parity(memory_budget=0.005, device="cuda")
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    def test_min_cut_partitioner_rng_budget_half_eager_parity_cuda(self):
+        self._assert_rng_mlp_eager_parity(memory_budget=0.5, device="cuda")
+
+    def _assert_rng_ops_saved_not_recomputed(self, memory_budget):
+        """Structural check on the partitioned graphs (#190717): under a
+        forcing memory budget the backward must contain no rng op, and the
+        forward must save the rng outputs (at least each dropout mask).
+        """
+        fw_graph_cell = [None]
+        bw_graph_cell = [None]
+
+        def f(x, w):
+            h = F.dropout(F.relu(x @ w), 0.5, True)
+            return F.dropout(h @ w, 0.3, True)
+
+        args = [torch.rand(64, 64, requires_grad=True) for _ in range(2)]
+        with torch._functorch.config.patch(activation_memory_budget=memory_budget):
+            aot_function(
+                f,
+                fw_compiler=partial(extract_graph, graph_cell=fw_graph_cell),
+                bw_compiler=partial(extract_graph, graph_cell=bw_graph_cell),
+                partition_fn=min_cut_rematerialization_partition,
+            )(*args).sum().backward()
+
+        fw_graph, bw_graph = fw_graph_cell[0], bw_graph_cell[0]
+        fw_calls = [n for n in fw_graph.graph.nodes if n.op == "call_function"]
+        bw_calls = [n for n in bw_graph.graph.nodes if n.op == "call_function"]
+        fw_rng = [n for n in fw_calls if is_rng_op(n)]
+        self.assertEqual(len(fw_rng), 2)
+        self.assertEqual([n for n in bw_calls if is_rng_op(n)], [])
+        # The budget did force recompute (relu reappears in the backward),
+        # so the absence of rng ops there is not vacuous.
+        self.assertIn(torch.ops.aten.relu.default, [n.target for n in bw_calls])
+        saved = get_ins_outs(fw_graph)[1]
+        for rng_node in fw_rng:
+            getitems = [u for u in rng_node.users if u.target is operator.getitem]
+            masks = [g for g in getitems if g.args[1] == 1]
+            self.assertEqual(len(masks), 1)
+            self.assertIn(masks[0], saved)
+            if memory_budget == 0:
+                # The budget == 0 shortcut saves every getitem projection
+                self.assertTrue(all(g in saved for g in getitems))
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_zero_bw_graph_has_no_rng_ops(self):
+        self._assert_rng_ops_saved_not_recomputed(memory_budget=0.0)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_knapsack_bw_graph_has_no_rng_ops(self):
+        self._assert_rng_ops_saved_not_recomputed(memory_budget=0.005)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
     @torch._functorch.config.patch(activation_memory_budget=0.0)
     def test_min_cut_partitioner_rng_budget_zero_backward_only_rng(self):
         """Backward-only rng ops are not forward nodes and must not be forced
-        into the saved values (that would make an invalid node an fw output).
+        into the saved values (that would make an invalid node an fw output);
+        with fallback_random the backward draw must match eager exactly.
         """
+        torch._dynamo.reset()
 
         class NoisyGrad(torch.autograd.Function):
             @staticmethod
@@ -7361,9 +7439,21 @@ def forward(self, primals_1, tangents_1):
         def f(x):
             return NoisyGrad.apply(x * 2.0).sum()
 
-        x = torch.randn(8, 8, requires_grad=True)
-        torch.compile(f)(x).backward()
-        self.assertEqual(x.grad.shape, x.shape)
+        def run(fn, seed):
+            arg = x.detach().clone().requires_grad_()
+            out = fn(arg)
+            torch.manual_seed(seed)
+            out.backward()
+            return arg.grad
+
+        x = torch.randn(8, 8)
+        with torch._inductor.config.patch(fallback_random=True):
+            compiled = torch.compile(f)
+            # Warm up first so compilation cannot perturb the measured rng
+            run(compiled, seed=99999)
+            eager_grad = run(f, seed=42)
+            compiled_grad = run(compiled, seed=42)
+        self.assertEqual(compiled_grad, eager_grad)
 
     def test_disable_functionalization_ignores_effect_token_metadata(self):
         def fn(args):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7266,110 +7266,6 @@ def forward(self, primals_1, tangents_1):
         # so the producer op does not appear in the backward graph.
         self.assertNotIn("topk", bw_graph["gm"].code)
 
-    def _assert_dropout_fw_bw_mask_consistency(self, memory_budget, device="cpu"):
-        """Partitioner-forced recompute must not redraw dropout randomness in
-        the backward (#190717): the gradient must match the mask the forward
-        applied, derived here from the compiled forward's own output.
-        """
-        # The tests sharing this helper differ only in config, so recompile
-        torch._dynamo.reset()
-        w = torch.arange(1.0, 26.0, device=device).view(5, 5)
-
-        def f(x):
-            return F.dropout(x @ w, 0.5, True)
-
-        with torch._functorch.config.patch(activation_memory_budget=memory_budget):
-            compiled = torch.compile(f)
-            torch.manual_seed(42)
-            x = torch.ones(2, 5, device=device, requires_grad=True)
-            out = compiled(x)
-            out.sum().backward()
-        # x @ w is strictly positive, so the forward output reveals the mask
-        # actually applied; the dropout scale at p=0.5 is 2.
-        mask = (out.detach() != 0).float()
-        self.assertEqual(x.grad, 2.0 * mask @ w.t())
-
-    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
-    def test_min_cut_partitioner_rng_budget_zero_dropout_mask_consistency(self):
-        self._assert_dropout_fw_bw_mask_consistency(memory_budget=0.0)
-
-    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
-    def test_min_cut_partitioner_rng_budget_one_dropout_mask_consistency(self):
-        self._assert_dropout_fw_bw_mask_consistency(memory_budget=1.0)
-
-    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
-    def test_min_cut_partitioner_rng_budget_zero_dropout_mask_consistency_cuda(self):
-        self._assert_dropout_fw_bw_mask_consistency(memory_budget=0.0, device="cuda")
-
-    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
-    def test_min_cut_partitioner_rng_budget_one_dropout_mask_consistency_cuda(self):
-        self._assert_dropout_fw_bw_mask_consistency(memory_budget=1.0, device="cuda")
-
-    def _assert_rng_mlp_eager_parity(self, memory_budget, device="cpu"):
-        """With fallback_random, compiled fw+bw must exactly match eager even
-        when the memory budget forces recompute of everything else (#190717).
-        """
-        # The tests sharing this helper differ only in config, so recompile
-        torch._dynamo.reset()
-
-        def f(x, w1, w2):
-            h = F.relu(x @ w1)
-            h = F.dropout(h, 0.5, True)
-            h = h * torch.randn_like(h)
-            h = F.relu(h @ w2)
-            return F.dropout(h, 0.3, True)
-
-        def run(fn, seed):
-            torch.manual_seed(seed)
-            kwargs = {"dtype": torch.float64, "device": device}
-            args = [torch.rand(64, 64, **kwargs, requires_grad=True) for _ in range(3)]
-            out = fn(*args)
-            out.sum().backward()
-            return out, args
-
-        fallback = torch._inductor.config.patch(fallback_random=True)
-        budget = torch._functorch.config.patch(activation_memory_budget=memory_budget)
-        with fallback, budget:
-            compiled = torch.compile(f)
-            # Warm up first so compilation cannot perturb the measured rng
-            run(compiled, seed=99999)
-            eager_out, eager_args = run(f, seed=42)
-            compiled_out, compiled_args = run(compiled, seed=42)
-        self.assertEqual(compiled_out, eager_out)
-        for eager_arg, compiled_arg in zip(eager_args, compiled_args):
-            self.assertEqual(compiled_arg.grad, eager_arg.grad)
-
-    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
-    def test_min_cut_partitioner_rng_budget_zero_eager_parity(self):
-        self._assert_rng_mlp_eager_parity(memory_budget=0.0)
-
-    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
-    def test_min_cut_partitioner_rng_budget_knapsack_eager_parity(self):
-        # A small fractional budget takes the knapsack path instead of the
-        # budget == 0 shortcut.
-        self._assert_rng_mlp_eager_parity(memory_budget=0.005)
-
-    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
-    def test_min_cut_partitioner_rng_budget_half_eager_parity(self):
-        self._assert_rng_mlp_eager_parity(memory_budget=0.5)
-
-    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
-    def test_min_cut_partitioner_rng_budget_zero_eager_parity_cuda(self):
-        self._assert_rng_mlp_eager_parity(memory_budget=0.0, device="cuda")
-
-    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
-    def test_min_cut_partitioner_rng_budget_knapsack_eager_parity_cuda(self):
-        self._assert_rng_mlp_eager_parity(memory_budget=0.005, device="cuda")
-
-    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
-    def test_min_cut_partitioner_rng_budget_half_eager_parity_cuda(self):
-        self._assert_rng_mlp_eager_parity(memory_budget=0.5, device="cuda")
-
     def _assert_rng_ops_saved_not_recomputed(self, memory_budget):
         """Structural check on the partitioned graphs (#190717): under a
         forcing memory budget the backward must contain no rng op, and the
@@ -10372,6 +10268,153 @@ def forward(self, primals_1, tangents_1):
         out.sum().backward()
 
 
+class TestPartitioningRngBudget(AOTTestCase):
+    def _assert_dropout_fw_bw_mask_consistency(self, memory_budget, device):
+        """Partitioner-forced recompute must not redraw dropout randomness in
+        the backward (#190717): the gradient must match the mask the forward
+        applied, derived here from the compiled forward's own output.
+        """
+        # The tests sharing this helper differ only in config, so recompile
+        torch._dynamo.reset()
+        w = torch.arange(1.0, 26.0, device=device).view(5, 5)
+
+        def f(x):
+            return F.dropout(x @ w, 0.5, True)
+
+        with torch._functorch.config.patch(activation_memory_budget=memory_budget):
+            compiled = torch.compile(f)
+            torch.manual_seed(42)
+            x = torch.ones(2, 5, device=device, requires_grad=True)
+            out = compiled(x)
+            out.sum().backward()
+        # x @ w is strictly positive, so the forward output reveals the mask
+        # actually applied; the dropout scale at p=0.5 is 2.
+        mask = (out.detach() != 0).float()
+        self.assertEqual(x.grad, 2.0 * mask @ w.t())
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_zero_dropout_mask_consistency(self, device):
+        self._assert_dropout_fw_bw_mask_consistency(memory_budget=0.0, device=device)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_one_dropout_mask_consistency(self, device):
+        self._assert_dropout_fw_bw_mask_consistency(memory_budget=1.0, device=device)
+
+    def _assert_rng_mlp_eager_parity(self, memory_budget, device):
+        """With fallback_random, compiled fw+bw must exactly match eager even
+        when the memory budget forces recompute of everything else (#190717).
+        """
+        # The tests sharing this helper differ only in config, so recompile
+        torch._dynamo.reset()
+
+        def f(x, w1, w2):
+            h = F.relu(x @ w1)
+            h = F.dropout(h, 0.5, True)
+            h = h * torch.randn_like(h)
+            h = F.relu(h @ w2)
+            return F.dropout(h, 0.3, True)
+
+        def run(fn, seed):
+            torch.manual_seed(seed)
+            kwargs = {"dtype": torch.float64, "device": device}
+            args = [torch.rand(64, 64, **kwargs, requires_grad=True) for _ in range(3)]
+            out = fn(*args)
+            out.sum().backward()
+            return out, args
+
+        fallback = torch._inductor.config.patch(fallback_random=True)
+        budget = torch._functorch.config.patch(activation_memory_budget=memory_budget)
+        with fallback, budget:
+            compiled = torch.compile(f)
+            # Warm up first so compilation cannot perturb the measured rng
+            run(compiled, seed=99999)
+            eager_out, eager_args = run(f, seed=42)
+            compiled_out, compiled_args = run(compiled, seed=42)
+        self.assertEqual(compiled_out, eager_out)
+        for eager_arg, compiled_arg in zip(eager_args, compiled_args):
+            self.assertEqual(compiled_arg.grad, eager_arg.grad)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_zero_eager_parity(self, device):
+        self._assert_rng_mlp_eager_parity(memory_budget=0.0, device=device)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_knapsack_eager_parity(self, device):
+        # A small fractional budget takes the knapsack path instead of the
+        # budget == 0 shortcut.
+        self._assert_rng_mlp_eager_parity(memory_budget=0.005, device=device)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_half_eager_parity(self, device):
+        self._assert_rng_mlp_eager_parity(memory_budget=0.5, device=device)
+
+    def _assert_multinomial_denylist_no_recompute(
+        self, aggressive_recomputation, device
+    ):
+        """Multinomial must be saved, not redrawn, at a fractional budget
+        (#190717): gather's backward depends on its forward-sampled indices.
+        """
+        size = 64
+
+        def f(table):
+            probabilities = torch.full_like(table, 1.0 / table.shape[1])
+            indices = torch.multinomial(
+                probabilities, num_samples=table.shape[1], replacement=True
+            )
+            return torch.gather(table, 1, indices)
+
+        fw_graph_cell = [None]
+        bw_graph_cell = [None]
+        table = torch.arange(float(size * size), device=device).view(size, size)
+        table.requires_grad_()
+        budget = torch._functorch.config.patch(
+            activation_memory_budget=0.5,
+            aggressive_recomputation=aggressive_recomputation,
+        )
+        with budget:
+            aot_function(
+                f,
+                fw_compiler=partial(extract_graph, graph_cell=fw_graph_cell),
+                bw_compiler=partial(extract_graph, graph_cell=bw_graph_cell),
+                partition_fn=min_cut_rematerialization_partition,
+            )(table).sum().backward()
+
+        bw_graph = bw_graph_cell[0]
+        bw_targets = [n.target for n in bw_graph.graph.nodes if n.op == "call_function"]
+        self.assertNotIn(torch.ops.aten.multinomial.default, bw_targets)
+
+        # The tests sharing this helper differ only in config, so recompile
+        torch._dynamo.reset()
+
+        def run(fn, seed):
+            torch.manual_seed(seed)
+            arg = torch.arange(float(size * size), device=device).view(size, size)
+            arg.requires_grad_()
+            out = fn(arg)
+            out.sum().backward()
+            return out, arg
+
+        fallback = torch._inductor.config.patch(fallback_random=True)
+        with fallback, budget:
+            compiled = torch.compile(f)
+            # Warm up first so compilation cannot perturb the measured rng
+            run(compiled, seed=99999)
+            eager_out, eager_arg = run(f, seed=42)
+            compiled_out, compiled_arg = run(compiled, seed=42)
+        self.assertEqual(compiled_out, eager_out)
+        self.assertEqual(compiled_arg.grad, eager_arg.grad)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_half_multinomial_no_recompute(self, device):
+        self._assert_multinomial_denylist_no_recompute(False, device=device)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_half_multinomial_no_recompute_aggressive(
+        self, device
+    ):
+        self._assert_multinomial_denylist_no_recompute(True, device=device)
+
+
 class TestAOTDispatch(AOTTestCase):
     # Tests to add cases for (non-exhaustive list, mostly for my notes):
     # - subclass / mode introduced in the middle of the compiled fn
@@ -12594,6 +12637,7 @@ instantiate_device_type_tests(
 )
 instantiate_device_type_tests(TestEagerFusionOpInfo, globals(), only_for=only_for)
 instantiate_device_type_tests(TestEagerFusionModuleInfo, globals(), only_for=only_for)
+instantiate_device_type_tests(TestPartitioningRngBudget, globals())
 
 
 @xfail_inherited_tests(

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7265,6 +7265,106 @@ def forward(self, primals_1, tangents_1):
         # so the producer op does not appear in the backward graph.
         self.assertNotIn("topk", bw_graph["gm"].code)
 
+    def _assert_dropout_fw_bw_mask_consistency(self, memory_budget):
+        """Partitioner-forced recompute must not redraw dropout randomness in
+        the backward (#190717): the gradient must match the mask the forward
+        applied, derived here from the compiled forward's own output.
+        """
+        # The tests sharing this helper differ only in config, so recompile
+        torch._dynamo.reset()
+        w = torch.arange(1.0, 26.0).view(5, 5)
+
+        def f(x):
+            return F.dropout(x @ w, 0.5, True)
+
+        with torch._functorch.config.patch(activation_memory_budget=memory_budget):
+            compiled = torch.compile(f)
+            torch.manual_seed(42)
+            x = torch.ones(2, 5, requires_grad=True)
+            out = compiled(x)
+            out.sum().backward()
+        # x @ w is strictly positive, so the forward output reveals the mask
+        # actually applied; the dropout scale at p=0.5 is 2.
+        mask = (out.detach() != 0).float()
+        self.assertEqual(x.grad, 2.0 * mask @ w.t())
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_zero_dropout_mask_consistency(self):
+        self._assert_dropout_fw_bw_mask_consistency(memory_budget=0.0)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_one_dropout_mask_consistency(self):
+        self._assert_dropout_fw_bw_mask_consistency(memory_budget=1.0)
+
+    def _assert_rng_mlp_eager_parity(self, memory_budget):
+        """With fallback_random, compiled fw+bw must exactly match eager even
+        when the memory budget forces recompute of everything else (#190717).
+        """
+        # The tests sharing this helper differ only in config, so recompile
+        torch._dynamo.reset()
+
+        def f(x, w1, w2):
+            h = F.relu(x @ w1)
+            h = F.dropout(h, 0.5, True)
+            h = h * torch.randn_like(h)
+            h = F.relu(h @ w2)
+            return F.dropout(h, 0.3, True)
+
+        def run(fn, seed):
+            torch.manual_seed(seed)
+            args = [
+                torch.rand(64, 64, dtype=torch.float64, requires_grad=True)
+                for _ in range(3)
+            ]
+            out = fn(*args)
+            out.sum().backward()
+            return out, args
+
+        fallback = torch._inductor.config.patch(fallback_random=True)
+        budget = torch._functorch.config.patch(activation_memory_budget=memory_budget)
+        with fallback, budget:
+            compiled = torch.compile(f)
+            # Warm up first so compilation cannot perturb the measured rng
+            run(compiled, seed=99999)
+            eager_out, eager_args = run(f, seed=42)
+            compiled_out, compiled_args = run(compiled, seed=42)
+        self.assertEqual(compiled_out, eager_out)
+        for eager_arg, compiled_arg in zip(eager_args, compiled_args):
+            self.assertEqual(compiled_arg.grad, eager_arg.grad)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_zero_eager_parity(self):
+        self._assert_rng_mlp_eager_parity(memory_budget=0.0)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_rng_budget_knapsack_eager_parity(self):
+        # A small fractional budget takes the knapsack path instead of the
+        # budget == 0 shortcut.
+        self._assert_rng_mlp_eager_parity(memory_budget=0.005)
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    @torch._functorch.config.patch(activation_memory_budget=0.0)
+    def test_min_cut_partitioner_rng_budget_zero_backward_only_rng(self):
+        """Backward-only rng ops are not forward nodes and must not be forced
+        into the saved values (that would make an invalid node an fw output).
+        """
+
+        class NoisyGrad(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, g):
+                return g * torch.rand_like(g)
+
+        def f(x):
+            return NoisyGrad.apply(x * 2.0).sum()
+
+        x = torch.randn(8, 8, requires_grad=True)
+        torch.compile(f)(x).backward()
+        self.assertEqual(x.grad.shape, x.shape)
+
     def test_disable_functionalization_ignores_effect_token_metadata(self):
         def fn(args):
             (x,) = args

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -3469,7 +3469,28 @@ def choose_saved_values_set(
             ban_if_not_in_allowlist=False,
         )
     if memory_budget == 0:
-        return node_info.inputs
+        # Saving only the inputs recomputes everything else in the backward,
+        # but recomputed RNG ops draw fresh randomness there (#190717): e.g.
+        # dropout would apply a different mask in fw and bw. Also save the
+        # tensor outputs of forward RNG ops.
+        saved_values = list(node_info.inputs)
+        saved_set = OrderedSet[fx.Node](saved_values)
+        for node in joint_graph.nodes:
+            if not (
+                node.op == "call_function"
+                and is_rng_op(node)
+                and node_info.is_required_fw(node)
+            ):
+                continue
+            if isinstance(node.meta.get("val"), (tuple, list)):
+                # Save every getitem projection, including bw-only ones such
+                # as dropout masks; the tuple node itself is not saveable.
+                outputs = [u for u in node.users if u.target is operator.getitem]
+            else:
+                outputs = [node]
+            saved_values.extend(o for o in outputs if o not in saved_set)
+            saved_set.update(outputs)
+        return saved_values
 
     runtime_optimized_saved_values, _ = solve_min_cut(
         joint_graph,
@@ -3537,6 +3558,8 @@ def choose_saved_values_set(
             if (
                 # Only allow recomputing nodes that are actually required for BW
                 i.dist_from_bw < int(1e9)  # type: ignore[attr-defined]
+                # RNG ops stay banned: recomputing them draws fresh randomness
+                and not is_rng_op(i)
                 and (
                     get_node_storage(i) not in input_storages
                     or is_non_builtin_to_include(i)

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -2550,7 +2550,7 @@ def solve_min_cut(
             if not op_types.is_recomputable(node):
                 return "not in recomputable allowlist"
         else:
-            if op_types.is_random(node):
+            if op_types.is_random(node) or is_rng_op(node):
                 return "random op"
             if op_types.is_compute_intensive(node):
                 return "compute intensive op"


### PR DESCRIPTION
below is the more refined submission, please read carefully,
P.S: Fable-Assisted

Fixes #190758, Fixes #190717

## Problem

With `torch._functorch.config.activation_memory_budget < 1.0`, the partitioner can
force RNG ops (dropout, `randn_like`) to be recomputed in the backward graph. The
recomputed op draws fresh randomness there, so the backward applies a different
dropout mask than the one the forward actually used. Gradients are silently wrong —
no error, no warning. In a small training test at budget=0 this diverges to NaN loss
and near-chance accuracy; with the fix, compiled training matches eager exactly.
Full analysis, minimal repro, graph traces and training numbers: #190758.

## Root cause

Two independent paths produce the same corruption:

1. At `budget == 0`, `choose_saved_values_set` returns early with only the graph
   inputs and never calls `solve_min_cut`, so the existing "random op" recompute ban
   never runs. With `TORCH_LOGS=aot_graphs` the forward and backward graphs each
   contain their own `prims.inductor_seeds` call.
2. At `0 < budget < 1`, the ban does run, but the knapsack path can trade the banned
   rng ops back into recompute: `get_recomputable_banned_nodes` has no rng filter,
   and `dont_ban` overrides the ban. Reproduced at budgets 0.005 and 0.5.

The rng state-pairing machinery (`functionalize_rng_ops`) helps in neither case:
it is gated on user activation-checkpointing recompute tags, which partitioner-forced
recompute never sets.

## Fix

- The `budget == 0` shortcut now also saves the tensor outputs of forward rng ops.
  Ops are selected with the partitioner's existing `is_rng_op` (the
  `nondeterministic_seeded` tag): this matches `prims.inductor_seeds` and the aten
  rng ops, but not `inductor_lookup_seed`/`inductor_random`, which are deterministic
  given the seeds — so on the default inductor path only the small seeds tensor is
  saved. For tuple-output ops (`native_dropout`) all getitem projections are saved
  (saving the tuple node breaks saved-tensor accounting); backward-only rng ops are
  excluded (forcing them into saved values makes an invalid node a forward output).
- `get_recomputable_banned_nodes` no longer offers rng ops as knapsack candidates,
  so the solver's ban stays final at every budget, as it already is at budget 1.0.

Memory cost, stated honestly: on the default inductor path this saves one small
`inductor_seeds` tensor. On paths where aten rng ops survive to partition time
(`fallback_random=True`, `aot_eager`), it saves the rng ops' actual outputs — the
same tensors budget=1.0 already saves for them. Correctness over savings.

An alternative design — threading real RNG state through partitioner-forced
recompute by extending `functionalize_rng_ops` beyond AC tags — would preserve more
of the memory savings, but is a larger, CUDA-entangled change. This PR takes the
minimal-blast-radius repair; the state-threading redesign is left as a possible
follow-up for maintainers to weigh.

## Verified

- Structural tests capture the partitioned graphs and assert the backward contains
  no rng op while the forward saves the rng outputs (each dropout mask at both
  forcing budgets, every projection at budget 0), with a non-vacuousness guard
  proving the budget really forced recompute. Both fail without the fix.
- Behavioral tests: dropout fw/bw mask self-consistency at budgets 0.0 and 1.0,
  exact eager parity under `fallback_random=True` at budgets 0.0, 0.005 (knapsack
  regime) and 0.5, and a backward-only rng op asserting bit-exact gradients via a
  seed-aligned eager comparison. The consistency and parity tests fail without the
  fix.
- CUDA twins for the helper-based tests, so GPU CI exercises the same checks on
  real GPUs.
- Saved-value sets at budget=1.0 verified byte-identical before/after the change.
- Training check at budget=0: a small two-dropout MLP goes from NaN loss and
  near-chance accuracy to matching eager exactly (numbers in #190758).