### PR TITLE
[CI] Use Claude Fable 5 for @claude PR reviews

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -17,6 +17,7 @@ jobs:
       id-token: write
     secrets: inherit
     with:
+      model: 'global.anthropic.claude-fable-5'
       additional_claude_args: '--allowedTools Skill'
       append_system_prompt: |
         When asked to review a PR, always use the /pr-review skill first.


### PR DESCRIPTION
Sets the `@claude` bot to use **Claude Fable 5** on `pytorch/pytorch` by passing `model: global.anthropic.claude-fable-5` to the reusable `pytorch/test-infra/.github/workflows/_claude-code.yml` workflow.

Scoped to this repo only — the reusable workflow's default (`global.anthropic.claude-opus-4-8`) is unchanged for every other caller.

Fable has reviewed well in recent experiments. Note this is a higher-cost model than the current Opus 4.8 default (higher per-token price, plus heavier output from always-on thinking); revert by removing the `model:` line.

🤖 Authored with AI assistance (iz2/Claude). Reviewed by @izaitsevfb, who is the responsible human for this contribution; see AI_POLICY.md.