### PR TITLE
Fix EmbeddingBag SEGV when include_last_offset has too few offsets

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -912,6 +912,12 @@ void check_arguments(
     TORCH_CHECK(
         offsets.size(0) >= 1,
         "include_last_offset: number of offset should be at least 1");
+    TORCH_CHECK(
+        offsets.size(0) >= 2 || indices.numel() == 0,
+        "embedding_bag: When include_last_offset is True and there are indices, "
+        "offsets must have at least 2 elements to define at least one bag, "
+        "but got offsets of size ", offsets.size(0),
+        " with ", indices.numel(), " indices");
   }
 }
 

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -375,6 +375,15 @@ _embedding_bag_cuda(const Tensor &weight, const Tensor &indices_,
     // implementation even this flag is enabled.
     TORCH_CHECK(
         numBags >= 1, "include_last_offset: numBags should be at least 1");
+    // Reject the combination that produces 0 bags with non-empty indices,
+    // which previously caused OOB access. See
+    // https://github.com/pytorch/pytorch/issues/190044.
+    TORCH_CHECK(
+        numBags >= 2 || numIndices == 0,
+        "embedding_bag: When include_last_offset is True and there are indices, "
+        "offsets must have at least 2 elements to define at least one bag, "
+        "but got offsets of size ", numBags,
+        " with ", numIndices, " indices");
     numBags -= 1;
   }
   int64_t featureSize = weight.size(1);

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -296,6 +296,26 @@ class TestEmbeddingNN(NNTestCase):
 
 
 class TestEmbeddingNNDeviceType(NNTestCase):
+    def test_embedding_bag_include_last_offset_invalid_offsets(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/190044
+        # Call torch.embedding_bag directly with include_last_offset=True and a
+        # single-element offsets tensor plus non-empty indices — the combination
+        # that previously SEGV'd on CPU (and could OOB on CUDA).
+        weight = torch.randn(5, 3, dtype=torch.float64, device=device)
+        indices = torch.tensor([0, 1, 2], dtype=torch.int64, device=device)
+        offsets = torch.tensor([0], dtype=torch.int64, device=device)
+        with self.assertRaisesRegex(RuntimeError, "include_last_offset"):
+            torch.embedding_bag(
+                weight, indices, offsets, False, 0, False, None, True, None
+            )
+
+        # Verify that 0 bags with 0 indices is fine
+        empty_indices = torch.tensor([], dtype=torch.int64, device=device)
+        result = torch.embedding_bag(
+            weight, empty_indices, offsets, False, 0, False, None, True, None
+        )
+        self.assertEqual(result[0].shape, (0, 3))
+
     def test_embedding_dense_grad(self, device):
         with set_default_dtype(torch.double):
             embd = nn.Embedding(20, 20).to(device)


### PR DESCRIPTION
## Summary
- Reject `include_last_offset=True` when offsets has fewer than 2 elements and indices are non-empty (CPU + CUDA)
- Turns ASan SEGV / OOB into a clear `RuntimeError`
- Adds a regression test via direct `torch.embedding_bag` call

Fixes #190044

## Test plan
- [x] `lintrunner` on touched files
- [x] `python -m pytest test/nn/test_embedding.py -q`
- [x] CI on this PR