### PR TITLE
[docs] Clarify grouped_mm offsets and add example

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -7151,9 +7151,8 @@ def grouped_mm(
             ``weight.transpose(-2, -1)`` as ``mat_b``.
         offs: Optional 1D tensor of monotonically increasing ``int32`` offsets that
             delimit the jagged dimension of any 2D operand. ``offs[i]`` marks the end
-            of group ``i`` and ``offs[-1]`` must be strictly less than the total
-            length of that operand's sliced dimension; elements beyond ``offs[-1]``
-            are ignored.
+            of group ``i`` and ``offs[-1]`` must be less than or equal to the
+            total length of that operand's sliced dimension.
         bias: Optional tensor that is added to the grouped outputs. Bias is not
             jagged and must be broadcastable to the result shape of each group.
         out_dtype: Optional dtype that controls the accumulation/output dtype.
@@ -7163,6 +7162,17 @@ def grouped_mm(
     Returns:
         A tensor containing the concatenated results of each per-group GEMM with
         shape inferred from the operands and ``offs``.
+
+    Examples::
+
+        >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)
+        >>> mat_a = torch.randn(32, 64, device="cuda", dtype=torch.bfloat16)  # (M, K)
+        >>> weight = torch.randn(2, 8, 64, device="cuda", dtype=torch.bfloat16)  # (num_groups, N, K)
+        >>> mat_b = weight.transpose(-2, -1)  # (num_groups, K, N)
+        >>> offs = torch.tensor([16, 32], device="cuda", dtype=torch.int32)
+        >>> out = F.grouped_mm(mat_a, mat_b, offs=offs)
+        >>> out.shape
+        torch.Size([32, 8])
     """
 
     return torch._grouped_mm(mat_a, mat_b, offs=offs, bias=bias, out_dtype=out_dtype)


### PR DESCRIPTION
Fixes #191650

Follow-up to #191610, which clarified the `mat_b` operand layout.

## Summary

- Clarify that `offs[-1]` may equal the length of the sliced operand dimension.
- Remove the ambiguous claim that elements beyond `offs[-1]` are ignored.
- Add a compact CUDA example with distinct `M` and `N` dimensions showing the standard Linear weight layout, the transposed `mat_b` operand, and a final offset equal to `mat_a.size(0)`.

The previous documentation required `offs[-1]` to be strictly less than the sliced dimension length. However, `test_grouped_gemm_2d_3d` constructs:

```python
offs = torch.arange(m, n_groups * m + 1, m, device=device, dtype=torch.int32)
```

With `mat_a.size(0) == n_groups * m`, this gives `offs[-1] == mat_a.size(0)`, and the test exercises that boundary successfully.

Test evidence:
https://github.com/pytorch/pytorch/blob/daf8a9d047b7a21a14b6bce71fee952537739c7e/test/test_matmul_cuda.py#L612-L654

## Test plan

- `git diff --check upstream/main...HEAD`
- `python3 -m py_compile torch/nn/functional.py`

AI assistance disclosure: Codex was used to verify the current documentation and implementation, prepare the documentation update, address automated review feedback, and run the local validation commands. I reviewed the final diff before submitting.