### PR TITLE
[inductor] make TORCHINDUCTOR_NAN_ASSERTS fp8-safe

### DIFF
--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -275,7 +275,7 @@ class MultiKernel:
                 if isinstance(precompile_arg, TensorArg):
                     line = f"assert not {arg}.isnan().any().item()"
                     wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
+                    line = f"assert not {arg}.float().isinf().any().item()"
                     wrapper.writeline(line)
 
     @property

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7480,7 +7480,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 else:
                     line = f"assert not {arg}.isnan().any().item()"
                     wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
+                    line = f"assert not {arg}.float().isinf().any().item()"
                     wrapper.writeline(line)
 
     def create_cse_var(self, *args, **kwargs) -> TritonCSEVariable:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1747,7 +1747,7 @@ class PythonWrapperCodegen(CodeGen):
                 continue
             line = f"assert not {name}.isnan().any().item()"
             self.prefix.writeline(line)
-            line = f"assert not {name}.isinf().any().item()"
+            line = f"assert not {name}.float().isinf().any().item()"
             self.prefix.writeline(line)
 
     def write_async_compile_wait(self) -> None:
@@ -2102,7 +2102,9 @@ class PythonWrapperCodegen(CodeGen):
                 self.wrapper_call.writeline("if isinstance(var, torch.Tensor):")
                 self.wrapper_call.do_indent()
                 self.wrapper_call.writeline("assert not var.isnan().any().item()")
-                self.wrapper_call.writeline("assert not var.isinf().any().item()")
+                self.wrapper_call.writeline(
+                    "assert not var.float().isinf().any().item()"
+                )
                 self.wrapper_call.do_unindent(2)
 
             self.wrapper_call.writeline("return (" + ", ".join(output_refs) + ", )")


### PR DESCRIPTION
Summary:
Running with `TORCHINDUCTOR_NAN_ASSERTS=1` codegens `x.isnan()`/`x.isinf()` after each kernel and on graph inputs/outputs, but `.isinf()` is not implemented for Float8_e4m3fn, so any model using fp8 activation quantization crashes the assert on the first fp8 buffer (NotImplementedError) regardless of any actual NaN.

Cast to float first (`x.float().isnan/isinf()`) in all four JIT codegen sites (triton per-kernel, multi_kernel, wrapper graph-input and graph-output asserts); the cast preserves NaN and fp8_e4m3fn has no representable infinity anyway.

Test Plan:
Reproduced on an APS ads training job (mtml_ctr_instagram, fp8 activation quantization / Float8_e4m3fn) with `TORCHINDUCTOR_NAN_ASSERTS=1:` before this fix the run crashed at the first fp8 kernel output with
```counterexample
NotImplementedError: "isinf" not implemented for 'Float8_e4m3fn' (ATen TensorCompare.cpp:468)
```
independent of any real NaN, because isinf is unimplemented for fp8 (e4m3fn has NaN but no representable inf). After casting to float in the four JIT nan-assert codegen sites (triton per-kernel, multi_kernel, wrapper graph-input and graph-output), the asserts run on fp8 buffers with NaN detection preserved. End-to-end validation on a MAST rerun with nan_asserts enabled on this fp8 model is in progress.

With this fix, we were able to run a known NaN/infinity-hitting job and it correctly hit the error:
```
line 7863, in call: assert not buf587.float().isinf().any().item()"...
```

Differential Revision: D113391104


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo