### PR TITLE
export: add weights_only param to torch.export.load for safe deserialization

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -7,6 +7,7 @@ with test_sym_bool)
 import copy
 import io
 import math
+import pickle
 import tempfile
 import unittest
 import zipfile
@@ -2181,6 +2182,16 @@ class TestSchemaVersioning(TestCase):
 unittest.expectedFailure(TestDeserialize.test_exportdb_supported_case_fn_with_kwargs)
 
 
+class _CustomObject:
+    def __init__(self, x):
+        self.x = x
+
+
+@dataclass
+class _CustomPytreeInput:
+    x: torch.Tensor
+
+
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestSaveLoad(TestCase):
     def test_save_buffer(self):
@@ -2525,6 +2536,115 @@ class TestSaveLoad(TestCase):
                         self.assertEqual(
                             node_source_orig.to_dict(), node_source_loaded.to_dict()
                         )
+
+    def test_deserialize_torch_artifact_default_loads_tensors(self):
+        # Tensors-only payloads must round-trip with the default (weights_only=None).
+        data = {"x": torch.tensor([1.0, 2.0]), "y": torch.tensor([3, 4])}
+        buf = io.BytesIO()
+        torch.save(data, buf)
+        result = deserialize_torch_artifact(buf.getvalue())
+        self.assertIsInstance(result, dict)
+        self.assertTrue(torch.equal(result["x"], data["x"]))
+        self.assertTrue(torch.equal(result["y"], data["y"]))
+
+    def test_deserialize_torch_artifact_explicit_weights_only(self):
+        # Explicit weights_only=True/False both work for plain tensor payloads.
+        data = {"x": torch.tensor([1.0, 2.0])}
+        buf = io.BytesIO()
+        torch.save(data, buf)
+        payload = buf.getvalue()
+        for weights_only in (True, False):
+            result = deserialize_torch_artifact(payload, weights_only=weights_only)
+            self.assertTrue(torch.equal(result["x"], data["x"]))
+
+    def test_deserialize_torch_artifact_custom_object_default_fallback(self):
+        # BC: payloads containing arbitrary pickled objects still load with the
+        # default (weights_only=None) via the historical weights_only=False fallback.
+        data = {"obj": _CustomObject(7)}
+        buf = io.BytesIO()
+        torch.save(data, buf)
+        with self.assertLogs("torch._export.serde.serialize", level="WARNING"):
+            result = deserialize_torch_artifact(buf.getvalue())
+        self.assertEqual(result["obj"].x, 7)
+
+    def test_deserialize_torch_artifact_custom_object_weights_only_true(self):
+        # weights_only=True rejects non-allowlisted pickled objects.
+        data = {"obj": _CustomObject(7)}
+        buf = io.BytesIO()
+        torch.save(data, buf)
+        with self.assertRaises(pickle.UnpicklingError):
+            deserialize_torch_artifact(buf.getvalue(), weights_only=True)
+
+    def test_deserialize_torch_artifact_custom_object_weights_only_false(self):
+        data = {"obj": _CustomObject(7)}
+        buf = io.BytesIO()
+        torch.save(data, buf)
+        result = deserialize_torch_artifact(buf.getvalue(), weights_only=False)
+        self.assertEqual(result["obj"].x, 7)
+
+    def test_deserialize_torch_artifact_empty_bytes(self):
+        # Empty bytes should return an empty dict regardless of weights_only.
+        self.assertEqual(deserialize_torch_artifact(b""), {})
+        self.assertEqual(deserialize_torch_artifact(b"", weights_only=False), {})
+
+    def test_deserialize_torch_artifact_passthrough(self):
+        # dict/tuple inputs are passed through without touching torch.load.
+        d = {"a": torch.tensor(1)}
+        self.assertIs(deserialize_torch_artifact(d), d)
+        t = (torch.tensor(1),)
+        self.assertIs(deserialize_torch_artifact(t), t)
+
+    def test_load_weights_only_default_and_explicit(self):
+        # Plain-tensor models load with the default (None) as well as explicit
+        # weights_only=True/False.
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        m = M()
+        inp = (torch.randn(2, 4),)
+        ep = export(m, inp, strict=True)
+
+        buffer = io.BytesIO()
+        save(ep, buffer)
+        expected = ep.module()(*inp)
+        for weights_only in (None, True, False):
+            buffer.seek(0)
+            loaded_ep = load(buffer, weights_only=weights_only)
+            self.assertTrue(torch.allclose(expected, loaded_ep.module()(*inp)))
+
+    def test_load_weights_only_true_rejects_custom_example_inputs(self):
+        # Archives whose example inputs contain non-allowlisted pickled objects
+        # cannot be loaded with weights_only=True; the error points to the
+        # weights_only=False escape hatch. The default (None) keeps the
+        # historical fallback and still loads them.
+        torch.export.register_dataclass(
+            _CustomPytreeInput,
+            serialized_type_name="test_serialize._CustomPytreeInput",
+        )
+
+        class M(torch.nn.Module):
+            def forward(self, inp: _CustomPytreeInput) -> torch.Tensor:
+                return inp.x * 2
+
+        x = torch.randn(4)
+        ep = export(M(), (_CustomPytreeInput(x),), strict=True)
+        buffer = io.BytesIO()
+        save(ep, buffer)
+
+        buffer.seek(0)
+        with self.assertRaisesRegex(pickle.UnpicklingError, "weights_only=False"):
+            load(buffer, weights_only=True)
+
+        buffer.seek(0)
+        loaded_ep = load(buffer)
+        expected = ep.module()(_CustomPytreeInput(x))
+        actual = loaded_ep.module()(_CustomPytreeInput(x))
+        self.assertTrue(torch.allclose(expected, actual))
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -426,6 +426,7 @@ def serialize_torch_artifact(
 
 def deserialize_torch_artifact(
     serialized: dict[str, Any] | tuple[Any, ...] | bytes,
+    weights_only: bool | None = None,
 ):
     if isinstance(serialized, (dict, tuple)):
         return serialized
@@ -433,18 +434,22 @@ def deserialize_torch_artifact(
         return {}
     buffer = io.BytesIO(serialized)
     buffer.seek(0)
-    # weights_only=False as we want to load custom objects here (e.g. ScriptObject)
-    try:
-        artifact = torch.load(buffer, weights_only=True)
-    except Exception as e:
-        buffer.seek(0)
-        artifact = torch.load(buffer, weights_only=False)
-        log.warning(
-            "Fallback to weights_only=False succeeded. "
-            "Loaded object of type %s after initial failure: %s",
-            type(artifact),
-            exc_info=e,
-        )
+    if weights_only is None:
+        # weights_only=False as we want to load custom objects here (e.g. ScriptObject)
+        try:
+            artifact = torch.load(buffer, weights_only=True)
+        except Exception as e:
+            buffer.seek(0)
+            artifact = torch.load(buffer, weights_only=False)
+            log.warning(
+                "Fallback to weights_only=False succeeded. "
+                "Loaded object of type %s after initial failure: %s",
+                type(artifact),
+                e,
+                exc_info=e,
+            )
+    else:
+        artifact = torch.load(buffer, weights_only=weights_only)
     if not isinstance(artifact, (tuple, dict)):
         raise AssertionError(f"expected tuple or dict, got {type(artifact).__name__}")
     return artifact
@@ -2919,6 +2924,7 @@ class GraphModuleDeserializer(metaclass=Final):
         | bytes
         | None = None,
         symbol_name_to_range: dict[str, symbolic_shapes.ValueRanges] | None = None,
+        weights_only: bool | None = None,
     ) -> Result:
         global _CURRENT_DESERIALIZER
         if _CURRENT_DESERIALIZER is not None:
@@ -2961,7 +2967,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 "Identity": torch.utils._sympy.functions.Identity,
             }
             self.symbol_name_to_symbol: dict[str, sympy.Symbol] = {}
-            self.constants = deserialize_torch_artifact(constants)
+            self.constants = deserialize_torch_artifact(constants, weights_only)
             self.signature = self.deserialize_signature(
                 serialized_graph_module.signature
             )
@@ -2997,7 +3003,9 @@ class GraphModuleDeserializer(metaclass=Final):
                 self.shape_env.unbacked_symint_counter += 1
 
             if example_inputs is not None and len(example_inputs) > 0:
-                self.example_inputs = deserialize_torch_artifact(example_inputs)
+                self.example_inputs = deserialize_torch_artifact(
+                    example_inputs, weights_only=weights_only
+                )
             else:
                 self.example_inputs = None
             self.deserialize_graph(serialized_graph_module.graph)
@@ -3023,7 +3031,9 @@ class GraphModuleDeserializer(metaclass=Final):
                 signature=self.signature,
                 module_call_graph=module_call_graph,
                 names_to_symbols=self.symbol_name_to_symbol,
-                state_dict=deserialize_torch_artifact(serialized_state_dict),
+                state_dict=deserialize_torch_artifact(
+                    serialized_state_dict, weights_only=weights_only
+                ),
                 constants=self.constants,
                 example_inputs=self.example_inputs,
             )
@@ -3586,6 +3596,7 @@ class ExportedProgramDeserializer(metaclass=Final):
         | None = None,
         *,
         _unsafe_skip_version_check=False,
+        weights_only: bool | None = None,
     ) -> ep.ExportedProgram:
         if not isinstance(exported_program, ExportedProgram):
             raise AssertionError(
@@ -3616,6 +3627,7 @@ class ExportedProgramDeserializer(metaclass=Final):
             constants,
             example_inputs,
             symbol_name_to_range,
+            weights_only=weights_only,
         )
         range_constraints = self.deserialize_range_constraints(
             symbol_name_to_range,
@@ -3788,6 +3800,7 @@ def deserialize(
     expected_opset_version: dict[str, int] | None = None,
     *,
     _unsafe_skip_version_check=False,
+    weights_only: bool | None = None,
 ) -> ep.ExportedProgram:
     if not isinstance(artifact.exported_program, bytes):
         raise AssertionError(
@@ -3802,6 +3815,7 @@ def deserialize(
         artifact.constants,
         artifact.example_inputs,
         _unsafe_skip_version_check=_unsafe_skip_version_check,
+        weights_only=weights_only,
     )
 
 

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pickle
 import warnings
 import zipfile
 from collections.abc import Callable, Mapping
@@ -340,6 +341,7 @@ def load(
     *,
     extra_files: dict[str, Any] | None = None,
     expected_opset_version: dict[str, int] | None = None,
+    weights_only: bool | None = None,
 ) -> ExportedProgram:
     """
 
@@ -363,6 +365,16 @@ def load(
 
         expected_opset_version (Optional[Dict[str, int]]): A map of opset names
          to expected opset versions
+
+        weights_only (Optional[bool]): If ``True``, payloads that require
+         pickling (e.g. tensor subclass weights) are loaded with
+         ``torch.load(weights_only=True)`` and fail on non-allowlisted
+         objects. If ``False``, arbitrary pickle-based loading is allowed;
+         only use with files from trusted sources. If ``None`` (default),
+         preserves the current behavior, which falls back to
+         ``weights_only=False`` when loading custom objects. Note that
+         TorchScript custom objects and opaque objects are always loaded via
+         pickle regardless of this flag.
 
     Returns:
         An :class:`ExportedProgram` object
@@ -398,10 +410,20 @@ def load(
         pt2_contents = load_pt2(
             f,
             expected_opset_version=expected_opset_version,
+            weights_only=weights_only,
         )
     except RuntimeError:
         log.warning("Ran into the following error when deserializing", exc_info=True)
         pt2_contents = PT2ArchiveContents({}, {}, {})
+    except pickle.UnpicklingError as e:
+        if weights_only:
+            raise pickle.UnpicklingError(
+                f"Failed to deserialize with weights_only=True: {e}. If you "
+                "trust the source of this file, load with weights_only=False, "
+                "or register the required classes via "
+                "torch.serialization.add_safe_globals."
+            ) from e
+        raise
 
     if len(pt2_contents.exported_programs) > 0 or len(pt2_contents.extra_files) > 0:
         for k, v in pt2_contents.extra_files.items():
@@ -484,7 +506,7 @@ def load(
         )
 
         # Deserialize ExportedProgram
-        ep = deserialize(artifact, expected_opset_version)
+        ep = deserialize(artifact, expected_opset_version, weights_only=weights_only)
 
         return ep
 

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -864,7 +864,12 @@ def _load_payload_config(
 def _load_state_dict(
     archive_reader: PT2ArchiveReader,
     model_name: str,
+    weights_only: bool | None = None,
 ) -> dict[str, torch.Tensor] | bytes:
+    # Pickled weights (e.g. tensor subclasses) were historically loaded with
+    # weights_only=False; keep that behavior unless explicitly overridden.
+    if weights_only is None:
+        weights_only = False
     # Make it BC compatible with legacy weight files
     legacy_weights_file = f"{WEIGHTS_DIR}{model_name}.pt"
     if legacy_weights_file in archive_reader.get_file_names():
@@ -891,7 +896,7 @@ def _load_state_dict(
                     os.path.join(WEIGHTS_DIR, payload_meta.path_name)
                 )
                 state_dict[weight_fqn] = torch.load(
-                    io.BytesIO(weight_bytes), weights_only=False
+                    io.BytesIO(weight_bytes), weights_only=weights_only
                 )
             else:
                 tensor_meta = payload_meta.tensor_meta
@@ -920,7 +925,12 @@ def _load_state_dict(
 def _load_constants(
     archive_reader: PT2ArchiveReader,
     model_name: str,
+    weights_only: bool | None = None,
 ) -> dict[str, torch.Tensor] | bytes:
+    # Pickled constants (e.g. tensor subclasses) were historically loaded with
+    # weights_only=False; keep that behavior unless explicitly overridden.
+    if weights_only is None:
+        weights_only = False
     # Make it BC compatible with legacy constant files
     legacy_constants_file = f"{CONSTANTS_DIR}{model_name}.pt"
     if legacy_constants_file in archive_reader.get_file_names():
@@ -949,7 +959,7 @@ def _load_constants(
                         os.path.join(CONSTANTS_DIR, path_name)
                     )
                     constants[constant_fqn] = torch.load(
-                        io.BytesIO(constant_bytes), weights_only=False
+                        io.BytesIO(constant_bytes), weights_only=weights_only
                     )
                 else:
                     tensor_meta = payload_meta.tensor_meta
@@ -989,6 +999,7 @@ def _load_exported_programs(
     archive_reader: PT2ArchiveReader,
     file_names: list[str],
     expected_opset_version: dict[str, int] | None,
+    weights_only: bool | None = None,
 ) -> dict[str, ExportedProgram]:
     exported_program_files = [
         file for file in file_names if file.startswith(MODELS_DIR)
@@ -1011,14 +1022,15 @@ def _load_exported_programs(
         serialized_exported_program = _bytes_to_dataclass(
             schema.ExportedProgram, exported_program_bytes
         )
-        state_dict = _load_state_dict(archive_reader, model_name)
-        constants = _load_constants(archive_reader, model_name)
+        state_dict = _load_state_dict(archive_reader, model_name, weights_only)
+        constants = _load_constants(archive_reader, model_name, weights_only)
 
         ep = ExportedProgramDeserializer(expected_opset_version).deserialize(
             serialized_exported_program,
             state_dict,
             constants,
             serialized_sample_inputs,
+            weights_only=weights_only,
         )
 
         exported_programs[model_name] = ep
@@ -1087,6 +1099,7 @@ def load_pt2(
     num_runners: int = 1,
     device_index: int = -1,
     load_weights_from_disk: bool = False,
+    weights_only: bool | None = None,
 ) -> PT2ArchiveContents:  # type: ignore[type-arg]
     """
     Loads all the artifacts previously saved with ``package_pt2``.
@@ -1108,6 +1121,12 @@ def load_pt2(
             to be loaded. By default, `device_index=-1` is used, which corresponds
             to the device `cuda` when using CUDA. Passing `device_index=1` would
             load the package to `cuda:1`, for example.
+
+        weights_only (Optional[bool]): If ``True``, pickled payloads in the
+         archive (e.g. tensor subclass weights) are loaded with
+         ``torch.load(weights_only=True)``. ``None`` (default) preserves the
+         current behavior, which may fall back to ``weights_only=False`` when
+         loading custom objects.
 
     Returns:
         A ``PT2ArchiveContents`` object which contains all the objects in the PT2.
@@ -1143,7 +1162,7 @@ def load_pt2(
         file_names = archive_reader.get_file_names()
 
         exported_programs = _load_exported_programs(
-            archive_reader, file_names, expected_opset_version
+            archive_reader, file_names, expected_opset_version, weights_only
         )
         extra_files = _load_extra_files(archive_reader, file_names)
 


### PR DESCRIPTION
## Summary

Adds an optional `weights_only` parameter to `torch.export.load` (#153410), plumbed through the pt2 archive load path (`load_pt2` → `_load_state_dict` / `_load_constants` → serde `deserialize` → `deserialize_torch_artifact`).

**This PR is plumbing only: no behavior change by default.**

- `weights_only=None` (default): current behavior — `weights_only=True` is attempted first, falling back to `weights_only=False` (with a warning) for custom objects; pickled tensor-subclass weights/constants load with `weights_only=False`.
- `weights_only=True`: strict opt-in — all `torch.load` calls use `weights_only=True`; failures raise `pickle.UnpicklingError` with a hint pointing at `weights_only=False` / `torch.serialization.add_safe_globals`.
- `weights_only=False`: explicit opt-out — arbitrary pickle loading (trusted files only).

Known limitation (unchanged by this PR): `ScriptObject` (`CUSTOM_OBJ_*`) and opaque (`OPAQUE_OBJ_*`) constants are always deserialized via pickle, regardless of `weights_only`.

## Rollout plan (follow-up PRs)

1. Escalate the fallback warning to a `FutureWarning` naming the release where the default becomes `True`.
2. Flip the default to `True` with a BC-breaking release note — mirroring the `torch.load` rollout (warn in 2.4, flip in 2.6).

## Test plan

```
python test/export/test_serialize.py
lintrunner torch/_export/serde/serialize.py torch/export/__init__.py torch/export/pt2_archive/_package.py test/export/test_serialize.py
```

New tests cover: default fallback (BC), explicit `True` rejection of custom payloads, explicit `False`, empty/passthrough payloads, e2e `load()` with `None`/`True`/`False`, and the `UnpicklingError` hint.

---
Authored with the assistance of an AI coding assistant.
