### PR TITLE
[dynamo] remove redundant nested_graph_breaks=True config patches in tests

### DIFF
--- a/test/dynamo/test_comprehensions.py
+++ b/test/dynamo/test_comprehensions.py
@@ -857,7 +857,6 @@ class ComprehensionTests(torch._dynamo.test_case.TestCase):
 
 @skipIfNotPy312
 class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_function_calls_with_comprehension_graph_break_nested_graph_breaks_true(
         self,
     ):
@@ -890,7 +889,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 3)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 3)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_result_var_name_collision(self):
         """Comprehension result_var in leaf frame shares a name with a root frame local."""
 
@@ -913,7 +911,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 1)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 3)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_function_comprehension_with_walrus(self):
         """Nested function with comprehension containing walrus operator."""
 
@@ -938,7 +935,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 4)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_function_comprehension_with_captured_var(self):
         """Nested function with comprehension capturing outer variable passed as parameter."""
 
@@ -964,7 +960,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 3)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_triple_nested_function_comprehension(self):
         """Triple nested function calls (f->g->h->deepest) with comprehension in deepest."""
 
@@ -1001,7 +996,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 4)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 4)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_multiple_nested_comprehensions_in_different_functions(self):
         """Two sequential nested function calls each with comprehensions."""
 
@@ -1033,7 +1027,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[2], operator.add), 1)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_function_comprehension_with_outer_list_mutation(self):
         """Nested function with comprehension mutating outer list."""
 
@@ -1059,7 +1052,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_list_comprehension_graph_break(self):
         """Nested version of test_list_comprehension_graph_break."""
 
@@ -1084,7 +1076,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_dict_comprehension_graph_break(self):
         """Nested version of test_dict_comprehension_graph_break."""
 
@@ -1109,7 +1100,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_list_comprehension_with_graph_break_function(self):
         """Nested version of test_list_comprehension_with_graph_break_function."""
 
@@ -1140,7 +1130,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.mul), 1)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 3)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_multiple_comprehensions_one_break(self):
         """Nested version of test_multiple_comprehensions_one_break."""
 
@@ -1167,7 +1156,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_nested_comprehension_inner_break(self):
         """Nested version of test_nested_comprehension_inner_break."""
 
@@ -1195,7 +1183,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_multi_iterator_comprehension_break(self):
         """Nested version of test_multi_iterator_comprehension_break."""
 
@@ -1224,7 +1211,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_discarded_comprehension_graph_break(self):
         """Nested version of test_discarded_comprehension_graph_break."""
 
@@ -1249,7 +1235,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_in_expression_graph_break(self):
         """Nested version of test_comprehension_in_expression_graph_break."""
 
@@ -1274,7 +1259,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_return_directly(self):
         """Nested version of test_comprehension_return_directly."""
 
@@ -1297,7 +1281,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 1)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_walrus_operator_in_comprehension(self):
         """Nested version of test_walrus_operator_in_comprehension."""
 
@@ -1322,7 +1305,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_walrus_operator_in_if_in_comprehension(self):
         """Nested version of test_walrus_operator_in_if_in_comprehension."""
 
@@ -1349,7 +1331,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_walrus_operator_in_comprehension_with_tensor(self):
         """Nested version of test_walrus_operator_in_comprehension_with_tensor."""
 
@@ -1378,7 +1359,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_multiple_walrus_operators_in_comprehension(self):
         """Nested version of test_multiple_walrus_operators_in_comprehension."""
 
@@ -1406,7 +1386,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_nested_comprehension_with_walrus_operators(self):
         """Nested version of test_nested_comprehension_with_walrus_operators."""
 
@@ -1440,7 +1419,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_nested_comprehension_with_captured_outer_variable(self):
         """Nested version of test_nested_comprehension_with_captured_outer_variable."""
 
@@ -1469,7 +1447,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_triple_nested_comprehension_with_walrus(self):
         """Nested version of test_triple_nested_comprehension_with_walrus."""
 
@@ -1504,7 +1481,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_nested_dict_comprehension_with_walrus_and_captured(self):
         """Nested version of test_nested_dict_comprehension_with_walrus_and_captured."""
 
@@ -1537,7 +1513,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_with_outer_variable_read(self):
         """Nested version of test_comprehension_with_outer_variable_read."""
 
@@ -1565,7 +1540,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_with_outer_list_mutation(self):
         """Nested version of test_comprehension_with_outer_list_mutation."""
 
@@ -1595,7 +1569,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_with_outer_dict_mutation(self):
         """Nested version of test_comprehension_with_outer_dict_mutation."""
 
@@ -1625,7 +1598,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_with_outer_list_extend(self):
         """Nested version of test_comprehension_with_outer_list_extend."""
 
@@ -1655,7 +1627,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_with_outer_list_pop(self):
         """Nested version of test_comprehension_with_outer_list_pop."""
 
@@ -1686,7 +1657,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_with_global_variable(self):
         """Nested version of test_comprehension_with_global_variable."""
         global _GLOBAL_VALUE_FOR_COMPREHENSION_TEST
@@ -1717,7 +1687,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_with_closure_variable(self):
         """Nested version of test_comprehension_with_closure_variable."""
 
@@ -1752,7 +1721,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_with_closure_list_mutation(self):
         """Nested version of test_comprehension_with_closure_list_mutation."""
 
@@ -1789,7 +1757,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_nested_multi_for_comprehension_graph_break(self):
         """Nested version of test_nested_multi_for_comprehension_graph_break."""
 
@@ -1818,7 +1785,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_multiple_comprehension_graph_breaks(self):
         """Nested version of test_multiple_comprehension_graph_breaks."""
 
@@ -1846,7 +1812,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[1], operator.add), 1)
         self.assertEqual(count_op(backend.graphs[2], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_modifying_global_variable(self):
         """Nested version of test_comprehension_modifying_global_variable."""
         global _GLOBAL_VALUE_FOR_COMPREHENSION_TEST
@@ -1885,7 +1850,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_modifying_closure_variable(self):
         """Nested version of test_comprehension_modifying_closure_variable."""
 
@@ -1921,7 +1885,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_list_and_dict_comprehension_graph_breaks(self):
         """Nested version of test_list_and_dict_comprehension_graph_breaks."""
 
@@ -1949,7 +1912,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[1], operator.add), 1)
         self.assertEqual(count_op(backend.graphs[2], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_nested_dict_in_list_comprehension_graph_break(self):
         """Nested version of test_nested_dict_in_list_comprehension_graph_break."""
 
@@ -1977,7 +1939,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_nonlocal_int_mutation(self):
         """Nonlocal int mutation around a comprehension graph break."""
 
@@ -2005,7 +1966,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 1)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 1)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_nonlocal_tensor_mutation(self):
         """Nonlocal tensor mutation around a comprehension graph break."""
 
@@ -2033,7 +1993,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 1)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_nonlocal_different_varnames(self):
         """Inner function uses different variable names than root function."""
 
@@ -2062,7 +2021,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 3)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 4)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_nonlocal_tensor_different_varnames(self):
         """Inner function uses different variable names than root function (tensor variant)."""
 
@@ -2091,7 +2049,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_captured_tensor(self):
         """Comprehension in inlined function captures a tensor from the inlined function."""
 
@@ -2113,7 +2070,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 1)
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_comprehension_name_shadowing(self):
         """Root and leaf frames have variables with the same name."""
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -2611,7 +2611,7 @@ User code traceback:
         def outer(x):
             return middle_with_try(x)
 
-        with torch._dynamo.config.patch(nested_graph_breaks=True, verbose=False):
+        with torch._dynamo.config.patch(verbose=False):
             torch.compile(outer, backend="eager")(torch.ones(3))
 
         full_messages = [
@@ -2710,7 +2710,7 @@ Call to `torch._dynamo.graph_break()`
             x = inner(x + 4) + 8
             return inner(x) + 16
 
-        with torch._dynamo.config.patch(nested_graph_breaks=True, verbose=False):
+        with torch._dynamo.config.patch(verbose=False):
             outer(torch.ones(3))
 
         self.assertEqual(

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -17069,7 +17069,6 @@ def forward(self, L_x_ : torch.Tensor):
         self.assertEqual(opt(), "1:2:3")
 
     @unittest.skipIf(sys.version_info >= (3, 12), "comprehensions inlined in 3.12+")
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_listcomp_implicit_iterator_survives_graph_break(self):
         """Regression test: the implicit .0 iterator in a list comprehension
         must survive graph breaks under NGB.
@@ -17097,7 +17096,6 @@ def forward(self, L_x_ : torch.Tensor):
         result = opt(x)
         self.assertTrue(torch.all(result > x))
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_module_hooks_dict_reconstructed_as_ordered_dict(self):
         """Empty hooks dicts on nn.Module must be reconstructed as OrderedDict,
         not plain dict, so that weakref.ref() works in RemovableHandle.

--- a/test/dynamo/test_subgraphs.py
+++ b/test/dynamo/test_subgraphs.py
@@ -308,7 +308,6 @@ class SubGraphTests(torch._dynamo.test_case.TestCase):
             ],
         )
 
-    @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_resume_del_releases_tensor(self):
         refs = []
         events = []


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191028

torch._dynamo.test_case.TestCase.setUp already forces
config.nested_graph_breaks = True unconditionally (both OSS and fbcode) for
every test using it, so per-test @config.patch(nested_graph_breaks=True)
decorators -- and the nested_graph_breaks=True argument in multi-config
patches -- are no-ops. Remove them, leaving TestCase.setUp as the single
source of truth for enabling NGB in unittests.

All affected classes inherit that setUp: NestedGraphBreakTests
(test_comprehensions), MiscTests (via torch._inductor.test_case.TestCase),
SubGraphTests, and ErrorMessagesTest (via LoggingTestCase). Behavior is
unchanged; the tests still run with NGB enabled.

Test Plan:

```
python test/dynamo/test_comprehensions.py NestedGraphBreakTests
python test/dynamo/test_subgraphs.py
python test/dynamo/test_error_messages.py ErrorMessagesTest.test_try_block_with_graph_break_suppression ErrorMessagesTest.test_nested_graph_break_different_call_sites_not_suppressed
```

Authored with assistance from Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98