### PR TITLE
Add torch.compiler.export_python: hill-climbable compiled kernels on disk

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -38,6 +38,7 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
      nested_compile_region
      load_cache_artifacts
      load_compiled_function
+     export_python
      save_cache_artifacts
      wrap_numpy
 ```

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -1,8 +1,11 @@
 # Owner(s): ["oncall: pt2"]
 import copy
+import inspect
 import io
 import os
 import pickle
+import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -859,6 +862,13 @@ class TestPrecompile(TestCase):
         # The public location: test_public_bindings.test_correct_module_names also
         # enforces this for every torch.compiler.__all__ member.
         self.assertEqual(torch.compiler.precompile.__module__, "torch.compiler")
+        # export_python is the disk-cached decorator over precompile; it lives
+        # under the same compiler namespace, not as a top-level torch.* verb.
+        self.assertIn("export_python", torch.compiler.__all__)
+        self.assertNotIn("export_python", torch.__all__)
+        self.assertFalse(hasattr(torch, "export_python"))
+        self.assertTrue(callable(torch.compiler.export_python))
+        self.assertEqual(torch.compiler.export_python.__module__, "torch.compiler")
 
     def test_backend_invalid_raises(self):
         a, b = torch.randn(4, 4), torch.randn(4, 4)
@@ -2610,6 +2620,702 @@ class TestPrecompileNumerics(TestCase):
 
 
 instantiate_device_type_tests(TestPrecompileNumerics, globals())
+
+
+@skipIfTorchDynamo("precompile's make_fx capture is incompatible with dynamo wrapping")
+class TestExportPython(TestCase):
+    # torch.compiler.export_python is the disk-cached decorator over
+    # torch.compiler.precompile: first call writes the emitted, self-contained python,
+    # later calls read and exec it directly. Run device-generically so the inductor
+    # path is exercised on CUDA too.
+
+    def _tmp_path(self, name="artifact.py"):
+        d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        return os.path.join(d, name)
+
+    def test_eager_write_then_load(self, device):
+        path = self._tmp_path()
+        x = make_tensor((4, 4), device=device, dtype=torch.float32)
+        y = make_tensor((4, 4), device=device, dtype=torch.float32)
+        expected = (x * 2 + y).relu()
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(a, b):
+                return (a * 2 + b).relu()
+
+            return run
+
+        self.assertFalse(os.path.exists(path))
+        self.assertEqual(build()(x, y), expected)
+        self.assertTrue(os.path.exists(path))
+        with open(path, encoding="utf-8") as f:
+            self.assertIn("def forward(", f.read())
+
+        # A fresh decorator over the same path loads the emitted source from disk
+        # rather than recompiling.
+        self.assertEqual(build()(x, y), expected)
+
+    def test_inductor_writes_output_code(self, device):
+        path = self._tmp_path("inductor.py")
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3)).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run(model, inp):
+            return model(inp)
+
+        self.assertEqual(run(m, x), m(x))
+        with open(path, encoding="utf-8") as f:
+            self.assertIn("Inductor output code", f.read())
+        # export_python writes only the self-contained source; there is no cache.
+        self.assertFalse(os.path.exists(path + ".cache"))
+
+    def test_inductor_reload_from_disk(self, device):
+        # Inductor analogue of test_eager_write_then_load: the first build() lowers
+        # through Inductor and commits the emitted source; a SECOND fresh decorator over
+        # the SAME path must load that source from disk and run it instead of
+        # recompiling, exercising the inductor load-from-disk path.
+        path = self._tmp_path("inductor_reload.py")
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3)).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+        expected = m(x)
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="inductor")
+            def run(model, inp):
+                return model(inp)
+
+            return run
+
+        self.assertEqual(build()(m, x), expected)
+        self.assertTrue(os.path.exists(path))
+        self.assertEqual(build()(m, x), expected)
+
+    def test_inductor_edited_source_takes_effect(self, device):
+        # Inductor hill-climb (ejectable compilation): after the first run commits the
+        # source, appending a harmless trailing comment changes the file but not its
+        # behavior. A fresh decorator over the same path must exec the edited source
+        # from disk (no cache, no recompile) and still produce the right result.
+        path = self._tmp_path("inductor_edit.py")
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3)).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+        expected = m(x)
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run(model, inp):
+            return model(inp)
+
+        self.assertEqual(run(m, x), expected)
+
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(code + "\n# hand-edited\n")
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run2(model, inp):
+            return model(inp)
+
+        self.assertEqual(run2(m, x), expected)
+
+    def test_creates_parent_dirs(self, device):
+        path = self._tmp_path(os.path.join("nested", "deep", "artifact.py"))
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp * 2
+
+        self.assertEqual(run(x), x * 2)
+        self.assertTrue(os.path.exists(path))
+
+    def test_example_inputs_drives_capture(self, device):
+        @torch.compiler.export_python(
+            path=self._tmp_path("ex.py"),
+            backend="eager",
+            example_inputs=[make_tensor((3, 3), device=device, dtype=torch.float32)],
+        )
+        def run(inp):
+            return inp.relu()
+
+        # Capture is specialized to the (3, 3) example, so a (5, 5) runtime input is
+        # rejected -- proving example_inputs, not the call args, drove capture.
+        with self.assertRaisesRegex(PrecompileError, "shape"):
+            run(make_tensor((5, 5), device=device, dtype=torch.float32))
+
+    def test_non_deepcopyable_first_call_arg_errors(self, device):
+        # A non-leaf tensor cannot be deep-copied; the None example_inputs path must
+        # surface a clear error pointing at example_inputs, not a raw deepcopy error.
+        @torch.compiler.export_python(path=self._tmp_path("nc.py"), backend="eager")
+        def run(inp):
+            return inp + 1
+
+        non_leaf = make_tensor(
+            (4,), device=device, dtype=torch.float32
+        ).requires_grad_()
+        with self.assertRaisesRegex(PrecompileError, "example_inputs"):
+            run(non_leaf * 2)
+
+    def test_no_cache_sidecar_written(self, device):
+        # export_python is cache-free: the first run commits only the self-contained
+        # .py, never a .cache sidecar, and a fresh decorator reloads from the .py alone.
+        path = self._tmp_path()
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return inp.sin()
+
+            return run
+
+        self.assertEqual(build()(x), x.sin())
+        self.assertFalse(os.path.exists(path + ".cache"))
+        self.assertEqual(build()(x), x.sin())
+
+    def test_hill_climb_edited_source_takes_effect(self, device):
+        path = self._tmp_path("edit.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+        edited = code.replace(
+            "torch.ops.aten.add.Tensor(flat_1, 1)",
+            "torch.ops.aten.add.Tensor(flat_1, 100)",
+        )
+        self.assertNotEqual(
+            edited, code, "expected the add constant in the emitted graph"
+        )
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(edited)
+
+        # A fresh decorator sees the edited source and always exec's it, so the edited
+        # constant takes effect.
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        self.assertEqual(run2(x), x + 100)
+
+    def test_first_call_applies_mutation_once(self, device):
+        path = self._tmp_path("bn.py")
+        torch.manual_seed(0)
+        m = torch.nn.BatchNorm1d(4).to(device).train()
+        x = make_tensor((8, 4), device=device, dtype=torch.float32)
+
+        ref = torch.nn.BatchNorm1d(4).to(device).train()
+        ref.load_state_dict(m.state_dict())
+        ref(x)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(model, inp):
+            return model(inp)
+
+        run(m, x)
+        # Capture deep-copies the args, so the running stats are updated exactly once
+        # (by the artifact), matching a single eager application -- not twice.
+        self.assertEqual(m.running_mean, ref.running_mean)
+        self.assertEqual(m.running_var, ref.running_var)
+
+    @parametrize("backend", ("eager", "inductor"))
+    def test_concurrent_first_calls_precompile_once(self, device, backend):
+        import threading
+        from unittest.mock import patch
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("concurrent.py"), backend=backend
+        )
+        def run(inp):
+            return inp + 1
+
+        real = torch.compiler.precompile
+
+        # Count precompile() invocations; the decorator calls torch.compiler.precompile
+        # exactly once behind its double-checked lock even under the racing first calls.
+        class _Counting:
+            def __init__(self):
+                self.n = 0
+
+            def __call__(self, *a, **k):
+                self.n += 1
+                return real(*a, **k)
+
+        counting = _Counting()
+        n = 8
+        barrier = threading.Barrier(n)
+        results: list = [None] * n
+
+        def worker(i):
+            barrier.wait()
+            results[i] = run(x)
+
+        with patch.object(torch.compiler, "precompile", counting):
+            threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        # The double-checked lock must precompile exactly once despite the race.
+        self.assertEqual(counting.n, 1)
+        for r in results:
+            self.assertEqual(r, x + 1)
+
+    def test_clobbered_non_artifact_source_raises_clean_error(self, device):
+        # A clobbered non-artifact source degrades to a clean PrecompileError
+        # referencing the path, not a raw KeyError/SyntaxError, so a stale hand-edit
+        # that drops the forward() surfaces an actionable message.
+        path = self._tmp_path("clobber.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("x = 1\n")
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        with self.assertRaisesRegex(
+            PrecompileError, "could not be run as precompile source"
+        ):
+            run2(x)
+
+    def test_kwargs_bound_positionally(self, device):
+        path = self._tmp_path("kw.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(a, b):
+            return a - b
+
+        # A keyword call binds onto (a, b) positionally and runs the artifact.
+        self.assertEqual(run(a=x, b=x + 1), x - (x + 1))
+
+    def test_keyword_only_params_rejected(self, device):
+        @torch.compiler.export_python(path=self._tmp_path("ko.py"), backend="eager")
+        def run(a, *, b):
+            return a + b
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(TypeError, "keyword-only"):
+            run(x, b=x)
+
+    def test_positional_default_skipped_by_keyword_rejected(self, device):
+        # A plain positional-or-keyword param passed by keyword while an earlier one
+        # is left to its default cannot be laid out positionally; the error must name
+        # that cause, not misreport it as an unsupported keyword-only parameter.
+        @torch.compiler.export_python(path=self._tmp_path("posdef.py"), backend="eager")
+        def run(a, b=1, c=2):
+            return a + b + c
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(TypeError, "left to its default"):
+            run(x, c=3)
+
+    def test_var_kwargs_rejected(self, device):
+        # A fn declaring **kwargs cannot be laid out positionally once extra keyword
+        # args are passed; the error must name **kwargs as the cause rather than
+        # misreporting it as a positional-or-keyword arg left to its default.
+        @torch.compiler.export_python(path=self._tmp_path("varkw.py"), backend="eager")
+        def run(a, **kw):
+            return a + kw["b"]
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(TypeError, r"\*\*kwargs"):
+            run(x, b=x)
+
+    def test_decompositions_forwarded(self, device):
+        from unittest.mock import patch
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        sentinel: dict = {}
+        real = torch.compiler.precompile
+        captured: dict = {}
+
+        def spy(fn, *a, **k):
+            captured["decompositions"] = k.get("decompositions")
+            return real(fn, *a, **k)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("dec.py"), backend="eager", decompositions=sentinel
+        )
+        def run(inp):
+            return inp + 1
+
+        with patch.object(torch.compiler, "precompile", spy):
+            self.assertEqual(run(x), x + 1)
+        self.assertIs(captured["decompositions"], sentinel)
+
+    def test_existing_artifact_ignores_changed_backend(self, device):
+        # Presence is the sole signal: a new decorator over an existing path loads it
+        # as-is even with a different backend, so the on-disk eager artifact is reused
+        # and NOT re-lowered through inductor.
+        path = self._tmp_path("sole_signal.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            first = f.read()
+        self.assertNotIn("Inductor output code", first)
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run2(inp):
+            return inp + 1
+
+        self.assertEqual(run2(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            self.assertEqual(f.read(), first)
+
+    def test_version_skew_warns(self, device):
+        path = self._tmp_path("skew.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().split("\n")
+        tag = "# torch.compiler.export_python torch-version: "
+        self.assertTrue(lines[0].startswith(tag))
+        lines[0] = tag + "0.0.0-bogus"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        # A stamped-but-mismatched artifact warns about the skew but still runs.
+        with self.assertLogs("torch.compiler._export_python", level="WARNING") as cm:
+            self.assertEqual(run2(x), x + 1)
+        self.assertTrue(any("0.0.0-bogus" in m for m in cm.output))
+
+    def test_no_version_warning_when_stamp_absent(self, device):
+        from unittest.mock import patch
+
+        import torch.compiler._export_python as _ep
+
+        path = self._tmp_path("nostamp.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().split("\n")
+        tag = "# torch.compiler.export_python torch-version: "
+        if lines and lines[0].startswith(tag):
+            lines = lines[1:]
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        # A hand-edit that drops the stamp must not warn about version skew.
+        with patch.object(_ep.log, "warning") as warn:
+            self.assertEqual(run2(x), x + 1)
+        warn.assert_not_called()
+
+    def test_env_import_failure_distinct_message(self, device):
+        # A valid artifact that fails to import a dependency under the current torch
+        # gets a distinct "different torch version or environment" error, not the
+        # clobbered-source message, so version skew is diagnosable.
+        path = self._tmp_path("badimport.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("import a_module_that_does_not_exist_xyz\n" + code)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        with self.assertRaisesRegex(PrecompileError, "different torch|environment"):
+            run2(x)
+
+    @parametrize("backend", ["eager", "inductor"])
+    def test_unsafe_reduce_overhead_matches_checked(self, device, backend):
+        # The unsafe entry point must compute exactly what the checked one does; the
+        # only difference is that the driver's invariant guards are gone, which is
+        # asserted below by feeding a shape the artifact was not traced with.
+        x = make_tensor((4, 4), device=device, dtype=torch.float32)
+        y = make_tensor((4, 4), device=device, dtype=torch.float32)
+        expected = ((x * 2 + y).relu(), x - y)
+
+        def build(unsafe):
+            @torch.compiler.export_python(
+                path=self._tmp_path(f"unsafe_{backend}_{unsafe}.py"),
+                backend=backend,
+                unsafe_reduce_overhead=unsafe,
+            )
+            def run(a, b):
+                return (a * 2 + b).relu(), a - b
+
+            return run
+
+        checked, unsafe = build(False), build(True)
+        self.assertEqual(checked(x, y), expected)
+        self.assertEqual(unsafe(x, y), expected)
+
+        big = make_tensor((8, 8), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(PrecompileError, "specialized to the static dims"):
+            checked(big, big)
+        # The unsafe entry point never reaches that diagnosis: depending on the backend
+        # it either computes silently (eager) or trips inductor's own stride assert.
+        try:
+            unsafe(big, big)
+        except Exception as e:
+            self.assertNotIn("specialized to the static dims", str(e))
+
+    def test_unsafe_reduce_overhead_single_output(self, device):
+        # An artifact whose out_spec is a bare leaf must hand back the tensor itself,
+        # not the one-element list the compiled call returns.
+        path = self._tmp_path("unsafe_single.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=path, backend="eager", unsafe_reduce_overhead=True
+        )
+        def run(inp):
+            return inp + 1
+
+        out = run(x)
+        self.assertIsInstance(out, torch.Tensor)
+        self.assertEqual(out, x + 1)
+
+    def test_unsafe_reduce_overhead_falls_back_for_module(self, device):
+        # A module argument means the driver is lifting params, not just checking, so
+        # there is nothing safe to strip: warn and keep the checked entry point.
+        path = self._tmp_path("unsafe_module.py")
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3)).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=path, backend="eager", unsafe_reduce_overhead=True
+        )
+        def run(model, inp):
+            return model(inp)
+
+        with self.assertLogs("torch.compiler._export_python", level="WARNING") as cm:
+            self.assertEqual(run(m, x), m(x))
+        self.assertIn("unsafe_reduce_overhead=True had no effect", "\n".join(cm.output))
+
+    def test_unsafe_reduce_overhead_arity_error(self, device):
+        # Arity is the one thing the lean entry point still checks, so a miscall gets
+        # a real message instead of an unpack error from generated source.
+        path = self._tmp_path("unsafe_arity.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=path, backend="eager", unsafe_reduce_overhead=True
+        )
+        def run(a, b):
+            return a + b
+
+        self.assertEqual(run(x, x), x + x)
+        with self.assertRaisesRegex(PrecompileError, "expected 2 positional args"):
+            run(x)
+
+    def _rope_artifact(self, device, **kwargs):
+        # Two outputs, both plain allocated buffers: the shape out= is designed for.
+        path = self._tmp_path("out_rope.py")
+
+        @torch.compiler.export_python(path=path, **kwargs)
+        def run(a, b, c):
+            return a * c + b, b * c - a
+
+        return run
+
+    def test_out_donation_matches(self, device):
+        # Donated outputs must hold exactly what the allocating call returns, on the
+        # recording call (which fills them by hand) and on every replayed call after.
+        run = self._rope_artifact(device, unsafe_reduce_overhead=True)
+        args = [
+            make_tensor((8, 8), device=device, dtype=torch.float32) for _ in range(3)
+        ]
+        expected = run(*args)
+
+        o0 = torch.empty_like(expected[0])
+        o1 = torch.empty_like(expected[1])
+        first = run(*args, out=(o0, o1))
+        self.assertIs(first[0], o0)
+        self.assertIs(first[1], o1)
+        self.assertEqual(first, expected)
+
+        # A second donating call goes through the recorded plan, not the recording
+        # path, and must land in the same tensors.
+        o0.zero_()
+        o1.zero_()
+        again = run(*args, out=(o0, o1))
+        self.assertIs(again[0], o0)
+        self.assertEqual(again, expected)
+
+        # A plain call afterwards still allocates its own outputs.
+        plain = run(*args)
+        self.assertIsNot(plain[0], o0)
+        self.assertEqual(plain, expected)
+
+    def test_out_donation_new_inputs(self, device):
+        # The recorded plan must not pin the inputs: different input values through the
+        # same donated buffers have to recompute, not replay a stale result.
+        run = self._rope_artifact(device, unsafe_reduce_overhead=True)
+        args = [
+            make_tensor((8, 8), device=device, dtype=torch.float32) for _ in range(3)
+        ]
+        o0 = torch.empty((8, 8), device=device, dtype=torch.float32)
+        o1 = torch.empty((8, 8), device=device, dtype=torch.float32)
+        run(*args, out=(o0, o1))
+
+        args2 = [
+            make_tensor((8, 8), device=device, dtype=torch.float32) for _ in range(3)
+        ]
+        run(*args2, out=(o0, o1))
+        self.assertEqual((o0, o1), run(*args2))
+
+    def test_out_requires_unsafe_reduce_overhead(self, device):
+        run = self._rope_artifact(device)
+        args = [
+            make_tensor((8, 8), device=device, dtype=torch.float32) for _ in range(3)
+        ]
+        o = torch.empty((8, 8), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(TypeError, "out= requires unsafe_reduce_overhead"):
+            run(*args, out=(o, o.clone()))
+
+    def test_out_mismatched_donor_rejected(self, device):
+        # The donated tensors are checked once, on the recording call: a kernel writing
+        # through baked sizes into a too-small buffer is memory corruption, not a wrong
+        # number, so this one check is worth its one-time cost.
+        run = self._rope_artifact(device, unsafe_reduce_overhead=True)
+        args = [
+            make_tensor((8, 8), device=device, dtype=torch.float32) for _ in range(3)
+        ]
+        good = torch.empty((8, 8), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(PrecompileError, r"out\[1\] must be a tensor"):
+            run(*args, out=(good, torch.empty((4, 4), device=device)))
+        with self.assertRaisesRegex(PrecompileError, "out= has 1 tensors"):
+            run(*args, out=(good,))
+
+    def test_out_rejected_when_output_is_a_view(self, device):
+        # A reshaped output comes back as a view of a buffer rather than the buffer, so
+        # there is no allocation to redirect into the caller's tensor. Reject it by
+        # name instead of donating the wrong slot.
+        path = self._tmp_path("out_view.py")
+
+        @torch.compiler.export_python(path=path, unsafe_reduce_overhead=True)
+        def run(a, b):
+            return (a @ b).reshape(-1)
+
+        a = make_tensor((8, 8), device=device, dtype=torch.float32)
+        b = make_tensor((8, 8), device=device, dtype=torch.float32)
+        o = torch.empty_like(run(a, b))
+        with self.assertRaisesRegex(PrecompileError, "not a buffer the artifact"):
+            run(a, b, out=(o,))
+
+    def test_out_rejected_for_eager_backend(self, device):
+        # An eager artifact runs a bare graph, so it binds none of the allocators the
+        # donation contract needs; the rejection names the contract it failed.
+        run = self._rope_artifact(device, backend="eager", unsafe_reduce_overhead=True)
+        args = [
+            make_tensor((8, 8), device=device, dtype=torch.float32) for _ in range(3)
+        ]
+        o = torch.empty((8, 8), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(PrecompileError, r"empty_strided\* callables"):
+            run(*args, out=(o, o.clone()))
+
+    def test_allocator_prefix_matches_codegen_call_sites(self, device):
+        # Pins the codegen side of _ALLOCATOR_PREFIX: every allocator name inductor can
+        # emit for a buffer starts with it. The donation plan is replayed by allocation
+        # ORDER, so an allocator the prefix missed would silently desync it rather than
+        # fail, which is why this is checked against the emitter rather than against a
+        # single generated artifact (whose device coverage is whatever the host has).
+        from torch._inductor.codegen.wrapper import PythonWrapperCodegen
+        from torch.compiler._export_python import _ALLOCATOR_PREFIX
+
+        source = inspect.getsource(PythonWrapperCodegen.make_allocation)
+        callees = re.findall(r"\{name\} = ([\w{}.]+)\(", source)
+        self.assertTrue(callees, "make_allocation no longer emits '{name} = alloc('")
+        for callee in callees:
+            if callee == "tracked_empty_strided":
+                # test_configs.track_memory_lifecycle routes EVERY allocation through
+                # this one name, so the pool intercepts none of them and the recording
+                # call raises instead of serving a partially donated plan.
+                continue
+            self.assertTrue(
+                callee.startswith(_ALLOCATOR_PREFIX),
+                f"inductor emits buffer allocations through {callee}, which "
+                f"_ALLOCATOR_PREFIX ({_ALLOCATOR_PREFIX!r}) does not match; "
+                "_BufferDonationPool would not intercept it",
+            )
+
+    def test_pool_intercepts_every_artifact_allocator(self, device):
+        # Runtime side of the same invariant: whatever allocators an artifact actually
+        # binds, the pool must wrap all of them. The bound set is found by identity
+        # against the real allocator functions, not by name, so a rename that escapes
+        # _ALLOCATOR_PREFIX fails here.
+        from torch.compiler._export_python import _ALLOCATOR_PREFIX, _BufferDonationPool
+
+        path = self._tmp_path("alloc_prefix.py")
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run(a, b):
+            return a * 2 + b
+
+        x = make_tensor((8, 8), device=device, dtype=torch.float32)
+        run(x, x)
+
+        guards = torch._C._dynamo.guards
+        real = [v for n, v in vars(guards).items() if n.startswith("_empty_strided")]
+        real.append(torch.empty_strided)
+        ns = run._loaded.__globals__
+        bound = sorted(n for n, v in ns.items() if any(v is r for r in real))
+        self.assertTrue(bound, "the artifact binds no inductor buffer allocator")
+
+        wrapped = dict(ns)
+        _BufferDonationPool(wrapped)
+        for name in bound:
+            self.assertIsNot(
+                wrapped[name],
+                ns[name],
+                f"the artifact allocates through {name}, which _ALLOCATOR_PREFIX "
+                f"({_ALLOCATOR_PREFIX!r}) does not match, so the donation plan would "
+                "be recorded and replayed with that allocator's buffers missing",
+            )
+
+
+instantiate_device_type_tests(TestExportPython, globals())
 
 
 if __name__ == "__main__":

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -1,18 +1,27 @@
 # Owner(s): ["oncall: pt2"]
+import contextlib
 import copy
+import errno
+import gc
+import inspect
 import io
 import os
 import pickle
+import re
+import shutil
 import subprocess
 import sys
 import tempfile
 import textwrap
 import unittest
+import weakref
+from unittest import mock
 
 import torch
 import torch.utils._pytree as _pytree
 from torch._dynamo.decorators import mark_dynamic, mark_unbacked
 from torch._precompile import PrecompileError
+from torch.distributed._functional_collectives import AsyncCollectiveTensor
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
@@ -23,6 +32,70 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TestCase,
 )
+from torch.testing._internal.two_tensor import TwoTensor
+
+
+class _MisreportedDevice(torch.Tensor):
+    """A wrapper subclass reporting a device that differs from the one holding its bytes.
+
+    torch.load builds exactly this from stock inputs: map_location="cuda" gives a bare
+    "cuda" over a "cuda:0" payload, and map_location={"cuda:0": "cpu"} gives a "cuda:0"
+    wrapper over a "cpu" payload. Both axes have to be decided on the leaf.
+    """
+
+    @staticmethod
+    def __new__(cls, payload, reported):
+        return torch.Tensor._make_wrapper_subclass(
+            cls, payload.shape, dtype=payload.dtype, device=reported
+        )
+
+    def __init__(self, payload, reported):
+        self.payload = payload
+
+    def __tensor_flatten__(self):
+        return ["payload"], None
+
+    @staticmethod
+    def __tensor_unflatten__(inner, ctx, outer_size, outer_stride):
+        payload = inner["payload"]
+        return _MisreportedDevice(payload, payload.device)
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        raise NotImplementedError
+
+
+@contextlib.contextmanager
+def _default_dtype(dtype):
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(previous)
+
+
+@contextlib.contextmanager
+def _deterministic(enabled):
+    previous = torch.are_deterministic_algorithms_enabled()
+    torch.use_deterministic_algorithms(enabled)
+    try:
+        yield
+    finally:
+        torch.use_deterministic_algorithms(previous)
+
+
+def _lying_device(device):
+    """A device label differing from `device` in INDEX only."""
+    real = torch.device(device)
+    if real.index is not None:
+        return torch.device(real.type)
+    return torch.device(real.type, 0)
+
+
+def _type_lying_device(device):
+    """A device label differing from `device` in TYPE. Requires no such hardware."""
+    return torch.device("cpu" if torch.device(device).type == "cuda" else "cuda", 0)
 
 
 # A module-level (global) model + a function referencing it, to exercise the
@@ -859,6 +932,13 @@ class TestPrecompile(TestCase):
         # The public location: test_public_bindings.test_correct_module_names also
         # enforces this for every torch.compiler.__all__ member.
         self.assertEqual(torch.compiler.precompile.__module__, "torch.compiler")
+        # export_python is the disk-cached decorator over precompile; it lives
+        # under the same compiler namespace, not as a top-level torch.* verb.
+        self.assertIn("export_python", torch.compiler.__all__)
+        self.assertNotIn("export_python", torch.__all__)
+        self.assertFalse(hasattr(torch, "export_python"))
+        self.assertTrue(callable(torch.compiler.export_python))
+        self.assertEqual(torch.compiler.export_python.__module__, "torch.compiler")
 
     def test_backend_invalid_raises(self):
         a, b = torch.randn(4, 4), torch.randn(4, 4)
@@ -2610,6 +2690,2286 @@ class TestPrecompileNumerics(TestCase):
 
 
 instantiate_device_type_tests(TestPrecompileNumerics, globals())
+
+
+def _artifact_of(wrapped):
+    # The decorator deliberately hands back a plain function with no handle on the
+    # artifact, so reach it through the wrapper's closure. Only tests need this; it is
+    # what lets them assert on load-time decisions like whether the lean entry bound.
+    from torch.compiler._export_python import ExportedPythonArtifact
+
+    return next(
+        cell.cell_contents
+        for cell in wrapped.__closure__
+        if isinstance(cell.cell_contents, ExportedPythonArtifact)
+    )
+
+
+@skipIfTorchDynamo("precompile's make_fx capture is incompatible with dynamo wrapping")
+class TestExportPython(TestCase):
+    # torch.compiler.export_python is the disk-cached decorator over
+    # torch.compiler.precompile: first call writes the emitted, self-contained python,
+    # later calls read and exec it directly. Run device-generically so the inductor
+    # path is exercised on CUDA too.
+
+    def _tmp_path(self, name="artifact.py"):
+        d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        return os.path.join(d, name)
+
+    def _library(self, name, kind="DEF"):
+        # _scoped_library's teardown without its block: these tests define an op and
+        # then use it several statements later, and wrapping each body in a with just
+        # to reach the op reads worse than destroying the library at cleanup.
+        stack = contextlib.ExitStack()
+        self.addCleanup(stack.close)
+        return stack.enter_context(torch.library._scoped_library(name, kind))
+
+    def test_eager_write_then_load(self, device):
+        path = self._tmp_path()
+        x = make_tensor((4, 4), device=device, dtype=torch.float32)
+        y = make_tensor((4, 4), device=device, dtype=torch.float32)
+        expected = (x * 2 + y).relu()
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(a, b):
+                return (a * 2 + b).relu()
+
+            return run
+
+        self.assertFalse(os.path.exists(path))
+        self.assertEqual(build()(x, y), expected)
+        self.assertTrue(os.path.exists(path))
+        with open(path, encoding="utf-8") as f:
+            self.assertIn("def forward(", f.read())
+
+        # A fresh decorator over the same path loads the emitted source from disk
+        # rather than recompiling.
+        with self.assertLogs("torch.compiler._export_python", level="WARNING") as cm:
+            self.assertEqual(build()(x, y), expected)
+        self.assertIn("about to EXEC", "\n".join(cm.output))
+
+    def test_inductor_writes_output_code(self, device):
+        path = self._tmp_path("inductor.py")
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3)).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run(model, inp):
+            return model(inp)
+
+        self.assertEqual(run(m, x), m(x))
+        with open(path, encoding="utf-8") as f:
+            self.assertIn("Inductor output code", f.read())
+        # export_python writes only the self-contained source; there is no cache.
+        self.assertFalse(os.path.exists(path + ".cache"))
+
+    def test_inductor_reload_from_disk(self, device):
+        # Inductor analogue of test_eager_write_then_load: the first build() lowers
+        # through Inductor and commits the emitted source; a SECOND fresh decorator over
+        # the SAME path must load that source from disk and run it instead of
+        # recompiling, exercising the inductor load-from-disk path.
+        path = self._tmp_path("inductor_reload.py")
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3)).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+        expected = m(x)
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="inductor")
+            def run(model, inp):
+                return model(inp)
+
+            return run
+
+        self.assertEqual(build()(m, x), expected)
+        self.assertTrue(os.path.exists(path))
+        self.assertEqual(build()(m, x), expected)
+
+    def test_inductor_edited_source_takes_effect(self, device):
+        # Inductor hill-climb (ejectable compilation): the emitted source is the source
+        # of truth, so an edit that CHANGES THE MATH must take effect on the next load.
+        # A comment-only edit cannot show that, since it is exec-inert either way.
+        path = self._tmp_path("inductor_edit.py")
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3)).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+        expected = m(x)
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run(model, inp):
+            return model(inp)
+
+        self.assertEqual(run(m, x), expected)
+
+        # Wrap the artifact's own entry point so the edit is backend-agnostic: whatever
+        # forward() computes, the edited file must return twice it.
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+        code = code.replace("def forward(", "def _orig_forward(", 1)
+        code += textwrap.dedent(
+            """
+
+            def forward(*args, **kwargs):
+                return _orig_forward(*args, **kwargs) * 2
+            """
+        )
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(code)
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run2(model, inp):
+            return model(inp)
+
+        self.assertEqual(run2(m, x), expected * 2)
+
+    def test_creates_parent_dirs(self, device):
+        path = self._tmp_path(os.path.join("nested", "deep", "artifact.py"))
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp * 2
+
+        self.assertEqual(run(x), x * 2)
+        self.assertTrue(os.path.exists(path))
+
+    def test_example_inputs_drives_capture(self, device):
+        @torch.compiler.export_python(
+            path=self._tmp_path("ex.py"),
+            backend="eager",
+            example_inputs=[make_tensor((3, 3), device=device, dtype=torch.float32)],
+        )
+        def run(inp):
+            return inp.relu()
+
+        # Capture is specialized to the (3, 3) example, so a (5, 5) runtime input is
+        # rejected -- proving example_inputs, not the call args, drove capture.
+        with self.assertRaisesRegex(PrecompileError, "shape"):
+            run(make_tensor((5, 5), device=device, dtype=torch.float32))
+
+    def test_non_deepcopyable_first_call_arg_errors(self, device):
+        # A non-leaf tensor cannot be deep-copied; the None example_inputs path must
+        # surface a clear error pointing at example_inputs, not a raw deepcopy error.
+        @torch.compiler.export_python(path=self._tmp_path("nc.py"), backend="eager")
+        def run(inp):
+            return inp + 1
+
+        non_leaf = make_tensor(
+            (4,), device=device, dtype=torch.float32
+        ).requires_grad_()
+        with self.assertRaisesRegex(PrecompileError, "example_inputs"):
+            run(non_leaf * 2)
+
+    def test_no_cache_sidecar_written(self, device):
+        # export_python is cache-free: the first run commits only the self-contained
+        # .py, never a .cache sidecar, and a fresh decorator reloads from the .py alone.
+        path = self._tmp_path()
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return inp.sin()
+
+            return run
+
+        self.assertEqual(build()(x), x.sin())
+        self.assertFalse(os.path.exists(path + ".cache"))
+        self.assertEqual(build()(x), x.sin())
+
+    @parametrize("backend", ("eager", "inductor"))
+    def test_first_call_preserves_rng_state(self, device, backend):
+        x = torch.empty((4,), device=device)
+        path = self._tmp_path(f"rng_{backend}.py")
+
+        def build():
+            @torch.compiler.export_python(path=path, backend=backend)
+            def run(inp):
+                return torch.rand_like(inp)
+
+            return run
+
+        def rng_state():
+            cpu = torch.random.get_rng_state()
+            if torch.device(device).type == "cpu":
+                return cpu, None
+            module = torch.get_device_module(torch.device(device).type)
+            return cpu, module.get_rng_state(torch.device(device))
+
+        torch.manual_seed(1234)
+        first = build()(x)
+        first_state = rng_state()
+
+        torch.manual_seed(1234)
+        loaded = build()(x)
+        loaded_state = rng_state()
+        self.assertEqual(first, loaded)
+        self.assertEqual(first_state, loaded_state)
+
+    def test_first_call_preserves_noncurrent_cuda_rng_state(self, device):
+        if not TEST_CUDA or torch.cuda.device_count() < 2:
+            self.skipTest("requires two CUDA devices")
+        path = self._tmp_path("rng_noncurrent.py")
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return torch.rand_like(inp)
+
+            return run
+
+        with torch.cuda.device(0):
+            x = torch.empty(8, device="cuda:1")
+            torch.manual_seed(1234)
+            torch.cuda.manual_seed_all(1234)
+            first = build()(x)
+            first_state = torch.cuda.get_rng_state(1)
+
+            torch.manual_seed(1234)
+            torch.cuda.manual_seed_all(1234)
+            loaded = build()(x)
+            loaded_state = torch.cuda.get_rng_state(1)
+
+        self.assertEqual(first, loaded)
+        self.assertEqual(first_state, loaded_state)
+
+    def _capture_racing_a_concurrent_draw(self, run, x):
+        """Run ``run(x)``'s first capture with a concurrent torch.rand(8) inside it.
+
+        Returns (error_or_None, the concurrently drawn tensor). The capture is stalled
+        on entry so the draw is guaranteed to land between the pre-capture generator
+        snapshot and the post-capture restore decision.
+        """
+        import threading
+        from unittest.mock import patch
+
+        import torch._precompile as precompile_impl
+
+        entered = threading.Event()
+        release = threading.Event()
+        real_capture = precompile_impl._capture
+
+        def synchronized_capture(*args, **kwargs):
+            entered.set()
+            self.assertTrue(release.wait(10))
+            return real_capture(*args, **kwargs)
+
+        errors = []
+
+        def worker():
+            try:
+                run(x)
+            except BaseException as e:
+                errors.append(e)
+
+        with patch.object(precompile_impl, "_capture", synchronized_capture):
+            thread = threading.Thread(target=worker)
+            thread.start()
+            self.assertTrue(entered.wait(10))
+            concurrent = torch.rand(8)
+            release.set()
+            thread.join(20)
+        self.assertFalse(thread.is_alive())
+        return (errors[0] if errors else None), concurrent
+
+    def test_deterministic_capture_ignores_a_concurrent_draw(self, device):
+        # The restore is keyed on whether the CAPTURED GRAPH draws, not on whether
+        # global generator state moved -- otherwise an unrelated thread's draw makes a
+        # deterministic capture look random, and rewinding it would replay that draw.
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("rng_concurrent.py"), backend="eager"
+        )
+        def run(inp):
+            return inp + 1
+
+        torch.manual_seed(1234)
+        error, concurrent = self._capture_racing_a_concurrent_draw(run, x)
+        self.assertIsNone(error)
+        self.assertNotEqual(torch.rand(8), concurrent)
+
+    def test_random_capture_restores_rng_off_the_main_thread(self, device):
+        # Restoring the generators the capture drew from is what keeps a random fn's
+        # first call faithful, and it is not conditioned on thread identity: the
+        # capturing call and the loading call agree even from a worker thread.
+        import threading
+
+        path = self._tmp_path("rng_worker.py")
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return torch.rand_like(inp)
+
+            return run
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                out = build()(x)
+                results.append((out, torch.random.get_rng_state()))
+            except BaseException as e:
+                errors.append(e)
+
+        for _ in range(2):
+            torch.manual_seed(1234)
+            thread = threading.Thread(target=worker)
+            thread.start()
+            thread.join(20)
+            self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(results[0], results[1])
+
+    def test_explicit_examples_released_after_materialization(self, device):
+        example = make_tensor((4,), device=device, dtype=torch.float32)
+        example_ref = weakref.ref(example)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("example_lifetime.py"),
+            backend="eager",
+            example_inputs=[example],
+        )
+        def run(inp):
+            return inp + 1
+
+        del example
+        self.assertEqual(
+            run(make_tensor((4,), device=device, dtype=torch.float32)).shape,
+            (4,),
+        )
+        gc.collect()
+        self.assertIsNone(example_ref())
+
+    def test_decompositions_released_after_materialization(self, device):
+        path = self._tmp_path("decomposition_lifetime.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def seed(inp):
+            return inp + 1
+
+        self.assertEqual(seed(x), x + 1)
+        payload = make_tensor((4,), device=device, dtype=torch.float32)
+        payload_ref = weakref.ref(payload)
+
+        def make_decomposition(value):
+            def decomposition(inp):
+                return inp + value.sum() * 0
+
+            return decomposition
+
+        decomposition = make_decomposition(payload)
+        table = {torch.ops.aten.sin.default: decomposition}
+
+        @torch.compiler.export_python(path=path, backend="eager", decompositions=table)
+        def loaded(inp):
+            return inp + 1
+
+        self.assertEqual(loaded(x), x + 1)
+        del payload, decomposition, table
+        gc.collect()
+        self.assertIsNone(payload_ref())
+
+    def test_decorated_method_binds_instance(self, device):
+        path = self._tmp_path("method.py")
+
+        class Model(torch.nn.Module):
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(self, inp):
+                return inp + 1
+
+        model = Model()
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        self.assertTrue(inspect.ismethod(model.run))
+        self.assertEqual(model.run(x), x + 1)
+
+    def test_module_training_state_is_guarded(self, device):
+        path = self._tmp_path("module_training.py")
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return inp + 1 if self.training else inp - 1
+
+        model = Model().to(device).train()
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(mod, inp):
+            return mod(inp)
+
+        self.assertEqual(run(model, x), x + 1)
+        model.eval()
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def loaded(mod, inp):
+            return mod(inp)
+
+        with self.assertRaisesRegex(PrecompileError, "training state"):
+            loaded(model, x)
+
+    def test_hand_edit_dropping_training_stamp_warns_and_runs(self, device):
+        # The artifact is meant to be hand-edited, so dropping the stamp turns the
+        # guard off with a warning rather than bricking the file -- the same contract
+        # the version stamp already has.
+        path = self._tmp_path("module_training_edit.py")
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return inp + 1 if self.training else inp - 1
+
+        model = Model().to(device).train()
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(mod, inp):
+            return mod(inp)
+
+        self.assertEqual(run(model, x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+        kept = [line for line in lines if "module-training:" not in line]
+        self.assertEqual(len(kept), len(lines) - 1)
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(kept)
+        model.eval()
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def loaded(mod, inp):
+            return mod(inp)
+
+        with self.assertLogs("torch.compiler._export_python", level="WARNING") as logs:
+            self.assertEqual(loaded(model, x), x + 1)
+        self.assertTrue(any("no recorded training state" in m for m in logs.output))
+
+    def test_decorated_function_is_picklable(self, device):
+        name = "_export_python_pickle_fixture"
+
+        def original(inp):
+            return inp + 1
+
+        original.__name__ = name
+        original.__qualname__ = name
+        original.__module__ = __name__
+        wrapped = torch.compiler.export_python(
+            path=self._tmp_path("pickle.py"), backend="eager"
+        )(original)
+        globals()[name] = wrapped
+        try:
+            self.assertIs(pickle.loads(pickle.dumps(wrapped)), wrapped)
+        finally:
+            del globals()[name]
+
+    def test_hill_climb_edited_source_takes_effect(self, device):
+        path = self._tmp_path("edit.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+        edited = code.replace(
+            "torch.ops.aten.add.Tensor(flat_1, 1)",
+            "torch.ops.aten.add.Tensor(flat_1, 100)",
+        )
+        self.assertNotEqual(
+            edited, code, "expected the add constant in the emitted graph"
+        )
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(edited)
+
+        # A fresh decorator sees the edited source and always exec's it, so the edited
+        # constant takes effect.
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        self.assertEqual(run2(x), x + 100)
+
+    def test_first_call_applies_mutation_once(self, device):
+        path = self._tmp_path("bn.py")
+        torch.manual_seed(0)
+        m = torch.nn.BatchNorm1d(4).to(device).train()
+        x = make_tensor((8, 4), device=device, dtype=torch.float32)
+
+        ref = torch.nn.BatchNorm1d(4).to(device).train()
+        ref.load_state_dict(m.state_dict())
+        ref(x)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(model, inp):
+            return model(inp)
+
+        run(m, x)
+        # Capture deep-copies the args, so the running stats are updated exactly once
+        # (by the artifact), matching a single eager application -- not twice.
+        self.assertEqual(m.running_mean, ref.running_mean)
+        self.assertEqual(m.running_var, ref.running_var)
+
+    @parametrize("backend", ("eager", "inductor"))
+    def test_concurrent_first_calls_precompile_once(self, device, backend):
+        import threading
+        from unittest.mock import patch
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("concurrent.py"), backend=backend
+        )
+        def run(inp):
+            return inp + 1
+
+        real = torch.compiler.precompile
+
+        # Count precompile() invocations; the decorator calls torch.compiler.precompile
+        # exactly once behind its double-checked lock even under the racing first calls.
+        class _Counting:
+            def __init__(self):
+                self.n = 0
+
+            def __call__(self, *a, **k):
+                self.n += 1
+                return real(*a, **k)
+
+        counting = _Counting()
+        n = 8
+        barrier = threading.Barrier(n)
+        results: list = [None] * n
+
+        def worker(i):
+            barrier.wait()
+            results[i] = run(x)
+
+        with patch.object(torch.compiler, "precompile", counting):
+            threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        # The double-checked lock must precompile exactly once despite the race.
+        self.assertEqual(counting.n, 1)
+        for r in results:
+            self.assertEqual(r, x + 1)
+
+    def test_concurrent_distinct_captures_are_serialized(self, device):
+        import threading
+        import time
+        from unittest.mock import patch
+
+        import torch._precompile as precompile_impl
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        runs = []
+        for i in range(4):
+
+            @torch.compiler.export_python(
+                path=self._tmp_path(f"concurrent_{i}.py"), backend="eager"
+            )
+            def run(inp):
+                return inp + 1
+
+            runs.append(run)
+
+        real = precompile_impl._capture
+        state_lock = threading.Lock()
+        active = 0
+        max_active = 0
+
+        def spy(*args, **kwargs):
+            nonlocal active, max_active
+            with state_lock:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                time.sleep(0.02)
+                return real(*args, **kwargs)
+            finally:
+                with state_lock:
+                    active -= 1
+
+        barrier = threading.Barrier(len(runs))
+        results: list = [None] * len(runs)
+
+        def worker(i):
+            barrier.wait()
+            results[i] = runs[i](x)
+
+        with patch.object(precompile_impl, "_capture", spy):
+            threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        self.assertEqual(max_active, 1)
+        for result in results:
+            self.assertEqual(result, x + 1)
+
+    def test_export_and_direct_precompile_captures_are_serialized(self, device):
+        import threading
+        import time
+        from unittest.mock import patch
+
+        import torch._precompile as precompile_impl
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("direct_concurrent.py"), backend="eager"
+        )
+        def exported(inp):
+            return inp + 1
+
+        real_capture = precompile_impl._capture
+        state_lock = threading.Lock()
+        active = 0
+        max_active = 0
+
+        def spy(*args, **kwargs):
+            nonlocal active, max_active
+            with state_lock:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                time.sleep(0.05)
+                return real_capture(*args, **kwargs)
+            finally:
+                with state_lock:
+                    active -= 1
+
+        barrier = threading.Barrier(2)
+        errors = []
+
+        def export_worker():
+            try:
+                barrier.wait()
+                exported(x)
+            except BaseException as e:
+                errors.append(e)
+
+        def precompile_worker():
+            try:
+                barrier.wait()
+                torch.compiler.precompile(lambda inp: inp + 2, x, backend="eager")
+            except BaseException as e:
+                errors.append(e)
+
+        with patch.object(precompile_impl, "_capture", spy):
+            threads = [
+                threading.Thread(target=export_worker),
+                threading.Thread(target=precompile_worker),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(20)
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual(errors, [])
+        self.assertEqual(max_active, 1)
+
+    def test_nested_first_capture_does_not_deadlock(self, device):
+        code = textwrap.dedent(
+            f"""
+            import os
+            import tempfile
+            import torch
+
+            with tempfile.TemporaryDirectory() as d:
+                example = torch.ones(1, device={device!r})
+
+                @torch.compiler.export_python(
+                    path=os.path.join(d, "inner.py"),
+                    backend="eager",
+                    example_inputs=[example],
+                )
+                def inner(x):
+                    return x + 1
+
+                @torch.compiler.export_python(
+                    path=os.path.join(d, "outer.py"), backend="eager"
+                )
+                def outer(x):
+                    return inner(x) * 2
+
+                torch.testing.assert_close(outer(example), (example + 1) * 2)
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_same_path_concurrent_publish_has_one_winner(self, device):
+        # Two PROCESSES racing a fresh path is the real scenario (in one process,
+        # materialization is serialized by the capture lock, so the second caller just
+        # finds the file). Both must end up running the winner's artifact, never their
+        # own divergent source, and no temp file may be left beside it.
+        code = textwrap.dedent(
+            f"""
+            import os, sys, torch
+            path, marker, barrier_dir = sys.argv[1], sys.argv[2], sys.argv[3]
+
+            real = torch.compiler.precompile
+            def fake(fn, *args, **kwargs):
+                return "def forward(x):\\n    return x + " + marker + "\\n", b""
+            torch.compiler.precompile = fake
+
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return inp
+
+            # Rendezvous so both processes are inside the presence gate together.
+            open(os.path.join(barrier_dir, marker), "w").close()
+            while len(os.listdir(barrier_dir)) < 2:
+                pass
+            print(int(run(torch.zeros(1, device={device!r})).item()))
+            """
+        )
+        path = self._tmp_path("publish.py")
+        barrier_dir = os.path.join(os.path.dirname(path), "barrier")
+        os.makedirs(barrier_dir, exist_ok=True)
+        procs = [
+            subprocess.Popen(
+                [sys.executable, "-c", code, path, marker, barrier_dir],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            for marker in ("1", "2")
+        ]
+        outs = []
+        for proc in procs:
+            stdout, stderr = proc.communicate(timeout=180)
+            self.assertEqual(proc.returncode, 0, stderr)
+            outs.append(stdout.strip().splitlines()[-1])
+        # Same answer in both, and it is one of the two candidate artifacts.
+        self.assertEqual(outs[0], outs[1])
+        self.assertIn(outs[0], ("1", "2"))
+        self.assertEqual(
+            sorted(os.listdir(os.path.dirname(path))),
+            sorted(["barrier", os.path.basename(path)]),
+        )
+
+        # A third, later reader gets that same winner off disk.
+        @torch.compiler.export_python(path=path, backend="eager")
+        def fresh(inp):
+            return inp
+
+        self.assertEqual(int(fresh(torch.zeros(1, device=device)).item()), int(outs[0]))
+
+    def test_publish_falls_back_when_filesystem_has_no_hard_links(self, device):
+        from torch.compiler._export_python import _atomic_publish
+
+        path = self._tmp_path("nolink.py")
+        real_link = os.link
+
+        def no_link(src, dst):
+            raise OSError(errno.EPERM, "operation not permitted")
+
+        with mock.patch.object(os, "link", no_link):
+            with self.assertLogs("torch.compiler._export_python", "WARNING") as logs:
+                self.assertTrue(_atomic_publish(path, b"payload"))
+        # Assert on wording only the implementation supplies: the mock's strerror is
+        # interpolated into the same message and would satisfy a looser match.
+        self.assertTrue(any("last-writer-wins" in m for m in logs.output))
+        with open(path, "rb") as f:
+            self.assertEqual(f.read(), b"payload")
+        self.assertEqual(os.listdir(os.path.dirname(path)), [os.path.basename(path)])
+        self.assertIs(os.link, real_link)
+
+    def test_publish_does_not_swallow_real_io_errors(self, device):
+        # Only "this filesystem has no hard links" degrades to last-writer-wins; a full
+        # disk must surface rather than silently weaken first-publisher-wins.
+        from torch.compiler._export_python import _atomic_publish
+
+        path = self._tmp_path("enospc.py")
+
+        def full_disk(src, dst):
+            raise OSError(errno.ENOSPC, "no space left on device")
+
+        with mock.patch.object(os, "link", full_disk):
+            with self.assertRaises(OSError):
+                _atomic_publish(path, b"payload")
+        self.assertFalse(os.path.exists(path))
+        self.assertEqual(os.listdir(os.path.dirname(path)), [])
+
+    def test_clobbered_non_artifact_source_raises_clean_error(self, device):
+        # A clobbered non-artifact source degrades to a clean PrecompileError
+        # referencing the path, not a raw KeyError/SyntaxError, so a stale hand-edit
+        # that drops the forward() surfaces an actionable message.
+        path = self._tmp_path("clobber.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("x = 1\n")
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        with self.assertRaisesRegex(
+            PrecompileError, "could not be run as precompile source"
+        ):
+            run2(x)
+
+    def test_kwargs_bound_positionally(self, device):
+        path = self._tmp_path("kw.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(a, b):
+            return a - b
+
+        # A keyword call binds onto (a, b) positionally and runs the artifact.
+        self.assertEqual(run(a=x, b=x + 1), x - (x + 1))
+
+    def test_keyword_only_params_rejected(self, device):
+        @torch.compiler.export_python(path=self._tmp_path("ko.py"), backend="eager")
+        def run(a, *, b):
+            return a + b
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(TypeError, "keyword-only"):
+            run(x, b=x)
+
+    def test_positional_defaults_are_canonicalized(self, device):
+        default = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=self._tmp_path("posdef.py"), backend="eager")
+        def run(a, b=default, c=default):
+            return a + b + c
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        other = make_tensor((4,), device=device, dtype=torch.float32)
+        self.assertEqual(run(x, c=other), x + default + other)
+        self.assertEqual(run(x, b=other), x + other + default)
+
+    def test_non_tensor_arguments_rejected(self, device):
+        @torch.compiler.export_python(path=self._tmp_path("scalar.py"), backend="eager")
+        def run(inp, scale=1):
+            return inp * scale
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(TypeError, "only Tensor pytrees"):
+            run(x, 1)
+
+    def test_var_kwargs_rejected(self, device):
+        # A fn declaring **kwargs cannot be laid out positionally once extra keyword
+        # args are passed; the error must name **kwargs as the cause rather than
+        # misreporting it as a positional-or-keyword arg left to its default.
+        @torch.compiler.export_python(path=self._tmp_path("varkw.py"), backend="eager")
+        def run(a, **kw):
+            return a + kw["b"]
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(TypeError, r"\*\*kwargs"):
+            run(x, b=x)
+
+    def test_decompositions_forwarded(self, device):
+        from unittest.mock import patch
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        sentinel: dict = {}
+        real = torch.compiler.precompile
+        captured: dict = {}
+
+        def spy(fn, *a, **k):
+            captured["decompositions"] = k.get("decompositions")
+            return real(fn, *a, **k)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("dec.py"), backend="eager", decompositions=sentinel
+        )
+        def run(inp):
+            return inp + 1
+
+        with patch.object(torch.compiler, "precompile", spy):
+            self.assertEqual(run(x), x + 1)
+        self.assertIs(captured["decompositions"], sentinel)
+
+    def test_existing_artifact_ignores_changed_backend(self, device):
+        # Presence is the sole signal: a new decorator over an existing path loads it
+        # as-is even with a different backend, so the on-disk eager artifact is reused
+        # and NOT re-lowered through inductor.
+        path = self._tmp_path("sole_signal.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            first = f.read()
+        self.assertNotIn("Inductor output code", first)
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run2(inp):
+            return inp + 1
+
+        self.assertEqual(run2(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            self.assertEqual(f.read(), first)
+
+    def test_version_skew_warns(self, device):
+        path = self._tmp_path("skew.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().split("\n")
+        tag = "# torch.compiler.export_python torch-version: "
+        self.assertTrue(lines[0].startswith(tag))
+        lines[0] = tag + repr("0.0.0-bogus")
+        # Displaced from line 1 on purpose: all four stamps are read from the leading
+        # comment block, so a hand-edit that adds a comment above them must not quietly
+        # disable the one check that catches a stale committed artifact.
+        lines.insert(0, "# a hand-edit above the stamps")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        # A stamped-but-mismatched artifact warns about the skew but still runs.
+        with self.assertLogs("torch.compiler._export_python", level="WARNING") as cm:
+            self.assertEqual(run2(x), x + 1)
+        self.assertTrue(any("0.0.0-bogus" in m for m in cm.output))
+
+    def test_no_version_warning_when_stamp_absent(self, device):
+        path = self._tmp_path("nostamp.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().split("\n")
+        tag = "# torch.compiler.export_python torch-version: "
+        if lines and lines[0].startswith(tag):
+            lines = lines[1:]
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        # A hand-edit that drops the stamp still gets the executable-file warning, but
+        # must not get a version-skew warning.
+        with self.assertLogs("torch.compiler._export_python", level="WARNING") as cm:
+            self.assertEqual(run2(x), x + 1)
+        self.assertTrue(any("about to EXEC" in message for message in cm.output))
+        self.assertFalse(any("produced by torch" in message for message in cm.output))
+
+    def test_env_import_failure_distinct_message(self, device):
+        # A valid artifact that fails to import a dependency under the current torch
+        # gets a distinct "different torch version or environment" error, not the
+        # clobbered-source message, so version skew is diagnosable.
+        path = self._tmp_path("badimport.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("import a_module_that_does_not_exist_xyz\n" + code)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        with self.assertRaisesRegex(PrecompileError, "different torch|environment"):
+            run2(x)
+
+    def test_artifact_raising_at_module_scope_is_a_distinct_error(self, device):
+        # The third arm of _load's taxonomy: not a syntax/structure problem and not a
+        # failed import, but source that blows up while being exec'd.
+        path = self._tmp_path("raises.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("raise RuntimeError('boom')\n" + code)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def loaded(inp):
+            return inp + 1
+
+        with self.assertRaisesRegex(PrecompileError, "unexpected error occurred"):
+            loaded(x)
+
+    def test_nested_submodule_training_state_is_guarded(self, device):
+        # named_modules() walks the whole tree, but every other test model is a leaf,
+        # so only this pins that a flip on a CHILD is caught.
+        path = self._tmp_path("nested_training.py")
+
+        class Inner(torch.nn.Module):
+            def forward(self, inp):
+                return inp + 1 if self.training else inp - 1
+
+        class Outer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.inner = Inner()
+
+            def forward(self, inp):
+                return self.inner(inp)
+
+        model = Outer().to(device).train()
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(mod, inp):
+            return mod(inp)
+
+        self.assertEqual(run(model, x), x + 1)
+        model.inner.eval()  # the root stays in train()
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def loaded(mod, inp):
+            return mod(inp)
+
+        with self.assertRaisesRegex(PrecompileError, "training state"):
+            loaded(model, x)
+
+    def test_recursive_decorated_function_raises_not_hangs(self, device):
+        path = self._tmp_path("recursive.py")
+        depth = [1]
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def f(inp):
+            if depth[0] > 0:
+                depth[0] -= 1
+                return f(inp + 1)
+            return inp * 2
+
+        with self.assertRaisesRegex(PrecompileError, "re-entrant call"):
+            f(make_tensor((4,), device=device, dtype=torch.float32))
+
+    def test_mangled_training_stamp_degrades_like_a_missing_one(self, device):
+        # The stamp is an exec-inert comment; a botched hand-edit of it must not raise
+        # a SyntaxError from a line that does not affect what the artifact runs.
+        path = self._tmp_path("mangled_stamp.py")
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return inp + 1
+
+        model = Model().to(device)
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(mod, inp):
+            return mod(inp)
+
+        self.assertEqual(run(model, x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+        for i, line in enumerate(lines):
+            if "module-training:" in line:
+                lines[i] = line.split(":")[0] + ": [(0, [('', unclosed\n"
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def loaded(mod, inp):
+            return mod(inp)
+
+        with self.assertLogs("torch.compiler._export_python", "WARNING") as logs:
+            self.assertEqual(loaded(model, x), x + 1)
+        self.assertTrue(any("no recorded training state" in m for m in logs.output))
+
+    def test_artifact_deleted_between_gate_and_read_regenerates(self, device):
+        # A peer deleting the artifact to force a regenerate must not surface as a bare
+        # FileNotFoundError from behind the presence gate.
+        path = self._tmp_path("toctou.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def seed(inp):
+            return inp + 1
+
+        self.assertEqual(seed(x), x + 1)
+
+        real_exists = os.path.exists
+
+        def exists_then_delete(p):
+            result = real_exists(p)
+            if p == path and result:
+                os.remove(p)
+            return result
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def racer(inp):
+            return inp + 1
+
+        with mock.patch.object(os.path, "exists", exists_then_delete):
+            self.assertEqual(racer(x), x + 1)
+        self.assertTrue(real_exists(path))
+
+    def test_path_naming_a_directory_is_a_clean_error(self, device):
+        path = self._tmp_path("adirectory.py")
+        os.makedirs(path)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        with self.assertRaisesRegex(PrecompileError, "readable file"):
+            run(make_tensor((4,), device=device, dtype=torch.float32))
+
+    def test_none_and_nested_module_arguments_name_their_own_cause(self, device):
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=self._tmp_path("none.py"), backend="eager")
+        def optional(inp, mask=None):
+            return inp + 1
+
+        with self.assertRaisesRegex(TypeError, "does not support None arguments"):
+            optional(x)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("nestmod.py"), backend="eager"
+        )
+        def nested(mods, inp):
+            return mods[0](inp)
+
+        with self.assertRaisesRegex(TypeError, "must be passed directly"):
+            nested([torch.nn.Linear(4, 4).to(device)], x)
+
+    def test_genuine_out_parameter_is_not_hijacked(self, device):
+        # Nothing about the name ``out`` is special any more -- the reserved keyword-only
+        # form went away with buffer donation -- so an ordinary parameter that happens to
+        # be called out must bind by keyword like any other.
+        @torch.compiler.export_python(
+            path=self._tmp_path("genuine.py"), backend="eager"
+        )
+        def run(a, out):
+            return a + out
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        self.assertEqual(run(x, out=x), x + x)
+
+    def test_capture_failure_leaves_rng_alone(self, device):
+        # A rejected capture has no graph to attribute draws to, so it must not rewind:
+        # capture rejections are routine and would replay a concurrent thread's draws.
+        import torch._precompile as precompile_impl
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("capture_fail.py"), backend="eager"
+        )
+        def run(inp):
+            return torch.rand_like(inp)
+
+        def boom(*args, **kwargs):
+            torch.rand(4)  # the half-run fn drew before failing
+            raise PrecompileError("synthetic capture failure")
+
+        torch.manual_seed(1234)
+        before = torch.random.get_rng_state().clone()
+        with mock.patch.object(precompile_impl, "_capture", boom):
+            with self.assertRaisesRegex(PrecompileError, "synthetic capture failure"):
+                run(x)
+        self.assertNotEqual(torch.random.get_rng_state(), before)
+
+    def test_gated_op_configured_not_to_draw_does_not_count_as_drawing(self, device):
+        # nondeterministic_seeded marks ops that MAY draw; the gate reads the argument
+        # that decides. SDPA is what actually exercises it: dropout(train=False) traces
+        # to no seeded op at all, so it would pass without any gate, and
+        # dropout(train=True) decomposes to bernoulli_, which is not a gated name.
+        from torch._precompile import (
+            _capture,
+            _graph_rng_devices,
+            _op_can_draw,
+            _rng_devices_indicate_a_draw,
+        )
+
+        q = make_tensor((1, 1, 8, 16), device=device, dtype=torch.float32)
+
+        def sdpa(a, p):
+            return torch.nn.functional.scaled_dot_product_attention(
+                a, a, a, dropout_p=p
+            )
+
+        def seeded(gm):
+            return [
+                n.target
+                for n in gm.graph.nodes
+                if isinstance(n.target, torch._ops.OpOverload)
+                and torch.Tag.nondeterministic_seeded in n.target.tags
+            ]
+
+        dead = _capture(lambda a: sdpa(a, 0.0), (q,), None).gm
+        live = _capture(lambda a: sdpa(a, 0.2), (q,), None).gm
+        # The no-draw graph still CONTAINS a tagged op, so the gate is the only thing
+        # that can classify it as non-drawing; without this assertion the next one
+        # would hold vacuously (which is how the previous version of this test passed).
+        self.assertTrue(seeded(dead), "expected a tagged SDPA op in the graph")
+        self.assertFalse(_rng_devices_indicate_a_draw(_graph_rng_devices(dead)))
+        self.assertTrue(_rng_devices_indicate_a_draw(_graph_rng_devices(live)))
+        # dropout_p is omitted from node.args at 0.0, so the schema-default arm of the
+        # lookup is covered too.
+        self.assertFalse(any(_op_can_draw(n) for n in dead.graph.nodes))
+
+    def test_rng_gate_table_matches_the_op_registry(self, device):
+        # The table is a hand-listed subset of the op registry, so it rots silently in
+        # both directions: a typo'd key never fires, and a newly tagged gated op that
+        # is missing is treated as always-drawing (rewinding concurrent work). Rebuild
+        # it from the static schema registry and compare. _jit_get_all_schemas is used
+        # rather than dir(torch.ops.aten), which grows as other tests touch ops.
+        from torch._precompile import _RNG_GATED_BY_ARG
+
+        discovered = {}
+        for schema in torch._C._jit_get_all_schemas():
+            if not schema.name.startswith("aten::"):
+                continue
+            args = [a.name for a in schema.arguments]
+            # Only names that genuinely gate drawing. "p"/"prob" are NOT gates:
+            # bernoulli(p=0.0) and geometric_(p=...) still consume randomness.
+            gate = next(
+                (g for g in ("dropout_p", "train", "training") if g in args), None
+            )
+            if gate is None:
+                continue
+            packet = getattr(torch.ops.aten, schema.name.split("::")[1], None)
+            overload = schema.overload_name or "default"
+            op = getattr(packet, overload, None) if packet is not None else None
+            if op is not None and torch.Tag.nondeterministic_seeded in op.tags:
+                discovered.setdefault(schema.name, gate)
+        self.assertEqual(discovered, dict(_RNG_GATED_BY_ARG))
+
+    def test_capture_drawing_only_on_the_accelerator_leaves_cpu_rng_alone(self, device):
+        # The restore is per generator, not all-or-nothing: rewinding the CPU generator
+        # for a graph that only drew on CUDA replays an unrelated CPU draw.
+        if not TEST_CUDA or torch.device(device).type != "cuda":
+            self.skipTest("needs a non-CPU generator to draw from")
+        path = self._tmp_path("cuda_only_rng.py")
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return torch.rand_like(inp)
+
+        x = torch.zeros(4, device=device)
+        torch.manual_seed(1234)
+        error, concurrent = self._capture_racing_a_concurrent_draw(run, x)
+        self.assertIsNone(error)
+        self.assertNotEqual(torch.rand(8), concurrent)
+
+    def test_gate_does_not_apply_to_a_lookalike_custom_op(self, device):
+        # The table is keyed on the qualified name. A custom op that merely shares a
+        # name with a gated aten op must stay conservative, or a graph that really
+        # draws is reported as not drawing and its consumed state is never restored.
+        from torch._precompile import _op_can_draw
+
+        lib = self._library("precompile_gate_test")
+        lib.define(
+            "dropout(Tensor input, float p, bool train) -> Tensor",
+            tags=(torch.Tag.nondeterministic_seeded,),
+        )
+        graph = torch.fx.Graph()
+        arg = graph.placeholder("x")
+        node = graph.call_function(
+            torch.ops.precompile_gate_test.dropout.default, (arg, 0.5, False)
+        )
+        self.assertTrue(_op_can_draw(node), "a lookalike op inherited aten's gate")
+
+    def _rope_artifact(self, device, **kwargs):
+        # Two outputs, both plain allocated buffers: the shape out= is designed for.
+        path = self._tmp_path("out_rope.py")
+
+        @torch.compiler.export_python(path=path, **kwargs)
+        def run(a, b, c, *, out=None):
+            return a * c + b, b * c - a
+
+        return run
+
+    def test_untagged_drawing_op_still_restores(self, device):
+        # An opaque custom op can draw inside its own kernel with nothing in the graph
+        # to say so -- the shape this API targets. Attributing the restore per device
+        # would leave those draws un-restored, so a non-aten op in the graph has to
+        # fall back to restoring every snapshotted generator.
+        lib = self._library("precompile_untagged")
+        lib.define("draw(Tensor x) -> Tensor")
+        lib.impl("draw", lambda x: x + torch.rand_like(x), "CompositeExplicitAutograd")
+        path = self._tmp_path("untagged.py")
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return torch.ops.precompile_untagged.draw(inp)
+
+            return run
+
+        x = torch.zeros(4, device=device)
+        torch.manual_seed(1234)
+        first = build()(x).clone()
+        torch.manual_seed(1234)
+        self.assertEqual(build()(x), first)
+
+    def test_fake_traced_capture_consumes_no_rng(self, device):
+        # Why the restore is skipped for a fake-traced capture: mark_unbacked traces on
+        # FakeTensors, so no kernel runs and nothing is consumed, even though the graph
+        # contains a drawing op. Restoring on the strength of the graph alone would
+        # rewind whatever a concurrent thread drew, for a capture that took nothing.
+        # (Only the premise is asserted here: the skip itself is unobservable through
+        # the public API, because the artifact's own real run redraws immediately.)
+        from torch._precompile import _capture, _graph_rng_devices
+
+        x = make_tensor((64,), device=device, dtype=torch.float32)
+        mark_unbacked(x, 0)
+        torch.manual_seed(1234)
+        before = torch.random.get_rng_state().clone()
+        capture = _capture(
+            lambda i: torch.nn.functional.dropout(i, 0.5, True), (x,), None
+        )
+        self.assertIsNotNone(capture.fake_mode)
+        self.assertEqual(torch.random.get_rng_state(), before)
+        # Anti-vacuity: the graph really does contain a draw the device scan attributes,
+        # so skipping the restore is a decision and not an empty set falling through.
+        self.assertTrue(_graph_rng_devices(capture.gm))
+
+    def test_inputs_sliced_from_one_buffer_are_not_aliased(self, device):
+        # Overlap must mean sharing actual bytes. torch._C._overlaps answers a different
+        # question -- storage IDENTITY -- and using it here rejected the arena /
+        # fused-QKV / KV-cache shape, where every input is a disjoint slice of one
+        # buffer. That is the main way real callers hand tensors to a kernel.
+        from torch.compiler._export_python import _shares_memory
+
+        base = make_tensor((8,), device=device, dtype=torch.float32)
+        self.assertFalse(_shares_memory(base[:4], base[4:]))
+        self.assertTrue(_shares_memory(base[:5], base[3:]))
+        self.assertTrue(_shares_memory(base, base))
+        self.assertFalse(_shares_memory(base[:0], base))
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("arena_inputs.py"),
+            backend="eager",
+            example_inputs=(
+                make_tensor((4,), device=device, dtype=torch.float32),
+                make_tensor((4,), device=device, dtype=torch.float32),
+            ),
+        )
+        def add(a, b):
+            return a + b
+
+        buf = make_tensor((8,), device=device, dtype=torch.float32)
+        self.assertEqual(add(buf[:4], buf[4:]), buf[:4] + buf[4:])
+
+    def test_capture_copy_that_loses_parameter_aliasing_is_refused(self, device):
+        # nn.Parameter.__deepcopy__ is self.data.clone(), which does not join the
+        # storage memo, so two Parameters over one storage come back independent.
+        # Capturing from that copy bakes in aliasing the caller does not have.
+        class Tied(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                base = torch.zeros(8, device=device)
+                self.a = torch.nn.Parameter(base[:4])
+                self.b = torch.nn.Parameter(base[4:])
+                self.a.data, self.b.data = base[:4], base[:4]
+
+        def fn(mod, inp):
+            mod.a.data.add_(inp)
+            return mod.b.data + 0
+
+        one = torch.ones(4, device=device)
+        path = self._tmp_path("tied_param.py")
+        with self.assertRaisesRegex(PrecompileError, "example_inputs="):
+            torch.compiler.export_python(path=path)(fn)(Tied(), one)
+        # Refused before publishing: a later call must not load a poisoned artifact.
+        self.assertFalse(os.path.exists(path))
+
+        # The escape hatch the message names has to actually work, and agree with eager.
+        wrapped = torch.compiler.export_python(
+            path=self._tmp_path("tied_param_ex.py"), example_inputs=(Tied(), one)
+        )(fn)
+        self.assertEqual(wrapped(Tied(), one), fn(Tied(), one))
+        self.assertEqual(wrapped(Tied(), one), fn(Tied(), one))
+
+        # Weight tying through one shared Parameter OBJECT (the usual idiom) survives
+        # the copy, so it must still capture.
+        class ObjectTied(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.emb = torch.nn.Embedding(6, 4, device=device)
+                self.head = torch.nn.Linear(4, 6, bias=False, device=device)
+                self.head.weight = self.emb.weight
+
+            def forward(self, ids):
+                return self.head(self.emb(ids))
+
+        mod = ObjectTied()
+        ids = torch.zeros(2, dtype=torch.long, device=device)
+        run = torch.compiler.export_python(path=self._tmp_path("obj_tied.py"))(
+            lambda m, t: m(t)
+        )
+        self.assertEqual(run(mod, ids), mod(ids))
+
+    def test_overlap_handles_awkward_subclass_shapes(self, device):
+        # __tensor_flatten__ names the attributes to transform, and they are not all
+        # tensors -- DTensor's list carries its DeviceMesh. getattr on one used to
+        # escape as a bare AttributeError, which only RuntimeError was catching.
+        from torch.compiler._export_python import _dense_leaves, _shares_memory
+
+        class HasMetadata(TwoTensor):
+            def __tensor_flatten__(self):
+                attrs, ctx = super().__tensor_flatten__()
+                return [*attrs, "label"], ctx
+
+        base = make_tensor((8,), device=device, dtype=torch.float32)
+        side = make_tensor((8,), device=device, dtype=torch.float32)
+        wrapper = HasMetadata(base[:4], side[:4])  # TwoTensor wants matching offsets
+        wrapper.label = "not a tensor"
+        self.assertTrue(_shares_memory(base, wrapper))
+        self.assertTrue(_shares_memory(side, wrapper))
+        self.assertFalse(_shares_memory(torch.zeros(4, device=device), wrapper))
+
+        # A subclass that flattens to exactly ONE tensor is the arity that made the
+        # plain-tensor test an elementwise Tensor ==, which raises above numel 1.
+        single = AsyncCollectiveTensor(base[:4])
+        self.assertEqual(len(_dense_leaves(single)), 1)
+        self.assertTrue(_shares_memory(base[:4], single))
+        self.assertFalse(_shares_memory(base[4:], single))
+
+    def test_duplicate_input_objects_are_guarded(self, device):
+        # Byte overlap cannot tell "two views that intersect" from "one tensor passed
+        # twice", and AOTAutograd folds the second into a single graph slot. Both report
+        # the same overlapping index pair, so without the duplicate stamp an artifact
+        # captured from views silently computes the wrong thing on a repeated argument.
+        def fn(a, b):
+            a.add_(1.0)
+            return b * 10
+
+        path = self._tmp_path("dup.py")
+        wrapped = torch.compiler.export_python(path=path)(fn)
+
+        def arena():
+            return torch.zeros(8, device=device)
+
+        base = arena()
+        wrapped(base[0:4], base[2:6])  # capture: distinct, overlapping
+
+        # the same object twice: same pair set, different meaning
+        repeated = arena()[0:4]
+        with self.assertRaisesRegex(PrecompileError, "repeat tensor objects"):
+            wrapped(repeated, repeated)
+
+        # and the converse: captured from a repeat, called with distinct views
+        dup_path = self._tmp_path("dup2.py")
+        from_repeat = torch.compiler.export_python(path=dup_path)(fn)
+        first = arena()[0:4]
+        from_repeat(first, first)
+        other = arena()
+        with self.assertRaisesRegex(PrecompileError, "repeat tensor objects"):
+            from_repeat(other[0:4], other[2:6])
+
+        # a call that repeats the way capture did still runs, and matches eager
+        same = arena()[0:4]
+        eager_in = arena()[0:4]
+        self.assertEqual(from_repeat(same, same), fn(eager_in, eager_in))
+
+        # Identity, not address. These two have the SAME data_ptr and the same overlap
+        # pair set, but are distinct objects with different strides, so AOTAutograd does
+        # not fold them; keying the stamp on the address accepts this and returns wrong
+        # numbers with nothing else to catch it.
+        square = self._tmp_path("dup_square.py")
+        squared = torch.compiler.export_python(path=square)(fn)
+        cap = make_tensor((4, 4), device=device, dtype=torch.float32)
+        squared(cap, cap)
+        live = make_tensor((4, 4), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(PrecompileError, "repeat tensor objects"):
+            squared(live, live.t())
+
+    def test_artifact_does_not_bake_the_capture_thread_count(self, device):
+        # Inductor sizes a CPU reduction's per-thread accumulator array at codegen time
+        # when the capturing process's thread count equals os.cpu_count(), while still
+        # emitting a team whose size is decided at run time. Replaying under a larger
+        # OMP team then indexes past the end -- a SIGSEGV on the SAME machine, reachable
+        # by one torch.set_num_threads() call, which no part of the artifact contract
+        # covers. Capture runs in a subprocess because it has to change a process-global
+        # thread count, and the invariant is asserted on the emitted source rather than
+        # by replaying: replaying a regression is a crash, which in-process would abort
+        # the interpreter and hide every later test, and out-of-process needs a second
+        # compile that made this test load-sensitive.
+        if torch.device(device).type != "cpu":
+            self.skipTest("the baked array is CPU reduction codegen")
+        path = self._tmp_path("threads.py")
+        code = textwrap.dedent(
+            f"""
+            import os, torch
+            torch.set_num_threads(os.cpu_count())
+            run = torch.compiler.export_python(path={path!r})(lambda a: a.sum())
+            run(torch.randn(1 << 20))
+            """
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, timeout=600
+        )
+        self.assertEqual(
+            proc.returncode, 0, f"{proc.returncode}\n{proc.stderr[-2000:]}"
+        )
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+        # A team-sized array is written as e.g. tmp_acc0_arr[384]; with dynamic_threads
+        # pinned it sizes itself from omp_get_max_threads() at run time instead.
+        baked = re.findall(r"_arr\[(\d+)\]", source)
+        self.assertEqual(baked, [], f"artifact bakes a fixed per-thread array: {baked}")
+
+    def test_subclass_input_dtype_and_device_are_still_guarded(self, device):
+        # A wrapper subclass's outer SHAPE is not the dense shape the artifact bakes, so
+        # it is deliberately not stamped -- but the driver skipped dtype and device on
+        # the same condition, and those are well defined. A float64 subclass then reached
+        # a graph built for float32 and came back as reinterpreted bytes with no error.
+        def fn(x):
+            return x * 2 + 1
+
+        run = torch.compiler.export_python(path=self._tmp_path("sub_guard.py"))(fn)
+        base = make_tensor((4,), device=device, dtype=torch.float32)
+        run(TwoTensor(base, base.clone()))
+
+        same = make_tensor((4,), device=device, dtype=torch.float32)
+        self.assertEqual(run(TwoTensor(same, same.clone())).a, fn(same))
+
+        wide = make_tensor((4,), device=device, dtype=torch.float64)
+        with self.assertRaisesRegex(PrecompileError, "dtype"):
+            run(TwoTensor(wide, wide.clone()))
+
+        if TEST_CUDA:
+            elsewhere = "cpu" if torch.device(device).type == "cuda" else "cuda"
+            moved = make_tensor((4,), device=elsewhere, dtype=torch.float32)
+            with self.assertRaisesRegex(PrecompileError, "device"):
+                run(TwoTensor(moved, moved.clone()))
+
+    def test_indented_comment_does_not_stop_the_stamp_reader(self, device):
+        # The documented rule is that the reader stops at the first NON-COMMENT line. An
+        # indented comment is still a comment, but it ended the scan -- silently turning
+        # off every stamp below it, which is the degradation mode the design reserves
+        # for a stamp actually being deleted.
+        def fn(a, b):
+            a.add_(1.0)
+            return b * 10
+
+        path = self._tmp_path("indented.py")
+        wrapped = torch.compiler.export_python(path=path)(fn)
+
+        def arena():
+            return torch.zeros(8, device=device)
+
+        base = arena()
+        wrapped(base[0:4], base[2:6])
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines(True)
+        lines.insert(1, "    # a note a human might indent\n")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("".join(lines))
+
+        # the duplicate stamp lives below the inserted line; it must still be read
+        repeated = arena()[0:4]
+        with self.assertRaisesRegex(PrecompileError, "repeat tensor objects"):
+            torch.compiler.export_python(path=path)(fn)(repeated, repeated)
+
+    def test_pathological_version_stamp_warns_rather_than_raising(self, device):
+        # torch.__version__ is a TorchVersion, whose __eq__ PEP-440-parses the operand
+        # and re-raises anything that is not InvalidVersion, so a stamp of enough digits
+        # took the whole load path down with a ValueError -- permanently, on every call.
+        # A mangled stamp is a hand-edit like any other and must degrade to a warning.
+        path = self._tmp_path("bigversion.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        def fn(inp):
+            return inp + 1
+
+        torch.compiler.export_python(path=path)(fn)(x)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines(True)
+        lines[0] = f"# torch.compiler.export_python torch-version: '{'9' * 4400}'\n"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("".join(lines))
+
+        self.assertEqual(torch.compiler.export_python(path=path)(fn)(x), fn(x))
+
+    def test_capture_specializes_is_grad_enabled_to_true(self, device):
+        # Capture traces with grad enabled so a backward inside fn is built as graph ops,
+        # which specializes a fn that READS torch.is_grad_enabled() to the grad-on branch.
+        # That is deliberate and documented. Tracing under the caller's ambient mode was
+        # tried instead and is worse: the baked branch then depends on ambient state no
+        # stamp records, so a no_grad capture returns the wrong branch in every later
+        # process -- and stamping grad mode is not an option either, because capturing at
+        # the default and calling under no_grad is the ordinary inference pattern.
+        seen = []
+
+        def fn(inp):
+            seen.append(torch.is_grad_enabled())
+            return inp * 2
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        with torch.no_grad():
+            torch.compiler.export_python(
+                path=self._tmp_path("gradmode.py"), backend="eager"
+            )(fn)(x)
+        self.assertEqual(seen, [True])
+
+        # And the pattern that must keep working: capture at the default, then call for
+        # inference under no_grad.
+        def plain(inp):
+            return inp.sin() + 1
+
+        run = torch.compiler.export_python(path=self._tmp_path("infer.py"))(plain)
+        run(x)
+        with torch.no_grad():
+            self.assertEqual(run(x), plain(x))
+
+    def test_global_state_stamp_survives_the_per_backend_fp32_api(self, device):
+        # torch.get_float32_matmul_precision() RAISES in a process that has used the
+        # per-backend fp32_precision API. Reading it while building the stamp killed
+        # capture outright there -- after a full compile -- and killed every call on an
+        # artifact that already existed.
+        previous = torch.backends.cuda.matmul.fp32_precision
+        try:
+            torch.backends.cuda.matmul.fp32_precision = "tf32"
+            with self.assertRaises(RuntimeError):
+                torch.get_float32_matmul_precision()  # the read that used to be in there
+
+            def fn(inp):
+                return inp + torch.ones(4, device=device)
+
+            x = make_tensor((4,), device=device, dtype=torch.float32)
+            run = torch.compiler.export_python(path=self._tmp_path("fp32api.py"))(fn)
+            self.assertEqual(run(x), fn(x))
+            self.assertEqual(run(x), fn(x))
+        finally:
+            torch.backends.cuda.matmul.fp32_precision = previous
+
+    def test_malformed_global_state_stamp_degrades_to_a_warning(self, device):
+        # Every other stamp treats a mangled value as a hand-edit and turns its own check
+        # off. This one unpacks the literal into key/value pairs, so a literal that is not
+        # a list of pairs escaped as a raw TypeError out of the load path.
+        path = self._tmp_path("mangled_state.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        def fn(inp):
+            return inp + 1
+
+        torch.compiler.export_python(path=path)(fn)(x)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines(True)
+        for i, line in enumerate(lines):
+            if "global-state:" in line:
+                lines[i] = "# torch.compiler.export_python global-state: 42\n"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("".join(lines))
+        self.assertEqual(torch.compiler.export_python(path=path)(fn)(x), fn(x))
+
+    def test_ambient_global_state_is_stamped_and_checked(self, device):
+        # The generated code resolves these once, at capture, and bakes the answer: a
+        # factory op with no dtype= takes the default dtype then, and inductor picks a
+        # deterministic or an atomic lowering from the determinism flag. Changing one and
+        # replaying must not silently get capture's answer. The artifact
+        # never re-reads either, so without a stamp a process that changes one silently
+        # gets capture's answer.
+        def fn(inp):
+            return inp + torch.ones(4, device=device)
+
+        path = self._tmp_path("globals.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        torch.compiler.export_python(path=path)(fn)(x)
+
+        with self.assertRaisesRegex(PrecompileError, "default_dtype"):
+            with _default_dtype(torch.float64):
+                torch.compiler.export_python(path=path)(fn)(x)
+
+        # Determinism is one-way: capture OFF and call ON means the artifact keeps a
+        # lowering the caller asked not to run, so that raises...
+        with self.assertRaisesRegex(PrecompileError, "deterministic"):
+            with _deterministic(True):
+                torch.compiler.export_python(path=path)(fn)(x)
+
+        # ...while capture ON and call OFF is conservative and must be allowed.
+        strict_path = self._tmp_path("globals_strict.py")
+        with _deterministic(True):
+            torch.compiler.export_python(path=strict_path)(fn)(x)
+        self.assertEqual(torch.compiler.export_python(path=strict_path)(fn)(x), fn(x))
+
+    @unittest.skipUnless(TEST_CUDA, "needs a device the inputs do not live on")
+    def test_autocast_stamp_covers_devices_only_the_graph_touches(self, device):
+        # Keying the stamp on the INPUT devices alone recorded [] for a graph whose
+        # inputs are on one device and whose matmuls run on another, so the check passed
+        # in both processes while the kernels had been built for autocast dtypes.
+        if torch.device(device).type != "cpu":
+            self.skipTest("the point is inputs on cpu and compute on the accelerator")
+
+        def fn(inp):
+            return (inp.cuda() @ inp.cuda().t()).cpu()
+
+        path = self._tmp_path("autocast_graph.py")
+        x = make_tensor((8, 8), device="cpu", dtype=torch.float32)
+        run = torch.compiler.export_python(path=path)(fn)
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            run(x)
+            run(x)
+        with open(path, encoding="utf-8") as f:
+            stamp = next(l for l in f if "autocast:" in l)
+        self.assertIn("cuda", stamp)
+        with self.assertRaisesRegex(PrecompileError, "autocast"):
+            run(x)  # outside the region the kernels were built for
+
+        # The case the input-only filter existed to protect still works: a pure-CPU
+        # helper first called inside a CUDA autocast region is not locked to it.
+        def cpu_only(inp):
+            return inp.sin() + 1
+
+        helper = torch.compiler.export_python(path=self._tmp_path("cpu_only.py"))(
+            cpu_only
+        )
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            helper(x)
+        self.assertEqual(helper(x), cpu_only(x))
+
+    def test_check_env_var_catches_a_hand_edit_that_changes_numerics(self, device):
+        # The artifact is deliberately frozen: your kernel edits survive because nothing
+        # re-captures behind your back. The cost is that nothing notices when an edit is
+        # wrong either, so COMPILER_EXPORT_PYTHON_CHECK re-runs fn eagerly on a copy of
+        # the same inputs every call and compares.
+        path = self._tmp_path("checked.py")
+        x = make_tensor((64,), device=device, dtype=torch.float32)
+
+        def fn(inp):
+            return inp * 3.5 + 1.0
+
+        torch.compiler.export_python(path=path)(fn)(x)
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+        self.assertIn("3.5", source)  # a constant distinctive enough to edit by hand
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(source.replace("3.5", "9.25"))  # every copy, so the edit lands
+
+        # off by default: the edit is silently honoured, which is the whole point
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("COMPILER_EXPORT_PYTHON_CHECK", None)
+            torch.compiler.export_python(path=path)(fn)(x)
+
+        with mock.patch.dict(os.environ, {"COMPILER_EXPORT_PYTHON_CHECK": "1"}):
+            with self.assertRaisesRegex(PrecompileError, "does not match"):
+                torch.compiler.export_python(path=path)(fn)(x)
+
+    def test_check_env_var_passes_an_honest_artifact(self, device):
+        # And it must not cry wolf: an unedited artifact, and a fn that mutates its input
+        # in place (the reference run gets a copy), and a fn that draws (the generators
+        # are rewound so both runs see the same stream).
+        x = make_tensor((32,), device=device, dtype=torch.float32)
+
+        def pure(inp):
+            return (inp * 2 + 1).relu()
+
+        def mutating(inp):
+            inp.add_(1.0)
+            return inp * 3
+
+        def drawing(inp):
+            return inp + torch.rand_like(inp)
+
+        with mock.patch.dict(os.environ, {"COMPILER_EXPORT_PYTHON_CHECK": "1"}):
+            for name, fn in (
+                ("pure", pure),
+                ("mutating", mutating),
+                ("drawing", drawing),
+            ):
+                run = torch.compiler.export_python(path=self._tmp_path(f"{name}.py"))(
+                    fn
+                )
+                run(x.clone())
+                run(x.clone())
+
+    def test_artifact_defines_each_kernel_once(self, device):
+        # A kernel emitted twice under one name means the first copy is dead: a reader
+        # tunes the block size they find first and nothing happens. For a file whose
+        # purpose is being edited, a silent no-op is the worst possible response.
+        import re as _re
+
+        path = self._tmp_path("dedupe.py")
+
+        def fn(a, b):
+            return (a * 2 + b).relu()
+
+        x = make_tensor((4096,), device=device, dtype=torch.float32)
+        y = make_tensor((4096,), device=device, dtype=torch.float32)
+        torch.compiler.export_python(path=path)(fn)(x, y)
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+        for name in set(
+            _re.findall(r"^(\w+) = async_compile\.", source, _re.MULTILINE)
+        ):
+            self.assertEqual(
+                len(_re.findall(rf"^{name} = async_compile\.", source, _re.MULTILINE)),
+                1,
+                f"{name} is assigned more than once; the earlier copies are dead code",
+            )
+
+    def test_artifact_header_invites_editing_and_loads_as_documented(self, device):
+        # The file's whole purpose is being hand-tuned, so a "do not edit" banner is
+        # actively wrong -- and the header's own load snippet has to work on an artifact
+        # whose kernel has been hoisted to module level, which a bare
+        # exec(open(...).read()) does not: @triton.jit resolves its source by filename.
+        path = self._tmp_path("header.py")
+
+        def fn(inp):
+            return inp.sin() + 1
+
+        x = make_tensor((8,), device=device, dtype=torch.float32)
+        torch.compiler.export_python(path=path)(fn)(x)
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+        self.assertNotIn("do not edit", source)
+        self.assertIn("Editing it is supported", source)
+        # the documented snippet, executed verbatim
+        self.assertIn('exec(compile(open(path).read(), path, "exec"), ns)', source)
+        namespace = {"__file__": path}
+        exec(compile(source, path, "exec"), namespace)
+        self.assertEqual(namespace["forward"](x), fn(x))
+
+    @unittest.skipUnless(TEST_CUDA, "needs a Triton kernel to break")
+    def test_broken_kernel_names_the_artifact_and_its_line(self, device):
+        # A kernel is compiled out of a cache file, so a syntax error in one is reported
+        # against /tmp/torchinductor_*/xx/yyy.py at a line number nobody can act on. The
+        # reader edited the artifact and needs to be pointed back at it.
+        if torch.device(device).type != "cuda":
+            self.skipTest("Triton kernels are the CUDA codegen path")
+        path = self._tmp_path("broken_kernel.py")
+
+        def fn(a, b):
+            return (a * 2 + b).relu()
+
+        x = make_tensor((4096,), device=device, dtype=torch.float32)
+        y = make_tensor((4096,), device=device, dtype=torch.float32)
+        torch.compiler.export_python(path=path)(fn)(x, y)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines(True)
+        target = next(
+            i for i, line in enumerate(lines) if line.strip().startswith("tl.store(")
+        )
+        lines.insert(target, "    broken = tl.load(\n")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("".join(lines))
+
+        with self.assertRaises(PrecompileError) as caught:
+            torch.compiler.export_python(path=path)(fn)(x, y)
+        message = str(caught.exception)
+        self.assertIn(path, message)
+        # Kernels are hoisted to module level, so this is an ordinary Python SyntaxError
+        # against the artifact and the line is exact -- no cache file, no line mapping.
+        self.assertIn("does not parse at line", message)
+        reported = re.search(r"does not parse at line (\d+)", message)
+        self.assertIsNotNone(reported, message)
+        self.assertEqual(int(reported.group(1)), target + 1, message)
+
+    @unittest.skipUnless(TEST_CUDA, "Triton kernels are the hoisted backend")
+    def test_artifact_carries_no_build_time_machinery(self, device):
+        # AsyncCompile farms kernel compilation out to a worker pool at build time; a
+        # file that is exec'd once has no use for it, and it forces every kernel to live
+        # inside a string where it cannot be edited cleanly or reported against.
+        if torch.device(device).type != "cuda":
+            self.skipTest("the CPU backend is not hoisted; see the bail in _lighten")
+        path = self._tmp_path("light.py")
+
+        def fn(a, b):
+            return (a * 2 + b).relu().sum(dim=-1)
+
+        x = make_tensor((256, 512), device=device, dtype=torch.float32)
+        y = make_tensor((256, 512), device=device, dtype=torch.float32)
+        expected = torch.compiler.export_python(path=path)(fn)(x, y)
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+        for machinery in (
+            "async_compile = AsyncCompile()",
+            "= async_compile.triton(",
+            "async_compile.wait(",
+            "import AsyncCompile",
+        ):
+            self.assertNotIn(machinery, source)
+        # the kernel is real module-level code, not a quoted string
+        self.assertRegex(source, r"(?m)^def triton_\w+\(")
+        self.assertNotIn("= async_compile.triton(", source)
+        # and it still runs, from a fresh load
+        self.assertEqual(torch.compiler.export_python(path=path)(fn)(x, y), expected)
+
+    def test_lighten_leaves_a_non_hoistable_backend_alone(self, device):
+        # Only Triton kernels are hoisted. A cpp_pybinding kernel still needs the
+        # AsyncCompile object, so the pass must publish the original rather than strand
+        # a live reference -- names alone cannot catch that, since such a call still
+        # binds its kernel name while its value becomes unresolvable.
+        from torch.compiler._export_python import _lighten
+
+        code = (
+            "async_compile = AsyncCompile()\n"
+            "cpp_fused_0 = async_compile.cpp_pybinding(['float*'], 'source')\n"
+            "async_compile.wait(globals())\n"
+            "del async_compile\n"
+        )
+        self.assertEqual(_lighten(code), code)
+
+    def test_meta_module_tensor_does_not_crash_the_autocast_stamp(self, device):
+        # autocast does not model every device an input can live on, and a module can
+        # carry a meta tensor it never reads (deferred init). Asking it about one raised
+        # a bare C++ RuntimeError from inside stamp emission, so nothing was ever
+        # published and every call re-paid the whole capture.
+        class DeferredInit(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4, device=device)
+                self.register_buffer("proto", torch.empty(4, device="meta"))
+                self.spare = torch.nn.Parameter(torch.empty(4, device="meta"))
+
+            def forward(self, inp):
+                return self.linear(inp)
+
+        mod = DeferredInit()
+        x = make_tensor((2, 4), device=device, dtype=torch.float32)
+        path = self._tmp_path("deferred.py")
+        run = torch.compiler.export_python(path=path)(lambda m, t: m(t))
+        self.assertEqual(run(mod, x), mod(x))
+        self.assertTrue(os.path.exists(path))  # published, so no capture is re-paid
+        self.assertEqual(run(mod, x), mod(x))  # and the loaded artifact runs too
+
+    def test_overlap_is_bytes_not_storage_identity(self, device):
+        # Two tensors can reach the same bytes through DIFFERENT UntypedStorages --
+        # from_numpy on overlapping slices, frombuffer, DLPack, __cuda_array_interface__
+        # onto a live arena. A storage-identity gate calls those disjoint, so the
+        # aliasing guard would go blind on exactly the arena / KV-cache shapes it is for.
+        import numpy as np
+
+        from torch.compiler._export_python import _shares_memory
+
+        arr = np.zeros(1024, dtype=np.float32)
+        lo, hi = torch.from_numpy(arr[0:512]), torch.from_numpy(arr[256:768])
+        self.assertNotEqual(
+            lo.untyped_storage().data_ptr(), hi.untyped_storage().data_ptr()
+        )
+        self.assertTrue(_shares_memory(lo, hi))
+
+        # Exactly ONE element of overlap: a two-element case survives dropping the +1
+        # from the span, so only this pins the boundary.
+        base = make_tensor((8,), device=device, dtype=torch.float32)
+        self.assertTrue(_shares_memory(base[:4], base[3:]))
+        self.assertFalse(_shares_memory(base[:4], base[4:]))
+        # A strided tensor's extent is not its numel; using numel under-reports it.
+        self.assertTrue(_shares_memory(base.as_strided((4,), (2,)), base[5:]))
+
+        # A wrapper subclass reports data_ptr() == 0 with a real device, so comparing
+        # its span directly would call every pair disjoint.
+        from torch.testing._internal.two_tensor import TwoTensor
+
+        payload = torch.from_numpy(np.zeros(8, dtype=np.float32))
+        self.assertTrue(
+            _shares_memory(
+                payload,
+                TwoTensor(payload, payload.clone()),
+            )
+        )
+        self.assertFalse(
+            _shares_memory(
+                TwoTensor(torch.zeros(4), torch.zeros(4)),
+                TwoTensor(torch.zeros(4), torch.zeros(4)),
+            )
+        )
+
+        # A 0-numel tensor whose bounding span is NOT empty: the numel guard is what
+        # rejects this, not the span arithmetic.
+        empty_wide = torch.empty(8, device=device).as_strided((3, 0), (1, 1))
+        self.assertFalse(_shares_memory(empty_wide, empty_wide))
+        self.assertFalse(
+            _shares_memory(torch.empty(4, device="meta"), torch.empty(4, device="meta"))
+        )
+
+    def test_overlap_sees_through_a_wrapper_that_misreports_its_device(self, device):
+        # A subclass can report a device differing from its payload's in INDEX
+        # (map_location="cuda" over a "cuda:0" payload) or in TYPE
+        # (map_location={"cuda:0": "cpu"}). Deciding on the wrapper rather than the leaf
+        # reported such a tensor as sharing memory with nothing -- including its own
+        # payload -- so the aliasing guard would go blind on it.
+        from torch.compiler._export_python import _shares_memory
+
+        base = make_tensor((8,), device=device, dtype=torch.float32)
+        # No hardware needed for any of these: _make_wrapper_subclass takes a device
+        # LABEL, so they run identically on a CPU-only runner. Gating them on TEST_CUDA
+        # meant the type axis pinned nothing there, and the index axis alone cannot tell
+        # a leaf-keyed predicate from a wrapper-device-type-keyed one.
+        lies = [
+            _lying_device(device),  # index axis
+            _type_lying_device(device),  # type axis
+            torch.device("meta"),  # is_meta is a device report too
+        ]
+        for reported in lies:
+            wrapper = _MisreportedDevice(base[:4], reported)
+            self.assertNotEqual(wrapper.device, wrapper.payload.device)
+            self.assertTrue(_shares_memory(base[:4], wrapper), reported)
+            self.assertTrue(_shares_memory(base[2:6], wrapper), reported)
+            self.assertFalse(_shares_memory(base[4:], wrapper), reported)
+            self.assertFalse(
+                _shares_memory(
+                    make_tensor((4,), device=device, dtype=torch.float32), wrapper
+                ),
+                reported,
+            )
+
+        # One empty component must not make the whole wrapper unlocatable. It used to,
+        # because every empty tensor reports data_ptr 0, which makes the predicate claim
+        # an overlap that does not exist for every caller of it.
+        from torch.compiler._export_python import _dense_leaves
+
+        side = make_tensor((8,), device=device, dtype=torch.float32)
+        unrelated = make_tensor((4,), device=device, dtype=torch.float32)
+        for spare in (
+            torch.empty(2, device=device),
+            torch.empty(0, device=device),  # owns no bytes
+            torch.empty(4, device="meta"),  # a leaf that genuinely IS meta
+        ):
+            partly_empty = TwoTensor(base[:4], side[:4])  # matching storage offsets
+            partly_empty.b = spare
+            self.assertIsNotNone(_dense_leaves(partly_empty), spare.device)
+            self.assertTrue(_shares_memory(base[:4], partly_empty), spare.device)
+            self.assertFalse(_shares_memory(unrelated, partly_empty), spare.device)
+
+        # Every component byte-less is a real answer -- "owns nothing" -- not "bytes we
+        # cannot find". Collapsing it back to unresolvable made such a wrapper alias
+        # every tensor of its device type.
+        all_empty = TwoTensor(
+            torch.empty(0, device=device), torch.empty(0, device=device)
+        )
+        self.assertEqual(_dense_leaves(all_empty), [])
+        self.assertFalse(_shares_memory(unrelated, all_empty))
+        # But a wrapper with no tensor components at all stays conservative: there is
+        # nothing to have looked at, so it must not read as disjoint from everything.
+        no_tensors = TwoTensor(base[:4], side[:4])
+        no_tensors.__tensor_flatten__ = lambda: ([], None)  # type: ignore[method-assign]
+        self.assertIsNone(_dense_leaves(no_tensors))
+        self.assertTrue(_shares_memory(unrelated, no_tensors))
+
+        # A tensor whose bytes cannot be located at all is assumed to alias -- but only
+        # within its own device type, which is the only evidence left once there are no
+        # leaves to inspect. The sweep routes these to the same predicate, so its
+        # cross-check cannot pin this; it needs asserting directly.
+        opaque = make_tensor((4, 4), device=device, dtype=torch.float32).to_sparse()
+        self.assertTrue(_shares_memory(opaque, base[:4]))
+        if TEST_CUDA:
+            elsewhere = "cpu" if torch.device(device).type == "cuda" else "cuda"
+            self.assertFalse(_shares_memory(opaque, torch.randn(4, device=elsewhere)))
+
+    def test_overlap_sweep_matches_the_pairwise_predicate(self, device):
+        # _input_overlaps sweeps sorted byte spans instead of running _shares_memory
+        # over every pair; the two must agree exactly, including the shapes that leave
+        # the sweep and fall back to the pairwise path.
+        from torch.compiler._export_python import _input_overlaps, _shares_memory
+
+        arena = make_tensor((32,), device=device, dtype=torch.float32)
+        other = make_tensor((32,), device=device, dtype=torch.float32)
+        cases = [
+            [arena[0:20], arena[10:30], arena[20:32], arena[24:32]],  # a chain
+            [arena[i:] for i in range(5)],  # a clique
+            [arena[:8], other[:8], arena[8:16], other[8:16]],  # two disjoint groups
+            [arena[:4], torch.empty(0, device=device), arena[2:6]],
+            [arena[:4], torch.randn(4, device="meta"), arena[2:6]],
+            [arena[:4], arena.to_sparse(), other[:4]],  # unresolvable: pairwise path
+            [TwoTensor(arena[:4], other[:4]), arena[2:6], other[6:10]],
+            # One wrapper whose two leaves overlap EACH OTHER: the only shape that
+            # can produce a bogus self-pair out of the sweep.
+            [TwoTensor(arena[:4], arena[:4]), other[:4]],
+            # Wrappers misreporting their device. The INDEX lie alone does not pin the
+            # sweep's keying -- the key it replaced was (wrapper device TYPE, leaf
+            # device), which already handled that axis -- so the TYPE lie has to be here
+            # too, or reverting the key passes while the sweep and the predicate
+            # demonstrably disagree.
+            [
+                _MisreportedDevice(arena[:4], _lying_device(device)),
+                arena[2:6],
+                other[:4],
+            ],
+            [arena[:4], _MisreportedDevice(arena[2:6], _lying_device(device))],
+            [
+                _MisreportedDevice(arena[:4], _type_lying_device(device)),
+                arena[2:6],
+                other[:4],
+            ],
+            [arena[:4], _MisreportedDevice(arena[2:6], torch.device("meta"))],
+            [arena.as_strided((4,), (7,)), arena[20:24], arena[28:32]],
+            [],
+            [arena],
+        ]
+        for tensors in cases:
+            pairwise = [
+                [i, j]
+                for i in range(len(tensors))
+                for j in range(i + 1, len(tensors))
+                if _shares_memory(tensors[i], tensors[j])
+            ]
+            self.assertEqual(_input_overlaps(None, tensors), pairwise)
+
+    def test_version_stamp_written_before_the_repr_change_still_warns(self, device):
+        # Artifacts already committed carry a bare, unquoted version. literal_eval
+        # rejects those, and treating that as "hand-edited, stay silent" would disable
+        # the skew warning for exactly the artifacts it exists to protect.
+        path = self._tmp_path("old_stamp.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return inp + 1
+
+            return run
+
+        build()(x)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines(True)
+        tag = "# torch.compiler.export_python torch-version: "
+        self.assertTrue(lines[0].startswith(tag))
+        lines[0] = tag + "0.0.0-bogus\n"  # pre-repr encoding, unquoted
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+        with self.assertLogs("torch.compiler._export_python", "WARNING") as logs:
+            build()(x)
+        self.assertTrue(any("0.0.0-bogus" in m for m in logs.output), logs.output)
+
+    def test_input_aliasing_a_module_buffer_is_guarded(self, device):
+        # A tensor argument that aliases a module buffer must enter the overlap stamp.
+        # AOTAutograd dedups the two into one graph slot, so an artifact captured with
+        # that alias computes -- and on the eager backend mutates -- the wrong thing
+        # when the runtime call passes independent tensors.
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("b", torch.zeros(4, device=device))
+
+        def fn(m, x):
+            m.b.add_(1.0)
+            return m.b + x * 2
+
+        captured = M()
+        aliased = torch.compiler.export_python(
+            path=self._tmp_path("module_alias.py"),
+            backend="eager",
+            example_inputs=(captured, captured.b),
+        )(fn)
+        aliased(captured, captured.b)
+
+        fresh = M()
+        independent = torch.zeros(4, device=device)
+        with self.assertRaisesRegex(PrecompileError, "do not share memory"):
+            aliased(fresh, independent)
+        # ...and the rejected call left the caller's tensor alone.
+        self.assertEqual(independent, torch.zeros(4, device=device))
+
+    def test_dropping_the_aliasing_or_autocast_stamp_warns(self, device):
+        # The docstring promises a warning for each dropped stamp; the module-training
+        # one warned and these two used to fall through in silence.
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        for tag, name in (("input-overlap:", "alias"), ("autocast:", "autocast")):
+            path = self._tmp_path(f"drop_{name}.py")
+
+            def build():
+                @torch.compiler.export_python(path=path, backend="eager")
+                def run(a, b):
+                    return a + b
+
+                return run
+
+            build()(x, x)
+            with open(path, encoding="utf-8") as f:
+                lines = f.readlines()
+            kept = [line for line in lines if tag not in line]
+            self.assertEqual(len(kept), len(lines) - 1, f"{tag} stamp not found")
+            with open(path, "w", encoding="utf-8") as f:
+                f.writelines(kept)
+            with self.assertLogs("torch.compiler._export_python", "WARNING") as logs:
+                build()(x, x)
+            self.assertTrue(
+                any("carries no recorded" in m for m in logs.output), logs.output
+            )
+
+    def test_input_aliasing_is_guarded(self, device):
+        # Aliasing decides what an in-place mutation means and is baked into the graph
+        # with no runtime guard, so an artifact captured on aliased inputs computes --
+        # and mutates -- the wrong thing when they are distinct. torch.compile guards
+        # this and recompiles; the artifact cannot, so it must refuse.
+        def fn(a, b):
+            a.add_(b)
+            return a * 2
+
+        seed = torch.arange(4.0, device=device)
+        aliased = torch.compiler.export_python(
+            path=self._tmp_path("alias_capture.py"),
+            backend="eager",
+            example_inputs=(seed, seed),
+        )(fn)
+        a = torch.arange(4.0, device=device)
+        with self.assertRaisesRegex(PrecompileError, "do not share memory"):
+            aliased(a, torch.ones(4, device=device))
+        self.assertEqual(a, torch.arange(4.0, device=device))  # left untouched
+
+        # The mirror case: captured distinct, called aliased.
+        distinct = torch.compiler.export_python(
+            path=self._tmp_path("alias_distinct.py"), backend="eager"
+        )(fn)
+        b = torch.arange(4.0, device=device)
+        distinct(b, torch.ones(4, device=device))
+        c = torch.arange(4.0, device=device)
+        with self.assertRaisesRegex(PrecompileError, "do not share memory"):
+            distinct(c, c)
+
+    def test_autocast_state_is_guarded(self, device):
+        # Ambient autocast picks the dtypes the kernels were specialized for, and is
+        # invisible to make_fx's guards, so calling under a different autocast context
+        # silently returns the capture-time dtype.
+        @torch.compiler.export_python(
+            path=self._tmp_path("autocast.py"), backend="eager"
+        )
+        def run(a, b):
+            return a @ b
+
+        device_type = torch.device(device).type
+        x = make_tensor((8, 8), device=device, dtype=torch.float32)
+        self.assertEqual(run(x, x).dtype, torch.float32)
+        with self.assertRaisesRegex(PrecompileError, "autocast state does not match"):
+            with torch.autocast(device_type, torch.bfloat16):
+                run(x, x)
+
+
+instantiate_device_type_tests(TestExportPython, globals())
 
 
 if __name__ == "__main__":

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -204,9 +204,12 @@ it.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import io
 import logging
+import os
+import threading
 from types import MappingProxyType
 from typing import Any, cast, NewType, TYPE_CHECKING
 
@@ -219,6 +222,253 @@ from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 
 log = logging.getLogger(__name__)
+_CAPTURE_LOCK = threading.RLock()
+
+
+def _reinit_capture_lock_after_fork() -> None:
+    # A child that inherits this lock held by a thread the fork did not carry over
+    # would block on it forever; only the forking thread survives, so nothing that
+    # held it can still be running.
+    global _CAPTURE_LOCK
+    _CAPTURE_LOCK = threading.RLock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reinit_capture_lock_after_fork)
+
+
+def _capture_rng_devices(args: tuple[object, ...]) -> list[torch.device]:
+    devices: set[torch.device] = set()
+    for arg in args:
+        if isinstance(arg, torch.nn.Module):
+            tensors = [*arg.parameters(), *arg.buffers()]
+        else:
+            tensors = [
+                leaf
+                for leaf in pytree.tree_leaves(arg)
+                if isinstance(leaf, torch.Tensor)
+            ]
+        for tensor in tensors:
+            if tensor.device.type in ("cuda", "xpu"):
+                devices.add(tensor.device)
+    for device_type in ("cuda", "xpu"):
+        device_module = getattr(torch, device_type, None)
+        if device_module is not None and device_module.is_initialized():
+            devices.add(torch.device(device_type, device_module.current_device()))
+    return sorted(
+        devices,
+        key=lambda device: (device.type, -1 if device.index is None else device.index),
+    )
+
+
+# nondeterministic_seeded marks ops that MAY draw. For these a parameter decides, and
+# they sit in the middle of every attention, dropout and RNN call site, so treating
+# them as unconditional draws would put essentially every real model on the
+# rewind-anything-concurrent path. The named argument is falsy iff the op cannot draw.
+# Qualified names: a custom op that merely shares a base name must not inherit a gate.
+# This is every tagged aten op taking a "dropout_p" or "train" argument;
+# test_rng_gate_table_matches_the_op_registry keeps it honest against the registry.
+_RNG_GATED_BY_ARG = {
+    "aten::_cudnn_attention_backward": "dropout_p",
+    "aten::_cudnn_attention_forward": "dropout_p",
+    "aten::_cudnn_init_dropout_state": "train",
+    "aten::_cudnn_rnn": "train",
+    "aten::_efficient_attention_forward": "dropout_p",
+    "aten::_fill_mem_eff_dropout_mask_": "dropout_p",
+    "aten::_flash_attention_forward": "dropout_p",
+    "aten::_flash_attention_forward_no_dropout_inplace": "dropout_p",
+    "aten::_fused_sdp_choice": "dropout_p",
+    "aten::_lstm_mps": "train",
+    "aten::_scaled_dot_product_attention_math": "dropout_p",
+    "aten::_scaled_dot_product_attention_math_for_mps": "dropout_p",
+    "aten::_scaled_dot_product_cudnn_attention": "dropout_p",
+    "aten::_scaled_dot_product_cudnn_attention_backward": "dropout_p",
+    "aten::_scaled_dot_product_efficient_attention": "dropout_p",
+    "aten::_scaled_dot_product_efficient_attention_backward": "dropout_p",
+    "aten::_scaled_dot_product_flash_attention": "dropout_p",
+    "aten::_scaled_dot_product_flash_attention_for_cpu": "dropout_p",
+    "aten::_scaled_dot_product_fused_attention_overrideable": "dropout_p",
+    "aten::_triton_scaled_dot_attention": "dropout_p",
+    "aten::alpha_dropout": "train",
+    "aten::alpha_dropout_": "train",
+    "aten::dropout": "train",
+    "aten::dropout_": "train",
+    "aten::feature_alpha_dropout": "train",
+    "aten::feature_alpha_dropout_": "train",
+    "aten::feature_dropout": "train",
+    "aten::feature_dropout_": "train",
+    "aten::gru": "train",
+    "aten::lstm": "train",
+    "aten::miopen_rnn": "train",
+    "aten::native_dropout": "train",
+    "aten::rnn_relu": "train",
+    "aten::rnn_tanh": "train",
+    "aten::rrelu": "training",
+    "aten::rrelu_": "training",
+    "aten::rrelu_with_noise": "training",
+    "aten::rrelu_with_noise_": "training",
+    "aten::rrelu_with_noise_functional": "training",
+    "aten::scaled_dot_product_attention": "dropout_p",
+}
+
+
+def _op_can_draw(node: torch.fx.Node) -> bool:
+    target = node.target
+    if not isinstance(target, torch._ops.OpOverload):
+        return False
+    if torch.Tag.nondeterministic_seeded not in target.tags:
+        return False
+    # Keyed on the qualified name: a custom op that merely shares a name with an
+    # aten op must not inherit its gate, since its argument may not control drawing.
+    arg_name = _RNG_GATED_BY_ARG.get(target._schema.name)
+    if arg_name is None:
+        return True
+    schema_args = target._schema.arguments
+    index = next((i for i, a in enumerate(schema_args) if a.name == arg_name), None)
+    if index is None:
+        return True
+    if arg_name in node.kwargs:
+        value = node.kwargs[arg_name]
+    elif index < len(node.args):
+        value = node.args[index]
+    else:
+        value = schema_args[index].default_value
+    # Anything not a plain constant (a symbolic or traced value) has to be assumed
+    # live; only a literal zero/False proves this call site cannot draw.
+    return not isinstance(value, (bool, int, float)) or bool(value)
+
+
+def _graph_rng_devices(gm: torch.fx.GraphModule) -> set[torch.device] | None:
+    """Devices whose generators the captured graph can draw from.
+
+    This is how a restore decides what it has of its own to undo. The alternative --
+    diffing global generator state across capture -- cannot tell the capture's own
+    draws from a concurrent thread's, so it rewinds unrelated work. Per device rather
+    than a single flag for the same reason: a graph that draws only on CUDA must not
+    rewind the CPU generator a concurrent thread is drawing from. None means a drawing
+    op whose device could not be read, which the caller treats as "all of them".
+    """
+    devices: set[torch.device] = set()
+    for node in gm.graph.nodes:
+        target = node.target
+        if isinstance(target, torch._ops.OpOverload) and not target.name().startswith(
+            "aten::"
+        ):
+            # An opaque custom op can draw inside its own kernel with nothing in the
+            # graph to say so (the vLLM-style attention/MoE shape this API targets).
+            # Attributing per device would leave those draws un-restored, so once one
+            # is present the only safe answer is "could be any generator".
+            return None
+        if not _op_can_draw(node):
+            continue
+        val = node.meta.get("val")
+        if isinstance(val, (tuple, list)):
+            val = next((v for v in val if isinstance(v, torch.Tensor)), None)
+        if not isinstance(val, torch.Tensor):
+            return None
+        devices.add(val.device)
+    return devices
+
+
+def _rng_devices_indicate_a_draw(drawn: set[torch.device] | None) -> bool:
+    """None means "could be any generator"; a non-empty set names them."""
+    return drawn is None or bool(drawn)
+
+
+class _CaptureRngState:
+    """Generator state saved across capture, restored only if capture consumed it.
+
+    make_fx runs ``fn`` for real, so a traced ``torch.rand`` advances the very
+    generators the first real call is about to draw from; without a restore, capturing
+    would visibly change the numbers a first call produces. The restore is conditional
+    because it writes process-global state: rewinding when the capture drew nothing
+    would silently replay a concurrent thread's draws.
+    """
+
+    def __init__(self, args: tuple[object, ...]) -> None:
+        with self._raw():
+            self._cpu = torch.random.get_rng_state().clone()
+            self._devices = []
+            self._states = []
+            self._unsnapshotted: list[torch.device] = []
+            for device in _capture_rng_devices(args):
+                try:
+                    module = torch.get_device_module(device.type)
+                    state = module.get_rng_state(device).clone()
+                except Exception:
+                    # Reading a generator can fail (a fake tensor naming a device this
+                    # host does not have). Record it so warn_on_unsnapshotted_devices
+                    # can report it, rather than dying with a bare driver error here or
+                    # dropping it silently.
+                    self._unsnapshotted.append(device)
+                    continue
+                self._devices.append((module, device))
+                self._states.append(state)
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _raw():
+        # Reading generator state must not be intercepted by whatever mode stack the
+        # caller is under; a tracing mode would turn these reads into graph nodes, and
+        # a torch-function mode can reject or rewrite the read outright.
+        with (
+            torch.utils._python_dispatch._disable_current_modes(),
+            torch._C._DisableFuncTorch(),
+            torch._C.DisableTorchFunction(),
+        ):
+            yield
+
+    def warn_on_unsnapshotted_devices(self, drawn: set[torch.device] | None) -> None:
+        # A device the graph drew on but that was not snapshotted (not current, not
+        # reachable from the arguments, or only initialized during capture) cannot be
+        # rewound, so the capturing run returns different numbers than every later run.
+        # Nothing can be done after the fact except say so.
+        if drawn is None:
+            # "Could be any generator" -- which is the common case now, since an opaque
+            # custom op forces it. Anything not snapshotted is unrestorable and there is
+            # no device name to report, so say that rather than going quiet.
+            if self._devices or self._unsnapshotted:
+                log.warning(
+                    "precompile: the captured graph contains an op whose draws cannot "
+                    "be attributed to a device, so only the generators saved at capture "
+                    "were restored; any other initialized generator it touched will not "
+                    "reproduce when the artifact is loaded."
+                )
+            return
+        saved = {device for _module, device in self._devices}
+        missed = sorted(
+            {d for d in drawn if d.type != "cpu" and d not in saved}
+            | set(self._unsnapshotted),
+            key=str,
+        )
+        if missed:
+            log.warning(
+                "precompile: the captured graph draws on %s, whose generator state was "
+                "not saved and so could not be restored; this capturing run may return "
+                "different random values than later runs load from the artifact. "
+                "Precompile with an example tensor on that device, or make it current.",
+                ", ".join(str(d) for d in missed),
+            )
+
+    def changed(self) -> bool:
+        with self._raw():
+            if not torch.equal(torch.random.get_rng_state(), self._cpu):
+                return True
+            return any(
+                not torch.equal(module.get_rng_state(device), state)
+                for (module, device), state in zip(self._devices, self._states)
+            )
+
+    def restore(self, drawn: set[torch.device] | None = None) -> None:
+        # Restore only the generators the capture could have drawn from. Writing back
+        # one it did not touch is not a no-op: it rewinds whatever another thread drew
+        # from that generator while capture ran.
+        with self._raw():
+            if drawn is None or any(d.type == "cpu" for d in drawn):
+                torch.random.set_rng_state(self._cpu)
+            for (module, device), state in zip(self._devices, self._states):
+                if drawn is None or device in drawn:
+                    module.set_rng_state(state, device)
 
 
 if TYPE_CHECKING:
@@ -282,7 +532,11 @@ def _dense_shape(t: object) -> tuple[int, ...] | None:
 
     Tensor subclasses (e.g. DTensor) go through AOTAutograd's flatten path, so their
     outer shape is not the dense shape the inductor artifact bakes; record ``None`` and
-    skip them in the shape check.
+    skip them in the SHAPE check only -- dtype and device are still recorded and still
+    checked. Note this leaves a subclass's INNER shapes unguarded: an artifact captured
+    from one sharding silently runs a differently-sharded input against capture's baked
+    local shapes, and an empty inner leaf is worse than a wrong number. Recording the
+    dense-leaf shapes is the real fix and is not done here.
     """
     if isinstance(t, torch.Tensor) and not is_traceable_wrapper_subclass(t):
         return tuple(t.shape)
@@ -290,26 +544,33 @@ def _dense_shape(t: object) -> tuple[int, ...] | None:
 
 
 def _dense_dtype(t: object) -> str | None:
-    """Return the dtype of a plain dense tensor as a string, else ``None``.
+    """Return a tensor's dtype as a string, else ``None`` for a non-tensor.
 
     Recorded as a string (e.g. ``"torch.float32"``) so it serializes into the artifact
-    metadata as a literal and compares cleanly against ``str(t.dtype)`` at runtime;
-    mirrors the _dense_shape convention (None for non-tensor / subclass leaves). The
+    metadata as a literal and compares cleanly against ``str(t.dtype)`` at runtime. The
     graph is specialized to the example dtype (invariant 6).
+
+    Unlike _dense_shape this DOES apply to a wrapper subclass: its outer dtype is the
+    one AOTAutograd specializes on, and skipping it let a float64 subclass reach a graph
+    built for float32 and come back as reinterpreted bytes with no error at all.
     """
-    if isinstance(t, torch.Tensor) and not is_traceable_wrapper_subclass(t):
+    if isinstance(t, torch.Tensor):
         return str(t.dtype)
     return None
 
 
 def _dense_device(t: object) -> str | None:
-    """Return the device (as a string) of a plain dense tensor, else ``None``.
+    """Return a tensor's device as a string, else ``None`` for a non-tensor.
 
     Recorded as a string so it serializes into the artifact metadata as a literal and
-    compares cleanly at runtime; mirrors _dense_shape (None for non-tensor / subclass
-    leaves). The graph is specialized to the example device (invariant 6).
+    compares cleanly at runtime. The graph is specialized to the example device
+    (invariant 6).
+
+    Applies to a wrapper subclass for the same reason as _dense_dtype, and here the
+    stakes are memory safety rather than a wrong number: skipping it handed a CUDA
+    subclass to a graph built for CPU.
     """
-    if isinstance(t, torch.Tensor) and not is_traceable_wrapper_subclass(t):
+    if isinstance(t, torch.Tensor):
         return str(t.device)
     return None
 
@@ -682,7 +943,6 @@ def _capture(
     interning/order established here for params then buffers is the calling
     convention the runtime model must reproduce (invariant 2).
     """
-    import contextlib
 
     args = tuple(args)
     module_positions = [i for i, a in enumerate(args) if isinstance(a, torch.nn.Module)]
@@ -847,10 +1107,17 @@ def _capture(
         captured_grad_param_indices = grad_param_indices
         return [*result_flat, *grad_flat]
 
-    # Trace with grad enabled so any backward in ``fn`` is built as graph ops; the
-    # forward graph is the same as under no_grad. Restore in finally so a make_fx
-    # failure (e.g. fn raising after running a backward) does not leave the user's
-    # example model with clobbered .grad fields.
+    # Trace with grad enabled, so a backward inside ``fn`` is built as graph ops. This
+    # DOES specialize a ``fn`` that reads torch.is_grad_enabled() and branches: it always
+    # captures the grad-enabled branch, which is documented alongside the other Python
+    # specializations. Tracing under the caller's ambient mode instead was tried and is
+    # worse: it makes the baked branch depend on ambient state that no stamp records, so
+    # a no_grad capture silently returns the wrong branch in every later process, and
+    # stamping it is not an option either -- capture-with-grad-on then call-under-no_grad
+    # is the ordinary inference pattern and a strict check would refuse it. A constant
+    # that is documented beats an ambient input that cannot be checked.
+    # Restore .grad in finally so a make_fx failure (e.g. fn raising after running a
+    # backward) does not leave the user's example model with clobbered .grad fields.
     from torch.fx.experimental.symbolic_shapes import GuardOnDataDependentSymNode
 
     tracing_mode = "symbolic" if fake_mode is not None else "real"
@@ -957,15 +1224,21 @@ class _Capture:
 
 
 _GENERATED_HEADER = """\
-# Generated by torch.compiler.precompile -- do not edit.
+# Generated by torch.compiler.precompile. Editing it is supported: this source is
+# what runs, so an edit here takes effect on the next load.
 #
 # This is a SELF-CONTAINED, EXECUTABLE artifact: it runs on its own, needing no
 # companion cache. You provide the model(s) at runtime, exactly as the original fn
 # took them, e.g.:
 #
-#     ns = {}
-#     exec(open("this_file.py").read(), ns)
+#     path = "this_file.py"
+#     ns = {"__file__": path}
+#     exec(compile(open(path).read(), path, "exec"), ns)
 #     out = ns["forward"](model, my_input)      # same args as the traced fn
+#
+# Compile with the real path rather than exec'ing the string: a @triton.jit kernel
+# looks up its own source by filename, so a bare exec(open(...).read()) breaks any
+# artifact whose kernel has been hoisted to module level by hand.
 #
 # The runtime model must be STRUCTURALLY IDENTICAL to the one precompile traced
 # (same parameter/buffer names, order, and weight tying); only the weight VALUES
@@ -1164,15 +1437,21 @@ def _build_python_source(
 
 
 _EAGER_GENERATED_HEADER = """\
-# Generated by torch.compiler.precompile (backend="eager") -- do not edit.
+# Generated by torch.compiler.precompile (backend="eager"). Editing it is supported:
+# this source is what runs, so an edit here takes effect on the next load.
 #
 # Self-contained, executable artifact: the captured ATen graph is inlined below (both
 # the human-readable rendering and the executable code) and runs on its own. Provide
 # the model(s) at runtime, exactly as the original fn took them:
 #
-#     ns = {}
-#     exec(open("this_file.py").read(), ns)
+#     path = "this_file.py"
+#     ns = {"__file__": path}
+#     exec(compile(open(path).read(), path, "exec"), ns)
 #     out = ns["forward"](model, my_input)      # same args as the traced fn
+#
+# Compile with the real path rather than exec'ing the string: a @triton.jit kernel
+# looks up its own source by filename, so a bare exec(open(...).read()) breaks any
+# artifact whose kernel has been hoisted to module level by hand.
 #
 # The runtime model must be structurally identical to the traced one (only weight
 # VALUES may differ), and control flow / shapes are specialized to the example inputs.
@@ -1387,7 +1666,34 @@ class PrecompiledModule:
                 "precompile: mark_unbacked (dynamic shapes) is only supported with "
                 "backend='inductor'; eager + unbacked is not supported."
             )
-        capture = _capture(self._fn, args, self._decompositions)
+        with _CAPTURE_LOCK:
+            rng = _CaptureRngState(args)
+            # No restore on the failure path. There is no graph to attribute draws to,
+            # and capture rejections are routine (an unsupported construct), so
+            # rewinding here would replay a concurrent thread's draws far more often
+            # than it would undo anything of ours.
+            capture = _capture(self._fn, args, self._decompositions)
+            if capture.fake_mode is not None:
+                # A fake-traced capture (mark_unbacked) runs no real kernel, so nothing
+                # was consumed however the graph reads, and restoring could only rewind
+                # what another thread drew. rng.changed() cannot substitute for this --
+                # a concurrent draw makes it true either way.
+                pass
+            elif _rng_devices_indicate_a_draw(drawn := _graph_rng_devices(capture.gm)):
+                rng.restore(drawn)
+                rng.warn_on_unsnapshotted_devices(drawn)
+            elif rng.changed():
+                # The capture consumed generator state that no graph op accounts for --
+                # most likely an opaque custom op that draws without being tagged
+                # nondeterministic_seeded. Nothing here can attribute it, so the
+                # capturing run will not reproduce on load.
+                log.warning(
+                    "precompile: capture consumed generator state that the captured "
+                    "graph does not account for, so it was left as-is and this run may "
+                    "not reproduce when the artifact is loaded. If %s draws inside an "
+                    "opaque custom op, tag that op with torch.Tag.nondeterministic_seeded.",
+                    getattr(self._fn, "__name__", "fn"),
+                )
         self._module_positions = capture.module_positions
         self._num_positional_args = capture.num_positional_args
         self._param_names = capture.param_names
@@ -1443,7 +1749,17 @@ class PrecompiledModule:
         # ShapeEnv through automatically, so there is no dynamic_shapes knob to pass and
         # no manual TracingContext to install: a static capture specializes to the
         # example shapes, an unbacked capture keeps the symbols.
-        options: dict[str, Any] = {"size_asserts": True}
+        # Pin cpp.dynamic_threads ON so the CPU reduction kernels size their per-thread
+        # accumulator arrays from omp_get_max_threads() at runtime. Off (the default when
+        # the capturing process's thread count happens to equal os.cpu_count()) inductor
+        # bakes a fixed-size array while still emitting a bare ``#pragma omp parallel``
+        # whose team size is decided at run time, so replaying the artifact after a
+        # torch.set_num_threads() to anything larger indexes past the end and segfaults --
+        # on the SAME machine, which no part of the artifact contract covers. This is a
+        # pin and not a sixth stamp on purpose: a stamp is droppable by hand-edit and a
+        # dropped stamp degrades to warn-and-continue, which here would silently restore
+        # a memory-safety bug rather than a wrong number.
+        options: dict[str, Any] = {"size_asserts": True, "cpp.dynamic_threads": True}
         if capture.fake_mode is not None and hasattr(_ind_config, "scalar_asserts"):
             options["scalar_asserts"] = True
         try:
@@ -1550,7 +1866,9 @@ class PrecompiledModule:
         return buf.getvalue()
 
 
-def _make_inlined_forward(python_code: str) -> Callable[..., object]:
+def _make_inlined_forward(
+    python_code: str, *, warn: bool = True, filename: str = "<precompile>"
+) -> Callable[..., object]:
     """Fallback: execute the self-contained python string (JITs kernels).
 
     ``python_code`` needs no cache -- the kernels (inductor) or graph (eager) are
@@ -1559,15 +1877,28 @@ def _make_inlined_forward(python_code: str) -> Callable[..., object]:
     inputs)."""
     # python_code is untrusted EXECUTABLE input -- exec'ing it runs whatever it contains
     # (JIT-compiling inlined kernels or running the inlined graph). Warn per load (not
-    # warning_once) before the exec so the inlined fallback is never silent about it.
-    log.warning(
-        "torch.compiler.precompile.load is about to EXEC python_code, which is untrusted "
-        "executable input (it runs inlined kernels / graph code). Only exec python_code "
-        "you produced or otherwise trust (Note [precompile programming model], "
-        "invariant 7)."
-    )
-    module_ns: dict[str, object] = {"__name__": "_precompiled_artifact"}
-    exec(compile(python_code, "<precompile>", "exec"), module_ns)
+    # warning_once) before the exec so the inlined fallback is never silent about it,
+    # but only when warn is True. A caller that has already established its own trust
+    # boundary and warning may pass warn=False.
+    if warn:
+        log.warning(
+            "torch.compiler.precompile.load is about to EXEC python_code, which is untrusted "
+            "executable input (it runs inlined kernels / graph code). Only exec python_code "
+            "you produced or otherwise trust (Note [precompile programming model], "
+            "invariant 7)."
+        )
+    # filename rides into every code object the exec creates, so a traceback out of the
+    # artifact names the file a reader can open. Under the anonymous default a hand-edit
+    # that raises at call time produced a frame with no path and no source line, which
+    # is the wrong diagnostic for source whose whole purpose is being edited in place.
+    # __file__ as well as __name__: a kernel hoisted to module level carries
+    # filename=__file__ from its heuristics decorator, and @triton.jit resolves its own
+    # source by that path, so a namespace without it cannot load such an artifact.
+    module_ns: dict[str, object] = {
+        "__name__": "_precompiled_artifact",
+        "__file__": filename,
+    }
+    exec(compile(python_code, filename, "exec"), module_ns)
     return cast("Callable[..., object]", module_ns["forward"])
 
 
@@ -1621,10 +1952,24 @@ class _PrecompileApi:
         contract; read Note [precompile programming model] before using it. The artifact
         faithfully reproduces ``fn`` only for callers that uphold that contract.
 
-        THREADING: the inductor lowering step drives process-global compiler state
-        and is serialized by an internal lock, so concurrent ``backend="inductor"``
-        calls lower one at a time. The make_fx capture phase and the ``backend="eager"``
-        path are NOT serialized.
+        THREADING: make_fx capture drives process-global tracing state and is serialized
+        by a shared reentrant lock across all precompile callers; the inductor lowering
+        step has its own compiler lock. The capture lock is held across ``fn`` itself, so
+        an ``fn`` that blocks waiting on another thread's precompile deadlocks.
+
+        Capture restores the generator state it consumed, and only that: a graph
+        containing no op that can draw leaves the generators untouched even if a
+        concurrent thread advanced them. Attribution is by the drawing op's output
+        device, not by which generator it names, so a draw taking an explicit
+        ``torch.Generator`` restores that device's default generator instead and leaves
+        the named one advanced. "Can draw" is decided conservatively from the
+        graph, so an attention or dropout op configured not to draw still counts unless
+        a literal argument proves otherwise. When a restore does happen it rewinds any
+        draw a concurrent thread made while capture ran, so precompile random
+        computations before starting threads that share the default generator. A capture
+        that RAISES restores nothing, since a partial graph attributes nothing. Only
+        already-initialized CUDA/XPU generators and those reachable from the arguments
+        are saved; a device first initialized during capture warns and is left as-is.
 
         ``backend`` selects how the captured graph is realized:
 

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -1550,7 +1550,7 @@ class PrecompiledModule:
         return buf.getvalue()
 
 
-def _make_inlined_forward(python_code: str) -> Callable[..., object]:
+def _make_inlined_forward(python_code: str, warn: bool = True) -> Callable[..., object]:
     """Fallback: execute the self-contained python string (JITs kernels).
 
     ``python_code`` needs no cache -- the kernels (inductor) or graph (eager) are
@@ -1559,13 +1559,16 @@ def _make_inlined_forward(python_code: str) -> Callable[..., object]:
     inputs)."""
     # python_code is untrusted EXECUTABLE input -- exec'ing it runs whatever it contains
     # (JIT-compiling inlined kernels or running the inlined graph). Warn per load (not
-    # warning_once) before the exec so the inlined fallback is never silent about it.
-    log.warning(
-        "torch.compiler.precompile.load is about to EXEC python_code, which is untrusted "
-        "executable input (it runs inlined kernels / graph code). Only exec python_code "
-        "you produced or otherwise trust (Note [precompile programming model], "
-        "invariant 7)."
-    )
+    # warning_once) before the exec so the inlined fallback is never silent about it,
+    # but only when warn is True -- callers that exec artifacts they produced themselves
+    # (e.g. export_python) pass warn=False to suppress the untrusted-exec warning.
+    if warn:
+        log.warning(
+            "torch.compiler.precompile.load is about to EXEC python_code, which is untrusted "
+            "executable input (it runs inlined kernels / graph code). Only exec python_code "
+            "you produced or otherwise trust (Note [precompile programming model], "
+            "invariant 7)."
+        )
     module_ns: dict[str, object] = {"__name__": "_precompiled_artifact"}
     exec(compile(python_code, "<precompile>", "exec"), module_ns)
     return cast("Callable[..., object]", module_ns["forward"])

--- a/torch/_precompile_driver.py
+++ b/torch/_precompile_driver.py
@@ -178,10 +178,12 @@ def _eager_forward(*args):
     for _t, _shp, _dt, _dev in zip(
         user_flat, USER_INPUT_SHAPES, USER_INPUT_DTYPES, USER_INPUT_DEVICES
     ):
-        if _shp is None or not isinstance(_t, _torch.Tensor):
+        if not isinstance(_t, _torch.Tensor):
             continue
         _act = tuple(_t.shape)
-        if len(_act) != len(_shp) or any(a != e for a, e in zip(_act, _shp)):
+        if _shp is not None and (
+            len(_act) != len(_shp) or any(a != e for a, e in zip(_act, _shp))
+        ):
             _fail(
                 f"precompile: a runtime input has shape {_act} but the artifact was "
                 f"traced with shape {tuple(_shp)}; the graph is specialized to the static "
@@ -270,12 +272,13 @@ def _inductor_forward(*args):
         USER_INPUT_DEVICES,
         USER_INPUT_BOUNDS,
     ):
-        if _shp is None or not isinstance(_t, _torch.Tensor):
+        if not isinstance(_t, _torch.Tensor):
             continue
         # A dim recorded as None was captured dynamic (unbacked); any size is valid.
         _act = tuple(_t.shape)
-        if len(_act) != len(_shp) or any(
-            e is not None and a != e for a, e in zip(_act, _shp)
+        if _shp is not None and (
+            len(_act) != len(_shp)
+            or any(e is not None and a != e for a, e in zip(_act, _shp))
         ):
             _fail(
                 f"precompile: a runtime input has shape {_act} but the artifact was "

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import contextlib
 import io
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
 
@@ -46,6 +46,7 @@ __all__ = [
     "cudagraph_mark_step_begin",
     "load_compiled_function",
     "precompile",
+    "export_python",
     "PrecompileError",
     "wrap_numpy",
     "is_compiling",
@@ -997,3 +998,126 @@ def load_compiled_function(
 
     data = file.read()
     return AOTCompiledFunction.deserialize(data, f_globals, external_data)
+
+
+def export_python(
+    *,
+    path: str,
+    backend: str = "inductor",
+    tracer: str = "make_fx",
+    decompositions: dict | None = None,
+    example_inputs: Sequence[object] | None = None,
+    unsafe_reduce_overhead: bool = False,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Export the human-readable Python emitted by :func:`torch.compiler.precompile` to disk.
+
+    ``export_python`` is a decorator wrapping :func:`torch.compiler.precompile`.
+    On the first run in an environment it precompiles the decorated function (make_fx
+    capture plus backend lowering) and writes the emitted, self-contained Python
+    source to ``path``. On any later run the ``.py`` is already present, so
+    precompilation is skipped: the source is read back from disk and executed
+    directly. There is no acceleration cache -- the emitted source is self-contained
+    and always exec'd as written.
+
+    It is a distinct entry point rather than a ``path=`` kwarg on
+    :func:`torch.compiler.precompile` because the two have different shapes: the raw
+    ``precompile(fn, *example_inputs)`` primitive is eager, takes the example inputs
+    positionally (mirroring how ``fn`` is called), and returns ``(python_code,
+    cache)`` for the caller to manage. ``export_python`` is a decorator that owns the
+    on-disk artifact and returns a runnable, so ``fn`` arrives via ``@`` and the
+    example inputs move to a keyword-only ``example_inputs`` list.
+
+    Keyword call arguments are supported: they are bound onto ``fn``'s positional
+    signature (so ``rope(q=..., k=...)`` works); keyword-only parameters are not
+    expressible in the artifact's positional convention and are rejected.
+
+    Unlike a binary artifact, ``path`` is readable, re-executable Python meant to be
+    committed and hand-edited. An engineer or agent can "hill-climb" the generated
+    kernel in place (ejectable compilation): the emitted source is always exec'd, so
+    edits always take effect. Keeping the edited source correct is the caller's
+    responsibility. The original eager function stays in source as the reference to
+    regenerate from (delete ``path`` to re-precompile).
+
+    Args:
+        path: Filesystem path for the emitted Python source. Parent directories are
+            created as needed. Its presence is the sole signal used to decide whether
+            to precompile or to load. Because presence is the sole signal, changing
+            ``backend``, ``tracer``, ``decompositions``, or ``example_inputs`` later
+            does NOT invalidate a previously written artifact: an existing ``path`` is
+            loaded as-is. To force a re-precompile after changing any of those, delete
+            ``path``. The artifact records the producing torch version in its first
+            line; loading it under a different torch logs a warning (it still runs) so
+            a committed artifact gone stale across a torch upgrade is visible. A
+            hand-edit that drops that line disables the warning.
+        backend: How the captured graph is realized: ``"inductor"`` (default) or
+            ``"eager"``. Forwarded to :func:`torch.compiler.precompile`.
+        tracer: Capture front-end; ``"make_fx"`` (default) is the only one
+            implemented. Forwarded to :func:`torch.compiler.precompile`.
+        decompositions: Optional decomposition table forwarded to ``make_fx`` during
+            capture.
+        example_inputs: Positional inputs used to drive precompilation, matching
+            ``fn``'s own positional signature (``nn.Module`` arguments stay at their
+            original positions; the rest are the runtime inputs). If None, the first
+            call's own arguments are used, deep-copied for capture so a mutating
+            ``fn`` is applied exactly once. Pass ``example_inputs`` explicitly when
+            the first-call arguments are not deep-copyable (e.g. non-leaf tensors or
+            ``weight_norm`` modules). Explicit ``example_inputs`` are consumed by
+            capture, which runs ``fn`` once and mutates them (e.g. module buffers), so
+            they must NOT be objects that also appear in the runtime call args --
+            otherwise the mutation is applied twice (once at capture, once by the
+            artifact). The None path avoids this by deep-copying the first call's args
+            for capture. Note that this deep copy includes the full weights of any
+            ``nn.Module`` argument, so it transiently doubles that memory. Pass
+            ``example_inputs`` explicitly for large modules to avoid the clone.
+        unsafe_reduce_overhead: Skip the artifact's per-call invariant checks. The
+            emitted ``forward`` re-verifies the precompile invariants on every call
+            (pytree round-trip against the traced structure, per-input shape / dtype /
+            device guards); with this set, the compiled ``call`` is invoked directly
+            instead, which on a small kernel removes most of the per-call host
+            overhead. AOTAutograd's own semantics (input-mutation reflection, subclass
+            unwrapping, grad disabling) are still applied -- only the checks go away.
+            Passing an input whose shape, dtype, device or layout differs from the
+            traced example is then undefined behavior (silent wrong results or a
+            crash) instead of a diagnosed error, so use it only where the call site
+            provably matches the capture. It has no effect (and warns) when the
+            calling convention needs the driver: an ``nn.Module`` argument, a gradient
+            to scatter, or a non-flat input/output structure. Note that ``forward`` is
+            bypassed in this mode, so a hand-edit to the driver in ``path`` does not
+            take effect (hand-edits to the kernels and to ``call`` still do). It also
+            enables the ``out=`` calling convention described below.
+
+    With ``unsafe_reduce_overhead=True`` and an artifact that allocates its own buffers
+    (``backend="inductor"`` does; ``backend="eager"`` emits a bare graph call and
+    raises), the artifact accepts an ``out=`` sequence of destination tensors. Donating the outputs also lets the
+    artifact reuse its internal scratch buffers, so a steady-state ``out=`` call
+    allocates nothing -- worth roughly a microsecond per buffer the graph would
+    otherwise have asked the caching allocator for::
+
+        o0, o1 = torch.empty_like(q), torch.empty_like(k)
+        for ... :
+            apply_rotary_pos_emb(q, k, cos, sin, out=(o0, o1))
+
+    The donated tensors are validated once, on the first ``out=`` call, and must match
+    the artifact's outputs exactly (shape, stride, dtype, device); passing different
+    ones later is undefined behavior and can corrupt memory, since the kernels write
+    through baked sizes and strides. Because the scratch buffers are shared across
+    ``out=`` calls, a donating call is neither reentrant nor thread-safe. Calls without
+    ``out=`` are unaffected and keep allocating their own outputs. ``out=`` raises if
+    the artifact's outputs are not buffers it allocates (a view of one, or an input
+    passed through), which is the case where there is nothing to donate into.
+
+    Example::
+
+        @torch.compiler.export_python(path="precompiled_kernels/rope.py")
+        def apply_rotary_pos_emb(q, k, cos, sin): ...
+    """
+    from torch.compiler._export_python import export_python as _export_python
+
+    return _export_python(
+        path=path,
+        backend=backend,
+        tracer=tracer,
+        decompositions=decompositions,
+        example_inputs=example_inputs,
+        unsafe_reduce_overhead=unsafe_reduce_overhead,
+    )

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import contextlib
 import io
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
 
@@ -46,6 +46,7 @@ __all__ = [
     "cudagraph_mark_step_begin",
     "load_compiled_function",
     "precompile",
+    "export_python",
     "PrecompileError",
     "wrap_numpy",
     "is_compiling",
@@ -997,3 +998,203 @@ def load_compiled_function(
 
     data = file.read()
     return AOTCompiledFunction.deserialize(data, f_globals, external_data)
+
+
+def export_python(
+    *,
+    path: str,
+    backend: str = "inductor",
+    tracer: str = "make_fx",
+    decompositions: dict | None = None,
+    example_inputs: Sequence[object] | None = None,
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    r"""Export the Python emitted by :func:`torch.compiler.precompile` to disk.
+
+    This exists for **hill climbing on generated kernels**, not for deployment. The
+    first call captures ``fn`` and writes a self-contained, readable Python file to
+    ``path``; later calls exec that file. Because the file is the source of truth, you
+    can open it, retune a block size or a schedule, rerun, and your edit takes effect --
+    no recapture, no cache to defeat, and the result can be committed and reviewed like
+    any other source. The artifact is read and exec'd once per decorated object per
+    process, so an edit is picked up by the next run of your script (or a freshly
+    decorated function), not by a wrapper you have already called in this process.
+
+    **The central tradeoff is that the artifact is sticky.** ``path`` is the whole cache
+    key: nothing hashes ``fn``'s body, the ambient config, or the machine. That is
+    deliberate and it is what makes the workflow above possible -- an artifact that
+    re-captured whenever something changed would throw away your edits. The cost is that
+    the artifact does not notice when it has gone stale: **edit ``fn`` and rerun, and you
+    get the old compiled code with no warning.** Delete ``path`` to recapture.
+
+    A handful of comment stamps (below) catch the ambient changes that would silently
+    change the answer, and they are a backstop, not a guarantee -- the list of things a
+    generated kernel bakes is longer than the list that is checked. When you are
+    iterating, set ``COMPILER_EXPORT_PYTHON_CHECK=1``: every call then re-runs ``fn``
+    eagerly on a copy of the same inputs and compares, so an edit that changes numerics
+    is reported instead of trusted. It is a debug mode -- it doubles the work per call --
+    and it is the intended way to know an edit is safe. It compares outputs *and* any input
+    the graph mutated in place. "Doubles the work" is the floor: the reference run needs a
+    deep copy of every argument, so an ``nn.Module`` argument is copied -- weights and
+    all -- on every checked call. ``COMPILER_EXPORT_PYTHON_CHECK_RTOL`` and ``..._ATOL``
+    override the per-dtype tolerances; a ``fn`` that draws from the generator is skipped
+    with a warning, since inductor's philox differs from eager's by design. Note that
+    ``fn`` runs a second time on every checked call, so any side effect it has -- writing
+    a log, appending to a list, stepping a counter -- happens twice while the check is on,
+    and a test that deliberately makes the artifact disagree with ``fn`` will fail under
+    it by construction.
+
+    .. warning::
+        This API is experimental and subject to change.
+
+    .. warning::
+        An artifact is only valid on the machine type that produced it. The emitted
+        source hardcodes the CPU vector width inductor chose, and for CUDA the compute
+        capability and device ordinal of the producing GPU. The vector width and the
+        compute capability are never re-checked; the device ordinal is re-checked by the
+        default driver. Running a CPU artifact
+        under a DIFFERENT ISA than it captured on is unsafe in both directions, and the
+        loop stride is baked at capture while the ISA is re-picked when the artifact
+        compiles. Loading under a WIDER ISA writes past the end of the output -- heap
+        corruption. Loading under a NARROWER one leaves roughly half of each vectorized
+        strip unwritten, so the output is part uninitialized memory. Neither raises. ``torch._inductor.config.cpp.simdlen``
+        and ``ATEN_CPU_CAPABILITY`` change this on one machine, so they count as part of
+        the machine type. Running a CUDA artifact on a
+        different architecture fails with a kernel-image error. Commit an artifact only
+        alongside the machine type it captured on, and regenerate (delete ``path``) when
+        that changes; nothing detects the change for you.
+
+    ``export_python`` is a decorator wrapping :func:`torch.compiler.precompile`.
+    On the first run in an environment it precompiles the decorated function (make_fx
+    capture plus backend lowering) and writes the emitted, self-contained Python
+    source to ``path``. On any later run the ``.py`` is already present, so
+    precompilation is skipped: the source is read back from disk and executed
+    directly. There is no acceleration cache -- the emitted source is self-contained
+    and always exec'd as written.
+
+    It is a distinct entry point rather than a ``path=`` kwarg on
+    :func:`torch.compiler.precompile` because the two have different shapes: the raw
+    ``precompile(fn, *example_inputs)`` primitive is eager, takes the example inputs
+    positionally (mirroring how ``fn`` is called), and returns ``(python_code,
+    cache)`` for the caller to manage. ``export_python`` is a decorator that owns the
+    on-disk artifact and returns a runnable, so ``fn`` arrives via ``@`` and the
+    example inputs move to a keyword-only ``example_inputs`` list.
+
+    Keyword call arguments and positional defaults are normalized onto ``fn``'s full
+    positional signature (so ``rope(q=..., k=...)`` works and omitted defaults do not
+    change the artifact arity). Runtime arguments must be ``Tensor`` pytrees or direct
+    ``nn.Module`` arguments. Python scalar/config arguments are rejected because
+    ``make_fx`` specializes their values without emitting runtime guards; close such
+    constants over in ``fn`` instead. Other keyword-only parameters are not expressible
+    in the artifact's positional convention and are rejected. Five things that
+    ``make_fx`` or the code generator resolves without emitting a guard are recorded as
+    comment stamps and checked on every call:
+    each ``nn.Module`` argument's per-submodule ``training`` state, which input tensors
+    shared memory at capture (aliasing decides what an in-place mutation means), which
+    input positions held the *same* tensor object (AOTAutograd folds those into a single
+    graph slot, which byte overlap alone cannot distinguish from two views that merely
+    intersect), and the ambient ``torch.autocast`` state (which picks the dtypes the
+    kernels were built for, for every device type the artifact's own source names, not
+    only the ones its inputs live on), and the ambient globals the generated code
+    resolves against rather than re-reads: the default dtype and device a factory op
+    with no explicit argument takes, the matmul precision a GEMM template bakes as a
+    constant, and whether deterministic algorithms were enabled when inductor chose
+    between a deterministic and an atomic lowering (checked one-way -- capturing with
+    determinism on and calling with it off is safe, the reverse is not). What is *not*
+    guarded is a change in *how* two aliased
+    inputs overlap: when capture and the call both pass intersecting views, the artifact
+    runs with capture's relative offsets baked in and may compute the wrong thing.
+    ``torch.compile`` has the same hole *there*, but this list is not a complete
+    account of what the artifact bakes: a tensor subclass's inner shapes and a DTensor's
+    placements are unrecorded, and so is the CPU vector ISA (see the machine-type warning
+    above). Where ``torch.compile`` would recompile, an artifact cannot, so treat any
+    ambient change between capture and call as needing a fresh capture unless a stamp
+    covers it. A hand-edit that drops a stamp turns that one check off with a warning.
+    All six stamps (these five plus the version stamp) must stay in the artifact's
+    leading comment block: the reader stops at the first non-comment line, so inserting code above them
+    turns every check off -- loudly for the checked stamps, each of which warns per
+    call while it is missing, and silently for the version warning, which just
+    returns. Other Python attributes and Python
+    control flow are specialized at capture and must remain compatible with the example.
+    That includes ``torch.is_grad_enabled()``: capture traces with grad enabled so a
+    backward inside ``fn`` is built as graph ops, so a ``fn`` that branches on it always
+    captures the grad-enabled branch, whatever the grad mode of the call that triggered
+    capture. Calling the artifact under ``torch.no_grad()`` is unaffected and is the
+    ordinary inference path.
+
+    Unlike a binary artifact, ``path`` is readable, re-executable Python meant to be
+    committed and hand-edited. An engineer or agent can "hill-climb" the generated
+    kernel in place (ejectable compilation): the emitted source is always exec'd, so
+    edits always take effect. Keeping the edited source correct is the caller's
+    responsibility. The original eager function stays in source as the reference to
+    regenerate from (delete ``path`` to re-precompile).
+
+    Args:
+        path: Filesystem path for the emitted Python source. Parent directories are
+            created as needed. Its presence is the sole signal used to decide whether
+            to precompile or to load. Nothing about ``fn`` is hashed, so changing the
+            body of ``fn`` itself -- or pointing a different function at the same
+            ``path`` -- does NOT invalidate a previously written artifact, and neither
+            does changing ``backend``, ``tracer``, ``decompositions``, or
+            ``example_inputs``: an existing ``path`` is loaded as-is. A stale artifact
+            after a source edit is the expected failure mode; delete ``path`` to force
+            a re-precompile. The artifact records the producing torch version in its first
+            line; loading it under a different torch logs a warning (it still runs) so
+            a committed artifact gone stale across a torch upgrade is visible. A
+            hand-edit that drops that line disables the version warning. Loading any
+            existing artifact also warns before executing it because ``path`` is trusted
+            executable Python and may have been edited or replaced. A CUDA artifact
+            additionally embeds inductor's kernel-cache paths, so it is not byte-stable
+            across machines or users even when the numerics are. Triton autotuning is
+            re-run on load rather than recorded, so a cold start may pick a different
+            config and return slightly different floating-point results. Concurrent first
+            writers use first-publisher-wins semantics: every loser loads the complete
+            artifact that won instead of executing different generated source. (On a
+            filesystem without hard links this degrades to last-writer-wins; the file
+            is never partial either way.) New files use the permissions selected by the
+            process umask.
+        backend: How the captured graph is realized: ``"inductor"`` (default) or
+            ``"eager"``. Forwarded to :func:`torch.compiler.precompile`.
+        tracer: Capture front-end; ``"make_fx"`` (default) is the only one
+            implemented. Forwarded to :func:`torch.compiler.precompile`.
+        decompositions: Optional decomposition table forwarded to ``make_fx`` during
+            capture.
+        example_inputs: Positional inputs used to drive precompilation, matching
+            ``fn``'s own positional signature (``nn.Module`` arguments stay at their
+            original positions; the rest are the runtime inputs). If None, the first
+            call's own arguments are used, deep-copied for capture so a mutating
+            ``fn`` is applied exactly once. Pass ``example_inputs`` explicitly when
+            the first-call arguments are not deep-copyable (e.g. non-leaf tensors or
+            ``weight_norm`` modules). Explicit ``example_inputs`` are consumed by
+            capture, which runs ``fn`` once and mutates them (e.g. module buffers), so
+            they must NOT be objects that also appear in the runtime call args --
+            otherwise the mutation is applied twice (once at capture, once by the
+            artifact). The None path avoids this by deep-copying the first call's args
+            for capture. Note that this deep copy includes the full weights of any
+            ``nn.Module`` argument, so it transiently doubles that memory. Pass
+            ``example_inputs`` explicitly for large modules to avoid the clone.
+            Capture restores the generator state it consumed, so capturing does not
+            advance the default generators the first call is about to draw from. A draw
+            naming an explicit ``torch.Generator`` is attributed to its output's device,
+            so the default generator for that device is restored while the named one is
+            left advanced. This is about
+            generator POSITION, not value parity with eager: ``backend="inductor"``
+            lowers random ops to inductor's own philox and produces different values
+            than eager at the same seed. The CPU generator is always saved; for
+            CUDA/XPU only the current device of each initialized accelerator and any
+            device reachable from the examples are, and a graph that draws elsewhere is
+            warned about rather than restored. The restore is process-global, so if
+            ``fn`` draws, a concurrent thread's draws during capture are rewound too --
+            precompile random computations before starting threads that share the
+            default generator. A graph containing no op that can draw never touches the
+            generators; one containing an opaque non-aten op conservatively restores
+            every saved generator; and a capture that raises restores nothing.
+    """
+    from torch.compiler._export_python import export_python as _export_python
+
+    return _export_python(
+        path=path,
+        backend=backend,
+        tracer=tracer,
+        decompositions=decompositions,
+        example_inputs=example_inputs,
+    )

--- a/torch/compiler/_export_python.py
+++ b/torch/compiler/_export_python.py
@@ -1,0 +1,1343 @@
+"""Path-cached ``torch.compiler.export_python`` decorator.
+
+``torch.compiler.precompile`` captures a function ahead of time and lowers it to a
+self-contained, human-readable Python source artifact (see
+``torch/_precompile.py``). ``torch.compiler.export_python`` wraps that in a
+decorator keyed off a file on disk: the first run writes the emitted
+``python_code`` to ``path``; every later run reads the ``.py`` back and executes
+it directly instead of recompiling.
+
+Because the artifact is self-contained, re-executable Python, ``path`` is meant to
+be committed and hand-edited: an engineer or agent can "hill-climb" the generated
+kernel in place. This is ejectable compilation -- the emitted source is the source
+of truth and is always exec'd, so hand edits always take effect. There is no
+acceleration cache and no ``precompile.load`` round-trip: the source is exec'd as
+written, so keeping the edited source correct is the caller's responsibility.
+"""
+
+import ast
+import copy
+import errno
+import functools
+import inspect
+import logging
+import os
+import re
+import secrets
+import threading
+from collections.abc import Callable, Sequence
+from typing import Any, cast, TypeVar
+from typing_extensions import ParamSpec
+
+import torch
+import torch.utils._pytree as pytree
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+
+log = logging.getLogger(__name__)
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+# Written as the artifact's first line so a later load can detect it was produced
+# by a different torch (see _warn_on_version_skew). It is a comment, so it does not
+# affect exec; a hand-edit that drops it just disables the skew warning, so
+# hill-climbing an artifact never triggers a spurious version warning.
+# All six stamps must stay in the artifact's LEADING comment block: the reader stops
+# at the first line that is not a comment, so inserting code above them turns every
+# check off -- each checked stamp warns per call while it is missing, and the version
+# warning is the only one that goes quiet.
+_VERSION_TAG = "# torch.compiler.export_python torch-version: "
+# The train()/eval() flags of every nn.Module argument at capture. Python control flow
+# on ``self.training`` is specialized into the graph with no runtime guard, so this
+# stamp is what catches an artifact captured in one mode being run in the other. Like
+# the version stamp it is exec-inert, and dropping it in a hand-edit just turns the
+# check off (see _check_module_training).
+_MODULE_TRAINING_TAG = "# torch.compiler.export_python module-training: "
+# Which input tensors overlapped in memory at capture, which of them were literally the
+# same object, and the ambient autocast state. make_fx bakes all three into the graph
+# with no runtime guard: aliased inputs change what a mutation means, one object passed
+# twice is deduped into a single graph slot, and autocast changes the dtypes the kernels
+# were specialized for. Exec-inert like the other stamps, and dropping one turns only
+# its own check off. What no stamp guards is a change in HOW two aliased inputs overlap
+# -- capture's relative offsets stay baked in, exactly as they do under torch.compile.
+_INPUT_OVERLAP_TAG = "# torch.compiler.export_python input-overlap: "
+_INPUT_DUPLICATE_TAG = "# torch.compiler.export_python input-duplicates: "
+_AUTOCAST_TAG = "# torch.compiler.export_python autocast: "
+# Ambient process state the generated code bakes that no other stamp covers: the default
+# dtype and device a factory op with no explicit argument resolves against, and whether
+# deterministic algorithms were on when inductor chose between a deterministic and an
+# atomic lowering.
+_GLOBAL_STATE_TAG = "# torch.compiler.export_python global-state: "
+
+# os.link failures that mean the filesystem cannot do hard links at all, as opposed to
+# a real I/O problem (a full disk, a bad permission) that must not be swallowed.
+_NO_HARDLINK_ERRNOS = frozenset(
+    getattr(errno, name)
+    for name in ("EPERM", "EOPNOTSUPP", "ENOTSUP", "EXDEV", "EMLINK", "ENOSYS")
+    if hasattr(errno, name)
+)
+
+
+def _atomic_publish(path: str, data: bytes) -> bool:
+    # Publish a fully-written file, never a partial one, and report whether this call
+    # is the writer that published it. A hard link is the no-replace publish: exactly
+    # one concurrent writer wins and every loser loads that winner rather than exec'ing
+    # its own divergent source. Only errnos that mean "this filesystem has no hard
+    # links" fall back to replace (last-writer-wins, still never partial); a full disk
+    # or a permissions problem must surface rather than silently weaken the guarantee.
+    dir_name = os.path.dirname(path) or "."
+    base = os.path.basename(path)
+    tmp = os.path.join(
+        dir_name,
+        f".{base}.{os.getpid()}.{threading.get_ident()}.{secrets.token_hex(8)}.tmp",
+    )
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        try:
+            os.link(tmp, path)
+        except FileExistsError:
+            return False
+        except OSError as e:
+            if e.errno not in _NO_HARDLINK_ERRNOS:
+                raise
+            log.warning(
+                "torch.compiler.export_python: %s has no hard links (%s), so %s is "
+                "published last-writer-wins; concurrent first writers may each run "
+                "their own generated source.",
+                dir_name,
+                e.strerror,
+                path,
+            )
+            os.replace(tmp, path)
+        return True
+    finally:
+        try:
+            os.remove(tmp)
+        except FileNotFoundError:
+            pass
+
+
+def _lighten(code: str) -> str:
+    """Strip inductor's build-time machinery out of a standalone artifact.
+
+    Three things it emits are for compiling, not for running, and only get in the way of
+    a file meant to be read and edited:
+
+      * each kernel is a STRING passed to async_compile.triton(...), so the source a
+        reader wants to tune is quoted, a syntax error in it is reported against an
+        opaque cache file, and a kernel emitted twice silently shadows itself;
+      * AsyncCompile exists to farm kernel compilation out to a worker pool at build
+        time, which a file that is exec'd once has no use for;
+      * a bare multi-line string holds the compile-time autotuning harness, inert here.
+
+    Hoisting each kernel to module level fixes all three at once: the kernel becomes real
+    code the reader can edit in place, Python reports errors in it against this file at
+    the right line, and duplicates become duplicate defs that this same pass drops.
+    """
+    lines = code.splitlines(True)
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        if re.match(r"\w+ = async_compile\.triton\(", lines[i]):
+            body = close = -1
+            for j in range(i, len(lines)):
+                if body < 0 and "'''" in lines[j]:
+                    body = j
+                elif body >= 0 and lines[j].startswith("'''" + ", device_str="):
+                    close = j
+                    break
+            if close > 0:
+                out.extend(lines[body + 1 : close])
+                out.append("\n")
+                i = close + 1
+                continue
+        if lines[i].startswith(
+            (
+                "async_compile = AsyncCompile()",
+                "async_compile.wait(",
+                "del async_compile",
+                "from torch._inductor.async_compile import AsyncCompile",
+            )
+        ):
+            i += 1
+            continue
+        out.append(lines[i])
+        i += 1
+    lightened = "".join(out)
+    try:
+        tree = ast.parse(lightened)
+    except SyntaxError:
+        return code
+    # drop the inert compile-time blocks, which are bare string expressions
+    kept = lightened.splitlines(True)
+    inert = [
+        (n.lineno - 1, n.end_lineno)
+        for n in tree.body
+        if isinstance(n, ast.Expr)
+        and isinstance(n.value, ast.Constant)
+        and isinstance(n.value.value, str)
+        and n.end_lineno is not None
+        and n.end_lineno - n.lineno > 3
+    ]
+    for a, b in sorted(inert, reverse=True):
+        del kept[a:b]
+    lightened = "".join(kept)
+    # Only Triton kernels are hoisted. A cpp_pybinding (the CPU backend) or any other
+    # async_compile call still needs the object this pass removed, so if one survives,
+    # publish the original: names alone are not enough to check here, because such a
+    # call still BINDS its kernel name while its value has become unresolvable.
+    if re.search(r"\basync_compile\s*\.", lightened):
+        return code
+    # Earn the claim: the result must still parse and must still bind every name the
+    # original did, minus the build-time machinery this pass exists to remove. Anything
+    # else and we publish the original -- a bulky artifact beats a broken one.
+    try:
+        before = _module_level_names(code) - {"async_compile"}
+        if not before <= _module_level_names(lightened):
+            return code
+    except SyntaxError:
+        return code
+    return lightened
+
+
+def _module_level_names(code: str) -> set[str]:
+    names = set()
+    for node in ast.parse(code).body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+    return names
+
+
+_INNER_BANNER = (
+    "# Generated by torch._functorch.aot_autograd.compile_to_python -- do not edit."
+)
+
+
+def _mark_editable(code: str) -> str:
+    """Correct the inner codegen banner.
+
+    aot_autograd emits it for every compile_to_python caller and tells the reader not to
+    do the one thing this artifact exists for. Rewritten here rather than upstream,
+    because only export_python promises the source is yours to change.
+    """
+    return code.replace(
+        _INNER_BANNER,
+        "# Generated by torch._functorch.aot_autograd.compile_to_python. Editing it is\n"
+        "# supported: this source is what runs. The kernels below are yours -- retune the\n"
+        "# heuristics decorator, replace it with an explicit triton.autotune, or delete\n"
+        "# inductor's machinery and hand-write the kernel. Two things to know if you\n"
+        "# hoist a kernel out of its async_compile.triton(NAME, '''...''') call: the\n"
+        "# launch site uses KERNEL.run(...), which only exists on inductor's autotuner,\n"
+        "# so switch it to KERNEL[grid](..., XBLOCK=..., num_warps=...); and @triton.jit\n"
+        "# finds its own source by filename, so load the artifact with\n"
+        "# exec(compile(src, path, 'exec'), ns) rather than exec(src, ns).",
+        1,
+    )
+
+
+def _explain_kernel_compile_error(
+    code: str, path: str, exc: BaseException
+) -> str | None:
+    """Map a kernel compile failure back to the artifact the reader actually edited.
+
+    Reached for backends whose kernels are not hoisted to module level -- the CPU
+    cpp_pybinding path -- where the source is still compiled out of a cache file. A
+    hoisted Triton kernel needs none of this: Python reports the error against this
+    artifact at the right line by itself.
+
+    Embedded kernel source is written to a cache file and imported from there, so a
+    syntax error in it is reported against an opaque /tmp/torchinductor_*/xx/yyy.py at a
+    line number nobody can act on. Recover the artifact line by locating the cache
+    file's own text inside the artifact.
+    """
+    message = str(exc)
+    if "torchinductor" not in message:
+        return None
+    hint = f"the failure is in a kernel embedded in {path}"
+    match = re.search(r"(/\S*torchinductor\S*?\.py)", message)
+    if match is None:
+        return hint
+    try:
+        with open(match.group(1), encoding="utf-8") as handle:
+            cached = handle.read().splitlines()
+    except OSError:
+        return hint
+    line_match = re.search(r"line (\d+)", message)
+    vague = f"{hint}; edit it there, not in the cache file"
+    if line_match is None:
+        return vague
+    # Anchor on a RUN of cache lines, not one def: an artifact can embed several
+    # kernels, and matching a single line would map into whichever appears first.
+    # Without a unique anchor, say nothing about the line rather than name a wrong one.
+    failing = int(line_match.group(1)) - 1
+    window = [l for l in cached[max(0, failing - 6) : failing + 1] if l.strip()]
+    if not window:
+        return vague
+    block = "\n".join(window)
+    if code.count(block) != 1:
+        return vague
+    return (
+        f"{hint} around line {code[: code.index(block)].count(chr(10)) + len(window)}; "
+        "edit it there, not in the cache file"
+    )
+
+
+_CHECK_ENV = "COMPILER_EXPORT_PYTHON_CHECK"
+
+
+def _check_enabled() -> bool:
+    return os.environ.get(_CHECK_ENV, "") not in ("", "0")
+
+
+def _check_tolerances(dtype: torch.dtype) -> tuple[float, float]:
+    """Tolerances for comparing THIS artifact against eager, overridable by env var.
+
+    Deliberately looser than torch.testing's defaults, which are calibrated for
+    eager-vs-eager. Inductor fuses and reassociates reductions, so a correct artifact
+    differs from eager by more than that on the first call -- torch.compile produces the
+    same divergence on the same graph. Using the tight defaults rejected freshly exported,
+    never-edited artifacts, which would make the check useless.
+
+    There is a lot of headroom: an ordinary fused reduction lands near 2e-5 relative,
+    while an edit that actually changes the math (exp for exp2) lands near 4e0. Anything
+    in between is worth a look, which is what these thresholds are for.
+    """
+    per_dtype = {
+        torch.float64: (1e-7, 1e-9),
+        torch.float32: (1e-3, 1e-4),
+        torch.float16: (1e-2, 1e-3),
+        torch.bfloat16: (5e-2, 5e-3),
+    }
+    rtol, atol = per_dtype.get(dtype, (1e-3, 1e-4))
+    override_rtol = os.environ.get(f"{_CHECK_ENV}_RTOL")
+    override_atol = os.environ.get(f"{_CHECK_ENV}_ATOL")
+    return (
+        float(override_rtol) if override_rtol else rtol,
+        float(override_atol) if override_atol else atol,
+    )
+
+
+def _eager_draws(
+    fn: Callable[..., Any],
+    args: tuple[Any, ...],
+    rng: torch.Tensor,
+) -> bool:
+    """Whether fn's result depends on the generator, i.e. whether it draws.
+
+    Only consulted after a mismatch, to tell "the edit broke it" apart from "this
+    function draws". Drawing has to be detected by running from two DIFFERENT generator
+    states -- running twice from the same state proves nothing, because eager is
+    perfectly reproducible at a fixed seed. What makes the comparison meaningless is that
+    inductor lowers random ops to its own philox and differs from eager at the same seed
+    by design.
+    """
+    devices = (
+        list(range(torch.cuda.device_count())) if torch.cuda.is_available() else []
+    )
+    try:
+        # fork_rng so neither the reseed below nor anything fn draws escapes: this runs
+        # only to answer a question, and must leave the caller's streams untouched.
+        with torch.random.fork_rng(devices=devices, enabled=True):
+            torch.random.set_rng_state(rng)
+            first = pytree.tree_leaves(fn(*copy.deepcopy(args)))
+            torch.random.manual_seed(int(torch.random.initial_seed()) + 1)
+            second = pytree.tree_leaves(fn(*copy.deepcopy(args)))
+    except Exception:
+        return False
+    pairs = [
+        (a, b)
+        for a, b in zip(first, second)
+        if isinstance(a, torch.Tensor) and isinstance(b, torch.Tensor)
+    ]
+    for a, b in pairs:
+        if a.shape != b.shape or a.dtype != b.dtype:
+            return True
+        rtol, atol = _check_tolerances(a.dtype)
+        if not torch.allclose(a, b, rtol=rtol, atol=atol, equal_nan=True):
+            return True
+    return False
+
+
+def _verify_against_eager(
+    fn: Callable[..., Any],
+    args: tuple[Any, ...],
+    reference_args: tuple[Any, ...],
+    produced: Any,
+    path: str,
+    rng: torch.Tensor,
+) -> None:
+    """Re-run fn eagerly on a pre-call copy of the inputs and compare the results.
+
+    The artifact is frozen at capture and stays frozen through every hand-edit -- that is
+    the point of it -- so the way to know an edit is still correct is to ask the original
+    function. Under COMPILER_EXPORT_PYTHON_CHECK every call does exactly that.
+    """
+    expected = fn(*reference_args)
+    # Outputs AND inputs. A graph is free to mutate what it was handed, and a fn whose
+    # whole job is an in-place write returns nothing to compare -- checking only the
+    # return value rubber-stamps exactly those.
+    got_leaves = [
+        t for t in pytree.tree_leaves((produced, args)) if isinstance(t, torch.Tensor)
+    ]
+    want_leaves = [
+        t
+        for t in pytree.tree_leaves((expected, reference_args))
+        if isinstance(t, torch.Tensor)
+    ]
+    if len(got_leaves) != len(want_leaves):
+        raise _precompile_error(
+            f"{_CHECK_ENV}: the artifact at {path} returned {len(got_leaves)} tensors "
+            f"but {getattr(fn, '__name__', 'fn')} returns {len(want_leaves)}."
+        )
+    for i, (got, want) in enumerate(zip(got_leaves, want_leaves)):
+        rtol, atol = _check_tolerances(got.dtype)
+        if got.shape != want.shape or got.dtype != want.dtype:
+            raise _precompile_error(
+                f"{_CHECK_ENV}: output {i} of the artifact at {path} is "
+                f"{tuple(got.shape)}/{got.dtype} but eager gives "
+                f"{tuple(want.shape)}/{want.dtype}."
+            )
+        if torch.allclose(
+            got, want.to(got.device), rtol=rtol, atol=atol, equal_nan=True
+        ):
+            continue
+        diff = (got.double() - want.to(got.device).double()).abs()
+        scale = (
+            want.to(got.device).double().abs().clamp_min(torch.finfo(torch.double).tiny)
+        )
+        if _eager_draws(fn, reference_args, rng):
+            log.warning(
+                "%s: %s draws from the generator, and inductor lowers random ops to its "
+                "own philox, which differs from eager at the same seed by design -- so "
+                "comparing the two says nothing. Skipping the check for %s.",
+                _CHECK_ENV,
+                getattr(fn, "__name__", "fn"),
+                path,
+            )
+            return
+        raise _precompile_error(
+            f"{_CHECK_ENV}: output {i} of the artifact at {path} does not match "
+            f"{getattr(fn, '__name__', 'fn')} run eagerly on the same inputs "
+            f"(max abs diff {diff.max().item():.3e}, max rel diff "
+            f"{(diff / scale).max().item():.3e}, tolerances rtol={rtol} atol={atol}). "
+            "If you have hand-edited the artifact, the edit changed its numerics; "
+            f"otherwise delete {path} to recapture."
+        )
+
+
+def _precompile_error(msg: str) -> Exception:
+    from torch._precompile import PrecompileError
+
+    return PrecompileError(msg)
+
+
+def _module_training_state(
+    args: Sequence[Any],
+) -> list[tuple[int, list[tuple[str, bool]]]]:
+    return [
+        (pos, [(name, module.training) for name, module in arg.named_modules()])
+        for pos, arg in enumerate(args)
+        if isinstance(arg, torch.nn.Module)
+    ]
+
+
+def _byte_span(t: torch.Tensor) -> tuple[int, int]:
+    # The [start, end) byte range the tensor can touch. Exact for a dense tensor and a
+    # bounding range for a strided one, which errs toward reporting overlap.
+    start = t.data_ptr()
+    extent = sum((size - 1) * stride for size, stride in zip(t.shape, t.stride()))
+    return start, start + (extent + 1) * t.element_size()
+
+
+def _dense_leaves(t: torch.Tensor) -> list[torch.Tensor] | None:
+    """The real-memory tensors inside t, or None if its bytes cannot be located.
+
+    A wrapper subclass (DTensor, TwoTensor, FunctionalTensor) reports data_ptr() == 0
+    with a real device and is_meta False, so comparing its byte span against a plain
+    tensor's would report every pair as disjoint. Decompose it instead.
+    """
+    if is_traceable_wrapper_subclass(t):
+        try:
+            attrs, _ = t.__tensor_flatten__()
+        except Exception:
+            return None
+        leaves: list[torch.Tensor] = []
+        saw_tensor = False
+        for attr in attrs:
+            # __tensor_flatten__ names the attributes that must be transformed, and
+            # not all of them are tensors -- DTensor's list includes its DeviceMesh.
+            component = getattr(t, attr, None)
+            if not isinstance(component, torch.Tensor):
+                continue
+            saw_tensor = True
+            inner = _dense_leaves(component)
+            if inner is None:
+                return None
+            leaves.extend(inner)
+        # An empty list here means every component owns no bytes, which is a real
+        # answer. Only a subclass we could not see INTO is unresolvable -- returning
+        # `leaves` unconditionally would make such a wrapper disjoint from everything
+        # and let a donor be written over a live input.
+        return leaves if saw_tensor else None
+    if t.numel() == 0 or t.is_meta:
+        # Owns no bytes, which is not the same as "bytes we cannot find". Both report
+        # data_ptr 0, so without this one such component (an absent bias, an empty KV
+        # cache, an uneven shard, a meta-initialized slot) would poison its whole
+        # wrapper into "assume it aliases everything" and refuse every donation against
+        # it. This is about a leaf that genuinely IS meta; a wrapper merely presenting
+        # meta over live payloads is still distrusted, in _reports_no_bytes.
+        return []
+    try:
+        if t.data_ptr() == 0:
+            return None
+    except RuntimeError:
+        return None
+    return [t]
+
+
+def _reports_no_bytes(t: torch.Tensor) -> bool:
+    """Whether t can be ruled out from its own report, without locating its bytes.
+
+    Only for tensors that are what they say they are. A wrapper subclass's numel and
+    is_meta describe what it PRESENTS: torch.load with
+    map_location={torch.device("cpu"): "meta"} -- keyed by a device OBJECT, which remaps
+    the wrapper without remapping its storages -- builds one reporting meta over live
+    cpu payloads, and taking that at face value says it aliases nothing, including its
+    own payload. The string form {"cpu": "meta"} does the reverse and is not the case
+    this guards.
+    """
+    return not is_traceable_wrapper_subclass(t) and (t.numel() == 0 or t.is_meta)
+
+
+def _shares_memory(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Whether two tensors can touch the same bytes.
+
+    NOT torch._C._overlaps, which is IValue::overlaps -- storage IDENTITY, ignoring
+    offsets. That reports byte-disjoint slices of one buffer as overlapping, which
+    rejects the arena / fused-QKV / KV-cache shape this API exists to serve.
+
+    Compares addresses, not storage objects: the same bytes can be reached through
+    different UntypedStorages (from_numpy on overlapping slices, frombuffer, DLPack,
+    __cuda_array_interface__ onto a live arena), and a storage-identity gate reports
+    those as disjoint -- a donor would then be written over a live input. data_ptr is a
+    process-global address and differing devices are rejected at the LEAF below, so
+    distinct allocations cannot collide. One allocation visible under two device types
+    still can: mapped pinned host memory has the same address as its CUDA view, and
+    this reports the pair disjoint. torch._C._overlaps answers that case identically.
+    Conservative for anything whose extent cannot be computed: a bounding range for
+    strided tensors, and for sparse or otherwise unlocatable tensors "aliases anything
+    of the same device type" -- NOT storage identity, which is the predicate this
+    function exists to avoid.
+    """
+    if _reports_no_bytes(a) or _reports_no_bytes(b):
+        # No real memory, and every meta tensor reports data_ptr 0, which would
+        # otherwise make every pair look coincident.
+        return False
+    a_leaves, b_leaves = _dense_leaves(a), _dense_leaves(b)
+    if a_leaves is None or b_leaves is None:
+        # An addressless or undecomposable tensor (a wrapper subclass whose components
+        # we cannot reach, sparse, nested). Its bytes are unknown, so the only safe
+        # answer is "assume it aliases" -- NOT storage identity, which is the predicate
+        # that made byte-disjoint arena slices look aliased in the first place. Device
+        # type is all that can still rule a pair out. Note this reads the OUTER device
+        # of both operands, including one that did resolve, because there is no leaf on
+        # the unresolved side to pair its leaves against; a wrapper misreporting its
+        # type is therefore still taken at its word here.
+        return a.device.type == b.device.type
+    if not (
+        len(a_leaves) == 1
+        and a_leaves[0] is a
+        and len(b_leaves) == 1
+        and b_leaves[0] is b
+    ):
+        return any(_shares_memory(x, y) for x in a_leaves for y in b_leaves)
+    if a.device != b.device:
+        # Compared here, on the LEAF, and never on the wrapper: a subclass can report a
+        # device that differs from the one holding its bytes in index (torch.load with
+        # map_location="cuda" over a "cuda:0" payload) or in TYPE (map_location=
+        # {"cuda:0": "cpu"}). Gating above reported such a tensor as sharing memory with
+        # nothing -- including with its own payload.
+        return False
+    try:
+        (a_start, a_end), (b_start, b_end) = _byte_span(a), _byte_span(b)
+    except RuntimeError:
+        return True
+    return a_start < b_end and b_start < a_end
+
+
+def _input_tensors(args: Sequence[Any]) -> list[torch.Tensor]:
+    """Every tensor an artifact call can reach, in a stable order.
+
+    Module params and buffers are included, and come after the user tensors so their
+    presence does not shift the indices a previously written stamp recorded. They have
+    to be here: AOTAutograd dedups a user tensor that aliases a module buffer into one
+    graph slot, so an artifact captured with that alias computes -- and mutates -- the
+    wrong thing when the runtime call passes independent tensors, and the reverse.
+    """
+    user = [
+        leaf
+        for arg in args
+        if not isinstance(arg, torch.nn.Module)
+        for leaf in pytree.tree_leaves(arg)
+        if isinstance(leaf, torch.Tensor)
+    ]
+    module: list[torch.Tensor] = []
+    seen: set[int] = set()
+    for arg in args:
+        if not isinstance(arg, torch.nn.Module):
+            continue
+        for tensor in [*arg.parameters(), *arg.buffers()]:
+            if id(tensor) not in seen:
+                seen.add(id(tensor))
+                module.append(tensor)
+    return [*user, *module]
+
+
+def _span_atoms(
+    t: torch.Tensor,
+) -> list[tuple[torch.device, int, int]] | None:
+    """t's byte ranges as (leaf device, start, end), or None if they cannot be located.
+
+    Keyed on the LEAF device only, matching _shares_memory: a wrapper subclass can
+    report a device that differs from the one holding its bytes, in index (torch.load
+    with map_location="cuda" over a "cuda:0" payload) or in type (map_location=
+    {"cuda:0": "cpu"}), so the wrapper's own report decides nothing. An empty list means
+    t owns no addressable bytes, so it overlaps nothing.
+    """
+    if _reports_no_bytes(t):
+        return []
+    leaves = _dense_leaves(t)
+    if leaves is None:
+        return None
+    atoms = []
+    for leaf in leaves:
+        if leaf.numel() == 0 or leaf.is_meta:
+            continue
+        try:
+            start, end = _byte_span(leaf)
+        except RuntimeError:
+            return None
+        atoms.append((leaf.device, start, end))
+    return atoms
+
+
+def _input_overlaps(
+    args: Sequence[Any], tensors: list[torch.Tensor] | None = None
+) -> list[list[int]]:
+    """Which pairs of input tensors share memory, as sorted [i, j] index pairs.
+
+    Runs on every artifact call, so it is a sweep and not the P-choose-2 pairwise scan:
+    a 32-block model has hundreds of parameters, and the quadratic form cost multiples
+    of the forward it guards. Lists (not tuples) so the stamp round-trips through
+    ast.literal_eval to something that compares equal.
+    """
+    if tensors is None:
+        tensors = _input_tensors(args)
+    by_device: dict[torch.device, list[tuple[int, int, int]]] = {}
+    unresolved: list[int] = []
+    for i, tensor in enumerate(tensors):
+        atoms = _span_atoms(tensor)
+        if atoms is None:
+            unresolved.append(i)
+            continue
+        for leaf, start, end in atoms:
+            by_device.setdefault(leaf, []).append((start, end, i))
+    pairs: set[tuple[int, int]] = set()
+    for spans in by_device.values():
+        spans.sort()
+        # Spans that started earlier and have not ended: exactly the ones this span can
+        # overlap, since the list is sorted by start.
+        open_spans: list[tuple[int, int]] = []
+        for start, end, i in spans:
+            open_spans = [(e, j) for e, j in open_spans if e > start]
+            for _, j in open_spans:
+                if j != i:
+                    pairs.add((min(i, j), max(i, j)))
+            open_spans.append((end, i))
+    for i in unresolved:
+        for j, other in enumerate(tensors):
+            if j != i and _shares_memory(tensors[i], other):
+                pairs.add((min(i, j), max(i, j)))
+    return [[i, j] for i, j in sorted(pairs)]
+
+
+def _input_duplicates(
+    args: Sequence[Any], tensors: list[torch.Tensor] | None = None
+) -> list[list[int]]:
+    """Which input positions hold the SAME tensor object, as [first, repeat] pairs.
+
+    Not implied by _input_overlaps: AOTAutograd dedups arguments that are one object
+    into a single graph slot, and byte overlap cannot tell that apart from two views
+    that merely intersect. Both report the same pair set, so without this an artifact
+    captured from overlapping views silently computes the wrong thing when handed one
+    tensor twice. torch.compile guards it and recompiles ("Duplicate tensors found").
+    """
+    if tensors is None:
+        tensors = _input_tensors(args)
+    first: dict[int, int] = {}
+    pairs = []
+    for i, tensor in enumerate(tensors):
+        seen_at = first.setdefault(id(tensor), i)
+        if seen_at != i:
+            pairs.append([seen_at, i])
+    return pairs
+
+
+def _code_devices(code: str) -> set[str]:
+    """The device types the emitted artifact names, from its own source.
+
+    The stamp and the per-call check have to agree, so this is computed from the source
+    once at capture and once at load rather than from anything ambient.
+    """
+    found = set(re.findall(r"empty_strided_(\w+)\(", code))
+    found.update(re.findall(r"device\(type=[\'\"](\w+)[\'\"]", code))
+    found.update(re.findall(r"\.to\([\'\"](\w+)[\'\"]", code))
+    devices = set()
+    for name in found:
+        # The allocator names are not all device types -- empty_strided_cpu_pinned is a
+        # cpu allocator -- and a hand-edited artifact can contain anything at all.
+        try:
+            devices.add(torch.device(name).type)
+        except (RuntimeError, ValueError):
+            continue
+    return devices
+
+
+def _autocast_state(
+    args: Sequence[Any],
+    tensors: list[torch.Tensor] | None = None,
+    code_devices: set[str] | None = None,
+) -> list[list[Any]]:
+    """Ambient autocast for every device type this artifact can compute on.
+
+    The input devices alone are not enough: a graph whose inputs are all on CPU can still
+    run its matmuls on an accelerator, and keying only on inputs recorded [] for it in
+    both processes, so the check passed while the kernels had been built for autocast
+    dtypes. Widened with the device types the emitted code names. Still not every device
+    type in the process: a CPU helper first called inside a `with torch.autocast("cuda")`
+    training region must not be locked to that region, and its graph never names cuda.
+    """
+    if tensors is None:
+        tensors = _input_tensors(args)
+    devices = {t.device.type for t in tensors}
+    if code_devices is not None:
+        devices.update(code_devices)
+    return [
+        [device, str(torch.get_autocast_dtype(device))]
+        for device in sorted(devices)
+        if torch.amp.is_autocast_available(device) and torch.is_autocast_enabled(device)
+    ]
+
+
+def _global_state() -> list[list[Any]]:
+    """Ambient globals the emitted code resolves against, as sorted [key, value] pairs.
+
+    Recorded as strings so the stamp round-trips through ast.literal_eval. Both are read
+    at CAPTURE and baked: a factory op with no dtype= takes the default dtype then, and
+    inductor picks a deterministic or an atomic-add lowering from the determinism flag.
+    The artifact never re-consults either, so a process that changes one and replays gets
+    capture's answer with no error.
+
+    float32_matmul_precision is deliberately NOT here. torch.get_float32_matmul_precision
+    raises outright in a process that has used the per-backend fp32_precision API, so
+    stamping it killed capture there; and on the default config the artifact reaches
+    extern_kernels.mm, which re-reads the setting at run time, so the check refused calls
+    the artifact would have served correctly. Only a max_autotune Triton GEMM template
+    bakes it as a tl.constexpr.
+    """
+    return [
+        ["default_dtype", str(torch.get_default_dtype())],
+        ["default_device", str(torch.get_default_device())],
+        ["deterministic", str(torch.are_deterministic_algorithms_enabled())],
+    ]
+
+
+class ExportedPythonArtifact:
+    """Materializes and disk-caches a ``torch.compiler.precompile`` artifact.
+
+    Materialization is lazy and happens on the first call: if ``path`` exists the
+    emitted Python is read from disk, otherwise the wrapped ``fn`` is precompiled
+    against the example inputs and the emitted source is written to disk. Either
+    way the source is exec'd directly to build the runnable. The loaded callable is
+    reused for all subsequent calls in the process; a later process re-reads
+    whatever is on disk.
+    """
+
+    def __init__(
+        self,
+        fn: Callable[..., Any],
+        *,
+        path: str,
+        backend: str,
+        tracer: str,
+        decompositions: dict | None,
+        example_inputs: Sequence[object] | None,
+    ) -> None:
+        self._fn = fn
+        self._signature = inspect.signature(fn)
+        self._call_signature = self._signature
+        self._path = path
+        self._backend = backend
+        self._tracer = tracer
+        self._decompositions = decompositions
+        self._example_inputs = None if example_inputs is None else tuple(example_inputs)
+        self._module_training: list[tuple[int, list[tuple[str, bool]]]] | None = None
+        self._input_overlaps: list[list[int]] | None = None
+        self._input_duplicates: list[list[int]] | None = None
+        self._global_state: list[list[str]] | None = None
+        self._code_devices: set[str] = set()
+        self._autocast: list[list[Any]] | None = None
+        self._loaded: Callable[..., Any] | None = None
+        # (pid, tid) currently inside _materialize. There is deliberately no
+        # per-artifact lock: capture is already serialized process-wide, so a second
+        # lock would add nothing but a second acquisition order to deadlock against.
+        # This is the re-entrancy guard the (reentrant) capture lock cannot provide.
+        # The pid makes it fork-safe without a registry -- a child never matches a
+        # marker left by a thread it did not inherit.
+        self._materializing: tuple[int, int] | None = None
+
+    def _precompile_and_save(self, args: tuple[Any, ...]) -> tuple[str, bool]:
+        example = self._example_inputs
+        if example is None:
+            # Capture runs fn once on the example inputs (real-mode make_fx), which
+            # mutates them; deep-copy the live call args so capture side effects (in-
+            # place input mutation, module buffer updates) do not leak onto the
+            # caller before the artifact itself runs on the real args exactly once.
+            try:
+                example = copy.deepcopy(args)
+            except Exception as e:
+                from torch._precompile import PrecompileError
+
+                raise PrecompileError(
+                    "torch.compiler.export_python could not deep-copy the "
+                    "first-call arguments to capture without mutating them (e.g. a "
+                    "non-leaf tensor or a weight_norm module). Pass explicit "
+                    "example_inputs=... to precompile against dedicated inputs."
+                ) from e
+            if _input_overlaps(example) != _input_overlaps(args):
+                from torch._precompile import PrecompileError
+
+                raise PrecompileError(
+                    "torch.compiler.export_python: deep-copying the first-call "
+                    "arguments did not preserve how their tensors share memory, so "
+                    "capturing from the copy would bake in aliasing the real arguments "
+                    "do not have. nn.Parameter.__deepcopy__ clones, so two Parameters "
+                    "backed by one storage become independent in the copy. Pass "
+                    "example_inputs=... built with the same sharing as the real "
+                    "arguments to capture against those instead."
+                )
+        else:
+            example = self._bind_positional(example, {}, "example_inputs=")
+            self._check_supported_args(example)
+        # precompile returns (python_code, cache); the cache is an acceleration
+        # artifact that export_python does not use -- the emitted source is
+        # self-contained and always exec'd -- so only the code is written to disk.
+        code, _cache = torch.compiler.precompile(
+            self._fn,
+            *example,
+            backend=self._backend,
+            tracer=self._tracer,
+            decompositions=self._decompositions,
+        )
+        code = _mark_editable(_lighten(code))
+        parent = os.path.dirname(self._path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        # The stamps lead the artifact as exec-inert comments, each guarding one thing
+        # make_fx specialized without a runtime guard. A hand-edit may drop any of them;
+        # each just turns its own check off.
+        example_tensors = _input_tensors(example)
+        code = (
+            f"{_VERSION_TAG}{torch.__version__!r}\n"
+            f"{_MODULE_TRAINING_TAG}{_module_training_state(example)!r}\n"
+            f"{_INPUT_OVERLAP_TAG}{_input_overlaps(example, example_tensors)!r}\n"
+            f"{_INPUT_DUPLICATE_TAG}{_input_duplicates(example, example_tensors)!r}\n"
+            f"{_AUTOCAST_TAG}"
+            f"{_autocast_state(example, example_tensors, _code_devices(code))!r}\n"
+            f"{_GLOBAL_STATE_TAG}{_global_state()!r}\n{code}"
+        )
+        if _atomic_publish(self._path, code.encode("utf-8")):
+            return code, False
+        # Lost the publish race; the winner's file is complete and already linked.
+        winner = self._load_from_disk()
+        if winner is None:
+            raise _precompile_error(
+                f"torch.compiler.export_python: another writer published {self._path} "
+                "and it was deleted before this call could load it. Retry."
+            )
+        return winner, True
+
+    def _load_from_disk(self) -> str | None:
+        # None means "not there after all" -- the presence gate raced a peer deleting
+        # the artifact to force a regenerate, which should fall through to capture
+        # rather than surface a bare FileNotFoundError.
+        try:
+            with open(self._path, encoding="utf-8") as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
+        except OSError as e:
+            raise _precompile_error(
+                f"torch.compiler.export_python: could not read the artifact at "
+                f"{self._path} ({e.strerror}). Check that the path names a readable "
+                "file rather than a directory."
+            ) from e
+
+    @staticmethod
+    def _read_raw_stamp(code: str, tag: str) -> str | None:
+        for line in code.splitlines():
+            if line.startswith(tag):
+                return line[len(tag) :].strip() or None
+            # An INDENTED comment is still a comment. The documented rule is "the
+            # first non-comment line", and stopping early here silently turns every
+            # later stamp's check off rather than reading it.
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                break
+        return None
+
+    @staticmethod
+    def _read_stamp(code: str, tag: str) -> Any:
+        for line in code.splitlines():
+            if line.startswith(tag):
+                try:
+                    return ast.literal_eval(line[len(tag) :])
+                except (ValueError, SyntaxError):
+                    # A mangled stamp is a hand-edit like any other: turn the check off
+                    # rather than raise a SyntaxError from a comment line that does not
+                    # affect what the artifact runs.
+                    return None
+            # An INDENTED comment is still a comment. The documented rule is "the
+            # first non-comment line", and stopping early here silently turns every
+            # later stamp's check off rather than reading it.
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                break
+        return None
+
+    def _check_capture_environment(self, args: tuple[Any, ...]) -> None:
+        # Two more things make_fx specialized with no runtime guard. Input ALIASING
+        # decides what an in-place mutation means, so an artifact captured with two
+        # arguments sharing memory computes the wrong thing (and mutates the wrong
+        # thing) when they are distinct at runtime -- torch.compile guards this and
+        # recompiles. Ambient AUTOCAST decides the dtypes the kernels were built for.
+        tensors: list[torch.Tensor] | None = None
+
+        def input_tensors() -> list[torch.Tensor]:
+            # Walked once and shared by the three checks below. Lazily, so an artifact
+            # whose stamps were all hand-edited away does not pay for a walk no check
+            # will read.
+            nonlocal tensors
+            if tensors is None:
+                tensors = _input_tensors(args)
+            return tensors
+
+        if self._input_overlaps is None:
+            log.warning(
+                "torch.compiler.export_python: the artifact at %s carries no recorded "
+                "input-aliasing stamp, so a runtime call whose inputs share memory "
+                "differently than capture is unchecked. Delete %s to regenerate it.",
+                self._path,
+                self._path,
+            )
+        else:
+            actual = _input_overlaps(args, input_tensors())
+            if actual != self._input_overlaps:
+                raise _precompile_error(
+                    "torch.compiler.export_python: the runtime inputs do not share "
+                    f"memory the way capture did (captured overlapping index pairs "
+                    f"{self._input_overlaps}, got {actual}). Aliasing is baked into the "
+                    "graph, so this call would compute against the wrong assumption."
+                )
+        if self._input_duplicates is None:
+            log.warning(
+                "torch.compiler.export_python: the artifact at %s carries no recorded "
+                "input-duplicate stamp, so a runtime call that repeats a tensor object "
+                "differently than capture is unchecked. Delete %s to regenerate it.",
+                self._path,
+                self._path,
+            )
+        else:
+            actual_duplicates = _input_duplicates(args, input_tensors())
+            if actual_duplicates != self._input_duplicates:
+                raise _precompile_error(
+                    "torch.compiler.export_python: the runtime inputs repeat tensor "
+                    "objects differently than capture did (captured duplicate index "
+                    f"pairs {self._input_duplicates}, got {actual_duplicates}). "
+                    "AOTAutograd folds arguments that are one object into a single "
+                    "graph slot, so this call would compute against the wrong "
+                    "assumption -- byte overlap alone cannot see the difference."
+                )
+        if self._global_state is None:
+            log.warning(
+                "torch.compiler.export_python: the artifact at %s carries no recorded "
+                "global-state stamp, so calling it under a different default dtype, "
+                "default device, matmul precision or determinism setting than capture "
+                "is unchecked. Delete %s to regenerate it.",
+                self._path,
+                self._path,
+            )
+        else:
+            actual_state = dict(_global_state())
+            try:
+                recorded = dict(self._global_state)
+            except (TypeError, ValueError):
+                # A hand-edit can leave a literal that is not [key, value] pairs. Every
+                # other stamp degrades to warn-and-continue for that; this one must not
+                # be the only one that raises a raw unpack error out of the load path.
+                log.warning(
+                    "torch.compiler.export_python: the global-state stamp at %s is not a "
+                    "list of [key, value] pairs, so that check is off. Delete %s to "
+                    "regenerate it.",
+                    self._path,
+                    self._path,
+                )
+                recorded = {}
+            for key, captured in recorded.items():
+                if key not in actual_state:
+                    continue  # a key this torch no longer records
+                live = actual_state[key]
+                if live == captured:
+                    continue
+                # Determinism is one-sided: capture with it OFF and replay with it ON
+                # means the artifact keeps a lowering the caller has asked not to run.
+                # ON at capture and OFF at replay is conservative, so it is not an error.
+                if key == "deterministic" and captured == "True":
+                    continue
+                raise _precompile_error(
+                    f"torch.compiler.export_python: {key} is {live} but the artifact "
+                    f"was captured with {key} {captured}. It is resolved when the code "
+                    "is generated and baked in, so this call would silently get "
+                    "capture's answer. Set it to the captured value, or delete "
+                    f"{self._path} to recapture."
+                )
+        if self._autocast is None:
+            log.warning(
+                "torch.compiler.export_python: the artifact at %s carries no recorded "
+                "autocast stamp, so calling it under a different autocast context than "
+                "capture is unchecked. Delete %s to regenerate it.",
+                self._path,
+                self._path,
+            )
+        else:
+            actual_autocast = _autocast_state(args, input_tensors(), self._code_devices)
+            if actual_autocast != self._autocast:
+                raise _precompile_error(
+                    "torch.compiler.export_python: the runtime autocast state does not "
+                    f"match capture (captured {self._autocast}, got {actual_autocast}). "
+                    "Autocast dtypes are baked into the artifact; capture under the "
+                    "same autocast context you call it in."
+                )
+
+    def _check_module_training(self, args: tuple[Any, ...]) -> None:
+        actual = _module_training_state(args)
+        if not actual:
+            return
+        if self._module_training is None:
+            # Missing stamp means a hand-edit dropped it, the same as the version
+            # stamp: warn that the guard is off rather than refuse to run an artifact
+            # whose source is by design the thing the caller is free to edit.
+            log.warning(
+                "torch.compiler.export_python: the artifact at %s takes nn.Module "
+                "arguments but carries no recorded training state, so train()/eval() "
+                "skew against capture is unchecked. Delete %s to regenerate the stamp.",
+                self._path,
+                self._path,
+            )
+            return
+        if actual != self._module_training:
+            raise _precompile_error(
+                "torch.compiler.export_python: the runtime module training state does "
+                f"not match capture (expected {self._module_training!r}, got {actual!r}). "
+                "Restore train()/eval() state or regenerate the artifact."
+            )
+
+    def _warn_on_version_skew(self, code: str) -> None:
+        # Warn (but still run) when the artifact carries a version stamp that does
+        # not match the current torch, so a committed artifact gone stale across a
+        # torch upgrade is visible rather than silently running old logic. A missing
+        # stamp (dropped by a hand-edit) is silent, so hill-climbing never warns.
+        produced = self._read_stamp(code, _VERSION_TAG)
+        if produced is None:
+            # Artifacts written before the stamp became a repr() carry a bare version
+            # string, which literal_eval rejects. Falling back to the raw text keeps the
+            # skew warning working for every artifact already committed -- silently
+            # losing it is exactly the case the stamp exists for.
+            produced = self._read_raw_stamp(code, _VERSION_TAG)
+        # str(): TorchVersion.__eq__ PEP-440-parses its operand and re-raises anything
+        # that is not InvalidVersion, so a stamp of 4300+ digits took the whole load path
+        # down with a ValueError. Comparing text keeps a mangled stamp to a warning.
+        if produced is None or produced == str(torch.__version__):
+            return
+        log.warning(
+            "torch.compiler.export_python: the artifact at %s was produced by "
+            "torch %s but the current torch is %s; running it as-is. Delete %s "
+            "to regenerate against the current torch.",
+            self._path,
+            produced,
+            torch.__version__,
+            self._path,
+        )
+
+    def _load(self, code: str, *, from_disk: bool) -> Callable[..., Any]:
+        # The emitted source is self-contained: exec it directly (no cache, no
+        # precompile.load round-trip). A clobbered hand-edit (dropped forward / syntax
+        # error) and an environment or version mismatch (an import that fails under the
+        # current torch) surface as distinct, actionable PrecompileErrors rather than
+        # one catch-all "delete to regenerate".
+        from torch._precompile import _make_inlined_forward, PrecompileError
+
+        try:
+            if from_disk:
+                log.warning(
+                    "torch.compiler.export_python is about to EXEC the artifact at %s; "
+                    "the file is trusted executable Python and may have been edited or "
+                    "replaced since export. Only load paths whose contents you trust.",
+                    self._path,
+                )
+            return _make_inlined_forward(code, warn=False, filename=self._path)
+        except SyntaxError as e:
+            # Kernels are hoisted to module level, so Python reports a typo in one
+            # against this file at the right line. Say so: telling someone to delete an
+            # artifact they are midway through tuning is the wrong advice.
+            where = f" at line {e.lineno}" if e.lineno else ""
+            raise PrecompileError(
+                f"torch.compiler.export_python: the artifact at {self._path} does not "
+                f"parse{where}: {e.msg}. Fix it there, or delete the file to regenerate "
+                "from the original function."
+            ) from e
+        except KeyError as e:
+            raise PrecompileError(
+                f"torch.compiler.export_python: the artifact at {self._path} could "
+                "not be run as precompile source; it is not a valid "
+                "torch.compiler.precompile artifact (a hand-edit may have clobbered "
+                "it, e.g. dropping forward()). Delete it to regenerate."
+            ) from e
+        except ImportError as e:
+            raise PrecompileError(
+                f"torch.compiler.export_python: the artifact at {self._path} failed "
+                "to import a dependency; it was likely produced by a different torch "
+                f"version or environment. Delete {self._path} to regenerate against "
+                "the current torch."
+            ) from e
+        except Exception as e:
+            # A Triton kernel is compiled out of a cache file, so a syntax error in one
+            # is reported against an opaque /tmp/torchinductor_*/xx/yyy.py at a line
+            # number the reader cannot act on. Map it back to this artifact.
+            explanation = _explain_kernel_compile_error(code, self._path, e)
+            if explanation is not None:
+                raise PrecompileError(
+                    f"torch.compiler.export_python: {explanation}."
+                ) from e
+            raise PrecompileError(
+                "torch.compiler.export_python: an unexpected error occurred running "
+                f"the artifact at {self._path}. Delete it to regenerate."
+            ) from e
+
+    def _materialize(self, args: tuple[Any, ...]) -> Callable[..., Any]:
+        code = self._load_from_disk() if os.path.exists(self._path) else None
+        from_disk = code is not None
+        if code is None:
+            code, from_disk = self._precompile_and_save(args)
+        if from_disk:
+            self._warn_on_version_skew(code)
+        self._module_training = self._read_stamp(code, _MODULE_TRAINING_TAG)
+        self._input_overlaps = self._read_stamp(code, _INPUT_OVERLAP_TAG)
+        self._input_duplicates = self._read_stamp(code, _INPUT_DUPLICATE_TAG)
+        self._autocast = self._read_stamp(code, _AUTOCAST_TAG)
+        self._global_state = self._read_stamp(code, _GLOBAL_STATE_TAG)
+        self._code_devices = _code_devices(code)
+        entry = self._load(code, from_disk=from_disk)
+        self._example_inputs = None
+        self._decompositions = None
+        return entry
+
+    def _materialize_once(self, args: tuple[Any, ...]) -> Callable[..., Any]:
+        # Materialization runs under the one process-wide capture lock. Capture runs
+        # fn, which may call another decorated function, so any second lock taken
+        # around this would give two threads two orders to acquire them in and deadlock
+        # -- which is why the artifact holds no lock of its own.
+        import torch._precompile as precompile_impl
+
+        ident = (os.getpid(), threading.get_ident())
+        if self._materializing == ident:
+            raise _precompile_error(
+                "torch.compiler.export_python: re-entrant call into "
+                f"{getattr(self._fn, '__name__', 'fn')} while it is being precompiled. "
+                "A decorated function cannot call itself: capture would have to run "
+                "inside its own capture. Move the recursion into an undecorated helper."
+            )
+        with precompile_impl._CAPTURE_LOCK:
+            if self._loaded is None:
+                self._materializing = ident
+                try:
+                    self._loaded = self._materialize(args)
+                finally:
+                    self._materializing = None
+            return self._loaded
+
+    def _bind_positional(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        source: str = "the call arguments",
+    ) -> tuple[Any, ...]:
+        # The artifact's forward is positional (the precompile calling convention),
+        # so map any keyword call args onto fn's positional parameters -- this lets
+        # callers invoke the decorated fn naturally (e.g. rope(q=..., k=...)).
+        # Anything that cannot be laid out positionally is rejected below.
+        sig = self._call_signature
+        try:
+            bound = sig.bind(*args, **kwargs)
+        except TypeError as e:
+            raise TypeError(
+                f"torch.compiler.export_python: could not bind {source} to "
+                f"{getattr(self._fn, '__name__', 'fn')}'s signature: {e}"
+            ) from e
+        bound.apply_defaults()
+        # bound.kwargs holds every argument bind() could not place positionally. That
+        # is a keyword-only / **kwargs param (never positional), or a plain
+        # positional-or-keyword param passed by keyword while an earlier one was left
+        # to its default -- distinguish them so the error names the real cause.
+        if bound.kwargs:
+            params = sig.parameters
+            kw_only = sorted(
+                n
+                for n in bound.kwargs
+                if n in params and params[n].kind == inspect.Parameter.KEYWORD_ONLY
+            )
+            if kw_only:
+                raise TypeError(
+                    "torch.compiler.export_python does not support keyword-only "
+                    f"parameters (got {kw_only}); the precompile calling convention "
+                    "is positional."
+                )
+            # Names not declared as parameters were absorbed by a **kwargs param;
+            # they are never positional, so name **kwargs as the cause rather than
+            # misreporting them as a positional-or-keyword arg left to its default.
+            var_kw = sorted(n for n in bound.kwargs if n not in params)
+            if var_kw:
+                raise TypeError(
+                    "torch.compiler.export_python does not support **kwargs "
+                    f"parameters (got {var_kw}); the precompile calling convention "
+                    "is positional."
+                )
+            raise TypeError(
+                "torch.compiler.export_python could not place keyword arguments "
+                f"{sorted(bound.kwargs)} positionally because an earlier positional "
+                "parameter was left to its default; pass those arguments positionally "
+                "or provide example_inputs."
+            )
+        return bound.args
+
+    def _check_supported_args(self, args: tuple[Any, ...]) -> None:
+        params = list(self._call_signature.parameters)
+        for pos, arg in enumerate(args):
+            if isinstance(arg, torch.nn.Module):
+                continue
+            unsupported = [
+                leaf
+                for leaf in pytree.tree_leaves(arg)
+                if not isinstance(leaf, torch.Tensor)
+            ]
+            if not unsupported:
+                continue
+            name = params[pos] if pos < len(params) else f"argument {pos}"
+            # These two land often enough that the generic "close the constant over"
+            # advice is actively wrong for them: a module must stay an argument, and an
+            # optional parameter has no constant to close over in the first place.
+            if any(isinstance(leaf, torch.nn.Module) for leaf in unsupported):
+                raise TypeError(
+                    "torch.compiler.export_python: nn.Module arguments must be passed "
+                    f"directly, not nested inside a container (parameter {name!r}). "
+                    "Pass the module itself as its own positional argument."
+                )
+            if all(leaf is None for leaf in unsupported):
+                raise TypeError(
+                    "torch.compiler.export_python does not support None arguments "
+                    f"(parameter {name!r}); make_fx specializes the None branch without "
+                    "a runtime guard. Split the function, or pass a tensor."
+                )
+            raise TypeError(
+                "torch.compiler.export_python supports only Tensor pytrees and "
+                "nn.Module positional arguments; Python scalar/config values are "
+                "specialized by make_fx without runtime guards. Close constants "
+                f"over in the function instead of passing parameter {name!r} "
+                f"({unsupported[0]!r})."
+            )
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        args = self._bind_positional(args, kwargs)
+        self._check_supported_args(args)
+        loaded = self._loaded
+        if loaded is None:
+            loaded = self._materialize_once(args)
+        self._check_capture_environment(args)
+        self._check_module_training(args)
+        if not _check_enabled():
+            return loaded(*args)
+        # Copy BEFORE the call: the graph may mutate its inputs in place, and the eager
+        # reference has to see what the artifact saw rather than what it left behind.
+        try:
+            reference = copy.deepcopy(args)
+        except Exception:
+            log.warning(
+                "%s is set but the arguments to %s could not be deep-copied, so an "
+                "eager comparison would see whatever the artifact mutated. Skipping "
+                "the check for this call.",
+                _CHECK_ENV,
+                self._path,
+            )
+            return loaded(*args)
+        # Three states matter here. `before` is what the artifact saw; the reference run
+        # is rewound to it so a draw is not mistaken for a bad edit. `after` is what the
+        # caller must be left with -- restoring `before` instead would discard whatever
+        # the artifact consumed and freeze the caller's stream, so a random function
+        # would return the same numbers on every checked call.
+        before = torch.random.get_rng_state()
+        produced = loaded(*args)
+        after = torch.random.get_rng_state()
+        try:
+            torch.random.set_rng_state(before)
+            _verify_against_eager(
+                self._fn, args, reference, produced, self._path, before
+            )
+        finally:
+            torch.random.set_rng_state(after)
+        return produced
+
+
+def export_python(
+    *,
+    path: str,
+    backend: str = "inductor",
+    tracer: str = "make_fx",
+    decompositions: dict | None = None,
+    example_inputs: Sequence[object] | None = None,
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    """See :func:`torch.compiler.export_python`."""
+
+    def decorator(fn: Callable[_P, _R]) -> Callable[_P, _R]:
+        artifact = ExportedPythonArtifact(
+            fn,
+            path=path,
+            backend=backend,
+            tracer=tracer,
+            decompositions=decompositions,
+            example_inputs=example_inputs,
+        )
+
+        @functools.wraps(fn)
+        def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            return cast("_R", artifact(*args, **kwargs))
+
+        return wrapped
+
+    return decorator

--- a/torch/compiler/_export_python.py
+++ b/torch/compiler/_export_python.py
@@ -1,0 +1,569 @@
+"""Path-cached ``torch.compiler.export_python`` decorator.
+
+``torch.compiler.precompile`` captures a function ahead of time and lowers it to a
+self-contained, human-readable Python source artifact (see
+``torch/_precompile.py``). ``torch.compiler.export_python`` wraps that in a
+decorator keyed off a file on disk: the first run writes the emitted
+``python_code`` to ``path``; every later run reads the ``.py`` back and executes
+it directly instead of recompiling.
+
+Because the artifact is self-contained, re-executable Python, ``path`` is meant to
+be committed and hand-edited: an engineer or agent can "hill-climb" the generated
+kernel in place. This is ejectable compilation -- the emitted source is the source
+of truth and is always exec'd, so hand edits always take effect. There is no
+acceleration cache and no ``precompile.load`` round-trip: the source is exec'd as
+written, so keeping the edited source correct is the caller's responsibility.
+"""
+
+import copy
+import functools
+import inspect
+import logging
+import operator
+import os
+import tempfile
+import threading
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import torch
+import torch.utils._pytree as pytree
+
+
+log = logging.getLogger(__name__)
+
+# Written as the artifact's first line so a later load can detect it was produced
+# by a different torch (see _warn_on_version_skew). It is a comment, so it does not
+# affect exec; a hand-edit that drops it just disables the skew warning, so
+# hill-climbing an artifact never triggers a spurious version warning.
+_VERSION_TAG = "# torch.compiler.export_python torch-version: "
+
+
+def _atomic_write(path: str, data: bytes) -> None:
+    # Write to a temp file in the same directory, fsync it, then rename it into
+    # place. os.replace is atomic, so an interrupted or concurrent writer never
+    # leaves a half-written artifact that the presence-only load gate would read
+    # as valid.
+    dir_name = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=dir_name)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        # mkstemp creates the temp file 0600 and os.replace preserves that mode,
+        # but this artifact is meant to be committed and hand-edited, so it needs
+        # conventional world-readable perms rather than the private tempfile mode.
+        os.chmod(tmp, 0o644)
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        raise
+
+
+# The buffer-donation contract, stated once here because out= is the one part of
+# export_python that needs anything of the artifact beyond "it is runnable python":
+#
+#   An artifact supports out= iff it takes every buffer it allocates from a callable
+#   bound at module level in its own namespace under a name starting with
+#   _ALLOCATOR_PREFIX. Rebinding those names is then enough to hand the generated code
+#   memory instead of letting it allocate (see _BufferDonationPool).
+#
+# Nothing here is keyed on the backend: an artifact that meets the contract donates,
+# one that does not is rejected at the first out= call. The inductor backend meets it
+# by binding one allocator per device type (empty_strided_cuda, empty_strided_cpu,
+# empty_strided_cpu_pinned, ...) regardless of which the graph uses; the eager backend
+# emits a bare graph call and binds none. Allocators are matched by prefix rather than
+# by an explicit list because the pool replays allocations BY ORDER: missing one
+# device's allocator would desync the whole plan rather than fail. Both halves of that
+# are pinned by tests -- test_allocator_prefix_matches_codegen_call_sites checks every
+# allocator inductor's codegen can emit, and test_pool_intercepts_every_artifact_allocator
+# checks every one a real artifact binds.
+_ALLOCATOR_PREFIX = "empty_strided"
+
+
+def _precompile_error(msg: str) -> Exception:
+    from torch._precompile import PrecompileError
+
+    return PrecompileError(msg)
+
+
+class _BufferDonationPool:
+    """Serves the artifact's buffer allocations when the caller donates outputs.
+
+    Takes the artifact as satisfying the donation contract above ``_ALLOCATOR_PREFIX``:
+    every buffer comes from a module-level allocator in its own namespace, so rebinding
+    those names is enough to hand it memory rather than let it allocate. The first
+    donating call records the ordered requests and which of them come back as graph
+    outputs; later donating calls replay that recording, serving scratch buffers from
+    the pool and outputs from the caller, so a steady-state donating call allocates
+    nothing.
+
+    Calls that do not donate go straight through to the real allocator, so adding an
+    ``out=`` call site never changes what the plain call path does.
+    """
+
+    def __init__(self, ns: dict[str, Any]) -> None:
+        allocators = [
+            n for n, v in ns.items() if n.startswith(_ALLOCATOR_PREFIX) and callable(v)
+        ]
+        if not allocators:
+            raise _precompile_error(
+                "torch.compiler.export_python: out= needs the artifact to allocate its "
+                f"buffers through {_ALLOCATOR_PREFIX}* callables bound in its own "
+                "namespace, and this one binds none (backend='eager' emits a bare graph "
+                "call). Use backend='inductor', or drop out=."
+            )
+        # Every device's allocator is wrapped, each keeping its OWN real function: the
+        # preamble binds all of them regardless of which the graph uses, and falling
+        # back through the wrong one would hand a CPU kernel device memory.
+        for name in allocators:
+            ns[name] = functools.partial(self._alloc, ns[name])
+        self.recorded = False
+        # (buffer, -1) for a pooled scratch slot, (None, position) for one the caller
+        # donates. Replayed in allocation order, which the specialized graph fixes.
+        self._plan: list[tuple[torch.Tensor | None, int]] = []
+        self._slots: list[torch.Tensor] = []
+        self._recording = False
+        self._donated: Sequence[torch.Tensor] | None = None
+        self._i = 0
+
+    def _alloc(
+        self, real: Callable[..., torch.Tensor], *args: Any, **kwargs: Any
+    ) -> torch.Tensor:
+        if self._recording:
+            buf = real(*args, **kwargs)
+            self._slots.append(buf)
+            return buf
+        if self._donated is None:
+            return real(*args, **kwargs)
+        i = self._i
+        self._i = i + 1
+        try:
+            buf, pos = self._plan[i]
+        except IndexError:
+            # The graph is shape-specialized, so the recorded request sequence is
+            # fixed; anything past it is not something to serve from the plan.
+            return real(*args, **kwargs)
+        return self._donated[pos] if pos >= 0 else buf  # type: ignore[return-value]
+
+    def record(
+        self, call: Callable[[list[Any]], Any], args: list[Any], out: Sequence[Any]
+    ) -> list[Any]:
+        """Run one recording call, then fix the plan and validate the donated tensors."""
+        self._recording = True
+        try:
+            outs = list(call(args))
+        finally:
+            self._recording = False
+        if len(out) != len(outs):
+            raise _precompile_error(
+                f"torch.compiler.export_python: out= has {len(out)} tensors but the "
+                f"artifact returns {len(outs)}."
+            )
+        slot_of = {id(t): i for i, t in enumerate(self._slots)}
+        out_slot: dict[int, int] = {}
+        for pos, produced in enumerate(outs):
+            i = slot_of.get(id(produced))
+            if i is None:
+                raise _precompile_error(
+                    f"torch.compiler.export_python: output {pos} is not a buffer the "
+                    "artifact allocates (it is a view of one, or an input passed "
+                    "through), so it cannot be donated. Drop out= for this artifact."
+                )
+            out_slot[i] = pos
+            _check_donor(out[pos], produced, pos)
+        # The plan holds the scratch buffers from here on, and holds no reference to
+        # the output slots (the caller owns those), so the recording list goes away.
+        self._plan = [
+            (None, out_slot[i]) if i in out_slot else (buf, -1)
+            for i, buf in enumerate(self._slots)
+        ]
+        self._slots = []
+        self.recorded = True
+        # This one call allocated its own outputs, so the donated tensors have to be
+        # filled by hand. Every later donating call writes into them directly.
+        for donor, produced in zip(out, outs):
+            donor.copy_(produced)
+        return list(out)
+
+    def begin(self, donated: Sequence[torch.Tensor]) -> None:
+        self._i = 0
+        self._donated = donated
+
+    def end(self) -> None:
+        self._donated = None
+
+    def check_complete(self) -> None:
+        # The plan is replayed by allocation ORDER, so a call that asked for a
+        # different number of buffers than was recorded served the wrong memory. That
+        # cannot happen for a shape-specialized graph, but if it ever does it must be
+        # loud on the first donating call rather than quietly wrong forever. Checked
+        # only after a call that returned, so it never masks a real exception.
+        if self._i != len(self._plan):
+            raise _precompile_error(
+                "torch.compiler.export_python: the donated call requested "
+                f"{self._i} buffers but {len(self._plan)} were recorded; the buffer "
+                "donation plan is out of sync. Drop out= for this artifact."
+            )
+
+
+def _check_donor(donor: Any, produced: torch.Tensor, pos: int) -> None:
+    # Checked once, on the recording call. Afterwards a donated tensor is written to
+    # by a kernel with baked sizes and strides, so a later mismatch is undefined
+    # behavior -- the same contract as the rest of unsafe_reduce_overhead.
+    if (
+        not isinstance(donor, torch.Tensor)
+        or donor.shape != produced.shape
+        or donor.stride() != produced.stride()
+        or donor.dtype != produced.dtype
+        or donor.device != produced.device
+    ):
+        raise _precompile_error(
+            f"torch.compiler.export_python: out[{pos}] must be a tensor matching the "
+            f"artifact's output exactly (shape {tuple(produced.shape)}, stride "
+            f"{produced.stride()}, {produced.dtype}, {produced.device}); got {donor!r}."
+        )
+
+
+def _lean_entry(forward: Callable[..., Any]) -> Callable[..., Any] | None:
+    """Bind the artifact's compiled ``call`` directly, skipping the driver's guards.
+
+    The emitted ``forward`` spends most of its time re-verifying the precompile
+    invariants on every call (pytree round-trip, per-input shape/dtype/device guards,
+    module structure). Everything it guards is fixed at capture, so a caller that
+    accepts the invariants can call the compiled ``call`` directly. Returns None when
+    the driver is doing real marshalling rather than checking -- an ``nn.Module``
+    argument to lift params out of, a gradient to scatter, or an input/output
+    structure that is not a flat sequence of leaves -- in which case there is nothing
+    safe to strip and the caller keeps ``forward``.
+    """
+    # forward was exec'd into the artifact's own module namespace, so its __globals__
+    # IS that namespace: the composed ``call`` and the baked calling convention are
+    # reachable through it without re-exec'ing or re-parsing the source.
+    ns = forward.__globals__
+    if ns.get("MODULE_POSITIONS") or ns.get("GRAD_PARAM_INDICES"):
+        return None
+    try:
+        # ``call`` is AOTAutograd's composed entry point, NOT the raw inductor one:
+        # it still reflects input mutation, unwraps subclasses and disables grad. Only
+        # the precompile driver's guards are dropped, never AOTAutograd's semantics.
+        call = ns["call"]
+        in_spec_str, out_spec_str = ns["IN_SPEC"], ns["OUT_SPEC"]
+    except KeyError:
+        return None
+    if in_spec_str is None or out_spec_str is None:
+        return None
+    in_spec = pytree.treespec_loads(in_spec_str)
+    if in_spec.type is not tuple or not all(c.is_leaf() for c in in_spec.children()):
+        return None
+    out_spec = pytree.treespec_loads(out_spec_str)
+    if out_spec.is_leaf():
+        rebuild: Callable[[list[Any]], Any] = operator.itemgetter(0)
+    elif out_spec.type in (tuple, list) and all(
+        c.is_leaf() for c in out_spec.children()
+    ):
+        rebuild = out_spec.type
+    else:
+        return None
+    num_args = in_spec.num_children
+    set_grad, grad_enabled = torch._C._set_grad_enabled, torch.is_grad_enabled
+    pool: _BufferDonationPool | None = None
+
+    def lean_forward(*args: Any, out: Sequence[torch.Tensor] | None = None) -> Any:
+        nonlocal pool
+        # Arity is checked because it costs ~30ns and the alternative is an unpack
+        # ValueError raised from generated source. Nothing else is: shapes, dtypes,
+        # devices and layouts are the caller's responsibility in this mode.
+        if len(args) != num_args:
+            raise _precompile_error(
+                f"precompile: expected {num_args} positional args (the same as the "
+                f"traced fn), got {len(args)}."
+            )
+        if out is not None and pool is None:
+            pool = _BufferDonationPool(ns)
+        # forward runs the call under no_grad and an eager-backend ``call`` is a bare
+        # graph call, so grad has to be disabled here too -- but with the C setter, as
+        # the torch.no_grad context manager costs more than everything else here.
+        grad = grad_enabled()
+        if grad:
+            set_grad(False)
+        try:
+            if out is None:
+                return rebuild(call(list(args)))
+            if not pool.recorded:  # type: ignore[union-attr]
+                return rebuild(pool.record(call, list(args), out))  # type: ignore[union-attr]
+            pool.begin(out)  # type: ignore[union-attr]
+            try:
+                result = rebuild(call(list(args)))
+            finally:
+                pool.end()  # type: ignore[union-attr]
+            pool.check_complete()  # type: ignore[union-attr]
+            return result
+        finally:
+            if grad:
+                set_grad(True)
+
+    return lean_forward
+
+
+class ExportedPythonArtifact:
+    """Materializes and disk-caches a ``torch.compiler.precompile`` artifact.
+
+    Materialization is lazy and happens on the first call: if ``path`` exists the
+    emitted Python is read from disk, otherwise the wrapped ``fn`` is precompiled
+    against the example inputs and the emitted source is written to disk. Either
+    way the source is exec'd directly to build the runnable. The loaded callable is
+    reused for all subsequent calls in the process; a later process re-reads
+    whatever is on disk.
+    """
+
+    def __init__(
+        self,
+        fn: Callable[..., Any],
+        *,
+        path: str,
+        backend: str,
+        tracer: str,
+        decompositions: dict | None,
+        example_inputs: Sequence[object] | None,
+        unsafe_reduce_overhead: bool = False,
+    ) -> None:
+        self._fn = fn
+        self._signature = inspect.signature(fn)
+        self._path = path
+        self._backend = backend
+        self._tracer = tracer
+        self._decompositions = decompositions
+        self._example_inputs = None if example_inputs is None else tuple(example_inputs)
+        self._unsafe_reduce_overhead = unsafe_reduce_overhead
+        # Whether the lean entry point (the one that accepts out=) is what got bound;
+        # unsafe_reduce_overhead can fall back to the checked forward at load time.
+        self._lean_bound = False
+        self._loaded: Callable[..., Any] | None = None
+        self._lock = threading.Lock()
+        functools.update_wrapper(self, fn)
+
+    def _precompile_and_save(self, args: tuple[Any, ...]) -> str:
+        example = self._example_inputs
+        if example is None:
+            # Capture runs fn once on the example inputs (real-mode make_fx), which
+            # mutates them; deep-copy the live call args so capture side effects (in-
+            # place input mutation, module buffer updates) do not leak onto the
+            # caller before the artifact itself runs on the real args exactly once.
+            try:
+                example = copy.deepcopy(args)
+            except Exception as e:
+                from torch._precompile import PrecompileError
+
+                raise PrecompileError(
+                    "torch.compiler.export_python could not deep-copy the "
+                    "first-call arguments to capture without mutating them (e.g. a "
+                    "non-leaf tensor or a weight_norm module). Pass explicit "
+                    "example_inputs=... to precompile against dedicated inputs."
+                ) from e
+        # precompile returns (python_code, cache); the cache is an acceleration
+        # artifact that export_python does not use -- the emitted source is
+        # self-contained and always exec'd -- so only the code is written to disk.
+        code, _cache = torch.compiler.precompile(
+            self._fn,
+            *example,
+            backend=self._backend,
+            tracer=self._tracer,
+            decompositions=self._decompositions,
+        )
+        parent = os.path.dirname(self._path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        # Stamp the producing torch version as the artifact's first line so a load
+        # by a different torch can warn about the skew. It is a comment (exec-inert)
+        # and a hand-edit may freely drop it (see _warn_on_version_skew).
+        code = f"{_VERSION_TAG}{torch.__version__}\n{code}"
+        # The write is atomic, so two first-call processes that both pass the
+        # presence gate each write a complete, self-contained artifact and the last
+        # rename wins; neither leaves a half-written file behind the gate.
+        _atomic_write(self._path, code.encode("utf-8"))
+        return code
+
+    def _load_from_disk(self) -> str:
+        with open(self._path, encoding="utf-8") as f:
+            return f.read()
+
+    def _warn_on_version_skew(self, code: str) -> None:
+        # Warn (but still run) when the artifact carries a version stamp that does
+        # not match the current torch, so a committed artifact gone stale across a
+        # torch upgrade is visible rather than silently running old logic. A missing
+        # stamp (dropped by a hand-edit) is silent, so hill-climbing never warns.
+        first_line = code.split("\n", 1)[0]
+        if not first_line.startswith(_VERSION_TAG):
+            return
+        produced = first_line[len(_VERSION_TAG) :].strip()
+        if produced != torch.__version__:
+            log.warning(
+                "torch.compiler.export_python: the artifact at %s was produced by "
+                "torch %s but the current torch is %s; running it as-is. Delete %s "
+                "to regenerate against the current torch.",
+                self._path,
+                produced,
+                torch.__version__,
+                self._path,
+            )
+
+    def _load(self, code: str) -> Callable[..., Any]:
+        # The emitted source is self-contained: exec it directly (no cache, no
+        # precompile.load round-trip) and without the untrusted-exec warning, since
+        # export_python only ever loads artifacts it produced. A clobbered hand-edit
+        # (dropped forward / syntax error) and an environment or version mismatch (an
+        # import that fails under the current torch) surface as distinct, actionable
+        # PrecompileErrors rather than one catch-all "delete to regenerate".
+        from torch._precompile import _make_inlined_forward, PrecompileError
+
+        try:
+            return _make_inlined_forward(code, warn=False)
+        except (SyntaxError, KeyError) as e:
+            raise PrecompileError(
+                f"torch.compiler.export_python: the artifact at {self._path} could "
+                "not be run as precompile source; it is not a valid "
+                "torch.compiler.precompile artifact (a hand-edit may have clobbered "
+                "it, e.g. dropping forward()). Delete it to regenerate."
+            ) from e
+        except ImportError as e:
+            raise PrecompileError(
+                f"torch.compiler.export_python: the artifact at {self._path} failed "
+                "to import a dependency; it was likely produced by a different torch "
+                f"version or environment. Delete {self._path} to regenerate against "
+                "the current torch."
+            ) from e
+        except Exception as e:
+            raise PrecompileError(
+                "torch.compiler.export_python: an unexpected error occurred running "
+                f"the artifact at {self._path}. Delete it to regenerate."
+            ) from e
+
+    def _materialize(self, args: tuple[Any, ...]) -> Callable[..., Any]:
+        if os.path.exists(self._path):
+            code = self._load_from_disk()
+            self._warn_on_version_skew(code)
+        else:
+            code = self._precompile_and_save(args)
+        forward = self._load(code)
+        if not self._unsafe_reduce_overhead:
+            return forward
+        # A fallback is a warning rather than an error: the artifact still runs, the
+        # flag just bought nothing, and failing a working call over a missed
+        # optimization would be worse than saying so.
+        lean = _lean_entry(forward)
+        if lean is None:
+            log.warning(
+                "torch.compiler.export_python: unsafe_reduce_overhead=True had no "
+                "effect for %s; its calling convention needs the artifact's driver (an "
+                "nn.Module argument, a gradient to scatter, or a non-flat input/output "
+                "structure). Running the checked entry point.",
+                self._path,
+            )
+            return forward
+        self._lean_bound = True
+        return lean
+
+    def _bind_positional(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> tuple[Any, ...]:
+        # The artifact's forward is positional (the precompile calling convention),
+        # so map any keyword call args onto fn's positional parameters -- this lets
+        # callers invoke the decorated fn naturally (e.g. rope(q=..., k=...)).
+        # Anything that cannot be laid out positionally is rejected below.
+        sig = self._signature
+        try:
+            bound = sig.bind(*args, **kwargs)
+        except TypeError as e:
+            raise TypeError(
+                "torch.compiler.export_python: could not bind the call arguments to "
+                f"{getattr(self._fn, '__name__', 'fn')}'s signature: {e}"
+            ) from e
+        # bound.kwargs holds every argument bind() could not place positionally. That
+        # is a keyword-only / **kwargs param (never positional), or a plain
+        # positional-or-keyword param passed by keyword while an earlier one was left
+        # to its default -- distinguish them so the error names the real cause.
+        if bound.kwargs:
+            params = sig.parameters
+            kw_only = sorted(
+                n
+                for n in bound.kwargs
+                if n in params and params[n].kind == inspect.Parameter.KEYWORD_ONLY
+            )
+            if kw_only:
+                raise TypeError(
+                    "torch.compiler.export_python does not support keyword-only "
+                    f"parameters (got {kw_only}); the precompile calling convention "
+                    "is positional."
+                )
+            # Names not declared as parameters were absorbed by a **kwargs param;
+            # they are never positional, so name **kwargs as the cause rather than
+            # misreporting them as a positional-or-keyword arg left to its default.
+            var_kw = sorted(n for n in bound.kwargs if n not in params)
+            if var_kw:
+                raise TypeError(
+                    "torch.compiler.export_python does not support **kwargs "
+                    f"parameters (got {var_kw}); the precompile calling convention "
+                    "is positional."
+                )
+            raise TypeError(
+                "torch.compiler.export_python could not place keyword arguments "
+                f"{sorted(bound.kwargs)} positionally because an earlier positional "
+                "parameter was left to its default; pass those arguments positionally "
+                "or provide example_inputs."
+            )
+        return bound.args
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        # out= is intercepted before signature binding: it is export_python's own
+        # calling convention, not one of fn's parameters, so binding it onto fn would
+        # report it as an unexpected keyword.
+        out = kwargs.pop("out", None)
+        if out is not None and not self._unsafe_reduce_overhead:
+            raise TypeError(
+                "torch.compiler.export_python: out= requires "
+                "unsafe_reduce_overhead=True; the checked entry point allocates its "
+                "own outputs."
+            )
+        if kwargs:
+            args = self._bind_positional(args, kwargs)
+        if self._loaded is None:
+            with self._lock:
+                if self._loaded is None:
+                    self._loaded = self._materialize(args)
+        if out is None:
+            return self._loaded(*args)
+        if not self._lean_bound:
+            raise TypeError(
+                "torch.compiler.export_python: out= is not available for this "
+                "artifact; unsafe_reduce_overhead had no effect for its calling "
+                "convention (see the warning logged on load)."
+            )
+        return self._loaded(*args, out=out)
+
+
+def export_python(
+    *,
+    path: str,
+    backend: str = "inductor",
+    tracer: str = "make_fx",
+    decompositions: dict | None = None,
+    example_inputs: Sequence[object] | None = None,
+    unsafe_reduce_overhead: bool = False,
+) -> Callable[[Callable[..., Any]], ExportedPythonArtifact]:
+    """See :func:`torch.compiler.export_python`."""
+
+    def decorator(fn: Callable[..., Any]) -> ExportedPythonArtifact:
+        return ExportedPythonArtifact(
+            fn,
+            path=path,
+            backend=backend,
+            tracer=tracer,
+            decompositions=decompositions,
+            example_inputs=example_inputs,
+            unsafe_reduce_overhead=unsafe_reduce_overhead,
+        )
+
+    return decorator


### PR DESCRIPTION
`torch.compiler.export_python` wraps `torch.compiler.precompile` in a decorator keyed by a readable Python artifact on disk. The first call captures and lowers the decorated function, publishes the self-contained source, and runs it; every later call, in every later process, `exec`s that file.

```python
@torch.compiler.export_python(path="kernels/attn.py")
def attn(q, k, v):
    ...
```

## What this is for

**Hill climbing on generated kernels, and convenient kernel generation — not deployment.**

The emitted file is the source of truth and is always `exec`'d, so you can open it, retune a block size or a schedule, rerun, and your edit takes effect immediately. No recapture, no cache to defeat. The result is ordinary source that can be committed, diffed and reviewed.

That is the whole motivation, and the design follows from it rather than from a safety story.

## The central tradeoff: the artifact is sticky

`path` is the entire cache key. Nothing hashes `fn`'s body, the ambient config, or the machine.

That is **deliberate**: an artifact that re-captured whenever something changed would throw away your edits, which would defeat the point. The cost is real and worth stating plainly — **edit `fn`, rerun, and you get the old compiled code with no warning.** Delete the path to recapture.

Six comment stamps catch the ambient changes most likely to change the answer silently (module train/eval, input aliasing, duplicate input objects, autocast, and the globals the code generator resolves against). They are a **backstop, not a guarantee**: the set of things a generated kernel bakes is longer than the set that is checked.

So for the iteration loop there is an explicit verifier:

```bash
COMPILER_EXPORT_PYTHON_CHECK=1 python train.py
```

Every call then re-runs `fn` eagerly on a deep copy of the same inputs and compares, raising with the max absolute and relative difference if they diverge. Inputs are copied before the call because the graph may mutate them; the generators are rewound so a draw is not mistaken for an edit; and a `fn` that draws is skipped with a warning rather than reported as broken, since inductor's philox differs from eager's at the same seed by design. It doubles the per-call work — it is a debug mode, and it is the intended way to know an edit is safe.

## What was deliberately removed

**Buffer donation (`out=` / `unsafe_reduce_overhead`)** was implemented and then taken back out. It is a deployment-throughput feature with no bearing on hill climbing or kernel generation; it was the largest and most dangerous part of the implementation; and measurement showed it to be a net per-call *slowdown* for the shapes in the docstring's own example. Removing it deleted roughly 40% of the module and every memory-safety hazard that lived there.

Separately: inductor can emit the same `async_compile.triton` block twice under one name, and the later assignment wins. In a file whose purpose is being hand-edited that is the worst possible failure — you tune the first kernel you find and nothing happens — so byte-identical shadowed blocks are now dropped before publishing.

## Review order

1. `torch/compiler/__init__.py` — the public contract, motivation and tradeoff.
2. `torch/compiler/_export_python.py` — artifact lifecycle, the stamps, the verifier.
3. `torch/_precompile.py` — capture, RNG restore, the capture lock.
4. `test/test_precompile.py` — device-generic coverage.

## Known limitations

None of these are addressed here, and a reviewer should know them rather than discover them:

- A tensor subclass's inner shapes and a DTensor's placements are unrecorded, so a resharded input silently runs against capture's baked local shapes.
- `path` is not rank-aware, and a DTensor artifact hardcodes the c10d process-group name.
- A closed-over `torch.Generator` or torchbind object produces an artifact that can never bind it.
- An artifact is valid only on the machine type that produced it. Loading under a *wider* CPU ISA writes past the end of the output; under a *narrower* one it leaves part of the output uninitialized. Neither raises. `cpp.simdlen` and `ATEN_CPU_CAPABILITY` count as machine type.
- The per-call guard costs a multiple of the guarded work on small graphs.
- Stamp-missing warnings are not latched; a dangling symlink at `path` is misdiagnosed; a non-UTF-8 byte escapes as `UnicodeDecodeError`.

## Testing

```bash
python test/test_precompile.py
```

```bash
COMPILER_EXPORT_PYTHON_CHECK=1 python test/test_precompile.py
```

GLOO is present in this build, but an editable install registers no `torch.distributed.backends` entry point, so `init_process_group("gloo")` cannot resolve the name and two DTensor tests error locally. Registering it first makes the file pass — **321 tests, OK**:

```bash
python -c "import torch.distributed.distributed_c10d as c; c._register_builtin_gloo_backend(); import runpy, sys; sys.argv=['test/test_precompile.py']; runpy.run_path('test/test_precompile.py', run_name='__main__')"
```

Coverage was checked by mutation: reverting each fix to the code it replaced fails a test, verified against the actual prior revision rather than an invented weakening.

---

Developed with the assistance of an AI coding assistant.
