### PR TITLE
Deduplicate ADAM_MODE enum and collapse fused Adam CUDA impls into one launcher

### DIFF
--- a/aten/src/ATen/native/FusedAdam.h
+++ b/aten/src/ATen/native/FusedAdam.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <ATen/core/Tensor.h>
 #include <ATen/native/DispatchStub.h>
 

--- a/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
@@ -1,11 +1,6 @@
 #include <ATen/native/cuda/fused_adam_amsgrad_impl.cuh>
 
-#include <ATen/Dispatch.h>
-#include <ATen/Dispatch_v2.h>
-#include <ATen/native/ForeachUtils.h>
-#include <ATen/native/cuda/MultiTensorApply.cuh>
 #include <ATen/native/cuda/fused_adam_utils.cuh>
-#include <vector>
 
 namespace at::native {
 
@@ -24,77 +19,22 @@ void _fused_adam_amsgrad_cuda_impl_(
     const bool maximize,
     const std::optional<at::Tensor>& grad_scale,
     const std::optional<at::Tensor>& found_inf) {
-  std::vector<std::vector<at::Tensor>> tensor_lists{
-      params.vec(),
-      grads.vec(),
-      exp_avgs.vec(),
-      exp_avg_sqs.vec(),
-      max_exp_avg_sqs.vec()};
-
-  const float* grad_scale_ptr =
-      grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  const float* found_inf_ptr =
-      found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  const float* lr_ptr = nullptr;
-
-  if (params[0].scalar_type() != exp_avgs[0].scalar_type()) {
-    validate_mixed_precision_dtypes(
-        params,
-        grads,
-        exp_avgs,
-        exp_avg_sqs,
-        max_exp_avg_sqs,
-        "Mixed-precision fused Adam");
-    AT_DISPATCH_V2(
-        exp_avgs[0].scalar_type(),
-        "fused_adam_amsgrad_mp_kernel_cuda",
-        AT_WRAP([&]() {
-          multi_tensor_apply_for_fused_optimizer<5>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctorMP<
-                  float,
-                  float,
-                  float,
-                  scalar_t,
-                  scalar_t,
-                  scalar_t,
-                  5,
-                  ADAM_MODE::ORIGINAL,
-                  true>(),
-              lr_ptr, // unused
-              lr,
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        }),
-        kBFloat16);
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf,
-        kBFloat16,
-        params[0].scalar_type(),
-        "fused_adam_kernel_cuda",
-        [&]() {
-          multi_tensor_apply_for_fused_optimizer<5>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL, true>(),
-              lr_ptr, // unused
-              lr,
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        });
-  }
+  _fused_adam_cuda_impl_common<ADAM_MODE::ORIGINAL, /*amsgrad=*/true>(
+      params,
+      grads,
+      exp_avgs,
+      exp_avg_sqs,
+      max_exp_avg_sqs,
+      state_steps,
+      /*lr_ptr=*/nullptr,
+      lr,
+      beta1,
+      beta2,
+      weight_decay,
+      eps,
+      maximize,
+      grad_scale,
+      found_inf);
 }
 
 // The following overload simply has a Tensor lr
@@ -113,77 +53,22 @@ void _fused_adam_amsgrad_cuda_impl_(
     const bool maximize,
     const std::optional<at::Tensor>& grad_scale,
     const std::optional<at::Tensor>& found_inf) {
-  std::vector<std::vector<at::Tensor>> tensor_lists{
-      params.vec(),
-      grads.vec(),
-      exp_avgs.vec(),
-      exp_avg_sqs.vec(),
-      max_exp_avg_sqs.vec()};
-
-  const float* grad_scale_ptr =
-      grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  const float* found_inf_ptr =
-      found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  const float* lr_ptr = lr.const_data_ptr<float>();
-
-  if (params[0].scalar_type() != exp_avgs[0].scalar_type()) {
-    validate_mixed_precision_dtypes(
-        params,
-        grads,
-        exp_avgs,
-        exp_avg_sqs,
-        max_exp_avg_sqs,
-        "Mixed-precision fused Adam");
-    AT_DISPATCH_V2(
-        exp_avgs[0].scalar_type(),
-        "fused_adam_amsgrad_mp_kernel_cuda",
-        AT_WRAP([&]() {
-          multi_tensor_apply_for_fused_optimizer<5>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctorMP<
-                  float,
-                  float,
-                  float,
-                  scalar_t,
-                  scalar_t,
-                  scalar_t,
-                  5,
-                  ADAM_MODE::ORIGINAL,
-                  true>(),
-              lr_ptr,
-              1.0, // unused
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        }),
-        kBFloat16);
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf,
-        kBFloat16,
-        params[0].scalar_type(),
-        "fused_adam_kernel_cuda",
-        [&]() {
-          multi_tensor_apply_for_fused_optimizer<5>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL, true>(),
-              lr_ptr,
-              1.0, // unused
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        });
-  }
+  _fused_adam_cuda_impl_common<ADAM_MODE::ORIGINAL, /*amsgrad=*/true>(
+      params,
+      grads,
+      exp_avgs,
+      exp_avg_sqs,
+      max_exp_avg_sqs,
+      state_steps,
+      /*lr_ptr=*/lr.const_data_ptr<float>(),
+      /*lr=*/1.0,
+      beta1,
+      beta2,
+      weight_decay,
+      eps,
+      maximize,
+      grad_scale,
+      found_inf);
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/fused_adam_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_impl.cu
@@ -1,11 +1,6 @@
 #include <ATen/native/cuda/fused_adam_impl.cuh>
 
-#include <ATen/Dispatch.h>
-#include <ATen/Dispatch_v2.h>
-#include <ATen/native/ForeachUtils.h>
-#include <ATen/native/cuda/MultiTensorApply.cuh>
 #include <ATen/native/cuda/fused_adam_utils.cuh>
-#include <vector>
 
 namespace at::native {
 
@@ -23,68 +18,22 @@ void _fused_adam_cuda_impl_(
     const bool maximize,
     const std::optional<at::Tensor>& grad_scale,
     const std::optional<at::Tensor>& found_inf) {
-  std::vector<std::vector<at::Tensor>> tensor_lists{
-      params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
-
-  const float* grad_scale_ptr =
-      grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  const float* found_inf_ptr =
-      found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  const float* lr_ptr = nullptr;
-
-  if (params[0].scalar_type() != exp_avgs[0].scalar_type()) {
-    validate_mixed_precision_dtypes(
-        params, grads, exp_avgs, exp_avg_sqs, "Mixed-precision fused Adam");
-    AT_DISPATCH_V2(
-        exp_avgs[0].scalar_type(),
-        "fused_adam_mp_kernel_cuda",
-        AT_WRAP([&]() {
-          multi_tensor_apply_for_fused_optimizer<4>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctorMP<
-                  float,
-                  float,
-                  float,
-                  scalar_t,
-                  scalar_t,
-                  float,
-                  4,
-                  ADAM_MODE::ORIGINAL,
-                  false>(),
-              lr_ptr, // unused
-              lr,
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        }),
-        kBFloat16);
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf,
-        kBFloat16,
-        params[0].scalar_type(),
-        "fused_adam_kernel_cuda",
-        [&]() {
-          multi_tensor_apply_for_fused_optimizer<4>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL, false>(),
-              lr_ptr, // unused
-              lr,
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        });
-  }
+  _fused_adam_cuda_impl_common<ADAM_MODE::ORIGINAL, /*amsgrad=*/false>(
+      params,
+      grads,
+      exp_avgs,
+      exp_avg_sqs,
+      /*max_exp_avg_sqs=*/{},
+      state_steps,
+      /*lr_ptr=*/nullptr,
+      lr,
+      beta1,
+      beta2,
+      weight_decay,
+      eps,
+      maximize,
+      grad_scale,
+      found_inf);
 }
 
 // The following overload simply has a Tensor lr
@@ -102,68 +51,22 @@ void _fused_adam_cuda_impl_(
     const bool maximize,
     const std::optional<at::Tensor>& grad_scale,
     const std::optional<at::Tensor>& found_inf) {
-  std::vector<std::vector<at::Tensor>> tensor_lists{
-      params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
-
-  const float* grad_scale_ptr =
-      grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  const float* found_inf_ptr =
-      found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  const float* lr_ptr = lr.const_data_ptr<float>();
-
-  if (params[0].scalar_type() != exp_avgs[0].scalar_type()) {
-    validate_mixed_precision_dtypes(
-        params, grads, exp_avgs, exp_avg_sqs, "Mixed-precision fused Adam");
-    AT_DISPATCH_V2(
-        exp_avgs[0].scalar_type(),
-        "fused_adam_mp_kernel_cuda",
-        AT_WRAP([&]() {
-          multi_tensor_apply_for_fused_optimizer<4>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctorMP<
-                  float,
-                  float,
-                  float,
-                  scalar_t,
-                  scalar_t,
-                  float,
-                  4,
-                  ADAM_MODE::ORIGINAL,
-                  false>(),
-              lr_ptr,
-              1.0, // unused
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        }),
-        kBFloat16);
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf,
-        kBFloat16,
-        params[0].scalar_type(),
-        "fused_adam_kernel_cuda",
-        [&]() {
-          multi_tensor_apply_for_fused_optimizer<4>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL, false>(),
-              lr_ptr,
-              1.0, // unused
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        });
-  }
+  _fused_adam_cuda_impl_common<ADAM_MODE::ORIGINAL, /*amsgrad=*/false>(
+      params,
+      grads,
+      exp_avgs,
+      exp_avg_sqs,
+      /*max_exp_avg_sqs=*/{},
+      state_steps,
+      /*lr_ptr=*/lr.const_data_ptr<float>(),
+      /*lr=*/1.0,
+      beta1,
+      beta2,
+      weight_decay,
+      eps,
+      maximize,
+      grad_scale,
+      found_inf);
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -1,5 +1,6 @@
 #pragma once
 #include <ATen/core/Tensor.h>
+#include <ATen/native/FusedAdam.h>
 #include <ATen/native/cuda/ForeachFunctors.cuh>
 #include <ATen/native/cuda/MultiTensorApply.cuh>
 #include <ATen/native/cuda/Pow.cuh>
@@ -7,8 +8,6 @@
 #include <utility>
 
 namespace at::native {
-
-enum class ADAM_MODE : uint8_t { ORIGINAL = 0, ADAMW = 1 };
 
 // Validates the dtype configuration for mixed-precision fused Adam/AdamW.
 //

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -1,11 +1,15 @@
 #pragma once
+#include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/FusedAdam.h>
 #include <ATen/native/cuda/ForeachFunctors.cuh>
 #include <ATen/native/cuda/MultiTensorApply.cuh>
 #include <ATen/native/cuda/Pow.cuh>
+#include <optional>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace at::native {
 
@@ -546,6 +550,118 @@ struct FusedAdamMathFunctorMP {
     }
   }
 };
+
+// Shared host launcher for _fused_adam[w][_amsgrad]_cuda_impl_. Parameterized
+// on mode (Adam vs AdamW) and amsgrad; depth, the extra max_exp_avg_sqs list,
+// the mixed-precision functor's max_exp_avg_sq type, and the dispatch/validate
+// names are all derived from those. max_exp_avg_sqs is ignored when !amsgrad.
+// lr_ptr is set for a Tensor lr (lr unused); null for a scalar lr. AT_DISPATCH
+// stays in this template body so each caller .cu instantiates only its own
+// kernel set.
+template <ADAM_MODE mode, bool amsgrad>
+void _fused_adam_cuda_impl_common(
+    at::TensorList params,
+    at::TensorList grads,
+    at::TensorList exp_avgs,
+    at::TensorList exp_avg_sqs,
+    at::TensorList max_exp_avg_sqs,
+    at::TensorList state_steps,
+    const float* lr_ptr,
+    const double lr,
+    const double beta1,
+    const double beta2,
+    const double weight_decay,
+    const double eps,
+    const bool maximize,
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
+  constexpr int depth = amsgrad ? 5 : 4;
+  constexpr bool is_adamw = (mode == ADAM_MODE::ADAMW);
+  constexpr const char* validate_msg =
+      is_adamw ? "Mixed-precision fused AdamW" : "Mixed-precision fused Adam";
+  constexpr const char* mp_name = is_adamw
+      ? (amsgrad ? "fused_adamw_amsgrad_mp_kernel_cuda"
+                 : "fused_adamw_mp_kernel_cuda")
+      : (amsgrad ? "fused_adam_amsgrad_mp_kernel_cuda"
+                 : "fused_adam_mp_kernel_cuda");
+  constexpr const char* kernel_name = is_adamw
+      ? (amsgrad ? "fused_adamw_amsgrad_kernel_cuda"
+                 : "fused_adamw_kernel_cuda")
+      : (amsgrad ? "fused_adam_amsgrad_kernel_cuda" : "fused_adam_kernel_cuda");
+
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  if constexpr (amsgrad) {
+    tensor_lists = {
+        params.vec(),
+        grads.vec(),
+        exp_avgs.vec(),
+        exp_avg_sqs.vec(),
+        max_exp_avg_sqs.vec()};
+  } else {
+    tensor_lists = {
+        params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
+  }
+
+  const float* grad_scale_ptr =
+      grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
+  const float* found_inf_ptr =
+      found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
+
+  if (params[0].scalar_type() != exp_avgs[0].scalar_type()) {
+    if constexpr (amsgrad) {
+      validate_mixed_precision_dtypes(
+          params, grads, exp_avgs, exp_avg_sqs, max_exp_avg_sqs, validate_msg);
+    } else {
+      validate_mixed_precision_dtypes(
+          params, grads, exp_avgs, exp_avg_sqs, validate_msg);
+    }
+    AT_DISPATCH_V2(
+        exp_avgs[0].scalar_type(),
+        mp_name,
+        AT_WRAP([&]() {
+          multi_tensor_apply_for_fused_optimizer<depth>(
+              tensor_lists,
+              state_steps,
+              FusedAdamMathFunctorMP<
+                  float,
+                  float,
+                  float,
+                  scalar_t,
+                  scalar_t,
+                  std::conditional_t<amsgrad, scalar_t, float>,
+                  depth,
+                  mode,
+                  amsgrad>(),
+              lr_ptr,
+              lr,
+              beta1,
+              beta2,
+              weight_decay,
+              eps,
+              maximize,
+              grad_scale_ptr,
+              found_inf_ptr);
+        }),
+        kBFloat16);
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        kHalf, kBFloat16, params[0].scalar_type(), kernel_name, [&]() {
+          multi_tensor_apply_for_fused_optimizer<depth>(
+              tensor_lists,
+              state_steps,
+              FusedAdamMathFunctor<scalar_t, depth, mode, amsgrad>(),
+              lr_ptr,
+              lr,
+              beta1,
+              beta2,
+              weight_decay,
+              eps,
+              maximize,
+              grad_scale_ptr,
+              found_inf_ptr);
+        });
+  }
+}
 
 } // namespace
 

--- a/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
@@ -1,11 +1,6 @@
 #include <ATen/native/cuda/fused_adamw_amsgrad_impl.cuh>
 
-#include <ATen/Dispatch.h>
-#include <ATen/Dispatch_v2.h>
-#include <ATen/native/ForeachUtils.h>
-#include <ATen/native/cuda/MultiTensorApply.cuh>
 #include <ATen/native/cuda/fused_adam_utils.cuh>
-#include <vector>
 
 namespace at::native {
 
@@ -24,77 +19,22 @@ void _fused_adamw_amsgrad_cuda_impl_(
     const bool maximize,
     const std::optional<at::Tensor>& grad_scale,
     const std::optional<at::Tensor>& found_inf) {
-  std::vector<std::vector<at::Tensor>> tensor_lists{
-      params.vec(),
-      grads.vec(),
-      exp_avgs.vec(),
-      exp_avg_sqs.vec(),
-      max_exp_avg_sqs.vec()};
-
-  const float* grad_scale_ptr =
-      grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  const float* found_inf_ptr =
-      found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  const float* lr_ptr = nullptr;
-
-  if (params[0].scalar_type() != exp_avgs[0].scalar_type()) {
-    validate_mixed_precision_dtypes(
-        params,
-        grads,
-        exp_avgs,
-        exp_avg_sqs,
-        max_exp_avg_sqs,
-        "Mixed-precision fused AdamW");
-    AT_DISPATCH_V2(
-        exp_avgs[0].scalar_type(),
-        "fused_adamw_amsgrad_mp_kernel_cuda",
-        AT_WRAP([&]() {
-          multi_tensor_apply_for_fused_optimizer<5>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctorMP<
-                  float,
-                  float,
-                  float,
-                  scalar_t,
-                  scalar_t,
-                  scalar_t,
-                  5,
-                  ADAM_MODE::ADAMW,
-                  true>(),
-              lr_ptr, // unused
-              lr,
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        }),
-        kBFloat16);
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf,
-        kBFloat16,
-        params[0].scalar_type(),
-        "fused_adamw_kernel_cuda",
-        [&]() {
-          multi_tensor_apply_for_fused_optimizer<5>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW, true>(),
-              lr_ptr, // unused
-              lr,
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        });
-  }
+  _fused_adam_cuda_impl_common<ADAM_MODE::ADAMW, /*amsgrad=*/true>(
+      params,
+      grads,
+      exp_avgs,
+      exp_avg_sqs,
+      max_exp_avg_sqs,
+      state_steps,
+      /*lr_ptr=*/nullptr,
+      lr,
+      beta1,
+      beta2,
+      weight_decay,
+      eps,
+      maximize,
+      grad_scale,
+      found_inf);
 }
 
 // The following overload simply has a Tensor lr
@@ -113,77 +53,22 @@ void _fused_adamw_amsgrad_cuda_impl_(
     const bool maximize,
     const std::optional<at::Tensor>& grad_scale,
     const std::optional<at::Tensor>& found_inf) {
-  std::vector<std::vector<at::Tensor>> tensor_lists{
-      params.vec(),
-      grads.vec(),
-      exp_avgs.vec(),
-      exp_avg_sqs.vec(),
-      max_exp_avg_sqs.vec()};
-
-  const float* grad_scale_ptr =
-      grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  const float* found_inf_ptr =
-      found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  const float* lr_ptr = lr.const_data_ptr<float>();
-
-  if (params[0].scalar_type() != exp_avgs[0].scalar_type()) {
-    validate_mixed_precision_dtypes(
-        params,
-        grads,
-        exp_avgs,
-        exp_avg_sqs,
-        max_exp_avg_sqs,
-        "Mixed-precision fused AdamW");
-    AT_DISPATCH_V2(
-        exp_avgs[0].scalar_type(),
-        "fused_adamw_amsgrad_mp_kernel_cuda",
-        AT_WRAP([&]() {
-          multi_tensor_apply_for_fused_optimizer<5>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctorMP<
-                  float,
-                  float,
-                  float,
-                  scalar_t,
-                  scalar_t,
-                  scalar_t,
-                  5,
-                  ADAM_MODE::ADAMW,
-                  true>(),
-              lr_ptr,
-              1.0, // unused
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        }),
-        kBFloat16);
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf,
-        kBFloat16,
-        params[0].scalar_type(),
-        "fused_adamw_kernel_cuda",
-        [&]() {
-          multi_tensor_apply_for_fused_optimizer<5>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW, true>(),
-              lr_ptr,
-              1.0, // unused
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        });
-  }
+  _fused_adam_cuda_impl_common<ADAM_MODE::ADAMW, /*amsgrad=*/true>(
+      params,
+      grads,
+      exp_avgs,
+      exp_avg_sqs,
+      max_exp_avg_sqs,
+      state_steps,
+      /*lr_ptr=*/lr.const_data_ptr<float>(),
+      /*lr=*/1.0,
+      beta1,
+      beta2,
+      weight_decay,
+      eps,
+      maximize,
+      grad_scale,
+      found_inf);
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/fused_adamw_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_impl.cu
@@ -1,11 +1,6 @@
 #include <ATen/native/cuda/fused_adamw_impl.cuh>
 
-#include <ATen/Dispatch.h>
-#include <ATen/Dispatch_v2.h>
-#include <ATen/native/ForeachUtils.h>
-#include <ATen/native/cuda/MultiTensorApply.cuh>
 #include <ATen/native/cuda/fused_adam_utils.cuh>
-#include <vector>
 
 namespace at::native {
 
@@ -23,68 +18,22 @@ void _fused_adamw_cuda_impl_(
     const bool maximize,
     const std::optional<at::Tensor>& grad_scale,
     const std::optional<at::Tensor>& found_inf) {
-  std::vector<std::vector<at::Tensor>> tensor_lists{
-      params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
-
-  const float* grad_scale_ptr =
-      grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  const float* found_inf_ptr =
-      found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  const float* lr_ptr = nullptr;
-
-  if (params[0].scalar_type() != exp_avgs[0].scalar_type()) {
-    validate_mixed_precision_dtypes(
-        params, grads, exp_avgs, exp_avg_sqs, "Mixed-precision fused AdamW");
-    AT_DISPATCH_V2(
-        exp_avgs[0].scalar_type(),
-        "fused_adamw_mp_kernel_cuda",
-        AT_WRAP([&]() {
-          multi_tensor_apply_for_fused_optimizer<4>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctorMP<
-                  float,
-                  float,
-                  float,
-                  scalar_t,
-                  scalar_t,
-                  float,
-                  4,
-                  ADAM_MODE::ADAMW,
-                  false>(),
-              lr_ptr, // unused
-              lr,
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        }),
-        kBFloat16);
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf,
-        kBFloat16,
-        params[0].scalar_type(),
-        "fused_adamw_kernel_cuda",
-        [&]() {
-          multi_tensor_apply_for_fused_optimizer<4>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW, false>(),
-              lr_ptr, // unused
-              lr,
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        });
-  }
+  _fused_adam_cuda_impl_common<ADAM_MODE::ADAMW, /*amsgrad=*/false>(
+      params,
+      grads,
+      exp_avgs,
+      exp_avg_sqs,
+      /*max_exp_avg_sqs=*/{},
+      state_steps,
+      /*lr_ptr=*/nullptr,
+      lr,
+      beta1,
+      beta2,
+      weight_decay,
+      eps,
+      maximize,
+      grad_scale,
+      found_inf);
 }
 
 // The following overload simply has a Tensor lr
@@ -102,68 +51,22 @@ void _fused_adamw_cuda_impl_(
     const bool maximize,
     const std::optional<at::Tensor>& grad_scale,
     const std::optional<at::Tensor>& found_inf) {
-  std::vector<std::vector<at::Tensor>> tensor_lists{
-      params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
-
-  const float* grad_scale_ptr =
-      grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  const float* found_inf_ptr =
-      found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  const float* lr_ptr = lr.const_data_ptr<float>();
-
-  if (params[0].scalar_type() != exp_avgs[0].scalar_type()) {
-    validate_mixed_precision_dtypes(
-        params, grads, exp_avgs, exp_avg_sqs, "Mixed-precision fused AdamW");
-    AT_DISPATCH_V2(
-        exp_avgs[0].scalar_type(),
-        "fused_adamw_mp_kernel_cuda",
-        AT_WRAP([&]() {
-          multi_tensor_apply_for_fused_optimizer<4>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctorMP<
-                  float,
-                  float,
-                  float,
-                  scalar_t,
-                  scalar_t,
-                  float,
-                  4,
-                  ADAM_MODE::ADAMW,
-                  false>(),
-              lr_ptr,
-              1.0, // unused
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        }),
-        kBFloat16);
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf,
-        kBFloat16,
-        params[0].scalar_type(),
-        "fused_adamw_kernel_cuda",
-        [&]() {
-          multi_tensor_apply_for_fused_optimizer<4>(
-              tensor_lists,
-              state_steps,
-              FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW, false>(),
-              lr_ptr,
-              1.0, // unused
-              beta1,
-              beta2,
-              weight_decay,
-              eps,
-              maximize,
-              grad_scale_ptr,
-              found_inf_ptr);
-        });
-  }
+  _fused_adam_cuda_impl_common<ADAM_MODE::ADAMW, /*amsgrad=*/false>(
+      params,
+      grads,
+      exp_avgs,
+      exp_avg_sqs,
+      /*max_exp_avg_sqs=*/{},
+      state_steps,
+      /*lr_ptr=*/lr.const_data_ptr<float>(),
+      /*lr=*/1.0,
+      beta1,
+      beta2,
+      weight_decay,
+      eps,
+      maximize,
+      grad_scale,
+      found_inf);
 }
 
 } // namespace at::native


### PR DESCRIPTION
Two no-functional-change cleanups in the fused Adam/AdamW CUDA implementations:

- `fused_adam_utils.cuh` redefined `ADAM_MODE`, an exact copy of the canonical enum in `ATen/native/FusedAdam.h`. Drop the copy and include that header (adding its missing include guard).
- The four `_fused_adam[w][_amsgrad]_cuda_impl_` files open-coded the same dispatch + `multi_tensor_apply` body (each also with duplicate scalar-`lr`/Tensor-`lr` overloads), differing only by `ADAM_MODE` and `amsgrad` — which also determine depth, the extra `max_exp_avg_sqs` list, the mixed-precision functor's max type, and the dispatch/validate name strings. Collapse it into one `template <ADAM_MODE mode, bool amsgrad>` launcher in `fused_adam_utils.cuh`; each `.cu` keeps two thin public overloads. `AT_DISPATCH` stays in the template body, so each `.cu` still instantiates only its own kernel set — no new kernel instantiations, and net ~300 fewer lines. The amsgrad non-mixed-precision dispatch label now also carries the `amsgrad` suffix (was `"fused_adam[w]_kernel_cuda"`).

Test Plan: existing optimizer tests (`test/test_optim.py`).