### PR TITLE
Fix foreach version counters for tensor subclasses

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -1806,6 +1806,7 @@ class DistTensorCppPyTree(DTensorContinuousTestBase):
                 torch.zeros(4, 4, device=self.device_type), mesh, [Shard(0)]
             )
             regular = torch.zeros(4, 4, device=self.device_type)
+            versions = (dt._version, regular._version)
 
             torch._foreach_add_([dt, regular], 1)
             hits, misses = _get_fast_path_sharding_prop_cache_stats()
@@ -1814,10 +1815,18 @@ class DistTensorCppPyTree(DTensorContinuousTestBase):
                 dt.full_tensor(), torch.ones(4, 4, device=self.device_type)
             )
             self.assertEqual(regular, torch.ones(4, 4, device=self.device_type))
+            self.assertEqual(
+                (dt._version, regular._version),
+                tuple(version + 1 for version in versions),
+            )
 
             torch._foreach_add_([dt, regular], 1)
             hits, misses = _get_fast_path_sharding_prop_cache_stats()
             self.assertEqual(hits, 1)
+            self.assertEqual(
+                (dt._version, regular._version),
+                tuple(version + 2 for version in versions),
+            )
 
     def test_two_list_op_cache_collision(self):
         from torch.distributed.tensor._op_schema import RuntimeSchemaInfo

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1102,6 +1102,24 @@ $1: f32[1] = torch._ops.aten.detach.default($0)""",
         x.data.add_(2)
         self.assertEqual(cur_vc, x._version)
 
+    def test_foreach_inplace_version(self) -> None:
+        tensors = [LoggingTensor(torch.ones(1)), LoggingTensor(torch.ones(1))]
+        other = [LoggingTensor(torch.ones(1)), LoggingTensor(torch.ones(1))]
+        versions = [tensor._version for tensor in tensors]
+
+        torch._foreach_add_(tensors, other)
+        self.assertEqual(
+            [tensor._version for tensor in tensors],
+            [version + 1 for version in versions],
+        )
+        self.assertEqual([tensor._version for tensor in other], [0, 0])
+
+        torch._foreach_mul_(tensors, 2)
+        self.assertEqual(
+            [tensor._version for tensor in tensors],
+            [version + 2 for version in versions],
+        )
+
     def test_subclass_priority(self) -> None:
         class ErrorA(RuntimeError):
             pass

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1120,6 +1120,17 @@ $1: f32[1] = torch._ops.aten.detach.default($0)""",
             [version + 2 for version in versions],
         )
 
+    def test_mutable_tensor_list_custom_op_version(self) -> None:
+        @torch.library.custom_op(
+            "test_python_dispatch::mutate_tensor_list", mutates_args={"tensors"}
+        )
+        def mutate_tensor_list(tensors: list[torch.Tensor]) -> None:
+            torch._foreach_add_(tensors, 1)
+
+        tensor = LoggingTensor(torch.ones(1))
+        mutate_tensor_list([tensor])
+        self.assertEqual(tensor._version, 1)
+
     def test_subclass_priority(self) -> None:
         class ErrorA(RuntimeError):
             pass

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -294,6 +294,20 @@ void ConcretePyInterpreterVTable::dispatch(
   const auto num_arguments = schema.arguments().size();
   auto arguments = torch::jit::pop(*stack, num_arguments);
 
+  std::vector<at::Tensor> mutable_tensor_list_args;
+  for (const auto idx : c10::irange(arguments.size())) {
+    const auto* alias_info = schema.arguments()[idx].alias_info();
+    if (alias_info == nullptr || !alias_info->isWrite() ||
+        !arguments[idx].isList()) {
+      continue;
+    }
+    for (const auto& item : arguments[idx].toListRef()) {
+      if (item.isTensor()) {
+        mutable_tensor_list_args.push_back(item.toTensor());
+      }
+    }
+  }
+
   // The plan: convert all the arguments back into PyObjects,
   // extracting out the tensor handles, then call
   // handle_torch_function_no_python_arg_parser
@@ -341,6 +355,13 @@ void ConcretePyInterpreterVTable::dispatch(
       &op,
       &arguments,
       TorchFunctionName::TorchDispatch);
+  // In-place TensorList ops redispatch before native foreach kernels can
+  // update the original tensors' version counters.
+  if (obj != nullptr) {
+    for (const auto& tensor : mutable_tensor_list_args) {
+      tensor.unsafeGetTensorImpl()->bump_version();
+    }
+  }
   pushPyOutToStack(
       op, stack, py::reinterpret_steal<py::object>(obj), "__torch_dispatch__");
 }

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -295,15 +295,17 @@ void ConcretePyInterpreterVTable::dispatch(
   auto arguments = torch::jit::pop(*stack, num_arguments);
 
   std::vector<at::Tensor> mutable_tensor_list_args;
-  for (const auto idx : c10::irange(arguments.size())) {
-    const auto* alias_info = schema.arguments()[idx].alias_info();
-    if (alias_info == nullptr || !alias_info->isWrite() ||
-        !arguments[idx].isList()) {
-      continue;
-    }
-    for (const auto& item : arguments[idx].toListRef()) {
-      if (item.isTensor()) {
-        mutable_tensor_list_args.push_back(item.toTensor());
+  if (schema.operator_name().name.rfind("aten::_foreach_", 0) == 0) {
+    for (const auto idx : c10::irange(arguments.size())) {
+      const auto* alias_info = schema.arguments()[idx].alias_info();
+      if (alias_info == nullptr || !alias_info->isWrite() ||
+          !arguments[idx].isList()) {
+        continue;
+      }
+      for (const auto& item : arguments[idx].toListRef()) {
+        if (item.isTensor()) {
+          mutable_tensor_list_args.push_back(item.toTensor());
+        }
       }
     }
   }
@@ -355,15 +357,13 @@ void ConcretePyInterpreterVTable::dispatch(
       &op,
       &arguments,
       TorchFunctionName::TorchDispatch);
-  // In-place TensorList ops redispatch before native foreach kernels can
-  // update the original tensors' version counters.
-  if (obj != nullptr) {
-    for (const auto& tensor : mutable_tensor_list_args) {
-      tensor.unsafeGetTensorImpl()->bump_version();
-    }
-  }
   pushPyOutToStack(
       op, stack, py::reinterpret_steal<py::object>(obj), "__torch_dispatch__");
+  // In-place TensorList ops redispatch before native foreach kernels can
+  // update the original tensors' version counters.
+  for (const auto& tensor : mutable_tensor_list_args) {
+    tensor.unsafeGetTensorImpl()->bump_version();
+  }
 }
 
 void ConcretePyInterpreterVTable::python_dispatcher(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191154

## Summary
- Advance version counters for writable lists in native `aten::_foreach_*` operations after successful Python dispatch.
- Leave custom-op mutation tracking unchanged to avoid double version increments.
- Cover generic tensor subclasses and mixed DTensor/plain-Tensor foreach operations.

## Test plan
- `TestPythonDispatch.test_foreach_inplace_version`
- `TestPythonDispatch.test_mutable_tensor_list_custom_op_version`
- Mixed DTensor/plain-Tensor foreach version-counter regression
- DTensor foreach AdamW parameter and moment version checks
- Direct compile of `torch/csrc/PyInterpreter.cpp`