### PR TITLE
Make test_execution_trace device-generic

### DIFF
--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -824,7 +824,9 @@ class TestExecutionTrace(TestCase):
                 raise AssertionError("Expected t2 contents to match [0, 0, 1, 0]")
 
 
-instantiate_device_type_tests(TestExecutionTrace, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestExecutionTrace, globals(), allow_mps=True, allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Enables MPS instantiation for `TestExecutionTrace` in `test/profiler/test_execution_trace.py`, alongside the existing XPU support.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @fffrog

## Changes

- Add `allow_mps=True` to the existing `instantiate_device_type_tests(TestExecutionTrace, globals(), allow_xpu=True)` call.

## Faithfulness

- No test methods added, removed, or modified
- CPU, CUDA, and XPU instantiation are unchanged

## Validation

- `py_compile` clean; lint gate (RUFF/PYFMT/FLAKE8/TEST_DEVICE_BIAS) clean
- Verified locally on CPU and MPS; CUDA leg validated on a V100 (behaviour identical to the pre-change CUDA path)
- CUDA and XPU legs re-exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
