### PR TITLE
[BE][Ez]: Add missing moves to std::get from std::tuple

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesNorm.cpp
+++ b/aten/src/ATen/functorch/BatchRulesNorm.cpp
@@ -642,7 +642,8 @@ static std::tuple<at::Tensor,at::Tensor,at::Tensor> native_layer_norm_backward_p
         normalized_shape,
         mean_value, mean_bdim,
         rstd_value, rstd_bdim);
-    grad_input = makeBatched(std::get<0>(results), std::get<1>(results), cur_level);
+    grad_input = makeBatched(
+        std::move(std::get<0>(results)), std::get<1>(results), cur_level);
   }
   return std::make_tuple(std::move(grad_input), std::move(grad_weight), std::move(grad_bias));
 }

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -330,19 +330,23 @@ Tensor index_plumbing(const Tensor & self, const List<std::optional<Tensor>> & i
   }
   auto [self_value, self_bdim] = unwrapTensorAtLevel(self, cur_level);
   std::vector<std::optional<Tensor>> indices_value;
+  indices_value.reserve(indices.size());
   std::vector<std::optional<int64_t>> indices_bdims;
+  indices_bdims.reserve(indices.size());
   for (const auto&& indRef : indices) {
-      std::optional<Tensor> ind = indRef;
-      std::optional<Tensor> index;
-      std::optional<int64_t> index_bdim;
-      if (ind.has_value()) {
-        std::tie(index, index_bdim) = unwrapTensorAtLevel(ind.value(), cur_level);
-      }
-    indices_value.push_back(index);
+    std::optional<Tensor> ind = indRef;
+    std::optional<Tensor> index;
+    std::optional<int64_t> index_bdim;
+    if (ind.has_value()) {
+      std::tie(index, index_bdim) =
+          unwrapTensorAtLevel(ind.value(), cur_level);
+    }
+    indices_value.push_back(std::move(index));
     indices_bdims.push_back(index_bdim);
   }
   auto results = index_batch_rule(self_value, self_bdim, indices_value, indices_bdims);
-  return makeBatched(std::get<0>(results), std::get<1>(results), cur_level);
+  return makeBatched(
+      std::move(std::get<0>(results)), std::get<1>(results), cur_level);
 }
 
 namespace {
@@ -676,7 +680,8 @@ Tensor index_put_plumbing(const Tensor & self, const List<std::optional<Tensor>>
   auto [self_value, self_bdim, indices_value, indices_bdims, values_value, values_bdim] =
       unpackSelfAndIndicesAndValuesAtCurrentLevel(self, indices, values_, cur_level);
   auto results = index_put_batch_rule(self_value, self_bdim, indices_value, indices_bdims, values_value, values_bdim, accumulate);
-  return makeBatched(std::get<0>(results), std::get<1>(results), cur_level);
+  return makeBatched(
+      std::move(std::get<0>(results)), std::get<1>(results), cur_level);
 }
 
 namespace {

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -333,13 +333,11 @@ Tensor index_plumbing(const Tensor & self, const List<std::optional<Tensor>> & i
   indices_value.reserve(indices.size());
   std::vector<std::optional<int64_t>> indices_bdims;
   indices_bdims.reserve(indices.size());
-  for (const auto&& indRef : indices) {
-    std::optional<Tensor> ind = indRef;
-    std::optional<Tensor> index;
+  for (std::optional<Tensor> index : indices) {
     std::optional<int64_t> index_bdim;
-    if (ind.has_value()) {
+    if (index.has_value()) {
       std::tie(index, index_bdim) =
-          unwrapTensorAtLevel(ind.value(), cur_level);
+          unwrapTensorAtLevel(index.value(), cur_level);
     }
     indices_value.push_back(std::move(index));
     indices_bdims.push_back(index_bdim);

--- a/aten/src/ATen/native/Pooling.cpp
+++ b/aten/src/ATen/native/Pooling.cpp
@@ -156,7 +156,7 @@ Tensor max_pool2d(
 #endif
   auto output_and_indices = at::max_pool2d_with_indices(
       self, kernel_size, stride, padding, dilation, ceil_mode);
-  return std::get<0>(output_and_indices);
+  return std::get<0>(std::move(output_and_indices));
 }
 
 Tensor max_pool3d(
@@ -176,7 +176,7 @@ Tensor max_pool3d(
   }
   auto output_and_indices = at::max_pool3d_with_indices(
       self, kernel_size, stride, padding, dilation, ceil_mode);
-  return std::get<0>(output_and_indices);
+  return std::get<0>(std::move(output_and_indices));
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -1093,15 +1093,15 @@ Tensor reduce_sparse_csr_dim0_cpu_template(const Tensor& sparse, ReductionOp rop
   // of float should be float in current scenario. In CUDA, float is the accumulate type
   // of float, while in CPU, double is the accumulate type of float.
   using acc_t = at::acc_type<scalar_t, true>;
-  auto [new_values, new_values_acc] =
-      at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
-          values.options(), values.scalar_type(), nnz);
+  auto acc_buffer = at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
+      values.options(), values.scalar_type(), nnz);
+  Tensor new_values = std::move(std::get<0>(acc_buffer));
+  Tensor new_values_acc = std::move(std::get<1>(acc_buffer));
   new_values_acc.fill_(rop.identity());
 
   const int64_t* columns_map_ptr = columns_map.const_data_ptr<int64_t>();
   const scalar_t* values_ptr = values.const_data_ptr<scalar_t>();
-  acc_t* new_values_acc_ptr =
-      new_values_acc.template data_ptr<acc_t>();
+  acc_t* new_values_acc_ptr = new_values_acc.data_ptr<acc_t>();
 
   // There is no point in parallelizing the following for-loop
   // because about 99.3% of the computation time is spent in the
@@ -1180,9 +1180,10 @@ Tensor reduce_sparse_csr_dim1_cpu_template(const Tensor& sparse, ReductionOp rop
   // of float should be float in current scenario. In CUDA, float is the accumulate type
   // of float, while in CPU, double is the accumulate type of float.
   using acc_t = at::acc_type<scalar_t, true>;
-  auto [new_values, new_values_acc] =
-      at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
-          values.options(), values.scalar_type());
+  auto acc_buffer = at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
+      values.options(), values.scalar_type());
+  Tensor new_values = std::move(std::get<0>(acc_buffer));
+  Tensor new_values_acc = std::move(std::get<1>(acc_buffer));
 
   AT_DISPATCH_INDEX_TYPES(crow_indices.scalar_type(), "reduce_sparse_csr_dim1_cpu_indices",
                           [&]() {
@@ -1204,8 +1205,7 @@ Tensor reduce_sparse_csr_dim1_cpu_template(const Tensor& sparse, ReductionOp rop
     new_values_acc.resize_(nnz);
 
     scalar_t* values_ptr = values.data_ptr<scalar_t>();
-    acc_t* new_values_acc_ptr =
-        new_values_acc.template data_ptr<acc_t>();
+    acc_t* new_values_acc_ptr = new_values_acc.data_ptr<acc_t>();
 
     at::parallel_for(
         0,

--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -1093,10 +1093,9 @@ Tensor reduce_sparse_csr_dim0_cpu_template(const Tensor& sparse, ReductionOp rop
   // of float should be float in current scenario. In CUDA, float is the accumulate type
   // of float, while in CPU, double is the accumulate type of float.
   using acc_t = at::acc_type<scalar_t, true>;
-  auto acc_buffer = at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
-      values.options(), values.scalar_type(), nnz);
-  Tensor new_values = std::get<0>(acc_buffer);
-  Tensor new_values_acc = std::get<1>(acc_buffer);
+  auto [new_values, new_values_acc] =
+      at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
+          values.options(), values.scalar_type(), nnz);
   new_values_acc.fill_(rop.identity());
 
   const int64_t* columns_map_ptr = columns_map.const_data_ptr<int64_t>();
@@ -1181,10 +1180,9 @@ Tensor reduce_sparse_csr_dim1_cpu_template(const Tensor& sparse, ReductionOp rop
   // of float should be float in current scenario. In CUDA, float is the accumulate type
   // of float, while in CPU, double is the accumulate type of float.
   using acc_t = at::acc_type<scalar_t, true>;
-  auto acc_buffer = at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
-      values.options(), values.scalar_type());
-  Tensor new_values = std::get<0>(acc_buffer);
-  Tensor new_values_acc = std::get<1>(acc_buffer);
+  auto [new_values, new_values_acc] =
+      at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
+          values.options(), values.scalar_type());
 
   AT_DISPATCH_INDEX_TYPES(crow_indices.scalar_type(), "reduce_sparse_csr_dim1_cpu_indices",
                           [&]() {

--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -1101,7 +1101,7 @@ Tensor reduce_sparse_csr_dim0_cpu_template(const Tensor& sparse, ReductionOp rop
   const int64_t* columns_map_ptr = columns_map.const_data_ptr<int64_t>();
   const scalar_t* values_ptr = values.const_data_ptr<scalar_t>();
   acc_t* new_values_acc_ptr =
-      new_values_acc.data_ptr<acc_t>();
+      new_values_acc.template data_ptr<acc_t>();
 
   // There is no point in parallelizing the following for-loop
   // because about 99.3% of the computation time is spent in the
@@ -1204,7 +1204,8 @@ Tensor reduce_sparse_csr_dim1_cpu_template(const Tensor& sparse, ReductionOp rop
     new_values_acc.resize_(nnz);
 
     scalar_t* values_ptr = values.data_ptr<scalar_t>();
-    acc_t* new_values_acc_ptr = new_values_acc.data_ptr<acc_t>();
+    acc_t* new_values_acc_ptr =
+        new_values_acc.template data_ptr<acc_t>();
 
     at::parallel_for(
         0,

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -1396,7 +1396,7 @@ SparseTensor& _sparse_mm_out(const SparseTensor& sparse,
 Tensor _sparse_mm(const Tensor& mat1, const Tensor& mat2, const std::string_view reduce) {
   // result: out, arg_out
   auto result = at::_sparse_mm_reduce_impl(mat1, mat2, reduce);
-  return std::get<0>(result);
+  return std::get<0>(std::move(result));
 }
 
 // --------------------------------------------------------------------

--- a/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
@@ -492,7 +492,7 @@ Tensor reduce_sparse_csr_dim0_cuda_template(const Tensor& sparse, ReductionOp ro
       at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
           values.options(), values.scalar_type(), new_nnz);
   scalar_t* values_ptr = values.data_ptr<scalar_t>();
-  acc_t* new_values_acc_ptr = new_values_acc.data_ptr<acc_t>();
+  acc_t* new_values_acc_ptr = new_values_acc.template data_ptr<acc_t>();
   int64_t THREADS = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   int64_t BLOCKS = (new_nnz + THREADS) / THREADS;
   at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
@@ -603,7 +603,8 @@ Tensor reduce_sparse_csr_dim1_cuda_template(const Tensor& sparse, ReductionOp ro
                             new_values_acc.resize_(new_nnz);
 
                             scalar_t* values_ptr = values.data_ptr<scalar_t>();
-                            acc_t* new_values_acc_ptr = new_values_acc.data_ptr<acc_t>();
+                            acc_t* new_values_acc_ptr =
+                                new_values_acc.template data_ptr<acc_t>();
                             reduce_sparse_csr_dim1_cuda_kernel<<<BLOCKS, THREADS, 0, stream>>>(new_values_acc_ptr,
                                                                                                values_ptr,
                                                                                                crow_indices_ptr,

--- a/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
@@ -488,10 +488,9 @@ Tensor reduce_sparse_csr_dim0_cuda_template(const Tensor& sparse, ReductionOp ro
   // of float should be float in current scenario. In CUDA, float is the accumulate type
   // of float, while in CPU, double is the accumulate type of float.
   using acc_t = at::acc_type<scalar_t, true>;
-  auto acc_buffer = at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
-      values.options(), values.scalar_type(), new_nnz);
-  Tensor new_values = std::get<0>(acc_buffer);
-  Tensor new_values_acc = std::get<1>(acc_buffer);
+  auto [new_values, new_values_acc] =
+      at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
+          values.options(), values.scalar_type(), new_nnz);
   scalar_t* values_ptr = values.data_ptr<scalar_t>();
   acc_t* new_values_acc_ptr = new_values_acc.data_ptr<acc_t>();
   int64_t THREADS = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
@@ -579,10 +578,9 @@ Tensor reduce_sparse_csr_dim1_cuda_template(const Tensor& sparse, ReductionOp ro
   // of float should be float in current scenario. In CUDA, float is the accumulate type
   // of float, while in CPU, double is the accumulate type of float.
   using acc_t = at::acc_type<scalar_t, true>;
-  auto acc_buffer = at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
-      values.options(), values.scalar_type());
-  Tensor new_values = std::get<0>(acc_buffer);
-  Tensor new_values_acc = std::get<1>(acc_buffer);
+  auto [new_values, new_values_acc] =
+      at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
+          values.options(), values.scalar_type());
 
   at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
   int64_t THREADS = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -596,7 +596,7 @@ at::Tensor _cslt_sparse_mm(
       (int)split_k,
       (int)split_k_mode,
       false);
-  return std::get<0>(result);
+  return std::get<0>(std::move(result));
 }
 
 int64_t _cslt_sparse_mm_search(

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -773,7 +773,7 @@ Tensor scaled_dot_product_attention(
       bool compute_logsumexp = should_compute_logsumexp(query_, key, value);
       auto out_lse_softmax = at::_scaled_dot_product_cudnn_attention(
           query_, key, value, attn_mask, compute_logsumexp, dropout_p, is_causal, false /*return_debug_mask*/, scale);
-      return std::get<0>(out_lse_softmax);
+      return std::get<0>(std::move(out_lse_softmax));
     }
     case SDPBackend::flash_attention: {
       if(query_device_type == DeviceType::CUDA ||
@@ -800,12 +800,12 @@ Tensor scaled_dot_product_attention(
       bool compute_logsumexp = should_compute_logsumexp_with_attn_mask(query_, key, value, attn_mask);
       auto out_and_lse = at::_scaled_dot_product_efficient_attention(
           query_, key, value, attn_mask, compute_logsumexp, dropout_p, is_causal, scale);
-      return std::get<0>(out_and_lse);
+      return std::get<0>(std::move(out_and_lse));
     }
     case SDPBackend::overrideable: {
       auto out_lse_softmax = at::_scaled_dot_product_fused_attention_overrideable(
           query_, key, value, attn_mask, dropout_p, is_causal, false /*return_debug_mask*/, scale);
-      return std::get<0>(out_lse_softmax);
+      return std::get<0>(std::move(out_lse_softmax));
     }
     case SDPBackend::math: {
       const bool any_inputs_require_grad = query_.requires_grad() || key.requires_grad() || value.requires_grad();

--- a/aten/src/ATen/native/vulkan/ops/Layernorm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Layernorm.cpp
@@ -75,7 +75,7 @@ Tensor run_layernorm_context(
   // mean, 1/sqrt(var+eps)>, but we only need the first tensor (layer_norm).
   std::tuple<Tensor, Tensor, Tensor> native_layer_norm_output =
       at::native_layer_norm(input, normalized_shape, weight_opt, bias_opt, eps);
-  return std::get<0>(native_layer_norm_output);
+  return std::get<0>(std::move(native_layer_norm_output));
 }
 
 static Tensor layer_norm(

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -2409,9 +2409,9 @@ compute_bucket_assignment_by_size(
   bucket_indices.reserve(result.size());
   std::vector<size_t> per_bucket_size_limits;
   per_bucket_size_limits.reserve(result.size());
-  for (const auto& bucket_indices_with_size : result) {
-    bucket_indices.emplace_back(std::get<0>(bucket_indices_with_size));
-    per_bucket_size_limits.emplace_back(std::get<1>(bucket_indices_with_size));
+  for (auto& [indices, size_limit] : result) {
+    bucket_indices.emplace_back(std::move(indices));
+    per_bucket_size_limits.emplace_back(size_limit);
   }
   return std::make_tuple(
       std::move(bucket_indices), std::move(per_bucket_size_limits));

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -1338,11 +1338,11 @@ struct IValuePacker<TypeAndSize> {
     return tuple;
   }
   static TypeAndSize unpack(const at::IValue& t) {
-    auto tuple =
+    auto [sym_sizes, options] =
         t.to<std::tuple<std::vector<at::SymInt>, packed_tensoroptions_t>>();
     TypeAndSize result;
-    result.sym_sizes = std::get<0>(tuple);
-    result.options = unpack_TensorOptions(std::get<1>(tuple));
+    result.sym_sizes = std::move(sym_sizes);
+    result.options = unpack_TensorOptions(options);
     return result;
   }
   static at::TypePtr packed_type() {

--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -1490,11 +1490,13 @@ InsertObserversHelper::insertObserversFor(
           }
         }
         auto* subblock = g->block();
-        auto info_from_callee = insertObserversFor(
-            subblock, m, callee_observed_inputs, false, is_udf_for_subblock);
-        auto input_observers = std::get<0>(info_from_callee);
-        auto output_observers = std::get<1>(info_from_callee);
-        auto callee_observed_outputs = std::get<2>(info_from_callee);
+        auto [input_observers, output_observers, callee_observed_outputs] =
+            insertObserversFor(
+                subblock,
+                m,
+                callee_observed_inputs,
+                false,
+                is_udf_for_subblock);
         for (auto idx : callee_observed_outputs) {
           block_observed_values.insert(n->outputs()[idx]);
         }
@@ -1531,8 +1533,9 @@ InsertObserversHelper::insertObserversFor(
           auto info_from_subblock =
               insertObserversFor(subblock, module, block_observed_values);
           // subblock for prim::If doesn't have inputs
-          auto output_observers = std::get<1>(info_from_subblock);
-          auto subblock_observed_outputs = std::get<2>(info_from_subblock);
+          auto output_observers = std::move(std::get<1>(info_from_subblock));
+          auto subblock_observed_outputs =
+              std::move(std::get<2>(info_from_subblock));
 
           // We'll insert output observer for each subblock, and in the end
           // we will check if output of subblocks are quantized consistently

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -1024,11 +1024,10 @@ void InsertQuantDeQuantHelper::quantizeTensors(
   }
   for (auto* n : observer_nodes_for_graph_.at(g)) {
     auto* original_value = n->input(1);
-    auto tp = getQSchemeAndQParamVector(module, n);
-    auto qscheme = std::get<0>(tp);
-    auto qparam_map = std::get<1>(tp);
+    auto [qscheme, qparam_map] = getQSchemeAndQParamVector(module, n);
     checkQScheme(g, qscheme);
     std::vector<std::string> qparam_names;
+    qparam_names.reserve(qparam_map.size());
     for (auto& pr : qparam_map) {
       const auto& name = pr.first;
       const auto& qparam = pr.second;
@@ -1041,7 +1040,7 @@ void InsertQuantDeQuantHelper::quantizeTensors(
       }
       qparam_name_map_for_node_[n][name] = qparam_name;
       module.register_attribute(qparam_name, qparam.type(), qparam);
-      qparam_names.push_back(qparam_name);
+      qparam_names.push_back(std::move(qparam_name));
     }
     insertQuantizationOps(
         module, self, n, isPerChannel(qscheme), qparam_names, quant_type_);
@@ -1417,9 +1416,8 @@ void InsertQuantDeQuantHelper::run(
   // TODO: dedup this part with code in quantizeTensors
   if (observer_nodes_for_graph_.count(graph.get())) {
     for (auto* n : observer_nodes_for_graph_.at(graph.get())) {
-      auto tp = getQSchemeAndQParamVector(module, n);
-      checkQScheme(graph.get(), std::get<0>(tp));
-      auto qparam_map = std::get<1>(tp);
+      auto [qscheme, qparam_map] = getQSchemeAndQParamVector(module, n);
+      checkQScheme(graph.get(), qscheme);
       // We check the size here because for some observers (like
       // PlaceholderObserver) the qparams might be empty.
       if (!qparam_map.empty()) {

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1785,7 +1785,8 @@ void initJITBindings(PyObject* module) {
           ToIValueAllowNumbersAsTensors g(allow_numbers_as_tensors);
           const auto overloads = getAllSortedOperatorsFor(symbol);
           auto opWithStack = getOpWithStack(overloads, args, kwargs);
-          std::shared_ptr<Operator> overload = std::get<0>(opWithStack);
+          std::shared_ptr<Operator> overload =
+              std::move(std::get<0>(opWithStack));
           auto result = overload->schema().overload_name();
           if (result.empty()) {
             result = "default";

--- a/torch/csrc/lazy/ts_backend/ts_autograd_functions.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_autograd_functions.cpp
@@ -21,8 +21,8 @@ at::Tensor MaxPool3dAutogradFunctionTS::forward(
   auto results = at::native::
       call_fallback_fn<&ltc_eager_fallback, ATEN_OP(max_pool3d_with_indices)>::
           call(self, kernel_size, stride, padding, dilation, ceil_mode);
-  ctx->save_for_backward({self, std::get<1>(results)});
-  return std::get<0>(results);
+  ctx->save_for_backward({self, std::get<1>(std::move(results))});
+  return std::get<0>(std::move(results));
 }
 
 torch::autograd::variable_list MaxPool3dAutogradFunctionTS::backward(

--- a/torch/csrc/lazy/ts_backend/ts_autograd_functions.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_autograd_functions.cpp
@@ -21,8 +21,8 @@ at::Tensor MaxPool3dAutogradFunctionTS::forward(
   auto results = at::native::
       call_fallback_fn<&ltc_eager_fallback, ATEN_OP(max_pool3d_with_indices)>::
           call(self, kernel_size, stride, padding, dilation, ceil_mode);
-  ctx->save_for_backward({self, std::get<1>(std::move(results))});
-  return std::get<0>(std::move(results));
+  ctx->save_for_backward({self, std::move(std::get<1>(results))});
+  return std::move(std::get<0>(results));
 }
 
 torch::autograd::variable_list MaxPool3dAutogradFunctionTS::backward(

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -588,7 +588,7 @@ static void appendValueInfo(
     std::vector<std::string>& strides,
     std::vector<std::string>& types,
     std::vector<std::string>& values) {
-  auto tuple = convertIValue(
+  auto [tensor_shape, tensor_stride, tensor_type, tensor_value] = convertIValue(
       ob,
       functionName,
       opId,
@@ -597,10 +597,10 @@ static void appendValueInfo(
       isInput,
       val,
       true);
-  shapes.push_back(std::get<0>(tuple));
-  strides.push_back(std::get<1>(tuple));
-  types.push_back(std::get<2>(tuple));
-  values.push_back(std::get<3>(tuple));
+  shapes.push_back(std::move(tensor_shape));
+  strides.push_back(std::move(tensor_stride));
+  types.push_back(std::move(tensor_type));
+  values.push_back(std::move(tensor_value));
 }
 
 static void handleKernelBackendInfo(


### PR DESCRIPTION
* RNVO does not work on items contained within tuple accessed through std::get, so explicitly call move on these contents.
* I asked codex to go and find places where std::get is being called on a tuple that is immediately destructed and either update the callsite to CPP17 structured binding syntax or call std::move on the std::get values to prevent unnecessary copies.
* Add a handful missing reserve calls for std::vector of known length
* And a couple other stray missing std::move

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @xmfan @aditvenk