### PR TITLE
Make test_dynamic_shapes device-generic

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -5290,7 +5290,10 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
             return torch.narrow(x, 0, start, end)
 
         x = torch.tensor(
-            [False], device="cuda:0" if torch.cuda.is_available() else "cpu"
+            [False],
+            device=f"{torch.accelerator.current_accelerator().type}:0"
+            if torch.accelerator.is_available()
+            else "cpu",
         )
         start = torch.tensor(0)
         res = f(x, start, 0)


### PR DESCRIPTION
## Summary

Makes the device selection in `test/test_dynamic_shapes.py` device-generic so the affected test runs on any available accelerator (CUDA, XPU, MPS) instead of being hard-coded to `cuda:0`.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @fffrog

## Changes

- Replace `device="cuda:0" if torch.cuda.is_available() else "cpu"` with an accelerator-generic selection using `torch.accelerator.is_available()` / `torch.accelerator.current_accelerator().type`.

## Faithfulness

- Single device-selection line changed; no test methods added, removed, or modified
- CPU fallback path is unchanged
- On CUDA, `torch.accelerator.current_accelerator().type` resolves to `"cuda"` → semantically identical

## Validation

- `py_compile` clean; lint gate (RUFF/PYFMT/FLAKE8/TEST_DEVICE_BIAS) clean
- Verified locally on CPU and MPS; CUDA leg validated on a V100 (behaviour identical to the pre-change CUDA path)
- CUDA and XPU legs re-exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
