### PR TITLE
Add FlyDSL native topk override

### DIFF
--- a/test/python_native/test_topk_flydsl.py
+++ b/test/python_native/test_topk_flydsl.py
@@ -1,0 +1,240 @@
+# Owner(s): ["module: dsl-native-ops"]
+
+import unittest
+
+import torch
+import torch._native
+import torch.backends.python_native as pn
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
+_REGISTER_KS = (2, 4, 8, 16)
+_RADIX_KS = (64, 128, 256, 512, 1024)
+_SUPPORTED_KS = _REGISTER_KS + _RADIX_KS
+
+
+def _flydsl_topk_registered() -> bool:
+    try:
+        ops = pn.get_dsl_operations("flydsl")
+        return "topk" in ops and "topk.values" in ops
+    except Exception:
+        return False
+
+
+def _test_n(k: int) -> int:
+    from torch._native.ops.topk.flydsl_impl import _RADIX_N_RANGE, _REGISTER_N_RANGE
+
+    if k in _REGISTER_KS:
+        return _REGISTER_N_RANGE[0]
+    return _RADIX_N_RANGE[k][0]
+
+
+@unittest.skipUnless(TEST_CUDA and torch.version.hip is not None, "ROCm required")
+@unittest.skipUnless(_flydsl_topk_registered(), "FlyDSL topk override not registered")
+class TestFlyDSLTopK(TestCase):
+    def setUp(self):
+        super().setUp()
+        from torch._native.ops.topk.flydsl_kernels import clear_topk_cache
+
+        clear_topk_cache()
+
+    def _make_input(self, *, shape=(512, 512)):
+        torch.manual_seed(0)
+        return torch.randn(shape, device="cuda", dtype=torch.float32)
+
+    def _assert_topk_matches_aten(self, x: torch.Tensor, k: int) -> None:
+        with pn.flydsl.disabled():
+            ref_v, _ = torch.topk(x, k, dim=-1)
+        got_v, got_i = torch.topk(x, k, dim=-1)
+        self.assertEqual(got_v, ref_v)
+        self.assertEqual(torch.gather(x, -1, got_i), got_v)
+        if k >= 2:
+            diffs = got_v[..., :-1] - got_v[..., 1:]
+            self.assertTrue((diffs >= 0).all(), "output is not descending")
+
+    @parametrize("k", _SUPPORTED_KS)
+    def test_correctness_random_gaussian(self, k: int):
+        torch.manual_seed(0)
+        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        self._assert_topk_matches_aten(x, k)
+
+    @parametrize("k", _SUPPORTED_KS)
+    def test_correctness_with_duplicates(self, k: int):
+        torch.manual_seed(1)
+        x = torch.randint(0, 50, (256, _test_n(k)), device="cuda", dtype=torch.float32)
+        self._assert_topk_matches_aten(x, k)
+
+    @parametrize("k", _SUPPORTED_KS)
+    def test_correctness_with_extreme_values(self, k: int):
+        torch.manual_seed(2)
+        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        x[:, 0] = float("inf")
+        x[:, 1] = float("-inf")
+        x[:, 2] = 1e38
+        x[:, 3] = -1e38
+        self._assert_topk_matches_aten(x, k)
+
+    @parametrize("k", (8, 512))
+    def test_correctness_with_nan(self, k: int):
+        import struct
+
+        torch.manual_seed(10)
+        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        neg_nan = struct.unpack("<f", struct.pack("<I", 0xFFC00000))[0]
+        x[:, 0] = float("nan")
+        x[:, 1] = neg_nan
+        x[:, 2] = float("inf")
+        x[:, 3] = float("-inf")
+        with pn.flydsl.disabled():
+            ref_v, _ = torch.topk(x, k, dim=-1)
+        got_v, got_i = torch.topk(x, k, dim=-1)
+        self.assertEqual(torch.gather(x, -1, got_i), got_v)
+        self.assertEqual(got_v.isnan().sum(dim=-1), ref_v.isnan().sum(dim=-1))
+        ref_finite = ref_v.masked_select(~ref_v.isnan()).reshape(256, -1)
+        got_finite = got_v.masked_select(~got_v.isnan()).reshape(256, -1)
+        self.assertEqual(got_finite, ref_finite)
+
+    @parametrize("k", _SUPPORTED_KS)
+    def test_nd_input(self, k: int):
+        torch.manual_seed(3)
+        n = _test_n(k)
+        x = torch.randn(4, 64, n, device="cuda", dtype=torch.float32)
+        self._assert_topk_matches_aten(x, k)
+        got_v, _ = torch.topk(x, k, dim=-1)
+        self.assertEqual(got_v.shape, (4, 64, k))
+
+    @parametrize("k", _SUPPORTED_KS)
+    def test_out_variant(self, k: int):
+        torch.manual_seed(4)
+        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        with pn.flydsl.disabled():
+            ref_v, _ = torch.topk(x, k, dim=-1)
+
+        out_v = torch.empty(256, k, dtype=torch.float32, device="cuda")
+        out_i = torch.empty(256, k, dtype=torch.int64, device="cuda")
+        got_v, got_i = torch.topk(x, k, dim=-1, out=(out_v, out_i))
+        self.assertIs(got_v, out_v)
+        self.assertIs(got_i, out_i)
+        self.assertEqual(got_v, ref_v)
+        self.assertEqual(torch.gather(x, -1, got_i), got_v)
+
+    def test_topk_uses_cache(self):
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
+        # Use a (k, n) that hits the register-kernel gate so the FlyDSL path
+        # actually compiles; both calls share one specialization so the second
+        # is a cache hit.
+        k = 8
+        n = _test_n(k)
+        x = self._make_input(shape=(256, n))
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, k, dim=-1)
+
+        got = torch.topk(x, k, dim=-1)
+        self.assertEqual(got.values, ref.values)
+        self.assertEqual(got.indices, ref.indices)
+
+        x3 = self._make_input(shape=(8, 32, n))
+        with pn.flydsl.disabled():
+            ref3 = torch.topk(x3, k, dim=-1)
+        got3 = torch.topk(x3, k, dim=-1)
+        self.assertEqual(got3.values, ref3.values)
+        self.assertEqual(got3.indices, ref3.indices)
+
+        info = topk_cache_info()
+        self.assertEqual(info.misses, 1)
+        self.assertGreaterEqual(info.hits, 1)
+        self.assertEqual(info.currsize, 1)
+
+    def test_user_disable_falls_back_to_aten(self):
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
+        x = self._make_input()
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, 8, dim=-1)
+            got = torch.topk(x, 8, dim=-1)
+
+        self.assertEqual(got.values, ref.values)
+        self.assertEqual(got.indices, ref.indices)
+        self.assertEqual(topk_cache_info().misses, 0)
+
+    def test_unsupported_k_falls_through(self):
+        torch.manual_seed(5)
+        x = torch.randn(256, 512, device="cuda", dtype=torch.float32)
+        for bad_k in (1, 10, 32):
+            with pn.flydsl.disabled():
+                ref = torch.topk(x, bad_k, dim=-1)
+            got = torch.topk(x, bad_k, dim=-1)
+            self.assertEqual(got.values, ref.values)
+            self.assertEqual(got.indices, ref.indices)
+
+    def test_register_non_power_of_two_n_falls_through(self):
+        torch.manual_seed(8)
+        x = torch.randn(256, 768, device="cuda", dtype=torch.float32)
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, 8, dim=-1)
+        got = torch.topk(x, 8, dim=-1)
+        self.assertEqual(got.values, ref.values)
+        self.assertEqual(got.indices, ref.indices)
+
+    def test_radix_non_multiple_of_four_n(self):
+        torch.manual_seed(11)
+        x = torch.randn(256, 16385, device="cuda", dtype=torch.float32)
+        self._assert_topk_matches_aten(x, 512)
+
+    @parametrize("k", (64, 512))
+    def test_deterministic_mode_matches_aten_with_heavy_ties(self, k: int):
+        torch.manual_seed(6)
+        x = torch.randint(0, 4, (256, _test_n(k)), device="cuda", dtype=torch.float32)
+        with pn.flydsl.disabled():
+            ref_v, ref_i = torch.topk(x, k, dim=-1)
+
+        prior = torch.are_deterministic_algorithms_enabled()
+        try:
+            torch.use_deterministic_algorithms(True)
+            v1, i1 = torch.topk(x, k, dim=-1)
+            v2, i2 = torch.topk(x, k, dim=-1)
+        finally:
+            torch.use_deterministic_algorithms(prior)
+        self.assertEqual(v1, v2)
+        self.assertEqual(i1, i2)
+        self.assertEqual(v1, ref_v)
+        self.assertEqual(i1, ref_i)
+
+    @parametrize("k", _REGISTER_KS)
+    def test_register_stable_with_heavy_ties(self, k: int):
+        torch.manual_seed(9)
+        x = torch.randint(0, 4, (256, _test_n(k)), device="cuda", dtype=torch.float32)
+        with pn.flydsl.disabled():
+            ref_v, _ = torch.topk(x, k, dim=-1)
+        v1, i1 = torch.topk(x, k, dim=-1)
+        v2, i2 = torch.topk(x, k, dim=-1)
+        self.assertEqual(v1, v2)
+        self.assertEqual(i1, i2)
+        self.assertEqual(v1, ref_v)
+        self.assertEqual(torch.gather(x, -1, i1), v1)
+
+    def test_autograd_passes_through(self):
+        torch.manual_seed(7)
+        x = torch.randn(
+            256, 4096, device="cuda", dtype=torch.float32, requires_grad=True
+        )
+        v, i = torch.topk(x, 256, dim=-1)
+        v.sum().backward()
+        self.assertIsNotNone(x.grad)
+        expected = torch.zeros_like(x)
+        expected.scatter_(-1, i, 1.0)
+        self.assertEqual(x.grad, expected)
+
+
+instantiate_parametrized_tests(TestFlyDSLTopK)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_topk_flydsl.py
+++ b/test/python_native/test_topk_flydsl.py
@@ -5,6 +5,7 @@ import unittest
 import torch
 import torch._native
 import torch.backends.python_native as pn
+from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -15,28 +16,108 @@ from torch.testing._internal.common_utils import (
 
 
 _REGISTER_KS = (2, 4, 8, 16)
-_RADIX_KS = (64, 128, 256, 512, 1024)
+_RADIX_KS = (
+    64,
+    128,
+    192,
+    256,
+    320,
+    384,
+    448,
+    512,
+    576,
+    640,
+    704,
+    768,
+    832,
+    896,
+    960,
+    1024,
+)
+_NON_STEP_RADIX_KS = (65, 257, 319, 385, 511, 513, 703, 705, 767, 833, 1023)
 _SUPPORTED_KS = _REGISTER_KS + _RADIX_KS
 
 
-def _flydsl_topk_registered() -> bool:
-    try:
-        ops = pn.get_dsl_operations("flydsl")
-        return "topk" in ops and "topk.values" in ops
-    except Exception:
-        return False
+def _unsupported_environment_reason() -> str | None:
+    if not TEST_CUDA or torch.version.hip is None:
+        return "ROCm required"
+
+    from torch._native import flydsl_utils as fu
+
+    if fu.check_native_jit_disabled():
+        return "native DSL overrides are disabled via TORCH_DISABLE_NATIVE_JIT"
+    if not fu.runtime_available():
+        return "FlyDSL runtime is not installed"
+    if not fu._version_is_ok():
+        return f"FlyDSL {fu.runtime_version()} is outside the supported release"
+    return None
+
+
+_UNSUPPORTED_REASON = _unsupported_environment_reason()
 
 
 def _test_n(k: int) -> int:
-    from torch._native.ops.topk.flydsl_impl import _RADIX_N_RANGE, _REGISTER_N_RANGE
+    from torch._native.ops.topk.flydsl_impl import _radix_n_range, _REGISTER_N_RANGE
 
     if k in _REGISTER_KS:
         return _REGISTER_N_RANGE[0]
-    return _RADIX_N_RANGE[k][0]
+    n_range = _radix_n_range(k)
+    if n_range is None:
+        raise AssertionError(f"missing radix gate for K={k}")
+    return n_range[0]
 
 
-@unittest.skipUnless(TEST_CUDA and torch.version.hip is not None, "ROCm required")
-@unittest.skipUnless(_flydsl_topk_registered(), "FlyDSL topk override not registered")
+def _test_m(device_index: int | None = None) -> int:
+    from torch._native.ops.topk.flydsl_impl import _min_rows_for_full_wave
+
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    return max(256, _min_rows_for_full_wave(device_index))
+
+
+class TestFlyDSLTopKHelpers(TestCase):
+    @parametrize(
+        "k,n,expected",
+        (
+            (2, 1024, "register"),
+            (4, 8192, "register"),
+            (8, 4096, "register"),
+            (16, 1024, "register"),
+            (8, 1023, None),
+            (8, 8193, None),
+            (8, 1537, None),
+            (64, 4096, "radix"),
+            (65, 4096, "radix"),
+            (128, 4096, "radix"),
+            (192, 4096, "radix"),
+            (256, 32768, "radix"),
+            (319, 32768, "radix"),
+            (321, 4096, None),
+            (512, 131072, "radix"),
+            (512, 262144, None),
+            (703, 131072, "radix"),
+            (704, 131072, "radix"),
+            (705, 131072, "radix"),
+            (769, 32768, None),
+            (833, 32768, "radix"),
+            (1023, 262144, "radix"),
+            (1024, 32768, "radix"),
+            (64, 4095, None),
+            (64, 32769, None),
+            (832, 16384, None),
+            (1024, 32767, None),
+            (1024, 262145, None),
+            (1088, 32768, None),
+            (32, 4096, None),
+        ),
+    )
+    def test_kernel_selection(self, k: int, n: int, expected: str | None):
+        from torch._native.ops.topk.flydsl_impl import _kernel_for
+
+        self.assertEqual(_kernel_for(k, n), expected)
+
+
+@unittest.skipIf(_UNSUPPORTED_REASON is not None, str(_UNSUPPORTED_REASON))
 class TestFlyDSLTopK(TestCase):
     def setUp(self):
         super().setUp()
@@ -44,36 +125,57 @@ class TestFlyDSLTopK(TestCase):
 
         clear_topk_cache()
 
-    def _make_input(self, *, shape=(512, 512)):
+    def _make_input(self, *, shape):
         torch.manual_seed(0)
-        return torch.randn(shape, device="cuda", dtype=torch.float32)
+        return make_tensor(shape, device="cuda", dtype=torch.float32)
+
+    def _assert_no_flydsl_compiles(self) -> None:
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
+        self.assertEqual(topk_cache_info().misses, 0)
 
     def _assert_topk_matches_aten(self, x: torch.Tensor, k: int) -> None:
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
         with pn.flydsl.disabled():
             ref_v, _ = torch.topk(x, k, dim=-1)
         got_v, got_i = torch.topk(x, k, dim=-1)
+        self.assertEqual(topk_cache_info().misses, 1)
         self.assertEqual(got_v, ref_v)
         self.assertEqual(torch.gather(x, -1, got_i), got_v)
         if k >= 2:
             diffs = got_v[..., :-1] - got_v[..., 1:]
             self.assertTrue((diffs >= 0).all(), "output is not descending")
 
+    def test_override_is_registered(self):
+        operations = pn.get_dsl_operations("flydsl")
+        self.assertIn("topk", operations)
+        self.assertIn("topk.values", operations)
+
     @parametrize("k", _SUPPORTED_KS)
     def test_correctness_random_gaussian(self, k: int):
         torch.manual_seed(0)
-        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        x = make_tensor((_test_m(), _test_n(k)), device="cuda", dtype=torch.float32)
+        self._assert_topk_matches_aten(x, k)
+
+    @parametrize("k", _NON_STEP_RADIX_KS)
+    def test_correctness_non_step_radix_k(self, k: int):
+        torch.manual_seed(12)
+        x = make_tensor((_test_m(), _test_n(k)), device="cuda", dtype=torch.float32)
         self._assert_topk_matches_aten(x, k)
 
     @parametrize("k", _SUPPORTED_KS)
     def test_correctness_with_duplicates(self, k: int):
         torch.manual_seed(1)
-        x = torch.randint(0, 50, (256, _test_n(k)), device="cuda", dtype=torch.float32)
+        x = torch.randint(
+            0, 50, (_test_m(), _test_n(k)), device="cuda", dtype=torch.float32
+        )
         self._assert_topk_matches_aten(x, k)
 
     @parametrize("k", _SUPPORTED_KS)
     def test_correctness_with_extreme_values(self, k: int):
         torch.manual_seed(2)
-        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        x = make_tensor((_test_m(), _test_n(k)), device="cuda", dtype=torch.float32)
         x[:, 0] = float("inf")
         x[:, 1] = float("-inf")
         x[:, 2] = 1e38
@@ -84,8 +186,11 @@ class TestFlyDSLTopK(TestCase):
     def test_correctness_with_nan(self, k: int):
         import struct
 
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
         torch.manual_seed(10)
-        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        m = _test_m()
+        x = make_tensor((m, _test_n(k)), device="cuda", dtype=torch.float32)
         neg_nan = struct.unpack("<f", struct.pack("<I", 0xFFC00000))[0]
         x[:, 0] = float("nan")
         x[:, 1] = neg_nan
@@ -94,31 +199,37 @@ class TestFlyDSLTopK(TestCase):
         with pn.flydsl.disabled():
             ref_v, _ = torch.topk(x, k, dim=-1)
         got_v, got_i = torch.topk(x, k, dim=-1)
+        self.assertEqual(topk_cache_info().misses, 1)
         self.assertEqual(torch.gather(x, -1, got_i), got_v)
         self.assertEqual(got_v.isnan().sum(dim=-1), ref_v.isnan().sum(dim=-1))
-        ref_finite = ref_v.masked_select(~ref_v.isnan()).reshape(256, -1)
-        got_finite = got_v.masked_select(~got_v.isnan()).reshape(256, -1)
+        ref_finite = ref_v.masked_select(~ref_v.isnan()).reshape(m, -1)
+        got_finite = got_v.masked_select(~got_v.isnan()).reshape(m, -1)
         self.assertEqual(got_finite, ref_finite)
 
     @parametrize("k", _SUPPORTED_KS)
     def test_nd_input(self, k: int):
         torch.manual_seed(3)
         n = _test_n(k)
-        x = torch.randn(4, 64, n, device="cuda", dtype=torch.float32)
+        rows = (_test_m() + 3) // 4
+        x = make_tensor((4, rows, n), device="cuda", dtype=torch.float32)
         self._assert_topk_matches_aten(x, k)
         got_v, _ = torch.topk(x, k, dim=-1)
-        self.assertEqual(got_v.shape, (4, 64, k))
+        self.assertEqual(got_v.shape, (4, rows, k))
 
     @parametrize("k", _SUPPORTED_KS)
     def test_out_variant(self, k: int):
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
         torch.manual_seed(4)
-        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        m = _test_m()
+        x = make_tensor((m, _test_n(k)), device="cuda", dtype=torch.float32)
         with pn.flydsl.disabled():
             ref_v, _ = torch.topk(x, k, dim=-1)
 
-        out_v = torch.empty(256, k, dtype=torch.float32, device="cuda")
-        out_i = torch.empty(256, k, dtype=torch.int64, device="cuda")
+        out_v = torch.empty(m, k, dtype=torch.float32, device="cuda")
+        out_i = torch.empty(m, k, dtype=torch.int64, device="cuda")
         got_v, got_i = torch.topk(x, k, dim=-1, out=(out_v, out_i))
+        self.assertEqual(topk_cache_info().misses, 1)
         self.assertIs(got_v, out_v)
         self.assertIs(got_i, out_i)
         self.assertEqual(got_v, ref_v)
@@ -127,7 +238,9 @@ class TestFlyDSLTopK(TestCase):
     def test_topk_uses_cache(self):
         from torch._native.ops.topk.flydsl_kernels import topk_cache_info
 
-        x = self._make_input(shape=(512, 512))
+        n = _test_n(8)
+        m = _test_m()
+        x = self._make_input(shape=(m, n))
         with pn.flydsl.disabled():
             ref = torch.topk(x, 8, dim=-1)
 
@@ -135,7 +248,7 @@ class TestFlyDSLTopK(TestCase):
         self.assertEqual(got.values, ref.values)
         self.assertEqual(got.indices, ref.indices)
 
-        x3 = self._make_input(shape=(8, 64, 512))
+        x3 = self._make_input(shape=(2, (m + 1) // 2, n))
         with pn.flydsl.disabled():
             ref3 = torch.topk(x3, 8, dim=-1)
         got3 = torch.topk(x3, 8, dim=-1)
@@ -147,50 +260,143 @@ class TestFlyDSLTopK(TestCase):
         self.assertGreaterEqual(info.hits, 1)
         self.assertEqual(info.currsize, 1)
 
-    def test_user_disable_falls_back_to_aten(self):
+    def test_user_disable_falls_back_and_restores(self):
         from torch._native.ops.topk.flydsl_kernels import topk_cache_info
 
-        x = self._make_input()
+        x = self._make_input(shape=(_test_m(), _test_n(8)))
         with pn.flydsl.disabled():
             ref = torch.topk(x, 8, dim=-1)
-            got = torch.topk(x, 8, dim=-1)
+            disabled = torch.topk(x, 8, dim=-1)
+            self._assert_no_flydsl_compiles()
 
+        got = torch.topk(x, 8, dim=-1)
+        self.assertEqual(disabled, ref)
+        self.assertEqual(got.values, ref.values)
+        self.assertEqual(torch.gather(x, -1, got.indices), got.values)
+        self.assertEqual(topk_cache_info().misses, 1)
+
+    @parametrize("bad_k", (1, 10, 32, 1088))
+    def test_unsupported_k_falls_through_without_compiling(self, bad_k: int):
+        torch.manual_seed(5)
+        x = make_tensor((_test_m(), 4096), device="cuda", dtype=torch.float32)
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, bad_k, dim=-1)
+        got = torch.topk(x, bad_k, dim=-1)
+        self._assert_no_flydsl_compiles()
         self.assertEqual(got.values, ref.values)
         self.assertEqual(got.indices, ref.indices)
-        self.assertEqual(topk_cache_info().misses, 0)
-
-    def test_unsupported_k_falls_through(self):
-        torch.manual_seed(5)
-        x = torch.randn(256, 512, device="cuda", dtype=torch.float32)
-        for bad_k in (1, 10, 32):
-            with pn.flydsl.disabled():
-                ref = torch.topk(x, bad_k, dim=-1)
-            got = torch.topk(x, bad_k, dim=-1)
-            self.assertEqual(got.values, ref.values)
-            self.assertEqual(got.indices, ref.indices)
 
     @parametrize("k", _REGISTER_KS)
-    def test_register_non_power_of_two_n(self, k: int):
-        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
-
+    def test_register_non_power_of_two_n_falls_through_without_compiling(self, k: int):
         torch.manual_seed(8)
-        x = torch.randn(512, 1537, device="cuda", dtype=torch.float32)
+        x = make_tensor((_test_m(), 1537), device="cuda", dtype=torch.float32)
         with pn.flydsl.disabled():
-            ref_v, _ = torch.topk(x, k, dim=-1)
-        got_v, got_i = torch.topk(x, k, dim=-1)
-        self.assertEqual(got_v, ref_v)
-        self.assertEqual(torch.gather(x, -1, got_i), got_v)
-        self.assertEqual(topk_cache_info().misses, 1)
+            ref = torch.topk(x, k, dim=-1)
+        got = torch.topk(x, k, dim=-1)
+        self._assert_no_flydsl_compiles()
+        self.assertEqual(got, ref)
 
     def test_radix_non_multiple_of_four_n(self):
         torch.manual_seed(11)
-        x = torch.randn(256, 16385, device="cuda", dtype=torch.float32)
+        x = make_tensor((_test_m(), 16385), device="cuda", dtype=torch.float32)
         self._assert_topk_matches_aten(x, 512)
 
-    @parametrize("k", (64, 512))
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    def test_unsupported_dtype_falls_through_without_compiling(self, dtype):
+        x = make_tensor((_test_m(), _test_n(8)), device="cuda", dtype=dtype)
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, 8, dim=-1)
+        got = torch.topk(x, 8, dim=-1)
+        self._assert_no_flydsl_compiles()
+        self.assertEqual(got.values, ref.values)
+        self.assertEqual(torch.gather(x, -1, got.indices), got.values)
+
+    @parametrize("largest,sorted_", ((False, True), (True, False)))
+    def test_unsupported_options_fall_through_without_compiling(
+        self, largest: bool, sorted_: bool
+    ):
+        x = self._make_input(shape=(_test_m(), _test_n(8)))
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, 8, dim=-1, largest=largest, sorted=sorted_)
+        got = torch.topk(x, 8, dim=-1, largest=largest, sorted=sorted_)
+        self._assert_no_flydsl_compiles()
+        self.assertEqual(torch.gather(x, -1, got.indices), got.values)
+        got_values = torch.sort(got.values, descending=largest).values
+        ref_values = torch.sort(ref.values, descending=largest).values
+        self.assertEqual(got_values, ref_values)
+
+    def test_non_last_dim_falls_through_without_compiling(self):
+        x = self._make_input(shape=(_test_m(), _test_n(8)))
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, 8, dim=0)
+        got = torch.topk(x, 8, dim=0)
+        self._assert_no_flydsl_compiles()
+        self.assertEqual(got, ref)
+
+    def test_noncontiguous_input_falls_through_without_compiling(self):
+        base = self._make_input(shape=(_test_n(8), _test_m()))
+        x = base.transpose(0, 1)
+        self.assertFalse(x.is_contiguous())
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, 8, dim=-1)
+        got = torch.topk(x, 8, dim=-1)
+        self._assert_no_flydsl_compiles()
+        self.assertEqual(got, ref)
+
+    def test_too_few_rows_falls_through_without_compiling(self):
+        from torch._native.ops.topk.flydsl_impl import _min_rows_for_full_wave
+
+        rows = _min_rows_for_full_wave(torch.cuda.current_device()) - 1
+        x = self._make_input(shape=(rows, _test_n(8)))
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, 8, dim=-1)
+        got = torch.topk(x, 8, dim=-1)
+        self._assert_no_flydsl_compiles()
+        self.assertEqual(got, ref)
+
+    def test_cow_input_falls_through_and_remains_cow(self):
+        x = self._make_input(shape=(_test_m(), _test_n(8)))._lazy_clone()
+        self.assertTrue(torch._C._is_cow_tensor(x))
+        data_ptr = x.const_data_ptr()
+
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, 8, dim=-1)
+        got = torch.topk(x, 8, dim=-1)
+
+        self._assert_no_flydsl_compiles()
+        self.assertEqual(got, ref)
+        self.assertTrue(torch._C._is_cow_tensor(x))
+        self.assertEqual(x.const_data_ptr(), data_ptr)
+
+    def test_noncontiguous_out_dispatches_and_matches_aten(self):
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
+        k = 8
+        m = _test_m()
+        x = self._make_input(shape=(m, _test_n(k)))
+        with pn.flydsl.disabled():
+            ref_v, _ = torch.topk(x, k, dim=-1)
+
+        values = torch.empty((m, 2 * k), device="cuda", dtype=torch.float32)[:, ::2]
+        indices = torch.empty((m, 2 * k), device="cuda", dtype=torch.int64)[:, ::2]
+        self.assertFalse(values.is_contiguous())
+        self.assertFalse(indices.is_contiguous())
+
+        got_v, got_i = torch.topk(x, k, dim=-1, out=(values, indices))
+        self.assertEqual(topk_cache_info().misses, 1)
+        self.assertIs(got_v, values)
+        self.assertIs(got_i, indices)
+        self.assertEqual(got_v, ref_v)
+        self.assertEqual(torch.gather(x, -1, got_i), got_v)
+
+    @parametrize("k", (64, 257, 385, 513, 703, 705, 833, 1023))
     def test_deterministic_mode_matches_aten_with_heavy_ties(self, k: int):
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
         torch.manual_seed(6)
-        x = torch.randint(0, 4, (256, _test_n(k)), device="cuda", dtype=torch.float32)
+        x = torch.randint(
+            0, 4, (_test_m(), _test_n(k)), device="cuda", dtype=torch.float32
+        )
         with pn.flydsl.disabled():
             ref_v, ref_i = torch.topk(x, k, dim=-1)
 
@@ -201,6 +407,7 @@ class TestFlyDSLTopK(TestCase):
             v2, i2 = torch.topk(x, k, dim=-1)
         finally:
             torch.use_deterministic_algorithms(prior)
+        self.assertEqual(topk_cache_info().misses, 1)
         self.assertEqual(v1, v2)
         self.assertEqual(i1, i2)
         self.assertEqual(v1, ref_v)
@@ -208,30 +415,86 @@ class TestFlyDSLTopK(TestCase):
 
     @parametrize("k", _REGISTER_KS)
     def test_register_stable_with_heavy_ties(self, k: int):
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
         torch.manual_seed(9)
-        x = torch.randint(0, 4, (256, _test_n(k)), device="cuda", dtype=torch.float32)
+        x = torch.randint(
+            0, 4, (_test_m(), _test_n(k)), device="cuda", dtype=torch.float32
+        )
         with pn.flydsl.disabled():
             ref_v, _ = torch.topk(x, k, dim=-1)
         v1, i1 = torch.topk(x, k, dim=-1)
         v2, i2 = torch.topk(x, k, dim=-1)
+        self.assertEqual(topk_cache_info().misses, 1)
         self.assertEqual(v1, v2)
         self.assertEqual(i1, i2)
         self.assertEqual(v1, ref_v)
         self.assertEqual(torch.gather(x, -1, i1), v1)
 
     def test_autograd_passes_through(self):
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
         torch.manual_seed(7)
-        x = torch.randn(
-            256, 4096, device="cuda", dtype=torch.float32, requires_grad=True
+        x = make_tensor(
+            (_test_m(), _test_n(8)),
+            device="cuda",
+            dtype=torch.float32,
+            requires_grad=True,
         )
-        v, i = torch.topk(x, 256, dim=-1)
+        v, i = torch.topk(x, 8, dim=-1)
         v.sum().backward()
+        self.assertEqual(topk_cache_info().misses, 1)
         self.assertIsNotNone(x.grad)
         expected = torch.zeros_like(x)
         expected.scatter_(-1, i, 1.0)
         self.assertEqual(x.grad, expected)
 
+    def test_cold_cuda_graph_capture_dispatches_and_replays(self):
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
 
+        k = 8
+        x = self._make_input(shape=(_test_m(), _test_n(k)))
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            got_v, got_i = torch.topk(x, k, dim=-1)
+
+        x.neg_()
+        with pn.flydsl.disabled():
+            ref_v, _ = torch.topk(x, k, dim=-1)
+        got_v.zero_()
+        got_i.zero_()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        self.assertEqual(topk_cache_info().misses, 1)
+        self.assertEqual(got_v, ref_v)
+        self.assertEqual(torch.gather(x, -1, got_i), got_v)
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "requires at least 2 visible CUDA devices",
+    )
+    def test_non_current_device(self):
+        old_device = torch.cuda.current_device()
+        try:
+            torch.cuda.set_device(0)
+            k = 8
+            x = make_tensor(
+                (_test_m(1), _test_n(k)), device="cuda:1", dtype=torch.float32
+            )
+            with pn.flydsl.disabled():
+                ref_v, _ = torch.topk(x, k, dim=-1)
+            got_v, got_i = torch.topk(x, k, dim=-1)
+
+            self.assertEqual(torch.cuda.current_device(), 0)
+            self.assertEqual(got_v.device, torch.device("cuda:1"))
+            self.assertEqual(got_v, ref_v)
+            self.assertEqual(torch.gather(x, -1, got_i), got_v)
+        finally:
+            torch.cuda.set_device(old_device)
+
+
+instantiate_parametrized_tests(TestFlyDSLTopKHelpers)
 instantiate_parametrized_tests(TestFlyDSLTopK)
 
 

--- a/test/python_native/test_topk_flydsl.py
+++ b/test/python_native/test_topk_flydsl.py
@@ -1,0 +1,239 @@
+# Owner(s): ["module: dsl-native-ops"]
+
+import unittest
+
+import torch
+import torch._native
+import torch.backends.python_native as pn
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
+_REGISTER_KS = (2, 4, 8, 16)
+_RADIX_KS = (64, 128, 256, 512, 1024)
+_SUPPORTED_KS = _REGISTER_KS + _RADIX_KS
+
+
+def _flydsl_topk_registered() -> bool:
+    try:
+        ops = pn.get_dsl_operations("flydsl")
+        return "topk" in ops and "topk.values" in ops
+    except Exception:
+        return False
+
+
+def _test_n(k: int) -> int:
+    from torch._native.ops.topk.flydsl_impl import _RADIX_N_RANGE, _REGISTER_N_RANGE
+
+    if k in _REGISTER_KS:
+        return _REGISTER_N_RANGE[0]
+    return _RADIX_N_RANGE[k][0]
+
+
+@unittest.skipUnless(TEST_CUDA and torch.version.hip is not None, "ROCm required")
+@unittest.skipUnless(_flydsl_topk_registered(), "FlyDSL topk override not registered")
+class TestFlyDSLTopK(TestCase):
+    def setUp(self):
+        super().setUp()
+        from torch._native.ops.topk.flydsl_kernels import clear_topk_cache
+
+        clear_topk_cache()
+
+    def _make_input(self, *, shape=(512, 512)):
+        torch.manual_seed(0)
+        return torch.randn(shape, device="cuda", dtype=torch.float32)
+
+    def _assert_topk_matches_aten(self, x: torch.Tensor, k: int) -> None:
+        with pn.flydsl.disabled():
+            ref_v, _ = torch.topk(x, k, dim=-1)
+        got_v, got_i = torch.topk(x, k, dim=-1)
+        self.assertEqual(got_v, ref_v)
+        self.assertEqual(torch.gather(x, -1, got_i), got_v)
+        if k >= 2:
+            diffs = got_v[..., :-1] - got_v[..., 1:]
+            self.assertTrue((diffs >= 0).all(), "output is not descending")
+
+    @parametrize("k", _SUPPORTED_KS)
+    def test_correctness_random_gaussian(self, k: int):
+        torch.manual_seed(0)
+        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        self._assert_topk_matches_aten(x, k)
+
+    @parametrize("k", _SUPPORTED_KS)
+    def test_correctness_with_duplicates(self, k: int):
+        torch.manual_seed(1)
+        x = torch.randint(0, 50, (256, _test_n(k)), device="cuda", dtype=torch.float32)
+        self._assert_topk_matches_aten(x, k)
+
+    @parametrize("k", _SUPPORTED_KS)
+    def test_correctness_with_extreme_values(self, k: int):
+        torch.manual_seed(2)
+        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        x[:, 0] = float("inf")
+        x[:, 1] = float("-inf")
+        x[:, 2] = 1e38
+        x[:, 3] = -1e38
+        self._assert_topk_matches_aten(x, k)
+
+    @parametrize("k", (8, 512))
+    def test_correctness_with_nan(self, k: int):
+        import struct
+
+        torch.manual_seed(10)
+        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        neg_nan = struct.unpack("<f", struct.pack("<I", 0xFFC00000))[0]
+        x[:, 0] = float("nan")
+        x[:, 1] = neg_nan
+        x[:, 2] = float("inf")
+        x[:, 3] = float("-inf")
+        with pn.flydsl.disabled():
+            ref_v, _ = torch.topk(x, k, dim=-1)
+        got_v, got_i = torch.topk(x, k, dim=-1)
+        self.assertEqual(torch.gather(x, -1, got_i), got_v)
+        self.assertEqual(got_v.isnan().sum(dim=-1), ref_v.isnan().sum(dim=-1))
+        ref_finite = ref_v.masked_select(~ref_v.isnan()).reshape(256, -1)
+        got_finite = got_v.masked_select(~got_v.isnan()).reshape(256, -1)
+        self.assertEqual(got_finite, ref_finite)
+
+    @parametrize("k", _SUPPORTED_KS)
+    def test_nd_input(self, k: int):
+        torch.manual_seed(3)
+        n = _test_n(k)
+        x = torch.randn(4, 64, n, device="cuda", dtype=torch.float32)
+        self._assert_topk_matches_aten(x, k)
+        got_v, _ = torch.topk(x, k, dim=-1)
+        self.assertEqual(got_v.shape, (4, 64, k))
+
+    @parametrize("k", _SUPPORTED_KS)
+    def test_out_variant(self, k: int):
+        torch.manual_seed(4)
+        x = torch.randn(256, _test_n(k), device="cuda", dtype=torch.float32)
+        with pn.flydsl.disabled():
+            ref_v, _ = torch.topk(x, k, dim=-1)
+
+        out_v = torch.empty(256, k, dtype=torch.float32, device="cuda")
+        out_i = torch.empty(256, k, dtype=torch.int64, device="cuda")
+        got_v, got_i = torch.topk(x, k, dim=-1, out=(out_v, out_i))
+        self.assertIs(got_v, out_v)
+        self.assertIs(got_i, out_i)
+        self.assertEqual(got_v, ref_v)
+        self.assertEqual(torch.gather(x, -1, got_i), got_v)
+
+    def test_topk_uses_cache(self):
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
+        x = self._make_input(shape=(512, 512))
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, 8, dim=-1)
+
+        got = torch.topk(x, 8, dim=-1)
+        self.assertEqual(got.values, ref.values)
+        self.assertEqual(got.indices, ref.indices)
+
+        x3 = self._make_input(shape=(8, 64, 512))
+        with pn.flydsl.disabled():
+            ref3 = torch.topk(x3, 8, dim=-1)
+        got3 = torch.topk(x3, 8, dim=-1)
+        self.assertEqual(got3.values, ref3.values)
+        self.assertEqual(got3.indices, ref3.indices)
+
+        info = topk_cache_info()
+        self.assertEqual(info.misses, 1)
+        self.assertGreaterEqual(info.hits, 1)
+        self.assertEqual(info.currsize, 1)
+
+    def test_user_disable_falls_back_to_aten(self):
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
+        x = self._make_input()
+        with pn.flydsl.disabled():
+            ref = torch.topk(x, 8, dim=-1)
+            got = torch.topk(x, 8, dim=-1)
+
+        self.assertEqual(got.values, ref.values)
+        self.assertEqual(got.indices, ref.indices)
+        self.assertEqual(topk_cache_info().misses, 0)
+
+    def test_unsupported_k_falls_through(self):
+        torch.manual_seed(5)
+        x = torch.randn(256, 512, device="cuda", dtype=torch.float32)
+        for bad_k in (1, 10, 32):
+            with pn.flydsl.disabled():
+                ref = torch.topk(x, bad_k, dim=-1)
+            got = torch.topk(x, bad_k, dim=-1)
+            self.assertEqual(got.values, ref.values)
+            self.assertEqual(got.indices, ref.indices)
+
+    @parametrize("k", _REGISTER_KS)
+    def test_register_non_power_of_two_n(self, k: int):
+        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
+
+        torch.manual_seed(8)
+        x = torch.randn(512, 1537, device="cuda", dtype=torch.float32)
+        with pn.flydsl.disabled():
+            ref_v, _ = torch.topk(x, k, dim=-1)
+        got_v, got_i = torch.topk(x, k, dim=-1)
+        self.assertEqual(got_v, ref_v)
+        self.assertEqual(torch.gather(x, -1, got_i), got_v)
+        self.assertEqual(topk_cache_info().misses, 1)
+
+    def test_radix_non_multiple_of_four_n(self):
+        torch.manual_seed(11)
+        x = torch.randn(256, 16385, device="cuda", dtype=torch.float32)
+        self._assert_topk_matches_aten(x, 512)
+
+    @parametrize("k", (64, 512))
+    def test_deterministic_mode_matches_aten_with_heavy_ties(self, k: int):
+        torch.manual_seed(6)
+        x = torch.randint(0, 4, (256, _test_n(k)), device="cuda", dtype=torch.float32)
+        with pn.flydsl.disabled():
+            ref_v, ref_i = torch.topk(x, k, dim=-1)
+
+        prior = torch.are_deterministic_algorithms_enabled()
+        try:
+            torch.use_deterministic_algorithms(True)
+            v1, i1 = torch.topk(x, k, dim=-1)
+            v2, i2 = torch.topk(x, k, dim=-1)
+        finally:
+            torch.use_deterministic_algorithms(prior)
+        self.assertEqual(v1, v2)
+        self.assertEqual(i1, i2)
+        self.assertEqual(v1, ref_v)
+        self.assertEqual(i1, ref_i)
+
+    @parametrize("k", _REGISTER_KS)
+    def test_register_stable_with_heavy_ties(self, k: int):
+        torch.manual_seed(9)
+        x = torch.randint(0, 4, (256, _test_n(k)), device="cuda", dtype=torch.float32)
+        with pn.flydsl.disabled():
+            ref_v, _ = torch.topk(x, k, dim=-1)
+        v1, i1 = torch.topk(x, k, dim=-1)
+        v2, i2 = torch.topk(x, k, dim=-1)
+        self.assertEqual(v1, v2)
+        self.assertEqual(i1, i2)
+        self.assertEqual(v1, ref_v)
+        self.assertEqual(torch.gather(x, -1, i1), v1)
+
+    def test_autograd_passes_through(self):
+        torch.manual_seed(7)
+        x = torch.randn(
+            256, 4096, device="cuda", dtype=torch.float32, requires_grad=True
+        )
+        v, i = torch.topk(x, 256, dim=-1)
+        v.sum().backward()
+        self.assertIsNotNone(x.grad)
+        expected = torch.zeros_like(x)
+        expected.scatter_(-1, i, 1.0)
+        self.assertEqual(x.grad, expected)
+
+
+instantiate_parametrized_tests(TestFlyDSLTopK)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_topk_flydsl.py
+++ b/test/python_native/test_topk_flydsl.py
@@ -1,9 +1,10 @@
 # Owner(s): ["module: dsl-native-ops"]
 
+import os
 import unittest
+from unittest.mock import patch
 
 import torch
-import torch._native
 import torch.backends.python_native as pn
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import TEST_CUDA
@@ -16,26 +17,20 @@ from torch.testing._internal.common_utils import (
 
 
 _REGISTER_KS = (2, 4, 8, 16)
-_RADIX_KS = (
+_CORRECTNESS_KS = (
+    2,
+    16,
     64,
-    128,
-    192,
-    256,
+    65,
     320,
-    384,
-    448,
-    512,
-    576,
-    640,
+    385,
+    511,
     704,
-    768,
+    705,
     832,
-    896,
-    960,
+    1023,
     1024,
 )
-_NON_STEP_RADIX_KS = (65, 257, 319, 385, 511, 513, 703, 705, 767, 833, 1023)
-_SUPPORTED_KS = _REGISTER_KS + _RADIX_KS
 
 
 def _unsupported_environment_reason() -> str | None:
@@ -50,6 +45,11 @@ def _unsupported_environment_reason() -> str | None:
         return "FlyDSL runtime is not installed"
     if not fu._version_is_ok():
         return f"FlyDSL {fu.runtime_version()} is outside the supported release"
+
+    from torch._native.ops.topk.flydsl_impl import _is_supported_arch
+
+    if not _is_supported_arch(torch.cuda.current_device()):
+        return "FlyDSL TopK override requires gfx950"
     return None
 
 
@@ -77,38 +77,59 @@ def _test_m(device_index: int | None = None) -> int:
 
 class TestFlyDSLTopKHelpers(TestCase):
     @parametrize(
+        "arch,expected",
+        (
+            ("gfx950", True),
+            ("gfx950:sramecc+", True),
+            ("gfx950:sramecc+:xnack-", True),
+            ("gfx942", False),
+            ("gfx942:sramecc+", False),
+            (None, False),
+        ),
+    )
+    def test_arch_gate_allows_only_gfx950(self, arch, expected):
+        import torch._native.ops.topk.flydsl_impl as flydsl_impl
+
+        arch_is_supported = flydsl_impl._is_supported_arch
+        arch_is_supported.cache_clear()
+        self.addCleanup(arch_is_supported.cache_clear)
+        with patch.object(flydsl_impl.fu, "_resolve_rocm_arch", return_value=arch):
+            self.assertEqual(arch_is_supported(0), expected)
+
+    def test_arch_gate_is_resolved_once_per_process(self):
+        import torch._native.ops.topk.flydsl_impl as flydsl_impl
+
+        arch_is_supported = flydsl_impl._is_supported_arch
+        arch_is_supported.cache_clear()
+        self.addCleanup(arch_is_supported.cache_clear)
+
+        with patch.dict(os.environ, {"FLYDSL_GPU_ARCH": "gfx950"}):
+            self.assertTrue(arch_is_supported(0))
+        with patch.dict(os.environ, {"FLYDSL_GPU_ARCH": "gfx942"}):
+            self.assertTrue(arch_is_supported(0))
+
+    @parametrize(
         "k,n,expected",
         (
             (2, 1024, "register"),
-            (4, 8192, "register"),
-            (8, 4096, "register"),
-            (16, 1024, "register"),
+            (16, 8192, "register"),
             (8, 1023, None),
             (8, 8193, None),
             (8, 1537, None),
             (64, 4096, "radix"),
-            (65, 4096, "radix"),
-            (128, 4096, "radix"),
-            (192, 4096, "radix"),
-            (256, 32768, "radix"),
-            (319, 32768, "radix"),
-            (321, 4096, None),
-            (512, 131072, "radix"),
-            (512, 262144, None),
-            (703, 131072, "radix"),
-            (704, 131072, "radix"),
-            (705, 131072, "radix"),
+            (320, 32768, "radix"),
+            (321, 32768, None),
+            (384, 32768, "radix"),
+            (768, 131072, "radix"),
             (769, 32768, None),
-            (833, 32768, "radix"),
-            (1023, 262144, "radix"),
-            (1024, 32768, "radix"),
+            (832, 32768, "radix"),
+            (1024, 262144, "radix"),
             (64, 4095, None),
-            (64, 32769, None),
-            (832, 16384, None),
-            (1024, 32767, None),
+            (384, 32767, None),
+            (832, 32767, None),
             (1024, 262145, None),
-            (1088, 32768, None),
             (32, 4096, None),
+            (1088, 32768, None),
         ),
     )
     def test_kernel_selection(self, k: int, n: int, expected: str | None):
@@ -152,27 +173,13 @@ class TestFlyDSLTopK(TestCase):
         self.assertIn("topk", operations)
         self.assertIn("topk.values", operations)
 
-    @parametrize("k", _SUPPORTED_KS)
+    @parametrize("k", _CORRECTNESS_KS)
     def test_correctness_random_gaussian(self, k: int):
         torch.manual_seed(0)
         x = make_tensor((_test_m(), _test_n(k)), device="cuda", dtype=torch.float32)
         self._assert_topk_matches_aten(x, k)
 
-    @parametrize("k", _NON_STEP_RADIX_KS)
-    def test_correctness_non_step_radix_k(self, k: int):
-        torch.manual_seed(12)
-        x = make_tensor((_test_m(), _test_n(k)), device="cuda", dtype=torch.float32)
-        self._assert_topk_matches_aten(x, k)
-
-    @parametrize("k", _SUPPORTED_KS)
-    def test_correctness_with_duplicates(self, k: int):
-        torch.manual_seed(1)
-        x = torch.randint(
-            0, 50, (_test_m(), _test_n(k)), device="cuda", dtype=torch.float32
-        )
-        self._assert_topk_matches_aten(x, k)
-
-    @parametrize("k", _SUPPORTED_KS)
+    @parametrize("k", (8, 704))
     def test_correctness_with_extreme_values(self, k: int):
         torch.manual_seed(2)
         x = make_tensor((_test_m(), _test_n(k)), device="cuda", dtype=torch.float32)
@@ -206,9 +213,9 @@ class TestFlyDSLTopK(TestCase):
         got_finite = got_v.masked_select(~got_v.isnan()).reshape(m, -1)
         self.assertEqual(got_finite, ref_finite)
 
-    @parametrize("k", _SUPPORTED_KS)
-    def test_nd_input(self, k: int):
+    def test_nd_input(self):
         torch.manual_seed(3)
+        k = 704
         n = _test_n(k)
         rows = (_test_m() + 3) // 4
         x = make_tensor((4, rows, n), device="cuda", dtype=torch.float32)
@@ -216,7 +223,7 @@ class TestFlyDSLTopK(TestCase):
         got_v, _ = torch.topk(x, k, dim=-1)
         self.assertEqual(got_v.shape, (4, rows, k))
 
-    @parametrize("k", _SUPPORTED_KS)
+    @parametrize("k", (8, 704))
     def test_out_variant(self, k: int):
         from torch._native.ops.topk.flydsl_kernels import topk_cache_info
 
@@ -260,24 +267,9 @@ class TestFlyDSLTopK(TestCase):
         self.assertGreaterEqual(info.hits, 1)
         self.assertEqual(info.currsize, 1)
 
-    def test_user_disable_falls_back_and_restores(self):
-        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
-
-        x = self._make_input(shape=(_test_m(), _test_n(8)))
-        with pn.flydsl.disabled():
-            ref = torch.topk(x, 8, dim=-1)
-            disabled = torch.topk(x, 8, dim=-1)
-            self._assert_no_flydsl_compiles()
-
-        got = torch.topk(x, 8, dim=-1)
-        self.assertEqual(disabled, ref)
-        self.assertEqual(got.values, ref.values)
-        self.assertEqual(torch.gather(x, -1, got.indices), got.values)
-        self.assertEqual(topk_cache_info().misses, 1)
-
-    @parametrize("bad_k", (1, 10, 32, 1088))
-    def test_unsupported_k_falls_through_without_compiling(self, bad_k: int):
+    def test_unsupported_k_falls_through_without_compiling(self):
         torch.manual_seed(5)
+        bad_k = 32
         x = make_tensor((_test_m(), 4096), device="cuda", dtype=torch.float32)
         with pn.flydsl.disabled():
             ref = torch.topk(x, bad_k, dim=-1)
@@ -286,9 +278,9 @@ class TestFlyDSLTopK(TestCase):
         self.assertEqual(got.values, ref.values)
         self.assertEqual(got.indices, ref.indices)
 
-    @parametrize("k", _REGISTER_KS)
-    def test_register_non_power_of_two_n_falls_through_without_compiling(self, k: int):
+    def test_register_non_power_of_two_n_falls_through_without_compiling(self):
         torch.manual_seed(8)
+        k = 8
         x = make_tensor((_test_m(), 1537), device="cuda", dtype=torch.float32)
         with pn.flydsl.disabled():
             ref = torch.topk(x, k, dim=-1)
@@ -298,12 +290,11 @@ class TestFlyDSLTopK(TestCase):
 
     def test_radix_non_multiple_of_four_n(self):
         torch.manual_seed(11)
-        x = make_tensor((_test_m(), 16385), device="cuda", dtype=torch.float32)
+        x = make_tensor((_test_m(), 32769), device="cuda", dtype=torch.float32)
         self._assert_topk_matches_aten(x, 512)
 
-    @parametrize("dtype", (torch.float16, torch.bfloat16))
-    def test_unsupported_dtype_falls_through_without_compiling(self, dtype):
-        x = make_tensor((_test_m(), _test_n(8)), device="cuda", dtype=dtype)
+    def test_unsupported_dtype_falls_through_without_compiling(self):
+        x = make_tensor((_test_m(), _test_n(8)), device="cuda", dtype=torch.float16)
         with pn.flydsl.disabled():
             ref = torch.topk(x, 8, dim=-1)
         got = torch.topk(x, 8, dim=-1)
@@ -354,20 +345,6 @@ class TestFlyDSLTopK(TestCase):
         self._assert_no_flydsl_compiles()
         self.assertEqual(got, ref)
 
-    def test_cow_input_falls_through_and_remains_cow(self):
-        x = self._make_input(shape=(_test_m(), _test_n(8)))._lazy_clone()
-        self.assertTrue(torch._C._is_cow_tensor(x))
-        data_ptr = x.const_data_ptr()
-
-        with pn.flydsl.disabled():
-            ref = torch.topk(x, 8, dim=-1)
-        got = torch.topk(x, 8, dim=-1)
-
-        self._assert_no_flydsl_compiles()
-        self.assertEqual(got, ref)
-        self.assertTrue(torch._C._is_cow_tensor(x))
-        self.assertEqual(x.const_data_ptr(), data_ptr)
-
     def test_noncontiguous_out_dispatches_and_matches_aten(self):
         from torch._native.ops.topk.flydsl_kernels import topk_cache_info
 
@@ -389,7 +366,7 @@ class TestFlyDSLTopK(TestCase):
         self.assertEqual(got_v, ref_v)
         self.assertEqual(torch.gather(x, -1, got_i), got_v)
 
-    @parametrize("k", (64, 257, 385, 513, 703, 705, 833, 1023))
+    @parametrize("k", (64, 257, 704, 1023))
     def test_deterministic_mode_matches_aten_with_heavy_ties(self, k: int):
         from torch._native.ops.topk.flydsl_kernels import topk_cache_info
 
@@ -413,11 +390,11 @@ class TestFlyDSLTopK(TestCase):
         self.assertEqual(v1, ref_v)
         self.assertEqual(i1, ref_i)
 
-    @parametrize("k", _REGISTER_KS)
-    def test_register_stable_with_heavy_ties(self, k: int):
+    def test_register_stable_with_heavy_ties(self):
         from torch._native.ops.topk.flydsl_kernels import topk_cache_info
 
         torch.manual_seed(9)
+        k = 8
         x = torch.randint(
             0, 4, (_test_m(), _test_n(k)), device="cuda", dtype=torch.float32
         )
@@ -430,45 +407,6 @@ class TestFlyDSLTopK(TestCase):
         self.assertEqual(i1, i2)
         self.assertEqual(v1, ref_v)
         self.assertEqual(torch.gather(x, -1, i1), v1)
-
-    def test_autograd_passes_through(self):
-        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
-
-        torch.manual_seed(7)
-        x = make_tensor(
-            (_test_m(), _test_n(8)),
-            device="cuda",
-            dtype=torch.float32,
-            requires_grad=True,
-        )
-        v, i = torch.topk(x, 8, dim=-1)
-        v.sum().backward()
-        self.assertEqual(topk_cache_info().misses, 1)
-        self.assertIsNotNone(x.grad)
-        expected = torch.zeros_like(x)
-        expected.scatter_(-1, i, 1.0)
-        self.assertEqual(x.grad, expected)
-
-    def test_cold_cuda_graph_capture_dispatches_and_replays(self):
-        from torch._native.ops.topk.flydsl_kernels import topk_cache_info
-
-        k = 8
-        x = self._make_input(shape=(_test_m(), _test_n(k)))
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph):
-            got_v, got_i = torch.topk(x, k, dim=-1)
-
-        x.neg_()
-        with pn.flydsl.disabled():
-            ref_v, _ = torch.topk(x, k, dim=-1)
-        got_v.zero_()
-        got_i.zero_()
-        graph.replay()
-        torch.cuda.synchronize()
-
-        self.assertEqual(topk_cache_info().misses, 1)
-        self.assertEqual(got_v, ref_v)
-        self.assertEqual(torch.gather(x, -1, got_i), got_v)
 
     @unittest.skipIf(
         torch.cuda.device_count() < 2,

--- a/torch/_native/ops/topk/__init__.py
+++ b/torch/_native/ops/topk/__init__.py
@@ -1,4 +1,6 @@
 from .cutedsl_impl import register_to_dispatch as _register_cutedsl
+from .flydsl_impl import register_to_dispatch as _register_flydsl
 
 
+_register_flydsl()
 _register_cutedsl()

--- a/torch/_native/ops/topk/flydsl_impl.py
+++ b/torch/_native/ops/topk/flydsl_impl.py
@@ -23,6 +23,7 @@ from ._common import (
 
 
 _RUNTIME_AVAILABLE: bool = fu.runtime_available()
+_SUPPORTED_ARCHES = ("gfx950",)
 _REGISTER_KS: frozenset[int] = frozenset({2, 4, 8, 16})
 
 # Per-K register ranges tuned on MI355.  K=32 loses to aten in the measured
@@ -73,6 +74,12 @@ def _kernel_for(k: int, n: int) -> str | None:
 
 
 @functools.cache
+def _is_supported_arch(device_index: int) -> bool:
+    arch = fu._resolve_rocm_arch(device_index)
+    return arch is not None and arch.split(":", 1)[0] in _SUPPORTED_ARCHES
+
+
+@functools.cache
 def _min_rows_for_full_wave(device_idx: int) -> int:
     return torch.cuda.get_device_properties(device_idx).multi_processor_count
 
@@ -86,6 +93,9 @@ def _eligible(
         return False
     if not self.is_cuda or self.dtype != torch.float32:
         return False
+    device_index = self.device.index
+    if device_index is None or not _is_supported_arch(device_index):
+        return False
     if any_cow(self):
         return False
     if not largest or not sorted_:
@@ -96,7 +106,7 @@ def _eligible(
         return False
     N = self.shape[-1] if self.ndim >= 1 else 0
     M = self.numel() // N if N else 0
-    if M < _min_rows_for_full_wave(self.device.index or 0):
+    if M < _min_rows_for_full_wave(device_index):
         return False
     return _kernel_for(k, N) is not None
 

--- a/torch/_native/ops/topk/flydsl_impl.py
+++ b/torch/_native/ops/topk/flydsl_impl.py
@@ -23,23 +23,20 @@ from ._common import (
 
 
 _RUNTIME_AVAILABLE: bool = fu.runtime_available()
-_RADIX_KS: frozenset[int] = frozenset({64, 128, 256, 512, 1024})
 _REGISTER_KS: frozenset[int] = frozenset({2, 4, 8, 16})
 
 # Per-K register ranges tuned on MI355.  K=32 loses to aten in the measured
 # range.  A separate row-count gate below handles GPU underutilization.
 _REGISTER_N_RANGE: tuple[int, int] = (1024, 8192)
 
-# Per-K radix ranges tuned on MI355.  Below these N ranges either
-# correctness is not guaranteed for the current FlyDSL radix kernel, or
-# aten wins.  A separate row-count gate below handles GPU underutilization.
-_RADIX_N_RANGE: dict[int, tuple[int, int]] = {
-    64: (16384, 32768),
-    128: (16384, 32768),
-    256: (16384, 32768),
-    512: (16384, 32768),
-    1024: (32768, 65536),
-}
+# Per-K radix ranges tuned on MI355.
+# A separate row-count gate below handles GPU underutilization.
+# K>1024 exceeds the device workgroup size limit.
+_RADIX_GATE_RANGES = (
+    ((64, 320), (4096, 32768)),
+    ((384, 768), (32768, 131072)),
+    ((832, 1024), (32768, 262144)),
+)
 _TOPK_KERNELS = None
 
 
@@ -52,19 +49,25 @@ def _register_wins(k: int, n: int) -> bool:
     return n_min <= n <= n_max
 
 
+def _radix_n_range(k: int) -> tuple[int, int] | None:
+    for (k_min, k_max), n_range in _RADIX_GATE_RANGES:
+        if k_min <= k <= k_max:
+            return n_range
+    return None
+
+
 def _radix_wins(k: int, n: int) -> bool:
-    n_range = _RADIX_N_RANGE.get(k)
-    if n_range is not None:
-        n_min, n_max = n_range
-        if n_min <= n <= n_max:
-            return True
-    return False
+    n_range = _radix_n_range(k)
+    if n_range is None:
+        return False
+    n_min, n_max = n_range
+    return n_min <= n <= n_max
 
 
 def _kernel_for(k: int, n: int) -> str | None:
     if (k in _REGISTER_KS) and _is_pow2(n) and _register_wins(k, n):
         return "register"
-    if k in _RADIX_KS and _radix_wins(k, n):
+    if _radix_wins(k, n):
         return "radix"
     return None
 

--- a/torch/_native/ops/topk/flydsl_impl.py
+++ b/torch/_native/ops/topk/flydsl_impl.py
@@ -1,0 +1,239 @@
+"""FlyDSL override registrations for ``aten::topk``.
+
+This is a conservative FlyDSL backend for topk.  The kernel currently handles
+small fp32, last-dimension, largest+sorted cases; other shapes fall through to
+the existing backends or aten.
+"""
+
+# mypy: allow-untyped-defs
+
+from __future__ import annotations
+
+import functools
+
+import torch
+
+from ... import flydsl_utils as fu
+from ._common import (
+    any_cow,
+    flatten_last_dim,
+    last_dim_row_major_ok,
+    unflatten_last_dim,
+)
+
+
+_RUNTIME_AVAILABLE: bool = fu.runtime_available()
+_RADIX_KS: frozenset[int] = frozenset({64, 128, 256, 512, 1024})
+_REGISTER_KS: frozenset[int] = frozenset({2, 4, 8, 16})
+
+# Per-K register ranges tuned on MI355.  K=32 loses to aten in the measured
+# range.  A separate row-count gate below handles GPU underutilization.
+_REGISTER_N_RANGE: tuple[int, int] = (1024, 8192)
+
+# Per-K radix ranges tuned on MI355.  Below these N ranges either
+# correctness is not guaranteed for the current FlyDSL radix kernel, or
+# aten wins.  A separate row-count gate below handles GPU underutilization.
+_RADIX_N_RANGE: dict[int, tuple[int, int]] = {
+    64: (16384, 32768),
+    128: (16384, 32768),
+    256: (16384, 32768),
+    512: (16384, 32768),
+    1024: (32768, 65536),
+}
+_TOPK_KERNELS = None
+
+
+def _is_pow2(x: int) -> bool:
+    return x > 0 and (x & (x - 1)) == 0
+
+
+def _register_wins(k: int, n: int) -> bool:
+    n_min, n_max = _REGISTER_N_RANGE
+    return n_min <= n <= n_max
+
+
+def _radix_wins(k: int, n: int) -> bool:
+    n_range = _RADIX_N_RANGE.get(k)
+    if n_range is not None:
+        n_min, n_max = n_range
+        if n_min <= n <= n_max:
+            return True
+    return False
+
+
+def _kernel_for(k: int, n: int) -> str | None:
+    if (k in _REGISTER_KS) and _is_pow2(n) and _register_wins(k, n):
+        return "register"
+    if k in _RADIX_KS and _radix_wins(k, n):
+        return "radix"
+    return None
+
+
+@functools.cache
+def _min_rows_for_full_wave(device_idx: int) -> int:
+    return torch.cuda.get_device_properties(device_idx).multi_processor_count
+
+
+def _eligible(
+    self: torch.Tensor, k: int, dim: int, largest: bool, sorted_: bool
+) -> bool:
+    if not _RUNTIME_AVAILABLE:
+        return False
+    if torch.version.hip is None:
+        return False
+    if not self.is_cuda or self.dtype != torch.float32:
+        return False
+    if any_cow(self):
+        return False
+    if not largest or not sorted_:
+        return False
+    if not last_dim_row_major_ok(self, dim):
+        return False
+    if self.numel() == 0:
+        return False
+    N = self.shape[-1] if self.ndim >= 1 else 0
+    M = self.numel() // N if N else 0
+    if M < _min_rows_for_full_wave(self.device.index or 0):
+        return False
+    return _kernel_for(k, N) is not None
+
+
+def _get_topk_kernels():
+    global _TOPK_KERNELS
+    if _TOPK_KERNELS is None:
+        from .flydsl_kernels import (
+            RadixSelectTopK,
+            RadixSelectTopKOut,
+            RegisterTopK,
+            RegisterTopKOut,
+        )
+
+        _TOPK_KERNELS = (
+            RadixSelectTopK,
+            RadixSelectTopKOut,
+            RegisterTopK,
+            RegisterTopKOut,
+        )
+    return _TOPK_KERNELS
+
+
+def _cond(
+    self: torch.Tensor,
+    k: int,
+    dim: int = -1,
+    largest: bool = True,
+    sorted: bool = True,
+    *args,
+    **kwargs,
+) -> bool:
+    return _eligible(self, int(k), int(dim), bool(largest), bool(sorted))
+
+
+def _out_cond(
+    self: torch.Tensor,
+    k: int,
+    dim: int = -1,
+    largest: bool = True,
+    sorted: bool = True,
+    *,
+    values: torch.Tensor,
+    indices: torch.Tensor,
+) -> bool:
+    if not _cond(self, k, dim, largest, sorted):
+        return False
+    if any_cow(values, indices):
+        return False
+    expected_shape = self.shape[:-1] + (int(k),)
+    if values.dtype != torch.float32 or values.shape != expected_shape:
+        return False
+    if indices.dtype != torch.int64 or indices.shape != expected_shape:
+        return False
+    if values.device != self.device or indices.device != self.device:
+        return False
+    return True
+
+
+def _run(self: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
+    RadixSelectTopK, _, RegisterTopK, _ = _get_topk_kernels()
+
+    self_2d = flatten_last_dim(self)
+    kernel = _kernel_for(k, self_2d.shape[-1])
+    if kernel == "register":
+        values_2d, indices_2d = RegisterTopK(self_2d, k)
+        return unflatten_last_dim(values_2d, indices_2d, self, k)
+    deterministic = torch.are_deterministic_algorithms_enabled()
+    values_2d, indices_2d = RadixSelectTopK(self_2d, k, deterministic=deterministic)
+    return unflatten_last_dim(values_2d, indices_2d, self, k)
+
+
+def _flatten_topk_out(out: torch.Tensor, k: int) -> torch.Tensor:
+    if out.ndim == 2:
+        return out
+    if out.ndim == 1:
+        return out.view(1, k)
+    return out.view(-1, k)
+
+
+def _run_out(
+    self: torch.Tensor, k: int, values: torch.Tensor, indices: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    _, RadixSelectTopKOut, _, RegisterTopKOut = _get_topk_kernels()
+
+    if not values.is_contiguous() or not indices.is_contiguous():
+        v, i = _run(self, k)
+        values.copy_(v)
+        indices.copy_(i)
+        return values, indices
+
+    self_2d = flatten_last_dim(self)
+    values_2d = _flatten_topk_out(values, k)
+    indices_2d = _flatten_topk_out(indices, k)
+    kernel = _kernel_for(k, self_2d.shape[-1])
+    if kernel == "register":
+        RegisterTopKOut(self_2d, k, values_2d, indices_2d)
+    else:
+        deterministic = torch.are_deterministic_algorithms_enabled()
+        RadixSelectTopKOut(
+            self_2d, k, values_2d, indices_2d, deterministic=deterministic
+        )
+    return values, indices
+
+
+def _impl(
+    self: torch.Tensor,
+    k: int,
+    dim: int = -1,
+    largest: bool = True,
+    sorted: bool = True,
+    *args,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _run(self, int(k))
+
+
+def _out_impl(
+    self: torch.Tensor,
+    k: int,
+    dim: int = -1,
+    largest: bool = True,
+    sorted: bool = True,
+    *,
+    values: torch.Tensor,
+    indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _run_out(self, int(k), values, indices)
+
+
+def register_to_dispatch() -> None:
+    for op_symbol, cond, impl in (
+        ("topk", _cond, _impl),
+        ("topk.values", _out_cond, _out_impl),
+    ):
+        fu.register_op_override(
+            "aten",
+            op_symbol,
+            "CUDA",
+            cond=cond,
+            impl=impl,
+            allow_multiple_override=True,
+        )

--- a/torch/_native/ops/topk/flydsl_kernels.py
+++ b/torch/_native/ops/topk/flydsl_kernels.py
@@ -1,0 +1,749 @@
+"""FlyDSL fp32 top-K kernel used by the native topk override."""
+
+# mypy: allow-untyped-defs
+
+import math
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir.dialects import llvm
+from flydsl.expr import (
+    arith,
+    Array,
+    Float32,
+    gpu,
+    Int32,
+    Int64,
+    range_constexpr,
+    rocdl as fly_rocdl,
+)
+from flydsl.expr.typing import T
+from flydsl.runtime.device import get_rocm_arch, is_rdna_arch
+
+import torch
+from torch._native.flydsl.cache import CacheInfo
+from torch._native.instrumentation import instrumented_flydsl_cache
+
+
+_RADIX_BITS = 8
+_RADIX_MASK = (1 << _RADIX_BITS) - 1
+_RADIX_SIGN_BIT = 1 << (_RADIX_BITS - 1)
+_NUM_RADIX_PASSES = 32 // _RADIX_BITS
+_N_HIST_BINS = 1 << _RADIX_BITS
+_VEC = 4
+DPP_ROW_SHR_1 = 0x111
+DPP_ROW_SHR_2 = 0x112
+DPP_ROW_SHR_4 = 0x114
+DPP_ROW_SHR_8 = 0x118
+DPP_ROW_MASK = 0xF
+DPP_BANK_MASK = 0xF
+
+
+def _i32_const(x: int) -> int:
+    return x - (1 << 32) if x >= (1 << 31) else x
+
+
+def _f32_to_ord(val):
+    bits = val.bitcast(Int32)
+    ords = bits ^ ((bits >> fx.Int32(31)) & fx.Int32(0x7FFFFFFF))
+    abs_bits = bits & fx.Int32(0x7FFFFFFF)
+    is_nan = arith.cmpi(arith.CmpIPredicate.ugt, abs_bits, fx.Int32(0x7F800000))
+    return arith.select(is_nan, fx.Int32(0x7FFFFFFF), ords)
+
+
+def _make_topk_storage(k: int, block_threads: int):
+    @fx.struct
+    class SharedStorage:
+        s_hist: Array[Int32, 256, 16]
+        s_prefix: Array[Int32, 1, 4]
+        s_mask: Array[Int32, 1, 4]
+        s_rem_k: Array[Int32, 1, 4]
+        s_write_ctr: Array[Int32, 1, 4]
+        s_eq_ctr: Array[Int32, 1, 4]
+        s_scan: Array[Int32, block_threads + 1, 16]
+        s_vals: Array[Float32, k, 16]
+        s_ords: Array[Int32, k, 16]
+        s_idxs: Array[Int32, k, 16]
+        s_eq_vals: Array[Float32, k, 16]
+        s_eq_idxs: Array[Int32, k, 16]
+
+    return SharedStorage
+
+
+def _build_radix_select_topk_module(n: int, k: int, deterministic: bool):
+    block_threads = max(k, _N_HIST_BINS)
+    warp_size = 32 if is_rdna_arch(get_rocm_arch()) else 64
+    num_warps = block_threads // warp_size
+    tile = block_threads * _VEC
+    vec_iters = n // tile
+    vec_tail_start = vec_iters * tile
+    scalar_tail_iters = (n - vec_tail_start + block_threads - 1) // block_threads
+    num_stages = (k - 1).bit_length()
+
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
+    def radix_select_topk_kernel(
+        input: fx.Tensor,
+        values: fx.Tensor,
+        indices: fx.Tensor,
+    ):
+        row = fx.block_idx.x
+        tid = fx.thread_idx.x
+
+        input_buf = fx.rocdl.make_buffer_tensor(input)
+        values_buf = fx.rocdl.make_buffer_tensor(values)
+        indices_buf = fx.rocdl.make_buffer_tensor(indices)
+
+        row_in = fx.slice(input_buf, (row, None))
+        row_values = fx.slice(values_buf, (row, None))
+        row_indices = fx.slice(indices_buf, (row, None))
+        input_div = fx.logical_divide(row_in, fx.make_layout(_VEC, 1))
+        copy_atom_v = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), 32)
+        storage = (
+            fx.SharedAllocator().allocate(_make_topk_storage(k, block_threads)).peek()
+        )
+        s_hist = storage.s_hist.view(fx.make_layout(_N_HIST_BINS, 1))
+        s_prefix = storage.s_prefix.view(fx.make_layout(1, 1))
+        s_mask = storage.s_mask.view(fx.make_layout(1, 1))
+        s_rem_k = storage.s_rem_k.view(fx.make_layout(1, 1))
+        s_write_ctr = storage.s_write_ctr.view(fx.make_layout(1, 1))
+        s_eq_ctr = storage.s_eq_ctr.view(fx.make_layout(1, 1))
+        s_scan = storage.s_scan.view(fx.make_layout(block_threads + 1, 1))
+        s_vals = storage.s_vals.view(fx.make_layout(k, 1))
+        s_ords = storage.s_ords.view(fx.make_layout(k, 1))
+        s_idxs = storage.s_idxs.view(fx.make_layout(k, 1))
+        s_eq_vals = storage.s_eq_vals.view(fx.make_layout(k, 1))
+        s_eq_idxs = storage.s_eq_idxs.view(fx.make_layout(k, 1))
+
+        def load_vec_f32(idx):
+            r = fx.make_rmem_tensor(4, Float32)
+            fx.copy_atom_call(copy_atom_v, fx.slice(input_div, (None, idx)), r)
+            return fx.memref_load_vec(r)
+
+        def atomic_add_i32_fetch(memref, val, offset):
+            ptr = fx.to_llvm_ptr(fx.get_iter(memref) + offset)
+            old = llvm.AtomicRMWOp(
+                llvm.AtomicBinOp.add,
+                ptr,
+                arith.unwrap(val),
+                llvm.AtomicOrdering.monotonic,
+                syncscope="workgroup",
+                alignment=4,
+            ).result
+            return fx.Int32(old)
+
+        def unwrap_val(val):
+            return val.ir_value() if hasattr(val, "ir_value") else arith.unwrap(val)
+
+        def warp_inclusive_prefix_i32(val, lane):
+            val_raw = unwrap_val(val)
+            zero_raw = unwrap_val(0)
+            for _, dpp_op, threshold in [
+                (1, DPP_ROW_SHR_1, 1),
+                (2, DPP_ROW_SHR_2, 2),
+                (4, DPP_ROW_SHR_4, 4),
+                (8, DPP_ROW_SHR_8, 8),
+            ]:
+                remote = fly_rocdl.update_dpp(
+                    T.i32, zero_raw, val_raw, dpp_op, DPP_ROW_MASK, DPP_BANK_MASK, True
+                )
+                val = (lane >= fx.Int32(threshold)).select(val + fx.Int32(remote), val)
+                val_raw = unwrap_val(val)
+
+            src_lane_16 = (lane & fx.Int32(0x30)) - 1
+            remote16 = fly_rocdl.ds_bpermute(T.i32, src_lane_16 * fx.Int32(4), val)
+            val = (lane >= fx.Int32(16)).select(val + fx.Int32(remote16), val)
+
+            if warp_size > 32:
+                src_lane_32 = (lane & fx.Int32(0x30)) - fx.Int32(17)
+                remote32 = fly_rocdl.ds_bpermute(T.i32, src_lane_32 * fx.Int32(4), val)
+                val = (lane >= fx.Int32(32)).select(val + fx.Int32(remote32), val)
+            return val
+
+        def block_excl_prefix_i32(packed_local, scan):
+            lane = tid % fx.Int32(warp_size)
+            warp = tid // fx.Int32(warp_size)
+            incl = warp_inclusive_prefix_i32(packed_local, lane)
+            excl_intra = incl - packed_local
+            if lane == fx.Int32(warp_size - 1):
+                scan[warp] = incl
+            gpu.barrier()
+
+            if warp == 0:
+                warp_val = 0
+                if lane < fx.Int32(num_warps):
+                    warp_val = scan[lane]
+                warp_incl = warp_inclusive_prefix_i32(warp_val, lane)
+                warp_excl = warp_incl - warp_val
+                if lane < fx.Int32(num_warps):
+                    scan[lane] = warp_excl
+                if lane == fx.Int32(num_warps - 1):
+                    scan[num_warps] = warp_incl
+            gpu.barrier()
+
+            packed_pfx = scan[warp] + excl_intra
+            packed_total = scan[num_warps]
+            gpu.barrier()
+            return packed_pfx, packed_total
+
+        if tid == 0:
+            s_prefix[0] = 0
+            s_mask[0] = 0
+            s_rem_k[0] = k
+        gpu.barrier()
+
+        # Phase 1: radix byte passes, MSB to LSB.
+        for byte_pos in range_constexpr(_NUM_RADIX_PASSES):
+            shift = (_NUM_RADIX_PASSES - 1 - byte_pos) * _RADIX_BITS
+            xor_val = _RADIX_SIGN_BIT if byte_pos == 0 else 0
+
+            # Zero the 256-bin histogram.
+            if tid < fx.Int32(_N_HIST_BINS):
+                s_hist[tid] = 0
+            gpu.barrier()
+
+            # Accumulate the current byte histogram.
+            prefix = s_prefix[0]
+            decided_mask = s_mask[0]
+            for step in range_constexpr(vec_iters):
+                rvals = load_vec_f32(step * block_threads + tid)
+                for vi in range_constexpr(_VEC):
+                    ords = _f32_to_ord(rvals[vi])
+                    if byte_pos == 0 or (ords & decided_mask) == prefix:
+                        byte_val = (
+                            (ords >> fx.Int32(shift)) & fx.Int32(_RADIX_MASK)
+                        ) ^ fx.Int32(xor_val)
+                        atomic_add_i32_fetch(s_hist, 1, byte_val)
+            for step in range_constexpr(scalar_tail_iters):
+                col = vec_tail_start + step * block_threads + tid
+                if col < n:
+                    ords = _f32_to_ord(row_in[col])
+                    if byte_pos == 0 or (ords & decided_mask) == prefix:
+                        byte_val = (
+                            (ords >> fx.Int32(shift)) & fx.Int32(_RADIX_MASK)
+                        ) ^ fx.Int32(xor_val)
+                        atomic_add_i32_fetch(s_hist, 1, byte_val)
+            gpu.barrier()
+
+            # Select the radix threshold.
+            if tid == 0:
+                remaining_k = s_rem_k[0]
+                acc = 0
+                found = 0
+                sel_bin = 0
+                elems_above = 0
+
+                for b in range_constexpr(_N_HIST_BINS):
+                    bin_idx = _N_HIST_BINS - 1 - b
+                    count = s_hist[bin_idx]
+                    if found == 0:
+                        if acc + count >= remaining_k:
+                            sel_bin = fx.Int32(bin_idx)
+                            elems_above = acc
+                            found = 1
+                    acc = acc + count
+
+                actual_byte = sel_bin ^ fx.Int32(xor_val)
+                s_prefix[0] = prefix | (actual_byte << fx.Int32(shift))
+                s_mask[0] = decided_mask | fx.Int32(_i32_const(_RADIX_MASK << shift))
+                s_rem_k[0] = remaining_k - elems_above
+            gpu.barrier()
+
+        # Phase 2: gather elements at-or-above the radix threshold.
+        threshold = s_prefix[0]  # Values above threshold are in top-k.
+        remaining_k = s_rem_k[0]  # Number of threshold ties to keep.
+
+        if tid == 0:
+            s_write_ctr[0] = 0
+            s_eq_ctr[0] = 0
+        if tid < fx.Int32(k):
+            s_vals[tid] = float("-inf")
+            s_idxs[tid] = 0
+        gpu.barrier()
+
+        if deterministic:
+            above_base = 0
+            eq_base = 0
+            for step in range_constexpr(vec_iters):
+                tile_base = step * tile
+                base = tile_base + tid * _VEC
+                rvals = load_vec_f32(step * block_threads + tid)
+
+                # Class encoding: 2 = above, 1 = eq, 0 = below.
+                cls_reg = fx.make_rmem_tensor(_VEC, Int32)
+                packed_local = 0
+                for vi in range_constexpr(_VEC):
+                    ords = _f32_to_ord(rvals[vi])
+                    if ords > threshold:
+                        cls_reg[vi] = 2
+                        packed_local = packed_local + fx.Int32(1 << 16)
+                    elif ords == threshold:
+                        cls_reg[vi] = 1
+                        packed_local = packed_local + 1
+                    else:
+                        cls_reg[vi] = 0
+
+                packed_pfx, packed_step_total = block_excl_prefix_i32(
+                    packed_local, s_scan
+                )
+                my_above = above_base + (packed_pfx >> fx.Int32(16))
+                my_eq = eq_base + (packed_pfx & fx.Int32(0xFFFF))
+                for vi in range_constexpr(_VEC):
+                    val = rvals[vi]
+                    cls = cls_reg[vi]
+                    idx = fx.Int32(base + vi)
+                    if cls == 2:
+                        s_vals[my_above] = val
+                        s_idxs[my_above] = idx
+                        my_above = my_above + 1
+                    elif cls == 1:
+                        if my_eq < remaining_k:
+                            s_eq_vals[my_eq] = val
+                            s_eq_idxs[my_eq] = idx
+                        my_eq = my_eq + 1
+
+                above_base = above_base + (packed_step_total >> fx.Int32(16))
+                next_eq_base = eq_base + (packed_step_total & fx.Int32(0xFFFF))
+                eq_base = (next_eq_base < remaining_k).select(next_eq_base, remaining_k)
+
+            # --- Scalar tail ---
+            for step in range_constexpr(scalar_tail_iters):
+                col = vec_tail_start + step * block_threads + tid
+                valid = col < n
+                packed_local = 0
+                if valid:
+                    ords = _f32_to_ord(row_in[col])
+                    if ords > threshold:
+                        packed_local = fx.Int32(1 << 16)
+                    elif ords == threshold:
+                        packed_local = 1
+
+                packed_pfx, packed_step_total = block_excl_prefix_i32(
+                    packed_local, s_scan
+                )
+                my_above = above_base + (packed_pfx >> fx.Int32(16))
+                my_eq = eq_base + (packed_pfx & fx.Int32(0xFFFF))
+                if valid:
+                    idx = fx.Int32(col)
+                    val = row_in[col]
+                    ords = _f32_to_ord(val)
+                    if ords > threshold:
+                        s_vals[my_above] = val
+                        s_idxs[my_above] = idx
+                    elif ords == threshold:
+                        if my_eq < remaining_k:
+                            s_eq_vals[my_eq] = val
+                            s_eq_idxs[my_eq] = idx
+
+                above_base = above_base + (packed_step_total >> fx.Int32(16))
+                next_eq_base = eq_base + (packed_step_total & fx.Int32(0xFFFF))
+                eq_base = (next_eq_base < remaining_k).select(next_eq_base, remaining_k)
+
+            gpu.barrier()
+            n_above = above_base
+            if tid < fx.Int32(k):
+                offset_into_eq = tid - n_above
+                if offset_into_eq >= 0 and offset_into_eq < remaining_k:
+                    s_vals[tid] = s_eq_vals[offset_into_eq]
+                    s_idxs[tid] = s_eq_idxs[offset_into_eq]
+            gpu.barrier()
+        else:
+
+            def gather_candidate(val, idx, vals, idxs):
+                ords = _f32_to_ord(val)
+                if ords > threshold:
+                    pos = atomic_add_i32_fetch(s_write_ctr, 1, 0)
+                    vals[pos] = val
+                    idxs[pos] = idx
+                elif ords == threshold:
+                    eq_pos = atomic_add_i32_fetch(s_eq_ctr, 1, 0)
+                    if eq_pos < remaining_k:
+                        pos = atomic_add_i32_fetch(s_write_ctr, 1, 0)
+                        vals[pos] = val
+                        idxs[pos] = idx
+
+            for step in range_constexpr(vec_iters):
+                tile_base = step * tile
+                base = tile_base + tid * _VEC
+                rvals = load_vec_f32(step * block_threads + tid)
+                for vi in range_constexpr(_VEC):
+                    idx = fx.Int32(base + vi)
+                    gather_candidate(rvals[vi], idx, s_vals, s_idxs)
+            for step in range_constexpr(scalar_tail_iters):
+                col = vec_tail_start + step * block_threads + tid
+                if col < n:
+                    gather_candidate(row_in[col], fx.Int32(col), s_vals, s_idxs)
+
+        gpu.barrier()
+
+        # Phase 3: cooperative bitonic sort.
+        active = tid < fx.Int32(k)
+        sort_tid = active.select(tid, 0)
+        if active:
+            s_ords[tid] = _f32_to_ord(s_vals[sort_tid])
+        gpu.barrier()
+
+        # Support non-power-of-two K by ignoring compare partners outside K.
+        # The bitonic network builds ascending blocks first, then the final
+        # stage merges everything into descending order.
+        for stage in range_constexpr(num_stages):
+            for sub_rev in range_constexpr(stage + 1):
+                sub = stage - sub_rev
+                step_size = 1 << sub
+                raw_partner = tid ^ fx.Int32(step_size)
+                partner_active = raw_partner < fx.Int32(k)
+                partner = (active & partner_active).select(raw_partner, 0)
+                my_o = s_ords[sort_tid]
+                my_i = s_idxs[sort_tid]
+                p_o = s_ords[partner]
+                p_v = s_vals[partner]
+                p_i = s_idxs[partner]
+                gpu.barrier()
+
+                self_lt_partner = my_o < p_o
+                self_gt_partner = my_o > p_o
+                if deterministic:
+                    self_lt_partner = (my_o < p_o) | ((my_o == p_o) & (my_i > p_i))
+                    self_gt_partner = (my_o > p_o) | ((my_o == p_o) & (my_i < p_i))
+                block_dir = (tid >> fx.Int32(stage + 1)) & 1
+                if active & partner_active:
+                    if stage < num_stages - 1:
+                        if tid < partner:
+                            if block_dir == 0:
+                                if self_gt_partner:
+                                    s_ords[tid] = p_o
+                                    s_vals[tid] = p_v
+                                    s_idxs[tid] = p_i
+                            else:
+                                if self_lt_partner:
+                                    s_ords[tid] = p_o
+                                    s_vals[tid] = p_v
+                                    s_idxs[tid] = p_i
+                        else:
+                            if block_dir == 0:
+                                if self_lt_partner:
+                                    s_ords[tid] = p_o
+                                    s_vals[tid] = p_v
+                                    s_idxs[tid] = p_i
+                            else:
+                                if self_gt_partner:
+                                    s_ords[tid] = p_o
+                                    s_vals[tid] = p_v
+                                    s_idxs[tid] = p_i
+                    else:
+                        if tid < partner:
+                            if block_dir == 0:
+                                if self_lt_partner:
+                                    s_ords[tid] = p_o
+                                    s_vals[tid] = p_v
+                                    s_idxs[tid] = p_i
+                            else:
+                                if self_gt_partner:
+                                    s_ords[tid] = p_o
+                                    s_vals[tid] = p_v
+                                    s_idxs[tid] = p_i
+                        else:
+                            if block_dir == 0:
+                                if self_gt_partner:
+                                    s_ords[tid] = p_o
+                                    s_vals[tid] = p_v
+                                    s_idxs[tid] = p_i
+                            else:
+                                if self_lt_partner:
+                                    s_ords[tid] = p_o
+                                    s_vals[tid] = p_v
+                                    s_idxs[tid] = p_i
+                gpu.barrier()
+
+        # Phase 4: results to gmem.
+        if tid < fx.Int32(k):
+            row_values[tid] = s_vals[tid]
+            row_indices[tid] = fx.Int64(s_idxs[tid])
+
+    @flyc.jit
+    def launch_radix_select_topk(
+        input: fx.Tensor,
+        values: fx.Tensor,
+        indices: fx.Tensor,
+        rows_m: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        launcher = radix_select_topk_kernel(input, values, indices)
+        launcher.launch(
+            grid=(rows_m, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_radix_select_topk
+
+
+def _build_register_topk_module(n: int, k: int, rows_per_cta: int = 2):
+    threads_per_row = 32 if is_rdna_arch(get_rocm_arch()) else 64
+    block_threads = threads_per_row * rows_per_cta
+    vec = n // threads_per_row
+    num_stages_vec = int(math.log2(vec)) if vec > 1 else 0
+    num_stages_k = int(math.log2(k)) if k > 1 else 0
+    log2_threads_per_row = int(math.log2(threads_per_row))
+
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
+    def register_topk_kernel(
+        input: fx.Tensor,
+        values: fx.Tensor,
+        indices: fx.Tensor,
+        rows_m: fx.Int32,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid % fx.Int32(threads_per_row)
+        row_local = tid // fx.Int32(threads_per_row)
+        row = bid * fx.Int32(rows_per_cta) + row_local
+        row_safe = (row < rows_m).select(row, 0)
+        in_bounds = row < rows_m
+
+        input_buf = fx.rocdl.make_buffer_tensor(input)
+        values_buf = fx.rocdl.make_buffer_tensor(values)
+        indices_buf = fx.rocdl.make_buffer_tensor(indices)
+        row_input = fx.slice(input_buf, (row_safe, None))
+        row_values = fx.slice(values_buf, (row_safe, None))
+        row_indices = fx.slice(indices_buf, (row_safe, None))
+
+        def make_key(val, idx):
+            ord64 = fx.Int64(_f32_to_ord(val)) & fx.Int64(0xFFFFFFFF)
+            inv_idx64 = fx.Int64(~idx) & fx.Int64(0xFFFFFFFF)
+            return (ord64 << fx.Int64(32)) | inv_idx64
+
+        def decode_key(key):
+            ord32 = fx.Int32(key >> fx.Int64(32))
+            inv_idx = fx.Int32(key & fx.Int64(0xFFFFFFFF))
+            val_bits = ord32 ^ ((ord32 >> fx.Int32(31)) & fx.Int32(0x7FFFFFFF))
+            return val_bits.bitcast(Float32), ~inv_idx
+
+        def cas_desc(arr, i: int, j: int):
+            a = arr[i]
+            b = arr[j]
+            swap = a < b
+            arr[i] = swap.select(b, a)
+            arr[j] = swap.select(a, b)
+
+        def bitonic_sort_desc(arr, length: int, stages: int):
+            if length > 1:
+                for s in range_constexpr(stages):
+                    for sub_rev in range_constexpr(s + 1):
+                        step = 1 << (s - sub_rev)
+                        for i in range_constexpr(length):
+                            j = i ^ step
+                            if j > i:
+                                block_dir = (i >> (s + 1)) & 1
+                                if block_dir == 0:
+                                    cas_desc(arr, i, j)
+                                else:
+                                    a = arr[i]
+                                    b = arr[j]
+                                    swap = a > b
+                                    arr[i] = swap.select(b, a)
+                                    arr[j] = swap.select(a, b)
+
+        def bitonic_merge_desc(arr, length: int, levels: int):
+            if length > 1:
+                for level in range_constexpr(levels):
+                    merge_len = length >> level
+                    step = merge_len // 2
+                    for i in range_constexpr(length // merge_len):
+                        start_i = i * merge_len
+                        for j in range_constexpr(step):
+                            cas_desc(arr, start_i + j, start_i + j + step)
+
+        def topk_merge_desc(a, b):
+            for i in range_constexpr(k):
+                x = a[i]
+                y = b[k - 1 - i]
+                take_y = y > x
+                a[i] = take_y.select(y, x)
+            bitonic_merge_desc(a, k, num_stages_k)
+
+        # Sort each lane's VEC elements in registers.
+        keys = fx.make_rmem_tensor(vec, Int64)
+        for i in range_constexpr(vec):
+            col = lane * fx.Int32(vec) + fx.Int32(i)
+            keys[i] = make_key(row_input[col], col)
+        bitonic_sort_desc(keys, vec, num_stages_vec)
+
+        # Build per-lane top-K. If VEC < K, pad with INT64_MIN so the
+        # sentinel sorts strictly below any real key; if VEC >= K take the
+        # leading K (already sorted).
+        topk = fx.make_rmem_tensor(k, Int64)
+        if vec >= k:
+            if vec == k:
+                fx.memref_store_vec(fx.memref_load_vec(keys), topk)
+            else:
+                keys_vec = fx.memref_load_vec(keys)
+                fx.memref_store_vec(keys_vec.shuffle(keys_vec, list(range(k))), topk)
+        else:
+            sentinel = fx.Int64(-(1 << 63))
+            for i in range_constexpr(vec):
+                topk[i] = keys[i]
+            for i in range_constexpr(k - vec):
+                topk[vec + i] = sentinel
+
+        # Warp-cooperative top-K merge via butterfly shuffles.
+        for s in range_constexpr(log2_threads_per_row):
+            other = fx.make_rmem_tensor(k, Int64)
+            for i in range_constexpr(k):
+                peer = gpu.shuffle_xor(topk[i], 1 << s, threads_per_row)
+                other[i] = peer
+            topk_merge_desc(topk, other)
+
+        if lane == 0 and in_bounds:
+            for i in range_constexpr(k):
+                val, idx = decode_key(topk[i])
+                row_values[i] = val
+                row_indices[i] = fx.Int64(idx)
+
+    @flyc.jit
+    def launch_register_topk(
+        input: fx.Tensor,
+        values: fx.Tensor,
+        indices: fx.Tensor,
+        rows_m: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        num_blocks = (rows_m + rows_per_cta - 1) // rows_per_cta
+        launcher = register_topk_kernel(input, values, indices, rows_m)
+        launcher.launch(
+            grid=(num_blocks, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_register_topk
+
+
+def _make_compile_arg(tensor: torch.Tensor):
+    return flyc.from_torch_tensor(tensor).mark_shape_dynamic(0)
+
+
+@instrumented_flydsl_cache("aten::topk")
+def _compile_register_topk(
+    n: int,
+    k: int,
+    rows_per_cta: int,
+    arch: str,
+    backend: str,
+    *,
+    compile_args,
+) -> flyc.CompiledFunction:
+    input_2d, values_2d, indices_2d, rows_m, stream = compile_args
+    launch = _build_register_topk_module(n, k, rows_per_cta=rows_per_cta)
+    return flyc.compile(
+        launch,
+        _make_compile_arg(input_2d),
+        _make_compile_arg(values_2d),
+        _make_compile_arg(indices_2d),
+        rows_m,
+        stream,
+    )
+
+
+def RegisterTopKOut(
+    input_2d: torch.Tensor,
+    k: int,
+    values_2d: torch.Tensor,
+    indices_2d: torch.Tensor,
+    *,
+    rows_per_cta: int = 2,
+) -> None:
+    rows_m = input_2d.shape[0]
+    n = input_2d.shape[1]
+
+    with torch.cuda.device(input_2d.device):
+        stream = torch.cuda.current_stream(input_2d.device)
+        compiled = _compile_register_topk(
+            n,
+            k,
+            rows_per_cta,
+            str(get_rocm_arch()),
+            flyc.compile_backend_name(),
+            compile_args=(input_2d, values_2d, indices_2d, rows_m, stream),
+        )
+        compiled(input_2d, values_2d, indices_2d, rows_m, stream)
+
+
+def RegisterTopK(
+    input_2d: torch.Tensor, k: int, *, rows_per_cta: int = 2
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows_m = input_2d.shape[0]
+    values_2d = torch.empty((rows_m, k), device=input_2d.device, dtype=input_2d.dtype)
+    indices_2d = torch.empty((rows_m, k), device=input_2d.device, dtype=torch.int64)
+    RegisterTopKOut(input_2d, k, values_2d, indices_2d, rows_per_cta=rows_per_cta)
+    return values_2d, indices_2d
+
+
+@instrumented_flydsl_cache("aten::topk")
+def _compile_radix_select_topk(
+    n: int,
+    k: int,
+    deterministic: bool,
+    arch: str,
+    backend: str,
+    *,
+    compile_args,
+) -> flyc.CompiledFunction:
+    input_2d, values_2d, indices_2d, rows_m, stream = compile_args
+    launch = _build_radix_select_topk_module(n, k, deterministic)
+    return flyc.compile(
+        launch,
+        _make_compile_arg(input_2d),
+        _make_compile_arg(values_2d),
+        _make_compile_arg(indices_2d),
+        rows_m,
+        stream,
+    )
+
+
+def RadixSelectTopKOut(
+    input_2d: torch.Tensor,
+    k: int,
+    values_2d: torch.Tensor,
+    indices_2d: torch.Tensor,
+    *,
+    deterministic: bool = True,
+) -> None:
+    rows_m = input_2d.shape[0]
+    n = input_2d.shape[1]
+
+    with torch.cuda.device(input_2d.device):
+        stream = torch.cuda.current_stream(input_2d.device)
+        compiled = _compile_radix_select_topk(
+            n,
+            k,
+            deterministic,
+            str(get_rocm_arch()),
+            flyc.compile_backend_name(),
+            compile_args=(input_2d, values_2d, indices_2d, rows_m, stream),
+        )
+        compiled(input_2d, values_2d, indices_2d, rows_m, stream)
+
+
+def RadixSelectTopK(
+    input_2d: torch.Tensor, k: int, *, deterministic: bool = True
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows_m = input_2d.shape[0]
+    values_2d = torch.empty((rows_m, k), device=input_2d.device, dtype=input_2d.dtype)
+    indices_2d = torch.empty((rows_m, k), device=input_2d.device, dtype=torch.int64)
+    RadixSelectTopKOut(input_2d, k, values_2d, indices_2d, deterministic=deterministic)
+    return values_2d, indices_2d
+
+
+def clear_topk_cache() -> None:
+    _compile_register_topk.cache_clear()
+    _compile_radix_select_topk.cache_clear()
+
+
+def topk_cache_info():
+    register = _compile_register_topk.cache_info()
+    radix = _compile_radix_select_topk.cache_info()
+    return CacheInfo(
+        register.hits + radix.hits,
+        register.misses + radix.misses,
+        register.currsize + radix.currsize,
+    )

--- a/torch/_native/ops/topk/flydsl_kernels.py
+++ b/torch/_native/ops/topk/flydsl_kernels.py
@@ -1,0 +1,809 @@
+"""FlyDSL fp32 top-K kernel used by the native topk override."""
+
+# mypy: allow-untyped-defs
+
+import math
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir.dialects import llvm
+from flydsl.expr import (
+    arith,
+    Array,
+    buffer_ops,
+    Float32,
+    gpu,
+    Int32,
+    Int64,
+    range_constexpr,
+    rocdl as fly_rocdl,
+)
+from flydsl.expr.typing import T
+from flydsl.runtime.device import get_rocm_arch, is_rdna_arch
+
+import torch
+from torch._native.flydsl_cache import CacheInfo, jit_cache
+
+
+_N_HIST_BINS = 256
+_VEC = 4
+DPP_ROW_SHR_1 = 0x111
+DPP_ROW_SHR_2 = 0x112
+DPP_ROW_SHR_4 = 0x114
+DPP_ROW_SHR_8 = 0x118
+DPP_ROW_MASK = 0xF
+DPP_BANK_MASK = 0xF
+
+
+def _i32_const(x: int) -> int:
+    return x - (1 << 32) if x >= (1 << 31) else x
+
+
+def _make_topk_storage(k: int, block_threads: int):
+    @fx.struct
+    class SharedStorage:
+        s_hist: Array[Int32, 256, 16]
+        s_prefix: Array[Int32, 1, 4]
+        s_mask: Array[Int32, 1, 4]
+        s_rem_k: Array[Int32, 1, 4]
+        s_write_ctr: Array[Int32, 1, 4]
+        s_eq_ctr: Array[Int32, 1, 4]
+        s_scan: Array[Int32, block_threads + 1, 16]
+        s_vals: Array[Float32, k, 16]
+        s_ords: Array[Int32, k, 16]
+        s_idxs: Array[Int32, k, 16]
+        s_eq_vals: Array[Float32, k, 16]
+        s_eq_idxs: Array[Int32, k, 16]
+
+    return SharedStorage
+
+
+def _build_radix_select_topk_module(n: int, k: int, deterministic: bool):
+    block_threads = max(k, _N_HIST_BINS)
+    warp_size = 32 if is_rdna_arch(get_rocm_arch()) else 64
+    num_warps = block_threads // warp_size
+    tile = block_threads * _VEC
+    vec_iters = n // tile
+    vec_tail_start = vec_iters * tile
+    scalar_tail_iters = (n - vec_tail_start + block_threads - 1) // block_threads
+    num_stages = (k - 1).bit_length()
+
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
+    def radix_select_topk_kernel(
+        input: fx.Tensor,
+        values: fx.Tensor,
+        indices: fx.Tensor,
+    ):
+        row = fx.block_idx.x
+        tid = fx.thread_idx.x
+
+        f32 = T.f32
+
+        input_rsrc = buffer_ops.create_buffer_resource(input, max_size=True)
+        values_rsrc = buffer_ops.create_buffer_resource(values, max_size=True)
+        indices_rsrc = buffer_ops.create_buffer_resource(indices, max_size=True)
+        input_buf = fx.rocdl.make_buffer_tensor(input)
+
+        base_in = row * fx.Int32(n)
+        base_out = row * fx.Int32(k)
+        row_in = fx.slice(input_buf, (row, None))
+        input_div = fx.logical_divide(row_in, fx.make_layout(_VEC, 1))
+        copy_atom_v = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), 32)
+        storage = (
+            fx.SharedAllocator().allocate(_make_topk_storage(k, block_threads)).peek()
+        )
+        s_hist = storage.s_hist.view(fx.make_layout(_N_HIST_BINS, 1))
+        s_prefix = storage.s_prefix.view(fx.make_layout(1, 1))
+        s_mask = storage.s_mask.view(fx.make_layout(1, 1))
+        s_rem_k = storage.s_rem_k.view(fx.make_layout(1, 1))
+        s_write_ctr = storage.s_write_ctr.view(fx.make_layout(1, 1))
+        s_eq_ctr = storage.s_eq_ctr.view(fx.make_layout(1, 1))
+        s_scan = storage.s_scan.view(fx.make_layout(block_threads + 1, 1))
+        s_vals = storage.s_vals.view(fx.make_layout(k, 1))
+        s_ords = storage.s_ords.view(fx.make_layout(k, 1))
+        s_idxs = storage.s_idxs.view(fx.make_layout(k, 1))
+        s_eq_vals = storage.s_eq_vals.view(fx.make_layout(k, 1))
+        s_eq_idxs = storage.s_eq_idxs.view(fx.make_layout(k, 1))
+
+        def ord_from_bits(bits):
+            ords = bits ^ ((bits >> fx.Int32(31)) & fx.Int32(0x7FFFFFFF))
+            abs_bits = bits & fx.Int32(0x7FFFFFFF)
+            is_nan = arith.cmpi(arith.CmpIPredicate.ugt, abs_bits, fx.Int32(0x7F800000))
+            return arith.select(is_nan, fx.Int32(0x7FFFFFFF), ords)
+
+        def gmem_f32_to_ord(val):
+            return ord_from_bits(val.bitcast(T.i32))
+
+        def rmem_f32_to_ord(val):
+            return ord_from_bits(val.bitcast(Int32))
+
+        def smem_f32_to_ord(val):
+            return ord_from_bits(val.bitcast(Int32))
+
+        def load_col(col):
+            return buffer_ops.buffer_load(
+                input_rsrc, base_in + fx.Int32(col), vec_width=1, dtype=f32
+            )
+
+        def load_vec_f32(idx):
+            r = fx.make_rmem_tensor(4, Float32)
+            fx.copy_atom_call(copy_atom_v, fx.slice(input_div, (None, idx)), r)
+            return fx.memref_load_vec(r)
+
+        def atomic_add_i32_fetch(memref, val, offset):
+            base_ptr = buffer_ops.create_llvm_ptr(
+                buffer_ops.extract_base_index(memref, address_space=3), address_space=3
+            )
+            byte_offset = arith.unwrap(offset * fx.Int32(4))
+            ptr = buffer_ops.get_element_ptr(base_ptr, byte_offset=byte_offset)
+            old = llvm.AtomicRMWOp(
+                llvm.AtomicBinOp.add,
+                ptr,
+                arith.unwrap(val),
+                llvm.AtomicOrdering.monotonic,
+                syncscope="workgroup",
+                alignment=4,
+            ).result
+            return fx.Int32(old)
+
+        def atomic_add_hist(bin_idx):
+            atomic_add_i32_fetch(s_hist, fx.Int32(1), bin_idx)
+
+        def unwrap_val(val):
+            return val.ir_value() if hasattr(val, "ir_value") else arith.unwrap(val)
+
+        def warp_inclusive_prefix_i32(val, lane):
+            val_raw = unwrap_val(val)
+            zero_raw = unwrap_val(fx.Int32(0))
+            for _, dpp_op, threshold in [
+                (1, DPP_ROW_SHR_1, 1),
+                (2, DPP_ROW_SHR_2, 2),
+                (4, DPP_ROW_SHR_4, 4),
+                (8, DPP_ROW_SHR_8, 8),
+            ]:
+                remote = fly_rocdl.update_dpp(
+                    T.i32, zero_raw, val_raw, dpp_op, DPP_ROW_MASK, DPP_BANK_MASK, True
+                )
+                val = (lane >= fx.Int32(threshold)).select(val + fx.Int32(remote), val)
+                val_raw = unwrap_val(val)
+
+            src_lane_16 = (lane & fx.Int32(0x30)) - fx.Int32(1)
+            remote16 = fly_rocdl.ds_bpermute(T.i32, src_lane_16 * fx.Int32(4), val)
+            val = (lane >= fx.Int32(16)).select(val + fx.Int32(remote16), val)
+
+            if warp_size > 32:
+                src_lane_32 = (lane & fx.Int32(0x30)) - fx.Int32(17)
+                remote32 = fly_rocdl.ds_bpermute(T.i32, src_lane_32 * fx.Int32(4), val)
+                val = (lane >= fx.Int32(32)).select(val + fx.Int32(remote32), val)
+            return val
+
+        def block_excl_prefix_i32(packed_local):
+            lane = tid % fx.Int32(warp_size)
+            warp = tid // fx.Int32(warp_size)
+            incl = warp_inclusive_prefix_i32(packed_local, lane)
+            excl_intra = incl - packed_local
+            if lane == fx.Int32(warp_size - 1):
+                fx.memref_store(incl, s_scan, warp)
+            gpu.barrier()
+
+            if warp == fx.Int32(0):
+                warp_val = fx.Int32(0)
+                if lane < fx.Int32(num_warps):
+                    warp_val = s_scan[lane]
+                warp_incl = warp_inclusive_prefix_i32(warp_val, lane)
+                warp_excl = warp_incl - warp_val
+                if lane < fx.Int32(num_warps):
+                    fx.memref_store(warp_excl, s_scan, lane)
+                if lane == fx.Int32(num_warps - 1):
+                    fx.memref_store(warp_incl, s_scan, num_warps)
+            gpu.barrier()
+
+            packed_pfx = s_scan[warp] + excl_intra
+            packed_total = s_scan[num_warps]
+            gpu.barrier()
+            return packed_pfx, packed_total
+
+        if tid == fx.Int32(0):
+            fx.memref_store(fx.Int32(0), s_prefix, 0)
+            fx.memref_store(fx.Int32(0), s_mask, 0)
+            fx.memref_store(fx.Int32(k), s_rem_k, 0)
+        gpu.barrier()
+
+        # Phase 1: four radix byte passes, MSB to LSB.
+        for byte_pos in range_constexpr(4):
+            shift = (3 - byte_pos) * 8
+            xor_val = 128 if byte_pos == 0 else 0
+
+            # Zero the 256-bin histogram.
+            if tid < fx.Int32(_N_HIST_BINS):
+                fx.memref_store(fx.Int32(0), s_hist, tid)
+            gpu.barrier()
+
+            # Accumulate the current byte histogram.
+            prefix = s_prefix[0]
+            decided_mask = s_mask[0]
+            for step in range_constexpr(vec_iters):
+                rvals = load_vec_f32(step * block_threads + tid)
+                for vi in range_constexpr(_VEC):
+                    ords = rmem_f32_to_ord(rvals[vi])
+                    if byte_pos == 0 or (ords & decided_mask) == prefix:
+                        byte_val = (
+                            (ords >> fx.Int32(shift)) & fx.Int32(255)
+                        ) ^ fx.Int32(xor_val)
+                        atomic_add_hist(byte_val)
+            for step in range_constexpr(scalar_tail_iters):
+                col = vec_tail_start + step * block_threads + tid
+                if col < n:
+                    ords = gmem_f32_to_ord(load_col(col))
+                    if byte_pos == 0 or (ords & decided_mask) == prefix:
+                        byte_val = (
+                            (ords >> fx.Int32(shift)) & fx.Int32(255)
+                        ) ^ fx.Int32(xor_val)
+                        atomic_add_hist(byte_val)
+            gpu.barrier()
+
+            # Select the radix threshold.
+            if tid == fx.Int32(0):
+                remaining_k = s_rem_k[0]
+                acc = fx.Int32(0)
+                found = fx.Int32(0)
+                sel_bin = fx.Int32(0)
+                elems_above = fx.Int32(0)
+
+                for b in range_constexpr(_N_HIST_BINS):
+                    bin_idx = _N_HIST_BINS - 1 - b
+                    count = s_hist[bin_idx]
+                    if found == fx.Int32(0):
+                        if acc + count >= remaining_k:
+                            sel_bin = fx.Int32(bin_idx)
+                            elems_above = acc
+                            found = fx.Int32(1)
+                    acc = acc + count
+
+                actual_byte = sel_bin ^ fx.Int32(xor_val)
+                fx.memref_store(prefix | (actual_byte << fx.Int32(shift)), s_prefix, 0)
+                fx.memref_store(
+                    decided_mask | fx.Int32(_i32_const(255 << shift)), s_mask, 0
+                )
+                fx.memref_store(remaining_k - elems_above, s_rem_k, 0)
+            gpu.barrier()
+
+        # Phase 2: gather elements at-or-above the radix threshold.
+        threshold = s_prefix[0]  # Values above threshold are in top-k.
+        remaining_k = s_rem_k[0]  # Number of threshold ties to keep.
+
+        if tid == fx.Int32(0):
+            fx.memref_store(fx.Int32(0), s_write_ctr, 0)
+            fx.memref_store(fx.Int32(0), s_eq_ctr, 0)
+        if tid < fx.Int32(k):
+            fx.memref_store(fx.Float32(float("-inf")), s_vals, tid)
+            fx.memref_store(fx.Int32(0), s_idxs, tid)
+        gpu.barrier()
+
+        if deterministic:
+            above_base = fx.Int32(0)
+            eq_base = fx.Int32(0)
+            for step in range_constexpr(vec_iters):
+                tile_base = step * tile
+                base = tile_base + tid * _VEC
+                rvals = load_vec_f32(step * block_threads + tid)
+
+                # Class encoding: 2 = above, 1 = eq, 0 = below.
+                cls_reg = fx.make_rmem_tensor(_VEC, Int32)
+                packed_local = fx.Int32(0)
+                for vi in range_constexpr(_VEC):
+                    ords = rmem_f32_to_ord(rvals[vi])
+                    if ords > threshold:
+                        fx.memref_store(fx.Int32(2), cls_reg, vi)
+                        packed_local = packed_local + fx.Int32(1 << 16)
+                    elif ords == threshold:
+                        fx.memref_store(fx.Int32(1), cls_reg, vi)
+                        packed_local = packed_local + fx.Int32(1)
+                    else:
+                        fx.memref_store(fx.Int32(0), cls_reg, vi)
+
+                packed_pfx, packed_step_total = block_excl_prefix_i32(packed_local)
+                my_above = above_base + (packed_pfx >> fx.Int32(16))
+                my_eq = eq_base + (packed_pfx & fx.Int32(0xFFFF))
+                for vi in range_constexpr(_VEC):
+                    val = rvals[vi]
+                    cls = cls_reg[vi]
+                    idx = fx.Int32(base + vi)
+                    if cls == fx.Int32(2):
+                        if my_above < fx.Int32(k):
+                            fx.memref_store(val, s_vals, my_above)
+                            fx.memref_store(idx, s_idxs, my_above)
+                        my_above = my_above + fx.Int32(1)
+                    elif cls == fx.Int32(1):
+                        if my_eq < remaining_k:
+                            fx.memref_store(val, s_eq_vals, my_eq)
+                            fx.memref_store(idx, s_eq_idxs, my_eq)
+                        my_eq = my_eq + fx.Int32(1)
+
+                above_base = above_base + (packed_step_total >> fx.Int32(16))
+                next_eq_base = eq_base + (packed_step_total & fx.Int32(0xFFFF))
+                eq_base = (next_eq_base < remaining_k).select(next_eq_base, remaining_k)
+
+            # --- Scalar tail ---
+            for step in range_constexpr(scalar_tail_iters):
+                col = vec_tail_start + step * block_threads + tid
+                valid = col < n
+                packed_local = fx.Int32(0)
+                if valid:
+                    ords = gmem_f32_to_ord(load_col(col))
+                    if ords > threshold:
+                        packed_local = fx.Int32(1 << 16)
+                    elif ords == threshold:
+                        packed_local = fx.Int32(1)
+
+                packed_pfx, packed_step_total = block_excl_prefix_i32(packed_local)
+                my_above = above_base + (packed_pfx >> fx.Int32(16))
+                my_eq = eq_base + (packed_pfx & fx.Int32(0xFFFF))
+                if valid:
+                    idx = fx.Int32(col)
+                    val = load_col(col)
+                    ords = gmem_f32_to_ord(val)
+                    if ords > threshold:
+                        if my_above < fx.Int32(k):
+                            fx.memref_store(val, s_vals, my_above)
+                            fx.memref_store(idx, s_idxs, my_above)
+                    elif ords == threshold:
+                        if my_eq < remaining_k:
+                            fx.memref_store(val, s_eq_vals, my_eq)
+                            fx.memref_store(idx, s_eq_idxs, my_eq)
+
+                above_base = above_base + (packed_step_total >> fx.Int32(16))
+                next_eq_base = eq_base + (packed_step_total & fx.Int32(0xFFFF))
+                eq_base = (next_eq_base < remaining_k).select(next_eq_base, remaining_k)
+
+            gpu.barrier()
+            n_above = above_base
+            if tid < fx.Int32(k):
+                offset_into_eq = tid - n_above
+                if offset_into_eq >= fx.Int32(0) and offset_into_eq < remaining_k:
+                    fx.memref_store(s_eq_vals[offset_into_eq], s_vals, tid)
+                    fx.memref_store(s_eq_idxs[offset_into_eq], s_idxs, tid)
+            gpu.barrier()
+        else:
+            for step in range_constexpr(vec_iters):
+                tile_base = step * tile
+                base = tile_base + tid * _VEC
+                rvals = load_vec_f32(step * block_threads + tid)
+                for vi in range_constexpr(_VEC):
+                    idx = fx.Int32(base + vi)
+                    val = rvals[vi]
+                    ords = rmem_f32_to_ord(val)
+                    if ords > threshold:
+                        pos = atomic_add_i32_fetch(
+                            s_write_ctr, fx.Int32(1), fx.Int32(0)
+                        )
+                        if pos < fx.Int32(k):
+                            fx.memref_store(val, s_vals, pos)
+                            fx.memref_store(idx, s_idxs, pos)
+                    elif ords == threshold:
+                        eq_pos = atomic_add_i32_fetch(
+                            s_eq_ctr, fx.Int32(1), fx.Int32(0)
+                        )
+                        if eq_pos < remaining_k:
+                            pos = atomic_add_i32_fetch(
+                                s_write_ctr, fx.Int32(1), fx.Int32(0)
+                            )
+                            if pos < fx.Int32(k):
+                                fx.memref_store(val, s_vals, pos)
+                                fx.memref_store(idx, s_idxs, pos)
+            for step in range_constexpr(scalar_tail_iters):
+                col = vec_tail_start + step * block_threads + tid
+                if col < n:
+                    idx = fx.Int32(col)
+                    val = load_col(col)
+                    ords = gmem_f32_to_ord(val)
+                    if ords > threshold:
+                        pos = atomic_add_i32_fetch(
+                            s_write_ctr, fx.Int32(1), fx.Int32(0)
+                        )
+                        if pos < fx.Int32(k):
+                            fx.memref_store(val, s_vals, pos)
+                            fx.memref_store(idx, s_idxs, pos)
+                    elif ords == threshold:
+                        eq_pos = atomic_add_i32_fetch(
+                            s_eq_ctr, fx.Int32(1), fx.Int32(0)
+                        )
+                        if eq_pos < remaining_k:
+                            pos = atomic_add_i32_fetch(
+                                s_write_ctr, fx.Int32(1), fx.Int32(0)
+                            )
+                            if pos < fx.Int32(k):
+                                fx.memref_store(val, s_vals, pos)
+                                fx.memref_store(idx, s_idxs, pos)
+
+        gpu.barrier()
+
+        # Phase 3: cooperative bitonic sort.
+        active = tid < fx.Int32(k)
+        sort_tid = active.select(tid, fx.Int32(0))
+        if active:
+            fx.memref_store(smem_f32_to_ord(s_vals[sort_tid]), s_ords, tid)
+        gpu.barrier()
+
+        # Support non-power-of-two K by ignoring compare partners outside K.
+        # The bitonic network builds ascending blocks first, then the final
+        # stage merges everything into descending order.
+        for stage in range_constexpr(num_stages):
+            for sub_rev in range_constexpr(stage + 1):
+                sub = stage - sub_rev
+                step_size = 1 << sub
+                raw_partner = tid ^ fx.Int32(step_size)
+                partner_active = raw_partner < fx.Int32(k)
+                partner = (active & partner_active).select(raw_partner, fx.Int32(0))
+                my_o = s_ords[sort_tid]
+                my_i = s_idxs[sort_tid]
+                p_o = s_ords[partner]
+                p_v = s_vals[partner]
+                p_i = s_idxs[partner]
+                gpu.barrier()
+
+                self_lt_partner = my_o < p_o
+                self_gt_partner = my_o > p_o
+                if deterministic:
+                    self_lt_partner = (my_o < p_o) | ((my_o == p_o) & (my_i > p_i))
+                    self_gt_partner = (my_o > p_o) | ((my_o == p_o) & (my_i < p_i))
+                block_dir = (tid >> fx.Int32(stage + 1)) & fx.Int32(1)
+                if active & partner_active:
+                    if stage < num_stages - 1:
+                        if tid < partner:
+                            if block_dir == fx.Int32(0):
+                                if self_gt_partner:
+                                    fx.memref_store(p_o, s_ords, tid)
+                                    fx.memref_store(p_v, s_vals, tid)
+                                    fx.memref_store(p_i, s_idxs, tid)
+                            else:
+                                if self_lt_partner:
+                                    fx.memref_store(p_o, s_ords, tid)
+                                    fx.memref_store(p_v, s_vals, tid)
+                                    fx.memref_store(p_i, s_idxs, tid)
+                        else:
+                            if block_dir == fx.Int32(0):
+                                if self_lt_partner:
+                                    fx.memref_store(p_o, s_ords, tid)
+                                    fx.memref_store(p_v, s_vals, tid)
+                                    fx.memref_store(p_i, s_idxs, tid)
+                            else:
+                                if self_gt_partner:
+                                    fx.memref_store(p_o, s_ords, tid)
+                                    fx.memref_store(p_v, s_vals, tid)
+                                    fx.memref_store(p_i, s_idxs, tid)
+                    else:
+                        if tid < partner:
+                            if block_dir == fx.Int32(0):
+                                if self_lt_partner:
+                                    fx.memref_store(p_o, s_ords, tid)
+                                    fx.memref_store(p_v, s_vals, tid)
+                                    fx.memref_store(p_i, s_idxs, tid)
+                            else:
+                                if self_gt_partner:
+                                    fx.memref_store(p_o, s_ords, tid)
+                                    fx.memref_store(p_v, s_vals, tid)
+                                    fx.memref_store(p_i, s_idxs, tid)
+                        else:
+                            if block_dir == fx.Int32(0):
+                                if self_gt_partner:
+                                    fx.memref_store(p_o, s_ords, tid)
+                                    fx.memref_store(p_v, s_vals, tid)
+                                    fx.memref_store(p_i, s_idxs, tid)
+                            else:
+                                if self_lt_partner:
+                                    fx.memref_store(p_o, s_ords, tid)
+                                    fx.memref_store(p_v, s_vals, tid)
+                                    fx.memref_store(p_i, s_idxs, tid)
+                gpu.barrier()
+
+        # Phase 4: results to gmem.
+        if tid < fx.Int32(k):
+            offset = base_out + tid
+            buffer_ops.buffer_store(s_vals[tid], values_rsrc, offset)
+            buffer_ops.buffer_store(fx.Int64(s_idxs[tid]), indices_rsrc, offset)
+
+    @flyc.jit
+    def launch_radix_select_topk(
+        input: fx.Tensor,
+        values: fx.Tensor,
+        indices: fx.Tensor,
+        rows_m: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        launcher = radix_select_topk_kernel(input, values, indices)
+        launcher.launch(
+            grid=(rows_m, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_radix_select_topk
+
+
+def _build_register_topk_module(n: int, k: int, rows_per_cta: int = 2):
+    threads_per_row = 32 if is_rdna_arch(get_rocm_arch()) else 64
+    block_threads = threads_per_row * rows_per_cta
+    vec = n // threads_per_row
+    num_stages_vec = int(math.log2(vec)) if vec > 1 else 0
+    num_stages_k = int(math.log2(k)) if k > 1 else 0
+    log2_threads_per_row = int(math.log2(threads_per_row))
+
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
+    def register_topk_kernel(
+        input: fx.Tensor,
+        values: fx.Tensor,
+        indices: fx.Tensor,
+        rows_m: fx.Int32,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid % fx.Int32(threads_per_row)
+        row_local = tid // fx.Int32(threads_per_row)
+        row = bid * fx.Int32(rows_per_cta) + row_local
+        row_safe = (row < rows_m).select(row, fx.Int32(0))
+        in_bounds = row < rows_m
+
+        input_rsrc = buffer_ops.create_buffer_resource(input, max_size=True)
+        values_rsrc = buffer_ops.create_buffer_resource(values, max_size=True)
+        indices_rsrc = buffer_ops.create_buffer_resource(indices, max_size=True)
+        base_in = row_safe * fx.Int32(n)
+        base_out = row * fx.Int32(k)
+
+        def load_col(col):
+            return buffer_ops.buffer_load(
+                input_rsrc, base_in + fx.Int32(col), vec_width=1, dtype=T.f32
+            )
+
+        def ord_from_bits(bits):
+            ords = bits ^ ((bits >> fx.Int32(31)) & fx.Int32(0x7FFFFFFF))
+            abs_bits = bits & fx.Int32(0x7FFFFFFF)
+            is_nan = arith.cmpi(arith.CmpIPredicate.ugt, abs_bits, fx.Int32(0x7F800000))
+            return arith.select(is_nan, fx.Int32(0x7FFFFFFF), ords)
+
+        def f32_to_ord(val):
+            return ord_from_bits(val.bitcast(T.i32))
+
+        def make_key(val, idx):
+            ord64 = fx.Int64(f32_to_ord(val)) & fx.Int64(0xFFFFFFFF)
+            inv_idx64 = fx.Int64(~idx) & fx.Int64(0xFFFFFFFF)
+            return (ord64 << fx.Int64(32)) | inv_idx64
+
+        def decode_key(key):
+            ord32 = fx.Int32(key >> fx.Int64(32))
+            inv_idx = fx.Int32(key & fx.Int64(0xFFFFFFFF))
+            val_bits = ord32 ^ ((ord32 >> fx.Int32(31)) & fx.Int32(0x7FFFFFFF))
+            return val_bits.bitcast(Float32), ~inv_idx
+
+        def cas_desc(arr, i: int, j: int):
+            a = arr[i]
+            b = arr[j]
+            swap = a < b
+            arr[i] = swap.select(b, a)
+            arr[j] = swap.select(a, b)
+
+        def bitonic_sort_desc(arr, length: int, stages: int):
+            if length > 1:
+                for s in range_constexpr(stages):
+                    for sub_rev in range_constexpr(s + 1):
+                        step = 1 << (s - sub_rev)
+                        for i in range_constexpr(length):
+                            j = i ^ step
+                            if j > i:
+                                block_dir = (i >> (s + 1)) & 1
+                                if block_dir == 0:
+                                    cas_desc(arr, i, j)
+                                else:
+                                    a = arr[i]
+                                    b = arr[j]
+                                    swap = a > b
+                                    arr[i] = swap.select(b, a)
+                                    arr[j] = swap.select(a, b)
+
+        def bitonic_merge_desc(arr, length: int, levels: int):
+            if length > 1:
+                for level in range_constexpr(levels):
+                    merge_len = length >> level
+                    step = merge_len // 2
+                    for i in range_constexpr(length // merge_len):
+                        start_i = i * merge_len
+                        for j in range_constexpr(step):
+                            cas_desc(arr, start_i + j, start_i + j + step)
+
+        def topk_merge_desc(a, b):
+            for i in range_constexpr(k):
+                x = a[i]
+                y = b[k - 1 - i]
+                take_y = y > x
+                a[i] = take_y.select(y, x)
+            bitonic_merge_desc(a, k, num_stages_k)
+
+        # Sort each lane's VEC elements in registers.
+        keys = fx.make_rmem_tensor(vec, Int64)
+        for i in range_constexpr(vec):
+            col = lane * fx.Int32(vec) + fx.Int32(i)
+            keys[i] = make_key(load_col(col), col)
+        bitonic_sort_desc(keys, vec, num_stages_vec)
+
+        # Build per-lane top-K. If VEC < K, pad with INT64_MIN so the
+        # sentinel sorts strictly below any real key; if VEC >= K take the
+        # leading K (already sorted).
+        topk = fx.make_rmem_tensor(k, Int64)
+        if vec >= k:
+            if vec == k:
+                fx.memref_store_vec(fx.memref_load_vec(keys), topk)
+            else:
+                keys_vec = fx.memref_load_vec(keys)
+                fx.memref_store_vec(keys_vec.shuffle(keys_vec, list(range(k))), topk)
+        else:
+            sentinel = fx.Int64(-(1 << 63))
+            for i in range_constexpr(vec):
+                topk[i] = keys[i]
+            for i in range_constexpr(k - vec):
+                topk[vec + i] = sentinel
+
+        # Warp-cooperative top-K merge via butterfly shuffles.
+        for s in range_constexpr(log2_threads_per_row):
+            other = fx.make_rmem_tensor(k, Int64)
+            for i in range_constexpr(k):
+                peer = gpu.shuffle_xor(
+                    topk[i], fx.Int32(1 << s), fx.Int32(threads_per_row)
+                )
+                other[i] = peer
+            topk_merge_desc(topk, other)
+
+        if lane == fx.Int32(0) and in_bounds:
+            for i in range_constexpr(k):
+                val, idx = decode_key(topk[i])
+                offset = base_out + fx.Int32(i)
+                buffer_ops.buffer_store(val, values_rsrc, offset)
+                buffer_ops.buffer_store(fx.Int64(idx), indices_rsrc, offset)
+
+    @flyc.jit
+    def launch_register_topk(
+        input: fx.Tensor,
+        values: fx.Tensor,
+        indices: fx.Tensor,
+        rows_m: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        num_blocks = (rows_m + rows_per_cta - 1) // rows_per_cta
+        launcher = register_topk_kernel(input, values, indices, rows_m)
+        launcher.launch(
+            grid=(num_blocks, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_register_topk
+
+
+def _make_compile_arg(tensor: torch.Tensor):
+    return flyc.from_torch_tensor(tensor).mark_shape_dynamic(0)
+
+
+@jit_cache
+def _compile_register_topk(
+    n: int,
+    k: int,
+    rows_per_cta: int,
+    arch: str,
+    backend: str,
+    *,
+    compile_args,
+) -> flyc.CompiledFunction:
+    input_2d, values_2d, indices_2d, rows_m, stream = compile_args
+    launch = _build_register_topk_module(n, k, rows_per_cta=rows_per_cta)
+    return flyc.compile(
+        launch,
+        _make_compile_arg(input_2d),
+        _make_compile_arg(values_2d),
+        _make_compile_arg(indices_2d),
+        rows_m,
+        stream,
+    )
+
+
+def RegisterTopKOut(
+    input_2d: torch.Tensor,
+    k: int,
+    values_2d: torch.Tensor,
+    indices_2d: torch.Tensor,
+    *,
+    rows_per_cta: int = 2,
+) -> None:
+    rows_m = input_2d.shape[0]
+    n = input_2d.shape[1]
+
+    with torch.cuda.device(input_2d.device):
+        stream = torch.cuda.current_stream(input_2d.device)
+        compiled = _compile_register_topk(
+            n,
+            k,
+            rows_per_cta,
+            str(get_rocm_arch()),
+            flyc.compile_backend_name(),
+            compile_args=(input_2d, values_2d, indices_2d, rows_m, stream),
+        )
+        compiled(input_2d, values_2d, indices_2d, rows_m, stream)
+
+
+def RegisterTopK(
+    input_2d: torch.Tensor, k: int, *, rows_per_cta: int = 2
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows_m = input_2d.shape[0]
+    values_2d = torch.empty((rows_m, k), device=input_2d.device, dtype=input_2d.dtype)
+    indices_2d = torch.empty((rows_m, k), device=input_2d.device, dtype=torch.int64)
+    RegisterTopKOut(input_2d, k, values_2d, indices_2d, rows_per_cta=rows_per_cta)
+    return values_2d, indices_2d
+
+
+@jit_cache
+def _compile_radix_select_topk(
+    n: int,
+    k: int,
+    deterministic: bool,
+    arch: str,
+    backend: str,
+    *,
+    compile_args,
+) -> flyc.CompiledFunction:
+    input_2d, values_2d, indices_2d, rows_m, stream = compile_args
+    launch = _build_radix_select_topk_module(n, k, deterministic)
+    return flyc.compile(
+        launch,
+        _make_compile_arg(input_2d),
+        _make_compile_arg(values_2d),
+        _make_compile_arg(indices_2d),
+        rows_m,
+        stream,
+    )
+
+
+def RadixSelectTopKOut(
+    input_2d: torch.Tensor,
+    k: int,
+    values_2d: torch.Tensor,
+    indices_2d: torch.Tensor,
+    *,
+    deterministic: bool = True,
+) -> None:
+    rows_m = input_2d.shape[0]
+    n = input_2d.shape[1]
+
+    with torch.cuda.device(input_2d.device):
+        stream = torch.cuda.current_stream(input_2d.device)
+        compiled = _compile_radix_select_topk(
+            n,
+            k,
+            deterministic,
+            str(get_rocm_arch()),
+            flyc.compile_backend_name(),
+            compile_args=(input_2d, values_2d, indices_2d, rows_m, stream),
+        )
+        compiled(input_2d, values_2d, indices_2d, rows_m, stream)
+
+
+def RadixSelectTopK(
+    input_2d: torch.Tensor, k: int, *, deterministic: bool = True
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows_m = input_2d.shape[0]
+    values_2d = torch.empty((rows_m, k), device=input_2d.device, dtype=input_2d.dtype)
+    indices_2d = torch.empty((rows_m, k), device=input_2d.device, dtype=torch.int64)
+    RadixSelectTopKOut(input_2d, k, values_2d, indices_2d, deterministic=deterministic)
+    return values_2d, indices_2d
+
+
+def clear_topk_cache() -> None:
+    _compile_register_topk.cache_clear()
+    _compile_radix_select_topk.cache_clear()
+
+
+def topk_cache_info():
+    register = _compile_register_topk.cache_info()
+    radix = _compile_radix_select_topk.cache_info()
+    return CacheInfo(
+        register.hits + radix.hits,
+        register.misses + radix.misses,
+        register.currsize + radix.currsize,
+    )

--- a/torch/_native/ops/topk/flydsl_kernels.py
+++ b/torch/_native/ops/topk/flydsl_kernels.py
@@ -51,19 +51,27 @@ def _f32_to_ord(val):
     return arith.select(is_nan, fx.Int32(0x7FFFFFFF), ords)
 
 
-def _make_topk_storage(k: int, block_threads: int):
+def _make_topk_storage(k: int, sort_len: int, block_threads: int):
+    @fx.struct
+    class CounterStorage:
+        s_write_ctr: Array[Int32, 1, 4]
+        s_eq_ctr: Array[Int32, 1, 4]
+
+    @fx.union
+    class PhaseStorage:
+        s_hist: Array[Int32, 256, 16]
+        s_counters: CounterStorage
+        s_scan: Array[Int32, block_threads + 1, 16]
+        s_ords: Array[Int32, sort_len, 16]
+
     @fx.struct
     class SharedStorage:
-        s_hist: Array[Int32, 256, 16]
+        s_phase: PhaseStorage
         s_prefix: Array[Int32, 1, 4]
         s_mask: Array[Int32, 1, 4]
         s_rem_k: Array[Int32, 1, 4]
-        s_write_ctr: Array[Int32, 1, 4]
-        s_eq_ctr: Array[Int32, 1, 4]
-        s_scan: Array[Int32, block_threads + 1, 16]
-        s_vals: Array[Float32, k, 16]
-        s_ords: Array[Int32, k, 16]
-        s_idxs: Array[Int32, k, 16]
+        s_vals: Array[Float32, sort_len, 16]
+        s_idxs: Array[Int32, sort_len, 16]
         s_eq_vals: Array[Float32, k, 16]
         s_eq_idxs: Array[Int32, k, 16]
 
@@ -71,14 +79,15 @@ def _make_topk_storage(k: int, block_threads: int):
 
 
 def _build_radix_select_topk_module(n: int, k: int, deterministic: bool):
-    block_threads = max(k, _N_HIST_BINS)
+    num_stages = (k - 1).bit_length()
+    sort_len = 1 << num_stages
+    block_threads = max(sort_len, _N_HIST_BINS)
     warp_size = 32 if is_rdna_arch(get_rocm_arch()) else 64
     num_warps = block_threads // warp_size
     tile = block_threads * _VEC
     vec_iters = n // tile
     vec_tail_start = vec_iters * tile
     scalar_tail_iters = (n - vec_tail_start + block_threads - 1) // block_threads
-    num_stages = (k - 1).bit_length()
 
     @flyc.kernel(known_block_size=[block_threads, 1, 1])
     def radix_select_topk_kernel(
@@ -98,21 +107,25 @@ def _build_radix_select_topk_module(n: int, k: int, deterministic: bool):
         row_indices = fx.slice(indices_buf, (row, None))
         input_div = fx.logical_divide(row_in, fx.make_layout(_VEC, 1))
         copy_atom_v = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), 32)
-        storage = (
-            fx.SharedAllocator().allocate(_make_topk_storage(k, block_threads)).peek()
+        storage = fx.SharedAllocator().allocate(
+            _make_topk_storage(k, sort_len, block_threads)
         )
-        s_hist = storage.s_hist.view(fx.make_layout(_N_HIST_BINS, 1))
-        s_prefix = storage.s_prefix.view(fx.make_layout(1, 1))
-        s_mask = storage.s_mask.view(fx.make_layout(1, 1))
-        s_rem_k = storage.s_rem_k.view(fx.make_layout(1, 1))
-        s_write_ctr = storage.s_write_ctr.view(fx.make_layout(1, 1))
-        s_eq_ctr = storage.s_eq_ctr.view(fx.make_layout(1, 1))
-        s_scan = storage.s_scan.view(fx.make_layout(block_threads + 1, 1))
-        s_vals = storage.s_vals.view(fx.make_layout(k, 1))
-        s_ords = storage.s_ords.view(fx.make_layout(k, 1))
-        s_idxs = storage.s_idxs.view(fx.make_layout(k, 1))
-        s_eq_vals = storage.s_eq_vals.view(fx.make_layout(k, 1))
-        s_eq_idxs = storage.s_eq_idxs.view(fx.make_layout(k, 1))
+        s_hist = storage.s_phase.s_hist.peek().view(fx.make_layout(_N_HIST_BINS, 1))
+        s_prefix = storage.s_prefix.peek().view(fx.make_layout(1, 1))
+        s_mask = storage.s_mask.peek().view(fx.make_layout(1, 1))
+        s_rem_k = storage.s_rem_k.peek().view(fx.make_layout(1, 1))
+        s_write_ctr = storage.s_phase.s_counters.s_write_ctr.peek().view(
+            fx.make_layout(1, 1)
+        )
+        s_eq_ctr = storage.s_phase.s_counters.s_eq_ctr.peek().view(fx.make_layout(1, 1))
+        s_scan = storage.s_phase.s_scan.peek().view(
+            fx.make_layout(block_threads + 1, 1)
+        )
+        s_vals = storage.s_vals.peek().view(fx.make_layout(sort_len, 1))
+        s_ords = storage.s_phase.s_ords.peek().view(fx.make_layout(sort_len, 1))
+        s_idxs = storage.s_idxs.peek().view(fx.make_layout(sort_len, 1))
+        s_eq_vals = storage.s_eq_vals.peek().view(fx.make_layout(k, 1))
+        s_eq_idxs = storage.s_eq_idxs.peek().view(fx.make_layout(k, 1))
 
         def load_vec_f32(idx):
             r = fx.make_rmem_tensor(4, Float32)
@@ -255,7 +268,7 @@ def _build_radix_select_topk_module(n: int, k: int, deterministic: bool):
         if tid == 0:
             s_write_ctr[0] = 0
             s_eq_ctr[0] = 0
-        if tid < fx.Int32(k):
+        if tid < fx.Int32(sort_len):
             s_vals[tid] = float("-inf")
             s_idxs[tid] = 0
         gpu.barrier()
@@ -375,23 +388,31 @@ def _build_radix_select_topk_module(n: int, k: int, deterministic: bool):
 
         gpu.barrier()
 
+        def store_entry(ords, vals, idxs, pos, ord_value, val_value, idx_value):
+            ords[pos] = ord_value
+            vals[pos] = val_value
+            idxs[pos] = idx_value
+
         # Phase 3: cooperative bitonic sort.
         active = tid < fx.Int32(k)
-        sort_tid = active.select(tid, 0)
-        if active:
-            s_ords[tid] = _f32_to_ord(s_vals[sort_tid])
+        sort_active = tid < fx.Int32(sort_len)
+        sort_tid = sort_active.select(tid, 0)
+        if sort_active:
+            if active:
+                s_ords[tid] = _f32_to_ord(s_vals[sort_tid])
+            else:
+                s_ords[tid] = fx.Int32(_i32_const(1 << 31))
         gpu.barrier()
 
-        # Support non-power-of-two K by ignoring compare partners outside K.
-        # The bitonic network builds ascending blocks first, then the final
-        # stage merges everything into descending order.
+        # The padded bitonic network builds ascending blocks first, then the
+        # final stage merges everything into descending order.
         for stage in range_constexpr(num_stages):
             for sub_rev in range_constexpr(stage + 1):
                 sub = stage - sub_rev
                 step_size = 1 << sub
                 raw_partner = tid ^ fx.Int32(step_size)
-                partner_active = raw_partner < fx.Int32(k)
-                partner = (active & partner_active).select(raw_partner, 0)
+                partner_active = raw_partner < fx.Int32(sort_len)
+                partner = (sort_active & partner_active).select(raw_partner, 0)
                 my_o = s_ords[sort_tid]
                 my_i = s_idxs[sort_tid]
                 p_o = s_ords[partner]
@@ -405,53 +426,53 @@ def _build_radix_select_topk_module(n: int, k: int, deterministic: bool):
                     self_lt_partner = (my_o < p_o) | ((my_o == p_o) & (my_i > p_i))
                     self_gt_partner = (my_o > p_o) | ((my_o == p_o) & (my_i < p_i))
                 block_dir = (tid >> fx.Int32(stage + 1)) & 1
-                if active & partner_active:
+                if sort_active & partner_active:
                     if stage < num_stages - 1:
                         if tid < partner:
                             if block_dir == 0:
                                 if self_gt_partner:
-                                    s_ords[tid] = p_o
-                                    s_vals[tid] = p_v
-                                    s_idxs[tid] = p_i
+                                    store_entry(
+                                        s_ords, s_vals, s_idxs, tid, p_o, p_v, p_i
+                                    )
                             else:
                                 if self_lt_partner:
-                                    s_ords[tid] = p_o
-                                    s_vals[tid] = p_v
-                                    s_idxs[tid] = p_i
+                                    store_entry(
+                                        s_ords, s_vals, s_idxs, tid, p_o, p_v, p_i
+                                    )
                         else:
                             if block_dir == 0:
                                 if self_lt_partner:
-                                    s_ords[tid] = p_o
-                                    s_vals[tid] = p_v
-                                    s_idxs[tid] = p_i
+                                    store_entry(
+                                        s_ords, s_vals, s_idxs, tid, p_o, p_v, p_i
+                                    )
                             else:
                                 if self_gt_partner:
-                                    s_ords[tid] = p_o
-                                    s_vals[tid] = p_v
-                                    s_idxs[tid] = p_i
+                                    store_entry(
+                                        s_ords, s_vals, s_idxs, tid, p_o, p_v, p_i
+                                    )
                     else:
                         if tid < partner:
                             if block_dir == 0:
                                 if self_lt_partner:
-                                    s_ords[tid] = p_o
-                                    s_vals[tid] = p_v
-                                    s_idxs[tid] = p_i
+                                    store_entry(
+                                        s_ords, s_vals, s_idxs, tid, p_o, p_v, p_i
+                                    )
                             else:
                                 if self_gt_partner:
-                                    s_ords[tid] = p_o
-                                    s_vals[tid] = p_v
-                                    s_idxs[tid] = p_i
+                                    store_entry(
+                                        s_ords, s_vals, s_idxs, tid, p_o, p_v, p_i
+                                    )
                         else:
                             if block_dir == 0:
                                 if self_gt_partner:
-                                    s_ords[tid] = p_o
-                                    s_vals[tid] = p_v
-                                    s_idxs[tid] = p_i
+                                    store_entry(
+                                        s_ords, s_vals, s_idxs, tid, p_o, p_v, p_i
+                                    )
                             else:
                                 if self_lt_partner:
-                                    s_ords[tid] = p_o
-                                    s_vals[tid] = p_v
-                                    s_idxs[tid] = p_i
+                                    store_entry(
+                                        s_ords, s_vals, s_idxs, tid, p_o, p_v, p_i
+                                    )
                 gpu.barrier()
 
         # Phase 4: results to gmem.
@@ -518,10 +539,10 @@ def _build_register_topk_module(n: int, k: int, rows_per_cta: int = 2):
             val_bits = ord32 ^ ((ord32 >> fx.Int32(31)) & fx.Int32(0x7FFFFFFF))
             return val_bits.bitcast(Float32), ~inv_idx
 
-        def cas_desc(arr, i: int, j: int):
+        def compare_and_swap(arr, i: int, j: int, descending: bool):
             a = arr[i]
             b = arr[j]
-            swap = a < b
+            swap = a < b if descending else a > b
             arr[i] = swap.select(b, a)
             arr[j] = swap.select(a, b)
 
@@ -534,14 +555,7 @@ def _build_register_topk_module(n: int, k: int, rows_per_cta: int = 2):
                             j = i ^ step
                             if j > i:
                                 block_dir = (i >> (s + 1)) & 1
-                                if block_dir == 0:
-                                    cas_desc(arr, i, j)
-                                else:
-                                    a = arr[i]
-                                    b = arr[j]
-                                    swap = a > b
-                                    arr[i] = swap.select(b, a)
-                                    arr[j] = swap.select(a, b)
+                                compare_and_swap(arr, i, j, block_dir == 0)
 
         def bitonic_merge_desc(arr, length: int, levels: int):
             if length > 1:
@@ -551,7 +565,7 @@ def _build_register_topk_module(n: int, k: int, rows_per_cta: int = 2):
                     for i in range_constexpr(length // merge_len):
                         start_i = i * merge_len
                         for j in range_constexpr(step):
-                            cas_desc(arr, start_i + j, start_i + j + step)
+                            compare_and_swap(arr, start_i + j, start_i + j + step, True)
 
         def topk_merge_desc(a, b):
             for i in range_constexpr(k):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -23067,6 +23067,10 @@ if "cutedsl" in dsl_ops_by_dsl:
     ])
 
 if "flydsl" in dsl_ops_by_dsl:
+    from torch._native.ops.topk.flydsl_impl import (
+        _is_supported_arch as _is_flydsl_topk_supported_arch,
+    )
+
     _flydsl_topk_skips = (
         DecorateInfo(skipCUDAIf(not torch.cuda.is_available(), "CUDA not available")),
         DecorateInfo(unittest.skip("topk override requires contiguous input"),
@@ -23096,7 +23100,20 @@ if "flydsl" in dsl_ops_by_dsl:
         supports_fwgrad_bwgrad=False,
         supports_out=False,
         supports_cow_input_no_materialize_forward=False,
-        decorators=[DecorateInfo(onlyCUDA)],
+        decorators=[
+            DecorateInfo(onlyCUDA),
+            DecorateInfo(
+                skipCUDAIf(
+                    not (
+                        torch.cuda.is_available()
+                        and _is_flydsl_topk_supported_arch(
+                            torch.cuda.current_device()
+                        )
+                    ),
+                    "flydsl topk override requires gfx950",
+                )
+            ),
+        ],
         skips=_flydsl_topk_skips,
     )
     dsl_ops_by_dsl["flydsl"].extend([

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5522,6 +5522,42 @@ def sample_inputs_cutedsl_topk(op_info, device, dtype, requires_grad, **kwargs):
         yield SampleInput(make_arg((4, 64, N)).contiguous(), args=(K,))
 
 
+def sample_inputs_flydsl_topk(op_info, device, dtype, requires_grad, **kwargs):
+    from torch._native.ops.topk.flydsl_impl import _radix_n_range, _REGISTER_N_RANGE
+
+    def make_arg(shape):
+        values = torch.randperm(math.prod(shape), dtype=torch.int64, device=device)
+        return values.reshape(shape).to(dtype)
+
+    def radix_min_n(k):
+        n_range = _radix_n_range(k)
+        if n_range is None:
+            raise AssertionError(f"missing radix gate for K={k}")
+        return n_range[0]
+
+    device_index = torch.device(device).index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    rows = max(256, torch.cuda.get_device_properties(device_index).multi_processor_count)
+
+    register_cases = ((2, _REGISTER_N_RANGE[0]), (16, _REGISTER_N_RANGE[1]))
+    # Cover radix block sizes and non-power-of-two sorts without duplicating
+    # the exhaustive per-K native test matrix.
+    radix_cases = tuple(
+        (K, radix_min_n(K)) for K in (64, 192, 320, 448, 768, 832, 1024)
+    )
+    for K, N in (*register_cases, *radix_cases):
+        yield SampleInput(make_arg((rows, N)).contiguous(), args=(K,))
+
+    nd_rows = (rows + 3) // 4
+    yield SampleInput(
+        make_arg((4, nd_rows, _REGISTER_N_RANGE[0])).contiguous(), args=(8, -1)
+    )
+    yield SampleInput(
+        make_arg((4, nd_rows, radix_min_n(320))).contiguous(), args=(320, -1)
+    )
+
+
 def _topk_deterministic(*args, **kwargs):
     prior = torch.are_deterministic_algorithms_enabled()
     try:
@@ -23027,6 +23063,57 @@ if "cutedsl" in dsl_ops_by_dsl:
             variant_test_name="cutedsl_optimized_deterministic",
             method_variant=_topk_method_deterministic,
             **_cutedsl_topk_kwargs,
+        ),
+    ])
+
+if "flydsl" in dsl_ops_by_dsl:
+    _flydsl_topk_skips = (
+        DecorateInfo(skipCUDAIf(not torch.cuda.is_available(), "CUDA not available")),
+        DecorateInfo(unittest.skip("topk override requires contiguous input"),
+                     "TestCommon", "test_noncontiguous_samples"),
+        DecorateInfo(unittest.skip("Sample generator allocates on the primary CUDA device"),
+                     "TestCommon", "test_multiple_devices"),
+        DecorateInfo(unittest.skip("torch.topk supports more dtypes than the DSL override"),
+                     "TestCommon", "test_dtypes"),
+        DecorateInfo(unittest.skip("topk override incompatible with FakeTensor"),
+                     "TestFakeTensor"),
+        DecorateInfo(unittest.skip("topk override not introspectable for tag inference"),
+                     "TestTags"),
+        DecorateInfo(unittest.skip("topk override not introspectable for conjugate/negate views"),
+                     "TestMathBits"),
+        DecorateInfo(unittest.skip("torch.topk supports out= even though the DSL OpInfo does not exercise it"),
+                     "TestCommon", "test_out"),
+        DecorateInfo(unittest.skip("torch.topk supports out= even though the DSL OpInfo does not exercise it"),
+                     "TestCommon", "test_out_warning"),
+    )
+    _flydsl_topk_kwargs = dict(
+        dtypes=_dispatch_dtypes((torch.float32,)),
+        dtypesIfCUDA=_dispatch_dtypes((torch.float32,)),
+        sample_inputs_func=sample_inputs_flydsl_topk,
+        ref=reference_topk,
+        supports_autograd=False,
+        supports_forward_ad=False,
+        supports_fwgrad_bwgrad=False,
+        supports_out=False,
+        supports_cow_input_no_materialize_forward=False,
+        decorators=[DecorateInfo(onlyCUDA)],
+        skips=_flydsl_topk_skips,
+    )
+    dsl_ops_by_dsl["flydsl"].extend([
+        OpInfo(
+            "topk", op=torch.topk,
+            variant_test_name="flydsl_optimized",
+            skips=_flydsl_topk_skips + (
+                DecorateInfo(unittest.skip("nondeterministic on tied indices by design"),
+                             "TestCommon", "test_variant_consistency_eager"),
+            ),
+            **{k: v for k, v in _flydsl_topk_kwargs.items() if k != "skips"},
+        ),
+        OpInfo(
+            "topk", op=_topk_deterministic,
+            variant_test_name="flydsl_optimized_deterministic",
+            method_variant=_topk_method_deterministic,
+            **_flydsl_topk_kwargs,
         ),
     ])
 


### PR DESCRIPTION
### Motivation

`aten::topk` on ROCm leaves performance on the table for the shapes common in LLM / MoE workloads — large row counts with either a small top-k or a large-k selection over a wide last dimension. FlyDSL lets us express hand-tuned selection kernels for these regimes. This PR wires a FlyDSL backend into the native-op dispatch layer as a **transparent, opt-out override**: it engages only for shapes where it is a measured win and falls through to the existing ATen implementation everywhere else, so it is safe to enable by default.

### Changes

- **`torch/_native/ops/topk/flydsl_kernels.py`** — the FlyDSL kernels: a *register* kernel for small K and a *radix-select* kernel for large K (with a deterministic tie-handling path), plus a per-specialization compile cache.
- **`torch/_native/ops/topk/flydsl_impl.py`** — the dispatch predicate, shape gates, and ATen fallback wiring (`topk` and `topk.values` / `out=`).
- **`torch/_native/ops/topk/__init__.py`** — registers the override.
- **`test/python_native/test_topk_flydsl.py`** — unit tests.

### When FlyDSL acceleration kicks in

The override engages only when **all** of these hold (otherwise it falls back to ATen):

- fp32, contiguous, not copy-on-write, last-dim, `largest=True`, `sorted=True`, non-empty.
- Row count `M = numel/N >= CU count` (GPU-occupancy gate).
- `(k, N)` lands in one of the tuned kernel ranges:

| kernel | k | N |
|--------|-----|-----|
| register | {2, 4, 8, 16} | power-of-two, `1024 <= N <= 8192` |
| radix | {64, 128, 256, 512} | `16384 <= N <= 32768` |
| radix | {1024} | `32768 <= N <= 65536` |

### Testing

#### Unit tests

`test/python_native/test_topk_flydsl.py`, run in the ROCm container:

```
python test/python_native/test_topk_flydsl.py
```

59 tests pass — numeric parity with ATen across register/radix K/shape ranges, deterministic-mode tie handling, `out=` variants, compile-cache reuse, and fallback for unsupported dtype/shape/flags.

#### Performance

End-to-end `torch.topk` latency, FlyDSL vs ATen, measured with CUDA events (20 warmup + 100 timed iters); the ATen baseline is taken under `pn.flydsl.disabled()`:

```python
def bench(fn, iters=100, warmup=20):
    for _ in range(warmup):
        fn()
    torch.cuda.synchronize()
    s = torch.cuda.Event(enable_timing=True)
    e = torch.cuda.Event(enable_timing=True)
    s.record()
    for _ in range(iters):
        fn()
    e.record()
    torch.cuda.synchronize()
    return s.elapsed_time(e) / iters  # ms / call

x = torch.randn(M, N, device="cuda", dtype=torch.float32)
with pn.flydsl.disabled():                        # ATen baseline
    aten_ms = bench(lambda: torch.topk(x, k, dim=-1))
fly_ms = bench(lambda: torch.topk(x, k, dim=-1))  # FlyDSL override
speedup = aten_ms / fly_ms
```

GPU: AMD 256-CU (MI300-class), fp32. Speedups: **register 1.4x–12.0x**, **radix 1.2x–2.8x**; all results consistent with ATen. Below-gate shapes fall back to ATen (~1.0x, no regression).

**Register kernel:**

| M | N | k | ATen (µs) | FlyDSL (µs) | speedup |
|------:|-----:|---:|----------:|------------:|--------:|
| 256 | 1024 | 8 | 34.2 | 18.4 | 1.86x |
| 256 | 8192 | 16 | 57.5 | 37.8 | 1.52x |
| 4096 | 1024 | 8 | 73.0 | 18.3 | 3.99x |
| 4096 | 2048 | 2 | 103.0 | 18.3 | 5.62x |
| 4096 | 4096 | 8 | 147.6 | 42.6 | 3.47x |
| 4096 | 8192 | 16 | 240.0 | 172.4 | 1.39x |
| 16384 | 1024 | 2 | 224.5 | 18.7 | **11.98x** |
| 16384 | 1024 | 8 | 225.3 | 37.6 | 6.00x |
| 16384 | 4096 | 8 | 539.1 | 140.9 | 3.83x |
| 16384 | 8192 | 2 | 1070.9 | 582.2 | 1.84x |

**Radix-select kernel:**

| M | N | k | ATen (µs) | FlyDSL (µs) | speedup |
|------:|-----:|-----:|----------:|------------:|--------:|
| 256 | 16384 | 64 | 80.0 | 66.7 | 1.20x |
| 256 | 16384 | 512 | 88.8 | 62.8 | 1.41x |
| 256 | 32768 | 512 | 126.2 | 79.6 | 1.59x |
| 256 | 65536 | 1024 | 210.5 | 115.7 | 1.82x |
| 4096 | 16384 | 64 | 484.5 | 272.0 | 1.78x |
| 4096 | 16384 | 512 | 540.4 | 421.3 | 1.28x |
| 4096 | 32768 | 64 | 1491.3 | 534.1 | **2.79x** |
| 4096 | 32768 | 512 | 1647.1 | 617.2 | 2.67x |
| 2048 | 32768 | 1024 | 874.7 | 616.1 | 1.42x |
| 2048 | 65536 | 1024 | 1204.1 | 886.6 | 1.36x |

Authored with assistance from Claude Code.
