### PR TITLE
[inductor][NVGEMM] Fuse grouped centering epilogues

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -1251,6 +1251,40 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         self.assertIn("'local_reduce_out'", code)
         self.assertIn("'local_reduce_source': 'square'", code)
 
+    def test_scaled_mm_grouped_reduce_feeds_main(self):
+        m, n, k, group = 128, 128, 512, 4
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(
+            0, 256, (n, packed_k), device="cuda", dtype=torch.uint8
+        ).view(torch.float4_e2m1fn_x2)
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(
+            _round_up(m, 128) * padded_k_blocks, device="cuda"
+        ).to(torch.float8_e4m3fn)
+        scale_b = torch.rand(
+            _round_up(n, 128) * padded_k_blocks, device="cuda"
+        ).to(torch.float8_e4m3fn)
+
+        def fn(a, b, scale_a, scale_b):
+            result = torch._scaled_mm(
+                a,
+                b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                out_dtype=torch.bfloat16,
+            )
+            grouped = result.float().view(-1, group, n)
+            mean = grouped.mean(1, keepdim=True).expand(-1, group, -1)
+            return result.float() - mean.reshape(m, n)
+
+        result, code, _ = self._compile_and_check(fn, a, b, scale_a, scale_b)
+        self.assertEqual(result, fn(a, b, scale_a, scale_b))
+        self.assertIn("'local_reduce_feeds_main': True", code)
+
     def test_matmul_add_relu_chained(self):
         """Multi-op pointwise chain (a@b + bias → relu) collapses to one
         ComputedBuffer and is fused as a single epilogue."""

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -406,14 +406,16 @@ def _create_gemm_arguments(
     local_reduce_axis: int = 1,
     local_reduce_type: str = "sum",
     local_reduce_source: str = "identity",
+    local_reduce_feeds_main: bool = False,
 ):
     import cutlass.operators
 
-    if local_reduce_out is not None and variant_name != "SCALED_GEMM":
+    has_local_reduce = local_reduce_out is not None or local_reduce_feeds_main
+    if has_local_reduce and variant_name != "SCALED_GEMM":
         raise NotImplementedError(
             "NVGEMM local reductions currently require scaled GEMM"
         )
-    if local_reduce_out is not None and (
+    if has_local_reduce and (
         local_reduce_axis not in (0, 1) or local_reduce_group <= 1
     ):
         raise NotImplementedError(
@@ -421,15 +423,18 @@ def _create_gemm_arguments(
         )
 
     def with_local_reduce(args):
-        if local_reduce_out is None:
+        if not has_local_reduce:
             return args
         from cutlass.operators.utils.tensor import TensorWrapper
 
-        args.local_reduce_out = TensorWrapper(local_reduce_out)
+        args.local_reduce_out = (
+            TensorWrapper(local_reduce_out) if local_reduce_out is not None else None
+        )
         args.local_reduce_group = local_reduce_group
         args.local_reduce_axis = local_reduce_axis
         args.local_reduce_type = local_reduce_type
         args.local_reduce_source = local_reduce_source
+        args.local_reduce_feeds_main = local_reduce_feeds_main
         return args
 
     if epilogue is not None and variant_name == "GROUPED_GEMM":
@@ -1070,7 +1075,7 @@ class NVUniversalGemmKernel(Kernel):
         epilogue_reads: list[str] | None = None,
         epilogue_writes: list[str] | None = None,
         epilogue_var_renames: dict[str, Any] | None = None,
-        local_reduce: tuple[str, int, int, str, str, str] | None = None,
+        local_reduce: tuple[str | None, int, int, str, str, str] | None = None,
         swap_ab: bool = False,
         bias_node: Buffer | None = None,
     ) -> None:
@@ -1256,7 +1261,12 @@ class NVUniversalGemmKernel(Kernel):
                     reduce_source,
                     _,
                 ) = self.local_reduce
-                reduce_ptr = f"out_ptr{output_buffers.index(reduce_name)}"
+                feed_main = reduce_name is None
+                reduce_ptr = (
+                    "None"
+                    if feed_main
+                    else f"out_ptr{output_buffers.index(reduce_name)}"
+                )
                 run_variant_kwargs = (
                     "_VARIANT_KWARGS | {"
                     f"'local_reduce_out': {reduce_ptr}, "
@@ -1264,9 +1274,11 @@ class NVUniversalGemmKernel(Kernel):
                     f"'local_reduce_axis': {reduce_axis}, "
                     f"'local_reduce_type': {reduce_type!r}, "
                     f"'local_reduce_source': {reduce_source!r}"
+                    f", 'local_reduce_feeds_main': {feed_main!r}"
                     "}"
                 )
-                aux_tensors_expr = f"({reduce_ptr},)"
+                if not feed_main:
+                    aux_tensors_expr = f"({reduce_ptr},)"
 
             code.writeline("_nvgemm_run(")
             with code.indent():
@@ -1330,7 +1342,7 @@ class NVUniversalGemmKernel(Kernel):
                 else self.output_node.get_name()
             )
             ordered = [primary_output]
-            if self.local_reduce is not None:
+            if self.local_reduce is not None and self.local_reduce[0] is not None:
                 ordered.append(self.local_reduce[0])
             return ordered
         d_buf = (self.epilogue_var_renames or {}).get("D")
@@ -1340,7 +1352,11 @@ class NVUniversalGemmKernel(Kernel):
         for w in self.epilogue_writes:
             if w != d_buf and w not in ordered:
                 ordered.append(w)
-        if self.local_reduce is not None and self.local_reduce[0] not in ordered:
+        if (
+            self.local_reduce is not None
+            and self.local_reduce[0] is not None
+            and self.local_reduce[0] not in ordered
+        ):
             ordered.append(self.local_reduce[0])
         return ordered
 

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
@@ -34,7 +34,7 @@ from ...scheduler import (
 )
 from ...virtualized import V
 from ..common import BackendFeature, IndentedBuffer
-from ..cutlass.python_evt import CutlassEVTCodegen
+from ..cutlass.python_evt import _ACCUMULATOR_ARG_NAME, CutlassEVTCodegen
 from .nv_universal_gemm import NVUniversalGemmCaller
 
 
@@ -323,6 +323,72 @@ class NVUniversalGemmScheduling(BaseScheduling):
                 return None
         return output_name, group, axis, reduction_type, source_type
 
+    @classmethod
+    def _grouped_reduce_feeds_main_config(
+        cls, gemm_node: Buffer, scheduler_node: BaseSchedulerNode
+    ) -> tuple[str, int, int, str, str] | None:
+        nodes = scheduler_node.get_nodes()
+        if len(nodes) != 1 or not isinstance(nodes[0].node, ComputedBuffer):
+            return None
+        node = cast(ComputedBuffer, nodes[0].node)
+        if not isinstance(node.data, Pointwise):
+            return None
+        targets = OrderedSet(
+            str(origin.target)
+            for origin in node.get_origins()
+            if hasattr(origin, "target")
+        )
+        required_targets = OrderedSet(("aten.sub.Tensor", "aten.mean.dim"))
+        allowed_targets = OrderedSet(
+            (
+                "aten.sub.Tensor",
+                "aten.reshape.default",
+                "prims.convert_element_type.default",
+                "aten.mean.dim",
+                "aten.expand.default",
+                "aten.clone.default",
+                "aten._unsafe_view.default",
+            )
+        )
+        if not required_targets.issubset(targets) or not targets.issubset(
+            allowed_targets
+        ):
+            return None
+        sub_origins = [
+            origin
+            for origin in node.get_origins()
+            if str(getattr(origin, "target", "")) == "aten.sub.Tensor"
+        ]
+        if len(sub_origins) != 1:
+            return None
+        lhs, rhs = sub_origins[0].args[:2]
+        if (
+            str(getattr(lhs, "target", ""))
+            != "prims.convert_element_type.default"
+            or str(getattr(rhs, "target", "")) != "aten.reshape.default"
+        ):
+            return None
+        reads = list(scheduler_node.read_writes.reads)
+        range_vars = scheduler_node.read_writes.range_vars
+        if range_vars is None or len(reads) <= 2:
+            return None
+        try:
+            _, n = map(V.graph.sizevars.optimization_hint, gemm_node.get_size())
+        except Exception:
+            return None
+        group = len(reads) - 1
+        if group <= 1 or group > 4:
+            return None
+        if any(read.name != gemm_node.get_name() for read in reads):
+            return None
+        grouped_base = reads[1].index
+        if any(
+            V.graph.sizevars.simplify(read.index - grouped_base) != i * n
+            for i, read in enumerate(reads[1:])
+        ):
+            return None
+        return node.get_name(), group, 0, "mean", "identity"
+
     @staticmethod
     def _is_mean_finalizer(
         reduction_node: BaseSchedulerNode, finalizer_node: BaseSchedulerNode
@@ -432,6 +498,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
             for epilogue_node in (*existing_epilogue_nodes, node_to_fuse)
             for node in epilogue_node.get_nodes()
         ]
+        feed_main = self._grouped_reduce_feeds_main_config(ir_node, node_to_fuse)
         _, local_reduce_nodes = self._partition_local_reductions(
             ir_node, all_scheduler_nodes
         )
@@ -459,14 +526,16 @@ class NVUniversalGemmScheduling(BaseScheduling):
                 log.debug("NVGEMM epilogue fusion: %s is not a ComputedBuffer", node)
                 return False
             if (
-                not isinstance(node.data, Pointwise)
+                feed_main is None
+                and not isinstance(node.data, Pointwise)
                 and s_node not in local_reduce_nodes
             ):
                 log.debug("NVGEMM epilogue fusion: %s is not a Pointwise op", node)
                 return False
 
             if (
-                s_node not in local_reduce_nodes
+                feed_main is None
+                and s_node not in local_reduce_nodes
                 and not V.graph.sizevars.statically_known_list_equals(
                     node.get_size(), ir_node.get_size()
                 )
@@ -567,7 +636,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
             evt_nodes = [
                 node
                 for node in all_epilogue_nodes
-                if node not in local_reduce_nodes
+                if node not in local_reduce_nodes and feed_main is None
             ]
             if evt_nodes:
                 trial_reads, trial_writes, _, _ = (
@@ -604,9 +673,10 @@ class NVUniversalGemmScheduling(BaseScheduling):
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:
         template = node1.get_template_node()
-        return isinstance(template, Buffer) and self._grouped_reduce_config(
-            template, node2
-        ) is not None
+        return isinstance(template, Buffer) and (
+            self._grouped_reduce_config(template, node2) is not None
+            or self._grouped_reduce_feeds_main_config(template, node2) is not None
+        )
 
     def define_kernel(
         self, src_code: str, node_schedule, precompile_metadata=None
@@ -701,7 +771,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
         epilogue_reads: list[str] = []
         epilogue_writes: list[str] = []
         epilogue_var_renames: dict[str, Any] = {}
-        local_reduce: tuple[str, int, int, str, str, str] | None = None
+        local_reduce: tuple[str | None, int, int, str, str, str] | None = None
 
         if epilogue_nodes:
             scheduler = V.graph.scheduler
@@ -720,6 +790,34 @@ class NVUniversalGemmScheduling(BaseScheduling):
                     if local_reductions
                     else None
                 )
+                feed_main = (
+                    self._grouped_reduce_feeds_main_config(
+                        original_ir_node, epilogue_nodes[0]
+                    )
+                    if len(epilogue_nodes) == 1
+                    else None
+                )
+                if feed_main is not None:
+                    output_name, group, axis, reduce_type, source = feed_main
+                    local_reduce = (
+                        None,
+                        group,
+                        axis,
+                        reduce_type,
+                        source,
+                        output_name,
+                    )
+                    local_reduce_nodes = OrderedSet(epilogue_nodes)
+                    epilogue_fn_code = (
+                        f"def {EPILOGUE_FN_NAME}(accum):\n"
+                        "    D = accum\n"
+                        "    return D"
+                    )
+                    epilogue_writes = [output_name]
+                    epilogue_var_renames = {
+                        _ACCUMULATOR_ARG_NAME: original_buffer_name,
+                        "D": output_name,
+                    }
                 evt_nodes = [
                     node
                     for node in epilogue_nodes
@@ -735,7 +833,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
                 ):
                     removed_buffers_with_gemm.add(original_buffer_name)
 
-                if evt_nodes:
+                if evt_nodes and feed_main is None:
                     reads, writes, var_renames, evt_code = (
                         CutlassEVTCodegen.ir_to_evt_python_code(
                             original_buffer_name,
@@ -917,10 +1015,17 @@ class NVUniversalGemmScheduling(BaseScheduling):
             local_reductions, local_reduce_nodes = self._partition_local_reductions(
                 template_sn.node, epilogue
             )
+            feed_main = (
+                self._grouped_reduce_feeds_main_config(
+                    template_sn.node, epilogue[0]
+                )
+                if len(epilogue) == 1
+                else None
+            )
             evt_nodes = [
                 node
                 for node in epilogue
-                if node not in local_reduce_nodes
+                if node not in local_reduce_nodes and feed_main is None
             ]
             removed_buffers_with_gemm = V.graph.removed_buffers.copy()
             if not local_reductions:
@@ -945,6 +1050,8 @@ class NVUniversalGemmScheduling(BaseScheduling):
                         *output_bufs,
                         local_reductions[0][0],
                     ]
+                elif feed_main is not None:
+                    output_bufs = [feed_main[0]]
             except (NotImplementedError, AssertionError) as e:
                 log.warning("NVGEMM benchmark epilogue codegen failed: %s", e)
 

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
@@ -440,6 +440,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         local_reduce_axis: cutlass.Constexpr = 1,
         local_reduce_type: cutlass.Constexpr = "sum",
         local_reduce_source: cutlass.Constexpr = "identity",
+        local_reduce_feeds_main: cutlass.Constexpr = False,
     ):
         """Execute the GEMM operation in steps:
         - Setup static attributes before smem/grid/tma computation
@@ -486,6 +487,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         self.local_reduce_axis = local_reduce_axis
         self.local_reduce_type = local_reduce_type
         self.local_reduce_source = local_reduce_source
+        self.local_reduce_feeds_main = local_reduce_feeds_main
         self.has_cross_warp_local_reduce = cutlass.const_expr(
             local_reduce_tensor is not None
             and local_reduce_axis == 0
@@ -1599,7 +1601,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
                 local_reduce_partial = None
                 if cutlass.const_expr(
-                    local_reduce_tensor is not None
+                    (local_reduce_tensor is not None or self.local_reduce_feeds_main)
                     and self.local_reduce_axis == 1
                     and self.local_reduce_group > self.epi_tile_n
                 ):
@@ -1721,7 +1723,10 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                             mma_tile_coord_mnl[2],
                                         ]
                                 epilogue_values.append(fragment.load())
-                    if cutlass.const_expr(local_reduce_tensor is not None):
+                    if cutlass.const_expr(
+                        local_reduce_tensor is not None
+                        or self.local_reduce_feeds_main
+                    ):
                         local_reduce_vec = acc_vec.to(epilogue_input_dtype).to(
                             self.acc_dtype
                         )
@@ -1729,9 +1734,37 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             local_reduce_vec = local_reduce_vec * local_reduce_vec
                         else:
                             assert self.local_reduce_source == "identity"
-                    epilogue_result = epilogue_op(
-                        acc_vec.to(epilogue_input_dtype), *tuple(epilogue_values)
-                    )
+                    if cutlass.const_expr(self.local_reduce_feeds_main):
+                        group = cutlass.const_expr(self.local_reduce_group)
+                        lane_layout_mn, _ = get_lane_warp_layouts(
+                            tiled_copy_t2r, reference_src=False
+                        )
+                        lanes_in_m = cutlass.const_expr(
+                            cute.size(lane_layout_mn, mode=[0])
+                        )
+                        assert group <= lanes_in_m
+                        feed_value = cute.make_rmem_tensor_like(
+                            local_reduce_vec, self.acc_dtype
+                        )
+                        feed_value.store(local_reduce_vec)
+                        feed_flt = cute.filter_zeros(feed_value)
+                        for i in cutlass.range(cute.size(feed_flt), unroll_full=True):
+                            rows = group // 2
+                            while rows > 0:
+                                feed_flt[i] += cute.arch.shuffle_sync_bfly(
+                                    feed_flt[i],
+                                    offset=cute.crd2idx((rows, 0), lane_layout_mn),
+                                )
+                                rows //= 2
+                            if cutlass.const_expr(self.local_reduce_type == "mean"):
+                                feed_flt[i] /= group
+                        epilogue_result = acc_vec.to(
+                            epilogue_input_dtype
+                        ) - feed_value.load()
+                    else:
+                        epilogue_result = epilogue_op(
+                            acc_vec.to(epilogue_input_dtype), *tuple(epilogue_values)
+                        )
                     if cutlass.const_expr(has_epilogue_outputs):
                         for output_index, tensor in enumerate(
                             (epilogue_output0, epilogue_output1, epilogue_output2)
@@ -1777,7 +1810,10 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                     else:
                         acc_vec = epilogue_result.to(self.c_dtype)
 
-                    if cutlass.const_expr(local_reduce_tensor is not None):
+                    if cutlass.const_expr(
+                        local_reduce_tensor is not None
+                        and not self.local_reduce_feeds_main
+                    ):
                         group = cutlass.const_expr(self.local_reduce_group)
                         mReduce = local_reduce_tensor[
                             mma_tile_coord_mnl[2], None, None

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
@@ -220,7 +220,8 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
             args, "compile_time_tensor"
         )
         local_reduce_out = getattr(args, "local_reduce_out", None)
-        if local_reduce_out is not None:
+        local_reduce_feeds_main = getattr(args, "local_reduce_feeds_main", False)
+        if local_reduce_out is not None or local_reduce_feeds_main:
             return self.cute_compile(
                 self.impl,
                 args.A.tensor,
@@ -238,11 +239,16 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
                 *epilogue_outputs,
                 output_count,
                 primary_output,
-                local_reduce_out.compile_time_tensor,
+                (
+                    local_reduce_out.compile_time_tensor
+                    if local_reduce_out is not None
+                    else None
+                ),
                 getattr(args, "local_reduce_group"),
                 getattr(args, "local_reduce_axis"),
                 getattr(args, "local_reduce_type"),
                 getattr(args, "local_reduce_source"),
+                local_reduce_feeds_main,
                 target_sm=target_sm,
             )
         return self.cute_compile(
@@ -289,7 +295,8 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
         epilogue_outputs, _, _ = _epilogue_outputs(args, "runtime_tensor")
 
         local_reduce_out = getattr(args, "local_reduce_out", None)
-        if local_reduce_out is not None:
+        local_reduce_feeds_main = getattr(args, "local_reduce_feeds_main", False)
+        if local_reduce_out is not None or local_reduce_feeds_main:
             self.cute_run(  # pyrefly: ignore[missing-attribute]
                 compiled_gemm,
                 args.A.tensor,
@@ -301,7 +308,7 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
                 alpha,
                 *epilogue_tensors,
                 *epilogue_outputs,
-                local_reduce_out.runtime_tensor,
+                local_reduce_out.runtime_tensor if local_reduce_out is not None else None,
             )
             return
 
@@ -329,7 +336,9 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
         from cutlass.operators.arguments import ScaledOperand
 
         local_reduce_out = getattr(args, "local_reduce_out", None)
-        if local_reduce_out is not None:
+        if local_reduce_out is not None or getattr(
+            args, "local_reduce_feeds_main", False
+        ):
             group = getattr(args, "local_reduce_group")
             axis = getattr(args, "local_reduce_axis")
             m, n = args.out.shape[-2:]
@@ -345,18 +354,19 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
                     "Grouped reduction requires a supported M- or N-axis group "
                     "that divides the selected dimension."
                 )
-            expected_shape = (m, n // group) if axis == 1 else (m // group, n)
-            if local_reduce_out.shape != expected_shape:
-                return Status.fail(
-                    "Grouped reduction output shape must be "
-                    f"{expected_shape}; got {local_reduce_out.shape}."
-                )
-            if local_reduce_out.dtype is not cutlass.Float32 or tuple(
-                local_reduce_out.stride
-            ) != (expected_shape[1], 1):
-                return Status.fail(
-                    "Grouped reduction output must be contiguous Float32."
-                )
+            if local_reduce_out is not None:
+                expected_shape = (m, n // group) if axis == 1 else (m // group, n)
+                if local_reduce_out.shape != expected_shape:
+                    return Status.fail(
+                        "Grouped reduction output shape must be "
+                        f"{expected_shape}; got {local_reduce_out.shape}."
+                    )
+                if local_reduce_out.dtype is not cutlass.Float32 or tuple(
+                    local_reduce_out.stride
+                ) != (expected_shape[1], 1):
+                    return Status.fail(
+                        "Grouped reduction output must be contiguous Float32."
+                    )
 
         m, n = args.out.shape[-2:]
         k = args.A.shape[-1]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190825
* #190824
* #190823
* #190822
* #190821
* #190820
* #190819
* __->__ #190818
* #190817
* #190816
* #190815
* #190814
* #190813
* #190812
* #190811
* #190810
* #190809
* #190808
* #190643
* #189841
* #189807
* #189806
* #189781
* #190642

Inductor folds grouped mean and its broadcast subtraction into one pointwise node. Generic template fusion rejected its indexed reads, and the block-scaled NVGEMM ABI required every local reduction to have an auxiliary output tensor.

Recognize the strict output-minus-grouped-mean pattern for same-warp M groups, carry a feed-main flag without allocating an auxiliary output, and broadcast the lane reduction into the primary epilogue. The matcher validates operation order, origins, and grouped read offsets so unrelated indexed pointwise graphs remain unfused.

Test Plan:

```

TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k feeds_main

TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k grouped_reduce

TORCHINDUCTOR_COMPILE_THREADS=1 python test/inductor/test_nv_universal_gemm.py -k scaled_mm

lintrunner -a  # tool downloads failed through the configured network tunnel

```

Authored with an AI assistant.