### PR TITLE
[Testcase Refactoring] Bind list_device to the runtime accelerator in test_utils.py

### DIFF
--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -41,7 +41,7 @@ if TEST_HPU:
 elif TEST_XPU:
     list_device = "xpu"
 else:
-    _acc = torch.accelerator.current_accelerator()
+    _acc = torch.accelerator.current_accelerator(check_available=True)
     list_device = _acc.type if _acc is not None else "cuda"
 
 

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -41,7 +41,8 @@ if TEST_HPU:
 elif TEST_XPU:
     list_device = "xpu"
 else:
-    list_device = "cuda"
+    _acc = torch.accelerator.current_accelerator()
+    list_device = _acc.type if _acc is not None else "cuda"
 
 
 class TestUtils(TestCase):


### PR DESCRIPTION
## Summary

Resolve `list_device` in `test/distributed/fsdp/test_utils.py` through the
runtime-registered accelerator instead of a hardcoded value.

## Motivation

The current implementation hardcodes `list_device = "cuda"` whenever
`TEST_HPU`/`TEST_XPU` are both false. On a runtime-registered out-of-tree
accelerator, no CUDA device is actually available, so
`TestUtilsPRIVATEUSE1.test_apply_to_tensors_*` fails with
`Torch not compiled with CUDA enabled`.

## Changes

- Resolve `list_device` via `torch.accelerator.current_accelerator()`.
- Preserve the existing fallback to `"cuda"` when no accelerator is
  detected (e.g. CPU-only CI).

## Test Plan

This change was exercised across accelerator and CPU backends.

NPU/HCCL:

- `test/distributed/fsdp/test_utils.py`: 6 tests passed

CUDA:

- `test/distributed/fsdp/test_utils.py`: 6 tests passed

CPU:

- `test/distributed/fsdp/test_utils.py`: `NO TESTS RAN` - pre-existing
  behavior unrelated to this change. `instantiate_device_type_tests(...,
  only_for=("cuda","hpu","xpu"))` at the bottom of this file does not
  generate a CPU test base regardless of this fix.

## Related

Related to #185590.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian
