### PR TITLE
[native_aot] index_add: the scatter_add TMA kernel serving a second aten op

### DIFF
--- a/test/python_native/test_native_aot_index_add.py
+++ b/test/python_native/test_native_aot_index_add.py
@@ -1,0 +1,286 @@
+# Owner(s): ["module: dsl-native-ops"]
+"""End-to-end tests for the native-AOT index_add @ CUDA.
+
+index_add re-exports the scatter_add TMA kernel (index_add(x, 0, i, s)
+with alpha=1 IS scatter_add on the expanded index; the TMA ABI takes a
+1D index, so the mapping is direct) -- one kernel body serving two aten
+ops is the feature under test. It also exercises: a precomputed dim
+(negative schema dims arrive wrapped), a prelude reject on a Scalar's
+VALUE (alpha != 1 declines; the kernel bakes alpha=1), and an
+early-return path (empty index). There is no JIT override for
+index_add, so routing is two-layer: AOT or stock aten.
+
+Duplicate indices accumulate via cp.reduce.async.bulk in
+nondeterministic order, so value checks use tolerances (matching aten's
+own nondeterministic CUDA index_add) rather than bit-exactness.
+
+Tests that require the AOT kernel library skip unless it was loaded at
+import; correctness tests run everywhere.
+"""
+
+import subprocess
+import sys
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import run_tests, skipIfNoCuteDSL, TestCase
+
+
+def _aot_lib_loaded() -> bool:
+    from torch._native import _native_aot_embedded
+
+    return _native_aot_embedded()
+
+
+def skipIfNoAotLib(fn):
+    return unittest.skipUnless(
+        _aot_lib_loaded(), "AOT kernels not embedded in this build"
+    )(fn)
+
+
+def _ran_aot(fn) -> bool:
+    from torch.profiler import profile, ProfilerActivity
+
+    with profile(activities=[ProfilerActivity.CUDA]) as prof:
+        fn()
+        torch.cuda.synchronize()
+    return any(
+        e.name.startswith("kernel_cutlass_")
+        for e in prof.events()
+        if e.device_type.name == "CUDA"
+    )
+
+
+def _load_covered_axes():
+    # The declaration module is stdlib-only and loaded by file path (it
+    # is not an importable member of the torch package).
+    import importlib.util
+    import os
+
+    path = os.path.join(
+        os.path.dirname(torch.__file__), "_native", "ops", "index_add", "aot.py"
+    )
+    spec = importlib.util.spec_from_file_location("index_add_aot_t", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.covered_axes
+
+
+def _reference(self_t, dim, index, source, alpha=1):
+    with torch.backends.python_native.cutedsl.disabled():
+        return torch.index_add(self_t, dim, index, source, alpha=alpha)
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA required")
+@skipIfNoCuteDSL
+class TestNativeAotIndexAdd(TestCase):
+    def _inputs(self, rows=1000, cols=256, n_idx=5000, seed=0):
+        # cols * 4B is 16B-aligned (TMA contract); fresh allocations are
+        # 16B-aligned bases.
+        torch.manual_seed(seed)
+        self_t = torch.randn(rows, cols, device="cuda")
+        index = torch.randint(0, rows, (n_idx,), device="cuda")
+        source = torch.randn(n_idx, cols, device="cuda")
+        return self_t, index, source
+
+    @skipIfNoAotLib
+    def test_covered_call_routes_to_aot(self):
+        self_t, index, source = self._inputs()
+        self.assertTrue(_ran_aot(lambda: torch.index_add(self_t, 0, index, source)))
+        out = torch.index_add(self_t, 0, index, source)
+        ref = _reference(self_t, 0, index, source)
+        self.assertEqual(out, ref, rtol=1e-4, atol=1e-4)
+
+    @skipIfNoAotLib
+    def test_same_kernel_as_scatter_add(self):
+        # The two ops must launch the IDENTICAL kernel symbol for the
+        # equivalent call -- the point of the shared-kernel design.
+        from torch.profiler import profile, ProfilerActivity
+
+        self_t, index, source = self._inputs(seed=10)
+        expanded = index.unsqueeze(-1).expand_as(source)
+
+        def kernels(fn):
+            with profile(activities=[ProfilerActivity.CUDA]) as prof:
+                fn()
+                torch.cuda.synchronize()
+            return {
+                e.name.split("tensorptr")[0]
+                for e in prof.events()
+                if e.device_type.name == "CUDA" and e.name.startswith("kernel_cutlass_")
+            }
+
+        ia = kernels(lambda: torch.index_add(self_t, 0, index, source))
+        sa = kernels(lambda: torch.scatter_add(self_t, 0, expanded, source))
+        self.assertTrue(ia, "index_add did not run the DSL kernel")
+        self.assertEqual(ia, sa)
+        out = torch.index_add(self_t, 0, index, source)
+        ref = torch.scatter_add(self_t, 0, expanded, source)
+        self.assertEqual(out, ref, rtol=1e-4, atol=1e-4)
+
+    @skipIfNoAotLib
+    def test_half_dtypes_route_to_aot(self):
+        for dtype in (torch.float16, torch.bfloat16):
+            self_t = torch.randn(1000, 256, device="cuda", dtype=dtype)
+            index = torch.randint(0, 1000, (5000,), device="cuda")
+            source = torch.randn(5000, 256, device="cuda", dtype=dtype)
+            self.assertTrue(
+                _ran_aot(lambda: torch.index_add(self_t, 0, index, source)), dtype
+            )
+            out = torch.index_add(self_t, 0, index, source)
+            ref = _reference(self_t, 0, index, source)
+            # Halves accumulate in-dtype on both routes; duplicate
+            # indices reorder the partial sums (same tolerance rationale
+            # as the scatter_add suite's _tol).
+            self.assertEqual(out, ref, rtol=5e-2, atol=1e-1)
+
+    @skipIfNoAotLib
+    def test_alpha_declines_to_aten(self):
+        # The kernel bakes alpha=1; a non-default alpha must decline (a
+        # prelude reject on the Scalar's VALUE) and still be correct.
+        self_t, index, source = self._inputs(seed=1)
+        self.assertFalse(
+            _ran_aot(lambda: torch.index_add(self_t, 0, index, source, alpha=2.5))
+        )
+        out = torch.index_add(self_t, 0, index, source, alpha=2.5)
+        ref = _reference(self_t, 0, index, source, alpha=2.5)
+        self.assertEqual(out, ref, rtol=1e-4, atol=1e-4)
+
+    @skipIfNoAotLib
+    def test_inplace_variant_routes_to_aot(self):
+        self_t, index, source = self._inputs(seed=2)
+        x = self_t.clone()
+        self.assertTrue(_ran_aot(lambda: x.index_add_(0, index, source)))
+        ref = _reference(self_t, 0, index, source)
+        # x has accumulated twice (once inside _ran_aot); recompute clean.
+        y = self_t.clone()
+        y.index_add_(0, index, source)
+        self.assertEqual(y, ref, rtol=1e-4, atol=1e-4)
+
+    @skipIfNoAotLib
+    def test_negative_dim_arrives_precomputed(self):
+        # Schema dim=-2 on a 2D tensor wraps to 0 in the structured
+        # precompute, so the AOT cond (dim != 0) accepts it.
+        self_t, index, source = self._inputs(seed=3)
+        self.assertTrue(_ran_aot(lambda: torch.index_add(self_t, -2, index, source)))
+        out = torch.index_add(self_t, -2, index, source)
+        ref = _reference(self_t, -2, index, source)
+        self.assertEqual(out, ref, rtol=1e-4, atol=1e-4)
+
+    @skipIfNoAotLib
+    def test_uncovered_calls_avoid_aot(self):
+        self_t, index, source = self._inputs(seed=4)
+        cases = {
+            "dim=1": lambda: torch.index_add(
+                self_t,
+                1,
+                torch.randint(0, 256, (64,), device="cuda"),
+                torch.randn(1000, 64, device="cuda"),
+            ),
+            "fp64": lambda: torch.index_add(self_t.double(), 0, index, source.double()),
+            "int32 index": lambda: torch.index_add(self_t, 0, index.int(), source),
+            # The sidecar ABI assumes a dense index (stride 1); strided
+            # index views must decline.
+            "noncontig index": lambda: torch.index_add(
+                self_t, 0, index.repeat_interleave(2)[::2], source
+            ),
+            # TMA 16B contract: a 1-col fp32 row (4B) cannot use the
+            # bulk-reduce path.
+            "row < 16B": lambda: torch.index_add(
+                torch.randn(1000, 1, device="cuda"),
+                0,
+                index,
+                torch.randn(5000, 1, device="cuda"),
+            ),
+        }
+        for label, fn in cases.items():
+            self.assertFalse(_ran_aot(fn), f"{label} must not route to AOT")
+
+    @skipIfNoAotLib
+    def test_deterministic_mode_avoids_aot(self):
+        self_t, index, source = self._inputs(seed=5)
+        prior = torch.are_deterministic_algorithms_enabled()
+        try:
+            torch.use_deterministic_algorithms(True)
+            self.assertFalse(
+                _ran_aot(lambda: torch.index_add(self_t, 0, index, source))
+            )
+        finally:
+            torch.use_deterministic_algorithms(prior)
+
+    @skipIfNoAotLib
+    def test_empty_index_early_return(self):
+        # The cond's early-return path: out = self, no kernel launch.
+        self_t = torch.randn(100, 32, device="cuda")
+        out = torch.index_add(
+            self_t,
+            0,
+            torch.empty(0, dtype=torch.long, device="cuda"),
+            torch.empty(0, 32, device="cuda"),
+        )
+        self.assertEqual(out, self_t)
+
+    @skipIfNoAotLib
+    def test_oob_index_traps(self):
+        # The shared TMA kernel bounds-checks indices with a predicated
+        # PTX trap (_ptx.trap_if_oob): an OOB index must surface as a
+        # CUDA error, never silent corruption (stock aten device-asserts
+        # on the same input). Subprocess: the trap poisons the context.
+        code = (
+            "import torch\n"
+            "x = torch.zeros(100, 32, device='cuda')\n"
+            "src = torch.ones(4, 32, device='cuda')\n"
+            "bad = torch.tensor([1, 2, {oob}, 3], device='cuda')\n"
+            "torch.index_add(x, 0, bad, src)\n"
+            "torch.cuda.synchronize()\n"
+            "print('NO-ERROR')\n"
+        )
+        for label, oob in (("too large", 100), ("negative", -1)):
+            proc = subprocess.run(
+                [sys.executable, "-c", code.format(oob=oob)],
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+            self.assertNotIn(
+                "NO-ERROR", proc.stdout, f"OOB index ({label}) completed silently"
+            )
+            self.assertNotEqual(proc.returncode, 0, label)
+
+    @skipIfNoAotLib
+    def test_disabled_context_masks_aot(self):
+        self_t, index, source = self._inputs(seed=6)
+        with torch.backends.python_native.cutedsl.disabled():
+            self.assertFalse(
+                _ran_aot(lambda: torch.index_add(self_t, 0, index, source))
+            )
+        self.assertTrue(_ran_aot(lambda: torch.index_add(self_t, 0, index, source)))
+
+    def test_covered_axes_function_directly(self):
+        # Raw negative dim normalizes inside the eligibility check --
+        # the Python side sees the schema call, unlike the C++ cond's
+        # precomputed dim. alpha != 1 kills coverage.
+        bind = _load_covered_axes()
+
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA required (TMA eligibility queries the device)")
+        x = torch.empty(100, 32, device="cuda")
+        idx = torch.zeros(8, dtype=torch.long, device="cuda")
+        src = torch.empty(8, 32, device="cuda")
+        sm90 = torch.cuda.get_device_capability()[0] >= 9
+        self.assertEqual(bind(x, -2, idx, src)["tma"], sm90)
+        self.assertEqual(bind(x, 0, idx, src)["tma"], sm90)
+        self.assertFalse(bind(x, 1, idx, src)["tma"])
+        self.assertFalse(bind(x, 0, idx, src, alpha=2)["tma"])
+
+    def test_covered_call_correct_regardless_of_routing(self):
+        # With or without the AOT library, results must be correct.
+        self_t, index, source = self._inputs(seed=7)
+        out = torch.index_add(self_t, 0, index, source)
+        ref = _reference(self_t, 0, index, source)
+        self.assertEqual(out, ref, rtol=1e-4, atol=1e-4)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_native/ops/index_add/__init__.py
+++ b/torch/_native/ops/index_add/__init__.py
@@ -1,0 +1,2 @@
+# AOT-only op: kernels are exported by tools/native_aot from
+# aot_kernel.py; there is no JIT override to register here.

--- a/torch/_native/ops/index_add/aot.py
+++ b/torch/_native/ops/index_add/aot.py
@@ -1,0 +1,157 @@
+"""Native-AOT declaration for aten::index_add @ CUDA (TMA path).
+
+index_add(x, 0, index, source) with alpha=1 IS scatter_add(x, 0,
+index.unsqueeze(-1).expand_as(source), source); the builder re-exports
+the scatter_add TMA kernel under this op's prefix (one kernel body, two
+aten ops). Coverage delegates to scatter_add's _cheap_tma_covered on
+the expanded index, so TMA eligibility has one source of truth.
+
+Beyond kernel sharing this exercises: a structured op with a
+precomputed dim (the C++ side receives the already-wrapped value;
+covered_axes sees the RAW schema call and normalizes itself), a
+prelude reject on a Scalar's VALUE (alpha != 1 declines -- the kernel
+bakes alpha=1), and a prelude early-return (empty index -> copy only).
+There is no JIT override for index_add: uncovered calls land on stock
+aten.
+
+Module scope must import with stdlib alone (torchgen loads this
+pre-build); torch and the scatter_add declaration are loaded lazily.
+"""
+
+import functools
+import importlib.util
+import os
+
+
+ATEN_OP = "index_add"
+DISPATCH_KEY = "CUDA"
+KERNEL_MODULE = "aot_kernel.py"
+
+_DTYPES = {
+    "float32": ("at::kFloat", 4),
+    "float16": ("at::kHalf", 2),
+    "bfloat16": ("at::kBFloat16", 2),
+}
+
+
+@functools.cache
+def _scatter_add_aot():
+    # File-path load (no package context at torchgen time); the sibling
+    # declaration owns _cheap_tma_covered, the TMA-eligibility check.
+    # Cached: covered_axes calls this and exec_module costs ~80us.
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(here, "..", "scatter_add", "aot.py")
+    spec = importlib.util.spec_from_file_location("scatter_add_aot_for_index_add", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def kernel_precompile_grid():
+    # Same grid as scatter_add: one TMA kernel per dtype, all shapes
+    # runtime. "tma" pins coverage to TMA-eligible calls.
+    return [{"dtype": list(_DTYPES), "tma": True, "deterministic": False}]
+
+
+# No cpp_covers, deliberately: index_add has no JIT override, so the
+# router never consults coverage per call -- a C++ covers op would be
+# dead weight. covered_axes exists for the contract (and tooling/tests).
+def covered_axes(self, dim, index, source, alpha=1):
+    import torch
+
+    # index_add's index is 1D; the TMA layout contract is stated over
+    # the scatter_add form, so check eligibility on the expanded view
+    # (free, no copy). alpha != 1 stays with stock aten: the kernel is
+    # a pure add (alpha baked at 1).
+    tma = False
+    if (
+        alpha == 1
+        and isinstance(index, torch.Tensor)
+        and index.dim() == 1
+        and index.is_contiguous()
+        and isinstance(source, torch.Tensor)
+        and source.dim() == self.dim()
+        and source.dim() >= 2
+        and index.numel() == source.shape[0]
+    ):
+        expanded = index.view(-1, *([1] * (source.dim() - 1))).expand_as(source)
+        tma = _scatter_add_aot()._cheap_tma_covered(self, dim, expanded, source, None)
+    return {
+        "dtype": self.dtype,
+        "tma": tma,
+        "deterministic": torch.are_deterministic_algorithms_enabled(),
+    }
+
+
+def cpp_dispatch_prelude():
+    dtype_reject = " && ".join(f"st != {t}" for t, _ in _DTYPES.values())
+    # dim arrives precomputed (maybe_wrap_dim applied by the structured
+    # META), unlike the raw schema dim covered_axes sees. index is 1D by
+    # schema, so the layout checks are direct (no TI analysis needed):
+    # rows dense past dim 0 and 16B-aligned, the TMA contract.
+    return f"""
+      const auto st = self.scalar_type();
+      if ({dtype_reject}) return false;
+      if (dim != 0) return false;
+      if (self.dim() < 2 || index.dim() != 1) return false;
+      if (index.scalar_type() != at::kLong || !index.is_contiguous()) return false;
+      if (source.scalar_type() != st || source.dim() != self.dim()) return false;
+      if (!alpha.equal(1)) return false;
+      if (at::globalContext().deterministicAlgorithms()) return false;
+      if (index.numel() == 0) {{
+        if (!out.is_same(self)) out.copy_(self);
+        return true;
+      }}
+      if (index.numel() != source.size(0)) return false;
+      // Rows dense past dim 0 (collapsible to 2D with row stride =
+      // stride(0)) on both source and out.
+      const auto rows_dense = [](const at::Tensor& t) {{
+        int64_t expect = 1;
+        for (int64_t k = t.dim() - 1; k >= 1; --k) {{
+          if (t.stride(k) != expect) return false;
+          expect *= t.size(k);
+        }}
+        return true;
+      }};
+      if (!rows_dense(source) || !rows_dense(out)) return false;
+      const int64_t N = source.numel() / source.size(0);
+      const int64_t M_src = source.size(0);
+      const int64_t elem = self.element_size();
+      // 16B contract: TMA tile load of source rows and the
+      // cp.reduce.async.bulk gmem operand on out rows.
+      if ((N * elem) % 16 != 0) return false;
+      if ((source.stride(0) * elem) % 16 != 0 || (out.stride(0) * elem) % 16 != 0) return false;
+      if (reinterpret_cast<uintptr_t>(source.const_data_ptr()) % 16 != 0) return false;
+      if (reinterpret_cast<uintptr_t>(out.data_ptr()) % 16 != 0) return false;
+    """
+
+
+def cpp_dispatch(spec):
+    return f"st == {_DTYPES[spec['dtype']][0]}"
+
+
+def cpp_launch(spec, launch_fn):
+    chunk_elems = 512 // _DTYPES[spec["dtype"]][1]
+    # Same grid plan as scatter_add's cpp_launch (mirrors
+    # tma_kernel._plan_grid): one warp per CTA; when M_src alone cannot
+    # fill a wave, split the chunk axis across grid_y.
+    return f"""
+      if (!out.is_same(self)) out.copy_(self);
+      auto out_2d = out.as_strided({{out.size(0), N}}, {{out.stride(0), 1}});
+      auto source_2d = source.as_strided({{M_src, N}}, {{source.stride(0), 1}});
+      const int64_t num_chunks = (N + {chunk_elems} - 1) / {chunk_elems};
+      const int64_t sm = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+      int64_t grid_x = M_src, grid_y = 1, chunks_per_cta = num_chunks;
+      if (M_src >= sm * 32) {{
+        grid_x = std::min<int64_t>(M_src, sm * 64);
+      }} else {{
+        const int64_t want_y = std::max<int64_t>(1, (sm * 32) / std::max<int64_t>(M_src, 1));
+        grid_y = std::min(num_chunks, want_y);
+        chunks_per_cta = (num_chunks + grid_y - 1) / grid_y;
+        grid_y = (num_chunks + chunks_per_cta - 1) / chunks_per_cta;
+      }}
+      {launch_fn}(source_2d, index, out_2d, static_cast<int32_t>(N),
+                  static_cast<int32_t>(num_chunks), static_cast<int32_t>(chunks_per_cta),
+                  static_cast<int32_t>(grid_x), static_cast<int32_t>(grid_y),
+                  out.stride(0), at::cuda::getCurrentCUDAStream());
+    """

--- a/torch/_native/ops/index_add/aot_kernel.py
+++ b/torch/_native/ops/index_add/aot_kernel.py
@@ -1,0 +1,23 @@
+"""AOT builder for index_add: the scatter_add TMA kernel, re-exported.
+
+``index_add(x, 0, index, source)`` with alpha=1 IS
+``scatter_add(x, 0, index.unsqueeze(-1).expand_as(source), source)``,
+and the TMA kernel's ABI already takes the index as a 1D tensor (the
+expansion is pattern-matched away at the host layer), so index_add's
+natural arguments map onto it directly. One kernel body serves two
+aten ops; index bounds checks (trap_if_oob) come with it.
+
+Only the artifact prefix changes: it names the exported C symbols, and
+two declarations cannot share a prefix (duplicate symbols at link).
+"""
+
+from ..scatter_add.tma_kernel import build as _tma_build
+
+
+def build(spec: dict) -> dict:
+    b = _tma_build(spec)
+    # A silently un-renamed prefix would export duplicate C symbols and
+    # fail at link time, far from this cause.
+    assert b["prefix"].startswith("scatter_add_tma"), b["prefix"]  # noqa: S101
+    b["prefix"] = b["prefix"].replace("scatter_add_tma", "index_add_tma")
+    return b


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #191049
* #191048
* __->__ #191047
* #191046
* #191045
* #191044
* #190899
* #190898
* #190897
* #190896
* #190895

index_add(x, 0, index, source) with alpha=1 IS scatter_add(x, 0,
index.unsqueeze(-1).expand_as(source), source), and the TMA kernel's
ABI already takes the index as a 1D tensor -- so the builder re-exports
the scatter_add kernel under this op's prefix and the declaration maps
index_add's arguments straight onto it. One kernel body, two aten ops:
coverage delegates to scatter_add's _cheap_tma_covered on the expanded
index (one source of truth for TMA eligibility), and the kernel's
index bounds checks (trap_if_oob) come along, so an out-of-range index
traps instead of corrupting memory -- matching stock aten's
device-side assert.

Also exercises: a structured op with a precomputed dim (negative
schema dims arrive wrapped), a prelude reject on a Scalar's VALUE
(alpha != 1 declines; the kernel bakes alpha=1), and a prelude
early-return (empty index -> copy only). No JIT override: uncovered
calls land on stock aten.

Coverage footprint vs a bespoke kernel: broadens to fp16/bf16 (the TMA
grid), narrows to the TMA layout contract (16B-aligned dense rows) and
alpha == 1 -- narrowed calls land on stock aten, which serves them
fine.

Authored with an AI assistant (Claude Code).

Test Plan:

```
.venv/bin/python test/python_native/test_native_aot_index_add.py
.venv/bin/python test/python_native/test_native_aot_scatter_add.py
.venv/bin/python test/test_torch.py -k index_add
```