### PR TITLE
[Dynamo] Add descr_check to C descriptor VT tp_descr_get_impl

### DIFF
--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -850,7 +850,6 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(fn(x), x + 20)
         self.assertEqual(cnt.frame_count, 2)
 
-
     # --- C descriptor type check (descr_check equivalent) ---
 
 
@@ -916,7 +915,6 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
             fn(x, b)
         with self.assertRaises(torch._dynamo.exc.Unsupported):
             torch.compile(fn, backend="eager", fullgraph=True)(x, b)
-
 
     def test_method_descriptor_compatible_type(self):
         def fn(x):

--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -852,7 +852,6 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
 
     # --- C descriptor type check (descr_check equivalent) ---
 
-
     def test_method_descriptor_incompatible_type(self):
         class Borrower:
             append = list.append

--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -909,11 +909,11 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
 
     def test_getset_descriptor_incompatible_type(self):
         class Borrower:
-            __class__ = int.__class__
+            denominator = int.denominator
 
         def fn(x, obj):
             try:
-                obj.__class__
+                obj.denominator
                 return x + 1
             except TypeError:
                 return x + 2
@@ -922,6 +922,18 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
         b = Borrower()
         eager = fn(x, b).sum()
         compiled = torch.compile(fn, backend="eager", fullgraph=True)(x, b).sum()
+        self.assertEqual(eager, compiled)
+
+
+    def test_method_descriptor_compatible_type(self):
+        def fn(x):
+            l = [1, 2, 3]
+            l.append(4)
+            return x
+
+        x = torch.randn(4)
+        eager = fn(x).sum()
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x).sum()
         self.assertEqual(eager, compiled)
 
 

--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -851,6 +851,80 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnt.frame_count, 2)
 
 
+    # --- C descriptor type check (descr_check equivalent) ---
+
+    def test_method_descriptor_incompatible_type(self):
+        class Borrower:
+            append = list.append
+
+        def fn(x, obj):
+            try:
+                obj.append
+                return x + 1
+            except TypeError:
+                return x + 2
+
+        x = torch.randn(4)
+        b = Borrower()
+        eager = fn(x, b).sum()
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x, b).sum()
+        self.assertEqual(eager, compiled)
+
+    def test_wrapper_descriptor_incompatible_type(self):
+        class Borrower:
+            add = list.__add__
+
+        def fn(x, obj):
+            try:
+                obj.add
+                return x + 1
+            except TypeError:
+                return x + 2
+
+        x = torch.randn(4)
+        b = Borrower()
+        eager = fn(x, b).sum()
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x, b).sum()
+        self.assertEqual(eager, compiled)
+
+    def test_member_descriptor_incompatible_type(self):
+        class Alien:
+            __slots__ = ("x",)
+
+        class Borrower:
+            x = Alien.x
+
+        def fn(x, obj):
+            try:
+                obj.x
+                return x + 1
+            except TypeError:
+                return x + 2
+
+        x = torch.randn(4)
+        b = Borrower()
+        eager = fn(x, b).sum()
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x, b).sum()
+        self.assertEqual(eager, compiled)
+
+    def test_getset_descriptor_incompatible_type(self):
+        class Borrower:
+            __class__ = int.__class__
+
+        def fn(x, obj):
+            try:
+                obj.__class__
+                return x + 1
+            except TypeError:
+                return x + 2
+
+        x = torch.randn(4)
+        b = Borrower()
+        eager = fn(x, b).sum()
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x, b).sum()
+        self.assertEqual(eager, compiled)
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -853,39 +853,36 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
 
     # --- C descriptor type check (descr_check equivalent) ---
 
+
     def test_method_descriptor_incompatible_type(self):
         class Borrower:
             append = list.append
 
         def fn(x, obj):
-            try:
-                obj.append
-                return x + 1
-            except TypeError:
-                return x + 2
+            obj.append
+            return x + 1
 
         x = torch.randn(4)
         b = Borrower()
-        eager = fn(x, b).sum()
-        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x, b).sum()
-        self.assertEqual(eager, compiled)
+        with self.assertRaises(TypeError):
+            fn(x, b)
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)(x, b)
 
     def test_wrapper_descriptor_incompatible_type(self):
         class Borrower:
             add = list.__add__
 
         def fn(x, obj):
-            try:
-                obj.add
-                return x + 1
-            except TypeError:
-                return x + 2
+            obj.add
+            return x + 1
 
         x = torch.randn(4)
         b = Borrower()
-        eager = fn(x, b).sum()
-        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x, b).sum()
-        self.assertEqual(eager, compiled)
+        with self.assertRaises(TypeError):
+            fn(x, b)
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)(x, b)
 
     def test_member_descriptor_incompatible_type(self):
         class Alien:
@@ -895,34 +892,30 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
             x = Alien.x
 
         def fn(x, obj):
-            try:
-                obj.x
-                return x + 1
-            except TypeError:
-                return x + 2
+            obj.x
+            return x + 1
 
         x = torch.randn(4)
         b = Borrower()
-        eager = fn(x, b).sum()
-        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x, b).sum()
-        self.assertEqual(eager, compiled)
+        with self.assertRaises(TypeError):
+            fn(x, b)
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)(x, b)
 
     def test_getset_descriptor_incompatible_type(self):
         class Borrower:
             denominator = int.denominator
 
         def fn(x, obj):
-            try:
-                obj.denominator
-                return x + 1
-            except TypeError:
-                return x + 2
+            obj.denominator
+            return x + 1
 
         x = torch.randn(4)
         b = Borrower()
-        eager = fn(x, b).sum()
-        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x, b).sum()
-        self.assertEqual(eager, compiled)
+        with self.assertRaises(TypeError):
+            fn(x, b)
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)(x, b)
 
 
     def test_method_descriptor_compatible_type(self):

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3942,6 +3942,36 @@ class TritonSetAllocatorVariable(VariableTracker):
 # the descriptor binding step faithfully.
 # ---------------------------------------------------------------------------
 
+def _check_descriptor_obj_type(
+    tx: "InstructionTranslatorBase",
+    descriptor: types.MethodDescriptorType
+    | types.WrapperDescriptorType
+    | types.MemberDescriptorType
+    | types.GetSetDescriptorType,
+    obj: "VariableTracker",
+) -> None:
+    """Check that obj's type is compatible with descriptor.__objclass__.
+
+    Mirrors CPython's descr_check which raises TypeError when a C descriptor
+    is bound to an object whose type is not a subtype of the descriptor's
+    __objclass__.
+
+    https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L79-L96
+    """
+    if obj is None:
+        return
+    try:
+        obj_type = obj.python_type()
+    except NotImplementedError:
+        return
+    if not issubclass(obj_type, descriptor.__objclass__):
+        raise_type_error(
+            tx,
+            f"descriptor '{descriptor.__name__}' for "
+            f"'{descriptor.__objclass__.__name__}' objects "
+            f"doesn't apply to a '{obj_type.__name__}' object",
+        )
+
 
 class WrapperDescriptorVariable(VariableTracker):
     """Unbound C slot wrapper (wrapper_descriptor on a type).
@@ -4013,6 +4043,7 @@ class WrapperDescriptorVariable(VariableTracker):
                 f"'{self.descriptor.__objclass__.__name__}' object needs an argument",
             )
         obj, *rest = args
+        _check_descriptor_obj_type(tx, self.descriptor, obj)
         # Dispatch through the owner (UDCV for the defining class) rather
         # than obj.call_method, which would do MRO resolution from type(obj)
         # and find Python overrides on subclasses. Routing through the class
@@ -4031,6 +4062,7 @@ class WrapperDescriptorVariable(VariableTracker):
         # a bound method-wrapper.
         # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L203-L213
         # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L1489-L1505
+        _check_descriptor_obj_type(tx, self.descriptor, obj)
         return MethodWrapperVariable(self.descriptor, obj, source=self.source)
 
 
@@ -4223,6 +4255,7 @@ class MethodDescriptorVariable(VariableTracker):
         # bound builtin_function_or_method.
         # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L137-L159
         # https://github.com/python/cpython/blob/3.13/Objects/methodobject.c#L40
+        _check_descriptor_obj_type(tx, self.descriptor, obj)
         return BoundBuiltinMethodVariable(self.descriptor, obj, source=self.source)
 
 
@@ -4517,6 +4550,7 @@ class MemberDescriptorVariable(VariableTracker):
         # Mirrors member_get which calls PyMember_GetOne to read the
         # C struct field.
         # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L162-L180
+        _check_descriptor_obj_type(tx, self.descriptor, obj)
         from .object_protocol import _UnhandledDescriptorError
 
         attr_name = self.descriptor.__name__
@@ -4607,6 +4641,7 @@ class GetSetDescriptorVariable(VariableTracker):
         # concrete Python object (UDOV.value, or as_python_constant
         # for classes/constants). Fall back to getattro_impl for
         # proxy-based VTs like TensorVariable.
+        _check_descriptor_obj_type(tx, self.descriptor, obj)
         obj_value = obj.get_real_python_backed_value()
         if obj_value is NO_SUCH_SUBOBJ:
             from .object_protocol import _UnhandledDescriptorError

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3942,6 +3942,7 @@ class TritonSetAllocatorVariable(VariableTracker):
 # the descriptor binding step faithfully.
 # ---------------------------------------------------------------------------
 
+
 def _check_descriptor_obj_type(
     tx: "InstructionTranslatorBase",
     descriptor: types.MethodDescriptorType
@@ -4229,17 +4230,7 @@ class MethodDescriptorVariable(VariableTracker):
             )
         obj, *rest = args
         name = self.descriptor.__name__
-        try:
-            obj_type = obj.python_type()
-            if not issubclass(obj_type, self.descriptor.__objclass__):
-                raise_type_error(
-                    tx,
-                    f"descriptor '{name}' for "
-                    f"'{self.descriptor.__objclass__.__name__}' objects "
-                    f"doesn't apply to a '{obj_type.__name__}' object",
-                )
-        except NotImplementedError:
-            pass
+        _check_descriptor_obj_type(tx, self.descriptor, obj)
         # Dispatch through the owner (UDCV for the defining class) rather
         # than obj.call_method, which would do MRO resolution from type(obj)
         # and find Python overrides on subclasses.


### PR DESCRIPTION
Fixes #190755

CPython's descr_check (Objects/descrobject.c:79) validates that the object bound to a C descriptor is actually a subtype of the descriptor's __objclass__. Without this check, Dynamo silently binds C descriptors to incompatible objects during tracing, producing wrong control flow.

The fix adds `_check_descriptor_obj_type` and calls it in the `tp_descr_get_impl` of all four C-descriptor VariableTracker classes:
- `WrapperDescriptorVariable` (`call_function` + `tp_descr_get_impl`)
- `MethodDescriptorVariable` (`tp_descr_get_impl`)
- `MemberDescriptorVariable` (`tp_descr_get_impl`)
- `GetSetDescriptorVariable` (`tp_descr_get_impl`)

## Test Plan

Reproducer from issue #190755:

```python
class Borrower:
    append = list.append

def fn(x, obj):
    try:
        m = obj.append
        return x + 1
    except TypeError:
        return x + 2

eager_result = fn(x, b).sum()
compiled_result = torch.compile(fn, backend='eager', fullgraph=True)(x, b).sum()
assert eager_result == compiled_result
```

1. `python test/dynamo/test_tp_getattro.py` — 71/72 pass (the 1 failure is a pre-existing sparse tensor precision issue)
2. `python test/dynamo/test_user_defined_object.py` — passes

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98