### PR TITLE
[ROCm] Re-enable subprocess environment tests on 7.14

### DIFF
--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -23,7 +23,6 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
     skipIfRocm,
-    skipIfRocmVersionAtLeast,
     TestCase,
 )
 from torch.utils import _pytree as pytree
@@ -146,7 +145,6 @@ selected_ops = {
 selected_op_db = [op for op in op_db if op.name in selected_ops]
 
 
-@skipIfRocmVersionAtLeast([7, 14])
 class TestExportOnFakeCuda(TestCase):
     # In CI, this test runs on a CUDA machine with cuda build
     # We set CUDA_VISIBLE_DEVICES="" to simulate a CPU machine with cuda build

--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -3,6 +3,7 @@
 # flake8: noqa
 
 import itertools
+import os
 import subprocess
 import sys
 import unittest
@@ -145,9 +146,20 @@ selected_ops = {
 selected_op_db = [op for op in op_db if op.name in selected_ops]
 
 
+def _env_without_visible_accelerators():
+    env = os.environ.copy()
+    for variable in (
+        "CUDA_VISIBLE_DEVICES",
+        "HIP_VISIBLE_DEVICES",
+        "ROCR_VISIBLE_DEVICES",
+    ):
+        env[variable] = ""
+    return env
+
+
 class TestExportOnFakeCuda(TestCase):
-    # In CI, this test runs on a CUDA machine with cuda build
-    # We set CUDA_VISIBLE_DEVICES="" to simulate a CPU machine with cuda build
+    # In CI, this test runs on a CUDA/ROCm machine with an accelerator build.
+    # Hide physical devices to simulate a CPU machine with that build.
     # Running this on all ops in op_db is too slow, so we only run on a selected subset
     @onlyCUDA
     @unittest.skipIf(
@@ -212,7 +224,7 @@ for op in ops:
             (
                 subprocess.check_output(
                     [sys.executable, "-c", test_script],
-                    env={"CUDA_VISIBLE_DEVICES": ""},
+                    env=_env_without_visible_accelerators(),
                 )
             )
             .decode("ascii")
@@ -279,7 +291,7 @@ cuda_calls_behavior_unchanged()
             (
                 subprocess.check_output(
                     [sys.executable, "-c", test_script],
-                    env={"CUDA_VISIBLE_DEVICES": ""},
+                    env=_env_without_visible_accelerators(),
                 )
             )
             .decode("ascii")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7014,7 +7014,6 @@ class TestCudaAllocator(TestCase):
                 "throw_on_cudamalloc_oom:False,per_process_memory_fraction:1.0"
             )
 
-    @skipIfRocmVersionAtLeast([7, 14])
     def test_allocator_backend(self):
         def subprocess_env():
             if IS_WINDOWS:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6732,7 +6732,11 @@ class TestCudaAllocator(TestCase):
                     )
                     if k in os.environ
                 }
-            return {}
+
+            env = os.environ.copy()
+            env.pop("PYTORCH_ALLOC_CONF", None)
+            env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
+            return env
 
         def check_output(script: str) -> str:
             kwargs = {"env": subprocess_env(), "text": True}


### PR DESCRIPTION
## Summary 
 Re-enable ten temporary ROCm 7.14 skips:  

- Nine `TestExportOnFakeCuda` subprocess tests. 
- `TestCudaAllocator.test_allocator_backend`.  

## Why these were skipped  
The export tests start child Python with `env={"CUDA_VISIBLE_DEVICES": ""}`, and the allocator test starts it with an empty environment. Passing `env` replaces the complete child environment. In the earlier TheRock wheel layout, this could remove loader configuration required for the child to resolve ROCm shared libraries during startup or `import torch`.  

## Why they can run now  
TheRock wheel support now resolves ROCm shared libraries through `$ORIGIN` RPATH entries pointing to the installed `_rocm_sdk_*` packages. Child processes no longer depend on the inherited legacy ROCm loader environment, so the original restricted subprocess environments work as intended.  This change therefore removes only the temporary ROCm 7.14 skips; it does not alter the test subprocess setup.  

## Test plan 
 - ROCm MI300 and trunk CI on this branch. - Existing Python compilation validation passed.  

## CI evidence

The PR head (`5e6531fb`) passed the re-enabled tests in ROCm trunk run [31405231223](https://github.com/pytorch/pytorch/actions/runs/31405231223), on MI350 default shard 1/8 ([job 93517779845](https://github.com/pytorch/pytorch/actions/runs/31405231223/job/93517779845)).

- All nine `TestExportOnFakeCudaCUDA` subprocess tests were scheduled in the shard ([log line 9362](https://github.com/pytorch/pytorch/actions/runs/31405231223/job/93517779845#L9362)), and the module passed: `export/test_export_opinfo 1/1 was successful` ([log line 9361](https://github.com/pytorch/pytorch/actions/runs/31405231223/job/93517779845#L9361)).
- `test/test_cuda.py::TestCudaAllocator::test_allocator_backend PASSED [1.7230s] [ 36%]` ([log line 9887](https://github.com/pytorch/pytorch/actions/runs/31405231223/job/93517779845#L9887)).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang