### PR TITLE
[MPS] Faster reductions (0/5): fix int64 min/max over partial simdgroups

### DIFF
--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -293,8 +293,13 @@ T threadgroup_max(threadgroup T* data, T val, unsigned idx, unsigned size) {
   }
   if (size > simdgroup_size) {
     ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-    if (idx < ((size + simdgroup_size - 1) / simdgroup_size)) {
-      auto rc1 = simd_max(data[idx]);
+    // Whole first simdgroup must stay active: simd_max<long> reads its
+    // neighbours' registers, and inactive lanes yield undefined data (0 in
+    // practice), not the op identity. Clamping the index re-reads the last
+    // partial instead, which max is idempotent over.
+    const auto nsimd = (size + simdgroup_size - 1) / simdgroup_size;
+    if (idx < simdgroup_size) {
+      auto rc1 = simd_max(data[::metal::min(idx, nsimd - 1)]);
       if (idx == 0) {
         data[0] = rc1;
       }
@@ -312,8 +317,9 @@ T threadgroup_min(threadgroup T* data, T val, unsigned idx, unsigned size) {
   }
   if (size > simdgroup_size) {
     ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-    if (idx < ((size + simdgroup_size - 1) / simdgroup_size)) {
-      auto rc1 = simd_min(data[idx]);
+    const auto nsimd = (size + simdgroup_size - 1) / simdgroup_size;
+    if (idx < simdgroup_size) {
+      auto rc1 = simd_min(data[::metal::min(idx, nsimd - 1)]);
       if (idx == 0) {
         data[0] = rc1;
       }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5934,6 +5934,17 @@ class TestMPS(TestCaseMPS):
             for cpu, mps in ((x.cpu(), x), (x.t().cpu(), x.t())):
                 self.assertEqual(mps.sum(**kw).cpu(), cpu.sum(**kw))
 
+    def test_int64_minmax_partial_simdgroups(self):
+        # simd_max/min<long> is emulated on top of simd_shuffle_and_fill_down and
+        # reads its neighbours' registers, so a reduction stage that leaves fewer
+        # than 32 lanes active used to fold their zeros into the result. Sizes
+        # span threadgroups of 64 to 1024 threads over the single-pass and
+        # split-K paths.
+        for n in (33, 64, 100, 1000, 20000, 262185, 1 << 20):
+            x = -torch.arange(1, n + 1, dtype=torch.int64, device="mps")
+            self.assertEqual(x.amax().cpu(), x.cpu().amax())
+            self.assertEqual((-x).amin().cpu(), (-x).cpu().amin())
+
     def test_trace_repeated(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/178497
         torch.manual_seed(42)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5934,16 +5934,16 @@ class TestMPS(TestCaseMPS):
             for cpu, mps in ((x.cpu(), x), (x.t().cpu(), x.t())):
                 self.assertEqual(mps.sum(**kw).cpu(), cpu.sum(**kw))
 
-    def test_int64_minmax_partial_simdgroups(self):
+    @parametrize("n", [33, 64, 100, 1000, 20000, 262185, 1 << 20])
+    def test_int64_minmax_partial_simdgroups(self, n):
         # simd_max/min<long> is emulated on top of simd_shuffle_and_fill_down and
         # reads its neighbours' registers, so a reduction stage that leaves fewer
         # than 32 lanes active used to fold their zeros into the result. Sizes
         # span threadgroups of 64 to 1024 threads over the single-pass and
         # split-K paths.
-        for n in (33, 64, 100, 1000, 20000, 262185, 1 << 20):
-            x = -torch.arange(1, n + 1, dtype=torch.int64, device="mps")
-            self.assertEqual(x.amax().cpu(), x.cpu().amax())
-            self.assertEqual((-x).amin().cpu(), (-x).cpu().amin())
+        x = -torch.arange(1, n + 1, dtype=torch.int64, device="mps")
+        self.assertEqual(x.amax().cpu(), x.cpu().amax())
+        self.assertEqual((-x).amin().cpu(), (-x).cpu().amin())
 
     def test_trace_repeated(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/178497


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #191100
* #191099
* #191098
* #191097
* #191101
* __->__ #191104

int64 `amax`/`amin` return 0 on MPS whenever the reduction runs in a threadgroup smaller than 1024 threads:

```python
>>> x = -torch.arange(1, 101, dtype=torch.int64, device="mps")
>>> torch.amax(x)
tensor(0, device='mps:0')   # want -1
```

`threadgroup_max`/`threadgroup_min` reduce in two stages: every simdgroup reduces its own lanes into `data[simdgroup_id]`, then simdgroup 0 folds those partials. Stage 2 is broken for int64 currently:

| | stage 1 | stage 2 |
| --- | --- | --- |
| who runs | all threads in threadgroup, rounded up to a multiple of 32 by the dispatch | `if (idx < ceil(tptg / 32))`, i.e. one lane per partial |
| threads with no data | execute, skip the load loop, keep `acc = Op::identity()` | never execute at all |
| result | correct, identity loses every comparison | lanes `nsimd..31` are masked off, and their registers are read anyway |

Metal has no 64-bit simd reduction, so `c10::metal::simd_max/min<long>` is used instead: lane 0 reads lane 16's register, then lane 8's, then 4, 2, 1, with just classic `shfl_down_sync` from cuda

Reading a lane that isn't executing gives 0, not the op identity. In a `max` over negative values that 0 wins. (The `fill` argument doesn't help; it only applies past lane 31)

Every other type uses hardware `simd_max`, which sees active lanes only. So this is `long`-only.

`threadgroup_max`/`threadgroup_min` break that requirement themselves. They reduce in two stages: every simdgroup reduces its own lanes into `data[simdgroup_id]`, then simdgroup 0 folds the partials. Stage 2 was guarded by the number of partials, not the width of a simdgroup:

```cpp
if (idx < ((size + simdgroup_size - 1) / simdgroup_size)) {   // 4 lanes for a 128-thread group
  auto rc1 = simd_max(data[idx]);                             // reads all 32, 28 of them dead
```

128 threads is 4 partials. Stage 2 runs 4 tids and reads 32. The other 28 come back as 0.

Perf stays the same
| dtype | threadgroups | elements each | threads/group | old us | new us | delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| f32 | 65536 | 64 | 64 | 96.55 | 97.66 | +1.1% |
| f32 | 65536 | 256 | 256 | 342.35 | 333.44 | -2.6% |
| f32 | 16384 | 1024 | 256 | 279.91 | 278.47 | -0.5% |
| f32 | 4096 | 8192 | 1024 | 550.42 | 541.15 | -1.7% |
| f32 | 512 | 8192 | 1024 | 43.59 | 41.57 | -4.6% |
| bf16 | 65536 | 64 | 64 | 99.62 | 100.32 | +0.7% |
| bf16 | 65536 | 256 | 256 | 346.75 | 340.53 | -1.8% |
| bf16 | 16384 | 1024 | 256 | 170.44 | 168.44 | -1.2% |
| bf16 | 4096 | 8192 | 1024 | 315.03 | 319.57 | +1.4% |
| bf16 | 512 | 8192 | 1024 | 37.13 | 36.47 | -1.8% |
| i64 | 65536 | 64 | 64 | 154.48 | 153.53 | -0.6% |
| i64 | 65536 | 256 | 256 | 569.26 | 576.91 | +1.3% |
| i64 | 16384 | 1024 | 256 | 538.41 | 538.67 | +0.0% |
| i64 | 4096 | 8192 | 1024 | 1076.05 | 1076.16 | +0.0% |
| i64 | 512 | 8192 | 1024 | 131.28 | 130.59 | -0.5% |