### PR TITLE
[caffe2] Avoid out-of-range float->integral conversions (UB) in test_tensor_creation_ops (#191025)

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1083,6 +1083,16 @@ class TestTensorCreation(TestCase):
             if torch.version.hip:
                 # HIP min float -> int64 conversion is divergent
                 vals = (-2, -1.5, -.5, 0, .5, 1.5, 2)
+            elif dtype == torch.uint8:
+                # CUDA out-of-range float -> uint8 is divergent under clang-21:
+                # out-of-range float->int is UB and codegen differs from numpy's
+                # reference. Test only in-range values so torch and numpy agree
+                # deterministically.
+                vals = (0, .5, 1.5, 2)
+            elif dtype in (torch.int8, torch.int16):
+                # CUDA min float -> int8/int16 is divergent under clang-21
+                # (out-of-range float->int is UB). Drop the out-of-range extreme.
+                vals = (-2, -1.5, -.5, 0, .5, 1.5, 2)
             else:
                 vals = (min, -2, -1.5, -.5, 0, .5, 1.5, 2)
         elif dtype == torch.uint8:


### PR DESCRIPTION
Summary:

Out-of-range floating point to integral conversion is undefined behavior in
C++, so the converted result is not guaranteed to match the numpy reference.
On CUDA the value diverges depending on codegen, so the integral-dtype cases
of this test can disagree with numpy for the out-of-range extremes. Restrict
the tested values to the in-range set for uint8/int8/int16 so torch and numpy
agree deterministically; the dropped extremes were exercising UB, not a
meaningful conversion contract.

Test Plan:
buck test -m llvmfb21 fbcode//caffe2/test:test_tensor_creation_ops (integral
dtype cases); torch and numpy agree for the restricted value sets. Also builds
clean under the current toolchain.

Differential Revision: D113565201


