### PR TITLE
[Inductor] Clean up OutputCode fields by removing underscores

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -12667,9 +12667,9 @@ class MockFXGraphCache:
         if gm is not None:
             gm = make_boxed_func(gm)
             gm = MockFXGraphCacheOutput(gm)
-            gm._fx_graph_cache_key = key  # (cache_key, debug lines)
-            gm._fx_graph_cache_debug_lines = []
-            gm._time_taken_ns = 0
+            gm.fx_graph_cache_key = key  # (cache_key, debug lines)
+            gm.fx_graph_cache_debug_lines = []
+            gm.time_taken_ns = 0
         return gm, {}
 
 

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -1473,9 +1473,9 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
             )
 
         else:
-            fw_key = getattr(compiled_fw_func, "_fx_graph_cache_key", None)
+            fw_key = getattr(compiled_fw_func, "fx_graph_cache_key", None)
             fw_debug_lines = getattr(
-                compiled_fw_func, "_fx_graph_cache_debug_lines", []
+                compiled_fw_func, "fx_graph_cache_debug_lines", []
             )
 
             if fw_key is None:
@@ -1486,9 +1486,9 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
             )
             compiled_backward = None
             if compiled_bw_func is not None:
-                bw_key = getattr(compiled_bw_func, "_fx_graph_cache_key", None)
+                bw_key = getattr(compiled_bw_func, "fx_graph_cache_key", None)
                 bw_debug_lines = getattr(
-                    compiled_bw_func, "_fx_graph_cache_debug_lines", []
+                    compiled_bw_func, "fx_graph_cache_debug_lines", []
                 )
                 if bw_key is None:
                     raise AssertionError("bw_key must not be None")

--- a/torch/_functorch/_aot_autograd/codegen.py
+++ b/torch/_functorch/_aot_autograd/codegen.py
@@ -191,7 +191,7 @@ def _compile_and_exec_source(
     """Compile generated source, exec it, and return the named function.
 
     If wrapped_fn is provided, applies functools.update_wrapper so that
-    __wrapped__ and __dict__ (e.g. _fx_graph_cache_key) propagate to the
+    __wrapped__ and __dict__ (e.g. fx_graph_cache_key) propagate to the
     generated function.
     """
     if log.isEnabledFor(logging.DEBUG):

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -122,7 +122,7 @@ def _should_save_cache(*compiled_fns: Callable[..., Any]) -> bool:
     if should_bundle_autograd_cache():
         return True
     return all(
-        getattr(fn, "_fx_graph_cache_key", None) is not None for fn in compiled_fns
+        getattr(fn, "fx_graph_cache_key", None) is not None for fn in compiled_fns
     )
 
 
@@ -2682,7 +2682,7 @@ def _cache_autograd_info(
                 # use the compiled_bw_func's inductor compile time instead.
                 # It's possible this changes in the future, in which case we should
                 # update backward_time_taken_ns to be more inclusive
-                backward_time_taken_ns = getattr(compiled_bw_func, "_time_taken_ns", 0)
+                backward_time_taken_ns = getattr(compiled_bw_func, "time_taken_ns", 0)
 
                 aot_forward_graph_str: str | None = fw_module_str
                 aot_backward_graph_str: str | None = bw_module_str

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2328,7 +2328,7 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
                 cache_stats.put("LocalFxGraphCache")
 
             if remote_cache:
-                time_taken_ms = int((disk_compiled_graph._time_taken_ns or 0) // 1e6)
+                time_taken_ms = int((disk_compiled_graph.time_taken_ns or 0) // 1e6)
                 cache_data: JsonDataTy = {
                     "data": base64.b64encode(content).decode("ascii"),
                     "time_taken_ms": time_taken_ms,
@@ -2445,7 +2445,7 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
             counters["inductor"]["fxgraph_cache_hit"] += 1
             cache_info["cache_state"] = "hit"
 
-            if (time_saved_ns := compiled_graph._time_taken_ns) is not None:
+            if (time_saved_ns := compiled_graph.time_taken_ns) is not None:
                 cache_info["time_saved_ns"] = time_saved_ns
                 CompileEventLogger.try_(
                     CompileEventLogger.increment_toplevel,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1177,10 +1177,10 @@ def _compile_fx_inner(
                     raise AssertionError(
                         "fx_codegen_and_compile returned None in cache miss path"
                     )
-                mb_compiled_graph._time_taken_ns = time.time_ns() - start_time
+                mb_compiled_graph.time_taken_ns = time.time_ns() - start_time
                 cache_key, debug_lines = key_info
-                mb_compiled_graph._fx_graph_cache_key = cache_key
-                mb_compiled_graph._fx_graph_cache_debug_lines = debug_lines
+                mb_compiled_graph.fx_graph_cache_key = cache_key
+                mb_compiled_graph.fx_graph_cache_debug_lines = debug_lines
                 (
                     triton_bundle,
                     triton_bundler_meta,
@@ -1196,7 +1196,7 @@ def _compile_fx_inner(
                 TritonBundler.end_compile()
             if triton_bundler_meta is not None:
                 cache_info["triton_bundler_meta"] = str(triton_bundler_meta)
-            cache_info["time_taken_ns"] = mb_compiled_graph._time_taken_ns
+            cache_info["time_taken_ns"] = mb_compiled_graph.time_taken_ns
             log.debug("Saving compiled graph to FX cache with key: %s", cache_key)
             FxGraphCache._save_graph(
                 cache_key,
@@ -1221,8 +1221,8 @@ def _compile_fx_inner(
                 raise AssertionError("Expected key_info to be set in cache hit path")
             (cache_key, debug_lines) = key_info
             log.debug("FX cache hit with key: %s", cache_key)
-            mb_compiled_graph._fx_graph_cache_key = cache_key
-            mb_compiled_graph._fx_graph_cache_debug_lines = debug_lines
+            mb_compiled_graph.fx_graph_cache_key = cache_key
+            mb_compiled_graph.fx_graph_cache_debug_lines = debug_lines
 
         if mb_compiled_graph is None:
             raise AssertionError(

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -100,16 +100,14 @@ log = logging.getLogger(__name__)
 
 @dataclasses.dataclass
 class OutputCode:
-    # TODO: Remove underscores here
-
     # None if the output is not remote cacheable
-    _fx_graph_cache_key: str | None = dataclasses.field(default=None, init=False)
-    _fx_graph_cache_debug_lines: list[str] | None = dataclasses.field(
+    fx_graph_cache_key: str | None = dataclasses.field(default=None, init=False)
+    fx_graph_cache_debug_lines: list[str] | None = dataclasses.field(
         default=None, init=False
     )
 
     # How long it took to compile this OutputCode, end to end
-    _time_taken_ns: int | None = dataclasses.field(default=None, init=False)
+    time_taken_ns: int | None = dataclasses.field(default=None, init=False)
 
     def __call__(self, inputs: Sequence[Any]) -> Any:
         raise NotImplementedError(type(self))
@@ -820,7 +818,7 @@ class CompiledFxGraph(OutputCode):
                     # Checking the profiler directly is faster than nullcontext
                     if torch.autograd.profiler._is_profiler_enabled:
                         with torch._C._profiler._RecordFunctionFast(
-                            f"## Call CompiledFxGraph {self._fx_graph_cache_key} ##",
+                            f"## Call CompiledFxGraph {self.fx_graph_cache_key} ##",
                             keyword_values={"scope": "user_scope"},
                         ):
                             return self.current_callable(inputs)


### PR DESCRIPTION
## Description
This PR resolves an explicit `TODO` in `torch/_inductor/output_code.py` to remove the leading underscores from the fields of the `OutputCode` dataclass.

The following fields have been made public (renamed) as requested by the inline comment:
- `_fx_graph_cache_key` -> `fx_graph_cache_key`
- `_fx_graph_cache_debug_lines` -> `fx_graph_cache_debug_lines`
- `_time_taken_ns` -> `time_taken_ns`

All references to these fields across `compile_fx.py` and `codecache.py` have been updated accordingly to ensure the compiler continues to function without issues.

Fixes an old technical debt item in the codebase.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo