### PR TITLE
Import torch for triton jits (#190834)

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6821,8 +6821,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     @lru_cache(None)
     def gen_common_triton_imports(cls) -> str:
         imports = IndentedBuffer()
+        # torch import is required: user-defined triton kernels may carry torch.Tensor
+        # param annotations that are evaluated when the generated module is executed.
         imports.splice(
             """
+            import torch
             import triton
             import triton.language as tl
             """


### PR DESCRIPTION
Summary:

- python type checking codemods are adding type hints to methods
- our jit compiler is not including a torch import in the compiled methods
- this breaks lowering with a NameError
- here, I add that import
- this should be fine, since we have to import torch anyways to run most of these methods

Test Plan:
CI
----------------

standalone publish jobs:

before: f1115529920

after: f1115827180

Differential Revision: D113249795




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo