### PR TITLE
[profiler][cupti] Emit only the lower 32-bit node id in the chrome trace args

### DIFF
--- a/test/profiler/test_cupti_monitor.py
+++ b/test/profiler/test_cupti_monitor.py
@@ -485,7 +485,8 @@ class TestCuptiRecords(TestCase):
                 "stream_id": i64(7, 7),  # both replayed on the capture stream
                 "correlation_id": i64(11, 12),
                 "graph_id": i64(1, 1),
-                "graph_node_id": i64(101, 102),
+                # graph id packed into the upper 32 bits; only the lower node id is kept
+                "graph_node_id": i64((1 << 32) | 101, (1 << 32) | 102),
                 "name": np.array(["graphKernelA", "graphKernelB"], dtype=object),
                 "annotation": np.array(
                     [{"ann_id": "a"}, {"ann_id": "b"}], dtype=object

--- a/torch/profiler/_cupti/monitor_trace.py
+++ b/torch/profiler/_cupti/monitor_trace.py
@@ -454,7 +454,9 @@ def _trace_window_entries(
                 if gid_l[i]:
                     a["graph id"] = gid_l[i]
                 if gnid_l[i]:
-                    a["graph node id"] = gnid_l[i]
+                    # Upper 32 bits are the graph id (emitted separately above); keep only the
+                    # lower 32-bit node id here rather than the full 9-digit packed value.
+                    a["graph node id"] = gnid_l[i] & 0xFFFFFFFF
                 _annotation_to_args(a, ann_l[i])
                 if meta_l is not None and meta_l[i] is not None:
                     _annotation_to_args(a, meta_l[i])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191119

CUPTI packs the graph id into the upper 32 bits of graphNodeId and the node id
into the lower 32, so the JSON export's "graph node id" arg was a 9+ digit packed
value. The graph id is already emitted as its own "graph id" arg, so mask the
packed value down to its lower 32-bit node id for a readable, non-redundant field.

Test Plan:
Ran on a CUDA 13.3 build with the cupti-python bindings (TEST_CUPTI true):

    python test/profiler/test_cupti_monitor.py \
        TestCuptiRecords.test_graph_kernel_reassigned_to_logical_lane

test_graph_kernel_reassigned_to_logical_lane packs a graph id into the upper 32
bits of graph_node_id and asserts the exported "graph node id" arg is the lower
node id (101); it passes. The full cupti-monitor suite is green:

    python test/profiler/test_cupti_monitor.py TestCuptiRecords
    # Ran 16 tests ... OK

Authored with the assistance of an AI coding assistant.