### PR TITLE
Fix GPU requirements for 2D composability tests

### DIFF
--- a/test/distributed/_composable/test_composability/test_2d_composability.py
+++ b/test/distributed/_composable/test_composability/test_2d_composability.py
@@ -130,7 +130,7 @@ class TestFullyShard2DTraining(FSDPTestContinuous):
         )
 
     @skip_if_rocm_arch_multiprocess(MI200_ARCH)
-    @skip_if_lt_x_gpu(2)
+    @skip_if_lt_x_gpu(4)
     def test_train_parity_2d_mlp(self):
         global_mesh = self.init_global_mesh()
         self.run_subtests(
@@ -176,7 +176,7 @@ class TestFullyShard2DTraining(FSDPTestContinuous):
                 _optim.step()
             self.assertEqual(losses[0], losses[1])
 
-    @skip_if_lt_x_gpu(2)
+    @skip_if_lt_x_gpu(4)
     @xfailIf(TEST_XPU)  # https://github.com/intel/torch-xpu-ops/issues/1881
     def test_train_parity_2d_transformer(self):
         self.run_subtests(
@@ -258,7 +258,7 @@ class TestFullyShard2DTraining(FSDPTestContinuous):
             full_param = param.full_tensor()
             self.assertEqual(full_param, ref_param)
 
-    @skip_if_lt_x_gpu(2)
+    @skip_if_lt_x_gpu(4)
     @xfailIf(TEST_XPU)  # https://github.com/pytorch/pytorch/issues/156782
     def test_tp_with_fsdp_offloading(self):
         global_mesh = init_device_mesh(
@@ -317,7 +317,7 @@ class TestFullyShard2DTraining(FSDPTestContinuous):
     @unittest.skipIf(
         IS_LINUX or TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/125644"
     )
-    @skip_if_lt_x_gpu(2)
+    @skip_if_lt_x_gpu(4)
     @xfailIf(TEST_XPU)  # https://github.com/intel/torch-xpu-ops/issues/1881
     @with_temp_dir
     def test_train_parity_2d_transformer_checkpoint_resume(self):


### PR DESCRIPTION
TestFullyShard2DTraining uses a fixed four-rank continuous test process group, but four tests retained their two-GPU skip decorators from when world size tracked available accelerators. This caused the declared requirement to disagree with harness initialization.

Update the decorators to require four accelerators.

This change was authored with assistance from an AI assistant.