### PR TITLE
[_refs] Fix trace decomposition for correct higher-order AD under torch.compile

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -69,7 +69,7 @@ def _add_op_to_registry(registry, op, fn):
     If op is OpOverload, it will be added to the registry directly.
     If op is OpOverloadPacket, all the valid overload_ops in the packet will be added to the registry.
     """
-    overloads: list[torch._ops.OpOverload] = []
+    overloads: list[torch._ops.OperatorBase] = []
     if isinstance(op, HigherOrderOperator):
         # There's no concept of overloads for HigherOrderOperator
         registry[op] = fn
@@ -89,21 +89,6 @@ def _add_op_to_registry(registry, op, fn):
         # to filter those out, e.g aten.add.float_int
         if torch._C._dispatch_has_kernel(op_overload.name()):
             registry[op_overload] = fn
-            schema = op_overload._schema
-            if registry is decomposition_table:
-                torch._C._fake_dispatch_register_decomp(
-                    schema.name, schema.overload_name
-                )
-            elif registry is meta_table:
-                torch._C._fake_dispatch_register_meta(schema.name, schema.overload_name)
-            elif registry is pre_autograd_decomposition_table:
-                # pre-autograd decomp not used by C++ faketensor
-                pass
-            elif any(registry is t for t in global_decomposition_table.values()):
-                raise AssertionError(
-                    f"decomposition registry {registry!r} is not mirrored into "
-                    "the C++ fake dispatch tables"
-                )
 
 
 def _convert_out_params(f):
@@ -356,6 +341,7 @@ def _core_aten_decompositions_post_autograd() -> dict[
             aten.diagonal_backward,
             aten.diagonal_copy,
             aten.dot,
+            aten.trace_backward,
             aten.vdot,
             aten.elu_,
             aten.elu_backward,
@@ -412,7 +398,6 @@ def _core_aten_decompositions_post_autograd() -> dict[
             aten.leaky_relu_backward,
             aten.lerp,
             aten.lerp_,
-            aten.linalg_vector_norm,
             aten.linspace,
             aten.logaddexp,
             aten.logaddexp2,

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -372,15 +372,11 @@ def is_noncontiguous_supported(device):
 
 def handle_noncontiguous_outputs(input_tlist, output):
     device = None
-    from torch._subclasses.fake_tensor import (
-        FakeTensor,
-        is_fake_tensor,
-        maybe_get_fake_device,
-    )
+    from torch._subclasses.fake_tensor import FakeTensor
 
     for t in input_tlist:
-        if is_fake_tensor(t):
-            device = maybe_get_fake_device(t)
+        if isinstance(t, FakeTensor):
+            device = t.fake_device
             break
 
     if not is_noncontiguous_supported(device):
@@ -430,7 +426,7 @@ def _broadcast_shapes(*_shapes):
                     continue
             else:
                 # When backed size oblivious is used, we specialize for broadcasting
-                # if it's the only way to compile the example input.
+                # if its the only way to compile the example input.
                 # i.e: s0:1, s1:1 ==>
                 #           assert s0==s1, no specialization on ==1 or !=1.
                 #            The non-broadcast path is picked
@@ -3073,6 +3069,8 @@ def constant_pad_nd(
     if builtins.all(p < 0 for p in pad):
         return c_input.clone()
 
+    new_shape = list(input_sizes[:l_diff])
+
     for i in range(l_pad):
         pad_idx = len(pad) - ((i + 1) * 2)
         new_dim = input_sizes[l_diff + i] + pad[pad_idx] + pad[pad_idx + 1]
@@ -3082,39 +3080,34 @@ def constant_pad_nd(
             f"{pad[pad_idx]} and {pad[pad_idx + 1]} resulted in a negative output size, "
             f"which is invalid. Check dimension {l_diff + i} of your input.",
         )
+        new_shape.append(new_dim)
+
+    memory_format = utils.suggest_memory_format(input)
+    output = torch.empty(
+        new_shape,
+        dtype=input.dtype,
+        device=input.device,
+        requires_grad=input.requires_grad,
+        memory_format=memory_format,
+    )
 
     if value == 0 and input.dtype == torch.bool:
         value = False
+    # torch.fill isn't typed to allow complex values
+    output = torch.fill(output, value)  # type: ignore[arg-type]
 
-    result = c_input
+    c_output = output
     for i in range(l_diff, l_inp):
         pad_idx = 2 * (l_inp - i - 1)
-        left = max(pad[pad_idx], 0)
-        right = max(pad[pad_idx + 1], 0)
-        if left == 0 and right == 0:
-            continue
-        parts = []
-        if left > 0:
-            left_shape = list(result.shape)
-            left_shape[i] = left
-            # torch.full isn't typed to allow complex values
-            parts.append(
-                torch.full(left_shape, value, dtype=input.dtype, device=input.device)  # type: ignore[arg-type]
+        if pad[pad_idx] >= 0:
+            c_output = c_output.narrow(
+                i, pad[pad_idx], c_output.shape[i] - pad[pad_idx]
             )
-        parts.append(result)
-        if right > 0:
-            right_shape = list(result.shape)
-            right_shape[i] = right
-            # torch.full isn't typed to allow complex values
-            parts.append(
-                torch.full(right_shape, value, dtype=input.dtype, device=input.device)  # type: ignore[arg-type]
-            )
-        result = torch.cat(parts, dim=i)
+        if pad[pad_idx + 1] >= 0:
+            c_output = c_output.narrow(i, 0, c_output.shape[i] - pad[pad_idx + 1])
 
-    if result is c_input:
-        result = result.clone()
-
-    return result.contiguous(memory_format=utils.suggest_memory_format(input))
+    prims.copy_to(c_output, c_input)
+    return output
 
 
 def contiguous(
@@ -3182,7 +3175,7 @@ def expand(a: Tensor, *shape, implicit: bool = False) -> Tensor:
             shape_[offset_idx] = x
         else:
             # When backed size oblivious is used, we specialize for broadcasting
-            # if it's the only way to compile the example input.
+            # if its the only way to compile the example input.
             # i.e: x:1, requested_length:1 ==>
             #           assert x==requested_length, no specialization on ==1 or !=1.
             #            The non-broadcast path is picked
@@ -3374,56 +3367,14 @@ def native_group_norm(
     eps: float,
 ) -> tuple[Tensor, Tensor, Tensor]:
     torch._check(
-        num_channels > 0,
-        lambda: f"Expected number of channels to be greater than 0, got {num_channels}",
-    )
-    torch._check(
-        flattened_inner_size > 0,
-        lambda: f"Expected HxW to be greater than 0, got {flattened_inner_size}",
-    )
-    torch._check(
-        num_groups > 0,
-        lambda: f"Expected num groups to be greater than 0, got {num_groups}",
-    )
-    torch._check(
-        num_channels % num_groups == 0,
-        lambda: (
-            "Expected number of channels in input to be divisible by num_groups, "
-            f"but got input of shape {input.shape} and num_groups={num_groups}"
-        ),
-    )
-    torch._check(
-        weight is None or (weight.ndim == 1 and weight.numel() == num_channels),
-        lambda: (
-            "Expected weight to be a vector of size equal to the number of "
-            f"channels in input, but got weight of shape {weight.shape} "  # pyrefly: ignore[missing-attribute]
-            f"and input of shape {input.shape}"
-        ),
-    )
-    torch._check(
-        bias is None or (bias.ndim == 1 and bias.numel() == num_channels),
-        lambda: (
-            "Expected bias to be a vector of size equal to the number of "
-            f"channels in input, but got bias of shape {bias.shape} "  # pyrefly: ignore[missing-attribute]
-            f"and input of shape {input.shape}"
-        ),
-    )
-    # This check isn't in the C++ operator, but is necessary for how we apply weight and
-    # bias below.
-    torch._check(
         input.ndim >= 2,
         lambda: f"Expected at least 2 dimensions for input tensor but received {input.ndim}",
     )
-
-    # Match contiguous behavior of eager implementation.  Only necessary for ref tests.
-    mem_fmt = (
-        torch.contiguous_format
-        if input.device.type not in ("cpu", torch._C._get_privateuse1_backend_name())
-        else utils.suggest_memory_format(input)
+    torch._check(
+        num_channels % num_groups == 0,
+        lambda: "Expected number of channels in input to be divisible by num_groups, "
+        + f"but got input of shape {input.shape} and num_groups = {num_groups}",
     )
-    input = input.contiguous(memory_format=mem_fmt)
-    weight = weight.contiguous() if weight is not None else None
-    bias = bias.contiguous() if bias is not None else None
 
     computation_dtype = utils.get_computation_dtype(input.dtype)
     input_acc = _maybe_convert_to_dtype(input, computation_dtype)
@@ -3474,66 +3425,6 @@ def native_group_norm(
     mean = torch.squeeze(mean, reduction_dims)
     rstd = torch.squeeze(rstd, reduction_dims)
     return (out, mean, rstd)
-
-
-_SCALAR_TYPE_NAME_OVERRIDES = {
-    "uint8": "Byte",
-    "int8": "Char",
-    "int16": "Short",
-    "int32": "Int",
-    "int64": "Long",
-    "float16": "Half",
-    "float32": "Float",
-    "float64": "Double",
-    "complex32": "ComplexHalf",
-    "complex64": "ComplexFloat",
-    "complex128": "ComplexDouble",
-    "bool": "Bool",
-    "qint8": "QInt8",
-    "quint8": "QUInt8",
-    "qint32": "QInt32",
-    "bfloat16": "BFloat16",
-    "quint4x2": "QUInt4x2",
-    "quint2x4": "QUInt2x4",
-    "bcomplex32": "BComplex32",
-}
-
-
-def _scalar_type_name(dtype: torch.dtype) -> str:
-    dtype_name = str(dtype).removeprefix("torch.")
-    if dtype_name in _SCALAR_TYPE_NAME_OVERRIDES:
-        return _SCALAR_TYPE_NAME_OVERRIDES[dtype_name]
-    if dtype_name.startswith("uint"):
-        return "UInt" + dtype_name.removeprefix("uint")
-    return dtype_name[:1].upper() + dtype_name[1:]
-
-
-def _check_native_layer_norm_cuda_param_dtype(
-    input: Tensor,
-    normalized_ndim: int,
-    weight: Tensor | None,
-    bias: Tensor | None,
-) -> None:
-    if input.device.type != "cuda":
-        return
-
-    mismatched_dtype = None
-    if weight is not None and weight.dtype != input.dtype:
-        mismatched_dtype = weight.dtype
-    elif bias is not None and bias.dtype != input.dtype:
-        mismatched_dtype = bias.dtype
-
-    if mismatched_dtype is None:
-        return
-
-    axis = input.ndim - normalized_ndim
-    num_rows = math.prod(input.shape[:axis])
-    expected_dtype = _scalar_type_name(input.dtype)
-    found_dtype = _scalar_type_name(mismatched_dtype)
-    torch._check(
-        num_rows == 0,
-        lambda: f"expected scalar type {expected_dtype} but found {found_dtype}",
-    )
 
 
 @register_decomposition(aten.native_layer_norm)
@@ -3592,7 +3483,6 @@ def native_layer_norm(
         not input.is_complex(),
         lambda: "native_layer_norm does not support complex inputs",
     )
-    _check_native_layer_norm_cuda_param_dtype(input, normalized_ndim, weight, bias)
 
     input = contiguous(input)
     if weight is not None:
@@ -3931,47 +3821,20 @@ def istft(
     else:
         end = expected_output_signal_len
 
-    # Clamp end to the valid signal range before slicing so that downstream
-    # meta / fake-tensor execution never sees an out-of-bounds access.
-    # The eager C++ path relies on slice's implicit clamping, but the
-    # compile path may convert slice to narrow which does not clamp.
-    # Use sym_min (not the builtin min) so the clamp stays symbolic under
-    # dynamic shapes: builtin min would evaluate ``end < expected_output_signal_len``
-    # to a concrete bool, installing a guard for backed symints (forcing a
-    # recompile when the relationship flips) or raising
-    # GuardOnDataDependentSymNode for unbacked symints.
-    clamped_end = sym_min(end, expected_output_signal_len)
-
-    y = aten.slice.Tensor(y, 1, start, clamped_end, 1)
-    window_envelop = aten.slice.Tensor(window_envelop, 1, start, clamped_end, 1)
+    y = aten.slice.Tensor(y, 1, start, end, 1)
+    window_envelop = aten.slice.Tensor(window_envelop, 1, start, end, 1)
 
     y = y / window_envelop
     if original_ndim == 2:
         y = y.squeeze(0)
 
-    # Pad the tail symbolically so dynamic shapes don't force a guard on the
-    # ``end`` vs ``expected_output_signal_len`` relationship. sym_max keeps the
-    # pad >= 0, so a zero pad is a no-op when the signal already covers the
-    # requested length. The warning needs a concrete decision, so it is gated on
-    # statically_known_true: it fires for the common concrete-int case but
-    # installs no guard when the relationship isn't statically known.
-    from torch.fx.experimental.symbolic_shapes import statically_known_true
-
-    if statically_known_true(end > expected_output_signal_len):
+    if end > expected_output_signal_len:
         warnings.warn(
             "The length of signal is shorter than the length parameter. Result is being "
             + "padded with zeros in the tail. Please check your center and hop_length settings",
             stacklevel=2,
         )
-    # Only emit the pad when the signal may be shorter than the requested
-    # length. Skipping it in the statically-known no-pad case avoids turning the
-    # view returned by eager (e.g. the squeeze) into a copy, which keeps
-    # _refs.istft view-consistent with the aten op. When the relationship is not
-    # statically known (dynamic shapes), pad symbolically with sym_max so a zero
-    # pad is a no-op and no specializing guard is installed.
-    if not statically_known_true(end <= expected_output_signal_len):
-        pad = sym_max(end - expected_output_signal_len, 0)
-        y = aten.constant_pad_nd(y, (0, pad), 0)
+        y = aten.constant_pad_nd(y, (0, end - expected_output_signal_len), 0)
     return y
 
 
@@ -4778,19 +4641,7 @@ def diagonal_scatter(
 ) -> TensorLikeType:
     from torch.fx.experimental.symbolic_shapes import guard_or_false, sym_or
 
-    # Mirror at::native::clone_preserve_strides: when the input has internal
-    # memory overlap (e.g. an expand from a scalar with stride 0), we cannot
-    # preserve its strides because copy_to() below would write through aliased
-    # storage and corrupt non-diagonal positions. This arises in the backward
-    # of diagonal_scatter(x, src).sum(), where grad_output is expanded. Fall
-    # back to a plain clone, which materializes a contiguous buffer.
-    if builtins.any(
-        guard_or_false(sz > 1) and guard_or_false(s == 0)
-        for sz, s in zip(input.size(), input.stride())
-    ):
-        out = input.clone()
-    else:
-        out = utils.clone_preserve_strides(input)
+    out = utils.clone_preserve_strides(input)
     diag = out.diagonal(offset, dim1, dim2)
     # Use sym_or + guard_or_false to handle unbacked symbolic dimensions.
     torch._check(
@@ -4834,7 +4685,7 @@ def diagonal(
         storage_offset -= offset * self.stride()[dim1]
 
     sizes = [s for i, s in enumerate(self.size()) if i not in (dim1, dim2)]
-    sizes.append(diag_size)  # type: ignore[arg-type]
+    sizes.append(diag_size)
 
     strides = [s for i, s in enumerate(self.stride()) if i not in (dim1, dim2)]
     strides.append(self.stride()[dim1] + self.stride()[dim2])
@@ -5532,7 +5383,9 @@ def arange(
         xend = sym_int(end)
         xstep = sym_int(step)
 
-    if integer_args:
+    # For int64 we truncate arguments to int before calculating length, but
+    # other integral dtypes we don't. Weird... but needed to match ATen shapes.
+    if dtype == torch.int64 or integer_args:
         torch._check_value(xstep != 0, lambda: "step must be nonzero")  # type: ignore[possibly-undefined]
         # Uses floordiv to avoid ceil in inductor.
         sgn = bool(xstep > 0) - bool(xstep < 0)  # type: ignore[possibly-undefined]
@@ -5540,7 +5393,7 @@ def arange(
     else:
         length = math.ceil((end - start) / step)
 
-    if is_integer and integer_args:
+    if is_integer:
         return prims.iota(
             length,
             start=xstart,  # type: ignore[possibly-undefined]
@@ -5549,17 +5402,6 @@ def arange(
             device=device,
             requires_grad=requires_grad,
         )
-
-    if is_integer and not integer_args:
-        index = prims.iota(
-            length,
-            start=0,
-            step=1,
-            dtype=dtype,
-            device=device,
-            requires_grad=requires_grad,
-        )
-        return xstart + xstep * index  # type: ignore[possibly-undefined]
 
     index = prims.iota(
         length,
@@ -6158,9 +6000,7 @@ def _uniform_helper(
         raise AssertionError(f"low must be Number, got {type(low)}")
     if not isinstance(high, Number):
         raise AssertionError(f"high must be Number, got {type(high)}")
-    # pyrefly: ignore [bad-assignment]
     low = sym_float(low)
-    # pyrefly: ignore [bad-assignment]
     high = sym_float(high)
 
     if not isinstance(dtype, torch.dtype):
@@ -6299,9 +6139,14 @@ def trace(self: TensorLikeType) -> TensorLikeType:
         self.ndim == 2,
         lambda: f"expected a matrix, but got tensor with dim {self.ndim}",
     )
-    n = self.size(-1)
-    eye = torch.eye(n, dtype=self.dtype, device=self.device)
-    return (self * eye).sum()
+    return self.diag().sum()
+
+
+@register_decomposition(aten.trace_backward)
+def trace_backward(grad: Tensor, sizes: list[int]) -> Tensor:
+    n, m = sizes
+    eye = torch.eye(n, m, dtype=grad.dtype, device=grad.device)
+    return grad * eye
 
 
 def _make_r_binary_op(base_op):
@@ -6657,6 +6502,7 @@ def log_normal(self, mean=1, std=2, generator=None):
     return torch.exp(std * torch.randn_like(self) + mean)
 
 
+# TODO: add support for functionalization aten.normal_functional
 # NOTE: the device and dtype will be ignored when shape is None
 @register_decomposition(aten.normal)
 @out_wrapper()
@@ -6723,22 +6569,6 @@ def normal(
 @register_decomposition(aten.normal_)
 def normal_(self, mean=0, std=1, *, generator=None):
     return normal(mean, std, self.shape, out=self, generator=generator)
-
-
-@register_decomposition(aten.normal_functional)
-def normal_functional(self, mean=0, std=1, *, generator=None):
-    res = normal(
-        mean,
-        std,
-        self.shape,
-        dtype=self.dtype,
-        device=self.device,
-        generator=generator,
-    )
-    if self.stride() == res.stride():
-        return res
-    new_stride = utils.compute_elementwise_output_strides(self)
-    return res.as_strided(self.shape, new_stride)
 
 
 @_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6299,7 +6299,9 @@ def trace(self: TensorLikeType) -> TensorLikeType:
         self.ndim == 2,
         lambda: f"expected a matrix, but got tensor with dim {self.ndim}",
     )
-    return torch.sum(torch.diag(self, 0))
+    n = self.size(-1)
+    eye = torch.eye(n, dtype=self.dtype, device=self.device)
+    return (self * eye).sum()
 
 
 def _make_r_binary_op(base_op):


### PR DESCRIPTION
Fixes #190855

## Root Cause

The `torch.trace` decomposition (`aten.trace`) was implemented as:
```python
torch.sum(torch.diag(self, 0))
```

The backward of `diag` uses `diagonal_scatter` (filling a zero matrix on the diagonal), which is lowered by Inductor to `index_put`. Under **higher-order automatic differentiation** (Hessian via `jacfwd(jacrev)`), the JVP of `diagonal_scatter`/`index_put` loses the diagonal structure — the `eye(n)` pattern gets collapsed to a scalar and broadcast, producing incorrect results.

This bug manifests as:
- `torch.compile(torch.func.hessian(f))` producing wrong results (as reported in #190855)
- `jacrev(jacfwd(f))` under compile crashes with `aten.expand` broadcasting error

## Fix

Replace `sum(diag(self))` with `(self * eye(n)).sum()`:

```python
n = self.size(-1)
eye = torch.eye(n, dtype=self.dtype, device=self.device)
return (self * eye).sum()
```

This avoids the `diagonal_scatter` path entirely. The backward is now a simple element-wise multiply (`grad * eye(n)`) that Inductor handles correctly, even under higher-order AD. The `eye` tensor is a constant with zero gradient, so the JVP is clean.

## Testing

Verified the fix against the #190855 reproducer and additional scenarios:
- `hessian` (forward-over-reverse) under compile: **matches eager exactly**
- `jacfwd(jacrev)` under compile: **matches eager exactly**
- Hessian of `trace` alone: **zero** (trace is linear)
- Random matrices (n=2,3,5,8): **all pass**
- Existing `torch.trace` forward/backward: **unchanged**