### PR TITLE
Make test_nativert device-generic

### DIFF
--- a/test/export/test_nativert.py
+++ b/test/export/test_nativert.py
@@ -18,7 +18,7 @@ from torch.nativert.backends._lower_utils import (
     package_nativert_with_aoti_delegate,
 )
 from torch.testing._internal.common_utils import IS_WINDOWS
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU_AND_TRITON
 from torch.utils import _pytree as pytree
 
 
@@ -262,8 +262,8 @@ class TestNativeRT(TestCase):
         return M()
 
     parameters = []
-    for device in ["cpu", "cuda"]:
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
+    for device in ["cpu", GPU_TYPE]:
+        if device == GPU_TYPE and not HAS_GPU_AND_TRITON:
             continue
         for module, sample_inputs in [
             (get_module.__func__().to(device), (torch.randn(4, 4).to(device),)),


### PR DESCRIPTION
## Summary

Makes the device loop in `test/export/test_nativert.py` device-generic so the accelerator packaging path uses the detected GPU type (CUDA or XPU) instead of hard-coded CUDA.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @fffrog

## Changes

- Import `GPU_TYPE, HAS_GPU_AND_TRITON` from `torch.testing._internal.inductor_utils` (replacing `HAS_CUDA_AND_TRITON`)
- Iterate over `["cpu", GPU_TYPE]` and gate the accelerator leg on `HAS_GPU_AND_TRITON`

## Faithfulness

- No test methods added or removed
- CPU leg is unchanged
- On CUDA, `GPU_TYPE == "cuda"` and `HAS_GPU_AND_TRITON == HAS_CUDA_AND_TRITON` → identical behaviour

## Validation

- `py_compile` clean; lint gate (RUFF/PYFMT/FLAKE8/TEST_DEVICE_BIAS) clean
- Verified locally on CPU and MPS; CUDA leg validated on a V100 (behaviour identical to the pre-change CUDA path)
- CUDA and XPU legs re-exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
