### PR TITLE
Add FlyDSL native RMSNorm forward override

### DIFF
--- a/test/python_native/test_flydsl_registry.py
+++ b/test/python_native/test_flydsl_registry.py
@@ -1,0 +1,16 @@
+# Owner(s): ["module: dsl-native-ops"]
+
+import torch
+import torch.backends.python_native as pn
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestFlyDSLRegistry(TestCase):
+    def test_flydsl_backend_is_exposed(self):
+        self.assertIsNotNone(torch)
+        self.assertIn("flydsl", pn.all_dsls)
+        self.assertTrue(hasattr(pn, "flydsl"))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_flydsl_rmsnorm_fwd.py
+++ b/test/python_native/test_flydsl_rmsnorm_fwd.py
@@ -1,0 +1,271 @@
+# Owner(s): ["module: dsl-native-ops"]
+
+import unittest
+
+import torch
+import torch.backends.python_native as pn
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+EPS = 1e-5
+DISPATCH_M = 8192
+DISPATCH_N = 4096
+DISPATCH_DTYPE = torch.float16
+
+
+def _flydsl_rmsnorm_registered() -> bool:
+    try:
+        operations = set(pn.get_dsl_operations("flydsl"))
+        return "_fused_rms_norm" in operations
+    except Exception:
+        return False
+
+
+def _tolerance(dtype: torch.dtype) -> tuple[float, float]:
+    return {
+        torch.float32: (1e-4, 1e-3),
+        torch.float16: (3e-2, 3e-2),
+        torch.bfloat16: (1e-1, 2e-1),
+    }[dtype]
+
+
+def _assert_close(test_case, actual, expected, dtype):
+    rtol, atol = _tolerance(dtype)
+    test_case.assertEqual(actual.shape, expected.shape)
+    test_case.assertEqual(actual, expected, rtol=rtol, atol=atol)
+
+
+@unittest.skipUnless(TEST_CUDA and torch.version.hip is not None, "ROCm required")
+@unittest.skipUnless(
+    _flydsl_rmsnorm_registered(), "FlyDSL RMSNorm overrides are not registered"
+)
+class TestFlyDSLRMSNorm(TestCase):
+    def setUp(self):
+        super().setUp()
+        from torch._native.ops.norm.flydsl_rmsnorm_fwd import clear_rmsnorm_caches
+
+        clear_rmsnorm_caches()
+        torch.manual_seed(0)
+
+    def _make_inputs(self, m, n, dtype, *, requires_grad=False):
+        x = torch.randn((m, n), device="cuda", dtype=dtype, requires_grad=requires_grad)
+        weight = torch.randn(
+            (n,), device="cuda", dtype=dtype, requires_grad=requires_grad
+        )
+        return x, weight
+
+    def _make_dispatch_inputs(self):
+        return self._make_inputs(DISPATCH_M, DISPATCH_N, DISPATCH_DTYPE)
+
+    def _assert_no_flydsl_compiles(self):
+        from torch._native.ops.norm.flydsl_rmsnorm_fwd import rmsnorm_cache_info
+
+        self.assertEqual(rmsnorm_cache_info()["fwd"].misses, 0)
+
+    def test_backward_through_override_matches_aten(self):
+        # The override sits at the CUDA key, below Autograd, so ATen's
+        # _fused_rms_norm_backward_cuda consumes the rstd this kernel writes:
+        # fp32, shaped (*batch, 1). A drift in that contract shows up as wrong
+        # gradients rather than an error, and OpInfo's test_backward only runs
+        # fp32, so fp16/bf16 -- where the fp32 rstd meets a lower-precision
+        # input -- would otherwise go unchecked.
+        from torch._native.ops.norm.flydsl_rmsnorm_fwd import (
+            clear_rmsnorm_caches,
+            rmsnorm_cache_info,
+        )
+
+        for dtype in (torch.float16, torch.bfloat16, torch.float32):
+            with self.subTest(dtype=dtype):
+                clear_rmsnorm_caches()
+                x, weight = self._make_inputs(
+                    DISPATCH_M, DISPATCH_N, dtype, requires_grad=True
+                )
+                grad_out = torch.randn_like(x)
+
+                def grads():
+                    out = torch.rms_norm(x, (DISPATCH_N,), weight, EPS)
+                    return torch.autograd.grad(out, (x, weight), grad_out)
+
+                with pn.flydsl.disabled():
+                    ref_dx, ref_dw = grads()
+                self._assert_no_flydsl_compiles()
+
+                got_dx, got_dw = grads()
+                self.assertEqual(rmsnorm_cache_info()["fwd"].misses, 1)
+                _assert_close(self, got_dx, ref_dx, dtype)
+                _assert_close(self, got_dw, ref_dw, dtype)
+
+    def test_direct_forward_matches_aten_and_reuses_cache(self):
+        from torch._native.ops.norm.flydsl_rmsnorm_fwd import (
+            rmsnorm_cache_info,
+            rmsnorm_fwd,
+        )
+
+        x, weight = self._make_inputs(16, 128, torch.float16)
+        with pn.flydsl.disabled():
+            ref_out, _ = torch.ops.aten._fused_rms_norm(x, [128], weight, EPS)
+
+        out, rstd = rmsnorm_fwd(x, [128], weight, EPS)
+        self.assertEqual(rstd.dtype, torch.float32)
+        self.assertEqual(rstd.shape, (16, 1))
+        self.assertEqual(rstd.device, x.device)
+        _assert_close(self, out, ref_out, x.dtype)
+
+        # A 3-D input with the same N/dtype/device must hit the same dynamic-M
+        # specialization instead of compiling a second kernel.
+        x3 = torch.randn((2, 16, 128), device="cuda", dtype=x.dtype)
+        out3, _ = rmsnorm_fwd(x3, [128], weight, EPS)
+        self.assertEqual(out3.shape, x3.shape)
+
+        info = rmsnorm_cache_info()["fwd"]
+        self.assertEqual(info.misses, 1)
+        self.assertGreaterEqual(info.hits, 1)
+        self.assertEqual(info.currsize, 1)
+
+    def test_numerics_across_kernel_paths_and_block_sizes(self):
+        # OpInfo covers the shapes the dispatcher accepts in the common case;
+        # this walks the kernel's internal branches instead, which OpInfo has
+        # no way to target. Each N is chosen for a specific one:
+        #
+        #   4096   fast path, 256 threads
+        #   12288  fast path, 512 threads (_forward_block_threads boundary)
+        #   24576  fast path, 1024 threads (second boundary)
+        #   114688 fast path, upper end of the dispatcher's N range
+        #
+        # The rest are odd, so N % vec_width != 0 for both vector widths (8 for
+        # fp16/bf16, 4 for fp32) and they take the generic path's scalar tail.
+        # 4097/8193/16385/32769 are the shapes the PR reports the largest wins
+        # on, so the tail is the branch those numbers actually come from. Those
+        # all leave exactly one element in the tail; 4103 leaves seven (three
+        # for fp32) so the tail's own bounds check is exercised too.
+        #
+        # Rows are kept small and rmsnorm_fwd is called directly: this is about
+        # the reduction being right, not about dispatch.
+        from torch._native.ops.norm.flydsl_rmsnorm_fwd import rmsnorm_fwd
+
+        rows = 8
+        fast_path = (4096, 12288, 24576, 114688)
+        scalar_tail = (4097, 4103, 8193, 16385, 32769, 98305)
+        for dtype in (torch.float16, torch.bfloat16, torch.float32):
+            for n in fast_path + scalar_tail:
+                with self.subTest(dtype=dtype, n=n):
+                    x, weight = self._make_inputs(rows, n, dtype)
+                    with pn.flydsl.disabled():
+                        ref, ref_rstd = torch.ops.aten._fused_rms_norm(
+                            x, [n], weight, EPS
+                        )
+                    got, got_rstd = rmsnorm_fwd(x, [n], weight, EPS)
+
+                    _assert_close(self, got, ref, dtype)
+                    self.assertEqual(got_rstd.dtype, torch.float32)
+                    self.assertEqual(got_rstd.shape, (rows, 1))
+                    # rstd is the reduction result itself, so it is compared at
+                    # fp32 tolerance regardless of the input dtype.
+                    self.assertEqual(got_rstd, ref_rstd, rtol=1e-5, atol=1e-6)
+
+    def test_public_rms_norm_dispatches_to_flydsl(self):
+        from torch._native.ops.norm.flydsl_rmsnorm_fwd import rmsnorm_cache_info
+
+        x, weight = self._make_dispatch_inputs()
+        with pn.flydsl.disabled():
+            ref = torch.rms_norm(x, (DISPATCH_N,), weight, EPS)
+        got = torch.rms_norm(x, (DISPATCH_N,), weight, EPS)
+
+        _assert_close(self, got, ref, x.dtype)
+        self.assertEqual(rmsnorm_cache_info()["fwd"].misses, 1)
+
+    def test_runtime_eps_dispatches_and_reuses_cache(self):
+        from torch._native.ops.norm.flydsl_rmsnorm_fwd import rmsnorm_cache_info
+
+        x, weight = self._make_dispatch_inputs()
+        for eps in (EPS, 1e-6):
+            with pn.flydsl.disabled():
+                ref = torch.rms_norm(x, (DISPATCH_N,), weight, eps)
+            got = torch.rms_norm(x, (DISPATCH_N,), weight, eps)
+            _assert_close(self, got, ref, x.dtype)
+
+        info = rmsnorm_cache_info()["fwd"]
+        self.assertEqual(info.misses, 1)
+        self.assertGreaterEqual(info.hits, 1)
+        self.assertEqual(info.currsize, 1)
+
+    def test_n_above_upper_bound_falls_back_without_compiling(self):
+        # 114688 is the largest N the perf table accepts; the row cache spills
+        # to scratch beyond it and the kernel loses to ATen.
+        n = 131072
+        x = torch.randn((2048, n), device="cuda", dtype=DISPATCH_DTYPE)
+        weight = torch.randn((n,), device="cuda", dtype=DISPATCH_DTYPE)
+
+        with pn.flydsl.disabled():
+            ref = torch.rms_norm(x, (n,), weight, EPS)
+        got = torch.rms_norm(x, (n,), weight, EPS)
+
+        self.assertEqual(got, ref)
+        self._assert_no_flydsl_compiles()
+
+    def test_fused_aten_noncontiguous_input_falls_back_without_compiling(self):
+        base = torch.randn(
+            (DISPATCH_N, DISPATCH_M), device="cuda", dtype=DISPATCH_DTYPE
+        )
+        x = base.transpose(0, 1)
+        self.assertFalse(x.is_contiguous())
+        weight = torch.randn((DISPATCH_N,), device="cuda", dtype=x.dtype)
+
+        with pn.flydsl.disabled():
+            ref = torch.rms_norm(x, (DISPATCH_N,), weight, EPS)
+        got = torch.rms_norm(x, (DISPATCH_N,), weight, EPS)
+
+        self.assertEqual(got, ref)
+        self._assert_no_flydsl_compiles()
+
+    def test_misaligned_base_dispatches_and_matches_aten(self):
+        from torch._native.ops.norm.flydsl_rmsnorm_fwd import (
+            clear_rmsnorm_caches,
+            rmsnorm_cache_info,
+        )
+
+        # Both dtypes issue 128-bit copies (fp32 4x32, fp16 8x16), so both hit
+        # the kernel with a base address that is not 16-byte aligned.
+        for dtype in (torch.float16, torch.float32):
+            with self.subTest(dtype=dtype):
+                clear_rmsnorm_caches()
+                storage = torch.randn(
+                    (DISPATCH_M * DISPATCH_N + 1,), device="cuda", dtype=dtype
+                )
+                weight_storage = torch.randn(
+                    (DISPATCH_N + 1,), device="cuda", dtype=dtype
+                )
+                x = storage[1:].view(DISPATCH_M, DISPATCH_N)
+                weight = weight_storage[1:]
+                self.assertTrue(x.is_contiguous())
+                self.assertNotEqual(x.data_ptr() % 16, 0)
+                self.assertNotEqual(weight.data_ptr() % 16, 0)
+
+                with pn.flydsl.disabled():
+                    ref = torch.rms_norm(x, (DISPATCH_N,), weight, EPS)
+                got = torch.rms_norm(x, (DISPATCH_N,), weight, EPS)
+
+                _assert_close(self, got, ref, dtype)
+                self.assertEqual(rmsnorm_cache_info()["fwd"].misses, 1)
+
+    def test_user_disable_falls_back_and_restores(self):
+        from torch._native.ops.norm.flydsl_rmsnorm_fwd import rmsnorm_cache_info
+
+        # A shape the dispatcher would otherwise take, so being disabled is the
+        # only reason nothing compiles inside the block.
+        x, weight = self._make_dispatch_inputs()
+
+        with pn.flydsl.disabled():
+            ref = torch.rms_norm(x, (DISPATCH_N,), weight, EPS)
+            self._assert_no_flydsl_compiles()
+
+        # Leaving the block must re-enable the override, so this call is the
+        # FlyDSL kernel and the comparison against ref is aten vs FlyDSL.
+        got = torch.rms_norm(x, (DISPATCH_N,), weight, EPS)
+        _assert_close(self, got, ref, x.dtype)
+        self.assertEqual(rmsnorm_cache_info()["fwd"].misses, 1)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_instrumentation.py
+++ b/test/python_native/test_instrumentation.py
@@ -565,6 +565,16 @@ _DSL_INSTRUMENTATION_RULES = (
         "instrument_cutedsl_compile",
         "instrumented_cutedsl_cache",
     ),
