### PR TITLE
[inductor] fwd-fix: Keep eager compile_fx import in inductor_utils

### DIFF
--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -11,6 +11,8 @@ from subprocess import CalledProcessError
 
 import torch
 import torch._inductor.config as config
+
+from torch._inductor import compile_fx  # noqa: F401
 from torch._inductor.utils import (
     get_gpu_shared_memory,
     get_gpu_type,


### PR DESCRIPTION
Summary:
PR#181617 deferred imports in `inductor_utils.py`, dropping the eager import that registered the `torch._inductor.compile_fx` attribute. Consumers reaching `torch._inductor.compile_fx` without importing it then hit `AttributeError`. Restore a minimal eager import (heavier deferred symbols stay deferred).

Authored with an AI assistant.

Test Plan: CI

Reviewed By: eellison

Differential Revision: D113308092
