### PR TITLE
Expose  NCCL commName in ncclConfig bindings to ProcessGroupNCCL.Options()

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4780,6 +4780,32 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         self._test_pass_nccl_options(pg_opts)
 
     @requires_nccl()
+    @requires_nccl_version(
+        (2, 27, 3), "Need NCCL 2.27.3+ for testing comm_name in ncclConfig_t"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_pass_nccl_options_config_comm_name(self):
+        nccl_cfg = c10d.ProcessGroupNCCL.NCCLConfig()
+        if not hasattr(nccl_cfg, "comm_name"):
+            raise SkipTest(
+                "comm_name binding absent (PyTorch might be built against NCCL < 2.27.3)"
+            )
+        pg_opts = c10d.ProcessGroupNCCL.Options()
+        new_comm_name = "test_comm"
+        pg_opts.config.comm_name = new_comm_name
+        self.assertEqual(pg_opts.config.comm_name, new_comm_name)
+        os.environ["NCCL_DEBUG"] = "INFO"
+        with tempfile.NamedTemporaryFile() as nccl_debug_file:
+            os.environ["NCCL_DEBUG_FILE"] = nccl_debug_file.name
+            # Tests functionality when passing nccl config
+            self._test_pass_nccl_options(pg_opts)
+            nccl_debug_file_content = nccl_debug_file.read()
+        comm_name = re.search(
+            rb"Comm config Comm name set to (.*)|$", nccl_debug_file_content
+        ).group(1)
+        self.assertEqual(pg_opts.config.comm_name, comm_name.decode())
+
+    @requires_nccl()
     @skip_if_lt_x_gpu(4)
     def test_nccl_barrier(self):
         store = c10d.FileStore(self.file_name, self.world_size)

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -38,6 +38,10 @@ static_assert(
 #define NCCL_HAS_COLLNET
 #endif
 
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 3)
+#define NCCL_HAS_COMM_NAME
+#endif
+
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
 #define NCCL_HAS_CTA_POLICY
 #endif

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3789,6 +3789,14 @@ for details.
 #ifdef NCCL_HAS_MAX_P2P_PEERS
       .def_readwrite("max_p2p_peers", &ncclConfig_t::maxP2pPeers)
 #endif
+#ifdef NCCL_HAS_COMM_NAME
+      .def_property(
+          "comm_name",
+          [](const ncclConfig_t& self) { return self.commName; },
+          [](ncclConfig_t& self, const char* tmp) {
+            self.commName = strdup(tmp);
+          })
+#endif
       .def(
           "unsafe_get_ptr",
           [](const ncclConfig_t& self) {


### PR DESCRIPTION
## Summary

Add new NCCL config `commName` (https://github.com/NVIDIA/nccl/blob/master/src/nccl.h.in), allowing users to set a name for an NCCL communicator via `ncclConfig_t`. This makes it easier to identify individual communicators in NCCL logs and profiler tools.

## Background

We would like to distinguish comm group using comm_name so that we can utilize NCCL plugins such as the tuner and profiler.

## Testing

```python
import torch
import torch.distributed as dist

def main():
    dist.init_process_group(backend="nccl")
    rank = dist.get_rank()

    nccl_options = dist.ProcessGroupNCCL.Options(is_high_priority_stream=False)
    nccl_options.config.comm_name = "tensor_parallel"

    sub_group = dist.new_group(
        ranks=[0, 1],
        backend="nccl",
        pg_options=nccl_options,
    )
    if rank in [0,1]:
        tensor = torch.ones(1, device=f"cuda:{rank}")
        dist.all_reduce(tensor, group=sub_group)
        print(f"rank {rank}: {tensor.item()}")

    dist.destroy_process_group()

if __name__ == "__main__":
    main()
```