### PR TITLE
[Dynamo] Trace requires_grad setattr on intermediates

### DIFF
--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -1400,6 +1400,45 @@ backward() with non-leaf tensor
         self.assertEqual(compiled_y, eager_y)
         self.assertEqual(compiled_grad, eager_grad)
 
+    def test_autograd_grad_with_requires_grad_setattr(self):
+        mod = torch.nn.Linear(4, 4)
+
+        def fn(x):
+            y = x.detach()
+            y.requires_grad = True
+            return torch.autograd.grad(mod(y).sum(), y)[0].detach()
+
+        x = torch.randn(2, 4)
+        eager = fn(x)
+        cnt = torch._dynamo.testing.CompileCounter()
+        compiled = torch.compile(fn, backend=cnt, fullgraph=True)(x)
+        self.assertEqual(compiled, eager)
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_requires_grad_setattr_unsupported_value_graph_breaks(self):
+        x = torch.randn(4)
+        for value in (False, 1, None):
+            with self.subTest(value=value):
+
+                def fn(x):
+                    y = x.detach()
+                    y.requires_grad = value
+                    return y.sum()
+
+                torch._dynamo.reset()
+                with self.assertRaises(torch._dynamo.exc.Unsupported):
+                    torch.compile(fn, backend="eager", fullgraph=True)(x)
+
+    def test_requires_grad_setattr_non_differentiable_dtype_graph_breaks(self):
+        def fn(x):
+            y = x.detach()
+            y.requires_grad = True
+            return y.sum()
+
+        x = torch.tensor([1, 2, 3])
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -9,6 +9,7 @@ import torch._dynamo
 from torch._dynamo.testing import (
     AotEagerAndRecordGraphs,
     EagerAndRecordGraphs,
+    empty_line_normalizer,
     normalize_gm,
 )
 from torch.testing._internal.common_utils import (
@@ -1419,27 +1420,22 @@ backward() with non-leaf tensor
         self.assertEqual(compiled, eager)
         self.assertEqual(len(backend.graphs), 1)
         self.assertExpectedInline(
-            normalize_gm(backend.graphs[0].print_readable(print_output=False)),
+            empty_line_normalizer(
+                normalize_gm(backend.graphs[0].print_readable(print_output=False))
+            ),
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, L_x_: "f32[2, 4]", L_mod_parameters_weight_: "f32[4, 4]", L_mod_parameters_bias_: "f32[4]"):
         l_x_ = L_x_
         l_mod_parameters_weight_ = L_mod_parameters_weight_
         l_mod_parameters_bias_ = L_mod_parameters_bias_
-
         y: "f32[2, 4]" = l_x_.detach();  l_x_ = None
-
         set_inplace_requires_grad_allowed = torch._C._functorch.set_inplace_requires_grad_allowed(True);  set_inplace_requires_grad_allowed = None
-
         requires_grad_ = y.requires_grad_();  requires_grad_ = None
-
         set_inplace_requires_grad_allowed_1 = torch._C._functorch.set_inplace_requires_grad_allowed(False);  set_inplace_requires_grad_allowed_1 = None
-
         linear: "f32[2, 4]" = torch._C._nn.linear(y, l_mod_parameters_weight_, l_mod_parameters_bias_);  l_mod_parameters_weight_ = l_mod_parameters_bias_ = None
         sum_1: "f32[]" = linear.sum();  linear = None
-
         grad = torch.autograd.grad(sum_1, y);  sum_1 = y = None
-
         getitem: "f32[2, 4]" = grad[0];  grad = None
         detach_1: "f32[2, 4]" = getitem.detach();  getitem = None
         return (detach_1,)

--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -1410,10 +1410,27 @@ backward() with non-leaf tensor
 
         x = torch.randn(2, 4)
         eager = fn(x)
-        cnt = torch._dynamo.testing.CompileCounter()
-        compiled = torch.compile(fn, backend=cnt, fullgraph=True)(x)
+        compiled = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
         self.assertEqual(compiled, eager)
-        self.assertEqual(cnt.frame_count, 1)
+
+    def test_requires_grad_setattr_leaked_output_graph_breaks(self):
+        mod = torch.nn.Linear(4, 4)
+
+        def fn(x):
+            y = x.detach()
+            y.requires_grad = True
+            return mod(y).sum()
+
+        x = torch.randn(2, 4)
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+
+        torch._dynamo.reset()
+        out = torch.compile(fn, backend="aot_eager")(x)
+        out.backward()
+        eager_out = fn(x)
+        eager_out.backward()
+        self.assertEqual(out, eager_out)
 
     def test_requires_grad_setattr_unsupported_value_graph_breaks(self):
         x = torch.randn(4)

--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -12,6 +12,8 @@ from torch._dynamo.testing import (
     normalize_gm,
 )
 from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
     run_tests,
     skipIfCrossRef,
     skipIfTorchDynamo,
@@ -21,6 +23,7 @@ from torch.testing._internal.common_utils import (
 
 @torch._dynamo.config.patch(trace_autograd_ops=True)
 @skipIfTorchDynamo()
+@instantiate_parametrized_tests
 class TestForwardLossBackward(TestCase):
     def _run_backward_test(self, fn, mod, x, backend=None):
         """
@@ -1400,6 +1403,7 @@ backward() with non-leaf tensor
         self.assertEqual(compiled_y, eager_y)
         self.assertEqual(compiled_grad, eager_grad)
 
+    @skipIfCrossRef
     def test_autograd_grad_with_requires_grad_setattr(self):
         mod = torch.nn.Linear(4, 4)
 
@@ -1410,8 +1414,56 @@ backward() with non-leaf tensor
 
         x = torch.randn(2, 4)
         eager = fn(x)
-        compiled = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        backend = AotEagerAndRecordGraphs()
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)(x)
         self.assertEqual(compiled, eager)
+        self.assertEqual(len(backend.graphs), 1)
+        self.assertExpectedInline(
+            normalize_gm(backend.graphs[0].print_readable(print_output=False)),
+            """\
+class GraphModule(torch.nn.Module):
+    def forward(self, L_x_: "f32[2, 4]", L_mod_parameters_weight_: "f32[4, 4]", L_mod_parameters_bias_: "f32[4]"):
+        l_x_ = L_x_
+        l_mod_parameters_weight_ = L_mod_parameters_weight_
+        l_mod_parameters_bias_ = L_mod_parameters_bias_
+
+        y: "f32[2, 4]" = l_x_.detach();  l_x_ = None
+
+        set_inplace_requires_grad_allowed = torch._C._functorch.set_inplace_requires_grad_allowed(True);  set_inplace_requires_grad_allowed = None
+
+        requires_grad_ = y.requires_grad_();  requires_grad_ = None
+
+        set_inplace_requires_grad_allowed_1 = torch._C._functorch.set_inplace_requires_grad_allowed(False);  set_inplace_requires_grad_allowed_1 = None
+
+        linear: "f32[2, 4]" = torch._C._nn.linear(y, l_mod_parameters_weight_, l_mod_parameters_bias_);  l_mod_parameters_weight_ = l_mod_parameters_bias_ = None
+        sum_1: "f32[]" = linear.sum();  linear = None
+
+        grad = torch.autograd.grad(sum_1, y);  sum_1 = y = None
+
+        getitem: "f32[2, 4]" = grad[0];  grad = None
+        detach_1: "f32[2, 4]" = getitem.detach();  getitem = None
+        return (detach_1,)
+""",
+        )
+
+    @parametrize("via", ("setattr", "method"))
+    @parametrize("dtype", (torch.float32, torch.float64, torch.complex64))
+    def test_requires_grad_setattr_intermediate_single_graph(self, via, dtype):
+        def fn(x):
+            y = x.detach()
+            if via == "setattr":
+                y.requires_grad = True
+            else:
+                y.requires_grad_()
+            out = (y * y.conj()).real.sum()
+            return torch.autograd.grad(out, y)[0].detach()
+
+        x = torch.randn(4, dtype=dtype)
+        eager = fn(x)
+        cnt = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
+        compiled = torch.compile(fn, backend=cnt, fullgraph=True)(x)
+        self.assertEqual(compiled, eager)
+        self.assertEqual(cnt.frame_count, 1)
 
     def test_requires_grad_setattr_leaked_output_graph_breaks(self):
         mod = torch.nn.Linear(4, 4)
@@ -1422,38 +1474,65 @@ backward() with non-leaf tensor
             return mod(y).sum()
 
         x = torch.randn(2, 4)
-        with self.assertRaises(torch._dynamo.exc.Unsupported):
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "returning intermediate with requires_grad_\\(\\)",
+        ):
             torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
 
         torch._dynamo.reset()
-        out = torch.compile(fn, backend="aot_eager")(x)
-        out.backward()
+        for p in mod.parameters():
+            p.grad = None
         eager_out = fn(x)
         eager_out.backward()
+        eager_grads = {name: p.grad.clone() for name, p in mod.named_parameters()}
+
+        for p in mod.parameters():
+            p.grad = None
+        cnt = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
+        out = torch.compile(fn, backend=cnt)(x)
+        out.backward()
+
         self.assertEqual(out, eager_out)
+        for name, p in mod.named_parameters():
+            self.assertEqual(eager_grads[name], p.grad)
+        self.assertEqual(cnt.frame_count, 2)
 
-    def test_requires_grad_setattr_unsupported_value_graph_breaks(self):
+    def test_requires_grad_setattr_graph_input_graph_breaks(self):
+        def fn(x):
+            x.requires_grad = True
+            return x.sum()
+
         x = torch.randn(4)
-        for value in (False, 1, None):
-            with self.subTest(value=value):
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported, "setattr\\(\\) on Tensor.requires_grad"
+        ):
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
 
-                def fn(x):
-                    y = x.detach()
-                    y.requires_grad = value
-                    return y.sum()
+    @parametrize("value", (False, 1, None))
+    def test_requires_grad_setattr_unsupported_value_graph_breaks(self, value):
+        def fn(x):
+            y = x.detach()
+            y.requires_grad = value
+            return y.sum()
 
-                torch._dynamo.reset()
-                with self.assertRaises(torch._dynamo.exc.Unsupported):
-                    torch.compile(fn, backend="eager", fullgraph=True)(x)
+        x = torch.randn(4)
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported, "setattr\\(\\) on Tensor.requires_grad"
+        ):
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
 
-    def test_requires_grad_setattr_non_differentiable_dtype_graph_breaks(self):
+    @parametrize("dtype", (torch.int64, torch.int32, torch.bool))
+    def test_requires_grad_setattr_non_differentiable_dtype_graph_breaks(self, dtype):
         def fn(x):
             y = x.detach()
             y.requires_grad = True
             return y.sum()
 
-        x = torch.tensor([1, 2, 3])
-        with self.assertRaises(torch._dynamo.exc.Unsupported):
+        x = torch.ones(3, dtype=dtype)
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported, "setattr\\(\\) on Tensor.requires_grad"
+        ):
             torch.compile(fn, backend="eager", fullgraph=True)(x)
 
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -3434,7 +3434,17 @@ class SetAttrBuiltinVariable(BaseBuiltinVariable):
                 from .builder import wrap_fx_proxy
 
                 if name == "requires_grad":
-                    # TODO(azahed98): Make it work properly
+                    dtype = obj.dtype  # type: ignore[attr-defined]
+                    if (
+                        obj.source is None
+                        and val.is_python_constant()
+                        and val.as_python_constant() is True
+                        and not obj.requires_grad  # type: ignore[attr-defined]
+                        and dtype is not None
+                        and (dtype.is_floating_point or dtype.is_complex)
+                    ):
+                        obj.method_requires_grad_(tx, val)  # type: ignore[attr-defined]
+                        return val
                     unimplemented(
                         gb_type="setattr() on Tensor.requires_grad",
                         context=f"setattr({obj}, {name}, {val})",

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -3620,7 +3620,17 @@ class SetAttrBuiltinVariable(BaseBuiltinVariable):
                 from .builder import wrap_fx_proxy
 
                 if name == "requires_grad":
-                    # TODO(azahed98): Make it work properly
+                    dtype = obj.dtype  # type: ignore[attr-defined]
+                    if (
+                        obj.source is None
+                        and val.is_python_constant()
+                        and val.as_python_constant() is True
+                        and not obj.requires_grad  # type: ignore[attr-defined]
+                        and dtype is not None
+                        and (dtype.is_floating_point or dtype.is_complex)
+                    ):
+                        obj.method_requires_grad_(tx, val)  # type: ignore[attr-defined]
+                        return val
                     unimplemented(
                         gb_type="setattr() on Tensor.requires_grad",
                         context=f"setattr({obj}, {name}, {val})",


### PR DESCRIPTION
## Related

Part of #170487

## Why

- Setting `tensor.requires_grad = True` inside `torch.compile` always broke the graph, even on tensors created in the compiled region
- The equivalent `.requires_grad_(True)` call already worked, so `fullgraph=True` failed for no good reason

## How

- Route the attribute assignment through the existing `requires_grad_()` tracing path
- Gate on `is True` and a differentiable dtype; everything else keeps the old graph break
- `= False` stays excluded because `method_requires_grad_` emits the proxy without its argument
- Add tests for the traced path, unsupported values, and non-differentiable dtypes

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
