### PR TITLE
[c10] Simplify TypeIndex.h using C++20 and drop dead constexpr macros

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -8,11 +8,6 @@
 #include <string>
 #include <type_traits>
 
-#if !defined(FBCODE_CAFFE2) && !defined(C10_NODEPRECATED)
-#define C10_TYPENAME_SUPPORTS_CONSTEXPR 1
-#define C10_TYPENAME_CONSTEXPR constexpr
-#endif
-
 namespace c10::util {
 
 struct type_index final : IdWrapper<type_index, uint64_t> {
@@ -57,12 +52,8 @@ inline constexpr c10::c10_string_view fully_qualified_type_name_impl() {
       "; c10::c10_string_view = c10::basic_string_view<char>]";
 #endif
 #if !defined(__CUDA_ARCH__) && !defined(__CUDA_ARCH_LIST__)
-  static_assert(c10::starts_with(
-      static_cast<std::string_view>(fun_sig),
-      static_cast<std::string_view>(prefix)));
-  static_assert(c10::ends_with(
-      static_cast<std::string_view>(fun_sig),
-      static_cast<std::string_view>(suffix)));
+  static_assert(fun_sig.starts_with(prefix));
+  static_assert(fun_sig.ends_with(suffix));
 #endif
   return fun_sig.substr(
       prefix.size(), fun_sig.size() - prefix.size() - suffix.size());


### PR DESCRIPTION
Summary:
Two small cleanups to `c10/util/TypeIndex.h` now that PyTorch requires C++20:

- Remove the unused `C10_TYPENAME_SUPPORTS_CONSTEXPR` / `C10_TYPENAME_CONSTEXPR`
  macro definitions. #138702 ("Eliminate C10_TYPENAME_CONSTEXPR") removed every
  use of these but left the definitions behind; they now have zero references in
  the live tree (the only other copies are frozen prebuilt libtorch snapshots
  under `arvr/` that carry their own self-contained definitions).
- Replace the pre-C++20 `c10::starts_with` / `c10::ends_with` free-function shims
  in `fully_qualified_type_name_impl()` with the standard
  `std::string_view::starts_with` / `ends_with` members, and drop the now
  redundant `static_cast<std::string_view>` wrapping (`fun_sig`, `prefix`, and
  `suffix` are already `std::string_view`).

The C++20 change is safe for ExecuTorch: `TypeIndex.h` is not part of
ExecuTorch's C++17 hermetic c10 mirror (see
`executorch/runtime/core/portable_type/c10/c10/targets.bzl`), and the only
ExecuTorch build paths that compile it go through ATen/PyTorch headers, which are
compiled with C++20.

Test Plan:
```
arc lint fbcode/caffe2/c10/util/TypeIndex.h  # No lint issues.
```
Relying on CI to build c10 (the `static_assert`s in `fully_qualified_type_name_impl`
exercise the changed `starts_with`/`ends_with` calls at compile time).

Authored with the assistance of Claude Code.

Differential Revision: D113572049