+    # FlyDSL's cache decorator is also named jit_cache, so a compile site that
+    # stacks it manually is indistinguishable from a CuTeDSL one by name alone
+    # and would be reported against the rule above. Only the combined
+    # decorator is listed here; FlyDSL kernels are expected to use it.
+    (
+        "flydsl",
+        "instrumented_flydsl_cache",
+        "instrument_flydsl_compile",
+        "instrumented_flydsl_cache",
+    ),
     (
         "helion",
         ("helion.kernel", "helion.jit", "helion.experimental.aot_kernel"),

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -165,7 +165,7 @@ class TestNativeDSLOps(TestCase):
         script = textwrap.dedent("""\
             import sys
             import torch
-            dsl_modules = ["triton", "cutlass", "tvm_ffi", "helion"]
+            dsl_modules = ["triton", "cutlass", "tvm_ffi", "helion", "flydsl"]
             leaked = [m for m in dsl_modules if m in sys.modules]
             print(repr(leaked))
         """)

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -423,9 +423,13 @@ class TestPublicBindings(TestCase):
                 "torch._vendor.quack",
                 "torch.profiler._cupti.",
             )
+            dsl_names = ("triton", "flydsl")
             if (
                 mod in private_allowlist
-                or (mod.startswith("torch._native.ops.") and "triton" in mod)
+                or (
+                    mod.startswith("torch._native.ops.")
+                    and any(dsl in mod for dsl in dsl_names)
+                )
                 or mod.startswith(cuda_dep_prefixes)
             ):
                 if self._is_mod_public(mod):

--- a/torch/_native/__init__.py
+++ b/torch/_native/__init__.py
@@ -5,7 +5,15 @@ from typing import cast
 
 # This handles collecting registration of all native ops
 # Also need to import DSL utils to make sure DSL registration is ok
-from . import cutedsl_utils, dsl_registry, helion_utils, ops, registry, triton_utils
+from . import (
+    cutedsl_utils,
+    dsl_registry,
+    flydsl_utils,
+    helion_utils,
+    ops,
+    registry,
+    triton_utils,
+)
 
 
 @cache

--- a/torch/_native/flydsl_cache.py
+++ b/torch/_native/flydsl_cache.py
@@ -1,0 +1,93 @@
+"""In-process specialization cache for FlyDSL native-op compile wrappers.
+
+FlyDSL already owns the heavy compiler artifact cache, including its persistent
+on-disk entries. PyTorch still benefits from a tiny native-op level cache: it
+keeps the ``flyc.compile(...)`` result for a specialization such as
+``(hidden_size, dtype, arch, backend)`` so repeated operator calls can skip
+rebuilding the launcher and re-entering FlyDSL's compile path.
+
+This mirrors the call shape of Quack/CuteDSL's ``@jit_cache`` while deliberately
+not copying its persistent ``.o`` cache behavior.
+"""
+
+# mypy: allow-untyped-defs
+
+from __future__ import annotations
+
+import functools
+from collections import namedtuple
+from threading import Lock
+
+
+CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "currsize"])
+
+
+class _JitCacheWrapper:
+    """Cache a compile function whose explicit arguments are specialization keys.
+
+    ``compile_args`` is a reserved keyword for cache-miss-only sample inputs such
+    as tensors or streams that ``flyc.compile`` needs to infer ABI metadata.
+    Those values are intentionally excluded from the cache key.
+    """
+
+    def __init__(self, fn):
+        functools.update_wrapper(self, fn)
+        self._fn = fn
+        self._cache = {}
+        self._lock = Lock()
+        self._hits = 0
+        self._misses = 0
+
+    def __call__(self, *args, **kwargs):
+        if not kwargs:
+            compile_args = None
+            cache_key = args
+        elif len(kwargs) == 1 and "compile_args" in kwargs:
+            compile_args = kwargs["compile_args"]
+            cache_key = args
+            kwargs = {}
+        else:
+            kwargs = dict(kwargs)
+            compile_args = kwargs.pop("compile_args", None)
+            cache_key = args + tuple(sorted(kwargs.items())) if kwargs else args
+
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            self._hits += 1
+            return cached
+
+        with self._lock:
+            cached = self._cache.get(cache_key)
+            if cached is not None:
+                self._hits += 1
+                return cached
+
+            self._misses += 1
+            if compile_args is None:
+                compiled = self._fn(*args, **kwargs)
+            else:
+                compiled = self._fn(*args, compile_args=compile_args, **kwargs)
+            self._cache[cache_key] = compiled
+            return compiled
+
+    def cache_clear(self) -> None:
+        with self._lock:
+            self._cache.clear()
+            self._hits = 0
+            self._misses = 0
+
+    def cache_info(self) -> CacheInfo:
+        with self._lock:
+            return CacheInfo(self._hits, self._misses, len(self._cache))
+
+
+def jit_cache(fn):
+    """Decorate a FlyDSL compile helper using its explicit args as the key.
+
+    The decorated function should take stable specialization parameters as its
+    normal arguments. Runtime sample objects can be passed by callers through the
+    reserved ``compile_args=...`` keyword; they are forwarded only on cache miss
+    and do not participate in keying.
+    """
+
+    return _JitCacheWrapper(fn)

--- a/torch/_native/flydsl_utils.py
+++ b/torch/_native/flydsl_utils.py
@@ -1,0 +1,206 @@
+"""Runtime and dispatcher helpers for optional FlyDSL native operators."""
+
+import functools
+import logging
+import sys
+from importlib.machinery import PathFinder as _PathFinder
+from importlib.util import find_spec as _find_spec
+from os import environ as _environ
+from typing import cast
+
+from torch._vendor.packaging.version import Version
+
+from ..backends import cuda as _cuda
+from .common_utils import (
+    _available_version,
+    check_native_jit_disabled,
+    check_native_version_skip,
+)
+from .dsl_registry import dsl_registry, DSLModuleProtocol
+from .registry import (
+    _OpCondFn,
+    _OpImplFn,
+    deregister_op_overrides as _deregister_op_overrides_impl,
+    register_op_override as _register_op_override_impl,
+)
+
+
+log = logging.getLogger(__name__)
+
+_FLYDSL_DSL_NAME = "flydsl"
+
+# The vendored kernels are validated against the FlyDSL 0.3.0 API. 0.3.0
+# removed flydsl.expr.vector, which the RMSNorm kernel imported from, so
+# earlier versions cannot load it at all. They fall back to ATen unless a
+# developer explicitly sets TORCH_NATIVE_SKIP_VERSION_CHECK=1.
+_FLYDSL_MINIMUM_VERSION = Version("0.3.0")
+
+
+def _flydsl_runtime_unavailable_reason() -> None | str:
+    flydsl_spec = _find_spec("flydsl")
+    if flydsl_spec is None or flydsl_spec.submodule_search_locations is None:
+        return "missing optional dependency `flydsl`"
+
+    # Looking up ``flydsl._mlir`` directly imports the parent package. Search
+    # the package paths instead so ``import torch`` remains fork-safe and lazy.
+    mlir_spec = _PathFinder.find_spec(
+        "_mlir", list(flydsl_spec.submodule_search_locations)
+    )
+    if mlir_spec is None:
+        return "missing optional dependency `flydsl._mlir` (runtime is not built)"
+    return None
+
+
+def _normalized_shape_1d(normalized_shape) -> int | None:
+    """Return N for one-dimensional normalization, or None if unsupported."""
+
+    if isinstance(normalized_shape, int):
+        return normalized_shape
+    if isinstance(normalized_shape, (tuple, list)):
+        if len(normalized_shape) != 1:
+            return None
+        try:
+            return int(normalized_shape[0])
+        except (TypeError, ValueError):
+            return None
+
+    try:
+        shape = tuple(int(x) for x in normalized_shape)
+    except TypeError:
+        try:
+            shape = (int(normalized_shape),)
+        except (TypeError, ValueError):
+            return None
+    except ValueError:
+        return None
+    return shape[0] if len(shape) == 1 else None
+
+
+@functools.cache
+def _check_runtime_available() -> tuple[bool, Version | None]:
+    """Check FlyDSL availability without importing or initializing the GPU."""
+
+    if not _cuda.is_built():
+        return False, None
+
+    import torch
+
+    if torch.version.hip is None:
+        return False, None
+
+    reason = _flydsl_runtime_unavailable_reason()
+    if reason is not None:
+        log.info("FlyDSL native operators are disabled: %s", reason)
+        return False, None
+    return True, _available_version("flydsl")
+
+
+def runtime_available() -> bool:
+    available, _ = _check_runtime_available()
+    return available
+
+
+def runtime_version() -> Version | None:
+    _, version = _check_runtime_available()
+    return version
+
+
+@functools.cache
+def _version_is_ok() -> bool:
+    _, version = _check_runtime_available()
+    if check_native_version_skip():
+        return True
+    # Compare on base_version so dev builds count as their target release.
+    # FlyDSL currently ships as dev tags (0.3.0.dev765 at the time of writing),
+    # and PEP 440 sorts those below 0.3.0, so a plain >= would reject them.
+    if version is not None and Version(version.base_version) >= _FLYDSL_MINIMUM_VERSION:
+        return True
+
+    log.info(
+        "FlyDSL version %s is not sufficient (>= %s); "
+        "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
+        version,
+        _FLYDSL_MINIMUM_VERSION,
+    )
+    return False
+
+
+def _arch_from_hsa_override(value: str) -> str | None:
+    """Parse HSA_OVERRIDE_GFX_VERSION, which is either a gfx name or M.m.s.
+
+    The stepping is hexadecimal: 9.0.10 is gfx90a, not gfx9010.
+    """
+    if value.startswith("gfx"):
+        return value.split(":", 1)[0]
+    parts = value.split(".")
+    if len(parts) != 3:
+        return None
+    major, minor, stepping = parts
+    try:
+        return f"gfx{major}{minor}{int(stepping):x}"
+    except ValueError:
+        log.debug("Ignoring invalid HSA_OVERRIDE_GFX_VERSION=%s", value)
+        return None
+
+
+@functools.lru_cache
+def _resolve_rocm_arch(device_index: int) -> str:
+    """Return the gfx name FlyDSL should compile for on ``device_index``.
+
+    Shared so the eager overrides and the Inductor FlyDSL templates cannot
+    disagree about what they are compiling for -- they run in different
+    processes and only one of them can import flydsl, so neither can rely on
+    the runtime's own resolver. Deliberately reads only the environment and
+    torch's device properties.
+    """
+    env = _environ.get("FLYDSL_GPU_ARCH")
+    if env:
+        return env.split(":", 1)[0]
+
+    hsa = _environ.get("HSA_OVERRIDE_GFX_VERSION")
+    if hsa:
+        arch = _arch_from_hsa_override(hsa)
+        if arch is not None:
+            return arch
+
+    import torch
+
+    # gcnArchName carries feature flags, e.g. "gfx950:sramecc+:xnack-".
+    return torch.cuda.get_device_properties(device_index).gcnArchName.split(":", 1)[0]
+
+
+def deregister_op_overrides() -> None:
+    """Temporarily deregister all FlyDSL overrides."""
+
+    _deregister_op_overrides_impl(disable_dsl_names=_FLYDSL_DSL_NAME)
+
+
+def register_op_override(
+    lib_symbol: str,
+    op_symbol: str,
+    dispatch_key: str,
+    cond: _OpCondFn | None,
+    impl: _OpImplFn,
+    *,
+    allow_multiple_override: bool = False,
+    unconditional_override: bool = False,
+) -> None:
+    """Register an override only when the known-good FlyDSL runtime exists."""
+
+    available, _ = _check_runtime_available()
+    if not available or check_native_jit_disabled() or not _version_is_ok():
+        return
+
+    _register_op_override_impl(
+        _FLYDSL_DSL_NAME,
+        lib_symbol,
+        op_symbol,
+        dispatch_key,
+        cond,
+        impl,
+        allow_multiple_override=allow_multiple_override,
+        unconditional_override=unconditional_override,
+    )
+
+
+dsl_registry.register_dsl("flydsl", cast(DSLModuleProtocol, sys.modules[__name__]))

--- a/torch/_native/instrumentation.py
+++ b/torch/_native/instrumentation.py
@@ -30,6 +30,11 @@ counter advanced. They differ only in how a snapshot is sampled:
   ``cute.compile``, so the measured wall time *is* the compile time;
   otherwise the key was served from the in-memory or on-disk ``.o`` cache.
 
+* :func:`instrument_flydsl_compile` -- for FlyDSL, stacked *above* the
+  vendored ``@jit_cache`` decorator, exactly like the CuTeDSL entry point.
+  FlyDSL's cache wrapper exposes the same ``cache_info()`` shape, so the two
+  share a sampler and differ only in the reported DSL name.
+
 * :func:`instrument_triton_kernel` -- for Triton ``@triton.jit`` kernels,
   which compile *and* launch in one ``kernel[grid](...)`` call and keep
   their own per-kernel cache (``JITFunction.device_caches``). Stacked above
@@ -295,6 +300,28 @@ def instrument_cutedsl_compile(
     return decorator
 
 
+def instrument_flydsl_compile(
+    op: str,
+    *,
+    key_fn: Callable[..., str] | None = None,
+) -> Callable[[Callable[..., R]], Callable[..., R]]:
+    """Instrument a FlyDSL (``@jit_cache``-decorated) compile function.
+
+    Same contract as :func:`instrument_cutedsl_compile`, including the
+    forwarding of the cache attributes, which callers use to clear the cache
+    and read its counters. Only the DSL name reported in the event differs.
+    """
+
+    def decorator(fn: Callable[..., R]) -> Callable[..., R]:
+        wrapper = _make_wrapper(fn, op, "flydsl", key_fn, _cache_info_sampler(fn))
+        for attr in ("cache", "cache_clear", "cache_info"):
+            if hasattr(fn, attr):
+                setattr(wrapper, attr, getattr(fn, attr))
+        return wrapper
+
+    return decorator
+
+
 def _triton_cache_size(kernel: Any) -> int | None:
     """Compiled-variant count across one JITFunction's per-device caches.
 
@@ -485,6 +512,30 @@ def instrumented_cutedsl_cache(
 
     def decorator(fn: Callable[..., R]) -> Callable[..., R]:
         return instrument_cutedsl_compile(op, key_fn=key_fn)(jit_cache(fn))
+
+    return decorator
+
+
+def instrumented_flydsl_cache(
+    op: str,
+    *,
+    key_fn: Callable[..., str] | None = None,
+) -> Callable[[Callable[..., R]], Callable[..., R]]:
+    """Cache + instrument a FlyDSL compile function in one decorator::
+
+        @instrumented_flydsl_cache("aten::_fused_rms_norm")
+        def _compile_rmsnorm_fwd(n, dtype, arch, ...):
+            return flyc.compile(...)
+
+    Equivalent to ``instrument_flydsl_compile(op)`` stacked above
+    ``@jit_cache``. Preferred over that stack because ``jit_cache`` is also the
+    name CuTeDSL's vendored cache goes by, and the instrumentation coverage
+    scan attributes compile sites by decorator name.
+    """
+    from torch._native.flydsl_cache import jit_cache
+
+    def decorator(fn: Callable[..., R]) -> Callable[..., R]:
+        return instrument_flydsl_compile(op, key_fn=key_fn)(jit_cache(fn))
 
     return decorator
 

--- a/torch/_native/ops/norm/__init__.py
+++ b/torch/_native/ops/norm/__init__.py
@@ -1,4 +1,8 @@
+from .flydsl_rmsnorm_impl import (
+    register_op_override as register_flydsl_rmsnorm_overrides,
+)
 from .rmsnorm_impl import register_rmsnorm_overrides
 
 
+register_flydsl_rmsnorm_overrides()
 register_rmsnorm_overrides()

--- a/torch/_native/ops/norm/flydsl_rmsnorm_fwd.py
+++ b/torch/_native/ops/norm/flydsl_rmsnorm_fwd.py
@@ -1,0 +1,424 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Vendored FlyDSL plain RMSNorm forward kernel and PyTorch wrapper."""
+
+import math
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import const_expr, gpu, math as fmath, range_constexpr, ReductionOp
+from flydsl.runtime.device import is_rdna_arch
+
+import torch
+from torch._native.flydsl_utils import _normalized_shape_1d, _resolve_rocm_arch
+from torch._native.instrumentation import instrumented_flydsl_cache
+
+
+_SUPPORTED_DTYPES: dict[torch.dtype, str] = {
+    torch.float32: "f32",
+    torch.float16: "f16",
+    torch.bfloat16: "bf16",
+}
+_COMPILE_BACKEND_NAME = flyc.compile_backend_name()
+BLOCK_THREADS = 256
+VEC_WIDTH = 8
+
+
+def get_warp_size(arch: str) -> int:
+    """Return wave64 for CDNA GPUs and wave32 for RDNA GPUs."""
+    return 32 if is_rdna_arch(arch) else 64
+
+
+def _make_single_reduction_storage(red_slots: int):
+    """Shared storage for one block-reduction accumulator."""
+
+    @fx.struct
+    class SharedStorage:
+        s_red: fx.Array[fx.Float32, red_slots, 16]
+
+    return SharedStorage
+
+
+def dtype_to_elem_type(dtype_str: str):
+    """Map the three supported PyTorch dtype strings to FlyDSL types."""
+    if dtype_str == "f32":
+        return fx.Float32
+    if dtype_str == "f16":
+        return fx.Float16
+    if dtype_str == "bf16":
+        return fx.BFloat16
+    raise ValueError(
+        f"unsupported dtype: {dtype_str!r} (expected 'f32', 'f16', or 'bf16')"
+    )
+
+
+def _load_vec(copy_atom, vec_width, elem_dtype, div_tensor, idx):
+    r = fx.make_rmem_tensor(vec_width, elem_dtype)
+    fx.copy_atom_call(copy_atom, div_tensor[None, idx], r)
+    return r.load()
+
+
+def _store_vec(copy_atom, vec_width, elem_dtype, val, div_tensor, idx):
+    r = fx.make_rmem_tensor(vec_width, elem_dtype)
+    r.store(val)
+    fx.copy_atom_call(copy_atom, r, div_tensor[None, idx])
+
+
+def _to_elem(dtype_str: str, elem_dtype, y):
+    if const_expr(dtype_str == "f32"):
+        return y
+    return y.to(elem_dtype)
+
+
+def _dtype_str(dtype: torch.dtype) -> str:
+    try:
+        return _SUPPORTED_DTYPES[dtype]
+    except KeyError as exc:
+        raise TypeError(f"unsupported RMSNorm dtype for FlyDSL: {dtype}") from exc
+
+
+def _forward_block_threads(n: int) -> int:
+    if n >= 24576:
+        return 1024
+    if n >= 12288:
+        return 512
+    return BLOCK_THREADS
+
+
+def build_rmsnorm_module(
+    N: int,
+    dtype_str: str,
+    arch: str,
+):
+    # Baked into the kernel below, so it must come from the arch this module is
+    # compiled for -- not from whichever device happened to be current at
+    # import time. A wave64 reduction on a wave32 device is silently wrong.
+    WARP_SIZE = get_warp_size(arch)
+
+    block_threads = _forward_block_threads(N)
+    elem_bits = 32 if dtype_str == "f32" else 16
+    vec_width = 4 if dtype_str == "f32" else VEC_WIDTH
+    tile_cols = block_threads * vec_width
+    RED_SLOTS = max(1, (block_threads + WARP_SIZE - 1) // WARP_SIZE)
+
+    SharedStorage = _make_single_reduction_storage(RED_SLOTS)
+
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
+    def rmsnorm_kernel(
+        Input: fx.Tensor,
+        Gamma: fx.Tensor,
+        Output: fx.Tensor,
+        Rstd: fx.Tensor,
+        Eps: fx.Float32,
+    ):
+        bid = fx.block_idx.x
+        tid = fx.thread_idx.x
+
+        elem_dtype = dtype_to_elem_type(dtype_str)
+        eps_c = Eps
+        n_float = float(N)
+
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        s_red = lds.s_red.view(fx.make_layout(RED_SLOTS, 1))
+
+        def wave_reduce_add(x):
+            w = x
+            for _sh_exp in range_constexpr(int(math.log2(WARP_SIZE))):
+                off = WARP_SIZE // (2 << _sh_exp)
+                w += gpu.shuffle_xor(w, off, WARP_SIZE)
+            return w
+
+        def block_reduce_add(val):
+            if const_expr(RED_SLOTS == 1):
+                return wave_reduce_add(val)
+            lane = tid % WARP_SIZE
+            wave = tid // WARP_SIZE
+            w = wave_reduce_add(val)
+            if lane == 0:
+                fx.memref_store(w, s_red, wave)
+            gpu.barrier()
+            if wave == 0:
+                in_range = lane < RED_SLOTS
+                lane_safe = in_range.select(lane, 0)
+                v = s_red[lane_safe]
+                ww = in_range.select(v, 0.0)
+                ww = wave_reduce_add(ww)
+                if lane == 0:
+                    fx.memref_store(ww, s_red, 0)
+            gpu.barrier()
+            return s_red[0]
+
+        # ==================================================================
+        # Fast path: N is a multiple of tile_cols
+        # ==================================================================
+        if const_expr(N >= tile_cols and N % tile_cols == 0):
+            num_tiles = N // tile_cols
+            # Layout API: buffer-backed tensors with tiled access.
+            Input_buf = fx.rocdl.make_buffer_tensor(Input)
+            Output_buf = fx.rocdl.make_buffer_tensor(Output)
+            Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
+
+            row_in = Input_buf[bid, None]
+            row_out = Output_buf[bid, None]
+
+            in_div = fx.logical_divide(row_in, fx.make_layout(vec_width, 1))
+            out_div = fx.logical_divide(row_out, fx.make_layout(vec_width, 1))
+            gamma_div = fx.logical_divide(Gamma_buf, fx.make_layout(vec_width, 1))
+
+            copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_bits)
+
+            c_zero_f = fx.Float32(0.0)
+            thread_sumsq = c_zero_f
+            in_local = []
+
+            # Pass 1: load + cache + sumsq
+            for tile_i in range_constexpr(num_tiles):
+                idx = tid + tile_i * block_threads
+                vec = _load_vec(copy_atom, vec_width, elem_dtype, in_div, idx)
+                in_local.append(vec)
+                x = vec.to(fx.Float32)
+
+                x2 = x * x
+                red2 = x2.reduce(ReductionOp.ADD)
+                thread_sumsq = thread_sumsq + red2
+
+            sum_sq = block_reduce_add(thread_sumsq)
+            mean_sq = sum_sq / n_float
+            ms_eps = mean_sq + eps_c
+            rrms = fmath.rsqrt(ms_eps)
+
+            # The fused ATen contract returns this value for backward.
+            if tid == 0:
+                Rstd[bid] = rrms
+
+            # Pass 2: normalize + gamma + store (reuse cached input)
+            for tile_i in range_constexpr(num_tiles):
+                idx = tid + tile_i * block_threads
+
+                g = _load_vec(copy_atom, vec_width, elem_dtype, gamma_div, idx).to(
+                    fx.Float32
+                )
+                x = in_local[tile_i].to(fx.Float32)
+
+                y = (x * rrms) * g
+                out_e = _to_elem(dtype_str, elem_dtype, y)
+
+                out_idx = tid + tile_i * block_threads
+                _store_vec(copy_atom, vec_width, elem_dtype, out_e, out_div, out_idx)
+
+        else:
+            # ==============================================================
+            # Generic path: 128-bit vector body plus scalar tail.
+            # ==============================================================
+            Input_buf = fx.rocdl.make_buffer_tensor(Input)
+            Output_buf = fx.rocdl.make_buffer_tensor(Output)
+            Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
+
+            row_in = Input_buf[bid, None]
+            row_out = Output_buf[bid, None]
+
+            generic_vec_width = 4 if dtype_str == "f32" else VEC_WIDTH
+            full_vecs = N // generic_vec_width
+            vec_steps = (full_vecs + block_threads - 1) // block_threads
+            scalar_tail_start = full_vecs * generic_vec_width
+            scalar_tail_elems = N - scalar_tail_start
+
+            copy_atom_v = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_bits)
+            in_div = fx.logical_divide(row_in, fx.make_layout(generic_vec_width, 1))
+            out_vec_div = fx.logical_divide(
+                row_out, fx.make_layout(generic_vec_width, 1)
+            )
+            gamma_vec_div = fx.logical_divide(
+                Gamma_buf, fx.make_layout(generic_vec_width, 1)
+            )
+
+            c_zero_f = fx.Float32(0.0)
+            thread_sumsq = c_zero_f
+            in_local = []
+            tail_x = c_zero_f
+
+            for step in range_constexpr(vec_steps):
+                vec_idx = tid + step * block_threads
+                is_valid = vec_idx < full_vecs
+                vec_idx_safe = is_valid.select(vec_idx, 0)
+                vec = _load_vec(
+                    copy_atom_v, generic_vec_width, elem_dtype, in_div, vec_idx_safe
+                )
+                in_local.append(vec)
+                x = vec.to(fx.Float32)
+                x2 = x * x
+                red2 = x2.reduce(ReductionOp.ADD)
+                red2_safe = is_valid.select(red2, c_zero_f)
+                thread_sumsq = thread_sumsq + red2_safe
+
+            if const_expr(scalar_tail_elems > 0):
+                tail_valid = tid < scalar_tail_elems
+                tail_idx = scalar_tail_start + tid
+                tail_x_e = row_in[tail_valid.select(tail_idx, 0)]
+                tail_x = tail_x_e if dtype_str == "f32" else tail_x_e.to(fx.Float32)
+                thread_sumsq = thread_sumsq + tail_valid.select(
+                    tail_x * tail_x, c_zero_f
+                )
+
+            sum_sq = block_reduce_add(thread_sumsq)
+            mean_sq = sum_sq / n_float
+            ms_eps = mean_sq + eps_c
+            rrms = fmath.rsqrt(ms_eps)
+
+            # The fused ATen contract returns this value for backward.
+            if tid == 0:
+                Rstd[bid] = rrms
+
+            for step in range_constexpr(vec_steps):
+                vec_idx = tid + step * block_threads
+                if vec_idx < full_vecs:
+                    g = _load_vec(
+                        copy_atom_v,
+                        generic_vec_width,
+                        elem_dtype,
+                        gamma_vec_div,
+                        vec_idx,
+                    ).to(fx.Float32)
+                    x = in_local[step].to(fx.Float32)
+                    y = (x * rrms) * g
+                    out_e = _to_elem(dtype_str, elem_dtype, y)
+                    _store_vec(
+                        copy_atom_v,
+                        generic_vec_width,
+                        elem_dtype,
+                        out_e,
+                        out_vec_div,
+                        vec_idx,
+                    )
+
+            if const_expr(scalar_tail_elems > 0):
+                tail_valid = tid < scalar_tail_elems
+                tail_idx = scalar_tail_start + tid
+                if tail_valid:
+                    g_e = Gamma_buf[tail_idx]
+                    g = g_e if dtype_str == "f32" else g_e.to(fx.Float32)
+                    y = (tail_x * rrms) * g
+                    y_e = _to_elem(dtype_str, elem_dtype, y)
+                    row_out[tail_idx] = elem_dtype(y_e)
+
+    @flyc.jit
+    def launch_rmsnorm(
+        Input: fx.Tensor,
+        Gamma: fx.Tensor,
+        Output: fx.Tensor,
+        Rstd: fx.Tensor,
+        m_in: fx.Int32,
+        eps: fx.Float32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        launcher = rmsnorm_kernel(Input, Gamma, Output, Rstd, eps)
+        launcher.launch(
+            grid=(m_in, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_rmsnorm
+
+
+def _make_compile_arg(tensor: torch.Tensor):
+    """Make only the row dimension dynamic so one kernel supports many M values."""
+    return flyc.from_torch_tensor(tensor).mark_shape_dynamic(0)
+
+
+@instrumented_flydsl_cache(
+    "aten::_fused_rms_norm",
+    key_fn=lambda n, dtype, arch, *a, **k: f"fwd N={n} {dtype} {arch}",
+)
+def _compile_rmsnorm_fwd(
+    n: int,
+    dtype: str,
+    arch: str,
+    backend: str,
+    device_index: int,
+    *,
+    compile_args,
+) -> flyc.CompiledFunction:
+    # backend/device_index are cache keys only. flyc.compile binds the resulting
+    # launcher to the active device/context, so cross-device reuse is unsafe
+    # even when two GPUs share the same architecture.
+    del backend, device_index
+    input_2d, weight, output_2d, rstd, rows_m, eps, stream = compile_args
+    launch = build_rmsnorm_module(n, dtype, arch)
+    return flyc.compile[{"fast_fp_math": True}](
+        launch,
+        _make_compile_arg(input_2d),
+        flyc.from_torch_tensor(weight),
+        _make_compile_arg(output_2d),
+        _make_compile_arg(rstd),
+        rows_m,
+        eps,
+        stream,
+    )
+
+
+def rmsnorm_fwd(
+    input: torch.Tensor,
+    normalized_shape,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run FlyDSL forward and return the ATen output/rstd pair."""
+    n = _normalized_shape_1d(normalized_shape)
+    if n is None:
+        raise ValueError("FlyDSL RMSNorm currently requires one normalized dimension")
+
+    rows_m = input.numel() // n
+    input_shape = input.shape
+
+    with torch.cuda.device(input.device):
+        is_2d = input.ndim == 2
+        input_2d = input if is_2d else input.reshape(rows_m, n)
+        output_2d = torch.empty_like(input_2d)
+        rstd_flat = torch.empty(rows_m, device=input.device, dtype=torch.float32)
+
+        stream = torch.cuda.current_stream()
+        device_index = input.device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+
+        compiled = _compile_rmsnorm_fwd(
+            n,
+            _dtype_str(input.dtype),
+            _resolve_rocm_arch(device_index),
+            _COMPILE_BACKEND_NAME,
+            device_index,
+            compile_args=(
+                input_2d,
+                weight,
+                output_2d,
+                rstd_flat,
+                rows_m,
+                float(eps),
+                stream,
+            ),
+        )
+
+        compiled(input_2d, weight, output_2d, rstd_flat, rows_m, float(eps), stream)
+
+    if is_2d:
+        result = output_2d, rstd_flat.view((rows_m, 1))
+    else:
+        stat_shape = (*input_shape[:-1], 1)
+        result = output_2d.view(input_shape), rstd_flat.view(stat_shape)
+    return result
+
+
+def clear_rmsnorm_caches() -> None:
+    """Clear native-op-level compile caches (used by tests/benchmarks)."""
+
+    _compile_rmsnorm_fwd.cache_clear()
+
+
+def rmsnorm_cache_info() -> dict[str, object]:
+    """Return forward cache statistics for diagnostics."""
+
+    return {
+        "fwd": _compile_rmsnorm_fwd.cache_info(),
+    }

--- a/torch/_native/ops/norm/flydsl_rmsnorm_impl.py
+++ b/torch/_native/ops/norm/flydsl_rmsnorm_impl.py
@@ -1,0 +1,121 @@
+"""FlyDSL override for ATen's internal fused RMSNorm forward operator."""
+
+# mypy: allow-untyped-defs
+
+from __future__ import annotations
+
+import torch
+
+from ... import flydsl_utils as fu
+
+
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+_HIP_AVAILABLE = torch.version.hip is not None
+_is_cow_tensor = torch._C._is_cow_tensor  # pyrefly: ignore[missing-attribute]
+_rmsnorm_fwd = None
+
+
+def _common_supported(
+    input: torch.Tensor,
+    n: int,
+    weight: torch.Tensor | None,
+) -> bool:
+    """Cheap dispatcher predicate for supported forward inputs."""
+    if not _HIP_AVAILABLE or input.device.type != "cuda":
+        return False
+    if input.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if input.ndim < 1 or input.shape[-1] != n or input.numel() == 0:
+        return False
+    if not input.is_contiguous():
+        return False
+    if weight is None:
+        return False
+    if (
+        weight.shape != (n,)
+        or weight.dtype != input.dtype
+        or weight.device != input.device
+        or not weight.is_contiguous()
+    ):
+        return False
+    # Reshaping a copy-on-write tensor would materialize it. Let ATen preserve
+    # its normal semantics for these uncommon inputs.
+    if _is_cow_tensor(input) or _is_cow_tensor(weight):
+        return False
+    # Deliberately no base-address alignment check. The kernel's 128-bit buffer
+    # copies tolerate misaligned inputs (verified against ATen for fp16 and
+    # fp32 on gfx950), and a misaligned base is where the override wins by the
+    # widest margin: ATen's own vectorized path bails out there, so declining
+    # these inputs would hand back the largest speedups the kernel has.
+    return True
+
+
+def _fused_rms_norm_fwd_perf_wins(input: torch.Tensor, n: int) -> bool:
+    rows_m = input.numel() // n
+    # Tuned on MI355. The kernel caches a whole row in registers to avoid
+    # re-reading it for the normalize pass, so the register footprint grows
+    # with N and eventually spills to scratch. Measured at rows_m=2048, the
+    # last N where all three dtypes keep a margin is 114688 (1.20x fp16, 1.21x
+    # bf16, 1.12x fp32); by 126976 fp16 is at 0.77x and fp32 at parity. Unlike
+    # the other bands this bound is not a power of two -- rounding down to
+    # 65536 would give up a measured 1.1x-1.6x across 81920..114688.
+    return (
+        (4096 <= n < 8192 and rows_m >= 8192)
+        or (8192 <= n < 16384 and rows_m >= 4096)
+        or (16384 <= n <= 114688 and rows_m >= 2048)
+    )
+
+
+def _fused_rms_norm_cond(
+    input: torch.Tensor,
+    normalized_shape,
+    weight: torch.Tensor | None,
+    eps: float | None,
+) -> bool:
+    n = fu._normalized_shape_1d(normalized_shape)
+    if n is None:
+        return False
+    if not _common_supported(input, n, weight):
+        return False
+    if eps is None:
+        return False
+    return _fused_rms_norm_fwd_perf_wins(input, n)
+
+
+def _get_rmsnorm_fwd(input: torch.Tensor):
+    global _rmsnorm_fwd
+    if _rmsnorm_fwd is None:
+        # Import under the input device guard because the vendored module
+        # resolves the FlyDSL compile backend at import time.
+        with torch.cuda.device(input.device):
+            from .flydsl_rmsnorm_fwd import rmsnorm_fwd
+
+        _rmsnorm_fwd = rmsnorm_fwd
+    return _rmsnorm_fwd
+
+
+def _fused_rms_norm_impl(
+    input: torch.Tensor,
+    normalized_shape,
+    weight: torch.Tensor | None,
+    eps: float | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # The predicate guarantees both values are present. Keeping the checks here
+    # makes failures clear if the implementation is ever called directly.
+    if weight is None or eps is None:
+        raise RuntimeError("FlyDSL RMSNorm requires explicit weight and eps")
+
+    rmsnorm_fwd = _get_rmsnorm_fwd(input)
+    return rmsnorm_fwd(input, normalized_shape, weight, float(eps))
+
+
+def register_op_override() -> None:
+    # QuACK registers against this symbol too, for NVIDIA. Both registrations
+    # coexist: the predicates are mutually exclusive (ROCm versus NVIDIA).
+    fu.register_op_override(
+        "aten",
+        "_fused_rms_norm",
+        "CUDA",
+        cond=_fused_rms_norm_cond,
+        impl=_fused_rms_norm_impl,
+    )

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4736,6 +4736,33 @@ def sample_inputs_rms_norm_cutedsl(opinfo, device, dtype, requires_grad, **kwarg
     yield SampleInput(make_arg((8, 128)), args=((128,),), kwargs={'eps': 1e-5})
 
 
+def sample_inputs_rms_norm_flydsl(opinfo, device, dtype, requires_grad, **kwargs):
+    # The FlyDSL override only fires on ROCm for large N with enough rows to
+    # amortize the launch, so most of these shapes sit inside that window:
+    # N in [4096, 8192) needs >= 8192 rows, [8192, 16384) needs >= 4096, and
+    # N >= 16384 needs >= 2048.
+    make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    cases = (
+        ((8192, 4096), (4096,), {'eps': 1e-5}),
+        ((4096, 8192), (8192,), {'eps': 1e-5}),
+        ((2048, 16384), (16384,), {'eps': 1e-5}),
+        # N is a multiple of neither vector width (8 for fp16/bf16, 4 for
+        # fp32), so this exercises the scalar tail of the vectorized path.
+        ((8192, 4098), (4098,), {'eps': 1e-5}),
+        # Below the row threshold and below the N threshold: both fall through
+        # to aten, which the override must leave numerically untouched.
+        ((64, 4096), (4096,), {'eps': 1e-5}),
+        ((8, 128), (128,), {'eps': 1e-5}),
+        # eps=None reaches the same aten fallback for the accumulator epsilon.
+        ((8, 128), (128,), {}),
+    )
+    for input_shape, normalized_shape, kw in cases:
+        weight = make_arg(normalized_shape)
+        yield SampleInput(make_arg(input_shape), args=(normalized_shape, weight), kwargs=kw)
+    # weight=None is declined by the predicate and handled by aten.
+    yield SampleInput(make_arg((8192, 4096)), args=((4096,),), kwargs={'eps': 1e-5})
+
+
 def error_inputs_group_norm(opinfo, device, **kwargs):
     make_arg = partial(make_tensor, device=device, dtype=torch.float32, requires_grad=False)
 
@@ -22980,6 +23007,45 @@ if "cutedsl" in dsl_ops_by_dsl:
             **_cutedsl_topk_kwargs,
         ),
     ])
+
+if "flydsl" in dsl_ops_by_dsl:
+    dsl_ops_by_dsl["flydsl"].append(
+        OpInfo(
+            "nn.functional.rms_norm",
+            variant_test_name="flydsl",
+            aten_name="rms_norm",
+            ref=reference_rms_norm,
+            dtypes=custom_types(torch.float16, torch.bfloat16, torch.float32),
+            dtypesIfCUDA=custom_types(torch.float16, torch.bfloat16, torch.float32),
+            supports_out=False,
+            supports_forward_ad=False,
+            supports_fwgrad_bwgrad=False,
+            sample_inputs_func=sample_inputs_rms_norm_flydsl,
+            decorators=[
+                onlyCUDA,
+                skipCUDAIf(not TEST_WITH_ROCM, "flydsl rms_norm override requires ROCm"),
+                # The predicate declines non-contiguous inputs, so this test
+                # compares the FlyDSL kernel against aten rather than one
+                # kernel against itself. Their reduction orders differ, which
+                # at N=4096 exceeds the default fp32 tolerance.
+                DecorateInfo(
+                    toleranceOverride({torch.float32: tol(atol=1e-4, rtol=1e-4)}),
+                    "TestCommon", "test_noncontiguous_samples",
+                ),
+            ],
+            skips=(
+                # test_dtypes probes every dtype and expects the listed set
+                # to exactly match what the op accepts. The override falls
+                # through to aten for fp64/complex, so those "work" from the
+                # probe's perspective -- but this variant is specifically for
+                # the override's supported dtypes only.
+                DecorateInfo(
+                    unittest.skip("override intentionally narrower than aten"),
+                    "TestCommon", "test_dtypes",
+                ),
+            ),
+        )
+    )
 
 op_db += opinfo.definitions.op_db
 


### PR DESCRIPTION
## Add FlyDSL native RMSNorm forward override

### Motivation

Fused RMSNorm is on the critical path of transformer layers. This PR adds a FlyDSL
implementation for `aten::_fused_rms_norm` on ROCm as a transparent, opt-out native-op
override: it is used only for measured-profitable shapes and otherwise falls back to ATen.

### Requirements

FlyDSL **0.3.0** or newer. 0.3.0 removed `flydsl.expr.vector` and `buffer_ops`, and the kernel
is only validated against the new API, so older installs fall back to ATen rather than failing
to import mid-dispatch.

### Changes

- `torch/_native/ops/norm/flydsl_rmsnorm_fwd.py` -- single-pass block-reduction forward kernel.
- `torch/_native/ops/norm/flydsl_rmsnorm_impl.py` -- registers the `aten::_fused_rms_norm` CUDA
  override, with the eligibility predicate, the performance gate, and ATen fallback.
- Shared FlyDSL registration and JIT compile-cache helpers, plus `_resolve_rocm_arch`, a single
  arch resolver that reads only the environment and device properties so the Inductor FlyDSL
  work can share it without importing flydsl.
- Compiles are reported through `torch/_native/instrumentation`, so they appear under
  `TORCH_LOGS=+native_dsl` and in tlparse like every other native op.
- An OpInfo entry under `dsl_ops_by_dsl["flydsl"]`, which brings in `test_ops.py`,
  `test_ops_gradients.py`, `test_export_opinfo.py`, the COW check and the dtype probe.

### Supported cases

fp16, bf16 and fp32 ROCm tensors, contiguous input and weight, 1-D `normalized_shape`, and
`weight` of shape `(N,)` with matching dtype and device. N-D inputs are logically flattened to
`(M, N)`. `eps` is passed through at runtime and does not participate in the cache key. The
kernel returns the forward result and the FP32 `rstd` that ATen's backward consumes.

There is deliberately no base-address alignment gate. The kernel already issues misaligned
128-bit buffer copies whenever N is not a multiple of the vector width -- row 1 of an N=4097
fp16 input starts at 2 mod 16 -- so gating on the base pointer would reject the same access
pattern the dispatcher otherwise accepts, and misalignment is where this override wins by the
widest margin (see below).

Everything else transparently uses ATen.

### When FlyDSL acceleration kicks in

ROCm, non-copy-on-write contiguous input and weight, one normalized dimension, and:

| N | minimum rows M |
|---|---:|
| `4096 <= N < 8192` | 8192 |
| `8192 <= N < 16384` | 4096 |
| `16384 <= N <= 114688` | 2048 |

The upper bound exists because the kernel caches a whole row in registers to avoid re-reading it
for the normalize pass; past ~114688 that spills to scratch and ATen wins. All unlisted ranges
fall back to ATen.

### Testing

```bash
python test/python_native/test_flydsl_rmsnorm_fwd.py -v
python test/python_native/test_flydsl_registry.py -v
python test/python_native/test_native_dsl_ops.py -v
python test/python_native/test_instrumentation.py -v
OPINFO_RESTRICT_TO_DSL=flydsl python test/test_ops.py -k rms_norm
OPINFO_RESTRICT_TO_DSL=flydsl python test/test_ops_gradients.py
OPINFO_RESTRICT_TO_DSL=flydsl python test/export/test_export_opinfo.py
```

The forward tests cover numeric parity with ATen across the kernel's internal branches -- all
three `_forward_block_threads` block sizes, the fast path, and the generic path's scalar tail at
the off-by-one N the speedups come from -- plus `rstd` values, JIT-cache reuse across dynamic row
counts, dispatch through public `torch.rms_norm`, gradients for every supported dtype, and
fallback for non-contiguous input, N above the upper bound, and user-disabled FlyDSL.

### Performance methodology

Latency is measured with CUDA events after 10 warmup iterations and over 50 timed iterations. The
ATen baseline runs with FlyDSL disabled; the FlyDSL measurement invokes the same operator with the
override enabled. Every row below was confirmed to actually dispatch, by checking the compile
cache registered a miss.

```python
def bench(fn, iters=50, warmup=10):
    for _ in range(warmup):
        fn()
    torch.cuda.synchronize()
    start = torch.cuda.Event(enable_timing=True)
    end = torch.cuda.Event(enable_timing=True)
    start.record()
    for _ in range(iters):
        fn()
    end.record()
    torch.cuda.synchronize()
    return start.elapsed_time(end) / iters

fwd = lambda: torch.ops.aten._fused_rms_norm(x, [N], weight, eps)

with pn.flydsl.disabled():
    aten_ms = bench(fwd)
flydsl_ms = bench(fwd)
speedup = aten_ms / flydsl_ms
```

### Performance

GPU: AMD 256-CU MI355X. FlyDSL 0.3.0.dev765.

| dtype | M | N | ATen (us) | FlyDSL (us) | speedup |
|:---|---:|---:|---:|---:|---:|
| fp16 | 8192 | 4096 | 26.7 | 20.6 | 1.30x |
| fp16 | 4096 | 8192 | 29.8 | 21.0 | 1.42x |
| fp16 | 2048 | 16384 | 30.8 | 21.9 | 1.41x |
| fp16 | 2048 | 65536 | 171.7 | 109.8 | 1.56x |
| fp16 | 2048 | 114688 | 302.1 | 248.6 | 1.22x |
| fp16 | 8192 | 4097 | 97.0 | 26.5 | 3.67x |
| fp16 | 4096 | 8193 | 94.0 | 25.7 | 3.66x |
| fp16 | 2048 | 16385 | 74.0 | 25.4 | 2.92x |
| bf16 | 8192 | 4096 | 26.4 | 20.8 | 1.27x |
| bf16 | 2048 | 16384 | 30.9 | 21.4 | 1.44x |
| bf16 | 8192 | 4097 | 96.6 | 26.5 | 3.64x |
| bf16 | 2048 | 16385 | 73.5 | 25.3 | 2.91x |
| fp32 | 8192 | 4096 | 55.6 | 40.0 | 1.39x |
| fp32 | 4096 | 8192 | 58.5 | 40.4 | 1.45x |
| fp32 | 2048 | 16384 | 57.9 | 42.2 | 1.37x |
| fp32 | 2048 | 32768 | 151.2 | 104.6 | 1.45x |
| fp32 | 2048 | 65536 | 321.1 | 212.7 | 1.51x |
| fp32 | 2048 | 114688 | 562.0 | 485.8 | 1.16x |
| fp32 | 8192 | 4097 | 91.9 | 41.4 | 2.22x |
| fp32 | 4096 | 8193 | 81.6 | 42.6 | 1.92x |
| fp32 | 2048 | 16385 | 78.6 | 42.8 | 1.83x |
| fp32 | 2048 | 32769 | 208.4 | 104.3 | 2.00x |

Aligned shapes improve by 1.2x to 1.6x. Off-by-one `N` improves by up to 3.7x: those rows do not
start on a 16-byte boundary, and ATen's vectorized path bails out where the FlyDSL kernel keeps
issuing 128-bit copies.

A misaligned base pointer, with N a multiple of the vector width, is the same story:

| dtype | M | N | ATen (us) | FlyDSL (us) | speedup |
|:---|---:|---:|---:|---:|---:|
| fp16 | 8192 | 4096 | 95.7 | 23.6 | 4.05x |
| bf16 | 8192 | 4096 | 95.5 | 23.7 | 4.03x |
| fp32 | 8192 | 4096 | 89.6 | 40.5 | 2.21x |

Unsupported shapes retain ATen behavior.

Authored with assistance from Claude Code.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo