### PR TITLE
[CPU][BLAS] Fix int overflow in bf16/fp16 gemm staging buffer size

### DIFF
--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -370,7 +370,7 @@ void gemm(
       int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;
       char transa_ = to_blas(transa), transb_ = to_blas(transb);
       float alpha_ = alpha, beta_ = beta;
-      int c_size = n_ * m_;
+      int64_t c_size = static_cast<int64_t>(n_) * m_;
       // C matrix in OpenBLAS sbgemm are of type "float" so we have to convert, copy and copy back.
       std::vector<float> float_v(c_size, 0.0f);
       for (const auto j : c10::irange(n)) {
@@ -431,7 +431,7 @@ void gemm(
       int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;
       char transa_ = to_blas(transa), transb_ = to_blas(transb);
       float alpha_ = alpha, beta_ = beta;
-      int c_size = n_ * m_;
+      int64_t c_size = static_cast<int64_t>(n_) * m_;
       // C matrix in OpenBLAS shgemm are of type "float" so we have to convert, copy and copy back.
       std::vector<float> float_v(c_size, 0.0f);
       for (const auto j : c10::irange(n)) {


### PR DESCRIPTION
Fixes #191083.

## Problem
In `aten/src/ATen/native/CPUBlas.cpp`, the `sbgemm_` (bf16) and `shgemm_` (fp16) external-BLAS copy-back paths size the fp32 staging buffer with a 32-bit `int`:

```cpp
int c_size = n_ * m_;
std::vector<float> float_v(c_size, 0.0f);
```

`use_blas_gemm` guards each of `m, n, k, lda, ldb, ldc` against `INT_MAX` individually, but not the product `m * n`. For a legal matmul whose output has ≥ 2³¹ elements, e.g. `46341 × 46341` (each dimension small, but product is 2,147,488,281 > 2³¹−1),`n_ * m_` overflows signed `int` and the `std::vector` constructor throws `std::length_error`.

## Fix
Compute the product in `int64_t` by promoting an operand with `static_cast` before the multiply, in both the `sbgemm_` and `shgemm_` blocks. This matches the `int64_t` indexing already used in the surrounding copy loops (`j * m_ + i` with `int64_t` loop variables from `c10::irange`), so the allocation size is now consistent with the indexing.

## Testing note
Reproducing the original throw requires a CPU build whose BLAS exports `sbgemm_`/`shgemm_` (e.g. OpenBLAS built with bf16 support) and an ~8.6 GB fp32 staging allocation for the 2³¹-element case mentioned in the issue, so I wasn't able to reproduce locally. The fix is by inspection: `static_cast<int64_t>(n_) * m_` cannot overflow for the boundary shape the issue documents (46340² works, 46341² throws on the old code). 

I'd appreciate guidance on the preferred way to add a regression test given the allocation size of ~8.6 GB.