### PR TITLE
[Inductor][autoWS] Fix USE_META_WS gate and add has_meta_ws()

### DIFF
--- a/test/inductor/test_autows_utils.py
+++ b/test/inductor/test_autows_utils.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 import sys
 
-from torch._inductor.autows_utils import has_meta_ws
 from torch._inductor.test_case import run_tests, TestCase
 
 

--- a/test/inductor/test_autows_utils.py
+++ b/test/inductor/test_autows_utils.py
@@ -1,34 +1,21 @@
 # Owner(s): ["module: inductor"]
-import os
-import subprocess
-import sys
-
+from torch._inductor.autows_utils import has_meta_ws, meta_ws_enabled
 from torch._inductor.test_case import run_tests, TestCase
 
 
-def _use_meta_ws(env_val: str | None) -> tuple[bool, bool]:
-    # USE_META_WS is evaluated at import, so vary the env in a fresh interpreter.
-    env = os.environ.copy()
-    if env_val is None:
-        env.pop("TRITON_USE_META_WS", None)
-    else:
-        env["TRITON_USE_META_WS"] = env_val
-    code = (
-        "import torch._inductor.heuristics.template.triton as m;"
-        "from torch._inductor.autows_utils import has_meta_ws;"
-        "print(int(m.USE_META_WS), int(has_meta_ws()))"
-    )
-    out = subprocess.check_output([sys.executable, "-c", code], env=env)
-    use_meta_ws, available = (bool(int(x)) for x in out.split())
-    return use_meta_ws, available
-
-
 class AutoWSUtilsTests(TestCase):
-    def test_use_meta_ws_env_gating(self) -> None:
-        for env_val, enabled in ((None, False), ("0", False), ("1", True)):
-            with self.subTest(env=env_val):
-                use_meta_ws, available = _use_meta_ws(env_val)
-                self.assertEqual(use_meta_ws, available and enabled)
+    def test_meta_ws_enabled_gating(self) -> None:
+        if not has_meta_ws():
+            # Without fb-Triton the gate is off regardless of the knob.
+            self.assertFalse(meta_ws_enabled())
+            return
+        from triton import knobs
+
+        with knobs.nvidia.scope():
+            knobs.nvidia.use_meta_ws = True
+            self.assertTrue(meta_ws_enabled())
+            knobs.nvidia.use_meta_ws = False
+            self.assertFalse(meta_ws_enabled())
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_autows_utils.py
+++ b/test/inductor/test_autows_utils.py
@@ -1,0 +1,36 @@
+# Owner(s): ["module: inductor"]
+import os
+import subprocess
+import sys
+
+from torch._inductor.autows_utils import has_meta_ws
+from torch._inductor.test_case import run_tests, TestCase
+
+
+def _use_meta_ws(env_val: str | None) -> tuple[bool, bool]:
+    # USE_META_WS is evaluated at import, so vary the env in a fresh interpreter.
+    env = os.environ.copy()
+    if env_val is None:
+        env.pop("TRITON_USE_META_WS", None)
+    else:
+        env["TRITON_USE_META_WS"] = env_val
+    code = (
+        "import torch._inductor.heuristics.template.triton as m;"
+        "from torch._inductor.autows_utils import has_meta_ws;"
+        "print(int(m.USE_META_WS), int(has_meta_ws()))"
+    )
+    out = subprocess.check_output([sys.executable, "-c", code], env=env)
+    use_meta_ws, available = (bool(int(x)) for x in out.split())
+    return use_meta_ws, available
+
+
+class AutoWSUtilsTests(TestCase):
+    def test_use_meta_ws_env_gating(self) -> None:
+        for env_val, enabled in ((None, False), ("0", False), ("1", True)):
+            with self.subTest(env=env_val):
+                use_meta_ws, available = _use_meta_ws(env_val)
+                self.assertEqual(use_meta_ws, available and enabled)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/autows_utils.py
+++ b/torch/_inductor/autows_utils.py
@@ -13,3 +13,17 @@ def has_meta_ws() -> bool:
     except ImportError:
         return False
     return hasattr(getattr(knobs, "nvidia", None), "use_meta_ws")
