### PR TITLE
[xpu][test]testing: enable tf32_on_and_off() for XPU devices

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -63,6 +63,7 @@ from torch.testing._internal.common_utils import (
     subtest,
     TEST_SCIPY,
     TEST_WITH_ROCM,
+    TEST_XPU,
     xfailIf,
 )
 
@@ -3418,7 +3419,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         self.assertEqual(output.cpu().float(), output_cpu, atol=1e-3, rtol=1e-3)
 
     @onlyAccelerator
-    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM or TEST_XPU else 0.005)
     def test_Conv2d_size_1_kernel(self, device):
         x_cpu = torch.randn(2, 3, 5, 5)
         conv_cpu = torch.nn.Conv2d(3, 3, kernel_size=1)
@@ -3450,7 +3451,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         )
 
     @onlyAccelerator
-    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM or TEST_XPU else 0.005)
     def test_ConvTranspose2d_size_1_kernel(self, device):
         x_cpu = torch.randn(2, 3, 5, 5)
         conv_cpu = torch.nn.ConvTranspose2d(3, 3, kernel_size=1)

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -61,6 +61,7 @@ from torch.testing._internal.common_utils import (
     subtest,
     TEST_SCIPY,
     TEST_WITH_ROCM,
+    TEST_XPU,
     xfailIf,
 )
 
@@ -3412,7 +3413,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         self.assertEqual(output.cpu().float(), output_cpu, atol=1e-3, rtol=1e-3)
 
     @onlyAccelerator
-    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM or TEST_XPU else 0.005)
     def test_Conv2d_size_1_kernel(self, device):
         x_cpu = torch.randn(2, 3, 5, 5)
         conv_cpu = torch.nn.Conv2d(3, 3, kernel_size=1)
@@ -3444,7 +3445,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         )
 
     @onlyAccelerator
-    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM or TEST_XPU else 0.005)
     def test_ConvTranspose2d_size_1_kernel(self, device):
         x_cpu = torch.randn(2, 3, 5, 5)
         conv_cpu = torch.nn.ConvTranspose2d(3, 3, kernel_size=1)

--- a/torch/testing/_internal/common.py
+++ b/torch/testing/_internal/common.py
@@ -18,22 +18,21 @@ import torch
 # TF32 context managers
 # ---------------------------------------------------------------------------
 
+
 @contextlib.contextmanager
 def tf32_off():
     """Context manager that disables TF32 for both CUDA (cuBLAS/cuDNN) and
     XPU (oneDNN/mkldnn) for the duration of the ``with`` block."""
     old_cuda_matmul = torch.backends.cuda.matmul.allow_tf32
-    old_onednn = torch.backends.mkldnn.allow_tf32
     try:
         torch.backends.cuda.matmul.allow_tf32 = False
-        torch.backends.mkldnn.allow_tf32 = False
         with torch.backends.cudnn.flags(
             enabled=None, benchmark=None, deterministic=None, allow_tf32=False
         ):
-            yield
+            with torch.backends.mkldnn.flags(allow_tf32=False):
+                yield
     finally:
         torch.backends.cuda.matmul.allow_tf32 = old_cuda_matmul
-        torch.backends.mkldnn.allow_tf32 = old_onednn
 
 
 @contextlib.contextmanager
@@ -41,8 +40,8 @@ def tf32_on(self, tf32_precision=1e-5):
     """Context manager that enables TF32 for both CUDA and XPU, and
     temporarily lowers the test's precision threshold to *tf32_precision*."""
     import os
+
     old_cuda_matmul = torch.backends.cuda.matmul.allow_tf32
-    old_onednn = torch.backends.mkldnn.allow_tf32
     old_precision = self.precision
     # ROCm uses an environment variable to enable TF32 in hipBLASLt
     hip_allow_tf32 = None
@@ -51,12 +50,12 @@ def tf32_on(self, tf32_precision=1e-5):
         os.environ["HIPBLASLT_ALLOW_TF32"] = "1"
     try:
         torch.backends.cuda.matmul.allow_tf32 = True
-        torch.backends.mkldnn.allow_tf32 = True
         self.precision = tf32_precision
         with torch.backends.cudnn.flags(
             enabled=None, benchmark=None, deterministic=None, allow_tf32=True
         ):
-            yield
+            with torch.backends.mkldnn.flags(allow_tf32=True):
+                yield
     finally:
         if torch.version.hip:
             if hip_allow_tf32 is not None:
@@ -64,7 +63,6 @@ def tf32_on(self, tf32_precision=1e-5):
             else:
                 del os.environ["HIPBLASLT_ALLOW_TF32"]
         torch.backends.cuda.matmul.allow_tf32 = old_cuda_matmul
-        torch.backends.mkldnn.allow_tf32 = old_onednn
         self.precision = old_precision
 
 
@@ -73,22 +71,21 @@ def tf32_enabled():
     """Context manager to temporarily enable TF32 for both CUDA and XPU
     operations.  Restores the previous TF32 state after exiting the context."""
     old_cuda_matmul = torch.backends.cuda.matmul.allow_tf32
-    old_onednn = torch.backends.mkldnn.allow_tf32
     try:
         torch.backends.cuda.matmul.allow_tf32 = True
-        torch.backends.mkldnn.allow_tf32 = True
         with torch.backends.cudnn.flags(
             enabled=None, benchmark=None, deterministic=None, allow_tf32=True
         ):
-            yield
+            with torch.backends.mkldnn.flags(allow_tf32=True):
+                yield
     finally:
         torch.backends.cuda.matmul.allow_tf32 = old_cuda_matmul
-        torch.backends.mkldnn.allow_tf32 = old_onednn
 
 
 # ---------------------------------------------------------------------------
 # TF32 test decorator
 # ---------------------------------------------------------------------------
+
 
 # This is a wrapper that wraps a test to run this test twice, one with
 # allow_tf32=True, another with allow_tf32=False. When running with
@@ -138,20 +135,25 @@ def tf32_on_and_off(tf32_precision=1e-5, *, only_if=True):
             kwargs.update(zip(arg_names, args, strict=False))
             # Condition: either CUDA or XPU must support TF32
             cuda_tf32 = torch.cuda.is_tf32_supported()
-            xpu_tf32 = torch.xpu.is_tf32_supported() if hasattr(torch.xpu, 'is_tf32_supported') else False
+            xpu_tf32 = (
+                torch.xpu.is_tf32_supported()
+                if hasattr(torch.xpu, "is_tf32_supported")
+                else False
+            )
             cond = (cuda_tf32 or xpu_tf32) and only_if
-            if 'device' in kwargs:
-                dev_type = torch.device(kwargs['device']).type
-                cond = cond and (dev_type in {'cuda', 'xpu'})
-            if 'dtype' in kwargs:
-                cond = cond and (kwargs['dtype'] in {torch.float32, torch.complex64})
+            if "device" in kwargs:
+                dev_type = torch.device(kwargs["device"]).type
+                cond = cond and (dev_type in {"cuda", "xpu"})
+            if "dtype" in kwargs:
+                cond = cond and (kwargs["dtype"] in {torch.float32, torch.complex64})
             if cond:
-                with_tf32_disabled(kwargs['self'], lambda: f(**kwargs))
-                with_tf32_enabled(kwargs['self'], lambda: f(**kwargs))
+                with_tf32_disabled(kwargs["self"], lambda: f(**kwargs))
+                with_tf32_enabled(kwargs["self"], lambda: f(**kwargs))
             else:
                 f(**kwargs)
 
         return wrapped
+
     return wrapper
 
 
@@ -159,6 +161,7 @@ def with_tf32_off(f):
     """Decorator that runs the wrapped test with TF32 disabled for both CUDA
     and XPU.  Use this when a test exercises matmul/convolutions as a side
     effect but its correctness should not depend on TF32 precision."""
+
     @functools.wraps(f)
     def wrapped(*args, **kwargs):
         with tf32_off():

--- a/torch/testing/_internal/common.py
+++ b/torch/testing/_internal/common.py
@@ -1,0 +1,167 @@
+# mypy: ignore-errors
+
+r"""Common test utilities shared across device types (CUDA, XPU, etc.).
+
+This file provides TF32-related test helpers that work for both CUDA and XPU
+devices. It is intended to be imported by device-specific common files (e.g.
+common_cuda.py) so that existing import sites need not change.
+"""
+
+import contextlib
+import functools
+import inspect
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# TF32 context managers
+# ---------------------------------------------------------------------------
+
+@contextlib.contextmanager
+def tf32_off():
+    """Context manager that disables TF32 for both CUDA (cuBLAS/cuDNN) and
+    XPU (oneDNN/mkldnn) for the duration of the ``with`` block."""
+    old_cuda_matmul = torch.backends.cuda.matmul.allow_tf32
+    old_onednn = torch.backends.mkldnn.allow_tf32
+    try:
+        torch.backends.cuda.matmul.allow_tf32 = False
+        torch.backends.mkldnn.allow_tf32 = False
+        with torch.backends.cudnn.flags(
+            enabled=None, benchmark=None, deterministic=None, allow_tf32=False
+        ):
+            yield
+    finally:
+        torch.backends.cuda.matmul.allow_tf32 = old_cuda_matmul
+        torch.backends.mkldnn.allow_tf32 = old_onednn
+
+
+@contextlib.contextmanager
+def tf32_on(self, tf32_precision=1e-5):
+    """Context manager that enables TF32 for both CUDA and XPU, and
+    temporarily lowers the test's precision threshold to *tf32_precision*."""
+    import os
+    old_cuda_matmul = torch.backends.cuda.matmul.allow_tf32
+    old_onednn = torch.backends.mkldnn.allow_tf32
+    old_precision = self.precision
+    # ROCm uses an environment variable to enable TF32 in hipBLASLt
+    hip_allow_tf32 = None
+    if torch.version.hip:
+        hip_allow_tf32 = os.environ.get("HIPBLASLT_ALLOW_TF32", None)
+        os.environ["HIPBLASLT_ALLOW_TF32"] = "1"
+    try:
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.mkldnn.allow_tf32 = True
+        self.precision = tf32_precision
+        with torch.backends.cudnn.flags(
+            enabled=None, benchmark=None, deterministic=None, allow_tf32=True
+        ):
+            yield
+    finally:
+        if torch.version.hip:
+            if hip_allow_tf32 is not None:
+                os.environ["HIPBLASLT_ALLOW_TF32"] = hip_allow_tf32
+            else:
+                del os.environ["HIPBLASLT_ALLOW_TF32"]
+        torch.backends.cuda.matmul.allow_tf32 = old_cuda_matmul
+        torch.backends.mkldnn.allow_tf32 = old_onednn
+        self.precision = old_precision
+
+
+@contextlib.contextmanager
+def tf32_enabled():
+    """Context manager to temporarily enable TF32 for both CUDA and XPU
+    operations.  Restores the previous TF32 state after exiting the context."""
+    old_cuda_matmul = torch.backends.cuda.matmul.allow_tf32
+    old_onednn = torch.backends.mkldnn.allow_tf32
+    try:
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.mkldnn.allow_tf32 = True
+        with torch.backends.cudnn.flags(
+            enabled=None, benchmark=None, deterministic=None, allow_tf32=True
+        ):
+            yield
+    finally:
+        torch.backends.cuda.matmul.allow_tf32 = old_cuda_matmul
+        torch.backends.mkldnn.allow_tf32 = old_onednn
+
+
+# ---------------------------------------------------------------------------
+# TF32 test decorator
+# ---------------------------------------------------------------------------
+
+# This is a wrapper that wraps a test to run this test twice, one with
+# allow_tf32=True, another with allow_tf32=False. When running with
+# allow_tf32=True, it will use reduced precision as specified by the
+# argument. For example:
+#    @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
+#    @tf32_on_and_off(0.005)
+#    def test_matmul(self, device, dtype):
+#        a = ...; b = ...;
+#        c = torch.matmul(a, b)
+#        self.assertEqual(c, expected)
+# In the above example, when testing torch.float32 and torch.complex64 on a
+# CUDA Ampere (or newer) device or an XPU device that supports TF32 via DPAS,
+# the matmul will be run in TF32 mode and with TF32 disabled, and on TF32 mode
+# the assertEqual will use reduced precision to check values.
+#
+# This decorator can be used for functions with or without device/dtype:
+# @tf32_on_and_off(0.005)
+# def test_my_op(self)
+# @tf32_on_and_off(0.005)
+# def test_my_op(self, device)
+# @tf32_on_and_off(0.005)
+# def test_my_op(self, device, dtype)
+# @tf32_on_and_off(0.005)
+# def test_my_op(self, dtype)
+#
+# - If neither device nor dtype is specified, checks whether the system has an
+#   Ampere (CUDA) or TF32-capable XPU device.
+# - If device is specified, checks whether device type is 'cuda' or 'xpu'.
+# - If dtype is specified, checks whether dtype is float32 or complex64.
+# TF32 and fp32 differ only when all three checks pass.
+def tf32_on_and_off(tf32_precision=1e-5, *, only_if=True):
+    def with_tf32_disabled(self, function_call):
+        with tf32_off():
+            function_call()
+
+    def with_tf32_enabled(self, function_call):
+        with tf32_on(self, tf32_precision):
+            function_call()
+
+    def wrapper(f):
+        params = inspect.signature(f).parameters
+        arg_names = tuple(params.keys())
+
+        @functools.wraps(f)
+        def wrapped(*args, **kwargs):
+            kwargs.update(zip(arg_names, args, strict=False))
+            # Condition: either CUDA or XPU must support TF32
+            cuda_tf32 = torch.cuda.is_tf32_supported()
+            xpu_tf32 = torch.xpu.is_tf32_supported() if hasattr(torch.xpu, 'is_tf32_supported') else False
+            cond = (cuda_tf32 or xpu_tf32) and only_if
+            if 'device' in kwargs:
+                dev_type = torch.device(kwargs['device']).type
+                cond = cond and (dev_type in {'cuda', 'xpu'})
+            if 'dtype' in kwargs:
+                cond = cond and (kwargs['dtype'] in {torch.float32, torch.complex64})
+            if cond:
+                with_tf32_disabled(kwargs['self'], lambda: f(**kwargs))
+                with_tf32_enabled(kwargs['self'], lambda: f(**kwargs))
+            else:
+                f(**kwargs)
+
+        return wrapped
+    return wrapper
+
+
+def with_tf32_off(f):
+    """Decorator that runs the wrapped test with TF32 disabled for both CUDA
+    and XPU.  Use this when a test exercises matmul/convolutions as a side
+    effect but its correctness should not depend on TF32 precision."""
+    @functools.wraps(f)
+    def wrapped(*args, **kwargs):
+        with tf32_off():
+            return f(*args, **kwargs)
+
+    return wrapped

--- a/torch/testing/_internal/common.py
+++ b/torch/testing/_internal/common.py
@@ -24,6 +24,7 @@ _tf32_off_lock = threading.Lock()
 _tf32_off_depth = 0
 _tf32_off_saved_precision = None
 _tf32_off_cudnn_ctx = None
+_tf32_off_mkldnn_ctx = None
 
 
 @contextlib.contextmanager
@@ -33,7 +34,8 @@ def tf32_off():
     # First-in saves state and disables TF32; last-out restores it. Nested
     # contexts can otherwise restore the process-global precision state in the
     # wrong order when tests enter this context from multiple threads.
-    global _tf32_off_depth, _tf32_off_saved_precision, _tf32_off_cudnn_ctx
+    global _tf32_off_depth, _tf32_off_saved_precision
+    global _tf32_off_cudnn_ctx, _tf32_off_mkldnn_ctx
     with _tf32_off_lock:
         if _tf32_off_depth == 0:
             # Save fp32_precision rather than allow_tf32 so that the ``None``
@@ -44,19 +46,22 @@ def tf32_off():
                 enabled=None, benchmark=None, deterministic=None, allow_tf32=False
             )
             _tf32_off_cudnn_ctx.__enter__()
+            _tf32_off_mkldnn_ctx = torch.backends.mkldnn.flags(
+                enabled=None,
+                deterministic=None,
+                allow_tf32=False,
+                fp32_precision=None,
+            )
+            _tf32_off_mkldnn_ctx.__enter__()
         _tf32_off_depth += 1
     try:
-        with torch.backends.mkldnn.flags(
-            enabled=None,
-            deterministic=None,
-            allow_tf32=False,
-            fp32_precision=None,
-        ):
-            yield
+        yield
     finally:
         with _tf32_off_lock:
             _tf32_off_depth -= 1
             if _tf32_off_depth == 0:
+                _tf32_off_mkldnn_ctx.__exit__(None, None, None)
+                _tf32_off_mkldnn_ctx = None
                 _tf32_off_cudnn_ctx.__exit__(None, None, None)
                 _tf32_off_cudnn_ctx = None
                 torch.backends.cuda.matmul.fp32_precision = _tf32_off_saved_precision

--- a/torch/testing/_internal/common.py
+++ b/torch/testing/_internal/common.py
@@ -29,7 +29,12 @@ def tf32_off():
         with torch.backends.cudnn.flags(
             enabled=None, benchmark=None, deterministic=None, allow_tf32=False
         ):
-            with torch.backends.mkldnn.flags(allow_tf32=False):
+            with torch.backends.mkldnn.flags(
+                enabled=None,
+                deterministic=None,
+                allow_tf32=False,
+                fp32_precision=None,
+            ):
                 yield
     finally:
         torch.backends.cuda.matmul.allow_tf32 = old_cuda_matmul
@@ -54,7 +59,12 @@ def tf32_on(self, tf32_precision=1e-5):
         with torch.backends.cudnn.flags(
             enabled=None, benchmark=None, deterministic=None, allow_tf32=True
         ):
-            with torch.backends.mkldnn.flags(allow_tf32=True):
+            with torch.backends.mkldnn.flags(
+                enabled=None,
+                deterministic=None,
+                allow_tf32=True,
+                fp32_precision=None,
+            ):
                 yield
     finally:
         if torch.version.hip:
@@ -69,14 +79,20 @@ def tf32_on(self, tf32_precision=1e-5):
 @contextlib.contextmanager
 def tf32_enabled():
     """Context manager to temporarily enable TF32 for both CUDA and XPU
-    operations.  Restores the previous TF32 state after exiting the context."""
+    operations. The previous backend TF32 state is automatically restored when
+    exiting the context."""
     old_cuda_matmul = torch.backends.cuda.matmul.allow_tf32
     try:
         torch.backends.cuda.matmul.allow_tf32 = True
         with torch.backends.cudnn.flags(
             enabled=None, benchmark=None, deterministic=None, allow_tf32=True
         ):
-            with torch.backends.mkldnn.flags(allow_tf32=True):
+            with torch.backends.mkldnn.flags(
+                enabled=None,
+                deterministic=None,
+                allow_tf32=True,
+                fp32_precision=None,
+            ):
                 yield
     finally:
         torch.backends.cuda.matmul.allow_tf32 = old_cuda_matmul
@@ -141,8 +157,11 @@ def tf32_on_and_off(tf32_precision=1e-5, *, only_if=True):
                 else False
             )
             cond = (cuda_tf32 or xpu_tf32) and only_if
-            if "device" in kwargs:
-                dev_type = torch.device(kwargs["device"]).type
+            device = kwargs.get(
+                "device", getattr(kwargs.get("self"), "device", None)
+            )
+            if device is not None:
+                dev_type = torch.device(device).type
                 cond = cond and (dev_type in {"cuda", "xpu"})
             if "dtype" in kwargs:
                 cond = cond and (kwargs["dtype"] in {torch.float32, torch.complex64})

--- a/torch/testing/_internal/common.py
+++ b/torch/testing/_internal/common.py
@@ -10,6 +10,7 @@ common_cuda.py) so that existing import sites need not change.
 import contextlib
 import functools
 import inspect
+import threading
 
 import torch
 
@@ -19,25 +20,47 @@ import torch
 # ---------------------------------------------------------------------------
 
 
+_tf32_off_lock = threading.Lock()
+_tf32_off_depth = 0
+_tf32_off_saved_precision = None
+_tf32_off_cudnn_ctx = None
+
+
 @contextlib.contextmanager
 def tf32_off():
     """Context manager that disables TF32 for both CUDA (cuBLAS/cuDNN) and
     XPU (oneDNN/mkldnn) for the duration of the ``with`` block."""
-    old_cuda_matmul = torch.backends.cuda.matmul.allow_tf32
+    # First-in saves state and disables TF32; last-out restores it. Nested
+    # contexts can otherwise restore the process-global precision state in the
+    # wrong order when tests enter this context from multiple threads.
+    global _tf32_off_depth, _tf32_off_saved_precision, _tf32_off_cudnn_ctx
+    with _tf32_off_lock:
+        if _tf32_off_depth == 0:
+            # Save fp32_precision rather than allow_tf32 so that the ``None``
+            # default is restored exactly instead of being changed to ``ieee``.
+            _tf32_off_saved_precision = torch.backends.cuda.matmul.fp32_precision
+            torch.backends.cuda.matmul.allow_tf32 = False
+            _tf32_off_cudnn_ctx = torch.backends.cudnn.flags(
+                enabled=None, benchmark=None, deterministic=None, allow_tf32=False
+            )
+            _tf32_off_cudnn_ctx.__enter__()
+        _tf32_off_depth += 1
     try:
-        torch.backends.cuda.matmul.allow_tf32 = False
-        with torch.backends.cudnn.flags(
-            enabled=None, benchmark=None, deterministic=None, allow_tf32=False
+        with torch.backends.mkldnn.flags(
+            enabled=None,
+            deterministic=None,
+            allow_tf32=False,
+            fp32_precision=None,
         ):
-            with torch.backends.mkldnn.flags(
-                enabled=None,
-                deterministic=None,
-                allow_tf32=False,
-                fp32_precision=None,
-            ):
-                yield
+            yield
     finally:
-        torch.backends.cuda.matmul.allow_tf32 = old_cuda_matmul
+        with _tf32_off_lock:
+            _tf32_off_depth -= 1
+            if _tf32_off_depth == 0:
+                _tf32_off_cudnn_ctx.__exit__(None, None, None)
+                _tf32_off_cudnn_ctx = None
+                torch.backends.cuda.matmul.fp32_precision = _tf32_off_saved_precision
+                _tf32_off_saved_precision = None
 
 
 @contextlib.contextmanager
@@ -46,7 +69,7 @@ def tf32_on(self, tf32_precision=1e-5):
     temporarily lowers the test's precision threshold to *tf32_precision*."""
     import os
 
-    old_cuda_matmul = torch.backends.cuda.matmul.allow_tf32
+    old_fp32_precision = torch.backends.cuda.matmul.fp32_precision
     old_precision = self.precision
     # ROCm uses an environment variable to enable TF32 in hipBLASLt
     hip_allow_tf32 = None
@@ -72,7 +95,7 @@ def tf32_on(self, tf32_precision=1e-5):
                 os.environ["HIPBLASLT_ALLOW_TF32"] = hip_allow_tf32
             else:
                 del os.environ["HIPBLASLT_ALLOW_TF32"]
-        torch.backends.cuda.matmul.allow_tf32 = old_cuda_matmul
+        torch.backends.cuda.matmul.fp32_precision = old_fp32_precision
         self.precision = old_precision
 
 
@@ -81,7 +104,7 @@ def tf32_enabled():
     """Context manager to temporarily enable TF32 for both CUDA and XPU
     operations. The previous backend TF32 state is automatically restored when
     exiting the context."""
-    old_cuda_matmul = torch.backends.cuda.matmul.allow_tf32
+    old_fp32_precision = torch.backends.cuda.matmul.fp32_precision
     try:
         torch.backends.cuda.matmul.allow_tf32 = True
         with torch.backends.cudnn.flags(
@@ -95,7 +118,7 @@ def tf32_enabled():
             ):
                 yield
     finally:
-        torch.backends.cuda.matmul.allow_tf32 = old_cuda_matmul
+        torch.backends.cuda.matmul.fp32_precision = old_fp32_precision
 
 
 # ---------------------------------------------------------------------------

--- a/torch/testing/_internal/common.py
+++ b/torch/testing/_internal/common.py
@@ -181,7 +181,8 @@ def tf32_on_and_off(tf32_precision=1e-5, *, only_if=True):
             )
             cond = (cuda_tf32 or xpu_tf32) and only_if
             device = kwargs.get(
-                "device", getattr(kwargs.get("self"), "device", None)
+                "device",
+                getattr(kwargs.get("self"), "device", None),
             )
             if device is not None:
                 dev_type = torch.device(device).type

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -3,7 +3,6 @@
 r"""This file is allowed to initialize CUDA context when imported."""
 
 import functools
-import threading
 import torch
 import torch.cuda
 from torch.testing._internal.common_utils import LazyVal, TEST_NUMBA, TEST_WITH_ROCM, TEST_CUDA, IS_WINDOWS, IS_MACOS, TEST_XPU

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -8,7 +8,6 @@ import torch
 import torch.cuda
 from torch.testing._internal.common_utils import LazyVal, TEST_NUMBA, TEST_WITH_ROCM, TEST_CUDA, IS_WINDOWS, IS_MACOS, TEST_XPU
 from torch.utils._import_utils import _check_module_exists
-import inspect
 import contextlib
 import os
 import unittest
@@ -356,7 +355,7 @@ def initialize_cuda_context_rng():
 # TF32 helpers (CUDA + XPU) are defined in common.py and re-exported here so
 # that existing ``from torch.testing._internal.common_cuda import tf32_*``
 # call sites continue to work without modification.
-from torch.testing._internal.common import (  # noqa: E402, F401
+from torch.testing._internal.common import (  # noqa: F401
     tf32_off,
     tf32_on,
     tf32_enabled,

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -353,143 +353,16 @@ def initialize_cuda_context_rng():
         __cuda_ctx_rng_initialized = True
 
 
-_tf32_off_lock = threading.Lock()
-_tf32_off_depth = 0
-_tf32_off_saved_precision = None
-_tf32_off_cudnn_ctx = None
-
-
-@contextlib.contextmanager
-def tf32_off():
-    # First-in saves state and disables tf32; last-out restores. Multithreaded
-    # test runners (e.g. MultiThreadedTestCase) enter this context once per
-    # rank thread over the same process-global flags, so per-entry
-    # save/restore can interleave and leak a modified state past the last
-    # exit, which the TestCase fp32 precision leak detector then flags.
-    global _tf32_off_depth, _tf32_off_saved_precision, _tf32_off_cudnn_ctx
-    with _tf32_off_lock:
-        if _tf32_off_depth == 0:
-            # Snapshot fp32_precision (a string), not allow_tf32 (a bool):
-            # writing allow_tf32 back can't reproduce the "none" default (it
-            # yields "ieee"), which the leak detector would flag on ROCm.
-            _tf32_off_saved_precision = torch.backends.cuda.matmul.fp32_precision
-            torch.backends.cuda.matmul.allow_tf32 = False
-            _tf32_off_cudnn_ctx = torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=False)
-            _tf32_off_cudnn_ctx.__enter__()
-        _tf32_off_depth += 1
-    try:
-        yield
-    finally:
-        with _tf32_off_lock:
-            _tf32_off_depth -= 1
-            if _tf32_off_depth == 0:
-                _tf32_off_cudnn_ctx.__exit__(None, None, None)
-                _tf32_off_cudnn_ctx = None
-                torch.backends.cuda.matmul.fp32_precision = _tf32_off_saved_precision
-                _tf32_off_saved_precision = None
-
-
-@contextlib.contextmanager
-def tf32_on(self, tf32_precision=1e-5):
-    old_fp32_precision = torch.backends.cuda.matmul.fp32_precision
-    old_precision = self.precision
-    try:
-        torch.backends.cuda.matmul.allow_tf32 = True
-        self.precision = tf32_precision
-        with torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=True):
-            yield
-    finally:
-        torch.backends.cuda.matmul.fp32_precision = old_fp32_precision
-        self.precision = old_precision
-
-
-@contextlib.contextmanager
-def tf32_enabled():
-    """
-    Context manager to temporarily enable TF32 for CUDA operations.
-    Restores the previous TF32 state after exiting the context.
-    """
-    old_fp32_precision = torch.backends.cuda.matmul.fp32_precision
-    try:
-        torch.backends.cuda.matmul.allow_tf32 = True
-        with torch.backends.cudnn.flags(
-            enabled=None, benchmark=None, deterministic=None, allow_tf32=True
-        ):
-            yield
-    finally:
-        torch.backends.cuda.matmul.fp32_precision = old_fp32_precision
-
-
-# This is a wrapper that wraps a test to run this test twice, one with
-# allow_tf32=True, another with allow_tf32=False. When running with
-# allow_tf32=True, it will use reduced precision as specified by the
-# argument. For example:
-#    @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
-#    @tf32_on_and_off(0.005)
-#    def test_matmul(self, device, dtype):
-#        a = ...; b = ...;
-#        c = torch.matmul(a, b)
-#        self.assertEqual(c, expected)
-# In the above example, when testing torch.float32 and torch.complex64 on CUDA
-# on a CUDA >= 11 build on an >=Ampere architecture, the matmul will be running at
-# TF32 mode and TF32 mode off, and on TF32 mode, the assertEqual will use reduced
-# precision to check values.
-#
-# This decorator can be used for function with or without device/dtype, such as
-# @tf32_on_and_off(0.005)
-# def test_my_op(self)
-# @tf32_on_and_off(0.005)
-# def test_my_op(self, device)
-# @tf32_on_and_off(0.005)
-# def test_my_op(self, device, dtype)
-# @tf32_on_and_off(0.005)
-# def test_my_op(self, dtype)
-# if neither device nor dtype is specified, it will check if the system has ampere device
-# if device is specified, it will check if device is cuda
-# if dtype is specified, it will check if dtype is float32 or complex64
-# tf32 and fp32 are different only when all the three checks pass
-def tf32_on_and_off(tf32_precision=1e-5, *, only_if=True):
-    def with_tf32_disabled(self, function_call):
-        with tf32_off():
-            function_call()
-
-    def with_tf32_enabled(self, function_call):
-        with tf32_on(self, tf32_precision):
-            function_call()
-
-    def wrapper(f):
-        params = inspect.signature(f).parameters
-        arg_names = tuple(params.keys())
-
-        @functools.wraps(f)
-        def wrapped(*args, **kwargs):
-            kwargs.update(zip(arg_names, args, strict=False))
-            cond = torch.cuda.is_tf32_supported() and only_if
-            if 'device' in kwargs:
-                cond = cond and (torch.device(kwargs['device']).type == 'cuda')
-            if 'dtype' in kwargs:
-                cond = cond and (kwargs['dtype'] in {torch.float32, torch.complex64})
-            if cond:
-                with_tf32_disabled(kwargs['self'], lambda: f(**kwargs))
-                with_tf32_enabled(kwargs['self'], lambda: f(**kwargs))
-            else:
-                f(**kwargs)
-
-        return wrapped
-    return wrapper
-
-# This is a wrapper that wraps a test to run it with TF32 turned off.
-# This wrapper is designed to be used when a test uses matmul or convolutions
-# but the purpose of that test is not testing matmul or convolutions.
-# Disabling TF32 will enforce torch.float tensors to be always computed
-# at full precision.
-def with_tf32_off(f):
-    @functools.wraps(f)
-    def wrapped(*args, **kwargs):
-        with tf32_off():
-            return f(*args, **kwargs)
-
-    return wrapped
+# TF32 helpers (CUDA + XPU) are defined in common.py and re-exported here so
+# that existing ``from torch.testing._internal.common_cuda import tf32_*``
+# call sites continue to work without modification.
+from torch.testing._internal.common import (  # noqa: E402, F401
+    tf32_off,
+    tf32_on,
+    tf32_enabled,
+    tf32_on_and_off,
+    with_tf32_off,
+)
 
 def _get_magma_version():
     if 'Magma' not in torch.__config__.show():

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -318,143 +318,16 @@ def initialize_cuda_context_rng():
         __cuda_ctx_rng_initialized = True
 
 
-_tf32_off_lock = threading.Lock()
-_tf32_off_depth = 0
-_tf32_off_saved_precision = None
-_tf32_off_cudnn_ctx = None
-
-
-@contextlib.contextmanager
-def tf32_off():
-    # First-in saves state and disables tf32; last-out restores. Multithreaded
-    # test runners (e.g. MultiThreadedTestCase) enter this context once per
-    # rank thread over the same process-global flags, so per-entry
-    # save/restore can interleave and leak a modified state past the last
-    # exit, which the TestCase fp32 precision leak detector then flags.
-    global _tf32_off_depth, _tf32_off_saved_precision, _tf32_off_cudnn_ctx
-    with _tf32_off_lock:
-        if _tf32_off_depth == 0:
-            # Snapshot fp32_precision (a string), not allow_tf32 (a bool):
-            # writing allow_tf32 back can't reproduce the "none" default (it
-            # yields "ieee"), which the leak detector would flag on ROCm.
-            _tf32_off_saved_precision = torch.backends.cuda.matmul.fp32_precision
-            torch.backends.cuda.matmul.allow_tf32 = False
-            _tf32_off_cudnn_ctx = torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=False)
-            _tf32_off_cudnn_ctx.__enter__()
-        _tf32_off_depth += 1
-    try:
-        yield
-    finally:
-        with _tf32_off_lock:
-            _tf32_off_depth -= 1
-            if _tf32_off_depth == 0:
-                _tf32_off_cudnn_ctx.__exit__(None, None, None)
-                _tf32_off_cudnn_ctx = None
-                torch.backends.cuda.matmul.fp32_precision = _tf32_off_saved_precision
-                _tf32_off_saved_precision = None
-
-
-@contextlib.contextmanager
-def tf32_on(self, tf32_precision=1e-5):
-    old_fp32_precision = torch.backends.cuda.matmul.fp32_precision
-    old_precision = self.precision
-    try:
-        torch.backends.cuda.matmul.allow_tf32 = True
-        self.precision = tf32_precision
-        with torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=True):
-            yield
-    finally:
-        torch.backends.cuda.matmul.fp32_precision = old_fp32_precision
-        self.precision = old_precision
-
-
-@contextlib.contextmanager
-def tf32_enabled():
-    """
-    Context manager to temporarily enable TF32 for CUDA operations.
-    Restores the previous TF32 state after exiting the context.
-    """
-    old_fp32_precision = torch.backends.cuda.matmul.fp32_precision
-    try:
-        torch.backends.cuda.matmul.allow_tf32 = True
-        with torch.backends.cudnn.flags(
-            enabled=None, benchmark=None, deterministic=None, allow_tf32=True
-        ):
-            yield
-    finally:
-        torch.backends.cuda.matmul.fp32_precision = old_fp32_precision
-
-
-# This is a wrapper that wraps a test to run this test twice, one with
-# allow_tf32=True, another with allow_tf32=False. When running with
-# allow_tf32=True, it will use reduced precision as specified by the
-# argument. For example:
-#    @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
-#    @tf32_on_and_off(0.005)
-#    def test_matmul(self, device, dtype):
-#        a = ...; b = ...;
-#        c = torch.matmul(a, b)
-#        self.assertEqual(c, expected)
-# In the above example, when testing torch.float32 and torch.complex64 on CUDA
-# on a CUDA >= 11 build on an >=Ampere architecture, the matmul will be running at
-# TF32 mode and TF32 mode off, and on TF32 mode, the assertEqual will use reduced
-# precision to check values.
-#
-# This decorator can be used for function with or without device/dtype, such as
-# @tf32_on_and_off(0.005)
-# def test_my_op(self)
-# @tf32_on_and_off(0.005)
-# def test_my_op(self, device)
-# @tf32_on_and_off(0.005)
-# def test_my_op(self, device, dtype)
-# @tf32_on_and_off(0.005)
-# def test_my_op(self, dtype)
-# if neither device nor dtype is specified, it will check if the system has ampere device
-# if device is specified, it will check if device is cuda
-# if dtype is specified, it will check if dtype is float32 or complex64
-# tf32 and fp32 are different only when all the three checks pass
-def tf32_on_and_off(tf32_precision=1e-5, *, only_if=True):
-    def with_tf32_disabled(self, function_call):
-        with tf32_off():
-            function_call()
-
-    def with_tf32_enabled(self, function_call):
-        with tf32_on(self, tf32_precision):
-            function_call()
-
-    def wrapper(f):
-        params = inspect.signature(f).parameters
-        arg_names = tuple(params.keys())
-
-        @functools.wraps(f)
-        def wrapped(*args, **kwargs):
-            kwargs.update(zip(arg_names, args, strict=False))
-            cond = torch.cuda.is_tf32_supported() and only_if
-            if 'device' in kwargs:
-                cond = cond and (torch.device(kwargs['device']).type == 'cuda')
-            if 'dtype' in kwargs:
-                cond = cond and (kwargs['dtype'] in {torch.float32, torch.complex64})
-            if cond:
-                with_tf32_disabled(kwargs['self'], lambda: f(**kwargs))
-                with_tf32_enabled(kwargs['self'], lambda: f(**kwargs))
-            else:
-                f(**kwargs)
-
-        return wrapped
-    return wrapper
-
-# This is a wrapper that wraps a test to run it with TF32 turned off.
-# This wrapper is designed to be used when a test uses matmul or convolutions
-# but the purpose of that test is not testing matmul or convolutions.
-# Disabling TF32 will enforce torch.float tensors to be always computed
-# at full precision.
-def with_tf32_off(f):
-    @functools.wraps(f)
-    def wrapped(*args, **kwargs):
-        with tf32_off():
-            return f(*args, **kwargs)
-
-    return wrapped
+# TF32 helpers (CUDA + XPU) are defined in common.py and re-exported here so
+# that existing ``from torch.testing._internal.common_cuda import tf32_*``
+# call sites continue to work without modification.
+from torch.testing._internal.common import (  # noqa: E402, F401
+    tf32_off,
+    tf32_on,
+    tf32_enabled,
+    tf32_on_and_off,
+    with_tf32_off,
+)
 
 def _get_magma_version():
     if 'Magma' not in torch.__config__.show():

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -8,7 +8,6 @@ import torch
 import torch.cuda
 from torch.testing._internal.common_utils import LazyVal, TEST_NUMBA, TEST_WITH_ROCM, TEST_CUDA, IS_WINDOWS, IS_MACOS, TEST_XPU
 from torch.utils._import_utils import _check_module_exists
-import inspect
 import contextlib
 import os
 import unittest
@@ -321,7 +320,7 @@ def initialize_cuda_context_rng():
 # TF32 helpers (CUDA + XPU) are defined in common.py and re-exported here so
 # that existing ``from torch.testing._internal.common_cuda import tf32_*``
 # call sites continue to work without modification.
-from torch.testing._internal.common import (  # noqa: E402, F401
+from torch.testing._internal.common import (  # noqa: F401
     tf32_off,
     tf32_on,
     tf32_enabled,


### PR DESCRIPTION
Related: intel/torch-xpu-ops#2400
This pull request refactors and extends the TF32 (TensorFloat-32) test utilities to support both CUDA and XPU devices. The main improvements involve moving TF32-related context managers and decorators from `common_cuda.py` to a new shared file, `common.py`, and updating test logic to properly handle XPU. This change ensures consistent TF32 test coverage across device types and simplifies maintenance by sharing code.

TF32 Test Utilities Refactor and XPU Support:

**Refactoring and Code Sharing**
* Moved all TF32-related context managers and decorators (`tf32_off`, `tf32_on`, `tf32_enabled`, `tf32_on_and_off`, `with_tf32_off`) from `torch/testing/_internal/common_cuda.py` to a new shared file `torch/testing/_internal/common.py`, allowing both CUDA and XPU backends to use the same logic.

**XPU Device Support**
* Enhanced the TF32 context managers and decorators to also handle XPU devices (e.g., oneDNN/mkldnn), including detection of TF32 support and correct backend state management. 

**Test Updates**
* Added `TEST_XPU` to the test imports in `test/nn/test_convolution.py` and updated the TF32 test decorators to use the correct precision threshold when either ROCm or XPU is enabled. 

This refactor improves code maintainability and ensures that TF32-related tests are consistently executed for both CUDA and XPU backends.

cc @gujinghui @EikanWang @fengyuan14 @guangyey