### PR TITLE
[MPS] Faster reductions (1/5): skip input up-casts and vec4 full reductions

### DIFF
--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -219,7 +219,11 @@ inline TensorIterator make_reduction(
   // product of templated kernel launches.
   const bool gpu_lowp_to_f32 = (
         (self.is_cuda() || self.is_xpu()) && (self.scalar_type() == kHalf || self.scalar_type() == kBFloat16) && out_dtype == kFloat);
-  auto in_dtype = gpu_lowp_to_f32 ? self.scalar_type()
+  // MPS sum kernels widen integral inputs to long in-register; passing the
+  // original input avoids materializing a 2-8x larger casted copy.
+  const bool mps_int_to_long = self.is_mps() && out_dtype == kLong &&
+      at::isIntegralType(self.scalar_type(), /*includeBool=*/true);
+  auto in_dtype = (gpu_lowp_to_f32 || mps_int_to_long) ? self.scalar_type()
                    : self.is_complex() ? c10::toComplexType(out_dtype)
                                        : out_dtype;
   return make_reduction(name, result, self, dim, keepdim, in_dtype, out_dtype);
@@ -452,10 +456,15 @@ inline TensorIterator make_reduction(
   // not generalize this to common mismatched input/output types to avoid cross
   // product of templated kernel launches.
   const bool gpu_lowp_to_f32 =
-      ((self.is_cuda() || self.is_xpu()) &&
+      ((self.is_cuda() || self.is_xpu() || self.is_mps()) &&
        (self.scalar_type() == kHalf || self.scalar_type() == kBFloat16) &&
        out_dtype == kFloat);
-  auto in_dtype = gpu_lowp_to_f32 ? self.scalar_type() : out_dtype;
+  // MPS sum kernels widen integral inputs to long in-register; passing the
+  // original input avoids materializing a 2-8x larger casted copy.
+  const bool mps_int_to_long = self.is_mps() && out_dtype == kLong &&
+      at::isIntegralType(self.scalar_type(), /*includeBool=*/true);
+  auto in_dtype =
+      (gpu_lowp_to_f32 || mps_int_to_long) ? self.scalar_type() : out_dtype;
   return make_reduction(self, result, opt_dims, keepdim, in_dtype);
 }
 

--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -661,24 +661,27 @@ REGISTER_NORM_INNER(float, float);
 REGISTER_NORM_INNER(half, half);
 REGISTER_NORM_INNER(bfloat, bfloat);
 
+// Pass-1 kernel for two-pass full reductions over a contiguous buffer:
+// threadgroup tgid reduces the slice input[tgid * E .. (tgid + 1) * E) with
+// flat indexing (params.y = E), no NormParams offset math. Each chain step
+// consumes 4 adjacent elements to cut loop overhead; loads stay scalar so
+// the slice base needs no vector alignment.
 template <
     typename TI,
     typename TO,
     uint NCHAINS = SUM_NCHAINS,
     LoadMode MODE = LOAD_IDENTITY>
-kernel void sum_reduction_vec(
+kernel void sum_reduction_flat(
     constant TI* input [[buffer(0)]],
     device TO* output [[buffer(1)]],
     constant uint2& params [[buffer(2)]],
     uint tid [[thread_position_in_threadgroup]],
     uint tptg [[threads_per_threadgroup]],
     uint tgid [[threadgroup_position_in_grid]]) {
-  using TA = opmath_t<TO>;
-  using V = vec4type_t<TI>;
+  using TA = ::metal::conditional_t<MODE == LOAD_NONZERO, uint, opmath_t<TO>>;
   const uint E = params.y;
-  const uint g_base = tgid * E;
-  const uint n_vec = E / 4;
-  constant V* vin = reinterpret_cast<constant V*>(input + g_base);
+  constant TI* in = input + tgid * E;
+  const uint n_quads = E / 4;
 
   metal::array<TA, NCHAINS> acc;
   for (uint j = 0; j < NCHAINS; j++) {
@@ -686,25 +689,23 @@ kernel void sum_reduction_vec(
   }
   const uint stride = tptg * NCHAINS;
   uint i = tid;
-  for (; i + (NCHAINS - 1) * tptg < n_vec; i += stride) {
+  for (; i + (NCHAINS - 1) * tptg < n_quads; i += stride) {
     for (uint j = 0; j < NCHAINS; j++) {
-      const V v = vin[i + j * tptg];
-      // widen lanes before the 4-way add; summing in TI overflows int32
-      acc[j] += static_cast<TA>(load_val<MODE>(v.x)) +
-          static_cast<TA>(load_val<MODE>(v.y)) +
-          static_cast<TA>(load_val<MODE>(v.z)) +
-          static_cast<TA>(load_val<MODE>(v.w));
+      const uint base = (i + j * tptg) * 4;
+#pragma unroll
+      for (uint k = 0; k < 4; k++) {
+        acc[j] += load_val<MODE>(in[base + k]);
+      }
     }
   }
-  for (; i < n_vec; i += tptg) {
-    const V v = vin[i];
-    acc[0] += static_cast<TA>(load_val<MODE>(v.x)) +
-        static_cast<TA>(load_val<MODE>(v.y)) +
-        static_cast<TA>(load_val<MODE>(v.z)) +
-        static_cast<TA>(load_val<MODE>(v.w));
+  for (; i < n_quads; i += tptg) {
+#pragma unroll
+    for (uint k = 0; k < 4; k++) {
+      acc[0] += load_val<MODE>(in[i * 4 + k]);
+    }
   }
-  for (uint k = n_vec * 4 + tid; k < E; k += tptg) {
-    acc[0] += load_val<MODE>(input[g_base + k]);
+  for (uint k = n_quads * 4 + tid; k < E; k += tptg) {
+    acc[0] += load_val<MODE>(in[k]);
   }
   TA sum = acc[0];
   for (uint j = 1; j < NCHAINS; j++) {
@@ -717,14 +718,14 @@ kernel void sum_reduction_vec(
   }
 }
 
-#define REGISTER_SUM_VEC_IMPL(TI, TO, PREFIX, MODE)           \
-  template [[host_name(PREFIX "reduction_vec_" #TI "_" #TO)]] \
-  kernel void sum_reduction_vec<TI, TO, SUM_NCHAINS, MODE>(   \
-      constant TI * input [[buffer(0)]],                      \
-      device TO * output [[buffer(1)]],                       \
-      constant uint2 & params [[buffer(2)]],                  \
-      uint tid [[thread_position_in_threadgroup]],            \
-      uint tptg [[threads_per_threadgroup]],                  \
+#define REGISTER_SUM_FLAT_IMPL(TI, TO, PREFIX, MODE)           \
+  template [[host_name(PREFIX "reduction_flat_" #TI "_" #TO)]] \
+  kernel void sum_reduction_flat<TI, TO, SUM_NCHAINS, MODE>(   \
+      constant TI * input [[buffer(0)]],                       \
+      device TO * output [[buffer(1)]],                        \
+      constant uint2 & params [[buffer(2)]],                   \
+      uint tid [[thread_position_in_threadgroup]],             \
+      uint tptg [[threads_per_threadgroup]],                   \
       uint tgid [[threadgroup_position_in_grid]]);
 
 #define REGISTER_SUM_IMPL(TI, TO, PREFIX, MODE)             \
@@ -750,37 +751,21 @@ kernel void sum_reduction_vec(
       uint tptg [[threads_per_threadgroup]],                          \
       uint tgid [[threadgroup_position_in_grid]]);
 
-#define REGISTER_SUM(TI, TO)                       \
-  REGISTER_SUM_IMPL(TI, TO, "sum_", LOAD_IDENTITY) \
-  REGISTER_SUM_STRIDED_IMPL(TI, TO, "sum_", LOAD_IDENTITY)
-#define REGISTER_NANSUM(TI, TO)                          \
-  REGISTER_SUM_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO) \
-  REGISTER_SUM_STRIDED_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO)
-#define REGISTER_COUNT_NONZERO(TI)                            \
-  REGISTER_SUM_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO) \
-  REGISTER_SUM_STRIDED_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO)
-
-#define REGISTER_SUM_VEC(TI, TO) \
-  REGISTER_SUM_VEC_IMPL(TI, TO, "sum_", LOAD_IDENTITY)
-#define REGISTER_NANSUM_VEC(TI, TO) \
-  REGISTER_SUM_VEC_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO)
-REGISTER_SUM_VEC(float, float);
-REGISTER_SUM_VEC(float, half);
-REGISTER_SUM_VEC(float, bfloat);
-REGISTER_SUM_VEC(half, half);
-REGISTER_SUM_VEC(half, float);
-REGISTER_SUM_VEC(bfloat, bfloat);
-REGISTER_SUM_VEC(bfloat, float);
-REGISTER_SUM_VEC(int, int);
-REGISTER_SUM_VEC(int, long);
-REGISTER_SUM_VEC(long, long);
-REGISTER_SUM_VEC(short, short);
-REGISTER_SUM_VEC(short, long);
-REGISTER_NANSUM_VEC(float, float);
-REGISTER_NANSUM_VEC(half, half);
-REGISTER_NANSUM_VEC(half, float);
-REGISTER_NANSUM_VEC(bfloat, bfloat);
-REGISTER_NANSUM_VEC(bfloat, float);
+// Every (op, TI, TO) with a plain pass-1 kernel also gets the strided and
+// flat variants, so the host dispatcher can pick a variant without keeping
+// its own table of which instantiations exist.
+#define REGISTER_SUM(TI, TO)                               \
+  REGISTER_SUM_IMPL(TI, TO, "sum_", LOAD_IDENTITY)         \
+  REGISTER_SUM_STRIDED_IMPL(TI, TO, "sum_", LOAD_IDENTITY) \
+  REGISTER_SUM_FLAT_IMPL(TI, TO, "sum_", LOAD_IDENTITY)
+#define REGISTER_NANSUM(TI, TO)                                  \
+  REGISTER_SUM_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO)         \
+  REGISTER_SUM_STRIDED_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO) \
+  REGISTER_SUM_FLAT_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO)
+#define REGISTER_COUNT_NONZERO(TI)                                    \
+  REGISTER_SUM_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO)         \
+  REGISTER_SUM_STRIDED_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO) \
+  REGISTER_SUM_FLAT_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO)
 
 REGISTER_SUM(float, float);
 REGISTER_SUM(float, half);
@@ -992,13 +977,15 @@ kernel void value_reduction(
   }
 }
 
+// Flat pass-1 variant of value_reduction; see sum_reduction_flat for the
+// layout (params.y = E, threadgroup tgid owns one contiguous slice).
 template <
     template <typename> class OpFn,
     typename Load,
     typename TI,
     typename TO,
     uint NCHAINS = SUM_NCHAINS>
-kernel void value_reduction_vec(
+kernel void value_reduction_flat(
     constant TI* input [[buffer(0)]],
     device TO* output [[buffer(1)]],
     constant uint2& params [[buffer(2)]],
@@ -1007,11 +994,9 @@ kernel void value_reduction_vec(
     uint tgid [[threadgroup_position_in_grid]]) {
   using TA = TO;
   using Op = OpFn<TA>;
-  using V = vec4type_t<TI>;
   const uint E = params.y;
-  const uint g_base = tgid * E;
-  const uint n_vec = E / 4;
-  constant V* vin = reinterpret_cast<constant V*>(input + g_base);
+  constant TI* in = input + tgid * E;
+  const uint n_quads = E / 4;
 
   metal::array<TA, NCHAINS> acc;
   for (uint j = 0; j < NCHAINS; j++) {
@@ -1019,24 +1004,23 @@ kernel void value_reduction_vec(
   }
   const uint stride = tptg * NCHAINS;
   uint i = tid;
-  for (; i + (NCHAINS - 1) * tptg < n_vec; i += stride) {
+  for (; i + (NCHAINS - 1) * tptg < n_quads; i += stride) {
     for (uint j = 0; j < NCHAINS; j++) {
-      const V v = vin[i + j * tptg];
-      acc[j] = Op::combine(acc[j], Load::template load<TA>(v.x));
-      acc[j] = Op::combine(acc[j], Load::template load<TA>(v.y));
-      acc[j] = Op::combine(acc[j], Load::template load<TA>(v.z));
-      acc[j] = Op::combine(acc[j], Load::template load<TA>(v.w));
+      const uint base = (i + j * tptg) * 4;
+#pragma unroll
+      for (uint k = 0; k < 4; k++) {
+        acc[j] = Op::combine(acc[j], Load::template load<TA>(in[base + k]));
+      }
     }
   }
-  for (; i < n_vec; i += tptg) {
-    const V v = vin[i];
-    acc[0] = Op::combine(acc[0], Load::template load<TA>(v.x));
-    acc[0] = Op::combine(acc[0], Load::template load<TA>(v.y));
-    acc[0] = Op::combine(acc[0], Load::template load<TA>(v.z));
-    acc[0] = Op::combine(acc[0], Load::template load<TA>(v.w));
+  for (; i < n_quads; i += tptg) {
+#pragma unroll
+    for (uint k = 0; k < 4; k++) {
+      acc[0] = Op::combine(acc[0], Load::template load<TA>(in[i * 4 + k]));
+    }
   }
-  for (uint k = n_vec * 4 + tid; k < E; k += tptg) {
-    acc[0] = Op::combine(acc[0], Load::template load<TA>(input[g_base + k]));
+  for (uint k = n_quads * 4 + tid; k < E; k += tptg) {
+    acc[0] = Op::combine(acc[0], Load::template load<TA>(in[k]));
   }
   TA output_val = acc[0];
   for (uint j = 1; j < NCHAINS; j++) {
@@ -1209,7 +1193,15 @@ kernel void value_reduction_inner(
       uint tptg [[threads_per_threadgroup]],                                \
       uint tgid [[threadgroup_position_in_grid]],                           \
       uint simd_lane_id [[thread_index_in_simdgroup]],                      \
-      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);                \
+  template [[host_name(NAME "_reduction_flat_" #TI "_" #TO)]]               \
+  kernel void value_reduction_flat<OP, LOAD, TI, TO, SUM_NCHAINS>(          \
+      constant TI * input [[buffer(0)]],                                    \
+      device TO * output [[buffer(1)]],                                     \
+      constant uint2 & params [[buffer(2)]],                                \
+      uint tid [[thread_position_in_threadgroup]],                          \
+      uint tptg [[threads_per_threadgroup]],                                \
+      uint tgid [[threadgroup_position_in_grid]]);
 
 #define REGISTER_MAX(T) \
   REGISTER_VALUE_REDUCTION_IMPL(T, T, "max", MaxOp, IdentityLoad)
@@ -1219,29 +1211,6 @@ kernel void value_reduction_inner(
   REGISTER_VALUE_REDUCTION_IMPL(TI, uchar, "any", MaxOp, PredicateLoad)
 #define REGISTER_ALL(TI) \
   REGISTER_VALUE_REDUCTION_IMPL(TI, uchar, "all", MinOp, PredicateLoad)
-
-#define REGISTER_VALUE_VEC_IMPL(TI, TO, NAME, OP, LOAD)           \
-  template [[host_name(NAME "_reduction_vec_" #TI "_" #TO)]]      \
-  kernel void value_reduction_vec<OP, LOAD, TI, TO, SUM_NCHAINS>( \
-      constant TI * input [[buffer(0)]],                          \
-      device TO * output [[buffer(1)]],                           \
-      constant uint2 & params [[buffer(2)]],                      \
-      uint tid [[thread_position_in_threadgroup]],                \
-      uint tptg [[threads_per_threadgroup]],                      \
-      uint tgid [[threadgroup_position_in_grid]]);
-
-#define REGISTER_VALUE_VEC(T)                                    \
-  REGISTER_VALUE_VEC_IMPL(T, T, "max", MaxOp, IdentityLoad)      \
-  REGISTER_VALUE_VEC_IMPL(T, T, "min", MinOp, IdentityLoad)      \
-  REGISTER_VALUE_VEC_IMPL(T, uchar, "any", MaxOp, PredicateLoad) \
-  REGISTER_VALUE_VEC_IMPL(T, uchar, "all", MinOp, PredicateLoad)
-
-REGISTER_VALUE_VEC(float);
-REGISTER_VALUE_VEC(half);
-REGISTER_VALUE_VEC(bfloat);
-REGISTER_VALUE_VEC(int);
-REGISTER_VALUE_VEC(long);
-REGISTER_VALUE_VEC(short);
 
 // Numeric types that participate in min/max AND all/any.
 #define REGISTER_REDUCTIONS_OPS_FOR_TYPE(T) \

--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -661,6 +661,72 @@ REGISTER_NORM_INNER(float, float);
 REGISTER_NORM_INNER(half, half);
 REGISTER_NORM_INNER(bfloat, bfloat);
 
+template <
+    typename TI,
+    typename TO,
+    uint NCHAINS = SUM_NCHAINS,
+    LoadMode MODE = LOAD_IDENTITY>
+kernel void sum_reduction_vec(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]]) {
+  using TA = opmath_t<TO>;
+  using V = vec4type_t<TI>;
+  const uint E = params.y;
+  const uint g_base = tgid * E;
+  const uint n_vec = E / 4;
+  constant V* vin = reinterpret_cast<constant V*>(input + g_base);
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++) {
+    acc[j] = 0;
+  }
+  const uint stride = tptg * NCHAINS;
+  uint i = tid;
+  for (; i + (NCHAINS - 1) * tptg < n_vec; i += stride) {
+    for (uint j = 0; j < NCHAINS; j++) {
+      const V v = vin[i + j * tptg];
+      // widen lanes before the 4-way add; summing in TI overflows int32
+      acc[j] += static_cast<TA>(load_val<MODE>(v.x)) +
+          static_cast<TA>(load_val<MODE>(v.y)) +
+          static_cast<TA>(load_val<MODE>(v.z)) +
+          static_cast<TA>(load_val<MODE>(v.w));
+    }
+  }
+  for (; i < n_vec; i += tptg) {
+    const V v = vin[i];
+    acc[0] += static_cast<TA>(load_val<MODE>(v.x)) +
+        static_cast<TA>(load_val<MODE>(v.y)) +
+        static_cast<TA>(load_val<MODE>(v.z)) +
+        static_cast<TA>(load_val<MODE>(v.w));
+  }
+  for (uint k = n_vec * 4 + tid; k < E; k += tptg) {
+    acc[0] += load_val<MODE>(input[g_base + k]);
+  }
+  TA sum = acc[0];
+  for (uint j = 1; j < NCHAINS; j++) {
+    sum += acc[j];
+  }
+  threadgroup TA shared[MAX_THREADGROUP_SIZE / 32];
+  const TA total = c10::metal::threadgroup_sum(shared, sum, tid, tptg);
+  if (tid == 0) {
+    output[tgid] = static_cast<TO>(total);
+  }
+}
+
+#define REGISTER_SUM_VEC_IMPL(TI, TO, PREFIX, MODE)           \
+  template [[host_name(PREFIX "reduction_vec_" #TI "_" #TO)]] \
+  kernel void sum_reduction_vec<TI, TO, SUM_NCHAINS, MODE>(   \
+      constant TI * input [[buffer(0)]],                      \
+      device TO * output [[buffer(1)]],                       \
+      constant uint2 & params [[buffer(2)]],                  \
+      uint tid [[thread_position_in_threadgroup]],            \
+      uint tptg [[threads_per_threadgroup]],                  \
+      uint tgid [[threadgroup_position_in_grid]]);
+
 #define REGISTER_SUM_IMPL(TI, TO, PREFIX, MODE)             \
   template [[host_name(PREFIX "reduction_" #TI "_" #TO)]]   \
   kernel void sum_reduction<TI, TO, SUM_NCHAINS, MODE>(     \
@@ -693,6 +759,28 @@ REGISTER_NORM_INNER(bfloat, bfloat);
 #define REGISTER_COUNT_NONZERO(TI)                            \
   REGISTER_SUM_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO) \
   REGISTER_SUM_STRIDED_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO)
+
+#define REGISTER_SUM_VEC(TI, TO) \
+  REGISTER_SUM_VEC_IMPL(TI, TO, "sum_", LOAD_IDENTITY)
+#define REGISTER_NANSUM_VEC(TI, TO) \
+  REGISTER_SUM_VEC_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO)
+REGISTER_SUM_VEC(float, float);
+REGISTER_SUM_VEC(float, half);
+REGISTER_SUM_VEC(float, bfloat);
+REGISTER_SUM_VEC(half, half);
+REGISTER_SUM_VEC(half, float);
+REGISTER_SUM_VEC(bfloat, bfloat);
+REGISTER_SUM_VEC(bfloat, float);
+REGISTER_SUM_VEC(int, int);
+REGISTER_SUM_VEC(int, long);
+REGISTER_SUM_VEC(long, long);
+REGISTER_SUM_VEC(short, short);
+REGISTER_SUM_VEC(short, long);
+REGISTER_NANSUM_VEC(float, float);
+REGISTER_NANSUM_VEC(half, half);
+REGISTER_NANSUM_VEC(half, float);
+REGISTER_NANSUM_VEC(bfloat, bfloat);
+REGISTER_NANSUM_VEC(bfloat, float);
 
 REGISTER_SUM(float, float);
 REGISTER_SUM(float, half);
@@ -904,6 +992,63 @@ kernel void value_reduction(
   }
 }
 
+template <
+    template <typename> class OpFn,
+    typename Load,
+    typename TI,
+    typename TO,
+    uint NCHAINS = SUM_NCHAINS>
+kernel void value_reduction_vec(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]]) {
+  using TA = TO;
+  using Op = OpFn<TA>;
+  using V = vec4type_t<TI>;
+  const uint E = params.y;
+  const uint g_base = tgid * E;
+  const uint n_vec = E / 4;
+  constant V* vin = reinterpret_cast<constant V*>(input + g_base);
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++) {
+    acc[j] = Op::identity();
+  }
+  const uint stride = tptg * NCHAINS;
+  uint i = tid;
+  for (; i + (NCHAINS - 1) * tptg < n_vec; i += stride) {
+    for (uint j = 0; j < NCHAINS; j++) {
+      const V v = vin[i + j * tptg];
+      acc[j] = Op::combine(acc[j], Load::template load<TA>(v.x));
+      acc[j] = Op::combine(acc[j], Load::template load<TA>(v.y));
+      acc[j] = Op::combine(acc[j], Load::template load<TA>(v.z));
+      acc[j] = Op::combine(acc[j], Load::template load<TA>(v.w));
+    }
+  }
+  for (; i < n_vec; i += tptg) {
+    const V v = vin[i];
+    acc[0] = Op::combine(acc[0], Load::template load<TA>(v.x));
+    acc[0] = Op::combine(acc[0], Load::template load<TA>(v.y));
+    acc[0] = Op::combine(acc[0], Load::template load<TA>(v.z));
+    acc[0] = Op::combine(acc[0], Load::template load<TA>(v.w));
+  }
+  for (uint k = n_vec * 4 + tid; k < E; k += tptg) {
+    acc[0] = Op::combine(acc[0], Load::template load<TA>(input[g_base + k]));
+  }
+  TA output_val = acc[0];
+  for (uint j = 1; j < NCHAINS; j++) {
+    output_val = Op::combine(output_val, acc[j]);
+  }
+  threadgroup TA shared_outputs[MAX_THREADGROUP_SIZE / simdgroup_size];
+  output_val = Op::threadgroup_reduce(shared_outputs, output_val, tid, tptg);
+  if (tid == 0) {
+    output[tgid] = output_val;
+  }
+}
+
 // Outer-dim variant: input is logically [M, N], reduce M down so output is
 // [N]. TG_X threads cover adjacent output columns (coalesced reads), TG_Y
 // threads split the M rows. Mirrors sum_reduction_outer; uses the same
@@ -1074,6 +1219,29 @@ kernel void value_reduction_inner(
   REGISTER_VALUE_REDUCTION_IMPL(TI, uchar, "any", MaxOp, PredicateLoad)
 #define REGISTER_ALL(TI) \
   REGISTER_VALUE_REDUCTION_IMPL(TI, uchar, "all", MinOp, PredicateLoad)
+
+#define REGISTER_VALUE_VEC_IMPL(TI, TO, NAME, OP, LOAD)           \
+  template [[host_name(NAME "_reduction_vec_" #TI "_" #TO)]]      \
+  kernel void value_reduction_vec<OP, LOAD, TI, TO, SUM_NCHAINS>( \
+      constant TI * input [[buffer(0)]],                          \
+      device TO * output [[buffer(1)]],                           \
+      constant uint2 & params [[buffer(2)]],                      \
+      uint tid [[thread_position_in_threadgroup]],                \
+      uint tptg [[threads_per_threadgroup]],                      \
+      uint tgid [[threadgroup_position_in_grid]]);
+
+#define REGISTER_VALUE_VEC(T)                                    \
+  REGISTER_VALUE_VEC_IMPL(T, T, "max", MaxOp, IdentityLoad)      \
+  REGISTER_VALUE_VEC_IMPL(T, T, "min", MinOp, IdentityLoad)      \
+  REGISTER_VALUE_VEC_IMPL(T, uchar, "any", MaxOp, PredicateLoad) \
+  REGISTER_VALUE_VEC_IMPL(T, uchar, "all", MinOp, PredicateLoad)
+
+REGISTER_VALUE_VEC(float);
+REGISTER_VALUE_VEC(half);
+REGISTER_VALUE_VEC(bfloat);
+REGISTER_VALUE_VEC(int);
+REGISTER_VALUE_VEC(long);
+REGISTER_VALUE_VEC(short);
 
 // Numeric types that participate in min/max AND all/any.
 #define REGISTER_REDUCTIONS_OPS_FOR_TYPE(T) \

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -980,8 +980,15 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
       const uint32_t elems_per_group = reduction_size / num_groups;
       auto partials = at::empty({(int64_t)num_groups}, output.options().dtype(opts.partial_dtype));
 
-      auto p1_kernel =
-          fmt::format("{}reduction{}_{}_{}", opts.prefix, use_strided ? "_strided" : "", in_str, partial_str);
+      const bool vec_ok = opts.input_kernel_dtype == kFloat || opts.input_kernel_dtype == kHalf ||
+          opts.input_kernel_dtype == kBFloat16 || opts.input_kernel_dtype == kInt || opts.input_kernel_dtype == kLong ||
+          opts.input_kernel_dtype == kShort;
+      const bool vec_op = opts.prefix == "sum_" || opts.prefix == "nansum_" || opts.prefix == "min_" ||
+          opts.prefix == "max_" || opts.prefix == "all_" || opts.prefix == "any_";
+      const bool use_vec = !use_strided && vec_op && vec_ok && (elems_per_group % 4 == 0);
+      auto p1_kernel = use_vec
+          ? fmt::format("{}reduction_vec_{}_{}", opts.prefix, in_str, partial_str)
+          : fmt::format("{}reduction{}_{}_{}", opts.prefix, use_strided ? "_strided" : "", in_str, partial_str);
       auto p2_kernel = fmt::format("{}reduction_{}_{}", opts.pass2_prefix, partial_str, out_str);
 
       NormParams params1{};
@@ -1022,19 +1029,16 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
           auto ps1 = lib.getPipelineStateForFunc(p1_kernel);
           getMPSProfiler().beginProfileKernel(ps1, opts.prefix + "reduction_pass1", {input});
           [ce setComputePipelineState:ps1];
-          mtl_setArgs(ce, input, partials, params1);
-          // Round both passes' TG sizes up to a full simdgroup. Required
-          // because c10::metal::simd_max/min<long> emulates 64-bit simd
-          // via simd_shuffle_and_fill_down, and inactive lanes (when active
-          // count < 32) return undefined data (in practice 0) instead of
-          // the op's identity — corrupting min/max of all-positive or
-          // all-negative longs. The fill value itself is fixed in
-          // reduction_utils.h, but the fill only applies to past-end
-          // shuffles, not to inactive-lane reads within the simdgroup.
-          // Padding threads here skip the load loop (tid >= rsize) and
-          // contribute Op::identity().
-          auto tpg1 = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(elems_per_group, 32u));
-          [ce dispatchThreads:MTLSizeMake(num_groups * tpg1, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg1, 1, 1)];
+          if (use_vec) {
+            const std::array<uint32_t, 2> vparams{num_groups, elems_per_group};
+            mtl_setArgs(ce, input, partials, vparams);
+            constexpr uint32_t TPG = 256;
+            [ce dispatchThreads:MTLSizeMake(num_groups * TPG, 1, 1) threadsPerThreadgroup:MTLSizeMake(TPG, 1, 1)];
+          } else {
+            mtl_setArgs(ce, input, partials, params1);
+            auto tpg1 = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(elems_per_group, 32u));
+            [ce dispatchThreads:MTLSizeMake(num_groups * tpg1, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg1, 1, 1)];
+          }
           getMPSProfiler().endProfileKernel(ps1);
 
           auto ps2 = lib.getPipelineStateForFunc(p2_kernel);

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -847,7 +847,9 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
 // Unified host-side dispatch for value-preserving reductions on MPS, shared
 // by sum/nansum/mean/count_nonzero and min/max/all/any. Kernel name pattern
 // is always `{prefix}reduction_{variant}_{TI}_{TO}` with variant in
-// `""/"outer"/"inner"`. Selects among four code paths:
+// `""/"outer"/"inner"/"flat"/"strided"`; every op/dtype pair with a base
+// kernel also has the flat and strided variants. Selects among four code
+// paths:
 //   1. Outer-dim kernel (dim=0 on contiguous input).
 //   2. Inner-dim kernel (last dim on contiguous input).
 //   3. Two-pass full reduction (scalar output, large input).
@@ -980,15 +982,8 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
       const uint32_t elems_per_group = reduction_size / num_groups;
       auto partials = at::empty({(int64_t)num_groups}, output.options().dtype(opts.partial_dtype));
 
-      const bool vec_ok = opts.input_kernel_dtype == kFloat || opts.input_kernel_dtype == kHalf ||
-          opts.input_kernel_dtype == kBFloat16 || opts.input_kernel_dtype == kInt || opts.input_kernel_dtype == kLong ||
-          opts.input_kernel_dtype == kShort;
-      const bool vec_op = opts.prefix == "sum_" || opts.prefix == "nansum_" || opts.prefix == "min_" ||
-          opts.prefix == "max_" || opts.prefix == "all_" || opts.prefix == "any_";
-      const bool use_vec = !use_strided && vec_op && vec_ok && (elems_per_group % 4 == 0);
-      auto p1_kernel = use_vec
-          ? fmt::format("{}reduction_vec_{}_{}", opts.prefix, in_str, partial_str)
-          : fmt::format("{}reduction{}_{}_{}", opts.prefix, use_strided ? "_strided" : "", in_str, partial_str);
+      auto p1_kernel =
+          fmt::format("{}reduction{}_{}_{}", opts.prefix, use_strided ? "_strided" : "_flat", in_str, partial_str);
       auto p2_kernel = fmt::format("{}reduction_{}_{}", opts.pass2_prefix, partial_str, out_str);
 
       NormParams params1{};
@@ -999,15 +994,6 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
           params1.input_sizes[d] = input.size(d);
           params1.input_strides[d] = input.stride(d);
         }
-      } else {
-        // Model as 2D: input is [num_groups, elems_per_group], reduce dim=1.
-        params1.ndim = 2;
-        params1.input_sizes[0] = num_groups;
-        params1.input_strides[0] = elems_per_group;
-        params1.output_sizes[0] = num_groups;
-        params1.output_strides[0] = 1;
-        params1.input_sizes[1] = elems_per_group;
-        params1.input_strides[1] = 1;
       }
 
       // Pass 2: partials[num_groups] -> output[1], reduce dim=0. divisor
@@ -1029,12 +1015,7 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
           auto ps1 = lib.getPipelineStateForFunc(p1_kernel);
           getMPSProfiler().beginProfileKernel(ps1, opts.prefix + "reduction_pass1", {input});
           [ce setComputePipelineState:ps1];
-          if (use_vec) {
-            const std::array<uint32_t, 2> vparams{num_groups, elems_per_group};
-            mtl_setArgs(ce, input, partials, vparams);
-            constexpr uint32_t TPG = 256;
-            [ce dispatchThreads:MTLSizeMake(num_groups * TPG, 1, 1) threadsPerThreadgroup:MTLSizeMake(TPG, 1, 1)];
-          } else {
+          if (use_strided) {
             mtl_setArgs(ce, input, partials, params1);
             // Round up to a full simdgroup: c10::metal::simd_max/min<long>
             // reads its neighbours' registers, and a partially populated
@@ -1043,6 +1024,11 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
             // and contribute Op::identity() instead.
             auto tpg1 = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(elems_per_group, 32u));
             [ce dispatchThreads:MTLSizeMake(num_groups * tpg1, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg1, 1, 1)];
+          } else {
+            const std::array<uint32_t, 2> fparams{num_groups, elems_per_group};
+            mtl_setArgs(ce, input, partials, fparams);
+            constexpr uint32_t TPG = 256;
+            [ce dispatchThreads:MTLSizeMake(num_groups * TPG, 1, 1) threadsPerThreadgroup:MTLSizeMake(TPG, 1, 1)];
           }
           getMPSProfiler().endProfileKernel(ps1);
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5934,6 +5934,14 @@ class TestMPS(TestCaseMPS):
             for cpu, mps in ((x.cpu(), x), (x.t().cpu(), x.t())):
                 self.assertEqual(mps.sum(**kw).cpu(), cpu.sum(**kw))
 
+    def test_sum_integer_no_overflow(self):
+        # int sums must accumulate in int64: 2**30 overflows int32 after 4 adds
+        cases = (((1 << 20,), None), ((1024, 1024), None), ((131072, 16), 1), ((65536, 16), 0))
+        for shape, dim in cases:
+            x = torch.full(shape, 2**30, dtype=torch.int32, device="mps")
+            args = () if dim is None else (dim,)
+            self.assertEqual(x.sum(*args).cpu(), x.cpu().sum(*args))
+
     def test_trace_repeated(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/178497
         torch.manual_seed(42)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #191100
* #191099
* #191098
* #191097
* __->__ #191101
* #191104 

Two changes to how MPS reductions handle dtypes and full (scalar-output) reductions:

`make_reduction` casts the input to the accumulation dtype when it differs from the output dtype, which on MPS materializes a 2-8x larger copy plus a cast kernel before the reduction starts. The Metal kernels never needed it: they are instantiated per (input, output) dtype pair and widen in-register. This PR passes the original input dtype through for integral -> int64 (new, MPS-only) and half/bf16 -> fp32, on the sum/mean overload only; the overload shared with `vector_norm`/nansum keeps casting since MPS has no (half, float) norm kernels.

Second, pass 1 of the two-pass full reduction (at most 512 contiguous slices, one threadgroup each) was walking the generic `NormParams` indexing helper one scalar at a time, even though the partition is just [num_groups, elems_per_group] over a contiguous buffer. `sum_reduction_flat` (sum/nansum/mean/count_nonzero) and `value_reduction_flat` (min/max/any/all) replace it with flat indexing, chained accumulators, and an unrolled 4-elements-per-step inner loop. Loads stay scalar, so every (op, input, output) pair with a base kernel gets a flat variant and dispatch is just strided vs flat.

<details>
<summary> 
Speedup over main
</summary>

| shape | dim | case | before us | after us | speedup |
| --- | --- | --- | ---: | ---: | ---: |
| `(1024,)` | full | f32 sum | 4.5 | 4.7 | 0.96x |
| `(1024,)` | full | bf16 sum | 3.7 | 3.7 | 1.01x |
| `(1024,)` | full | bf16 amax | 4.1 | 3.9 | 1.05x |
| `(1024,)` | full | i32 sum | 6.0 | 4.1 | 1.46x |
| `(1024,)` | full | bf16 sum, fp32 out | 5.6 | 3.5 | 1.60x |
| `(4096,)` | full | f32 sum | 3.8 | 3.9 | 0.99x |
| `(4096,)` | full | bf16 sum | 3.8 | 3.8 | 0.99x |
| `(4096,)` | full | bf16 amax | 4.1 | 4.2 | 0.96x |
| `(4096,)` | full | i32 sum | 6.3 | 4.1 | 1.55x |
| `(4096,)` | full | bf16 sum, fp32 out | 6.0 | 3.8 | 1.55x |
| `(8192,)` | full | f32 sum | 4.2 | 4.4 | 0.95x |
| `(8192,)` | full | bf16 sum | 4.1 | 3.8 | 1.07x |
| `(8192,)` | full | bf16 amax | 4.5 | 4.7 | 0.96x |
| `(8192,)` | full | i32 sum | 7.0 | 4.5 | 1.55x |
| `(8192,)` | full | bf16 sum, fp32 out | 6.1 | 4.1 | 1.51x |
| `(10000,)` | full | f32 sum | 6.3 | 5.5 | 1.14x |
| `(10000,)` | full | bf16 sum | 6.2 | 5.8 | 1.08x |
| `(10000,)` | full | bf16 amax | 6.9 | 6.2 | 1.12x |
| `(10000,)` | full | i32 sum | 9.4 | 6.3 | 1.49x |
| `(10000,)` | full | bf16 sum, fp32 out | 8.5 | 5.7 | 1.49x |
| `(16384,)` | full | f32 sum | 6.7 | 5.6 | 1.21x |
| `(16384,)` | full | bf16 sum | 6.4 | 5.6 | 1.15x |
| `(16384,)` | full | bf16 amax | 7.2 | 6.1 | 1.17x |
| `(16384,)` | full | i32 sum | 9.7 | 6.2 | 1.58x |
| `(16384,)` | full | bf16 sum, fp32 out | 8.9 | 5.5 | 1.63x |
| `(32768,)` | full | f32 sum | 6.7 | 5.7 | 1.19x |
| `(32768,)` | full | bf16 sum | 6.5 | 5.5 | 1.18x |
| `(32768,)` | full | bf16 amax | 7.3 | 6.4 | 1.14x |
| `(32768,)` | full | i32 sum | 10.3 | 6.2 | 1.66x |
| `(32768,)` | full | bf16 sum, fp32 out | 9.3 | 5.7 | 1.64x |
| `(65536,)` | full | f32 sum | 6.9 | 5.7 | 1.22x |
| `(65536,)` | full | bf16 sum | 6.5 | 5.3 | 1.23x |
| `(65536,)` | full | bf16 amax | 7.2 | 6.2 | 1.17x |
| `(65536,)` | full | i32 sum | 10.4 | 6.0 | 1.73x |
| `(65536,)` | full | bf16 sum, fp32 out | 9.4 | 5.6 | 1.69x |
| `(131072,)` | full | f32 sum | 6.7 | 5.8 | 1.16x |
| `(131072,)` | full | bf16 sum | 6.3 | 5.3 | 1.20x |
| `(131072,)` | full | bf16 amax | 7.0 | 6.0 | 1.17x |
| `(131072,)` | full | i32 sum | 11.1 | 6.2 | 1.78x |
| `(131072,)` | full | bf16 sum, fp32 out | 11.0 | 5.6 | 1.95x |
| `(262144,)` | full | f32 sum | 7.7 | 6.3 | 1.23x |
| `(262144,)` | full | bf16 sum | 7.2 | 5.8 | 1.23x |
| `(262144,)` | full | bf16 amax | 8.5 | 6.8 | 1.25x |
| `(262144,)` | full | i32 sum | 14.2 | 6.7 | 2.13x |
| `(262144,)` | full | bf16 sum, fp32 out | 14.5 | 5.8 | 2.52x |
| `(524288,)` | full | f32 sum | 9.7 | 7.1 | 1.37x |
| `(524288,)` | full | bf16 sum | 9.2 | 6.1 | 1.50x |
| `(524288,)` | full | bf16 amax | 11.6 | 7.8 | 1.48x |
| `(524288,)` | full | i32 sum | 29.5 | 7.8 | 3.77x |
| `(524288,)` | full | bf16 sum, fp32 out | 20.9 | 6.3 | 3.31x |
| `(1048576,)` | full | f32 sum | 15.9 | 11.7 | 1.36x |
| `(1048576,)` | full | bf16 sum | 12.6 | 7.3 | 1.73x |
| `(1048576,)` | full | bf16 amax | 17.1 | 10.3 | 1.67x |
| `(1048576,)` | full | i32 sum | 52.9 | 12.2 | 4.36x |
| `(1048576,)` | full | bf16 sum, fp32 out | 33.7 | 7.3 | 4.63x |
| `(4194304,)` | full | f32 sum | 48.1 | 37.4 | 1.29x |
| `(4194304,)` | full | bf16 sum | 34.0 | 21.5 | 1.58x |
| `(4194304,)` | full | bf16 amax | 51.3 | 34.5 | 1.49x |
| `(4194304,)` | full | i32 sum | 307.7 | 37.8 | 8.13x |
| `(4194304,)` | full | bf16 sum, fp32 out | 114.3 | 21.6 | 5.29x |
| `(16777216,)` | full | f32 sum | 243.0 | 233.4 | 1.04x |
| `(16777216,)` | full | bf16 sum | 118.2 | 108.2 | 1.09x |
| `(16777216,)` | full | bf16 amax | 116.7 | 108.1 | 1.08x |
| `(16777216,)` | full | i32 sum | 1266.9 | 233.9 | 5.42x |
| `(16777216,)` | full | bf16 sum, fp32 out | 644.7 | 108.2 | 5.96x |
| `(2048, 2048)` | 1 | i32 sum | 302.3 | 35.9 | 8.43x |
| `(2048, 2048)` | 0 | i32 sum | 298.3 | 37.4 | 7.98x |
| `(2048, 2048)` | full | i32 sum | 308.2 | 37.9 | 8.12x |
| `(2048, 2048)` | 1 | bf16 sum, fp32 out | 102.9 | 20.2 | 5.10x |
| `(2048, 2048)` | 1 | f16 sum, fp32 out | 101.7 | 20.1 | 5.05x |
| `(2048, 2048)` | full | bf16 sum | 34.2 | 21.5 | 1.59x |
| `(1048576,)` | full | i64 amax | 25.8 | 22.9 | 1.13x |
| `(32,)` | full | f32 sum (enqueue floor) | 3.4 | 3.4 | 0.99x |

</details>

<details> 
<summary> 
Benchmark script:
</summary>

```python
import csv
import sys
import time

import torch

WARMUP = 200
ITERS = 200
ROUNDS = 7

SIZES = (
    1024,
    4096,
    8192,
    10000,
    16384,
    32768,
    65536,
    131072,
    262144,
    524288,
    1 << 20,
    1 << 22,
    1 << 24,
)

VARIANTS = (
    ("f32 sum", torch.float32, lambda x: x.sum()),
    ("bf16 sum", torch.bfloat16, lambda x: x.sum()),
    ("i32 sum", torch.int32, lambda x: x.sum()),
    ("bf16 sum, fp32 out", torch.bfloat16, lambda x: x.sum(dtype=torch.float32)),
    ("bf16 amax", torch.bfloat16, lambda x: x.amax()),
)

CASES = [
    (f"({n},)", "full", case, dtype, (n,), fn) for n in SIZES for case, dtype, fn in VARIANTS
] + [
    ("(2048, 2048)", "1", "i32 sum", torch.int32, (2048, 2048), lambda x: x.sum(1)),
    ("(2048, 2048)", "0", "i32 sum", torch.int32, (2048, 2048), lambda x: x.sum(0)),
    ("(2048, 2048)", "full", "i32 sum", torch.int32, (2048, 2048), lambda x: x.sum()),
    ("(2048, 2048)", "1", "bf16 sum, fp32 out", torch.bfloat16, (2048, 2048), lambda x: x.sum(1, dtype=torch.float32)),
    ("(2048, 2048)", "1", "f16 sum, fp32 out", torch.float16, (2048, 2048), lambda x: x.sum(1, dtype=torch.float32)),
    ("(2048, 2048)", "full", "bf16 sum", torch.bfloat16, (2048, 2048), lambda x: x.sum()),
    ("(1048576,)", "full", "i64 amax", torch.int64, (1 << 20,), lambda x: x.amax()),
    ("(32,)", "full", "f32 sum (enqueue floor)", torch.float32, (32,), lambda x: x.sum()),
]


def make(dtype, shape):
    if dtype.is_floating_point:
        return torch.randn(shape, device="mps", dtype=dtype)
    return torch.randint(-8, 8, shape, device="mps", dtype=dtype)


def bench(fn, x):
    for _ in range(WARMUP):
        fn(x)
    torch.mps.synchronize()
    best = float("inf")
    for _ in range(ROUNDS):
        t0 = time.perf_counter()
        for _ in range(ITERS):
            fn(x)
        torch.mps.synchronize()
        best = min(best, (time.perf_counter() - t0) / ITERS * 1e6)
    return best


def main():
    torch.manual_seed(0)
    with open(sys.argv[1], "w", newline="") as f:
        w = csv.writer(f)
        w.writerow(("shape", "dim", "case", "us", "git_version"))
        for shape_name, dim, case, dtype, shape, fn in CASES:
            x = make(dtype, shape)
            us = bench(fn, x)
            w.writerow((shape_name, dim, case, f"{us:.6f}", torch.version.git_version))
            print(f"{shape_name:<14} {dim:<5} {case:<24} {us:8.1f} us", flush=True)


if __name__ == "__main__":
    main()

```

</details>

