### PR TITLE
Fix OverflowError in PM sampling _pull_hw on garbage timestamps

### DIFF
--- a/torch/profiler/_cupti/pm_sampling.py
+++ b/torch/profiler/_cupti/pm_sampling.py
@@ -429,20 +429,24 @@ class PmSampler:
                 "PM sampling decoded the maximum %d samples; some were dropped.",
                 self._max_samples,
             )
-        ts = np.empty(n, dtype=np.int64)
+        # start_timestamp is a C uint64; read it unsigned so a garbage sample
+        # carrying a full-uint64 value can't overflow the int64 assignment.
+        raw_ts = np.empty(n, dtype=np.uint64)
         vals = np.empty((n, len(self._metric_names)), dtype=np.float64)
         for i, s in enumerate(cd):
-            ts[i] = s.start_timestamp
+            raw_ts[i] = s.start_timestamp
             vals[i] = s.metric_values
-        # Drop an unset interval-start (0) or a stale small value from a
-        # different clock domain (observed ~7.5e13 vs the real ~1.78e18).
-        # Real samples fall within the look-back of the newest.
-        keep = ts > 0
+        # Drop an unset interval-start (0), a stale small value from a different
+        # clock domain (observed ~7.5e13 vs the real ~1.78e18), or a garbage
+        # sample whose timestamp overflows int64. Real samples fall within the
+        # look-back of the newest.
+        keep = (raw_ts > 0) & (raw_ts <= np.uint64(np.iinfo(np.int64).max))
         if keep.any():
-            keep &= ts >= int(ts[keep].max()) - self._lookback_window_ns
+            newest = int(raw_ts[keep].max())
+            keep &= raw_ts >= np.uint64(max(0, newest - self._lookback_window_ns))
         if not keep.any():
             return
-        ts = ts[keep]
+        ts = raw_ts[keep].astype(np.int64)
         vals = vals[keep]
         if self._retained_ts.size:
             self._retained_ts = np.concatenate([self._retained_ts, ts])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191066

CUPTI PM sampling decodes samples from a fixed-size hardware ring that can
contain unset or partially-filled entries. Such a garbage sample can carry a
full-uint64 start_timestamp (near 1.8e19), which exceeds int64 max (9.2e18).
_pull_hw preallocated the timestamp array as int64 and assigned each sample's
Python-int start_timestamp element-wise, so numpy range-checked the assignment
and raised "OverflowError: Python int too large to convert to C long" before
the existing look-back filter could discard the garbage sample.

The fix reads timestamps into a uint64 buffer (assignment can no longer
overflow), then drops any sample that is 0, exceeds int64 max, or falls outside
the look-back window of the newest sample, and narrows only the survivors to
int64. Real timestamps (~1.78e18) are unaffected; downstream storage and cursor
comparisons stay int64 as before, avoiding a uint64->float64 promotion that
would lose precision at ~1e18.

Test Plan:
Rebuilt torch with the change:

    pip install -e . -v --no-build-isolation

Verified the revised filter drops an overflowing garbage timestamp while
keeping a real one:

    python -c "
    import numpy as np
    raw = np.array([2**64-1, 1_780_000_000_000_000_000], dtype=np.uint64)
    keep = (raw > 0) & (raw <= np.uint64(np.iinfo(np.int64).max))
    newest = int(raw[keep].max())
    keep &= raw >= np.uint64(max(0, newest - 10_000_000_000))
    assert list(keep) == [False, True]
    "

Authored with the assistance of an AI coding assistant.