### PR TITLE
Make test_custom_ops device-generic

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -6442,11 +6442,11 @@ opcheck(op, args, kwargs, test_utils="test_schema")
             (torch.randn(3),),
             (torch.randn(3, requires_grad=True),),
         ]
-        if torch.cuda.is_available():
+        if TEST_ACCELERATOR:
             sample_inputs.extend(
                 [
-                    (torch.randn(3, device="cuda"),),
-                    (torch.randn(3, device="cuda", requires_grad=True),),
+                    (torch.randn(3, device=device_type),),
+                    (torch.randn(3, device=device_type, requires_grad=True),),
                 ]
             )
         for args in sample_inputs:


### PR DESCRIPTION
## Summary

Makes the accelerator sample-input path in `test/test_custom_ops.py` device-generic so it exercises whichever accelerator is present (CUDA, XPU) rather than CUDA only.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @fffrog

## Changes

- Replace the `torch.cuda.is_available()` guard with `TEST_ACCELERATOR` (already imported)
- Replace `device="cuda"` sample tensors with the module-level `device_type` (resolved from `torch.accelerator.current_accelerator()`)

## Faithfulness

- Only the accelerator branch of the sample-input builder changes; the CPU samples are untouched
- No test methods added or removed
- On CUDA, `device_type == "cuda"` → identical tensors to the original

## Validation

- `py_compile` clean; lint gate (RUFF/PYFMT/FLAKE8/TEST_DEVICE_BIAS) clean
- Verified locally on CPU and MPS; CUDA leg validated on a V100 (behaviour identical to the pre-change CUDA path)
- CUDA and XPU legs re-exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
