### PR TITLE
Preserve while_loop effect-token ABI through AOTAutograd and Inductor

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -10025,6 +10025,32 @@ def forward(self, x):
                 ):
                     ep.run_decompositions()
 
+        # An op that is effectful at pre-dispatch keeps the same contract:
+        # the initial export stays valid and runnable, and only
+        # run_decompositions raises.
+        class P(torch.nn.Module):
+            def forward(self, x, count):
+                def cond(i, x):
+                    return i < count
+
+                def body(i, x):
+                    torch.ops.aten._print("loop")
+                    return i + 1, x + 1
+
+                carries = (torch.zeros_like(count), x)
+                return torch.while_loop(cond, body, carries)[1]
+
+        p_inputs = (torch.ones(2), torch.tensor(1))
+        for strict in (True, False):
+            with self.subTest(strict=strict, pre_dispatch_effect=True):
+                ep = export(P(), p_inputs, strict=strict)
+                self.assertEqual(ep.module()(*p_inputs), torch.ones(2) + 1)
+                with self.assertRaisesRegex(
+                    NotImplementedError,
+                    "effects in while_loop are unsupported during export",
+                ):
+                    ep.run_decompositions()
+
     def test_constrain_size_with_various_cases(self):
         class Module1(torch.nn.Module):
             def forward(self, x, y):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -10001,6 +10001,30 @@ def forward(self, x):
         ep = export(Simple(), example_inputs)
         self.assertEqual(ep.module()(*example_inputs), Simple()(*example_inputs))
 
+    def test_effectful_while_loop_export_nyi(self):
+        class M(torch.nn.Module):
+            def forward(self, matrix, count):
+                def cond(i, out):
+                    return i < count
+
+                def body(i, out):
+                    return i + 1, out + torch.linalg.inv(matrix)
+
+                carries = (torch.zeros_like(count), torch.zeros_like(matrix))
+                return torch.while_loop(cond, body, carries)[1]
+
+        inputs = (torch.eye(2), torch.tensor(1))
+        expected = M()(*inputs)
+        for strict in (True, False):
+            with self.subTest(strict=strict):
+                ep = export(M(), inputs, strict=strict)
+                self.assertEqual(ep.module()(*inputs), expected)
+                with self.assertRaisesRegex(
+                    NotImplementedError,
+                    "effects in while_loop are unsupported during export",
+                ):
+                    ep.run_decompositions()
+
     def test_constrain_size_with_various_cases(self):
         class Module1(torch.nn.Module):
             def forward(self, x, y):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -10001,6 +10001,10 @@ def forward(self, x):
         ep = export(Simple(), example_inputs)
         self.assertEqual(ep.module()(*example_inputs), Simple()(*example_inputs))
 
+    # This suite folds run_decompositions into export, so the NYI error is
+    # raised by export itself rather than the explicit run_decompositions call.
+    @testing.expectedFailureTrainingIRToRunDecomp
+    @testing.expectedFailureTrainingIRToRunDecompNonStrict
     def test_effectful_while_loop_export_nyi(self):
         class M(torch.nn.Module):
             def forward(self, matrix, count):

--- a/test/higher_order_ops/test_with_effects.py
+++ b/test/higher_order_ops/test_with_effects.py
@@ -246,6 +246,38 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         res = torch.compile(f, backend="aot_eager")(*inputs)
         self.assertTrue(torch.allclose(res, f(*inputs)))
 
+    def test_pure_while_loop_empty_carry_with_unrelated_effect(self):
+        class M(torch.nn.Module):
+            def forward(self, matrix, post, count):
+                def cond(empty, i, out):
+                    return i < count
+
+                def body(empty, i, out):
+                    return empty.clone(), i + 1, out + 1
+
+                carries = (matrix.new_empty(0), torch.zeros_like(count), matrix)
+                out = torch.while_loop(cond, body, carries)[2]
+                return out + torch.linalg.inv(post)
+
+        inputs = (torch.eye(2), 2 * torch.eye(2), torch.tensor(2))
+        expected = inputs[0] + 2 + torch.linalg.inv(inputs[1])
+
+        backend = AotEagerAndRecordGraphs()
+        actual = torch.compile(M(), backend=backend, fullgraph=True)(*inputs)
+        self.assertEqual(actual, expected)
+        loop_op = torch.ops.higher_order.while_loop
+        aot_loop = backend.fw_graphs[0].graph.find_nodes(
+            op="call_function", target=loop_op
+        )[0]
+        self.assertNotIn("num_effect_tokens", aot_loop.kwargs)
+
+        ep = torch.export.export(M(), inputs).run_decompositions()
+        self.assertEqual(ep.module()(*inputs), expected)
+        export_loop = ep.graph_module.graph.find_nodes(
+            op="call_function", target=loop_op
+        )[0]
+        self.assertNotIn("num_effect_tokens", export_loop.kwargs)
+
     @unittest.skipIf(IS_WINDOWS, "triton")
     @unittest.skipIf(not SM70OrLater, "triton")
     def test_compile_inductor(self):

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -1601,6 +1601,121 @@ class WhileLoopTests(TestCase):
         loop_op = torch.ops.higher_order.while_loop
         loop = next(node for node in with_effect_nodes if node.args[1] is loop_op)
         self.assertEqual(len(loop.args[4]), 2)
+        # The loop participates in the ordered chain: the effect that follows
+        # it consumes the loop's token output.
+        check_errors = torch.ops.aten._linalg_check_errors.default
+        post_effect = next(n for n in with_effect_nodes if n.args[1] is check_errors)
+        # Both effects belong to one ordered chain: one consumes the getitem of
+        # the other. The direction depends on effect-discovery order.
+        post_token, loop_token = post_effect.args[0], loop.args[0]
+        chained = (
+            isinstance(post_token, torch.fx.Node) and post_token.args[:1] == (loop,)
+        ) or (
+            isinstance(loop_token, torch.fx.Node)
+            and loop_token.args[:1] == (post_effect,)
+        )
+        self.assertTrue(chained)
+
+    @requires_gpu
+    def test_while_loop_effect_provenance_gpu(self):
+        inv = torch.linalg.inv
+
+        def fn(matrix, count):
+            def cond(i, out):
+                return i < count
+
+            def body(i, out):
+                return i + 1, out + inv(matrix).contiguous()
+
+            carries = (torch.zeros_like(count), torch.zeros_like(matrix))
+            return torch.while_loop(cond, body, carries)[1]
+
+        compiled = torch.compile(fn, fullgraph=True)
+        matrix = torch.tensor([[2.0, 1.0], [1.0, 3.0]], device=GPU_TYPE)
+        count = torch.tensor(2, device=GPU_TYPE)
+        self.assertEqual(compiled(matrix, count), 2 * inv(matrix))
+
+    def test_while_loop_effect_empty_leading_carry(self):
+        inv = torch.linalg.inv
+
+        def fn(matrix, count):
+            buf = torch.zeros(0)
+            acc = torch.zeros_like(matrix)
+            i0 = torch.zeros_like(count)
+
+            def cond(buf, acc, i):
+                return i < count
+
+            def body(buf, acc, i):
+                return buf.clone(), acc + inv(matrix).contiguous(), i + 1
+
+            buf_out, acc_out, _ = torch.while_loop(cond, body, (buf, acc, i0))
+            return buf_out, acc_out
+
+        backend = torch._dynamo.testing.InductorAndRecordGraphs()
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)
+        matrix = torch.tensor([[2.0, 1.0], [1.0, 3.0]])
+        buf_out, acc_out = compiled(matrix, torch.tensor(2))
+        self.assertEqual(buf_out, torch.zeros(0))
+        self.assertEqual(acc_out, 2 * inv(matrix))
+        singular = torch.tensor([[1.0, 2.0], [2.0, 4.0]])
+        with self.assertRaisesRegex(torch.linalg.LinAlgError, "singular"):
+            compiled(singular, torch.tensor(1))
+
+        with_effect_nodes = backend.inductor_graphs[0].graph.find_nodes(
+            op="call_function", target=torch.ops.higher_order.with_effects
+        )
+        loop_op = torch.ops.higher_order.while_loop
+        loop = next(node for node in with_effect_nodes if node.args[1] is loop_op)
+        # The zero-element user carry must survive as a user carry; only the
+        # marker-designated token is stripped.
+        self.assertEqual(len(loop.args[4]), 3)
+
+    def test_while_loop_effect_nested(self):
+        inv = torch.linalg.inv
+
+        def fn(matrix, count):
+            i0 = torch.zeros_like(count)
+            acc = torch.zeros_like(matrix)
+
+            def cond(i, out):
+                return i < count
+
+            def body(i, out):
+                def inner_cond(j, o):
+                    return j < count
+
+                def inner_body(j, o):
+                    return j + 1, o + inv(matrix).contiguous()
+
+                j0 = torch.zeros_like(i)
+                inner = torch.while_loop(inner_cond, inner_body, (j0, out))
+                return i + 1, inner[1]
+
+            return torch.while_loop(cond, body, (i0, acc))[1]
+
+        compiled = torch.compile(fn, fullgraph=True)
+        matrix = torch.tensor([[2.0, 1.0], [1.0, 3.0]])
+        self.assertEqual(compiled(matrix, torch.tensor(2)), 4 * inv(matrix))
+        singular = torch.tensor([[1.0, 2.0], [2.0, 4.0]])
+        with self.assertRaisesRegex(torch.linalg.LinAlgError, "singular"):
+            compiled(singular, torch.tensor(1))
+
+    def test_while_loop_body_alias_error(self):
+        def fn(matrix, count):
+            i0 = torch.zeros_like(count)
+
+            def cond(i, out):
+                return i < count
+
+            def body(i, out):
+                return i + 1, out
+
+            return torch.while_loop(cond, body, (i0, matrix))[1]
+
+        compiled = torch.compile(fn, fullgraph=True)
+        with self.assertRaisesRegex(Exception, "alias"):
+            compiled(torch.ones(2, 2), torch.tensor(1))
 
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -1569,6 +1569,39 @@ class WhileLoopTests(TestCase):
                 dynamic=False,
             )
 
+    def test_while_loop_effect_provenance(self):
+        inv = torch.linalg.inv
+
+        def fn(matrix, post, count, return_loop):
+            def cond(i, out):
+                return i < count
+
+            def body(i, out):
+                return i + 1, out + inv(matrix).contiguous()
+
+            carries = (torch.zeros_like(count), torch.zeros_like(matrix))
+            loop_result = torch.while_loop(cond, body, carries)[1]
+            return loop_result if return_loop else inv(post).contiguous()
+
+        backend = torch._dynamo.testing.InductorAndRecordGraphs()
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)
+        matrix = torch.tensor([[2.0, 1.0], [1.0, 3.0]])
+        post = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
+        actual = compiled(matrix, post, torch.tensor(2), True)
+        self.assertEqual(actual, 2 * inv(matrix))
+        singular = torch.tensor([[1.0, 2.0], [2.0, 4.0]])
+        actual = compiled(singular, post, torch.tensor(0), False)
+        self.assertEqual(actual, inv(post))
+        with self.assertRaisesRegex(torch.linalg.LinAlgError, "singular"):
+            compiled(singular, post, torch.tensor(1), False)
+
+        with_effect_nodes = backend.inductor_graphs[-1].graph.find_nodes(
+            op="call_function", target=torch.ops.higher_order.with_effects
+        )
+        loop_op = torch.ops.higher_order.while_loop
+        loop = next(node for node in with_effect_nodes if node.args[1] is loop_op)
+        self.assertEqual(len(loop.args[4]), 2)
+
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2312,7 +2312,7 @@
     {
       "Gb_type": "torch.while_loop: effect token marker",
       "Context": "num_effect_tokens is an internal capture marker",
-      "Explanation": "Effectful while_loop export recompilation is unsupported.",
+      "Explanation": "Recompiling an AOT-produced graph that contains an effectful while_loop is unsupported.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2308,6 +2308,16 @@
       "Hints": []
     }
   ],
+  "GB8679": [
+    {
+      "Gb_type": "torch.while_loop: effect token marker",
+      "Context": "num_effect_tokens is an internal capture marker",
+      "Explanation": "Effectful while_loop export recompilation is unsupported.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
   "GB0157": [
     {
       "Gb_type": "Unsupported ndarray attribute access",

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -765,7 +765,7 @@ def _call_while_loop(
         unimplemented(
             gb_type="torch.while_loop: effect token marker",
             context="num_effect_tokens is an internal capture marker",
-            explanation="Effectful while_loop export recompilation is unsupported.",
+            explanation="Recompiling an AOT-produced graph that contains an effectful while_loop is unsupported.",
             hints=[*graph_break_hints.SUPPORTABLE],
         )
     cond_fn, body_fn, operands, additional_inputs = args

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -761,6 +761,13 @@ def _call_while_loop(
     from torch._higher_order_ops.while_loop import _create_unbacked_symint
 
     args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
+    if "num_effect_tokens" in kwargs:
+        unimplemented(
+            gb_type="torch.while_loop: effect token marker",
+            context="num_effect_tokens is an internal capture marker",
+            explanation="Effectful while_loop export recompilation is unsupported.",
+            hints=[*graph_break_hints.SUPPORTABLE],
+        )
     cond_fn, body_fn, operands, additional_inputs = args
 
     # Input checks

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -518,6 +518,10 @@ def unlift_tokens(
                     raise AssertionError(
                         "Expected tokenized while_loop subgraphs to be GraphModules"
                     )
+                # The cond token placeholder must be erased here: no with_effects
+                # node consumes it, so the named_modules sweep cannot see it. The
+                # body is swept again by that loop, but the second pass is a
+                # no-op since its token input is a _make_token call by then.
                 if cond_module not in unlifted_while_loop_conds:
                     cond_nodes = cond_module.graph.find_nodes(op="placeholder")
                     cond_token = cond_nodes[0] if cond_nodes else None
@@ -529,6 +533,23 @@ def unlift_tokens(
                     cond_module.recompile()
                     unlifted_while_loop_conds.add(cond_module)
                 if body_module not in unlifted_while_loop_bodies:
+                    if not any(
+                        n.op == "call_function"
+                        and (
+                            n.target is torch.ops.higher_order.with_effects
+                            or (
+                                n.target is torch.ops.higher_order.while_loop
+                                and "num_effect_tokens" in n.kwargs
+                            )
+                        )
+                        for n in body_module.graph.nodes
+                    ):
+                        raise AssertionError(
+                            f"while_loop body {body_node.target} is marked with "
+                            "num_effect_tokens=1 but contains no with_effects "
+                            "nodes and no tokenized inner while_loop; effect "
+                            "detection and emission disagree"
+                        )
                     _unlift_tokens_from_module_helper(
                         body_module,
                         f"{subgraph_str}_{body_node.target}",

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -11,7 +11,7 @@ import warnings
 from collections.abc import Callable, Sequence
 from contextlib import nullcontext
 from functools import partial, wraps
-from typing import Any, overload, TYPE_CHECKING
+from typing import Any, cast, overload, TYPE_CHECKING
 from typing_extensions import ParamSpec, TypeVar, TypeVarTuple, Unpack
 
 import torch
@@ -393,6 +393,9 @@ def unlift_tokens(
                         output_tokens.add(user)
         return output_tokens
 
+    unlifted_while_loop_conds: set[torch.fx.GraphModule] = set()
+    unlifted_while_loop_bodies: set[torch.fx.GraphModule] = set()
+
     def _unlift_tokens_from_module_helper(
         module: torch.fx.GraphModule,
         subgraph_str: str,
@@ -482,6 +485,81 @@ def unlift_tokens(
                     output_token_nodes = (
                         output_token_nodes | tokens_from_invoke_subgraph
                     )
+
+            elif (
+                node.op == "call_function"
+                and node.target is torch.ops.higher_order.while_loop
+                and "num_effect_tokens" in node.kwargs
+            ):
+                num_effect_tokens = node.kwargs["num_effect_tokens"]
+                if type(num_effect_tokens) is not int or num_effect_tokens != 1:
+                    raise NotImplementedError(
+                        "torch.while_loop currently supports exactly one ORDERED "
+                        f"effect token, got {num_effect_tokens!r}"
+                    )
+                if len(node.args) != 4:
+                    raise AssertionError(f"Malformed tokenized while_loop node: {node}")
+                cond_node, body_node, carried_inputs, additional_inputs = node.args
+                if not all(
+                    isinstance(n, torch.fx.Node)
+                    and n.op == "get_attr"
+                    and isinstance(n.target, str)
+                    for n in (cond_node, body_node)
+                ) or (
+                    not isinstance(carried_inputs, (tuple, list)) or not carried_inputs
+                ):
+                    raise AssertionError(f"Malformed tokenized while_loop node: {node}")
+
+                cond_module = module.get_submodule(cast(str, cond_node.target))
+                body_module = module.get_submodule(cast(str, body_node.target))
+                if not isinstance(cond_module, torch.fx.GraphModule) or not isinstance(
+                    body_module, torch.fx.GraphModule
+                ):
+                    raise AssertionError(
+                        "Expected tokenized while_loop subgraphs to be GraphModules"
+                    )
+                if cond_module not in unlifted_while_loop_conds:
+                    cond_nodes = cond_module.graph.find_nodes(op="placeholder")
+                    cond_token = cond_nodes[0] if cond_nodes else None
+                    if cond_token is None or cond_token.users:
+                        raise NotImplementedError(
+                            "effects in torch.while_loop cond_fn are not supported"
+                        )
+                    cond_module.graph.erase_node(cond_token)
+                    cond_module.recompile()
+                    unlifted_while_loop_conds.add(cond_module)
+                if body_module not in unlifted_while_loop_bodies:
+                    _unlift_tokens_from_module_helper(
+                        body_module,
+                        f"{subgraph_str}_{body_node.target}",
+                        num_effect_tokens,
+                    )
+                    unlifted_while_loop_bodies.add(body_module)
+
+                token, *non_token_args = carried_inputs
+                inner_kwargs = dict(node.kwargs)
+                del inner_kwargs["num_effect_tokens"]
+                with module.graph.inserting_before(node):
+                    new_node = module.graph.call_function(
+                        torch.ops.higher_order.with_effects,
+                        # pyrefly: ignore [bad-argument-type]
+                        (
+                            token,
+                            torch.ops.higher_order.while_loop,
+                            cond_node,
+                            body_node,
+                            type(carried_inputs)(non_token_args),
+                            additional_inputs,
+                        ),
+                        inner_kwargs,
+                    )
+                    node.replace_all_uses_with(new_node)
+                    new_node.meta = node.meta
+                    module.graph.erase_node(node)
+                if isinstance(token, torch.fx.Node) and token.op == "placeholder":
+                    input_token_nodes.add(token)
+                    replace_input_token_with_make_token(module, token)
+                output_token_nodes |= get_output_tokens(new_node)
 
         if not output_token_nodes and not input_token_nodes:
             return

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -369,13 +369,15 @@ def _maybe_fake_tracing(fn, inputs: list[Any], pre_dispatch):
         return gm
 
 
-def potential_input_alias_or_mutation(gm, inputs, pre_dispatch=False):
+def potential_input_alias_or_mutation(
+    gm, inputs, pre_dispatch=False, *, return_graph=False
+):
     try:
         gm = _maybe_fake_tracing(gm, inputs, pre_dispatch)
     except UnsupportedAliasMutationException:
         # this can happen when nested cond_op is
         # functionalized
-        return True
+        return (True, None) if return_graph else True
     except Exception as e:
         raise e
 
@@ -388,7 +390,8 @@ def potential_input_alias_or_mutation(gm, inputs, pre_dispatch=False):
         out_out_alias_map,
         inp_mutation,
     ) = check_input_alias_and_mutation(gm, example_inputs)
-    return (inp_inp_alias_map, inp_out_alias_map, out_out_alias_map), inp_mutation
+    result = (inp_inp_alias_map, inp_out_alias_map, out_out_alias_map), inp_mutation
+    return (result, gm) if return_graph else result
 
 
 def analyze_potential_input_alias_or_mutation(name, aliases, input_mutations):
@@ -419,7 +422,17 @@ def _has_potential_branch_input_mutation(gm, inputs, pre_dispatch=False):
     return len(inp_mutation) > 0
 
 
-def has_potential_input_alias_or_mutation(gm, inputs, pre_dispatch=False):
+def has_potential_input_alias_or_mutation(
+    gm, inputs, pre_dispatch=False, *, return_graph=False
+):
+    result, graph = potential_input_alias_or_mutation(
+        gm, inputs, pre_dispatch, return_graph=True
+    )
+
+    if result is True:
+        alias_or_mutation = (True, True)
+        return (*alias_or_mutation, graph) if return_graph else alias_or_mutation
+
     (
         (
             inp_inp_alias_map,
@@ -427,8 +440,8 @@ def has_potential_input_alias_or_mutation(gm, inputs, pre_dispatch=False):
             out_out_alias_map,
         ),
         inp_mutation,
-    ) = potential_input_alias_or_mutation(gm, inputs, pre_dispatch)
-    return (
+    ) = result
+    alias_or_mutation = (
         any(
             (
                 len(inp_inp_alias_map) > 0,
@@ -438,6 +451,7 @@ def has_potential_input_alias_or_mutation(gm, inputs, pre_dispatch=False):
         ),
         len(inp_mutation) > 0,
     )
+    return (*alias_or_mutation, graph) if return_graph else alias_or_mutation
 
 
 def _collect_fake_inputs(inputs):
@@ -497,13 +511,19 @@ def _collect_fake_inputs(inputs):
 
 
 def _check_alias_and_mutation(graph_module, inputs_fake, name, pre_dispatch):
-    aliases, inp_mutation = has_potential_input_alias_or_mutation(
-        graph_module, inputs_fake, pre_dispatch=pre_dispatch
+    aliases, inp_mutation, checked_graph = has_potential_input_alias_or_mutation(
+        graph_module,
+        inputs_fake,
+        pre_dispatch=pre_dispatch,
+        return_graph=True,
     )
     if aliases:
         raise RuntimeError(f"{name} might be aliasing the input or the output!")
     if inp_mutation:
         raise RuntimeError(f"{name} might be modifying the input!")
+    if checked_graph is None:
+        raise AssertionError("alias and mutation check did not produce a graph")
+    return checked_graph
 
 
 def unique_graph_id(proxy_mode, prefix):

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -521,8 +521,6 @@ def _check_alias_and_mutation(graph_module, inputs_fake, name, pre_dispatch):
         raise RuntimeError(f"{name} might be aliasing the input or the output!")
     if inp_mutation:
         raise RuntimeError(f"{name} might be modifying the input!")
-    if checked_graph is None:
-        raise AssertionError("alias and mutation check did not produce a graph")
     return checked_graph
 
 

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -44,12 +44,19 @@ def _validate_num_effect_tokens(num_effect_tokens, num_carries=None):
 def _graph_has_effects(gm):
     from torch._higher_order_ops.effects import has_effects, with_effects
 
-    for node in gm.graph.nodes:
-        if node.op == "call_function":
-            nested_tokens = node.kwargs.get("num_effect_tokens", 0)
-            _validate_num_effect_tokens(nested_tokens)
-            if nested_tokens or node.target is with_effects or has_effects(node.target):
-                return True
+    for submodule in gm.modules():
+        if not isinstance(submodule, torch.fx.GraphModule):
+            continue
+        for node in submodule.graph.nodes:
+            if node.op == "call_function":
+                nested_tokens = node.kwargs.get("num_effect_tokens", 0)
+                _validate_num_effect_tokens(nested_tokens)
+                if (
+                    nested_tokens
+                    or node.target is with_effects
+                    or has_effects(node.target)
+                ):
+                    return True
     return False
 
 
@@ -705,20 +712,23 @@ def while_loop_func(
         functional_cond_fn = ctx.functionalize(_maybe_run_with_interpreter(cond_fn))
         functional_body_fn = ctx.functionalize(_maybe_run_with_interpreter(body_fn))
         pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
+        checked_graphs = {}
         for fn, fn_name in [
             (cond_fn, "cond_fn"),
             (body_fn, "body_fn"),
         ]:
-            _check_alias_and_mutation(fn, unwrapped_inputs, fn_name, pre_dispatch)
+            checked_graphs[fn_name] = _check_alias_and_mutation(
+                fn, unwrapped_inputs, fn_name, pre_dispatch
+            )
 
         body_has_effect = False
         if not num_effect_tokens:
 
-            def _probe_effects(fn):
+            def _discover_effect_tokens(fn):
                 tokens_before = dict(mode._tokens) if mode is not None else {}
                 probed_tokens = {}
                 try:
-                    gm = materialize_as_graph(fn, unwrapped_inputs)
+                    materialize_as_graph(fn, unwrapped_inputs)
                     if mode is not None:
                         probed_tokens = dict(mode._tokens)
                 finally:
@@ -726,13 +736,12 @@ def while_loop_func(
                 if mode is not None and mode._allow_token_discovery:
                     for key, token in probed_tokens.items():
                         mode._tokens.setdefault(key, token)
-                return _graph_has_effects(gm)
 
-            if _probe_effects(functional_cond_fn):
+            if _graph_has_effects(checked_graphs["cond_fn"]):
                 raise NotImplementedError(
                     "effects in while_loop cond_fn are unsupported"
                 )
-            body_has_effect = _probe_effects(functional_body_fn)
+            body_has_effect = _graph_has_effects(checked_graphs["body_fn"])
             if stack_output and body_has_effect:
                 raise NotImplementedError(
                     "effects in while_loop_stack_output are unsupported"
@@ -749,6 +758,8 @@ def while_loop_func(
                 raise NotImplementedError(
                     "effects in while_loop are unsupported during export"
                 )
+            if body_has_effect:
+                _discover_effect_tokens(functional_body_fn)
 
         active_mode = mode if body_has_effect else None
         if active_mode is not None:

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -2,7 +2,7 @@
 import contextlib
 import functools
 from collections.abc import Callable
-from typing import Any, cast
+from typing import Any
 
 import torch
 import torch.utils._pytree as pytree
@@ -48,15 +48,14 @@ def _graph_has_effects(gm):
         if not isinstance(submodule, torch.fx.GraphModule):
             continue
         for node in submodule.graph.nodes:
-            if node.op == "call_function":
+            if node.op != "call_function":
+                continue
+            nested_tokens = 0
+            if node.target in (while_loop_op, while_loop_stack_output_op):
                 nested_tokens = node.kwargs.get("num_effect_tokens", 0)
                 _validate_num_effect_tokens(nested_tokens)
-                if (
-                    nested_tokens
-                    or node.target is with_effects
-                    or has_effects(node.target)
-                ):
-                    return True
+            if nested_tokens or node.target is with_effects or has_effects(node.target):
+                return True
     return False
 
 
@@ -87,15 +86,18 @@ class WhileLoopOp(HigherOrderOperator):
         _validate_num_effect_tokens(num_effect_tokens, len(carried_inputs))
         if num_effect_tokens and carried_inputs[0] is None:
             raise NotImplementedError(
-                "effectful torch.while_loop requires an effect-token-unlifting backend"
+                "the leading effect-token carry of this while_loop is None, "
+                "which means the compiling backend keeps effect tokens lifted "
+                "(unlift_effect_tokens=False); effectful torch.while_loop "
+                "requires an effect-token-unlifting backend such as inductor"
             )
         validate_subgraph_args_types(carried_inputs)
         validate_subgraph_args_types(additional_inputs)
-        kwargs = {}
+        kwargs: dict[str, Any] = {}
         if mutated_arg_indices:
             kwargs["mutated_arg_indices"] = mutated_arg_indices
         if num_effect_tokens:
-            kwargs["num_effect_tokens"] = cast(Any, num_effect_tokens)
+            kwargs["num_effect_tokens"] = num_effect_tokens
         # pyrefly: ignore [missing-attribute]
         return super().__call__(
             cond_fn,
@@ -376,6 +378,10 @@ def while_loop_autograd(
     mutated_arg_indices="",
     num_effect_tokens=0,
 ):
+    if num_effect_tokens:
+        raise NotImplementedError(
+            "effects in torch.while_loop are not supported with autograd"
+        )
     return WhileLoopAutogradOp.apply(
         cond_fn,
         body_fn,
@@ -531,11 +537,11 @@ def while_loop_tracing(
         proxy_mode.tracer.root.register_module(body_graph_name, body_graph)
 
         args = (cond_graph, body_graph, carried_inputs, additional_inputs)
-        kwargs = {}
+        kwargs: dict[str, Any] = {}
         if not stack_output and mutated_arg_indices:
             kwargs["mutated_arg_indices"] = mutated_arg_indices
         if not stack_output and num_effect_tokens:
-            kwargs["num_effect_tokens"] = cast(Any, num_effect_tokens)
+            kwargs["num_effect_tokens"] = num_effect_tokens
 
         proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
 
@@ -782,15 +788,22 @@ def while_loop_func(
                 finally:
                     _restore_tokens(saved_tokens)
 
-        op_kwargs = {}
+        op_kwargs: dict[str, Any] = {}
         if not stack_output and mutated_arg_indices:
             op_kwargs["mutated_arg_indices"] = mutated_arg_indices
         if not stack_output and (num_effect_tokens or body_has_effect):
-            op_kwargs["num_effect_tokens"] = cast(Any, 1)
+            op_kwargs["num_effect_tokens"] = 1
 
         loop_carried_inputs = unwrapped_carried_inputs
         if active_mode is not None:
-            token = ctx.unwrap_tensors((active_mode._tokens[EffectType.ORDERED],))[0]
+            ordered_token = active_mode._tokens.get(EffectType.ORDERED)
+            if ordered_token is None:
+                raise NotImplementedError(
+                    "while_loop body effect detection and token discovery "
+                    "disagree: the materialized body graph contains an effect "
+                    "but no ORDERED token was discovered for this trace"
+                )
+            token = ctx.unwrap_tensors((ordered_token,))[0]
             loop_carried_inputs = (token, *loop_carried_inputs)
         ret = op(
             functional_cond_fn,

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -2,6 +2,7 @@
 import contextlib
 import functools
 from collections.abc import Callable
+from typing import Any, cast
 
 import torch
 import torch.utils._pytree as pytree
@@ -23,6 +24,7 @@ from torch._higher_order_ops.utils import (
     reenter_make_fx,
     validate_subgraph_args_types,
 )
+from torch._library.effects import EffectType
 from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
@@ -30,6 +32,25 @@ from torch.fx.experimental.proxy_tensor import (
     ProxyTorchDispatchMode,
     track_tensor_tree,
 )
+
+
+def _validate_num_effect_tokens(num_effect_tokens, num_carries=None):
+    if type(num_effect_tokens) is not int or num_effect_tokens not in (0, 1):
+        raise ValueError("num_effect_tokens must be 0 or 1")
+    if num_carries is not None and num_effect_tokens > num_carries:
+        raise ValueError("effect token is missing from carried_inputs")
+
+
+def _graph_has_effects(gm):
+    from torch._higher_order_ops.effects import has_effects, with_effects
+
+    for node in gm.graph.nodes:
+        if node.op == "call_function":
+            nested_tokens = node.kwargs.get("num_effect_tokens", 0)
+            _validate_num_effect_tokens(nested_tokens)
+            if nested_tokens or node.target is with_effects or has_effects(node.target):
+                return True
+    return False
 
 
 class WhileLoopOp(HigherOrderOperator):
@@ -45,6 +66,7 @@ class WhileLoopOp(HigherOrderOperator):
         /,
         *,
         mutated_arg_indices: str = "",
+        num_effect_tokens: int = 0,
     ):
         if not isinstance(carried_inputs, (tuple, list)):
             raise RuntimeError(
@@ -55,11 +77,18 @@ class WhileLoopOp(HigherOrderOperator):
                 f"additional_inputs must be a tuple or list, got {type(additional_inputs)}"
             )
 
+        _validate_num_effect_tokens(num_effect_tokens, len(carried_inputs))
+        if num_effect_tokens and carried_inputs[0] is None:
+            raise NotImplementedError(
+                "effectful torch.while_loop requires an effect-token-unlifting backend"
+            )
         validate_subgraph_args_types(carried_inputs)
         validate_subgraph_args_types(additional_inputs)
         kwargs = {}
         if mutated_arg_indices:
             kwargs["mutated_arg_indices"] = mutated_arg_indices
+        if num_effect_tokens:
+            kwargs["num_effect_tokens"] = cast(Any, num_effect_tokens)
         # pyrefly: ignore [missing-attribute]
         return super().__call__(
             cond_fn,
@@ -77,10 +106,12 @@ class WhileLoopOp(HigherOrderOperator):
         carried_inputs,
         additional_inputs,
         mutated_arg_indices="",
+        num_effect_tokens=0,
     ):
         from torch._higher_order_ops.schema import HopSchemaGenerator
         from torch._higher_order_ops.utils import materialize_as_graph
 
+        _validate_num_effect_tokens(num_effect_tokens, len(carried_inputs))
         all_inputs = carried_inputs + additional_inputs
 
         cond_gm: torch.fx.GraphModule = (
@@ -265,6 +296,7 @@ def while_loop_dense(
     additional_inputs,
     stack_output=False,
     mutated_arg_indices="",
+    num_effect_tokens=0,
 ):
     carried_vals = carried_inputs
 
@@ -330,7 +362,12 @@ def while_loop_dense(
 
 @while_loop_op.py_autograd_impl
 def while_loop_autograd(
-    cond_fn, body_fn, operands, additional_inputs, mutated_arg_indices=""
+    cond_fn,
+    body_fn,
+    operands,
+    additional_inputs,
+    mutated_arg_indices="",
+    num_effect_tokens=0,
 ):
     return WhileLoopAutogradOp.apply(
         cond_fn,
@@ -375,6 +412,7 @@ def while_loop_tracing(
     additional_inputs,
     stack_output=False,
     mutated_arg_indices="",
+    num_effect_tokens=0,
 ):
     op = while_loop_stack_output_op if stack_output else while_loop_op
 
@@ -386,6 +424,7 @@ def while_loop_tracing(
         carried_inputs,
         additional_inputs,
         mutated_arg_indices,
+        num_effect_tokens,
     ):
         # NOTE [unspecialize int carry with unbacked symints]
         # When we support int carry, we'll also need to support int output of body_fn because.
@@ -488,6 +527,8 @@ def while_loop_tracing(
         kwargs = {}
         if not stack_output and mutated_arg_indices:
             kwargs["mutated_arg_indices"] = mutated_arg_indices
+        if not stack_output and num_effect_tokens:
+            kwargs["num_effect_tokens"] = cast(Any, num_effect_tokens)
 
         proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
 
@@ -514,6 +555,7 @@ def while_loop_tracing(
         carried_inputs,
         additional_inputs,
         mutated_arg_indices,
+        num_effect_tokens,
     )
 
 
@@ -526,6 +568,7 @@ def while_loop_fake_tensor_mode(
     additional_inputs,
     stack_output=False,
     mutated_arg_indices="",
+    num_effect_tokens=0,
 ):
     with mode:
         # NOTE: [Handling unback symints in subgraph of while_loop]
@@ -614,11 +657,27 @@ def while_loop_func(
     additional_inputs,
     stack_output=False,
     mutated_arg_indices="",
+    num_effect_tokens=0,
 ):
     op = while_loop_stack_output_op if stack_output else while_loop_op
+    _validate_num_effect_tokens(num_effect_tokens, len(carried_inputs))
+    mode = ctx.mode if hasattr(ctx, "mode") else None
+
+    def _restore_tokens(tokens):
+        if mode is not None:
+            mode._tokens.clear()
+            mode._tokens.update(tokens)
+
+    if num_effect_tokens and mode is not None:
+        raise NotImplementedError(
+            "Python re-functionalization of an effectful while_loop is unsupported"
+        )
+    if num_effect_tokens and mutated_arg_indices:
+        raise NotImplementedError("while_loop effects with mutation are unsupported")
+
     # For now, we only support auto-functionalization for while_loop when using python
     # functionalization mode
-    if not stack_output and hasattr(ctx, "mode"):
+    if not stack_output and mode is not None:
         hop_instance = HopInstance.create(
             op,
             cond_fn,
@@ -629,7 +688,7 @@ def while_loop_func(
         )
         if can_auto_functionalize(hop_instance):
             return do_auto_functionalize_v2(
-                ctx.mode,
+                mode,
                 hop_instance,
                 tuple(
                     pytree.tree_flatten(
@@ -651,16 +710,84 @@ def while_loop_func(
             (body_fn, "body_fn"),
         ]:
             _check_alias_and_mutation(fn, unwrapped_inputs, fn_name, pre_dispatch)
+
+        body_has_effect = False
+        if not num_effect_tokens:
+
+            def _probe_effects(fn):
+                tokens_before = dict(mode._tokens) if mode is not None else {}
+                probed_tokens = {}
+                try:
+                    gm = materialize_as_graph(fn, unwrapped_inputs)
+                    if mode is not None:
+                        probed_tokens = dict(mode._tokens)
+                finally:
+                    _restore_tokens(tokens_before)
+                if mode is not None and mode._allow_token_discovery:
+                    for key, token in probed_tokens.items():
+                        mode._tokens.setdefault(key, token)
+                return _graph_has_effects(gm)
+
+            if _probe_effects(functional_cond_fn):
+                raise NotImplementedError(
+                    "effects in while_loop cond_fn are unsupported"
+                )
+            body_has_effect = _probe_effects(functional_body_fn)
+            if stack_output and body_has_effect:
+                raise NotImplementedError(
+                    "effects in while_loop_stack_output are unsupported"
+                )
+            if body_has_effect and mode is None:
+                raise NotImplementedError(
+                    "while_loop effects require Python functionalization"
+                )
+            if body_has_effect and mutated_arg_indices:
+                raise NotImplementedError(
+                    "while_loop effects with mutation are unsupported"
+                )
+
+        active_mode = mode if body_has_effect else None
+        if active_mode is not None:
+            orig_functional_cond_fn = functional_cond_fn
+            orig_functional_body_fn = functional_body_fn
+
+            @functools.wraps(orig_functional_cond_fn)
+            def functional_cond_fn(_token, *args):
+                return orig_functional_cond_fn(*args)
+
+            @functools.wraps(orig_functional_body_fn)
+            def functional_body_fn(token, *args):
+                saved_tokens = dict(active_mode._tokens)
+                try:
+                    _restore_tokens({EffectType.ORDERED: ctx.wrap_tensors((token,))[0]})
+                    body_outs = orig_functional_body_fn(*args)
+                    ordered_token = active_mode._tokens[EffectType.ORDERED]
+                    token_out = ctx.unwrap_tensors((ordered_token,))[0]
+                    return (token_out, *body_outs)
+                finally:
+                    _restore_tokens(saved_tokens)
+
         op_kwargs = {}
         if not stack_output and mutated_arg_indices:
             op_kwargs["mutated_arg_indices"] = mutated_arg_indices
+        if not stack_output and (num_effect_tokens or body_has_effect):
+            op_kwargs["num_effect_tokens"] = cast(Any, 1)
+
+        loop_carried_inputs = unwrapped_carried_inputs
+        if active_mode is not None:
+            token = ctx.unwrap_tensors((active_mode._tokens[EffectType.ORDERED],))[0]
+            loop_carried_inputs = (token, *loop_carried_inputs)
         ret = op(
             functional_cond_fn,
             functional_body_fn,
-            unwrapped_carried_inputs,
+            loop_carried_inputs,
             unwrapped_additional_inputs,
+            # pyrefly: ignore [bad-argument-type]
             **op_kwargs,
         )
+        if active_mode is not None:
+            active_mode._tokens[EffectType.ORDERED] = ctx.wrap_tensors((ret[0],))[0]
+            ret = ret[1:]
         return ctx.wrap_tensors(ret)
 
 

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -745,6 +745,10 @@ def while_loop_func(
                 raise NotImplementedError(
                     "while_loop effects with mutation are unsupported"
                 )
+            if body_has_effect and torch.compiler.is_exporting():
+                raise NotImplementedError(
+                    "effects in while_loop are unsupported during export"
+                )
 
         active_mode = mode if body_has_effect else None
         if active_mode is not None:

--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -350,6 +350,12 @@ def _extract_subgraphs_and_args(
         subgraph_args = (*args[2], *args[3])
         yield args[0], subgraph_args
         yield args[1], subgraph_args
+    elif (
+        node.target is torch.ops.higher_order.with_effects
+        and args[1] is torch.ops.higher_order.while_loop
+    ):
+        yield args[2], (*args[4], *args[5])
+        yield args[3], (*args[4], *args[5])
     elif node.target is torch.ops.higher_order.switch:
         # args: (index, [branch_gm_0, ...], operands)
         subgraph_args = tuple(args[2])

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -9366,11 +9366,18 @@ def with_effects(token, op, *args, **kwargs):
     old_bindings = None
     bindings = V.graph.current_node.meta.get("unbacked_bindings")
     if wrapped_while_loop and bindings is not None:
+        # Same purpose as symbolic_shapes._remove_effect_token_unbacked_bindings,
+        # but a wrapped while_loop flattens its results next to the token, so
+        # the leading SequenceKey is decremented rather than stripped.
         if not all(
             path and isinstance(path[0], pytree.SequenceKey) and path[0].idx > 0
             for path in bindings.values()
         ):
-            raise AssertionError("Expected bindings after the effect token")
+            raise AssertionError(
+                "Expected unbacked bindings of a with_effects(while_loop) node "
+                f"to start after the effect token, got {bindings} on node "
+                f"{V.graph.current_node.format_node()}"
+            )
         old_bindings = bindings
         V.graph.current_node.meta["unbacked_bindings"] = {
             symbol: (pytree.SequenceKey(path[0].idx - 1), *path[1:])

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -9335,9 +9335,11 @@ def with_effects(token, op, *args, **kwargs):
     the newly created nodes in the graph.
     """
     from torch._higher_order_ops.effects import _get_effect, _get_schema
+    from torch._library.effects import EffectType
 
     # Get effect type
-    effect_type = _get_effect(op)
+    wrapped_while_loop = op is torch.ops.higher_order.while_loop
+    effect_type = EffectType.ORDERED if wrapped_while_loop else _get_effect(op)
     if effect_type is None and op is torch.ops.higher_order.invoke_subgraph:
         from torch._guards import InvokeSubgraphCache, TracingContext
 
@@ -9361,19 +9363,37 @@ def with_effects(token, op, *args, **kwargs):
     # Track operations before
     operation_len = len(V.graph.operations)
 
+    old_bindings = None
+    bindings = V.graph.current_node.meta.get("unbacked_bindings")
+    if wrapped_while_loop and bindings is not None:
+        if not all(
+            path and isinstance(path[0], pytree.SequenceKey) and path[0].idx > 0
+            for path in bindings.values()
+        ):
+            raise AssertionError("Expected bindings after the effect token")
+        old_bindings = bindings
+        V.graph.current_node.meta["unbacked_bindings"] = {
+            symbol: (pytree.SequenceKey(path[0].idx - 1), *path[1:])
+            for symbol, path in bindings.items()
+        }
+
     # Lower the op
-    if op in lowerings:
-        result = lowerings[op](*args, **kwargs)
-        # Realize so that we can get the ops to show up in V.graph.operations
-        pytree.tree_map_only(TensorBox, lambda a: a.realize(), result)
-    else:
+    try:
+        if op in lowerings:
+            result = lowerings[op](*args, **kwargs)
+            # Realize so that we can get the ops to show up in V.graph.operations
+            pytree.tree_map_only(TensorBox, lambda a: a.realize(), result)
+        else:
 
-        def wrap_tensors(x):
-            return x.wrap_for_lowering() if isinstance(x, ir.IRNode) else x
+            def wrap_tensors(x):
+                return x.wrap_for_lowering() if isinstance(x, ir.IRNode) else x
 
-        result = pytree.tree_map(
-            wrap_tensors, ir.FallbackKernel.create(op, *args, **kwargs)
-        )
+            result = pytree.tree_map(
+                wrap_tensors, ir.FallbackKernel.create(op, *args, **kwargs)
+            )
+    finally:
+        if old_bindings is not None:
+            V.graph.current_node.meta["unbacked_bindings"] = old_bindings
 
     # Get all the operations created during the lowering above, and add StarDeps
     # to the previous node with the same effect
@@ -9393,6 +9413,9 @@ def with_effects(token, op, *args, **kwargs):
         V.graph.effectful_ops[effect_type] = (
             new_op  # pyrefly: ignore[unsupported-operation]
         )
+
+    if wrapped_while_loop:
+        return (token, *result)
 
     try:
 


### PR DESCRIPTION
## Issue

Fixes #190908.

Functionalization rewrites the ordered effect in a `while_loop` body to `with_effects`, so the body consumes and returns an effect token. AOTAutograd previously unlifted the top-level token without preserving the same ABI across the nested `while_loop`/body boundary. Inductor then called the body without its token argument.

## Fix

For a functionalized body with graph-proven effect provenance, this patch:

- prepends one ordered token to the loop carry;
- records that prefix with an internal, defaulted `num_effect_tokens` kwarg;
- recursively unlifts only the marked token prefix before Inductor;
- keeps the token out of the user carry ABI and lowers the parent loop as an ordered `with_effects` operation; and
- normalizes shared cond/body `GraphModule`s once by identity.

The marker is explicit provenance. It does not infer tokens from tensor shapes, carry position, or ambient effects, so an empty leading user carry cannot be misclassified.

Export functionalization now fails before inserting a token when it discovers an effectful loop body. This makes `ExportedProgram.run_decompositions()` return a clear `NotImplementedError` instead of producing a malformed program. Initial export remains valid while the loop is undecomposed.

## Investigation and scope

The design follows the existing ordered-token sinking dependency in #122347, the `invoke_subgraph` token-threading and recursive-unlift patterns in #167231 and #167363, and the related `cond` handling in #185116. I also tested a global token-sinking scope change; although it handled more backends, it relaxed ordering semantics outside `while_loop`, so this patch keeps the fix local and provenance-based.

This PR intentionally covers inference AOTAutograd + Inductor with a pure condition and one ordered body effect. The following remain explicit follow-ups instead of silently generating invalid graphs:

- effectful conditions;
- training / `while_loop_stack_output`;
- mutation combined with effects;
- effectful `aot_eager` or other non-unlifting backends; and
- effectful export decomposition and recompilation.

The reporter also offered to work on training support in #190908.

> **AI-assisted factual update:** Current size is 10 files, +400/-25. The implementation and focused regressions remain together because the tests pin the supported Inductor path, the export boundary, the empty-carry false-positive boundary, and the pure-loop tracing regression found in CI.

## Validation

Run against a clean PyTorch nightly with the exact candidate files overlaid:

- `test_while_loop_effect_provenance`: passes and reproduces the #190908 Inductor numerics.
- `test_effectful_while_loop_export_nyi`: passes for strict and non-strict export; the exported module runs and decomposition fails cleanly.
- `test_pure_while_loop_empty_carry_with_unrelated_effect`: passes through `aot_eager` and export decomposition, with no effect-token marker attached to the pure loop.
- Full `test/higher_order_ops/test_with_effects.py`: 20 passed, 4 hardware-gated skips.
- `test/inductor/test_control_flow.py -k while_loop`: 4 passed, 97 hardware-gated skips.
- Adversarial matrix: 9/9 expected outcomes across the original repro, pure loops, empty carries, nested loops, cond effects, `aot_eager`, and export.
- `git diff --check`: clean.

> **AI-assisted post-CI update:** The initial CI run exposed an unrelated autograd snapshot regression: unconditional effect probes retraced both subgraphs for pure loops, consumed two ShapeEnv symbol IDs, and shifted the expected symbol from `u7` to `u9`. Commit `851735c467` reuses the graphs already produced by alias/mutation validation, so pure loops perform zero extra effect traces. A supported effectful body is materialized once only when runtime token discovery is required.
>
> The exact failing test now passes unchanged. `test/functorch/test_control_flow.py -k while_loop` completed with 90 passes and 23 hardware-gated skips. The alias-helper compatibility check, `py_compile`, `git diff --check`, and path-scoped `spin quicklint -a` also pass; the auto-fixing lint gate made no changes to the reviewed patch.

> **AI-assisted audit update (commit `149520f8cf7`):** A blind audit of this PR produced a hardening round, Docker-verified against `torch 2.14.0.dev20260807+cpu`. Detection/emission disagreements are now hard errors at both ends instead of a raw `KeyError` or a silently mis-arity'd graph, the autograd impl rejects marker-bearing loops instead of dropping the marker, and new regressions cover the ordered token chain linking the loop to a following effect, an effectful loop with a zero-element leading user carry, a nested effectful loop, the body-aliasing error path, and a GPU provenance variant.
>
> The export contract is stronger than previously stated: for ops that are effectful at pre-dispatch (`aten::_print` in the body), the initial export also stays valid and runnable, with only `run_decompositions()` raising - now pinned by tests in both strict modes. Two limitations worth stating explicitly: `torch._inductor.aot_compile` executes under the exporting flag, so AOTInductor currently rejects effectful while_loops; and effects reached through `invoke_subgraph` (`nested_compile_region`) in a loop body are detected but not supported. Both are follow-up work alongside training support.
>
> **Correction (supersedes the `invoke_subgraph` sentence above, which said such effects are not detected).** Deliberate hunting with a matching nightly (`2.14.0.dev20260725+cpu`) shows they are detected: `_graph_has_effects` iterates `gm.modules()` recursively, so it sees an effect inside the region's subgraph. What actually happens depends on how often the region is called. Called once, Dynamo inlines it, no `invoke_subgraph` node survives, and the loop compiles as an ordinary effectful body. Called more than once the HOP does survive, detection reports an effect, and the loop is then rejected at emission with `while_loop body effect detection and token discovery disagree`, because no ORDERED token is discovered for that trace. So the practical conclusion is unchanged -- these loops are not supported and nothing silently miscompiles -- but the stated mechanism was wrong.

There is no public API change and no change to the user-visible carry ABI.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98

