### PR TITLE
[Profiler] Clamp overrun python events

### DIFF
--- a/test/cpp/profiler/test_profiler_collection.cpp
+++ b/test/cpp/profiler/test_profiler_collection.cpp
@@ -31,12 +31,14 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include <c10/util/Exception.h>
 #include <torch/csrc/autograd/profiler_kineto.h>
+#include <torch/csrc/profiler/collection.h>
 #include <torch/csrc/profiler/standalone/privateuse1_profiler.h>
 
 #include <GenericTraceActivity.h>
@@ -261,6 +263,112 @@ TEST(ProfilerCollectionTest, DuplicateFlowIdHandledGracefully) {
   }
   EXPECT_TRUE(saw_per_id_warning);
   EXPECT_TRUE(saw_summary_warning);
+}
+
+namespace {
+using torch::profiler::impl::EventType;
+using torch::profiler::impl::ExtraFields;
+using torch::profiler::impl::PyFrameState;
+using torch::profiler::impl::Result;
+
+std::shared_ptr<Result> makePyCall(
+    int64_t start_ns,
+    int64_t end_ns,
+    uint64_t system_tid,
+    size_t python_tid) {
+  PyFrameState frame{0, at::StringView("f.py"), at::StringView("fn")};
+  PyFrameState caller{0, at::StringView("caller.py"), at::StringView("caller")};
+  ExtraFields<EventType::PyCall>::args_t args{frame, std::nullopt, std::nullopt};
+  return Result::create(
+      start_ns,
+      system_tid,
+      torch::profiler::impl::kineto::DeviceAndResource(),
+      ExtraFields<EventType::PyCall>(
+          end_ns, python_tid, caller, std::move(args)));
+}
+
+std::shared_ptr<Result> makePyCCall(
+    int64_t start_ns,
+    int64_t end_ns,
+    uint64_t system_tid,
+    size_t python_tid) {
+  PyFrameState caller{0, at::StringView("caller.py"), at::StringView("caller")};
+  return Result::create(
+      start_ns,
+      system_tid,
+      torch::profiler::impl::kineto::DeviceAndResource(),
+      ExtraFields<EventType::PyCCall>(
+          end_ns,
+          python_tid,
+          caller,
+          at::StringView("<built-in method foo>")));
+}
+
+} // namespace
+
+TEST(PythonEventTimestampClampTest, ClampsOrphanToParentEnd) {
+  auto parent = makePyCall(100, 200, /*system_tid=*/7, /*python_tid=*/1);
+  auto orphan = makePyCCall(150, 10000, /*system_tid=*/7, /*python_tid=*/1);
+  std::vector<std::shared_ptr<Result>> events{parent, orphan};
+
+  torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
+
+  EXPECT_EQ(orphan->endTimeNS(), 200);
+}
+
+TEST(PythonEventTimestampClampTest, CascadesClampsToDescendants) {
+  auto parent = makePyCall(100, 200, /*system_tid=*/7, /*python_tid=*/1);
+  auto child = makePyCCall(120, 10000, /*system_tid=*/7, /*python_tid=*/1);
+  auto grandchild = makePyCall(140, 10000, /*system_tid=*/7, /*python_tid=*/1);
+  std::vector<std::shared_ptr<Result>> events{parent, child, grandchild};
+
+  torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
+
+  EXPECT_EQ(child->endTimeNS(), 200);
+  EXPECT_EQ(grandchild->endTimeNS(), 200);
+}
+
+TEST(PythonEventTimestampClampTest, LeavesActiveStackUnchanged) {
+  auto parent = makePyCall(100, 10000, /*system_tid=*/7, /*python_tid=*/1);
+  auto child = makePyCCall(150, 10000, /*system_tid=*/7, /*python_tid=*/1);
+  std::vector<std::shared_ptr<Result>> events{parent, child};
+
+  torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
+
+  EXPECT_EQ(parent->endTimeNS(), 10000);
+  EXPECT_EQ(child->endTimeNS(), 10000);
+}
+
+TEST(PythonEventTimestampClampTest, DoesNotUseExpiredAncestor) {
+  auto ancestor = makePyCCall(100, 200, /*system_tid=*/7, /*python_tid=*/1);
+  auto event = makePyCall(500, 600, /*system_tid=*/7, /*python_tid=*/1);
+  std::vector<std::shared_ptr<Result>> events{ancestor, event};
+
+  torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
+
+  EXPECT_EQ(event->endTimeNS(), 600);
+}
+
+TEST(PythonEventTimestampClampTest, DoesNotNestAdjacentEvents) {
+  auto first = makePyCall(100, 200, /*system_tid=*/7, /*python_tid=*/1);
+  auto second = makePyCall(200, 300, /*system_tid=*/7, /*python_tid=*/1);
+  std::vector<std::shared_ptr<Result>> events{first, second};
+
+  torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
+
+  EXPECT_EQ(second->endTimeNS(), 300);
+}
+
+TEST(PythonEventTimestampClampTest, SeparatesUnresolvedSystemThreads) {
+  constexpr auto unresolved_tid = std::numeric_limits<uint64_t>::max();
+  auto ancestor =
+      makePyCCall(100, 5000, unresolved_tid, /*python_tid=*/1);
+  auto event = makePyCall(500, 10000, unresolved_tid, /*python_tid=*/2);
+  std::vector<std::shared_ptr<Result>> events{ancestor, event};
+
+  torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
+
+  EXPECT_EQ(event->endTimeNS(), 10000);
 }
 
 #endif // USE_KINETO

--- a/test/cpp/profiler/test_profiler_collection.cpp
+++ b/test/cpp/profiler/test_profiler_collection.cpp
@@ -276,7 +276,8 @@ std::shared_ptr<Result> makePyCall(
     size_t python_tid) {
   PyFrameState frame{0, at::StringView("f.py"), at::StringView("fn")};
   PyFrameState caller{0, at::StringView("caller.py"), at::StringView("caller")};
-  ExtraFields<EventType::PyCall>::args_t args{frame, std::nullopt, std::nullopt};
+  ExtraFields<EventType::PyCall>::args_t args{
+      frame, std::nullopt, std::nullopt};
   return Result::create(
       start_ns,
       /*start_tid=*/7,
@@ -295,10 +296,7 @@ std::shared_ptr<Result> makePyCCall(
       /*start_tid=*/7,
       torch::profiler::impl::kineto::DeviceAndResource(),
       ExtraFields<EventType::PyCCall>(
-          end_ns,
-          python_tid,
-          caller,
-          at::StringView("<built-in method foo>")));
+          end_ns, python_tid, caller, at::StringView("<built-in method foo>")));
 }
 
 } // namespace

--- a/test/cpp/profiler/test_profiler_collection.cpp
+++ b/test/cpp/profiler/test_profiler_collection.cpp
@@ -31,7 +31,6 @@
 
 #include <gtest/gtest.h>
 
-#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -274,14 +273,13 @@ using torch::profiler::impl::Result;
 std::shared_ptr<Result> makePyCall(
     int64_t start_ns,
     int64_t end_ns,
-    uint64_t system_tid,
     size_t python_tid) {
   PyFrameState frame{0, at::StringView("f.py"), at::StringView("fn")};
   PyFrameState caller{0, at::StringView("caller.py"), at::StringView("caller")};
   ExtraFields<EventType::PyCall>::args_t args{frame, std::nullopt, std::nullopt};
   return Result::create(
       start_ns,
-      system_tid,
+      /*start_tid=*/7,
       torch::profiler::impl::kineto::DeviceAndResource(),
       ExtraFields<EventType::PyCall>(
           end_ns, python_tid, caller, std::move(args)));
@@ -290,12 +288,11 @@ std::shared_ptr<Result> makePyCall(
 std::shared_ptr<Result> makePyCCall(
     int64_t start_ns,
     int64_t end_ns,
-    uint64_t system_tid,
     size_t python_tid) {
   PyFrameState caller{0, at::StringView("caller.py"), at::StringView("caller")};
   return Result::create(
       start_ns,
-      system_tid,
+      /*start_tid=*/7,
       torch::profiler::impl::kineto::DeviceAndResource(),
       ExtraFields<EventType::PyCCall>(
           end_ns,
@@ -306,69 +303,27 @@ std::shared_ptr<Result> makePyCCall(
 
 } // namespace
 
-TEST(PythonEventTimestampClampTest, ClampsOrphanToParentEnd) {
-  auto parent = makePyCall(100, 200, /*system_tid=*/7, /*python_tid=*/1);
-  auto orphan = makePyCCall(150, 10000, /*system_tid=*/7, /*python_tid=*/1);
-  std::vector<std::shared_ptr<Result>> events{parent, orphan};
+TEST(PythonEventTimestampClampTest, ClampsOverrunsWithinPythonThread) {
+  auto parent = makePyCall(100, 500, /*python_tid=*/1);
+  auto valid_child = makePyCall(110, 180, /*python_tid=*/1);
+  auto overrun = makePyCCall(200, 10000, /*python_tid=*/1);
+  auto descendant = makePyCall(220, 10000, /*python_tid=*/1);
+  auto other_thread = makePyCall(250, 900, /*python_tid=*/2);
+  auto adjacent = makePyCall(500, 600, /*python_tid=*/1);
+  std::vector<std::shared_ptr<Result>> events{
+      parent, valid_child, overrun, descendant, other_thread, adjacent};
 
   torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
 
-  EXPECT_EQ(orphan->endTimeNS(), 200);
-}
-
-TEST(PythonEventTimestampClampTest, CascadesClampsToDescendants) {
-  auto parent = makePyCall(100, 200, /*system_tid=*/7, /*python_tid=*/1);
-  auto child = makePyCCall(120, 10000, /*system_tid=*/7, /*python_tid=*/1);
-  auto grandchild = makePyCall(140, 10000, /*system_tid=*/7, /*python_tid=*/1);
-  std::vector<std::shared_ptr<Result>> events{parent, child, grandchild};
-
-  torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
-
-  EXPECT_EQ(child->endTimeNS(), 200);
-  EXPECT_EQ(grandchild->endTimeNS(), 200);
-}
-
-TEST(PythonEventTimestampClampTest, LeavesActiveStackUnchanged) {
-  auto parent = makePyCall(100, 10000, /*system_tid=*/7, /*python_tid=*/1);
-  auto child = makePyCCall(150, 10000, /*system_tid=*/7, /*python_tid=*/1);
-  std::vector<std::shared_ptr<Result>> events{parent, child};
-
-  torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
-
-  EXPECT_EQ(parent->endTimeNS(), 10000);
-  EXPECT_EQ(child->endTimeNS(), 10000);
-}
-
-TEST(PythonEventTimestampClampTest, DoesNotUseExpiredAncestor) {
-  auto ancestor = makePyCCall(100, 200, /*system_tid=*/7, /*python_tid=*/1);
-  auto event = makePyCall(500, 600, /*system_tid=*/7, /*python_tid=*/1);
-  std::vector<std::shared_ptr<Result>> events{ancestor, event};
-
-  torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
-
-  EXPECT_EQ(event->endTimeNS(), 600);
-}
-
-TEST(PythonEventTimestampClampTest, DoesNotNestAdjacentEvents) {
-  auto first = makePyCall(100, 200, /*system_tid=*/7, /*python_tid=*/1);
-  auto second = makePyCall(200, 300, /*system_tid=*/7, /*python_tid=*/1);
-  std::vector<std::shared_ptr<Result>> events{first, second};
-
-  torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
-
-  EXPECT_EQ(second->endTimeNS(), 300);
-}
-
-TEST(PythonEventTimestampClampTest, SeparatesUnresolvedSystemThreads) {
-  constexpr auto unresolved_tid = std::numeric_limits<uint64_t>::max();
-  auto ancestor =
-      makePyCCall(100, 5000, unresolved_tid, /*python_tid=*/1);
-  auto event = makePyCall(500, 10000, unresolved_tid, /*python_tid=*/2);
-  std::vector<std::shared_ptr<Result>> events{ancestor, event};
-
-  torch::profiler::impl::python_tracer::clampOverrunningPythonEvents(events);
-
-  EXPECT_EQ(event->endTimeNS(), 10000);
+  const std::vector<int64_t> expected_end_times{500, 180, 500, 500, 900, 600};
+  const std::vector<int64_t> actual_end_times{
+      parent->endTimeNS(),
+      valid_child->endTimeNS(),
+      overrun->endTimeNS(),
+      descendant->endTimeNS(),
+      other_thread->endTimeNS(),
+      adjacent->endTimeNS()};
+  EXPECT_EQ(actual_end_times, expected_end_times);
 }
 
 #endif // USE_KINETO

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -1496,6 +1496,7 @@ std::vector<std::shared_ptr<Result>> PythonTracer::getEvents(
   std::stable_sort(out.begin(), out.end(), [](const auto& a, const auto& b) {
     return a->start_time_ns_ < b->start_time_ns_;
   });
+  python_tracer::clampOverrunningPythonEvents(out);
 
   PythonIDVisitor id_visitor;
   for (auto& i : out) {

--- a/torch/csrc/profiler/orchestration/python_tracer.cpp
+++ b/torch/csrc/profiler/orchestration/python_tracer.cpp
@@ -1,5 +1,8 @@
 #include <torch/csrc/profiler/orchestration/python_tracer.h>
 
+#include <c10/util/overloaded.h>
+#include <torch/csrc/profiler/collection.h>
+
 namespace torch::profiler::impl::python_tracer {
 namespace {
 MakeFn make_fn;
@@ -29,6 +32,47 @@ struct NoOpMemoryPythonTracer : public PythonMemoryTracerBase {
 };
 
 } // namespace
+
+void clampOverrunningPythonEvents(
+    const std::vector<std::shared_ptr<Result>>& sorted_events) {
+  std::vector<std::vector<Result*>> stacks;
+  for (const auto& event : sorted_events) {
+    const auto tag = event->tag();
+    TORCH_INTERNAL_ASSERT(
+        tag == EventType::PyCall || tag == EventType::PyCCall,
+        "Expected a Python event");
+
+    size_t python_tid = 0;
+    event->visit_if_base<PyExtraFieldsBase>(
+        [&](const auto& fields) { python_tid = fields.python_tid_; });
+    if (python_tid >= stacks.size()) {
+      stacks.resize(python_tid + 1);
+    }
+    auto& stack = stacks[python_tid];
+
+    while (!stack.empty() &&
+           stack.back()->endTimeNS() <= event->start_time_ns_) {
+      stack.pop_back();
+    }
+
+    if (!stack.empty() &&
+        event->endTimeNS() > stack.back()->endTimeNS()) {
+      const auto parent_end_ns = stack.back()->endTimeNS();
+      event->visit(c10::overloaded(
+          [parent_end_ns](ExtraFields<EventType::PyCall>& fields) {
+            fields.end_time_ns_ = parent_end_ns;
+          },
+          [parent_end_ns](ExtraFields<EventType::PyCCall>& fields) {
+            fields.end_time_ns_ = parent_end_ns;
+          },
+          [](auto&) {}));
+    }
+
+    if (event->endTimeNS() > event->start_time_ns_) {
+      stack.push_back(event.get());
+    }
+  }
+}
 
 void registerTracer(MakeFn make_tracer) {
   make_fn = make_tracer;

--- a/torch/csrc/profiler/orchestration/python_tracer.cpp
+++ b/torch/csrc/profiler/orchestration/python_tracer.cpp
@@ -38,29 +38,28 @@ void clampOverrunningPythonEvents(
   // If a Python event is pushed to the CALL queue, but a corresponding RETURN
   // event is never pushed, this can cause imbalance between the stacks during
   // replay. When this happens we attempt to remedy the situation by assigning
-  // the imbalanced event an end time equal to the end time of the profiling session.
-  // This can cause weird visualizations in the profile.
+  // the imbalanced event an end time equal to the end time of the profiling
+  // session. This can cause weird visualizations in the profile.
   //
   // To fix this, we perform an initial pass through the events to identify
-  // mismatches and clamp the end timestamp to the parent event to avoid this overrun.
+  // mismatches and clamp the end timestamp to the parent event to avoid this
+  // overrun.
 
-  // One stack per thread, dynamically resized below. We only need to track the end
-  // timestamp for the events we've seen before.
+  // One stack per thread, dynamically resized below. We only need to track the
+  // end timestamp for the events we've seen before.
   std::vector<std::vector<c10::time_t>> stacks;
   for (const auto& event : sorted_events) {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-        event->tag() == EventType::PyCall ||
-            event->tag() == EventType::PyCCall,
+        event->tag() == EventType::PyCall || event->tag() == EventType::PyCCall,
         "Expected a Python event");
 
     const auto start_time_ns = event->start_time_ns_;
     size_t python_tid = 0;
     c10::time_t end_time_ns = 0;
-    event->visit_if_base<PyExtraFieldsBase>(
-        [&](const auto& fields) {
-          python_tid = fields.python_tid_;
-          end_time_ns = fields.end_time_ns_;
-        });
+    event->visit_if_base<PyExtraFieldsBase>([&](const auto& fields) {
+      python_tid = fields.python_tid_;
+      end_time_ns = fields.end_time_ns_;
+    });
 
     if (python_tid >= stacks.size()) {
       stacks.resize(python_tid + 1);

--- a/torch/csrc/profiler/orchestration/python_tracer.cpp
+++ b/torch/csrc/profiler/orchestration/python_tracer.cpp
@@ -35,29 +35,54 @@ struct NoOpMemoryPythonTracer : public PythonMemoryTracerBase {
 
 void clampOverrunningPythonEvents(
     const std::vector<std::shared_ptr<Result>>& sorted_events) {
-  std::vector<std::vector<Result*>> stacks;
+  // If a Python event is pushed to the CALL queue, but a corresponding RETURN
+  // event is never pushed, this can cause imbalance between the stacks during
+  // replay. When this happens we attempt to remedy the situation by assigning
+  // the imbalanced event an end time equal to the end time of the profiling session.
+  // This can cause weird visualizations in the profile.
+  //
+  // To fix this, we perform an initial pass through the events to identify
+  // mismatches and clamp the end timestamp to the parent event to avoid this overrun.
+
+  // One stack per thread, dynamically resized below. We only need to track the end
+  // timestamp for the events we've seen before.
+  std::vector<std::vector<c10::time_t>> stacks;
   for (const auto& event : sorted_events) {
-    const auto tag = event->tag();
-    TORCH_INTERNAL_ASSERT(
-        tag == EventType::PyCall || tag == EventType::PyCCall,
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+        event->tag() == EventType::PyCall ||
+            event->tag() == EventType::PyCCall,
         "Expected a Python event");
 
+    const auto start_time_ns = event->start_time_ns_;
     size_t python_tid = 0;
+    c10::time_t end_time_ns = 0;
     event->visit_if_base<PyExtraFieldsBase>(
-        [&](const auto& fields) { python_tid = fields.python_tid_; });
+        [&](const auto& fields) {
+          python_tid = fields.python_tid_;
+          end_time_ns = fields.end_time_ns_;
+        });
+
     if (python_tid >= stacks.size()) {
       stacks.resize(python_tid + 1);
     }
     auto& stack = stacks[python_tid];
 
-    while (!stack.empty() &&
-           stack.back()->endTimeNS() <= event->start_time_ns_) {
+    // For the current python_tid's stack, remove events that
+    // ended <= the start time of the current event. Afterward,
+    // stack.back() is the nearest active candidate parent.
+    c10::time_t parent_end_ns = 0;
+    while (!stack.empty()) {
+      parent_end_ns = stack.back();
+      if (parent_end_ns > start_time_ns) {
+        break;
+      }
       stack.pop_back();
     }
 
-    if (!stack.empty() &&
-        event->endTimeNS() > stack.back()->endTimeNS()) {
-      const auto parent_end_ns = stack.back()->endTimeNS();
+    // If the current event has end time greater than parent end time,
+    // perform clamping by assigning it the parent's end time.
+    if (!stack.empty() && end_time_ns > parent_end_ns) {
+      end_time_ns = parent_end_ns;
       event->visit(c10::overloaded(
           [parent_end_ns](ExtraFields<EventType::PyCall>& fields) {
             fields.end_time_ns_ = parent_end_ns;
@@ -68,9 +93,7 @@ void clampOverrunningPythonEvents(
           [](auto&) {}));
     }
 
-    if (event->endTimeNS() > event->start_time_ns_) {
-      stack.push_back(event.get());
-    }
+    stack.push_back(end_time_ns);
   }
 }
 

--- a/torch/csrc/profiler/orchestration/python_tracer.h
+++ b/torch/csrc/profiler/orchestration/python_tracer.h
@@ -31,6 +31,11 @@ struct CompressedEvent {
   c10::time_t enter_t_{};
 };
 
+// Bounds Python events by their nearest same-thread Python ancestor.
+// `sorted_events` must be ordered by start time.
+TORCH_API void clampOverrunningPythonEvents(
+    const std::vector<std::shared_ptr<Result>>& sorted_events);
+
 /*
 Libtorch does not depend on Python (e.g. cannot #include <Python.h>); however
 when we call the profiler from libtorch_python we need the profiler to be able


### PR DESCRIPTION
@hjli-creator recently called out that Python stack traces can look weird in profiles when the end time of the event is incorrectly reported. Specifically, when profiler receives a CALL callback for a function but doesn't receive a corresponding RETURN, the two will be mismatched on replay and the extra, open CALL will be assumed to have an end timestamp equal to the end time of the profile. When viewed as a JSON trace, these events can get punted into a different track, making Python stack analysis hard.

To fix this, when reconstructing the python stack, we check to make sure that any child functions do not have end timestamp greater than the parent's. If so, we clamp the end to the parent's end. This is the same approach taken in https://github.com/pytorch/pytorch/pull/189794, but done without sorting and rebuilding a tree out of the events list.

An example of the previous, bad behavior:
<img width="1467" height="582" alt="image" src="https://github.com/user-attachments/assets/7cfa1fd5-7384-491e-9c09-8876bf496e18" />

Re-running it shows that this has been fixed, and things are now nested properly:
<img width="1458" height="533" alt="image" src="https://github.com/user-attachments/assets/e9432548-233d-4aec-8bf2-6c8c47d7d34e" />

I expect about a ~1.5% runtime regression on `profiler.stop()` as a result of this change. This was measured by timing the clamp itself and comparing it against the overall runtime, and repeating 15 times. Specifically we measured for a dummy profile with 100k `python_function` events:

Average **173.47ms** spent on clamp itself
**11,736.21ms** total time spent in profiler.stop() total

So **~1.48%** of time was spent in the clamp. 