### PR TITLE
[Doc] CTCLoss: clarify that log_probs must come from log_softmax

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3119,8 +3119,10 @@ def ctc_loss(
     Args:
         log_probs: :math:`(T, N, C)` or :math:`(T, C)` where `C = number of characters in alphabet including blank`,
             `T = input length`, and `N = batch size`.
-            The logarithmized probabilities of the outputs
-            (e.g. obtained with :func:`torch.nn.functional.log_softmax`).
+            The logarithmized probabilities of the outputs, which must be the
+            result of applying :func:`torch.nn.functional.log_softmax` to
+            unnormalized logits. See :class:`~torch.nn.CTCLoss` for details on
+            gradient correctness requirements.
         targets: :math:`(N, S)` or `(sum(target_lengths))`.
                 May be an empty tensor if all entries in `target_lengths` are zero.
                 In the second form, the targets are assumed to be concatenated.

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -2174,8 +2174,9 @@ class CTCLoss(_Loss):
           where :math:`T = \text{input length}`,
           :math:`N = \text{batch size}`, and
           :math:`C = \text{number of classes (including blank)}`.
-          The logarithmized probabilities of the outputs (e.g. obtained with
-          :func:`torch.nn.functional.log_softmax`).
+          The logarithmized probabilities of the outputs, which must be the
+          result of applying :func:`torch.nn.functional.log_softmax` to
+          unnormalized logits. See the gradient correctness note below.
         - Targets: Tensor of size :math:`(N, S)` or
           :math:`(\operatorname{sum}(\text{target\_lengths}))`,
           where :math:`N = \text{batch size}` and
@@ -2279,6 +2280,15 @@ class CTCLoss(_Loss):
         A. Graves et al.: Connectionist Temporal Classification:
         Labelling Unsegmented Sequence Data with Recurrent Neural Networks:
         https://www.cs.toronto.edu/~graves/icml_2006.pdf
+
+    Note:
+        The backward pass computes gradients with respect to the unnormalized
+        logits that precede :func:`~torch.nn.functional.log_softmax`, not with
+        respect to :attr:`log_probs` directly. For correct gradients,
+        :attr:`log_probs` must be the output of
+        :func:`~torch.nn.functional.log_softmax` and remain part of the autograd
+        graph. Passing other values will produce correct loss but incorrect
+        gradients.
 
     Note:
         In order to use CuDNN, the following must be satisfied: the :attr:`targets` must be


### PR DESCRIPTION
## Summary

The CTCLoss docs currently state that `log_probs` should be log-probabilities "e.g. obtained with `log_softmax`", which makes `log_softmax` sound optional. However, the backward pass computes gradients with respect to the pre-softmax
logits, so `log_softmax` must be part of the autograd graph for gradients to be correct. Without it, the forward loss is correct but the gradients are silently incorrect.

This PR updates the documentation to make this requirement explicit by changing
"e.g." to "must" and adding a note explaining the backward behavior.

Fixes #181534  
Related: #82545, #52241

## Test plan

-  gradcheck passes with log_softmax in the graph, fails without (expected)
- lintrunner clean on both files

cc @svekars @sekyondaMeta @AlannaBurke @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki