### PR TITLE
Enable C++ stack traces for distributed detail debug

### DIFF
--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -1209,7 +1209,7 @@ For fine-grained control of the debug level during runtime the functions {func}`
 {func}`torch.distributed.get_debug_level` can also be used.
 :::
 
-In addition, `TORCH_DISTRIBUTED_DEBUG=DETAIL` can be used in conjunction with `TORCH_SHOW_CPP_STACKTRACES=1` to log the entire callstack when a collective desynchronization is detected. These
+In addition, `TORCH_DISTRIBUTED_DEBUG=DETAIL` enables C++ stack traces by default to log the entire callstack when a collective desynchronization is detected. Set `TORCH_SHOW_CPP_STACKTRACES=0` to opt out. These
 collective desynchronization checks will work for all applications that use `c10d` collective calls backed by process groups created with the
 {func}`torch.distributed.init_process_group` and {func}`torch.distributed.new_group` APIs.
 

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -1561,11 +1561,12 @@ class TestCppExtensionJIT(common.TestCase):
             )
 
     def test_torch_check_eq_stacktrace(self):
-        """Test that TORCH_CHECK_EQ includes C++ stack trace when TORCH_SHOW_CPP_STACKTRACES=1.
+        """Test that TORCH_CHECK_EQ includes C++ stack trace when debug env enables it.
 
-        When TORCH_SHOW_CPP_STACKTRACES=1, errors from TORCH_CHECK_EQ should include
-        a C++ stack trace via DealWithFatal's call to GetFetchStackTrace.
-        Since this env var is cached on first use, we use subprocess to test both cases.
+        Errors from TORCH_CHECK_EQ should include a C++ stack trace via
+        DealWithFatal's call to GetFetchStackTrace when enabled explicitly or via
+        TORCH_DISTRIBUTED_DEBUG=DETAIL. Since this setting is cached on first
+        use, we use subprocess to test each case.
         """
         test_script = """
 import torch
@@ -1594,10 +1595,26 @@ except RuntimeError as e:
     print(str(e))
 """
 
-        for show_cpp_stacktraces in [False, True]:
-            with self.subTest(show_cpp_stacktraces=show_cpp_stacktraces):
+        cases = (
+            ({}, False),
+            ({"TORCH_SHOW_CPP_STACKTRACES": "0"}, False),
+            ({"TORCH_SHOW_CPP_STACKTRACES": "1"}, True),
+            ({"TORCH_DISTRIBUTED_DEBUG": "DETAIL"}, True),
+            (
+                {
+                    "TORCH_SHOW_CPP_STACKTRACES": "0",
+                    "TORCH_DISTRIBUTED_DEBUG": "DETAIL",
+                },
+                False,
+            ),
+        )
+
+        for stacktrace_env, expect_cpp_stacktraces in cases:
+            with self.subTest(stacktrace_env=stacktrace_env):
                 env = os.environ.copy()
-                env["TORCH_SHOW_CPP_STACKTRACES"] = "1" if show_cpp_stacktraces else "0"
+                env.pop("TORCH_DISTRIBUTED_DEBUG", None)
+                env.pop("TORCH_SHOW_CPP_STACKTRACES", None)
+                env.update(stacktrace_env)
                 env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
                 result = subprocess.run(
@@ -1615,7 +1632,7 @@ except RuntimeError as e:
                     f"Expected 'Check failed: a == b' in error message, got: {error_message}",
                 )
 
-                if show_cpp_stacktraces:
+                if expect_cpp_stacktraces:
                     # C++ CapturedTraceback is not available on aarch64 due to:
                     # #if !defined(FBCODE_CAFFE2) && !defined(__aarch64__)
                     # in torch/csrc/Module.cpp
@@ -1626,7 +1643,7 @@ except RuntimeError as e:
                         self.assertIn(
                             "C++ CapturedTraceback:",
                             error_message,
-                            f"Expected C++ stack trace info in error message when TORCH_SHOW_CPP_STACKTRACES=1, got: {error_message}",
+                            f"Expected C++ stack trace info in error message for {stacktrace_env}, got: {error_message}",
                         )
                     self.assertRegex(
                         error_message,
@@ -1636,7 +1653,7 @@ except RuntimeError as e:
                     self.assertNotIn(
                         "C++ CapturedTraceback:",
                         error_message,
-                        f"Did not expect 'C++ CapturedTraceback:' in error message when TORCH_SHOW_CPP_STACKTRACES=0, got: {error_message}",
+                        f"Did not expect 'C++ CapturedTraceback:' in error message for {stacktrace_env}, got: {error_message}",
                     )
 
 

--- a/torch/csrc/utils/cpp_stacktraces.cpp
+++ b/torch/csrc/utils/cpp_stacktraces.cpp
@@ -3,10 +3,27 @@
 #include <c10/util/Exception.h>
 #include <c10/util/env.h>
 
+#include <algorithm>
+#include <cctype>
+#include <string>
+
 namespace torch {
 namespace {
 bool compute_cpp_stack_traces_enabled() {
-  return c10::utils::check_env("TORCH_SHOW_CPP_STACKTRACES") == true;
+  auto show_cpp_stacktraces =
+      c10::utils::check_env("TORCH_SHOW_CPP_STACKTRACES");
+  if (show_cpp_stacktraces.has_value()) {
+    return show_cpp_stacktraces.value();
+  }
+
+  auto distributed_debug =
+      c10::utils::get_env("TORCH_DISTRIBUTED_DEBUG").value_or("");
+  std::transform(
+      distributed_debug.begin(),
+      distributed_debug.end(),
+      distributed_debug.begin(),
+      [](unsigned char c) { return std::toupper(c); });
+  return distributed_debug == "DETAIL";
 }
 
 bool compute_disable_addr2line() {


### PR DESCRIPTION
Fixes pytorch/pytorch#78842

## Summary

- Treat `TORCH_DISTRIBUTED_DEBUG=DETAIL` as enabling C++ stack traces when `TORCH_SHOW_CPP_STACKTRACES` is unset.
- Preserve an explicit `TORCH_SHOW_CPP_STACKTRACES=0` opt-out.
- Extend the C++ stacktrace env test matrix and update the distributed debugging docs.

## Test plan

- `git diff --check`
- `PYTHONPYCACHEPREFIX=/private/tmp/codex-pycache python3 -m py_compile test/test_cpp_extensions_jit.py`

I could not run the full stacktrace behavior test locally because this sparse checkout is not a built PyTorch tree.
