### PR TITLE
[dynamo] preserve non-tensor autograd.Function outputs in reconstructed node

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -531,6 +531,101 @@ class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, Foo.apply(x))
         self.assertEqual(cnt.frame_count, 1)
 
+    def test_non_tensor_output_grad_fn_hook_arity(self):
+        # Non-tensor forward outputs are dropped from the traced fwd graph, but
+        # must be re-inserted into the reconstructed autograd node so grad_fn
+        # hooks observe the same number of grad_outputs as eager. Exercise
+        # leading / trailing / multiple non-tensor output orderings so the
+        # merge/strip/slice index arithmetic is covered beyond the single
+        # middle-non-tensor case.
+        class Leading(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, k, y):
+                return k, x * 2, y * 3
+
+            @staticmethod
+            def backward(ctx, gk, g1, g2):
+                return g1 * 2, None, g2 * 3
+
+        class Trailing(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, k, y):
+                return x * 2, y * 3, k
+
+            @staticmethod
+            def backward(ctx, g1, g2, gk):
+                return g1 * 2, None, g2 * 3
+
+        class Multiple(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, k, y):
+                return k, x * 2, k + 1, y * 3, k + 2
+
+            @staticmethod
+            def backward(ctx, gk0, g1, gk1, g2, gk2):
+                return g1 * 2, None, g2 * 3
+
+        def run(fn, compiled):
+            torch._dynamo.reset()
+            a = torch.ones(3, requires_grad=True)
+            b = torch.ones(3, requires_grad=True)
+            counts = []
+
+            def apply_fn(a, b):
+                out = fn.apply(a, 3, b)
+                tensors = [o for o in out if isinstance(o, torch.Tensor)]
+                tensors[0].grad_fn.register_prehook(
+                    lambda go: counts.append(len(go)) or None
+                )
+                return tensors
+
+            f = torch.compile(apply_fn, backend="eager") if compiled else apply_fn
+            tensors = f(a, b)
+            sum(t.sum() for t in tensors).backward()
+            return counts, a.grad, b.grad
+
+        for fn in (Leading, Trailing, Multiple):
+            e_counts, e_ga, e_gb = run(fn, compiled=False)
+            c_counts, c_ga, c_gb = run(fn, compiled=True)
+            self.assertEqual(e_counts, c_counts)
+            self.assertEqual(e_ga, c_ga)
+            self.assertEqual(e_gb, c_gb)
+
+    def test_non_tensor_output_with_mark_non_differentiable(self):
+        # A non-tensor output preceding a mark_non_differentiable tensor output
+        # previously misindexed mark_non_differentiable under compile.
+        class Fn(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, k, y):
+                a = x * 2
+                aux = y * 3
+                ctx.mark_non_differentiable(aux)
+                return k, a, aux
+
+            @staticmethod
+            def backward(ctx, gk, ga, gaux):
+                return ga * 2, None, None
+
+        def run(compiled):
+            torch._dynamo.reset()
+            x = torch.ones(3, requires_grad=True)
+            y = torch.ones(3, requires_grad=True)
+
+            def apply_fn(x, y):
+                _k, a, aux = Fn.apply(x, 3, y)
+                return a, aux
+
+            f = torch.compile(apply_fn, backend="eager") if compiled else apply_fn
+            a, aux = f(x, y)
+            a.sum().backward()
+            return x.grad, aux.requires_grad
+
+        e_grad, e_req = run(compiled=False)
+        c_grad, c_req = run(compiled=True)
+        self.assertEqual(e_grad, c_grad)
+        self.assertEqual(e_req, c_req)
+        self.assertFalse(c_req)
+
     def test_data_in_bwd(self):
         class Foo(torch.autograd.Function):
             @staticmethod

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -5255,6 +5255,32 @@ class AutogradFunctionApplyVariable(VariableTracker):
                 if x.is_tensor() and x.as_proxy() in non_differentiable_set:
                     non_differentiable_idx.append(i)
 
+        # Only tensor/symint/custom-class outputs flow through the fwd graph;
+        # any remaining (non-tensor) outputs are dropped from it. To keep the
+        # reconstructed autograd node's output arity matching eager (so hooks
+        # registered on grad_fn see the right number of grad_outputs), we thread
+        # these non-tensor outputs, which are compile-time constants, and their
+        # original positions to ApplyTemplate so they are re-inserted there.
+        non_tensor_output_indices: list[int] = []
+        non_tensor_output_values: list[Any] = []
+        if isinstance(fwd_out, variables.BaseListVariable):
+            try:
+                for i, x in enumerate(fwd_out.items):
+                    if not (
+                        x.is_tensor()
+                        or isinstance(x, (SymNodeVariable, CustomClassObjectVariable))
+                    ):
+                        non_tensor_output_indices.append(i)
+                        non_tensor_output_values.append(x.as_python_constant())
+            except NotImplementedError:
+                # A non-tensor output is not a compile-time constant; fall back
+                # to the historical behavior of dropping non-tensor outputs. In
+                # this path the reconstructed node keeps the shorter tensor-only
+                # arity, so a mark_non_differentiable/mark_dirty on a tensor
+                # after a dropped output stays misindexed (pre-existing).
+                non_tensor_output_indices = []
+                non_tensor_output_values = []
+
         dirty_idx: list[int] = []
         if ctx.dirty_tensors is not None:
             dirty_tensor_set: set[Proxy] = {
@@ -5333,6 +5359,10 @@ class AutogradFunctionApplyVariable(VariableTracker):
         # Preserve the existing HOP call shape for the common no-mark_dirty case.
         if dirty_idx:
             kwargs_for_fn["dirty_idx"] = dirty_idx
+        # Preserve the existing HOP call shape when there are no non-tensor outputs.
+        if non_tensor_output_indices:
+            kwargs_for_fn["non_tensor_output_indices"] = non_tensor_output_indices
+            kwargs_for_fn["non_tensor_output_values"] = non_tensor_output_values
 
         # Store the invocation as a call
         from torch._functorch.autograd_function import autograd_function_apply

--- a/torch/_functorch/autograd_function.py
+++ b/torch/_functorch/autograd_function.py
@@ -821,6 +821,17 @@ class AutogradFunctionApply(HigherOrderOperator):
         dirty_idx_set = set(dirty_idx)
         non_differentiable_idx = fwd_kwargs["non_differentiable_idx"]
         saved_for_backward_idx = fwd_kwargs["saved_for_backward_idx"]
+        # Non-tensor forward outputs are dropped from the traced fwd graph. We
+        # re-insert them at their original positions so the autograd node has the
+        # same output arity as eager (grad_fn hooks then see the right number of
+        # grad_outputs). These positions get None grads in backward, which we
+        # strip before running the bwd graph (which only takes tensor grads).
+        non_tensor_output_indices = fwd_kwargs.get("non_tensor_output_indices", [])
+        non_tensor_output_values = fwd_kwargs.get("non_tensor_output_values", [])
+        non_tensor_output_map = dict(
+            zip(non_tensor_output_indices, non_tensor_output_values)
+        )
+        non_tensor_output_idx_set = set(non_tensor_output_indices)
 
         class ApplyTemplate(torch.autograd.Function):
             @staticmethod
@@ -831,6 +842,16 @@ class AutogradFunctionApply(HigherOrderOperator):
                 # from the dynamo graph body to the local_map graph body.
                 # This is required for fx_traceback.annotate for work.
                 output, saved_values = torch.fx.Interpreter(fwd).run(*args)
+
+                if non_tensor_output_map:
+                    merged = []
+                    tensor_iter = iter(output)
+                    for i in range(len(output) + len(non_tensor_output_map)):
+                        if i in non_tensor_output_map:
+                            merged.append(non_tensor_output_map[i])
+                        else:
+                            merged.append(next(tensor_iter))
+                    output = tuple(merged)
 
                 # See Note [Activations with no version counter checks in eager]
                 # Mark tensors that came from ctx.save_for_backward with metadata.
@@ -871,9 +892,24 @@ class AutogradFunctionApply(HigherOrderOperator):
 
                 if saved_values is None:
                     raise AssertionError("saved_values must not be None")
+                if non_tensor_output_idx_set:
+                    grad = tuple(
+                        g
+                        for i, g in enumerate(grad)
+                        if i not in non_tensor_output_idx_set
+                    )
                 return torch.fx.Interpreter(bwd).run(*grad, *saved_values)
 
-        return ApplyTemplate.apply(*fwd_args)
+        result = ApplyTemplate.apply(*fwd_args)
+        if non_tensor_output_idx_set:
+            # Return only the tensor outputs so the HOP result stays aligned with
+            # the traced fwd graph outputs; the non-tensor outputs are still part
+            # of the autograd node (correct arity) but are consumed via the
+            # original output structure Dynamo keeps tracing with.
+            result = tuple(
+                r for i, r in enumerate(result) if i not in non_tensor_output_idx_set
+            )
+        return result
 
 
 autograd_function_apply = AutogradFunctionApply()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

When a custom torch.autograd.Function.forward returns a mix of tensor and
non-tensor outputs, Dynamo's speculate_subgraph_with_auto_output_flattening
only routes tensor/symint/custom-class outputs into the traced forward fx
graph; non-tensor outputs are dropped. The reconstructed autograd node
(AutogradFunctionApply -> ApplyTemplate) therefore had fewer output slots
than eager, so hooks registered on grad_fn (e.g. register_prehook) received
the wrong number of grad_outputs. Gradients themselves were correct (the
missing slots were non-differentiable).

Thread the dropped non-tensor outputs -- which are compile-time constants --
and their original positions to ApplyTemplate, which re-inserts them in
forward (restoring eager-matching arity), strips their None grad slots in
backward before running the tensor-only bwd graph, and slices them back out
of the HOP result to preserve alignment with the tensor-only fwd graph
outputs. This also realigns non_differentiable_idx/dirty_idx, which are
computed over full output positions but were previously indexed into the
tensor-only outputs. Non-tensor outputs that are not compile-time constants
keep the historical drop behavior.

Test Plan:
```
python test/dynamo/test_autograd_function.py AutogradFunctionTests.test_non_tensor_output_grad_fn_hook_arity AutogradFunctionTests.test_non_tensor_output_with_mark_non_differentiable
python test/dynamo/test_autograd_function.py
```

Co-authored-by: Claude <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98