### PR TITLE
Fix typos in comments and docstrings across torch

### DIFF
--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -454,7 +454,7 @@ AOT_COUNTER = itertools.count()
 # However, Inductor does not want the concept of tokens in the final generated
 # code's input and output. Since changing the graph signature inside of inductor
 # is difficult, after generating the forward graph, we will run a pass to
-# remove the tokens from the inputgenerate the following graph for Inductor, where
+# remove the tokens from the input and generate the following graph for Inductor, where
 # the tokens are created and sunk within the graph, rather than as inputs and
 # outputs:
 #

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -970,7 +970,7 @@ class ExternKernelBenchmarkRequest(BenchmarkRequest):
 
     def benchmark(self, *input_tensors: torch.Tensor, out: torch.Tensor | None = None):
         if out is not None and out.numel() == 0:
-            # no need to run the kernel of do benchmarking
+            # no need to run the kernel or do benchmarking
             return 0.0
         if self.has_out_variant or len(input_tensors) == 0:
             return super().benchmark(*input_tensors, out=out)

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -1742,7 +1742,7 @@ class KernelArgs:
         Returns:
             Tuple[str, str, int]: A tuple containing:
                 - "ws_ptr": A string identifier for the workspace pointer.
-                - "workspace_{i}": agraph level unique identifier for
+                - "workspace_{i}": a graph level unique identifier for
                     the workspace tensor.
                 - offset: An integer representing the item offset in the workspace.
         """
@@ -2331,7 +2331,7 @@ class Kernel(CodeGen, Generic[CSEVariableType]):
         raise NotImplementedError
 
     def indirect_load(self, name: str, index: sympy.Expr) -> CSEVariable:
-        """A load the depends on an index we have read"""
+        """A load that depends on an index we have read"""
         prior = self.loads
         try:
             # put the load in the compute section as it might have deps

--- a/torch/_inductor/codegen/halide.py
+++ b/torch/_inductor/codegen/halide.py
@@ -1664,7 +1664,7 @@ class HalideKernel(SIMDKernel):
             }
             cuda_device = max(0, current_device.index)
 
-        # strict_float is requires for correctness
+        # strict_float is required for correctness
         target.append("strict_float")
 
         # without this we will initialize cuda once per kernel and hit errors

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -781,7 +781,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                 if trigger != ReInplaceTrigger.AUTO_FUNC_V2:
                     for user in node.users:
                         # For auto_functionalize_v2, arg is the index of the base, where base at index i corresponds to
-                        # output atindex size(out)+i.
+                        # output at index size(out)+i.
                         # This used to compare string with integers before for auto_functionalize_v2. Not sure
                         # if it was needed for inplaceable_triton_ops?
                         if user.target is operator.getitem and user.args[1] == arg:

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -2305,7 +2305,7 @@ def register_lowering_pattern(
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     Register an aten to inductor IR replacement pattern.  The decorated
-    function is saved and then called a lowering time allowing direct
+    function is saved and then called at lowering time allowing direct
     pattern to inductor IR conversion.
     """
 

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -146,7 +146,7 @@ class EventList(list):
         s1 and e1 would be start and end of the child event's interval. And
         s2 and e2 start and end of the parent event's interval
 
-        Example: In event list [[0, 10], [1, 3], [3, 4]] would have make [0, 10]
+        Example: In event list [[0, 10], [1, 3], [3, 4]] would make [0, 10]
         be a parent of two other intervals.
 
         If for any reason two intervals intersect only partially, this function

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -207,7 +207,7 @@ class PowerSGDState:
 
         self.process_group = process_group
         self.matrix_approximation_rank = matrix_approximation_rank
-        # Deferring PowerSGD compression util step 'start_powerSGD_iter' can have two advantages:
+        # Deferring PowerSGD compression until step 'start_powerSGD_iter' can have two advantages:
         # 1) It turns out that PowerSGD may lead to a non-trivial accuracy loss,
         # even if the matrix approximation rank is increased to a large value.
         # To mitigate the accuracy loss, a simple yet effective way is mixing vanilla allreduce

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -422,7 +422,7 @@ def view_groups(from_size: Shape, to_size: Shape) -> DimMap:
     3) Split one dimension into multiple dimensions
 
     view_groups identifies these operations and returns, for each output dimension, what
-    is operation was performed in the input dimension. For example:
+    operation was performed in the input dimension. For example:
 
         view_groups([2, 3, 4], [2, 12]) -> (
             InputDim(0),

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1464,7 +1464,7 @@ def _process_jit_trace_inputs_for_export(example_inputs, example_kwarg_inputs):
 
 
 def _get_original_state_dict(mod: torch.nn.Module) -> dict[str, Any]:
-    # Explicitly not calling mode.state_dict() as we do not want the module state for serialization
+    # Explicitly not calling mod.state_dict() as we do not want the module state for serialization
     # but the running module state so we can always match by id() the entries here with the graph inputs
     named_parameters = dict(mod.named_parameters(remove_duplicate=False))
     named_buffers = dict(mod.named_buffers(remove_duplicate=False))

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -1882,7 +1882,7 @@ def _sink_params(
 
         inputs_to_state_of_scope[node] = state_name
 
-    # Record name of remove inputs for return purpose.
+    # Record name of removed inputs for return purpose.
     inputs_removed: set[str] = set()
 
     for node, state_name in inputs_to_state_of_scope.items():

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -536,7 +536,7 @@ def stft(
         such as :func:`torch.hann_window`.
 
     The STFT computes the Fourier transform of short overlapping windows of the
-    input. This giving frequency components of the signal as they change over
+    input. This gives frequency components of the signal as they change over
     time. The interface of this function is modeled after (but *not* a drop-in
     replacement for) librosa_ stft function.
 
@@ -1482,7 +1482,7 @@ def block_diag(*tensors):
 
 def cdist(x1, x2, p=2.0, compute_mode="use_mm_for_euclid_dist_if_necessary"):
     # type: (Tensor, Tensor, float, str) -> (Tensor)
-    r"""Computes batched the p-norm distance between each pair of the two collections of row vectors.
+    r"""Computes the batched p-norm distance between each pair of the two collections of row vectors.
 
     Args:
         x1 (Tensor): input tensor where the last two dimensions represent the points and the feature dimension respectively.

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1942,7 +1942,7 @@ class DistributedDataParallel(Module, Joinable):
             authoritative_rank = self._find_common_rank(self._distributed_rank, False)
             self._sync_module_buffers(authoritative_rank)
 
-    # When running in join model, agrees upon a common rank and broadcast model
+    # When running in join mode, agrees upon a common rank and broadcast model
     # parameters to all other ranks.
     def _sync_final_model(self, is_last_joiner):
         # Agree upon the process that will be the authoritative model copy.

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -873,7 +873,7 @@ class _CheckpointFrame:
         if not len(self.weak_holders) == self.recomp_counter[gid]:
             # 2. During recompute, fewer tensors were saved
             #
-            # We know that every time we save something do original forward
+            # We know that every time we save something during original forward
             # we append to weak_holder, and every time we save a tensor
             # during recompute we increment recompute_counter.
             raise CheckpointError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190827

These are all single-word typo corrections in comments and docstrings:
dropped or transposed words ("inputgenerate" -> "input and generate",
"agraph" -> "a graph"), wrong words ("of" -> "or", "do" -> "during",
"is" -> "was", "model" -> "mode", "mode" -> "mod", "util" -> "until"),
and grammar fixes ("This giving" -> "This gives", "Computes batched the"
-> "Computes the batched"). No functional changes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo