### PR TITLE
[Testcase Refactoring] Device-agnostic move_to_device_pass tests via instantiate + device

### DIFF
--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -46,7 +46,7 @@ from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.fx.passes.infra.partitioner import Partition
 from torch.fx.passes.operator_support import OperatorSupport
 from torch.library import _scoped_library, impl
-from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
@@ -1324,87 +1324,61 @@ default](args = (%x, %b_state), kwargs = {})
     return (b_state, getitem_3, getitem_4)""",
             )
 
-    @unittest.skipIf(not TEST_CUDA, "requires cuda")
-    def test_move_device_to(self):
+
+@skipIfTorchDynamo("recursively running dynamo on export is unlikely")
+@unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
+class TestPassesDevice(TestCase):
+    def test_move_device_to(self, device):
+        device_type = str(device).split(":", 1)[0]
+        device0 = f"{device_type}:0"
+
         class M(torch.nn.Module):
             def forward(self, x):
-                x = torch.ops.aten.to.device(x, device="cuda:0", dtype=torch.float32)
+                x = torch.ops.aten.to.device(x, device=device0, dtype=torch.float32)
                 return x + x
 
         ep = torch.export.export(M(), (torch.ones(3),))
-        ep = move_to_device_pass(ep, "cuda")
+        ep = move_to_device_pass(ep, device_type)
         ep.graph_module.recompile()
         self.assertExpectedInline(
             ep.graph_module.code.strip("\n"),
-            """\
+            f"""\
 def forward(self, x):
-    _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(x, dtype = torch.float32, device = 'cuda', layout = torch.strided);  _assert_tensor_metadata_default = None
-    to = torch.ops.aten.to.device(x, 'cuda', torch.float32);  x = None
+    _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(x, dtype = torch.float32, device = '{device_type}', layout = torch.strided);  _assert_tensor_metadata_default = None
+    to = torch.ops.aten.to.device(x, '{device_type}', torch.float32);  x = None
     add = torch.ops.aten.add.Tensor(to, to);  to = None
     return (add,)
     """,
         )
 
-    @unittest.skipIf(not TEST_CUDA, "requires cuda")
-    def test_move_device_submod(self):
+    def test_move_device_submod(self, device):
+        device_type = str(device).split(":", 1)[0]
+        device0 = f"{device_type}:0"
+
         class M(torch.nn.Module):
             def forward(self, x):
-                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
-                    x = x.to(device="cuda:0")
+                with torch.autocast(device_type=device_type, dtype=torch.bfloat16):
+                    x = x.to(device=device0)
                     return x + x
 
         ep = torch.export.export(M(), (torch.ones(3),))
-        ep = move_to_device_pass(ep, "cuda")
+        ep = move_to_device_pass(ep, device_type)
         ep.graph_module.submod_1.recompile()
         self.assertExpectedInline(
             ep.graph_module.submod_1.code.strip("\n"),
-            """\
+            f"""\
 def forward(self, arg0_1):
-    _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(arg0_1, dtype = torch.float32, device = 'cuda', layout = torch.strided);  _assert_tensor_metadata_default = None
-    to = torch.ops.aten.to.dtype_layout(arg0_1, dtype = torch.float32, layout = torch.strided, device = 'cuda');  arg0_1 = None
+    _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(arg0_1, dtype = torch.float32, device = '{device_type}', layout = torch.strided);  _assert_tensor_metadata_default = None
+    to = torch.ops.aten.to.dtype_layout(arg0_1, dtype = torch.float32, layout = torch.strided, device = '{device_type}');  arg0_1 = None
     add = torch.ops.aten.add.Tensor(to, to);  to = None
     return (add,)
     """,
         )
 
-    @unittest.skipIf(not TEST_CUDA, "requires cuda")
-    def test_move_to_device_pass(self):
-        class Model(torch.nn.Module):
-            def __init__(self, size=4, h_dim=10):
-                super().__init__()
-                self.rnn = torch.nn.GRU(size, h_dim, batch_first=True)
+    def test_move_device_example_inputs(self, device):
+        device_type = str(device).split(":", 1)[0]
+        device0 = f"{device_type}:0"
 
-            def forward(self, x):
-                _, states = self.rnn(x)
-                return states
-
-        # move the exported program from cpu to cuda:0
-        mod = Model()
-        example_inputs = (torch.rand(1, 10, 4),)
-        ep = export(mod, example_inputs, strict=True)
-        location = torch.device("cuda:0")
-        ep = move_to_device_pass(ep, location=location)
-        gm = ep.module()
-        test_inputs = (torch.rand(1, 10, 4).to("cuda:0"),)
-        outputs = gm(*test_inputs)
-        self.assertEqual(outputs.device, torch.device("cuda:0"))
-        # move it back to cpu
-        location = "cpu"
-        ep = move_to_device_pass(ep, location=location)
-        gm = ep.module()
-        test_inputs = (torch.rand(1, 10, 4).to("cpu"),)
-        outputs = gm(*test_inputs)
-        self.assertEqual(outputs.device, torch.device("cpu"))
-        # move it to cuda:0 again
-        location = {"cpu": "cuda:0"}
-        ep = move_to_device_pass(ep, location=location)
-        gm = ep.module()
-        test_inputs = (torch.rand(1, 10, 4).to("cuda:0"),)
-        outputs = gm(*test_inputs)
-        self.assertEqual(outputs.device, torch.device("cuda:0"))
-
-    @unittest.skipIf(not TEST_CUDA, "requires cuda")
-    def test_move_device_example_inputs(self):
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1426,14 +1400,57 @@ def forward(self, arg0_1):
         self.assertEqual(ep.example_inputs[0][1].device, torch.device("cpu"))
         self.assertEqual(ep.example_inputs[1]["z"].device, torch.device("cpu"))
 
-        # Move to CUDA
-        location = torch.device("cuda:0")
-        ep_cuda = move_to_device_pass(ep, location=location)
+        # Move to accelerator
+        location = torch.device(device0)
+        ep_moved = move_to_device_pass(ep, location=location)
 
-        # Verify example_inputs moved to CUDA
-        self.assertEqual(ep_cuda.example_inputs[0][0].device, torch.device("cuda:0"))
-        self.assertEqual(ep_cuda.example_inputs[0][1].device, torch.device("cuda:0"))
-        self.assertEqual(ep_cuda.example_inputs[1]["z"].device, torch.device("cuda:0"))
+        # Verify example_inputs moved
+        self.assertEqual(ep_moved.example_inputs[0][0].device, torch.device(device0))
+        self.assertEqual(ep_moved.example_inputs[0][1].device, torch.device(device0))
+        self.assertEqual(ep_moved.example_inputs[1]["z"].device, torch.device(device0))
+
+    def test_move_to_device_pass(self, device):
+        device_type = str(device).split(":", 1)[0]
+        if device_type not in ("cuda", "xpu"):
+            self.skipTest("move_to_device_pass RNN is supported only on cuda/xpu")
+        device0 = f"{device_type}:0"
+
+        class Model(torch.nn.Module):
+            def __init__(self, size=4, h_dim=10):
+                super().__init__()
+                self.rnn = torch.nn.GRU(size, h_dim, batch_first=True)
+
+            def forward(self, x):
+                _, states = self.rnn(x)
+                return states
+
+        # move the exported program from cpu to accelerator:0
+        mod = Model()
+        example_inputs = (torch.rand(1, 10, 4),)
+        ep = export(mod, example_inputs, strict=True)
+        location = torch.device(device0)
+        ep = move_to_device_pass(ep, location=location)
+        gm = ep.module()
+        test_inputs = (torch.rand(1, 10, 4).to(device0),)
+        outputs = gm(*test_inputs)
+        self.assertEqual(outputs.device, torch.device(device0))
+        # move it back to cpu
+        location = "cpu"
+        ep = move_to_device_pass(ep, location=location)
+        gm = ep.module()
+        test_inputs = (torch.rand(1, 10, 4).to("cpu"),)
+        outputs = gm(*test_inputs)
+        self.assertEqual(outputs.device, torch.device("cpu"))
+        # move it to accelerator:0 again
+        location = {"cpu": device0}
+        ep = move_to_device_pass(ep, location=location)
+        gm = ep.module()
+        test_inputs = (torch.rand(1, 10, 4).to(device0),)
+        outputs = gm(*test_inputs)
+        self.assertEqual(outputs.device, torch.device(device0))
+
+
+instantiate_device_type_tests(TestPassesDevice, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -1414,12 +1414,6 @@ def forward(self, arg0_1):
         self.assertEqual(ep_moved.example_inputs[0][1].device, torch.device(device0))
         self.assertEqual(ep_moved.example_inputs[1]["z"].device, torch.device(device0))
 
-
-@skipIfTorchDynamo("recursively running dynamo on export is unlikely")
-@unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
-class TestPassesRNN(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
-
     def test_move_to_device_pass(self, device):
         device_type = torch.device(device).type
         device0 = f"{device_type}:0"
@@ -1460,7 +1454,6 @@ class TestPassesRNN(TestCase):
 
 
 instantiate_device_type_tests(TestPassesDevice, globals(), except_for="cpu")
-instantiate_device_type_tests(TestPassesRNN, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -1335,11 +1335,10 @@ class TestPassesDevice(TestCase):
 
     def test_move_device_to(self, device):
         device_type = torch.device(device).type
-        device0 = f"{device_type}:0"
 
         class M(torch.nn.Module):
             def forward(self, x):
-                x = torch.ops.aten.to.device(x, device=device0, dtype=torch.float32)
+                x = torch.ops.aten.to.device(x, device=device, dtype=torch.float32)
                 return x + x
 
         ep = torch.export.export(M(), (torch.ones(3),))
@@ -1358,12 +1357,11 @@ def forward(self, x):
 
     def test_move_device_submod(self, device):
         device_type = torch.device(device).type
-        device0 = f"{device_type}:0"
 
         class M(torch.nn.Module):
             def forward(self, x):
                 with torch.autocast(device_type=device_type, dtype=torch.bfloat16):
-                    x = x.to(device=device0)
+                    x = x.to(device=device)
                     return x + x
 
         ep = torch.export.export(M(), (torch.ones(3),))
@@ -1381,8 +1379,7 @@ def forward(self, arg0_1):
         )
 
     def test_move_device_example_inputs(self, device):
-        device_type = torch.device(device).type
-        device0 = f"{device_type}:0"
+        target_device = torch.device(device)
 
         class Model(torch.nn.Module):
             def __init__(self):
@@ -1406,17 +1403,15 @@ def forward(self, arg0_1):
         self.assertEqual(ep.example_inputs[1]["z"].device, torch.device("cpu"))
 
         # Move to accelerator
-        location = torch.device(device0)
-        ep_moved = move_to_device_pass(ep, location=location)
+        ep_moved = move_to_device_pass(ep, location=target_device)
 
         # Verify example_inputs moved
-        self.assertEqual(ep_moved.example_inputs[0][0].device, torch.device(device0))
-        self.assertEqual(ep_moved.example_inputs[0][1].device, torch.device(device0))
-        self.assertEqual(ep_moved.example_inputs[1]["z"].device, torch.device(device0))
+        self.assertEqual(ep_moved.example_inputs[0][0].device, target_device)
+        self.assertEqual(ep_moved.example_inputs[0][1].device, target_device)
+        self.assertEqual(ep_moved.example_inputs[1]["z"].device, target_device)
 
     def test_move_to_device_pass(self, device):
-        device_type = torch.device(device).type
-        device0 = f"{device_type}:0"
+        target_device = torch.device(device)
 
         class Model(torch.nn.Module):
             def __init__(self, size=4, h_dim=10):
@@ -1427,16 +1422,15 @@ def forward(self, arg0_1):
                 _, states = self.rnn(x)
                 return states
 
-        # move the exported program from cpu to accelerator:0
+        # move the exported program from cpu to accelerator
         mod = Model()
         example_inputs = (torch.rand(1, 10, 4),)
         ep = export(mod, example_inputs, strict=True)
-        location = torch.device(device0)
-        ep = move_to_device_pass(ep, location=location)
+        ep = move_to_device_pass(ep, location=target_device)
         gm = ep.module()
-        test_inputs = (torch.rand(1, 10, 4).to(device0),)
+        test_inputs = (torch.rand(1, 10, 4).to(target_device),)
         outputs = gm(*test_inputs)
-        self.assertEqual(outputs.device, torch.device(device0))
+        self.assertEqual(outputs.device, target_device)
         # move it back to cpu
         location = "cpu"
         ep = move_to_device_pass(ep, location=location)
@@ -1444,16 +1438,18 @@ def forward(self, arg0_1):
         test_inputs = (torch.rand(1, 10, 4).to("cpu"),)
         outputs = gm(*test_inputs)
         self.assertEqual(outputs.device, torch.device("cpu"))
-        # move it to accelerator:0 again
-        location = {"cpu": device0}
+        # move it to accelerator again
+        location = {"cpu": str(target_device)}
         ep = move_to_device_pass(ep, location=location)
         gm = ep.module()
-        test_inputs = (torch.rand(1, 10, 4).to(device0),)
+        test_inputs = (torch.rand(1, 10, 4).to(target_device),)
         outputs = gm(*test_inputs)
-        self.assertEqual(outputs.device, torch.device(device0))
+        self.assertEqual(outputs.device, target_device)
 
 
-instantiate_device_type_tests(TestPassesDevice, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestPassesDevice, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -1421,7 +1421,6 @@ class TestPassesRNN(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     def test_move_to_device_pass(self, device):
-        # NPU fp32 GRU fails after move_to_device_pass (DynamicGRUV2); keep cuda/xpu.
         device_type = torch.device(device).type
         device0 = f"{device_type}:0"
 
@@ -1461,7 +1460,7 @@ class TestPassesRNN(TestCase):
 
 
 instantiate_device_type_tests(TestPassesDevice, globals(), except_for="cpu")
-instantiate_device_type_tests(TestPassesRNN, globals(), only_for=("cuda", "xpu"))
+instantiate_device_type_tests(TestPassesRNN, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -48,6 +48,7 @@ from torch.fx.passes.operator_support import OperatorSupport
 from torch.library import _scoped_library, impl
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_WINDOWS,
     run_tests,
     skipIfTorchDynamo,
@@ -374,6 +375,8 @@ def _sequential_split_inline_tests():
 @skipIfTorchDynamo("recursively running dynamo on export is unlikely")
 @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
 class TestPasses(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.MIXED_AUTOCAST_SET_GRAD_TESTS = _with_mixed_autocast_set_grad_tests()
@@ -1328,6 +1331,8 @@ default](args = (%x, %b_state), kwargs = {})
 @skipIfTorchDynamo("recursively running dynamo on export is unlikely")
 @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
 class TestPassesDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_move_device_to(self, device):
         device_type = str(device).split(":", 1)[0]
         device0 = f"{device_type}:0"

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -1334,7 +1334,7 @@ class TestPassesDevice(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     def test_move_device_to(self, device):
-        device_type = str(device).split(":", 1)[0]
+        device_type = torch.device(device).type
         device0 = f"{device_type}:0"
 
         class M(torch.nn.Module):
@@ -1357,7 +1357,7 @@ def forward(self, x):
         )
 
     def test_move_device_submod(self, device):
-        device_type = str(device).split(":", 1)[0]
+        device_type = torch.device(device).type
         device0 = f"{device_type}:0"
 
         class M(torch.nn.Module):
@@ -1381,7 +1381,7 @@ def forward(self, arg0_1):
         )
 
     def test_move_device_example_inputs(self, device):
-        device_type = str(device).split(":", 1)[0]
+        device_type = torch.device(device).type
         device0 = f"{device_type}:0"
 
         class Model(torch.nn.Module):
@@ -1414,10 +1414,15 @@ def forward(self, arg0_1):
         self.assertEqual(ep_moved.example_inputs[0][1].device, torch.device(device0))
         self.assertEqual(ep_moved.example_inputs[1]["z"].device, torch.device(device0))
 
+
+@skipIfTorchDynamo("recursively running dynamo on export is unlikely")
+@unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
+class TestPassesRNN(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_move_to_device_pass(self, device):
-        device_type = str(device).split(":", 1)[0]
-        if device_type not in ("cuda", "xpu"):
-            self.skipTest("move_to_device_pass RNN is supported only on cuda/xpu")
+        # NPU fp32 GRU fails after move_to_device_pass (DynamicGRUV2); keep cuda/xpu.
+        device_type = torch.device(device).type
         device0 = f"{device_type}:0"
 
         class Model(torch.nn.Module):
@@ -1456,6 +1461,7 @@ def forward(self, arg0_1):
 
 
 instantiate_device_type_tests(TestPassesDevice, globals(), except_for="cpu")
+instantiate_device_type_tests(TestPassesRNN, globals(), only_for=("cuda", "xpu"))
 
 
 if __name__ == "__main__":

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -1344,15 +1344,16 @@ class TestPassesDevice(TestCase):
         ep = torch.export.export(M(), (torch.ones(3),))
         ep = move_to_device_pass(ep, device_type)
         ep.graph_module.recompile()
-        self.assertExpectedInline(
-            ep.graph_module.code.strip("\n"),
-            f"""\
+        expected = """\
 def forward(self, x):
-    _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(x, dtype = torch.float32, device = '{device_type}', layout = torch.strided);  _assert_tensor_metadata_default = None
-    to = torch.ops.aten.to.device(x, '{device_type}', torch.float32);  x = None
+    _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(x, dtype = torch.float32, device = 'cuda', layout = torch.strided);  _assert_tensor_metadata_default = None
+    to = torch.ops.aten.to.device(x, 'cuda', torch.float32);  x = None
     add = torch.ops.aten.add.Tensor(to, to);  to = None
     return (add,)
-    """,
+    """
+        self.assertExpectedInline(
+            ep.graph_module.code.strip("\n"),
+            expected.replace("cuda", device_type),
         )
 
     def test_move_device_submod(self, device):
@@ -1367,15 +1368,16 @@ def forward(self, x):
         ep = torch.export.export(M(), (torch.ones(3),))
         ep = move_to_device_pass(ep, device_type)
         ep.graph_module.submod_1.recompile()
-        self.assertExpectedInline(
-            ep.graph_module.submod_1.code.strip("\n"),
-            f"""\
+        expected = """\
 def forward(self, arg0_1):
-    _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(arg0_1, dtype = torch.float32, device = '{device_type}', layout = torch.strided);  _assert_tensor_metadata_default = None
-    to = torch.ops.aten.to.dtype_layout(arg0_1, dtype = torch.float32, layout = torch.strided, device = '{device_type}');  arg0_1 = None
+    _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(arg0_1, dtype = torch.float32, device = 'cuda', layout = torch.strided);  _assert_tensor_metadata_default = None
+    to = torch.ops.aten.to.dtype_layout(arg0_1, dtype = torch.float32, layout = torch.strided, device = 'cuda');  arg0_1 = None
     add = torch.ops.aten.add.Tensor(to, to);  to = None
     return (add,)
-    """,
+    """
+        self.assertExpectedInline(
+            ep.graph_module.submod_1.code.strip("\n"),
+            expected.replace("cuda", device_type),
         )
 
     def test_move_device_example_inputs(self, device):
@@ -1447,9 +1449,7 @@ def forward(self, arg0_1):
         self.assertEqual(outputs.device, target_device)
 
 
-instantiate_device_type_tests(
-    TestPassesDevice, globals(), except_for="cpu", allow_xpu=True
-)
+instantiate_device_type_tests(TestPassesDevice, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Make `move_to_device_pass` tests in `test_passes.py` device-agnostic via `instantiate_device_type_tests` and injected `device`, so accelerators including privateuse1 (NPU) are covered.

## Changes

- Move `move_to_device` cases into `TestPassesDevice` with `hw_classification = ACCELERATOR` and `except_for="cpu"`.
- Replace hardcoded `"cuda"` / `@requires_gpu` with the injected `device`.
- Keep `assertExpectedInline` goldens, parameterized by `device_type`.
- Keep the RNN case in the same `TestPassesDevice` class (no separate `TestPassesRNN`).

## Test Plan

```bash
python test/export/test_passes.py -v -k TestPassesDevice
```
Local NPU:

python test/export/test_passes.py -v -k TestPassesDevice
(with PYTORCH_TESTING_DEVICE_ONLY_FOR=privateuse1, import torch_npu before run)

Result: Ran 4 tests — 3 passed, 1 error

PASS: test_move_device_to_npu, test_move_device_submod_npu, test_move_device_example_inputs_npu
ERROR: test_move_to_device_pass_npu — DynamicGRUV2 unsupported on NPU (float32 GRU); torch_npu backend gap, not a pass regression
This is a torch_npu backend gap (DynamicGRUV2), not a move_to_device_pass bug. The case stays on the accelerator class (no per-device skip). Tracking: https://gitcode.com/Ascend/pytorch/issues/3886
CPU: not run (TestPassesDevice uses except_for="cpu").

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian