### PR TITLE
[MPS] Fix uniform upper-bound rounding

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Distributions.metal
+++ b/aten/src/ATen/native/mps/kernels/Distributions.metal
@@ -103,23 +103,30 @@ kernel void exponential(
   }
 }
 
+template <typename T>
+struct UniformParams {
+  T from;
+  T to;
+};
+
 // Uniform[from, to). One Philox round per 4 outputs.
 template <typename T>
 kernel void uniform_dist(
     device T* output [[buffer(0)]],
-    constant float2& params [[buffer(1)]],
+    constant UniformParams<T>& params [[buffer(1)]],
     constant long2& seed_base_offset [[buffer(2)]],
     constant uint& numel [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
   uint base = tid * 4;
   uint4 raw =
       c10::metal::philox4::rand(seed_base_offset.x, seed_base_offset.y + tid);
-  float from = params.x;
-  float scale = params.y - params.x;
+  float from = static_cast<float>(params.from);
+  float scale = static_cast<float>(params.to) - from;
   uint count = min(4u, numel - base);
   for (uint i = 0; i < count; ++i) {
     float u = c10::metal::detail::uint32_to_uniform_float(raw[i]);
-    output[base + i] = static_cast<T>(from + scale * u);
+    T value = static_cast<T>(from + scale * u);
+    output[base + i] = value == params.to ? params.from : value;
   }
 }
 
@@ -214,9 +221,18 @@ REGISTER_OP(geometric, short);
 REGISTER_OP(geometric, char);
 REGISTER_OP(geometric, uchar);
 
-REGISTER_OP(uniform_dist, float);
-REGISTER_OP(uniform_dist, half);
-REGISTER_OP(uniform_dist, bfloat);
+#define REGISTER_UNIFORM_OP(DTYPE)                           \
+  template [[host_name("uniform_dist_" #DTYPE)]] kernel void \
+  uniform_dist<DTYPE>(                                       \
+      device DTYPE*,                                         \
+      constant UniformParams<DTYPE>&,                        \
+      constant long2&,                                       \
+      constant uint&,                                        \
+      uint)
+
+REGISTER_UNIFORM_OP(float);
+REGISTER_UNIFORM_OP(half);
+REGISTER_UNIFORM_OP(bfloat);
 
 REGISTER_OP(normal, float);
 REGISTER_OP(normal, half);

--- a/aten/src/ATen/native/mps/kernels/Distributions.metal
+++ b/aten/src/ATen/native/mps/kernels/Distributions.metal
@@ -103,10 +103,15 @@ kernel void exponential(
   }
 }
 
+// Layout must stay in sync with `UniformParams` in Distributions.mm.
 template <typename T>
 struct UniformParams {
-  T from;
-  T to;
+  float from;
+  float to;
+  // `from` narrowed to T. The kernel can't narrow it itself: the Metal
+  // compiler miscompiles a thread-invariant `static_cast<bfloat>(float)` into
+  // an f32->f16 convert whose bits are then read back as bfloat.
+  T from_t;
 };
 
 // Uniform[from, to). One Philox round per 4 outputs.
@@ -120,13 +125,16 @@ kernel void uniform_dist(
   uint base = tid * 4;
   uint4 raw =
       c10::metal::philox4::rand(seed_base_offset.x, seed_base_offset.y + tid);
-  float from = static_cast<float>(params.from);
-  float scale = static_cast<float>(params.to) - from;
+  float from = params.from;
+  float scale = params.to - params.from;
   uint count = min(4u, numel - base);
   for (uint i = 0; i < count; ++i) {
     float u = c10::metal::detail::uint32_to_uniform_float(raw[i]);
     T value = static_cast<T>(from + scale * u);
-    output[base + i] = value == params.to ? params.from : value;
+    // `u` is drawn from [0, 1), but narrowing to T can round the sample up
+    // onto the exclusive bound; fold those back to `from` like CUDA does.
+    output[base + i] =
+        static_cast<float>(value) >= params.to ? params.from_t : value;
   }
 }
 
@@ -221,6 +229,8 @@ REGISTER_OP(geometric, short);
 REGISTER_OP(geometric, char);
 REGISTER_OP(geometric, uchar);
 
+// `uniform_dist` takes `UniformParams` rather than `float2`, so it can't go
+// through `REGISTER_OP`.
 #define REGISTER_UNIFORM_OP(DTYPE)                           \
   template [[host_name("uniform_dist_" #DTYPE)]] kernel void \
   uniform_dist<DTYPE>(                                       \

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -221,10 +221,19 @@ static void bernoulli_tensor_kernel_mps(const TensorBase& self, const TensorBase
 REGISTER_MPS_DISPATCH(bernoulli_scalar_stub, &bernoulli_scalar_kernel_mps)
 REGISTER_MPS_DISPATCH(bernoulli_tensor_stub, &bernoulli_tensor_kernel_mps)
 
+// Layout must stay in sync with `UniformParams` in kernels/Distributions.metal.
+template <typename T>
+struct UniformParams {
+  float from;
+  float to;
+  T from_t;
+};
+
 static void uniform_kernel_mps(TensorIteratorBase& iter, double from, double to, std::optional<Generator> gen) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, iter.dtype(), "uniform_kernel_mps", [&] {
-    distribution_kernel_mps_impl(
-        iter, std::array<scalar_t, 2>{static_cast<scalar_t>(from), static_cast<scalar_t>(to)}, "uniform_dist", 1, gen);
+    const auto params =
+        UniformParams<scalar_t>{static_cast<float>(from), static_cast<float>(to), static_cast<scalar_t>(from)};
+    distribution_kernel_mps_impl(iter, params, "uniform_dist", 1, gen);
   });
 }
 

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -222,7 +222,10 @@ REGISTER_MPS_DISPATCH(bernoulli_scalar_stub, &bernoulli_scalar_kernel_mps)
 REGISTER_MPS_DISPATCH(bernoulli_tensor_stub, &bernoulli_tensor_kernel_mps)
 
 static void uniform_kernel_mps(TensorIteratorBase& iter, double from, double to, std::optional<Generator> gen) {
-  distribution_kernel_mps_impl(iter, from, to, "uniform_dist", 1, gen);
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, iter.dtype(), "uniform_kernel_mps", [&] {
+    distribution_kernel_mps_impl(
+        iter, std::array<scalar_t, 2>{static_cast<scalar_t>(from), static_cast<scalar_t>(to)}, "uniform_dist", 1, gen);
+  });
 }
 
 static void normal_kernel_mps(const TensorBase& self, double mean, double std, std::optional<Generator> gen) {

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -218,6 +218,15 @@ meta_consistency_out_dtype_mismatch_xfails = {
 class TestCommon(TestCase):
     exact_dtype = True
 
+    @ops(
+        [op for op in op_db if op.name == "uniform"],
+        allowed_dtypes=(torch.float16, torch.bfloat16),
+    )
+    def test_uniform_bounds(self, device, dtype, op):
+        result = op(torch.empty(1_000_000, device=device, dtype=dtype), 0.0, 1.0)
+        self.assertGreaterEqual(result.min().item(), 0.0)
+        self.assertLess(result.max().item(), 1.0)
+
     # Verifies, on teardown, that no OpInfo is still using dynamic dtypes in CI
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #190931

On current main these diverge, i.e. correct is 0
```
import torch
torch.manual_seed(0)
x = torch.rand(1_000_000, dtype=torch.bfloat16, device='mps')
print((x == 1.0).sum().item())
print(torch.log(1 - x).isinf().sum())

x = torch.rand(1_000_000, dtype=torch.bfloat16, device='cpu')
print((x == 1.0).sum().item())
print(torch.log(1 - x).isinf().sum())
```

MPS uniform sampling computed values in float before casting to the output dtype, which meant that for fp16/bf16, that cast could round a value up to the exclusive upper bound. Changes align it to how CUDA does it