### PR TITLE
[distributed] Enable C++ stack traces for DETAIL debug level

### DIFF
--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -1209,9 +1209,9 @@ For fine-grained control of the debug level during runtime the functions {func}`
 {func}`torch.distributed.get_debug_level` can also be used.
 :::
 
-In addition, `TORCH_DISTRIBUTED_DEBUG=DETAIL` can be used in conjunction with `TORCH_SHOW_CPP_STACKTRACES=1` to log the entire callstack when a collective desynchronization is detected. These
-collective desynchronization checks will work for all applications that use `c10d` collective calls backed by process groups created with the
-{func}`torch.distributed.init_process_group` and {func}`torch.distributed.new_group` APIs.
+In addition, `TORCH_DISTRIBUTED_DEBUG=DETAIL` enables C++ callstacks for errors, including when a collective desynchronization is detected. Set
+`TORCH_SHOW_CPP_STACKTRACES=0` to explicitly disable these callstacks. Collective desynchronization checks work for all applications that use `c10d`
+collective calls backed by process groups created with the {func}`torch.distributed.init_process_group` and {func}`torch.distributed.new_group` APIs.
 
 
 ### torch.distributed.debug HTTP Server

--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -1714,6 +1714,61 @@ class AbstractLargeCommTest:
         self.assertEqual(output_tensor_list, expected)
 
 
+class CppStacktraceTest(TestCase):
+    @parametrize(
+        "distributed_debug,show_cpp_stacktraces,expect_backtrace",
+        [
+            ("DETAIL", None, True),
+            ("detail", None, True),
+            ("INFO", None, False),
+            ("DETAIL", "0", False),
+            ("OFF", "1", True),
+        ],
+        name_fn=lambda distributed_debug, show_cpp_stacktraces, _: (
+            f"{distributed_debug}_show_{show_cpp_stacktraces or 'unset'}"
+        ),
+    )
+    def test_cpp_stacktraces_with_distributed_debug(
+        self,
+        distributed_debug,
+        show_cpp_stacktraces,
+        expect_backtrace,
+    ):
+        script = """
+import torch
+
+try:
+    torch.empty(-1)
+except RuntimeError as error:
+    print(error)
+"""
+        env = os.environ.copy()
+        env.pop("TORCH_DISTRIBUTED_DEBUG", None)
+        env.pop("TORCH_SHOW_CPP_STACKTRACES", None)
+        env["TORCH_DISABLE_ADDR2LINE"] = "1"
+        env["TORCH_DISTRIBUTED_DEBUG"] = distributed_debug
+        if show_cpp_stacktraces is not None:
+            env["TORCH_SHOW_CPP_STACKTRACES"] = show_cpp_stacktraces
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+            timeout=60,
+        )
+
+        self.assertIn("negative dimension", result.stdout)
+        self.assertEqual(
+            "Exception raised from" in result.stdout,
+            expect_backtrace,
+        )
+
+
+instantiate_parametrized_tests(CppStacktraceTest)
+
+
 class CommTest(AbstractCommTest, MultiProcessTestCase):
     def setUp(self):
         super().setUp()

--- a/torch/csrc/utils/cpp_stacktraces.cpp
+++ b/torch/csrc/utils/cpp_stacktraces.cpp
@@ -3,10 +3,29 @@
 #include <c10/util/Exception.h>
 #include <c10/util/env.h>
 
+#include <algorithm>
+#include <cctype>
+
 namespace torch {
 namespace {
 bool compute_cpp_stack_traces_enabled() {
-  return c10::utils::check_env("TORCH_SHOW_CPP_STACKTRACES") == true;
+  const auto show_cpp_stacktraces =
+      c10::utils::check_env("TORCH_SHOW_CPP_STACKTRACES");
+  if (show_cpp_stacktraces.has_value()) {
+    return show_cpp_stacktraces.value();
+  }
+
+  auto distributed_debug = c10::utils::get_env("TORCH_DISTRIBUTED_DEBUG");
+  if (!distributed_debug.has_value()) {
+    return false;
+  }
+
+  std::transform(
+      distributed_debug->begin(),
+      distributed_debug->end(),
+      distributed_debug->begin(),
+      [](unsigned char c) { return toupper(c); });
+  return distributed_debug.value() == "DETAIL";
 }
 
 bool compute_disable_addr2line() {


### PR DESCRIPTION
Honor TORCH_DISTRIBUTED_DEBUG=DETAIL when TORCH_SHOW_CPP_STACKTRACES is unset, while preserving the explicit stack-trace override. Add subprocess coverage for precedence and case handling, and document the behavior.