### PR TITLE
Modernize Claude workflow models

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -17,6 +17,7 @@ jobs:
       id-token: write
     secrets: inherit
     with:
+      model: global.anthropic.claude-fable-5
       additional_claude_args: '--allowedTools Skill'
       append_system_prompt: |
         When asked to review a PR, always use the /pr-review skill first.

--- a/.github/workflows/claude-distributed-triage.yml
+++ b/.github/workflows/claude-distributed-triage.yml
@@ -117,7 +117,7 @@ jobs:
           # so the actor is github-actions[bot]).
           allowed_bots: "*"
           claude_args: |
-            --model global.anthropic.claude-sonnet-4-5-20250929-v1:0
+            --model global.anthropic.claude-sonnet-5
             --mcp-config /tmp/mcp-config/mcp-servers.json
             --allowedTools "mcp__github__issue_read,mcp__github__get_issue,mcp__github__issue_write,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__search_issues"
           prompt: |

--- a/.github/workflows/claude-issue-triage-run.yml
+++ b/.github/workflows/claude-issue-triage-run.yml
@@ -110,7 +110,7 @@ jobs:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model global.anthropic.claude-sonnet-4-5-20250929-v1:0
+            --model global.anthropic.claude-sonnet-5
             --mcp-config /tmp/mcp-config/mcp-servers.json
             --allowedTools "mcp__github__issue_read,mcp__github__get_issue,mcp__github__issue_write,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__search_issues"
           prompt: |


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #190960

Bumps the verisons, tested in CI forge we can add the fable check if once we let this run a few rounds and check in on price and re-asses aferwords

Use Sonnet 5 for issue triage and distributed triage, and use Fable 5
for comment-triggered Claude interactions.

Test Plan:
```text
ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path); puts path }' .github/workflows/claude-code.yml .github/workflows/claude-distributed-triage.yml .github/workflows/claude-issue-triage-run.yml
git diff --check
```

`lintrunner -a` was attempted but lintrunner is not installed in the checkout's `.venv`.

Prepared with assistance from an AI assistant.