### PR TITLE
[Test][XPU] Enable `test_bits.py` and `test_floatx.py` quantization tests for XPU and remove XPU skip from `test_memory_profiler.py`

### DIFF
--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -1499,10 +1499,6 @@ class TestMemoryProfilerE2EDeviceType(TestCase):
 class TestMemoryProfilerTimeline(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @skipXPUIf(
-        True,
-        "The XPU Profiler will not cover this case for now. Will support it in next period.",
-    )
     def test_memory_timeline_no_id(self, device) -> None:
         # On CPU the default behavior is to simply forward to malloc. That
         # means that when we free `x` the allocator doesn't actually know how

--- a/test/quantization/core/experimental/test_bits.py
+++ b/test/quantization/core/experimental/test_bits.py
@@ -86,7 +86,7 @@ class TestBits(TestCase):
         s = s + 1 - 1
         self.assertTrue(torch.allclose(s, torch.zeros(20, dtype=torch.bits16)))
 
-instantiate_device_type_tests(TestBits, globals())
+instantiate_device_type_tests(TestBits, globals(), allow_xpu=True)
 
 
 if __name__ == '__main__':

--- a/test/quantization/core/experimental/test_bits.py
+++ b/test/quantization/core/experimental/test_bits.py
@@ -3,7 +3,7 @@
 import torch
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, skipIfXpu, TestCase
 from torch.utils._mode_utils import no_dispatch
 from torch.utils._pytree import tree_map
 
@@ -52,6 +52,7 @@ class Int16Tensor(torch.Tensor):
 
 
 class TestBits(TestCase):
+    @skipIfXpu(msg="https://github.com/intel/torch-xpu-ops/issues/4445")
     def test_types(self, device):
         bits_types = [torch.bits1x8, torch.bits2x4, torch.bits4x2, torch.bits8, torch.bits16]
         for bits_type in bits_types:

--- a/test/quantization/core/experimental/test_bits.py
+++ b/test/quantization/core/experimental/test_bits.py
@@ -3,7 +3,7 @@
 import torch
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
-from torch.testing._internal.common_utils import run_tests, skipIfXpu, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.utils._mode_utils import no_dispatch
 from torch.utils._pytree import tree_map
 
@@ -52,7 +52,6 @@ class Int16Tensor(torch.Tensor):
 
 
 class TestBits(TestCase):
-    @skipIfXpu(msg="https://github.com/intel/torch-xpu-ops/issues/4445")
     def test_types(self, device):
         bits_types = [torch.bits1x8, torch.bits2x4, torch.bits4x2, torch.bits8, torch.bits16]
         for bits_type in bits_types:

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -442,8 +442,8 @@ class TestFloat4Dtype(TestCase):
             )
 
 
-instantiate_device_type_tests(TestFloat8Dtype, globals())
-instantiate_device_type_tests(TestFloat4Dtype, globals())
+instantiate_device_type_tests(TestFloat8Dtype, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestFloat4Dtype, globals(), allow_xpu=True)
 
 
 class TestFloat8DtypeCPUOnly(TestCase):

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -15,7 +15,6 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     parametrize,
     run_tests,
-    skipIfXpu,
     subtest,
     TemporaryFileName,
     TestCase,
@@ -409,7 +408,6 @@ class TestFloat8Dtype(TestCase):
 
 class TestFloat4Dtype(TestCase):
     # TODO(#146647): make the testing generic for shell dtypes
-    @skipIfXpu(msg="https://github.com/intel/torch-xpu-ops/issues/4445")
     def test_float4_e2m1fn_x2(self, device):
         # can create a tensor of dtype float4
         x1 = torch.empty(4096, 4096, device=device, dtype=torch.float4_e2m1fn_x2)

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -15,6 +15,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     parametrize,
     run_tests,
+    skipIfXpu,
     subtest,
     TemporaryFileName,
     TestCase,
@@ -408,6 +409,7 @@ class TestFloat8Dtype(TestCase):
 
 class TestFloat4Dtype(TestCase):
     # TODO(#146647): make the testing generic for shell dtypes
+    @skipIfXpu(msg="https://github.com/intel/torch-xpu-ops/issues/4445")
     def test_float4_e2m1fn_x2(self, device):
         # can create a tensor of dtype float4
         x1 = torch.empty(4096, 4096, device=device, dtype=torch.float4_e2m1fn_x2)


### PR DESCRIPTION
This PR enables test files to be launched directly with XPU devices.

### Changes

- test/profiler/test_memory_profiler.py - remove unnecessary skip for XPU as test case has been fixed and is passing
- test/quantization/core/experimental/test_bits.py - add `allow_xpu=True` to already generic test class
- test/quantization/core/experimental/test_floatx.py - add `allow_xpu=True` to already generic test class