### PR TITLE
[xpu][inductor] Add reduction heuristic for xpu INNER hint

### DIFF
--- a/torch/_inductor/heuristics/triton_codegen/pointwise.py
+++ b/torch/_inductor/heuristics/triton_codegen/pointwise.py
@@ -202,7 +202,7 @@ class XPUPointwiseHeuristic(PointwiseHeuristic):
         )
         if len(configs) > 1:
             configs.append(
-                # intel-xpu-backend-for-triton #5133
+                # intel-xpu-backend-for-triton #5124
                 triton_config_fn(size_hints, 32)
             )
         return configs

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -308,6 +308,9 @@ class ReductionHeuristic(CodegenConfigHeuristics):
         elif max_autotune_enabled:
             pass
         elif reduction_hint == ReductionHint.INNER:
+            configs.extend(
+                self._get_inner_extra_configs(make_config, register_intensive)
+            )
             return configs + [contiguous_config]
         elif reduction_hint == ReductionHint.OUTER:
             return configs + [outer_config]
@@ -497,6 +500,10 @@ class ReductionHeuristic(CodegenConfigHeuristics):
     def _finalize_configs(self, configs, make_config, size_hints, inductor_meta):
         """Post-process non-persistent configs."""
         return configs
+
+    def _get_inner_extra_configs(self, make_config, register_intensive):
+        """Extra candidate configs to try for the INNER reduction hint."""
+        return []
 
     def _persistent_xblock_vals(self) -> list[int]:
         """XBLOCK values for persistent reduction."""
@@ -724,6 +731,12 @@ class ROCmReductionHeuristic(ReductionHeuristic):
 @register_codegen_heuristic("reduction", "xpu", register=torch.xpu._is_compiled())
 class XPUReductionHeuristic(ReductionHeuristic):
     """Reduction configs for XPU devices."""
+
+    def _get_inner_extra_configs(self, make_config, register_intensive):
+        # We see performance regression on xpu in some models because the
+        # default INNER config lacks a high-num_warps candidate. Add one back
+        # for XPU to recover the regressed performance.
+        return [make_config(64, 64, num_warps=16)]
 
     def _persistent_inner_config(
         self,

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -308,6 +308,9 @@ class ReductionHeuristic(CodegenConfigHeuristics):
         elif max_autotune_enabled:
             pass
         elif reduction_hint == ReductionHint.INNER:
+            configs.extend(
+                self._get_inner_extra_configs(make_config, register_intensive)
+            )
             return configs + [contiguous_config]
         elif reduction_hint == ReductionHint.OUTER:
             return configs + [outer_config]
@@ -497,6 +500,10 @@ class ReductionHeuristic(CodegenConfigHeuristics):
     def _finalize_configs(self, configs, make_config, size_hints, inductor_meta):
         """Post-process non-persistent configs."""
         return configs
+
+    def _get_inner_extra_configs(self, make_config, register_intensive):
+        """Extra candidate configs to try for the INNER reduction hint."""
+        return []
 
     def _persistent_xblock_vals(self) -> list[int]:
         """XBLOCK values for persistent reduction."""
@@ -720,6 +727,12 @@ class ROCmReductionHeuristic(ReductionHeuristic):
 @register_codegen_heuristic("reduction", "xpu", register=torch.xpu._is_compiled())
 class XPUReductionHeuristic(ReductionHeuristic):
     """Reduction configs for XPU devices."""
+
+    def _get_inner_extra_configs(self, make_config, register_intensive):
+        # We see performance regression on xpu in some models because the
+        # default INNER config lacks a high-num_warps candidate. Add one back
+        # for XPU to recover the regressed performance.
+        return [make_config(64, 64, num_warps=16)]
 
     def _persistent_inner_config(
         self,


### PR DESCRIPTION
Re-opening #176049 (closed) rebased onto latest `main`.

We see performance regression on xpu in some models because reduction hint changed from default to inner in the 2.11 release by bc4d0bf39cc56f4ff3517d503dd80e225143580b.

Since the original PR was closed, `torch/_inductor/runtime/triton_heuristics.py`'s monolithic reduction/pointwise config logic was refactored into a per-device heuristic registry (`torch/_inductor/heuristics/triton_codegen/{reduction,pointwise}.py`). This PR re-implements the same fix against that new structure:

- Adds a `_get_inner_extra_configs` hook to `ReductionHeuristic` (no-op by default), overridden in `XPUReductionHeuristic` to add a `num_warps=16` candidate for the `INNER` reduction hint on XPU.
- Fixes a stale comment reference in `XPUPointwiseHeuristic` (`#5133` -> `#5124`).

> This PR description and commit message were drafted with the help of an AI coding assistant; the code changes have been reviewed by me.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo