### PR TITLE
[dynamo] Serialize symbolic storage sizes as executable Python (#190838)

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -1,5 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
+import ast
+import math
 import os
 from unittest.mock import patch
 
@@ -8,6 +10,7 @@ import torch._dynamo
 import torch._dynamo.config
 from torch._dynamo import debug_utils
 from torch._dynamo.debug_utils import (
+    _serialize_storage_nbytes,
     aot_graph_input_parser,
     generate_env_vars_string,
     NNModuleToString,
@@ -23,6 +26,64 @@ i32 = torch.int32
 
 
 class TestDebugUtils(TestCase):
+    def test_serialize_symbolic_storage_nbytes(self):
+        from sympy import floor
+
+        from torch._dynamo.source import ConstantSource
+        from torch.fx.experimental.sym_node import SymNode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+        from torch.utils._sympy.functions import Max
+
+        shape_env = ShapeEnv()
+        symbol = shape_env.create_symbol(4, ConstantSource("storage_size"))
+        expr = 4 * symbol + 18428 * Max(1, symbol)
+        nbytes = torch.SymInt(SymNode(expr, shape_env, int, hint=73728))
+        source = _serialize_storage_nbytes(nbytes)
+
+        self.assertNotIn("Max", source)
+        for value in (0, 1, 4):
+            self.assertEqual(
+                eval(source, {"max": max}, {str(symbol): value}),
+                int(expr.subs(symbol, value)),
+            )
+
+        floor_expr = floor(symbol / 2)
+        floor_nbytes = torch.SymInt(SymNode(floor_expr, shape_env, int, hint=2))
+        floor_source = _serialize_storage_nbytes(floor_nbytes)
+        self.assertIn("math.floor", floor_source)
+        self.assertEqual(
+            eval(floor_source, {"math": math}, {str(symbol): 4}),
+            2,
+        )
+
+    def test_repro_templates_import_symexpr_dependencies(self):
+        from torch._dynamo.repro.after_aot import generate_compiler_repro_string
+        from torch._dynamo.repro.after_dynamo import generate_dynamo_fx_repro_string
+
+        gm = torch.fx.symbolic_trace(lambda x: x + 1)
+        args = [torch.ones(1)]
+
+        repros = {
+            "after_aot": generate_compiler_repro_string(gm, args),
+            "after_dynamo": generate_dynamo_fx_repro_string(
+                gm, args, compiler_name="eager"
+            ),
+        }
+        for name, source in repros.items():
+            with self.subTest(name=name):
+                tree = ast.parse(source)
+                imports = ast.Module(
+                    body=[
+                        node
+                        for node in tree.body
+                        if isinstance(node, (ast.Import, ast.ImportFrom))
+                    ],
+                    type_ignores=[],
+                )
+                namespace = {}
+                exec(compile(imports, f"<{name}>", "exec"), namespace)
+                self.assertEqual(eval("math.floor(3 / 2)", namespace), 1)
+
     def test_cast_model_to_fp64_dtype_args(self):
         # Test that dtype arguments are converted to fp64
 

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -947,6 +947,14 @@ class InputReader:
 #     works too" but this is delicate so we don't do it
 
 
+def _serialize_storage_nbytes(nbytes: int | torch.SymInt) -> str:
+    if isinstance(nbytes, torch.SymInt):
+        from torch.fx.experimental.symbolic_shapes import SymExprPrinter
+
+        return SymExprPrinter().doprint(nbytes.node.expr)
+    return repr(nbytes)
+
+
 class InputWriter:
     def __init__(self, save_dir: str | None, *, stable_hash: bool = False) -> None:
         self._lines: list[str] = []
@@ -1003,11 +1011,12 @@ class InputWriter:
         if _device_or_default(None) != device:
             maybe_device = f", device={device!r}"
         nbytes = untyped_storage.nbytes()
+        nbytes_source = _serialize_storage_nbytes(nbytes)
         storage_hash = None
         if self.store is not None and untyped_storage.device.type != "meta":
             storage_hash = self.store.write_storage(untyped_storage)
         self._lines.append(
-            f"{v} = reader.storage({storage_hash!r}, {nbytes!r}{maybe_device}{maybe_dtype_hint})"
+            f"{v} = reader.storage({storage_hash!r}, {nbytes_source}{maybe_device}{maybe_dtype_hint})"
         )
         self.seen_storages[ws] = v
         return v

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -563,6 +563,7 @@ import torch
 from torch import tensor, device
 import torch.fx as fx
 from torch._dynamo.testing import rand_strided
+import math
 from math import inf
 import torch._inductor.inductor_prims
 {distributed_imports}

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -215,6 +215,7 @@ def generate_dynamo_fx_repro_string(
     return textwrap.dedent(
         f"""
 {generate_env_vars_string(stable_output=stable_output)}
+import math
 from math import inf
 import torch
 from torch import tensor, device


### PR DESCRIPTION
Summary:

- `InputWriter.storage()` previously embedded symbolic storage sizes using `repr()`, which could emit undefined function names such as `Max` into generated after-AOT repros. Executing the generated repro then failed while load_args() reconstructed its input storage:
```
  File "/tmp/model_extractor_manifold_sz1wgkm7/graph_41_bwd_recompile_1.py", line 1488, in load_args
    buf14 = reader.storage(None, 4*s35 + 18428*Max(1, s35), device=device(type='cuda', index=0))
                                               ^^^
NameError: name 'Max' is not defined. Did you mean: 'max'?

Failed to generate output_code.py for graph_41_bwd_recompile_1
```
- This diff serializes torch.SymInt storage sizes using the existing SymExprPrinter, producing executable Python while preserving the symbolic expression. Concrete storage sizes remain unchanged. It adds regression coverage for the production-derived Max expression

- SymExprPrinter can also emit math-qualified operations such as math.floor(), math.ceil(), and math.trunc(). The generated after-AOT and after-Dynamo templates now import math so these expressions execute in the generated module namespace.

 Newly generated repros now emit the same symbolic storage expression as executable Python:
  
   buf14 = reader.storage(
       None,
       4 * s35 + 18428 * max(1, s35),
       device=device(type="cuda", index=0),
   )
  
This preserves the symbolic relationship while avoiding the undefined SymPy Max name.

Test Plan:
`buck2 test fbcode//mode/opt fbcode//caffe2/test/dynamo:test_debug_utils`

`buck2 test fbcode//mode/opt fbcode//pytorch/tritonbench/tools/fb/model_extractor/tests:test_tlx_registry_compat fbcode//pytorch/tritonbench/tools/fb/model_extractor/tests:test_recompile_custom_ops`

Differential Revision: D113325636




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98