### PR TITLE
[Dynamo] Support unary ops on lazy constants

### DIFF
--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -580,6 +580,77 @@ class ComputedLazyConstantTests(TestCase):
 
         self._check(fn, [(t, 1, 2), (t, 3, 4)], expected_frames=1)
 
+    def test_unused_unary_ops_do_not_recompile(self):
+        t = torch.ones(2)
+        cases = [
+            ("neg_int", lambda t, a: (t.sin(), -a), [(t, 5), (t, 9)]),
+            ("pos_int", lambda t, a: (t.sin(), +a), [(t, 5), (t, 9)]),
+            ("abs_int", lambda t, a: (t.sin(), abs(a)), [(t, -5), (t, 9)]),
+            ("not_int", lambda t, a: (t.sin(), not a), [(t, 5), (t, 0)]),
+            ("neg_float", lambda t, a: (t.sin(), -a), [(t, 5.5), (t, -9.25)]),
+            ("neg_bool", lambda t, a: (t.sin(), -a), [(t, True), (t, False)]),
+            ("not_bool", lambda t, a: (t.sin(), not a), [(t, True), (t, False)]),
+            ("not_str", lambda t, a: (t.sin(), not a), [(t, "x"), (t, "")]),
+        ]
+        for name, fn, arg_sets in cases:
+            with self.subTest(name=name):
+                torch._dynamo.reset()
+                self._check(fn, arg_sets, expected_frames=1)
+
+    def test_invert_falls_back(self):
+        t = torch.ones(2)
+
+        def fn(t, a):
+            return t.sin(), ~a
+
+        opt_fn = torch.compile(fn, backend="eager")
+        for a in (5, 9):
+            self.assertTrue(same(fn(t, a), opt_fn(t, a)))
+
+    @torch._dynamo.config.patch(specialize_int=False, assume_static_by_default=False)
+    def test_unary_symbolic_operand_realizes(self):
+        t = torch.ones(3)
+        cases = [
+            ("neg", lambda t, a: t * (-a)),
+            ("pos", lambda t, a: t * (+a)),
+            ("abs", lambda t, a: t * abs(a)),
+            ("not", lambda t, a: t * (not a)),
+        ]
+        for name, fn in cases:
+            with self.subTest(name=name):
+                torch._dynamo.reset()
+                opt_fn = torch.compile(fn, backend="eager")
+                for a in (5, 7):
+                    self.assertTrue(same(fn(t, a), opt_fn(t, a)))
+
+    def test_unary_type_error_surfaces(self):
+        t = torch.ones(2)
+
+        def fn(t, a):
+            return t.sin(), ~a
+
+        opt_fn = torch.compile(fn, backend="eager")
+        with self.assertRaises(TypeError):
+            opt_fn(t, 1.5)
+
+    def test_unary_op_in_branch_recompiles(self):
+        t = torch.ones(2)
+
+        def fn(t, a):
+            if -a < 0:
+                return t + 1
+            return t - 1
+
+        self._check(fn, [(t, 5), (t, -5)], expected_frames=2)
+
+    def test_chained_unary_binary_does_not_recompile(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            return t.sin(), -(a + b) * 2
+
+        self._check(fn, [(t, 1, 2), (t, 7, 5)], expected_frames=1)
+
     def test_unused_division_recompiles(self):
         t = torch.ones(2)
 

--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -579,6 +579,77 @@ class ComputedLazyConstantTests(TestCase):
 
         self._check(fn, [(t, 1, 2), (t, 3, 4)], expected_frames=1)
 
+    def test_unused_unary_ops_do_not_recompile(self):
+        t = torch.ones(2)
+        cases = [
+            ("neg_int", lambda t, a: (t.sin(), -a), [(t, 5), (t, 9)]),
+            ("pos_int", lambda t, a: (t.sin(), +a), [(t, 5), (t, 9)]),
+            ("abs_int", lambda t, a: (t.sin(), abs(a)), [(t, -5), (t, 9)]),
+            ("not_int", lambda t, a: (t.sin(), not a), [(t, 5), (t, 0)]),
+            ("neg_float", lambda t, a: (t.sin(), -a), [(t, 5.5), (t, -9.25)]),
+            ("neg_bool", lambda t, a: (t.sin(), -a), [(t, True), (t, False)]),
+            ("not_bool", lambda t, a: (t.sin(), not a), [(t, True), (t, False)]),
+            ("not_str", lambda t, a: (t.sin(), not a), [(t, "x"), (t, "")]),
+        ]
+        for name, fn, arg_sets in cases:
+            with self.subTest(name=name):
+                torch._dynamo.reset()
+                self._check(fn, arg_sets, expected_frames=1)
+
+    def test_invert_falls_back(self):
+        t = torch.ones(2)
+
+        def fn(t, a):
+            return t.sin(), ~a
+
+        opt_fn = torch.compile(fn, backend="eager")
+        for a in (5, 9):
+            self.assertTrue(same(fn(t, a), opt_fn(t, a)))
+
+    @torch._dynamo.config.patch(specialize_int=False, assume_static_by_default=False)
+    def test_unary_symbolic_operand_realizes(self):
+        t = torch.ones(3)
+        cases = [
+            ("neg", lambda t, a: t * (-a)),
+            ("pos", lambda t, a: t * (+a)),
+            ("abs", lambda t, a: t * abs(a)),
+            ("not", lambda t, a: t * (not a)),
+        ]
+        for name, fn in cases:
+            with self.subTest(name=name):
+                torch._dynamo.reset()
+                opt_fn = torch.compile(fn, backend="eager")
+                for a in (5, 7):
+                    self.assertTrue(same(fn(t, a), opt_fn(t, a)))
+
+    def test_unary_type_error_surfaces(self):
+        t = torch.ones(2)
+
+        def fn(t, a):
+            return t.sin(), ~a
+
+        opt_fn = torch.compile(fn, backend="eager")
+        with self.assertRaises(TypeError):
+            opt_fn(t, 1.5)
+
+    def test_unary_op_in_branch_recompiles(self):
+        t = torch.ones(2)
+
+        def fn(t, a):
+            if -a < 0:
+                return t + 1
+            return t - 1
+
+        self._check(fn, [(t, 5), (t, -5)], expected_frames=2)
+
+    def test_chained_unary_binary_does_not_recompile(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            return t.sin(), -(a + b) * 2
+
+        self._check(fn, [(t, 1, 2), (t, 7, 5)], expected_frames=1)
+
     def test_unused_division_recompiles(self):
         t = torch.ones(2)
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -277,13 +277,13 @@ BUILTIN_TO_TENSOR_RFN_MAP: dict[Callable[..., Any], Callable[..., Any]] = {}
 # opt-out).
 _MISSING_SENTINEL = object()
 
-_COMPUTED_LAZY_CONSTANT_OPS: frozenset[Callable[..., Any]] = frozenset(
-    [
-        operator.add,
-        operator.sub,
-        operator.mul,
-    ]
-)
+_COMPUTED_LAZY_CONSTANT_OPS_BY_ARITY: dict[int, frozenset[Callable[..., Any]]] = {
+    # invert is excluded: SymNodeVariable has no nb_invert_impl for symbolic realization
+    1: frozenset([operator.neg, operator.pos, operator.abs, operator.not_]),
+    2: frozenset([operator.add, operator.sub, operator.mul]),
+}
+
+_BUILTIN_TO_OPERATOR: dict[Callable[..., Any], Callable[..., Any]] = {abs: operator.abs}
 
 
 def _try_computed_lazy_constant(
@@ -293,7 +293,8 @@ def _try_computed_lazy_constant(
     from .lazy import ComputedLazyConstantVariable, LazyConstantVariable
 
     fn = IN_PLACE_DESUGARING_MAP.get(fn, fn)
-    if fn not in _COMPUTED_LAZY_CONSTANT_OPS or len(args) != 2:
+    fn = _BUILTIN_TO_OPERATOR.get(fn, fn)
+    if fn not in _COMPUTED_LAZY_CONSTANT_OPS_BY_ARITY.get(len(args), frozenset()):
         return None
     any_unrealized = False
     for arg in args:

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -264,13 +264,13 @@ BUILTIN_TO_TENSOR_RFN_MAP: dict[Callable[..., Any], Callable[..., Any]] = {}
 # opt-out).
 _MISSING_SENTINEL = object()
 
-_COMPUTED_LAZY_CONSTANT_OPS: frozenset[Callable[..., Any]] = frozenset(
-    [
-        operator.add,
-        operator.sub,
-        operator.mul,
-    ]
-)
+_COMPUTED_LAZY_CONSTANT_OPS_BY_ARITY: dict[int, frozenset[Callable[..., Any]]] = {
+    # invert is excluded: SymNodeVariable has no nb_invert_impl for symbolic realization
+    1: frozenset([operator.neg, operator.pos, operator.abs, operator.not_]),
+    2: frozenset([operator.add, operator.sub, operator.mul]),
+}
+
+_BUILTIN_TO_OPERATOR: dict[Callable[..., Any], Callable[..., Any]] = {abs: operator.abs}
 
 
 def _try_computed_lazy_constant(
@@ -280,7 +280,8 @@ def _try_computed_lazy_constant(
     from .lazy import ComputedLazyConstantVariable, LazyConstantVariable
 
     fn = IN_PLACE_DESUGARING_MAP.get(fn, fn)
-    if fn not in _COMPUTED_LAZY_CONSTANT_OPS or len(args) != 2:
+    fn = _BUILTIN_TO_OPERATOR.get(fn, fn)
+    if fn not in _COMPUTED_LAZY_CONSTANT_OPS_BY_ARITY.get(len(args), frozenset()):
         return None
     any_unrealized = False
     for arg in args:

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import functools
 import inspect
+import operator
 from typing import Any, TYPE_CHECKING
 
 from .. import config
@@ -74,6 +75,9 @@ class ComputedLazyCache:
         op: Callable[..., Any],
         num_nodes: int,
     ) -> None:
+        if getattr(operator, op.__name__, None) is not op:
+            # reconstruct() loads the op as operator.<name>; enforce that eagerly
+            raise AssertionError(f"op must be reachable as operator.{op.__name__}")
         self.value = value
         self.lazy_vars = lazy_vars
         self.args = args

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import functools
 import inspect
+import operator
 from typing import Any, TYPE_CHECKING
 
 from .. import config
@@ -73,6 +74,9 @@ class ComputedLazyCache:
         args: list[VariableTracker],
         op: Callable[..., Any],
     ) -> None:
+        if getattr(operator, op.__name__, None) is not op:
+            # reconstruct() loads the op as operator.<name>; enforce that eagerly
+            raise AssertionError(f"op must be reachable as operator.{op.__name__}")
         self.value = value
         self.lazy_vars = lazy_vars
         self.args = args


### PR DESCRIPTION
## Related Issue

Part of #187590

## Why

- Unary ops on lazy constants realize and guard, so unused results still recompile

## How

- Adds arity-keyed op table `_COMPUTED_LAZY_CONSTANT_OPS_BY_ARITY` with `neg`, `pos`, `abs`, `not_`
- Excludes `invert`: `SymNodeVariable` has no `nb_invert_impl` for the symbolic realization path
- Maps builtin `abs` to `operator.abs` via `_BUILTIN_TO_OPERATOR`
- Asserts the cached op is reachable as `operator.<name>`, which `reconstruct()` relies on

Authored with an AI assistant (Claude Code).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
