### PR TITLE
[docs] Add examples to reduce_scatter documentation

### DIFF
--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -862,7 +862,7 @@ class ShardedTensor(ShardedTensorBase):
         Examples:
             >>> # xdoctest: +SKIP
             >>> # All tensors below are of torch.int64 type.
-            >>> # We have 2 process groups, 2 ranks.
+            >>> # We have 2 ranks.
             >>> tensor = torch.arange(2, dtype=torch.int64) + 1 + 2 * rank
             >>> local_tensor = torch.unsqueeze(torch.cat([tensor, tensor + 2]))
             >>> local_tensor
@@ -1100,7 +1100,7 @@ class ShardedTensor(ShardedTensorBase):
 
         Examples:
             >>> # xdoctest: +SKIP
-            >>> # We have 2 process groups, 2 ranks.
+            >>> # We have 2 ranks.
             >>> tensor = torch.arange(4, dtype=torch.int64) + 1 + 2 * rank
             >>> tensor = torch.stack([tensor, tensor])
             >>> tensor

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3829,7 +3829,7 @@ def all_reduce(
     Examples:
         >>> # xdoctest: +SKIP("no rank")
         >>> # All tensors below are of torch.int64 type.
-        >>> # We have 2 process groups, 2 ranks.
+        >>> # We have 2 ranks.
         >>> device = torch.device(f"cuda:{rank}")
         >>> tensor = torch.arange(2, dtype=torch.int64, device=device) + 1 + 2 * rank
         >>> tensor
@@ -3841,7 +3841,7 @@ def all_reduce(
         tensor([4, 6], device='cuda:1') # Rank 1
 
         >>> # All tensors below are of torch.cfloat type.
-        >>> # We have 2 process groups, 2 ranks.
+        >>> # We have 2 ranks.
         >>> tensor = torch.tensor(
         ...     [1 + 1j, 2 + 2j], dtype=torch.cfloat, device=device
         ... ) + 2 * rank * (1 + 1j)
@@ -4967,7 +4967,7 @@ def all_gather(
     Examples:
         >>> # xdoctest: +SKIP("need process group init")
         >>> # All tensors below are of torch.int64 dtype.
-        >>> # We have 2 process groups, 2 ranks.
+        >>> # We have 2 ranks.
         >>> device = torch.device(f"cuda:{rank}")
         >>> tensor_list = [
         ...     torch.zeros(2, dtype=torch.int64, device=device) for _ in range(2)
@@ -4985,7 +4985,7 @@ def all_gather(
         [tensor([1, 2], device='cuda:1'), tensor([3, 4], device='cuda:1')] # Rank 1
 
         >>> # All tensors below are of torch.cfloat dtype.
-        >>> # We have 2 process groups, 2 ranks.
+        >>> # We have 2 ranks.
         >>> tensor_list = [
         ...     torch.zeros(2, dtype=torch.cfloat, device=device) for _ in range(2)
         ... ]
@@ -5380,7 +5380,7 @@ def gather(
 
     Example::
         >>> # xdoctest: +SKIP("no rank")
-        >>> # We have 2 process groups, 2 ranks.
+        >>> # We have 2 ranks.
         >>> tensor_size = 2
         >>> device = torch.device(f'cuda:{rank}')
         >>> tensor = torch.ones(tensor_size, device=device) + rank
@@ -5748,6 +5748,40 @@ def reduce_scatter(
     Returns:
         Async work handle, if async_op is set to True.
         None, if not async_op or if not part of the group.
+
+    Examples:
+        >>> # xdoctest: +SKIP("need process group init")
+        >>> # All tensors below are of torch.int64 dtype.
+        >>> # We have 2 ranks.
+        >>> device = torch.device(f"cuda:{rank}")
+        >>> tensor_list = [
+        ...     torch.arange(2, dtype=torch.int64, device=device) + 1 + 2 * rank + i * 2
+        ...     for i in range(2)
+        ... ]
+        >>> tensor_list
+        [tensor([1, 2], device='cuda:0'), tensor([3, 4], device='cuda:0')] # Rank 0
+        [tensor([3, 4], device='cuda:1'), tensor([5, 6], device='cuda:1')] # Rank 1
+        >>> output = torch.zeros(2, dtype=torch.int64, device=device)
+        >>> dist.reduce_scatter(output, tensor_list)
+        >>> output
+        tensor([4, 6], device='cuda:0') # Rank 0 (1+3, 2+4)
+        tensor([8, 10], device='cuda:1') # Rank 1 (3+5, 4+6)
+
+        >>> # All tensors below are of torch.cfloat dtype.
+        >>> # We have 2 ranks.
+        >>> tensor_list = [
+        ...     torch.tensor([1 + 1j, 2 + 2j], dtype=torch.cfloat, device=device)
+        ...     + (2 * rank + i * 2) * (1 + 1j)
+        ...     for i in range(2)
+        ... ]
+        >>> tensor_list
+        [tensor([1.+1.j, 2.+2.j], device='cuda:0'), tensor([3.+3.j, 4.+4.j], device='cuda:0')] # Rank 0
+        [tensor([3.+3.j, 4.+4.j], device='cuda:1'), tensor([5.+5.j, 6.+6.j], device='cuda:1')] # Rank 1
+        >>> output = torch.zeros(2, dtype=torch.cfloat, device=device)
+        >>> dist.reduce_scatter(output, tensor_list)
+        >>> output
+        tensor([4.+4.j, 6.+6.j], device='cuda:0') # Rank 0
+        tensor([8.+8.j, 10.+10.j], device='cuda:1') # Rank 1
 
     """
     relevant_args = (output,)

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -181,7 +181,7 @@ def _all_gather_base(output_tensor, input_tensor, group=group.WORLD):
 
     Examples:
         >>> # All tensors below are of torch.int64 dtype.
-        >>> # We have 2 process groups, 2 ranks.
+        >>> # We have 2 ranks.
         >>> # xdoctest: +SKIP("incorrect want text")
         >>> output_tensor = torch.zeros(2, dtype=torch.int64)
         >>> output_tensor


### PR DESCRIPTION
## Summary

Add Examples section to `reduce_scatter` function docstring, matching the format used in `all_gather`. Includes examples for both int64 and complex tensor types demonstrating the reduce-scatter operation across ranks.

Also fix misleading "We have 2 process groups, 2 ranks" comment to "We have 2 ranks" across distributed module docstrings — there is only 1 process group with 2 ranks in these examples.

## Note

Recreated from #178069, which was closed by the stale bot. GitHub would not allow reopening that PR (HTTP 422), so this is a fresh branch rebased onto current `main` with the same content.

Previous history: #173654 → #178069 → this PR.

cc @svekars @sekyondaMeta @AlannaBurke