### PR TITLE
Fix _weight_norm_interface for g, v, and layout cases it mishandled

### DIFF
--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -48,9 +48,15 @@ Tensor norm_except_dim(const Tensor & v, int64_t pow, int64_t dim)
 }
 
 std::tuple<Tensor,Tensor> weight_norm_cpu(
-    const Tensor& v,
-    const Tensor& g,
+    const Tensor& v_in,
+    const Tensor& g_in,
     int64_t dim) {
+  // The fused kernels walk v and g as flat buffers, so a non-contiguous input
+  // would be read in storage order and silently give a wrong result. The
+  // backward already requires its saved tensors to be contiguous.
+  auto v = v_in.contiguous();
+  auto g = g_in.contiguous();
+
   auto w = at::empty_like(v, at::MemoryFormat::Contiguous);
 
   // align with cuda behavior, keep norm in 'Float' when g is 'BFloat16'/'Half'

--- a/aten/src/ATen/native/cuda/WeightNorm.cu
+++ b/aten/src/ATen/native/cuda/WeightNorm.cu
@@ -335,10 +335,16 @@ __global__ void weight_norm_bwd_last_dim_kernel
 } // anonymous namespace
 
 std::tuple<Tensor,Tensor> weight_norm_cuda
-  (const Tensor & v,
-   const Tensor & g,
+  (const Tensor & v_in,
+   const Tensor & g_in,
    int64_t dim)
 {
+  // The fused kernels walk v and g as flat buffers, so a non-contiguous input
+  // would be read in storage order and silently give a wrong result. The
+  // backward already requires its saved tensors to be contiguous.
+  auto v = v_in.contiguous();
+  auto g = g_in.contiguous();
+
   auto w = at::empty_like(v, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
   // weight_norm_fused does have a derivative defined in derivatives.yaml, therefore, VariableType.cpp

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -2,6 +2,7 @@
 
 import functools
 import itertools
+import math
 import re
 import unittest
 from collections import defaultdict
@@ -34,6 +35,7 @@ from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.common_utils import (
     is_iterable_of_tensors,
+    parametrize,
     run_tests,
     skipIfCrossRef,
     skipIfTorchDynamo,
@@ -1294,6 +1296,155 @@ class DecompOneOffTests(TestCase):
             torch.ops.aten._weight_norm_interface(inp, inp2),
             torch._decomp.decompositions._weight_norm_interface(inp, inp2),
         )
+
+    @onlyNativeDeviceTypes
+    @skipIfCrossRef
+    @parametrize(
+        "v_shape,g_shape,dim",
+        [
+            ((128, 64, 3, 3), (128,), 0),
+            ((128, 64, 3, 3), (128, 1, 1, 1), 0),
+            ((8, 4, 3, 5), (5,), 3),
+            ((8, 4, 3, 5), (1, 1, 1, 5), 3),
+            ((6, 5), (6,), 0),
+            ((6, 5), (5,), 1),
+        ],
+    )
+    def test_weight_norm_interface_g_shape(self, device, v_shape, g_shape, dim):
+        # The kernels index g as a flat buffer of length v.size(dim), so any g
+        # shape with a matching numel is accepted and norm comes back with g's
+        # shape. assertEqual also covers those shapes, not just the values.
+        v = torch.randn(v_shape, device=device)
+        g = torch.randn(g_shape, device=device)
+
+        self.assertEqual(
+            torch.ops.aten._weight_norm_interface(v, g, dim),
+            torch._decomp.decompositions._weight_norm_interface(v, g, dim),
+        )
+
+    @onlyNativeDeviceTypes
+    @skipIfCrossRef
+    @parametrize("dtype", [torch.half, torch.bfloat16])
+    def test_weight_norm_interface_reduced_dtype_norm(self, device, dtype):
+        v = torch.randn((8, 4), device=device, dtype=dtype)
+        g = torch.randn((8,), device=device, dtype=dtype)
+
+        ref = torch.ops.aten._weight_norm_interface(v, g, 0)
+        res = torch._decomp.decompositions._weight_norm_interface(v, g, 0)
+        self.assertEqual(ref[1].dtype, torch.float)
+        self.assertEqual(ref, res)
+
+    @onlyNativeDeviceTypes
+    @skipIfCrossRef
+    def test_weight_norm_interface_rank1_v(self, device):
+        # keep_dim is empty for 1-D v, and reducing over an empty dim list
+        # collapses v to its global norm instead of the per-element magnitude
+        # that the kernels compute for single-element slices.
+        v = torch.tensor([3.0, -4.0, 0.5, 2.0], device=device)
+        g = torch.tensor([2.0, 1.0, 5.0, 0.25], device=device)
+
+        w, norm = torch._decomp.decompositions._weight_norm_interface(v, g, 0)
+        self.assertEqual(norm, v.abs())
+        self.assertEqual(w, torch.sign(v) * g)
+        self.assertEqual(torch.ops.aten._weight_norm_interface(v, g, 0), (w, norm))
+
+    @onlyNativeDeviceTypes
+    @skipIfCrossRef
+    @parametrize("dtype", [torch.float32, torch.float64, torch.half, torch.bfloat16])
+    def test_weight_norm_interface_stress(self, device, dtype):
+        # Sweep v ranks against both fused dims and every g rank with a matching
+        # numel. Inputs stay contiguous: the kernels read v and g as flat
+        # buffers, so a non-contiguous input is outside the op's contract (the
+        # _weight_norm wrapper makes both contiguous before dispatching here).
+        v_shapes = [
+            (7,),
+            (6, 5),
+            (1, 8),
+            (8, 1),
+            (4, 3, 5),
+            (5, 1, 1),
+            (8, 4, 3, 3),
+            (2, 3, 4, 5),
+            (1, 3, 1, 7),
+            (2, 3, 2, 3, 4),
+        ]
+        # The kernels accumulate the norm and divide in float, so reduced
+        # precision lands a couple of ulps off the decomposition, not bit-exact.
+        reduced = dtype in (torch.half, torch.bfloat16)
+        tol = {"rtol": 2e-2, "atol": 1e-2} if reduced else {}
+
+        for v_shape in v_shapes:
+            rank = len(v_shape)
+            for dim in sorted({0, rank - 1}):
+                n = v_shape[dim]
+                keepdim_shape = [1] * rank
+                keepdim_shape[dim] = n
+                g_shapes = {(n,), (n, 1), (1, n), tuple(keepdim_shape)}
+                g_shapes.update(
+                    tuple(keepdim_shape[lead:])
+                    for lead in range(1, rank)
+                    if math.prod(keepdim_shape[lead:]) == n
+                )
+
+                for g_shape in sorted(g_shapes):
+                    v = torch.randn(v_shape, device=device, dtype=dtype)
+                    # keep g away from zero so w stays well conditioned
+                    g = torch.randn(g_shape, device=device, dtype=dtype).abs() + 0.5
+                    msg = f"v={v_shape} g={g_shape} dim={dim}"
+
+                    ref = torch.ops.aten._weight_norm_interface(v, g, dim)
+                    res = torch._decomp.decompositions._weight_norm_interface(v, g, dim)
+                    for expected, actual in zip(ref, res):
+                        self.assertEqual(expected.shape, actual.shape, msg=msg)
+                        self.assertEqual(expected.dtype, actual.dtype, msg=msg)
+                    self.assertEqual(ref, res, msg=msg, **tol)
+
+    @onlyNativeDeviceTypes
+    @skipIfCrossRef
+    @parametrize("layout", ["channels_last", "transposed", "non_contiguous_g"])
+    def test_weight_norm_interface_non_contiguous(self, device, layout):
+        # The kernels walk v and g as flat buffers, so before they took
+        # .contiguous() internally a non-contiguous input was consumed in
+        # storage order and silently gave a wrong result.
+        g = torch.randn(8, device=device).abs() + 0.5
+        if layout == "channels_last":
+            v = torch.randn(8, 4, 3, 3, device=device).to(
+                memory_format=torch.channels_last
+            )
+        elif layout == "transposed":
+            v = torch.randn(4, 8, device=device).t()
+        else:
+            v = torch.randn(8, 4, device=device)
+            g = (torch.randn(16, device=device).abs() + 0.5)[::2]
+
+        self.assertEqual(
+            torch.ops.aten._weight_norm_interface(v, g, 0),
+            torch._decomp.decompositions._weight_norm_interface(v, g, 0),
+        )
+
+    @onlyNativeDeviceTypes
+    @skipIfCrossRef
+    @skipIfTorchDynamo("recursive torch.compile")
+    @parametrize(
+        "v_shape,g_shape,dim",
+        [
+            ((128, 64, 3, 3), (128,), 0),
+            ((8, 4, 3, 5), (5,), 3),
+            ((7,), (7,), 0),
+        ],
+    )
+    def test_weight_norm_interface_compile_parity(self, device, v_shape, g_shape, dim):
+        def fn(v, g):
+            return torch.ops.aten._weight_norm_interface(v, g, dim)
+
+        v = torch.randn(v_shape, device=device)
+        g = torch.randn(g_shape, device=device).abs() + 0.5
+
+        # aot_eager still traces through the decomposition as the meta kernel,
+        # which is where a rank-mismatched g used to fail, without pulling in a
+        # Triton dependency just to check shape propagation.
+        compiled = torch.compile(fn, fullgraph=True, backend="aot_eager")
+        self.assertEqual(fn(v, g), compiled(v, g))
 
     @onlyCUDA
     @skipIfCrossRef

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5936,10 +5936,19 @@ def squeeze_default(self: Tensor, dim: int | None = None):
 def _weight_norm_interface(v, g, dim=0):
     # https://github.com/pytorch/pytorch/blob/852f8526c52190125446adc9a6ecbcc28fb66182/aten/src/ATen/native/WeightNorm.cpp#L58
     keep_dim = tuple(i for i in range(len(v.shape)) if i != dim)
-    # align with cuda behavior, keep norm in 'float' when g is 'bfloat16'
-    norm_dtype = torch.float if g.dtype == torch.bfloat16 else None
-    norm = v.norm(2, keep_dim, keepdim=True, dtype=norm_dtype)
-    return v * (g / norm.to(g.dtype)), norm
+    # align with kernel behavior, keep norm in 'float' when g is 'bfloat16'/'half'
+    norm_dtype = torch.float if g.dtype in (torch.bfloat16, torch.half) else None
+    if keep_dim:
+        norm = v.norm(2, keep_dim, keepdim=True, dtype=norm_dtype)
+    else:
+        # v is 1-D, so each slice holds a single element whose 2-norm is its
+        # magnitude. An empty dim list would make norm() reduce over every dim.
+        norm = v.abs() if norm_dtype is None else v.to(norm_dtype).abs()
+    # The kernels index g as a flat buffer of length v.size(dim), so its shape
+    # need not line up with norm's; reshape it to broadcast along dim. norm is
+    # returned with g's shape, matching how the kernels allocate it.
+    w = v * (g.reshape(norm.shape) / norm.to(g.dtype))
+    return w, norm.reshape(g.shape)
 
 
 @register_decomposition(aten.isin)


### PR DESCRIPTION
Fixes #191137.

`torch.compile` rejected `aten._weight_norm_interface` with a 1-D `g` that eager accepts, failing during FakeTensor propagation with:

```
Attempting to broadcast a dimension of length 128 at -1! Mismatching argument at
index 1 had torch.Size([128, 1, 1, 128]); but expected shape should be
broadcastable to [128, 64, 3, 3]
```

## Root cause

The decomposition computed the norm with `keepdim=True` (giving it `v`'s rank) and then divided `g` by it directly, silently assuming `g` already had `v`'s rank. The CPU and CUDA kernels make no such assumption: both index `g` as a **flat buffer** of length `v.size(dim)`, so its shape is irrelevant as long as the numel matches, and both allocate the returned `norm` with `g.sizes()/g.strides()`.

With `v` of shape `[128, 64, 3, 3]` and `g` of shape `[128]`, the keepdim norm is `[128, 1, 1, 1]` and `g / norm` broadcasts to `[128, 1, 1, 128]` instead of the intended per-slice scale.

The fix reshapes `g` to the norm's shape before dividing and returns `norm` with `g`'s shape.

## Additional defects found by a stress sweep

A sweep over v ranks, both fused dims, every `g` rank with a matching numel, four dtypes and both devices turned up three more divergences in the same op, all predating this change:

- **Rank-1 `v` silently produced wrong values.** `keep_dim` is the empty tuple when `v` is 1-D, and `norm(2, (), keepdim=True)` reduces over *every* dim, so `v` collapsed to its global norm instead of the per-element magnitude. For `v = [3, -4, 0.5, 2]`, `g = [2, 1, 5, 0.25]` the decomposition returned `w[0] = 1.109` against eager's `2.0`.
- **Norm dtype diverged for float16.** Both kernels stash `norm` as float for Half as well as BFloat16; the decomposition only checked BFloat16.
- **The forward kernels silently corrupted non-contiguous input.** `weight_norm_cpu`/`weight_norm_cuda` passed `v`/`g` straight to kernels that walk them as flat buffers, so channels_last, transposed or strided inputs were read in storage order. Here the decomposition was correct and *eager* was wrong. Both forwards now take `.contiguous()` internally, matching the `_weight_norm` wrapper and the backward's contiguity requirements. A `TORCH_CHECK` was rejected as the alternative: it would make eager raise where the decomposition succeeds, recreating the divergence this PR removes.

## Test plan

```
python test/test_decomp.py -k weight_norm_interface
```

40 tests across CPU and CUDA. 24 of the 34 that do not depend on the kernel change fail without the decomposition fix.

> [!IMPORTANT]
> The 6 `test_weight_norm_interface_non_contiguous` cases require the kernel change to be compiled and have not been run green locally. They were confirmed to fail against a build without the change, and the fix's semantics were verified across 12 layouts on both devices by checking that `_weight_norm_interface(v.contiguous(), g.contiguous())` — exactly what the patched kernels now compute — equals the decomposition applied to the original non-contiguous input. **Please confirm CI is green on these.**

`lintrunner` could not be run in the authoring environment (it shells out to `uv`, which was not installed); changes were checked manually for line length and ASCII-only comments. **A lint pass before merge is advisable.**

Known adjacent issue left unfixed: the CUDA kernel uses `sqrtf` and `1.f/result`, truncating float64 math to float precision. Precision-only, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
