### PR TITLE
[inductor][cpu] Fix max parallel depth to prevent OMP fork overhead when freezing

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1530,8 +1530,7 @@ class CPUReproTests(TestCase):
                 )
                 s = q @ k.transpose(-1, -2) / math.sqrt(c // NH)
                 s = (
-                    s.view(1, n, NH, WS * WS, WS * WS)
-                    + mask.unsqueeze(1).unsqueeze(0)
+                    s.view(1, n, NH, WS * WS, WS * WS) + mask.unsqueeze(1).unsqueeze(0)
                 ).view(-1, NH, WS * WS, WS * WS)
                 o = (s.softmax(-1) @ v).transpose(1, 2).reshape(n, WS * WS, c)
                 return self.out(o)

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from unittest.mock import patch
 
 import sympy
+
 import torch
 from torch import nn
 from torch._C import FileCheck

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1549,8 +1549,7 @@ class CPUReproTests(TestCase):
                 )
                 s = q @ k.transpose(-1, -2) / math.sqrt(c // NH)
                 s = (
-                    s.view(1, n, NH, WS * WS, WS * WS)
-                    + mask.unsqueeze(1).unsqueeze(0)
+                    s.view(1, n, NH, WS * WS, WS * WS) + mask.unsqueeze(1).unsqueeze(0)
                 ).view(-1, NH, WS * WS, WS * WS)
                 o = (s.softmax(-1) @ v).transpose(1, 2).reshape(n, WS * WS, c)
                 return self.out(o)

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1458,6 +1458,91 @@ class CPUReproTests(TestCase):
             # for parallel reduction.
             self.common(mod, (x, weight), atol=5e-1, rtol=5e-1)
 
+    @requires_vectorization
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
+    @config.patch(freezing=True)
+    def test_parallel_reduction_not_nested_in_loop(self):
+        # Fix issue: https://github.com/pytorch/pytorch/issues/190757
+        # Under freezing, the channels-last layout propagated from the conv /
+        # linear rewrites leaves the shifted-window masked-softmax reduction with
+        # a small (size-4, the number of attention heads) vectorized outer loop.
+        # The outer-work estimate in LoopNest.max_parallel_depth used to underflow
+        # to 0 (FloorDiv(4, vec_width)), so parallelism was relocated onto the
+        # inner reduction, emitting an OpenMP parallel region *inside* a serial
+        # loop that re-forked the thread pool once per iteration. Make sure no
+        # parallel region is nested inside a loop body.
+        C, WS, SHIFT, NH = 96, 8, 4, 4
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj = torch.nn.Conv2d(1, C, 4, 4)
+                self.gate = torch.nn.Conv2d(C, C, 1)
+                self.ln = torch.nn.LayerNorm(C)
+                self.qkv = torch.nn.Linear(C, 3 * C)
+                self.out = torch.nn.Linear(C, C)
+
+            def forward(self, x):
+                x = F.interpolate(
+                    x, (1024, 64), mode="bicubic", align_corners=True
+                ).reshape(1, 1, 256, 256)
+                g = self.proj(x)
+                x = g * torch.sigmoid(self.gate(g))
+                b, c, h, w = x.shape
+                x = self.ln(x.flatten(2).transpose(1, 2)).view(b, h, w, c)
+                x = torch.roll(x, (-SHIFT, -SHIFT), (1, 2))
+                win = (
+                    x.view(b, h // WS, WS, w // WS, WS, c)
+                    .permute(0, 1, 3, 2, 4, 5)
+                    .reshape(-1, WS * WS, c)
+                )
+                n = win.shape[0]
+                r = (torch.arange(h) >= h - WS).long() + (
+                    torch.arange(h) >= h - SHIFT
+                ).long()
+                reg = (
+                    (r[:, None] * 3 + r[None, :])
+                    .view(h // WS, WS, w // WS, WS)
+                    .permute(0, 2, 1, 3)
+                    .reshape(-1, WS * WS)
+                )
+                mask = (
+                    (reg.unsqueeze(1) - reg.unsqueeze(2))
+                    .to(x.dtype)
+                    .masked_fill_(reg.unsqueeze(1) != reg.unsqueeze(2), -100.0)
+                )
+                q, k, v = (
+                    self.qkv(win)
+                    .view(n, WS * WS, 3, NH, c // NH)
+                    .permute(2, 0, 3, 1, 4)
+                )
+                s = q @ k.transpose(-1, -2) / math.sqrt(c // NH)
+                s = (
+                    s.view(1, n, NH, WS * WS, WS * WS) + mask.unsqueeze(1).unsqueeze(0)
+                ).view(-1, NH, WS * WS, WS * WS)
+                o = (s.softmax(-1) @ v).transpose(1, 2).reshape(n, WS * WS, c)
+                return self.out(o)
+
+        mod = Model().eval()
+        x = torch.randn(1, 1, 1001, 64)
+        with torch.no_grad():
+            expected = mod(x)
+            compiled_m = torch.compile(mod)
+            actual, code = run_and_get_cpp_code(compiled_m, x)
+            self.assertEqual(expected, actual, atol=1e-3, rtol=1e-3)
+            # An OpenMP parallel region must never be opened inside a loop body:
+            # doing so re-forks the thread pool on every iteration. Every
+            # `#pragma omp parallel` should be hoisted to the top of its kernel
+            # (i.e. at the kernel body indentation level, not nested in loops).
+            for line in code.splitlines():
+                if "#pragma omp parallel" in line:
+                    indent = len(line) - len(line.lstrip())
+                    self.assertLessEqual(
+                        indent,
+                        4,
+                        msg=f"OpenMP parallel region nested inside a loop: {line!r}",
+                    )
+
     def test_cat_mul(self):
         # https://github.com/pytorch/pytorch/issues/93365
         def fn(p0, p1):

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -12,13 +12,21 @@ import unittest
 from collections.abc import Callable
 from unittest.mock import patch
 
+import sympy
 import torch
 from torch import nn
 from torch._C import FileCheck
 from torch._dynamo.testing import CompileCounterWithBackend, rand_strided
 from torch._dynamo.utils import same
 from torch._inductor import config, cpu_vec_isa, metrics, test_operators
-from torch._inductor.codegen.cpp import CppOverrides, CppVecOverrides
+from torch._inductor.codegen.cpp import (
+    CppKernelProxy,
+    CppOverrides,
+    CppVecOverrides,
+    KernelGroup,
+    LoopLevel,
+    LoopNest,
+)
 from torch._inductor.compile_fx import compile_fx, compile_fx_inner
 from torch._inductor.exc import InductorError
 from torch._inductor.graph import GraphLowering
@@ -1458,90 +1466,19 @@ class CPUReproTests(TestCase):
             # for parallel reduction.
             self.common(mod, (x, weight), atol=5e-1, rtol=5e-1)
 
-    @requires_vectorization
-    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
-    @config.patch(freezing=True)
-    def test_parallel_reduction_not_nested_in_loop(self):
+    def test_max_parallel_depth_sub_vector_width_loop(self):
         # Fix issue: https://github.com/pytorch/pytorch/issues/190757
-        # Under freezing, the channels-last layout propagated from the conv /
-        # linear rewrites leaves the shifted-window masked-softmax reduction with
-        # a small (size-4, the number of attention heads) vectorized outer loop.
-        # The outer-work estimate in LoopNest.max_parallel_depth used to underflow
-        # to 0 (FloorDiv(4, vec_width)), so parallelism was relocated onto the
-        # inner reduction, emitting an OpenMP parallel region *inside* a serial
-        # loop that re-forked the thread pool once per iteration. Make sure no
-        # parallel region is nested inside a loop body.
-        C, WS, SHIFT, NH = 96, 8, 4, 4
-
-        class Model(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.proj = torch.nn.Conv2d(1, C, 4, 4)
-                self.gate = torch.nn.Conv2d(C, C, 1)
-                self.ln = torch.nn.LayerNorm(C)
-                self.qkv = torch.nn.Linear(C, 3 * C)
-                self.out = torch.nn.Linear(C, C)
-
-            def forward(self, x):
-                x = F.interpolate(
-                    x, (1024, 64), mode="bicubic", align_corners=True
-                ).reshape(1, 1, 256, 256)
-                g = self.proj(x)
-                x = g * torch.sigmoid(self.gate(g))
-                b, c, h, w = x.shape
-                x = self.ln(x.flatten(2).transpose(1, 2)).view(b, h, w, c)
-                x = torch.roll(x, (-SHIFT, -SHIFT), (1, 2))
-                win = (
-                    x.view(b, h // WS, WS, w // WS, WS, c)
-                    .permute(0, 1, 3, 2, 4, 5)
-                    .reshape(-1, WS * WS, c)
-                )
-                n = win.shape[0]
-                r = (torch.arange(h) >= h - WS).long() + (
-                    torch.arange(h) >= h - SHIFT
-                ).long()
-                reg = (
-                    (r[:, None] * 3 + r[None, :])
-                    .view(h // WS, WS, w // WS, WS)
-                    .permute(0, 2, 1, 3)
-                    .reshape(-1, WS * WS)
-                )
-                mask = (
-                    (reg.unsqueeze(1) - reg.unsqueeze(2))
-                    .to(x.dtype)
-                    .masked_fill_(reg.unsqueeze(1) != reg.unsqueeze(2), -100.0)
-                )
-                q, k, v = (
-                    self.qkv(win)
-                    .view(n, WS * WS, 3, NH, c // NH)
-                    .permute(2, 0, 3, 1, 4)
-                )
-                s = q @ k.transpose(-1, -2) / math.sqrt(c // NH)
-                s = (
-                    s.view(1, n, NH, WS * WS, WS * WS) + mask.unsqueeze(1).unsqueeze(0)
-                ).view(-1, NH, WS * WS, WS * WS)
-                o = (s.softmax(-1) @ v).transpose(1, 2).reshape(n, WS * WS, c)
-                return self.out(o)
-
-        mod = Model().eval()
-        x = torch.randn(1, 1, 1001, 64)
-        with torch.no_grad():
-            expected = mod(x)
-            compiled_m = torch.compile(mod)
-            actual, code = run_and_get_cpp_code(compiled_m, x)
-            self.assertEqual(expected, actual, atol=1e-3, rtol=1e-3)
-            # An OpenMP parallel region must never be opened inside a loop body:
-            # doing so re-forks the thread pool on every iteration. Every
-            # `#pragma omp parallel` should be hoisted to the top of its kernel
-            # (i.e. at the kernel body indentation level, not nested in loops).
-            for line in code.splitlines():
-                if "#pragma omp parallel" in line:
-                    indent = len(line) - len(line.lstrip())
-                    self.assertLessEqual(
-                        indent,
-                        4,
-                        msg=f"OpenMP parallel region nested inside a loop: {line!r}",
-                    )
+        # A vectorized loop smaller than the vector width runs 1 iteration, not
+        # 0. Counting it as 0 zeroed the outer-work estimate and relocated
+        # parallelism onto the inner reduction, nesting an OpenMP parallel
+        # region inside a serial loop.
+        outer = LoopLevel(sympy.Symbol("x0"), sympy.Integer(4)).tile(16)
+        reduction = LoopLevel(sympy.Symbol("x1"), sympy.Integer(64))
+        reduction.is_reduction = True
+        nest = LoopNest([outer, reduction], CppKernelProxy(KernelGroup()))
+        depth = nest.max_parallel_depth()
+        self.assertEqual(depth.start_depth, 0)
+        self.assertEqual(depth.parallel_depth, 1)
 
     def test_cat_mul(self):
         # https://github.com/pytorch/pytorch/issues/93365

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -23,6 +23,7 @@ from torch._inductor import config, cpu_vec_isa, metrics, test_operators
 from torch._inductor.codegen.cpp import (
     CppKernelProxy,
     CppOverrides,
+    CppVecKernel,
     CppVecOverrides,
     KernelGroup,
     LoopLevel,
@@ -1467,19 +1468,102 @@ class CPUReproTests(TestCase):
             # for parallel reduction.
             self.common(mod, (x, weight), atol=5e-1, rtol=5e-1)
 
+    @requires_vectorization
     def test_max_parallel_depth_sub_vector_width_loop(self):
         # Fix issue: https://github.com/pytorch/pytorch/issues/190757
         # A vectorized loop smaller than the vector width runs 1 iteration, not
         # 0. Counting it as 0 zeroed the outer-work estimate and relocated
         # parallelism onto the inner reduction, nesting an OpenMP parallel
         # region inside a serial loop.
+        kernel_group = KernelGroup()
+        proxy = CppKernelProxy(kernel_group)
+        # Populate `kernels` with a vec kernel so the relocation guard's
+        # `has_scalar_kernel(self)` is intentionally False (the repro's softmax
+        # kernel is vectorized), rather than relying on `kernels` being empty.
+        proxy.kernels = [
+            CppVecKernel(kernel_group.args, 1, tiling_factor=16, tiling_idx=0)
+        ]
         outer = LoopLevel(sympy.Symbol("x0"), sympy.Integer(4)).tile(16)
         reduction = LoopLevel(sympy.Symbol("x1"), sympy.Integer(64))
         reduction.is_reduction = True
-        nest = LoopNest([outer, reduction], CppKernelProxy(KernelGroup()))
+        nest = LoopNest([outer, reduction], proxy)
         depth = nest.max_parallel_depth()
         self.assertEqual(depth.start_depth, 0)
         self.assertEqual(depth.parallel_depth, 1)
+
+    @requires_vectorization
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
+    @config.patch(freezing=True)
+    def test_masked_softmax_freezing_no_parallel_reduction(self):
+        # Fix issue: https://github.com/pytorch/pytorch/issues/190757
+        # End-to-end check of the symptom: under freezing, the shifted-window
+        # masked-softmax reduction was left with a size-4 (num heads) vectorized
+        # outer loop, whose trip count underflowed to 0 and relocated
+        # parallelism onto the inner reduction -- nesting an OpenMP parallel
+        # region inside a serial loop (30-50x slowdown). Assert that parallelism
+        # never lands on a reduction loop.
+        C, WS, SHIFT, NH = 96, 8, 4, 4
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj = torch.nn.Conv2d(1, C, 4, 4)
+                self.gate = torch.nn.Conv2d(C, C, 1)
+                self.ln = torch.nn.LayerNorm(C)
+                self.qkv = torch.nn.Linear(C, 3 * C)
+                self.out = torch.nn.Linear(C, C)
+
+            def forward(self, x):
+                x = F.interpolate(
+                    x, (1024, 64), mode="bicubic", align_corners=True
+                ).reshape(1, 1, 256, 256)
+                g = self.proj(x)
+                x = g * torch.sigmoid(self.gate(g))
+                b, c, h, w = x.shape
+                x = self.ln(x.flatten(2).transpose(1, 2)).view(b, h, w, c)
+                x = torch.roll(x, (-SHIFT, -SHIFT), (1, 2))
+                win = (
+                    x.view(b, h // WS, WS, w // WS, WS, c)
+                    .permute(0, 1, 3, 2, 4, 5)
+                    .reshape(-1, WS * WS, c)
+                )
+                n = win.shape[0]
+                r = (torch.arange(h) >= h - WS).long() + (
+                    torch.arange(h) >= h - SHIFT
+                ).long()
+                reg = (
+                    (r[:, None] * 3 + r[None, :])
+                    .view(h // WS, WS, w // WS, WS)
+                    .permute(0, 2, 1, 3)
+                    .reshape(-1, WS * WS)
+                )
+                mask = (
+                    (reg.unsqueeze(1) - reg.unsqueeze(2))
+                    .to(x.dtype)
+                    .masked_fill_(reg.unsqueeze(1) != reg.unsqueeze(2), -100.0)
+                )
+                q, k, v = (
+                    self.qkv(win)
+                    .view(n, WS * WS, 3, NH, c // NH)
+                    .permute(2, 0, 3, 1, 4)
+                )
+                s = q @ k.transpose(-1, -2) / math.sqrt(c // NH)
+                s = (
+                    s.view(1, n, NH, WS * WS, WS * WS)
+                    + mask.unsqueeze(1).unsqueeze(0)
+                ).view(-1, NH, WS * WS, WS * WS)
+                o = (s.softmax(-1) @ v).transpose(1, 2).reshape(n, WS * WS, c)
+                return self.out(o)
+
+        mod = Model().eval()
+        x = torch.randn(1, 1, 1001, 64)
+        with torch.no_grad():
+            metrics.reset()
+            expected = mod(x)
+            compiled_m = torch.compile(mod)
+            actual = compiled_m(x)
+            self.assertEqual(expected, actual, atol=1e-3, rtol=1e-3)
+            self.assertEqual(metrics.parallel_reduction_count, 0)
 
     def test_cat_mul(self):
         # https://github.com/pytorch/pytorch/issues/93365

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1439,6 +1439,91 @@ class CPUReproTests(TestCase):
             # for parallel reduction.
             self.common(mod, (x, weight), atol=5e-1, rtol=5e-1)
 
+    @requires_vectorization
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
+    @config.patch(freezing=True)
+    def test_parallel_reduction_not_nested_in_loop(self):
+        # Fix issue: https://github.com/pytorch/pytorch/issues/190757
+        # Under freezing, the channels-last layout propagated from the conv /
+        # linear rewrites leaves the shifted-window masked-softmax reduction with
+        # a small (size-4, the number of attention heads) vectorized outer loop.
+        # The outer-work estimate in LoopNest.max_parallel_depth used to underflow
+        # to 0 (FloorDiv(4, vec_width)), so parallelism was relocated onto the
+        # inner reduction, emitting an OpenMP parallel region *inside* a serial
+        # loop that re-forked the thread pool once per iteration. Make sure no
+        # parallel region is nested inside a loop body.
+        C, WS, SHIFT, NH = 96, 8, 4, 4
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj = torch.nn.Conv2d(1, C, 4, 4)
+                self.gate = torch.nn.Conv2d(C, C, 1)
+                self.ln = torch.nn.LayerNorm(C)
+                self.qkv = torch.nn.Linear(C, 3 * C)
+                self.out = torch.nn.Linear(C, C)
+
+            def forward(self, x):
+                x = F.interpolate(
+                    x, (1024, 64), mode="bicubic", align_corners=True
+                ).reshape(1, 1, 256, 256)
+                g = self.proj(x)
+                x = g * torch.sigmoid(self.gate(g))
+                b, c, h, w = x.shape
+                x = self.ln(x.flatten(2).transpose(1, 2)).view(b, h, w, c)
+                x = torch.roll(x, (-SHIFT, -SHIFT), (1, 2))
+                win = (
+                    x.view(b, h // WS, WS, w // WS, WS, c)
+                    .permute(0, 1, 3, 2, 4, 5)
+                    .reshape(-1, WS * WS, c)
+                )
+                n = win.shape[0]
+                r = (torch.arange(h) >= h - WS).long() + (
+                    torch.arange(h) >= h - SHIFT
+                ).long()
+                reg = (
+                    (r[:, None] * 3 + r[None, :])
+                    .view(h // WS, WS, w // WS, WS)
+                    .permute(0, 2, 1, 3)
+                    .reshape(-1, WS * WS)
+                )
+                mask = (
+                    (reg.unsqueeze(1) - reg.unsqueeze(2))
+                    .to(x.dtype)
+                    .masked_fill_(reg.unsqueeze(1) != reg.unsqueeze(2), -100.0)
+                )
+                q, k, v = (
+                    self.qkv(win)
+                    .view(n, WS * WS, 3, NH, c // NH)
+                    .permute(2, 0, 3, 1, 4)
+                )
+                s = q @ k.transpose(-1, -2) / math.sqrt(c // NH)
+                s = (
+                    s.view(1, n, NH, WS * WS, WS * WS) + mask.unsqueeze(1).unsqueeze(0)
+                ).view(-1, NH, WS * WS, WS * WS)
+                o = (s.softmax(-1) @ v).transpose(1, 2).reshape(n, WS * WS, c)
+                return self.out(o)
+
+        mod = Model().eval()
+        x = torch.randn(1, 1, 1001, 64)
+        with torch.no_grad():
+            expected = mod(x)
+            compiled_m = torch.compile(mod)
+            actual, code = run_and_get_cpp_code(compiled_m, x)
+            self.assertEqual(expected, actual, atol=1e-3, rtol=1e-3)
+            # An OpenMP parallel region must never be opened inside a loop body:
+            # doing so re-forks the thread pool on every iteration. Every
+            # `#pragma omp parallel` should be hoisted to the top of its kernel
+            # (i.e. at the kernel body indentation level, not nested in loops).
+            for line in code.splitlines():
+                if "#pragma omp parallel" in line:
+                    indent = len(line) - len(line.lstrip())
+                    self.assertLessEqual(
+                        indent,
+                        4,
+                        msg=f"OpenMP parallel region nested inside a loop: {line!r}",
+                    )
+
     def test_cat_mul(self):
         # https://github.com/pytorch/pytorch/issues/93365
         def fn(p0, p1):

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -23,6 +23,7 @@ from torch._inductor import config, cpu_vec_isa, metrics, test_operators
 from torch._inductor.codegen.cpp import (
     CppKernelProxy,
     CppOverrides,
+    CppVecKernel,
     CppVecOverrides,
     KernelGroup,
     LoopLevel,
@@ -1448,19 +1449,102 @@ class CPUReproTests(TestCase):
             # for parallel reduction.
             self.common(mod, (x, weight), atol=5e-1, rtol=5e-1)
 
+    @requires_vectorization
     def test_max_parallel_depth_sub_vector_width_loop(self):
         # Fix issue: https://github.com/pytorch/pytorch/issues/190757
         # A vectorized loop smaller than the vector width runs 1 iteration, not
         # 0. Counting it as 0 zeroed the outer-work estimate and relocated
         # parallelism onto the inner reduction, nesting an OpenMP parallel
         # region inside a serial loop.
+        kernel_group = KernelGroup()
+        proxy = CppKernelProxy(kernel_group)
+        # Populate `kernels` with a vec kernel so the relocation guard's
+        # `has_scalar_kernel(self)` is intentionally False (the repro's softmax
+        # kernel is vectorized), rather than relying on `kernels` being empty.
+        proxy.kernels = [
+            CppVecKernel(kernel_group.args, 1, tiling_factor=16, tiling_idx=0)
+        ]
         outer = LoopLevel(sympy.Symbol("x0"), sympy.Integer(4)).tile(16)
         reduction = LoopLevel(sympy.Symbol("x1"), sympy.Integer(64))
         reduction.is_reduction = True
-        nest = LoopNest([outer, reduction], CppKernelProxy(KernelGroup()))
+        nest = LoopNest([outer, reduction], proxy)
         depth = nest.max_parallel_depth()
         self.assertEqual(depth.start_depth, 0)
         self.assertEqual(depth.parallel_depth, 1)
+
+    @requires_vectorization
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
+    @config.patch(freezing=True)
+    def test_masked_softmax_freezing_no_parallel_reduction(self):
+        # Fix issue: https://github.com/pytorch/pytorch/issues/190757
+        # End-to-end check of the symptom: under freezing, the shifted-window
+        # masked-softmax reduction was left with a size-4 (num heads) vectorized
+        # outer loop, whose trip count underflowed to 0 and relocated
+        # parallelism onto the inner reduction -- nesting an OpenMP parallel
+        # region inside a serial loop (30-50x slowdown). Assert that parallelism
+        # never lands on a reduction loop.
+        C, WS, SHIFT, NH = 96, 8, 4, 4
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj = torch.nn.Conv2d(1, C, 4, 4)
+                self.gate = torch.nn.Conv2d(C, C, 1)
+                self.ln = torch.nn.LayerNorm(C)
+                self.qkv = torch.nn.Linear(C, 3 * C)
+                self.out = torch.nn.Linear(C, C)
+
+            def forward(self, x):
+                x = F.interpolate(
+                    x, (1024, 64), mode="bicubic", align_corners=True
+                ).reshape(1, 1, 256, 256)
+                g = self.proj(x)
+                x = g * torch.sigmoid(self.gate(g))
+                b, c, h, w = x.shape
+                x = self.ln(x.flatten(2).transpose(1, 2)).view(b, h, w, c)
+                x = torch.roll(x, (-SHIFT, -SHIFT), (1, 2))
+                win = (
+                    x.view(b, h // WS, WS, w // WS, WS, c)
+                    .permute(0, 1, 3, 2, 4, 5)
+                    .reshape(-1, WS * WS, c)
+                )
+                n = win.shape[0]
+                r = (torch.arange(h) >= h - WS).long() + (
+                    torch.arange(h) >= h - SHIFT
+                ).long()
+                reg = (
+                    (r[:, None] * 3 + r[None, :])
+                    .view(h // WS, WS, w // WS, WS)
+                    .permute(0, 2, 1, 3)
+                    .reshape(-1, WS * WS)
+                )
+                mask = (
+                    (reg.unsqueeze(1) - reg.unsqueeze(2))
+                    .to(x.dtype)
+                    .masked_fill_(reg.unsqueeze(1) != reg.unsqueeze(2), -100.0)
+                )
+                q, k, v = (
+                    self.qkv(win)
+                    .view(n, WS * WS, 3, NH, c // NH)
+                    .permute(2, 0, 3, 1, 4)
+                )
+                s = q @ k.transpose(-1, -2) / math.sqrt(c // NH)
+                s = (
+                    s.view(1, n, NH, WS * WS, WS * WS)
+                    + mask.unsqueeze(1).unsqueeze(0)
+                ).view(-1, NH, WS * WS, WS * WS)
+                o = (s.softmax(-1) @ v).transpose(1, 2).reshape(n, WS * WS, c)
+                return self.out(o)
+
+        mod = Model().eval()
+        x = torch.randn(1, 1, 1001, 64)
+        with torch.no_grad():
+            metrics.reset()
+            expected = mod(x)
+            compiled_m = torch.compile(mod)
+            actual = compiled_m(x)
+            self.assertEqual(expected, actual, atol=1e-3, rtol=1e-3)
+            self.assertEqual(metrics.parallel_reduction_count, 0)
 
     def test_cat_mul(self):
         # https://github.com/pytorch/pytorch/issues/93365

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -12,13 +12,21 @@ import unittest
 from collections.abc import Callable
 from unittest.mock import patch
 
+import sympy
 import torch
 from torch import nn
 from torch._C import FileCheck
 from torch._dynamo.testing import rand_strided
 from torch._dynamo.utils import same
 from torch._inductor import config, cpu_vec_isa, metrics, test_operators
-from torch._inductor.codegen.cpp import CppOverrides, CppVecOverrides
+from torch._inductor.codegen.cpp import (
+    CppKernelProxy,
+    CppOverrides,
+    CppVecOverrides,
+    KernelGroup,
+    LoopLevel,
+    LoopNest,
+)
 from torch._inductor.compile_fx import compile_fx, compile_fx_inner
 from torch._inductor.exc import InductorError
 from torch._inductor.graph import GraphLowering
@@ -1439,90 +1447,19 @@ class CPUReproTests(TestCase):
             # for parallel reduction.
             self.common(mod, (x, weight), atol=5e-1, rtol=5e-1)
 
-    @requires_vectorization
-    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
-    @config.patch(freezing=True)
-    def test_parallel_reduction_not_nested_in_loop(self):
+    def test_max_parallel_depth_sub_vector_width_loop(self):
         # Fix issue: https://github.com/pytorch/pytorch/issues/190757
-        # Under freezing, the channels-last layout propagated from the conv /
-        # linear rewrites leaves the shifted-window masked-softmax reduction with
-        # a small (size-4, the number of attention heads) vectorized outer loop.
-        # The outer-work estimate in LoopNest.max_parallel_depth used to underflow
-        # to 0 (FloorDiv(4, vec_width)), so parallelism was relocated onto the
-        # inner reduction, emitting an OpenMP parallel region *inside* a serial
-        # loop that re-forked the thread pool once per iteration. Make sure no
-        # parallel region is nested inside a loop body.
-        C, WS, SHIFT, NH = 96, 8, 4, 4
-
-        class Model(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.proj = torch.nn.Conv2d(1, C, 4, 4)
-                self.gate = torch.nn.Conv2d(C, C, 1)
-                self.ln = torch.nn.LayerNorm(C)
-                self.qkv = torch.nn.Linear(C, 3 * C)
-                self.out = torch.nn.Linear(C, C)
-
-            def forward(self, x):
-                x = F.interpolate(
-                    x, (1024, 64), mode="bicubic", align_corners=True
-                ).reshape(1, 1, 256, 256)
-                g = self.proj(x)
-                x = g * torch.sigmoid(self.gate(g))
-                b, c, h, w = x.shape
-                x = self.ln(x.flatten(2).transpose(1, 2)).view(b, h, w, c)
-                x = torch.roll(x, (-SHIFT, -SHIFT), (1, 2))
-                win = (
-                    x.view(b, h // WS, WS, w // WS, WS, c)
-                    .permute(0, 1, 3, 2, 4, 5)
-                    .reshape(-1, WS * WS, c)
-                )
-                n = win.shape[0]
-                r = (torch.arange(h) >= h - WS).long() + (
-                    torch.arange(h) >= h - SHIFT
-                ).long()
-                reg = (
-                    (r[:, None] * 3 + r[None, :])
-                    .view(h // WS, WS, w // WS, WS)
-                    .permute(0, 2, 1, 3)
-                    .reshape(-1, WS * WS)
-                )
-                mask = (
-                    (reg.unsqueeze(1) - reg.unsqueeze(2))
-                    .to(x.dtype)
-                    .masked_fill_(reg.unsqueeze(1) != reg.unsqueeze(2), -100.0)
-                )
-                q, k, v = (
-                    self.qkv(win)
-                    .view(n, WS * WS, 3, NH, c // NH)
-                    .permute(2, 0, 3, 1, 4)
-                )
-                s = q @ k.transpose(-1, -2) / math.sqrt(c // NH)
-                s = (
-                    s.view(1, n, NH, WS * WS, WS * WS) + mask.unsqueeze(1).unsqueeze(0)
-                ).view(-1, NH, WS * WS, WS * WS)
-                o = (s.softmax(-1) @ v).transpose(1, 2).reshape(n, WS * WS, c)
-                return self.out(o)
-
-        mod = Model().eval()
-        x = torch.randn(1, 1, 1001, 64)
-        with torch.no_grad():
-            expected = mod(x)
-            compiled_m = torch.compile(mod)
-            actual, code = run_and_get_cpp_code(compiled_m, x)
-            self.assertEqual(expected, actual, atol=1e-3, rtol=1e-3)
-            # An OpenMP parallel region must never be opened inside a loop body:
-            # doing so re-forks the thread pool on every iteration. Every
-            # `#pragma omp parallel` should be hoisted to the top of its kernel
-            # (i.e. at the kernel body indentation level, not nested in loops).
-            for line in code.splitlines():
-                if "#pragma omp parallel" in line:
-                    indent = len(line) - len(line.lstrip())
-                    self.assertLessEqual(
-                        indent,
-                        4,
-                        msg=f"OpenMP parallel region nested inside a loop: {line!r}",
-                    )
+        # A vectorized loop smaller than the vector width runs 1 iteration, not
+        # 0. Counting it as 0 zeroed the outer-work estimate and relocated
+        # parallelism onto the inner reduction, nesting an OpenMP parallel
+        # region inside a serial loop.
+        outer = LoopLevel(sympy.Symbol("x0"), sympy.Integer(4)).tile(16)
+        reduction = LoopLevel(sympy.Symbol("x1"), sympy.Integer(64))
+        reduction.is_reduction = True
+        nest = LoopNest([outer, reduction], CppKernelProxy(KernelGroup()))
+        depth = nest.max_parallel_depth()
+        self.assertEqual(depth.start_depth, 0)
+        self.assertEqual(depth.parallel_depth, 1)
 
     def test_cat_mul(self):
         # https://github.com/pytorch/pytorch/issues/93365

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -20,7 +20,7 @@ import torch.fx
 from torch._inductor import dependencies
 from torch._prims_common import is_float_dtype, is_integer_dtype
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._sympy.functions import CeilDiv, FloorDiv, ModularIndexing
+from torch.utils._sympy.functions import CeilDiv, FloorDiv, Max, ModularIndexing
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
 
 from ..._dynamo.utils import counters
@@ -6388,7 +6388,9 @@ class LoopNest:
         for loop in self.loops:
             if loop.is_reduction != is_reduction:
                 break
-            num_steps = num_steps * FloorDiv(loop.size, loop.steps)
+            # num_steps == 0 would make the heuristic below think there is no outer
+            # work and wrongly move parallelism onto an inner reduction loop.
+            num_steps = num_steps * Max(1, FloorDiv(loop.size, loop.steps))
             max_depth += 1
 
         def get_simd_vec_depth(loops):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -20,7 +20,7 @@ import torch.fx
 from torch._inductor import dependencies
 from torch._prims_common import is_float_dtype, is_integer_dtype
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._sympy.functions import CeilDiv, FloorDiv, Max, ModularIndexing
+from torch.utils._sympy.functions import CeilDiv, FloorDiv, ModularIndexing
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
 
 from ..._dynamo.utils import counters
@@ -6388,9 +6388,9 @@ class LoopNest:
         for loop in self.loops:
             if loop.is_reduction != is_reduction:
                 break
-            # num_steps == 0 would make the heuristic below think there is no outer
-            # work and wrongly move parallelism onto an inner reduction loop.
-            num_steps = num_steps * Max(1, FloorDiv(loop.size, loop.steps))
+            # Use CeilDiv to prevent zeroing the whole product and making the 
+            # heuristic below think there is no outer work.
+            num_steps = num_steps * CeilDiv(loop.size, loop.steps)
             max_depth += 1
 
         def get_simd_vec_depth(loops):
@@ -6419,7 +6419,7 @@ class LoopNest:
             and isinstance(num_steps, sympy.Integer)
             and isinstance(self.loops[max_depth].size, sympy.Integer)
             and num_steps * 300
-            < FloorDiv(self.loops[max_depth].size, self.loops[max_depth].steps)
+            < CeilDiv(self.loops[max_depth].size, self.loops[max_depth].steps)
             and not (
                 # Disable parallel reduction under the vec loop
                 simd_vec_depth is not None

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -6388,7 +6388,7 @@ class LoopNest:
         for loop in self.loops:
             if loop.is_reduction != is_reduction:
                 break
-            # Use CeilDiv to prevent zeroing the whole product and making the 
+            # Use CeilDiv to prevent zeroing the whole product and making the
             # heuristic below think there is no outer work.
             num_steps = num_steps * CeilDiv(loop.size, loop.steps)
             max_depth += 1

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -6388,8 +6388,11 @@ class LoopNest:
         for loop in self.loops:
             if loop.is_reduction != is_reduction:
                 break
-            # Use CeilDiv to prevent zeroing the whole product and making the
-            # heuristic below think there is no outer work.
+            # Trip count of `for (var = 0; var < size; var += steps)`. The bound
+            # is `size` and the increment is `steps`, so a loop with size < steps
+            # (a vectorized loop narrower than the vector width) still runs one
+            # iteration. Use CeilDiv, not FloorDiv, which would count 0 and zero
+            # out the whole product.
             num_steps = num_steps * CeilDiv(loop.size, loop.steps)
             max_depth += 1
 
@@ -6419,7 +6422,7 @@ class LoopNest:
             and isinstance(num_steps, sympy.Integer)
             and isinstance(self.loops[max_depth].size, sympy.Integer)
             and num_steps * 300
-            < CeilDiv(self.loops[max_depth].size, self.loops[max_depth].steps)
+            < FloorDiv(self.loops[max_depth].size, self.loops[max_depth].steps)
             and not (
                 # Disable parallel reduction under the vec loop
                 simd_vec_depth is not None

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -20,7 +20,7 @@ import torch.fx
 from torch._inductor import dependencies
 from torch._prims_common import is_float_dtype, is_integer_dtype
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._sympy.functions import CeilDiv, FloorDiv, Max, ModularIndexing
+from torch.utils._sympy.functions import CeilDiv, FloorDiv, ModularIndexing
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
 
 from ..._dynamo.utils import counters
@@ -6381,9 +6381,9 @@ class LoopNest:
         for loop in self.loops:
             if loop.is_reduction != is_reduction:
                 break
-            # num_steps == 0 would make the heuristic below think there is no outer
-            # work and wrongly move parallelism onto an inner reduction loop.
-            num_steps = num_steps * Max(1, FloorDiv(loop.size, loop.steps))
+            # Use CeilDiv to prevent zeroing the whole product and making the 
+            # heuristic below think there is no outer work.
+            num_steps = num_steps * CeilDiv(loop.size, loop.steps)
             max_depth += 1
 
         def get_simd_vec_depth(loops):
@@ -6412,7 +6412,7 @@ class LoopNest:
             and isinstance(num_steps, sympy.Integer)
             and isinstance(self.loops[max_depth].size, sympy.Integer)
             and num_steps * 300
-            < FloorDiv(self.loops[max_depth].size, self.loops[max_depth].steps)
+            < CeilDiv(self.loops[max_depth].size, self.loops[max_depth].steps)
             and not (
                 # Disable parallel reduction under the vec loop
                 simd_vec_depth is not None

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -20,7 +20,7 @@ import torch.fx
 from torch._inductor import dependencies
 from torch._prims_common import is_float_dtype, is_integer_dtype
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._sympy.functions import CeilDiv, FloorDiv, ModularIndexing
+from torch.utils._sympy.functions import CeilDiv, FloorDiv, Max, ModularIndexing
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
 
 from ..._dynamo.utils import counters
@@ -6381,7 +6381,9 @@ class LoopNest:
         for loop in self.loops:
             if loop.is_reduction != is_reduction:
                 break
-            num_steps = num_steps * FloorDiv(loop.size, loop.steps)
+            # num_steps == 0 would make the heuristic below think there is no outer
+            # work and wrongly move parallelism onto an inner reduction loop.
+            num_steps = num_steps * Max(1, FloorDiv(loop.size, loop.steps))
             max_depth += 1
 
         def get_simd_vec_depth(loops):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -6381,7 +6381,7 @@ class LoopNest:
         for loop in self.loops:
             if loop.is_reduction != is_reduction:
                 break
-            # Use CeilDiv to prevent zeroing the whole product and making the 
+            # Use CeilDiv to prevent zeroing the whole product and making the
             # heuristic below think there is no outer work.
             num_steps = num_steps * CeilDiv(loop.size, loop.steps)
             max_depth += 1

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -6381,8 +6381,11 @@ class LoopNest:
         for loop in self.loops:
             if loop.is_reduction != is_reduction:
                 break
-            # Use CeilDiv to prevent zeroing the whole product and making the
-            # heuristic below think there is no outer work.
+            # Trip count of `for (var = 0; var < size; var += steps)`. The bound
+            # is `size` and the increment is `steps`, so a loop with size < steps
+            # (a vectorized loop narrower than the vector width) still runs one
+            # iteration. Use CeilDiv, not FloorDiv, which would count 0 and zero
+            # out the whole product.
             num_steps = num_steps * CeilDiv(loop.size, loop.steps)
             max_depth += 1
 
@@ -6412,7 +6415,7 @@ class LoopNest:
             and isinstance(num_steps, sympy.Integer)
             and isinstance(self.loops[max_depth].size, sympy.Integer)
             and num_steps * 300
-            < CeilDiv(self.loops[max_depth].size, self.loops[max_depth].steps)
+            < FloorDiv(self.loops[max_depth].size, self.loops[max_depth].steps)
             and not (
                 # Disable parallel reduction under the vec loop
                 simd_vec_depth is not None


### PR DESCRIPTION
Fixes #190757

LoopNest.max_parallel_depth decides whether to relocate parallelism from the outer loops onto an inner reduction loop by comparing the outer loops' work against the inner loop size. The outer-work estimate multiplies `FloorDiv(loop.size, loop.steps)` over the leading loops. When an outer loop is vectorized and its size is smaller than the vector step (e.g. size=4, steps=16 for a float SIMD width of 16), `FloorDiv(4, 16) == 0` zeroes the entire product. The heuristic then concludes the outer loops have ~0 work and moves parallelism onto the reduction, emitting a #pragma omp parallel region inside a serial outer loop — re-forking the thread pool on every iteration.

This changes `FloorDiv` to `CeilDiv` so a sub-vector-width loop contributes 1 iteration rather than underflowing to 0.

# Motivation
A model with `F.interpolate` to a tall/asymmetric shape + a conv patch-embed with a sigmoid gate + one shifted-window masked-attention layer regresses ~30-50x when compiled with `TORCHINDUCTOR_FREEZING=1` versus plain torch.compile, across different data types.

Root cause: freezing propagates a channels-last / head-innermost layout (from the mkldnn conv/linear rewrites) into the attention block, leaving the softmax reduction with a size-4 (num-heads) vectorized outer loop. The heuristic above then parallelized the 64-element reduction inside a serial 4096-iteration loop, so the kernel re-forked a 72-thread team ~4096× per call.

# Result
On the reporter's target model (freezing, 72 threads):
| *Time (ms)* | Eager | Compile | Compile+Freezing | Compile+Freezing+(This PR)
|--------|--------|--------|--------|---------|
| Small Repro | 2.07 | 1.37 | 82.87 | 0.95 |
| Full Model | 82.87 | 62.97 | 149.91 | 60.87 |

<details>
  <summary>Small Repro</summary>

```python
import math, os, sys, time
import torch
import torch.nn as nn
import torch.nn.functional as F

torch.manual_seed(0)
C, WS, SHIFT, NH = 96, 8, 4, 4


class Net(nn.Module):
    def __init__(self):
        super().__init__()
        self.proj = nn.Conv2d(1, C, 4, 4)
        self.gate = nn.Conv2d(C, C, 1)
        self.ln = nn.LayerNorm(C)
        self.qkv = nn.Linear(C, 3 * C)
        self.out = nn.Linear(C, C)

    def forward(self, x):
        x = F.interpolate(x, (1024, 64), mode="bicubic", align_corners=True).reshape(1, 1, 256, 256)
        g = self.proj(x)
        x = g * torch.sigmoid(self.gate(g))
        b, c, h, w = x.shape
        x = self.ln(x.flatten(2).transpose(1, 2)).view(b, h, w, c)
        x = torch.roll(x, (-SHIFT, -SHIFT), (1, 2))
        win = x.view(b, h // WS, WS, w // WS, WS, c).permute(0, 1, 3, 2, 4, 5).reshape(-1, WS * WS, c)
        n = win.shape[0]
        r = (torch.arange(h) >= h - WS).long() + (torch.arange(h) >= h - SHIFT).long()
        reg = (r[:, None] * 3 + r[None, :]).view(h // WS, WS, w // WS, WS).permute(0, 2, 1, 3).reshape(-1, WS * WS)
        mask = (reg.unsqueeze(1) - reg.unsqueeze(2)).half().masked_fill_(reg.unsqueeze(1) != reg.unsqueeze(2), -100.0)
        q, k, v = self.qkv(win).view(n, WS * WS, 3, NH, c // NH).permute(2, 0, 3, 1, 4)
        s = q @ k.transpose(-1, -2) / math.sqrt(c // NH)
        s = (s.view(1, n, NH, WS * WS, WS * WS) + mask.unsqueeze(1).unsqueeze(0)).view(-1, NH, WS * WS, WS * WS)
        o = (s.softmax(-1) @ v).transpose(1, 2).reshape(n, WS * WS, c)
        return self.out(o)


def bench(m, x, n=30):
    with torch.inference_mode():
        for _ in range(10):
            m(x)
        ts = []
        for _ in range(n):
            s = time.time()
            m(x)
            ts.append((time.time() - s) * 1000)
    return sorted(ts)[n // 2]


x = torch.randn(1, 1, 1001, 64, dtype=torch.float16)
m = Net().eval().to(torch.float16)
mode = sys.argv[1] if len(sys.argv) > 1 else "eager"
if mode == "compile":
    m.forward = torch.compile(m.forward, backend="inductor")
tag = "eager" if mode != "compile" else ("compile+freeze" if os.environ.get("TORCHINDUCTOR_FREEZING") == "1" else "compile")
print(f"{tag:16s} median={bench(m, x):.2f}ms")
```

</details>

<details>
  <summary>Full Model</summary>

```python
import os, sys, time, torch
from transformers import ClapModel

torch.manual_seed(0)
audio = ClapModel.from_pretrained("laion/clap-htsat-fused", dtype=torch.float16).eval().audio_model
inputs = dict(
    input_features=torch.randn(1, 4, 1001, 64, dtype=torch.float16),
    is_longer=torch.ones(1, 1, dtype=torch.bool),
)

if len(sys.argv) > 1 and sys.argv[1] == "compile":
    audio.forward = torch.compile(audio.forward, backend="inductor")

with torch.inference_mode():
    for _ in range(10):
        audio(**inputs)
    ts = []
    for _ in range(30):
        s = time.time()
        audio(**inputs)
        ts.append((time.time() - s) * 1000)

tag = "eager" if len(sys.argv) < 2 else ("compile+freeze" if os.environ.get("TORCHINDUCTOR_FREEZING") == "1" else "compile")
print(f"{tag:16s} median={sorted(ts)[15]:.2f}ms")
```

</details>

# Test
Adds `test_parallel_reduction_not_nested_in_loop` to `test/inductor/test_cpu_repro.py`, which compiles the pattern under `config.patch(freezing=True)` and asserts no #pragma omp parallel region is nested inside a loop body. Verified it fails without the fix and passes with it; the existing reduction/tiling/vec/parallel-reduction tests continue to pass (66 passed / 2 skipped).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo