### PR TITLE
[TEST] Add hw_classification to test_embedding_ops.py and test_dtensor_checkpoint.py

### DIFF
--- a/test/distributed/checkpoint/test_dtensor_checkpoint.py
+++ b/test/distributed/checkpoint/test_dtensor_checkpoint.py
@@ -11,7 +11,8 @@ from torch.distributed.tensor import (
     Shard,
     zeros,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     skip_if_lt_x_gpu,
@@ -69,6 +70,8 @@ class MyTestModule(torch.nn.Module):
 
 
 class DTensorPlanner(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def create_dtensor_model(
         self,
         tensor_to_shard: torch.tensor,
@@ -259,6 +262,11 @@ class DTensorPlanner(DTensorTestBase):
                 self.assertEqual(1, v["extra_state"])
                 self.assertEqual(torch.tensor([0.0]), v["extra_state_tensor"])
 
+
+devices = ("cuda", "hpu", "xpu")
+instantiate_device_type_tests(
+    DTensorPlanner, globals(), only_for=devices, allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_embedding_ops.py
+++ b/test/distributed/tensor/test_embedding_ops.py
@@ -11,7 +11,12 @@ from torch.distributed.tensor import (
     Shard,
 )
 from torch.distributed.tensor.debug import CommDebugMode
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -31,6 +36,8 @@ funcol = torch.ops.c10d_functional
 
 
 class TestEmbeddingOp(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _apply_sharding(self, embedding_mod, shard_dim, device_mesh):
         def shard_embedding_fn(name, module, device_mesh):
             for name, param in module.named_parameters():
@@ -263,6 +270,8 @@ class TestEmbeddingOp(DTensorTestBase):
 TestEmbeddingOpWithLocalTensor = create_local_tensor_test_class(
     TestEmbeddingOp,
 )
+
+instantiate_device_type_tests(TestEmbeddingOp, globals())
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_embedding_ops.py
+++ b/test/distributed/tensor/test_embedding_ops.py
@@ -11,7 +11,11 @@ from torch.distributed.tensor import (
     Shard,
 )
 from torch.distributed.tensor.debug import CommDebugMode
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -31,6 +35,8 @@ funcol = torch.ops.c10d_functional
 
 
 class TestEmbeddingOp(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _apply_sharding(self, embedding_mod, shard_dim, device_mesh):
         def shard_embedding_fn(name, module, device_mesh):
             for name, param in module.named_parameters():


### PR DESCRIPTION
## Summary
Add `hw_classification = HardwareClassification.ACCELERATOR` to `TestEmbeddingOp` in `test/distributed/tensor/test_embedding_ops.py` following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `TestEmbeddingOp`, distributed embedding tests that are backend-agnostic
- `TestEmbeddingOpWithLocalTensor` (dynamically created via `create_local_tensor_test_class`) inherits the attribute automatically
- No class splitting needed, all 5 test methods belong to the same category
- Addressed review feedback: added `instantiate_device_type_tests(TestEmbeddingOp, globals())` (was missing despite ACCELERATOR classification)

---

Combined with #191733 into a single PR covering 2 test files:
- test/distributed/tensor/test_embedding_ops.py
- test/distributed/checkpoint/test_dtensor_checkpoint.py

Each addresses outstanding reviewer feedback on instantiate_device_type_tests usage per the device-agnostic testing initiative.
