### PR TITLE
[Dynamo] Remove Relay path from TVM backend

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -1,5 +1,4 @@
 # Owner(s): ["module: dynamo"]
-import importlib.machinery
 import importlib.util
 import sys
 import unittest
@@ -163,12 +162,6 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
     @unittest.skipIf(not has_tvm(), "requires tvm")
     def test_tvm(self, device):
         self._check_backend_works("tvm", device, boxed=False, backward=False)
-        self._check_backend_works(
-            "tvm", device, boxed=False, backward=False, options={"scheduler": None}
-        )
-        self._check_backend_works(
-            "tvm", device, boxed=False, backward=False, options={"opt_level": 0}
-        )
 
     @unittest.skipIf(not has_tvm(), "requires tvm")
     def test_tvm_scalar_tensor_input(self, device):
@@ -202,84 +195,12 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
             )
             self.assertTrue(same(expected, compiled(x), tol=0.01))
 
-    def test_tvm_scheduler_backends(self, device):
-        from torch._dynamo.backends.tvm import tvm_auto_scheduler, tvm_meta_schedule
+    def test_tvm_missing_install_error(self, device):
+        from torch._dynamo.backends.tvm import tvm as tvm_backend
 
         gm = torch.fx.symbolic_trace(lambda x: x + 1)
-        for backend in (tvm_meta_schedule, tvm_auto_scheduler):
-            # blocking the tvm import keeps this fast and deterministic;
-            # reaching ImportError proves the partial's kwargs are valid
-            with patch.dict(sys.modules, {"tvm": None}):
-                self.assertRaises(ImportError, backend, gm, [torch.randn(2)])
-
-    def test_tvm_relay_future_warning(self, device):
-        import torch._dynamo.backends.tvm as tvm_backend
-
-        gm = torch.fx.symbolic_trace(lambda x: x + 1)
-        with patch.dict(sys.modules, {"tvm": None}):
-            with self.assertWarns(FutureWarning):
-                self.assertRaises(
-                    ImportError,
-                    tvm_backend._tvm_relay_compile,
-                    gm,
-                    [torch.randn(2)],
-                    {},
-                )
-
-    def test_tvm_dispatches_relay_or_relax(self, device):
-        import torch._dynamo.backends.tvm as tvm_backend
-
-        gm = torch.fx.symbolic_trace(lambda x: x + 1)
-        sentinel = object()
-
-        def find_spec(present):
-            return lambda name: MagicMock() if name == present else None
-
-        with (
-            patch.dict(sys.modules, {"tvm": MagicMock()}),
-            patch.object(
-                tvm_backend, "_tvm_relay_compile", return_value=sentinel
-            ) as relay,
-            patch.object(
-                tvm_backend, "_tvm_relax_compile", return_value=sentinel
-            ) as relax,
-        ):
-            with patch("importlib.util.find_spec", side_effect=find_spec("tvm.relay")):
-                self.assertIs(tvm_backend.tvm(gm, [torch.randn(2)]), sentinel)
-            relay.assert_called_once()
-            relax.assert_not_called()
-
-            with patch(
-                "importlib.util.find_spec",
-                side_effect=find_spec("tvm.relax.frontend.torch"),
-            ):
-                self.assertIs(tvm_backend.tvm(gm, [torch.randn(2)]), sentinel)
-            relax.assert_called_once()
-            relay.assert_called_once()
-
-    def test_tvm_dynamic_shapes_error(self, device):
-        def fn(x):
-            return x.view(x.size(0), -1) + 1
-
-        x = torch.randn(2, 3, device=device)
-        compiled = torch.compile(fn, backend="tvm", dynamic=True)
-        # stub tvm imports; the error fires before any tvm API is used.
-        # find_spec() reads __spec__ off modules already in sys.modules, so
-        # the relay stub needs a real ModuleSpec to route to the relay path.
-        relay_stub = MagicMock()
-        relay_stub.__spec__ = importlib.machinery.ModuleSpec("tvm.relay", None)
-        stubs = {
-            "tvm": MagicMock(),
-            "tvm.contrib": MagicMock(),
-            "tvm.relay": relay_stub,
-        }
-        with patch.dict(sys.modules, stubs):
-            with self.assertRaisesRegex(
-                torch._dynamo.exc.BackendCompilerFailed,
-                "does not support dynamic shapes",
-            ):
-                compiled(x)
-        torch._dynamo.reset()
+        with patch.dict(sys.modules, {"tvm": None, "tvm.relax.frontend.torch": None}):
+            self.assertRaises(ImportError, tvm_backend, gm, [torch.randn(2)])
 
     @onlyHPU
     def test_intel_gaudi_backend(self, device):

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -2,50 +2,27 @@
 This module provides TVM backend integration for TorchDynamo.
 
 Apache TVM is a deep learning compiler framework that can optimize and execute
