### PR TITLE
[docs-preview] Stop sourcing untrusted artifact metadata (OIDC/shell injection)

### DIFF
--- a/.github/workflows/upload-docs-preview.yml
+++ b/.github/workflows/upload-docs-preview.yml
@@ -48,19 +48,18 @@ jobs:
         id: metadata
         shell: bash
         run: |
-          set -ex
-          if [ ! -f docs-preview-staging/pr-metadata.txt ]; then
+          set -eu
+          meta="docs-preview-staging/pr-metadata.txt"
+          if [ ! -f "${meta}" ]; then
             echo "pr-metadata.txt missing from artifact, aborting."
             exit 1
           fi
-          # shellcheck disable=SC1091
-          source docs-preview-staging/pr-metadata.txt
-          if [ -z "${PR_NUMBER:-}" ]; then
-            echo "PR_NUMBER is empty, aborting."
+          PR_NUMBER="$(grep -m1 '^PR_NUMBER=' "${meta}" | cut -d= -f2- || true)"
+          if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "PR_NUMBER is not a positive integer, aborting."
             exit 1
           fi
           echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
-          echo "docs_type=${DOCS_TYPE}" >> "${GITHUB_OUTPUT}"
 
       - name: Configure AWS credentials
         if: steps.download.outcome == 'success'


### PR DESCRIPTION
## Summary

`.github/workflows/upload-docs-preview.yml` runs in the **base-repo context** with `id-token: write` and downloads an artifact produced by the **fork-triggerable** `docs-build` workflow. It then executed:

```bash
source docs-preview-staging/pr-metadata.txt
```

Because the artifact is attacker-controlled (a fork PR's build job runs the PR's own code on the runner and can overwrite the staged `pr-metadata.txt` before it is uploaded), `source` allowed **arbitrary shell execution in the privileged job** — before AWS credentials are configured. That code has automatic access to `ACTIONS_ID_TOKEN_REQUEST_URL`/`ACTIONS_ID_TOKEN_REQUEST_TOKEN` and could mint/exfiltrate the GitHub OIDC token (→ assume `role/arc`, write to `s3://doc-previews`).

## Fix

- **Stop `source`-ing the artifact.** Parse only `PR_NUMBER` with `grep`/`cut` and validate it as a positive integer (`^[0-9]+$`). This removes the code-execution vector and also prevents the value from steering the `s3://doc-previews/pytorch/pytorch/${PR_NUMBER}` key.
- **Drop `DOCS_TYPE` from the artifact** — the upload steps already gate on `matrix.docs_type`, so nothing consumed the metadata output. One fewer untrusted value read from the artifact.
- Dropped `set -x` so metadata contents aren't echoed into logs.

No behavioral change for legitimate builds (`pr-metadata.txt` already contains `PR_NUMBER=<int>`).

## Test 

https://github.com/pytorch/pytorch/actions/runs/30108936177/job/89533210137

## Follow-ups (not in this PR)
- Resolve `PR_NUMBER` from the trusted `workflow_run.head_sha` via the API instead of the artifact.
- Tighten the `role/arc` trust policy (`sub`/`aud` pinning) and scope S3 to `doc-previews/pytorch/pytorch/*`.
- Split parse/validate (no `id-token`) from the privileged upload job.