### PR TITLE
[Testcase Refactoring] Add hardware classification for test_tp_random_state.py

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_random_state.py
+++ b/test/distributed/tensor/parallel/test_tp_random_state.py
@@ -7,8 +7,9 @@ from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import Replicate
 from torch.distributed.tensor.parallel.api import parallelize_module
 from torch.distributed.tensor.parallel.style import ColwiseParallel
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -18,6 +19,8 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 
 class TensorParallelRandomStateTests(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def get_tensor_slice(self, idx, n, large_tensor):
         shape = large_tensor.shape
         if shape[0] % n != 0:
@@ -40,7 +43,8 @@ class TensorParallelRandomStateTests(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_model_init(self):
+    def test_model_init(self, device):
+        self.device_type = torch.device(device).type
         dp_size = 2
         tp_size = self.world_size // dp_size
         mesh_2d = init_device_mesh(
@@ -136,6 +140,19 @@ class TensorParallelRandomStateTests(DTensorTestBase):
 
 TensorParallelRandomStateTestsWithLocalTensor = create_local_tensor_test_class(
     TensorParallelRandomStateTests
+)
+
+instantiate_device_type_tests(
+    TensorParallelRandomStateTests,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True
+)
+instantiate_device_type_tests(
+    TensorParallelRandomStateTestsWithLocalTensor,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True
 )
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/parallel/test_tp_random_state.py
+++ b/test/distributed/tensor/parallel/test_tp_random_state.py
@@ -7,8 +7,12 @@ from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import Replicate
 from torch.distributed.tensor.parallel.api import parallelize_module
 from torch.distributed.tensor.parallel.style import ColwiseParallel
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -18,6 +22,8 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 
 class TensorParallelRandomStateTests(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def get_tensor_slice(self, idx, n, large_tensor):
         shape = large_tensor.shape
         if shape[0] % n != 0:
@@ -136,6 +142,12 @@ class TensorParallelRandomStateTests(DTensorTestBase):
 
 TensorParallelRandomStateTestsWithLocalTensor = create_local_tensor_test_class(
     TensorParallelRandomStateTests
+)
+
+instantiate_device_type_tests(
+    TensorParallelRandomStateTestsWithLocalTensor,
+    globals(),
+    allow_xpu=True
 )
 
 if __name__ == "__main__":

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -813,7 +813,12 @@ class BackendConfig:
         elif normalized_backend in Backend.backend_list:
             # Cases for when backend is a single string (without device types)
             # e.g. "nccl", "gloo", "ucc", "mpi"
-            supported_devices = Backend.backend_capability[normalized_backend]
+            supported_devices = list(Backend.backend_capability[normalized_backend])
+            if normalized_backend == Backend.FAKE:
+                # FAKE backend should support all registered device types
+                for device in Backend.default_device_backend_map:
+                    if device not in supported_devices:
+                        supported_devices.append(device)
             backend_val = Backend(backend)
 
             self.device_backend_map = dict.fromkeys(supported_devices, backend_val)


### PR DESCRIPTION
## Summary:
  Add hardware classification for test_tp_random_state.py and classify
  `TensorParallelRandomStateTestsWithLocalTensor` as ACCELERATOR.

## Changes:
  I. Set `hw_classification = HardwareClassification.ACCELERATOR` on
     `TensorParallelRandomStateTestsWithLocalTensor`.
  II. Instantiating `TensorParallelRandomStateTests` and
      `TensorParallelRandomStateTestsWithLocalTensor`.
  III. Add additional devices supporting in initializing BackendConfig
       when using `FAKE` backend.

## Test Plan:
  python test/distributed/tensor/parallel/test_tp_random_state.py -v --hw-classification ACCELERATOR

This PR depends on the merge of #189850 and #193550 .