### PR TITLE
[SDPA] Add memory-efficient GQA and vmap backward support

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesLinearAlgebra.cpp
+++ b/aten/src/ATen/functorch/BatchRulesLinearAlgebra.cpp
@@ -4,6 +4,7 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <ATen/core/grad_mode.h>
 #include <ATen/functorch/BatchRulesHelper.h>
 
 #include <algorithm>
@@ -633,6 +634,14 @@ fourOutputs _scaled_dot_product_efficient_attention_batch_rule(
         value_bdim.has_value() || attn_bias_bdim.has_value();
     check_randomness(randomness, any_tensor_batched);
   }
+  // BatchedTensor wrappers hide requires_grad from the composite SDPA wrapper.
+  // Recompute it after unwrapping so training forwards produce LSE for backward.
+  compute_log_sumexp =
+      compute_log_sumexp ||
+      (at::GradMode::is_enabled() &&
+       (query.requires_grad() || key.requires_grad() || value.requires_grad() ||
+        (attn_bias.has_value() && attn_bias->defined() &&
+         attn_bias->requires_grad())));
   auto batch_size = attn_bias.has_value() && attn_bias->defined()
       ? get_bdim_size4(query, query_bdim, key, key_bdim, value, value_bdim, *attn_bias, attn_bias_bdim)
       : get_bdim_size3(query, query_bdim, key, key_bdim, value, value_bdim);

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -652,6 +652,31 @@ bool should_compute_logsumexp_with_attn_mask(
   return any_inputs_require_grad && gradmode_enabled;
 }
 
+std::tuple<at::Tensor, at::Tensor> expand_singleton_kv_heads(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value) {
+  if (query.is_nested() || key.is_nested() || value.is_nested() ||
+      query.dim() != 4 || key.dim() != 4 || value.dim() != 4) {
+    return std::make_tuple(key, value);
+  }
+
+  const auto query_num_heads = query.sym_size(-3);
+  if (query_num_heads == 0 || query_num_heads == 1) {
+    return std::make_tuple(key, value);
+  }
+
+  const auto expand_kv = [query_num_heads](const at::Tensor& kv) -> at::Tensor {
+    if (kv.sym_size(-3) != 1) {
+      return kv;
+    }
+    auto expanded_size = kv.sym_sizes().vec();
+    expanded_size[expanded_size.size() - 3] = query_num_heads;
+    return kv.expand_symint(expanded_size);
+  };
+  return std::make_tuple(expand_kv(key), expand_kv(value));
+}
+
 std::tuple<at::Tensor, at::Tensor> pre_process_group_query_attention_input(
     const at::Tensor& query,
     const at::Tensor& key,
@@ -794,12 +819,16 @@ Tensor scaled_dot_product_attention(
           query_, key, value, dropout_p, is_causal, attn_mask, scale));
     }
     case SDPBackend::efficient_attention: {
+      auto [expanded_key, expanded_value] =
+          expand_singleton_kv_heads(query_, key, value);
       if (attn_mask.has_value()) {
-        attn_mask.value() = preprocess_mask(attn_mask.value(), query_, key, value);;
+        attn_mask.value() = preprocess_mask(
+            attn_mask.value(), query_, expanded_key, expanded_value);
       }
-      bool compute_logsumexp = should_compute_logsumexp_with_attn_mask(query_, key, value, attn_mask);
+      bool compute_logsumexp = should_compute_logsumexp_with_attn_mask(
+          query_, expanded_key, expanded_value, attn_mask);
       auto out_and_lse = at::_scaled_dot_product_efficient_attention(
-          query_, key, value, attn_mask, compute_logsumexp, dropout_p, is_causal, scale);
+          query_, expanded_key, expanded_value, attn_mask, compute_logsumexp, dropout_p, is_causal, scale);
       return std::get<0>(out_and_lse);
     }
     case SDPBackend::overrideable: {

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -652,31 +652,6 @@ bool should_compute_logsumexp_with_attn_mask(
   return any_inputs_require_grad && gradmode_enabled;
 }
 
-std::tuple<at::Tensor, at::Tensor> expand_singleton_kv_heads(
-    const at::Tensor& query,
-    const at::Tensor& key,
-    const at::Tensor& value) {
-  if (query.is_nested() || key.is_nested() || value.is_nested() ||
-      query.dim() != 4 || key.dim() != 4 || value.dim() != 4) {
-    return std::make_tuple(key, value);
-  }
-
-  const auto query_num_heads = query.sym_size(-3);
-  if (query_num_heads == 0 || query_num_heads == 1) {
-    return std::make_tuple(key, value);
-  }
-
-  const auto expand_kv = [query_num_heads](const at::Tensor& kv) -> at::Tensor {
-    if (kv.sym_size(-3) != 1) {
-      return kv;
-    }
-    auto expanded_size = kv.sym_sizes().vec();
-    expanded_size[expanded_size.size() - 3] = query_num_heads;
-    return kv.expand_symint(expanded_size);
-  };
-  return std::make_tuple(expand_kv(key), expand_kv(value));
-}
-
 std::tuple<at::Tensor, at::Tensor> pre_process_group_query_attention_input(
     const at::Tensor& query,
     const at::Tensor& key,
@@ -819,16 +794,13 @@ Tensor scaled_dot_product_attention(
           query_, key, value, dropout_p, is_causal, attn_mask, scale));
     }
     case SDPBackend::efficient_attention: {
-      auto [expanded_key, expanded_value] =
-          expand_singleton_kv_heads(query_, key, value);
       if (attn_mask.has_value()) {
-        attn_mask.value() = preprocess_mask(
-            attn_mask.value(), query_, expanded_key, expanded_value);
+        attn_mask.value() = preprocess_mask(attn_mask.value(), query_, key, value);
       }
       bool compute_logsumexp = should_compute_logsumexp_with_attn_mask(
-          query_, expanded_key, expanded_value, attn_mask);
+          query_, key, value, attn_mask);
       auto out_and_lse = at::_scaled_dot_product_efficient_attention(
-          query_, expanded_key, expanded_value, attn_mask, compute_logsumexp, dropout_p, is_causal, scale);
+          query_, key, value, attn_mask, compute_logsumexp, dropout_p, is_causal, scale);
       return std::get<0>(out_and_lse);
     }
     case SDPBackend::overrideable: {

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -801,7 +801,7 @@ Tensor scaled_dot_product_attention(
           query_, key, value, attn_mask);
       auto out_and_lse = at::_scaled_dot_product_efficient_attention(
           query_, key, value, attn_mask, compute_logsumexp, dropout_p, is_causal, scale);
-      return std::get<0>(out_and_lse);
+      return std::get<0>(std::move(out_and_lse));
     }
     case SDPBackend::overrideable: {
       auto out_lse_softmax = at::_scaled_dot_product_fused_attention_overrideable(

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1427,8 +1427,17 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt> _efficient_
   TORCH_CHECK(key.size(1) == value.size(1));
 
   // Num heads
-  TORCH_CHECK(query.size(2) == key.size(2));
-  TORCH_CHECK(query.size(2) == value.size(2));
+  const int64_t num_heads = query.size(2);
+  const int64_t num_heads_kv = key.size(2);
+  TORCH_CHECK(num_heads_kv == value.size(2));
+#ifdef USE_ROCM
+  TORCH_CHECK(num_heads == num_heads_kv);
+#else
+  TORCH_CHECK(num_heads_kv > 0);
+  TORCH_CHECK(
+      num_heads % num_heads_kv == 0,
+      "Number of heads in key/value must divide number of heads in query");
+#endif
 
   // Embedding per head
   TORCH_CHECK(query.size(3) == key.size(3));
@@ -1462,7 +1471,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt> _efficient_
   int64_t B = query.size(0);
   int64_t M = query.size(1);
   int64_t N = key.size(1);
-  int64_t num_heads = query.size(-2);
   int64_t K = query.size(-1);
   int64_t Kv = value.size(-1);
 
@@ -1766,6 +1774,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt> _efficient_
     }
 
     p.num_heads = num_heads;
+    p.q_heads_per_kv = num_heads / num_heads_kv;
     p.head_dim = query.size(3);
     p.head_dim_value = value.size(3);
     p.num_queries = max_seqlen_q;

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1433,9 +1433,10 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt> _efficient_
 #ifdef USE_ROCM
   TORCH_CHECK(num_heads == num_heads_kv);
 #else
-  TORCH_CHECK(num_heads_kv > 0);
   TORCH_CHECK(
-      num_heads % num_heads_kv == 0,
+      (num_heads == 0 && num_heads_kv == 0) ||
+          (num_heads > 0 && num_heads_kv > 0 &&
+           num_heads % num_heads_kv == 0),
       "Number of heads in key/value must divide number of heads in query");
 #endif
 
@@ -1747,6 +1748,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt> _efficient_
          num_heads,
          compute_logsumexp ? ceil_div(max_seqlen_q, kAlignLSE) * kAlignLSE : 0},
         query.options().dtype(at::ScalarType::Float));
+    if (num_heads == 0) {
+      return;
+    }
     typename Kernel::Params p;
     p.query_ptr = (const scalar_t*)query.const_data_ptr();
     p.key_ptr = (const scalar_t*)key.const_data_ptr();

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -29,6 +29,8 @@
 #include <ATen/ops/empty_strided.h>
 #include <ATen/ops/empty_permuted.h>
 #include <ATen/ops/pad.h>
+#include <ATen/ops/reshape.h>
+#include <ATen/ops/sum.h>
 #include <ATen/ops/_cudnn_attention_backward.h>
 #include <ATen/ops/_cudnn_attention_backward_native.h>
 #include <ATen/ops/_flash_attention_backward.h>
@@ -416,9 +418,18 @@ _efficient_attention_backward(
   TORCH_CHECK(query.size(1) == grad_out_.size(1));
 
   // Num heads
-  TORCH_CHECK(query.size(2) == key.size(2));
-  TORCH_CHECK(query.size(2) == value.size(2));
-  TORCH_CHECK(query.size(2) == grad_out_.size(2));
+  const int64_t nH = query.size(2);
+  const int64_t nHkv = key.size(2);
+  TORCH_CHECK(nHkv == value.size(2));
+  TORCH_CHECK(nH == grad_out_.size(2));
+#ifdef USE_ROCM
+  TORCH_CHECK(nH == nHkv);
+#else
+  TORCH_CHECK(nHkv > 0);
+  TORCH_CHECK(
+      nH % nHkv == 0,
+      "Number of heads in key/value must divide number of heads in query");
+#endif
 
   // Embedding per head
   TORCH_CHECK(query.size(3) == key.size(3));
@@ -461,12 +472,14 @@ _efficient_attention_backward(
   int64_t B = query.size(0);
   int64_t M = query.size(1);
   int64_t N = key.size(1);
-  int64_t nH = query.size(2);
   int64_t K = query.size(3);
   int64_t Kv = value.size(3);
 
   at::Tensor grad_q, grad_k, grad_v, grad_bias;
   if (shared_storage_dqdkdv) {
+    TORCH_CHECK(
+        nH == nHkv,
+        "`shared_storage_dqdkdv` does not support grouped query attention");
     // Create one big contiguous chunk
     // This is because q, k and v usually come from a single
     // output of a linear layer that is chunked.
@@ -493,6 +506,15 @@ _efficient_attention_backward(
     grad_k = at::empty(key.sizes(), key.options());
     grad_v = at::empty(value.sizes(), value.options());
   }
+
+  at::Tensor grad_k_expanded = grad_k;
+  at::Tensor grad_v_expanded = grad_v;
+#ifndef USE_ROCM
+  if (nH != nHkv) {
+    grad_k_expanded = at::empty({B, N, nH, K}, key.options());
+    grad_v_expanded = at::empty({B, N, nH, Kv}, value.options());
+  }
+#endif
 
   if (bias_requires_grad) {
     TORCH_CHECK(
@@ -746,8 +768,8 @@ _efficient_attention_backward(
     p.output_ptr = (const scalar_t*)out.const_data_ptr();
     p.grad_output_ptr = (const scalar_t*)grad_out.const_data_ptr();
     p.grad_query_ptr = (scalar_t*)grad_q.data_ptr();
-    p.grad_key_ptr = (scalar_t*)grad_k.data_ptr();
-    p.grad_value_ptr = (scalar_t*)grad_v.data_ptr();
+    p.grad_key_ptr = (scalar_t*)grad_k_expanded.data_ptr();
+    p.grad_value_ptr = (scalar_t*)grad_v_expanded.data_ptr();
     p.delta_ptr = (float*)delta.data_ptr();
     p.head_dim = query.size(3);
     p.head_dim_value = value.size(3);
@@ -755,6 +777,7 @@ _efficient_attention_backward(
     p.num_keys = max_seqlen_k;
     p.num_batches = cu_seqlens_q.has_value() ? cu_seqlens_q->size(0) - 1 : B;
     p.num_heads = nH;
+    p.q_heads_per_kv = nH / nHkv;
     p.custom_mask_type = custom_mask_type;
     p.scale = sdp::calculate_scale(query, scale).expect_float();
     if (cu_seqlens_q.has_value()) {
@@ -775,15 +798,15 @@ _efficient_attention_backward(
     ASSIGN_CHECK_OVERFLOW(p.o_strideH, out.stride(2));
 
     ASSIGN_CHECK_OVERFLOW(p.gQ_strideB, grad_q.stride(0));
-    ASSIGN_CHECK_OVERFLOW(p.gK_strideB, grad_k.stride(0));
-    ASSIGN_CHECK_OVERFLOW(p.gV_strideB, grad_v.stride(0));
+    ASSIGN_CHECK_OVERFLOW(p.gK_strideB, grad_k_expanded.stride(0));
+    ASSIGN_CHECK_OVERFLOW(p.gV_strideB, grad_v_expanded.stride(0));
     ASSIGN_CHECK_OVERFLOW(p.gQ_strideH, grad_q.stride(2));
-    ASSIGN_CHECK_OVERFLOW(p.gK_strideH, grad_k.stride(2));
-    ASSIGN_CHECK_OVERFLOW(p.gV_strideH, grad_v.stride(2));
+    ASSIGN_CHECK_OVERFLOW(p.gK_strideH, grad_k_expanded.stride(2));
+    ASSIGN_CHECK_OVERFLOW(p.gV_strideH, grad_v_expanded.stride(2));
     p.gQKV_strideM_multiplier = shared_storage_dqdkdv ? 3 : 1;
     TORCH_INTERNAL_ASSERT(p.gQ_strideM() == grad_q.stride(1));
-    TORCH_INTERNAL_ASSERT(p.gK_strideM() == grad_k.stride(1));
-    TORCH_INTERNAL_ASSERT(p.gV_strideM() == grad_v.stride(1));
+    TORCH_INTERNAL_ASSERT(p.gK_strideM() == grad_k_expanded.stride(1));
+    TORCH_INTERNAL_ASSERT(p.gV_strideM() == grad_v_expanded.stride(1));
 
     ASSIGN_CHECK_OVERFLOW(p.q_strideB, query.stride(0));
     ASSIGN_CHECK_OVERFLOW(p.k_strideB, key.stride(0));
@@ -893,8 +916,8 @@ _efficient_attention_backward(
     // Handle the edge-cases where some tensors are empty
     if (p.num_queries == 0 || p.num_keys == 0 || p.num_batches == 0 ||
         p.num_heads == 0) {
-      grad_k.zero_();
-      grad_v.zero_();
+      grad_k_expanded.zero_();
+      grad_v_expanded.zero_();
       grad_q.zero_();
       return;
     }
@@ -940,6 +963,16 @@ _efficient_attention_backward(
                  }));
   TORCH_CHECK(kernel_launched, "cutlassB: no kernel found to launch!");
   AT_CUDA_CHECK(cudaGetLastError());
+  if (nH != nHkv) {
+    at::sum_out(
+        grad_k,
+        at::reshape(grad_k_expanded, {B, N, nHkv, nH / nHkv, K}),
+        {3});
+    at::sum_out(
+        grad_v,
+        at::reshape(grad_v_expanded, {B, N, nHkv, nH / nHkv, Kv}),
+        {3});
+  }
 #endif // USE_ROCM
   return std::make_tuple(std::move(grad_q), std::move(grad_k), std::move(grad_v), std::move(grad_bias));
   #endif // defined(USE_MEM_EFF_ATTENTION)

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -768,6 +768,7 @@ _efficient_attention_backward(
     TORCH_INTERNAL_ASSERT(delta.size(1) == nH);
     TORCH_INTERNAL_ASSERT(delta.size(2) == M);
 
+    // TODO: Initialize unconditional Params fields with C++20 designated initializers.
     typename Kernel::Params p;
     p.query_ptr = (const scalar_t*)query.const_data_ptr();
     p.key_ptr = (const scalar_t*)key.const_data_ptr();
@@ -776,8 +777,10 @@ _efficient_attention_backward(
     p.output_ptr = (const scalar_t*)out.const_data_ptr();
     p.grad_output_ptr = (const scalar_t*)grad_out.const_data_ptr();
     p.grad_query_ptr = (scalar_t*)grad_q.data_ptr();
-    p.grad_key_ptr = (scalar_t*)grad_k_expanded.data_ptr();
-    p.grad_value_ptr = (scalar_t*)grad_v_expanded.data_ptr();
+    p.grad_key_ptr =
+        static_cast<scalar_t*>(grad_k_expanded.mutable_data_ptr());
+    p.grad_value_ptr =
+        static_cast<scalar_t*>(grad_v_expanded.mutable_data_ptr());
     p.delta_ptr = (float*)delta.data_ptr();
     p.head_dim = query.size(3);
     p.head_dim_value = value.size(3);

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -425,9 +425,9 @@ _efficient_attention_backward(
 #ifdef USE_ROCM
   TORCH_CHECK(nH == nHkv);
 #else
-  TORCH_CHECK(nHkv > 0);
   TORCH_CHECK(
-      nH % nHkv == 0,
+      (nH == 0 && nHkv == 0) ||
+          (nH > 0 && nHkv > 0 && nH % nHkv == 0),
       "Number of heads in key/value must divide number of heads in query");
 #endif
 
@@ -748,6 +748,14 @@ _efficient_attention_backward(
 
     kernel_launched = true;
 
+    if (M == 0 || N == 0 || B == 0 || nH == 0 ||
+        (cu_seqlens_q.has_value() && cu_seqlens_q->size(0) == 1)) {
+      grad_k_expanded.zero_();
+      grad_v_expanded.zero_();
+      grad_q.zero_();
+      return;
+    }
+
     // TODO: Fuse this into a kernel?
     // This is a bottleneck for smaller sequences (M <= 128)
     auto delta = Kernel::kKernelComputesDelta
@@ -913,14 +921,6 @@ _efficient_attention_backward(
       }
     }
 
-    // Handle the edge-cases where some tensors are empty
-    if (p.num_queries == 0 || p.num_keys == 0 || p.num_batches == 0 ||
-        p.num_heads == 0) {
-      grad_k_expanded.zero_();
-      grad_v_expanded.zero_();
-      grad_q.zero_();
-      return;
-    }
     Kernel::check_supported(p);
 
     if (smem_bytes > 0xc000) {

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
@@ -628,9 +628,9 @@ struct AttentionBackwardKernel {
 
   struct Params {
     // Input tensors
-    const scalar_t* query_ptr = nullptr; // [Mq, nH, K]
-    const scalar_t* key_ptr = nullptr; // [Mk, nH, K]
-    const scalar_t* value_ptr = nullptr; // [Mk, nH, Kv]
+    const scalar_t* query_ptr = nullptr; // [Mq, nHq, K]
+    const scalar_t* key_ptr = nullptr; // [Mk, nHkv, K]
+    const scalar_t* value_ptr = nullptr; // [Mk, nHkv, Kv]
     const scalar_t* bias_ptr = nullptr;
     const lse_scalar_t* logsumexp_ptr = nullptr; // [nH, Mq]
     const scalar_t* output_ptr = nullptr; // [Mq, nH, Kv]
@@ -640,9 +640,9 @@ struct AttentionBackwardKernel {
     const int32_t* cu_seqlens_k_ptr = nullptr;
 
     // Output tensors
-    output_t* grad_query_ptr = nullptr; //  [Mq, nH, K]
-    output_t* grad_key_ptr = nullptr; //    [Mk, nH, K]
-    output_t* grad_value_ptr = nullptr; //  [Mk, nH, Kv]
+    output_t* grad_query_ptr = nullptr; //  [Mq, nHq, K]
+    output_t* grad_key_ptr = nullptr; //    [Mk, nHq, K]
+    output_t* grad_value_ptr = nullptr; //  [Mk, nHq, Kv]
     output_t* grad_bias_ptr = nullptr;
 
     // Accumulators
@@ -664,6 +664,7 @@ struct AttentionBackwardKernel {
     int32_t num_queries = -1;
     int32_t num_keys = -1;
     int32_t num_heads = -1;
+    int32_t q_heads_per_kv = 1;
     uint8_t custom_mask_type = NoCustomMask;
 
     int64_t q_strideM = -1;
@@ -741,6 +742,7 @@ struct AttentionBackwardKernel {
     CUTLASS_DEVICE bool advance_to_block() {
       int64_t batch_id = blockIdx.z;
       int32_t head_id = blockIdx.y;
+      int32_t kv_head_id = head_id / q_heads_per_kv;
 
       if (kNeedsAccumGradQ || kNeedsAccumGradK || kNeedsAccumGradV) {
         assert(workspace_size() == 0 || workspace != nullptr);
@@ -799,8 +801,8 @@ struct AttentionBackwardKernel {
       }
 
       query_ptr += batch_id * q_strideB + head_id * q_strideH;
-      key_ptr += batch_id * k_strideB + head_id * k_strideH;
-      value_ptr += batch_id * v_strideB + head_id * v_strideH;
+      key_ptr += batch_id * k_strideB + kv_head_id * k_strideH;
+      value_ptr += batch_id * v_strideB + kv_head_id * v_strideH;
       if (bias_ptr != nullptr) {
         bias_ptr += batch_id * bias_strideB + head_id * bias_strideH;
       }
@@ -1263,6 +1265,7 @@ struct AttentionBackwardKernel {
     TORCH_CHECK(p.num_queries > 0, "Invalid value for `num_queries`");
     TORCH_CHECK(p.num_keys > 0, "Invalid value for `num_keys`");
     TORCH_CHECK(p.num_heads > 0, "Invalid value for `num_heads`");
+    TORCH_CHECK(p.q_heads_per_kv > 0, "Invalid GQA group size");
     TORCH_CHECK(p.num_batches > 0, "Invalid value for `num_batches`");
     TORCH_CHECK(p.head_dim <= kMaxK, "kMaxK: Expected `head_dim < kMaxK`");
     TORCH_CHECK(

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
@@ -131,9 +131,9 @@ struct AttentionKernel {
 
   struct Params {
     // Input tensors
-    const scalar_t* query_ptr = nullptr; // [num_queries, num_heads, head_dim]
-    const scalar_t* key_ptr = nullptr; // [num_keys, num_heads, head_dim]
-    const scalar_t* value_ptr = nullptr; // [num_keys, num_heads, head_dim_value]
+    const scalar_t* query_ptr = nullptr; // [num_queries, num_query_heads, head_dim]
+    const scalar_t* key_ptr = nullptr; // [num_keys, num_kv_heads, head_dim]
+    const scalar_t* value_ptr = nullptr; // [num_keys, num_kv_heads, head_dim_value]
     const scalar_t* attn_bias_ptr = nullptr; // [num_heads, num_queries, num_keys]
     const int32_t* seqstart_q_ptr = nullptr;
     const int32_t* seqstart_k_ptr = nullptr;
@@ -184,6 +184,7 @@ struct AttentionKernel {
 
     int32_t num_batches = 0;
     int32_t num_heads = 0;
+    int32_t q_heads_per_kv = 1;
 
     // dropout
     bool use_dropout = false;
@@ -198,6 +199,7 @@ struct AttentionKernel {
     CUTLASS_DEVICE bool advance_to_block() {
       auto batch_id = blockIdx.z;
       auto head_id = blockIdx.y;
+      auto kv_head_id = head_id / q_heads_per_kv;
       auto query_start = blockIdx.x * kQueriesPerBlock;
 
       auto lse_dim = ceil_div((int32_t)num_queries, kAlignLSE) * kAlignLSE;
@@ -248,9 +250,9 @@ struct AttentionKernel {
 
       // Advance to the current batch / head / query_start
       query_ptr += (q_start + query_start) * q_strideM + head_id * q_strideH;
-      key_ptr += k_start * k_strideM + head_id * k_strideH;
+      key_ptr += k_start * k_strideM + kv_head_id * k_strideH;
 
-      value_ptr += k_start * v_strideM + head_id * v_strideH;
+      value_ptr += k_start * v_strideM + kv_head_id * v_strideH;
       output_ptr +=
           int64_t(q_start + query_start) * o_strideM + head_id * head_dim_value;
 
@@ -609,6 +611,7 @@ struct AttentionKernel {
     TORCH_CHECK(
         p.num_heads <= 1 || p.v_strideH % kAlignmentV == 0,
         "value is not correctly aligned (strideH)");
+    TORCH_CHECK(p.q_heads_per_kv > 0, "invalid GQA group size");
     TORCH_CHECK(
         p.custom_mask_type < NumCustomMaskTypes,
         "invalid value for `custom_mask_type`");

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -965,7 +965,7 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
       std::to_array<bool (*)(sdp_params const&, bool)>({
       check_nonzero_sequence_lengths_dense,
       check_last_dim_stride_equals_1_dense<true /*ignore_singleton_dim=*/>,
-      check_batch_size_and_num_heads_dense<true /*enable_gqa*/, false /*requires_same_num_heads*/>,
+      check_batch_size_and_num_heads_dense<true /*supports_gqa*/, false /*requires_same_num_heads*/, true /*supports_mqa*/>,
       check_cudnn_tensor_shapes,
       check_cudnn_d256_bprop_head_dim
   });
@@ -1038,7 +1038,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
   constexpr bool backend_supports_grouped_query_attention = true;
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints = std::to_array<bool (*)(sdp_params const&, bool)>({
-        check_batch_size_and_num_heads_dense<backend_supports_grouped_query_attention>,
+        check_batch_size_and_num_heads_dense<backend_supports_grouped_query_attention, true, true /*supports_mqa*/>,
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<true /*ignore_singleton_dim=*/>});
     for (auto& constraint : dense_constraints) {
@@ -1098,10 +1098,15 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
     }
   }
   if (has_only_dense_inputs(params)) {
+#ifdef USE_ROCM
+    constexpr bool supports_gqa = false;
+#else
+    constexpr bool supports_gqa = true;
+#endif
     constexpr auto dense_constraints = std::to_array<bool (*)(sdp_params const&, bool)>({
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim=*/>,
-        check_batch_size_and_num_heads_dense<false /*supports_grouped_query_attention=*/>});
+        check_batch_size_and_num_heads_dense<supports_gqa, true, true /*supports_mqa*/>});
     for (auto& constraint : dense_constraints) {
       if (!constraint(params, debug)) {
         return false;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -1100,13 +1100,15 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
   if (has_only_dense_inputs(params)) {
 #ifdef USE_ROCM
     constexpr bool supports_gqa = false;
+    constexpr bool supports_mqa = false;
 #else
     constexpr bool supports_gqa = true;
+    constexpr bool supports_mqa = true;
 #endif
     constexpr auto dense_constraints = std::to_array<bool (*)(sdp_params const&, bool)>({
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim=*/>,
-        check_batch_size_and_num_heads_dense<supports_gqa, true, true /*supports_mqa*/>});
+        check_batch_size_and_num_heads_dense<supports_gqa, true, supports_mqa>});
     for (auto& constraint : dense_constraints) {
       if (!constraint(params, debug)) {
         return false;

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
@@ -43,7 +43,7 @@ bool use_flash_attention_cpp(sdp_params const& params, bool debug) {
       check_nested_tensor,
       check_for_dropout,
       check_tensor_shapes,
-      check_batch_size_and_num_heads_dense<true /*supports_grouped_query_attention*/>,
+      check_batch_size_and_num_heads_dense<true /*supports_gqa*/, true, true /*supports_mqa*/>,
       check_attn_mask_shape,
       check_head_dim_size_cpp,
       check_nonzero_sequence_lengths_dense,

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -393,7 +393,10 @@ inline bool check_grouped_query_attention(sdp_params const& params, bool debug) 
   return true;
 }
 
-template <bool supports_gqa, bool requires_same_num_heads=true>
+template <
+    bool supports_gqa,
+    bool requires_same_num_heads = true,
+    bool supports_mqa = false>
 inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool debug) {
   // This is expected to be called after check_tensor_shapes ensuring that the
   // size() calls won't error since the inputs are all 4 dimensional
@@ -433,6 +436,13 @@ inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool 
 
   // same num heads condition for non-gqa case
   if (!same_num_heads){
+    if constexpr (supports_mqa) {
+      const bool broadcastable_num_heads =
+          q_num_heads > 0 && k_num_heads == 1 && v_num_heads == 1;
+      if (broadcastable_num_heads) {
+        return true;
+      }
+    }
     if (debug) {
       TORCH_WARN(
           "For dense input, both fused kernels require query, key and value to have the same num_heads. ",

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3360,6 +3360,57 @@ class TestSDPACudaOnly(NNTestCase):
         for actual_grad, expected_grad in zip(actual_grads, expected_grads):
             self.assertEqual(actual_grad, expected_grad, atol=5e-4, rtol=4e-4)
 
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Memory efficient attention is not supported on this system")
+    def test_mem_efficient_attention_zero_heads(self, device):
+        """Zero-head low-level attention should return empty outputs and gradients."""
+        query = torch.empty(2, 3, 0, 8, device=device)
+        key = torch.empty(2, 4, 0, 8, device=device)
+        value = torch.empty(2, 4, 0, 16, device=device)
+        output, logsumexp, seed, offset, max_q, max_k = (
+            torch.ops.aten._efficient_attention_forward.default(
+                query,
+                key,
+                value,
+                None,
+                None,
+                None,
+                None,
+                None,
+                0.0,
+                0,
+                True,
+            )
+        )
+        grad_query, grad_key, grad_value, _ = (
+            torch.ops.aten._efficient_attention_backward.default(
+                torch.empty_like(output),
+                query,
+                key,
+                value,
+                None,
+                output,
+                None,
+                None,
+                max_q,
+                max_k,
+                logsumexp,
+                0.0,
+                seed,
+                offset,
+                0,
+                False,
+            )
+        )
+
+        self.assertEqual(output.shape, (2, 3, 0, 16))
+        self.assertEqual(logsumexp.shape[:2], (2, 0))
+        for grad, source in zip(
+            (grad_query, grad_key, grad_value), (query, key, value)
+        ):
+            self.assertEqual(grad.shape, source.shape)
+            self.assertEqual(grad.numel(), 0)
+
     @parametrize(
         "fused_kernel",
         [SDPBackend.FLASH_ATTENTION, SDPBackend.CUDNN_ATTENTION],

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -284,6 +284,46 @@ def rand_sdpa_tensor(shape: SdpaShape, device: str, dtype: torch.dtype, type: st
         size = (batch, seq_len, num_heads, head_dim) if not packed else (batch, seq_len, 3 * num_heads * head_dim)
         return torch.randn(size, device=device, dtype=dtype, requires_grad=requires_grad)
 
+
+def make_strided_sdpa_input(
+    shape: tuple[int, int, int, int],
+    layout: str,
+    device: str,
+    dtype: torch.dtype,
+    requires_grad: bool = True,
+) -> torch.Tensor:
+    """Create a leaf SDPA input with last-dimension stride one."""
+    batch, num_heads, seq_len, head_dim = shape
+    match layout:
+        case "padded":
+            tensor = torch.randn(
+                batch, num_heads, seq_len, head_dim + 8, device=device, dtype=dtype
+            )[..., :head_dim]
+        case "offset":
+            tensor = torch.randn(
+                batch, num_heads, seq_len, head_dim + 16, device=device, dtype=dtype
+            )[..., 8 : head_dim + 8]
+        case "sequence_sliced":
+            tensor = torch.randn(
+                batch, num_heads, seq_len * 2, head_dim, device=device, dtype=dtype
+            )[:, :, ::2]
+        case "head_sliced":
+            tensor = torch.randn(
+                batch, num_heads * 2, seq_len, head_dim, device=device, dtype=dtype
+            )[:, ::2]
+        case "transposed":
+            tensor = torch.randn(
+                num_heads, batch, seq_len, head_dim, device=device, dtype=dtype
+            ).transpose(0, 1)
+        case "batch_expanded":
+            tensor = torch.randn(
+                1, num_heads, seq_len, head_dim, device=device, dtype=dtype
+            ).expand(batch, -1, -1, -1)
+        case _:
+            raise AssertionError(f"Unknown layout: {layout}")
+    return tensor.detach().requires_grad_(requires_grad)
+
+
 class TestTransformers(NNTestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
@@ -1851,7 +1891,7 @@ class TestSDPAFailureModes(NNTestCase):
                 with self.assertWarnsRegex(UserWarning, "For dense inputs, both fused kernels require query, "
                                            "key and value to have"):
                     F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0,
-                                                   is_causal=False, enable_gqa=True)
+                                                   is_causal=False, enable_gqa=False)
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not flash_attention fused scaled dot product attention")
@@ -2616,6 +2656,19 @@ class TestSDPACpuOnly(NNTestCase):
                 self.assertEqual(grad_k_actual, grad_k_ref, atol=tol_grad.atol, rtol=tol_grad.rtol)
                 self.assertEqual(grad_v_actual, grad_v_ref, atol=tol_grad.atol, rtol=tol_grad.rtol)
 
+    def test_mqa_singleton_head_broadcast(self, device):
+        """Singleton KV heads should select CPU flash attention without GQA."""
+        query = torch.randn(2, 8, 16, 32, device=device)
+        key = torch.randn(2, 1, 32, 32, device=device)
+        value = torch.randn(2, 1, 32, 32, device=device)
+
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            expected = scaled_dot_product_attention(query, key, value)
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+            actual = scaled_dot_product_attention(query, key, value)
+
+        self.assertEqual(actual, expected)
+
     @parametrize("fused_kernel", [SDPBackend.FLASH_ATTENTION])
     @parametrize("dtype", [torch.float64, torch.float32, torch.bfloat16, torch.float16])
     @parametrize("n_heads", [[65, 5], [16, 4], [27, 1], [5, 1]])
@@ -3044,6 +3097,302 @@ class TestSDPACudaOnly(NNTestCase):
                 attn_mask=None, dropout_p=0.0, is_causal=False)
 
         self.assertEqual(actual.contiguous(), math_ref.contiguous().to(dtype), atol=1e-3, rtol=1e-2)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Memory efficient attention is not supported on this system")
+    @parametrize("enable_gqa", [False, True])
+    def test_mqa_singleton_head_broadcast(self, device, enable_gqa):
+        """Singleton KV heads should use fused attention with either GQA mode."""
+        dtype = torch.float16 if TEST_WITH_ROCM else torch.float32
+        forward_tolerance = 1e-2 if dtype == torch.float16 else 1e-5
+        grad_tolerance = 1e-1 if dtype == torch.float16 else 1e-4
+        make_tensor = partial(
+            torch.randn, device=device, dtype=dtype, requires_grad=True
+        )
+        query = make_tensor(2, 8, 16, 32)
+        key = make_tensor(2, 1, 32, 32)
+        value = make_tensor(2, 1, 32, 32)
+        grad_out = torch.randn(2, 8, 16, 32, device=device, dtype=dtype)
+
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            expected = scaled_dot_product_attention(
+                query, key, value, enable_gqa=enable_gqa
+            )
+            expected_grads = torch.autograd.grad(
+                expected, (query, key, value), grad_out
+            )
+
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            actual = scaled_dot_product_attention(
+                query, key, value, enable_gqa=enable_gqa
+            )
+            actual_grads = torch.autograd.grad(
+                actual, (query, key, value), grad_out
+            )
+
+        self.assertEqual(
+            actual,
+            expected,
+            atol=forward_tolerance,
+            rtol=forward_tolerance,
+        )
+        for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+            self.assertEqual(
+                actual_grad,
+                expected_grad,
+                atol=grad_tolerance,
+                rtol=grad_tolerance,
+            )
+
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Memory efficient attention is not supported on this system")
+    @parametrize("dtype", [torch.float32, torch.float16])
+    @parametrize(
+        "num_query_heads,num_kv_heads,is_causal,use_attn_mask,q_layout,k_layout,v_layout",
+        [
+            (8, 2, False, True, "padded", "sequence_sliced", "transposed"),
+            (8, 4, True, False, "transposed", "offset", "head_sliced"),
+            (6, 2, False, False, "sequence_sliced", "batch_expanded", "padded"),
+        ],
+    )
+    def test_mem_efficient_attention_gqa(
+        self,
+        device,
+        dtype,
+        num_query_heads,
+        num_kv_heads,
+        is_causal,
+        use_attn_mask,
+        q_layout,
+        k_layout,
+        v_layout,
+    ):
+        """Map query heads to KV groups while keeping masks query-head indexed."""
+        query = make_strided_sdpa_input(
+            (2, num_query_heads, 16, 32), q_layout, device, dtype
+        )
+        key = make_strided_sdpa_input(
+            (2, num_kv_heads, 32, 32), k_layout, device, dtype
+        )
+        value = make_strided_sdpa_input(
+            (2, num_kv_heads, 32, 16), v_layout, device, dtype
+        )
+        attn_mask = (
+            make_strided_sdpa_input(
+                (2, num_query_heads, 16, 32), "offset", device, dtype
+            )
+            if use_attn_mask
+            else None
+        )
+        grad_out = torch.randn(
+            2, num_query_heads, 16, 16, device=device, dtype=dtype
+        )
+        inputs = (query, key, value, attn_mask) if attn_mask is not None else (query, key, value)
+
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            expected = scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=attn_mask,
+                is_causal=is_causal,
+                enable_gqa=True,
+            )
+            expected_grads = torch.autograd.grad(expected, inputs, grad_out)
+
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            actual = scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=attn_mask,
+                is_causal=is_causal,
+                enable_gqa=True,
+            )
+            actual_grads = torch.autograd.grad(actual, inputs, grad_out)
+
+        forward_tolerance = 1e-2 if dtype == torch.float16 else 1e-5
+        grad_tolerance = 1e-1 if dtype == torch.float16 else 1e-4
+        self.assertEqual(
+            actual,
+            expected,
+            atol=forward_tolerance,
+            rtol=forward_tolerance,
+        )
+        for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+            self.assertEqual(
+                actual_grad,
+                expected_grad,
+                atol=grad_tolerance,
+                rtol=grad_tolerance,
+            )
+
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Memory efficient attention is not supported on this system")
+    def test_mem_efficient_attention_gqa_dropout(self, device):
+        """GQA should preserve query-head dropout and mask semantics."""
+        batch, num_query_heads, num_kv_heads = 2, 6, 2
+        group_size = num_query_heads // num_kv_heads
+        query = make_strided_sdpa_input(
+            (batch, num_query_heads, 17, 32), "sequence_sliced", device, torch.float32
+        )
+        key = make_strided_sdpa_input(
+            (batch, num_kv_heads, 33, 32), "offset", device, torch.float32
+        )
+        value = make_strided_sdpa_input(
+            (batch, num_kv_heads, 33, 24), "transposed", device, torch.float32
+        )
+        attn_mask = make_strided_sdpa_input(
+            (batch, num_query_heads, 17, 33), "padded", device, torch.float32
+        )
+        grad_out = torch.randn(
+            batch, num_query_heads, 17, 24, device=device, dtype=torch.float32
+        )
+
+        query_expanded = query.detach().clone().requires_grad_()
+        key_expanded = (
+            key.detach().repeat_interleave(group_size, dim=1).requires_grad_()
+        )
+        value_expanded = (
+            value.detach().repeat_interleave(group_size, dim=1).requires_grad_()
+        )
+        attn_mask_expanded = attn_mask.detach().clone().requires_grad_()
+
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            torch.cuda.manual_seed(1234)
+            actual = scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask,
+                dropout_p=0.2,
+                scale=0.37,
+                enable_gqa=True,
+            )
+            torch.cuda.manual_seed(1234)
+            expected = scaled_dot_product_attention(
+                query_expanded,
+                key_expanded,
+                value_expanded,
+                attn_mask_expanded,
+                dropout_p=0.2,
+                scale=0.37,
+            )
+
+        actual_grads = torch.autograd.grad(
+            actual, (query, key, value, attn_mask), grad_out
+        )
+        expanded_grads = torch.autograd.grad(
+            expected,
+            (query_expanded, key_expanded, value_expanded, attn_mask_expanded),
+            grad_out,
+        )
+        expected_grads = (
+            expanded_grads[0],
+            expanded_grads[1]
+            .unflatten(1, (num_kv_heads, group_size))
+            .sum(2),
+            expanded_grads[2]
+            .unflatten(1, (num_kv_heads, group_size))
+            .sum(2),
+            expanded_grads[3],
+        )
+
+        self.assertEqual(actual, expected, atol=2e-5, rtol=2e-5)
+        for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+            self.assertEqual(actual_grad, expected_grad, atol=4e-4, rtol=3e-4)
+
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Memory efficient attention is not supported on this system")
+    def test_mem_efficient_attention_gqa_split_key(self, device):
+        """Split-key backward should reduce per-query-head KV gradients."""
+        batch, num_query_heads, num_kv_heads = 1, 6, 2
+        query = torch.randn(
+            batch, num_query_heads, 17, 64, device=device, requires_grad=True
+        )
+        key = torch.randn(
+            batch, num_kv_heads, 4096, 64, device=device, requires_grad=True
+        )
+        value = torch.randn(
+            batch, num_kv_heads, 4096, 40, device=device, requires_grad=True
+        )
+        grad_out = torch.randn(batch, num_query_heads, 17, 40, device=device)
+
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            expected = scaled_dot_product_attention(
+                query, key, value, enable_gqa=True
+            )
+        expected_grads = torch.autograd.grad(expected, (query, key, value), grad_out)
+
+        query_bmhd = query.detach().transpose(1, 2)
+        key_bmhd = key.detach().transpose(1, 2)
+        value_bmhd = value.detach().transpose(1, 2)
+        output, logsumexp, seed, offset, max_q, max_k = (
+            torch.ops.aten._efficient_attention_forward.default(
+                query_bmhd,
+                key_bmhd,
+                value_bmhd,
+                None,
+                None,
+                None,
+                None,
+                None,
+                0.0,
+                0,
+                True,
+            )
+        )
+        grad_query, grad_key, grad_value, _ = (
+            torch.ops.aten._efficient_attention_backward.default(
+                grad_out.transpose(1, 2),
+                query_bmhd,
+                key_bmhd,
+                value_bmhd,
+                None,
+                output,
+                None,
+                None,
+                max_q,
+                max_k,
+                logsumexp,
+                0.0,
+                seed,
+                offset,
+                0,
+                False,
+                num_splits_key=4,
+            )
+        )
+        actual_grads = (
+            grad_query.transpose(1, 2),
+            grad_key.transpose(1, 2),
+            grad_value.transpose(1, 2),
+        )
+
+        self.assertEqual(output.transpose(1, 2), expected, atol=3e-5, rtol=2e-5)
+        for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+            self.assertEqual(actual_grad, expected_grad, atol=5e-4, rtol=4e-4)
+
+    @parametrize(
+        "fused_kernel",
+        [SDPBackend.FLASH_ATTENTION, SDPBackend.CUDNN_ATTENTION],
+    )
+    def test_mqa_singleton_head_broadcast_native_cuda(self, device, fused_kernel):
+        """Native GQA backends should accept implicit MQA broadcasting."""
+        if fused_kernel == SDPBackend.FLASH_ATTENTION and not PLATFORM_SUPPORTS_FLASH_ATTENTION:
+            self.skipTest("Flash attention is not supported on this system")
+        if fused_kernel == SDPBackend.CUDNN_ATTENTION and not PLATFORM_SUPPORTS_CUDNN_ATTENTION:
+            self.skipTest("cuDNN attention is not supported on this system")
+
+        query = torch.randn(2, 8, 16, 32, device=device, dtype=torch.float16)
+        key = torch.randn(2, 1, 32, 32, device=device, dtype=torch.float16)
+        value = torch.randn(2, 1, 32, 32, device=device, dtype=torch.float16)
+
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            expected = scaled_dot_product_attention(query, key, value)
+        with sdpa_kernel(backends=[fused_kernel]):
+            actual = scaled_dot_product_attention(query, key, value)
+
+        self.assertEqual(actual, expected, atol=1e-3, rtol=1e-2)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN Attention is not supported on this system")
     def test_cudnn_attention_gqa(self, device):
@@ -3559,7 +3908,14 @@ class TestSDPACudaOnly(NNTestCase):
     def test_mem_efficient_attention_vmap_attn_mask(self, device, mask_factory: str):
         """Exercise vmap masking through the fused memory-efficient SDPA batch rule."""
         batch, vmap_batch, num_heads, seq_len, embed_dim = 2, 8, 2, 4, 64
-        x = torch.randn(batch, vmap_batch, seq_len, embed_dim, device=device)
+        x = torch.randn(
+            batch,
+            vmap_batch,
+            seq_len,
+            embed_dim,
+            device=device,
+            requires_grad=True,
+        )
 
         def run_attention(x):
             qkv = x.view(batch, seq_len, num_heads, embed_dim // num_heads).transpose(1, 2)
@@ -3573,14 +3929,19 @@ class TestSDPACudaOnly(NNTestCase):
         with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
             actual = torch.vmap(run_attention, in_dims=1, out_dims=1)(x)
             expected = torch.stack([run_attention(x[:, i]) for i in range(vmap_batch)], dim=1)
+        actual_grad = torch.autograd.grad(actual.sum(), x)[0]
+        expected_grad = torch.autograd.grad(expected.sum(), x)[0]
         self.assertEqual(actual, expected)
+        self.assertEqual(actual_grad, expected_grad)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
     def test_mem_efficient_attention_vmap_attn_mask_only(self, device):
         """Exercise vmap when only the SDPA attention mask is batched."""
         vmap_batch, batch, num_heads, seq_len, head_dim = 8, 2, 2, 4, 32
         query = torch.randn(batch, num_heads, seq_len, head_dim, device=device)
-        attn_masks = torch.ones(vmap_batch, seq_len, seq_len, device=device, dtype=torch.bool)
+        attn_masks = torch.randn(
+            vmap_batch, seq_len, seq_len, device=device, requires_grad=True
+        )
 
         def run_attention(attn_mask):
             return F.scaled_dot_product_attention(query, query, query, attn_mask=attn_mask)
@@ -3588,7 +3949,51 @@ class TestSDPACudaOnly(NNTestCase):
         with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
             actual = torch.vmap(run_attention)(attn_masks)
             expected = torch.stack([run_attention(attn_masks[i]) for i in range(vmap_batch)])
+        actual_grad = torch.autograd.grad(actual.sum(), attn_masks)[0]
+        expected_grad = torch.autograd.grad(expected.sum(), attn_masks)[0]
         self.assertEqual(actual, expected)
+        self.assertEqual(actual_grad, expected_grad)
+
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
+    def test_mem_efficient_attention_vmap_gqa_backward(self, device):
+        """Exercise GQA backward with a per-query-head mask under vmap."""
+        vmap_batch, batch, num_query_heads, num_kv_heads = 3, 2, 6, 2
+        make_tensor = partial(
+            torch.randn,
+            vmap_batch,
+            batch,
+            device=device,
+            requires_grad=True,
+        )
+        query = make_tensor(num_query_heads, 7, 32)
+        key = make_tensor(num_kv_heads, 11, 32)
+        value = make_tensor(num_kv_heads, 11, 24)
+        attn_mask = make_tensor(num_query_heads, 7, 11)
+        grad_out = torch.randn(
+            vmap_batch, batch, num_query_heads, 7, 24, device=device
+        )
+
+        def run_attention(query, key, value, attn_mask):
+            return F.scaled_dot_product_attention(
+                query, key, value, attn_mask, enable_gqa=True
+            )
+
+        inputs = (query, key, value, attn_mask)
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            actual = torch.vmap(run_attention)(*inputs)
+            expected = torch.stack(
+                [
+                    run_attention(query[i], key[i], value[i], attn_mask[i])
+                    for i in range(vmap_batch)
+                ]
+            )
+        actual_grads = torch.autograd.grad(actual, inputs, grad_out)
+        expected_grads = torch.autograd.grad(expected, inputs, grad_out)
+
+        self.assertEqual(actual, expected)
+        for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+            self.assertEqual(actual_grad, expected_grad, atol=1e-4, rtol=1e-4)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("dtype", [torch.float, torch.float16])

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3098,20 +3098,18 @@ class TestSDPACudaOnly(NNTestCase):
 
         self.assertEqual(actual.contiguous(), math_ref.contiguous().to(dtype), atol=1e-3, rtol=1e-2)
 
+    @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Memory efficient attention is not supported on this system")
     @parametrize("enable_gqa", [False, True])
     def test_mqa_singleton_head_broadcast(self, device, enable_gqa):
         """Singleton KV heads should use fused attention with either GQA mode."""
-        dtype = torch.float16 if TEST_WITH_ROCM else torch.float32
-        forward_tolerance = 1e-2 if dtype == torch.float16 else 1e-5
-        grad_tolerance = 1e-1 if dtype == torch.float16 else 1e-4
         make_tensor = partial(
-            torch.randn, device=device, dtype=dtype, requires_grad=True
+            torch.randn, device=device, dtype=torch.float32, requires_grad=True
         )
         query = make_tensor(2, 8, 16, 32)
         key = make_tensor(2, 1, 32, 32)
         value = make_tensor(2, 1, 32, 32)
-        grad_out = torch.randn(2, 8, 16, 32, device=device, dtype=dtype)
+        grad_out = torch.randn(2, 8, 16, 32, device=device)
 
         with sdpa_kernel(backends=[SDPBackend.MATH]):
             expected = scaled_dot_product_attention(
@@ -3129,19 +3127,9 @@ class TestSDPACudaOnly(NNTestCase):
                 actual, (query, key, value), grad_out
             )
 
-        self.assertEqual(
-            actual,
-            expected,
-            atol=forward_tolerance,
-            rtol=forward_tolerance,
-        )
+        self.assertEqual(actual, expected, atol=1e-5, rtol=1e-5)
         for actual_grad, expected_grad in zip(actual_grads, expected_grads):
-            self.assertEqual(
-                actual_grad,
-                expected_grad,
-                atol=grad_tolerance,
-                rtol=grad_tolerance,
-            )
+            self.assertEqual(actual_grad, expected_grad, atol=1e-4, rtol=1e-4)
 
     @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Memory efficient attention is not supported on this system")

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6664,7 +6664,9 @@ def meta__scaled_dot_product_efficient_backward(
     scale: float | None = None,
 ):
     batch_size = query.size(0)
-    num_heads = query.size(1)
+    num_heads_q = query.size(1)
+    num_heads_k = key.size(1)
+    num_heads_v = value.size(1)
     max_q = query.size(2)
     head_dim = query.size(3)
     head_dim_v = value.size(3)
@@ -6672,19 +6674,19 @@ def meta__scaled_dot_product_efficient_backward(
     max_k = key.size(2)
 
     grad_q = torch.empty_permuted(
-        (batch_size, num_heads, max_q, head_dim),
+        (batch_size, num_heads_q, max_q, head_dim),
         (0, 2, 1, 3),
         dtype=query.dtype,
         device=query.device,
     )
     grad_k = torch.empty_permuted(
-        (batch_size, num_heads, max_k, head_dim),
+        (batch_size, num_heads_k, max_k, head_dim),
         (0, 2, 1, 3),
         dtype=key.dtype,
         device=key.device,
     )
     grad_v = torch.empty_permuted(
-        (batch_size, num_heads, max_k, head_dim_v),
+        (batch_size, num_heads_v, max_k, head_dim_v),
         (0, 2, 1, 3),
         dtype=value.dtype,
         device=value.device,
@@ -7025,6 +7027,10 @@ def meta__efficient_attention_backward(
         torch._check(
             query.shape[3] == key.shape[3],
             lambda: "embedding dim must match for `shared_storage_dqdkdv",
+        )
+        torch._check(
+            query.shape[2] == key.shape[2],
+            lambda: "num heads must match for `shared_storage_dqdkdv",
         )
         chunk = torch.empty(
             (*query.shape[0:-2], 3, query.shape[-2], query.shape[-1]),

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6471,8 +6471,9 @@ scaled_dot_product_attention = _add_docstr(
         For math backend, all intermediates are kept in torch.float if inputs are in torch.half or torch.bfloat16.
     For more information please see :doc:`/notes/numerical_accuracy`
 
-        Grouped Query Attention (GQA) is an experimental feature. It currently works only for Flash_attention
-        and math kernel on CUDA tensor, and does not support Nested tensor.
+        Grouped Query Attention (GQA) is an experimental feature. It works with FlashAttention,
+        cuDNN attention, and the math kernel on CUDA tensors. Memory-efficient attention also supports
+        GQA on NVIDIA CUDA. GQA does not support Nested tensors.
         Constraints for GQA:
 
             - number_of_heads_query % number_of_heads_key_value == 0 and,


### PR DESCRIPTION
## Human Note
Okay, this has been a footgun for a wwhile and something i wanted to add but jsut didnt feel like it was high pri enough. 
It is realtively straightforward i just copied what we did for the flex-attention bwd, no atomics and launch a follow up 
kernel to reduce for gqa bwd. 


While i was here i found that the vmap fix i added was only sufficent for fwd so fixed the bwd case as well

## Agent Report
# Summary

Fixes the implicit multi-query attention (MQA) memory regression from `pytorch/pytorch#154363`, adds native grouped-query attention (GQA) to NVIDIA CUDA memory-efficient SDPA, and restores memory-efficient SDPA backward under `vmap`.

For dense inputs, fused SDPA now accepts implicit singleton K/V broadcasting when `Hq > 0`, `Hk == 1`, and `Hv == 1`, even without `enable_gqa=True`. CUDA memory-efficient attention additionally supports general GQA when:

- `Hk == Hv`
- `Hkv > 0`
- `Hq % Hkv == 0`
- `enable_gqa=True` for non-singleton GQA

The public math and nested-tensor behavior is otherwise unchanged.

# Root cause

Dense fused-backend validation rejected differing Q/K/V head counts unless `enable_gqa=True` and the backend advertised GQA. Implicit MQA therefore fell through to the quadratic math backend. On an NVIDIA GB200 with `B=4`, `Hq=32`, `L=2048`, and `D=128`, this raised peak attention memory from 64 MiB to 4904.25 MiB.

CUDA memory-efficient attention also required equal Q/K/V head counts internally. Supporting general GQA requires separate query/KV head indexing in the kernels and a reduction of the per-query-head K/V gradients.

# Implementation

## Fused MQA dispatch

- Dense backend validation recognizes exact singleton-K/V MQA independently of `enable_gqa`.
- CPU flash, CUDA flash, and cuDNN use their native MQA behavior.
- NVIDIA CUDA memory-efficient attention routes implicit MQA through the same native grouped-head indexing as general GQA; no K/V expansion workaround remains.
- General head mismatches without `enable_gqa=True` remain rejected.

## Native CUDA memory-efficient GQA

- Forward and backward kernel parameters now carry `q_heads_per_kv`.
- The grid remains query-head scheduled.
- Q, output, LSE, attention bias/mask, and dropout RNG remain indexed by query head.
- K/V reads use `kv_head_id = query_head_id / q_heads_per_kv`, including the `Hkv=1` MQA case.
- Backward writes dK/dV into query-head-sized temporary tensors, reshapes them as `[B, S, Hkv, Hq / Hkv, D]`, and sums the query-group dimension into the original K/V shapes.
- GQA is rejected for `shared_storage_dqdkdv`, whose packed Q/K/V layout requires equal head counts.
- Meta registrations return distinct Q/K/V gradient head shapes and enforce the same shared-storage restriction.
- All-zero query/KV heads retain the low-level operator's empty-output/gradient behavior without dividing by the KV-head count or entering split-key heuristics.
- ROCm memory-efficient attention retains the previous equal-head requirement and no longer advertises the removed MQA expansion workaround; native MQA/GQA is enabled only for NVIDIA CUDA.

The SDPA documentation now includes NVIDIA CUDA memory-efficient attention among the GQA-capable backends.

## Memory-efficient SDPA backward under vmap

The earlier attention-bias batching fix from `c9361abd6c4` is present in this checkout, but its regression tests covered forward only. During training, the composite SDPA wrapper sees `BatchedTensor` arguments whose `requires_grad` state is hidden and requests an empty LSE. Backward then rejects that tensor because its head stride does not satisfy the LSE alignment contract.

The memory-efficient batching rule now recomputes `compute_log_sumexp` from the unwrapped Q/K/V/bias tensors while grad mode is enabled. Training receives a padded, aligned LSE; inference and `torch.no_grad()` retain the empty-LSE path.

# Head semantics and feature composition

The head axis for masks and other query-side state is `Hq`, not `Hkv`:

- memory-efficient bias validation requires `bias.size(1) == Hq`;
- forward/backward bias pointers use the query `head_id`;
- LSE, output, dropout counters, and the launch grid are query-head-sized;
- only K/V data pointers map to the grouped KV head.

This matches FlexAttention. A compiled FlexAttention check using a per-query-head `BlockMask` (`H=Hq`) matched the same dense GQA reference in forward and backward. `BlockMask` itself is a FlexAttention API and is not accepted by memory-efficient SDPA; the verified composition point is the shared `Hq` mask-head convention.

Additional composition checks passed for:

- causal and dense per-`Hq` masks, including mask gradients;
- dropout with identical per-query-head RNG streams versus explicitly expanded K/V;
- custom scale;
- forced split-key backward (`num_splits_key=4`);
- packed variable-length low-level attention with three unequal sequence lengths;
- chunked forward/backward at batch size 65,536;
- dynamic `torch.compile(..., backend="aot_eager", fullgraph=True)` forward/backward;
- ordinary MHA and GQA `vmap` forward/backward, including input-only gradients, bias-only gradients, a per-`Hq` GQA mask, and compiled fullgraph execution;
- nested `vmap`, dropout under `vmap`, and `torch.vmap(torch.func.grad(...))` smoke checks.

# Validation

## Rebuild

The final C++/CUDA source rebuilt successfully with:

```text
bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260724-pytorch-154363/pytorch
```

The complete output is in `rebuild_final.log`.

## Targeted regression tests

```text
.venv/bin/pytest -q test/test_transformers.py -k "vmap_attn_mask or vmap_gqa_backward"
```

Passed four memory-efficient `vmap` forward/backward cases. Before the batching-rule fix, all four failed with `LSE is not correctly aligned (strideH)`.

```text
.venv/bin/pytest -q test/test_transformers.py -k "mem_efficient_attention_gqa or mqa_singleton_head_broadcast or invalid_sdpa_kernel_grouped_query_attention_cuda or mem_efficient_attention_zero_heads"
```

Passed 15 cases with one expected CUDA-only skip, covering:

- implicit MQA on CPU flash and CUDA fused backends;
- `Hq/Hkv` ratios 2, 3, and 4;
- fp32 and fp16;
- forward, dQ, dK, dV, and attention-mask gradients;
- causal attention and a dense per-query-head mask;
- independently non-contiguous Q/K/V layouts, including padding, aligned storage offsets, sequence/head slicing, transposed batch/head strides, and zero batch stride;
- dropout and custom scale against explicitly expanded K/V;
- forced split-key backward;
- direct low-level all-zero-head forward/backward;
- rejection of general GQA without `enable_gqa=True`.

Five existing memory-efficient MHA/mask-gradient tests also pass. Existing cuDNN GQA, all 32 CPU flash GQA variants, bf16 smoke cases, and dynamic compile checks passed earlier in the same worktree.

## Differential fuzzing

After removing the MQA expansion workaround, `agent_space/fuzz_mem_eff_gqa.py` passed 500 seeded forward/backward comparisons against the math backend (`250` cases each with seeds `154363` and `154364`). The matrix varied:

- `Hkv` from 1 to 4 and group size from 1 to 5, including non-power-of-two grouping;
- fp32, fp16, and bf16;
- query/key lengths from 1 to 65;
- Q/K dimensions from 8 to 256 and V dimensions from 8 to 128;
- causal and per-head attention-mask cases;
- independent Q/K/V/grad-output layouts: contiguous, padded, aligned offset, sequence-sliced, head-sliced, transposed, and zero-stride batch-expanded.

The complete output is in `gqa_fuzz.log`.

## Compute Sanitizer

NVIDIA Compute Sanitizer memcheck ran four forward/backward cases spanning group sizes 3, 4, 5, and 8; fp32/fp16/bf16; head dimensions 32, 64, 200, and 256; masks, causal mode, dropout, and distinct Q/K/V/gradient strides:

```text
========= ERROR SUMMARY: 0 errors
```

Separate memchecks of forced `num_splits_key=4` backward, GQA backward under `vmap`, and direct all-zero-head forward/backward also reported zero errors. Complete outputs are in `compute_sanitizer_memcheck.log`, `compute_sanitizer_split_key.log`, `compute_sanitizer_vmap.log`, and `compute_sanitizer_zero_heads.log`.

## Memory reproduction

The original `B=4, Hq=32, L=2048, D=128, fp16` reproduction now reports:

- standard MHA: 64 MiB peak attention memory;
- explicit MQA expansion: 64 MiB;
- implicit MQA broadcasting: 64 MiB, down from 4904.25 MiB;
- MQA with `enable_gqa=True`: 64 MiB.

Outputs are saved in `repro_before.txt` and `repro_after.txt`.

## Review and prerequisite checks

- An independent CUDA kernel review found no critical correctness, race, layout, dispatch, or meta-registration issue.
- A final simplification follow-up removed the singleton K/V expansion helper entirely after direct and public-path validation confirmed native `Hkv=1` support; no other implementation or test structure was reducible without losing clarity or coverage.
- Automated review correctly identified a low-level all-zero-head regression, although the cited public SDPA path already passed through its earlier empty-output fast path. The low-level forward/backward behavior is restored and directly tested.
- Reviewer follow-ups use explicit mutable pointers for the new dK/dV staging buffers, leave a C++20 designated-initializer TODO, and move the efficient-attention tuple element on return. The mutable pointers remain untyped before `static_cast` because kernel `scalar_t` can be a CUTLASS type such as `cutlass::half_t`, for which `TensorBase::mutable_data_ptr<T>()` is not exported.
- The review-follow-up rebuild and full targeted matrix pass: four vmap tests, 15 GQA/MQA/zero-head tests with one expected skip, and five existing gradient tests.
- Changed-file formatters and non-clang-tidy linters report no issues; output is in `lintrunner_changed_final.log`.
- `git diff --check` passes.
- Clang-tidy reports six pre-existing `modernize-use-bool-literals` findings at unchanged lines 119–146 of `BatchRulesLinearAlgebra.cpp`; output is in `lintrunner_clangtidy_known.log`.
- A broad full-repository lint also reports unrelated findings outside the modified files.

# Scope and residual risks

- Hardware validation was limited to NVIDIA GB200/CUDA 13.1; ROCm and XPU hardware were unavailable.
- General-GQA backward temporarily allocates query-head-sized dK/dV tensors, so its transient K/V-gradient storage is `Hq / Hkv` times the final dK/dV size.
- For fp16/bf16, each per-query-head temporary gradient is rounded to its storage dtype before the group reduction. This follows the existing CUDA FlashAttention expand-then-reduce design; direct fp32 accumulation by KV head would require a larger backward-kernel redesign.


Fixes #154363


<details>
<summary>Repro Script</summary>

```python
import torch
import torch.nn.functional as F
import gc
from typing import Tuple, Dict


def get_gpu_memory_usage() -> float:
    """Get current GPU memory usage in MB"""
    if torch.cuda.is_available():
        return torch.cuda.memory_allocated() / 1024 / 1024
    return 0.0


def get_peak_gpu_memory() -> float:
    """Get peak GPU memory usage in MB"""
    if torch.cuda.is_available():
        return torch.cuda.max_memory_allocated() / 1024 / 1024
    return 0.0


def reset_peak_memory():
    """Reset peak memory tracking"""
    if torch.cuda.is_available():
        torch.cuda.reset_peak_memory_stats()


def clear_memory():
    """Clear GPU memory and run garbage collection"""
    if torch.cuda.is_available():
        torch.cuda.empty_cache()
    gc.collect()


def create_attention_tensors(
    batch_size: int,
    n_heads: int,
    seq_length: int,
    head_dim: int,
    device: str = "cuda",
    dtype: torch.dtype = torch.float16
) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
    """Create query, key, value tensors for attention"""
    q = torch.randn(batch_size, n_heads, seq_length, head_dim, device=device, dtype=dtype)
    k = torch.randn(batch_size, n_heads, seq_length, head_dim, device=device, dtype=dtype)
    v = torch.randn(batch_size, n_heads, seq_length, head_dim, device=device, dtype=dtype)
    return q, k, v


def create_mqa_tensors(
    batch_size: int,
    n_heads: int,
    seq_length: int,
    head_dim: int,
    device: str = "cuda",
    dtype: torch.dtype = torch.float16
) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
    """Create tensors for multiquery attention (k/v have 1 head)"""
    q = torch.randn(batch_size, n_heads, seq_length, head_dim, device=device, dtype=dtype)
    k = torch.randn(batch_size, 1, seq_length, head_dim, device=device, dtype=dtype)
    v = torch.randn(batch_size, 1, seq_length, head_dim, device=device, dtype=dtype)
    return q, k, v


def test_multiheaded_attention(
    batch_size: int,
    n_heads: int,
    seq_length: int,
    head_dim: int,
    device: str = "cuda",
    dtype: torch.dtype = torch.float16
) -> Dict[str, float]:
    """Test standard multiheaded attention"""
    clear_memory()
    reset_peak_memory()
    
    initial_memory = get_gpu_memory_usage()
    
    # Create tensors
    q, k, v = create_attention_tensors(batch_size, n_heads, seq_length, head_dim, device, dtype)
    
    after_tensor_creation = get_gpu_memory_usage()
    
    # Run attention
    with torch.no_grad():
        output = F.scaled_dot_product_attention(q, k, v)
        # Force computation to complete
        torch.cuda.synchronize()
    
    peak_memory = get_peak_gpu_memory()
    final_memory = get_gpu_memory_usage()
    
    return {
        "initial_memory": initial_memory,
        "after_tensor_creation": after_tensor_creation,
        "peak_memory": peak_memory,
        "final_memory": final_memory,
        "tensor_memory": after_tensor_creation - initial_memory,
        "peak_attention_memory": peak_memory - after_tensor_creation
    }


def test_mqa_with_expand(
    batch_size: int,
    n_heads: int,
    seq_length: int,
    head_dim: int,
    device: str = "cuda",
    dtype: torch.dtype = torch.float16
) -> Dict[str, float]:
    """Test MQA with explicit expand_as"""
    clear_memory()
    reset_peak_memory()
    
    initial_memory = get_gpu_memory_usage()
    
    # Create MQA tensors
    q, k, v = create_mqa_tensors(batch_size, n_heads, seq_length, head_dim, device, dtype)
    
    after_tensor_creation = get_gpu_memory_usage()
    
    # Expand k and v to match q's head dimension
    k_expanded = k.expand_as(q)
    v_expanded = v.expand_as(q)
    
    after_expand = get_gpu_memory_usage()
    
    # Run attention
    with torch.no_grad():
        output = F.scaled_dot_product_attention(q, k_expanded, v_expanded)
        # Force computation to complete
        torch.cuda.synchronize()
    
    peak_memory = get_peak_gpu_memory()
    final_memory = get_gpu_memory_usage()
    
    return {
        "initial_memory": initial_memory,
        "after_tensor_creation": after_tensor_creation,
        "after_expand": after_expand,
        "peak_memory": peak_memory,
        "final_memory": final_memory,
        "tensor_memory": after_tensor_creation - initial_memory,
        "expand_memory": after_expand - after_tensor_creation,
        "peak_attention_memory": peak_memory - after_expand
    }


def test_mqa_without_expand(
    batch_size: int,
    n_heads: int,
    seq_length: int,
    head_dim: int,
    device: str = "cuda",
    dtype: torch.dtype = torch.float16
) -> Dict[str, float]:
    """Test MQA without explicit expand (relying on broadcasting)"""
    clear_memory()
    reset_peak_memory()
    
    initial_memory = get_gpu_memory_usage()
    
    # Create MQA tensors
    q, k, v = create_mqa_tensors(batch_size, n_heads, seq_length, head_dim, device, dtype)
    
    after_tensor_creation = get_gpu_memory_usage()
    
    # Run attention with broadcasting
    with torch.no_grad():
        output = F.scaled_dot_product_attention(q, k, v)
        # Force computation to complete
        torch.cuda.synchronize()
    
    peak_memory = get_peak_gpu_memory()
    final_memory = get_gpu_memory_usage()
    
    return {
        "initial_memory": initial_memory,
        "after_tensor_creation": after_tensor_creation,
        "peak_memory": peak_memory,
        "final_memory": final_memory,
        "tensor_memory": after_tensor_creation - initial_memory,
        "peak_attention_memory": peak_memory - after_tensor_creation
    }


def test_mqa_with_gqa_flag(
    batch_size: int,
    n_heads: int,
    seq_length: int,
    head_dim: int,
    device: str = "cuda",
    dtype: torch.dtype = torch.float16
) -> Dict[str, float]:
    """Test MQA with enable_gqa=True flag"""
    clear_memory()
    reset_peak_memory()
    
    initial_memory = get_gpu_memory_usage()
    
    # Create MQA tensors
    q, k, v = create_mqa_tensors(batch_size, n_heads, seq_length, head_dim, device, dtype)
    
    after_tensor_creation = get_gpu_memory_usage()
    
    # Run attention with enable_gqa=True
    with torch.no_grad():
        output = F.scaled_dot_product_attention(q, k, v, enable_gqa=True)
        # Force computation to complete
        torch.cuda.synchronize()
    
    peak_memory = get_peak_gpu_memory()
    final_memory = get_gpu_memory_usage()
    
    return {
        "initial_memory": initial_memory,
        "after_tensor_creation": after_tensor_creation,
        "peak_memory": peak_memory,
        "final_memory": final_memory,
        "tensor_memory": after_tensor_creation - initial_memory,
        "peak_attention_memory": peak_memory - after_tensor_creation
    }


def print_results(name: str, results: Dict[str, float]):
    """Print formatted results"""
    print(f"\n{name}:")
    print(f"  Initial memory: {results['initial_memory']:.2f} MB")
    print(f"  After tensor creation: {results['after_tensor_creation']:.2f} MB")
    if 'after_expand' in results:
        print(f"  After expand: {results['after_expand']:.2f} MB")
    print(f"  Peak memory: {results['peak_memory']:.2f} MB")
    print(f"  Final memory: {results['final_memory']:.2f} MB")
    print(f"  Tensor memory usage: {results['tensor_memory']:.2f} MB")
    if 'expand_memory' in results:
        print(f"  Expand memory usage: {results['expand_memory']:.2f} MB")
    print(f"  Peak attention memory: {results['peak_attention_memory']:.2f} MB")


def run_memory_comparison():
    """Run comprehensive memory comparison"""
    if not torch.cuda.is_available():
        print("CUDA not available. This test requires a GPU.")
        return
    
    # Test parameters
    batch_size = 4
    n_heads = 32
    seq_length = 2048
    head_dim = 128
    device = "cuda"
    dtype = torch.float16
    
    print(f"Testing with parameters:")
    print(f"  Batch size: {batch_size}")
    print(f"  Number of heads: {n_heads}")
    print(f"  Sequence length: {seq_length}")
    print(f"  Head dimension: {head_dim}")
    print(f"  Data type: {dtype}")
    print(f"  Device: {device}")
    
    # Test 1: Standard multiheaded attention
    print("\n" + "="*60)
    print("TEST 1: Standard Multiheaded Attention")
    print("="*60)
    mha_results = test_multiheaded_attention(batch_size, n_heads, seq_length, head_dim, device, dtype)
    print_results("Multiheaded Attention", mha_results)
    
    # Test 2: MQA with expand_as
    print("\n" + "="*60)
    print("TEST 2: MQA with expand_as")
    print("="*60)
    mqa_expand_results = test_mqa_with_expand(batch_size, n_heads, seq_length, head_dim, device, dtype)
    print_results("MQA with expand_as", mqa_expand_results)
    
    # Test 3: MQA without expand (broadcasting)
    print("\n" + "="*60)
    print("TEST 3: MQA without expand (broadcasting)")
    print("="*60)
    mqa_broadcast_results = test_mqa_without_expand(batch_size, n_heads, seq_length, head_dim, device, dtype)
    print_results("MQA without expand", mqa_broadcast_results)
    
    # Test 4: MQA with enable_gqa=True
    print("\n" + "="*60)
    print("TEST 4: MQA with enable_gqa=True")
    print("="*60)
    mqa_gqa_results = test_mqa_with_gqa_flag(batch_size, n_heads, seq_length, head_dim, device, dtype)
    print_results("MQA with enable_gqa=True", mqa_gqa_results)
    
    # Summary comparison
    print("\n" + "="*60)
    print("SUMMARY COMPARISON")
    print("="*60)
    print(f"Peak attention memory usage:")
    print(f"  Multiheaded: {mha_results['peak_attention_memory']:.2f} MB")
    print(f"  MQA with expand: {mqa_expand_results['peak_attention_memory']:.2f} MB")
    print(f"  MQA without expand: {mqa_broadcast_results['peak_attention_memory']:.2f} MB")
    print(f"  MQA with enable_gqa: {mqa_gqa_results['peak_attention_memory']:.2f} MB")
    
    print(f"\nTotal peak memory usage:")
    print(f"  Multiheaded: {mha_results['peak_memory']:.2f} MB")
    print(f"  MQA with expand: {mqa_expand_results['peak_memory']:.2f} MB")
    print(f"  MQA without expand: {mqa_broadcast_results['peak_memory']:.2f} MB")
    print(f"  MQA with enable_gqa: {mqa_gqa_results['peak_memory']:.2f} MB")
    
    # Check if the bug is reproduced
    mha_peak = mha_results['peak_attention_memory']
    mqa_broadcast_peak = mqa_broadcast_results['peak_attention_memory']
    mqa_expand_peak = mqa_expand_results['peak_attention_memory']
    mqa_gqa_peak = mqa_gqa_results['peak_attention_memory']
    
    print(f"\nBug analysis:")
    if mqa_broadcast_peak > mha_peak:
        print(f"  ✓ BUG REPRODUCED: MQA without expand uses MORE memory than multiheaded attention")
        print(f"    ({mqa_broadcast_peak:.2f} MB vs {mha_peak:.2f} MB, difference: {mqa_broadcast_peak - mha_peak:.2f} MB)")
    else:
        print(f"  ✗ Bug not reproduced: MQA without expand uses less or equal memory")
    
    if mqa_expand_peak < mqa_broadcast_peak:
        print(f"  ✓ WORKAROUND 1 CONFIRMED: expand_as reduces memory usage")
        print(f"    ({mqa_expand_peak:.2f} MB vs {mqa_broadcast_peak:.2f} MB, savings: {mqa_broadcast_peak - mqa_expand_peak:.2f} MB)")
    else:
        print(f"  ✗ Workaround 1 not effective: expand_as doesn't reduce memory usage")
    
    if mqa_gqa_peak < mqa_broadcast_peak:
        print(f"  ✓ WORKAROUND 2 CONFIRMED: enable_gqa=True reduces memory usage")
        print(f"    ({mqa_gqa_peak:.2f} MB vs {mqa_broadcast_peak:.2f} MB, savings: {mqa_broadcast_peak - mqa_gqa_peak:.2f} MB)")
    else:
        print(f"  ✗ Workaround 2 not effective: enable_gqa=True doesn't reduce memory usage")


if __name__ == "__main__":
    print("PyTorch Scaled Dot Product Attention Memory Usage Test")
    print(f"PyTorch version: {torch.__version__}")
    if torch.cuda.is_available():
        print(f"CUDA version: {torch.version.cuda}")
        print(f"GPU: {torch.cuda.get_device_name()}")
        print(f"GPU memory: {torch.cuda.get_device_properties(0).total_memory / 1024**3:.1f} GB")
    
    # Run the main comparison
    run_memory_comparison()
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Reproduced implicit MQA broadcasting memory blowup

Ran the provided `repro.py` with the job Python on an NVIDIA GB200 and the current source build (`2.14.0a0+git4fbc0c5`). Plain SDPA with query heads 32 and key/value heads 1 used 4904.25 MiB of peak attention memory, versus 64 MiB for both explicit `expand_as` and `enable_gqa=True`. Saved the complete baseline output in `repro_before.txt`.

### Located fused-backend exclusion

`check_batch_size_and_num_heads_dense` rejects mismatched query/key/value head counts whenever `enable_gqa=False`, so `_fused_sdp_choice` selects the math backend before any kernel runs. A manual zero-stride `expand` of singleton key/value heads makes all three CUDA fused backends accept the input; forced memory-efficient attention matched the math forward and gradients for fp32, while flash, cuDNN, and memory-efficient attention all matched for fp16. This confirms the fix can remain in the composite SDPA layer and does not require kernel changes.

### Added a failing regression test

Added `TestSDPACudaOnly.test_mqa_singleton_head_broadcast`, which compares fp32 memory-efficient attention and its input gradients against the math backend while passing singleton key/value heads without `enable_gqa`. Before the fix, the targeted test fails with `RuntimeError: No available kernel`, confirming it exercises the reported dispatch failure.

### Implemented MQA-aware fused dispatch

Dense backend validation now recognizes the exact MQA broadcasting case where both key and value have one head. Flash and cuDNN consume those tensors through their native MQA support; memory-efficient attention receives zero-stride expanded key/value views after selection. This preserves native GQA dispatch when `enable_gqa=True`, while also letting fp32 memory-efficient attention handle either flag value. The math path still receives the original inputs.

### Confirmed the memory regression is fixed

Re-ran `repro.py` after rebuilding. Implicit MQA broadcasting dropped from 4904.25 MiB to 64 MiB of peak attention memory and now matches explicit `expand_as`, `enable_gqa=True`, and standard MHA. Saved the complete fixed output in `repro_after.txt`.

### Final targeted validation

Rebuilt the refined C++ implementation successfully. The new CUDA forward/gradient test passes for both `enable_gqa=False` and `True`; the CPU flash regression test also passes without `enable_gqa`. Existing invalid general-GQA, cuDNN GQA, and all 32 CPU flash GQA test variants pass, as does a dynamic-head `torch.compile(..., fullgraph=True)` smoke test. Manual forced-backend checks confirm no-flag MQA works with CUDA flash, cuDNN, and memory-efficient attention.

`spin fixlint` applied formatting to the changed files and reported no issues in its selected fixable lint set, but its broad prerequisite lint run exits nonzero on unrelated pre-existing ShellCheck and clang-tidy findings in `.ci` scripts and header-only half/complex utilities.

### Independent review follow-up

A read-only reviewer found no correctness issues and identified direct flash/cuDNN coverage and cross-GPU gradient tolerances as test gaps. Added forced CUDA flash and cuDNN MQA-without-GQA cases, made the memory-efficient gradient tolerance backend-appropriate, and removed a touched duplicate semicolon. Rebuilt again; all five focused MQA cases pass. Final `spin quicklint` reports no lint issues in the changed files.

### Final artifacts

Generated `report.md`, `pr_title.txt`, and `fix.diff`. The saved diff exactly matches the final uncommitted worktree changes; baseline/fixed memory outputs and the final `spin fixlint` log are also retained in the job directory.

### Investigated native memory-efficient GQA

The CUDA CUTLASS forward kernel launches one block-grid head per query head and currently offsets Q/K/V with the same `head_id`; native GQA can map only K/V through `kv_head_id = query_head_id / group_size` while keeping output, LSE, bias, dropout RNG, and grid dimensions indexed by query head. The host wrappers must separately track query and KV head counts and relax their equal-head checks.

For backward, the least invasive design mirrors CUDA FlashAttention: keep the grid/workspace per query head, map K/V reads to the grouped KV head, write dK/dV into temporary query-head-sized tensors, then reshape to `[B, S, Hkv, group_size, D]` and reduce the group dimension with `sum_out`. The current MQA expansion already gets equivalent behavior through `ExpandBackward`. FlexAttention's current Triton backward instead loops over `GQA_SHARED_HEADS` inside its dK/dV section and accumulates directly; its visible follow-up reduction is for broadcasted batch dimensions, not GQA heads.

### Began native GQA implementation

Added separate query-to-KV head mapping parameters to the CUDA CUTLASS forward/backward kernels, relaxed the CUDA host wrappers to accept equal K/V heads that divide query heads, and added query-head-sized dK/dV temporaries followed by group reductions. Added forced memory-efficient forward/gradient regression cases for `Hq=8, Hkv=2` and `Hkv=4`; both fail on the pre-change binary with `No available kernel`, confirming the new tests cover the missing dispatch path.

### First native GQA validation passed

The incremental C++/CUDA rebuild succeeded. Both new forced memory-efficient cases now pass against the math reference, including dQ/dK/dV checks and a causal case. The returned dK/dV shapes match the original `Hkv` inputs after the query-group reduction.

### Expanded stride and dtype coverage

Added durable GQA cases with independent non-contiguous Q/K/V layouts: padded storage, aligned offsets, sequence/head slicing, transposed batch/head strides, and zero-stride batch expansion. The matrix covers fp32/fp16, causal and dense per-`Hq` masks, mask gradients, and group ratios 2, 3, and 4. Added explicit dropout/custom-scale coverage against K/V repeated to query heads and a forced `num_splits_key=4` backward regression.

Ran 500 seeded differential fuzz cases against the math backend across fp32/fp16/bf16, `Hkv=1..4`, group sizes 1..5, head dimensions 8..256, query/key lengths 1..65, masks/causal modes, and independently varied Q/K/V/grad-output strides. Both 250-case seeds passed; output is in `gqa_fuzz.log`.

### Sanitizer validation passed

Ran NVIDIA Compute Sanitizer memcheck after the final rebuild with four forward/backward cases spanning group sizes 3/4/5/8, fp32/fp16/bf16, dimensions 32/64/200/256, masks, causal mode, dropout, and distinct strides. It reported `ERROR SUMMARY: 0 errors`. A second memcheck run forcing `num_splits_key=4` also reported zero errors; outputs are in `compute_sanitizer_memcheck.log` and `compute_sanitizer_split_key.log`.

### Verified feature composition and head semantics

Confirmed mask/bias, output, LSE, dropout RNG, and launch-grid semantics remain query-head indexed (`Hq`), while only K/V pointers use grouped `Hkv` indexing. A compiled FlexAttention test with a head-dependent `BlockMask` created with `H=Hq` matched the same dense GQA reference in forward and backward. The memory-efficient dense per-head mask and mask-gradient cases match that convention.

Dropout with reset Philox state, custom scale, forced split-key backward, packed variable-length low-level attention, batch-size-65,536 chunked forward/backward, and dynamic fullgraph AOTAutograd all pass. GQA `vmap` forward also matches a loop. Backward under `vmap` fails with an LSE alignment error for both GQA and ordinary equal-head MHA, identifying a pre-existing memory-efficient backend limitation rather than a regression in this change.

### Final review and validation

A focused independent CUDA-kernel review found no critical correctness, race, layout, dispatch, or meta-registration issue. The final rebuild completed successfully. Five MQA tests, eight memory-efficient GQA tests, and the existing invalid-no-flag GQA test pass. The original memory reproduction remains fixed at 64 MiB peak attention memory versus 4904.25 MiB before the change.

Changed-file `lintrunner` and `git diff --check` pass. The broad full-repository lint still reports unrelated diagnostics outside the modified files. Updated `report.md`, `pr_title.txt`, and the saved validation artifacts for the native GQA implementation.

### Fixed memory-efficient vmap backward LSE handling

Traced the user's earlier SDPA vmap fix to merged commit `c9361abd6c4` (`Fix #161310`). That change correctly flattened attention bias under vmap but its regression tests covered forward only. Saved-tensor inspection showed that the composite SDPA wrapper sees hidden `requires_grad` state on `BatchedTensor` inputs and requests an empty LSE with shape `[6, 2, 0]`; memory-efficient backward then rejects its head stride. Forcing `compute_log_sumexp=True` produced aligned `[6, 2, 32]` LSE storage and made backward pass.

Extended the existing vmap mask tests with input and bias-only gradients and added a GQA vmap backward test with a per-`Hq` mask. Before the fix, all four cases failed with `LSE is not correctly aligned (strideH)`. Updated the memory-efficient batching rule to recompute the LSE requirement from unwrapped Q/K/V/bias tensors while grad mode is enabled. Inference and `torch.no_grad()` still return empty LSE.

The final vmap pytest selection passes four tests; the combined GQA/MQA selection passes 14 with one expected skip, and five existing MHA/mask-gradient tests pass. Nested vmap, dropout under vmap, and `torch.vmap(torch.func.grad(...))` smoke checks also pass. Compute Sanitizer memcheck of GQA vmap backward reports zero errors in `compute_sanitizer_vmap.log`.

Changed-file formatters and non-clang-tidy linters pass. Clang-tidy reports six existing `modernize-use-bool-literals` findings on unchanged lines 119–146 of `BatchRulesLinearAlgebra.cpp`; these are recorded in `lintrunner_clangtidy_known.log` and were not changed as part of this fix.

### Final simplification pass

Ran one independent simplification pass over the complete diff. It found one behavior-preserving cleanup: consolidated the duplicated singleton key/value expansion logic in `expand_singleton_kv_heads` into one local lambda. The pass found no other safe simplifications without obscuring query/KV head semantics or reducing backend and gradient coverage. Rebuilt successfully and reran the final pytest matrix: four vmap tests passed, 14 GQA/MQA tests passed with one expected skip, and five existing memory-efficient gradient tests passed. Changed-file formatting, non-clang-tidy lint, and `git diff --check` remain clean.

### Removed the MQA expansion workaround

Confirmed through a direct low-level forward/backward comparison that the native grouped-head kernel handles `Hkv=1` without expansion. Removed `expand_singleton_kv_heads` and now pass original singleton K/V tensors into NVIDIA memory-efficient attention for both `enable_gqa=False` and `True`. The special MQA selector capability remains necessary because implicit MQA does not set `enable_gqa=True`.

ROCm memory-efficient attention still requires equal heads, so its selector no longer advertises MQA rather than retaining a zero-stride expansion workaround; the NVIDIA memory-efficient MQA regression is now explicitly skipped on ROCm. After rebuilding, the final pytest matrix remained at four vmap passes, 14 GQA/MQA passes with one expected skip, and five existing gradient passes. The 500-case fuzz matrix passed again with `Hkv=1` now exercising native indexing, Compute Sanitizer reported zero errors including the native MQA case, and the 2048-token memory reproduction remained at 64 MiB.

During this follow-up the previously reviewed diff was committed and pushed as `5b434befca4`; the three-file workaround-removal cleanup remains uncommitted for the user to amend or commit separately.

### Triaged the zero-head review comment

The workaround-removal cleanup was subsequently amended and pushed as `c82fc492ee4`. Investigated Codex inline comment `#3649426219`. Its exact claim about public `F.scaled_dot_product_attention` under an efficient-only context is not reproducible: the composite empty-output fast path returns `[B, 0, Lq, Dv]` and produces correctly shaped zero gradients before backend dispatch.

The underlying compatibility concern was nevertheless real for the directly callable `_efficient_attention_forward` operator. Before this follow-up, all-zero Q/K/V heads threw at `num_heads_kv > 0`; before the GQA change, equal-head validation admitted them and the zero-grid path returned empty output. Updated forward and backward validation to admit only the all-zero head case, return before computing `q_heads_per_kv` or split-key heuristics, and added a direct low-level forward/backward regression. The test failed before the fix and now passes. The full final selection passes four vmap tests, 15 GQA/MQA/zero-head tests with one expected skip, and five existing gradient tests. Compute Sanitizer reports zero errors for the zero-head regression.

### Addressed reviewer follow-ups

The zero-head fix was amended and pushed as `e4d28229e294`. Reviewed the five remaining Skylion007 threads one by one. Kept ROCm GQA disabled because the ROCm path selects separate CK or AOTriton implementations and only CK support was verifiable from this checkout; retained `at::empty` for dense internal CUTLASS scratch because NestedTensor inputs are unpacked before this low-level operator and subclass redispatch is undesirable there.

Changed the new dK/dV staging pointers from legacy `data_ptr()` to explicit `mutable_data_ptr()` and `static_cast`, added the requested C++20 designated-initializer TODO, and moved `out_and_lse` into the return. The initially suggested `mutable_data_ptr<scalar_t>()` form compiled but made `libtorch_cuda.so` fail to import because kernel `scalar_t` can be `cutlass::half_t`, for which TensorBase has no exported template instantiation; the final untyped mutable pointer plus cast preserves explicit mutability without that unresolved symbol. Rebuild, import, changed-file lint, `git diff --check`, and the full targeted matrix pass.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @ptrblck @msaroufim @eqy @tinglvv @nWEIdia @liangel-02 @howardzhang-cv