### PR TITLE
[ROCm] Update log10 and sampled_addmm metadata for ROCm 7.14 and later

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -492,7 +492,11 @@ ROCM_UNARY_NUMERICAL_XFAILS = {
         "tanh": {fp32},
     },
     "inductor_numerics": {
-        "log10": {fp16, fp32},
+        **(
+            {}
+            if TEST_WITH_ROCM and getRocmVersion() >= (7, 14)
+            else {"log10": {fp16, fp32}}
+        ),
         "sigmoid": {fp32},
     },
 }
@@ -565,6 +569,11 @@ ROCM_RELAXED_PROPERTY_CASES = {
             "cos": {fp32},
             "exp": {fp32},
             "log1p": {fp16, fp32},
+            **(
+                {"log10": {fp16, fp32}}
+                if TEST_WITH_ROCM and getRocmVersion() >= (7, 14)
+                else {}
+            ),
         },
         "inductor_numerics": {
             "rsqrt": {bf16},

--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -957,14 +957,6 @@ class TestOpInfoProperties(TestCase):
 
         Verifies bitwise equivalence between eager and compiled execution.
         """
-        if (
-            TEST_WITH_ROCM
-            and getRocmVersion() >= (7, 14)
-            and op.name == "log10"
-            and dtype in (torch.float16, torch.float32)
-            and backend in ("inductor_default", "inductor_numerics")
-        ):
-            self.skipTest("known log10 eager-vs-compiled failure on ROCm 7.14")
         torch._dynamo.reset()
         device_type = torch.device(device).type
 

--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -54,11 +54,13 @@ from torch.testing._internal.common_methods_invocations import (
     unary_ufuncs,
 )
 from torch.testing._internal.common_utils import (
+    getRocmVersion,
     IS_FBCODE,
     IS_WINDOWS,
     parametrize,
     skipIfTorchDynamo,
     TEST_WITH_ASAN,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.testing._internal.opinfo.core import _filter_unary_elementwise_tensor
@@ -490,7 +492,11 @@ ROCM_UNARY_NUMERICAL_XFAILS = {
         "tanh": {fp32},
     },
     "inductor_numerics": {
-        "log10": {fp16, fp32},
+        **(
+            {}
+            if TEST_WITH_ROCM and getRocmVersion() >= (7, 14)
+            else {"log10": {fp16, fp32}}
+        ),
         "sigmoid": {fp32},
     },
 }
@@ -563,6 +569,11 @@ ROCM_RELAXED_PROPERTY_CASES = {
             "cos": {fp32},
             "exp": {fp32},
             "log1p": {fp16, fp32},
+            **(
+                {"log10": {fp16, fp32}}
+                if TEST_WITH_ROCM and getRocmVersion() >= (7, 14)
+                else {}
+            ),
         },
         "inductor_numerics": {
             "rsqrt": {bf16},

--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -492,11 +492,7 @@ ROCM_UNARY_NUMERICAL_XFAILS = {
         "tanh": {fp32},
     },
     "inductor_numerics": {
-        **(
-            {}
-            if TEST_WITH_ROCM and getRocmVersion() >= (7, 14)
-            else {"log10": {fp16, fp32}}
-        ),
+        "log10": {fp16, fp32},
         "sigmoid": {fp32},
     },
 }
@@ -569,17 +565,20 @@ ROCM_RELAXED_PROPERTY_CASES = {
             "cos": {fp32},
             "exp": {fp32},
             "log1p": {fp16, fp32},
-            **(
-                {"log10": {fp16, fp32}}
-                if TEST_WITH_ROCM and getRocmVersion() >= (7, 14)
-                else {}
-            ),
         },
         "inductor_numerics": {
             "rsqrt": {bf16},
         },
     },
 }
+
+if TEST_WITH_ROCM and getRocmVersion() >= (7, 14):
+    # ROCm 7.14 fixes log10 strict numerics but still needs default-mode tolerance.
+    del ROCM_UNARY_NUMERICAL_XFAILS["inductor_numerics"]["log10"]
+    ROCM_RELAXED_PROPERTY_CASES["unary_numerical"]["inductor_default"]["log10"] = {
+        fp16,
+        fp32,
+    }
 
 
 def is_expected_failure(device_type, op_name, backend, test_type, dtype=None):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -57,7 +57,6 @@ from torch.testing._internal.common_methods_invocations import (
 from torch.testing._internal.common_utils import (
     clone_input_helper,
     first_sample,
-    getRocmVersion,
     HardwareClassification,
     IS_CI,
     IS_FBCODE,
@@ -72,7 +71,6 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     skipIfTorchInductor,
     suppress_warnings,
-    TEST_WITH_ROCM,
     TEST_WITH_TORCHDYNAMO,
     TEST_WITH_TORCHINDUCTOR,
     TestCase,
@@ -1612,12 +1610,6 @@ class TestCommon(TestCase):
     @onlyNativeDeviceTypesAnd(["hpu"])
     @ops(ops_and_refs, dtypes=OpDTypes.none)
     def test_dtypes(self, device, op):
-        if (
-            TEST_WITH_ROCM
-            and getRocmVersion() >= (7, 14)
-            and op.name == "sparse.sampled_addmm"
-        ):
-            self.skipTest("stale sparse.sampled_addmm OpInfo dtypes on ROCm 7.14")
         # Check complex32 support only if the op claims.
         # TODO: Once the complex32 support is better, we should add check for complex32 unconditionally.
         device_type = torch.device(device).type

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -42,6 +42,7 @@ from torch.testing._internal.common_quantized import (
     _bfloat16_to_float4_e2m1fn_x2,
 )
 from torch.testing._internal.common_utils import (
+    getRocmVersion,
     make_fullrank_matrices_with_distinct_singular_values,
     TEST_WITH_ROCM, IS_FBCODE, IS_LINUX, IS_WINDOWS, IS_MACOS, MACOS_VERSION, TEST_SCIPY,
     torch_to_numpy_dtype_dict, numpy_to_torch_dtype, TEST_WITH_ASAN,
@@ -13776,11 +13777,17 @@ op_db: list[OpInfo] = [
            # CUDA forward supports float16 (native cuSPARSE SDDMM) and bfloat16
            # (computed in float32; cuSPARSE has no bf16 SDDMM kernel). Backward
            # routes through cuSPARSE SpMM: float16 needs CC >= 5.3, bfloat16 needs
-           # CC >= 8.0, and ROCm's hipSPARSE SpMM implements neither dtype.
+           # CC >= 8.0. hipSPARSE SpMM supports both low-precision dtypes from
+           # ROCm 7.14.
            dtypesIfCUDA=floating_and_complex_types_and(torch.half, torch.bfloat16),
            backward_dtypesIfCUDA=floating_and_complex_types_and(
                *([torch.half] if not TEST_WITH_ROCM else []),
                *([torch.bfloat16] if SM80OrLater and not TEST_WITH_ROCM else [])),
+           backward_dtypesIfROCM=(
+               floating_and_complex_types_and(torch.half, torch.bfloat16)
+               if TEST_WITH_ROCM and getRocmVersion() >= (7, 14)
+               else floating_and_complex_types()
+           ),
            supports_autograd=True,
            sample_inputs_func=sample_inputs_sparse_sampled_addmm,
            decorators=[

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13818,8 +13818,7 @@ op_db: list[OpInfo] = [
            # ROCm 7.14.
            dtypesIfCUDA=floating_and_complex_types_and(torch.half, torch.bfloat16),
            backward_dtypesIfCUDA=floating_and_complex_types_and(
-               *([torch.half] if not TEST_WITH_ROCM else []),
-               *([torch.bfloat16] if SM80OrLater and not TEST_WITH_ROCM else [])),
+               torch.half, *([torch.bfloat16] if SM80OrLater else [])),
            backward_dtypesIfROCM=(
                floating_and_complex_types_and(torch.half, torch.bfloat16)
                if TEST_WITH_ROCM and getRocmVersion() >= (7, 14)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -42,6 +42,7 @@ from torch.testing._internal.common_quantized import (
     _bfloat16_to_float4_e2m1fn_x2,
 )
 from torch.testing._internal.common_utils import (
+    getRocmVersion,
     make_fullrank_matrices_with_distinct_singular_values,
     TEST_WITH_ROCM, IS_FBCODE, IS_LINUX, IS_WINDOWS, IS_MACOS, MACOS_VERSION, TEST_SCIPY,
     torch_to_numpy_dtype_dict, numpy_to_torch_dtype, TEST_WITH_ASAN,
@@ -13813,11 +13814,17 @@ op_db: list[OpInfo] = [
            # CUDA forward supports float16 (native cuSPARSE SDDMM) and bfloat16
            # (computed in float32; cuSPARSE has no bf16 SDDMM kernel). Backward
            # routes through cuSPARSE SpMM: float16 needs CC >= 5.3, bfloat16 needs
-           # CC >= 8.0, and ROCm's hipSPARSE SpMM implements neither dtype.
+           # CC >= 8.0. hipSPARSE SpMM supports both low-precision dtypes from
+           # ROCm 7.14.
            dtypesIfCUDA=floating_and_complex_types_and(torch.half, torch.bfloat16),
            backward_dtypesIfCUDA=floating_and_complex_types_and(
                *([torch.half] if not TEST_WITH_ROCM else []),
                *([torch.bfloat16] if SM80OrLater and not TEST_WITH_ROCM else [])),
+           backward_dtypesIfROCM=(
+               floating_and_complex_types_and(torch.half, torch.bfloat16)
+               if TEST_WITH_ROCM and getRocmVersion() >= (7, 14)
+               else floating_and_complex_types()
+           ),
            supports_autograd=True,
            sample_inputs_func=sample_inputs_sparse_sampled_addmm,
            decorators=[


### PR DESCRIPTION
This change updates ROCm metadata for three test expressions.  
- Remove the FP16 and FP32 `log10` strict-numerics xfails on ROCm 7.14 and later
- Use standard dtype tolerance for FP16 and FP32 `log10` default tests on ROCm 7.14 and later
- Declare FP16 and BF16 `sampled_addmm` backward support on ROCm 7.14 and later.  Earlier ROCm versions keep the existing metadata.
## ROCm CI evidence

The PR head (`9e260f5`) passed the five concrete tests in trunk run [31396168412](https://github.com/pytorch/pytorch/actions/runs/31396168412). The inductor-rocm-mi300 run [31396166430](https://github.com/pytorch/pytorch/actions/runs/31396166430) was build-only; its test job was skipped.

The exact per-test `PASSED` text below comes from the `logs-runattempt1-*` pytest artifacts. The linked GitHub Actions lines identify the corresponding shard or artifact path.

- `log10` strict numerics, FP16: `inductor/test_torchinductor_opinfo_properties.py::TestOpInfoPropertiesCUDA::test_unary_ufunc_numerical_log10_backend_inductor_numerics_cuda_float16 PASSED [0.2994s] [ 91%]` ([job 93485984696, line 8891](https://github.com/pytorch/pytorch/actions/runs/31396168412/job/93485984696#L8891)).
- `log10` strict numerics, FP32: `inductor/test_torchinductor_opinfo_properties.py::TestOpInfoPropertiesCUDA::test_unary_ufunc_numerical_log10_backend_inductor_numerics_cuda_float32 PASSED [0.2606s] [ 96%]` ([job 93485984819, line 9289](https://github.com/pytorch/pytorch/actions/runs/31396168412/job/93485984819#L9289)).
- `log10` default, FP16: `inductor/test_torchinductor_opinfo_properties.py::TestOpInfoPropertiesCUDA::test_unary_ufunc_numerical_log10_backend_inductor_default_cuda_float16 PASSED [0.2644s] [ 95%]` ([job 93485984819, line 9289](https://github.com/pytorch/pytorch/actions/runs/31396168412/job/93485984819#L9289)).
- `log10` default, FP32: `inductor/test_torchinductor_opinfo_properties.py::TestOpInfoPropertiesCUDA::test_unary_ufunc_numerical_log10_backend_inductor_default_cuda_float32 PASSED [0.2634s] [ 88%]` ([job 93485984862, line 9330](https://github.com/pytorch/pytorch/actions/runs/31396168412/job/93485984862#L9330); the opinfo shard is also identified at [line 9214](https://github.com/pytorch/pytorch/actions/runs/31396168412/job/93485984862#L9214)).

- `sampled_addmm` backward dtype metadata: `test_ops.py::TestCommonCUDA::test_dtypes_sparse_sampled_addmm_cuda PASSED [0.2699s] [ 5%]` ([job 93485984862, line 9330](https://github.com/pytorch/pytorch/actions/runs/31396168412/job/93485984862#L9330)).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben