### PR TITLE
[native_aot] scatter_add: TMA-path AOT with TensorIterator prelude analysis

### DIFF
--- a/test/python_native/test_native_aot_scatter_add.py
+++ b/test/python_native/test_native_aot_scatter_add.py
@@ -1,0 +1,268 @@
+# Owner(s): ["module: dsl-native-ops"]
+"""End-to-end tests for the native-AOT scatter_add TMA kernel @ CUDA.
+
+scatter_add stress-tests manifest features the earlier ops don't: only
+ONE of the op's two JIT paths is AOT-embedded (TMA; vec-scatter shapes
+must keep their JIT eligibility), covered_axes reuses the JIT cond's
+own eligibility helpers (TI layout analysis) instead of a hand-written
+projection, the C++ prelude runs a TensorIterator analysis, and the
+in-place variant registers under the trailing-underscore symbol
+("scatter_add_") which must share the base declaration's coverage.
+
+Routing is three-layer: AOT (TMA-eligible calls), JIT (vec-scatter-only
+shapes, int32 indices), stock aten (everything else). JIT and AOT
+compile the same kernel body, so profiler names can't separate those
+two layers; layer preference is proven by the JIT compile cache staying
+cold while the DSL kernel appears in the profile.
+
+The kernel accumulates via cp.reduce.async.bulk in nondeterministic
+order, so value checks use tolerances rather than bit-exactness.
+
+Tests that require the AOT kernel library skip unless it was loaded at
+import; correctness tests run everywhere.
+"""
+
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import SM90OrLater, TEST_CUDA
+from torch.testing._internal.common_utils import run_tests, skipIfNoCuteDSL, TestCase
+
+
+def _aot_lib_loaded() -> bool:
+    from torch._native import _native_aot_embedded
+
+    return _native_aot_embedded()
+
+
+def skipIfNoAotLib(fn):
+    return unittest.skipUnless(
+        _aot_lib_loaded(), "AOT kernels not embedded in this build"
+    )(fn)
+
+
+def _ran_dsl_kernel(fn) -> bool:
+    """True if the CuTeDSL TMA kernel ran (either JIT or AOT layer);
+    False when stock aten served (its kernels are named
+    at::native::tma_scatter_add_kernel / _cuda_scatter_gather...)."""
+    from torch.profiler import profile, ProfilerActivity
+
+    with profile(activities=[ProfilerActivity.CUDA]) as prof:
+        fn()
+        torch.cuda.synchronize()
+    return any(
+        e.name.startswith("kernel_cutlass_")
+        for e in prof.events()
+        if e.device_type.name == "CUDA"
+    )
+
+
+def _jit_cache_misses() -> int:
+    from torch._native.ops.scatter_add.tma_kernel import _compile_tma_scatter
+
+    return _compile_tma_scatter.cache_info().misses
+
+
+def _reference(self_t, dim, index, src):
+    with torch.backends.python_native.cutedsl.disabled():
+        return torch.scatter_add(self_t, dim, index, src)
+
+
+@unittest.skipUnless(TEST_CUDA and SM90OrLater, "CUDA sm_90+ required")
+@skipIfNoCuteDSL
+class TestNativeAotScatterAdd(TestCase):
+    def _inputs(self, m=8192, n=512, rows=4096, dtype=torch.float32, seed=0):
+        torch.manual_seed(seed)
+        src = torch.randn(m, n, device="cuda", dtype=dtype)
+        index = torch.randint(0, rows, (m,), device="cuda")
+        index = index.unsqueeze(-1).expand(m, n)
+        self_t = torch.randn(rows, n, device="cuda", dtype=dtype)
+        return self_t, index, src
+
+    def _tol(self, dtype):
+        # Accumulation order differs between kernels; halves accumulate
+        # in-dtype (both routes), so order changes cost up to an ulp of
+        # the partial-sum magnitude (~1e-1 at bf16 magnitude 4-8).
+        return {"rtol": 5e-2, "atol": 1e-1} if dtype != torch.float32 else {}
+
+    @skipIfNoAotLib
+    def test_covered_call_routes_to_aot(self):
+        self_t, index, src = self._inputs()
+        misses_before = _jit_cache_misses()
+        self.assertTrue(
+            _ran_dsl_kernel(lambda: torch.scatter_add(self_t, 0, index, src))
+        )
+        # The DSL kernel ran but the JIT layer never compiled: AOT served.
+        self.assertEqual(_jit_cache_misses(), misses_before)
+        out = torch.scatter_add(self_t, 0, index, src)
+        ref = _reference(self_t, 0, index, src)
+        self.assertEqual(out, ref, rtol=1e-4, atol=1e-4)
+
+    @skipIfNoAotLib
+    def test_all_grid_dtypes(self):
+        for dtype in (torch.float32, torch.float16, torch.bfloat16):
+            self_t, index, src = self._inputs(dtype=dtype, seed=1)
+            misses_before = _jit_cache_misses()
+            out = torch.scatter_add(self_t, 0, index, src)
+            self.assertEqual(_jit_cache_misses(), misses_before, str(dtype))
+            ref = _reference(self_t, 0, index, src)
+            self.assertEqual(out, ref, **self._tol(dtype))
+
+    @skipIfNoAotLib
+    def test_inplace_and_out_variants(self):
+        self_t, index, src = self._inputs(seed=2)
+        ref = _reference(self_t, 0, index, src)
+        x = self_t.clone()
+        self.assertTrue(_ran_dsl_kernel(lambda: x.scatter_add_(0, index, src)))
+        y = self_t.clone()
+        y.scatter_add_(0, index, src)
+        self.assertEqual(y, ref, rtol=1e-4, atol=1e-4)
+        out = torch.empty_like(self_t)
+        torch.scatter_add(self_t, 0, index, src, out=out)
+        self.assertEqual(out, ref, rtol=1e-4, atol=1e-4)
+
+    @skipIfNoAotLib
+    def test_vec_scatter_shapes_keep_jit_eligibility(self):
+        # Only the TMA path is AOT-embedded. A dst whose row stride is
+        # 4B- but not 16B-aligned (here 516 floats = 2064 B... use 517)
+        # fails TMA's 16B stride contract but satisfies vec-scatter's 4B
+        # one, so the call must be UNCOVERED (keeps JIT eligibility) and
+        # the vec-scatter JIT kernel must serve it.
+        from torch._native import aot_manifest
+        from torch._native.ops.scatter_add.vec_scatter_kernel import (
+            _compile_vec_scatter,
+        )
+
+        m, rows, n = 4096, 512, 512
+        base = torch.randn(rows, n + 5, device="cuda")
+        self_t = base[:, :n]  # row stride 517 floats = 2068 B: %16 != 0
+        src = torch.randn(m, n, device="cuda")
+        index = torch.randint(0, rows, (m,), device="cuda")
+        index = index.unsqueeze(-1).expand(m, n)
+        self.assertFalse(
+            aot_manifest.covers("scatter_add", "CUDA", (self_t, 0, index, src), {})
+        )
+        misses_before = _compile_vec_scatter.cache_info().misses
+        out = torch.scatter_add(self_t, 0, index, src)
+        served_by_jit_vec = _compile_vec_scatter.cache_info().misses > misses_before
+        self.assertTrue(served_by_jit_vec or _compile_vec_scatter.cache_info().currsize)
+        ref = _reference(self_t, 0, index, src)
+        self.assertEqual(out, ref, rtol=1e-4, atol=1e-4)
+
+    @skipIfNoAotLib
+    def test_uncovered_calls_avoid_aot(self):
+        from torch._native import aot_manifest
+
+        self_t, index, src = self._inputs(seed=3)
+        # dim=1 needs index values < self_t.size(1).
+        idx_d1 = torch.randint(0, self_t.size(1), (256, 512), device="cuda")
+        cases = {
+            "fp64": (self_t.double(), 0, index, src.double()),
+            "int32 index": (self_t, 0, index.int(), src),
+            "dim=1": (self_t[:256], 1, idx_d1, src[:256, :512]),
+        }
+        for label, args in cases.items():
+            self.assertFalse(
+                aot_manifest.covers("scatter_add", "CUDA", args, {}),
+                f"{label} must not be covered",
+            )
+            out = torch.scatter_add(*args)
+            with torch.backends.python_native.cutedsl.disabled():
+                ref = torch.scatter_add(*args)
+            self.assertEqual(out, ref, rtol=1e-4, atol=1e-4)
+
+    @skipIfNoAotLib
+    def test_deterministic_mode_avoids_dsl(self):
+        self_t, index, src = self._inputs(seed=4)
+        prior = torch.are_deterministic_algorithms_enabled()
+        try:
+            torch.use_deterministic_algorithms(True)
+            self.assertFalse(
+                _ran_dsl_kernel(lambda: torch.scatter_add(self_t, 0, index, src))
+            )
+        finally:
+            torch.use_deterministic_algorithms(prior)
+
+    @skipIfNoAotLib
+    def test_empty_index_early_return(self):
+        self_t = torch.randn(128, 32, device="cuda")
+        index = torch.empty(0, 32, dtype=torch.long, device="cuda")
+        src = torch.empty(0, 32, device="cuda")
+        out = torch.scatter_add(self_t, 0, index, src)
+        self.assertEqual(out, self_t)
+
+    @skipIfNoAotLib
+    def test_disabled_context_masks_aot(self):
+        self_t, index, src = self._inputs(seed=5)
+        with torch.backends.python_native.cutedsl.disabled():
+            self.assertFalse(
+                _ran_dsl_kernel(lambda: torch.scatter_add(self_t, 0, index, src))
+            )
+        self.assertTrue(
+            _ran_dsl_kernel(lambda: torch.scatter_add(self_t, 0, index, src))
+        )
+
+    @skipIfNoAotLib
+    def test_cpp_covers_agrees_with_python(self):
+        # The AOT lib registers torch.ops._native_aot.covers_scatter_add
+        # (from the declaration's cpp_covers); the router prefers it. It
+        # must decide the same covered set as the Python covered_axes
+        # matching on every case this suite exercises.
+        from torch._native import aot_manifest
+
+        c = aot_manifest.get_coverage("scatter_add", "CUDA")
+        self.assertIsNotNone(c._resolve_cpp_covers())
+        py = aot_manifest._Coverage("scatter_add", c._covered_axes, c._grid)
+        py._cpp_probed = True  # pin to the Python path
+
+        self_t, index, src = self._inputs(seed=7)
+        base = torch.randn(4096, 517, device="cuda")
+        cases = {
+            "covered": ((self_t, 0, index, src), {}),
+            "neg dim": ((self_t, -2, index, src), {}),
+            "out kwarg": ((self_t, 0, index, src), {"out": torch.empty_like(self_t)}),
+            "int32 index": ((self_t, 0, index.int(), src), {}),
+            "fp64": ((self_t.double(), 0, index, src.double()), {}),
+            "unaligned stride": ((base[:, :512], 0, index[:4096], src[:4096]), {}),
+        }
+        for label, (args, kwargs) in cases.items():
+            self.assertEqual(
+                c.covers(args, kwargs), py.covers(args, kwargs), f"drift on {label}"
+            )
+
+    @skipIfNoAotLib
+    def test_oob_index_traps(self):
+        # The kernels bounds-check indices with a predicated PTX trap
+        # (_ptx.trap_if_oob, replacing --enable-assertions): an OOB
+        # index must surface as a CUDA error, never silent corruption.
+        # Subprocess: the trap poisons the CUDA context.
+        import subprocess
+        import sys
+
+        code = (
+            "import torch\n"
+            "M, N = 512, 512\n"
+            "src = torch.randn(M, N, device='cuda')\n"
+            "bad = torch.randint(0, M // 2, (M,), device='cuda')\n"
+            "bad[7] = M\n"
+            "index = bad.unsqueeze(-1).expand(M, N)\n"
+            "self_t = torch.randn(M // 2, N, device='cuda')\n"
+            "torch.scatter_add(self_t, 0, index, src)\n"
+            "torch.cuda.synchronize()\n"
+            "print('NO-ERROR')\n"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, timeout=600
+        )
+        self.assertNotIn("NO-ERROR", proc.stdout, "OOB index completed silently")
+        self.assertNotEqual(proc.returncode, 0)
+
+    def test_covered_call_correct_regardless_of_routing(self):
+        self_t, index, src = self._inputs(seed=6)
+        out = torch.scatter_add(self_t, 0, index, src)
+        ref = _reference(self_t, 0, index, src)
+        self.assertEqual(out, ref, rtol=1e-4, atol=1e-4)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_native/ops/scatter_add/_ptx.py
+++ b/torch/_native/ops/scatter_add/_ptx.py
@@ -75,6 +75,35 @@ def make_bulk_reduce_add(ptx_suffix: str):
     return _op
 
 
+@dsl_user_op
+def trap_if_oob(val_i64, bound_i64, *, loc=None, ip=None):
+    """Predicated device trap unless ``0 <= val < bound``.
+
+    The bounds-check equivalent of aten's ``CUDA_KERNEL_ASSERT`` (see
+    TmaScatterAddKernel.cu): two ``setp`` + predicated ``trap``
+    instructions, effectively free on the happy path. This replaces
+    ``cute_testing.assert_`` + ``--enable-assertions``, whose DSL
+    assert machinery cost ~10% device time on these kernels. The trap
+    aborts the kernel before any OOB write and surfaces as a CUDA
+    launch error (sticky, fails the next sync), matching the intent --
+    though not the exact error text -- of aten's device-side assert.
+    """
+    _inline_asm(
+        None,
+        [as_ir(val_i64, loc=loc, ip=ip), as_ir(bound_i64, loc=loc, ip=ip)],
+        "{\n"
+        ".reg .pred %oob;\n"
+        "setp.lt.s64 %oob, $0, 0;\n"
+        "@%oob trap;\n"
+        "setp.ge.s64 %oob, $0, $1;\n"
+        "@%oob trap;\n"
+        "}",
+        "l,l",
+        loc=loc,
+        ip=ip,
+    )
+
+
 def make_packed_half_atomic_add(ptx_suffix: str):
     """Emit ``red.global.add.noftz.<suffix>`` with a single ``i32`` packed
     register holding two halves. Used by the vec-scatter kernel for

--- a/torch/_native/ops/scatter_add/aot.py
+++ b/torch/_native/ops/scatter_add/aot.py
@@ -1,0 +1,219 @@
+"""Native-AOT declaration for aten::scatter_add @ CUDA (TMA path only).
+
+Only the TMA kernel (sm_90+, cp.reduce.async.bulk) is AOT-embedded; the
+vec-scatter fallback shapes stay JIT-eligible, so covered_axes reports a
+"tma" axis computed with the SAME eligibility helpers the JIT cond uses
+(cutedsl_impl) and the grid pins it True. Everything about the call is
+a runtime argument, so the grid is one kernel per dtype.
+
+The C++ prelude ports the TI-driven layout analysis: restride out so its
+scatter-axis stride is 0 with index's shape, let TensorIterator coalesce
+and reorder, then pattern-match the 2D iter strides -- the same scheme
+as aten's fast_scatter_add_kernel_eligible (IndexKernelUtils.h) and the
+Python _scatter_add_eligibility. The analysis runs on ``out`` (the
+tensor the kernel writes); the wrapper's meta() gives it self's shape,
+and for in-place calls out IS self.
+
+Module scope must import with stdlib alone (torchgen loads this
+pre-build); torch is imported lazily inside covered_axes.
+"""
+
+ATEN_OP = "scatter_add"
+DISPATCH_KEY = "CUDA"
+KERNEL_MODULE = "tma_kernel.py"
+
+# dtype -> (ScalarType, itemsize). chunk_elems (the static TMA box dim)
+# is 512B / itemsize, mirroring tma_kernel.chunk_elems_for.
+_DTYPES = {
+    "float32": ("at::kFloat", 4),
+    "float16": ("at::kHalf", 2),
+    "bfloat16": ("at::kBFloat16", 2),
+}
+
+
+def kernel_precompile_grid():
+    # One TMA kernel per dtype; shapes/strides/grid are runtime args.
+    # "tma" pins coverage to TMA-eligible calls only: vec-scatter-only
+    # shapes (alignment or sm < 90) report tma=False and stay JIT.
+    return [{"dtype": list(_DTYPES), "tma": True, "deterministic": False}]
+
+
+def _cheap_tma_covered(self, dim, index, src, out):
+    """Cheap (no TensorIterator) projection of TMA eligibility.
+
+    covered_axes runs on EVERY call of the op (it is the JIT-decline
+    check), so it must not build a TensorIterator the way the JIT cond
+    does -- that costs ~30us/call in Python and would erase the AOT
+    path's host-overhead win. Instead pattern-match the canonical
+    layout directly: dim 0 scatter, expanded-1D index (stride (1, 0,
+    ...)), inner-contiguous rows on src/dst with everything past dim 0
+    dense. This is deliberately NARROWER than the C++ prelude's TI
+    analysis (rank-permuted layouts that TI would coalesce stay JIT --
+    the JIT TMA path serves them with the same kernel); it must never
+    be WIDER than TMA eligibility or vec-scatter-only calls would
+    decline JIT and land unaccelerated on stock aten.
+    """
+    import torch
+
+    if index.dtype != torch.int64:
+        return False  # AOT ABI is int64-only; JIT widens int32
+    ndim = self.dim()
+    if ndim < 2 or src.dim() != ndim or index.dim() != ndim:
+        return False
+    d = dim + ndim if dim < 0 else dim
+    if d != 0:
+        return False
+    if index.shape != src.shape:
+        return False
+    if index.stride(0) != 1 or any(index.stride(k) != 0 for k in range(1, ndim)):
+        return False
+    dst = self if out is None else out
+    if out is not None and (out.dtype != self.dtype or out.shape != self.shape):
+        return False
+
+    # Rows must be dense past dim 0 (collapsible to 2D with row stride
+    # = stride(0)): exactly the contiguous-tail check.
+    def rows_dense(t):
+        expect = 1
+        for k in range(ndim - 1, 0, -1):
+            if t.stride(k) != expect:
+                return False
+            expect *= t.size(k)
+        return True
+
+    if not rows_dense(src) or not rows_dense(dst):
+        return False
+    n = src.numel() // src.size(0)
+    elem = self.element_size()
+    if (n * elem) % 16 or (src.stride(0) * elem) % 16 or (dst.stride(0) * elem) % 16:
+        return False
+    # Alignment via storage_offset, NOT data_ptr(): Python data_ptr()
+    # materializes copy-on-write inputs and coverage runs on every call.
+    if (src.storage_offset() * elem) % 16 or (dst.storage_offset() * elem) % 16:
+        return False
+    if not torch.cuda.is_available() or torch.version.hip is not None:
+        return False
+    return torch.cuda.get_device_capability(self.device)[0] >= 9
+
+
+def covered_axes(self, dim, index, src, out=None):
+    import torch
+
+    return {
+        "dtype": self.dtype,
+        "tma": _cheap_tma_covered(self, dim, index, src, out),
+        "deterministic": torch.are_deterministic_algorithms_enabled(),
+    }
+
+
+def cpp_covers():
+    # C++ port of covered_axes + grid matching (registered by the AOT
+    # library as torch.ops._native_aot.covers_scatter_add; ~1.5us vs
+    # ~7us for the Python path). Same covered set as _cheap_tma_covered.
+    dtype_reject = " && ".join(f"st != {t}" for t, _ in _DTYPES.values())
+    return f"""
+      const auto st = self.scalar_type();
+      if ({dtype_reject}) return false;
+      if (at::globalContext().deterministicAlgorithms()) return false;
+      if (index.scalar_type() != at::kLong) return false;
+      const int64_t ndim = self.dim();
+      if (ndim < 2 || src.dim() != ndim || index.dim() != ndim) return false;
+      const int64_t d = dim < 0 ? dim + ndim : dim;
+      if (d != 0) return false;
+      if (index.sizes() != src.sizes()) return false;
+      if (index.stride(0) != 1) return false;
+      for (int64_t k = 1; k < ndim; ++k) {{
+        if (index.stride(k) != 0) return false;
+      }}
+      const at::Tensor& dst = out.has_value() ? *out : self;
+      if (out.has_value() && (out->scalar_type() != st || out->sizes() != self.sizes())) return false;
+      // Rows dense past dim 0 (collapsible to 2D with row stride = stride(0)).
+      int64_t expect = 1;
+      for (int64_t k = ndim - 1; k >= 1; --k) {{
+        if (src.stride(k) != expect || dst.stride(k) != expect) return false;
+        expect *= src.size(k);
+      }}
+      const int64_t elem = self.element_size();
+      const int64_t n = src.numel() / std::max<int64_t>(src.size(0), 1);
+      if ((n * elem) % 16 || (src.stride(0) * elem) % 16 || (dst.stride(0) * elem) % 16) return false;
+      if (reinterpret_cast<uintptr_t>(src.const_data_ptr()) % 16 || reinterpret_cast<uintptr_t>(dst.const_data_ptr()) % 16) return false;
+      // sm gate: emitted by gen_aot_lib from ARCHS x shipped artifacts.
+      return self.is_cuda();
+    """
+
+
+def cpp_dispatch_prelude():
+    dtype_reject = " && ".join(f"st != {t}" for t, _ in _DTYPES.values())
+    return f"""
+      const auto st = self.scalar_type();
+      if ({dtype_reject}) return false;
+      if (index.scalar_type() != at::kLong) return false;
+      if (self.dim() == 0 || self.dim() != index.dim() || self.dim() != src.dim()) return false;
+      if (at::globalContext().deterministicAlgorithms()) return false;
+      const int64_t d = c10::maybe_wrap_dim(dim, self.dim());
+      if (index.numel() == 0) {{
+        if (!out.is_same(self)) out.copy_(self);
+        return true;
+      }}
+      // TI-driven layout analysis (same scheme as aten's
+      // fast_scatter_add_kernel_eligible in IndexKernelUtils.h): restride
+      // out so its scatter-axis stride is 0 with index's shape, let
+      // TensorIterator coalesce + reorder, then require a 2D iter whose
+      // dim 0 is the contiguous slice axis and dim 1 the index axis.
+      auto out_r_strides = out.strides().vec();
+      out_r_strides[d] = 0;
+      auto out_r = out.as_strided(index.sizes(), out_r_strides);
+      auto src_r = src.as_strided(index.sizes(), src.strides());
+      auto it = at::TensorIteratorConfig()
+                    .set_check_mem_overlap(false)
+                    .check_all_same_dtype(false)
+                    .resize_outputs(false)
+                    .add_output(out_r)
+                    .add_const_input(src_r)
+                    .add_const_input(index)
+                    .build();
+      if (it.ndim() != 2) return false;
+      const int64_t elem = out.element_size();
+      if (it.strides(2)[0] != 0 || it.strides(2)[1] != index.element_size()) return false;
+      if (it.strides(0)[0] != elem || it.strides(1)[0] != elem || it.strides(0)[1] != 0) return false;
+      const int64_t N = it.shape()[0];
+      const int64_t M_src = it.shape()[1];
+      // 16B contract: TMA tile load of src rows and the
+      // cp.reduce.async.bulk gmem operand on out rows.
+      if ((N * elem) % 16 != 0) return false;
+      if (reinterpret_cast<uintptr_t>(src.const_data_ptr()) % 16 != 0) return false;
+      if (reinterpret_cast<uintptr_t>(out.data_ptr()) % 16 != 0) return false;
+      if ((src.stride(d) * elem) % 16 != 0 || (out.stride(d) * elem) % 16 != 0) return false;
+    """
+
+
+def cpp_dispatch(spec):
+    return f"st == {_DTYPES[spec['dtype']][0]}"
+
+
+def cpp_launch(spec, launch_fn):
+    chunk_elems = 512 // _DTYPES[spec["dtype"]][1]
+    return f"""
+      if (!out.is_same(self)) out.copy_(self);
+      auto out_2d = out.as_strided({{out.size(d), N}}, {{out.stride(d), 1}});
+      auto src_2d = src.as_strided({{M_src, N}}, {{src.stride(d), 1}});
+      auto index_1d = index.as_strided({{M_src}}, {{1}});
+      const int64_t num_chunks = (N + {chunk_elems} - 1) / {chunk_elems};
+      // Grid plan (mirrors tma_kernel._plan_grid): one warp per CTA, so
+      // the row axis alone must reach sm*32 CTAs for occupancy; when M
+      // is too small, split the chunk axis across grid_y.
+      const int64_t sm = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+      int64_t grid_x = M_src, grid_y = 1, chunks_per_cta = num_chunks;
+      if (M_src >= sm * 32) {{
+        grid_x = std::min<int64_t>(M_src, sm * 64);
+      }} else {{
+        const int64_t want_y = std::max<int64_t>(1, (sm * 32) / std::max<int64_t>(M_src, 1));
+        grid_y = std::min(num_chunks, want_y);
+        chunks_per_cta = (num_chunks + grid_y - 1) / grid_y;
+        grid_y = (num_chunks + chunks_per_cta - 1) / chunks_per_cta;
+      }}
+      {launch_fn}(src_2d, index_1d, out_2d, static_cast<int32_t>(N),
+                  static_cast<int32_t>(num_chunks), static_cast<int32_t>(chunks_per_cta),
+                  static_cast<int32_t>(grid_x), static_cast<int32_t>(grid_y),
+                  out.stride(d), at::cuda::getCurrentCUDAStream());
+    """

--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -8,37 +8,11 @@ chunk-index range): a tile-mode TMA bulk load (``cute.copy`` with
 ``cp.reduce.async.bulk.global.shared::cta.bulk_group.add`` deposits the
 reduction into ``out[index[i], d_start:d_end]``.
 
-Using the tile-mode TMA with a descriptor over the full ``(M_src, N)``
-source tensor lets TMA clamp out-of-range column reads to zero, so the
-final partial chunk (when ``N`` isn't a multiple of ``chunk_elems``) is
-handled natively -- we just reduce only the valid byte count on the
-store side. That widens coverage to any ``row_bytes`` that's 16-byte
-aligned (the ``cp.reduce.async.bulk`` gmem operand requirement).
-
-Synchronization between the load and the reduce uses
-``cutlass.pipeline.PipelineTmaAsync`` with ``num_stages=2``: producer
-``acquire``/``commit`` guards the TMA issue, consumer ``wait``/``release``
-guards the reduce. Producer and consumer cooperative groups are both
-``Agent.Thread, size=1`` -- the single driver thread inside the warp
-does both roles. ``PipelineState.advance()`` handles the stage index +
-phase bit.
-
-The pipeline is software-pipelined across the flat sequence of
-``(entry, chunk)`` pairs: each loop iteration issues the TMA load for
-the current pair and consumes the previous one, keeping one TMA load
-in flight alongside an in-progress bulk-reduce. An epilogue drains
-the final outstanding load.
-
-Chunks along D at a compile-time ``chunk_elems``: small rows travel as
-a single chunk, large rows chunk at 512 B. The TMA descriptor OOB-clamp
-handles rows whose length isn't a multiple of ``chunk_elems``.
-
-Grid layout is 2D to maintain SM utilization for shapes with small N
-and large D: ``(grid_x, grid_y)``, where ``grid_y`` partitions the
-chunk-index axis. When N is large the host sets ``grid_y = 1`` so the
-inner chunk loop recovers the classic schedule. When N is tiny (say
-100 rows, D=640K), ``grid_y`` grows so the grid still fills the
-machine.
+One module serves both routes: the JIT wrapper (instrumented compile
+cache + torch host function) and the AOT ``build(spec)`` entry point
+compile the same ``_make_kernel`` body, so same-kernel is by
+construction. The AOT export tool imports this module as a package
+import with the built torch available (two-stage build).
 
 Restrictions (enforced by the host cond in ``cutedsl_impl.py``):
   - sm_90+ (cp.reduce.async.bulk availability)
@@ -54,14 +28,13 @@ import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.cpasync as cpasync
-import cutlass.cute.testing as cute_testing
 import cutlass.pipeline as pipeline
 from cutlass import BFloat16, Float16, Float32, Int32, Int64
 
 import torch
 from torch._native.instrumentation import instrumented_cutedsl_cache
 
-from ._ptx import cvta_smem, make_bulk_reduce_add
+from ._ptx import cvta_smem, make_bulk_reduce_add, trap_if_oob
 
 
 _MAX_CHUNK_BYTES = 512
@@ -72,13 +45,6 @@ _SMEM_ALIGN_BYTES = 128
 
 def _round_up(x: int, m: int) -> int:
     return (x + m - 1) // m * m
-
-
-_TORCH_TO_CUTE = {
-    torch.float32: Float32,
-    torch.float16: Float16,
-    torch.bfloat16: BFloat16,
-}
 
 
 _bulk_reduce_add_f32 = make_bulk_reduce_add("f32")
@@ -216,13 +182,14 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op):
             while chunk_idx < chunk_end:
                 if tidx == Int32(0):
                     r = Int64(mIndex[entry_id])
-                    # Bounds check: index values must be valid output
-                    # rows. Compiling with ``--enable-assertions`` turns
-                    # this into a device-side trap; otherwise it folds
-                    # away. Driver thread only -- no need to replicate
-                    # the check across all 32 lanes.
-                    cute_testing.assert_(r >= Int64(0))
-                    cute_testing.assert_(r < Int64(mOut.shape[0]))
+                    # Bounds check: an OOB index would corrupt unrelated
+                    # gmem via cp.reduce.async.bulk. Predicated PTX trap
+                    # (same mechanism as aten's CUDA_KERNEL_ASSERT in
+                    # TmaScatterAddKernel.cu) -- free on the happy path,
+                    # unlike --enable-assertions (~10% device time).
+                    # Driver thread only -- no need to replicate the
+                    # check across all 32 lanes.
+                    trap_if_oob(r, Int64(mOut.shape[0]))
 
                     pipe.producer_acquire(producer_state)
                     cute.copy(
@@ -288,13 +255,13 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op):
         mSrc: cute.Tensor,
         mIndex: cute.Tensor,
         mOut: cute.Tensor,
-        stream: cuda.CUstream,
         N: Int32,
         num_chunks: Int32,
         chunks_per_cta: Int32,
         grid_x: Int32,
         grid_y: Int32,
         out_row_stride: Int64,
+        stream: cuda.CUstream,
     ):
         # Build the tile-mode TMA descriptor over the (M_src, N) source.
         # Both global dims are dynamic; the ``(1, chunk_elems)`` box is
@@ -325,15 +292,91 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op):
     return _launch
 
 
-def _chunk_elems_for(torch_dtype: torch.dtype) -> int:
+_DTYPES = {"float32": Float32, "float16": Float16, "bfloat16": BFloat16}
+_DTYPE_SHORT = {"float32": "f32", "float16": "f16", "bfloat16": "bf16"}
+
+
+def chunk_elems_for(dtype_name: str) -> int:
     """Compile-time ``chunk_elems`` (the static TMA box dim): always
-    ``_MAX_CHUNK_BYTES // elem_bytes``. Since ``N`` is now a runtime arg
+    ``_MAX_CHUNK_BYTES // elem_bytes``. Since ``N`` is a runtime arg
     the box can't shrink to fit small rows -- instead a short row loads
     one box and the TMA descriptor OOB-clamps the tail to 0, and the
     reduce writes only ``min(chunk_elems, N)`` valid elements. 512 B is
     a multiple of 16 for every supported dtype, so the box always meets
     the reduce's 16-byte alignment."""
-    return _MAX_CHUNK_BYTES // torch_dtype.itemsize
+    dtype = _DTYPES[dtype_name]
+    return _MAX_CHUNK_BYTES // (dtype.width // 8)
+
+
+def build(spec: dict) -> dict:
+    """One manifest spec point -> compile inputs + marshalling sidecar.
+
+    ``spec`` carries {"dtype": "float32"|"float16"|"bfloat16", ...};
+    everything else about the call (shapes, strides, grid) is a runtime
+    argument, so the grid is one kernel per dtype. Index bounds checks
+    are always-on predicated PTX traps (``trap_if_oob``); no
+    ``--enable-assertions`` needed.
+    """
+    dtype = _DTYPES[spec["dtype"]]
+    elem_bytes = dtype.width // 8
+    chunk_elems = chunk_elems_for(spec["dtype"])
+    launcher = _make_kernel(dtype, elem_bytes, chunk_elems, _reduce_op_for(dtype))
+
+    src_fake = cute.runtime.make_fake_tensor(
+        dtype, (cute.sym_int(), cute.sym_int()), stride=(cute.sym_int64(), 1)
+    )
+    # Index is contiguous int64 (the C++ prelude enforces both); fix
+    # stride=1 so `mIndex[i]` doesn't emit a runtime stride multiply.
+    idx_fake = cute.runtime.make_fake_tensor(Int64, (cute.sym_int(),), stride=(1,))
+    out_fake = cute.runtime.make_fake_tensor(
+        dtype, (cute.sym_int(), cute.sym_int()), stride=(cute.sym_int64(), 1)
+    )
+    prefix = f"scatter_add_tma_{_DTYPE_SHORT[spec['dtype']]}"
+    return {
+        "prefix": prefix,
+        "fn": launcher,
+        "fake_args": [
+            src_fake,
+            idx_fake,
+            out_fake,
+            Int32(0),  # N
+            Int32(0),  # num_chunks
+            Int32(0),  # chunks_per_cta
+            Int32(0),  # grid_x
+            Int32(0),  # grid_y
+            Int64(0),  # out_row_stride
+            cute.runtime.make_fake_stream(),
+        ],
+        "tensor_args": [
+            {
+                "name": "mSrc",
+                "dynamic_sizes": [0, 1],
+                "dynamic_strides": [0],
+                "read_only": True,
+            },
+            {"name": "mIndex", "dynamic_sizes": [0], "read_only": True},
+            {"name": "mOut", "dynamic_sizes": [0, 1], "dynamic_strides": [0]},
+        ],
+        "scalar_args": [
+            {"name": "N", "ctype": "int32_t"},
+            {"name": "num_chunks", "ctype": "int32_t"},
+            {"name": "chunks_per_cta", "ctype": "int32_t"},
+            {"name": "grid_x", "ctype": "int32_t"},
+            {"name": "grid_y", "ctype": "int32_t"},
+            {"name": "out_row_stride", "ctype": "int64_t"},
+        ],
+    }
+
+
+_TORCH_TO_NAME = {
+    torch.float32: "float32",
+    torch.float16: "float16",
+    torch.bfloat16: "bfloat16",
+}
+
+
+def _chunk_elems_for(torch_dtype: torch.dtype) -> int:
+    return chunk_elems_for(_TORCH_TO_NAME[torch_dtype])
 
 
 @instrumented_cutedsl_cache(
@@ -344,11 +387,11 @@ def _compile_tma_scatter(torch_dtype: torch.dtype):
     # N and num_chunks are runtime args, so one compile per dtype serves
     # every row length. chunk_elems (the static TMA box) depends only on
     # the dtype's element size.
-    dtype = _TORCH_TO_CUTE[torch_dtype]
+    name = _TORCH_TO_NAME[torch_dtype]
+    dtype = _DTYPES[name]
     elem_bytes = dtype.width // 8
-    chunk_elems = _chunk_elems_for(torch_dtype)
-    reduce_op = _reduce_op_for(dtype)
-    launcher = _make_kernel(dtype, elem_bytes, chunk_elems, reduce_op)
+    chunk_elems = chunk_elems_for(name)
+    launcher = _make_kernel(dtype, elem_bytes, chunk_elems, _reduce_op_for(dtype))
 
     mSrc_fake = cute.runtime.make_fake_tensor(
         dtype, (cute.sym_int(), cute.sym_int()), stride=(cute.sym_int64(), 1)
@@ -364,19 +407,17 @@ def _compile_tma_scatter(torch_dtype: torch.dtype):
         mSrc_fake,
         mIndex_fake,
         mOut_fake,
-        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
         Int32(0),  # N
         Int32(0),  # num_chunks
         Int32(0),  # chunks_per_cta
         Int32(0),  # grid_x
         Int32(0),  # grid_y
         Int64(0),  # out_row_stride
-        # ``--enable-assertions`` keeps the ``cute_testing.assert_``
-        # bounds checks on ``r`` live in production. Cost is roughly
-        # +1-10% (geomean +7.7%) on most shapes; the safety net is
-        # worth it because an OOB ``r`` would otherwise silently
-        # corrupt unrelated gmem via ``cp.reduce.async.bulk``.
-        options="--enable-tvm-ffi --enable-assertions",
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        # Bounds checks on ``r`` are always-on predicated PTX traps in
+        # the kernel body (``trap_if_oob``) -- effectively free,
+        # unlike ``--enable-assertions`` (~10% device time).
+        options="--enable-tvm-ffi",
     )
 
 

--- a/torch/_native/ops/scatter_add/vec_scatter_kernel.py
+++ b/torch/_native/ops/scatter_add/vec_scatter_kernel.py
@@ -17,7 +17,6 @@ per lane per step) and issue atomics into ``out[ind, :]``:
 import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]
 import cutlass
 import cutlass.cute as cute
-import cutlass.cute.testing as cute_testing
 from cutlass import BFloat16, const_expr, Float16, Float32, Int32, Int64
 from cutlass._mlir import ir
 from cutlass._mlir.dialects import llvm, vector as mlir_vector
@@ -26,7 +25,7 @@ from cutlass.cutlass_dsl import dsl_user_op, T
 import torch
 from torch._native.instrumentation import instrumented_cutedsl_cache
 
-from ._ptx import make_packed_half_atomic_add
+from ._ptx import make_packed_half_atomic_add, trap_if_oob
 
 
 _WARPS_PER_BLOCK = 8
@@ -116,11 +115,10 @@ def _make_kernel(dtype, elem_bytes: int, vec_elems: int, contig: bool):
             if entry_id < num_entries:
                 r = Int64(mIndex[entry_id])
                 # Bounds check: out-of-range ``r`` would make the
-                # atomicAdd below corrupt unrelated memory. Compiling
-                # with ``--enable-assertions`` turns this into a
-                # device-side trap; otherwise it folds away.
-                cute_testing.assert_(r >= Int64(0))
-                cute_testing.assert_(r < Int64(mOut.shape[0]))
+                # atomicAdd below corrupt unrelated memory. Predicated
+                # PTX trap (same mechanism as aten's
+                # CUDA_KERNEL_ASSERT) -- free on the happy path.
+                trap_if_oob(r, Int64(mOut.shape[0]))
 
                 lane_offset = lane * Int32(vec_elems)
                 stride_elems = Int32(32 * vec_elems)
@@ -224,12 +222,10 @@ def _compile_vec_scatter(torch_dtype: torch.dtype, contig: bool):
         Int32(0),
         Int64(0),
         Int64(0),
-        # ``--enable-assertions`` keeps the ``cute_testing.assert_``
-        # bounds checks on ``r`` live in production. Cost is roughly
-        # +1-10% (geomean +7.7%) on most shapes; the safety net is
-        # worth it because an OOB ``r`` would otherwise silently
-        # corrupt unrelated gmem via the per-element ``atomicAdd``.
-        options="--enable-tvm-ffi --enable-assertions",
+        # Bounds checks on ``r`` are always-on predicated PTX traps in
+        # the kernel body (``_ptx.trap_if_oob``) -- effectively free,
+        # unlike ``--enable-assertions`` (~10% device time).
+        options="--enable-tvm-ffi",
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #191049
* #191048
* #191047
* __->__ #191046
* #191045
* #191044
* #190899
* #190898
* #190897
* #190896
* #190895

AOT-embeds the TMA kernel only (sm_90+); vec-scatter shapes keep JIT
eligibility -- the first op where AOT covers one of several JIT paths.
The kernel body, JIT wrapper, and AOT build(spec) share one module.

The C++ prelude runs the TensorIterator layout analysis (restride,
coalesce, pattern-match the 2D iter); Python coverage is a cheaper
pattern-match of the canonical layout. In-place calls (scatter_add_)
share the base declaration's coverage. Index bounds checks are
predicated PTX traps (trap_if_oob) in both scatter kernels, replacing
--enable-assertions and its ~10% device-time cost.

Authored with an AI assistant (Claude Code).

Test Plan:

```
.venv/bin/python test/python_native/test_native_aot_scatter_add.py
.venv/bin/python test/test_scatter_gather_ops.py -k scatter_add
.venv/bin/python test/test_torch.py -k scatter
```