### PR TITLE
Pass cudagraph config via inductor_meta (#190906)

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6870,6 +6870,13 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             "force_disable_caches": config.force_disable_caches,
             "dynamic_scale_rblock": config.dynamic_scale_rblock,
             "incremental_autotune": config.incremental_autotune,
+            # Captured at codegen time so it reflects the per-graph cudagraph
+            # decision, including override_cudagraphs annotations that patch
+            # config.triton.cudagraphs on only for this region's compilation
+            # (see cudagraph_annotation_context). The live global flag is back
+            # to its default by the time the kernel runs, so runtime checks of
+            # config.triton.cudagraphs miss per-region cudagraphs.
+            "cudagraphs": config.triton.cudagraphs,
             "max_autotune": config.max_autotune,
             "max_autotune_pointwise": config.max_autotune_pointwise,
             "min_split_scan_rblock": config.triton.min_split_scan_rblock,


### PR DESCRIPTION
Summary:

Add support to get cudagraph enablement in runtime not via the global toggle, because we have [apis](https://www.internalfb.com/code/fbsource/[c84e43cb84678e2f8941bf4130933a831e916e8a]/fbcode/caffe2/torch/_dynamo/decorators.py?lines=1719) to partially turn on cudagraph, so if we only check the global toggle which is not enough, here we get it during codegen so that it gets the ground truth.

Test Plan: f1114969875

Differential Revision: D112721127




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo