### PR TITLE
[inductor] Support global scratch in static Triton launcher

### DIFF
--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -8,7 +8,6 @@ from types import SimpleNamespace
 from unittest import mock
 
 import torch
-
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor.codecache import PyCodeCache
 from torch._inductor.runtime import triton_helpers
@@ -145,7 +144,12 @@ class TestStaticTritonLauncherUnit(TestCase):
             global_scratch_size=32,
             global_scratch_align=16,
         )
-        compiled_kernel = SimpleNamespace(
+
+        class FakeCompiledKernel(SimpleNamespace):
+            launch_enter_hook = None
+            launch_exit_hook = None
+
+        compiled_kernel = FakeCompiledKernel(
             src=src,
             metadata=metadata,
             _cubin_path="/tmp/scratch_kernel.cubin",

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -3,6 +3,7 @@ import gc
 import os
 import random
 import tempfile
+import unittest
 import weakref
 from types import SimpleNamespace
 from unittest import mock
@@ -31,6 +32,7 @@ from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import IS_WINDOWS, skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_XPU_AND_TRITON
 from torch.testing._internal.triton_utils import requires_gpu_and_triton
+from torch.utils._triton import has_triton_tensor_descriptor_host_tma
 
 
 if HAS_XPU_AND_TRITON:
@@ -151,6 +153,7 @@ class TestStaticTritonLauncherUnit(TestCase):
         with DeviceGuard(iface, _resolve_load_device(None, "cpu")):
             pass
 
+    @skipIfRocm
     def test_global_scratch_allocation(self):
         import types
 
@@ -1035,6 +1038,108 @@ class TestFastCudaLauncherCompileResult(TestCase):
                 any(results),
                 "_FastCudaLauncher should not be built when config is disabled",
             )
+
+    @skipIfXpu(msg="Tests CUDA device-side TMA global scratch")
+    @unittest.skipIf(
+        not has_triton_tensor_descriptor_host_tma(),
+        "requires Triton TensorDescriptor TMA support",
+    )
+    @torch._inductor.config.patch(
+        {"compile_threads": 1, "static_launch_user_defined_triton_kernels": True}
+    )
+    def test_device_tma_gemm_falls_back_from_fast_launcher(self):
+        """A global-scratch kernel repeatedly uses the regular static launcher."""
+
+        @triton.jit
+        def device_tma_gemm(
+            a_ptr,
+            b_ptr,
+            c_ptr,
+            M: tl.constexpr,
+            N: tl.constexpr,
+            K: tl.constexpr,
+            BLOCK_M: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+            BLOCK_K: tl.constexpr,
+        ):
+            a_desc = tl.make_tensor_descriptor(
+                a_ptr,
+                [M, K],
+                [K, 1],
+                [BLOCK_M, BLOCK_K],
+            )
+            b_desc = tl.make_tensor_descriptor(
+                b_ptr,
+                [N, K],
+                [K, 1],
+                [BLOCK_N, BLOCK_K],
+            )
+            c_desc = tl.make_tensor_descriptor(
+                c_ptr,
+                [M, N],
+                [N, 1],
+                [BLOCK_M, BLOCK_N],
+            )
+
+            pid_m = tl.program_id(0)
+            pid_n = tl.program_id(1)
+            offset_m = pid_m * BLOCK_M
+            offset_n = pid_n * BLOCK_N
+            accumulator = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+            for offset_k in range(0, K, BLOCK_K):
+                a = a_desc.load([offset_m, offset_k])
+                b = b_desc.load([offset_n, offset_k])
+                accumulator = tl.dot(a, b.T, accumulator)
+            c_desc.store([offset_m, offset_n], accumulator.to(tl.bfloat16))
+
+        M = 64
+        N = 64
+        K = 32
+        BLOCK_M = 32
+        BLOCK_N = 32
+        BLOCK_K = 32
+
+        @torch.compile(fullgraph=True)
+        def gemm(a, b):
+            out = torch.empty((M, N), device=a.device, dtype=a.dtype)
+            device_tma_gemm[(M // BLOCK_M, N // BLOCK_N)](
+                a,
+                b,
+                out,
+                M=M,
+                N=N,
+                K=K,
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+                BLOCK_K=BLOCK_K,
+            )
+            return out
+
+        from triton.runtime._allocation import _allocator
+
+        previous_allocator = _allocator.get()
+        patcher, results = self._patch_build_fast_launcher()
+        triton.set_allocator(
+            lambda size, alignment, stream: torch.empty(
+                size, dtype=torch.uint8, device="cuda"
+            )
+        )
+        try:
+            with patcher:
+                for _ in range(3):
+                    a = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
+                    b = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
+                    torch.testing.assert_close(
+                        gemm(a, b), a @ b.T, atol=1e-2, rtol=1e-2
+                    )
+        finally:
+            triton.set_allocator(previous_allocator)
+
+        self.assertTrue(results, "_build_fast_launcher was not reached")
+        self.assertFalse(
+            any(results),
+            "global-scratch kernels must use the regular static launcher",
+        )
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -32,7 +32,7 @@ from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import IS_WINDOWS, skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_XPU_AND_TRITON
 from torch.testing._internal.triton_utils import requires_gpu_and_triton
-from torch.utils._triton import has_triton_tensor_descriptor_host_tma
+from torch.utils._triton import has_triton_tma_device
 
 
 if HAS_XPU_AND_TRITON:
@@ -50,6 +50,33 @@ def _patched_getitem(self, grid):
 
 
 class TestStaticTritonLauncherUnit(TestCase):
+    @staticmethod
+    def _global_scratch_kernel(kernel_cls=StaticallyLaunchedCudaKernel):
+        fn = SimpleNamespace(__name__="scratch_kernel", arg_names=["out"], params=[])
+        src = SimpleNamespace(fn=fn, signature={0: "*fp32"}, constants={})
+        metadata = SimpleNamespace(
+            num_warps=4,
+            shared=0,
+            num_ctas=1,
+            global_scratch_size=32,
+            global_scratch_align=16,
+        )
+
+        class FakeCompiledKernel(SimpleNamespace):
+            launch_enter_hook = None
+            launch_exit_hook = None
+
+        compiled_kernel = FakeCompiledKernel(
+            src=src,
+            metadata=metadata,
+            _cubin_path="/tmp/scratch_kernel.cubin",
+            hash="hash",
+            asm={"cubin": b"cubin"},
+        )
+        kernel = kernel_cls(compiled_kernel)
+        kernel.function = 1
+        return kernel
+
     def test_xpu_load_kernel_uses_existing_three_tuple_abi(self):
         load_calls = []
         kernel_capsule = object()
@@ -155,52 +182,27 @@ class TestStaticTritonLauncherUnit(TestCase):
 
     @skipIfRocm
     def test_global_scratch_allocation(self):
-        import types
-
-        fn = SimpleNamespace(__name__="scratch_kernel", arg_names=["out"], params=[])
-        src = SimpleNamespace(fn=fn, signature={0: "*fp32"}, constants={})
-        metadata = SimpleNamespace(
-            num_warps=4,
-            shared=0,
-            num_ctas=1,
-            global_scratch_size=32,
-            global_scratch_align=16,
-        )
-
-        class FakeCompiledKernel(SimpleNamespace):
-            launch_enter_hook = None
-            launch_exit_hook = None
-
-        compiled_kernel = FakeCompiledKernel(
-            src=src,
-            metadata=metadata,
-            _cubin_path="/tmp/scratch_kernel.cubin",
-            hash="hash",
-            asm={"cubin": b"cubin"},
-        )
-        kernel = StaticallyLaunchedCudaKernel(compiled_kernel)
-        kernel.function = 1
+        kernel = self._global_scratch_kernel()
         scratch = SimpleNamespace(data_ptr=lambda: 2)
         alloc_fn = mock.Mock(return_value=scratch)
         launch_kernel = mock.Mock()
         kernel.C_impl = SimpleNamespace(_launch_kernel=launch_kernel)
 
-        allocation = types.ModuleType("triton.runtime._allocation")
-        allocation._allocator = SimpleNamespace(get=lambda: alloc_fn)
-        runtime = types.ModuleType("triton.runtime")
-        runtime._allocation = allocation
-        triton_module = types.ModuleType("triton")
-        triton_module.runtime = runtime
-        modules = {
-            "triton": triton_module,
-            "triton.runtime": runtime,
-            "triton.runtime._allocation": allocation,
-        }
-        with mock.patch.dict("sys.modules", modules):
+        allocator_var = SimpleNamespace(get=lambda: alloc_fn)
+        with mock.patch(
+            "torch._inductor.runtime.static_triton_launcher._triton_allocator_var",
+            return_value=allocator_var,
+        ):
             kernel.run(2, 3, 1, 4, 5)
 
         alloc_fn.assert_called_once_with(192, 16, 4)
         launch_kernel.assert_called_once_with(1, 2, 3, 1, 4, 0, "OO", (5, scratch), 4)
+
+    @skipIfRocm
+    def test_fast_launcher_rejects_global_scratch(self):
+        import types
+
+        kernel = self._global_scratch_kernel()
 
         def launcher_body(grid_0, grid_1, grid_2, stream, *args):
             runner(grid_0, grid_1, grid_2, stream, *args)  # noqa: F821
@@ -215,6 +217,12 @@ class TestStaticTritonLauncherUnit(TestCase):
         with mock.patch("torch._C._FastCudaLauncher", create=True) as fast_launcher:
             self.assertIsNone(autotuner._build_fast_launcher(launcher))
         fast_launcher.assert_not_called()
+
+    def test_xpu_rejects_global_scratch(self):
+        with self.assertRaisesRegex(
+            NotImplementedError, "Global scratch not yet supported"
+        ):
+            self._global_scratch_kernel(StaticallyLaunchedXpuKernel)
 
     @staticmethod
     def _autotuner_with_static_cubin(cubin_raw):
@@ -1041,8 +1049,8 @@ class TestFastCudaLauncherCompileResult(TestCase):
 
     @skipIfXpu(msg="Tests CUDA device-side TMA global scratch")
     @unittest.skipIf(
-        not has_triton_tensor_descriptor_host_tma(),
-        "requires Triton TensorDescriptor TMA support",
+        not has_triton_tma_device(),
+        "requires Triton device-side TMA support",
     )
     @torch._inductor.config.patch(
         {"compile_threads": 1, "static_launch_user_defined_triton_kernels": True}

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -135,6 +135,8 @@ class TestStaticTritonLauncherUnit(TestCase):
         self.assertIsNone(owner_ref())
 
     def test_global_scratch_allocation(self):
+        import types
+
         fn = SimpleNamespace(__name__="scratch_kernel", arg_names=["out"], params=[])
         src = SimpleNamespace(fn=fn, signature={0: "*fp32"}, constants={})
         metadata = SimpleNamespace(
@@ -163,16 +165,22 @@ class TestStaticTritonLauncherUnit(TestCase):
         launch_kernel = mock.Mock()
         kernel.C_impl = SimpleNamespace(_launch_kernel=launch_kernel)
 
-        from triton.runtime import _allocation
-
-        allocator = SimpleNamespace(get=lambda: alloc_fn)
-        with mock.patch.object(_allocation, "_allocator", allocator):
+        allocation = types.ModuleType("triton.runtime._allocation")
+        allocation._allocator = SimpleNamespace(get=lambda: alloc_fn)
+        runtime = types.ModuleType("triton.runtime")
+        runtime._allocation = allocation
+        triton_module = types.ModuleType("triton")
+        triton_module.runtime = runtime
+        modules = {
+            "triton": triton_module,
+            "triton.runtime": runtime,
+            "triton.runtime._allocation": allocation,
+        }
+        with mock.patch.dict("sys.modules", modules):
             kernel.run(2, 3, 1, 4, 5)
 
         alloc_fn.assert_called_once_with(192, 16, 4)
         launch_kernel.assert_called_once_with(1, 2, 3, 1, 4, 0, "OO", (5, scratch), 4)
-
-        import types
 
         def launcher_body(grid_0, grid_1, grid_2, stream, *args):
             runner(grid_0, grid_1, grid_2, stream, *args)  # noqa: F821

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -152,6 +152,8 @@ class TestStaticTritonLauncherUnit(TestCase):
             pass
 
     def test_global_scratch_allocation(self):
+        import types
+
         fn = SimpleNamespace(__name__="scratch_kernel", arg_names=["out"], params=[])
         src = SimpleNamespace(fn=fn, signature={0: "*fp32"}, constants={})
         metadata = SimpleNamespace(
@@ -180,16 +182,22 @@ class TestStaticTritonLauncherUnit(TestCase):
         launch_kernel = mock.Mock()
         kernel.C_impl = SimpleNamespace(_launch_kernel=launch_kernel)
 
-        from triton.runtime import _allocation
-
-        allocator = SimpleNamespace(get=lambda: alloc_fn)
-        with mock.patch.object(_allocation, "_allocator", allocator):
+        allocation = types.ModuleType("triton.runtime._allocation")
+        allocation._allocator = SimpleNamespace(get=lambda: alloc_fn)
+        runtime = types.ModuleType("triton.runtime")
+        runtime._allocation = allocation
+        triton_module = types.ModuleType("triton")
+        triton_module.runtime = runtime
+        modules = {
+            "triton": triton_module,
+            "triton.runtime": runtime,
+            "triton.runtime._allocation": allocation,
+        }
+        with mock.patch.dict("sys.modules", modules):
             kernel.run(2, 3, 1, 4, 5)
 
         alloc_fn.assert_called_once_with(192, 16, 4)
         launch_kernel.assert_called_once_with(1, 2, 3, 1, 4, 0, "OO", (5, scratch), 4)
-
-        import types
 
         def launcher_body(grid_0, grid_1, grid_2, stream, *args):
             runner(grid_0, grid_1, grid_2, stream, *args)  # noqa: F821

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import torch
+
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor.codecache import PyCodeCache
 from torch._inductor.runtime import triton_helpers
@@ -150,6 +151,55 @@ class TestStaticTritonLauncherUnit(TestCase):
         iface = get_interface_for_device("cpu")
         with DeviceGuard(iface, _resolve_load_device(None, "cpu")):
             pass
+
+    def test_global_scratch_allocation(self):
+        fn = SimpleNamespace(__name__="scratch_kernel", arg_names=["out"], params=[])
+        src = SimpleNamespace(fn=fn, signature={0: "*fp32"}, constants={})
+        metadata = SimpleNamespace(
+            num_warps=4,
+            shared=0,
+            num_ctas=1,
+            global_scratch_size=32,
+            global_scratch_align=16,
+        )
+        compiled_kernel = SimpleNamespace(
+            src=src,
+            metadata=metadata,
+            _cubin_path="/tmp/scratch_kernel.cubin",
+            hash="hash",
+            asm={"cubin": b"cubin"},
+        )
+        kernel = StaticallyLaunchedCudaKernel(compiled_kernel)
+        kernel.function = 1
+        scratch = SimpleNamespace(data_ptr=lambda: 2)
+        alloc_fn = mock.Mock(return_value=scratch)
+        launch_kernel = mock.Mock()
+        kernel.C_impl = SimpleNamespace(_launch_kernel=launch_kernel)
+
+        from triton.runtime import _allocation
+
+        allocator = SimpleNamespace(get=lambda: alloc_fn)
+        with mock.patch.object(_allocation, "_allocator", allocator):
+            kernel.run(2, 3, 1, 4, 5)
+
+        alloc_fn.assert_called_once_with(192, 16, 4)
+        launch_kernel.assert_called_once_with(1, 2, 3, 1, 4, 0, "OO", (5, scratch), 4)
+
+        import types
+
+        def launcher_body(grid_0, grid_1, grid_2, stream, *args):
+            runner(grid_0, grid_1, grid_2, stream, *args)  # noqa: F821
+
+        launcher = types.FunctionType(
+            launcher_body.__code__, {"runner": kernel.run}, "launcher"
+        )
+        launcher._is_static = True
+        autotuner = object.__new__(CachingAutotuner)
+        autotuner.inductor_meta = {"use_fast_triton_launcher": True}
+        autotuner.device_props = SimpleNamespace(type="cuda")
+        with mock.patch("torch._C._FastCudaLauncher", create=True) as fast_launcher:
+            self.assertIsNone(autotuner._build_fast_launcher(launcher))
+        fast_launcher.assert_not_called()
 
     @staticmethod
     def _autotuner_with_static_cubin(cubin_raw):

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -32,7 +32,7 @@ from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import IS_WINDOWS, skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_XPU_AND_TRITON
 from torch.testing._internal.triton_utils import requires_gpu_and_triton
-from torch.utils._triton import has_triton_tensor_descriptor_host_tma
+from torch.utils._triton import has_triton_tma_device
 
 
 if HAS_XPU_AND_TRITON:
@@ -50,6 +50,33 @@ def _patched_getitem(self, grid):
 
 
 class TestStaticTritonLauncherUnit(TestCase):
+    @staticmethod
+    def _global_scratch_kernel(kernel_cls=StaticallyLaunchedCudaKernel):
+        fn = SimpleNamespace(__name__="scratch_kernel", arg_names=["out"], params=[])
+        src = SimpleNamespace(fn=fn, signature={0: "*fp32"}, constants={})
+        metadata = SimpleNamespace(
+            num_warps=4,
+            shared=0,
+            num_ctas=1,
+            global_scratch_size=32,
+            global_scratch_align=16,
+        )
+
+        class FakeCompiledKernel(SimpleNamespace):
+            launch_enter_hook = None
+            launch_exit_hook = None
+
+        compiled_kernel = FakeCompiledKernel(
+            src=src,
+            metadata=metadata,
+            _cubin_path="/tmp/scratch_kernel.cubin",
+            hash="hash",
+            asm={"cubin": b"cubin"},
+        )
+        kernel = kernel_cls(compiled_kernel)
+        kernel.function = 1
+        return kernel
+
     def test_xpu_load_kernel_uses_existing_three_tuple_abi(self):
         load_calls = []
         kernel_capsule = object()
@@ -138,52 +165,27 @@ class TestStaticTritonLauncherUnit(TestCase):
 
     @skipIfRocm
     def test_global_scratch_allocation(self):
-        import types
-
-        fn = SimpleNamespace(__name__="scratch_kernel", arg_names=["out"], params=[])
-        src = SimpleNamespace(fn=fn, signature={0: "*fp32"}, constants={})
-        metadata = SimpleNamespace(
-            num_warps=4,
-            shared=0,
-            num_ctas=1,
-            global_scratch_size=32,
-            global_scratch_align=16,
-        )
-
-        class FakeCompiledKernel(SimpleNamespace):
-            launch_enter_hook = None
-            launch_exit_hook = None
-
-        compiled_kernel = FakeCompiledKernel(
-            src=src,
-            metadata=metadata,
-            _cubin_path="/tmp/scratch_kernel.cubin",
-            hash="hash",
-            asm={"cubin": b"cubin"},
-        )
-        kernel = StaticallyLaunchedCudaKernel(compiled_kernel)
-        kernel.function = 1
+        kernel = self._global_scratch_kernel()
         scratch = SimpleNamespace(data_ptr=lambda: 2)
         alloc_fn = mock.Mock(return_value=scratch)
         launch_kernel = mock.Mock()
         kernel.C_impl = SimpleNamespace(_launch_kernel=launch_kernel)
 
-        allocation = types.ModuleType("triton.runtime._allocation")
-        allocation._allocator = SimpleNamespace(get=lambda: alloc_fn)
-        runtime = types.ModuleType("triton.runtime")
-        runtime._allocation = allocation
-        triton_module = types.ModuleType("triton")
-        triton_module.runtime = runtime
-        modules = {
-            "triton": triton_module,
-            "triton.runtime": runtime,
-            "triton.runtime._allocation": allocation,
-        }
-        with mock.patch.dict("sys.modules", modules):
+        allocator_var = SimpleNamespace(get=lambda: alloc_fn)
+        with mock.patch(
+            "torch._inductor.runtime.static_triton_launcher._triton_allocator_var",
+            return_value=allocator_var,
+        ):
             kernel.run(2, 3, 1, 4, 5)
 
         alloc_fn.assert_called_once_with(192, 16, 4)
         launch_kernel.assert_called_once_with(1, 2, 3, 1, 4, 0, "OO", (5, scratch), 4)
+
+    @skipIfRocm
+    def test_fast_launcher_rejects_global_scratch(self):
+        import types
+
+        kernel = self._global_scratch_kernel()
 
         def launcher_body(grid_0, grid_1, grid_2, stream, *args):
             runner(grid_0, grid_1, grid_2, stream, *args)  # noqa: F821
@@ -198,6 +200,12 @@ class TestStaticTritonLauncherUnit(TestCase):
         with mock.patch("torch._C._FastCudaLauncher", create=True) as fast_launcher:
             self.assertIsNone(autotuner._build_fast_launcher(launcher))
         fast_launcher.assert_not_called()
+
+    def test_xpu_rejects_global_scratch(self):
+        with self.assertRaisesRegex(
+            NotImplementedError, "Global scratch not yet supported"
+        ):
+            self._global_scratch_kernel(StaticallyLaunchedXpuKernel)
 
     @staticmethod
     def _autotuner_with_static_cubin(cubin_raw):
@@ -1022,8 +1030,8 @@ class TestFastCudaLauncherCompileResult(TestCase):
 
     @skipIfXpu(msg="Tests CUDA device-side TMA global scratch")
     @unittest.skipIf(
-        not has_triton_tensor_descriptor_host_tma(),
-        "requires Triton TensorDescriptor TMA support",
+        not has_triton_tma_device(),
+        "requires Triton device-side TMA support",
     )
     @torch._inductor.config.patch(
         {"compile_threads": 1, "static_launch_user_defined_triton_kernels": True}

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -8,7 +8,6 @@ from types import SimpleNamespace
 from unittest import mock
 
 import torch
-
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor.codecache import PyCodeCache
 from torch._inductor.runtime import triton_helpers
@@ -162,7 +161,12 @@ class TestStaticTritonLauncherUnit(TestCase):
             global_scratch_size=32,
             global_scratch_align=16,
         )
-        compiled_kernel = SimpleNamespace(
+
+        class FakeCompiledKernel(SimpleNamespace):
+            launch_enter_hook = None
+            launch_exit_hook = None
+
+        compiled_kernel = FakeCompiledKernel(
             src=src,
             metadata=metadata,
             _cubin_path="/tmp/scratch_kernel.cubin",

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import torch
+
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor.codecache import PyCodeCache
 from torch._inductor.runtime import triton_helpers
@@ -133,6 +134,55 @@ class TestStaticTritonLauncherUnit(TestCase):
         del fast_launcher
         gc.collect()
         self.assertIsNone(owner_ref())
+
+    def test_global_scratch_allocation(self):
+        fn = SimpleNamespace(__name__="scratch_kernel", arg_names=["out"], params=[])
+        src = SimpleNamespace(fn=fn, signature={0: "*fp32"}, constants={})
+        metadata = SimpleNamespace(
+            num_warps=4,
+            shared=0,
+            num_ctas=1,
+            global_scratch_size=32,
+            global_scratch_align=16,
+        )
+        compiled_kernel = SimpleNamespace(
+            src=src,
+            metadata=metadata,
+            _cubin_path="/tmp/scratch_kernel.cubin",
+            hash="hash",
+            asm={"cubin": b"cubin"},
+        )
+        kernel = StaticallyLaunchedCudaKernel(compiled_kernel)
+        kernel.function = 1
+        scratch = SimpleNamespace(data_ptr=lambda: 2)
+        alloc_fn = mock.Mock(return_value=scratch)
+        launch_kernel = mock.Mock()
+        kernel.C_impl = SimpleNamespace(_launch_kernel=launch_kernel)
+
+        from triton.runtime import _allocation
+
+        allocator = SimpleNamespace(get=lambda: alloc_fn)
+        with mock.patch.object(_allocation, "_allocator", allocator):
+            kernel.run(2, 3, 1, 4, 5)
+
+        alloc_fn.assert_called_once_with(192, 16, 4)
+        launch_kernel.assert_called_once_with(1, 2, 3, 1, 4, 0, "OO", (5, scratch), 4)
+
+        import types
+
+        def launcher_body(grid_0, grid_1, grid_2, stream, *args):
+            runner(grid_0, grid_1, grid_2, stream, *args)  # noqa: F821
+
+        launcher = types.FunctionType(
+            launcher_body.__code__, {"runner": kernel.run}, "launcher"
+        )
+        launcher._is_static = True
+        autotuner = object.__new__(CachingAutotuner)
+        autotuner.inductor_meta = {"use_fast_triton_launcher": True}
+        autotuner.device_props = SimpleNamespace(type="cuda")
+        with mock.patch("torch._C._FastCudaLauncher", create=True) as fast_launcher:
+            self.assertIsNone(autotuner._build_fast_launcher(launcher))
+        fast_launcher.assert_not_called()
 
     @staticmethod
     def _autotuner_with_static_cubin(cubin_raw):

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -224,6 +224,13 @@ class TestStaticTritonLauncherUnit(TestCase):
         ):
             self._global_scratch_kernel(StaticallyLaunchedXpuKernel)
 
+    @unittest.skipUnless(torch.version.hip, "ROCm only")
+    def test_rocm_rejects_global_scratch(self):
+        with self.assertRaisesRegex(
+            NotImplementedError, "Global scratch not yet supported"
+        ):
+            self._global_scratch_kernel()
+
     @staticmethod
     def _autotuner_with_static_cubin(cubin_raw):
         autotuner = object.__new__(CachingAutotuner)
@@ -1127,22 +1134,24 @@ class TestFastCudaLauncherCompileResult(TestCase):
 
         previous_allocator = _allocator.get()
         patcher, results = self._patch_build_fast_launcher()
-        triton.set_allocator(
-            lambda size, alignment, stream: torch.empty(
+        alloc_fn = mock.Mock(
+            side_effect=lambda size, _alignment, _stream: torch.empty(
                 size, dtype=torch.uint8, device="cuda"
             )
         )
+        triton.set_allocator(alloc_fn)
         try:
             with patcher:
                 for _ in range(3):
                     a = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
                     b = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
-                    torch.testing.assert_close(
-                        gemm(a, b), a @ b.T, atol=1e-2, rtol=1e-2
-                    )
+                    self.assertEqual(gemm(a, b), a @ b.T, atol=1e-2, rtol=1e-2)
         finally:
             triton.set_allocator(previous_allocator)
 
+        self.assertGreater(alloc_fn.call_count, 0)
+        for call in alloc_fn.call_args_list:
+            self.assertGreater(call.args[0], 0)
         self.assertTrue(results, "_build_fast_launcher was not reached")
         self.assertFalse(
             any(results),

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -3,6 +3,7 @@ import gc
 import os
 import random
 import tempfile
+import unittest
 import weakref
 from types import SimpleNamespace
 from unittest import mock
@@ -31,6 +32,7 @@ from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import IS_WINDOWS, skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_XPU_AND_TRITON
 from torch.testing._internal.triton_utils import requires_gpu_and_triton
+from torch.utils._triton import has_triton_tensor_descriptor_host_tma
 
 
 if HAS_XPU_AND_TRITON:
@@ -134,6 +136,7 @@ class TestStaticTritonLauncherUnit(TestCase):
         gc.collect()
         self.assertIsNone(owner_ref())
 
+    @skipIfRocm
     def test_global_scratch_allocation(self):
         import types
 
@@ -1016,6 +1019,108 @@ class TestFastCudaLauncherCompileResult(TestCase):
                 any(results),
                 "_FastCudaLauncher should not be built when config is disabled",
             )
+
+    @skipIfXpu(msg="Tests CUDA device-side TMA global scratch")
+    @unittest.skipIf(
+        not has_triton_tensor_descriptor_host_tma(),
+        "requires Triton TensorDescriptor TMA support",
+    )
+    @torch._inductor.config.patch(
+        {"compile_threads": 1, "static_launch_user_defined_triton_kernels": True}
+    )
+    def test_device_tma_gemm_falls_back_from_fast_launcher(self):
+        """A global-scratch kernel repeatedly uses the regular static launcher."""
+
+        @triton.jit
+        def device_tma_gemm(
+            a_ptr,
+            b_ptr,
+            c_ptr,
+            M: tl.constexpr,
+            N: tl.constexpr,
+            K: tl.constexpr,
+            BLOCK_M: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+            BLOCK_K: tl.constexpr,
+        ):
+            a_desc = tl.make_tensor_descriptor(
+                a_ptr,
+                [M, K],
+                [K, 1],
+                [BLOCK_M, BLOCK_K],
+            )
+            b_desc = tl.make_tensor_descriptor(
+                b_ptr,
+                [N, K],
+                [K, 1],
+                [BLOCK_N, BLOCK_K],
+            )
+            c_desc = tl.make_tensor_descriptor(
+                c_ptr,
+                [M, N],
+                [N, 1],
+                [BLOCK_M, BLOCK_N],
+            )
+
+            pid_m = tl.program_id(0)
+            pid_n = tl.program_id(1)
+            offset_m = pid_m * BLOCK_M
+            offset_n = pid_n * BLOCK_N
+            accumulator = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+            for offset_k in range(0, K, BLOCK_K):
+                a = a_desc.load([offset_m, offset_k])
+                b = b_desc.load([offset_n, offset_k])
+                accumulator = tl.dot(a, b.T, accumulator)
+            c_desc.store([offset_m, offset_n], accumulator.to(tl.bfloat16))
+
+        M = 64
+        N = 64
+        K = 32
+        BLOCK_M = 32
+        BLOCK_N = 32
+        BLOCK_K = 32
+
+        @torch.compile(fullgraph=True)
+        def gemm(a, b):
+            out = torch.empty((M, N), device=a.device, dtype=a.dtype)
+            device_tma_gemm[(M // BLOCK_M, N // BLOCK_N)](
+                a,
+                b,
+                out,
+                M=M,
+                N=N,
+                K=K,
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+                BLOCK_K=BLOCK_K,
+            )
+            return out
+
+        from triton.runtime._allocation import _allocator
+
+        previous_allocator = _allocator.get()
+        patcher, results = self._patch_build_fast_launcher()
+        triton.set_allocator(
+            lambda size, alignment, stream: torch.empty(
+                size, dtype=torch.uint8, device="cuda"
+            )
+        )
+        try:
+            with patcher:
+                for _ in range(3):
+                    a = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
+                    b = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
+                    torch.testing.assert_close(
+                        gemm(a, b), a @ b.T, atol=1e-2, rtol=1e-2
+                    )
+        finally:
+            triton.set_allocator(previous_allocator)
+
+        self.assertTrue(results, "_build_fast_launcher was not reached")
+        self.assertFalse(
+            any(results),
+            "global-scratch kernels must use the regular static launcher",
+        )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -437,6 +437,8 @@ class StaticallyLaunchedTritonKernel:
                     if hasattr(allocator, "get"):
                         allocator = allocator.get()
                     global_scratch = allocator(
+                        # num_ctas == 1 is required above, so it drops out of
+                        # Triton's grid * num_ctas * global_scratch_size formula.
                         grid_x * grid_y * grid_z * self.global_scratch_size,
                         self.global_scratch_align,
                         stream,

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -104,23 +104,17 @@ class StaticallyLaunchedTritonKernel:
             kernel.shared if hasattr(kernel, "shared") else kernel.metadata.shared
         )
 
-        def needs_scratch_arg(scratch_name: str, param_name: str) -> bool:
-            # pyrefly: ignore [missing-attribute]
-            if hasattr(kernel.metadata, param_name):
-                # pyrefly: ignore [missing-attribute]
-                if getattr(kernel.metadata, param_name) > 0:
-                    raise NotImplementedError(
-                        f"{scratch_name} scratch not yet supported"
-                    )
-                return True
-            return False
-
-        # Newer triton versions pass an extra global scratch parameter to the compiled cuda kernel.
-        # Inductor never uses this field or enables it, but we still have to pass
-        # an extra None into the set of params if its enabled
-        self.has_global_scratch = needs_scratch_arg("Global", "global_scratch_size")
+        # Newer triton versions pass extra scratch parameters to the compiled kernel.
+        self.global_scratch_size = getattr(kernel.metadata, "global_scratch_size", None)
+        self.global_scratch_align = getattr(kernel.metadata, "global_scratch_align", 1)
+        self.has_global_scratch = self.global_scratch_size is not None
         # same situation for profile scratch - triton-lang/triton#7258
-        self.has_profile_scratch = needs_scratch_arg("Profile", "profile_scratch_size")
+        self.profile_scratch_size = getattr(
+            kernel.metadata, "profile_scratch_size", None
+        )
+        if self.profile_scratch_size and self.profile_scratch_size > 0:
+            raise NotImplementedError("Profile scratch not yet supported")
+        self.has_profile_scratch = self.profile_scratch_size is not None
 
         # pyrefly: ignore [missing-attribute]
         self.tensordesc_meta = getattr(kernel.metadata, "tensordesc_meta", None)
@@ -435,10 +429,24 @@ class StaticallyLaunchedTritonKernel:
             args = (*args, None, None)
 
         else:
-            for has_scratch in [self.has_global_scratch, self.has_profile_scratch]:
-                if has_scratch:
-                    arg_tys = arg_tys + "O"
-                    args = (*args, None)
+            if self.has_global_scratch:
+                global_scratch = None
+                if self.global_scratch_size:
+                    from triton.runtime import _allocation
+
+                    allocator = _allocation._allocator
+                    if hasattr(allocator, "get"):
+                        allocator = allocator.get()
+                    global_scratch = allocator(
+                        grid_x * grid_y * grid_z * self.global_scratch_size,
+                        self.global_scratch_align,
+                        stream,
+                    )
+                arg_tys = arg_tys + "O"
+                args = (*args, global_scratch)
+            if self.has_profile_scratch:
+                arg_tys = arg_tys + "O"
+                args = (*args, None)
         # pyrefly: ignore [bad-argument-type]
         if len(args) != len(arg_tys):
             raise AssertionError(f"Expected {len(arg_tys)} args, got {len(args)}")

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -23,6 +23,13 @@ def _tma_arg_helpers():
     return make_arg, TensorDescriptor
 
 
+@functools.lru_cache(None)
+def _triton_allocator_var():
+    from triton.runtime._allocation import _allocator
+
+    return _allocator
+
+
 class StaticallyLaunchedTritonKernel:
     """
     Parses the metadata of a CompiledKernel from Triton into a structure that can
@@ -53,6 +60,8 @@ class StaticallyLaunchedTritonKernel:
     @cached_property
     def C_impl(self):
         raise NotImplementedError
+
+    supports_global_scratch = False
 
     def __init__(self, kernel: CompiledKernel) -> None:
         # pyrefly: ignore [missing-attribute]
@@ -108,7 +117,13 @@ class StaticallyLaunchedTritonKernel:
         # pyrefly: ignore [missing-attribute]
         metadata = kernel.metadata
         self.global_scratch_size = getattr(metadata, "global_scratch_size", None)
-        self.global_scratch_align = getattr(metadata, "global_scratch_align", 1)
+        self.global_scratch_align = getattr(metadata, "global_scratch_align", 1) or 1
+        if (
+            self.global_scratch_size
+            and self.global_scratch_size > 0
+            and not self.supports_global_scratch
+        ):
+            raise NotImplementedError("Global scratch not yet supported")
         self.has_global_scratch = self.global_scratch_size is not None
         # same situation for profile scratch - triton-lang/triton#7258
         self.profile_scratch_size = getattr(metadata, "profile_scratch_size", None)
@@ -343,31 +358,7 @@ class StaticallyLaunchedTritonKernel:
         arg_tys = self.arg_tys
 
         if is_rocm():
-            # ROCm/HIP kernel ABI: The Triton HIP backend ALWAYS includes both
-            # global_scratch and profile_scratch parameters in the kernel signature,
-            # even when the kernel doesn't use them (i.e., when has_*_scratch is False).
-            #
-            # This differs fundamentally from CUDA, where these parameters are only
-            # present in the signature if the corresponding has_*_scratch flag is True.
-            #
-            # The flags indicate whether memory will be allocated/used:
-            # - has_global_scratch: Whether global scratch workspace is needed
-            # - has_profile_scratch: Whether profiling instrumentation is enabled
-            #
-            # However, regardless of flag values, we MUST always pass both parameters
-            # to match the HIP kernel ABI. Passing None is safe:
-            #
-            # - If scratch is not needed (has_*_scratch=False or scratch_size=0):
-            #   The None becomes nullptr, which the kernel never dereferences
-            #
-            # - If scratch is needed (has_*_scratch=True and scratch_size>0):
-            #   The None becomes nullptr initially, but the HIP runtime intercepts
-            #   the kernel launch, allocates the required scratch memory based on
-            #   kernel metadata, and replaces the nullptr with a valid pointer before
-            #   the kernel actually executes
-            #
-            # Not passing both parameters causes segmentation faults because the kernel
-            # expects them at specific positions in the argument array.
+            # HIP always includes both scratch slots in the kernel ABI.
             arg_tys = arg_tys + "OO"
             args = (*args, None, None)
 
@@ -375,14 +366,10 @@ class StaticallyLaunchedTritonKernel:
             if self.has_global_scratch:
                 global_scratch = None
                 if self.global_scratch_size:
-                    from triton.runtime import _allocation
-
-                    allocator = _allocation._allocator
-                    if hasattr(allocator, "get"):
-                        allocator = allocator.get()
+                    allocator = _triton_allocator_var().get()
                     global_scratch = allocator(
-                        # num_ctas == 1 is required above, so it drops out of
-                        # Triton's grid * num_ctas * global_scratch_size formula.
+                        # Keep grid scaling in sync with _generate_lazy_scratch and
+                        # test_lazy_tma_global_scratch_scales_with_launch_grid.
                         grid_x * grid_y * grid_z * self.global_scratch_size,
                         self.global_scratch_align,
                         stream,
@@ -412,6 +399,8 @@ class StaticallyLaunchedTritonKernel:
 
 
 class StaticallyLaunchedCudaKernel(StaticallyLaunchedTritonKernel):
+    supports_global_scratch = not is_rocm()
+
     @cached_property
     def C_impl(self):
         from torch._C import _StaticCudaLauncher

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -23,6 +23,13 @@ def _tma_arg_helpers():
     return make_arg, TensorDescriptor
 
 
+@functools.lru_cache(None)
+def _triton_allocator_var():
+    from triton.runtime._allocation import _allocator
+
+    return _allocator
+
+
 class StaticallyLaunchedTritonKernel:
     """
     Parses the metadata of a CompiledKernel from Triton into a structure that can
@@ -53,6 +60,8 @@ class StaticallyLaunchedTritonKernel:
     @cached_property
     def C_impl(self):
         raise NotImplementedError
+
+    supports_global_scratch = False
 
     def __init__(self, kernel: CompiledKernel) -> None:
         # pyrefly: ignore [missing-attribute]
@@ -108,7 +117,13 @@ class StaticallyLaunchedTritonKernel:
         # pyrefly: ignore [missing-attribute]
         metadata = kernel.metadata
         self.global_scratch_size = getattr(metadata, "global_scratch_size", None)
-        self.global_scratch_align = getattr(metadata, "global_scratch_align", 1)
+        self.global_scratch_align = getattr(metadata, "global_scratch_align", 1) or 1
+        if (
+            self.global_scratch_size
+            and self.global_scratch_size > 0
+            and not self.supports_global_scratch
+        ):
+            raise NotImplementedError("Global scratch not yet supported")
         self.has_global_scratch = self.global_scratch_size is not None
         # same situation for profile scratch - triton-lang/triton#7258
         self.profile_scratch_size = getattr(metadata, "profile_scratch_size", None)
@@ -399,31 +414,7 @@ class StaticallyLaunchedTritonKernel:
         arg_tys = self.arg_tys
 
         if is_rocm():
-            # ROCm/HIP kernel ABI: The Triton HIP backend ALWAYS includes both
-            # global_scratch and profile_scratch parameters in the kernel signature,
-            # even when the kernel doesn't use them (i.e., when has_*_scratch is False).
-            #
-            # This differs fundamentally from CUDA, where these parameters are only
-            # present in the signature if the corresponding has_*_scratch flag is True.
-            #
-            # The flags indicate whether memory will be allocated/used:
-            # - has_global_scratch: Whether global scratch workspace is needed
-            # - has_profile_scratch: Whether profiling instrumentation is enabled
-            #
-            # However, regardless of flag values, we MUST always pass both parameters
-            # to match the HIP kernel ABI. Passing None is safe:
-            #
-            # - If scratch is not needed (has_*_scratch=False or scratch_size=0):
-            #   The None becomes nullptr, which the kernel never dereferences
-            #
-            # - If scratch is needed (has_*_scratch=True and scratch_size>0):
-            #   The None becomes nullptr initially, but the HIP runtime intercepts
-            #   the kernel launch, allocates the required scratch memory based on
-            #   kernel metadata, and replaces the nullptr with a valid pointer before
-            #   the kernel actually executes
-            #
-            # Not passing both parameters causes segmentation faults because the kernel
-            # expects them at specific positions in the argument array.
+            # HIP always includes both scratch slots in the kernel ABI.
             arg_tys = arg_tys + "OO"
             args = (*args, None, None)
 
@@ -431,14 +422,10 @@ class StaticallyLaunchedTritonKernel:
             if self.has_global_scratch:
                 global_scratch = None
                 if self.global_scratch_size:
-                    from triton.runtime import _allocation
-
-                    allocator = _allocation._allocator
-                    if hasattr(allocator, "get"):
-                        allocator = allocator.get()
+                    allocator = _triton_allocator_var().get()
                     global_scratch = allocator(
-                        # num_ctas == 1 is required above, so it drops out of
-                        # Triton's grid * num_ctas * global_scratch_size formula.
+                        # Keep grid scaling in sync with _generate_lazy_scratch and
+                        # test_lazy_tma_global_scratch_scales_with_launch_grid.
                         grid_x * grid_y * grid_z * self.global_scratch_size,
                         self.global_scratch_align,
                         stream,
@@ -468,6 +455,8 @@ class StaticallyLaunchedTritonKernel:
 
 
 class StaticallyLaunchedCudaKernel(StaticallyLaunchedTritonKernel):
+    supports_global_scratch = not is_rocm()
+
     @cached_property
     def C_impl(self):
         from torch._C import _StaticCudaLauncher

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -104,23 +104,17 @@ class StaticallyLaunchedTritonKernel:
             kernel.shared if hasattr(kernel, "shared") else kernel.metadata.shared
         )
 
-        def needs_scratch_arg(scratch_name: str, param_name: str) -> bool:
-            # pyrefly: ignore [missing-attribute]
-            if hasattr(kernel.metadata, param_name):
-                # pyrefly: ignore [missing-attribute]
-                if getattr(kernel.metadata, param_name) > 0:
-                    raise NotImplementedError(
-                        f"{scratch_name} scratch not yet supported"
-                    )
-                return True
-            return False
-
-        # Newer triton versions pass an extra global scratch parameter to the compiled cuda kernel.
-        # Inductor never uses this field or enables it, but we still have to pass
-        # an extra None into the set of params if its enabled
-        self.has_global_scratch = needs_scratch_arg("Global", "global_scratch_size")
+        # Newer triton versions pass extra scratch parameters to the compiled kernel.
+        self.global_scratch_size = getattr(kernel.metadata, "global_scratch_size", None)
+        self.global_scratch_align = getattr(kernel.metadata, "global_scratch_align", 1)
+        self.has_global_scratch = self.global_scratch_size is not None
         # same situation for profile scratch - triton-lang/triton#7258
-        self.has_profile_scratch = needs_scratch_arg("Profile", "profile_scratch_size")
+        self.profile_scratch_size = getattr(
+            kernel.metadata, "profile_scratch_size", None
+        )
+        if self.profile_scratch_size and self.profile_scratch_size > 0:
+            raise NotImplementedError("Profile scratch not yet supported")
+        self.has_profile_scratch = self.profile_scratch_size is not None
 
         # pyrefly: ignore [missing-attribute]
         self.tensordesc_meta = getattr(kernel.metadata, "tensordesc_meta", None)
@@ -379,10 +373,24 @@ class StaticallyLaunchedTritonKernel:
             args = (*args, None, None)
 
         else:
-            for has_scratch in [self.has_global_scratch, self.has_profile_scratch]:
-                if has_scratch:
-                    arg_tys = arg_tys + "O"
-                    args = (*args, None)
+            if self.has_global_scratch:
+                global_scratch = None
+                if self.global_scratch_size:
+                    from triton.runtime import _allocation
+
+                    allocator = _allocation._allocator
+                    if hasattr(allocator, "get"):
+                        allocator = allocator.get()
+                    global_scratch = allocator(
+                        grid_x * grid_y * grid_z * self.global_scratch_size,
+                        self.global_scratch_align,
+                        stream,
+                    )
+                arg_tys = arg_tys + "O"
+                args = (*args, global_scratch)
+            if self.has_profile_scratch:
+                arg_tys = arg_tys + "O"
+                args = (*args, None)
         # pyrefly: ignore [bad-argument-type]
         if len(args) != len(arg_tys):
             raise AssertionError(f"Expected {len(arg_tys)} args, got {len(args)}")

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -105,19 +105,18 @@ class StaticallyLaunchedTritonKernel:
         )
 
         # Newer triton versions pass extra scratch parameters to the compiled kernel.
-        self.global_scratch_size = getattr(kernel.metadata, "global_scratch_size", None)
-        self.global_scratch_align = getattr(kernel.metadata, "global_scratch_align", 1)
+        # pyrefly: ignore [missing-attribute]
+        metadata = kernel.metadata
+        self.global_scratch_size = getattr(metadata, "global_scratch_size", None)
+        self.global_scratch_align = getattr(metadata, "global_scratch_align", 1)
         self.has_global_scratch = self.global_scratch_size is not None
         # same situation for profile scratch - triton-lang/triton#7258
-        self.profile_scratch_size = getattr(
-            kernel.metadata, "profile_scratch_size", None
-        )
+        self.profile_scratch_size = getattr(metadata, "profile_scratch_size", None)
         if self.profile_scratch_size and self.profile_scratch_size > 0:
             raise NotImplementedError("Profile scratch not yet supported")
         self.has_profile_scratch = self.profile_scratch_size is not None
 
-        # pyrefly: ignore [missing-attribute]
-        self.tensordesc_meta = getattr(kernel.metadata, "tensordesc_meta", None)
+        self.tensordesc_meta = getattr(metadata, "tensordesc_meta", None)
         self._has_tensordesc = False
         # pyrefly: ignore [missing-attribute]
         self.arg_tys = self.arg_ty_from_signature(kernel.src)

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -381,6 +381,8 @@ class StaticallyLaunchedTritonKernel:
                     if hasattr(allocator, "get"):
                         allocator = allocator.get()
                     global_scratch = allocator(
+                        # num_ctas == 1 is required above, so it drops out of
+                        # Triton's grid * num_ctas * global_scratch_size formula.
                         grid_x * grid_y * grid_z * self.global_scratch_size,
                         self.global_scratch_align,
                         stream,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -32,6 +32,7 @@ from typing import (
 )
 
 import torch
+
 from torch._dynamo.utils import counters, set_feature_use
 from torch._inductor import metrics
 from torch._inductor.config import triton as inductor_triton_config
@@ -2611,6 +2612,8 @@ class CachingAutotuner(KernelInterface):
             if not callable(runner):
                 return None
             kernel = runner.__self__
+            if getattr(kernel, "global_scratch_size", 0):
+                return None
             cu_function = kernel.function
             num_warps = kernel.num_warps
             shared = kernel.shared

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -32,6 +32,7 @@ from typing import (
 )
 
 import torch
+
 from torch._dynamo.utils import counters, set_feature_use
 from torch._inductor import metrics
 from torch._inductor.config import triton as inductor_triton_config
@@ -2641,6 +2642,8 @@ class CachingAutotuner(KernelInterface):
             # kernel.function is None; the fast launcher binds a single device's
             # function pointer, so fall back to the per-device static launcher.
             if getattr(kernel, "device_agnostic", False):
+                return None
+            if getattr(kernel, "global_scratch_size", 0):
                 return None
             cu_function = kernel.function
             num_warps = kernel.num_warps

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -32,7 +32,6 @@ from typing import (
 )
 
 import torch
-
 from torch._dynamo.utils import counters, set_feature_use
 from torch._inductor import metrics
 from torch._inductor.config import triton as inductor_triton_config


### PR DESCRIPTION
## Related Issue

Fixes #191124

## Why

Device-side TMA kernels require global scratch space. The static Triton launcher rejected kernels with nonzero global-scratch metadata, preventing their static autotuner state from being restored directly on FX graph cache hits and requiring a compile-worker round trip to reconstruct the kernel.

## How

Preserve the global-scratch size and alignment from Triton’s kernel metadata. Before launching, allocate scratch space for the complete grid through Triton’s configured allocator and pass it through the kernel ABI.

Kernels requiring global-scratch allocation use the regular static launcher because `_FastCudaLauncher` bypasses the allocation path. Profile scratch remains unsupported.

## Test

- Device-side descriptor copy passed 20 repeated launches on a non-default stream after pickle/reload.
- Persistent descriptor GEMM matched `a @ b.T`.
- Scratch metadata was 384 bytes/program with 128-byte alignment; the launcher allocated 1,536 bytes for four programs.
- `git diff --check` passed.
- Python syntax checks passed.
- `spin` is unavailable, so repository lint remains for CI.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo