### PR TITLE
Skip non-fd shareable_handle in ExpandableSegment cleanup

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -954,7 +954,11 @@ struct ExpandableSegment {
 #endif
       if (h.shareable_handle) {
 #ifndef _WIN32
-        close(std::get<int>(*h.shareable_handle));
+        // shareable_handle also holds CUmemFabricHandle for fabric segments;
+        // std::get_if skips those (no fd to close) instead of throwing.
+        if (auto* fd = std::get_if<int>(&*h.shareable_handle)) {
+          close(*fd);
+        }
 #endif
       }
 #ifdef USE_ROCM


### PR DESCRIPTION
ExpandableSegment::unmapHandles releases each handle's exported shareable handle with close(std::get<int>(*h.shareable_handle)). But shareable_handle is a std::variant that also holds CUmemFabricHandle for fabric segments, so once a fabric segment has been shared (share() caches the exported CUmemFabricHandle), destroying it makes std::get<int> throw std::bad_variant_access from the destructor, which calls std::terminate.

Use std::get_if<int> so only POSIX-fd handles are closed; fabric handles (plain values with nothing to close) are skipped.

Test: inspection-level fix. Reproducing the crash needs a fabric-capable multi-process setup and no such CI job exists. std::get_if<int> returns nullptr for a variant holding CUmemFabricHandle, so close() is skipped instead of throwing.