### PR TITLE
[CUDA] Only suggest expandable segments when disabled

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1949,10 +1949,12 @@ class DeviceCachingAllocator {
           format_size(
               reserved_bytes - allocated_bytes - allocated_in_private_pools),
           " is reserved by PyTorch but unallocated.",
-          " If reserved but unallocated memory is large try setting",
-          " PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid"
-          " fragmentation.  See documentation for Memory Management "
-          " (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)");
+          CUDAAllocatorConfig::expandable_segments()
+              ? ""
+              : " If reserved but unallocated memory is large try setting"
+                " PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid"
+                " fragmentation.  See documentation for Memory Management "
+                " (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)");
     }
 
     bool split_remainder = should_split(

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6922,44 +6922,6 @@ print(value, end="")
             torch.empty(1024 * 1024 * 1024 * 1024, device="cuda")
         self.assertTrue(x)
 
-    @unittest.skipIf(
-        TEST_CUDAMALLOCASYNC,
-        "expandable_segments is not supported with cudaMallocAsync",
-    )
-    @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
-    @serialTest()
-    def test_oom_expandable_segments_hint(self):
-        hint = "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True"
-        original_settings = torch._C._accelerator_getAllocatorSettings()
-        original_expandable_segments = torch.cuda.memory._snapshot()[
-            "allocator_settings"
-        ]["expandable_segments"]
-
-        def settings_with_expandable_segments(enabled: bool) -> str:
-            return (
-                f"{original_settings},expandable_segments:{enabled}"
-                if original_settings
-                else f"expandable_segments:{enabled}"
-            )
-
-        try:
-            for enabled in (False, True):
-                torch.cuda.memory._set_allocator_settings(
-                    settings_with_expandable_segments(enabled)
-                )
-                with self.assertRaises(torch.cuda.OutOfMemoryError) as cm:
-                    torch.empty(1024 * 1024 * 1024 * 1024, device="cuda")
-
-                if enabled:
-                    self.assertNotIn(hint, str(cm.exception))
-                else:
-                    self.assertIn(hint, str(cm.exception))
-        finally:
-            torch.cuda.memory._set_allocator_settings(
-                settings_with_expandable_segments(original_expandable_segments)
-            )
-            torch.cuda.memory._set_allocator_settings(original_settings)
-
     def test_allocator_fuzz(self):
         # fuzz
         if (

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6922,6 +6922,44 @@ print(value, end="")
             torch.empty(1024 * 1024 * 1024 * 1024, device="cuda")
         self.assertTrue(x)
 
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "expandable_segments is not supported with cudaMallocAsync",
+    )
+    @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
+    @serialTest()
+    def test_oom_expandable_segments_hint(self):
+        hint = "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True"
+        original_settings = torch._C._accelerator_getAllocatorSettings()
+        original_expandable_segments = torch.cuda.memory._snapshot()[
+            "allocator_settings"
+        ]["expandable_segments"]
+
+        def settings_with_expandable_segments(enabled: bool) -> str:
+            return (
+                f"{original_settings},expandable_segments:{enabled}"
+                if original_settings
+                else f"expandable_segments:{enabled}"
+            )
+
+        try:
+            for enabled in (False, True):
+                torch.cuda.memory._set_allocator_settings(
+                    settings_with_expandable_segments(enabled)
+                )
+                with self.assertRaises(torch.cuda.OutOfMemoryError) as cm:
+                    torch.empty(1024 * 1024 * 1024 * 1024, device="cuda")
+
+                if enabled:
+                    self.assertNotIn(hint, str(cm.exception))
+                else:
+                    self.assertIn(hint, str(cm.exception))
+        finally:
+            torch.cuda.memory._set_allocator_settings(
+                settings_with_expandable_segments(original_expandable_segments)
+            )
+            torch.cuda.memory._set_allocator_settings(original_settings)
+
     def test_allocator_fuzz(self):
         # fuzz
         if (


### PR DESCRIPTION
## Issue

Fixes #173049

## Summary

Only include the `expandable_segments:True` OOM hint when expandable segments are disabled. Add a CUDA regression test covering both allocator settings and restoring the complete original allocator configuration afterward.

Local checks:
- `python3 -m py_compile test/test_cuda.py`
- `lintrunner --take CLANGFORMAT,PYFMT,RUFF -r origin/main`

The CUDA regression test was not run locally because the development host has no CUDA device; it is left to CI.

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [x] Updated documentation (not applicable)
- [x] Included benchmark results (not applicable; no performance impact)

## BC-breaking?

No.

## AI-assisted development disclosure

Codex was used to assist with this contribution.