### PR TITLE
Make test_legacy_vmap device-generic

### DIFF
--- a/test/test_legacy_vmap.py
+++ b/test/test_legacy_vmap.py
@@ -1196,7 +1196,7 @@ class TestVmapOperatorsLegacy(Namespace.TestVmapBaseLegacy):
             test(op, (getter([B0, 2], device), getter([B0], device, torch.double)))
             test(op, (getter([B0], device, torch.double), getter([B0, 2], device)))
 
-            if not torch.cuda.is_available():
+            if not torch.accelerator.is_available():
                 continue
 
             # TODO(rzou): fix the following


### PR DESCRIPTION
## Summary

Makes the accelerator guard in `test/test_legacy_vmap.py` device-generic so the accelerator-only portion of the vmap OpInfo helper runs on any accelerator, not just CUDA.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @fffrog

## Changes

- Replace `torch.cuda.is_available()` with `torch.accelerator.is_available()` in the device helper's early-continue guard.

## Faithfulness

- Single guard changed; no test methods added or removed
- On a CPU-only machine behaviour is unchanged (guard still short-circuits)
- On CUDA, `torch.accelerator.is_available()` is true exactly when CUDA is available → identical

## Validation

- `py_compile` clean; lint gate (RUFF/PYFMT/FLAKE8/TEST_DEVICE_BIAS) clean
- Verified locally on CPU and MPS; CUDA leg validated on a V100 (behaviour identical to the pre-change CUDA path)
- CUDA and XPU legs re-exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
