### PR TITLE
Fix PP composability skip decorator ordering

### DIFF
--- a/test/distributed/_composable/test_composability/test_pp_composability.py
+++ b/test/distributed/_composable/test_composability/test_pp_composability.py
@@ -101,8 +101,8 @@ class ComposabilityTest(MultiProcContinuousTest):
         return self.rank
 
     @requires_accelerator_dist_backend()
-    @skip_if_lt_x_gpu(8)
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
+    @skip_if_lt_x_gpu(8)
     def test_pp_and_dcp(self):
         """
         Test that pipeline parallelism and distributed checkpointing can be used together and
@@ -184,8 +184,8 @@ class ComposabilityTest(MultiProcContinuousTest):
         _dcp_test(self)
 
     @requires_accelerator_dist_backend()
-    @skip_if_lt_x_gpu(8)
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
+    @skip_if_lt_x_gpu(8)
     @parametrize(
         "ScheduleClass",
         [
@@ -327,8 +327,8 @@ class ComposabilityTest(MultiProcContinuousTest):
                 optimizer.step()
 
     @requires_accelerator_dist_backend()
-    @skip_if_lt_x_gpu(8)
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
+    @skip_if_lt_x_gpu(8)
     @parametrize(
         "ScheduleClass",
         [
@@ -511,8 +511,8 @@ class ComposabilityTest(MultiProcContinuousTest):
                 ref_optimizer.step()
 
     @requires_accelerator_dist_backend()
-    @skip_if_lt_x_gpu(8)
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
+    @skip_if_lt_x_gpu(8)
     @parametrize(
         "ScheduleClass",
         [


### PR DESCRIPTION
The GPU-count skip wrapped the sandcastle silent-pass decorator, so short-GPU sandcastle workers exited before they could silently pass. Reverse the two decorators on the four affected tests. Keeping the change at the call sites avoids changing shared skip behavior.

Authored with assistance from an AI assistant (Codex).