### PR TITLE
[Profiler] Use typed metadata for parent id

### DIFF
--- a/test/cpp/profiler/test_profiler_collection.cpp
+++ b/test/cpp/profiler/test_profiler_collection.cpp
@@ -42,7 +42,6 @@
 
 #include <GenericTraceActivity.h>
 #include <IActivityProfiler.h>
-#include <MetadataFieldCatalog.h>
 #include <libkineto.h>
 #include <output_base.h>
 
@@ -208,45 +207,6 @@ class CapturingWarningHandler : public c10::WarningHandler {
 };
 
 } // namespace
-
-TEST(ProfilerCollectionTest, PythonParentIdIsTypedAndAbsentWithoutParent) {
-  using namespace torch::autograd::profiler;
-  using namespace torch::profiler::impl;
-
-  auto make_python_event = [](size_t id,
-                              libkineto::GenericTraceActivity& activity) {
-    auto result = Result::create(
-        /*start_time_ns=*/0,
-        /*start_tid=*/0,
-        kineto::DeviceAndResource{},
-        ExtraFields<EventType::PyCall>{
-            /*end_time_ns=*/1,
-            /*python_tid=*/0,
-            PyFrameState{},
-            ExtraFields<EventType::PyCall>::args_t{}});
-    std::get<ExtraFields<EventType::PyCall>>(result->extra_fields_).id_ = id;
-    result->kineto_activity_ = &activity;
-    return result;
-  };
-
-  constexpr size_t kRootId = 17;
-  libkineto::GenericTraceActivity root_activity;
-  libkineto::GenericTraceActivity child_activity;
-  auto root = make_python_event(kRootId, root_activity);
-  auto child = make_python_event(18, child_activity);
-  child->parent_ = root;
-
-  addTensorboardFields(root, {}, {});
-  addTensorboardFields(child, {}, {});
-
-  EXPECT_EQ(
-      root_activity.metadataJson().find("\"Python parent id\""),
-      std::string::npos);
-  const auto parent_id = child_activity.getMetadataValue(
-      libkineto::GenericMetadataFields::kPythonParentId);
-  ASSERT_TRUE(parent_id.has_value());
-  EXPECT_EQ(*parent_id, kRootId);
-}
 
 // A backend producing duplicate async-CPU-GPU flow start IDs must be handled
 // gracefully.

--- a/test/cpp/profiler/test_profiler_collection.cpp
+++ b/test/cpp/profiler/test_profiler_collection.cpp
@@ -42,6 +42,7 @@
 
 #include <GenericTraceActivity.h>
 #include <IActivityProfiler.h>
+#include <MetadataFieldCatalog.h>
 #include <libkineto.h>
 #include <output_base.h>
 
@@ -207,6 +208,45 @@ class CapturingWarningHandler : public c10::WarningHandler {
 };
 
 } // namespace
+
+TEST(ProfilerCollectionTest, PythonParentIdIsTypedAndAbsentWithoutParent) {
+  using namespace torch::autograd::profiler;
+  using namespace torch::profiler::impl;
+
+  auto make_python_event = [](size_t id,
+                              libkineto::GenericTraceActivity& activity) {
+    auto result = Result::create(
+        /*start_time_ns=*/0,
+        /*start_tid=*/0,
+        kineto::DeviceAndResource{},
+        ExtraFields<EventType::PyCall>{
+            /*end_time_ns=*/1,
+            /*python_tid=*/0,
+            PyFrameState{},
+            ExtraFields<EventType::PyCall>::args_t{}});
+    std::get<ExtraFields<EventType::PyCall>>(result->extra_fields_).id_ = id;
+    result->kineto_activity_ = &activity;
+    return result;
+  };
+
+  constexpr size_t kRootId = 17;
+  libkineto::GenericTraceActivity root_activity;
+  libkineto::GenericTraceActivity child_activity;
+  auto root = make_python_event(kRootId, root_activity);
+  auto child = make_python_event(18, child_activity);
+  child->parent_ = root;
+
+  addTensorboardFields(root, {}, {});
+  addTensorboardFields(child, {}, {});
+
+  EXPECT_EQ(
+      root_activity.metadataJson().find("\"Python parent id\""),
+      std::string::npos);
+  const auto parent_id = child_activity.getMetadataValue(
+      libkineto::GenericMetadataFields::kPythonParentId);
+  ASSERT_TRUE(parent_id.has_value());
+  EXPECT_EQ(*parent_id, kRootId);
+}
 
 // A backend producing duplicate async-CPU-GPU flow start IDs must be handled
 // gracefully.

--- a/torch/csrc/profiler/kineto_metadata.cpp
+++ b/torch/csrc/profiler/kineto_metadata.cpp
@@ -144,9 +144,7 @@ struct AddTensorboardFields : public MetadataBase {
       std::shared_ptr<Result> parent = result->parent_.lock();
       while (parent && !parent_id.has_value()) {
         parent->visit_if_base<PyExtraFieldsBase>(
-            [&](const auto& j) {
-              parent_id = static_cast<uint64_t>(j.id_);
-            });
+            [&](const auto& j) { parent_id = static_cast<uint64_t>(j.id_); });
         parent = parent->parent_.lock();
       }
       if (parent_id.has_value()) {

--- a/torch/csrc/profiler/kineto_metadata.cpp
+++ b/torch/csrc/profiler/kineto_metadata.cpp
@@ -140,15 +140,18 @@ struct AddTensorboardFields : public MetadataBase {
     result->visit_if_base<PyExtraFieldsBase>([&, this](const auto& i) -> void {
       this->addMetadata(fields::kPythonId, static_cast<uint64_t>(i.id_));
 
-      std::optional<std::string> parent_id;
+      std::optional<uint64_t> parent_id;
       std::shared_ptr<Result> parent = result->parent_.lock();
       while (parent && !parent_id.has_value()) {
         parent->visit_if_base<PyExtraFieldsBase>(
-            [&](const auto& j) { parent_id = std::to_string(j.id_); });
+            [&](const auto& j) {
+              parent_id = static_cast<uint64_t>(j.id_);
+            });
         parent = parent->parent_.lock();
       }
-      // Dynamic value ("null" or a number) -> stays on the string path.
-      this->addMetadata("Python parent id", parent_id.value_or("null"));
+      if (parent_id.has_value()) {
+        this->addMetadata(fields::kPythonParentId, *parent_id);
+      }
       if (i.caller_.line_no_ > 0) {
         this->addMetadata(
             fields::kCallFrom,


### PR DESCRIPTION
Originally this stayed on the string path because it could be a number or null, but I think it makes more sense to exclude the field if it's null. That means we can maintain this as an int.