### PR TITLE
Revert "Update ROCm dynamic TIMM training baseline"

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_timm_training.csv
@@ -66,7 +66,7 @@ visformer_small,pass,7
 
 
 
-vit_base_patch14_dinov2.lvd142m,fail_accuracy,7
+vit_base_patch14_dinov2.lvd142m,pass,7
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190245
* #190794
* #190246
* #186414
* __->__ #191053
* #191052
* #190244
* #190243

This reverts commit 7e731bc138bc5174ed2a0a2568601fa5037c207e.