### PR TITLE
Fix LoggingTensor test crash under INFO-level log capture

### DIFF
--- a/torch/testing/_internal/logging_tensor.py
+++ b/torch/testing/_internal/logging_tensor.py
@@ -13,6 +13,13 @@ import functools
 from torch._C._profiler import gather_traceback, symbolize_tracebacks
 
 logger = logging.getLogger("LoggingTensor")
+# The __torch_dispatch__ hooks below log with extra positional args that are only
+# meaningful to LoggingTensorHandler (which reads record.args directly). Those args
+# are not printf-style format arguments for the message, so if the record reaches a
+# generic Formatter (e.g. pytest's log capture on the root logger) it raises
+# "TypeError: not all arguments converted during string formatting". Keep these
+# records off the ancestor loggers; LoggingTensorHandler is always attached directly.
+logger.propagate = False
 
 # How the chain of calls works for LoggingTensor:
 # 1. Call torch.sin


### PR DESCRIPTION
**Problem**

The *_logging_tensor autograd functional tests crash with TypeError: not all arguments converted during string formatting when logs are captured at INFO level (recent pytest defaults, or --log-cli-level=INFO).

**Cause**

logging_tensor.py logs ops as logger.info(msg, args, kwargs, rs), where the trailing values aren't printf args, they are extra data that only the custom LoggingTensorHandler reads from record.args. The message has no % placeholders. Because records propagate to ancestor loggers, a generic formatter up the tree (e.g. pytest's root-logger capture) runs msg % record.args and raises. At the default WARNING level .info() is a no-op, so it only surfaces under INFO capture. Reproduces identically on upstream release/2.13.

**Fix**

Set logger.propagate = False so records reach only the directly attached LoggingTensorHandler, never a generic ancestor formatter. 

**Testing**

Fresh clone + installed build: autograd functional suite passes at default level and under --log-cli-level=INFO (previously failed under INFO capture).