### PR TITLE
[EXPERIMENT][DO NOT MERGE] BPF-traced target determination: phase-1 data collection

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -124,6 +124,13 @@ on:
         type: string
         default: ""
         description: CUDA version to use for the OSDC build.
+      bpf-td-extract-build-graph:
+        description: |
+          If set to "1", extract the ninja source -> artifact graph into
+          dist/build_graph_map.json so it travels inside the build artifact.
+        required: false
+        type: string
+        default: ""
 
     secrets:
       HUGGING_FACE_HUB_TOKEN:
@@ -261,6 +268,16 @@ jobs:
             mkdir -p "dist/$(dirname "$src")"
             mv "$src" "dist/$(dirname "$src")/"
           fi
+
+      - name: Extract BPF-TD build graph
+        if: inputs.bpf-td-extract-build-graph == '1' && steps.build.outcome != 'skipped'
+        shell: bash
+        run: |
+          mkdir -p dist
+          python3 tools/testing/bpf_td/extract_build_graph.py \
+            --build-dir build \
+            --repo-root "$(pwd)" \
+            --out dist/build_graph_map.json
 
       - name: Archive artifacts into zip
         if: inputs.build-generates-artifacts && steps.build.outcome != 'skipped' && steps.use-old-whl.outputs.reuse != 'true'

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -40,6 +40,13 @@ on:
         default: ""
         type: string
         description: Prefix for runner label
+      skip-arc-mapping:
+        required: false
+        default: ""
+        type: string
+        description: |
+          If "true", pass the test matrix through unmapped (keep EC2 labels
+          like linux.4xlarge) instead of rewriting them to ARC equivalents.
       runner:
         required: false
         type: string
@@ -163,7 +170,7 @@ jobs:
     timeout-minutes: 480
     outputs:
       docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${{ inputs.docker-image-name }}${{ inputs.ci-docker-hash && format('-{0}', inputs.ci-docker-hash) || '' }}
-      test-matrix: ${{ steps.map-runners.outputs.test-matrix }}
+      test-matrix: ${{ inputs.skip-arc-mapping == 'true' && steps.filter.outputs.test-matrix || steps.map-runners.outputs.test-matrix }}
       build-environment: ${{ inputs.build-environment }}
     steps:
       - name: Setup Linux
@@ -199,6 +206,7 @@ jobs:
 
       - name: Map EC2 runners to ARC runners
         id: map-runners
+        if: inputs.skip-arc-mapping != 'true'
         env:
           FILTERED_TEST_MATRIX: ${{ steps.filter.outputs.test-matrix }}
           RUNNER_PREFIX: ${{ inputs.runner_prefix }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -105,6 +105,20 @@ on:
         required: false
         type: string
         default: ""
+      docker-container-options:
+        description: |
+          Extra options passed to the job container. Defaults to the standard
+          "--gpus all"; the BPF-TD trace workflow overrides this to add BPF caps.
+        required: false
+        type: string
+        default: "--gpus all"
+      bpf-td:
+        description: |
+          If set to "1", run the test command under bpf_td/run_traced.sh to
+          collect syscall traces for target-determination mapping.
+        required: false
+        type: string
+        default: ""
     secrets:
       HUGGING_FACE_HUB_TOKEN:
         required: false
@@ -133,7 +147,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ inputs.docker-image }}
-      options: "--gpus all"
+      options: ${{ inputs.docker-container-options }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       id-token: write
@@ -215,7 +229,7 @@ jobs:
           for dll in win-torch-wheel/cudart64_*.dll; do
             if [ -f "$dll" ]; then
               mv "$dll" win-torch-wheel-extracted/bin/x64/
-              echo "Moved $(basename $dll) to win-torch-wheel-extracted/bin/x64/"
+              echo "Moved $(basename "$dll") to win-torch-wheel-extracted/bin/x64/"
             fi
           done
 
@@ -306,6 +320,7 @@ jobs:
           ARTIFACTS_FILE_SUFFIX: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.setup-linux.outputs.job-id }}
           TORCH_TPU_TEXT_FILE: /var/lib/jenkins/workspace/.github/ci_commit_pins/torch_tpu.txt
           USE_ARC: "1"
+          PYTORCH_BPF_TD: ${{ inputs.bpf-td }}
         shell: bash
         run: |
           set -x
