### PR TITLE
Remove build variables that no longer have consumers

### DIFF
--- a/.ci/macwheel/build_env_setup.py
+++ b/.ci/macwheel/build_env_setup.py
@@ -21,14 +21,13 @@ from pathlib import Path
 
 # macOS arm64 build flags.
 # USE_DISTRIBUTED=1 needs libuv, built as part of the tensorpipe submodule.
-# MKLDNN/QNNPACK are off on Apple silicon.
+# MKLDNN is off on Apple silicon.
 MACOS_BUILD_ENV: dict[str, str] = {
     "TH_BINARY_BUILD": "1",
     "INSTALL_TEST": "0",
     "MACOSX_DEPLOYMENT_TARGET": "14.0",
     "USE_DISTRIBUTED": "1",
     "USE_MKLDNN": "OFF",
-    "USE_QNNPACK": "OFF",
     "BUILD_TEST": "OFF",
     "USE_PYTORCH_METAL_EXPORT": "1",
     "USE_COREML_DELEGATE": "1",

--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -160,7 +160,6 @@ fi
 echo "Building wheel at $(date)"
 
 time CMAKE_ARGS=${CMAKE_ARGS[@]} \
-    EXTRA_CAFFE2_CMAKE_FLAGS=${EXTRA_CAFFE2_CMAKE_FLAGS[@]} \
     BUILD_LIBTORCH_CPU_WITH_DEBUG=$BUILD_DEBUG_INFO \
     USE_NCCL=${USE_NCCL} USE_RCCL=${USE_RCCL} USE_KINETO=${USE_KINETO} \
     python -m build --wheel --no-isolation --outdir /tmp/$WHEELHOUSE_DIR
@@ -177,15 +176,10 @@ if [[ -n "$BUILD_PYTHONLESS" ]]; then
     # Note - just use whichever python we happen to be on
     python -m spin clean
 
-    if [[ $LIBTORCH_VARIANT = *"static"* ]]; then
-        STATIC_CMAKE_FLAG="-DTORCH_STATIC=1"
-    fi
-
     mkdir -p build
     pushd build
     echo "Calling tools/build_libtorch.py at $(date)"
     time CMAKE_ARGS=${CMAKE_ARGS[@]} \
-         EXTRA_CAFFE2_CMAKE_FLAGS="${EXTRA_CAFFE2_CMAKE_FLAGS[@]} $STATIC_CMAKE_FLAG" \
          python ../tools/build_libtorch.py
     echo "Finished tools/build_libtorch.py at $(date)"
     popd

--- a/.ci/manywheel/build_cpu.sh
+++ b/.ci/manywheel/build_cpu.sh
@@ -11,9 +11,6 @@ export USE_CUDA=0
 if [[ -z "$CMAKE_ARGS" ]]; then
     CMAKE_ARGS=()
 fi
-if [[ -z "$EXTRA_CAFFE2_CMAKE_FLAGS" ]]; then
-    EXTRA_CAFFE2_CMAKE_FLAGS=()
-fi
 
 ARCH=$(uname -m)
 echo "Building CPU wheel for architecture: $ARCH"

--- a/.ci/manywheel/build_libtorch.sh
+++ b/.ci/manywheel/build_libtorch.sh
@@ -100,17 +100,12 @@ fi
 
 echo "Calling -m pip install . -v --no-build-isolation at $(date)"
 
-if [[ $LIBTORCH_VARIANT = *"static"* ]]; then
-    STATIC_CMAKE_FLAG="-DTORCH_STATIC=1"
-fi
-
 (
     set -x
 
     mkdir -p build
 
     time CMAKE_ARGS=${CMAKE_ARGS[@]} \
-        EXTRA_CAFFE2_CMAKE_FLAGS="${EXTRA_CAFFE2_CMAKE_FLAGS[@]} $STATIC_CMAKE_FLAG" \
         # TODO: Remove this flag once https://github.com/pytorch/pytorch/issues/55952 is closed
         CFLAGS='-Wno-deprecated-declarations' \
         BUILD_LIBTORCH_CPU_WITH_DEBUG=1 \

--- a/.ci/pytorch/win-test-helpers/arm64/build_pytorch.ps1
+++ b/.ci/pytorch/win-test-helpers/arm64/build_pytorch.ps1
@@ -37,7 +37,6 @@ $env:CMAKE_POLICY_VERSION_MINIMUM = "3.5"
 # Set BLAS type
 if ($env:ENABLE_APL -eq "1") {
     $env:BLAS = "APL"
-    $env:USE_LAPACK = "1"
 } elseif ($env:ENABLE_OPENBLAS -eq "1") {
     $env:BLAS = "OpenBLAS"
     $env:OpenBLAS_HOME = Join-Path $env:DEPENDENCIES_DIR "OpenBLAS\install"

--- a/.ci/pytorch/windows/arm64/build_libtorch.bat
+++ b/.ci/pytorch/windows/arm64/build_libtorch.bat
@@ -14,7 +14,6 @@ if defined PYTORCH_BUILD_VERSION (
 :: Set BLAS type
 if %ENABLE_APL% == 1 (
     set BLAS=APL
-    set USE_LAPACK=1
 ) else if %ENABLE_OPENBLAS% == 1 (
     set BLAS=OpenBLAS
     set OpenBLAS_HOME=%DEPENDENCIES_DIR%\OpenBLAS\install

--- a/.ci/pytorch/windows/arm64/build_pytorch.bat
+++ b/.ci/pytorch/windows/arm64/build_pytorch.bat
@@ -15,7 +15,6 @@ if defined PYTORCH_BUILD_VERSION (
 :: Set BLAS type
 if %ENABLE_APL% == 1 (
     set BLAS=APL
-    set USE_LAPACK=1
 ) else if %ENABLE_OPENBLAS% == 1 (
     set BLAS=OpenBLAS
     set OpenBLAS_HOME=%DEPENDENCIES_DIR%\OpenBLAS\install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -791,7 +791,6 @@ On the initial build, you can also speed things up by disabling the features you
 - `BUILD_TEST=0` will disable building C++ test binaries.
 - `USE_FBGEMM=0` will disable using FBGEMM (quantized 8-bit server operators).
 - `USE_NNPACK=0` will disable compiling with NNPACK.
-- `USE_QNNPACK=0` will disable QNNPACK build (quantized 8-bit operators).
 - `USE_XNNPACK=0` will disable compiling with XNNPACK.
 - `USE_FLASH_ATTENTION=0` and `USE_MEM_EFF_ATTENTION=0` will disable compiling flash attention and memory efficient kernels respectively.
 - `BUILD_LAZY_TS_BACKEND=0` will disable the lazy TorchScript backend (Lazy Tensor Core).
@@ -801,7 +800,7 @@ On the initial build, you can also speed things up by disabling the features you
 
 For example, a good default for the most minimal build is to add to your bashrc is:
 ```bash
-alias BUILD_CONFIG='CMAKE_GENERATOR=Ninja USE_DISTRIBUTED=0 USE_FLASH_ATTENTION=0 USE_MEM_EFF_ATTENTION=0 USE_MKLDNN=0 USE_CUDA=0 BUILD_TEST=0 USE_FBGEMM=0 USE_NNPACK=0 USE_QNNPACK=0 USE_XNNPACK=0 BUILD_LAZY_TS_BACKEND=0 USE_PYTORCH_QNNPACK=0 USE_CPU_VECTORIZATION=0 USE_COLORIZE_OUTPUT=1'
+alias BUILD_CONFIG='CMAKE_GENERATOR=Ninja USE_DISTRIBUTED=0 USE_FLASH_ATTENTION=0 USE_MEM_EFF_ATTENTION=0 USE_MKLDNN=0 USE_CUDA=0 BUILD_TEST=0 USE_FBGEMM=0 USE_NNPACK=0 USE_XNNPACK=0 BUILD_LAZY_TS_BACKEND=0 USE_PYTORCH_QNNPACK=0 USE_CPU_VECTORIZATION=0 USE_COLORIZE_OUTPUT=1'
 ```
 
 You can then re-enable features selectively


### PR DESCRIPTION
While inventorying how build configuration switches reach CMake, four
variables turned out to be set by CI but read by nobody. All four predate
the scikit-build-core migration; none is fallout from it.

EXTRA_CAFFE2_CMAKE_FLAGS lost its consumers in #16289 (2019), which
deleted tools/build_pytorch_libs.{sh,bat} and replaced them with a Python
script that never read the variable. TORCH_STATIC, reachable only through
EXTRA_CAFFE2_CMAKE_FLAGS via STATIC_CMAKE_FLAG, was removed as a CMake
option by #20774 (2019) a month after #17783 introduced it. USE_QNNPACK
was cleared by #126941 (2024) along with the third_party/QNNPACK
submodule (#126657); the surviving in-tree fork is gated by the
separate USE_PYTORCH_QNNPACK, which this change leaves alone. USE_LAPACK
has been a computed output rather than an input since #47803 (2020):
cmake/Dependencies.cmake unconditionally sets it to 0 and then to 1 if
find_package(LAPACK) succeeds, so setting it in the environment has never
had an effect.

CONTRIBUTING.md documented USE_QNNPACK as a working toggle and included
it in the suggested BUILD_CONFIG alias; both are dropped. The neighboring
USE_PYTORCH_QNNPACK entry already covers the kernels that still exist.

Every removal is behavior-preserving, so there is nothing to verify at
runtime beyond the scripts still parsing. Two adjacent issues are
deliberately left in place rather than folded in, since fixing either
would change what CI produces:

- The macOS comment claimed QNNPACK was off on Apple silicon. It was not:
  USE_PYTORCH_QNNPACK defaults ON and is auto-disabled only for
  unsupported architectures or MSVC, neither of which applies to arm64
  macOS. The comment is corrected to describe what the dict actually
  does; whether macOS wheels should disable USE_PYTORCH_QNNPACK is a
  separate question.
- In .ci/manywheel/build_libtorch.sh a comment sits between two
  line-continuations, which terminates the command. CMAKE_ARGS is
  therefore silently dropped from the pip invocation, and only CFLAGS and
  BUILD_LIBTORCH_CPU_WITH_DEBUG reach it. This change removes one
  assignment from that construct without altering it.

Test Plan:

Confirmed no consumer exists anywhere in the tree (and none in
pytorch/test-infra, which sets none of these):

```
grep -rn "EXTRA_CAFFE2_CMAKE_FLAGS\|TORCH_STATIC\|USE_QNNPACK\|USE_LAPACK" \
  --include="*.py" --include="*.cmake" --include="CMakeLists.txt" \
  --include="*.toml" . | grep -v third_party
```

Confirmed nothing references the removed names afterwards, that the
surviving USE_LAPACK hits are only the computed variable and its summary
line, and that the edited scripts still parse:

```
grep -rn "EXTRA_CAFFE2_CMAKE_FLAGS\|STATIC_CMAKE_FLAG\|TORCH_STATIC\|USE_QNNPACK" \
  . --exclude-dir=.git --exclude-dir=third_party
bash -n .ci/manywheel/build_common.sh .ci/manywheel/build_cpu.sh \
        .ci/manywheel/build_libtorch.sh
python -c "import ast; ast.parse(open('.ci/macwheel/build_env_setup.py').read())"
lintrunner -a <changed files>
```

The CD jobs that run these scripts (manywheel linux, macOS arm64 wheel,
Windows arm64) are the real check and need to stay green.

Authored with assistance from Claude Code.

