### PR TITLE
[TEST] Add hw_classification to test_dtensor_testbase.py

### DIFF
--- a/test/distributed/tensor/test_dtensor_testbase.py
+++ b/test/distributed/tensor/test_dtensor_testbase.py
@@ -4,26 +4,21 @@
 import numpy as np
 
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
 )
 
 
-class DTensorTestBaseUtilCPUTest(DTensorTestBase):
+class DTensorTestBaseUtilTest(DTensorTestBase):
     """
     This class tests if the basic functionalities of DTensorTestBase are
     working as expected on CPU, regardless of the presence of CUDA devices.
     """
 
-    @property
-    def backend(self):
-        return "gloo"
-
-    @property
-    def device_type(self) -> str:
-        return "cpu"
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self):
@@ -46,6 +41,8 @@ class DTensorTestBaseUtilCPUTest(DTensorTestBase):
         # This tests destroy_pg() correctly finishes.
         device_mesh = self.build_device_mesh()  # noqa: F841
 
+
+instantiate_device_type_tests(DTensorTestBaseUtilTest, globals(), only_for=("cpu",))
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Adds `hw_classification` to `DTensorTestBaseUtilTest` in `test/distributed/tensor/test_dtensor_testbase.py` and wires it into `instantiate_device_type_tests()`.

- DTensorTestBaseUtilTest -> ACCELERATOR. Renamed from DTensorTestBaseUtilCPUTest. This is classified as ACCELERATOR as the class extends DTensorTestBase, so setUp() actually spawns real worker processes and @with_comms stands up a genuine gloo process group to test destroy_pg() teardown, that real multi-process/PG behavior is what makes it a distributed test, regardless of the fact that it happens to run on CPU.
- Removed hardcoding of device and backend. Restricted instantiation to CPU (`only_for=("cpu",)`). world_size here is derived from mesh_dim_sizes (2x3x5 = 30), intentionally larger than any real host's accelerator count so the test still exercises the destroy_pg() fix from [DTensor] fix DTensorTestCase.destroy_pg() when device_type is "cpu" but CUDA device is available #161015 (world_size > device_count). Without the only_for restriction, instantiate_device_type_tests also generates a CUDA variant on CUDA-enabled hosts; that variant crashes with `KeyError: 'multi-gpu-30' because TEST_SKIPS only defines multi-gpu-1 through multi-gpu-8`, so init_pg() can't skip gracefully. only_for=("cpu",) avoids generating that variant.

## Test Plan

```bash
python -m pytest test/distributed/tensor/test_dtensor_testbase.py --collect-only -q
# 1 test collected

python -m pytest test/distributed/tensor/test_dtensor_testbase.py --collect-only -q --hw-classification ACCELERATOR
# HW classification mode active (['ACCELERATOR']): total=1, passed=1, unclassified=0, mismatched=0
# 1 test collected

# ACCELERATOR: 1, total: 1, unclassified: 0
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508