### PR TITLE
Enable TORCH_SHOW_CPP_STACKTRACES automatically under TORCH_DISTRIBUT…

### DIFF
--- a/torch/csrc/distributed/c10d/debug.cpp
+++ b/torch/csrc/distributed/c10d/debug.cpp
@@ -6,6 +6,7 @@
 
 #include <c10/util/env.h>
 #include <torch/csrc/distributed/c10d/debug.h>
+#include <torch/csrc/utils/cpp_stacktraces.h>
 
 #include <algorithm>
 #include <cctype>
@@ -61,6 +62,14 @@ DebugLevel g_debug_level = DebugLevel::Off;
 
 void setDebugLevel(DebugLevel level) {
   g_debug_level = level;
+
+  // When DETAIL is requested, also turn on C++ stack traces -- otherwise
+  // errors raised from collective ops under DETAIL debugging lack the
+  // C++-side context needed to pin down where in the backend they came
+  // from. See https://github.com/pytorch/pytorch/issues/78842.
+  if (level == DebugLevel::Detail) {
+    torch::set_cpp_stacktraces_enabled(true);
+  }
 }
 
 void setDebugLevelFromEnvironment() {

--- a/torch/csrc/utils/cpp_stacktraces.cpp
+++ b/torch/csrc/utils/cpp_stacktraces.cpp
@@ -12,11 +12,24 @@ bool compute_cpp_stack_traces_enabled() {
 bool compute_disable_addr2line() {
   return c10::utils::check_env("TORCH_DISABLE_ADDR2LINE") == true;
 }
+
+// Owns the single cached flag so both the getter and setter operate on the
+// same storage. get_cpp_stacktraces_enabled() previously computed this via
+// its own local static, which meant there was no way to override it later
+// (e.g. from c10d's debug level) -- returning by value gave callers a copy,
+// not the underlying storage.
+bool& cpp_stacktraces_enabled_ref() {
+  static bool enabled = compute_cpp_stack_traces_enabled();
+  return enabled;
+}
 } // namespace
 
 bool get_cpp_stacktraces_enabled() {
-  static bool enabled = compute_cpp_stack_traces_enabled();
-  return enabled;
+  return cpp_stacktraces_enabled_ref();
+}
+
+void set_cpp_stacktraces_enabled(bool enabled) {
+  cpp_stacktraces_enabled_ref() = enabled;
 }
 
 static torch::unwind::Mode compute_symbolize_mode() {

--- a/torch/csrc/utils/cpp_stacktraces.h
+++ b/torch/csrc/utils/cpp_stacktraces.h
@@ -5,5 +5,9 @@
 
 namespace torch {
 TORCH_API bool get_cpp_stacktraces_enabled();
+// Overrides the cached cpp-stacktraces-enabled value. Used so that other
+// subsystems (e.g. c10d debug level) can force stacktraces on even after
+// the env-var-derived value has already been cached.
+TORCH_API void set_cpp_stacktraces_enabled(bool enabled);
 TORCH_API torch::unwind::Mode get_symbolize_mode();
 } // namespace torch


### PR DESCRIPTION
Errors raised from collective ops under DETAIL-level distributed debugging currently
lack C++-side stack context, making it hard to pin down where in the backend a
failure originated. This adds a set_cpp_stacktraces_enabled() override (the existing
getter cached its value in a function-local static with no way to override it) and
calls it from setDebugLevel() when the level is Detail.

## How was this tested?

Verified the core getter/setter logic in isolation (the reference-returning
`cpp_stacktraces_enabled_ref()` pattern) with a standalone reproduction outside
the full build — confirms `set_cpp_stacktraces_enabled(true)` persists across
subsequent `get_cpp_stacktraces_enabled()` calls. Have not yet built PyTorch
end-to-end to confirm this compiles cleanly against the real headers/macros or
verify the Python-level behavior (`torch.distributed.debug.get_debug_level()` +
`torch._C._get_cpp_stacktraces_enabled()`) — will do that next and update this
PR, or welcome a reviewer doing a CI build check first.

Fixes #78842