### PR TITLE
[inductor][NVGEMM] Support scaled multi-store epilogues

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -1038,6 +1038,44 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         torch.testing.assert_close(result, fn(a, b, scale_a, scale_b), equal_nan=True)
         self.assertTrue(epilogue_fused, "multiply was NOT fused into scaled epilogue")
 
+    def test_scaled_mm_multi_store_epilogue_fusion(self):
+        m, n, k = self.M, self.N, self.K
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(
+            0, 256, (n, packed_k), device="cuda", dtype=torch.uint8
+        ).view(torch.float4_e2m1fn_x2)
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(
+            _round_up(m, 128) * padded_k_blocks, device="cuda"
+        ).to(torch.float8_e4m3fn)
+        scale_b = torch.rand(
+            _round_up(n, 128) * padded_k_blocks, device="cuda"
+        ).to(torch.float8_e4m3fn)
+
+        def fn(a, b, scale_a, scale_b):
+            result = torch._scaled_mm(
+                a,
+                b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                out_dtype=torch.bfloat16,
+            )
+            result_fp32 = result.float()
+            return result, torch.relu(result_fp32), result_fp32 * 0.5
+
+        result, code, epilogue_fused = self._compile_and_check(
+            fn, a, b, scale_a, scale_b
+        )
+        expected = fn(a, b, scale_a, scale_b)
+        self.assertEqual(result, expected)
+        self.assertTrue(epilogue_fused)
+        self.assertIn("out_ptr1", code)
+        self.assertIn("out_ptr2", code)
+
     @parametrize(
         "case",
         (

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
@@ -552,28 +552,20 @@ class NVUniversalGemmScheduling(BaseScheduling):
         preserve_gemm_output = not V.graph.scheduler.can_buffer_be_removed_through_fusion(
             ir_node.get_name(), fused_buffer_names
         )
-        has_local_reduce = local_reduce is not None or any(
-            self._grouped_reduce_config(ir_node, node) is not None
-            for node in existing_epilogue_nodes
-        )
-        if scaled_epilogue and preserve_gemm_output and not has_local_reduce:
-            log.debug("NVGEMM scaled EVT does not support multiple output stores")
-            return False
-
-        # Dense EFC supports multiple EVT stores. Scaled kernels use a separate
-        # local-reduction output slot but otherwise require one EVT output.
+        # Multi-store epilogues wire each output to its own destination tensor.
         trial_removed_buffers = V.graph.removed_buffers.copy()
         if not preserve_gemm_output:
             trial_removed_buffers.add(ir_node.get_name())
         try:
             trial_reads: list[str] = []
+            trial_writes: list[str] = []
             evt_nodes = [
                 node
                 for node in all_epilogue_nodes
                 if self._grouped_reduce_config(ir_node, node) is None
             ]
             if evt_nodes:
-                trial_reads, _, _, _ = (
+                trial_reads, trial_writes, _, _ = (
                     CutlassEVTCodegen.ir_to_evt_python_code(
                         ir_node.get_name(),
                         evt_nodes,
@@ -581,7 +573,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
                     )
                 )
             if scaled_epilogue:
-                if len(trial_reads) > 4:
+                if len(trial_reads) > 4 or len(trial_writes) > 4:
                     return False
                 for read_name in trial_reads:
                     read_buf = name_to_buf.get(read_name)

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
@@ -430,6 +430,11 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         epilogue_tensor_kind1: cutlass.Constexpr = 0,
         epilogue_tensor_kind2: cutlass.Constexpr = 0,
         epilogue_tensor_kind3: cutlass.Constexpr = 0,
+        epilogue_output0: cute.Tensor = None,
+        epilogue_output1: cute.Tensor = None,
+        epilogue_output2: cute.Tensor = None,
+        epilogue_output_count: cutlass.Constexpr = 1,
+        primary_epilogue_output: cutlass.Constexpr = 0,
         local_reduce_tensor: cute.Tensor = None,
         local_reduce_group: cutlass.Constexpr = 0,
         local_reduce_axis: cutlass.Constexpr = 1,
@@ -505,6 +510,15 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             epilogue_tensor2 = epilogue_tensor_to_mnl(epilogue_tensor2)
         if cutlass.const_expr(epilogue_tensor3 is not None):
             epilogue_tensor3 = epilogue_tensor_to_mnl(epilogue_tensor3)
+        if cutlass.const_expr(epilogue_output0 is not None):
+            epilogue_output0 = epilogue_tensor_to_mnl(epilogue_output0)
+        if cutlass.const_expr(epilogue_output1 is not None):
+            epilogue_output1 = epilogue_tensor_to_mnl(epilogue_output1)
+        if cutlass.const_expr(epilogue_output2 is not None):
+            epilogue_output2 = epilogue_tensor_to_mnl(epilogue_output2)
+
+        self.epilogue_output_count = epilogue_output_count
+        self.primary_epilogue_output = primary_epilogue_output
 
         # Setup static attributes before smem/grid/tma computation
         self.a_dtype: Type[cutlass.Numeric] = a_tensor.element_type
@@ -748,6 +762,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             epilogue_tensor_kind1,
             epilogue_tensor_kind2,
             epilogue_tensor_kind3,
+            epilogue_output0,
+            epilogue_output1,
+            epilogue_output2,
             local_reduce_tensor,
         ).launch(
             grid=grid,
@@ -794,6 +811,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         epilogue_tensor_kind1: cutlass.Constexpr,
         epilogue_tensor_kind2: cutlass.Constexpr,
         epilogue_tensor_kind3: cutlass.Constexpr,
+        epilogue_output0: cute.Tensor,
+        epilogue_output1: cute.Tensor,
+        epilogue_output2: cute.Tensor,
         local_reduce_tensor: cute.Tensor,
     ):
         """
@@ -1604,8 +1624,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         or epilogue_tensor2 is not None
                         or epilogue_tensor3 is not None
                     )
+                    has_epilogue_outputs = cutlass.const_expr(
+                        self.epilogue_output_count > 1
+                    )
                     if cutlass.const_expr(
-                        has_epilogue_tensors or local_reduce_tensor is not None
+                        has_epilogue_tensors
+                        or has_epilogue_outputs
+                        or local_reduce_tensor is not None
                     ):
                         tDcC = partition_for_epilogue(
                             cute.make_identity_tensor(self.cta_tile_shape_mnk[:2]),
@@ -1618,9 +1643,12 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         coord_flt = cute.filter_zeros(tDcC)
 
                     epilogue_values = []
-                    if cutlass.const_expr(has_epilogue_tensors):
+                    if cutlass.const_expr(
+                        has_epilogue_tensors or has_epilogue_outputs
+                    ):
                         output_m = cute.size(mC_mnl, mode=[0])
                         output_n = cute.size(mC_mnl, mode=[1])
+                    if cutlass.const_expr(has_epilogue_tensors):
                         for tensor, kind in (
                             (epilogue_tensor0, epilogue_tensor_kind0),
                             (epilogue_tensor1, epilogue_tensor_kind1),
@@ -1672,9 +1700,53 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             local_reduce_vec = local_reduce_vec * local_reduce_vec
                         else:
                             assert self.local_reduce_source == "identity"
-                    acc_vec = epilogue_op(
+                    epilogue_result = epilogue_op(
                         acc_vec.to(epilogue_input_dtype), *tuple(epilogue_values)
-                    ).to(self.c_dtype)
+                    )
+                    if cutlass.const_expr(has_epilogue_outputs):
+                        for output_index, tensor in enumerate(
+                            (epilogue_output0, epilogue_output1, epilogue_output2)
+                        ):
+                            if cutlass.const_expr(tensor is not None):
+                                result_index = cutlass.const_expr(
+                                    output_index
+                                    if output_index < self.primary_epilogue_output
+                                    else output_index + 1
+                                )
+                                output_vec = epilogue_result[result_index].to(
+                                    tensor.element_type
+                                )
+                                fragment = cute.make_rmem_tensor_like(
+                                    output_vec, tensor.element_type
+                                )
+                                fragment.store(output_vec)
+                                fragment_flt = cute.filter_zeros(fragment)
+                                for i in cutlass.range(
+                                    cute.size(fragment_flt), unroll_full=True
+                                ):
+                                    row_idx = coord_flt[i][0]
+                                    col_idx = coord_flt[i][1]
+                                    global_m = (
+                                        mma_tile_coord_mnl[0]
+                                        * self.cta_tile_shape_mnk[0]
+                                        + row_idx
+                                    )
+                                    global_n = (
+                                        mma_tile_coord_mnl[1]
+                                        * self.cta_tile_shape_mnk[1]
+                                        + col_idx
+                                    )
+                                    if global_m < output_m and global_n < output_n:
+                                        tensor[
+                                            global_m,
+                                            global_n,
+                                            mma_tile_coord_mnl[2],
+                                        ] = fragment_flt[i]
+                        acc_vec = epilogue_result[
+                            self.primary_epilogue_output
+                        ].to(self.c_dtype)
+                    else:
+                        acc_vec = epilogue_result.to(self.c_dtype)
 
                     if cutlass.const_expr(local_reduce_tensor is not None):
                         group = cutlass.const_expr(self.local_reduce_group)

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
@@ -36,11 +36,18 @@ _ONES_ALPHA: dict = {}
 
 
 @functools.cache
-def _epilogue_input_names(epilogue_fn) -> tuple[str, ...]:
+def _epilogue_signature(epilogue_fn) -> tuple[tuple[str, ...], tuple[str, ...]]:
     from cutlass.operators.fusion import trace_in_out
 
-    inputs, _ = trace_in_out(epilogue_fn)
-    return tuple(name for name in inputs if name != "accum")
+    inputs, outputs = trace_in_out(epilogue_fn)
+    return (
+        tuple(name for name in inputs if name != "accum"),
+        tuple(outputs),
+    )
+
+
+def _epilogue_input_names(epilogue_fn) -> tuple[str, ...]:
+    return _epilogue_signature(epilogue_fn)[0]
 
 
 def _epilogue_tensors(args, attr: str) -> tuple:
@@ -76,6 +83,24 @@ def _epilogue_tensor_kinds(args) -> tuple[int, ...]:
         else:
             kinds.append(1)
     return tuple(kinds) + (0,) * (4 - len(kinds))
+
+
+def _epilogue_outputs(args, attr: str) -> tuple[tuple, int, int]:
+    epilogue = getattr(args, "epilogue", None)
+    if epilogue is None:
+        return (None, None, None), 1, 0
+    output_names = _epilogue_signature(epilogue.epilogue_fn)[1]
+    if not output_names or len(output_names) > 4:
+        raise NotImplementedError("NVGEMM scaled epilogues support 1-4 outputs")
+    if len(output_names) > 1 and "D" not in output_names:
+        raise NotImplementedError("NVGEMM scaled multi-store requires a D output")
+    primary_index = output_names.index("D") if "D" in output_names else 0
+    tensors = tuple(
+        getattr(epilogue.tensors[name], attr)
+        for index, name in enumerate(output_names)
+        if index != primary_index
+    )
+    return tensors + (None,) * (3 - len(tensors)), len(output_names), primary_index
 
 
 def _ones_alpha():
@@ -190,6 +215,9 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
                 epilogue_op = scope[fn_name]
         epilogue_tensors = _epilogue_tensors(args, "compile_time_tensor")
         epilogue_tensor_kinds = _epilogue_tensor_kinds(args)
+        epilogue_outputs, output_count, primary_output = _epilogue_outputs(
+            args, "compile_time_tensor"
+        )
         local_reduce_out = getattr(args, "local_reduce_out", None)
         if local_reduce_out is not None:
             return self.cute_compile(
@@ -206,6 +234,9 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
                 alpha,
                 *epilogue_tensors,
                 *epilogue_tensor_kinds,
+                *epilogue_outputs,
+                output_count,
+                primary_output,
                 local_reduce_out.compile_time_tensor,
                 getattr(args, "local_reduce_group"),
                 getattr(args, "local_reduce_axis"),
@@ -227,6 +258,9 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
             alpha,
             *epilogue_tensors,
             *epilogue_tensor_kinds,
+            *epilogue_outputs,
+            output_count,
+            primary_output,
             target_sm=target_sm,
         )
 
@@ -251,6 +285,7 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
         if alpha is None:
             alpha = _ones_alpha()
         epilogue_tensors = _epilogue_tensors(args, "runtime_tensor")
+        epilogue_outputs, _, _ = _epilogue_outputs(args, "runtime_tensor")
 
         local_reduce_out = getattr(args, "local_reduce_out", None)
         if local_reduce_out is not None:
@@ -264,6 +299,7 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
                 stream,
                 alpha,
                 *epilogue_tensors,
+                *epilogue_outputs,
                 local_reduce_out.runtime_tensor,
             )
             return
@@ -278,6 +314,7 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
             stream,
             alpha,
             *epilogue_tensors,
+            *epilogue_outputs,
             None,
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190825
* #190824
* #190823
* #190822
* #190821
* #190820
* #190819
* #190818
* #190817
* #190816
* __->__ #190815
* #190814
* #190813
* #190812
* #190811
* #190810
* #190809
* #190808
* #190643
* #189841
* #189807
* #189806
* #189781
* #190642

Thread up to three auxiliary EVT output tensors through the vendored scaled
CuTeDSL wrapper, in addition to the primary C output. Cached epilogue signature
parsing separates captured inputs from output names and uses the generated `D`
output to select the existing TMA store destination.

For tuple-valued epilogues, keep the primary fragment on the normal TMA path
and write auxiliary fragments directly with the accumulator coordinate map and
tail predicates. This supports up to four total outputs with independent output
dtypes while leaving single-output kernels on their existing path.

Test Plan:

```
python -m py_compile torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py test/inductor/test_nv_universal_gemm.py
git diff --check
TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k scaled_mm_multi_store_epilogue_fusion
TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k grouped_reduce
TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k scaled_mm_broadcast_epilogue_fusion
TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k test_scaled_gemm
lintrunner -a
```

Authored with an AI assistant.