### PR TITLE
[inductor] Peak aware fusions compile time fast config

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -3006,6 +3006,81 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         self.assertEqual(ctx.tracked_nodes, {fused, c})
         self.assertEqual(ctx.last_use_steps, {1: 0, 3: 4})
 
+    def test_fusion_memory_update_modes(self):
+        from torch._inductor.scheduler import FusionMemoryContext, Scheduler
+
+        a, b, peak, far = (_PeakMemFakeNode(n) for n in ("a", "b", "peak", "far"))
+        ctx = FusionMemoryContext(
+            nodes=[a, b, peak, far],
+            tracked_nodes={a, b, peak, far},
+            graph_outputs=set(),
+            node_to_idx={a: 0, b: 1, peak: 2, far: 3},
+            baseline_peak=100,
+            baseline_live_before=[0, 10, 20, 100, 90],
+            baseline_live_after=[10, 20, 100, 90],
+        )
+        ctx.refresh_peak_range()
+        scheduler = object.__new__(Scheduler)
+        fast_update = object()
+        with (
+            torch._inductor.config.patch(
+                fusion_memory_timeline_peak_allowed_increase_mb=0,
+                fusion_memory_timeline_full_correctness=False,
+            ),
+            patch.object(
+                scheduler,
+                "_fusion_memory_update",
+                return_value=(False, fast_update),
+            ) as update_mock,
+        ):
+            self.assertEqual(
+                scheduler._check_fusion_memory(ctx, a, b),
+                (False, None),
+            )
+            update_mock.assert_not_called()
+            self.assertEqual(
+                scheduler._check_fusion_memory(ctx, a, far),
+                (False, fast_update),
+            )
+            update_mock.assert_called_once_with(ctx, a, far, 0)
+            fused = _PeakMemFakeNode("fused")
+            self.assertEqual(
+                scheduler._check_fusion_memory(ctx, fused, b),
+                (False, None),
+            )
+            update_mock.assert_called_once_with(ctx, a, far, 0)
+
+            ctx.decision_cache.clear()
+            update_mock.return_value = (True, None)
+            self.assertEqual(
+                scheduler._check_fusion_memory(ctx, a, far),
+                (True, None),
+            )
+            self.assertEqual(
+                scheduler._check_fusion_memory(None, a, far),
+                (False, None),
+            )
+
+        ctx.decision_cache.clear()
+        exact_update = object()
+        with (
+            torch._inductor.config.patch(
+                fusion_memory_timeline_peak_allowed_increase_mb=0,
+                fusion_memory_timeline_full_correctness=True,
+            ),
+            patch.object(
+                scheduler,
+                "_fusion_memory_update",
+                return_value=(False, exact_update),
+            ) as update_mock,
+        ):
+            self.assertEqual(
+                scheduler._check_fusion_memory(ctx, a, b),
+                (False, exact_update),
+            )
+            update_mock.assert_called_once_with(ctx, a, b, 0)
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -993,6 +993,12 @@ score_fusion_memory_threshold = 10
 # value is the allowed estimated peak increase in megabytes.
 fusion_memory_timeline_peak_allowed_increase_mb = None
 
+# Supporting full memory timeline could increase compile time,
+# By default we do heuristically based fast path that minimally increases compile time
+# at cost of not absolutely correct predictions.
+# Use True if not regressing peak memory is prioritized over compile time.
+fusion_memory_timeline_full_correctness = False
+
 # For Triton Templates, select fastest of best template + epilogue vs best template + separate epilogue kernel
 benchmark_epilogue_fusion = (
     os.environ.get("TORCHINDUCTOR_BENCHMARK_EPILOGUE_FUSION", "1") == "1"

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -7196,6 +7196,19 @@ class Scheduler:
         node2: BaseSchedulerNode,
         peak_allowed_increase: int,
     ) -> tuple[bool, FusionMemoryUpdate | None]:
+        if not config.fusion_memory_timeline_full_correctness:
+            if node1 not in ctx.tracked_nodes or node2 not in ctx.tracked_nodes:
+                return False, None
+            step1 = ctx.node_to_idx[node1]
+            step2 = ctx.node_to_idx[node2]
+            peak_start = ctx.peak_start
+            peak_end = ctx.peak_end
+            if peak_start is None or peak_end is None:
+                return False, None
+            region_start = min(step1, step2)
+            region_end = max(step1, step2)
+            if region_end < peak_start or region_start > peak_end:
+                return False, None
         cache_key = (ctx.version, id(node1), id(node2))
         if cache_key not in ctx.decision_cache:
             ctx.decision_cache[cache_key] = self._fusion_memory_update(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190804
* #190777
* #190344
* #190342

Description:
Make crossing-only fusion memory checks the default while retaining
fusion_memory_timeline_full_correctness=True for exact checking.

The parent commit maintains an incrementally updated memory timeline for every
checked fusion. The fast mode narrows that policy: it checks a candidate only
when both nodes are represented by the current timeline and their scheduling
interval overlaps the current peak. Accepted checked candidates update the
timeline normally. Off-peak candidates are accepted without simulation and the
resulting fused node remains untracked until the fresh context built for the
next fusion round.

This applies to every fusion round and every graph. Restricting checks to the
first two rounds or top-level graphs missed material regressions. Output-size
and local-headroom filters were also evaluated, but output size did not bound
the memory increase caused by extending input lifetimes. The fast policy
therefore uses only whether a tracked candidate crosses the current peak.

On graph-trainer d14 w3584 t256k with clean caches:

| Mode | Regional Inductor | All passes | Trace + compile | Peak memory |
|---|---:|---:|---:|---:|
| No fusion-memory config | 162.407s | 174.706s | 195.145s | 83613.1 MiB |
| Fast | 165.344s (+1.81%) | 177.886s (+1.82%) | 198.817s (+1.88%) | 60691.7 MiB (-27.41%) |
| Full correctness | 180.935s (+11.41%) | 193.296s (+10.64%) | 213.792s (+9.56%) | 60270.9 MiB (-27.92%) |

Fast is under the 2% compile-time target on these three timing scopes. Its d14
peak is 420.8 MiB, or 0.70%, above full correctness. On d4 w3072 t16k, fast
measured 48.051s versus a recent 48.938s disabled baseline and reduced peak from
10472.5 MiB to 10423.6 MiB.

Test Plan:

```bash
lintrunner -a
```

```bash
LD_LIBRARY_PATH=/home/ivankobzarev/local/e/pytorch-env/lib python test/inductor/test_combo_kernels.py -k test_fusion_memory_update_splices_context
LD_LIBRARY_PATH=/home/ivankobzarev/local/e/pytorch-env/lib python test/inductor/test_combo_kernels.py -k test_fusion_memory_update_modes
LD_LIBRARY_PATH=/home/ivankobzarev/local/e/pytorch-env/lib python test/inductor/test_combo_kernels.py -k test_estimate_region_peak_memory
LD_LIBRARY_PATH=/home/ivankobzarev/local/e/pytorch-env/lib python -m py_compile torch/_inductor/config.py torch/_inductor/memory.py torch/_inductor/scheduler.py test/inductor/test_combo_kernels.py
git diff --check
```

```bash
env DEPTH=14 DIM=3584 MAXTOK=262144 TAG=d14_w3584_t256k FUSION_MEMORY_MB=none FUSION_MEMORY_FULL_CORRECTNESS=0 agent_space/run_peak_fusion_proxy.sh current_baseline
env DEPTH=14 DIM=3584 MAXTOK=262144 TAG=d14_w3584_t256k FUSION_MEMORY_MB=0 FUSION_MEMORY_FULL_CORRECTNESS=0 agent_space/run_peak_fusion_proxy.sh crossing_early_exit_fast
env DEPTH=14 DIM=3584 MAXTOK=262144 TAG=d14_w3584_t256k FUSION_MEMORY_MB=0 FUSION_MEMORY_FULL_CORRECTNESS=1 agent_space/run_peak_fusion_proxy.sh crossing_early_exit_full
env DEPTH=4 DIM=3072 MAXTOK=16384 TAG=d4_w3072_t16k FUSION_MEMORY_MB=0 FUSION_MEMORY_FULL_CORRECTNESS=0 agent_space/run_peak_fusion_proxy.sh crossing_early_exit_fast
```

Authored with assistance from an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo