### PR TITLE
[Testcase Refactoring]  Dynamic AOTI runner lookup + torchbind instantiate with capability gating

### DIFF
--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -99,17 +99,16 @@ class AOTIRunnerUtil:
                     temp_so_path, device == "cpu"
                 )
         else:
-            device_type = torch.device(device).type
-            runner_cls_name = f"AOTIModelContainerRunner{device_type.capitalize()}"
+            runner_cls_name = f"AOTIModelContainerRunner{device.capitalize()}"
             runner_cls = getattr(torch._C._aoti, runner_cls_name, None)
             if runner_cls is None:
                 raise RuntimeError(
                     f"Unsupported device '{device}': expected {runner_cls_name} "
                     f"in torch._C._aoti"
                 )
-            if device_type in ("cpu", "mps"):
+            if device in ("cpu", "mps"):
                 return runner_cls(so_path, 1)
-            return runner_cls(so_path, 1, str(device))
+            return runner_cls(so_path, 1, device)
 
     @staticmethod
     def legacy_load(device, so_path):

--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -99,14 +99,17 @@ class AOTIRunnerUtil:
                     temp_so_path, device == "cpu"
                 )
         else:
-            if device == "cpu":
-                return torch._C._aoti.AOTIModelContainerRunnerCpu(so_path, 1)
-            elif device == "xpu":
-                return torch._C._aoti.AOTIModelContainerRunnerXpu(so_path, 1, device)
-            elif device == "mps":
-                return torch._C._aoti.AOTIModelContainerRunnerMps(so_path, 1)
-            else:
-                return torch._C._aoti.AOTIModelContainerRunnerCuda(so_path, 1, device)
+            device_type = torch.device(device).type
+            runner_cls_name = f"AOTIModelContainerRunner{device_type.capitalize()}"
+            runner_cls = getattr(torch._C._aoti, runner_cls_name, None)
+            if runner_cls is None:
+                raise RuntimeError(
+                    f"Unsupported device '{device}': expected {runner_cls_name} "
+                    f"in torch._C._aoti"
+                )
+            if device_type in ("cpu", "mps"):
+                return runner_cls(so_path, 1)
+            return runner_cls(so_path, 1, str(device))
 
     @staticmethod
     def legacy_load(device, so_path):

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -2,26 +2,26 @@
 
 import torch
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
+from torch.utils._triton import has_triton_package
 
 
-class TestTorchbindAOTI(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
+def _ensure_triton(test_case, device):
+    torch_device = torch.device(device)
+    if not has_triton_package():
+        test_case.skipTest("requires triton")
+    from torch._dynamo.device_interface import get_interface_for_device
+    from torch._inductor.exc import GPUTooOldForTriton
 
-    """Verify that torchbind constants embedded in an AOTI .pt2 are reachable
-    via AOTIModelPackageLoader.get_custom_objs() after load.
+    try:
+        get_interface_for_device(torch_device.type).raise_if_triton_unavailable(torch_device)
+    except (ImportError, NotImplementedError, RuntimeError, GPUTooOldForTriton) as e:
+        test_case.skipTest(str(e) or f"requires triton on {torch_device.type}")
 
-    Backends (e.g. torch-tensorrt) need post-load access to torchbind
-    constants to mutate runtime state (stream binding, comm binding, profiling
-    toggles). Before this accessor existed, the IValues lived in
-    OSSProxyExecutor::custom_objs_ with no public way out.
-    """
+
+class _TorchbindAOTIHelpers:
 
     @classmethod
     def setUpClass(cls):
@@ -41,7 +41,21 @@ class TestTorchbindAOTI(TestCase):
 
         return M()
 
-    @requires_capabilities(Capability.lib.triton)
+
+class _TorchbindAOTITests:
+    """Verify that torchbind constants embedded in an AOTI .pt2 are reachable
+    via AOTIModelPackageLoader.get_custom_objs() after load.
+
+    Backends (e.g. torch-tensorrt) need post-load access to torchbind
+    constants to mutate runtime state (stream binding, comm binding, profiling
+    toggles). Before this accessor existed, the IValues lived in
+    OSSProxyExecutor::custom_objs_ with no public way out.
+
+    Test methods are copied onto TestCase classes rather than inherited, so
+    instantiate_device_type_tests can see them and unittest does not collect
+    unsuffixed mixin methods that lack an injected device.
+    """
+
     def test_custom_objs_exposed_through_loader(self, device):
         m = self._make_model().to(device)
         x = torch.randn(2, 3, device=device)
@@ -65,7 +79,6 @@ class TestTorchbindAOTI(TestCase):
             msg=lambda msg: f"{msg}\nExpected a torchbind ScriptObject, got {type(any_torchbind)}",
         )
 
-    @requires_capabilities(Capability.lib.triton)
     def test_mutating_custom_obj_after_load_affects_run(self, device):
         # The central contract: IValues returned by get_custom_objs() share
         # intrusive_ptr ownership with the live entries inside
@@ -101,7 +114,6 @@ class TestTorchbindAOTI(TestCase):
         after = loader.run([x])[0]
         torch.testing.assert_close(after, 40 * x + x)
 
-    @requires_capabilities(Capability.lib.triton)
     def test_custom_objs_empty_when_no_torchbind(self, device):
         # A plain model with no torchbind attrs should yield an empty map.
         class Plain(torch.nn.Module):
@@ -118,7 +130,31 @@ class TestTorchbindAOTI(TestCase):
         self.assertEqual(loader.get_custom_objs(), {})
 
 
-instantiate_device_type_tests(TestTorchbindAOTI, globals(), allow_xpu=True)
+def _expose_mixin_tests(cls):
+    for name, meth in _TorchbindAOTITests.__dict__.items():
+        if name.startswith("test_"):
+            setattr(cls, name, meth)
+    return cls
+
+
+@_expose_mixin_tests
+class TestTorchbindAOTI(_TorchbindAOTIHelpers, TestCase):
+    hw_classification = HardwareClassification.CPU
+
+
+@_expose_mixin_tests
+class TestTorchbindAOTIAccelerator(_TorchbindAOTIHelpers, TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def setUp(self):
+        super().setUp()
+        _ensure_triton(self, self.get_primary_device())
+
+
+instantiate_device_type_tests(TestTorchbindAOTI, globals(), only_for="cpu")
+instantiate_device_type_tests(
+    TestTorchbindAOTIAccelerator, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -1,15 +1,11 @@
 # Owner(s): ["module: inductor"]
 
-import unittest
-
 import torch
 from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests
-from torch.testing._internal.inductor_utils import HAS_TRITON
+from torch.testing._internal.inductor_utils import ensure_triton
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
-
-
-HAS_CUDA = torch.cuda.is_available()
 
 
 class TestTorchbindAOTI(TestCase):
@@ -40,9 +36,8 @@ class TestTorchbindAOTI(TestCase):
 
         return M()
 
-    @unittest.skipIf(HAS_CUDA and not HAS_TRITON, "requires triton on CUDA builds")
-    def test_custom_objs_exposed_through_loader(self):
-        device = "cuda" if HAS_CUDA else "cpu"
+    def test_custom_objs_exposed_through_loader(self, device):
+        ensure_triton(self, device, required_on_cpu=False)
         m = self._make_model().to(device)
         x = torch.randn(2, 3, device=device)
         ep = torch.export.export(m, (x,), strict=False)
@@ -65,15 +60,14 @@ class TestTorchbindAOTI(TestCase):
             msg=lambda msg: f"{msg}\nExpected a torchbind ScriptObject, got {type(any_torchbind)}",
         )
 
-    @unittest.skipIf(HAS_CUDA and not HAS_TRITON, "requires triton on CUDA builds")
-    def test_mutating_custom_obj_after_load_affects_run(self):
+    def test_mutating_custom_obj_after_load_affects_run(self, device):
         # The central contract: IValues returned by get_custom_objs() share
         # intrusive_ptr ownership with the live entries inside
         # OSSProxyExecutor::custom_objs_, so mutating state on the returned
         # custom-class instance affects subsequent run() invocations.
         # Forward computes self.attr.add_tensor(x) + x, where Foo.add_tensor
         # returns (x + y) * z. Foo.increment(k) does x += k, y += k.
-        device = "cuda" if HAS_CUDA else "cpu"
+        ensure_triton(self, device, required_on_cpu=False)
         m = self._make_model().to(device)  # Foo(10, 20), so x+y == 30
         x = torch.randn(2, 3, device=device)
         ep = torch.export.export(m, (x,), strict=False)
@@ -102,14 +96,14 @@ class TestTorchbindAOTI(TestCase):
         after = loader.run([x])[0]
         torch.testing.assert_close(after, 40 * x + x)
 
-    @unittest.skipIf(HAS_CUDA and not HAS_TRITON, "requires triton on CUDA builds")
-    def test_custom_objs_empty_when_no_torchbind(self):
+    def test_custom_objs_empty_when_no_torchbind(self, device):
         # A plain model with no torchbind attrs should yield an empty map.
+        ensure_triton(self, device, required_on_cpu=False)
+
         class Plain(torch.nn.Module):
             def forward(self, x):
                 return x + 1
 
-        device = "cuda" if HAS_CUDA else "cpu"
         m = Plain().to(device)
         x = torch.randn(2, 3, device=device)
         ep = torch.export.export(m, (x,), strict=False)
@@ -118,6 +112,11 @@ class TestTorchbindAOTI(TestCase):
 
         loader = torch._C._aoti.AOTIModelPackageLoader(pt2_path, "model", False, 1, -1)
         self.assertEqual(loader.get_custom_objs(), {})
+
+
+instantiate_device_type_tests(
+    TestTorchbindAOTI, globals(), allow_xpu=True, allow_mps=True
+)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -3,12 +3,14 @@
 import torch
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.inductor_utils import ensure_triton
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 
 
 class TestTorchbindAOTI(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     """Verify that torchbind constants embedded in an AOTI .pt2 are reachable
     via AOTIModelPackageLoader.get_custom_objs() after load.
 

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -114,9 +114,7 @@ class TestTorchbindAOTI(TestCase):
         self.assertEqual(loader.get_custom_objs(), {})
 
 
-instantiate_device_type_tests(
-    TestTorchbindAOTI, globals(), allow_xpu=True, allow_mps=True
-)
+instantiate_device_type_tests(TestTorchbindAOTI, globals(), allow_xpu=True)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -1,16 +1,28 @@
 # Owner(s): ["module: inductor"]
 
-import unittest
-
 import torch
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    skipIf,
+)
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.inductor_utils import HAS_TRITON
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 
 
-class _TorchbindAOTIHelpers:
+class TestTorchbindAOTI(TestCase):
+    """Verify that torchbind constants embedded in an AOTI .pt2 are reachable
+    via AOTIModelPackageLoader.get_custom_objs() after load.
+
+    Backends (e.g. torch-tensorrt) need post-load access to torchbind
+    constants to mutate runtime state (stream binding, comm binding, profiling
+    toggles). Before this accessor existed, the IValues lived in
+    OSSProxyExecutor::custom_objs_ with no public way out.
+    """
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @classmethod
     def setUpClass(cls):
         # Loads the test torchbind library AND registers fake classes for
@@ -29,21 +41,7 @@ class _TorchbindAOTIHelpers:
 
         return M()
 
-
-class _TorchbindAOTITests:
-    """Verify that torchbind constants embedded in an AOTI .pt2 are reachable
-    via AOTIModelPackageLoader.get_custom_objs() after load.
-
-    Backends (e.g. torch-tensorrt) need post-load access to torchbind
-    constants to mutate runtime state (stream binding, comm binding, profiling
-    toggles). Before this accessor existed, the IValues lived in
-    OSSProxyExecutor::custom_objs_ with no public way out.
-
-    Test methods are copied onto TestCase classes rather than inherited, so
-    instantiate_device_type_tests can see them and unittest does not collect
-    unsuffixed mixin methods that lack an injected device.
-    """
-
+    @skipIf(not HAS_TRITON, "requires triton", device_type="cuda")
     def test_custom_objs_exposed_through_loader(self, device):
         m = self._make_model().to(device)
         x = torch.randn(2, 3, device=device)
@@ -67,6 +65,7 @@ class _TorchbindAOTITests:
             msg=lambda msg: f"{msg}\nExpected a torchbind ScriptObject, got {type(any_torchbind)}",
         )
 
+    @skipIf(not HAS_TRITON, "requires triton", device_type="cuda")
     def test_mutating_custom_obj_after_load_affects_run(self, device):
         # The central contract: IValues returned by get_custom_objs() share
         # intrusive_ptr ownership with the live entries inside
@@ -102,6 +101,7 @@ class _TorchbindAOTITests:
         after = loader.run([x])[0]
         torch.testing.assert_close(after, 40 * x + x)
 
+    @skipIf(not HAS_TRITON, "requires triton", device_type="cuda")
     def test_custom_objs_empty_when_no_torchbind(self, device):
         # A plain model with no torchbind attrs should yield an empty map.
         class Plain(torch.nn.Module):
@@ -118,28 +118,7 @@ class _TorchbindAOTITests:
         self.assertEqual(loader.get_custom_objs(), {})
 
 
-def _expose_mixin_tests(cls):
-    for name, meth in _TorchbindAOTITests.__dict__.items():
-        if name.startswith("test_"):
-            setattr(cls, name, meth)
-    return cls
-
-
-@_expose_mixin_tests
-class TestTorchbindAOTI(_TorchbindAOTIHelpers, TestCase):
-    hw_classification = HardwareClassification.CPU
-
-
-@unittest.skipUnless(HAS_TRITON, "requires triton")
-@_expose_mixin_tests
-class TestTorchbindAOTIAccelerator(_TorchbindAOTIHelpers, TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
-
-
-instantiate_device_type_tests(TestTorchbindAOTI, globals(), only_for="cpu")
-instantiate_device_type_tests(
-    TestTorchbindAOTIAccelerator, globals(), except_for="cpu", allow_xpu=True
-)
+instantiate_device_type_tests(TestTorchbindAOTI, globals())
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -3,11 +3,11 @@
 import torch
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_device_type import (
+    Capability,
     instantiate_device_type_tests,
-    skipGPUIf,
+    requires_capabilities,
 )
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
-from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 
 
@@ -41,7 +41,7 @@ class TestTorchbindAOTI(TestCase):
 
         return M()
 
-    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    @requires_capabilities(Capability.lib.triton)
     def test_custom_objs_exposed_through_loader(self, device):
         m = self._make_model().to(device)
         x = torch.randn(2, 3, device=device)
@@ -65,7 +65,7 @@ class TestTorchbindAOTI(TestCase):
             msg=lambda msg: f"{msg}\nExpected a torchbind ScriptObject, got {type(any_torchbind)}",
         )
 
-    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    @requires_capabilities(Capability.lib.triton)
     def test_mutating_custom_obj_after_load_affects_run(self, device):
         # The central contract: IValues returned by get_custom_objs() share
         # intrusive_ptr ownership with the live entries inside
@@ -101,7 +101,7 @@ class TestTorchbindAOTI(TestCase):
         after = loader.run([x])[0]
         torch.testing.assert_close(after, 40 * x + x)
 
-    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    @requires_capabilities(Capability.lib.triton)
     def test_custom_objs_empty_when_no_torchbind(self, device):
         # A plain model with no torchbind attrs should yield an empty map.
         class Plain(torch.nn.Module):

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -2,9 +2,12 @@
 
 import torch
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    skipGPUIf,
+)
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
-from torch.testing._internal.inductor_utils import ensure_triton
+from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 
 
@@ -38,8 +41,8 @@ class TestTorchbindAOTI(TestCase):
 
         return M()
 
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     def test_custom_objs_exposed_through_loader(self, device):
-        ensure_triton(self, device, required_on_cpu=False)
         m = self._make_model().to(device)
         x = torch.randn(2, 3, device=device)
         ep = torch.export.export(m, (x,), strict=False)
@@ -62,6 +65,7 @@ class TestTorchbindAOTI(TestCase):
             msg=lambda msg: f"{msg}\nExpected a torchbind ScriptObject, got {type(any_torchbind)}",
         )
 
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     def test_mutating_custom_obj_after_load_affects_run(self, device):
         # The central contract: IValues returned by get_custom_objs() share
         # intrusive_ptr ownership with the live entries inside
@@ -69,7 +73,6 @@ class TestTorchbindAOTI(TestCase):
         # custom-class instance affects subsequent run() invocations.
         # Forward computes self.attr.add_tensor(x) + x, where Foo.add_tensor
         # returns (x + y) * z. Foo.increment(k) does x += k, y += k.
-        ensure_triton(self, device, required_on_cpu=False)
         m = self._make_model().to(device)  # Foo(10, 20), so x+y == 30
         x = torch.randn(2, 3, device=device)
         ep = torch.export.export(m, (x,), strict=False)
@@ -98,10 +101,9 @@ class TestTorchbindAOTI(TestCase):
         after = loader.run([x])[0]
         torch.testing.assert_close(after, 40 * x + x)
 
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     def test_custom_objs_empty_when_no_torchbind(self, device):
         # A plain model with no torchbind attrs should yield an empty map.
-        ensure_triton(self, device, required_on_cpu=False)
-
         class Plain(torch.nn.Module):
             def forward(self, x):
                 return x + 1

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -1,21 +1,13 @@
 # Owner(s): ["module: inductor"]
 
+import unittest
+
 import torch
-from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
+from torch.testing._internal.inductor_utils import HAS_TRITON
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
-from torch.utils._triton import has_triton_package
-
-
-def _ensure_triton(test_case, device):
-    if not has_triton_package():
-        test_case.skipTest("requires triton")
-    torch_device = torch.device(device)
-    get_interface_for_device(torch_device.type).raise_if_triton_unavailable(
-        torch_device
-    )
 
 
 class _TorchbindAOTIHelpers:
@@ -138,13 +130,10 @@ class TestTorchbindAOTI(_TorchbindAOTIHelpers, TestCase):
     hw_classification = HardwareClassification.CPU
 
 
+@unittest.skipUnless(HAS_TRITON, "requires triton")
 @_expose_mixin_tests
 class TestTorchbindAOTIAccelerator(_TorchbindAOTIHelpers, TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
-
-    def setUp(self):
-        super().setUp()
-        _ensure_triton(self, self.get_primary_device())
 
 
 instantiate_device_type_tests(TestTorchbindAOTI, globals(), only_for="cpu")

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 import torch
+from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
@@ -9,20 +10,15 @@ from torch.utils._triton import has_triton_package
 
 
 def _ensure_triton(test_case, device):
-    torch_device = torch.device(device)
     if not has_triton_package():
         test_case.skipTest("requires triton")
-    from torch._dynamo.device_interface import get_interface_for_device
-    from torch._inductor.exc import GPUTooOldForTriton
-
-    try:
-        get_interface_for_device(torch_device.type).raise_if_triton_unavailable(torch_device)
-    except (ImportError, RuntimeError, GPUTooOldForTriton) as e:
-        test_case.skipTest(str(e) or f"requires triton on {torch_device.type}")
+    torch_device = torch.device(device)
+    get_interface_for_device(torch_device.type).raise_if_triton_unavailable(
+        torch_device
+    )
 
 
 class _TorchbindAOTIHelpers:
-
     @classmethod
     def setUpClass(cls):
         # Loads the test torchbind library AND registers fake classes for

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -17,7 +17,7 @@ def _ensure_triton(test_case, device):
 
     try:
         get_interface_for_device(torch_device.type).raise_if_triton_unavailable(torch_device)
-    except (ImportError, NotImplementedError, RuntimeError, GPUTooOldForTriton) as e:
+    except (ImportError, RuntimeError, GPUTooOldForTriton) as e:
         test_case.skipTest(str(e) or f"requires triton on {torch_device.type}")
 
 

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -23,7 +23,7 @@ from torch._inductor.utils import (
 )
 from torch.utils._helion import has_helion
 from torch.utils._pallas import has_pallas_package, has_tpu_pallas
-from torch.utils._triton import has_triton
+from torch.utils._triton import has_triton, has_triton_package
 from torch.utils._config_module import ConfigModule
 from torch.testing._internal.common_device_type import (
     get_desired_device_type_test_bases,
@@ -177,6 +177,40 @@ requires_gpu = functools.partial(
 )
 requires_triton = functools.partial(unittest.skipIf, not HAS_TRITON, "requires triton")
 requires_helion = functools.partial(unittest.skipIf, not HAS_HELION, "requires helion")
+
+
+def ensure_triton(test_case, device, *, required_on_cpu=True):
+    """Skip unless Triton is available for the given device.
+
+    Unlike module-level HAS_TRITON / requires_triton (any-device global via
+    has_triton()), this gates on the device's DeviceInterface so privateuse1
+    backends that call register_interface_for_device(...) with an interface
+    whose is_triton_capable() is True are not skipped solely because CUDA/XPU
+    are absent.
+
+    required_on_cpu=False also skips the Triton gate for devices whose AOTI
+    path does not use Triton (CPU, and MPS Metal).
+    """
+    device_type = torch.device(device).type
+    # CPU and MPS AOTI backends do not require Triton.
+    if not required_on_cpu and device_type in ("cpu", "mps"):
+        return
+
+    # raise_if_triton_unavailable assumes the package is importable.
+    if not has_triton_package():
+        test_case.skipTest("requires triton")
+
+    from torch._dynamo.device_interface import get_interface_for_device
+
+    try:
+        iface = get_interface_for_device(device_type)
+    except NotImplementedError:
+        test_case.skipTest(f"requires triton on {device_type}")
+
+    try:
+        iface.raise_if_triton_unavailable(device)
+    except (RuntimeError, ImportError) as e:
+        test_case.skipTest(str(e) or f"requires triton on {device_type}")
 
 
 def requires_gpu_with_enough_memory(min_mem_required):

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -23,7 +23,7 @@ from torch._inductor.utils import (
 )
 from torch.utils._helion import has_helion
 from torch.utils._pallas import has_pallas_package, has_tpu_pallas
-from torch.utils._triton import has_triton, has_triton_package
+from torch.utils._triton import has_triton
 from torch.utils._config_module import ConfigModule
 from torch.testing._internal.common_device_type import (
     get_desired_device_type_test_bases,
@@ -177,40 +177,6 @@ requires_gpu = functools.partial(
 )
 requires_triton = functools.partial(unittest.skipIf, not HAS_TRITON, "requires triton")
 requires_helion = functools.partial(unittest.skipIf, not HAS_HELION, "requires helion")
-
-
-def ensure_triton(test_case, device, *, required_on_cpu=True):
-    """Skip unless Triton is available for the given device.
-
-    Unlike module-level HAS_TRITON / requires_triton (any-device global via
-    has_triton()), this gates on the device's DeviceInterface so privateuse1
-    backends that call register_interface_for_device(...) with an interface
-    whose is_triton_capable() is True are not skipped solely because CUDA/XPU
-    are absent.
-
-    required_on_cpu=False also skips the Triton gate for devices whose AOTI
-    path does not use Triton (CPU, and MPS Metal).
-    """
-    device_type = torch.device(device).type
-    # CPU and MPS AOTI backends do not require Triton.
-    if not required_on_cpu and device_type in ("cpu", "mps"):
-        return
-
-    # raise_if_triton_unavailable assumes the package is importable.
-    if not has_triton_package():
-        test_case.skipTest("requires triton")
-
-    from torch._dynamo.device_interface import get_interface_for_device
-
-    try:
-        iface = get_interface_for_device(device_type)
-    except NotImplementedError:
-        test_case.skipTest(f"requires triton on {device_type}")
-
-    try:
-        iface.raise_if_triton_unavailable(device)
-    except (RuntimeError, ImportError) as e:
-        test_case.skipTest(str(e) or f"requires triton on {device_type}")
 
 
 def requires_gpu_with_enough_memory(min_mem_required):


### PR DESCRIPTION
## Summary

Device-agnostic AOTI test infrastructure: dynamic runner selection and torchbind tests via `instantiate_device_type_tests` + capability-based Triton gating.

## Changes

- `test/inductor/test_aot_inductor_utils.py`: replace hardcoded cpu/xpu/mps/else→Cuda branch in `AOTIRunnerUtil.new_loader` with dynamic `AOTIModelContainerRunner{DeviceType}` lookup via `getattr`. Raises `RuntimeError` when the runner class is missing instead of silently falling back to CUDA.
- `test/inductor/test_aoti_torchbind_constants.py`: convert `TestTorchbindAOTI` to `instantiate_device_type_tests` with injected `device` and `hw_classification = ACCELERATOR`. Gate Triton-required tests with `@requires_capabilities(Capability.lib.triton)` instead of `@skipGPUIf(not HAS_GPU)`.


## Test Plan

```bash
python test/inductor/test_aoti_torchbind_constants.py -v
PYTORCH_TESTING_DEVICE_ONLY_FOR=cuda python test/inductor/test_aoti_torchbind_constants.py -v
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo