### PR TITLE
[inductor] Peak aware fusions: incrementally update fusion memory timeline after fusions

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -2904,8 +2904,59 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         self.assertEqual(live_before, [0, 0, 100, 300, 250, 250, 50])
         self.assertEqual(live_after, [0, 100, 300, 350, 250, 250])
 
+        step_calls = 0
+
+        def cached_step_of(node):
+            nonlocal step_calls
+            step_calls += 1
+            return steps[node]
+
+        last_use_step_cache = {}
+        cached_result = mem_mod.estimate_region_peak_memory(
+            nodes_in_window,
+            region_start=0,
+            region_end=5,
+            step_of=cached_step_of,
+            graph_outputs={"bufC"},
+            last_use_step_cache=last_use_step_cache,
+            known_last_use_steps={
+                id(bufA.mpi_buffer): 3,
+                id(bufB.mpi_buffer): 5,
+            },
+            node_steps=steps,
+        )
+        self.assertEqual(cached_result, (peak, live_before, live_after))
+        self.assertEqual(step_calls, 0)
+        self.assertEqual(last_use_step_cache[id(bufA.mpi_buffer)], 3)
+        self.assertEqual(last_use_step_cache[id(bufB.mpi_buffer)], 5)
+
+        peak_only = mem_mod.estimate_region_peak_memory(
+            nodes_in_window,
+            region_start=0,
+            region_end=5,
+            step_of=lambda n: steps[n],
+            graph_outputs={"bufC"},
+            include_live_memory=False,
+        )
+        self.assertEqual(peak_only, (peak, [], []))
+
+        early_peak, early_before, early_after = mem_mod.estimate_region_peak_memory(
+            nodes_in_window,
+            region_start=0,
+            region_end=5,
+            step_of=lambda n: steps[n],
+            graph_outputs={"bufC"},
+            max_peak=299,
+        )
+        self.assertGreater(early_peak, 299)
+        self.assertEqual((early_before, early_after), ([], []))
+
     def test_fusion_memory_update_splices_context(self):
-        from torch._inductor.scheduler import FusionMemoryContext, FusionMemoryUpdate
+        from torch._inductor.scheduler import (
+            FusionMemoryContext,
+            FusionMemoryUpdate,
+            Scheduler,
+        )
 
         a, b, c = (_PeakMemFakeNode(n) for n in ("a", "b", "c"))
         candidate = _PeakMemFakeNode("candidate")
@@ -2913,11 +2964,13 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         fused.snodes = [a, b]
         ctx = FusionMemoryContext(
             nodes=[a, b, c],
+            tracked_nodes={a, b, c},
             graph_outputs=set(),
             node_to_idx={a: 0, b: 1, c: 2},
             baseline_peak=30,
             baseline_live_before=[0, 10, 20, 30],
             baseline_live_after=[10, 20, 30, 30],
+            last_use_steps={1: 2},
         )
         update = FusionMemoryUpdate(
             node1=a,
@@ -2929,9 +2982,19 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
             local_nodes=[candidate],
             live_before=[1, 2, 3],
             live_after=[4, 5],
+            last_use_steps={1: 0, 3: 4},
+            candidate_outputs=[],
         )
 
-        ctx.apply_accepted_fusion(update, fused)
+        scheduler = object.__new__(Scheduler)
+        scheduler._fusion_memory_context = ctx
+        with (
+            patch.object(
+                scheduler, "_check_fusion_memory", return_value=(False, update)
+            ),
+            patch.object(scheduler, "fuse_two_nodes", return_value=fused),
+        ):
+            self.assertIs(scheduler._fuse_two_nodes_memory_checked(a, b, set()), fused)
 
         self.assertEqual(ctx.nodes, [fused, None, c])
         self.assertEqual(ctx.baseline_live_before, [1, 2, 3, 30])
@@ -2940,7 +3003,8 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         self.assertEqual(ctx.node_to_idx[fused], 0)
         self.assertEqual(ctx.node_to_idx[a], 0)
         self.assertEqual(ctx.node_to_idx[b], 0)
-
+        self.assertEqual(ctx.tracked_nodes, {fused, c})
+        self.assertEqual(ctx.last_use_steps, {1: 0, 3: 4})
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -2579,6 +2579,9 @@ class _PeakMemFakeNode:
             return out
         return self._outputs
 
+    def get_nodes(self):
+        return self.snodes if self.snodes is not None else [self]
+
 
 class _PeakMemFakeBuffer:
     def __init__(self, name: str, succ_nodes, size_alloc: int, size_free: int) -> None:
@@ -2881,7 +2884,7 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         steps = {a1: 1, a2: 2, a3: 3, a100: 100, b3: 3, b5: 5}
         nodes_in_window = [a1, a2, a3, b3, b5]
 
-        peak = mem_mod.estimate_region_peak_memory(
+        peak, live_before, live_after = mem_mod.estimate_region_peak_memory(
             nodes_in_window,
             region_start=0,
             region_end=5,
@@ -2898,6 +2901,45 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         # a100 (step 100) is outside the window, so bufD is never seen.
         # bufC is a graph output, so it is never freed.
         self.assertEqual(peak, 350)
+        self.assertEqual(live_before, [0, 0, 100, 300, 250, 250, 50])
+        self.assertEqual(live_after, [0, 100, 300, 350, 250, 250])
+
+    def test_fusion_memory_update_splices_context(self):
+        from torch._inductor.scheduler import FusionMemoryContext, FusionMemoryUpdate
+
+        a, b, c = (_PeakMemFakeNode(n) for n in ("a", "b", "c"))
+        candidate = _PeakMemFakeNode("candidate")
+        fused = _PeakMemFakeNode("fused")
+        fused.snodes = [a, b]
+        ctx = FusionMemoryContext(
+            nodes=[a, b, c],
+            graph_outputs=set(),
+            node_to_idx={a: 0, b: 1, c: 2},
+            baseline_peak=30,
+            baseline_live_before=[0, 10, 20, 30],
+            baseline_live_after=[10, 20, 30, 30],
+        )
+        update = FusionMemoryUpdate(
+            node1=a,
+            node2=b,
+            candidate=candidate,
+            candidate_step=0,
+            region_start=0,
+            region_end=1,
+            local_nodes=[candidate],
+            live_before=[1, 2, 3],
+            live_after=[4, 5],
+        )
+
+        ctx.apply_accepted_fusion(update, fused)
+
+        self.assertEqual(ctx.nodes, [fused, None, c])
+        self.assertEqual(ctx.baseline_live_before, [1, 2, 3, 30])
+        self.assertEqual(ctx.baseline_live_after, [4, 5, 30, 30])
+        self.assertEqual(ctx.baseline_peak, 30)
+        self.assertEqual(ctx.node_to_idx[fused], 0)
+        self.assertEqual(ctx.node_to_idx[a], 0)
+        self.assertEqual(ctx.node_to_idx[b], 0)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -3006,6 +3006,81 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         self.assertEqual(ctx.tracked_nodes, {fused, c})
         self.assertEqual(ctx.last_use_steps, {1: 0, 3: 4})
 
+    def test_fusion_memory_update_modes(self):
+        from torch._inductor.scheduler import FusionMemoryContext, Scheduler
+
+        a, b, peak, far = (_PeakMemFakeNode(n) for n in ("a", "b", "peak", "far"))
+        ctx = FusionMemoryContext(
+            nodes=[a, b, peak, far],
+            tracked_nodes={a, b, peak, far},
+            graph_outputs=set(),
+            node_to_idx={a: 0, b: 1, peak: 2, far: 3},
+            baseline_peak=100,
+            baseline_live_before=[0, 10, 20, 100, 90],
+            baseline_live_after=[10, 20, 100, 90],
+        )
+        ctx.refresh_peak_range()
+        scheduler = object.__new__(Scheduler)
+        fast_update = object()
+        with (
+            torch._inductor.config.patch(
+                fusion_memory_timeline_peak_allowed_increase_mb=0,
+                fusion_memory_timeline_full_correctness=False,
+            ),
+            patch.object(
+                scheduler,
+                "_fusion_memory_update",
+                return_value=(False, fast_update),
+            ) as update_mock,
+        ):
+            self.assertEqual(
+                scheduler._check_fusion_memory(ctx, a, b),
+                (False, None),
+            )
+            update_mock.assert_not_called()
+            self.assertEqual(
+                scheduler._check_fusion_memory(ctx, a, far),
+                (False, fast_update),
+            )
+            update_mock.assert_called_once_with(ctx, a, far, 0)
+            fused = _PeakMemFakeNode("fused")
+            self.assertEqual(
+                scheduler._check_fusion_memory(ctx, fused, b),
+                (False, None),
+            )
+            update_mock.assert_called_once_with(ctx, a, far, 0)
+
+            ctx.decision_cache.clear()
+            update_mock.return_value = (True, None)
+            self.assertEqual(
+                scheduler._check_fusion_memory(ctx, a, far),
+                (True, None),
+            )
+            self.assertEqual(
+                scheduler._check_fusion_memory(None, a, far),
+                (False, None),
+            )
+
+        ctx.decision_cache.clear()
+        exact_update = object()
+        with (
+            torch._inductor.config.patch(
+                fusion_memory_timeline_peak_allowed_increase_mb=0,
+                fusion_memory_timeline_full_correctness=True,
+            ),
+            patch.object(
+                scheduler,
+                "_fusion_memory_update",
+                return_value=(False, exact_update),
+            ) as update_mock,
+        ):
+            self.assertEqual(
+                scheduler._check_fusion_memory(ctx, a, b),
+                (False, exact_update),
+            )
+            update_mock.assert_called_once_with(ctx, a, b, 0)
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -993,6 +993,12 @@ score_fusion_memory_threshold = 10
 # value is the allowed estimated peak increase in megabytes.
 fusion_memory_timeline_peak_allowed_increase_mb = None
 
+# Supporting full memory timeline could increase compile time,
+# By default we do heuristically based fast path that minimally increases compile time
+# at cost of not absolutely correct predictions.
+# Use True if not regressing peak memory is prioritized over compile time.
+fusion_memory_timeline_full_correctness = False
+
 # For Triton Templates, select fastest of best template + epilogue vs best template + separate epilogue kernel
 benchmark_epilogue_fusion = (
     os.environ.get("TORCHINDUCTOR_BENCHMARK_EPILOGUE_FUSION", "1") == "1"

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -510,7 +510,7 @@ def estimate_region_peak_memory(
     step_of: Callable[[BaseSchedulerNode], int],
     graph_outputs: OrderedSet[str],
     cur_memory: int = 0,
-) -> int:
+) -> tuple[int, list[int], list[int]]:
     """Peak memory inside `[region_start, region_end]` for the
     hypothetical post-reorder schedule.
 
@@ -518,18 +518,23 @@ def estimate_region_peak_memory(
     each node: alloc = sum of `size_alloc` over its outputs; free =
     sum of `size_free` over `pred_buffers` whose proposed last
     consumer is this node. Then accumulates per step starting from
-    `cur_memory` (live bytes at the window boundary) and returns
-    the maximum live bytes.
+    `cur_memory` (live bytes at the window boundary) and returns the peak
+    plus live-before/live-after vectors for the simulated region.
     """
     R = region_end - region_start + 1
-    region = [SNodeMemory(0, 0) for _ in range(R)]
+    allocs = [0] * R
+    frees = [0] * R
     last_use_step_cache: dict[int, int | None] = {}
 
     def last_use_step(buffer) -> int | None:
         key = id(buffer)
         if key not in last_use_step_cache:
-            succ_steps = [step_of(n) for n in buffer.succ_nodes]
-            last_use_step_cache[key] = max(succ_steps) if succ_steps else None
+            last_step = None
+            for n in buffer.succ_nodes:
+                step = step_of(n)
+                if last_step is None or step > last_step:
+                    last_step = step
+            last_use_step_cache[key] = last_step
         return last_use_step_cache[key]
 
     for node in nodes_in_window:
@@ -540,12 +545,12 @@ def estimate_region_peak_memory(
 
         for buf in node.get_outputs():
             bi = buf.mpi_buffer
-            region[slot].size_alloc += bi.size_alloc
+            allocs[slot] += bi.size_alloc
             name = buf.get_name()
             if name in graph_outputs:
                 continue
             if last_use_step(bi) is None:
-                region[slot].size_free += bi.size_free
+                frees[slot] += bi.size_free
 
         for pb in node.mpi_node.pred_buffers:
             name = pb.get_name()
@@ -555,16 +560,22 @@ def estimate_region_peak_memory(
             if last_step is None:
                 raise AssertionError("expected non-empty succ_steps")
             if last_step == s:
-                region[slot].size_free += pb.mpi_buffer.size_free
+                frees[slot] += pb.mpi_buffer.size_free
 
     cur = cur_memory
     peak = cur
-    for af in region:
-        cur += af.size_alloc
+    region_live_before = [0] * (R + 1)
+    region_live_after = [0] * R
+    for i in range(R):
+        region_live_before[i] = cur
+        cur += allocs[i]
         if cur > peak:
             peak = cur
-        cur -= af.size_free
-    return peak
+        # Match peak_memory_from_buf_info_list: frees apply at the next step.
+        region_live_after[i] = cur
+        cur -= frees[i]
+    region_live_before[R] = cur
+    return peak, region_live_before, region_live_after
 
 
 @dataclasses.dataclass

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -18,7 +18,7 @@ from .virtualized import V
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Iterable, Sequence
 
     from .dependencies import Dep
     from .scheduler import BaseSchedulerNode, SchedulerBuffer
@@ -226,13 +226,15 @@ def compute_size_for_scheduler_buffer(
 def assign_memory_planning_info_for_scheduler_buffers(
     nodes: list[BaseSchedulerNode],
     name_to_buf: dict[str, SchedulerBuffer],
+    sched_buf_to_size: dict[str, tuple[int, int]] | None = None,
 ) -> None:
     """
     For each SchedulerBuffer, assign its size info and successor nodes.
     A buffer's successor nodes determines when a buffer can be freed.
     """
     # get buffer sizes
-    sched_buf_to_size = compute_size_for_scheduler_buffer(name_to_buf)
+    if sched_buf_to_size is None:
+        sched_buf_to_size = compute_size_for_scheduler_buffer(name_to_buf)
 
     # get buffer's successor nodes for memory lifetime (excludes is_fake WeakDeps)
     # and for ordering (includes all deps)
@@ -261,15 +263,15 @@ def assign_memory_planning_info_for_scheduler_buffers(
             dep_name_to_succ_nodes_for_ordering[mutating_buf_name]
         )
 
-    # populate the MemoryPlanningInfoForBuffer attribute to each scheduler buffer
-    # note: there are scheduler buffers not in dep_name_to_succ_nodes (e.g., graph outputs)
+    # Populate each scheduler buffer. Reuse the planning-info object because this
+    # function runs once per fusion round and buffer sizes do not change.
     for buf_name in name_to_buf:
-        name_to_buf[buf_name].mpi_buffer = MemoryPlanningInfoForBuffer(
-            size_alloc=sched_buf_to_size[buf_name][0],
-            size_free=sched_buf_to_size[buf_name][1],
-            succ_nodes=dep_name_to_succ_nodes[buf_name],
-            succ_nodes_for_ordering=dep_name_to_succ_nodes_for_ordering[buf_name],
-        )
+        mpi_buffer = name_to_buf[buf_name].mpi_buffer
+        mpi_buffer.size_alloc, mpi_buffer.size_free = sched_buf_to_size[buf_name]
+        mpi_buffer.succ_nodes = dep_name_to_succ_nodes[buf_name]
+        mpi_buffer.succ_nodes_for_ordering = dep_name_to_succ_nodes_for_ordering[
+            buf_name
+        ]
 
 
 def assign_memory_planning_info_for_scheduler_nodes(
@@ -510,6 +512,12 @@ def estimate_region_peak_memory(
     step_of: Callable[[BaseSchedulerNode], int],
     graph_outputs: OrderedSet[str],
     cur_memory: int = 0,
+    last_use_step_cache: dict[int, int | None] | None = None,
+    known_last_use_steps: dict[int, int | None] | None = None,
+    node_outputs: dict[BaseSchedulerNode, Sequence[SchedulerBuffer]] | None = None,
+    node_steps: dict[BaseSchedulerNode, int] | None = None,
+    max_peak: int | None = None,
+    include_live_memory: bool = True,
 ) -> tuple[int, list[int], list[int]]:
     """Peak memory inside `[region_start, region_end]` for the
     hypothetical post-reorder schedule.
@@ -519,58 +527,74 @@ def estimate_region_peak_memory(
     sum of `size_free` over `pred_buffers` whose proposed last
     consumer is this node. Then accumulates per step starting from
     `cur_memory` (live bytes at the window boundary) and returns the peak
-    plus live-before/live-after vectors for the simulated region.
+    plus optional live-before/live-after vectors for the simulated region.
+    Candidate overrides in `last_use_step_cache` take precedence over
+    context-wide `known_last_use_steps`. If `max_peak` is exceeded, returns
+    immediately with empty live-memory vectors.
     """
     R = region_end - region_start + 1
     allocs = [0] * R
     frees = [0] * R
-    last_use_step_cache: dict[int, int | None] = {}
+    if last_use_step_cache is None:
+        last_use_step_cache = {}
 
     def last_use_step(buffer) -> int | None:
         key = id(buffer)
         if key not in last_use_step_cache:
-            last_step = None
-            for n in buffer.succ_nodes:
-                step = step_of(n)
-                if last_step is None or step > last_step:
-                    last_step = step
-            last_use_step_cache[key] = last_step
+            if known_last_use_steps is not None and key in known_last_use_steps:
+                last_use_step_cache[key] = known_last_use_steps[key]
+            else:
+                last_step = None
+                for n in buffer.succ_nodes:
+                    step = step_of(n)
+                    if last_step is None or step > last_step:
+                        last_step = step
+                last_use_step_cache[key] = last_step
         return last_use_step_cache[key]
 
     for node in nodes_in_window:
-        s = step_of(node)
-        slot = s - region_start
+        step = node_steps[node] if node_steps is not None else step_of(node)
+        slot = step - region_start
         if not (0 <= slot < R):
             raise AssertionError(f"expected 0 <= slot < {R}, got {slot}")
 
-        for buf in node.get_outputs():
+        outputs = node_outputs[node] if node_outputs is not None else node.get_outputs()
+        for buf in outputs:
             bi = buf.mpi_buffer
             allocs[slot] += bi.size_alloc
-            name = buf.get_name()
-            if name in graph_outputs:
-                continue
-            if last_use_step(bi) is None:
+            if buf.get_name() not in graph_outputs and last_use_step(bi) is None:
                 frees[slot] += bi.size_free
 
-        for pb in node.mpi_node.pred_buffers:
-            name = pb.get_name()
-            if name in graph_outputs:
+        for pred_buf in node.mpi_node.pred_buffers:
+            if pred_buf.get_name() in graph_outputs:
                 continue
-            last_step = last_use_step(pb.mpi_buffer)
+            last_step = last_use_step(pred_buf.mpi_buffer)
             if last_step is None:
                 raise AssertionError("expected non-empty succ_steps")
-            if last_step == s:
-                frees[slot] += pb.mpi_buffer.size_free
+            if last_step == step:
+                frees[slot] += pred_buf.mpi_buffer.size_free
 
     cur = cur_memory
     peak = cur
+    if max_peak is not None and peak > max_peak:
+        return peak, [], []
+    for i in range(R):
+        cur += allocs[i]
+        if cur > peak:
+            peak = cur
+        if max_peak is not None and peak > max_peak:
+            return peak, [], []
+        cur -= frees[i]
+
+    if not include_live_memory:
+        return peak, [], []
+
+    cur = cur_memory
     region_live_before = [0] * (R + 1)
     region_live_after = [0] * R
     for i in range(R):
         region_live_before[i] = cur
         cur += allocs[i]
-        if cur > peak:
-            peak = cur
         # Match peak_memory_from_buf_info_list: frees apply at the next step.
         region_live_after[i] = cur
         cur -= frees[i]

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from torch._inductor.codegen.wrapper import EnterCudaStreamContextLine
 
     from .codegen.wrapper import PythonWrapperCodegen
+    from .memory import FreeableInputBuffer
     from .tiling_utils import CoalesceVarAnalysis
 
 import sympy
@@ -179,6 +180,8 @@ class FusionMemoryUpdate:
     local_nodes: list[BaseSchedulerNode]
     live_before: list[int]
     live_after: list[int]
+    last_use_steps: dict[int, int | None]
+    candidate_outputs: Sequence[SchedulerBuffer]
 
 
 @dataclasses.dataclass(slots=True)
@@ -206,11 +209,16 @@ class ComboKernelMemoryContext:
 @dataclasses.dataclass(slots=True)
 class FusionMemoryContext:
     nodes: list[BaseSchedulerNode | None]
+    tracked_nodes: OrderedSet[BaseSchedulerNode]
     graph_outputs: OrderedSet[str]
     node_to_idx: dict[BaseSchedulerNode, int]
     baseline_peak: int
     baseline_live_before: list[int]
     baseline_live_after: list[int]
+    last_use_steps: dict[int, int | None] = dataclasses.field(default_factory=dict)
+    node_outputs: dict[BaseSchedulerNode, Sequence[SchedulerBuffer]] = (
+        dataclasses.field(default_factory=dict)
+    )
     peak_start: int | None = None
     peak_end: int | None = None
     version: int = 0
@@ -248,6 +256,10 @@ class FusionMemoryContext:
 
         self.baseline_live_after[start:end] = update.live_after
         self.baseline_live_before[start : end + 1] = update.live_before
+        self.last_use_steps.update(update.last_use_steps)
+        self.node_outputs[fused_node] = update.candidate_outputs
+        self.tracked_nodes.difference_update((update.node1, update.node2))
+        self.tracked_nodes.add(fused_node)
         self.refresh_peak_range()
 
         for idx, node in enumerate(region_nodes, start):
@@ -4226,6 +4238,7 @@ class Scheduler:
         self.post_grad_graph_id = next(_post_grad_graph_counter)
         self._graph_partition_counter = itertools.count()
         self._fusion_memory_context: FusionMemoryContext | None = None
+        self._fusion_memory_buffer_sizes: dict[str, tuple[int, int]] | None = None
 
         self.completed_operations: OrderedSet[str] = OrderedSet()
         self.available_buffer_names = OrderedSet(
@@ -4969,7 +4982,6 @@ class Scheduler:
         from .memory import (
             assign_memory_planning_info_for_scheduler_buffers,
             compute_memory_timeline,
-            FreeableInputBuffer,
             get_freeable_input_buf,
         )
 
@@ -5117,23 +5129,6 @@ class Scheduler:
         for node in nodes:
             visit(node)
         return result
-
-    def topological_sort_schedule_after_fusion_if_needed(
-        self, nodes: list[BaseSchedulerNode], candidate: BaseSchedulerNode
-    ) -> list[BaseSchedulerNode]:
-        """
-        Avoid the full DFS topo sort when moving only the fused candidate kept
-        the local order valid.
-        """
-        candidate_idx = nodes.index(candidate)
-        deps = OrderedSet(dep.name for dep in candidate.unmet_dependencies)
-        if not deps:
-            return nodes
-        for node in nodes[candidate_idx + 1 :]:
-            for name in node.get_buffer_names():
-                if name in deps:
-                    return self.topological_sort_schedule(nodes)
-        return nodes
 
     def _enforce_conditional_ordering(self) -> None:
         conditional_nodes = [
@@ -6190,9 +6185,10 @@ class Scheduler:
             and not self.will_fusion_create_cycle(node1, node2)
             and speedup_fn()
         ):
-            return self._fuse_two_nodes_memory_checked(
-                node1, node2, fused_nodes
-            ) is not None
+            return (
+                self._fuse_two_nodes_memory_checked(node1, node2, fused_nodes)
+                is not None
+            )
 
         return False
 
@@ -6317,9 +6313,12 @@ class Scheduler:
                 if not is_speedup() or self.will_fusion_create_cycle(node1, node2):
                     continue
 
-                if self._fuse_two_nodes_memory_checked(
-                    node_key1, node_key2, fused_nodes
-                ) is None:
+                if (
+                    self._fuse_two_nodes_memory_checked(
+                        node_key1, node_key2, fused_nodes
+                    )
+                    is None
+                ):
                     continue
 
         for node1, node2 in possible_fusion_pairs:
@@ -6776,6 +6775,7 @@ class Scheduler:
             step_of=step_of,
             graph_outputs=mem_ctx.graph_outputs,
             cur_memory=cur_memory,
+            include_live_memory=False,
         )
 
         # Compare against the *original* baseline peak (not the running
@@ -7024,6 +7024,7 @@ class Scheduler:
             assign_memory_planning_info_for_scheduler_buffers,
             assign_memory_planning_info_for_scheduler_nodes,
             compute_memory_timeline,
+            compute_size_for_scheduler_buffer,
             get_freeable_input_buf,
             live_memory_before_steps_from_buf_info_list,
             peak_memory_from_buf_info_list,
@@ -7032,7 +7033,13 @@ class Scheduler:
         graph_inputs = OrderedSet(V.graph.graph_inputs.keys())
         graph_outputs = OrderedSet(V.graph.get_output_names())
         name_to_freeable = get_freeable_input_buf(nodes, graph_inputs)
-        assign_memory_planning_info_for_scheduler_buffers(nodes, self.name_to_buf)
+        if self._fusion_memory_buffer_sizes is None:
+            self._fusion_memory_buffer_sizes = compute_size_for_scheduler_buffer(
+                self.name_to_buf
+            )
+        assign_memory_planning_info_for_scheduler_buffers(
+            nodes, self.name_to_buf, self._fusion_memory_buffer_sizes
+        )
         assign_memory_planning_info_for_scheduler_nodes(
             nodes, self.name_to_fused_node, self.name_to_buf, name_to_freeable
         )
@@ -7045,6 +7052,14 @@ class Scheduler:
         baseline_live_before = live_memory_before_steps_from_buf_info_list(
             buf_info_list, len(nodes)
         )
+        last_use_steps = {
+            id(buf_info.buffer.mpi_buffer): (
+                buf_info.end_step if buf_info.buffer.mpi_buffer.succ_nodes else None
+            )
+            for buf_info in buf_info_list
+            if buf_info.buffer.get_name() not in graph_outputs
+        }
+        node_outputs = {node: node.get_outputs() for node in nodes}
 
         node_to_idx: dict[BaseSchedulerNode, int] = {}
         for idx, node in enumerate(nodes):
@@ -7054,11 +7069,14 @@ class Scheduler:
 
         ctx = FusionMemoryContext(
             nodes=list(nodes),
+            tracked_nodes=OrderedSet(nodes),
             graph_outputs=graph_outputs,
             node_to_idx=node_to_idx,
             baseline_peak=baseline_peak,
             baseline_live_before=baseline_live_before,
             baseline_live_after=baseline_live_after,
+            last_use_steps=last_use_steps,
+            node_outputs=node_outputs,
         )
         ctx.refresh_peak_range()
         return ctx
@@ -7082,7 +7100,9 @@ class Scheduler:
         return min(steps) if steps else None
 
     @staticmethod
-    def _fusion_pred_buffers(node: BaseSchedulerNode) -> OrderedSet[SchedulerBuffer]:
+    def _fusion_pred_buffers(
+        node: BaseSchedulerNode,
+    ) -> OrderedSet[SchedulerBuffer | FreeableInputBuffer]:
         if hasattr(node, "mpi_node"):
             return node.mpi_node.pred_buffers
         pred_buffers = OrderedSet()
@@ -7090,18 +7110,84 @@ class Scheduler:
             pred_buffers.update(snode.mpi_node.pred_buffers)
         return pred_buffers
 
+    def _assign_fusion_memory_planning_info(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        candidate: BaseSchedulerNode,
+    ) -> Sequence[SchedulerBuffer]:
+        candidate_buffers = candidate.get_buffer_names()
+        candidate_outputs = candidate.get_outputs()
+        input_buffers = OrderedSet()
+        for node in (node1, node2):
+            input_buffers.update(self._fusion_pred_buffers(node))
+        candidate.mpi_node = MemoryPlanningInfoForNode(
+            size=sum(buf.mpi_buffer.size_alloc for buf in candidate_outputs),
+            pred_buffers=OrderedSet(
+                buf for buf in input_buffers if buf.get_name() not in candidate_buffers
+            ),
+        )
+        return candidate_outputs
+
     def _check_fusion_memory(
         self,
         ctx: FusionMemoryContext | None,
         node1: BaseSchedulerNode,
         node2: BaseSchedulerNode,
     ) -> tuple[bool, FusionMemoryUpdate | None]:
-        peak_allowed_increase = self.fusion_memory_timeline_peak_allowed_increase_bytes()
+        peak_allowed_increase = (
+            self.fusion_memory_timeline_peak_allowed_increase_bytes()
+        )
         if ctx is None or peak_allowed_increase is None:
             return False, None
         return self._fusion_memory_update_cached(
-            ctx, node1, node2, peak_allowed_increase
+            ctx,
+            node1,
+            node2,
+            peak_allowed_increase,
         )
+
+    def _fusion_dep_producer(self, dep: Dep) -> BaseSchedulerNode | None:
+        buf = self.name_to_buf.get(dep.name)
+        return (
+            self.name_to_fused_node.get(buf.defining_op_name())
+            if buf is not None
+            else None
+        )
+
+    @staticmethod
+    def _fusion_has_peak_spanning_output(
+        ctx: FusionMemoryContext,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        region_start: int,
+        peak_allowed_increase: int,
+    ) -> bool:
+        peak_start = ctx.peak_start
+        peak_end = ctx.peak_end
+        if peak_start is None or peak_end is None:
+            return False
+
+        has_pre_peak_output = False
+        has_large_peak_spanning_output = False
+        min_size = max(peak_allowed_increase, 16 * 1024 * 1024)
+        for node in (node1, node2):
+            for buf in ctx.node_outputs[node]:
+                if buf.get_name() in ctx.graph_outputs:
+                    continue
+                end_step = ctx.last_use_steps[id(buf.mpi_buffer)]
+                if end_step is None:
+                    continue
+                if end_step < peak_start:
+                    has_pre_peak_output = True
+                if (
+                    max(buf.mpi_buffer.size_alloc, buf.mpi_buffer.size_free) > min_size
+                    and region_start <= peak_end
+                    and end_step >= peak_start
+                ):
+                    has_large_peak_spanning_output = True
+
+        return has_pre_peak_output and has_large_peak_spanning_output
 
     def _fusion_memory_update_cached(
         self,
@@ -7110,24 +7196,21 @@ class Scheduler:
         node2: BaseSchedulerNode,
         peak_allowed_increase: int,
     ) -> tuple[bool, FusionMemoryUpdate | None]:
-        key = (ctx.version, id(node1), id(node2))
-        if key not in ctx.decision_cache:
-            ctx.decision_cache[key] = self._fusion_memory_update(
+        cache_key = (ctx.version, id(node1), id(node2))
+        if cache_key not in ctx.decision_cache:
+            ctx.decision_cache[cache_key] = self._fusion_memory_update(
                 ctx, node1, node2, peak_allowed_increase
             )
-        return ctx.decision_cache[key]
+        return ctx.decision_cache[cache_key]
 
     def _fusion_memory_update(
         self,
-        ctx: FusionMemoryContext | None,
+        ctx: FusionMemoryContext,
         node1: BaseSchedulerNode,
         node2: BaseSchedulerNode,
         peak_allowed_increase: int,
     ) -> tuple[bool, FusionMemoryUpdate | None]:
         from .memory import estimate_region_peak_memory
-
-        if ctx is None:
-            return False, None
 
         step1 = self._fusion_node_step(ctx, node1)
         step2 = self._fusion_node_step(ctx, node2)
@@ -7136,50 +7219,56 @@ class Scheduler:
 
         region_start = min(step1, step2)
         region_end = max(step1, step2)
-        peak_start = ctx.peak_start
-        peak_end = ctx.peak_end
 
         candidate = self.get_backend(node1.get_device()).fuse(node1, node2)
-        candidate_buffers = candidate.get_buffer_names()
-        pred_buffers = OrderedSet()
-        for node in (node1, node2):
-            pred_buffers.update(
-                buf
-                for buf in self._fusion_pred_buffers(node)
-                if buf.get_name() not in candidate_buffers
-            )
-        candidate.mpi_node = MemoryPlanningInfoForNode(
-            size=sum(buf.mpi_buffer.size_alloc for buf in candidate.get_outputs()),
-            pred_buffers=pred_buffers,
+        candidate_outputs = self._assign_fusion_memory_planning_info(
+            node1, node2, candidate
         )
 
-        local_entries: list[_LocalEntry] = []
-        inserted_candidate = False
-        originals = OrderedSet((node1, node2))
+        local_nodes: list[BaseSchedulerNode] = [candidate]
         for idx in range(region_start, region_end + 1):
             node = ctx.nodes[idx]
-            if node is None:
+            if node is None or node is node1 or node is node2:
                 continue
-            if node in originals:
-                if not inserted_candidate:
-                    local_entries.append(_LocalEntry(region_start, idx, candidate))
-                    inserted_candidate = True
+            local_nodes.append(node)
+
+        for dep in candidate.unmet_dependencies:
+            producer = self._fusion_dep_producer(dep)
+            if producer is None or producer is node1 or producer is node2:
                 continue
-            local_entries.append(_LocalEntry(idx, idx, node))
+            producer_step = ctx.node_to_idx.get(producer)
+            if (
+                producer_step is not None
+                and region_start <= producer_step <= region_end
+            ):
+                local_set = OrderedSet(local_nodes)
+                seen: OrderedSet[BaseSchedulerNode] = OrderedSet()
+                ordered_nodes: list[BaseSchedulerNode] = []
 
-        local_nodes = [
-            e.node for e in sorted(local_entries, key=lambda e: (e.cur, e.baseline))
-        ]
-        local_nodes = self.topological_sort_schedule_after_fusion_if_needed(
-            local_nodes, candidate
-        )
+                def visit(node: BaseSchedulerNode) -> None:
+                    if node in seen:
+                        return
+                    seen.add(node)
+                    for node_dep in sorted(
+                        node.unmet_dependencies, key=lambda d: d.name
+                    ):
+                        dep_producer = self._fusion_dep_producer(node_dep)
+                        if dep_producer is not None and dep_producer in local_set:
+                            visit(dep_producer)
+                    ordered_nodes.append(node)
 
+                visit(candidate)
+                ordered_nodes.extend(node for node in local_nodes if node not in seen)
+                local_nodes = ordered_nodes
+                break
         new_step = {node: region_start + idx for idx, node in enumerate(local_nodes)}
         candidate_step = new_step[candidate]
+        for node in local_nodes:
+            step = new_step[node]
+            for snode in node.get_nodes():
+                new_step[snode] = step
         for node in (node1, node2):
             new_step[node] = candidate_step
-            for snode in node.get_nodes():
-                new_step[snode] = candidate_step
 
         node_to_idx = ctx.node_to_idx
         step_cache = {}
@@ -7195,14 +7284,44 @@ class Scheduler:
                     step_cache[node] = min(steps) if steps else node_to_idx[node]
             return step_cache[node]
 
-        region_peak, live_before, live_after = estimate_region_peak_memory(
-            local_nodes,
-            region_start=region_start,
-            region_end=region_end,
-            step_of=step_of,
-            graph_outputs=ctx.graph_outputs,
-            cur_memory=ctx.baseline_live_before[region_start],
-        )
+        candidate_last_use_steps: dict[int, int | None] = {}
+        affected_buffers = OrderedSet()
+        for node, step in new_step.items():
+            if node_to_idx.get(node) != step:
+                affected_buffers.update(node.mpi_node.pred_buffers)
+        for buf in affected_buffers:
+            last_step = None
+            for succ in buf.mpi_buffer.succ_nodes:
+                step = step_of(succ)
+                if last_step is None or step > last_step:
+                    last_step = step
+            candidate_last_use_steps[id(buf.mpi_buffer)] = last_step
+
+        ctx.node_outputs[candidate] = candidate_outputs
+        try:
+            region_peak, live_before, live_after = estimate_region_peak_memory(
+                local_nodes,
+                region_start=region_start,
+                region_end=region_end,
+                step_of=step_of,
+                graph_outputs=ctx.graph_outputs,
+                cur_memory=ctx.baseline_live_before[region_start],
+                last_use_step_cache=candidate_last_use_steps,
+                known_last_use_steps=ctx.last_use_steps,
+                node_outputs=ctx.node_outputs,
+                node_steps=new_step,
+                max_peak=ctx.baseline_peak + peak_allowed_increase,
+            )
+        finally:
+            del ctx.node_outputs[candidate]
+        if not live_after:
+            fusion_log.debug(
+                "memory-timeline fusion rejected %s with %s: estimated peak delta %d bytes",
+                node1.get_name(),
+                node2.get_name(),
+                region_peak - ctx.baseline_peak,
+            )
+            return True, None
         update = FusionMemoryUpdate(
             node1=node1,
             node2=node2,
@@ -7213,51 +7332,18 @@ class Scheduler:
             local_nodes=local_nodes,
             live_before=live_before,
             live_after=live_after,
+            last_use_steps=candidate_last_use_steps,
+            candidate_outputs=candidate_outputs,
         )
-
-        peak_delta = region_peak - ctx.baseline_peak
-        if peak_delta > peak_allowed_increase:
-            fusion_log.debug(
-                "memory-timeline fusion rejected %s with %s: estimated peak delta %d bytes",
-                node1.get_name(),
-                node2.get_name(),
-                peak_delta,
-            )
-            return True, None
 
         # A fusion can make one large output live through peak while another dies early.
         if (node1.get_operation_names() & node2.ancestors) or (
             node2.get_operation_names() & node1.ancestors
         ):
             return False, update
-        if peak_start is None or peak_end is None:
-            return False, update
-
-        has_pre_peak_output = False
-        has_large_peak_spanning_output = False
-        min_size = max(peak_allowed_increase, 16 * 1024 * 1024)
-        for node in (node1, node2):
-            for buf in node.get_outputs():
-                if buf.get_name() in ctx.graph_outputs:
-                    continue
-                succ_steps = [
-                    step
-                    for succ in buf.mpi_buffer.succ_nodes
-                    if (step := self._fusion_node_step(ctx, succ)) is not None
-                ]
-                if not succ_steps:
-                    continue
-                end_step = max(succ_steps)
-                if end_step < peak_start:
-                    has_pre_peak_output = True
-                if (
-                    max(buf.mpi_buffer.size_alloc, buf.mpi_buffer.size_free) > min_size
-                    and region_start <= peak_end
-                    and end_step >= peak_start
-                ):
-                    has_large_peak_spanning_output = True
-
-        if has_pre_peak_output and has_large_peak_spanning_output:
+        if self._fusion_has_peak_spanning_output(
+            ctx, node1, node2, region_start, peak_allowed_increase
+        ):
             fusion_log.debug(
                 "memory-timeline fusion rejected %s with %s: large output would "
                 "span baseline peak while another output dies before it",

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -169,6 +169,19 @@ class _LocalEntry(NamedTuple):
 
 
 @dataclasses.dataclass(slots=True)
+class FusionMemoryUpdate:
+    node1: BaseSchedulerNode
+    node2: BaseSchedulerNode
+    candidate: BaseSchedulerNode
+    candidate_step: int
+    region_start: int
+    region_end: int
+    local_nodes: list[BaseSchedulerNode]
+    live_before: list[int]
+    live_after: list[int]
+
+
+@dataclasses.dataclass(slots=True)
 class ComboKernelMemoryContext:
     """Shared state used by the memory-aware combo gate.
 
@@ -192,13 +205,65 @@ class ComboKernelMemoryContext:
 
 @dataclasses.dataclass(slots=True)
 class FusionMemoryContext:
-    nodes: list[BaseSchedulerNode]
-    node_set: OrderedSet[BaseSchedulerNode]
+    nodes: list[BaseSchedulerNode | None]
     graph_outputs: OrderedSet[str]
     node_to_idx: dict[BaseSchedulerNode, int]
     baseline_peak: int
     baseline_live_before: list[int]
     baseline_live_after: list[int]
+    peak_start: int | None = None
+    peak_end: int | None = None
+    version: int = 0
+    decision_cache: dict[
+        tuple[int, int, int], tuple[bool, FusionMemoryUpdate | None]
+    ] = dataclasses.field(default_factory=dict)
+
+    def refresh_peak_range(self) -> None:
+        self.baseline_peak = max(self.baseline_live_after)
+        self.peak_start = None
+        self.peak_end = None
+        for i, live in enumerate(self.baseline_live_after):
+            if live >= self.baseline_peak:
+                if self.peak_start is None:
+                    self.peak_start = i
+                self.peak_end = i
+
+    def apply_accepted_fusion(
+        self, update: FusionMemoryUpdate, fused_node: BaseSchedulerNode
+    ) -> None:
+        start = update.region_start
+        end = update.region_end + 1
+        if len(update.live_after) != end - start:
+            raise AssertionError("unexpected live-after region length")
+        if len(update.live_before) != end - start + 1:
+            raise AssertionError("unexpected live-before region length")
+
+        fused_node.mpi_node = update.candidate.mpi_node
+        region_nodes: list[BaseSchedulerNode | None] = [None] * (end - start)
+        for idx, node in enumerate(update.local_nodes):
+            if idx >= len(region_nodes):
+                raise AssertionError("too many nodes in fused memory region")
+            region_nodes[idx] = fused_node if node is update.candidate else node
+        self.nodes[start:end] = region_nodes
+
+        self.baseline_live_after[start:end] = update.live_after
+        self.baseline_live_before[start : end + 1] = update.live_before
+        self.refresh_peak_range()
+
+        for idx, node in enumerate(region_nodes, start):
+            if node is None:
+                continue
+            self.node_to_idx[node] = idx
+            for snode in node.get_nodes():
+                self.node_to_idx[snode] = idx
+
+        self.node_to_idx[fused_node] = update.candidate_step
+        for node in (update.node1, update.node2):
+            self.node_to_idx[node] = update.candidate_step
+            for snode in node.get_nodes():
+                self.node_to_idx[snode] = update.candidate_step
+        self.version += 1
+        self.decision_cache.clear()
 
 
 def _is_gpu_triton_backend(
@@ -4160,6 +4225,7 @@ class Scheduler:
         self.backends: dict[torch.device, BaseScheduling] = {}
         self.post_grad_graph_id = next(_post_grad_graph_counter)
         self._graph_partition_counter = itertools.count()
+        self._fusion_memory_context: FusionMemoryContext | None = None
 
         self.completed_operations: OrderedSet[str] = OrderedSet()
         self.available_buffer_names = OrderedSet(
@@ -5051,6 +5117,23 @@ class Scheduler:
         for node in nodes:
             visit(node)
         return result
+
+    def topological_sort_schedule_after_fusion_if_needed(
+        self, nodes: list[BaseSchedulerNode], candidate: BaseSchedulerNode
+    ) -> list[BaseSchedulerNode]:
+        """
+        Avoid the full DFS topo sort when moving only the fused candidate kept
+        the local order valid.
+        """
+        candidate_idx = nodes.index(candidate)
+        deps = OrderedSet(dep.name for dep in candidate.unmet_dependencies)
+        if not deps:
+            return nodes
+        for node in nodes[candidate_idx + 1 :]:
+            for name in node.get_buffer_names():
+                if name in deps:
+                    return self.topological_sort_schedule(nodes)
+        return nodes
 
     def _enforce_conditional_ordering(self) -> None:
         conditional_nodes = [
@@ -6052,6 +6135,7 @@ class Scheduler:
         node1: BaseSchedulerNode,
         node2: BaseSchedulerNode,
         fused_nodes: OrderedSet[BaseSchedulerNode],
+        node3: BaseSchedulerNode | None = None,
     ) -> BaseSchedulerNode:
         fusion_log.debug("fusing %s with %s", node1.get_name(), node2.get_name())
 
@@ -6060,7 +6144,8 @@ class Scheduler:
             raise AssertionError(
                 f"expected node2 device to be {device}, got {node2.get_device()}"
             )
-        node3 = self.get_backend(device).fuse(node1, node2)
+        if node3 is None:
+            node3 = self.get_backend(device).fuse(node1, node2)
         fused_nodes.remove(node1)
         fused_nodes.remove(node2)
         fused_nodes.add(node3)
@@ -6070,6 +6155,27 @@ class Scheduler:
         # fusion rounds still respect stream boundaries.
         self.node_to_stream[node3] = self.get_node_stream(node1)
 
+        return node3
+
+    def _fuse_two_nodes_memory_checked(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        fused_nodes: OrderedSet[BaseSchedulerNode],
+    ) -> BaseSchedulerNode | None:
+        ctx = self._fusion_memory_context
+        rejected, memory_update = self._check_fusion_memory(ctx, node1, node2)
+        if rejected:
+            return None
+
+        node3 = self.fuse_two_nodes(
+            node1,
+            node2,
+            fused_nodes,
+            memory_update.candidate if memory_update is not None else None,
+        )
+        if ctx is not None and memory_update is not None:
+            ctx.apply_accepted_fusion(memory_update, node3)
         return node3
 
     def fuse_if_speedup(
@@ -6084,8 +6190,9 @@ class Scheduler:
             and not self.will_fusion_create_cycle(node1, node2)
             and speedup_fn()
         ):
-            self.fuse_two_nodes(node1, node2, fused_nodes)
-            return True
+            return self._fuse_two_nodes_memory_checked(
+                node1, node2, fused_nodes
+            ) is not None
 
         return False
 
@@ -6152,7 +6259,10 @@ class Scheduler:
                 else:
                     # Non AsyncCompile path, perform fusion
                     if self.fuse_if_speedup(
-                        node1, node2, pending_fusion.callable_fn, fused_nodes
+                        node1,
+                        node2,
+                        pending_fusion.callable_fn,
+                        fused_nodes,
                     ):
                         fusions_to_remove.add(candidate)
 
@@ -6177,7 +6287,6 @@ class Scheduler:
         template_fusion_nodes: dict[BaseSchedulerNode, list[PendingFusion]],
         fused_nodes: OrderedSet[BaseSchedulerNode],
         is_reorder_round: bool,
-        fusion_memory_context: FusionMemoryContext | None,
     ):
         def resolve_pending_fusions(
             node1: BaseSchedulerNode,
@@ -6208,7 +6317,10 @@ class Scheduler:
                 if not is_speedup() or self.will_fusion_create_cycle(node1, node2):
                     continue
 
-                self.fuse_two_nodes(node_key1, node_key2, fused_nodes)
+                if self._fuse_two_nodes_memory_checked(
+                    node_key1, node_key2, fused_nodes
+                ) is None:
+                    continue
 
         for node1, node2 in possible_fusion_pairs:
             # if either node is in a pending fusion, resolve it.
@@ -6227,18 +6339,10 @@ class Scheduler:
             if self.can_fuse(
                 node1, node2, is_reorder_round
             ) and not self.will_fusion_create_cycle(node1, node2):
-                peak_allowed_increase = (
-                    self.fusion_memory_timeline_peak_allowed_increase_bytes()
+                rejected, _ = self._check_fusion_memory(
+                    self._fusion_memory_context, node1, node2
                 )
-                if (
-                    peak_allowed_increase is not None
-                    and self.fusion_regresses_estimated_peak_memory(
-                        fusion_memory_context,
-                        node1,
-                        node2,
-                        peak_allowed_increase,
-                    )
-                ):
+                if rejected:
                     continue
                 fusion_res = self.speedup_by_fusion(node1, node2)
                 if fusion_res.callable_fn is not None:
@@ -6269,7 +6373,7 @@ class Scheduler:
                 if not fusion_res.should_fuse:
                     continue
 
-                self.fuse_two_nodes(node1, node2, fused_nodes)
+                self._fuse_two_nodes_memory_checked(node1, node2, fused_nodes)
 
     def _finish_pending_fusions(
         self,
@@ -6295,7 +6399,12 @@ class Scheduler:
             if self.get_fused_node(node_key2) is not node_key2:
                 raise AssertionError("expected node_key2 to be its own fused node")
 
-            self.fuse_if_speedup(node_key1, node_key2, is_speedup_fn, fused_nodes)
+            self.fuse_if_speedup(
+                node_key1,
+                node_key2,
+                is_speedup_fn,
+                fused_nodes,
+            )
 
     def _handle_template_overlap(
         self,
@@ -6353,11 +6462,11 @@ class Scheduler:
         fusion_memory_context = None
         if self.fusion_memory_timeline_peak_allowed_increase_bytes() is not None:
             fusion_memory_context = self._init_fusion_memory_context(nodes)
+        self._fusion_memory_context = fusion_memory_context
 
         possible_fusions = self.get_possible_fusions(
             nodes,
             is_reorder_round,
-            fusion_memory_context,
         )
 
         if config.max_autotune_gemm or config.max_autotune:
@@ -6371,7 +6480,6 @@ class Scheduler:
             template_fusion_nodes,
             fused_nodes,
             is_reorder_round,
-            fusion_memory_context,
         )
         self._finish_pending_fusions(fused_nodes, pending_fusions)
 
@@ -6385,12 +6493,12 @@ class Scheduler:
                 template_fusion_nodes,
                 fused_nodes,
                 is_reorder_round,
-                fusion_memory_context,
             )
             self._evaluate_pending_template_fusions(template_fusion_nodes, fused_nodes)
 
         nodes = sorted(fused_nodes, key=lambda x: x.min_order)
         nodes = self.topological_sort_schedule(nodes)
+        self._fusion_memory_context = None
         return nodes
 
     @staticmethod
@@ -6661,7 +6769,7 @@ class Scheduler:
         # therefore the original-schedule live memory before this region starts.
         cur_memory = mem_ctx.baseline_live_before[region_start]
 
-        region_peak = estimate_region_peak_memory(
+        region_peak, _, _ = estimate_region_peak_memory(
             local_nodes,
             region_start=region_start,
             region_end=region_end,
@@ -6754,7 +6862,6 @@ class Scheduler:
         self,
         nodes: list[BaseSchedulerNode],
         is_reorder_round: bool,
-        fusion_memory_context: FusionMemoryContext | None = None,
     ) -> list[tuple[BaseSchedulerNode, BaseSchedulerNode]]:
         """
         Helper to find all legal fusion opportunities, sorted by self.score_fusion()
@@ -6801,7 +6908,7 @@ class Scheduler:
                 check_all_pairs(node_grouping)
 
         possible_fusions = self.get_possible_fusions_with_highest_priority(
-            possible_fusions, fusion_memory_context
+            possible_fusions
         )
         possible_fusions.sort(key=self.score_fusion_key, reverse=True)
         fusion_log.debug("found %d possible fusions", len(possible_fusions))
@@ -6946,14 +7053,14 @@ class Scheduler:
                 node_to_idx[snode] = idx
 
         ctx = FusionMemoryContext(
-            nodes=nodes,
-            node_set=OrderedSet(nodes),
+            nodes=list(nodes),
             graph_outputs=graph_outputs,
             node_to_idx=node_to_idx,
             baseline_peak=baseline_peak,
             baseline_live_before=baseline_live_before,
             baseline_live_after=baseline_live_after,
         )
+        ctx.refresh_peak_range()
         return ctx
 
     @staticmethod
@@ -6974,35 +7081,63 @@ class Scheduler:
         steps = [ctx.node_to_idx[n] for n in node.get_nodes() if n in ctx.node_to_idx]
         return min(steps) if steps else None
 
-    def fusion_regresses_estimated_peak_memory(
+    @staticmethod
+    def _fusion_pred_buffers(node: BaseSchedulerNode) -> OrderedSet[SchedulerBuffer]:
+        if hasattr(node, "mpi_node"):
+            return node.mpi_node.pred_buffers
+        pred_buffers = OrderedSet()
+        for snode in node.get_nodes():
+            pred_buffers.update(snode.mpi_node.pred_buffers)
+        return pred_buffers
+
+    def _check_fusion_memory(
+        self,
+        ctx: FusionMemoryContext | None,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+    ) -> tuple[bool, FusionMemoryUpdate | None]:
+        peak_allowed_increase = self.fusion_memory_timeline_peak_allowed_increase_bytes()
+        if ctx is None or peak_allowed_increase is None:
+            return False, None
+        return self._fusion_memory_update_cached(
+            ctx, node1, node2, peak_allowed_increase
+        )
+
+    def _fusion_memory_update_cached(
+        self,
+        ctx: FusionMemoryContext,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        peak_allowed_increase: int,
+    ) -> tuple[bool, FusionMemoryUpdate | None]:
+        key = (ctx.version, id(node1), id(node2))
+        if key not in ctx.decision_cache:
+            ctx.decision_cache[key] = self._fusion_memory_update(
+                ctx, node1, node2, peak_allowed_increase
+            )
+        return ctx.decision_cache[key]
+
+    def _fusion_memory_update(
         self,
         ctx: FusionMemoryContext | None,
         node1: BaseSchedulerNode,
         node2: BaseSchedulerNode,
         peak_allowed_increase: int,
-    ) -> bool:
-        """Return true when fusing two nodes would raise the estimated memory peak."""
+    ) -> tuple[bool, FusionMemoryUpdate | None]:
         from .memory import estimate_region_peak_memory
 
         if ctx is None:
-            return False
+            return False, None
 
         step1 = self._fusion_node_step(ctx, node1)
         step2 = self._fusion_node_step(ctx, node2)
         if step1 is None or step2 is None:
-            return False
-        if node1 not in ctx.node_set or node2 not in ctx.node_set:
-            return False
+            return False, None
 
         region_start = min(step1, step2)
         region_end = max(step1, step2)
-        peak_steps = [
-            i
-            for i, live in enumerate(ctx.baseline_live_after)
-            if live >= ctx.baseline_peak
-        ]
-        peak_start = min(peak_steps) if peak_steps else None
-        peak_end = max(peak_steps) if peak_steps else None
+        peak_start = ctx.peak_start
+        peak_end = ctx.peak_end
 
         candidate = self.get_backend(node1.get_device()).fuse(node1, node2)
         candidate_buffers = candidate.get_buffer_names()
@@ -7010,7 +7145,7 @@ class Scheduler:
         for node in (node1, node2):
             pred_buffers.update(
                 buf
-                for buf in node.mpi_node.pred_buffers
+                for buf in self._fusion_pred_buffers(node)
                 if buf.get_name() not in candidate_buffers
             )
         candidate.mpi_node = MemoryPlanningInfoForNode(
@@ -7023,6 +7158,8 @@ class Scheduler:
         originals = OrderedSet((node1, node2))
         for idx in range(region_start, region_end + 1):
             node = ctx.nodes[idx]
+            if node is None:
+                continue
             if node in originals:
                 if not inserted_candidate:
                     local_entries.append(_LocalEntry(region_start, idx, candidate))
@@ -7033,7 +7170,9 @@ class Scheduler:
         local_nodes = [
             e.node for e in sorted(local_entries, key=lambda e: (e.cur, e.baseline))
         ]
-        local_nodes = self.topological_sort_schedule(local_nodes)
+        local_nodes = self.topological_sort_schedule_after_fusion_if_needed(
+            local_nodes, candidate
+        )
 
         new_step = {node: region_start + idx for idx, node in enumerate(local_nodes)}
         candidate_step = new_step[candidate]
@@ -7042,26 +7181,38 @@ class Scheduler:
             for snode in node.get_nodes():
                 new_step[snode] = candidate_step
 
+        node_to_idx = ctx.node_to_idx
         step_cache = {}
 
         def step_of(node: BaseSchedulerNode) -> int:
             if node not in step_cache:
                 if node in new_step:
                     step_cache[node] = new_step[node]
-                elif node in ctx.node_to_idx:
-                    step_cache[node] = ctx.node_to_idx[node]
+                elif node in node_to_idx:
+                    step_cache[node] = node_to_idx[node]
                 else:
                     steps = [new_step[n] for n in node.get_nodes() if n in new_step]
-                    step_cache[node] = min(steps) if steps else ctx.node_to_idx[node]
+                    step_cache[node] = min(steps) if steps else node_to_idx[node]
             return step_cache[node]
 
-        region_peak = estimate_region_peak_memory(
+        region_peak, live_before, live_after = estimate_region_peak_memory(
             local_nodes,
             region_start=region_start,
             region_end=region_end,
             step_of=step_of,
             graph_outputs=ctx.graph_outputs,
             cur_memory=ctx.baseline_live_before[region_start],
+        )
+        update = FusionMemoryUpdate(
+            node1=node1,
+            node2=node2,
+            candidate=candidate,
+            candidate_step=candidate_step,
+            region_start=region_start,
+            region_end=region_end,
+            local_nodes=local_nodes,
+            live_before=live_before,
+            live_after=live_after,
         )
 
         peak_delta = region_peak - ctx.baseline_peak
@@ -7072,15 +7223,15 @@ class Scheduler:
                 node2.get_name(),
                 peak_delta,
             )
-            return True
+            return True, None
 
         # A fusion can make one large output live through peak while another dies early.
         if (node1.get_operation_names() & node2.ancestors) or (
             node2.get_operation_names() & node1.ancestors
         ):
-            return False
+            return False, update
         if peak_start is None or peak_end is None:
-            return False
+            return False, update
 
         has_pre_peak_output = False
         has_large_peak_spanning_output = False
@@ -7113,9 +7264,23 @@ class Scheduler:
                 node1.get_name(),
                 node2.get_name(),
             )
-            return True
+            return True, None
 
-        return False
+        return False, update
+
+    def fusion_regresses_estimated_peak_memory(
+        self,
+        ctx: FusionMemoryContext | None,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        peak_allowed_increase: int,
+    ) -> bool:
+        if ctx is None:
+            return False
+        rejected, _ = self._fusion_memory_update_cached(
+            ctx, node1, node2, peak_allowed_increase
+        )
+        return rejected
 
     def fusion_prevent_too_many_reads_and_writes(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode, threshold: int
@@ -8982,7 +9147,6 @@ class Scheduler:
     def get_possible_fusions_with_highest_priority(
         self,
         possible_fusions: list[tuple[BaseSchedulerNode, BaseSchedulerNode]],
-        fusion_memory_context: FusionMemoryContext | None = None,
     ) -> list[tuple[BaseSchedulerNode, BaseSchedulerNode]]:
         # Group the possible fusions based on their priority from the backend.
         # Only return the group of possible fusions with highest priority.
@@ -9020,7 +9184,7 @@ class Scheduler:
                     (node1, node2)
                     for node1, node2 in possible_fusions_with_highest_priority
                     if not self.fusion_regresses_estimated_peak_memory(
-                        fusion_memory_context,
+                        self._fusion_memory_context,
                         node1,
                         node2,
                         peak_allowed_increase,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -7196,6 +7196,19 @@ class Scheduler:
         node2: BaseSchedulerNode,
         peak_allowed_increase: int,
     ) -> tuple[bool, FusionMemoryUpdate | None]:
+        if not config.fusion_memory_timeline_full_correctness:
+            if node1 not in ctx.tracked_nodes or node2 not in ctx.tracked_nodes:
+                return False, None
+            step1 = ctx.node_to_idx[node1]
+            step2 = ctx.node_to_idx[node2]
+            peak_start = ctx.peak_start
+            peak_end = ctx.peak_end
+            if peak_start is None or peak_end is None:
+                return False, None
+            region_start = min(step1, step2)
+            region_end = max(step1, step2)
+            if region_end < peak_start or region_start > peak_end:
+                return False, None
         cache_key = (ctx.version, id(node1), id(node2))
         if cache_key not in ctx.decision_cache:
             ctx.decision_cache[cache_key] = self._fusion_memory_update(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190777
* #190344
* #190342

Description:
Keep the fusion peak-memory guard's timeline exact after accepted fusions by
splicing the simulated local region timeline into the fusion memory context.
This avoids making later fusion decisions against a stale baseline while keeping
the public scheduler fusion flow mostly unchanged.

The guard is controlled by fusion_memory_timeline_peak_allowed_increase_mb.
None disables the guard and is the baseline below. 0 enables the guard. The
"no incremental" rows are from the previous guarded implementation; the
"incremental optimized" rows are this change with the cheaper local timeline
update path.

The update path is kept cheap by caching the current peak range, avoiding a full
local topo sort when the candidate order is already valid, reusing the fused
candidate built for memory simulation, and making region peak estimation use
plain alloc/free lists instead of per-slot objects.

| Config | Backend | Mode | First compiled | Step avg | Active peak | Reserved peak |
|---|---|---|---:|---:|---:|---:|
| d12 w3072 t256k | compile | None | 315s | 12148.9 ms | 59498.4 MiB | 64706 MiB |
| d12 w3072 t256k | compile | 0, no incremental | 329s (+4.44%) | 12196.4 ms (+0.39%) | 52425.4 MiB (-11.89%) | 60610 MiB (-6.33%) |
| d12 w3072 t256k | compile | 0, incremental before opt | 351s (+11.43%) | 12332.5 ms (+1.51%) | 52424.7 MiB (-11.89%) | 60608 MiB (-6.33%) |
| d12 w3072 t256k | compile | 0, incremental optimized | 340s (+7.94%) | 12207.6 ms (+0.48%) | 52424.7 MiB (-11.89%) | 60608 MiB (-6.33%) |
| d12 w3072 t256k | graph_trainer | None | 232s | 10889.8 ms | 64814.8 MiB | 72976 MiB |
| d12 w3072 t256k | graph_trainer | 0, no incremental | 241s (+3.88%) | 10999.9 ms (+1.01%) | 47907.3 MiB (-26.09%) | 55100 MiB (-24.50%) |
| d12 w3072 t256k | graph_trainer | 0, incremental before opt | 250s (+7.76%) | 11084.1 ms (+1.78%) | 47907.1 MiB (-26.09%) | 55950 MiB (-23.33%) |
| d12 w3072 t256k | graph_trainer | 0, incremental optimized | 249s (+7.33%) | 11108.4 ms (+2.01%) | 47907.1 MiB (-26.09%) | 55950 MiB (-23.33%) |

The measurements show the memory benefit comes from the guard itself. The
incremental update keeps decisions exact; the optimized update recovers most of
the avoidable compile-time overhead from the initial implementation.

Test Plan:
- git diff --check
- python -m py_compile torch/_inductor/scheduler.py torch/_inductor/memory.py test/inductor/test_combo_kernels.py
- python test/inductor/test_combo_kernels.py -k test_estimate_region_peak_memory
- python test/inductor/test_combo_kernels.py -k test_fusion_memory_update_splices_context

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo