### PR TITLE
[Inductor] Fix torch.addmm lowering with out_dtype and torch.compile

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19426,13 +19426,44 @@ if RUN_GPU or HAS_MPS:
         def test_addmm_out_dtype_compile(self):
             x = torch.randn(2, 8, device=self.device, dtype=torch.float16)
             w = torch.randn(8, 13, device=self.device, dtype=torch.float16)
-            bias = torch.zeros(13, device=self.device, dtype=torch.float16)
+            bias = torch.randn(13, device=self.device, dtype=torch.float16)
+
+            def eager_fn(bias, x, w):
+                return torch.addmm(bias, x, w, out_dtype=torch.float32)
+
+            eager_result = eager_fn(bias, x, w)
+            compiled_result = torch.compile(eager_fn, fullgraph=True)(bias, x, w)
+            self.assertEqual(compiled_result.dtype, torch.float32)
+            self.assertEqual(compiled_result, eager_result)
+
+        @requires_cuda_and_triton
+        def test_addmm_out_dtype_compile_beta_alpha(self):
+            x = torch.randn(2, 8, device=self.device, dtype=torch.float16)
+            w = torch.randn(8, 13, device=self.device, dtype=torch.float16)
+            bias = torch.randn(13, device=self.device, dtype=torch.float16)
+
+            def fn(bias, x, w, beta, alpha):
+                return torch.addmm(bias, x, w, out_dtype=torch.float32, beta=beta, alpha=alpha)
+
+            for beta, alpha in [(0.5, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 1.0)]:
+                eager_result = fn(bias, x, w, beta, alpha)
+                compiled_result = torch.compile(fn, fullgraph=True)(bias, x, w, beta, alpha)
+                self.assertEqual(compiled_result.dtype, torch.float32)
+                self.assertEqual(compiled_result, eager_result)
+
+        @requires_cuda_and_triton
+        def test_addmm_out_dtype_compile_bf16(self):
+            x = torch.randn(2, 8, device=self.device, dtype=torch.bfloat16)
+            w = torch.randn(8, 13, device=self.device, dtype=torch.bfloat16)
+            bias = torch.randn(13, device=self.device, dtype=torch.bfloat16)
 
             def fn(bias, x, w):
                 return torch.addmm(bias, x, w, out_dtype=torch.float32)
 
-            result = torch.compile(fn, fullgraph=True)(bias, x, w)
-            self.assertEqual(result.dtype, torch.float32)
+            eager_result = fn(bias, x, w)
+            compiled_result = torch.compile(fn, fullgraph=True)(bias, x, w)
+            self.assertEqual(compiled_result.dtype, torch.float32)
+            self.assertEqual(compiled_result, eager_result)
 
     copy_tests(CommonTemplate, GPUTests, GPU_TYPE)
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19422,6 +19422,18 @@ if RUN_GPU or HAS_MPS:
                     ),
                 )
 
+        @requires_cuda_and_triton
+        def test_addmm_out_dtype_compile(self):
+            x = torch.randn(2, 8, device=self.device, dtype=torch.float16)
+            w = torch.randn(8, 13, device=self.device, dtype=torch.float16)
+            bias = torch.zeros(13, device=self.device, dtype=torch.float16)
+
+            def fn(bias, x, w):
+                return torch.addmm(bias, x, w, out_dtype=torch.float32)
+
+            result = torch.compile(fn, fullgraph=True)(bias, x, w)
+            self.assertEqual(result.dtype, torch.float32)
+
     copy_tests(CommonTemplate, GPUTests, GPU_TYPE)
 
 if RUN_TPU:

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -5,7 +5,7 @@ import math
 import operator
 import sys
 from collections.abc import Callable
-from typing import Any, cast, TypeAlias, TypeVar
+from typing import Any, TypeAlias, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -36,11 +36,7 @@ from torch._prims_common import (
     type_to_dtype,
 )
 from torch._refs import native_layer_norm as decomp_native_layer_norm
-from torch.fx.experimental.symbolic_shapes import (
-    guard_or_false,
-    statically_known_true,
-    sym_eq,
-)
+from torch.fx.experimental.symbolic_shapes import guard_or_false, statically_known_true
 
 from . import config, inductor_prims
 from .utils import (
@@ -69,6 +65,8 @@ inductor_decompositions = get_decompositions(
         aten.adaptive_max_pool3d,
         aten.index_select,
         aten.addmv,
+        aten.addmm.dtype,
+        aten.addmm.dtype_out,
         aten.arange,
         aten.bitwise_and_,
         aten.bitwise_or_,
@@ -158,72 +156,6 @@ def register_decomposition(
         if op in decompositions:
             log.warning("duplicate decomp: %s", ops)
     return decomp.register_decomposition(ops, decompositions)
-
-
-if torch.distributed.is_available():
-
-    @register_decomposition([torch.ops._dtensor.shard_dim_alltoall.default])
-    def shard_dim_alltoall_decomp(
-        inp: torch.Tensor,
-        gather_dim: int,
-        shard_dim: int,
-        group_name: str,
-    ) -> torch.Tensor:
-        if not config.decompose_shard_dim_alltoall:
-            return NotImplemented
-        if inp.dtype.is_complex:
-            return NotImplemented
-
-        ndim = inp.dim()
-        gather_dim = gather_dim + ndim if gather_dim < 0 else gather_dim
-        shard_dim = shard_dim + ndim if shard_dim < 0 else shard_dim
-        if not (0 <= gather_dim < ndim and 0 <= shard_dim < ndim):
-            return NotImplemented
-        if gather_dim == shard_dim:
-            return NotImplemented
-
-        try:
-            from torch.distributed.distributed_c10d import (
-                _get_group_size_by_name,
-                GroupName,
-            )
-
-            group_size = _get_group_size_by_name(GroupName(group_name))
-        except (RuntimeError, ValueError):
-            return NotImplemented
-
-        input_shape = list(inp.shape)
-        shard_dim_size = input_shape[shard_dim]
-        # Match eager shard_dim_alltoall semantics. DTensor pads uneven logical
-        # shards before reaching this op, so the local shard dim should split
-        # evenly across the process group here. If the guard fails at runtime,
-        # Dynamo recompiles and may keep the original shard_dim_alltoall fallback.
-        if not guard_or_false(sym_eq(shard_dim_size % group_size, 0)):
-            return NotImplemented
-        local_shard_dim_size = shard_dim_size // group_size
-
-        pre_view_shape = list(input_shape)
-        pre_view_shape[shard_dim] = local_shard_dim_size
-        pre_view_shape.insert(shard_dim, group_size)
-
-        post_view_shape = list(input_shape)
-        post_view_shape[shard_dim] = local_shard_dim_size
-        post_view_shape[gather_dim] = post_view_shape[gather_dim] * group_size
-
-        out = aten.view.default(inp, pre_view_shape)
-        out = aten.movedim.int(out, shard_dim, 0)
-        out = aten.clone.default(out, memory_format=torch.contiguous_format)
-        out = torch.ops._c10d_functional.all_to_all_single.default(
-            out,
-            [1] * group_size,
-            [1] * group_size,
-            group_name,
-        )
-        out = torch.ops._c10d_functional.wait_tensor.default(out)
-        out = aten.movedim.int(out, 0, gather_dim)
-        out = aten.clone.default(out, memory_format=torch.contiguous_format)
-        counters["inductor"]["decompose_shard_dim_alltoall"] += 1
-        return aten.view.default(out, post_view_shape)
 
 
 @register_decomposition([aten.lerp.Scalar])
@@ -453,25 +385,17 @@ def bmm(
     return NotImplemented
 
 
-@register_decomposition([aten.addmm])
+@register_decomposition([aten.addmm.default, aten.addmm.out])
 @pw_cast_for_opmath
 def addmm(
     self: torch.Tensor,
     mat1: torch.Tensor,
     mat2: torch.Tensor,
+    out_dtype: torch.dtype | None = None,
     beta: torch.types.Number = 1,
     alpha: torch.types.Number = 1,
 ) -> torch.Tensor:
-    def add_input(out: torch.Tensor) -> torch.Tensor:
-        if alpha != 1:
-            out = alpha * out
-        if beta != 1:
-            return out + beta * self
-        return out + self
-
     if mat1.device.type not in ["cpu", "mps"]:
-        if beta == 0 and mat1.device.type == "cuda":
-            return NotImplemented
         if (
             statically_known_true(mat1.size(-1) == 1)
             and statically_known_true(mat1.size(0) != 1)
@@ -479,7 +403,7 @@ def addmm(
         ):
             counters["inductor"]["decompose_addmm"] += 1
             out = mat1 * mat2
-            return add_input(out)
+            return alpha * out + beta * self
 
     if self.device.type == "cpu":
         if statically_known_true(mat1.size(0) == 1) and statically_known_true(
@@ -501,38 +425,9 @@ def addmm(
     return NotImplemented
 
 
-def _addmm_dtype(
-    self: torch.Tensor,
-    mat1: torch.Tensor,
-    mat2: torch.Tensor,
-    out_dtype: torch.dtype,
-    beta: torch.types.Number = 1,
-    alpha: torch.types.Number = 1,
-) -> torch.Tensor:
-    out = alpha * torch.mm(mat1, mat2, out_dtype=out_dtype)
-    if beta == 0:
-        return out
-    return out + beta * self.to(out_dtype)
-
-
-def _addmm_dtype_out(
-    self: torch.Tensor,
-    mat1: torch.Tensor,
-    mat2: torch.Tensor,
-    out_dtype: torch.dtype,
-    out: torch.Tensor,
-    beta: torch.types.Number = 1,
-    alpha: torch.types.Number = 1,
-) -> torch.Tensor:
-    result = _addmm_dtype(self, mat1, mat2, out_dtype, beta, alpha)
-    out.copy_(result)
-    return out
-
-
-# Override the existing addmm.dtype entries. The @pw_cast_for_opmath decorator on the
-# aten.addmm decomposition would incorrectly downcast the result when out_dtype is specified.
-decompositions[aten.addmm.dtype] = _addmm_dtype
-decompositions[aten.addmm.dtype_out] = _addmm_dtype_out
+# addmm.dtype and addmm.dtype_out are provided by core's addmm_dtype
+# in torch/_decomp/decompositions.py:1649, picked up via the
+# inductor_decompositions list below.
 
 
 @register_decomposition([aten.mm])
@@ -754,35 +649,6 @@ def fmax(self: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
     return torch.where(torch.isnan(other) | (other < self), self, other)
 
 
-@register_decomposition(prims.normal)
-def normal(
-    shape: list[int | torch.SymInt],
-    *,
-    mean: torch.types.Number,
-    std: torch.types.Number,
-    dtype: torch.dtype,
-    device: torch.device,
-    requires_grad: bool,
-    generator: torch.Generator | None = None,
-) -> torch.Tensor:
-    if generator is None:
-        normal_samples = torch.randn(
-            shape,
-            dtype=dtype,
-            device=device,
-            requires_grad=requires_grad,
-        )
-    else:
-        normal_samples = torch.randn(
-            shape,
-            generator=generator,
-            dtype=dtype,
-            device=device,
-            requires_grad=requires_grad,
-        )
-    return std * normal_samples + mean
-
-
 @register_decomposition(aten.amax)
 def amax(
     self: torch.Tensor,
@@ -877,8 +743,7 @@ def full_like(
         return result.to(memory_format=memory_format)
 
     else:
-        if layout != torch.strided:
-            raise AssertionError(f"expected torch.strided layout, got {layout}")
+        assert layout == torch.strided
         shape, permutation = _get_shape_permutation_like(self)
         result = torch.full(
             shape,
@@ -955,30 +820,6 @@ def randint(
     **kwargs: Any,
 ) -> torch.Tensor:
     return aten.randint.low(0, high, size, **kwargs)
-
-
-@register_decomposition(prims.uniform)
-def uniform(
-    shape: list[int | torch.SymInt],
-    *,
-    low: torch.types.Number,
-    high: torch.types.Number,
-    dtype: torch.dtype,
-    device: torch.device,
-    stride: list[int | torch.SymInt],
-    generator: torch.Generator | None = None,
-) -> torch.Tensor:
-    if generator is None:
-        rand_samples = torch.rand(shape, dtype=dtype, device=device)
-    else:
-        rand_samples = torch.rand(
-            shape, generator=generator, dtype=dtype, device=device
-        )
-    res = (high - low) * rand_samples + low
-
-    if tuple(stride) != utils.make_contiguous_strides_for(cast(list[int], shape)):
-        return res.as_strided(shape, stride)
-    return res
 
 
 @register_decomposition(quantized.linear_dynamic_fp16_unpacked_weight.default)
@@ -1074,75 +915,12 @@ def _foreach_lerp_scalar(
     end_tensors: list[torch.Tensor],
     weight: torch.types.Number,
 ) -> list[torch.Tensor]:
-    def opmath_dtype(t: torch.Tensor) -> torch.dtype:
-        if t.dtype in (torch.float16, torch.bfloat16):
-            return torch.float32
-        return t.dtype
-
-    def cast_weight(dtype: torch.dtype) -> float | complex:
-        if isinstance(weight, complex) and not dtype.is_complex:
-            if weight.imag != 0:
-                return torch.tensor(weight, dtype=dtype).item()
-            return torch.tensor(weight.real, dtype=dtype).item()
-        return torch.tensor(weight, dtype=dtype).item()
-
-    def use_high_formula(dtype: torch.dtype) -> bool:
-        casted_weight = cast_weight(dtype)
-        if isinstance(casted_weight, complex):
-            return (
-                casted_weight.real * casted_weight.real
-                + casted_weight.imag * casted_weight.imag
-                >= 0.25
-            )
-        return casted_weight >= 0.5 or casted_weight <= -0.5
-
-    def scalar_tensor(
-        dtype: torch.dtype, device: torch.device, high_weight: bool
-    ) -> torch.Tensor:
-        if isinstance(weight, complex) and not dtype.is_complex:
-            if weight.imag != 0:
-                weight_tensor = torch.tensor(weight, dtype=dtype, device=device)
-                if high_weight:
-                    return -(1.0 - weight_tensor)
-                return weight_tensor
-            weight_tensor = torch.tensor(weight.real, dtype=dtype, device=device)
-            if high_weight:
-                return -(1.0 - weight_tensor)
-            return weight_tensor
-        weight_tensor = torch.tensor(weight, dtype=dtype, device=device)
-        if high_weight:
-            return -(1.0 - weight_tensor)
-        return weight_tensor
-
-    dtype = start_tensors[0].dtype
-    device = start_tensors[0].device
-    compute_dtype = opmath_dtype(start_tensors[0])
-    use_foreach = dtype not in (torch.float16, torch.bfloat16) and all(
-        t.dtype == dtype and t.device == device for t in start_tensors
+    return aten._foreach_add.List(
+        start_tensors,
+        aten._foreach_mul.Scalar(
+            aten._foreach_sub.List(end_tensors, start_tensors), weight
+        ),
     )
-    if use_foreach:
-        high_weight = use_high_formula(compute_dtype)
-        bases = end_tensors if high_weight else start_tensors
-        diff = aten._foreach_sub.List(end_tensors, start_tensors)
-        scalar = scalar_tensor(dtype, device, high_weight)
-        return aten._foreach_addcmul.Scalar(bases, [scalar] * len(diff), diff)
-
-    return [
-        torch.addcmul(
-            (end if high_weight else t).to(compute_dtype),
-            scalar_tensor(compute_dtype, t.device, high_weight),
-            end.to(compute_dtype) - t.to(compute_dtype),
-        ).to(t.dtype)
-        for t, end, compute_dtype, high_weight in (
-            (
-                t,
-                end,
-                opmath_dtype(t),
-                use_high_formula(opmath_dtype(t)),
-            )
-            for t, end in zip(start_tensors, end_tensors)
-        )
-    ]
 
 
 @register_decomposition(aten._foreach_lerp.ScalarList)
@@ -1507,12 +1285,8 @@ def repeat_interleave_Tensor(
         return NotImplemented
     if repeat.device.type == "mps":
         return NotImplemented
-    if repeat.dtype not in [torch.int32, torch.int64]:
-        raise AssertionError(
-            f"expected repeat dtype int32 or int64, got {repeat.dtype}"
-        )
-    if repeat.ndim != 1:
-        raise AssertionError(f"expected repeat.ndim == 1, got {repeat.ndim}")
+    assert repeat.dtype in [torch.int32, torch.int64]
+    assert repeat.ndim == 1
     cumsum = repeat.cumsum(0)
     pos = torch.arange(output_size, device=repeat.device)
     indices = torch.searchsorted(
@@ -1521,7 +1295,7 @@ def repeat_interleave_Tensor(
     return torch.clamp(indices, max=repeat.size(0) - 1)
 
 
-# intentionally not registered
+# intentionally not regiestered
 def conv1d_to_conv2d(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -1535,8 +1309,9 @@ def conv1d_to_conv2d(
     # input:  (N, C_in, L_in)
     # weight: (C_out, C_in // groups, K)
     # bias:   (C_out,)
-    if not (input.dim() == 3 and weight.dim() == 3):
-        raise AssertionError("Expect (N,C_in,L) and (C_out,C_in//groups,K)")
+    assert input.dim() == 3 and weight.dim() == 3, (
+        "Expect (N,C_in,L) and (C_out,C_in//groups,K)"
+    )
 
     # pyrefly: ignore [bad-assignment]
     stride = stride[0]

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -520,9 +520,9 @@ def _addmm_dtype_out(
     mat1: torch.Tensor,
     mat2: torch.Tensor,
     out_dtype: torch.dtype,
+    out: torch.Tensor,
     beta: torch.types.Number = 1,
     alpha: torch.types.Number = 1,
-    out: torch.Tensor,
 ) -> torch.Tensor:
     result = _addmm_dtype(self, mat1, mat2, out_dtype, beta, alpha)
     out.copy_(result)

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -502,6 +502,40 @@ def addmm(
     return NotImplemented
 
 
+def _addmm_dtype(
+    self: torch.Tensor,
+    mat1: torch.Tensor,
+    mat2: torch.Tensor,
+    out_dtype: torch.dtype,
+    beta: torch.types.Number = 1,
+    alpha: torch.types.Number = 1,
+) -> torch.Tensor:
+    out = alpha * torch.mm(mat1, mat2, out_dtype=out_dtype)
+    if beta == 0:
+        return out
+    return out + beta * self.to(out_dtype)
+
+
+def _addmm_dtype_out(
+    self: torch.Tensor,
+    mat1: torch.Tensor,
+    mat2: torch.Tensor,
+    out_dtype: torch.dtype,
+    beta: torch.types.Number = 1,
+    alpha: torch.types.Number = 1,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    result = _addmm_dtype(self, mat1, mat2, out_dtype, beta, alpha)
+    out.copy_(result)
+    return out
+
+
+# Override the existing addmm.dtype entries. The @pw_cast_for_opmath decorator on the
+# aten.addmm decomposition would incorrectly downcast the result when out_dtype is specified.
+decompositions[aten.addmm.dtype] = _addmm_dtype
+decompositions[aten.addmm.dtype_out] = _addmm_dtype_out
+
+
 @register_decomposition([aten.mm])
 @pw_cast_for_opmath
 def mm(

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -459,7 +459,6 @@ def addmm(
     self: torch.Tensor,
     mat1: torch.Tensor,
     mat2: torch.Tensor,
-    out_dtype: torch.dtype | None = None,
     beta: torch.types.Number = 1,
     alpha: torch.types.Number = 1,
 ) -> torch.Tensor:


### PR DESCRIPTION
aten.addmm.dtype decomposition uses @pw_cast_for_opmath which downcasts the result to the input dtype, overriding the specified out_dtype.

Fix: override the dtype overloads in the decomposition table with dedicated functions that handle out_dtype without pw_cast_for_opmath.

Also adds proper out tensor handling for the addmm.dtype_out overload.

Fixes #163880

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo