### PR TITLE
[native_aot] bmm_outer_product: first Triton AOT op, block-size bucket dispatch

### DIFF
--- a/test/python_native/test_instrumentation.py
+++ b/test/python_native/test_instrumentation.py
@@ -693,7 +693,13 @@ class TestInstrumentationCoverage(TestCase):
         ops_dir = os.path.join(os.path.dirname(torch._native.__file__), "ops")
         for root, _, files in os.walk(ops_dir):
             for name in files:
-                if name.endswith(".py"):
+                # aot_kernel.py modules are exempt: their kernels are
+                # compiled at EXPORT time by tools/native_aot (no runtime
+                # compile to instrument). triton.tools.compile also needs
+                # to find a plain JITFunction by name, which a wrapper
+                # would hide. aot.py declaration modules are stdlib-only
+                # metadata (torchgen loads them pre-build).
+                if name.endswith(".py") and name not in ("aot_kernel.py", "aot.py"):
                     yield os.path.join(root, name)
 
     def test_required_decorators_exist(self):

--- a/test/python_native/test_native_aot_bmm.py
+++ b/test/python_native/test_native_aot_bmm.py
@@ -1,0 +1,237 @@
+# Owner(s): ["module: dsl-native-ops"]
+"""End-to-end tests for the native-AOT bmm outer-product kernels @ CUDA.
+
+First Triton-kind AOT op: kernels are compiled by triton.tools.compile
+into flat-signature C entry points (cubin embedded, grid baked in) and
+dispatched by per-spec range guards over (M, N) -- the block-size
+buckets the JIT wrapper picks dynamically. The narrow starter grid is
+fp32/bf16 x BLOCK_M {32 (M in (32,96]), 64 (M in (96,192])} with
+N >= 128; everything else (fp16, other buckets, small N, non-CUDA
+accelerators) stays with the JIT override, which shares the same
+@triton.jit kernel body from aot_kernel.py.
+
+bmm outer-product is a pure per-element product (K == 1): no
+accumulation order, so no det-mode carve-out, and results should be
+exact vs the reference for matching dtypes.
+
+Tests that require the AOT kernel library skip unless it was loaded at
+import; correctness tests run everywhere.
+"""
+
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    skipIfNoCuteDSL,
+    TestCase,
+)
+
+
+def _aot_lib_loaded() -> bool:
+    from torch._native import _native_aot_embedded
+
+    return _native_aot_embedded()
+
+
+def skipIfNoAotLib(fn):
+    return unittest.skipUnless(
+        _aot_lib_loaded(), "AOT kernels not embedded in this build"
+    )(fn)
+
+
+def _ran_aot(fn) -> bool:
+    # The AOT entry points embed the kernel under its jit name; the JIT
+    # path launches the same-named kernel, so profiler name alone cannot
+    # distinguish the layers -- tests that need layer attribution mask
+    # the JIT side via the registry-disabling context instead.
+    from torch.profiler import profile, ProfilerActivity
+
+    with profile(activities=[ProfilerActivity.CUDA]) as prof:
+        fn()
+        torch.cuda.synchronize()
+    return any(
+        "_bmm_outer_product_aot_kernel" in e.name
+        for e in prof.events()
+        if e.device_type.name == "CUDA"
+    )
+
+
+def _load_covered_axes():
+    # The declaration module is stdlib-only and loaded by file path (it
+    # is not an importable member of the torch package).
+    import importlib.util
+    import os
+
+    path = os.path.join(
+        os.path.dirname(torch.__file__), "_native", "ops", "bmm_outer_product", "aot.py"
+    )
+    spec = importlib.util.spec_from_file_location("bmm_outer_product_aot_t", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.covered_axes
+
+
+def _reference(a, b):
+    # triton.disabled() removes the JIT override AND flips the shared
+    # native-AOT Context switch, so the reference is stock cublas.
+    with torch.backends.python_native.triton.disabled():
+        return torch.bmm(a, b)
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA required")
+@skipIfNoCuteDSL
+class TestNativeAotBmmOuter(TestCase):
+    def _outer(self, B, M, N, dtype=torch.float32, seed=0):
+        torch.manual_seed(seed)
+        a = torch.randn(B, M, 1, device="cuda", dtype=dtype)
+        b = torch.randn(B, 1, N, device="cuda", dtype=dtype)
+        return a, b
+
+    @skipIfNoAotLib
+    @parametrize("dtype", [torch.float32, torch.bfloat16])
+    @parametrize("m", [48, 128])  # one M per BLOCK_M bucket
+    def test_covered_buckets_route_to_aot(self, dtype, m):
+        a, b = self._outer(16, m, 256, dtype)
+        ref = _reference(a, b)
+        # Mask the JIT layer (deregister overrides) so the profiled
+        # kernel can only come from the AOT stub.
+        pn = torch.backends.python_native
+        pn.triton.disable()
+        try:
+            self.assertTrue(
+                _ran_aot(lambda: torch.bmm(a, b)),
+                f"AOT kernel did not fire for {dtype} M={m}",
+            )
+            out = torch.bmm(a, b)
+        finally:
+            pn.triton.enable()
+        self.assertEqual(out, ref, atol=0, rtol=0)
+
+    @skipIfNoAotLib
+    def test_bucket_edges(self):
+        # Guard edges: M=32 uncovered, 33 covered (bm32), 96/97 bucket
+        # boundary, 192 covered (bm64), 193 uncovered.
+        pn = torch.backends.python_native
+        pn.triton.disable()
+        try:
+            for m, covered in (
+                (32, False),
+                (33, True),
+                (96, True),
+                (97, True),
+                (192, True),
+                (193, False),
+            ):
+                a, b = self._outer(8, m, 128, seed=m)
+                self.assertEqual(
+                    _ran_aot(lambda a=a, b=b: torch.bmm(a, b)),
+                    covered,
+                    f"M={m}: expected covered={covered}",
+                )
+                out = torch.bmm(a, b)
+                self.assertEqual(out, _reference(a, b), atol=0, rtol=0)
+        finally:
+            pn.triton.enable()
+
+    @skipIfNoAotLib
+    def test_uncovered_stay_jit_or_stock(self):
+        pn = torch.backends.python_native
+        pn.triton.disable()
+        try:
+            cases = {
+                "fp16": self._outer(8, 48, 256, torch.float16),
+                "small N": self._outer(8, 48, 64),
+                "K>1 (not outer)": (
+                    torch.randn(8, 48, 4, device="cuda"),
+                    torch.randn(8, 4, 256, device="cuda"),
+                ),
+            }
+            for label, (a, b) in cases.items():
+                self.assertFalse(
+                    _ran_aot(lambda a=a, b=b: torch.bmm(a, b)),
+                    f"{label} must not route to AOT",
+                )
+        finally:
+            pn.triton.enable()
+
+    @skipIfNoAotLib
+    def test_covered_shape_prefers_aot_over_jit(self):
+        # With the JIT layer live, coverage subtraction sends the covered
+        # bucket to AOT: profiler can't attribute (same kernel name), so
+        # assert via the JIT compile cache staying cold.
+        from torch._native.ops.bmm_outer_product.triton_kernels import (
+            _bmm_outer_product_kernel,
+        )
+
+        a, b = self._outer(16, 48, 256, seed=42)
+
+        def jit_cache_size():
+            k = _bmm_outer_product_kernel.jit_kernel
+            return sum(len(c) for c in getattr(k, "device_caches", {}).values())
+
+        before = jit_cache_size()
+        out = torch.bmm(a, b)
+        self.assertEqual(jit_cache_size(), before, "covered call must not JIT-compile")
+        self.assertEqual(out, _reference(a, b), atol=0, rtol=0)
+
+    @skipIfNoAotLib
+    def test_noncontiguous_inputs(self):
+        # Strides are runtime args; transposed views must work and match.
+        torch.manual_seed(1)
+        a = torch.randn(16, 1, 48, device="cuda").transpose(1, 2)
+        b = torch.randn(16, 256, 1, device="cuda").transpose(1, 2)
+        pn = torch.backends.python_native
+        pn.triton.disable()
+        try:
+            self.assertTrue(_ran_aot(lambda: torch.bmm(a, b)))
+            out = torch.bmm(a, b)
+        finally:
+            pn.triton.enable()
+        self.assertEqual(out, _reference(a, b), atol=0, rtol=0)
+
+    @skipIfNoAotLib
+    def test_out_variant_routes_to_aot(self):
+        a, b = self._outer(16, 48, 256, seed=3)
+        out = torch.empty(16, 48, 256, device="cuda")
+        pn = torch.backends.python_native
+        pn.triton.disable()
+        try:
+            self.assertTrue(_ran_aot(lambda: torch.bmm(a, b, out=out)))
+        finally:
+            pn.triton.enable()
+        self.assertEqual(out, _reference(a, b), atol=0, rtol=0)
+
+    @skipIfNoAotLib
+    def test_disabled_context_masks_aot(self):
+        a, b = self._outer(16, 48, 256, seed=4)
+        with torch.backends.python_native.triton.disabled():
+            self.assertFalse(_ran_aot(lambda: torch.bmm(a, b)))
+
+    def test_covered_axes_function_directly(self):
+        # bind() short-circuits shape access behind is_outer -- exercising
+        # it on non-3D inputs must not raise.
+        bind = _load_covered_axes()
+
+        # The new covered_axes folds bucket/min-N checks into "outer".
+        a, b = torch.empty(4, 48, 1), torch.empty(4, 1, 256)
+        self.assertTrue(bind(a, b)["outer"])
+        self.assertFalse(bind(torch.empty(4, 48, 2), b)["outer"])  # K > 1
+        self.assertFalse(bind(torch.empty(4, 8), torch.empty(4, 8))["outer"])  # 2-D
+        self.assertFalse(bind(torch.empty(4, 16, 1), b)["outer"])  # off-bucket M
+        self.assertFalse(bind(a, torch.empty(4, 1, 64))["outer"])  # small N
+
+    def test_covered_call_correct_regardless_of_routing(self):
+        a, b = self._outer(16, 48, 256, seed=5)
+        out = torch.bmm(a, b)
+        self.assertEqual(out, _reference(a, b), atol=0, rtol=0)
+
+
+instantiate_parametrized_tests(TestNativeAotBmmOuter)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_native/ops/bmm_outer_product/aot.py
+++ b/torch/_native/ops/bmm_outer_product/aot.py
@@ -1,0 +1,110 @@
+"""Native-AOT declaration for aten::bmm @ CUDA (outer-product, K == 1).
+
+First triton-kind op. Precompile points carry BLOCK_M/BLOCK_N (which
+compiled kernel) plus the (lo, hi] M-bucket the JIT wrapper's block-size
+picker assigns them -- cpp_dispatch renders the bucket as a range
+condition, mirrored by covered_axes' bucket booleans. Narrow starter
+grid: fp32/bf16, M in (32,192], N >= 128; fp16, other buckets, small N,
+and non-CUDA accelerators stay with the JIT override.
+"""
+
+ATEN_OP = "bmm"
+DISPATCH_KEY = "CUDA"
+KERNEL_MODULE = "aot_kernel.py"
+
+_DTYPES = {"float32": "at::kFloat", "bfloat16": "at::kBFloat16"}
+# (BLOCK_M, m_lo, m_hi): one compiled kernel per (dtype, BLOCK_M),
+# serving M in (m_lo, m_hi]. Matches _pick_block_sizes in
+# triton_kernels.py for these ranges (BLOCK_N = 128 there).
+_M_BUCKETS = [(32, 32, 96), (64, 96, 192)]
+_MIN_N = 128
+
+
+def kernel_precompile_grid():
+    # NB: coverage matches a call iff some point agrees on every field
+    # covered_axes() returns -- so "outer" must appear here (pinned True)
+    # or non-outer calls would falsely match on dtype alone. BLOCK_* and
+    # m_lo/m_hi are export/dispatch-only (absent from covered_axes).
+    return [
+        {
+            "dtype": list(_DTYPES),
+            "outer": True,
+            "BLOCK_M": bm,
+            "BLOCK_N": 128,
+            "m_lo": lo,
+            "m_hi": hi,
+        }
+        for bm, lo, hi in _M_BUCKETS
+    ]
+
+
+def covered_axes(self, mat2):
+    is_outer = (
+        self.dim() == 3
+        and self.shape[2] == 1
+        and mat2.shape[1] == 1
+        and self.numel() > 0
+        and mat2.numel() > 0
+    )
+    m = self.shape[1] if is_outer else 0
+    covered_bucket = any(lo < m <= hi for _, lo, hi in _M_BUCKETS)
+    # Mirror the prelude's specialization conditions (baked innermost
+    # strides + 16B-aligned pointers) so covered calls don't silently
+    # fall to stock aten when the C++ side declines. Alignment via
+    # storage_offset, NOT data_ptr(): Python data_ptr() materializes
+    # copy-on-write inputs and coverage runs on every call. Allocator
+    # bases are >=256B aligned; the C++ prelude re-checks the pointer.
+    specialized = (
+        is_outer
+        and self.stride(1) == 1
+        and mat2.stride(2) == 1
+        and (self.storage_offset() * self.element_size()) % 16 == 0
+        and (mat2.storage_offset() * mat2.element_size()) % 16 == 0
+    )
+    return {
+        "dtype": self.dtype,
+        "outer": specialized and covered_bucket and mat2.shape[2] >= _MIN_N,
+    }
+
+
+def cpp_dispatch_prelude():
+    dtype_reject = " && ".join(f"st != {t}" for t in _DTYPES.values())
+    return f"""
+      const auto st = self.scalar_type();
+      if ({dtype_reject}) return false;
+      if (self.size(2) != 1 || mat2.size(1) != 1) return false;
+      if (self.numel() == 0 || mat2.numel() == 0) return false;
+      if (self.size(0) > std::numeric_limits<int32_t>::max()) return false;
+      // i32 stride parity with the JIT specialization (values checked;
+      // out is dense from meta so its strides are bounded by numel).
+      if (self.stride(0) > std::numeric_limits<int32_t>::max() ||
+          mat2.stride(0) > std::numeric_limits<int32_t>::max() ||
+          out.numel() > std::numeric_limits<int32_t>::max()) return false;
+      const int64_t M = self.size(1);
+      const int64_t N = mat2.size(2);
+      if (N < {_MIN_N}) return false;
+      // Specialization parity with the exported kernels: innermost
+      // strides are baked to 1 and pointers hinted 16B-aligned.
+      if (self.stride(1) != 1 || mat2.stride(2) != 1 || out.stride(2) != 1) return false;
+      // const_data_ptr on inputs: data_ptr() would materialize COW.
+      if (reinterpret_cast<std::uintptr_t>(self.const_data_ptr()) % 16 != 0 ||
+          reinterpret_cast<std::uintptr_t>(mat2.const_data_ptr()) % 16 != 0 ||
+          reinterpret_cast<std::uintptr_t>(out.data_ptr()) % 16 != 0) return false;
+    """
+
+
+def cpp_dispatch(spec):
+    return (
+        f"st == {_DTYPES[spec['dtype']]} && M > {spec['m_lo']} && M <= {spec['m_hi']}"
+    )
+
+
+def cpp_launch(spec, launch_fn):
+    return f"""
+      {launch_fn}(self, mat2, out,
+                static_cast<int32_t>(self.size(0)), static_cast<int32_t>(M), static_cast<int32_t>(N),
+                static_cast<int32_t>(self.stride(0)),
+                static_cast<int32_t>(mat2.stride(0)),
+                static_cast<int32_t>(out.stride(0)), static_cast<int32_t>(out.stride(1)),
+                at::cuda::getCurrentCUDAStream());
+    """

--- a/torch/_native/ops/bmm_outer_product/aot_kernel.py
+++ b/torch/_native/ops/bmm_outer_product/aot_kernel.py
@@ -1,0 +1,135 @@
+"""Triton bmm outer-product kernel for AOT export.
+
+This file exists separately from triton_kernels.py because
+triton.tools.compile takes a kernel FILE path and executes it
+standalone to find the JITFunction -- so the file must hold the bare
+@triton.jit function without the JIT wrapper's instrumentation
+decorator. The JIT wrapper (triton_kernels.py) imports the kernel from
+here, so both routes share one body.
+
+``_bmm_outer_product_aot_kernel`` computes ``out[b] = a[b] @ b[b]`` for
+the K==1 outer-product case: a is (B, M, 1), b is (B, 1, N), out is
+(B, M, N); strides are runtime arguments so non-contiguous inputs work.
+Identical math to the JIT kernel minus the instrumentation decorator.
+
+``build(spec)`` is the AOT entry point (see tools/native_aot/export.py,
+kind="triton"): each spec point bakes one (dtype, BLOCK_M, BLOCK_N)
+specialization; the grid expression is baked into the generated C
+entry point in terms of the named integer arguments.
+"""
+
+import os
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _bmm_outer_product_aot_kernel(
+    A_ptr,
+    B_ptr,
+    OUT_ptr,
+    B_dim,
+    M,
+    N,
+    stride_ab,
+    stride_am,
+    stride_bb,
+    stride_bn,
+    stride_ob,
+    stride_om,
+    stride_on,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    tiles_per_batch = grid_m * grid_n
+
+    pid_b = pid // tiles_per_batch
+    pid_mn = pid % tiles_per_batch
+    pid_m = pid_mn // grid_n
+    pid_n = pid_mn % grid_n
+
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask_m = rm < M
+    mask_n = rn < N
+
+    a = tl.load(A_ptr + pid_b * stride_ab + rm * stride_am, mask=mask_m, other=0.0)
+    b = tl.load(B_ptr + pid_b * stride_bb + rn * stride_bn, mask=mask_n, other=0.0)
+
+    out = a[:, None] * b[None, :]
+
+    mask = mask_m[:, None] & mask_n[None, :]  # pyrefly: ignore[bad-index]
+    tl.store(
+        OUT_ptr + pid_b * stride_ob + rm[:, None] * stride_om + rn[None, :] * stride_on,
+        out,
+        mask=mask,
+    )
+
+
+_TL_DTYPES = {"float32": "fp32", "float16": "fp16", "bfloat16": "bf16"}
+_DTYPE_SHORT = {"float32": "f32", "float16": "f16", "bfloat16": "bf16"}
+
+
+def build(spec: dict) -> dict:
+    """One manifest spec point -> a Triton AOT compile request + sidecar.
+
+    spec: {"dtype": ..., "BLOCK_M": int, "BLOCK_N": int}. Tensor strides
+    are runtime i64 args, so one specialization serves all layouts; the
+    guard over which (M, N) bucket routes here lives in the manifest
+    (per-spec `guard:`), mirroring the JIT wrapper's block-size picker.
+    """
+    dtype = spec["dtype"]
+    tl_ty = _TL_DTYPES[dtype]
+    bm, bn = int(spec["BLOCK_M"]), int(spec["BLOCK_N"])
+    kind = spec.get("toolchain", "triton")
+    prefix = f"bmm_outer_{_DTYPE_SHORT[dtype]}_bm{bm}_bn{bn}"
+    if kind == "triton_cubin":
+        prefix += "_rc"  # distinct artifacts for the raw-cubin A/B spike
+    # Specialization parity with the JIT route: Triton's runtime
+    # specializer bakes the innermost (contiguous) strides to constexpr 1
+    # and hints 16-byte pointer alignment; without matching this the AOT
+    # SASS is generically-addressed and measurably slower (up to ~7x on
+    # this memory-bound kernel). The declaration's prelude enforces the
+    # corresponding runtime conditions (innermost stride 1, aligned
+    # data_ptrs); batch/row strides stay runtime i64.
+    ptr = f"*{tl_ty}:16"
+    signature = ", ".join(
+        [ptr, ptr, ptr, "i32", "i32", "i32"]
+        + ["i32", "1", "i32", "1", "i32", "i32", "1"]  # am/bn/on baked to 1
+        + [str(bm), str(bn)]
+    )
+    grid_x = f"B_dim*(((M+{bm - 1})/{bm})*((N+{bn - 1})/{bn}))"
+    return {
+        "kind": kind,
+        "prefix": prefix,
+        "kernel_path": os.path.abspath(__file__),
+        "kernel_name": "_bmm_outer_product_aot_kernel",
+        "signature": signature,
+        # triton kind: grid string baked into the C entry point.
+        # triton_cubin kind: grid exprs consumed by the generic launcher.
+        "grid": f"{grid_x}, 1, 1",
+        "launch": {"grid_x": grid_x},
+        "num_warps": 4,
+        # Flat argument list in signature order (constexprs excluded):
+        # the launcher passes data_ptr()/int values positionally.
+        # Constexpr-baked strides (am/bn/on = 1) are excluded from the
+        # entry-point prototype; the launcher passes only these.
+        "args": [
+            {"name": "a", "kind": "tensor", "read_only": True},
+            {"name": "b", "kind": "tensor", "read_only": True},
+            {"name": "out", "kind": "tensor"},
+            {"name": "B_dim", "kind": "scalar", "ctype": "int32_t"},
+            {"name": "M", "kind": "scalar", "ctype": "int32_t"},
+            {"name": "N", "kind": "scalar", "ctype": "int32_t"},
+            {"name": "stride_ab", "kind": "scalar", "ctype": "int32_t"},
+            {"name": "stride_bb", "kind": "scalar", "ctype": "int32_t"},
+            {"name": "stride_ob", "kind": "scalar", "ctype": "int32_t"},
+            {"name": "stride_om", "kind": "scalar", "ctype": "int32_t"},
+        ],
+    }

--- a/torch/_native/ops/bmm_outer_product/triton_kernels.py
+++ b/torch/_native/ops/bmm_outer_product/triton_kernels.py
@@ -1,10 +1,14 @@
 import triton
-import triton.language as tl
 
 import torch
-from torch._native.instrumentation import instrumented_triton_cache
+from torch._native.instrumentation import instrument_triton_kernel
 
 from ...triton import ConstTensorWrapper
+
+# Kernel body is shared with the AOT export path: aot_kernel.py carries
+# the @triton.jit function (torch-free, loadable by triton.tools.compile);
+# here we only add the runtime instrumentation wrapper.
+from .aot_kernel import _bmm_outer_product_aot_kernel
 
 
 def _bmm_log_key(a, b, out, B, M, N, *strides, BLOCK_M, BLOCK_N) -> str:
@@ -13,52 +17,9 @@ def _bmm_log_key(a, b, out, B, M, N, *strides, BLOCK_M, BLOCK_N) -> str:
     return f"bmm_outer B={B} M={M} N={N} {a.dtype} BLOCK_M={BLOCK_M} BLOCK_N={BLOCK_N}"
 
 
-@instrumented_triton_cache("aten::bmm", key_fn=_bmm_log_key)
-def _bmm_outer_product_kernel(
-    A_ptr,
-    B_ptr,
-    OUT_ptr,
-    B_dim,
-    M,
-    N,
-    stride_ab,
-    stride_am,
-    stride_bb,
-    stride_bn,
-    stride_ob,
-    stride_om,
-    stride_on,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-):
-    pid = tl.program_id(0)
-
-    grid_m = tl.cdiv(M, BLOCK_M)
-    grid_n = tl.cdiv(N, BLOCK_N)
-    tiles_per_batch = grid_m * grid_n
-
-    pid_b = pid // tiles_per_batch
-    pid_mn = pid % tiles_per_batch
-    pid_m = pid_mn // grid_n
-    pid_n = pid_mn % grid_n
-
-    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-
-    mask_m = rm < M
-    mask_n = rn < N
-
-    a = tl.load(A_ptr + pid_b * stride_ab + rm * stride_am, mask=mask_m, other=0.0)
-    b = tl.load(B_ptr + pid_b * stride_bb + rn * stride_bn, mask=mask_n, other=0.0)
-
-    out = a[:, None] * b[None, :]
-
-    mask = mask_m[:, None] & mask_n[None, :]  # pyrefly: ignore[bad-index]
-    tl.store(
-        OUT_ptr + pid_b * stride_ob + rm[:, None] * stride_om + rn[None, :] * stride_on,
-        out,
-        mask=mask,
-    )
+_bmm_outer_product_kernel = instrument_triton_kernel("aten::bmm", key_fn=_bmm_log_key)(
+    _bmm_outer_product_aot_kernel
+)
 
 
 def _pick_block_sizes(m: int, n: int) -> tuple[int, int]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #191049
* #191048
* #191047
* #191046
* __->__ #191045
* #191044
* #190899
* #190898
* #190897
* #190896
* #190895

Exercises the Triton toolchains: the shared @triton.jit body lives in
aot_kernel.py (triton.tools.compile needs the bare kernel file), each
spec point bakes one (dtype, BLOCK_M, BLOCK_N) specialization, and
per-spec range guards dispatch M into block-size buckets.

The AOT signature matches Triton's JIT specialization (innermost
strides baked to 1, 16-byte alignment hints, i32 strides), with the
corresponding runtime conditions enforced in the prelude and
coverage -- without this the AOT SASS is generically addressed and
much slower.

Authored with an AI assistant (Claude Code).

Test Plan:

```
.venv/bin/python test/python_native/test_native_aot_bmm.py
.venv/bin/python test/python_native/test_instrumentation.py
```