### PR TITLE
[inductor][NVGEMM] Fuse grouped square reductions

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -1163,6 +1163,42 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         self.assertEqual(result[1], expected[1])
         self.assertIn("'local_reduce_out'", code)
 
+    def test_scaled_mm_grouped_reduce_source_fusion(self):
+        m, n, k, group = 128, 128, 512, 32
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(
+            0, 256, (n, packed_k), device="cuda", dtype=torch.uint8
+        ).view(torch.float4_e2m1fn_x2)
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(
+            _round_up(m, 128) * padded_k_blocks, device="cuda"
+        ).to(torch.float8_e4m3fn)
+        scale_b = torch.rand(
+            _round_up(n, 128) * padded_k_blocks, device="cuda"
+        ).to(torch.float8_e4m3fn)
+
+        def fn(a, b, scale_a, scale_b):
+            result = torch._scaled_mm(
+                a,
+                b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                out_dtype=torch.bfloat16,
+            )
+            grouped = result.float().view(m, -1, group)
+            return result, grouped.square().mean(-1)
+
+        result, code, _ = self._compile_and_check(fn, a, b, scale_a, scale_b)
+        expected = fn(a, b, scale_a, scale_b)
+        self.assertEqual(result[0], expected[0])
+        self.assertEqual(result[1], expected[1])
+        self.assertIn("'local_reduce_out'", code)
+        self.assertIn("'local_reduce_source': 'square'", code)
+
     def test_matmul_add_relu_chained(self):
         """Multi-op pointwise chain (a@b + bias → relu) collapses to one
         ComputedBuffer and is fused as a single epilogue."""

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -405,6 +405,7 @@ def _create_gemm_arguments(
     local_reduce_group: int = 0,
     local_reduce_axis: int = 1,
     local_reduce_type: str = "sum",
+    local_reduce_source: str = "identity",
 ):
     import cutlass.operators
 
@@ -428,6 +429,7 @@ def _create_gemm_arguments(
         args.local_reduce_group = local_reduce_group
         args.local_reduce_axis = local_reduce_axis
         args.local_reduce_type = local_reduce_type
+        args.local_reduce_source = local_reduce_source
         return args
 
     if epilogue is not None and variant_name == "GROUPED_GEMM":
@@ -727,7 +729,7 @@ def _nvgemm_run(
 
     epilogue_specialization = tuple(
         (key, variant_kwargs[key])
-        for key in ("local_reduce_type",)
+        for key in ("local_reduce_type", "local_reduce_source")
         if variant_kwargs is not None and key in variant_kwargs
     )
     cache_key = _create_gemm_cache_key(
@@ -1068,7 +1070,7 @@ class NVUniversalGemmKernel(Kernel):
         epilogue_reads: list[str] | None = None,
         epilogue_writes: list[str] | None = None,
         epilogue_var_renames: dict[str, Any] | None = None,
-        local_reduce: tuple[str, int, int, str, str] | None = None,
+        local_reduce: tuple[str, int, int, str, str, str] | None = None,
         swap_ab: bool = False,
         bias_node: Buffer | None = None,
     ) -> None:
@@ -1246,16 +1248,22 @@ class NVUniversalGemmKernel(Kernel):
 
             run_variant_kwargs = "_VARIANT_KWARGS"
             if self.local_reduce is not None:
-                reduce_name, reduce_group, reduce_axis, reduce_type, _ = (
-                    self.local_reduce
-                )
+                (
+                    reduce_name,
+                    reduce_group,
+                    reduce_axis,
+                    reduce_type,
+                    reduce_source,
+                    _,
+                ) = self.local_reduce
                 reduce_ptr = f"out_ptr{output_buffers.index(reduce_name)}"
                 run_variant_kwargs = (
                     "_VARIANT_KWARGS | {"
                     f"'local_reduce_out': {reduce_ptr}, "
                     f"'local_reduce_group': {reduce_group}, "
                     f"'local_reduce_axis': {reduce_axis}, "
-                    f"'local_reduce_type': {reduce_type!r}"
+                    f"'local_reduce_type': {reduce_type!r}, "
+                    f"'local_reduce_source': {reduce_source!r}"
                     "}"
                 )
                 aux_tensors_expr = f"({reduce_ptr},)"
@@ -1317,7 +1325,7 @@ class NVUniversalGemmKernel(Kernel):
         """
         if not self.epilogue_writes:
             primary_output = (
-                self.local_reduce[4]
+                self.local_reduce[5]
                 if self.local_reduce is not None
                 else self.output_node.get_name()
             )
@@ -1375,7 +1383,7 @@ class NVUniversalGemmKernel(Kernel):
         wrapper = V.graph.wrapper_code
 
         if self.local_reduce is not None:
-            primary_name = self.local_reduce[4]
+            primary_name = self.local_reduce[5]
             V.graph.removed_buffers.discard(primary_name)
             primary_output = V.graph.get_buffer(primary_name)
             wrapper.codegen_allocation(primary_output or self.output_node)

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
@@ -193,7 +193,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
     @classmethod
     def _grouped_reduce_config(
         cls, gemm_node: Buffer, scheduler_node: BaseSchedulerNode
-    ) -> tuple[str, int, int, str] | None:
+    ) -> tuple[str, int, int, str, str] | None:
         nodes = scheduler_node.get_nodes()
         if len(nodes) not in (1, 2):
             return None
@@ -214,16 +214,29 @@ class NVUniversalGemmScheduling(BaseScheduling):
             "aten.amax.default": "max",
             "aten.amin.default": "min",
         }
+        source_targets = OrderedSet(["aten.pow.Tensor_Scalar"])
         matched_reductions = origin_targets & reduction_targets.keys()
         allowed_targets = OrderedSet(
             ("aten.reshape.default", "prims.convert_element_type.default")
-        ) | OrderedSet(reduction_targets)
+        ) | OrderedSet(reduction_targets) | source_targets
         if (
             len(matched_reductions) != 1
             or not origin_targets.issubset(allowed_targets)
         ):
             return None
         reduction_type = reduction_targets[next(iter(matched_reductions))]
+        source_origins = OrderedSet(
+            origin
+            for buffer in buffers
+            for origin in buffer.get_origins()
+            if str(getattr(origin, "target", "")) in source_targets
+        )
+        if not source_origins:
+            source_type = "identity"
+        elif len(source_origins) == 1 and next(iter(source_origins)).args[1] == 2:
+            source_type = "square"
+        else:
+            return None
         node = buffers[0]
         access_node = scheduler_node
         output_name = node.get_name()
@@ -288,7 +301,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
         if range_vars is None:
             return None
         if not range_vars:
-            return output_name, group, axis, reduction_type
+            return output_name, group, axis, reduction_type, source_type
         if isinstance(node.data, Reduction):
             if len(reads) != 1:
                 return None
@@ -308,7 +321,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
             expected_offsets = OrderedSet(offset * n for offset in range(group))
             if OrderedSet(offsets) != expected_offsets:
                 return None
-        return output_name, group, axis, reduction_type
+        return output_name, group, axis, reduction_type, source_type
 
     @staticmethod
     def _is_mean_finalizer(
@@ -339,7 +352,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
     @classmethod
     def _partition_local_reductions(
         cls, gemm_node: Buffer, epilogue_nodes: Sequence[BaseSchedulerNode]
-    ) -> tuple[list[tuple[str, int, int, str]], OrderedSet[BaseSchedulerNode]]:
+    ) -> tuple[list[tuple[str, int, int, str, str]], OrderedSet[BaseSchedulerNode]]:
         reductions = []
         reduction_nodes: OrderedSet[BaseSchedulerNode] = OrderedSet()
         index = 0
@@ -539,13 +552,18 @@ class NVUniversalGemmScheduling(BaseScheduling):
         preserve_gemm_output = not V.graph.scheduler.can_buffer_be_removed_through_fusion(
             ir_node.get_name(), fused_buffer_names
         )
+        has_local_reduce = local_reduce is not None or any(
+            self._grouped_reduce_config(ir_node, node) is not None
+            for node in existing_epilogue_nodes
+        )
+        if scaled_epilogue and preserve_gemm_output and not has_local_reduce:
+            log.debug("NVGEMM scaled EVT does not support multiple output stores")
+            return False
 
-        # Multi-store epilogues (the GEMM output feeding >1 graph output) are
-        # supported: each output store is wired to its own out_ptr (see
-        # NVUniversalGemmKernel._ordered_output_buffers). The trial EVT codegen
-        # below still gates any chain cutlass can't express.
+        # Dense EFC supports multiple EVT stores. Scaled kernels use a separate
+        # local-reduction output slot but otherwise require one EVT output.
         trial_removed_buffers = V.graph.removed_buffers.copy()
-        if not preserve_gemm_output and local_reduce is None:
+        if not preserve_gemm_output:
             trial_removed_buffers.add(ir_node.get_name())
         try:
             trial_reads: list[str] = []
@@ -686,7 +704,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
         epilogue_reads: list[str] = []
         epilogue_writes: list[str] = []
         epilogue_var_renames: dict[str, Any] = {}
-        local_reduce: tuple[str, int, int, str, str] | None = None
+        local_reduce: tuple[str, int, int, str, str, str] | None = None
 
         if epilogue_nodes:
             scheduler = V.graph.scheduler
@@ -715,7 +733,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
                 )
                 fused_buffer_names.add(original_buffer_name)
                 removed_buffers_with_gemm = V.graph.removed_buffers.copy()
-                if local_reduce is None and scheduler.can_buffer_be_removed_through_fusion(
+                if scheduler.can_buffer_be_removed_through_fusion(
                     original_buffer_name, fused_buffer_names
                 ):
                     removed_buffers_with_gemm.add(original_buffer_name)
@@ -748,8 +766,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
                         ):
                             V.graph.removed_buffers.add(node_name)
                     if (
-                        local_reduce is None
-                        and original_buffer_name not in write_bufs
+                        original_buffer_name not in write_bufs
                         and scheduler.can_buffer_be_removed_through_fusion(
                             original_buffer_name, fused_buffer_names
                         )

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
@@ -434,6 +434,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         local_reduce_group: cutlass.Constexpr = 0,
         local_reduce_axis: cutlass.Constexpr = 1,
         local_reduce_type: cutlass.Constexpr = "sum",
+        local_reduce_source: cutlass.Constexpr = "identity",
     ):
         """Execute the GEMM operation in steps:
         - Setup static attributes before smem/grid/tma computation
@@ -479,6 +480,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         self.local_reduce_group = local_reduce_group
         self.local_reduce_axis = local_reduce_axis
         self.local_reduce_type = local_reduce_type
+        self.local_reduce_source = local_reduce_source
 
         a_tensor = cute.make_tensor(
             a_tensor.iterator, cute.select(a_tensor.layout, [1, 2, 0])
@@ -1662,6 +1664,14 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                             mma_tile_coord_mnl[2],
                                         ]
                                 epilogue_values.append(fragment.load())
+                    if cutlass.const_expr(local_reduce_tensor is not None):
+                        local_reduce_vec = acc_vec.to(epilogue_input_dtype).to(
+                            self.acc_dtype
+                        )
+                        if cutlass.const_expr(self.local_reduce_source == "square"):
+                            local_reduce_vec = local_reduce_vec * local_reduce_vec
+                        else:
+                            assert self.local_reduce_source == "identity"
                     acc_vec = epilogue_op(
                         acc_vec.to(epilogue_input_dtype), *tuple(epilogue_values)
                     ).to(self.c_dtype)
@@ -1678,7 +1688,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             assert group > 1 and group <= fragment_n
                             assert fragment_n % group == 0
                             repeats = cutlass.const_expr(fragment_n // group)
-                            grouped = acc_vec.to(self.acc_dtype).reshape(
+                            grouped = local_reduce_vec.reshape(
                                 ((1, group, repeats), 1, 1)
                             )
                             if cutlass.const_expr(
@@ -1743,9 +1753,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                     gReduce[row_idx, group_idx] = reduced_flt[i]
                         else:
                             tDrReduce = cute.make_rmem_tensor_like(
-                                acc_vec, self.acc_dtype
+                                local_reduce_vec, self.acc_dtype
                             )
-                            tDrReduce.store(acc_vec.to(self.acc_dtype))
+                            tDrReduce.store(local_reduce_vec)
                             reduced_flt = cute.filter_zeros(tDrReduce)
                             lane_layout_mn, _ = get_lane_warp_layouts(
                                 tiled_copy_t2r, reference_src=False

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
@@ -210,6 +210,7 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
                 getattr(args, "local_reduce_group"),
                 getattr(args, "local_reduce_axis"),
                 getattr(args, "local_reduce_type"),
+                getattr(args, "local_reduce_source"),
                 target_sm=target_sm,
             )
         return self.cute_compile(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190825
* #190824
* #190823
* #190822
* #190821
* #190820
* #190819
* #190818
* #190817
* #190816
* #190815
* __->__ #190814
* #190813
* #190812
* #190811
* #190810
* #190809
* #190808
* #190643
* #189841
* #189807
* #189806
* #189781
* #190642

Extend scaled NVGEMM local reductions with a validated source transform. The
scheduler recognizes an exact exponent-2 reduction source, carries that
specialization through the generated launcher and artifact cache key, and the
vendored kernel applies it to the rounded scaled-mm output before reducing.
Keeping a pre-main-epilogue reduction fragment also prevents future main output
expressions from changing auxiliary reduction semantics.

Scaled EFC does not implement generic tuple-valued EVT stores. Reject that
capability when preserving the GEMM output would require a second EVT store;
the dedicated local-reduction output remains supported. Previously such a
schedule could reach the kernel with a tuple-valued callback and fail during
CuTeDSL compilation.

Test Plan:

```
python -m py_compile torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py test/inductor/test_nv_universal_gemm.py
git diff --check
TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k grouped_reduce
TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k scaled_mm_broadcast_epilogue_fusion
TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k test_scaled_gemm
lintrunner -a  # Python linters could not download their toolchain; SET_LINTER passed after its automatic fix.
```

Authored with an AI assistant.