### PR TITLE
[distributed] Support avg backward for functional reduce_scatter

### DIFF
--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -357,7 +357,8 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
 
     @parametrize("device", devices)
     @parametrize("scatter_dim", [0, 1])
-    def test_reduce_scatter_tensor_backward(self, device, scatter_dim):
+    @parametrize("reduce_op", ["sum", "avg"])
+    def test_reduce_scatter_tensor_backward(self, device, scatter_dim, reduce_op):
         """Test reduce_scatter_tensor backward does all_gather.
 
         Both tensor AND gradients are VARYING (different across ranks).
@@ -376,21 +377,22 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
             )
 
         output = fcols.reduce_scatter_single(
-            input_tensor, "sum", scatter_dim=scatter_dim, group=group_name
+            input_tensor, reduce_op, scatter_dim=scatter_dim, group=group_name
         )
 
         # Backward with ones
         output.sum().backward()
 
-        # Gradient should be all_gather of ones
+        # Gradient should be all_gather of ones, scaled for avg.
         self.assertIsNotNone(input_tensor.grad)
         self.assertEqual(input_tensor.grad.shape, input_tensor.shape)
 
-        # All gradients should be 1 (gathered from all ranks)
-        expected_grad = torch.ones_like(input_tensor)
+        # Average reduction scales each gathered gradient by the group size.
+        expected_value = 1 / self.world_size if reduce_op == "avg" else 1
+        expected_grad = torch.full_like(input_tensor, expected_value)
         self.assertEqual(input_tensor.grad, expected_grad)
 
-        # Backward is all_gather (sum)
+        # Backward is all_gather, scaled for avg.
         grad_outputs = torch.rand_like(output, device=device)
         (grad_input,) = torch.autograd.grad(
             output, input_tensor, grad_outputs=grad_outputs
@@ -398,6 +400,8 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         expected_grad_input = fcols.all_gather_single(
             grad_outputs, scatter_dim, group=group_name
         )
+        if reduce_op == "avg":
+            expected_grad_input = expected_grad_input / self.world_size
         self.assertEqual(grad_input, expected_grad_input)
 
     @parametrize("device", devices)
@@ -493,10 +497,11 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
             self.assertEqual(input_tensor.grad, expected_grad)
 
     @parametrize("device", devices)
-    def test_reduce_scatter_tensor_coalesced_backward(self, device):
+    @parametrize("reduce_op", ["sum", "avg"])
+    def test_reduce_scatter_tensor_coalesced_backward(self, device, reduce_op):
         """Test reduce_scatter_tensor_coalesced backward does all_gather on each gradient.
 
-        Tensors AND gradients are VARYING (different across ranks).
+        Tensors are VARYING (different across ranks).
         Forward reduces and scatters each tensor, backward gathers each gradient.
         """
         group_name = dist.group.WORLD.group_name
@@ -508,17 +513,18 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         scatter_dims = [0, 0]
 
         outputs = fcols.reduce_scatter_single_coalesced(
-            input_tensors, "sum", scatter_dims, group=group_name
+            input_tensors, reduce_op, scatter_dims, group=group_name
         )
 
         # Backward with ones
         loss = sum(output.sum() for output in outputs)
         loss.backward()
 
-        # Each gradient should be all_gather of ones
+        # Each gradient should be all_gather of ones, scaled for avg.
         for input_tensor in input_tensors:
             self.assertIsNotNone(input_tensor.grad)
-            expected_grad = torch.ones_like(input_tensor)
+            expected_value = 1 / self.world_size if reduce_op == "avg" else 1
+            expected_grad = torch.full_like(input_tensor, expected_value)
             self.assertEqual(input_tensor.grad, expected_grad)
 
     # ============================================================

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -764,10 +764,13 @@ def reduce_scatter_tensor_backward(ctx, grad_output: torch.Tensor):
     reduce_op = ctx.reduce_op
 
     # Lazy validation: check reduce_op only when backward is called
-    if reduce_op != "sum":
+    if reduce_op not in ("sum", "avg"):
         raise RuntimeError(
-            f"reduce_scatter_tensor backward only supports 'sum' reduction, got '{reduce_op}'"
+            f"reduce_scatter_tensor backward only supports 'sum' and 'avg' reductions, got '{reduce_op}'"
         )
+
+    if reduce_op == "avg":
+        grad_output = grad_output / group_size
 
     # Backward is all_gather
     output = torch.ops._c10d_functional.all_gather_into_tensor(
@@ -991,10 +994,13 @@ def reduce_scatter_tensor_coalesced_backward(ctx, grad_outputs: list[torch.Tenso
     reduce_op = ctx.reduce_op
 
     # Lazy validation: check reduce_op only when backward is called
-    if reduce_op != "sum":
+    if reduce_op not in ("sum", "avg"):
         raise RuntimeError(
-            f"reduce_scatter_tensor_coalesced backward only supports 'sum' reduction, got '{reduce_op}'"
+            f"reduce_scatter_tensor_coalesced backward only supports 'sum' and 'avg' reductions, got '{reduce_op}'"
         )
+
+    if reduce_op == "avg":
+        grad_outputs = [grad_output / group_size for grad_output in grad_outputs]
 
     # Backward does all_gather on list of gradients
     grad_inputs = torch.ops._c10d_functional.all_gather_into_tensor_coalesced(


### PR DESCRIPTION
## Summary

Functional reduce-scatter accepts `avg` in the forward pass, but both its scalar and coalesced autograd paths reject it during backward.

For a group of size `N`, an average reduction contributes a `1 / N` factor to the gradient. The backward is therefore an all-gather of each incoming gradient divided by the group size.

This change:

- permits `avg` in the scalar and coalesced backward paths
- scales incoming gradients by the group size before all-gather
- parametrizes the existing backward tests over `sum` and `avg`

Support for non-`sum` reductions was deferred to a follow-up during #168140.

## Test plan

- `git diff --check`
- Not run locally because no configured PyTorch test environment is available

## Disclosure

Prepared with AI assistance and reviewed by the author.