### PR TITLE
[caffe2][miniz] Guard WIN32_LEAN_AND_MEAN redefinition (clang17 -Wmacro-redefined) (#190929)

### DIFF
--- a/third_party/miniz-3.0.2/miniz.c
+++ b/third_party/miniz-3.0.2/miniz.c
@@ -3134,7 +3134,9 @@ extern "C" {
 
 #if defined(_MSC_VER) || defined(__MINGW64__)
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #include <share.h>
 


### PR DESCRIPTION
Summary:

Under the Windows clang 15 -> 17 switch (D110606117), clang17's
`-Wmacro-redefined -Werror` errors because the build command line already
defines `WIN32_LEAN_AND_MEAN=1`, and vendored `miniz.c` unconditionally
re-`#define`s it (to empty) inside its MSVC block.

Guard the definition with `#ifndef WIN32_LEAN_AND_MEAN` so miniz defers to
the command-line definition when present. This unblocks the arfx
body-tracking Windows targets. No `-Wno-error`.

Test Plan: Windows CI on this diff (arfx SparkVisionBodyTracking*Windows).

Reviewed By: francoiscoulombe

Differential Revision: D113427022


