### PR TITLE
[Doc] Clarify torch.distributed.checkpoint.load() reads metadata via pickle; add untrusted-source warning

### DIFF
--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -88,8 +88,17 @@ def load(
         All tensors in ``state_dict`` must be allocated on their
         destination device *prior to* calling this function.
 
-        All non-tensor data is loaded using `torch.load()` and modified in place
-        on state_dict.
+        Non-tensor payloads are loaded using ``torch.load()`` and modified in
+        place on ``state_dict``. Note, however, that the checkpoint's
+        ``.metadata`` sidecar is read with a plain ``pickle.load()`` (in
+        ``FileSystemReader.read_metadata``), so the ``weights_only`` safeguard
+        of ``torch.load`` does **not** apply to the metadata read.
+
+    .. warning::
+        Loading a checkpoint deserializes data with ``pickle`` (the
+        ``.metadata`` sidecar, and by default the non-tensor payloads), which
+        can execute arbitrary code. Only load checkpoints produced by a source
+        you trust -- the same caveat :func:`torch.load` documents.
 
     .. warning::
         Users must call `load_state_dict` on the root module to ensure load


### PR DESCRIPTION
### Summary

`torch.distributed.checkpoint.load()`'s docstring states that "All non-tensor data is loaded using `torch.load()`". That is inaccurate for the checkpoint **metadata**: `FileSystemReader.read_metadata` reads the `.metadata` sidecar with a plain `pickle.load` (`torch/distributed/checkpoint/filesystem.py`), so `torch.load`'s `weights_only` safeguard does **not** apply to that read. DCP is recommended over `torch.save`/`torch.load` for sharded checkpoints, yet — unlike `torch.load` — its public entry point carries no untrusted-source warning.

### Change (docs-only, public `load()` entry point)
- Correct the wording so it no longer implies `weights_only` / `torch.load` covers the metadata read.
- Add a `.. warning::` about loading checkpoints only from trusted sources, consistent with the caveat `torch.load` already documents.

No behavior change.

### Context
Addresses the hardening/documentation request in #189308 (first raised privately, closed under SECURITY.md's "models are programs" policy, then reopened as a docs/API-hardening ask). Scoped intentionally to the public `load()` docstring; happy to extend the wording or add a short note at the `read_metadata` sink if reviewers prefer.

### AI assistance
Drafted with AI assistance; I verified the cited code paths (`read_metadata`'s `pickle.load` and the `load()` docstring) against current `main` and reviewed the RST myself.

## AI Disclosure

AI-assisted debugging/initial draft/testing with human review of the diff and test scope (per the contribution workflow).