### PR TITLE
Add more ops support for functional all_reduce

### DIFF
--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -266,32 +266,38 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
     # ============================================================
 
     @parametrize("device", devices)
-    def test_all_reduce_backward(self, device):
+    @parametrize("reduce_op", ["sum", "avg"])
+    def test_all_reduce_backward(self, device, reduce_op):
         """Test all_reduce backward does all_reduce.
 
         Both tensor AND gradients are VARYING (different across ranks).
-        Backward aggregates gradients via all_reduce(sum).
+        Backward aggregates gradients via all_reduce().
         """
+        shape = (3, 3)
         group_name = dist.group.WORLD.group_name
 
         input_tensor = torch.randn(3, 3, requires_grad=True, device=device)
-        output = fcols.all_reduce(input_tensor, "sum", group=group_name)
+        output = fcols.all_reduce(input_tensor, reduce_op, group=group_name)
 
         # Backward with ones
         output.sum().backward()
 
         # Gradient should be aggregated (backward is all_reduce)
-        expected_grad = torch.full(
-            (3, 3), fill_value=float(self.world_size), device=device
-        )
+        if reduce_op == "sum":
+            expected_grad = torch.full(
+                shape, fill_value=float(self.world_size), device=device
+            )
+        elif reduce_op == "avg":
+            expected_grad = torch.full(shape, fill_value=1.0, device=device)
         self.assertEqual(input_tensor.grad, expected_grad)
 
-        # Backward is all_reduce (sum)
         grad_outputs = torch.rand_like(output, device=device)
         (grad_input,) = torch.autograd.grad(
             output, input_tensor, grad_outputs=grad_outputs
         )
-        expected_grad_input = fcols.all_reduce(grad_outputs, "sum", group=group_name)
+        expected_grad_input = fcols.all_reduce(
+            grad_outputs, reduce_op, group=group_name
+        )
         self.assertEqual(grad_input, expected_grad_input)
 
     @parametrize("device", devices)

--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -104,9 +104,7 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         factor = 0.5
 
         premul_sum_op = dist.ReduceOp.PREMUL_SUM(factor)
-        input_tensor = torch.full(
-            shape, fill_value=float(rank + 1), device=device
-        )
+        input_tensor = torch.full(shape, fill_value=float(rank + 1), device=device)
         output = fcols.all_reduce(
             input_tensor, reduceOp=premul_sum_op, group=group_name
         )
@@ -826,6 +824,7 @@ class TestFunctionalDifferentialsWithCompile(DistributedTestBase):
 
         for reduce_op in ["sum", "avg", "min", "max"]:
             with self.subTest(reduce_op=reduce_op):
+
                 @torch.compile(fullgraph=True)
                 def compiled_fn(tensor):
                     output = fcols.all_reduce(tensor, reduce_op, group=group_name)
@@ -833,10 +832,15 @@ class TestFunctionalDifferentialsWithCompile(DistributedTestBase):
 
                 if reduce_op in ("min", "max"):
                     input_tensor = torch.full(
-                        shape, fill_value=float(self.rank), device=self.device, requires_grad=True
+                        shape,
+                        fill_value=float(self.rank),
+                        device=self.device,
+                        requires_grad=True,
                     )
                 else:
-                    input_tensor = torch.randn(*shape, device=self.device, requires_grad=True)
+                    input_tensor = torch.randn(
+                        *shape, device=self.device, requires_grad=True
+                    )
 
                 loss = compiled_fn(input_tensor)
                 loss.backward()
@@ -847,13 +851,23 @@ class TestFunctionalDifferentialsWithCompile(DistributedTestBase):
                         shape, fill_value=float(self.world_size), device=self.device
                     )
                 elif reduce_op == "avg":
-                    expected_grad = torch.full(shape, fill_value=1.0, device=self.device)
+                    expected_grad = torch.full(
+                        shape, fill_value=1.0, device=self.device
+                    )
                 elif reduce_op == "min":
                     grad_val = float(self.world_size) if self.rank == 0 else 0.0
-                    expected_grad = torch.full(shape, fill_value=grad_val, device=self.device)
+                    expected_grad = torch.full(
+                        shape, fill_value=grad_val, device=self.device
+                    )
                 elif reduce_op == "max":
-                    grad_val = float(self.world_size) if self.rank == self.world_size - 1 else 0.0
-                    expected_grad = torch.full(shape, fill_value=grad_val, device=self.device)
+                    grad_val = (
+                        float(self.world_size)
+                        if self.rank == self.world_size - 1
+                        else 0.0
+                    )
+                    expected_grad = torch.full(
+                        shape, fill_value=grad_val, device=self.device
+                    )
                 self.assertEqual(input_tensor.grad, expected_grad)
 
     @with_comms

--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -68,25 +68,51 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
     # ============================================================
 
     @parametrize("device", devices)
-    def test_all_reduce_forward(self, device):
+    @parametrize("reduce_op", ["sum", "avg", "min", "max"])
+    def test_all_reduce_forward(self, device, reduce_op):
         """Test all_reduce does all_reduce in forward.
 
         Tensor is VARYING (different across ranks).
-        Forward aggregates varying tensors via all_reduce(sum).
+        Forward aggregates varying tensors via all_reduce.
         """
+        shape = (3, 3)
         group_name = dist.group.WORLD.group_name
         rank = dist.get_rank()
 
         # Each rank contributes its rank value (tensor is varying)
-        input_tensor = torch.full((3, 3), fill_value=float(rank), device=device)
-        output = fcols.all_reduce(input_tensor, "sum", group=group_name)
+        input_tensor = torch.full(shape, fill_value=float(rank), device=device)
+        output = fcols.all_reduce(input_tensor, reduce_op, group=group_name)
 
-        # Forward does all_reduce: sum of 0+1+2+3 = 6
-        expected = torch.full(
-            (3, 3),
-            fill_value=self.world_size * (self.world_size - 1) / 2,
-            device=device,
+        rank_values = [float(r) for r in range(self.world_size)]
+        if reduce_op == "sum":
+            expected_val = sum(rank_values)
+        elif reduce_op == "avg":
+            expected_val = sum(rank_values) / self.world_size
+        elif reduce_op == "min":
+            expected_val = min(rank_values)
+        elif reduce_op == "max":
+            expected_val = max(rank_values)
+        expected = torch.full(shape, fill_value=expected_val, device=device)
+        self.assertEqual(output, expected)
+
+    @parametrize("device", devices)
+    def test_all_reduce_premul_sum_forward(self, device):
+        """Test all_reduce forward with PREMUL_SUM ReduceOp."""
+        shape = (3, 3)
+        group_name = dist.group.WORLD.group_name
+        rank = dist.get_rank()
+        factor = 0.5
+
+        premul_sum_op = dist.ReduceOp.PREMUL_SUM(factor)
+        input_tensor = torch.full(
+            shape, fill_value=float(rank + 1), device=device
         )
+        output = fcols.all_reduce(
+            input_tensor, reduceOp=premul_sum_op, group=group_name
+        )
+
+        expected_val = factor * sum(float(r + 1) for r in range(self.world_size))
+        expected = torch.full(shape, fill_value=expected_val, device=device)
         self.assertEqual(output, expected)
 
     @parametrize("device", devices)
@@ -345,31 +371,6 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
             shape, fill_value=factor * float(self.world_size), device=device
         )
         self.assertEqual(input_tensor.grad, expected_grad)
-
-    @parametrize("device", devices)
-    def test_all_reduce_avg_backward(self, device):
-        """Test all_reduce backward with the 'avg' reduction.
-
-        Both tensor AND gradients are VARYING (different across ranks).
-        Backward aggregates gradients via all_reduce(avg).
-        """
-        group_name = dist.group.WORLD.group_name
-
-        input_tensor = torch.randn(3, 3, requires_grad=True, device=device)
-        output = fcols.all_reduce(input_tensor, "avg", group=group_name)
-
-        # Backward with ones: avg of ones across ranks is ones.
-        output.sum().backward()
-        expected_grad = torch.ones(3, 3, device=device)
-        self.assertEqual(input_tensor.grad, expected_grad)
-
-        # Backward is all_reduce (avg) of the incoming gradients.
-        grad_outputs = torch.rand_like(output, device=device)
-        (grad_input,) = torch.autograd.grad(
-            output, input_tensor, grad_outputs=grad_outputs
-        )
-        expected_grad_input = fcols.all_reduce(grad_outputs, "avg", group=group_name)
-        self.assertEqual(grad_input, expected_grad_input)
 
     @parametrize("device", devices)
     @parametrize("gather_dim", [0, 1, 2])
@@ -820,22 +821,40 @@ class TestFunctionalDifferentialsWithCompile(DistributedTestBase):
     @with_comms
     def test_all_reduce_compile(self):
         """Test that all_reduce backward works with torch.compile."""
+        shape = (3, 3)
         group_name = dist.group.WORLD.group_name
 
-        @torch.compile(fullgraph=True)
-        def compiled_fn(tensor):
-            output = fcols.all_reduce(tensor, "sum", group=group_name)
-            return output.sum()
+        for reduce_op in ["sum", "avg", "min", "max"]:
+            with self.subTest(reduce_op=reduce_op):
+                @torch.compile(fullgraph=True)
+                def compiled_fn(tensor):
+                    output = fcols.all_reduce(tensor, reduce_op, group=group_name)
+                    return output.sum()
 
-        input_tensor = torch.randn(3, 3, device=self.device, requires_grad=True)
+                if reduce_op in ("min", "max"):
+                    input_tensor = torch.full(
+                        shape, fill_value=float(self.rank), device=self.device, requires_grad=True
+                    )
+                else:
+                    input_tensor = torch.randn(*shape, device=self.device, requires_grad=True)
 
-        loss = compiled_fn(input_tensor)
-        loss.backward()
+                loss = compiled_fn(input_tensor)
+                loss.backward()
 
-        # Gradient should be aggregated
-        self.assertIsNotNone(input_tensor.grad)
-        expected_grad = torch.full((3, 3), fill_value=float(self.world_size))
-        self.assertEqual(input_tensor.grad, expected_grad)
+                self.assertIsNotNone(input_tensor.grad)
+                if reduce_op == "sum":
+                    expected_grad = torch.full(
+                        shape, fill_value=float(self.world_size), device=self.device
+                    )
+                elif reduce_op == "avg":
+                    expected_grad = torch.full(shape, fill_value=1.0, device=self.device)
+                elif reduce_op == "min":
+                    grad_val = float(self.world_size) if self.rank == 0 else 0.0
+                    expected_grad = torch.full(shape, fill_value=grad_val, device=self.device)
+                elif reduce_op == "max":
+                    grad_val = float(self.world_size) if self.rank == self.world_size - 1 else 0.0
+                    expected_grad = torch.full(shape, fill_value=grad_val, device=self.device)
+                self.assertEqual(input_tensor.grad, expected_grad)
 
     @with_comms
     def test_all_gather_tensor_compile(self):

--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -266,7 +266,7 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
     # ============================================================
 
     @parametrize("device", devices)
-    @parametrize("reduce_op", ["sum", "avg"])
+    @parametrize("reduce_op", ["sum", "avg", "min", "max"])
     def test_all_reduce_backward(self, device, reduce_op):
         """Test all_reduce backward does all_reduce.
 
@@ -276,29 +276,75 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         shape = (3, 3)
         group_name = dist.group.WORLD.group_name
 
-        input_tensor = torch.randn(3, 3, requires_grad=True, device=device)
+        rank = dist.get_rank()
+
+        if reduce_op in ("min", "max"):
+            # Use distinct per-rank values so there's a unique extremum holder
+            input_tensor = torch.full(
+                shape, fill_value=float(rank), requires_grad=True, device=device
+            )
+        else:
+            input_tensor = torch.randn(*shape, requires_grad=True, device=device)
         output = fcols.all_reduce(input_tensor, reduce_op, group=group_name)
 
         # Backward with ones
         output.sum().backward()
 
-        # Gradient should be aggregated (backward is all_reduce)
         if reduce_op == "sum":
             expected_grad = torch.full(
                 shape, fill_value=float(self.world_size), device=device
             )
         elif reduce_op == "avg":
             expected_grad = torch.full(shape, fill_value=1.0, device=device)
+        elif reduce_op == "min":
+            # Grad flows only to the rank that held the min (rank 0)
+            grad_val = float(self.world_size) if rank == 0 else 0.0
+            expected_grad = torch.full(shape, fill_value=grad_val, device=device)
+        elif reduce_op == "max":
+            # Grad flows only to the rank that held the max (last rank)
+            grad_val = float(self.world_size) if rank == self.world_size - 1 else 0.0
+            expected_grad = torch.full(shape, fill_value=grad_val, device=device)
         self.assertEqual(input_tensor.grad, expected_grad)
 
-        grad_outputs = torch.rand_like(output, device=device)
-        (grad_input,) = torch.autograd.grad(
-            output, input_tensor, grad_outputs=grad_outputs
+        if reduce_op not in ("min", "max"):
+            grad_outputs = torch.rand_like(output, device=device)
+            (grad_input,) = torch.autograd.grad(
+                output, input_tensor, grad_outputs=grad_outputs
+            )
+            expected_grad_input = fcols.all_reduce(
+                grad_outputs, reduce_op, group=group_name
+            )
+            self.assertEqual(grad_input, expected_grad_input)
+
+    @parametrize("device", devices)
+    def test_all_reduce_premul_sum_backward(self, device):
+        """Test all_reduce backward with PREMUL_SUM ReduceOp."""
+        shape = (3, 3)
+        group_name = dist.group.WORLD.group_name
+        rank = dist.get_rank()
+        factor = 0.5
+
+        premul_sum_op = dist.ReduceOp.PREMUL_SUM(factor)
+
+        input_tensor = torch.full(
+            shape, fill_value=float(rank + 1), requires_grad=True, device=device
         )
-        expected_grad_input = fcols.all_reduce(
-            grad_outputs, reduce_op, group=group_name
+        output = fcols.all_reduce(
+            input_tensor, reduceOp=premul_sum_op, group=group_name
         )
-        self.assertEqual(grad_input, expected_grad_input)
+
+        # Forward: premul_sum(0.5) premultiplies then sums
+        expected_fwd = factor * sum(float(r + 1) for r in range(self.world_size))
+        self.assertEqual(
+            output, torch.full(shape, fill_value=expected_fwd, device=device)
+        )
+
+        output.sum().backward()
+        # Backward: all_reduce(1, premul_sum(0.5)) = 0.5 * world_size
+        expected_grad = torch.full(
+            shape, fill_value=factor * float(self.world_size), device=device
+        )
+        self.assertEqual(input_tensor.grad, expected_grad)
 
     @parametrize("device", devices)
     def test_all_reduce_avg_backward(self, device):

--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -371,6 +371,38 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         self.assertEqual(input_tensor.grad, expected_grad)
 
     @parametrize("device", devices)
+    @parametrize("reduce_op", ["min", "max"])
+    def test_all_reduce_nan_backward(self, device, reduce_op):
+        """Test all_reduce backward passes through all-reduced grad for NaN inputs."""
+        shape = (3, 3)
+        group_name = dist.group.WORLD.group_name
+        rank = dist.get_rank()
+
+        input_tensor = torch.full(
+            shape, fill_value=float(rank), requires_grad=True, device=device
+        )
+        # Inject a NaN on rank 0
+        if rank == 0:
+            with torch.no_grad():
+                input_tensor[0, 0] = float("nan")
+
+        output = fcols.all_reduce(input_tensor, reduce_op, group=group_name)
+        output.sum().backward()
+
+        grad = input_tensor.grad
+        # NaN elements receive the all-reduced grad (world_size) rather than NaN
+        all_reduced_grad = float(self.world_size)
+        if rank == 0:
+            self.assertEqual(grad[0, 0], all_reduced_grad)
+            # Non-NaN elements on the extremum-holding rank get world_size
+            if reduce_op == "min":
+                self.assertEqual(grad[0, 1], all_reduced_grad)
+            else:
+                self.assertEqual(grad[0, 1], 0.0)
+        else:
+            self.assertFalse(grad.isnan().any())
+
+    @parametrize("device", devices)
     @parametrize("gather_dim", [0, 1, 2])
     def test_all_gather_tensor_backward(self, device, gather_dim):
         """Test all_gather_tensor backward does reduce_scatter.

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -144,6 +144,9 @@ class ReduceOp:
     # pyrefly: ignore  # unknown-name
     UNUSED: RedOpType = ...
 
+    # pyrefly: ignore  # unknown-name
+    op: RedOpType
+
     # mypy error being ignored:
     # Detected enum "torch._C._distributed_c10d.ReduceOp.RedOpType" in a type
     # stub with zero members. There is a chance this is due to a recent change

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -7,27 +7,28 @@
 #include <torch/csrc/jit/frontend/schema_type_parser.h>
 #include <torch/custom_class_detail.h>
 #include <utility>
+#include <torch/csrc/distributed/c10d/Types.hpp>
 
 namespace {
 
-const std::unordered_map<std::string, c10d::ReduceOp> str_to_reduce_op = {
-    {"sum", c10d::ReduceOp(c10d::ReduceOp::RedOpType::SUM)},
-    {"avg", c10d::ReduceOp(c10d::ReduceOp::RedOpType::AVG)},
-    {"product", c10d::ReduceOp(c10d::ReduceOp::RedOpType::PRODUCT)},
-    {"min", c10d::ReduceOp(c10d::ReduceOp::RedOpType::MIN)},
-    {"max", c10d::ReduceOp(c10d::ReduceOp::RedOpType::MAX)},
-    {"band", c10d::ReduceOp(c10d::ReduceOp::RedOpType::BAND)},
-    {"bor", c10d::ReduceOp(c10d::ReduceOp::RedOpType::BOR)},
-    {"bxor", c10d::ReduceOp(c10d::ReduceOp::RedOpType::BXOR)},
-    // TODO: support premul_sum
-    // {"premul_sum", c10d::ReduceOp(c10d::ReduceOp::RedOpType::PREMUL_SUM)},
-    {"unused", c10d::ReduceOp(c10d::ReduceOp::RedOpType::UNUSED)}};
+const std::unordered_map<std::string, c10d::ReduceOp::RedOpType>
+    str_to_reduce_op = {
+        {"sum", c10d::ReduceOp::RedOpType::SUM},
+        {"avg", c10d::ReduceOp::RedOpType::AVG},
+        {"product", c10d::ReduceOp::RedOpType::PRODUCT},
+        {"min", c10d::ReduceOp::RedOpType::MIN},
+        {"max", c10d::ReduceOp::RedOpType::MAX},
+        {"band", c10d::ReduceOp::RedOpType::BAND},
+        {"bor", c10d::ReduceOp::RedOpType::BOR},
+        {"bxor", c10d::ReduceOp::RedOpType::BXOR},
+        {"premul_sum", c10d::ReduceOp::RedOpType::PREMUL_SUM},
+        {"unused", c10d::ReduceOp::RedOpType::UNUSED}};
 
-c10d::ReduceOp to_reduce_op(const std::string& reduce_op) {
+c10::intrusive_ptr<c10d::ReduceOp> to_reduce_op(const std::string& reduce_op) {
   auto it = str_to_reduce_op.find(reduce_op);
   TORCH_CHECK(
       it != str_to_reduce_op.end(), "Unrecognized reduce_op: ", reduce_op);
-  return it->second;
+  return c10::make_intrusive<c10d::ReduceOp>(it->second);
 }
 
 at::Tensor allocate_all_gather_output(
@@ -66,10 +67,10 @@ namespace c10d {
 at::Tensor& all_reduce_(
     at::Tensor& input,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::string reduce_op,
+    c10::intrusive_ptr<c10d::ReduceOp> reduce_op,
     c10::intrusive_ptr<c10d::ProcessGroup> group) {
   c10d::AllreduceOptions opts;
-  opts.reduceOp = to_reduce_op(reduce_op);
+  opts.reduceOp = *reduce_op;
 
   std::vector<at::Tensor> inputs{input};
   auto work = group->allreduce(inputs, opts);
@@ -79,17 +80,15 @@ at::Tensor& all_reduce_(
 
 at::Tensor all_reduce(
     const at::Tensor& input,
-    std::string reduce_op,
+    c10::intrusive_ptr<c10d::ReduceOp> reduce_op,
     c10::intrusive_ptr<c10d::ProcessGroup> group) {
   if (input.is_complex()) {
     TORCH_CHECK(
-        // TODO - ideally use 'to_reduce_op' helper but it currently errors on
-        // premul_sum
-        reduce_op == "sum" || reduce_op == "avg" || reduce_op == "premul_sum" ||
-            reduce_op == "unused",
-        "all_reduce: reduce_op ",
-        reduce_op,
-        " does not support complex tensors");
+        *reduce_op == c10d::ReduceOp::SUM ||
+            *reduce_op == c10d::ReduceOp::AVG ||
+            *reduce_op == c10d::ReduceOp::PREMUL_SUM ||
+            *reduce_op == c10d::ReduceOp::UNUSED,
+        "all_reduce: reduce_op does not support complex tensors");
   }
   auto input_real = input.is_complex() ? at::view_as_real(input) : input;
   auto output = input_real.clone(at::MemoryFormat::Contiguous);
@@ -102,7 +101,7 @@ at::Tensor& all_reduce_(
     std::string reduce_op,
     std::string group_name) {
   auto group = c10d::resolve_process_group(std::move(group_name));
-  return all_reduce_(input, std::move(reduce_op), std::move(group));
+  return all_reduce_(input, to_reduce_op(reduce_op), std::move(group));
 }
 
 at::Tensor all_reduce(
@@ -110,7 +109,7 @@ at::Tensor all_reduce(
     std::string reduce_op,
     std::string group_name) {
   auto group = c10d::resolve_process_group(std::move(group_name));
-  return all_reduce(input, std::move(reduce_op), std::move(group));
+  return all_reduce(input, to_reduce_op(reduce_op), std::move(group));
 }
 
 std::vector<at::Tensor> all_reduce_coalesced_(
@@ -129,7 +128,7 @@ std::vector<at::Tensor> all_reduce_coalesced_(
     std::string reduce_op,
     c10::intrusive_ptr<c10d::ProcessGroup> group) {
   c10d::AllreduceCoalescedOptions opts;
-  opts.reduceOp = to_reduce_op(reduce_op);
+  opts.reduceOp = *to_reduce_op(reduce_op);
 
   auto work = group->allreduce_coalesced(inputs, opts);
   for (const auto& tensor : inputs) {
@@ -246,7 +245,7 @@ std::vector<at::Tensor> reduce_scatter_tensor_coalesced(
     int64_t group_size,
     c10::intrusive_ptr<c10d::ProcessGroup> group) {
   c10d::ReduceScatterOptions opts;
-  opts.reduceOp = to_reduce_op(reduce_op);
+  opts.reduceOp = *to_reduce_op(reduce_op);
   std::vector<at::Tensor> outputs;
   outputs.reserve(inputs.size());
   for (auto& tensor : inputs) {
@@ -269,7 +268,7 @@ static std::vector<at::Tensor> reduce_scatter_tensor_coalesced_out(
     c10::intrusive_ptr<c10d::ProcessGroup> group,
     std::vector<at::Tensor>& outputs) {
   c10d::ReduceScatterOptions opts;
-  opts.reduceOp = to_reduce_op(reduce_op);
+  opts.reduceOp = *to_reduce_op(reduce_op);
 
   auto work = group->reduce_scatter_single_coalesced(outputs, inputs, opts);
   for (const auto& tensor : outputs) {
@@ -534,6 +533,24 @@ c10::intrusive_ptr<c10d::ProcessGroup> get_process_group(
   }
 }
 
+c10::intrusive_ptr<c10d::ReduceOp> get_reduce_op(
+    const c10::IValue& op_name,
+    const char* func_name) {
+  if (op_name.isString()) {
+    return to_reduce_op(op_name.toStringRef());
+  } else if (op_name.isCapsule()) {
+    return c10::static_intrusive_pointer_cast<c10d::ReduceOp>(
+        op_name.toCapsule());
+  } else {
+    TORCH_CHECK(
+        false,
+        func_name,
+        "(): argument 'reduce_op' must be either a string (op name) "
+        "or a ReduceOp object, but got ",
+        op_name.type()->str());
+  }
+}
+
 // all_to_all_single_dispatch is kept as a named function because it is
 // referenced via decltype inside the AllToAllSingle autograd class.
 at::Tensor all_to_all_single_dispatch(
@@ -552,28 +569,28 @@ at::Tensor all_to_all_single_dispatch(
 
 TORCH_LIBRARY(_c10d_functional, m) {
   m.def(
-      "all_reduce(Tensor input, str reduce_op, Any group_name) -> Tensor",
+      "all_reduce(Tensor input, Any reduce_op, Any group_name) -> Tensor",
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd,
           [](const at::Tensor& input,
-             std::string reduce_op,
+             const c10::IValue& reduce_op,
              const c10::IValue& group) {
             return c10d::all_reduce(
                 input,
-                std::move(reduce_op),
+                get_reduce_op(reduce_op, "all_reduce"),
                 get_process_group(group, "all_reduce"));
           }),
       {at::Tag::pt2_compliant_tag});
 
   m.def(
-      "all_reduce_(Tensor(a!) input, str reduce_op, Any group_name) -> Tensor(a!)",
+      "all_reduce_(Tensor(a!) input, Any reduce_op, Any group_name) -> Tensor(a!)",
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd,
-          [](at::Tensor& input, std::string reduce_op, const c10::IValue& group)
+          [](at::Tensor& input, const c10::IValue& reduce_op, const c10::IValue& group)
               -> at::Tensor& {
             return c10d::all_reduce_(
                 input,
-                std::move(reduce_op),
+                get_reduce_op(reduce_op, "all_reduce_"),
                 get_process_group(group, "all_reduce_"));
           }),
       {at::Tag::pt2_compliant_tag});

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -4,10 +4,10 @@
 #include <torch/csrc/distributed/c10d/Functional.hpp>
 #include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/Types.hpp>
 #include <torch/csrc/jit/frontend/schema_type_parser.h>
 #include <torch/custom_class_detail.h>
 #include <utility>
-#include <torch/csrc/distributed/c10d/Types.hpp>
 
 namespace {
 
@@ -586,8 +586,9 @@ TORCH_LIBRARY(_c10d_functional, m) {
       "all_reduce_(Tensor(a!) input, Any reduce_op, Any group_name) -> Tensor(a!)",
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd,
-          [](at::Tensor& input, const c10::IValue& reduce_op, const c10::IValue& group)
-              -> at::Tensor& {
+          [](at::Tensor& input,
+             const c10::IValue& reduce_op,
+             const c10::IValue& group) -> at::Tensor& {
             return c10d::all_reduce_(
                 input,
                 get_reduce_op(reduce_op, "all_reduce_"),

--- a/torch/csrc/distributed/c10d/Functional.hpp
+++ b/torch/csrc/distributed/c10d/Functional.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/Types.hpp>
 
 namespace c10d {
 
@@ -14,6 +15,11 @@ C10_EXPORT at::Tensor& all_reduce_(
     std::string reduce_op,
     c10::intrusive_ptr<ProcessGroup> group);
 
+C10_EXPORT at::Tensor& all_reduce_(
+    at::Tensor& input,
+    c10::intrusive_ptr<ReduceOp> reduce_op,
+    c10::intrusive_ptr<ProcessGroup> group);
+
 C10_EXPORT at::Tensor all_reduce(
     const at::Tensor& input,
     std::string reduce_op,
@@ -22,6 +28,11 @@ C10_EXPORT at::Tensor all_reduce(
 C10_EXPORT at::Tensor all_reduce(
     const at::Tensor& input,
     std::string reduce_op,
+    c10::intrusive_ptr<ProcessGroup> group);
+
+C10_EXPORT at::Tensor all_reduce(
+    const at::Tensor& input,
+    c10::intrusive_ptr<ReduceOp> reduce_op,
     c10::intrusive_ptr<ProcessGroup> group);
 
 C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced_(

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -841,7 +841,7 @@ An enum-like class for built-in communication hooks: ``ALLREDUCE`` and ``FP16_CO
           R"(Sets the debug level of the torch.distributed package from the
           ``TORCH_DISTRIBUTED_DEBUG`` environment variable.)");
 
-  py::class_<::c10d::ReduceOp> reduce_op(
+  intrusive_ptr_class_<::c10d::ReduceOp> reduce_op(
       module,
       "ReduceOp",
       py::metaclass(reinterpret_cast<PyObject*>(GetReduceOpMetaclass())),

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -841,7 +841,7 @@ An enum-like class for built-in communication hooks: ``ALLREDUCE`` and ``FP16_CO
           R"(Sets the debug level of the torch.distributed package from the
           ``TORCH_DISTRIBUTED_DEBUG`` environment variable.)");
 
-  intrusive_ptr_class_<::c10d::ReduceOp> reduce_op(
+  py::class_<::c10d::ReduceOp> reduce_op(
       module,
       "ReduceOp",
       py::metaclass(reinterpret_cast<PyObject*>(GetReduceOpMetaclass())),

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -555,8 +555,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
         return IValue::make_capsule(cpp_obj);
       }
       if (py::isinstance<c10d::ReduceOp>(obj)) {
-        const auto& op = obj.cast<const c10d::ReduceOp&>();
-        auto cpp_obj = c10::make_intrusive<c10d::ReduceOp>(op);
+        auto cpp_obj = obj.cast<c10::intrusive_ptr<c10d::ReduceOp>>();
         return IValue::make_capsule(cpp_obj);
       }
 #endif
@@ -778,8 +777,7 @@ py::object toPyObject(IValue ivalue) {
     auto capsule = ivalue.toCapsule();
 #ifdef USE_DISTRIBUTED
     if (dynamic_cast<c10d::ReduceOp*>(capsule.get())) {
-      auto op = c10::static_intrusive_pointer_cast<c10d::ReduceOp>(capsule);
-      return py::cast(*op);
+      return py::cast(c10::static_intrusive_pointer_cast<c10d::ReduceOp>(std::move(capsule)));
     }
     {
       auto pg = c10::static_intrusive_pointer_cast<c10d::ProcessGroup>(capsule);

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -555,7 +555,8 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
         return IValue::make_capsule(cpp_obj);
       }
       if (py::isinstance<c10d::ReduceOp>(obj)) {
-        auto cpp_obj = obj.cast<c10::intrusive_ptr<c10d::ReduceOp>>();
+        const auto& op = obj.cast<const c10d::ReduceOp&>();
+        auto cpp_obj = c10::make_intrusive<c10d::ReduceOp>(op);
         return IValue::make_capsule(cpp_obj);
       }
 #endif
@@ -777,7 +778,9 @@ py::object toPyObject(IValue ivalue) {
     auto capsule = ivalue.toCapsule();
 #ifdef USE_DISTRIBUTED
     if (dynamic_cast<c10d::ReduceOp*>(capsule.get())) {
-      return py::cast(c10::static_intrusive_pointer_cast<c10d::ReduceOp>(std::move(capsule)));
+      auto op = c10::static_intrusive_pointer_cast<c10d::ReduceOp>(
+          std::move(capsule));
+      return py::cast(*op);
     }
     {
       auto pg = c10::static_intrusive_pointer_cast<c10d::ProcessGroup>(capsule);

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -552,12 +552,12 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
           target = obj.attr("real_obj");
         }
         auto cpp_obj = target.cast<c10::intrusive_ptr<c10d::ProcessGroup>>();
-        return IValue::make_capsule(cpp_obj);
+        return IValue::make_capsule(std::move(cpp_obj));
       }
       if (py::isinstance<c10d::ReduceOp>(obj)) {
         const auto& op = obj.cast<const c10d::ReduceOp&>();
         auto cpp_obj = c10::make_intrusive<c10d::ReduceOp>(op);
-        return IValue::make_capsule(cpp_obj);
+        return IValue::make_capsule(std::move(cpp_obj));
       }
 #endif
 

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -7,6 +7,7 @@
 
 #ifdef USE_DISTRIBUTED
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/Types.hpp>
 #endif
 
 #include <ATen/ScalarOps.h>
@@ -553,6 +554,11 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
         auto cpp_obj = target.cast<c10::intrusive_ptr<c10d::ProcessGroup>>();
         return IValue::make_capsule(cpp_obj);
       }
+      if (py::isinstance<c10d::ReduceOp>(obj)) {
+        const auto& op = obj.cast<const c10d::ReduceOp&>();
+        auto cpp_obj = c10::make_intrusive<c10d::ReduceOp>(op);
+        return IValue::make_capsule(cpp_obj);
+      }
 #endif
 
       // Original: handle generic c10::Capsule Python objects
@@ -771,6 +777,10 @@ py::object toPyObject(IValue ivalue) {
   } else if (ivalue.isCapsule()) {
     auto capsule = ivalue.toCapsule();
 #ifdef USE_DISTRIBUTED
+    if (dynamic_cast<c10d::ReduceOp*>(capsule.get())) {
+      auto op = c10::static_intrusive_pointer_cast<c10d::ReduceOp>(capsule);
+      return py::cast(*op);
+    }
     {
       auto pg = c10::static_intrusive_pointer_cast<c10d::ProcessGroup>(capsule);
       if (pg != nullptr) {
@@ -1012,6 +1022,9 @@ py::object _get_operation_for_overload_or_packet(
 std::optional<InferredType> detail::_tryToInferTypeImpl(py::handle input) {
 #ifdef USE_DISTRIBUTED
   if (py::isinstance<c10d::ProcessGroup>(input)) {
+    return InferredType(CapsuleType::get());
+  }
+  if (py::isinstance<c10d::ReduceOp>(input)) {
     return InferredType(CapsuleType::get());
   }
   // During Dynamo tracing with compile-on-one-rank (CooR), opaque reference

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -11,6 +11,7 @@ import torch.compiler.config
 import torch.distributed as dist
 import torch.distributed.distributed_c10d as c10d
 from torch._utils import _maybe_view_chunk_cat
+from torch.distributed import ReduceOp
 from torch.distributed.device_mesh import DeviceMesh
 from torch.fx.experimental.proxy_tensor import get_proxy_mode
 
@@ -644,24 +645,20 @@ torch.library.register_autograd(
 )
 
 
-def _is_min_max(op):
-    from torch.distributed import ReduceOp as _ReduceOp
-
-    if isinstance(op, _ReduceOp):
-        return op.op in (_ReduceOp.MIN, _ReduceOp.MAX)
+def _is_min_max(op: str | ReduceOp):
+    if isinstance(op, ReduceOp):
+        return op.op in (ReduceOp.MIN, ReduceOp.MAX)
     return op in ("min", "max")
 
 
-def _is_reduceop_supported(op):
-    from torch.distributed import ReduceOp as _ReduceOp
-
-    if isinstance(op, _ReduceOp):
+def _is_reduceop_supported(op: str | ReduceOp):
+    if isinstance(op, ReduceOp):
         return op.op in (
-            _ReduceOp.SUM,
-            _ReduceOp.AVG,
-            _ReduceOp.PREMUL_SUM,
-            _ReduceOp.MAX,
-            _ReduceOp.MIN,
+            ReduceOp.SUM,
+            ReduceOp.AVG,
+            ReduceOp.PREMUL_SUM,
+            ReduceOp.MAX,
+            ReduceOp.MIN,
         )
     return op in ("sum", "avg", "premul_sum", "max", "min")
 
@@ -670,7 +667,7 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
     reduce_op = ctx.reduce_op
     if not _is_reduceop_supported(reduce_op):
         raise RuntimeError(
-            f"all_reduce backward only supports sum-like reductions, got '{reduce_op}'"
+            f"all_reduce backward only supports `sum`, `premul_sum`, `avg`, `max`, `min` reductions, got '{reduce_op}'"
         )
     grad_reduce_op = "sum" if _is_min_max(reduce_op) else reduce_op
     output = torch.ops._c10d_functional.all_reduce(

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -678,7 +678,10 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
     )
     if _is_min_max(reduce_op):
         fwd_input, fwd_output = ctx.saved_tensors
-        output = torch.ops.aten.where.ScalarOther(fwd_input == fwd_output, output, 0)
+        output = torch.ops.aten.where.ScalarOther(
+            fwd_input == fwd_output, wait_tensor(output), 0
+        )
+        return output, None, None
     return wait_tensor(output), None, None
 
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -158,7 +158,9 @@ def broadcast(self: torch.Tensor, src: int, group: RANK_TYPES, tag: str = ""):
     return _maybe_wrap_tensor(tensor)
 
 
-def all_reduce(self: torch.Tensor, reduceOp: str, group: RANK_TYPES, tag: str = ""):
+def all_reduce(
+    self: torch.Tensor, reduceOp: str | dist.ReduceOp, group: RANK_TYPES, tag: str = ""
+):
     """
     Reduces the tensor data across all machines in such a way that all get
     the final result.
@@ -176,8 +178,9 @@ def all_reduce(self: torch.Tensor, reduceOp: str, group: RANK_TYPES, tag: str = 
     that information and perform collective algebraic optimization. Use other forms of input for that.
     """
     group = _resolve_group(group, tag)
+    reduce_op = reduceOp.lower() if isinstance(reduceOp, str) else reduceOp
     tensor = torch.ops._c10d_functional.all_reduce(
-        self, reduceOp.lower(), _group_or_group_name(group)
+        self, reduce_op, _group_or_group_name(group)
     )
     return _maybe_wrap_tensor(tensor)
 
@@ -641,24 +644,41 @@ torch.library.register_autograd(
 )
 
 
+def _is_min_max(op):
+    from torch.distributed import ReduceOp as _ReduceOp
+
+    if isinstance(op, _ReduceOp):
+        return op.op in (_ReduceOp.MIN, _ReduceOp.MAX)
+    return op in ("min", "max")
+
+
 def _is_reduceop_supported(op):
     from torch.distributed import ReduceOp as _ReduceOp
+
     if isinstance(op, _ReduceOp):
-        return op.op in (_ReduceOp.SUM, _ReduceOp.AVG, _ReduceOp.PREMUL_SUM, _ReduceOp.MAX, _ReduceOp.MIN)
+        return op.op in (
+            _ReduceOp.SUM,
+            _ReduceOp.AVG,
+            _ReduceOp.PREMUL_SUM,
+            _ReduceOp.MAX,
+            _ReduceOp.MIN,
+        )
     return op in ("sum", "avg", "premul_sum", "max", "min")
 
 
 def all_reduce_backward(ctx, grad_output: torch.Tensor):
-    from torch.distributed import ReduceOp as _ReduceOp
     reduce_op = ctx.reduce_op
     if not _is_reduceop_supported(reduce_op):
-        raise RuntimeError(f"all_reduce backward only supports sum-like reductions, got '{reduce_op}'")
+        raise RuntimeError(
+            f"all_reduce backward only supports sum-like reductions, got '{reduce_op}'"
+        )
+    grad_reduce_op = "sum" if _is_min_max(reduce_op) else reduce_op
     output = torch.ops._c10d_functional.all_reduce(
-        grad_output.contiguous(), reduce_op, ctx.group_name
+        grad_output.contiguous(), grad_reduce_op, ctx.group_name
     )
-    if reduce_op == "min" or reduce_op == "max" or reduce_op == _ReduceOp.MIN or reduce_op == _ReduceOp.MAX:
-        output = torch.ops.aten.where.ScalarOther(ctx.mask, output, 0)
-
+    if _is_min_max(reduce_op):
+        fwd_input, fwd_output = ctx.saved_tensors
+        output = torch.ops.aten.where.ScalarOther(fwd_input == fwd_output, output, 0)
     return wait_tensor(output), None, None
 
 
@@ -666,10 +686,9 @@ def all_reduce_setup_context(ctx, inputs, output):
     input, reduce_op, group_name = inputs
     ctx.group_name = group_name
     ctx.reduce_op = reduce_op.lower() if isinstance(reduce_op, str) else reduce_op
-    if reduce_op == "min" or reduce_op == "max" or reduce_op == _ReduceOp.MIN or reduce_op == _ReduceOp.MAX:
-        # TODO: handle is_nan
-        print("input", input, "output", output)
-        ctx.mask = input == output
+    if _is_min_max(reduce_op):
+        ctx.save_for_backward(input, output)
+
 
 torch.library.register_autograd(
     "_c10d_functional::all_reduce",

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -641,46 +641,35 @@ torch.library.register_autograd(
 )
 
 
+def _is_reduceop_supported(op):
+    from torch.distributed import ReduceOp as _ReduceOp
+    if isinstance(op, _ReduceOp):
+        return op.op in (_ReduceOp.SUM, _ReduceOp.AVG, _ReduceOp.PREMUL_SUM, _ReduceOp.MAX, _ReduceOp.MIN)
+    return op in ("sum", "avg", "premul_sum", "max", "min")
+
+
 def all_reduce_backward(ctx, grad_output: torch.Tensor):
-    """
-    Backward for all_reduce: all_reduce with same reduce_op.
-    Forward aggregates tensors, backward aggregates gradients.
-
-    Args:
-        ctx: Context object
-        grad_output: Gradient from downstream operations
-
-    Returns:
-        Tuple of (grad_input, grad_group_name, grad_reduce_op)
-        grad_group_name and grad_reduce_op are None (not differentiable)
-    """
-    group_name = ctx.group_name
+    from torch.distributed import ReduceOp as _ReduceOp
     reduce_op = ctx.reduce_op
-
-    if reduce_op not in ("sum", "avg"):
-        raise RuntimeError(
-            f"all_reduce backward only supports 'sum' and 'avg' reductions, got '{reduce_op}'"
-        )
-
-    # Backward does all_reduce with the same reduce_op
+    if not _is_reduceop_supported(reduce_op):
+        raise RuntimeError(f"all_reduce backward only supports sum-like reductions, got '{reduce_op}'")
     output = torch.ops._c10d_functional.all_reduce(
-        grad_output.contiguous(), reduce_op, group_name
+        grad_output.contiguous(), reduce_op, ctx.group_name
     )
+    if reduce_op == "min" or reduce_op == "max" or reduce_op == _ReduceOp.MIN or reduce_op == _ReduceOp.MAX:
+        output = torch.ops.aten.where.ScalarOther(ctx.mask, output, 0)
+
     return wait_tensor(output), None, None
 
 
 def all_reduce_setup_context(ctx, inputs, output):
-    """
-    Setup context for all_reduce backward.
-    Args:
-        ctx: Context object to save state for backward
-        inputs: Tuple of (input, reduce_op, group_name)
-        output: Output from forward pass
-    """
     input, reduce_op, group_name = inputs
     ctx.group_name = group_name
-    ctx.reduce_op = reduce_op.lower()
-
+    ctx.reduce_op = reduce_op.lower() if isinstance(reduce_op, str) else reduce_op
+    if reduce_op == "min" or reduce_op == "max" or reduce_op == _ReduceOp.MIN or reduce_op == _ReduceOp.MAX:
+        # TODO: handle is_nan
+        print("input", input, "output", output)
+        ctx.mask = input == output
 
 torch.library.register_autograd(
     "_c10d_functional::all_reduce",

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -664,6 +664,19 @@ def _is_reduceop_supported(op: str | ReduceOp):
 
 
 def all_reduce_backward(ctx, grad_output: torch.Tensor):
+    """
+    Backward for all_reduce: all_reduce with same reduce_op.
+    Forward aggregates tensors, backward aggregates gradients.
+
+    Args:
+        ctx: Context object
+        grad_output: Gradient from downstream operations
+
+    Returns:
+        Tuple of (grad_input, grad_group_name, grad_reduce_op)
+        grad_group_name and grad_reduce_op are None (not differentiable)
+    """
+    group_name = ctx.group_name
     reduce_op = ctx.reduce_op
     if not _is_reduceop_supported(reduce_op):
         raise RuntimeError(
@@ -671,7 +684,7 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
         )
     grad_reduce_op = "sum" if _is_min_max(reduce_op) else reduce_op
     output = torch.ops._c10d_functional.all_reduce(
-        grad_output.contiguous(), grad_reduce_op, ctx.group_name
+        grad_output.contiguous(), grad_reduce_op, group_name
     )
     if _is_min_max(reduce_op):
         fwd_input, fwd_output = ctx.saved_tensors
@@ -683,6 +696,13 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
 
 
 def all_reduce_setup_context(ctx, inputs, output):
+    """
+    Setup context for all_reduce backward.
+    Args:
+        ctx: Context object to save state for backward
+        inputs: Tuple of (input, reduce_op, group_name)
+        output: Output from forward pass
+    """
     input, reduce_op, group_name = inputs
     ctx.group_name = group_name
     ctx.reduce_op = reduce_op.lower() if isinstance(reduce_op, str) else reduce_op

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -657,10 +657,6 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
     group_name = ctx.group_name
     reduce_op = ctx.reduce_op
 
-    # Only linear reductions have a well-defined all_reduce backward: for both
-    # 'sum' and 'avg' the gradient is an all_reduce of grad_output with the same
-    # op (grad wrt each rank's input is the same reduction of the per-rank
-    # grad_outputs). Nonlinear ops (min/max/product/premul_sum) do not.
     if reduce_op not in ("sum", "avg"):
         raise RuntimeError(
             f"all_reduce backward only supports 'sum' and 'avg' reductions, got '{reduce_op}'"

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -686,13 +686,19 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
     output = torch.ops._c10d_functional.all_reduce(
         grad_output.contiguous(), grad_reduce_op, group_name
     )
+
+    output = wait_tensor(output)
     if _is_min_max(reduce_op):
         fwd_input, fwd_output = ctx.saved_tensors
-        output = torch.ops.aten.where.ScalarOther(
-            fwd_input == fwd_output, wait_tensor(output), 0
+        fwd_input_isnan = fwd_input.isnan()
+        output = torch.ops.aten.where.self(
+            fwd_input_isnan,
+            output,
+            torch.ops.aten.where.ScalarOther(
+                fwd_input == wait_tensor(fwd_output), output, 0
+            ),
         )
-        return output, None, None
-    return wait_tensor(output), None, None
+    return output, None, None
 
 
 def all_reduce_setup_context(ctx, inputs, output):

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -152,13 +152,24 @@ class AllToAllBase:
         return sizes
 
 
+def _premul_sum_reduce(tensors, factor):
+    if isinstance(factor, torch.Tensor):
+        factor = factor.to(tensors[0].device)
+    return torch.sum(torch.stack([t * factor for t in tensors]), dim=0)
+
+
 class AllReduce:
     def __init__(self, op):
-        if op.op not in _reduce_ops:
+        if op.op == ReduceOp.PREMUL_SUM:
+            self.op = op.op
+            self.premul_factor = op.factor
+        elif op.op in _reduce_ops:
+            self.op = op.op
+            self.premul_factor = None
+        else:
             raise NotImplementedError(
                 f"AllReduce op {op.op} not supported on multithreaded pg for now."
             )
-        self.op = op.op
 
     @torch.no_grad()
     def work(self, data):
@@ -172,7 +183,10 @@ class AllReduce:
             ]
 
             # now mimic reduce across all ranks
-            res = _reduce_ops[self.op](tensors)
+            if self.premul_factor is not None:
+                res = _premul_sum_reduce(tensors, self.premul_factor)
+            else:
+                res = _reduce_ops[self.op](tensors)
 
             # copy all the reduced value to each rank
             for src_rank in range(len(data)):


### PR DESCRIPTION
This PR
1. adds `premul_sum` support for functional all_reduce forward (& backward) by making the `reduce_op` argument `Any` in the schema so that we can pass `ReduceOp` object directly with factor supplement.
2. adds `min` and `max`'s backward support by comparing the output value with the inputs locally to route the gradients.
3. parameterizes the existing all_reduce tests to cover the changes made.
4. Prior discussion thread pertaining to supporting these ops: https://github.com/pytorch/pytorch/pull/168140#discussion_r2557161472

Authored with AI assistance.