### PR TITLE
[Testcase Refactoring] Replace CUDA/XPU-only skip conditions in test_wrap.py with generic accelerator checks

### DIFF
--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -418,7 +418,9 @@ class TestAutoWrap(TestCase):
         # For all the tests here, we use a fake group
         self.process_group = DummyProcessGroup(rank=0, size=1)
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_wrap(self, wrap_method):
         if wrap_method == WrapMethod.WRAP_API:
@@ -438,7 +440,9 @@ class TestAutoWrap(TestCase):
         self.assertEqual(layer.rank, self.process_group.rank())
         self.assertEqual(layer.world_size, self.process_group.size())
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_wrap_disabled_outside_context(self):
         pg = self.process_group
 
@@ -455,7 +459,9 @@ class TestAutoWrap(TestCase):
         self.assertFalse(isinstance(model.lin, FSDP))
         self.assertTrue(isinstance(model.lin, nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_wrap_override_defaults(self):
         new_process_group = DummyProcessGroup(rank=0, size=2)
         with enable_wrap(wrapper_cls=FSDP, process_group=self.process_group):
@@ -479,7 +485,9 @@ class TestAutoWrap(TestCase):
         )
         TestFSDPWrap.NestedSequentialModel.verify_model_all_wrapped(self, model)
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_transformer_auto_wrap_policy(self):
         """Tests the ``transformer_auto_wrap_policy``."""
         auto_wrap_policy = functools.partial(
@@ -488,7 +496,9 @@ class TestAutoWrap(TestCase):
         )
         self._test_transformer_wrapping(auto_wrap_policy)
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_module_wrap_policy(self):
         """Tests the ``ModuleWrapPolicy``."""
         auto_wrap_policy = ModuleWrapPolicy(
@@ -496,7 +506,9 @@ class TestAutoWrap(TestCase):
         )
         self._test_transformer_wrapping(auto_wrap_policy)
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_module_wrap_policy_callable(self):
         """Tests the ``ModuleWrapPolicy`` as a ``Callable``."""
         auto_wrap_policy = ModuleWrapPolicy(
@@ -526,7 +538,9 @@ class TestAutoWrap(TestCase):
             else:
                 self.assertFalse(isinstance(module, FSDP))
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_custom_policy(self):
         """
         Tests ``CustomPolicy`` with both a lambda function that uses uniform
@@ -629,7 +643,9 @@ class TestAutoWrap(TestCase):
             else:
                 self.assertFalse(isinstance(module, FSDP))
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_auto_wrap_api(self):
         """
         Test to ensure with auto wrap, we wrap child modules correctly based on the min_num_params.
@@ -647,7 +663,9 @@ class TestAutoWrap(TestCase):
 
         TestFSDPWrap.NestedSequentialModel.verify_model(self, model)
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_auto_wrap_preset_exclude_wrap(self):
         """
         Test to ensure excluded modules are not wrapped, regardless if the total param size is greater than the
@@ -668,7 +686,9 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model[0], nn.Linear))
         self.assertTrue(isinstance(model[1], nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_auto_wrap_preset_exclude_wrap_include_children(self):
         """
         Test to ensure excluded modules are not wrapped, but children are if param size is greater than
@@ -687,7 +707,9 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model, FSDP))
         self.assertTrue(isinstance(model[0], FSDP))
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_auto_wrap_preset_force_leaf(self):
         """
         Test to ensure force-leaf modules are not wrapped, and children are not wrapped. The
@@ -707,7 +729,9 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[1], nn.MultiheadAttention))
         self.assertTrue(isinstance(model.module[1].out_proj, nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_auto_wrap_preset_force_leaf_custom(self):
         """
         Test to ensure force-leaf modules are not wrapped.
@@ -803,7 +827,9 @@ class TestAutoWrap(TestCase):
         except FileNotFoundError:
             pass
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_always_wrap_with_ignored_modules(self, wrap_method: WrapMethod):
         sequential = TestFSDPWrap.NestedSequentialModel.get_model(device=False)
