### PR TITLE
Make test_parametrization device-generic

### DIFF
--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1917,7 +1917,7 @@ class TestNNParametrizationDevice(NNTestCase):
             self.assertEqual(m(input), expected_output)
 
 
-instantiate_device_type_tests(TestNNParametrizationDevice, globals())
+instantiate_device_type_tests(TestNNParametrizationDevice, globals(), allow_mps=True)
 instantiate_parametrized_tests(TestNNParametrization)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Enables MPS instantiation for the device parametrization suite in `test/nn/test_parametrization.py`.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @fffrog

## Changes

- Pass `allow_mps=True` to `instantiate_device_type_tests(TestNNParametrizationDevice, globals())`.

## Faithfulness

- No test methods added, removed, or modified
- The parametrization tests operate on float32 tensors (no float64/complex128), so they are MPS-safe
- CPU and CUDA instantiation are unchanged

## Validation

- `py_compile` clean; lint gate (RUFF/PYFMT/FLAKE8/TEST_DEVICE_BIAS) clean
- Verified locally on CPU and MPS; CUDA leg validated on a V100 (behaviour identical to the pre-change CUDA path)
- CUDA and XPU legs re-exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
