### PR TITLE
[CUDA] Restore scale_result for float8 _scaled_mm output

### DIFF
--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -384,8 +384,17 @@ _scaled_gemm(
           const std::optional<Tensor>& bias,
           const bool use_fast_accum,
           Tensor& out,
+          const std::optional<Tensor>& scale_result = std::nullopt,
           const std::optional<Tensor>& alpha = std::nullopt) {
-  cublasCommonArgs args(mat1, mat2, out, scale_a, scale_b, std::nullopt, scaling_choice_a, scaling_choice_b);
+  cublasCommonArgs args(
+      mat1,
+      mat2,
+      out,
+      scale_a,
+      scale_b,
+      isFloat8Type(out.scalar_type()) ? scale_result : std::nullopt,
+      scaling_choice_a,
+      scaling_choice_b);
   const auto out_dtype_ = args.result->scalar_type();
   // H100 only supports row-major x column-major, but all permutaitons are supported on Blackwells
   if (_scaled_mm_allowed_device(true, false)) {
@@ -662,7 +671,7 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
 #endif
   }
 
-  return _scaled_gemm(mat1, mat2, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out);
+  return _scaled_gemm(mat1, mat2, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out, scale_result);
 }
 
 Tensor
@@ -1241,7 +1250,7 @@ _scaled_nvfp4_nvfp4(
 
   auto scaling_choice_a = ScalingType::BlockWise1x16;
   auto scaling_choice_b = ScalingType::BlockWise1x16;
-  return _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, false /* use_fast_accum */, out, alpha);
+  return _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, false /* use_fast_accum */, out, std::nullopt, alpha);
 #else
   TORCH_CHECK_NOT_IMPLEMENTED(false, "NVFP4 scaling not supported on ROCM");
 #endif

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -732,6 +732,45 @@ class TestFP8Matmul(TestCase):
         out_fp8_s = scaled_mm_wrap(x, y, scale_a=scale_a, scale_b=scale_b)
         self.assertEqual(out_fp8, out_fp8_s)
 
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    def test_float8_scale_result(self, device) -> None:
+        torch.manual_seed(0)
+        a = torch.randint(-1, 2, (32, 16), device=device).float().to(e4m3_type)
+        b = torch.randint(-1, 2, (16, 32), device=device).float().t().contiguous().t().to(e4m3_type)
+        scale = torch.ones((), device=device)
+        scale_result = torch.full((), 0.5, device=device)
+
+        actual = torch._scaled_mm(
+            a,
+            b,
+            scale_a=scale,
+            scale_b=scale,
+            scale_result=scale_result,
+            out_dtype=e4m3_type,
+        )
+        expected = (a.float() @ b.float()).mul(scale_result).to(e4m3_type)
+
+        self.assertEqual(actual, expected)
+
+        high_precision = torch._scaled_mm(
+            a,
+            b,
+            scale_a=scale,
+            scale_b=scale,
+            scale_result=scale_result,
+            out_dtype=torch.bfloat16,
+        )
+        unscaled = torch._scaled_mm(
+            a,
+            b,
+            scale_a=scale,
+            scale_b=scale,
+            out_dtype=torch.bfloat16,
+        )
+        self.assertEqual(high_precision, unscaled)
+
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM, mxfp8_grouped_mm_skip_msg)
     @parametrize("G", [1, 4, 16])


### PR DESCRIPTION
## Human Note
This one is pretty self contained, we stopped passing the scale_result correclty when output is float8

## Agent Report
# CUDA `_scaled_mm` float8 output scaling fix

## Summary

`torch._scaled_mm(..., out_dtype=torch.float8_e4m3fn, scale_result=s)` silently ignored `scale_result`. On the original build, outputs for scales 1.0 and 0.5 were bitwise identical, with maximum error 4.5 against the exactly representable `0.5 * reference` result.

The fix restores `scale_result` forwarding for float8 output while preserving the documented behavior that BF16, FP16, and FP32 output does not apply it.

## Root cause

`_scaled_mm_out_cuda` validated `scale_result` but dropped it when calling `_scaled_gemm`. `_scaled_gemm` then constructed `cublasCommonArgs` with `std::nullopt`, leaving `args.scale_result_ptr` null. Consequently, `at::cuda::blas::scaled_gemm` never set `CUBLASLT_MATMUL_DESC_D_SCALE_POINTER`.

This dataflow was lost during the v1/v2 scaled-matmul refactor; the earlier v1 implementation passed `scale_result` directly to `cublasCommonArgs`.

## Fix

- Added an optional `scale_result` argument to `_scaled_gemm` and forwarded it from `_scaled_mm_out_cuda`.
- Passed the scale to `cublasCommonArgs` only when the output dtype is float8. Forwarding it for high-precision output causes cuBLAS to reject the descriptor and would violate the existing ignore semantics.
- Preserved the separate NVFP4 `alpha` argument.
- Added a CUDA regression test using exact integer products. It verifies that a 0.5 output scale multiplies the accumulator before float8 quantization and that BF16 output remains unchanged.

<details>
<summary>Repro Script</summary>

```python
import torch

E4M3 = torch.float8_e4m3fn
dev = "cuda"
torch.manual_seed(0)
M, K, N = 32, 16, 32

# Integer operands in {-1,0,1}, K=16 -> accumulated sums in [-16,16], all exact
# in e4m3; 0.5*ref lands on the 0.5 grid (also exact). Any nonzero diff is a real
# bug, not fp reordering.
a_int = torch.randint(-1, 2, (M, K), device=dev)
b_int = torch.randint(-1, 2, (K, N), device=dev)
A = a_int.float().to(E4M3)
B = b_int.float().t().contiguous().t().to(E4M3)  # column-major B

one = torch.tensor(1.0, device=dev)
half = torch.tensor(0.5, device=dev)

o1 = torch._scaled_mm(A, B, scale_a=one, scale_b=one, scale_result=one, out_dtype=E4M3)
o2 = torch._scaled_mm(A, B, scale_a=one, scale_b=one, scale_result=half, out_dtype=E4M3)

ref = (A.float().double() @ B.float().double()).cpu()
o1_eq_o2 = bool(torch.equal(o1.view(torch.int8), o2.view(torch.int8)))
err2 = float((o2.float().double().cpu() - 0.5 * ref).abs().max())

print("torch", torch.__version__)
print("o1 == o2 bitwise:", o1_eq_o2, "(expected False; True == bug)")
print("err deq(o2) vs 0.5*ref:", err2, "(expected 0.0; nonzero == scale_result ignored)")
```

```text
torch 2.14.0a0+git4fbc0c5
o1 == o2 bitwise: False (expected False; True == bug)
err deq(o2) vs 0.5*ref: 0.0 (expected 0.0; nonzero == scale_result ignored)
```

</details>

## Validation

- Rebuilt the C++ change successfully:
  `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260723-pytorch-190449/pytorch`
- Confirmed the new regression test failed before the source fix with 874/1024 mismatched elements.
- Passed three targeted CUDA tests:
  `./.venv/bin/python pytorch/test/test_scaled_matmul_cuda.py TestFP8MatmulCUDA.test_float8_scale_cuda TestFP8MatmulCUDA.test_float8_scale_result_cuda TestFP8MatmulCUDA.test_blockwise_nvfp4_with_global_scale_128_128_128_cuda`
- Re-ran `./.venv/bin/python ./repro.py`; the scaled result now has zero error.
- Confirmed BF16, FP16, and FP32 outputs are bitwise unchanged when `scale_result` is supplied.
- `git diff --check` passes.

## Lint status

`spin fixlint` ran. Its changed-file apply phase reported no lint issues, but the overall command exited nonzero because the broad initial pass found unrelated pre-existing ShellCheck and clang-tidy findings in files outside this change. No unrelated files were modified.


Fixes #190449


<details>
<summary>Repro Script</summary>

```python
import torch

E4M3 = torch.float8_e4m3fn
dev = "cuda"
torch.manual_seed(0)
M, K, N = 32, 16, 32

# Integer operands in {-1,0,1}, K=16 -> accumulated sums in [-16,16], all exact
# in e4m3; 0.5*ref lands on the 0.5 grid (also exact). Any nonzero diff is a real
# bug, not fp reordering.
a_int = torch.randint(-1, 2, (M, K), device=dev)
b_int = torch.randint(-1, 2, (K, N), device=dev)
A = a_int.float().to(E4M3)
B = b_int.float().t().contiguous().t().to(E4M3)  # column-major B

one = torch.tensor(1.0, device=dev)
half = torch.tensor(0.5, device=dev)

o1 = torch._scaled_mm(A, B, scale_a=one, scale_b=one, scale_result=one, out_dtype=E4M3)
o2 = torch._scaled_mm(A, B, scale_a=one, scale_b=one, scale_result=half, out_dtype=E4M3)

ref = (A.float().double() @ B.float().double()).cpu()
o1_eq_o2 = bool(torch.equal(o1.view(torch.int8), o2.view(torch.int8)))
err2 = float((o2.float().double().cpu() - 0.5 * ref).abs().max())

print("torch", torch.__version__)
print("o1 == o2 bitwise:", o1_eq_o2, "(expected False; True == bug)")
print("err deq(o2) vs 0.5*ref:", err2, "(expected 0.0; nonzero == scale_result ignored)")
```

</details>


<details>
<summary>Agent Worklog</summary>

# Worklog

## Reproduced on current build

Ran `./.venv/bin/python ./repro.py` with PyTorch `2.14.0a0+git4fbc0c5` on an NVIDIA GB200. The two float8 outputs were bitwise identical for `scale_result=1.0` and `0.5`, and the scaled output had maximum error 4.5 against `0.5 * ref`, confirming that CUDA ignores `scale_result`.

## Root cause and regression coverage

`_scaled_mm_out_cuda` validates `scale_result` but calls `_scaled_gemm` without it. `_scaled_gemm` constructs `cublasCommonArgs` with `std::nullopt`, leaving `args.scale_result_ptr` null and preventing `CUBLASLT_MATMUL_DESC_D_SCALE_POINTER` from being set. Historical source before the v1/v2 refactor passed `scale_result` to `cublasCommonArgs` directly.

Added `TestFP8Matmul.test_float8_scale_result`, which compares CUDA float8 output against an exact integer-product reference multiplied by 0.5. The targeted test fails before the source fix with 874/1024 mismatched elements, demonstrating that it catches the regression.

## Fix and validation

Threaded `scale_result` through `_scaled_gemm` into `cublasCommonArgs`, but only for float8 output. An intermediate build that forwarded it unconditionally made cuBLAS reject BF16/FP16/FP32 output, so the final implementation preserves the documented behavior that high-precision output ignores `scale_result`. The test covers both the float8 multiply convention and unchanged BF16 output.

Rebuilt successfully with `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260723-pytorch-190449/pytorch`. The repro now reports distinct outputs and zero error against `0.5 * ref`. The targeted CUDA test, the existing float8 scale test, and an NVFP4 global-scale test all pass. A direct smoke check also confirmed BF16, FP16, and FP32 outputs remain bitwise equal with and without `scale_result`.

## Lint

Ran `spin fixlint` as required. Its changed-file lint/apply phase reported `ok No lint issues`, but the overall command exited nonzero because its broad initial pass reported pre-existing ShellCheck and clang-tidy findings in unrelated files such as `.ci/pytorch/test.sh` and `torch/headeronly/util/Half.h`. It did not modify any unrelated files; `git diff --check` passes.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*