### PR TITLE
Document Node.next_functions graph edges

### DIFF
--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -73,6 +73,12 @@ class Node(abc.ABC):
     @property
     @abc.abstractmethod
     def next_functions(self) -> tuple[tuple[Optional["Node"], int], ...]:
+        r"""Return the edges from this node to its input functions.
+
+        Each entry is a ``(Node, int)`` pair. The node is ``None`` for an input
+        that does not require gradients. The integer is the output index of the
+        input function to which this edge connects.
+        """
         raise NotImplementedError
 
     @abc.abstractmethod


### PR DESCRIPTION
Fixes #171620

## AI assistance disclosure

> Codex drafted the following summary and test plan:
>
> `Node.next_functions` currently has no property documentation. This change documents each `(Node, int)` edge, including `None` for inputs that do not require gradients and the connected output index. It does not change runtime behavior.
>
> Test Plan:
>
> ```bash
> python agent_space/test_next_functions_doc.py
> python -m py_compile torch/autograd/graph.py
> spin fixlint torch/autograd/graph.py
> spin lint torch/autograd/graph.py
> git diff --check
> ```

i care about making code easier to understand. while reviewing the existing autograd test, i noticed that this small change could make next_functions clearer for future readers without affecting how it behaves.
