### PR TITLE
Device-generalize dynamo tests to run on accelerator backends

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -554,7 +554,7 @@ class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
         def fn(x):
             return Foo.apply(x)
 
-        x = torch.tensor([-2.0, 1.0, 3.0], requires_grad=True)
+        x = torch.tensor([-2.0, 1.0, 3.0], device=device_type, requires_grad=True)
         res = fn(x)
         self.assertEqual(res, Foo.apply(x))
         res.sum().backward()
@@ -581,7 +581,7 @@ class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
         def fn(x):
             return Foo.apply(x)
 
-        x = torch.tensor([1.0, 3.0], requires_grad=True)
+        x = torch.tensor([1.0, 3.0], device=device_type, requires_grad=True)
         res = fn(x)
         self.assertEqual(res, Foo.apply(x))
         res.sum().backward()
@@ -1012,8 +1012,8 @@ class GraphModule(torch.nn.Module):
             b = torch.rand(1, requires_grad=True)
             MyFn.apply(a)
 
-            a = torch.ones(2, requires_grad=True)
-            b = torch.ones(2, requires_grad=True)
+            a = torch.ones(2, device=device_type, requires_grad=True)
+            b = torch.ones(2, device=device_type, requires_grad=True)
             c = MyAdder.apply(a.clone(), b)
             c.sum().backward()
 
@@ -1559,7 +1559,7 @@ class GraphModule(torch.nn.Module):
             x, _ = MyCube.apply(x)
             return x
 
-        inp = torch.ones(2, requires_grad=True)
+        inp = torch.ones(2, device=device_type, requires_grad=True)
         out = fn(inp)
         out.sum().backward()
         self.assertEqual(out, inp**3)
@@ -2286,7 +2286,7 @@ class GraphModule(torch.nn.Module):
         def fn(x):
             return Foo.apply(x)
 
-        x = torch.randn(8, device="cpu", requires_grad=True)
+        x = torch.randn(8, device=device_type, requires_grad=True)
 
         # Eager reference
         x_ref = x.detach().clone().requires_grad_(True)
@@ -2914,7 +2914,7 @@ class AutogradFunctionFunctorchTests(torch._dynamo.test_case.TestCase):
         def loss_fn(x):
             return compiled_fn(x).sum()
 
-        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        x = torch.tensor([1.0, 2.0], device=device_type, requires_grad=True)
         result = torch.func.grad(loss_fn)(x)
         self.assertEqual(result, torch.tensor([2.0, 2.0]))
 

--- a/test/dynamo/test_backward_higher_order_ops.py
+++ b/test/dynamo/test_backward_higher_order_ops.py
@@ -15,6 +15,11 @@ from torch._dynamo.testing import normalize_gm
 from torch.fx.experimental.proxy_tensor import make_fx
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 def _multiply(x):
     return x * x
 
@@ -40,8 +45,8 @@ class BackwardHigherOrderOpTests(torch._dynamo.test_case.TestCase):
     def test_invoke_in_pt2(self):
         for backend in ["eager", "aot_eager", "inductor"]:
             torch._dynamo.reset()
-            x = torch.tensor([0.5, 0.5], requires_grad=True)
-            y = torch.tensor([0.5, 0.5], requires_grad=True)
+            x = torch.tensor([0.5, 0.5], device=device_type, requires_grad=True)
+            y = torch.tensor([0.5, 0.5], device=device_type, requires_grad=True)
 
             def fn(x, y):
                 x.register_hook(_multiply_invoke)
@@ -49,7 +54,7 @@ class BackwardHigherOrderOpTests(torch._dynamo.test_case.TestCase):
 
             fn = torch.compile(fn, backend=backend)
             out = fn(x, y)
-            grad_out = torch.tensor([2.0, 2.0])
+            grad_out = torch.tensor([2.0, 2.0], device=device_type)
             out.backward(grad_out)
             self.assertEqual(x.grad, grad_out * y)
 
@@ -217,8 +222,8 @@ class GraphModule(torch.nn.Module):
 
         for backend in ["inductor"]:
             torch._dynamo.reset()
-            x = torch.tensor([0.5, 0.5], requires_grad=True)
-            y = torch.tensor([0.5, 0.5], requires_grad=True)
+            x = torch.tensor([0.5, 0.5], device=device_type, requires_grad=True)
+            y = torch.tensor([0.5, 0.5], device=device_type, requires_grad=True)
 
             class MyObj:
                 def __init__(self) -> None:
@@ -234,7 +239,7 @@ class GraphModule(torch.nn.Module):
 
             fn = torch.compile(fn, backend=backend, fullgraph=True)
             out = fn(x, y)
-            grad_out = torch.tensor([2.0, 2.0])
+            grad_out = torch.tensor([2.0, 2.0], device=device_type)
             with compiled_autograd._enable(compiler_fn):
                 out.backward(grad_out)
             actual = normalize_gm(graph.print_readable(False))
@@ -297,8 +302,8 @@ class GraphModule(torch.nn.Module):
 
         for backend in ["eager", "aot_eager", "inductor"]:
             torch._dynamo.reset()
-            x = torch.tensor([0.5, 0.5], requires_grad=True)
-            y = torch.tensor([0.5, 0.5], requires_grad=True)
+            x = torch.tensor([0.5, 0.5], device=device_type, requires_grad=True)
+            y = torch.tensor([0.5, 0.5], device=device_type, requires_grad=True)
 
             def fn(x, y):
                 x.register_hook(_graph_break_invoke)
@@ -306,7 +311,7 @@ class GraphModule(torch.nn.Module):
 
             fn = torch.compile(fn, backend=backend, fullgraph=True)
             out = fn(x, y)
-            grad_out = torch.tensor([2.0, 2.0])
+            grad_out = torch.tensor([2.0, 2.0], device=device_type)
             with self.assertRaisesRegex(
                 torch._dynamo.exc.Unsupported,
                 "print",

--- a/test/dynamo/test_bytecode_debugger.py
+++ b/test/dynamo/test_bytecode_debugger.py
@@ -16,6 +16,11 @@ from torch._dynamo.bytecode_debugger import debug
 from torch._dynamo.test_case import run_tests, TestCase
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 class InteractiveDebugSession:
     """Allows reactive interaction with the bytecode debugger in tests.
 
@@ -148,7 +153,7 @@ class TestBytecodeDebugger(TestCase):
         def fn(x):
             return x + 1
 
-        input_tensor = torch.tensor([1.0, 2.0, 3.0])
+        input_tensor = torch.tensor([1.0, 2.0, 3.0], device=device_type)
         expected_result = input_tensor + 1
 
         def test_logic(sess, initial):

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -4176,7 +4176,7 @@ class GraphModule(torch.nn.Module):
             y = ctx.__enter__()
             return x + y, ctx
 
-        x = torch.tensor([1.0])
+        x = torch.tensor([1.0], device=device_type)
         expected = fn(x)
         result = torch.compile(fn, backend="eager", fullgraph=False)(x)
         self.assertEqual(expected[0], result[0])

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -452,7 +452,7 @@ partial_fn = functools.partial(fn, scale=2)
 
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         i1, i2, a = fn(torch.ones(3, 3))
-        it1, it2, b = opt_fn(torch.ones(3, 3))
+        it1, it2, b = opt_fn(torch.ones(3, 3, device=device_type))
         self.assertEqual(next(i1), next(it1))
         self.assertEqual(next(i2), next(it2))
         self.assertEqual(a, b)
@@ -3117,7 +3117,7 @@ partial_fn = functools.partial(fn, scale=2)
                 list(zip(range(10, 12), filter(lambda y: y > 10, itertools.count()))),
             )
 
-        inputs = torch.ones(1)
+        inputs = torch.ones(1, device=device_type)
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertTupleEqual(opt_fn(inputs), fn(inputs))
 
@@ -3742,8 +3742,8 @@ class GraphModule(torch.nn.Module):
             res += inner()
             return res
 
-        input1 = torch.randn(1)
-        input2 = torch.randn(1)
+        input1 = torch.randn(1, device=device_type)
+        input2 = torch.randn(1, device=device_type)
 
         self.assertTrue(same(program(input1, input2), input1 + input1))
 
@@ -4512,7 +4512,7 @@ class GraphModule(torch.nn.Module):
             return x
 
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
-        self.assertEqual(fn(torch.ones(3, 3)), opt_fn(torch.ones(3, 3)))
+        self.assertEqual(fn(torch.ones(3, 3)), opt_fn(torch.ones(3, 3, device=device_type)))
 
     @unittest.skip("https://github.com/pytorch/pytorch/pull/146527 exposed a bug")
     def test_enumerate_reconstruct(self):

--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -19,6 +19,11 @@ from torch.testing._internal.common_utils import (
 )
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 @torch._dynamo.config.patch(trace_autograd_ops=True)
 @skipIfTorchDynamo()
 class TestForwardLossBackward(TestCase):
@@ -341,8 +346,8 @@ class <lambda>(torch.nn.Module):
             # Return loss - with retain_graph=True, loss can still be backwarded
             return loss, grad_weight
 
-        x = torch.randn(2, 4, requires_grad=True)
-        weight = torch.randn(4, 3, requires_grad=True)
+        x = torch.randn(2, 4, device=device_type, requires_grad=True)
+        weight = torch.randn(4, 3, device=device_type, requires_grad=True)
 
         x_eager = x.clone().detach().requires_grad_(True)
         weight_eager = weight.clone().detach().requires_grad_(True)
@@ -422,9 +427,9 @@ autograd.grad with external grad_fn
 
     @skipIfCrossRef
     def test_autograd_grad_manual_update_matches_eager(self):
-        mod_eager = torch.nn.Linear(4, 4)
+        mod_eager = torch.nn.Linear(4, 4).to(device_type)
         mod_compiled = copy.deepcopy(mod_eager)
-        x = torch.randn(2, 4)
+        x = torch.randn(2, 4, device=device_type)
 
         def step_fn(mod):
             res = mod(x)
@@ -1259,8 +1264,8 @@ backward() with in-graph created tensor
         In eager mode, backward([x, x]) doesn't double-accumulate gradients.
         Our dynamo rewrite must match this behavior by deduplicating inputs.
         """
-        mod = torch.nn.Linear(4, 4)
-        x = torch.randn(2, 4)
+        mod = torch.nn.Linear(4, 4).to(device_type)
+        x = torch.randn(2, 4, device=device_type)
 
         def fn(x):
             res = mod(x)

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -3624,7 +3624,7 @@ class HigherOrderOpVmapGuardTests(LoggingTestCase):
         def fn(x):
             return torch.vmap(lambda x: x.sin())(x)
 
-        x = torch.randn(3, 3, 4, 5)
+        x = torch.randn(3, 3, 4, 5, device=device_type)
         y = fn(x)
         # sanity check
         self.assertEqual(len(records), 0)
@@ -6167,7 +6167,7 @@ class GraphModule(torch.nn.Module):
         def f(x):
             return x**2
 
-        x = torch.randn(2, requires_grad=True)
+        x = torch.randn(2, device=device_type, requires_grad=True)
         y = f(x)
 
         def get_vjp(v):
@@ -6185,7 +6185,7 @@ class GraphModule(torch.nn.Module):
         def f(x):
             return x**2
 
-        x = torch.randn(2, requires_grad=True)
+        x = torch.randn(2, device=device_type, requires_grad=True)
         y = f(x)
 
         def get_vjp(v):
@@ -6203,7 +6203,7 @@ class GraphModule(torch.nn.Module):
         def f(x):
             return x**2
 
-        x = torch.randn(2, requires_grad=True)
+        x = torch.randn(2, device=device_type, requires_grad=True)
         y = f(x)
 
         def get_vjp(v):

--- a/test/dynamo/test_hooks.py
+++ b/test/dynamo/test_hooks.py
@@ -19,6 +19,11 @@ from torch.testing._internal.common_utils import skipIfRocm
 from torch.utils.hooks import RemovableHandle
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 def compiler_fn(gm):
     return torch.compile(gm, backend="inductor", fullgraph=True, dynamic=True)
 
@@ -313,7 +318,7 @@ class HooksTests(torch._dynamo.test_case.TestCase):
             y.register_hook(lambda grad: grad + 1)
             return y.sum()
 
-        x_compiled = torch.randn(4, requires_grad=True)
+        x_compiled = torch.randn(4, device=device_type, requires_grad=True)
         compiled_fn = torch.compile(fn, backend="eager", fullgraph=True)
         result_compiled = compiled_fn(x_compiled)
         result_compiled.backward()
@@ -339,13 +344,13 @@ class HooksTests(torch._dynamo.test_case.TestCase):
 
         glb_list.clear()
         glb_dict.clear()
-        x_eager = torch.ones(4, requires_grad=True)
+        x_eager = torch.ones(4, device=device_type, requires_grad=True)
         result_eager = fn(x_eager)
         result_eager.backward()
 
         glb_list.clear()
         glb_dict.clear()
-        x_compiled = torch.ones(4, requires_grad=True)
+        x_compiled = torch.ones(4, device=device_type, requires_grad=True)
         compiled_fn = torch.compile(fn, backend="eager", fullgraph=True)
         result_compiled = compiled_fn(x_compiled)
         result_compiled.backward()
@@ -384,11 +389,11 @@ def forward(self, L_x_ : torch.Tensor):
             w = y * 3  # Use y AFTER hook
             return (z + w).sum()
 
-        x_eager = torch.ones(2, requires_grad=True)
+        x_eager = torch.ones(2, device=device_type, requires_grad=True)
         result_eager = fn(x_eager)
         result_eager.backward()
 
-        x_compiled = torch.ones(2, requires_grad=True)
+        x_compiled = torch.ones(2, device=device_type, requires_grad=True)
         compiled_fn = torch.compile(fn, backend="eager", fullgraph=True)
         result_compiled = compiled_fn(x_compiled)
         result_compiled.backward()
@@ -426,11 +431,11 @@ def forward(self, L_x_ : torch.Tensor):
             y.register_hook(lambda g: None)
             return y.sum()
 
-        x_eager = torch.ones(4, requires_grad=True)
+        x_eager = torch.ones(4, device=device_type, requires_grad=True)
         result_eager = fn(x_eager)
         result_eager.backward()
 
-        x_compiled = torch.ones(4, requires_grad=True)
+        x_compiled = torch.ones(4, device=device_type, requires_grad=True)
         compiled_fn = torch.compile(fn, backend="eager", fullgraph=True)
         result_compiled = compiled_fn(x_compiled)
         result_compiled.backward()
@@ -446,11 +451,11 @@ def forward(self, L_x_ : torch.Tensor):
             w = y * 3  # Use y AFTER hook
             return (z + w).sum()
 
-        x_eager = torch.ones(2, requires_grad=True)
+        x_eager = torch.ones(2, device=device_type, requires_grad=True)
         result_eager = fn(x_eager)
         result_eager.backward()
 
-        x_compiled = torch.ones(2, requires_grad=True)
+        x_compiled = torch.ones(2, device=device_type, requires_grad=True)
         compiled_fn = torch.compile(fn, backend="eager", fullgraph=True)
         result_compiled = compiled_fn(x_compiled)
         result_compiled.backward()
@@ -492,11 +497,11 @@ def forward(self, L_x_ : torch.Tensor):
             y.register_hook(lambda g: g + 1)
             return result.sum() + y.sum()
 
-        x_eager = torch.ones(6, requires_grad=True)
+        x_eager = torch.ones(6, device=device_type, requires_grad=True)
         result_eager = fn(x_eager)
         result_eager.backward()
 
-        x_compiled = torch.ones(6, requires_grad=True)
+        x_compiled = torch.ones(6, device=device_type, requires_grad=True)
         compiled_fn = torch.compile(fn, backend="eager", fullgraph=True)
         result_compiled = compiled_fn(x_compiled)
         result_compiled.backward()
@@ -974,16 +979,16 @@ def forward(self, L_x_ : torch.Tensor):
             self.assertEqual(x.grad, b * 5)
 
         # Eager values
-        x = torch.tensor([0.5, 0.5, 0.5], requires_grad=True)
-        y = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+        x = torch.tensor([0.5, 0.5, 0.5], device=device_type, requires_grad=True)
+        y = torch.tensor([1.0, 2.0, 3.0], device=device_type, requires_grad=True)
         test_fn(reg_and_mul)
 
         # Compiled
         for backend in ["eager", "aot_eager", "inductor"]:
             for compiled_bwd in [False, True]:
                 torch._dynamo.reset()
-                x = torch.tensor([0.5, 0.5, 0.5], requires_grad=True)
-                y = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+                x = torch.tensor([0.5, 0.5, 0.5], device=device_type, requires_grad=True)
+                y = torch.tensor([1.0, 2.0, 3.0], device=device_type, requires_grad=True)
 
                 cnts = torch._dynamo.testing.CompileCounterWithBackend(backend)
                 compiled_fn = torch.compile(reg_and_mul, backend=cnts, fullgraph=True)

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -1482,7 +1482,7 @@ fn(torch.randn(5))
         def baz(x):
             return x + 1
 
-        baz(torch.ones(3))
+        baz(torch.ones(3, device=device_type))
 
         # `_log_traced_frames` is registered as an atexit callback, so we invoke
         # it explicitly for testing.

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -111,6 +111,11 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.jit_utils import JitTestCase
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 pytree_modules = {
     "python": python_pytree,
 }
@@ -712,7 +717,7 @@ graph():
 
         res = add_fn(2, 3, torch.tensor(0.0))
         add_fn = torch.compile(add_fn, backend="eager", fullgraph=True)
-        res_compiled = add_fn(2, 3, torch.tensor(0.0))
+        res_compiled = add_fn(2, 3, torch.tensor(0.0, device=device_type))
         self.assertEqual(res, res_compiled)
 
     def test_callpacked(self):
@@ -1056,7 +1061,7 @@ graph():
             return y
 
         opt_f = torch.compile(f, backend="eager", fullgraph=True)
-        x = torch.ones(5)
+        x = torch.ones(5, device=device_type)
 
         res = opt_f(x)
         ref = f(x)
@@ -4385,9 +4390,9 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         shapes = [(2, 1), (6, 1), (4, 1)]
         for shape in shapes:
             vec1, vec2 = shape
-            input_tensor1 = torch.randn(vec1)
-            input_tensor2 = torch.randn(vec2)
-            out_tensor = torch.empty(shape)
+            input_tensor1 = torch.randn(vec1, device=device_type)
+            input_tensor2 = torch.randn(vec2, device=device_type)
+            out_tensor = torch.empty(shape, device=device_type)
             args = {"input": input_tensor1, "vec2": input_tensor2, "out": out_tensor}
             res = compile_fn(args)
             opt_res = res.clone()  # cuz this is out and we mutate it
@@ -8113,14 +8118,14 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             self.assertLogs(logger="torch._dynamo", level=logging.DEBUG) as log,
             torch._dynamo.config.patch(verbose=True),
         ):
-            f1(torch.randn(10), torch.randn(10))
+            f1(torch.randn(10, device=device_type), torch.randn(10, device=device_type))
             self.assertGreater(count_graph_break_msgs(log.output), 1)
 
         with (
             self.assertLogs(logger="torch._dynamo", level=logging.DEBUG) as log,
             torch._dynamo.config.patch(verbose=False),
         ):
-            g1(torch.randn(10), torch.randn(10))
+            g1(torch.randn(10, device=device_type), torch.randn(10, device=device_type))
             self.assertEqual(count_graph_break_msgs(log.output), 1)
 
         # reset logging state
@@ -14128,7 +14133,7 @@ ShapeEnv not equal: field values don't match:
             [True, False], [True, False]
         ):
             torch.use_deterministic_algorithms(forward_deterministic)
-            a = torch.randn(10, requires_grad=True)
+            a = torch.randn(10, requires_grad=True, device=device_type)
             res = func(a, 1)
             grad = torch.ones_like(res)
             torch.use_deterministic_algorithms(backward_deterministic)
@@ -14938,8 +14943,8 @@ fn
         ref_y = torch.clone(z).detach()
         ref_x_grad = torch.clone(x.grad).detach()
 
-        y = torch.arange(4).reshape(2, 2).to(torch.float)
-        x = torch.randn(2, 2)
+        y = torch.arange(4, device=device_type).reshape(2, 2).to(torch.float)
+        x = torch.randn(2, 2, device=device_type)
         x.grad = None
 
         opt_fn = torch.compile(fn, backend="eager")
@@ -16221,7 +16226,7 @@ fn
         capture_scalar_outputs=True, capture_dynamic_output_shape_ops=True
     )
     def test_new_tensor_break(self):
-        a = torch.tensor([1, 0, 0, 5])
+        a = torch.tensor([1, 0, 0, 5], device=device_type)
 
         cases = {
             "scalar": lambda a: a.new_tensor([a.nonzero().squeeze(-1).numel()]),
@@ -16577,7 +16582,7 @@ with torch.library._scoped_library("mylib_ci", "FRAGMENT") as lib:
             x.requires_grad_()
             return (x * 2).sum()
 
-        x_ref = torch.randn(3, 3)
+        x_ref = torch.randn(3, 3, device=device_type)
         x_test = x_ref.clone()
 
         fn(x_ref).backward()
@@ -16722,8 +16727,8 @@ def forward(self, L_x_ : torch.Tensor):
             h.backward(x_detached.grad)
             return x.grad, total_loss
 
-        x_ref = torch.randn(4, 8, requires_grad=True)
-        targets = torch.randint(0, 8, (4,))
+        x_ref = torch.randn(4, 8, requires_grad=True, device=device_type)
+        targets = torch.randint(0, 8, (4,), device=device_type)
 
         x_test = x_ref.clone().detach().requires_grad_(True)
         ref_grad, ref_loss = fn(x_ref, targets)
@@ -17504,10 +17509,10 @@ class TestCustomFunction(torch.testing._internal.common_utils.TestCase):
             res.add_(1.0)
             return res.sum()
 
-        inp1_custom = torch.randn(4, 1, 2, requires_grad=True)
+        inp1_custom = torch.randn(4, 1, 2, requires_grad=True, device=device_type)
         inp1_usual = inp1_custom.detach().clone().requires_grad_(True)
 
-        inp2 = torch.randn(2, 4)
+        inp2 = torch.randn(2, 4, device=device_type)
         c_custom_func = torch.compile(outer_function, backend="eager")
         c_usual_func = torch.compile(usual_function, backend="eager")
 

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -36,6 +36,10 @@ except ImportError:
     import test_functions
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
 _variable = 0
 _variable1 = 0
 
@@ -1285,8 +1289,8 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         y = model(x)
 
     def test_module_forward_has_graph_break(self):
-        m = ModuleForwardHasGraphBreak()
-        x = torch.rand([10, 10])
+        m = ModuleForwardHasGraphBreak().to(device_type)
+        x = torch.rand([10, 10], device=device_type)
         ref = m(x)
         opt_m = torch.compile(m, backend="eager")
         res = opt_m(x)
@@ -3597,12 +3601,12 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
                 return self.linear(x)
 
         torch.manual_seed(0)
-        model = SimpleModel()
+        model = SimpleModel().to(device_type)
 
         model.linear.register_forward_pre_hook(pre_forward_rename_hook)
         model.linear.register_forward_hook(post_forward_restore_hook)
 
-        input_tensor = torch.randn(4, 10)
+        input_tensor = torch.randn(4, 10, device=device_type)
 
         eager_output = model(input_tensor)
         if not hasattr(model.linear, "weight"):
@@ -3611,7 +3615,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
             raise AssertionError("Expected model.linear to not have _tmp_weight")
 
         torch.manual_seed(0)
-        model_to_compile = SimpleModel()
+        model_to_compile = SimpleModel().to(device_type)
         model_to_compile.linear.register_forward_pre_hook(pre_forward_rename_hook)
         model_to_compile.linear.register_forward_hook(post_forward_restore_hook)
 
@@ -3654,8 +3658,8 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         def noop_hook(module, args, kwargs, output):
             pass
 
-        inp = torch.randn(4, 4)
-        model = NLayerModel(num_layers=20, dim=4)
+        inp = torch.randn(4, 4, device=device_type)
+        model = NLayerModel(num_layers=20, dim=4).to(device_type)
         output_eager = model(inp)
 
         # Set hooks for compiled layers

--- a/test/dynamo/test_nested_graph_breaks.py
+++ b/test/dynamo/test_nested_graph_breaks.py
@@ -13,6 +13,11 @@ except ImportError:
     import _test_nested_graph_breaks_helper
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 # for use in test_side_effects_globals
 global1, global2, global3, global4 = (torch.zeros(3),) * 4
 
@@ -764,7 +769,7 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
             return x
 
         # test normal graph break
-        x = torch.zeros(3)
+        x = torch.zeros(3, device=device_type)
 
         def inner1(x):
             x += 1
@@ -774,7 +779,7 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(ref, torch.zeros(3) + 7)
 
         # test step graph break
-        x = torch.zeros(3)
+        x = torch.zeros(3, device=device_type)
 
         def inner2(x):
             x += 1
@@ -818,7 +823,7 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         inner3.__code__ = inner3_code
 
         torch._dynamo.utils.counters.clear()
-        x = torch.zeros(3)
+        x = torch.zeros(3, device=device_type)
         ref = f3(inner3, x)
         self.assertEqual(ref, torch.zeros(3) + 1006)
         # make sure we're actually STORE_ATTR graph breaking
@@ -841,7 +846,7 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
             x += 4
             return f2(inner4, x)
 
-        x = torch.zeros(3)
+        x = torch.zeros(3, device=device_type)
         ref = f4(x)
         self.assertEqual(ref, torch.zeros(3) + 15)
 

--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -16,6 +16,11 @@ from torch.testing._internal.common_utils import (
 )
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 logger = logging.getLogger(__name__)
 logger_test = logging.getLogger("test")
 
@@ -189,14 +194,14 @@ class ReorderLogsTests(torch._dynamo.test_case.TestCase):
             x3 = x2 + x2
             return (x1, x3)
 
-        x = torch.ones(3, 3)
+        x = torch.ones(3, 3, device=device_type)
         opt_f = torch.compile(backend="eager", fullgraph=True)(f)
         with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
             opt_out = opt_f(x)
             printed_output = mock_stdout.getvalue().strip()
             orig_out = f(x)
 
-        self.assertEqual(printed_output, f"moo\n{torch.ones(3, 3) * 2}\n1 2 3")
+        self.assertEqual(printed_output, f"moo\n{torch.ones(3, 3, device=device_type) * 2}\n1 2 3")
         self.assertTrue(same(orig_out, opt_out))
 
     @torch._dynamo.config.patch(reorderable_logging_functions={warnings.warn})
@@ -232,14 +237,14 @@ class ReorderLogsTests(torch._dynamo.test_case.TestCase):
             print(1, 2, 3)
             return x3
 
-        x = torch.ones(3, 3)
+        x = torch.ones(3, 3, device=device_type)
         opt_f = torch.compile(backend="eager")(f)
         with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
             opt_out = opt_f(x)
             printed_output = mock_stdout.getvalue().strip()
             orig_out = f(x)
 
-        self.assertEqual(printed_output, f"res: {torch.ones(3, 3) * 2}\n1 2 3")
+        self.assertEqual(printed_output, f"res: {torch.ones(3, 3, device=device_type) * 2}\n1 2 3")
         self.assertTrue(same(orig_out, opt_out))
 
     def test_reorder_custom_log_fn(self):
@@ -255,7 +260,7 @@ class ReorderLogsTests(torch._dynamo.test_case.TestCase):
             custom_log(f"{x1}")
             return x + x
 
-        x = torch.ones(3, 3)
+        x = torch.ones(3, 3, device=device_type)
         counters.clear()
         with torch._dynamo.config.patch(reorderable_logging_functions={custom_log}):
             opt_f = torch.compile(backend="eager")(f)
@@ -263,7 +268,7 @@ class ReorderLogsTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(sum(counters["graph_break"].values()), 1)
         self.assertEqual(custom_logs[0], "moo")
-        self.assertEqual(custom_logs[1], f"{torch.ones(3, 3) * 2}")
+        self.assertEqual(custom_logs[1], f"{torch.ones(3, 3, device=device_type) * 2}")
 
     @torch._dynamo.config.patch(reorderable_logging_functions={print})
     def test_constant_mutation(self):
@@ -277,7 +282,7 @@ class ReorderLogsTests(torch._dynamo.test_case.TestCase):
             res.sum().item()  # graph break
             return res
 
-        inputs = (torch.tensor([1]),)
+        inputs = (torch.tensor([1], device=device_type),)
         counters.clear()
         opt_f = torch.compile(backend="eager")(f)
         with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -92,6 +92,10 @@ from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils._python_dispatch import TorchDispatchMode
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
 _orig_module_call = torch.nn.Module.__call__
 
 # Custom operator that only supports CPU and Meta
@@ -1333,7 +1337,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             return leaf, leaf * 2
 
         f_compiled = torch.compile(f, backend="aot_eager")
-        x = torch.arange(4, dtype=torch.float32).reshape(2, 2)
+        x = torch.arange(4, dtype=torch.float32, device=device_type).reshape(2, 2)
 
         leaf, out = f(x)
         leaf_test, out_test = f_compiled(x)
@@ -1362,8 +1366,8 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             unpack_count += 1
             return x
 
-        x = torch.ones(4, requires_grad=True)
-        y = torch.ones(4, requires_grad=False)
+        x = torch.ones(4, requires_grad=True, device=device_type)
+        y = torch.ones(4, requires_grad=False, device=device_type)
         with torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook):
             out_test = f_compiled(x, y)
             self.assertEqual(pack_count, 1)
@@ -1379,8 +1383,8 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
         f_compiled = torch.compile(f, backend="aot_eager")
 
-        x = torch.ones(4, requires_grad=True)
-        y = torch.ones(4, requires_grad=False)
+        x = torch.ones(4, requires_grad=True, device=device_type)
+        y = torch.ones(4, requires_grad=False, device=device_type)
         with torch.autograd.graph.disable_saved_tensors_hooks("hooks are disabled"):
             out_test = f_compiled(x, y)
             out_test.sum().backward()
@@ -1397,8 +1401,8 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
         f_compiled = torch.compile(f, backend="aot_eager")
 
-        x = torch.ones(4, requires_grad=True)
-        y = torch.ones(4, requires_grad=False)
+        x = torch.ones(4, requires_grad=True, device=device_type)
+        y = torch.ones(4, requires_grad=False, device=device_type)
         out_test = f_compiled(x, y)
         out_test.sum().backward()
 
@@ -1414,8 +1418,8 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             d_loss = fake_d_pred.mean()
             d_loss.backward()
 
-        a_ref = torch.randn(2, 2, requires_grad=True)
-        b_ref = torch.randn(2, 2, requires_grad=True)
+        a_ref = torch.randn(2, 2, requires_grad=True, device=device_type)
+        b_ref = torch.randn(2, 2, requires_grad=True, device=device_type)
         out_ref = f(a_ref, b_ref)
 
         a_test = a_ref.detach().clone().requires_grad_(True)
@@ -2066,7 +2070,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
                 c.sum().backward()
                 return x.grad
 
-        x = torch.randn(3, requires_grad=True)
+        x = torch.randn(3, requires_grad=True, device=device_type)
         x.grad = None
         with torch.no_grad():
             ref = fn(x)
@@ -2092,7 +2096,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
                     c.sum().backward()
                     return x.grad
 
-        x = torch.randn(3, requires_grad=True)
+        x = torch.randn(3, requires_grad=True, device=device_type)
         x.grad = None
         with torch.no_grad():
             ref = fn(x)
@@ -3101,7 +3105,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
                 x += i
             return x
 
-        self.assertEqual(fn(torch.zeros(1)), torch.full([1], 6.0))
+        self.assertEqual(fn(torch.zeros(1, device=device_type)), torch.full([1], 6.0))
 
     def test_stop_iteration_reconstruct(self):
         @torch.compile(backend="eager", fullgraph=True)
@@ -3678,14 +3682,14 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
         torch.manual_seed(1337)
 
-        m_ref = Repro()
+        m_ref = Repro().to(device_type)
         m_test = deepcopy(m_ref)
 
         @torch.compile(backend="aot_eager_decomp_partition")
         def compiled_fn(x):
             return m_test(x)
 
-        x_ref = torch.randn(2, 64, 32, 32, requires_grad=True)
+        x_ref = torch.randn(2, 64, 32, 32, requires_grad=True, device=device_type)
         x_test = x_ref.clone()
 
         # Loop multiple times: each iteration the running_mean/var on batchnorm will update,
@@ -4535,7 +4539,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
                 backend = CompileCounter()
             opt_fn = torch.compile(fn, backend=backend)
 
-            eager = torch.zeros(5)
+            eager = torch.zeros(5, device=device_type)
             compiled = eager.clone()
 
             out_eager = fn(eager)
@@ -5073,7 +5077,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             f.add_(1.0)
             return a
 
-        a = torch.randn(2, 4)
+        a = torch.randn(2, 4, device=device_type)
         a_ref = a.clone()
         out_ref = foo(a_ref)
         f_compiled = torch.compile(foo, backend="aot_eager")
@@ -5700,10 +5704,10 @@ def forward(self, L_x_ : torch.Tensor, s77 : torch.SymInt, s27 : torch.SymInt):
                     drhs = torch.full_like(rhs, 1.0 if trans_b else 2.0)
                 return dlhs, drhs, None, None
 
-        x1 = torch.randn((8, 8), requires_grad=True)
-        y1 = torch.randn((8, 8)).transpose(0, 1).requires_grad_(True)
-        x2 = torch.randn((8, 8), requires_grad=True)
-        y2 = torch.randn((8, 8)).transpose(0, 1).requires_grad_(True)
+        x1 = torch.randn((8, 8), requires_grad=True, device=device_type)
+        y1 = torch.randn((8, 8), device=device_type).transpose(0, 1).requires_grad_(True)
+        x2 = torch.randn((8, 8), requires_grad=True, device=device_type)
+        y2 = torch.randn((8, 8), device=device_type).transpose(0, 1).requires_grad_(True)
 
         SDD.apply(x1, y1).sum().backward()
 
@@ -5996,8 +6000,8 @@ def forward(self, L_x_ : torch.Tensor, s77 : torch.SymInt, s27 : torch.SymInt):
             y.grad = x + 2
             return x.grad.data, y._grad.data
 
-        x0 = torch.randn(4, requires_grad=True)
-        y0 = torch.randn(4, requires_grad=True)
+        x0 = torch.randn(4, requires_grad=True, device=device_type)
+        y0 = torch.randn(4, requires_grad=True, device=device_type)
         x1 = x0.clone()
         y1 = y0.clone()
         opt_fn = torch.compile(fn, backend="eager")
@@ -6162,7 +6166,7 @@ def forward(self, L_x_ : torch.Tensor, s77 : torch.SymInt, s27 : torch.SymInt):
             x.data.mul_(2)
             return out
 
-        x = torch.randn(4, requires_grad=True)
+        x = torch.randn(4, requires_grad=True, device=device_type)
         x_test = x.detach().clone().requires_grad_(True)
 
         out = f(x)
@@ -6850,7 +6854,7 @@ def forward(self, L_x_ : torch.Tensor, s77 : torch.SymInt, s27 : torch.SymInt):
         def f(x):
             return x.copy_(1)
 
-        t = torch.zeros(2)
+        t = torch.zeros(2, device=device_type)
         res = f(t)
         self.assertEqual(torch.ones_like(t), res)
 
@@ -7198,9 +7202,9 @@ def forward(self, L_x_ : torch.Tensor, s77 : torch.SymInt, s27 : torch.SymInt):
         def f(x, out):
             torch.nanmean(x, out=out)
 
-        x = torch.randn(4)
+        x = torch.randn(4, device=device_type)
         out_ref = torch.tensor(0.0)
-        out_res = torch.tensor(0.0)
+        out_res = torch.tensor(0.0, device=device_type)
 
         f(x, out_ref)
         torch.compile(f, backend="eager", fullgraph=True)(x, out_res)
@@ -7321,8 +7325,8 @@ def forward(self, L_x_ : torch.Tensor, s77 : torch.SymInt, s27 : torch.SymInt):
 
         def inputs():
             torch.manual_seed(123)
-            x = torch.randn(10, 10)
-            y = torch.randn(10, 10, requires_grad=True)
+            x = torch.randn(10, 10, device=device_type)
+            y = torch.randn(10, 10, requires_grad=True, device=device_type)
             return x, y
 
         x1, y1 = inputs()

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -38,6 +38,11 @@ from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils._python_dispatch import return_and_correct_aliasing
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 def nontraceable_subclass(c):
     return torch._dynamo.config.patch("nontraceable_tensor_subclasses", {c})
 
@@ -1216,7 +1221,7 @@ class SubclassTests(_SubclassCompileCheckMixin, torch._dynamo.test_case.TestCase
             res = x * y + z
             return res
 
-        x0 = torch.randn(2, 2)
+        x0 = torch.randn(2, 2, device=device_type)
         x1 = x0.clone()
 
         fn_opt = compile_full_eager(fn)

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -24,6 +24,10 @@ from torch.testing._internal.common_utils import (
 )
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
 _IS_WINDOWS = sys.platform == "win32"
 
 
@@ -346,12 +350,12 @@ class TestDynamoTimed(TestCase):
         if hasattr(torch._dynamo, "reset_recompile_user_contexts"):
             torch._dynamo.reset_recompile_user_contexts()
 
-    def run_forward_backward(self):
-        model = torch.compile(TestModel())  # noqa: UNSPECIFIED_BACKEND
-        x = torch.rand([3], requires_grad=True)
+    def run_forward_backward(self, device="cpu"):
+        model = torch.compile(TestModel()).to(device)  # noqa: UNSPECIFIED_BACKEND
+        x = torch.rand([3], requires_grad=True, device=device)
         output = model(x)
         loss_fn = torch.nn.MSELoss()
-        target = torch.tensor([1.0])
+        target = torch.tensor([1.0], device=device)
         loss = loss_fn(output, target)
         loss.backward()
 
@@ -373,7 +377,7 @@ class TestDynamoTimed(TestCase):
 
         compilation_events = []
         with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
-            self.run_forward_backward()
+            self.run_forward_backward(device_type)
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
         stack_trace_list = []
         for e in compilation_events:
@@ -399,7 +403,7 @@ class TestDynamoTimed(TestCase):
 
         compilation_events = []
         with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
-            self.run_forward_backward()
+            self.run_forward_backward(device_type)
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
 
         self.assertEqual(
@@ -415,7 +419,7 @@ class TestDynamoTimed(TestCase):
         import torch._dynamo.convert_frame as convert_frame
 
         self.warmup()
-        self.run_forward_backward()
+        self.run_forward_backward(device_type)
 
         # Dummy code object
         def sample_func():


### PR DESCRIPTION
Many test/dynamo tests hardcode CPU input tensors (no device= argument). torch.compile is device-preserving, but accelerator backends that execute the compiled graph on-device return device tensors, so autograd rejects the device mismatch on backward, e.g.:

    RuntimeError: Function CompiledFunctionBackward returned an invalid
    gradient at index 0 - expected device cpu but got <accel>:0

Create inputs on the current accelerator via a module-level device_type (torch.accelerator.current_accelerator, falling back to "cpu"), adding device=device_type to input tensor factories and .to(device_type) to nn.Module instances in the affected tests. Because device_type resolves to "cpu" when no accelerator is present, these edits are a no-op on CPU and CUDA CI and only take effect on accelerator backends. run_forward_backward in test_utils gains an optional device="cpu" parameter so its device-sensitive caller is unaffected while the target tests opt in.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98