### PR TITLE
[Inductor] Fall back to ATen if GEMM autotuning OOMs at allocating buffers for benchmarking

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6336,8 +6336,41 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
         self, hint_override: int | None = None
     ) -> dict[ChoiceCaller, float]:
         if hint_override not in self._choice_timings:
-            self._choice_timings[hint_override] = self._choice_timings_fn(hint_override)
+            try:
+                self._choice_timings[hint_override] = self._choice_timings_fn(
+                    hint_override
+                )
+            except torch.OutOfMemoryError:
+                # Deferred autotuning OOMed allocating example tensors at scheduler
+                # time (peak memory). Fall back to the extern/ATen choice without
+                # benchmarking instead of failing compile.
+                self._choice_timings[hint_override] = self._autotune_oom_fallback()
         return self._choice_timings[hint_override]
+
+    def _autotune_oom_fallback(self) -> dict[ChoiceCaller, float]:
+        fallback = next(
+            (
+                choice
+                for choice in self._choices
+                if isinstance(
+                    choice, torch._inductor.select_algorithm.ExternKernelCaller
+                )
+            ),
+            None,
+        )
+        if fallback is None:
+            raise torch.OutOfMemoryError(
+                "Deferred GEMM autotuning ran out of memory and no ATen fallback "
+                "choice was available to skip benchmarking."
+            )
+        log.warning(
+            "CUDA OOM during deferred autotuning; skipping benchmarking and "
+            "falling back to %s.",
+            getattr(fallback, "name", fallback),
+        )
+        timings = {choice: float("inf") for choice in self._choices}
+        timings[fallback] = 0.0
+        return timings
 
     @contextlib.contextmanager
     def swap_as_triton_caller(self, caller: TritonTemplateCallerBase) -> Iterator[None]:

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -5393,14 +5393,42 @@ class AlgorithmSelectorCache(PersistentCache):
         hint_override: int | None = None,
         is_collective=False,
     ) -> dict[ChoiceCaller, float]:
-        inputs = cls.get_inputs(
-            choices, input_nodes, layout, input_gen_fns, hint_override=hint_override
-        )
+        try:
+            inputs = cls.get_inputs(
+                choices, input_nodes, layout, input_gen_fns, hint_override=hint_override
+            )
+        except torch.OutOfMemoryError:
+            # The example tensors are shared across all choices, so OOMing here
+            # dooms autotuning entirely. Fall back to the extern/ATen choice
+            # (always correct, no benchmarking needed) instead of failing compile.
+            return cls._autotune_oom_fallback(choices)
         return cls.benchmark_choices(
             choices,
             inputs,
             is_collective=is_collective,
         )
+
+    @classmethod
+    def _autotune_oom_fallback(
+        cls, choices: Sequence[ChoiceCaller]
+    ) -> dict[ChoiceCaller, float]:
+        fallback = next(
+            (choice for choice in choices if cls._is_extern(choice)),
+            None,
+        )
+        if fallback is None:
+            raise torch.OutOfMemoryError(
+                "Autotuning ran out of memory allocating benchmark inputs and no "
+                "ATen fallback choice was available to skip benchmarking."
+            )
+        log.warning(
+            "CUDA OOM while allocating autotuning inputs; skipping benchmarking "
+            "and falling back to %s.",
+            getattr(fallback, "name", fallback),
+        )
+        timings = {choice: float("inf") for choice in choices}
+        timings[fallback] = 0.0
+        return timings
 
     @classmethod
     def benchmark_in_sub_process(


### PR DESCRIPTION
Summary:
In-process GEMM autotuning allocates an example output buffer (via `torch.rand_strided`) to benchmark candidates. In certain cases, we OOM when there is no longer enough memory available to allocate the tensor for benchmarking, and that OOM is fatal without proper OOM handling.

The fix adds a `try/except` to fall back to ATen on OOM: benchmark when we have sufficient memory capacity, and fall back to ATen when the allocation can't fit within memory.

Differential Revision: D110090222




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo