### PR TITLE
[inductor][NVGEMM] Compose reductions with multi-store epilogues

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -1228,7 +1228,7 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
                 out_dtype=torch.bfloat16,
             )
             grouped = result.float().view(m, -1, group)
-            return result, grouped.square().mean(-1)
+            return torch.relu(result), grouped.square().mean(-1)
 
         result, code, _ = self._compile_and_check(fn, a, b, scale_a, scale_b)
         expected = fn(a, b, scale_a, scale_b)

--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -133,7 +133,11 @@ class CUDACombinedScheduling(BaseScheduling):
     def can_fuse_reduction_epilogue(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:
-        if self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(node1):
+        if self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(
+            node1
+        ) or self._nv_universal_gemm_scheduling.is_nv_universal_gemm_fused_template(
+            node1
+        ):
             return self._nv_universal_gemm_scheduling.can_fuse_reduction_epilogue(
                 node1, node2
             )

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
@@ -432,6 +432,9 @@ class NVUniversalGemmScheduling(BaseScheduling):
             for epilogue_node in (*existing_epilogue_nodes, node_to_fuse)
             for node in epilogue_node.get_nodes()
         ]
+        _, local_reduce_nodes = self._partition_local_reductions(
+            ir_node, all_scheduler_nodes
+        )
         local_reduce = self._grouped_reduce_config(ir_node, node_to_fuse)
         variants = (
             (ir_node.variant,)
@@ -452,16 +455,18 @@ class NVUniversalGemmScheduling(BaseScheduling):
 
         for s_node in all_scheduler_nodes:
             node = s_node.node
-            node_local_reduce = self._grouped_reduce_config(ir_node, s_node)
             if not isinstance(node, ComputedBuffer):
                 log.debug("NVGEMM epilogue fusion: %s is not a ComputedBuffer", node)
                 return False
-            if not isinstance(node.data, Pointwise) and node_local_reduce is None:
+            if (
+                not isinstance(node.data, Pointwise)
+                and s_node not in local_reduce_nodes
+            ):
                 log.debug("NVGEMM epilogue fusion: %s is not a Pointwise op", node)
                 return False
 
             if (
-                node_local_reduce is None
+                s_node not in local_reduce_nodes
                 and not V.graph.sizevars.statically_known_list_equals(
                     node.get_size(), ir_node.get_size()
                 )
@@ -562,7 +567,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
             evt_nodes = [
                 node
                 for node in all_epilogue_nodes
-                if self._grouped_reduce_config(ir_node, node) is None
+                if node not in local_reduce_nodes
             ]
             if evt_nodes:
                 trial_reads, trial_writes, _, _ = (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190825
* #190824
* #190823
* #190822
* #190821
* #190820
* #190819
* #190818
* #190817
* __->__ #190816
* #190815
* #190814
* #190813
* #190812
* #190811
* #190810
* #190809
* #190808
* #190643
* #189841
* #189807
* #189806
* #189781
* #190642

CUDA combined scheduling stopped delegating grouped-reduction checks after an NVGEMM template had fused its first pointwise output. In addition, NVGEMM validated the leaves of a recognized mean reduction independently, causing its finalizer to look like an unsupported size-mismatched pointwise output.

Keep NVGEMM reduction dispatch active for fused templates and validate/store recognized grouped-reduction leaves as one partition. This allows transformed primary outputs and grouped auxiliary reductions to share the same scaled GEMM without changing candidate discovery.

Test Plan:

```

TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k grouped_reduce

TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k multi_store

TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k scaled_mm

lintrunner -a  # tool downloads failed through the configured network tunnel

```

Authored with an AI assistant.