### PR TITLE
[native_aot] Import CuTeDSL reduction + pointwise override stack (squashed)

### DIFF
--- a/test/python_native/test_hw_caps.py
+++ b/test/python_native/test_hw_caps.py
@@ -1,0 +1,60 @@
+# Owner(s): ["module: dsl-native-ops"]
+#
+# Unit tests for the pure-arithmetic surface of _cutedsl.hw_caps.HWCaps -- the
+# derived occupancy quantities the launch heuristics reason in. These are integer
+# formulas over device properties (no kernel launch), so they are checked here for
+# internal consistency and against hand-computed values; the rest of the _cutedsl
+# machinery (traits / launch) only does work once compiled into a kernel and is
+# exercised by the reduction-override suites that build on it.
+
+import unittest
+
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA required")
+class TestHWCaps(TestCase):
+    def _caps(self):
+        from torch._native.ops._cutedsl.hw_caps import caps
+
+        return caps()
+
+    def test_max_warps_per_sm(self):
+        c = self._caps()
+        self.assertEqual(c.max_warps_per_sm, c.max_threads_per_sm // c.warp)
+
+    def test_peak_bw_positive(self):
+        # bus_width/8 * memclock * 1e3 * 2 (DDR): a positive byte/s rate.
+        self.assertGreater(self._caps().peak_bw_bytes, 0)
+
+    def test_waves_scales_with_grid(self):
+        # waves is linear in total_blocks: an empty grid is 0 waves, and doubling
+        # the block count doubles the wave count for a fixed block size.
+        c = self._caps()
+        self.assertEqual(c.waves(0, 256), 0.0)
+        self.assertEqual(c.waves(2000, 256), 2 * c.waves(1000, 256))
+
+    def test_fill_blocks_is_one_wave(self):
+        # fill_blocks(tpb, 1.0) is exactly the concurrent-block count, i.e. the grid
+        # whose waves() is 1.0; and N waves scales it by N.
+        c = self._caps()
+        for tpb in (128, 256, 1024):
+            fill = c.fill_blocks(tpb, 1.0)
+            self.assertEqual(fill, c.fill_blocks(tpb, 2.0) // 2)
+            self.assertAlmostEqual(c.waves(fill, tpb), 1.0, places=5)
+
+    def test_blocks_per_sm_floor(self):
+        # A block larger than the SM thread cap still yields >= 1 block/SM (the
+        # max(1, ...) floor), so fill_blocks never collapses to 0.
+        c = self._caps()
+        huge = c.max_threads_per_sm * 4
+        self.assertGreaterEqual(c.fill_blocks(huge, 1.0), c.sm_count)
+
+    def test_caps_cached_per_device(self):
+        # caps() memoizes per device index -> same object back.
+        self.assertIs(self._caps(), self._caps())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_instrumentation.py
+++ b/test/python_native/test_instrumentation.py
@@ -699,7 +699,14 @@ class TestInstrumentationCoverage(TestCase):
                 # to find a plain JITFunction by name, which a wrapper
                 # would hide. aot.py declaration modules are stdlib-only
                 # metadata (torchgen loads them pre-build).
+                # _cutedsl/launch.py holds the central compile() helper
+                # of the reduction/pointwise stack, whose callers cache
+                # at PLAN level (plan_cache.cached_plan) rather than via
+                # @jit_cache; unifying the two conventions is a known
+                # follow-up (PAIN_POINTS P10).
                 if name.endswith(".py") and name not in ("aot_kernel.py", "aot.py"):
+                    if root.endswith("_cutedsl") and name == "launch.py":
+                        continue
                     yield os.path.join(root, name)
 
     def test_required_decorators_exist(self):

--- a/test/python_native/test_kernel_col.py
+++ b/test/python_native/test_kernel_col.py
@@ -1,0 +1,31 @@
+# Owner(s): ["module: dsl-native-ops"]
+#
+# Minimal smoke test for the K2 vectorized column kernel (reduce dim 0). Proves it
+# compiles and runs on a tiny input; real numeric coverage comes from the reduction
+# overrides' OpInfo suites in a later commit.
+
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import run_tests, skipIfNoCuteDSL, TestCase
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA required")
+@skipIfNoCuteDSL
+class TestKernelCol(TestCase):
+    def test_reduce_col(self):
+        import cutlass
+
+        from torch._native.ops._cutedsl import traits as T
+        from torch._native.ops.reductions import kernel_col
+
+        x = torch.randn(256, 1024, device="cuda")
+        out = kernel_col.reduce_col(
+            T.SumOps(acc=cutlass.Float32), "smoke", x, torch.float32
+        )
+        self.assertEqual(out, x.sum(dim=0), atol=1e-2, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_kernel_general.py
+++ b/test/python_native/test_kernel_general.py
@@ -1,0 +1,34 @@
+# Owner(s): ["module: dsl-native-ops"]
+#
+# Minimal smoke test for the general (K0) reduction kernel + dispatcher. This only
+# proves the kernel COMPILES and runs the general ReduceBlock path end to end on a
+# tiny input; real numeric coverage arrives with the reduction OVERRIDES (via the
+# numpy-referenced OpInfo suites) in a later commit. Reduces a MIDDLE dim so the
+# dispatcher stays in the general path and does not pull in the row/col/xcta fast
+# kernels (added in later commits).
+
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import run_tests, skipIfNoCuteDSL, TestCase
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA required")
+@skipIfNoCuteDSL
+class TestKernelGeneral(TestCase):
+    def test_reduce_dim_general_path(self):
+        import cutlass
+
+        from torch._native.ops._cutedsl import traits as T
+        from torch._native.ops.reductions import kernel_general as kg
+
+        x = torch.randn(8, 16, 32, device="cuda")
+        out = kg.reduce_dim(
+            T.SumOps(acc=cutlass.Float32), "smoke", x, [1], torch.float32
+        )
+        self.assertEqual(out, x.sum(dim=1), atol=1e-2, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_kernel_row.py
+++ b/test/python_native/test_kernel_row.py
@@ -1,0 +1,31 @@
+# Owner(s): ["module: dsl-native-ops"]
+#
+# Minimal smoke test for the K1 vectorized row kernel. Proves it compiles and reduces
+# a contiguous last dim on a tiny input; real numeric coverage comes from the
+# reduction overrides' OpInfo suites in a later commit.
+
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import run_tests, skipIfNoCuteDSL, TestCase
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA required")
+@skipIfNoCuteDSL
+class TestKernelRow(TestCase):
+    def test_reduce_row(self):
+        import cutlass
+
+        from torch._native.ops._cutedsl import traits as T
+        from torch._native.ops.reductions import kernel_row
+
+        x = torch.randn(128, 512, device="cuda")
+        out = kernel_row.reduce_row(
+            T.SumOps(acc=cutlass.Float32), "smoke", x, torch.float32
+        )
+        self.assertEqual(out, x.sum(dim=1), atol=1e-2, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_kernel_xcta.py
+++ b/test/python_native/test_kernel_xcta.py
@@ -1,0 +1,31 @@
+# Owner(s): ["module: dsl-native-ops"]
+#
+# Minimal smoke test for the fused two-stage cross-CTA kernel (few-row / huge-N).
+# Proves it compiles and runs on a tiny single huge row; real numeric coverage comes
+# from the reduction overrides' OpInfo suites in a later commit.
+
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import run_tests, skipIfNoCuteDSL, TestCase
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA required")
+@skipIfNoCuteDSL
+class TestKernelXcta(TestCase):
+    def test_reduce_row_xcta(self):
+        import cutlass
+
+        from torch._native.ops._cutedsl import traits as T
+        from torch._native.ops.reductions import kernel_xcta
+
+        x = torch.randn(1, 1 << 20, device="cuda")
+        out = kernel_xcta.reduce_row_xcta(
+            T.SumOps(acc=cutlass.Float32), "smoke", x, torch.float32
+        )
+        self.assertEqual(out, x.sum(dim=1), atol=1e-1, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_native_utils.py
+++ b/test/python_native/test_native_utils.py
@@ -1,0 +1,37 @@
+# Owner(s): ["module: dsl-native-ops"]
+#
+# Minimal tests for the DSL-agnostic native-op utils. These are torch-only helpers
+# (no cutlass), so they are testable with no GPU/DSL. Broader behavior is exercised
+# by every override family's cond in later commits.
+
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestNativeUtils(TestCase):
+    def test_lazy_module_defers_import(self):
+        # LazyModule must NOT import its target until first attribute access -- this is
+        # what keeps `import torch` free of DSL runtimes (the lazy-DSL-import contract).
+        import sys
+
+        from torch._native.utils.lazy import LazyModule
+
+        # A stdlib module not yet imported: pick one unlikely to be loaded.
+        name = "wave"
+        sys.modules.pop(name, None)
+        mod = LazyModule(name)
+        self.assertNotIn(name, sys.modules)  # constructing the proxy imports nothing
+        self.assertTrue(callable(mod.open))  # first attr access triggers the import
+        self.assertIn(name, sys.modules)
+
+    def test_capability_is_traced_on_meta(self):
+        # is_traced declines meta tensors (no real storage to launch on). Pure torch,
+        # no CUDA needed.
+        import torch
+        from torch._native.utils import capability as cap
+
+        self.assertTrue(cap.is_traced(torch.empty(2, device="meta")))
+        self.assertFalse(cap.is_traced(torch.empty(2)))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_reductions_cutedsl.py
+++ b/test/python_native/test_reductions_cutedsl.py
@@ -1,0 +1,198 @@
+# Owner(s): ["module: dsl-native-ops"]
+#
+# WIRING tests for the CuTeDSL reduction overrides. NUMERIC correctness (value /
+# shape / dtype vs a reference) is NOT tested here -- the overrides are transparent
+# replacements for aten reduction kernels, so their numerics are covered by the
+# existing numpy-referenced OpInfo suites (test_reductions.py, test_ops.py) running
+# with the override active. Duplicating that here would (a) be weaker than the
+# numpy reference and (b) risk self-reference (computing a tolerance via an
+# overridden op recurses into the kernel under test).
+#
+# This file covers only invariants of the OVERRIDE WIRING that OpInfo cannot
+# express: that a supported call actually routes through our kernel (vs silent
+# fallback), that the capability `cond` declines unsupported inputs and lets aten
+# serve them, and that the kernels capture into CUDA graphs.
+
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import run_tests, skipIfNoCuteDSL, TestCase
+
+
+def _disabled():
+    return torch.backends.python_native.cutedsl.disabled()
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA required")
+@skipIfNoCuteDSL
+class TestCuTeDSLReductionWiring(TestCase):
+    def _fired_count(self, fn):
+        # Count invocations of the dispatcher entry points our overrides funnel
+        # through (reduce_dim / reduce_all single-output, reduce_dim2 two-output),
+        # to prove a call routed to our kernel rather than aten.
+        from torch._native.ops.reductions import kernel_general as kg
+
+        names = ("reduce_dim", "reduce_dim2", "reduce_all")
+        orig = {nm: getattr(kg, nm) for nm in names}
+        n = [0]
+
+        def wrap(f):
+            def counting(*a, **k):
+                n[0] += 1
+                return f(*a, **k)
+
+            return counting
+
+        for nm in names:
+            setattr(kg, nm, wrap(orig[nm]))
+        try:
+            fn()
+        finally:
+            for nm in names:
+                setattr(kg, nm, orig[nm])
+        return n[0]
+
+    def test_supported_call_fires(self):
+        # A supported call (CUDA, float, contiguous, valid dim) must route through
+        # our kernel -- guards against a silently-all-fallback regression.
+        x = torch.randn(128, 512, device="cuda")
+        self.assertEqual(self._fired_count(lambda: torch.sum(x, dim=-1)), 1)
+        self.assertEqual(self._fired_count(lambda: torch.mean(x, dim=-1)), 1)
+        self.assertEqual(self._fired_count(lambda: torch.amax(x, dim=-1)), 1)
+        # Group B: single-output index (argmax) and two-output (max.dim).
+        self.assertEqual(self._fired_count(lambda: torch.argmax(x, dim=-1)), 1)
+        self.assertEqual(self._fired_count(lambda: torch.max(x, dim=-1)), 1)
+        # Group C: parameterized / non-float-output single reductions.
+        self.assertEqual(self._fired_count(lambda: torch.var(x, dim=-1)), 1)
+        self.assertEqual(
+            self._fired_count(lambda: torch.linalg.vector_norm(x, dim=-1)), 1
+        )
+        self.assertEqual(self._fired_count(lambda: torch.count_nonzero(x, dim=-1)), 1)
+        # Group D: two float-output reductions.
+        self.assertEqual(self._fired_count(lambda: torch.var_mean(x, dim=-1)), 1)
+        self.assertEqual(self._fired_count(lambda: torch.aminmax(x, dim=-1)), 1)
+
+    def test_fp64_fires(self):
+        # fp64 is a supported accumulator (not a fp32 cast), so a fp64 call must
+        # route through our kernel rather than fall back to aten.
+        x = torch.randn(128, 512, device="cuda", dtype=torch.float64)
+        self.assertEqual(self._fired_count(lambda: torch.sum(x, dim=-1)), 1)
+        self.assertEqual(self._fired_count(lambda: torch.amax(x, dim=-1)), 1)
+
+    def test_unsupported_dtype_falls_back(self):
+        # Integer input is outside the supported set -> must NOT hit our kernel.
+        xi = torch.randint(0, 9, (64, 64), device="cuda")
+        self.assertEqual(self._fired_count(lambda: torch.sum(xi, dim=-1)), 0)
+        # ... and the result is still correct (served by aten).
+        with _disabled():
+            ref = torch.sum(xi, dim=-1)
+        self.assertEqual(torch.sum(xi, dim=-1), ref)
+
+    def test_noncontiguous_falls_back_correct(self):
+        xt = torch.randn(64, 128, device="cuda").t()  # non-contiguous
+        self.assertEqual(self._fired_count(lambda: torch.sum(xt, dim=-1)), 0)
+        with _disabled():
+            ref = torch.sum(xt, dim=-1)
+        self.assertEqual(torch.sum(xt, dim=-1), ref)
+
+    def test_scalar_falls_back(self):
+        # 0-dim input must not crash the cond (regression: d % ndim with ndim==0).
+        s = torch.tensor(3.5, device="cuda")
+        self.assertEqual(self._fired_count(lambda: torch.sum(s)), 0)
+        with _disabled():
+            ref = torch.sum(s, dim=0, keepdim=True)
+        self.assertEqual(torch.sum(s, dim=0, keepdim=True), ref)
+
+    def test_invalid_dim_defers_to_aten(self):
+        # dim args aten rejects (out-of-range / duplicate) must surface aten's
+        # normal error -- the cond declines so aten validates, no wrapped result.
+        x = torch.randn(4, 5, 6, device="cuda")
+        with self.assertRaises(IndexError):
+            torch.sum(x, dim=3)
+        with self.assertRaises(RuntimeError):
+            torch.sum(x, dim=(0, 0))
+
+    def test_cow_input_served_and_preserved(self):
+        # A copy-on-write input is SERVED by our kernel (it exports read-only via
+        # ReadOnlyTensorWrapper -> from_dlpack reads through const_data_ptr()), and
+        # must stay COW after -- reading it must not materialize it.
+        base = torch.randn(128, 512, device="cuda")
+        x = torch._lazy_clone(base)
+        self.assertEqual(self._fired_count(lambda: torch.sum(x, dim=-1)), 1)
+        self.assertTrue(torch._C._is_cow_tensor(x))
+
+    def test_fast_geometry_routing(self):
+        # The cond gates on whether a FAST kernel (row/col/xcta) can serve the
+        # POST-TI-coalesce geometry; a K0-only geometry declines to aten (K0 is
+        # ~5-8x slower than aten, so declining is a win, not a fallback).
+        #   contiguous n-D whose reduced/kept axes coalesce -> served
+        #   mid-dim / transposed / gapped (K0-only)            -> declined
+        served = [
+            ("2D last-dim", torch.randn(512, 512, device="cuda"), -1),
+            ("2D dim0", torch.randn(512, 512, device="cuda"), 0),
+            (
+                "3D last-dim coalesces to row",
+                torch.randn(64, 32, 512, device="cuda"),
+                -1,
+            ),
+            (
+                "3D dims (1,2) coalesce to row",
+                torch.randn(128, 32, 32, device="cuda"),
+                (1, 2),
+            ),
+        ]
+        for name, x, dim in served:
+            self.assertEqual(
+                self._fired_count(lambda: torch.sum(x, dim=dim)),
+                1,
+                f"{name} should fire",
+            )
+        declined = [
+            ("3D mid-dim (K0-only)", torch.randn(512, 512, 64, device="cuda"), 1),
+            ("transpose (irregular)", torch.randn(512, 512, device="cuda").t(), -1),
+        ]
+        for name, x, dim in declined:
+            self.assertEqual(
+                self._fired_count(lambda: torch.sum(x, dim=dim)),
+                0,
+                f"{name} should decline",
+            )
+            with _disabled():
+                ref = torch.sum(x, dim=dim)
+            self.assertEqual(torch.sum(x, dim=dim), ref)  # aten serves it correctly
+
+    @unittest.skipUnless(torch.cuda.device_count() >= 2, "needs >= 2 GPUs")
+    def test_other_device_defers(self):
+        # A tensor not on the current device must fall back (kernel/stream caches
+        # are current-device-bound). cuda:1 with cuda:0 current -> aten.
+        x = torch.randn(128, 512, device="cuda:1")
+        self.assertEqual(self._fired_count(lambda: torch.sum(x, dim=-1)), 0)
+
+    def test_graph_capturable(self):
+        # The override must capture into a CUDA graph and replay correctly (the
+        # earlier _stream() bug made cute launches deadlock / produce empty graphs).
+        x = torch.randn(8192, 1024, device="cuda")
+        f = lambda: torch.sum(x, dim=-1)  # noqa: E731
+        with _disabled():
+            ref = f()
+        for _ in range(3):
+            f()
+        torch.cuda.synchronize()
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(3):
+                f()
+        torch.cuda.current_stream().wait_stream(s)
+        torch.cuda.synchronize()
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            out = f()
+        g.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(out, ref, atol=1e-2, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_native/README.md
+++ b/torch/_native/README.md
@@ -216,6 +216,67 @@ their functional counterparts (`aten::add_` → `aten::add`) before running
 decompositions. If you want overrides to fire in compiled graphs as well
 as eager, register overrides for the **functional** variant too.
 
+### Scalar arguments and type promotion on the fallback path
+
+Ops like `add`/`sub`/`mul`/`div`/comparisons accept a Python number where a
+Tensor is expected (`x + 0.5`, `2.0 - x`, `x.div(1e5)`). aten coerces that
+number into a **wrapped-number tensor** in its unboxed arg-parsing layer,
+*above* the dispatcher (`torch/csrc/utils/python_arg_parser.cpp`, which builds a
+0-d tensor via `scalar_to_tensor` then flags it with
+`TensorImpl::set_wrapped_number(true)` -- cf. `at::native::wrapped_scalar_tensor`
+in `aten/src/ATen/ScalarOps.h` and the flag in `c10/core/TensorImpl.h`). Our
+eager
+router is installed at a **backend dispatch key**, *below* that layer, so when a
+`cond` declines and we fall back to the captured aten kernel, the raw Python
+number is still sitting in a Tensor slot and `call_boxed` rejects it. The
+registry's `_scalar_arg_coercer` reconstructs the wrapped-number coercion before
+calling the fallback.
+
+A wrapped number is a **weak** operand with two independent properties that must
+both be reproduced:
+
+- **Value** is held at full precision and the op computes in fp32 opmath. So
+  `fp16_tensor + (-70000.0)` must stay `-10000` (not overflow to `-inf`), and
+  `fp16_0d.div(1e5)` must keep `1e5` exact (not round it to `inf`).
+- **Dtype** promotion is weak: the number's dtype *category* participates but its
+  width does not. `bf16 + 1.5 -> bf16`, `int + 0.5 -> float`, `int + 2 -> int`.
+  Whether the category propagates depends on the other operands' dimensionality
+  (documented in `torch/_prims_common/__init__.py::elementwise_dtypes`): against
+  a **dim>0** tensor the number never bumps the category (`fp16[4] + 1e5 ->
+  fp16`), but among only **0-d** ("scalar-like") operands categories *do* combine
+  (`uint8_0d + 1 -> uint8`, and `long_0d + half_0d -> half`). The ground-truth
+  promotion lives in `aten/src/ATen/TensorIterator.cpp::compute_types` and
+  `aten/src/ATen/native/TypeProperties.cpp::result_type`.
+
+There is **no Python binding** for `set_wrapped_number`, so we cannot build a
+true wrapped number; the coercer approximates it in three steps:
+
+1. Wrap each scalar at **natural precision** -- `torch.as_tensor(num)` (float ->
+   f64, int -> i64, bool -> bool, complex -> c128). This never rounds the value,
+   so the fp32-opmath value semantics are preserved.
+2. Compute the **weak-promotion output dtype** by folding `torch.result_type`
+   over the *raw* operands (numbers must stay numbers -- pre-wrapping them into
+   strong 0-d tensors would defeat the weak rule).
+3. Call the fallback, then **cast the result down** to that dtype -- but *only*
+   when the result and the target are the **same kind** (both integer, or both
+   floating). A differing kind means the op itself changed category (`div` maps
+   int -> float), in which case `result_type` is *not* the output dtype and
+   casting to it would truncate (`div(-10, tensor(9)) -> 1` instead of `1.11`).
+   The same-kind gate also leaves bool comparison outputs untouched.
+
+Against a dim>0 tensor the natural wrap already yields the correct dtype, so the
+cast is a no-op; it only fires to narrow the over-promotion that the natural wrap
+introduces among 0-d operands (`uint8_0d + 1` naturally gives `int64`, cast back
+to `uint8`). Op families that override scalar-overload siblings
+(`add`/`sub`/`mul`/`div`/...) get this for free via the shared router; families
+with no Tensor slots pay nothing (the coercer is `None`).
+
+Separately, an override's own `cond` must **decline inputs its kernels cannot
+serve** so the fallback (with this coercion) handles them: e.g. the pointwise
+family declines complex scalar args (`add(real, real, alpha=1j)`) and operands
+on a different device from `self`, letting aten raise its native errors instead
+of launching a real-dtype CUDA kernel on them.
+
 ## Registering a New Operator
 
 We currently don't have a use for this functionality, please come talk to us if you want it!

--- a/torch/_native/ops/__init__.py
+++ b/torch/_native/ops/__init__.py
@@ -1,1 +1,10 @@
-from . import bmm_outer_product, foreach_mm, norm, polar, scatter_add, topk
+from . import (
+    bmm_outer_product,
+    foreach_mm,
+    norm,
+    pointwise,
+    polar,
+    reductions,
+    scatter_add,
+    topk,
+)

--- a/torch/_native/ops/_cutedsl/__init__.py
+++ b/torch/_native/ops/_cutedsl/__init__.py
@@ -1,0 +1,16 @@
+# Shared CuteDSL machinery for native ops: the trait library (traits), launch glue
+# (launch), the hardware-capability struct (hw_caps), and the shape-keyed launch-plan
+# memo (plan_cache). Reused by the reduction ops under ../reductions/ and by future
+# pointwise ops so a new op family does not re-derive the host-overhead-minimizing
+# launch path or the trait protocol. (The DSL-agnostic per-tensor cond primitives --
+# is_cow / is_traced / device_ok / on_current_device -- live in torch/_native/utils/
+# instead, since they import only torch and run in the cond on every dispatch.)
+#
+# Importing this package pulls in `cutlass` (traits/launch are @cute.jit code), so it
+# must stay off the `import torch` path; the heavy work happens only when a kernel is
+# actually compiled/launched.
+
+from . import hw_caps, launch, plan_cache, traits
+
+
+__all__ = ["hw_caps", "launch", "plan_cache", "traits"]

--- a/torch/_native/ops/_cutedsl/hw_caps.py
+++ b/torch/_native/ops/_cutedsl/hw_caps.py
@@ -1,0 +1,66 @@
+# Hardware capability struct for launch heuristics.
+#
+# WHY: the reduction launch heuristics were full of magic numbers (2*sm, block_x=64,
+# the 3/4*sm gate) that are really PROXIES for hardware quantities. Expressing them
+# as formulas in device properties makes the SAME heuristic code reason correctly
+# across architectures -- Hopper (132 SM, 228KB smem), Blackwell (148 SM, 232KB),
+# Rubin (future, unknown counts) -- instead of being silently tuned to one GPU.
+#
+# Everything here is read from torch.cuda.get_device_properties; nothing is baked.
+# Cached per device index (properties don't change at runtime).
+
+import torch
+
+from .plan_cache import cached_plan
+
+
+_CACHE = {}
+
+
+class HWCaps:
+    # Raw, portable device facts + a few derived quantities the heuristics want.
+    def __init__(self, device=None):
+        p = torch.cuda.get_device_properties(device)
+        # --- raw, all architecture-portable ---
+        self.name = p.name
+        self.cc = (p.major, p.minor)  # compute capability
+        self.sm_count = p.multi_processor_count  # # of SMs (132 H100, 148 B200)
+        self.warp = p.warp_size  # 32 (stable, but read it)
+        self.max_threads_per_sm = (
+            p.max_threads_per_multi_processor
+        )  # 2048 occupancy cap
+        self.max_threads_per_block = p.max_threads_per_block  # 1024
+        self.regs_per_sm = p.regs_per_multiprocessor
+        self.smem_per_block_optin = p.shared_memory_per_block_optin  # 228KB H, 232KB B
+        self.smem_per_sm = p.shared_memory_per_multiprocessor
+        self.l2_bytes = p.L2_cache_size
+        # peak DRAM bandwidth (bytes/s): bus_width(bits)/8 * memclock(kHz)*1e3 * 2 (DDR)
+        self.peak_bw_bytes = p.memory_bus_width // 8 * p.memory_clock_rate * 1000 * 2
+
+    # --- derived quantities the launch heuristics reason in ---
+    @property
+    def max_warps_per_sm(self):
+        return self.max_threads_per_sm // self.warp
+
+    def waves(self, total_blocks, threads_per_block):
+        # How many occupancy "waves" a grid of `total_blocks` spans. A wave = the
+        # device running its max concurrent blocks once. Concurrency is occupancy-
+        # bound: blocks_per_sm = max_threads_per_sm // threads_per_block (ignoring
+        # reg/smem limits, which the caller checks separately for big kernels).
+        blocks_per_sm = max(1, self.max_threads_per_sm // max(threads_per_block, 1))
+        concurrent = self.sm_count * blocks_per_sm
+        return total_blocks / max(concurrent, 1)
+
+    def fill_blocks(self, threads_per_block, waves=1.0):
+        # Number of blocks needed to fill the device to `waves` occupancy waves.
+        blocks_per_sm = max(1, self.max_threads_per_sm // max(threads_per_block, 1))
+        return int(self.sm_count * blocks_per_sm * waves)
+
+
+def caps(device=None):
+    idx = (
+        torch.cuda.current_device()
+        if device is None
+        else (device if isinstance(device, int) else torch.cuda.current_device())
+    )
+    return cached_plan(_CACHE, idx, lambda: HWCaps(device))

--- a/torch/_native/ops/_cutedsl/launch.py
+++ b/torch/_native/ops/_cutedsl/launch.py
@@ -1,0 +1,107 @@
+# Shared CuteDSL launch glue: torch <-> cute tensor wrapping, stream handle, and
+# the EnableTVMFFI-compiled launcher. Reused by all CuteDSL native ops (reductions
+# today, pointwise later) -- the host-overhead-minimizing path established by the
+# pointwise/reduction experiment.
+#
+# Three host-overhead levers, all measured on B200 (see the experiment notes):
+#   - enable_tvm_ffi=True on from_dlpack: ~0.8us vs ~3.6us for the __dlpack__()
+#     capsule roundtrip (takes torch's fast C exchange).
+#   - options="--enable-tvm-ffi" on cute.compile: per-compile arg-passing convention
+#     that skips the per-arg get_c_pointers marshalling (~30% off the launch
+#     dispatch). Equivalent to the cute.compile[EnableTVMFFI] typed form.
+#   - _stream via _cuda_getCurrentRawStream: the raw cudaStream_t POINTER in ~0.07us
+#     (vs ~2.7us for the torch.cuda.current_stream() wrapper) AND it correctly
+#     tracks the CUDA-graph capture stream. Do NOT use _cuda_getCurrentStream(dev)[0]
+#     (a packed stream id, not a pointer -- deadlocks graph capture).
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Float64, Int32, Int64
+
+import torch
+from torch.utils.dlpack import ReadOnlyTensorWrapper
+
+
+# torch dtype -> cute numeric type. Extend as new dtypes are supported.
+torch2cute = {
+    torch.float32: Float32,
+    torch.float64: Float64,
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.int32: Int32,
+    torch.int64: Int64,
+    torch.bool: cutlass.Boolean,
+}
+
+
+def _ro(t, read_only):
+    # Wrap an INPUT tensor read-only so the fast tvm-ffi from_dlpack exports through
+    # const_data_ptr(): a copy-on-write input is exported WITHOUT materializing (the
+    # autograd backward contract forbids materializing a COW view under a transparent
+    # override), so the overrides no longer need a COW cond check. Apply ONLY to
+    # inputs -- outputs are written by the kernel and must stay writable, so callers
+    # pass read_only=False for them. The wrapper is export-only and rejects every
+    # non-DLPack op, so it must wrap the FINAL-shape tensor, immediately before the
+    # from_dlpack call (after any reshape/expand the helper did itself).
+    return ReadOnlyTensorWrapper(t) if read_only else t
+
+
+def cute_tensor(t, read_only=False):
+    # Wrap a torch tensor as a cute tensor via the fast tvm-ffi exchange.
+    ct = cute.runtime.from_dlpack(_ro(t, read_only), enable_tvm_ffi=True)
+    ct.element_type = torch2cute[t.dtype]
+    return ct
+
+
+def cute_tensor_vec(t, V, read_only=False):
+    # Flat-coalesce a contiguous tensor to a (numel/V, V) cute tensor for the
+    # vectorized elementwise path: row i is one thread's V-wide fragment. assumed
+    # 16-byte alignment lets the DSL emit wide (128-bit) loads; torch allocations are
+    # >=256 B aligned and V*dtype == 128 bits, so this is safe. Caller guarantees
+    # numel % V == 0 and contiguity (see kernel._vec_ok).
+    tv = t.reshape(-1, V)
+    ct = cute.runtime.from_dlpack(
+        _ro(tv, read_only), assumed_align=16, enable_tvm_ffi=True
+    )
+    ct.element_type = torch2cute[t.dtype]
+    return ct
+
+
+def cute_tensor_dynM(t, align=None, ndim=None, read_only=False):
+    # Like cute_tensor but marks the LEADING dim (mode 0 = the M / output-row axis)
+    # DYNAMIC while keeping the others static. For row reductions M is just the grid
+    # size; baking it forces a recompile per distinct M (e.g. every batch size in a
+    # training loop). mark_compact_shape_dynamic(mode=0) lets ONE compiled kernel
+    # serve any M at a fixed N. stride_order is row-major outer->inner: (0,1) for 2D
+    # (M, N), (0,) for 1D (M,). N stays static so the kernel's const_expr vec/tile
+    # checks still resolve.
+    w = _ro(t, read_only)
+    ct = (
+        cute.runtime.from_dlpack(w, assumed_align=align, enable_tvm_ffi=True)
+        if align is not None
+        else cute.runtime.from_dlpack(w, enable_tvm_ffi=True)
+    )
+    ct.element_type = torch2cute[t.dtype]
+    nd = ndim if ndim is not None else t.dim()
+    ct.mark_compact_shape_dynamic(mode=0, stride_order=tuple(range(nd)), divisibility=1)
+    return ct
+
+
+# tvm-ffi launcher. Compile every native CuteDSL kernel through this (not bare
+# cute.compile) for the fast arg-passing convention that skips per-arg
+# get_c_pointers marshalling. The `--enable-tvm-ffi` codegen flag is equivalent to
+# the cute.compile[EnableTVMFFI] typed form (measured identical host dispatch on
+# B200, +-0.03us) and matches the convention used by the other native CuteDSL ops.
+def compile(op, *args):
+    return cute.compile(op, *args, options="--enable-tvm-ffi")
+
+
+def stream():
+    # Live current stream handle, read every call (never cached: callers may set a
+    # different stream/device per call, and the kernel must launch on whatever is
+    # current, including the CUDA-graph capture stream). _cuda_getCurrentRawStream
+    # returns the real cudaStream_t pointer cheaply and capture-correctly.
+    import cuda.bindings.driver as cuda
+
+    dev = torch.cuda.current_device()
+    return cuda.CUstream(torch._C._cuda_getCurrentRawStream(dev))

--- a/torch/_native/ops/_cutedsl/plan_cache.py
+++ b/torch/_native/ops/_cutedsl/plan_cache.py
@@ -1,0 +1,40 @@
+# Shared launch-plan memoization for the CuteDSL native ops.
+#
+# Every op family does the same thing: derive a "plan" (the compiled kernel + all
+# shape-invariant host-side decisions -- chosen path, vector width, output dtypes,
+# alignment, ...) once per distinct operand signature, then on later calls reuse it
+# and only do the per-call work (wrap the live tensors, launch). The plan is a pure
+# function of the cache KEY (dtypes, shapes/strides, device, op params), which is
+# exactly what is baked into the compiled kernel.
+#
+# Without this, the eager host cost is dominated by recomputing the plan every call
+# (shape/promotion derivation, path selection, kernel lookup) -- far more than the
+# irreducible wrap + launch. Caching collapses a repeated-shape workload to wrap +
+# launch.
+#
+# A plan of None is a valid memoized result meaning "declined -- the caller should
+# fall back" (e.g. a geometry this kernel cannot serve). It is cached like any other
+# so the (sometimes non-trivial) decline decision is not recomputed; callers use the
+# returned (hit, plan) pair to tell a cached-None from a miss.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def cached_plan(cache: dict, key, build: Callable):
+    """Return ``build()``'s plan for ``key``, memoized in ``cache`` (including a
+    None plan, which means "declined / fall back"). ``build`` is called at most once
+    per key. Returns the plan (possibly None)."""
+    plan = cache.get(key, _MISS)
+    if plan is _MISS:
+        plan = build()
+        cache[key] = plan
+    return plan
+
+
+_MISS = object()  # sentinel so a cached None (declined) is distinct from a miss

--- a/torch/_native/ops/_cutedsl/traits.py
+++ b/torch/_native/ops/_cutedsl/traits.py
@@ -1,0 +1,837 @@
+# CuTeDSL trait library for native reductions: the trait protocol + cross-thread
+# reduce helpers (warp_reduce / block_reduce). Shared machinery under _cutedsl/ so
+# future pointwise ops can reuse the same abstractions. The kernels and the aten
+# overrides live in ../reductions/.
+#
+# Input is 2D (M, N); reduce along the contiguous last axis, producing one
+# output per row. One CTA handles one row; the whole reduction fits in a block
+# via warp-shuffle butterfly + a shared-memory block reduce.
+#
+# ACCUMULATOR DTYPE is a PARAMETER (`acc`, default Float32). Every trait threads it
+# through fdtypes + its init/reduce/combine/project literals so the SAME trait can
+# accumulate in fp32 (fp16/bf16/fp32 inputs) or a wider type (fp64) -- and, later,
+# integer/complex accumulators. The accumulator identity (0 / 1 / +-inf) is taken
+# from the dtype via _zero/_one/_pos_id/_neg_id so it is correct for any acc dtype
+# (e.g. ints have no inf; they will supply min/max int instead). The argmax/argmin
+# INDEX field is Int32 by default (a position, not an accumuland) and Int64 when the
+# reduced extent can exceed 2^31 -- both threaded via the trait's `idx` parameter.
+#
+# Discovered cute intrinsics (the productive ones):
+#   scalar select  : Python ternary (a if pred else b) INSIDE a @cute.jit body;
+#                    the jit preprocessor lowers it to a select. It does NOT
+#                    lower inside plain (undecorated) callees, so every trait
+#                    value-method is @cute.jit.
+#   isnan(x)       : x != x  (Boolean SSA)
+#   -inf           : -<acc>.inf
+#   abs            : cute.math.absf
+#   pow / sqrt     : cute.math.exp/log for x**p; cute.math.sqrt for sqrt
+#   fmax           : cute.arch.fmax  (NaN-SUPPRESSING: returns the non-NaN arg,
+#                    so argmax NaN handling is done explicitly via x != x)
+#   butterfly shfl : cute.arch.shuffle_sync_bfly(value, offset=...)
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Boolean, const_expr, Float32, Int32, Int64
+
+
+WARP = 32
+
+# argmax/argmin "no winner yet" sentinel, per index dtype. Int32 is the default (an
+# index is a position, not an accumuland, and the narrow field halves partial-buffer
+# traffic + speeds the warp shuffle); the builder switches an index trait to Int64
+# only when the reduced extent can exceed the Int32 range (see _idx_sentinel).
+_INT32_MAX = (1 << 31) - 1
+_INT64_MAX = (1 << 63) - 1
+_INT_MAX = _INT32_MAX  # back-comat alias (Int32 default sentinel)
+
+
+def _idx_sentinel(idx_dtype):
+    return idx_dtype(_INT64_MAX if idx_dtype is Int64 else _INT32_MAX)
+
+
+def _pos_id(acc):
+    # "Largest" identity for a min-reduction's init / the value that loses every
+    # max. For floats this is +inf; integer accumulators (a later family) will
+    # override with their max representable value. Wrap in `acc(...)` so the result
+    # carries the accumulator dtype -- `acc.inf` is a bare Python float, which the
+    # DSL treats as Float32, breaking the ifexp type-match in `_pick` for fp64.
+    return acc(acc.inf)
+
+
+def _neg_id(acc):
+    # "Smallest" identity for a max-reduction's init. -inf for floats; typed via
+    # `acc(...)` for the same reason as `_pos_id`.
+    return acc(-acc.inf)
+
+
+class SumOps:
+    # acc = (sum,). Validates vs torch.sum(x, dim=-1).
+    nfields = 1
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    def init(self):
+        return (self.acc(0.0),)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        add = val if valid else self.acc(0.0)
+        return (acc[0] + add,)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (a[0] + b[0],)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[0]
+
+
+class NormOps:
+    # acc = (sum of |x|**p,). project = sum**(1/p).
+    # Validates vs torch.linalg.vector_norm(x, ord=p, dim=-1).
+    nfields = 1
+
+    def __init__(self, p, acc=Float32):
+        self.p = float(p)
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    @cute.jit
+    def _absp(self, val):
+        a = self.acc(cute.math.absf(val))
+        if const_expr(self.p == 1.0):
+            return a
+        elif const_expr(self.p == 2.0):
+            return a * a
+        else:
+            # |x|**p via exp(p*log|x|); log(0)=-inf so 0**p -> exp(-inf)=0 for p>0.
+            return cute.math.exp(self.acc(self.p) * cute.math.log(a))
+
+    def init(self):
+        return (self.acc(0.0),)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        contrib = self._absp(val) if valid else self.acc(0.0)
+        return (acc[0] + contrib,)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (a[0] + b[0],)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        s = acc[0]
+        if const_expr(self.p == 1.0):
+            return s
+        elif const_expr(self.p == 2.0):
+            return cute.math.sqrt(s)
+        else:
+            return cute.math.exp(cute.math.log(s) / self.acc(self.p))
+
+
+class WelfordOps:
+    # acc = (mean, m2, nf) all in the accumulator dtype.
+    #   reduce  = ONLINE (Welford) update of a single element.
+    #   combine = PARALLEL (Chan) merge of two partial accumulators.
+    # These two formulas are deliberately different. project computes
+    #   var = m2 / max(nf - correction, 0), optionally sqrt, optionally mean.
+    # Validates vs torch.var / torch.std (dim=-1, correction).
+    nfields = 3
+
+    def __init__(self, correction=1, take_sqrt=False, return_mean=False, acc=Float32):
+        self.correction = float(correction)
+        self.take_sqrt = bool(take_sqrt)
+        self.return_mean = bool(return_mean)
+        self.acc = acc
+        self.fdtypes = (acc, acc, acc)
+
+    def init(self):
+        z = self.acc(0.0)
+        return (z, z, z)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        mean, m2, nf = acc
+        new_nf = nf + self.acc(1.0)
+        delta = val - mean
+        new_mean = mean + delta / new_nf
+        new_m2 = m2 + delta * (val - new_mean)
+        # OOB element: keep accumulator unchanged (do not advance the count).
+        out_mean = new_mean if valid else mean
+        out_m2 = new_m2 if valid else m2
+        out_nf = new_nf if valid else nf
+        return (out_mean, out_m2, out_nf)
+
+    @cute.jit
+    def combine(self, a, b):
+        ma, m2a, na = a
+        mb, m2b, nb = b
+        nn = na + nb
+        nb_over_n = (nb / nn) if (nn > self.acc(0.0)) else self.acc(0.0)
+        delta = mb - ma
+        mean = ma + delta * nb_over_n
+        m2 = m2a + m2b + delta * delta * na * nb_over_n
+        return (mean, m2, nn)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (
+            cute.arch.shuffle_sync_bfly(acc[0], offset=offset),
+            cute.arch.shuffle_sync_bfly(acc[1], offset=offset),
+            cute.arch.shuffle_sync_bfly(acc[2], offset=offset),
+        )
+
+    @cute.jit
+    def project(self, acc, n):
+        mean, m2, nf = acc
+        if const_expr(self.return_mean):
+            return mean
+        var = m2 / (nf - self.acc(self.correction))
+        if const_expr(self.take_sqrt):
+            return cute.math.sqrt(var)
+        return var
+
+
+class ArgMaxOps:
+    # acc = (best_val: acc dtype, best_idx: idx dtype, default Int32).
+    # GreaterOrNan winner: NaN beats everything; exact tie -> LOWER index wins;
+    # otherwise larger value wins. Matches torch.argmax (first NaN, first max).
+    # has_index: the accumulator carries a per-element INDEX. The index dtype is a
+    # parameter: Int32 by default (cheaper partials + shuffle), Int64 when the reduced
+    # extent can exceed 2^31 so the winning position never overflows -- the builder
+    # picks it from N (this is what lets the cross-CTA split serve huge-N argmax; the
+    # stage-1 fold's chunk-global column must be computed in the same width, see
+    # kernel_row.col_base).
+    nfields = 2
+    has_index = True
+
+    def __init__(self, acc=Float32, idx=Int32):
+        self.acc = acc
+        self.idx = idx
+        self.fdtypes = (acc, idx)
+
+    def init(self):
+        return (_neg_id(self.acc), _idx_sentinel(self.idx))
+
+    @cute.jit
+    def _pick(self, bv, bi, cv, ci):
+        # Does candidate (cv, ci) beat current best (bv, bi)?
+        cand_nan = cv != cv
+        best_nan = bv != bv
+        repl = (
+            ((ci < bi) if best_nan else Boolean(True))
+            if cand_nan
+            else (
+                Boolean(False) if best_nan else ((ci < bi) if (cv == bv) else (cv > bv))
+            )
+        )
+        nv = cv if repl else bv
+        ni = ci if repl else bi
+        return (nv, ni)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        nv, ni = self._pick(acc[0], acc[1], val, self.idx(idx))
+        out_v = nv if valid else acc[0]
+        out_i = ni if valid else acc[1]
+        return (out_v, out_i)
+
+    @cute.jit
+    def combine(self, a, b):
+        return self._pick(a[0], a[1], b[0], b[1])
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (
+            cute.arch.shuffle_sync_bfly(acc[0], offset=offset),
+            cute.arch.shuffle_sync_bfly(acc[1], offset=offset),
+        )
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[1]
+
+
+class ProdOps:
+    # acc = (product,). Validates vs torch.prod(x, dim=-1).
+    nfields = 1
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    def init(self):
+        return (self.acc(1.0),)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        mul = val if valid else self.acc(1.0)
+        return (acc[0] * mul,)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (a[0] * b[0],)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[0]
+
+
+class MeanOps:
+    # acc = (sum,); factor applied in project. Validates vs torch.mean(x, dim=-1).
+    nfields = 1
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    def init(self):
+        return (self.acc(0.0),)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        add = val if valid else self.acc(0.0)
+        return (acc[0] + add,)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (a[0] + b[0],)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[0] / n
+
+
+class NanSumOps:
+    # acc = (sum,); NaN inputs map to 0. Validates vs torch.nansum(x, dim=-1).
+    nfields = 1
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    def init(self):
+        return (self.acc(0.0),)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        clean = val if (val == val) else self.acc(0.0)
+        add = clean if valid else self.acc(0.0)
+        return (acc[0] + add,)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (a[0] + b[0],)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[0]
+
+
+class AllOps:
+    # acc = (1.0 while all-true,). x != 0 is True (NaN is truthy, matches torch).
+    # AND via product of 0/1 flags. Validates vs torch.all(x, dim=-1).
+    nfields = 1
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    def init(self):
+        return (self.acc(1.0),)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        flag = self.acc(1.0) if (val != self.acc(0.0)) else self.acc(0.0)
+        keep = flag if valid else self.acc(1.0)
+        return (acc[0] * keep,)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (a[0] * b[0],)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[0]
+
+
+class AnyOps:
+    # acc = (1.0 if any-true,). OR via max of 0/1 flags. Validates vs torch.any.
+    nfields = 1
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    def init(self):
+        return (self.acc(0.0),)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        flag = self.acc(1.0) if (val != self.acc(0.0)) else self.acc(0.0)
+        keep = flag if valid else self.acc(0.0)
+        return (max(keep, acc[0]),)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (max(b[0], a[0]),)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[0]
+
+
+class CountNonzeroOps:
+    # acc = (count,). Also serves p=0 norm. Validates vs torch.count_nonzero and
+    # torch.linalg.vector_norm(x, ord=0, dim=-1). NaN counts as nonzero.
+    nfields = 1
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    def init(self):
+        return (self.acc(0.0),)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        flag = self.acc(1.0) if (val != self.acc(0.0)) else self.acc(0.0)
+        add = flag if valid else self.acc(0.0)
+        return (acc[0] + add,)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (a[0] + b[0],)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[0]
+
+
+class AbsMaxOps:
+    # acc = (max|x|,). p=inf norm. Validates vs vector_norm(x, ord=inf, dim=-1).
+    nfields = 1
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    def init(self):
+        return (self.acc(0.0),)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        a = self.acc(cute.math.absf(val))
+        m = max(acc[0], a)
+        return (m if valid else acc[0],)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (max(b[0], a[0]),)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[0]
+
+
+class AbsMinOps:
+    # acc = (min|x|,). p=-inf norm. Validates vs vector_norm(x, ord=-inf, dim=-1).
+    nfields = 1
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    def init(self):
+        return (_pos_id(self.acc),)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        a = self.acc(cute.math.absf(val))
+        m = min(acc[0], a)
+        return (m if valid else acc[0],)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (min(b[0], a[0]),)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[0]
+
+
+class ArgMinOps:
+    # acc = (best_val, best_idx). LessOrNan: NaN beats everything; tie -> lower
+    # index; else smaller value wins. Matches torch.argmin.
+    nfields = 2
+    has_index = (
+        True  # index dtype parametric (Int32 default / Int64 huge-N); see ArgMaxOps
+    )
+
+    def __init__(self, acc=Float32, idx=Int32):
+        self.acc = acc
+        self.idx = idx
+        self.fdtypes = (acc, idx)
+
+    def init(self):
+        return (_pos_id(self.acc), _idx_sentinel(self.idx))
+
+    @cute.jit
+    def _pick(self, bv, bi, cv, ci):
+        cand_nan = cv != cv
+        best_nan = bv != bv
+        repl = (
+            ((ci < bi) if best_nan else Boolean(True))
+            if cand_nan
+            else (
+                Boolean(False) if best_nan else ((ci < bi) if (cv == bv) else (cv < bv))
+            )
+        )
+        nv = cv if repl else bv
+        ni = ci if repl else bi
+        return (nv, ni)
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        nv, ni = self._pick(acc[0], acc[1], val, self.idx(idx))
+        out_v = nv if valid else acc[0]
+        out_i = ni if valid else acc[1]
+        return (out_v, out_i)
+
+    @cute.jit
+    def combine(self, a, b):
+        return self._pick(a[0], a[1], b[0], b[1])
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (
+            cute.arch.shuffle_sync_bfly(acc[0], offset=offset),
+            cute.arch.shuffle_sync_bfly(acc[1], offset=offset),
+        )
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[1]
+
+
+class AMaxOps:
+    # acc = (max,). Pure single-field NaN-propagating max -- amax returns only the
+    # value, so it does NOT carry the index accumulator argmax needs. Keeping it
+    # 1-field (vs subclassing ArgMaxOps) halves the warp-shuffle / smem traffic and,
+    # because it is not has_index, lets the dispatcher take the cross-CTA fast path
+    # at huge N. NaN propagates: if either operand is NaN the result is NaN (matches
+    # torch.amax). Validates vs torch.amax(x, dim=-1).
+    nfields = 1
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    def init(self):
+        return (_neg_id(self.acc),)
+
+    @cute.jit
+    def _maxnan(self, a, b):
+        # NaN-propagating max: b if (b > a or b is NaN) else a. b != b detects NaN.
+        return b if ((b > a) or (b != b)) else a
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        m = self._maxnan(acc[0], val)
+        return (m if valid else acc[0],)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (self._maxnan(a[0], b[0]),)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[0]
+
+
+class AMinOps:
+    # acc = (min,). Pure single-field NaN-propagating min (the AMaxOps mirror).
+    # Validates vs torch.amin(x, dim=-1).
+    nfields = 1
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc,)
+
+    def init(self):
+        return (_pos_id(self.acc),)
+
+    @cute.jit
+    def _minnan(self, a, b):
+        return b if ((b < a) or (b != b)) else a
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        m = self._minnan(acc[0], val)
+        return (m if valid else acc[0],)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (self._minnan(a[0], b[0]),)
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (cute.arch.shuffle_sync_bfly(acc[0], offset=offset),)
+
+    @cute.jit
+    def project(self, acc, n):
+        return acc[0]
+
+
+def _offsets(threads_per_row):
+    # Decreasing butterfly offsets: matches the PyTorch/Triton fp reduction order.
+    n = min(threads_per_row, WARP)
+    offs = []
+    o = n // 2
+    while o > 0:
+        offs.append(o)
+        o = o // 2
+    return offs
+
+
+@cute.jit
+def warp_reduce(trait, acc, threads_per_row: cutlass.Constexpr):
+    for offset in _offsets(threads_per_row):
+        acc = trait.combine(acc, trait.shfl_down(acc, offset))
+    return acc
+
+
+@cute.jit
+def block_reduce(
+    trait,
+    acc,
+    bufs,
+    warps_per_row: cutlass.Constexpr,
+    rows_per_block: cutlass.Constexpr = 1,
+):
+    # Cross-warp reduction WITHIN each row's warp group. A block may hold
+    # rows_per_block rows, each spanning warps_per_row warps; warp w belongs to
+    # row (w // warps_per_row) at group position (w % warps_per_row). Each row
+    # reduces its own group independently -- mixing groups (the old flat version)
+    # corrupted multi-row blocks. Smem bufs are (rows_per_block, warps_per_row)
+    # per field; lane 0 of each warp writes its group slot, then the group's
+    # position-0 warp re-reduces its row's warps_per_row partials.
+    lane = cute.arch.lane_idx()
+    warp = cute.arch.warp_idx()
+    row_g = warp // warps_per_row
+    col_g = warp % warps_per_row
+    if lane == 0:
+        for f in cutlass.range_constexpr(trait.nfields):
+            bufs[f][row_g * const_expr(warps_per_row) + col_g] = acc[f]
+    cute.arch.barrier()
+    # Every warp re-loads its OWN row's group (so all lanes of all warps get the
+    # reduced value, matching the broadcast the row kernel's lane-0 store expects).
+    out = trait.init()
+    if lane < warps_per_row:
+        out = tuple(
+            bufs[f][row_g * const_expr(warps_per_row) + lane]
+            for f in range(trait.nfields)
+        )
+    out = warp_reduce(trait, out, warps_per_row)
+    return out
+
+
+@cute.jit
+def cluster_reduce(
+    trait,
+    acc,
+    bufs,
+    mbar_ptr,
+    cluster_n: cutlass.Constexpr,
+    warps_per_row: cutlass.Constexpr,
+    rows_per_block: cutlass.Constexpr,
+    phase=None,
+):
+    # Cross-CTA reduction over a launch cluster of cluster_n CTAs (each owns a
+    # distinct N/cluster_n column slice of the row). Trait-aware analogue of quack's
+    # scalar cluster_reduce (reduce.py:32): a SINGLE combined pass that folds BOTH
+    # the warps-per-row AND the cluster ranks, so it REPLACES block_reduce (do not
+    # block-reduce first). `acc` must be the WARP-reduced per-warp partial.
+    #
+    # bufs[f] is laid out (rows_per_block, (warps_per_row, cluster_n)); every warp
+    # writes its partial to slot (row_idx, (col_idx, cta_rank)) in each peer CTA, so
+    # after the barrier all warps_per_row*cluster_n partials for a row group are
+    # present and each thread folds them. The expected-tx byte count MUST match the
+    # exact set of stores issued (num_warps*cluster_n fields), or the barrier hangs.
+    from torch._vendor.quack import utils as _qu
+
+    lane = cute.arch.lane_idx()
+    warp = cute.arch.warp_idx()
+    # Linearized cluster rank; our cluster is [1, cluster_n, 1] so it is the y-rank.
+    cta_rank = cute.arch.block_idx_in_cluster()
+    row_idx = warp // const_expr(warps_per_row)
+    col_idx = warp % const_expr(warps_per_row)
+    nf = const_expr(trait.nfields)
+    num_warps = const_expr(rows_per_block * warps_per_row)
+
+    # One elected thread declares the total bytes ALL peers will deposit: every one
+    # of num_warps warps in each of cluster_n CTAs stores nf fields. Must equal the
+    # stores below exactly.
+    if warp == 0:
+        with cute.arch.elect_one():
+            nbytes = 0
+            for f in cutlass.range_constexpr(nf):
+                nbytes += num_warps * cluster_n * (trait.fdtypes[f].width // 8)
+            cute.arch.mbarrier_arrive_and_expect_tx(mbar_ptr, nbytes)
+
+    # Each warp's lanes 0..cluster_n-1 push this warp's partial to peer `lane`'s
+    # buffer at this warp's fixed slot (row_idx, (col_idx, cta_rank)).
+    if lane < cluster_n:
+        for f in cutlass.range_constexpr(nf):
+            ptr = _qu.elem_pointer(bufs[f], (row_idx, (col_idx, cta_rank)))
+            _qu.store_shared_remote(
+                trait.fdtypes[f](acc[f]), ptr, mbar_ptr, peer_cta_rank_in_cluster=lane
+            )
+    cute.arch.mbarrier_wait(mbar_ptr, phase if phase is not None else Int32(0))
+
+    # Fold all warps_per_row*cluster_n partials for this warp's row group.
+    merged = trait.init()
+    for c in cutlass.range_constexpr(warps_per_row):
+        for r in cutlass.range_constexpr(cluster_n):
+            part = tuple(bufs[f][(row_idx, (c, r))] for f in range(nf))
+            merged = trait.combine(merged, part)
+    return merged
+
+
+# --- Two-output traits (var_mean / std_mean, max.dim / min.dim, aminmax). They
+# reuse the single-output accumulators above and only change project() to return
+# a tuple of `nouts` values; nouts (1 or 2) tells the kernel how many outputs to
+# store. ---
+
+
+class VarMeanOps(WelfordOps):
+    # Reuse the validated Welford accumulator (mean, m2, nf); project BOTH the
+    # variance/std AND the mean. correction and take_sqrt behave as in the base.
+    # Validates vs torch.var_mean / torch.std_mean (dim=-1, correction).
+    nouts = 2
+
+    def __init__(self, correction=1, take_sqrt=False, acc=Float32):
+        super().__init__(correction=correction, take_sqrt=take_sqrt, acc=acc)
+
+    @cute.jit
+    def project(self, acc, n):
+        mean, m2, nf = acc
+        var = m2 / (nf - self.acc(self.correction))
+        result = cute.math.sqrt(var) if const_expr(self.take_sqrt) else var
+        return (result, mean)
+
+
+class MaxDimOps(ArgMaxOps):
+    # Reuse the GreaterOrNan winner logic (NaN propagates, lowest index on tie);
+    # project BOTH the winning value and its index. Validates vs torch.max(dim).
+    nouts = 2
+
+    @cute.jit
+    def project(self, acc, n):
+        return (acc[0], acc[1])
+
+
+class MinDimOps(ArgMinOps):
+    # LessOrNan winner; project (value, index). Validates vs torch.min(dim).
+    nouts = 2
+
+    @cute.jit
+    def project(self, acc, n):
+        return (acc[0], acc[1])
+
+
+class AMinMaxOps:
+    # acc = (min_val, max_val), both the accumulator dtype. reduce/combine track
+    # both extremes; project returns (min, max). NaN-propagating like torch.aminmax
+    # (any NaN in the row makes both outputs NaN). Validates vs torch.aminmax.
+    nfields = 2
+    nouts = 2
+
+    def __init__(self, acc=Float32):
+        self.acc = acc
+        self.fdtypes = (acc, acc)
+
+    def init(self):
+        return (_pos_id(self.acc), _neg_id(self.acc))
+
+    @cute.jit
+    def _fmin(self, a, b):
+        # NaN-propagating min: if either is NaN, result is NaN. Keep the explicit
+        # ternary -- in a @cute.jit body it lowers to a cute select over SSA
+        # scalars; Python's min()/max() (RUFF FURB136) would NOT lower the same way.
+        return (a if a != a else (a if a < b else b)) if b == b else b  # noqa: FURB136
+
+    @cute.jit
+    def _fmax(self, a, b):
+        return (a if a != a else (a if a > b else b)) if b == b else b  # noqa: FURB136
+
+    @cute.jit
+    def reduce(self, acc, val, idx, valid):
+        lo = self._fmin(acc[0], val)
+        hi = self._fmax(acc[1], val)
+        out_lo = lo if valid else acc[0]
+        out_hi = hi if valid else acc[1]
+        return (out_lo, out_hi)
+
+    @cute.jit
+    def combine(self, a, b):
+        return (self._fmin(a[0], b[0]), self._fmax(a[1], b[1]))
+
+    @cute.jit
+    def shfl_down(self, acc, offset):
+        return (
+            cute.arch.shuffle_sync_bfly(acc[0], offset=offset),
+            cute.arch.shuffle_sync_bfly(acc[1], offset=offset),
+        )
+
+    @cute.jit
+    def project(self, acc, n):
+        return (acc[0], acc[1])

--- a/torch/_native/ops/pointwise/__init__.py
+++ b/torch/_native/ops/pointwise/__init__.py
@@ -1,0 +1,7 @@
+# CuTeDSL native pointwise (elementwise) op overrides. Importing this package
+# registers the aten pointwise overrides with the _native registry.
+
+from .overrides import register_pointwise_overrides
+
+
+register_pointwise_overrides()

--- a/torch/_native/ops/pointwise/kernel.py
+++ b/torch/_native/ops/pointwise/kernel.py
@@ -1,0 +1,207 @@
+# Generic elementwise (pointwise) CuteDSL kernels.
+#
+# One op-agnostic kernel family serves every row of the pointwise definition table.
+# Each thread applies the row's @cute.jit `fn` (with baked scalar consts) to inputs
+# converted to the compute dtype, storing each output cast to its out dtype. No
+# cross-thread communication.
+#
+# TWO paths, chosen host-side:
+#   FAST (run_vec): all operands contiguous, identical shape, numel % V == 0. The
+#     arrays coalesce to a flat (numel/V, V) layout; each thread vector-loads a
+#     V-wide fragment (V*dtype = 128 bits -> wide global load), computes, stores.
+#     This is the bandwidth path and hits ~parity with aten.
+#   GENERAL (run_strided): anything else (broadcast / transposed / strided / ragged
+#     numel). Operands are expanded to the broadcast shape and wrapped via
+#     from_dlpack, which carries each operand's real layout (broadcast dims are
+#     stride-0); the kernel indexes linearly and CuTe decodes the offset. Correct
+#     for all cases, not vectorized.
+#
+# Addressing is canonical CuTe in both paths -- no hand-rolled offset math.
+
+import math
+from typing import NamedTuple
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import const_expr
+
+import torch
+
+from .._cutedsl import launch as _L
+from .._cutedsl.plan_cache import cached_plan
+
+
+_BLOCK = 256
+_PLAN = {}  # key -> _Plan (compiled kernel + shape-invariant launch decisions)
+
+
+def _vec_width(compute_bits: int) -> int:
+    # Elements per 128-bit vector for the compute dtype (fp32->4, fp16/bf16->8,
+    # fp64->2). The fast path requires numel divisible by this.
+    return max(128 // compute_bits, 1)
+
+
+class _ElementwiseVec:
+    # Vectorized flat path. Operands are (nvec, V) cute tensors; each thread owns one
+    # V-wide row. fn/consts/compute/out_types as in the strided op.
+    def __init__(self, fn, nin, nout, consts, compute, out_types, V):
+        self.fn = fn
+        self.nin = nin
+        self.nout = nout
+        self.consts = consts
+        self.compute = compute
+        self.out_types = out_types
+        self.V = V
+
+    @cute.jit
+    def __call__(self, mIns: list, mOuts: list, stream: cuda.CUstream):
+        nvec = mOuts[0].shape[0]
+        self.kernel(mIns, mOuts, nvec).launch(
+            grid=[cute.ceil_div(nvec, _BLOCK), 1, 1],
+            block=[_BLOCK, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(self, mIns: list, mOuts: list, nvec: cutlass.Int32):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        i = bidx * _BLOCK + tidx
+        if i < nvec:
+            V = const_expr(self.V)
+            # Wide vector load of each input's V-element row into registers.
+            regs = []
+            for k in cutlass.range_constexpr(self.nin):
+                g = mIns[k][i, None]
+                r = cute.make_rmem_tensor_like(g)
+                cute.autovec_copy(g, r)
+                regs.append(r)
+            outs = [
+                cute.make_rmem_tensor_like(mOuts[j][i, None]) for j in range(self.nout)
+            ]
+            # Per-element compute over the fragment.
+            for e in cutlass.range_constexpr(V):
+                vals = tuple(
+                    self.compute(regs[k][e]) for k in range(const_expr(self.nin))
+                )
+                res = self.fn(*vals, *self.consts)
+                if const_expr(self.nout == 1):
+                    outs[0][e] = self.out_types[0](res)
+                else:
+                    for j in cutlass.range_constexpr(self.nout):
+                        outs[j][e] = self.out_types[j](res[j])
+            for j in cutlass.range_constexpr(self.nout):
+                cute.autovec_copy(outs[j], mOuts[j][i, None])
+
+
+class _ElementwiseStrided:
+    # General path: one thread per output element, linear index into each operand's
+    # (possibly broadcast / strided) layout -- CuTe decodes the offset.
+    def __init__(self, fn, nin, nout, consts, compute, out_types):
+        self.fn = fn
+        self.nin = nin
+        self.nout = nout
+        self.consts = consts
+        self.compute = compute
+        self.out_types = out_types
+
+    @cute.jit
+    def __call__(self, mIns: list, mOuts: list, stream: cuda.CUstream):
+        n = cute.size(mOuts[0])
+        self.kernel(mIns, mOuts, n).launch(
+            grid=[cute.ceil_div(n, _BLOCK), 1, 1], block=[_BLOCK, 1, 1], stream=stream
+        )
+
+    @cute.kernel
+    def kernel(self, mIns: list, mOuts: list, n: cutlass.Int32):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        i = bidx * _BLOCK + tidx
+        if i < n:
+            vals = tuple(self.compute(mIns[k][i]) for k in range(const_expr(self.nin)))
+            outs = self.fn(*vals, *self.consts)
+            if const_expr(self.nout == 1):
+                mOuts[0][i] = self.out_types[0](outs)
+            else:
+                for j in cutlass.range_constexpr(self.nout):
+                    mOuts[j][i] = self.out_types[j](outs[j])
+
+
+def _vec_ok(inputs, shape, out_dtypes, compute_torch, V):
+    # Fast path requires: every input already has the output shape (no broadcast),
+    # is contiguous, 16-byte aligned (the (numel/V, V) wrap asserts
+    # assumed_align=16 and from_dlpack RAISES on a misaligned base -- e.g. a
+    # sliced view from diff/istft decompositions; those must take the strided
+    # path), the element count is a multiple of V, AND every output dtype
+    # equals the compute dtype. The last rules out bool (gt) and mixed
+    # (frexp -> int32) outputs, whose narrow / non-compute element widths
+    # can't take the wide vector copy. Those go general.
+    if any(d != compute_torch for d in out_dtypes):
+        return False
+    numel = math.prod(shape)
+    if numel == 0 or numel % V != 0:
+        return False
+    return all(
+        tuple(t.shape) == tuple(shape)
+        and t.is_contiguous()
+        and (t.storage_offset() * t.element_size()) % 16 == 0
+        for t in inputs
+    )
+
+
+class _Plan(NamedTuple):
+    path: str  # "vec" | "strided"
+    shape: tuple  # broadcast output shape
+    V: int  # vector width (vec path)
+    out_dtypes: tuple  # per-output torch dtype (its length is the output count)
+    fn: object  # the compiled kernel
+
+
+def _build_plan(fn, nin, nout, consts, compute, compute_torch, inputs, out_dtypes):
+    # ALL shape-invariant work for this operand signature: broadcast shape, path
+    # selection, op construction, and the kernel compile (against the live tensors as
+    # seeds -- their layout matches every later call with this key). Run once per
+    # key; the result is memoized so repeat calls only alloc + wrap + launch.
+    shape = tuple(torch.broadcast_shapes(*(t.shape for t in inputs)))
+    out_types = [_L.torch2cute[d] for d in out_dtypes]
+    V = _vec_width(compute.width)
+    dev = inputs[0].device
+    seed_outs = [torch.empty(shape, device=dev, dtype=d) for d in out_dtypes]
+    if _vec_ok(inputs, shape, out_dtypes, compute_torch, V):
+        op = _ElementwiseVec(fn, nin, nout, consts, compute, out_types, V)
+        cin = [_L.cute_tensor_vec(t, V, read_only=True) for t in inputs]
+        cout = [_L.cute_tensor_vec(o, V) for o in seed_outs]
+        path = "vec"
+    else:
+        op = _ElementwiseStrided(fn, nin, nout, consts, compute, out_types)
+        cin = [_L.cute_tensor(t.expand(shape), read_only=True) for t in inputs]
+        cout = [_L.cute_tensor(o) for o in seed_outs]
+        path = "strided"
+    compiled = _L.compile(op, cin, cout, _L.stream())
+    return _Plan(path, shape, V, tuple(out_dtypes), compiled)
+
+
+def run(fn, key, nin, nout, consts, compute, compute_torch, inputs, out_dtypes):
+    # inputs: torch tensors (any broadcastable shapes / strides). Returns nout torch
+    # tensors of the broadcast shape. The plan (path / shape / compiled kernel) is
+    # memoized per `key`; a cache hit does only the irreducible per-call work --
+    # allocate outputs, wrap the live operands, launch.
+    plan = cached_plan(
+        _PLAN,
+        key,
+        lambda: _build_plan(
+            fn, nin, nout, consts, compute, compute_torch, inputs, out_dtypes
+        ),
+    )
+    dev = inputs[0].device
+    outs = [torch.empty(plan.shape, device=dev, dtype=d) for d in plan.out_dtypes]
+    if plan.path == "vec":
+        cin = [_L.cute_tensor_vec(t, plan.V, read_only=True) for t in inputs]
+        cout = [_L.cute_tensor_vec(o, plan.V) for o in outs]
+    else:
+        cin = [_L.cute_tensor(t.expand(plan.shape), read_only=True) for t in inputs]
+        cout = [_L.cute_tensor(o) for o in outs]
+    plan.fn(cin, cout, _L.stream())
+    return tuple(outs)

--- a/torch/_native/ops/pointwise/ops.py
+++ b/torch/_native/ops/pointwise/ops.py
@@ -1,0 +1,278 @@
+# The @cute.jit kernel functions referenced by the pointwise op table (see table.py,
+# which is cutlass-free and holds the declarative rows). Each function is plain
+# @cute.jit math over COMPUTE-dtype scalars:
+#   fn(*input_vals, *scalar_consts) -> result | tuple-of-results
+# Inputs arrive already converted to the compute dtype; baked scalar args (e.g. add's
+# `alpha`) follow, as compute-dtype constants. The result is cast to the op's output
+# dtype. A function references only DSL ops (operators, cute.math.*), never a
+# user-class method (which would trip the IR flattener).
+#
+# This module imports `cutlass` (the @cute.jit decorator), so it must NOT be imported
+# at `import torch` time -- overrides.py resolves a row's function lazily via get_fn()
+# on the first real (non-declined) call. table.py carries the registration metadata.
+
+from __future__ import annotations
+
+import cutlass.cute as cute
+
+
+# ---- op math (module-level named functions; reused/composed freely) ----
+
+
+@cute.jit
+def _neg(x):
+    return -x
+
+
+@cute.jit
+def _add(x, y, alpha):
+    return x + alpha * y
+
+
+@cute.jit
+def _mul(x, y):
+    return x * y
+
+
+@cute.jit
+def _sub(x, y, alpha):
+    return x - alpha * y
+
+
+@cute.jit
+def _div(x, y):
+    return x / y
+
+
+@cute.jit
+def _maximum(x, y):
+    # NaN-PROPAGATING max (matches torch.maximum, NOT fmax which suppresses): take y
+    # when it is larger OR is NaN (y != y detects NaN), so a NaN in either operand
+    # propagates. Same form as the reduction AMaxOps._maxnan. (Planned: Blackwell
+    # PTX min/max with the NaN-propagating mode, later.)
+    return y if ((y > x) or (y != y)) else x
+
+
+@cute.jit
+def _minimum(x, y):
+    return y if ((y < x) or (y != y)) else x
+
+
+# ---- unary math (INT_TO_FLOAT promotion) ----
+
+
+@cute.jit
+def _exp(x):
+    return cute.math.exp(x)
+
+
+@cute.jit
+def _exp2(x):
+    return cute.math.exp2(x)
+
+
+@cute.jit
+def _expm1(x):
+    return cute.math.exp(x) - x.__class__(1.0)
+
+
+@cute.jit
+def _log(x):
+    return cute.math.log(x)
+
+
+@cute.jit
+def _log2(x):
+    return cute.math.log2(x)
+
+
+@cute.jit
+def _log10(x):
+    return cute.math.log10(x)
+
+
+@cute.jit
+def _log1p(x):
+    return cute.math.log(x + x.__class__(1.0))
+
+
+@cute.jit
+def _sqrt(x):
+    return cute.math.sqrt(x)
+
+
+@cute.jit
+def _rsqrt(x):
+    return cute.math.rsqrt(x)
+
+
+@cute.jit
+def _reciprocal(x):
+    return x.__class__(1.0) / x
+
+
+@cute.jit
+def _sin(x):
+    return cute.math.sin(x)
+
+
+@cute.jit
+def _cos(x):
+    return cute.math.cos(x)
+
+
+@cute.jit
+def _tan(x):
+    return cute.math.tan(x)
+
+
+@cute.jit
+def _asin(x):
+    return cute.math.asin(x)
+
+
+@cute.jit
+def _acos(x):
+    return cute.math.acos(x)
+
+
+@cute.jit
+def _atan(x):
+    return cute.math.atan(x)
+
+
+@cute.jit
+def _atan2(x, y):
+    return cute.math.atan2(x, y)
+
+
+@cute.jit
+def _tanh(x):
+    return cute.math.tanh(x)
+
+
+@cute.jit
+def _erf(x):
+    return cute.math.erf(x)
+
+
+@cute.jit
+def _sigmoid(x):
+    one = x.__class__(1.0)
+    return one / (one + cute.math.exp(-x))
+
+
+# ---- rounding / sign (DEFAULT promotion; output dtype follows input) ----
+
+
+@cute.jit
+def _floor(x):
+    return cute.math.floor(x)
+
+
+@cute.jit
+def _ceil(x):
+    return -cute.math.floor(-x)
+
+
+@cute.jit
+def _trunc(x):
+    # toward-zero rounding: floor for x>=0, ceil(-floor(-x)) for x<0. (Avoid chaining
+    # cute.math.absf into floor -- absf yields an ArithValue that floor rejects.)
+    z = x.__class__(0.0)
+    return cute.math.floor(x) if x >= z else -cute.math.floor(-x)
+
+
+@cute.jit
+def _sign(x):
+    z = x.__class__(0.0)
+    return x.__class__(1.0) if x > z else (x.__class__(-1.0) if x < z else z)
+
+
+@cute.jit
+def _relu(x):
+    # NB: builtin max() does not lower in the DSL -- keep the explicit select.
+    z = x.__class__(0.0)
+    return x if x > z else z  # noqa: FURB136
+
+
+# ---- comparisons (ALWAYS_BOOL) ----
+
+
+@cute.jit
+def _gt(x, y):
+    return x > y
+
+
+@cute.jit
+def _lt(x, y):
+    return x < y
+
+
+@cute.jit
+def _ge(x, y):
+    return x >= y
+
+
+@cute.jit
+def _le(x, y):
+    return x <= y
+
+
+@cute.jit
+def _eq(x, y):
+    return x == y
+
+
+@cute.jit
+def _ne(x, y):
+    return x != y
+
+
+@cute.jit
+def _addcmul(x, t1, t2, value):
+    # nin=3, scalar `value`: out = self + value * t1 * t2.
+    return x + value * t1 * t2
+
+
+@cute.jit
+def _frexp(x):
+    # nout=2: (mantissa, exponent) with x == mantissa * 2**exponent, |mantissa| in
+    # [0.5, 1). DSL has no frexp primitive; derive from log2|x|. We need log2 of the
+    # MAGNITUDE, but every way of forming |x| with a single value (cute.math.absf, a
+    # ternary select, copysign) yields an ArithValue that log2 rejects -- only pure
+    # arithmetic on the value stays a Numeric. So compute log2(x) and log2(-x)
+    # separately (each argument is a plain negation, still Numeric) and select the
+    # RESULT by sign. e = floor(log2|x|)+1, m = x * 2**(-e); the exponent is projected
+    # as Float and cast to int32 at the store (the row's out dtype). Constants use
+    # x.__class__ so all ifexp branches share x's dtype (a bare Float32 literal breaks
+    # fp64). NB: do NOT use log2(x*x)*0.5 -- x*x overflows to inf for large |x|
+    # (fp16 above ~256) and corrupts the exponent.
+    #
+    # Only finite, nonzero x take the log2 path: zero would give log2(0) = -inf, and
+    # inf/nan must pass through as (x, 0) to match aten (frexp(inf) = (inf, 0)). A
+    # value is finite-and-nonzero iff (x - x == 0) -- false (nan) for inf/nan -- AND
+    # x != 0.
+    #
+    # NOTE: exact for fp16/bf16/fp32 but NOT fp64 -- at exact powers of two the fp64
+    # log2 lands just under the integer boundary and floor() picks the wrong exponent.
+    # A correct fp64 frexp needs IEEE exponent-field bit extraction (Float64.bitcast);
+    # deferred -> the row restricts dtypes to exclude fp64.
+    flt = x.__class__
+    zero = flt(0.0)
+    use_log2 = (x - x == zero) and (x != zero)
+    log2_abs = cute.math.log2(x) if x > zero else cute.math.log2(-x)
+    e = cute.math.floor(log2_abs) + flt(1.0)
+    e = e if use_log2 else zero
+    m = x * cute.math.exp2(-e) if use_log2 else x
+    return (m, e)
+
+
+# ---- lazy fn resolver (table.py rows reference these by name) ----
+
+
+def get_fn(name: str):
+    # Resolve a table row's `fn` name to the @cute.jit callable defined above. Called
+    # from overrides.py's impl on the first real dispatch, so importing this module
+    # (and thus cutlass) is deferred off the `import torch` / registration path.
+    return globals()[name]

--- a/torch/_native/ops/pointwise/overrides.py
+++ b/torch/_native/ops/pointwise/overrides.py
@@ -1,0 +1,160 @@
+# Generic registration of the pointwise definition table as aten CUDA overrides. Each row -> a
+# (cond, impl) pair; the impl picks compute/output dtypes via aten's elementwise type
+# promotion, bakes the row's scalar args as compute-dtype constants, and runs the one
+# generic elementwise kernel. No per-op code beyond the table row.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from torch._prims_common import elementwise_dtypes
+
+from ... import cutedsl_utils as cu
+from ...utils import capability as cap
+from ...utils.lazy import LazyModule
+from .table import POINTWISE_DEF_TABLE, PointwiseDef
+
+
+# The launch glue (_L), kernel runner (K), and op-math module (ops) all import
+# `cutlass`, which `import torch` must not do (the lazy-DSL-import contract; see
+# test_no_dsl_imports_after_import_torch). None is touched by a `cond` or by
+# registration -- only by the `*_impl` closures on a real (non-declined) call, where
+# the DSL runtime is present. table.py (imported above) is cutlass-free and carries
+# the registration metadata; a row's `fn` is a NAME resolved via ops.get_fn() at call
+# time. Bind the cutlass-laden modules as lazy proxies so their imports fire then.
+if TYPE_CHECKING:
+    from .._cutedsl import launch as _L
+    from . import kernel as K, ops
+else:
+    _L = LazyModule("torch._native.ops._cutedsl.launch")
+    K = LazyModule("torch._native.ops.pointwise.kernel")
+    ops = LazyModule("torch._native.ops.pointwise.ops")
+
+
+_SUPPORTED = (torch.float16, torch.bfloat16, torch.float32, torch.float64)
+
+
+def _supported(t, dtypes) -> bool:
+    # COW is not gated: inputs export read-only (launch._ro / ReadOnlyTensorWrapper),
+    # so a COW input flows through the kernel without materializing.
+    return (
+        isinstance(t, torch.Tensor)
+        and t.dtype in dtypes
+        and t.is_contiguous()
+        and t.numel() > 0
+        and not cap.is_traced(t)
+    )
+
+
+def _scalars(row: PointwiseDef, args, kwargs):
+    # Resolve the row's named scalar args, which the caller may pass either
+    # positionally (after the nin tensors) or by keyword (e.g. torch.add(x, y,
+    # alpha=2)). Missing -> the aten default (1 for add's alpha; the only scalar
+    # default in the current table). Returns a tuple in row.scalars order.
+    pos = args[row.nin :]
+    out = []
+    for i, name in enumerate(row.scalars):
+        if name in kwargs:
+            out.append(kwargs[name])
+        elif i < len(pos):
+            out.append(pos[i])
+        else:
+            out.append(1)
+    return tuple(out)
+
+
+def _make_cond(row: PointwiseDef):
+    # The first `nin` args are always the positional tensor operands; serve only
+    # when all are supported (row.dtypes or the family default), contiguous, on the
+    # current device, and same-shape (no broadcast yet). Scalar args do not gate.
+    dtypes = row.dtypes or _SUPPORTED
+
+    def cond(*args, **kwargs):
+        ins = args[: row.nin]
+        if len(ins) < row.nin or not all(_supported(t, dtypes) for t in ins):
+            return False
+        if not (cap.device_ok(ins[0]) and cap.on_current_device(ins[0])):
+            return False
+        # A complex scalar arg (e.g. add's alpha) on real inputs is invalid for our
+        # real-dtype kernels -- decline so aten raises its "argument alpha must not be
+        # a complex number" error rather than us choking on the const bake.
+        if any(isinstance(s, complex) for s in _scalars(row, args, kwargs)):
+            return False
+        # Every operand must share ins[0]'s shape (no broadcast yet) AND its device:
+        # a CPU / other-device operand in a later slot would otherwise launch into the
+        # CUDA kernel (illegal access). Declining lets aten raise its cross-device
+        # error (or coerce a 0-d CPU scalar) instead.
+        return all(
+            t.shape == ins[0].shape and t.device == ins[0].device for t in ins[1:]
+        )
+
+    return cond
+
+
+def _make_impl(row: PointwiseDef):
+    # Promotion (compute / output dtypes) is a pure function of the input dtypes and
+    # the row's fixed promotion kind -- NOT the shapes -- so memoize it per input-
+    # dtype tuple. This keeps elementwise_dtypes (a non-trivial Python helper, ~4us)
+    # off the hot path; the only per-call promotion work is then a dict lookup.
+    promo_cache: dict = {}
+
+    def _promo(in_dtypes):
+        got = promo_cache.get(in_dtypes)
+        if got is None:
+            # elementwise_dtypes takes tensors/numbers; 0-d tensors of the dtype are
+            # representative for the (tensor-only) promotion of our overrides.
+            probes = [torch.empty(0, dtype=d, device="cuda") for d in in_dtypes]
+            compute, out_dtype = elementwise_dtypes(
+                *probes, type_promotion_kind=row.promotion
+            )
+            ct = _L.torch2cute[compute]
+            out_dtypes = (
+                row.out_dtypes(out_dtype) if row.out_dtypes else [out_dtype] * row.nout
+            )
+            got = (ct, compute, tuple(out_dtypes))
+            promo_cache[in_dtypes] = got
+        return got
+
+    def impl(*args, **kwargs):
+        ins = list(args[: row.nin])
+        scalars = _scalars(row, args, kwargs)
+        in_dtypes = tuple(t.dtype for t in ins)
+        ct, compute, out_dtypes = _promo(in_dtypes)
+        consts = tuple(ct(s) for s in scalars)
+        # The operand LAYOUTS (per-operand shape + stride) are baked into the
+        # compiled kernel, so they must be in the cache key -- distinct shapes /
+        # broadcast patterns compile distinct kernels.
+        # Alignment is in the key because it picks the PATH (vec wraps
+        # assert 16B alignment and raise on sliced views); two calls
+        # with identical shapes/strides but different storage offsets
+        # must not share a plan. storage_offset, not data_ptr(): the
+        # latter materializes COW inputs.
+        key = (
+            row.aten,
+            in_dtypes,
+            tuple((t.shape, t.stride()) for t in ins),
+            tuple((t.storage_offset() * t.element_size()) % 16 == 0 for t in ins),
+            scalars,
+        )
+        outs = K.run(
+            ops.get_fn(row.fn),
+            key,
+            row.nin,
+            row.nout,
+            consts,
+            ct,
+            compute,
+            ins,
+            out_dtypes,
+        )
+        return outs[0] if row.nout == 1 else outs
+
+    return impl
+
+
+def register_pointwise_overrides() -> None:
+    for row in POINTWISE_DEF_TABLE:
+        cu.register_op_override(
+            "aten", row.aten, "CUDA", cond=_make_cond(row), impl=_make_impl(row)
+        )

--- a/torch/_native/ops/pointwise/table.py
+++ b/torch/_native/ops/pointwise/table.py
@@ -1,0 +1,75 @@
+# The pointwise op definition table (POINTWISE_DEF_TABLE): one PointwiseDef row per
+# aten elementwise op. Each row is fully declarative -- the generic registration
+# machinery (overrides.py) turns it into a (cond, impl) override, so adding an op is
+# one row plus its kernel function in ops.py, not a hand-written override.
+#
+# This module is deliberately cutlass-FREE: it holds only the metadata registration
+# needs (aten name, arity, promotion kind, scalar args, output-dtype policy) so that
+# `import torch` -> override registration can read the table without pulling in the
+# DSL runtime (the lazy-DSL-import contract; see test_no_dsl_imports_after_import_torch).
+# The actual kernel math lives in ops.py, where every `fn` is a @cute.jit function;
+# a row references it BY NAME (`fn`, a str) and overrides.py resolves the callable
+# lazily via ops.get_fn(name) on the first real (non-declined) call.
+#
+# The named ops.py function is @cute.jit-able over COMPUTE-dtype scalars:
+#   fn(*input_vals, *scalar_consts) -> result | tuple-of-results
+# Inputs arrive already converted to the compute dtype; baked scalar args (e.g. add's
+# `alpha`) follow, as compute-dtype constants. The result is cast to the op's output
+# dtype. `fn` references only DSL ops (operators, cute.math.*), never a user-class
+# method (which would trip the IR flattener).
+
+from __future__ import annotations
+
+from typing import NamedTuple, TYPE_CHECKING
+
+import torch
+from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND as PromotionKind
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class PointwiseDef(NamedTuple):
+    aten: str  # aten op symbol incl overload, e.g. "add.Tensor", "neg"
+    nin: int  # number of tensor inputs
+    fn: str  # name of the @cute.jit kernel function in ops.py (resolved lazily)
+    # aten elementwise type-promotion kind (single value, not combinable: a closed
+    # Enum keying torch's elementwise_dtypes algorithm, not a bitwise Flag).
+    promotion: PromotionKind = PromotionKind.DEFAULT
+    scalars: tuple[str, ...] = ()  # positional arg names baked as compute consts
+    nout: int = 1  # number of outputs (>1: e.g. frexp)
+    # ESCAPE HATCH for ops whose output dtypes are NOT all the promotion result
+    # (e.g. frexp -> (float mantissa, int32 exponent)). Maps the promotion result
+    # torch dtype -> list[torch dtype] of length nout. None -> every output uses the
+    # promotion result dtype (the common case).
+    out_dtypes: Callable | None = None
+    # Restrict the INPUT dtypes this override serves; inputs outside the set fall
+    # back to aten. None -> the family default (all supported floats). Use to narrow
+    # an op whose kernel is only correct for some dtypes (e.g. frexp excludes fp64).
+    dtypes: tuple | None = None
+
+
+# Row data lives in _table_data.py as torch-free tuples (the AOT
+# declaration factory reads it at torchgen time, where torch is not
+# importable -- see PAIN_POINTS P13); this module rebuilds the typed
+# rows with the real PromotionKind and callable escape hatches.
+from ._table_data import PW_ROWS
+
+
+_OUT_DTYPES = {"frexp": lambda compute: [compute, torch.int32]}
+_DTYPE_SETS = {"no_fp64": (torch.float16, torch.bfloat16, torch.float32)}
+
+POINTWISE_DEF_TABLE: tuple[PointwiseDef, ...] = tuple(
+    PointwiseDef(
+        aten,
+        nin,
+        fn,
+        promotion=PromotionKind[promotion],
+        scalars=scalars,
+        nout=nout,
+        out_dtypes=_OUT_DTYPES.get(out_tag),
+        dtypes=_DTYPE_SETS.get(dt_tag),
+    )
+    for (aten, nin, fn, promotion, scalars, nout, out_tag, dt_tag) in PW_ROWS
+)

--- a/torch/_native/ops/reductions/__init__.py
+++ b/torch/_native/ops/reductions/__init__.py
@@ -1,0 +1,24 @@
+# CuTeDSL native reduction kernels + dispatcher.
+#
+# Kernels (all built on .._cutedsl traits + launch glue):
+#   kernel_general - K0: TensorIterator-driven general kernel, any geometry (row,
+#                    column, n-D, transposed, reduce-all); the correctness floor +
+#                    the _reduce/_try_fast_row dispatcher that routes to the fast paths.
+#   kernel_row     - K1: vectorized one-shot row reduction (contiguous last dim,
+#                    smem-fits), dynamic-M.
+#   kernel_col     - K2: vectorized column reduction (reduce dim 0) with an M-split.
+#   kernel_xcta    - fused two-stage cross-CTA row reduction for few-row / huge-N
+#                    and reduce-all.
+#
+# Importing this package registers the aten reduction overrides (sum / mean / ...)
+# with the _native registry via register_reduction_overrides(); the registry
+# installs them at its _register_all_overrides() step. Each override is gated by a
+# capability `cond` and falls back to aten when it does not apply.
+
+# The kernel modules import `cutlass`, so they are NOT imported here -- that
+# would pull the DSL runtime into `import torch` (the lazy-DSL-import contract;
+# see test_no_dsl_imports_after_import_torch). overrides.py binds them lazily.
+from .overrides import register_reduction_overrides
+
+
+register_reduction_overrides()

--- a/torch/_native/ops/reductions/kernel_col.py
+++ b/torch/_native/ops/reductions/kernel_col.py
@@ -1,0 +1,378 @@
+# Vectorized COLUMN reduction (reduce dim 0 of (M, N) -> (N,)). The "outer" /
+# K2 geometry: the KEPT axis (columns, N) is contiguous, so adjacent threads own
+# adjacent columns and gmem loads coalesce for free. Each thread carries `vec`
+# INDEPENDENT accumulators (one per column in its 128-bit vector) and folds DOWN
+# the M rows -- "vectorize along output". No cross-thread reduce along the reduced
+# axis when one thread owns a column fully; when M is tiled across thread-rows
+# (block.y), the per-column partials combine via smem along y only.
+#
+# Contrast K1 (inner/row): there a warp COOPERATES on one output via shuffle. Here
+# threads are INDEPENDENT across columns -- the dual. This is why K0's scalar-load
+# column path was ~0.2x ATen: it never vectorized the contiguous column axis.
+#
+# M-SPLIT (mirrors ATen setReduceConfig ctas_per_output for OUTER reductions):
+# parallelizing only over columns (grid.x) underfills the device when N is small
+# (few columns -> few blocks -> e.g. (65536,1024) gave grid.x=4 blocks on 148
+# SMs). So when columns alone don't fill the grid we ALSO split the reduced M axis
+# across grid.y CTA-rows: block (bx, by) reduces a disjoint row-stripe of its
+# columns into a raw partial, then a cheap stage-2 column reduction combines the
+# grid_y partials per column and projects once with the TRUE M. grid_y==1 keeps
+# the original single-launch path. This is the dual of reduce_xcta's row split.
+#
+# Trait protocol reused from reduce_traits; the per-column fold is the trait's
+# reduce/combine on a tuple accumulator, one tuple PER column-in-vector.
+
+import math
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import const_expr, Float32, Float64, Int32
+
+import torch
+
+from .._cutedsl import hw_caps as _hw, launch as _L
+from .._cutedsl.plan_cache import cached_plan
+
+
+_cute = _L.cute_tensor
+_compile = _L.compile  # cute.compile + options="--enable-tvm-ffi"
+_stream = _L.stream
+_PART_TORCH = {Float32: torch.float32, Float64: torch.float64, Int32: torch.int32}
+
+# Threads along the column (kept) axis per block. The dispatcher in kernel_general
+# uses this to size grid_x when deciding the K2 column path, so it must match the
+# block_x the kernel actually launches with -- keep them tied to this constant.
+_DEFAULT_BLOCK_X = 64
+_DEFAULT_BLOCK_Y = 8
+
+
+class ColReduce:
+    # Grid (ceil(N / (block_x*vec)), grid_y). Block = (block_x, block_y). Thread
+    # (tx, ty) in CTA-row `by` owns columns [col0, col0+vec) where
+    # col0 = (bx*block_x + tx)*vec, and folds the row-stripe by*block_y+ty,
+    # +grid_y*block_y, ... down `rows`. The block_y partials combine via smem; the
+    # grid_y CTA-row partials combine in stage 2 (from_partials).
+    #
+    # final=True  -> project (with true_m) and write one result per column.
+    # final=False -> write RAW per-field accumulators to nfields (grid_y, N) gmem
+    #                partial buffers (stage 1 of the M-split).
+    # from_partials=True -> ingest COMBINES nfields pre-reduced partial buffers
+    #                instead of REDUCing raw input (stage 2 of the M-split).
+    def __init__(
+        self,
+        trait,
+        rows,
+        N,
+        vec,
+        true_m,
+        grid_y=1,
+        final=True,
+        from_partials=False,
+        block_x=_DEFAULT_BLOCK_X,
+        block_y=_DEFAULT_BLOCK_Y,
+    ):
+        self.trait = trait
+        self.rows = rows  # rows of THIS stage's input
+        self.N = N
+        self.vec = vec
+        self.true_m = true_m  # original M, the projection divisor
+        self.grid_y = grid_y  # CTA-rows splitting the reduced axis
+        self.final = final
+        self.from_partials = from_partials
+        self.block_x = block_x
+        self.block_y = block_y
+        self.cols_per_block = block_x * vec
+        self.grid_x = (N + self.cols_per_block - 1) // self.cols_per_block
+
+    @cute.jit
+    def __call__(self, mIns: list, mOuts: list, stream: cuda.CUstream):
+        self.kernel(mIns, mOuts).launch(
+            grid=[self.grid_x, self.grid_y, 1],
+            block=[self.block_x, self.block_y, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(self, mIns: list, mOuts: list):
+        trait = self.trait
+        tx, ty, _ = cute.arch.thread_idx()
+        bx, by, _ = cute.arch.block_idx()
+        rows = const_expr(self.rows)
+        N = const_expr(self.N)
+        vec = const_expr(self.vec)
+        by_n = const_expr(self.block_y)
+        nf = const_expr(trait.nfields)
+        acc_dtype = trait.acc  # accumulator dtype (a compile-time Python class)
+
+        col0 = (bx * const_expr(self.block_x) + tx) * vec
+        accs = [trait.init() for _ in range(vec)]
+        # Global thread-row partition: CTA-row `by` thread-row `ty` starts at
+        # by*block_y+ty and strides by the TOTAL thread-rows grid_y*block_y, so
+        # the grid_y CTA-rows tile `rows` disjointly. row_stride collapses to
+        # block_y when grid_y==1 (the single-launch path).
+        row_stride = const_expr(self.grid_y * self.block_y)
+        gty0 = by * by_n + ty
+        n_full = const_expr(rows // row_stride)
+
+        if const_expr(not self.from_partials):
+            reduce_fn = trait.reduce
+            mX = mIns[0]
+            frag = cute.make_rmem_tensor(cute.make_layout(vec), mX.element_type)
+            rr = gty0
+            for _ in cutlass.range(n_full):
+                # Int64 row base: rr*N overflows int32 when rows*N >= 2^31 (large
+                # column reductions) -> negative wrap -> illegal access. Cast rr.
+                cute.autovec_copy(_row_vec(mX, cutlass.Int64(rr) * N + col0, vec), frag)
+                xf = frag.load().to(acc_dtype)
+                for v in cutlass.range_constexpr(vec):
+                    accs[v] = reduce_fn(accs[v], xf[v], rr, col0 + v < N)
+                rr = rr + row_stride
+            if const_expr(rows % row_stride != 0):
+                ok = rr < rows
+                cute.autovec_copy(
+                    _row_vec(mX, cutlass.Int64(rr if ok else Int32(0)) * N + col0, vec),
+                    frag,
+                )
+                xf = frag.load().to(acc_dtype)
+                for v in cutlass.range_constexpr(vec):
+                    accs[v] = reduce_fn(accs[v], xf[v], rr, ok and (col0 + v < N))
+        else:
+            # Combine pre-reduced partials: nfields buffers, each (rows, N).
+            combine_fn = trait.combine
+            frags = [
+                cute.make_rmem_tensor(cute.make_layout(vec), mIns[f].element_type)
+                for f in range(nf)
+            ]
+            rr = gty0
+            for _ in cutlass.range(n_full):
+                rb64 = (
+                    cutlass.Int64(rr) * N + col0
+                )  # Int64 base (rows*N may exceed 2^31)
+                for f in cutlass.range_constexpr(nf):
+                    cute.autovec_copy(_row_vec(mIns[f], rb64, vec), frags[f])
+                for v in cutlass.range_constexpr(vec):
+                    part = tuple(frags[f][v] for f in range(nf))
+                    merged = combine_fn(accs[v], part)
+                    valid = col0 + v < N
+                    accs[v] = tuple(
+                        (merged[f] if valid else accs[v][f]) for f in range(nf)
+                    )
+                rr = rr + row_stride
+            if const_expr(rows % row_stride != 0):
+                ok = rr < rows
+                rb64 = cutlass.Int64(rr if ok else Int32(0)) * N + col0
+                for f in cutlass.range_constexpr(nf):
+                    cute.autovec_copy(_row_vec(mIns[f], rb64, vec), frags[f])
+                for v in cutlass.range_constexpr(vec):
+                    part = tuple(frags[f][v] for f in range(nf))
+                    merged = combine_fn(accs[v], part)
+                    valid = ok and (col0 + v < N)
+                    accs[v] = tuple(
+                        (merged[f] if valid else accs[v][f]) for f in range(nf)
+                    )
+
+        # Combine the block_y partials per column via smem (cross thread-row).
+        smem = cutlass.utils.SmemAllocator()
+        if const_expr(by_n > 1):
+            bufs = [
+                smem.allocate_tensor(
+                    trait.fdtypes[f],
+                    cute.make_ordered_layout(
+                        (by_n, const_expr(self.block_x * vec)), order=(1, 0)
+                    ),
+                    byte_alignment=8,
+                )
+                for f in range(nf)
+            ]
+            for v in cutlass.range_constexpr(vec):
+                cidx = tx * vec + v
+                for f in cutlass.range_constexpr(nf):
+                    bufs[f][(ty, cidx)] = trait.fdtypes[f](accs[v][f])
+            cute.arch.barrier()
+            for v in cutlass.range_constexpr(vec):
+                cidx = tx * vec + v
+                merged = trait.init()
+                for yy in cutlass.range_constexpr(by_n):
+                    part = tuple(bufs[f][(yy, cidx)] for f in range(nf))
+                    merged = trait.combine(merged, part)
+                accs[v] = merged
+
+        # ty==0 of each (bx, by) block writes its column results. final ->
+        # project (true_m divisor) one value per column; not-final -> store RAW
+        # per-field accumulators to parts[f][by, col] for the stage-2 combine.
+        if const_expr(self.final):
+            for v in cutlass.range_constexpr(vec):
+                col = col0 + v
+                res = mOuts[0].element_type(
+                    trait.project(accs[v], acc_dtype(const_expr(self.true_m)))
+                )
+                if ty == 0 and col < N:
+                    mOuts[0][col] = res
+        else:
+            for v in cutlass.range_constexpr(vec):
+                col = col0 + v
+                vals = [trait.fdtypes[f](accs[v][f]) for f in range(nf)]
+                if ty == 0 and col < N:
+                    for f in cutlass.range_constexpr(nf):
+                        mOuts[f][by * N + col] = vals[f]
+
+
+@cute.jit
+def _row_vec(mX, base, vec: cutlass.Constexpr):
+    # A vec-wide contiguous slice of the flat input starting at `base`, viewed as
+    # a (vec,) tensor for autovec_copy.
+    return cute.make_tensor(mX.iterator + base, cute.make_layout(vec))
+
+
+_CACHE = {}
+
+
+def _aligned(t, align, read_only=False):
+    # enable_tvm_ffi: fast torch->tvm-ffi C exchange (~0.8us vs ~3.6us capsule).
+    # read_only wraps an INPUT so a COW input exports without materializing (launch._ro).
+    w = _L.ReadOnlyTensorWrapper(t) if read_only else t
+    ct = cute.runtime.from_dlpack(w, assumed_align=align, enable_tvm_ffi=True)
+    ct.element_type = _L.torch2cute[t.dtype]
+    return ct
+
+
+def _choose_config(M, N, vec, hw):
+    # Launch config (block_x, block_y, grid_y) for the column reduction.
+    #
+    # NO-REGRESSION baseline. A dense landscape sweep (characterize_k2.py, f32/f16 x
+    # 11 shapes) showed there's real headroom (up to +0.3x on some shapes) BUT no
+    # single closed-form rule captures the surface without REGRESSING other shape
+    # classes -- every scalar formula trades square/wide against tall-narrow. Since
+    # the directive is "don't regress any case," we keep the proven heuristic here
+    # and leave the headroom to a future AUTOTUNER (which measures per shape-key and
+    # picks the best, so it cannot regress -- the documented follow-up). The sweep
+    # data + hw_caps are the inputs that autotuner will use.
+    #
+    # block_x/block_y fixed at the validated defaults; grid_y from _choose_grid_y:
+    # split the M (reduced) axis only when the column-blocks underfill the device,
+    # to ~2*sm_count total blocks, capped by available M. sm_count is read from hw
+    # so the fill target tracks the GPU (Hopper/Blackwell/Rubin).
+    block_x, block_y = _DEFAULT_BLOCK_X, _DEFAULT_BLOCK_Y
+    grid_x = -(-N // (block_x * vec))
+    gy = _choose_grid_y(M, grid_x, block_y, hw.sm_count)
+    return block_x, block_y, gy
+
+
+def _choose_grid_y(M, grid_x, block_y, sm, min_vpt=64):
+    # ctas_per_output for the M (reduced) axis. Split M ONLY when the column-blocks
+    # alone leave the device underfilled (splitting adds a gmem partial round-trip,
+    # so it only pays when it buys occupancy). Near a full wave (grid_x >= 3/4 sm)
+    # don't split. Otherwise target ~2*sm total blocks; cap so each thread-row still
+    # folds >= min_vpt rows. sm is hw.sm_count (portable across GPUs).
+    if grid_x >= (3 * sm) // 4:
+        return 1
+    gy = max(1, -(-(2 * sm) // max(grid_x, 1)))
+    return max(1, min(gy, max(1, M // (block_y * min_vpt))))
+
+
+def reduce_col(
+    trait,
+    trait_key,
+    x,
+    out_dtype,
+    block_x=None,
+    block_y=None,
+    grid_y=None,
+    vec_bits=128,
+):
+    # Vectorized column reduction (reduce dim 0). x: (M, N) contiguous.
+    # block_x/block_y/grid_y default to the HW-parameterized heuristic
+    # (_choose_config); pass explicit values to override (used by the autotune
+    # landscape sweep characterize_k2.py). vec_bits is the exposed load/store vector
+    # width in bits (default 128 = the wide LDG/STG target); 64/256 are the other
+    # candidates. gcd with N keeps it a legal divisor for ragged N.
+    assert x.dim() == 2 and x.is_cuda and x.stride(-1) == 1  # noqa: S101
+    M, N = x.shape
+    vec = math.gcd(N, vec_bits // (x.element_size() * 8))
+    cbx, cby, cgy = _choose_config(M, N, vec, _hw.caps(x.device))
+    block_x = cbx if block_x is None else block_x
+    block_y = cby if block_y is None else block_y
+    grid_y = cgy if grid_y is None else grid_y
+    out = torch.empty(N, device=x.device, dtype=out_dtype)
+    xf = x.reshape(-1)
+    align = 16 if (N % vec == 0) else x.element_size()
+
+    if grid_y == 1:
+        op = ColReduce(
+            trait,
+            M,
+            N,
+            vec,
+            true_m=M,
+            grid_y=1,
+            final=True,
+            block_x=block_x,
+            block_y=block_y,
+        )
+        xin = _aligned(xf, align, read_only=True)
+        key = (
+            "col",
+            trait_key,
+            x.dtype,
+            out_dtype,
+            M,
+            N,
+            vec,
+            block_x,
+            block_y,
+            trait.nfields,
+        )
+        fn = cached_plan(
+            _CACHE, key, lambda: _compile(op, [xin], [_cute(out)], _stream())
+        )
+        fn([xin], [_cute(out)], _stream())
+        return out
+
+    # M-split: stage 1 -> grid_y raw partials per column; stage 2 combines them.
+    nf = trait.nfields
+    parts = [
+        torch.empty(grid_y * N, device=x.device, dtype=_PART_TORCH[trait.fdtypes[f]])
+        for f in range(nf)
+    ]
+    op1 = ColReduce(
+        trait,
+        M,
+        N,
+        vec,
+        true_m=M,
+        grid_y=grid_y,
+        final=False,
+        from_partials=False,
+        block_x=block_x,
+        block_y=block_y,
+    )
+    xin = _aligned(xf, align, read_only=True)
+    k1 = ("col-s1", trait_key, x.dtype, M, N, vec, grid_y, block_x, block_y, nf)
+    f1 = cached_plan(
+        _CACHE, k1, lambda: _compile(op1, [xin], [_cute(p) for p in parts], _stream())
+    )
+    f1([xin], [_cute(p) for p in parts], _stream())
+
+    # Stage 2: column-reduce the (grid_y, N) partials -> (N,), project with M.
+    # Partials are Float32/Int32 storage; recompute vec for their element size.
+    pvec = math.gcd(N, 128 // (parts[0].element_size() * 8))
+    op2 = ColReduce(
+        trait,
+        grid_y,
+        N,
+        pvec,
+        true_m=M,
+        grid_y=1,
+        final=True,
+        from_partials=True,
+        block_x=block_x,
+        block_y=block_y,
+    )
+    palign = 16 if (N % pvec == 0) else parts[0].element_size()
+    pin = [_aligned(p, palign, read_only=True) for p in parts]
+    k2 = ("col-s2", trait_key, out_dtype, grid_y, N, pvec, block_x, block_y, nf)
+    f2 = cached_plan(_CACHE, k2, lambda: _compile(op2, pin, [_cute(out)], _stream()))
+    f2(pin, [_cute(out)], _stream())
+    return out

--- a/torch/_native/ops/reductions/kernel_general.py
+++ b/torch/_native/ops/reductions/kernel_general.py
@@ -1,0 +1,657 @@
+# General CuTeDSL reduction kernel (K0) + the dispatcher for the whole fold-
+# reduction taxonomy. K0 is one @cute.kernel that handles ANY geometry (row,
+# column, n-D, transposed, sliced, reduce-all) via a TensorIterator-derived
+# offset decode -- the correctness floor and fallback. _reduce() dispatches the
+# perf-critical cases to specialized kernels and falls back to K0 otherwise:
+#   contiguous last-dim, smem-fits   -> kernel_row.reduce_row   (K1, vectorized)
+#   contiguous last-dim, larger N    -> reduce_xcta.reduce_row_xcta  (cross-CTA)
+#   dim-0 (columns), wide N          -> kernel_col.reduce_col     (K2, vectorized)
+#   everything else                  -> K0 here
+#
+# The trait protocol (init/reduce/combine/shfl_down/project, nfields/fdtypes) and
+# the warp_reduce/block_reduce helpers are REUSED UNCHANGED from reduce_traits.
+#
+# How one kernel covers everything -- block `o` (one per KEPT-dim coordinate)
+# reduces `count` elements along the reduced dims; threads stride the linear
+# reduction index r by blockDim; then warp + block reduce.
+#
+# ADDRESSING is driven by torch's TensorIterator (see kernel_general /
+# _decompose_via_ti). TI coalesces/reorders ANY reduction (any dim set, any
+# strides, n-D) into an iteration where a dim is REDUCED iff the output stride
+# along it is 0, else KEPT. The host passes two compile-time lists of
+# (extent, element_stride) pairs over the INPUT tensor:
+#     red_dims : the reduced dims  -> the per-thread fold walks these
+#     kept_dims: the kept dims     -> one block per kept coordinate
+# The kernel turns a linear index into a flat input offset by mixed-radix
+# decode against those pairs (decode_offset). For the common single-reduced-run
+# case this collapses to base + r*rstride; multi-dim reductions (e.g. dim=(1,3))
+# and arbitrary strides (transpose, slice) fall out of the same decode with no
+# special cases -- replacing the old x.t()/reshape geometry hacks.
+#
+# Reduce-all is just the degenerate "all dims reduced, zero kept dims" case for
+# stage 1, plus a flat stage-2 fold of the G partials.
+#
+# const_expr policy flags (all compiled away -> specialized SASS, no runtime br):
+#   red_pairs    : tuple of (extent, stride) for reduced dims (input elements).
+#   kept_pairs   : tuple of (extent, stride) for kept dims (input elements).
+#   in_base      : flat input element offset of output coordinate 0.
+#   nouts        : 1 or 2 result tensors (var_mean / max.dim are 2).
+#   gidx_from    : "r" -> argmax index is the linear reduction index r (per-axis
+#                  reductions); "flat" -> the global flat input offset (reduce-all).
+#   final        : True  -> project the accumulator, store nouts result(s);
+#                  False -> store the RAW accumulator fields to per-field gmem
+#                           partial buffers (cross-CTA stage 1).
+#   from_partials: True  -> per-thread step COMBINES pre-reduced accumulator
+#                  tuples read from nfields partial buffers (stage 2);
+#                  False -> it REDUCEs raw scalar inputs.
+#
+# I/O passed as python lists (cute kernels accept lists):
+#   mIns  : [mX]                         when from_partials is False
+#           [p0, ... p(nfields-1)]       when from_partials is True (stage 2)
+#   mOuts : [o0] or [o0, o1]             when final is True
+#           [p0, ... p(nfields-1)]       when final is False (stage 1 partials)
+
+import math
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import const_expr, Float32, Float64, Int32, Int64
+
+import torch
+from torch._tensor_iterator import reduce_op
+
+from .._cutedsl import launch as _L
+from .._cutedsl.plan_cache import cached_plan
+from .._cutedsl.traits import block_reduce, WARP, warp_reduce
+
+
+def _decode_offset(linear, pairs):
+    # Mixed-radix decode of a linear index into a flat element offset over the
+    # given (extent, stride) pairs. pairs are ordered fastest-varying first, so
+    # successive divisions peel off each dim. Pure const_expr structure (the loop
+    # and the pairs are compile-time); for a single pair this is linear*stride.
+    #
+    # INT64: the flat offset can exceed int32 (numel >= 2^31, e.g. a (300000, 8192)
+    # reduction). Cast the linear index to Int64 up front so every rem*stride product
+    # and accumulation is 64-bit; an int32 product silently wraps negative and reads
+    # out of bounds. The returned offset indexes a flat gmem tensor, which expects a
+    # 64-bit offset.
+    off = cutlass.Int64(0)
+    rem = cutlass.Int64(linear)
+    for ext, strd in pairs:
+        if const_expr(len(pairs) == 1):
+            off = rem * const_expr(strd)
+        else:
+            off = off + (rem % const_expr(ext)) * const_expr(strd)
+            rem = rem // const_expr(ext)
+    return off
+
+
+class ReduceBlock:
+    def __init__(
+        self,
+        trait,
+        *,
+        count,
+        num_o,
+        red_pairs,
+        kept_pairs,
+        in_base=0,
+        limit=None,
+        project_n=None,
+        nouts=1,
+        final=True,
+        gidx_from="r",
+        flat_tail=False,
+        from_partials=False,
+        block=128,
+        dyn_num_o=False,
+    ):
+        self.trait = trait
+        self.count = count  # elements reduced per output (= prod red exts)
+        self.num_o = num_o  # number of outputs / blocks (= prod kept exts)
+        # dyn_num_o: drive the grid from mOuts[0].shape[0] at launch instead of the
+        # baked num_o, and exclude num_o from cache_sig. Valid ONLY for a SINGLE kept
+        # dim (the output-row axis): _decode_offset then ignores the extent (single
+        # pair -> rem*stride), so the kernel is correct for any num_o. Lets one
+        # compiled kernel serve any M (e.g. varying batch size) with no recompile.
+        self.dyn_num_o = dyn_num_o
+        # (extent, input-element-stride) pairs from TensorIterator, fastest first.
+        self.red_pairs = tuple(red_pairs)
+        self.kept_pairs = tuple(kept_pairs)
+        self.in_base = in_base  # flat input offset of output coordinate 0
+        self.limit = limit if limit is not None else count  # ragged tail bound
+        # The N passed to project (mean's divisor). = count single-stage; = L for
+        # reduce-all stage 2 (where count is the partial count G, not L).
+        self.project_n = project_n if project_n is not None else count
+        self.nouts = nouts
+        self.final = final
+        self.gidx_from = gidx_from  # "r" (per-axis index) or "flat" (reduce-all)
+        self.flat_tail = flat_tail  # extra off<limit guard for reduce-all stage 1
+        self.from_partials = from_partials
+        self.block = block
+        self.num_warps = block // WARP
+        self.iters = (count + block - 1) // block
+
+    @property
+    def cache_sig(self):
+        # EVERY value baked into the kernel as a const_expr. The compile cache key
+        # must include all of these: each distinct combination compiles a distinct
+        # kernel. (Missing one -- e.g. project_n -- silently reuses a kernel with a
+        # stale baked-in constant; that was a real bug.) Callers prepend trait_key
+        # and the operand dtypes (not captured here).
+        # num_o is excluded when dynamic (grid comes from the output extent at launch,
+        # not baked) so one kernel serves any M; dyn_num_o is in the sig instead.
+        num_o_sig = "dynM" if self.dyn_num_o else self.num_o
+        return (
+            self.count,
+            num_o_sig,
+            self.red_pairs,
+            self.kept_pairs,
+            self.in_base,
+            self.limit,
+            self.project_n,
+            self.nouts,
+            self.final,
+            self.gidx_from,
+            self.flat_tail,
+            self.from_partials,
+            self.block,
+            self.trait.nfields,
+        )
+
+    @cute.jit
+    def __call__(self, mIns: list, mOuts: list, stream):
+        # Dynamic grid: read the output row count live so one compile serves any M.
+        grid_o = mOuts[0].shape[0] if const_expr(self.dyn_num_o) else self.num_o
+        self.kernel(mIns, mOuts).launch(
+            grid=[grid_o, 1, 1], block=[self.block, 1, 1], stream=stream
+        )
+
+    @cute.kernel
+    def kernel(self, mIns: list, mOuts: list):
+        trait = self.trait
+        tidx, _, _ = cute.arch.thread_idx()
+        o, _, _ = cute.arch.block_idx()
+        count = const_expr(self.count)
+        nfields = const_expr(trait.nfields)
+
+        acc = trait.init()
+        # Base flat input offset for this block's KEPT coordinate (decode o
+        # against the kept dims). const_expr in/0-kept (reduce-all) -> just in_base.
+        obase = const_expr(self.in_base) + _decode_offset(o, self.kept_pairs)
+        reduce_fn = trait.reduce  # local bind: attribute access trips a dyn loop
+        acc_dtype = trait.acc  # accumulator dtype (a compile-time Python class)
+        if const_expr(self.from_partials):
+            # Stage-2: COMBINE pre-reduced accumulator tuples from the per-field
+            # partial buffers. Partials for output o are the contiguous run
+            # [obase, obase+count); obase = o*C decoded from kept_pairs (Int64) -- must
+            # offset by it, else every row reads row 0's partials (multi-row bug).
+            #
+            # count is the partial count (for a huge-N reduce-all split, LARGE -- ~1e5).
+            # A range_constexpr(ceil(count/block)) unroll scaled the compile with count
+            # (count=98125 -> ~384-deep unroll -> ~3s compile; the reduce-all backup's
+            # G-chunk was worse). Same fix as the per-axis fold below: a DYNAMIC
+            # full-wave loop (all-in-range, so the constant valid=True doesn't trip the
+            # IR flattener) + a CONSTEXPR remainder. Compile depth is O(1) in count.
+            # Bind trait attributes to locals -- attribute access on `trait` inside a
+            # dynamic loop trips the IR flattener (like reduce_fn above); nfields is a
+            # small python int so a bare-range comprehension is trace-time unrolled and
+            # leaves no trait access in the loop body (range_constexpr can't appear in a
+            # cutlass.range loop).
+            combine_fn = trait.combine
+            fdtypes = trait.fdtypes
+            nf = const_expr(nfields)
+            n_full = const_expr(count // self.block)
+            r = tidx
+            for _ in cutlass.range(n_full):
+                rr = obase + cutlass.Int64(r)
+                part = tuple(fdtypes[f](mIns[f][rr]) for f in range(nf))
+                acc = combine_fn(acc, part)
+                r = r + const_expr(self.block)
+            if const_expr(count % self.block != 0):
+                valid = r < count
+                rr = (
+                    (obase + cutlass.Int64(r))
+                    if valid
+                    else cutlass.Int64(const_expr(self.in_base))
+                )
+                part = tuple(fdtypes[f](mIns[f][rr]) for f in range(nf))
+                merged = combine_fn(acc, part)
+                acc = tuple((merged[f] if valid else acc[f]) for f in range(nf))
+        elif const_expr(self.flat_tail):
+            # Reduce-all stage 1: a full wave can still have off >= L on the last
+            # chunk (G*chunk > L), so its guard is genuinely dynamic per element ->
+            # keep the constexpr loop. count here is a bounded chunk size, not the
+            # whole reduction, so the unroll stays small.
+            for i in cutlass.range_constexpr(self.iters):
+                r = tidx + i * self.block
+                off = obase + _decode_offset(r, self.red_pairs)  # Int64 (obase Int64)
+                valid = (r < count) and (off < const_expr(self.limit))
+                # both ifexp branches Int64 (off is Int64); in_base fits in int32 but
+                # the type must match.
+                off_s = off if valid else cutlass.Int64(const_expr(self.in_base))
+                val = acc_dtype(mIns[0][off_s])
+                # gidx is the argmax/flat index fed to the trait (Int32 domain): for
+                # reduce-all flat indexing the global offset fits int32 here because
+                # flat_tail is only used per-chunk; cast back to Int32.
+                gidx = Int32(off_s) if const_expr(self.gidx_from == "flat") else r
+                acc = reduce_fn(acc, val, gidx, valid)
+        else:
+            # Per-axis fold. ceil(count/block) used to be a CONSTEXPR loop -> unroll
+            # depth scaled with count (count=1M gave an 8192-deep unroll that barely
+            # compiled). Split into:
+            #   (a) FULL waves [0, count//block): every thread is in range, so valid
+            #       is the python constant True -> a DYNAMIC loop compiles (a dynamic
+            #       `valid` would trip the IR flattener; a constant one does not).
+            #   (b) a CONSTEXPR remainder pass for the < block leftover, predicated.
+            # Compile depth is now O(1) regardless of count. (Only valid when the
+            # full-wave guard really is all-true, i.e. NOT the flat_tail case above.)
+            n_full = const_expr(count // self.block)
+            base_r = tidx
+            for _ in cutlass.range(n_full):
+                # Inline the offset (no intermediate name that the DSL would treat
+                # as loop-carried across iterations). acc and base_r are the only
+                # carried values; both are initialized before the loop.
+                acc = reduce_fn(
+                    acc,
+                    acc_dtype(mIns[0][obase + _decode_offset(base_r, self.red_pairs)]),
+                    base_r,
+                    True,
+                )
+                base_r = base_r + const_expr(self.block)
+            if const_expr(count % self.block != 0):
+                r = const_expr(n_full * self.block) + tidx
+                valid = r < count
+                rs = r if valid else Int32(0)
+                acc = reduce_fn(
+                    acc,
+                    acc_dtype(mIns[0][obase + _decode_offset(rs, self.red_pairs)]),
+                    r,
+                    valid,
+                )
+
+        acc = warp_reduce(trait, acc, WARP)
+        if const_expr(self.num_warps > 1):
+            smem = cutlass.utils.SmemAllocator()
+            bufs = [
+                smem.allocate_tensor(
+                    trait.fdtypes[f], cute.make_layout(self.num_warps), byte_alignment=8
+                )
+                for f in range(nfields)
+            ]
+            acc = block_reduce(trait, acc, bufs, self.num_warps)
+
+        if const_expr(self.final):
+            # project (post-op) applied exactly once; store nouts result(s).
+            # project_n is the TRUE reduction size (= count single-stage; = L for
+            # reduce-all stage 2, where count is just the partial count G).
+            result = trait.project(acc, acc_dtype(const_expr(self.project_n)))
+            if tidx == 0:
+                if const_expr(self.nouts == 1):
+                    mOuts[0][o] = mOuts[0].element_type(result)
+                else:
+                    for k in cutlass.range_constexpr(self.nouts):
+                        mOuts[k][o] = mOuts[k].element_type(result[k])
+        else:
+            # Cross-CTA stage 1: store the RAW (pre-project) accumulator fields.
+            if tidx == 0:
+                for f in cutlass.range_constexpr(nfields):
+                    mOuts[f][o] = trait.fdtypes[f](acc[f])
+
+
+# ---------------------------------------------------------------------------
+# Host plumbing + the geometry chooser. These build ReduceBlock launches; the
+# kernel above is the only @cute.kernel in the whole library.
+# ---------------------------------------------------------------------------
+_cute = _L.cute_tensor
+_stream = _L.stream
+_compile = (
+    _L.compile
+)  # _L.compile: cute.compile + options="--enable-tvm-ffi" (fast per-call arg passing)
+_PART_TORCH = {
+    Float32: torch.float32,
+    Float64: torch.float64,
+    Int32: torch.int32,
+    Int64: torch.int64,
+}
+
+_COMPILE_CACHE = {}
+
+
+def _cute_list(ts, read_only=False):
+    # read_only wraps INPUT tensors so a COW input exports without materializing
+    # (see launch._ro); outputs are written by the kernel and stay writable.
+    return [_cute(t, read_only=read_only) for t in ts]
+
+
+def _compiled(op, key, ins, outs):
+    return cached_plan(
+        _COMPILE_CACHE,
+        key,
+        lambda: _compile(
+            op, _cute_list(ins, read_only=True), _cute_list(outs), _stream()
+        ),
+    )
+
+
+def _launch(op, key, ins, outs):
+    fn = _compiled(op, key, ins, outs)
+    fn(_cute_list(ins, read_only=True), _cute_list(outs), _stream())
+
+
+def _ti_pairs(x, out):
+    """The kernel's input addressing for ``reduce x into out``, from TensorIterator.
+    A dim is REDUCED iff the iterator's output stride along it is 0, else KEPT.
+    Returns (red_pairs, kept_pairs) of (extent, input_element_stride). TI handles
+    all the broadcast/coalesce/reorder; this is a thin read of its result.
+
+    KEPT dims are ordered by OUTPUT stride ascending (fastest output dim first),
+    because block index o is decoded mixed-radix fastest-first (_decode_offset)
+    and must land on out.reshape(-1)[o] -- i.e. match the output's flat traversal.
+    REDUCED dims need no ordering: the fold visits every reduced element exactly
+    once and the combine is commutative (single-dim argmax has one pair anyway)."""
+    it = reduce_op(out, x)
+    in_str = it.element_strides(it.noutputs)  # input operand follows the outputs
+    out_str = it.element_strides(0)
+    red = [(it.shape[i], in_str[i]) for i in range(it.ndim) if out_str[i] == 0]
+    kept = [
+        (it.shape[i], in_str[i], out_str[i]) for i in range(it.ndim) if out_str[i] != 0
+    ]
+    kept.sort(key=lambda p: p[2])  # fastest output dim first
+    return red, [(e, s) for e, s, _ in kept]
+
+
+def _probe(x, red_axes):
+    # A dummy output tensor with the reduced dims set to size 1, as reduce_op /
+    # _ti_pairs expect (it reads shapes+strides only, no compute). Shared by the
+    # fast-path classifier and the K0 fallback so both see the same TI decode.
+    return torch.empty(
+        [1 if i in red_axes else s for i, s in enumerate(x.shape)],
+        device=x.device,
+        dtype=x.dtype,
+    )
+
+
+def _flat(x):
+    # A 1D stride-1 view over x's ENTIRE underlying storage. TI's element strides
+    # are storage-relative, so the kernel indexes THIS (not x.reshape(-1), which
+    # for a non-contiguous x would copy + reorder and break the stride math).
+    n = max(x.untyped_storage().nbytes() // x.element_size(), 1)
+    return torch.as_strided(x, (n,), (1,), storage_offset=0)
+
+
+# --- Fast-path classification (the ONE source of truth shared by the router below
+# and the override cond gate in overrides.py). Operates on the TI-decomposed
+# (red_pairs, kept_pairs) so it sees the POST-coalesce geometry, not the raw dim
+# arg: e.g. a contiguous 3D last-dim reduction coalesces to a single reduced run +
+# a single kept run and is serviceable by the fast ROW kernel after a 2D reshape.
+#
+# The K0 general kernel is correct for ANY geometry but is ~5-8x slower than aten
+# (it does scalar/strided offset-decoded loads). So instead of running K0 for
+# non-2D geometries, we (a) RESHAPE the coalescible ones into the fast row/col
+# kernels here, and (b) DECLINE the rest to aten via the cond gate. "fast_kind"
+# returns which fast path a reduction maps to, or None if only K0 could serve it
+# (-> the cond declines, aten takes it). ---
+
+
+def fast_kind(red_pairs, kept_pairs, nouts, has_index):
+    """Which fast kernel serves this TI-decomposed reduction, or None (-> K0/aten).
+
+    "row"     : reduced axis is the single contiguous (stride-1) innermost run;
+                kept is a single run. Reshape to (prod(kept), prod(red)), reduce
+                last dim -> K1 / xcta. Serves any nouts / index trait.
+    "col"     : kept axis is the single contiguous (stride-1) innermost run;
+                reduced is a single run. Reshape to (prod(red), prod(kept)),
+                reduce dim 0 -> K2. ONLY nouts==1 non-index (K2 is value-only).
+    "all"     : no kept dims (full reduction) -> xcta / two-stage. Any trait.
+    None      : neither -- only the K0 general kernel could serve it; the cond
+                declines to aten instead (K0 is far slower than aten's kernel).
+
+    Both axes must coalesce to a SINGLE run (len==1) so the reduction is a dense
+    2D (kept, red) or (red, kept) view. For a contiguous input TI collapses each
+    dense axis to one pair, so a genuine row/col/coalescible-n-D case gives exactly
+    one red + one kept pair; a transpose / multi-run / gapped layout gives >1 and
+    falls to None (aten). The stride-1 pair is the innermost (contiguous) axis and
+    decides row vs col.
+    """
+    if len(kept_pairs) == 0:
+        return "all"
+    if len(red_pairs) != 1 or len(kept_pairs) != 1:
+        return None
+    if red_pairs[0][1] == 1:  # reduced run is innermost/contiguous -> row
+        return "row"
+    if kept_pairs[0][1] == 1 and nouts == 1 and not has_index:  # kept innermost -> col
+        return "col"
+    return None
+
+
+# The one-shot K1 stages a whole row tile in smem, so its tile is ~N*dtype_bytes;
+# it must fit the ~228 KB B200 smem budget. Above that, route to the multi-CTA
+# split (which caps each chunk's smem tile). Use a conservative 192 KB so the
+# reduction-buffer + alignment slack also fit.
+_SMEM_BUDGET = 192 * 1024
+
+
+def _oneshot_ok(x):
+    # One-shot K1 smem tile fits? (tile ~ N elements of the input dtype).
+    return x.shape[-1] * x.element_size() <= _SMEM_BUDGET
+
+
+def _try_fast_row(trait, trait_key, x, out_dtypes, nouts):
+    # Fast path for reduction of the CONTIGUOUS last dim of a 2D problem. Sub-paths;
+    # returns the result tuple, or None if not handled:
+    #   nouts==2, smem-safe N            -> one-shot K1 two-output (reduce_row_2out)
+    #   nouts==1, smem-safe N            -> one-shot K1 (reduce_row)
+    #   nouts==1, larger N, non-index op -> single-kernel cross-CTA (reduce_xcta)
+    # The two-output one-shot path serves max.dim/min.dim (value + index): no split,
+    # so the projected index is the true per-row column. nouts==2 larger-N and
+    # index-trait larger-N still fall to the general kernel (no index-aware split).
+    if x.dim() != 2 or x.stride(-1) != 1:
+        return None
+    N = x.shape[-1]
+    if N < 1:
+        return None
+    from . import kernel_row as row
+
+    if nouts == 2:
+        if _oneshot_ok(x):
+            return row.reduce_row_2out(trait, trait_key, x, out_dtypes)
+        return None
+    if nouts != 1:
+        return None
+    if _oneshot_ok(x):
+        return (row.reduce_row(trait, trait_key, x, out_dtypes[0]),)
+    # Larger N: two-stage cross-CTA reduction (one fused launch). Index traits
+    # (argmax/argmin) are now served too: stage-1 accumulates the GLOBAL column
+    # index (index_chunks=C), so stage-2 combine over the C partials picks the true
+    # global winner with no remap. (max.dim/min.dim are nouts==2 and handled by the
+    # one-shot branch above; they do not reach here.)
+    from . import kernel_xcta as xc
+
+    res = xc.reduce_row_xcta(trait, trait_key, x, out_dtypes[0])
+    if res is None:
+        return None  # xcta declined (prime/poorly-factored N) -> use K0 general kernel
+    return (res,)
+
+
+def _reduce(trait, trait_key, x, dims, out_dtypes, nouts, block=128):
+    # General reduction of x over `dims` (int / tuple / None=all), driven by TI.
+    # Covers row/column/n-D/transposed/sliced uniformly. Returns nouts tensors.
+    # block = K0 threads-per-block (exposed knob); baked into ReduceBlock + cache_sig.
+    assert x.is_cuda  # noqa: S101
+    red_axes = (
+        range(x.dim()) if dims is None else ([dims] if isinstance(dims, int) else dims)
+    )
+    red_axes = {d % x.dim() for d in red_axes}
+    has_index = getattr(trait, "has_index", False)
+    out_shape = [s for i, s in enumerate(x.shape) if i not in red_axes]
+
+    # Full reduction (every axis reduced -> scalar): route to reduce_all (xcta /
+    # two-stage), not the K0 fallback. Reached when a multi-dim `dims` happens to
+    # cover all axes, or a 1D reduce (the override's reduce-ALL path calls reduce_all
+    # directly, but reduce_dim with an explicit full dim set lands here). Single
+    # output only; a 2-output full reduction is rare and stays on K0.
+    if len(out_shape) == 0 and nouts == 1:
+        return (reduce_all(trait, trait_key, x, out_dtypes[0], block=block),)
+
+    # Classify the POST-TI-coalesce geometry and route to the fast kernels via a
+    # dense 2D reshape. A contiguous n-D reduction whose reduced (or kept) axes are
+    # innermost coalesces to a single reduced + single kept run -> serviceable by
+    # the row/col kernels after reshaping to (kept, red) / (red, kept). This is why
+    # e.g. a contiguous (A,B,C) reduce over dim 2 (or dims (1,2)) goes fast instead
+    # of to the ~5-8x-slower K0 general kernel. The override cond declines any
+    # geometry that returns None here (only K0 could serve it) so aten takes it;
+    # `_reduce` therefore only sees fast_kind in {row, col} on the real (non-
+    # declined) call. K0 below stays as the correctness fallback for direct callers
+    # and for the case a fast kernel itself declines (e.g. xcta on a prime N).
+    if len(out_shape) > 0 and x.is_contiguous():
+        red_pairs, kept_pairs = _ti_pairs(x, _probe(x, red_axes))
+        kind = fast_kind(red_pairs, kept_pairs, nouts, has_index)
+        red_n = x.numel() // max(1, math.prod(out_shape))
+        if kind == "row":
+            x2 = x.reshape(math.prod(out_shape), red_n)
+            fast = _try_fast_row(trait, trait_key, x2, out_dtypes, nouts)
+            if fast is not None:
+                return tuple(o.reshape(out_shape) for o in fast)
+        elif kind == "col":
+            from . import kernel_col as cv
+
+            x2 = x.reshape(red_n, math.prod(out_shape))
+            out = cv.reduce_col(trait, trait_key, x2, out_dtypes[0])
+            return (out.reshape(out_shape),)
+
+    outs = [torch.empty(out_shape, device=x.device, dtype=d) for d in out_dtypes]
+    num_o = max(1, math.prod(out_shape))  # blocks (kept coordinates)
+    count = x.numel() // num_o  # elements reduced per output
+    red_pairs, kept_pairs = _ti_pairs(x, _probe(x, red_axes))
+    op = ReduceBlock(
+        trait,
+        count=count,
+        num_o=num_o,
+        red_pairs=red_pairs,
+        kept_pairs=kept_pairs,
+        in_base=x.storage_offset(),
+        nouts=nouts,
+        block=block,
+    )
+    # The kernel's input operand is _flat(x) -- a view over x's ENTIRE
+    # storage -- and the cute wrap bakes its length statically. cache_sig
+    # covers the TI geometry but not the storage size, so two calls with
+    # identical geometry over different-sized buffers would collide and
+    # feed the second a kernel compiled for the first's flat length
+    # (tvm-ffi shape mismatch; hit by conv backward's bias-grad sums in
+    # the OpInfo noncontiguous sweep). Key the flat length explicitly.
+    flat = _flat(x)
+    key = ("reduce", trait_key, x.dtype, tuple(out_dtypes), flat.numel()) + op.cache_sig
+    _launch(op, key, [flat], [o.reshape(-1) for o in outs])
+    return tuple(outs)
+
+
+def reduce_dim(trait, trait_key, x, dims, out_dtype, block=128):
+    return _reduce(trait, trait_key, x, dims, [out_dtype], 1, block=block)[0]
+
+
+def reduce_dim2(trait, trait_key, x, dims, out_dtypes, block=128):
+    return _reduce(trait, trait_key, x, dims, list(out_dtypes), 2, block=block)
+
+
+# --- Back-compat shims: the existing harnesses call reduce_row/col/row2 on 2D
+# inputs. These now route through the TI-driven general path (dim=-1 for row,
+# dim=0 for column). The old x.t() geometry hack is gone -- TI handles strides.
+
+
+def reduce_row(trait, trait_key, x, out_dtype, block=128):
+    assert x.dim() == 2  # noqa: S101
+    return reduce_dim(trait, trait_key, x, -1, out_dtype, block=block)
+
+
+def reduce_row_2out(trait, trait_key, x, out_dtypes, block=128):
+    assert x.dim() == 2  # noqa: S101
+    return reduce_dim2(trait, trait_key, x, -1, out_dtypes, block=block)
+
+
+def reduce_col(trait, trait_key, x, out_dtype, block=128, **_legacy):
+    # _legacy absorbs the old ColReduction block_x/block_y knobs (now irrelevant:
+    # the unified kernel parallelizes one block per kept coordinate).
+    assert x.dim() == 2  # noqa: S101
+    return reduce_dim(trait, trait_key, x, 0, out_dtype, block=block)
+
+
+def _grid_size(L, block, sm_count, grid_mult=4):
+    # G = number of stage-1 chunks (CTAs). Fill the device to grid_mult waves, capped
+    # by the work available. grid_mult is the exposed fan-out knob: more chunks = more
+    # parallelism in stage 1 but a larger stage-2 fold. Default 4 (the prior constant).
+    by_work = (L + block - 1) // block
+    return max(1, min(by_work, sm_count * grid_mult))
+
+
+def reduce_all(trait, trait_key, x, out_dtype, block=256, grid_mult=4):
+    # Full-tensor reduce-all. Routes through the two-stage cross-CTA path (reduce_xcta,
+    # the M=1 case) -- it mirrors ATen's ctas_per_output split. Index traits
+    # (argmax/min) are served too: the (1, L) -> (C, L/C) reshape makes each sub-row's
+    # global column the flat index, and stage-1's index_chunks=C accumulates exactly
+    # that, so the winner's index is the true global flat index with no remap.
+    assert x.is_cuda and x.is_contiguous()  # noqa: S101
+    L = x.numel()
+    xf = x.reshape(-1)
+    from . import kernel_xcta as xc
+
+    res = xc.reduce_row_xcta(trait, trait_key, xf, out_dtype, flatten=True)
+    if res is not None:
+        return res
+    # xcta declined (prime/poorly-factored L) -> fall through to two-stage K0,
+    # which grid-strides any L with no reshape (O(1) compile regardless of L).
+    sm = torch.cuda.get_device_properties(x.device).multi_processor_count
+    G = _grid_size(L, block, sm, grid_mult)
+    chunk = (L + G - 1) // G
+
+    parts = [
+        torch.empty(G, device=x.device, dtype=_PART_TORCH[trait.fdtypes[f]])
+        for f in range(trait.nfields)
+    ]
+    out = torch.empty(1, device=x.device, dtype=out_dtype)
+
+    # Stage 1: 1D input split into G contiguous chunks. Modeled in the general
+    # scheme as kept dim (G, chunk) and reduced dim (chunk, 1): obase = o*chunk,
+    # off = o*chunk + r, with flat_tail guarding off < L on the last chunk.
+    # gidx_from="flat" -> argmax carries the true global flat index.
+    s1 = ReduceBlock(
+        trait,
+        count=chunk,
+        num_o=G,
+        red_pairs=[(chunk, 1)],
+        kept_pairs=[(G, chunk)],
+        limit=L,
+        flat_tail=True,
+        gidx_from="flat",
+        nouts=trait.nfields,
+        final=False,
+        block=block,
+    )
+    _launch(s1, ("all1", trait_key, x.dtype) + s1.cache_sig, [xf], parts)
+
+    # Stage 2: fold the G per-field partials in one block, project once. The
+    # divisor for mean/etc. is the TRUE element count L, not G. (from_partials
+    # ignores red_pairs/kept_pairs; pass trivial ones.) project_n=L is in
+    # cache_sig, so distinct L never reuse a stale baked-in divisor.
+    s2 = ReduceBlock(
+        trait,
+        count=G,
+        num_o=1,
+        red_pairs=[(G, 1)],
+        kept_pairs=[],
+        from_partials=True,
+        project_n=L,
+        nouts=1,
+        final=True,
+        block=block,
+    )
+    # Key on the partial-buffer dtypes the stage-2 kernel binds to, not just
+    # out_dtype: for index traits out_dtype is the int32 INDEX and does not track
+    # the value accumulator, so fp32 and fp64 argmax would otherwise collide on one
+    # cached kernel (the fp32 one then rejects fp64 partials).
+    part_dtypes = tuple(p.dtype for p in parts)
+    s2_key = ("all2", trait_key, out_dtype, part_dtypes) + s2.cache_sig
+    _launch(s2, s2_key, parts, [out])
+    return out.reshape(())

--- a/torch/_native/ops/reductions/kernel_row.py
+++ b/torch/_native/ops/reductions/kernel_row.py
@@ -1,0 +1,600 @@
+# Fragment-based unified row reduction, built on quack's ReductionBase.
+#
+# WHY ReductionBase: the v1 kernel folded with a CONSTEXPR loop over count/block
+# elements, so unroll depth scaled with N -- a 16M-element row wants a 131072-deep
+# unroll and never compiles. v1 also did scalar loads. ReductionBase provides the
+# proven vectorized-tiled-load scaffolding (TiledCopy + cp.async + smem) that the
+# production rmsnorm/softmax kernels use; we reuse it verbatim and only swap in
+# OUR trait fold + per-field cross-thread reduce.
+#
+# HOW the trait survives the DSL: quack's own grid-stride loops only ever call
+# DSL enums / module funcs (operator.add, cute.arch.fmax) -- never a user-class
+# bound method, which is what trips the IR flattener ("'for' encountered a
+# user-defined Python object"). So we do NOT put trait calls in any dynamic loop.
+# Instead the whole row tile is loaded into a register fragment (N is a
+# compile-time const -> fixed fragment size), and the per-thread fold over that
+# fragment is a CONSTEXPR loop. Trait calls in a constexpr loop are fine (this is
+# exactly what v1 did and what the trait library was validated on). The dynamic
+# work (the vectorized copy) is pure DSL ops with no trait reference.
+#
+# Trait protocol + warp_reduce/block_reduce reused unchanged from reduce_traits.
+# Row / last-dim-contiguous geometry only -- the perf-critical common case.
+#
+# STATUS: validated (full 2018-case suite passes with this wired in as the row
+# fast path via kernel_general._try_fast_row) and memory-clean (0 compute-sanitizer
+# errors on ragged-N). fp32 row sum hits ~6.6 TB/s on (8192,8192) = ~1.5x torch
+# and ~80% of B200 peak. CAVEATS: (1) the whole row goes into ONE block's
+# register fragment, so compile time and register pressure grow with N -- capped
+# at N<=65536 by kernel_general._MAX_N, above which the general kernel handles
+# it. (2) fp16 wins on large N but LOSES to torch on small/wide N (e.g. 2048x16384
+# torch is ~2x faster) -- those shapes want a different (persistent/multi-pass)
+# strategy, still open.
+
+import math
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import const_expr, pipeline
+from cutlass.cute.nvgpu import cpasync
+
+import torch
+from torch._vendor.quack import copy_utils
+from torch._vendor.quack.reduction_base import ReductionBase
+
+from .._cutedsl import launch as _L
+from .._cutedsl.plan_cache import cached_plan
+from .._cutedsl.traits import block_reduce, cluster_reduce, WARP, warp_reduce
+
+
+_cute = _L.cute_tensor
+_compile = _L.compile  # cute.compile + options="--enable-tvm-ffi"
+_stream = _L.stream
+
+
+class RowReduce(ReductionBase):
+    # Reduce the contiguous last dim of (M, N) -> (M,). One CTA handles
+    # tiler_mn[0] rows; each thread vector-loads its slice of a row, folds the
+    # fragment with the trait, then warp+block reduce across the row.
+    #
+    # `final` (default True) projects the accumulator and writes one result per
+    # row. `final=False` writes the RAW per-field accumulators to nfields partial
+    # buffers instead -- this is stage 1 of the multi-CTA-per-row split, where a
+    # long row is cut into chunks (each handled as its own "row" of a reshaped
+    # (M*C, N/C) input) and a cheap stage-2 row reduction combines the C partials
+    # and projects once with the TRUE row length (project_n).
+    def __init__(
+        self,
+        trait,
+        dtype,
+        N,
+        final=True,
+        project_n=None,
+        nouts=1,
+        index_chunks=1,
+        tpr_override=None,
+        nt_override=None,
+        cp_async=True,
+        cluster_n=1,
+        use_tma=False,
+    ):
+        # stage=1: a single reduction buffer (we drive the combine ourselves).
+        super().__init__(dtype, N, stage=1)
+        self.trait = trait
+        self.final = final
+        self.nouts = nouts  # 1 (most ops) or 2 (max.dim/min.dim: value + index).
+        # Exposed occupancy knobs (autotuner overrides; None -> the tuned ladder):
+        #   tpr_override: threads PER ROW, replacing the _threads_per_row ladder pick.
+        #   nt_override:  threads per BLOCK, replacing the _num_threads 128/256 gate.
+        # The ragged-N correctness guard in _threads_per_row still applies to the
+        # override (a multi-row tile needs N a clean multiple of vec*tpr).
+        self.tpr_override = tpr_override
+        self.nt_override = nt_override
+        # cluster_n: split each row across cluster_n CTAs (a launch cluster); each CTA
+        # reduces a distinct N/cluster_n column slice, then a cross-CTA cluster reduce
+        # (traits.cluster_reduce, via distributed-shared-memory mbarrier) folds the
+        # peers. 1 = no clustering (the default; every cluster branch below is a
+        # compile-time no-op, so the kernel is identical to the pre-cluster version).
+        # Requires sm_90+; the host builder caps it (see reduce_row_cluster).
+        self.cluster_n = cluster_n
+        # cp_async: use the SMEM-staged wide cp.async load path when its preconditions
+        # (even N, vector >= 32 bits) hold. False forces the direct gmem->rmem path
+        # even when cp.async is legal -- an exposed knob, since skipping smem staging
+        # can win on occupancy for some shapes. It NEVER enables cp.async where it is
+        # illegal (ragged/narrow): that gate stays a hard correctness requirement.
+        self.cp_async = cp_async
+        # use_tma: load the (tiler_m, N) tile gmem->smem via the TMA unit
+        # (cp.async.bulk.tensor) instead of cp.async/direct. A third load path filling
+        # the SAME staged sX tile the fragment fold reads; the reduce math is
+        # unchanged. Driven by the tested PipelineTmaAsync (correct mbarrier count /
+        # fence / phase -- hand-rolling deadlocks). Requires an even tile (TMA moves
+        # the whole static box) and is incompatible with cluster_n>1 and the
+        # index-chunk path; the host builder only enables it in the plain one-shot
+        # row-sum-class case (see reduce_row use_tma gate).
+        self.use_tma = use_tma
+        # index_chunks (C): for INDEX traits used as the xcta two-stage stage-1, the
+        # input (M, N) is reshaped to (M*C, N/C), so each sub-row's column index is
+        # CHUNK-LOCAL [0, N/C). To make the accumulated index the true GLOBAL column
+        # [0, N), the fold adds (sub_row % C) * (N/C) -- the chunk's column base. C=1
+        # (the default, non-split case) makes this a no-op. Mirrors ATen carrying the
+        # absolute index in the partial so stage-2 combine needs no remap.
+        self.index_chunks = index_chunks
+        self.project_n = project_n if project_n is not None else N
+        self.vec = math.gcd(N, 128 // dtype.width)  # elems per 128-bit vector
+
+    def _num_threads(self):
+        if self.nt_override is not None:
+            return self.nt_override
+        return 128 if self.N <= 16 * 1024 else 256
+
+    def _threads_per_row(self):
+        # CRITICAL for occupancy: use only as many threads PER ROW as the row
+        # needs, so num_threads/threads_per_row rows pack into each block. The old
+        # heuristic maxed this out (1 row/block), starving occupancy and forcing a
+        # cross-warp smem reduce for tiny rows -- fp16 N=1024 ran at <3 TB/s. This
+        # ladder is quack's production rmsnorm tuning (rmsnorm_config _for_hopper_
+        # fwd): small N -> 1 warp/row -> many rows/block AND no cross-warp reduce.
+        nt = self._num_threads()
+        if self.tpr_override is not None:
+            tpr = self.tpr_override
+        else:
+            # Sub-warp rungs (8/16 in quack's ladder) are NOT supported by
+            # the block-reduce math below: warps_per_row = tpr // WARP
+            # would be 0 (ZeroDivisionError at build for e.g. fp32 N=64,
+            # fp64 N=16). Clamp to one warp per row; nt/32 rows per block
+            # still packs well for tiny N.
+            tpr = 256
+            for limit, t in [(128, 32), (3072, 32), (6144, 64), (16384, 128)]:
+                if self.N <= limit:
+                    tpr = t
+                    break
+        # Packing >1 row per block (nt//tpr) is only correct when each row's tile
+        # is exactly N wide. For RAGGED N the tile is padded to a multiple of
+        # vec*tpr, so a multi-row tile's row stride != N and rows misalign. Force
+        # 1 row/block (tpr == num_threads) when N isn't a clean multiple. Even N
+        # keeps the occupancy-friendly small tpr.
+        vec = math.gcd(self.N, 128 // self.dtype.width)
+        even = self.N % (vec * tpr) == 0
+        return tpr if even else nt
+
+    @cute.jit
+    def __call__(self, mX: cute.Tensor, mOuts: list, stream: cuda.CUstream):
+        # mOuts: [result] when final; [partial_field_0, ...] when not final.
+        # cluster_n is set by the host builder (const), NOT _set_cluster_n() (which
+        # would reset it to 1); _get_tiled_copy reads it to narrow each CTA's column
+        # tile to N/cluster_n. grid.y = cluster_n places the peer CTAs in one cluster.
+        vecsize = const_expr(math.gcd(self.N, 128 // self.dtype.width))
+        tiled_copy, tiler_mn, threads_per_row = self._get_tiled_copy(vecsize=vecsize)
+        num_threads = tiled_copy.size
+        # TMA atom (host-compile-time, inside the jit region). mX_tma replaces mX for
+        # the load; the atom is baked into the kernel. Only when use_tma is on.
+        if const_expr(self.use_tma):
+            tma_smem_layout = cute.make_ordered_layout(tiler_mn, order=(1, 0))
+            tma_atom, mX_tma = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileG2SOp(), mX, tma_smem_layout, tiler_mn
+            )
+        else:
+            tma_atom, mX_tma = None, mX
+        self.kernel(
+            mX_tma, mOuts, tiler_mn, tiled_copy, threads_per_row, tma_atom
+        ).launch(
+            grid=[cute.ceil_div(mX.shape[0], tiler_mn[0]), self.cluster_n, 1],
+            block=[num_threads, 1, 1],
+            cluster=(
+                [1, self.cluster_n, 1] if const_expr(self.cluster_n > 1) else None
+            ),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mX: cute.Tensor,
+        mOuts: list,
+        tiler_mn: cute.Shape,
+        tiled_copy: cute.TiledCopy,
+        threads_per_row: cutlass.Constexpr,
+        tma_atom=None,
+    ):
+        trait = self.trait
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        # Cluster column tile: CTA rank `cluster_y` in the cluster owns column-tile
+        # `cluster_y` of the row (tiler_mn[1] = N/cluster_n wide). cluster_n==1 ->
+        # cluster_y is the compile-time 0 -> identical to the single-CTA tiling.
+        # block_idx_in_cluster() returns the LINEARIZED rank; our cluster is
+        # [1, cluster_n, 1], so the linear rank IS the y-rank (0..cluster_n-1).
+        cluster_y = (
+            const_expr(0)
+            if const_expr(self.cluster_n == 1)
+            else cute.arch.block_idx_in_cluster()
+        )
+
+        shape = (cute.size(mX, mode=[0]), cute.size(mX, mode=[1]))
+        idX = cute.make_identity_tensor(shape)
+        # INT64 tile coordinate: local_tile computes the tile's gmem offset in the
+        # COORDINATE's integer type. block_idx() is i32, so (bidx, 0) overflows the
+        # offset when M*N >= 2^31 (e.g. 300000x8192) -> negative wrap -> illegal
+        # access. Cast the block index to Int64 so the offset math is 64-bit. (cX
+        # indexes the small identity tensor so it can't overflow, but keep it
+        # consistent.) NOT a DSL bug -- local_tile honors the type we pass.
+        bidx64 = cutlass.Int64(bidx)
+        gX = cute.local_tile(mX, tiler_mn, (bidx64, cluster_y))
+        cX = cute.local_tile(idX, tiler_mn, (bidx64, cluster_y))
+
+        smem = cutlass.utils.SmemAllocator()
+        thr_copy = tiled_copy.get_slice(tidx)
+        tXgX = thr_copy.partition_S(gX)
+        tXcX = thr_copy.partition_S(cX)
+        # Under TMA, mX is a TMA-descriptor tensor, so tXgX is a coordinate partition
+        # with no concrete element dtype -> give the register fragment the input dtype
+        # explicitly. The direct/cp.async paths keep the dtype-inferring form.
+        tXrX = (
+            cute.make_rmem_tensor_like(tXgX, dtype=self.dtype)
+            if const_expr(self.use_tma)
+            else cute.make_rmem_tensor_like(tXgX)
+        )
+
+        # Row is fully covered when the cluster_n tiles together span N exactly.
+        is_even = const_expr(shape[1] == tiler_mn[1] * self.cluster_n)
+        row = tXcX[(0, None), None, None][0][0]
+        # Per-thread contiguous copy width in bits. cp.async only supports 32/64/
+        # 128-bit transfers, so the wide SMEM-staged path is used only when the
+        # vector is >= 32 bits (the perf-critical fp16/bf16 even case: vec*16 =
+        # 128). Narrow/ragged (e.g. vec=1 for a prime N) falls back to a direct
+        # autovec gmem->rmem, which is correct and memory-safe (compute-sanitizer
+        # clean) just not maximally wide -- acceptable off the fast path.
+        # Use self.dtype (a concrete numeric class) not mX.element_type: under TMA mX
+        # is a descriptor tensor whose element_type is not a plain Numeric.
+        cp_bits = const_expr(self.vec * self.dtype.width)
+        if const_expr(self.use_tma):
+            # TMA-staged load: the TMA unit moves the whole (tiler_m, N) tile
+            # gmem->smem in one bulk transfer, driven by the tested PipelineTmaAsync
+            # (correct mbarrier count/fence/phase). Then the SAME fragment fold reads
+            # sX. The host builder only enables use_tma for the even one-shot case, so
+            # is_even holds and OOB rows are handled by the descriptor.
+            sX = smem.allocate_tensor(
+                self.dtype,
+                cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+                byte_alignment=16,
+            )
+            mbar = smem.allocate_array(cutlass.Int64, num_elems=2)
+            tx = const_expr(cute.size(tiler_mn) * self.dtype.width // 8)
+            pipe = pipeline.PipelineTmaAsync.create(
+                num_stages=1,
+                producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+                consumer_group=pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread, const_expr(tiled_copy.size)
+                ),
+                tx_count=tx,
+                barrier_storage=mbar,
+            )
+            pstate = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1)
+            cstate = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1)
+            tSsX, tSgX = cpasync.tma_partition(
+                tma_atom,
+                0,
+                cute.make_layout(1),
+                cute.group_modes(sX, 0, 2),
+                cute.group_modes(gX, 0, 2),
+            )
+            if cute.arch.warp_idx() == 0:
+                pipe.producer_acquire(pstate)
+                cute.copy(
+                    tma_atom, tSgX, tSsX, tma_bar_ptr=pipe.producer_get_barrier(pstate)
+                )
+                pipe.producer_commit(pstate)
+            pipe.consumer_wait(cstate)
+            cute.autovec_copy(thr_copy.partition_D(sX), tXrX)
+            pipe.consumer_release(cstate)
+        elif const_expr(is_even and cp_bits >= 32 and self.cp_async):
+            # SMEM-staged wide async load (the rmsnorm idiom). gmem ptr is marked
+            # 128-bit aligned host-side so this emits a true wide global transfer.
+            sX = smem.allocate_tensor(
+                mX.element_type,
+                cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+                byte_alignment=16,
+            )
+            tXsX = thr_copy.partition_D(sX)
+            if row < shape[0]:
+                copy_utils.copy(tXgX, tXsX, is_async=True)
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(0)
+            cute.arch.barrier()
+            cute.autovec_copy(tXsX, tXrX)
+        else:
+            # Direct gmem -> rmem (no smem). OOB lanes for ragged N pull data the
+            # fold's per-element column guard then discards; memory-safe.
+            if row < shape[0]:
+                cute.autovec_copy(tXgX, tXrX)
+
+        # Convert the WHOLE fragment to the accumulator dtype in ONE packed op, into
+        # a reg fragment with the SAME layout as tXrX. For fp16/bf16 this is the
+        # load-bearing perf fix: a per-element scalar conversion caps throughput at
+        # ~half bandwidth, while load().to(acc) emits packed conversion over the
+        # vector. Keeping the layout lets us index value and coordinate with the SAME
+        # (v,rv,m,k) tuple, so argmax indices stay correct.
+        acc_dtype = trait.acc  # accumulator dtype (a compile-time Python class)
+        tXrXf = cute.make_rmem_tensor(tXrX.layout, acc_dtype)
+        tXrXf.store(tXrX.load().to(acc_dtype))
+
+        acc = trait.init()
+        nvec, nrv = const_expr(tXrX.shape[0][0]), const_expr(tXrX.shape[0][1])
+        nrm = const_expr(tXrX.shape[1])
+        nrk = const_expr(tXrX.shape[2])
+        # Even N (common case) -> branch-free fold. Ragged N -> a tile column past
+        # N WRAPS to (row+1, 0) in the identity coordinate, so guard on BOTH the
+        # coordinate's row matching this element's intended row AND col < N. The
+        # wrapped element reports row+1 != erow, so it is correctly excluded; the
+        # column we pass to the trait (argmax index) is then always the true col.
+        # Chunk-local -> global column base for the xcta two-stage split (index
+        # traits only). col_base = (sub_row % C) * sub_N; C=1 -> col_base=0 (folded
+        # away as a compile-time no-op for the normal, non-split case). Compute in the
+        # trait's INDEX dtype: for a huge N the global column reaches N (~4e9), so the
+        # (sub_row % C) * sub_N product overflows Int32 -- the trait carries Int64 then
+        # (traits._idx_sentinel) and this arithmetic must match, or the index wraps
+        # negative before it ever reaches trait.reduce's cast.
+        # col_base only matters for INDEX traits (has .idx); non-index traits ignore the
+        # index arg entirely, so a bare 0 is fine and avoids calling a None dtype. When
+        # it does matter, compute in the trait's index dtype so a huge global column
+        # (up to N ~ 4e9) doesn't overflow Int32 before trait.reduce's cast.
+        idx_dtype = getattr(trait, "idx", None)  # compile-time class (Int32/Int64/None)
+        col_base = (
+            idx_dtype(row % const_expr(self.index_chunks)) * const_expr(shape[1])
+            if const_expr(self.index_chunks > 1 and idx_dtype is not None)
+            else 0
+        )
+        for rk in cutlass.range_constexpr(nrk):
+            for rm in cutlass.range_constexpr(nrm):
+                erow = tXcX[(0, 0), rm, 0][0]
+                for rv in cutlass.range_constexpr(nrv):
+                    for v in cutlass.range_constexpr(nvec):
+                        crd = tXcX[(v, rv), rm, rk]
+                        valid = (
+                            True
+                            if const_expr(is_even)
+                            else (crd[0] == erow) and (crd[1] < shape[1])
+                        )
+                        gcol = (
+                            crd[1] + col_base
+                            if const_expr(self.index_chunks > 1)
+                            else crd[1]
+                        )
+                        acc = trait.reduce(acc, tXrXf[(v, rv), rm, rk], gcol, valid)
+
+        # Cross-thread reduce along the row: warp shuffle, then smem across warps.
+        # Allocate the per-warp reduction buffers from the SAME allocator as sX
+        # (after it), so they don't alias the still-live staging tile.
+        acc = warp_reduce(trait, acc, threads_per_row)
+        warps_per_row = const_expr(threads_per_row // WARP)
+        num_warps = const_expr(self._num_threads() // WARP)
+        rows_per_block = const_expr(num_warps // warps_per_row)
+        if const_expr(self.cluster_n > 1):
+            # CLUSTERED: one combined cross-warp + cross-CTA reduce (replaces the
+            # block reduce). Init the cluster mbarrier, allocate the (warps_per_row,
+            # cluster_n)-moded buffers, cluster_wait so every peer's smem is mapped,
+            # then fold. After this every CTA in the cluster holds the full-row
+            # result; only rank 0 stores (guarded below).
+            cbar = smem.allocate_array(cutlass.Int64, num_elems=1)
+            if tidx == 0:
+                cute.arch.mbarrier_init(cbar, 1)
+            cute.arch.mbarrier_init_fence()
+            cute.arch.cluster_arrive_relaxed()
+            cbufs = [
+                smem.allocate_tensor(
+                    trait.fdtypes[f],
+                    cute.make_ordered_layout(
+                        (rows_per_block, (warps_per_row, self.cluster_n)),
+                        order=(1, 0),
+                    ),
+                    byte_alignment=8,
+                )
+                for f in range(trait.nfields)
+            ]
+            cute.arch.cluster_wait()
+            acc = cluster_reduce(
+                trait, acc, cbufs, cbar, self.cluster_n, warps_per_row, rows_per_block
+            )
+        elif const_expr(warps_per_row > 1):
+            cute.arch.barrier()  # sX reads done before reusing smem
+            bufs = [
+                smem.allocate_tensor(
+                    trait.fdtypes[f], cute.make_layout(num_warps), byte_alignment=8
+                )
+                for f in range(trait.nfields)
+            ]
+            # Reduce within each row's warp group only (multi-row blocks must not
+            # mix rows' warps -- that was the rows/blk=2 corruption).
+            acc = block_reduce(trait, acc, bufs, warps_per_row, rows_per_block)
+
+        # Lane 0 of each row (column coordinate 0) writes the output. final ->
+        # project (true row length project_n) and store one result; not-final
+        # (multi-CTA stage 1) -> store RAW per-field accumulators for stage 2.
+        # `final` is a compile-time constant so it is the OUTER (constexpr) branch;
+        # only the store address is data-dependent (the inner dynamic guard).
+        # Trait calls stay OUT of the dynamic if (they leak the trait object into
+        # the IR flattener) -- compute values first, store under the guard.
+        # Only cluster rank 0 (which owns column tile 0, hence local col 0 == global
+        # col 0) stores; the other peers computed the same full-row result via the
+        # cluster reduce but must not double-write. cluster_n==1 -> the extra guard
+        # is a compile-time True.
+        col0 = tXcX[(0, 0), 0, 0][1]
+        rank0 = const_expr(True) if const_expr(self.cluster_n == 1) else cluster_y == 0
+        store = col0 == 0 and row < shape[0] and rank0
+        if const_expr(self.final):
+            projected = trait.project(acc, acc_dtype(const_expr(self.project_n)))
+            # nouts==1 -> project returns a scalar; nouts==2 (max.dim/min.dim) ->
+            # project returns (value, index), stored to mOuts[0]/mOuts[1]. This is
+            # the ONE-SHOT path only: the row is not split, so the index is already
+            # the true per-row column (no cross-chunk global-index remap needed).
+            if const_expr(self.nouts == 1):
+                result = mOuts[0].element_type(projected)
+                if store:
+                    mOuts[0][row] = result
+            else:
+                results = [
+                    mOuts[f].element_type(projected[f])
+                    for f in range(const_expr(self.nouts))
+                ]
+                if store:
+                    for f in cutlass.range_constexpr(self.nouts):
+                        mOuts[f][row] = results[f]
+        else:
+            vals = [trait.fdtypes[f](acc[f]) for f in range(trait.nfields)]
+            if store:
+                for f in cutlass.range_constexpr(trait.nfields):
+                    mOuts[f][row] = vals[f]
+
+
+_CACHE = {}
+
+
+def _cute_aligned(t, align_bytes):
+    # Mark the gmem pointer as `align_bytes`-aligned so the DSL may emit wide
+    # (128-bit) cp.async loads. from_dlpack defaults to the element's natural
+    # alignment (2 B for fp16), which forces narrow loads and halves bandwidth.
+    # torch allocations are >=256 B aligned, and even-N row stride is a multiple
+    # of the vector width, so 16 B is safe here.
+    # enable_tvm_ffi: fast torch->tvm-ffi C exchange (~0.8us vs ~3.6us capsule).
+    # read-only: only called for the INPUT (via _aligned_in), so a COW input exports
+    # without materializing (see launch._ro).
+    ct = cute.runtime.from_dlpack(
+        _L.ReadOnlyTensorWrapper(t), assumed_align=align_bytes, enable_tvm_ffi=True
+    )
+    ct.element_type = _L.torch2cute[t.dtype]
+    return ct
+
+
+def _align_bytes(x, op):
+    # 16-byte alignment enables the 128-bit load only when the row stride keeps it
+    # (even N); for ragged N the second row may be misaligned, so assume just the
+    # element width and let the per-element-guarded narrow path handle it.
+    N = x.shape[-1]
+    vec = math.gcd(N, 128 // (x.element_size() * 8))
+    return (
+        (vec * x.element_size())
+        if (N % (vec * op._threads_per_row()) == 0)
+        else x.element_size()
+    )
+
+
+def _aligned_in(x, op):
+    return _cute_aligned(x, _align_bytes(x, op))
+
+
+def _aligned_in_dynM(x, op):
+    # DYNAMIC-M input wrapper (mode 0 = rows dynamic, N static). One compiled kernel
+    # serves any M at this N -- no recompile per batch size. N stays static so the
+    # kernel's const_expr vec/tile checks resolve; alignment is N-derived (static).
+    return _L.cute_tensor_dynM(x, align=_align_bytes(x, op), ndim=2, read_only=True)
+
+
+def _cap_cluster_n(N, vec, tpr, want, device):
+    # Cap the requested cluster_n to what is legal + supported:
+    #   - sm_90+ only (Ampere/Ada lack cluster support); Blackwell caps at 8, else 16.
+    #   - each peer CTA must own a distinct, non-empty column tile: tpr*cluster_n must
+    #     not exceed the row's vector-block count (N//vec) -- mirrors quack _cap_cluster_n.
+    if want <= 1:
+        return 1
+    major = torch.cuda.get_device_properties(device).major
+    if major < 9:
+        return 1
+    hw_max = 8 if major == 12 else 16
+    tpr = tpr if tpr is not None else 1
+    max_by_tile = max(1, (N // vec) // max(tpr, 1))
+    return max(1, min(want, hw_max, max_by_tile))
+
+
+def reduce_row(
+    trait,
+    trait_key,
+    x,
+    out_dtype,
+    block=None,
+    tpr=None,
+    nt=None,
+    cp_async=True,
+    cluster_n=1,
+    use_tma=False,
+):
+    assert x.dim() == 2 and x.is_cuda and x.stride(-1) == 1  # noqa: S101
+    M, N = x.shape
+    out = torch.empty(M, device=x.device, dtype=out_dtype)
+    vec = math.gcd(N, 128 // (x.element_size() * 8))
+    cn = _cap_cluster_n(N, vec, tpr, cluster_n, x.device)
+    # TMA gate: the bulk tensor load moves the whole static (tiler_m, N) tile, so it
+    # needs an EVEN tile (N a clean multiple of vec*tpr) and is exclusive with the
+    # cluster split. Silently fall back to the cp.async/direct path otherwise so the
+    # knob never produces a wrong or illegal launch.
+    eff_tpr = tpr if tpr is not None else 0
+    even_tile = (eff_tpr == 0) or (N % (vec * eff_tpr) == 0)
+    tma = bool(use_tma) and cn == 1 and even_tile
+    if tma and torch.cuda.get_device_properties(x.device).major < 9:
+        tma = False  # TMA is sm_90+
+    # DYNAMIC M: only N (+dtype/trait) keys the kernel; the grid reads mX.shape[0]
+    # and the M/output extents are dynamic, so one compile serves all M. The input
+    # alignment is also a pure function of (N, dtype), so it is cached next to the
+    # compiled fn -- on the hot path we skip both the op construction and the
+    # _align_bytes/_threads_per_row math (only the per-call tensor wrap + launch).
+    # tpr/nt are the exposed occupancy knobs (threads-per-row / threads-per-block);
+    # cp_async gates the smem-staged load path; cluster_n splits the row across a
+    # launch cluster. All key the plan. None/True/1 -> the tuned defaults.
+    key = (
+        "row",
+        trait_key,
+        x.dtype,
+        out_dtype,
+        N,
+        trait.nfields,
+        tpr,
+        nt,
+        cp_async,
+        cn,
+        tma,
+    )
+
+    def _build():
+        op = RowReduce(
+            trait,
+            _L.torch2cute[x.dtype],
+            N,
+            tpr_override=tpr,
+            nt_override=nt,
+            cp_async=cp_async,
+            cluster_n=cn,
+            use_tma=tma,
+        )
+        align = _align_bytes(x, op)
+        xin = _L.cute_tensor_dynM(x, align=align, ndim=2, read_only=True)
+        fn = _compile(op, xin, [_L.cute_tensor_dynM(out, ndim=1)], _stream())
+        return (fn, align)
+
+    fn, align = cached_plan(_CACHE, key, _build)
+    xin = _L.cute_tensor_dynM(x, align=align, ndim=2, read_only=True)
+    fn(xin, [_L.cute_tensor_dynM(out, ndim=1)], _stream())
+    return out
+
+
+def reduce_row_2out(trait, trait_key, x, out_dtypes, block=None):
+    # Two-output one-shot row reduction (max.dim/min.dim: value + index). Same K1
+    # kernel as reduce_row but the `final` store writes both projected outputs. Used
+    # ONLY on the one-shot (smem-fits) path: the row is not split, so the projected
+    # index is already the true per-row column with no global-index remap.
+    assert x.dim() == 2 and x.is_cuda and x.stride(-1) == 1  # noqa: S101
+    M, N = x.shape
+    outs = [torch.empty(M, device=x.device, dtype=d) for d in out_dtypes]
+    key = ("row_2out", trait_key, x.dtype, tuple(out_dtypes), N, trait.nfields)
+    mouts = [_L.cute_tensor_dynM(o, ndim=1) for o in outs]
+
+    def _build():
+        op = RowReduce(trait, _L.torch2cute[x.dtype], N, nouts=2)
+        align = _align_bytes(x, op)
+        xin = _L.cute_tensor_dynM(x, align=align, ndim=2, read_only=True)
+        fn = _compile(op, xin, mouts, _stream())
+        return (fn, align)
+
+    fn, align = cached_plan(_CACHE, key, _build)
+    xin = _L.cute_tensor_dynM(x, align=align, ndim=2, read_only=True)
+    fn(xin, mouts, _stream())
+    return tuple(outs)

--- a/torch/_native/ops/reductions/kernel_xcta.py
+++ b/torch/_native/ops/reductions/kernel_xcta.py
@@ -1,0 +1,239 @@
+# TWO-STAGE cross-CTA row reduction for few-row / huge-N reductions (and the M=1
+# reduce-all case), mirroring ATen's Reduce.cuh structure.
+#
+# An earlier design used a SINGLE kernel: grid (C, M), every block reduced a chunk
+# then a semaphore elected one "last" block to combine the C partials. That made
+# ALL C*M blocks run a GPU-scope fence + a redundant finalize after phase 1; for a
+# huge single row (C ~ 1024) those serialized down to ~36% DRAM (confirmed by ncu:
+# 36% dram, 11% sm, 77% warp occupancy -- latency/sync bound, not bandwidth bound).
+# The clean two-stage split removes ALL cross-block sync from the bandwidth-bound
+# pass and beats both the semaphore design and ATen (5.4 TB/s on (1,16M) fp32 =
+# 1.13x ATen; fp16 up to 1.66x).
+#
+#   stage 1: reshape (M, N) -> (M*C, N/C). The vectorized K1 row kernel
+#            (kernel_row) reduces each sub-row to a RAW per-field accumulator
+#            (final=False -> no projection). No cross-block sync -> full bandwidth.
+#   stage 2: ReduceBlock from_partials COMBINES the C partials of each row (one
+#            block per row) and projects ONCE with the true N. Using combine (not
+#            re-reduce) keeps mean/var/norm correct, not just sum.
+#
+# C is chosen so each stage-1 sub-row fits K1's smem tile AND the M*C blocks fill
+# the device. Index traits (argmax/min) do NOT come here -- the dispatcher keeps
+# them on the general kernel (their stage-2 needs a global-index remap not built).
+
+import math
+
+import cuda.bindings.driver as cuda
+
+import cutlass.cute as cute
+from cutlass import const_expr, Float32, Float64, Int32, Int64
+
+import torch
+
+from .._cutedsl import launch as _L
+from .._cutedsl.plan_cache import cached_plan
+from . import (  # safe: kernel_general imports us only lazily
+    kernel_general as _RB,
+    kernel_row as _row,
+)
+
+
+_PART_TORCH = {
+    Float32: torch.float32,
+    Float64: torch.float64,
+    Int32: torch.int32,
+    Int64: torch.int64,
+}
+
+
+_C_MAX = 1 << 22  # cap stage-2 partial count (its combine is a dynamic loop -> cheap)
+# Target stage-1 sub-row length (elements). The reshape (M*C, N/C) puts the WHOLE
+# sub-row of s = N/C elements into ONE K1 block's smem tile, so s trades off directly
+# against occupancy: s at the smem ceiling (~44k fp32 = 175KB) -> ~1 block/SM -> ~3.5
+# TB/s; s ~8-20k -> several blocks/SM -> ~7.3 TB/s on B200 (measured, >aten's 5.8).
+# Below ~4k the stage-2 combine (one block folding C = N/s partials) starts to cost.
+# 8192 sits in the flat top of that curve for both throughput and the ~0.6s compile.
+_SUBROW_TARGET = 8192
+
+
+def _split_C(M, N, vec, sm, smem_budget_elems, subrow_target=None):
+    # Choose C = chunks per output row for the two-stage split. The reshape
+    # (M*C, N/C) requires C | N exactly, i.e. the sub-row length s = N/C must be a
+    # DIVISOR of N that (1) is a multiple of vec (K1 vectorizes the load) and (2) fits
+    # K1's smem tile (s <= smem_budget_elems). We do NOT maximize s -- that pins ~1
+    # block/SM and halves bandwidth. Instead aim for subrow_target (the measured
+    # occupancy sweet spot, default _SUBROW_TARGET) and take the nearest divisor,
+    # searching outward. The search is bounded by the smem budget (~12k candidates)
+    # regardless of N or its factorization -- unlike the old width-1 window around a
+    # single C target, which for a huge N missed divisors tens of thousands apart and
+    # fell to the slow backup (N=4.396e9: divisors bracket the smem ceiling at 87920
+    # and 98125). subrow_target is the exposed knob (autotuner overrides it).
+    target = _SUBROW_TARGET if subrow_target is None else subrow_target
+    step = max(vec, 1)
+    # Floor on sub-row length: below this, stage 1 barely reduces (a subrow of 1 for a
+    # prime N degenerates to C=N partials + a no-op stage 1). Keeps genuinely awkward N
+    # (prime / only tiny divisors) on the backup K0 grid-stride path instead.
+    lo = max(step, 256)
+    hi = min(smem_budget_elems, N)
+    hi -= hi % step
+    if hi < lo:
+        return None
+    tgt = min(max(target - (target % step), lo), hi)
+    # Expand symmetrically from tgt; first divisor of N (that keeps C <= _C_MAX) wins.
+    for d in range(0, hi - lo + step, step):
+        for s in (tgt + d, tgt - d):
+            if lo <= s <= hi and N % s == 0 and N // s <= _C_MAX:
+                return N // s
+    return None
+
+
+class FusedTwoStage:
+    # BOTH stage launches in ONE @cute.jit region -> one cute.compile artifact, one
+    # host-side fn() call. Two cuLaunchKernel still issue on the device (serialized
+    # on the stream, stage 2 sees stage 1's writes), but the expensive Python/
+    # framework dispatch + arg marshalling is paid ONCE instead of twice. Keeps the
+    # GOOD two-stage kernels (full grid, no cluster cap) AND graph-capturability.
+    #
+    # s1 is a kernel_row.RowReduce (final=False); s2 a kernel_general.ReduceBlock
+    # (from_partials). Both expose a bound @cute.kernel `.kernel`; we replicate their
+    # __call__ launch bodies here back-to-back.
+    def __init__(self, s1, s2):
+        self.s1 = s1
+        self.s2 = s2
+
+    @cute.jit
+    def __call__(
+        self, mX: cute.Tensor, parts: list, mOut: cute.Tensor, stream: cuda.CUstream
+    ):
+        s1 = self.s1
+        # --- stage 1 launch (mirrors RowReduce.__call__) ---
+        s1._set_cluster_n()
+        vecsize = const_expr(math.gcd(s1.N, 128 // s1.dtype.width))
+        tiled_copy, tiler_mn, threads_per_row = s1._get_tiled_copy(vecsize=vecsize)
+        num_threads = tiled_copy.size
+        s1.kernel(mX, parts, tiler_mn, tiled_copy, threads_per_row).launch(
+            grid=[cute.ceil_div(mX.shape[0], tiler_mn[0]), 1, 1],
+            block=[num_threads, 1, 1],
+            stream=stream,
+        )
+        # --- stage 2 launch (mirrors ReduceBlock.__call__); reads `parts` ---
+        # Stage-2 grid = one block per output row = mOut.shape[0] (read live, so this
+        # fused kernel serves any M with no recompile). s2 has a single kept dim, so
+        # _decode_offset ignores the extent -- correct for any M.
+        s2 = self.s2
+        s2.kernel(parts, [mOut]).launch(
+            grid=[mOut.shape[0], 1, 1], block=[s2.block, 1, 1], stream=stream
+        )
+
+
+_DEV_SM = {}  # device -> multi_processor_count (get_device_properties is ~1.3us)
+_PLAN = {}  # shape-key -> derived launch plan (everything shape-invariant)
+
+
+def _device_sm(device):
+    sm = _DEV_SM.get(device)
+    if sm is None:
+        sm = torch.cuda.get_device_properties(device).multi_processor_count
+        _DEV_SM[device] = sm
+    return sm
+
+
+def reduce_row_xcta(
+    trait, trait_key, x, out_dtype, block=256, flatten=False, subrow_target=None
+):
+    # FUSED two-stage row reduction (reduce last dim). x: (M, N) contiguous, or (N,)
+    # for reduce-all. Returns (M,) results. flatten=True (reduce-ALL of a 1-D input)
+    # collapses the single (M==1) result to a 0-d scalar; a 2-D (1, N) reduce-DIM
+    # caller leaves flatten=False so the result stays (1,) -- matching aten's shape.
+    #
+    # Both stage launches live in ONE @cute.jit region (FusedTwoStage) -> ONE
+    # cute.compile artifact + ONE host-side fn() call. The two cuLaunchKernel still
+    # issue on the device (serialized on the stream, stage 2 reads stage 1's
+    # partials), but the expensive Python/framework dispatch is paid ONCE instead of
+    # twice. This is what turns the few-row/huge-N regime from ~0.6x ATen (two
+    # separate launches) into ~1.15-1.44x in plain eager -- graph-class perf without
+    # graphs. It also captures into CUDA graphs cleanly.
+    assert x.is_cuda and x.is_contiguous()  # noqa: S101
+    if x.dim() == 1:
+        x = x.view(1, -1)
+    M, N = x.shape
+
+    # DYNAMIC M: the plan (C, ops, compiled fn) depends only on N+dtype+trait, NOT M.
+    # One compiled fused kernel serves any M (e.g. every batch size in a training
+    # loop) with no recompile. M only sizes the grid + scratch, both handled live.
+    # (Stage-1 K1 casts its block-index tile coordinate to Int64, so the >2^31 M*N
+    # offset overflow that previously broke large-M is fixed -- see kernel_row.)
+    # subrow_target is in the key: it changes C (the reshape split), so distinct
+    # values compile distinct plans. None -> the _SUBROW_TARGET heuristic.
+    pkey = (trait_key, x.dtype, out_dtype, N, block, subrow_target, str(x.device))
+
+    def _build():
+        sm = _device_sm(x.device)
+        vec = math.gcd(N, 128 // (x.element_size() * 8))
+        # M only sizes the device-fill heuristic in _split_C; C is fixed in the plan
+        # (it sets stage-1's sub-row length N//C and stage-2's partial count), so the
+        # same C must be used for every M -> derive it once here.
+        C = _split_C(M, N, vec, sm, _RB._SMEM_BUDGET // x.element_size(), subrow_target)
+        if C is None:
+            # Prime / poorly-factored N: no clean reshape split. Plan is None ->
+            # caller uses the K0 general kernel (any N, no reshape, O(1) compile).
+            return None
+        # index_chunks=C so an INDEX trait's stage-1 fold accumulates the GLOBAL
+        # column (chunk-local + chunk base), making the partial index absolute -- so
+        # stage-2 combine needs no remap (mirrors ATen carrying the absolute index).
+        # For non-index traits C is harmless (the index arg is ignored).
+        s1 = _row.RowReduce(
+            trait, _L.torch2cute[x.dtype], N // C, final=False, index_chunks=C
+        )
+        s2 = _RB.ReduceBlock(
+            trait,
+            count=C,
+            num_o=M,
+            red_pairs=[(C, 1)],
+            kept_pairs=[(M, C)],
+            from_partials=True,
+            project_n=N,
+            nouts=1,
+            final=True,
+            block=block,
+            dyn_num_o=True,
+        )
+        fop = FusedTwoStage(s1, s2)
+        # Dynamic-M seed wrappers; the compiled fn then serves any M.
+        sub0 = x.reshape(M * C, N // C)
+        parts0 = [
+            torch.empty(M * C, device=x.device, dtype=_PART_TORCH[trait.fdtypes[f]])
+            for f in range(trait.nfields)
+        ]
+        cparts0 = [_L.cute_tensor_dynM(p, ndim=1) for p in parts0]
+        out0 = torch.empty(M, device=x.device, dtype=out_dtype)
+        fn = _L.compile(
+            fop,
+            _row._aligned_in_dynM(sub0, s1),
+            cparts0,
+            _L.cute_tensor_dynM(out0, ndim=1),
+            _L.stream(),
+        )
+        return (C, s1, fn)
+
+    plan = cached_plan(_PLAN, pkey, _build)
+    if plan is None:  # memoized refusal (prime N) -> caller uses K0
+        return None
+    C, s1, fn = plan
+
+    # One fused launch. Scratch partials sized to THIS M*C (allocated per call since M
+    # varies); input + partials + output all dynamic-M so the cached kernel serves any
+    # M. Stage 1 folds sub-rows -> raw partials; stage 2 combines per row.
+    sub = x.reshape(M * C, N // C)
+    parts = [
+        torch.empty(M * C, device=x.device, dtype=_PART_TORCH[trait.fdtypes[f]])
+        for f in range(trait.nfields)
+    ]
+    out = torch.empty(M, device=x.device, dtype=out_dtype)
+    fn(
+        _row._aligned_in_dynM(sub, s1),
+        [_L.cute_tensor_dynM(p, ndim=1) for p in parts],
+        _L.cute_tensor_dynM(out, ndim=1),
+        _L.stream(),
+    )
+    return out.view(()) if flatten and out.numel() == 1 and M == 1 else out

--- a/torch/_native/ops/reductions/overrides.py
+++ b/torch/_native/ops/reductions/overrides.py
@@ -1,0 +1,585 @@
+"""aten reduction overrides backed by the CuteDSL reduction kernels.
+
+Registers CUDA overrides for a small set of reduction ops via the _native
+registry. Each override is a (cond, impl) pair: ``cond`` decides per-call whether
+we should serve the call; when it returns False the dispatcher falls back to the
+normal aten kernel. ``cond`` gates on capability (device, arch, dtype, contiguity,
+valid dim) AND on whether one of our FAST kernels (row K1/xcta, col K2) can serve
+the post-TI-coalesce geometry (see ``_geometry_supported`` / kernel_general
+``fast_kind``). The general K0 kernel is correct for any geometry but ~5-8x slower
+than aten, so a K0-only geometry is DECLINED to aten rather than served -- gating
+here IS a performance decision, because running K0 would regress vs the very kernel
+we fall back to. Host-bound cases on the served (fast) regimes are addressed
+elsewhere (CUDA-graph capture, dynamic-M).
+
+The single-output value/sum reductions are wired here: ``sum`` and ``mean``
+(fp32-accumulated, optional out ``dtype``) plus ``amax`` / ``amin`` / ``prod``
+(output dtype follows the input). The remaining reductions (var/std, norm, arg*,
+*_mean, aminmax, all/any, count_nonzero) carry an index or a second output and
+follow the same (cond, impl) template; they are added incrementally as the
+trait/kernel support for those shapes lands.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from ... import cutedsl_utils as cu
+from ...utils import capability as cap
+from ...utils.lazy import LazyModule
+
+
+if TYPE_CHECKING:
+    from .._cutedsl import traits as T
+    from . import kernel_general as kg
+else:
+    # T (trait library) and kg (general-kernel dispatcher) import `cutlass`,
+    # which `import torch` must not do (the lazy-DSL-import contract; see
+    # test_no_dsl_imports_after_import_torch). Neither is touched by a `cond`
+    # or by registration -- only by the `*_impl` functions on a real
+    # (non-declined) call, where the DSL runtime is present. Lazy module
+    # proxies keep the `T.SumOps` / `kg.reduce_dim` call sites unchanged.
+    T = LazyModule("torch._native.ops._cutedsl.traits")
+    kg = LazyModule("torch._native.ops.reductions.kernel_general")
+
+
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32, torch.float64)
+
+
+def _acc_policy():
+    # Lazy (its values are `cutlass` dtypes): resolved on first real call so
+    # `import torch` stays cutlass-free. INPUT torch dtype -> (accumulator cute
+    # dtype, torch dtype the kernel writes). Kernel out dtype == the accumulator
+    # dtype; the impl casts the result to aten's final output dtype. The one
+    # place to extend coverage: add a row plus matching trait/kernel support.
+    import cutlass
+
+    return {
+        torch.float16: (cutlass.Float32, torch.float32),
+        torch.bfloat16: (cutlass.Float32, torch.float32),
+        torch.float32: (cutlass.Float32, torch.float32),
+        torch.float64: (cutlass.Float64, torch.float64),
+    }
+
+
+def _normalize_dims(dim, ndim: int):
+    """aten dim arg (None | int | list[int]) -> sorted set of non-negative axes.
+
+    Returns None for "reduce all" (dim is None or empty list). Caller must have
+    already validated the dims via `_dims_ok` (this assumes in-range, so it is
+    only ever invoked from `*_impl`, never from `cond`)."""
+    if dim is None:
+        return None
+    dims = [dim] if isinstance(dim, int) else list(dim)
+    if len(dims) == 0:
+        return None
+    return {d % ndim for d in dims}
+
+
+def _dims_ok(dim, ndim: int) -> bool:
+    # Decline (-> fall back to aten) any dim arg aten would reject or that our
+    # kernels can't serve, WITHOUT raising -- a cond must never throw. Mirrors
+    # aten's dim validation just enough to defer: every reduced axis must be in
+    # [-ndim, ndim), no duplicates (after normalization), and ndim must be small
+    # enough that aten doesn't itself raise the >64-dim error. For a 0-dim
+    # (scalar) tensor ndim==0: only dim in {None, [], 0, -1} reduce-all is valid;
+    # the modulo math is undefined, so just decline scalars (aten handles them
+    # trivially and they are not a perf concern).
+    if ndim == 0:
+        return False
+    if ndim > 64:
+        return False
+    if dim is None:
+        return True
+    dims = [dim] if isinstance(dim, int) else list(dim)
+    if len(dims) == 0:
+        return True
+    for d in dims:
+        if d < -ndim or d >= ndim:  # out of range -> let aten raise
+            return False
+    norm = [d % ndim for d in dims]
+    if len(set(norm)) != len(norm):  # duplicate dims -> let aten raise
+        return False
+    return True
+
+
+def _geometry_supported(x: torch.Tensor, dim, nouts=1, has_index=False) -> bool:
+    # Gate on whether our FAST kernels (row K1/xcta, col K2) can serve this call --
+    # NOT merely whether we are correct. The K0 general kernel is correct for any
+    # geometry but ~5-8x slower than aten, so declining a K0-only geometry to aten
+    # is a WIN, not a fallback. We classify the POST-TI-coalesce geometry (via
+    # kernel_general.fast_kind, the SAME source of truth the router uses) so a
+    # contiguous n-D reduction that coalesces to a fast row/col (e.g. (A,B,C) over
+    # dim 2) is served, while a genuinely irregular one (transpose, mixed multi-run,
+    # gapped) declines to aten. Reduce-all (dim None/empty) is always fast (xcta).
+    # K0 needs contiguity for its flat-offset addressing; a non-contiguous input is
+    # neither fast-serviceable nor K0-serviceable here, so decline. A COW input no
+    # longer needs a cond check: the kernels export it read-only via
+    # ReadOnlyTensorWrapper (launch._ro). dim validity is checked by _dims_ok.
+    if not (x.is_contiguous() and x.numel() > 0):
+        return False
+    red = _normalize_dims(dim, x.dim())
+    if red is None:  # reduce-all -> xcta / two-stage: always a fast path
+        return True
+    # kg is the lazy proxy bound at module top; touching it here (in a cond, i.e. a
+    # real call) fires the cutlass import, which is fine -- registration never calls
+    # this. Same TI decode + fast_kind the router uses, so gate and router agree.
+    red_pairs, kept_pairs = kg._ti_pairs(x, kg._probe(x, red))
+    return kg.fast_kind(red_pairs, kept_pairs, nouts, has_index) is not None
+
+
+def _keepdim_reshape(out: torch.Tensor, x_shape, red: set | None, keepdim: bool):
+    # Our kernels return the NON-keepdim result. Restore size-1 reduced dims when
+    # keepdim=True so the output matches aten's shape exactly.
+    if not keepdim:
+        return out
+    if red is None:
+        target = [1] * len(x_shape)
+    else:
+        target = [1 if i in red else s for i, s in enumerate(x_shape)]
+    return out.reshape(target)
+
+
+# ----------------------------------------------------------- shared cond helpers
+
+
+def _out_dtype(self: torch.Tensor, dtype) -> torch.dtype:
+    # aten output-dtype rule for float reductions: the explicit `dtype` if given,
+    # else the input's own dtype (fp16 in -> fp16 out). Our kernels accumulate in
+    # fp32 internally and we cast the result to this at the end.
+    return dtype if dtype is not None else self.dtype
+
+
+def _supported_out_dtype(dtype) -> bool:
+    # We can deliver any of our supported float out dtypes (we accumulate in fp32
+    # and cast down). A non-float requested dtype falls back to aten.
+    return dtype is None or dtype in _SUPPORTED_DTYPES
+
+
+def _base_cond(self, dim, nouts=1, has_index=False) -> bool:
+    # Shared capability gate for every reduction override: not traced (fake/meta) +
+    # CUDA + sm9/10 + a supported float dtype + current device + valid dim +
+    # FAST-serviceable geometry. Per-op conds pass nouts/has_index (they know these
+    # statically) so the geometry gate matches the op's actual fast-path options
+    # (K2 col is single-output value-only; index/2-out ops route only row/xcta or
+    # K0 -> decline). Per-op conds add only their extra checks (e.g. an out dtype=
+    # argument). Never raises -- a cond that throws would crash the dispatcher
+    # instead of falling back. (COW is no longer gated: inputs export read-only,
+    # see launch._ro.)
+    return (
+        not cap.is_traced(self)
+        and cap.device_ok(self)
+        and self.dtype in _SUPPORTED_DTYPES
+        and cap.on_current_device(self)
+        and _dims_ok(dim, self.dim())
+        and _geometry_supported(self, dim, nouts, has_index)
+    )
+
+
+def _run1(make_trait, key, self, red, keepdim, out_torch_dtype):
+    # Run a single-output trait through the dispatcher (TI-driven general path +
+    # fast paths) and restore keepdim. acc/kernel-out come from _ACC_POLICY; the
+    # final result is cast to `out_torch_dtype` (aten's output dtype for this op).
+    # Every single-output reduction override funnels through here.
+    acc, kout = _acc_policy()[self.dtype]
+    trait = make_trait(acc)
+    if red is None:
+        out = kg.reduce_all(trait, key, self, kout)
+    else:
+        out = kg.reduce_dim(trait, key, self, sorted(red), kout)
+    out = _keepdim_reshape(out, self.shape, red, keepdim)
+    return out.to(out_torch_dtype)
+
+
+# --- sum / mean: fp32-accumulated, optional out dtype= (else input dtype). ---
+
+
+def _sum_cond(self, dim=None, keepdim=False, *, dtype=None):
+    return _base_cond(self, dim) and _supported_out_dtype(dtype)
+
+
+def _sum_impl(self, dim=None, keepdim=False, *, dtype=None):
+    red = _normalize_dims(dim, self.dim())
+    odt = _out_dtype(self, dtype)
+    return _run1(lambda acc: T.SumOps(acc=acc), "sum", self, red, keepdim, odt)
+
+
+def _mean_cond(self, dim=None, keepdim=False, *, dtype=None):
+    return _base_cond(self, dim) and _supported_out_dtype(dtype)
+
+
+def _mean_impl(self, dim=None, keepdim=False, *, dtype=None):
+    red = _normalize_dims(dim, self.dim())
+    odt = _out_dtype(self, dtype)
+    return _run1(lambda acc: T.MeanOps(acc=acc), "mean", self, red, keepdim, odt)
+
+
+# --- amax / amin / prod: single-output VALUE reductions; output dtype follows the
+# input (amax/amin) or the optional out dtype= (prod). ---
+
+
+def _amax_impl(self, dim=(), keepdim=False):
+    red = _normalize_dims(dim, self.dim())
+    return _run1(lambda acc: T.AMaxOps(acc=acc), "amax", self, red, keepdim, self.dtype)
+
+
+def _amin_impl(self, dim=(), keepdim=False):
+    red = _normalize_dims(dim, self.dim())
+    return _run1(lambda acc: T.AMinOps(acc=acc), "amin", self, red, keepdim, self.dtype)
+
+
+def _prod_impl(self, dim, keepdim=False, *, dtype=None):
+    red = _normalize_dims(dim, self.dim())
+    odt = _out_dtype(self, dtype)
+    return _run1(lambda acc: T.ProdOps(acc=acc), "prod", self, red, keepdim, odt)
+
+
+def _amax_cond(self, dim=(), keepdim=False):
+    return _base_cond(self, dim)
+
+
+def _amin_cond(self, dim=(), keepdim=False):
+    return _base_cond(self, dim)
+
+
+def _prod_cond(self, dim, keepdim=False, *, dtype=None):
+    return _base_cond(self, dim) and _supported_out_dtype(dtype)
+
+
+# --- Group B: INDEX reductions. argmax / argmin return the winning index (int64);
+# max.dim / min.dim return (values, indices). The traits carry the index in a
+# second accumulator field (has_index), so these route through the index-aware
+# dispatcher paths (two-stage K0 / reduce_dim2) rather than the value fast paths.
+# Tie-break and NaN handling match aten (first max/min, first NaN). ---
+
+
+def _idx_width(self, red):
+    # Choose the in-kernel INDEX dtype for an argmax/argmin/max.dim/min.dim: the
+    # winning position ranges over the REDUCED extent, so Int32 overflows once that
+    # reaches 2^31. Return (cute idx dtype, torch kernel-out dtype, key tag). Int32 is
+    # the default (cheaper partials + shuffle); Int64 only when needed. red is the set
+    # of reduced axes (None = reduce-all).
+    import cutlass
+
+    if red is None:
+        extent = self.numel()
+    else:
+        extent = 1
+        for d in red:
+            extent *= self.shape[d]
+    if extent > (1 << 31) - 1:
+        return cutlass.Int64, torch.int64, "i64"
+    return cutlass.Int32, torch.int32, "i32"
+
+
+def _run_arg(make_trait, key, self, red, keepdim):
+    # Single-output INDEX reduction (argmax/argmin). aten indices are int64; the kernel
+    # emits its index field (Int32 or, for a huge reduced extent, Int64 -- see
+    # _idx_width) and we cast the result up to int64. acc dtype is the value
+    # accumulator (from _ACC_POLICY).
+    acc, _ = _acc_policy()[self.dtype]
+    idx_cute, idx_torch, tag = _idx_width(self, red)
+    trait = make_trait(acc, idx_cute)
+    key = key + tag  # distinct idx width -> distinct compiled kernel
+    if red is None:
+        out = kg.reduce_all(trait, key, self, idx_torch)
+    else:
+        out = kg.reduce_dim(trait, key, self, sorted(red), idx_torch)
+    out = _keepdim_reshape(out, self.shape, red, keepdim)
+    return out.to(torch.int64)
+
+
+def _run_dim2(make_trait, key, self, dim, keepdim):
+    # Two-output reduction over a single dim (max.dim/min.dim): (values, indices).
+    # Values keep the input dtype, indices are int64 (kernel emits Int32/Int64 per
+    # _idx_width -- Int64 when the reduced dim can exceed the Int32 range).
+    acc, kout = _acc_policy()[self.dtype]
+    red = {dim % self.dim()}
+    idx_cute, idx_torch, tag = _idx_width(self, red)
+    vals, idxs = kg.reduce_dim2(
+        make_trait(acc, idx_cute), key + tag, self, sorted(red), [kout, idx_torch]
+    )
+    vals = _keepdim_reshape(vals, self.shape, red, keepdim).to(self.dtype)
+    idxs = _keepdim_reshape(idxs, self.shape, red, keepdim).to(torch.int64)
+    return vals, idxs
+
+
+def _argmax_impl(self, dim=None, keepdim=False):
+    red = _normalize_dims(dim, self.dim())
+    return _run_arg(
+        lambda acc, idx: T.ArgMaxOps(acc=acc, idx=idx), "argmax", self, red, keepdim
+    )
+
+
+def _argmin_impl(self, dim=None, keepdim=False):
+    red = _normalize_dims(dim, self.dim())
+    return _run_arg(
+        lambda acc, idx: T.ArgMinOps(acc=acc, idx=idx), "argmin", self, red, keepdim
+    )
+
+
+def _max_dim_impl(self, dim, keepdim=False):
+    return _run_dim2(
+        lambda acc, idx: T.MaxDimOps(acc=acc, idx=idx), "max.dim", self, dim, keepdim
+    )
+
+
+def _min_dim_impl(self, dim, keepdim=False):
+    return _run_dim2(
+        lambda acc, idx: T.MinDimOps(acc=acc, idx=idx), "min.dim", self, dim, keepdim
+    )
+
+
+def _argmax_cond(self, dim=None, keepdim=False):
+    return _base_cond(self, dim, has_index=True)
+
+
+def _argmin_cond(self, dim=None, keepdim=False):
+    return _base_cond(self, dim, has_index=True)
+
+
+def _max_dim_cond(self, dim, keepdim=False):
+    # max.dim/min.dim take a required single int dim (not a list); _base_cond's
+    # _dims_ok accepts the int form and declines scalars / out-of-range.
+    return _base_cond(self, dim, nouts=2, has_index=True)
+
+
+def _min_dim_cond(self, dim, keepdim=False):
+    return _base_cond(self, dim, nouts=2, has_index=True)
+
+
+# --- Group C: single-output reductions with a parameter or a non-float output.
+# var/std (Welford + correction; std = sqrt(var)), linalg_vector_norm (ord selects
+# the trait), all/any (bool output), count_nonzero (int64 output). All accumulate in
+# the float _ACC_POLICY acc and cast the projected value to aten's output dtype. ---
+
+
+def _correction(correction, unbiased=None):
+    # aten var/std correction: explicit `correction` wins; else `unbiased` (the old
+    # bool API) maps True->1 / False->0; default unbiased -> 1.
+    if correction is not None:
+        return correction
+    if unbiased is None:
+        return 1
+    return 1 if unbiased else 0
+
+
+def _var_impl(self, dim=None, *, correction=None, keepdim=False):
+    red = _normalize_dims(dim, self.dim())
+    c = _correction(correction)
+    # `correction` is baked into the kernel as a const_expr, so it MUST be in the
+    # trait_key -- else the first-compiled correction is reused for all others.
+    return _run1(
+        lambda acc: T.WelfordOps(correction=c, acc=acc),
+        f"var{c}",
+        self,
+        red,
+        keepdim,
+        self.dtype,
+    )
+
+
+def _std_impl(self, dim=None, *, correction=None, keepdim=False):
+    red = _normalize_dims(dim, self.dim())
+    c = _correction(correction)
+    return _run1(
+        lambda acc: T.WelfordOps(correction=c, take_sqrt=True, acc=acc),
+        f"std{c}",
+        self,
+        red,
+        keepdim,
+        self.dtype,
+    )
+
+
+# linalg_vector_norm ord -> trait factory. inf/-inf are max/min |x| (AbsMax/AbsMin);
+# finite p uses NormOps(p). ord=0 (count nonzero) is NOT handled here -> falls back.
+def _norm_trait(ord_val):
+    if ord_val == float("inf"):
+        return lambda acc: T.AbsMaxOps(acc=acc)
+    if ord_val == float("-inf"):
+        return lambda acc: T.AbsMinOps(acc=acc)
+    return lambda acc: T.NormOps(float(ord_val), acc=acc)
+
+
+def _vector_norm_impl(self, ord=2, dim=None, keepdim=False, *, dtype=None):
+    red = _normalize_dims(dim, self.dim())
+    odt = _out_dtype(self, dtype)
+    return _run1(_norm_trait(ord), f"vnorm{ord}", self, red, keepdim, odt)
+
+
+def _all_impl(self, dim, keepdim=False):
+    red = _normalize_dims(dim, self.dim())
+    return _run1(lambda acc: T.AllOps(acc=acc), "all", self, red, keepdim, torch.bool)
+
+
+def _any_impl(self, dim, keepdim=False):
+    red = _normalize_dims(dim, self.dim())
+    return _run1(lambda acc: T.AnyOps(acc=acc), "any", self, red, keepdim, torch.bool)
+
+
+def _count_nonzero_impl(self, dim):
+    red = _normalize_dims(dim, self.dim())
+    return _run1(
+        lambda acc: T.CountNonzeroOps(acc=acc), "cnz", self, red, False, torch.int64
+    )
+
+
+def _var_cond(self, dim=None, *, correction=None, keepdim=False):
+    return _base_cond(self, dim)
+
+
+def _std_cond(self, dim=None, *, correction=None, keepdim=False):
+    return _base_cond(self, dim)
+
+
+def _vector_norm_cond(self, ord=2, dim=None, keepdim=False, *, dtype=None):
+    # ord=0 is a nonzero-count, not a |x|**p norm -> let aten handle it.
+    return _base_cond(self, dim) and ord != 0 and _supported_out_dtype(dtype)
+
+
+def _all_cond(self, dim, keepdim=False):
+    return _base_cond(self, dim)
+
+
+def _any_cond(self, dim, keepdim=False):
+    return _base_cond(self, dim)
+
+
+def _count_nonzero_cond(self, dim):
+    return _base_cond(self, dim)
+
+
+# --- Group D: two-output VALUE reductions (both outputs float, input dtype).
+# var_mean / std_mean (Welford -> (var|std, mean)) and aminmax (-> (min, max)).
+# Same reduce_dim2 path as max.dim/min.dim but both outputs are values, not an
+# index, so they cast to the input dtype rather than int64. ---
+
+
+def _run_dim2_vals(make_trait, key, self, dim, keepdim):
+    # Two FLOAT-output reduction. dim None -> reduce-all (scalar pair); else reduce
+    # that axis set. reduce_dim2 takes dims=None directly for reduce-all. Both
+    # outputs cast to the input dtype.
+    acc, kout = _acc_policy()[self.dtype]
+    red = _normalize_dims(dim, self.dim())
+    dims = None if red is None else sorted(red)
+    o0, o1 = kg.reduce_dim2(make_trait(acc), key, self, dims, [kout, kout])
+    o0 = _keepdim_reshape(o0, self.shape, red, keepdim).to(self.dtype)
+    o1 = _keepdim_reshape(o1, self.shape, red, keepdim).to(self.dtype)
+    return o0, o1
+
+
+def _var_mean_impl(self, dim=None, *, correction=None, keepdim=False):
+    c = _correction(correction)
+    return _run_dim2_vals(
+        lambda acc: T.VarMeanOps(correction=c, acc=acc),
+        f"varmean{c}",
+        self,
+        dim,
+        keepdim,
+    )
+
+
+def _std_mean_impl(self, dim=None, *, correction=None, keepdim=False):
+    c = _correction(correction)
+    return _run_dim2_vals(
+        lambda acc: T.VarMeanOps(correction=c, take_sqrt=True, acc=acc),
+        f"stdmean{c}",
+        self,
+        dim,
+        keepdim,
+    )
+
+
+def _aminmax_impl(self, *, dim=None, keepdim=False):
+    return _run_dim2_vals(
+        lambda acc: T.AMinMaxOps(acc=acc), "aminmax", self, dim, keepdim
+    )
+
+
+def _var_mean_cond(self, dim=None, *, correction=None, keepdim=False):
+    return _base_cond(self, dim, nouts=2)
+
+
+def _std_mean_cond(self, dim=None, *, correction=None, keepdim=False):
+    return _base_cond(self, dim, nouts=2)
+
+
+def _aminmax_cond(self, *, dim=None, keepdim=False):
+    # aminmax with dim=None reduces ALL dims to a scalar pair; _dims_ok handles
+    # None (reduce-all) and declines scalars / bad dims.
+    return _base_cond(self, dim, nouts=2)
+
+
+def register_reduction_overrides() -> None:
+    # CUDA overrides; cu.register_op_override short-circuits when the CuteDSL
+    # runtime is unavailable, so this is safe to call unconditionally at import.
+    cu.register_op_override(
+        "aten", "sum.dim_IntList", "CUDA", cond=_sum_cond, impl=_sum_impl
+    )
+    cu.register_op_override(
+        "aten", "mean.dim", "CUDA", cond=_mean_cond, impl=_mean_impl
+    )
+    # Group A: amax / amin / prod (single-output value reductions).
+    cu.register_op_override("aten", "amax", "CUDA", cond=_amax_cond, impl=_amax_impl)
+    cu.register_op_override("aten", "amin", "CUDA", cond=_amin_cond, impl=_amin_impl)
+    cu.register_op_override(
+        "aten", "prod.dim_int", "CUDA", cond=_prod_cond, impl=_prod_impl
+    )
+    # Group B: argmax / argmin (int64 index) and max.dim / min.dim (values, indices).
+    cu.register_op_override(
+        "aten", "argmax", "CUDA", cond=_argmax_cond, impl=_argmax_impl
+    )
+    cu.register_op_override(
+        "aten", "argmin", "CUDA", cond=_argmin_cond, impl=_argmin_impl
+    )
+    cu.register_op_override(
+        "aten", "max.dim", "CUDA", cond=_max_dim_cond, impl=_max_dim_impl
+    )
+    cu.register_op_override(
+        "aten", "min.dim", "CUDA", cond=_min_dim_cond, impl=_min_dim_impl
+    )
+    # Group C: var / std (correction), linalg_vector_norm (ord), all / any (bool
+    # output), count_nonzero (int64 output). Single-output, float input.
+    cu.register_op_override(
+        "aten", "var.correction", "CUDA", cond=_var_cond, impl=_var_impl
+    )
+    cu.register_op_override(
+        "aten", "std.correction", "CUDA", cond=_std_cond, impl=_std_impl
+    )
+    cu.register_op_override(
+        "aten",
+        "linalg_vector_norm",
+        "CUDA",
+        cond=_vector_norm_cond,
+        impl=_vector_norm_impl,
+    )
+    cu.register_op_override("aten", "all.dim", "CUDA", cond=_all_cond, impl=_all_impl)
+    cu.register_op_override("aten", "any.dim", "CUDA", cond=_any_cond, impl=_any_impl)
+    cu.register_op_override(
+        "aten",
+        "count_nonzero.dim_IntList",
+        "CUDA",
+        cond=_count_nonzero_cond,
+        impl=_count_nonzero_impl,
+    )
+    # Group D: var_mean / std_mean (correction) and aminmax -- two float outputs.
+    cu.register_op_override(
+        "aten",
+        "var_mean.correction",
+        "CUDA",
+        cond=_var_mean_cond,
+        impl=_var_mean_impl,
+    )
+    cu.register_op_override(
+        "aten",
+        "std_mean.correction",
+        "CUDA",
+        cond=_std_mean_cond,
+        impl=_std_mean_impl,
+    )
+    cu.register_op_override(
+        "aten", "aminmax", "CUDA", cond=_aminmax_cond, impl=_aminmax_impl
+    )

--- a/torch/_native/registry.py
+++ b/torch/_native/registry.py
@@ -355,6 +355,83 @@ def _aten_schema_tail(op_symbol: str) -> str:
     return f"({args}"
 
 
+def _same_dtype_kind(a: torch.dtype, b: torch.dtype) -> bool:
+    # Same promotion category (bool / integer / floating / complex). Used to gate the
+    # scalar-fallback down-cast: only narrow within a kind, never across one.
+    def kind(d: torch.dtype) -> int:
+        if d == torch.bool:
+            return 0
+        if d.is_complex:
+            return 3
+        return 2 if d.is_floating_point else 1
+
+    return kind(a) == kind(b)
+
+
+def _scalar_arg_coercer(overload: "torch._ops.OpOverload | None"):
+    """Build a fn ``args -> (coerced_args, cast_dtype)`` that wraps Python-number args
+    sitting in Tensor-typed positional slots into 0-d tensors, or None if the op has no
+    such slots. ``cast_dtype`` is aten's weak-promotion result dtype; the caller casts
+    the fallback's output to it (a no-op in the common case), unless the output is bool.
+
+    aten coerces a Python number passed where a Tensor is expected (e.g. ``x + 0.5``
+    dispatches ``add.Tensor(Tensor, float)``, and ``2.0 - x`` puts the number in
+    ``self``) in its UNBOXED arg-parsing layer, ABOVE the dispatcher. Our router
+    intercepts at the backend key with the number already in hand, and the captured
+    fallback's ``call_boxed`` -- which expects a real Tensor in that slot -- rejects it.
+    A Python number is a "weak" wrapped-number operand whose VALUE is held at full
+    precision while only its dtype CATEGORY participates in promotion, and aten computes
+    in fp32 opmath. There is no Python API to set TensorImpl's wrapped-number flag, so we
+    reproduce both halves separately:
+
+      * VALUE: wrap at NATURAL precision (``torch.as_tensor(num)``: float->f64, int->i64,
+        bool->bool, complex->c128). This never rounds the number, so ``fp16 + (-70000.0)``
+        stays -10000 (computed in fp32) instead of overflowing to -inf, and ``fp16_0d /
+        1e5`` keeps the 1e5 exact instead of rounding it to inf.
+      * DTYPE: fold ``torch.result_type`` over the RAW operands (numbers stay numbers so
+        the weak rule applies: ``uint8_0d + 1 -> uint8``, ``int + 0.5 -> float``) and cast
+        the result to it. Against a dim>0 tensor the natural wrap already yields this dtype
+        (the cast is a no-op); against only 0-d operands the natural wrap over-promotes
+        (``uint8_0d + 1 -> int64``) and the cast corrects it. Comparisons output bool
+        regardless of operand dtype, so the caller skips the cast when the result is bool.
+
+    Schema is static (which slots are Tensors); args are read per call.
+    """
+    if overload is None:
+        return None
+    tensor_slots = [
+        i
+        for i, a in enumerate(overload._schema.arguments)
+        if str(a.type) in ("Tensor", "Tensor?")  # not Tensor[] / TensorList
+    ]
+    if not tensor_slots:
+        return None
+
+    def coerce(args):
+        scalar_slots = [
+            i
+            for i in tensor_slots
+            if i < len(args) and isinstance(args[i], (bool, int, float, complex))
+        ]
+        if not scalar_slots:
+            return args, None
+        operands = [
+            a for a in args if isinstance(a, (torch.Tensor, bool, int, float, complex))
+        ]
+        acc = operands[0]
+        for b in operands[1:]:
+            acc = torch.empty((), dtype=torch.result_type(acc, b))
+        cast_dtype = (
+            acc.dtype if isinstance(acc, torch.Tensor) else torch.as_tensor(acc).dtype
+        )
+        out = list(args)
+        for i in scalar_slots:
+            out[i] = torch.as_tensor(args[i])
+        return tuple(out), cast_dtype
+
+    return coerce
+
+
 def _define_native_op_once(name: str, op_symbol: str) -> None:
     # Invariant: callers must only install the eager router at a real backend
     # dispatch key (CPU, CUDA, XPU, ...). The fake kernel below redispatches
@@ -908,6 +985,9 @@ def _register_overrides_from_graph(
     # otherwise appear in aten's backward formulas (e.g. bmm's backward
     # calls bmm, which would route back to us).
     fallback_kernel = torch.library.get_kernel(f"aten::{op_symbol}", dispatch_key)
+    # Python numbers passed into Tensor-typed slots (e.g. x + 0.5) reach us
+    # un-coerced; the boxed fallback needs them wrapped. None if no Tensor slots.
+    _coerce_scalars = _scalar_arg_coercer(overload)
 
     # Build the router closures. Both share a first-match-wins loop over
     # `cond_impl`; they differ only in
@@ -972,7 +1052,25 @@ def _register_overrides_from_graph(
 
         result = _dispatch(args, kwargs, swallow_cond_exceptions=False)
         if result is _NO_MATCH:
-            return _fallback.call_boxed(keyset, *args, **kwargs)
+            cast_dtype = None
+            if _coerce_scalars is not None:
+                args, cast_dtype = _coerce_scalars(args)
+            out = _fallback.call_boxed(keyset, *args, **kwargs)
+            # The natural-precision scalar wrap can OVER-PROMOTE against 0-d operands
+            # (uint8_0d + 1 -> int64, should stay uint8); cast down to aten's
+            # weak-promotion dtype. Only when the output and that dtype are the SAME KIND
+            # (both int, or both float): a differing kind means the OP changed category
+            # (div maps int -> float), so result_type is not the output dtype and casting
+            # to it would truncate (div(-10, 9) -> 1 instead of 1.11). This also skips
+            # bool comparison outputs (kind mismatch vs a numeric result_type).
+            if (
+                cast_dtype is not None
+                and isinstance(out, torch.Tensor)
+                and out.dtype != cast_dtype
+                and _same_dtype_kind(out.dtype, cast_dtype)
+            ):
+                out = out.to(cast_dtype)
+            return out
         return result
 
     def compile_router(*args, **kwargs):

--- a/torch/_native/utils/__init__.py
+++ b/torch/_native/utils/__init__.py
@@ -1,0 +1,10 @@
+# General, DSL-agnostic utilities shared by all torch._native op families. Modules
+# here must NOT import any DSL runtime (cutlass, triton, tvm_ffi) at module scope --
+# they are imported during override registration / cond evaluation, which the
+# lazy-DSL-import contract keeps free of the DSL toolchain (see
+# test_no_dsl_imports_after_import_torch and the README's import note).
+
+from . import capability, lazy
+
+
+__all__ = ["capability", "lazy"]

--- a/torch/_native/utils/capability.py
+++ b/torch/_native/utils/capability.py
@@ -1,0 +1,64 @@
+# Per-tensor capability gating shared by ALL CuteDSL native-op override families
+# (reductions today, pointwise/etc. later). Every override's `cond` runs on EVERY
+# eager dispatch, so these must be cheap and must NEVER raise (a throwing cond would
+# crash the dispatcher instead of falling back to aten).
+#
+# These three checks are op-agnostic -- they say nothing about reductions, dims, or
+# geometry, only "can our kernels run on this tensor's device/storage at all". Op
+# families layer their own dtype / geometry / shape checks on top.
+
+from __future__ import annotations
+
+import torch
+import torch._subclasses.fake_tensor
+
+
+def is_cow(t: torch.Tensor) -> bool:
+    # A copy-on-write tensor would be MATERIALIZED (a real copy) the moment our
+    # launch path reads its data pointer via DLPack export -- which the autograd
+    # backward contract forbids for a transparent op override. Decline COW inputs
+    # and let aten handle them.
+    return torch._C._is_cow_tensor(t)  # pyrefly: ignore[missing-attribute]
+
+
+def is_traced(t: torch.Tensor) -> bool:
+    # FakeTensor (compile/export tracing) and meta tensors have no real storage to
+    # launch a kernel on; the decomposition / shape-inference path should use aten's
+    # reference, not our kernel. Decline so the compile router falls back. (Eager on
+    # real tensors is unaffected -- that is the path our kernels target.)
+    #
+    # This cond runs on EVERY eager dispatch, and is_fake() is a ~0.5us Python
+    # subclass walk. A FakeTensor / FunctionalTensor / traceable-wrapper subclass is
+    # never EXACTLY torch.Tensor, so for a plain tensor (the hot path) we skip is_fake
+    # entirely -- the only trace case left for an exact-type tensor is a meta tensor,
+    # caught by the cheap device read (~0.24us total vs ~0.80us).
+    if type(t) is torch.Tensor:
+        return t.device.type == "meta"
+    return torch._subclasses.fake_tensor.is_fake(t) or t.device.type == "meta"
+
+
+# Per-device "is this an arch we target?" cache. get_device_capability queries
+# device properties (~1.4us) and the answer is IMMUTABLE per device, but a cond runs
+# on every eager call -- so memoize by device index. Absent = HIP / not-yet-seen.
+_ARCH_OK: dict[int, bool] = {}
+
+
+def device_ok(x: torch.Tensor) -> bool:
+    # CUDA, not HIP, and a compute capability our kernels target (Hopper/Blackwell).
+    if x.device.type != "cuda" or torch.version.hip is not None:
+        return False
+    idx = x.device.index
+    ok = _ARCH_OK.get(idx)
+    if ok is None:
+        major, _ = torch.cuda.get_device_capability(x.device)
+        ok = major in (9, 10)  # Hopper / Blackwell -- the archs the kernels target
+        _ARCH_OK[idx] = ok
+    return ok
+
+
+def on_current_device(x: torch.Tensor) -> bool:
+    # The compiled-kernel and stream caches are keyed/bound to the CURRENT CUDA
+    # device; launching a cuda:0-compiled kernel on a cuda:1 tensor raises
+    # cudaErrorInvalidResourceHandle. Until the caches are per-device, decline when
+    # the input is not on the current device and let aten handle it.
+    return x.device.index == torch.cuda.current_device()

--- a/torch/_native/utils/lazy.py
+++ b/torch/_native/utils/lazy.py
@@ -1,0 +1,37 @@
+# Lazy module proxy for torch._native. Binding a heavy / optional-dependency module
+# through LazyModule defers its import to first ATTRIBUTE ACCESS, not to the point the
+# binding is created. This keeps `import torch` (and native-op registration) free of
+# DSL runtimes like cutlass -- the lazy-DSL-import contract enforced by
+# test_no_dsl_imports_after_import_torch -- while call sites keep writing `mod.attr`
+# unchanged. Mirrors torch/onnx/_internal/_lazy_import._LazyModule.
+#
+# Use the TYPE_CHECKING-real / else-lazy idiom so static tooling still resolves attrs:
+#
+#     if TYPE_CHECKING:
+#         from .._cutedsl import traits as T
+#     else:
+#         T = LazyModule("torch._native.ops._cutedsl.traits")
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+class LazyModule:
+    """A stand-in for a module that imports the real module on first attribute access."""
+
+    __slots__ = ("_name", "_module")
+
+    def __init__(self, module_name: str) -> None:
+        self._name = module_name
+        self._module: Any = None
+
+    def __repr__(self) -> str:
+        state = "loaded" if self._module is not None else "lazy"
+        return f"<LazyModule {self._name!r} ({state})>"
+
+    def __getattr__(self, attr: str) -> Any:
+        if self._module is None:
+            self._module = importlib.import_module(self._name)
+        return getattr(self._module, attr)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #191049
* __->__ #191048
* #191047
* #191046
* #191045
* #191044
* #190899
* #190898
* #190897
* #190896
* #190895

Squash of slayton58/cutedsl_reduction_prototype: shared CuTeDSL
machinery (ops/_cutedsl/: traits, launch glue, plan cache), four
reduction kernels (K0 general, K1 row, K2 column, K3 fused cross-CTA)
with JIT overrides for 18 reduction ops, and a declarative pointwise
table (40 ops) over one generic elementwise kernel. Substrate for the
family declarations in the next commit.

Authored with an AI assistant (Claude Code).

Test Plan:

```
.venv/bin/python test/python_native/test_reductions_cutedsl.py
.venv/bin/python test/python_native/test_kernel_row.py
.venv/bin/python test/python_native/test_kernel_general.py
.venv/bin/python test/python_native/test_kernel_xcta.py
```