### PR TITLE
[Testcase Refactoring]Add PrivateUse1 backend support to test_embedding_bag

### DIFF
--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
@@ -166,14 +166,14 @@ class TestShardedEmbeddingBag(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_sharded_embedding_bag_colwise(self):
         for spec in generate_chunk_sharding_specs_for_test(1):
             self._test_sharded_embedding_bag_with_test_cases(spec, 1)
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_sharded_embedding_bag_rowwise(self):
         for spec in generate_chunk_sharding_specs_for_test(0):
             self._test_sharded_embedding_bag_with_test_cases(spec, 0)


### PR DESCRIPTION
### Summary
This PR adds "privateuse1" to the @requires_accelerator_dist_backend decorator in test_embedding_bag.py to enable ShardedTensor embedding bag tests on out-of-tree backends.

This is a step toward making distributed ShardedTensor tests compatible with PrivateUse1-based accelerators.

### Changes
Updated @requires_accelerator_dist_backend(["nccl", "xccl"]) to @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"]) in test_sharded_embedding_bag_colwise.
Updated @requires_accelerator_dist_backend(["nccl", "xccl"]) to @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"]) in test_sharded_embedding_bag_rowwise.
### Motivation
The test file already uses device-agnostic APIs (torch.accelerator.current_accelerator(True) and get_default_backend_for_device(device_type)), but the requires_accelerator_dist_backend decorator only allowed "nccl" and "xccl" backends. Adding "privateuse1" enables out-of-tree backends to run these tests without modifying the test logic.

### Test Plan
CI: python test/run_test.py -i distributed/_shard/sharded_tensor/test_embedding_bag
TODO: Verify on a PrivateUse1-compatible backend if available.
### Notes
The test logic remains unchanged; only the decorator backend list is extended.
TEST_GPU_NUM and skip_if_lt_x_gpu naming are preserved for backward compatibility.


@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian