### PR TITLE
[Testcase Refactoring] Split test_c10d_spawn_gloo by hardware classification

### DIFF
--- a/test/distributed/test_c10d_spawn.py
+++ b/test/distributed/test_c10d_spawn.py
@@ -117,14 +117,14 @@ class TestDistributedNNFunctions(MultiProcessTestCase):
     def world_size(self):
         return 2
 
-    def _test_broadcast(self, backend):
+    def _test_broadcast(self, backend, device_type="cuda"):
         store = c10d.FileStore(self.file_name, self.world_size)
         # This is required because these functions calls directly to the .dist and needs
         # the world to be initialized
         c10d.init_process_group(
             store=store, rank=self.rank, world_size=self.world_size, backend=backend
         )
-        device = torch.device(f"cuda:{self.rank}")
+        device = torch.device(device_type, self.rank)
         x = torch.ones(5, 5, device=device) + self.rank
         x.requires_grad = True
         y = torch.distributed.nn.broadcast(x, 1)
@@ -137,14 +137,14 @@ class TestDistributedNNFunctions(MultiProcessTestCase):
         elif self.rank == 0:
             self.assertEqual(x.grad, torch.zeros(5, 5, device=device))
 
-    def _test_reduce(self, backend):
+    def _test_reduce(self, backend, device_type="cuda"):
         store = c10d.FileStore(self.file_name, self.world_size)
         # This is required because these functions calls directly to the .dist and needs
         # the world to be initialized
         c10d.init_process_group(
             store=store, rank=self.rank, world_size=self.world_size, backend=backend
         )
-        device = torch.device(f"cuda:{self.rank}")
+        device = torch.device(device_type, self.rank)
         x = torch.ones(5, 5, device=device) + self.rank
         x.requires_grad = True
         y = torch.distributed.nn.reduce(x, 1, op=c10d.ReduceOp.SUM)
@@ -158,14 +158,14 @@ class TestDistributedNNFunctions(MultiProcessTestCase):
         x_g = (3 * torch.ones(5, 5, device=device)).cos()
         self.assertEqual(x.grad, x_g)
 
-    def _test_allreduce(self, backend):
+    def _test_allreduce(self, backend, device_type="cuda"):
         store = c10d.FileStore(self.file_name, self.world_size)
         # This is required because these functions calls directly to the .dist and needs
         # the world to be initialized
         c10d.init_process_group(
             store=store, rank=self.rank, world_size=self.world_size, backend=backend
         )
-        device = torch.device(f"cuda:{self.rank}")
+        device = torch.device(device_type, self.rank)
         x = torch.ones(5, 5, device=device) + self.rank
         x.requires_grad = True
         y = torch.distributed.nn.all_reduce(x, op=c10d.ReduceOp.SUM)
@@ -177,14 +177,14 @@ class TestDistributedNNFunctions(MultiProcessTestCase):
         x_g = 2 * (3 * torch.ones(5, 5, device=device)).cos()
         self.assertEqual(x.grad, x_g)
 
-    def _test_all_gather(self, backend):
+    def _test_all_gather(self, backend, device_type="cuda"):
         store = c10d.FileStore(self.file_name, self.world_size)
         # This is required because these functions calls directly to the .dist and needs
         # the world to be initialized
         c10d.init_process_group(
             store=store, rank=self.rank, world_size=self.world_size, backend=backend
         )
-        device = torch.device(f"cuda:{self.rank}")
+        device = torch.device(device_type, self.rank)
         x = torch.ones(5, 5, device=device) + self.rank
         x.requires_grad = True
         tensors = torch.distributed.nn.all_gather(x)
@@ -197,14 +197,14 @@ class TestDistributedNNFunctions(MultiProcessTestCase):
         x_s = 2 * (3 * torch.ones(5, 5, device=device)).cos()
         self.assertEqual(x.grad, x_s)
 
-    def _test_all_to_all(self, backend):
+    def _test_all_to_all(self, backend, device_type="cuda"):
         store = c10d.FileStore(self.file_name, self.world_size)
         # This is required because these functions calls directly to the .dist and needs
         # the world to be initialized
         c10d.init_process_group(
             store=store, rank=self.rank, world_size=self.world_size, backend=backend
         )
-        device = torch.device(f"cuda:{self.rank}")
+        device = torch.device(device_type, self.rank)
         x0 = torch.ones(5, 5, device=device) + 2 * self.rank
         x1 = torch.ones(5, 5, device=device) + 2 * self.rank
         x0.requires_grad = True
@@ -221,14 +221,14 @@ class TestDistributedNNFunctions(MultiProcessTestCase):
         self.assertEqual(x0.grad, x_s)
         self.assertEqual(x1.grad, x_s)
 
-    def _test_all_to_all_single(self, backend):
+    def _test_all_to_all_single(self, backend, device_type="cuda"):
         store = c10d.FileStore(self.file_name, self.world_size)
         # This is required because these functions calls directly to the .dist and needs
         # the world to be initialized
         c10d.init_process_group(
             store=store, rank=self.rank, world_size=self.world_size, backend=backend
         )
-        device = torch.device(f"cuda:{self.rank}")
+        device = torch.device(device_type, self.rank)
         row = self.world_size * (self.rank + 1) * (self.world_size + 1) / 2
         x = torch.ones(int(row), 5, device=device) * (self.rank + 1)
         x.requires_grad = True

--- a/test/distributed/test_c10d_spawn_gloo.py
+++ b/test/distributed/test_c10d_spawn_gloo.py
@@ -9,9 +9,10 @@ from test_c10d_spawn import _torch_dist_nn_available, TestDistributedNNFunctions
 import torch
 import torch.distributed as c10d
 import torch.nn as nn
-from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import requires_gloo, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
     TEST_WITH_DEV_DBG_ASAN,
@@ -22,7 +23,7 @@ from torch.testing._internal.common_utils import (
 # Fails on Python-3.9, see https://github.com/pytorch/pytorch/issues/51619
 
 
-class DistributedDataParallelSingleProcessTest(TestCase):
+class _DistributedDataParallelSingleProcessBase(TestCase):
     def setUp(self):
         super().setUp()
         self.rank = 0
@@ -42,8 +43,8 @@ class DistributedDataParallelSingleProcessTest(TestCase):
             backend="gloo", store=store, rank=self.rank, world_size=self.world_size
         )
         process_group = c10d.distributed_c10d._get_default_group()
-        if inp[0].is_cuda:
-            device_ids = [torch.cuda.current_device()]
+        if not inp[0].is_cpu:
+            device_ids = [torch.accelerator.current_device_index()]
         else:
             device_ids = None
 
@@ -71,18 +72,28 @@ class DistributedDataParallelSingleProcessTest(TestCase):
             for i, j in zip(ddp.parameters(), net.parameters()):
                 self.assertTrue(i.allclose(j))
 
-    @requires_gloo()
-    def test_cpu(self):
-        self._test_base(nn.Linear(2, 2), [torch.randn(30, 2)])
+
+class DistributedDataParallelSingleProcessTest(
+    _DistributedDataParallelSingleProcessBase
+):
+    hw_classification = HardwareClassification.CPU
 
     @requires_gloo()
-    @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "At least 1 CUDA GPUS needed")
-    def test_cuda(self):
+    def test_cpu(self, device):
+        self._test_base(nn.Linear(2, 2), [torch.randn(30, 2)])
+
+
+class DistributedDataParallelSingleProcessTestCUDA(
+    _DistributedDataParallelSingleProcessBase
+):
+    hw_classification = HardwareClassification.CUDA
+
+    @requires_gloo()
+    def test_cuda(self, device):
         self._test_base(nn.Linear(2, 2).to(0), [torch.randn(30, 2).to(0)])
 
     @requires_gloo()
-    @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "At least 1 CUDA GPUS needed")
-    def test_rnn(self):
+    def test_rnn(self, device):
         # This test is inspired by the bug reported in
         # https://github.com/pytorch/pytorch/issues/36268
         BATCH_SIZE = 12  # Divisible by 2, 3, 4
@@ -123,78 +134,68 @@ class DistributedDataParallelSingleProcessTest(TestCase):
         self._test_base(net, inp, check_allclose=False)
 
 
+instantiate_device_type_tests(
+    DistributedDataParallelSingleProcessTest, globals(), only_for=("cpu",)
+)
+instantiate_device_type_tests(
+    DistributedDataParallelSingleProcessTestCUDA, globals(), only_for=("cuda",)
+)
+
+
 # Skip dev-asan as torch + multiprocessing spawn have known issues
 if not TEST_WITH_DEV_DBG_ASAN:
 
-    class TestDistributedNNFunctionsGloo(TestDistributedNNFunctions):
+    class TestDistributedNNFunctionsGlooCUDA(TestDistributedNNFunctions):
+        hw_classification = HardwareClassification.CUDA
+
         # Test Common Ops First.
         @requires_gloo()
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_broadcast(self):
-            self._test_broadcast("gloo")
-
-        @requires_gloo()
-        @skip_but_pass_in_sandcastle_if(
-            not _torch_dist_nn_available, "torch.distributed.nn is not available"
-        )
-        def test_broadcast_subgroup_with_nonzero_global_src(self):
-            store = c10d.FileStore(self.file_name, self.world_size)
-            c10d.init_process_group(
-                store=store,
-                rank=self.rank,
-                world_size=self.world_size,
-                backend="gloo",
-            )
-            group = c10d.new_group([1])
-
-            if self.rank == 1:
-                x = torch.ones(5, 5, requires_grad=True)
-                y = torch.distributed.nn.broadcast(x, 1, group=group)
-                y.sum().backward()
-                self.assertEqual(x.grad, torch.ones_like(x))
+        def test_broadcast(self, device):
+            self._test_broadcast("gloo", self.device_type)
 
         @requires_gloo()
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_reduce(self):
-            self._test_reduce("gloo")
+        def test_reduce(self, device):
+            self._test_reduce("gloo", self.device_type)
 
         @requires_gloo()
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_allreduce(self):
-            self._test_allreduce("gloo")
+        def test_allreduce(self, device):
+            self._test_allreduce("gloo", self.device_type)
 
         @requires_gloo()
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_all_gather(self):
-            self._test_all_gather("gloo")
+        def test_all_gather(self, device):
+            self._test_all_gather("gloo", self.device_type)
 
         @requires_gloo()
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_all_to_all(self):
-            self._test_all_to_all("gloo")
+        def test_all_to_all(self, device):
+            self._test_all_to_all("gloo", self.device_type)
 
         @requires_gloo()
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_all_to_all_single(self):
-            self._test_all_to_all_single("gloo")
+        def test_all_to_all_single(self, device):
+            self._test_all_to_all_single("gloo", self.device_type)
 
         # Test Ops only supported in GLOO.
         @requires_gloo()
@@ -202,14 +203,14 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_gather(self):
+        def test_gather(self, device):
             store = c10d.FileStore(self.file_name, self.world_size)
             # This is required because these functions calls directly to the .dist and needs
             # the world to be initialized
             c10d.init_process_group(
                 store=store, rank=self.rank, world_size=self.world_size, backend="gloo"
             )
-            device = torch.device(f"cuda:{self.rank}")
+            device = torch.device(self.device_type, self.rank)
             x = torch.ones(5, 5, device=device) + self.rank
             x.requires_grad = True
             tensors = torch.distributed.nn.gather(x, 1)
@@ -233,14 +234,14 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_scatter(self):
+        def test_scatter(self, device):
             store = c10d.FileStore(self.file_name, self.world_size)
             # This is required because these functions calls directly to the .dist and needs
             # the world to be initialized
             c10d.init_process_group(
                 store=store, rank=self.rank, world_size=self.world_size, backend="gloo"
             )
-            device = torch.device(f"cuda:{self.rank}")
+            device = torch.device(self.device_type, self.rank)
             x0 = torch.ones(5, 5, device=device)
             x1 = torch.ones(5, 5, device=device) + 1
             x0.requires_grad = True
@@ -262,6 +263,36 @@ if not TEST_WITH_DEV_DBG_ASAN:
                 self.assertEqual(x1.grad, x1_s)
             if self.rank == 0:
                 self.assertEqual(x0.grad, torch.zeros(5, 5, device=device))
+
+    class TestDistributedNNFunctionsGloo(TestDistributedNNFunctions):
+        hw_classification = HardwareClassification.CPU
+
+        @requires_gloo()
+        @skip_but_pass_in_sandcastle_if(
+            not _torch_dist_nn_available, "torch.distributed.nn is not available"
+        )
+        def test_broadcast_subgroup_with_nonzero_global_src(self, device):
+            store = c10d.FileStore(self.file_name, self.world_size)
+            c10d.init_process_group(
+                store=store,
+                rank=self.rank,
+                world_size=self.world_size,
+                backend="gloo",
+            )
+            group = c10d.new_group([1])
+
+            if self.rank == 1:
+                x = torch.ones(5, 5, requires_grad=True)
+                y = torch.distributed.nn.broadcast(x, 1, group=group)
+                y.sum().backward()
+                self.assertEqual(x.grad, torch.ones_like(x))
+
+    instantiate_device_type_tests(
+        TestDistributedNNFunctionsGlooCUDA, globals(), only_for=("cuda",)
+    )
+    instantiate_device_type_tests(
+        TestDistributedNNFunctionsGloo, globals(), only_for=("cpu",)
+    )
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_spawn_gloo.py
+++ b/test/distributed/test_c10d_spawn_gloo.py
@@ -12,6 +12,7 @@ import torch.nn as nn
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_distributed import requires_gloo, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
     TEST_WITH_DEV_DBG_ASAN,
@@ -22,7 +23,7 @@ from torch.testing._internal.common_utils import (
 # Fails on Python-3.9, see https://github.com/pytorch/pytorch/issues/51619
 
 
-class DistributedDataParallelSingleProcessTest(TestCase):
+class _DistributedDataParallelSingleProcessBase(TestCase):
     def setUp(self):
         super().setUp()
         self.rank = 0
@@ -71,9 +72,21 @@ class DistributedDataParallelSingleProcessTest(TestCase):
             for i, j in zip(ddp.parameters(), net.parameters()):
                 self.assertTrue(i.allclose(j))
 
+
+class DistributedDataParallelSingleProcessTest(
+    _DistributedDataParallelSingleProcessBase
+):
+    hw_classification = HardwareClassification.GENERIC
+
     @requires_gloo()
     def test_cpu(self):
         self._test_base(nn.Linear(2, 2), [torch.randn(30, 2)])
+
+
+class DistributedDataParallelSingleProcessTestCUDA(
+    _DistributedDataParallelSingleProcessBase
+):
+    hw_classification = HardwareClassification.CUDA
 
     @requires_gloo()
     @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "At least 1 CUDA GPUS needed")
@@ -126,7 +139,9 @@ class DistributedDataParallelSingleProcessTest(TestCase):
 # Skip dev-asan as torch + multiprocessing spawn have known issues
 if not TEST_WITH_DEV_DBG_ASAN:
 
-    class TestDistributedNNFunctionsGloo(TestDistributedNNFunctions):
+    class TestDistributedNNFunctionsGlooCUDA(TestDistributedNNFunctions):
+        hw_classification = HardwareClassification.CUDA
+
         # Test Common Ops First.
         @requires_gloo()
         @skip_if_lt_x_gpu(2)
@@ -135,26 +150,6 @@ if not TEST_WITH_DEV_DBG_ASAN:
         )
         def test_broadcast(self):
             self._test_broadcast("gloo")
-
-        @requires_gloo()
-        @skip_but_pass_in_sandcastle_if(
-            not _torch_dist_nn_available, "torch.distributed.nn is not available"
-        )
-        def test_broadcast_subgroup_with_nonzero_global_src(self):
-            store = c10d.FileStore(self.file_name, self.world_size)
-            c10d.init_process_group(
-                store=store,
-                rank=self.rank,
-                world_size=self.world_size,
-                backend="gloo",
-            )
-            group = c10d.new_group([1])
-
-            if self.rank == 1:
-                x = torch.ones(5, 5, requires_grad=True)
-                y = torch.distributed.nn.broadcast(x, 1, group=group)
-                y.sum().backward()
-                self.assertEqual(x.grad, torch.ones_like(x))
 
         @requires_gloo()
         @skip_if_lt_x_gpu(2)
@@ -262,6 +257,29 @@ if not TEST_WITH_DEV_DBG_ASAN:
                 self.assertEqual(x1.grad, x1_s)
             if self.rank == 0:
                 self.assertEqual(x0.grad, torch.zeros(5, 5, device=device))
+
+    class TestDistributedNNFunctionsGloo(TestDistributedNNFunctions):
+        hw_classification = HardwareClassification.GENERIC
+
+        @requires_gloo()
+        @skip_but_pass_in_sandcastle_if(
+            not _torch_dist_nn_available, "torch.distributed.nn is not available"
+        )
+        def test_broadcast_subgroup_with_nonzero_global_src(self):
+            store = c10d.FileStore(self.file_name, self.world_size)
+            c10d.init_process_group(
+                store=store,
+                rank=self.rank,
+                world_size=self.world_size,
+                backend="gloo",
+            )
+            group = c10d.new_group([1])
+
+            if self.rank == 1:
+                x = torch.ones(5, 5, requires_grad=True)
+                y = torch.distributed.nn.broadcast(x, 1, group=group)
+                y.sum().backward()
+                self.assertEqual(x.grad, torch.ones_like(x))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR splits `test_c10d_spawn_gloo.py`'s mixed CPU/CUDA classes by `HardwareClassification`, generalizes the DDP `device_ids` selection to the accelerator API, and — per review feedback — parameterizes the six shared `_test_*` collective helpers in the `TestDistributedNNFunctions` base class (`test_c10d_spawn.py`) so the Gloo CUDA class's `device` params are actually consumed.

## Changes
- **`test/distributed/test_c10d_spawn_gloo.py`**:
  - Extracted `_DistributedDataParallelSingleProcessBase(TestCase)` holding the shared `setUp`/`tearDown`/`_test_base` logic, split into:
    - `DistributedDataParallelSingleProcessTest` labeled `CPU`, `only_for=("cpu",)` — holds `test_cpu` (pure-CPU DDP parity).
    - `DistributedDataParallelSingleProcessTestCUDA` labeled `CUDA`, `only_for=("cuda",)` — holds `test_cuda`/`test_rnn` (DDP parity on CUDA tensors).
  - Split `TestDistributedNNFunctionsGloo` into:
    - `TestDistributedNNFunctionsGlooCUDA` labeled `CUDA`, `only_for=("cuda",)` — holds the 8 `@requires_gloo()` + `@skip_if_lt_x_gpu(2)` collective methods (`test_broadcast`/`test_reduce`/`test_allreduce`/`test_all_gather`/`test_all_to_all`/`test_all_to_all_single`/`test_gather`/`test_scatter`).
    - `TestDistributedNNFunctionsGloo` labeled `CPU`, `only_for=("cpu",)` — holds `test_broadcast_subgroup_with_nonzero_global_src` (pure-CPU Gloo broadcast).
  - `_test_base` DDP `device_ids` selection generalized from `inp[0].is_cuda` + `torch.cuda.current_device()` to `not inp[0].is_cpu` + `torch.accelerator.current_device_index()` (review feedback; the accelerator API is `current_device_index` — there is no `current_device`).
  - Per-rank device construction in `test_gather`/`test_scatter` uses `torch.device(self.device_type, self.rank)` — the injected `device` is an indexed string (e.g. `"cuda:0"`) and cannot be passed directly to `torch.device(..., self.rank)`, so the per-variant type (`self.device_type`) + rank is the correct form.
  - Added the `device` parameter to all `test_*` methods; removed the redundant per-method `@skip_but_pass_in_sandcastle_if(not TEST_CUDA, ...)` and the unused `TEST_CUDA` import.
- **`test/distributed/test_c10d_spawn.py`** (shared base class, review feedback "refactor `_test_broadcast` first"):
  - The six `_test_*` helpers now take `device_type="cuda"` and build the per-rank device as `torch.device(device_type, self.rank)` — the default is equivalent to the previous `torch.device(f"cuda:{self.rank}")`, so the unchanged single-arg callers in `test_c10d_spawn_ucc.py` and `test_c10d_spawn_nccl.py` keep their exact behavior.
  - The Gloo CUDA class passes `self.device_type` at all six call sites, so the `device` params added to its `test_*` methods are now consumed.

## Motivation
An unclassified `TestCase` is silently dropped when `--hw-classification` filtering is passed. The original classes were mixed CPU/CUDA and could not be labeled correctly; each is split into CPU/CUDA subclasses. The gloo backend's non-CPU tensor path only supports CUDA (`ProcessGroupGloo` dispatches `at::kCUDA` exclusively), which is what pins the CUDA classes to `only_for=("cuda",)`. The base-class helper parameterization removes the hardcoded `"cuda"` string from the shared helpers while keeping the UCC/NCCL callers byte-identical in behavior.

## Test Plan
- Verified on an 8-card out-of-tree accelerator backend (CPU classes run; the CUDA classes are 0-collected there because of `only_for=("cuda",)`):
  - `python test/distributed/test_c10d_spawn_gloo.py` → `Ran 2 tests ... OK` (both CPU classes)
  - `python test/distributed/test_c10d_spawn_ucc.py` → `Ran 6 tests ... OK (skipped=6)` (helper signature change is backward-compatible; skips are the expected `requires_ucc` behavior on non-UCC builds)
- The CUDA-variant paths (`self.device_type` call sites, `current_device_index()` in `_test_base`, helper `device_type` consumption) are verified by construction: `torch.device(self.device_type, self.rank)` with `self.device_type == "cuda"` builds the same device as the previous `torch.device(f"cuda:{self.rank}")`. 
- `lintrunner` reports no lint issues on both files.

## Notes
- `@skip_if_lt_x_gpu` is kept unchanged on the CUDA collective methods. Making `skip_if_lt_x_gpu` recognize out-of-tree accelerators (PrivateUse1) is a separate framework-level change to `common_distributed.py`, tracked in pytorch/pytorch#187650; this PR does not modify that helper.
- This is part of the test case refactoring initiative tracked in #185590.
