### PR TITLE
[profiler][cupti] Keep GPU user-annotation spans on the capture stream

### DIFF
--- a/test/profiler/test_cupti_monitor.py
+++ b/test/profiler/test_cupti_monitor.py
@@ -542,9 +542,11 @@ class TestCuptiRecords(TestCase):
         self.assertEqual(names[(0, 7)].strip(), "stream 7")
 
     def test_gpu_user_annotation_stays_on_capture_stream(self):
-        # A GPU-side user annotation is emitted on the kernel's real capture stream, even for
-        # graphed kernels the lane resolver reassigned to a logical lane -- the annotation is
-        # never moved onto those synthetic lanes. No CUDA.
+        # A GPU-side user annotation stays on its kernels' real capture stream, never a lane the
+        # resolver reassigned kernels onto. But when a capture stream has no work left to
+        # show (all its ops moved to a logical lane), the span would be orphaned on an empty
+        # lane, so it is dropped instead. A stream that still has non-reassigned work keeps
+        # its annotation. No CUDA.
         import numpy as np
 
         from torch.profiler._cupti.monitor_trace import _gpu_user_annotation_events
@@ -554,33 +556,35 @@ class TestCuptiRecords(TestCase):
 
         columns = {
             "external_correlation": {
-                "correlation_id": i64(11, 12),
-                "user_external_id": i64(555, 666),
+                "correlation_id": i64(11, 12, 13, 14),
+                "user_external_id": i64(555, 666, 777, 999),
             },
             "kernel": {
-                "correlation_id": i64(11, 12),
-                "device_id": i64(0, 0),
-                "stream_id": i64(7, 9),  # both replayed on their capture streams
-                "start_ns": i64(1000, 3000),
-                "end_ns": i64(2000, 4000),
-                # first is graphed (lane resolver would move it to lane 8); second is eager
-                "graph_node_id": i64(101, 0),
-                "logical_lane": i64(8, 9),
+                "correlation_id": i64(11, 12, 13, 14),
+                "device_id": i64(0, 0, 0, 0),
+                "stream_id": i64(7, 9, 5, 5),
+                "start_ns": i64(1000, 3000, 5000, 5500),
+                "end_ns": i64(2000, 4000, 6000, 6500),
+                # k11 graphed -> lane 8 (orphans stream 7); k12 eager on 9; k13 graphed -> lane
+                # 6 but k14 is eager on the same stream 5, so stream 5 still shows work.
+                "graph_node_id": i64(101, 0, 103, 0),
+                "logical_lane": i64(8, 9, 6, 5),
             },
         }
         trace_window = {
             "columns": columns,
-            "user_annotations": {555: "all_reduce", 666: "matmul"},
+            "user_annotations": {555: "all_reduce", 666: "matmul", 777: "reduce_scatter"},
         }
         events = _gpu_user_annotation_events(trace_window, base_ns=0)
         by_name = {e["name"]: e for e in events}
 
-        # graphed: annotation stays on the capture stream (7), not the logical lane (8)
-        self.assertEqual(by_name["all_reduce"]["cat"], "gpu_user_annotation")
-        self.assertEqual(by_name["all_reduce"]["pid"], 0)
-        self.assertEqual(by_name["all_reduce"]["tid"], 7)
+        # graphed op moved off stream 7 and nothing else renders there -> annotation dropped
+        self.assertNotIn("all_reduce", by_name)
         # eager: stays on the kernel's capture stream
+        self.assertEqual(by_name["matmul"]["cat"], "gpu_user_annotation")
         self.assertEqual(by_name["matmul"]["tid"], 9)
+        # stream 5 still has non-reassigned work (k14), so its annotation is kept there
+        self.assertEqual(by_name["reduce_scatter"]["tid"], 5)
 
     def test_chrome_counter_events_from_pm(self):
         # PM counters render as chrome "C" (counter) events in a dedicated per-device

--- a/test/profiler/test_cupti_monitor.py
+++ b/test/profiler/test_cupti_monitor.py
@@ -541,11 +541,10 @@ class TestCuptiRecords(TestCase):
         self.assertEqual(names[(0, 8)], "side comms")
         self.assertEqual(names[(0, 7)].strip(), "stream 7")
 
-    def test_gpu_user_annotation_follows_reassigned_lane(self):
-        # A GPU-side user annotation spanning graphed kernels that the lane resolver moved
-        # onto a logical lane is emitted on that same lane -- not the capture stream -- so it
-        # nests over its kernels. An annotation over non-reassigned (eager) kernels stays on
-        # the kernel's CUDA stream. No CUDA.
+    def test_gpu_user_annotation_stays_on_capture_stream(self):
+        # A GPU-side user annotation is emitted on the kernel's real capture stream, even for
+        # graphed kernels the lane resolver reassigned to a logical lane -- the annotation is
+        # never moved onto those synthetic lanes. No CUDA.
         import numpy as np
 
         from torch.profiler._cupti.monitor_trace import _gpu_user_annotation_events
@@ -564,7 +563,7 @@ class TestCuptiRecords(TestCase):
                 "stream_id": i64(7, 9),  # both replayed on their capture streams
                 "start_ns": i64(1000, 3000),
                 "end_ns": i64(2000, 4000),
-                # first is graphed and moved to lane 8; second is eager (no reassign)
+                # first is graphed (lane resolver would move it to lane 8); second is eager
                 "graph_node_id": i64(101, 0),
                 "logical_lane": i64(8, 9),
             },
@@ -576,11 +575,11 @@ class TestCuptiRecords(TestCase):
         events = _gpu_user_annotation_events(trace_window, base_ns=0)
         by_name = {e["name"]: e for e in events}
 
-        # reassigned: the annotation follows its kernels onto lane 8
+        # graphed: annotation stays on the capture stream (7), not the logical lane (8)
         self.assertEqual(by_name["all_reduce"]["cat"], "gpu_user_annotation")
         self.assertEqual(by_name["all_reduce"]["pid"], 0)
-        self.assertEqual(by_name["all_reduce"]["tid"], 8)
-        # not reassigned: stays on the kernel's capture stream
+        self.assertEqual(by_name["all_reduce"]["tid"], 7)
+        # eager: stays on the kernel's capture stream
         self.assertEqual(by_name["matmul"]["tid"], 9)
 
     def test_chrome_counter_events_from_pm(self):

--- a/test/profiler/test_cupti_monitor.py
+++ b/test/profiler/test_cupti_monitor.py
@@ -573,7 +573,11 @@ class TestCuptiRecords(TestCase):
         }
         trace_window = {
             "columns": columns,
-            "user_annotations": {555: "all_reduce", 666: "matmul", 777: "reduce_scatter"},
+            "user_annotations": {
+                555: "all_reduce",
+                666: "matmul",
+                777: "reduce_scatter",
+            },
         }
         events = _gpu_user_annotation_events(trace_window, base_ns=0)
         by_name = {e["name"]: e for e in events}

--- a/torch/profiler/_cupti/monitor_trace.py
+++ b/torch/profiler/_cupti/monitor_trace.py
@@ -728,6 +728,11 @@ def _gpu_user_annotation_events(
         return []
 
     span_map: dict[tuple[int, int, int], dict[str, int]] = {}
+    # (device, stream) lanes that still render real GPU work after lane reassignment. A graphed
+    # op the resolver moved to a logical lane no longer displays on its capture stream (mirrors
+    # the display rule in _trace_window_entries); a span stranded on such a stream is dropped
+    # below.
+    streams_with_display: set[tuple[int, int]] = set()
     for ks in ("kernel", "gpu_memcpy", "gpu_memset"):
         c = columns.get(ks)
         if not c or not len(c["correlation_id"]):
@@ -739,7 +744,19 @@ def _gpu_user_annotation_events(
         str_l = c["stream_id"].tolist()
         start_l = c["start_ns"].tolist()
         end_l = c["end_ns"].tolist()
+        lane_col = c.get("logical_lane")
+        gnid_col = c.get("graph_node_id")
+        lane_l = lane_col.tolist() if lane_col is not None else None
+        gnid_l = gnid_col.tolist() if gnid_col is not None else None
         for i in range(len(corr_l)):
+            reassigned = (
+                lane_l is not None
+                and gnid_l is not None
+                and gnid_l[i]
+                and lane_l[i] != str_l[i]
+            )
+            if not reassigned:
+                streams_with_display.add((dev_l[i], str_l[i]))
             external_id = correlation_to_user_external.get(corr_l[i])
             if external_id is None:
                 continue
@@ -757,6 +774,10 @@ def _gpu_user_annotation_events(
     for (external_id, device_id, stream_id), span in sorted(span_map.items()):
         name = user_annotations.get(external_id)
         if not isinstance(name, str):
+            continue
+        # Orphaned span: the capture stream's ops all moved to logical lanes, so it would sit
+        # alone on an empty lane divorced from its kernels -- drop it instead.
+        if (device_id, stream_id) not in streams_with_display:
             continue
         start_us = max((span["start_ns"] - base_ns) / 1000.0 - 0.001, 0.0)
         dur_us = max((span["end_ns"] - span["start_ns"]) / 1000.0 + 0.002, 0.0)

--- a/torch/profiler/_cupti/monitor_trace.py
+++ b/torch/profiler/_cupti/monitor_trace.py
@@ -734,14 +734,9 @@ def _gpu_user_annotation_events(
             continue
         corr_l = c["correlation_id"].tolist()
         dev_l = c["device_id"].tolist()
-        # Follow graphed ops onto their reassigned logical lane so the spanning annotation
-        # lands on the same lane as its kernels (else it stays on the capture stream).
-        stream_arr = c["stream_id"]
-        lane_col = c.get("logical_lane")
-        if lane_col is not None:
-            reassign = (c["graph_node_id"] != 0) & (lane_col != stream_arr)
-            stream_arr = np.where(reassign, lane_col, stream_arr)
-        str_l = stream_arr.tolist()
+        # Keep the annotation on the kernel's real capture stream; do not follow graphed
+        # ops onto the synthetic logical lanes assigned by the lane resolver.
+        str_l = c["stream_id"].tolist()
         start_l = c["start_ns"].tolist()
         end_l = c["end_ns"].tolist()
         for i in range(len(corr_l)):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190851
* #190850
* #187898
* #188939
* __->__ #191118

The CUPTI monitor's JSON export moved a GPU user-annotation span onto the
synthetic logical lane that the graph lane resolver assigned to the graphed
kernels it enclosed, so the annotation followed those kernels off their capture
stream. Stop doing that: emit the span on the kernel's real capture stream and
never onto a lane-resolver logical lane. Eager annotations were already on their
CUDA stream and are unaffected.

When a capture stream's ops were all reassigned to a logical lane, no real GPU
work remains on it, so the span would be stranded on an otherwise-empty lane,
divorced from the kernels it describes. Drop such orphaned spans rather than
emit them; a stream that still has non-reassigned work keeps its annotation.

Test Plan:
Ran on a CUDA 13.3 build with the cupti-python bindings (TEST_CUPTI true):

    python test/profiler/test_cupti_monitor.py \
        TestCuptiRecords.test_gpu_user_annotation_stays_on_capture_stream

test_gpu_user_annotation_stays_on_capture_stream asserts an eager annotation
stays on its capture stream, a stream that still has non-reassigned work keeps
its span, and an annotation whose only op was reassigned off its capture stream
is dropped (orphaned). The full cupti-monitor suite is green:

    python test/profiler/test_cupti_monitor.py TestCuptiRecords

Authored with the assistance of an AI coding assistant.