### PR TITLE
[dynamo] Standardize slot handler naming to <family>_<slot_name>_impl

### DIFF
--- a/test/distributed/tensor/test_compile_on_one_rank.py
+++ b/test/distributed/tensor/test_compile_on_one_rank.py
@@ -209,7 +209,7 @@ class TestCompileOnOneRank(DTensorTestBase):
         """`dist.all_reduce(t)` with no `group=` (implicit `dist.group.WORLD`)
         should compile under compile_on_one_rank=True.
 
-        `WorldMetaClassVariable.getattro_impl` was routing the WORLD lookup through
+        `WorldMetaClassVariable.tp_getattro_impl` was routing the WORLD lookup through
         `SourcelessBuilder`, dropping the source it had just constructed for the
         guard. The resulting `CustomClassObjectVariable` had the raw ProcessGroup
         as its `proxy` field and blew up later in `as_proxy()` when the PG was

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -15159,7 +15159,7 @@ fn
         from torch._dynamo.variables.user_defined import InspectVariable
 
         redirected_attrs = []
-        original_getattro_impl = InspectVariable.getattro_impl
+        original_getattro_impl = InspectVariable.tp_getattro_impl
 
         def tracking_getattro_impl(self, tx, name):
             redirects = self._PROPERTY_REDIRECTS.get(type(self.value), {})
@@ -15177,7 +15177,7 @@ fn
             return a + b
 
         x = torch.randn(2, 3)
-        with patch.object(InspectVariable, "getattro_impl", tracking_getattro_impl):
+        with patch.object(InspectVariable, "tp_getattro_impl", tracking_getattro_impl):
             opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
             result = opt_fn(x, gn)
 

--- a/test/dynamo/test_repr_protocol.py
+++ b/test/dynamo/test_repr_protocol.py
@@ -459,7 +459,7 @@ class TpReprTests(TestCase):
     def test_repr_of_hash_of_compile_time_object(self):
         # hash() returning id(self) on a sourceless object yields a
         # FakeIdVariable (HASH kind); repr() must route through its
-        # repr_impl and mirror int.__repr__ (a decimal string).
+        # tp_repr_impl and mirror int.__repr__ (a decimal string).
         class Obj:
             def __hash__(self):
                 return id(self)

--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -1,5 +1,5 @@
 # Owner(s): ["module: dynamo"]
-"""Tests for getattro_impl: unified attribute access protocol in Dynamo."""
+"""Tests for tp_getattro_impl: unified attribute access protocol in Dynamo."""
 
 import torch
 import torch._dynamo.test_case
@@ -420,7 +420,7 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(result, torch.sin(x))
 
-    # --- Descriptor protocol (tp_descr_get through getattro_impl) ---
+    # --- Descriptor protocol (tp_descr_get through tp_getattro_impl) ---
 
     def test_data_descriptor_priority_over_instance_dict(self):
         """Data descriptors (property) take precedence over instance __dict__."""
@@ -731,7 +731,7 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
             torch.compile(fn, backend="eager")()
 
     def test_range_start_stop_step(self):
-        """RangeVariable.getattro_impl fast path for start/stop/step."""
+        """RangeVariable.tp_getattro_impl fast path for start/stop/step."""
 
         def fn():
             r = range(2, 10, 3)

--- a/test/dynamo/test_tp_richcompare.py
+++ b/test/dynamo/test_tp_richcompare.py
@@ -1,5 +1,5 @@
 # Owner(s): ["module: dynamo"]
-"""Tests for richcompare_impl: unified comparison protocol in Dynamo."""
+"""Tests for tp_richcompare_impl: unified comparison protocol in Dynamo."""
 
 import operator
 import unittest

--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3016,7 +3016,7 @@ def forward(self, primals_1, tangents_1):
 
         This tests the code path where:
         1. An opaque class (like Color) is accessed via CustomClassVariable
-        2. Attribute access (Color.RED) goes through getattro_impl with static getattr
+        2. Attribute access (Color.RED) goes through tp_getattro_impl with static getattr
         3. The opaque object is correctly lifted as a graph input
         """
         from torch._library.opaque_object import is_opaque_symbolic_type
@@ -3205,7 +3205,7 @@ def forward(self, L_x_ : torch.Tensor):
     def test_opaque_class_staticmethod(self):
         """Test that accessing a staticmethod on an opaque class works correctly.
 
-        This verifies that CustomClassVariable.getattro_impl properly handles
+        This verifies that CustomClassVariable.tp_getattro_impl properly handles
         staticmethod descriptors (instead of raising 'Unsupported descriptor').
         """
         captured = {"graph": None}
@@ -3228,7 +3228,7 @@ def forward(self, L_x_ : torch.Tensor):
     def test_opaque_class_property(self):
         """Test that accessing a property descriptor on an opaque class works correctly.
 
-        This verifies that CustomClassVariable.getattro_impl properly handles
+        This verifies that CustomClassVariable.tp_getattro_impl properly handles
         property descriptors. When accessing a property on the class (not instance),
         you get the property object back.
         """

--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3070,7 +3070,7 @@ def forward(self, primals_1, tangents_1):
 
         This tests the code path where:
         1. An opaque class (like Color) is accessed via CustomClassVariable
-        2. Attribute access (Color.RED) goes through getattro_impl with static getattr
+        2. Attribute access (Color.RED) goes through tp_getattro_impl with static getattr
         3. The opaque object is correctly lifted as a graph input
         """
         from torch._library.opaque_object import is_opaque_symbolic_type
@@ -3259,7 +3259,7 @@ def forward(self, L_x_ : torch.Tensor):
     def test_opaque_class_staticmethod(self):
         """Test that accessing a staticmethod on an opaque class works correctly.
 
-        This verifies that CustomClassVariable.getattro_impl properly handles
+        This verifies that CustomClassVariable.tp_getattro_impl properly handles
         staticmethod descriptors (instead of raising 'Unsupported descriptor').
         """
         captured = {"graph": None}
@@ -3282,7 +3282,7 @@ def forward(self, L_x_ : torch.Tensor):
     def test_opaque_class_property(self):
         """Test that accessing a property descriptor on an opaque class works correctly.
 
-        This verifies that CustomClassVariable.getattro_impl properly handles
+        This verifies that CustomClassVariable.tp_getattro_impl properly handles
         property descriptors. When accessing a property on the class (not instance),
         you get the property object back.
         """

--- a/torch/_dynamo/CLAUDE.md
+++ b/torch/_dynamo/CLAUDE.md
@@ -36,7 +36,7 @@ The compilation pipeline, in execution order:
 
 Every Python value encountered during tracing is wrapped in a `VariableTracker`
 subclass. Key interface: `as_python_constant()`, `as_proxy()`,
-`call_function()`, `call_method()`, `getattro_impl()`, `reconstruct()`.
+`call_function()`, `call_method()`, `tp_getattro_impl()`, `reconstruct()`.
 
 Key fields: `source` (where the value came from, for guards) and
 `mutation_type` (whether/how mutations are tracked).

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -406,7 +406,7 @@
   "GB0031": [
     {
       "Gb_type": "Custom __getattribute__ in nn.Module attribute access",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Dynamo could not trace through the custom `__getattribute__` method on this `nn.Module`.",
       "Hints": [
         "Simplify your `__getattribute__` implementation, ",
@@ -1488,7 +1488,7 @@
   "GB0102": [
     {
       "Gb_type": "Strict mode banned op",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Getattr invocation '{name}' in strict mode is not supported.",
       "Hints": [
         "Remove `{name}` from the list of banned ops by ",
@@ -1520,7 +1520,7 @@
   "GB0104": [
     {
       "Gb_type": "Tensor with grad_fn()",
-      "Context": "getattro_impl {self} grad_fn",
+      "Context": "tp_getattro_impl {self} grad_fn",
       "Explanation": "Dynamo does not support tracing tensors with a grad_fn directly.",
       "Hints": []
     },
@@ -1575,7 +1575,7 @@
   "GB0108": [
     {
       "Gb_type": "Tensor.retain_grad() with AOTDispatcher",
-      "Context": "getattro_impl {self} retain_grad",
+      "Context": "tp_getattro_impl {self} retain_grad",
       "Explanation": "`Tensor.retain_grad()` does not work with AOTDispatcher.",
       "Hints": []
     },
@@ -1822,7 +1822,7 @@
   "GB5976": [
     {
       "Gb_type": "Data pointer comparison",
-      "Context": "richcompare_impl {self} {op} {other}",
+      "Context": "tp_richcompare_impl {self} {op} {other}",
       "Explanation": "Dynamo can only trace data pointer comparisons when it can prove both operands have the same data pointer.",
       "Hints": []
     },
@@ -2023,7 +2023,7 @@
   "GB0137": [
     {
       "Gb_type": "Unsupported attribute for slice() object",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Expected attribute to be one of {','.join(fields)} but got {name}",
       "Hints": [
         "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
@@ -2293,6 +2293,14 @@
   "GB4411": [
     {
       "Gb_type": "missing sq_contains",
+      "Context": "sq_contains_impl not implemented for {self.python_type_name()}",
+      "Explanation": "Dynamo does not know how to check if `{item.debug_repr()}` is in `{self.debug_repr()}`.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "missing sq_contains",
       "Context": "sq_contains not implemented for {self.python_type_name()}",
       "Explanation": "Dynamo does not know how to check if `{item.debug_repr()}` is in `{self.debug_repr()}`.",
       "Hints": [
@@ -2349,7 +2357,7 @@
   "GB0157": [
     {
       "Gb_type": "Unsupported ndarray attribute access",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
       "Hints": []
     },
@@ -2371,7 +2379,7 @@
   "GB0159": [
     {
       "Gb_type": "Unsupported ndarray.__version__ access",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
       "Hints": []
     },
@@ -2832,9 +2840,9 @@
   ],
   "GB9648": [
     {
-      "Gb_type": "Missing richcompare_impl override",
-      "Context": "richcompare_impl {self} {op}",
-      "Explanation": "{type(self).__name__} does not implement richcompare_impl. Add a richcompare_impl override to {type(self).__name__}.",
+      "Gb_type": "Missing tp_richcompare_impl override",
+      "Context": "tp_richcompare_impl {self} {op}",
+      "Explanation": "{type(self).__name__} does not implement tp_richcompare_impl. Add a tp_richcompare_impl override to {type(self).__name__}.",
       "Hints": [
         "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
       ]
@@ -2860,8 +2868,8 @@
   ],
   "GB2483": [
     {
-      "Gb_type": "str_impl not implemented",
-      "Context": "{type(self).__name__} has no str_impl override for {self.python_type_name()}",
+      "Gb_type": "tp_str_impl not implemented",
+      "Context": "{type(self).__name__} has no tp_str_impl override for {self.python_type_name()}",
       "Explanation": "Dynamo does not implement __str__ for {self.python_type_name()} in {type(self).__name__}.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
@@ -2902,7 +2910,7 @@
   "GB0188": [
     {
       "Gb_type": "getattr with no source",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Dynamo does not know how to access an attribute on an `nn.Module` instance that lacks a source. This is usually an internal error in Dynamo.",
       "Hints": [
         "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
@@ -3074,7 +3082,7 @@
   "GB6215": [
     {
       "Gb_type": "Unresolved GetAttrVariable comparison",
-      "Context": "richcompare_impl {self} {op}",
+      "Context": "tp_richcompare_impl {self} {op}",
       "Explanation": "Cannot compare {self} because the attribute could not be resolved to a concrete value.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
@@ -3269,7 +3277,7 @@
   "GB0211": [
     {
       "Gb_type": "torch.nn.Module with a non-function custom __getattr__",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Dynamo detected a nn.Module object with a custom `__getattr__` method, but this method is not a standard Python function (e.g., it might be implemented in C/C++). Dynamo cannot currently trace into such non-standard `__getattr__` methods.",
       "Hints": [
         "Avoid using objects with non-standard __getattr__ methods ",
@@ -4954,7 +4962,7 @@
   "GB1220": [
     {
       "Gb_type": "Untraceable C tp_richcompare",
-      "Context": "richcompare_impl {self} {op}",
+      "Context": "tp_richcompare_impl {self} {op}",
       "Explanation": "{cls.__name__} defines a C comparison method that Dynamo cannot trace into.",
       "Hints": [
         "Use torch._dynamo.allow_c_slot({cls.__name__}) to ",
@@ -5864,9 +5872,9 @@
   ],
   "GB6053": [
     {
-      "Gb_type": "repr_impl not implemented",
-      "Context": "{type(self).__name__} has tp_repr slot but no repr_impl override",
-      "Explanation": "The type {self.python_type_name()} has a tp_repr C slot but the corresponding VariableTracker doesn't implement repr_impl.",
+      "Gb_type": "tp_repr_impl not implemented",
+      "Context": "{type(self).__name__} has tp_repr slot but no tp_repr_impl override",
+      "Explanation": "The type {self.python_type_name()} has a tp_repr C slot but the corresponding VariableTracker doesn't implement tp_repr_impl.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -416,6 +416,16 @@
     },
     {
       "Gb_type": "Custom __getattribute__ in nn.Module attribute access",
+      "Context": "getattro_impl {self} {name}",
+      "Explanation": "Dynamo could not trace through the custom `__getattribute__` method on this `nn.Module`.",
+      "Hints": [
+        "Simplify your `__getattribute__` implementation, ",
+        "or replace it with a targeted `@property`.",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "Custom __getattribute__ in nn.Module attribute access",
       "Context": "var_getattr {self} {name}",
       "Explanation": "Dynamo could not trace through the custom `__getattribute__` method on this `nn.Module`.",
       "Hints": [
@@ -1497,6 +1507,15 @@
     },
     {
       "Gb_type": "Strict mode banned op",
+      "Context": "getattro_impl {self} {name}",
+      "Explanation": "Getattr invocation '{name}' in strict mode is not supported.",
+      "Hints": [
+        "Remove `{name}` from the list of banned ops by ",
+        "setting `torch._dynamo.config._autograd_backward_strict_mode_banned_ops`."
+      ]
+    },
+    {
+      "Gb_type": "Strict mode banned op",
       "Context": "var_getattr {self} {name}",
       "Explanation": "Getattr invocation '{name}' in strict mode is not supported.",
       "Hints": [
@@ -1521,6 +1540,12 @@
     {
       "Gb_type": "Tensor with grad_fn()",
       "Context": "tp_getattro_impl {self} grad_fn",
+      "Explanation": "Dynamo does not support tracing tensors with a grad_fn directly.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Tensor with grad_fn()",
+      "Context": "getattro_impl {self} grad_fn",
       "Explanation": "Dynamo does not support tracing tensors with a grad_fn directly.",
       "Hints": []
     },
@@ -1576,6 +1601,12 @@
     {
       "Gb_type": "Tensor.retain_grad() with AOTDispatcher",
       "Context": "tp_getattro_impl {self} retain_grad",
+      "Explanation": "`Tensor.retain_grad()` does not work with AOTDispatcher.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Tensor.retain_grad() with AOTDispatcher",
+      "Context": "getattro_impl {self} retain_grad",
       "Explanation": "`Tensor.retain_grad()` does not work with AOTDispatcher.",
       "Hints": []
     },
@@ -1828,6 +1859,12 @@
     },
     {
       "Gb_type": "Data pointer comparison",
+      "Context": "richcompare_impl {self} {op} {other}",
+      "Explanation": "Dynamo can only trace data pointer comparisons when it can prove both operands have the same data pointer.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Data pointer comparison",
       "Context": "call_method {self} {name} {args} {kwargs}",
       "Explanation": "Dynamo can only trace data pointer comparisons when it can prove both operands have the same data pointer.",
       "Hints": []
@@ -2024,6 +2061,14 @@
     {
       "Gb_type": "Unsupported attribute for slice() object",
       "Context": "tp_getattro_impl {self} {name}",
+      "Explanation": "Expected attribute to be one of {','.join(fields)} but got {name}",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    },
+    {
+      "Gb_type": "Unsupported attribute for slice() object",
+      "Context": "getattro_impl {self} {name}",
       "Explanation": "Expected attribute to be one of {','.join(fields)} but got {name}",
       "Hints": [
         "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
@@ -2363,6 +2408,12 @@
     },
     {
       "Gb_type": "Unsupported ndarray attribute access",
+      "Context": "getattro_impl {self} {name}",
+      "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Unsupported ndarray attribute access",
       "Context": "var_getattr {self} {name}",
       "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
       "Hints": []
@@ -2380,6 +2431,12 @@
     {
       "Gb_type": "Unsupported ndarray.__version__ access",
       "Context": "tp_getattro_impl {self} {name}",
+      "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Unsupported ndarray.__version__ access",
+      "Context": "getattro_impl {self} {name}",
       "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
       "Hints": []
     },
@@ -2846,6 +2903,14 @@
       "Hints": [
         "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
       ]
+    },
+    {
+      "Gb_type": "Missing richcompare_impl override",
+      "Context": "richcompare_impl {self} {op}",
+      "Explanation": "{type(self).__name__} does not implement richcompare_impl. Add a richcompare_impl override to {type(self).__name__}.",
+      "Hints": [
+        "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
+      ]
     }
   ],
   "GB0185": [
@@ -2870,6 +2935,14 @@
     {
       "Gb_type": "tp_str_impl not implemented",
       "Context": "{type(self).__name__} has no tp_str_impl override for {self.python_type_name()}",
+      "Explanation": "Dynamo does not implement __str__ for {self.python_type_name()} in {type(self).__name__}.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "str_impl not implemented",
+      "Context": "{type(self).__name__} has no str_impl override for {self.python_type_name()}",
       "Explanation": "Dynamo does not implement __str__ for {self.python_type_name()} in {type(self).__name__}.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
@@ -2911,6 +2984,14 @@
     {
       "Gb_type": "getattr with no source",
       "Context": "tp_getattro_impl {self} {name}",
+      "Explanation": "Dynamo does not know how to access an attribute on an `nn.Module` instance that lacks a source. This is usually an internal error in Dynamo.",
+      "Hints": [
+        "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
+      ]
+    },
+    {
+      "Gb_type": "getattr with no source",
+      "Context": "getattro_impl {self} {name}",
       "Explanation": "Dynamo does not know how to access an attribute on an `nn.Module` instance that lacks a source. This is usually an internal error in Dynamo.",
       "Hints": [
         "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
@@ -3083,6 +3164,14 @@
     {
       "Gb_type": "Unresolved GetAttrVariable comparison",
       "Context": "tp_richcompare_impl {self} {op}",
+      "Explanation": "Cannot compare {self} because the attribute could not be resolved to a concrete value.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "Unresolved GetAttrVariable comparison",
+      "Context": "richcompare_impl {self} {op}",
       "Explanation": "Cannot compare {self} because the attribute could not be resolved to a concrete value.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
@@ -3278,6 +3367,17 @@
     {
       "Gb_type": "torch.nn.Module with a non-function custom __getattr__",
       "Context": "tp_getattro_impl {self} {name}",
+      "Explanation": "Dynamo detected a nn.Module object with a custom `__getattr__` method, but this method is not a standard Python function (e.g., it might be implemented in C/C++). Dynamo cannot currently trace into such non-standard `__getattr__` methods.",
+      "Hints": [
+        "Avoid using objects with non-standard __getattr__ methods ",
+        "within the compiled region. If possible, implement ",
+        "__getattr__ as a standard Python function.",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "torch.nn.Module with a non-function custom __getattr__",
+      "Context": "getattro_impl {self} {name}",
       "Explanation": "Dynamo detected a nn.Module object with a custom `__getattr__` method, but this method is not a standard Python function (e.g., it might be implemented in C/C++). Dynamo cannot currently trace into such non-standard `__getattr__` methods.",
       "Hints": [
         "Avoid using objects with non-standard __getattr__ methods ",
@@ -4970,6 +5070,17 @@
         "and deterministic.",
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]
+    },
+    {
+      "Gb_type": "Untraceable C tp_richcompare",
+      "Context": "richcompare_impl {self} {op}",
+      "Explanation": "{cls.__name__} defines a C comparison method that Dynamo cannot trace into.",
+      "Hints": [
+        "Use torch._dynamo.allow_c_slot({cls.__name__}) to ",
+        "register it as safe if its comparison methods are pure ",
+        "and deterministic.",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
     }
   ],
   "GB0309": [
@@ -5875,6 +5986,14 @@
       "Gb_type": "tp_repr_impl not implemented",
       "Context": "{type(self).__name__} has tp_repr slot but no tp_repr_impl override",
       "Explanation": "The type {self.python_type_name()} has a tp_repr C slot but the corresponding VariableTracker doesn't implement tp_repr_impl.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "repr_impl not implemented",
+      "Context": "{type(self).__name__} has tp_repr slot but no repr_impl override",
+      "Explanation": "The type {self.python_type_name()} has a tp_repr C slot but the corresponding VariableTracker doesn't implement repr_impl.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -426,6 +426,16 @@
     },
     {
       "Gb_type": "Custom __getattribute__ in nn.Module attribute access",
+      "Context": "getattro_impl {self} {name}",
+      "Explanation": "Dynamo could not trace through the custom `__getattribute__` method on this `nn.Module`.",
+      "Hints": [
+        "Simplify your `__getattribute__` implementation, ",
+        "or replace it with a targeted `@property`.",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "Custom __getattribute__ in nn.Module attribute access",
       "Context": "var_getattr {self} {name}",
       "Explanation": "Dynamo could not trace through the custom `__getattribute__` method on this `nn.Module`.",
       "Hints": [
@@ -1507,6 +1517,15 @@
     },
     {
       "Gb_type": "Strict mode banned op",
+      "Context": "getattro_impl {self} {name}",
+      "Explanation": "Getattr invocation '{name}' in strict mode is not supported.",
+      "Hints": [
+        "Remove `{name}` from the list of banned ops by ",
+        "setting `torch._dynamo.config._autograd_backward_strict_mode_banned_ops`."
+      ]
+    },
+    {
+      "Gb_type": "Strict mode banned op",
       "Context": "var_getattr {self} {name}",
       "Explanation": "Getattr invocation '{name}' in strict mode is not supported.",
       "Hints": [
@@ -1531,6 +1550,12 @@
     {
       "Gb_type": "Tensor with grad_fn()",
       "Context": "tp_getattro_impl {self} grad_fn",
+      "Explanation": "Dynamo does not support tracing tensors with a grad_fn directly.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Tensor with grad_fn()",
+      "Context": "getattro_impl {self} grad_fn",
       "Explanation": "Dynamo does not support tracing tensors with a grad_fn directly.",
       "Hints": []
     },
@@ -1586,6 +1611,12 @@
     {
       "Gb_type": "Tensor.retain_grad() with AOTDispatcher",
       "Context": "tp_getattro_impl {self} retain_grad",
+      "Explanation": "`Tensor.retain_grad()` does not work with AOTDispatcher.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Tensor.retain_grad() with AOTDispatcher",
+      "Context": "getattro_impl {self} retain_grad",
       "Explanation": "`Tensor.retain_grad()` does not work with AOTDispatcher.",
       "Hints": []
     },
@@ -1838,6 +1869,12 @@
     },
     {
       "Gb_type": "Data pointer comparison",
+      "Context": "richcompare_impl {self} {op} {other}",
+      "Explanation": "Dynamo can only trace data pointer comparisons when it can prove both operands have the same data pointer.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Data pointer comparison",
       "Context": "call_method {self} {name} {args} {kwargs}",
       "Explanation": "Dynamo can only trace data pointer comparisons when it can prove both operands have the same data pointer.",
       "Hints": []
@@ -2042,6 +2079,14 @@
     {
       "Gb_type": "Unsupported attribute for slice() object",
       "Context": "tp_getattro_impl {self} {name}",
+      "Explanation": "Expected attribute to be one of {','.join(fields)} but got {name}",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    },
+    {
+      "Gb_type": "Unsupported attribute for slice() object",
+      "Context": "getattro_impl {self} {name}",
       "Explanation": "Expected attribute to be one of {','.join(fields)} but got {name}",
       "Hints": [
         "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
@@ -2391,6 +2436,12 @@
     },
     {
       "Gb_type": "Unsupported ndarray attribute access",
+      "Context": "getattro_impl {self} {name}",
+      "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Unsupported ndarray attribute access",
       "Context": "var_getattr {self} {name}",
       "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
       "Hints": []
@@ -2408,6 +2459,12 @@
     {
       "Gb_type": "Unsupported ndarray.__version__ access",
       "Context": "tp_getattro_impl {self} {name}",
+      "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Unsupported ndarray.__version__ access",
+      "Context": "getattro_impl {self} {name}",
       "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
       "Hints": []
     },
@@ -2874,6 +2931,14 @@
       "Hints": [
         "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
       ]
+    },
+    {
+      "Gb_type": "Missing richcompare_impl override",
+      "Context": "richcompare_impl {self} {op}",
+      "Explanation": "{type(self).__name__} does not implement richcompare_impl. Add a richcompare_impl override to {type(self).__name__}.",
+      "Hints": [
+        "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
+      ]
     }
   ],
   "GB0185": [
@@ -2898,6 +2963,14 @@
     {
       "Gb_type": "tp_str_impl not implemented",
       "Context": "{type(self).__name__} has no tp_str_impl override for {self.python_type_name()}",
+      "Explanation": "Dynamo does not implement __str__ for {self.python_type_name()} in {type(self).__name__}.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "str_impl not implemented",
+      "Context": "{type(self).__name__} has no str_impl override for {self.python_type_name()}",
       "Explanation": "Dynamo does not implement __str__ for {self.python_type_name()} in {type(self).__name__}.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
@@ -2939,6 +3012,14 @@
     {
       "Gb_type": "getattr with no source",
       "Context": "tp_getattro_impl {self} {name}",
+      "Explanation": "Dynamo does not know how to access an attribute on an `nn.Module` instance that lacks a source. This is usually an internal error in Dynamo.",
+      "Hints": [
+        "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
+      ]
+    },
+    {
+      "Gb_type": "getattr with no source",
+      "Context": "getattro_impl {self} {name}",
       "Explanation": "Dynamo does not know how to access an attribute on an `nn.Module` instance that lacks a source. This is usually an internal error in Dynamo.",
       "Hints": [
         "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
@@ -3111,6 +3192,14 @@
     {
       "Gb_type": "Unresolved GetAttrVariable comparison",
       "Context": "tp_richcompare_impl {self} {op}",
+      "Explanation": "Cannot compare {self} because the attribute could not be resolved to a concrete value.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "Unresolved GetAttrVariable comparison",
+      "Context": "richcompare_impl {self} {op}",
       "Explanation": "Cannot compare {self} because the attribute could not be resolved to a concrete value.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
@@ -3306,6 +3395,17 @@
     {
       "Gb_type": "torch.nn.Module with a non-function custom __getattr__",
       "Context": "tp_getattro_impl {self} {name}",
+      "Explanation": "Dynamo detected a nn.Module object with a custom `__getattr__` method, but this method is not a standard Python function (e.g., it might be implemented in C/C++). Dynamo cannot currently trace into such non-standard `__getattr__` methods.",
+      "Hints": [
+        "Avoid using objects with non-standard __getattr__ methods ",
+        "within the compiled region. If possible, implement ",
+        "__getattr__ as a standard Python function.",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "torch.nn.Module with a non-function custom __getattr__",
+      "Context": "getattro_impl {self} {name}",
       "Explanation": "Dynamo detected a nn.Module object with a custom `__getattr__` method, but this method is not a standard Python function (e.g., it might be implemented in C/C++). Dynamo cannot currently trace into such non-standard `__getattr__` methods.",
       "Hints": [
         "Avoid using objects with non-standard __getattr__ methods ",
@@ -4998,6 +5098,17 @@
         "and deterministic.",
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]
+    },
+    {
+      "Gb_type": "Untraceable C tp_richcompare",
+      "Context": "richcompare_impl {self} {op}",
+      "Explanation": "{cls.__name__} defines a C comparison method that Dynamo cannot trace into.",
+      "Hints": [
+        "Use torch._dynamo.allow_c_slot({cls.__name__}) to ",
+        "register it as safe if its comparison methods are pure ",
+        "and deterministic.",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
     }
   ],
   "GB0309": [
@@ -5903,6 +6014,14 @@
       "Gb_type": "tp_repr_impl not implemented",
       "Context": "{type(self).__name__} has tp_repr slot but no tp_repr_impl override",
       "Explanation": "The type {self.python_type_name()} has a tp_repr C slot but the corresponding VariableTracker doesn't implement tp_repr_impl.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "repr_impl not implemented",
+      "Context": "{type(self).__name__} has tp_repr slot but no repr_impl override",
+      "Explanation": "The type {self.python_type_name()} has a tp_repr C slot but the corresponding VariableTracker doesn't implement repr_impl.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -416,7 +416,7 @@
   "GB0031": [
     {
       "Gb_type": "Custom __getattribute__ in nn.Module attribute access",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Dynamo could not trace through the custom `__getattribute__` method on this `nn.Module`.",
       "Hints": [
         "Simplify your `__getattribute__` implementation, ",
@@ -1498,7 +1498,7 @@
   "GB0102": [
     {
       "Gb_type": "Strict mode banned op",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Getattr invocation '{name}' in strict mode is not supported.",
       "Hints": [
         "Remove `{name}` from the list of banned ops by ",
@@ -1530,7 +1530,7 @@
   "GB0104": [
     {
       "Gb_type": "Tensor with grad_fn()",
-      "Context": "getattro_impl {self} grad_fn",
+      "Context": "tp_getattro_impl {self} grad_fn",
       "Explanation": "Dynamo does not support tracing tensors with a grad_fn directly.",
       "Hints": []
     },
@@ -1585,7 +1585,7 @@
   "GB0108": [
     {
       "Gb_type": "Tensor.retain_grad() with AOTDispatcher",
-      "Context": "getattro_impl {self} retain_grad",
+      "Context": "tp_getattro_impl {self} retain_grad",
       "Explanation": "`Tensor.retain_grad()` does not work with AOTDispatcher.",
       "Hints": []
     },
@@ -1832,7 +1832,7 @@
   "GB5976": [
     {
       "Gb_type": "Data pointer comparison",
-      "Context": "richcompare_impl {self} {op} {other}",
+      "Context": "tp_richcompare_impl {self} {op} {other}",
       "Explanation": "Dynamo can only trace data pointer comparisons when it can prove both operands have the same data pointer.",
       "Hints": []
     },
@@ -2041,7 +2041,7 @@
   "GB0137": [
     {
       "Gb_type": "Unsupported attribute for slice() object",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Expected attribute to be one of {','.join(fields)} but got {name}",
       "Hints": [
         "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
@@ -2311,6 +2311,14 @@
   "GB4411": [
     {
       "Gb_type": "missing sq_contains",
+      "Context": "sq_contains_impl not implemented for {self.python_type_name()}",
+      "Explanation": "Dynamo does not know how to check if `{item.debug_repr()}` is in `{self.debug_repr()}`.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "missing sq_contains",
       "Context": "sq_contains not implemented for {self.python_type_name()}",
       "Explanation": "Dynamo does not know how to check if `{item.debug_repr()}` is in `{self.debug_repr()}`.",
       "Hints": [
@@ -2377,7 +2385,7 @@
   "GB0157": [
     {
       "Gb_type": "Unsupported ndarray attribute access",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
       "Hints": []
     },
@@ -2399,7 +2407,7 @@
   "GB0159": [
     {
       "Gb_type": "Unsupported ndarray.__version__ access",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Dynamo currently does not support tracing `ndarray.{name}`.",
       "Hints": []
     },
@@ -2860,9 +2868,9 @@
   ],
   "GB9648": [
     {
-      "Gb_type": "Missing richcompare_impl override",
-      "Context": "richcompare_impl {self} {op}",
-      "Explanation": "{type(self).__name__} does not implement richcompare_impl. Add a richcompare_impl override to {type(self).__name__}.",
+      "Gb_type": "Missing tp_richcompare_impl override",
+      "Context": "tp_richcompare_impl {self} {op}",
+      "Explanation": "{type(self).__name__} does not implement tp_richcompare_impl. Add a tp_richcompare_impl override to {type(self).__name__}.",
       "Hints": [
         "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
       ]
@@ -2888,8 +2896,8 @@
   ],
   "GB2483": [
     {
-      "Gb_type": "str_impl not implemented",
-      "Context": "{type(self).__name__} has no str_impl override for {self.python_type_name()}",
+      "Gb_type": "tp_str_impl not implemented",
+      "Context": "{type(self).__name__} has no tp_str_impl override for {self.python_type_name()}",
       "Explanation": "Dynamo does not implement __str__ for {self.python_type_name()} in {type(self).__name__}.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
@@ -2930,7 +2938,7 @@
   "GB0188": [
     {
       "Gb_type": "getattr with no source",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Dynamo does not know how to access an attribute on an `nn.Module` instance that lacks a source. This is usually an internal error in Dynamo.",
       "Hints": [
         "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
@@ -3102,7 +3110,7 @@
   "GB6215": [
     {
       "Gb_type": "Unresolved GetAttrVariable comparison",
-      "Context": "richcompare_impl {self} {op}",
+      "Context": "tp_richcompare_impl {self} {op}",
       "Explanation": "Cannot compare {self} because the attribute could not be resolved to a concrete value.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
@@ -3297,7 +3305,7 @@
   "GB0211": [
     {
       "Gb_type": "torch.nn.Module with a non-function custom __getattr__",
-      "Context": "getattro_impl {self} {name}",
+      "Context": "tp_getattro_impl {self} {name}",
       "Explanation": "Dynamo detected a nn.Module object with a custom `__getattr__` method, but this method is not a standard Python function (e.g., it might be implemented in C/C++). Dynamo cannot currently trace into such non-standard `__getattr__` methods.",
       "Hints": [
         "Avoid using objects with non-standard __getattr__ methods ",
@@ -4982,7 +4990,7 @@
   "GB1220": [
     {
       "Gb_type": "Untraceable C tp_richcompare",
-      "Context": "richcompare_impl {self} {op}",
+      "Context": "tp_richcompare_impl {self} {op}",
       "Explanation": "{cls.__name__} defines a C comparison method that Dynamo cannot trace into.",
       "Hints": [
         "Use torch._dynamo.allow_c_slot({cls.__name__}) to ",
@@ -5892,9 +5900,9 @@
   ],
   "GB6053": [
     {
-      "Gb_type": "repr_impl not implemented",
-      "Context": "{type(self).__name__} has tp_repr slot but no repr_impl override",
-      "Explanation": "The type {self.python_type_name()} has a tp_repr C slot but the corresponding VariableTracker doesn't implement repr_impl.",
+      "Gb_type": "tp_repr_impl not implemented",
+      "Context": "{type(self).__name__} has tp_repr slot but no tp_repr_impl override",
+      "Explanation": "The type {self.python_type_name()} has a tp_repr C slot but the corresponding VariableTracker doesn't implement tp_repr_impl.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -315,7 +315,7 @@ class SideEffects:
         """Record an attribute mutation for deferred validation.
 
         Returns True if successfully deferred, False if we cannot read the
-        original value (getattro_impl raises NotImplementedError) or the
+        original value (tp_getattro_impl raises NotImplementedError) or the
         original is not a python constant — caller should fall back to
         check_allowed_side_effect.
         """
@@ -333,7 +333,7 @@ class SideEffects:
                 raise AssertionError("output_graph weakref is dead")
             tx = output_graph.current_tx
             try:
-                original_vt = item.getattro_impl(tx, name)  # type: ignore[arg-type]
+                original_vt = item.tp_getattro_impl(tx, name)  # type: ignore[arg-type]
             except NotImplementedError:
                 return False
             if not original_vt.is_python_constant():

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2706,7 +2706,7 @@ class InstructionTranslatorBase(
     def _attach_traceback_to_exception(self, exc: ExceptionVals) -> None:
         # based on CPython's PyTraceBack_Here impl
         frame_summary = self.frame_summary()
-        tb = exc.getattro_impl(
+        tb = exc.tp_getattro_impl(
             # pyrefly: ignore [bad-argument-type]
             self,
             "__traceback__",
@@ -2878,7 +2878,7 @@ class InstructionTranslatorBase(
                     "expected _exception_instance_check(val) to be true"
                 )
             typ = BuiltinVariable(val.exc_type)  # type: ignore[attr-defined, union-attr]
-            tb = val.getattro_impl(
+            tb = val.tp_getattro_impl(
                 # pyrefly: ignore[bad-argument-type]
                 self,
                 "__traceback__",
@@ -2897,7 +2897,7 @@ class InstructionTranslatorBase(
                 )
             typ = BuiltinVariable(val.exc_type)  # type: ignore[attr-defined]
 
-            tb = val.getattro_impl(self, "__traceback__")
+            tb = val.tp_getattro_impl(self, "__traceback__")
 
         args += [typ, val, tb]
         self.call_function(fn, args, {})
@@ -3389,7 +3389,7 @@ class InstructionTranslatorBase(
 
     def _maybe_sync_dealloc_attr(self, obj: VariableTracker, name: str) -> None:
         # Only check side_effects — a pure dict lookup with no observable
-        # side effects. We intentionally avoid getattro_impl here because it
+        # side effects. We intentionally avoid tp_getattro_impl here because it
         # can trigger __getattr__, add graph nodes, or cause graph breaks.
         if self.output.side_effects.has_pending_mutation_of_attr(obj, name):
             attr_var = self.output.side_effects.load_attr(obj, name)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2706,7 +2706,7 @@ class InstructionTranslatorBase(
     def _attach_traceback_to_exception(self, exc: ExceptionVals) -> None:
         # based on CPython's PyTraceBack_Here impl
         frame_summary = self.frame_summary()
-        tb = exc.getattro_impl(
+        tb = exc.tp_getattro_impl(
             # pyrefly: ignore [bad-argument-type]
             self,
             "__traceback__",
@@ -2878,7 +2878,7 @@ class InstructionTranslatorBase(
                     "expected _exception_instance_check(val) to be true"
                 )
             typ = BuiltinVariable(val.exc_type)  # type: ignore[attr-defined, union-attr]
-            tb = val.getattro_impl(
+            tb = val.tp_getattro_impl(
                 # pyrefly: ignore[bad-argument-type]
                 self,
                 "__traceback__",
@@ -2897,7 +2897,7 @@ class InstructionTranslatorBase(
                 )
             typ = BuiltinVariable(val.exc_type)  # type: ignore[attr-defined]
 
-            tb = val.getattro_impl(self, "__traceback__")
+            tb = val.tp_getattro_impl(self, "__traceback__")
 
         args += [typ, val, tb]
         self.call_function(fn, args, {})
@@ -3390,7 +3390,7 @@ class InstructionTranslatorBase(
 
     def _maybe_sync_dealloc_attr(self, obj: VariableTracker, name: str) -> None:
         # Only check side_effects — a pure dict lookup with no observable
-        # side effects. We intentionally avoid getattro_impl here because it
+        # side effects. We intentionally avoid tp_getattro_impl here because it
         # can trigger __getattr__, add graph nodes, or cause graph breaks.
         if self.output.side_effects.has_pending_mutation_of_attr(obj, name):
             attr_var = self.output.side_effects.load_attr(obj, name)

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -769,7 +769,7 @@ def _wrap_descr_get(
     if len(args) not in (1, 2):
         raise_type_error(tx, f"expected 1 or 2 arguments, got {len(args)}")
     obj = args[0]
-    owner = args[1] if len(args) > 1 else obj.getattro_impl(tx, "__class__")
+    owner = args[1] if len(args) > 1 else obj.tp_getattro_impl(tx, "__class__")
     return func(self, tx, obj, owner)
 
 
@@ -927,31 +927,31 @@ _BIT_FIELD: dict[SlotGroup, dict[int, str]] = {
 _SLOT_FN: dict[SlotGroup, dict[str, str]] = {
     SlotGroup.NUMBER: {
         **{f: f"{f}_impl" for f in PyNumberMethods._fields},
-        "nb_bool": "bool_impl",
+        "nb_bool": "nb_bool_impl",
     },
     SlotGroup.SEQUENCE: {
-        "sq_length": "sq_length",
+        "sq_length": "sq_length_impl",
         "sq_concat": "sq_concat_impl",
         "sq_repeat": "sq_repeat_impl",
         "sq_item": "sq_item_impl",
         "sq_ass_item": "sq_ass_item_impl",
-        "sq_contains": "sq_contains",
+        "sq_contains": "sq_contains_impl",
         "sq_inplace_concat": "sq_inplace_concat_impl",
         "sq_inplace_repeat": "sq_inplace_repeat_impl",
     },
     SlotGroup.MAPPING: {
-        "mp_length": "mp_length",
+        "mp_length": "mp_length_impl",
         "mp_subscript": "mp_subscript_impl",
         "mp_ass_subscript": "mp_ass_subscript_impl",
     },
     SlotGroup.TYPE: {
-        "tp_repr": "repr_impl",
+        "tp_repr": "tp_repr_impl",
         "tp_hash": "tp_hash_impl",
         "tp_call": "call_function",
-        "tp_str": "str_impl",
-        "tp_getattro": "getattro_impl",
-        "tp_setattro": "setattro_impl",
-        "tp_richcompare": "richcompare_impl",
+        "tp_str": "tp_str_impl",
+        "tp_getattro": "tp_getattro_impl",
+        "tp_setattro": "tp_setattro_impl",
+        "tp_richcompare": "tp_richcompare_impl",
         "tp_iter": "tp_iter_impl",
         "tp_iternext": "tp_iternext_impl",
         "tp_descr_get": "tp_descr_get_impl",
@@ -1060,19 +1060,19 @@ _SLOTDEFS: list[SlotDef] = [
     # SlotDef("__getattr__", ),
     # SlotDef("__setattr__", ),
     # SlotDef("__delattr__", ),
-    TPSLOT("__repr__", "repr_impl", PyTypeSlots.TP_REPR, _wrap_unaryfunc),
+    TPSLOT("__repr__", "tp_repr_impl", PyTypeSlots.TP_REPR, _wrap_unaryfunc),
     # TPSLOT("__hash__", "tp_hash_impl", PyTypeSlots.TP_HASH, _wrap_unaryfunc),
     TPSLOT("__call__", "call_function", PyTypeSlots.TP_CALL, wrap_call),
-    TPSLOT("__str__", "str_impl", PyTypeSlots.TP_STR, _wrap_unaryfunc),
+    TPSLOT("__str__", "tp_str_impl", PyTypeSlots.TP_STR, _wrap_unaryfunc),
     TPSLOT(
         "__getattribute__",
-        "getattro_impl",
+        "tp_getattro_impl",
         PyTypeSlots.TP_GETATTRO,
         _wrap_getattro,
     ),
     TPSLOT(
         "__getattr__",
-        "getattro_impl",
+        "tp_getattro_impl",
         PyTypeSlots.TP_GETATTRO,
         _wrap_getattro,
     ),
@@ -1091,37 +1091,37 @@ _SLOTDEFS: list[SlotDef] = [
     # ),
     TPSLOT(
         "__lt__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_lt,
     ),
     TPSLOT(
         "__le__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_le,
     ),
     TPSLOT(
         "__eq__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_eq,
     ),
     TPSLOT(
         "__ne__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_ne,
     ),
     TPSLOT(
         "__gt__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_gt,
     ),
     TPSLOT(
         "__ge__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_ge,
     ),
@@ -1250,7 +1250,7 @@ _SLOTDEFS: list[SlotDef] = [
     ),
     NBSLOT(
         "__bool__",
-        "bool_impl",
+        "nb_bool_impl",
         PyNumberSlots.NB_BOOL,
         _wrap_unaryfunc,
     ),
@@ -1455,7 +1455,7 @@ _SLOTDEFS: list[SlotDef] = [
     # Mapping
     MPSLOT(
         "__len__",
-        "mp_length",
+        "mp_length_impl",
         PyMappingSlots.MP_LENGTH,
         _wrap_unaryfunc,
     ),
@@ -1480,7 +1480,7 @@ _SLOTDEFS: list[SlotDef] = [
     # Sequence
     SQSLOT(
         "__len__",
-        "sq_length",
+        "sq_length_impl",
         PySequenceSlots.SQ_LENGTH,
         _wrap_unaryfunc,
     ),
@@ -1522,7 +1522,7 @@ _SLOTDEFS: list[SlotDef] = [
     ),
     SQSLOT(
         "__contains__",
-        "sq_contains",
+        "sq_contains_impl",
         PySequenceSlots.SQ_CONTAINS,
         _wrap_objobjproc,
     ),
@@ -1824,7 +1824,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         except NotImplementedError:
             return False
 
-    def bool_impl(self, tx: InstructionTranslatorBase) -> VariableTracker | None:
+    def nb_bool_impl(self, tx: InstructionTranslatorBase) -> VariableTracker | None:
         # Mirrors CPython's tp_as_number->nb_bool slot.
         # https://github.com/python/cpython/blob/c09ccd9c429/Objects/object.c#L2135-L2158
         #
@@ -1880,7 +1880,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         # Sourceless: no real object to hash — fake id.
         return id(self), True
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: InstructionTranslatorBase,
         other: VariableTracker,
@@ -1893,17 +1893,17 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         the comparison (signaling do_richcompare to try the other operand).
 
         Called from two paths:
-        - call_method("__eq__") calls richcompare_impl directly (like CPython's
+        - call_method("__eq__") calls tp_richcompare_impl directly (like CPython's
           a.__eq__(b) calling tp_richcompare without do_richcompare).
-        - generic_richcompare calls richcompare_impl as part of the 4-step
+        - generic_richcompare calls tp_richcompare_impl as part of the 4-step
           do_richcompare algorithm (subclass priority, forward, reflected,
           fallback).
         """
         unimplemented(
-            gb_type="Missing richcompare_impl override",
-            context=f"richcompare_impl {self} {op}",
+            gb_type="Missing tp_richcompare_impl override",
+            context=f"tp_richcompare_impl {self} {op}",
             explanation=f"{type(self).__name__} does not implement "
-            f"richcompare_impl. Add a richcompare_impl override to "
+            f"tp_richcompare_impl. Add a tp_richcompare_impl override to "
             f"{type(self).__name__}.",
             hints=[*graph_break_hints.DYNAMO_BUG],
         )
@@ -1981,7 +1981,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         """
         return None
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: InstructionTranslatorBase, name: str
     ) -> VariableTracker:
         """Default attribute access via object_generic_getattr.
@@ -2100,7 +2100,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def call_obj_hasattr(
         self, tx: InstructionTranslatorBase, name: str
     ) -> ConstantVariable:
-        """Dynamo's hasattr(): try getattro_impl, catch AttributeError.
+        """Dynamo's hasattr(): try tp_getattro_impl, catch AttributeError.
 
         Mirrors CPython's PyObject_HasAttr (via PyObject_GetOptionalAttr):
         call tp_getattro, suppress AttributeError via PyErr_Clear, return
@@ -2112,7 +2112,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             return result
 
         try:
-            self.getattro_impl(tx, name)
+            self.tp_getattro_impl(tx, name)
             return variables.ConstantVariable.create(True)
         except ObservedAttributeError:
             tx.exn_vt_stack.clear_current_exception()
@@ -2187,7 +2187,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             ],
         )
 
-    def sq_length(self, tx: InstructionTranslatorBase) -> VariableTracker:
+    def sq_length_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
         """Called when sq_length is not implemented."""
         raise_observed_exception(
             TypeError,
@@ -2195,7 +2195,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             args=[f"object of type '{self.python_type_name()}' has no len()"],
         )
 
-    def mp_length(self, tx: InstructionTranslatorBase) -> VariableTracker:
+    def mp_length_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
         """Called when mp_length is not implemented."""
         raise_observed_exception(
             TypeError,
@@ -2234,13 +2234,13 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             hints=[],
         )
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: InstructionTranslatorBase, item: VariableTracker
     ) -> VariableTracker:
         """Called when sq_contains is not implemented."""
         unimplemented(
             gb_type="missing sq_contains",
-            context=f"sq_contains not implemented for {self.python_type_name()}",
+            context=f"sq_contains_impl not implemented for {self.python_type_name()}",
             explanation=f"Dynamo does not know how to check if `{item.debug_repr()}` is in `{self.debug_repr()}`.",
             hints=[*graph_break_hints.SUPPORTABLE],
         )
@@ -2647,7 +2647,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             ],
         )
 
-    def repr_impl(
+    def tp_repr_impl(
         self,
         tx: InstructionTranslatorBase,
     ) -> VariableTracker:
@@ -2659,14 +2659,14 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         Subclasses override to provide the actual repr implementation.
         """
         unimplemented(
-            gb_type="repr_impl not implemented",
-            context=f"{type(self).__name__} has tp_repr slot but no repr_impl override",
+            gb_type="tp_repr_impl not implemented",
+            context=f"{type(self).__name__} has tp_repr slot but no tp_repr_impl override",
             explanation=f"The type {self.python_type_name()} has a tp_repr C slot but "
-            "the corresponding VariableTracker doesn't implement repr_impl.",
+            "the corresponding VariableTracker doesn't implement tp_repr_impl.",
             hints=[*graph_break_hints.SUPPORTABLE],
         )
 
-    def str_impl(
+    def tp_str_impl(
         self,
         tx: InstructionTranslatorBase,
     ) -> VariableTracker:
@@ -2675,8 +2675,8 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         handles dispatch and repr fallback.
         """
         unimplemented(
-            gb_type="str_impl not implemented",
-            context=f"{type(self).__name__} has no str_impl override for {self.python_type_name()}",
+            gb_type="tp_str_impl not implemented",
+            context=f"{type(self).__name__} has no tp_str_impl override for {self.python_type_name()}",
             explanation=f"Dynamo does not implement __str__ for {self.python_type_name()} "
             f"in {type(self).__name__}.",
             hints=[*graph_break_hints.SUPPORTABLE],

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -783,7 +783,7 @@ def _wrap_descr_get(
     if len(args) not in (1, 2):
         raise_type_error(tx, f"expected 1 or 2 arguments, got {len(args)}")
     obj = args[0]
-    owner = args[1] if len(args) > 1 else obj.getattro_impl(tx, "__class__")
+    owner = args[1] if len(args) > 1 else obj.tp_getattro_impl(tx, "__class__")
     return func(self, tx, obj, owner)
 
 
@@ -941,31 +941,31 @@ _BIT_FIELD: dict[SlotGroup, dict[int, str]] = {
 _SLOT_FN: dict[SlotGroup, dict[str, str]] = {
     SlotGroup.NUMBER: {
         **{f: f"{f}_impl" for f in PyNumberMethods._fields},
-        "nb_bool": "bool_impl",
+        "nb_bool": "nb_bool_impl",
     },
     SlotGroup.SEQUENCE: {
-        "sq_length": "sq_length",
+        "sq_length": "sq_length_impl",
         "sq_concat": "sq_concat_impl",
         "sq_repeat": "sq_repeat_impl",
         "sq_item": "sq_item_impl",
         "sq_ass_item": "sq_ass_item_impl",
-        "sq_contains": "sq_contains",
+        "sq_contains": "sq_contains_impl",
         "sq_inplace_concat": "sq_inplace_concat_impl",
         "sq_inplace_repeat": "sq_inplace_repeat_impl",
     },
     SlotGroup.MAPPING: {
-        "mp_length": "mp_length",
+        "mp_length": "mp_length_impl",
         "mp_subscript": "mp_subscript_impl",
         "mp_ass_subscript": "mp_ass_subscript_impl",
     },
     SlotGroup.TYPE: {
-        "tp_repr": "repr_impl",
+        "tp_repr": "tp_repr_impl",
         "tp_hash": "tp_hash_impl",
         "tp_call": "call_function",
-        "tp_str": "str_impl",
-        "tp_getattro": "getattro_impl",
-        "tp_setattro": "setattro_impl",
-        "tp_richcompare": "richcompare_impl",
+        "tp_str": "tp_str_impl",
+        "tp_getattro": "tp_getattro_impl",
+        "tp_setattro": "tp_setattro_impl",
+        "tp_richcompare": "tp_richcompare_impl",
         "tp_iter": "tp_iter_impl",
         "tp_iternext": "tp_iternext_impl",
         "tp_descr_get": "tp_descr_get_impl",
@@ -1074,19 +1074,19 @@ _SLOTDEFS: list[SlotDef] = [
     # SlotDef("__getattr__", ),
     # SlotDef("__setattr__", ),
     # SlotDef("__delattr__", ),
-    TPSLOT("__repr__", "repr_impl", PyTypeSlots.TP_REPR, _wrap_unaryfunc),
+    TPSLOT("__repr__", "tp_repr_impl", PyTypeSlots.TP_REPR, _wrap_unaryfunc),
     # TPSLOT("__hash__", "tp_hash_impl", PyTypeSlots.TP_HASH, _wrap_unaryfunc),
     TPSLOT("__call__", "call_function", PyTypeSlots.TP_CALL, wrap_call),
-    TPSLOT("__str__", "str_impl", PyTypeSlots.TP_STR, _wrap_unaryfunc),
+    TPSLOT("__str__", "tp_str_impl", PyTypeSlots.TP_STR, _wrap_unaryfunc),
     TPSLOT(
         "__getattribute__",
-        "getattro_impl",
+        "tp_getattro_impl",
         PyTypeSlots.TP_GETATTRO,
         _wrap_getattro,
     ),
     TPSLOT(
         "__getattr__",
-        "getattro_impl",
+        "tp_getattro_impl",
         PyTypeSlots.TP_GETATTRO,
         _wrap_getattro,
     ),
@@ -1105,37 +1105,37 @@ _SLOTDEFS: list[SlotDef] = [
     # ),
     TPSLOT(
         "__lt__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_lt,
     ),
     TPSLOT(
         "__le__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_le,
     ),
     TPSLOT(
         "__eq__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_eq,
     ),
     TPSLOT(
         "__ne__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_ne,
     ),
     TPSLOT(
         "__gt__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_gt,
     ),
     TPSLOT(
         "__ge__",
-        "richcompare_impl",
+        "tp_richcompare_impl",
         PyTypeSlots.TP_RICHCOMPARE,
         richcmp_ge,
     ),
@@ -1264,7 +1264,7 @@ _SLOTDEFS: list[SlotDef] = [
     ),
     NBSLOT(
         "__bool__",
-        "bool_impl",
+        "nb_bool_impl",
         PyNumberSlots.NB_BOOL,
         _wrap_unaryfunc,
     ),
@@ -1469,7 +1469,7 @@ _SLOTDEFS: list[SlotDef] = [
     # Mapping
     MPSLOT(
         "__len__",
-        "mp_length",
+        "mp_length_impl",
         PyMappingSlots.MP_LENGTH,
         _wrap_unaryfunc,
     ),
@@ -1494,7 +1494,7 @@ _SLOTDEFS: list[SlotDef] = [
     # Sequence
     SQSLOT(
         "__len__",
-        "sq_length",
+        "sq_length_impl",
         PySequenceSlots.SQ_LENGTH,
         _wrap_unaryfunc,
     ),
@@ -1536,7 +1536,7 @@ _SLOTDEFS: list[SlotDef] = [
     ),
     SQSLOT(
         "__contains__",
-        "sq_contains",
+        "sq_contains_impl",
         PySequenceSlots.SQ_CONTAINS,
         _wrap_objobjproc,
     ),
@@ -1838,7 +1838,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         except NotImplementedError:
             return False
 
-    def bool_impl(self, tx: InstructionTranslatorBase) -> VariableTracker | None:
+    def nb_bool_impl(self, tx: InstructionTranslatorBase) -> VariableTracker | None:
         # Mirrors CPython's tp_as_number->nb_bool slot.
         # https://github.com/python/cpython/blob/c09ccd9c429/Objects/object.c#L2135-L2158
         #
@@ -1894,7 +1894,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         # Sourceless: no real object to hash — fake id.
         return id(self), True
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: InstructionTranslatorBase,
         other: VariableTracker,
@@ -1907,17 +1907,17 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         the comparison (signaling do_richcompare to try the other operand).
 
         Called from two paths:
-        - call_method("__eq__") calls richcompare_impl directly (like CPython's
+        - call_method("__eq__") calls tp_richcompare_impl directly (like CPython's
           a.__eq__(b) calling tp_richcompare without do_richcompare).
-        - generic_richcompare calls richcompare_impl as part of the 4-step
+        - generic_richcompare calls tp_richcompare_impl as part of the 4-step
           do_richcompare algorithm (subclass priority, forward, reflected,
           fallback).
         """
         unimplemented(
-            gb_type="Missing richcompare_impl override",
-            context=f"richcompare_impl {self} {op}",
+            gb_type="Missing tp_richcompare_impl override",
+            context=f"tp_richcompare_impl {self} {op}",
             explanation=f"{type(self).__name__} does not implement "
-            f"richcompare_impl. Add a richcompare_impl override to "
+            f"tp_richcompare_impl. Add a tp_richcompare_impl override to "
             f"{type(self).__name__}.",
             hints=[*graph_break_hints.DYNAMO_BUG],
         )
@@ -1995,7 +1995,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         """
         return None
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: InstructionTranslatorBase, name: str
     ) -> VariableTracker:
         """Default attribute access via object_generic_getattr.
@@ -2114,7 +2114,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def call_obj_hasattr(
         self, tx: InstructionTranslatorBase, name: str
     ) -> ConstantVariable:
-        """Dynamo's hasattr(): try getattro_impl, catch AttributeError.
+        """Dynamo's hasattr(): try tp_getattro_impl, catch AttributeError.
 
         Mirrors CPython's PyObject_HasAttr (via PyObject_GetOptionalAttr):
         call tp_getattro, suppress AttributeError via PyErr_Clear, return
@@ -2126,7 +2126,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             return result
 
         try:
-            self.getattro_impl(tx, name)
+            self.tp_getattro_impl(tx, name)
             return variables.ConstantVariable.create(True)
         except ObservedAttributeError:
             tx.exn_vt_stack.clear_current_exception()
@@ -2201,7 +2201,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             ],
         )
 
-    def sq_length(self, tx: InstructionTranslatorBase) -> VariableTracker:
+    def sq_length_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
         """Called when sq_length is not implemented."""
         raise_observed_exception(
             TypeError,
@@ -2209,7 +2209,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             args=[f"object of type '{self.python_type_name()}' has no len()"],
         )
 
-    def mp_length(self, tx: InstructionTranslatorBase) -> VariableTracker:
+    def mp_length_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
         """Called when mp_length is not implemented."""
         raise_observed_exception(
             TypeError,
@@ -2248,13 +2248,13 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             hints=[],
         )
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: InstructionTranslatorBase, item: VariableTracker
     ) -> VariableTracker:
         """Called when sq_contains is not implemented."""
         unimplemented(
             gb_type="missing sq_contains",
-            context=f"sq_contains not implemented for {self.python_type_name()}",
+            context=f"sq_contains_impl not implemented for {self.python_type_name()}",
             explanation=f"Dynamo does not know how to check if `{item.debug_repr()}` is in `{self.debug_repr()}`.",
             hints=[*graph_break_hints.SUPPORTABLE],
         )
@@ -2661,7 +2661,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             ],
         )
 
-    def repr_impl(
+    def tp_repr_impl(
         self,
         tx: InstructionTranslatorBase,
     ) -> VariableTracker:
@@ -2673,14 +2673,14 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         Subclasses override to provide the actual repr implementation.
         """
         unimplemented(
-            gb_type="repr_impl not implemented",
-            context=f"{type(self).__name__} has tp_repr slot but no repr_impl override",
+            gb_type="tp_repr_impl not implemented",
+            context=f"{type(self).__name__} has tp_repr slot but no tp_repr_impl override",
             explanation=f"The type {self.python_type_name()} has a tp_repr C slot but "
-            "the corresponding VariableTracker doesn't implement repr_impl.",
+            "the corresponding VariableTracker doesn't implement tp_repr_impl.",
             hints=[*graph_break_hints.SUPPORTABLE],
         )
 
-    def str_impl(
+    def tp_str_impl(
         self,
         tx: InstructionTranslatorBase,
     ) -> VariableTracker:
@@ -2689,8 +2689,8 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         handles dispatch and repr fallback.
         """
         unimplemented(
-            gb_type="str_impl not implemented",
-            context=f"{type(self).__name__} has no str_impl override for {self.python_type_name()}",
+            gb_type="tp_str_impl not implemented",
+            context=f"{type(self).__name__} has no tp_str_impl override for {self.python_type_name()}",
             explanation=f"Dynamo does not implement __str__ for {self.python_type_name()} "
             f"in {type(self).__name__}.",
             hints=[*graph_break_hints.SUPPORTABLE],

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -925,38 +925,13 @@ _BIT_FIELD: dict[SlotGroup, dict[int, str]] = {
 
 # The actual slot function (a VariableTracker method) each struct field dispatches to
 _SLOT_FN: dict[SlotGroup, dict[str, str]] = {
-    SlotGroup.NUMBER: {
-        **{f: f"{f}_impl" for f in PyNumberMethods._fields},
-        "nb_bool": "nb_bool_impl",
-    },
-    SlotGroup.SEQUENCE: {
-        "sq_length": "sq_length_impl",
-        "sq_concat": "sq_concat_impl",
-        "sq_repeat": "sq_repeat_impl",
-        "sq_item": "sq_item_impl",
-        "sq_ass_item": "sq_ass_item_impl",
-        "sq_contains": "sq_contains_impl",
-        "sq_inplace_concat": "sq_inplace_concat_impl",
-        "sq_inplace_repeat": "sq_inplace_repeat_impl",
-    },
-    SlotGroup.MAPPING: {
-        "mp_length": "mp_length_impl",
-        "mp_subscript": "mp_subscript_impl",
-        "mp_ass_subscript": "mp_ass_subscript_impl",
-    },
+    SlotGroup.NUMBER: {f: f"{f}_impl" for f in PyNumberMethods._fields},
+    SlotGroup.SEQUENCE: {f: f"{f}_impl" for f in PySequenceMethods._fields},
+    SlotGroup.MAPPING: {f: f"{f}_impl" for f in PyMappingMethods._fields},
     SlotGroup.TYPE: {
-        "tp_repr": "tp_repr_impl",
-        "tp_hash": "tp_hash_impl",
+        **{f: f"{f}_impl" for f in _TYPE_FIELDS},
         "tp_call": "call_function",
-        "tp_str": "tp_str_impl",
-        "tp_getattro": "tp_getattro_impl",
-        "tp_setattro": "tp_setattro_impl",
-        "tp_richcompare": "tp_richcompare_impl",
-        "tp_iter": "tp_iter_impl",
-        "tp_iternext": "tp_iternext_impl",
-        "tp_descr_get": "tp_descr_get_impl",
-        "tp_descr_set": "tp_descr_set_impl",
-        "tp_init": "tp_init_impl",
+        "tp_hash": "hash_impl",
     },
 }
 

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -939,38 +939,13 @@ _BIT_FIELD: dict[SlotGroup, dict[int, str]] = {
 
 # The actual slot function (a VariableTracker method) each struct field dispatches to
 _SLOT_FN: dict[SlotGroup, dict[str, str]] = {
-    SlotGroup.NUMBER: {
-        **{f: f"{f}_impl" for f in PyNumberMethods._fields},
-        "nb_bool": "nb_bool_impl",
-    },
-    SlotGroup.SEQUENCE: {
-        "sq_length": "sq_length_impl",
-        "sq_concat": "sq_concat_impl",
-        "sq_repeat": "sq_repeat_impl",
-        "sq_item": "sq_item_impl",
-        "sq_ass_item": "sq_ass_item_impl",
-        "sq_contains": "sq_contains_impl",
-        "sq_inplace_concat": "sq_inplace_concat_impl",
-        "sq_inplace_repeat": "sq_inplace_repeat_impl",
-    },
-    SlotGroup.MAPPING: {
-        "mp_length": "mp_length_impl",
-        "mp_subscript": "mp_subscript_impl",
-        "mp_ass_subscript": "mp_ass_subscript_impl",
-    },
+    SlotGroup.NUMBER: {f: f"{f}_impl" for f in PyNumberMethods._fields},
+    SlotGroup.SEQUENCE: {f: f"{f}_impl" for f in PySequenceMethods._fields},
+    SlotGroup.MAPPING: {f: f"{f}_impl" for f in PyMappingMethods._fields},
     SlotGroup.TYPE: {
-        "tp_repr": "tp_repr_impl",
-        "tp_hash": "tp_hash_impl",
+        **{f: f"{f}_impl" for f in _TYPE_FIELDS},
         "tp_call": "call_function",
-        "tp_str": "tp_str_impl",
-        "tp_getattro": "tp_getattro_impl",
-        "tp_setattro": "tp_setattro_impl",
-        "tp_richcompare": "tp_richcompare_impl",
-        "tp_iter": "tp_iter_impl",
-        "tp_iternext": "tp_iternext_impl",
-        "tp_descr_get": "tp_descr_get_impl",
-        "tp_descr_set": "tp_descr_set_impl",
-        "tp_init": "tp_init_impl",
+        "tp_hash": "hash_impl",
     },
 }
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2017,7 +2017,7 @@ class VariableBuilder:
             # tracing, but in dynamo we handle it as a regular object so that
             # trace_rules-based graph breaks (e.g. initial_seed, manual_seed)
             # work gracefully — allowing dynamo to compile code before and
-            # after the generator call. CustomClassObjectVariable's getattro_impl
+            # after the generator call. CustomClassObjectVariable's tp_getattro_impl
             # and call_method are decorated with @_raise_hard_error_if_graph_break,
             # which turns any graph break into a hard error that falls back to
             # eager for the entire function. Generator methods intentionally
@@ -5168,7 +5168,7 @@ class SourcelessBuilder:
                 cls_obj_vt = SourcelessBuilder.create(tx, value.__self__)
                 try:
                     # pyrefly: ignore[bad-argument-type]
-                    return cls_obj_vt.getattro_impl(tx, value.__func__.__name__)
+                    return cls_obj_vt.tp_getattro_impl(tx, value.__func__.__name__)
                 except NotImplementedError:
                     pass  # failthrough to unimplemented branch
             else:

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -385,7 +385,7 @@ class BaseBuiltinVariable(VariableTracker):
 
     Specialized subclasses (e.g. DictBuiltinVariable) set `_fn` as a class
     attribute. BuiltinVariable stores the callable on the instance as `self.fn`
-    and overrides as_python_constant / reconstruct / getattro_impl accordingly.
+    and overrides as_python_constant / reconstruct / tp_getattro_impl accordingly.
     """
 
     _fn: Any = None
@@ -448,7 +448,7 @@ class BaseBuiltinVariable(VariableTracker):
             raise AssertionError("shadowed global")
         codegen.append_output(codegen.create_load_global(name, add=True))
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # Declarative type-attribute dispatch, mirroring the consultation at the
@@ -471,7 +471,7 @@ class BaseBuiltinVariable(VariableTracker):
         # CPython meth_hash: https://github.com/python/cpython/blob/e76aa128fe/Objects/methodobject.c#L319
         return hash(self.as_python_constant()), False
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -917,7 +917,7 @@ class BuiltinVariable(BaseBuiltinVariable):
                 )
 
                 # COMPARE_OP (a == b) dispatches through generic_richcompare,
-                # which implements do_richcompare via richcompare_impl slots.
+                # which implements do_richcompare via tp_richcompare_impl slots.
                 # See object_protocol.py for details.
                 dunder = _OPERATOR_TO_DUNDER[op]
 
@@ -1553,7 +1553,7 @@ class BuiltinVariable(BaseBuiltinVariable):
             raise_type_error(tx, f"vars expected at most 1 argument, got {len(args)}")
         # vars(obj) is obj.__dict__ if __dict__ is present else TypeError
         try:
-            return args[0].getattro_impl(tx, "__dict__")
+            return args[0].tp_getattro_impl(tx, "__dict__")
         except ObservedAttributeError:
             raise_observed_exception(TypeError, tx)
 
@@ -2742,7 +2742,7 @@ class BuiltinVariable(BaseBuiltinVariable):
             mutation_type=ValueMutationNew(),
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # Declarative type-attribute dispatch (__name__, __bases__, __base__,
@@ -3419,7 +3419,7 @@ class GetAttrBuiltinVariable(BaseBuiltinVariable):
         except Unsupported:
             # Replicate the constant-fold fallback from BuiltinVariable._make_handler:
             # if all args are python constants, evaluate getattr() directly rather
-            # than propagating a graph break from getattro_impl.
+            # than propagating a graph break from tp_getattro_impl.
             if not check_unspec_or_constant_args(args, kwargs):
                 raise
             try:
@@ -3707,7 +3707,9 @@ class SetAttrBuiltinVariable(BaseBuiltinVariable):
                 assigning_fake_val = get_fake_value(val.as_proxy().node, tx)
 
                 try:
-                    getattr_var = obj.getattro_impl(tx, name_var.as_python_constant())
+                    getattr_var = obj.tp_getattro_impl(
+                        tx, name_var.as_python_constant()
+                    )
                 except (AttributeError, ObservedAttributeError):
                     getattr_var = None
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -386,7 +386,7 @@ class BaseBuiltinVariable(VariableTracker):
 
     Specialized subclasses (e.g. DictBuiltinVariable) set `_fn` as a class
     attribute. BuiltinVariable stores the callable on the instance as `self.fn`
-    and overrides as_python_constant / reconstruct / getattro_impl accordingly.
+    and overrides as_python_constant / reconstruct / tp_getattro_impl accordingly.
     """
 
     _fn: Any = None
@@ -449,7 +449,7 @@ class BaseBuiltinVariable(VariableTracker):
             raise AssertionError("shadowed global")
         codegen.append_output(codegen.create_load_global(name, add=True))
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # Declarative type-attribute dispatch, mirroring the consultation at the
@@ -472,7 +472,7 @@ class BaseBuiltinVariable(VariableTracker):
         # CPython meth_hash: https://github.com/python/cpython/blob/e76aa128fe/Objects/methodobject.c#L319
         return hash(self.as_python_constant()), False
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -918,7 +918,7 @@ class BuiltinVariable(BaseBuiltinVariable):
                 )
 
                 # COMPARE_OP (a == b) dispatches through generic_richcompare,
-                # which implements do_richcompare via richcompare_impl slots.
+                # which implements do_richcompare via tp_richcompare_impl slots.
                 # See object_protocol.py for details.
                 dunder = _OPERATOR_TO_DUNDER[op]
 
@@ -1554,7 +1554,7 @@ class BuiltinVariable(BaseBuiltinVariable):
             raise_type_error(tx, f"vars expected at most 1 argument, got {len(args)}")
         # vars(obj) is obj.__dict__ if __dict__ is present else TypeError
         try:
-            return args[0].getattro_impl(tx, "__dict__")
+            return args[0].tp_getattro_impl(tx, "__dict__")
         except ObservedAttributeError:
             raise_observed_exception(TypeError, tx)
 
@@ -2776,7 +2776,7 @@ class BuiltinVariable(BaseBuiltinVariable):
             mutation_type=ValueMutationNew(),
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # Declarative type-attribute dispatch (__name__, __bases__, __base__,
@@ -3453,7 +3453,7 @@ class GetAttrBuiltinVariable(BaseBuiltinVariable):
         except Unsupported:
             # Replicate the constant-fold fallback from BuiltinVariable._make_handler:
             # if all args are python constants, evaluate getattr() directly rather
-            # than propagating a graph break from getattro_impl.
+            # than propagating a graph break from tp_getattro_impl.
             if not check_unspec_or_constant_args(args, kwargs):
                 raise
             try:
@@ -3742,7 +3742,9 @@ class SetAttrBuiltinVariable(BaseBuiltinVariable):
                 assigning_fake_val = get_fake_value(val.as_proxy().node, tx)
 
                 try:
-                    getattr_var = obj.getattro_impl(tx, name_var.as_python_constant())
+                    getattr_var = obj.tp_getattro_impl(
+                        tx, name_var.as_python_constant()
+                    )
                 except (AttributeError, ObservedAttributeError):
                     getattr_var = None
 

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -143,7 +143,7 @@ class ConstantVariable(VariableTracker):
     def is_python_constant(self) -> Literal[True]:
         return True
 
-    def repr_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
+    def tp_repr_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
         return ConstantVariable.create(repr(self.value))
 
     def is_symnode_like(self) -> bool:
@@ -232,14 +232,14 @@ class ConstantVariable(VariableTracker):
         """Dynamo tracing rule for long_hash, float_hash, unicode_hash, etc."""
         return hash(self.value), False
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: InstructionTranslatorBase, other: VariableTracker, op: str
     ) -> VariableTracker:
         from .object_protocol import python_constant_richcompare_impl
 
         return python_constant_richcompare_impl(self, tx, other, op)
 
-    def str_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
+    def tp_str_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
         return ConstantVariable.create(str(self.value))
 
     def len_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
@@ -249,11 +249,11 @@ class ConstantVariable(VariableTracker):
         except TypeError as e:
             raise_observed_exception(type(e), tx, args=list(e.args))
 
-    def sq_length(self, tx: InstructionTranslatorBase) -> VariableTracker:
+    def sq_length_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
         """Sequence length - delegates to len_impl for constants."""
         return self.len_impl(tx)
 
-    def mp_length(self, tx: InstructionTranslatorBase) -> VariableTracker:
+    def mp_length_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
         """Mapping length - delegates to len_impl for constants."""
         return self.len_impl(tx)
 
@@ -267,7 +267,7 @@ class ConstantVariable(VariableTracker):
             raise NotImplementedError
         return member
 
-    def sq_contains(self, tx: InstructionTranslatorBase, item: VariableTracker):
+    def sq_contains_impl(self, tx: InstructionTranslatorBase, item: VariableTracker):
         """Sequence contains for constants."""
         if item.is_python_constant():
             search = item.as_python_constant()
@@ -280,7 +280,7 @@ class ConstantVariable(VariableTracker):
                     tx,
                     args=list(e.args),
                 )
-        return super().sq_contains(tx, item)
+        return super().sq_contains_impl(tx, item)
 
     def tp_iter_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
         from .lists import ListIteratorVariable
@@ -906,14 +906,14 @@ class FakeIdVariable(VariableTracker):
     def hash_impl(self, tx: InstructionTranslatorBase) -> tuple[int, bool]:
         return hash(self.value), True
 
-    def repr_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
+    def tp_repr_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
         # Mirrors int.__repr__: the value is an int, so str()/repr() yield its
         # decimal string. The distinct-but-compile-time-only identity carried by
         # the fake id is preserved in the resulting string, matching how
         # FakeIdVariable already resolves same-kind id()/hash() comparisons.
         return ConstantVariable.create(repr(self.value))
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: InstructionTranslatorBase, other: VariableTracker, op: str
     ) -> VariableTracker:
         if (

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -82,7 +82,7 @@ class ContextWrappingVariable(VariableTracker):
                 f"Sequence, got {type(target_values).__name__}"
             )
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .object_protocol import object_richcompare
@@ -257,10 +257,10 @@ class RepararametrizeModuleContextVariable(GenericContextWrappingVariable):
         with torch._dynamo.variables.higher_order_ops.dynamo_allow_side_effects_in_hop(
             tx
         ):
-            self.old_parameters_var = self.mod.getattro_impl(
+            self.old_parameters_var = self.mod.tp_getattro_impl(
                 tx, "_parameters"
             ).realize()
-            self.old_buffer_var = self.mod.getattro_impl(tx, "_buffers").realize()
+            self.old_buffer_var = self.mod.tp_getattro_impl(tx, "_buffers").realize()
             tx.output.side_effects.ignore_mutations_on(self.old_parameters_var)
             tx.output.side_effects.ignore_mutations_on(self.old_buffer_var)
             return self.cm_vt.enter(tx)
@@ -1350,7 +1350,7 @@ class PreserveVersionContextVariable(ContextWrappingVariable):
     ) -> "PreserveVersionContextVariable":
         if tensors.is_tensor():
             versions = variables.TupleVariable(
-                [x.getattro_impl(tx, "_version") for x in [tensors]]
+                [x.tp_getattro_impl(tx, "_version") for x in [tensors]]
             )
             tensors_tuple = variables.TupleVariable([tensors])
         else:
@@ -1359,7 +1359,7 @@ class PreserveVersionContextVariable(ContextWrappingVariable):
                     f"tensors must be a TupleVariable, got {type(tensors)}"
                 )
             versions = variables.TupleVariable(
-                [x.getattro_impl(tx, "_version") for x in tensors.items]
+                [x.tp_getattro_impl(tx, "_version") for x in tensors.items]
             )
             tensors_tuple = tensors
         return PreserveVersionContextVariable(tensors_tuple, versions)
@@ -1781,7 +1781,7 @@ class WithEnterFunctionVariable(VariableTracker):
         super().__init__(**kwargs)
         self.ctx = ctx
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .object_protocol import object_richcompare
@@ -1835,7 +1835,7 @@ class WithExitFunctionVariable(VariableTracker):
         *VariableTracker._nonvar_fields,
     }
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .object_protocol import object_richcompare

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -81,7 +81,7 @@ if TYPE_CHECKING:
 # [Adding a new supported class within the keys of ConstDictVariable]
 # - Implement hash_impl(self, tx) on the VariableTracker subclass (or rely on the
 #   base class default which uses get_real_python_backed_value())
-# - Implement richcompare_impl() for key equality
+# - Implement tp_richcompare_impl() for key equality
 
 
 def pydict_check(obj: VariableTracker) -> bool:
@@ -194,7 +194,7 @@ class ConstDictVariable(VariableTracker):
             for k, v in self.items.items()
         }
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         items = [
             f"{tracked_repr(tx, key.vt)}: {tracked_repr(tx, value)}"
             for key, value in self.items.items()
@@ -472,7 +472,7 @@ class ConstDictVariable(VariableTracker):
         # Unhashable key check happens inside HashableTracker (hash_impl → TypeError).
         return self.getitem_const_raise_exception_if_absent(tx, key)
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/dictobject.c#L4657-L4668
@@ -768,7 +768,7 @@ class ConstDictVariable(VariableTracker):
             self.items[hkey] = value
         return ConstantVariable.create(None)
 
-    def mp_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def mp_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """Mapping length for dict objects."""
         self.install_dict_keys_match_guard()
         return VariableTracker.build(tx, len(self.items))
@@ -810,7 +810,7 @@ class ConstDictVariable(VariableTracker):
 
         raise_type_error(tx, f"unhashable type: '{self.python_type_name()}'")
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         # dict_richcompare: https://github.com/python/cpython/blob/e76aa128fe/Objects/dictobject.c#L4198
@@ -839,7 +839,7 @@ class ConstDictVariable(VariableTracker):
             return VariableTracker.build(tx, not eq_result.as_python_constant())
         return eq_result
 
-    def getattro_impl(self, tx: "InstructionTranslatorBase", name: str):
+    def tp_getattro_impl(self, tx: "InstructionTranslatorBase", name: str):
         if name == "__class__":
             return VariableTracker.build(tx, self.python_type())
         # DictGuardManager does not support getattr_manager for plain dicts,
@@ -849,7 +849,7 @@ class ConstDictVariable(VariableTracker):
         type_attr = mro_lookup(self.python_type(), name)
         if type_attr is not NO_SUCH_SUBOBJ and _is_method_type(type_attr):
             return variables.CallMethodVariable(self, name)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 class OrderedDictVariable(ConstDictVariable):
@@ -947,7 +947,7 @@ class OrderedDictVariable(ConstDictVariable):
         items = [(k.vt.debug_repr(), v.debug_repr()) for k, v in self.items.items()]
         return self._ordered_dict_repr(items)
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # Python < 3.12 uses the historical list-of-pairs form, while 3.12+
         # uses dict-style formatting.
         items = [
@@ -1109,16 +1109,16 @@ class MappingProxyVariable(VariableTracker):
     def tp_iter_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         return self.dv_dict.tp_iter_impl(tx)
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # https://github.com/python/cpython/blob/60403a5409ff/Objects/descrobject.c#L1087-L1095
-        return self.dv_dict.sq_contains(tx, item)
+        return self.dv_dict.sq_contains_impl(tx, item)
 
-    def mp_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
-        return self.dv_dict.mp_length(tx)
+    def mp_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        return self.dv_dict.mp_length_impl(tx)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         # mappingproxy_richcompare delegates to the underlying mapping:
@@ -1207,7 +1207,7 @@ class DictViewVariable(VariableTracker):
             return ConstantVariable.create(True)
         return ConstantVariable.create(False)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # dictview_mapping getset returns a read-only mappingproxy of the
@@ -1215,9 +1215,9 @@ class DictViewVariable(VariableTracker):
         # https://github.com/python/cpython/blob/v3.13.0/Objects/dictobject.c#L5032-L5040
         if name == "mapping":
             return MappingProxyVariable(self.dv_dict)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         if self.kv == "keys":
             items = ", ".join(tracked_repr(tx, key.vt) for key in self.view_items)
         elif self.kv == "values":
@@ -1253,7 +1253,7 @@ class DictViewVariable(VariableTracker):
             )
         return super().call_method(tx, name, args, kwargs)
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """Sequence length for dict view objects."""
         return VariableTracker.build(tx, len(self.view_items))
 
@@ -1338,13 +1338,13 @@ class DictKeysVariable(DictViewVariable):
                 items.append(key_str)
             return "dict_keys([" + ", ".join(items) + "])"
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/dictobject.c#L5998-L6005
-        return self.dv_dict.sq_contains(tx, item)
+        return self.dv_dict.sq_contains_impl(tx, item)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         # dictview_richcompare: accepts set/frozenset and dict_keys/dict_items.
@@ -1419,7 +1419,7 @@ class DictValuesVariable(DictViewVariable):
             tx.output.guard_on_key_order.add(self.dv_dict.source)
         return DictValuesIterator(self.dv_dict.items)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         # dict_values has no tp_richcompare (inherits object's).
@@ -1470,7 +1470,7 @@ class DictItemsVariable(DictViewVariable):
                 items.append(f"({key_str}, {val_str})")
             return "dict_items([" + ", ".join(items) + "])"
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/dictobject.c#L6433-L6451
@@ -1492,7 +1492,7 @@ class DictItemsVariable(DictViewVariable):
 
         return iter_contains(self.view_items_vt, item, tx)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         # dictview_richcompare: accepts set/frozenset and dict_keys/dict_items.

--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -73,7 +73,7 @@ class DistributedVariable(VariableTracker):
     def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         return hash(self.value), False
 
-    def richcompare_impl(self, tx, other, op):
+    def tp_richcompare_impl(self, tx, other, op):
         from .object_protocol import object_richcompare
 
         return object_richcompare(self, tx, other, op)
@@ -128,7 +128,7 @@ class WorldMetaClassVariable(DistributedVariable):
     def python_type(self) -> type:
         return type(self.value)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "WORLD":
@@ -147,7 +147,7 @@ class WorldMetaClassVariable(DistributedVariable):
             source = AttrSource(base=self.source, member="NON_GROUP_MEMBER")
             install_guard(source.make_guard(GuardBuilder.ID_MATCH))
             return VariableTracker.build(tx, self.value.NON_GROUP_MEMBER, source)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 class BackwardHookVariable(VariableTracker):

--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -73,7 +73,7 @@ class DistributedVariable(VariableTracker):
     def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         return hash(self.value), False
 
-    def richcompare_impl(self, tx, other, op):
+    def tp_richcompare_impl(self, tx, other, op):
         from .object_protocol import object_richcompare
 
         return object_richcompare(self, tx, other, op)

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -412,7 +412,7 @@ class BaseUserFunctionVariable(VariableTracker):
     # Materialized per-instance once accessed/assigned.
     annotations: "VariableTracker | None" = None
 
-    def richcompare_impl(self, tx, other, op):
+    def tp_richcompare_impl(self, tx, other, op):
         from .object_protocol import object_richcompare
 
         return object_richcompare(self, tx, other, op)
@@ -423,7 +423,7 @@ class BaseUserFunctionVariable(VariableTracker):
     def get_source(self) -> Source | None:
         return self.source
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/funcobject.c
         return VariableTracker.build(tx, repr(self.as_python_constant()))
 
@@ -654,7 +654,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
             self.is_constant = False
 
         # TODO putting this here to avoid duplication, because we could hit this
-        # from several paths (e.g., SuperVariable or `getattro_impl`s).
+        # from several paths (e.g., SuperVariable or `tp_getattro_impl`s).
         if not isinstance(fn, (types.FunctionType, torch.jit.ScriptFunction)):
             unimplemented(
                 gb_type="can't handle functions not implemented in python ",
@@ -1277,7 +1277,7 @@ class LocalGeneratorObjectVariable(VariableTracker):
     def python_type(self) -> type:
         return types.GeneratorType
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         # Generators have no tp_richcompare: identity for ==/!=, TypeError for
@@ -1783,7 +1783,7 @@ class UserMethodVariable(UserFunctionVariable):
         # a `nonstrict_trace`-ed function will be wrapped by
         # `VariableTracker.build` and route to `TorchInGraphFunctionVariable`,
         # but in the case of method, we manually wrap it with `UserMethodVariable`
-        # inside `UserDefinedObjectVariable.getattro_impl`.
+        # inside `UserDefinedObjectVariable.tp_getattro_impl`.
         #
         # We might be able to simplify this away by canonicalizing the
         # function/method wrapping code paths.
@@ -2012,9 +2012,9 @@ class NestedUserFunctionVariable(BaseUserFunctionVariable):
     def as_python_constant(self) -> types.FunctionType:
         return self.get_function()
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         try:
-            return super().repr_impl(tx)
+            return super().tp_repr_impl(tx)
         except ClosureConversionError as e:
             unimplemented(
                 gb_type="repr() on nested function with non-constructible closure",
@@ -2364,7 +2364,7 @@ class SkipFunctionVariable(VariableTracker):
             return None
         return self.value
 
-    def richcompare_impl(self, tx, other, op):
+    def tp_richcompare_impl(self, tx, other, op):
         from .object_protocol import object_richcompare
 
         return object_richcompare(self, tx, other, op)
@@ -2693,14 +2693,14 @@ class WrapperUserFunctionVariable(BaseUserFunctionVariable):
     def get_code(self) -> types.CodeType:
         return self.get_function().__code__
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == self.attr_to_trace:
             val = getattr(self.wrapper_obj, self.attr_to_trace)
             source = self.source and AttrSource(self.source, name)
             return VariableTracker.build(tx, val, source)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def get_function(self):
         return getattr(self.wrapper_obj, self.attr_to_trace)
@@ -2969,7 +2969,7 @@ class CollectiveFunctionRewriteVariable(UserFunctionVariable):
                         "`P2POp` used incorrectly"
                     )
 
-                op_var = item.getattro_impl(tx, "op")
+                op_var = item.tp_getattro_impl(tx, "op")
                 if op_var.is_python_constant():
                     op = op_var.as_python_constant()
                     if op not in (dist.isend, dist.irecv):
@@ -2985,13 +2985,13 @@ class CollectiveFunctionRewriteVariable(UserFunctionVariable):
                     )
 
                 ops.append(op_var)
-                tensors.append(item.getattro_impl(tx, "tensor"))
+                tensors.append(item.tp_getattro_impl(tx, "tensor"))
                 # batch_p2p_ops expects a group-local rank, which is what
                 # P2POp.group_peer provides.
-                peers.append(item.getattro_impl(tx, "group_peer"))
-                tags.append(item.getattro_impl(tx, "tag"))
+                peers.append(item.tp_getattro_impl(tx, "group_peer"))
+                tags.append(item.tp_getattro_impl(tx, "tag"))
                 if group_var is None:
-                    group_var = item.getattro_impl(tx, "group")
+                    group_var = item.tp_getattro_impl(tx, "group")
 
             if group_var is None:
                 raise AssertionError("group_var must be set from P2POp items")
@@ -3104,7 +3104,7 @@ class FunctoolsPartialVariable(VariableTracker):
         # Store cache_hash from the original partial for SAC context_fn caching
         self.original_cache_hash = original_cache_hash
 
-    def richcompare_impl(self, tx, other, op):
+    def tp_richcompare_impl(self, tx, other, op):
         from .object_protocol import object_richcompare
 
         return object_richcompare(self, tx, other, op)
@@ -3166,7 +3166,7 @@ class FunctoolsPartialVariable(VariableTracker):
         "keywords": Member(_get_keywords, None),
     }
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         try:
@@ -3351,7 +3351,7 @@ class SysFunctionVariable(VariableTracker):
         if len(tx.exn_vt_stack):
             exn = tx.exn_vt_stack[-1]
             typ = exn.exc_type  # type: ignore[union-attr]
-            tb = exn.getattro_impl(tx, "__traceback__")
+            tb = exn.tp_getattro_impl(tx, "__traceback__")
             items = [VariableTracker.build(tx, typ), exn, tb]
         else:
             items = [
@@ -4253,7 +4253,7 @@ class MethodWrapperVariable(VariableTracker):
                 # Avoid the generic descriptor path's implicit owner lookup, which
                 # would read __class__ on tensor subclasses during __torch_function__.
                 descriptor = cast(Any, method_wrapper.__self__)
-                return args[0].getattro_impl(tx, descriptor.__name__)
+                return args[0].tp_getattro_impl(tx, descriptor.__name__)
 
         return self.obj.call_method(tx, self.descriptor.__name__, list(args), kwargs)
 
@@ -4269,7 +4269,7 @@ class MethodWrapperVariable(VariableTracker):
         except NotImplementedError:
             return super().hash_impl(tx)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import python_constant_richcompare_impl
@@ -4406,7 +4406,7 @@ class BoundBuiltinMethodVariable(VariableTracker):
         except AsPythonConstantNotImplementedError:
             return id(self), True
 
-    def richcompare_impl(self, tx, other, op):
+    def tp_richcompare_impl(self, tx, other, op):
         from .object_protocol import object_richcompare
 
         return object_richcompare(self, tx, other, op)
@@ -4730,7 +4730,7 @@ class GetSetDescriptorVariable(VariableTracker):
     def as_python_constant(self) -> types.GetSetDescriptorType:
         return self.descriptor
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import python_constant_richcompare_impl
@@ -4748,7 +4748,7 @@ class GetSetDescriptorVariable(VariableTracker):
         attr_name = self.descriptor.__name__
         # Try to eagerly call the C getter when we can obtain the
         # concrete Python object (UDOV.value, or as_python_constant
-        # for classes/constants). Fall back to getattro_impl for
+        # for classes/constants). Fall back to tp_getattro_impl for
         # proxy-based VTs like TensorVariable.
         _check_descriptor_obj_type(tx, self.descriptor, obj)
         obj_value = obj.get_real_python_backed_value()

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3170,7 +3170,7 @@ class FunctoolsPartialVariable(VariableTracker):
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         try:
-            return super().getattro_impl(tx, name)
+            return super().tp_getattro_impl(tx, name)
         except NotImplementedError:
             raise_observed_exception(AttributeError, tx, args=[name])
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2306,7 +2306,7 @@ class TorchHigherOrderOperatorVariable(VariableTracker):
             ],
         )
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .object_protocol import python_constant_richcompare_impl
@@ -5120,7 +5120,7 @@ class AutogradFunctionApplyVariable(VariableTracker):
         self.bwd_fn = bwd_fn
         self.parent_source = parent_source
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .object_protocol import object_richcompare

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -82,7 +82,7 @@ class ItertoolsVariable(VariableTracker):
         super().__init__(**kwargs)
         self.value = value
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .object_protocol import python_constant_richcompare_impl
@@ -306,7 +306,7 @@ class IteratorVariable(VariableTracker):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .object_protocol import object_richcompare
@@ -472,7 +472,7 @@ class RepeatIteratorVariable(IteratorVariable):
         "__length_hint__": Method(repeat_length_hint),
     }
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         item_repr = tracked_repr(tx, self.item)
         if self.times is None:
             return ConstantVariable.create(f"repeat({item_repr})")
@@ -532,10 +532,10 @@ class CountIteratorVariable(IteratorVariable):
         self.advance_count += 1
         return old_item
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/3.13/Modules/itertoolsmodule.c#L4218-L4243
         if not (self.item.is_python_constant() and self.step.is_python_constant()):
-            return super().repr_impl(tx)
+            return super().tp_repr_impl(tx)
         cnt = self.item.as_python_constant()
         step = self.step.as_python_constant()
         # Suppress step in the repr when it is an integer equal to 1.

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -168,7 +168,7 @@ class BaseListVariable(VariableTracker):
     def as_python_constant(self) -> Any:
         return self.python_type()([x.as_python_constant() for x in self.items])
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         return VariableTracker.build(tx, self.debug_repr())
 
     def as_proxy(self) -> Any:
@@ -215,13 +215,13 @@ class BaseListVariable(VariableTracker):
     ) -> list[VariableTracker]:
         return list(self.items)
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """Sequence length for lists, tuples, and range objects."""
         return VariableTracker.build(tx, len(self.items))
 
-    mp_length = sq_length
+    mp_length_impl = sq_length_impl
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/listobject.c#L635-L652
@@ -563,7 +563,7 @@ class RangeVariable(BaseListVariable):
         repr += ")"
         return repr
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # ref: range_repr in https://github.com/python/cpython/blob/6280bb547840b609feedb78887c6491af75548e8/Objects/rangeobject.c#L673-L691
         return VariableTracker.build(tx, self.debug_repr())
 
@@ -711,15 +711,15 @@ class RangeVariable(BaseListVariable):
         rng = range(self.start(), self.stop(), self.step())
         return [variables.ConstantVariable.create(x) for x in rng]
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """Sequence length for range objects."""
         length = self.range_length()
         if length > sys.maxsize:
             raise_observed_exception(OverflowError, tx)
         return VariableTracker.build(tx, length)
 
-    def mp_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
-        return self.sq_length(tx)
+    def mp_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        return self.sq_length_impl(tx)
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         if "range" in codegen.tx.f_globals:
@@ -779,7 +779,7 @@ class RangeVariable(BaseListVariable):
         # range_subscript: https://github.com/python/cpython/blob/62a6e898e01/Objects/rangeobject.c#L729-L748
         return self.getitem_const(tx, key)
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # range_contains: https://github.com/python/cpython/blob/60403a5409ff2c3f3b07dd2ca91a7a3e096839c7/Objects/rangeobject.c#L482-L490
@@ -809,7 +809,7 @@ class RangeVariable(BaseListVariable):
         index = key.as_python_constant()
         return self.apply_index(tx, index)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -879,14 +879,14 @@ class RangeVariable(BaseListVariable):
             )
         return super().call_method(tx, name, args, kwargs)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         fields = ["start", "stop", "step"]
         if name in fields:
             return self.items[fields.index(name)]
 
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         # CPython range_hash: https://github.com/python/cpython/blob/e76aa128fe/Objects/rangeobject.c#L572
@@ -1043,7 +1043,7 @@ class ListVariable(CommonListMethodsVariable):
     # PyList_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/listobject.c#L3776
     _cpython_type = list
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -1060,7 +1060,7 @@ class ListVariable(CommonListMethodsVariable):
     def debug_repr(self) -> str:
         return self.debug_repr_helper("[", "]")
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         items = ", ".join(tracked_repr(tx, item) for item in self.items)
         return VariableTracker.build(tx, f"[{items}]")
 
@@ -1220,7 +1220,7 @@ class ListVariable(CommonListMethodsVariable):
             self.call_method(tx, "extend", args, {})
         return ConstantVariable.create(None)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "__class__":
@@ -1230,7 +1230,7 @@ class ListVariable(CommonListMethodsVariable):
                 return VariableTracker.build(tx, class_type, source=source)
             else:
                 return VariableTracker.build(tx, class_type, source)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def call_obj_hasattr(
         self, tx: "InstructionTranslatorBase", name: str
@@ -1418,7 +1418,7 @@ class DequeVariable(CommonListMethodsVariable):
 
     tp_methods = {"rotate": Method(_rotate)}
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -1573,7 +1573,7 @@ class DequeVariable(CommonListMethodsVariable):
             "deque([", "], maxlen=" + self.maxlen.debug_repr() + ")"
         )
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         items = ", ".join(tracked_repr(tx, item) for item in self.items)
         if self.maxlen.as_python_constant() is None:
             return VariableTracker.build(tx, f"{self.python_type_name()}([{items}])")
@@ -1617,12 +1617,12 @@ class DequeVariable(CommonListMethodsVariable):
             ]
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "maxlen":
             return self.maxlen
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def call_method(
         self,
@@ -1793,7 +1793,7 @@ class TupleVariable(BaseListVariable):
     # PyTuple_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/tupleobject.c#L846
     _cpython_type = tuple
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -1812,7 +1812,7 @@ class TupleVariable(BaseListVariable):
             return self.debug_repr_helper("(", ",)")
         return self.debug_repr_helper("(", ")")
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         items = ", ".join(tracked_repr(tx, item) for item in self.items)
         if len(self.items) == 1:
             items += ","
@@ -1832,14 +1832,14 @@ class TupleVariable(BaseListVariable):
         else:
             return f"({', '.join([item.reconstruct_pycode(codegen) for item in self.items])},)"
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "__class__":
             source = AttrSource(self.source, name) if self.source else None
             class_type = self.python_type()
             return VariableTracker.build(tx, class_type, source=source)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def call_obj_hasattr(
         self, tx: "InstructionTranslatorBase", name: str
@@ -1932,7 +1932,7 @@ class SizeVariable(TupleVariable):
     def debug_repr(self) -> str:
         return self.debug_repr_helper("torch.Size([", "])")
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         items = ", ".join(tracked_repr(tx, item) for item in self.items)
         return VariableTracker.build(tx, f"torch.Size([{items}])")
 
@@ -2235,7 +2235,7 @@ class SliceVariable(VariableTracker):
             raise_observed_exception(TypeError, tx, args=[str(e)])
         return h, False
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -2257,7 +2257,7 @@ class SliceVariable(VariableTracker):
         codegen.foreach(self.items)
         codegen.append_output(create_instruction("BUILD_SLICE", arg=len(self.items)))
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name in cmp_name_to_op_mapping or name in ("__hash__", "indices"):
@@ -2268,7 +2268,7 @@ class SliceVariable(VariableTracker):
         if name not in fields:
             unimplemented(
                 gb_type="Unsupported attribute for slice() object",
-                context=f"getattro_impl {self} {name}",
+                context=f"tp_getattro_impl {self} {name}",
                 explanation=f"Expected attribute to be one of {','.join(fields)} "
                 f"but got {name}",
                 hints=[*graph_break_hints.USER_ERROR],

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -169,7 +169,7 @@ class BaseListVariable(VariableTracker):
     def as_python_constant(self) -> Any:
         return self.python_type()([x.as_python_constant() for x in self.items])
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         return VariableTracker.build(tx, self.debug_repr())
 
     def as_proxy(self) -> Any:
@@ -216,13 +216,13 @@ class BaseListVariable(VariableTracker):
     ) -> list[VariableTracker]:
         return list(self.items)
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """Sequence length for lists, tuples, and range objects."""
         return VariableTracker.build(tx, len(self.items))
 
-    mp_length = sq_length
+    mp_length_impl = sq_length_impl
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/listobject.c#L635-L652
@@ -564,7 +564,7 @@ class RangeVariable(BaseListVariable):
         repr += ")"
         return repr
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # ref: range_repr in https://github.com/python/cpython/blob/6280bb547840b609feedb78887c6491af75548e8/Objects/rangeobject.c#L673-L691
         return VariableTracker.build(tx, self.debug_repr())
 
@@ -712,15 +712,15 @@ class RangeVariable(BaseListVariable):
         rng = range(self.start(), self.stop(), self.step())
         return [variables.ConstantVariable.create(x) for x in rng]
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """Sequence length for range objects."""
         length = self.range_length()
         if length > sys.maxsize:
             raise_observed_exception(OverflowError, tx)
         return VariableTracker.build(tx, length)
 
-    def mp_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
-        return self.sq_length(tx)
+    def mp_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        return self.sq_length_impl(tx)
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         if "range" in codegen.tx.f_globals:
@@ -780,7 +780,7 @@ class RangeVariable(BaseListVariable):
         # range_subscript: https://github.com/python/cpython/blob/62a6e898e01/Objects/rangeobject.c#L729-L748
         return self.getitem_const(tx, key)
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # range_contains: https://github.com/python/cpython/blob/60403a5409ff2c3f3b07dd2ca91a7a3e096839c7/Objects/rangeobject.c#L482-L490
@@ -810,7 +810,7 @@ class RangeVariable(BaseListVariable):
         index = key.as_python_constant()
         return self.apply_index(tx, index)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -880,14 +880,14 @@ class RangeVariable(BaseListVariable):
             )
         return super().call_method(tx, name, args, kwargs)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         fields = ["start", "stop", "step"]
         if name in fields:
             return self.items[fields.index(name)]
 
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         # CPython range_hash: https://github.com/python/cpython/blob/e76aa128fe/Objects/rangeobject.c#L572
@@ -1044,7 +1044,7 @@ class ListVariable(CommonListMethodsVariable):
     # PyList_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/listobject.c#L3776
     _cpython_type = list
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -1061,7 +1061,7 @@ class ListVariable(CommonListMethodsVariable):
     def debug_repr(self) -> str:
         return self.debug_repr_helper("[", "]")
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         items = ", ".join(tracked_repr(tx, item) for item in self.items)
         return VariableTracker.build(tx, f"[{items}]")
 
@@ -1221,7 +1221,7 @@ class ListVariable(CommonListMethodsVariable):
             self.call_method(tx, "extend", args, {})
         return ConstantVariable.create(None)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "__class__":
@@ -1231,7 +1231,7 @@ class ListVariable(CommonListMethodsVariable):
                 return VariableTracker.build(tx, class_type, source=source)
             else:
                 return VariableTracker.build(tx, class_type, source)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def call_obj_hasattr(
         self, tx: "InstructionTranslatorBase", name: str
@@ -1424,7 +1424,7 @@ class DequeVariable(CommonListMethodsVariable):
 
     tp_methods = {"rotate": Method(_rotate)}
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -1579,7 +1579,7 @@ class DequeVariable(CommonListMethodsVariable):
             "deque([", "], maxlen=" + self.maxlen.debug_repr() + ")"
         )
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         items = ", ".join(tracked_repr(tx, item) for item in self.items)
         if self.maxlen.as_python_constant() is None:
             return VariableTracker.build(tx, f"{self.python_type_name()}([{items}])")
@@ -1809,7 +1809,7 @@ class TupleVariable(BaseListVariable):
     # PyTuple_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/tupleobject.c#L846
     _cpython_type = tuple
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -1828,7 +1828,7 @@ class TupleVariable(BaseListVariable):
             return self.debug_repr_helper("(", ",)")
         return self.debug_repr_helper("(", ")")
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         items = ", ".join(tracked_repr(tx, item) for item in self.items)
         if len(self.items) == 1:
             items += ","
@@ -1848,14 +1848,14 @@ class TupleVariable(BaseListVariable):
         else:
             return f"({', '.join([item.reconstruct_pycode(codegen) for item in self.items])},)"
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "__class__":
             source = AttrSource(self.source, name) if self.source else None
             class_type = self.python_type()
             return VariableTracker.build(tx, class_type, source=source)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def call_obj_hasattr(
         self, tx: "InstructionTranslatorBase", name: str
@@ -1948,7 +1948,7 @@ class SizeVariable(TupleVariable):
     def debug_repr(self) -> str:
         return self.debug_repr_helper("torch.Size([", "])")
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         items = ", ".join(tracked_repr(tx, item) for item in self.items)
         return VariableTracker.build(tx, f"torch.Size([{items}])")
 
@@ -2251,7 +2251,7 @@ class SliceVariable(VariableTracker):
             raise_observed_exception(TypeError, tx, args=[str(e)])
         return h, False
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -2273,7 +2273,7 @@ class SliceVariable(VariableTracker):
         codegen.foreach(self.items)
         codegen.append_output(create_instruction("BUILD_SLICE", arg=len(self.items)))
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name in cmp_name_to_op_mapping or name in ("__hash__", "indices"):
@@ -2284,7 +2284,7 @@ class SliceVariable(VariableTracker):
         if name not in fields:
             unimplemented(
                 gb_type="Unsupported attribute for slice() object",
-                context=f"getattro_impl {self} {name}",
+                context=f"tp_getattro_impl {self} {name}",
                 explanation=f"Expected attribute to be one of {','.join(fields)} "
                 f"but got {name}",
                 hints=[*graph_break_hints.USER_ERROR],

--- a/torch/_dynamo/variables/memory.py
+++ b/torch/_dynamo/variables/memory.py
@@ -91,7 +91,7 @@ class CUDAMemPoolVariable(VariableTracker):
     def get_real_python_backed_value(self) -> object:
         return self.value
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "id":

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -76,13 +76,11 @@ from ..utils import (
 )
 from .base import (
     AsPythonConstantNotImplementedError,
-    GetSet,
     getset_build,
     getset_read,
     Member,
     Method,
     NO_SUCH_SUBOBJ,
-    unsupported_attr,
     VariableTracker,
 )
 from .constant import ConstantVariable
@@ -532,13 +530,13 @@ class TracebackVariable(VariableTracker):
             self.tb_next = val
         return variables.ConstantVariable.create(None)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "tb_next":
             return self.tb_next
         elif name == "tb_lineno":
-            return self.frame_summary.getattro_impl(tx, "lineno")
+            return self.frame_summary.tp_getattro_impl(tx, "lineno")
         elif name == "frame_summary":
             return self.frame_summary
         elif name == "tb_lasti":
@@ -548,7 +546,7 @@ class TracebackVariable(VariableTracker):
                 explanation="Dynamo does not support accessing the tb_lasti attribute of traceback objects.",
                 hints=[*graph_break_hints.SUPPORTABLE],
             )
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
@@ -740,7 +738,7 @@ class ExceptionVariable(VariableTracker):
         else:
             return super().call_method(tx, name, args, kwargs)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "__class__":
@@ -765,7 +763,7 @@ class ExceptionVariable(VariableTracker):
             # to the generic lookup that finds nothing means the attribute is
             # genuinely absent -- match CPython's BaseException tp_getattro
             # (PyObject_GenericGetAttr) and raise AttributeError.
-            return super().getattro_impl(tx, name)
+            return super().tp_getattro_impl(tx, name)
         except NotImplementedError:
             raise_observed_exception(
                 AttributeError,
@@ -818,12 +816,12 @@ class StopIterationVariable(ExceptionVariable):
         self.value = args[0] if args else variables.ConstantVariable.create(None)
         super().__init__(exc_type, args, init_kwargs, source, mutation_type)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "value":
             return self.value
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 class _KwargAttrExceptionVariable(ExceptionVariable):
@@ -846,12 +844,12 @@ class _KwargAttrExceptionVariable(ExceptionVariable):
         self._attrs = {name: init_kwargs.pop(name, none) for name in self._kwarg_attrs}
         super().__init__(exc_type, args, init_kwargs, source, mutation_type)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name in self._attrs:
             return self._attrs[name]
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         super().reconstruct(codegen)
@@ -2662,12 +2660,12 @@ class ContextVarVariable(VariableTracker):
         except LookupError:
             raise_observed_exception(LookupError, tx, args=[f"{self.cv_obj!r}"])
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> "VariableTracker":
         if name == "name":
             return ConstantVariable.create(self.cv_obj.name)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 class RandomClassVariable(VariableTracker):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -202,7 +202,7 @@ class SuperVariable(VariableTracker):
             ],
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # Check if getattr is a constant. If not, delay the actual work by
@@ -532,42 +532,25 @@ class TracebackVariable(VariableTracker):
             self.tb_next = val
         return variables.ConstantVariable.create(None)
 
-    def _get_tb_next(self, tx: "InstructionTranslatorBase"):
-        return self.tb_next
-
-    def _set_tb_next(self, tx: "InstructionTranslatorBase", val):
-        if not self.is_valid_traceback(val):
-            raise_observed_exception(TypeError, tx)
-        if not isinstance(val, (TracebackVariable, ConstantVariable)):
-            raise AssertionError(
-                f"tb_next val must be TracebackVariable or ConstantVariable, got {type(val)}"
+    def getattro_impl(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        if name == "tb_next":
+            return self.tb_next
+        elif name == "tb_lineno":
+            return self.frame_summary.getattro_impl(tx, "lineno")
+        elif name == "frame_summary":
+            return self.frame_summary
+        elif name == "tb_lasti":
+            unimplemented(
+                gb_type="traceback.tb_lasti not supported",
+                context=f"{self} accessing 'tb_lasti'",
+                explanation="Dynamo does not support accessing the tb_lasti attribute of traceback objects.",
+                hints=[*graph_break_hints.SUPPORTABLE],
             )
-        if self.has_reference_cycle(val) or (
-            istype(val, TracebackVariable) and val.has_reference_cycle(self)
-        ):
-            raise_observed_exception(ValueError, tx)
-        self.tb_next = val
-        return variables.ConstantVariable.create(None)
+        return super().getattro_impl(tx, name)
 
-    def _get_tb_lineno(self, tx: "InstructionTranslatorBase"):
-        return self.frame_summary.getattro_impl(tx, "lineno")
-
-    # ref: CPython Objects/traceback.c tb_getsetters. `tb_next` is a getset with
-    # getter+setter (tb_next_get / tb_next_set, which runs a reference-cycle
-    # check); `tb_lineno` is a get-only getset. `frame_summary` is dynamo-internal
-    # (not a real CPython traceback attribute).
-    tp_getset = {
-        "tb_next": GetSet(_get_tb_next, _set_tb_next),
-        "tb_lineno": GetSet(_get_tb_lineno, None),
-        "frame_summary": GetSet(getset_read(lambda s: s.frame_summary)),
-    }
-
-    # ref: CPython Objects/traceback.c tb_memberlist.
-    tp_members = {
-        "tb_lasti": Member(unsupported_attr("tb_lasti")),
-    }
-
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import object_richcompare
@@ -654,7 +637,7 @@ class ExceptionVariable(VariableTracker):
     def python_type(self) -> type:
         return self.exc_type
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import object_richcompare
@@ -669,27 +652,113 @@ class ExceptionVariable(VariableTracker):
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
         if name == "__setattr__":
-            attr = args[0].as_python_constant()
-            # Writable attributes route through their tp_getset/tp_members
-            # setter. Anything else becomes a custom instance-dict attribute.
-            getset = self.lookup_tp_getset_member(attr)
-            if getset is not None and getset.setter is not None:
-                result = getset.setter(self, tx, args[1])
-                if result is not None:
-                    return result
+            name = args[0].as_python_constant()
+            val = args[1]
+            if name == "__context__":
+                # Constant can be either an Exceptior or None
+                if not (
+                    val.is_constant_none()
+                    or isinstance(
+                        val,
+                        (
+                            variables.ExceptionVariable,
+                            variables.UserDefinedExceptionClassVariable,
+                            variables.UserDefinedExceptionObjectVariable,
+                        ),
+                    )
+                ):
+                    raise_type_error(
+                        tx,
+                        "exception context must be None or derive from BaseException",
+                    )
+                self.set_context(val)
+            elif name == "__cause__":
+                if val.is_constant_none() or isinstance(
+                    val,
+                    (
+                        variables.BuiltinVariable,
+                        variables.ExceptionVariable,
+                        variables.UserDefinedExceptionClassVariable,
+                        variables.UserDefinedExceptionObjectVariable,
+                    ),
+                ):
+                    self.__cause__ = val
+                    self.__suppress_context__ = variables.ConstantVariable.create(True)
+                else:
+                    raise_type_error(
+                        tx, "exception cause must be None or derive from BaseException"
+                    )
+            elif name == "__suppress_context__":
+                if val.is_constant_match(True, False):
+                    self.__suppress_context__ = val
+                else:
+                    raise_type_error(
+                        tx, "exception cause must be None or derive from BaseException"
+                    )
+            elif name == "__traceback__":
+                if not TracebackVariable.is_valid_traceback(val):
+                    raise_type_error(tx, "__traceback__ must be a traceback or None")
+                self.__traceback__ = val
+            elif name == "args":
+                # CPython coerces any iterable to a tuple (PySequence_Tuple).
+                self.args = unpack_iterable(tx, val)
             else:
                 # Arbitrary user attribute -> store in the instance __dict__
                 # via the side effects table.
                 se = tx.output.side_effects
                 if not se.is_attribute_mutation(self):
                     se.track_attribute_mutation_new(self)
-                se.store_instance_dict_attr(self, attr, args[1])
+                se.store_instance_dict_attr(self, name, val)
             return variables.ConstantVariable.create(None)
-        return super().call_method(tx, name, args, kwargs)
+        elif name == "__setstate__":
+            if len(args) != 1:
+                raise_type_error(
+                    tx, f"__setstate__() takes exactly one argument ({len(args)} given)"
+                )
+            [state] = args
+            # BaseException.__setstate__(None) is a documented no-op.
+            if state.is_constant_none():
+                return variables.ConstantVariable.create(None)
+            if not isinstance(state, variables.ConstDictVariable):
+                raise_type_error(tx, "state is not a dictionary")
+            for key, value in state.keys_as_python_constant().items():
+                self.call_method(
+                    tx, "__setattr__", [ConstantVariable.create(key), value], {}
+                )
+            return variables.ConstantVariable.create(None)
+        elif name == "with_traceback":
+            if len(args) != 1:
+                raise_type_error(
+                    tx,
+                    f"with_traceback() takes exactly one argument ({len(args)} given)",
+                )
+            [tb] = args
+            if not TracebackVariable.is_valid_traceback(tb):
+                raise_type_error(tx, "__traceback__ must be a traceback or None")
+            self.__traceback__ = tb
+            return self
+        else:
+            return super().call_method(tx, name, args, kwargs)
 
     def getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
+        if name == "__class__":
+            return VariableTracker.build(tx, self.exc_type)
+        elif name == "__context__":
+            return self.__context__
+        elif name == "__cause__":
+            return self.__cause__
+        elif name == "__suppress_context__":
+            return self.__suppress_context__
+        elif name == "__traceback__":
+            return self.__traceback__
+        elif name == "args":
+            return VariableTracker.build(
+                tx,
+                tuple(self.args),
+                source=self.source and AttrSource(self.source, "args"),
+            )
         try:
             # Custom attributes are stored in the side effects instance dict and
             # resolved by generic_getattr before reaching here, so a fall-through
@@ -704,130 +773,7 @@ class ExceptionVariable(VariableTracker):
                 args=[f"'{self.exc_type.__name__}' object has no attribute '{name}'"],
             )
 
-    def _set_context(self, tx: "InstructionTranslatorBase", val):
-        # Constant can be either an Exception or None
-        if not (
-            val.is_constant_none()
-            or isinstance(
-                val,
-                (
-                    variables.ExceptionVariable,
-                    variables.UserDefinedExceptionClassVariable,
-                    variables.UserDefinedExceptionObjectVariable,
-                ),
-            )
-        ):
-            raise_type_error(
-                tx, "exception context must be None or derive from BaseException"
-            )
-        self.set_context(val)
-        return variables.ConstantVariable.create(None)
-
-    def _set_cause(self, tx: "InstructionTranslatorBase", val):
-        if val.is_constant_none() or isinstance(
-            val,
-            (
-                variables.BuiltinVariable,
-                variables.ExceptionVariable,
-                variables.UserDefinedExceptionClassVariable,
-                variables.UserDefinedExceptionObjectVariable,
-            ),
-        ):
-            self.__cause__ = val
-            self.__suppress_context__ = variables.ConstantVariable.create(True)
-        else:
-            raise_type_error(
-                tx, "exception cause must be None or derive from BaseException"
-            )
-        return variables.ConstantVariable.create(None)
-
-    def _set_suppress_context(self, tx: "InstructionTranslatorBase", val):
-        if val.is_constant_match(True, False):
-            self.__suppress_context__ = val
-        else:
-            raise_type_error(
-                tx, "exception cause must be None or derive from BaseException"
-            )
-        return variables.ConstantVariable.create(None)
-
-    def _set_traceback(self, tx: "InstructionTranslatorBase", val):
-        if not TracebackVariable.is_valid_traceback(val):
-            raise_type_error(tx, "__traceback__ must be a traceback or None")
-        self.__traceback__ = val
-        return variables.ConstantVariable.create(None)
-
-    def with_traceback(
-        self,
-        tx: "InstructionTranslatorBase",
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        if len(args) != 1:
-            raise_type_error(
-                tx,
-                f"with_traceback() takes exactly one argument ({len(args)} given)",
-            )
-        [tb] = args
-        if not TracebackVariable.is_valid_traceback(tb):
-            raise_type_error(tx, "__traceback__ must be a traceback or None")
-        self.__traceback__ = tb
-        return self
-
-    def setstate(
-        self,
-        tx: "InstructionTranslatorBase",
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        if len(args) != 1:
-            raise_type_error(
-                tx, f"__setstate__() takes exactly one argument ({len(args)} given)"
-            )
-        [state] = args
-        # BaseException.__setstate__(None) is a documented no-op.
-        if state.is_constant_none():
-            return variables.ConstantVariable.create(None)
-        if not isinstance(state, variables.ConstDictVariable):
-            raise_type_error(tx, "state is not a dictionary")
-        for key, value in state.keys_as_python_constant().items():
-            self.call_method(
-                tx, "__setattr__", [ConstantVariable.create(key), value], {}
-            )
-        return variables.ConstantVariable.create(None)
-
-    tp_methods = {
-        "with_traceback": Method(with_traceback),
-        "__setstate__": Method(setstate),
-    }
-
-    def _get_args(self, tx: "InstructionTranslatorBase"):
-        return VariableTracker.build(
-            tx,
-            tuple(self.args),
-            source=self.source and AttrSource(self.source, "args"),
-        )
-
-    def _set_args(self, tx: "InstructionTranslatorBase", val):
-        # CPython coerces any iterable to a tuple (PySequence_Tuple).
-        self.args = unpack_iterable(tx, val)
-        return variables.ConstantVariable.create(None)
-
-    tp_getset = {
-        "__class__": GetSet(getset_build(lambda s: s.exc_type)),
-        "__context__": GetSet(getset_read(lambda s: s.__context__), _set_context),
-        "__cause__": GetSet(getset_read(lambda s: s.__cause__), _set_cause),
-        "__traceback__": GetSet(getset_read(lambda s: s.__traceback__), _set_traceback),
-        "args": GetSet(_get_args, _set_args),
-    }
-    # __suppress_context__ is a writable PyMemberDef on BaseException, not a
-    # getset, so it lives in tp_members.
-    tp_members = {
-        "__suppress_context__": Member(
-            getset_read(lambda s: s.__suppress_context__), _set_suppress_context
-        ),
-    }
-
-    def str_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_str_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/exceptions.c#L118-L129
         if len(self.args) == 0:
             return VariableTracker.build(tx, "")
@@ -855,7 +801,7 @@ class ExceptionVariable(VariableTracker):
         args = ", ".join(self._debug_format_arg(arg) for arg in self.args)
         return f"{self.python_type_name()}({args})"
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # ref: BaseException_repr in https://github.com/python/cpython/blob/3.13/Objects/exceptions.c#L135-L142
         return VariableTracker.build(tx, self.debug_repr())
 
@@ -872,10 +818,12 @@ class StopIterationVariable(ExceptionVariable):
         self.value = args[0] if args else variables.ConstantVariable.create(None)
         super().__init__(exc_type, args, init_kwargs, source, mutation_type)
 
-    # ref: StopIteration_members in CPython Objects/exceptions.c
-    tp_members = {
-        "value": Member(getset_read(lambda s: s.value)),
-    }
+    def getattro_impl(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        if name == "value":
+            return self.value
+        return super().getattro_impl(tx, name)
 
 
 class _KwargAttrExceptionVariable(ExceptionVariable):
@@ -897,6 +845,13 @@ class _KwargAttrExceptionVariable(ExceptionVariable):
         none = variables.ConstantVariable.create(None)
         self._attrs = {name: init_kwargs.pop(name, none) for name in self._kwarg_attrs}
         super().__init__(exc_type, args, init_kwargs, source, mutation_type)
+
+    def getattro_impl(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        if name in self._attrs:
+            return self._attrs[name]
+        return super().getattro_impl(tx, name)
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         super().reconstruct(codegen)
@@ -969,7 +924,7 @@ class ComptimeVariable(VariableTracker):
     def reconstruct(self, codegen: "PyCodegen") -> None:
         raise NotImplementedError("comptime is special form")
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         from ..comptime import comptime
@@ -1502,7 +1457,7 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
             self.saved_tensors.tensors.append(arg)
         return variables.ConstantVariable.create(None)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name in ["save_for_backward", "mark_dirty", "mark_non_differentiable"]:
@@ -1516,7 +1471,7 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
         if name == "saved_tensors" and self.saved_tensors is not None:
             return variables.TupleVariable(list(self.saved_tensors.tensors))
 
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 class AutogradEngineVariable(UserDefinedObjectVariable):
@@ -1682,13 +1637,13 @@ class GetAttrVariable(VariableTracker):
         codegen(self.obj)
         codegen.extend_output(codegen.create_load_attrs(self.name))
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import generic_richcompare
 
         try:
-            resolved = self.obj.getattro_impl(tx, self.name)
+            resolved = self.obj.tp_getattro_impl(tx, self.name)
         except NotImplementedError:
             resolved = None
         if resolved is None or isinstance(resolved, GetAttrVariable):
@@ -1698,7 +1653,7 @@ class GetAttrVariable(VariableTracker):
             else:
                 unimplemented(
                     gb_type="Unresolved GetAttrVariable comparison",
-                    context=f"richcompare_impl {self} {op}",
+                    context=f"tp_richcompare_impl {self} {op}",
                     explanation=f"Cannot compare {self} because the attribute "
                     f"could not be resolved to a concrete value.",
                     hints=[*graph_break_hints.SUPPORTABLE],
@@ -1763,7 +1718,7 @@ class CallMethodVariable(VariableTracker):
         except AsPythonConstantNotImplementedError:
             return id(self), True
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -1813,7 +1768,7 @@ class PythonModuleVariable(VariableTracker):
     def __repr__(self) -> str:
         return f"PythonModuleVariable({self.value})"
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if tx.output.side_effects.has_pending_mutation_of_attr(self, name):
@@ -1831,7 +1786,7 @@ class PythonModuleVariable(VariableTracker):
         source = self.source and AttrSource(self.source, name)
         return VariableTracker.build(tx, attr_value, source)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import object_richcompare
@@ -1860,7 +1815,7 @@ class TypingVariable(VariableTracker):
         new_typing = self.value[key.as_python_constant()]
         return TypingVariable(new_typing)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         if op in ("__eq__", "__ne__"):
@@ -1906,7 +1861,7 @@ class TypingVariable(VariableTracker):
             return VariableTracker.build(tx, NotImplemented)
         return VariableTracker.build(tx, result)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         from .builder import SourcelessBuilder, VariableBuilder
@@ -2004,7 +1959,7 @@ class NumpyVariable(VariableTracker):
     def get_real_python_backed_value(self) -> Any:
         return self.value
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -2304,7 +2259,7 @@ class ObjectVariable(VariableTracker):
     def python_type(self) -> type[object]:
         return object
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import object_richcompare
@@ -2525,7 +2480,7 @@ class ConstantLikeVariable(VariableTracker):
     def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         return hash(self.value), False
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import python_constant_richcompare_impl
@@ -2571,7 +2526,7 @@ class ConstantLikeVariable(VariableTracker):
             ],
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         result = getattr(self.value, name)
@@ -2707,8 +2662,12 @@ class ContextVarVariable(VariableTracker):
         except LookupError:
             raise_observed_exception(LookupError, tx, args=[f"{self.cv_obj!r}"])
 
-    # contextvars.ContextVar.name is a read-only member.
-    tp_members = {"name": Member(getset_build(lambda s: s.cv_obj.name))}
+    def getattro_impl(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> "VariableTracker":
+        if name == "name":
+            return ConstantVariable.create(self.cv_obj.name)
+        return super().getattro_impl(tx, name)
 
 
 class RandomClassVariable(VariableTracker):
@@ -3053,7 +3012,7 @@ class WeakRefVariable(VariableTracker):
 
         return generic_hash_impl(tx, self.referent_vt)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import generic_richcompare

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -191,7 +191,7 @@ class SuperVariable(VariableTracker):
             ],
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # Check if getattr is a constant. If not, delay the actual work by
@@ -441,7 +441,7 @@ class FrameSummaryVariable(VariableTracker):
     def python_type(self) -> type:
         return traceback.FrameSummary
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "lineno":
@@ -452,7 +452,7 @@ class FrameSummaryVariable(VariableTracker):
             return VariableTracker.build(tx, self.frame_summary.name)
         elif name == "line":
             return VariableTracker.build(tx, self.frame_summary.line)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 class TracebackVariable(VariableTracker):
@@ -525,13 +525,13 @@ class TracebackVariable(VariableTracker):
             self.tb_next = val
         return variables.ConstantVariable.create(None)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "tb_next":
             return self.tb_next
         elif name == "tb_lineno":
-            return self.frame_summary.getattro_impl(tx, "lineno")
+            return self.frame_summary.tp_getattro_impl(tx, "lineno")
         elif name == "frame_summary":
             return self.frame_summary
         elif name == "tb_lasti":
@@ -541,9 +541,9 @@ class TracebackVariable(VariableTracker):
                 explanation="Dynamo does not support accessing the tb_lasti attribute of traceback objects.",
                 hints=[*graph_break_hints.SUPPORTABLE],
             )
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import object_richcompare
@@ -630,7 +630,7 @@ class ExceptionVariable(VariableTracker):
     def python_type(self) -> type:
         return self.exc_type
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import object_richcompare
@@ -733,7 +733,7 @@ class ExceptionVariable(VariableTracker):
         else:
             return super().call_method(tx, name, args, kwargs)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "__class__":
@@ -758,7 +758,7 @@ class ExceptionVariable(VariableTracker):
             # to the generic lookup that finds nothing means the attribute is
             # genuinely absent -- match CPython's BaseException tp_getattro
             # (PyObject_GenericGetAttr) and raise AttributeError.
-            return super().getattro_impl(tx, name)
+            return super().tp_getattro_impl(tx, name)
         except NotImplementedError:
             raise_observed_exception(
                 AttributeError,
@@ -766,7 +766,7 @@ class ExceptionVariable(VariableTracker):
                 args=[f"'{self.exc_type.__name__}' object has no attribute '{name}'"],
             )
 
-    def str_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_str_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/exceptions.c#L118-L129
         if len(self.args) == 0:
             return VariableTracker.build(tx, "")
@@ -794,7 +794,7 @@ class ExceptionVariable(VariableTracker):
         args = ", ".join(self._debug_format_arg(arg) for arg in self.args)
         return f"{self.python_type_name()}({args})"
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # ref: BaseException_repr in https://github.com/python/cpython/blob/3.13/Objects/exceptions.c#L135-L142
         return VariableTracker.build(tx, self.debug_repr())
 
@@ -811,12 +811,12 @@ class StopIterationVariable(ExceptionVariable):
         self.value = args[0] if args else variables.ConstantVariable.create(None)
         super().__init__(exc_type, args, init_kwargs, source, mutation_type)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name == "value":
             return self.value
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 class _KwargAttrExceptionVariable(ExceptionVariable):
@@ -839,12 +839,12 @@ class _KwargAttrExceptionVariable(ExceptionVariable):
         self._attrs = {name: init_kwargs.pop(name, none) for name in self._kwarg_attrs}
         super().__init__(exc_type, args, init_kwargs, source, mutation_type)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name in self._attrs:
             return self._attrs[name]
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         super().reconstruct(codegen)
@@ -912,7 +912,7 @@ class ComptimeVariable(VariableTracker):
     def reconstruct(self, codegen: "PyCodegen") -> None:
         raise NotImplementedError("comptime is special form")
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         from ..comptime import comptime
@@ -1445,7 +1445,7 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
             self.saved_tensors.tensors.append(arg)
         return variables.ConstantVariable.create(None)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name in ["save_for_backward", "mark_dirty", "mark_non_differentiable"]:
@@ -1459,7 +1459,7 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
         if name == "saved_tensors" and self.saved_tensors is not None:
             return variables.TupleVariable(list(self.saved_tensors.tensors))
 
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 class AutogradEngineVariable(UserDefinedObjectVariable):
@@ -1625,13 +1625,13 @@ class GetAttrVariable(VariableTracker):
         codegen(self.obj)
         codegen.extend_output(codegen.create_load_attrs(self.name))
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import generic_richcompare
 
         try:
-            resolved = self.obj.getattro_impl(tx, self.name)
+            resolved = self.obj.tp_getattro_impl(tx, self.name)
         except NotImplementedError:
             resolved = None
         if resolved is None or isinstance(resolved, GetAttrVariable):
@@ -1641,7 +1641,7 @@ class GetAttrVariable(VariableTracker):
             else:
                 unimplemented(
                     gb_type="Unresolved GetAttrVariable comparison",
-                    context=f"richcompare_impl {self} {op}",
+                    context=f"tp_richcompare_impl {self} {op}",
                     explanation=f"Cannot compare {self} because the attribute "
                     f"could not be resolved to a concrete value.",
                     hints=[*graph_break_hints.SUPPORTABLE],
@@ -1706,7 +1706,7 @@ class CallMethodVariable(VariableTracker):
         except AsPythonConstantNotImplementedError:
             return id(self), True
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -1756,7 +1756,7 @@ class PythonModuleVariable(VariableTracker):
     def __repr__(self) -> str:
         return f"PythonModuleVariable({self.value})"
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if tx.output.side_effects.has_pending_mutation_of_attr(self, name):
@@ -1774,7 +1774,7 @@ class PythonModuleVariable(VariableTracker):
         source = self.source and AttrSource(self.source, name)
         return VariableTracker.build(tx, attr_value, source)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import object_richcompare
@@ -1803,7 +1803,7 @@ class TypingVariable(VariableTracker):
         new_typing = self.value[key.as_python_constant()]
         return TypingVariable(new_typing)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         if op in ("__eq__", "__ne__"):
@@ -1849,7 +1849,7 @@ class TypingVariable(VariableTracker):
             return VariableTracker.build(tx, NotImplemented)
         return VariableTracker.build(tx, result)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         from .builder import SourcelessBuilder, VariableBuilder
@@ -1952,7 +1952,7 @@ class NumpyVariable(VariableTracker):
     def get_real_python_backed_value(self) -> Any:
         return self.value
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -2252,7 +2252,7 @@ class ObjectVariable(VariableTracker):
     def python_type(self) -> type[object]:
         return object
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import object_richcompare
@@ -2473,7 +2473,7 @@ class ConstantLikeVariable(VariableTracker):
     def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         return hash(self.value), False
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import python_constant_richcompare_impl
@@ -2519,7 +2519,7 @@ class ConstantLikeVariable(VariableTracker):
             ],
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         result = getattr(self.value, name)
@@ -2655,12 +2655,12 @@ class ContextVarVariable(VariableTracker):
         except LookupError:
             raise_observed_exception(LookupError, tx, args=[f"{self.cv_obj!r}"])
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> "VariableTracker":
         if name == "name":
             return ConstantVariable.create(self.cv_obj.name)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 class RandomClassVariable(VariableTracker):
@@ -2949,7 +2949,7 @@ class WeakRefVariable(VariableTracker):
 
         return generic_hash_impl(tx, self.referent_vt)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: "VariableTracker", op: str
     ) -> "VariableTracker":
         from .object_protocol import generic_richcompare

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -300,7 +300,7 @@ class NNModuleVariable(VariableTracker):
     def get_real_python_backed_value(self) -> object:
         return self.value
 
-    def bool_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def nb_bool_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """nb_bool for nn.Module.
 
         nn.Module itself has no __bool__ or __len__, so bare modules are always
@@ -313,7 +313,7 @@ class NNModuleVariable(VariableTracker):
         mod = tx.output.get_submodule(self.module_key)
         return ConstantVariable.create(bool(mod))
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         mod = tx.output.get_submodule(self.module_key)
         return VariableTracker.build(tx, repr(mod))
 
@@ -410,7 +410,7 @@ class NNModuleVariable(VariableTracker):
             except Unsupported:
                 unimplemented(
                     gb_type="Custom __getattribute__ in nn.Module attribute access",
-                    context=f"getattro_impl {self} {name}",
+                    context=f"tp_getattro_impl {self} {name}",
                     explanation="Dynamo could not trace through the custom "
                     "`__getattribute__` method on this `nn.Module`.",
                     hints=[
@@ -427,7 +427,7 @@ class NNModuleVariable(VariableTracker):
         if not isinstance(getattr_fn, types.FunctionType):
             unimplemented(
                 gb_type="torch.nn.Module with a non-function custom __getattr__",
-                context=f"getattro_impl {self} {name}",
+                context=f"tp_getattro_impl {self} {name}",
                 explanation=(
                     "Dynamo detected a nn.Module object with a custom "
                     "`__getattr__` method, but this method is not a standard "
@@ -449,7 +449,7 @@ class NNModuleVariable(VariableTracker):
             tx, [VariableTracker.build(tx, name)], {}
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         source = self.source and AttrSource(self.source, name)
@@ -467,7 +467,7 @@ class NNModuleVariable(VariableTracker):
         if not self.source:
             unimplemented(
                 gb_type="getattr with no source",
-                context=f"getattro_impl {self} {name}",
+                context=f"tp_getattro_impl {self} {name}",
                 explanation="Dynamo does not know how to access an attribute "
                 "on an `nn.Module` instance that lacks a source. This is "
                 "usually an internal error in Dynamo.",
@@ -566,7 +566,7 @@ class NNModuleVariable(VariableTracker):
                     ],
                 )
 
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def call_function(
         self,
@@ -1180,7 +1180,7 @@ class NNModuleVariable(VariableTracker):
         else:
             return super().call_method(tx, name, list(args), kwargs)
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         """Sequence length for container modules (e.g., nn.Sequential)."""
         module = tx.output.get_submodule(self.module_key)
         return VariableTracker.build(tx, len(module))  # type: ignore[arg-type]
@@ -1312,7 +1312,7 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 globals_vt = tx.nn_modules_globals_vt
 
                 def _hooks_dict_len(obj: VariableTracker, attr: str) -> int:
-                    vt = obj.getattro_impl(tx, attr)
+                    vt = obj.tp_getattro_impl(tx, attr)
                     vt = vt.realize() if hasattr(vt, "realize") else vt
                     return vt.len()  # type: ignore[union-attr]
 
@@ -1467,14 +1467,14 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
     def getattr_helper(
         self, tx: "InstructionTranslatorBase", field: str, name_vt: VariableTracker
     ) -> VariableTracker | None:
-        dict_vt = self.getattro_impl(tx, field)
+        dict_vt = self.tp_getattro_impl(tx, field)
         if isinstance(dict_vt, variables.UserDefinedDictVariable):
             dict_vt = dict_vt._base_vt
         if isinstance(dict_vt, variables.ConstDictVariable):
             return dict_vt.maybe_getitem_const(name_vt)
         return None
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if (
@@ -1569,7 +1569,7 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
             )
 
             return variables.NNModuleHooksDictVariable(result, source=hooks_dict_source)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def manually_trace_nn_module_getattr(
         self, tx: "InstructionTranslatorBase", name: str

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -303,7 +303,7 @@ class NNModuleVariable(VariableTracker):
     def get_real_python_backed_value(self) -> object:
         return self.value
 
-    def bool_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def nb_bool_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """nb_bool for nn.Module.
 
         nn.Module itself has no __bool__ or __len__, so bare modules are always
@@ -316,7 +316,7 @@ class NNModuleVariable(VariableTracker):
         mod = tx.output.get_submodule(self.module_key)
         return ConstantVariable.create(bool(mod))
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         mod = tx.output.get_submodule(self.module_key)
         return VariableTracker.build(tx, repr(mod))
 
@@ -413,7 +413,7 @@ class NNModuleVariable(VariableTracker):
             except Unsupported:
                 unimplemented(
                     gb_type="Custom __getattribute__ in nn.Module attribute access",
-                    context=f"getattro_impl {self} {name}",
+                    context=f"tp_getattro_impl {self} {name}",
                     explanation="Dynamo could not trace through the custom "
                     "`__getattribute__` method on this `nn.Module`.",
                     hints=[
@@ -430,7 +430,7 @@ class NNModuleVariable(VariableTracker):
         if not isinstance(getattr_fn, types.FunctionType):
             unimplemented(
                 gb_type="torch.nn.Module with a non-function custom __getattr__",
-                context=f"getattro_impl {self} {name}",
+                context=f"tp_getattro_impl {self} {name}",
                 explanation=(
                     "Dynamo detected a nn.Module object with a custom "
                     "`__getattr__` method, but this method is not a standard "
@@ -452,7 +452,7 @@ class NNModuleVariable(VariableTracker):
             tx, [VariableTracker.build(tx, name)], {}
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         source = self.source and AttrSource(self.source, name)
@@ -470,7 +470,7 @@ class NNModuleVariable(VariableTracker):
         if not self.source:
             unimplemented(
                 gb_type="getattr with no source",
-                context=f"getattro_impl {self} {name}",
+                context=f"tp_getattro_impl {self} {name}",
                 explanation="Dynamo does not know how to access an attribute "
                 "on an `nn.Module` instance that lacks a source. This is "
                 "usually an internal error in Dynamo.",
@@ -569,7 +569,7 @@ class NNModuleVariable(VariableTracker):
                     ],
                 )
 
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def call_function(
         self,
@@ -1183,7 +1183,7 @@ class NNModuleVariable(VariableTracker):
         else:
             return super().call_method(tx, name, list(args), kwargs)
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         """Sequence length for container modules (e.g., nn.Sequential)."""
         module = tx.output.get_submodule(self.module_key)
         return VariableTracker.build(tx, len(module))  # type: ignore[arg-type]
@@ -1315,7 +1315,7 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 globals_vt = tx.nn_modules_globals_vt
 
                 def _hooks_dict_len(obj: VariableTracker, attr: str) -> int:
-                    vt = obj.getattro_impl(tx, attr)
+                    vt = obj.tp_getattro_impl(tx, attr)
                     vt = vt.realize() if hasattr(vt, "realize") else vt
                     return vt.len()  # type: ignore[union-attr]
 
@@ -1470,14 +1470,14 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
     def getattr_helper(
         self, tx: "InstructionTranslatorBase", field: str, name_vt: VariableTracker
     ) -> VariableTracker | None:
-        dict_vt = self.getattro_impl(tx, field)
+        dict_vt = self.tp_getattro_impl(tx, field)
         if isinstance(dict_vt, variables.UserDefinedDictVariable):
             dict_vt = dict_vt._base_vt
         if isinstance(dict_vt, variables.ConstDictVariable):
             return dict_vt.maybe_getitem_const(name_vt)
         return None
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if (
@@ -1572,7 +1572,7 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
             )
 
             return variables.NNModuleHooksDictVariable(result, source=hooks_dict_source)
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def manually_trace_nn_module_getattr(
         self, tx: "InstructionTranslatorBase", name: str

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -3,7 +3,7 @@ Dynamo implementations of CPython's PyObject_* default slot algorithms.
 
 Analogous to CPython's Objects/object.c, this module holds the general
 dispatch machinery that is independent of any specific type.
-Per-type hook implementations (bool_impl, richcompare_impl, getattro_impl,
+Per-type hook implementations (nb_bool_impl, tp_richcompare_impl, tp_getattro_impl,
 etc.) live in their respective VT files.
 """
 
@@ -351,7 +351,7 @@ def pymapping_size(
 ) -> "VariableTracker":
     # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/abstract.c#L2308-L2330
     if obj.tp_as_mapping.mp_length:
-        return obj.mp_length(tx)
+        return obj.mp_length_impl(tx)
 
     if obj.tp_as_sequence.sq_length is not None:
         raise_type_error(tx, f"{obj.python_type_name()} is not a mapping")
@@ -369,7 +369,7 @@ def generic_size(
     """
 
     if obj.tp_as_sequence.sq_length:
-        return obj.sq_length(tx)
+        return obj.sq_length_impl(tx)
     return pymapping_size(tx, obj)
 
 
@@ -391,7 +391,7 @@ def generic_is_true(
             raise_observed_exception(type(e), tx, args=[str(e)])
 
     if obj.tp_as_number.nb_bool:
-        result = obj.bool_impl(tx)
+        result = obj.nb_bool_impl(tx)
         if result is not None:
             return result
 
@@ -435,7 +435,7 @@ def generic_repr(
             return ConstantVariable.create(sentinel.get(obj_type, "..."))
         _repr_running.add(obj_id)
         try:
-            result = obj.repr_impl(tx)
+            result = obj.tp_repr_impl(tx)
         finally:
             _repr_running.discard(obj_id)
         result_type = maybe_get_python_type(result)
@@ -457,7 +457,7 @@ def generic_str(
 
     https://github.com/python/cpython/blob/v3.13.3/Objects/object.c#L781-L829
 
-    Resolution order: str identity check -> tp_str (str_impl) -> tp_repr fallback.
+    Resolution order: str identity check -> tp_str (tp_str_impl) -> tp_repr fallback.
     """
     from ..exc import TorchDynamoException
 
@@ -465,8 +465,8 @@ def generic_str(
         return obj
 
     try:
-        if obj.tp_str and type(obj).str_impl is not VariableTracker.str_impl:
-            result = obj.str_impl(tx)
+        if obj.tp_str and type(obj).tp_str_impl is not VariableTracker.tp_str_impl:
+            result = obj.tp_str_impl(tx)
         else:
             result = generic_repr(tx, obj)
     except TorchDynamoException:
@@ -547,7 +547,7 @@ def pysequence_getitem(
             index_val = index.as_python_constant()
             if isinstance(index_val, int) and index_val < 0:
                 if obj.tp_as_sequence.sq_length is not None:
-                    length = obj.sq_length(tx)
+                    length = obj.sq_length_impl(tx)
                     index = ConstantVariable.create(
                         index_val + length.as_python_constant()
                     )
@@ -573,7 +573,7 @@ def pysequence_setitem(
             index_val = i.as_python_constant()
             if isinstance(index_val, int) and index_val < 0:
                 if s.tp_as_sequence.sq_length is not None:
-                    length = s.sq_length(tx)
+                    length = s.sq_length_impl(tx)
                     i = ConstantVariable.create(index_val + length.as_python_constant())
         return s.sq_ass_item_impl(tx, i, o)
 
@@ -622,7 +622,7 @@ def pysequence_delitem(
             idx = i.as_python_constant()
             if idx < 0:
                 if s.tp_as_sequence.sq_length is not None:
-                    length = s.sq_length(tx)
+                    length = s.sq_length_impl(tx)
                     i = pynumber_add(tx, i, length)
         return s.sq_ass_item_impl(tx, i, None)
 
@@ -798,7 +798,7 @@ def getindex(
     i = pynumber_as_ssize_t(tx, arg, err=OverflowError)
     if i.as_python_constant() < 0:
         if type_implements_sq_length(obj_type):
-            length = obj.sq_length(tx)
+            length = obj.sq_length_impl(tx)
             i = pynumber_add(tx, i, length)
     return i
 
@@ -1686,29 +1686,29 @@ def slot_wrapper_iadd(
 #
 # Dynamo implementation:
 #
-#   richcompare_impl(self, tx, other, op) -- per-VT slot, analogous to
+#   tp_richcompare_impl(self, tx, other, op) -- per-VT slot, analogous to
 #     tp_richcompare.  Returns ConstantVariable(NotImplemented) when the
 #     type does not handle the comparison.
 #
 #   generic_richcompare(tx, lhs, rhs, op) -- analogous to do_richcompare.
-#     Implements the 4-step algorithm directly using richcompare_impl
+#     Implements the 4-step algorithm directly using tp_richcompare_impl
 #     slots.  If a user comparison method graph-breaks, the Unsupported
 #     exception propagates to COMPARE_OP (which has
 #     @break_graph_if_unsupported) and runs the comparison eagerly.
-#     UDOV.richcompare_impl disables nested graph breaks on the resolved
+#     UDOV.tp_richcompare_impl disables nested graph breaks on the resolved
 #     funcvar so the InliningInstructionTranslator does not try to split
 #     the inlined user method mid-function.
 #
-# Two entry points converge on richcompare_impl:
+# Two entry points converge on tp_richcompare_impl:
 #
 #   COMPARE_OP (a == b):
 #     -> BuiltinVariable dispatch -> generic_richcompare
-#       -> richcompare_impl (4-step: subclass priority, forward, reflected, fallback)
+#       -> tp_richcompare_impl (4-step: subclass priority, forward, reflected, fallback)
 #
 #   call_method("__eq__") (a.__eq__(b) in user code):
-#     -> base.py call_method -> richcompare_impl directly
+#     -> base.py call_method -> tp_richcompare_impl directly
 #
-# The call_method path calls richcompare_impl directly (not
+# The call_method path calls tp_richcompare_impl directly (not
 # generic_richcompare) to match CPython semantics: a.__eq__(b) invokes
 # the type's tp_richcompare slot without do_richcompare's reflected-
 # operand protocol, and may return NotImplemented.
@@ -1740,7 +1740,7 @@ def object_richcompare(
         # https://github.com/python/cpython/blob/e76aa128fe/Objects/typeobject.c#L6279-L6298
         # Safe to call as_python_constant(): only identity-based types use
         # object_richcompare, so eq_result is always True or NotImplemented.
-        eq_result = self.richcompare_impl(tx, other, "__eq__")
+        eq_result = self.tp_richcompare_impl(tx, other, "__eq__")
         if is_richcompare_not_implemented(eq_result):
             return eq_result
         return ConstantVariable.create(not eq_result.as_python_constant())
@@ -1796,9 +1796,9 @@ def generic_richcompare(
 
     https://github.com/python/cpython/blob/e76aa128fe/Objects/object.c#L994-L1039
 
-    Implements the 4-step algorithm directly using richcompare_impl slots.
+    Implements the 4-step algorithm directly using tp_richcompare_impl slots.
     Graph breaks inside user comparison methods propagate to COMPARE_OP
-    (which runs eagerly) because UDOV.richcompare_impl disables nested
+    (which runs eagerly) because UDOV.tp_richcompare_impl disables nested
     graph breaks on the resolved funcvar.
     """
     reflected = _REFLECTED_OP[op]
@@ -1822,18 +1822,18 @@ def generic_richcompare(
         and issubclass(w_type, v_type)
     ):
         checked_reverse = True
-        result = w.richcompare_impl(tx, v, reflected)
+        result = w.tp_richcompare_impl(tx, v, reflected)
         if not is_richcompare_not_implemented(result):
             return result
 
     # Step 2: forward
-    result = v.richcompare_impl(tx, w, op)
+    result = v.tp_richcompare_impl(tx, w, op)
     if not is_richcompare_not_implemented(result):
         return result
 
     # Step 3: reflected (if not already tried)
     if not checked_reverse:
-        result = w.richcompare_impl(tx, v, reflected)
+        result = w.tp_richcompare_impl(tx, v, reflected)
         if not is_richcompare_not_implemented(result):
             return result
 
@@ -1918,13 +1918,13 @@ def pysequence_contains(
     """
     Implements PySequence_Contains semantics for VariableTracker objects.
 
-    If the object has sq_contains (i.e., __contains__), calls obj.sq_contains(tx, item).
+    If the object has sq_contains (i.e., __contains__), calls obj.sq_contains_impl(tx, item).
     Otherwise falls back to iterating over obj and comparing each element.
     """
     # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/abstract.c#L2272-L2283
     sq_contains = obj.tp_as_sequence.sq_contains
     if sq_contains is not None:
-        return obj.sq_contains(tx, item)
+        return obj.sq_contains_impl(tx, item)
     else:
         # iter fallback handles both __iter__ and __getitem__ sequence protocol cases
         it = generic_getiter(tx, obj)
@@ -2060,16 +2060,16 @@ def generic_issubclass(
 #
 # Dispatch path:
 #     LOAD_ATTR / getattr() -> GetAttrBuiltinVariable -> generic_getattr
-#         -> obj.getattro_impl(tx, name)
+#         -> obj.tp_getattro_impl(tx, name)
 #
-# The base VariableTracker.getattro_impl tries object_generic_getattr()
+# The base VariableTracker.tp_getattro_impl tries object_generic_getattr()
 # first (MRO walk + descriptor protocol), falling back to const_getattr
 # on _UnhandledDescriptorError.  Callers of object_generic_getattr
 # directly must handle _UnhandledDescriptorError at every step (2, 4,
 # and 7), not just for unrecognized descriptor types.
 #
 # VTs with custom tp_getattro (TensorVariable, NNModuleVariable,
-# UserDefinedClassVariable, SuperVariable) override getattro_impl.
+# UserDefinedClassVariable, SuperVariable) override tp_getattro_impl.
 
 _NO_DEFAULT = object()
 
@@ -2260,7 +2260,7 @@ def generic_getattr(
     """Dynamo's PyObject_GetAttr: attribute access dispatch.
 
     Checks side effects for pending attribute mutations, then dispatches
-    to obj.getattro_impl(tx, name).  On NotImplementedError, falls back
+    to obj.tp_getattro_impl(tx, name).  On NotImplementedError, falls back
     to GetAttrVariable (deferred resolution).
     """
     from .user_defined import is_data_descriptor
@@ -2294,17 +2294,17 @@ def generic_getattr(
             return default  # type: ignore[return-value]
 
     # tp_getset/tp_members are data descriptors: resolve ahead of the VT's
-    # tp_getattro so a getattro_impl override need not repeat the consult.
+    # tp_getattro so a tp_getattro_impl override need not repeat the consult.
     getset = obj.lookup_tp_getset_member(name)
     if getset is not None:
         result = getset.getter(obj, tx)
         if result is not None:
             return result
 
-    # Core dispatch: call the VT's getattro_impl (tp_getattro).
+    # Core dispatch: call the VT's tp_getattro_impl (tp_getattro).
     source = obj.source and AttrSource(obj.source, name)
     try:
-        return obj.getattro_impl(tx, name)
+        return obj.tp_getattro_impl(tx, name)
     except AsPythonConstantNotImplementedError:
         raise
     except NotImplementedError:

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -3,7 +3,7 @@ Dynamo implementations of CPython's PyObject_* default slot algorithms.
 
 Analogous to CPython's Objects/object.c, this module holds the general
 dispatch machinery that is independent of any specific type.
-Per-type hook implementations (bool_impl, richcompare_impl, getattro_impl,
+Per-type hook implementations (nb_bool_impl, tp_richcompare_impl, tp_getattro_impl,
 etc.) live in their respective VT files.
 """
 
@@ -351,7 +351,7 @@ def pymapping_size(
 ) -> "VariableTracker":
     # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/abstract.c#L2308-L2330
     if obj.tp_as_mapping.mp_length:
-        return obj.mp_length(tx)
+        return obj.mp_length_impl(tx)
 
     if obj.tp_as_sequence.sq_length is not None:
         raise_type_error(tx, f"{obj.python_type_name()} is not a mapping")
@@ -369,7 +369,7 @@ def generic_size(
     """
 
     if obj.tp_as_sequence.sq_length:
-        return obj.sq_length(tx)
+        return obj.sq_length_impl(tx)
     return pymapping_size(tx, obj)
 
 
@@ -391,7 +391,7 @@ def generic_is_true(
             raise_observed_exception(type(e), tx, args=[str(e)])
 
     if obj.tp_as_number.nb_bool:
-        result = obj.bool_impl(tx)
+        result = obj.nb_bool_impl(tx)
         if result is not None:
             return result
 
@@ -435,7 +435,7 @@ def generic_repr(
             return ConstantVariable.create(sentinel.get(obj_type, "..."))
         _repr_running.add(obj_id)
         try:
-            result = obj.repr_impl(tx)
+            result = obj.tp_repr_impl(tx)
         finally:
             _repr_running.discard(obj_id)
         result_type = maybe_get_python_type(result)
@@ -457,7 +457,7 @@ def generic_str(
 
     https://github.com/python/cpython/blob/v3.13.3/Objects/object.c#L781-L829
 
-    Resolution order: str identity check -> tp_str (str_impl) -> tp_repr fallback.
+    Resolution order: str identity check -> tp_str (tp_str_impl) -> tp_repr fallback.
     """
     from ..exc import TorchDynamoException
 
@@ -465,8 +465,8 @@ def generic_str(
         return obj
 
     try:
-        if obj.tp_str and type(obj).str_impl is not VariableTracker.str_impl:
-            result = obj.str_impl(tx)
+        if obj.tp_str and type(obj).tp_str_impl is not VariableTracker.tp_str_impl:
+            result = obj.tp_str_impl(tx)
         else:
             result = generic_repr(tx, obj)
     except TorchDynamoException:
@@ -547,7 +547,7 @@ def pysequence_getitem(
             index_val = index.as_python_constant()
             if isinstance(index_val, int) and index_val < 0:
                 if obj.tp_as_sequence.sq_length is not None:
-                    length = obj.sq_length(tx)
+                    length = obj.sq_length_impl(tx)
                     index = ConstantVariable.create(
                         index_val + length.as_python_constant()
                     )
@@ -573,7 +573,7 @@ def pysequence_setitem(
             index_val = i.as_python_constant()
             if isinstance(index_val, int) and index_val < 0:
                 if s.tp_as_sequence.sq_length is not None:
-                    length = s.sq_length(tx)
+                    length = s.sq_length_impl(tx)
                     i = ConstantVariable.create(index_val + length.as_python_constant())
         return s.sq_ass_item_impl(tx, i, o)
 
@@ -622,7 +622,7 @@ def pysequence_delitem(
             idx = i.as_python_constant()
             if idx < 0:
                 if s.tp_as_sequence.sq_length is not None:
-                    length = s.sq_length(tx)
+                    length = s.sq_length_impl(tx)
                     i = pynumber_add(tx, i, length)
         return s.sq_ass_item_impl(tx, i, None)
 
@@ -798,7 +798,7 @@ def getindex(
     i = pynumber_as_ssize_t(tx, arg, err=OverflowError)
     if i.as_python_constant() < 0:
         if type_implements_sq_length(obj_type):
-            length = obj.sq_length(tx)
+            length = obj.sq_length_impl(tx)
             i = pynumber_add(tx, i, length)
     return i
 
@@ -1670,29 +1670,29 @@ def slot_wrapper_iadd(
 #
 # Dynamo implementation:
 #
-#   richcompare_impl(self, tx, other, op) -- per-VT slot, analogous to
+#   tp_richcompare_impl(self, tx, other, op) -- per-VT slot, analogous to
 #     tp_richcompare.  Returns ConstantVariable(NotImplemented) when the
 #     type does not handle the comparison.
 #
 #   generic_richcompare(tx, lhs, rhs, op) -- analogous to do_richcompare.
-#     Implements the 4-step algorithm directly using richcompare_impl
+#     Implements the 4-step algorithm directly using tp_richcompare_impl
 #     slots.  If a user comparison method graph-breaks, the Unsupported
 #     exception propagates to COMPARE_OP (which has
 #     @break_graph_if_unsupported) and runs the comparison eagerly.
-#     UDOV.richcompare_impl disables nested graph breaks on the resolved
+#     UDOV.tp_richcompare_impl disables nested graph breaks on the resolved
 #     funcvar so the InliningInstructionTranslator does not try to split
 #     the inlined user method mid-function.
 #
-# Two entry points converge on richcompare_impl:
+# Two entry points converge on tp_richcompare_impl:
 #
 #   COMPARE_OP (a == b):
 #     -> BuiltinVariable dispatch -> generic_richcompare
-#       -> richcompare_impl (4-step: subclass priority, forward, reflected, fallback)
+#       -> tp_richcompare_impl (4-step: subclass priority, forward, reflected, fallback)
 #
 #   call_method("__eq__") (a.__eq__(b) in user code):
-#     -> base.py call_method -> richcompare_impl directly
+#     -> base.py call_method -> tp_richcompare_impl directly
 #
-# The call_method path calls richcompare_impl directly (not
+# The call_method path calls tp_richcompare_impl directly (not
 # generic_richcompare) to match CPython semantics: a.__eq__(b) invokes
 # the type's tp_richcompare slot without do_richcompare's reflected-
 # operand protocol, and may return NotImplemented.
@@ -1724,7 +1724,7 @@ def object_richcompare(
         # https://github.com/python/cpython/blob/e76aa128fe/Objects/typeobject.c#L6279-L6298
         # Safe to call as_python_constant(): only identity-based types use
         # object_richcompare, so eq_result is always True or NotImplemented.
-        eq_result = self.richcompare_impl(tx, other, "__eq__")
+        eq_result = self.tp_richcompare_impl(tx, other, "__eq__")
         if is_richcompare_not_implemented(eq_result):
             return eq_result
         return ConstantVariable.create(not eq_result.as_python_constant())
@@ -1780,9 +1780,9 @@ def generic_richcompare(
 
     https://github.com/python/cpython/blob/e76aa128fe/Objects/object.c#L994-L1039
 
-    Implements the 4-step algorithm directly using richcompare_impl slots.
+    Implements the 4-step algorithm directly using tp_richcompare_impl slots.
     Graph breaks inside user comparison methods propagate to COMPARE_OP
-    (which runs eagerly) because UDOV.richcompare_impl disables nested
+    (which runs eagerly) because UDOV.tp_richcompare_impl disables nested
     graph breaks on the resolved funcvar.
     """
     reflected = _REFLECTED_OP[op]
@@ -1806,18 +1806,18 @@ def generic_richcompare(
         and issubclass(w_type, v_type)
     ):
         checked_reverse = True
-        result = w.richcompare_impl(tx, v, reflected)
+        result = w.tp_richcompare_impl(tx, v, reflected)
         if not is_richcompare_not_implemented(result):
             return result
 
     # Step 2: forward
-    result = v.richcompare_impl(tx, w, op)
+    result = v.tp_richcompare_impl(tx, w, op)
     if not is_richcompare_not_implemented(result):
         return result
 
     # Step 3: reflected (if not already tried)
     if not checked_reverse:
-        result = w.richcompare_impl(tx, v, reflected)
+        result = w.tp_richcompare_impl(tx, v, reflected)
         if not is_richcompare_not_implemented(result):
             return result
 
@@ -1902,13 +1902,13 @@ def pysequence_contains(
     """
     Implements PySequence_Contains semantics for VariableTracker objects.
 
-    If the object has sq_contains (i.e., __contains__), calls obj.sq_contains(tx, item).
+    If the object has sq_contains (i.e., __contains__), calls obj.sq_contains_impl(tx, item).
     Otherwise falls back to iterating over obj and comparing each element.
     """
     # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/abstract.c#L2272-L2283
     sq_contains = obj.tp_as_sequence.sq_contains
     if sq_contains is not None:
-        return obj.sq_contains(tx, item)
+        return obj.sq_contains_impl(tx, item)
     else:
         # iter fallback handles both __iter__ and __getitem__ sequence protocol cases
         it = generic_getiter(tx, obj)
@@ -2044,16 +2044,16 @@ def generic_issubclass(
 #
 # Dispatch path:
 #     LOAD_ATTR / getattr() -> GetAttrBuiltinVariable -> generic_getattr
-#         -> obj.getattro_impl(tx, name)
+#         -> obj.tp_getattro_impl(tx, name)
 #
-# The base VariableTracker.getattro_impl tries object_generic_getattr()
+# The base VariableTracker.tp_getattro_impl tries object_generic_getattr()
 # first (MRO walk + descriptor protocol), falling back to const_getattr
 # on _UnhandledDescriptorError.  Callers of object_generic_getattr
 # directly must handle _UnhandledDescriptorError at every step (2, 4,
 # and 7), not just for unrecognized descriptor types.
 #
 # VTs with custom tp_getattro (TensorVariable, NNModuleVariable,
-# UserDefinedClassVariable, SuperVariable) override getattro_impl.
+# UserDefinedClassVariable, SuperVariable) override tp_getattro_impl.
 
 _NO_DEFAULT = object()
 
@@ -2244,7 +2244,7 @@ def generic_getattr(
     """Dynamo's PyObject_GetAttr: attribute access dispatch.
 
     Checks side effects for pending attribute mutations, then dispatches
-    to obj.getattro_impl(tx, name).  On NotImplementedError, falls back
+    to obj.tp_getattro_impl(tx, name).  On NotImplementedError, falls back
     to GetAttrVariable (deferred resolution).
     """
     from .user_defined import is_data_descriptor
@@ -2278,17 +2278,17 @@ def generic_getattr(
             return default  # type: ignore[return-value]
 
     # tp_getset/tp_members are data descriptors: resolve ahead of the VT's
-    # tp_getattro so a getattro_impl override need not repeat the consult.
+    # tp_getattro so a tp_getattro_impl override need not repeat the consult.
     getset = obj.lookup_tp_getset_member(name)
     if getset is not None:
         result = getset.getter(obj, tx)
         if result is not None:
             return result
 
-    # Core dispatch: call the VT's getattro_impl (tp_getattro).
+    # Core dispatch: call the VT's tp_getattro_impl (tp_getattro).
     source = obj.source and AttrSource(obj.source, name)
     try:
-        return obj.getattro_impl(tx, name)
+        return obj.tp_getattro_impl(tx, name)
     except AsPythonConstantNotImplementedError:
         raise
     except NotImplementedError:

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -144,7 +144,7 @@ class OptimizerVariable(UserDefinedObjectVariable):
 
         return super().call_method(tx, name, args, kwargs)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # Note: this allows us to intercept the call in call_method
@@ -153,7 +153,7 @@ class OptimizerVariable(UserDefinedObjectVariable):
         if name in ("_init_group"):
             if not self.source:
                 raise AssertionError(
-                    "OptimizerVariable requires a source for getattro_impl"
+                    "OptimizerVariable requires a source for tp_getattro_impl"
                 )
             return GetAttrVariable(
                 self,
@@ -171,7 +171,7 @@ class OptimizerVariable(UserDefinedObjectVariable):
 
             self._set_capturable(tx)
 
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def graph_break_if_pending_mutation(self, tx: "InstructionTranslatorBase") -> None:
         # If there are pending mutations on a parameter (due to using closure)

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -103,7 +103,7 @@ class CustomClassVariable(UserDefinedVariable):
 
     def is_python_constant(self) -> bool:
         # prevents constant folding of attribute accesses on
-        # opaque classes. this ensures getattro_impl is called,
+        # opaque classes. this ensures tp_getattro_impl is called,
         # allowing for proper validation and error handling
         return False
 
@@ -134,7 +134,7 @@ class CustomClassVariable(UserDefinedVariable):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.value})"
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         obj = None
@@ -335,7 +335,7 @@ class CustomClassObjectVariable(UserDefinedObjectVariable):
 
     __repr__ = __str__
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: "VariableTracker",
@@ -366,7 +366,7 @@ class CustomClassObjectVariable(UserDefinedObjectVariable):
     @_raise_hard_error_if_graph_break(
         "Dynamo cannot safely trace script object due to graph break."
     )
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         from torch._higher_order_ops.torchbind import call_torchbind
@@ -387,7 +387,7 @@ class CustomClassObjectVariable(UserDefinedObjectVariable):
                         lambda *args, **kwargs: self.call_method(tx, name, args, kwargs)
                     )
                 else:
-                    return super().getattro_impl(tx, name)
+                    return super().tp_getattro_impl(tx, name)
 
             elif member_type == MemberType.INLINED:
                 value = getattr(real_obj, name)
@@ -400,10 +400,10 @@ class CustomClassObjectVariable(UserDefinedObjectVariable):
                     return LambdaVariable(
                         lambda *args, **kwargs: self.call_method(tx, name, args, kwargs)
                     )
-                return super().getattro_impl(tx, name)
+                return super().tp_getattro_impl(tx, name)
 
             elif is_opaque_constant_type(real_obj_type):
-                return super().getattro_impl(tx, name)
+                return super().tp_getattro_impl(tx, name)
 
             elif name in ("__bool__", "__len__") and not hasattr(real_obj, name):
                 # Special case: __bool__ and __len__ are used for truthiness checks.
@@ -446,7 +446,7 @@ class CustomClassObjectVariable(UserDefinedObjectVariable):
 
         if self.source is None:
             raise AssertionError(
-                "CustomClassObjectVariable requires a source for getattro_impl"
+                "CustomClassObjectVariable requires a source for tp_getattro_impl"
             )
         return TorchHigherOrderOperatorVariable.make(
             call_torchbind,
@@ -465,7 +465,7 @@ class CustomClassObjectVariable(UserDefinedObjectVariable):
         return CustomClassObjectVariable.call_method(self, tx, "__getitem__", [key], {})
 
     # We only support method calls on script objects. Interpreting the bytecodes
-    # should go through getattro_impl then call_function instead of call_method.
+    # should go through tp_getattro_impl then call_function instead of call_method.
 
     # However, it's possible for call_method to be used directly e.g. for __setattr__.
     @_raise_hard_error_if_graph_break(

--- a/torch/_dynamo/variables/sdpa.py
+++ b/torch/_dynamo/variables/sdpa.py
@@ -68,7 +68,7 @@ class SDPAParamsVariable(VariableTracker):
     def as_proxy(self) -> Proxy:
         return self.proxy
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         import torch._C

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -157,7 +157,7 @@ class SetVariable(VariableTracker):
     def as_python_constant(self) -> Any:
         return {k.vt.as_python_constant() for k in self.set_items}
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         # https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L763-L822
         if not self.items:
             return VariableTracker.build(tx, f"{self.python_type_name()}()")
@@ -295,7 +295,7 @@ class SetVariable(VariableTracker):
         # OrderedSet.
         return type(self)(list(items), mutation_type=ValueMutationNew())
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L2131-L2149
@@ -728,10 +728,10 @@ class SetVariable(VariableTracker):
         self.call_method(tx, "symmetric_difference_update", [other], {})
         return self
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         return VariableTracker.build(tx, len(self.set_items))
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -853,7 +853,7 @@ class OrderedSetVariable(SetVariable):
                 items.append(key_str)
             return "OrderedSet([" + ", ".join(items) + "])"
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         items = ", ".join(tracked_repr(tx, item.vt) for item in self.set_items)
         return VariableTracker.build(tx, f"{self.python_type_name()}([{items}])")
 
@@ -944,7 +944,7 @@ class FrozensetVariable(SetVariable):
     def as_python_constant(self) -> Any:
         return frozenset({k.vt.as_python_constant() for k in self.set_items})
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         # https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L763-L822
         if not self.items:
             return VariableTracker.build(tx, f"{self.python_type_name()}()")

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -506,7 +506,7 @@ class SetVariable(VariableTracker):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        if not self.sq_contains(tx, args[0]).as_python_constant():
+        if not self.sq_contains_impl(tx, args[0]).as_python_constant():
             raise_observed_exception(KeyError, tx, args=[args[0]])
         self.should_reconstruct_all = True
         tx.output.side_effects.mutation(self)

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -522,7 +522,7 @@ class SetVariable(VariableTracker):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        if self.sq_contains(tx, args[0]).as_python_constant():
+        if self.sq_contains_impl(tx, args[0]).as_python_constant():
             self.should_reconstruct_all = True
             tx.output.side_effects.mutation(self)
             # sq_contains validated/normalized args[0]; a set key was coerced

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -533,7 +533,7 @@ class StreamVariable(StreamContextVariable):
         "record_event": Method(record_event),
     }
 
-    def richcompare_impl(self, tx, other, op):
+    def tp_richcompare_impl(self, tx, other, op):
         from ..guards import GuardBuilder, install_guard
         from ..utils import cmp_name_to_op_mapping
         from .constant import ConstantVariable
@@ -658,7 +658,7 @@ class EventVariable(VariableTracker):
         self.value = value
         self.user_object_index = user_object_index
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .object_protocol import object_richcompare

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -345,7 +345,7 @@ class TensorVariable(VariableTracker):
             self.proxy.node.meta["example_value"], self.python_type_name()
         )
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         unimplemented(
             gb_type="repr() on tensor",
             context=f"repr() on {self.python_type_name()}",
@@ -363,7 +363,7 @@ class TensorVariable(VariableTracker):
     def is_tensor(self) -> bool:
         return True
 
-    def bool_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def nb_bool_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # THPVariable_bool calls at::Tensor::is_nonzero(), i.e. .item() != 0.
         from .constant import ConstantVariable
 
@@ -376,7 +376,7 @@ class TensorVariable(VariableTracker):
             return VariableTracker.build(tx, bool(item.value))
         return SymNodeVariable.create(tx, item.as_proxy() != 0)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -638,7 +638,7 @@ class TensorVariable(VariableTracker):
     def method_attr_retain_grad(self, tx: "InstructionTranslatorBase") -> NoReturn:
         unimplemented(
             gb_type="Tensor.retain_grad() with AOTDispatcher",
-            context=f"getattro_impl {self} retain_grad",
+            context=f"tp_getattro_impl {self} retain_grad",
             explanation="`Tensor.retain_grad()` does not work with AOTDispatcher.",
             hints=[],
         )
@@ -653,7 +653,7 @@ class TensorVariable(VariableTracker):
             and not self.has_grad_fn
         ):
             return ConstantVariable.create(None)
-        # None tells getattro_impl to use default .grad handling
+        # None tells tp_getattro_impl to use default .grad handling
         return None
 
     def method_attr_data(self, tx: "InstructionTranslatorBase") -> VariableTracker:
@@ -667,7 +667,7 @@ class TensorVariable(VariableTracker):
         if self.has_grad_fn:
             unimplemented(
                 gb_type="Tensor with grad_fn()",
-                context=f"getattro_impl {self} grad_fn",
+                context=f"tp_getattro_impl {self} grad_fn",
                 explanation="Dynamo does not support tracing tensors with a grad_fn directly.",
                 hints=[],
             )
@@ -687,7 +687,7 @@ class TensorVariable(VariableTracker):
         from . import GetAttrVariable
 
         # TODO - This is not a good solution but solves an accuracy issue.
-        # Today, getattro_impl returns GetAttrVariable for both non-existent
+        # Today, tp_getattro_impl returns GetAttrVariable for both non-existent
         # attributes and existing attributes. This is a bug and requires more
         # deep dive.
         if name in all_tensor_attrs:
@@ -712,7 +712,7 @@ class TensorVariable(VariableTracker):
 
         return VariableTracker.build(tx, ret_val)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         fake_val = self.as_proxy().node.meta["example_value"]
@@ -732,7 +732,7 @@ class TensorVariable(VariableTracker):
             if name in self._strict_mode_banned_ops():
                 unimplemented(
                     gb_type="Strict mode banned op",
-                    context=f"getattro_impl {self} {name}",
+                    context=f"tp_getattro_impl {self} {name}",
                     explanation=f"Getattr invocation '{name}' in strict mode is not supported.",
                     hints=[
                         f"Remove `{name}` from the list of banned ops by "
@@ -1855,9 +1855,9 @@ class TensorVariable(VariableTracker):
         )
 
     def method___len__(self, tx: "InstructionTranslatorBase") -> VariableTracker:
-        return self.sq_length(tx)
+        return self.sq_length_impl(tx)
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """Sequence length for tensors (size along first dimension)."""
         return self.call_method(tx, "size", [VariableTracker.build(tx, 0)], {})
 
@@ -2044,7 +2044,7 @@ class TensorVariable(VariableTracker):
             return self.call_method(tx, "copy_", [fma_result], {})
         return None
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # Rewrite __contains__ here so that downstream passes can trace through
@@ -2062,7 +2062,7 @@ class TensorVariable(VariableTracker):
     def method___contains__(
         self, tx: "InstructionTranslatorBase", arg: VariableTracker
     ) -> VariableTracker:
-        return self.sq_contains(tx, arg)
+        return self.sq_contains_impl(tx, arg)
 
     def method_register_hook(
         self,
@@ -2345,8 +2345,8 @@ class TensorVariable(VariableTracker):
                 return None
         fwd_kwargs = dict(kwargs)
         fwd_kwargs.pop("layout", None)
-        fwd_kwargs.setdefault("dtype", self.getattro_impl(tx, "dtype"))
-        fwd_kwargs.setdefault("device", self.getattro_impl(tx, "device"))
+        fwd_kwargs.setdefault("dtype", self.tp_getattro_impl(tx, "dtype"))
+        fwd_kwargs.setdefault("device", self.tp_getattro_impl(tx, "device"))
         return variables.TorchInGraphFunctionVariable(torch.tensor).call_function(
             tx,
             [data_arg],
@@ -2802,7 +2802,7 @@ class SymNodeVariable(VariableTracker):
     def as_proxy(self) -> Any:
         return self.proxy
 
-    def bool_impl(
+    def nb_bool_impl(
         self,
         tx: "InstructionTranslatorBase",
     ) -> VariableTracker:
@@ -2817,7 +2817,7 @@ class SymNodeVariable(VariableTracker):
             )
         return SymNodeVariable.create(tx, self.as_proxy() != 0)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -3226,7 +3226,7 @@ class NumpyNdarrayVariable(TensorVariable):
 
         raise_type_error(tx, "unhashable type: 'numpy.ndarray'")
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -3275,7 +3275,7 @@ class NumpyNdarrayVariable(TensorVariable):
         "flat": GetSet(lambda s, tx: s._get_numpy_attr(tx, "flat")),
     }
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # NB: This INTENTIONALLY does not call super(), because there is
@@ -3322,14 +3322,14 @@ class NumpyNdarrayVariable(TensorVariable):
         elif name in ["base", "flags", "dtype"]:
             unimplemented(
                 gb_type="Unsupported ndarray attribute access",
-                context=f"getattro_impl {self} {name}",
+                context=f"tp_getattro_impl {self} {name}",
                 explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
                 hints=[],
             )
         elif name == "__version__":
             unimplemented(
                 gb_type="Unsupported ndarray.__version__ access",
-                context=f"getattro_impl {self} {name}",
+                context=f"tp_getattro_impl {self} {name}",
                 explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
                 hints=[],
             )
@@ -3641,7 +3641,7 @@ class DataPtrVariable(VariableTracker):
         )
         return self_root is other_root
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -3655,7 +3655,7 @@ class DataPtrVariable(VariableTracker):
             return ConstantVariable.create(op == "__eq__")
         unimplemented(
             gb_type="Data pointer comparison",
-            context=f"richcompare_impl {self} {op} {other}",
+            context=f"tp_richcompare_impl {self} {op} {other}",
             explanation="Dynamo can only trace data pointer comparisons "
             "when it can prove both operands have the same data pointer.",
             hints=[],

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -341,7 +341,7 @@ class TensorVariable(VariableTracker):
             self.proxy.node.meta["example_value"], self.python_type_name()
         )
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         unimplemented(
             gb_type="repr() on tensor",
             context=f"repr() on {self.python_type_name()}",
@@ -359,7 +359,7 @@ class TensorVariable(VariableTracker):
     def is_tensor(self) -> bool:
         return True
 
-    def bool_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def nb_bool_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # THPVariable_bool calls at::Tensor::is_nonzero(), i.e. .item() != 0.
         from .constant import ConstantVariable
 
@@ -372,7 +372,7 @@ class TensorVariable(VariableTracker):
             return VariableTracker.build(tx, bool(item.value))
         return SymNodeVariable.create(tx, item.as_proxy() != 0)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -634,7 +634,7 @@ class TensorVariable(VariableTracker):
     def method_attr_retain_grad(self, tx: "InstructionTranslatorBase") -> NoReturn:
         unimplemented(
             gb_type="Tensor.retain_grad() with AOTDispatcher",
-            context=f"getattro_impl {self} retain_grad",
+            context=f"tp_getattro_impl {self} retain_grad",
             explanation="`Tensor.retain_grad()` does not work with AOTDispatcher.",
             hints=[],
         )
@@ -649,7 +649,7 @@ class TensorVariable(VariableTracker):
             and not self.has_grad_fn
         ):
             return ConstantVariable.create(None)
-        # None tells getattro_impl to use default .grad handling
+        # None tells tp_getattro_impl to use default .grad handling
         return None
 
     def method_attr_data(self, tx: "InstructionTranslatorBase") -> VariableTracker:
@@ -663,7 +663,7 @@ class TensorVariable(VariableTracker):
         if self.has_grad_fn:
             unimplemented(
                 gb_type="Tensor with grad_fn()",
-                context=f"getattro_impl {self} grad_fn",
+                context=f"tp_getattro_impl {self} grad_fn",
                 explanation="Dynamo does not support tracing tensors with a grad_fn directly.",
                 hints=[],
             )
@@ -683,7 +683,7 @@ class TensorVariable(VariableTracker):
         from . import GetAttrVariable
 
         # TODO - This is not a good solution but solves an accuracy issue.
-        # Today, getattro_impl returns GetAttrVariable for both non-existent
+        # Today, tp_getattro_impl returns GetAttrVariable for both non-existent
         # attributes and existing attributes. This is a bug and requires more
         # deep dive.
         if name in all_tensor_attrs:
@@ -708,7 +708,7 @@ class TensorVariable(VariableTracker):
 
         return VariableTracker.build(tx, ret_val)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         fake_val = self.as_proxy().node.meta["example_value"]
@@ -728,7 +728,7 @@ class TensorVariable(VariableTracker):
             if name in self._strict_mode_banned_ops():
                 unimplemented(
                     gb_type="Strict mode banned op",
-                    context=f"getattro_impl {self} {name}",
+                    context=f"tp_getattro_impl {self} {name}",
                     explanation=f"Getattr invocation '{name}' in strict mode is not supported.",
                     hints=[
                         f"Remove `{name}` from the list of banned ops by "
@@ -1853,9 +1853,9 @@ class TensorVariable(VariableTracker):
         )
 
     def method___len__(self, tx: "InstructionTranslatorBase") -> VariableTracker:
-        return self.sq_length(tx)
+        return self.sq_length_impl(tx)
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """Sequence length for tensors (size along first dimension)."""
         return self.call_method(tx, "size", [VariableTracker.build(tx, 0)], {})
 
@@ -2042,7 +2042,7 @@ class TensorVariable(VariableTracker):
             return self.call_method(tx, "copy_", [fma_result], {})
         return None
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # Rewrite __contains__ here so that downstream passes can trace through
@@ -2060,7 +2060,7 @@ class TensorVariable(VariableTracker):
     def method___contains__(
         self, tx: "InstructionTranslatorBase", arg: VariableTracker
     ) -> VariableTracker:
-        return self.sq_contains(tx, arg)
+        return self.sq_contains_impl(tx, arg)
 
     def method_register_hook(
         self,
@@ -2343,8 +2343,8 @@ class TensorVariable(VariableTracker):
                 return None
         fwd_kwargs = dict(kwargs)
         fwd_kwargs.pop("layout", None)
-        fwd_kwargs.setdefault("dtype", self.getattro_impl(tx, "dtype"))
-        fwd_kwargs.setdefault("device", self.getattro_impl(tx, "device"))
+        fwd_kwargs.setdefault("dtype", self.tp_getattro_impl(tx, "dtype"))
+        fwd_kwargs.setdefault("device", self.tp_getattro_impl(tx, "device"))
         return variables.TorchInGraphFunctionVariable(torch.tensor).call_function(
             tx,
             [data_arg],
@@ -2800,7 +2800,7 @@ class SymNodeVariable(VariableTracker):
     def as_proxy(self) -> Any:
         return self.proxy
 
-    def bool_impl(
+    def nb_bool_impl(
         self,
         tx: "InstructionTranslatorBase",
     ) -> VariableTracker:
@@ -2815,7 +2815,7 @@ class SymNodeVariable(VariableTracker):
             )
         return SymNodeVariable.create(tx, self.as_proxy() != 0)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -3224,7 +3224,7 @@ class NumpyNdarrayVariable(TensorVariable):
 
         raise_type_error(tx, "unhashable type: 'numpy.ndarray'")
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -3273,7 +3273,7 @@ class NumpyNdarrayVariable(TensorVariable):
         "flat": GetSet(lambda s, tx: s._get_numpy_attr(tx, "flat")),
     }
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # NB: This INTENTIONALLY does not call super(), because there is
@@ -3320,14 +3320,14 @@ class NumpyNdarrayVariable(TensorVariable):
         elif name in ["base", "flags", "dtype"]:
             unimplemented(
                 gb_type="Unsupported ndarray attribute access",
-                context=f"getattro_impl {self} {name}",
+                context=f"tp_getattro_impl {self} {name}",
                 explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
                 hints=[],
             )
         elif name == "__version__":
             unimplemented(
                 gb_type="Unsupported ndarray.__version__ access",
-                context=f"getattro_impl {self} {name}",
+                context=f"tp_getattro_impl {self} {name}",
                 explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
                 hints=[],
             )
@@ -3639,7 +3639,7 @@ class DataPtrVariable(VariableTracker):
         )
         return self_root is other_root
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
@@ -3653,7 +3653,7 @@ class DataPtrVariable(VariableTracker):
             return ConstantVariable.create(op == "__eq__")
         unimplemented(
             gb_type="Data pointer comparison",
-            context=f"richcompare_impl {self} {op} {other}",
+            context=f"tp_richcompare_impl {self} {op} {other}",
             explanation="Dynamo can only trace data pointer comparisons "
             "when it can prove both operands have the same data pointer.",
             hints=[],

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -632,7 +632,7 @@ class BaseTorchVariable(VariableTracker):
     def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         return hash(self.value), False
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .object_protocol import object_richcompare
@@ -1095,7 +1095,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                     raise AssertionError(
                         "Expected first argument to accumulate_grad_ to be a tensor"
                     )
-                variable_grad = variable.getattro_impl(tx, "grad")
+                variable_grad = variable.tp_getattro_impl(tx, "grad")
                 updated_grad = tx.inline_user_function_return(
                     VariableTracker.build(tx, polyfills.accumulate_grad),
                     [variable, variable_grad, new_grad],
@@ -3332,7 +3332,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         return handlers
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> "VariableTracker":
         source = self.source and AttrSource(self.source, name)
@@ -4148,9 +4148,9 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             )
 
         try:
-            shape = tuple(data.getattro_impl(tx, "shape").as_python_constant())
-            dtype = data.getattro_impl(tx, "dtype").as_python_constant()
-            device = data.getattro_impl(tx, "device").as_python_constant()
+            shape = tuple(data.tp_getattro_impl(tx, "shape").as_python_constant())
+            dtype = data.tp_getattro_impl(tx, "dtype").as_python_constant()
+            device = data.tp_getattro_impl(tx, "device").as_python_constant()
         except NotImplementedError as e:
             unimplemented(
                 gb_type="`torch.nn.Parameter` with non-constant Tensor attributes",
@@ -4297,7 +4297,7 @@ class DispatchKeySetVariable(BaseTorchVariable):
         install_guard(source.make_guard(GuardBuilder.DISPATCH_KEY_SET_MATCH))
         return cls(value, source=source)
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .object_protocol import python_constant_richcompare_impl

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -641,7 +641,7 @@ class TensorWithTFOverrideVariable(TensorVariable):
             tx, f"__subclass_{self.class_type.__name__}", self.class_type
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # [Note: __torch_function__] We currently only support attributes that are defined on
@@ -681,7 +681,7 @@ class TensorWithTFOverrideVariable(TensorVariable):
                     kwargs,
                 )
         else:
-            # `TensorVariable.getattro_impl` doesn't handle user-defined
+            # `TensorVariable.tp_getattro_impl` doesn't handle user-defined
             # function/attribute well, so we explicitly handle them here.
             #
             # TODO move this logic into `TensorVariable`, or try to merge it
@@ -724,7 +724,7 @@ class TensorWithTFOverrideVariable(TensorVariable):
                         ],
                     )
 
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def call_torch_function(
         self,

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -143,7 +143,7 @@ def _safe_c_slots() -> OrderedSet[object]:
     """C slot wrappers known to be safe to call at trace time.
 
     Covers tp_hash and tp_richcompare slots for C extension types.
-    Used by UDOV's hash_impl and richcompare_impl MRO walks.
+    Used by UDOV's hash_impl and tp_richcompare_impl MRO walks.
     """
     global _SAFE_C_SLOTS
     if _SAFE_C_SLOTS is None:
@@ -334,7 +334,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 pass
         return hash(self.value), True
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .constant import ConstantVariable
@@ -494,7 +494,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
         """Walk type(cls).__mro__ (the metaclass chain) to find *name*."""
         return mro_lookup(type(self.value), name)
 
-    def bool_impl(
+    def nb_bool_impl(
         self,
         tx: "InstructionTranslatorBase",
     ) -> "VariableTracker":
@@ -507,7 +507,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             return self.call_method(tx, "__bool__", [], {})
         return ConstantVariable.create(True)
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # https://github.com/python/cpython/blob/3.13/Objects/typeobject.c#L2379-L2408
         metaclass = type(self.value)
         if metaclass is type or metaclass.__repr__ is type.__repr__:
@@ -518,7 +518,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             raise_type_error(tx, "'NoneType' object is not callable")
         return self.call_method(tx, "__repr__", [], {})
 
-    def str_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_str_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         metaclass = type(self.value)
         if metaclass is type or metaclass.__str__ is type.__str__:
             return generic_repr(tx, self)
@@ -545,7 +545,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             return VariableTracker.build(tx, NotImplemented)
         return VariableTracker.build(tx, result)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         source = AttrSource(self.source, name) if self.source is not None else None
@@ -893,19 +893,19 @@ class UserDefinedClassVariable(UserDefinedVariable):
             ).call_function(tx, [], {})
         raise_type_error(tx, f"object of type {self.python_type_name()} has no length")
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         return self.len_impl(tx)
 
-    def mp_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def mp_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         return self.len_impl(tx)
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         m = self._maybe_get_baseclass_method("__contains__")
         if m:
             return self.call_method(tx, "__contains__", [item], {})
-        return super().sq_contains(tx, item)
+        return super().sq_contains_impl(tx, item)
 
     def tp_iter_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         m = self._maybe_get_baseclass_method("__iter__")
@@ -1894,7 +1894,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return self.value
         return super().guard_as_python_constant()
 
-    def bool_impl(
+    def nb_bool_impl(
         self,
         tx: "InstructionTranslatorBase",
     ) -> "VariableTracker | None":
@@ -1930,7 +1930,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
             raise_type_error(tx, err_str)
 
-    def repr_impl(
+    def tp_repr_impl(
         self,
         tx: "InstructionTranslatorBase",
     ) -> VariableTracker:
@@ -1950,7 +1950,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             skip_frame=True,
         )
 
-    def str_impl(
+    def tp_str_impl(
         self,
         tx: "InstructionTranslatorBase",
     ) -> VariableTracker:
@@ -2047,7 +2047,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             kwargs,
         )
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/4833e1cc666375454e4f86aff11b6587968b3333/Objects/typeobject.c#L9337
@@ -2773,7 +2773,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 )
 
             # Delegate to _base_vt for non-overridden base-class methods.
-            # Skip comparison ops: they go through richcompare_impl on the
+            # Skip comparison ops: they go through tp_richcompare_impl on the
             # UserDefined*Variable subclass, which handles _base_vt
             # unwrapping and avoids tracing tensor elements via list_cmp.
             if (
@@ -2871,7 +2871,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return self
         return super().sq_inplace_concat_impl(tx, other)
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/4833e1cc666375454e4f86aff11b6587968b3333/Objects/typeobject.c#L9266
         res = self._vectorcall_method(tx, "__len__", [], {})
 
@@ -2892,7 +2892,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         return pynumber_as_ssize_t(tx, res, OverflowError)
 
     # ref: https://github.com/python/cpython/blob/4833e1cc666375454e4f86aff11b6587968b3333/Objects/typeobject.c#L9368
-    mp_length = sq_length
+    mp_length_impl = sq_length_impl
 
     def method_setattr_standard(
         self,
@@ -3202,7 +3202,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             # If the object has an overridden getattribute method, Dynamo has
             # already tried tracing it, and encountered an AttributeError. We
             # call getattr_static only when the __getattribute__ tracing fails
-            # (check getattro_impl impl). So, it is safe here to raise the
+            # (check tp_getattro_impl impl). So, it is safe here to raise the
             # AttributeError.
             raise AttributeError
 
@@ -3321,7 +3321,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         """Dynamo implementation of CPython's PyObject_GenericGetAttr.
 
         This mirrors object.__getattribute__ and is called from:
-        - getattro_impl (for objects without a custom __getattribute__)
+        - tp_getattro_impl (for objects without a custom __getattribute__)
         - SuperVariable.call_method (when super().__getattribute__() resolves
           to object.__getattribute__)
 
@@ -3426,7 +3426,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             kwargs={"name": variables.ConstantVariable.create(name), "obj": self},
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if self._object_has_getattribute:
@@ -3468,7 +3468,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 source = self.get_source_by_walking_mro(tx, name)
             prop_vt = variables.PropertyVariable(type_attr, source=source)
             return prop_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
         if isinstance(type_attr, types.MemberDescriptorType):
             if tx.output.side_effects.has_pending_mutation_of_attr(
@@ -3486,7 +3486,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 return result
             md_vt = variables.MemberDescriptorVariable(type_attr, source=source)
             return md_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
 
         if isinstance(type_attr, types.GetSetDescriptorType):
@@ -3505,13 +3505,13 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 return result
             gs_vt = variables.GetSetDescriptorVariable(type_attr, source=source)
             return gs_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
 
         if isinstance(type_attr, _collections._tuplegetter):
             tg_vt = variables.TupleGetterVariable(type_attr, source=source)
             return tg_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
 
         get_fn = inspect.getattr_static(type(type_attr), "__get__", None)
@@ -3560,7 +3560,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 source = self.get_source_by_walking_mro(tx, name)
             sm_vt = variables.StaticMethodVariable(type_attr, source=source)
             return sm_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
         elif isinstance(type_attr, classmethod):
             # Source points to the descriptor in the class __dict__ via MRO
@@ -3570,21 +3570,21 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 source = self.get_source_by_walking_mro(tx, name)
             cm_vt = variables.ClassMethodVariable(type_attr, source=source)
             return cm_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
         elif isinstance(type_attr, types.ClassMethodDescriptorType):
             cmd_vt = variables.ClassMethodDescriptorVariable(type_attr, source=source)
             return cmd_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
         elif isinstance(type_attr, types.WrapperDescriptorType):
-            class_vt = self.getattro_impl(tx, "__class__")
+            class_vt = self.tp_getattro_impl(tx, "__class__")
             wd_vt = variables.WrapperDescriptorVariable(
                 type_attr, owner=class_vt, source=source
             )
             return wd_vt.tp_descr_get_impl(tx, self, class_vt)
         elif isinstance(type_attr, types.MethodDescriptorType):
-            class_vt = self.getattro_impl(tx, "__class__")
+            class_vt = self.tp_getattro_impl(tx, "__class__")
             md_vt = variables.MethodDescriptorVariable(
                 type_attr, owner=class_vt, source=source
             )
@@ -3775,7 +3775,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 return variables.ConstantVariable.create(True)
 
         try:
-            var_vt = self.getattro_impl(tx, name)
+            var_vt = self.tp_getattro_impl(tx, name)
             return VariableTracker.build(
                 tx, not isinstance(var_vt, variables.DeletedVariable)
             )
@@ -3877,7 +3877,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         # (e.g. IntEnum inheriting int.__hash__).
         return hash(self.value), False
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         """MRO walk for tp_richcompare, analogous to slot_tp_richcompare.
@@ -3943,7 +3943,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 return ConstantVariable.create(NotImplemented)
             unimplemented(
                 gb_type="Untraceable C tp_richcompare",
-                context=f"richcompare_impl {self} {op}",
+                context=f"tp_richcompare_impl {self} {op}",
                 explanation=f"{cls.__name__} defines a C comparison method "
                 f"that Dynamo cannot trace into.",
                 hints=[
@@ -3955,7 +3955,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             )
 
         if self._base_vt is not None:
-            return self._base_vt.richcompare_impl(tx, other, op)
+            return self._base_vt.tp_richcompare_impl(tx, other, op)
 
         return object_richcompare(self, tx, other, op)
 
@@ -4140,14 +4140,14 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
 
     Construction is handled by the generic polyfill path (tracing through
     the auto-generated __init__). Field values are retrieved dynamically
-    via getattro_impl using InstructionTranslator.current_tx().
+    via tp_getattro_impl using InstructionTranslator.current_tx().
     """
 
     def _get_field_vt(self, field_name: str) -> VariableTracker:
         from torch._dynamo.symbolic_convert import InstructionTranslator
 
         tx = InstructionTranslator.current_tx()
-        return self.getattro_impl(tx, field_name)
+        return self.tp_getattro_impl(tx, field_name)
 
     def as_python_constant(self) -> object:
         from dataclasses import fields
@@ -4318,7 +4318,7 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
             return variables.ConstantVariable.create(None)
         return super().tp_init_impl(tx, args, kwargs)
 
-    def getattro_impl(self, tx: "InstructionTranslatorBase", name: str):
+    def tp_getattro_impl(self, tx: "InstructionTranslatorBase", name: str):
         if name in (
             "args",
             "__cause__",
@@ -4326,8 +4326,8 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
             "__suppress_context__",
             "__traceback__",
         ):
-            return self._base_vt.getattro_impl(tx, name)  # type: ignore[missing-attribute]
-        return super().getattro_impl(tx, name)
+            return self._base_vt.tp_getattro_impl(tx, name)  # type: ignore[missing-attribute]
+        return super().tp_getattro_impl(tx, name)
 
     @property
     def __context__(self) -> "ConstantVariable":
@@ -4351,17 +4351,17 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
     def debug_repr(self) -> str:
         return self.exc_vt.debug_repr()
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         # ref: BaseException_repr in https://github.com/python/cpython/blob/3.13/Objects/exceptions.c#L135-L142
         if type(self.value).__repr__ is not BaseException.__repr__:
-            return super().repr_impl(tx)
-        return self.exc_vt.repr_impl(tx)
+            return super().tp_repr_impl(tx)
+        return self.exc_vt.tp_repr_impl(tx)
 
-    def str_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def tp_str_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         # ref: BaseException_str in https://github.com/python/cpython/blob/3.13/Objects/exceptions.c#L118-L129
         if type(self.value).__str__ is not BaseException.__str__:
-            return super().str_impl(tx)
-        return self.exc_vt.str_impl(tx)
+            return super().tp_str_impl(tx)
+        return self.exc_vt.tp_str_impl(tx)
 
     @python_stack.setter
     def python_stack(self, value: traceback.StackSummary) -> None:
@@ -4388,13 +4388,13 @@ class InspectVariable(UserDefinedObjectVariable):
     def is_matching_class(obj: object) -> bool:
         return obj in InspectVariable._PROPERTY_REDIRECTS
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         redirects = self._PROPERTY_REDIRECTS.get(type(self.value), {})
         if name in redirects:
-            return super().getattro_impl(tx, redirects[name])
-        return super().getattro_impl(tx, name)
+            return super().tp_getattro_impl(tx, redirects[name])
+        return super().tp_getattro_impl(tx, name)
 
 
 class KeyedJaggedTensorVariable(UserDefinedObjectVariable):
@@ -4412,7 +4412,7 @@ class KeyedJaggedTensorVariable(UserDefinedObjectVariable):
             raise AssertionError(f"Expected KeyedJaggedTensor, got {type(value)}")
         super().__init__(value, **kwargs)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if (
@@ -4421,8 +4421,8 @@ class KeyedJaggedTensorVariable(UserDefinedObjectVariable):
             and name in ("_length_per_key", "_offset_per_key")
         ):
             with TracingContext.patch(force_unspec_int_unbacked_size_like=True):
-                return super().getattro_impl(tx, name)
-        return super().getattro_impl(tx, name)
+                return super().tp_getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 _CONSTANT_BASE_TYPES = (int, float, str)
@@ -4563,10 +4563,10 @@ class UserDefinedDictVariable(UserDefinedObjectVariable):
             raise AssertionError("_base_vt must not be None in len")
         return self._base_vt.len()  # type: ignore[union-attr]
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # Dict implements __len__ via mp_length (mapping protocol), not
         # sq_length (sequence protocol). Redirect so generic_size works.
-        return self.mp_length(tx)
+        return self.mp_length_impl(tx)
 
     def mp_subscript_impl(
         self,
@@ -4656,7 +4656,7 @@ class UserDefinedDictVariable(UserDefinedObjectVariable):
             return f"{type(self.value).__name__}({{{contents}}})"
         return base_vt.debug_repr()
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # https://github.com/python/cpython/blob/3.13/Lib/collections/__init__.py#L748-L757
         method = self._maybe_get_baseclass_method("__repr__")
         if type(self.value).__repr__ is collections.Counter.__repr__:
@@ -4684,8 +4684,8 @@ class UserDefinedDictVariable(UserDefinedObjectVariable):
         if method in self._base_methods:
             if self._base_vt is None:
                 raise AssertionError("_base_vt must not be None for dict repr")
-            return self._base_vt.repr_impl(tx)
-        return super().repr_impl(tx)
+            return self._base_vt.tp_repr_impl(tx)
+        return super().tp_repr_impl(tx)
 
 
 # TODO: move to dicts.py alongside ConstDictVariable.
@@ -4777,7 +4777,7 @@ class DefaultDictVariable(UserDefinedDictVariable):
             f"{self._base_vt.debug_repr()})"
         )
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # https://github.com/python/cpython/blob/3.13/Modules/_collectionsmodule.c#L2373-L2405
         if self._base_vt is None:
             raise AssertionError("_base_vt must not be None for defaultdict repr")
@@ -4787,14 +4787,14 @@ class DefaultDictVariable(UserDefinedDictVariable):
             f"{tracked_repr(tx, self._base_vt)})",
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self,
         tx: "InstructionTranslatorBase",
         name: str,
     ) -> VariableTracker:
         if name == "default_factory":
             return self.default_factory
-        return super().getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
     def _missing_impl(
         self,
@@ -5095,15 +5095,15 @@ class UserDefinedDequeVariable(UserDefinedObjectVariable):
         if self._base_vt is None:
             raise AssertionError("_base_vt must not be None after initialization")
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # maxlen is a read-only getset on deque, not a method, so it is not
         # covered by the _base_methods call_method delegation; route it to the
         # DequeVariable which tracks maxlen on the base deque.
         if name == "maxlen" and self._base_vt is not None:
-            return self._base_vt.getattro_impl(tx, name)
-        return super().getattro_impl(tx, name)
+            return self._base_vt.tp_getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 class UserDefinedTupleVariable(UserDefinedObjectVariable):
@@ -5337,7 +5337,7 @@ class NamedTupleVariable(UserDefinedTupleVariable):
         items = [x.as_proxy() for x in self.items]
         return self.tuple_cls(*items)  # type: ignore[arg-type]
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         fields = namedtuple_fields(self.tuple_cls)
         items = ", ".join(
             f"{name}={tracked_repr(tx, item)}" for name, item in zip(fields, self.items)
@@ -5385,7 +5385,7 @@ class StructSequenceVariable(UserDefinedTupleVariable):
         )
         return f"{self.tuple_cls.__module__}.{self.tuple_cls.__qualname__}({items})"
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         fields = namedtuple_fields(self.tuple_cls)
         items = ", ".join(
             f"{name}={tracked_repr(tx, item)}" for name, item in zip(fields, self.items)
@@ -5436,7 +5436,7 @@ class MutableMappingVariable(UserDefinedObjectVariable):
 
         return super().method_setattr_standard(tx, name, value)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         # A common pattern in the init code of MutableMapping objects is to
@@ -5449,12 +5449,12 @@ class MutableMappingVariable(UserDefinedObjectVariable):
         ):
             return variables.UserMethodVariable(polyfills.mapping_get, self)
         else:
-            return super().getattro_impl(tx, name)
+            return super().tp_getattro_impl(tx, name)
 
-    def mp_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def mp_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         if self._maybe_get_baseclass_method("__len__") in dict_methods:
             return VariableTracker.build(tx, len(self.value))  # type: ignore[bad-argument-type]
-        return super().mp_length(tx)
+        return super().mp_length_impl(tx)
 
 
 class RandomVariable(UserDefinedObjectVariable):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -4345,16 +4345,16 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
     # BaseException args/__cause__/__context__/__suppress_context__/__traceback__
     # are members/getsets; delegate each to the wrapped base exception VT.
     tp_members = {
-        "args": Member(lambda s, tx: s._base_vt.getattro_impl(tx, "args")),
-        "__cause__": Member(lambda s, tx: s._base_vt.getattro_impl(tx, "__cause__")),
+        "args": Member(lambda s, tx: s._base_vt.tp_getattro_impl(tx, "args")),
+        "__cause__": Member(lambda s, tx: s._base_vt.tp_getattro_impl(tx, "__cause__")),
         "__context__": Member(
-            lambda s, tx: s._base_vt.getattro_impl(tx, "__context__")
+            lambda s, tx: s._base_vt.tp_getattro_impl(tx, "__context__")
         ),
         "__suppress_context__": Member(
-            lambda s, tx: s._base_vt.getattro_impl(tx, "__suppress_context__")
+            lambda s, tx: s._base_vt.tp_getattro_impl(tx, "__suppress_context__")
         ),
         "__traceback__": Member(
-            lambda s, tx: s._base_vt.getattro_impl(tx, "__traceback__")
+            lambda s, tx: s._base_vt.tp_getattro_impl(tx, "__traceback__")
         ),
     }
 
@@ -4422,7 +4422,7 @@ class InspectVariable(UserDefinedObjectVariable):
     ) -> VariableTracker | None:
         redirects = self._PROPERTY_REDIRECTS.get(type(self.value), {})
         if name in redirects:
-            return super().getattro_impl(tx, redirects[name])
+            return super().tp_getattro_impl(tx, redirects[name])
         return None
 
     def _parameters(self, tx: "InstructionTranslatorBase") -> VariableTracker | None:
@@ -5126,7 +5126,7 @@ class UserDefinedDequeVariable(UserDefinedObjectVariable):
         # covered by the _base_methods call_method delegation; route it to the
         # DequeVariable which tracks maxlen on the base deque.
         if self._base_vt is not None:
-            return self._base_vt.getattro_impl(tx, "maxlen")
+            return self._base_vt.tp_getattro_impl(tx, "maxlen")
         return None
 
     # ref: deque_getset[] in CPython Modules/_collectionsmodule.c; maxlen is a

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -146,7 +146,7 @@ def _safe_c_slots() -> OrderedSet[object]:
     """C slot wrappers known to be safe to call at trace time.
 
     Covers tp_hash and tp_richcompare slots for C extension types.
-    Used by UDOV's hash_impl and richcompare_impl MRO walks.
+    Used by UDOV's hash_impl and tp_richcompare_impl MRO walks.
     """
     global _SAFE_C_SLOTS
     if _SAFE_C_SLOTS is None:
@@ -337,7 +337,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 pass
         return hash(self.value), True
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         from .constant import ConstantVariable
@@ -497,7 +497,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
         """Walk type(cls).__mro__ (the metaclass chain) to find *name*."""
         return mro_lookup(type(self.value), name)
 
-    def bool_impl(
+    def nb_bool_impl(
         self,
         tx: "InstructionTranslatorBase",
     ) -> "VariableTracker":
@@ -510,7 +510,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             return self.call_method(tx, "__bool__", [], {})
         return ConstantVariable.create(True)
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # https://github.com/python/cpython/blob/3.13/Objects/typeobject.c#L2379-L2408
         metaclass = type(self.value)
         if metaclass is type or metaclass.__repr__ is type.__repr__:
@@ -521,7 +521,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             raise_type_error(tx, "'NoneType' object is not callable")
         return self.call_method(tx, "__repr__", [], {})
 
-    def str_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_str_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         metaclass = type(self.value)
         if metaclass is type or metaclass.__str__ is type.__str__:
             return generic_repr(tx, self)
@@ -548,7 +548,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             return VariableTracker.build(tx, NotImplemented)
         return VariableTracker.build(tx, result)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         source = AttrSource(self.source, name) if self.source is not None else None
@@ -896,19 +896,19 @@ class UserDefinedClassVariable(UserDefinedVariable):
             ).call_function(tx, [], {})
         raise_type_error(tx, f"object of type {self.python_type_name()} has no length")
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         return self.len_impl(tx)
 
-    def mp_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def mp_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         return self.len_impl(tx)
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         m = self._maybe_get_baseclass_method("__contains__")
         if m:
             return self.call_method(tx, "__contains__", [item], {})
-        return super().sq_contains(tx, item)
+        return super().sq_contains_impl(tx, item)
 
     def tp_iter_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         m = self._maybe_get_baseclass_method("__iter__")
@@ -1897,7 +1897,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return self.value
         return super().guard_as_python_constant()
 
-    def bool_impl(
+    def nb_bool_impl(
         self,
         tx: "InstructionTranslatorBase",
     ) -> "VariableTracker | None":
@@ -1933,7 +1933,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
             raise_type_error(tx, err_str)
 
-    def repr_impl(
+    def tp_repr_impl(
         self,
         tx: "InstructionTranslatorBase",
     ) -> VariableTracker:
@@ -1953,7 +1953,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             skip_frame=True,
         )
 
-    def str_impl(
+    def tp_str_impl(
         self,
         tx: "InstructionTranslatorBase",
     ) -> VariableTracker:
@@ -2050,7 +2050,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             kwargs,
         )
 
-    def sq_contains(
+    def sq_contains_impl(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/4833e1cc666375454e4f86aff11b6587968b3333/Objects/typeobject.c#L9337
@@ -2792,7 +2792,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                     return result
 
             # Delegate to _base_vt for non-overridden base-class methods.
-            # Skip comparison ops: they go through richcompare_impl on the
+            # Skip comparison ops: they go through tp_richcompare_impl on the
             # UserDefined*Variable subclass, which handles _base_vt
             # unwrapping and avoids tracing tensor elements via list_cmp.
             if (
@@ -2890,7 +2890,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return self
         return super().sq_inplace_concat_impl(tx, other)
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/4833e1cc666375454e4f86aff11b6587968b3333/Objects/typeobject.c#L9266
         res = self._vectorcall_method(tx, "__len__", [], {})
 
@@ -2911,7 +2911,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         return pynumber_as_ssize_t(tx, res, OverflowError)
 
     # ref: https://github.com/python/cpython/blob/4833e1cc666375454e4f86aff11b6587968b3333/Objects/typeobject.c#L9368
-    mp_length = sq_length
+    mp_length_impl = sq_length_impl
 
     def method_setattr_standard(
         self,
@@ -3221,7 +3221,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             # If the object has an overridden getattribute method, Dynamo has
             # already tried tracing it, and encountered an AttributeError. We
             # call getattr_static only when the __getattribute__ tracing fails
-            # (check getattro_impl impl). So, it is safe here to raise the
+            # (check tp_getattro_impl impl). So, it is safe here to raise the
             # AttributeError.
             raise AttributeError
 
@@ -3340,7 +3340,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         """Dynamo implementation of CPython's PyObject_GenericGetAttr.
 
         This mirrors object.__getattribute__ and is called from:
-        - getattro_impl (for objects without a custom __getattribute__)
+        - tp_getattro_impl (for objects without a custom __getattribute__)
         - SuperVariable.call_method (when super().__getattribute__() resolves
           to object.__getattribute__)
 
@@ -3445,7 +3445,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             kwargs={"name": variables.ConstantVariable.create(name), "obj": self},
         )
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if self._object_has_getattribute:
@@ -3487,7 +3487,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 source = self.get_source_by_walking_mro(tx, name)
             prop_vt = variables.PropertyVariable(type_attr, source=source)
             return prop_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
         if isinstance(type_attr, types.MemberDescriptorType):
             if tx.output.side_effects.has_pending_mutation_of_attr(
@@ -3505,7 +3505,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 return result
             md_vt = variables.MemberDescriptorVariable(type_attr, source=source)
             return md_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
 
         if isinstance(type_attr, types.GetSetDescriptorType):
@@ -3524,13 +3524,13 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 return result
             gs_vt = variables.GetSetDescriptorVariable(type_attr, source=source)
             return gs_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
 
         if isinstance(type_attr, _collections._tuplegetter):
             tg_vt = variables.TupleGetterVariable(type_attr, source=source)
             return tg_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
 
         get_fn = inspect.getattr_static(type(type_attr), "__get__", None)
@@ -3579,7 +3579,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 source = self.get_source_by_walking_mro(tx, name)
             sm_vt = variables.StaticMethodVariable(type_attr, source=source)
             return sm_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
         elif isinstance(type_attr, classmethod):
             # Source points to the descriptor in the class __dict__ via MRO
@@ -3589,21 +3589,21 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 source = self.get_source_by_walking_mro(tx, name)
             cm_vt = variables.ClassMethodVariable(type_attr, source=source)
             return cm_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
         elif isinstance(type_attr, types.ClassMethodDescriptorType):
             cmd_vt = variables.ClassMethodDescriptorVariable(type_attr, source=source)
             return cmd_vt.tp_descr_get_impl(
-                tx, self, self.getattro_impl(tx, "__class__")
+                tx, self, self.tp_getattro_impl(tx, "__class__")
             )
         elif isinstance(type_attr, types.WrapperDescriptorType):
-            class_vt = self.getattro_impl(tx, "__class__")
+            class_vt = self.tp_getattro_impl(tx, "__class__")
             wd_vt = variables.WrapperDescriptorVariable(
                 type_attr, owner=class_vt, source=source
             )
             return wd_vt.tp_descr_get_impl(tx, self, class_vt)
         elif isinstance(type_attr, types.MethodDescriptorType):
-            class_vt = self.getattro_impl(tx, "__class__")
+            class_vt = self.tp_getattro_impl(tx, "__class__")
             md_vt = variables.MethodDescriptorVariable(
                 type_attr, owner=class_vt, source=source
             )
@@ -3794,7 +3794,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 return variables.ConstantVariable.create(True)
 
         try:
-            var_vt = self.getattro_impl(tx, name)
+            var_vt = self.tp_getattro_impl(tx, name)
             return VariableTracker.build(
                 tx, not isinstance(var_vt, variables.DeletedVariable)
             )
@@ -3896,7 +3896,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         # (e.g. IntEnum inheriting int.__hash__).
         return hash(self.value), False
 
-    def richcompare_impl(
+    def tp_richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
     ) -> VariableTracker:
         """MRO walk for tp_richcompare, analogous to slot_tp_richcompare.
@@ -3962,7 +3962,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 return ConstantVariable.create(NotImplemented)
             unimplemented(
                 gb_type="Untraceable C tp_richcompare",
-                context=f"richcompare_impl {self} {op}",
+                context=f"tp_richcompare_impl {self} {op}",
                 explanation=f"{cls.__name__} defines a C comparison method "
                 f"that Dynamo cannot trace into.",
                 hints=[
@@ -3974,7 +3974,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             )
 
         if self._base_vt is not None:
-            return self._base_vt.richcompare_impl(tx, other, op)
+            return self._base_vt.tp_richcompare_impl(tx, other, op)
 
         return object_richcompare(self, tx, other, op)
 
@@ -4159,14 +4159,14 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
 
     Construction is handled by the generic polyfill path (tracing through
     the auto-generated __init__). Field values are retrieved dynamically
-    via getattro_impl using InstructionTranslator.current_tx().
+    via tp_getattro_impl using InstructionTranslator.current_tx().
     """
 
     def _get_field_vt(self, field_name: str) -> VariableTracker:
         from torch._dynamo.symbolic_convert import InstructionTranslator
 
         tx = InstructionTranslator.current_tx()
-        return self.getattro_impl(tx, field_name)
+        return self.tp_getattro_impl(tx, field_name)
 
     def as_python_constant(self) -> object:
         from dataclasses import fields
@@ -4380,17 +4380,17 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
     def debug_repr(self) -> str:
         return self.exc_vt.debug_repr()
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         # ref: BaseException_repr in https://github.com/python/cpython/blob/3.13/Objects/exceptions.c#L135-L142
         if type(self.value).__repr__ is not BaseException.__repr__:
-            return super().repr_impl(tx)
-        return self.exc_vt.repr_impl(tx)
+            return super().tp_repr_impl(tx)
+        return self.exc_vt.tp_repr_impl(tx)
 
-    def str_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+    def tp_str_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         # ref: BaseException_str in https://github.com/python/cpython/blob/3.13/Objects/exceptions.c#L118-L129
         if type(self.value).__str__ is not BaseException.__str__:
-            return super().str_impl(tx)
-        return self.exc_vt.str_impl(tx)
+            return super().tp_str_impl(tx)
+        return self.exc_vt.tp_str_impl(tx)
 
     @python_stack.setter
     def python_stack(self, value: traceback.StackSummary) -> None:
@@ -4460,7 +4460,7 @@ class KeyedJaggedTensorVariable(UserDefinedObjectVariable):
             raise AssertionError(f"Expected KeyedJaggedTensor, got {type(value)}")
         super().__init__(value, **kwargs)
 
-    def getattro_impl(
+    def tp_getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if (
@@ -4469,8 +4469,8 @@ class KeyedJaggedTensorVariable(UserDefinedObjectVariable):
             and name in ("_length_per_key", "_offset_per_key")
         ):
             with TracingContext.patch(force_unspec_int_unbacked_size_like=True):
-                return super().getattro_impl(tx, name)
-        return super().getattro_impl(tx, name)
+                return super().tp_getattro_impl(tx, name)
+        return super().tp_getattro_impl(tx, name)
 
 
 _CONSTANT_BASE_TYPES = (int, float, str)
@@ -4610,10 +4610,10 @@ class UserDefinedDictVariable(UserDefinedObjectVariable):
             raise AssertionError("_base_vt must not be None in len")
         return self._base_vt.len()  # type: ignore[union-attr]
 
-    def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # Dict implements __len__ via mp_length (mapping protocol), not
         # sq_length (sequence protocol). Redirect so generic_size works.
-        return self.mp_length(tx)
+        return self.mp_length_impl(tx)
 
     def mp_subscript_impl(
         self,
@@ -4679,7 +4679,7 @@ class UserDefinedDictVariable(UserDefinedObjectVariable):
             return f"{type(self.value).__name__}({{{contents}}})"
         return base_vt.debug_repr()
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # https://github.com/python/cpython/blob/3.13/Lib/collections/__init__.py#L748-L757
         method = self._maybe_get_baseclass_method("__repr__")
         if type(self.value).__repr__ is collections.Counter.__repr__:
@@ -4707,8 +4707,8 @@ class UserDefinedDictVariable(UserDefinedObjectVariable):
         if method in self._base_methods:
             if self._base_vt is None:
                 raise AssertionError("_base_vt must not be None for dict repr")
-            return self._base_vt.repr_impl(tx)
-        return super().repr_impl(tx)
+            return self._base_vt.tp_repr_impl(tx)
+        return super().tp_repr_impl(tx)
 
 
 # TODO: move to dicts.py alongside ConstDictVariable.
@@ -4800,7 +4800,7 @@ class DefaultDictVariable(UserDefinedDictVariable):
             f"{self._base_vt.debug_repr()})"
         )
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # https://github.com/python/cpython/blob/3.13/Modules/_collectionsmodule.c#L2373-L2405
         if self._base_vt is None:
             raise AssertionError("_base_vt must not be None for defaultdict repr")
@@ -5367,7 +5367,7 @@ class NamedTupleVariable(UserDefinedTupleVariable):
         items = [x.as_proxy() for x in self.items]
         return self.tuple_cls(*items)  # type: ignore[arg-type]
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         fields = namedtuple_fields(self.tuple_cls)
         items = ", ".join(
             f"{name}={tracked_repr(tx, item)}" for name, item in zip(fields, self.items)
@@ -5415,7 +5415,7 @@ class StructSequenceVariable(UserDefinedTupleVariable):
         )
         return f"{self.tuple_cls.__module__}.{self.tuple_cls.__qualname__}({items})"
 
-    def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         fields = namedtuple_fields(self.tuple_cls)
         items = ", ".join(
             f"{name}={tracked_repr(tx, item)}" for name, item in zip(fields, self.items)
@@ -5478,10 +5478,10 @@ class MutableMappingVariable(UserDefinedObjectVariable):
 
     tp_getset = {"get": GetSet(_get, None)}
 
-    def mp_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+    def mp_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         if self._maybe_get_baseclass_method("__len__") in dict_methods:
             return VariableTracker.build(tx, len(self.value))  # type: ignore[bad-argument-type]
-        return super().mp_length(tx)
+        return super().mp_length_impl(tx)
 
 
 class RandomVariable(UserDefinedObjectVariable):


### PR DESCRIPTION
Renames the nine slot handler methods listed in #190841:

| Field | Old | New |
| --- | --- | --- |
| `nb_bool` | `bool_impl` | `nb_bool_impl` |
| `sq_length` | `sq_length` | `sq_length_impl` |
| `sq_contains` | `sq_contains` | `sq_contains_impl` |
| `mp_length` | `mp_length` | `mp_length_impl` |
| `tp_repr` | `repr_impl` | `tp_repr_impl` |
| `tp_str` | `str_impl` | `tp_str_impl` |
| `tp_getattro` | `getattro_impl` | `tp_getattro_impl` |
| `tp_setattro` | `setattro_impl` | `tp_setattro_impl` |
| `tp_richcompare` | `richcompare_impl` | `tp_richcompare_impl` |

Follows #190702. The `_SLOT_FN` mapping in `variables/base.py` is updated accordingly.

Two notes on scope:
- C struct field names (`PySequenceMethods.sq_length`, `PyMappingMethods.mp_length`, etc.) are left unchanged, since they mirror CPython's layout rather than naming the handler.
- `gb_type` strings keep the bare slot name, matching the existing `mp_subscript` precedent; only the `context` strings pick up the `_impl` suffix. `graph_break_registry.json` is updated to match.

Verified locally: `lintrunner` clean, and all passing — `test_misc.py` (826), `test_contains_protocol.py` (185), `test_tp_richcompare.py` (167), `test_getitem.py` (107), `test_tp_getattro.py` (72), `test_repr_protocol.py` (38), `test_tp_slots.py` (25).

Fixes #190841

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98