### PR TITLE
[TEST] Add hw_classification to test_math_ops.py

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -27,7 +27,11 @@ from torch.distributed.tensor.parallel import (
     SequenceParallel,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests, skipIfRocm
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfRocm,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -41,6 +45,8 @@ funcol = torch.ops.c10d_functional
 
 
 class DistMathOpsTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _check_module(self, m1, m2, check_grad=False):
         named_parameters = dict(m1.named_parameters())
         for name, param_m2 in m2.named_parameters():


### PR DESCRIPTION
## [TEST] Add hw_classification to test_math_ops.py

### Summary

Adds `hw_classification = HardwareClassification.ACCELERATOR` to `DistMathOpsTest` in `test/distributed/tensor/test_math_ops.py`, following the community test refactoring initiative.

### Changes

**Classification**
- `DistMathOpsTest`: `ACCELERATOR` — tests distributed tensor math operations across any available accelerator via `DTensorTestBase.device_type` (auto-selects CPU/CUDA/XPU/HPU at runtime)
- `DistMathOpsTestWithLocalTensor`: inherits classification automatically via `create_local_tensor_test_class`

**Why no `instantiate_device_type_tests`?**
- `DTensorTestBase` (via `MultiProcessTestCase`) has its own device-type mechanism that auto-selects the accelerator at runtime
- This is architecturally incompatible with `instantiate_device_type_tests` which requires `DeviceTypeTestBase`
- No class splitting needed — all 53 tests are already device-agnostic using `self.device_type`

**Why ACCELERATOR?**
- No `@onlyCUDA` / `@onlyXPU` / `@onlyMPS` decorators
- No hardcoded device strings (`"cuda"`, `"xpu"`, `"mps"`)
- ~70 uses of `self.device_type` throughout
- 10 tests with `@skip_unless_torch_gpu` / `@skip_if_lt_x_gpu(4)` are feature gates (known CPU limitations), not device locks
- Conditional `self.device_type == "cuda"` checks are feature gates (e.g., RMSNorm availability), not hard locks

### Test Plan

```
# All tests
python -m pytest test/distributed/tensor/test_math_ops.py -v
# 112 tests passed

# By classification
python test/distributed/tensor/test_math_ops.py --hw-classification ACCELERATOR -v
```

Co-authored-by: AI assistant

cc: @mansiag05 @RiyaP2508