### PR TITLE
[Inductor] Avoid reciprocal powers in symbolic stride guards

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -25,6 +25,8 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_utils import parametrize, skipIfXpu
 from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.utils._ordered_set import OrderedSet
+from torch.utils._sympy.functions import FloorDiv
+from torch.utils._sympy.printers import PythonPrinter
 
 
 class TestUnbackedSymints(InductorTestCase):
@@ -1302,6 +1304,52 @@ class TestUnbackedSymints(InductorTestCase):
         cpp_code = cpp_wrapper.prefix.getvalue()
         self.assertIn("int64_t s4 = arg0_1_size[1];", cpp_code)
         self.assertRegex(cpp_code, r"int64_t s5 = .*arg0_1_size_0")
+
+    def test_stride_ordered_handles_reciprocal_in_divisibility_check(self, device):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        seq = shape_env.create_unbacked_symint().node.expr
+        shape_env.constrain_symbol_range(seq, 4, 1024)
+        half = FloorDiv(seq, 2)
+        reduced = FloorDiv(half**2, half)
+        left = 16 * reduced - 30
+        right = 16 * (64 * half * reduced - 120 * half - 120 * reduced + 225)
+        sizevars = SizeVarAllocator(shape_env)
+        graph = mock.Mock(sizevars=sizevars)
+
+        layout = ir.FixedLayout(
+            torch.device(device),
+            torch.float32,
+            size=[seq, 2],
+            stride=[left, right],
+        )
+        with V.set_graph_handler(graph):
+            with mock.patch.object(
+                sizevars,
+                "optimization_hint",
+                side_effect=AssertionError("unexpected optimization hint"),
+            ):
+                self.assertTrue(layout.is_stride_ordered([0, 1]))
+
+        fallback_sizevars = mock.Mock()
+        fallback_sizevars.guard_or_false.return_value = False
+        fallback_sizevars.statically_known_multiple_of.return_value = False
+        graph = mock.Mock(sizevars=fallback_sizevars)
+        with V.set_graph_handler(graph):
+            self.assertFalse(ir.Layout._stride_expr_ge_or_false(left, right))
+
+        fallback_sizevars.statically_known_multiple_of.assert_called_once_with(
+            left, right
+        )
+        guard = fallback_sizevars.guard_or_false.call_args.args[0]
+        negative_powers = [
+            power
+            for power in guard.atoms(sympy.Pow)
+            if power.args[1].is_negative is True
+        ]
+        self.assertEqual(negative_powers, [])
+        self.assertIn("%", PythonPrinter().doprint(guard))
 
     @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4542,9 +4542,13 @@ class Layout(OutputSpec):
             return True
         if sizevars.guard_or_false(sympy.Eq(left, 0)):
             return False
-        return sizevars.guard_or_false(
-            sympy.Ge(left, right)
-        ) or sizevars.guard_or_false(sympy.Eq(left % right, 0))
+        # Prove unbacked divisibility structurally, and keep SymPy from
+        # introducing reciprocal powers into any backed-symbol guard.
+        return (
+            sizevars.guard_or_false(sympy.Ge(left, right))
+            or sizevars.statically_known_multiple_of(left, right)
+            or sizevars.guard_or_false(sympy.Eq(Mod(left, right), 0))
+        )
 
     def is_stride_ordered(self, order: Sequence[int]) -> bool:
         if len(self.stride) != len(order):


### PR DESCRIPTION
## Summary

`Layout._stride_expr_ge_or_false` used Python modulo to build a symbolic
divisibility guard. For compound strides, SymPy can rewrite that expression
through a reciprocal `Pow` with exponent `-1`. Value-range analysis rejects the
negative exponent; redirecting non-natural powers to generic range analysis, as
in #188636, only moves the failure to guard printing.

This change fixes the predicate at its source:

- prove divisibility structurally first, preserving the stride optimization for
  unbacked symbols without adding a semantic guard;
- use PyTorch's non-simplifying integer `Mod` when a backed-symbol guard is still
  required.

The regression test reconstructs the compound symbolic strides, verifies that
the layout remains stride ordered, and checks that the fallback guard contains
no negative powers and can be printed.

Supersedes #188636. #185786 remains an independent generic SymPy range-analysis
fix.

Fixes #188323. Related to #188422.

## Test Plan

```bash
python test/inductor/test_unbacked_symints.py -k stride_ordered -v
```

All six instantiated CPU and CUDA tests passed. The CPU model reproducer from
#188323 also compiled successfully and matched eager outputs.

This PR was authored with the assistance of an AI assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo