### PR TITLE
[CUDA] Support CPU scalar denominator in addcdiv

### DIFF
--- a/aten/src/ATen/native/PointwiseOps.cpp
+++ b/aten/src/ATen/native/PointwiseOps.cpp
@@ -32,23 +32,32 @@ TORCH_META_FUNC(addcmul)
 
 TORCH_META_FUNC(addcdiv)
 (const Tensor& self,
- const Tensor& tensor1,
- const Tensor& tensor2,
+ const Tensor& numerator,
+ const Tensor& denominator,
  const Scalar& value) {
-  if (isIntegralType(tensor1.scalar_type(), /*includeBool=*/true) &&
-      isIntegralType(tensor2.scalar_type(), /*includeBool=*/true)) {
+  if (isIntegralType(numerator.scalar_type(), /*includeBool=*/true) &&
+      isIntegralType(denominator.scalar_type(), /*includeBool=*/true)) {
     TORCH_CHECK(
         false,
         "Integer division with addcdiv is no longer supported, and in a future  ",
-        "release addcdiv will perform a true division of tensor1 and tensor2. ",
+        "release addcdiv will perform a true division of numerator and ",
+        "denominator. ",
         "The historic addcdiv behavior can be implemented as ",
-        "(input + value * torch.trunc(tensor1 / tensor2)).to(input.dtype) ",
+        "(input + value * torch.trunc(numerator / denominator)).to(input.dtype) ",
         "for integer inputs and as ",
-        "(input + value * tensor1 / tensor2) for float inputs. ",
+        "(input + value * numerator / denominator) for float inputs. ",
         "The future addcdiv behavior is just the latter implementation: ",
-        "(input + value * tensor1 / tensor2), for all dtypes.");
+        "(input + value * numerator / denominator), for all dtypes.");
   }
-  build_ternary_op(maybe_get_output(), self, tensor1, tensor2);
+  build(TensorIteratorConfig()
+      .allow_cpu_scalars(true)
+      .promote_inputs_to_common_dtype(true)
+      .cast_common_dtype_to_outputs(true)
+      .enforce_safe_casting_to_output(true)
+      .add_owned_output(maybe_get_output())
+      .add_owned_const_input(self)
+      .add_owned_const_input(numerator)
+      .add_owned_const_input(denominator));
 }
 
 } // namespace at::meta

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -140,11 +140,26 @@ void addcmul_cuda_scalar_tensor2_kernel(TensorIteratorBase& iter, const Scalar& 
   }
 }
 
+void addcdiv_cuda_scalar_denominator_kernel(
+    TensorIteratorBase& iter,
+    const Scalar& scalar_denominator,
+    const Scalar& value);
+
 #if AT_USE_JITERATOR()
 // return a + alpha * (b / static_cast<accscalar_t>(c));
 constexpr char addcdiv_name[] = "addcdiv";
 #endif
 void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
+  TORCH_CHECK_VALUE(
+      !iter.is_cpu_scalar(1),
+      "CPU scalar support for the self argument is not supported when "
+      "calling addcdiv on CUDA tensors.");
+
+  TORCH_CHECK_VALUE(
+      !iter.is_cpu_scalar(2),
+      "CPU scalar support for the numerator argument is not supported when "
+      "calling addcdiv on CUDA tensors.");
+
   auto dtype = iter.common_dtype();
   if (at::isComplexType(dtype)) {
     #if AT_USE_JITERATOR()
@@ -153,6 +168,11 @@ void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
         static const auto addcdiv_string =
             jiterator_stringify(template <typename T> T addcdiv(
                 T a, T b, T c, T alpha) { return a + alpha * (b / c); });
+        if (iter.is_cpu_scalar(3)) {
+          auto denominator = iter.scalar_value<scalar_t>(3);
+          iter.remove_operand(3);
+          return addcdiv_cuda_scalar_denominator_kernel(iter, denominator, value);
+        }
         jitted_gpu_kernel<
             /*name=*/addcdiv_name,
             /*return_dtype=*/scalar_t,
@@ -166,6 +186,11 @@ void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
       });
     #else
       AT_DISPATCH_COMPLEX_TYPES(dtype, "addcdiv_cuda", [&]() {
+        if (iter.is_cpu_scalar(3)) {
+          auto denominator = iter.scalar_value<scalar_t>(3);
+          iter.remove_operand(3);
+          return addcdiv_cuda_scalar_denominator_kernel(iter, denominator, value);
+        }
         auto alpha = value.to<scalar_t>();
         gpu_kernel(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b, scalar_t c) -> scalar_t {
           return a + alpha * (b / c);
@@ -174,6 +199,11 @@ void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
     #endif
   } else {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, dtype, "addcdiv_cuda", [&]() {
+      if (iter.is_cpu_scalar(3)) {
+        auto denominator = iter.scalar_value<scalar_t>(3);
+        iter.remove_operand(3);
+        return addcdiv_cuda_scalar_denominator_kernel(iter, denominator, value);
+      }
       // note(mkozuki): If scalar_t is fp16 or bfloat16, cast scalar to float
       // and do math in fp32 for better accuracy.
       using accscalar_t = at::acc_type<scalar_t, true>;
@@ -181,6 +211,59 @@ void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
       gpu_kernel(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b, scalar_t c) -> scalar_t {
         //return a + alpha * (b / static_cast<accscalar_t>(c));
         return pointwise_op_impl<accscalar_t>(a, b, c, alpha, std::divides<accscalar_t>());
+      });
+    });
+  }
+}
+
+#if AT_USE_JITERATOR()
+constexpr char addcdiv_scalar_denominator_name[] =
+    "addcdiv_scalar_denominator";
+#endif
+void addcdiv_cuda_scalar_denominator_kernel(
+    TensorIteratorBase& iter,
+    const Scalar& scalar_denominator,
+    const Scalar& value) {
+  auto dtype = iter.common_dtype();
+
+  if (at::isComplexType(dtype)) {
+    #if AT_USE_JITERATOR()
+      AT_DISPATCH_COMPLEX_TYPES(dtype, "addcdiv_cuda_scalar_denominator", [&]() {
+        auto denominator = scalar_denominator.to<scalar_t>();
+        auto alpha = value.to<scalar_t>();
+        static const auto addcdiv_scalar_denominator_string =
+            jiterator_stringify(template <typename T> T addcdiv_scalar_denominator(
+                T a, T b, T denominator, T alpha) {
+              return a + alpha * (b / denominator);
+            });
+        jitted_gpu_kernel<
+            /*name=*/addcdiv_scalar_denominator_name,
+            /*return_dtype=*/scalar_t,
+            /*common_dtype=*/scalar_t,
+            /*arity=*/2>(
+            iter,
+            addcdiv_scalar_denominator_string,
+            /*scalar_pos=*/at::cuda::jit::BinaryFuncVariant::NoScalar,
+            /*scalar_val=*/0,
+            /*extra_args=*/std::make_tuple(denominator, alpha));
+      });
+    #else
+      AT_DISPATCH_COMPLEX_TYPES(dtype, "addcdiv_cuda_scalar_denominator", [&]() {
+        auto denominator = scalar_denominator.to<scalar_t>();
+        auto alpha = value.to<scalar_t>();
+        gpu_kernel(iter, [alpha, denominator]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+          return a + alpha * (b / denominator);
+        });
+      });
+    #endif
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, dtype, "addcdiv_cuda_scalar_denominator", [&]() {
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      auto denominator = scalar_denominator.to<accscalar_t>();
+      auto alpha = value.to<accscalar_t>();
+      gpu_kernel(iter, [alpha, denominator]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+        return pointwise_op_impl<accscalar_t>(
+            a, b, denominator, alpha, std::divides<accscalar_t>());
       });
     });
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4183,9 +4183,10 @@ class TestTorchDeviceType(TestCase):
 
     # FIXME: move to elementwise ternary test suite
     @onlyNativeDeviceTypes
+    @parametrize("use_cpu_scalar", [True, False])
     @dtypesIfCUDA(*set(get_all_math_dtypes('cuda')))
     @dtypes(*set(get_all_math_dtypes('cpu')))
-    def test_addcdiv(self, device, dtype):
+    def test_addcdiv(self, device, dtype, use_cpu_scalar):
         # Returns floating or integral scalar corresponding to dtype
         def _number(floating, integer, dtype):
             if dtype in [torch.half, torch.float, torch.double, torch.bfloat16]:
@@ -4207,7 +4208,10 @@ class TestTorchDeviceType(TestCase):
         def _test_addcdiv():
             a = non_zero_rand((2, 2), dtype=dtype, device=device)
             b = non_zero_rand((2, 2), dtype=dtype, device=device)
-            c = non_zero_rand((2, 2), dtype=dtype, device=device)
+            if use_cpu_scalar:
+                c = non_zero_rand([], dtype=dtype, device="cpu")
+            else:
+                c = non_zero_rand((2, 2), dtype=dtype, device=device)
             alpha = _number(0.5, 3, dtype)
 
             expected = a + (alpha * b) / c
@@ -4231,6 +4235,21 @@ class TestTorchDeviceType(TestCase):
             c = torch.tensor([1.0], device=device, dtype=dtype)
             out = torch.addcmul(a, b, c, value=-2)
             self.assertTrue(not (out.isnan() or out.isinf()))
+
+    @onlyCUDA
+    def test_addcdiv_cuda_errors_with_cpu_scalars(self, device):
+        a = torch.rand((2, 2), device=device)
+        numerator = torch.rand((2, 2), device=device)
+        denominator = torch.rand((2, 2), device=device)
+        scalar = torch.rand([], device="cpu")
+
+        with self.assertRaisesRegex(
+                ValueError, r"CPU scalar support for the numerator argument"):
+            torch.addcdiv(a, scalar, denominator)
+
+        with self.assertRaisesRegex(
+                ValueError, r"CPU scalar support for the self argument"):
+            torch.addcdiv(scalar, numerator, denominator)
 
     def test_nullary_op_mem_overlap(self, device):
         ops = (


### PR DESCRIPTION
Overall, the current implementation has passed the build, targeted tests, and validation of the main API paths in the target environment, providing reasonable confidence that the functionality is sound. The remaining work is to broaden the dtype, numerical, and platform test matrix and confirm overall compatibility through upstream CI.

> The following PR description was prepared with AI assistance and reviewed by the contributor.
>
> ## Issue
>
> Fixes #143306
>
> ## Summary
>
> Allow CUDA `addcdiv` to accept a CPU zero-dimensional scalar as its denominator, matching the CPU-scalar behavior already supported by `addcmul`.
>
> This revisits #144192 and incorporates the review feedback from that earlier implementation. Credit to @emmett-bicker for the original work.
>
> The CUDA kernel extracts the denominator scalar before launch and uses a binary kernel for real and complex dtypes. CPU scalar inputs remain unsupported for `self` and the numerator, with explicit `ValueError` messages. Tests cover the supported denominator path and both rejected argument positions.
>
> ## Checklist
>
> - [x] Passes targeted lint (`spin quicklint`)
> - [x] Added/updated tests
> - [x] Documentation not applicable; this completes behavior already requested by the actionable issue
> - [x] Benchmark results not applicable; the change specializes a scalar input path and does not alter the tensor/tensor kernel
>
> ## Test plan
>
> - `python -m pip install -e . -v --no-build-isolation`
> - `spin quicklint`
> - `git diff --check`
> - `CUDA_VISIBLE_DEVICES=0 PYTORCH_TEST_WITH_SLOW=0 python test/test_torch.py -k addcdiv` — 42 tests run, 1 skipped, 0 failures
> - Manual CUDA smoke on an NVIDIA GeForce RTX 3090 with CUDA 13.0: float16, bfloat16, float32, float64, complex64, complex128, `out=`, in-place, error paths, and autograd passed
>
> ## BC-breaking?
>
> No. This adds support for a previously rejected denominator input. CPU scalar `self` and numerator inputs remain rejected.
>
> ## Remaining validation
>
> Full upstream CI has not run. Dedicated mixed-dtype, boundary-value, other NVIDIA architecture, and ROCm/HIP coverage remains to be exercised by the upstream test matrix or follow-up validation.
