### PR TITLE
[Testcase Refactoring]Make test_tensor_ops.py device-agnostic

### DIFF
--- a/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
@@ -26,7 +26,7 @@ backend = torch.distributed.get_default_backend_for_device(device_type)
 class TestTensorOps(ShardedTensorTestBase):
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend()
     def test_deep_copy(self):
         spec = ChunkShardingSpec(
             dim=0,
@@ -45,7 +45,7 @@ class TestTensorOps(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend()
     def test_inplace_copy(self):
         spec = ChunkShardingSpec(
             dim=0,
@@ -72,7 +72,7 @@ class TestTensorOps(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend()
     def test_clone(self):
         spec = ChunkShardingSpec(
             dim=0,
@@ -91,7 +91,7 @@ class TestTensorOps(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend()
     def test_detach(self):
         spec = ChunkShardingSpec(
             dim=0,
@@ -116,7 +116,7 @@ class TestTensorOps(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend()
     def test_set_requires_grad(self):
         spec = ChunkShardingSpec(
             dim=0,


### PR DESCRIPTION
### **Summary**
This PR makes test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py more device-agnostic by removing hard-coded backend types from @requires_accelerator_dist_backend() decorator.

This is a step toward making sharded tensor distributed tests device-agnostic for out-of-tree backends.

### **Changes**
Removed ["nccl", "xccl"] argument from all @requires_accelerator_dist_backend() decorators in test_tensor_ops.py.
Affects 5 test methods: test_deep_copy, test_inplace_copy, test_clone, test_detach, test_set_requires_grad.
**Motivation**
Hard-coding ["nccl", "xccl"] restricts tests to specific backends. Removing this argument allows the decorator to use the default backend detection based on torch.accelerator.current_accelerator(), making tests compatible with any accelerator-supported backend (e.g., PrivateUse1-based out-of-tree backends).

### **Test Plan**
CI: python test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
Verified locally on CPU and GPU.
### **Notes**
Additional sharded tensor tests will be migrated in follow-up PRs.

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian