### PR TITLE
[Distributed] Fail fast on SymmetricMemory MemPool slot mismatch to prevent silent corruption

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -107,6 +107,27 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         self.assertFalse(_SymmetricMemory.has_multicast_support(DeviceType.CPU, 0))
         # NOTE: DeviceType.CUDA is implicitly tested through @requires_multicast_support
 
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_rendezvous_mismatch_fails_fast(self) -> None:
+        self._init_process()
+
+        # Desynchronize allocation IDs: rank 0 does an extra allocation,
+        # so its alloc_id sequence is shifted by 1 relative to other ranks.
+        if self.rank == 0:
+            extra = symm_mem.empty(64, device="cuda")
+
+        t = symm_mem.empty(64, device="cuda")
+
+        # This collective rendezvous should detect the alloc_id mismatch and fail fast
+        # rather than silent collective corruption.
+        with self.assertRaises(RuntimeError) as ctx:
+            symm_mem.rendezvous(t, group=dist.group.WORLD)
+
+        self.assertIn("Symmetric window mismatch detected during rendezvous", str(ctx.exception))
+
     @requires_cuda
     @skipIf(
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -329,13 +329,15 @@ Block::Block(
     size_t block_size,
     size_t buffer_size,
     size_t buffer_offset,
-    const std::optional<std::string>& group_name)
+    const std::optional<std::string>& group_name,
+    int64_t alloc_id)
     : alloc_ref(std::move(alloc_ref)),
       device_idx(device_idx),
       block_size(block_size),
       buffer_size(buffer_size),
       buffer_offset(buffer_offset),
-      default_group_name(std::move(group_name)) {}
+      default_group_name(std::move(group_name)),
+      alloc_id(alloc_id) {}
 
 namespace {
 using Expandable_Segments_Handle_Type =
@@ -432,6 +434,12 @@ void* CUDASymmetricMemoryAllocator::alloc(
   // (and thus alloc_base) is released internally by ~AllocationRef.
   void* buffer_ptr = static_cast<char*>(alloc_base) + buffer_offset;
 
+  int64_t alloc_id = 0;
+  {
+    std::unique_lock lock(mutex_);
+    alloc_id = alloc_counter_++;
+  }
+
   auto alloc_ref = c10::make_intrusive<AllocationRef>(
       alloc_base, handle, block_size, device_idx);
   auto block = c10::make_intrusive<Block>(
@@ -440,7 +448,8 @@ void* CUDASymmetricMemoryAllocator::alloc(
       block_size,
       size,
       buffer_offset,
-      group_name);
+      group_name,
+      alloc_id);
   {
     std::unique_lock lock(mutex_);
     // Key by the data pointer we return (that's what free()/rendezvous see).
@@ -461,6 +470,15 @@ size_t CUDASymmetricMemoryAllocator::get_alloc_size(void* ptr) {
       "CUDASymmetricMemoryAllocator::get_alloc_size: input must be allocated ",
       "via CUDASymmetricMemoryAllocator::alloc");
   return block->buffer_size;
+}
+
+int64_t CUDASymmetricMemoryAllocator::get_alloc_id(void* ptr) {
+  size_t offset = 0;
+  auto block = find_block_covering(ptr, offset);
+  if (block != nullptr) {
+    return block->alloc_id;
+  }
+  return -1;
 }
 
 struct RendezvousRequest {

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
@@ -118,6 +118,7 @@ struct Block : public c10::intrusive_ptr_target {
   size_t buffer_offset;
   std::optional<std::string> default_group_name;
   std::map<std::string, c10::intrusive_ptr<CUDAPeerAllocInfo>> symm_mems;
+  int64_t alloc_id{-1};
 
   Block(
       c10::intrusive_ptr<AllocationRef> alloc_ref,
@@ -125,7 +126,8 @@ struct Block : public c10::intrusive_ptr_target {
       size_t block_size,
       size_t buffer_size,
       size_t buffer_offset,
-      const std::optional<std::string>& group_name);
+      const std::optional<std::string>& group_name,
+      int64_t alloc_id);
 };
 
 class CUDASymmetricMemoryAllocator : public SymmetricMemoryAllocator {
@@ -137,6 +139,7 @@ class CUDASymmetricMemoryAllocator : public SymmetricMemoryAllocator {
 
   void free(void* ptr) override;
   size_t get_alloc_size(void* ptr) override;
+  int64_t get_alloc_id(void* ptr) override;
   c10::intrusive_ptr<SymmetricMemory> rendezvous(
       void* ptr,
       const std::optional<std::string>& group_name) override;
@@ -154,6 +157,7 @@ class CUDASymmetricMemoryAllocator : public SymmetricMemoryAllocator {
   c10::cuda::CUDACachingAllocator::Expandable_Segments_Handle_Type
       handle_type_ = c10::cuda::CUDACachingAllocator::
           Expandable_Segments_Handle_Type::UNSPECIFIED;
+  int64_t alloc_counter_{0};
 };
 
 } // namespace c10d::symmetric_memory

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -47,16 +47,19 @@ struct NCCLAllocation {
   // Map of group name to peer alloc info
   ska::flat_hash_map<std::string, c10::intrusive_ptr<NCCLPeerAllocInfo>>
       peer_alloc_infos_;
+  int64_t alloc_id{-1};
 
   NCCLAllocation(
       void* alloc_base,
       size_t buffer_size,
       size_t buffer_offset,
-      int device_idx)
+      int device_idx,
+      int64_t alloc_id)
       : alloc_base(alloc_base),
         buffer_size(buffer_size),
         buffer_offset(buffer_offset),
-        device_idx(device_idx) {}
+        device_idx(device_idx),
+        alloc_id(alloc_id) {}
 
   ~NCCLAllocation() {
     // Avoid calling CUDA functions after driver shutting down
@@ -519,13 +522,18 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     // alloc_base in its destructor, so free() only needs the data ptr to drop
     // the allocation entry.
     void* buffer_ptr = static_cast<char*>(alloc_base) + buffer_offset;
+    int64_t alloc_id = 0;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      alloc_id = alloc_counter_++;
+    }
     {
       std::lock_guard<std::mutex> lock(mutex_);
       // Key by the data pointer we return (that's what `free()` receives).
       allocations_.emplace(
           buffer_ptr,
           std::make_unique<NCCLAllocation>(
-              alloc_base, size, buffer_offset, device_idx));
+              alloc_base, size, buffer_offset, device_idx, alloc_id));
     }
     return buffer_ptr;
   }
@@ -555,6 +563,15 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     }
     return it->second->buffer_size;
   };
+
+  int64_t get_alloc_id(void* ptr) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto alloc_it = find_allocation_covering(ptr, allocations_);
+    if (alloc_it != allocations_.end()) {
+      return alloc_it->second->alloc_id;
+    }
+    return -1;
+  }
 
   c10::intrusive_ptr<SymmetricMemory> rendezvous(
       void* ptr,
@@ -641,6 +658,7 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
   NCCLAllocMap allocations_;
   NCCLSymmMemMap symm_mems_;
   NCCLSymmMemKeysByAlloc symm_mem_keys_by_alloc_;
+  int64_t alloc_counter_{0};
 };
 
 struct RegisterNCCLSymmetricMemoryAllocator {

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -43,16 +43,19 @@ struct NVSHMEMAllocation {
   size_t buffer_size;
   size_t buffer_offset;
   int device_idx;
+  int64_t alloc_id{-1};
 
   NVSHMEMAllocation(
       void* alloc_base,
       size_t buffer_size,
       size_t buffer_offset,
-      int device_idx)
+      int device_idx,
+      int64_t alloc_id)
       : alloc_base(alloc_base),
         buffer_size(buffer_size),
         buffer_offset(buffer_offset),
-        device_idx(device_idx) {}
+        device_idx(device_idx),
+        alloc_id(alloc_id) {}
 
   // Delete copy and move operations to prevent double-free
   NVSHMEMAllocation(const NVSHMEMAllocation&) = delete;
@@ -422,12 +425,17 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     // alloc_base in its destructor, so free() only needs the data ptr to drop
     // the allocation entry.
     void* buffer_ptr = static_cast<char*>(alloc_base) + buffer_offset;
+    int64_t alloc_id = 0;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      alloc_id = alloc_counter_++;
+    }
     {
       std::lock_guard<std::mutex> lock(mutex_);
       allocations_.try_emplace(
           buffer_ptr,
           std::make_unique<NVSHMEMAllocation>(
-              alloc_base, size, buffer_offset, device_idx));
+              alloc_base, size, buffer_offset, device_idx, alloc_id));
     }
     return buffer_ptr;
   }
@@ -446,6 +454,22 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     }
     return it->second->buffer_size;
   };
+
+  int64_t get_alloc_id(void* ptr) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto alloc_it = std::find_if(
+        allocations_.begin(), allocations_.end(), [&](const auto& pair) {
+          auto& allocation = pair.second;
+          auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
+          auto buffer_ptr = reinterpret_cast<uintptr_t>(pair.first);
+          return ptr_int >= buffer_ptr &&
+              ptr_int < buffer_ptr + allocation->buffer_size;
+        });
+    if (alloc_it != allocations_.end()) {
+      return alloc_it->second->alloc_id;
+    }
+    return -1;
+  }
 
   c10::intrusive_ptr<SymmetricMemory> rendezvous(
       void* ptr,
@@ -550,6 +574,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       c10::intrusive_ptr<NVSHMEMSymmetricMemory>,
       SymmMemKeyHash>
       symm_mems_;
+  int64_t alloc_counter_{0};
 };
 
 struct RegisterNVSHMEMSymmetricMemoryAllocator {

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -362,8 +362,14 @@ TORCH_API c10::intrusive_ptr<SymmetricMemory> rendezvous(
 
   int64_t local_alloc_id = allocator->get_alloc_id(tensor.storage().data_ptr().get());
 
-  if (store && rank >= 0 && world_size > 1 && local_alloc_id >= 0) {
-    validate_rendezvous_alloc_id(store, resolved_group_name, rank, world_size, rendezvous_idx, local_alloc_id);
+  if (store && rank >= 0 && world_size > 1) {
+    validate_rendezvous_alloc_id(
+        store,
+        resolved_group_name,
+        rank,
+        world_size,
+        rendezvous_idx,
+        local_alloc_id);
   }
 
   return allocator->rendezvous(tensor.storage().data_ptr().get(), group_name);

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -5,6 +5,8 @@
 
 #include <atomic>
 #include <mutex>
+#include <sstream>
+#include <cstring>
 
 namespace {
 
@@ -288,10 +290,82 @@ at::Tensor empty_strided_p2p(
       options);
 }
 
+static std::mutex rendezvous_counters_mutex;
+static std::unordered_map<std::string, int64_t> rendezvous_counters;
+
+void validate_rendezvous_alloc_id(
+    const c10::intrusive_ptr<c10d::Store>& store,
+    const std::string& group_name,
+    int rank,
+    int world_size,
+    int64_t rendezvous_idx,
+    int64_t local_alloc_id) {
+  if (!store || rank < 0 || world_size <= 1) {
+    return;
+  }
+
+  std::vector<std::string> peer_keys;
+  peer_keys.reserve(world_size);
+  for (int r = 0; r < world_size; ++r) {
+    std::ostringstream oss;
+    oss << "symm_mem_validate/" << group_name << '/' << rendezvous_idx << '/' << r;
+    peer_keys.push_back(std::move(oss).str());
+  }
+
+  {
+    std::vector<uint8_t> payload(
+        reinterpret_cast<uint8_t*>(&local_alloc_id),
+        reinterpret_cast<uint8_t*>(&local_alloc_id) + sizeof(int64_t));
+    store->set(peer_keys[rank], payload);
+  }
+
+  auto payloads = store->multiGet(peer_keys);
+
+  for (int r = 0; r < world_size; ++r) {
+    TORCH_CHECK(payloads[r].size() == sizeof(int64_t), "Validation payload size mismatch");
+    int64_t peer_alloc_id = 0;
+    std::memcpy(&peer_alloc_id, payloads[r].data(), sizeof(int64_t));
+    TORCH_CHECK(
+        peer_alloc_id == local_alloc_id,
+        "Symmetric window mismatch detected during rendezvous. "
+        "Rank ", rank, " has alloc_id ", local_alloc_id,
+        " but rank ", r, " has alloc_id ", peer_alloc_id,
+        ". This indicates that different ranks are reusing different slots of the Symmetric Memory MemPool, "
+        "which can lead to silent collective corruption. Please check allocation and free patterns across ranks.");
+  }
+}
+
 TORCH_API c10::intrusive_ptr<SymmetricMemory> rendezvous(
     const at::Tensor& tensor,
     const std::optional<std::string>& group_name) {
   auto allocator = get_allocator(tensor.device().type());
+
+  std::string resolved_group_name = group_name.value_or("0");
+  c10::intrusive_ptr<c10d::Store> store = nullptr;
+  int rank = -1;
+  int world_size = -1;
+  {
+    std::lock_guard<std::mutex> lock(group_info_mutex);
+    auto it = group_info_map.find(resolved_group_name);
+    if (it != group_info_map.end()) {
+      store = it->second.store;
+      rank = it->second.rank;
+      world_size = it->second.world_size;
+    }
+  }
+
+  int64_t rendezvous_idx = 0;
+  if (store && rank >= 0 && world_size > 1) {
+    std::lock_guard<std::mutex> lock(rendezvous_counters_mutex);
+    rendezvous_idx = rendezvous_counters[resolved_group_name]++;
+  }
+
+  int64_t local_alloc_id = allocator->get_alloc_id(tensor.storage().data_ptr().get());
+
+  if (store && rank >= 0 && world_size > 1 && local_alloc_id >= 0) {
+    validate_rendezvous_alloc_id(store, resolved_group_name, rank, world_size, rendezvous_idx, local_alloc_id);
+  }
+
   return allocator->rendezvous(tensor.storage().data_ptr().get(), group_name);
 }
 

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -107,6 +107,9 @@ class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {
 
   virtual void free(void* ptr) = 0;
   virtual size_t get_alloc_size(void* ptr) = 0;
+  virtual int64_t get_alloc_id(void* ptr) {
+    return -1;
+  }
   virtual c10::intrusive_ptr<SymmetricMemory> rendezvous(
       void* ptr,
       const std::optional<std::string>& group_name) = 0;


### PR DESCRIPTION

Root Cause:
When ranks perform divergent GPU memory setup allocations, the local allocator counters can diverge. During collective rendezvous under SymmetricMemory, this causes ranks to map and reuse mismatched backing segments/slots of the Symmetric Memory MemPool (since rendezvous order no longer matches address order). The resulting window generation splits lead to silent collective corruption.

Fix:
1. Introduced a monotonic allocation sequence ID (lloc_id) tracking mechanism on physical backing segment allocation for CUDA, NCCL, and NVSHMEM allocators.
2. Implemented get_alloc_id(void*) in the SymmetricMemoryAllocator interface to retrieve the covering segment's sequence ID.
3. Added sequence index tracking for 
endezvous() calls per logical process group.
4. Added cross-rank validation using the ProcessGroup's Store (set and multiGet) to exchange and validate allocation sequence IDs during 
endezvous(). If any rank attempts to map different allocations, it now fails fast with a clean RuntimeError rather than silently corrupting communication.

Test Plan:
Run the newly added unit test which intentionally desynchronizes allocator states across ranks to verify that rendezvous fails fast with a clean mismatch error: `ash
python test/distributed/test_symmetric_memory.py -k test_rendezvous_mismatch_fails_fast