### PR TITLE
[BE] Generalize docker image plumbing

### DIFF
--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -151,10 +151,11 @@ RUN rm install_onnx.sh common_utils.sh
 
 # Build TSan-instrumented CPython for thread sanitizer testing
 ARG TSAN
+ARG CLANG_VERSION
 COPY ./common/install_cpython.sh install_cpython.sh
 COPY requirements-ci.txt /tmp/requirements-ci.txt
 RUN if [ -n "${TSAN}" ]; then \
-      CC=clang-18 CXX=clang++-18 \
+      CC=clang-${CLANG_VERSION} CXX=clang++-${CLANG_VERSION} \
       CPYTHON_VERSIONS="3.14.4t+tsan" bash ./install_cpython.sh && \
       /opt/python/cp314-cp314t+tsan/bin/pip install -r /tmp/requirements-ci.txt; \
     fi

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -195,7 +195,7 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
     with:
       build-environment: linux-jammy-py${{ matrix.python-version }}-clang18
-      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-py${{ matrix.python-version }}-clang18${{ needs.get-label-type.outputs.ci-docker-hash && format('-{0}', needs.get-label-type.outputs.ci-docker-hash) || '' }}
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-py${{ matrix.python-version }}-clang18-${{ needs.get-label-type.outputs.ci-docker-hash }}
       test-matrix: ${{ needs.inductor-cpu-core-build.outputs.test-matrix }}
       python-version: "${{ matrix.python-version }}"
       compiler: clang18

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -195,7 +195,7 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
     with:
       build-environment: linux-jammy-py${{ matrix.python-version }}-clang18
-      docker-image: ${{ needs.inductor-cpu-core-build.outputs.docker-image }}
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-py${{ matrix.python-version }}-clang18${{ needs.get-label-type.outputs.ci-docker-hash && format('-{0}', needs.get-label-type.outputs.ci-docker-hash) || '' }}
       test-matrix: ${{ needs.inductor-cpu-core-build.outputs.test-matrix }}
       python-version: "${{ matrix.python-version }}"
       compiler: clang18

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -195,7 +195,7 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
     with:
       build-environment: linux-jammy-py${{ matrix.python-version }}-clang18
-      docker-image: ghcr.io/pytorch/ci-image:pytorch-linux-jammy-py${{ matrix.python-version }}-clang18
+      docker-image: ${{ needs.inductor-cpu-core-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-cpu-core-build.outputs.test-matrix }}
       python-version: "${{ matrix.python-version }}"
       compiler: clang18


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #191108
* __->__ #191117

----

- The TSAN CPython build in ubuntu/Dockerfile hardcoded clang-18/clang++-18 instead of relying on CLANG_VERSION variable like rest of the containers
- inductor-cpu-core-test consumed a hardcoded floating ghcr.io tag (pytorch-linux-jammy-py<ver>-clangNN) instead of the content-hashed image produced by its inductor-cpu-core-build job

Authored-with: Claude Opus 4.8