+
+
+def meta_ws_enabled() -> bool:
+    """Whether Meta Triton autoWS is available and enabled via its knob.
+
+    Reads the live ``knobs.nvidia.use_meta_ws`` value (backed by
+    TRITON_USE_META_WS) rather than the env var directly, so it honors the knob
+    set programmatically or within a ``knobs.nvidia.scope()``.
+    """
+    if not has_meta_ws():
+        return False
+    from triton import knobs
+
+    return bool(knobs.nvidia.use_meta_ws)

--- a/torch/_inductor/autows_utils.py
+++ b/torch/_inductor/autows_utils.py
@@ -16,12 +16,7 @@ def has_meta_ws() -> bool:
 
 
 def meta_ws_enabled() -> bool:
-    """Whether Meta Triton autoWS is available and enabled via its knob.
-
-    Reads the live ``knobs.nvidia.use_meta_ws`` value (backed by
-    TRITON_USE_META_WS) rather than the env var directly, so it honors the knob
-    set programmatically or within a ``knobs.nvidia.scope()``.
-    """
+    """Whether Meta Triton autoWS is available and enabled via its knob."""
     if not has_meta_ws():
         return False
     from triton import knobs

--- a/torch/_inductor/autows_utils.py
+++ b/torch/_inductor/autows_utils.py
@@ -1,0 +1,15 @@
+"""Utils for Meta Triton autoWS."""
+
+from __future__ import annotations
+
+import functools
+
+
+@functools.cache
+def has_meta_ws() -> bool:
+    """Whether Meta Triton autoWS is available."""
+    try:
+        from triton import knobs
+    except ImportError:
+        return False
+    return hasattr(getattr(knobs, "nvidia", None), "use_meta_ws")

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -18,7 +18,7 @@ from torch.utils._sympy.functions import Min, Mod
 from torch.utils._triton import has_triton_stable_tma_api
 
 from ... import config
-from ...autows_utils import has_meta_ws
+from ...autows_utils import meta_ws_enabled
 from ...kernel.bmm import bmm_template
 from ...kernel.mm import (
     blackwell_ws_persistent_device_tma_mm_template,
@@ -63,7 +63,7 @@ def _origami_enabled() -> bool:
     return config.rocm.origami
 
 
-USE_META_WS = has_meta_ws() and os.environ.get("TRITON_USE_META_WS", "0") == "1"
+USE_META_WS = meta_ws_enabled()
 
 # Check if running on ROCm
 IS_ROCM = torch.version.hip is not None

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -18,6 +18,7 @@ from torch.utils._sympy.functions import Min, Mod
 from torch.utils._triton import has_triton_stable_tma_api
 
 from ... import config
+from ...autows_utils import has_meta_ws
 from ...kernel.bmm import bmm_template
 from ...kernel.mm import (
     blackwell_ws_persistent_device_tma_mm_template,
@@ -62,7 +63,7 @@ def _origami_enabled() -> bool:
     return config.rocm.origami
 
 
-USE_META_WS = os.environ.get("TRITON_USE_META_WS", "0") == "1"
+USE_META_WS = has_meta_ws() and os.environ.get("TRITON_USE_META_WS", "0") == "1"
 
 # Check if running on ROCm
 IS_ROCM = torch.version.hip is not None

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -62,7 +62,7 @@ def _origami_enabled() -> bool:
     return config.rocm.origami
 
 
-USE_META_WS = os.environ.get("TRITON_USE_META_WS", "0") == "0"
+USE_META_WS = os.environ.get("TRITON_USE_META_WS", "0") == "1"
 
 # Check if running on ROCm
 IS_ROCM = torch.version.hip is not None
@@ -2677,7 +2677,7 @@ class BlackwellTMATemplateConfigMixin(TMATemplateConfigMixin):
             flatten = (
                 template_kwargs.get("FLATTEN", True)
                 and not constraints_violated
-                and USE_META_WS
+                and not USE_META_WS
             )
             yield {
                 **template_kwargs,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190769
* #190768
* __->__ #190767

Fix inverted `USE_META_WS` env var, used only by the Blackwell
persistent TMA template, to follow existing naming convention. Add
`has_meta_ws()` to check whether Meta Triton autoWS is present.

Differential Revision: [D113434254](https://our.internmc.facebook.com/intern/diff/D113434254)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo