### PR TITLE
Fix typos in inductor, ao, distributed, and nn comments and docstrings

### DIFF
--- a/torch/_inductor/codegen/memory_planning.py
+++ b/torch/_inductor/codegen/memory_planning.py
@@ -108,7 +108,7 @@ class AllocationTreeNode:
 
     def allocate(self, block: Allocation, is_last: bool) -> bool:
         """
-        Try to assign block to a memory location in this bool.  Return True if
+        Try to assign block to a memory location in this pool.  Return True if
         an assignment was made.
         """
         return False

--- a/torch/_inductor/config_comms.py
+++ b/torch/_inductor/config_comms.py
@@ -31,7 +31,7 @@ sink_iterative_use_runtime_estimations: bool = False
 # Broadcast runtime estimations doing real Collective operation between all ranks.
 # If non-deterministic runtime estimations are used this must be used to make
 # all ranks to do identical decisions and prevent global Collectives reordering,
-# (that will result un NCCL hangs)
+# (that will result in NCCL hangs)
 reorder_for_compute_comm_overlap_broadcast_runtime_estimations: bool = False
 
 # Block of Ratios to workaround imperfection of current runtime estimations

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -100,7 +100,7 @@ def _freeze(
     aot_autograd_gm: torch.fx.GraphModule,
     example_inputs: list[torch._subclasses.FakeTensor],
 ) -> tuple[torch.fx.GraphModule, list[int]]:
-    # We have convert conv's weight to channels last which may meet error for .view
+    # We have converted conv's weight to channels last which may meet error for .view
     # when doing fake_tensor_prop. So we need to convert view to reshape first.
     # See the details in fx_codegen_and_compile of compile_fx.py.
     view_to_reshape(aot_autograd_gm)

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -82,7 +82,7 @@ lookup_seed = make_prim(
 )
 # inductor_random() doesn't accept a dtype.
 # instead, its lowering always burns in float32, and conversions to a different type
-# are explicit in the graph. We therefore need this impl (used during tracing) to hardcoded
+# are explicit in the graph. We therefore need this impl (used during tracing) to hardcode
 # the dtype, so it always faithfully produces a float32 tensor during tracing,
 # even if the default dtype is set to something else.
 random = make_prim(

--- a/torch/_inductor/kernel/flex/flex_cpu.py
+++ b/torch/_inductor/kernel/flex/flex_cpu.py
@@ -155,7 +155,7 @@ def lower_cpu(
 
     # The original mask_graph works on a scalar and only includes
     # the logic of calculating the mask value.
-    # We need to add the logic of applying the mark to the qk_data tensor
+    # We need to add the logic of applying the mask to the qk_data tensor
     # into the graph for the later codegen of this part.
     # Example:
     #   mask_graph:

--- a/torch/_inductor/lookup_table/choices.py
+++ b/torch/_inductor/lookup_table/choices.py
@@ -370,7 +370,7 @@ class LookupTableChoices(InductorChoices):
     ) -> list[KernelTemplateChoice]:
         """Fallback to parent if no lookup table or no matches."""
         # NOTE: this is broken out, so that subclasses are able to override this
-        # to handle explicitly the situations where the lookup take had a miss vs
+        # to handle explicitly the situations where the lookup table had a miss vs
         # overriding the entire logic
         return super()._finalize_template_configs(
             template_choices,

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -483,7 +483,7 @@ class LoopBody:
 
     def is_memory_copy(self) -> bool:
         """
-        True of this contains only a single loads and store.
+        True if this contains only a single loads and store.
         Note, this could involve a layout change.
         """
         return (

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -192,7 +192,7 @@ def _prepare_convolution_fusion_create(
         output_stride: StrideType = FlexibleLayout.contiguous_strides(output_size)
     # Currently we don't support channel last for the situation that stride of input's batch dim is 0,
     # eg. input_size = (1, 1280, 64, 64), but input_stride=(0, 1, 81920, 1280).
-    # So we use NCHW hear instead.
+    # So we use NCHW here instead.
     # Different with cpu, cpu conv always use channels_last for convolution when weight is prepacked,
     # but xpu does not do the prepack, so the problem exposed here is only for xpu.
     # TODO support channels_last for such zero stride input.
@@ -457,7 +457,7 @@ class ConvolutionBinaryInplace(ExternKernelAlloc):
         inputs,
         constant_args=(),
     ) -> None:
-        # Due to constrain of op.call, other (Tensor&) should be at input[0]
+        # Due to constraint of op.call, other (Tensor&) should be at input[0]
         self.device_type = get_device_type(inputs[0])
         reordered_inputs = [inputs[1], inputs[0]] + inputs[2:]
 

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -50,7 +50,7 @@ def try_to_reduce_precision(
     replacement_vals: dict[Any, ValueRanges[sympy.Expr]],
 ) -> None:
     # if a downstream use of a node explicitly converts to int32, or float16/float32/float64,
-    # then it's precision is set for that chain of uses, and we don't need to consider those
+    # then its precision is set for that chain of uses, and we don't need to consider those
     # dominated values
     def skip_filter(node: Any) -> bool:
         return node.target == "to_dtype" and node.args[2] in (

--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -301,7 +301,7 @@ class RedisRemoteCacheBackend(RemoteCacheBackend[bytes]):
         # pyrefly: ignore [missing-attribute]
         except redis.exceptions.ConnectionError:
             # Redis is lazy and doesn't actually attempt to connect until the
-            # first use. Mark is as unavailable now.
+            # first use. Mark it as unavailable now.
             self._redis = None
             return None
 
@@ -322,7 +322,7 @@ class RedisRemoteCacheBackend(RemoteCacheBackend[bytes]):
         # pyrefly: ignore [missing-attribute]
         except redis.exceptions.ConnectionError:
             # Redis is lazy and doesn't actually attempt to connect until the
-            # first use. Mark is as unavailable now.
+            # first use. Mark it as unavailable now.
             self._redis = None
 
 

--- a/torch/ao/ns/fx/graph_passes.py
+++ b/torch/ao/ns/fx/graph_passes.py
@@ -122,7 +122,7 @@ def add_loggers_to_model(
                 ref_name, ref_node_type = node_to_instrument_inputs_to_ref_node_name[
                     node
                 ]
-                # Ops such add and mul are special because either
+                # Ops such as add and mul are special because either
                 # one or two of the first two arguments can be tensors,
                 # and if one argument is a tensor it can be first or
                 # second (x + 1 versus 1 + x).

--- a/torch/ao/ns/fx/pattern_utils.py
+++ b/torch/ao/ns/fx/pattern_utils.py
@@ -86,7 +86,7 @@ def get_reversed_fusions() -> list[tuple[NSFusionType, int]]:
             quant_pattern = (quant_pattern[0], quant_pattern[1][0], quant_pattern[1][1])
 
         # Only patterns of multiple ops are fusions, ignore
-        # patterns which contain a single ops (they get matched
+        # patterns which contain a single op (they get matched
         # without caring about fusions).
         if isinstance(quant_pattern, tuple):
             results.append((quant_pattern, default_base_op_idx))  # type: ignore[arg-type]

--- a/torch/ao/pruning/_experimental/data_scheduler/base_data_scheduler.py
+++ b/torch/ao/pruning/_experimental/data_scheduler/base_data_scheduler.py
@@ -90,7 +90,7 @@ class BaseDataScheduler:
     def get_schedule_param(self):
         r"""
         Abstract method that needs to be implemented by the child class.
-        The expected return type should is a dictionary of name to schedule_param value
+        The expected return type should be a dictionary of name to schedule_param value
         The returned values will be updated in sparsifier when the scheduler step() function
         is called.
 

--- a/torch/distributed/_composable/replicate.py
+++ b/torch/distributed/_composable/replicate.py
@@ -22,7 +22,7 @@ class _ReplicateState(_State):
         self.module: nn.Module = nn.ParameterList()
         self.has_initialized: bool = False
         self._param_list: nn.ParameterList = nn.ParameterList()
-        # TODO(@fegin): this variable is originally create for testing, we
+        # TODO(@fegin): this variable is originally created for testing, we
         # should remove this if possible.
         self._orig_module = self.module
         self._param_names: list[str] = []

--- a/torch/distributed/checkpoint/storage.py
+++ b/torch/distributed/checkpoint/storage.py
@@ -149,7 +149,7 @@ class StorageWriter(abc.ABC):
     @abc.abstractmethod
     def validate_checkpoint_id(cls, checkpoint_id: str | os.PathLike) -> bool:
         """
-        Check if the given checkpoint_id is supported by the storage. This allow
+        Check if the given checkpoint_id is supported by the storage. This allows
         us to enable automatic storage selection.
         """
         ...
@@ -173,7 +173,7 @@ class StorageReader(abc.ABC):
     in a distributed checkpoint. As part of initialization, each instance
     is told its role.
 
-    A subclass should expected the following sequence of calls by ``load_state_dict``:
+    A subclass should expect the following sequence of calls by ``load_state_dict``:
 
     0) (all ranks) set checkpoint_id if users pass a valid checkpoint_id.
     1) (all ranks) read_metadata()
@@ -282,7 +282,7 @@ class StorageReader(abc.ABC):
     @abc.abstractmethod
     def validate_checkpoint_id(cls, checkpoint_id: str | os.PathLike) -> bool:
         """
-        Check if the given checkpoint_id is supported by the storage. This allow
+        Check if the given checkpoint_id is supported by the storage. This allows
         us to enable automatic storage selection.
         """
         ...

--- a/torch/nn/utils/_expanded_weights/conv_utils.py
+++ b/torch/nn/utils/_expanded_weights/conv_utils.py
@@ -301,7 +301,7 @@ def unfold3d(
     dilation,
 ):
     r"""
-    Extract sliding local blocks from an batched input tensor.
+    Extract sliding local blocks from a batched input tensor.
 
     :class:`torch.nn.Unfold` only supports 4D inputs (batched image-like tensors).
     This method implements the same action for 5D inputs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Correct assorted spelling and grammar mistakes in comments and
docstrings across inductor, ao, distributed, and nn. No functional
changes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo