### PR TITLE
[cpu][blas] Fix 32-bit int overflow when computing float staging vector size in sbgemm and shgemm

### DIFF
--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -370,12 +370,12 @@ void gemm(
       int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;
       char transa_ = to_blas(transa), transb_ = to_blas(transb);
       float alpha_ = alpha, beta_ = beta;
-      int c_size = n_ * m_;
+      size_t c_size = static_cast<size_t>(n) * static_cast<size_t>(m);
       // C matrix in OpenBLAS sbgemm are of type "float" so we have to convert, copy and copy back.
       std::vector<float> float_v(c_size, 0.0f);
       for (const auto j : c10::irange(n)) {
         for (const auto i : c10::irange(m)) {
-          float_v[j * m_ + i] = c10::convert<float>(c[j * ldc_ + i]);
+          float_v[j * static_cast<size_t>(m_) + i] = c10::convert<float>(c[j * ldc_ + i]);
         }
       }
       sbgemm_(&transa_, &transb_,
@@ -387,7 +387,7 @@ void gemm(
               float_v.data(), &m_);
       for (const auto j : c10::irange(n)) {
         for (const auto i : c10::irange(m)) {
-          c[j * ldc_ + i] = c10::convert<at::BFloat16>(float_v[j * m_ + i]);
+          c[j * ldc_ + i] = c10::convert<at::BFloat16>(float_v[j * static_cast<size_t>(m_) + i]);
         }
       }
       return;
@@ -431,12 +431,12 @@ void gemm(
       int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;
       char transa_ = to_blas(transa), transb_ = to_blas(transb);
       float alpha_ = alpha, beta_ = beta;
-      int c_size = n_ * m_;
+      size_t c_size = static_cast<size_t>(n) * static_cast<size_t>(m);
       // C matrix in OpenBLAS shgemm are of type "float" so we have to convert, copy and copy back.
       std::vector<float> float_v(c_size, 0.0f);
       for (const auto j : c10::irange(n)) {
         for (const auto i : c10::irange(m)) {
-          float_v[j * m_ + i] = c10::convert<float>(c[j * ldc_ + i]);
+          float_v[j * static_cast<size_t>(m_) + i] = c10::convert<float>(c[j * ldc_ + i]);
         }
       }
       shgemm_(&transa_, &transb_,
@@ -448,7 +448,7 @@ void gemm(
               float_v.data(), &m_);
       for (const auto j : c10::irange(n)) {
         for (const auto i : c10::irange(m)) {
-          c[j * ldc_ + i] = c10::convert<at::Half>(float_v[j * m_ + i]);
+          c[j * ldc_ + i] = c10::convert<at::Half>(float_v[j * static_cast<size_t>(m_) + i]);
         }
       }
       return;


### PR DESCRIPTION
[cpu][blas] Fix 32-bit int overflow when computing float staging vector size in sbgemm and shgemm

Fixes #191083

### Root Cause
In aten/src/ATen/native/CPUBlas.cpp, the sbgemm_ (bfloat16) and shgemm_ (fp16) BLAS fallback paths convert matrix elements to/from a temporary float staging vector float_v because OpenBLAS's sbgemm_ / shgemm_ work with float C matrices.

When performing matrix multiplications with outputs having >= 2^31 total elements (e.g. 46,341 x 46,341 = 2,147,488,281), int c_size = n_ * m_; performed signed 32-bit int multiplication. Because m_ and n_ were int, n_ * m_ overflowed INT32_MAX, producing a negative integer. Passing a negative size to std::vector<float> float_v(c_size, 0.0f) raised a std::length_error exception.

### Fix
Widen c_size to size_t by casting n and m (int64_t) to size_t during calculation:
size_t c_size = static_cast<size_t>(n) * static_cast<size_t>(m);
Also promote offset calculations inside the element conversion loops (j * static_cast<size_t>(m_) + i) to prevent intermediate int multiplication overflows when indexing into float_v.

### Test Plan
Ran spin lint to verify code format and style rules:
```bash
spin lint aten/src/ATen/native/CPUBlas.cpp
```

Authored with the assistance of an AI assistant.
