### PR TITLE
Add c10::Bitfield and reuse it in CUDA's software bitfield path

### DIFF
--- a/aten/src/ATen/cuda/AsmUtils.cuh
+++ b/aten/src/ATen/cuda/AsmUtils.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include <c10/util/bitfield.h>
 #include <cstdint>
 
 // Collection of direct PTX functions
@@ -13,11 +14,7 @@ struct Bitfield<unsigned int> {
   static __device__ __host__ __forceinline__
   unsigned int getBitfield(unsigned int val, int pos, int len) {
 #if !defined(__CUDA_ARCH__)
-    pos &= 0xff;
-    len &= 0xff;
-
-    unsigned int m = (1u << len) - 1u;
-    return (val >> pos) & m;
+    return c10::Bitfield<unsigned int>::getBitfield(val, pos, len);
 #else
     unsigned int ret;
     asm("bfe.u32 %0, %1, %2, %3;" : "=r"(ret) : "r"(val), "r"(pos), "r"(len));
@@ -28,15 +25,8 @@ struct Bitfield<unsigned int> {
   static __device__ __host__ __forceinline__
   unsigned int setBitfield(unsigned int val, unsigned int toInsert, int pos, int len) {
 #if !defined(__CUDA_ARCH__)
-    pos &= 0xff;
-    len &= 0xff;
-
-    unsigned int m = (1u << len) - 1u;
-    toInsert &= m;
-    toInsert <<= pos;
-    m <<= pos;
-
-    return (val & ~m) | toInsert;
+    return c10::Bitfield<unsigned int>::setBitfield(
+        val, toInsert, pos, len);
 #else
     unsigned int ret;
     asm("bfi.b32 %0, %1, %2, %3, %4;" :
@@ -51,11 +41,7 @@ struct Bitfield<uint64_t> {
   static __device__ __host__ __forceinline__
   uint64_t getBitfield(uint64_t val, int pos, int len) {
 #if !defined(__CUDA_ARCH__)
-    pos &= 0xff;
-    len &= 0xff;
-
-    uint64_t m = (static_cast<uint64_t>(1) << len) - 1;
-    return (val >> pos) & m;
+    return c10::Bitfield<uint64_t>::getBitfield(val, pos, len);
 #else
     uint64_t ret;
     asm("bfe.u64 %0, %1, %2, %3;" : "=l"(ret) : "l"(val), "r"(pos), "r"(len));
@@ -66,15 +52,8 @@ struct Bitfield<uint64_t> {
   static __device__ __host__ __forceinline__
   uint64_t setBitfield(uint64_t val, uint64_t toInsert, int pos, int len) {
 #if !defined(__CUDA_ARCH__)
-    pos &= 0xff;
-    len &= 0xff;
-
-    uint64_t m = (static_cast<uint64_t>(1) << len) - 1;
-    toInsert &= m;
-    toInsert <<= pos;
-    m <<= pos;
-
-    return (val & ~m) | toInsert;
+    return c10::Bitfield<uint64_t>::setBitfield(
+        val, toInsert, pos, len);
 #else
     uint64_t ret;
     asm("bfi.b64 %0, %1, %2, %3, %4;" :

--- a/c10/util/bitfield.h
+++ b/c10/util/bitfield.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+
+#include <type_traits>
+
+namespace c10 {
+
+// getBitfield/setBitfield require pos, len in [0, bit-width of T); out-of-range
+// values shift by >= the width and are undefined.
+template <typename T>
+requires std::is_unsigned_v<T> struct Bitfield {
+  C10_HOST_DEVICE static inline T getBitfield(T val, int pos, int len) {
+    T m = (static_cast<T>(1) << len) - 1;
+    return (val >> pos) & m;
+  }
+
+  C10_HOST_DEVICE static inline T setBitfield(
+      T val,
+      T toInsert,
+      int pos,
+      int len) {
+    T m = (static_cast<T>(1) << len) - 1;
+    toInsert &= m;
+    toInsert <<= pos;
+    m <<= pos;
+    return (val & ~m) | toInsert;
+  }
+};
+
+} // namespace c10


### PR DESCRIPTION
The C++ (non-PTX) bitfield extract/insert was duplicated across the CUDA host path and other backends. Move it to a portable c10::Bitfield; CUDA's host branch delegates to it while device code keeps the PTX bfe/bfi fast path. Drops the vestigial pos/len &= 0xff masking (a no-op in range, and no protection against the out-of-range shift UB). No defined behavior change.

Test Plan: existing top-k/sort tests, e.g. test/test_sort_and_select.py.

Authored with the assistance of an AI agent.