### PR TITLE
Fix cpp_extension header/library paths for editable installs

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -28,6 +28,7 @@ from ._filelock import FileLock
 from ._cpp_extension_versioner import ExtensionVersioner
 from typing_extensions import deprecated
 from torch.torch_version import TorchVersion, Version
+from torch._utils_internal import get_file_path
 
 
 IS_WINDOWS = sys.platform == 'win32'
@@ -39,8 +40,12 @@ CLIB_PREFIX = '' if IS_WINDOWS else 'lib'
 CLIB_EXT = '.dll' if IS_WINDOWS else '.so'
 SHARED_FLAG = '/DLL' if IS_WINDOWS else '-shared'
 
-_HERE = os.path.abspath(__file__)
-_TORCH_PATH = os.path.dirname(os.path.dirname(_HERE))
+# Torch root used below to locate compiled artifacts (lib/, include/, bin/).
+# Editable installs using scikit-build-core redirect mode place these in the
+# installed package directory rather than the source tree this file loads
+# from, so resolve it the same way torch._utils_internal does instead of from
+# this file's location.
+_TORCH_PATH = get_file_path("torch")
 TORCH_LIB_PATH = os.path.join(_TORCH_PATH, 'lib')
 
 


### PR DESCRIPTION
**Problem**

Building a C++ or CUDA extension against a PyTorch installed in editable mode (`pip install -e .`) fails to find any installed torch header. The compile aborts on the first include, e.g.:
```
  fatal error: torch/csrc/autograd/profiler_kineto.h: No such file or directory
```
The recent migration to scikit-build-core changed editable installs so that compiled artifacts (the installed headers, libraries, and binaries) live in the installed package directory instead of the source tree. The C++ extension helper still looked for them under the source tree, which an editable install never populates, so extension builds lose their header and library search paths. Regular wheel installs are unaffected because their package directory and their import location are the same.

**Fix**

The scikit-build-core migration (#180247) already added `_compute_torch_parent` so `get_file_path` resolves to the installed package directory for editable installs, but `torch.utils.cpp_extension` still computed its own root from `dirname(dirname(__file__))`. Resolve `_TORCH_PATH` with `get_file_path("torch")` instead, so `cpp_extension` reuses that same editable-aware logic. `_TORCH_PATH` feeds every include, library, precompiled-header, and hipify path in the module, so this single change fixes all of them; non-editable installs resolve exactly as before.

Authored with assistance from an AI agent (Claude Code).