### PR TITLE
Default expandable_segments_handle_type to UNSPECIFIED on all CUDA versions

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -208,12 +208,11 @@ class C10_CUDA_API CUDAAllocatorConfig {
 
   std::atomic<size_t> m_pinned_num_register_threads{1};
   std::atomic<size_t> m_pinned_reserve_segment_size_mb{0};
-  std::atomic<Expandable_Segments_Handle_Type> m_expandable_segments_handle_type
-#if CUDA_VERSION >= 12030
-      {Expandable_Segments_Handle_Type::UNSPECIFIED};
-#else
-      {Expandable_Segments_Handle_Type::POSIX_FD};
-#endif
+  // UNSPECIFIED resolves to FABRIC where supported and POSIX_FD otherwise, so a
+  // separate POSIX_FD default for older CUDA is redundant.
+  std::atomic<Expandable_Segments_Handle_Type>
+      m_expandable_segments_handle_type{
+          Expandable_Segments_Handle_Type::UNSPECIFIED};
   std::atomic<bool> m_release_lock_on_cudamalloc{false};
   std::atomic<bool> m_pinned_use_cuda_host_register{false};
   std::atomic<bool> m_graph_capture_record_stream_reuse{false};


### PR DESCRIPTION
The `m_expandable_segments_handle_type` default carried a separate `POSIX_FD` value for `CUDA_VERSION < 12030`. That branch is redundant:

- `UNSPECIFIED` resolves in `detectHandleType` to `FABRIC_HANDLE` when the device supports it and `POSIX_FD` otherwise.
- `get_fabric_access` is itself gated on `CUDA_VERSION >= 12040`, so it returns `false` on any CUDA below 12.4.

So on every CUDA below 12.4, `UNSPECIFIED` already resolves to `POSIX_FD`. Defaulting to `UNSPECIFIED` everywhere is therefore behavior-preserving on all supported CUDA versions (minimum is 12.1 per `cmake/public/cuda.cmake`):

| CUDA | Before (`#else POSIX_FD`) | After (always `UNSPECIFIED`) |
|------|---------------------------|------------------------------|
| 12.1-12.2 (`<12030`) | `POSIX_FD` | `UNSPECIFIED` -> fabric=false -> `POSIX_FD` |
| 12.3 (`12030-12039`) | `UNSPECIFIED` -> fabric=false -> `POSIX_FD` | same |
| >=12.4 | `UNSPECIFIED` -> fabric-or-posix | same |
 
---
_Prepared with AI assistance; the change has been read and understood by the author._