### PR TITLE
[c10d][torchcomms] Add MCCL backend wrapper example (#190292)

### DIFF
--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -759,5 +759,74 @@ class TestC10dTorchCommsDestroyDedup(TestCase):
         self.assertEqual(comm.finalize_calls, 1)
 
 
+class TestC10dTorchCommsBackendConfig(TestCase):
+    def test_registered_device_qualified_torchcomms_backend_uses_custom_type(self):
+        backend_name = "tc_test_backend"
+        self.assertNotIn(backend_name, dist.Backend.backend_type_map)
+
+        orig_use = c10d._use_torchcomms_enabled
+        orig_registered = c10d._torchcomms_is_backend_registered
+        orig_built = c10d._torchcomms_is_backend_built
+        c10d._use_torchcomms_enabled = lambda: True
+        c10d._torchcomms_is_backend_registered = lambda backend: backend == backend_name
+        c10d._torchcomms_is_backend_built = lambda backend: False
+        try:
+            backend_config = dist.BackendConfig(f"cuda:{backend_name}")
+            self.assertEqual(
+                c10d._get_default_backend_type_for_backend_config(backend_config),
+                dist.ProcessGroup.BackendType.CUSTOM,
+            )
+        finally:
+            c10d._use_torchcomms_enabled = orig_use
+            c10d._torchcomms_is_backend_registered = orig_registered
+            c10d._torchcomms_is_backend_built = orig_built
+
+    def test_unregistered_device_qualified_backend_with_torchcomms_keeps_gloo_type(
+        self,
+    ):
+        backend_name = "tc_test_backend"
+        self.assertNotIn(backend_name, dist.Backend.backend_type_map)
+
+        orig_use = c10d._use_torchcomms_enabled
+        orig_registered = c10d._torchcomms_is_backend_registered
+        orig_built = c10d._torchcomms_is_backend_built
+        c10d._use_torchcomms_enabled = lambda: True
+        c10d._torchcomms_is_backend_registered = lambda backend: False
+        c10d._torchcomms_is_backend_built = lambda backend: False
+        try:
+            backend_config = dist.BackendConfig(f"cuda:{backend_name}")
+            self.assertEqual(
+                c10d._get_default_backend_type_for_backend_config(backend_config),
+                dist.ProcessGroup.BackendType.GLOO,
+            )
+        finally:
+            c10d._use_torchcomms_enabled = orig_use
+            c10d._torchcomms_is_backend_registered = orig_registered
+            c10d._torchcomms_is_backend_built = orig_built
+
+    def test_registered_device_qualified_backend_without_torchcomms_keeps_gloo_type(
+        self,
+    ):
+        backend_name = "tc_test_backend"
+        self.assertNotIn(backend_name, dist.Backend.backend_type_map)
+
+        orig_use = c10d._use_torchcomms_enabled
+        orig_registered = c10d._torchcomms_is_backend_registered
+        orig_built = c10d._torchcomms_is_backend_built
+        c10d._use_torchcomms_enabled = lambda: False
+        c10d._torchcomms_is_backend_registered = lambda backend: backend == backend_name
+        c10d._torchcomms_is_backend_built = lambda backend: True
+        try:
+            backend_config = dist.BackendConfig(f"cuda:{backend_name}")
+            self.assertEqual(
+                c10d._get_default_backend_type_for_backend_config(backend_config),
+                dist.ProcessGroup.BackendType.GLOO,
+            )
+        finally:
+            c10d._use_torchcomms_enabled = orig_use
+            c10d._torchcomms_is_backend_registered = orig_registered
+            c10d._torchcomms_is_backend_built = orig_built
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -192,13 +192,19 @@ _XCCL_AVAILABLE = True
 try:
     try:
         # pyrefly: ignore [missing-import]
-        from torchcomms._comms import _BackendWrapper
+        from torchcomms._comms import (
+            _BackendWrapper,
+            _is_backend_registered as _torchcomms_is_backend_registered,
+        )
     except ImportError:
         # pyrefly: ignore [missing-import]
         from torchcomms._backend_wrapper import _BackendWrapper
 
+        def _torchcomms_is_backend_registered(backend: str) -> bool:
+            return False
+
     # pyrefly: ignore [missing-import]
-    from torchcomms import new_comm
+    from torchcomms import is_backend_built as _torchcomms_is_backend_built, new_comm
 
     # pyrefly: ignore [missing-import]
     from torchcomms.hooks import FlightRecorderHook
@@ -207,10 +213,23 @@ try:
 except ImportError:
     _TORCHCOMM_AVAILABLE = False
 
+    def _torchcomms_is_backend_built(backend: str) -> bool:
+        return False
+
+    def _torchcomms_is_backend_registered(backend: str) -> bool:
+        return False
+
 
 def _use_torchcomms_enabled() -> bool:
     """Check if torchcomms is enabled via config."""
     return _TORCHCOMM_AVAILABLE and dist_config.use_torchcomms
+
+
+def _is_torchcomms_backend(backend: str) -> bool:
+    return _use_torchcomms_enabled() and (
+        _torchcomms_is_backend_registered(backend)
+        or _torchcomms_is_backend_built(backend)
+    )
 
 
 def _pg_options_to_hints(pg_options: object) -> dict[str, str] | None:
@@ -961,6 +980,27 @@ def _parse_backend_string(
             f"or use one of: {sorted(Backend.default_device_backend_map.values())}"
         )
     return dict.fromkeys(device_types, backend)
+
+
+def _get_default_backend_type_for_backend_config(
+    backend_config: BackendConfig,
+) -> ProcessGroup.BackendType:
+    if Backend.NCCL in backend_config.device_backend_map.values():
+        return ProcessGroup.BackendType.NCCL
+
+    custom_backend = next(
+        (
+            backend
+            for backend in backend_config.device_backend_map.values()
+            if Backend.backend_type_map.get(str(backend))
+            == ProcessGroup.BackendType.CUSTOM
+            or _is_torchcomms_backend(str(backend))
+        ),
+        None,
+    )
+    if custom_backend is not None:
+        return ProcessGroup.BackendType.CUSTOM
+    return ProcessGroup.BackendType.GLOO
 
 
 class _reduce_op:
@@ -2635,22 +2675,9 @@ def _new_process_group_helper(
     # In order to correctly call pg._has_hooks(), we should set the default backend
     # when multi backend is passed in
     if not pg_backend_set:
-        if Backend.NCCL in backend_config.device_backend_map.values():
-            pg._set_default_backend(ProcessGroup.BackendType.NCCL)
-        else:
-            custom_backend = next(
-                (
-                    backend
-                    for backend in backend_config.device_backend_map.values()
-                    if Backend.backend_type_map.get(str(backend))
-                    == ProcessGroup.BackendType.CUSTOM
-                ),
-                None,
-            )
-            if custom_backend is not None:
-                pg._set_default_backend(ProcessGroup.BackendType.CUSTOM)
-            else:
-                pg._set_default_backend(ProcessGroup.BackendType.GLOO)
+        pg._set_default_backend(
+            _get_default_backend_type_for_backend_config(backend_config)
+        )
 
     if device_id:
         pg.bound_device_id = device_id


### PR DESCRIPTION
Summary:

X-link: https://github.com/meta-pytorch/torchcomms/pull/3163

D111755956 proved the PTD -> TorchComms NCCLX path, but the example had to mutate c10d internals with dist.Backend.backend_type_map.setdefault("ncclx", CUSTOM) before calling dist.init_process_group(backend="cuda:ncclx"). That made the example work, but it pushed c10d bookkeeping onto every user of an otherwise valid TorchComms backend string.

Keep that policy in c10d instead: unknown device-qualified TorchComms backends are treated as CUSTOM when c10d selects the process-group default backend type. This lets backend="cuda:mccl" and backend="cuda:ncclx" initialize through PTD without mutating dist.Backend.backend_type_map in user code.

Refactor the default-backend type decision into a small helper near the backend-string parsing helpers and cover it in test_c10d_torchcomms with a synthetic backend name: TorchComms enabled maps the unknown device-qualified backend to CUSTOM, while TorchComms disabled keeps the existing GLOO fallback.

Remove the old NCCLX AllGatherP example-side backend_type_map workaround now that c10d owns the policy.

Add small straight-line MCCL examples that call dist.init_process_group(backend="cuda:mccl"), verify the PTD backend implementation is a TorchComms _BackendWrapper, and verify the underlying TorchComm backend is mccl / TorchCommMCCL. One example checks ordinary allreduce. The new AllGatherP example allocates through the MCCL TorchComms allocator, calls comm.all_gather_p_init/exec/free through wrapper.get_comm(), and verifies gathered rank chunks.

The multi-backend new_group case is intentionally left for a follow-up diff.

Test Plan:
Static checks:

```
python3 -m py_compile fbcode/caffe2/torch/distributed/distributed_c10d.py xplat/caffe2/torch/distributed/distributed_c10d.py fbcode/caffe2/test/distributed/test_c10d_torchcomms.py xplat/caffe2/test/distributed/test_c10d_torchcomms.py fbcode/comms/torchcomms/fb/mccl/examples/AllReduceBackendWrapper.py fbcode/comms/torchcomms/fb/mccl/examples/AllGatherPBackendWrapper.py
arc lint fbcode/caffe2/torch/distributed/distributed_c10d.py xplat/caffe2/torch/distributed/distributed_c10d.py fbcode/caffe2/test/distributed/test_c10d_torchcomms.py xplat/caffe2/test/distributed/test_c10d_torchcomms.py fbcode/comms/torchcomms/ncclx/examples/AllGatherPBackendWrapper.py fbcode/comms/torchcomms/fb/mccl/examples/AllReduceBackendWrapper.py fbcode/comms/torchcomms/fb/mccl/examples/AllGatherPBackendWrapper.py fbcode/comms/torchcomms/fb/mccl/examples/BUCK
```

Result: py_compile passed; arc lint passed with no issues.

Run the c10d TorchComms backend policy unit test locally:

```
buck2 test --local-only --test-executor-stdout=- --test-executor-stderr=- fbcode//caffe2/test/distributed:c10d_torchcomms -- TestC10dTorchCommsBackendConfig --timeout=300 --print-passing-details
```

Result: Pass 3, Fail 0.
TestInfra: https://www.internalfb.com/intern/testinfra/testrun/5066549958097665

Run the MCCL allreduce example locally on a devgpu:

```
buck2 test --local-only --test-executor-stdout=- --test-executor-stderr=- -c comms.hosts=localhost fbcode//comms/torchcomms/fb/mccl/examples:AllReduceMCCLBackendWrapperPy -- --timeout=600 --print-passing-details
```

Result: Pass 1, Fail 0.
Buck UI: https://www.internalfb.com/buck2/cd7a1b90-0a9c-4912-960a-861d0109bc8e
TestInfra: https://www.internalfb.com/intern/testinfra/testrun/27303072774825496

Relevant passing output:

```
Verified PTD backend _BackendWrapper -> TorchComms mccl backend implementation TorchCommMCCL
Verified PTD TorchComms MCCL all_reduce for 2 ranks
```

Run the MCCL AllGatherP example locally on a devgpu:

```
buck2 test --local-only --test-executor-stdout=- --test-executor-stderr=- -c comms.hosts=localhost fbcode//comms/torchcomms/fb/mccl/examples:AllGatherPMCCLBackendWrapperPy -- --timeout=600 --print-passing-details
```

Result: Pass 1, Fail 0.
Buck UI: https://www.internalfb.com/buck2/8646f393-46b9-4794-9bf9-0f5b79dc71e6
TestInfra: https://www.internalfb.com/intern/testinfra/testrun/34339947179716490

Relevant passing output:

```
Verified PTD backend _BackendWrapper -> TorchComms mccl backend implementation TorchCommMCCL
Verified PTD TorchComms MCCL AllGatherP for 2 ranks
```

Reviewed By: d4l3k

Differential Revision: D111994473
