### PR TITLE
Run rms_norm under the autocast promote policy instead of fp32

### DIFF
--- a/aten/src/ATen/autocast_mode.h
+++ b/aten/src/ATen/autocast_mode.h
@@ -238,24 +238,32 @@ inline at::ScalarType prioritize(
     TORCH_CHECK(false, "promote type is double in at::autocast::prioritize");
     return current;
   }
-  at::ScalarType lower_precision_fp =
-      get_lower_precision_fp_from_device_type(device_type);
   if (is_autocast_eligible(nextArg, device_type)) {
     auto next = nextArg.scalar_type();
-    if (next == at::kDouble) {
-      return current; // ignores double tensors
-    } else if (current == at::kFloat || next == at::kFloat) {
-      return at::kFloat; // prioritizes float over lower_precision_fp
-    } else if (current == lower_precision_fp && next == lower_precision_fp) {
-      return lower_precision_fp;
-    } else {
-      TORCH_CHECK(
-          false, "Unexpected floating ScalarType in at::autocast::prioritize");
+    // Double tensors are ignored, and matching types need no widening.
+    if (next == at::kDouble || current == next) {
       return current;
     }
+    // The types differ, so either one of them is already fp32, or they are two
+    // different low precision types (e.g. an fp16 tensor inside a bf16 autocast
+    // region). fp32 is the narrowest type that covers both.
+    return at::kFloat;
   } else {
     return current;
   }
+}
+
+// Overload to catch optional Tensor args. Without this they fall through to the
+// catch-all template below and their dtype is silently left out of the promote
+// decision.
+inline at::ScalarType prioritize(
+    at::ScalarType current,
+    const std::optional<Tensor>& arg,
+    c10::DeviceType device_type = c10::DeviceType::CUDA) {
+  if (!arg.has_value()) {
+    return current;
+  }
+  return prioritize(current, *arg, device_type);
 }
 
 // Overload to catch TensorList args (for e.g. cat, stack).

--- a/aten/src/ATen/autocast_mode.h
+++ b/aten/src/ATen/autocast_mode.h
@@ -880,7 +880,6 @@ copy pasted in from VariableTypeEverything.cpp with appropriate substitutions.
   _(softplus)                         \
   _(layer_norm)                       \
   _(native_layer_norm)                \
-  _(rms_norm)                         \
   _(group_norm)                       \
   _(frobenius_norm, dim)              \
   _(nuclear_norm)                     \
@@ -961,4 +960,5 @@ copy pasted in from VariableTypeEverything.cpp with appropriate substitutions.
   _(grid_sampler)            \
   _(index_put)               \
   _(tensordot)               \
-  _(scatter_add)
+  _(scatter_add)             \
+  _(rms_norm)

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -279,11 +279,12 @@ class TestAutocastDevice(TestCase):
     # That means:
     #   (1) double precision is ignored,
     #   (2) if any argument is float, then all arguments are promoted to float,
-    #   (3) if all arguments are of lower precision dtype, then all dtypes must be equal to the same amp autocast dtype.
-    # Since AMP autocast dtype is thread-local, it is not preserved across thread boundaries during autograd execution,
-    # and due to the multi-threaded nature of the autograd, the forward pass is being run in bfloat16, while the backward
-    # pass defaults to float16. The dtype mismatch leads to the error in the policy, as the criteria (3) is not satisfied.
-    # For more info see https://github.com/pytorch/pytorch/issues/132715.
+    #   (3) if all arguments share one lower precision dtype, that dtype is kept.
+    # Mixing two different lower precision dtypes also promotes to float, per (2)'s
+    # reasoning: float is the narrowest type covering both. This used to raise
+    # instead, which is what https://github.com/pytorch/pytorch/issues/132715 hit
+    # when autograd ran the backward pass in a different autocast dtype than the
+    # forward pass.
     @onlyAccelerator
     def test_autocast_prioritize(self, device):
         dtype = torch.bfloat16
@@ -299,6 +300,40 @@ class TestAutocastDevice(TestCase):
 
             loss = res.mean()
             loss.backward()
+
+    @onlyAccelerator
+    def test_autocast_prioritize_mixed_low_precision(self, device):
+        # Two different lower precision dtypes meeting in one op promote to float
+        # rather than raising. Every op on the promote policy is affected, so a
+        # pointwise one stands in for the rest.
+        for autocast_dtype, other in (
+            (torch.bfloat16, torch.float16),
+            (torch.float16, torch.bfloat16),
+        ):
+            with torch.autocast(device_type=device, dtype=autocast_dtype):
+                a = torch.randn(8, device=device, dtype=other)
+                b = torch.randn(8, device=device, dtype=autocast_dtype)
+                self.assertEqual(torch.atan2(a, b).dtype, torch.float32)
+
+    @onlyAccelerator
+    def test_autocast_prioritize_optional_arg(self, device):
+        # bilinear's bias is optional, and optional arguments must still count
+        # towards the promote decision. Note the positional arguments are all
+        # lower precision here, so only the bias can force the promotion.
+        with torch.autocast(device_type=device, dtype=torch.bfloat16):
+            i1 = torch.randn(4, 8, device=device, dtype=torch.bfloat16)
+            i2 = torch.randn(4, 6, device=device, dtype=torch.bfloat16)
+            weight = torch.randn(5, 8, 6, device=device, dtype=torch.bfloat16)
+
+            bias_fp32 = torch.randn(5, device=device, dtype=torch.float32)
+            self.assertEqual(
+                torch.bilinear(i1, i2, weight, bias_fp32).dtype, torch.float32
+            )
+
+            bias_bf16 = bias_fp32.bfloat16()
+            self.assertEqual(
+                torch.bilinear(i1, i2, weight, bias_bf16).dtype, torch.bfloat16
+            )
 
     @onlyMPS
     def test_mps_autocast_error_message(self, device):

--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -146,7 +146,6 @@ class AutocastTestLists:
             ("softmax", pointwise0_fp16 + (0,)),
             ("log_softmax", pointwise0_fp16 + (0,)),
             ("layer_norm", pointwise0_fp16 + ((pointwise0_fp16[0].numel(),),)),
-            ("rms_norm", pointwise0_fp16 + ((pointwise0_fp16[0].numel(),),)),
             ("group_norm", mat0_fp16 + (1,)),
             ("norm", pointwise0_fp16),
             ("norm", pointwise0_fp16, {"dim": 0}),
@@ -189,6 +188,9 @@ class AutocastTestLists:
                        torch.randn(3, dtype=torch.float16, device=dev))),
             ("dot", pointwise0_fp16 + pointwise1_fp32),
             ("vdot", pointwise0_fp16 + pointwise1_fp32),
+            # weight is an optional arg, so this also covers prioritize()'s
+            # optional<Tensor> overload
+            ("rms_norm", pointwise0_fp16 + ((pointwise0_fp16[0].numel(),), pointwise1_fp32[0])),
             ("grid_sampler", (torch.randn((2, 3, 33, 22), dtype=torch.float16, device=dev),
                               torch.randn((2, 22, 11, 2), dtype=torch.float32, device=dev),
                               0, 0, False)),


### PR DESCRIPTION
Fixes #188955. Stacked on  [Fix optional Tensor args and mixed low precision in autocast promote policy
#191125](https://github.com/pytorch/pytorch/pull/191125) the first commit here is that PR; do not land alone.

## Summary

#174824 put `rms_norm` on the fp32 cast policy to fix #167308, where a bf16 activation
meeting an fp32 weight tripped the dtype-mismatch guard and fell back to the composite
path. That fixed the mismatch by making both dtypes agree, but it applies unconditionally
— including when input and weight are already both bf16, where promotion recovers no
information. `rms_norm` upcasts internally regardless, so the only effect is a full-size
fp32 copy of the activation plus, under `torch.compile`, standalone
`triton_poi_fused__to_copy` kernels for the casts that didn't fuse.

#167308 stays fixed. That last part depends on the optional-argument fix in #191125, without
which `weight` — being optional — would not participate in the promote decision at all.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5