### PR TITLE
[Inductor] A path for users to provide custom pad_mm policies

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -701,6 +701,75 @@ class PadMMTest(TestCase):
         test_masked_mha(B, H, S, D, device, dtype)
 
 
+class PadMMPolicyTest(TestCase):
+    """Tests for torch._inductor.config.pad_mm_policy (the pad_mm override hook)."""
+
+    def _count_pads(self, m, k, n, dtype=torch.float16):
+        # Compile `a @ b` in deterministic mode and count the constant_pad_nd nodes
+        # (GEMM operands pad_mm chose to pad) in the post-grad graph.
+        pad_counts = []
+
+        def count_pads(graph):
+            pad_counts.append(
+                sum(
+                    node.target is torch.ops.aten.constant_pad_nd.default
+                    for node in graph.nodes
+                )
+            )
+
+        a = torch.randn(m, k, device=GPU_TYPE, dtype=dtype)
+        b = torch.randn(k, n, device=GPU_TYPE, dtype=dtype)
+        # Reset so each shape compiles fresh and static (avoid automatic dynamic
+        # shapes across calls, which would make dims symbolic and unpaddable).
+        torch._dynamo.reset()
+        with (
+            fresh_cache(),
+            inductor_config.patch(
+                deterministic=True, post_grad_custom_post_pass=count_pads
+            ),
+        ):
+            out = torch.compile(lambda x, y: x @ y)(a, b)
+        self.assertEqual(out, a @ b)
+        return sum(pad_counts)
+
+    @unittest.skipIf(not HAS_GPU_AND_TRITON, "GPU and Triton required")
+    def test_deterministic_pad_mm_policy_respected(self):
+        # A policy that force-pads one shape, force-skips another, and defers
+        # (returns None) for the rest. All shapes are unaligned pad candidates.
+        pad_shape = (2048, 2048, 2050)
+        skip_shape = (2048, 2048, 2054)
+        defer_shape = (2048, 2048, 2058)
+        seen = []
+
+        def policy(ctx):
+            seen.append(ctx)
+            if (ctx.m, ctx.k, ctx.n) == pad_shape:
+                return True
+            if (ctx.m, ctx.k, ctx.n) == skip_shape:
+                return False
+            return None  # defer to Inductor's built-in decision
+
+        # Install exactly the way a user would ship a policy.
+        with inductor_config.patch(pad_mm_policy=policy):
+            # True -> padded, even though deterministic mode would otherwise skip
+            # padding (it cannot benchmark to decide).
+            self.assertGreater(self._count_pads(*pad_shape), 0)
+            # False -> not padded, even though the shape is a valid pad candidate.
+            self.assertEqual(self._count_pads(*skip_shape), 0)
+            # None -> defer to the default, which does not pad in deterministic mode.
+            self.assertEqual(self._count_pads(*defer_shape), 0)
+
+        # The policy was consulted for each shape with the concrete (m, k, n)...
+        shapes_seen = {(c.m, c.k, c.n) for c in seen}
+        self.assertIn(pad_shape, shapes_seen)
+        self.assertIn(skip_shape, shapes_seen)
+        self.assertIn(defer_shape, shapes_seen)
+        # ...and the context is well-formed (unaligned N -> nonzero pad length).
+        pad_ctx = next(c for c in seen if (c.m, c.k, c.n) == pad_shape)
+        self.assertEqual(pad_ctx.op, "mm")
+        self.assertGreater(pad_ctx.n_padded_length, 0)
+
+
 if __name__ == "__main__":
     if HAS_GPU_AND_TRITON:
         run_tests()

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1146,6 +1146,13 @@ class CacheabilityValidator:
         for p in config._fuse_ddp_communication_passes:
             if callable(p) and not isinstance(p, CustomGraphPass):
                 self.bypass("Unsupported _fuse_ddp_communication_pass")
+        # pad_mm_policy must be a PadMMPolicy with a uuid() to be cacheable; a raw
+        # callable cannot be identified in the cache key.
+        if config.pad_mm_policy is not None and (
+            not isinstance(config.pad_mm_policy, CustomPassBase)
+            or not config.pad_mm_policy.uuid()
+        ):
+            self.bypass("Unsupported pad_mm_policy")
 
     def _check_nested_region_inductor_config_patches(self) -> None:
         # Nested region config patches are hashed by pickling their raw value
@@ -1669,6 +1676,7 @@ class FxGraphHashDetails:
         self._fuse_ddp_communication_passes = self._get_custom_pass_detail_unsafe(
             config._fuse_ddp_communication_passes
         )
+        self.pad_mm_policy = self._get_custom_pass_detail_unsafe(config.pad_mm_policy)
 
         # Register inductor backends and custom passes and get their UUIDs.
         init_backend_registration()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1584,7 +1584,7 @@ force_shape_pad: bool = False
 #     def policy(ctx):
 #         return SHIPPED_TABLE.get((ctx.m, ctx.k, ctx.n, ctx.mat1_dtype))
 #     torch._inductor.config.pad_mm_policy = policy
-pad_mm_policy: "torch._inductor.custom_graph_pass.PadMMPolicyType" = None
+pad_mm_policy: torch._inductor.custom_graph_pass.PadMMPolicyType = None
 
 # Fx-based linear/matmul/bmm + permute/transpose vertical fusion
 permute_fusion = os.environ.get("TORCHINDUCTOR_PERMUTE_FUSION", "0") == "1"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1574,6 +1574,18 @@ bw_outputs_user_visible = True
 # Whether to always use shape padding if it is enabled and possible
 force_shape_pad: bool = False
 
+# User-overridable policy for pad_mm's shape-padding decisions. Either a callable
+# or a PadMMPolicy taking a PadMMContext and returning True (pad this mm/addmm/bmm),
+# False (do not pad), or None (defer to Inductor's built-in decision). Consulted
+# before the built-in heuristics and the AutoHeuristic, so a returned bool is
+# honored even in deterministic mode. Use a PadMMPolicy (with uuid()) rather than a
+# bare callable to keep compiled-artifact caching enabled. Example:
+#
+#     def policy(ctx):
+#         return SHIPPED_TABLE.get((ctx.m, ctx.k, ctx.n, ctx.mat1_dtype))
+#     torch._inductor.config.pad_mm_policy = policy
+pad_mm_policy: "torch._inductor.custom_graph_pass.PadMMPolicyType" = None
+
 # Fx-based linear/matmul/bmm + permute/transpose vertical fusion
 permute_fusion = os.environ.get("TORCHINDUCTOR_PERMUTE_FUSION", "0") == "1"
 
@@ -2950,6 +2962,8 @@ _save_config_ignore: list[str] = [
     "post_grad_custom_post_pass",
     "_fuse_ddp_communication_passes",
     "_pre_fusion_custom_pass",
+    # pad_mm_policy may be a callable/PadMMPolicy; hashed via its uuid() instead.
+    "pad_mm_policy",
     # CUDAGraphPolicy objects are not picklable and only affect
     # post_compile wrapping, not compiled code itself.
     "cudagraph_policy",
@@ -2973,6 +2987,8 @@ _cache_config_ignore_prefix: list[str] = [
     "pre_grad_custom_pass",
     "_fuse_ddp_communication_passes",
     "_pre_fusion_custom_pass",
+    # see CustomPassBase; hashed specially via its uuid() in FxGraphHashDetails
+    "pad_mm_policy",
     # CUDAGraphPolicy only affects post_compile, not compiled output
     "cudagraph_policy",
     # tests assume that changes here don't invalidate cache

--- a/torch/_inductor/custom_graph_pass.py
+++ b/torch/_inductor/custom_graph_pass.py
@@ -9,6 +9,7 @@ import torch.fx.graph
 
 if TYPE_CHECKING:
     from torch._functorch.partitioners import NodeInfo
+    from torch._inductor.fx_passes.pad_mm import PadMMContext
     from torch._inductor.scheduler import BaseSchedulerNode
 
 
@@ -276,3 +277,33 @@ class CustomKnapsackSolver(CustomPassBase):
         """
         Implementation of the custom knapsack solver.
         """
+
+
+class PadMMPolicy(CustomPassBase):
+    """Implement this interface to override pad_mm's shape-padding decisions.
+
+    1) __call__() returns True to force padding a GEMM (mm/addmm/bmm), False to
+       force skipping it, or None to defer to Inductor's built-in decision.
+
+    2) See CustomPassBase.uuid() docstring for implementing the uuid() method.
+
+    EXAMPLE:
+
+    from torch._inductor.custom_graph_pass import get_hash_for_files
+
+    class MyPadMMPolicy(PadMMPolicy):
+        def __call__(self, ctx: "PadMMContext") -> Optional[bool]:
+            return TABLE.get((ctx.m, ctx.k, ctx.n, ctx.mat1_dtype))
+
+        def uuid(self) -> Optional[Any]:
+            return get_hash_for_files((__file__,))
+    """
+
+    @abstractmethod
+    def __call__(self, ctx: "PadMMContext") -> bool | None:
+        """Return True to pad, False to skip, or None to defer to the default."""
+
+
+PadMMPolicyType: TypeAlias = (
+    PadMMPolicy | Callable[["PadMMContext"], "bool | None"] | None
+)

--- a/torch/_inductor/fuzzer.py
+++ b/torch/_inductor/fuzzer.py
@@ -15,7 +15,11 @@ from typing import Any, get_args, get_origin, Literal, TypeVar, Union
 
 import torch
 from functorch.compile import min_cut_rematerialization_partition
-from torch._inductor.custom_graph_pass import CustomGraphPass, CustomPartitionerFn
+from torch._inductor.custom_graph_pass import (
+    CustomGraphPass,
+    CustomPartitionerFn,
+    PadMMPolicy,
+)
 from torch._inductor.scheduler import BaseSchedulerNode
 from torch.utils._config_module import _ConfigEntry, ConfigModule
 from torch.utils._ordered_set import OrderedSet
@@ -80,6 +84,18 @@ class DummyPartitionerFn(CustomPartitionerFn):
         return None
 
 
+class DummyPadMMPolicy(PadMMPolicy):
+    """
+    A Dummy pad_mm policy to be used by ConfigFuzzer
+    """
+
+    def __call__(self, ctx: Any) -> bool | None:
+        return None
+
+    def uuid(self) -> Any | None:
+        return None
+
+
 T = TypeVar("T")
 
 
@@ -91,6 +107,7 @@ class TypeExemplars:
     TYPE_EXEMPLARS: dict[str, Any] = {
         CustomGraphPass.__name__: DummyPass(),
         CustomPartitionerFn.__name__: DummyPartitionerFn(),
+        PadMMPolicy.__name__: DummyPadMMPolicy(),
         torch.fx.graph.Graph.__name__: torch.fx.graph.Graph(),
         BaseSchedulerNode.__name__: BaseSchedulerNode(None),  # type: ignore[arg-type]
     }

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -3,6 +3,7 @@ import itertools
 import operator
 import typing
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -44,6 +45,36 @@ aten = torch.ops.aten
 # Changing it to True will ignore comparing do_bench times
 # between original pattern and padded one.
 _skip_do_bench_times = False
+
+
+@dataclass(frozen=True)
+class PadMMContext:
+    """Inputs passed to the user-overridable pad_mm policy hook.
+
+    See ``torch._inductor.config.pad_mm_policy``. ``op`` is one of "mm", "addmm", "bmm".
+    ``m``/``k``/``n`` are the logical GEMM dims (concrete size hints). Each
+    ``*_padded_length`` is how many rows/cols would be appended to align that dim
+    (0 means that dim is already aligned). ``device_capability`` is the CUDA
+    (major, minor) tuple, or None on non-CUDA, so an offline-tuned policy can be
+    keyed per GPU.
+    """
+
+    op: str
+    m: int
+    k: int
+    n: int
+    m_padded_length: int
+    k_padded_length: int
+    n_padded_length: int
+    mat1_dtype: torch.dtype
+    mat2_dtype: torch.dtype
+    mat1_stride: tuple[int, ...]
+    mat2_stride: tuple[int, ...]
+    device_capability: tuple[int, int] | None
+
+
+# op -> PadMMContext.op name; op is guaranteed to be one of these by the callers.
+_PAD_MM_OP_NAMES = {aten.mm: "mm", aten.addmm: "addmm", aten.bmm: "bmm"}
 
 
 def fetch_fake_tensors(match: Match, kwarg_names: Sequence[str]) -> list[Tensor]:
@@ -159,12 +190,14 @@ def can_pad(
         if m_padded_length == k_padded_length == n_padded_length == 0:
             return False
 
-    # In deterministic mode, we can't safely benchmark - disallow padding
-    # Check this after other basic checks so force_shape_pad/autoheuristic can override
+    # In deterministic mode, we can't safely benchmark - disallow padding.
+    # Check this after other basic checks so force_shape_pad, the autoheuristic, or
+    # a user-provided pad_mm policy (config.pad_mm_policy) can override.
     if (
         torch._inductor.config.deterministic
         and not torch._inductor.config.force_shape_pad
         and not torch._inductor.config.use_autoheuristic("pad_mm")
+        and torch._inductor.config.pad_mm_policy is None
     ):
         return False
 
@@ -533,6 +566,33 @@ def _should_pad(
         # Resolve symbolic dims to concrete hints for heuristic checks below.
         # These are performance decisions, not correctness — optimization_hint is safe.
         m_concrete, k_concrete, n_concrete = hint_symbols((m, k, n))
+
+        # User-overridable pad_mm policy (torch._inductor.config.pad_mm_policy).
+        # Consulted before the built-in heuristics and the AutoHeuristic, and
+        # applied to mm/addmm/bmm alike, so a returned bool is honored even in
+        # deterministic mode. Skipped (no context built) unless a policy is set.
+        pad_mm_policy = torch._inductor.config.pad_mm_policy
+        if pad_mm_policy is not None:
+            pad_mm_override = pad_mm_policy(
+                PadMMContext(
+                    op=_PAD_MM_OP_NAMES[op],
+                    m=m_concrete,
+                    k=k_concrete,
+                    n=n_concrete,
+                    m_padded_length=m_padded_length,
+                    k_padded_length=k_padded_length,
+                    n_padded_length=n_padded_length,
+                    mat1_dtype=mat1.dtype,
+                    mat2_dtype=mat2.dtype,
+                    mat1_stride=tuple(hint_symbols(mat1.stride())),
+                    mat2_stride=tuple(hint_symbols(mat2.stride())),
+                    device_capability=(
+                        torch.cuda.get_device_capability() if mat1.is_cuda else None
+                    ),
+                )
+            )
+            if pad_mm_override is not None:
+                return pad_mm_override
 
         # Performance heuristic for bf16 large K scenarios
         if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #190847
* __->__ #190844

`pad_mm` decides whether to shape-pad each `mm`/`addmm`/`bmm` either by
benchmarking (default mode) or via the learned AutoHeuristic. Neither works for a
model that wants to ship a fixed, offline-tuned padding policy: in deterministic
mode `pad_mm` cannot benchmark and falls back to "do not pad", and the
AutoHeuristic only runs for `aten.mm` (never `addmm`/`bmm`) and only above its
size precondition.

This adds an overridable policy hook, `torch._inductor.config.pad_mm_policy`. It
is consulted in `_should_pad` before the built-in heuristics and the
AutoHeuristic and applies uniformly to `mm`/`addmm`/`bmm`; `can_pad`'s
deterministic-mode guard also defers to it, so a policy decision is honored even
in deterministic mode. It is only consulted once padding is already known to be
safe (`can_pad`) and the GEMM is not already aligned, and returning `None` defers
to the existing logic, so the change is purely additive when no policy is set.

Usage. The policy takes a `PadMMContext` and returns `True` (pad), `False` (do
not pad), or `None` (defer to Inductor's built-in decision):

```py
from torch._inductor.custom_graph_pass import PadMMPolicy, get_hash_for_files

# Plain function. ctx exposes: op, m, k, n, {m,k,n}_padded_length,
# mat1_dtype, mat2_dtype, mat1_stride, mat2_stride, device_capability.
def policy(ctx):
    return SHIPPED_TABLE.get(
        (ctx.m, ctx.k, ctx.n, ctx.mat1_dtype, ctx.device_capability)
    )
torch._inductor.config.pad_mm_policy = policy

# Cache-safe form: subclass PadMMPolicy and return a stable uuid() so that
# changing the policy correctly invalidates the FX graph cache.
class AdsPadPolicy(PadMMPolicy):
    def __call__(self, ctx):
        return SHIPPED_TABLE.get((ctx.m, ctx.k, ctx.n, ctx.mat1_dtype))
    def uuid(self):
        return get_hash_for_files((__file__,))
torch._inductor.config.pad_mm_policy = AdsPadPolicy()
```

A bare callable cannot be identified in the cache key, so its presence bypasses
the FX graph cache (`CacheabilityValidator`). A `PadMMPolicy` with a `uuid()`
keeps caching enabled: the uuid is folded into the key via `FxGraphHashDetails`,
while the config value itself is excluded from the config hash via
`_save_config_ignore` and `_cache_config_ignore_prefix`.

Test Plan:
New test drives deterministic mode with a policy that force-pads one shape,
force-skips another, and defers on a third, and checks the resulting post-grad
graph for the padding op:

```bash
python test/inductor/test_pad_mm.py PadMMPolicyTest.test_deterministic_pad_mm_policy_respected
```

Existing `pad_mm` suite (no behavior change when no policy is set):

```bash
python test/inductor/test_pad_mm.py
```

Authored with assistance from an AI coding assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo