### PR TITLE
[dynamo] Clear discarded-attempt weakrefs so swap_tensors works after compile

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -8387,8 +8387,16 @@ SavedForBackwardsAOTOutput(idx=5)""",
         torch._dynamo.reset()
         m3 = TensorifyMod()
         x = torch.randn(4, 8)
-        with mock.patch.object(
-            DynamoTracerOutput, "_cleanup_output_graph", recording_cleanup
+        # specialize_float=False is required for the scalar-tensorify restart to
+        # fire: the dynamic-shapes test variant sets specialize_float=True, which
+        # constant-folds the float so no symfloat (and no tensorify restart) is
+        # produced. Pin it here so axis 3 deterministically triggers the restart
+        # under both the default config and the dynamic-shapes variant.
+        with (
+            torch._dynamo.config.patch(specialize_float=False),
+            mock.patch.object(
+                DynamoTracerOutput, "_cleanup_output_graph", recording_cleanup
+            ),
         ):
             cm3 = torch.compile(m3, backend="aot_eager")
             cm3(x, 2.0)

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -8297,6 +8297,118 @@ SavedForBackwardsAOTOutput(idx=5)""",
             ):
                 torch.compile(fn, backend="eager", fullgraph=True)(dual)
 
+    def test_swap_tensors_after_discarded_attempt(self):
+        # Issue #186796: a discarded restart/skip attempt fakifies the real
+        # params and builds guards on them, leaving weakrefs on the real params
+        # (guard TensorWeakRef, tensor_to_context WeakIdRef, fake-mode describer
+        # WeakIdRef) that block torch.utils.swap_tensors after compile.
+        # _cleanup_output_graph must drop those weakrefs.
+        def assert_swappable(param):
+            # Raises "Cannot swap ... has weakref" if any observational weakref
+            # is left on the real param.
+            torch.utils.swap_tensors(param, nn.Parameter(torch.zeros_like(param.data)))
+
+        # Axis 1: SpeculationRestartAnalysis - a graph break after the param is
+        # fakified discards the first attempt.
+        torch._dynamo.reset()
+
+        class RestartMod(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(4, 4))
+
+            def forward(self, x):
+                y = x @ self.weight
+                torch._dynamo.graph_break()
+                return y + 1
+
+        m1 = RestartMod()
+        torch.compile(m1, backend="eager")(torch.randn(2, 4))
+        assert_swappable(m1.weight)
+
+        # Axis 2: SkipFrame - reading the param but tracing no ops skips the
+        # frame after the param is fakified.
+        torch._dynamo.reset()
+
+        class SkipMod(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(4, 4))
+
+            def forward(self, x):
+                return self.weight.shape[0]
+
+        m2 = SkipMod()
+        torch.compile(m2, backend="eager")(torch.randn(2, 4))
+        assert_swappable(m2.weight)
+
+        # Axis 3: TensorifyScalarRestartAnalysis (backend-raised restart). By
+        # the time cleanup runs, tracing_context.fake_mode has been swapped to a
+        # fresh backend fake_mode and the tracing describer holding the real
+        # params lives on _old_fake_mode, so cleanup must clear BOTH. We assert
+        # both describers are emptied on the discarded attempt: without clearing
+        # _old_fake_mode its describer still pins the real-param WeakIdRefs
+        # (whether they still block swap depends on non-deterministic GC).
+        import math
+
+        from torch._dynamo.output_graph import DynamoTracerOutput
+
+        records = []
+        orig_cleanup = DynamoTracerOutput._cleanup_output_graph
+
+        def recording_cleanup(tracer_self):
+            orig_cleanup(tracer_self)
+            og = tracer_self.output_graph_for_cleanup
+            if og is None:
+                return
+
+            def describer_len(fake_mode):
+                if fake_mode is None:
+                    return None
+                d = fake_mode.fake_tensor_converter.meta_converter.describer
+                return len(d.lookup_tensor) + len(d.lookup_storage)
+
+            old_fake_mode = getattr(og, "_old_fake_mode", None)
+            records.append(
+                (
+                    describer_len(og.tracing_context.fake_mode),
+                    describer_len(old_fake_mode),
+                )
+            )
+
+        class TensorifyMod(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(8, 8))
+
+            def forward(self, x, y):
+                return math.floor(y**2) * (x @ self.weight)
+
+        torch._dynamo.reset()
+        m3 = TensorifyMod()
+        x = torch.randn(4, 8)
+        with mock.patch.object(
+            DynamoTracerOutput, "_cleanup_output_graph", recording_cleanup
+        ):
+            cm3 = torch.compile(m3, backend="aot_eager")
+            cm3(x, 2.0)
+            cm3(x, 3.0)  # automatic dynamic -> symfloat -> tensorify restart
+            cm3(x, 4.0)
+
+        # At least one discarded attempt must have had _old_fake_mode set (the
+        # tensorify restart raised after the backend fake_mode swap).
+        self.assertTrue(
+            any(old is not None for _, old in records),
+            "expected a discarded attempt with _old_fake_mode set",
+        )
+        # Cleanup must empty BOTH describers on every discarded attempt.
+        for cur, old in records:
+            if cur is not None:
+                self.assertEqual(cur, 0)
+            if old is not None:
+                self.assertEqual(old, 0)
+        assert_swappable(m3.weight)
+
 
 class ReproTestsDevice(torch._dynamo.test_case.TestCase):
     @serialTest()

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -3739,14 +3739,43 @@ class DynamoTracerOutput:
     def _cleanup_output_graph(self) -> None:
         output_graph = self.output_graph_for_cleanup
         if output_graph:
+            # Lazy import to avoid a circular import (convert_frame imports
+            # output_graph at module load time).
+            from .convert_frame import _clear_fake_mode_weakrefs
+
+            # A discarded restart/skip attempt fakified real tensors and built
+            # guards on them, leaving weakrefs on the real params that block
+            # torch.utils.swap_tensors after compile (issue #186796): guard
+            # create_fn partials hold a TensorWeakRef, and tensor_to_context /
+            # the describer memos / grapharg examples hold WeakIdRef/weakref.
+            # The end-of-compile clear_compile_context_weakrefs only clears the
+            # final attempt's tracing_context, never these discarded attempts,
+            # and never touches guards. Unlike that final clear (which is gated
+            # by config.invalidate_compile_context_weakrefs), the discard-path
+            # clear is unconditional: a discarded attempt has no consumers, so
+            # dropping its weakrefs can never break anything downstream.
+            # Drop grapharg examples first, before clearing nodes drops the meta.
+            for node in output_graph.graph.nodes:
+                if "grapharg" in node.meta:
+                    del node.meta["grapharg"]
             for tracer in output_graph.tracers:
                 tracer.graph._clear_nodes()
-            # Also clear tracked_fakes to break FakeTensorMode → ShapeEnv → TrackedFake → FakeTensor cycle
-            if (
-                output_graph.tracing_context.fake_mode
-                and output_graph.tracing_context.fake_mode.shape_env
-            ):
-                output_graph.tracing_context.fake_mode.shape_env.tracked_fakes = None
+            output_graph.guards.clear()
+            tc = output_graph.tracing_context
+            tc.tensor_to_context.clear()
+            # Clear the describer weakrefs from both the current tracing_context
+            # fake_mode and the _old_fake_mode saved during compile: on a
+            # backend-raised restart (e.g. TensorifyScalarRestartAnalysis),
+            # tracing_context.fake_mode has already been swapped to a fresh
+            # empty backend fake_mode, so the real-param weakrefs live on
+            # _old_fake_mode instead.
+            _clear_fake_mode_weakrefs(tc.fake_mode)
+            if hasattr(output_graph, "_old_fake_mode"):
+                _clear_fake_mode_weakrefs(output_graph._old_fake_mode)
+            # Also clear tracked_fakes to break the
+            # FakeTensorMode -> ShapeEnv -> TrackedFake -> FakeTensor cycle.
+            if tc.fake_mode and tc.fake_mode.shape_env:
+                tc.fake_mode.shape_env.tracked_fakes = None
 
 
 err_epilogue = (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190951

Fixes #186796.

A live `torch.compile`'d module could not have its parameters moved via
`torch.utils.swap_tensors` -- e.g. diffusers group offloading onloading a
TorchAO-quantized block. `swap_tensors` rejects a tensor that has any weakref,
and Dynamo leaves weakrefs on the real params, so the swap raises
`RuntimeError: Cannot swap t1 because it has weakref associated with it` at
onload time.

## Root cause

Prior cleanups (#180566, #171209) clear the weakrefs of the **final,
successful** tracing attempt. But a **discarded** restart/skip attempt
(`RestartAnalysis` / `SkipFrame`) also fakifies the real params and installs
guards on them, leaving three refs on each real param:

- a `TENSOR_MATCH` guard `create_fn`'s `TensorWeakRef`,
- a `TracingContext.tensor_to_context` `WeakIdRef`,
- the fake-mode describer's `WeakIdRef`.

`DynamoTracerOutput._cleanup_output_graph` runs on exactly these discarded
attempts, but only cleared graph nodes and `tracked_fakes` -- so those weakrefs
survived on the real params and blocked `swap_tensors` after compile.
Concretely, in a group-offload run 144/145 onload swaps succeed (their attempts
finished and were cleared) while the in-flight block's param -- fakified in a
restart-discarded attempt -- stays blocked.

## Fix

Extend `_cleanup_output_graph` to also clear `output_graph.guards`,
`tensor_to_context`, and the fake-mode describer weakrefs, mirroring the
end-of-compile `clear_compile_context_weakrefs`. It clears BOTH
`tracing_context.fake_mode` and `_old_fake_mode`: on a backend-raised restart
(`TensorifyScalarRestartAnalysis`) the tracing mode holding the real-param
weakrefs has already been swapped out to `_old_fake_mode`.

Safe because `_cleanup_output_graph` runs only on discarded attempts (never the
compiled artifact that installs live guards); a discarded attempt has no
downstream consumers, and a new attempt re-traces fresh. No change to
`torch.utils.swap_tensors`.

## Why not relax swap_tensors

Relaxing the `swap_tensors` weakref assert (attempted in #186801, reverted
twice; and both the blanket-removal and structural-weakref-filter variants) is
the wrong layer: the real-param blocker is a `WeakIdRef`, which a
"reject only non-internal weakrefs" filter still rejects (so it does not fix
the issue), and blanket removal lets fake-tensor `Module._apply` during export
silently produce a broken exported graph. Fixing where the stale weakref is
created keeps `swap_tensors`'s safety intact.

## Test plan

```
python test/dynamo/test_repros.py ReproTests.test_swap_tensors_after_discarded_attempt
python test/export/test_export.py -k test_exception
python test/test_torch.py -k test_swap
```

The new test covers the SpeculationRestart, SkipFrame, and TensorifyScalar
(backend-raised, `_old_fake_mode`) axes; it fails without the `_old_fake_mode`
clear (`Expected 0 but got 6`) and passes with it. Also validated against the
reporter's diffusers `FluxTransformer` + `group_offloading` repro
(`use_stream=True`, and a real 28-param TorchAO-quantized model) -- fails on
current `main`, succeeds with this change.

Authored with the assistance of an AI coding assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98