### PR TITLE
[ROCm][NN] Preserve Module.to meta tensor guidance with C++ stack traces

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13087,17 +13087,6 @@ if __name__ == '__main__':
     @dtypesIfMPS(torch.float32)
     @dtypes(torch.float32, torch.float64)
     def test_module_to_empty(self, device, dtype):
-        if (
-            TEST_WITH_ROCM
-            and getRocmVersion() >= (7, 14)
-            and torch.device(device).type == "cuda"
-            and dtype == torch.float32
-        ):
-            self.skipTest(
-                "order/state-dependent NotImplementedError regex mismatch on "
-                "ROCm 7.14+ (cuda, float32)"
-            )
-
         class MyModule(nn.Module):
             def __init__(self, in_features, out_features, device=None, dtype=None):
                 super().__init__()

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1374,10 +1374,14 @@ class Module:
                     non_blocking,
                 )
             except NotImplementedError as e:
-                if str(e) == "Cannot copy out of meta tensor; no data!":
+                message = str(e)
+                base_message = "Cannot copy out of meta tensor; no data!"
+                if message.startswith(base_message):
+                    diagnostic_suffix = message[len(base_message) :]
                     raise NotImplementedError(
-                        f"{e} Please use torch.nn.Module.to_empty() instead of torch.nn.Module.to() "
-                        f"when moving module from meta to a different device."
+                        f"{base_message} Please use torch.nn.Module.to_empty() instead of "
+                        f"torch.nn.Module.to() when moving module from meta to a different device."
+                        f"{diagnostic_suffix}"
                     ) from None
                 else:
                     raise


### PR DESCRIPTION
## Summary

This change fixes the error message from `Module.to()` for a module on the `meta` device.

The fix:
- Recognizes the base error when PyTorch adds a C++ stack trace.
- Keeps the `Module.to_empty()` guidance next to the base error.
- Preserves the C++ stack trace after the guidance.

## Problem

A meta tensor contains metadata but does not contain data. Therefore, `Module.to()` cannot copy a meta tensor to a real device.

PyTorch catches this error and adds guidance to use `Module.to_empty()`:

> Cannot copy out of meta tensor; no data! Please use torch.nn.Module.to_empty() instead...

The current code uses an exact string comparison. When `TORCH_SHOW_CPP_STACKTRACES=1`, PyTorch adds source information and a C++ stack trace to the error. The exact comparison then fails. PyTorch returns the lower-level error without the `Module.to_empty()` guidance.

## Fix

The new code checks that the error starts with the stable base message. It then separates the diagnostic suffix from the base message.

The code puts the messages in this order:

1. Base error.
2. `Module.to_empty()` guidance.
3. C++ diagnostic information.

This order keeps the user guidance clear and preserves the diagnostic data.

## Original test intent

The test verifies that `Module.to()` rejects an invalid copy from a meta tensor. It also verifies that the error tells the user to call `Module.to_empty()`. This change does not allow the invalid copy. It does not weaken the expected error message. It only makes the error translation work when C++ stack traces are enabled.

## Validation

I tested the change with a ROCm PyTorch wheel and matching source commit.

Before the change:
- Stack traces unset: pass.
- `TORCH_SHOW_CPP_STACKTRACES=1`: fail.

After the change:
- Stack traces unset: pass.
- `TORCH_SHOW_CPP_STACKTRACES=1`: pass.
- The `Module.to_empty()` guidance remains contiguous.
- The C++ captured traceback remains in the error message.

Test:

```bash
python test/test_nn.py \
  TestNNDeviceTypeCUDA.test_module_to_empty_cuda_float32

TORCH_SHOW_CPP_STACKTRACES=1 python test/test_nn.py \
  TestNNDeviceTypeCUDA.test_module_to_empty_cuda_float32
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

## ROCm CI evidence

The PR head (`4b2ef056`) passed the re-enabled test in ROCm trunk run [31396211188](https://github.com/pytorch/pytorch/actions/runs/31396211188), on MI350 default shard 2/8 ([job 93488986613](https://github.com/pytorch/pytorch/actions/runs/31396211188/job/93488986613)).

- Main job log: `test_nn 2/4 was successful` ([line 9217](https://github.com/pytorch/pytorch/actions/runs/31396211188/job/93488986613#L9217)); the shard list includes `test/test_nn.py::TestNNDeviceTypeCUDA::test_module_to_empty_cuda_float32` ([line 9218](https://github.com/pytorch/pytorch/actions/runs/31396211188/job/93488986613#L9218)).
- Exact test result: `test_nn.py::TestNNDeviceTypeCUDA::test_module_to_empty_cuda_float32 PASSED [0.0061s] [ 53%]`, line 429 of the uploaded [test log artifact](https://github.com/pytorch/pytorch/actions/runs/31396211188/artifacts/9073999252).
