### PR TITLE
[Dynamo] Extend lazy constant ops to bitwise and comparisons

### DIFF
--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -565,6 +565,16 @@ class ComputedLazyConstantTests(TestCase):
             (lambda t, a, b: (t.sin(), a - b), [(t, 5, 2), (t, 9, 3)]),
             (lambda t, a, b: (t.sin(), a * b), [(t, 5, 2), (t, 9, 3)]),
             (lambda t, a, b: (t.sin(), a + b), [(t, "x", "y"), (t, "p", "q")]),
+            (lambda t, a, b: (t.sin(), a & b), [(t, 6, 3), (t, 12, 10)]),
+            (lambda t, a, b: (t.sin(), a | b), [(t, 6, 3), (t, 12, 10)]),
+            (lambda t, a, b: (t.sin(), a ^ b), [(t, 6, 3), (t, 12, 10)]),
+            (lambda t, a, b: (t.sin(), a == b), [(t, 1, 1), (t, 1, 2)]),
+            (lambda t, a, b: (t.sin(), a != b), [(t, 1, 1), (t, 1, 2)]),
+            (lambda t, a, b: (t.sin(), a < b), [(t, 1, 2), (t, 3, 2)]),
+            (lambda t, a, b: (t.sin(), a <= b), [(t, 1, 2), (t, 3, 2)]),
+            (lambda t, a, b: (t.sin(), a > b), [(t, 1, 2), (t, 3, 2)]),
+            (lambda t, a, b: (t.sin(), a >= b), [(t, 1, 2), (t, 3, 2)]),
+            (lambda t, a, b: (t.sin(), a < b), [(t, "x", "y"), (t, "p", "q")]),
         ]
         for i, (fn, arg_sets) in enumerate(cases):
             with self.subTest(case=i):
@@ -580,6 +590,15 @@ class ComputedLazyConstantTests(TestCase):
 
         self._check(fn, [(t, 1, 2), (t, 3, 4)], expected_frames=1)
 
+    def test_unused_computed_inplace_bitwise_does_not_recompile(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            a &= b
+            return t.sin(), a
+
+        self._check(fn, [(t, 6, 3), (t, 12, 10)], expected_frames=1)
+
     def test_unused_division_recompiles(self):
         t = torch.ones(2)
 
@@ -587,6 +606,29 @@ class ComputedLazyConstantTests(TestCase):
             return t.sin(), a / b
 
         self._check(fn, [(t, 4, 2), (t, 9, 3)], expected_frames=2)
+
+    def test_unused_comparison_does_not_recompile(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            return t.sin(), a + 1 == b
+
+        self._check(fn, [(t, 1, 2), (t, 3, 4), (t, 5, 0)], expected_frames=1)
+
+    @torch._dynamo.config.patch(specialize_int=False, assume_static_by_default=False)
+    def test_bitwise_symbolic_operand_realizes(self):
+        t = torch.ones(3)
+        cases = [
+            ("and", lambda t, a, b: t * (a & b)),
+            ("or", lambda t, a, b: t * (a | b)),
+            ("xor", lambda t, a, b: t * (a ^ b)),
+        ]
+        for name, fn in cases:
+            with self.subTest(name=name):
+                torch._dynamo.reset()
+                opt_fn = torch.compile(fn, backend="eager")
+                for a, b in ((6, 3), (12, 10)):
+                    self.assertTrue(same(fn(t, a, b), opt_fn(t, a, b)))
 
     def test_operand_type_change_recompiles(self):
         t = torch.ones(2)

--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -564,6 +564,16 @@ class ComputedLazyConstantTests(TestCase):
             (lambda t, a, b: (t.sin(), a - b), [(t, 5, 2), (t, 9, 3)]),
             (lambda t, a, b: (t.sin(), a * b), [(t, 5, 2), (t, 9, 3)]),
             (lambda t, a, b: (t.sin(), a + b), [(t, "x", "y"), (t, "p", "q")]),
+            (lambda t, a, b: (t.sin(), a & b), [(t, 6, 3), (t, 12, 10)]),
+            (lambda t, a, b: (t.sin(), a | b), [(t, 6, 3), (t, 12, 10)]),
+            (lambda t, a, b: (t.sin(), a ^ b), [(t, 6, 3), (t, 12, 10)]),
+            (lambda t, a, b: (t.sin(), a == b), [(t, 1, 1), (t, 1, 2)]),
+            (lambda t, a, b: (t.sin(), a != b), [(t, 1, 1), (t, 1, 2)]),
+            (lambda t, a, b: (t.sin(), a < b), [(t, 1, 2), (t, 3, 2)]),
+            (lambda t, a, b: (t.sin(), a <= b), [(t, 1, 2), (t, 3, 2)]),
+            (lambda t, a, b: (t.sin(), a > b), [(t, 1, 2), (t, 3, 2)]),
+            (lambda t, a, b: (t.sin(), a >= b), [(t, 1, 2), (t, 3, 2)]),
+            (lambda t, a, b: (t.sin(), a < b), [(t, "x", "y"), (t, "p", "q")]),
         ]
         for i, (fn, arg_sets) in enumerate(cases):
             with self.subTest(case=i):
@@ -579,6 +589,15 @@ class ComputedLazyConstantTests(TestCase):
 
         self._check(fn, [(t, 1, 2), (t, 3, 4)], expected_frames=1)
 
+    def test_unused_computed_inplace_bitwise_does_not_recompile(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            a &= b
+            return t.sin(), a
+
+        self._check(fn, [(t, 6, 3), (t, 12, 10)], expected_frames=1)
+
     def test_unused_division_recompiles(self):
         t = torch.ones(2)
 
@@ -586,6 +605,29 @@ class ComputedLazyConstantTests(TestCase):
             return t.sin(), a / b
 
         self._check(fn, [(t, 4, 2), (t, 9, 3)], expected_frames=2)
+
+    def test_unused_comparison_does_not_recompile(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            return t.sin(), a + 1 == b
+
+        self._check(fn, [(t, 1, 2), (t, 3, 4), (t, 5, 0)], expected_frames=1)
+
+    @torch._dynamo.config.patch(specialize_int=False, assume_static_by_default=False)
+    def test_bitwise_symbolic_operand_realizes(self):
+        t = torch.ones(3)
+        cases = [
+            ("and", lambda t, a, b: t * (a & b)),
+            ("or", lambda t, a, b: t * (a | b)),
+            ("xor", lambda t, a, b: t * (a ^ b)),
+        ]
+        for name, fn in cases:
+            with self.subTest(name=name):
+                torch._dynamo.reset()
+                opt_fn = torch.compile(fn, backend="eager")
+                for a, b in ((6, 3), (12, 10)):
+                    self.assertTrue(same(fn(t, a, b), opt_fn(t, a, b)))
 
     def test_operand_type_change_recompiles(self):
         t = torch.ones(2)

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -277,11 +277,21 @@ BUILTIN_TO_TENSOR_RFN_MAP: dict[Callable[..., Any], Callable[..., Any]] = {}
 # opt-out).
 _MISSING_SENTINEL = object()
 
+# Runtime-raising ops (e.g. truediv) excluded: recompute escapes traced handlers
 _COMPUTED_LAZY_CONSTANT_OPS: frozenset[Callable[..., Any]] = frozenset(
     [
         operator.add,
         operator.sub,
         operator.mul,
+        operator.and_,
+        operator.or_,
+        operator.xor,
+        operator.eq,
+        operator.ne,
+        operator.lt,
+        operator.le,
+        operator.gt,
+        operator.ge,
     ]
 )
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -264,11 +264,21 @@ BUILTIN_TO_TENSOR_RFN_MAP: dict[Callable[..., Any], Callable[..., Any]] = {}
 # opt-out).
 _MISSING_SENTINEL = object()
 
+# Runtime-raising ops (e.g. truediv) excluded: recompute escapes traced handlers
 _COMPUTED_LAZY_CONSTANT_OPS: frozenset[Callable[..., Any]] = frozenset(
     [
         operator.add,
         operator.sub,
         operator.mul,
+        operator.and_,
+        operator.or_,
+        operator.xor,
+        operator.eq,
+        operator.ne,
+        operator.lt,
+        operator.le,
+        operator.gt,
+        operator.ge,
     ]
 )
 


### PR DESCRIPTION
## Related Issue

Part of #187590

## Why

- Bitwise and comparison ops on lazy constants realize and install value guards
- Changing those constant inputs then recompiles even when the result is unused

## How

- Adds `and_`, `or_`, `xor` and rich comparisons to `_COMPUTED_LAZY_CONSTANT_OPS`
- Keeps value-raising ops (e.g. `truediv`) excluded: runtime recompute escapes traced handlers

Authored with an AI assistant (Claude Code).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
