### PR TITLE
[Test] Refactor test_dtensor.py to have hw_classification

### DIFF
--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -77,7 +77,7 @@ class DummyMLP(torch.nn.Module):
 
 
 class DTensorTest(DTensorTestBase):
-    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @with_comms
     def test_dtensor_constructor(self):
@@ -1012,7 +1012,7 @@ DTensorTestWithLocalTensor = create_local_tensor_test_class(
 
 
 class DTensorSubclassTest(DTensorTestBase):
-    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _make_dtensor(self, cls, mesh):
         base = DTensor.from_local(
@@ -1081,7 +1081,7 @@ class DTensorSubclassTest(DTensorTestBase):
 
 
 class DTensorMeshTest(DTensorTestBase):
-    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self):
@@ -1527,7 +1527,7 @@ DTensorMeshTestWithLocalTensor = create_local_tensor_test_class(
 
 
 class TestDTensorPlacementTypes(DTensorTestBase):
-    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self):
@@ -1598,7 +1598,7 @@ TestDTensorPlacementTypesWithLocalTensor = create_local_tensor_test_class(
 
 
 class TestDTensorSpec(DTensorTestBase):
-    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self):

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -38,7 +38,9 @@ from torch.distributed.tensor.parallel import (
 )
 from torch.distributed.tensor.placement_types import _StridedShard
 from torch.testing import make_tensor
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_FBCODE,
     run_tests,
     skipIfHpu,
@@ -75,6 +77,8 @@ class DummyMLP(torch.nn.Module):
 
 
 class DTensorTest(DTensorTestBase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+
     @with_comms
     def test_dtensor_constructor(self):
         device_mesh = self.build_device_mesh()
@@ -1008,6 +1012,8 @@ DTensorTestWithLocalTensor = create_local_tensor_test_class(
 
 
 class DTensorSubclassTest(DTensorTestBase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+
     def _make_dtensor(self, cls, mesh):
         base = DTensor.from_local(
             torch.randn(4, 4, device=self.device_type), mesh, [Replicate()]
@@ -1075,6 +1081,8 @@ class DTensorSubclassTest(DTensorTestBase):
 
 
 class DTensorMeshTest(DTensorTestBase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+
     @property
     def world_size(self):
         return 8
@@ -1425,7 +1433,7 @@ class DTensorMeshTest(DTensorTestBase):
                 placements=None,
             )
 
-        x = make_dtensor(1, 1, dtype=torch.bfloat16, device="cuda")
+        x = make_dtensor(1, 1, dtype=torch.bfloat16, device=self.device_type)
 
         # Fails with AssertionError: P1972527564
         torch.cond(
@@ -1519,6 +1527,8 @@ DTensorMeshTestWithLocalTensor = create_local_tensor_test_class(
 
 
 class TestDTensorPlacementTypes(DTensorTestBase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+
     @property
     def world_size(self):
         return 8
@@ -1588,6 +1598,8 @@ TestDTensorPlacementTypesWithLocalTensor = create_local_tensor_test_class(
 
 
 class TestDTensorSpec(DTensorTestBase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+
     @property
     def world_size(self):
         return 8
@@ -1841,6 +1853,8 @@ TestDTensorSpecWithLocalTensor = create_local_tensor_test_class(
 class TestMixedPartialTypes(TestCase):
     """Test that mixed Partial reduce types are rejected by all DTensor APIs."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         dist.init_process_group(backend="fake", rank=0, world_size=8, store=FakeStore())
@@ -1893,6 +1907,13 @@ class TestMixedPartialTypes(TestCase):
         )
         # no error
         redistribute_local_tensor(tensor, current_spec, target_spec)
+
+
+instantiate_device_type_tests(DTensorTest, globals())
+instantiate_device_type_tests(DTensorSubclassTest, globals())
+instantiate_device_type_tests(DTensorMeshTest, globals())
+instantiate_device_type_tests(TestDTensorPlacementTypes, globals())
+instantiate_device_type_tests(TestDTensorSpec, globals())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds `hw_classification` to all test classes in `test/distributed/tensor/test_dtensor.py`.

- DTensorTest, DTensorSubclassTest, DTensorMeshTest, TestDTensorPlacementTypes, TestDTensorSpec -> MULTI_ACCELERATOR. These derive from `DTensorTestBase `and use `@with_comms `to spawn real multi-rank process groups, resolving the backend at runtime via self.device_type (nccl/xccl/gloo). Hence MULTI_ACCELERATOR.
- TestMixedPartialTypes -> GENERIC. Only uses a single-process FakePG.
- Replaced a hardcoded device="cuda" in DTensorMeshTest with `device=self.device_type`.
- Added `instantiate_device_type_tests` for the five MULTI_ACCELERATOR classes.

## Test plan:
```bash
python test/distributed/tensor/test_dtensor.py -v
python test/distributed/tensor/test_dtensor.py --hw-classification GENERIC -v
python test/distributed/tensor/test_dtensor.py --hw-classification MULTI_ACCELERATOR -v
```
CC: @mansiag05 @vishalgoyal316 @RiyaP2508 