@@ -828,7 +854,9 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[2].module[0], nn.Linear))
         self.assertTrue(isinstance(model.module[2].module[1], FSDP))
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_auto_wrap_with_ignored_modules(self, wrap_method: WrapMethod):
         sequential = TestFSDPWrap.NestedSequentialModel.get_model(device=False)
@@ -861,7 +889,9 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[2][0], nn.Linear))
         self.assertTrue(isinstance(model.module[2][1], nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
     def test_frozen_params(self):
         """
         Tests that mixing frozen/non-frozen parameters in an FSDP instance

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -33,7 +33,6 @@ from torch.distributed.fsdp.wrap import (
 )
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.modules.batchnorm import _BatchNorm
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     _move_to_device,
@@ -49,8 +48,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
-    TEST_CUDA,
-    TEST_XPU,
+    TEST_MULTIACCELERATOR,
     TestCase,
 )
 
@@ -420,7 +418,7 @@ class TestAutoWrap(TestCase):
         # For all the tests here, we use a fake group
         self.process_group = DummyProcessGroup(rank=0, size=1)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_wrap(self, wrap_method):
         if wrap_method == WrapMethod.WRAP_API:
@@ -440,7 +438,7 @@ class TestAutoWrap(TestCase):
         self.assertEqual(layer.rank, self.process_group.rank())
         self.assertEqual(layer.world_size, self.process_group.size())
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_wrap_disabled_outside_context(self):
         pg = self.process_group
 
@@ -457,7 +455,7 @@ class TestAutoWrap(TestCase):
         self.assertFalse(isinstance(model.lin, FSDP))
         self.assertTrue(isinstance(model.lin, nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_wrap_override_defaults(self):
         new_process_group = DummyProcessGroup(rank=0, size=2)
         with enable_wrap(wrapper_cls=FSDP, process_group=self.process_group):
@@ -467,7 +465,9 @@ class TestAutoWrap(TestCase):
         self.assertEqual(layer.rank, 0)
         self.assertEqual(layer.world_size, 2)
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test Requires CUDA or XPU")
+    @unittest.skipIf(
+        torch.accelerator.current_accelerator() is None, "Test Requires an accelerator"
+    )
     def test_always_wrap(self):
         """
         Test to ensure that if `always_wrap_policy` is
@@ -479,7 +479,7 @@ class TestAutoWrap(TestCase):
         )
         TestFSDPWrap.NestedSequentialModel.verify_model_all_wrapped(self, model)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_transformer_auto_wrap_policy(self):
         """Tests the ``transformer_auto_wrap_policy``."""
         auto_wrap_policy = functools.partial(
@@ -488,7 +488,7 @@ class TestAutoWrap(TestCase):
         )
         self._test_transformer_wrapping(auto_wrap_policy)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_module_wrap_policy(self):
         """Tests the ``ModuleWrapPolicy``."""
         auto_wrap_policy = ModuleWrapPolicy(
@@ -496,7 +496,7 @@ class TestAutoWrap(TestCase):
         )
         self._test_transformer_wrapping(auto_wrap_policy)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_module_wrap_policy_callable(self):
         """Tests the ``ModuleWrapPolicy`` as a ``Callable``."""
         auto_wrap_policy = ModuleWrapPolicy(
@@ -526,7 +526,7 @@ class TestAutoWrap(TestCase):
             else:
                 self.assertFalse(isinstance(module, FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_custom_policy(self):
         """
         Tests ``CustomPolicy`` with both a lambda function that uses uniform
@@ -629,7 +629,7 @@ class TestAutoWrap(TestCase):
             else:
                 self.assertFalse(isinstance(module, FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_auto_wrap_api(self):
         """
         Test to ensure with auto wrap, we wrap child modules correctly based on the min_num_params.
@@ -647,7 +647,7 @@ class TestAutoWrap(TestCase):
 
         TestFSDPWrap.NestedSequentialModel.verify_model(self, model)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_auto_wrap_preset_exclude_wrap(self):
         """
         Test to ensure excluded modules are not wrapped, regardless if the total param size is greater than the
@@ -668,7 +668,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model[0], nn.Linear))
         self.assertTrue(isinstance(model[1], nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_auto_wrap_preset_exclude_wrap_include_children(self):
         """
         Test to ensure excluded modules are not wrapped, but children are if param size is greater than
@@ -687,7 +687,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model, FSDP))
         self.assertTrue(isinstance(model[0], FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_auto_wrap_preset_force_leaf(self):
         """
         Test to ensure force-leaf modules are not wrapped, and children are not wrapped. The
@@ -707,7 +707,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[1], nn.MultiheadAttention))
         self.assertTrue(isinstance(model.module[1].out_proj, nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_auto_wrap_preset_force_leaf_custom(self):
         """
         Test to ensure force-leaf modules are not wrapped.
@@ -732,7 +732,9 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[0], nn.Linear))
         self.assertTrue(isinstance(model.module[1], nn.ModuleList))
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test Requires CUDA or XPU")
+    @unittest.skipIf(
+        torch.accelerator.current_accelerator() is None, "Test Requires an accelerator"
+    )
     @parametrize(
         "device_init_mode", [DEVICEInitMode.DEVICE_BEFORE, DEVICEInitMode.DEVICE_AFTER]
     )
@@ -801,7 +803,7 @@ class TestAutoWrap(TestCase):
         except FileNotFoundError:
             pass
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_always_wrap_with_ignored_modules(self, wrap_method: WrapMethod):
         sequential = TestFSDPWrap.NestedSequentialModel.get_model(device=False)
@@ -826,7 +828,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[2].module[0], nn.Linear))
         self.assertTrue(isinstance(model.module[2].module[1], FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_auto_wrap_with_ignored_modules(self, wrap_method: WrapMethod):
         sequential = TestFSDPWrap.NestedSequentialModel.get_model(device=False)
@@ -859,7 +861,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[2][0], nn.Linear))
         self.assertTrue(isinstance(model.module[2][1], nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices")
     def test_frozen_params(self):
         """
         Tests that mixing frozen/non-frozen parameters in an FSDP instance


### PR DESCRIPTION
## Summary

Replace two CUDA/XPU-only skip conditions in
`test/distributed/fsdp/test_wrap.py` with generic accelerator checks.

## Motivation

`TEST_MULTIGPU` (`common_cuda.py`) only checks
`torch.cuda.device_count()`, so the 13 tests gated on it unconditionally
skip on any non-CUDA multi-device host even though the underlying test
logic has no CUDA dependency. Separately, 2 tests gated on `not TEST_CUDA
and not TEST_XPU` skip on other accelerators despite their model
construction (`NestedSequentialModel.get_model`) already being
accelerator-generic via `sequential.to(device=device_type)`.

## Changes

- 13 sites using `TEST_MULTIGPU` -> replaced with the existing generic
  `TEST_MULTIACCELERATOR` (`common_utils.py`).
- 2 sites using `not TEST_CUDA and not TEST_XPU` (`test_always_wrap`, one
  parametrized `test_auto_wrap_smoke_test` group) -> replaced with
  `torch.accelerator.current_accelerator() is None`, matching this
  file's own existing device-detection pattern.

Both replacements preserve existing behavior on CUDA/HPU/XPU.

## Test Plan

This change was exercised across accelerator and CPU backends.

NPU/HCCL (with the device-detection fixes from #187650 applied, since
this file cannot reach a meaningful accelerator signal without them):

- `test/distributed/fsdp/test_wrap.py`: 52 tests passed, 0 skipped

CUDA (4 GPUs, no additional patches applied):

- `test/distributed/fsdp/test_wrap.py`: 52 tests passed, 0 skipped

CPU (no accelerator):

- `test/distributed/fsdp/test_wrap.py`: `OK (skipped=51)` - all 15 sites
  touched by this change correctly skip with the new messages
  (`Test Requires an accelerator` / `Requires at least 2 accelerator
  devices`); 1 unrelated test (`test_validate_frozen_params`) passes; no
  failures, no errors.

## Related

Related to #185590. Companion change for #187650, which makes
`skip_if_lt_x_gpu` and `common_fsdp.py`'s device detection
hardware-agnostic for out-of-tree accelerator backends.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian