### PR TITLE
[docs] Fix config option in PGO docs

### DIFF
--- a/docs/source/user_guide/torch_compiler/compile/dynamic_shapes_advanced_control_options.md
+++ b/docs/source/user_guide/torch_compiler/compile/dynamic_shapes_advanced_control_options.md
@@ -15,7 +15,7 @@ may inlvolve setting additional tools. These options include:
 
 Profile-Guided Optimization (PGO) enhances automatic dynamic by sharing profiling decisions across runs of your model. Specifically, it serializes all the choices made by automatic dynamic into a file on disk. You can then copy this file—or store it in a centralized metadata service like S3—and reuse it on other machines to ensure consistent behavior across environments.
 
-For the purposes of the rest of this tutorial, you can use the following environmental variables to turn on PGO locally `TORCH_COMPILE_JOB_ID=a TORCH_DYNAMO_AUTOMATIC_DYNAMIC_LOCAL_PGO=a`
+For the purposes of the rest of this tutorial, you can use the following environmental variables to turn on PGO locally `TORCH_COMPILE_JOB_ID=profile_1 TORCH_DYNAMO_AUTOMATIC_DYNAMIC_LOCAL_PGO=profile_1`
 
 (identifying-dynamic-elements-marked-by-pgo)=
 ### Identifying Dynamic Elements Marked by PGO

--- a/docs/source/user_guide/torch_compiler/compile/dynamic_shapes_advanced_control_options.md
+++ b/docs/source/user_guide/torch_compiler/compile/dynamic_shapes_advanced_control_options.md
@@ -15,7 +15,7 @@ may inlvolve setting additional tools. These options include:
 
 Profile-Guided Optimization (PGO) enhances automatic dynamic by sharing profiling decisions across runs of your model. Specifically, it serializes all the choices made by automatic dynamic into a file on disk. You can then copy this file—or store it in a centralized metadata service like S3—and reuse it on other machines to ensure consistent behavior across environments.
 
-For the purposes of the rest of this tutorial, you can use the following environmental variables to turn on PGO locally `TORCH_COMPILE_JOB_ID=1 TORCH_DYNAMO_AUTOMATIC_DYNAMIC_LOCAL_PGO=1`
+For the purposes of the rest of this tutorial, you can use the following environmental variables to turn on PGO locally `TORCH_COMPILE_JOB_ID=a TORCH_DYNAMO_AUTOMATIC_DYNAMIC_LOCAL_PGO=a`
 
 (identifying-dynamic-elements-marked-by-pgo)=
 ### Identifying Dynamic Elements Marked by PGO


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191027

0/1 config options get converted to bool, which crashes
[here](https://github.com/pytorch/pytorch/blob/96dbc5eae90a3ae4bee7886b881f0fdc6c9ee965/torch/_dynamo/pgo.py#L613).
Update to use a safer string