### PR TITLE
Fix wording in contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Pointers to get you started:
 
 Typically, PyTorch has three minor releases a year. Please let us know if you encounter a bug by [filing an issue](https://github.com/pytorch/pytorch/issues).
 
-We appreciate all contributions. If you are planning to contribute back bug-fixes, please do so without any further discussion.
+We appreciate all contributions. If you are planning to contribute bug-fixes, please do so without any further discussion.
 
 If you plan to contribute new features, utility functions, or extensions to the core, please first open an issue and discuss the feature with us.
 Sending a PR without discussion might end up resulting in a rejected PR because we might be taking the core in a different direction than you might be aware of.


### PR DESCRIPTION
Updated the contribution guidelines by changing "contribute back bug-fixes" to "contribute bug fixes" for clearer and more natural wording. No functional changes were made.