### PR TITLE
Validate saved stats in CUDA batch norm backward

### DIFF
--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -638,6 +638,31 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cuda_template(const Tenso
                                                                      bool train, double epsilon, std::array<bool,3> grad_input_mask) {
 
   using accscalar_t = at::acc_type<stat_scalar_t, true>;
+    if (train) {
+    const auto num_features = input_.size(1);
+
+    TORCH_CHECK(
+        save_mean_.defined(),
+        "save_mean must be defined in training mode");
+
+    TORCH_CHECK(
+        save_mean_.numel() == num_features,
+        "Expected save_mean to contain ",
+        num_features,
+        " elements, but got ",
+        save_mean_.numel());
+
+    TORCH_CHECK(
+        save_invstd_.defined(),
+        "save_invstd must be defined in training mode");
+
+    TORCH_CHECK(
+        save_invstd_.numel() == num_features,
+        "Expected save_invstd to contain ",
+        num_features,
+        " elements, but got ",
+        save_invstd_.numel());
+  }
   Tensor grad_input_;
   Tensor grad_input_reshaped;
   Tensor grad_weight_;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7882,7 +7882,6 @@ class TestNNDeviceType(NNTestCase):
         output.sum().backward()
         self.assertEqualTypeString(output, input)
 
-    @onlyCUDA
     def test_native_batch_norm_backward_rejects_invalid_saved_stats(
         self, device
     ):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7882,6 +7882,50 @@ class TestNNDeviceType(NNTestCase):
         output.sum().backward()
         self.assertEqualTypeString(output, input)
 
+    @onlyCUDA
+    def test_native_batch_norm_backward_rejects_invalid_saved_stats(
+        self, device
+    ):
+        input_tensor = torch.full(
+            (4, 2, 0, 3),
+            1.0,
+            device=device,
+        )
+        grad_out = torch.zeros(0, device=device)
+        weight = torch.full(
+            (2,),
+            float("nan"),
+            device=device,
+        )
+        running_mean = torch.ones(2, device=device)
+
+        valid_stat = torch.ones(2, device=device)
+        empty_stat = torch.empty(0, device=device)
+
+        test_cases = (
+            ("save_mean", empty_stat, valid_stat),
+            ("save_invstd", valid_stat, empty_stat),
+        )
+
+        for stat_name, save_mean, save_invstd in test_cases:
+            with self.subTest(stat_name=stat_name):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    rf"Expected {stat_name} to contain 2 elements, but got 0",
+                ):
+                    torch.ops.aten.native_batch_norm_backward(
+                        grad_out,
+                        input_tensor,
+                        weight,
+                        running_mean,
+                        None,
+                        save_mean,
+                        save_invstd,
+                        True,
+                        float("-inf"),
+                        [True, False, False],
+                    )
+
     def _test_LayerNorm_cpu_mixed_dtype(self, device, dtype):
         for elementwise_affine in [True, False]:
             # layer norm input shape is normalized to m x n, cpu vectorized on n,


### PR DESCRIPTION
Fixes #189831

## Summary

`native_batch_norm_backward` could launch the CUDA backward kernel with
invalid saved statistics.

In training mode, the kernel reads one value per input channel from
`save_mean` and `save_invstd`. If either tensor does not contain exactly
one element per input channel, the kernel may perform an out-of-bounds
device read.

In the reported case, an empty `save_invstd` caused an illegal CUDA
memory access through a null pointer.

This change validates `save_mean` and `save_invstd` on the host before
creating the packed tensor accessors and launching the CUDA kernel.

Invalid saved statistics now raise a controlled `RuntimeError` instead
of causing a CUDA device memory fault. The execution path for valid
inputs remains unchanged.

## Test plan

The change was tested using both the dedicated regression test and a
locally rebuilt PyTorch installation containing the proposed fix.

### Regression test

Added a CUDA regression test covering empty `save_mean` and
`save_invstd` tensors.

Command:

```text
python test/test_nn.py -k native_batch_norm_backward_rejects_invalid_saved_stats

Result:

Ran 2 tests in 0.158s

OK (skipped=1)

The CUDA test passed successfully. One generated non-applicable test
variant was skipped.

Locally rebuilt PyTorch

PyTorch was rebuilt locally from source with the proposed change.

The original failure case was then executed against the rebuilt library.
The invalid input now raises the expected controlled error:

Expected save_invstd to contain 2 elements, but got 0

This confirms that the rebuilt native CUDA implementation contains and
executes the new host-side validation.

NVIDIA Compute Sanitizer

The original failure case was also executed against the locally rebuilt
PyTorch library using NVIDIA Compute Sanitizer.

Result:

PASS: Expected save_invstd to contain 2 elements, but got 0
ERROR SUMMARY: 0 errors

No invalid global reads, illegal CUDA memory accesses, or other device
memory errors were detected.