### PR TITLE
Make test_eager_transforms device-generic

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -5709,7 +5709,7 @@ class TestGradTrackingTensorToList(TestCase):
         self.assertEqual(result, [2.0 + 4.0j, 6.0 + 8.0j])
 
 
-only_for = ("cpu", "cuda")
+only_for = ("cpu", "cuda", "xpu")
 instantiate_device_type_tests(
     TestGradTransform,
     globals(),


### PR DESCRIPTION
## Summary

Extends the device instantiation in `test/functorch/test_eager_transforms.py` to XPU so the grad-transform suites also run on XPU accelerators.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @fffrog

## Changes

- Add `"xpu"` to the `only_for` tuple passed to `instantiate_device_type_tests(...)`.

## Faithfulness

- No test methods added, removed, or modified — only the set of device types the existing suites are instantiated for
- CPU and CUDA instantiation are unchanged

## Validation

- `py_compile` clean; lint gate (RUFF/PYFMT/FLAKE8/TEST_DEVICE_BIAS) clean
- Verified locally on CPU and MPS; CUDA leg validated on a V100 (behaviour identical to the pre-change CUDA path)
- CUDA and XPU legs re-exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
