### PR TITLE
[dynamo] Fix flaky NameError when CompilePackage.install() reuses a global name

### DIFF
--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import gc
 import importlib
 import os
 import sys
@@ -15,6 +16,7 @@ import torch.utils.cpp_extension
 from torch._dynamo.package import CompilePackage, DiskDynamoStore, DynamoCache
 from torch._dynamo.precompile_context import PrecompileContext
 from torch._dynamo.testing import reduce_to_scalar_loss
+from torch._dynamo.utils import CleanupManager
 from torch._functorch import config as functorch_config
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.testing._internal.common_utils import (
@@ -304,6 +306,84 @@ class TestPackage(torch._inductor.test_case.TestCase):
                 "Detected recompile when torch.compile stance is 'fail_on_recompile'",
             ):
                 compiled_fn(*args2)
+
+    def test_install_survives_stale_cleanup_hooks(self):
+        # The first compile installs its generated functions -- and, on every
+        # compile, a builtins-dict global (see install_builtins_dict_in_fglobals)
+        # -- into the module globals behind a CleanupHook keyed on the generated
+        # code object. install() rebinds __compiled_fn/__resume_at names to fresh
+        # values, but leaves the builtins-dict binding alone when it's already
+        # correct, since it's the same dict object on every compile in this
+        # module. Either way, a hook firing afterwards must not delete the
+        # binding install() is now responsible for.
+        ctx = DiskDynamoStore()
+
+        def fn(x):
+            y = x + x.shape[0]
+            if y.sum() > 0:  # data-dependent branch, forces a resume function
+                return y * 2
+            return y
+
+        args = (torch.randn(3, 2),)
+        expected = fn(*args)
+
+        # Other tests in this file compile functions defined in this same
+        # module, so ignore what they left behind in the shared globals, and
+        # hold their code objects alive so ids stay unambiguous below.
+        prefixes = ("__compiled_fn", "__resume_at", "__builtins_dict__")
+        scope = fn.__globals__
+        preexisting = {name for name in scope if name.startswith(prefixes)}
+        # Plain loops with an explicit del, rather than a walrus in a list
+        # comprehension: a walrus target leaks into this method's own frame,
+        # which would pin the last code object seen and defeat the gc.collect()
+        # below.
+        others = []
+        code = None
+        for ref in list(CleanupManager.instance.refs.values()):
+            code = ref()
+            if code is not None:
+                others.append(code)
+        del code
+        other_ids = {id(o) for o in others}
+
+        package = CompilePackage(fn)
+        compiled_fn = torch._dynamo.optimize(backend="eager", package=package)(fn)
+        compiled_fn(*args)
+        for backend_id, backend in package.cached_backends.items():
+            ctx.record_eager_backend(backend_id, backend)
+        ctx.save_package(package, self.path())
+
+        # Whether the hooks fire before or after install() is left to the
+        # garbage collector, so pin the code objects they are keyed on to pick
+        # the losing order deterministically.
+        pinned = []
+        code = None
+        for idx, ref in list(CleanupManager.instance.refs.items()):
+            if idx in other_ids:
+                continue
+            code = ref()
+            if code is not None:
+                pinned.append(code)
+        del code
+        pinned_ids = {id(p) for p in pinned}
+        self.assertTrue(pinned_ids)
+
+        torch._dynamo.reset()
+        package, backends = ctx.load_package(fn, self.path())
+        compiled_fn = torch._dynamo.optimize(package=package)(fn)
+        package.install(backends)
+
+        installed = {name for name in scope if name.startswith(prefixes)} - preexisting
+        self.assertTrue(installed)
+
+        del pinned
+        gc.collect()
+
+        # Without this the assert below can pass without any hook ever running.
+        self.assertTrue(pinned_ids - set(CleanupManager.instance.refs))
+        self.assertEqual(installed - set(scope), set())
+        with torch.compiler.set_stance("fail_on_recompile"):
+            self.assertEqual(expected, compiled_fn(*args))
 
     def test_file_change(self):
         ctx = DiskDynamoStore()

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -40,7 +40,7 @@ from .bytecode_transformation import (
     get_code_keys,
     is_compiled_fn_name,
 )
-from .utils import counters, dynamo_timed, increment_frame
+from .utils import CleanupHook, counters, dynamo_timed, increment_frame
 
 
 logger = logging.getLogger(__name__)
@@ -854,6 +854,10 @@ class CompilePackage:
             )
 
     def _install_global(self, module: types.ModuleType, name: str, value: Any) -> None:
+        # A pre-reset compile in this process may still own `name` via a
+        # CleanupHook that hasn't fired yet. We're taking over the binding now,
+        # so that hook must not delete it once its code object is collected.
+        CleanupHook.disown(module.__dict__, name)
         module.__dict__[name] = value
         self._installed_globals.setdefault(module, []).append(name)
 
@@ -864,7 +868,7 @@ class CompilePackage:
             raise AssertionError("_innermost_fn is not set in uninstall")
         for module, names in self._installed_globals.items():
             for name in names:
-                module.__dict__.pop(name)
+                module.__dict__.pop(name, None)
 
         self._installed_globals = {}
 
@@ -960,6 +964,11 @@ class CompilePackage:
                         builtin_dict_name
                         := guards_state.output_graph.name_of_builtins_dict_key_in_fglobals
                     ):
+                        # A pre-reset compile's CleanupHook may still own this
+                        # name even when we're about to leave its value alone
+                        # below (same dict object every compile in this
+                        # module), so it must not delete it once collected.
+                        CleanupHook.disown(runtime_global_scope, builtin_dict_name)
                         builtins_dict = get_builtins_dict(runtime_global_scope)
                         if builtin_dict_name in runtime_global_scope:
                             if (

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2468,17 +2468,33 @@ def chromium_event_timed(
             chromium_event_log._reset_to_state(*reset_state)
 
 
+# (id(scope), name) -> the token of whichever hook currently owns that
+# binding. A value comparison isn't enough here: CompilePackage.install() can
+# re-materialize a name like __builtins_dict__ with the *same* object a
+# pre-reset hook already installed, so an identity-of-value check would still
+# let the stale hook delete it. A token makes ownership explicit instead.
+_cleanup_owners: dict[tuple[int, str], object] = {}
+
+
 @dataclasses.dataclass
 class CleanupHook:
     """Remove a global variable when hook is called"""
 
     scope: dict[str, Any]
     name: str
+    token: object = dataclasses.field(compare=False, repr=False)
 
     def __call__(self, *args: Any) -> None:
         # Make sure we're not shutting down
         if CleanupManager is not None:
             CleanupManager.count -= 1
+        # Hooks fire when the owning code object is collected, which can happen
+        # after something else has taken over this name -- CompilePackage.install()
+        # reinstalls precompiled state under names a pre-reset compile still
+        # owns. Only clean up while nothing has claimed the name out from under us.
+        key = (id(self.scope), self.name)
+        if _cleanup_owners.pop(key, None) is not self.token:
+            return
         # During interpreter shutdown the scope's module __dict__ may already
         # have been cleared, so the name can be gone. Use pop to avoid a
         # KeyError surfacing as an "Exception ignored in weakref callback".
@@ -2490,7 +2506,16 @@ class CleanupHook:
             raise AssertionError(f"Name {name!r} already exists in scope")
         CleanupManager.count += 1
         scope[name] = val
-        return CleanupHook(scope, name)
+        token = object()
+        _cleanup_owners[(id(scope), name)] = token
+        return CleanupHook(scope, name, token)
+
+    @staticmethod
+    def disown(scope: dict[str, Any], name: str) -> None:
+        """Invalidate whichever hook currently owns (scope, name), so that if
+        its code object outlives this call, firing later is a no-op instead of
+        deleting a binding something else has since taken over."""
+        _cleanup_owners.pop((id(scope), name), None)
 
 
 class CleanupManager(ExactWeakKeyDictionary):


### PR DESCRIPTION
Fixes #186865
Fixes #190664

`output_graph` installs generated functions -- and, on every compile, a builtins-dict global (`install_builtins_dict_in_fglobals`) -- into the frame globals via `CleanupHook.create`, registering the hook in `CleanupManager` keyed on the transformed code object so the global is dropped once that code object is collected.

`CompilePackage` serializes those names deterministically, so a package installed after `torch._dynamo.reset()` binds exactly the names an earlier compile in the same process already used. The pre-reset code object is garbage by that point but not necessarily collected; when it finally is, its hook can delete a binding `install()` is now responsible for, so the next call raises `NameError: name '__compiled_fn_N_<uuid>' is not defined`. Because this hinges on collection timing it surfaces as a flake, and it is likelier on free-threaded builds where deferred refcounting delays collection.

An earlier version of this fix (thanks @jansel for reviewing) compared the hook's recorded value against the current binding and skipped the delete on a mismatch. That covers `_install_global`'s writes (`__compiled_fn`/`__resume_at`, always fresh objects), but not `install()`'s builtins-dict path: that name is deliberately left untouched when the existing value already matches (same dict object every compile in a module), so the stale hook's value comparison still succeeded and it deleted a binding nothing had rewritten. `CleanupHook` now tracks ownership with a token instead of a value comparison, and `CompilePackage` explicitly disowns a name's previous hook at every point it takes over that name -- in `_install_global`, and in the builtins-dict path even when it decides no write is needed -- so a stale hook is inert regardless of whether the value it guarded ever changed. This also closes a latent `KeyError` in `CompilePackage.uninstall()`, whose `module.__dict__.pop(name)` had no default and could run after a stale hook had already removed the name; it now passes a default as well, as defense in depth.

On lifetimes: previously the hook held a strong reference to the value it installed; the token design drops that entirely, so there is no change to what stays alive relative to before this fix existed.

### Test plan

The new test pins the pre-reset code objects so their hooks are guaranteed to fire after `install()`, turning the race into a deterministic failure. Its function graph-breaks on a data-dependent branch, and the checked names include the builtins-dict global, so it covers `__compiled_fn`, `__resume_at`, and `__builtins_dict__` -- all three ways `install()` can take over a name:

```
python test/dynamo/test_package.py TestPackage.test_install_survives_stale_cleanup_hooks
```

It fails without the change (including on an earlier version of this fix that only compared values) and passes with it, on CPython 3.12 and on free-threaded CPython 3.14. Full file:

```
python test/dynamo/test_package.py
```

and `test_misc.py` give the same results with and without the change apart from the new test (the pre-existing failures are local toolchain/environment limitations -- e.g. no C++ compiler for inductor codegen -- not regressions).

One caveat worth stating plainly: I did not catch the original flake in the act. Looping the reported test 200x in-process produced no failures, so the race was demonstrated by forcing collection at the critical moment, which reproduces the exact `NameError` from the issue. The mechanism is proven; attributing the specific CI flake to it is inference from the matching signature.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98