### PR TITLE
Back out "Release the GIL in the _disable_profiler pybind binding (#187594)"

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -439,10 +439,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       py::arg("config"),
       py::arg("activities"),
       py::arg("scopes") = std::unordered_set<at::RecordScope>());
-  m.def(
-      "_disable_profiler",
-      disableProfiler,
-      py::call_guard<py::gil_scoped_release>());
+  m.def("_disable_profiler", disableProfiler);
   m.def(
       "_prepare_profiler",
       prepareProfiler,


### PR DESCRIPTION
Summary:
Original commit changeset: 359db0b2ba67

Original Phabricator Diff: D108962294

Test Plan: Ran 100 clones of f1114384043 with version eval_worker:684f2314dccce5b91a3f1fb109b4e082 (backout) and found IMA's occurring at only ~2% whereas with the diff included, IMA rate is 15-20%

Differential Revision: D113451484


