### PR TITLE
[RFC] [Testcase Refactoring]Make distributed replicate with FSDP tests device-agnostic using torch.accelerator APIs

### DIFF
--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -62,10 +62,9 @@ class ReplicateTest(MultiProcContinuousTest):
         """
         Distributed communication backend.
 
-        Environment variable:
-            TEST_DIST_BACKEND: Distributed backend (nccl, hccl, gloo, etc.)
+        Returns the default backend for the current device type.
         """
-        return os.environ.get("TEST_DIST_BACKEND", "nccl")
+        return dist.get_default_backend_for_device(cls.device_type())
 
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file):

--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -88,6 +88,9 @@ class ReplicateTest(MultiProcContinuousTest):
     def test_replicate_transformer(self, device):
         """
         This tests that replicate works on a transformer model with fully_shard and replicate layers
+
+        Args:
+            device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
         """
         run_subtests(
             self,
@@ -167,6 +170,8 @@ class ReplicateTest(MultiProcContinuousTest):
                 13. w2
                 14. resid_dropout
 
+        Args:
+            device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
         """
 
         model_args = ModelArgs()
@@ -209,6 +214,9 @@ class ReplicateTest(MultiProcContinuousTest):
     def test_replicate_tp_device_mesh(self, device):
         """
         This tests that a user can pass in a device mesh to replicate a module
+
+        Args:
+            device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
         """
 
         device = torch.device(device)
@@ -236,6 +244,9 @@ class ReplicateTest(MultiProcContinuousTest):
     def test_train_replicate_fsdp(self, device):
         """
         Tests that replicate_model has the same behavior as original model when training
+
+        Args:
+            device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
         """
 
         device = torch.device(device)
@@ -283,6 +294,9 @@ class ReplicateTest(MultiProcContinuousTest):
     def test_train_parity_2d_mlp(self, device):
         """
         Verifies when a device mesh is passed in, the model has the same behavior as the original model when training
+
+        Args:
+            device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
         """
         global_mesh = self.init_replicate_tp_mesh()
         run_subtests(

--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -25,8 +25,16 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     TEST_SKIPS,
 )
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_fsdp import check_sharded_parity, MLPStack
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
@@ -45,6 +53,8 @@ class Net(nn.Module):
 
 
 class ReplicateTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     world_size = 4
 
     @classmethod
@@ -58,17 +68,6 @@ class ReplicateTest(MultiProcContinuousTest):
         return os.environ.get("TEST_DIST_BACKEND", "nccl")
 
     @classmethod
-    def device_type(cls) -> str:
-        """
-        Device type for testing.
-
-        Environment variable:
-            TEST_DEVICE: Device type (cuda, npu, xpu, hpu, cpu)
-        """
-        _accelerator = torch.accelerator.current_accelerator()
-        return os.environ.get("TEST_DEVICE", _accelerator.type if _accelerator else "cpu")
-
-    @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file):
         if torch.accelerator.is_available():
             if torch.accelerator.device_count() < world_size:
@@ -80,13 +79,14 @@ class ReplicateTest(MultiProcContinuousTest):
         # Prefer to test with >=4 GPUs, but for 2 GPUs, use 2-way TP
         replicate_size = 2
         return init_device_mesh(
-            self.device_type(),
+            self.device_type,
             (replicate_size, 1, self.world_size // replicate_size),
             mesh_dim_names=("replicate", "shard", "tp"),
         )
 
     @skip_if_lt_x_gpu(4)
-    def test_replicate_transformer(self):
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
+    def test_replicate_transformer(self, device):
         """
         This tests that replicate works on a transformer model with fully_shard and replicate layers
         """
@@ -96,6 +96,7 @@ class ReplicateTest(MultiProcContinuousTest):
                 "sharding_strategy": ["replicate", "fully_shard"],
             },
             self._test_replicate_transformer,
+            device=device,
         )
 
     def _composable_api_module_check(self, module, sharding_strategy):
@@ -104,7 +105,7 @@ class ReplicateTest(MultiProcContinuousTest):
         else:
             self.assertTrue("fully_shard" in _get_registry(module))
 
-    def _test_replicate_transformer(self, sharding_strategy):
+    def _test_replicate_transformer(self, sharding_strategy, device=None):
         model_args = ModelArgs()
 
         model = Transformer(model_args)
@@ -135,7 +136,8 @@ class ReplicateTest(MultiProcContinuousTest):
                     self.assertEqual(parameter.placements, (Shard(dim=0),))
 
     @skip_if_lt_x_gpu(4)
-    def test_replicate_transformer_managed_modules(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_replicate_transformer_managed_modules(self, device):
         """
         This tests that replicate managed modules works properly. In this test we use a Transformer Module with 3 layers,
         which means there are 49 submodules. We apply replicate on the first layer and fully shard on the second layer,
@@ -204,12 +206,13 @@ class ReplicateTest(MultiProcContinuousTest):
         )
 
     @skip_if_lt_x_gpu(4)
-    def test_replicate_tp_device_mesh(self):
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.dtensor)
+    def test_replicate_tp_device_mesh(self, device):
         """
         This tests that a user can pass in a device mesh to replicate a module
         """
 
-        device = torch.device(f"{self.device_type()}:{self.rank % getattr(torch, self.device_type()).device_count()}")
+        device = torch.device(device)
         model = Net().to(device)
         replicate_model = deepcopy(model)
 
@@ -230,12 +233,13 @@ class ReplicateTest(MultiProcContinuousTest):
                 self.assertEqual(parameter.placements, (Replicate(),))
 
     @skip_if_lt_x_gpu(4)
-    def test_train_replicate_fsdp(self):
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
+    def test_train_replicate_fsdp(self, device):
         """
         Tests that replicate_model has the same behavior as original model when training
         """
 
-        device = torch.device(f"{self.device_type()}:{self.rank % getattr(torch, self.device_type()).device_count()}")
+        device = torch.device(device)
         model = Net().to(device)
         replicate_model = deepcopy(model)
 
@@ -276,7 +280,8 @@ class ReplicateTest(MultiProcContinuousTest):
             check_sharded_parity(self, model, replicate_model)
 
     @skip_if_lt_x_gpu(4)
-    def test_train_parity_2d_mlp(self):
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
+    def test_train_parity_2d_mlp(self, device):
         """
         Verifies when a device mesh is passed in, the model has the same behavior as the original model when training
         """
@@ -288,6 +293,7 @@ class ReplicateTest(MultiProcContinuousTest):
                 "mlp_dim": [3, 16, 17],
             },
             functools.partial(self._test_train_parity_2d_mlp, global_mesh),
+            device=device,
         )
 
     def _test_train_parity_2d_mlp(
@@ -295,6 +301,7 @@ class ReplicateTest(MultiProcContinuousTest):
         global_mesh: DeviceMesh,
         use_activation_checkpointing: bool,
         mlp_dim: int,
+        device=None,
     ):
         replicate_shard_mesh, tp_mesh = (
             global_mesh["replicate", "shard"],
@@ -305,7 +312,7 @@ class ReplicateTest(MultiProcContinuousTest):
 
         torch.manual_seed(42)
         model = MLPStack(mlp_dim)
-        ref_model = copy.deepcopy(model).to(self.device_type())
+        ref_model = copy.deepcopy(model).to(device)
         replicate(ref_model, mesh=replicate_mesh)
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2, foreach=False)
         model.parallelize(
@@ -316,7 +323,7 @@ class ReplicateTest(MultiProcContinuousTest):
         optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=False)
 
         torch.manual_seed(42 + replicate_pg.rank() + 1)
-        device = torch.device(self.device_type())
+        device = torch.device(device)
         for iter_idx in range(10):
             inp = torch.randn((8, mlp_dim), device=device)
             losses: list[torch.Tensor] = []
@@ -327,6 +334,8 @@ class ReplicateTest(MultiProcContinuousTest):
                 _optim.step()
             self.assertEqual(losses[0], losses[1])
 
+
+instantiate_device_type_tests(ReplicateTest, globals(), except_for=["cpu"])
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -25,11 +25,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     TEST_SKIPS,
 )
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_fsdp import check_sharded_parity, MLPStack
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -84,7 +80,6 @@ class ReplicateTest(MultiProcContinuousTest):
         )
 
     @skip_if_lt_x_gpu(4)
-    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     def test_replicate_transformer(self, device):
         """
         This tests that replicate works on a transformer model with fully_shard and replicate layers
@@ -138,7 +133,6 @@ class ReplicateTest(MultiProcContinuousTest):
                     self.assertEqual(parameter.placements, (Shard(dim=0),))
 
     @skip_if_lt_x_gpu(4)
-    @requires_capabilities(Capability.distributed.backend)
     def test_replicate_transformer_managed_modules(self, device):
         """
         This tests that replicate managed modules works properly. In this test we use a Transformer Module with 3 layers,
@@ -210,7 +204,6 @@ class ReplicateTest(MultiProcContinuousTest):
         )
 
     @skip_if_lt_x_gpu(4)
-    @requires_capabilities(Capability.distributed.backend, Capability.distributed.dtensor)
     def test_replicate_tp_device_mesh(self, device):
         """
         This tests that a user can pass in a device mesh to replicate a module
@@ -240,7 +233,6 @@ class ReplicateTest(MultiProcContinuousTest):
                 self.assertEqual(parameter.placements, (Replicate(),))
 
     @skip_if_lt_x_gpu(4)
-    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     def test_train_replicate_fsdp(self, device):
         """
         Tests that replicate_model has the same behavior as original model when training
@@ -290,7 +282,6 @@ class ReplicateTest(MultiProcContinuousTest):
             check_sharded_parity(self, model, replicate_model)
 
     @skip_if_lt_x_gpu(4)
-    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     def test_train_parity_2d_mlp(self, device):
         """
         Verifies when a device mesh is passed in, the model has the same behavior as the original model when training
@@ -348,7 +339,7 @@ class ReplicateTest(MultiProcContinuousTest):
             self.assertEqual(losses[0], losses[1])
 
 
-instantiate_device_type_tests(ReplicateTest, globals(), except_for=["cpu"])
+instantiate_device_type_tests(ReplicateTest, globals(), except_for="cpu", allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -85,7 +85,7 @@ class ReplicateTest(MultiProcContinuousTest):
         This tests that replicate works on a transformer model with fully_shard and replicate layers
 
         Args:
-            device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
+            device: Device to run the test on. typically designated by an identifier such as "cuda:0".
         """
         run_subtests(
             self,
@@ -165,7 +165,7 @@ class ReplicateTest(MultiProcContinuousTest):
                 14. resid_dropout
 
         Args:
-            device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
+            device: Device to run the test on. typically designated by an identifier such as "cuda:0".
         """
 
         model_args = ModelArgs()
@@ -209,7 +209,7 @@ class ReplicateTest(MultiProcContinuousTest):
         This tests that a user can pass in a device mesh to replicate a module
 
         Args:
-            device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
+            device: Device to run the test on. typically designated by an identifier such as "cuda:0".
         """
 
         device = torch.device(f"{device}:{self.rank % getattr(torch, device).device_count()}")
@@ -238,7 +238,7 @@ class ReplicateTest(MultiProcContinuousTest):
         Tests that replicate_model has the same behavior as original model when training
 
         Args:
-            device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
+            device: Device to run the test on. typically designated by an identifier such as "cuda:0".
         """
 
         device = torch.device(f"{device}:{self.rank % getattr(torch, device).device_count()}")
@@ -287,7 +287,7 @@ class ReplicateTest(MultiProcContinuousTest):
         Verifies when a device mesh is passed in, the model has the same behavior as the original model when training
 
         Args:
-            device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
+            device: Device to run the test on. typically designated by an identifier such as "cuda:0".
         """
         global_mesh = self.init_replicate_tp_mesh()
         run_subtests(

--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -93,7 +93,6 @@ class ReplicateTest(MultiProcContinuousTest):
                 "sharding_strategy": ["replicate", "fully_shard"],
             },
             self._test_replicate_transformer,
-            device=device,
         )
 
     def _composable_api_module_check(self, module, sharding_strategy):
@@ -102,7 +101,7 @@ class ReplicateTest(MultiProcContinuousTest):
         else:
             self.assertTrue("fully_shard" in _get_registry(module))
 
-    def _test_replicate_transformer(self, sharding_strategy, device=None):
+    def _test_replicate_transformer(self, sharding_strategy):
         model_args = ModelArgs()
 
         model = Transformer(model_args)
@@ -212,7 +211,8 @@ class ReplicateTest(MultiProcContinuousTest):
             device: Device to run the test on. typically designated by an identifier such as "cuda:0".
         """
 
-        device = torch.device(f"{device}:{self.rank % getattr(torch, device).device_count()}")
+        device_type = torch.device(device).type
+        device = torch.device(f"{device_type}:{self.rank}")
         model = Net().to(device)
         replicate_model = deepcopy(model)
 
@@ -241,7 +241,8 @@ class ReplicateTest(MultiProcContinuousTest):
             device: Device to run the test on. typically designated by an identifier such as "cuda:0".
         """
 
-        device = torch.device(f"{device}:{self.rank % getattr(torch, device).device_count()}")
+        device_type = torch.device(device).type
+        device = torch.device(f"{device_type}:{self.rank}")
         model = Net().to(device)
         replicate_model = deepcopy(model)
 

--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -2,6 +2,7 @@
 
 import copy
 import functools
+import os
 import sys
 from copy import deepcopy
 
@@ -48,11 +49,24 @@ class ReplicateTest(MultiProcContinuousTest):
 
     @classmethod
     def backend_str(cls) -> str:
-        return "nccl"
+        """
+        Distributed communication backend.
+
+        Environment variable:
+            TEST_DIST_BACKEND: Distributed backend (nccl, hccl, gloo, etc.)
+        """
+        return os.environ.get("TEST_DIST_BACKEND", "nccl")
 
     @classmethod
     def device_type(cls) -> str:
-        return "cuda"
+        """
+        Device type for testing.
+
+        Environment variable:
+            TEST_DEVICE: Device type (cuda, npu, xpu, hpu, cpu)
+        """
+        _accelerator = torch.accelerator.current_accelerator()
+        return os.environ.get("TEST_DEVICE", _accelerator.type if _accelerator else "cpu")
 
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file):
@@ -66,7 +80,7 @@ class ReplicateTest(MultiProcContinuousTest):
         # Prefer to test with >=4 GPUs, but for 2 GPUs, use 2-way TP
         replicate_size = 2
         return init_device_mesh(
-            "cuda",
+            self.device_type(),
             (replicate_size, 1, self.world_size // replicate_size),
             mesh_dim_names=("replicate", "shard", "tp"),
         )
@@ -195,7 +209,7 @@ class ReplicateTest(MultiProcContinuousTest):
         This tests that a user can pass in a device mesh to replicate a module
         """
 
-        device = torch.device(f"cuda:{self.rank % torch.cuda.device_count()}")
+        device = torch.device(f"{self.device_type()}:{self.rank % getattr(torch, self.device_type()).device_count()}")
         model = Net().to(device)
         replicate_model = deepcopy(model)
 
@@ -221,7 +235,7 @@ class ReplicateTest(MultiProcContinuousTest):
         Tests that replicate_model has the same behavior as original model when training
         """
 
-        device = torch.device(f"cuda:{self.rank % torch.cuda.device_count()}")
+        device = torch.device(f"{self.device_type()}:{self.rank % getattr(torch, self.device_type()).device_count()}")
         model = Net().to(device)
         replicate_model = deepcopy(model)
 
@@ -291,7 +305,7 @@ class ReplicateTest(MultiProcContinuousTest):
 
         torch.manual_seed(42)
         model = MLPStack(mlp_dim)
-        ref_model = copy.deepcopy(model).cuda()
+        ref_model = copy.deepcopy(model).to(self.device_type())
         replicate(ref_model, mesh=replicate_mesh)
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2, foreach=False)
         model.parallelize(
@@ -302,7 +316,7 @@ class ReplicateTest(MultiProcContinuousTest):
         optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=False)
 
         torch.manual_seed(42 + replicate_pg.rank() + 1)
-        device = torch.device("cuda")
+        device = torch.device(self.device_type())
         for iter_idx in range(10):
             inp = torch.randn((8, mlp_dim), device=device)
             losses: list[torch.Tensor] = []

--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -212,7 +212,7 @@ class ReplicateTest(MultiProcContinuousTest):
             device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
         """
 
-        device = torch.device(device)
+        device = torch.device(f"{device}:{self.rank % getattr(torch, device).device_count()}")
         model = Net().to(device)
         replicate_model = deepcopy(model)
 
@@ -241,7 +241,7 @@ class ReplicateTest(MultiProcContinuousTest):
             device: Device to run the test on. Typically "cuda:0", "npu:0", etc.
         """
 
-        device = torch.device(device)
+        device = torch.device(f"{device}:{self.rank % getattr(torch, device).device_count()}")
         model = Net().to(device)
         replicate_model = deepcopy(model)
 

--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -2,7 +2,6 @@
 
 import copy
 import functools
-import os
 import sys
 from copy import deepcopy
 
@@ -25,12 +24,9 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     TEST_SKIPS,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_fsdp import check_sharded_parity, MLPStack
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    run_tests,
-)
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
@@ -340,7 +336,9 @@ class ReplicateTest(MultiProcContinuousTest):
             self.assertEqual(losses[0], losses[1])
 
 
-instantiate_device_type_tests(ReplicateTest, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(
+    ReplicateTest, globals(), except_for="cpu", allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

This PR refactors `test/distributed/_composable/test_replicate_with_fsdp.py` to be fully device-agnostic and eliminates per-test-class `backend_str()` overrides by migrating to the common base class `MultiProcContinuousForInstantiateTest` (from [#195000](https://github.com/pytorch/pytorch/pull/195000)).

### Relationship to existing PRs

| PR | Scope | Status |
|----|-------|--------|
| [#190998](https://github.com/pytorch/pytorch/pull/190998) | Initial device-agnostic refactor: removed hardcoded `"nccl"`/`"cuda"`, added `instantiate_device_type_tests`, `hw_classification`, `device` parameter, made `init_replicate_tp_mesh` device-generic, replaced `.cuda()` with `.to(device)` | **Superseded by this PR** (folded in) |
| [#195000](https://github.com/pytorch/pytorch/pull/195000) | Adds `MultiProcContinuousForInstantiateTest` common base class to `common_distributed.py`, providing `backend_str()` and `current_device` for `instantiate_device_type_tests`-based distributed tests | Open (dependency of this PR) |
| **This PR** | All changes from #190998 **plus** migration from `MultiProcContinuousTest` + per-class `backend_str()` → `MultiProcContinuousForInstantiateTest` (inherited `backend_str()`) | New |

> **Note**: This PR supersedes #190998 by folding in all its changes and adding the `MultiProcContinuousForInstantiateTest` migration on top. It depends on #195000 for the `MultiProcContinuousForInstantiateTest` class in `common_distributed.py`.

## Motivation

The original `test_replicate_with_fsdp.py` had two categories of problems:

### Problem 1: Hardcoded CUDA assumptions

- `backend_str()` returned hardcoded `"nccl"` regardless of device type
- `device_type()` was overridden to always return `"cuda"`
- `init_replicate_tp_mesh()` hardcoded `"cuda"` in `init_device_mesh()`
- Test methods used `torch.device(f"cuda:{self.rank % torch.cuda.device_count()}")` and `.cuda()`
- No `device` parameter, no `instantiate_device_type_tests`, no `hw_classification`

### Problem 2: Per-class `backend_str()` duplication 

After #190998 replaced hardcoded `"nccl"` with `dist.get_default_backend_for_device()`, the test class still re-implemented `backend_str()` inline:

```python
class ReplicateTest(MultiProcContinuousTest):
    @classmethod
    def backend_str(cls) -> str:
        device_type = cls.device_type
        if callable(device_type):
            device_type = device_type()
        return dist.get_default_backend_for_device(device_type)
```

This is the exact same logic already provided by `MultiProcContinuousForInstantiateTest` (from #195000). The test-case refactoring guideline requires that test classes should not re-implement `backend_str`/`device_type` inline, but instead obtain them from a common middle class.

## Changes

### Part 1: Device-agnostic refactor 

#### 1.1 Add `HardwareClassification` and `instantiate_device_type_tests`

```python
# Added imports
from torch.testing._internal.common_utils import HardwareClassification, run_tests
from torch.testing._internal.common_device_type import instantiate_device_type_tests

class ReplicateTest(MultiProcContinuousTest):
    hw_classification = HardwareClassification.ACCELERATOR
```

#### 1.2 Replace hardcoded backend and device_type with dynamic resolution

```python
# Before
@classmethod
def backend_str(cls) -> str:
    return "nccl"

@classmethod
def device_type(cls) -> str:
    return "cuda"

# After (intermediate — further refined in Part 2)
@classmethod
def backend_str(cls) -> str:
    device_type = cls.device_type
    if callable(device_type):
        device_type = device_type()
    return dist.get_default_backend_for_device(device_type)
# device_type() override removed — uses MultiProcContinuousTest.device_type() base implementation
```

#### 1.3 Make `init_replicate_tp_mesh` device-generic

```python
# Before
return init_device_mesh("cuda", ...)

# After
return init_device_mesh(self.device_type, ...)
```

#### 1.4 Add `device` parameter to all test methods

```python
# Before
def test_replicate_transformer(self):
    ...

# After
def test_replicate_transformer(self, device):
    ...
```

Applied to all 5 test methods: `test_replicate_transformer`, `test_replicate_transformer_managed_modules`, `test_replicate_tp_device_mesh`, `test_train_replicate_fsdp`, `test_train_parity_2d_mlp`.

#### 1.5 Replace hardcoded device creation with generic API

```python
# Before
device = torch.device(f"cuda:{self.rank % torch.cuda.device_count()}")
ref_model = copy.deepcopy(model).cuda()
device = torch.device("cuda")

# After
device_type = torch.device(device).type
device = torch.device(f"{device_type}:{self.rank}")
ref_model = copy.deepcopy(model).to(device)
```

#### 1.6 Add `instantiate_device_type_tests` call

```python
instantiate_device_type_tests(
    ReplicateTest, globals(), except_for="cpu", allow_xpu=True
)
```

### Part 2: Migrate to `MultiProcContinuousForInstantiateTest` (this PR's incremental change)

#### 2.1 Import change

```python
# Before
from torch.testing._internal.common_distributed import (
    MultiProcContinuousTest,
    run_subtests,
    skip_if_lt_x_gpu,
    TEST_SKIPS,
)

# After
from torch.testing._internal.common_distributed import (
    MultiProcContinuousForInstantiateTest,
    run_subtests,
    skip_if_lt_x_gpu,
    TEST_SKIPS,
)
```

#### 2.2 Change base class, remove `backend_str()` override

```python
# Before
class ReplicateTest(MultiProcContinuousTest):
    hw_classification = HardwareClassification.ACCELERATOR

    world_size = 4

    @classmethod
    def backend_str(cls) -> str:
        """
        Distributed communication backend.

        Returns the default backend for the current device type.
        """
        device_type = cls.device_type
        if callable(device_type):
            device_type = device_type()
        return dist.get_default_backend_for_device(device_type)

    @classmethod
    def _init_pg(cls, rank, world_size, rdvz_file):
        ...

# After
class ReplicateTest(MultiProcContinuousForInstantiateTest):
    hw_classification = HardwareClassification.ACCELERATOR

    world_size = 4

    # backend_str() inherited from MultiProcContinuousForInstantiateTest

    @classmethod
    def _init_pg(cls, rank, world_size, rdvz_file):
        ...
```

#### 2.3 `_init_pg()` override — retained

The `_init_pg()` override is **kept** because `MultiProcContinuousTest._init_pg()` does not include accelerator device setup (`torch.accelerator.is_available()` / `torch.accelerator.device_count()` / `torch.accelerator.set_device_index(rank)`), which is required for this test to correctly bind each rank to a device before PG initialization.

## How `backend_str()` resolution works after this PR

`instantiate_device_type_tests` creates device-specific subclasses with MRO:

```
ReplicateTestCUDA → CUDATestBase → DeviceTypeTestBase → TestCase →
ReplicateTest → MultiProcContinuousForInstantiateTest → MultiProcContinuousTest → ...
```

| MRO level | `device_type` | Type |
|-----------|--------------|------|
| `CUDATestBase` (`common_device_type.py:745`) | `"cuda"` | string class attribute |
| `MultiProcContinuousTest` (`common_distributed.py:1850`) | `@classmethod` returning `current_accelerator().type` | classmethod |

`CUDATestBase` precedes `MultiProcContinuousTest` in MRO, so the string attribute **shadows** the classmethod. Therefore `cls.device_type` resolves to `"cuda"` (a string), and `MultiProcContinuousForInstantiateTest.backend_str()` correctly passes it to `c10d.get_default_backend_for_device("cuda")` → `"nccl"`.

## Test Plan

Verified statically (no runtime environment available):

1. **Syntax**: `ast.parse` passes for the modified file.
2. **ruff check**: All checks passed.
3. **ruff format**: 1 file already formatted.
4. **`get_default_backend_for_device` availability**: Function is defined at `distributed_c10d.py:2033`, exported in `__all__` at line 126, and `c10d` is imported in `common_distributed.py` as `import torch.distributed as c10d` (line 33).
5. **MRO correctness**: `CUDATestBase.device_type` (string) shadows `MultiProcContinuousTest.device_type` (classmethod) in MRO, so `cls.device_type` in `MultiProcContinuousForInstantiateTest.backend_str()` receives a string.
6. **`dist` import retained**: `dist` is still used in test methods (`dist.all_reduce`, `dist.ReduceOp.SUM`), so the import is correctly kept.
7. **`_init_pg` preserved**: The accelerator device setup logic in `_init_pg()` is not available in the base class, so the override is correctly retained.
8. **No behavior change for CUDA**: `get_default_backend_for_device("cuda")` returns `"nccl"`, same as the previous inline implementation.

### Expected runtime verification (to be run in CI)

```bash
# CUDA (requires 4 GPUs)
python test/distributed/_composable/test_replicate_with_fsdp.py
```

## Compatibility

- **Fully backward compatible**: CUDA behavior is identical to before.
- **No hardcoded device/backend references**: All device and backend resolution goes through `torch.accelerator` and `dist.get_default_backend_for_device`.
- **Supports NPU, HPU, XPU and other accelerators** via `torch.accelerator` public API and `instantiate_device_type_tests`.
- **Depends on #195000**: The `MultiProcContinuousForInstantiateTest` class is provided by #195000. This PR should be stacked on top of #195000.

## Files Changed

| File | Description |
|------|-------------|
| `test/distributed/_composable/test_replicate_with_fsdp.py` | Device-agnostic refactor (from #190998) + migration to `MultiProcContinuousForInstantiateTest` (this PR): removed hardcoded `"nccl"`/`"cuda"`/`.cuda()`, added `instantiate_device_type_tests`/`hw_classification`/`device` parameter, made `init_replicate_tp_mesh` device-generic, replaced per-class `backend_str()` with inherited implementation from `MultiProcContinuousForInstantiateTest` |
