### PR TITLE
[inductor] Defer profitable pointwise materialization

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -2202,6 +2202,12 @@ class ComboKernelTestsMaxAutotune(TestCase):
                 {"x": 8, "r0_": 1},
                 2,
             ),
+            (
+                "different heavy reduction rblock",
+                ("inductor_meta_1", "add_heavy_reduction_rblock"),
+                True,
+                2,
+            ),
         ]
 
         for desc, path, value, expected_groups in cases:

--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -994,6 +994,85 @@ class TestScheduler(TestCase):
     @xfailIfNoAcceleratorTriton
     @onlyCUDA
     @parametrize(
+        "broadcast_reads,index_repeats,expected_kernels",
+        ((True, 1, 1), (False, 1, 2), (True, 2, 2)),
+    )
+    @inductor_config.patch(realize_acc_reads_threshold=1)
+    def test_accumulated_read_realization_uses_io_cost(
+        self, broadcast_reads, index_repeats, expected_kernels
+    ):
+        def fn(x, other, index):
+            gathered = (x.sin() + other.cos())[index]
+            if index_repeats > 1:
+                return gathered.view(index_repeats, -1).sum(0)
+            return gathered + 1
+
+        torch.manual_seed(0)
+        x = torch.randn(4096, device="cuda")
+        shape = () if broadcast_reads else x.shape
+        args = (
+            x,
+            torch.randn(shape, device="cuda"),
+            torch.randperm(x.numel(), device="cuda").repeat(index_repeats),
+        )
+        expected = fn(*args)
+
+        torch._dynamo.reset()
+        metrics.reset()
+        with fresh_inductor_cache():
+            actual = torch.compile(fn, fullgraph=True)(*args)
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(metrics.generated_kernel_count, expected_kernels)
+
+    @xfailIfNoAcceleratorTriton
+    @onlyCUDA
+    @inductor_config.patch("triton.multi_kernel", 0)
+    def test_single_use_nonexpanding_consumer_defers_realization(self):
+        def fn(
+            expert, expert_idx, payload, logits, permutation, skip, residual, weight
+        ):
+            rows = payload.shape[0]
+            values = payload + expert[expert_idx]
+            probabilities = torch.softmax(logits.float(), dim=-1).to(payload.dtype)
+            weights = probabilities.reshape(-1)[permutation]
+            weighted = torch.where(skip, 0.0, values * weights[:, None])
+            inverse = torch.empty_like(permutation)
+            inverse[permutation] = torch.arange(rows, device=permutation.device)
+            routed = weighted[inverse].view(*logits.shape, -1).sum(1)
+            add = residual + routed
+            norm_input = add.float()
+            scale = torch.rsqrt(norm_input.square().mean(-1, keepdim=True) + 1e-5)
+            return add, (norm_input * scale * weight).to(payload.dtype)
+
+        tokens, topk, hidden = 64, 4, 2880
+        rows = tokens * topk
+        torch.manual_seed(0)
+        permutation = torch.randperm(rows, device="cuda")
+        args = (
+            torch.randn(32, hidden, device="cuda", dtype=torch.bfloat16),
+            torch.randint(0, 32, (rows,), device="cuda"),
+            torch.randn(rows, hidden, device="cuda", dtype=torch.bfloat16),
+            torch.randn(tokens, topk, device="cuda", dtype=torch.bfloat16),
+            permutation,
+            torch.randint(0, 2, (rows, 1), device="cuda", dtype=torch.bool),
+            torch.randn(tokens, hidden, device="cuda", dtype=torch.bfloat16),
+            torch.randn(hidden, device="cuda", dtype=torch.bfloat16),
+        )
+        expected = fn(*args)
+
+        torch._dynamo.reset()
+        metrics.reset()
+        with fresh_inductor_cache():
+            actual, code = run_and_get_code(torch.compile(fn, fullgraph=True), *args)
+
+        self.assertEqual(expected, actual, atol=5e-2, rtol=2e-2)
+        self.assertEqual(metrics.generated_kernel_count, 2)
+        self.assertIn("'add_heavy_reduction_rblock': True", "\n".join(code))
+
+    @xfailIfNoAcceleratorTriton
+    @onlyCUDA
+    @parametrize(
         "extra_cols,with_residual,expected_kernels",
         ((1, False, 1), (1, True, 2), (16, False, 2)),
     )

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -43,6 +43,7 @@ from torch._inductor.runtime.hints import (
     HeuristicType,
     native_matmul_block_numel,
     native_matmul_persistent_rblock,
+    ReductionHint,
     TRITON_MAX_BLOCK,
     TRITON_MAX_TENSOR_NUMEL,
 )
@@ -183,6 +184,36 @@ class TestTritonHeuristics(TestCase):
         )[0]
         self.assertEqual(cfg.kwargs["XBLOCK"], 512)
         self.assertEqual(cfg.kwargs["R0_BLOCK"], 128)
+
+    @parametrize(
+        "loads_and_reductions,expected_full_rblocks", ((8, 3), (9, 3), (10, 0))
+    )
+    def test_heavy_reduction_rblock_configs(
+        self, loads_and_reductions, expected_full_rblocks
+    ):
+        device = DeviceProperties(
+            type="cuda",
+            index=0,
+            multi_processor_count=132,
+            cc=90,
+            major=9,
+            max_threads_per_block=1024,
+            warp_size=32,
+        )
+        configs = _reduction_configs(
+            size_hints={"x": 1024, "r0_": 4096},
+            inductor_meta={
+                "add_heavy_reduction_rblock": True,
+                "num_load": loads_and_reductions - 1,
+                "num_reduction": 1,
+                "reduction_hint": ReductionHint.INNER,
+            },
+            triton_meta={"device": device},
+        )
+        full_rblocks = [
+            config for config in configs if config.kwargs["R0_BLOCK"] == 4096
+        ]
+        self.assertEqual(len(full_rblocks), expected_full_rblocks)
 
     def test_cached_autotune_enforces_reduction_min_block(self):
         def triton_fn(XBLOCK: tl.constexpr, R0_BLOCK: tl.constexpr):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6989,6 +6989,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             out["native_matmul_persistent_rblock"] = rblock
         if self.add_persistent_rblock:
             out["add_persistent_rblock"] = True
+        if self.add_heavy_reduction_rblock:
+            out["add_heavy_reduction_rblock"] = True
         if (
             config.benchmark_kernel
             or config.profile_bandwidth
@@ -7098,6 +7100,42 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             ):
                 return True
         return False
+
+    @functools.cached_property
+    def add_heavy_reduction_rblock(self) -> bool:
+        if (
+            torch.version.hip
+            or V.graph.get_current_device_or_throw().type != "cuda"
+            or not self.features.is_reduction()
+            or self.persistent_reduction
+            or len(self.tiling) != 2
+        ):
+            return False
+
+        memory_stats = self.features.memory_stats(self.tiling)
+        loop_stats = memory_stats.looped.memory.loop
+        if len(loop_stats) < 2:
+            return False
+
+        first_loop_ops = loop_stats[0].count_per_thread
+        remaining_loop_ops = max(stat.count_per_thread for stat in loop_stats[1:])
+        looped_bytes = V.graph.sizevars.optimization_hint(
+            memory_stats.looped.memory.bytes
+        )
+        persistent_bytes = V.graph.sizevars.optimization_hint(
+            memory_stats.persistent.memory.bytes
+        )
+        reduction_numel = self.features.reduction_numel
+        # A full RBLOCK reduces loop overhead for the large first reduction phase.
+        return (
+            self.features.get_reduction_hint(self.tiling_scores)
+            == ReductionHint.INNER
+            and V.graph.sizevars.statically_known_gt(reduction_numel, 2048)
+            and V.graph.sizevars.statically_known_leq(reduction_numel, 4096)
+            and 10 * looped_bytes >= 11 * max(persistent_bytes, 1)
+            and first_loop_ops >= 16
+            and first_loop_ops >= 2 * remaining_loop_ops
+        )
 
     def codegen_kernel(self, name=None) -> str:
         """

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -108,9 +108,11 @@ from .runtime import autotune_cache
 from .runtime.autotune_cache import AutotuneCacheBundler
 from .sizevars import SizeVarAllocator
 from .utils import (
+    convert_symint_to_expr,
     gather_origins,
     get_cloned_parameter_buffer_name,
     get_donated_idxs,
+    get_dtype_size,
     get_sympy_Expr_dtype,
     GraphPartitionMap,
     is_same_tensor,
@@ -1922,6 +1924,46 @@ class GraphLowering(torch.fx.Interpreter):
             if isinstance(ir_value, ir.TensorBox):
                 ir_value.realize()
 
+    def _should_defer_accumulated_read_realization(
+        self, n: torch.fx.Node, result: TensorBox
+    ) -> bool:
+        if config.deterministic or torch.are_deterministic_algorithms_enabled():
+            return False
+        if len(n.users) != 1:
+            return False
+
+        user = next(iter(n.users))
+        value = n.meta.get("val")
+        user_value = user.meta.get("val")
+        if not isinstance(value, torch.Tensor) or not isinstance(
+            user_value, torch.Tensor
+        ):
+            return False
+        value_numel = convert_symint_to_expr(value.numel())
+        user_numel = convert_symint_to_expr(user_value.numel())
+        if not self.sizevars.statically_known_leq(user_numel, value_numel):
+            return False
+
+        data = result.data
+        while not isinstance(data, StorageBox) and isinstance(
+            data, (ir.BaseView, ir.MutableBox)
+        ):
+            data = data.data
+        if (
+            not isinstance(data, StorageBox)
+            or not isinstance(data.data, Pointwise)
+            or data.get_device().type != "cuda"
+        ):
+            return False
+
+        output_numel = self.sizevars.optimization_hint(data.get_numel(), fallback=0)
+        read_bytes = [self.get_dep_size_hint(dep) for dep in data.get_reads()]
+        if output_numel == 0 or not read_bytes or any(size == 0 for size in read_bytes):
+            return False
+        # Realization adds one write and one read of the producer output.
+        output_bytes = output_numel * get_dtype_size(data.get_dtype())
+        return 2 * output_bytes > sum(read_bytes)
+
     def run_node(self, n: torch.fx.Node) -> object:
         """Lower and execute a single FX node into Inductor IR."""
 
@@ -2236,7 +2278,11 @@ class GraphLowering(torch.fx.Interpreter):
                 result.mark_reuse(len(n.users))
 
             # Realize if the IRNode already has accumulated lots of reads
-            if isinstance(result, TensorBox) and result.has_exceeded_max_reads():
+            if (
+                isinstance(result, TensorBox)
+                and result.has_exceeded_max_reads()
+                and not self._should_defer_accumulated_read_realization(n, result)
+            ):
                 # Prevent excessive accumulation in a computed buffer, when
                 # there are multiple branches each with small number of memory
                 # reads, but they converge to a user.

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -302,6 +302,17 @@ class ReductionHeuristic(CodegenConfigHeuristics):
             )
             configs.append(c)
 
+        if inductor_meta.get("add_heavy_reduction_rblock") and loads_and_red <= 9:
+            for xblock, num_warps in ((1, 2), (1, 4), (2, 8)):
+                c = make_config(
+                    xblock,
+                    min(rnumel, 4096),
+                    num_warps=num_warps,
+                    register_intensive=True,
+                    dynamic_scale_rblock=False,
+                )
+                configs.append(c)
+
         # For 3d tiling, default to more autotuning initially
         if "y" in size_hints:
             pass

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -327,6 +327,7 @@ class InductorMeta(typing.TypedDict, total=False):
     persistent_reduction: bool
     native_matmul_persistent_rblock: int
     add_persistent_rblock: bool
+    add_heavy_reduction_rblock: bool
     max_persistent_rblock: int
     kernel_num_gb: float
     kernel_flop: int

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4050,6 +4050,7 @@ def _subkernel_fingerprint(combo_meta: dict[str, Any], i: int) -> tuple[Any, ...
         combo_meta.get(f"reduction_hint_{i}"),
         combo_meta.get(f"tile_hint_{i}"),
         sub_meta.get("add_persistent_rblock", False),
+        sub_meta.get("add_heavy_reduction_rblock", False),
         sub_meta.get("has_loadstore_with_contiguous_rdim"),
         tuple(sorted(tma.items())),
         tuple(sorted(tiling_scores.items())),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190926
* #190925
* #190924
* __->__ #190945

The accumulated-read heuristic realizes pointwise IR based on read count. In
the GPT-OSS routed MoE combine, that materializes a 23 MB intermediate even
though its sole consumer contracts the domain and writing plus rereading the
intermediate costs more than all of the producer's source reads. The indirect
gather then becomes a StarDep, so the scheduler cannot recover the fusion.

Defer this realization only for a single statically non-expanding CUDA
consumer when the avoided output round trip exceeds the producer's known input
traffic. Unknown sizes, deterministic mode, non-pointwise producers, and
multiple consumers keep the existing behavior.

Inlining the producer creates a much heavier inner reduction. Add full-RBLOCK
autotuning choices only for 2D inner reductions in the (2048, 4096] range whose
first phase has at least 16 memory operations, is at least twice as heavy as
later phases, and has measurable looped-memory overhead. The candidate is also
isolated in combo-kernel tuning fingerprints. These changes stay together
because deferring realization without the schedule choices can produce a
slower fused kernel. Raising the global read threshold was rejected because it
does not account for output expansion or the relative traffic saved.

On H100 with locked clocks and coordinate descent disabled:

| Better Benchmark capture | Before | After | Oracle | Generated kernels |
| --- | ---: | ---: | ---: | ---: |
| `a184947064f0` | 67.55 us | 30.43 us | 29.70 us | 4 -> 3 |
| `4053b14a3062` | 66.66 us | 33.66 us | 29.44 us | 4 -> 3 |

The main capture improves 54.9% and represents 23 GPT-OSS occurrences. The
single-output sibling represents the final occurrence. Structured traversal of
the saved full FX graph found all 24 routed-combine chains satisfy the sole-use,
non-expanding preconditions. The rollup projects about 0.79 ms or 3.4% lower
GPT-OSS model time from this change.

Across the 4,969 points common to paired 4,977-point dashboard runs, the
change improves geomean by 0.18%. Exactly four common points change generated
kernel count, all from one fewer kernel and all faster (4.3%-13.5%). The target
captures were among the concurrent OOMs and are measured separately above;
the OOM points checked sequentially compile and run successfully.

A locked-clock rerun of the ten largest apparent dashboard regressions is
neutral at +0.28% geomean, with every point between -0.59% and +0.83% and no
kernel-count changes.

Test Plan:

```bash
python test/inductor/test_inductor_scheduler.py -k realization
python test/inductor/test_inductor_scheduler.py -k expand_reuse
python test/inductor/test_inductor_scheduler.py -k cat_reduction_slice_fusion
python test/inductor/test_triton_heuristics.py -k heavy_reduction_rblock_configs
python test/inductor/test_combo_kernels.py -k combo_autotune_grouping_by_metadata_fingerprint
python scripts/bench_parallel.py repros/canonical --all-shapes --gpus 0,1 --workers-per-gpu 4 --no-cd --no-share-cache --no-lock-clocks --inductor-config triton.multi_kernel=1
python -m py_compile torch/_inductor/graph.py torch/_inductor/codegen/triton.py torch/_inductor/heuristics/triton_codegen/reduction.py torch/_inductor/runtime/hints.py torch/_inductor/runtime/triton_heuristics.py test/inductor/test_inductor_scheduler.py test/inductor/test_triton_heuristics.py test/inductor/test_combo_kernels.py
git diff --check
lintrunner -a
```

`lintrunner -a` could not start its linters because their packages could not be
fetched from PyPI through the configured proxy.

Authored with an AI assistant.