### PR TITLE
[inductor] shlex.quote library dirs in cpp_builder to handle paths with spaces

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -2498,7 +2498,7 @@ class CppBuilder:
             if _IS_WINDOWS:
                 self._libraries_dirs_args += f'/LIBPATH:"{lib_dir}" '
             else:
-                self._libraries_dirs_args += f"-L{lib_dir} "
+                self._libraries_dirs_args += f"-L{shlex.quote(lib_dir)} "
 
         for lib in BuildOption.get_libraries():
             if _IS_WINDOWS:


### PR DESCRIPTION
## Summary

`-I` include dirs were switched to `shlex.quote` in #148271, but the `-L` library dirs assembled a few lines below are still interpolated unquoted. When the Python installation lives in a path containing a space, the linker command is split at the space and Inductor's C++ compile fails.

This is the *default* situation for uv-managed Pythons on macOS, which are installed under `~/Library/Application Support/uv/` — so on such machines any `torch.compile` call that reaches Inductor C++ codegen fails.

## Repro

On macOS with a uv-managed Python (installed under `~/Library/Application Support/uv/python/...`), `torch.compile(model)` on any model fails at first forward with:

```
InductorError: CppCompileError: C++ compile error
...
clang++: error: no such file or directory: 'Support/uv/python/cpython-3.12.12-macos-aarch64-none/lib'
```

because the generated command contains an unquoted
`-L/Users/<user>/Library/Application Support/uv/python/cpython-3.12.12-macos-aarch64-none/lib`.

Reproduced on torch 2.13.0; the unquoted interpolation is still present on `main`.

## Fix

Quote `lib_dir` the same way `inc_dir` already is. `get_command_line()` output is consumed via `shlex.split` in `run_compile_cmd`, so `shlex.quote` round-trips correctly.

Related: #122476 (same class of bug in cpp_extension), follow-up to #148271.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo