### PR TITLE
[RFC] [Testcase Refactoring]Make distributed replicate training tests device-agnostic

### DIFF
--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -4,7 +4,6 @@ import contextlib
 import copy
 import functools
 import itertools
-import unittest
 from collections import defaultdict
 from collections.abc import Iterable
 
@@ -57,11 +56,6 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 
 c10d_ops = torch.ops.c10d
 funcol = torch.ops.c10d_functional
-
-from torch.testing._internal.common_fsdp import get_devtype
-
-
-device_type = torch.device(get_devtype())
 
 
 class TestReplicateForwardInputs(FSDPTestMultiThread):

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -53,12 +53,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     Transformer,
     TransformerBlock,
 )
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    Capability, 
-    requires_capabilities,
-)
-
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
 c10d_ops = torch.ops.c10d
 funcol = torch.ops.c10d_functional
@@ -221,7 +216,6 @@ class TestReplicateCastAfterInitPrecision(FSDPTestMultiThread):
 
     @skip_if_lt_x_gpu(1)
     @wrapSwapTensorsTest(True)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_to_float64_after_init(self):
         """Tests that the user can cast the module to float64 after init."""
         # NOTE: Test fp64 instead of a lower precision dtype like bf16 for
@@ -436,7 +430,6 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_multi_groups(self):
         """
         Tests train parity against DDP when using multiple parameter groups for
@@ -457,7 +450,6 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_multi_group_cpu_offload_eager(self):
         """
         Tests train parity when using multiple parameter groups for
@@ -1177,7 +1169,6 @@ class TestReplicateTPTraining(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(8)
-    @requires_capabilities(Capability.distributed.dtensor)
     def test_replicate_tp(self):
         global_mesh = self.init_global_mesh()
         self.run_subtests(

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -364,6 +364,53 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
+    def test_non_root_forward_backward(self, device):
+        """
+        Tests running forward/backward through the root and then through a
+        non-root. The non-root needs to synchronize streams/queue the callback.
+        """
+        torch.manual_seed(42)
+        lin_dim = 32
+        model = nn.Sequential(*[MLP(lin_dim, torch.device("cpu")) for _ in range(3)])
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
+        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
+        for mlp in model:
+            replicate(mlp)
+        replicate(model)
+        optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=True)
+        torch.manual_seed(42 + self.rank)
+        inp = torch.randn((8, lin_dim), device=self.device_type)
+
+        ref_root_loss = ref_model(inp).sum()
+        ref_root_loss.backward()
+        for param in ref_model.parameters():
+            dist.all_reduce(param.grad)
+            param.grad.detach().div_(self.world_size)
+        ref_optim.step()
+        ref_optim.zero_grad()
+        ref_nonroot_loss = ref_model[0](inp).sum()
+        ref_nonroot_loss.backward()
+        for param in ref_model.parameters():
+            if param.grad is not None:
+                dist.all_reduce(param.grad)
+                param.grad.detach().div_(self.world_size)
+        ref_optim.step()
+
+        root_loss = model(inp).sum()
+        root_loss.backward()
+        torch.get_device_module(self.device_type)._sleep(int(100 * get_cycles_per_ms()))
+        optim.step()
+        optim.zero_grad()
+        nonroot_loss = model[0](inp).sum()
+        nonroot_loss.backward()
+        optim.step()
+
+        self.assertEqual(ref_root_loss, root_loss)
+        self.assertEqual(ref_nonroot_loss, nonroot_loss)
+        self.assertEqual(ref_model(inp).sum(), model(inp).sum())
+
+
+    @skip_if_lt_x_gpu(2)
     def test_explicit_prefetching(self, device):
         torch.manual_seed(42)
         model_args = ModelArgs(n_layers=8, dropout_p=0.0)
@@ -415,7 +462,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
 instantiate_device_type_tests(TestReplicate1DTrainingCore, globals(), except_for="cpu", allow_xpu=True)
 
 
-class TestReplicate1DTrainingCoreSleep(FSDPTest):
+class TestReplicate1DTrainingCoreNoHpu(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @property
@@ -569,52 +616,6 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
                 self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    def test_non_root_forward_backward(self, device):
-        """
-        Tests running forward/backward through the root and then through a
-        non-root. The non-root needs to synchronize streams/queue the callback.
-        """
-        torch.manual_seed(42)
-        lin_dim = 32
-        model = nn.Sequential(*[MLP(lin_dim, torch.device("cpu")) for _ in range(3)])
-        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
-        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
-        for mlp in model:
-            replicate(mlp)
-        replicate(model)
-        optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=True)
-        torch.manual_seed(42 + self.rank)
-        inp = torch.randn((8, lin_dim), device=self.device_type)
-
-        ref_root_loss = ref_model(inp).sum()
-        ref_root_loss.backward()
-        for param in ref_model.parameters():
-            dist.all_reduce(param.grad)
-            param.grad.detach().div_(self.world_size)
-        ref_optim.step()
-        ref_optim.zero_grad()
-        ref_nonroot_loss = ref_model[0](inp).sum()
-        ref_nonroot_loss.backward()
-        for param in ref_model.parameters():
-            if param.grad is not None:
-                dist.all_reduce(param.grad)
-                param.grad.detach().div_(self.world_size)
-        ref_optim.step()
-
-        root_loss = model(inp).sum()
-        root_loss.backward()
-        torch.get_device_module(self.device_type)._sleep(int(100 * get_cycles_per_ms()))
-        optim.step()
-        optim.zero_grad()
-        nonroot_loss = model[0](inp).sum()
-        nonroot_loss.backward()
-        optim.step()
-
-        self.assertEqual(ref_root_loss, root_loss)
-        self.assertEqual(ref_nonroot_loss, nonroot_loss)
-        self.assertEqual(ref_model(inp).sum(), model(inp).sum())
-
-    @skip_if_lt_x_gpu(2)
     def test_post_optim_event(self, device):
         torch.manual_seed(42)
         model_args = ModelArgs(dropout_p=0.0)
@@ -660,7 +661,7 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
             self.assertEqual(ref_loss, loss)
 
 
-instantiate_device_type_tests(TestReplicate1DTrainingCoreSleep, globals(), except_for=["cpu", "hpu"], allow_xpu=True)
+instantiate_device_type_tests(TestReplicate1DTrainingCoreNoHpu, globals(), except_for=["cpu", "hpu"], allow_xpu=True)
 
 
 class TestReplicateTrainingCompose(FSDPTest):

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -32,6 +32,7 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_device_type import Capability, requires_capabilities
 from torch.testing._internal.common_fsdp import (
     check_sharded_parity,
     compiled_fsdp_test,
@@ -43,6 +44,7 @@ from torch.testing._internal.common_fsdp import (
     patch_reduce_scatter,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     get_cycles_per_ms,
     run_tests,
     wrapSwapTensorsTest,
@@ -70,11 +72,14 @@ def _should_skip_for_accelerator():
 
 
 class TestReplicateForwardInputs(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 2
 
     @skip_if_lt_x_gpu(1)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_root_move_forward_input_to_device(self):
         device = torch.device(device_type.type, 0)
 
@@ -102,11 +107,14 @@ class TestReplicateForwardInputs(FSDPTestMultiThread):
 
 
 class TestReplicateRegisteredParams(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 4
 
     @skip_if_lt_x_gpu(1)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_param_registration_after_forward(self):
         """Tests the parameter registration after forward."""
         device = torch.device(device_type.type, 0)
@@ -156,6 +164,7 @@ class TestReplicateRegisteredParams(FSDPTestMultiThread):
         self._assert_same_params(model.parameters(), ref_model.parameters())
 
     @skip_if_lt_x_gpu(1)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_param_registration_after_backward(self):
         """Tests the parameter registration after backward."""
         device = torch.device(device_type.type, 0)
@@ -203,12 +212,15 @@ class TestReplicateRegisteredParams(FSDPTestMultiThread):
 
 
 class TestReplicateCastAfterInit(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 2
 
     @skip_if_lt_x_gpu(1)
     @wrapSwapTensorsTest(True)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_to_float64_after_init(self):
         """Tests that the user can cast the module to float64 after init."""
         if device_type.type == "npu":
@@ -261,11 +273,14 @@ class TestReplicateCastAfterInit(FSDPTestMultiThread):
 
 
 class TestReplicate1DTrainingCore(FSDPTest):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return min(8, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_single_group(self):
         """
         Tests train parity with DDP for a single FSDP group when sharding
@@ -311,10 +326,9 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(
-        _should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU"
-    )
+    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_multi_groups(self):
         """
         Tests train parity against DDP when using multiple parameter groups for
@@ -335,9 +349,8 @@ class TestReplicate1DTrainingCore(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(
-        _should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU"
-    )
+    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_multi_group_cpu_offload_eager(self):
         """
         Tests train parity when using multiple parameter groups for
@@ -465,9 +478,8 @@ class TestReplicate1DTrainingCore(FSDPTest):
                 self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(
-        _should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU"
-    )
+    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_non_root_forward_backward(self):
         """
         Tests running forward/backward through the root and then through a
@@ -514,6 +526,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
         self.assertEqual(ref_model(inp).sum(), model(inp).sum())
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_multi_forward_module(self):
         """
         Tests parity when running a module that participates multiple
@@ -563,6 +576,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_explicit_prefetching(self):
         torch.manual_seed(42)
         model_args = ModelArgs(n_layers=8, dropout_p=0.0)
@@ -611,9 +625,8 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(
-        _should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU"
-    )
+    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_post_optim_event(self):
         torch.manual_seed(42)
         model_args = ModelArgs(dropout_p=0.0)
@@ -664,6 +677,8 @@ class TestReplicate1DTrainingCore(FSDPTest):
 
 
 class TestReplicateTrainingCompose(FSDPTest):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         # Since these tests run with a larger transformer model, they may see
@@ -672,6 +687,7 @@ class TestReplicateTrainingCompose(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_with_activation_checkpointing(self):
         """
         Tests train parity against DDP when composing with activation
@@ -796,11 +812,14 @@ class TestReplicateTrainingCompose(FSDPTest):
 
 
 class TestReplicateSharedParams(FSDPTest):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return min(4, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_with_shared_params(self):
         self.run_subtests(
             {
@@ -850,11 +869,14 @@ class TestReplicateSharedParams(FSDPTest):
 
 
 class TestReplicateGradientAccumulation(FSDPTest):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return min(4, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_gradient_accumulation(self):
         """
         Tests gradient accumulation with/without gradient reduction and
@@ -1013,6 +1035,7 @@ class TestReplicateGradientAccumulation(FSDPTest):
                 _optim.zero_grad(set_to_none=(iter_idx % 2))
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_1f1b_microbatching(self):
         self.run_subtests(
             {
@@ -1082,11 +1105,14 @@ class TestReplicateGradientAccumulation(FSDPTest):
 
 
 class TestReplicateCustomForwardMethod(FSDPTest):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return min(torch.get_device_module(device_type).device_count(), 2)
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(Capability.distributed.fsdp)
     def test_register_fsdp_forward_method(self):
         class VisionTransformer(nn.Module):
             def __init__(self) -> None:
@@ -1130,6 +1156,8 @@ class TestReplicateCustomForwardMethod(FSDPTest):
 
 
 class TestReplicateTPTraining(FSDPTest):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return min(4, torch.get_device_module(device_type).device_count())
@@ -1142,6 +1170,7 @@ class TestReplicateTPTraining(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(8)
+    @requires_capabilities(Capability.distributed.fsdp, Capability.distributed.dtensor)
     def test_replicate_tp(self):
         global_mesh = self.init_global_mesh()
         self.run_subtests(

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -475,6 +475,7 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
         delay_before_optim: bool,
         unshard_async_op: bool,
     ):
+        # Only test individual delays or all four delays to save test time
         if (
             delay_after_forward
             + delay_before_all_gather

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -311,7 +311,9 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
+    @unittest.skipIf(
+        _should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU"
+    )
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
     def test_train_parity_multi_groups(self):
         """
@@ -333,7 +335,9 @@ class TestReplicate1DTrainingCore(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
+    @unittest.skipIf(
+        _should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU"
+    )
     def test_train_parity_multi_group_cpu_offload_eager(self):
         """
         Tests train parity when using multiple parameter groups for
@@ -461,7 +465,9 @@ class TestReplicate1DTrainingCore(FSDPTest):
                 self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
+    @unittest.skipIf(
+        _should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU"
+    )
     def test_non_root_forward_backward(self):
         """
         Tests running forward/backward through the root and then through a
@@ -605,7 +611,9 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
+    @unittest.skipIf(
+        _should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU"
+    )
     def test_post_optim_event(self):
         torch.manual_seed(42)
         model_args = ModelArgs(dropout_p=0.0)

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -72,8 +72,8 @@ class TestReplicateForwardInputs(FSDPTestMultiThread):
         return 2
 
     @skip_if_lt_x_gpu(1)
-    def test_root_move_forward_input_to_device(self):
-        device = torch.device(device_type.type, 0)
+    def test_root_move_forward_input_to_device(self, device):
+        device = torch.device(device)
 
         class ParamlessModule(nn.Module):
             def forward(self, x: torch.Tensor, ys: tuple[torch.Tensor, ...]):
@@ -98,7 +98,7 @@ class TestReplicateForwardInputs(FSDPTestMultiThread):
         model(x, ys)
 
 
-instantiate_device_type_tests(TestReplicateForwardInputs, globals(), except_for="cpu")
+instantiate_device_type_tests(TestReplicateForwardInputs, globals(), except_for="cpu", allow_xpu=True)
 
 
 class TestReplicateRegisteredParams(FSDPTestMultiThread):
@@ -109,9 +109,9 @@ class TestReplicateRegisteredParams(FSDPTestMultiThread):
         return 4
 
     @skip_if_lt_x_gpu(1)
-    def test_param_registration_after_forward(self):
+    def test_param_registration_after_forward(self, device):
         """Tests the parameter registration after forward."""
-        device = torch.device(device_type.type, 0)
+        device = torch.device(self.device_type)
         # Single Replicate group
         torch.manual_seed(42)
         model = MLP(3, device)
@@ -121,7 +121,7 @@ class TestReplicateRegisteredParams(FSDPTestMultiThread):
             dist.broadcast(param, src=0)
         ref_model = copy.deepcopy(model)
         replicate(model)  # root only
-        inp = torch.randn((2, 3), device=device_type.type)
+        inp = torch.randn((2, 3), device=self.device_type)
         self._assert_dtensor_params(model.parameters())
         self._assert_same_params(model.parameters(), ref_model.parameters())
         model(inp)
@@ -158,13 +158,13 @@ class TestReplicateRegisteredParams(FSDPTestMultiThread):
         self._assert_same_params(model.parameters(), ref_model.parameters())
 
     @skip_if_lt_x_gpu(1)
-    def test_param_registration_after_backward(self):
+    def test_param_registration_after_backward(self, device):
         """Tests the parameter registration after backward."""
-        device = torch.device(device_type.type, 0)
+        device = torch.device(self.device_type)
         # Single Replicate group
         model = MLP(8, device)
         replicate(model)  # root only
-        inp = torch.randn((2, 8), device=device_type.type)
+        inp = torch.randn((2, 8), device=self.device_type)
         self._assert_dtensor_params(model.parameters())
         model(inp).sum().backward()
         self._assert_dtensor_params(model.parameters())
@@ -204,7 +204,7 @@ class TestReplicateRegisteredParams(FSDPTestMultiThread):
             self.assertEqual(param, ref_param)
 
 
-instantiate_device_type_tests(TestReplicateRegisteredParams, globals(), except_for="cpu")
+instantiate_device_type_tests(TestReplicateRegisteredParams, globals(), except_for="cpu", allow_xpu=True)
 
 
 class TestReplicateCastAfterInitPrecision(FSDPTestMultiThread):
@@ -216,13 +216,13 @@ class TestReplicateCastAfterInitPrecision(FSDPTestMultiThread):
 
     @skip_if_lt_x_gpu(1)
     @wrapSwapTensorsTest(True)
-    def test_to_float64_after_init(self):
+    def test_to_float64_after_init(self, device):
         """Tests that the user can cast the module to float64 after init."""
         # NOTE: Test fp64 instead of a lower precision dtype like bf16 for
         # better numerics. The important part is changing the dtype.
 
         torch.manual_seed(42)
-        mlp_dim, device, dtype = 4, device_type, torch.float64
+        mlp_dim, device, dtype = 4, torch.device(self.device_type), torch.float64
         model = MLP(mlp_dim, device=device)
         for param in model.parameters():
             dist.broadcast(param, src=0)
@@ -239,7 +239,7 @@ class TestReplicateCastAfterInitPrecision(FSDPTestMultiThread):
         optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=True)
         check_sharded_parity(self, ref_model, model)
         torch.manual_seed(42 + self.rank + 1)
-        inp = torch.randn((2, mlp_dim), device=device_type.type, dtype=dtype)
+        inp = torch.randn((2, mlp_dim), device=self.device_type, dtype=dtype)
         for iter_idx in range(10):
             losses: list[torch.Tensor] = []
             for _model in (ref_model, model):
@@ -265,7 +265,7 @@ class TestReplicateCastAfterInitPrecision(FSDPTestMultiThread):
                 _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
 
 
-instantiate_device_type_tests(TestReplicateCastAfterInitPrecision, globals(), except_for="cpu")
+instantiate_device_type_tests(TestReplicateCastAfterInitPrecision, globals(), except_for="cpu", allow_xpu=True)
 
 
 class TestReplicate1DTrainingCore(FSDPTest):
@@ -273,10 +273,10 @@ class TestReplicate1DTrainingCore(FSDPTest):
 
     @property
     def world_size(self) -> int:
-        return min(8, torch.get_device_module(device_type).device_count())
+        return min(8, torch.get_device_module(self.device_type).device_count())
 
     @skip_if_lt_x_gpu(2)
-    def test_train_parity_single_group(self):
+    def test_train_parity_single_group(self, device):
         """
         Tests train parity with DDP for a single FSDP group when sharding
         parameters on dim-0.
@@ -297,13 +297,13 @@ class TestReplicate1DTrainingCore(FSDPTest):
         model = nn.Sequential(
             nn.Linear(*lin_shapes[0]), nn.ReLU(), nn.Linear(*lin_shapes[1])
         )
-        ref_model = copy.deepcopy(model).to(device_type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
 
         replicate(model)
         optim = torch.optim.Adam(model.parameters(), lr=1e-2)
         torch.manual_seed(42 + self.rank + 1)
-        inp = (torch.randn((4, lin_shapes[0][0]), device=device_type.type),)
+        inp = (torch.randn((4, lin_shapes[0][0]), device=self.device_type),)
         for iter_idx in range(10):
             losses: list[torch.Tensor] = []
             for _model in (ref_model, model):
@@ -321,7 +321,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    def test_multi_forward_module(self):
+    def test_multi_forward_module(self, device):
         """
         Tests parity when running a module that participates multiple
         times in forward.
@@ -342,8 +342,8 @@ class TestReplicate1DTrainingCore(FSDPTest):
                 return self.outer(i + j)
 
         torch.manual_seed(42)
-        model = MultiForwardModule(device=device_type.type)
-        ref_model = copy.deepcopy(model).to(device_type)
+        model = MultiForwardModule(device=self.device_type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
 
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
         replicate(model.inner)
@@ -351,7 +351,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
         optim = torch.optim.Adam(model.parameters(), lr=1e-2)
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randn((32, 4), device=device_type.type)
+        inp = torch.randn((32, 4), device=self.device_type)
         for iter_idx in range(10):
             losses: list[torch.Tensor] = []
             for _model in (ref_model, model):
@@ -370,11 +370,11 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    def test_explicit_prefetching(self):
+    def test_explicit_prefetching(self, device):
         torch.manual_seed(42)
         model_args = ModelArgs(n_layers=8, dropout_p=0.0)
         model = Transformer(model_args)
-        ref_model = copy.deepcopy(model).to(device_type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
         ref_optim = torch.optim.AdamW(ref_model.parameters(), lr=1e-2)
 
         for layer in itertools.chain(model.layers, [model]):
@@ -398,7 +398,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
             layer.set_modules_to_backward_prefetch(layers_to_prefetch)
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 8), device=device_type.type)
+        inp = torch.randint(0, model_args.vocab_size, (2, 8), device=self.device_type)
         for _ in range(10):
             losses: list[torch.Tensor] = []
 
@@ -418,7 +418,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
 
-instantiate_device_type_tests(TestReplicate1DTrainingCore, globals(), except_for="cpu")
+instantiate_device_type_tests(TestReplicate1DTrainingCore, globals(), except_for="cpu", allow_xpu=True)
 
 
 class TestReplicate1DTrainingCoreSleep(FSDPTest):
@@ -426,11 +426,11 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
 
     @property
     def world_size(self) -> int:
-        return min(8, torch.get_device_module(device_type).device_count())
+        return min(8, torch.get_device_module(self.device_type).device_count())
 
     @skip_if_lt_x_gpu(2)
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
-    def test_train_parity_multi_groups(self):
+    def test_train_parity_multi_groups(self, device):
         """
         Tests train parity against DDP when using multiple parameter groups for
         communication (for communication and computation overlap plus memory
@@ -438,7 +438,7 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
         """
         self.run_subtests(
             {
-                "test_device_type": [device_type.type],
+                "test_device_type": [self.device_type],
                 "offload_policy": [OffloadPolicy()],
                 "delay_after_forward": [False, True],
                 "delay_before_all_gather": [False, True],
@@ -450,7 +450,7 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2)
-    def test_train_parity_multi_group_cpu_offload_eager(self):
+    def test_train_parity_multi_group_cpu_offload_eager(self, device):
         """
         Tests train parity when using multiple parameter groups for
         communication and CPU offloading.
@@ -461,7 +461,7 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
                     CPUOffloadPolicy(pin_memory=True),
                     CPUOffloadPolicy(pin_memory=False),
                 ],
-                "test_device_type": [device_type.type],
+                "test_device_type": [self.device_type],
                 "delay_after_forward": [False, True],
                 "delay_before_all_gather": [False, True],
                 "delay_before_reduce_scatter": [False, True],
@@ -499,7 +499,7 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
             dropout_p=0,
         )
         model = Transformer(model_args)
-        ref_model = copy.deepcopy(model).to(device_type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
 
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
         mesh = init_device_mesh(
@@ -525,13 +525,13 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
         orig_reduce_scatter = dist.reduce_scatter_single
 
         def delayed_all_gather(*args, **kwargs):
-            torch.get_device_module(device_type)._sleep(
+            torch.get_device_module(self.device_type)._sleep(
                 int(delay_in_ms * get_cycles_per_ms())
             )
             return orig_all_gather(*args, **kwargs)
 
         def delayed_reduce_scatter(*args, **kwargs):
-            torch.get_device_module(device_type)._sleep(
+            torch.get_device_module(self.device_type)._sleep(
                 int(delay_in_ms * get_cycles_per_ms())
             )
             return orig_reduce_scatter(*args, **kwargs)
@@ -549,17 +549,17 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
         )
         with patch_all_gather_ctx, patch_reduce_scatter_ctx:
             for iter_idx in range(10):
-                inp = torch.randint(0, vocab_size, (3, 64), device=device_type)
+                inp = torch.randint(0, vocab_size, (3, 64), device=self.device_type)
                 losses: list[torch.Tensor] = []
                 for _model, _optim in ((ref_model, ref_optim), (model, optim)):
                     losses.append(_model(inp).sum())
                     if _model is model and delay_after_forward:
-                        torch.get_device_module(device_type)._sleep(
+                        torch.get_device_module(self.device_type)._sleep(
                             int(delay_in_ms * get_cycles_per_ms())
                         )
                     losses[-1].backward()
                     if _model is model and delay_before_optim:
-                        torch.get_device_module(device_type)._sleep(
+                        torch.get_device_module(self.device_type)._sleep(
                             int(delay_in_ms * get_cycles_per_ms())
                         )
 
@@ -574,7 +574,7 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
                 self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    def test_non_root_forward_backward(self):
+    def test_non_root_forward_backward(self, device):
         """
         Tests running forward/backward through the root and then through a
         non-root. The non-root needs to synchronize streams/queue the callback.
@@ -582,14 +582,14 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
         torch.manual_seed(42)
         lin_dim = 32
         model = nn.Sequential(*[MLP(lin_dim, torch.device("cpu")) for _ in range(3)])
-        ref_model = copy.deepcopy(model).to(device_type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
         for mlp in model:
             replicate(mlp)
         replicate(model)
         optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=True)
         torch.manual_seed(42 + self.rank)
-        inp = torch.randn((8, lin_dim), device=device_type)
+        inp = torch.randn((8, lin_dim), device=self.device_type)
 
         ref_root_loss = ref_model(inp).sum()
         ref_root_loss.backward()
@@ -608,7 +608,7 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
 
         root_loss = model(inp).sum()
         root_loss.backward()
-        torch.get_device_module(device_type)._sleep(int(100 * get_cycles_per_ms()))
+        torch.get_device_module(self.device_type)._sleep(int(100 * get_cycles_per_ms()))
         optim.step()
         optim.zero_grad()
         nonroot_loss = model[0](inp).sum()
@@ -620,11 +620,11 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
         self.assertEqual(ref_model(inp).sum(), model(inp).sum())
 
     @skip_if_lt_x_gpu(2)
-    def test_post_optim_event(self):
+    def test_post_optim_event(self, device):
         torch.manual_seed(42)
         model_args = ModelArgs(dropout_p=0.0)
         model = Transformer(model_args)
-        ref_model = copy.deepcopy(model).to(device_type.type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
         ref_optim = torch.optim.AdamW(ref_model.parameters(), lr=1e-2)
         for layer in itertools.chain(model.layers, [model]):
             replicate(layer)
@@ -634,14 +634,14 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
             fsdp_module: FSDPModule, opt: torch.optim.Optimizer, args, kwargs
         ) -> None:
             post_optim_event = (
-                torch.get_device_module(device_type).current_stream().record_event()
+                torch.get_device_module(self.device_type).current_stream().record_event()
             )
             fsdp_module.set_post_optim_event(post_optim_event)
 
         optim.register_step_post_hook(functools.partial(step_post_hook, model))
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 8), device=device_type.type)
+        inp = torch.randint(0, model_args.vocab_size, (2, 8), device=self.device_type)
         ref_losses: list[torch.Tensor] = []
         losses: list[torch.Tensor] = []
         for _ in range(10):
@@ -660,12 +660,12 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
             losses.append(model(inp).sum())
             losses[-1].backward()
             optim.step()
-            torch.get_device_module(device_type)._sleep(int(25 * get_cycles_per_ms()))
+            torch.get_device_module(self.device_type)._sleep(int(25 * get_cycles_per_ms()))
         for ref_loss, loss in zip(ref_losses, losses):
             self.assertEqual(ref_loss, loss)
 
 
-instantiate_device_type_tests(TestReplicate1DTrainingCoreSleep, globals(), except_for=["cpu", "hpu"])
+instantiate_device_type_tests(TestReplicate1DTrainingCoreSleep, globals(), except_for=["cpu", "hpu"], allow_xpu=True)
 
 
 class TestReplicateTrainingCompose(FSDPTest):
@@ -675,11 +675,11 @@ class TestReplicateTrainingCompose(FSDPTest):
     def world_size(self) -> int:
         # Since these tests run with a larger transformer model, they may see
         # some numeric drift with >2 GPUs
-        return min(torch.get_device_module(device_type).device_count(), 2)
+        return min(torch.get_device_module(self.device_type).device_count(), 2)
 
     @skip_if_lt_x_gpu(2)
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
-    def test_train_parity_with_activation_checkpointing(self):
+    def test_train_parity_with_activation_checkpointing(self, device):
         """
         Tests train parity against DDP when composing with activation
         checkpointing.
@@ -688,7 +688,7 @@ class TestReplicateTrainingCompose(FSDPTest):
             {
                 "checkpoint_impl": ["composable", "utils", "wrapper"],
                 "module_grouping": ["block", "mem_eff", "mem_eff_weight_tied"],
-                "test_device_type": [device_type.type],
+                "test_device_type": [self.device_type],
             },
             self._test_train_parity_with_activation_checkpointing,
         )
@@ -708,7 +708,7 @@ class TestReplicateTrainingCompose(FSDPTest):
             return
         torch.manual_seed(42)
         vocab_size = 1024
-        with torch.device(device_type):
+        with torch.device(self.device_type):
             model_args = ModelArgs(
                 n_layers=3,
                 n_heads=4,
@@ -722,7 +722,7 @@ class TestReplicateTrainingCompose(FSDPTest):
                 weight_tying=module_grouping != "mem_eff",
             )
             model = Transformer(model_args)
-        ref_model = copy.deepcopy(model).to(device_type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
 
         # Apply activation checkpointing
@@ -772,7 +772,7 @@ class TestReplicateTrainingCompose(FSDPTest):
         torch.manual_seed(42 + self.rank)
         # Reuse the same input across iterations to avoid loss explosion from
         # trying to learn from random inputs
-        inp = torch.randint(0, vocab_size, (3, 64), device=device_type.type)
+        inp = torch.randint(0, vocab_size, (3, 64), device=self.device_type)
         check_sharded_parity(
             self, ref_model, model, prefixes_to_ignore=prefixes_to_ignore
         )
@@ -802,7 +802,7 @@ class TestReplicateTrainingCompose(FSDPTest):
                 )
 
 
-instantiate_device_type_tests(TestReplicateTrainingCompose, globals(), except_for="cpu")
+instantiate_device_type_tests(TestReplicateTrainingCompose, globals(), except_for="cpu", allow_xpu=True)
 
 
 class TestReplicateSharedParams(FSDPTest):
@@ -810,10 +810,10 @@ class TestReplicateSharedParams(FSDPTest):
 
     @property
     def world_size(self) -> int:
-        return min(4, torch.get_device_module(device_type).device_count())
+        return min(4, torch.get_device_module(self.device_type).device_count())
 
     @skip_if_lt_x_gpu(2)
-    def test_train_parity_with_shared_params(self):
+    def test_train_parity_with_shared_params(self, device):
         self.run_subtests(
             {
                 "use_activation_checkpointing": [False, True],
@@ -828,7 +828,7 @@ class TestReplicateSharedParams(FSDPTest):
         torch.manual_seed(42)
         model_args = ModelArgs(n_layers=3, dropout_p=0.0, weight_tying=True)
         model = Transformer(model_args)
-        ref_model = copy.deepcopy(model).to(device_type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
 
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
         for module in model.modules():
@@ -842,7 +842,7 @@ class TestReplicateSharedParams(FSDPTest):
         torch.manual_seed(42 + self.rank + 1)
         for iter_idx in range(10):
             inp = torch.randint(
-                0, model_args.vocab_size, (2, 16), device=device_type.type
+                0, model_args.vocab_size, (2, 16), device=self.device_type
             )
             losses: list[torch.Tensor] = []
             for _model in (ref_model, model):
@@ -861,7 +861,7 @@ class TestReplicateSharedParams(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
 
-instantiate_device_type_tests(TestReplicateSharedParams, globals(), except_for="cpu")
+instantiate_device_type_tests(TestReplicateSharedParams, globals(), except_for="cpu", allow_xpu=True)
 
 
 class TestReplicateGradientAccumulation(FSDPTest):
@@ -869,10 +869,10 @@ class TestReplicateGradientAccumulation(FSDPTest):
 
     @property
     def world_size(self) -> int:
-        return min(4, torch.get_device_module(device_type).device_count())
+        return min(4, torch.get_device_module(self.device_type).device_count())
 
     @skip_if_lt_x_gpu(2)
-    def test_gradient_accumulation(self):
+    def test_gradient_accumulation(self, device):
         """
         Tests gradient accumulation with/without gradient reduction and
         with/without resharding after backward.
@@ -880,7 +880,7 @@ class TestReplicateGradientAccumulation(FSDPTest):
 
         replicate_size = self.world_size
         meshes = init_device_mesh(
-            device_type.type,
+            self.device_type,
             (replicate_size,),
             mesh_dim_names=("replicate",),
         )
@@ -935,7 +935,7 @@ class TestReplicateGradientAccumulation(FSDPTest):
         modules = [nn.Linear(lin_dim, lin_dim)]
         modules.extend(MLP(lin_dim) for _ in range(num_mlps))
         model = nn.Sequential(*modules)
-        ref_model = copy.deepcopy(model).to(device_type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
         replicate_fn = functools.partial(
             replicate,
             mesh=mesh,
@@ -977,7 +977,7 @@ class TestReplicateGradientAccumulation(FSDPTest):
             for microbatch_idx in range(num_microbatches):
                 is_last_microbatch = microbatch_idx == num_microbatches - 1
                 set_backward_flags(model, is_last_microbatch)
-                inp = torch.randn(batch_size, lin_dim, device=device_type.type)
+                inp = torch.randn(batch_size, lin_dim, device=self.device_type)
                 losses: list[torch.Tensor] = []
                 for _model in (ref_model, model):
                     with CommDebugMode() as comm_mode:
@@ -1030,7 +1030,7 @@ class TestReplicateGradientAccumulation(FSDPTest):
                 _optim.zero_grad(set_to_none=(iter_idx % 2))
 
     @skip_if_lt_x_gpu(2)
-    def test_1f1b_microbatching(self):
+    def test_1f1b_microbatching(self, device):
         self.run_subtests(
             {
                 "use_explicit_unshard": [False, True],
@@ -1045,7 +1045,7 @@ class TestReplicateGradientAccumulation(FSDPTest):
         torch.manual_seed(42)
         model_args = ModelArgs(dropout_p=0.0)
         model = Transformer(model_args)
-        ref_model = copy.deepcopy(model).to(device_type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
         ref_optim = torch.optim.AdamW(ref_model.parameters(), lr=1e-2)
         for module in model.modules():
             if isinstance(module, TransformerBlock):
@@ -1061,7 +1061,7 @@ class TestReplicateGradientAccumulation(FSDPTest):
                 0,
                 model_args.vocab_size,
                 (local_batch_size, 16),
-                device=device_type.type,
+                device=self.device_type,
             )
             for _ in range(num_microbatches)
         ]
@@ -1098,7 +1098,7 @@ class TestReplicateGradientAccumulation(FSDPTest):
         check_sharded_parity(self, ref_model, model)
 
 
-instantiate_device_type_tests(TestReplicateGradientAccumulation, globals(), except_for="cpu")
+instantiate_device_type_tests(TestReplicateGradientAccumulation, globals(), except_for="cpu", allow_xpu=True)
 
 
 class TestReplicateCustomForwardMethod(FSDPTest):
@@ -1106,10 +1106,10 @@ class TestReplicateCustomForwardMethod(FSDPTest):
 
     @property
     def world_size(self) -> int:
-        return min(torch.get_device_module(device_type).device_count(), 2)
+        return min(torch.get_device_module(self.device_type).device_count(), 2)
 
     @skip_if_lt_x_gpu(2)
-    def test_register_fsdp_forward_method(self):
+    def test_register_fsdp_forward_method(self, device):
         class VisionTransformer(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -1133,14 +1133,14 @@ class TestReplicateCustomForwardMethod(FSDPTest):
 
         torch.manual_seed(42)
         model = Model()
-        ref_model = copy.deepcopy(model).to(device_type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
         replicate(model.vit)
         replicate(model.projector)
         replicate(model)
         register_fsdp_forward_method(model.vit, "forward_features")
 
         torch.manual_seed(42 + self.rank + 1)
-        inp = torch.randn(4, 3, 224, 224, device=device_type.type)
+        inp = torch.randn(4, 3, 224, 224, device=self.device_type)
         ref_loss = ref_model(inp).sum()
         loss = model(inp).sum()
         self.assertEqual(ref_loss, loss)
@@ -1151,7 +1151,7 @@ class TestReplicateCustomForwardMethod(FSDPTest):
         check_sharded_parity(self, ref_model, model)
 
 
-instantiate_device_type_tests(TestReplicateCustomForwardMethod, globals(), except_for="cpu")
+instantiate_device_type_tests(TestReplicateCustomForwardMethod, globals(), except_for="cpu", allow_xpu=True)
 
 
 class TestReplicateTPTraining(FSDPTest):
@@ -1159,17 +1159,17 @@ class TestReplicateTPTraining(FSDPTest):
 
     @property
     def world_size(self) -> int:
-        return min(4, torch.get_device_module(device_type).device_count())
+        return min(4, torch.get_device_module(self.device_type).device_count())
 
     def init_global_mesh(self) -> DeviceMesh:
         return init_device_mesh(
-            device_type.type,
+            self.device_type,
             (2, 2),
             mesh_dim_names=("dp_replicate", "tp"),
         )
 
     @skip_if_lt_x_gpu(8)
-    def test_replicate_tp(self):
+    def test_replicate_tp(self, device):
         global_mesh = self.init_global_mesh()
         self.run_subtests(
             {
@@ -1192,7 +1192,7 @@ class TestReplicateTPTraining(FSDPTest):
 
         torch.manual_seed(42)
         model = MLPStack(mlp_dim)
-        ref_model = copy.deepcopy(model).to(device_type)
+        ref_model = copy.deepcopy(model).to(torch.device(self.device_type))
 
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2, foreach=foreach)
 
@@ -1226,9 +1226,8 @@ class TestReplicateTPTraining(FSDPTest):
         optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=foreach)
 
         torch.manual_seed(42 + dp_pg.rank() + 1)
-        device = device_type
         for iter_idx in range(10):
-            inp = torch.randn((8, mlp_dim), device=device)
+            inp = torch.randn((8, mlp_dim), device=self.device_type)
             losses: list[torch.Tensor] = []
             for _model in (ref_model, model):
                 losses.append(_model(inp).sum())
@@ -1251,7 +1250,7 @@ class TestReplicateTPTraining(FSDPTest):
             self.assertEqual(p.device_mesh.mesh_dim_names, ("dp_replicate", "tp"))
 
 
-instantiate_device_type_tests(TestReplicateTPTraining, globals(), except_for="cpu")
+instantiate_device_type_tests(TestReplicateTPTraining, globals(), except_for="cpu", allow_xpu=True)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -45,7 +45,6 @@ from torch.testing._internal.common_fsdp import (
 from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
     run_tests,
-    TEST_HPU,
     wrapSwapTensorsTest,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -62,6 +61,12 @@ from torch.testing._internal.common_fsdp import get_devtype
 
 
 device_type = torch.device(get_devtype())
+
+
+def _should_skip_for_accelerator():
+    acc = torch.accelerator.current_accelerator()
+    return acc is not None and acc.type in ("npu", "hpu")
+
 
 
 class TestReplicateForwardInputs(FSDPTestMultiThread):
@@ -206,6 +211,8 @@ class TestReplicateCastAfterInit(FSDPTestMultiThread):
     @wrapSwapTensorsTest(True)
     def test_to_float64_after_init(self):
         """Tests that the user can cast the module to float64 after init."""
+        if device_type.type == "npu":
+            self.skipTest("NPU backend does not fully support DTensor.to() for dtype conversion")
         # NOTE: Test fp64 instead of a lower precision dtype like bf16 for
         # better numerics. The important part is changing the dtype.
 
@@ -304,7 +311,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(TEST_HPU, "Sleep kernel not supported for HPU")
+    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
     def test_train_parity_multi_groups(self):
         """
@@ -326,7 +333,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(TEST_HPU, "sleep kernel not supported on HPU")
+    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
     def test_train_parity_multi_group_cpu_offload_eager(self):
         """
         Tests train parity when using multiple parameter groups for
@@ -454,6 +461,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
                 self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
     def test_non_root_forward_backward(self):
         """
         Tests running forward/backward through the root and then through a
@@ -597,7 +605,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(TEST_HPU, "Sleep is not supported on HPU")
+    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
     def test_post_optim_event(self):
         torch.manual_seed(42)
         model_args = ModelArgs(dropout_p=0.0)

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -32,7 +32,6 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_device_type import Capability, requires_capabilities
 from torch.testing._internal.common_fsdp import (
     check_sharded_parity,
     compiled_fsdp_test,
@@ -44,15 +43,20 @@ from torch.testing._internal.common_fsdp import (
     patch_reduce_scatter,
 )
 from torch.testing._internal.common_utils import (
-    HardwareClassification,
     get_cycles_per_ms,
     run_tests,
     wrapSwapTensorsTest,
+    HardwareClassification,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
     TransformerBlock,
+)
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    Capability, 
+    requires_capabilities,
 )
 
 
@@ -65,21 +69,14 @@ from torch.testing._internal.common_fsdp import get_devtype
 device_type = torch.device(get_devtype())
 
 
-def _should_skip_for_accelerator():
-    acc = torch.accelerator.current_accelerator()
-    return acc is not None and acc.type in ("npu", "hpu")
-
-
-
 class TestReplicateForwardInputs(FSDPTestMultiThread):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
         return 2
 
     @skip_if_lt_x_gpu(1)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_root_move_forward_input_to_device(self):
         device = torch.device(device_type.type, 0)
 
@@ -106,15 +103,17 @@ class TestReplicateForwardInputs(FSDPTestMultiThread):
         model(x, ys)
 
 
+instantiate_device_type_tests(TestReplicateForwardInputs, globals(), except_for="cpu")
+
+
 class TestReplicateRegisteredParams(FSDPTestMultiThread):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
         return 4
 
     @skip_if_lt_x_gpu(1)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_param_registration_after_forward(self):
         """Tests the parameter registration after forward."""
         device = torch.device(device_type.type, 0)
@@ -164,7 +163,6 @@ class TestReplicateRegisteredParams(FSDPTestMultiThread):
         self._assert_same_params(model.parameters(), ref_model.parameters())
 
     @skip_if_lt_x_gpu(1)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_param_registration_after_backward(self):
         """Tests the parameter registration after backward."""
         device = torch.device(device_type.type, 0)
@@ -211,8 +209,11 @@ class TestReplicateRegisteredParams(FSDPTestMultiThread):
             self.assertEqual(param, ref_param)
 
 
-class TestReplicateCastAfterInit(FSDPTestMultiThread):
-    hw_classification = HardwareClassification.GENERIC
+instantiate_device_type_tests(TestReplicateRegisteredParams, globals(), except_for="cpu")
+
+
+class TestReplicateCastAfterInitPrecision(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
@@ -223,8 +224,6 @@ class TestReplicateCastAfterInit(FSDPTestMultiThread):
     @requires_capabilities(Capability.distributed.fsdp)
     def test_to_float64_after_init(self):
         """Tests that the user can cast the module to float64 after init."""
-        if device_type.type == "npu":
-            self.skipTest("NPU backend does not fully support DTensor.to() for dtype conversion")
         # NOTE: Test fp64 instead of a lower precision dtype like bf16 for
         # better numerics. The important part is changing the dtype.
 
@@ -272,15 +271,17 @@ class TestReplicateCastAfterInit(FSDPTestMultiThread):
                 _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
 
 
+instantiate_device_type_tests(TestReplicateCastAfterInitPrecision, globals(), except_for=["cpu", "npu"])
+
+
 class TestReplicate1DTrainingCore(FSDPTest):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
         return min(8, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_single_group(self):
         """
         Tests train parity with DDP for a single FSDP group when sharding
@@ -326,7 +327,114 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
+    def test_multi_forward_module(self):
+        """
+        Tests parity when running a module that participates multiple
+        times in forward.
+        """
+
+        self._test_multi_forward_module()
+
+    def _test_multi_forward_module(self):
+        class MultiForwardModule(nn.Module):
+            def __init__(self, device: torch.device):
+                super().__init__()
+                self.inner = nn.Linear(4, 4, device=device)
+                self.outer = nn.Linear(4, 5, device=device)
+
+            def forward(self, x):
+                i = self.inner(x)
+                j = self.inner(x)
+                return self.outer(i + j)
+
+        torch.manual_seed(42)
+        model = MultiForwardModule(device=device_type.type)
+        ref_model = copy.deepcopy(model).to(device_type)
+
+        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
+        replicate(model.inner)
+        replicate(model)
+        optim = torch.optim.Adam(model.parameters(), lr=1e-2)
+
+        torch.manual_seed(42 + self.rank)
+        inp = torch.randn((32, 4), device=device_type.type)
+        for iter_idx in range(10):
+            losses: list[torch.Tensor] = []
+            for _model in (ref_model, model):
+                losses.append(_model(inp).sum())
+                losses[-1].backward()
+
+            for param in ref_model.parameters():
+                if param.grad is not None:
+                    dist.all_reduce(param.grad)
+                    param.grad.div_(self.world_size)
+
+            for _optim in (ref_optim, optim):
+                _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+                _optim.step()
+
+            self.assertEqual(losses[0], losses[1])
+
+    @skip_if_lt_x_gpu(2)
+    def test_explicit_prefetching(self):
+        torch.manual_seed(42)
+        model_args = ModelArgs(n_layers=8, dropout_p=0.0)
+        model = Transformer(model_args)
+        ref_model = copy.deepcopy(model).to(device_type)
+        ref_optim = torch.optim.AdamW(ref_model.parameters(), lr=1e-2)
+
+        for layer in itertools.chain(model.layers, [model]):
+            replicate(layer)
+        optim = torch.optim.AdamW(model.parameters(), lr=1e-2)
+
+        num_to_forward_prefetch = num_to_backward_prefetch = 2
+        for i, layer in enumerate(model.layers):
+            if i >= len(model.layers) - num_to_forward_prefetch:
+                break
+            layers_to_prefetch = [
+                model.layers[i + j] for j in range(1, num_to_forward_prefetch + 1)
+            ]
+            layer.set_modules_to_forward_prefetch(layers_to_prefetch)
+        for i, layer in enumerate(model.layers):
+            if i < num_to_backward_prefetch:
+                continue
+            layers_to_prefetch = [
+                model.layers[i - j] for j in range(1, num_to_backward_prefetch + 1)
+            ]
+            layer.set_modules_to_backward_prefetch(layers_to_prefetch)
+
+        torch.manual_seed(42 + self.rank)
+        inp = torch.randint(0, model_args.vocab_size, (2, 8), device=device_type.type)
+        for _ in range(10):
+            losses: list[torch.Tensor] = []
+
+            for _model in (ref_model, model):
+                losses.append(_model(inp).sum())
+                losses[-1].backward()
+
+            for param in ref_model.parameters():
+                if param.grad is not None:
+                    dist.all_reduce(param.grad)
+                    param.grad.div_(self.world_size)
+
+            for _optim in (ref_optim, optim):
+                _optim.zero_grad()
+                _optim.step()
+
+            self.assertEqual(losses[0], losses[1])
+
+
+instantiate_device_type_tests(TestReplicate1DTrainingCore, globals(), except_for="cpu")
+
+
+class TestReplicate1DTrainingCoreSleep(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @property
+    def world_size(self) -> int:
+        return min(8, torch.get_device_module(device_type).device_count())
+
+    @skip_if_lt_x_gpu(2)
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
     @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_multi_groups(self):
@@ -349,7 +457,6 @@ class TestReplicate1DTrainingCore(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
     @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_multi_group_cpu_offload_eager(self):
         """
@@ -382,7 +489,6 @@ class TestReplicate1DTrainingCore(FSDPTest):
         delay_before_optim: bool,
         unshard_async_op: bool,
     ):
-        # Only test individual delays or all four delays to save test time
         if (
             delay_after_forward
             + delay_before_all_gather
@@ -391,7 +497,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
             in (2, 3)
         ):
             return
-        if test_device_type not in ("cuda", "hpu", "xpu", "cpu"):
+        if test_device_type not in ("cuda", "hpu", "xpu", "npu", "cpu"):
             raise AssertionError(f"Unexpected device type: {test_device_type}")
         torch.manual_seed(42)
         vocab_size = 1024
@@ -478,8 +584,6 @@ class TestReplicate1DTrainingCore(FSDPTest):
                 self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_non_root_forward_backward(self):
         """
         Tests running forward/backward through the root and then through a
@@ -526,107 +630,6 @@ class TestReplicate1DTrainingCore(FSDPTest):
         self.assertEqual(ref_model(inp).sum(), model(inp).sum())
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(Capability.distributed.fsdp)
-    def test_multi_forward_module(self):
-        """
-        Tests parity when running a module that participates multiple
-        times in forward.
-        """
-
-        self._test_multi_forward_module()
-
-    def _test_multi_forward_module(self):
-        class MultiForwardModule(nn.Module):
-            def __init__(self, device: torch.device):
-                super().__init__()
-                self.inner = nn.Linear(4, 4, device=device)
-                self.outer = nn.Linear(4, 5, device=device)
-
-            def forward(self, x):
-                i = self.inner(x)
-                j = self.inner(x)
-                return self.outer(i + j)
-
-        torch.manual_seed(42)
-        model = MultiForwardModule(device=device_type.type)
-        ref_model = copy.deepcopy(model).to(device_type)
-
-        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
-        replicate(model.inner)
-        replicate(model)
-        optim = torch.optim.Adam(model.parameters(), lr=1e-2)
-
-        torch.manual_seed(42 + self.rank)
-        inp = torch.randn((32, 4), device=device_type.type)
-        for iter_idx in range(10):
-            losses: list[torch.Tensor] = []
-            for _model in (ref_model, model):
-                losses.append(_model(inp).sum())
-                losses[-1].backward()
-
-            for param in ref_model.parameters():
-                if param.grad is not None:
-                    dist.all_reduce(param.grad)
-                    param.grad.div_(self.world_size)
-
-            for _optim in (ref_optim, optim):
-                _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
-                _optim.step()
-
-            self.assertEqual(losses[0], losses[1])
-
-    @skip_if_lt_x_gpu(2)
-    @requires_capabilities(Capability.distributed.fsdp)
-    def test_explicit_prefetching(self):
-        torch.manual_seed(42)
-        model_args = ModelArgs(n_layers=8, dropout_p=0.0)
-        model = Transformer(model_args)
-        ref_model = copy.deepcopy(model).to(device_type)
-        ref_optim = torch.optim.AdamW(ref_model.parameters(), lr=1e-2)
-
-        for layer in itertools.chain(model.layers, [model]):
-            replicate(layer)
-        optim = torch.optim.AdamW(model.parameters(), lr=1e-2)
-
-        num_to_forward_prefetch = num_to_backward_prefetch = 2
-        for i, layer in enumerate(model.layers):
-            if i >= len(model.layers) - num_to_forward_prefetch:
-                break
-            layers_to_prefetch = [
-                model.layers[i + j] for j in range(1, num_to_forward_prefetch + 1)
-            ]
-            layer.set_modules_to_forward_prefetch(layers_to_prefetch)
-        for i, layer in enumerate(model.layers):
-            if i < num_to_backward_prefetch:
-                continue
-            layers_to_prefetch = [
-                model.layers[i - j] for j in range(1, num_to_backward_prefetch + 1)
-            ]
-            layer.set_modules_to_backward_prefetch(layers_to_prefetch)
-
-        torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 8), device=device_type.type)
-        for _ in range(10):
-            losses: list[torch.Tensor] = []
-
-            for _model in (ref_model, model):
-                losses.append(_model(inp).sum())
-                losses[-1].backward()
-
-            for param in ref_model.parameters():
-                if param.grad is not None:
-                    dist.all_reduce(param.grad)
-                    param.grad.div_(self.world_size)
-
-            for _optim in (ref_optim, optim):
-                _optim.zero_grad()
-                _optim.step()
-
-            self.assertEqual(losses[0], losses[1])
-
-    @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(_should_skip_for_accelerator(), "Sleep kernel not supported for NPU/HPU")
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_post_optim_event(self):
         torch.manual_seed(42)
         model_args = ModelArgs(dropout_p=0.0)
@@ -649,8 +652,6 @@ class TestReplicate1DTrainingCore(FSDPTest):
 
         torch.manual_seed(42 + self.rank)
         inp = torch.randint(0, model_args.vocab_size, (2, 8), device=device_type.type)
-        # Track all losses and check for equality at the end to avoid a CPU
-        # sync point after each iteration
         ref_losses: list[torch.Tensor] = []
         losses: list[torch.Tensor] = []
         for _ in range(10):
@@ -669,15 +670,16 @@ class TestReplicate1DTrainingCore(FSDPTest):
             losses.append(model(inp).sum())
             losses[-1].backward()
             optim.step()
-            # Sleep after the optimizer step to allow CPU to run ahead into the
-            # next iteration's forward, exercising the post-optim stream sync
             torch.get_device_module(device_type)._sleep(int(25 * get_cycles_per_ms()))
         for ref_loss, loss in zip(ref_losses, losses):
             self.assertEqual(ref_loss, loss)
 
 
+instantiate_device_type_tests(TestReplicate1DTrainingCoreSleep, globals(), except_for=["cpu", "hpu", "npu"])
+
+
 class TestReplicateTrainingCompose(FSDPTest):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
@@ -687,7 +689,6 @@ class TestReplicateTrainingCompose(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_with_activation_checkpointing(self):
         """
         Tests train parity against DDP when composing with activation
@@ -811,15 +812,17 @@ class TestReplicateTrainingCompose(FSDPTest):
                 )
 
 
+instantiate_device_type_tests(TestReplicateTrainingCompose, globals(), except_for="cpu")
+
+
 class TestReplicateSharedParams(FSDPTest):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
         return min(4, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_train_parity_with_shared_params(self):
         self.run_subtests(
             {
@@ -868,15 +871,17 @@ class TestReplicateSharedParams(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
 
+instantiate_device_type_tests(TestReplicateSharedParams, globals(), except_for="cpu")
+
+
 class TestReplicateGradientAccumulation(FSDPTest):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
         return min(4, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_gradient_accumulation(self):
         """
         Tests gradient accumulation with/without gradient reduction and
@@ -1035,7 +1040,6 @@ class TestReplicateGradientAccumulation(FSDPTest):
                 _optim.zero_grad(set_to_none=(iter_idx % 2))
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_1f1b_microbatching(self):
         self.run_subtests(
             {
@@ -1104,15 +1108,17 @@ class TestReplicateGradientAccumulation(FSDPTest):
         check_sharded_parity(self, ref_model, model)
 
 
+instantiate_device_type_tests(TestReplicateGradientAccumulation, globals(), except_for="cpu")
+
+
 class TestReplicateCustomForwardMethod(FSDPTest):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
         return min(torch.get_device_module(device_type).device_count(), 2)
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(Capability.distributed.fsdp)
     def test_register_fsdp_forward_method(self):
         class VisionTransformer(nn.Module):
             def __init__(self) -> None:
@@ -1155,8 +1161,11 @@ class TestReplicateCustomForwardMethod(FSDPTest):
         check_sharded_parity(self, ref_model, model)
 
 
+instantiate_device_type_tests(TestReplicateCustomForwardMethod, globals(), except_for="cpu")
+
+
 class TestReplicateTPTraining(FSDPTest):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
@@ -1170,7 +1179,7 @@ class TestReplicateTPTraining(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(8)
-    @requires_capabilities(Capability.distributed.fsdp, Capability.distributed.dtensor)
+    @requires_capabilities(Capability.distributed.dtensor)
     def test_replicate_tp(self):
         global_mesh = self.init_global_mesh()
         self.run_subtests(
@@ -1251,6 +1260,9 @@ class TestReplicateTPTraining(FSDPTest):
             self.assertEqual(p.device_mesh.ndim, 2)
             self.assertEqual(len(p.placements), 2)
             self.assertEqual(p.device_mesh.mesh_dim_names, ("dp_replicate", "tp"))
+
+
+instantiate_device_type_tests(TestReplicateTPTraining, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -271,7 +271,7 @@ class TestReplicateCastAfterInitPrecision(FSDPTestMultiThread):
                 _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
 
 
-instantiate_device_type_tests(TestReplicateCastAfterInitPrecision, globals(), except_for=["cpu", "npu"])
+instantiate_device_type_tests(TestReplicateCastAfterInitPrecision, globals(), except_for="cpu")
 
 
 class TestReplicate1DTrainingCore(FSDPTest):
@@ -497,8 +497,6 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
             in (2, 3)
         ):
             return
-        if test_device_type not in ("cuda", "hpu", "xpu", "npu", "cpu"):
-            raise AssertionError(f"Unexpected device type: {test_device_type}")
         torch.manual_seed(42)
         vocab_size = 1024
         model_args = ModelArgs(
@@ -675,7 +673,7 @@ class TestReplicate1DTrainingCoreSleep(FSDPTest):
             self.assertEqual(ref_loss, loss)
 
 
-instantiate_device_type_tests(TestReplicate1DTrainingCoreSleep, globals(), except_for=["cpu", "hpu", "npu"])
+instantiate_device_type_tests(TestReplicate1DTrainingCoreSleep, globals(), except_for=["cpu", "hpu"])
 
 
 class TestReplicateTrainingCompose(FSDPTest):

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -30,6 +30,7 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     check_sharded_parity,
@@ -42,17 +43,16 @@ from torch.testing._internal.common_fsdp import (
     patch_reduce_scatter,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     get_cycles_per_ms,
     run_tests,
     wrapSwapTensorsTest,
-    HardwareClassification,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
     TransformerBlock,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
 c10d_ops = torch.ops.c10d
 funcol = torch.ops.c10d_functional
@@ -92,7 +92,9 @@ class TestReplicateForwardInputs(FSDPTestMultiThread):
         model(x, ys)
 
 
-instantiate_device_type_tests(TestReplicateForwardInputs, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(
+    TestReplicateForwardInputs, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 class TestReplicateRegisteredParams(FSDPTestMultiThread):
@@ -198,7 +200,9 @@ class TestReplicateRegisteredParams(FSDPTestMultiThread):
             self.assertEqual(param, ref_param)
 
 
-instantiate_device_type_tests(TestReplicateRegisteredParams, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(
+    TestReplicateRegisteredParams, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 class TestReplicateCastAfterInitPrecision(FSDPTestMultiThread):
@@ -259,7 +263,9 @@ class TestReplicateCastAfterInitPrecision(FSDPTestMultiThread):
                 _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
 
 
-instantiate_device_type_tests(TestReplicateCastAfterInitPrecision, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(
+    TestReplicateCastAfterInitPrecision, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 class TestReplicate1DTrainingCore(FSDPTest):
@@ -459,7 +465,9 @@ class TestReplicate1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
 
-instantiate_device_type_tests(TestReplicate1DTrainingCore, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(
+    TestReplicate1DTrainingCore, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 class TestReplicate1DTrainingCoreNoHpu(FSDPTest):
@@ -630,7 +638,9 @@ class TestReplicate1DTrainingCoreNoHpu(FSDPTest):
             fsdp_module: FSDPModule, opt: torch.optim.Optimizer, args, kwargs
         ) -> None:
             post_optim_event = (
-                torch.get_device_module(self.device_type).current_stream().record_event()
+                torch.get_device_module(self.device_type)
+                .current_stream()
+                .record_event()
             )
             fsdp_module.set_post_optim_event(post_optim_event)
 
@@ -656,12 +666,19 @@ class TestReplicate1DTrainingCoreNoHpu(FSDPTest):
             losses.append(model(inp).sum())
             losses[-1].backward()
             optim.step()
-            torch.get_device_module(self.device_type)._sleep(int(25 * get_cycles_per_ms()))
+            torch.get_device_module(self.device_type)._sleep(
+                int(25 * get_cycles_per_ms())
+            )
         for ref_loss, loss in zip(ref_losses, losses):
             self.assertEqual(ref_loss, loss)
 
 
-instantiate_device_type_tests(TestReplicate1DTrainingCoreNoHpu, globals(), except_for=["cpu", "hpu"], allow_xpu=True)
+instantiate_device_type_tests(
+    TestReplicate1DTrainingCoreNoHpu,
+    globals(),
+    except_for=["cpu", "hpu"],
+    allow_xpu=True,
+)
 
 
 class TestReplicateTrainingCompose(FSDPTest):
@@ -798,7 +815,9 @@ class TestReplicateTrainingCompose(FSDPTest):
                 )
 
 
-instantiate_device_type_tests(TestReplicateTrainingCompose, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(
+    TestReplicateTrainingCompose, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 class TestReplicateSharedParams(FSDPTest):
@@ -857,7 +876,9 @@ class TestReplicateSharedParams(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
 
-instantiate_device_type_tests(TestReplicateSharedParams, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(
+    TestReplicateSharedParams, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 class TestReplicateGradientAccumulation(FSDPTest):
@@ -1094,7 +1115,9 @@ class TestReplicateGradientAccumulation(FSDPTest):
         check_sharded_parity(self, ref_model, model)
 
 
-instantiate_device_type_tests(TestReplicateGradientAccumulation, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(
+    TestReplicateGradientAccumulation, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 class TestReplicateCustomForwardMethod(FSDPTest):
@@ -1147,7 +1170,9 @@ class TestReplicateCustomForwardMethod(FSDPTest):
         check_sharded_parity(self, ref_model, model)
 
 
-instantiate_device_type_tests(TestReplicateCustomForwardMethod, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(
+    TestReplicateCustomForwardMethod, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 class TestReplicateTPTraining(FSDPTest):
@@ -1246,7 +1271,9 @@ class TestReplicateTPTraining(FSDPTest):
             self.assertEqual(p.device_mesh.mesh_dim_names, ("dp_replicate", "tp"))
 
 
-instantiate_device_type_tests(TestReplicateTPTraining, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(
+    TestReplicateTPTraining, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR refactors `test/distributed/_composable/test_replicate_training.py` to be device-agnostic by removing the global `device_type` variable, splitting HPU-incompatible tests into a separate class, and adding `instantiate_device_type_tests` with `HardwareClassification` tags.

## Motivation

The original test had hardcoded device assumptions:
- Module-level global `device_type = torch.device(get_devtype())`
- `@unittest.skipIf(TEST_HPU, ...)` decorators for sleep kernel tests
- Device type validation `if test_device_type not in ("cuda", "hpu", "xpu", "cpu")`
- No `device` parameter, no `hw_classification`, no `instantiate_device_type_tests`

## Changes

### 1. Remove global `device_type` variable and imports

```diff
-from torch.testing._internal.common_fsdp import get_devtype
-device_type = torch.device(get_devtype())
-import unittest
-    TEST_HPU,
```

### 2. Add imports

```diff
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     ...
 )
```

### 3. Add `hw_classification` (10 classes)

All classes set `hw_classification = HardwareClassification.ACCELERATOR`.

### 4. Class split

**`TestReplicateCastAfterInit` → renamed to `TestReplicateCastAfterInitPrecision`**

**`TestReplicate1DTrainingCore` → split into two classes:**

| Retained in `TestReplicate1DTrainingCore` | Moved to `TestReplicate1DTrainingCoreNoHpu` |
|-------------------------------------------|--------------------------------------------|
| `test_train_parity_single_group` | `test_train_parity_multi_groups` |
| `test_non_root_forward_backward` | `test_train_parity_multi_group_cpu_offload_eager` |
| `test_multi_forward_module` | `test_post_optim_event` |
| `test_explicit_prefetching` | |

`TestReplicate1DTrainingCoreNoHpu` uses `except_for=["cpu", "hpu"]` (contains sleep kernel tests).

### 5. Add `device` parameter (16 methods)

All test methods get `device` parameter.

### 6. Add `instantiate_device_type_tests` (10 classes)

```python
instantiate_device_type_tests(TestReplicateForwardInputs, globals(), except_for="cpu", allow_xpu=True)
instantiate_device_type_tests(TestReplicateRegisteredParams, globals(), except_for="cpu", allow_xpu=True)
instantiate_device_type_tests(TestReplicateCastAfterInitPrecision, globals(), except_for="cpu", allow_xpu=True)
instantiate_device_type_tests(TestReplicate1DTrainingCore, globals(), except_for="cpu", allow_xpu=True)
instantiate_device_type_tests(TestReplicate1DTrainingCoreNoHpu, globals(), except_for=["cpu", "hpu"], allow_xpu=True)
instantiate_device_type_tests(TestReplicateTrainingCompose, globals(), except_for="cpu", allow_xpu=True)
instantiate_device_type_tests(TestReplicateSharedParams, globals(), except_for="cpu", allow_xpu=True)
instantiate_device_type_tests(TestReplicateGradientAccumulation, globals(), except_for="cpu", allow_xpu=True)
instantiate_device_type_tests(TestReplicateCustomForwardMethod, globals(), except_for="cpu", allow_xpu=True)
instantiate_device_type_tests(TestReplicateTPTraining, globals(), except_for="cpu", allow_xpu=True)
```

## Testing

- **NPU**: 6 tests skipped (4 sleep + 2 fp64), 11 tests passed
- **HPU**: Behavior unchanged
- **CUDA**: Behavior unchanged
- **CPU**: All tests skipped (expected)

## Compatibility

- Uses `torch.accelerator.current_accelerator()` public API
- Maintains CUDA/HPU behavior unchanged
- Note: NPU has a specific DTensor.to() limitation that requires a device-type check

## Notes

1. This PR depends on the following PR code changes(in OPEN state):
<img width="1283" height="28" alt="image" src="https://github.com/user-attachments/assets/91350be6-2a12-448c-a403-83fc81e5d718" />

2. The NPU does not support the `_sleep` kernel. An issue has been submitted. After the issue is resolved, the corresponding skip can be enabled. The issue link is as follows: https://gitcode.com/Ascend/pytorch/issues/3958.

