### PR TITLE
Revert "[dynamo] Fix Dynamo automatic dynamic int specialization (#185280)"

### DIFF
--- a/test/dynamo/test_recompiles.py
+++ b/test/dynamo/test_recompiles.py
@@ -7,10 +7,6 @@ import torch._dynamo.testing
 from torch._dynamo import config as dc
 
 
-_GLOBAL_SPLIT_SIZE = 0
-_MISSING = object()
-
-
 class RecompileTests(torch._dynamo.test_case.TestCase):
     def test_automatic_dynamic_reduce_recompiles(self):
         # Test the counterfactual, lots of recompiles without this config
@@ -167,51 +163,6 @@ class RecompileTests(torch._dynamo.test_case.TestCase):
         with_automatic = run_with_automatic()
         self.assertEqual(with_automatic.frame_count, 3)
         self.assertEqual(with_automatic.op_count, 3)
-
-    def test_automatic_dynamic_unspecializes_global_int_split_size(self):
-        global _GLOBAL_SPLIT_SIZE
-
-        def foo(hidden_states):
-            hidden_states_t = hidden_states.transpose(0, 1)
-            _, prefill = torch.split(hidden_states_t, [0, _GLOBAL_SPLIT_SIZE], dim=-1)
-            return prefill.transpose(0, 1).sin()
-
-        counter = torch._dynamo.testing.CompileCounter()
-        opt = torch.compile(foo, backend=counter, fullgraph=True)
-
-        old_split_size = _GLOBAL_SPLIT_SIZE
-        try:
-            for split_size in [8, 4, 3, 2, 6]:
-                _GLOBAL_SPLIT_SIZE = split_size
-                opt(torch.randn(split_size, 4))
-        finally:
-            _GLOBAL_SPLIT_SIZE = old_split_size
-
-        self.assertEqual(counter.frame_count, 2)
-
-    def test_automatic_dynamic_keeps_torch_module_int_attrs_static(self):
-        attr_name = "_dynamo_test_int"
-        old_value = getattr(torch, attr_name, _MISSING)
-
-        def foo(x):
-            import torch
-
-            return x * torch._dynamo_test_int
-
-        counter = torch._dynamo.testing.CompileCounter()
-        opt = torch.compile(foo, backend=counter, fullgraph=True)
-
-        try:
-            for value in [2, 3, 4]:
-                setattr(torch, attr_name, value)
-                opt(torch.randn(2))
-        finally:
-            if old_value is _MISSING:
-                delattr(torch, attr_name)
-            else:
-                setattr(torch, attr_name, old_value)
-
-        self.assertEqual(counter.frame_count, 3)
 
     def test_aliasing_guard_failures(self):
         def foo(a, b, c):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -141,7 +141,6 @@ from ..source import (
     DynamicScalarSource,
     FloatTensorSource,
     GetItemSource,
-    GlobalSource,
     GradSource,
     is_constant_source,
     is_from_closure_source,
@@ -648,17 +647,6 @@ def bound_builtin_method_descriptor(value: Any) -> Any | None:
 
 class _missing:
     pass
-
-
-def _is_torch_module_attr_source(source: Source) -> bool:
-    if not isinstance(source, ChainedSource):
-        return False
-    base_source = source.get_base()
-    return isinstance(base_source, GlobalSource) and (
-        base_source.global_name == "torch"
-        or base_source.global_name == "__import_torch"
-        or base_source.global_name.startswith("__import_torch_dot")
-    )
 
 
 @dataclasses.dataclass
@@ -2808,21 +2796,12 @@ class VariableBuilder:
                             "integer into a tensor."
                         )
 
-                    frame_state_entry = process_automatic_dynamic(
+                    process_automatic_dynamic(
                         self.tx,
                         self.source.name,
                         FrameStateSizeEntry.make_scalar(value),
                         is_unspecialized_nn_module=self.source.guard_source.is_unspecialized_nn_module(),
                     )
-                    if (
-                        config.automatic_dynamic_shapes
-                        and frame_state_entry.scalar is auto_dynamic
-                        and not self.source.guard_source.is_unspecialized_builtin_nn_module()
-                        and not _is_torch_module_attr_source(self.source)
-                    ):
-                        return self.wrap_symint(
-                            value, frame_state_entry=frame_state_entry
-                        )
                     self.install_guards(
                         functools.partial(
                             GuardBuilder.EQUALS_MATCH, recompile_hint=recompile_hint
@@ -3314,7 +3293,6 @@ class VariableBuilder:
         value: int,
         dynamism: DimDynamic | None = None,
         context: SymIntSymbolicContext | None = None,
-        frame_state_entry: FrameStateSizeEntry | None = None,
     ) -> VariableTracker:
         if type(value) is not int:
             raise AssertionError(f"Expected exact int type, got {type(value)}")
@@ -3323,6 +3301,7 @@ class VariableBuilder:
             return self.tx.output.unspec_variable_map[self.name]
 
         shape_env = self.tx.output.shape_env
+        frame_state_entry: FrameStateSizeEntry | None = None
         if TracingContext.get().force_unspec_int_unbacked_size_like:
             wrapped_value = shape_env.create_unbacked_symint()
             _constrain_range_for_size(wrapped_value)
@@ -3345,13 +3324,12 @@ class VariableBuilder:
 
             name = self.source.name
 
-            if frame_state_entry is None:
-                frame_state_entry = process_automatic_dynamic(
-                    self.tx,
-                    name,
-                    FrameStateSizeEntry.make_scalar(value),
-                    is_unspecialized_nn_module=self.source.guard_source.is_unspecialized_nn_module(),
-                )
+            frame_state_entry = process_automatic_dynamic(
+                self.tx,
+                name,
+                FrameStateSizeEntry.make_scalar(value),
+                is_unspecialized_nn_module=self.source.guard_source.is_unspecialized_nn_module(),
+            )
 
             # TODO: This should be dynamic, as we in general do not
             # know if bare integers are actually going to be sizevars


### PR DESCRIPTION
Summary:
Revert of #185280 ("[dynamo] Fix Dynamo automatic dynamic int specialization").

That change stopped installing the EQUALS_MATCH guard on scalar ints that automatic-dynamic learned are varying. A downstream model uses such an int to size an nn.Parameter dimension; without the per-value guard, one compiled graph is reused across instances of different sizes, so inductor specializes the parameter's dim to the first-seen value and assert_size_stride_grouped fails at runtime ("expected size 1024==192 at dim=1"). Reverting to unblock.

Test Plan: Rebuilt with this revert and ran the previously-failing workload past the point where it deterministically crashed at the start of training. Relying on the exported PR's CI for build/test signal.

Reviewed By: ergaziz

Differential Revision: D113559523




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98