### PR TITLE
[ROCm] [Inductor] Unskipped two tests in cuda_repro

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1838,7 +1838,6 @@ class CudaReproTests(TestCase):
                     atol=1e-3,
                 )
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/163765")
     @torch._inductor.config.patch(emulate_precision_casts=True)
     def test_emulate_precision_casts_mean_ratio_chain(self):
         torch.manual_seed(12345)
@@ -2825,7 +2824,6 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         self.assertEqual(result, a + b)
         self.assertIn("znumel", code)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/163701")
     @unittest.skipIf(config.is_fbcode(), "Dependence on functorch.einops")
     def test_repeated_masked_load(self):
         counters.clear()


### PR DESCRIPTION
Removes two stale `@skipIfRocm` decorators in `test/inductor/test_cuda_repro.py`. Neither test has been failing for months; both skips were mechanically re-inlined from the auto-disabler JSON by #185013 (2026-05-26), which landed well after the underlying failures were already fixed. The skips have been suppressing passing tests on ROCm ever since, and the closed state of the referenced issues is not itself a signal, since #185013 is what closed them.

`test_emulate_precision_casts_mean_ratio_chain` (#163765) was a numerics failure under `emulate_precision_casts` introduced by #163520. It was fixed by #164997, which replaced gelu with relu in the repro, and #169309, which raised the comparison tolerance to `rtol=5e-2 / atol=1e-1`. Both landed in 2025-12.

`test_repeated_masked_load` (#163701) was failing as an unexpected success rather than a real failure: the test carried an xfail that did not hold consistently on python 3.12, so ROCm runners reported XPASS depending on the runner's python version. #170656 removed the xfail and replaced it with a direct assertion that Dynamo records a single `unique_graphs`, so the outcome no longer depends on the python version.

The third ROCm skip in this file, `test_qwen2_7b_sdpa_input_alignment_requires_recompile` (#163689), is left in place deliberately. It still fails on ROCm and is not covered by either fix above.

## Test Plan

Both tests run in the `default` (not `inductor`) config, in shard 1 on each ROCm platform. Locally:

```
python test/inductor/test_cuda_repro.py CudaReproTests.test_emulate_precision_casts_mean_ratio_chain CudaReproTests.test_repeated_masked_load -v
```

To confirm the whole file is unaffected:

```
python test/inductor/test_cuda_repro.py -v
```

CI on this PR confirms both tests execute and pass, rather than merely not appearing in a failure list. Verified from the `test-reports` JUnit XML for run attempt 1, where each testcase has no `skipped` element and a non-zero runtime:

| Platform | Job | Shard |
| --- | --- | --- |
| MI200 gfx90a, jammy py3.10 | 88905833312 | default 1/10 |
| MI300 gfx942, noble py3.12 | 88921620900 | default 1/8 |
| MI350 gfx950, jammy py3.10 | 88905881977 | default 1/8 |

Each shard emitted exactly one `inductor.test_cuda_repro` report, so neither test was rescued by the retry-in-a-new-process path. Both python versions in the ROCm fleet are covered, which matters for #163701 specifically.

Note: this PR description was drafted by an AI assistant (Claude Code) and reviewed by @jeffdaily. The code change itself is @iupaikov-amd's work.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben
