### PR TITLE
Refuse ModularIndexing term-stripping when surviving terms may be negative

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5107,33 +5107,6 @@ class CPUReproTests(TestCase):
 
         torch.testing.assert_close(actual, expected)
 
-    def test_issue_190765_tiny_repro(self):
-        def fn(p):
-            return torch.flip(torch.repeat_interleave(torch.flatten(p + 1.0), 2), [0])
-
-        torch.manual_seed(0)
-        p = torch.randn(2, 2, dtype=torch.float32)
-        compiled = torch.compile(fn, backend="inductor", dynamic=True)
-        for _ in range(4):
-            self.assertEqual(compiled(p), fn(p))
-
-    def test_issue_190765_intermediate_graph(self):
-        def postprocess(z):
-            return torch.flip(torch.repeat_interleave(torch.flatten(z), 2), [0])
-
-        def fn(x, a, b):
-            left = (x @ a).transpose(0, 1)
-            right = (x @ b).transpose(0, 1)
-            return postprocess((left + right).transpose(0, 1))
-
-        torch.manual_seed(0)
-        x = torch.randn(8, 6, dtype=torch.float32)
-        a = torch.randn(6, 8, dtype=torch.float32)
-        b = torch.randn(6, 8, dtype=torch.float32)
-        compiled = torch.compile(fn, backend="inductor", dynamic=True)
-        for _ in range(4):
-            self.assertEqual(compiled(x, a, b), fn(x, a, b))
-
     def test_scalar_mul_bfloat16(self):
         def f(x):
             return torch.ops.aten.mul.Tensor(x, 1.7015043497085571)

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5107,6 +5107,33 @@ class CPUReproTests(TestCase):
 
         torch.testing.assert_close(actual, expected)
 
+    def test_issue_190765_tiny_repro(self):
+        def fn(p):
+            return torch.flip(torch.repeat_interleave(torch.flatten(p + 1.0), 2), [0])
+
+        torch.manual_seed(0)
+        p = torch.randn(2, 2, dtype=torch.float32)
+        compiled = torch.compile(fn, backend="inductor", dynamic=True)
+        for _ in range(4):
+            self.assertEqual(compiled(p), fn(p))
+
+    def test_issue_190765_intermediate_graph(self):
+        def postprocess(z):
+            return torch.flip(torch.repeat_interleave(torch.flatten(z), 2), [0])
+
+        def fn(x, a, b):
+            left = (x @ a).transpose(0, 1)
+            right = (x @ b).transpose(0, 1)
+            return postprocess((left + right).transpose(0, 1))
+
+        torch.manual_seed(0)
+        x = torch.randn(8, 6, dtype=torch.float32)
+        a = torch.randn(6, 8, dtype=torch.float32)
+        b = torch.randn(6, 8, dtype=torch.float32)
+        compiled = torch.compile(fn, backend="inductor", dynamic=True)
+        for _ in range(4):
+            self.assertEqual(compiled(x, a, b), fn(x, a, b))
+
     def test_scalar_mul_bfloat16(self):
         def f(x):
             return torch.ops.aten.mul.Tensor(x, 1.7015043497085571)

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -142,10 +142,10 @@ class TestIndexingSimplification(InductorTestCase):
 
     def test_indexing_simplification(self):
         sizevars = SizeVarAllocator()
-        i0 = sympy.Symbol("i0", integer=True)
-        i1 = sympy.Symbol("i1", integer=True)
-        i2 = sympy.Symbol("i2", integer=True)
-        r3 = sympy.Symbol("r3", integer=True)
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        i1 = sympy.Symbol("i1", integer=True, nonnegative=True)
+        i2 = sympy.Symbol("i2", integer=True, nonnegative=True)
+        r3 = sympy.Symbol("r3", integer=True, nonnegative=True)
 
         var_ranges = {i0: 3136, i1: 64, i2: 32, r3: 3}
         expr = (
@@ -1042,8 +1042,8 @@ class TestWideExpressionThresholds(InductorTestCase):
         self.assertEqual(result, FloorDiv(128 * i1, 8192))
 
     def test_modular_indexing_simplification_small(self):
-        i0 = sympy.Symbol("i0", integer=True)
-        i1 = sympy.Symbol("i1", integer=True)
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        i1 = sympy.Symbol("i1", integer=True, nonnegative=True)
         self.assertEqual(
             ModularIndexing(i0 + i1 * 10, 1, 10),
             ModularIndexing(i0, 1, 10),

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19044,6 +19044,33 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertEqual(out.stride(), (1,))
         self.assertTrue(out._is_zerotensor())
 
+    def test_issue_190765_tiny_repro(self):
+        def fn(p):
+            return torch.flip(torch.repeat_interleave(torch.flatten(p + 1.0), 2), [0])
+
+        torch.manual_seed(0)
+        p = torch.randn(2, 2, dtype=torch.float32, device=self.device)
+        compiled = torch.compile(fn, backend="inductor", dynamic=True)
+        for _ in range(4):
+            self.assertEqual(compiled(p), fn(p))
+
+    def test_issue_190765_intermediate_graph(self):
+        def postprocess(z):
+            return torch.flip(torch.repeat_interleave(torch.flatten(z), 2), [0])
+
+        def fn(x, a, b):
+            left = (x @ a).transpose(0, 1)
+            right = (x @ b).transpose(0, 1)
+            return postprocess((left + right).transpose(0, 1))
+
+        torch.manual_seed(0)
+        x = torch.randn(8, 6, dtype=torch.float32, device=self.device)
+        a = torch.randn(6, 8, dtype=torch.float32, device=self.device)
+        b = torch.randn(6, 8, dtype=torch.float32, device=self.device)
+        compiled = torch.compile(fn, backend="inductor", dynamic=True)
+        for _ in range(4):
+            self.assertEqual(compiled(x, a, b), fn(x, a, b))
+
     # end of class CommonTemplate - add new tests here
 
 

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -1107,7 +1107,7 @@ class TestSympyFunctions(TestCase):
 
         self.assertNotEqual(expr, ModularIndexing(-1 - q0, 2, n**2))
         for nv in range(2, 9):
-            for q0v in range(2 * nv * nv):
+            for q0v in range(4 * nv * nv):
                 actual = int(expr.subs({n: nv, q0: q0v}))
                 expected = (nv * nv + (-1 - q0v) // 2) % (nv * nv)
                 self.assertEqual(actual, expected)

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -27,6 +27,7 @@ from torch.utils._sympy.functions import (
     Min as TorchSymMin,
     LShift,
     Mod,
+    ModularIndexing,
     OpaqueUnaryFn_cos,
     PythonMod,
     RShift,
@@ -1097,6 +1098,20 @@ class TestSympyFunctions(TestCase):
         x = sympy.Symbol("x", integer=True)
         self.assertIsInstance(TorchSymMin(128 * x, 512 * x), TorchSymMin)
         self.assertIsInstance(TorchSymMax(128 * x, 512 * x), TorchSymMax)
+
+    def test_modular_indexing_does_not_strip_unproven_nonnegative_term(self):
+        q0 = sympy.Symbol("q0", integer=True, nonnegative=True)
+        n = sympy.Symbol("n", integer=True, positive=True)
+        poisoned_base = n**2 + FloorDiv(-1 - q0, 2)
+        expr = ModularIndexing(poisoned_base, 1, n**2)
+
+        self.assertNotEqual(expr, ModularIndexing(-1 - q0, 2, n**2))
+        for nv in range(2, 9):
+            for q0v in range(2 * nv * nv):
+                actual = int(expr.subs({n: nv, q0: q0v}))
+                expected = (nv * nv + (-1 - q0v) // 2) % (nv * nv)
+                self.assertEqual(actual, expected)
+                self.assertTrue(0 <= actual < nv * nv)
 
 
 class TestSingletonInt(TestCase):

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -369,13 +369,10 @@ class ModularIndexing(sympy.Function):
             all_positive: bool = True
             for term in base.args:
                 if safe_gcd(term, modulus * divisor) != modulus * divisor:
-                    if (isinstance(term, sympy.Integer) and term < 0) or (
-                        isinstance(term, sympy.Mul)
-                        and isinstance(term.args[0], sympy.Integer)
-                        and term.args[0] < 0
-                    ):
+                    if term.is_nonnegative is not True:
                         # workaround for https://github.com/triton-lang/triton/issues/619,
-                        # if there are negative terms, // produces wrong result
+                        # if terms are not provably nonnegative, // can produce
+                        # the wrong result
                         # TODO if https://github.com/triton-lang/triton/issues/619 is fixed
                         # this optimization would become valid
                         all_positive = False

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -366,7 +366,7 @@ class ModularIndexing(sympy.Function):
         # on wide Add expressions (e.g. in sizevars.simplify).
         if isinstance(base, sympy.Add) and not _is_wide_add(base):
             new_terms: list[sympy.Integer] = []
-            all_positive: bool = True
+            all_nonnegative: bool = True
             for term in base.args:
                 if safe_gcd(term, modulus * divisor) != modulus * divisor:
                     if term.is_nonnegative is not True:
@@ -375,12 +375,12 @@ class ModularIndexing(sympy.Function):
                         # the wrong result
                         # TODO if https://github.com/triton-lang/triton/issues/619 is fixed
                         # this optimization would become valid
-                        all_positive = False
+                        all_nonnegative = False
                         break
                     else:
                         new_terms.append(term)
 
-            if len(new_terms) != len(base.args) and all_positive:
+            if len(new_terms) != len(base.args) and all_nonnegative:
                 return ModularIndexing(sum(new_terms), divisor, modulus)
 
         if isinstance(base, FloorDiv):


### PR DESCRIPTION
Chased garbage outputs from an equality-saturation report all the way down to one algebra rule. P.S: written with the assistance of AI, reviewed and tested by me.

> **What happens:** `torch.compile(backend="inductor", dynamic=True)` returns silently wrong, sometimes nondeterministic outputs for graphs whose fused index chain is `flip(repeat_interleave(flatten(<non-contiguous producer>)))` (#190765). Forward outputs of the surrounding graph stay bit-identical, so nothing warns the user. A 4-op function on a 2x2 tensor triggers it.
>
> **Root cause:** `ModularIndexing.eval`'s Add branch strips additive terms that are exact multiples of modulus x divisor. The strip is only sound when the surviving base is provably nonnegative - `ModularIndexing` is printed as C truncated `%` - but the old guard only recognized a negative `Integer` or a `Mul` with a negative leading `Integer`. The always-negative `FloorDiv(-1 - q0, 2)` (arising after `join_dimensions` nests the index and the inner mod is rewritten) slipped through with `is_nonnegative = None`, producing `ModularIndexing(-1 - q0, 2, s**2)` - negative base, negative C `%`, out-of-bounds reads before the input buffers.
>
> **Fix:** permit the strip only when every surviving term satisfies `is_nonnegative is True`. Strictly conservative - the change can only refuse a rewrite, so it cannot introduce new miscompiles; previously-correct kernels are unchanged (verified: the passing graphs' generated code is byte-identical). Real inductor index symbols are constructed nonnegative (`torch/_inductor/utils.py`), so common strips are unaffected. Two `test_indexing.py` tests that used bare integer symbols now declare them nonnegative, matching inductor's own construction.
>
> **Tests:** a structural sympy unit test asserting the poisoned expression no longer collapses (plus a numeric floor-mod sweep), and two end-to-end CPU repros (the 4-op minimal case and the issue's original graph), all verified to fail before the fix and pass after. Full `test_sympy_utils.py` (234) and `test_indexing.py` (72) green; the issue's four equivalent graphs plus an interleaved variant all match eager 4/4; lintrunner clean.

Fixes #190765

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jansel @eellison @laithsakka


---

**Review round:** tests moved to `CommonTemplate` (device-generic), `all_positive` -> `all_nonnegative`, sweep widened to reach negative bases.

**Unbacked symbols:** they carry only `integer=True`, so the guard now declines those strips — a missed simplification, not a correctness issue. `eval` has no ShapeEnv access; a range-aware strip in sizevars would be the follow-up if it matters in practice.
