### PR TITLE
[CI] Use Claude Opus 5 for @claude requests

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      model: global.anthropic.claude-fable-5
+      model: global.anthropic.claude-opus-5
       additional_claude_args: '--allowedTools Skill'
       append_system_prompt: |
         When asked to review a PR, always use the /pr-review skill first.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #191112

Switch the comment-triggered Claude workflow from Fable 5 to Opus 5. The
same global Bedrock inference profile was validated end to end in ciforge.

Test Plan:

```
PATH="$HOME/.venvs/dev/bin:$PATH" lintrunner -a
```

This change was authored with an AI assistant.