-models on various hardware backends. This module enables:
+models on various hardware backends. The backend compiles graphs through TVM's
+relax frontend and can be used with torch.compile():
 
-- Compilation of PyTorch models to TVM's computation graphs
-- Multiple scheduling options:
-  - Default scheduler
-  - Auto-scheduler for automatic optimization
-  - Meta-schedule for evolutionary search-based tuning
-- Hardware-specific optimizations:
-  - CUDA GPU support
-  - CPU support with LLVM targeting and architecture-specific tuning
-  - Automatic detection of CPU capabilities (AVX2, AVX512)
-- Tensor conversion utilities between PyTorch and TVM formats
-- Configurable optimization levels and tuning trials
-
-The backend can be used with torch.compile():
     model = torch.compile(model, backend="tvm")
 
-The scheduler/trials options only apply to the legacy relay frontend
-(removed in TVM 0.20). With the relax frontend, pass a TVM pipeline instead:
+Tuning and target selection are configured through a TVM pipeline:
 
     pipeline = tvm.relax.get_pipeline("static_shape_tuning", target="llvm", total_trials=2000)
     model = torch.compile(model, backend="tvm", options={"pipeline": pipeline})
 """
 
-import functools
 import importlib.util
-import logging
-import os
-import sys
-import tempfile
-import warnings
 from collections.abc import Callable
-from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
 import torch
 from torch import fx
 
-from .common import device_from_inputs, fake_tensor_unsupported
+from .common import fake_tensor_unsupported
 from .registry import register_backend
-
-
-log = logging.getLogger(__name__)
 
 
 @register_backend
@@ -56,206 +33,18 @@ def tvm(
     *,
     options: MappingProxyType[str, Any] | None = None,
 ) -> Callable[..., Any]:
-    if options is None:
-        options = MappingProxyType({"scheduler": None, "trials": 20000, "opt_level": 3})
     try:
-        import tvm  # type: ignore[import]  # noqa: F401
+        from tvm.relax.frontend.torch import relax_dynamo  # type: ignore[import]
     except ImportError as e:
         raise ImportError(
             "Please install apache-tvm to use the tvm backend. "
             "See https://tvm.apache.org/docs/install/index.html for instructions."
         ) from e
 
-    # relay was removed in TVM 0.20; newer pip wheels only ship the relax
-    # frontend, so dispatch on whichever API the installed TVM provides.
-    if importlib.util.find_spec("tvm.relay") is not None:
-        return _tvm_relay_compile(gm, example_inputs, options)
-    if importlib.util.find_spec("tvm.relax.frontend.torch") is not None:
-        return _tvm_relax_compile(gm, example_inputs, options)
-    raise ImportError(
-        "The installed apache-tvm provides neither the legacy relay frontend nor "
-        "the relax torch frontend, so the tvm backend cannot compile this graph."
-    )
-
-
-def _tvm_relax_compile(
-    gm: fx.GraphModule,
-    example_inputs: list[torch.Tensor],
-    options: MappingProxyType[str, Any],
-) -> Callable[..., Any]:
-    from tvm.relax.frontend.torch import relax_dynamo  # type: ignore[import]
-
-    scheduler = options.get("scheduler", None) or os.environ.get("TVM_SCHEDULER", None)
-    if scheduler in ("auto_scheduler", "meta_schedule"):
-        log.warning(
-            "scheduler=%s has no equivalent in the relax TVM backend; "
-            "falling back to the default relax pipeline.",
-            scheduler,
-        )
-    return relax_dynamo(pipeline=options.get("pipeline", None))(gm, example_inputs)
-
-
-def _tvm_relay_compile(
-    gm: fx.GraphModule,
-    example_inputs: list[torch.Tensor],
-    options: MappingProxyType[str, Any],
-) -> Callable[..., Any]:
-    warnings.warn(
-        "The tvm backend's relay path is deprecated and will be removed; "
-        "install a recent apache-tvm to use the relax frontend instead.",
-        FutureWarning,
-        stacklevel=2,
-    )
-    import tvm  # type: ignore[import]
-    from tvm import relay  # type: ignore[import]
-    from tvm.contrib import graph_executor  # type: ignore[import]
-
-    if any(
-        isinstance(x, (torch.SymInt, torch.SymFloat, torch.SymBool))
-        for x in example_inputs
-    ):
-        raise RuntimeError(
-            "The TVM (relay) backend does not support dynamic shapes: got symbolic "
-            "scalar graph inputs. Either compile with dynamic=False or use TVM's "
-            "relax frontend instead: from tvm.relax.frontend.torch import relax_dynamo; "
-            "torch.compile(model, backend=relax_dynamo())."
-        )
-    jit_mod = torch.jit.trace(gm, example_inputs)
-    device = device_from_inputs(example_inputs)
-    shape_list = [(f"inp_{idx}", i.shape) for idx, i in enumerate(example_inputs)]
-    example_outputs = gm(*example_inputs)
-    if len(example_outputs) == 0:
-        log.warning("Explicitly fall back to eager due to zero output")
-        return gm.forward
-    mod, params = relay.frontend.from_pytorch(jit_mod, shape_list)
-    if device.type == "cuda":
-        dev = tvm.cuda(device.index)
-        target = tvm.target.cuda()
-    else:
-        dev = tvm.cpu(0)
-        target = tvm.target.Target(llvm_target())
-
-    scheduler = options.get("scheduler", None)
-    if scheduler is None:
-        scheduler = os.environ.get("TVM_SCHEDULER", None)
-
-    trials = options.get("trials", 20000)
-    opt_level = options.get("opt_level", 3)
-
-    if scheduler == "auto_scheduler":
-        # pyrefly: ignore [missing-import]
-        from tvm import auto_scheduler
-
-        with (
-            tempfile.NamedTemporaryFile() as log_file,
-            auto_scheduler.ApplyHistoryBest(log_file),
-            tvm.transform.PassContext(
-                opt_level=opt_level, config={"relay.backend.use_auto_scheduler": True}
-            ),
-        ):
-            lib = relay.build(mod, target=target, params=params)
-    elif scheduler == "meta_schedule":
-        # pyrefly: ignore [missing-import]
-        from tvm import meta_schedule as ms
-
-        with tempfile.TemporaryDirectory() as work_dir:
-            if device.type != "cuda":
-                # meta_schedule needs num-cores to be specified
-                # here we use the maximum core count
-                target = tvm.target.Target(
-                    f"{llvm_target()} --num-cores {ms.utils.cpu_count(logical=False)}"
-                )
-            # TODO(shingjan): This could be replaced by tvm.contrib.torch.optimize_torch
-            # once USE_PT_TVMDSOOP is updated and turned on by default in TVM.
-            if trials <= 0:
-                raise AssertionError(f"trials must be positive, got {trials}")
-            database = ms.relay_integration.tune_relay(
-                mod=mod,
-                target=target,
-                work_dir=work_dir,
-                max_trials_global=trials,
-                num_trials_per_iter=64,
-                params=params,
-                strategy="evolutionary",
-                opt_level=opt_level,
-            )
-            lib = ms.relay_integration.compile_relay(
-                database=database,
-                mod=mod,
-                target=target,
-                params=params,
-                opt_level=opt_level,
-            )
-    elif scheduler == "default" or not scheduler:
-        # no autotuning
-        with tvm.transform.PassContext(opt_level=opt_level):
-            lib = relay.build(mod, target=target, params=params)
-    else:
-        raise NotImplementedError(
-            "This tuning option is invalid/not implemented for torchdynamo's TVM-related backend. "
-            "There are three available options: default, auto_scheduler and meta_schedule."
-        )
-    m = graph_executor.GraphModule(lib["default"](dev))
-
-    def to_torch_tensor(nd_tensor: tvm.nd.array) -> torch.Tensor:
-        """A helper function to transfer a NDArray to torch.tensor."""
-        if nd_tensor.dtype == "bool":
-            # DLPack does not support boolean so it can't be handled by
-            # torch.utils.dlpack.from_pack. Workaround by going through
-            # numpy, although this brings additional data copy overhead.
-            return torch.from_numpy(nd_tensor.numpy())
-        return torch.utils.dlpack.from_dlpack(nd_tensor.to_dlpack())
-
-    def to_tvm_tensor(torch_tensor: torch.Tensor) -> tvm.nd.array:
-        """A helper function to transfer a torch.tensor to NDArray."""
-        if torch_tensor.dtype == torch.bool:
-            # same reason as above, fallback to numpy conversion which
-            # could introduce data copy overhead
-            return tvm.nd.array(torch_tensor.cpu().numpy())
-        return tvm.nd.from_dlpack(torch_tensor)
-
-    # input info is fixed at compile time, so query it once instead of per call
-    shape_info, _ = m.get_input_info()
-    active_inputs = set(shape_info.keys())
-
-    def exec_tvm(*i_args: torch.Tensor) -> list[torch.Tensor]:
-        args = [a.contiguous() for a in i_args]
-        for idx, arg in enumerate(args, 0):
-            inp_name = f"inp_{idx}"
-            if inp_name not in active_inputs:
-                log.warning(
-                    "input %s skipped as not found in tvm's runtime library",
-                    inp_name,
-                )
-                continue
-            if arg.requires_grad:
-                arg = arg.detach()
-            m.set_input(inp_name, to_tvm_tensor(arg))
-        m.run()
-        return [to_torch_tensor(m.get_output(i)) for i in range(m.get_num_outputs())]
-
-    return exec_tvm
-
-
-tvm_meta_schedule = functools.partial(
-    tvm, options=MappingProxyType({"scheduler": "meta_schedule"})
-)
-tvm_auto_scheduler = functools.partial(
-    tvm, options=MappingProxyType({"scheduler": "auto_scheduler"})
-)
+    pipeline = options.get("pipeline", None) if options else None
+    return relax_dynamo(pipeline=pipeline)(gm, example_inputs)
 
 
 def has_tvm() -> bool:
     # avoid the heavy tvm import just to check availability
     return importlib.util.find_spec("tvm") is not None
-
-
-@functools.cache
-def llvm_target() -> str:
-    if sys.platform == "linux":
-        cpuinfo = Path("/proc/cpuinfo").read_text()
-        if "avx512" in cpuinfo:
-            return "llvm -mcpu=skylake-avx512"
-        elif "avx2" in cpuinfo:
-            return "llvm -mcpu=core-avx2"
-    return "llvm"


### PR DESCRIPTION
## Related PR

Follow up per https://github.com/pytorch/pytorch/pull/189639#pullrequestreview-4690623207

## Why

- relay was removed in TVM 0.20, so the relay path is dead for any recent apache-tvm wheel

## How

- Makes the relax frontend the only path
- Tuning is configured through `options={"pipeline": ...}` instead of the relay-only scheduler options

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98