### PR TITLE
Fix optional Tensor args and mixed low precision in autocast promote policy

### DIFF
--- a/aten/src/ATen/autocast_mode.h
+++ b/aten/src/ATen/autocast_mode.h
@@ -238,24 +238,32 @@ inline at::ScalarType prioritize(
     TORCH_CHECK(false, "promote type is double in at::autocast::prioritize");
     return current;
   }
-  at::ScalarType lower_precision_fp =
-      get_lower_precision_fp_from_device_type(device_type);
   if (is_autocast_eligible(nextArg, device_type)) {
     auto next = nextArg.scalar_type();
-    if (next == at::kDouble) {
-      return current; // ignores double tensors
-    } else if (current == at::kFloat || next == at::kFloat) {
-      return at::kFloat; // prioritizes float over lower_precision_fp
-    } else if (current == lower_precision_fp && next == lower_precision_fp) {
-      return lower_precision_fp;
-    } else {
-      TORCH_CHECK(
-          false, "Unexpected floating ScalarType in at::autocast::prioritize");
+    // Double tensors are ignored, and matching types need no widening.
+    if (next == at::kDouble || current == next) {
       return current;
     }
+    // The types differ, so either one of them is already fp32, or they are two
+    // different low precision types (e.g. an fp16 tensor inside a bf16 autocast
+    // region). fp32 is the narrowest type that covers both.
+    return at::kFloat;
   } else {
     return current;
   }
+}
+
+// Overload to catch optional Tensor args. Without this they fall through to the
+// catch-all template below and their dtype is silently left out of the promote
+// decision.
+inline at::ScalarType prioritize(
+    at::ScalarType current,
+    const std::optional<Tensor>& arg,
+    c10::DeviceType device_type = c10::DeviceType::CUDA) {
+  if (!arg.has_value()) {
+    return current;
+  }
+  return prioritize(current, *arg, device_type);
 }
 
 // Overload to catch TensorList args (for e.g. cat, stack).

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -279,11 +279,12 @@ class TestAutocastDevice(TestCase):
     # That means:
     #   (1) double precision is ignored,
     #   (2) if any argument is float, then all arguments are promoted to float,
-    #   (3) if all arguments are of lower precision dtype, then all dtypes must be equal to the same amp autocast dtype.
-    # Since AMP autocast dtype is thread-local, it is not preserved across thread boundaries during autograd execution,
-    # and due to the multi-threaded nature of the autograd, the forward pass is being run in bfloat16, while the backward
-    # pass defaults to float16. The dtype mismatch leads to the error in the policy, as the criteria (3) is not satisfied.
-    # For more info see https://github.com/pytorch/pytorch/issues/132715.
+    #   (3) if all arguments share one lower precision dtype, that dtype is kept.
+    # Mixing two different lower precision dtypes also promotes to float, per (2)'s
+    # reasoning: float is the narrowest type covering both. This used to raise
+    # instead, which is what https://github.com/pytorch/pytorch/issues/132715 hit
+    # when autograd ran the backward pass in a different autocast dtype than the
+    # forward pass.
     @onlyAccelerator
     def test_autocast_prioritize(self, device):
         dtype = torch.bfloat16
@@ -299,6 +300,40 @@ class TestAutocastDevice(TestCase):
 
             loss = res.mean()
             loss.backward()
+
+    @onlyAccelerator
+    def test_autocast_prioritize_mixed_low_precision(self, device):
+        # Two different lower precision dtypes meeting in one op promote to float
+        # rather than raising. Every op on the promote policy is affected, so a
+        # pointwise one stands in for the rest.
+        for autocast_dtype, other in (
+            (torch.bfloat16, torch.float16),
+            (torch.float16, torch.bfloat16),
+        ):
+            with torch.autocast(device_type=device, dtype=autocast_dtype):
+                a = torch.randn(8, device=device, dtype=other)
+                b = torch.randn(8, device=device, dtype=autocast_dtype)
+                self.assertEqual(torch.atan2(a, b).dtype, torch.float32)
+
+    @onlyAccelerator
+    def test_autocast_prioritize_optional_arg(self, device):
+        # bilinear's bias is optional, and optional arguments must still count
+        # towards the promote decision. Note the positional arguments are all
+        # lower precision here, so only the bias can force the promotion.
+        with torch.autocast(device_type=device, dtype=torch.bfloat16):
+            i1 = torch.randn(4, 8, device=device, dtype=torch.bfloat16)
+            i2 = torch.randn(4, 6, device=device, dtype=torch.bfloat16)
+            weight = torch.randn(5, 8, 6, device=device, dtype=torch.bfloat16)
+
+            bias_fp32 = torch.randn(5, device=device, dtype=torch.float32)
+            self.assertEqual(
+                torch.bilinear(i1, i2, weight, bias_fp32).dtype, torch.float32
+            )
+
+            bias_bf16 = bias_fp32.bfloat16()
+            self.assertEqual(
+                torch.bilinear(i1, i2, weight, bias_bf16).dtype, torch.bfloat16
+            )
 
     @onlyMPS
     def test_mps_autocast_error_message(self, device):


### PR DESCRIPTION
## Summary

`prioritize()` decides the dtype that `CastPolicy::promote` runs an op in. Two
defects, both reachable from user code today.

**1. Optional Tensor args are ignored.** There are overloads for `Tensor` and
`TensorList` but none for `std::optional<Tensor>`, so an optional tensor falls
through to the catch-all template and its dtype has no say in the promote
decision. Among the 11 promote-policy ops this only reaches `bilinear`'s
`bias` — the only one with an optional Tensor arg. `index_put`'s
`Tensor?[] indices` also goes through the catch-all, but is unaffected in
practice since indices are integral and `is_autocast_eligible` requires a
floating type.

**2. Mixed reduced-precision types raise.** The final branch assumed the only
floating types reaching it were `kFloat` and the current autocast's
`lower_precision_fp`. Any other reduced float hits
`TORCH_CHECK(false, "Unexpected floating ScalarType")`. This is not fp16/bf16
specific — `is_autocast_eligible` gates on `is_floating_point()`, so fp8 and
fp4 tensors take the same path. Users have hit this exact message: #132715.
That issue was closed by #133938, which made autograd propagate the autocast
dtype so the mismatch stopped arising through normal backward — a fix one
layer above this branch, which remained.

## What changes and what doesn't

Enumerating `prioritize`'s reachable states (`current` is always either the
active autocast dtype `L`, or `kFloat` — those are the only values it is
seeded or returned with):

| `current` | `next` | before | after |
|---|---|---|---|
| any | `kDouble` | `current` | `current` |
| `kFloat` | anything | `kFloat` | `kFloat` |
| `L` | `kFloat` | `kFloat` | `kFloat` |
| `L` | `L` | `L` | `L` |
| `L` | other reduced float | **raise** | `kFloat` |

Nothing that runs today changes dtype. The only behavior change is the last
row: what used to raise now promotes to `kFloat`.

One consequence worth stating explicitly, since it's the non-obvious half of
"mixed low precision promotes to fp32": the *uniform* case also changes when
it disagrees with the ambient autocast dtype. An op with all-fp16 arguments,
run inside a `bfloat16` autocast region, now executes in fp32 — not because
its own arguments disagree with each other, but because `current` is seeded
with the region's dtype (`L = bfloat16`) before the first argument is even
examined. That's row 5 of the table (`current=L=bf16`, `next=fp16`), and it
is intended: criterion (2) is "promote to the widest dtype among the args
*and* the active autocast dtype." But it's easy to read the fix as narrower
than it is.

## Test plan

Two tests added next to the existing `test_autocast_prioritize` in
`test/test_autocast.py`, one per defect. That test's comment documented the
old criterion — that all reduced-precision arguments must equal the autocast
dtype — and is updated to match the table above.

```bash
python test_autocast.py -k prioritize
python test_autocast.py
python test_cuda.py -k autocast
```
RTX 3080 / CUDA 13.0 source build: `test_cuda.py -k autocast` 30 passed, `test_autocast.py`
passed. All 11 promote ops verified against a stock 2.12.1 build for the table above.

Against an unpatched 2.12.1 build, the two new tests contribute three failing
assertions, and pass here:
```bash
mixed bf16/fp16      RuntimeError: Unexpected floating ScalarType  ->  float32
mixed fp16/bf16      RuntimeError: Unexpected floating ScalarType  ->  float32
fp32 optional bias   bfloat16                                      ->  float32
bf16 optional bias   bfloat16                                      ->  bfloat16   (control, unchanged)
```

The existing list-driven tests are insensitive to both defects: the current
`bilinear` entry in `torch_need_autocast_promote` also supplies an fp32
positional argument, so it passes whether or not the optional one is honored.

## Compatibility

Removing the `TORCH_CHECK` is BC-visible: code catching that `RuntimeError`
stops seeing it, and fp8/fp4 tensors that used to raise now silently promote
to fp32. I have no evidence anyone relies on either, but can't rule it out.

## Is this worth landing

The direct path to the old `TORCH_CHECK` is already closed by #133938 for the
autograd case that #132715 hit — reaching it now takes deliberately mixing
reduced-precision dtypes inside an autocast region. The case for landing this
is that it removes a latent `TORCH_CHECK(false)` sitting under all 11
promote-policy ops rather than leaving it papered over one layer up; the case
against is that autocast is legacy surface and every BC-visible change to it
has a cost.

If the `prioritize` restructure isn't worth that judgment call on its own,
the `std::optional<Tensor>` overload is independently correct, ~10 lines, and
not BC-visible — happy to split it into its own PR and drop or defer the rest.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5