### PR TITLE
[fix]#191153 add Meta kernels for fused GRU cells

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1580,19 +1580,36 @@ class FakeTensorTest(TestCase):
                 self.assertEqual(h_n.shape, (D * num_layers, N, H_out))
                 self.assertEqual(c_n.shape, (D * num_layers, N, hidden_size))
 
-    @parametrize("bias", [False, True])
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
-    def test_cuda_gru_cell(self, bias):
-        with FakeTensorMode(allow_fallback_kernels=False):
-            batch_size = 2
-            hidden_size = 4
-            cell = torch.nn.GRUCell(hidden_size, hidden_size, bias=bias, device="cuda")
-            hidden = torch.randn(batch_size, hidden_size, device="cuda")
-            inp = torch.randn(batch_size, hidden_size, device="cuda")
-            output = cell(inp, hidden)
-            output.sum().backward()
+    def test_cuda_gru(self):
+        with torch.backends.cudnn.flags(enabled=False):
+            fake_tensor_mode = FakeTensorMode(allow_fallback_kernels=False)
+            with fake_tensor_mode:
+                N = 5
+                L = 4
+                H_in = 2
+                hidden_size = 3
+                num_layers = 2
+                bidir = False
+                D = 2 if bidir else 1
 
-            self.assertEqual(output.shape, hidden.shape)
+                gru = torch.nn.GRU(
+                    input_size=H_in,
+                    hidden_size=hidden_size,
+                    num_layers=num_layers,
+                    batch_first=False,
+                    bias=True,
+                    bidirectional=bidir,
+                    device="cuda",
+                )
+
+                h_0 = torch.randn((num_layers * D, N, hidden_size), device="cuda")
+                inp = torch.randn((L, N, H_in), device="cuda")
+                output, h_n = gru(inp, h_0)
+                output.sum().backward()
+
+                self.assertEqual(output.shape, (L, N, D * hidden_size))
+                self.assertEqual(h_n.shape, (D * num_layers, N, hidden_size))
 
     def test_data_dependent_operator(self):
         with FakeTensorMode(allow_fallback_kernels=False):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1580,6 +1580,20 @@ class FakeTensorTest(TestCase):
                 self.assertEqual(h_n.shape, (D * num_layers, N, H_out))
                 self.assertEqual(c_n.shape, (D * num_layers, N, hidden_size))
 
+    @parametrize("bias", [False, True])
+    @unittest.skipIf(not RUN_CUDA, "requires cuda")
+    def test_cuda_gru_cell(self, bias):
+        with FakeTensorMode(allow_fallback_kernels=False):
+            batch_size = 2
+            hidden_size = 4
+            cell = torch.nn.GRUCell(hidden_size, hidden_size, bias=bias, device="cuda")
+            hidden = torch.randn(batch_size, hidden_size, device="cuda")
+            inp = torch.randn(batch_size, hidden_size, device="cuda")
+            output = cell(inp, hidden)
+            output.sum().backward()
+
+            self.assertEqual(output.shape, hidden.shape)
+
     def test_data_dependent_operator(self):
         with FakeTensorMode(allow_fallback_kernels=False):
             x = torch.rand([10, 10])

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7542,7 +7542,7 @@ def rnn_cell_checkSizes(
     )
     torch._check(
         all(
-            x.device == input_gates.device
+            x is None or x.device == input_gates.device
             for x in [hidden_gates, input_bias, hidden_bias, prev_hidden]
         ),
         lambda: "expected all inputs to be same device",
@@ -7562,6 +7562,23 @@ def _thnn_fused_lstm_cell_meta(
     hy = torch.empty_like(cx, memory_format=torch.contiguous_format)
     cy = torch.empty_like(cx, memory_format=torch.contiguous_format)
     return (hy, cy, workspace)
+
+
+GRU_WORKSPACE_MULTIPLIER = 5
+
+
+@register_meta(aten._thnn_fused_gru_cell.default)
+def _thnn_fused_gru_cell_meta(
+    input_gates,
+    hidden_gates,
+    hx,
+    input_bias=None,
+    hidden_bias=None,
+):
+    rnn_cell_checkSizes(input_gates, hidden_gates, input_bias, hidden_bias, 3, hx)
+    workspace = hx.new_empty((hx.size(0), hx.size(1) * GRU_WORKSPACE_MULTIPLIER))
+    hy = torch.empty_like(hx, memory_format=torch.contiguous_format)
+    return (hy, workspace)
 
 
 @register_meta(aten._cudnn_rnn.default)
@@ -7831,6 +7848,35 @@ def _thnn_fused_lstm_cell_backward_impl(grad_hy, grad_cy, cx, cy, workspace, has
     grad_cx = torch.empty_like(cx, memory_format=legacy_contiguous_memory_format)
     grad_bias = grad_gates.sum(0, keepdim=False) if has_bias else None
     return grad_gates, grad_cx, grad_bias
+
+
+def checkGRUBackwardSizes(grad_hy, workspace):
+    torch._check(grad_hy.dim() == 2, lambda: "")
+    torch._check(workspace.dim() == 2, lambda: "")
+    torch._check(workspace.size(0) == grad_hy.size(0), lambda: "")
+    torch._check(
+        workspace.size(1) == grad_hy.size(1) * GRU_WORKSPACE_MULTIPLIER,
+        lambda: "",
+    )
+
+
+@register_meta(aten._thnn_fused_gru_cell_backward.default)
+def _thnn_fused_gru_cell_backward(grad_hy, workspace, has_bias):
+    checkGRUBackwardSizes(grad_hy, workspace)
+    hidden_size = workspace.size(1) // GRU_WORKSPACE_MULTIPLIER
+    gates_shape = (workspace.size(0), hidden_size * 3)
+    grad_input_gates = workspace.new_empty(gates_shape)
+    grad_hidden_gates = workspace.new_empty(gates_shape)
+    grad_hx = torch.empty_like(grad_hy, memory_format=legacy_contiguous_memory_format)
+    grad_input_bias = grad_input_gates.sum(0, keepdim=False) if has_bias else None
+    grad_hidden_bias = grad_hidden_gates.sum(0, keepdim=False) if has_bias else None
+    return (
+        grad_input_gates,
+        grad_hidden_gates,
+        grad_hx,
+        grad_input_bias,
+        grad_hidden_bias,
+    )
 
 
 # From aten/src/ATen/native/mps/operations/Linear.mm

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7564,9 +7564,6 @@ def _thnn_fused_lstm_cell_meta(
     return (hy, cy, workspace)
 
 
-GRU_WORKSPACE_MULTIPLIER = 5
-
-
 @register_meta(aten._thnn_fused_gru_cell.default)
 def _thnn_fused_gru_cell_meta(
     input_gates,
@@ -7576,7 +7573,7 @@ def _thnn_fused_gru_cell_meta(
     hidden_bias=None,
 ):
     rnn_cell_checkSizes(input_gates, hidden_gates, input_bias, hidden_bias, 3, hx)
-    workspace = hx.new_empty((hx.size(0), hx.size(1) * GRU_WORKSPACE_MULTIPLIER))
+    workspace = hx.new_empty((hx.size(0), hx.size(1) * 5))
     hy = torch.empty_like(hx, memory_format=torch.contiguous_format)
     return (hy, workspace)
 
@@ -7851,20 +7848,35 @@ def _thnn_fused_lstm_cell_backward_impl(grad_hy, grad_cy, cx, cy, workspace, has
 
 
 def checkGRUBackwardSizes(grad_hy, workspace):
-    torch._check(grad_hy.dim() == 2, lambda: "")
-    torch._check(workspace.dim() == 2, lambda: "")
-    torch._check(workspace.size(0) == grad_hy.size(0), lambda: "")
     torch._check(
-        workspace.size(1) == grad_hy.size(1) * GRU_WORKSPACE_MULTIPLIER,
-        lambda: "",
+        grad_hy.dim() == 2,
+        lambda: f"Expected grad_hy to be 2-D, but got {grad_hy.dim()}-D",
+    )
+    torch._check(
+        workspace.dim() == 2,
+        lambda: f"Expected workspace to be 2-D, but got {workspace.dim()}-D",
+    )
+    torch._check(
+        workspace.size(0) == grad_hy.size(0),
+        lambda: (
+            f"Expected workspace batch size ({workspace.size(0)}) to match "
+            f"grad_hy batch size ({grad_hy.size(0)})"
+        ),
+    )
+    torch._check(
+        workspace.size(1) == grad_hy.size(1) * 5,
+        lambda: (
+            "Expected workspace.size(1) to equal grad_hy.size(1) * 5, but got "
+            f"workspace.size(1)={workspace.size(1)} and "
+            f"grad_hy.size(1)={grad_hy.size(1)}"
+        ),
     )
 
 
 @register_meta(aten._thnn_fused_gru_cell_backward.default)
 def _thnn_fused_gru_cell_backward(grad_hy, workspace, has_bias):
     checkGRUBackwardSizes(grad_hy, workspace)
-    hidden_size = workspace.size(1) // GRU_WORKSPACE_MULTIPLIER
-    gates_shape = (workspace.size(0), hidden_size * 3)
+    gates_shape = (grad_hy.size(0), grad_hy.size(1) * 3)
     grad_input_gates = workspace.new_empty(gates_shape)
     grad_hidden_gates = workspace.new_empty(gates_shape)
     grad_hx = torch.empty_like(grad_hy, memory_format=legacy_contiguous_memory_format)


### PR DESCRIPTION
## Issue
Fixes #191153
## Summary

Add Meta implementations for the fused GRU cell forward and backward operators so CUDA `GRUCell` can be captured through FakeTensor, including the `scan` compilation path.

The implementations match the CUDA output, workspace, and gradient shapes. The regression test covers forward and backward with and without bias while disabling unsafe fallback kernels.

## Checklist

- [x] Passes lint
- [x] Added/updated tests