### PR TITLE
[AOTI] Fix const-graph missing CUDA header in DualWrapper

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -519,6 +519,27 @@ class AOTInductorTestsTemplate:
         with config.patch({"aot_inductor.use_runtime_constant_folding": True}):
             self.check_model(Model(self.device), example_inputs)
 
+    def test_const_graph_no_autotune_at_compile_time(self):
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.w_pre = torch.randn(16, 16, device=device)
+                self.b = torch.randn(16, device=device)
+
+            def forward(self, x):
+                w_t = torch.transpose(self.w_pre, 0, 1)
+                w = torch.nn.functional.relu(w_t) + self.b
+                return torch.matmul(x, w)
+
+        example_inputs = (torch.randn(16, 16, device=self.device),)
+        with config.patch(
+            {
+                "triton.autotune_at_compile_time": False,
+                "aot_inductor.use_runtime_constant_folding": True,
+            }
+        ):
+            self.check_model(Model(self.device), example_inputs)
+
     def test_constant_folding_with_update(self):
         class Model(torch.nn.Module):
             def __init__(self, device):

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1145,6 +1145,13 @@ class CppWrapperGpu(CppWrapperCpu):
             # For a dual-wrapper-mode const graph, only the standalone JIT
             # output needs this header content. The AOTI const body is spliced
             # into the main AOTI source, which has its own kernel driver.
+            # super().write_header() early-returns for const graphs before it
+            # can call add_device_include, so emit the JIT device include here;
+            # otherwise the kernel driver's CUfunction/CUmodule/uint32_t types
+            # have no declaring header and fail to compile under -nostdinc.
+            for device in V.graph.device_types:
+                if device != "meta":
+                    self.header.splice_jit(self.get_device_include_path_jit(device))
             self.header.splice_jit(kernel_driver)
         else:
             self.header.splice(kernel_driver)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #191050

Summary:
With `autotune_at_compile_time=False`, a `use_runtime_constant_folding` const graph
that lowers to a Triton kernel is emitted as a standalone JIT `.cpp` carrying the CUDA
`loadKernel` helper but no CUDA header, so it failed to compile (in fbcode, where
-nostdinc is used).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo