### PR TITLE
[WIP][FSDP2] post_backward idempotency guard — does not fix the underlying AOT-aliasing bug

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -257,6 +257,12 @@ class FSDPParamGroup:
         # Holds the reshard-after-forward CUDA event when resharding to a
         # different world size, which should be waited on in the next unshard
         self._reshard_after_forward_event: torch.Event | None = None
+        # Tracks whether post_backward() has already reduced this iter's
+        # grads. Used to avoid a second reduce-scatter when the root's
+        # queued post_backward_final_callback fires after the AOT-compiled
+        # backward has already performed the reduce (see
+        # https://github.com/pytorch/pytorch/issues/142358 for context).
+        self._already_reduced_this_iter: bool = False
 
         # Only for HSDP, if accumulating gradients without all-reduce, save the
         # partial reduce output (only reduce-scattered but not all-reduced)
@@ -620,6 +626,13 @@ class FSDPParamGroup:
                 and self._training_state == TrainingState.FORWARD  # partial path taken
             )
             self._training_state = TrainingState.POST_BACKWARD
+            if self._already_reduced_this_iter:
+                # Guard against double-reduce: e.g. when a queued root
+                # callback fires post_backward after the AOT-compiled
+                # backward already reduced this iter (mixed eager-parent /
+                # compiled-child execution under module.compile()).
+                return
+            self._already_reduced_this_iter = True
             with record_function(self._with_fqn("FSDP::post_backward_accumulate")):
                 for fsdp_param in self.fsdp_params:
                     fsdp_param.accumulate_unsharded_grad_if_needed()
@@ -806,6 +819,7 @@ class FSDPParamGroup:
                 work.wait()
             self._all_gather_result = None
         self._post_forward_indices.clear()
+        self._already_reduced_this_iter = False
 
     def _wait_for_post_backward(self):
         if self._post_reduce_event is not None:


### PR DESCRIPTION
> **UPDATE 2026-07-24: this patch has no effect on the bug.** Verified in source: `post_backward` fires **exactly once** in the buggy run. There is no double-reduce. The idempotency guard here is defensively fine but does not fix the observed grad-norm inflation. The real mechanism is a dynamo/AOT-autograd tensor-aliasing miswiring — the compiled backward feeds the wrong slice tensor into `F.cross_entropy`'s `target` argument when two forward inputs share storage. Keeping this PR as a draft while the root cause is investigated upstream. See comment below for the walkthrough. Original body preserved below.

## Status: WIP — needs rework

Companion to #190938 (also being reworked). Neither patch as-currently-authored addresses the actual bug.

## What we now believe the bug is

`torch.compile` + input tensors that share storage produce a silent-correctness backward under nightly `2.14.0.dev20260722+cu130`. FSDP2 / CP / `ModuleList` are not required — they were just ingredients that put dynamo on the codepath where the miswiring occurs.

Repro (23 lines, single GPU, no FSDP, no CP):

```python
import torch, torch.nn as nn, torch.nn.functional as F
D, S = 512, 512

def _sl(x): return x

class B(nn.Module):
    def __init__(s):
        super().__init__(); s.i = nn.Linear(D, D, bias=False)
    def forward(s, x): return s.i(x)

class M(nn.Module):
    def __init__(s):
        super().__init__()
        s.e = nn.Embedding(D, D)
        s.b = nn.ModuleList([B()])
    def forward(s, tok, tgt):
        h = s.e(_sl(tok.flatten())).view(1, -1, D)
        for blk in s.b:
            h = blk(h)
        return F.cross_entropy(h.reshape(-1, D), _sl(tgt.flatten()), reduction="none")

torch.manual_seed(0)
m = M().cuda()
for p in m.parameters(): p.data.normal_(0, 0.02)
m.compile()
torch.manual_seed(1)
r = ((torch.rand(1, S+1) ** 8) * D).long().cuda()
loss = m(r[:, :-1], r[:, 1:]).float().mean()   # tok and tgt share storage with r
loss.backward()
print(f"loss={loss.item():.6f} grad e.weight:{m.e.weight.grad.float().norm():.4f}")
```

Cloning the two slices before the call is bit-perfect:

```python
tok = r[:, :-1].clone()
tgt = r[:, 1:].clone()
loss = m(tok, tgt).float().mean()
```

| Variant                  | loss     | grad `e.weight` |
|--------------------------|----------|-----------------|
| aliased inputs, compile  | 6.242074 | 0.1992 (BUG)    |
| aliased inputs, eager    | 6.239221 | 0.0863          |
| cloned inputs, compile   | 6.239221 | 0.0863 (FIXED)  |
| cloned inputs, eager     | 6.239221 | 0.0863          |

## Why this PR's patch has no effect

- Instrumentation of `FSDPParamGroup.post_backward` shows it fires **exactly once** in the buggy run.
- `RegisterPostBackwardFunction.apply` / `.backward` and `AccumulateGrad` each fire once.
- The compiled backward FX graph has a single `mm` per weight, into a fresh output buffer. Nothing is being reduced twice.
- The `tangents_1.norm()` handed to the compiled backward matches eager (0.062440 vs 0.062439). But **element-wise** the tangent is a row-shifted version of the eager tangent: recovering the target-index sequence from it produces the `tok` slice, not the `tgt` slice. So the compiled forward is feeding the wrong slice-graph output into `F.cross_entropy`'s `target`.

An idempotency guard on `post_backward` is a fine sanity-check to keep around, but it is not what fixes this bug.

## Where a real fix likely goes

`torch/_functorch/_aot_autograd/*` — input-alias / view-tracking. Possibly with a contributing bug in `torch/_dynamo/variables/tensor.py` in how views over a shared base storage are exposed to AOT. Investigation ongoing.

## Temporary user-side mitigation

`.clone()` input tensor pairs that share storage before calling a compiled module.

## References

- Umbrella issue: #142358
- Companion PR (also being reworked): #190938 (dynamo `gb7000` recursive-SKIP — was the previous best guess at the root cause; now known to only workaround the AOT miswiring by forcing eager).

---

<details>
<summary>Original PR body (misdiagnosis, kept for context)</summary>

**LLM Statement:** This is in most part the work of my Claude, both the bug diagnostic, the narrowing down to a minimal reprod, the suggestion of a fix, and the body of this PR where done by it.

## Summary

**Companion patch to the dynamo loop-break fix** (which addresses the root cause: recursive SKIP propagation for `gb7000` graph-break-in-loop). This PR adds defense-in-depth on the FSDP2 side by guarding `post_backward` against being invoked twice within a single iteration.

(rest of original body elided — see PR history.)

</details>
