### PR TITLE
[autograd] Align clamp and min/max subgradients with dispatcher schemas

### DIFF
--- a/docs/source/notes/autograd.md
+++ b/docs/source/notes/autograd.md
@@ -100,6 +100,8 @@ To try and reduce the impact of functions that are non-differentiable, we define
 For these rules, the function and its input space are defined by the selected dispatcher overload and its schema signature.
 This applies to built-in operators and user-defined operators, including Python ``custom_op`` definitions.
 Overload resolution occurs before autograd applies these rules; Python-level syntax does not redefine the function's input space.
+For details about how Python values select Scalar and Tensor overloads, see
+{ref}`python-number-overload-resolution`.
 
 All differentiable Tensor arguments in the selected dispatcher signature jointly form the function's input space, regardless of whether a particular argument currently requires grad.
 ``requires_grad`` only controls which gradient components autograd computes.

--- a/docs/source/notes/autograd.md
+++ b/docs/source/notes/autograd.md
@@ -91,11 +91,32 @@ Unfortunately many of the functions we use in practice do not have this property
 To try and reduce the impact of functions that are non-differentiable, we define the gradients of the elementary operations by applying the following rules in order:
 
 1. If the function is differentiable and thus a gradient exists at the current point, use it.
-2. If the function is convex (at least locally), use the sub-gradient of minimum norm.
-3. If the function is concave (at least locally), use the super-gradient of minimum norm (consider `-f(x)` and apply the previous point).
+2. If the function is convex (at least locally), use a subgradient of minimum norm.
+3. If the function is concave (at least locally), use a supergradient of minimum norm (consider `-f(x)` and apply the previous point).
 4. If the function is defined, define the gradient at the current point by continuity (note that ``inf`` is possible here, for example for ``sqrt(0)``). If multiple values are possible, pick one arbitrarily.
 5. If the function is not defined (``sqrt(-1)``, ``log(-1)`` or most functions when the input is ``NaN``, for example) then the value used as the gradient is arbitrary (we might also raise an error but that is not guaranteed). Most functions will use ``NaN`` as the gradient, but for performance reasons, some functions will use other values (``log(-1)``, for example).
 6. If the function is not a deterministic mapping (i.e. it is not a [mathematical function](https://en.wikipedia.org/wiki/Function_%28mathematics%29)), it will be marked as non-differentiable. This will make it error out in the backward if used on tensors that require grad outside of a ``no_grad`` environment.
+
+For these rules, the function and its input space are defined by the selected dispatcher overload and its schema signature.
+This applies to built-in operators and user-defined operators, including Python ``custom_op`` definitions.
+Overload resolution occurs before autograd applies these rules; Python-level syntax does not redefine the function's input space.
+
+All differentiable Tensor arguments in the selected dispatcher signature jointly form the function's input space, regardless of whether a particular argument currently requires grad.
+``requires_grad`` only controls which gradient components autograd computes.
+Non-Tensor arguments, including Scalar parameters, are fixed parameters.
+The norm is the Euclidean norm on this joint Tensor input space.
+
+Consequently, different dispatcher signatures can intentionally produce different subgradients.
+Consider these two schemas:
+
+```text
+max(Tensor x, Scalar c) -> Tensor
+max.Tensor(Tensor x, Tensor y) -> Tensor
+```
+
+At equality, the first schema treats ``c`` as fixed, so the minimum-norm derivative with respect to ``x`` is ``0``.
+The second schema is jointly a function of ``x`` and ``y``, so its minimum-norm joint subgradient is ``(1/2, 1/2)``.
+A zero-dimensional Tensor remains a Tensor argument for this purpose.
 
 
 ### Division by Zero in Autograd

--- a/docs/source/notes/autograd.md
+++ b/docs/source/notes/autograd.md
@@ -97,6 +97,8 @@ To try and reduce the impact of functions that are non-differentiable, we define
 5. If the function is not defined (``sqrt(-1)``, ``log(-1)`` or most functions when the input is ``NaN``, for example) then the value used as the gradient is arbitrary (we might also raise an error but that is not guaranteed). Most functions will use ``NaN`` as the gradient, but for performance reasons, some functions will use other values (``log(-1)``, for example).
 6. If the function is not a deterministic mapping (i.e. it is not a [mathematical function](https://en.wikipedia.org/wiki/Function_%28mathematics%29)), it will be marked as non-differentiable. This will make it error out in the backward if used on tensors that require grad outside of a ``no_grad`` environment.
 
+In particular, a ``NaN`` input is outside the mathematical input domain used by these rules, even when the operator has specified floating-point behavior for ``NaN``. An autograd formula may return any gradient at such an input and does not need to propagate the ``NaN`` input into the gradient. This is distinct from a ``NaN`` incoming gradient or tangent: formulas must propagate it when that contribution is used, without allowing an inactive contribution to contaminate the result.
+
 For these rules, the function and its input space are defined by the selected dispatcher overload and its schema signature.
 This applies to built-in operators and user-defined operators, including Python ``custom_op`` definitions.
 Overload resolution occurs before autograd applies these rules; Python-level syntax does not redefine the function's input space.

--- a/docs/source/notes/extending.md
+++ b/docs/source/notes/extending.md
@@ -1116,6 +1116,59 @@ In a similar way where ``__torch_function__`` is able to interpose on all of tor
 Most of these functions are defined in ``native_functions.yaml`` which specifies the properties of these functions as well as their backend implementation. Their implementation alongside specified features are then automatically registered via codegen.
 Some more exotic functions or features are also registered in other places in the C++ codebase or in user-defined C++ extensions.
 
+(python-number-overload-resolution)=
+
+### Python argument binding and dispatcher overloads
+
+The Python binding selects an operator overload before the dispatcher selects
+feature and backend keys. For built-in operators, code generation groups the
+available schemas into Python signatures and orders otherwise-equivalent
+``Tensor`` signatures before ``Scalar`` signatures. This ordering is independent
+of the order in which the schemas appear in ``native_functions.yaml``.
+
+A Python number normally matches a ``Scalar`` parameter, while a
+{class}`Tensor` matches a ``Tensor`` parameter. For example, the generated
+binding for ``clamp_min`` exposes these signatures in this order:
+
+```text
+clamp_min(Tensor input, Tensor min)
+clamp_min(Tensor input, Scalar min)
+```
+
+The first signature rejects a Python number, so ``torch.clamp_min(x, 1.0)``
+selects ``aten::clamp_min(Tensor, Scalar)``. In contrast,
+``torch.clamp_min(x, torch.tensor(1.0))`` selects
+``aten::clamp_min.Tensor(Tensor, Tensor)``. After the binding selects a
+signature, it converts the arguments according to that signature and calls the
+corresponding dispatcher overload. The dispatcher does not reconsider the
+Scalar-versus-Tensor choice based on argument values.
+
+As a compatibility exception, the Python argument parser allows numbers to
+match ``Tensor`` parameters for the following operator names:
+
+- ``add``, ``sub``, ``mul``, ``div``, and their in-place and ``out`` variants;
+- the ``subtract``, ``multiply``, ``divide``, and ``true_divide`` aliases and
+  their in-place and ``out`` variants;
+- ``floor_divide`` and its in-place and ``out`` variants;
+- ``to``, ``_to_copy``, ``copy``, and ``copy_``; and
+- ``_conj``.
+
+For these names, the Tensor signature is tried first. If it accepts a Python
+number, the binding converts the number with ``scalar_to_tensor`` into a
+zero-dimensional Tensor and marks it as a wrapped number. This is a temporary,
+name-based compatibility allowlist, not the default conversion rule for Tensor
+parameters.
+
+The distinction matters when schemas have different semantics. A ``Scalar``
+argument is a fixed parameter, whereas a zero-dimensional Tensor is still a
+Tensor argument. Custom operator schemas, including schemas inferred from
+{func}`torch.library.custom_op`, should therefore use ``Scalar`` for Python
+numbers that are parameters and ``Tensor`` for values that belong to the
+operator's Tensor input space. Reordering overload declarations does not change
+this distinction, and adding an operator to the number-as-Tensor allowlist can
+cause a Python number to select the Tensor overload instead of the Scalar
+overload.
+
 It is also possible to add `new` native functions using {mod}`torch.library`. This Python feature allows defining and/or adding new implementations to native functions. This can be used to add missing kernels, replace existing ones or define brand new native functions.
 
 You can find many examples of ``__torch_dispatch__``-based subclasses in the [subclass zoo](https://github.com/albanD/subclass_zoo) repo.

--- a/docs/source/notes/extending.md
+++ b/docs/source/notes/extending.md
@@ -1153,11 +1153,17 @@ match ``Tensor`` parameters for the following operator names:
 - ``to``, ``_to_copy``, ``copy``, and ``copy_``; and
 - ``_conj``.
 
-For these names, the Tensor signature is tried first. If it accepts a Python
-number, the binding converts the number with ``scalar_to_tensor`` into a
+For these names, the Tensor signature is tried first and accepts a Python
+number. The binding converts the number with ``scalar_to_tensor`` into a
 zero-dimensional Tensor and marks it as a wrapped number. This is a temporary,
 name-based compatibility allowlist, not the default conversion rule for Tensor
 parameters.
+
+Wrapped numbers are also important when an operation runs on an accelerator.
+Kernels can extract their value and pass it as a kernel argument, just as they
+do for a Scalar, without transferring a Tensor between devices. Naively moving
+a CPU scalar Tensor to the accelerator before using it would introduce a
+blocking CPU-to-accelerator copy for a value that can instead be passed directly.
 
 The distinction matters when schemas have different semantics. A ``Scalar``
 argument is a fixed parameter, whereas a zero-dimensional Tensor is still a

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1598,7 +1598,6 @@ class TestOperators(TestCase):
                 xfail("nn.functional.dropout2d", ""),
                 xfail("svd_lowrank", ""),
                 xfail("pca_lowrank", ""),
-                xfail("clamp"),
                 # something weird happening with channels_last
                 xfail("bfloat16"),
                 xfail("double"),

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12542,23 +12542,6 @@ get_out().sum().backward()
         ):
             torch.autograd.grad(g2.sum(), x)
 
-    def test_clamp_min_max_scalar_subgradient_at_boundary(self):
-        def grad_at(fn):
-            x = torch.tensor(0.0, requires_grad=True)
-            fn(x).backward()
-            return x.grad.item()
-
-        self.assertEqual(grad_at(lambda x: torch.clamp_min(x, 0.0)), 0.0)
-        self.assertEqual(grad_at(lambda x: torch.clamp_max(x, 0.0)), 0.0)
-
-        x = torch.tensor(1.0, requires_grad=True)
-        torch.clamp_min(x, 0.0).backward()
-        self.assertEqual(x.grad.item(), 1.0)
-
-        x = torch.tensor(-1.0, requires_grad=True)
-        torch.clamp_max(x, 0.0).backward()
-        self.assertEqual(x.grad.item(), 1.0)
-
 
 def index_perm_variable(shape, max_indices):
     if not isinstance(shape, tuple):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12542,6 +12542,23 @@ get_out().sum().backward()
         ):
             torch.autograd.grad(g2.sum(), x)
 
+    def test_clamp_min_max_scalar_subgradient_at_boundary(self):
+        def grad_at(fn):
+            x = torch.tensor(0.0, requires_grad=True)
+            fn(x).backward()
+            return x.grad.item()
+
+        self.assertEqual(grad_at(lambda x: torch.clamp_min(x, 0.0)), 0.0)
+        self.assertEqual(grad_at(lambda x: torch.clamp_max(x, 0.0)), 0.0)
+
+        x = torch.tensor(1.0, requires_grad=True)
+        torch.clamp_min(x, 0.0).backward()
+        self.assertEqual(x.grad.item(), 1.0)
+
+        x = torch.tensor(-1.0, requires_grad=True)
+        torch.clamp_max(x, 0.0).backward()
+        self.assertEqual(x.grad.item(), 1.0)
+
 
 def index_perm_variable(shape, max_indices):
     if not isinstance(shape, tuple):

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2674,6 +2674,22 @@ class TestBinaryUfuncsDevice(TestCase):
             [0.0, 0.0, 0.0],
             [0.0, 0.0, 0.0],
         )
+
+        for op, expected in (
+            (lambda x: torch.clamp_min(x, 0.0), [0.0, 0.0, float("nan")]),
+            (lambda x: torch.clamp_max(x, 0.0), [float("nan"), 0.0, 0.0]),
+        ):
+            x = torch.tensor(
+                [-1.0, 0.0, 1.0], device=device, dtype=dtype, requires_grad=True
+            )
+            op(x).backward(torch.full_like(x, float("nan")))
+            self.assertEqual(x.grad, expected)
+
+            with fwAD.dual_level():
+                tangent = fwAD.unpack_dual(
+                    op(fwAD.make_dual(x.detach(), torch.full_like(x, float("nan"))))
+                ).tangent
+            self.assertEqual(tangent, expected)
         run_test(
             lambda x: torch.clamp(x, min=1.0, max=0.0),
             [0.0, 0.0, 0.0],
@@ -2727,25 +2743,6 @@ class TestBinaryUfuncsDevice(TestCase):
                 [20.0] * 3,
             )
 
-        for op in (torch.clamp_min, torch.clamp_max):
-            nan_self = torch.tensor(
-                [float("nan")], device=device, dtype=dtype, requires_grad=True
-            )
-            bound = torch.zeros(1, device=device, dtype=dtype, requires_grad=True)
-            op(nan_self, bound).sum().backward()
-            self.assertEqual(nan_self.grad, [0.0])
-            self.assertEqual(bound.grad, [0.0])
-
-        nan_self = torch.tensor(
-            [float("nan")], device=device, dtype=dtype, requires_grad=True
-        )
-        nan_min = torch.tensor([-1.0], device=device, dtype=dtype, requires_grad=True)
-        nan_max = torch.tensor([1.0], device=device, dtype=dtype, requires_grad=True)
-        torch.clamp(nan_self, min=nan_min, max=nan_max).sum().backward()
-        self.assertEqual(nan_self.grad, [0.0])
-        self.assertEqual(nan_min.grad, [0.0])
-        self.assertEqual(nan_max.grad, [0.0])
-
         x = torch.tensor(
             [[0.0, 1.0, 2.0], [1.0, 1.0, 0.0]],
             device=device,
@@ -2795,68 +2792,76 @@ class TestBinaryUfuncsDevice(TestCase):
             tangent = fwAD.unpack_dual(torch.clamp(x_dual, max=max_dual)).tangent
         self.assertEqual(tangent, [[2.0, 17.0, 40.0], [14.0, 20.0, 12.0]])
 
-    @dtypes(torch.float, torch.double)
-    def test_fmin_fmax_nan_subgradient(self, device, dtype):
-        for op in (torch.fmin, torch.fmax):
-            a = torch.tensor(
-                [float("nan"), 1.0], device=device, dtype=dtype, requires_grad=True
-            )
-            b = torch.tensor(
-                [2.0, float("nan")], device=device, dtype=dtype, requires_grad=True
-            )
-            op(a, b).sum().backward()
-            self.assertEqual(a.grad, [0.0, 1.0])
-            self.assertEqual(b.grad, [1.0, 0.0])
-
-            with fwAD.dual_level():
-                a_dual = fwAD.make_dual(
-                    a.detach(), torch.tensor([3.0, 4.0], device=device, dtype=dtype)
-                )
-                b_dual = fwAD.make_dual(
-                    b.detach(), torch.tensor([5.0, 6.0], device=device, dtype=dtype)
-                )
-                tangent = fwAD.unpack_dual(op(a_dual, b_dual)).tangent
-            self.assertEqual(tangent, [5.0, 4.0])
-
-            both_nan_a = torch.tensor(
-                [float("nan")], device=device, dtype=dtype, requires_grad=True
-            )
-            both_nan_b = both_nan_a.detach().clone().requires_grad_()
-            op(both_nan_a, both_nan_b).sum().backward()
-            self.assertEqual(both_nan_a.grad, [1.0])
-            self.assertEqual(both_nan_b.grad, [0.0])
-
-            with fwAD.dual_level():
-                a_dual = fwAD.make_dual(
-                    both_nan_a.detach(), torch.tensor([7.0], device=device, dtype=dtype)
-                )
-                b_dual = fwAD.make_dual(
-                    both_nan_b.detach(), torch.tensor([9.0], device=device, dtype=dtype)
-                )
-                tangent = fwAD.unpack_dual(op(a_dual, b_dual)).tangent
-            self.assertEqual(tangent, [7.0])
-
-        for op, a, b in (
-            (torch.maximum, 0.0, 1.0),
-            (torch.fmax, 0.0, 1.0),
-            (torch.minimum, 1.0, 0.0),
-            (torch.fmin, 1.0, 0.0),
+        for op, values in (
+            (torch.clamp_min, [2.0, 1.0, 0.0]),
+            (torch.clamp_max, [0.0, 1.0, 2.0]),
         ):
+            x = torch.tensor(values, device=device, dtype=dtype, requires_grad=True)
+            bound = torch.ones(3, device=device, dtype=dtype, requires_grad=True)
+            op(x, bound).backward(torch.full_like(x, float("nan")))
+            self.assertEqual(x.grad, [float("nan"), float("nan"), 0.0])
+            self.assertEqual(bound.grad, [0.0, float("nan"), float("nan")])
+
             with fwAD.dual_level():
-                inf_tangent = torch.tensor([float("inf")], device=device, dtype=dtype)
-                finite_tangent = torch.ones(1, device=device, dtype=dtype)
                 tangent = fwAD.unpack_dual(
                     op(
-                        fwAD.make_dual(
-                            torch.tensor([a], device=device, dtype=dtype), inf_tangent
-                        ),
-                        fwAD.make_dual(
-                            torch.tensor([b], device=device, dtype=dtype),
-                            finite_tangent,
-                        ),
+                        fwAD.make_dual(x.detach(), torch.full_like(x, float("nan"))),
+                        fwAD.make_dual(bound.detach(), torch.ones_like(bound)),
                     )
                 ).tangent
-            self.assertEqual(tangent, [1.0])
+            self.assertEqual(tangent, [float("nan"), float("nan"), 1.0])
+
+        x = torch.tensor(
+            [0.0, 1.0, 2.0, 3.0], device=device, dtype=dtype, requires_grad=True
+        )
+        min = torch.ones(4, device=device, dtype=dtype, requires_grad=True)
+        max = torch.full((4,), 2.0, device=device, dtype=dtype, requires_grad=True)
+        torch.clamp(x, min=min, max=max).backward(torch.full_like(x, float("nan")))
+        self.assertEqual(x.grad, [0.0, float("nan"), float("nan"), 0.0])
+        self.assertEqual(min.grad, [float("nan"), float("nan"), 0.0, 0.0])
+        self.assertEqual(max.grad, [0.0, 0.0, float("nan"), float("nan")])
+
+        with fwAD.dual_level():
+            tangent = fwAD.unpack_dual(
+                torch.clamp(
+                    fwAD.make_dual(x.detach(), torch.full_like(x, float("nan"))),
+                    min=fwAD.make_dual(min.detach(), torch.ones_like(min)),
+                    max=fwAD.make_dual(max.detach(), torch.ones_like(max)),
+                )
+            ).tangent
+        self.assertEqual(tangent, [1.0, float("nan"), float("nan"), 1.0])
+
+    @dtypes(torch.float, torch.double)
+    def test_min_max_nan_gradients(self, device, dtype):
+        for op, a_values in (
+            (torch.maximum, [2.0, 1.0, 0.0]),
+            (torch.fmax, [2.0, 1.0, 0.0]),
+            (torch.minimum, [0.0, 1.0, 2.0]),
+            (torch.fmin, [0.0, 1.0, 2.0]),
+        ):
+            a = torch.tensor(a_values, device=device, dtype=dtype, requires_grad=True)
+            b = torch.ones(3, device=device, dtype=dtype, requires_grad=True)
+            op(a, b).backward(torch.full_like(a, float("nan")))
+            self.assertEqual(a.grad, [float("nan"), float("nan"), 0.0])
+            self.assertEqual(b.grad, [0.0, float("nan"), float("nan")])
+
+            with fwAD.dual_level():
+                tangent = fwAD.unpack_dual(
+                    op(
+                        fwAD.make_dual(a.detach(), torch.full_like(a, float("nan"))),
+                        fwAD.make_dual(b.detach(), torch.ones_like(b)),
+                    )
+                ).tangent
+            self.assertEqual(tangent, [float("nan"), float("nan"), 1.0])
+
+            with fwAD.dual_level():
+                tangent = fwAD.unpack_dual(
+                    op(
+                        fwAD.make_dual(a.detach(), torch.ones_like(a)),
+                        fwAD.make_dual(b.detach(), torch.full_like(b, float("nan"))),
+                    )
+                ).tangent
+            self.assertEqual(tangent, [1.0, float("nan"), float("nan")])
 
     # TODO: tests like this should be generic
     @dtypesIfCUDA(torch.half, torch.float, torch.double)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -30,6 +30,7 @@ from torch.testing._internal.common_device_type import (
     OpDTypes,
     ops,
     precisionOverride,
+    skipCPUIf,
     skipCUDAIfNotRocm,
     skipIf,
     skipMeta,
@@ -1374,6 +1375,7 @@ class TestBinaryUfuncsDevice(TestCase):
         res = nom / denom
         self.assertEqual(res, expected)
 
+    @skipCPUIf(True, "test compares accelerator division implementations")
     @dtypes(torch.float, torch.bfloat16)
     def test_division_by_scalar(self, device, dtype):
         num = torch.rand(1024, device=device, dtype=dtype)
@@ -1385,6 +1387,7 @@ class TestBinaryUfuncsDevice(TestCase):
 
     # Tests that trying to add, inplace, a CUDA tensor to a CPU tensor
     #   throws the correct error message
+    @skipCPUIf(True, "test requires distinct CPU and accelerator devices")
     def test_cross_device_inplace_error_msg(self, device):
         a = torch.tensor(2.0)
         b = torch.tensor(2.0, device=device)
@@ -2724,6 +2727,25 @@ class TestBinaryUfuncsDevice(TestCase):
                 [20.0] * 3,
             )
 
+        for op in (torch.clamp_min, torch.clamp_max):
+            nan_self = torch.tensor(
+                [float("nan")], device=device, dtype=dtype, requires_grad=True
+            )
+            bound = torch.zeros(1, device=device, dtype=dtype, requires_grad=True)
+            op(nan_self, bound).sum().backward()
+            self.assertEqual(nan_self.grad, [0.0])
+            self.assertEqual(bound.grad, [0.0])
+
+        nan_self = torch.tensor(
+            [float("nan")], device=device, dtype=dtype, requires_grad=True
+        )
+        nan_min = torch.tensor([-1.0], device=device, dtype=dtype, requires_grad=True)
+        nan_max = torch.tensor([1.0], device=device, dtype=dtype, requires_grad=True)
+        torch.clamp(nan_self, min=nan_min, max=nan_max).sum().backward()
+        self.assertEqual(nan_self.grad, [0.0])
+        self.assertEqual(nan_min.grad, [0.0])
+        self.assertEqual(nan_max.grad, [0.0])
+
         x = torch.tensor(
             [[0.0, 1.0, 2.0], [1.0, 1.0, 0.0]],
             device=device,
@@ -2814,31 +2836,27 @@ class TestBinaryUfuncsDevice(TestCase):
                 tangent = fwAD.unpack_dual(op(a_dual, b_dual)).tangent
             self.assertEqual(tangent, [7.0])
 
-        with fwAD.dual_level():
-            inf_tangent = torch.tensor([float("inf")], device=device, dtype=dtype)
-            finite_tangent = torch.ones(1, device=device, dtype=dtype)
-            fmax_tangent = fwAD.unpack_dual(
-                torch.fmax(
-                    fwAD.make_dual(
-                        torch.zeros(1, device=device, dtype=dtype), inf_tangent
-                    ),
-                    fwAD.make_dual(
-                        torch.ones(1, device=device, dtype=dtype), finite_tangent
-                    ),
-                )
-            ).tangent
-            fmin_tangent = fwAD.unpack_dual(
-                torch.fmin(
-                    fwAD.make_dual(
-                        torch.ones(1, device=device, dtype=dtype), inf_tangent
-                    ),
-                    fwAD.make_dual(
-                        torch.zeros(1, device=device, dtype=dtype), finite_tangent
-                    ),
-                )
-            ).tangent
-        self.assertEqual(fmax_tangent, [1.0])
-        self.assertEqual(fmin_tangent, [1.0])
+        for op, a, b in (
+            (torch.maximum, 0.0, 1.0),
+            (torch.fmax, 0.0, 1.0),
+            (torch.minimum, 1.0, 0.0),
+            (torch.fmin, 1.0, 0.0),
+        ):
+            with fwAD.dual_level():
+                inf_tangent = torch.tensor([float("inf")], device=device, dtype=dtype)
+                finite_tangent = torch.ones(1, device=device, dtype=dtype)
+                tangent = fwAD.unpack_dual(
+                    op(
+                        fwAD.make_dual(
+                            torch.tensor([a], device=device, dtype=dtype), inf_tangent
+                        ),
+                        fwAD.make_dual(
+                            torch.tensor([b], device=device, dtype=dtype),
+                            finite_tangent,
+                        ),
+                    )
+                ).tangent
+            self.assertEqual(tangent, [1.0])
 
     # TODO: tests like this should be generic
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
@@ -4149,6 +4167,7 @@ class TestBinaryUfuncsDevice(TestCase):
             lambda: torch.add(m1, m1, out=m2),
         )
 
+    @skipCPUIf(True, "test covers accelerator half precision")
     def test_addsub_half_tensor(self, device):
         x = torch.tensor([60000.0], dtype=torch.half, device=device)
         for op, y, alpha in (
@@ -5061,27 +5080,10 @@ def generate_not_implemented_tests(cls):
 generate_not_implemented_tests(TestBinaryUfuncsDevice)
 
 
-class TestBinaryUfuncSubgradientsCPU(TestCase):
-    test_min_max_and_clamp_subgradient = (
-        TestBinaryUfuncsDevice.test_min_max_and_clamp_subgradient
-    )
-    test_min_max_and_clamp_forward_ad = (
-        TestBinaryUfuncsDevice.test_min_max_and_clamp_forward_ad
-    )
-    test_scalar_clamp_subgradient = TestBinaryUfuncsDevice.test_scalar_clamp_subgradient
-    test_tensor_clamp_subgradient = TestBinaryUfuncsDevice.test_tensor_clamp_subgradient
-    test_fmin_fmax_nan_subgradient = (
-        TestBinaryUfuncsDevice.test_fmin_fmax_nan_subgradient
-    )
-
-
 instantiate_device_type_tests(
     TestChebyshevNanPropagation, globals(), only_for=("cpu", "cuda")
 )
-instantiate_device_type_tests(TestBinaryUfuncSubgradientsCPU, globals(), only_for="cpu")
-instantiate_device_type_tests(
-    TestBinaryUfuncsDevice, globals(), allow_xpu=True, except_for="cpu"
-)
+instantiate_device_type_tests(TestBinaryUfuncsDevice, globals(), allow_xpu=True)
 instantiate_device_type_tests(TestBinaryUfuncsCUDA, globals(), only_for="cuda")
 
 if __name__ == "__main__":

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -70,6 +70,7 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     slowTest,
     TEST_SCIPY,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
     torch_to_numpy_dtype_dict,
     xfailIfTorchDynamo,
@@ -1669,6 +1670,8 @@ class TestBinaryUfuncsDevice(TestCase):
         except ValueError as e:
             err_msg = "Integers to negative integer powers are not allowed."
             self.assertEqual(str(e), err_msg)
+            if TEST_WITH_TORCHDYNAMO:
+                return
             out = torch.empty_like(base)
             test_cases = [
                 lambda: base.pow(exponent),
@@ -1700,7 +1703,7 @@ class TestBinaryUfuncsDevice(TestCase):
                     actual2 = actual.pow_(exponent)
                     self.assertEqual(actual, expected.to(actual))
                     self.assertEqual(actual2, expected.to(actual2))
-                else:
+                elif not TEST_WITH_TORCHDYNAMO:
                     self.assertRaisesRegex(
                         RuntimeError,
                         r"result type \w+ can't be cast to the desired output type \w+",
@@ -1834,6 +1837,8 @@ class TestBinaryUfuncsDevice(TestCase):
             self.assertRaisesRegex(RuntimeError, regex, base.pow_, exponent)
 
     def test_int_tensor_pow_neg_ints(self, device):
+        if TEST_WITH_TORCHDYNAMO:
+            return
         ints = [
             torch.iinfo(torch.int32).min,
             -3,
@@ -4134,6 +4139,9 @@ class TestBinaryUfuncsDevice(TestCase):
             [10.0 + 13.0j, 8.0 + 11.0j], dtype=torch.complex64, device=device
         )
         self.assertEqual(res, expected)
+
+        if TEST_WITH_TORCHDYNAMO:
+            return
 
         # mismatched alpha
         m1 = torch.tensor([1], dtype=torch.int8, device=device)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2550,7 +2550,7 @@ class TestBinaryUfuncsDevice(TestCase):
             floating_types_and(torch.half, torch.bfloat16),
         )
     )
-    def test_maximum_and_minimum_subgradient(self, device, dtypes):
+    def test_min_max_and_clamp_subgradient(self, device, dtypes):
         def run_test(f, a, b, expected_a_grad, expected_b_grad):
             a = torch.tensor(a, requires_grad=True, device=device, dtype=dtypes[0])
             b = torch.tensor(b, requires_grad=True, device=device, dtype=dtypes[1])
@@ -2559,47 +2559,286 @@ class TestBinaryUfuncsDevice(TestCase):
             self.assertEqual(a.grad, expected_a_grad)
             self.assertEqual(b.grad, expected_b_grad)
 
-        run_test(
+        a = [0.0, 1.0, 2.0]
+        b = [1.0, 1.0, 1.0]
+        max_a_grad = [0.0, 0.5, 1.0]
+        max_b_grad = [1.0, 0.5, 0.0]
+        min_a_grad = [1.0, 0.5, 0.0]
+        min_b_grad = [0.0, 0.5, 1.0]
+
+        max_ops = (
             torch.maximum,
-            [0.0, 1.0, 2.0],
-            [1.0, 1.0, 1.0],
-            [0.0, 0.5, 1.0],
-            [1.0, 0.5, 0.0],
+            torch.fmax,
+            torch.clamp_min,
+            lambda x, bound: torch.clamp(x, min=bound),
+            lambda x, bound: torch.clip(x, min=bound),
+        )
+        min_ops = (
+            torch.minimum,
+            torch.fmin,
+            torch.clamp_max,
+            lambda x, bound: torch.clamp(x, max=bound),
+            lambda x, bound: torch.clip(x, max=bound),
+        )
+        for op in max_ops:
+            run_test(op, a, b, max_a_grad, max_b_grad)
+        for op in min_ops:
+            run_test(op, a, b, min_a_grad, min_b_grad)
+
+        for op, expected_a_grad in (
+            (torch.maximum, max_a_grad),
+            (torch.clamp_min, max_a_grad),
+            (lambda x, bound: torch.clamp(x, min=bound), max_a_grad),
+            (lambda x, bound: torch.clip(x, min=bound), max_a_grad),
+            (torch.minimum, min_a_grad),
+            (torch.clamp_max, min_a_grad),
+            (lambda x, bound: torch.clamp(x, max=bound), min_a_grad),
+            (lambda x, bound: torch.clip(x, max=bound), min_a_grad),
+        ):
+            a_tensor = torch.tensor(
+                a, requires_grad=True, device=device, dtype=dtypes[0]
+            )
+            b_tensor = torch.tensor(b, device=device, dtype=dtypes[1])
+            op(a_tensor, b_tensor).sum().backward()
+            self.assertEqual(a_tensor.grad, expected_a_grad)
+
+    def test_min_max_and_clamp_forward_ad(self, device):
+        def run_test(op, expected):
+            a = torch.tensor([0.0, 1.0, 2.0], device=device)
+            b = torch.tensor([1.0, 1.0, 1.0], device=device)
+            a_tangent = torch.tensor([2.0, 4.0, 6.0], device=device)
+            b_tangent = torch.tensor([10.0, 20.0, 30.0], device=device)
+
+            with fwAD.dual_level():
+                a_dual = fwAD.make_dual(a, a_tangent)
+                b_dual = fwAD.make_dual(b, b_tangent)
+                tangent = fwAD.unpack_dual(op(a_dual, b_dual)).tangent
+
+            self.assertEqual(tangent, expected)
+
+        for op in (
+            torch.maximum,
+            torch.fmax,
+            torch.clamp_min,
+            lambda x, bound: torch.clamp(x, min=bound),
+            lambda x, bound: torch.clip(x, min=bound),
+        ):
+            run_test(op, [10.0, 12.0, 6.0])
+        for op in (
+            torch.minimum,
+            torch.fmin,
+            torch.clamp_max,
+            lambda x, bound: torch.clamp(x, max=bound),
+            lambda x, bound: torch.clip(x, max=bound),
+        ):
+            run_test(op, [2.0, 12.0, 30.0])
+
+    @dtypes(*floating_types_and(torch.half, torch.bfloat16))
+    def test_scalar_clamp_subgradient(self, device, dtype):
+        def run_test(op, expected_grad, expected_tangent):
+            values = torch.tensor([-1.0, 0.0, 1.0], device=device, dtype=dtype)
+            x = values.clone().requires_grad_()
+            op(x).sum().backward()
+            self.assertEqual(x.grad, expected_grad)
+
+            tangent = torch.tensor([2.0, 4.0, 6.0], device=device, dtype=dtype)
+            with fwAD.dual_level():
+                dual = fwAD.make_dual(values, tangent)
+                actual_tangent = fwAD.unpack_dual(op(dual)).tangent
+            self.assertEqual(actual_tangent, expected_tangent)
+
+        for op in (
+            lambda x: torch.clamp_min(x, 0.0),
+            lambda x: torch.clamp(x, min=0.0),
+            lambda x: torch.clip(x, min=0.0),
+        ):
+            run_test(op, [0.0, 0.0, 1.0], [0.0, 0.0, 6.0])
+
+        for op in (
+            lambda x: torch.clamp_max(x, 0.0),
+            lambda x: torch.clamp(x, max=0.0),
+            lambda x: torch.clip(x, max=0.0),
+        ):
+            run_test(op, [1.0, 0.0, 0.0], [2.0, 0.0, 0.0])
+
+        run_test(
+            lambda x: torch.clamp(x, min=-1.0, max=1.0),
+            [0.0, 1.0, 0.0],
+            [0.0, 4.0, 0.0],
         )
         run_test(
-            torch.minimum,
-            [0.0, 1.0, 2.0],
-            [1.0, 1.0, 1.0],
-            [1.0, 0.5, 0.0],
-            [0.0, 0.5, 1.0],
+            lambda x: torch.clamp(x, min=0.0, max=0.0),
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+        )
+        run_test(
+            lambda x: torch.clamp(x, min=1.0, max=0.0),
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
         )
 
-    def test_maximum_minimum_forward_ad_float32(self, device):
-        # TODO: This should really be covered by OpInfo but it isn't. The problem
-        # is that our gradient tests test using float64 but it should also test
-        # float32
-        x = torch.randn(3, device=device, dtype=torch.float32)
-        y = torch.randn(3, device=device, dtype=torch.float32)
-        tx = torch.randn(3, device=device, dtype=torch.float32)
-        ty = torch.randn(3, device=device, dtype=torch.float32)
+    @dtypes(torch.float, torch.double)
+    def test_tensor_clamp_subgradient(self, device, dtype):
+        def run_test(op, primals, tangents, expected_grads, expected_tangent):
+            inputs = [
+                torch.tensor(p, device=device, dtype=dtype, requires_grad=True)
+                for p in primals
+            ]
+            op(inputs[0], min=inputs[1], max=inputs[2]).sum().backward()
+            for input, expected in zip(inputs, expected_grads):
+                self.assertEqual(input.grad, expected)
+
+            with fwAD.dual_level():
+                duals = [
+                    fwAD.make_dual(
+                        torch.tensor(p, device=device, dtype=dtype),
+                        torch.tensor(t, device=device, dtype=dtype),
+                    )
+                    for p, t in zip(primals, tangents)
+                ]
+                actual_tangent = fwAD.unpack_dual(
+                    op(duals[0], min=duals[1], max=duals[2])
+                ).tangent
+            self.assertEqual(actual_tangent, expected_tangent)
+
+        for op in (torch.clamp, torch.clip):
+            run_test(
+                op,
+                ([0.0, 1.0, 2.0, 3.0], [1.0] * 4, [2.0] * 4),
+                ([2.0, 4.0, 6.0, 8.0], [10.0] * 4, [20.0] * 4),
+                ([0.0, 0.5, 0.5, 0.0], [1.0, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 1.0]),
+                [10.0, 7.0, 13.0, 20.0],
+            )
+            run_test(
+                op,
+                ([0.0, 1.0, 2.0], [1.0] * 3, [1.0] * 3),
+                ([2.0, 4.0, 6.0], [10.0] * 3, [20.0] * 3),
+                ([0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]),
+                [10.0, 4.0, 20.0],
+            )
+            run_test(
+                op,
+                ([0.0, 1.0, 2.0], [2.0] * 3, [1.0] * 3),
+                ([2.0, 4.0, 6.0], [10.0] * 3, [20.0] * 3),
+                ([0.0] * 3, [0.0] * 3, [1.0] * 3),
+                [20.0] * 3,
+            )
+
+        x = torch.tensor(
+            [[0.0, 1.0, 2.0], [1.0, 1.0, 0.0]],
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        min = torch.ones(3, device=device, dtype=dtype, requires_grad=True)
+        torch.clamp(x, min=min).sum().backward()
+        self.assertEqual(x.grad, [[0.0, 0.5, 1.0], [0.5, 0.5, 0.0]])
+        self.assertEqual(min.grad, [1.5, 1.0, 1.0])
 
         with fwAD.dual_level():
-            x_dual = fwAD.make_dual(x, tx)
-            y_dual = fwAD.make_dual(y, ty)
-            result = torch.maximum(x_dual, y_dual)
-            _, result_tangent = fwAD.unpack_dual(result)
+            x_dual = fwAD.make_dual(
+                x.detach(),
+                torch.tensor(
+                    [[2.0, 4.0, 6.0], [8.0, 10.0, 12.0]],
+                    device=device,
+                    dtype=dtype,
+                ),
+            )
+            min_dual = fwAD.make_dual(
+                min.detach(),
+                torch.tensor([20.0, 30.0, 40.0], device=device, dtype=dtype),
+            )
+            tangent = fwAD.unpack_dual(torch.clamp(x_dual, min=min_dual)).tangent
+        self.assertEqual(tangent, [[20.0, 17.0, 6.0], [14.0, 20.0, 40.0]])
 
-        expected = torch.where(x > y, tx, ty)
-        self.assertEqual(result_tangent, expected)
+        max = torch.ones(3, device=device, dtype=dtype, requires_grad=True)
+        max_x = x.detach().requires_grad_()
+        torch.clamp(max_x, max=max).sum().backward()
+        self.assertEqual(max_x.grad, [[1.0, 0.5, 0.0], [0.5, 0.5, 1.0]])
+        self.assertEqual(max.grad, [0.5, 1.0, 1.0])
 
         with fwAD.dual_level():
-            x_dual = fwAD.make_dual(x, tx)
-            y_dual = fwAD.make_dual(y, ty)
-            result = torch.minimum(x_dual, y_dual)
-            _, result_tangent = fwAD.unpack_dual(result)
+            x_dual = fwAD.make_dual(
+                x.detach(),
+                torch.tensor(
+                    [[2.0, 4.0, 6.0], [8.0, 10.0, 12.0]],
+                    device=device,
+                    dtype=dtype,
+                ),
+            )
+            max_dual = fwAD.make_dual(
+                max.detach(),
+                torch.tensor([20.0, 30.0, 40.0], device=device, dtype=dtype),
+            )
+            tangent = fwAD.unpack_dual(torch.clamp(x_dual, max=max_dual)).tangent
+        self.assertEqual(tangent, [[2.0, 17.0, 40.0], [14.0, 20.0, 12.0]])
 
-        expected = torch.where(x < y, tx, ty)
-        self.assertEqual(result_tangent, expected)
+    @dtypes(torch.float, torch.double)
+    def test_fmin_fmax_nan_subgradient(self, device, dtype):
+        for op in (torch.fmin, torch.fmax):
+            a = torch.tensor(
+                [float("nan"), 1.0], device=device, dtype=dtype, requires_grad=True
+            )
+            b = torch.tensor(
+                [2.0, float("nan")], device=device, dtype=dtype, requires_grad=True
+            )
+            op(a, b).sum().backward()
+            self.assertEqual(a.grad, [0.0, 1.0])
+            self.assertEqual(b.grad, [1.0, 0.0])
+
+            with fwAD.dual_level():
+                a_dual = fwAD.make_dual(
+                    a.detach(), torch.tensor([3.0, 4.0], device=device, dtype=dtype)
+                )
+                b_dual = fwAD.make_dual(
+                    b.detach(), torch.tensor([5.0, 6.0], device=device, dtype=dtype)
+                )
+                tangent = fwAD.unpack_dual(op(a_dual, b_dual)).tangent
+            self.assertEqual(tangent, [5.0, 4.0])
+
+            both_nan_a = torch.tensor(
+                [float("nan")], device=device, dtype=dtype, requires_grad=True
+            )
+            both_nan_b = both_nan_a.detach().clone().requires_grad_()
+            op(both_nan_a, both_nan_b).sum().backward()
+            self.assertEqual(both_nan_a.grad, [1.0])
+            self.assertEqual(both_nan_b.grad, [0.0])
+
+            with fwAD.dual_level():
+                a_dual = fwAD.make_dual(
+                    both_nan_a.detach(), torch.tensor([7.0], device=device, dtype=dtype)
+                )
+                b_dual = fwAD.make_dual(
+                    both_nan_b.detach(), torch.tensor([9.0], device=device, dtype=dtype)
+                )
+                tangent = fwAD.unpack_dual(op(a_dual, b_dual)).tangent
+            self.assertEqual(tangent, [7.0])
+
+        with fwAD.dual_level():
+            inf_tangent = torch.tensor([float("inf")], device=device, dtype=dtype)
+            finite_tangent = torch.ones(1, device=device, dtype=dtype)
+            fmax_tangent = fwAD.unpack_dual(
+                torch.fmax(
+                    fwAD.make_dual(
+                        torch.zeros(1, device=device, dtype=dtype), inf_tangent
+                    ),
+                    fwAD.make_dual(
+                        torch.ones(1, device=device, dtype=dtype), finite_tangent
+                    ),
+                )
+            ).tangent
+            fmin_tangent = fwAD.unpack_dual(
+                torch.fmin(
+                    fwAD.make_dual(
+                        torch.ones(1, device=device, dtype=dtype), inf_tangent
+                    ),
+                    fwAD.make_dual(
+                        torch.zeros(1, device=device, dtype=dtype), finite_tangent
+                    ),
+                )
+            ).tangent
+        self.assertEqual(fmax_tangent, [1.0])
+        self.assertEqual(fmin_tangent, [1.0])
 
     # TODO: tests like this should be generic
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
@@ -4820,9 +5059,26 @@ def generate_not_implemented_tests(cls):
 
 
 generate_not_implemented_tests(TestBinaryUfuncsDevice)
+
+
+class TestBinaryUfuncSubgradientsCPU(TestCase):
+    test_min_max_and_clamp_subgradient = (
+        TestBinaryUfuncsDevice.test_min_max_and_clamp_subgradient
+    )
+    test_min_max_and_clamp_forward_ad = (
+        TestBinaryUfuncsDevice.test_min_max_and_clamp_forward_ad
+    )
+    test_scalar_clamp_subgradient = TestBinaryUfuncsDevice.test_scalar_clamp_subgradient
+    test_tensor_clamp_subgradient = TestBinaryUfuncsDevice.test_tensor_clamp_subgradient
+    test_fmin_fmax_nan_subgradient = (
+        TestBinaryUfuncsDevice.test_fmin_fmax_nan_subgradient
+    )
+
+
 instantiate_device_type_tests(
     TestChebyshevNanPropagation, globals(), only_for=("cpu", "cuda")
 )
+instantiate_device_type_tests(TestBinaryUfuncSubgradientsCPU, globals(), only_for="cpu")
 instantiate_device_type_tests(
     TestBinaryUfuncsDevice, globals(), allow_xpu=True, except_for="cpu"
 )

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3623,26 +3623,28 @@ class TestBinaryUfuncsDevice(TestCase):
                     shift_left_expected,
                     msg=lambda msg: f"{msg}\n<< {shift}",
                 )
-                self.compare_with_numpy(
-                    lambda x: x << shift,
-                    lambda x: np.left_shift(x, shift),
-                    input,
-                    exact_dtype=exact_dtype,
-                    msg=f"<< {shift}",
-                )
+                if not (TEST_WITH_TORCHDYNAMO and shift < 0):
+                    self.compare_with_numpy(
+                        lambda x: x << shift,
+                        lambda x: np.left_shift(x, shift),
+                        input,
+                        exact_dtype=exact_dtype,
+                        msg=f"<< {shift}",
+                    )
                 shift_right = input >> shift
                 self.assertEqual(
                     shift_right,
                     shift_right_expected,
                     msg=lambda msg: f"{msg}\n>> {shift}",
                 )
-                self.compare_with_numpy(
-                    lambda x: x >> shift,
-                    lambda x: np.right_shift(x, shift),
-                    input,
-                    exact_dtype=exact_dtype,
-                    msg=f">> {shift}",
-                )
+                if not (TEST_WITH_TORCHDYNAMO and shift < 0):
+                    self.compare_with_numpy(
+                        lambda x: x >> shift,
+                        lambda x: np.right_shift(x, shift),
+                        input,
+                        exact_dtype=exact_dtype,
+                        msg=f">> {shift}",
+                    )
 
     @onlyNativeDeviceTypes
     @dtypes(

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8872,14 +8872,11 @@ BACKWARD_SKIPS_AND_XFAILS = [
         ),
         name="clone_wrong_nested_int_for_gradient",
     ),
-    # some min / max ops use masked_fill_ underneath sometimes, which isn't implemented
+    # copysign uses masked_fill_ underneath, which isn't implemented
     XFailRule(
         error_type=NotImplementedError,
         error_msg="aten.masked_fill_.Scalar",
-        op_match_fn=lambda device, op: (
-            op.full_name
-            in {"max.binary", "min.binary", "minimum", "maximum", "copysign"}
-        ),
+        op_match_fn=lambda device, op: op.full_name == "copysign",
         name="unimplemented_masked_fill",
     ),
     XFailRule(

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -427,7 +427,7 @@
   result: auto_element_wise
 
 - name: clamp_min(Tensor self, Scalar min) -> Tensor
-  self: where(self >= min, grad, at::scalar_tensor(0., grad.options()))
+  self: where(self > min, grad, at::scalar_tensor(0., grad.options()))
   result: auto_element_wise
 
 - name: clamp_min.Tensor(Tensor self, Tensor min) -> Tensor
@@ -436,7 +436,7 @@
   result: where(self_p >= min_p, self_t, min_t)
 
 - name: clamp_max(Tensor self, Scalar max) -> Tensor
-  self: where(self <= max, grad, at::scalar_tensor(0., grad.options()))
+  self: where(self < max, grad, at::scalar_tensor(0., grad.options()))
   result: auto_element_wise
 
 - name: clamp_max.Tensor(Tensor self, Tensor max) -> Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -431,8 +431,10 @@
   result: auto_element_wise
 
 - name: clamp_min.Tensor(Tensor self, Tensor min) -> Tensor
-  self: at::where(self == min, grad / 2, grad).masked_fill_(self < min, 0)
-  min: at::where(self == min, grad / 2, grad).masked_fill_(self > min, 0)
+  # Split ties first, then reuse the where output when transforms and tensor subclasses allow safe in-place masking.
+  self: masked_fill_inplace_if_safe(at::where(self == min, grad / 2, grad), (self >= min).logical_not_(), 0)
+  min: masked_fill_inplace_if_safe(at::where(self == min, grad / 2, grad), (self <= min).logical_not_(), 0)
+  # masked_fill_ cannot select the Tensor-valued min_t; use where to keep the JVP differentiable for higher-order AD.
   result: at::where(self_p == min_p, (self_t + min_t) / 2, at::where(self_p > min_p, self_t, min_t))
 
 - name: clamp_max(Tensor self, Scalar max) -> Tensor
@@ -440,8 +442,10 @@
   result: auto_element_wise
 
 - name: clamp_max.Tensor(Tensor self, Tensor max) -> Tensor
-  self: at::where(self == max, grad / 2, grad).masked_fill_(self > max, 0)
-  max: at::where(self == max, grad / 2, grad).masked_fill_(self < max, 0)
+  # Split ties first, then reuse the where output when transforms and tensor subclasses allow safe in-place masking.
+  self: masked_fill_inplace_if_safe(at::where(self == max, grad / 2, grad), (self <= max).logical_not_(), 0)
+  max: masked_fill_inplace_if_safe(at::where(self == max, grad / 2, grad), (self >= max).logical_not_(), 0)
+  # masked_fill_ cannot select the Tensor-valued max_t; use where to keep the JVP differentiable for higher-order AD.
   result: at::where(self_p == max_p, (self_t + max_t) / 2, at::where(self_p < max_p, self_t, max_t))
 
 - name: clone(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor
@@ -1132,11 +1136,14 @@
   result: evenly_read_jvp(self_t, self_p, result)
 
 - name: maximum(Tensor self, Tensor other) -> Tensor
-  self: at::where(self == other, grad / 2, grad).masked_fill_(self < other, 0)
-  other: at::where(self == other, grad / 2, grad).masked_fill_(self > other, 0)
-  result: other_t + at::where(self_p == other_p, at::scalar_tensor(0.5, result.options()), (self_p > other_p).to(result.scalar_type())) * (self_t - other_t)
+  # Reuse the tie-split output when transforms and tensor subclasses allow safe in-place masking.
+  self: masked_fill_inplace_if_safe(at::where(self == other, grad / 2, grad), self < other, 0)
+  other: masked_fill_inplace_if_safe(at::where(self == other, grad / 2, grad), self > other, 0)
+  # Do not blend tangents arithmetically: an inactive infinite tangent would produce 0 * inf = nan.
+  result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where(self_p > other_p, self_t, other_t))
 
 - name: fmax(Tensor self, Tensor other) -> Tensor
+  # Preserve fmax's NaN routing outside finite ties. Nested where avoids arithmetic with an inactive NaN or infinite tangent.
   self: at::where(self == other, grad / 2, grad.masked_fill((self >= other).logical_or_(other.isnan()).logical_not_(), 0))
   other: at::where(self == other, grad / 2, grad.masked_fill((self >= other).logical_or_(other.isnan()), 0))
   result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where((self_p > other_p).logical_or_(other_p.isnan()), self_t, other_t))
@@ -1194,11 +1201,14 @@
   result: evenly_read_jvp(self_t, self_p, result)
 
 - name: minimum(Tensor self, Tensor other) -> Tensor
-  self: at::where(self == other, grad / 2, grad).masked_fill_(self > other, 0)
-  other: at::where(self == other, grad / 2, grad).masked_fill_(self < other, 0)
-  result: other_t + at::where(self_p == other_p, at::scalar_tensor(0.5, result.options()), (self_p < other_p).to(result.scalar_type())) * (self_t - other_t)
+  # Reuse the tie-split output when transforms and tensor subclasses allow safe in-place masking.
+  self: masked_fill_inplace_if_safe(at::where(self == other, grad / 2, grad), self > other, 0)
+  other: masked_fill_inplace_if_safe(at::where(self == other, grad / 2, grad), self < other, 0)
+  # Do not blend tangents arithmetically: an inactive infinite tangent would produce 0 * inf = nan.
+  result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where(self_p < other_p, self_t, other_t))
 
 - name: fmin(Tensor self, Tensor other) -> Tensor
+  # Preserve fmin's NaN routing outside finite ties. Nested where avoids arithmetic with an inactive NaN or infinite tangent.
   self: at::where(self == other, grad / 2, grad.masked_fill((self <= other).logical_or_(other.isnan()).logical_not_(), 0))
   other: at::where(self == other, grad / 2, grad.masked_fill((self <= other).logical_or_(other.isnan()), 0))
   result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where((self_p < other_p).logical_or_(other_p.isnan()), self_t, other_t))

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -432,8 +432,8 @@
 
 - name: clamp_min.Tensor(Tensor self, Tensor min) -> Tensor
   # Split ties first, then reuse the where output when transforms and tensor subclasses allow safe in-place masking.
-  self: masked_fill_inplace_if_safe(at::where(self == min, grad / 2, grad), (self >= min).logical_not_(), 0)
-  min: masked_fill_inplace_if_safe(at::where(self == min, grad / 2, grad), (self <= min).logical_not_(), 0)
+  self: masked_fill_inplace_if_safe(at::where(self == min, grad / 2, grad), self < min, 0)
+  min: masked_fill_inplace_if_safe(at::where(self == min, grad / 2, grad), self > min, 0)
   # masked_fill_ cannot select the Tensor-valued min_t; use where to keep the JVP differentiable for higher-order AD.
   result: at::where(self_p == min_p, (self_t + min_t) / 2, at::where(self_p > min_p, self_t, min_t))
 
@@ -443,8 +443,8 @@
 
 - name: clamp_max.Tensor(Tensor self, Tensor max) -> Tensor
   # Split ties first, then reuse the where output when transforms and tensor subclasses allow safe in-place masking.
-  self: masked_fill_inplace_if_safe(at::where(self == max, grad / 2, grad), (self <= max).logical_not_(), 0)
-  max: masked_fill_inplace_if_safe(at::where(self == max, grad / 2, grad), (self >= max).logical_not_(), 0)
+  self: masked_fill_inplace_if_safe(at::where(self == max, grad / 2, grad), self > max, 0)
+  max: masked_fill_inplace_if_safe(at::where(self == max, grad / 2, grad), self < max, 0)
   # masked_fill_ cannot select the Tensor-valued max_t; use where to keep the JVP differentiable for higher-order AD.
   result: at::where(self_p == max_p, (self_t + max_t) / 2, at::where(self_p < max_p, self_t, max_t))
 
@@ -1143,10 +1143,11 @@
   result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where(self_p > other_p, self_t, other_t))
 
 - name: fmax(Tensor self, Tensor other) -> Tensor
-  # Preserve fmax's NaN routing outside finite ties. Nested where avoids arithmetic with an inactive NaN or infinite tangent.
-  self: at::where(self == other, grad / 2, grad.masked_fill((self >= other).logical_or_(other.isnan()).logical_not_(), 0))
-  other: at::where(self == other, grad / 2, grad.masked_fill((self >= other).logical_or_(other.isnan()), 0))
-  result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where((self_p > other_p).logical_or_(other_p.isnan()), self_t, other_t))
+  # Reuse the tie-split output when transforms and tensor subclasses allow safe in-place masking.
+  self: masked_fill_inplace_if_safe(at::where(self == other, grad / 2, grad), self < other, 0)
+  other: masked_fill_inplace_if_safe(at::where(self == other, grad / 2, grad), self > other, 0)
+  # Do not blend tangents arithmetically: an inactive NaN or infinite tangent must not contaminate the result.
+  result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where(self_p > other_p, self_t, other_t))
 
 - name: mean(Tensor self, *, ScalarType? dtype=None) -> Tensor
   dispatch:
@@ -1208,10 +1209,11 @@
   result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where(self_p < other_p, self_t, other_t))
 
 - name: fmin(Tensor self, Tensor other) -> Tensor
