### PR TITLE
[native_aot] reductions + pointwise: family declarations (row path, vec path)

### DIFF
--- a/torch/_native/ops/pointwise/_table_data.py
+++ b/torch/_native/ops/pointwise/_table_data.py
@@ -1,0 +1,57 @@
+# Torch-free pointwise row data: the single source of truth for the op
+# table, readable at EVERY build stage. table.py (JIT registration,
+# torch importable) rebuilds typed PointwiseDef rows from these tuples;
+# aot.py (torchgen stage 1, stdlib only) file-path-loads this module
+# directly. Fields mirror PointwiseDef with promotion as a NAME and the
+# two callable escape hatches reduced to flags/names:
+#   (aten, nin, fn, promotion, scalars, nout, out_dtypes_tag, dtypes_tag)
+# out_dtypes_tag: None | "frexp" (mantissa + int32 exponent).
+# dtypes_tag: None | "no_fp64" (frexp's log2 trick is inexact in fp64).
+
+PW_ROWS = (
+    # --- binary / unary arithmetic (DEFAULT promotion) ---
+    ("neg", 1, "_neg", "DEFAULT", (), 1, None, None),
+    ("add.Tensor", 2, "_add", "DEFAULT", ("alpha",), 1, None, None),
+    ("sub.Tensor", 2, "_sub", "DEFAULT", ("alpha",), 1, None, None),
+    ("mul.Tensor", 2, "_mul", "DEFAULT", (), 1, None, None),
+    ("div.Tensor", 2, "_div", "DEFAULT", (), 1, None, None),
+    ("maximum", 2, "_maximum", "DEFAULT", (), 1, None, None),
+    ("minimum", 2, "_minimum", "DEFAULT", (), 1, None, None),
+    ("atan2", 2, "_atan2", "DEFAULT", (), 1, None, None),
+    # --- rounding / sign / activation (DEFAULT) ---
+    ("floor", 1, "_floor", "DEFAULT", (), 1, None, None),
+    ("ceil", 1, "_ceil", "DEFAULT", (), 1, None, None),
+    ("trunc", 1, "_trunc", "DEFAULT", (), 1, None, None),
+    ("sign", 1, "_sign", "DEFAULT", (), 1, None, None),
+    ("relu", 1, "_relu", "DEFAULT", (), 1, None, None),
+    # --- unary transcendental (INT_TO_FLOAT) ---
+    ("exp", 1, "_exp", "INT_TO_FLOAT", (), 1, None, None),
+    ("exp2", 1, "_exp2", "INT_TO_FLOAT", (), 1, None, None),
+    ("expm1", 1, "_expm1", "INT_TO_FLOAT", (), 1, None, None),
+    ("log", 1, "_log", "INT_TO_FLOAT", (), 1, None, None),
+    ("log2", 1, "_log2", "INT_TO_FLOAT", (), 1, None, None),
+    ("log10", 1, "_log10", "INT_TO_FLOAT", (), 1, None, None),
+    ("log1p", 1, "_log1p", "INT_TO_FLOAT", (), 1, None, None),
+    ("sqrt", 1, "_sqrt", "INT_TO_FLOAT", (), 1, None, None),
+    ("rsqrt", 1, "_rsqrt", "INT_TO_FLOAT", (), 1, None, None),
+    ("reciprocal", 1, "_reciprocal", "INT_TO_FLOAT", (), 1, None, None),
+    ("sin", 1, "_sin", "INT_TO_FLOAT", (), 1, None, None),
+    ("cos", 1, "_cos", "INT_TO_FLOAT", (), 1, None, None),
+    ("tan", 1, "_tan", "INT_TO_FLOAT", (), 1, None, None),
+    ("asin", 1, "_asin", "INT_TO_FLOAT", (), 1, None, None),
+    ("acos", 1, "_acos", "INT_TO_FLOAT", (), 1, None, None),
+    ("atan", 1, "_atan", "INT_TO_FLOAT", (), 1, None, None),
+    ("tanh", 1, "_tanh", "INT_TO_FLOAT", (), 1, None, None),
+    ("erf", 1, "_erf", "INT_TO_FLOAT", (), 1, None, None),
+    ("sigmoid", 1, "_sigmoid", "INT_TO_FLOAT", (), 1, None, None),
+    # --- comparisons (ALWAYS_BOOL) ---
+    ("gt.Tensor", 2, "_gt", "ALWAYS_BOOL", (), 1, None, None),
+    ("lt.Tensor", 2, "_lt", "ALWAYS_BOOL", (), 1, None, None),
+    ("ge.Tensor", 2, "_ge", "ALWAYS_BOOL", (), 1, None, None),
+    ("le.Tensor", 2, "_le", "ALWAYS_BOOL", (), 1, None, None),
+    ("eq.Tensor", 2, "_eq", "ALWAYS_BOOL", (), 1, None, None),
+    ("ne.Tensor", 2, "_ne", "ALWAYS_BOOL", (), 1, None, None),
+    # --- ternary / multi-output ---
+    ("addcmul", 3, "_addcmul", "DEFAULT", ("value",), 1, None, None),
+    ("frexp.Tensor", 1, "_frexp", "DEFAULT", (), 2, "frexp", "no_fp64"),
+)

--- a/torch/_native/ops/pointwise/aot.py
+++ b/torch/_native/ops/pointwise/aot.py
@@ -1,0 +1,251 @@
+"""Native-AOT declarations for the pointwise family @ CUDA (vec path).
+
+A FAMILY module: declarations() returns one declaration object per
+AOT-able row of POINTWISE_DEF_TABLE -- structured aten op, single
+output, no dtype restriction conflicts -- covering the vec fast path
+only: all operands same dtype (fp32/bf16), same shape, contiguous,
+numel % V == 0, 16B-aligned, scalar args at their defaults. Broadcast,
+strided, mixed-dtype, bool-output (comparisons), int-promotion inputs
+and non-default scalars stay JIT (see PAIN_POINTS P1/P8 for why the
+line sits here).
+
+Structured-overload note: comparison rows (gt.Tensor etc.) would need
+overload-qualified declarations AND have bool outputs (not vec-able),
+so they are excluded by the bool check, not the overload one.
+
+Module scope must import with stdlib alone AND without package context
+(torchgen file-path-loads this pre-build), so the row data comes from
+the torch-free ``_table_data.py`` sibling, loaded by file path -- the
+same single source of truth ``table.py`` rebuilds the typed
+PointwiseDef rows from (PAIN_POINTS P13).
+"""
+
+import collections
+import importlib.util
+import os
+
+
+def _load_rows():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_table_data.py")
+    spec = importlib.util.spec_from_file_location("pointwise_table_data", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.PW_ROWS
+
+
+_Row = collections.namedtuple(
+    "_Row", ["aten", "nin", "fn", "promotion", "scalars", "nout", "out_tag", "dt_tag"]
+)
+_ROWS = [_Row(*r) for r in _load_rows()]
+
+_DTYPES = {"float32": "at::kFloat", "bfloat16": "at::kBFloat16"}
+
+# Rows NOT AOT-able. Values are the reason (documentation; the factory
+# also derives most of these mechanically from the row).
+_EXCLUDED = {
+    "relu": "not structured (composite to clamp_min)",
+    "frexp.Tensor": "not structured; multi-output, mixed out dtypes",
+    "gt.Tensor": "bool output: not vec-able (out dtype != compute)",
+    "lt.Tensor": "bool output",
+    "ge.Tensor": "bool output",
+    "le.Tensor": "bool output",
+    "eq.Tensor": "bool output",
+    "ne.Tensor": "bool output",
+}
+
+
+import itertools
+
+
+# Promotion table baked at DECLARATION time (stdlib-only mirror of
+# elementwise_dtypes on this grid, verified against it by the export
+# builder, which calls the real thing): compute is always fp32; out is
+# bf16 iff every input is bf16, else fp32. V = 128 bits / widest input
+# element width (mixed tuples contain fp32 -> V=4; all-bf16 -> V=8).
+def _out_name(in_names):
+    return "bfloat16" if all(n == "bfloat16" for n in in_names) else "float32"
+
+
+def _tuple_vec(in_names):
+    return 8 if all(n == "bfloat16" for n in in_names) else 4
+
+
+class _PointwiseDecl:
+    DISPATCH_KEY = "CUDA"
+    KERNEL_MODULE = "aot_kernel.py"
+
+    def __init__(self, row):
+        self.ATEN_OP = row.aten
+        self._row = row
+        # All input-dtype tuples over the grid (mixed included): 2
+        # points for unary, 4 for binary, 8 for ternary (P8 corrected).
+        self._tuples = list(itertools.product(list(_DTYPES), repeat=row.nin))
+
+    def kernel_precompile_grid(self):
+        # in_dtypes is a TUPLE, not a list: expand_specs cross-multiplies
+        # list-valued fields, and the dtype tuple must stay one axis
+        # value per point.
+        return [{"aten": self._row.aten, "in_dtypes": t} for t in self._tuples]
+
+    def covered_axes(self, *args, **kwargs):
+        import torch
+
+        row = self._row
+        ins = args[: row.nin]
+        if len(ins) < row.nin:
+            return {"aten": None}
+        names = tuple(
+            {torch.float32: "float32", torch.bfloat16: "bfloat16"}.get(t.dtype)
+            if isinstance(t, torch.Tensor)
+            else None
+            for t in ins
+        )
+        t0 = ins[0]
+        if any(n is None for n in names):
+            return {"aten": None}
+        v = _tuple_vec(names)
+        # Alignment via storage_offset, NOT data_ptr() (COW-safe; see
+        # PAIN_POINTS P15): each operand needs one V-wide row of ITS
+        # dtype aligned. Allocator bases are >=256B aligned; the C++
+        # prelude re-checks the real pointer.
+        ok = (
+            all(
+                t.shape == t0.shape
+                and t.is_contiguous()
+                and (t.storage_offset() * t.element_size()) % (v * t.element_size())
+                == 0
+                for t in ins
+            )
+            and t0.numel() > 0
+            and t0.numel() % v == 0
+        )
+        # Non-default scalar args (add's alpha=2 etc.) stay JIT: the AOT
+        # kernels bake the default (1).
+        pos_scalars = args[row.nin :]
+        for i, sname in enumerate(row.scalars):
+            val = kwargs.get(sname, pos_scalars[i] if i < len(pos_scalars) else 1)
+            if val != 1:
+                ok = False
+        # Tuple to match the grid points (list != tuple in coverage
+        # matching's equality check).
+        return {"aten": row.aten if ok else None, "in_dtypes": names}
+
+    def cpp_covers(self):
+        # C++ port of covered_axes + grid matching (registered as
+        # torch.ops._native_aot.covers_<decl_id>; ~1.3us vs ~3.8us for
+        # the Python path). Standalone body rather than prelude reuse:
+        # the covers signature carries `out` as an optional (functional
+        # schema + trailing out), and V is derived at runtime from the
+        # dtype tuple instead of baked per grid point. Every tuple over
+        # {fp32, bf16} is on the grid, so on-grid dtypes ARE grid
+        # membership. Out, when supplied, must pass the stub's own
+        # checks (contiguity, promotion dtype, alignment) or coverage
+        # would be wider than the stub's acceptance and gated calls
+        # would lose their JIT route to stock aten.
+        row = self._row
+        names = self._tensor_params()
+        lines = [
+            "const int64_t numel = self.numel();",
+            "if (numel == 0) return false;",
+        ]
+        for n in names:
+            lines.append(
+                f"if ({n}.scalar_type() != at::kFloat && {n}.scalar_type() != at::kBFloat16) return false;"
+            )
+            lines.append(f"if (!{n}.is_contiguous()) return false;")
+            if n != "self":
+                lines.append(f"if ({n}.sizes() != self.sizes()) return false;")
+        all_bf16 = " && ".join(f"{n}.scalar_type() == at::kBFloat16" for n in names)
+        lines.append(f"const bool all_bf16 = {all_bf16};")
+        lines.append("const int64_t v = all_bf16 ? 8 : 4;")
+        lines.append("if (numel % v != 0) return false;")
+        for n in names:
+            lines.append(
+                f"if (reinterpret_cast<uintptr_t>({n}.const_data_ptr()) % (v * {n}.element_size()) != 0) return false;"
+            )
+        for s in row.scalars:
+            lines.append(f"if (!{s}.equal(1)) return false;")
+        lines += [
+            "if (out.has_value()) {",
+            "  if (out->scalar_type() != (all_bf16 ? at::kBFloat16 : at::kFloat)) return false;",
+            "  if (!out->is_contiguous() || out->sizes() != self.sizes()) return false;",
+            "  if (reinterpret_cast<uintptr_t>(out->const_data_ptr()) % (v * out->element_size()) != 0) return false;",
+            "}",
+            "return true;",
+        ]
+        return "\n      ".join(["", *lines]) + "\n"
+
+    # ---- C++ side (over the structured impl signature: tensor inputs,
+    # then declared Scalars, then out) ----
+
+    def _tensor_params(self):
+        # Structured impl arg names for the row's tensor inputs. aten's
+        # binary/ternary structured ops name them (self, other) and
+        # (self, tensor1, tensor2); unary just (self).
+        n = self._row.nin
+        if n == 1:
+            return ["self"]
+        if n == 2:
+            return ["self", "other"]
+        return ["self", "tensor1", "tensor2"]
+
+    def cpp_dispatch_prelude(self):
+        row = self._row
+        names = self._tensor_params()
+        # Per-operand dtype must be ON the grid; the exact tuple match
+        # happens in cpp_dispatch. Alignment/vec checks are per-point
+        # (V varies by tuple), so they live in cpp_dispatch too via the
+        # baked constants; here only tuple-independent gates.
+        on_grid = " || ".join(f"{{n}}.scalar_type() == {t}" for t in _DTYPES.values())
+        checks = [
+            "const int64_t numel = self.numel();",
+            "if (numel == 0) return false;",
+        ]
+        for n in names:
+            checks.append(
+                f"if (!(({on_grid.replace('{n}', n)}))) return false;".replace("{n}", n)
+            )
+            checks.append(f"if (!{n}.is_contiguous()) return false;")
+            checks.append(
+                f"if ({n}.sizes() != self.sizes()) return false;" if n != "self" else ""
+            )
+        checks.append("if (!out.is_contiguous()) return false;")
+        scalar_default = " && ".join(f"{s}.equal(1)" for s in row.scalars)
+        if scalar_default:
+            checks.append(f"if (!({scalar_default})) return false;")
+        return "\n      ".join(["", *[c for c in checks if c]]) + "\n"
+
+    def cpp_dispatch(self, spec):
+        names = self._tensor_params()
+        in_names = tuple(spec["in_dtypes"])
+        v = _tuple_vec(in_names)
+        conds = [f"numel % {v} == 0"]
+        for n, dt in zip(names, in_names):
+            conds.append(f"{n}.scalar_type() == {_DTYPES[dt]}")
+            elem = 4 if dt == "float32" else 2
+            conds.append(
+                f"reinterpret_cast<uintptr_t>({n}.const_data_ptr()) % {v * elem} == 0"
+            )
+        out_elem = 4 if _out_name(in_names) == "float32" else 2
+        conds.append(
+            f"reinterpret_cast<uintptr_t>(out.data_ptr()) % {v * out_elem} == 0"
+        )
+        return " && ".join(conds)
+
+    def cpp_launch(self, spec, launch_fn):
+        in_names = tuple(spec["in_dtypes"])
+        v = _tuple_vec(in_names)
+        names = self._tensor_params()
+        views = "\n      ".join(
+            f"auto {n}_v = {n}.view({{numel / {v}, {v}}});" for n in names
+        )
+        args = ", ".join(f"{n}_v" for n in names)
+        return f"""
+      {views}
+      auto out_v = out.view({{numel / {v}, {v}}});
+      {launch_fn}({args}, out_v, at::cuda::getCurrentCUDAStream());
+    """
+
+
+def declarations():
+    return [_PointwiseDecl(row) for row in _ROWS if row.aten not in _EXCLUDED]

--- a/torch/_native/ops/pointwise/aot_kernel.py
+++ b/torch/_native/ops/pointwise/aot_kernel.py
@@ -1,0 +1,155 @@
+"""AOT builder for the pointwise family: fixed-arity export adapters
+over the generic vec kernel.
+
+Deltas from the JIT route, forced by the export surface:
+
+* ``_ElementwiseVec`` takes ``mIns: list, mOuts: list`` -- fine for
+  cute.compile, but ``export_to_c`` cannot emit a C ABI for list
+  arguments (PAIN_POINTS P11). ``_Adapter<nin>to<nout>`` wraps the op
+  in an explicit-arity @cute.jit signature forwarding as lists; the
+  kernel body underneath is the same one the JIT route compiles.
+* The JIT route bakes each operand's layout per compile (plan cache
+  keyed on shapes/strides). The AOT compile marks mode 0 of the
+  (nvec, V) view dynamic so ONE kernel per (op, dtype tuple) serves
+  every size on the vec path (PAIN_POINTS P1); numel % V == 0 and
+  per-operand alignment are coverage conditions.
+
+Dtype axis: the grid enumerates INPUT-DTYPE TUPLES over {float32,
+bfloat16} (mixed tuples included). Promotion is resolved HERE at
+export time via the same ``elementwise_dtypes`` the JIT impl calls --
+compute dtype and out dtype are baked per point, so the generated C++
+matches dtype tuples by equality and never restates promotion
+(PAIN_POINTS P8, corrected). On this grid: compute is always fp32; out
+is bf16 iff every input is bf16, else fp32.
+
+The vector width V is shared across operands (one flat (numel/V, V)
+view per tensor), so V = 128 bits / WIDEST element width in the tuple
+(fp32 present -> V=4; all-bf16 -> V=8). Narrow (bf16) operands in a
+mixed tuple then load 64 bits per lane -- correct, slightly sub-peak.
+Each operand's assumed_align follows its own V * elem_bytes.
+"""
+
+import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]
+import cutlass.cute as cute
+from cutlass import BFloat16, Float32
+
+import torch
+from torch._prims_common import elementwise_dtypes
+
+from .kernel import _ElementwiseVec
+from .ops import get_fn
+from .table import POINTWISE_DEF_TABLE
+
+
+_CUTE = {"float32": Float32, "bfloat16": BFloat16}
+_TORCH = {"float32": torch.float32, "bfloat16": torch.bfloat16}
+_TORCH_TO_NAME = {v: k for k, v in _TORCH.items()}
+_DTYPE_SHORT = {"float32": "f32", "bfloat16": "bf16"}
+
+
+class _Adapter1to1:
+    def __init__(self, op):
+        self.op = op
+
+    @cute.jit
+    def __call__(self, mIn0: cute.Tensor, mOut0: cute.Tensor, stream: cuda.CUstream):
+        self.op([mIn0], [mOut0], stream)
+
+
+class _Adapter2to1:
+    def __init__(self, op):
+        self.op = op
+
+    @cute.jit
+    def __call__(
+        self,
+        mIn0: cute.Tensor,
+        mIn1: cute.Tensor,
+        mOut0: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        self.op([mIn0, mIn1], [mOut0], stream)
+
+
+class _Adapter3to1:
+    def __init__(self, op):
+        self.op = op
+
+    @cute.jit
+    def __call__(
+        self,
+        mIn0: cute.Tensor,
+        mIn1: cute.Tensor,
+        mIn2: cute.Tensor,
+        mOut0: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        self.op([mIn0, mIn1, mIn2], [mOut0], stream)
+
+
+_ADAPTERS = {1: _Adapter1to1, 2: _Adapter2to1, 3: _Adapter3to1}
+
+
+def _row(aten: str):
+    for r in POINTWISE_DEF_TABLE:
+        if r.aten == aten:
+            return r
+    raise KeyError(f"no pointwise table row for {aten!r}")
+
+
+def promote(row_aten: str, in_names: tuple) -> tuple:
+    """(compute torch dtype, out torch dtype) for an input-dtype tuple,
+    via the SAME elementwise_dtypes call the JIT impl uses. Shared with
+    aot.py's coverage/codegen so all three consumers agree."""
+    row = _row(row_aten)
+    probes = [torch.empty(0, dtype=_TORCH[n], device="meta") for n in in_names]
+    return elementwise_dtypes(*probes, type_promotion_kind=row.promotion)
+
+
+def vec_width(in_names: tuple) -> int:
+    """Shared V across operands: 128 bits / widest element width."""
+    widest = max(_TORCH[n].itemsize for n in in_names)
+    return 16 // widest
+
+
+def _fake_vec(dtype, V: int):
+    # (nvec dynamic, V static); alignment = one V-wide row of THIS dtype.
+    return cute.runtime.make_fake_tensor(
+        dtype, (cute.sym_int(), V), stride=(V, 1), assumed_align=V * dtype.width // 8
+    )
+
+
+def build(spec: dict) -> dict:
+    """One grid point -> compile inputs + marshalling sidecar.
+
+    spec: {"aten": table-row op symbol, "in_dtypes": tuple of dtype
+    names, one per tensor input}. Scalar args (add's alpha etc.) are
+    baked at their aten DEFAULT (1); non-default scalars stay JIT.
+    """
+    row = _row(spec["aten"])
+    in_names = tuple(spec["in_dtypes"])
+    assert len(in_names) == row.nin  # noqa: S101
+    compute_t, out_t = promote(spec["aten"], in_names)
+    compute = _CUTE[_TORCH_TO_NAME[compute_t]]
+    out_cute = _CUTE[_TORCH_TO_NAME[out_t]]
+    V = vec_width(in_names)
+    consts = tuple(compute(1) for _ in row.scalars)
+    op = _ElementwiseVec(
+        get_fn(row.fn), row.nin, row.nout, consts, compute, [out_cute] * row.nout, V
+    )
+    adapter = _ADAPTERS[row.nin](op)
+    in_fakes = [_fake_vec(_CUTE[n], V) for n in in_names]
+    out_fake = _fake_vec(out_cute, V)
+    decl_id = row.aten.replace(".", "_")
+    tag = "_".join(_DTYPE_SHORT[n] for n in in_names)
+    prefix = f"pw_{decl_id}_{tag}"
+    return {
+        "prefix": prefix,
+        "fn": adapter,
+        "fake_args": [*in_fakes, out_fake, cute.runtime.make_fake_stream()],
+        "tensor_args": [
+            {"name": f"mIn{i}", "dynamic_sizes": [0], "read_only": True}
+            for i in range(row.nin)
+        ]
+        + [{"name": "mOut0", "dynamic_sizes": [0]}],
+    }

--- a/torch/_native/ops/reductions/aot.py
+++ b/torch/_native/ops/reductions/aot.py
@@ -1,0 +1,188 @@
+"""Native-AOT declarations for the reduction family @ CUDA (K1 row path).
+
+A FAMILY module: declarations() returns one declaration object per
+covered op (sum.dim_IntList, mean.dim, amax, amin, prod.dim_int), all
+built by one factory over a shared axis table. Coverage is the K1
+one-shot row-reduce regime only: 2D-collapsible contiguous input,
+reduction over exactly the last axis, N on a bucket, fp32/bf16,
+default out dtype. Reduce-all, column, index traits, off-bucket N and
+everything else stay JIT (PAIN_POINTS P5/P7 record why).
+
+Module scope must import with stdlib alone (torchgen loads this
+pre-build); torch is imported lazily inside covered_axes bodies.
+"""
+
+_DTYPES = {"float32": "at::kFloat", "bfloat16": "at::kBFloat16"}
+# N buckets: >= 1024 keeps clear of the small-N tpr crash (P12); powers
+# of two are 16B-aligned rows for every grid dtype.
+_NS = [1024, 2048, 4096, 8192, 16384, 32768]
+
+# op axis: (ATEN_OP, trait, has dtype= arg in schema, dim arg style)
+#   dim styles: "opt_list" (sum/mean: int[1]? dim), "list" (amax/amin:
+#   int[1] dim=[]), "int" (prod: int dim).
+_OPS = [
+    ("sum.dim_IntList", "sum", True, "opt_list"),
+    ("mean.dim", "mean", True, "opt_list"),
+    ("amax", "amax", False, "list"),
+    ("amin", "amin", False, "list"),
+    ("prod.dim_int", "prod", True, "int"),
+]
+
+
+def _covers_last_dim(self, dim, dim_style):
+    # True iff dim reduces exactly the trailing axis of a >=1D tensor
+    # whose leading axes collapse (contiguity checked separately).
+    ndim = self.dim()
+    if ndim < 1:
+        return False
+    if dim_style == "int":
+        d = dim
+    else:
+        if dim is None:
+            return False  # reduce-all -> xcta (JIT)
+        dims = [dim] if isinstance(dim, int) else list(dim)
+        if len(dims) != 1:
+            return False
+        d = dims[0]
+    if not isinstance(d, int) or not (-ndim <= d < ndim):
+        return False
+    return d % ndim == ndim - 1
+
+
+class _RowReduceDecl:
+    DISPATCH_KEY = "CUDA"
+    KERNEL_MODULE = "aot_kernel.py"
+
+    def __init__(self, aten_op, trait, has_dtype_arg, dim_style):
+        self.ATEN_OP = aten_op
+        self._trait = trait
+        self._has_dtype_arg = has_dtype_arg
+        self._dim_style = dim_style
+
+    def kernel_precompile_grid(self):
+        return [{"trait": self._trait, "dtype": list(_DTYPES), "N": _NS}]
+
+    def covered_axes(self, self_t, dim=None, keepdim=False, *, dtype=None):
+        # Alignment via storage_offset, NOT data_ptr(): data_ptr()
+        # materializes copy-on-write inputs, and coverage runs on every
+        # call (PAIN_POINTS P15). Allocator bases are >=256B aligned, so
+        # offset alignment implies pointer alignment for framework
+        # tensors; exotic bases are re-checked by the C++ prelude.
+        aligned = (self_t.storage_offset() * self_t.element_size()) % 16 == 0
+        covered = (
+            self_t.is_contiguous()
+            and _covers_last_dim(self_t, dim, self._dim_style)
+            and (dtype is None or dtype == self_t.dtype)
+            and aligned
+        )
+        n = self_t.shape[-1] if self_t.dim() >= 1 else 0
+        return {
+            "trait": self._trait if covered else None,
+            "dtype": self_t.dtype,
+            "N": n,
+        }
+
+    def cpp_covers(self):
+        # C++ port of covered_axes + grid matching (registered as
+        # torch.ops._native_aot.covers_<decl_id>; ~1.3us vs ~3.8us for
+        # the Python path). Same covered set: contiguous >=1D, reduce
+        # over exactly the last axis, on-grid dtype, default out dtype,
+        # 16B-aligned base, N on a bucket. The signature is the
+        # FUNCTIONAL schema (dim arrives raw -- wrap before comparing,
+        # PAIN_POINTS P14) plus a trailing optional out.
+        dtype_reject = " && ".join(f"st != {t}" for t in _DTYPES.values())
+        n_accept = " || ".join(f"N == {n}" for n in _NS)
+        if self._dim_style == "int":
+            last_dim = "const bool last = (c10::maybe_wrap_dim(dim, self.dim()) == self.dim() - 1);"
+        elif self._dim_style == "list":
+            last_dim = "const bool last = (dim.size() == 1 && c10::maybe_wrap_dim(dim[0], self.dim()) == self.dim() - 1);"
+        else:
+            last_dim = "const bool last = (dim.has_value() && dim->size() == 1 && c10::maybe_wrap_dim((*dim)[0], self.dim()) == self.dim() - 1);"
+        dtype_arg = (
+            "if (dtype.has_value() && *dtype != st) return false;"
+            if self._has_dtype_arg
+            else ""
+        )
+        return f"""
+      const auto st = self.scalar_type();
+      if ({dtype_reject}) return false;
+      {dtype_arg}
+      if (self.dim() < 1 || !self.is_contiguous()) return false;
+      if (reinterpret_cast<uintptr_t>(self.const_data_ptr()) % 16 != 0) return false;
+      {last_dim}
+      if (!last) return false;
+      const int64_t N = self.size(-1);
+      if (N == 0 || self.numel() == 0) return false;
+      return {n_accept};
+    """
+
+    # ---- C++ side ----
+
+    def cpp_dispatch_prelude(self):
+        dtype_reject = " && ".join(f"st != {t}" for t in _DTYPES.values())
+        # Reduction dims arrive at the structured impl RAW (no
+        # maybe_wrap_dim precompute, unlike e.g. index_add's dim), so
+        # the negative spelling (dim=-1) must be wrapped here or it
+        # silently declines to stock aten while covered_axes says
+        # covered (PAIN_POINTS P14).
+        if self._dim_style == "int":
+            last_dim = (
+                "const bool last = "
+                "(c10::maybe_wrap_dim(dim, self.dim()) == self.dim() - 1);"
+            )
+        elif self._dim_style == "list":
+            last_dim = (
+                "const bool last = (dim.size() == 1 && "
+                "c10::maybe_wrap_dim(dim[0], self.dim()) == self.dim() - 1);"
+            )
+        else:
+            # sum/mean: OptionalIntArrayRef; empty/absent = reduce-all.
+            last_dim = (
+                "const bool last = (dim.has_value() && dim->size() == 1 && "
+                "c10::maybe_wrap_dim((*dim)[0], self.dim()) == self.dim() - 1);"
+            )
+        dtype_arg = (
+            "if (dtype.has_value() && *dtype != self.scalar_type()) return false;"
+            if self._has_dtype_arg
+            else ""
+        )
+        return f"""
+      const auto st = self.scalar_type();
+      if ({dtype_reject}) return false;
+      {dtype_arg}
+      if (self.dim() < 1 || !self.is_contiguous()) return false;
+      if (reinterpret_cast<uintptr_t>(self.const_data_ptr()) % 16 != 0) return false;
+      {last_dim}
+      if (!last) return false;
+      const int64_t N = self.size(-1);
+      // N == 0 must be rejected BEFORE the division: numel()/0 is a
+      // C++ integer division by zero (SIGFPE, found by the OpInfo
+      // test_out sweep via _refs.linalg.norm's empty samples).
+      if (N == 0) return false;
+      const int64_t M = self.numel() / N;
+      if (M == 0) return false;
+    """
+
+    def cpp_dispatch(self, spec):
+        return f"st == {_DTYPES[spec['dtype']]} && N == {spec['N']}"
+
+    def cpp_launch(self, spec, launch_fn):
+        if spec["dtype"] == "float32":
+            # Kernel writes fp32 = aten's out dtype: write out directly.
+            return f"""
+      auto self_2d = self.view({{M, N}});
+      auto out_1d = out.view({{M}});
+      {launch_fn}(self_2d, out_1d, at::cuda::getCurrentCUDAStream());
+    """
+        # bf16 in -> fp32 kernel out -> cast into aten's bf16 out (the
+        # same .to() the JIT impl pays).
+        return f"""
+      auto self_2d = self.view({{M, N}});
+      auto acc = at::empty({{M}}, self.options().dtype(at::kFloat));
+      {launch_fn}(self_2d, acc, at::cuda::getCurrentCUDAStream());
+      out.view({{M}}).copy_(acc);
+    """
+
+
+def declarations():
+    return [_RowReduceDecl(*row) for row in _OPS]

--- a/torch/_native/ops/reductions/aot_kernel.py
+++ b/torch/_native/ops/reductions/aot_kernel.py
@@ -1,0 +1,97 @@
+"""AOT builder for the reduction family: K1 row-reduce, last-dim, final.
+
+Phase 1 of AOT-ing the reductions (see PAIN_POINTS P5/P7): only the
+one-shot row kernel is exported -- it is already dynamic-M with the
+grid computed inside the @cute.jit region, so the exported launcher
+needs no host planning. Reduce-all (xcta two-stage, scratch + C-split
+planning in C++), column (K2), index traits, and the K0 general path
+stay JIT.
+
+The kernel body is the same RowReduce the JIT route compiles
+(same-kernel by construction; two-stage build). ``_Adapter1`` exists
+only because export_to_c cannot emit a C ABI for the kernel's
+``mOuts: list`` argument (PAIN_POINTS P11).
+
+Grid axes: trait (sum/mean/amax/amin/prod) x dtype {float32, bfloat16}
+(user decision: fp16/fp64 stay JIT) x N buckets. N is a compile-time
+constant of RowReduce (const_expr vec/tile selection), so off-bucket N
+stays JIT -- the finite-grid compromise of P5.
+
+The kernel accumulates and stores in fp32 (the _acc_policy the JIT
+uses); for bf16 inputs the C++ launch allocates an fp32 scratch and
+casts into aten's bf16 out, exactly the .to() the JIT impl pays.
+"""
+
+import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]
+import cutlass.cute as cute
+from cutlass import Float32
+
+from .._cutedsl import traits as T
+from . import kernel_row
+
+
+_DTYPES_CUTE = {}  # populated lazily; cutlass dtype objects
+
+
+def _cute_dtype(name: str):
+    if not _DTYPES_CUTE:
+        import cutlass
+
+        _DTYPES_CUTE.update({"float32": cutlass.Float32, "bfloat16": cutlass.BFloat16})
+    return _DTYPES_CUTE[name]
+
+
+_DTYPE_SHORT = {"float32": "f32", "bfloat16": "bf16"}
+
+_TRAITS = {
+    "sum": lambda: T.SumOps(acc=Float32),
+    "mean": lambda: T.MeanOps(acc=Float32),
+    "amax": lambda: T.AMaxOps(acc=Float32),
+    "amin": lambda: T.AMinOps(acc=Float32),
+    "prod": lambda: T.ProdOps(acc=Float32),
+}
+
+
+class _Adapter1:
+    # export_to_c cannot marshal list arguments; forward a fixed-arity
+    # signature into RowReduce's (mX, mOuts: list, stream).
+    def __init__(self, op):
+        self.op = op
+
+    @cute.jit
+    def __call__(self, mX: cute.Tensor, mOut0: cute.Tensor, stream: cuda.CUstream):
+        self.op(mX, [mOut0], stream)
+
+
+def build(spec: dict) -> dict:
+    """One grid point -> compile inputs + marshalling sidecar.
+
+    spec: {"trait": sum|mean|amax|amin|prod, "dtype": name, "N": int}.
+    M (rows) is dynamic: mode 0 of the (M, N) input and the (M,) output
+    are cute.sym_int, so one kernel per point serves every M.
+    """
+    trait = _TRAITS[spec["trait"]]()
+    dtype = _cute_dtype(spec["dtype"])
+    N = int(spec["N"])
+    op = kernel_row.RowReduce(trait, dtype, N)
+    adapter = _Adapter1(op)
+    # Bucketed N is a multiple of the vector width, so rows are 16B
+    # apart and the wide-load path is legal; the C++ prelude enforces
+    # the matching base-pointer alignment.
+    x_fake = cute.runtime.make_fake_tensor(
+        dtype, (cute.sym_int(), N), stride=(N, 1), assumed_align=16
+    )
+    # Kernel out = the fp32 accumulator dtype (see module docstring).
+    out_fake = cute.runtime.make_fake_tensor(
+        Float32, (cute.sym_int(),), stride=(1,), assumed_align=4
+    )
+    prefix = f"red_{spec['trait']}_{_DTYPE_SHORT[spec['dtype']]}_n{N}"
+    return {
+        "prefix": prefix,
+        "fn": adapter,
+        "fake_args": [x_fake, out_fake, cute.runtime.make_fake_stream()],
+        "tensor_args": [
+            {"name": "mX", "dynamic_sizes": [0], "read_only": True},
+            {"name": "mOut0", "dynamic_sizes": [0]},
+        ],
+    }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #191049
* #191048
* #191047
* #191046
* #191045
* #191044
* #190899
* #190898
* #190897
* #190896
* #190895

First family-scale declarations, built by factories over the tables
that drive JIT registration.

Reductions (5: sum.dim_IntList, mean.dim, amax, amin, prod.dim_int):
the K1 row path -- contiguous last-axis reduction, N buckets
{1024..32768}, fp32/bf16, default out dtype. Reduce-all, column,
index traits, and off-bucket N stay JIT.

Pointwise (32 of 40 table rows; comparisons/relu/frexp excluded): the
vec fast path with dynamic-size operand wraps, one kernel per (op,
input-dtype tuple) over {fp32, bf16} including mixed tuples --
promotion is resolved at export by the same elementwise_dtypes call
the JIT uses and baked per point. Broadcast, strided, and non-default
scalars stay JIT. Both factories emit cpp_covers (C++ coverage
predicates over the functional schema), cutting the per-call covers
cost from ~3.8us (Python) to ~1.3us. Row data lives in torch-free
_table_data.py so the declaration factory can run at torchgen time.

Authored with an AI assistant (Claude Code).

Test Plan:

```
.venv/bin/python test/python_native/test_reductions_cutedsl.py
.venv/bin/python test/test_reductions.py
.venv/bin/python test/test_binary_ufuncs.py -k add
.venv/bin/python test/test_unary_ufuncs.py -k exp
.venv/bin/python test/test_unary_ufuncs.py -k sigmoid
```