### PR TITLE
Remove redundant zero-init of fully-overwritten buffers in CUDA kernels

### DIFF
--- a/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
@@ -645,7 +645,6 @@ std::tuple<Tensor&, Tensor&, Tensor&> conv_depthwise3d_backward_cuda_out(const T
     Tensor& grad_bias) {
   if (grad_weight.defined()) {
     grad_weight.resize_(weight.sizes());
-    grad_weight.zero_();
   }
 
   return _depthwise_3d_backward_cuda_out(

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -27,6 +27,7 @@
 #include <ATen/ops/aminmax.h>
 #include <ATen/ops/arange.h>
 #include <ATen/ops/empty.h>
+#include <ATen/ops/empty_like.h>
 #include <ATen/ops/zeros_like.h>
 #include <ATen/ops/ones_like.h>
 #include <ATen/ops/empty_quantized.h>
@@ -1910,8 +1911,8 @@ Tensor index_select_sparse_cuda(const Tensor& self, int64_t dim, const Tensor& i
     Tensor intrsc_counts_nneg_index;
     Tensor intrsc_first_match_nneg_index;
     std::tie(intrsc_counts_nneg_index, intrsc_first_match_nneg_index) = [&]() -> std::tuple<Tensor, Tensor> {
-      auto intrsc_counts_nneg_index = at::zeros_like(nneg_index);
-      auto intrsc_first_match_nneg_index = at::zeros_like(nneg_index);
+      auto intrsc_counts_nneg_index = at::empty_like(nneg_index);
+      auto intrsc_first_match_nneg_index = at::empty_like(nneg_index);
 
       auto iter = TensorIteratorConfig()
         .add_output(intrsc_first_match_nneg_index)

--- a/aten/src/ATen/native/cuda/MaxUnpooling.cu
+++ b/aten/src/ATen/native/cuda/MaxUnpooling.cu
@@ -482,7 +482,6 @@ at::Tensor& max_unpooling2d_backward_out_cuda(const Tensor& grad_output_,
   }
 
   grad_input.resize_as_(self);
-  grad_input.zero_();
 
   int64_t count = self.numel();
   if (count == 0) {
@@ -568,7 +567,6 @@ at::Tensor& max_unpooling3d_backward_out_cuda(const Tensor& grad_output_,
   }
 
   grad_input.resize_as_(self);
-  grad_input.zero_();
 
   // Collapse batch and feature dimensions if needed
   auto grad_input_reshaped = grad_input;

--- a/aten/src/ATen/native/cuda/MultiLabelMarginCriterion.cu
+++ b/aten/src/ATen/native/cuda/MultiLabelMarginCriterion.cu
@@ -14,7 +14,7 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/empty.h>
-#include <ATen/ops/zeros_like.h>
+#include <ATen/ops/empty_like.h>
 #include <ATen/ops/sum_cuda_dispatch.h>
 #include <ATen/ops/multilabel_margin_loss.h>
 #endif
@@ -433,7 +433,7 @@ Tensor multilabel_margin_loss_backward_cuda(
     const Tensor& target,
     int64_t reduction,
     const Tensor& is_target) {
-  auto grad_input = at::zeros_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  auto grad_input = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   multilabel_margin_loss_backward_cuda_out_template(
       grad_output, self, target, reduction, is_target, grad_input);
   return grad_input;

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
@@ -736,7 +736,6 @@ std::tuple<Tensor&, Tensor&, Tensor&> slow_conv_transpose2d_backward_out_cuda(co
 
   if (grad_bias.defined()) {
     grad_bias.resize_({weight.size(1)});
-    grad_bias.zero_();
   }
 
   if (grad_weight.defined() || grad_bias.defined()) {
@@ -809,7 +808,6 @@ std::tuple<Tensor, Tensor, Tensor> slow_conv_transpose2d_backward_cuda(
 
   if (grad_bias.defined()) {
     grad_bias.resize_({weight.size(1)});
-    grad_bias.zero_();
   }
 
   if (grad_weight.defined() || grad_bias.defined()) {

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
@@ -925,7 +925,6 @@ std::tuple<Tensor&, Tensor&, Tensor&> slow_conv_transpose3d_backward_out_cuda(co
 
   if (grad_bias.defined()) {
     grad_bias.resize_({weight.size(1)});
-    grad_bias.zero_();
   }
 
   if (grad_weight.defined() || grad_bias.defined()) {
@@ -998,7 +997,6 @@ std::tuple<Tensor, Tensor, Tensor> slow_conv_transpose3d_backward_cuda(
 
   if (grad_bias.defined()) {
     grad_bias.resize_({weight.size(1)});
-    grad_bias.zero_();
   }
 
   if (grad_weight.defined() || grad_bias.defined()) {

--- a/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu
@@ -257,8 +257,6 @@ static void upsample_bicubic2d_out_cuda_template(
   int input_height = input.size(2);
   int input_width = input.size(3);
 
-  output.zero_();
-
   const int num_output_elements = output_height * output_width;
   const int max_threads = std::min(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -129,8 +129,6 @@ static void upsample_linear1d_out_cuda_template(
 
   int input_width = input.size(2);
 
-  output.zero_();
-
   AT_ASSERT(input_width > 0 && output_width > 0);
 
   const int num_kernels = output_width;


### PR DESCRIPTION
Several CUDA kernels zero-initialize a buffer and then unconditionally overwrite
every element before any read, so the memset is dead work. This drops the
redundant zero-init in those cases. Each was verified against the kernel or
reduction that writes the buffer.

| Op | Buffer | Why the zero is redundant |
|----|--------|---------------------------|
| `slow_conv_transpose2d/3d` backward | `grad_bias` | fully written by `at::sum_out`. `grad_weight` is left zeroed -- it accumulates via GEMM (beta=1). |
| `conv_depthwise3d` backward (out=) | `grad_weight` | fully written by the weight-grad kernel (grid == `grad_weight.numel()`, plain assignment). The functional variant already allocates it with `at::empty`. |
| `multilabel_margin_loss` backward | `grad_input` | the kernel zeros then writes every element itself; the out= variant already relies on this and does not pre-zero. |
| `max_unpooling2d/3d` backward | `grad_input` | dense gather over every element (`resize_as_(self)`). |
| `index_select` (sparse) | two intersection buffers | one is a `TensorIterator` output; the other a scatter indexed by a complete `arange`. |
| `upsample_linear1d` / `upsample_bicubic2d` forward | `output` | the kernels write every output element (copy fast-path and interpolation path). |
 
Authored with the assistance of Claude, an AI coding assistant.
