### PR TITLE
[Testcase Refactoring]Make test_sharding_plan.py device-agnostic

### DIFF
--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -54,7 +54,7 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 class TestShardingPlan(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend()
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_sharding_plan_errors(self):
         rowwise_sharding_spec = generate_chunk_sharding_specs_for_test(1)[0]
         sharding_plan_wrong_plan = ShardingPlan(
@@ -106,7 +106,7 @@ class TestShardingPlan(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend()
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_custom_sharding_planner(self):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).cuda(
             self.rank
@@ -126,7 +126,7 @@ class TestShardingPlan(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend()
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_shard_module_sub_process_group(self):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank)
         colwise_sharding_spec = ChunkShardingSpec(

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -12,6 +12,7 @@ from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -61,7 +62,7 @@ class TestShardingPlan(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_sharding_plan_errors(self):
+    def test_sharding_plan_errors(self, device):
         rowwise_sharding_spec = generate_chunk_sharding_specs_for_test(1)[0]
         sharding_plan_wrong_plan = ShardingPlan(
             plan={
@@ -70,8 +71,9 @@ class TestShardingPlan(ShardedTensorTestBase):
             output_plan={"": rowwise_sharding_spec},
         )
 
-        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(torch.device(self.device_type, self.rank)
-)
+        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(
+            torch.device(device, self.rank)
+        )
 
         with self.assertRaisesRegex(
             TypeError, "Only `ShardingSpec` and `Sharder` are supported to shard"
@@ -113,12 +115,12 @@ class TestShardingPlan(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_custom_sharding_planner(self):
-        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).cuda(
-            self.rank
+    def test_custom_sharding_planner(self, device):
+        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(
+            torch.device(device, self.rank)
         )
         planner = ChunkAllShardingPlanner(
-            device_count=TEST_GPU_NUM,device_type=self.device_type
+            device_count=TEST_GPU_NUM,device_type=device
         )
         sharding_plan = planner.build_plan(megatron_lm)
 
@@ -133,20 +135,20 @@ class TestShardingPlan(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_shard_module_sub_process_group(self):
+    def test_shard_module_sub_process_group(self, device):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank)
         colwise_sharding_spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:2/{self.device_type}:2",
-                "rank:3/{self.device_type}:3",
+                f"rank:2/{device}:2",
+                f"rank:3/{device}:3",
             ],
         )
         rowwise_sharding_spec = ChunkShardingSpec(
             dim=1,
             placements=[
-                "rank:2/{self.device_type}:2",
-                "rank:3/{self.device_type}:3",
+                f"rank:2/{device}:2",
+                f"rank:3/{device}:3",
             ],
         )
         sharding_plan = ShardingPlan(
@@ -160,6 +162,9 @@ class TestShardingPlan(ShardedTensorTestBase):
 
         if self.rank >= 2:
             shard_module(megatron_lm, sharding_plan, process_group=pg)
+
+
+instantiate_device_type_tests(TestShardingPlan, globals())
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -12,7 +12,11 @@ from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     TEST_GPU_NUM,
@@ -52,6 +56,8 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 
 
 class TestShardingPlan(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+    
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -8,13 +8,13 @@ from torch.distributed._shard import shard_module
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._shard.sharding_plan import ShardingPlan, ShardingPlanner
 from torch.distributed._shard.sharding_spec import ChunkShardingSpec
-from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
-    skip_if_lt_x_gpu,
-)
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
+)
+from torch.testing._internal.common_distributed import (
+    requires_accelerator_dist_backend,
+    skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -61,7 +61,7 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 
 class TestShardingPlan(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
-    
+
     @onlyAccelerator
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
@@ -125,7 +125,7 @@ class TestShardingPlan(ShardedTensorTestBase):
             torch.device(device)
         )
         planner = ChunkAllShardingPlanner(
-            device_count=TEST_GPU_NUM,device_type=torch.device(device).type
+            device_count=TEST_GPU_NUM, device_type=torch.device(device).type
         )
         sharding_plan = planner.build_plan(megatron_lm)
 

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -12,7 +12,10 @@ from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -59,6 +62,7 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 class TestShardingPlan(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
     
+    @onlyAccelerator
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
@@ -72,7 +76,7 @@ class TestShardingPlan(ShardedTensorTestBase):
         )
 
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(
-            torch.device(device, self.rank)
+            torch.device(device)
         )
 
         with self.assertRaisesRegex(
@@ -112,15 +116,16 @@ class TestShardingPlan(ShardedTensorTestBase):
             # shard the module with the provided sharding plan
             shard_module(megatron_lm, sharding_plan_wrong_param_path)
 
+    @onlyAccelerator
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_custom_sharding_planner(self, device):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(
-            torch.device(device, self.rank)
+            torch.device(device)
         )
         planner = ChunkAllShardingPlanner(
-            device_count=TEST_GPU_NUM,device_type=device
+            device_count=TEST_GPU_NUM,device_type=torch.device(device).type
         )
         sharding_plan = planner.build_plan(megatron_lm)
 
@@ -132,6 +137,7 @@ class TestShardingPlan(ShardedTensorTestBase):
         self.assertTrue(isinstance(megatron_lm.fc1.bias, ShardedTensor))
         self.assertTrue(isinstance(megatron_lm.fc2.bias, ShardedTensor))
 
+    @onlyAccelerator
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
@@ -140,15 +146,15 @@ class TestShardingPlan(ShardedTensorTestBase):
         colwise_sharding_spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                f"rank:2/{device}:2",
-                f"rank:3/{device}:3",
+                f"rank:2/{torch.device(device).type}:2",
+                f"rank:3/{torch.device(device).type}:3",
             ],
         )
         rowwise_sharding_spec = ChunkShardingSpec(
             dim=1,
             placements=[
-                f"rank:2/{device}:2",
-                f"rank:3/{device}:3",
+                f"rank:2/{torch.device(device).type}:2",
+                f"rank:3/{torch.device(device).type}:3",
             ],
         )
         sharding_plan = ShardingPlan(

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -8,7 +8,10 @@ from torch.distributed._shard import shard_module
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._shard.sharding_plan import ShardingPlan, ShardingPlanner
 from torch.distributed._shard.sharding_spec import ChunkShardingSpec
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu,requires_accelerator_dist_backend
+from torch.testing._internal.common_distributed import (
+    requires_accelerator_dist_backend,
+    skip_if_lt_x_gpu,
+)
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
@@ -35,9 +38,9 @@ class ChunkAllShardingPlanner(ShardingPlanner):
     dim = 0
     devices = []
 
-    def __init__(self, chunk_dim=0, device_count=0,device_type="cuda"):
+    def __init__(self, chunk_dim=0, device_count=0, device_type="cuda"):
         self.dim = chunk_dim
-        self.devices = [f"rank:{i}/{device_type}:{i}" for i in range(device_count)] 
+        self.devices = [f"rank:{i}/{device_type}:{i}" for i in range(device_count)]
 
     def build_plan(self, module: nn.Module) -> ShardingPlan:
         named_params = module.named_parameters()
@@ -108,7 +111,9 @@ class TestShardingPlan(ShardedTensorTestBase):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).cuda(
             self.rank
         )
-        planner = ChunkAllShardingPlanner(device_count=TEST_GPU_NUM,device_type=self.device_type)
+        planner = ChunkAllShardingPlanner(
+            device_count=TEST_GPU_NUM,device_type=self.device_type
+        )
         sharding_plan = planner.build_plan(megatron_lm)
 
         shard_module(megatron_lm, sharding_plan)

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -8,7 +8,7 @@ from torch.distributed._shard import shard_module
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._shard.sharding_plan import ShardingPlan, ShardingPlanner
 from torch.distributed._shard.sharding_spec import ChunkShardingSpec
-from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu,requires_accelerator_dist_backend
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
@@ -35,9 +35,9 @@ class ChunkAllShardingPlanner(ShardingPlanner):
     dim = 0
     devices = []
 
-    def __init__(self, chunk_dim=0, device_count=0):
+    def __init__(self, chunk_dim=0, device_count=0,device_type="cuda"):
         self.dim = chunk_dim
-        self.devices = [f"rank:{i}/cuda:{i}" for i in range(device_count)]
+        self.devices = [f"rank:{i}/{device_type}:{i}" for i in range(device_count)] 
 
     def build_plan(self, module: nn.Module) -> ShardingPlan:
         named_params = module.named_parameters()
@@ -51,7 +51,7 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 class TestShardingPlan(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     def test_sharding_plan_errors(self):
         rowwise_sharding_spec = generate_chunk_sharding_specs_for_test(1)[0]
         sharding_plan_wrong_plan = ShardingPlan(
@@ -61,7 +61,8 @@ class TestShardingPlan(ShardedTensorTestBase):
             output_plan={"": rowwise_sharding_spec},
         )
 
-        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]]).cuda(self.rank)
+        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(torch.device(self.device_type, self.rank)
+)
 
         with self.assertRaisesRegex(
             TypeError, "Only `ShardingSpec` and `Sharder` are supported to shard"
@@ -102,12 +103,12 @@ class TestShardingPlan(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     def test_custom_sharding_planner(self):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).cuda(
             self.rank
         )
-        planner = ChunkAllShardingPlanner(device_count=TEST_GPU_NUM)
+        planner = ChunkAllShardingPlanner(device_count=TEST_GPU_NUM,device_type=self.device_type)
         sharding_plan = planner.build_plan(megatron_lm)
 
         shard_module(megatron_lm, sharding_plan)
@@ -120,21 +121,21 @@ class TestShardingPlan(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     def test_shard_module_sub_process_group(self):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank)
         colwise_sharding_spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                "rank:2/{self.device_type}:2",
+                "rank:3/{self.device_type}:3",
             ],
         )
         rowwise_sharding_spec = ChunkShardingSpec(
             dim=1,
             placements=[
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                "rank:2/{self.device_type}:2",
+                "rank:3/{self.device_type}:3",
             ],
         )
         sharding_plan = ShardingPlan(

--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -141,9 +141,9 @@ class StageTest(MultiProcContinuousTest):
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     @parametrize("ModelClass", [ExampleCode, MultiMLP])
     def test_tracer(self, ModelClass):
@@ -190,9 +190,9 @@ class StageTest(MultiProcContinuousTest):
                 f"Some keys not found in old_keys: {[k for k in submod_keys if k not in old_keys]}"
             )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     @parametrize("ModelClass", [ModelWithKwargs])
     def test_tracer_kwargs(self, ModelClass):
@@ -244,9 +244,9 @@ class StageTest(MultiProcContinuousTest):
                 f"Some keys not found in old_keys: {[k for k in submod_keys if k not in old_keys]}"
             )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     def test_manual(self):
         full_mod = MultiMLP(d_hid, n_layers=self.world_size)
@@ -278,9 +278,9 @@ class StageTest(MultiProcContinuousTest):
             ref_out = full_mod(x)
             torch.testing.assert_close(out, ref_out)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     def test_custom_dw_with_fb_schedule(self):
         """Tests that separate weight grad function 'dw_runner' gets run under a schedule that's only aware of F/B."""
@@ -340,9 +340,9 @@ class StageTest(MultiProcContinuousTest):
             ref_out = full_mod(x)
             torch.testing.assert_close(out, ref_out)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     def test_output_chunks_memory_usage(self):
         """Test that output_chunks doesn't store memory for non-first stages."""
@@ -417,9 +417,9 @@ class StageNegativeTest(MultiProcContinuousTest):
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     def test_shape_prop_mismatch(self):
         """Tests shape prop errors are raised"""
@@ -466,9 +466,9 @@ class StageNegativeTest(MultiProcContinuousTest):
             with self.assertRaisesRegex(PipeliningMetadataError, "dtype mismatch"):
                 _run_step(x)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     def test_custom_dw_errors(self):
         """Tests expected errors are raised"""

--- a/test/test_as_strided.py
+++ b/test/test_as_strided.py
@@ -3,7 +3,11 @@
 from collections import deque
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def get_state(t: torch.Tensor) -> tuple[tuple[int, ...], tuple[int, ...]]:
@@ -84,6 +88,8 @@ def enumerate_reachable_states(
 
 
 class TestAsStrided(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_size_10_exhaustive(self) -> None:
         """Test that size 10 produces exactly the expected 54 states."""
         expected_states = {

--- a/test/test_function_schema.py
+++ b/test/test_function_schema.py
@@ -2,10 +2,12 @@
 
 import torch
 from torch._C import parse_schema
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase, HardwareClassification
 
 
 class TestFunctionSchema(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_serialize_and_deserialize(self):
         schemas = torch._C._jit_get_all_schemas()
         # so far we have around 1700 registered schemas

--- a/test/test_namedtuple_return_api.py
+++ b/test/test_namedtuple_return_api.py
@@ -6,7 +6,7 @@ import yaml
 import textwrap
 import torch
 
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests, HardwareClassification
 from collections import namedtuple
 
 
@@ -35,6 +35,7 @@ all_operators_with_namedtuple_return_skip_list = {
 
 
 class TestNamedTupleAPI(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_import_return_types(self):
         import torch.return_types  # noqa: F401

--- a/test/test_native_functions.py
+++ b/test/test_native_functions.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: unknown"]
 
 import torch
-from torch.testing._internal.common_utils import TestCase, run_tests, skipIfTorchDynamo
+from torch.testing._internal.common_utils import TestCase, run_tests, skipIfTorchDynamo, HardwareClassification
 
 # End-to-end tests of features in native_functions.yaml
 
@@ -17,6 +17,7 @@ class IntListWrapperModule(torch.nn.Module):
 
 
 class TestNativeFunctions(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def _lists_with_str(self):
         return [

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -10,6 +10,7 @@ from torch.testing._internal.common_device_type import (
     dtypes,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     TestCase,
     run_tests,
     gradcheck,
@@ -36,6 +37,8 @@ def get_default_value(initial_value, reduction):
 
 
 class TestSegmentReductions(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _test_common(
         self,
         reduction,

--- a/test/test_type_info.py
+++ b/test/test_type_info.py
@@ -2,6 +2,7 @@
 # Owner(s): ["module: typing"]
 
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     load_tests,
     run_tests,
     set_default_dtype,
@@ -25,6 +26,8 @@ if TEST_NUMPY:
 
 
 class TestDTypeInfo(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_invalid_input(self):
         for dtype in [
             torch.float16,

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -50,6 +50,8 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
     TEST_WITH_TSAN,
     TEST_XPU,
+    TEST_PRIVATEUSE1,
+    TEST_PRIVATEUSE1_DEVICE_TYPE,
     TestCase,
 )
 from torch.testing._internal.distributed.multi_threaded_pg import (
@@ -549,22 +551,28 @@ def requires_accelerator_dist_backend(backends=None):
     Decorator to skip tests if no accelerator communication backend (NCCL, XCCL, HCCL) is available.
 
     Args:
-        backends (Optional[List[str]]): Specific accelerator backends to check (e.g., ["nccl", "xccl", "hccl"]).
+        backends (Optional[List[str]]): Specific accelerator backends to check (e.g., ["nccl", "xccl", "hccl", "privateuse1"]).
                                        If None, checks all supported accelerator backends (NCCL, XCCL, HCCL).
 
     Returns:
         callable: A decorator that skips the test if no specified accelerator backend is available.
+
+    Note:
+        "privateuse1" is a placeholder resolved to the actual backend name for PrivateUse1 at call time via ``Backend.default_device_backend_map``.
     """
     if backends is None:
         backends = ACCELERATOR_DIST_BACKENDS
+    
+    _resolve = lambda backend: (
+        c10d.Backend.default_device_backend_map.get(TEST_PRIVATEUSE1_DEVICE_TYPE)
+        if backend == "privateuse1" and TEST_PRIVATEUSE1
+        else (None if backend == "privateuse1" else backend)
+    )
 
     backend_available = any(
-        {
-            "nccl": c10d.is_nccl_available,
-            "xccl": c10d.is_xccl_available,
-            "hccl": lambda: TEST_HPU,
-        }.get(backend, lambda: False)()
-        for backend in backends
+        c10d.is_backend_available(backend)
+        for backend in (_resolve(b) for b in backends)
+        if backend is not None
     )
 
     return skip_but_pass_in_sandcastle_if(

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -312,6 +312,10 @@ def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:
 def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     """Skip if fewer than x accelerators available.
 
+    NOTE: The naming retains "gpu" for backward compatibility, but the logic
+    is hardware-agnostic and works for any accelerator supported by
+    torch.accelerator (e.g., CUDA, XPU, HPU, and PrivateUse1-based backends).
+
     Args:
         x: Minimum number of accelerators required.
         allow_cpu: If True, run the test on CPU-only machines (no accelerators).
@@ -320,15 +324,23 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if torch.cuda.is_available() and torch.cuda.device_count() >= x:
+            acc = torch.accelerator.current_accelerator()
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.is_available() and device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
                 return func(*args, **kwargs)
-            if TEST_HPU and torch.hpu.device_count() >= x:
-                return func(*args, **kwargs)
-            if TEST_XPU and torch.xpu.device_count() >= x:
-                return func(*args, **kwargs)
-            if allow_cpu and not (torch.cuda.is_available() or TEST_HPU or TEST_XPU):
-                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-gpu-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
             test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -33,9 +33,14 @@ class ShardedTensorTestBase(MultiProcessTestCase):
         )
 
         # Set the per-rank device for the current accelerator backend.
-        if torch.accelerator.is_available():
-            device_type = torch.accelerator.current_accelerator().type
-            if backend == dist.get_default_backend_for_device(device_type):
+        accelerator = torch.accelerator.current_accelerator()
+        if accelerator is not None:
+            device_type = accelerator.type
+            # Keep the existing HPU/HCCL behavior unchanged.
+            if (
+                device_type != "hpu"
+                and backend == dist.get_default_backend_for_device(device_type)
+            ):
                 torch.accelerator.set_device_index(self.rank)
 
     def init_rpc(self):

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -32,9 +32,11 @@ class ShardedTensorTestBase(MultiProcessTestCase):
             init_method=f"file://{self.file_name}",
         )
 
-        # set device for nccl pg for collectives
-        if backend == "nccl" or backend == "xccl":
-            torch.accelerator.set_device_index(self.rank)
+        # Set the per-rank device for the current accelerator backend.
+        if torch.accelerator.is_available():
+            device_type = torch.accelerator.current_accelerator().type
+            if backend == dist.get_default_backend_for_device(device_type):
+                torch.accelerator.set_device_index(self.rank)
 
     def init_rpc(self):
         rpc_backend_options = rpc.TensorPipeRpcBackendOptions(


### PR DESCRIPTION
This PR makes `test/distributed/_shard/sharding_plan/test_sharding_plan.py` device-agnostic by replacing hard-coded CUDA calls with `self.device_type`, enabling tests to run on any accelerator (CUDA, NPU, XPU, etc.).

- Replaced `.cuda(self.rank)` with `.to(torch.device(self.device_type, self.rank))` in test methods.
- Updated `ChunkAllShardingPlanner` to accept `device_type` parameter instead of hard-coding `"cuda"`.
- Fixed `placements` strings in `test_shard_module_sub_process_group` to use `self.device_type`.

The original test only supported CUDA devices. This change enables distributed sharding tests to run on out-of-tree backends (e.g., NPU, PrivateUse1-based accelerators) without modification.

- CI: `python test/distributed/_shard/sharding_plan/test_sharding_plan.py`
- Verified locally on CPU and NPU.

- Uses existing `ShardedTensorTestBase.device_type` property for device detection.
- Enables existing test infrastructure (`@skip_if_lt_x_gpu`, `@requires_accelerator_dist_backend`) to work with device-agnostic code.
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal