### PR TITLE
[dynamo] Add inductor regression test for package reset (fixes #190664)

### DIFF
--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -412,33 +412,11 @@ def add(x, y):
             self.assertEqual(expected, [result1, result2])
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
-    def test_reset_clears_installed_package(self):
-        from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
-
-        ctx = DiskDynamoStore()
-
-        def fn(x):
-            return x.sin() + x.cos()
-
-        package = CompilePackage(fn)
-        compiled_fn = torch._dynamo.optimize(backend="eager", package=package)(fn)
-        compiled_fn(torch.randn(3, 2))
-        for backend_id, backend in package.cached_backends.items():
-            ctx.record_eager_backend(backend_id, backend)
-        ctx.save_package(package, self.path())
-
-        torch._dynamo.reset()
-        package, backends = ctx.load_package(fn, self.path())
-        package.install(backends)
-        self.assertGreater(len(_debug_get_precompile_entries(fn.__code__)), 0)
-
-        torch._dynamo.reset()
-        self.assertEqual(len(_debug_get_precompile_entries(fn.__code__)), 0)
-
-    def test_reset_clears_installed_package_inductor(self):
+    @parametrize("backend", ("eager", "inductor"))
+    def test_reset_clears_installed_package(self, backend):
         # Regression test for https://github.com/pytorch/pytorch/issues/190664.
         # package.install() must register target_code in input_codes so that
-        # torch._dynamo.reset() clears precompile entries for the inductor backend.
+        # torch._dynamo.reset() clears precompile entries on the installed code.
         from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
 
         ctx = DiskDynamoStore()
@@ -447,8 +425,11 @@ def add(x, y):
             return x.sin() + x.cos()
 
         package = CompilePackage(fn)
-        compiled_fn = torch._dynamo.optimize(backend="inductor", package=package)(fn)
+        compiled_fn = torch._dynamo.optimize(backend=backend, package=package)(fn)
         compiled_fn(torch.randn(3, 2))
+        if backend == "eager":
+            for backend_id, bknd in package.cached_backends.items():
+                ctx.record_eager_backend(backend_id, bknd)
         ctx.save_package(package, self.path())
 
         torch._dynamo.reset()

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -435,6 +435,30 @@ def add(x, y):
         torch._dynamo.reset()
         self.assertEqual(len(_debug_get_precompile_entries(fn.__code__)), 0)
 
+    def test_reset_clears_installed_package_inductor(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/190664.
+        # package.install() must register target_code in input_codes so that
+        # torch._dynamo.reset() clears precompile entries for the inductor backend.
+        from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
+
+        ctx = DiskDynamoStore()
+
+        def fn(x):
+            return x.sin() + x.cos()
+
+        package = CompilePackage(fn)
+        compiled_fn = torch._dynamo.optimize(backend="inductor", package=package)(fn)
+        compiled_fn(torch.randn(3, 2))
+        ctx.save_package(package, self.path())
+
+        torch._dynamo.reset()
+        package, backends = ctx.load_package(fn, self.path())
+        package.install(backends)
+        self.assertGreater(len(_debug_get_precompile_entries(fn.__code__)), 0)
+
+        torch._dynamo.reset()
+        self.assertEqual(len(_debug_get_precompile_entries(fn.__code__)), 0)
+
     @parametrize("device", ("cpu", "cuda", "xpu"))
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_serialize(self, device):


### PR DESCRIPTION
## Summary

Adds `test_reset_clears_installed_package_inductor` as a targeted regression test for the inductor backend, covering the bug tracked in #190664.

The root-cause fix (`input_codes.add(target_code)` in `package.install()`) landed in #189206. The existing `test_reset_clears_installed_package` only covered the eager backend; this PR adds the same coverage for inductor.

The test verifies the full install → reset → clear cycle: after `package.install(backends)` precompile entries are present on `fn.__code__`, and after `torch._dynamo.reset()` they are gone — the invariant the bug violated.

Fixes #190664

## Test plan

- [ ] `python test/dynamo/test_package.py TestPackage.test_reset_clears_installed_package_inductor`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98