### PR TITLE
[Dynamo] Support SDPAParams construction in fullgraph

### DIFF
--- a/test/dynamo/test_sdpa.py
+++ b/test/dynamo/test_sdpa.py
@@ -1,22 +1,9 @@
 # Owner(s): ["module: dynamo"]
-import contextlib
-
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.testing import CompileCounter
-from torch.backends.cuda import SDPAParams
+from torch.backends.cuda import can_use_flash_attention, SDPAParams
 from torch.nn.attention import _cur_sdpa_kernel_backends, sdpa_kernel, SDPBackend
-
-
-@contextlib.contextmanager
-def allow_in_graph_sdpa_params():
-    global SDPAParams
-    try:
-        old = SDPAParams
-        SDPAParams = torch._dynamo.allow_in_graph(SDPAParams)
-        yield
-    finally:
-        SDPAParams = old
 
 
 class TestSDPA(torch._dynamo.test_case.TestCase):
@@ -27,78 +14,86 @@ class TestSDPA(torch._dynamo.test_case.TestCase):
         self.assertIs(actual.attn_mask, expected.attn_mask)
 
     def test_returns_SDPAParams(self):
-        with allow_in_graph_sdpa_params():
-            counter = CompileCounter()
+        counter = CompileCounter()
 
-            @torch.compile(fullgraph=True, backend=counter)
-            def fn(q, k, v, m):
-                return SDPAParams(q, k, v, m, 0.1, True, False)
+        @torch.compile(fullgraph=True, backend=counter)
+        def fn(q, k, v, m):
+            return SDPAParams(q, k, v, m, 0.1, True, False)
 
-            q = torch.randn(10)
-            k = torch.randn(10)
-            v = torch.randn(10)
-            m = torch.randn(10)
-            o = fn(q, k, v, m)
-            self.assertTrue(isinstance(o, SDPAParams))
-            self.assert_ref_equals_params(o, SDPAParams(q, k, v, m, 0.1, True, False))
-            self.assertEqual(counter.frame_count, 1)
+        q = torch.randn(10)
+        k = torch.randn(10)
+        v = torch.randn(10)
+        m = torch.randn(10)
+        o = fn(q, k, v, m)
+        self.assertTrue(isinstance(o, SDPAParams))
+        self.assert_ref_equals_params(o, SDPAParams(q, k, v, m, 0.1, True, False))
+        self.assertEqual(counter.frame_count, 1)
 
     def test_graph_break_SDPAParams(self):
-        with allow_in_graph_sdpa_params():
-            counter = CompileCounter()
+        counter = CompileCounter()
 
-            @torch.compile(backend=counter)
-            def fn(q, k, v, m):
-                z = SDPAParams(q, k, v, m, 0.1, True, False)
-                torch._dynamo.graph_break()
-                return z, q + 1
+        @torch.compile(backend=counter)
+        def fn(q, k, v, m):
+            z = SDPAParams(q, k, v, m, 0.1, True, False)
+            torch._dynamo.graph_break()
+            return z, q + 1
 
-            q = torch.randn(10)
-            k = torch.randn(10)
-            v = torch.randn(10)
-            m = torch.randn(10)
-            o, _ = fn(q, k, v, m)
-            self.assertTrue(isinstance(o, SDPAParams))
-            self.assert_ref_equals_params(o, SDPAParams(q, k, v, m, 0.1, True, False))
-            self.assertEqual(counter.frame_count, 2)
+        q = torch.randn(10)
+        k = torch.randn(10)
+        v = torch.randn(10)
+        m = torch.randn(10)
+        o, _ = fn(q, k, v, m)
+        self.assertTrue(isinstance(o, SDPAParams))
+        self.assert_ref_equals_params(o, SDPAParams(q, k, v, m, 0.1, True, False))
+        self.assertEqual(counter.frame_count, 2)
 
     def test_input_SDPAParams(self):
-        with allow_in_graph_sdpa_params():
-            counter = CompileCounter()
+        counter = CompileCounter()
 
-            @torch.compile(backend=counter)
-            def fn(sdpap, q):
-                torch._dynamo.graph_break()
-                return sdpap, sdpap.query + q
+        @torch.compile(backend=counter)
+        def fn(sdpap, q):
+            torch._dynamo.graph_break()
+            return sdpap, sdpap.query + q
 
-            q = torch.randn(10)
-            k = torch.randn(10)
-            v = torch.randn(10)
-            m = torch.randn(10)
-            s = SDPAParams(q, k, v, m, 0.1, True, False)
-            o, _ = fn(s, q)
-            self.assertIs(o, s)
-            self.assertEqual(counter.frame_count, 1)
+        q = torch.randn(10)
+        k = torch.randn(10)
+        v = torch.randn(10)
+        m = torch.randn(10)
+        s = SDPAParams(q, k, v, m, 0.1, True, False)
+        o, _ = fn(s, q)
+        self.assertIs(o, s)
+        self.assertEqual(counter.frame_count, 1)
 
     def test_intermediate_attr_access_SDPAParams(self):
-        with allow_in_graph_sdpa_params():
-            counter = CompileCounter()
+        counter = CompileCounter()
 
-            @torch.compile(fullgraph=True, backend=counter)
-            def fn(q, k, v, m):
-                q += 1
-                z = SDPAParams(q, k, v, m, 0.1, True, False)
-                a = z.query
-                return a + 1, z, q
+        @torch.compile(fullgraph=True, backend=counter)
+        def fn(q, k, v, m):
+            q += 1
+            z = SDPAParams(q, k, v, m, 0.1, True, False)
+            a = z.query
+            return a + 1, z, q
 
-            q = torch.randn(10)
-            k = torch.randn(10)
-            v = torch.randn(10)
-            m = torch.randn(10)
-            _, o, _ = fn(q, k, v, m)
-            expected = SDPAParams(q, k, v, m, 0.1, True, False)
-            self.assert_ref_equals_params(o, expected)
-            self.assertEqual(counter.frame_count, 1)
+        q = torch.randn(10)
+        k = torch.randn(10)
+        v = torch.randn(10)
+        m = torch.randn(10)
+        _, o, _ = fn(q, k, v, m)
+        expected = SDPAParams(q, k, v, m, 0.1, True, False)
+        self.assert_ref_equals_params(o, expected)
+        self.assertEqual(counter.frame_count, 1)
+
+    def test_can_use_flash_attention_no_graph_break(self):
+        counter = CompileCounter()
+
+        @torch.compile(fullgraph=True, backend=counter)
+        def fn(q, k, v):
+            return can_use_flash_attention(SDPAParams(q, k, v, None, 0.0, True, False))
+
+        q = torch.randn(2, 2, 8, 8)
+        expected = can_use_flash_attention(SDPAParams(q, q, q, None, 0.0, True, False))
+        self.assertEqual(fn(q, q, q), expected)
+        self.assertEqual(counter.frame_count, 1)
 
     def test_sdpa_c_functions_no_graph_break(self):
         counter = CompileCounter()

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -232,6 +232,7 @@ manual_torch_name_rule_map: dict[
     "torch.nn.utils.rnn.pad_packed_sequence": SkipFunctionVariable,
     "torch.nn.Parameter": TorchInGraphFunctionVariable,
     "torch.nn.Buffer": TorchInGraphFunctionVariable,
+    "torch.backends.cuda.SDPAParams": TorchInGraphFunctionVariable,
     "torch._nested_tensor_from_mask": SkipFunctionVariable,
     "torch.nested._internal.nested_tensor.nested_from_padded": TorchInGraphFunctionVariable,
     "torch.nested.nested_tensor_from_jagged": UserFunctionVariable,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1956,6 +1956,7 @@ class VariableBuilder:
                 torch.utils.hooks.BackwardHook,
                 torch.nn.Parameter,
                 torch.nn.Buffer,
+                torch.backends.cuda.SDPAParams,
             ):
                 # TODO(jansel): combine this case with the one above
                 # type: ignore[attr-defined]


### PR DESCRIPTION
Fixes #182684

## Why

- Constructing `SDPAParams` inside a compiled region graph-breaks under `fullgraph=True`: the pybind11 class is wrapped as a user-defined class, even though a construction handler already exists

## How

- Routes `torch.backends.cuda.SDPAParams` to `TorchInGraphFunctionVariable`, following the `torch.nn.Parameter` pattern
- Drops the `allow_in_graph` workaround in `test/dynamo/test_sdpa.py`, which is no longer needed

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98