### PR TITLE
[ROCm][CI] Introduce amd-dpx runner experiment

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -122,7 +122,7 @@ runner_mapping:
   # amd-vtr experiment routes trunk-rocm-sandbox gfx942 tests to AMD's dedicated
   # runners via this prefix; passthrough so the OSDC build's runner mapping keeps it.
   amd-vtr-linux.rocm.gpu.gfx942.1: amd-vtr-linux.rocm.gpu.gfx942.1
-  amd-vtr-linux.rocm.gpu.gfx942.4: amd-vtr-linux.rocm.gpu.gfx942.4
+  amd-vtr-linux.rocm.gpu.gfx942.2: amd-vtr-linux.rocm.gpu.gfx942.2
 
 # Runners whose hardware exists only on the Meta fleet (no LF / no AWS EC2
 # equivalent). The mapper forces the 'mt-' prefix on these regardless of which

--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -119,6 +119,10 @@ runner_mapping:
   # prefix; kept as passthrough so the OSDC build's runner mapping preserves it.
   amd-do-linux.rocm.gpu.gfx950.1: amd-do-linux.rocm.gpu.gfx950.1
   amd-do-linux.rocm.gpu.gfx950.2: amd-do-linux.rocm.gpu.gfx950.2
+  # amd-vtr experiment routes trunk-rocm-sandbox gfx942 tests to AMD's dedicated
+  # runners via this prefix; passthrough so the OSDC build's runner mapping keeps it.
+  amd-vtr-linux.rocm.gpu.gfx942.1: amd-vtr-linux.rocm.gpu.gfx942.1
+  amd-vtr-linux.rocm.gpu.gfx942.4: amd-vtr-linux.rocm.gpu.gfx942.4
 
 # Runners whose hardware exists only on the Meta fleet (no LF / no AWS EC2
 # equivalent). The mapper forces the 'mt-' prefix on these regardless of which

--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -119,10 +119,10 @@ runner_mapping:
   # prefix; kept as passthrough so the OSDC build's runner mapping preserves it.
   amd-do-linux.rocm.gpu.gfx950.1: amd-do-linux.rocm.gpu.gfx950.1
   amd-do-linux.rocm.gpu.gfx950.2: amd-do-linux.rocm.gpu.gfx950.2
-  # amd-vtr experiment routes trunk-rocm-sandbox gfx942 tests to AMD's dedicated
+  # amd-sandbox experiment routes trunk-rocm-sandbox gfx942 tests to AMD's dedicated
   # runners via this prefix; passthrough so the OSDC build's runner mapping keeps it.
-  amd-vtr-linux.rocm.gpu.gfx942.1: amd-vtr-linux.rocm.gpu.gfx942.1
-  amd-vtr-linux.rocm.gpu.gfx942.2: amd-vtr-linux.rocm.gpu.gfx942.2
+  amd-sandbox-linux.rocm.gpu.gfx942.1: amd-sandbox-linux.rocm.gpu.gfx942.1
+  amd-sandbox-linux.rocm.gpu.gfx942.2: amd-sandbox-linux.rocm.gpu.gfx942.2
 
 # Runners whose hardware exists only on the Meta fleet (no LF / no AWS EC2
 # equivalent). The mapper forces the 'mt-' prefix on these regardless of which

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -77,6 +77,7 @@ GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
 GH_OUTPUT_KEY_AMI = "runner-ami"
 GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
 GH_OUTPUT_KEY_AMD_DO_LABEL_TYPE = "amd-do-label-type"
+GH_OUTPUT_KEY_AMD_VTR_LABEL_TYPE = "amd-vtr-label-type"
 OPT_OUT_LABEL = "no-runner-experiments"
 
 SETTING_EXPERIMENTS = "experiments"
@@ -94,6 +95,9 @@ LF_LABEL_PREFIX = "lf-"
 
 AMD_DO_EXPERIMENT = "amd-do"
 AMD_DO_LABEL_PREFIX = "amd-do-"
+
+AMD_VTR_EXPERIMENT = "amd-vtr"
+AMD_VTR_LABEL_PREFIX = "amd-vtr-"
 
 
 class Experiment(NamedTuple):
@@ -122,6 +126,9 @@ class RunnerPrefixResult(NamedTuple):
     # Dedicated prefix for the amd-do experiment, exposed via its own output
     # (amd-do-label-type) instead of being folded into ``prefix``.
     amd_do_prefix: str = ""
+    # Dedicated prefix for the amd-vtr experiment, exposed via its own output
+    # (amd-vtr-label-type) instead of being folded into ``prefix``.
+    amd_vtr_prefix: str = ""
 
 
 class Settings(NamedTuple):
@@ -531,6 +538,7 @@ def get_runner_prefix(
 
     lf_enabled = False
     amd_do_prefix = ""
+    amd_vtr_prefix = ""
     for experiment_name, experiment_settings in settings.experiments.items():
         if not experiment_settings.all_branches and is_exception_branch(branch):
             log.info(
@@ -649,6 +657,14 @@ def get_runner_prefix(
                 log.info(
                     "amd-do experiment enabled. Exposing 'amd-do-' prefix via the amd-do-label-type output."
                 )
+            elif experiment_name == AMD_VTR_EXPERIMENT:
+                # The amd-vtr experiment is exposed through its own
+                # amd-vtr-label-type output rather than being mixed into the
+                # shared label-type prefix, so it can be applied per-job.
+                amd_vtr_prefix = AMD_VTR_LABEL_PREFIX
+                log.info(
+                    "amd-vtr experiment enabled. Exposing 'amd-vtr-' prefix via the amd-vtr-label-type output."
+                )
             elif experiment_name == LF_FLEET_EXPERIMENT:
                 lf_enabled = True
                 log.info("lf experiment enabled. Using the Linux Foundation fleet.")
@@ -664,7 +680,9 @@ def get_runner_prefix(
         prefix = LF_LABEL_PREFIX
     else:
         prefix = META_CANARY_LABEL_PREFIX if is_canary else META_LABEL_PREFIX
-    return RunnerPrefixResult(prefix=prefix, amd_do_prefix=amd_do_prefix)
+    return RunnerPrefixResult(
+        prefix=prefix, amd_do_prefix=amd_do_prefix, amd_vtr_prefix=amd_vtr_prefix
+    )
 
 
 def get_rollout_state_from_issue(github_token: str, repo: str, issue_num: int) -> str:
@@ -728,6 +746,7 @@ def main() -> None:
 
     runner_label_prefix = META_LABEL_PREFIX
     amd_do_label_prefix = ""
+    amd_vtr_label_prefix = ""
 
     # no-runner-experiments means "use Meta, not LF": opt out of the lf
     # experiment, so the run stays on the default Meta fleet.
@@ -770,6 +789,7 @@ def main() -> None:
         )
         runner_label_prefix = result.prefix
         amd_do_label_prefix = result.amd_do_prefix
+        amd_vtr_label_prefix = result.amd_vtr_prefix
 
     except Exception as e:
         log.error(
@@ -778,6 +798,7 @@ def main() -> None:
 
     set_github_output(GH_OUTPUT_KEY_LABEL_TYPE, runner_label_prefix)
     set_github_output(GH_OUTPUT_KEY_AMD_DO_LABEL_TYPE, amd_do_label_prefix)
+    set_github_output(GH_OUTPUT_KEY_AMD_VTR_LABEL_TYPE, amd_vtr_label_prefix)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -76,8 +76,7 @@ from github.Issue import Issue
 GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
 GH_OUTPUT_KEY_AMI = "runner-ami"
 GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
-GH_OUTPUT_KEY_AMD_DO_LABEL_TYPE = "amd-do-label-type"
-GH_OUTPUT_KEY_AMD_VTR_LABEL_TYPE = "amd-vtr-label-type"
+GH_OUTPUT_KEY_AMD_SANDBOX_LABEL_TYPE = "amd-sandbox-label-type"
 OPT_OUT_LABEL = "no-runner-experiments"
 
 SETTING_EXPERIMENTS = "experiments"
@@ -93,11 +92,8 @@ META_LABEL_PREFIX = "mt-"
 META_CANARY_LABEL_PREFIX = "c-mt-"
 LF_LABEL_PREFIX = "lf-"
 
-AMD_DO_EXPERIMENT = "amd-do"
-AMD_DO_LABEL_PREFIX = "amd-do-"
-
-AMD_VTR_EXPERIMENT = "amd-vtr"
-AMD_VTR_LABEL_PREFIX = "amd-vtr-"
+AMD_SANDBOX_EXPERIMENT = "amd-sandbox"
+AMD_SANDBOX_LABEL_PREFIX = "amd-sandbox-"
 
 
 class Experiment(NamedTuple):
@@ -123,12 +119,9 @@ class Experiment(NamedTuple):
 
 class RunnerPrefixResult(NamedTuple):
     prefix: str
-    # Dedicated prefix for the amd-do experiment, exposed via its own output
-    # (amd-do-label-type) instead of being folded into ``prefix``.
-    amd_do_prefix: str = ""
-    # Dedicated prefix for the amd-vtr experiment, exposed via its own output
-    # (amd-vtr-label-type) instead of being folded into ``prefix``.
-    amd_vtr_prefix: str = ""
+    # Dedicated prefix for the amd-sandbox experiment, exposed via its own output
+    # (amd-sandbox-label-type) instead of being folded into ``prefix``.
+    amd_sandbox_prefix: str = ""
 
 
 class Settings(NamedTuple):
@@ -537,8 +530,7 @@ def get_runner_prefix(
     user_optins = parse_users(rollout_state)
 
     lf_enabled = False
-    amd_do_prefix = ""
-    amd_vtr_prefix = ""
+    amd_sandbox_prefix = ""
     for experiment_name, experiment_settings in settings.experiments.items():
         if not experiment_settings.all_branches and is_exception_branch(branch):
             log.info(
@@ -649,21 +641,13 @@ def get_runner_prefix(
                     enabled = True
 
         if enabled:
-            if experiment_name == AMD_DO_EXPERIMENT:
-                # The amd-do experiment is exposed through its own
-                # amd-do-label-type output rather than being mixed into the
+            if experiment_name == AMD_SANDBOX_EXPERIMENT:
+                # The amd-sandbox experiment is exposed through its own
+                # amd-sandbox-label-type output rather than being mixed into the
                 # shared label-type prefix, so it can be applied per-job.
-                amd_do_prefix = AMD_DO_LABEL_PREFIX
+                amd_sandbox_prefix = AMD_SANDBOX_LABEL_PREFIX
                 log.info(
-                    "amd-do experiment enabled. Exposing 'amd-do-' prefix via the amd-do-label-type output."
-                )
-            elif experiment_name == AMD_VTR_EXPERIMENT:
-                # The amd-vtr experiment is exposed through its own
-                # amd-vtr-label-type output rather than being mixed into the
-                # shared label-type prefix, so it can be applied per-job.
-                amd_vtr_prefix = AMD_VTR_LABEL_PREFIX
-                log.info(
-                    "amd-vtr experiment enabled. Exposing 'amd-vtr-' prefix via the amd-vtr-label-type output."
+                    "amd-sandbox experiment enabled. Exposing 'amd-sandbox-' prefix via the amd-sandbox-label-type output."
                 )
             elif experiment_name == LF_FLEET_EXPERIMENT:
                 lf_enabled = True
@@ -680,9 +664,7 @@ def get_runner_prefix(
         prefix = LF_LABEL_PREFIX
     else:
         prefix = META_CANARY_LABEL_PREFIX if is_canary else META_LABEL_PREFIX
-    return RunnerPrefixResult(
-        prefix=prefix, amd_do_prefix=amd_do_prefix, amd_vtr_prefix=amd_vtr_prefix
-    )
+    return RunnerPrefixResult(prefix=prefix, amd_sandbox_prefix=amd_sandbox_prefix)
 
 
 def get_rollout_state_from_issue(github_token: str, repo: str, issue_num: int) -> str:
@@ -745,8 +727,7 @@ def main() -> None:
     args = parse_args()
 
     runner_label_prefix = META_LABEL_PREFIX
-    amd_do_label_prefix = ""
-    amd_vtr_label_prefix = ""
+    amd_sandbox_label_prefix = ""
 
     # no-runner-experiments means "use Meta, not LF": opt out of the lf
     # experiment, so the run stays on the default Meta fleet.
@@ -788,8 +769,7 @@ def main() -> None:
             workflow_name=args.workflow_name,
         )
         runner_label_prefix = result.prefix
-        amd_do_label_prefix = result.amd_do_prefix
-        amd_vtr_label_prefix = result.amd_vtr_prefix
+        amd_sandbox_label_prefix = result.amd_sandbox_prefix
 
     except Exception as e:
         log.error(
@@ -797,8 +777,7 @@ def main() -> None:
         )
 
     set_github_output(GH_OUTPUT_KEY_LABEL_TYPE, runner_label_prefix)
-    set_github_output(GH_OUTPUT_KEY_AMD_DO_LABEL_TYPE, amd_do_label_prefix)
-    set_github_output(GH_OUTPUT_KEY_AMD_VTR_LABEL_TYPE, amd_vtr_label_prefix)
+    set_github_output(GH_OUTPUT_KEY_AMD_SANDBOX_LABEL_TYPE, amd_sandbox_label_prefix)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -795,6 +795,70 @@ class TestRunnerDeterminatorAmdDoExperiment(TestCase):
         self.assertEqual("amd-do-", result.amd_do_prefix)
 
 
+class TestRunnerDeterminatorAmdVtrExperiment(TestCase):
+    AMD_VTR_SETTINGS = """
+        experiments:
+            amd-vtr:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,amd-vtr
+        @User2,lf
+
+        """
+
+    def test_amd_vtr_opted_in_returns_prefix(self) -> None:
+        result = rd.get_runner_prefix(self.AMD_VTR_SETTINGS, ["User1"], USER_BRANCH)
+        self.assertEqual("amd-vtr-", result.amd_vtr_prefix)
+        # amd-vtr is exposed via its own output; the base prefix is the default fleet
+        self.assertEqual("mt-", result.prefix)
+
+    def test_amd_vtr_not_enabled_returns_default_fleet(self) -> None:
+        # User2 opts into lf, but lf is not defined here, so it falls back to Meta
+        result = rd.get_runner_prefix(self.AMD_VTR_SETTINGS, ["User2"], USER_BRANCH)
+        self.assertEqual("", result.amd_vtr_prefix)
+        self.assertEqual("mt-", result.prefix)
+
+    def test_amd_vtr_with_lf_keeps_both(self) -> None:
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+            amd-vtr:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf,amd-vtr
+
+        """
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("lf-", result.prefix)
+        self.assertEqual("amd-vtr-", result.amd_vtr_prefix)
+
+    def test_amd_vtr_and_amd_do_are_independent(self) -> None:
+        settings_text = """
+        experiments:
+            amd-do:
+                rollout_perc: 0
+            amd-vtr:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,amd-vtr
+        @User2,amd-do
+
+        """
+        vtr_only = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("amd-vtr-", vtr_only.amd_vtr_prefix)
+        self.assertEqual("", vtr_only.amd_do_prefix)
+        do_only = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH)
+        self.assertEqual("amd-do-", do_only.amd_do_prefix)
+        self.assertEqual("", do_only.amd_vtr_prefix)
+
+
 class TestRunnerDeterminatorNoRunnerExperimentsLabel(TestCase):
     """no-runner-experiments opts out of lf, so the run stays on the default Meta fleet."""
 

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -752,111 +752,47 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         self.assertEqual("mt-", result.prefix, "Runner prefix not correct for user")
 
 
-class TestRunnerDeterminatorAmdDoExperiment(TestCase):
-    AMD_DO_SETTINGS = """
+class TestRunnerDeterminatorAmdSandboxExperiment(TestCase):
+    AMD_SANDBOX_SETTINGS = """
         experiments:
-            amd-do:
+            amd-sandbox:
                 rollout_perc: 0
         ---
 
         Users:
-        @User1,amd-do
+        @User1,amd-sandbox
         @User2,lf
 
         """
 
-    def test_amd_do_opted_in_returns_prefix(self) -> None:
-        result = rd.get_runner_prefix(self.AMD_DO_SETTINGS, ["User1"], USER_BRANCH)
-        self.assertEqual("amd-do-", result.amd_do_prefix)
-        # amd-do is exposed via its own output; the base prefix is the default fleet
+    def test_amd_sandbox_opted_in_returns_prefix(self) -> None:
+        result = rd.get_runner_prefix(self.AMD_SANDBOX_SETTINGS, ["User1"], USER_BRANCH)
+        self.assertEqual("amd-sandbox-", result.amd_sandbox_prefix)
+        # amd-sandbox is exposed via its own output; the base prefix is the default fleet
         self.assertEqual("mt-", result.prefix)
 
-    def test_amd_do_not_enabled_returns_default_fleet(self) -> None:
+    def test_amd_sandbox_not_enabled_returns_default_fleet(self) -> None:
         # User2 opts into lf, but lf is not defined here, so it falls back to Meta
-        result = rd.get_runner_prefix(self.AMD_DO_SETTINGS, ["User2"], USER_BRANCH)
-        self.assertEqual("", result.amd_do_prefix)
+        result = rd.get_runner_prefix(self.AMD_SANDBOX_SETTINGS, ["User2"], USER_BRANCH)
+        self.assertEqual("", result.amd_sandbox_prefix)
         self.assertEqual("mt-", result.prefix)
 
-    def test_amd_do_with_lf_keeps_both(self) -> None:
+    def test_amd_sandbox_with_lf_keeps_both(self) -> None:
         settings_text = """
         experiments:
             lf:
                 rollout_perc: 0
-            amd-do:
+            amd-sandbox:
                 rollout_perc: 0
         ---
 
         Users:
-        @User1,lf,amd-do
+        @User1,lf,amd-sandbox
 
         """
         result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
         self.assertEqual("lf-", result.prefix)
-        self.assertEqual("amd-do-", result.amd_do_prefix)
-
-
-class TestRunnerDeterminatorAmdVtrExperiment(TestCase):
-    AMD_VTR_SETTINGS = """
-        experiments:
-            amd-vtr:
-                rollout_perc: 0
-        ---
-
-        Users:
-        @User1,amd-vtr
-        @User2,lf
-
-        """
-
-    def test_amd_vtr_opted_in_returns_prefix(self) -> None:
-        result = rd.get_runner_prefix(self.AMD_VTR_SETTINGS, ["User1"], USER_BRANCH)
-        self.assertEqual("amd-vtr-", result.amd_vtr_prefix)
-        # amd-vtr is exposed via its own output; the base prefix is the default fleet
-        self.assertEqual("mt-", result.prefix)
-
-    def test_amd_vtr_not_enabled_returns_default_fleet(self) -> None:
-        # User2 opts into lf, but lf is not defined here, so it falls back to Meta
-        result = rd.get_runner_prefix(self.AMD_VTR_SETTINGS, ["User2"], USER_BRANCH)
-        self.assertEqual("", result.amd_vtr_prefix)
-        self.assertEqual("mt-", result.prefix)
-
-    def test_amd_vtr_with_lf_keeps_both(self) -> None:
-        settings_text = """
-        experiments:
-            lf:
-                rollout_perc: 0
-            amd-vtr:
-                rollout_perc: 0
-        ---
-
-        Users:
-        @User1,lf,amd-vtr
-
-        """
-        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
-        self.assertEqual("lf-", result.prefix)
-        self.assertEqual("amd-vtr-", result.amd_vtr_prefix)
-
-    def test_amd_vtr_and_amd_do_are_independent(self) -> None:
-        settings_text = """
-        experiments:
-            amd-do:
-                rollout_perc: 0
-            amd-vtr:
-                rollout_perc: 0
-        ---
-
-        Users:
-        @User1,amd-vtr
-        @User2,amd-do
-
-        """
-        vtr_only = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
-        self.assertEqual("amd-vtr-", vtr_only.amd_vtr_prefix)
-        self.assertEqual("", vtr_only.amd_do_prefix)
-        do_only = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH)
-        self.assertEqual("amd-do-", do_only.amd_do_prefix)
-        self.assertEqual("", do_only.amd_vtr_prefix)
+        self.assertEqual("amd-sandbox-", result.amd_sandbox_prefix)
 
 
 class TestRunnerDeterminatorNoRunnerExperimentsLabel(TestCase):

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -57,12 +57,9 @@ on:
       runner-label:
         description: Fully qualified runner label derived from runner_config
         value: ${{ jobs.runner-determinator.outputs.runner-label }}
-      amd-do-label-type:
-        description: Runner prefix for the "amd-do" experiment (empty when not enabled)
-        value: ${{ jobs.runner-determinator.outputs.amd-do-label-type }}
-      amd-vtr-label-type:
-        description: Runner prefix for the "amd-vtr" experiment (empty when not enabled)
-        value: ${{ jobs.runner-determinator.outputs.amd-vtr-label-type }}
+      amd-sandbox-label-type:
+        description: Runner prefix for the "amd-sandbox" experiment (empty when not enabled)
+        value: ${{ jobs.runner-determinator.outputs.amd-sandbox-label-type }}
       ci-docker-hash:
         description: "Git tree hash of .ci/docker, used as the suffix of CI docker image tags"
         value: ${{ jobs.runner-determinator.outputs.ci-docker-hash }}
@@ -77,8 +74,7 @@ jobs:
       runner-config: ${{ steps.set-runner-info.outputs.runner-config }}
       runner-type: ${{ steps.set-runner-info.outputs.runner-type }}
       runner-label: ${{ steps.set-runner-info.outputs.runner-label }}
-      amd-do-label-type: ${{ steps.set-condition.outputs.amd-do-label-type }}
-      amd-vtr-label-type: ${{ steps.set-condition.outputs.amd-vtr-label-type }}
+      amd-sandbox-label-type: ${{ steps.set-condition.outputs.amd-sandbox-label-type }}
       ci-docker-hash: ${{ steps.ci-docker-hash.outputs.ci-docker-hash }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -60,6 +60,9 @@ on:
       amd-do-label-type:
         description: Runner prefix for the "amd-do" experiment (empty when not enabled)
         value: ${{ jobs.runner-determinator.outputs.amd-do-label-type }}
+      amd-vtr-label-type:
+        description: Runner prefix for the "amd-vtr" experiment (empty when not enabled)
+        value: ${{ jobs.runner-determinator.outputs.amd-vtr-label-type }}
       ci-docker-hash:
         description: "Git tree hash of .ci/docker, used as the suffix of CI docker image tags"
         value: ${{ jobs.runner-determinator.outputs.ci-docker-hash }}
@@ -75,6 +78,7 @@ jobs:
       runner-type: ${{ steps.set-runner-info.outputs.runner-type }}
       runner-label: ${{ steps.set-runner-info.outputs.runner-label }}
       amd-do-label-type: ${{ steps.set-condition.outputs.amd-do-label-type }}
+      amd-vtr-label-type: ${{ steps.set-condition.outputs.amd-vtr-label-type }}
       ci-docker-hash: ${{ steps.ci-docker-hash.outputs.ci-docker-hash }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -60,6 +60,13 @@ on:
       amd-sandbox-label-type:
         description: Runner prefix for the "amd-sandbox" experiment (empty when not enabled)
         value: ${{ jobs.runner-determinator.outputs.amd-sandbox-label-type }}
+      # Deprecated empty-string alias kept only so the MI350/gfx950 workflows that
+      # still reference amd-do-label-type resolve to a bare (unprefixed) label,
+      # matching the old inactive amd-do experiment. Removed once #191249 drops
+      # those references.
+      amd-do-label-type:
+        description: Deprecated no-op alias; removed by the amd-do cleanup PR.
+        value: ${{ '' }}
       ci-docker-hash:
         description: "Git tree hash of .ci/docker, used as the suffix of CI docker image tags"
         value: ${{ jobs.runner-determinator.outputs.ci-docker-hash }}

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -6,13 +6,6 @@ on:
   #  branches:
   #    - main
   #    - release/*
-  # TEMPORARY: revert before merge - trigger this workflow off the existing
-  # registered ciflow/trunk push tag so the amd-vtr determinator change can be
-  # exercised on the PR (trunk-rocm-sandbox has no registered ciflow tag of its
-  # own). Remove this push block before merging.
-  push:
-    tags:
-      - ciflow/trunk/*
   workflow_dispatch:
   schedule:
     - cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
@@ -39,11 +32,7 @@ jobs:
 
   get-label-type:
     name: get-label-type
-    # TEMPORARY: revert to @main before merge - reference the PR's own reusable
-    # workflow so the new amd-vtr-label-type output resolves (it does not exist
-    # on @main yet). Restore pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    # before merging.
-    uses: ./.github/workflows/_runner-determinator.yml
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
@@ -75,8 +64,10 @@ jobs:
           { config: "default", shard: 6, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
           { config: "default", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
           { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "inductor", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "inductor", shard: 1, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "inductor", shard: 2, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "inductor", shard: 3, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "inductor", shard: 4, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
           { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
           { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
           { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -39,7 +39,7 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
-      check_experiments: amd-vtr
+      check_experiments: amd-sandbox
 
   linux-noble-rocm-py3_12-build:
     name: linux-noble-rocm-py3.12-mi300
@@ -50,27 +50,27 @@ jobs:
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       build-environment: linux-noble-rocm-py3.12-mi300
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
-      # The amd-vtr experiment routes the gfx942 test shards onto the
-      # amd-vtr- prefixed runner scale sets via the dedicated
-      # amd-vtr-label-type output (empty when the experiment is disabled, in
+      # The amd-sandbox experiment routes the gfx942 test shards onto the
+      # amd-sandbox- prefixed runner scale sets via the dedicated
+      # amd-sandbox-label-type output (empty when the experiment is disabled, in
       # which case the canonical linux.rocm.gpu.gfx942.* labels are used).
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 2, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 3, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 4, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 5, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 6, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "inductor", shard: 1, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "inductor", shard: 2, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "inductor", shard: 3, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "inductor", shard: 4, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "default", shard: 1, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 2, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 3, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 4, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 5, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 6, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "inductor", shard: 1, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "inductor", shard: 2, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "inductor", shard: 3, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "inductor", shard: 4, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
         ]}
     secrets: inherit
 

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -39,44 +39,48 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+      check_experiments: amd-vtr
 
-  linux-jammy-rocm-py3_10-build:
-    name: linux-jammy-rocm-py3.10
+  linux-noble-rocm-py3_12-build:
+    name: linux-noble-rocm-py3.12-mi300
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      build-environment: linux-jammy-rocm-py3.10
-      docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
+      build-environment: linux-noble-rocm-py3.12-mi300
+      docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       sync-tag: rocm-build
+      # The amd-vtr experiment routes the gfx942 test shards onto the
+      # amd-vtr- prefixed runner scale sets via the dedicated
+      # amd-vtr-label-type output (empty when the experiment is disabled, in
+      # which case the canonical linux.rocm.gpu.gfx942.* labels are used).
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 2, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 3, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 4, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 5, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 6, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 7, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 8, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 9, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 10, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "inductor", shard: 1, num_shards: 4, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "inductor", shard: 2, num_shards: 4, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "inductor", shard: 3, num_shards: 4, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "inductor", shard: 4, num_shards: 4, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "default", shard: 1, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 2, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 3, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 4, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 5, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 6, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "inductor", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.4", owners: ["module:rocm", "oncall:distributed"] },
         ]}
     secrets: inherit
 
-  linux-jammy-rocm-py3_10-test:
-    name: linux-jammy-rocm-py3.10
+  linux-noble-rocm-py3_12-test:
+    name: linux-noble-rocm-py3.12-mi300
     uses: ./.github/workflows/_rocm-test.yml
     needs:
-      - linux-jammy-rocm-py3_10-build
+      - linux-noble-rocm-py3_12-build
       - target-determination
     with:
-      build-environment: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.build-environment }}
-      docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
+      build-environment: ${{ needs.linux-noble-rocm-py3_12-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-noble-rocm-py3_12-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-noble-rocm-py3_12-build.outputs.test-matrix }}
     secrets: inherit

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -77,9 +77,9 @@ jobs:
           { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
           { config: "inductor", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
           { config: "inductor", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.4", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.4", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-vtr-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
         ]}
     secrets: inherit
 

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -61,7 +61,6 @@ jobs:
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       build-environment: linux-noble-rocm-py3.12-mi300
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
-      sync-tag: rocm-build
       # The amd-vtr experiment routes the gfx942 test shards onto the
       # amd-vtr- prefixed runner scale sets via the dedicated
       # amd-vtr-label-type output (empty when the experiment is disabled, in

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -6,6 +6,13 @@ on:
   #  branches:
   #    - main
   #    - release/*
+  # TEMPORARY: revert before merge - trigger this workflow off the existing
+  # registered ciflow/trunk push tag so the amd-vtr determinator change can be
+  # exercised on the PR (trunk-rocm-sandbox has no registered ciflow tag of its
+  # own). Remove this push block before merging.
+  push:
+    tags:
+      - ciflow/trunk/*
   workflow_dispatch:
   schedule:
     - cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
@@ -32,7 +39,11 @@ jobs:
 
   get-label-type:
     name: get-label-type
-    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    # TEMPORARY: revert to @main before merge - reference the PR's own reusable
+    # workflow so the new amd-vtr-label-type output resolves (it does not exist
+    # on @main yet). Restore pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    # before merging.
+    uses: ./.github/workflows/_runner-determinator.yml
     if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}


### PR DESCRIPTION
## Motivation

We are migrating CI capacity for MI300 runners, and need to shadow test it on the trunk-rocm-sandbox workflow to ensure there are no infra issues, before we migrate the MI300 workflows.

As part of this effort, we are also generalizing the amd-sandbox experiment, so it can be reused in future similar situations.

## Details
- Route the `trunk-rocm-sandbox` workflow onto the `amd-sandbox` runner-determinator experiment so its gfx942 (MI300) test shards land on `amd-sandbox-linux.rocm.gpu.gfx942.*` runner scale sets. This is implemented by repurposing the existing (inactive) `amd-do` runner-determinator experiment and renaming its prefix to `amd-sandbox`, scoped to the `trunk-rocm-sandbox` workflow.
- `runner_determinator.py`: add `AMD_SANDBOX_EXPERIMENT`/`AMD_SANDBOX_LABEL_PREFIX`, `amd_sandbox_prefix` on `RunnerPrefixResult`, and a dedicated `amd-sandbox-label-type` output (kept separate from the shared `label-type` prefix so it can be applied per-job).
- `_runner-determinator.yml`: expose `amd-sandbox-label-type`.
- `trunk-rocm-sandbox.yml`: build/test on the gfx942 (MI300) noble py3.12 image with `default`, `inductor`, and `distributed` configs. `get-label-type` adds `check_experiments: amd-sandbox`; gfx942 test shards route onto `amd-sandbox-` prefixed runner scale sets via `amd-sandbox-label-type`, falling back to the canonical `linux.rocm.gpu.gfx942.*` labels when the experiment is disabled. `default`/`inductor` shards use `.1`; `distributed` shards use the 2-GPU `.2` pool.
- `arc.yaml`: gfx942 passthrough entries for `amd-sandbox-linux.rocm.gpu.gfx942.{1,2}`.

Non-breaking note: `amd-do` was inactive in test-infra#5132 (`rollout_perc: 0`, `default: false`, no opt-in users), so the six MI350/gfx950 workflows that still reference `amd-do` already resolve `amd-do-label-type` to empty/default today. Repurposing the experiment therefore changes no live routing (undefined reusable-workflow outputs resolve to empty, not a hard error). Their now-orphaned `amd-do` references are cleaned up in a follow-up PR:  https://github.com/pytorch/pytorch/pull/191249

## Test plan
- [x] `python .github/scripts/test_runner_determinator.py` (44 tests pass, incl. `TestRunnerDeterminatorAmdSandboxExperiment`)
- [x] `actionlint` clean on `trunk-rocm-sandbox.yml` and `_runner-determinator.yml`
- [x] Routing mechanism validated end-to-end on gfx942 (run https://github.com/pytorch/pytorch/actions/runs/30123524345): `get-label-type` resolved the experiment and the gfx942 default/inductor/distributed shards routed onto the prefixed scale sets.

Made with Cursor


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang