### PR TITLE
[torch][inductor] Get shape information for extern/Aten kernels with enable_kernel_profile (#191063)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -294,6 +294,31 @@ def _record_bmm_shared_a_choices(example_inputs, model=None, **config_overrides)
     return offered
 
 
+def profiled_ivalue_kinds(code, kernel_name):
+    """The kinds of IValue recorded for the profiled kernel whose recorded name
+    matches kernel_name, in recorded order: "tensor" for a real tensor handle
+    and "scalar" for the placeholder that stands in for a non-tensor argument.
+
+    kernel_name is matched against the whole recorded name so a fused Triton
+    kernel over the same op cannot be picked up by mistake. Reading the IValue
+    vector rather than the individual conversions pins down the order as well
+    as the count."""
+    record = re.search(
+        rf'RAIIAtenRecordFunctionHandle \w+\("{kernel_name}", nullptr, (\w+)\);', code
+    )
+    if record is None:
+        raise AssertionError(f"no profiled record function for {kernel_name}")
+    vector = re.search(
+        rf"std::vector<C10IValueHandle> {record.group(1)}\(\{{(.*?)\}}\)", code
+    )
+    if vector is None:
+        raise AssertionError(f"no profiling IValue vector for {kernel_name}")
+    return [
+        "scalar" if "_scalar_" in entry else "tensor"
+        for entry in vector.group(1).split(",")
+    ]
+
+
 class AOTInductorTestsTemplate:
     @common_utils.parametrize("embed_kernel_binary", [False, True])
     @common_utils.parametrize("max_autotune", [False, True])
@@ -6555,6 +6580,177 @@ class AOTInductorTestsTemplate:
             self.check_model(Model(N, K, self.device), example_inputs)
 
     @unittest.skipIf(
+        config.triton.native_matmul, "different kernel name when native matmul"
+    )
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_input_shapes(self):
+        # Verify that kernel profiling records tensor input shapes,
+        # scalar args, output handles, and ReinterpretView logical shapes.
+        class Model(torch.nn.Module):
+            def __init__(self, n, k, device):
+                super().__init__()
+                self.weight = torch.randn(n, k, device=device)
+                self.bias = torch.randn(n, device=device)
+
+            def forward(self, a):
+                # addmm: exercises scalar args (alpha, beta) and output handle
+                out = torch.nn.functional.linear(a, self.weight, self.bias)
+                # mm with transposed view: exercises ReinterpretView input path
+                return torch.mm(out.t(), a)
+
+        M = 8
+        N = 6
+        K = 16
+        model = Model(N, K, self.device)
+        a = torch.randn(M, K, device=self.device)
+        example_inputs = (a,)
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Verify that tensor inputs are converted to IValues for
+            # shape recording (3-arg RAIIAtenRecordFunctionHandle form).
+            FileCheck().check("aoti_torch_tensor_to_ivalue").run(code)
+            # Verify dummy scalar IValues are generated for non-tensor args.
+            FileCheck().check("aoti_torch_int64_to_ivalue").run(code)
+            FileCheck().check("std::vector<C10IValueHandle>").run(code)
+            # Verify output tensor is included in IValues for out-variant
+            # kernels.
+            FileCheck().check_regex(r"tmp_.*_output\b").run(code)
+            # Verify ReinterpretView inputs use reinterpret_tensor_wrapper
+            # for correct logical shapes in profiling.
+            FileCheck().check("reinterpret_tensor_wrapper").run(code)
+
+            self.check_model(Model(N, K, self.device), example_inputs)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_conv_input_shapes(self):
+        # Convolution is a single-output ExternKernelAlloc, so it flows through
+        # the alloc codegen path; verify its tensor inputs are recorded with
+        # shapes when profiling is enabled (3-arg RAIIAtenRecordFunctionHandle
+        # with an IValue vector).
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 6, kernel_size=3, padding=1).to(device)
+
+            def forward(self, x):
+                return self.conv(x)
+
+        model = Model(self.device)
+        x = torch.randn(2, 3, 16, 16, device=self.device)
+        example_inputs = (x,)
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Conv tensor inputs are converted to IValues for shape recording,
+            # collected into a vector, and passed to the record function.
+            FileCheck().check("aoti_torch_tensor_to_ivalue").run(code)
+            FileCheck().check("std::vector<C10IValueHandle>").run(code)
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            # Conv on CUDA uses TF32, which differs from the fp32 reference by
+            # ~1e-3; the profiling assertions above are this test's focus.
+            self.check_model(Model(self.device), example_inputs, atol=1e-2, rtol=1e-2)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_multi_output_fallback_input_shapes(self):
+        # A tuple-returning fallback (scaled_dot_product_attention) is the
+        # representative kernel reaching generate_c_shim_fallback_kernel;
+        # zero-output and dict-returning fallbacks route there too. Its q/k/v
+        # are transposed views, so this pins down that the recorded shapes are
+        # the logical view shapes and not the base buffers.
+        #
+        # A fused backend is required: without one SDPA decomposes to math and
+        # emits no extern shim. CPU always has one; XPU has no fp32 fused path.
+        if self.device == "xpu":
+            raise unittest.SkipTest("XPU has no fused fp32 SDPA backend")
+        if self.device != "cpu" and not (
+            PLATFORM_SUPPORTS_FLASH_ATTENTION or PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
+        ):
+            raise unittest.SkipTest("Some archs don't support fused SDPA")
+
+        class Model(torch.nn.Module):
+            def forward(self, q, k, v):
+                # transpose() makes each operand a ReinterpretView whose logical
+                # shape differs from its base buffer.
+                return torch.nn.functional.scaled_dot_product_attention(
+                    q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+                )
+
+        example_inputs = tuple(
+            torch.randn(4, 8, 2, 16, device=self.device) for _ in range(3)
+        )
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            # The handle must be the reinterpret expression, not a bare buffer
+            # name: a base-buffer handle would record the wrong shape while
+            # still looking populated to a trace consumer. The IValue variable
+            # carries the shim name, so match it in the same line to pin the
+            # assertion to this kernel rather than any transposed GEMM.
+            FileCheck().check_regex(
+                r"aoti_torch_tensor_to_ivalue\(wrap_with_raii_handle_if_needed\("
+                r"reinterpret_tensor_wrapper.*"
+                r"tmp_aoti_torch_\w*scaled_dot_product\w*_input_0\)"
+            ).run(code)
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            self.check_model(Model(), example_inputs)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_tensor_list_input_shapes(self):
+        # A tensor-list fallback collapses its whole list into a single codegen
+        # arg, so the profiling handles for its ReinterpretView inputs have no
+        # positional correspondence with the kernel's args.
+        if self.device != "cpu":
+            raise unittest.SkipTest("aten.cat only falls back to ATen for cpu uint8")
+
+        class Model(torch.nn.Module):
+            def forward(self, a, b, c, d):
+                # Slicing makes every list element a ReinterpretView, and four
+                # elements outnumber the kernel's args.
+                return torch.cat([a[:, :2], b[:, :2], c[:, :2], d[:, :2]], dim=1)
+
+        example_inputs = tuple(
+            torch.randint(0, 255, (4, 8), dtype=torch.uint8, device=self.device)
+            for _ in range(4)
+        )
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            FileCheck().check("aoti_torch_cpu_cat").run(code)
+            # A handle for the fourth input proves the handles are derived per
+            # input: the kernel's args collapse the whole list into a single
+            # entry, so a positional args lookup cannot reach index 3.
+            FileCheck().check("tmp_aoti_torch_cpu_cat_input_3").run(code)
+            # The IValue variable name is built from the loop index alone, so
+            # pin the handle expression too: the slices must be recorded as
+            # reinterpret views rather than their base buffers.
+            FileCheck().check(
+                "aoti_torch_tensor_to_ivalue(wrap_with_raii_handle_if_needed("
+                "reinterpret_tensor_wrapper"
+            ).run(code)
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            self.check_model(Model(), example_inputs)
+
+    @unittest.skipIf(
         sys.platform not in ["linux", "win32"],
         "enable_kernel_profile only supported on linux and win32",
     )
@@ -6599,6 +6795,143 @@ class AOTInductorTestsTemplate:
                 example_inputs,
                 dynamic_shapes=dynamic_shapes,
             )
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_records_schema_arg_order(self):
+        # index_reduce interleaves non-tensor and tensor arguments:
+        #   (Tensor self, int dim, Tensor index, Tensor source, str reduce,
+        #    *, bool include_self)
+        # Partitioning a kernel's arguments into tensors and constants loses
+        # that interleaving, so the recording has to be rebuilt from the
+        # schema. Assert the exact sequence, not just the count: a recording
+        # that lists all three tensors first has the right length but reports
+        # every shape against the wrong argument.
+        class Model(torch.nn.Module):
+            def forward(self, x, index, source):
+                return x.index_reduce(0, index, source, "prod", include_self=False)
+
+        example_inputs = (
+            torch.randn(4, 8, device=self.device),
+            torch.tensor([0, 2, 1], device=self.device, dtype=torch.int64),
+            torch.randn(3, 8, device=self.device),
+        )
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            self.assertEqual(
+                profiled_ivalue_kinds(code, r"aoti_torch_\w*_index_reduce"),
+                ["tensor", "scalar", "tensor", "tensor", "scalar", "scalar"],
+            )
+
+            self.check_model(Model(), example_inputs)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_records_unprovided_default_args(self):
+        # _embedding_bag_forward_only takes nine arguments and the lowering
+        # provides only the three tensors, leaving the rest to their defaults.
+        # The shim call still passes all nine, so the recording must too;
+        # otherwise a consumer reading positionally attributes the shapes to
+        # the wrong arguments of every later kernel in the trace.
+        class Model(torch.nn.Module):
+            def forward(self, weight, indices, offsets):
+                return torch.nn.functional.embedding_bag(
+                    indices, weight, offsets, mode="sum"
+                )
+
+        example_inputs = (
+            torch.randn(10, 4, device=self.device),
+            torch.tensor([1, 2, 4, 5, 4, 3, 2, 9], device=self.device),
+            torch.tensor([0, 4], device=self.device, dtype=torch.int64),
+        )
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            self.assertEqual(
+                profiled_ivalue_kinds(
+                    code, r"aoti_torch_\w*__embedding_bag_forward_only"
+                ),
+                ["tensor"] * 3 + ["scalar"] * 6,
+            )
+
+            self.check_model(Model(), example_inputs)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_records_kwarg_only_tensor_once(self):
+        # searchsorted's `sorter` is a keyword-only tensor:
+        #   (Tensor sorted_sequence, Tensor self, *, bool out_int32,
+        #    bool right, str? side, Tensor? sorter)
+        # It is both a tensor input and a keyword argument, so it is the case
+        # that gets recorded twice -- once with its real shape and once as a
+        # placeholder -- unless every schema argument is visited exactly once.
+        if self.device != "cpu":
+            raise unittest.SkipTest("searchsorted only falls back to ATen for cpu")
+
+        class Model(torch.nn.Module):
+            def forward(self, sequence, values, sorter):
+                return torch.searchsorted(sequence, values, sorter=sorter)
+
+        example_inputs = (
+            torch.tensor([[1.0, 3.0, 5.0, 7.0]], device=self.device),
+            torch.tensor([[2.0, 6.0]], device=self.device),
+            torch.tensor([[0, 1, 2, 3]], device=self.device, dtype=torch.int64),
+        )
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            self.assertEqual(
+                profiled_ivalue_kinds(code, r"aoti_torch_\w*_searchsorted_Tensor"),
+                ["tensor", "tensor", "scalar", "scalar", "scalar", "tensor"],
+            )
+
+            self.check_model(Model(), example_inputs)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_records_kwarg_supplied_positional_args_once(self):
+        # convolution has nine positional arguments and no keyword-only ones,
+        # but the lowering supplies everything after `weight` by keyword, so
+        # they reach the kernel through both its keyword list and the
+        # fill-in-defaults path. They must still be recorded once each.
+        # The convolution is bias-free so that the recording is the same on
+        # every device: with a bias, CUDA folds it into a separate epilogue
+        # and passes none to the kernel while CPU passes the tensor.
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(
+                    3, 6, kernel_size=3, padding=1, bias=False
+                ).to(device)
+
+            def forward(self, x):
+                return self.conv(x)
+
+        example_inputs = (torch.randn(2, 3, 16, 16, device=self.device),)
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(self.device), example_inputs
+            )
+            self.assertEqual(
+                profiled_ivalue_kinds(code, r"aoti_torch_\w*_convolution"),
+                ["tensor"] * 2 + ["scalar"] * 7,
+            )
+
+            # Conv on CUDA uses TF32, which differs from the fp32 reference by
+            # ~1e-3; the profiling assertion above is this test's focus.
+            self.check_model(Model(self.device), example_inputs, atol=1e-2, rtol=1e-2)
 
     def test_aoti_user_defined_triton_kernel_profiling(self):
         if self.device != GPU_TYPE or self.device == "mps":

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6309,6 +6309,120 @@ class AOTInductorTestsTemplate:
             self.check_model(Model(N, K, self.device), example_inputs)
 
     @unittest.skipIf(
+        config.triton.native_matmul, "different kernel name when native matmul"
+    )
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_input_shapes(self):
+        # Verify that kernel profiling records tensor input shapes,
+        # scalar args, output handles, and ReinterpretView logical shapes.
+        class Model(torch.nn.Module):
+            def __init__(self, n, k, device):
+                super().__init__()
+                self.weight = torch.randn(n, k, device=device)
+                self.bias = torch.randn(n, device=device)
+
+            def forward(self, a):
+                # addmm: exercises scalar args (alpha, beta) and output handle
+                out = torch.nn.functional.linear(a, self.weight, self.bias)
+                # mm with transposed view: exercises ReinterpretView input path
+                return torch.mm(out.t(), a)
+
+        M = 8
+        N = 6
+        K = 16
+        model = Model(N, K, self.device)
+        a = torch.randn(M, K, device=self.device)
+        example_inputs = (a,)
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Verify that tensor inputs are converted to IValues for
+            # shape recording (3-arg RAIIAtenRecordFunctionHandle form).
+            FileCheck().check("aoti_torch_tensor_to_ivalue").run(code)
+            # Verify dummy scalar IValues are generated for non-tensor args.
+            FileCheck().check("aoti_torch_int64_to_ivalue").run(code)
+            FileCheck().check("std::vector<C10IValueHandle>").run(code)
+            # Verify output tensor is included in IValues for out-variant
+            # kernels.
+            FileCheck().check_regex(r"tmp_.*_output\b").run(code)
+            # Verify ReinterpretView inputs use reinterpret_tensor_wrapper
+            # for correct logical shapes in profiling.
+            FileCheck().check("reinterpret_tensor_wrapper").run(code)
+
+            self.check_model(Model(N, K, self.device), example_inputs)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_conv_input_shapes(self):
+        # Convolution flows through the extern/fallback kernel codegen path;
+        # verify its tensor inputs are recorded with shapes when profiling is
+        # enabled (3-arg RAIIAtenRecordFunctionHandle with an IValue vector).
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 6, kernel_size=3, padding=1).to(device)
+
+            def forward(self, x):
+                return self.conv(x)
+
+        model = Model(self.device)
+        x = torch.randn(2, 3, 16, 16, device=self.device)
+        example_inputs = (x,)
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Conv tensor inputs are converted to IValues for shape recording,
+            # collected into a vector, and passed to the record function.
+            FileCheck().check("aoti_torch_tensor_to_ivalue").run(code)
+            FileCheck().check("std::vector<C10IValueHandle>").run(code)
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            # Conv on CUDA uses TF32, which differs from the fp32 reference by
+            # ~1e-3; the profiling assertions above are this test's focus.
+            self.check_model(Model(self.device), example_inputs, atol=1e-2, rtol=1e-2)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_tensor_list_input_shapes(self):
+        # A tensor-list fallback collapses its whole list into a single codegen
+        # arg, so the profiling handles for its ReinterpretView inputs have no
+        # positional correspondence with the kernel's args.
+        if self.device != "cpu":
+            raise unittest.SkipTest("aten.cat only falls back to ATen for cpu uint8")
+
+        class Model(torch.nn.Module):
+            def forward(self, a, b, c, d):
+                # Slicing makes every list element a ReinterpretView, and four
+                # elements outnumber the kernel's args.
+                return torch.cat([a[:, :2], b[:, :2], c[:, :2], d[:, :2]], dim=1)
+
+        example_inputs = tuple(
+            torch.randint(0, 255, (4, 8), dtype=torch.uint8, device=self.device)
+            for _ in range(4)
+        )
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            FileCheck().check("aoti_torch_cpu_cat").run(code)
+            # A handle for the fourth input proves the handles are derived per
+            # input: the kernel's args collapse the whole list into a single
+            # entry, so a positional args lookup cannot reach index 3.
+            FileCheck().check("tmp_aoti_torch_cpu_cat_input_3").run(code)
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            self.check_model(Model(), example_inputs)
+
+    @unittest.skipIf(
         sys.platform not in ["linux", "win32"],
         "enable_kernel_profile only supported on linux and win32",
     )

--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -208,6 +208,12 @@ CPU_TEST_FAILURES = {
     "test_duplicate_constant_folding": fail_stack_allocation(is_skip=True),
     "test_aot_inductor_consts_cpp_build": fail_stack_allocation(is_skip=True),
     "test_stride_with_unbacked_expr": fail_minimal_arrayref_interface(is_skip=True),
+    # TODO: error: no member named 'get' in 'ArrayRefTensor<T>' -- a TensorList
+    # fallback renders its elements as `<elem>.get()`, which graph inputs do not
+    # provide under the minimal arrayref interface.
+    "test_aoti_profiler_tensor_list_input_shapes": fail_minimal_arrayref_interface(
+        is_skip=True
+    ),
     # TODO: use of deleted function RAIIAtenTensorHandle
     "test_dup_unbacked_sym_decl": fail_minimal_arrayref_interface(is_skip=True),
     # TODO: use of deleted function RAIIAtenTensorHandle

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -46,11 +46,13 @@ from .cpp_utils import (
     LAYOUT_TO_ATEN,
 )
 from .wrapper import (
+    _get_profiling_input_handles,
     _rewrite_symbol_solution_for_int_codegen,
     codegen_reinterpret_view_helper,
     EnterSubgraphLine,
     ExitSubgraphLine,
     HasWriteLine,
+    kernel_profile_enabled,
     PythonWrapperCodegen,
     SymbolicCallArg,
     WrapperLine,
@@ -1875,6 +1877,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
         *,
         debug_args: list[str] | None = None,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
+        output_handle: str | None = None,
     ) -> None:
         """debug_args kwarg allows CppWrapperCpuArrayRef to pass in wrapped arguments in
         place of args while preserving debug printer output."""
@@ -1885,10 +1890,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         debug_printer_manager.set_printer_args(
             debug_args if debug_args is not None else args, kernel, None, None, "extern"
         )
-        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
-            "linux",
-            "win32",
-        ]
+        enable_kernel_profile = kernel_profile_enabled()
         enable_kernel_context_guard = (
             enable_kernel_profile and config.cpp.enable_kernel_context_guard
         )
@@ -1899,7 +1901,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
             ]
             if enable_kernel_profile:
                 call_code = shim_fn_codes[0]
-                shim_fn_codes = ["{"]
+                stack_trace_str = ""
                 if enable_kernel_context_guard:
                     stack_trace_str = 'R"('
                     if stack_traces:
@@ -1908,16 +1910,80 @@ class CppWrapperCpu(PythonWrapperCodegen):
                                 stack_trace_str += f"\n{line}"
                             stack_trace_str += "\n"
                     stack_trace_str += ')"'
-                    shim_fn_codes.append(
-                        f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+
+                has_profiling_inputs = input_handles or num_scalars > 0 or output_handle
+                if has_profiling_inputs:
+                    # Generate IValue conversions so that tensor shapes
+                    # and scalar types are recorded by the profiler.
+                    ivalue_lines: list[str] = []
+                    ivalue_names: list[str] = []
+
+                    if input_handles:
+                        for idx, handle in enumerate(input_handles):
+                            ivalue_var = f"tmp_{shim_fn}_input_{idx}"
+                            ivalue_lines.extend(
+                                [
+                                    f"C10IValueHandle {ivalue_var};",
+                                    f"aoti_torch_tensor_to_ivalue({handle}, &{ivalue_var});",
+                                    f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                                ]
+                            )
+                            ivalue_names.append(ivalue_var)
+
+                    # Generate dummy scalar IValues (we only care about
+                    # shapes, so use int64(0) as a placeholder).
+                    for idx in range(num_scalars):
+                        ivalue_var = f"tmp_{shim_fn}_scalar_{idx}"
+                        ivalue_lines.extend(
+                            [
+                                f"C10IValueHandle {ivalue_var};",
+                                f"aoti_torch_int64_to_ivalue(0, &{ivalue_var});",
+                                f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                            ]
+                        )
+                        ivalue_names.append(ivalue_var)
+
+                    if output_handle:
+                        ivalue_var = f"tmp_{shim_fn}_output"
+                        ivalue_lines.extend(
+                            [
+                                f"C10IValueHandle {ivalue_var};",
+                                f"aoti_torch_tensor_to_ivalue({output_handle}, &{ivalue_var});",
+                                f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                            ]
+                        )
+                        ivalue_names.append(ivalue_var)
+
+                    inputs_vec_var = f"{shim_fn}_inputs_"
+                    ivalue_lines.append(
+                        f"std::vector<C10IValueHandle> {inputs_vec_var}({{{', '.join(ivalue_names)}}});"
                     )
-                shim_fn_codes.extend(
-                    [
-                        f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
-                        call_code,
-                        "}",
-                    ]
-                )
+
+                    shim_fn_codes = ["{", *ivalue_lines]
+                    if enable_kernel_context_guard:
+                        shim_fn_codes.append(
+                            f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+                        )
+                    shim_fn_codes.extend(
+                        [
+                            f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr, {inputs_vec_var});""",
+                            call_code,
+                            "}",
+                        ]
+                    )
+                else:
+                    shim_fn_codes = ["{"]
+                    if enable_kernel_context_guard:
+                        shim_fn_codes.append(
+                            f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+                        )
+                    shim_fn_codes.extend(
+                        [
+                            f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
+                            call_code,
+                            "}",
+                        ]
+                    )
             self.writelines(shim_fn_codes)
 
     def generate_c_shim_extern_kernel_alloc(
@@ -1937,8 +2003,22 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
         device = d.type if (d := extern_kernel.get_device()) else self.device
 
+        # input_handles / num_scalars are consumed only inside the C shim's
+        # enable_kernel_profile branch, so compute them only when profiling is on.
+        input_handles = None
+        num_scalars = 0
+        if kernel_profile_enabled():
+            num_kwargs = sum(
+                1 for key in extern_kernel.ordered_kwargs_for_cpp_kernel if key != "out"
+            )
+            input_handles = _get_profiling_input_handles(extern_kernel.inputs)
+            num_scalars = len(extern_kernel.constant_args) + num_kwargs
         self.generate_c_shim_extern_kernel_call(
-            extern_kernel.get_kernel_name(), args, device
+            extern_kernel.get_kernel_name(),
+            args,
+            device,
+            input_handles=input_handles,
+            num_scalars=num_scalars,
         )
 
         if extern_kernel.python_kernel_name in (
@@ -1964,6 +2044,18 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def generate_c_shim_fallback_kernel(
         self, fallback_kernel: ir.FallbackKernel, args: list[str]
     ) -> None:
+        # input_handles / num_scalars are consumed only inside the C shim's
+        # enable_kernel_profile branch, so compute them only when profiling is on.
+        # Multi-output fallbacks record the physical buffer for every tensor
+        # input; the logical view shape is not tracked here.
+        input_handles = None
+        if kernel_profile_enabled():
+            input_handles = [
+                inp.get_name()
+                for inp in fallback_kernel.inputs
+                if isinstance(inp, ir.IRNode)
+            ]
+
         output_args = []
         output_raii_handles = []
         output_name_base = fallback_kernel.get_name()
@@ -1997,10 +2089,20 @@ class CppWrapperCpu(PythonWrapperCodegen):
         args = args + output_args
         device = d.type if (d := fallback_kernel.get_device()) else self.device
 
+        num_scalars = 0
+        if kernel_profile_enabled():
+            num_kwargs = sum(
+                1
+                for key in fallback_kernel.ordered_kwargs_for_cpp_kernel
+                if key != "out"
+            )
+            num_scalars = len(fallback_kernel.constant_args) + num_kwargs
         self.generate_c_shim_extern_kernel_call(
             fallback_kernel.cpp_kernel_name,  # type: ignore[arg-type]
             args,
             device,
+            input_handles=input_handles,
+            num_scalars=num_scalars,
         )
         for raii_handle in output_raii_handles:
             self.writeline(raii_handle)
@@ -2013,16 +2115,25 @@ class CppWrapperCpu(PythonWrapperCodegen):
         args: list[str],
         device: str,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
     ) -> None:
         if out_view:
             out_name = f"{out}_as_strided"
             self.writeline(f"auto {out_name} = {out_view};")
             args.insert(0, out_name)
         else:
+            out_name = out
             args.insert(0, out)
 
         self.generate_c_shim_extern_kernel_call(
-            kernel, args, device, stack_traces=stack_traces
+            kernel,
+            args,
+            device,
+            stack_traces=stack_traces,
+            input_handles=input_handles,
+            num_scalars=num_scalars,
+            output_handle=out_name,
         )
 
     def _get_scatter_reduce_enum(self, reduce):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -46,11 +46,13 @@ from .cpp_utils import (
     LAYOUT_TO_ATEN,
 )
 from .wrapper import (
+    _get_profiling_args,
     _rewrite_symbol_solution_for_int_codegen,
     codegen_reinterpret_view_helper,
     EnterSubgraphLine,
     ExitSubgraphLine,
     HasWriteLine,
+    kernel_profile_enabled,
     PythonWrapperCodegen,
     SymbolicCallArg,
     WrapperLine,
@@ -271,6 +273,20 @@ class DeferredCpuTritonCallWrapper:
         # Register .so artifacts so the AOTI packager picks them up.
         V.graph.wrapper_code.additional_files.append(info["kernel_so_path"])
         V.graph.wrapper_code.additional_files.append(info["launcher_so_path"])
+
+
+def _ivalue_conversion(ivalue_var: str, to_ivalue_call: str) -> list[str]:
+    """The lines that turn one kernel argument into an IValue for the profiler:
+    declare the handle, fill it, and hand it to an RAII guard.
+
+    The conversion is error-checked because it leaves the handle untouched when
+    it fails, and the guard would then take ownership of an indeterminate
+    pointer."""
+    return [
+        f"C10IValueHandle {ivalue_var} = nullptr;",
+        f"AOTI_TORCH_ERROR_CODE_CHECK({to_ivalue_call});",
+        f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+    ]
 
 
 class CppWrapperCpu(PythonWrapperCodegen):
@@ -1881,6 +1897,8 @@ class CppWrapperCpu(PythonWrapperCodegen):
         *,
         debug_args: list[str] | None = None,
         stack_traces: OrderedSet[str] | None = None,
+        profiling_args: Sequence[str | None] | None = None,
+        output_handle: str | None = None,
     ) -> None:
         """debug_args kwarg allows CppWrapperCpuArrayRef to pass in wrapped arguments in
         place of args while preserving debug printer output."""
@@ -1891,10 +1909,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         debug_printer_manager.set_printer_args(
             debug_args if debug_args is not None else args, kernel, None, None, "extern"
         )
-        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
-            "linux",
-            "win32",
-        ]
+        enable_kernel_profile = kernel_profile_enabled()
         enable_kernel_context_guard = (
             enable_kernel_profile and config.cpp.enable_kernel_context_guard
         )
@@ -1905,7 +1920,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
             ]
             if enable_kernel_profile:
                 call_code = shim_fn_codes[0]
-                shim_fn_codes = ["{"]
+                stack_trace_str = ""
                 if enable_kernel_context_guard:
                     stack_trace_str = 'R"('
                     if stack_traces:
@@ -1914,16 +1929,81 @@ class CppWrapperCpu(PythonWrapperCodegen):
                                 stack_trace_str += f"\n{line}"
                             stack_trace_str += "\n"
                     stack_trace_str += ')"'
-                    shim_fn_codes.append(
-                        f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+
+                has_profiling_inputs = profiling_args or output_handle
+                if has_profiling_inputs:
+                    # Generate IValue conversions so that tensor shapes
+                    # and scalar types are recorded by the profiler.
+                    # Recorded order is the operator's schema order, with `out`
+                    # last where the caller records one, matching the eager
+                    # trace layout. It is not the shim's argument order, which
+                    # passes `out` first, so consumers must not zip "Input
+                    # Dims" against the shim signature.
+                    ivalue_lines: list[str] = []
+                    ivalue_names: list[str] = []
+                    # Tensors and placeholders are numbered independently so a
+                    # name identifies which kind of argument it holds.
+                    num_inputs = 0
+                    num_scalars = 0
+
+                    for profiling_arg in profiling_args or ():
+                        if profiling_arg is None:
+                            # A non-tensor argument only has to hold its schema
+                            # position, so record a dummy int64.
+                            ivalue_var = f"tmp_{shim_fn}_scalar_{num_scalars}"
+                            num_scalars += 1
+                            to_ivalue = f"aoti_torch_int64_to_ivalue(0, &{ivalue_var})"
+                        else:
+                            ivalue_var = f"tmp_{shim_fn}_input_{num_inputs}"
+                            num_inputs += 1
+                            to_ivalue = (
+                                f"aoti_torch_tensor_to_ivalue({profiling_arg}, "
+                                f"&{ivalue_var})"
+                            )
+                        ivalue_lines.extend(_ivalue_conversion(ivalue_var, to_ivalue))
+                        ivalue_names.append(ivalue_var)
+
+                    if output_handle:
+                        ivalue_var = f"tmp_{shim_fn}_output"
+                        ivalue_lines.extend(
+                            _ivalue_conversion(
+                                ivalue_var,
+                                f"aoti_torch_tensor_to_ivalue({output_handle}, "
+                                f"&{ivalue_var})",
+                            )
+                        )
+                        ivalue_names.append(ivalue_var)
+
+                    inputs_vec_var = f"{shim_fn}_inputs_"
+                    ivalue_lines.append(
+                        f"std::vector<C10IValueHandle> {inputs_vec_var}({{{', '.join(ivalue_names)}}});"
                     )
-                shim_fn_codes.extend(
-                    [
-                        f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
-                        call_code,
-                        "}",
-                    ]
-                )
+
+                    shim_fn_codes = ["{", *ivalue_lines]
+                    if enable_kernel_context_guard:
+                        shim_fn_codes.append(
+                            f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+                        )
+                    shim_fn_codes.extend(
+                        [
+                            f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr, {inputs_vec_var});""",
+                            call_code,
+                            "}",
+                        ]
+                    )
+                else:
+                    shim_fn_codes = ["{"]
+                    if enable_kernel_context_guard:
+                        shim_fn_codes.append(
+                            f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+                        )
+                    shim_fn_codes.extend(
+                        [
+                            f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
+                            call_code,
+                            "}",
+                        ]
+                    )
             self.writelines(shim_fn_codes)
 
     def generate_c_shim_extern_kernel_alloc(
@@ -1943,8 +2023,16 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
         device = d.type if (d := extern_kernel.get_device()) else self.device
 
+        # profiling_args is consumed only inside the C shim's
+        # enable_kernel_profile branch, so build it only when profiling is on.
+        profiling_args = None
+        if kernel_profile_enabled():
+            profiling_args = _get_profiling_args(extern_kernel)
         self.generate_c_shim_extern_kernel_call(
-            extern_kernel.get_kernel_name(), args, device
+            extern_kernel.get_kernel_name(),
+            args,
+            device,
+            profiling_args=profiling_args,
         )
 
         if extern_kernel.python_kernel_name in (
@@ -1970,6 +2058,12 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def generate_c_shim_fallback_kernel(
         self, fallback_kernel: ir.FallbackKernel, args: list[str]
     ) -> None:
+        # profiling_args is consumed only inside the C shim's
+        # enable_kernel_profile branch, so build it only when profiling is on.
+        profiling_args = None
+        if kernel_profile_enabled():
+            profiling_args = _get_profiling_args(fallback_kernel)
+
         output_args = []
         output_raii_handles = []
         output_name_base = fallback_kernel.get_name()
@@ -2007,6 +2101,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
             fallback_kernel.cpp_kernel_name,  # type: ignore[arg-type]
             args,
             device,
+            profiling_args=profiling_args,
         )
         for raii_handle in output_raii_handles:
             self.writeline(raii_handle)
@@ -2019,16 +2114,23 @@ class CppWrapperCpu(PythonWrapperCodegen):
         args: list[str],
         device: str,
         stack_traces: OrderedSet[str] | None = None,
+        profiling_args: Sequence[str | None] | None = None,
     ) -> None:
         if out_view:
             out_name = f"{out}_as_strided"
             self.writeline(f"auto {out_name} = {out_view};")
             args.insert(0, out_name)
         else:
+            out_name = out
             args.insert(0, out)
 
         self.generate_c_shim_extern_kernel_call(
-            kernel, args, device, stack_traces=stack_traces
+            kernel,
+            args,
+            device,
+            stack_traces=stack_traces,
+            profiling_args=profiling_args,
+            output_handle=out_name,
         )
 
     def _get_scatter_reduce_enum(self, reduce):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -1050,29 +1050,55 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
         self.writeline("}")
 
     def generate_c_shim_extern_kernel_call(
-        self, kernel: str, args: list[str], device: str, **_
+        self,
+        kernel: str,
+        args: list[str],
+        device: str,
+        *,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
+        output_handle: str | None = None,
+        **_,
     ) -> None:
         # In the abi_compatible mode, we call fallback aten ops through a C shim layer
         # Setting self.allow_stack_allocation to False because the exchange between
         # ArrayRefTensor and at::Tensor is still fragile.
         self.allow_stack_allocation = False
 
-        wrapped_args = []
-        for arg in args:
+        def borrow_as_tensor_if_needed(expr: str) -> str:
             # We only really *need* borrow_arrayref_tensor_as_tensor for
             # ArrayRefTensors. The code flowing into here uses `0` for nullptr, which
             # borrow_arrayref_tensor_as_tensor would blindly coerce to int, so just
             # avoid wrapping integers.  Name matching is to find tensor is hacky, but
             # fixing all the ArrayRefTensor issues is not a priority for now.
-            if isinstance(arg, str) and arg.startswith(
+            if isinstance(expr, str) and expr.startswith(
                 ("buf", "arg", "wrap_with_raii_handle_if_needed")
             ):
                 self._assert_safe_to_use_borrow_arrayref_tensor_as_tensor()
-                arg = f"borrow_arrayref_tensor_as_tensor({arg})"
-            wrapped_args.append(arg)
+                return f"borrow_arrayref_tensor_as_tensor({expr})"
+            return expr
 
+        wrapped_args = [borrow_as_tensor_if_needed(arg) for arg in args]
+
+        # The profiling handles are passed to aoti_torch_tensor_to_ivalue, which
+        # takes an AtenTensorHandle. ArrayRefTensor has no conversion to one, so
+        # borrow it as a tensor exactly like the positional args above.
         super().generate_c_shim_extern_kernel_call(
-            kernel, wrapped_args, device, debug_args=args
+            kernel,
+            wrapped_args,
+            device,
+            debug_args=args,
+            input_handles=(
+                None
+                if input_handles is None
+                else [borrow_as_tensor_if_needed(handle) for handle in input_handles]
+            ),
+            num_scalars=num_scalars,
+            output_handle=(
+                None
+                if output_handle is None
+                else borrow_as_tensor_if_needed(output_handle)
+            ),
         )
 
     def generate_scatter_fallback(self, node: ir.ScatterFallback):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -1050,29 +1050,57 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
         self.writeline("}")
 
     def generate_c_shim_extern_kernel_call(
-        self, kernel: str, args: list[str], device: str, **_
+        self,
+        kernel: str,
+        args: list[str],
+        device: str,
+        *,
+        profiling_args: Sequence[str | None] | None = None,
+        output_handle: str | None = None,
+        **_,
     ) -> None:
         # In the abi_compatible mode, we call fallback aten ops through a C shim layer
         # Setting self.allow_stack_allocation to False because the exchange between
         # ArrayRefTensor and at::Tensor is still fragile.
         self.allow_stack_allocation = False
 
-        wrapped_args = []
-        for arg in args:
+        def borrow_as_tensor_if_needed(expr: str) -> str:
             # We only really *need* borrow_arrayref_tensor_as_tensor for
             # ArrayRefTensors. The code flowing into here uses `0` for nullptr, which
             # borrow_arrayref_tensor_as_tensor would blindly coerce to int, so just
             # avoid wrapping integers.  Name matching is to find tensor is hacky, but
             # fixing all the ArrayRefTensor issues is not a priority for now.
-            if isinstance(arg, str) and arg.startswith(
+            if isinstance(expr, str) and expr.startswith(
                 ("buf", "arg", "wrap_with_raii_handle_if_needed")
             ):
                 self._assert_safe_to_use_borrow_arrayref_tensor_as_tensor()
-                arg = f"borrow_arrayref_tensor_as_tensor({arg})"
-            wrapped_args.append(arg)
+                return f"borrow_arrayref_tensor_as_tensor({expr})"
+            return expr
 
+        wrapped_args = [borrow_as_tensor_if_needed(arg) for arg in args]
+
+        # The profiling handles are passed to aoti_torch_tensor_to_ivalue, which
+        # takes an AtenTensorHandle. ArrayRefTensor has no conversion to one, so
+        # borrow it as a tensor exactly like the positional args above. A None
+        # entry stands for a non-tensor argument and has nothing to borrow.
         super().generate_c_shim_extern_kernel_call(
-            kernel, wrapped_args, device, debug_args=args
+            kernel,
+            wrapped_args,
+            device,
+            debug_args=args,
+            profiling_args=(
+                None
+                if profiling_args is None
+                else [
+                    None if arg is None else borrow_as_tensor_if_needed(arg)
+                    for arg in profiling_args
+                ]
+            ),
+            output_handle=(
+                None
+                if output_handle is None
+                else borrow_as_tensor_if_needed(output_handle)
+            ),
         )
 
     def generate_scatter_fallback(self, node: ir.ScatterFallback):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -12,6 +12,7 @@ import operator
 import os
 import re
 import secrets
+import sys
 import tempfile
 from collections.abc import Callable
 from enum import Enum
@@ -724,6 +725,100 @@ class ExternKernelAllocLine(WrapperLine):
         return converter._generate_extern_kernel_alloc
 
 
+def kernel_profile_enabled() -> bool:
+    """Whether the C shim emits kernel-profiling instrumentation.
+
+    The RAIIAtenRecordFunctionHandle declaration reaches the generated code
+    through an include that only these platforms emit. Callers that build
+    profiling metadata must use this rather than the config flag alone:
+    `_get_profiling_args` emits codegen for ReinterpretView arguments, so
+    building metadata the shim then declines to emit would leak a handle."""
+    return config.cpp.enable_kernel_profile and sys.platform in ("linux", "win32")
+
+
+def _profiling_arg_entry(value: Any) -> str | None:
+    """Profiling metadata for one argument value: an expression yielding a
+    tensor handle, or None for a value the C shim records as a placeholder.
+
+    A ReinterpretView re-derives its codegen expression so the recorded shape
+    is the logical view shape; get_name() would name the base buffer, which a
+    trace consumer would read as a real but wrong shape.
+
+    Generators, torchbind objects and the stand-ins for a None or SymInt
+    argument are IRNodes that no tensor handle can be made from, so they take
+    a placeholder like any other non-tensor."""
+    if isinstance(value, ReinterpretView):
+        return value.codegen_reference()
+    if isinstance(
+        value, (ir.NonTensorObj, ir.NoneAsConstantBuffer, ir.ShapeAsConstantBuffer)
+    ):
+        return None
+    if isinstance(value, IRNode):
+        return value.get_name()
+    return None
+
+
+def _profiling_arg_entries(values: Sequence[Any]) -> list[str | None]:
+    """One entry per value, except that a tensor list expands to one entry per
+    element so the element shapes survive. Eager records a list as a single
+    IValue; expanding it is the one deliberate deviation, and it keeps the
+    shape data for ops like cat, whose list is its only tensor argument. A
+    list holding no tensor, such as a SymInt[] stride, stays a single
+    placeholder."""
+    entries: list[str | None] = []
+    for value in values:
+        if isinstance(value, (list, tuple)) and any(
+            isinstance(element, IRNode) for element in value
+        ):
+            entries.extend(_profiling_arg_entry(element) for element in value)
+        else:
+            entries.append(_profiling_arg_entry(value))
+    return entries
+
+
+def _get_profiling_args(node: ir.ExternKernel) -> list[str | None]:
+    """Profiling metadata for an extern kernel: one entry per operator schema
+    argument, in schema order, except for a tensor list, which expands per
+    element. `out` is left out, so a caller holding an output buffer can append
+    it last, where eager records it.
+
+    The argument list is rebuilt the same way the kernel's own call arguments
+    are, which is what keeps the two in step. A FallbackKernel restores the
+    original interleaving of tensor and non-tensor arguments through
+    unflatten_args, since partitioning into inputs and constant_args discards
+    it; every other ExternKernel follows the tensors-before-constants
+    convention that ExternKernel.codegen_args relies on. Filling in unprovided
+    positional arguments matches the call the shim actually makes; those
+    arguments are then skipped in the keyword pass, because
+    ordered_kwargs_for_cpp_kernel can name a positional argument that was
+    supplied as a keyword (convolution passes its whole stride/padding/groups
+    tail that way) and it must still be recorded once."""
+    if isinstance(node, ir.FallbackKernel):
+        args, kwargs = node.unflatten_args(node.inputs, node.constant_args)
+    else:
+        args, kwargs = [*node.inputs, *node.constant_args], node.kwargs
+    arg_properties = node.arg_properties or []
+    schema_args: Sequence[Any] = (
+        node.fill_non_provided_args(args, kwargs)
+        if arg_properties and isinstance(node.op_overload, torch._ops.OpOverload)
+        else args
+    )
+    profiling_args = _profiling_arg_entries(schema_args)
+    positional_names = OrderedSet(
+        [
+            arg_property.get("name")
+            for arg_property in arg_properties[: len(schema_args)]
+        ]
+    )
+    for arg_name in node.ordered_kwargs_for_cpp_kernel:
+        if arg_name == "out" or arg_name in positional_names:
+            continue
+        profiling_args.append(
+            _profiling_arg_entry(node.get_kwargs_value(arg_name, **kwargs))
+        )
+    return profiling_args
+
+
 @dataclasses.dataclass
 class ExternKernelOutLine(WrapperLine):
     wrapper: PythonWrapperCodegen
@@ -742,6 +837,12 @@ class ExternKernelOutLine(WrapperLine):
         else:
             kernel_name = node.get_kernel_name()
         device = d.type if (d := node.get_device()) else V.graph.device_type
+        # profiling_args is consumed only inside the C shim's
+        # enable_kernel_profile branch, so build it only when the C++ wrapper
+        # is generating code and profiling is on.
+        profiling_args = None
+        if V.graph.cpp_wrapper and kernel_profile_enabled():
+            profiling_args = _get_profiling_args(node)
         self.wrapper._generate_extern_kernel_out_helper(
             kernel_name,
             node.codegen_reference(),
@@ -749,6 +850,7 @@ class ExternKernelOutLine(WrapperLine):
             args,
             device,
             self.node.get_stack_traces(),
+            profiling_args=profiling_args,
         )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
@@ -2364,7 +2466,10 @@ class PythonWrapperCodegen(CodeGen):
         args: list[str],
         device: str,
         stack_traces: OrderedSet[str] | None = None,
+        profiling_args: Sequence[str | None] | None = None,
     ) -> None:
+        # profiling_args is consumed only by the CppWrapperCpu override (to
+        # record profiling metadata); the Python wrapper ignores it.
         # add debug printer code for triton kernel calls at (jit) inductor level
         debug_printer_manager = V.graph.wrapper_code.debug_printer
         debug_printer_manager.set_printer_args(args, kernel, None, None, "extern")

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -12,6 +12,7 @@ import operator
 import os
 import random
 import re
+import sys
 import tempfile
 from collections.abc import Callable
 from itertools import chain, count
@@ -667,6 +668,38 @@ class ExternKernelAllocLine(WrapperLine):
         return converter._generate_extern_kernel_alloc
 
 
+def kernel_profile_enabled() -> bool:
+    """Whether the C shim emits kernel-profiling instrumentation.
+
+    RAIIAtenRecordFunctionHandle is only available on these platforms. Callers
+    that build profiling metadata must use this rather than the config flag
+    alone: `_get_profiling_input_handles` emits codegen for its inputs, so
+    building metadata the shim then declines to emit would leak a handle."""
+    return config.cpp.enable_kernel_profile and sys.platform in ("linux", "win32")
+
+
+def _get_profiling_input_handles(
+    inputs: Sequence[IRNode | Sequence[IRNode]],
+) -> list[str]:
+    """Build input handles for profiling: re-derive the codegen expression for
+    ReinterpretView inputs (to capture logical view shapes) and use get_name()
+    for everything else. Nested Sequence[IRNode] inputs (e.g. a tensor list)
+    have no single handle and are skipped.
+
+    The expression is derived per input rather than read out of the kernel's
+    codegen args: a kernel whose schema interleaves non-tensor arguments, takes
+    an optional tensor, or collapses a tensor list into a single
+    `<array-ptr>, <len>` token has no positional correspondence between its
+    inputs and its args."""
+    handles = []
+    for inp in inputs:
+        if isinstance(inp, ReinterpretView):
+            handles.append(inp.codegen_reference())
+        elif isinstance(inp, IRNode):
+            handles.append(inp.get_name())
+    return handles
+
+
 @dataclasses.dataclass
 class ExternKernelOutLine(WrapperLine):
     wrapper: PythonWrapperCodegen
@@ -685,6 +718,19 @@ class ExternKernelOutLine(WrapperLine):
         else:
             kernel_name = node.get_kernel_name()
         device = d.type if (d := node.get_device()) else V.graph.device_type
+        # input_handles / num_scalars are consumed only inside the C shim's
+        # enable_kernel_profile branch, so compute them only when the C++ wrapper
+        # is generating code and profiling is on.
+        input_handles = None
+        num_scalars = 0
+        if V.graph.cpp_wrapper and kernel_profile_enabled():
+            # Count scalar args from both constant_args and kwargs
+            # (e.g., addmm has alpha/beta in kwargs, not constant_args).
+            num_kwargs = sum(
+                1 for key in self.node.ordered_kwargs_for_cpp_kernel if key != "out"
+            )
+            input_handles = _get_profiling_input_handles(self.node.inputs)
+            num_scalars = len(self.node.constant_args) + num_kwargs
         self.wrapper._generate_extern_kernel_out_helper(
             kernel_name,
             node.codegen_reference(),
@@ -692,6 +738,8 @@ class ExternKernelOutLine(WrapperLine):
             args,
             device,
             self.node.get_stack_traces(),
+            input_handles=input_handles,
+            num_scalars=num_scalars,
         )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
@@ -2278,7 +2326,11 @@ class PythonWrapperCodegen(CodeGen):
         args: list[str],
         device: str,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
     ) -> None:
+        # input_handles / num_scalars are consumed only by the CppWrapperCpu
+        # override (to record profiling metadata); the Python wrapper ignores them.
         # add debug printer code for triton kernel calls at (jit) inductor level
         debug_printer_manager = V.graph.wrapper_code.debug_printer
         debug_printer_manager.set_printer_args(args, kernel, None, None, "extern")


### PR DESCRIPTION
Summary:

This relands D94735563 (reverted by D112476171 after it broke ADS AOTI-lowering tests, T280020129). Three things changed relative to the reverted version:

 1. Building the profiling metadata is gated on kernel_profile_enabled(), so it does not run at all during AOTI lowering when profiling is off. That alone removes the IndexError that caused the revert.
 2. _get_profiling_input_handles no longer indexes the kernel's args by the input index. It derives the expression per input via codegen_reference(), which is what codegen_args() itself does for tensor arguments. The positional lookup was only correct when every input mapped to exactly one arg token; a schema that interleaves non-tensor arguments, takes an optional tensor, or collapses a tensor list into a single "<array-ptr>, <len>" token breaks that assumption. Single-tensor-output FallbackKernels (cat, index, convolution) all reach this path.
 3. The CppWrapperCpuArrayRef override borrows the profiling handles as tensors instead of forwarding them raw. ArrayRefTensor<T> has no conversion to AtenTensorHandle, so aoti_torch_tensor_to_ivalue would not compile under use_minimal_arrayref_interface.

The generated trace/IR output is unchanged for every kernel that previously worked.

 # Problem

 When profiling AOT Inductor compiled models with TORCHINDUCTOR_CPP_ENABLE_KERNEL_PROFILE=1, the generated GPU trace showed input tensor shapes for Triton kernels but not for extern/ATen kernels (e.g., aten::mm, aten::addmm).

 # Root Cause

 The issue was in cpp_wrapper_cpu.py, in the generate_c_shim_extern_kernel_call method. When kernel profiling is enabled, each kernel call is wrapped in a {} scope block containing a RAIIAtenRecordFunctionHandle object. This RAII object creates an at::RecordFunction event that the PyTorch
 profiler picks up.

 The RAIIAtenRecordFunctionHandle class has two constructors:
  - 2-arg: (name, kwargs) — records the kernel name but no input shapes
  - 3-arg: (name, kwargs, inputs) — records the kernel name AND a std::vector of input tensors, whose shapes are then visible in the trace

 For Triton kernels, the codegen in cpp_wrapper_gpu.py already used the 3-arg constructor: it iterated over each kernel argument, checked its type via arg_types, converted tensor arguments to c10::IValue using aoti_torch_tensor_to_ivalue(), and passed the resulting vector to
  RAIIAtenRecordFunctionHandle.

 For extern kernels, the codegen in cpp_wrapper_cpu.py used the 2-arg constructor with nullptr in place of inputs:
  RAIIAtenRecordFunctionHandle record_aoti_torch_cuda_mm_out_("aoti_torch_cuda_mm_out", nullptr);

 This meant the profiler had no tensor inputs to extract shapes from, so extern kernels appeared in the trace without any shape information.

 # Solution

 Tensor input shape recording

 Extended generate_c_shim_extern_kernel_call to accept an optional input_handles: list[str] parameter — a list of C++ expressions corresponding to the tensor inputs for the kernel. When kernel profiling is enabled and input_handles is provided, the method now generates code that:

  - Converts each tensor handle to a c10::IValue via aoti_torch_tensor_to_ivalue(handle, &ivalue_var)
  - Wraps each in an RAII guard (RAIIC10IValueHandle) for automatic cleanup
  - Collects them into a std::vector
  - Passes the vector to the 3-arg RAIIAtenRecordFunctionHandle constructor

 The generated C++ code for an extern kernel like aten::mm now looks like:
  {
    C10IValueHandle tmp_aoti_torch_cuda_mm_out_input_0;
    aoti_torch_tensor_to_ivalue(buf0, &tmp_aoti_torch_cuda_mm_out_input_0);
    RAIIC10IValueHandle RAII_tmp_aoti_torch_cuda_mm_out_input_0(tmp_aoti_torch_cuda_mm_out_input_0);
    C10IValueHandle tmp_aoti_torch_cuda_mm_out_input_1;
    aoti_torch_tensor_to_ivalue(buf1, &tmp_aoti_torch_cuda_mm_out_input_1);
    RAIIC10IValueHandle RAII_tmp_aoti_torch_cuda_mm_out_input_1(tmp_aoti_torch_cuda_mm_out_input_1);
    std::vector<C10IValueHandle> aoti_torch_cuda_mm_out_inputs_({tmp_aoti_torch_cuda_mm_out_input_0, tmp_aoti_torch_cuda_mm_out_input_1});
    KernelContextGuard _ctx("aoti_torch_cuda_mm_out", R"(...)");
    RAIIAtenRecordFunctionHandle record_aoti_torch_cuda_mm_out_("aoti_torch_cuda_mm_out", nullptr, aoti_torch_cuda_mm_out_inputs_);
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_cuda_mm_out(buf0, buf1, &buf2_handle));
  }

 Building input handles: the _get_profiling_input_handles method

 The input handles are built by the module-level _get_profiling_input_handles helper in wrapper.py, shared by both C-shim call sites. For each input:

 - ReinterpretView inputs: inp.codegen_reference(), so the profiler records the logical view shape rather than the physical buffer shape. For the common case (a transposed GEMM operand) this returns the identical wrap_with_raii_handle_if_needed(reinterpret_tensor_wrapper(...)) expression the kernel call itself uses, and emits no additional lines because codegen_int_array_var is cached. Each emitted expression owns the temporary it creates, so no ownership stripping is needed.
 - All other IRNode inputs: inp.get_name(), a simple C++ variable name (e.g. buf0). Nested Sequence[IRNode] inputs (tensor lists) have no single handle and are skipped.

 Deriving per input rather than reading args[i] is what makes this correct for kernels whose inputs and args are not positionally aligned. For the rare ReinterpretView whose layout exactly matches its base (a dtype-only view), codegen_reference() mints a fresh temporary handle, so profiling-on codegen gains one extra aoti_torch_new_tensor_handle for that input; recorded shapes and dtypes are unchanged.

 The three callers of generate_c_shim_extern_kernel_call were updated:

 - generate_c_shim_extern_kernel_alloc — uses _get_profiling_input_handles(extern_kernel.inputs)
  - generate_c_shim_fallback_kernel — _get_profiling_input_handles(fallback_kernel.inputs), the same helper as the other two callers. It previously used get_name(), which returns the base buffer for a ReinterpretView: tuple-returning fallbacks (chiefly aten._scaled_dot_product_flash_attention.default, whose q/k/v are usually transposed views) recorded base-buffer shapes instead of logical view shapes. That is not merely inaccurate -- trace consumers such as triton_trace_analyzer, WPS Purple and component_benchmarks drop cpu_op events that carry no "Input Dims" and then read the key unconditionally, so before this stack these events self-excluded from shape analysis and afterwards they self-include with the wrong shapes. Measured on real traces: 100% of SDPA events had inconsistent operand ranks, e.g. [[24576, 96], [1536, 1, 200, 96], [1536, 1, 200, 96], [], []], where q/k/v must share a rank.
  - _generate_extern_kernel_out_helper — receives input_handles from ExternKernelOutLine.codegen()

 All three build the metadata only under kernel_profile_enabled(), which is the same condition the C shim uses to decide whether to emit the profiling block (config.cpp.enable_kernel_profile, and a platform where RAIIAtenRecordFunctionHandle exists). Keeping producer and consumer on one predicate matters because the producer now emits codegen: building metadata the shim then declines to emit would leak a handle.

 Output tensor shapes (out-variant kernels)

 For out-variant extern kernels (ExternKernelOut), the output tensor is pre-allocated and available at recording time. The _generate_extern_kernel_out_helper method now passes the output tensor handle (out or out_as_strided) via a new output_handle parameter to generate_c_shim_extern_kernel_call,
 which converts it to an IValue and appends it at the end of the inputs vector. This matches eager trace behavior where the out parameter appears last in "Input Dims".

 Scalar argument recording

 ATen ops like addmm have scalar arguments (e.g., beta, alpha) that appear in eager traces as entries with Input type "Scalar" and empty Input Dims []. To match this, generate_c_shim_extern_kernel_call now accepts a num_scalars parameter and generates dummy int64(0) IValues via
 aoti_torch_int64_to_ivalue (the same approach used by Triton kernel profiling in cpp_wrapper_gpu.py). Only shapes matter for profiling analysis, so the actual scalar values are not preserved similar to how it is done for triton operations.

 Scalar args can be stored in two places on ExternKernel nodes:
  - constant_args: positional non-tensor args (from process_kernel)
  - kwargs + ordered_kwargs_for_cpp_kernel: keyword-only scalar args (e.g., alpha, beta for addmm)

 The total scalar count is computed as:
   len(node.constant_args) + len(ordered_kwargs_for_cpp_kernel excluding "out")

 Resulting trace format

  For an addmm kernel, the generated AOTI trace now shows:
    "Input type": ["c10::Half", "c10::Half", "c10::Half", "Scalar", "Scalar", "c10::Half"]
    "Input Dims": [[N], [M, K], [K, N], [], [], [M, N]]

 matching the eager trace format.

 ## Files changed

  - caffe2/torch/_inductor/codegen/cpp_wrapper_cpu.py — added input_handles, num_scalars and output_handle parameters to generate_c_shim_extern_kernel_call and _generate_extern_kernel_out_helper; generate_c_shim_extern_kernel_alloc and generate_c_shim_fallback_kernel build them only under kernel_profile_enabled()
  - caffe2/torch/_inductor/codegen/wrapper.py — added the module-level _get_profiling_input_handles helper and the kernel_profile_enabled() gate; ExternKernelOutLine.codegen() passes the handles, and computes them only when the C++ wrapper is generating code
 - caffe2/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py — the generate_c_shim_extern_kernel_call override routes input_handles and output_handle through borrow_arrayref_tensor_as_tensor(...), exactly as it already did for the positional args
 - caffe2/test/inductor/test_aot_inductor.py — added test_aoti_profiler_multi_output_fallback_input_shapes: scaled_dot_product_attention with transposed q/k/v, the one shape that enters generate_c_shim_fallback_kernel (no earlier test did). It asserts the recorded handle is the reinterpret expression, anchored to the SDPA shim name so a transposed GEMM elsewhere in the graph cannot satisfy it. Verified to fail without the fix on cpu, cuda and DualWrapper. Also added test_aoti_profiler_tensor_list_input_shapes: a tensor-list fallback (aten.cat over four sliced uint8 CPU tensors) whose inputs outnumber the kernel's args. This is the shape that produced the IndexError behind the revert; it asserts a handle exists for the fourth input, which a positional args lookup cannot reach.
 - caffe2/test/inductor/test_aot_inductor_arrayref.py — skip entry for that test under the minimal arrayref interface only. A tensor-list fallback renders its elements as "<elem>.get()", which graph inputs do not provide when they are ArrayRefTensor<T>. Verified pre-existing and independent of this stack: the same model fails to compile there with profiling off.


 # Recording order follows the operator schema

Reviewer feedback (P2465236096) pointed out that the metadata built above does not preserve the operator's argument order. This version fixes that.

The old shape was a pair: `input_handles`, a list of tensor handles, plus `num_scalars`, a count. The shim emitted every tensor first and then `num_scalars` placeholders, so the recording was `[tensor inputs..., placeholders..., out]`. That equals schema order only when a schema happens to list all its tensors before all its non-tensors. Eager records exactly one entry per schema argument, in schema order, with empty dims for the non-tensors (`Dispatcher.h` boxes the full C++ signature and `InputOutputEncoder::push` pushes one tag per IValue), so a consumer that reads "Input Dims" positionally is reading the wrong argument for any other schema.

Three distinct defects came out of that shape:

 1. **Order lost.** `process_kernel` flattens the call and partitions the leaves into `inputs` and `constant_args`; the interleaving survives only in the `unflatten_args` closure, which the metadata builder never called. `index_reduce(Tensor self, int dim, Tensor index, Tensor source, str reduce, *, bool include_self)` recorded `[self, index, source, S, S, S, S]` instead of `[self, S, index, source, S, S]`.
 2. **Counted twice.** `ordered_kwargs_for_cpp_kernel` is derived from the schema while `constant_args` is derived from the call, so an explicitly supplied keyword-only argument was counted in both. A keyword-only *tensor* was worse: `searchsorted`'s `sorter` was recorded once with its real shape and once as a placeholder, giving 10 entries for a 6-argument op.
 3. **Counted short.** An argument left at its default is in neither list, yet `fill_non_provided_args` means the shim call passes it. `_embedding_bag_forward_only` recorded 3 entries for 9 arguments; `_scaled_dot_product_flash_attention_for_cpu` recorded 5 for 7.

Roughly eighteen registered fallback ops are affected unconditionally, including the whole attention-backward family, `_embedding_bag`, `_cudnn_rnn`, `max_pool2d/3d_with_indices_backward`, `segment_reduce` and `index_reduce`.

 ## Change

`input_handles` and `num_scalars` are replaced by one ordered `profiling_args: list[str | None]`, where a `str` is a tensor handle expression and `None` is a placeholder. `output_handle` stays separate and is still appended last, matching eager, where `out` is a trailing keyword-only argument.

The list is built by `_get_profiling_args`, which rebuilds the argument list exactly the way the kernel's own call arguments are built, so the two stay in step:

 - a `FallbackKernel` restores the original interleaving through `unflatten_args`; every other `ExternKernel` follows the tensors-before-constants convention `ExternKernel.codegen_args` already relies on;
 - `fill_non_provided_args` fills in the defaulted positional arguments, matching the call the shim actually makes (fixes 3);
 - the keyword pass skips names already consumed positionally, because `ordered_kwargs_for_cpp_kernel` can name a positional argument supplied as a keyword -- `convolution` passes its whole `stride`/`padding`/`groups` tail that way -- and reads the rest out of the schema's keyword-only names rather than the call site (fixes 2).

Visiting each schema position exactly once is what fixes all three, with no per-op special casing.

The shim keeps two independent IValue counters, `tmp_<shim>_input_<n>` and `tmp_<shim>_scalar_<n>`, rather than numbering the merged sequence. That is what keeps the generated C++ byte-identical for every op that was already in schema order.

A tensor list still expands to one entry per element instead of the single IValue eager records. There is no `aoti_torch_tensorlist_to_ivalue` shim to build a list IValue with, and collapsing the list to one placeholder would throw away the only shape data `cat` has. This is the one deliberate deviation from eager.

 ## Effect on generated code

Generated C++ was dumped for 11 models across the CPU, CUDA and DualWrapper configurations, before and after. 23 of the 33 outputs are byte-identical, including `mm`, `addmm`, `bmm`, `baddbmm`, `cat`, `convolution`, `scatter` and `index_put`. The 10 that change are the ops the defects above describe:

| kernel | before | after | schema arguments |
|---|---|---|---|
| `index_reduce` | 7, wrong order | 6, schema order | 6 |
| `searchsorted.Tensor` | 10 | 6 | 6 |
| `_scaled_dot_product_flash_attention_for_cpu` | 5 | 7 | 7 |
| `_scaled_dot_product_efficient_attention` | 6 | 8 | 8 |
| `_embedding_bag_forward_only` | 3 | 9 | 9 |

Tensor entries and their recorded shapes are unchanged in every case; what changes is that non-tensor arguments now hold their schema position.

 # What changes for trace consumers

Recorded tensor entries and their shapes are unchanged everywhere. What changes is that a non-tensor argument now occupies its schema position, so a consumer reading "Input Dims" positionally lines up with the operator schema.

Two ops in the table above are worth calling out, because their schemas are tensor-first and so look like they should have been unaffected: `_scaled_dot_product_flash_attention_for_cpu` (5 -> 7) and `_embedding_bag_forward_only` (3 -> 9). Neither was reordered; both were short. Their trailing arguments are left at their defaults by the lowering, and an argument that is in neither `constant_args` nor `ordered_kwargs_for_cpp_kernel` went unrecorded -- even though `fill_non_provided_args` means the shim call passes it. That is the same defect as `mm.dtype_out`, and the entry count now equals the schema arity.

A consumer keyed on tensor dims sees no difference. One that counts entries sees the correct arity.

 # Also in this version

The IValue conversions are error-checked. `aoti_torch_tensor_to_ivalue` and `aoti_torch_int64_to_ivalue` leave the handle untouched when they fail, so an unchecked conversion let `RAIIC10IValueHandle` take ownership of an indeterminate pointer. Both now go through `_ivalue_conversion`, which initializes the handle and wraps the call in `AOTI_TORCH_ERROR_CODE_CHECK`, matching every other shim call in the file.

Test Plan:
Now generates a trace that has shape information and has the correct order for the shapes (not transposed or more dims than it should):
```
  {
    "ph": "X", "cat": "cpu_op", "name": "aoti_torch_cuda_mm_out", "pid": 4023436, "tid": 4023436,
    "ts": 5464826158019.994, "dur": 85.519,
    "args": {
      "External id": 890,"Record function id": 0, "Concrete Inputs": ["", "", ""], "Input type": ["c10::Half", "c10::Half", "c10::Half"], "Input Dims": [[800, 14400], [14400, 1024], [800, 1024]], "Ev Idx": 889
    }
  },
```
while before the change this would look like:
```
  {
    "ph": "X", "cat": "cpu_op", "name": "aoti_torch_cuda_mm_out", "pid": 2290421, "tid": 2290421,
    "ts": 4971258491467.797, "dur": 41.293,
    "args": {
      "External id": 1672,"Record function id": 0, "Ev Idx": 1671
    }
  },
```
and operations also have the Scalars in their args:
```
  {
    "ph": "X", "cat": "cpu_op", "name": "aoti_torch_cuda_addmm_out", "pid": 4023436, "tid": 4023436,
    "ts": 5464826172563.836, "dur": 61.243,
    "args": {
      "External id": 2456,"Record function id": 0, "Concrete Inputs": ["", "", "", "0", "0", ""], "Input type": ["c10::Half", "c10::Half", "c10::Half", "Scalar", "Scalar", "c10::Half"], "Input Dims": [[800, 5120], [800, 8192], [8192, 5120], [], [], [800, 5120]], "Ev Idx": 2455
    }
  },
```

Reviewed By: desertfire

Differential Revision: D113606047




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo