### PR TITLE
[Test] Refactor the test_dtensor_ops.py to have hw_classification

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -32,6 +32,7 @@ from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_ops_unbacked import ops_dde_xfail, ops_unbacked_skip
 from torch.testing._internal.common_utils import (
     freeze_rng_state,
+    HardwareClassification,
     np,
     run_tests,
     SEED,
@@ -686,6 +687,8 @@ class TestDTensorOps(TestCase):
 
 
 class TestMultiThreadedDTensorOps(DTensorOpTestBase, TestDTensorOps):
+    hw_classification = HardwareClassification.GENERIC
+
     _op_db = repurpose_ops(op_db, "TestDTensorOps", "TestMultiThreadedDTensorOps")
     _op_db_sample_lock = threading.Lock()
 
@@ -705,6 +708,8 @@ class TestMultiThreadedDTensorOps(DTensorOpTestBase, TestDTensorOps):
 
 
 class TestLocalDTensorOps(TestDTensorOps):
+    hw_classification = HardwareClassification.GENERIC
+
     _op_db = repurpose_ops(op_db, "TestDTensorOps", "TestLocalDTensorOps")
 
     def setUp(self) -> None:
@@ -874,6 +879,8 @@ class TestUnbackedDTensorOps(TestDTensorOps):
     and the op compiled with fullgraph=True to catch DDEs during tracing.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     _op_db = repurpose_ops(op_db, "TestDTensorOps", "TestUnbackedDTensorOps")
 
     def setUp(self) -> None:
@@ -986,6 +993,8 @@ class TestUnbackedDTensorOps(TestDTensorOps):
 
 
 class TestSingleDimStrategies(DTensorOpTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 2
@@ -1127,6 +1136,8 @@ class TestCompiledDTensorOps(TestDTensorOps):
     Test DTensor ops compile successfully with aot_eager backend.
     Uses fake PG for speed - focuses on compilation, not output correctness.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     _op_db = repurpose_ops(op_db, "TestDTensorOps", "TestCompiledDTensorOps")
 

--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -687,7 +687,7 @@ class TestDTensorOps(TestCase):
 
 
 class TestMultiThreadedDTensorOps(DTensorOpTestBase, TestDTensorOps):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     _op_db = repurpose_ops(op_db, "TestDTensorOps", "TestMultiThreadedDTensorOps")
     _op_db_sample_lock = threading.Lock()
@@ -708,7 +708,7 @@ class TestMultiThreadedDTensorOps(DTensorOpTestBase, TestDTensorOps):
 
 
 class TestLocalDTensorOps(TestDTensorOps):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     _op_db = repurpose_ops(op_db, "TestDTensorOps", "TestLocalDTensorOps")
 
@@ -879,7 +879,7 @@ class TestUnbackedDTensorOps(TestDTensorOps):
     and the op compiled with fullgraph=True to catch DDEs during tracing.
     """
 
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     _op_db = repurpose_ops(op_db, "TestDTensorOps", "TestUnbackedDTensorOps")
 
@@ -993,7 +993,7 @@ class TestUnbackedDTensorOps(TestDTensorOps):
 
 
 class TestSingleDimStrategies(DTensorOpTestBase):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
@@ -1137,7 +1137,7 @@ class TestCompiledDTensorOps(TestDTensorOps):
     Uses fake PG for speed - focuses on compilation, not output correctness.
     """
 
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     _op_db = repurpose_ops(op_db, "TestDTensorOps", "TestCompiledDTensorOps")
 


### PR DESCRIPTION
## Summary

Adds `hw_classification` to the 5 test classes in `test/distributed/tensor/test_dtensor_ops.py`.

**ACCELERATOR**

- `TestLocalDTensorOps`, `TestUnbackedDTensorOps`, `TestCompiledDTensorOps` — all three spin up a "fake" process group in setUp.
- `TestMultiThreadedDTensorOps`, `TestSingleDimStrategies` — these use `MultiThreadedTestCase` under the hood.

All 5 classes use `instantiate_device_type_tests`, which requires ACCELERATOR per the hw_classification contract regardless of fake PG usage or DEVICE_TYPE being hardcoded to "cpu".

Note: The DEVICE_TYPE is hardcoded to "cpu" since running on CUDA is expected to fail per pytorch/pytorch#92611.

## Test Plan

```bash
python -m pytest test/distributed/tensor/test_dtensor_ops.py --collect-only -q
# 3398 tests collected

python -m pytest test/distributed/tensor/test_dtensor_ops.py --collect-only -q --hw-classification ACCELERATOR
# HW classification mode active (['ACCELERATOR']): total=3398, passed=3398, unclassified=0, mismatched=0
# 3398 tests collected

# ACCELERATOR: 3398, total: 3398, unclassified: 0
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508