### PR TITLE
[WIP][dynamo/AOT] Grad miswiring with aliased inputs under torch.compile (was: [dynamo] Propagate SKIP to child frames on graph-break-in-loop)

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5336,15 +5336,32 @@ class InstructionTranslatorBase(
     def raise_loop_graph_break(
         code: types.CodeType, exc: Unsupported | UserError
     ) -> NoReturn:
-        unimplemented(
-            gb_type="graph break in loop",
-            context=f"frame skipped: {format_frame_info(code)}",
-            explanation="torch.compile detected a graph break in a for/while loop. "
-            "Skipping the frame and falling back to eager, as graph breaks in loops are not supported.",
-            hints=[*graph_break_hints.CAUSED_BY_EARLIER_GRAPH_BREAK],
-            from_exc=exc,
-            skip_frame=True,
-        )
+        # A graph break in a loop forces us to skip THIS frame and run it
+        # eagerly. If we let child frames still be intercepted (the default
+        # FrameExecStrategy(SKIP, DEFAULT)), children (e.g. nn.Module blocks
+        # inside a `for blk in self.blocks:` loop under `module.compile()`)
+        # get compiled independently while their parent runs eager. That
+        # mixed eager-parent / compiled-child execution breaks correctness
+        # for wrappers whose forward/backward hooks assume a single
+        # execution mode per iteration (e.g. FSDP2, which then double-counts
+        # the reduce-scatter). Propagate SKIP recursively for this failure.
+        from .types import FrameAction, FrameExecStrategy
+
+        try:
+            unimplemented(
+                gb_type="graph break in loop",
+                context=f"frame skipped: {format_frame_info(code)}",
+                explanation="torch.compile detected a graph break in a for/while loop. "
+                "Skipping the frame and falling back to eager, as graph breaks in loops are not supported.",
+                hints=[*graph_break_hints.CAUSED_BY_EARLIER_GRAPH_BREAK],
+                from_exc=exc,
+                skip_frame=True,
+            )
+        except Unsupported as new_exc:
+            new_exc.frame_exec_strategy = FrameExecStrategy(
+                FrameAction.SKIP, FrameAction.SKIP
+            )
+            raise
 
     def __init__(
         self,


### PR DESCRIPTION
> **UPDATE 2026-07-24: original diagnosis was wrong.** The real mechanism is a dynamo/AOT-autograd tensor-aliasing miswiring, not a mixed eager-parent / compiled-child FSDP2 double-reduce. This PR's SKIP-recursive patch "fixes" the symptom only by forcing more of the frame graph to eager, which happens to break the aliasing path — it does not address the root cause. Keeping as draft while reworking. See comment below for details. Original body preserved further down for context.

## Status: WIP — needs rework

This PR is being kept as a **draft** while the actual root cause is investigated upstream. The patch here is not the right fix and should not be merged.

## What we now believe the bug is

The minimal repro can be reduced further, dropping FSDP2 and CP entirely. On nightly `2.14.0.dev20260722+cu130`, this 23-line program (`ULTRA_MIN.py`) reproduces the ~2.3x grad-norm inflation under `torch.compile`:

```python
import torch, torch.nn as nn, torch.nn.functional as F
D, S = 512, 512

def _sl(x): return x

class B(nn.Module):
    def __init__(s):
        super().__init__(); s.i = nn.Linear(D, D, bias=False)
    def forward(s, x): return s.i(x)

class M(nn.Module):
    def __init__(s):
        super().__init__()
        s.e = nn.Embedding(D, D)
        s.b = nn.ModuleList([B()])
    def forward(s, tok, tgt):
        h = s.e(_sl(tok.flatten())).view(1, -1, D)
        for blk in s.b:
            h = blk(h)
        return F.cross_entropy(h.reshape(-1, D), _sl(tgt.flatten()), reduction="none")

torch.manual_seed(0)
m = M().cuda()
for p in m.parameters(): p.data.normal_(0, 0.02)
m.compile()
torch.manual_seed(1)
r = ((torch.rand(1, S+1) ** 8) * D).long().cuda()
loss = m(r[:, :-1], r[:, 1:]).float().mean()   # <-- tok and tgt share storage
loss.backward()
print(f"loss={loss.item():.6f} grad e.weight:{m.e.weight.grad.float().norm():.4f}")
```

Cloning the two slices before the call fixes it, bit-for-bit:

```python
tok = r[:, :-1].clone()
tgt = r[:, 1:].clone()
loss = m(tok, tgt).float().mean()
```

Observed:

| Variant              | loss     | grad `e.weight` |
|----------------------|----------|-----------------|
| repro, compile       | 6.242074 | 0.1992  (BUG)   |
| repro, eager         | 6.239221 | 0.0863          |
| clone variant, compile | 6.239221 | 0.0863 (FIXED) |
| clone variant, eager | 6.239221 | 0.0863          |

## The mechanism (evidence)

- `post_backward` fires **exactly once** in the buggy run — the "double-reduce" hypothesis on which the original patch was built is false.
- `RegisterPostBackwardFunction.apply` / `.backward` and `AccumulateGrad` each fire 1x. The compiled backward FX graph is clean: single `mm` per weight, fresh output buffer.
- `tangents_1.norm()` matches eager (0.062440 vs 0.062439), i.e. the loss's own gradient is right.
- But element-wise, the compiled tangent is a **shifted** version of the eager tangent. Recovering the target index sequence from the tangent shows that under `torch.compile`, `F.cross_entropy` receives the **`tok` slice** as its `target=` argument, not the `tgt` slice. The two slice-graph outputs get miswired somewhere in AOTAutograd's input-alias handling.
- `tok = r[:, :-1]` and `tgt = r[:, 1:]` share storage with `r`. Breaking that aliasing with `.clone()` before the call restores correctness. FSDP2 / CP / ModuleList were just ingredients that put dynamo on the codepath where the miswiring happens.

## Where a real fix likely goes

Best guess based on the evidence: `torch/_functorch/_aot_autograd/*` (input-alias handling — deduplication or view-tracking), possibly with a contributing bug in `torch/_dynamo/variables/tensor.py` (how aliasing views are exposed to AOT). This PR's patch to `torch/_dynamo/symbolic_convert.py` (gb7000 recursive-SKIP) is upstream of that codepath and only helps because it forces `M.forward` to run eager end-to-end, which sidesteps the miswiring. That's a workaround at best.

## Temporary user-side mitigation

`.clone()` any input tensor pair that shares storage before calling a compiled module. E.g. in a next-token-prediction loop, clone `tokens[:-1]` and `tokens[1:]` before passing them to the model.

## References

- Umbrella issue: #142358
- Companion PR (also being reworked): #190939 (FSDP2 idempotency guard; its patch has been confirmed to have no effect in isolation, consistent with the new understanding).

---

<details>
<summary>Original PR body (misdiagnosis, kept for context)</summary>

**LLM Statement:** This is in most part the work of my Claude, both the bug diagnostic, the narrowing down to a minimal reprod, the suggestion of a fix, and the body of this PR where done by it.


## Summary

Fixes a silent-correctness bug where `torch.compile` + FSDP2 + a `ModuleList` loop that graph-breaks under `module.compile()` produces gradients that are ~3x too large. The root cause is that `raise_loop_graph_break` (gb7000) raises `Unsupported(skip_frame=True)` without attaching a `frame_exec_strategy`. `ConvertFrameAssert` then falls through to the default `FrameExecStrategy(SKIP, DEFAULT)`, which skips **this** frame but leaves the eval-frame callback active for **child** frames. The children (e.g. `nn.Module` blocks inside a `for blk in self.blocks:` loop) then get compiled independently while their parent runs eager. That mixed eager-parent / compiled-child execution violates the invariants of wrappers whose forward/backward hooks assume a single execution mode per iteration — most notably FSDP2, whose root post-backward callback then fires a second reduce-scatter on top of the AOT-compiled backward's already-reduced grads.

The one-line fix: on the `skip_frame=True` path in `raise_loop_graph_break`, upgrade the strategy to `FrameExecStrategy(SKIP, SKIP)` so child frames are also skipped and the whole subtree runs eager. With this patch, eager and compile produce bit-identical gradients on the repro.

(rest of original body elided — see PR history.)

</details>
