### PR TITLE
[inductor][NVGEMM] Fuse grouped reduction epilogues

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -1038,8 +1038,23 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         torch.testing.assert_close(result, fn(a, b, scale_a, scale_b), equal_nan=True)
         self.assertTrue(epilogue_fused, "multiply was NOT fused into scaled epilogue")
 
-    @parametrize("axis", (0, 1))
-    def test_scaled_mm_grouped_reduce_fusion(self, axis):
+    @parametrize(
+        "case",
+        (
+            (0, "sum"),
+            (0, "mean"),
+            (0, "prod"),
+            (0, "amax"),
+            (0, "amin"),
+            (1, "sum"),
+            (1, "prod"),
+            (1, "amax"),
+            (1, "amin"),
+        ),
+        name_fn=lambda case: f"axis_{case[0]}_{case[1]}",
+    )
+    def test_scaled_mm_grouped_reduce_fusion(self, case):
+        axis, reduction = case
         m, n, k = 128, 128, 512
         packed_k = k // 2
         group = 4 if axis == 0 else 32
@@ -1066,11 +1081,22 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
                 scale_b=scale_b,
                 out_dtype=torch.bfloat16,
             )
-            reduced = (
-                result.float().view(-1, group, n).sum(1)
+            grouped = (
+                result.float().view(-1, group, n)
                 if axis == 0
-                else result.float().view(m, -1, group).sum(-1)
+                else result.float().view(m, -1, group)
             )
+            dim = 1 if axis == 0 else -1
+            if reduction == "sum":
+                reduced = grouped.sum(dim)
+            elif reduction == "mean":
+                reduced = grouped.mean(dim)
+            elif reduction == "prod":
+                reduced = grouped.prod(dim)
+            elif reduction == "amax":
+                reduced = grouped.amax(dim)
+            else:
+                reduced = grouped.amin(dim)
             return result, reduced
 
         result, code, _ = self._compile_and_check(fn, a, b, scale_a, scale_b)

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -404,6 +404,7 @@ def _create_gemm_arguments(
     local_reduce_out: Any | None = None,
     local_reduce_group: int = 0,
     local_reduce_axis: int = 1,
+    local_reduce_type: str = "sum",
 ):
     import cutlass.operators
 
@@ -426,6 +427,7 @@ def _create_gemm_arguments(
         args.local_reduce_out = TensorWrapper(local_reduce_out)
         args.local_reduce_group = local_reduce_group
         args.local_reduce_axis = local_reduce_axis
+        args.local_reduce_type = local_reduce_type
         return args
 
     if epilogue is not None and variant_name == "GROUPED_GEMM":
@@ -532,13 +534,14 @@ def _create_gemm_cache_key(
     *,
     has_epilogue: bool = False,
     aux_tensors: tuple = (),
+    epilogue_specialization: tuple = (),
 ):
     cache_key = tuple(s for t in input_tensors for s in _tensor_sig(t))
     cache_key = (*cache_key, *_tensor_sig(out))
 
     if has_epilogue:
         aux_sig = tuple(_tensor_sig(t) for t in aux_tensors)
-        return (*cache_key, "epilogue", aux_sig)
+        return (*cache_key, "epilogue", aux_sig, epilogue_specialization)
     return cache_key
 
 
@@ -722,11 +725,17 @@ def _nvgemm_run(
 
     from torch._inductor.runtime.cutedsl_cache import disk_cache_get, disk_cache_set
 
+    epilogue_specialization = tuple(
+        (key, variant_kwargs[key])
+        for key in ("local_reduce_type",)
+        if variant_kwargs is not None and key in variant_kwargs
+    )
     cache_key = _create_gemm_cache_key(
         input_tensors,
         out,
         has_epilogue=has_epilogue,
         aux_tensors=aux_tensors,
+        epilogue_specialization=epilogue_specialization,
     )
     dev_idx = input_tensors[0].device.index or 0
     mem_key = (cache_key, dev_idx)
@@ -1059,7 +1068,7 @@ class NVUniversalGemmKernel(Kernel):
         epilogue_reads: list[str] | None = None,
         epilogue_writes: list[str] | None = None,
         epilogue_var_renames: dict[str, Any] | None = None,
-        local_reduce: tuple[str, int, int, str] | None = None,
+        local_reduce: tuple[str, int, int, str, str] | None = None,
         swap_ab: bool = False,
         bias_node: Buffer | None = None,
     ) -> None:
@@ -1237,13 +1246,16 @@ class NVUniversalGemmKernel(Kernel):
 
             run_variant_kwargs = "_VARIANT_KWARGS"
             if self.local_reduce is not None:
-                reduce_name, reduce_group, reduce_axis, _ = self.local_reduce
+                reduce_name, reduce_group, reduce_axis, reduce_type, _ = (
+                    self.local_reduce
+                )
                 reduce_ptr = f"out_ptr{output_buffers.index(reduce_name)}"
                 run_variant_kwargs = (
                     "_VARIANT_KWARGS | {"
                     f"'local_reduce_out': {reduce_ptr}, "
                     f"'local_reduce_group': {reduce_group}, "
-                    f"'local_reduce_axis': {reduce_axis}"
+                    f"'local_reduce_axis': {reduce_axis}, "
+                    f"'local_reduce_type': {reduce_type!r}"
                     "}"
                 )
                 aux_tensors_expr = f"({reduce_ptr},)"
@@ -1305,7 +1317,7 @@ class NVUniversalGemmKernel(Kernel):
         """
         if not self.epilogue_writes:
             primary_output = (
-                self.local_reduce[3]
+                self.local_reduce[4]
                 if self.local_reduce is not None
                 else self.output_node.get_name()
             )
@@ -1363,7 +1375,7 @@ class NVUniversalGemmKernel(Kernel):
         wrapper = V.graph.wrapper_code
 
         if self.local_reduce is not None:
-            primary_name = self.local_reduce[3]
+            primary_name = self.local_reduce[4]
             V.graph.removed_buffers.discard(primary_name)
             primary_output = V.graph.get_buffer(primary_name)
             wrapper.codegen_allocation(primary_output or self.output_node)

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
@@ -193,7 +193,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
     @staticmethod
     def _grouped_reduce_config(
         gemm_node: Buffer, scheduler_node: BaseSchedulerNode
-    ) -> tuple[str, int, int] | None:
+    ) -> tuple[str, int, int, str] | None:
         nodes = scheduler_node.get_nodes()
         if len(nodes) != 1:
             return None
@@ -205,18 +205,24 @@ class NVUniversalGemmScheduling(BaseScheduling):
             for origin in node.get_origins()
             if hasattr(origin, "target")
         )
+        reduction_targets = {
+            "aten.sum.dim_IntList": "sum",
+            "aten.mean.dim": "mean",
+            "aten.prod.dim_int": "prod",
+            "aten.amax.default": "max",
+            "aten.amin.default": "min",
+        }
+        matched_reductions = origin_targets & reduction_targets.keys()
         allowed_targets = OrderedSet(
-            (
-                "aten.reshape.default",
-                "aten.sum.dim_IntList",
-                "prims.convert_element_type.default",
-            )
-        )
+            ("aten.reshape.default", "prims.convert_element_type.default")
+        ) | OrderedSet(reduction_targets)
         if (
-            "aten.sum.dim_IntList" not in origin_targets
+            len(matched_reductions) != 1
             or not origin_targets.issubset(allowed_targets)
         ):
             return None
+        reduction_type = reduction_targets[next(iter(matched_reductions))]
+        output_name = node.get_name()
         if len(node.data.ranges) != 2 or len(gemm_node.get_size()) != 2:
             return None
         try:
@@ -232,7 +238,8 @@ class NVUniversalGemmScheduling(BaseScheduling):
         if isinstance(node.data, Reduction):
             reduction = node.data
             if (
-                reduction.reduction_type != "sum"
+                reduction.reduction_type
+                != ("sum" if reduction_type == "mean" else reduction_type)
                 or len(reduction.reduction_ranges) != 1
             ):
                 return None
@@ -268,7 +275,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
         if range_vars is None:
             return None
         if not range_vars:
-            return node.get_name(), group, axis
+            return output_name, group, axis, reduction_type
         if isinstance(node.data, Reduction):
             if len(reads) != 1:
                 return None
@@ -288,7 +295,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
             expected_offsets = OrderedSet(offset * n for offset in range(group))
             if OrderedSet(offsets) != expected_offsets:
                 return None
-        return node.get_name(), group, axis
+        return output_name, group, axis, reduction_type
 
     def _can_fuse_epilogue_impl(
         self,
@@ -567,7 +574,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
         epilogue_reads: list[str] = []
         epilogue_writes: list[str] = []
         epilogue_var_renames: dict[str, Any] = {}
-        local_reduce: tuple[str, int, int, str] | None = None
+        local_reduce: tuple[str, int, int, str, str] | None = None
 
         if epilogue_nodes:
             scheduler = V.graph.scheduler

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
@@ -424,6 +424,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         local_reduce_tensor: cute.Tensor = None,
         local_reduce_group: cutlass.Constexpr = 0,
         local_reduce_axis: cutlass.Constexpr = 1,
+        local_reduce_type: cutlass.Constexpr = "sum",
     ):
         """Execute the GEMM operation in steps:
         - Setup static attributes before smem/grid/tma computation
@@ -468,6 +469,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
         self.local_reduce_group = local_reduce_group
         self.local_reduce_axis = local_reduce_axis
+        self.local_reduce_type = local_reduce_type
 
         a_tensor = cute.make_tensor(
             a_tensor.iterator, cute.select(a_tensor.layout, [1, 2, 0])
@@ -1579,11 +1581,28 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             grouped = acc_vec.to(self.acc_dtype).reshape(
                                 ((1, group, repeats), 1, 1)
                             )
+                            if cutlass.const_expr(
+                                self.local_reduce_type in ("sum", "mean")
+                            ):
+                                reduce_op = cute.ReductionOp.ADD
+                                init_val = 0.0
+                            elif cutlass.const_expr(self.local_reduce_type == "prod"):
+                                reduce_op = cute.ReductionOp.MUL
+                                init_val = 1.0
+                            elif cutlass.const_expr(self.local_reduce_type == "max"):
+                                reduce_op = cute.ReductionOp.MAX
+                                init_val = -cutlass.Float32.inf
+                            else:
+                                assert self.local_reduce_type == "min"
+                                reduce_op = cute.ReductionOp.MIN
+                                init_val = cutlass.Float32.inf
                             reduced = grouped.reduce(
-                                cute.ReductionOp.ADD,
-                                init_val=0.0,
+                                reduce_op,
+                                init_val=init_val,
                                 reduction_profile=((None, 1, None), 1, 1),
                             )
+                            if cutlass.const_expr(self.local_reduce_type == "mean"):
+                                reduced = reduced / group
                             reduced = reduced.reshape(((1, 1, repeats), 1, 1))
                             reduced = reduced.broadcast_to(grouped.shape)
                             tDrReduce = cute.make_rmem_tensor(
@@ -1641,13 +1660,36 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             ):
                                 rows = group // 2
                                 while rows > 0:
-                                    reduced_flt[i] += cute.arch.shuffle_sync_bfly(
+                                    other = cute.arch.shuffle_sync_bfly(
                                         reduced_flt[i],
                                         offset=cute.crd2idx(
                                             (rows, 0), lane_layout_mn
                                         ),
                                     )
+                                    if cutlass.const_expr(
+                                        self.local_reduce_type in ("sum", "mean")
+                                    ):
+                                        reduced_flt[i] += other
+                                    elif cutlass.const_expr(
+                                        self.local_reduce_type == "prod"
+                                    ):
+                                        reduced_flt[i] *= other
+                                    elif cutlass.const_expr(
+                                        self.local_reduce_type == "max"
+                                    ):
+                                        reduced_flt[i] = cute.arch.fmax(
+                                            reduced_flt[i], other
+                                        )
+                                    else:
+                                        assert self.local_reduce_type == "min"
+                                        reduced_flt[i] = cute.arch.fmin(
+                                            reduced_flt[i], other
+                                        )
                                     rows = rows // 2
+                                if cutlass.const_expr(
+                                    self.local_reduce_type == "mean"
+                                ):
+                                    reduced_flt[i] /= group
                             groups_per_cta = cutlass.const_expr(
                                 self.cta_tile_shape_mnk[0] // group
                             )

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
@@ -152,6 +152,7 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
                 local_reduce_out.compile_time_tensor,
                 getattr(args, "local_reduce_group"),
                 getattr(args, "local_reduce_axis"),
+                getattr(args, "local_reduce_type"),
                 target_sm=target_sm,
             )
         return self.cute_compile(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190825
* #190824
* #190823
* #190822
* #190821
* #190820
* #190819
* #190818
* #190817
* #190816
* #190815
* #190814
* #190813
* #190812
* __->__ #190811
* #190810
* #190809
* #190808
* #190643
* #189841
* #189807
* #189806
* #189781
* #190642

Extend scaled NVGEMM grouped epilogues beyond sums by carrying the logical
reduction kind through scheduling, argument construction, and the vendored
CuTeDSL kernel. The kernel now selects add, multiply, maximum, or minimum
combines and applies mean finalization for reductions represented as one
scheduler unit.

Include the reduction kind in the compiled-artifact cache key. Without this,
same-shaped reductions could reuse an artifact specialized for a different
combine operation and silently produce incorrect results.

The implementation retains the existing group geometry limits. N-axis mean is
still represented as a separate reduction and pointwise finalizer and will be
handled with cross-node finalization support rather than partially fusing it.

Test Plan:

```
python -m py_compile torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py test/inductor/test_nv_universal_gemm.py
git diff --check
TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k grouped_reduce_fusion
TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k test_scaled_gemm
TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k epilogue
lintrunner -a  # Tool bootstrap failed downloading Python through the network tunnel.
```

Authored with an AI assistant.