### PR TITLE
[AOTI cuda graph][7/7] cpp wrapper codegen (activation)

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -7,15 +7,14 @@ import re
 import sys
 from itertools import count, zip_longest
 from typing import Any, cast
-from typing_extensions import Self
 
 import sympy
-
 import torch
 from torch import dtype as torch_dtype
 from torch._inductor.codecache import get_cpp_wrapper_cubin_path_name
 from torch._inductor.runtime.runtime_utils import dynamo_timed
 from torch.utils._ordered_set import OrderedSet
+from typing_extensions import Self
 
 from .. import config
 from ..codecache import CudaKernelParamCache
@@ -85,10 +84,12 @@ def generate_aoti_kernel_config_header(kernel_names: list[str]) -> str:
         return "{" + ", ".join(str(v) for v in values) + "}"
 
     buf = IndentedBuffer()
-    buf.splice("""
+    buf.splice(
+        """
         #pragma once
         // Auto-generated kernel configurations for AOTInductor lazy compile.
-    """)
+    """
+    )
 
     for kernel_name in kernel_names:
         params = CudaKernelParamCache.get(kernel_name)
@@ -161,7 +162,8 @@ def generate_aoti_kernel_config_header(kernel_names: list[str]) -> str:
         ps = params.get("profile_scratch", -1) or -1
 
         buf.writeline("")
-        buf.splice(f"""
+        buf.splice(
+            f"""
             // Kernel: {kernel_name}
             #define {macro_prefix}_CUBIN_PATH {cubin_path}
             #define {macro_prefix}_MANGLED_NAME {mangled_name}
@@ -176,7 +178,8 @@ def generate_aoti_kernel_config_header(kernel_names: list[str]) -> str:
             #define {macro_prefix}_CONFIG_INDEX {ci}
             #define {macro_prefix}_GLOBAL_SCRATCH {gs}
             #define {macro_prefix}_PROFILE_SCRATCH {ps}
-        """)
+        """
+        )
 
     return buf.getvalue()
 
@@ -1130,8 +1133,12 @@ class CppWrapperGpu(CppWrapperCpu):
         parent_wrapper: PythonWrapperCodegen | None,
         partition_signatures: GraphPartitionSignature | None = None,
     ):
-        # TODO - support subgraph codegen by lifting functions. Check the
-        # comment at CppWrapperCpu `codegen_subgraph` function.
+        if is_subgraph and partition_signatures is not None:
+            assert subgraph_name is not None
+            assert parent_wrapper is not None
+            return SubgraphCppWrapperGpu(
+                subgraph_name, parent_wrapper, partition_signatures
+            )
         return CppWrapperGpu()
 
     def write_header(self):
@@ -1148,6 +1155,15 @@ class CppWrapperGpu(CppWrapperCpu):
             self.header.splice_jit(kernel_driver)
         else:
             self.header.splice(kernel_driver)
+        if config.aot_inductor.enable_cuda_graph and V.graph.aot_mode:
+            # The AOTI regional cuda-graph runtime: flat per-(partition, shape)
+            # capture + replay over one private pool, with slab-resident outputs
+            # (no tree, no allocator checkpoint). See cudagraph_tree.h.
+            self.header.splice(
+                """
+                #include <torch/csrc/inductor/aoti_runtime/cudagraph_tree.h>
+                """
+            )
 
     def _generate(self, is_inference):
         # Per-Run()-function state, reset each generation. Do NOT reset
@@ -1862,6 +1878,434 @@ static inline void ensure_triton_kernel_compiles_started() {{
 
     def make_zero_buffer(self, name):
         return f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_zero_({name}.get()));"
+
+    def codegen_partition_call(
+        self,
+        partition_id: int,
+        partition_signatures: GraphPartitionSignature,
+    ):
+        skip_cudagraph = partition_signatures.skip_cudagraph
+        use_cudagraph = (
+            config.aot_inductor.enable_cuda_graph
+            and V.graph.aot_mode
+            and not skip_cudagraph
+        )
+
+        if not use_cudagraph:
+            return super().codegen_partition_call(partition_id, partition_signatures)
+
+        # Emit the per-symbol handoff slabs ONCE, before any partition lambda is
+        # defined, so each partition body's [&] capture sees the slab handle
+        # (cudagraph_handoff_pool_<sym>) in scope. Each slab is routed through
+        # AllocationPool.codegen_create -> the per-instance cached-slab path
+        # (this->cudagraph_slabs_), so the base address is address-stable across
+        # forwards. Emitted only when memory_planning published handoff pools;
+        # none -> no lines.
+        if not getattr(self, "_cg_handoff_slab_emitted", False):
+            handoff_pools = getattr(V.graph, "_cudagraph_handoff_pools", None) or {}
+            for _pool_name, pool in handoff_pools.items():
+                pool.codegen_create(self, self)
+            self._cg_handoff_slab_emitted = True
+
+        # When enable_cuda_graph is on, we handle ALL partitions ourselves
+        # to properly track outer-scope variables for deallocation.
+        # The base class emits .reset() for all input_deallocation entries,
+        # but some buffers are only declared inside the partition lambda
+        # (e.g., SDPA auxiliary outputs) and don't exist in the outer scope.
+        input_deallocation = partition_signatures.input_deallocation
+        output_nodes = partition_signatures.output_nodes
+        output_names = [node.get_name() for node in output_nodes]
+        num_tensor_inputs = len(input_deallocation)
+        num_outputs = len(output_names)
+        partition_name = f"partition_{partition_id}"
+        partition_bodies = getattr(self, "_partition_bodies", [])
+        partition_code = (
+            partition_bodies[partition_id]
+            if partition_id < len(partition_bodies)
+            else None
+        )
+        if partition_code is not None:
+            self.writeline(f"auto {partition_name} = [&](")
+            self.writeline(
+                f"    AtenTensorHandle* partition_inputs, int32_t num_inputs,"
+            )
+            self.writeline(
+                f"    AtenTensorHandle* partition_outputs, int32_t num_outputs"
+            )
+            self.writeline(") {")
+            self.writeline(partition_code)
+            self.writeline("};")
+
+        for i, name in enumerate(list(input_deallocation.keys())):
+            self.writeline(f"AtenTensorHandle p{partition_id}_in_{i} = {name}.get();")
+        inputs_list = ", ".join(
+            f"p{partition_id}_in_{i}" for i in range(num_tensor_inputs)
+        )
+        self.writeline(
+            f"AtenTensorHandle p{partition_id}_inputs[] = {{{inputs_list}}};"
+        )
+        self.writeline(f"AtenTensorHandle p{partition_id}_outputs[{num_outputs}];")
+
+        # Per-AOTInductorModel-instance manager (a model member declared in
+        # model.h), lazily created so each instance owns its own private graph pool
+        # + capture stream -> concurrent instances in a model_container are
+        # isolated.
+        if not getattr(self, "_cg_mgr_emitted", False):
+            self.writeline("if (!this->cudagraph_mgr_) {")
+            self.writeline(
+                "  this->cudagraph_mgr_ = std::make_unique<"
+                "torch::aot_inductor::AOTICUDAGraphTreeManager>(this->device_idx_);"
+            )
+            self.writeline("}")
+            self._cg_mgr_emitted = True
+
+        # Single dynamic symbol (enforced by the scheduler) is the per-shape key.
+        sym_vars = [s.name for s in partition_signatures.symbol_inputs]
+        if len(sym_vars) == 1:
+            shape_key = f"(int64_t){sym_vars[0]}"
+        elif len(sym_vars) == 0:
+            shape_key = "0LL"
+        else:
+            raise RuntimeError(
+                f"AOTI cuda graph partition has {len(sym_vars)} dynamic symbols "
+                f"({sym_vars}), expected at most 1; scheduler should have demoted it."
+            )
+
+        # Compile-time liveness from the scheduler pre-pass: chained (no-copy)
+        # inputs and escaping outputs. An input is "chained" (read in-place, no
+        # per-replay copy) when its memory is at a stable address for this
+        # partition's capture to bake; otherwise it must copy_in into the
+        # captured region's static slot, which is refreshed per replay via
+        # aoti_torch_copy_. There are three chain cases, all unconditional:
+        #
+        #   1. Real captured producer: real_producer_pid[name] = the lowest
+        #      captured cpid that truly allocates `name` (name in
+        #      cap_out_names[cpid] AND NOT in cap_in_names[cpid], so it is NOT a
+        #      passthrough re-export). Chain when that producer runs EARLIER than
+        #      this partition. A global-name classifier (`name in
+        #      captured_outputs`) would be wrong: that set includes passthrough
+        #      re-exports whose real allocator is eager, so a captured downstream
+        #      kernel would bake the eager-fresh address and read stale memory on
+        #      later forwards. This per-edge classifier is the only correct path.
+        #   2. Passthrough re-export: the runtime's output_meta[i] for such a
+        #      re-export points at the emitting partition's static_inputs[i]
+        #      address -- stable across replays, refreshed each replay by the
+        #      FIRST eager->CG copy_in. So a downstream captured consumer Y can
+        #      chain B from the earliest passthrough emitter A (cpid < Y) instead
+        #      of issuing its own copy_in. Correctness-safe: valid only AFTER A
+        #      has materialized its slot for B, and requires the passthrough
+        #      output handoff below to ALSO reassign outer-scope B to A's slot
+        #      view -- the two stay in sync.
+        #   3. Eager->CG edge: an intermediate produced by an eager(skip)
+        #      partition is slab-resident at a stable address (re-written fresh
+        #      each forward by the eager re-run), so the captured consumer reads
+        #      it in place. Excluded: graph inputs (reallocate each forward) and
+        #      extern-kernel outputs (not pooled -> not slab-stable). Relies on
+        #      cg-aware reuse keeping the boundary buffers' offsets stable.
+        input_names = list(input_deallocation.keys())
+        graph_input_names = set(getattr(V.graph, "graph_inputs", {}) or {})
+        extern_output_names = (
+            getattr(V.graph, "_cudagraph_extern_output_names", None) or set()
+        )
+        # Runtime-folded constants are not slab-resident, and their address is not
+        # stable across a weight-update re-fold+swap, so a captured partition must
+        # copy_in each replay rather than bake the address (chained).
+        folded_constant_names = getattr(V.graph, "folded_constants", None) or ()
+        real_producer_pid = getattr(V.graph, "_cudagraph_real_producer_pid", None) or {}
+        passthrough_producer_pid = (
+            getattr(V.graph, "_cudagraph_passthrough_producer_pid", None) or {}
+        )
+
+        def _is_chained(name: str) -> bool:
+            if name in folded_constant_names:
+                return False
+            if name in real_producer_pid and real_producer_pid[name] < partition_id:
+                return True
+            if name in passthrough_producer_pid:
+                return passthrough_producer_pid[name] < partition_id
+            return name not in graph_input_names and name not in extern_output_names
+
+        copy_in = [i for i, name in enumerate(input_names) if not _is_chained(name)]
+        escape_outs = (getattr(V.graph, "_cudagraph_escape_outs", {}) or {}).get(
+            partition_id, []
+        )
+
+        def _vec_i32(xs: list[int]) -> str:
+            return "std::vector<int32_t>{" + ", ".join(str(x) for x in xs) + "}"
+
+        self.writeline(
+            f"this->cudagraph_mgr_->run_partition({partition_id}, {shape_key}, "
+            f"p{partition_id}_inputs, {num_tensor_inputs}, "
+            f"p{partition_id}_outputs, {num_outputs}, "
+            f"{_vec_i32(copy_in)}, {_vec_i32(escape_outs)}, "
+            "[&](AtenTensorHandle* in, AtenTensorHandle* out, void* cs) {"
+        )
+        self.writeline(
+            f"  auto p{partition_id}_saved = stream; "
+            "stream = reinterpret_cast<decltype(stream)>(cs);"
+        )
+        self.writeline(
+            f"  {partition_name}(in, {num_tensor_inputs}, out, {num_outputs});"
+        )
+        self.writeline(f"  stream = p{partition_id}_saved;")
+        self.writeline("});")
+
+        # Unpack outputs. Every output (model or internal) hands off a stable
+        # non-owning view of its recorded output address -- no clone. For a
+        # slab-resident output that address is the durable model slab, so the
+        # view stays valid across forwards; model outputs additionally have their
+        # deleter neutralized (escape_outs) so the caller keeps owning them.
+        # Contract (consume-before-next-run): an output must be read before the
+        # next run of its (partition, shape) -- the next replay overwrites the
+        # memory in place. Inference serving copies outputs into the response
+        # within the request, satisfying this; only harnesses that hold outputs
+        # across forwards (e.g. multi-shape accuracy collection) see stale values.
+        if not hasattr(self, "_outer_scope_vars"):
+            self._outer_scope_vars = set()
+        self._outer_scope_vars.update(input_deallocation.keys())
+        passthrough_names = set(input_deallocation.keys())
+        # Passthrough outputs (output name == one of this partition's input
+        # names): run_partition returned a NON-OWNING view at output_meta[i],
+        # which for an eager-copied input is THIS partition's static_inputs[i]
+        # address. When THIS partition is the EARLIEST captured passthrough
+        # emitter for `name`, reassign outer-scope `name` to that stable
+        # static-slot view so downstream captured consumers can chain (see
+        # _is_chained above). Otherwise the view is dropped (the original input
+        # handle stays in scope).
+        passthrough_producer_pid_map = (
+            getattr(V.graph, "_cudagraph_passthrough_producer_pid", None) or {}
+        )
+        for i, name in enumerate(output_names):
+            src = f"p{partition_id}_outputs[{i}]"
+            if name in passthrough_names:
+                if passthrough_producer_pid_map.get(name) == partition_id:
+                    if name in self._outer_scope_vars:
+                        self.writeline(f"{name} = RAIIAtenTensorHandle({src});")
+                    else:
+                        self.writeline(f"RAIIAtenTensorHandle {name}({src});")
+                    self._outer_scope_vars.add(name)
+                else:
+                    self.writeline(f"aoti_torch_delete_tensor_object({src});")
+                continue
+            if name in self._outer_scope_vars:
+                self.writeline(f"{name} = RAIIAtenTensorHandle({src});")
+            else:
+                self.writeline(f"RAIIAtenTensorHandle {name}({src});")
+            self._outer_scope_vars.add(name)
+
+        # Only free buffers that exist in the outer scope. Buffers
+        # declared only inside the partition lambda (e.g., SDPA auxiliary
+        # outputs) are freed when the lambda returns -- emitting .reset()
+        # for them would be an "undeclared identifier" error.
+        for name, deallocate in input_deallocation.items():
+            if deallocate and name in self._outer_scope_vars:
+                self.writeline(f"{name}.reset();")
+
+    def define_subgraph_launcher_fn(self, name: str, subgraph_code):
+        if not hasattr(self, "_partition_bodies"):
+            self._partition_bodies = []
+        code = (
+            subgraph_code.value
+            if hasattr(subgraph_code, "value")
+            else (
+                subgraph_code.getvalue()
+                if hasattr(subgraph_code, "getvalue")
+                else str(subgraph_code)
+            )
+        )
+        self._partition_bodies.append(code)
+
+    def set_all_partition_names(self, num_partitions: int):
+        self.all_partition_names = [f"partition_{idx}" for idx in range(num_partitions)]
+
+    def generate_after_suffix(self, result: IndentedBuffer) -> None:
+        pass
+
+
+class SubgraphCppWrapperGpu(CppWrapperGpu):
+    """
+    Generates a separate C++ function for a graph partition.
+    Analogous to SubgraphPythonWrapperCodegen for the Python wrapper.
+    """
+
+    def __init__(
+        self,
+        subgraph_name: str,
+        parent_wrapper: PythonWrapperCodegen,
+        partition_signatures: GraphPartitionSignature,
+    ) -> None:
+        self.subgraph_name = subgraph_name
+        self.parent_wrapper = parent_wrapper
+        self.partition_signatures = partition_signatures
+        super().__init__()
+        root = self._get_root_wrapper()
+        self.src_to_kernel = root.src_to_kernel
+        self._triton_call_wrappers = root._triton_call_wrappers
+        self._kernel_name_to_body = root._kernel_name_to_body
+        self.used_cached_dtypes = root.used_cached_dtypes
+        self.used_cached_devices = root.used_cached_devices
+        self.used_cached_layouts = root.used_cached_layouts
+        self.used_cached_memory_formats = root.used_cached_memory_formats
+        self.kernel_declarations = root.kernel_declarations
+        self.initialized_kernels = root.initialized_kernels
+        self.user_defined_kernel_cache = root.user_defined_kernel_cache
+        self.kernel_autotune_defs = root.kernel_autotune_defs
+        self.kernel_autotune_calls = root.kernel_autotune_calls
+        self.kernel_autotune_names = root.kernel_autotune_names
+        self.kernel_autotune_example_args = root.kernel_autotune_example_args
+
+    def _get_root_wrapper(self) -> PythonWrapperCodegen:
+        w = self.parent_wrapper
+        while isinstance(w, SubgraphCppWrapperGpu):
+            w = w.parent_wrapper
+        return w
+
+    def generate(self, is_inference):
+        # Use parent's generate which populates all buffers.
+        # This subgraph wrapper has a fresh, empty codegened_graph_stack and
+        # partition codegen never pushes onto it, so nothing pops it either
+        # (the scheduler must not pop here -- that would pop an empty stack).
+        result_obj, kernel_code = super().generate(is_inference)
+        # Strip #include, namespace, and closing brace from result
+        # since this code goes inside a lambda body
+        if hasattr(result_obj, "value"):
+            raw = result_obj.value
+        elif hasattr(result_obj, "getvalue"):
+            raw = result_obj.getvalue()
+        else:
+            raw = str(result_obj)
+        lines = raw.split("\n")
+        filtered = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("#include"):
+                continue
+            if stripped.startswith("namespace "):
+                continue
+            if stripped.startswith("} // namespace"):
+                continue
+            if stripped.startswith("using namespace"):
+                continue
+            filtered.append(line)
+        clean = IndentedBuffer()
+        clean.writelines(filtered)
+        return clean, kernel_code
+
+    def set_launcher_fn_name(self) -> None:
+        self.launcher_fn_name = self.subgraph_name
+
+    def write_header(self) -> None:
+        pass
+
+    def add_benchmark_harness(self, output):
+        pass
+
+    def benchmark_compiled_module(self, output):
+        pass
+
+    def write_async_compile_wait(self):
+        pass
+
+    def generate_and_run_autotune_block(self):
+        pass
+
+    def next_kernel_suffix(self) -> str:
+        return self.parent_wrapper.next_kernel_suffix()
+
+    def generate_after_suffix(self, result: IndentedBuffer) -> None:
+        return
+
+    def write_wrapper_decl(self) -> None:
+        inputs = self.partition_signatures.input_deallocation
+
+        # Emit input unpacking from partition_inputs array (lambda body)
+        for idx, input_name in enumerate(inputs.keys()):
+            if isinstance(
+                self.partition_signatures.input_nodes.get(input_name),
+                sympy.Expr,
+            ):
+                from ..graph import may_get_constant_buffer_dtype
+
+                dtype = may_get_constant_buffer_dtype(
+                    self.partition_signatures.input_nodes[input_name]
+                )
+                assert dtype is not None
+                self.codegen_tensor_item(
+                    dtype,
+                    f"wrap_with_raii_handle_if_needed(partition_inputs[{idx}])",
+                    input_name,
+                    self.prefix,
+                )
+            else:
+                self.prefix.writeline(
+                    f"auto {input_name} = "
+                    f"wrap_with_raii_handle_if_needed(partition_inputs[{idx}]);"
+                )
+
+            # Unpack symbol inputs
+            for sym in self.partition_signatures.symbol_inputs:
+                # Symbol inputs are passed after tensor inputs
+                pass
+
+    def finalize_prefix(self):
+        pass
+
+    def generate_input_output_runtime_checks(self):
+        pass
+
+    def get_graph_inputs(self):
+        if sig := self.partition_signatures:
+            return sig.input_nodes | {str(s): s for s in sig.symbol_inputs}
+        return V.graph.graph_inputs
+
+    def get_graph_input_names(self) -> list[str]:
+        if sig := self.partition_signatures:
+            return list(sig.input_nodes.keys()) + [s.name for s in sig.symbol_inputs]
+        return V.graph.graph_input_names
+
+    def get_graph_outputs(self):
+        if sig := self.partition_signatures:
+            return sig.output_nodes
+        return V.graph.graph_outputs
+
+    def codegen_allocation(self, buffer):
+        from ..ir import Buffer
+
+        if isinstance(buffer, Buffer):
+            name = buffer.get_name()
+            if (
+                self.partition_signatures
+                and name in self.partition_signatures.input_nodes
+            ):
+                return
+        super().codegen_allocation(buffer)
+
+    def generate_return(self, output_refs: list[str]):
+        output2idx: dict[str, int] = {}
+        output_refs = [
+            self.create_tmp_raii_handle_var_if_needed(o, self.wrapper_call)
+            for o in output_refs
+        ]
+        for idx, output in enumerate(output_refs):
+            if output == "nullptr":
+                continue
+            if output in output2idx:
+                src_idx = output2idx[output]
+                self.wrapper_call.writeline(
+                    f"partition_outputs[{idx}] = partition_outputs[{src_idx}];"
+                )
+            else:
+                self.wrapper_call.writeline(
+                    f"partition_outputs[{idx}] = {output}.release();"
+                )
+            if output not in output2idx:
+                output2idx[output] = idx
+
+    def generate_before_suffix(self, result):
+        pass
+
+    def write_suffix(self, result):
+        pass
 
 
 @dataclasses.dataclass

--- a/torch/_inductor/codegen/memory_planning.py
+++ b/torch/_inductor/codegen/memory_planning.py
@@ -4,16 +4,26 @@ from __future__ import annotations
 import collections
 import dataclasses
 import itertools
+import math
+import os
 import pprint
 from typing import Any, Protocol, TYPE_CHECKING
 
+import sympy
 import torch
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import Max
 
 from .. import config
-from ..utils import _align, align, cache_on_self, CachedMethod, IndentedBuffer
+from ..utils import (
+    _align,
+    align,
+    ALIGN_BYTES,
+    cache_on_self,
+    CachedMethod,
+    IndentedBuffer,
+)
 from ..virtualized import V
 from .wrapper import (
     AllocateLine,
@@ -23,6 +33,31 @@ from .wrapper import (
     NullLine,
     ReuseLine,
 )
+
+
+def _cudagraph_slab_cache_enabled(wrapper: Any) -> bool:
+    """The AOTI cuda-graph runtime captures partitions whose kernels bake in the
+    address of every reinterpret_tensor view INTO the memory_planning slab.
+    If the slab is re-allocated each forward (the default empty_strided), those
+    captured addresses go stale and a replay reads/writes the wrong memory ->
+    illegal memory access or silent garbage. Caching the slab per-shape in the
+    wrapper makes the base address stable across forwards of the same shape,
+    so the captured partitions stay valid. Gated to AOTI cpp wrapper + cuda-graph;
+    Python/CPU paths are unaffected.
+    """
+    if not config.aot_inductor.enable_cuda_graph:
+        return False
+    if not V.graph.aot_mode:
+        return False
+    # The const-folding graph is not cuda-graph-captured, so its buffers need no
+    # stable slab; and it shares this->cudagraph_slabs_ with the main graph but
+    # restarts pools at pool0 in a partition_key=0 scope, colliding with the main
+    # graph's outer pools (main reuses a wrong-sized slab -> illegal memory access).
+    if V.graph.is_const_graph:
+        return False
+    # cpp_wrapper_cpu.CppWrapperCpu (inherited by CppWrapperGpu) defines
+    # make_allocation; the Python PythonWrapperCodegen path has a different API.
+    return hasattr(wrapper, "codegen_int_array_var")
 
 
 if TYPE_CHECKING:
@@ -402,6 +437,11 @@ class AllocationPool:
     name: str | None = None
     names_to_del: list[str] = dataclasses.field(default_factory=list)
     creation_cache: dict[str, str] = dataclasses.field(default_factory=dict)
+    # Explicit cudagraph-slab-cache id, folded into the per-instance cache key so
+    # each pool's cached slab stays disjoint. None -> derive from the pool name
+    # (pool0/pool1/... numeric path). Set explicitly for the cross-partition
+    # handoff pools, whose names are not poolN, to a reserved collision-free id.
+    pool_id: int | None = None
 
     def __post_init__(self) -> None:
         for block in self.root.allocations:
@@ -459,6 +499,33 @@ class AllocationPool:
         if not self.name:
             raise AssertionError("pool must be finalized before codegen_create")
         nbytes = self.root.get_symbolic_size()
+        # Under AOTI cuda-graph the slab base address must be stable across
+        # forwards so captured partitions' reinterpret_tensor views (which bake
+        # the slab address at capture time) stay valid. Route the slab allocation
+        # through a per-instance cached slab. See _cudagraph_slab_cache_enabled.
+        if _cudagraph_slab_cache_enabled(wrapper):
+            for block in self.root.allocations:
+                if (
+                    isinstance(block, Allocation)
+                    and nbytes == block.get_symbolic_size()
+                ):
+                    node = block.node
+                    self._codegen_create_cudagraph_cached(
+                        wrapper,
+                        code,
+                        dtype=node.get_dtype(),
+                        shape=tuple(node.get_size()),
+                        stride=tuple(node.get_stride()),
+                    )
+                    return
+            self._codegen_create_cudagraph_cached(
+                wrapper,
+                code,
+                dtype=torch.uint8,
+                shape=(nbytes,),
+                stride=(1,),
+            )
+            return
         for block in self.root.allocations:
             if isinstance(block, Allocation) and nbytes == block.get_symbolic_size():
                 node = block.node
@@ -483,7 +550,294 @@ class AllocationPool:
                 )
             )
 
+    def _codegen_create_cudagraph_cached(
+        self, wrapper, code: IndentedBuffer, dtype, shape, stride
+    ):
+        """Emit the persistent per-shape slab. The cache is the per-instance
+        member `this->cudagraph_slabs_` (an
+        unordered_map<int64_t, RAIIAtenTensorHandle> on AOTInductorModel) that
+        owns the allocation; the local `pool<i>` is a non-owning view at the
+        cached base address, so the existing AllocFromPoolLine codegen (which
+        calls `aoti_torch__alloc_from_pool(pool<i>, ...)`) is unchanged and free
+        of per-replay re-allocation. The member is owned by the AOTInductorModel
+        instance and freed with it (RAII), matching the per-instance scope of
+        `this->cudagraph_mgr_` -- concurrent instances in a model_container get
+        isolated slabs. The single member is shared by every pool, so the cache
+        key folds a stable per-pool id into the high bits (see below) to keep
+        pools disjoint; under single-max-slab the per-pool key is otherwise a
+        constant, so every shape of a pool reuses that pool's one max-sized slab.
+
+        Single-max-slab: when the slab's shape/stride contains dynamic
+        symbols, size the slab ONCE to those symbols' upper bounds (max batch)
+        and share it across all shapes via a constant cache key. Small shapes use
+        a prefix of the max slab; the per-buffer offset views are unchanged and
+        fit inside the max slab. Every contributing dynamic symbol must have a
+        finite upper bound; an unbounded symbol is a compile-time error (see
+        below). Static slabs (no dynamic symbol) keep the constant cache key
+        directly.
+        """
+        # Collect the dynamic-symbol names referenced by the slab's shape OR
+        # stride. Their presence decides whether we resize the slab to the
+        # dynamic-shape upper bounds below; the slab packs many partitions so it
+        # can depend on several (s13, s14, ...).
+        sym_set: OrderedSet[sympy.Symbol] = OrderedSet()
+        for expr in [*shape, *stride]:
+            if isinstance(expr, sympy.Expr):
+                for sym in expr.free_symbols:
+                    if isinstance(sym, sympy.Symbol):
+                        sym_set.add(sym)
+        sym_list = sorted(sym_set, key=str)
+
+        # Single-max-slab path: replace the symbolic shape/stride with
+        # their dynamic-shape upper bounds (max batch) so ONE slab, keyed on a
+        # constant, is shared across all shapes. Use the same bound_sympy
+        # mechanism AOTI uses for runtime input upper-bound checks (see
+        # cpp_wrapper_cpu.py). Every contributing symbol MUST have a finite upper
+        # bound; an unbounded dim (math.isinf / sympy oo / int_oo) is a
+        # compile-time error -- AOTI regional cuda-graph needs a fixed max slab
+        # size, which an unbounded dim cannot provide.
+        if sym_list:
+            from torch.utils._sympy.numbers import int_oo
+            from torch.utils._sympy.value_ranges import bound_sympy
+
+            var_to_range = V.graph.sizevars.shape_env.var_to_range
+
+            def _const_upper_bound(expr):
+                if isinstance(expr, (int, sympy.Integer)):
+                    return int(expr)
+                if not isinstance(expr, sympy.Expr):
+                    return None
+                # The slab size/stride can contain Inductor's `align` sympy
+                # Function (from SpatialSplit.get_symbolic_size / finalize), which
+                # the ValueRanges interpreter behind bound_sympy has no handler
+                # for -> KeyError. align(e) rounds e up to the next multiple of
+                # ALIGN_BYTES, so align(e) <= e + (ALIGN_BYTES - 1); substitute
+                # that boundable upper bound before bounding. Taking .upper then
+                # still yields a valid (>= true max) slab dimension.
+                expr = expr.replace(align, lambda e: e + (ALIGN_BYTES - 1))
+                upper = bound_sympy(expr, var_to_range).upper
+                if upper in (sympy.oo, int_oo) or math.isinf(upper):
+                    return None
+                return int(upper)
+
+            max_shape = [_const_upper_bound(d) for d in shape]
+            max_stride = [_const_upper_bound(s) for s in stride]
+            if any(d is None for d in max_shape) or any(s is None for s in max_stride):
+                raise RuntimeError(
+                    "AOTI regional cuda-graph requires finite dynamic-shape upper "
+                    "bounds; set them via the export Dim(max=...) / "
+                    "dynamic_shapes_strategy. Slab shape="
+                    f"{shape}, stride={stride} has an unbounded dynamic dimension."
+                )
+            # Size the slab to the max so a single slab is shared across all
+            # shapes (the per-pool cache key below is a constant).
+            shape = tuple(max_shape)
+            stride = tuple(max_stride)
+        # Under single-max-slab the per-shape key is always a constant: the slab
+        # is sized to the dynamic-shape upper bounds and shared across shapes, so
+        # only the per-pool id (folded in below) distinguishes cache slots.
+        #
+        # Memory planning is PER-PARTITION: each captured partition is codegen'd
+        # through its OWN subgraph wrapper with its OWN MemoryPlanner, so pool
+        # names RESTART per partition (every partition's first pool is "pool0",
+        # pool_id 0). The slab cache (this->cudagraph_slabs_) is process-shared
+        # across partition bodies, so without further disambiguation EVERY
+        # partition's "pool0" maps to the SAME cache key (pool_id 0, key 0) and
+        # thus the SAME physical slab. Two partitions then alias the same slab
+        # offsets: a later partition's buffer clobbers an earlier partition's
+        # slab-resident output that must survive to the end of the forward (model
+        # outputs / handoffs), producing deterministic wrong outputs on every
+        # forward (the captured graph itself is fine -- the memory is overwritten
+        # by a downstream partition before the caller reads it). Per-subgraph
+        # live-range analysis cannot see this: it only orders buffers WITHIN one
+        # partition. So fold the owning partition id into the cache key here, in
+        # the low 40 bits, giving each captured partition DISJOINT slabs. This is
+        # the correctness baseline (no cross-partition memory reuse); cross-SHAPE
+        # sharing within a partition is preserved (the key stays constant per
+        # (partition, pool)). The id is partition_id + 1 so partition 0's slab
+        # never collides with a non-subgraph (outer-scope) pool whose key low
+        # bits are 0. Handoff pools are created in the OUTER wrapper (no
+        # subgraph_name) and are already disambiguated by an explicit reserved
+        # self.pool_id, so they keep key low bits 0.
+        subgraph_name = getattr(wrapper, "subgraph_name", None)
+        partition_key = 0
+        if isinstance(subgraph_name, str) and subgraph_name.startswith("partition_"):
+            partition_suffix = subgraph_name[len("partition_") :]
+            if partition_suffix.isdigit():
+                partition_key = int(partition_suffix) + 1
+        key_expr = f"{partition_key}LL"
+        shape_log_expr = '""'
+
+        # Reuse the existing cpp wrapper helpers for size/stride/dtype/device
+        # rendering -- this keeps the slab's ABI call identical to the
+        # non-cached path (same aoti_torch_empty_strided signature).
+        device_str = wrapper.codegen_device(self.device)
+        dtype_code = wrapper.codegen_dtype(dtype)
+        size_str = wrapper.codegen_shape_tuple(shape)
+        stride_str = wrapper.codegen_shape_tuple(stride)
+        device_type, device_id = device_str.split(",")
+        device_idx = "this->device_idx_" if V.graph.aot_mode else device_id
+
+        size_array_var = wrapper.codegen_int_array_var(
+            size_str,
+            wrapper.wrapper_call.writeline,
+            known_statically=wrapper.is_statically_known_list_of_ints(shape),
+            graph=wrapper.get_codegened_graph(),
+        )
+        stride_array_var = wrapper.codegen_int_array_var(
+            stride_str,
+            wrapper.wrapper_call.writeline,
+            known_statically=wrapper.is_statically_known_list_of_ints(stride),
+            graph=wrapper.get_codegened_graph(),
+        )
+        ndim = str(len(shape))
+
+        pool_name = self.name
+        cache_member = "this->cudagraph_slabs_"
+        owner_name = f"{pool_name}_owner_handle"
+        data_ptr_name = f"{pool_name}_data_ptr"
+        view_name = f"{pool_name}_view_handle"
+        key_name = f"{pool_name}_shape_key"
+        # On only for a truthy AOTI_CGTREE_DEBUG. Unset/empty/"0" is off so a
+        # production run that exports AOTI_CGTREE_DEBUG=0 (e.g. the scorecard
+        # harness) does not codegen the per-forward [smp-bind] address audit.
+        debug = os.environ.get("AOTI_CGTREE_DEBUG", "") not in ("", "0")
+
+        # Stable per-pool id, folded into the cache key so the single shared
+        # member keeps each pool's slabs disjoint. An explicit self.pool_id
+        # (cross-partition handoff pools) wins; otherwise pools are named "pool0",
+        # "pool1", ...; parse the trailing integer. Fall back to a hash bucket if
+        # the name ever changes shape (keeps the id deterministic + bounded).
+        pool_suffix = pool_name[len("pool") :] if pool_name.startswith("pool") else ""
+        if self.pool_id is not None:
+            pool_id = self.pool_id
+        elif pool_suffix.isdigit():
+            pool_id = int(pool_suffix)
+        else:
+            pool_id = abs(hash(pool_name)) % (1 << 20)
+
+        # Per-instance cache (this->cudagraph_slabs_) survives across forwards and
+        # is owned by the AOTInductorModel instance (NOT process-static), matching
+        # the per-instance scope of this->cudagraph_mgr_ so concurrent instances
+        # in a model_container have isolated slabs. The key mirrors the
+        # cudagraph_tree.h encode() packing: the pool id occupies the high bits
+        # ((pool_id) << 40) and the low 40 bits (key_expr & 0xFFFFFFFFFFLL) hold
+        # the owning partition id (partition_key, set above) so a partition's
+        # pool is disjoint from the same-named pool of every other partition.
+        # pool_id and partition_key occupy disjoint bit ranges, so the key is
+        # injective over (pool_id, partition_id); distinct pools never collide.
+        code.writeline(
+            f"int64_t {key_name} = "
+            f"((int64_t){pool_id} << 40) ^ (({key_expr}) & 0xFFFFFFFFFFLL);"
+        )
+        code.writeline(f"auto {pool_name}_it = {cache_member}.find({key_name});")
+        code.writeline(f"if ({pool_name}_it == {cache_member}.end()) {{")
+        code.writeline(f"    AtenTensorHandle {owner_name};")
+        code.writeline(
+            f"    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_empty_strided("
+            f"{ndim}, {size_array_var}, {stride_array_var}, "
+            f"{dtype_code}, {device_type}, {device_idx}, &{owner_name}));"
+        )
+        code.writeline(
+            f"    auto {pool_name}_ins = {cache_member}.emplace("
+            f"{key_name}, RAIIAtenTensorHandle({owner_name}));"
+        )
+        code.writeline(f"    {pool_name}_it = {pool_name}_ins.first;")
+        if debug:
+            code.writeline(
+                f'    std::cerr << "[smp-bind] FIRST pool=" << "{pool_name}"'
+                f' << " shape=" << {shape_log_expr}'
+                f' << " addr=" << ({pool_name}_it->second.operator AtenTensorHandle())'
+                f" << std::endl;"
+            )
+        code.writeline("}")
+        # NOTE on the "largest-seen" defensive guard (peer's caveat): the slab
+        # nbytes is a sympy formula in the dynamic symbols (s13/s14) so it is
+        # deterministic for a fixed shape key -- the same key cannot produce
+        # different slab sizes. Skipping the guard keeps the per-forward path
+        # branch-free; if a future refactor ever decouples size from key,
+        # re-add a `static unordered_map<int64_t,int64_t> shape_to_nbytes` check
+        # and grow via empty_strided + std::move.
+        # Audit: detect any drift between first-bind and reuse (must be impossible
+        # with this construction, but guards future refactors). Cheap, gated on
+        # AOTI_CGTREE_DEBUG -- zero cost when unset.
+        code.writeline(f"void* {data_ptr_name} = nullptr;")
+        code.writeline(
+            f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_data_ptr("
+            f"{pool_name}_it->second, &{data_ptr_name}));"
+        )
+        if debug:
+            audit_map = f"{pool_name}_audit"
+            code.writeline(f"static std::unordered_map<int64_t, void*> {audit_map};")
+            code.writeline(f"auto {pool_name}_ait = {audit_map}.find({key_name});")
+            code.writeline(f"if ({pool_name}_ait == {audit_map}.end()) {{")
+            code.writeline(f"    {audit_map}.emplace({key_name}, {data_ptr_name});")
+            code.writeline("} else {")
+            code.writeline(f"    if ({pool_name}_ait->second != {data_ptr_name}) {{")
+            code.writeline(
+                f'        std::cerr << "[smp-VIOLATION P1] pool=" << "{pool_name}"'
+                f' << " shape=" << {shape_log_expr}'
+                f' << " addr_now=" << {data_ptr_name}'
+                f' << " addr_first=" << {pool_name}_ait->second'
+                f" << std::endl;"
+            )
+            code.writeline("        std::abort();")
+            code.writeline("    }")
+            code.writeline("}")
+            code.writeline(
+                f'std::cerr << "[smp-bind] REUSE pool=" << "{pool_name}"'
+                f' << " shape=" << {shape_log_expr}'
+                f' << " addr=" << {data_ptr_name}'
+                f" << std::endl;"
+            )
+        # Expose the cached OWNER handle directly as a raw (borrowed) AtenTensorHandle
+        # named after the pool. The downstream codegen (`AllocFromPoolLine`) emits
+        # `aoti_torch__alloc_from_pool(pool<i>, ...)`, which accepts any
+        # AtenTensorHandle; an AtenTensorHandle is just a pointer to TensorImpl
+        # and is implicitly convertible to/from raw, so the existing call sites
+        # compile unchanged. We deliberately do NOT wrap in a local
+        # RAIIAtenTensorHandle: the per-instance member (this->cudagraph_slabs_)
+        # owns the handle for the model's lifetime, and a local RAII destructor
+        # would try to free it on `codegen_destroy` -> `pool<i>.reset()`.
+        # `codegen_destroy` is overridden below to omit the pool from
+        # `names_to_del` so no `.reset()` is emitted.
+        code.writeline(
+            f"AtenTensorHandle {pool_name} = "
+            f"static_cast<AtenTensorHandle>({pool_name}_it->second);"
+        )
+
     def codegen_destroy(self, wrapper, code: IndentedBuffer):
+        # The cg-cached pool slab is owned by the per-instance member
+        # this->cudagraph_slabs_; the local `pool<i>` is a raw borrowed handle, so
+        # emitting `pool<i>.reset()` would not compile and would also try to free a
+        # member-owned handle. Drop the pool name from the destroy list when the
+        # cached path was used; the slab is freed by the member's RAII at model
+        # destruction.
+        #
+        # Additionally, when codegenning a captured cuda-graph partition body
+        # (cpp_wrapper_gpu.codegen_partition_call has set partition_signatures
+        # with skip_cudagraph=False), the partition body ends with
+        # `partition_outputs[i] = bufXXX.release();` for each output handed off
+        # to the cg-tree runtime. The default pool-last-use destroy emits
+        # `bufXXX.reset();` for ALL pool-allocated names INCLUDING bufXXX,
+        # nullifying the handle before `.release()` runs and SIGSEGV'ing in
+        # `cuda_graph_capture_meta -> aoti_torch_get_data_ptr(nullptr)`. So
+        # drop subgraph-output names from the destroy list -- they're still
+        # owned via the outer-scope handoff and freed by the caller's RAII at
+        # end of wrapper_call.
+        if _cudagraph_slab_cache_enabled(wrapper):
+            # Emit NO per-buffer reset. Every pooled buffer is a view into the
+            # member-cached slab; any early reset risks nulling a handle still
+            # needed across a partition/scope boundary -- a partition output handed
+            # to the cg-tree (`= bufXXX.release()` next line -> capture_meta
+            # nullptr) or a boundary buffer that is a LATER captured partition's
+            # input, reset by an earlier scope before that partition records (->
+            # clone_preserve_strides nullptr, cudagraph_tree.h:351). Output-name
+            # exclusion can't cover inputs produced by another scope. Views are
+            # freed by local RAII at scope exit; the slab is fixed and owned by
+            # this->cudagraph_slabs_, and in-order cuda-graph replay keeps reuse
+            # sequence-correct.
+            return
         code.writeline(wrapper.make_free_by_names(self.names_to_del))
 
     def __eq__(self, other):
@@ -627,6 +981,35 @@ class AllocFromPoolLine(PoolMemoryPlanningLine):
         pool = allocation.pool
         name = self.node.get_name()
 
+        # Cross-partition handoff producer-suppression + redirect. When this
+        # buffer is a published cross-partition handoff, its storage lives in the
+        # OUTER-owned per-symbol slab (cudagraph_handoff_pool_<sym>), in scope in
+        # this producer body via the partition lambda's [&] capture. Bind the
+        # name to a view into that slab at the published byte offset instead of
+        # this subgraph's pool0; the existing generate_return .release() then
+        # hands off the slab-resident view. pool0 is still created (for the
+        # partition's other pooled buffers) but this handoff is NOT added to
+        # pool0.names_to_del -- it is owned by the outer slab, not pool0. The
+        # dict is empty (no redirect) unless plan_cudagraph_handoff_slab ran for
+        # this graph, so non-cuda-graph codegen is unaffected.
+        boundary_offsets = getattr(V.graph, "_cudagraph_boundary_offsets", None) or {}
+        if name in boundary_offsets:
+            if self.is_first_pool_usage:
+                pool.codegen_create(self.wrapper, code)
+            handoff_pool_name, handoff_offset = boundary_offsets[name]
+            alloc_from_pool, lines_to_write = self.wrapper.codegen_alloc_from_pool(
+                handoff_pool_name,
+                handoff_offset,
+                self.node.get_dtype(),
+                tuple(self.node.get_size()),
+                tuple(self.node.get_stride()),
+            )
+            code.writelines(lines_to_write)
+            code.writeline(
+                f"{self.wrapper.declare}{name} = {alloc_from_pool}{self.wrapper.ending}"
+            )
+            return
+
         if self.is_first_pool_usage:
             pool.codegen_create(self.wrapper, code)
 
@@ -680,6 +1063,12 @@ class MemoryPlanner:
         self.compute_live_ranges(lines)
         self.allocate_groups()
         self.mark_first_last_usage(lines)
+        # The cross-partition handoff slab is NOT planned here. Its readers (the
+        # per-partition body AllocFromPoolLine redirect and the outer
+        # codegen_partition_call) run in scheduler.codegen() (Phase 1), which
+        # strictly precedes this outer wrapper plan (Phase 2). Planning is done in
+        # the scheduler pre-pass instead -- see plan_cudagraph_handoff_slab and
+        # its single call site in Scheduler._codegen_partitions.
         return lines
 
     def drop_removed_buffers(self, lines):
@@ -773,6 +1162,21 @@ class MemoryPlanner:
         for group in self.buffer_groups:
             if group.is_output:
                 group.update_usage(timestep)
+
+        # cg slab offset-reuse control. memory_planning packs buffers at shared
+        # offsets via sequential live ranges, but cg capture/replay + eager-rerun
+        # does not preserve those lifetimes, so a shared offset can be clobbered
+        # across a partition boundary (deterministic out-N corruption). Forcing a
+        # buffer's live range to overlap everything gives it a UNIQUE offset.
+        # Protect ONLY cross-cg-boundary buffers (captured partition inputs +
+        # outputs, _cudagraph_boundary_names): their slab offset must persist
+        # until the captured partition replays, while intra-scope buffers reuse
+        # safely (sequential within their own scope).
+        if _cudagraph_slab_cache_enabled(self.wrapper):
+            boundary = getattr(V.graph, "_cudagraph_boundary_names", None) or set()
+            for group in self.buffer_groups:
+                if any(nm in boundary for nm in group.names):
+                    group.live_range = LiveRange(0, timestep + 1)
 
     def allocate_groups(self):
         """

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -18,11 +18,10 @@ from itertools import chain, count
 from typing import Any, Literal, Protocol, TYPE_CHECKING
 
 import sympy
-from sympy import Expr
-
 import torch
 import torch._ops
 import torch.utils._pytree as pytree
+from sympy import Expr
 from torch import dtype as torch_dtype
 from torch._dynamo.utils import counters, dynamo_timed, get_debug_dir
 from torch._inductor.codegen.debug_utils import DebugPrinterManager
@@ -1967,6 +1966,12 @@ class PythonWrapperCodegen(CodeGen):
         return name
 
     def get_codegened_graph(self):
+        # Under trace_aot_inductor_module=True lowering (e.g. generate_merge_net_file)
+        # with graph-partition / cuda-graph codegen, the outer allocation codegen runs
+        # without a pushed graph, leaving this stack empty. Fall back to the active
+        # top-level GraphLowering instead of raising IndexError.
+        if not self.codegened_graph_stack:
+            return V.graph
         return self.codegened_graph_stack[-1]
 
     def push_codegened_graph(self, graph):
@@ -2128,7 +2133,9 @@ class PythonWrapperCodegen(CodeGen):
         return
 
     def generate_after_suffix(self, result: IndentedBuffer) -> None:
-        if config.graph_partition:
+        # Const graphs (runtime const folding) skip _codegen_partitions in
+        # Scheduler.codegen, so all_partition_names is unset for them.
+        if config.graph_partition and not V.graph.is_const_graph:
             all_partition_name_list = ", ".join(self.all_partition_names) + (
                 "," if len(self.all_partition_names) == 1 else ""
             )
@@ -2912,17 +2919,20 @@ class PythonWrapperCodegen(CodeGen):
     def codegen_alloc_from_pool(
         self, name, offset, dtype, shape, stride
     ) -> tuple[str, list[str]]:
-        return "alloc_from_pool({})".format(
-            ", ".join(
-                [
-                    name,
-                    pexpr(offset),  # bytes not numel
-                    str(dtype),
-                    self.codegen_python_shape_tuple(shape),
-                    self.codegen_python_shape_tuple(stride),
-                ]
-            )
-        ), []
+        return (
+            "alloc_from_pool({})".format(
+                ", ".join(
+                    [
+                        name,
+                        pexpr(offset),  # bytes not numel
+                        str(dtype),
+                        self.codegen_python_shape_tuple(shape),
+                        self.codegen_python_shape_tuple(stride),
+                    ]
+                )
+            ),
+            [],
+        )
 
     def codegen_reinterpret_view(
         self,
@@ -4506,9 +4516,12 @@ class PythonWrapperCodegen(CodeGen):
                         # In this case, we strip the first key path away.
                         return go(
                             outputs[0].get_name(),
-                            keypath[1:]
-                            if isinstance(out, ir.MultiOutput) and len(out.indices) != 0
-                            else keypath,
+                            (
+                                keypath[1:]
+                                if isinstance(out, ir.MultiOutput)
+                                and len(out.indices) != 0
+                                else keypath
+                            ),
                         )
                     else:
                         if not isinstance(keypath[0], pytree.SequenceKey):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -21,7 +21,6 @@ from inspect import currentframe
 from itertools import count
 from operator import attrgetter
 from typing import Any, Generic, TYPE_CHECKING, TypeVar
-from typing_extensions import Never, override, ParamSpec, Protocol, TypedDict, Unpack
 from unittest import mock
 
 import torch._inductor.async_compile
@@ -109,6 +108,7 @@ from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols, SymExpr
 from torch.fx.passes.fake_tensor_prop import FakeTensorProp
 from torch.monitor import _WaitCounter
 from torch.utils._ordered_set import OrderedSet
+from typing_extensions import Never, override, ParamSpec, Protocol, TypedDict, Unpack
 
 from .._dynamo.exc import ShortenTraceback, SkipFrame
 from ..fx._lazy_graph_module import _use_lazy_graph_module
@@ -771,9 +771,12 @@ def maybe_disable_graph_partition(
     cpp_wrapper: bool, aot_mode: bool
 ) -> AbstractContextManager[None, None]:
     """
-    graph partition does not support cpp_wrapper and aot_mode yet.
+    graph partition does not support cpp_wrapper and aot_mode yet,
+    unless aot_inductor.enable_cuda_graph is explicitly enabled.
     """
-    if cpp_wrapper or aot_mode:
+    if config.aot_inductor.enable_cuda_graph and aot_mode:
+        return config.patch(graph_partition=True)
+    elif cpp_wrapper or aot_mode:
         return config.patch(graph_partition=False)
     else:
         return contextlib.nullcontext()
@@ -2259,6 +2262,21 @@ def compile_fx_aot(
 
     config_patches = maybe_aoti_standalone_config(config_patches)
 
+    # Regional cuda graph relies on memory planning to place captured partition
+    # buffers into a stable slab. Auto-enable it so the two stay in sync;
+    # otherwise capture would replay against reallocated addresses.
+    enable_cuda_graph = config_patches.get(
+        "aot_inductor.enable_cuda_graph", config.aot_inductor.enable_cuda_graph
+    )
+    memory_planning = config_patches.get("memory_planning", config.memory_planning)
+    if enable_cuda_graph and not memory_planning:
+        log.warning(
+            "Enabling config.memory_planning because "
+            "config.aot_inductor.enable_cuda_graph is set (regional cuda graph "
+            "requires memory planning)."
+        )
+        config_patches["memory_planning"] = True
+
     extern_node_serializer = config_patches.pop("extern_node_serializer", None)
     saved_compile_id = model_.meta.get("dynamo_compile_id", None)
     saved_compile_context = torch._guards.CompileContext(saved_compile_id)
@@ -2425,8 +2443,8 @@ def get_cpp_wrapper_config(log_cudagraph_skip: bool = True) -> dict[str, object]
         "triton.autotune_at_compile_time": autotune_at_compile_time,
         "triton.autotune_cublasLt": not autotune_at_compile_time,
         "triton.cudagraphs": (
-            config.triton.cudagraphs
-            and not V.aot_compilation
+            (config.triton.cudagraphs or config.aot_inductor.enable_cuda_graph)
+            and (not V.aot_compilation or config.aot_inductor.enable_cuda_graph)
             and not config.graph_partition
         ),
         "triton.store_cubin": True,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -601,6 +601,7 @@ graph_partition: bool = (
     == "1"
 )
 
+
 # Pluggable CUDAGraph wrapping policy.  When set to a ``CUDAGraphPolicy``
 # instance, ``post_compile`` delegates cudagraph wrapping to the policy
 # instead of the built-in ``cudagraphify`` pipeline.  This allows custom
@@ -2357,6 +2358,19 @@ class aot_inductor:
 
     # flag to decide whether to create a submodule for constant graph.
     use_runtime_constant_folding: bool = False
+
+    # Enable regional CUDA graph for AOTI. Partitions the graph at compile
+    # time into cudagraph-eligible and non-eligible subgraphs. The generated
+    # C++ code lazily captures eligible partitions as CUDA graphs and replays
+    # them on subsequent calls.
+    enable_cuda_graph: bool = (
+        os.environ.get("AOT_INDUCTOR_ENABLE_CUDA_GRAPH", "0") == "1"
+    )
+
+    # Regional cuda-graph behavior (single max-sized per-instance slab with
+    # cg-aware slab reuse, eager/passthrough chaining, and in-slab partition
+    # handoff) is unconditional when enable_cuda_graph is set; there are no
+    # separate tuning flags.
 
     # flag to force weight to be appended to the shared library and mapped by the runtime
     # rather than embedded into the data section. Needed to support 1B+ parameter models

--- a/torch/_inductor/cudagraph_partition.py
+++ b/torch/_inductor/cudagraph_partition.py
@@ -1,0 +1,692 @@
+# mypy: allow-untyped-defs
+"""AOTI regional cuda-graph partitioning helpers.
+
+Pure helpers extracted from scheduler.py and codegen/memory_planning.py: node
+classification for cuda-graph eligibility, agglomerative convex clustering of the
+scheduler node order, and cross-partition handoff-slab planning. Kept free of
+scheduler/memory_planning instance state so both modules can import this module
+at top level; the few scheduler- and memory_planning-local classes needed at
+runtime are imported lazily inside the functions to avoid an import cycle.
+"""
+
+from __future__ import annotations
+
+import heapq
+from typing import Any, TYPE_CHECKING
+
+import sympy
+import torch
+from torch.utils._ordered_set import OrderedSet
+
+from . import config
+from .virtualized import V
+
+
+if TYPE_CHECKING:
+    from .codegen.memory_planning import Allocation, AllocationPool
+    from .codegen.wrapper import BufferLike
+    from .scheduler import BaseSchedulerNode, SchedulerBuffer
+
+
+# Minimum number of kernels in a cudagraph-eligible partition. Capturing a tiny
+# partition as its own cuda graph costs per-replay staging + launch overhead that
+# outweighs the kernel-launch saving when there are only a few kernels to amortize
+# it over, so partitions below this size are demoted to eager.
+MIN_CG_SIZE = 4
+
+
+def _cudagraph_shared_storage_names(
+    nodes: list[BaseSchedulerNode],
+) -> OrderedSet[str]:
+    """Names of all buffers whose storage is shared via aliasing or mutation,
+    in BOTH directions: every view/ReinterpretView buffer AND every base buffer
+    it points into. Capturing only part of such a storage group inside a cuda
+    graph splits a concat/chunk across the capture boundary (see
+    _node_touches_shared_storage). Computed over `nodes`; the caller caches the
+    result."""
+    names: OrderedSet[str] = OrderedSet()
+    for n in nodes:
+        for buf in n.get_outputs():
+            aliases = buf.get_aliases()
+            mutations = buf.get_mutations()
+            if aliases or mutations:
+                names.add(buf.get_name())
+                names.update(aliases)
+                names.update(mutations)
+    return names
+
+
+def _node_touches_shared_storage(
+    node: BaseSchedulerNode, shared_names: OrderedSet[str]
+) -> bool:
+    """True if any output of node is part of a shared-storage group (see
+    _cudagraph_shared_storage_names). Catches both a view buffer and the base
+    buffer that views point into."""
+    from .scheduler import FusedSchedulerNode
+
+    if isinstance(node, FusedSchedulerNode):
+        return any(
+            _node_touches_shared_storage(snode, shared_names) for snode in node.snodes
+        )
+    return any(buf.get_name() in shared_names for buf in node.get_outputs())
+
+
+def _node_uses_broadcast_gather(node: BaseSchedulerNode) -> bool:
+    """True if the node performs an index_select / advanced-index gather.
+    In ads (ROCS) models these implement user->ad broadcasting: a gather of
+    user-level rows by a per-request index tensor (batch_indices/rev_indices).
+    They are not safe inside an AOTI regional cuda graph -- the gather is the
+    batch-dim broadcast boundary and is request-structure dependent, so it
+    must stay eager (matches _is_batch_dim_transition, but also catches gathers
+    fused into otherwise single-symbol s13 kernels where dim0 does not change).
+    Detect through FX origins: match the aten op of the origin target or its
+    meta['original_aten'] (the gather may be fused/lowered, but the source op
+    is preserved in origins)."""
+    from .scheduler import FusedSchedulerNode
+
+    if isinstance(node, FusedSchedulerNode):
+        return any(_node_uses_broadcast_gather(snode) for snode in node.snodes)
+    ir_node = node.node
+    if ir_node is None:
+        return False
+    origins = getattr(ir_node, "origins", None)
+    if not origins:
+        return False
+    aten = torch.ops.aten
+    gather_packets: OrderedSet[object] = OrderedSet()
+    for name in ("index_select", "index", "_unsafe_index"):
+        op = getattr(aten, name, None)
+        if op is not None:
+            gather_packets.add(op)
+
+    def _packet(op: object) -> object:
+        return op.overloadpacket if isinstance(op, torch._ops.OpOverload) else op
+
+    for fx_node in origins:
+        target = getattr(fx_node, "target", None)
+        if target is not None and _packet(target) in gather_packets:
+            return True
+        meta = getattr(fx_node, "meta", None)
+        if meta is not None:
+            orig = meta.get("original_aten")
+            if orig is not None and _packet(orig) in gather_packets:
+                return True
+    return False
+
+
+def _node_uses_rng(node: BaseSchedulerNode) -> bool:
+    """True if the node involves RNG (random draw or seed generation). Such
+    nodes are unsafe inside an AOTI regional cuda graph: capture freezes the
+    philox seed+offset, so every replay reproduces identical draws instead of
+    advancing, diverging from the eager reference. (cuda graph trees handle
+    this via capturable generator state registered on the graph; AOTI has no
+    equivalent, so we keep RNG nodes eager.) Detect through FX origins: aten
+    RNG ops carry Tag.nondeterministic_seeded, and Inductor lowers them to
+    inductor_prims.{random,randint,seed,seeds,lookup_seed} (see
+    fx_passes/replace_random.py)."""
+    from .scheduler import FusedSchedulerNode
+
+    if isinstance(node, FusedSchedulerNode):
+        return any(_node_uses_rng(snode) for snode in node.snodes)
+    ir_node = node.node
+    if ir_node is None:
+        return False
+    origins = getattr(ir_node, "origins", None)
+    if not origins:
+        return False
+    # When fallback_random is False (default), replace_random rewrites aten
+    # RNG into these inductor_prims ops, which become the FX targets (and the
+    # IR origins). seed/seeds also carry nondeterministic_seeded; random/
+    # randint/lookup_seed do not, so match the op objects directly. The tag
+    # check additionally covers aten RNG kept as fallbacks.
+    from torch._inductor import inductor_prims
+
+    rng_ops: OrderedSet[object] = OrderedSet()
+    for name in ("seed", "seeds", "lookup_seed", "random", "randint"):
+        op = getattr(inductor_prims, name, None)
+        if op is not None:
+            rng_ops.add(op)
+    for fx_node in origins:
+        target = getattr(fx_node, "target", None)
+        if target is None:
+            continue
+        if target in rng_ops:
+            return True
+        if isinstance(target, torch._ops.OpOverload):
+            if torch.Tag.nondeterministic_seeded in target.tags:
+                return True
+            if target.overloadpacket in rng_ops:
+                return True
+    return False
+
+
+def _get_node_dynamic_symbols(
+    node: BaseSchedulerNode,
+) -> OrderedSet[sympy.Symbol]:
+    """Return the set of free dynamic symbols in this node's output shapes."""
+    from .scheduler import FusedSchedulerNode
+
+    result: OrderedSet[sympy.Symbol] = OrderedSet()
+    if isinstance(node, FusedSchedulerNode):
+        for snode in node.snodes:
+            result.update(_get_node_dynamic_symbols(snode))
+        return result
+    ir_node = node.node
+    if ir_node is None:
+        return result
+    for out in ir_node.get_outputs():
+        try:
+            layout = getattr(out, "layout", None)
+            if layout is None and hasattr(out, "get_layout"):
+                layout = out.get_layout()
+            if layout and hasattr(layout, "size"):
+                for d in layout.size:
+                    if isinstance(d, sympy.Expr) and not d.is_number:
+                        result.update(d.free_symbols)
+        except NotImplementedError:
+            pass
+    return result
+
+
+def _get_output_dim0_symbol(
+    node: BaseSchedulerNode,
+) -> sympy.Expr | int | None:
+    """
+    Return the dim0 expression for this node's outputs.
+    - A sympy.Symbol if dim0 is dynamic (e.g. s0 for user batch, s1 for ads batch)
+    - An int if dim0 is static and > 1
+    - None if unknown or scalar (dim0 == 1)
+    """
+    from .scheduler import FusedSchedulerNode
+
+    if isinstance(node, FusedSchedulerNode):
+        for snode in node.snodes:
+            r = _get_output_dim0_symbol(snode)
+            if r is not None:
+                return r
+        return None
+    ir_node = node.node
+    if ir_node is None:
+        return None
+    for out in ir_node.get_outputs():
+        try:
+            layout = getattr(out, "layout", None)
+            if layout is None and hasattr(out, "get_layout"):
+                layout = out.get_layout()
+            if layout and hasattr(layout, "size") and len(layout.size) > 0:
+                d = layout.size[0]
+                if isinstance(d, sympy.Expr) and not d.is_number:
+                    syms = d.free_symbols
+                    if len(syms) == 1:
+                        return next(iter(syms))
+                    return d
+                if isinstance(d, (int, sympy.Integer)) and int(d) > 1:
+                    return int(d)
+        except NotImplementedError:
+            pass
+    return None
+
+
+def _is_batch_dim_transition(node: BaseSchedulerNode) -> str | None:
+    """
+    Check if this node is a broadcast/gather boundary: it reads from
+    inputs with one batch dimension and writes outputs with a *different*
+    batch dimension. Covers both dynamic->static (user batch -> fixed) and
+    dynamic->different-dynamic (user batch s0 -> ads batch s1) transitions.
+    """
+    from .scheduler import FusedSchedulerNode
+
+    if isinstance(node, FusedSchedulerNode):
+        for snode in node.snodes:
+            if reason := _is_batch_dim_transition(snode):
+                return reason
+        return None
+
+    ir_node = node.node
+    if ir_node is None:
+        return None
+
+    def _get_dim0(layout: object) -> sympy.Expr | int | None:
+        if layout and hasattr(layout, "size") and len(layout.size) > 0:
+            return layout.size[0]
+        return None
+
+    out_symbols: set[sympy.Symbol] = set()
+    out_statics: set[int] = set()
+    for out in ir_node.get_outputs():
+        try:
+            layout = getattr(out, "layout", None)
+            if layout is None and hasattr(out, "get_layout"):
+                layout = out.get_layout()
+            d = _get_dim0(layout)
+            if d is None:
+                continue
+            if isinstance(d, sympy.Expr) and not d.is_number:
+                out_symbols.update(d.free_symbols)
+            elif isinstance(d, (int, sympy.Integer)) and int(d) > 1:
+                out_statics.add(int(d))
+        except NotImplementedError:
+            pass
+
+    if not out_symbols and not out_statics:
+        return None
+
+    input_symbols: set[sympy.Symbol] = set()
+    dep_names = {dep.name for dep in node.read_writes.reads}
+    for dep_name in dep_names:
+        try:
+            sz = None
+            if dep_name in V.graph.graph_inputs:
+                inp = V.graph.graph_inputs[dep_name]
+                if hasattr(inp, "get_size"):
+                    sz = inp.get_size()
+            else:
+                buf = V.graph.get_buffer(dep_name)
+                if buf is not None and hasattr(buf, "get_size"):
+                    sz = buf.get_size()
+            if sz and isinstance(sz[0], sympy.Expr) and not sz[0].is_number:
+                input_symbols.update(sz[0].free_symbols)
+        except (NotImplementedError, AttributeError):
+            pass
+
+    if not input_symbols:
+        return None
+
+    if out_statics and not out_symbols:
+        return (
+            f"batch dim transition (reads dynamic {input_symbols}, writes static dim0)"
+        )
+
+    if out_symbols and out_statics:
+        return f"batch dim transition (mixed dynamic {out_symbols} and static outputs)"
+
+    if out_symbols and input_symbols and out_symbols != input_symbols:
+        return f"batch dim transition (reads {input_symbols}, writes {out_symbols})"
+
+    return None
+
+
+def _get_node_input_dynamic_symbols(
+    node: BaseSchedulerNode, name_to_buf: dict[str, SchedulerBuffer]
+) -> OrderedSet[sympy.Symbol]:
+    """Free dynamic symbols in this node's READ buffers' layout sizes.
+    Mirrors _get_node_dynamic_symbols but over inputs, so eligibility can
+    union both: a node reading [s13,s14] and writing [s13] otherwise slips
+    through (output={s13}) and a second dynamic symbol leaks into the
+    captured partition via a non-dim0 input."""
+    from .scheduler import FusedSchedulerNode
+
+    result: OrderedSet[sympy.Symbol] = OrderedSet()
+    if isinstance(node, FusedSchedulerNode):
+        for snode in node.snodes:
+            result.update(_get_node_input_dynamic_symbols(snode, name_to_buf))
+        return result
+    for dep in node.read_writes.reads:
+        buf = name_to_buf.get(dep.name)
+        if buf is None or buf.node is None:
+            continue
+        try:
+            layout = getattr(buf.node, "layout", None)
+            if layout is None and hasattr(buf.node, "get_layout"):
+                layout = buf.node.get_layout()
+            if layout and hasattr(layout, "size"):
+                for d in layout.size:
+                    if isinstance(d, sympy.Expr) and not d.is_number:
+                        result.update(d.free_symbols)
+        except NotImplementedError:
+            pass
+    return result
+
+
+def _partition_io_dynamic_symbols(
+    node: BaseSchedulerNode, name_to_buf: dict[str, SchedulerBuffer]
+) -> OrderedSet[sympy.Symbol]:
+    """Union of free dynamic symbols across this node's INPUTS and OUTPUTS,
+    simplified. Used for cuda-graph eligibility so a node reading
+    [s13, s14] and writing [s13] is correctly counted as 2-symbol -- the
+    output-only check misses it and a second dynamic symbol can leak into the
+    captured partition via a non-dim0 input, causing wrong replays."""
+    syms: OrderedSet[sympy.Symbol] = OrderedSet()
+    combined = _get_node_dynamic_symbols(node) | _get_node_input_dynamic_symbols(
+        node, name_to_buf
+    )
+    for s in combined:
+        simplified = V.graph.sizevars.simplify(s)
+        if simplified.free_symbols:
+            syms.update(simplified.free_symbols)
+    return syms
+
+
+def _agglomerative_convex_clusters(
+    n: int,
+    succ: list[list[int]],
+    ancestors: list[set[int]],
+    eligible: list[bool],
+    sym: list[str | None],
+) -> list[int]:
+    """Cuda graph partitioning step 2: iteratively merge eligible neighbor
+    subgraphs when (a) combined dynamic symbols <= 1 and (b) the merge keeps
+    the partition graph acyclic (convex). Ineligible nodes are never merged.
+    Returns a cluster id (a representative node index) per node. Nodes are
+    indexed 0..n-1 in a topological order; `ancestors[i]` are i's transitive
+    ancestor indices."""
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    # Per-cluster (keyed by rep): dynamic-symbol set and ancestor-cluster set.
+    csyms: list[set[str]] = [
+        set() if sym[i] is None else {sym[i]}
+        for i in range(n)  # type: ignore[arg-type]
+    ]
+    canc: list[set[int]] = [set(ancestors[i]) - {i} for i in range(n)]
+
+    def try_merge(ru: int, rv: int) -> bool:
+        # Edge u->v: rv depends on ru, so ru is an ancestor of rv.
+        if ru == rv or not (eligible[ru] and eligible[rv]):
+            return False
+        if len(csyms[ru] | csyms[rv]) > 1:
+            return False
+        # Convex iff no third cluster z strictly between ru and rv.
+        for z in canc[rv]:
+            if z != ru and z != rv and ru in canc[z]:
+                return False
+        parent[rv] = ru
+        csyms[ru] |= csyms[rv]
+        canc[ru] |= canc[rv]
+        canc[ru].discard(ru)
+        canc[ru].discard(rv)
+        for z in range(n):
+            if parent[z] == z and rv in canc[z]:
+                canc[z].discard(rv)
+                canc[z].add(ru)
+        return True
+
+    changed = True
+    while changed:
+        changed = False
+        for u in range(n):
+            ru = find(u)
+            for v in succ[u]:
+                if try_merge(ru, find(v)):
+                    changed = True
+                    ru = find(u)
+
+    return [find(i) for i in range(n)]
+
+
+def _linearize_clusters(n: int, cluster: list[int], succ: list[list[int]]) -> list[int]:
+    """Cluster-level topological sort; nodes within a cluster keep their
+    original relative order. Returns a node-index order where each cluster is
+    contiguous and all dependencies are respected (valid because clusters are
+    convex)."""
+    members: dict[int, list[int]] = {}
+    for i in range(n):
+        members.setdefault(cluster[i], []).append(i)
+    cedges: dict[int, OrderedSet[int]] = {r: OrderedSet() for r in members}
+    cindeg: dict[int, int] = {r: 0 for r in members}
+    for u in range(n):
+        cu = cluster[u]
+        for v in succ[u]:
+            cv = cluster[v]
+            if cu != cv and cv not in cedges[cu]:
+                cedges[cu].add(cv)
+                cindeg[cv] += 1
+    minidx = {r: members[r][0] for r in members}
+    ready = [(minidx[r], r) for r in members if cindeg[r] == 0]
+    heapq.heapify(ready)
+    order: list[int] = []
+    while ready:
+        _, r = heapq.heappop(ready)
+        order.extend(members[r])
+        for cv in cedges[r]:
+            cindeg[cv] -= 1
+            if cindeg[cv] == 0:
+                heapq.heappush(ready, (minidx[cv], cv))
+    assert len(order) == n, "cluster graph not a DAG (linearize failed)"
+    return order
+
+
+def _resolve_handoff_buffer(name: str) -> BufferLike | None:
+    """Return the underlying ir.Buffer for a handoff name, or None.
+
+    V.graph.try_get_buffer may return a TensorBox/StorageBox (MutableBox)
+    wrapping the Buffer; peel the box so the synthetic Allocation reads the
+    real layout. WorkspaceArg / TorchBindObject have no tensor layout and
+    are not valid handoff buffers, so they resolve to None.
+    """
+    from . import ir
+
+    node = V.graph.try_get_buffer(name)
+    while isinstance(node, ir.MutableBox):
+        node = node.data
+    if isinstance(node, ir.Buffer):
+        return node
+    return None
+
+
+def _pack_handoff_pool(
+    pool_name: str,
+    named_allocations: list[tuple[str, Allocation]],
+    pool_id: int,
+) -> AllocationPool:
+    """Pack one per-symbol group of handoff allocations into a single pool.
+
+    Seeds the pool with the first block, then allocates the rest with
+    is_last=True so a block that fits no existing slot grows the pool at the
+    end; allocate_at_end is the fallback when allocate() refuses a block
+    whose earliest_available (unbacked-symint shapes) is past the pool
+    begin. finalize() assigns each Allocation its byte offset. pool_id is the
+    reserved cudagraph-slab-cache id for this pool.
+    """
+    from .codegen.memory_planning import AllocationPool, TemporalSplit
+
+    first_allocation = named_allocations[0][1]
+    first_allocation.mark_allocated()
+    pool = AllocationPool(
+        first_allocation.device,
+        TemporalSplit([first_allocation]),
+        can_expand=config.memory_pool != "none",
+        pool_id=pool_id,
+    )
+    for _name, allocation in named_allocations[1:]:
+        if not pool.allocate(allocation, is_last=True):
+            pool.allocate_at_end(allocation)
+    pool.finalize(pool_name)
+    return pool
+
+
+def _cudagraph_handoff_slab_planning_enabled() -> bool:
+    """Wrapper-free gate for the handoff slab planning, equivalent to
+    _cudagraph_slab_cache_enabled but evaluated without a wrapper instance so it
+    can run in the scheduler pre-pass (Phase 1).
+
+    AOTI cpp-wrapper + GPU target, with cuda-graph + memory_planning on. Because
+    this runs once on the outer graph in the scheduler pre-pass (NOT per subgraph
+    wrapper), the original "only the outer wrapper" guard (subgraph_name is None)
+    is satisfied implicitly. Off (any condition false) -> early return, leaving
+    non-cuda-graph behavior unchanged.
+    """
+    from .utils import is_gpu
+
+    if not config.aot_inductor.enable_cuda_graph:
+        return False
+    if not config.memory_planning:
+        return False
+    if not (V.graph.aot_mode and V.graph.cpp_wrapper):
+        return False
+    return is_gpu(V.graph.device_type)
+
+
+def plan_cudagraph_handoff_slab() -> None:
+    """Hoist captured-partition handoff buffers into OUTER-owned, PER-SYMBOL slab
+    regions.
+
+    Memory planning is per-partition: each captured partition is codegen'd
+    through its own subgraph wrapper with its own MemoryPlanner -> its own
+    AllocationPools, so pool names restart per partition (pool0 in every
+    partition). The outer wrapper sees a partition only as one
+    codegen_partition_call line, so it never builds an Allocation for any
+    cross-partition handoff buffer (a partition output consumed by a LATER
+    partition). Those handoff buffers therefore live in the per-partition
+    runtime pool, not the slab.
+
+    PHASE ORDERING (why this is a scheduler pre-pass, not a wrapper plan pass):
+    the two readers of the dicts published here both run in Phase 1
+    (Scheduler.codegen): (a) the per-partition body's AllocFromPoolLine.codegen
+    reads _cudagraph_boundary_offsets, and (b) the outer codegen_partition_call
+    reads _cudagraph_handoff_pools. The outer wrapper's MemoryPlanner.plan runs
+    in Phase 2 (wrapper_code.generate, after Scheduler.codegen). So this MUST be
+    called from the scheduler pre-pass, before the partition codegen loop, or the
+    dicts would still be empty when both readers run.
+
+    This pass runs ONCE on the outer graph and builds dedicated AllocationPools
+    for exactly the buffers in V.graph._cudagraph_handoff_liveness (populated by
+    the scheduler pre-pass). These buffers have NO outer AllocateLine, so we
+    construct synthetic BufferGroup/Allocation objects directly from each
+    buffer's ir.Buffer layout (size/stride/dtype live on V.graph, independent of
+    which partition emits the buffer).
+
+    PER-SYMBOL POOLS (the key ABI decision): a handoff's byte offset is a sum of
+    aligned sizes of the OTHER handoffs packed before it in the same pool. The
+    producer partition body emits alloc_from_pool(pool, offset, ...) inline, and
+    a partition is restricted to <=1 dynamic symbol in its C++ scope. So we group
+    handoffs by the single dynamic symbol of their symbolic nbytes and give each
+    group its own pool: every offset in a pool then references only that pool's
+    one symbol, which is exactly the symbol live in any producing partition's
+    body. Static-size handoffs (no dynamic symbol) go to a separate static pool
+    (int offsets). A handoff whose nbytes carries >=2 dynamic symbols cannot be
+    made single-symbol-safe and is EXCLUDED (left on the runtime copy_in path ==
+    current behavior).
+
+    Within each pool, offsets are assigned by pid-interval overlap, NOT by
+    timestep: each handoff's live_range is its [first_producer_pid ..
+    last_consumer_pid] captured-partition execution interval, so two handoffs
+    share a slot iff their pid intervals are disjoint. There is no global
+    timestep axis (per-partition planners restart timestep at 0), so we bypass
+    compute_live_ranges and feed the pid-interval live_range straight into the
+    existing AllocationPool / TemporalSplit / SpatialSplit packer; pool.finalize()
+    then assigns each Allocation a byte offset via Allocation.finalize(pool,
+    offset).
+
+    The result is exposed as
+    V.graph._cudagraph_boundary_offsets[name] = (per_symbol_pool_name, offset),
+    where per_symbol_pool_name is the single stable pool name for that symbol
+    (resolving the per-partition pool0 ambiguity) and offset is the byte offset
+    into that pool (int for static handoffs, a sympy.Expr in that pool's single
+    symbol otherwise).
+
+    Gated (via _cudagraph_handoff_slab_planning_enabled) on AOTI cpp-wrapper +
+    GPU + cuda-graph + memory_planning; when off this function early-returns and
+    leaves non-cuda-graph behavior unchanged.
+    """
+    if not _cudagraph_handoff_slab_planning_enabled():
+        return
+
+    from .codegen.memory_planning import BufferGroup, LiveRange
+
+    handoff_liveness: dict[str, tuple[int, int]] = (
+        getattr(V.graph, "_cudagraph_handoff_liveness", None) or {}
+    )
+    if not handoff_liveness:
+        V.graph._cudagraph_boundary_offsets = {}
+        return
+
+    # Group handoffs by the single dynamic symbol of their symbolic nbytes.
+    # sym_key is "" for static (no dynamic symbol) -> the static pool.
+    groups_by_sym: dict[str, list[tuple[str, Allocation]]] = {}
+    for name, (producer_pid, last_consumer_pid) in handoff_liveness.items():
+        node = _resolve_handoff_buffer(name)
+        if node is None:
+            # No materialized ir.Buffer (e.g. unexpected alias/view). Skip
+            # slab placement; the codegen side keeps such a buffer on the
+            # existing copy_in path.
+            continue
+        group = BufferGroup(node)
+        syms = sorted(
+            (s for s in group.sym_nbytes().free_symbols if isinstance(s, sympy.Symbol)),
+            key=str,
+        )
+        if len(syms) >= 2:
+            # Offsets in a shared pool would reference >1 symbol, but a
+            # producer partition body has only its single symbol in scope.
+            # Cannot place safely -> fall back to copy_in (current behavior).
+            continue
+        sym_key = str(syms[0]) if syms else ""
+        # pid interval [producer .. last_consumer], both inclusive. LiveRange
+        # end is exclusive, so +1 makes a handoff consumed at pid K and one
+        # produced at pid K correctly overlap (both live during pid K's run)
+        # and thus get disjoint slots, while truly disjoint intervals share.
+        group.live_range = LiveRange(producer_pid, last_consumer_pid + 1)
+        group.make_allocation()
+        if group.allocation is None:
+            raise AssertionError("handoff group has no allocation")
+        groups_by_sym.setdefault(sym_key, []).append((name, group.allocation))
+
+    boundary_offsets: dict[str, tuple[str, Any]] = {}
+    # Retain the finalized pools so the OUTER cpp wrapper can emit each
+    # handoff slab once (via AllocationPool.codegen_create, reusing the
+    # per-instance cached-slab path). Keyed by stable pool name.
+    handoff_pools: dict[str, AllocationPool] = {}
+    # Reserved cache-key id base for handoff pools. The slab-cache key packs the
+    # pool id into the high bits as ((int64_t)pool_id << 40) (see
+    # _codegen_create_cudagraph_cached and cudagraph_tree.h encode()). With a
+    # signed int64 key, the base must satisfy (base << 40) < 2**63: 1<<22 gives
+    # (1<<22) << 40 == 2**62, in range and positive. (The earlier 1<<30 made
+    # (1<<30) << 40 == 2**70, which overflows int64 and aliases to 0 -- handoff
+    # pool index i would then collide with the ordinary pool{i} slab.) The base
+    # also stays above the legacy hash-bucket range 1<<20 used for non-poolN
+    # names, so handoff slabs never alias a per-partition pool0 slab in
+    # this->cudagraph_slabs_.
+    handoff_pool_id_base = 1 << 22
+    for pool_index, (sym_key, named_allocations) in enumerate(
+        sorted(groups_by_sym.items())
+    ):
+        # Keep base+index < 2**23 so (pool_id << 40) < 2**63 stays in signed
+        # int64 range and distinct from the small ordinary pool ids 0..N and the
+        # legacy 1<<20 hash bucket. 1<<17 distinct handoff pools is far beyond the
+        # handful of dynamic symbols a model has.
+        if pool_index >= (1 << 17):
+            raise AssertionError(
+                f"too many cudagraph handoff pools ({pool_index + 1}); "
+                "pool id would exceed the reserved int64 key range"
+            )
+        pool_name = (
+            f"cudagraph_handoff_pool_{sym_key}"
+            if sym_key
+            else "cudagraph_handoff_pool_static"
+        )
+        pool = _pack_handoff_pool(
+            pool_name, named_allocations, handoff_pool_id_base + pool_index
+        )
+        # Compare by symbol NAME, not Symbol object: Inductor size symbols
+        # carry assumptions (positive/integer) so a bare sympy.Symbol(name)
+        # would not equal them and would spuriously fail the subset check.
+        allowed = {sym_key} if sym_key else set()
+        placed_any = False
+        for name, allocation in named_allocations:
+            if allocation.offset is None:
+                raise AssertionError("handoff allocation not finalized")
+            offset_syms = set()
+            if isinstance(allocation.offset, sympy.Expr):
+                offset_syms = {
+                    str(s)
+                    for s in allocation.offset.free_symbols
+                    if isinstance(s, sympy.Symbol)
+                }
+            if not offset_syms.issubset(allowed):
+                # Defensive: packing produced a cross-symbol offset despite
+                # single-symbol grouping. Exclude rather than emit an
+                # out-of-scope symbol in the producer body.
+                continue
+            boundary_offsets[name] = (pool_name, allocation.offset)
+            placed_any = True
+        if placed_any:
+            handoff_pools[pool_name] = pool
+
+    V.graph._cudagraph_boundary_offsets = boundary_offsets
+    V.graph._cudagraph_handoff_pools = handoff_pools

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -29,9 +29,9 @@ from typing import (
     TypeAlias,
     TypeVar,
 )
-from typing_extensions import ParamSpec
 
 from torch.utils._ordered_set import OrderedSet
+from typing_extensions import ParamSpec
 
 from .ir import ComputedBuffer, Pointwise
 
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
     from .tiling_utils import CoalesceVarAnalysis
 
 import sympy
-
 import torch
 import torch._inductor.async_compile
 import torch.utils._pytree as pytree
@@ -61,7 +60,15 @@ from torch.utils._sympy.functions import FloorDiv
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
 from torch.utils._triton import has_triton
 
-from . import comms, config, config_comms, dependencies, ir, metrics
+from . import (
+    comms,
+    config,
+    config_comms,
+    cudagraph_partition,
+    dependencies,
+    ir,
+    metrics,
+)
 from .analyze_preserves_zero_mask import can_codegen_without_upcasts
 from .codegen.common import BackendFeature, get_scheduling_for_device, Kernel
 from .comm_analysis import (
@@ -4401,6 +4408,12 @@ class Scheduler:
         ):
             self.nodes = self.maybe_reorder_for_minimizing_partition(self.nodes)
             self.nodes = self.reorder_for_partition_with_simple_dependency(self.nodes)
+
+        # AOTI cuda graph: reorder so each single-symbol convex cluster is
+        # contiguous (agglomerative convex merge). Must run before
+        # compute_last_usage so buffer-free liveness matches the emitted order.
+        if config.aot_inductor.enable_cuda_graph:
+            self.nodes = self._cudagraph_cluster_reorder(self.nodes)
 
         self.compute_last_usage()
 
@@ -9144,7 +9157,42 @@ class Scheduler:
             if get_scheduler_node_symbol_uses(node):
                 return "dynamic shape ops"
 
+        if config.aot_inductor.enable_cuda_graph:
+            if reason := cudagraph_partition._is_batch_dim_transition(node):
+                return reason
+            if cudagraph_partition._node_uses_rng(node):
+                return "RNG ops (philox seed/offset frozen under AOTI cuda graph)"
+            if cudagraph_partition._node_uses_broadcast_gather(node):
+                return "index_select/gather (ROCS broadcast not cuda-graph-safe)"
+            if cudagraph_partition._node_touches_shared_storage(
+                node, self._cudagraph_shared_storage_names()
+            ):
+                # A node touching a buffer whose storage is shared with another
+                # buffer is unsafe to capture: the partitioner can place the
+                # buffer's writers/readers on opposite sides of a capture boundary,
+                # so the partition allocates a fresh output buffer and the slices
+                # written in the eager region are lost (wrong numerics) AND the
+                # buffer gets declared twice in the generated C++
+                # (RAIIAtenTensorHandle redefinition -> CppCompileError). This
+                # covers BOTH alias directions: a view/ReinterpretView (e.g. a
+                # concat slice) and the base buffer that other views point into
+                # (e.g. a concat/chunk base feeding a bmm, whose own output has no
+                # aliases so node.has_aliasing_or_mutation() alone misses it). Keep
+                # these eager so shared-storage buffers are never split.
+                return "shared storage buffer (concat/slice/alias unsafe to split)"
+
         return None
+
+    def _cudagraph_shared_storage_names(self) -> OrderedSet[str]:
+        """Cache the shared-storage name set (see
+        cudagraph_partition._cudagraph_shared_storage_names) on the scheduler so
+        should_partition computes it once over self.nodes."""
+        cached = getattr(self, "_cg_shared_storage_names", None)
+        if cached is not None:
+            return cached
+        names = cudagraph_partition._cudagraph_shared_storage_names(self.nodes)
+        self._cg_shared_storage_names = names
+        return names
 
     @cache_on_self
     def _get_cudagraph_unsafe_unbacked_symints(self) -> OrderedSet[sympy.Symbol]:
@@ -9436,9 +9484,25 @@ class Scheduler:
                 for name in returned_output_names
             )
 
+            # Expand MultiOutputLayout buffers to their MultiOutput children.
+            # MultiOutputLayout is the parent ExternKernel (e.g. SDPA) which has
+            # no C++ tensor variable -- only its MultiOutput children do.
+            expanded_output_names: OrderedSet[str] = OrderedSet()
+            for name in returned_output_names:
+                buf = self.name_to_buf.get(name, None)
+                if buf is not None and isinstance(buf.node.layout, MultiOutputLayout):
+                    for out_buf in buf.defining_op.outputs:
+                        child_name = out_buf.get_name()
+                        if not isinstance(
+                            out_buf.node.layout, (NoneLayout, MultiOutputLayout)
+                        ):
+                            expanded_output_names.add(child_name)
+                else:
+                    expanded_output_names.add(name)
+
             output_nodes = [
                 name_to_node[name]
-                for name in returned_output_names
+                for name in expanded_output_names
                 if not is_unallocated_buffer(name)
             ]
 
@@ -9636,6 +9700,122 @@ class Scheduler:
 
         return front + middle + back
 
+    def _cudagraph_cluster_reorder(
+        self, nodes: list[BaseSchedulerNode]
+    ) -> list[BaseSchedulerNode]:
+        """Spec-based partitioning reorder for AOTI regional cuda graph. Builds the
+        dependency graph, classifies nodes (op-eligible AND <=1 dynamic shape),
+        agglomeratively merges eligible neighbor subgraphs keeping each cluster
+        single-symbol and convex, then linearizes clusters and returns the new
+        node order (each convex cluster contiguous). Stores per-node cluster id and
+        eligibility (aligned to the returned order) for graph_partition. MUST run
+        before compute_last_usage so buffer-free liveness matches the final order."""
+        n = len(nodes)
+        node_to_index = {node: i for i, node in enumerate(nodes)}
+
+        def idx_of_op(name: str) -> int | None:
+            fused = self.name_to_fused_node.get(name)
+            return node_to_index.get(fused) if fused is not None else None
+
+        succ: list[list[int]] = [[] for _ in range(n)]
+        succ_seen: list[OrderedSet[int]] = [OrderedSet() for _ in range(n)]
+        ancestors: list[set[int]] = [set() for _ in range(n)]
+        eligible: list[bool] = [False] * n
+        sym: list[str | None] = [None] * n
+        for i, node in enumerate(nodes):
+            for aname in node.ancestors:
+                j = idx_of_op(aname)
+                if j is not None and j != i:
+                    ancestors[i].add(j)
+            for dep in node.unmet_dependencies:
+                buf = self.name_to_buf.get(dep.name)
+                if buf is None:
+                    continue
+                j = idx_of_op(buf.defining_op_name())
+                if j is not None and j != i and i not in succ_seen[j]:
+                    succ_seen[j].add(i)
+                    succ[j].append(i)
+            # Input-aware: union(input_syms, output_syms) so a node reading
+            # [s13, s14] and writing [s13] is correctly counted as 2-symbol.
+            # Output-only would let it through (output={s13}) and a second
+            # dynamic symbol would leak into the captured partition via a
+            # non-dim0 input -> wrong replay.
+            syms = cudagraph_partition._partition_io_dynamic_symbols(
+                node, self.name_to_buf
+            )
+            is_eligible = self.should_partition(node) is None and len(syms) <= 1
+            if is_eligible:
+                eligible[i] = True
+                sym[i] = next(iter(syms)).name if syms else None
+
+        cluster = cudagraph_partition._agglomerative_convex_clusters(
+            n, succ, ancestors, eligible, sym
+        )
+        order = cudagraph_partition._linearize_clusters(n, cluster, succ)
+        # Safety: the contiguous-cluster order must remain a valid topological
+        # order (every transitive ancestor precedes). A failure means a cluster
+        # was not convex (emitting it contiguously moved a node out of dep order).
+        pos = [0] * n
+        for k, i in enumerate(order):
+            pos[i] = k
+        for i in range(n):
+            for a in ancestors[i]:
+                assert pos[a] < pos[i], (
+                    f"cudagraph cluster reorder broke topo order: ancestor {a} "
+                    f"(cluster {cluster[a]}) not before {i} (cluster {cluster[i]})"
+                )
+        # Store cluster id + eligibility per node, aligned to the returned order,
+        # so graph_partition can build partitions without reordering again.
+        self._cg_cluster_ids = [cluster[i] for i in order]
+        self._cg_node_eligible = [eligible[i] for i in order]
+        return [nodes[i] for i in order]
+
+    def _cudagraph_partitions_from_clusters(
+        self,
+    ) -> tuple[list[PartitionType], list[bool]]:
+        """Build partitions from the cluster assignment computed by
+        _cudagraph_cluster_reorder (self.nodes is already in cluster-contiguous
+        order): consecutive ineligible nodes -> one skip partition; each eligible
+        cluster -> its own partition."""
+        cluster_ids = getattr(self, "_cg_cluster_ids", None)
+        eligible = getattr(self, "_cg_node_eligible", None)
+        assert (
+            cluster_ids is not None
+            and eligible is not None
+            and len(cluster_ids) == len(self.nodes)
+        ), "cuda graph cluster assignment missing or misaligned with self.nodes"
+        # Demote eligible clusters below the size threshold to skip (eager):
+        # capturing a tiny partition as its own cuda graph costs per-replay
+        # staging + launch overhead that outweighs the kernel-launch saving when
+        # there are only a few kernels to amortize it over.
+        min_cg_size = cudagraph_partition.MIN_CG_SIZE
+        cluster_size: dict[object, int] = {}
+        for k in range(len(self.nodes)):
+            if eligible[k]:
+                cid = cluster_ids[k]
+                cluster_size[cid] = cluster_size.get(cid, 0) + 1
+        partitions: list[PartitionType] = []
+        skip_cudagraphs: list[bool] = []
+        cur: PartitionType = []
+        cur_key: object = None
+        cur_skip = True
+        for k, node in enumerate(self.nodes):
+            skip = (not eligible[k]) or cluster_size.get(
+                cluster_ids[k], 0
+            ) < min_cg_size
+            key: object = "skip" if skip else ("cluster", cluster_ids[k])
+            if cur and key != cur_key:
+                partitions.append(cur)
+                skip_cudagraphs.append(cur_skip)
+                cur = []
+            cur.append(node)
+            cur_key = key
+            cur_skip = skip
+        if cur:
+            partitions.append(cur)
+            skip_cudagraphs.append(cur_skip)
+        return partitions, skip_cudagraphs
+
     def graph_partition(
         self,
     ) -> tuple[list[PartitionType], list[GraphPartitionSignature]]:
@@ -9643,23 +9823,40 @@ class Scheduler:
         Given a list of BaseSchedulerNodes, split into a list of
         graph partitions and compute partition input/output signatures.
         """
-        partitions: list[PartitionType] = []
-        skip_cudagraph = True
-        cur_partition: PartitionType = []
-        skip_cudagraphs = []
-        for node in self.nodes:
-            node_should_partition = self.should_partition(node) is not None
-            if cur_partition and skip_cudagraph != node_should_partition:
+        partitions: list[PartitionType]
+        skip_cudagraphs: list[bool]
+        if config.aot_inductor.enable_cuda_graph:
+            # Spec-based partitioning: partitions from the agglomerative convex
+            # cluster assignment computed in __init__ (cluster-contiguous order,
+            # before compute_last_usage so liveness matches the emitted order).
+            partitions, skip_cudagraphs = self._cudagraph_partitions_from_clusters()
+        else:
+            partitions = []
+            skip_cudagraph = True
+            cur_partition: PartitionType = []
+            skip_cudagraphs = []
+            for node in self.nodes:
+                node_should_partition = self.should_partition(node) is not None
+                if cur_partition and skip_cudagraph != node_should_partition:
+                    partitions.append(cur_partition)
+                    skip_cudagraphs.append(skip_cudagraph)
+                    cur_partition = []
+
+                skip_cudagraph = node_should_partition
+                cur_partition.append(node)
+
+            if cur_partition:
                 partitions.append(cur_partition)
                 skip_cudagraphs.append(skip_cudagraph)
-                cur_partition = []
 
-            skip_cudagraph = node_should_partition
-            cur_partition.append(node)
-
-        if cur_partition:
-            partitions.append(cur_partition)
-            skip_cudagraphs.append(skip_cudagraph)
+        n_eligible = sum(1 for s in skip_cudagraphs if not s)
+        n_skip = sum(1 for s in skip_cudagraphs if s)
+        cudagraphs_log.debug(
+            "graph_partition: %d partitions, %d eligible, %d non-eligible",
+            len(partitions),
+            n_eligible,
+            n_skip,
+        )
 
         # Apply minimum partition size threshold: if a cudagraph-eligible partition
         # has fewer kernels than the threshold, mark it as non-cudagraphable
@@ -9680,6 +9877,43 @@ class Scheduler:
         signatures = self.get_graph_partition_signature(
             partitions=partitions, skip_cudagraphs=skip_cudagraphs
         )
+
+        if config.aot_inductor.enable_cuda_graph:
+            min_cg_size = cudagraph_partition.MIN_CG_SIZE
+            new_sigs = []
+            for partition, sig in zip(partitions, signatures):
+                # Demote a captured partition to eager (skip) when either:
+                #   * it is below the size threshold (per-replay staging + launch
+                #     overhead is not amortized over enough kernels), or
+                #   * its signature requires more than one dynamic symbol. The
+                #     runtime shape_key in codegen_partition_call keys the captured
+                #     graph on a SINGLE symbol, so a multi-symbol partition cannot
+                #     be replayed and codegen rejects it.
+                #
+                # Node-level eligibility (_cudagraph_cluster_reorder) and the
+                # cluster-merge guard count symbols via _partition_io_dynamic_symbols,
+                # which only inspects buffer SIZE dims. The codegen invariant is
+                # enforced on sig.symbol_inputs (get_graph_partition_symbol_inputs),
+                # a strictly wider set: it also pulls symbols from strides/offsets,
+                # node indexing exprs (get_free_symbol_uses), and partition INPUT
+                # node layouts. A cluster whose nodes each carry <=1 size-dim symbol
+                # can therefore still produce a 2-symbol signature. This pass closes
+                # that gap by demoting on the exact set the invariant checks.
+                multi_symbol = len(sig.symbol_inputs) > 1
+                if not sig.skip_cudagraph and (
+                    len(partition) < min_cg_size or multi_symbol
+                ):
+                    sig = GraphPartitionSignature(
+                        sig.symbol_inputs,
+                        sig.input_nodes,
+                        sig.output_nodes,
+                        sig.input_deallocation,
+                        True,
+                        sig.constant_names,
+                    )
+                new_sigs.append(sig)
+            signatures = new_sigs
+
         self.compute_graph_partition_maps(signatures)
 
         self._log_graph_partitions(partitions, signatures)
@@ -9691,9 +9925,6 @@ class Scheduler:
         partitions: list[PartitionType],
         signatures: list[GraphPartitionSignature],
     ) -> None:
-        if not cudagraphs_log.isEnabledFor(logging.DEBUG):
-            return
-
         # Don't log partition reasons for CPU-only graphs since cudagraph
         # partitioning is not relevant when there are no GPU devices
         has_gpu_device = any(is_gpu(device) for device in V.graph.device_types)
@@ -9702,55 +9933,42 @@ class Scheduler:
 
         cudagraphable_count = sum(1 for s in signatures if not s.skip_cudagraph)
         non_cudagraphable_count = len(signatures) - cudagraphable_count
-        cudagraphs_log.debug(
-            "Created %d graph partitions: %d cudagraphable, %d non-cudagraphable",
+        cudagraphs_log.warning(
+            "graph_partition: %d partitions, %d cudagraphable, %d non-cudagraphable",
             len(partitions),
             cudagraphable_count,
             non_cudagraphable_count,
         )
         for i, (partition, signature) in enumerate(zip(partitions, signatures)):
-            cudagraphs_log.debug(
-                "  Partition %d: %d nodes, %s, inputs=%d, outputs=%d",
+            sym_names = [s.name for s in signature.symbol_inputs]
+            cudagraphs_log.warning(
+                "  Partition %d: %d nodes, %s, inputs=%d, outputs=%d, symbols=%s",
                 i,
                 len(partition),
-                "non-cudagraphable" if signature.skip_cudagraph else "cudagraphable",
+                "ELIGIBLE" if not signature.skip_cudagraph else "SKIP",
                 len(signature.input_nodes),
                 len(signature.output_nodes),
+                sym_names,
             )
-            if signature.skip_cudagraph:
-                # Log details for each non-cudagraphable node
+            if signature.skip_cudagraph and len(partition) <= 3:
                 for node in partition:
-                    self._log_non_cudagraphable_node(node)
-
-    def _log_non_cudagraphable_node(self, node: BaseSchedulerNode) -> None:
-        """Log details for a non-cudagraphable node."""
-        reason = self.should_partition(node)
-        if not reason:
-            return
-
-        node_name = node.get_name()
-        fx_node = node.node.get_origin_node() if node.node is not None else None
-        parts = [f"reason={reason}"]
-        ir_type = type(node.node).__name__
-        parts.append(f"ir={ir_type}")
-        if fx_node is not None:
-            fx_str = f"{fx_node.target}({', '.join(str(a) for a in fx_node.args)})"
-            parts.append(f"fx={fx_str}")
-
-        cudagraphs_log.debug("    %s: %s", node_name, ", ".join(parts))
-
-        # Log full stack trace if available
-        if fx_node is not None:
-            stack_trace = fx_node.meta.get("stack_trace", None)
-            if stack_trace:
-                for line in stack_trace.strip().split("\n"):
-                    cudagraphs_log.debug("         %s", line)
+                    ir_type = type(node.node).__name__ if node.node else "?"
+                    fx_node = (
+                        node.node.get_origin_node() if node.node is not None else None
+                    )
+                    fx_target = str(fx_node.target) if fx_node is not None else "?"
+                    cudagraphs_log.warning(
+                        "    node %s: ir=%s, fx=%s",
+                        node.get_name(),
+                        ir_type,
+                        fx_target,
+                    )
 
     def codegen(self) -> None:
         with dynamo_timed("Scheduler.codegen"):
             return (
                 self._codegen_partitions()
-                if torch._inductor.config.graph_partition
+                if config.graph_partition and not V.graph.is_const_graph
                 else self._codegen(self.nodes)
             )
 
@@ -9786,7 +10004,16 @@ class Scheduler:
             # and recorded in V.graph.removed_buffers. So we cleanup signature and write
             # prefix (i.e., generating call function and return outputs) after we have
             # codegen the partition.
-            if not isinstance(V.graph.wrapper_code, SubgraphPythonWrapperCodegen):
+            # AOTI cuda-graph emits each partition body through the C++ wrapper
+            # (a CppWrapperGpu subgraph), which carries partition_signatures and
+            # subgraph_name but is not a SubgraphPythonWrapperCodegen. Accept both.
+            if not (
+                isinstance(V.graph.wrapper_code, SubgraphPythonWrapperCodegen)
+                or (
+                    hasattr(V.graph.wrapper_code, "partition_signatures")
+                    and hasattr(V.graph.wrapper_code, "subgraph_name")
+                )
+            ):
                 raise AssertionError(
                     "expected wrapper_code to be a SubgraphPythonWrapperCodegen"
                 )
@@ -9800,6 +10027,11 @@ class Scheduler:
             V.graph.wrapper_code.write_prefix()
 
             partition_code, _ = V.graph.wrapper_code.generate(V.graph.is_inference)
+            # Do not pop codegened_graph_stack here. init_wrapper_code above made a
+            # fresh subgraph wrapper whose stack is empty, and partition codegen
+            # never pushes onto it (only GraphLowering.codegen and HOO
+            # EnterSubgraphLine push, neither of which runs for a partition body).
+            # A pop here pops an empty stack -> IndexError.
 
         V.graph.wrapper_code.define_subgraph_launcher_fn(graph_name, partition_code)
 
@@ -9893,6 +10125,149 @@ class Scheduler:
         if len(partitions) > 1:
             counters["inductor"]["cudagraph_partitions"] += len(partitions)
 
+        num_cg_partitions = sum(1 for sig in signatures if not sig.skip_cudagraph)
+        V.graph.wrapper_code.set_all_partition_names(num_cg_partitions)
+
+        # [AOTI cuda graph] Compile-time liveness for the cuda-graph runtime
+        # (cudagraph_tree.h). Captured partitions are indexed in execution
+        # order (== graph_partition_id). For each captured output we precompute:
+        #   * _cudagraph_escape_outs[cpid]: output indices that leave the captured
+        #     region (model outputs or consumed by an eager partition) -> kept.
+        #   * _cudagraph_real_producer_pid[name]: earliest captured cpid that
+        #     truly allocates `name` (per-edge chained-input classifier).
+        if config.aot_inductor.enable_cuda_graph:
+            captured = [sig for sig in signatures if not sig.skip_cudagraph]
+            model_outs = OrderedSet(V.graph.get_output_names())
+            cap_out_names: list[list[str]] = [
+                [n.get_name() for n in sig.output_nodes] for sig in captured
+            ]
+            cap_in_names: list[OrderedSet[str]] = [
+                OrderedSet(sig.input_nodes.keys()) for sig in captured
+            ]
+            eager_in_names: OrderedSet[str] = OrderedSet()
+            for sig in signatures:
+                if sig.skip_cudagraph:
+                    eager_in_names.update(sig.input_nodes.keys())
+            escape_outs: dict[int, list[int]] = {}
+            for cpid, names in enumerate(cap_out_names):
+                for idx, name in enumerate(names):
+                    consumers = [
+                        c
+                        for c in range(len(captured))
+                        if c != cpid and name in cap_in_names[c]
+                    ]
+                    if name in model_outs or name in eager_in_names or not consumers:
+                        escape_outs.setdefault(cpid, []).append(idx)
+            V.graph._cudagraph_escape_outs = escape_outs
+            # real_producer_pid[name] = the EARLIEST captured-partition cpid
+            # that truly ALLOCATES `name` (i.e. name is in cap_out_names[cpid]
+            # AND NOT in cap_in_names[cpid] -- so it is NOT a passthrough re-
+            # export). The codegen consumer in cpp_wrapper_gpu.py uses this
+            # for the chained-input classifier: an input is chained iff its
+            # real producer is captured AND ran earlier in the path. Passthrough
+            # re-exports are excluded because their real allocator is an EAGER
+            # partition that reallocates at a fresh address each forward, so a
+            # captured downstream kernel chaining off one would bake a stale
+            # address. mutation_real_name is already applied to both partition
+            # input names and returned output names, so post-rename names are
+            # consistent on both sides; no extra rename lookup is needed here.
+            real_producer_pid: dict[str, int] = {}
+            for cpid, names in enumerate(cap_out_names):
+                for name in names:
+                    if name not in cap_in_names[cpid]:
+                        if name not in real_producer_pid:
+                            real_producer_pid[name] = cpid
+            V.graph._cudagraph_real_producer_pid = real_producer_pid
+            # Slab-stability exclusion for eager->CG chaining: buffers produced
+            # by extern kernels (ExternKernelAlloc/FallbackKernel) are NOT pooled
+            # by memory_planning -> not slab-stable -> a captured consumer must
+            # copy_in, not chain. Computed HERE (before codegen) so the classifier
+            # sees the COMPLETE set; the per-scope memory_planning recording
+            # finishes too late (the outer wrapper's pool is recorded only after
+            # all chain decisions have already been emitted).
+            extern_output_names: set[str] = set()
+            for _snode in self.nodes:
+                if isinstance(_snode, ExternKernelSchedulerNode):
+                    extern_output_names.update(_snode.get_buffer_names())
+            V.graph._cudagraph_extern_output_names = extern_output_names
+            # Cross-cg-boundary buffers (captured partition inputs + outputs):
+            # their slab offset must persist until the captured partition replays,
+            # so cg-aware reuse must NOT share their offset. Intra-scope buffers
+            # (not in this set) reuse safely. Union over all captured partitions.
+            boundary_names: set[str] = set()
+            for _names in cap_in_names:
+                boundary_names.update(_names)
+            for _names in cap_out_names:
+                boundary_names.update(_names)
+            V.graph._cudagraph_boundary_names = boundary_names
+            # passthrough_producer_pid[name] = earliest captured cpid that
+            # re-emits `name` as a passthrough (name in BOTH cap_in_names[cpid]
+            # and cap_out_names[cpid]) and is NOT real-producer-allocated.
+            # Drives passthrough chaining in cpp_wrapper_gpu.py: the earliest
+            # such emitter A reassigns outer-scope `name` to A's stable
+            # static_inputs[i] view (refreshed per replay by A's copy_in), and
+            # downstream captured consumers chain from there instead of issuing
+            # their own copy_in -- one eager->CG copy at A, rest chain.
+            passthrough_producer_pid: dict[str, int] = {}
+            for cpid, names in enumerate(cap_out_names):
+                for name in names:
+                    if name in cap_in_names[cpid] and name not in real_producer_pid:
+                        if name not in passthrough_producer_pid:
+                            passthrough_producer_pid[name] = cpid
+            V.graph._cudagraph_passthrough_producer_pid = passthrough_producer_pid
+            # Cross-partition handoff liveness for slab placement.
+            #
+            # handoff_liveness[name] = (first_producer_pid, last_consumer_pid):
+            #   a captured-partition output that is REAL-allocated by a captured
+            #   partition (first_producer_pid) and whose LAST captured consumer
+            #   is last_consumer_pid (first_producer_pid < last_consumer_pid).
+            # These are exactly the buffers the cuda-graph runtime hands off
+            # between two captured partitions; they are placed in the
+            # memory_planning slab, so the memory_planning handoff planner needs
+            # both:
+            #   (a) the SET of names to slab-place == handoff_liveness.keys()
+            #   (b) the producer->last-consumer partition-id range == the value
+            # so the slab offset can persist over [producer .. last_consumer]
+            # rather than the whole program (the conservative full-overlap that
+            # _cudagraph_boundary_names forces today).
+            #
+            # EXCLUSIONS (must stay copy_in, NOT slab-placed):
+            #   * extern_output_names: produced by ExternKernelAlloc/
+            #     FallbackKernel, not pooled by memory_planning -> not
+            #     slab-stable, so a captured consumer must copy_in.
+            #   * passthrough re-exports (name not in real_producer_pid): the
+            #     real allocator is an eager partition that reallocates at a
+            #     fresh address each forward -> not slab-stable. Restricting the
+            #     producer to real_producer_pid drops these.
+            #   * model outputs / eager-partition inputs / no captured consumer:
+            #     these ESCAPE the captured region and are kept by the runtime
+            #     (see escape_outs); they are not cross-partition handoffs.
+            handoff_liveness: dict[str, tuple[int, int]] = {}
+            for name, producer_pid in real_producer_pid.items():
+                if name in model_outs or name in eager_in_names:
+                    continue
+                if name in extern_output_names:
+                    continue
+                consumers = [
+                    c
+                    for c in range(len(captured))
+                    if c != producer_pid and name in cap_in_names[c]
+                ]
+                if not consumers:
+                    continue
+                handoff_liveness[name] = (producer_pid, max(consumers))
+            V.graph._cudagraph_handoff_liveness = handoff_liveness
+            # Plan the cross-partition handoff slab HERE, in the
+            # scheduler pre-pass, right after _cudagraph_handoff_liveness is
+            # populated and BEFORE the partition codegen loop below. Both readers
+            # of the dicts it publishes -- the per-partition body's
+            # AllocFromPoolLine redirect (_cudagraph_boundary_offsets) and the
+            # outer codegen_partition_call (_cudagraph_handoff_pools) -- run
+            # during this same Scheduler.codegen (Phase 1), which strictly
+            # precedes the outer wrapper's MemoryPlanner.plan (Phase 2). Planning
+            # in Phase 2 would be a silent no-op.
+            cudagraph_partition.plan_cudagraph_handoff_slab()
+
         with self.use_default_device_context(partitions, signatures):
             for partition, signature in zip(partitions, signatures):
                 if len(partition) < 1:
@@ -9906,7 +10281,7 @@ class Scheduler:
                     self._codegen_partition_wrapper(partition, signature)
 
         num_partitions = next(self._graph_partition_counter)
-        V.graph.wrapper_code.set_all_partition_names(num_partitions)
+        assert num_partitions == num_cg_partitions
 
         # See [Note: Graph Partition Map for CUDAGraph]
         if num_partitions > 0:

--- a/torch/csrc/inductor/aoti_runtime/cudagraph_tree.h
+++ b/torch/csrc/inductor/aoti_runtime/cudagraph_tree.h
@@ -1,0 +1,429 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#pragma once
+
+// AOTI regional cuda-graph runtime (flat, no-tree, no-checkpoint).
+//
+//   * One private graph mempool is shared by every capture, so different dynamic
+//     shapes reuse the same memory.
+//   * Dispatch is a single flat map keyed by encode(partition_id, shape). There
+//     is no recording tree: no parent/child walk, no per-node allocator
+//     checkpoint, no checkpoint snapshot/restore, no divergence handling.
+//   * Most of a partition's outputs live in the model's memory-planning slab (a
+//     durable, address-stable allocation owned by the generated model instance,
+//     NOT by this manager's private pool). For a slab-resident output the body's
+//     fresh handle is a non-owning view: the slab keeps the memory alive across
+//     every replay. The exception is an output produced by an extern / fallback
+//     op (cublas/cudnn/aten) that crosses a partition boundary: the scheduler
+//     excludes those from the slab, so they are real owning allocations. To keep
+//     both cases correct, every output handle is held in owning_outputs until the
+//     node is destroyed (a slab-view delete is a harmless no-op there because the
+//     slab storage keeps refcount >= 1; an extern boundary output is the sole
+//     owner and is freed correctly). Outputs that escape the model (escape_outs)
+//     get their deleter neutralized so the caller can keep owning them.
+//   * Replay is one-directional and touches no allocator state -- the hot serving
+//     path is a pure cudaGraphLaunch. The private pool keeps only capture-stream
+//     ordering (sync_before_record) and the single shared cuBLAS workspace slot
+//     (clear_cublas_workspaces); the slab address is fixed, so there is no
+//     allocator bookkeeping to snapshot or rewind.
+//
+// Header-only over the stable AOTI C ABI, so the generated model .so includes it
+// and hands the partition body in as a lambda (capturing the wrapper's locals).
+
+#include <torch/csrc/inductor/aoti_runtime/utils.h>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace torch::aot_inductor {
+
+// Address + metadata of a captured output, enough to reconstruct a non-owning
+// handle at the same device address on replay (mirrors cudagraph_trees'
+// reconstruct_outputs / outputs_metadata).
+struct CUDAGraphOutputMeta {
+  void* data_ptr{nullptr};
+  int64_t ndim{0};
+  std::vector<int64_t> sizes;
+  std::vector<int64_t> strides;
+  int32_t dtype{0};
+  int32_t device_type{0};
+  int32_t device_index{0};
+};
+
+inline CUDAGraphOutputMeta cuda_graph_capture_meta(AtenTensorHandle h) {
+  CUDAGraphOutputMeta m;
+  aoti_torch_get_data_ptr(h, &m.data_ptr);
+  aoti_torch_get_dim(h, &m.ndim);
+  int64_t* sizes = nullptr;
+  int64_t* strides = nullptr;
+  aoti_torch_get_sizes(h, &sizes);
+  aoti_torch_get_strides(h, &strides);
+  m.sizes.assign(sizes, sizes + m.ndim);
+  m.strides.assign(strides, strides + m.ndim);
+  aoti_torch_get_dtype(h, &m.dtype);
+  aoti_torch_get_device_type(h, &m.device_type);
+  aoti_torch_get_device_index(h, &m.device_index);
+  return m;
+}
+
+// Non-owning view at the recorded address (partition outputs are fresh
+// allocations, so storage_offset is 0).
+inline AtenTensorHandle cuda_graph_reconstruct(const CUDAGraphOutputMeta& m) {
+  AtenTensorHandle h = nullptr;
+  aoti_torch_create_tensor_from_blob(
+      m.data_ptr,
+      m.ndim,
+      m.sizes.data(),
+      m.strides.data(),
+      /*storage_offset=*/0,
+      m.dtype,
+      m.device_type,
+      m.device_index,
+      &h);
+  return h;
+}
+
+// One captured graph for a single (partition_id, dynamic-shape).
+struct CUDAGraphNode {
+  AOTICudaGraphHandle graph{nullptr};
+
+  // Eager input slots (external, fixed-address; copied into per replay). nullptr
+  // for chained inputs (read a producer output address directly).
+  std::vector<AtenTensorHandle> static_inputs;
+
+  // Per output: address+metadata for reconstruct-on-replay.
+  std::vector<CUDAGraphOutputMeta> output_meta;
+  // Every output handle is held until teardown. Slab-resident outputs are
+  // non-owning views (delete is a no-op); extern boundary outputs are the sole
+  // owner and are freed here; escaping (model) outputs are neutralized and kept.
+  std::vector<AtenTensorHandle> owning_outputs;
+
+  CUDAGraphNode() = default;
+  CUDAGraphNode(const CUDAGraphNode&) = delete;
+  CUDAGraphNode& operator=(const CUDAGraphNode&) = delete;
+
+  ~CUDAGraphNode() {
+    for (auto h : owning_outputs) {
+      if (h) {
+        aoti_torch_delete_tensor_object(h);
+      }
+    }
+    for (auto h : static_inputs) {
+      if (h) {
+        aoti_torch_delete_tensor_object(h);
+      }
+    }
+    if (graph) {
+      aoti_torch_cuda_graph_destroy(graph);
+    }
+  }
+};
+
+// Owns the shared pool and a flat table of recordings. Mirrors
+// cudagraph_trees.CUDAGraphTreeManager (single-pool, inference-only: no
+// generation tracking, no runtime liveness -- liveness is a compile-time
+// decision passed in via copy_in/escape_outs).
+class AOTICUDAGraphTreeManager {
+ public:
+  using PartitionBody = std::function<
+      void(AtenTensorHandle* in, AtenTensorHandle* out, void* stream)>;
+
+  explicit AOTICUDAGraphTreeManager(int32_t device_index)
+      : device_index_(device_index) {
+    // On only when AOTI_CGTREE_DEBUG is set to a truthy value. An unset, empty,
+    // or "0" value is off so production runs that export AOTI_CGTREE_DEBUG=0
+    // (e.g. the scorecard harness) do not get the per-replay RECORD/REPLAY flood.
+    const char* debug_env = std::getenv("AOTI_CGTREE_DEBUG");
+    debug_ = debug_env != nullptr && debug_env[0] != '\0' &&
+        !(debug_env[0] == '0' && debug_env[1] == '\0');
+    // This manager's OWN private graph pool + capture stream (see shim). Owned
+    // here and destroyed in the destructor -> per-AOTInductorModel-instance
+    // isolation: concurrent instances in a model_container never share pool
+    // memory or a capture stream.
+    aoti_torch_cuda_graph_pool_create(device_index, &pool_handle_);
+    // Balance the pool use_count for the destructor. Captures take a net +N on
+    // the pool via cuda_graph_create (+N) that the node dtors drop (-N);
+    // pool_destroy_handle then drops one more (-1). ensure_created here adds the
+    // matching +1 so the count balances (N+1 vs N+1) instead of going to -1 and
+    // tripping the releasePool use_count assert at teardown. It also
+    // materializes the PrivatePool so the zero-recorded-nodes case has a real
+    // pool for releasePool to release.
+    aoti_torch_cuda_graph_pool_ensure_created(pool_handle_);
+  }
+  AOTICUDAGraphTreeManager(const AOTICUDAGraphTreeManager&) = delete;
+  AOTICUDAGraphTreeManager& operator=(const AOTICUDAGraphTreeManager&) = delete;
+
+  ~AOTICUDAGraphTreeManager() {
+    // Destroy nodes (their captured graphs) BEFORE the pool: each ~CUDAGraph
+    // releases the pool ref it took at capture; pool_destroy_handle then drops
+    // the remaining ref (from ensure_created) -> use_count 0 -> freed.
+    flat_nodes_.clear();
+    aoti_torch_cuda_graph_pool_destroy_handle(pool_handle_);
+  }
+
+  // Run one captured partition.
+  //   copy_in     : EAGER input indices (cloned into static slots; copied per replay).
+  //                 All other inputs are chained -- read in place, never copied.
+  //   escape_outs : output indices that escape the model (neutralize + keep).
+  //   body        : runs the partition eagerly into `out` on the given stream.
+  // Fills `outs` with non-owning handles to this node's output addresses.
+  void run_partition(
+      int32_t partition_id,
+      int64_t shape_key,
+      AtenTensorHandle* ins,
+      int32_t num_ins,
+      AtenTensorHandle* outs,
+      int32_t num_outs,
+      const std::vector<int32_t>& copy_in,
+      const std::vector<int32_t>& escape_outs,
+      const PartitionBody& body) {
+    const int64_t key = encode(partition_id, shape_key);
+    // Shared (read) lock over capture/replay (see captureMutex in the shim):
+    // replay + output reconstruction run concurrently with other instances'
+    // replays but are excluded while ANY instance holds the exclusive capture
+    // lock -- so the capture-unsafe query in reconstruct (getDeviceFromPtr ->
+    // cudaPointerGetAttributes) never runs during a concurrent capture. RAII.
+    struct ReplayLock {
+      ReplayLock() {
+        aoti_torch_cuda_graph_replay_lock();
+      }
+      ~ReplayLock() {
+        aoti_torch_cuda_graph_replay_unlock();
+      }
+    };
+    // Reconstruct non-owning views at the recorded slab addresses. The body runs
+    // only at capture time, so on replay (and right after record) we hand the
+    // caller fresh from_blob handles over the durable slab memory.
+    auto reconstruct_outputs = [&](CUDAGraphNode* n) {
+      for (int32_t i = 0; i < num_outs; i++) {
+        outs[i] = cuda_graph_reconstruct(n->output_meta[i]);
+      }
+    };
+
+    auto it = flat_nodes_.find(key);
+    CUDAGraphNode* node = nullptr;
+    if (it != flat_nodes_.end()) {
+      node = it->second.get();
+      ReplayLock rlk;
+      replay_node(node, ins, copy_in);
+      reconstruct_outputs(node);
+      // Log once per forward (partition 0) to avoid per-partition spam.
+      if (debug_ && partition_id == 0) {
+        fprintf(
+            stderr,
+            "[cgtree] REPLAY forward start pid=0 shape=%ld total_nodes=%zu\n",
+            shape_key,
+            recorded_nodes_);
+      }
+    } else {
+      // record_node takes the EXCLUSIVE capture lock internally (no replay of any
+      // instance runs during it); reconstruct afterwards under the shared lock.
+      node = record_node(
+          partition_id,
+          shape_key,
+          key,
+          ins,
+          num_ins,
+          num_outs,
+          copy_in,
+          escape_outs,
+          body);
+      ++recorded_nodes_;
+      {
+        ReplayLock rlk;
+        reconstruct_outputs(node);
+      }
+      if (debug_) {
+        int64_t used_bytes = 0;
+        aoti_torch_cuda_graph_device_used_bytes(device_index_, &used_bytes);
+        fprintf(
+            stderr,
+            "[cgtree] RECORD pid=%d shape=%ld total_nodes=%zu dev_used_mb=%ld\n",
+            partition_id,
+            shape_key,
+            recorded_nodes_,
+            used_bytes / (1024 * 1024));
+        fflush(stderr);
+      }
+    }
+  }
+
+ private:
+  static int64_t encode(int32_t partition_id, int64_t shape_key) {
+    return (static_cast<int64_t>(partition_id) << 40) ^
+        (shape_key & 0xFFFFFFFFFFLL);
+  }
+
+  void replay_node(
+      CUDAGraphNode* node,
+      AtenTensorHandle* ins,
+      const std::vector<int32_t>& copy_in) {
+    for (int32_t i : copy_in) {
+      aoti_torch_copy_(node->static_inputs[i], ins[i], /*non_blocking=*/0);
+    }
+    aoti_torch_cuda_graph_replay(node->graph);
+  }
+
+  CUDAGraphNode* record_node(
+      int32_t partition_id,
+      int64_t shape_key,
+      int64_t key,
+      AtenTensorHandle* ins,
+      int32_t num_ins,
+      int32_t num_outs,
+      const std::vector<int32_t>& copy_in,
+      const std::vector<int32_t>& escape_outs,
+      const PartitionBody& body) {
+    // Serialize capture across concurrent model instances (see captureMutex in
+    // the shim): concurrent cuda-graph capture on a device is unsafe (illegal
+    // memory access). REPLAY (the hot path) never takes this lock; only this
+    // recording path does. RAII so it releases on any return/exception.
+    struct CaptureLock {
+      CaptureLock() {
+        aoti_torch_cuda_graph_capture_lock();
+      }
+      ~CaptureLock() {
+        aoti_torch_cuda_graph_capture_unlock();
+      }
+    } capture_lock_guard;
+
+    // Order the shared capture stream after the caller's stream before we touch
+    // the pool or capture. All partitions share one capture stream + one cuBLAS
+    // workspace slot, so without this the previous partition's first-replay
+    // (caller stream) and this one's warmup/capture (capture stream) would race
+    // on that workspace. Recording-only; not on the hot path. No checkpoint
+    // restore: the slab address is fixed, so there is nothing to rewind.
+    aoti_torch_cuda_graph_sync_before_record(device_index_);
+
+    auto child = std::make_unique<CUDAGraphNode>();
+    aoti_torch_cuda_graph_create(&child->graph, pool_handle_);
+
+    // Eager inputs get node-owned static slots refreshed per replay via copy_in;
+    // chained inputs are read in place.
+    std::vector<bool> is_eager(num_ins, false);
+    for (int32_t i : copy_in) {
+      is_eager[i] = true;
+    }
+    child->static_inputs.assign(num_ins, nullptr);
+    std::vector<AtenTensorHandle> cap_in(num_ins);
+    for (int32_t i = 0; i < num_ins; i++) {
+      if (is_eager[i]) {
+        // Guard the copy_in staging clone: if it fails (or returns a null
+        // handle) the downstream make_input_views -> cuda_graph_capture_meta ->
+        // aoti_torch_get_data_ptr would dereference a null handle and SIGSEGV
+        // at 0x0. The usual trigger is an out-of-bounds input dimension (e.g. a
+        // dynamic dim larger than its compiled max). Fail with an actionable
+        // message naming the partition and shape instead.
+        AOTITorchError clone_err =
+            aoti_torch_clone_preserve_strides(ins[i], &child->static_inputs[i]);
+        if (clone_err != AOTI_TORCH_SUCCESS ||
+            child->static_inputs[i] == nullptr) {
+          std::stringstream ss;
+          ss << "AOTI cuda-graph: copy_in staging "
+                "(aoti_torch_clone_preserve_strides) failed for partition "
+             << partition_id << " input " << i << " at shape_key " << shape_key
+             << " -- likely an out-of-bounds input dimension";
+          throw std::runtime_error(std::move(ss).str());
+        }
+        cap_in[i] = child->static_inputs[i];
+      } else {
+        cap_in[i] = ins[i]; // chained: read the producer output in place
+      }
+    }
+
+    void* cap_stream = nullptr;
+    aoti_torch_cuda_graph_get_stream(child->graph, &cap_stream);
+
+    // The generated partition body TAKES OWNERSHIP of its input handles (wraps
+    // each in a RAII handle and frees it, or releases passthrough ones as
+    // outputs). Our inputs must NOT be freed by it: eager inputs are node-owned
+    // static buffers needed for replay, chained inputs are producer-owned, and
+    // the wrapper's outer scope still owns and reuses the borrowed handles. So
+    // hand the body fresh NON-OWNING views (from_blob, no-op deleter) over each
+    // input's memory -- it can take, free, or pass them through without ever
+    // touching the real input storage. Views point at the same addresses, so the
+    // captured graph is identical. Fresh set per call (warmup + capture) since
+    // each consumes its own.
+    auto make_input_views = [&]() {
+      std::vector<AtenTensorHandle> views(num_ins, nullptr);
+      for (int32_t i = 0; i < num_ins; i++) {
+        views[i] = cuda_graph_reconstruct(cuda_graph_capture_meta(cap_in[i]));
+      }
+      return views;
+    };
+
+    // Warmup (lazy cuBLAS/Triton init) with throwaway input views + outputs.
+    {
+      std::vector<AtenTensorHandle> warm_in = make_input_views();
+      std::vector<AtenTensorHandle> warm_out(num_outs, nullptr);
+      body(warm_in.data(), warm_out.data(), cap_stream);
+      for (auto h : warm_out) {
+        if (h) {
+          aoti_torch_delete_tensor_object(h);
+        }
+      }
+    }
+
+    // Capture. The body writes fresh output handles into child->owning_outputs.
+    // Most outputs are slab-resident (their storage is the durable slab, so the
+    // captured graph bakes stable slab addresses); the rest are extern / fallback
+    // op outputs that cross a partition boundary and are real owning allocations
+    // excluded from the slab. We must NOT blanket-delete these handles here: that
+    // would free the extern allocations and dangle their recorded output_meta
+    // data_ptr (UAF on replay). Instead we retain EVERY handle in owning_outputs
+    // (freed at node teardown by ~CUDAGraphNode) and neutralize the
+    // model-escaping ones below. At teardown a slab-view delete is a no-op (the
+    // slab storage is owned by the model, refcount stays >= 1); an extern
+    // boundary output's delete correctly frees it. Recorded addresses stay valid
+    // for the node's whole life.
+    aoti_torch_cuda_graph_begin_capture(child->graph);
+    child->owning_outputs.assign(num_outs, nullptr);
+    {
+      std::vector<AtenTensorHandle> cap_views = make_input_views();
+      body(cap_views.data(), child->owning_outputs.data(), cap_stream);
+    }
+    aoti_torch_cuda_graph_end_capture(child->graph);
+
+    // Clear cuBLAS workspaces after capture (mirrors cudagraph_trees'
+    // clear_cublas_manager exit). With the single shared capture stream there is
+    // exactly one workspace, reused at a fixed slot across all captures. The
+    // captured graph keeps using that still-reserved memory as transient scratch.
+    aoti_torch_cuda_graph_clear_cublas_workspaces(pool_handle_);
+
+    child->output_meta.resize(num_outs);
+    for (int32_t i = 0; i < num_outs; i++) {
+      child->output_meta[i] = cuda_graph_capture_meta(child->owning_outputs[i]);
+    }
+    // Escaping (model) outputs: neutralize the deleter so node teardown does not
+    // free an allocation that the caller still owns. For a slab-view output this
+    // is also harmless (its storage is already non-owning).
+    for (int32_t i : escape_outs) {
+      aoti_torch_storage_set_noop_deleter(child->owning_outputs[i]);
+    }
+
+    CUDAGraphNode* node = child.get();
+    flat_nodes_.emplace(key, std::move(child));
+
+    // Produce the correct first result with the real inputs (capture ran on the
+    // empty static input slots).
+    replay_node(node, ins, copy_in);
+    return node;
+  }
+
+  int32_t device_index_;
+  void* pool_handle_{nullptr}; // this manager's private graph pool + capture stream
+  size_t recorded_nodes_{0}; // total captured (partition, shape) nodes
+  bool debug_{false}; // AOTI_CGTREE_DEBUG: log RECORD/REPLAY per partition
+  // The only dispatch table: a flat encode(pid, shape) -> node map, no tree.
+  std::unordered_map<int64_t, std::unique_ptr<CUDAGraphNode>> flat_nodes_;
+};
+
+} // namespace torch::aot_inductor

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -5,6 +5,11 @@
 // C ABI defined in torch/csrc/inductor/aoti_torch/c/shim.h. The same rule
 // applies to other files under torch/csrc/inductor/aoti_runtime/.
 #include <torch/csrc/inductor/aoti_runtime/model_base.h>
+#ifdef USE_CUDA
+// Header-only over the stable C ABI (shim.h), so it is safe to include here per
+// the rule above. Provides the per-instance cuda-graph tree manager member below.
+#include <torch/csrc/inductor/aoti_runtime/cudagraph_tree.h>
+#endif
 
 struct AOTInductorArrayRefTensor;
 
@@ -65,6 +70,24 @@ class AOTInductorModel : public AOTInductorModelBase<AOTInductorModel> {
 
  private:
   std::unique_ptr<AOTInductorModelKernelsBase> kernels_;
+#ifdef USE_CUDA
+  // Per-instance cuda-graph manager: owns THIS model's private graph pool
+  // + capture stream, so concurrent instances in a model_container are isolated.
+  // Lazily created by the generated run_impl on the first captured partition;
+  // stays null for models with no cuda-graph partitions. Destroyed with the
+  // model (no leak). See cudagraph_tree.h.
+  std::unique_ptr<AOTICUDAGraphTreeManager> cudagraph_mgr_;
+  // Per-instance cuda-graph memory_planning slab cache. Keyed by a packed
+  // (pool id, partition id) int64; each value owns the persistent slab whose
+  // base address the captured partitions bake into their reinterpret_tensor
+  // views, so the address stays stable across forwards. The slab is sized to the
+  // dynamic-shape upper bounds and shared across shapes (single max slab). Lives
+  // per AOTInductorModel instance (NOT process-static) so concurrent instances
+  // in a model_container have isolated slabs; the RAII handles free the slabs at
+  // model destruction. Populated by the generated memory_planning codegen (see
+  // _codegen_create_cudagraph_cached in memory_planning.py).
+  std::unordered_map<int64_t, RAIIAtenTensorHandle> cudagraph_slabs_;
+#endif
 };
 
 } // namespace torch::aot_inductor

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -620,6 +620,84 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_caching_allocator_raw_alloc(
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_cuda_caching_allocator_raw_delete(void* ptr);
 
+struct AOTICudaGraphOpaque;
+using AOTICudaGraphHandle = AOTICudaGraphOpaque*;
+
+// Create/destroy a per-manager (per-AOTInductorModel) graph pool handle: an
+// opaque owner of one PRIVATE graph mempool + capture stream. Each tree manager
+// creates one in its constructor and destroys it in its destructor, so concurrent
+// model instances in a model_container are fully isolated (no shared pool/stream).
+// destroy_handle also reclaims the pool (releasePool) and clears the stream's
+// cuBLAS workspace. The cuda-graph functions below operate on this handle's pool.
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cuda_graph_pool_create(int32_t device_index, void** ret_handle);
+
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cuda_graph_pool_destroy_handle(void* pool_handle);
+
+// Process-global capture lock: the tree runtime serializes record_node across
+// concurrent model instances (cuda-graph capture is unsafe to interleave on a
+// device). Replay (the hot path) never takes it.
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_capture_lock();
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_capture_unlock();
+// Shared (read) lock for replay + output reconstruction (concurrent across
+// instances; excluded only while some instance holds the exclusive capture lock).
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_replay_lock();
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_replay_unlock();
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_create(
+    AOTICudaGraphHandle* ret_handle,
+    void* pool_handle);
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_begin_capture(
+    AOTICudaGraphHandle handle);
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_end_capture(
+    AOTICudaGraphHandle handle);
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_replay(
+    AOTICudaGraphHandle handle);
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_get_stream(
+    AOTICudaGraphHandle handle,
+    void** ret_stream);
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_destroy(
+    AOTICudaGraphHandle handle);
+
+// Materialize the (empty) private graph pool so releasePool at teardown has a
+// real pool to release even when no partition is ever captured, and so the
+// manager's matching pool use ref balances the destructor's drop. Operates on
+// the caller's per-manager pool handle (aoti_torch_cuda_graph_pool_create).
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_pool_ensure_created(
+    void* pool_handle);
+
+// Synchronize the device and order the shared capture stream after the caller's
+// stream before recording a partition (mirrors cudagraph_trees' pre-record
+// synchronize + wait_stream). Required because all partitions share one capture
+// stream and one cuBLAS workspace slot.
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cuda_graph_sync_before_record(int32_t device_index);
+
+// Clear cuBLAS's per-(handle,stream) workspace cache. cuBLAS workspaces are
+// caching-allocator allocations that land in the graph pool during capture; the
+// runtime clears them after each capture (mirroring cudagraph_trees'
+// clear_cublas_manager) so teardown does not double-free a block the cuBLAS
+// workspace map still references.
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cuda_graph_clear_cublas_workspaces(void* pool_handle);
+
+// Debug instrumentation: total in-use GPU bytes (total - free) on the device.
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cuda_graph_device_used_bytes(int32_t device_index, int64_t* ret_bytes);
+
+// Neutralize a tensor's storage deleter so destroying the handle does NOT free
+// the underlying graph-pool block (the captured graph still references that
+// address). The pool is freed wholesale via aoti_torch_cuda_graph_pool_destroy_handle
+// at teardown. This is the AOTI analog of cudagraph_trees' removeStorageDeleterFns.
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_storage_set_noop_deleter(
+    AtenTensorHandle tensor);
+
 #endif // USE_CUDA
 
 // See `ProxyExecutor Design Note` in ir.py for more details

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -534,6 +534,13 @@ AOTITorchError aoti_torch_create_tensor_from_blob(
                                 .strides(strides)
                                 .storage_offset(storage_offset)
                                 .options(options)
+                                // Set the device explicitly so make_tensor()
+                                // skips getDeviceFromPtr (cudaPointerGetAttributes):
+                                // that driver query is illegal during CUDA graph
+                                // capture and a needless round-trip on the hot
+                                // path. The device is caller-provided and already
+                                // required to match opts above.
+                                .target_device(device)
                                 .make_tensor()
                           : at::empty_strided(sizes, strides, options));
   });

--- a/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
@@ -2,9 +2,106 @@
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <torch/csrc/inductor/aoti_torch/utils.h>
 
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGraph.h>
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
+
+#include <shared_mutex>
+
+namespace {
+// No-op deleter: leaves the underlying graph-pool block alone so destroying a
+// captured tensor handle does not free a block the captured graph still
+// references. Such blocks are reclaimed wholesale via releasePool at teardown.
+void noopDeleter(void*) {}
+
+// Per-manager (per-AOTInductorModel) graph state: a PRIVATE graph mempool plus a
+// single capture stream. Each AOTInductorModel instance owns one (created via
+// aoti_torch_cuda_graph_pool_create, freed via ..._pool_destroy_handle), so
+// concurrent instances in a model_container never share pool memory or a capture
+// stream -- full isolation. Mirrors cudagraph_trees' per-tree-manager pool +
+// self.stream. One capture stream per manager keeps a SINGLE cuBLAS workspace
+// (keyed by (handle,stream)) for all of that manager's captures, avoiding
+// per-node-stream workspace bloat; replay is stream-independent so this stream
+// only affects recording.
+struct AOTICudaGraphPool {
+  c10::cuda::MempoolId_t pool;
+  c10::cuda::CUDAStream stream;
+  int32_t device_index;
+  explicit AOTICudaGraphPool(int32_t dev)
+      : pool(at::cuda::graph_pool_handle()),
+        stream(c10::cuda::getStreamFromPool(false, dev)),
+        device_index(dev) {}
+};
+
+// One captured graph, bound to its manager's pool (borrowed, not owned).
+struct AOTICudaGraphContext {
+  at::cuda::CUDAGraph graph;
+  std::unique_ptr<c10::cuda::CUDAStreamGuard> stream_guard;
+  AOTICudaGraphPool* pool;
+
+  explicit AOTICudaGraphContext(AOTICudaGraphPool* p) : pool(p) {}
+};
+
+// Process-global READER-WRITER lock coordinating cuda-graph capture vs replay
+// across all manager instances on a device. CAPTURE takes it EXCLUSIVE (write);
+// REPLAY + output reconstruction take it SHARED (read). Two reasons concurrency
+// here is unsafe: (1) the caching allocator's per-device capture bookkeeping
+// (markCaptureBegin/beginAllocateToPool/...) and device-global capture state
+// can't interleave across instances; (2) while one instance captures, another
+// instance's replay must NOT run capture-unsafe CUDA queries -- output
+// reconstruction calls getDeviceFromPtr (cudaPointerGetAttributes), which faults
+// during a concurrent capture. So: at most one capture at a time AND no replay
+// during a capture, but MANY replays run concurrently (shared). Capture is rare
+// (warmup); steady-state serving only ever takes the shared lock, so concurrent
+// inference across instances stays parallel.
+std::shared_mutex& captureMutex() {
+  static std::shared_mutex m;
+  return m;
+}
+} // namespace
+
+AOTITorchError aoti_torch_cuda_graph_pool_create(
+    int32_t device_index,
+    void** ret_handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      { *ret_handle = new AOTICudaGraphPool(device_index); });
+}
+
+AOTITorchError aoti_torch_cuda_graph_pool_destroy_handle(void* handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* p = reinterpret_cast<AOTICudaGraphPool*>(handle);
+    // Drop this manager's capture-stream cuBLAS workspace BEFORE releasing the
+    // pool (matching CUDAGraph::reset order): releasePool frees the pool segments
+    // once use_count hits 0, so clearing the workspace afterwards would free an
+    // already-freed block. Per-stream, so a concurrent manager is untouched.
+    at::cuda::clearCublasWorkspacesForStream(p->stream.stream());
+    c10::cuda::CUDACachingAllocator::releasePool(
+        static_cast<c10::DeviceIndex>(p->device_index), p->pool);
+    delete p;
+  });
+}
+
+// Acquire/release the process-global capture/replay lock (see captureMutex). The
+// tree runtime wraps record_node in capture_lock/unlock (EXCLUSIVE write) and
+// wraps replay + output reconstruction in replay_lock/unlock (SHARED read).
+AOTITorchError aoti_torch_cuda_graph_capture_lock() {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({ captureMutex().lock(); });
+}
+
+AOTITorchError aoti_torch_cuda_graph_capture_unlock() {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({ captureMutex().unlock(); });
+}
+
+AOTITorchError aoti_torch_cuda_graph_replay_lock() {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({ captureMutex().lock_shared(); });
+}
+
+AOTITorchError aoti_torch_cuda_graph_replay_unlock() {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({ captureMutex().unlock_shared(); });
+}
 
 AOTITorchError aoti_torch_create_cuda_guard(
     int32_t device_index,
@@ -81,5 +178,132 @@ AOTITorchError aoti_torch_cuda_caching_allocator_raw_delete(void* ptr) {
     if (ptr != nullptr) {
       c10::cuda::CUDACachingAllocator::raw_delete(ptr);
     }
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_create(
+    AOTICudaGraphHandle* ret_handle,
+    void* pool_handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* ctx = new AOTICudaGraphContext(
+        reinterpret_cast<AOTICudaGraphPool*>(pool_handle));
+    *ret_handle = reinterpret_cast<AOTICudaGraphHandle>(ctx);
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_begin_capture(
+    AOTICudaGraphHandle handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* ctx = reinterpret_cast<AOTICudaGraphContext*>(handle);
+    auto stream = ctx->pool->stream;
+    stream.synchronize();
+    ctx->stream_guard = std::make_unique<c10::cuda::CUDAStreamGuard>(stream);
+    // ThreadLocal (not the default Global) capture mode: serialized against other
+    // captures by the global capture lock, this avoids disrupting other model
+    // instances' concurrent replays on other threads.
+    ctx->graph.capture_begin(ctx->pool->pool, cudaStreamCaptureModeThreadLocal);
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_end_capture(
+    AOTICudaGraphHandle handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* ctx = reinterpret_cast<AOTICudaGraphContext*>(handle);
+    ctx->graph.capture_end();
+    ctx->stream_guard.reset();
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_replay(AOTICudaGraphHandle handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* ctx = reinterpret_cast<AOTICudaGraphContext*>(handle);
+    ctx->graph.replay();
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_get_stream(
+    AOTICudaGraphHandle handle,
+    void** ret_stream) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* ctx = reinterpret_cast<AOTICudaGraphContext*>(handle);
+    *(cudaStream_t*)(ret_stream) = ctx->pool->stream.stream();
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_destroy(AOTICudaGraphHandle handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    delete reinterpret_cast<AOTICudaGraphContext*>(handle);
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_pool_ensure_created(void* pool_handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    // Materialize this manager's PrivatePool (empty) so releasePool at teardown
+    // has a real pool to release even when no partition is ever captured, and so
+    // the constructor's matching pool use ref balances the destructor's drop. A
+    // no-op begin/end allocation scope creates the pool via create_or_incref_pool
+    // without allocating anything. This adds one pool use ref (only raises
+    // use_count, never drives it negative), so the pool may stay reserved until
+    // process exit; harmless for inference.
+    auto* p = reinterpret_cast<AOTICudaGraphPool*>(pool_handle);
+    auto dev = static_cast<c10::DeviceIndex>(p->device_index);
+    c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+        dev, p->pool, [](cudaStream_t) { return false; });
+    c10::cuda::CUDACachingAllocator::endAllocateToPool(dev, p->pool);
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_sync_before_record(int32_t device_index) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    // Mirror cudagraph_trees' pre-record torch.cuda.synchronize(). The single
+    // shared capture stream means every partition reuses one cuBLAS workspace
+    // slot; without ordering, a previous partition's first-replay on the caller's
+    // stream and this partition's warmup/capture on the capture stream would race
+    // on that workspace. A full device sync serializes all prior work before we
+    // touch the pool or capture, which subsumes ordering the capture stream after
+    // the caller's stream (everything is idle afterward). Recording-only.
+    c10::cuda::CUDAGuard guard(static_cast<c10::DeviceIndex>(device_index));
+    C10_CUDA_CHECK(cudaDeviceSynchronize());
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_clear_cublas_workspaces(void* pool_handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    // Drop this manager's capture-stream cuBLAS workspace after capture. cuBLAS
+    // allocates its matmul workspace through the caching allocator, so during
+    // capture it lands in the graph pool and is tracked in a per-(handle,stream)
+    // global map. Clearing this stream's entry stops the map from referencing a
+    // block that teardown frees, which would double-free at teardown
+    // (CUDAGraph::reset -> clearCublasWorkspacesForStream). Per-stream (not the
+    // global clear) so a concurrent manager's workspace is left intact. Mirrors
+    // cudagraph_trees' clear_cublas_manager (clear after each recording).
+    auto* p = reinterpret_cast<AOTICudaGraphPool*>(pool_handle);
+    at::cuda::clearCublasWorkspacesForStream(p->stream.stream());
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_device_used_bytes(
+    int32_t device_index,
+    int64_t* ret_bytes) {
+  // Debug/instrumentation only: total GPU bytes in use on the device
+  // (total - free). On an otherwise-idle benchmark GPU this reflects this
+  // process's reservation, so the delta across recorded shapes isolates the
+  // graph-pool growth (the cross-shape memory-sharing signal).
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    c10::cuda::CUDAGuard guard(device_index);
+    size_t free_bytes = 0;
+    size_t total_bytes = 0;
+    C10_CUDA_CHECK(cudaMemGetInfo(&free_bytes, &total_bytes));
+    *ret_bytes = static_cast<int64_t>(total_bytes - free_bytes);
+  });
+}
+
+AOTITorchError aoti_torch_storage_set_noop_deleter(AtenTensorHandle tensor) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* t = reinterpret_cast<at::Tensor*>(tensor);
+    c10::DataPtr& data_ptr =
+        t->storage().unsafeGetStorageImpl()->mutable_data_ptr();
+    // expected == current deleter, so the swap always succeeds; ignore result.
+    (void)data_ptr.compare_exchange_deleter(data_ptr.get_deleter(), &noopDeleter);
   });
 }


### PR DESCRIPTION
Summary:
The codegen half that activates the feature. `codegen_partition_call` emits `cudagraph_mgr_->run_partition(...)` for each eligible partition with its `copy_in` / `escape_outs` metadata; captured-partition handoff buffers are placed into per-symbol memory-planning slabs (`cudagraph_handoff_pool_<sym>`) and chained in place, with `copy_in` only at the genuine eager->CG boundary and for extern/op-allocated outputs. Memory is one per-instance max-sized slab (`this->cudagraph_slabs_`) sized to the dynamic-shape upper bounds and shared across shapes, so cross-shape memory is bounded at the largest shape's footprint. Adds the `SubgraphCppWrapperGpu` subgraph wrapper (kept next to its `CppWrapperGpu` base). The whole feature stays gated behind `aot_inductor.enable_cuda_graph` (default off).

Top of the 6-diff stack: with [2/6] gating, [3/6] shims, [4/6] runtime, and [5/6] partition module in place, this diff makes the feature emit code. Originals D104683973 / D109083080 / D109083079 are preserved unchanged.

Authored with Claude.

Test Plan: `arc lint -a` clean; fbcode/xplat byte-identical. Feature validated end-to-end on the original stack (16/16 accuracy at the true max spec, on-par latency vs plain AOTI, serving-runtime CG active with RECORD/REPLAY, multi-shape transitions clean); this stack is a behavior-preserving re-split + modularization of that validated code. Relies on Sandcastle CI for the per-diff compile.

Differential Revision: D111062962




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo