### PR TITLE
Allow row-major mat_b for _scaled_mm on CPU in Inductor

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -607,6 +607,38 @@ class TestFP8Lowering(TestCase):
         self.assertEqual(expected, actual)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    @parametrize("use_v2", (False, True))
+    @onlyOn(["cpu"])
+    def test_scaled_mm_row_major_mat_b(self, use_v2: bool, device):
+        # The col-major mat_b requirement is cuBLAS-specific; the CPU kernel
+        # accepts any layout, so compile must not reject what eager allows.
+        M, K, N = 16, 32, 24
+        x = torch.randn(M, K, device=device)
+        w = torch.randn(K, N, device=device)
+        x_fp8, x_scale = _quantize_tensorwise(x, torch.float8_e4m3fn)
+        w_fp8, w_scale = _quantize_tensorwise(w, torch.float8_e4m3fn)
+        self.assertEqual(w_fp8.stride(), (N, 1))
+
+        def fn(x_fp8, w_fp8, x_scale, w_scale):
+            if use_v2:
+                return scaled_mm(
+                    x_fp8,
+                    w_fp8,
+                    x_scale,
+                    ScalingType.TensorWise,
+                    w_scale,
+                    ScalingType.TensorWise,
+                    output_dtype=torch.float32,
+                )
+            return torch._scaled_mm(
+                x_fp8, w_fp8, x_scale, w_scale, out_dtype=torch.float32
+            )
+
+        expected = fn(x_fp8, w_fp8, x_scale, w_scale)
+        actual = torch.compile(fn, fullgraph=True)(x_fp8, w_fp8, x_scale, w_scale)
+        self.assertEqual(expected, actual)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @skipIfRocm(msg="FP8 scaled_mm tensorwise eager path is not supported by hipBLAS")
     @onlyCUDA
     @parametrize(

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -25,7 +25,7 @@ from ..codegen.cutlass.gemm_template import CUTLASS2xGemmTemplate, CUTLASS3xGemm
 from ..codegen.rocm.ck_tile_universal_gemm_template import CKTileGemmTemplate
 from ..codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from ..codegen.subgraph import SubgraphChoiceCaller, SubgraphTemplate
-from ..ir import Buffer, ChoiceCaller, is_triton, Layout
+from ..ir import Buffer, ChoiceCaller, get_device_type, is_triton, Layout
 from ..kernel_inputs import MMKernelInputs
 from ..lowering import (
     fallback_handler,
@@ -182,6 +182,12 @@ def bias_addmm(inp, mat1, mat2, *, out=None, alpha=1, beta=1):
 
 
 def check_supported_striding(mat_a, mat_b) -> None:
+    # These layout requirements come from the cuBLAS-style scaled GEMM backends.
+    # The CPU kernel makes both operands contiguous internally and accepts any
+    # layout, and the meta kernel skips these checks on CPU for the same reason.
+    if get_device_type(mat_a) == "cpu":
+        return
+
     def is_row_major(stride) -> bool:
         return V.graph.sizevars.statically_known_equals(stride[1], 1)
 


### PR DESCRIPTION
Fixes #191138. `torch._scaled_mm` with a plain row-major `mat_b` runs fine on CPU in eager, but `torch.compile` rejected it with

    LoweringException: RuntimeError: mat_b must be col_major, got stride [24, 1]

Root cause: `check_supported_striding` in the Inductor lowering enforced the row-major `mat_a` / col-major `mat_b` layout on every device. Those constraints belong to the cuBLAS-style scaled GEMM backends, not to the operator. The CPU kernel (`_scaled_mm_out_cpu_emulated`) calls `.contiguous()` on both operands and imposes no layout requirement, and the meta kernel already skips these checks on CPU (`_check_scaled_mm_sizes` guards them behind `device_hint(self) != "cpu"`). Inductor was therefore stricter than both eager and meta, and rejected programs that are perfectly valid.

The fix returns early from `check_supported_striding` for CPU inputs, bringing Inductor in line with the meta kernel. This covers both `tuned_scaled_mm` (`aten._scaled_mm`) and `tuned_scaled_mm_v2` (`aten._scaled_mm_v2`), which share the helper; the CPU v2 kernel routes to the same emulated implementation and is equally layout-agnostic.

The alternative considered was falling back to the eager op on CPU, following the swizzle handling in `tuned_scaled_mm_v2`. That was rejected because nothing is actually unsupported here: the ATen extern choice is registered for all device types and produces correct code for any input layout, so a fallback would give up autotuning for no reason.

The near-identical `check_supported_striding` in `kernel/mm_common.py` is left alone. Its only caller is the grouped-mm lowering, and `_scaled_grouped_mm` is CUDA-only in `native_functions.yaml`, so it can never see a CPU tensor.

Test Plan:

New device-generic regression test covering both the `_scaled_mm` and `_scaled_mm_v2` (`torch.nn.functional.scaled_mm`) spellings with a row-major `mat_b`:

```
python test/inductor/test_fp8.py -k row_major_mat_b -v
```

Verified it fails without the lowering change (2 errors) and passes with it.

No regressions in the CPU FP8 lowering suite (136 tests, OK, 42 skipped):

```
python test/inductor/test_fp8.py TestFP8LoweringCPU
```

The reproducer from the issue now matches eager rather than raising, and on CUDA a row-major `mat_b` is still rejected (by the meta kernel, during tracing).

This change was authored with the assistance of Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo