### PR TITLE
[ci] Set allowed_bots on Claude Issue Triage Run

### DIFF
--- a/.github/workflows/claude-issue-triage-run.yml
+++ b/.github/workflows/claude-issue-triage-run.yml
@@ -109,6 +109,9 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Allow pytorch-bot (opens the DISABLED-test issues) past the
+          # action's bot gate. Widen to "*" if other bots start opening issues.
+          allowed_bots: "pytorch-bot"
           claude_args: |
             --model global.anthropic.claude-sonnet-5
             --mcp-config /tmp/mcp-config/mcp-servers.json


### PR DESCRIPTION
Bot-opened issues fail the claude-code-action bot gate (default allows no bots), so pytorch-bot DISABLED-test issues never get triaged and each run attaches a red job to main. Scope allowed_bots to pytorch-bot, the only bot that opens issues in pytorch/pytorch.

Fixes meta-pytorch/pytorch-gha-infra#1329.

Test Plan: YAML parses; verified allowed_bots semantics in claude-code-action@v1.0.89; confirmed pytorch-bot is the sole issue-opening bot via gh issue list.

Authored with assistance from an AI coding assistant.