### PR TITLE
Make test_prims device-generic

### DIFF
--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -35,7 +35,6 @@ NVPRIM_ATEN_FALLBACK_WARNING = "fallback to aten executor"
 GET_ISOLATED_GRAPHMODULE_ERROR = "get_isolated_graphmodule failed on decomposition"
 
 class TestPrims(TestCase):
-    @onlyCUDA
     @dtypes(torch.float32)
     def test_broadcast_in_dim(self, device, dtype):
         def _wrapper(a, b, broadcast_dimensions):
@@ -84,7 +83,6 @@ class TestPrims(TestCase):
             self.assertEqual(result.shape, b.shape)
             self.assertEqual(a.unsqueeze(2), result)
 
-    @onlyCUDA
     @dtypes(torch.float32)
     def test_broadcast_in_dim_sum(self, device, dtype):
         def _wrapper(a):
@@ -175,7 +173,6 @@ class TestPrims(TestCase):
         )
         self.assertTrue(all_prims_namespace)
 
-    @onlyCUDA
     @dtypes(torch.float32)
     @parametrize("correction", [0, 1])
     def test_var(self, device, dtype, correction):


### PR DESCRIPTION
## Summary

Removes redundant `@onlyCUDA` decorators from three device-neutral prim tests in `test/test_prims.py` so they also provide coverage on CPU, MPS, and other accelerators.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @fffrog

## Changes

- Drop `@onlyCUDA` from `test_broadcast_in_dim`, `test_broadcast_in_dim_sum`, and `test_var`.

## Faithfulness

- No test methods added, removed, or modified — only the device-restriction decorator is dropped
- These tests use device-agnostic prim operations and the `device`/`dtype` fixtures from `instantiate_device_type_tests`; they contain no CUDA-specific APIs
- The CUDA leg continues to run exactly as before

## Validation

- `py_compile` clean; lint gate (RUFF/PYFMT/FLAKE8/TEST_DEVICE_BIAS) clean
- Verified locally on CPU and MPS; CUDA leg validated on a V100 (behaviour identical to the pre-change CUDA path)
- CUDA and XPU legs re-exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