@@ -343,7 +358,12 @@ jobs:
 
           # shellcheck disable=SC2046
           python3 -m pip install $(echo dist/*.whl)[opt-einsum]
-          ${TEST_COMMAND}
+          if [[ "${PYTORCH_BPF_TD}" == "1" ]]; then
+            # shellcheck disable=SC2086
+            tools/testing/bpf_td/run_traced.sh ${TEST_COMMAND}
+          else
+            ${TEST_COMMAND}
+          fi
 
       - name: Configure AWS credentials
         id: aws-creds-benchmark

--- a/.github/workflows/bpf-td-trace.yml
+++ b/.github/workflows/bpf-td-trace.yml
@@ -31,31 +31,69 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       check_experiments: lf
 
-  # Fail fast (minutes, not hours) if the runner/docker policy forbids the BPF
-  # caps the trace job needs. Uses a tiny image on the same runner+caps combo.
-  bpf-canary:
-    name: bpf-canary
+  # Canary variants -- test three BPF-caps hypotheses in ONE run so we spend
+  # one CI round-trip, not one per hypothesis. All three are independent and
+  # non-blocking on each other; build/test gate on canary-capadd only.
+  #
+  #   control  -- same runner label, plain container, no extra options. If this
+  #               schedules but canary-capadd does not, the cap options (not the
+  #               label/pool) are what blocks scheduling.
+  #   capadd   -- job-level container with cap-add set (the test-job approach).
+  #   bare     -- no job-level container; docker run --privileged on the bare
+  #               runner (the proven _rocm-test / _s390x pattern).
+
+  canary-control:
+    name: canary-control
     needs: get-label-type
     runs-on: ${{ needs.get-label-type.outputs.label-type }}linux.4xlarge
+    timeout-minutes: 20
     container:
       image: ubuntu:22.04
-      options: "--privileged"
     steps:
-      - name: Install bpftrace
-        run: |
-          apt-get update -y
-          apt-get install -y bpftrace
-      - name: Attach a probe
+      - name: Scheduled and started
+        run: true
+
+  canary-capadd:
+    name: canary-capadd
+    needs: get-label-type
+    runs-on: ${{ needs.get-label-type.outputs.label-type }}linux.4xlarge
+    timeout-minutes: 20
+    container:
+      image: ubuntu:22.04
+      options: "--cap-add=SYS_ADMIN --cap-add=PERFMON --cap-add=BPF --security-opt seccomp=unconfined"
+    steps:
+      - name: Install bpftrace and attach a probe
         run: |
           set -eux
+          apt-get update -y && apt-get install -y bpftrace
           timeout 30 bpftrace -e \
             'tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }'
+
+  canary-bare:
+    name: canary-bare
+    needs: get-label-type
+    runs-on: ${{ needs.get-label-type.outputs.label-type }}linux.4xlarge
+    timeout-minutes: 20
+    steps:
+      - name: Setup Linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@main
+        with:
+          use-arc: true
+          submodules: 'false'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: docker run --privileged + bpftrace
+        run: |
+          set -eux
+          docker run --rm --privileged --security-opt seccomp=unconfined ubuntu:22.04 \
+            bash -c "apt-get update -qq && apt-get install -qq -y bpftrace && \
+              timeout 30 bpftrace -e \
+              'tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }'"
 
   build:
     name: linux-jammy-py3.10-gcc11
     needs:
       - get-label-type
-      - bpf-canary
+      - canary-capadd
     uses: ./.github/workflows/_linux-build.yml
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
@@ -90,7 +128,7 @@ jobs:
       build-environment: ${{ needs.build.outputs.build-environment }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      docker-container-options: "--gpus all --privileged"
+      docker-container-options: "--gpus all --cap-add=SYS_ADMIN --cap-add=PERFMON --cap-add=BPF --security-opt seccomp=unconfined"
       bpf-td: "1"
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/bpf-td-trace.yml
+++ b/.github/workflows/bpf-td-trace.yml
@@ -1,0 +1,97 @@
+# Owner(s): ["module: ci"]
+# TEMPORARY experimental workflow for BPF-traced target determination (phase 1).
+# Runs one Linux CPU config with all tests (NO_TD=1) under bpftrace syscall
+# tracing, uploads a test-file -> touched-files mapping plus the build graph.
+# Triggers only on its own PR (paths filter) and manual dispatch.
+name: bpf-td-trace
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/bpf-td-trace.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  get-label-type:
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    if: github.repository_owner == 'pytorch'
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      check_experiments: lf
+
+  # Fail fast (minutes, not hours) if the runner/docker policy forbids the BPF
+  # caps the trace job needs. Uses a tiny image on the same runner+caps combo.
+  bpf-canary:
+    name: bpf-canary
+    needs: get-label-type
+    runs-on: ${{ needs.get-label-type.outputs.label-type }}linux.4xlarge
+    container:
+      image: ubuntu:22.04
+      options: "--privileged"
+    steps:
+      - name: Install bpftrace
+        run: |
+          apt-get update -y
+          apt-get install -y bpftrace
+      - name: Attach a probe
+        run: |
+          set -eux
+          timeout 30 bpftrace -e \
+            'tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }'
+
+  build:
+    name: linux-jammy-py3.10-gcc11
+    needs:
+      - get-label-type
+      - bpf-canary
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-jammy-py3.10-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang18
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      bpf-td-extract-build-graph: "1"
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 2, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 3, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 4, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 5, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 6, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 7, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 8, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 9, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 10, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+        ]}
+      python-version: "3.10"
+      compiler: gcc11
+    secrets: inherit
+
+  test:
+    name: linux-jammy-py3.10-gcc11
+    needs:
+      - build
+      - get-label-type
+    uses: ./.github/workflows/_linux-test.yml
+    with:
+      build-environment: ${{ needs.build.outputs.build-environment }}
+      docker-image: ${{ needs.build.outputs.docker-image }}
+      test-matrix: ${{ needs.build.outputs.test-matrix }}
+      docker-container-options: "--gpus all --privileged"
+      bpf-td: "1"
+      python-version: "3.10"
+      compiler: gcc11
+    secrets: inherit

--- a/.github/workflows/bpf-td-trace.yml
+++ b/.github/workflows/bpf-td-trace.yml
@@ -66,10 +66,12 @@ jobs:
       - canary
     uses: ./.github/workflows/_linux-build.yml
     with:
-      # Keep raw EC2 labels (skip-arc-mapping) so the test shards land on the
-      # classic docker-on-VM pool where a privileged container can mount
-      # tracefs; ARC strips those caps. The build itself still runs on ARC.
-      runner_prefix: ""
+      # skip-arc-mapping keeps the test matrix's raw EC2 labels (linux.4xlarge)
+      # so shards land on the classic docker-on-VM pool where a privileged
+      # container can mount tracefs (ARC strips those caps). runner_prefix still
+      # applies to the BUILD's own runner (label-type is mt-); zeroing it points
+      # the build at a dead bare label, so keep it.
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       skip-arc-mapping: "true"
       build-environment: linux-jammy-py3.10-gcc11
       docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang18

--- a/.github/workflows/bpf-td-trace.yml
+++ b/.github/workflows/bpf-td-trace.yml
@@ -61,32 +61,32 @@ jobs:
 
   build:
     name: linux-jammy-py3.10-gcc11
-    # Disabled this round: build+test would ARC-map to l-x86iavx512 and can't
-    # trace. Re-enable once the EC2 routing (skip-arc-mapping) lands, after the
-    # canary confirms which attach path works.
-    if: false
     needs:
       - get-label-type
       - canary
     uses: ./.github/workflows/_linux-build.yml
     with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      # Keep raw EC2 labels (skip-arc-mapping) so the test shards land on the
+      # classic docker-on-VM pool where a privileged container can mount
+      # tracefs; ARC strips those caps. The build itself still runs on ARC.
+      runner_prefix: ""
+      skip-arc-mapping: "true"
       build-environment: linux-jammy-py3.10-gcc11
       docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang18
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       bpf-td-extract-build-graph: "1"
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 2, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 3, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 4, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 5, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 6, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 7, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 8, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 9, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 10, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 1, num_shards: 10, runner: "linux.4xlarge" },
+          { config: "default", shard: 2, num_shards: 10, runner: "linux.4xlarge" },
+          { config: "default", shard: 3, num_shards: 10, runner: "linux.4xlarge" },
+          { config: "default", shard: 4, num_shards: 10, runner: "linux.4xlarge" },
+          { config: "default", shard: 5, num_shards: 10, runner: "linux.4xlarge" },
+          { config: "default", shard: 6, num_shards: 10, runner: "linux.4xlarge" },
+          { config: "default", shard: 7, num_shards: 10, runner: "linux.4xlarge" },
+          { config: "default", shard: 8, num_shards: 10, runner: "linux.4xlarge" },
+          { config: "default", shard: 9, num_shards: 10, runner: "linux.4xlarge" },
+          { config: "default", shard: 10, num_shards: 10, runner: "linux.4xlarge" },
         ]}
       python-version: "3.10"
       compiler: gcc11
@@ -102,7 +102,9 @@ jobs:
       build-environment: ${{ needs.build.outputs.build-environment }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      docker-container-options: "--gpus all --cap-add=SYS_ADMIN --cap-add=PERFMON --cap-add=BPF --security-opt seccomp=unconfined"
+      # EC2 docker-on-VM honors these; privileged lets run_traced.sh mount
+      # tracefs. No --gpus all: this is a CPU pool with no nvidia runtime.
+      docker-container-options: "--privileged --security-opt seccomp=unconfined"
       bpf-td: "1"
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/bpf-td-trace.yml
+++ b/.github/workflows/bpf-td-trace.yml
@@ -31,46 +31,55 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       check_experiments: lf
 
-  # Prior run settled two questions: a plain job-level container schedules and
-  # runs on this label (control passed), and a bare no-container job is
-  # forbidden here ("Jobs without a job container are forbidden on this
-  # runner"), so a job-level container is mandatory. The cap-add container also
-  # scheduled and started fine -- scheduling was never the blocker. It failed
-  # only at "tracepoint not found: syscalls:sys_enter_openat", i.e. tracefs is
-  # not visible in the pod. This canary mounts host tracefs/debugfs and dumps
-  # caps + tracefs + attach state in one shot, so a single round-trip tells us
-  # whether in-container bpftrace is viable on these ARC runners at all.
-  canary-capadd:
-    name: canary-capadd
-    needs: get-label-type
-    runs-on: ${{ needs.get-label-type.outputs.label-type }}l-x86iavx512-16-128
+  # The ARC/k8s fleet is a dead end: its container hook silently ignores
+  # container cap-add options and hostPath volume mounts (effective caps came
+  # back as the stock docker default, no tracefs mounted). Per Eli, the classic
+  # EC2 docker-on-VM pool still exists behind the UNPREFIXED linux.4xlarge label
+  # (only prefixed labels route to ARC). This canary runs bare (no job-level
+  # container) on that pool and tests both attach paths in one shot:
+  #   1. host-side: sudo bpftrace directly on the runner VM (simplest wiring).
+  #   2. docker run --privileged: bpftrace inside a privileged container.
+  # Each is best-effort with a clear verdict line; the job fails only if both
+  # fail so a total dead end is visible.
+  canary:
+    name: canary
+    runs-on: linux.4xlarge
     timeout-minutes: 20
-    container:
-      image: ubuntu:22.04
-      options: "--cap-add=SYS_ADMIN --cap-add=PERFMON --cap-add=BPF --security-opt seccomp=unconfined"
-      volumes:
-        - /sys/kernel/debug:/sys/kernel/debug:rw
-        - /sys/kernel/tracing:/sys/kernel/tracing:rw
     steps:
-      - name: Diagnose caps + tracefs, then attach bpftrace
+      - name: host-side sudo bpftrace
+        id: host
+        continue-on-error: true
         run: |
-          set -ux
-          apt-get update -y && apt-get install -y bpftrace
-          echo "=== effective caps ==="; grep Cap /proc/self/status || true
-          echo "=== tracefs/debugfs mounts ==="; mount | grep -E "tracefs|debugfs" || true
-          echo "=== syscall tracepoint present? ==="
-          ls -la /sys/kernel/debug/tracing/events/syscalls/sys_enter_openat 2>&1 || true
-          ls -la /sys/kernel/tracing/events/syscalls/sys_enter_openat 2>&1 || true
-          echo "=== bpftrace --info (probe support) ==="; bpftrace --info 2>&1 | head -30 || true
-          echo "=== attach attempt (this is the gate) ==="
-          timeout 30 bpftrace -e \
+          set -x
+          sudo apt-get update -y && sudo apt-get install -y bpftrace
+          sudo timeout 30 bpftrace -e \
             'tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }'
+          echo "HOST_BPFTRACE=pass"
+      - name: docker run --privileged bpftrace
+        id: docker
+        continue-on-error: true
+        run: |
+          set -x
+          docker run --rm --privileged --security-opt seccomp=unconfined ubuntu:22.04 \
+            bash -c "apt-get update -qq && apt-get install -qq -y bpftrace && \
+              timeout 30 bpftrace -e \
+              'tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }'"
+          echo "DOCKER_BPFTRACE=pass"
+      - name: Verdict
+        run: |
+          echo "host=${{ steps.host.outcome }} docker=${{ steps.docker.outcome }}"
+          [ "${{ steps.host.outcome }}" = "success" ] || \
+            [ "${{ steps.docker.outcome }}" = "success" ]
 
   build:
     name: linux-jammy-py3.10-gcc11
+    # Disabled this round: build+test would ARC-map to l-x86iavx512 and can't
+    # trace. Re-enable once the EC2 routing (skip-arc-mapping) lands, after the
+    # canary confirms which attach path works.
+    if: false
     needs:
       - get-label-type
-      - canary-capadd
+      - canary
     uses: ./.github/workflows/_linux-build.yml
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"

--- a/.github/workflows/bpf-td-trace.yml
+++ b/.github/workflows/bpf-td-trace.yml
@@ -31,28 +31,15 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       check_experiments: lf
 
-  # Canary variants -- test three BPF-caps hypotheses in ONE run so we spend
-  # one CI round-trip, not one per hypothesis. All three are independent and
-  # non-blocking on each other; build/test gate on canary-capadd only.
-  #
-  #   control  -- same runner label, plain container, no extra options. If this
-  #               schedules but canary-capadd does not, the cap options (not the
-  #               label/pool) are what blocks scheduling.
-  #   capadd   -- job-level container with cap-add set (the test-job approach).
-  #   bare     -- no job-level container; docker run --privileged on the bare
-  #               runner (the proven _rocm-test / _s390x pattern).
-
-  canary-control:
-    name: canary-control
-    needs: get-label-type
-    runs-on: ${{ needs.get-label-type.outputs.label-type }}l-x86iavx512-16-128
-    timeout-minutes: 20
-    container:
-      image: ubuntu:22.04
-    steps:
-      - name: Scheduled and started
-        run: true
-
+  # Prior run settled two questions: a plain job-level container schedules and
+  # runs on this label (control passed), and a bare no-container job is
+  # forbidden here ("Jobs without a job container are forbidden on this
+  # runner"), so a job-level container is mandatory. The cap-add container also
+  # scheduled and started fine -- scheduling was never the blocker. It failed
+  # only at "tracepoint not found: syscalls:sys_enter_openat", i.e. tracefs is
+  # not visible in the pod. This canary mounts host tracefs/debugfs and dumps
+  # caps + tracefs + attach state in one shot, so a single round-trip tells us
+  # whether in-container bpftrace is viable on these ARC runners at all.
   canary-capadd:
     name: canary-capadd
     needs: get-label-type
@@ -61,33 +48,23 @@ jobs:
     container:
       image: ubuntu:22.04
       options: "--cap-add=SYS_ADMIN --cap-add=PERFMON --cap-add=BPF --security-opt seccomp=unconfined"
+      volumes:
+        - /sys/kernel/debug:/sys/kernel/debug:rw
+        - /sys/kernel/tracing:/sys/kernel/tracing:rw
     steps:
-      - name: Install bpftrace and attach a probe
+      - name: Diagnose caps + tracefs, then attach bpftrace
         run: |
-          set -eux
+          set -ux
           apt-get update -y && apt-get install -y bpftrace
+          echo "=== effective caps ==="; grep Cap /proc/self/status || true
+          echo "=== tracefs/debugfs mounts ==="; mount | grep -E "tracefs|debugfs" || true
+          echo "=== syscall tracepoint present? ==="
+          ls -la /sys/kernel/debug/tracing/events/syscalls/sys_enter_openat 2>&1 || true
+          ls -la /sys/kernel/tracing/events/syscalls/sys_enter_openat 2>&1 || true
+          echo "=== bpftrace --info (probe support) ==="; bpftrace --info 2>&1 | head -30 || true
+          echo "=== attach attempt (this is the gate) ==="
           timeout 30 bpftrace -e \
             'tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }'
-
-  canary-bare:
-    name: canary-bare
-    needs: get-label-type
-    runs-on: ${{ needs.get-label-type.outputs.label-type }}l-x86iavx512-16-128
-    timeout-minutes: 20
-    steps:
-      - name: Setup Linux
-        uses: pytorch/pytorch/.github/actions/setup-linux@main
-        with:
-          use-arc: true
-          submodules: 'false'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: docker run --privileged + bpftrace
-        run: |
-          set -eux
-          docker run --rm --privileged --security-opt seccomp=unconfined ubuntu:22.04 \
-            bash -c "apt-get update -qq && apt-get install -qq -y bpftrace && \
-              timeout 30 bpftrace -e \
-              'tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }'"
 
   build:
     name: linux-jammy-py3.10-gcc11

--- a/.github/workflows/bpf-td-trace.yml
+++ b/.github/workflows/bpf-td-trace.yml
@@ -31,45 +31,32 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       check_experiments: lf
 
-  # The ARC/k8s fleet is a dead end: its container hook silently ignores
-  # container cap-add options and hostPath volume mounts (effective caps came
-  # back as the stock docker default, no tracefs mounted). Per Eli, the classic
-  # EC2 docker-on-VM pool still exists behind the UNPREFIXED linux.4xlarge label
-  # (only prefixed labels route to ARC). This canary runs bare (no job-level
-  # container) on that pool and tests both attach paths in one shot:
-  #   1. host-side: sudo bpftrace directly on the runner VM (simplest wiring).
-  #   2. docker run --privileged: bpftrace inside a privileged container.
-  # Each is best-effort with a clear verdict line; the job fails only if both
-  # fail so a total dead end is visible.
+  # Prior EC2 run settled it: a bare (no job-level container) job schedules on
+  # the unprefixed linux.4xlarge pool (real EC2 instance, c5.4xlarge). Host-side
+  # bpftrace is out (the host AMI has no apt and no preinstalled bpftrace), and
+  # docker run --privileged failed only at "tracepoint not found" because a
+  # privileged container does not auto-mount tracefs. Unlike ARC, a real
+  # docker-on-VM host lets a privileged container mount debugfs/tracefs itself
+  # (it has CAP_SYS_ADMIN). This canary proves that recipe end to end.
   canary:
     name: canary
     runs-on: linux.4xlarge
     timeout-minutes: 20
     steps:
-      - name: host-side sudo bpftrace
-        id: host
-        continue-on-error: true
+      - name: docker run --privileged, self-mount tracefs, attach bpftrace
         run: |
-          set -x
-          sudo apt-get update -y && sudo apt-get install -y bpftrace
-          sudo timeout 30 bpftrace -e \
-            'tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }'
-          echo "HOST_BPFTRACE=pass"
-      - name: docker run --privileged bpftrace
-        id: docker
-        continue-on-error: true
-        run: |
-          set -x
+          set -eux
           docker run --rm --privileged --security-opt seccomp=unconfined ubuntu:22.04 \
-            bash -c "apt-get update -qq && apt-get install -qq -y bpftrace && \
+            bash -c '
+              set -eux
+              mount -t debugfs debugfs /sys/kernel/debug 2>/dev/null || true
+              mount -t tracefs tracefs /sys/kernel/tracing 2>/dev/null || true
+              ls /sys/kernel/debug/tracing/events/syscalls/sys_enter_openat \
+                || ls /sys/kernel/tracing/events/syscalls/sys_enter_openat
+              apt-get update -qq && apt-get install -qq -y bpftrace
               timeout 30 bpftrace -e \
-              'tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }'"
-          echo "DOCKER_BPFTRACE=pass"
-      - name: Verdict
-        run: |
-          echo "host=${{ steps.host.outcome }} docker=${{ steps.docker.outcome }}"
-          [ "${{ steps.host.outcome }}" = "success" ] || \
-            [ "${{ steps.docker.outcome }}" = "success" ]
+                "tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }"
+            '
 
   build:
     name: linux-jammy-py3.10-gcc11

--- a/.github/workflows/bpf-td-trace.yml
+++ b/.github/workflows/bpf-td-trace.yml
@@ -31,19 +31,17 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       check_experiments: lf
 
-  # Prior EC2 run settled it: a bare (no job-level container) job schedules on
-  # the unprefixed linux.4xlarge pool (real EC2 instance, c5.4xlarge). Host-side
-  # bpftrace is out (the host AMI has no apt and no preinstalled bpftrace), and
-  # docker run --privileged failed only at "tracepoint not found" because a
-  # privileged container does not auto-mount tracefs. Unlike ARC, a real
-  # docker-on-VM host lets a privileged container mount debugfs/tracefs itself
-  # (it has CAP_SYS_ADMIN). This canary proves that recipe end to end.
+  # Prior EC2 run got further: the privileged container self-mounted tracefs
+  # fine (tracepoint present), then failed because Ubuntu 22.04's bpftrace 0.14
+  # does BCC-style header compilation and needs linux/types.h (absent). Fix:
+  # use the upstream static bpftrace binary (BTF/CO-RE, no kernel headers) --
+  # the same mechanism the jammy test container will use via run_traced.sh.
   canary:
     name: canary
     runs-on: linux.4xlarge
     timeout-minutes: 20
     steps:
-      - name: docker run --privileged, self-mount tracefs, attach bpftrace
+      - name: docker run --privileged, self-mount tracefs, static bpftrace attach
         run: |
           set -eux
           docker run --rm --privileged --security-opt seccomp=unconfined ubuntu:22.04 \
@@ -51,9 +49,12 @@ jobs:
               set -eux
               mount -t debugfs debugfs /sys/kernel/debug 2>/dev/null || true
               mount -t tracefs tracefs /sys/kernel/tracing 2>/dev/null || true
-              ls /sys/kernel/debug/tracing/events/syscalls/sys_enter_openat \
-                || ls /sys/kernel/tracing/events/syscalls/sys_enter_openat
-              apt-get update -qq && apt-get install -qq -y bpftrace
+              apt-get update -qq && apt-get install -qq -y curl ca-certificates
+              curl -fsSL -o /usr/local/bin/bpftrace \
+                https://github.com/bpftrace/bpftrace/releases/download/v0.26.1/bpftrace
+              chmod +x /usr/local/bin/bpftrace
+              bpftrace --version
+              ls /sys/kernel/btf/vmlinux
               timeout 30 bpftrace -e \
                 "tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }"
             '

--- a/.github/workflows/bpf-td-trace.yml
+++ b/.github/workflows/bpf-td-trace.yml
@@ -105,8 +105,10 @@ jobs:
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       # EC2 docker-on-VM honors these; privileged lets run_traced.sh mount
-      # tracefs. No --gpus all: this is a CPU pool with no nvidia runtime.
-      docker-container-options: "--privileged --security-opt seccomp=unconfined"
+      # tracefs. --pid=host makes container pids equal the host pids that
+      # system-wide bpftrace reports, so the pid-tree join in build_mapping.py
+      # matches (without it every test maps to 0 files). No --gpus all: CPU pool.
+      docker-container-options: "--privileged --pid=host --security-opt seccomp=unconfined"
       bpf-td: "1"
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/bpf-td-trace.yml
+++ b/.github/workflows/bpf-td-trace.yml
@@ -45,7 +45,7 @@ jobs:
   canary-control:
     name: canary-control
     needs: get-label-type
-    runs-on: ${{ needs.get-label-type.outputs.label-type }}linux.4xlarge
+    runs-on: ${{ needs.get-label-type.outputs.label-type }}l-x86iavx512-16-128
     timeout-minutes: 20
     container:
       image: ubuntu:22.04
@@ -56,7 +56,7 @@ jobs:
   canary-capadd:
     name: canary-capadd
     needs: get-label-type
-    runs-on: ${{ needs.get-label-type.outputs.label-type }}linux.4xlarge
+    runs-on: ${{ needs.get-label-type.outputs.label-type }}l-x86iavx512-16-128
     timeout-minutes: 20
     container:
       image: ubuntu:22.04
@@ -72,7 +72,7 @@ jobs:
   canary-bare:
     name: canary-bare
     needs: get-label-type
-    runs-on: ${{ needs.get-label-type.outputs.label-type }}linux.4xlarge
+    runs-on: ${{ needs.get-label-type.outputs.label-type }}l-x86iavx512-16-128
     timeout-minutes: 20
     steps:
       - name: Setup Linux

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -676,6 +676,13 @@ def run_test(
     )
     print_to_stderr(f"Executing {command} ... [{datetime.now()}]")
 
+    # BPF-TD: record the owning process pid + monotonic time window so the
+    # post-processor can attribute this test file's syscall-traced pid subtree.
+    # The test subprocess is forked from this (pool worker) process, so its
+    # whole descendant tree is captured by pid-tree join in build_mapping.py.
+    bpf_td_dir = os.environ.get("PYTORCH_BPF_TD_TRACE_DIR")
+    bpf_td_start = time.clock_gettime(time.CLOCK_MONOTONIC) if bpf_td_dir else None
+
     with ExitStack() as stack:
         output = None
         if options.pipe_logs:
@@ -712,6 +719,24 @@ def run_test(
             # this writing have been excluded and new ones should be added to
             # the list of exclusions in tools/testing/discover_tests.py
             ret_code = 0 if ret_code == 5 else ret_code
+
+    if bpf_td_dir:
+        record = {
+            "test_file": test_file,
+            "pid": os.getpid(),
+            "start_ns": int(bpf_td_start * 1e9),
+            "end_ns": int(time.clock_gettime(time.CLOCK_MONOTONIC) * 1e9),
+        }
+        line = json.dumps(record) + "\n"
+        fd = os.open(
+            os.path.join(bpf_td_dir, "test_pids.jsonl"),
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            0o644,
+        )
+        try:
+            os.write(fd, line.encode())
+        finally:
+            os.close(fd)
 
     if options.pipe_logs and print_log:
         handle_log_file(

--- a/tools/testing/bpf_td/build_mapping.py
+++ b/tools/testing/bpf_td/build_mapping.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Join bpftrace output with run_test.py pid records into a test-file -> touched-files map.
+
+The tracer (trace_opens.bt) emits fork/exec/open events tagged with monotonic
+nanosecond timestamps. run_test.py records, per test file, the pool-worker pid
+that spawned the test subprocess plus the [start, end] monotonic window. Here we
+reconstruct each test's pid subtree (descendants of the worker forked inside the
+window) and attribute the files those pids opened, filtered to the repo checkout
+and the installed torch package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import defaultdict
+
+
+def parse_trace(path):
+    """Return (forks, events) where forks is a list of (ns, ppid, cpid) sorted by
+    ns, and events is a dict pid -> list of (ns, abspath) for open/exec events."""
+    forks = []
+    events = defaultdict(list)
+    with open(path, errors="replace") as f:
+        for line in f:
+            parts = line.split(" ", 3)
+            if len(parts) < 3:
+                continue
+            tag = parts[0]
+            try:
+                ns = int(parts[1])
+                pid = int(parts[2])
+            except ValueError:
+                continue
+            if tag == "F":
+                if len(parts) < 4:
+                    continue
+                try:
+                    cpid = int(parts[3].strip())
+                except ValueError:
+                    continue
+                forks.append((ns, pid, cpid))
+            elif tag in ("O", "E"):
+                if len(parts) < 4:
+                    continue
+                p = parts[3].rstrip("\n")
+                if p.startswith("/"):
+                    events[pid].append((ns, p))
+    forks.sort()
+    return forks, events
+
+
+def subtree_pids(forks, owner, start_ns, end_ns):
+    """Pids forked (transitively) from owner within [start_ns, end_ns].
+
+    forks is sorted by ns, so a single ascending pass reaches fixpoint: a child
+    is always forked after its parent joined the tree."""
+    included = set()
+    for ns, ppid, cpid in forks:
+        if ns < start_ns or ns > end_ns:
+            continue
+        if ppid == owner or ppid in included:
+            included.add(cpid)
+    return included
+
+
+def normalize(path, repo_root, torch_root):
+    """Map an absolute path to a repo-relative path, or None if outside scope."""
+    if repo_root and path.startswith(repo_root):
+        rel = os.path.relpath(path, repo_root)
+        if not rel.startswith(".."):
+            return rel
+    if torch_root and path.startswith(torch_root):
+        # torch_root is .../site-packages/torch; key generated/installed files
+        # under a stable "torch/..." prefix.
+        rel = os.path.relpath(path, os.path.dirname(torch_root))
+        if not rel.startswith(".."):
+            return rel
+    return None
+
+
+def build(forks, events, records, repo_root, torch_root):
+    mapping = defaultdict(set)
+    for rec in records:
+        owner = rec["pid"]
+        start_ns, end_ns = rec["start_ns"], rec["end_ns"]
+        pids = subtree_pids(forks, owner, start_ns, end_ns)
+        touched = mapping[rec["test_file"]]
+        for pid in pids:
+            for ns, path in events.get(pid, ()):
+                if start_ns <= ns <= end_ns:
+                    rel = normalize(path, repo_root, torch_root)
+                    if rel is not None:
+                        touched.add(rel)
+    return mapping
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--trace", required=True, help="bpftrace output file")
+    ap.add_argument("--pids", required=True, help="test_pids.jsonl from run_test.py")
+    ap.add_argument("--repo-root", required=True)
+    ap.add_argument("--torch-root", default="", help="installed torch package dir")
+    ap.add_argument("--config", default=os.environ.get("TEST_CONFIG", "unknown"))
+    ap.add_argument("--shard", default=os.environ.get("SHARD_NUMBER", "0"))
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    repo_root = os.path.realpath(args.repo_root)
+    torch_root = os.path.realpath(args.torch_root) if args.torch_root else ""
+
+    forks, events = parse_trace(args.trace)
+    records = []
+    with open(args.pids, errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+
+    mapping = build(forks, events, records, repo_root, torch_root)
+    out = {tf: sorted(paths) for tf, paths in sorted(mapping.items())}
+    out["meta"] = {
+        "config": args.config,
+        "shard": args.shard,
+        "num_test_files": len(mapping),
+        "num_fork_events": len(forks),
+        "num_pid_records": len(records),
+        "total_paths": sum(len(v) for v in mapping.values()),
+    }
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(out, f, indent=2, sort_keys=True)
+    print(f"wrote {args.out}: {out['meta']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/testing/bpf_td/build_mapping.py
+++ b/tools/testing/bpf_td/build_mapping.py
@@ -65,15 +65,27 @@ def subtree_pids(forks, owner, start_ns, end_ns):
     return included
 
 
+# Runtime writes under the repo that are not source dependencies.
+_NOISE = ("/.git/", "/.pytest_cache/", "/test/test-reports/", "/.additional_ci_files/")
+
+
 def normalize(path, repo_root, torch_root):
     """Map an absolute path to a repo-relative path, or None if outside scope."""
-    if repo_root and path.startswith(repo_root):
+    if any(n in path for n in _NOISE):
+        return None
+    if repo_root and path.startswith(repo_root + os.sep):
         rel = os.path.relpath(path, repo_root)
         if not rel.startswith(".."):
             return rel
-    if torch_root and path.startswith(torch_root):
-        # torch_root is .../site-packages/torch; key generated/installed files
-        # under a stable "torch/..." prefix.
+    # Tests import the INSTALLED torch from site/dist-packages; map it back to
+    # the repo-relative "torch/..." so a changed repo file joins to the runtime
+    # open. This pattern is independent of torch_root env detection (which has
+    # proven unreliable in CI).
+    for marker in ("/site-packages/", "/dist-packages/"):
+        i = path.find(marker + "torch/")
+        if i != -1:
+            return path[i + len(marker):]
+    if torch_root and path.startswith(torch_root + os.sep):
         rel = os.path.relpath(path, os.path.dirname(torch_root))
         if not rel.startswith(".."):
             return rel

--- a/tools/testing/bpf_td/build_mapping.py
+++ b/tools/testing/bpf_td/build_mapping.py
@@ -80,16 +80,18 @@ def normalize(path, repo_root, torch_root):
     return None
 
 
-def build(forks, events, records, repo_root, torch_root):
+def build(forks, events, records, repo_root, torch_root, diag):
     mapping = defaultdict(set)
     for rec in records:
         owner = rec["pid"]
         start_ns, end_ns = rec["start_ns"], rec["end_ns"]
         pids = subtree_pids(forks, owner, start_ns, end_ns)
+        diag["subtree_pids"] += len(pids)
         touched = mapping[rec["test_file"]]
         for pid in pids:
             for ns, path in events.get(pid, ()):
                 if start_ns <= ns <= end_ns:
+                    diag["paths_pre_filter"] += 1
                     rel = normalize(path, repo_root, torch_root)
                     if rel is not None:
                         touched.add(rel)
@@ -118,15 +120,32 @@ def main():
             if line:
                 records.append(json.loads(line))
 
-    mapping = build(forks, events, records, repo_root, torch_root)
+    diag = {"subtree_pids": 0, "paths_pre_filter": 0}
+    mapping = build(forks, events, records, repo_root, torch_root, diag)
+
+    # Diagnostics to distinguish failure modes without shipping the raw trace:
+    # pid_overlap == 0 means the recorded owner pids never appear as fork
+    # parents -> pid-namespace mismatch (need --pid=host). paths_pre_filter > 0
+    # but total_paths == 0 -> the repo/torch normalize filter dropped everything.
+    fork_ppids = {ppid for _, ppid, _ in forks}
+    record_pids = {r["pid"] for r in records}
+    sample_paths = sorted({p for evs in events.values() for _, p in evs})[:10]
+
     out = {tf: sorted(paths) for tf, paths in sorted(mapping.items())}
     out["meta"] = {
         "config": args.config,
         "shard": args.shard,
         "num_test_files": len(mapping),
         "num_fork_events": len(forks),
+        "num_open_events": sum(len(v) for v in events.values()),
         "num_pid_records": len(records),
+        "pid_overlap": len(record_pids & fork_ppids),
+        "subtree_pids": diag["subtree_pids"],
+        "paths_pre_filter": diag["paths_pre_filter"],
         "total_paths": sum(len(v) for v in mapping.values()),
+        "repo_root": repo_root,
+        "torch_root": torch_root,
+        "sample_open_paths": sample_paths,
     }
     os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
     with open(args.out, "w") as f:

--- a/tools/testing/bpf_td/extract_build_graph.py
+++ b/tools/testing/bpf_td/extract_build_graph.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Extract a source-file -> final-build-artifact map from a ninja build dir.
+
+Combines two sources of edges:
+  * `ninja -t deps` -- compiler-discovered header/source -> object edges.
+  * `build.ninja` build statements -- every explicit input -> output edge,
+    which covers object -> .so links and codegen edges (native_functions.yaml,
+    torchgen/**, templates -> generated .cpp -> object -> .so).
+
+We then compute, for each input file, the set of *terminal* artifacts it can
+reach (shared libs, static libs, and linked executables). Terminals are what
+target determination cares about: a changed file that reaches libtorch_cpu.so
+has global blast radius; one reaching only a leaf artifact is cheap to select.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from collections import defaultdict
+
+
+def _unescape(tok):
+    return tok.replace("$:", ":").replace("$ ", " ").replace("$$", "$")
+
+
+def _join_continuations(text):
+    out = []
+    buf = ""
+    for line in text.splitlines():
+        if line.endswith("$") and not line.endswith("$$"):
+            buf += line[:-1]
+        else:
+            out.append(buf + line)
+            buf = ""
+    if buf:
+        out.append(buf)
+    return out
+
+
+def _split_tokens(s):
+    """Split a ninja path list on unescaped spaces."""
+    toks, cur, i = [], "", 0
+    while i < len(s):
+        c = s[i]
+        if c == "$" and i + 1 < len(s):
+            cur += s[i : i + 2]
+            i += 2
+            continue
+        if c == " ":
+            if cur:
+                toks.append(cur)
+                cur = ""
+        else:
+            cur += c
+        i += 1
+    if cur:
+        toks.append(cur)
+    return toks
+
+
+def parse_build_ninja(build_dir, edges):
+    """Add input -> {outputs} edges from every `build` statement."""
+    path = os.path.join(build_dir, "build.ninja")
+    if not os.path.exists(path):
+        return
+    with open(path, errors="replace") as f:
+        lines = _join_continuations(f.read())
+    for line in lines:
+        if not line.startswith("build "):
+            continue
+        rest = line[len("build ") :]
+        # Outputs and inputs are separated by the first unescaped ':'.
+        i, colon = 0, -1
+        while i < len(rest):
+            if rest[i] == "$" and i + 1 < len(rest):
+                i += 2
+                continue
+            if rest[i] == ":":
+                colon = i
+                break
+            i += 1
+        if colon < 0:
+            continue
+        outs = [_unescape(t) for t in _split_tokens(rest[:colon]) if t not in ("|",)]
+        # Input side starts after the rule name; drop rule + separators.
+        in_toks = _split_tokens(rest[colon + 1 :])
+        ins = [
+            _unescape(t)
+            for t in in_toks[1:]  # first token is the rule name
+            if t not in ("|", "||")
+        ]
+        for src in ins:
+            edges[src].update(outs)
+
+
+def parse_ninja_deps(build_dir, edges):
+    """Add dep-file -> object edges from `ninja -t deps`."""
+    try:
+        proc = subprocess.run(
+            ["ninja", "-C", build_dir, "-t", "deps"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return
+    obj = None
+    for line in proc.stdout.splitlines():
+        if not line:
+            obj = None
+        elif not line.startswith(" ") and line.rstrip().endswith(")"):
+            # e.g. "caffe2/CMakeFiles/torch_cpu.dir/foo.cpp.o: #deps ... (VALID)"
+            obj = line.split(":", 1)[0].strip()
+        elif line.startswith(" ") and obj:
+            edges[line.strip()].add(obj)
+
+
+TERMINAL_SUFFIXES = (".so", ".a", ".dylib", ".dll")
+
+
+def _is_terminal(path):
+    base = path.rsplit("/", 1)[-1]
+    if any(path.endswith(s) or ".so." in base for s in TERMINAL_SUFFIXES):
+        return True
+    # Linked executables live under bin/ with no extension.
+    return "/bin/" in path and "." not in base
+
+
+def reachable_terminals(edges):
+    """Memoized forward DFS: node -> frozenset of terminal artifacts reachable."""
+    memo = {}
+    WORKING = object()
+
+    def visit(node):
+        cached = memo.get(node)
+        if cached is not None and cached is not WORKING:
+            return cached
+        if cached is WORKING:
+            return frozenset()  # cycle guard; ninja graphs are DAGs in practice
+        memo[node] = WORKING
+        acc = set()
+        if _is_terminal(node):
+            acc.add(node)
+        for succ in edges.get(node, ()):
+            if succ != node:
+                acc |= visit(succ)
+        result = frozenset(acc)
+        memo[node] = result
+        return result
+
+    for node in list(edges.keys()):
+        visit(node)
+    return memo
+
+
+def main():
+    import sys
+
+    sys.setrecursionlimit(1 << 20)
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--build-dir", required=True)
+    ap.add_argument("--repo-root", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    build_dir = os.path.realpath(args.build_dir)
+    repo_root = os.path.realpath(args.repo_root)
+
+    edges = defaultdict(set)
+    parse_build_ninja(build_dir, edges)
+    parse_ninja_deps(build_dir, edges)
+
+    memo = reachable_terminals(edges)
+
+    def repo_rel(node):
+        p = node if os.path.isabs(node) else os.path.join(build_dir, node)
+        p = os.path.realpath(p)
+        if p.startswith(repo_root):
+            rel = os.path.relpath(p, repo_root)
+            if not rel.startswith(".."):
+                return rel
+        return None
+
+    mapping = {}
+    for node, terminals in memo.items():
+        if not terminals:
+            continue
+        rel = repo_rel(node)
+        if rel is None:
+            continue
+        mapping[rel] = sorted(os.path.basename(t) for t in terminals)
+
+    out = {
+        "sources": mapping,
+        "meta": {
+            "num_edges": sum(len(v) for v in edges.values()),
+            "num_sources": len(mapping),
+            "build_dir": build_dir,
+        },
+    }
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(out, f, indent=2, sort_keys=True)
+    print(f"wrote {args.out}: {out['meta']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/testing/bpf_td/run_traced.sh
+++ b/tools/testing/bpf_td/run_traced.sh
@@ -85,7 +85,10 @@ set -e
 stop_tracer
 trap - EXIT
 
-TORCH_ROOT="$(python -c 'import os,torch; print(os.path.dirname(torch.__file__))' 2>/dev/null || true)"
+# Fallback only: build_mapping.py also pattern-matches site-packages/torch, so
+# an empty TORCH_ROOT is not fatal. Use python3 (matches the wheel install).
+TORCH_ROOT="$(python3 -c 'import os,torch; print(os.path.dirname(torch.__file__))' 2>/dev/null || true)"
+[ -z "${TORCH_ROOT}" ] && echo "run_traced.sh: WARN torch not importable here; relying on path pattern" >&2
 OUT="${REPO_ROOT}/test/test-reports/bpf_td_mapping_${TEST_CONFIG:-unknown}_${SHARD_NUMBER:-0}.json"
 
 echo "run_traced.sh: building mapping -> ${OUT}" >&2

--- a/tools/testing/bpf_td/run_traced.sh
+++ b/tools/testing/bpf_td/run_traced.sh
@@ -27,25 +27,40 @@ PIDS_FILE="${TRACE_DIR}/test_pids.jsonl"
 
 maybe_sudo() { if [ "$(id -u)" -ne 0 ]; then sudo "$@"; else "$@"; fi; }
 
-if ! command -v bpftrace >/dev/null 2>&1; then
-    echo "run_traced.sh: installing bpftrace via apt" >&2
-    maybe_sudo apt-get update -y
-    maybe_sudo apt-get install -y bpftrace
+# The CI test container is privileged (see bpf-td-trace.yml) but does not
+# auto-mount tracefs, and its apt bpftrace is too old (BCC, needs kernel
+# headers). Mount tracefs ourselves and use the upstream static bpftrace
+# binary (BTF/CO-RE, no headers). This is the recipe proven by the canary.
+maybe_sudo mount -t debugfs debugfs /sys/kernel/debug 2>/dev/null || true
+maybe_sudo mount -t tracefs tracefs /sys/kernel/tracing 2>/dev/null || true
+
+BPFTRACE_VERSION=v0.26.1
+BPFTRACE="$(command -v bpftrace || true)"
+if [ -z "${BPFTRACE}" ]; then
+    BPFTRACE="${TRACE_DIR}/bpftrace"
+    if [ ! -x "${BPFTRACE}" ]; then
+        echo "run_traced.sh: fetching static bpftrace ${BPFTRACE_VERSION}" >&2
+        # ponytail: ~164MB download per shard; cache in the CI image or a build
+        # artifact if this outgrows the experiment.
+        curl -fsSL -o "${BPFTRACE}" \
+            "https://github.com/bpftrace/bpftrace/releases/download/${BPFTRACE_VERSION}/bpftrace"
+        chmod +x "${BPFTRACE}"
+    fi
 fi
 
-echo "run_traced.sh: verifying BPF attach capability" >&2
-if ! maybe_sudo timeout 30 bpftrace -e \
+echo "run_traced.sh: verifying BPF attach capability (${BPFTRACE})" >&2
+if ! maybe_sudo timeout 30 "${BPFTRACE}" -e \
     'tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }' \
     >/dev/null 2>"${TRACE_DIR}/canary.err"; then
     echo "run_traced.sh: FATAL: bpftrace cannot attach probes." >&2
-    echo "  The container likely lacks BPF caps (need --privileged or" >&2
-    echo "  --cap-add SYS_ADMIN --cap-add BPF --cap-add PERFMON)." >&2
+    echo "  The container likely lacks BPF caps (need --privileged) or" >&2
+    echo "  tracefs is unavailable (need a real docker-on-VM host, not ARC)." >&2
     cat "${TRACE_DIR}/canary.err" >&2 || true
     exit 3
 fi
 
 echo "run_traced.sh: starting tracer -> ${TRACE_OUT}" >&2
-maybe_sudo bpftrace "${HERE}/trace_opens.bt" >"${TRACE_OUT}" 2>"${TRACE_ERR}" &
+maybe_sudo "${BPFTRACE}" "${HERE}/trace_opens.bt" >"${TRACE_OUT}" 2>"${TRACE_ERR}" &
 TRACER_PID=$!
 
 stop_tracer() {

--- a/tools/testing/bpf_td/run_traced.sh
+++ b/tools/testing/bpf_td/run_traced.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Run a command (typically .ci/pytorch/test.sh) under system-wide bpftrace
+# syscall tracing, then post-process the trace into a test-file -> touched-files
+# map. Errors never pass silently: if BPF cannot attach we abort before running
+# the (expensive) test command.
+#
+# Usage: run_traced.sh <command> [args...]
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "run_traced.sh: no command given" >&2
+    exit 2
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../../.." && pwd)"
+TRACE_DIR="${PYTORCH_BPF_TD_TRACE_DIR:-${RUNNER_TEMP:-/tmp}/bpf_td}"
+mkdir -p "${TRACE_DIR}"
+export PYTORCH_BPF_TD_TRACE_DIR="${TRACE_DIR}"
+
+TRACE_OUT="${TRACE_DIR}/trace.out"
+TRACE_ERR="${TRACE_DIR}/trace.err"
+PIDS_FILE="${TRACE_DIR}/test_pids.jsonl"
+: >"${PIDS_FILE}"
+
+maybe_sudo() { if [ "$(id -u)" -ne 0 ]; then sudo "$@"; else "$@"; fi; }
+
+if ! command -v bpftrace >/dev/null 2>&1; then
+    echo "run_traced.sh: installing bpftrace via apt" >&2
+    maybe_sudo apt-get update -y
+    maybe_sudo apt-get install -y bpftrace
+fi
+
+echo "run_traced.sh: verifying BPF attach capability" >&2
+if ! maybe_sudo timeout 30 bpftrace -e \
+    'tracepoint:syscalls:sys_enter_openat { @n = count(); exit(); }' \
+    >/dev/null 2>"${TRACE_DIR}/canary.err"; then
+    echo "run_traced.sh: FATAL: bpftrace cannot attach probes." >&2
+    echo "  The container likely lacks BPF caps (need --privileged or" >&2
+    echo "  --cap-add SYS_ADMIN --cap-add BPF --cap-add PERFMON)." >&2
+    cat "${TRACE_DIR}/canary.err" >&2 || true
+    exit 3
+fi
+
+echo "run_traced.sh: starting tracer -> ${TRACE_OUT}" >&2
+maybe_sudo bpftrace "${HERE}/trace_opens.bt" >"${TRACE_OUT}" 2>"${TRACE_ERR}" &
+TRACER_PID=$!
+
+stop_tracer() {
+    if kill -0 "${TRACER_PID}" 2>/dev/null; then
+        maybe_sudo kill -TERM "${TRACER_PID}" 2>/dev/null || true
+        wait "${TRACER_PID}" 2>/dev/null || true
+    fi
+}
+trap stop_tracer EXIT
+
+# Give bpftrace a moment to attach before the workload starts.
+sleep 3
+
+# Trace ALL tests: disable target determination so nothing is skipped.
+export NO_TD=1
+
+set +e
+"$@"
+CMD_RC=$?
+set -e
+
+stop_tracer
+trap - EXIT
+
+TORCH_ROOT="$(python -c 'import os,torch; print(os.path.dirname(torch.__file__))' 2>/dev/null || true)"
+OUT="${REPO_ROOT}/test/test-reports/bpf_td_mapping_${TEST_CONFIG:-unknown}_${SHARD_NUMBER:-0}.json"
+
+echo "run_traced.sh: building mapping -> ${OUT}" >&2
+python "${HERE}/build_mapping.py" \
+    --trace "${TRACE_OUT}" \
+    --pids "${PIDS_FILE}" \
+    --repo-root "${REPO_ROOT}" \
+    --torch-root "${TORCH_ROOT}" \
+    --out "${OUT}"
+
+exit "${CMD_RC}"

--- a/tools/testing/bpf_td/trace_opens.bt
+++ b/tools/testing/bpf_td/trace_opens.bt
@@ -1,0 +1,47 @@
+#!/usr/bin/env bpftrace
+//
+// System-wide syscall tracer for BPF-based target determination.
+//
+// Emits line-oriented events to stdout so build_mapping.py can reconstruct
+// per-test pid trees and attribute opened files to the owning test file:
+//
+//   F <nsecs> <parent_pid> <child_pid>     process fork
+//   E <nsecs> <pid> <path>                 process exec (new image)
+//   O <nsecs> <pid> <path>                 openat / openat2 (absolute paths only)
+//
+// <nsecs> is CLOCK_MONOTONIC nanoseconds (bpf_ktime_get_ns), matching the
+// time.clock_gettime(CLOCK_MONOTONIC) timestamps recorded by run_test.py.
+//
+// In-kernel we keep only absolute-path opens (str(,2) is a 1-char string --
+// bpftrace's length arg includes the null terminator) and drop the /proc,
+// /sys, /dev firehose. Relative (dirfd-based) opens are intentionally dropped;
+// reconstructing them is out of scope for phase 1 and Python/compiler tooling
+// opens via absolute paths. build_mapping.py does the final repo/torch filter.
+
+tracepoint:sched:sched_process_fork
+{
+    printf("F %llu %d %d\n", nsecs, args->parent_pid, args->child_pid);
+}
+
+tracepoint:sched:sched_process_exec
+{
+    printf("E %llu %d %s\n", nsecs, pid, str(args->filename));
+}
+
+tracepoint:syscalls:sys_enter_openat
+/str(args->filename, 2) == "/" &&
+ strncmp(str(args->filename), "/proc", 5) != 0 &&
+ strncmp(str(args->filename), "/sys", 4) != 0 &&
+ strncmp(str(args->filename), "/dev", 4) != 0/
+{
+    printf("O %llu %d %s\n", nsecs, pid, str(args->filename));
+}
+
+tracepoint:syscalls:sys_enter_openat2
+/str(args->filename, 2) == "/" &&
+ strncmp(str(args->filename), "/proc", 5) != 0 &&
+ strncmp(str(args->filename), "/sys", 4) != 0 &&
+ strncmp(str(args->filename), "/dev", 4) != 0/
+{
+    printf("O %llu %d %s\n", nsecs, pid, str(args->filename));
+}


### PR DESCRIPTION
> [!NOTE]
> This is an **AI-authored draft PR** (Claude Code), opened on behalf of @eliuriegas per an explicit pre-authorization, as part of an experiment. It is **not for merge** — it exists to collect one round of CI trace data. Per `AI_POLICY.md`, the AI-generated description follows in the quote block below.

> ## What this is
>
> Phase-1 data collection for evaluating **eBPF syscall tracing as a target-determination (TD) signal**. PyTorch's TD already skips ~75% of tests on PRs; one of its heuristics (`Profiling`) relies on a stale, Python-only `td_heuristic_profiling.json` mapping. Syscall-level tracing can regenerate that mapping continuously and also capture native dependencies (`.so` loads, dlopen, data files) that Python coverage cannot see.
>
> ## What it does
>
> A temporary workflow `bpf-td-trace.yml` (triggers only on this PR's path filter + `workflow_dispatch`) runs the standard `linux-jammy-py3.10-gcc11` CPU config, all 10 shards, with `NO_TD=1`, wrapped in `tools/testing/bpf_td/run_traced.sh`:
>
> - `trace_opens.bt` (bpftrace) records fork/exec/open events system-wide
> - a small hook in `test/run_test.py` (gated on `PYTORCH_BPF_TD_TRACE_DIR`) records each test file's pool-worker pid + monotonic time window
> - `build_mapping.py` joins the two by pid-tree into `test/test-reports/bpf_td_mapping_*.json` (picked up by the existing artifact upload)
> - `_linux-build.yml` gains an opt-in step extracting the ninja source→artifact graph (`build_graph_map.json`) into the build artifact, so changes to codegen inputs (`native_functions.yaml`, `torchgen/`) can later be expanded to the runtime artifacts tests actually load
>
> All hooks are opt-in (`bpf-td`, `docker-container-options`, `bpf-td-extract-build-graph` inputs); **default CI behavior is unchanged** — `docker-container-options` defaults to the previously hardcoded `--gpus all`. A fast `bpf-canary` job fails in minutes if runner policy forbids `--privileged`/BPF.
>
> ## What happens next
>
> One successful traced run → artifacts feed an offline backtest against the last 2500 main commits (time-savings % + failure-recall vs recorded test stats). Results will be shared separately; this PR then closes.
