### PR TITLE
[inductor] Preserve real signed zero in add no-op folding

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -9506,7 +9506,7 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             x.copy_(src)
 
         def fn(b):
-            zeros = torch.zeros_like(b)
+            zeros = torch.full_like(b, -0.0)
             result = b + zeros
             mutate_tensor(b, zeros)
             return result

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8649,11 +8649,13 @@ for dtype in (torch.int32, torch.int64):
 
         # test no-op
         fns = (
-            lambda x: x + torch.zeros([256, 256], dtype=torch.float32, device=x.device),
+            lambda x: (
+                x + torch.full([256, 256], -0.0, dtype=torch.float32, device=x.device)
+            ),
             lambda x: x - torch.zeros([256, 256], dtype=torch.float32, device=x.device),
             lambda x: x * torch.ones([256, 256], dtype=torch.float32, device=x.device),
             lambda x: x / torch.ones([256, 256], dtype=torch.float32, device=x.device),
-            lambda x: x + 0,
+            lambda x: torch.add(x, -0.0),
             lambda x: x - 0,
             lambda x: x * 1,
             lambda x: x / 1,
@@ -8693,6 +8695,85 @@ for dtype in (torch.int32, torch.int64):
             self.assertEqual(
                 out, matmul_with_op(inps[0], inps[1], fn), atol=atol, rtol=rtol
             )
+
+    @parametrize("dtype", (torch.float32, torch.float64))
+    @torch._inductor.config.patch(joint_graph_constant_folding=True)
+    def test_add_positive_zero_signed_zero(self, dtype):
+        if not self.is_dtype_supported(dtype):
+            raise unittest.SkipTest(f"{dtype} is not supported on {self.device}")
+
+        def fn(x):
+            zero = torch.zeros_like(x)
+            integer_zero = torch.full(
+                x.shape,
+                -0.0,
+                dtype=torch.int32,
+                device=x.device,
+            )
+            outputs = (
+                x + 0.0,
+                0.0 + x,
+                x + zero,
+                zero + x,
+                x + integer_zero,
+                integer_zero + x,
+            )
+            return tuple((torch.reciprocal(y), torch.signbit(y)) for y in outputs)
+
+        compiled = torch.compile(
+            fn,
+            backend="inductor",
+            fullgraph=True,
+        )
+        inputs = [
+            torch.tensor(
+                [-0.0, +0.0, -1.0, +1.0],
+                dtype=dtype,
+                device=self.device,
+            )
+        ]
+        if is_dynamic_shape_enabled():
+            inputs.append(
+                torch.tensor(
+                    [-0.0, +0.0, -2.0, +2.0, +3.0],
+                    dtype=dtype,
+                    device=self.device,
+                )
+            )
+
+        post_grad_graph = get_post_grad_graph(compiled, (inputs[0],))
+        FileCheck().check("torch.ops.aten.add.Tensor").run(post_grad_graph)
+
+        int_dtype = torch.int32 if dtype == torch.float32 else torch.int64
+        for x in inputs:
+            expected = fn(x)
+            actual = compiled(x)
+            for expected_group, actual_group in zip(expected, actual, strict=True):
+                expected_reciprocal, expected_signbit = expected_group
+                actual_reciprocal, actual_signbit = actual_group
+                self.assertEqual(
+                    actual_reciprocal.cpu().view(int_dtype),
+                    expected_reciprocal.cpu().view(int_dtype),
+                )
+                self.assertEqual(actual_signbit, expected_signbit)
+
+    @torch._inductor.config.patch(joint_graph_constant_folding=True)
+    def test_remove_no_ops_add_zero_integral(self):
+        def fn(x):
+            zero = torch.zeros_like(x)
+            outputs = (x + zero, zero + x, x + 0, 0 + x)
+            return tuple(torch.logical_not(y) for y in outputs)
+
+        for dtype in (torch.bool, torch.int32):
+            x = torch.tensor(
+                [0, 1, 1, 0],
+                dtype=dtype,
+                device=self.device,
+            )
+            compiled = torch.compile(fn, fullgraph=True)
+            post_grad_graph = get_post_grad_graph(compiled, (x,))
+            FileCheck().check_not("torch.ops.aten.add.Tensor").run(post_grad_graph)
+            self.assertEqual(compiled(x), fn(x))
 
     def test_remove_noop_copy(self):
         def fn(x, y):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -51,6 +51,7 @@ from inductor.test_torchinductor import (  # @manual=fbcode//caffe2/test/inducto
     check_model_gpu,
     CommonTemplate,
     copy_tests,
+    get_post_grad_graph,
     TestFailure,
 )
 
@@ -222,10 +223,10 @@ class TestInductorDynamic(DynamicShapesTestCase):
         torch._dynamo.reset()
 
     def test_constant_fold_uniform_value_dynamic(self, device):
-        def full_add_zero(x):
-            a = torch.full(x.shape, 1, dtype=x.dtype, device=x.device)
-            b = a - 1
-            return x + b
+        def full_add_negative_zero(x):
+            a = torch.full(x.shape, 0.0, dtype=x.dtype, device=x.device)
+            b = -a
+            return torch.sin(x + b)
 
         def full_mul_one(x):
             a = torch.full(x.shape, -1, dtype=x.dtype, device=x.device)
@@ -242,7 +243,7 @@ class TestInductorDynamic(DynamicShapesTestCase):
             b = 2 + a
             return b * x.shape[0]
 
-        fns = (full_add_zero, full_mul_one, full_view_op)
+        fns = (full_add_negative_zero, full_mul_one, full_view_op)
 
         x = torch.randn((2, 4), device=device)
         y = torch.randn((3, 4), device=device)
@@ -253,9 +254,14 @@ class TestInductorDynamic(DynamicShapesTestCase):
                 ref = fn(x)
                 fn_c = torch.compile(fn, dynamic=dynamic)
 
-                actual, source_codes = run_and_get_code(fn_c, x)
-
-                if fn is not full_mul_symint:
+                if fn is full_add_negative_zero:
+                    post_grad_graph = get_post_grad_graph(fn_c, (x,))
+                    FileCheck().check_not("torch.ops.aten.add.Tensor").run(
+                        post_grad_graph
+                    )
+                    actual = fn_c(x)
+                else:
+                    actual, source_codes = run_and_get_code(fn_c, x)
                     # due to constant folding, fn returns x directly.
                     if device == "cpu":
                         FileCheck().check_not("cpp_fused").run(source_codes[0])

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -2,6 +2,7 @@
 import functools
 import itertools
 import logging
+import math
 import operator
 import typing
 from collections import Counter
@@ -123,6 +124,26 @@ def remove_no_ops(
         def isScalarValue(arg):
             return isinstance(arg, (int, float))
 
+        def is_negative_zero(arg):
+            value = arg
+            if isinstance(arg, torch.fx.Node):
+                val = arg.meta.get("val")
+                if not (
+                    arg in zeros
+                    and arg.op == "call_function"
+                    and arg.target is aten.full.default
+                    and len(arg.args) == 2
+                    and isinstance(val, torch.Tensor)
+                    and val.dtype.is_floating_point
+                ):
+                    return False
+                value = arg.args[1]
+            return (
+                isinstance(value, float)
+                and value == 0.0
+                and math.copysign(1.0, value) < 0
+            )
+
         def replace_no_op(node, replace_input_index):
             replacement = node.args[replace_input_index]
 
@@ -179,8 +200,16 @@ def remove_no_ops(
                 replacement = node.args[replace_index]
                 if isinstance(replacement, torch.fx.Node):
                     val = replacement.meta.get("val")
-                    if isinstance(val, torch.Tensor) and val.is_conj():
-                        continue
+                    if isinstance(val, torch.Tensor):
+                        if val.is_conj():
+                            continue
+                        # Adding +0.0 to -0.0 produces +0.0, so +0.0 is not an
+                        # identity for real floating tensors. Adding -0.0 does
+                        # preserve both signed zeros, so signed-zero semantics
+                        # do not block the existing no-op replacement.
+                        zero = node.args[1 - replace_index]
+                        if val.dtype.is_floating_point and not is_negative_zero(zero):
+                            continue
                 replace_no_op(node, replace_index)
 
         for node in graph.find_nodes(op="call_function", target=aten.sub.Tensor):


### PR DESCRIPTION
## AI assistance disclosure

I personally reviewed the implementation, the four-file diff, and the supporting CPU/MPS validation results. Based on this review, I believe the quoted Codex analysis correctly identifies the root cause, accurately describes the narrowly scoped fix for real floating-point `aten.add(..., +0.0)`, and clearly reflects the limitations that this PR does not attempt to address.

> Codex assisted with tracing the `remove_no_ops` rewrite, preparing the implementation and tests, running local validation, and drafting the contained material below.

## Issue

> Addresses the real-floating `aten.add(..., +0.0)` path in #189799. This PR intentionally does not close the broader issue.

## Summary

> For real floating tensors, adding `+0.0` is not an identity when the other operand is `-0.0`: eager produces `+0.0`, while `remove_no_ops` could return the original `-0.0`. This change removes a real-floating add-zero node only when the zero operand is provably `-0.0`, while preserving integral folding and the existing conjugate and mutation safeguards. Tests cover exact reciprocal bits and sign bits, scalar and tensor `+0.0` in both operand orders, static and dynamic shapes, integral folding, and mutation safety.

## Test plan

> - Original reproducers 1 and 2 passed on the compatible July 23 source/runtime baseline.
> - Focused static and dynamic CPU signed-zero, existing no-op, integral-zero, and mutation tests passed.
> - Focused MPS validation completed with 6 passes and 2 expected float64 skips.
> - Current-main static integration checks passed.
> - Current-main runtime and CI remain pending because the available local nightly binary is ABI-incompatible with the current source checkout.

## Checklist

> - [ ] Passes lint (`spin fixlint`)
> - [x] Added/updated tests
> - [x] Updated documentation (not applicable; no user-facing API change)
> - [ ] Included benchmark results (not run; this correctness fix can retain an `add(+0.0)` node)

## BC-breaking?

> No.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98