### PR TITLE
[Inductor] Preserve positional args in pre-grad batch math fusion

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -280,8 +280,8 @@ class _TestMathOps(torch.nn.Module):
         others = [x.to(self.device) for i in range(10)]
         clamp_input = [x.clamp(min=-1000.1, max=1000.1) for x in inputs]
         clamp_other = [x.clamp(min=-1000.1, max=1000.1) for x in others]
-        nan_to_num_input = [torch.nan_to_num(x, 0.0) for x in clamp_input]
-        nan_to_num_other = [torch.nan_to_num(x, 0.0) for x in clamp_other]
+        nan_to_num_input = [torch.nan_to_num(x, 7.0) for x in clamp_input]
+        nan_to_num_other = [torch.nan_to_num(x, 7.0) for x in clamp_other]
         detach_input = [x.detach() for x in nan_to_num_input]
         detach_other = [x.detach() for x in nan_to_num_other]
         stack_input = torch.stack(detach_input, dim=0)
@@ -758,6 +758,24 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(counters["inductor"]["unbind_stack_to_slices_pass"], 2)
         self.assertEqual(counters["inductor"]["unbind_stack_pass"], 2)
         self.assertTrue(torch.allclose(ref, res))
+        counters.clear()
+
+    @config.patch(
+        is_predispatch=True,
+        pre_grad_fusion_options={"batch_clamp": {}},
+    )
+    def test_math_op_fusion_predispatch_positional_args(self):
+        counters.clear()
+
+        def fn(x):
+            return torch.stack(
+                [torch.clamp(x + i, -1.0, 1.0) for i in range(5)]
+                + [torch.clamp(x + i, 0.0, 2.0) for i in range(5, 10)]
+            )
+
+        x = torch.randn(8)
+        self.assertEqual(fn(x), torch.compile(fn, fullgraph=True)(x))
+        self.assertEqual(counters["inductor"]["batch_clamp"], 2)
         counters.clear()
 
     @requires_gpu()

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -1326,6 +1326,7 @@ class BatchMathOpsPreGradFusion(BatchPointwiseOpsFusionFactory):
             child = next(iter(node.users.keys()))
             group_key = (
                 str(input.meta["example_value"].shape)
+                + str(node.args[1:])
                 + str(node.kwargs)
                 + str(child.target)
             )
@@ -1340,6 +1341,7 @@ class BatchMathOpsPreGradFusion(BatchPointwiseOpsFusionFactory):
         batch_nodes = []
         batch_inputs = []
         batch_inputs_metadata = []
+        args = subset[0].args[1:]
         kwargs = subset[0].kwargs
 
         for node in subset:
@@ -1355,11 +1357,11 @@ class BatchMathOpsPreGradFusion(BatchPointwiseOpsFusionFactory):
             update_stack_example_value(stack_inputs, batch_inputs_metadata)
             batch_op = graph.call_function(  # type: ignore[operator]
                 self.op,
-                args=(stack_inputs,),
+                args=(stack_inputs, *args),
                 kwargs=kwargs,
             )
             batch_op.meta["example_value"] = self.op(
-                stack_inputs.meta["example_value"], **kwargs
+                stack_inputs.meta["example_value"], *args, **kwargs
             )
             unbind_op = graph.call_function(  # type: ignore[operator]
                 torch.unbind, args=(batch_op,), kwargs={"dim": 0}


### PR DESCRIPTION
Summary:
BatchMathOpsPreGradFusion currently groups only keyword arguments, and ignores positional arguments. For models that use positional arguments for ops like torch.clamp and torch.nan_to_num, this can lead to dropped parameters/errors. An error we recently encountered on an internal model is 
`BackendCompilerFailed: backend='inductor' raised:\nValueError: clamp called but both min and max are none!` due to positional min and max arguments of torch.clamp being dropped

In this diff we include positional arguments in both the fusion group key and the batched call. Add regression coverage for positional clamp bounds and distinct bound groups.

This allows us to use positional arguments for the following 4 ops:
* torch.detach(input) (no change)
* torch.clamp(input, min, max)
*  torch.nan_to_num(input, nan, posinf, neginf)
* torch.nn.functional.dropout(input, p, training, inplace)

Test Plan:
- buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/inductor:group_batch_fusion -- test_math_op_fusion_predispatch_positional_args
- buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/inductor:group_batch_fusion -- test_math_op_fusion
- arc lint --never-apply-patches fbcode/caffe2/torch/_inductor/fx_passes/group_batch_fusion.py fbcode/caffe2/test/inductor/test_group_batch_fusion.py

Differential Revision: D113485896




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo