### PR TITLE
[docs] Add programming model pages on reducing compile time and guard overhead

### DIFF
--- a/docs/source/user_guide/torch_compiler/compile/programming_model.md
+++ b/docs/source/user_guide/torch_compiler/compile/programming_model.md
@@ -13,6 +13,8 @@ programming_model.dynamo_core_concepts
 programming_model.graph_breaks_index
 programming_model.non_strict_tracing_model
 programming_model.recompilation
+programming_model.reducing_compile_time
+programming_model.reducing_guard_overhead
 programming_model.observability
 programming_model.reporting_issues
 ```

--- a/docs/source/user_guide/torch_compiler/compile/programming_model.reducing_compile_time.md
+++ b/docs/source/user_guide/torch_compiler/compile/programming_model.reducing_compile_time.md
@@ -1,0 +1,102 @@
+# Reducing Compile Time
+
+`torch.compile` is a just-in-time compiler, so the first one or two calls to a
+compiled function pay a compilation cost before you see any speedup. Cold-start
+(uncached) compile time typically ranges from seconds to minutes for common
+models, and can reach tens of minutes to a few hours for very large ones. This
+page collects strategies for reducing that cost.
+
+This is distinct from reducing the per-call *guard* overhead paid on every
+invocation — for that, see
+[Reducing Guard Overhead](programming_model.reducing_guard_overhead).
+
+## Avoid unnecessary recompilations
+
+Each recompilation pays the compile cost again, so the single most common cause
+of excessive compile time is recompiling more than necessary. Diagnose
+recompilations with tlparse or `TORCH_LOGS=recompiles`, then remove their
+causes. See [Dealing with Recompilations](programming_model.recompilation) for
+the full workflow.
+
+## Use dynamic shapes to avoid shape-driven recompiles
+
+By default, `torch.compile` specializes on the shapes it sees, so a program that
+runs many different input shapes can recompile once per shape. Letting Dynamo
+treat a dimension as dynamic compiles a single graph that covers a range of
+sizes, avoiding a recompile per shape.
+
+`torch.compile(dynamic=None)` (the default) automatically tries dynamic shapes
+after the first recompilation. You can also annotate dimensions explicitly:
+
+```python
+import torch
+
+# Mark dim 0 of x as dynamic, optionally with a min/max range, BEFORE compiling.
+torch._dynamo.mark_dynamic(x, 0, min=1, max=1024)
+
+opt_fn = torch.compile(fn)
+opt_fn(x)
+```
+
+`mark_dynamic` must be called on the input tensors *before* they are passed into
+the compiled function (not inside the compiled region). For the full model of
+what "dynamic" means, automatic dynamic, and other annotations, see
+{ref}`dynamic_shapes`.
+
+## Regional compilation
+
+Instead of compiling an entire large model in one shot, you can compile a
+smaller *region* that is repeated throughout the model — for example, a single
+transformer block — and let that same compiled region run for every repetition.
+Because the region is compiled once rather than once per repetition, cold-start
+compile time drops substantially for models built from many identical blocks.
+
+See the
+[Regional compilation recipe](https://docs.pytorch.org/tutorials/recipes/regional_compilation.html)
+for a worked example.
+
+## Hierarchical compilation with `nested_compile_region`
+
+`torch.compiler.nested_compile_region` marks a set of operations — again,
+typically a repeated structural unit such as an LLM's transformer layer — as a
+nested compile region. During a full-model `torch.compile`, the compiler emits
+optimized code for the region the first time it is encountered and re-emits
+("stamps out") that compiled code on every subsequent occurrence, rather than
+re-compiling each one. This can substantially reduce overall compile time for
+deeply-stacked, structurally-identical components.
+
+```python
+import torch
+
+@torch.compiler.nested_compile_region
+def transformer_layer(x):
+    ...
+
+@torch.compile
+def model(x):
+    for _ in range(num_layers):
+        x = transformer_layer(x)
+    return x
+```
+
+Unlike regional compilation, this works *inside* a single `torch.compile` call
+and does not require restructuring how you apply `torch.compile`. It is also
+safe: it does **not** guarantee the region is compiled exactly once — if new
+input conditions (shape, dtype, device, stride, globals, etc.) would make the
+cached region invalid, the compiler transparently re-compiles it, so correctness
+is always preserved and you only pay the extra compile cost when required.
+Outside a `torch.compile` context the call is a no-op.
+
+## Measuring compile time
+
+Before optimizing, measure where compile time is going:
+
+- `torch._dynamo.utils.compile_times()` prints the time spent in each Dynamo
+  compilation phase.
+- `TORCH_COMPILE_DEBUG=1` surfaces Inductor phase timings and artifacts.
+- tlparse / `TORCH_TRACE` gives a per-compilation report; see
+  [tlparse / TORCH_TRACE](programming_model.observability).
+
+Finally, remember that `torch.compile`'s caches persist compiled artifacts
+across invocations and even across processes, so a warmed-up (cached) run
+compiles much faster than a cold start.

--- a/docs/source/user_guide/torch_compiler/compile/programming_model.reducing_guard_overhead.md
+++ b/docs/source/user_guide/torch_compiler/compile/programming_model.reducing_guard_overhead.md
@@ -1,0 +1,133 @@
+# Reducing Guard Overhead
+
+Every time you call a `torch.compile`d function, Dynamo runs a set of *guards*
+before dispatching to a compiled artifact. Guards check that the assumptions
+made at compile time (tensor shapes and dtypes, `nn.Module` attributes, global
+state, etc.) still hold, so that it is sound to reuse the compiled code. This
+check happens on **every call**, so for functions that are cheap relative to
+their guard set, guard evaluation can become a measurable fraction of runtime.
+
+Closely related is the *pre-graph bytecode* that Dynamo runs before entering the
+compiled graph to marshal inputs (for example, looking up parameters and buffers
+to pass into the graph). Like guards, this runs on every call.
+
+This page collects the knobs for reducing that per-call overhead. This is
+distinct from reducing *compilation* time; if your problem is slow or repeated
+compilation, see [Dealing with Recompilations](programming_model.recompilation).
+
+```{warning}
+Most of the options below are **unsafe** by design: they trade soundness for
+speed by dropping or skipping guards. They assume your model code does not
+mutate the guarded state (e.g. `nn.Module` attributes or globals) between calls
+after warmup. If that assumption is violated, `torch.compile` may silently run a
+stale compiled artifact and produce **incorrect results**. Only enable them once
+you understand the assumption each one makes.
+```
+
+You can inspect which guards are being evaluated using tlparse or
+`TORCH_LOGS=guards`; see [tlparse / TORCH_TRACE](programming_model.observability).
+
+## 1. Reduce pre-graph bytecode time with `install_free_tensors`
+
+```python
+import torch._dynamo
+
+with torch._dynamo.config.patch(install_free_tensors=True):
+    # torch.compile your model / call the compiled function here
+    ...
+```
+
+This installs free tensors (such as parameters and buffers) as graph attributes
+rather than graph inputs, which reduces the pre-graph bytecode work needed to
+marshal them into the graph. As a side effect it also changes how those
+parameters and buffers are guarded (they no longer need a per-input tensor
+match), so you may see a small guard-overhead improvement as well. That guard
+improvement is often small on its own, because most of the per-call cost is in
+*accessing* the object being checked rather than in the guard check itself.
+
+`install_free_tensors` is `False` by default (it originated as an export aid for
+producing a consistent number of graph inputs), so you must opt in via the
+config patch above.
+
+## 2. Skip guards on `nn.Module`s with `guard_filter_fn`
+
+`torch.compile` accepts a `guard_filter_fn` option that decides, guard by guard,
+which guards to keep. `torch.compiler` ships several ready-made filters. The most
+impactful for guard overhead is skipping guards on `nn.Module`s:
+
+```python
+import torch
+
+opt_mod = torch.compile(
+    mod,
+    options={"guard_filter_fn": torch.compiler.skip_guard_on_all_nn_modules_unsafe},
+)
+```
+
+This typically gives a large reduction in guard overhead, since models tend to
+have many module attributes that are guarded but never mutated. Note the
+interaction with pre-graph bytecode: skipping these guards means the cache of
+parameter/buffer pointers goes cold, so some of the overhead you removed from
+guards **shifts into pre-graph bytecode**. To see the full benefit, combine this
+with `install_free_tensors=True` above — apply **both (1) and (2)** together.
+
+Other filters available in `torch.compiler` (all `_unsafe`, same caveats):
+
+- `skip_guard_on_inbuilt_nn_modules_unsafe` — skip guards only on built-in
+  modules like `torch.nn.Linear`.
+- `skip_guard_on_globals_unsafe` — skip guards on globals.
+- `keep_tensor_guards_unsafe` — keep only tensor guards (optionally including
+  parameters).
+- `keep_global_context_and_tensor_guards_unsafe` — keep only global-state and
+  (non-global) tensor guards.
+- `skip_all_guards_unsafe` — drop **all** guards; removes every safety guarantee,
+  use with extreme caution.
+
+## 3. Try `use_recursive_dict_tags_for_guards` first
+
+```python
+import torch._dynamo
+
+torch._dynamo.config.use_recursive_dict_tags_for_guards = True
+```
+
+This speeds up guard execution for nested `nn.Module`s by recursively checking
+dict tags to avoid running the full guard set. It relies on a fairly complicated
+mechanism using low-level CPython features. A few concerns have been raised in
+OSS issues, so it is off by default and may be revisited. It is worth trying
+**before** options (1) and (2): if it works for your model, you will not need to
+skip `nn.Module` guards (2), though you would still benefit from
+`install_free_tensors` (1).
+
+## 4. Skip guard evaluation after warmup with `skip_guard_eval_unsafe`
+
+```python
+import torch
+
+# 1. Warm up: run the compiled model with a sufficient variety of inputs until
+#    no further recompilation occurs.
+# 2. Then switch stance to run only the minimal set of differentiating guards.
+with torch.compiler.set_stance(skip_guard_eval_unsafe=True):
+    # steady-state inference / training iterations
+    ...
+```
+
+Once you have warmed up the compiled model to the point where no further
+recompilations happen, `skip_guard_eval_unsafe` runs only the minimal set of
+guards needed to differentiate between the compiled artifacts you already have,
+skipping the rest. Unlike the options above, this cannot be set at
+`torch.compile` time — you must enable it in the serving/training loop *after*
+warmup. If the no-more-recompilation assumption fails (a genuinely new input
+arrives), there is a risk of silently producing incorrect results, hence the
+`unsafe` in the name.
+
+## Putting it together
+
+- Start by measuring where the per-call time goes (guards vs. pre-graph bytecode)
+  with tlparse / `TORCH_LOGS=guards`.
+- Optionally try `use_recursive_dict_tags_for_guards=True` first.
+- Otherwise, apply `install_free_tensors=True` **and** a `guard_filter_fn` such
+  as `skip_guard_on_all_nn_modules_unsafe` together — one reduces guard overhead,
+  the other keeps that saving from reappearing as pre-graph bytecode overhead.
+- For steady-state serving after warmup, consider
+  `set_stance(skip_guard_eval_unsafe=True)`.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191072

Adds two new pages to the torch.compile programming model docs, under the
existing programming_model toctree (after "Dealing with Recompilations"):

- Reducing Compile Time: recompilation avoidance, dynamic shapes
  (mark_dynamic), regional compilation, and hierarchical compilation via
  torch.compiler.nested_compile_region, plus how to measure compile time.
- Reducing Guard Overhead: reducing per-call guard/pre-graph-bytecode cost via
  install_free_tensors, the skip_guard_on_all_nn_modules_unsafe (and sibling)
  guard_filter_fn helpers, use_recursive_dict_tags_for_guards, and
  set_stance(skip_guard_eval_unsafe=True), with the appropriate "unsafe"
  caveats.

Both pages cross-link the existing recompilation, dynamic-shapes, and
observability docs. Content based on guidance from Animesh Jain and
Richard Zou.