### PR TITLE
[Testcase Refactoring] Mark test_create_cpu_state_dict as CUDA-only

### DIFF
--- a/test/distributed/checkpoint/test_state_dict_utils.py
+++ b/test/distributed/checkpoint/test_state_dict_utils.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 import copy
 import io
+import unittest
 
 import torch
 import torch.distributed as dist
@@ -21,6 +22,7 @@ from torch.distributed._state_dict_utils import (
 )
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Shard
+from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -128,6 +130,10 @@ class TestStateDictUtils(DTensorTestBase):
         }
         self.assertEqual(state_dict, _gather_state_dict(dist_state_dict))
 
+    @unittest.skipIf(
+        not TEST_CUDA,
+        "The shared and pinned CPU state dict path requires CUDA",
+    )
     @with_comms
     @skip_if_lt_x_gpu(2)
     def test_create_cpu_state_dict(self):


### PR DESCRIPTION
## Issue

Part of #185590.

This is a companion change for #187650, which makes `skip_if_lt_x_gpu` hardware-agnostic for out-of-tree accelerator backends.

## Summary

`TestStateDictUtils.test_create_cpu_state_dict` exercises the combined `share_memory=True` and `pin_memory=True` path, which currently uses CUDA host registration.

Mark the test as CUDA-only so that non-CUDA accelerator backends enabled by #187650 do not enter this CUDA-specific path.

## Changes

- Import `TEST_CUDA`.
- Add a method-level `unittest.skipIf(not TEST_CUDA, ...)` guard to `test_create_cpu_state_dict`.

## Test Plan

Target test:

```text
python test/distributed/checkpoint/test_state_dict_utils.py TestStateDictUtils.test_create_cpu_state_dict -v
```

Results:

- CPU: skipped as expected (`OK (skipped=1)`).
- NPU/HCCL: skipped as expected (`OK (skipped=1)`).
- CUDA/NCCL: executed successfully (`Ran 1 test`, `OK`, no skips).

## BC-breaking?

No.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian