### PR TITLE
Preserve requires_grad when unwrapping ACT inputs in process_inputs

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -1804,16 +1804,18 @@ def forward(self, L_x_ : torch.Tensor, L_mesh_ : torch.distributed.device_mesh.D
         x2 = x2.to_local()
         self.assertTrue(isinstance(x2, AsyncCollectiveTensor))
         opt_fn(x2)
-        # ACTs are unwrapped before AOT autograd tracing in
-        # process_inputs, so the graph receives a plain tensor with
-        # no wait_tensor op.
+        # ACTs are unwrapped before AOT autograd tracing in process_inputs, so the
+        # graph receives a plain tensor with no wait_tensor op. The ACT here
+        # requires grad, and process_inputs re-syncs requires_grad onto the
+        # unwrapped input, so AOTAutograd builds a training graph: the input is
+        # a `primals_` and is saved for backward (returned as a graph output).
         self.assertExpectedInline(
             str(fw_graph_cell[0]).strip(),
             """\
-def forward(self, arg0_1):
-    sin = torch.ops.aten.sin.default(arg0_1);  arg0_1 = None
+def forward(self, primals_1):
+    sin = torch.ops.aten.sin.default(primals_1)
     sin_1 = torch.ops.aten.sin.default(sin);  sin = None
-    return (sin_1,)""",
+    return (sin_1, primals_1)""",
         )
 
     @skipIfTorchDynamo()

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -1591,6 +1591,40 @@ class ACTCompileTest(TestCase):
         ref = elem.detach().unsqueeze(0)
         self.assertEqual(out.detach(), ref)
 
+    def test_act_compile_preserves_input_grad(self):
+        """
+        A grad-requiring top-level ACT input must still propagate a gradient to
+        its upstream producer. Mirrors the TP shape where a redistributed DTensor's
+        ``to_local()`` yields an ACT whose wrapper requires grad but whose inner
+        ``.elem`` is plain; unwrapping via trigger_wait() drops the wrapper's
+        requires_grad, so without the fix AOTAutograd builds a non-differentiable
+        graph and the gradient is lost. Asserts the recovered gradient value.
+        """
+
+        # Hands a compiled region an ACT with the wrapper-requires-grad /
+        # inner-plain split (as DTensor.to_local does), chaining backward to leaf.
+        class _MakeSplitACT(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return AsyncCollectiveTensor(x.detach())
+
+            @staticmethod
+            def backward(ctx, g):
+                return g.trigger_wait() if isinstance(g, AsyncCollectiveTensor) else g
+
+        leaf = torch.randn(4, 4, requires_grad=True)
+        act = _MakeSplitACT.apply(leaf)
+        self.assertTrue(act.requires_grad)
+        self.assertFalse(act.elem.requires_grad)  # the split that triggers the bug
+
+        compiled_fn = torch.compile(lambda x: (x * x).sum(), backend="aot_eager")
+        compiled_fn(act).backward()
+
+        self.assertIsNotNone(
+            leaf.grad, "input gradient was dropped (ACT requires_grad not preserved)"
+        )
+        self.assertEqual(leaf.grad, 2 * leaf.detach())
+
     def test_act_runtime_unwrap(self):
         """
         Verify that ACT inputs are resolved before the compiled graph

--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -69,9 +69,17 @@ def process_inputs(
     # here prevents ACT from appearing in the traced metadata.
     AsyncCollectiveTensor = get_loaded_async_collective_tensor_type()
     act_input_paths: list[ActInputPath] = []
+    # Unwrapping a grad-requiring top-level ACT below yields its waited inner
+    # tensor, which drops the wrapper's requires_grad. The fake built from it
+    # then reads requires_grad=False, so AOTAutograd treats the graph as
+    # non-differentiable and drops the input gradient. Record these inputs to
+    # re-sync requires_grad onto their fakes below.
+    grad_act_indices: list[int] = []
     if AsyncCollectiveTensor is not None:
         tracing_context = torch._guards.TracingContext.try_get()
         for i, a in enumerate(flat_args):
+            if isinstance(a, AsyncCollectiveTensor) and a.requires_grad:
+                grad_act_indices.append(i)
             resolved_arg = _resolve_input_async_collectives(
                 a, i, (), act_input_paths, AsyncCollectiveTensor
             )
@@ -170,9 +178,17 @@ def process_inputs(
             )
             return result
 
-        return FakifiedFlatArgs(
-            [convert(idx, x) for idx, x in enumerate(flat_args)]
-        ), act_input_paths
+        fakified = [convert(idx, x) for idx, x in enumerate(flat_args)]
+        # Re-sync requires_grad onto the fakes for the grad-requiring ACTs
+        # unwrapped above (see grad_act_indices). Mutate in place rather than
+        # substitute a fresh tensor: `convert` keys per-tensor symbolic-shape
+        # context in `tracing_context.tensor_to_context` by object identity, so a
+        # replacement object would miss that mapping.
+        for i in grad_act_indices:
+            fi = fakified[i]
+            if isinstance(fi, torch.Tensor) and not fi.requires_grad:
+                fi.requires_grad_(True)
+        return FakifiedFlatArgs(fakified), act_input_paths
 
 
 def _resolve_input_async_collectives(


### PR DESCRIPTION
### Context
  #179849 unwraps top-level `AsyncCollectiveTensor` (ACT) inputs before AOTAutograd tracing (via `trigger_wait()`) to fix a tangent-type-mismatch crash and a silent-data-corruption path. But `trigger_wait()` returns the grad-less inner `.elem`, so a **grad-requiring** ACT input loses its `requires_grad`.

### Problem
  When a grad-requiring top-level ACT reaches a compiled region (e.g. a TP `RowwiseParallel` activation redistributed into a `torch.compile`'d block, where `DTensor.to_local()` yields a bare ACT), the unwrapped input fakeifies with `requires_grad=False`. AOTAutograd then builds an inference-only graph and the gradient to the upstream producer is silently dropped.

### Fix
Record grad-requiring top-level ACT inputs before the unwrap, then re-sync `requires_grad` onto their fakes. Additive to #179849 , keeps its crash/corruption fixes, only recovers the lost autograd edge. The flag is restored by mutating the fake in place (not substituting a fresh tensor) to preserve `process_inputs`' per-tensor symbolic-shape context, which is keyed by object identity.

### Test
`ACTCompileTest.test_act_compile_preserves_input_grad`: feeds a grad-requiring top-level ACT (wrapper-requires-grad / inner-elem-plain split, as `DTensor.to_local` produces) into a compiled region and asserts the recovered input-gradient value. Fails without the fix (`RuntimeError: element 0 of tensors does not require grad`), passes with it.

*AI usage disclosure: this change was investigated and drafted with the assistance of an AI coding tool. All code, tests, and results were reviewed and verified by the author.*