-  # Preserve fmin's NaN routing outside finite ties. Nested where avoids arithmetic with an inactive NaN or infinite tangent.
-  self: at::where(self == other, grad / 2, grad.masked_fill((self <= other).logical_or_(other.isnan()).logical_not_(), 0))
-  other: at::where(self == other, grad / 2, grad.masked_fill((self <= other).logical_or_(other.isnan()), 0))
-  result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where((self_p < other_p).logical_or_(other_p.isnan()), self_t, other_t))
+  # Reuse the tie-split output when transforms and tensor subclasses allow safe in-place masking.
+  self: masked_fill_inplace_if_safe(at::where(self == other, grad / 2, grad), self > other, 0)
+  other: masked_fill_inplace_if_safe(at::where(self == other, grad / 2, grad), self < other, 0)
+  # Do not blend tangents arithmetically: an inactive NaN or infinite tangent must not contaminate the result.
+  result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where(self_p < other_p, self_t, other_t))
 
 - name: amax(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
   self: scale_grad_by_count(restore_reduced_dims(grad, dim, keepdim), restore_reduced_dims(result, dim, keepdim) == self, dim)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -415,8 +415,8 @@
   self: cholesky_inverse_backward(grad, self, upper, result)
   result: cholesky_inverse_jvp(self_p, self_t, result, upper)
 
-# For clamp, gradient is not defined at the boundaries. But empirically it's helpful
-# to be able to get gradient on min and max, so we return the subgradient 1 for these cases.
+# Tensor-bound clamp treats its differentiable Tensor arguments jointly, so
+# ordinary boundary ties split the gradient evenly between the Tensor inputs.
 - name: clamp.Tensor(Tensor self, Tensor? min=None, Tensor? max=None) -> Tensor
   self: clamp_backward(grad, self, min, max)
   min, max: clamp_backward_min_max(grad, self, min, max, grad_input_mask)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -431,18 +431,18 @@
   result: auto_element_wise
 
 - name: clamp_min.Tensor(Tensor self, Tensor min) -> Tensor
-  self: where(self >= min, grad, at::scalar_tensor(0., grad.options()))
-  min: where(self < min, grad, at::scalar_tensor(0., grad.options()))
-  result: where(self_p >= min_p, self_t, min_t)
+  self: at::where(self == min, grad / 2, grad).masked_fill_(self < min, 0)
+  min: at::where(self == min, grad / 2, grad).masked_fill_(self > min, 0)
+  result: at::where(self_p == min_p, (self_t + min_t) / 2, at::where(self_p > min_p, self_t, min_t))
 
 - name: clamp_max(Tensor self, Scalar max) -> Tensor
   self: where(self < max, grad, at::scalar_tensor(0., grad.options()))
   result: auto_element_wise
 
 - name: clamp_max.Tensor(Tensor self, Tensor max) -> Tensor
-  self: where(self <= max, grad, at::scalar_tensor(0., grad.options()))
-  max: where(self > max, grad, at::scalar_tensor(0., grad.options()))
-  result: where(self_p <= max_p, self_t, max_t)
+  self: at::where(self == max, grad / 2, grad).masked_fill_(self > max, 0)
+  max: at::where(self == max, grad / 2, grad).masked_fill_(self < max, 0)
+  result: at::where(self_p == max_p, (self_t + max_t) / 2, at::where(self_p < max_p, self_t, max_t))
 
 - name: clone(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor
   self: grad
@@ -1137,9 +1137,9 @@
   result: other_t + at::where(self_p == other_p, at::scalar_tensor(0.5, result.options()), (self_p > other_p).to(result.scalar_type())) * (self_t - other_t)
 
 - name: fmax(Tensor self, Tensor other) -> Tensor
-  self: grad.masked_fill((self >= other).logical_or_(other.isnan()).logical_not_(), 0)
-  other: grad.masked_fill((self >= other).logical_or_(other.isnan()), 0)
-  result: other_t + (self_p > other_p).logical_or_(other_p.isnan()) * (self_t - other_t)
+  self: at::where(self == other, grad / 2, grad.masked_fill((self >= other).logical_or_(other.isnan()).logical_not_(), 0))
+  other: at::where(self == other, grad / 2, grad.masked_fill((self >= other).logical_or_(other.isnan()), 0))
+  result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where((self_p > other_p).logical_or_(other_p.isnan()), self_t, other_t))
 
 - name: mean(Tensor self, *, ScalarType? dtype=None) -> Tensor
   dispatch:
@@ -1199,9 +1199,9 @@
   result: other_t + at::where(self_p == other_p, at::scalar_tensor(0.5, result.options()), (self_p < other_p).to(result.scalar_type())) * (self_t - other_t)
 
 - name: fmin(Tensor self, Tensor other) -> Tensor
-  self: grad.masked_fill((self <= other).logical_or_(other.isnan()).logical_not_(), 0)
-  other: grad.masked_fill((self <= other).logical_or_(other.isnan()), 0)
-  result: other_t + (self_p <= other_p).logical_or_(other_p.isnan()) * (self_t - other_t)
+  self: at::where(self == other, grad / 2, grad.masked_fill((self <= other).logical_or_(other.isnan()).logical_not_(), 0))
+  other: at::where(self == other, grad / 2, grad.masked_fill((self <= other).logical_or_(other.isnan()), 0))
+  result: at::where(self_p == other_p, (self_t + other_t) / 2, at::where((self_p < other_p).logical_or_(other_p.isnan()), self_t, other_t))
 
 - name: amax(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
   self: scale_grad_by_count(restore_reduced_dims(grad, dim, keepdim), restore_reduced_dims(result, dim, keepdim) == self, dim)

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1469,22 +1469,18 @@ Tensor clamp_backward(
     const Tensor& max) {
   if (max.defined() && min.defined()) {
     const auto min_lt_max = min < max;
-    const auto min_eq_max = min == max;
     const auto tie =
         ((self == min).logical_or(self == max)).logical_and(min_lt_max);
-    const auto active = min_lt_max.logical_and(self >= min)
-                            .logical_and(self <= max)
-                            .logical_or(min_eq_max.logical_and(self == min));
-    // Reuse the tie-split output when zeroing inactive entries. The explicit
-    // active mask also makes NaNs inactive and handles equal/reversed bounds.
-    return masked_fill_inplace_if_safe(
-        where(tie, grad / 2, grad), active.logical_not(), 0);
+    const auto inactive = (self < min).logical_or(self > max);
+    // The same strict losing-side mask handles ordered, equal, and reversed
+    // finite bounds.
+    return masked_fill_inplace_if_safe(where(tie, grad / 2, grad), inactive, 0);
   } else if (min.defined()) {
     return masked_fill_inplace_if_safe(
-        where(self == min, grad / 2, grad), (self >= min).logical_not_(), 0);
+        where(self == min, grad / 2, grad), self < min, 0);
   } else if (max.defined()) {
     return masked_fill_inplace_if_safe(
-        where(self == max, grad / 2, grad), (self <= max).logical_not_(), 0);
+        where(self == max, grad / 2, grad), self > max, 0);
   } else {
     return grad;
   }
@@ -1527,10 +1523,10 @@ std::tuple<at::Tensor, at::Tensor> clamp_backward_min_max(
     }
   } else if (min.defined() && grad_input_mask[0]) {
     std::get<0>(ret) = masked_fill_inplace_if_safe(
-        where(self == min, grad / 2, grad), (self <= min).logical_not_(), 0);
+        where(self == min, grad / 2, grad), self > min, 0);
   } else if (max.defined() && grad_input_mask[1]) {
     std::get<1>(ret) = masked_fill_inplace_if_safe(
-        where(self == max, grad / 2, grad), (self >= max).logical_not_(), 0);
+        where(self == max, grad / 2, grad), self < max, 0);
   }
   return ret;
 }

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -87,6 +87,7 @@ void update_wrapped_number(Tensor& input, Tensor& output) {
   }
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 void copy_range(variable_list& out, IndexRange range, const Tensor& t) {
   TORCH_CHECK(range.second <= out.size());
   TORCH_CHECK(
@@ -94,6 +95,7 @@ void copy_range(variable_list& out, IndexRange range, const Tensor& t) {
   out[range.first] = t;
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 void copy_range(variable_list& out, IndexRange range, at::ArrayRef<Tensor> t) {
   TORCH_CHECK(range.second <= out.size());
   TORCH_CHECK(
@@ -128,6 +130,7 @@ Tensor not_implemented(const char* name, const char* reason) {
   return not_implemented_base<Tensor>(name, reason);
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 std::vector<Tensor> not_implemented_list(const char* name, const char* reason) {
   return not_implemented_base<std::vector<Tensor>>(name, reason);
 }
@@ -623,6 +626,7 @@ Tensor _nested_from_padded_backward(
   return grad.to_padded_tensor(0, input.sizes());
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 std::tuple<Tensor, Tensor, Tensor> linear_double_backward(
     const variable_list& grads,
     const Tensor& self,
@@ -714,6 +718,7 @@ Tensor pow_backward(Tensor grad, const Tensor& self, const Scalar& exponent) {
     return pow_backward_self(
         grad, self, at::scalar_tensor(exponent, self.options()));
   }
+  // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   if (exponent.equal(0.0)) {
     return at::zeros_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   } else {
@@ -782,6 +787,7 @@ Tensor pow_backward_exponent(
   auto base_ = at::isComplexType(promoted_dtype)
       ? Scalar(base.toComplexDouble())
       : Scalar(base.toDouble());
+  // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   if (base.equal(0.0)) {
     auto cond = [](const auto& exp) {
       if (exp.is_complex()) {
@@ -854,6 +860,7 @@ template Tensor mul_tensor_backward(const Tensor&, const Tensor&, ScalarType);
 template Tensor mul_tensor_backward(const Tensor&, const Scalar&, ScalarType);
 
 template <typename T>
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 Tensor div_tensor_self_backward(
     const Tensor& grad,
     const T& other,
@@ -877,6 +884,7 @@ template Tensor div_tensor_self_backward(
     ScalarType,
     const std::optional<std::string_view>&);
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 Tensor div_tensor_other_backward(
     const Tensor& grad,
     const Tensor& self,
@@ -979,7 +987,7 @@ Tensor mean_backward(
     const Tensor& grad,
     c10::SymIntArrayRef shape,
     OptionalIntArrayRef opt_dim,
-    c10::SymInt numel,
+    const c10::SymInt& numel,
     bool keepdim) {
   bool is_all_reduce = !opt_dim.has_value() || opt_dim.value().empty();
   auto n =
@@ -987,6 +995,7 @@ Tensor mean_backward(
   return sum_backward(grad, shape, opt_dim, keepdim) / std::move(n);
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 std::vector<c10::SymInt> reverse_list_symint(const c10::SymIntArrayRef list) {
   auto result = std::vector<c10::SymInt>();
   result.reserve(list.size());
@@ -997,6 +1006,7 @@ std::vector<c10::SymInt> reverse_list_symint(const c10::SymIntArrayRef list) {
   return result;
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 std::vector<int64_t> reverse_list(const IntArrayRef list) {
   auto result = std::vector<int64_t>();
   result.reserve(list.size());
@@ -1188,6 +1198,7 @@ Tensor logcumsumexp_jvp(
   // NB: for simplicity, we recompute some values that can be reused from
   // forward
   auto self_p_exp = [&self_p, dim]() {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (!at::is_complex(self_p)) {
       return (self_p - std::get<0>(at::max(self_p, dim, true)))
           .exp(); // Use the exp-normalize trick
@@ -1214,6 +1225,7 @@ Tensor logcumsumexp_jvp(
   }
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 Tensor unbind_backward(const variable_list& grads, int64_t dim) {
   c10::SymIntArrayRef sizes;
   at::TensorOptions o;
@@ -1232,6 +1244,7 @@ Tensor unbind_backward(const variable_list& grads, int64_t dim) {
   return at::stack(grads_tensors, dim);
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 Tensor unbind_backward_nested(
     const variable_list& grads,
     const Tensor& nt_sizes,
@@ -1253,6 +1266,7 @@ Tensor unbind_backward_nested(
   return at::_nested_tensor_from_tensor_list(grads_tensors);
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 Tensor unbind_backward_nested_jagged(
     const variable_list& grads,
     const Tensor& self,
@@ -1305,6 +1319,7 @@ Tensor unsqueeze_to(
   return unsqueeze_to(self, IntArrayRef{dim}, sym_sizes);
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 std::vector<Tensor> cat_tensors_backward(
     const Tensor& grad,
     const std::vector<std::vector<c10::SymInt>>& sizes,
@@ -1345,6 +1360,7 @@ std::vector<Tensor> cat_tensors_backward(
   return grad_inputs;
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 std::vector<Tensor> stack_tensors_backward(
     const Tensor& grad,
     int64_t dim,
@@ -1364,6 +1380,7 @@ std::vector<Tensor> stack_tensors_backward(
   return grad_inputs;
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 std::vector<Tensor> block_diag_backward(
     const Tensor& grad,
     const std::vector<std::vector<int64_t>>& sizes,
@@ -1971,6 +1988,7 @@ Tensor renorm_jvp(
   auto dtype = self_p.scalar_type();
   auto acc_type = at::toAccumulateType(dtype, /*is_cuda=*/true);
   Tensor norm = [&self_p, &p, &reduce_dims, acc_type, dtype]() {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (acc_type != dtype) {
       return at::linalg_vector_norm(
           self_p,
@@ -2406,6 +2424,7 @@ Tensor pinv_backward(const Tensor& grad, const Tensor& pinvA, const Tensor& A) {
   }
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 Tensor chunk_backward_nested(
     const std::vector<torch::autograd::Variable>& grads,
     const Tensor& self,
@@ -2425,6 +2444,7 @@ Tensor chunk_backward_nested(
   return ret;
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 Tensor split_with_sizes_backward(
     const std::vector<torch::autograd::Variable>& grads,
     c10::SymIntArrayRef split_sizes,
@@ -2451,6 +2471,7 @@ Tensor split_with_sizes_backward(
   return ret;
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 Tensor _nested_split_with_sizes_backward(
     const std::vector<torch::autograd::Variable>& grads,
     c10::SymIntArrayRef split_sizes,
@@ -2486,6 +2507,7 @@ Tensor _nested_split_with_sizes_backward(
   return ret;
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 Tensor split_backward(
     const std::vector<torch::autograd::Variable>& grads,
     const c10::SymInt& split_size,
@@ -3429,7 +3451,7 @@ static bool _maybe_overlapping_memory(
 static c10::SymInt _min_storage_size(
     c10::SymIntArrayRef sizes,
     c10::SymIntArrayRef strides,
-    c10::SymInt storage_offset) {
+    const c10::SymInt& storage_offset) {
   c10::SymInt storage_size = storage_offset + 1;
   auto dim = sizes.size();
   for (const auto i : c10::irange(dim)) {
@@ -3692,7 +3714,7 @@ Tensor slice_backward_wrapper(
     int64_t dim,
     std::optional<c10::SymInt> start,
     std::optional<c10::SymInt> end,
-    c10::SymInt step) {
+    const c10::SymInt& step) {
   auto start_val = start.has_value() ? start.value() : 0;
   auto end_val = end.has_value() ? end.value() : INT64_MAX;
 
@@ -3989,6 +4011,7 @@ Tensor svd_backward(
       }();
 
       if (gU.defined()) {
+        // NOLINTNEXTLINE(bugprone-branch-clone)
         if (gVh.defined()) {
           return (UhgU * S.unsqueeze(-2) + S.unsqueeze(-1) * VhgV) / E;
         } else {
@@ -4164,6 +4187,7 @@ std::tuple<Tensor, Tensor> linalg_eig_jvp(
       return ret;
     }();
 
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (is_hermitian) {
       return dX;
     } else {
@@ -5682,6 +5706,7 @@ Tensor embedding_dense_double_backward_symint(
   return gg_weight.view(size);
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 Tensor index_backward(
     Tensor zeros_like_self,
     const torch::List<std::optional<Tensor>>& indices,
@@ -5717,6 +5742,7 @@ Tensor _miopen_ctc_loss_backward(
   return _cudnn_ctc_loss_backward(grad_out, loss, raw_grad, zero_infinity);
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 bool any_variable_defined(const variable_list& variables) {
   for (const auto& variable : variables) {
     if (variable.defined()) {
@@ -7343,6 +7369,7 @@ Tensor lu_factor_ex_jvp(
 
   auto m = dA.size(-2);
   auto n = dA.size(-1);
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   if (m >= n) {
     dL.narrow(-2, 0, n).add_(dU);
     return dL;
@@ -7360,6 +7387,7 @@ Tensor logsumexp_jvp(
   // NB: for simplicity, we recompute some values that can be reused from
   // forward
   auto self_p_exp = [&self_p, &dim]() {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (self_p.sym_numel() > 0) {
       // Use only the real part for complex tensors
       return (self_p - at::amax(at::real(self_p), dim, true))
@@ -7422,7 +7450,7 @@ std::tuple<Tensor, Tensor> _cudnn_convolution_backward(
     at::SymIntArrayRef stride,
     at::SymIntArrayRef dilation,
     bool transposed,
-    c10::SymInt groups,
+    const c10::SymInt& groups,
     ::std::array<bool, 2> output_mask) {
   if (!grad_output.defined()) {
     return std::tuple<Tensor, Tensor>();
@@ -7837,7 +7865,7 @@ Tensor values_backward(const Tensor& grad, const Tensor& self) {
           grad,
           self.sym_sizes(),
           self.options(),
-          /*is_coalesced=*/true);
+          /*is_coalesced=*/true); // NOLINT(bugprone-argument-comment)
     } else if (at::sparse_csr::is_sparse_compressed(self)) {
       auto [compressed_indices, plain_indices] =
           at::sparse_csr::getCompressedPlainIndices(self);

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -848,6 +848,15 @@ Tensor masked_fill_backward(const Tensor& grad, const Tensor& mask) {
       : grad.masked_select(mask).sum();
 }
 
+Tensor masked_fill_inplace_if_safe(
+    Tensor tensor,
+    const Tensor& mask,
+    const Scalar& value) {
+  return areAnyTensorSubclassLike({tensor, mask})
+      ? tensor.masked_fill(mask, value)
+      : tensor.masked_fill_(mask, value);
+}
+
 template <typename T>
 Tensor mul_tensor_backward(
     const Tensor& grad,
@@ -990,8 +999,7 @@ Tensor mean_backward(
     const c10::SymInt& numel,
     bool keepdim) {
   bool is_all_reduce = !opt_dim.has_value() || opt_dim.value().empty();
-  auto n =
-      is_all_reduce ? std::move(numel) : _safe_size(shape, opt_dim.value());
+  auto n = is_all_reduce ? numel : _safe_size(shape, opt_dim.value());
   return sum_backward(grad, shape, opt_dim, keepdim) / std::move(n);
 }
 
@@ -1460,21 +1468,23 @@ Tensor clamp_backward(
     const Tensor& min,
     const Tensor& max) {
   if (max.defined() && min.defined()) {
-    auto zero = at::scalar_tensor(0., grad.options());
     const auto min_lt_max = min < max;
     const auto min_eq_max = min == max;
-    const auto interior = (self > min).logical_and(self < max);
     const auto tie =
         ((self == min).logical_or(self == max)).logical_and(min_lt_max);
-    const auto degenerate_tie = (self == min).logical_and(min_eq_max);
-    return where(
-        interior.logical_or(degenerate_tie), grad, where(tie, grad / 2, zero));
+    const auto active = min_lt_max.logical_and(self >= min)
+                            .logical_and(self <= max)
+                            .logical_or(min_eq_max.logical_and(self == min));
+    // Reuse the tie-split output when zeroing inactive entries. The explicit
+    // active mask also makes NaNs inactive and handles equal/reversed bounds.
+    return masked_fill_inplace_if_safe(
+        where(tie, grad / 2, grad), active.logical_not(), 0);
   } else if (min.defined()) {
-    auto zero = at::scalar_tensor(0., grad.options());
-    return where(self > min, grad, where(self == min, grad / 2, zero));
+    return masked_fill_inplace_if_safe(
+        where(self == min, grad / 2, grad), (self >= min).logical_not_(), 0);
   } else if (max.defined()) {
-    auto zero = at::scalar_tensor(0., grad.options());
-    return where(self < max, grad, where(self == max, grad / 2, zero));
+    return masked_fill_inplace_if_safe(
+        where(self == max, grad / 2, grad), (self <= max).logical_not_(), 0);
   } else {
     return grad;
   }
@@ -1492,35 +1502,35 @@ std::tuple<at::Tensor, at::Tensor> clamp_backward_min_max(
     return ret;
   }
 
-  auto zero = at::scalar_tensor(0., grad.options());
   if (max.defined() && min.defined()) {
+    const auto min_lt_max = min < max;
+    const auto min_eq_max = min == max;
     if (grad_input_mask[0]) {
-      const auto self_lt_min = self < min;
-      const auto min_lt_max = min < max;
-      const auto self_eq_min = self == min;
-      std::get<0>(ret) = where(
-          min_lt_max,
-          where(self_lt_min, grad, where(self_eq_min, grad / 2, zero)),
-          where((min == max).logical_and(self_lt_min), grad, zero));
+      const auto active = min_lt_max.logical_and(self <= min)
+                              .logical_or(min_eq_max.logical_and(self < min));
+      // min is active below its bound, splits ordinary ties, is inactive at
+      // equal bounds, and is inactive everywhere for reversed bounds.
+      std::get<0>(ret) = masked_fill_inplace_if_safe(
+          where(self == min, grad / 2, grad), active.logical_not(), 0);
     }
     if (grad_input_mask[1]) {
-      const auto self_gt_max = self > max;
       const auto max_lt_min = max < min;
-      const auto self_eq_max = self == max;
-      std::get<1>(ret) = where(
-          max_lt_min,
-          grad,
-          where(
-              min < max,
-              where(self_gt_max, grad, where(self_eq_max, grad / 2, zero)),
-              where(self_gt_max, grad, zero)));
+      const auto active =
+          max_lt_min.logical_or(min_lt_max.logical_and(self >= max))
+              .logical_or(min_eq_max.logical_and(self > max));
+      // max receives the whole gradient for reversed bounds, splits only
+      // ordinary ties, and is inactive at equality when both bounds are equal.
+      std::get<1>(ret) = masked_fill_inplace_if_safe(
+          where((self == max).logical_and(min_lt_max), grad / 2, grad),
+          active.logical_not(),
+          0);
     }
   } else if (min.defined() && grad_input_mask[0]) {
-    std::get<0>(ret) =
-        where(self < min, grad, where(self == min, grad / 2, zero));
+    std::get<0>(ret) = masked_fill_inplace_if_safe(
+        where(self == min, grad / 2, grad), (self <= min).logical_not_(), 0);
   } else if (max.defined() && grad_input_mask[1]) {
-    std::get<1>(ret) =
-        where(self > max, grad, where(self == max, grad / 2, zero));
+    std::get<1>(ret) = masked_fill_inplace_if_safe(
+        where(self == max, grad / 2, grad), (self >= max).logical_not_(), 0);
   }
   return ret;
 }
@@ -1533,24 +1543,28 @@ at::Tensor clamp_jvp(
     const Tensor& max_p,
     const Tensor& max_t) {
   if (min_p.defined() && max_p.defined()) {
-    return where(
-        min_p > max_p,
-        max_t,
-        where(
-            min_p == max_p,
-            where(self_p < min_p, min_t, where(self_p > max_p, max_t, self_t)),
-            where(
-                self_p < min_p,
-                min_t,
-                where(
-                    self_p == min_p,
-                    (self_t + min_t) / 2,
-                    where(
-                        self_p > max_p,
-                        max_t,
-                        where(
-                            self_p == max_p, (self_t + max_t) / 2, self_t))))));
+    // Build the common selection first, then adjust ordinary ties. This uses
+    // five full-tensor where passes instead of eagerly evaluating eight nested
+    // branches. These cannot use masked_fill_ because every selected value is
+    // a Tensor tangent, and where_out would break higher-order autograd. Equal
+    // bounds retain self_t at equality, while reversed bounds select max_t
+    // everywhere to match the forward operation.
+    auto result = where(self_p < min_p, min_t, self_t);
+    result = where(self_p > max_p, max_t, result);
+    const auto ordered_bounds = min_p < max_p;
+    result = where(
+        ordered_bounds.logical_and(self_p == min_p),
+        (self_t + min_t) / 2,
+        result);
+    result = where(
+        ordered_bounds.logical_and(self_p == max_p),
+        (self_t + max_t) / 2,
+        result);
+    return where(min_p > max_p, max_t, result);
   } else if (min_p.defined()) {
+    // Both non-tie branches select Tensor tangents, so scalar-only
+    // masked_fill_ cannot replace either where without losing
+    // differentiability.
     return where(
         self_p == min_p,
         (self_t + min_t) / 2,
@@ -3719,12 +3733,7 @@ Tensor slice_backward_wrapper(
   auto end_val = end.has_value() ? end.value() : INT64_MAX;
 
   return slice_backward_symint(
-      grad,
-      input_sizes,
-      dim,
-      std::move(start_val),
-      std::move(end_val),
-      std::move(step));
+      grad, input_sizes, dim, std::move(start_val), std::move(end_val), step);
 }
 
 std::tuple<Tensor, Tensor, Tensor> linalg_svd_jvp(
@@ -7468,7 +7477,7 @@ std::tuple<Tensor, Tensor> _cudnn_convolution_backward(
           dilation,
           transposed,
           output_padding,
-          std::move(groups),
+          groups,
           {output_mask[0], output_mask[1], false});
   return std::make_tuple(
       std::move(std::get<0>(grad_inputs)), std::move(std::get<1>(grad_inputs)));

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1423,17 +1423,15 @@ Tensor clamp_backward(
     const Tensor& self,
     const std::optional<Scalar>& min,
     const std::optional<Scalar>& max) {
-  // clamp: gradients not defined on min and max, so we return the subgradient 1
-  // for these cases.
   if (max && min) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where((self >= *min).logical_and_(self <= *max), grad, zero);
+    return where((self > *min).logical_and_(self < *max), grad, zero);
   } else if (min) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where(self >= *min, grad, zero);
+    return where(self > *min, grad, zero);
   } else if (max) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where(self <= *max, grad, zero);
+    return where(self < *max, grad, zero);
   } else {
     return grad;
   }
@@ -1444,22 +1442,22 @@ Tensor clamp_backward(
     const Tensor& self,
     const Tensor& min,
     const Tensor& max) {
-  // clamp: gradients not defined on min and max, so we return the subgradient 1
-  // for these cases.
   if (max.defined() && min.defined()) {
     auto zero = at::scalar_tensor(0., grad.options());
-    const auto self_ge_min = self >= min;
-    const auto self_le_max = self <= max;
-    const auto& pred = areAnyTensorSubclassLike({self, min, max})
-        ? self_ge_min.logical_and(self_le_max)
-        : self_ge_min.logical_and_(self_le_max);
-    return where(pred, grad, zero);
+    const auto min_lt_max = min < max;
+    const auto min_eq_max = min == max;
+    const auto interior = (self > min).logical_and(self < max);
+    const auto tie =
+        ((self == min).logical_or(self == max)).logical_and(min_lt_max);
+    const auto degenerate_tie = (self == min).logical_and(min_eq_max);
+    return where(
+        interior.logical_or(degenerate_tie), grad, where(tie, grad / 2, zero));
   } else if (min.defined()) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where(self >= min, grad, zero);
+    return where(self > min, grad, where(self == min, grad / 2, zero));
   } else if (max.defined()) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where(self <= max, grad, zero);
+    return where(self < max, grad, where(self == max, grad / 2, zero));
   } else {
     return grad;
   }
@@ -1482,23 +1480,30 @@ std::tuple<at::Tensor, at::Tensor> clamp_backward_min_max(
     if (grad_input_mask[0]) {
       const auto self_lt_min = self < min;
       const auto min_lt_max = min < max;
-      const auto& pred = areAnyTensorSubclassLike({self, min, max})
-          ? self_lt_min.logical_and(min_lt_max)
-          : self_lt_min.logical_and_(min_lt_max);
-      std::get<0>(ret) = where(pred, grad, zero);
+      const auto self_eq_min = self == min;
+      std::get<0>(ret) = where(
+          min_lt_max,
+          where(self_lt_min, grad, where(self_eq_min, grad / 2, zero)),
+          where((min == max).logical_and(self_lt_min), grad, zero));
     }
     if (grad_input_mask[1]) {
       const auto self_gt_max = self > max;
       const auto max_lt_min = max < min;
-      const auto& pred = areAnyTensorSubclassLike({self, min, max})
-          ? self_gt_max.logical_or(max_lt_min)
-          : self_gt_max.logical_or_(max_lt_min);
-      std::get<1>(ret) = where(pred, grad, zero);
+      const auto self_eq_max = self == max;
+      std::get<1>(ret) = where(
+          max_lt_min,
+          grad,
+          where(
+              min < max,
+              where(self_gt_max, grad, where(self_eq_max, grad / 2, zero)),
+              where(self_gt_max, grad, zero)));
     }
   } else if (min.defined() && grad_input_mask[0]) {
-    std::get<0>(ret) = where(self < min, grad, zero);
+    std::get<0>(ret) =
+        where(self < min, grad, where(self == min, grad / 2, zero));
   } else if (max.defined() && grad_input_mask[1]) {
-    std::get<1>(ret) = where(self > max, grad, zero);
+    std::get<1>(ret) =
+        where(self > max, grad, where(self == max, grad / 2, zero));
   }
   return ret;
 }
@@ -1514,11 +1519,30 @@ at::Tensor clamp_jvp(
     return where(
         min_p > max_p,
         max_t,
-        where(self_p < min_p, min_t, where(self_p > max_p, max_t, self_t)));
+        where(
+            min_p == max_p,
+            where(self_p < min_p, min_t, where(self_p > max_p, max_t, self_t)),
+            where(
+                self_p < min_p,
+                min_t,
+                where(
+                    self_p == min_p,
+                    (self_t + min_t) / 2,
+                    where(
+                        self_p > max_p,
+                        max_t,
+                        where(
+                            self_p == max_p, (self_t + max_t) / 2, self_t))))));
   } else if (min_p.defined()) {
-    return where(self_p > min_p, self_t, min_t);
+    return where(
+        self_p == min_p,
+        (self_t + min_t) / 2,
+        where(self_p > min_p, self_t, min_t));
   } else if (max_p.defined()) {
-    return where(self_p < max_p, self_t, max_t);
+    return where(
+        self_p == max_p,
+        (self_t + max_t) / 2,
+        where(self_p < max_p, self_t, max_t));
   } else {
     return self_t;
   }

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -381,6 +381,10 @@ at::Tensor evenly_distribute_backward(
     const at::Tensor& value);
 Tensor sgn_backward(const Tensor& x, const Tensor& gx, const Tensor& sgn);
 Tensor masked_fill_backward(const Tensor& grad, const Tensor& mask);
+Tensor masked_fill_inplace_if_safe(
+    Tensor tensor,
+    const Tensor& mask,
+    const Scalar& value);
 at::Tensor var_backward(
     at::Tensor grad,
     const at::Tensor& self,

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -405,7 +405,7 @@ Tensor mean_backward(
     const Tensor& grad,
     c10::SymIntArrayRef shape,
     at::OptionalIntArrayRef opt_dim,
-    c10::SymInt numel,
+    const c10::SymInt& numel,
     bool keepdim);
 Tensor var_mean_backward(
     const Tensor& gvar,
@@ -641,7 +641,7 @@ Tensor slice_backward_wrapper(
     int64_t dim,
     std::optional<c10::SymInt> start,
     std::optional<c10::SymInt> end,
-    c10::SymInt step);
+    const c10::SymInt& step);
 std::tuple<Tensor, Tensor> linalg_eig_jvp(
     const Tensor& dA,
     const Tensor& L,
@@ -1129,7 +1129,7 @@ std::tuple<Tensor, Tensor> _cudnn_convolution_backward(
     at::SymIntArrayRef stride,
     at::SymIntArrayRef dilation,
     bool transposed,
-    c10::SymInt groups,
+    const c10::SymInt& groups,
     ::std::array<bool, 2> output_mask);
 
 Tensor scatter_reduce_jvp(


### PR DESCRIPTION
## Author Notes

Fix for https://github.com/pytorch/pytorch/issues/184572 and supersedes https://github.com/pytorch/pytorch/pull/185831. Taking it over as the changes are quite involved. Tried to document everything and then apply the corresponding changes. You can skip the clang-tidy-only commit, which is just clang-tidy being annoying because this file was touched (trying to figure that out on the side, as Richard was also complaining about it).

## Agent Notes

> AI-generated summary:
>
> Defines nonsmooth autograd policy in terms of the selected dispatcher schema, preserves Raj Firke's ownership of the changes from #185831, and aligns Scalar-bound and Tensor-bound clamp, min/max, fmin, and fmax derivatives for backward and forward AD. It adds generic coverage for boundary, broadcasting, alias, NaN, equal-bound, and reversed-bound behavior.
>
> The documentation also explains Python Tensor/Scalar overload resolution and the compatibility allowlist for wrapping Python numbers as zero-dimensional tensors.
>
> Validation:
>
> - `BUILD_CONFIG spin develop`
> - Focused forward- and reverse-AD tests
> - Full `spin lint`


cc @ezyang @gchanan