### PR TITLE
[CD] Enable XPU/ROCm binary build jobs to use get-docker-tag output

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -360,10 +360,8 @@ jobs:
       GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
-      # ROCm/XPU are excluded from the content-addressed ECR path: their test
-      # runners have no ECR pull credentials, so they stay on the Docker Hub
-      # image (this matrix only carries rocm/xpu; cpu/cuda build inline above).
-      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}!{{ docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "!{{ docker_registry_host }}"
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       runner_prefix: "!{{ runner_prefix }}"
       runs_on: !{{ build_runs_on }}

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -67,6 +67,15 @@ on:
       DOCKER_IMAGE_TAG_PREFIX:
         required: true
         type: string
+      DOCKER_IMAGE_REGISTRY_HOST:
+        required: false
+        default: ""
+        type: string
+        description: |
+          Registry host prefix (with trailing slash) prepended to the
+          pytorch/<image> path, e.g.
+          "308535385114.dkr.ecr.us-east-1.amazonaws.com/". Empty (default)
+          means Docker Hub, preserving the historical nightly/release behavior.
       DESIRED_PYTHON:
         required: false
         type: string
@@ -86,14 +95,14 @@ jobs:
     runs-on: ${{ inputs.runner_prefix }}${{ inputs.runs_on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     container:
-      image: ${{ inputs.use_container_directive && format('pytorch/{0}:{1}', inputs.DOCKER_IMAGE, inputs.DOCKER_IMAGE_TAG_PREFIX) || '' }}
+      image: ${{ inputs.use_container_directive && format('{0}pytorch/{1}:{2}', inputs.DOCKER_IMAGE_REGISTRY_HOST, inputs.DOCKER_IMAGE, inputs.DOCKER_IMAGE_TAG_PREFIX) || '' }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: ${{ inputs.PACKAGE_TYPE }}
       DESIRED_CUDA: ${{ inputs.DESIRED_CUDA }}
       GPU_ARCH_VERSION: ${{ inputs.GPU_ARCH_VERSION }}
       GPU_ARCH_TYPE: ${{ inputs.GPU_ARCH_TYPE }}
-      DOCKER_IMAGE: pytorch/${{ inputs.DOCKER_IMAGE }}:${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
+      DOCKER_IMAGE: ${{ inputs.DOCKER_IMAGE_REGISTRY_HOST }}pytorch/${{ inputs.DOCKER_IMAGE }}:${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
       SKIP_ALL_TESTS: 1
       DESIRED_PYTHON: ${{ inputs.DESIRED_PYTHON }}
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: ${{ inputs.PYTORCH_EXTRA_INSTALL_REQUIREMENTS }}

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -728,10 +728,8 @@ jobs:
       GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
-      # ROCm/XPU are excluded from the content-addressed ECR path: their test
-      # runners have no ECR pull credentials, so they stay on the Docker Hub
-      # image (this matrix only carries rocm/xpu; cpu/cuda build inline above).
-      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "${{ needs.get-docker-tag.outputs.docker_registry_host }}"
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runs_on: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}

--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -120,10 +120,8 @@ jobs:
       GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
-      # ROCm/XPU are excluded from the content-addressed ECR path: their test
-      # runners have no ECR pull credentials, so they stay on the Docker Hub
-      # image (this matrix only carries rocm/xpu; cpu/cuda build inline above).
       DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
+      DOCKER_IMAGE_REGISTRY_HOST: ""
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       runner_prefix: ""
       runs_on: linux.s390x


### PR DESCRIPTION
## Summary

Follows PR #190749 to enable the manywheel-build matrix job (which carries ROCm/XPU configs) to use
the `docker_image_suffix` and `docker_registry_host` outputs from the
`get-docker-tag` job. On `ciflow/binaries` PR test runs, the build jobs now
pull the content-addressed builder image from ECR -- the same mechanism the
inline cpu/cuda builds already use.

XPU/ROCm **test** jobs remain on the Docker Hub floating tag since those test
runners lack ECR pull credentials.

## Changes

- `_binary-build-linux.yml`: add `DOCKER_IMAGE_REGISTRY_HOST` input; update
  `container.image` and `DOCKER_IMAGE` env to prepend it.
- `linux_binary_build_workflow.yml.j2`: pass `docker_image_suffix` and
  `docker_registry_host` to the `manywheel-build` job for all arch types
  (previously excluded ROCm/XPU).
- Regenerated linux manywheel binary workflows.

## Test Plan

```
python .github/scripts/generate_ci_workflows.py
```
Verified generated workflows have correct GHA expressions with no nested `${{ }}`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang