### PR TITLE
Add FlyDSL native RMSNorm backward override

### DIFF
--- a/test/python_native/test_flydsl_rmsnorm_bwd.py
+++ b/test/python_native/test_flydsl_rmsnorm_bwd.py
@@ -1,0 +1,284 @@
+# Owner(s): ["module: dsl-native-ops"]
+
+import unittest
+
+import torch
+import torch.backends.python_native as pn
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
+EPS = 1e-5
+# This shape is below the FWD gate but wins for BWD, which exercises that the
+# two operator predicates dispatch independently.
+BWD_DISPATCH_M = 2048
+BWD_DISPATCH_N = 8192
+BWD_DISPATCH_DTYPE = torch.float16
+
+DIRECT_CASES = (
+    (128, 4096, torch.float16),
+    (128, 8192, torch.bfloat16),
+    (128, 4096, torch.float32),
+    # Non-aligned N exercises the generic vector body and scalar tail in
+    # K1/K2/K3. M=65 also crosses the 64-way dweight split boundary.
+    (65, 4197, torch.float16),
+    (65, 4197, torch.bfloat16),
+    (65, 4197, torch.float32),
+    # Tail-only cases cover N smaller than one 128-bit vector.
+    (65, 7, torch.float16),
+    (65, 3, torch.float32),
+)
+
+# dtype, inclusive N range, first enabled M, and previous M kept on ATen.
+BWD_PERF_RANGES = (
+    (torch.float16, 16, 63, 8192, 4096),
+    (torch.float16, 1024, 2047, 65536, 32768),
+    (torch.float16, 2048, 4095, 32768, 16384),
+    (torch.float16, 4096, 8191, 8192, 4096),
+    (torch.float16, 8192, 16383, 2048, 1024),
+    (torch.float16, 16384, 32767, 512, 256),
+    (torch.float16, 32768, 65536, 16, 8),
+    (torch.bfloat16, 16, 63, 8192, 4096),
+    (torch.bfloat16, 1024, 2047, 65536, 32768),
+    (torch.bfloat16, 2048, 4095, 32768, 16384),
+    (torch.bfloat16, 4096, 8191, 8192, 4096),
+    (torch.bfloat16, 8192, 16383, 2048, 1024),
+    (torch.bfloat16, 16384, 32767, 512, 256),
+    (torch.bfloat16, 32768, 65536, 16, 8),
+    (torch.float32, 16, 63, 16384, 8192),
+    (torch.float32, 256, 511, 65536, 32768),
+    (torch.float32, 512, 2047, 16384, 8192),
+    (torch.float32, 2048, 4095, 8192, 4096),
+    (torch.float32, 4096, 8191, 4096, 2048),
+    (torch.float32, 8192, 16383, 2048, 1024),
+    (torch.float32, 16384, 32767, 64, 32),
+    (torch.float32, 32768, 65536, 16, 8),
+)
+
+
+def _flydsl_bwd_registered() -> bool:
+    try:
+        return "_fused_rms_norm_backward" in pn.get_dsl_operations("flydsl")
+    except Exception:
+        return False
+
+
+def _cache_counts() -> dict[str, int]:
+    from torch._native.ops.norm.flydsl_rmsnorm_bwd import rmsnorm_bwd_cache_info
+
+    info = rmsnorm_bwd_cache_info()
+    return {
+        "hits": info.hits,
+        "misses": info.misses,
+        "currsize": info.currsize,
+    }
+
+
+def _route_delta(before, after) -> int:
+    return after["hits"] + after["misses"] - before["hits"] - before["misses"]
+
+
+def _shared_rstd(x: torch.Tensor) -> torch.Tensor:
+    """Create an FP32 rstd fixture without invoking any RMSNorm FWD path."""
+
+    return torch.rsqrt(x.float().square().mean(dim=-1, keepdim=True) + EPS).contiguous()
+
+
+def _tolerance(dtype: torch.dtype, result: str) -> tuple[float, float]:
+    if result == "dweight":
+        return {
+            torch.float32: (1e-4, 1e-2),
+            torch.float16: (3e-2, 2e-1),
+            torch.bfloat16: (1e-1, 1.0),
+        }[dtype]
+    return {
+        torch.float32: (1e-4, 1e-3),
+        torch.float16: (3e-2, 3e-2),
+        torch.bfloat16: (1e-1, 2e-1),
+    }[dtype]
+
+
+def _direct_case_name(case) -> str:
+    m, n, dtype = case
+    return f"M{m}_N{n}_{str(dtype).removeprefix('torch.')}"
+
+
+def _perf_case_name(case) -> str:
+    dtype, n_first, n_last, enabled_m, _ = case
+    return f"{str(dtype).removeprefix('torch.')}_N{n_first}_{n_last}_M{enabled_m}"
+
+
+class TestFlyDSLRMSNormBwdPerfGate(TestCase):
+    @parametrize("case", BWD_PERF_RANGES, name_fn=_perf_case_name)
+    def test_mi355_wall_to_sync_ranges(self, case):
+        from torch._native.ops.norm.flydsl_rmsnorm_bwd_impl import (
+            _fused_rms_norm_bwd_perf_wins,
+        )
+
+        dtype, n_first, n_last, enabled_m, aten_m = case
+        for n in (n_first, n_last):
+            enabled = torch.empty((enabled_m, n), device="meta", dtype=dtype)
+            self.assertTrue(_fused_rms_norm_bwd_perf_wins(enabled, n))
+            fallback = torch.empty((aten_m, n), device="meta", dtype=dtype)
+            self.assertFalse(_fused_rms_norm_bwd_perf_wins(fallback, n))
+
+    def test_unprofitable_n_gaps_stay_on_aten(self):
+        from torch._native.ops.norm.flydsl_rmsnorm_bwd_impl import (
+            _fused_rms_norm_bwd_perf_wins,
+        )
+
+        cases = (
+            (torch.float16, 64),
+            (torch.float16, 512),
+            (torch.bfloat16, 64),
+            (torch.bfloat16, 512),
+            (torch.float32, 64),
+            (torch.float32, 128),
+        )
+        for dtype, n in cases:
+            with self.subTest(dtype=dtype, n=n):
+                x = torch.empty((65536, n), device="meta", dtype=dtype)
+                self.assertFalse(_fused_rms_norm_bwd_perf_wins(x, n))
+
+    def test_n_outside_measured_range_stays_on_aten(self):
+        from torch._native.ops.norm.flydsl_rmsnorm_bwd_impl import (
+            _fused_rms_norm_bwd_perf_wins,
+        )
+
+        for dtype in (torch.float16, torch.bfloat16, torch.float32):
+            for n in (15, 65537):
+                with self.subTest(dtype=dtype, n=n):
+                    x = torch.empty((32768, n), device="meta", dtype=dtype)
+                    self.assertFalse(_fused_rms_norm_bwd_perf_wins(x, n))
+
+        unsupported = torch.empty((32768, 32768), device="meta", dtype=torch.float64)
+        self.assertFalse(_fused_rms_norm_bwd_perf_wins(unsupported, 32768))
+
+    def test_bwd_buffer_address_limit(self):
+        from torch._native.ops.norm.flydsl_rmsnorm_bwd_impl import (
+            _fused_rms_norm_bwd_buffer_addressable,
+        )
+
+        for dtype, m, n in (
+            (torch.float16, 32768, 65536),
+            (torch.bfloat16, 32768, 65536),
+            (torch.float32, 16384, 65536),
+        ):
+            with self.subTest(dtype=dtype):
+                below_limit = torch.empty((m // 2, n), device="meta", dtype=dtype)
+                at_limit = torch.empty((m, n), device="meta", dtype=dtype)
+                self.assertTrue(_fused_rms_norm_bwd_buffer_addressable(below_limit))
+                self.assertFalse(_fused_rms_norm_bwd_buffer_addressable(at_limit))
+
+
+@unittest.skipUnless(TEST_CUDA and torch.version.hip is not None, "ROCm required")
+@unittest.skipUnless(
+    _flydsl_bwd_registered(), "FlyDSL RMSNorm backward is not registered"
+)
+class TestFlyDSLRMSNormBwd(TestCase):
+    def setUp(self):
+        super().setUp()
+        from torch._native.ops.norm.flydsl_rmsnorm_bwd import clear_rmsnorm_bwd_caches
+
+        clear_rmsnorm_bwd_caches()
+        torch.manual_seed(0)
+
+    def _make_inputs(self, m, n, dtype):
+        x = torch.randn((m, n), device="cuda", dtype=dtype)
+        weight = torch.randn((n,), device="cuda", dtype=dtype)
+        grad_out = torch.randn((m, n), device="cuda", dtype=dtype)
+        return x, weight, grad_out
+
+    def _assert_close(self, actual, expected, dtype, result):
+        rtol, atol = _tolerance(dtype, result)
+        self.assertEqual(actual, expected, rtol=rtol, atol=atol)
+
+    def _call_bwd(self, grad_out, x, rstd, weight, output_mask):
+        return torch.ops.aten._fused_rms_norm_backward.default(
+            grad_out,
+            x,
+            [x.shape[-1]],
+            rstd,
+            weight,
+            output_mask,
+        )
+
+    @parametrize("case", DIRECT_CASES, name_fn=_direct_case_name)
+    def test_direct_backward_matches_aten(self, case):
+        from torch._native.ops.norm.flydsl_rmsnorm_bwd import (
+            rmsnorm_bwd,
+            rmsnorm_bwd_cache_info,
+        )
+
+        m, n, dtype = case
+        x, weight, grad_out = self._make_inputs(m, n, dtype)
+        with torch.inference_mode():
+            rstd = _shared_rstd(x)
+        with torch.inference_mode(), pn.flydsl.disabled():
+            ref_dx, ref_dw = self._call_bwd(grad_out, x, rstd, weight, [True, True])
+
+        with torch.inference_mode():
+            got_dx, got_dw = rmsnorm_bwd(grad_out, x, rstd, weight)
+
+        self.assertEqual(rmsnorm_bwd_cache_info().misses, 1)
+        self.assertEqual(got_dx.dtype, dtype)
+        self.assertEqual(got_dw.dtype, dtype)
+        self._assert_close(got_dx, ref_dx, dtype, "dx")
+        self._assert_close(got_dw, ref_dw, dtype, "dweight")
+
+    def test_backward_dispatch_reuses_cache_and_masks_fall_back(self):
+        m, n, dtype = BWD_DISPATCH_M, BWD_DISPATCH_N, BWD_DISPATCH_DTYPE
+        x, weight, grad_out = self._make_inputs(m, n, dtype)
+        with torch.inference_mode():
+            rstd = _shared_rstd(x)
+        with torch.inference_mode(), pn.flydsl.disabled():
+            ref_dx, ref_dw = self._call_bwd(grad_out, x, rstd, weight, [True, True])
+
+        for _ in range(2):
+            before = _cache_counts()
+            with torch.inference_mode():
+                got_dx, got_dw = self._call_bwd(grad_out, x, rstd, weight, [True, True])
+            self.assertEqual(_route_delta(before, _cache_counts()), 1)
+            self._assert_close(got_dx, ref_dx, dtype, "dx")
+            self._assert_close(got_dw, ref_dw, dtype, "dweight")
+
+        for output_mask in ([True, False], [False, True]):
+            with torch.inference_mode(), pn.flydsl.disabled():
+                ref = self._call_bwd(grad_out, x, rstd, weight, output_mask)
+            before = _cache_counts()
+            with torch.inference_mode():
+                got = self._call_bwd(grad_out, x, rstd, weight, output_mask)
+            self.assertEqual(_route_delta(before, _cache_counts()), 0)
+            for actual, expected, result in zip(got, ref, ("dx", "dweight")):
+                if expected is None:
+                    self.assertIsNone(actual)
+                else:
+                    self._assert_close(actual, expected, dtype, result)
+
+    def test_backward_below_perf_threshold_falls_back(self):
+        m, n, dtype = 2048, 6144, torch.float16
+        x, weight, grad_out = self._make_inputs(m, n, dtype)
+        with torch.inference_mode():
+            rstd = _shared_rstd(x)
+        with torch.inference_mode(), pn.flydsl.disabled():
+            ref_dx, ref_dw = self._call_bwd(grad_out, x, rstd, weight, [True, True])
+
+        before = _cache_counts()
+        with torch.inference_mode():
+            got_dx, got_dw = self._call_bwd(grad_out, x, rstd, weight, [True, True])
+        self.assertEqual(_route_delta(before, _cache_counts()), 0)
+        self._assert_close(got_dx, ref_dx, dtype, "dx")
+        self._assert_close(got_dw, ref_dw, dtype, "dweight")
+
+
+instantiate_parametrized_tests(TestFlyDSLRMSNormBwdPerfGate)
+instantiate_parametrized_tests(TestFlyDSLRMSNormBwd)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_native/ops/norm/__init__.py
+++ b/torch/_native/ops/norm/__init__.py
@@ -1,4 +1,8 @@
+from .flydsl_rmsnorm_bwd_impl import (
+    register_op_override as register_flydsl_rmsnorm_bwd_overrides,
+)
 from .rmsnorm_impl import register_rmsnorm_overrides
 
 
 register_rmsnorm_overrides()
+register_flydsl_rmsnorm_bwd_overrides()

--- a/torch/_native/ops/norm/flydsl_rmsnorm_bwd.py
+++ b/torch/_native/ops/norm/flydsl_rmsnorm_bwd.py
@@ -1,0 +1,795 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""FlyDSL RMSNorm backward kernel and PyTorch wrapper.
+
+This implementation replaces M*N global FP32 dweight atomics with three kernels:
+
+* K1: one block per row computes k[row] = rstd**2/N * sum(x*dy*gamma).
+* K2: a (column tile, split-M) grid writes dx and one FP32 dweight partial.
+* K3: one column tile reduces the 64 partials and writes weight.dtype.
+
+The public ``rmsnorm_bwd`` entry point is consumed by the native-op integration
+in ``flydsl_rmsnorm_impl.py``.
+"""
+
+# mypy: allow-untyped-defs
+
+import functools
+import math
+
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, const_expr, gpu, range_constexpr
+from flydsl.expr import math as fmath
+from flydsl.expr.typing import Vector as Vec
+from flydsl.expr.vector import ReductionOp, full
+from flydsl.runtime.device import get_rocm_arch, is_rdna_arch
+
+from torch._native.flydsl_cache import jit_cache
+
+
+__all__ = [
+    "clear_rmsnorm_bwd_caches",
+    "rmsnorm_bwd",
+    "rmsnorm_bwd_cache_info",
+]
+
+_K1_BLOCK_THREADS = 256
+_K2_BLOCK_THREADS_LOWP = 256
+_K2_BLOCK_THREADS_F32 = 128
+_K3_BLOCK_THREADS = 256
+_DWEIGHT_SPLITS = 64
+_PARTIAL_VEC_WIDTH = 4  # Four FP32 values == one 128-bit transaction.
+_SUPPORTED_DTYPES: dict[torch.dtype, str] = {
+    torch.float32: "f32",
+    torch.float16: "f16",
+    torch.bfloat16: "bf16",
+}
+
+
+def _dtype_to_elem_type(dtype_str: str):
+    if dtype_str == "f32":
+        return fx.Float32
+    if dtype_str == "f16":
+        return fx.Float16
+    if dtype_str == "bf16":
+        return fx.BFloat16
+    raise ValueError(
+        f"unsupported dtype: {dtype_str!r} "
+        "(expected 'f32', 'f16', or 'bf16')"
+    )
+
+
+def _dtype_str(dtype: torch.dtype) -> str:
+    try:
+        return _SUPPORTED_DTYPES[dtype]
+    except KeyError as exc:
+        raise TypeError(f"unsupported RMSNorm dtype for FlyDSL: {dtype}") from exc
+
+
+def _warp_size_for_arch(arch: str) -> int:
+    return 32 if is_rdna_arch(arch) else 64
+
+
+def _make_single_reduction_storage(red_slots: int):
+    @fx.struct
+    class SharedStorage:
+        s_red: fx.Array[fx.Float32, red_slots, 16]
+
+    return SharedStorage
+
+
+def _load_scalar(copy_atom, elem_dtype, divided_tensor, index):
+    view = fx.slice(divided_tensor, (None, index))
+    register = fx.make_rmem_tensor(1, elem_dtype)
+    fx.copy_atom_call(copy_atom, view, register)
+    return fx.memref_load_vec(register)[0]
+
+
+def _store_scalar(copy_atom, elem_dtype, divided_tensor, index, value):
+    register = fx.make_rmem_tensor(1, elem_dtype)
+    fx.memref_store_vec(full(1, value, elem_dtype), register)
+    view = fx.slice(divided_tensor, (None, index))
+    fx.copy_atom_call(copy_atom, register, view)
+
+
+def _load_vec(copy_atom, vec_width, elem_dtype, divided_tensor, index):
+    register = fx.make_rmem_tensor(vec_width, elem_dtype)
+    fx.copy_atom_call(copy_atom, divided_tensor[None, index], register)
+    return register.load()
+
+
+def _store_vec(copy_atom, vec_width, elem_dtype, divided_tensor, index, value):
+    register = fx.make_rmem_tensor(vec_width, elem_dtype)
+    register.store(value)
+    fx.copy_atom_call(copy_atom, register, divided_tensor[None, index])
+
+
+def _load_f32_vec4_scalar(copy_atom_f32, divided_tensor, vec_index):
+    """Load one logical FP32 vec4 as four BufferCopy32b transactions."""
+
+    base = vec_index * 4
+    return Vec.from_elements(
+        [
+            _load_scalar(copy_atom_f32, fx.Float32, divided_tensor, base),
+            _load_scalar(copy_atom_f32, fx.Float32, divided_tensor, base + 1),
+            _load_scalar(copy_atom_f32, fx.Float32, divided_tensor, base + 2),
+            _load_scalar(copy_atom_f32, fx.Float32, divided_tensor, base + 3),
+        ],
+        fx.Float32,
+    )
+
+
+def _store_f32_vec4_scalar(copy_atom_f32, divided_tensor, vec_index, value):
+    """Store one logical FP32 vec4 as four BufferCopy32b transactions."""
+
+    base = vec_index * 4
+    value = Vec(value)
+    _store_scalar(copy_atom_f32, fx.Float32, divided_tensor, base, value[0])
+    _store_scalar(copy_atom_f32, fx.Float32, divided_tensor, base + 1, value[1])
+    _store_scalar(copy_atom_f32, fx.Float32, divided_tensor, base + 2, value[2])
+    _store_scalar(copy_atom_f32, fx.Float32, divided_tensor, base + 3, value[3])
+
+
+def _to_elem_vec(dtype_str: str, elem_dtype, use_hw_cvt_bf16: bool, value):
+    """Convert an FP32 vector to the output dtype."""
+
+    if const_expr(dtype_str == "bf16"):
+        if const_expr(use_hw_cvt_bf16):
+            return value.to(elem_dtype)
+        bits = value.bitcast(fx.Uint32)
+        upper = bits >> 16
+        lsb = upper & 1
+        rounded = value.bitcast(fx.Uint32) + lsb + 0x7FFF
+        bf16_bits = rounded >> 16
+        even = bf16_bits.shuffle(bf16_bits, [0, 2, 4, 6])
+        odd = bf16_bits.shuffle(bf16_bits, [1, 3, 5, 7])
+        packed = even | (odd << 16)
+        return packed.bitcast(elem_dtype)
+    if const_expr(dtype_str == "f32"):
+        return value
+    return value.to(elem_dtype)
+
+
+def _to_elem_scalar(dtype_str: str, elem_dtype, value):
+    """Convert one FP32 scalar to the output dtype."""
+
+    if const_expr(dtype_str == "f32"):
+        return value
+    return value.to(elem_dtype)
+
+
+def _build_rmsnorm_bwd_module(n: int, dtype_str: str, arch: str):
+    """Build the K1/K2/K3 specialization."""
+
+    warp_size = _warp_size_for_arch(arch)
+    red_slots = max(1, (_K1_BLOCK_THREADS + warp_size - 1) // warp_size)
+    elem_bits = 32 if dtype_str == "f32" else 16
+    elem_vec_width = 128 // elem_bits
+    k2_copy_width = 1 if dtype_str == "f32" else elem_vec_width
+    k2_block_threads = (
+        _K2_BLOCK_THREADS_F32
+        if dtype_str == "f32"
+        else _K2_BLOCK_THREADS_LOWP
+    )
+    k1_tile_cols = _K1_BLOCK_THREADS * elem_vec_width
+    k2_tile_cols = k2_block_threads * elem_vec_width
+    k3_tile_cols = _K3_BLOCK_THREADS * elem_vec_width
+    full_vecs = n // elem_vec_width
+    scalar_tail_start = full_vecs * elem_vec_width
+    scalar_tail_elems = n - scalar_tail_start
+    k1_vec_steps = (full_vecs + _K1_BLOCK_THREADS - 1) // _K1_BLOCK_THREADS
+    k2_col_tiles = max(
+        1, (full_vecs + k2_block_threads - 1) // k2_block_threads
+    )
+    k3_col_tiles = max(
+        1, (full_vecs + _K3_BLOCK_THREADS - 1) // _K3_BLOCK_THREADS
+    )
+    use_hw_cvt_bf16 = arch == "gfx950" or str(arch).startswith("gfx95")
+    SharedStorage = _make_single_reduction_storage(red_slots)
+
+    @flyc.kernel
+    def rmsnorm_bwd_row_reduce_kernel(
+        Input: fx.Tensor,
+        Gamma: fx.Tensor,
+        DY: fx.Tensor,
+        Rstd: fx.Tensor,
+        RowK: fx.Tensor,
+    ):
+        """K1: one block owns one row and writes its scalar projection k."""
+
+        row = fx.block_idx.x
+        tid = fx.thread_idx.x
+        elem_dtype = _dtype_to_elem_type(dtype_str)
+        fm_fast = arith.FastMathFlags.fast
+        c_zero_f = fx.Float32(0.0)
+
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        s_red = lds.s_red.view(fx.make_layout(red_slots, 1))
+
+        def wave_reduce_add(value):
+            reduced = value
+            for shift_exp in range_constexpr(int(math.log2(warp_size))):
+                offset = warp_size // (2 << shift_exp)
+                reduced = reduced.addf(
+                    reduced.shuffle_xor(offset, warp_size), fastmath=fm_fast
+                )
+            return reduced
+
+        def block_reduce_add(value):
+            if const_expr(red_slots == 1):
+                return wave_reduce_add(value)
+            lane = tid % warp_size
+            wave = tid // warp_size
+            reduced = wave_reduce_add(value)
+            if lane == 0:
+                fx.memref_store(reduced, s_red, wave)
+            gpu.barrier()
+            if wave == 0:
+                in_range = lane < red_slots
+                lane_safe = in_range.select(lane, 0)
+                partial = s_red[lane_safe]
+                partial = in_range.select(partial, c_zero_f)
+                if const_expr(red_slots == 4):
+                    partial = partial.addf(
+                        partial.shuffle_xor(2, warp_size), fastmath=fm_fast
+                    )
+                    partial = partial.addf(
+                        partial.shuffle_xor(1, warp_size), fastmath=fm_fast
+                    )
+                else:
+                    partial = wave_reduce_add(partial)
+                if lane == 0:
+                    fx.memref_store(partial, s_red, 0)
+            gpu.barrier()
+            return s_red[0]
+
+        input_buf = fx.rocdl.make_buffer_tensor(Input)
+        gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
+        dy_buf = fx.rocdl.make_buffer_tensor(DY)
+        rstd_buf = fx.rocdl.make_buffer_tensor(Rstd)
+        row_k_buf = fx.rocdl.make_buffer_tensor(RowK)
+
+        row_in = input_buf[row, None]
+        row_dy = dy_buf[row, None]
+        row_div = fx.logical_divide(row_in, fx.make_layout(elem_vec_width, 1))
+        dy_div = fx.logical_divide(row_dy, fx.make_layout(elem_vec_width, 1))
+        gamma_div = fx.logical_divide(
+            gamma_buf, fx.make_layout(elem_vec_width, 1)
+        )
+        copy_atom_v = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_bits)
+
+        acc0 = c_zero_f
+        acc1 = c_zero_f
+        if const_expr(n % k1_tile_cols == 0):
+            k1_col_tiles = n // k1_tile_cols
+            for tile_i in range_constexpr(k1_col_tiles):
+                idx = tid + tile_i * _K1_BLOCK_THREADS
+                x_e = _load_vec(
+                    copy_atom_v, elem_vec_width, elem_dtype, row_div, idx
+                )
+                dy_e = _load_vec(
+                    copy_atom_v, elem_vec_width, elem_dtype, dy_div, idx
+                )
+                gamma_e = _load_vec(
+                    copy_atom_v, elem_vec_width, elem_dtype, gamma_div, idx
+                )
+                x = x_e if dtype_str == "f32" else x_e.to(fx.Float32)
+                dy = dy_e if dtype_str == "f32" else dy_e.to(fx.Float32)
+                gamma = (
+                    gamma_e if dtype_str == "f32" else gamma_e.to(fx.Float32)
+                )
+                tile_sum = (x * (dy * gamma)).reduce(
+                    ReductionOp.ADD, fastmath=fm_fast
+                )
+                if const_expr(tile_i % 2 == 0):
+                    acc0 = acc0 + tile_sum
+                else:
+                    acc1 = acc1 + tile_sum
+        else:
+            for step in range_constexpr(k1_vec_steps):
+                vec_idx = tid + step * _K1_BLOCK_THREADS
+                vec_valid = vec_idx < full_vecs
+                vec_idx_safe = vec_valid.select(vec_idx, 0)
+                x_e = _load_vec(
+                    copy_atom_v, elem_vec_width, elem_dtype, row_div, vec_idx_safe
+                )
+                dy_e = _load_vec(
+                    copy_atom_v, elem_vec_width, elem_dtype, dy_div, vec_idx_safe
+                )
+                gamma_e = _load_vec(
+                    copy_atom_v,
+                    elem_vec_width,
+                    elem_dtype,
+                    gamma_div,
+                    vec_idx_safe,
+                )
+                x = x_e if dtype_str == "f32" else x_e.to(fx.Float32)
+                dy = dy_e if dtype_str == "f32" else dy_e.to(fx.Float32)
+                gamma = (
+                    gamma_e if dtype_str == "f32" else gamma_e.to(fx.Float32)
+                )
+                tile_sum = (x * (dy * gamma)).reduce(
+                    ReductionOp.ADD, fastmath=fm_fast
+                )
+                tile_sum = vec_valid.select(tile_sum, c_zero_f)
+                if const_expr(step % 2 == 0):
+                    acc0 = acc0 + tile_sum
+                else:
+                    acc1 = acc1 + tile_sum
+
+            if const_expr(scalar_tail_elems > 0):
+                tail_valid = tid < scalar_tail_elems
+                tail_idx = scalar_tail_start + tid
+                tail_idx_safe = tail_valid.select(tail_idx, 0)
+                x_e = row_in[tail_idx_safe]
+                dy_e = row_dy[tail_idx_safe]
+                gamma_e = gamma_buf[tail_idx_safe]
+                x = x_e if dtype_str == "f32" else x_e.to(fx.Float32)
+                dy = dy_e if dtype_str == "f32" else dy_e.to(fx.Float32)
+                gamma = gamma_e if dtype_str == "f32" else gamma_e.to(fx.Float32)
+                tail_sum = x * (dy * gamma)
+                acc0 = acc0 + tail_valid.select(tail_sum, c_zero_f)
+
+        t = block_reduce_add(acc0 + acc1)
+        rstd = rstd_buf[row]
+        k = t * ((rstd * rstd) / float(n))
+        if tid == 0:
+            row_k_buf[row] = k
+
+    @flyc.kernel
+    def rmsnorm_bwd_dx_partial_kernel(
+        Input: fx.Tensor,
+        Gamma: fx.Tensor,
+        DY: fx.Tensor,
+        Rstd: fx.Tensor,
+        RowK: fx.Tensor,
+        DX: fx.Tensor,
+        DWeightPartial: fx.Tensor,
+        m_in: fx.Int32,
+    ):
+        """K2: logical column tiles compute dx and split-M dweight partials."""
+
+        col_tile = fx.block_idx.x
+        split = fx.block_idx.y
+        tid = fx.thread_idx.x
+        elem_dtype = _dtype_to_elem_type(dtype_str)
+        fm_fast = arith.FastMathFlags.fast
+        c_zero_f = fx.Float32(0.0)
+
+        input_buf = fx.rocdl.make_buffer_tensor(Input)
+        gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
+        dy_buf = fx.rocdl.make_buffer_tensor(DY)
+        rstd_buf = fx.rocdl.make_buffer_tensor(Rstd)
+        row_k_buf = fx.rocdl.make_buffer_tensor(RowK)
+        dx_buf = fx.rocdl.make_buffer_tensor(DX)
+        partial_buf = fx.rocdl.make_buffer_tensor(DWeightPartial)
+
+        copy_atom_v = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_bits)
+        copy_atom_f32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), 32)
+        copy_atom_f32_v = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), 32)
+        gamma_div = fx.logical_divide(
+            gamma_buf, fx.make_layout(k2_copy_width, 1)
+        )
+
+        def compute_vec(vec_idx):
+            if const_expr(dtype_str == "f32"):
+                gamma_e = _load_f32_vec4_scalar(
+                    copy_atom_f32, gamma_div, vec_idx
+                )
+            else:
+                gamma_e = _load_vec(
+                    copy_atom_v, elem_vec_width, elem_dtype, gamma_div, vec_idx
+                )
+            gamma = gamma_e if dtype_str == "f32" else gamma_e.to(fx.Float32)
+            zero_vec = full(elem_vec_width, c_zero_f, fx.Float32)
+
+            for row, state in fx.range(
+                fx.Index(split),
+                fx.Index(m_in),
+                _DWEIGHT_SPLITS,
+                init=[zero_vec],
+            ):
+                dw_acc = Vec(state[0])
+                row_in = input_buf[row, None]
+                row_dy = dy_buf[row, None]
+                row_dx = dx_buf[row, None]
+                row_div = fx.logical_divide(
+                    row_in, fx.make_layout(k2_copy_width, 1)
+                )
+                dy_div = fx.logical_divide(
+                    row_dy, fx.make_layout(k2_copy_width, 1)
+                )
+                dx_div = fx.logical_divide(
+                    row_dx, fx.make_layout(k2_copy_width, 1)
+                )
+                if const_expr(dtype_str == "f32"):
+                    x_e = _load_f32_vec4_scalar(
+                        copy_atom_f32, row_div, vec_idx
+                    )
+                    dy_e = _load_f32_vec4_scalar(
+                        copy_atom_f32, dy_div, vec_idx
+                    )
+                else:
+                    x_e = _load_vec(
+                        copy_atom_v, elem_vec_width, elem_dtype, row_div, vec_idx
+                    )
+                    dy_e = _load_vec(
+                        copy_atom_v, elem_vec_width, elem_dtype, dy_div, vec_idx
+                    )
+                x = x_e if dtype_str == "f32" else x_e.to(fx.Float32)
+                dy = dy_e if dtype_str == "f32" else dy_e.to(fx.Float32)
+                rstd = rstd_buf[row]
+                k = row_k_buf[row]
+                projected = fmath.fma(
+                    x,
+                    full(elem_vec_width, c_zero_f - k, fx.Float32),
+                    dy * gamma,
+                    fastmath=fm_fast,
+                )
+                dx = projected * rstd
+                dx_e = _to_elem_vec(
+                    dtype_str, elem_dtype, use_hw_cvt_bf16, dx
+                )
+                if const_expr(dtype_str == "f32"):
+                    _store_f32_vec4_scalar(
+                        copy_atom_f32, dx_div, vec_idx, dx_e
+                    )
+                else:
+                    _store_vec(
+                        copy_atom_v,
+                        elem_vec_width,
+                        elem_dtype,
+                        dx_div,
+                        vec_idx,
+                        dx_e,
+                    )
+                next_dw_acc = dw_acc + ((dy * x) * rstd)
+                loop_results = yield [next_dw_acc]
+
+            dw_acc = Vec(loop_results)
+            partial_row = partial_buf[split, None]
+            partial_div = fx.logical_divide(
+                partial_row, fx.make_layout(_PARTIAL_VEC_WIDTH, 1)
+            )
+            if const_expr(elem_vec_width == _PARTIAL_VEC_WIDTH):
+                _store_vec(
+                    copy_atom_f32_v,
+                    _PARTIAL_VEC_WIDTH,
+                    fx.Float32,
+                    partial_div,
+                    vec_idx,
+                    dw_acc,
+                )
+            else:
+                partial_idx = vec_idx * 2
+                lo = dw_acc.shuffle(dw_acc, [0, 1, 2, 3])
+                hi = dw_acc.shuffle(dw_acc, [4, 5, 6, 7])
+                _store_vec(
+                    copy_atom_f32_v,
+                    _PARTIAL_VEC_WIDTH,
+                    fx.Float32,
+                    partial_div,
+                    partial_idx,
+                    lo,
+                )
+                _store_vec(
+                    copy_atom_f32_v,
+                    _PARTIAL_VEC_WIDTH,
+                    fx.Float32,
+                    partial_div,
+                    partial_idx + 1,
+                    hi,
+                )
+
+        def compute_tail(tail_idx):
+            gamma_e = gamma_buf[tail_idx]
+            gamma = (
+                gamma_e if dtype_str == "f32" else gamma_e.to(fx.Float32)
+            )
+            for row, state in fx.range(
+                fx.Index(split),
+                fx.Index(m_in),
+                _DWEIGHT_SPLITS,
+                init=[c_zero_f],
+            ):
+                dw_acc = fx.Float32(state[0])
+                x_e = input_buf[row, tail_idx]
+                dy_e = dy_buf[row, tail_idx]
+                x = x_e if dtype_str == "f32" else x_e.to(fx.Float32)
+                dy = dy_e if dtype_str == "f32" else dy_e.to(fx.Float32)
+                rstd = rstd_buf[row]
+                k = row_k_buf[row]
+                projected = fmath.fma(
+                    x,
+                    c_zero_f - k,
+                    dy * gamma,
+                    fastmath=fm_fast,
+                )
+                dx = projected * rstd
+                dx_e = _to_elem_scalar(dtype_str, elem_dtype, dx)
+                dx_buf[row, tail_idx] = elem_dtype(dx_e)
+                next_dw_acc = dw_acc + ((dy * x) * rstd)
+                scalar_results = yield [next_dw_acc]
+
+            partial_buf[split, tail_idx] = fx.Float32(scalar_results)
+
+        vec_idx = col_tile * k2_block_threads + tid
+        if const_expr(n % k2_tile_cols == 0):
+            compute_vec(vec_idx)
+        else:
+            if vec_idx < full_vecs:
+                compute_vec(vec_idx)
+            if const_expr(scalar_tail_elems > 0):
+                tail_block = k2_col_tiles - 1
+                tail_idx = scalar_tail_start + tid
+                if col_tile == tail_block:
+                    if tid < scalar_tail_elems:
+                        compute_tail(tail_idx)
+
+    @flyc.kernel
+    def rmsnorm_bwd_dweight_reduce_kernel(
+        DWeightPartial: fx.Tensor,
+        DWeight: fx.Tensor,
+    ):
+        """K3: reduce 64 FP32 partial rows and directly write weight dtype."""
+
+        col_tile = fx.block_idx.x
+        tid = fx.thread_idx.x
+        elem_dtype = _dtype_to_elem_type(dtype_str)
+        c_zero_f = fx.Float32(0.0)
+        partial_buf = fx.rocdl.make_buffer_tensor(DWeightPartial)
+        dweight_buf = fx.rocdl.make_buffer_tensor(DWeight)
+        copy_atom_f32_v = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), 32)
+        copy_atom_out = fx.make_copy_atom(
+            fx.rocdl.BufferCopy128b(), elem_bits
+        )
+
+        def reduce_vec(vec_idx):
+            acc_lo = full(_PARTIAL_VEC_WIDTH, c_zero_f, fx.Float32)
+            if const_expr(elem_vec_width == 8):
+                acc_hi = full(_PARTIAL_VEC_WIDTH, c_zero_f, fx.Float32)
+
+            for split_i in range_constexpr(_DWEIGHT_SPLITS):
+                partial_row = partial_buf[split_i, None]
+                partial_div = fx.logical_divide(
+                    partial_row, fx.make_layout(_PARTIAL_VEC_WIDTH, 1)
+                )
+                if const_expr(elem_vec_width == _PARTIAL_VEC_WIDTH):
+                    acc_lo = acc_lo + _load_vec(
+                        copy_atom_f32_v,
+                        _PARTIAL_VEC_WIDTH,
+                        fx.Float32,
+                        partial_div,
+                        vec_idx,
+                    )
+                else:
+                    partial_idx = vec_idx * 2
+                    acc_lo = acc_lo + _load_vec(
+                        copy_atom_f32_v,
+                        _PARTIAL_VEC_WIDTH,
+                        fx.Float32,
+                        partial_div,
+                        partial_idx,
+                    )
+                    acc_hi = acc_hi + _load_vec(
+                        copy_atom_f32_v,
+                        _PARTIAL_VEC_WIDTH,
+                        fx.Float32,
+                        partial_div,
+                        partial_idx + 1,
+                    )
+
+            dweight_div = fx.logical_divide(
+                dweight_buf, fx.make_layout(elem_vec_width, 1)
+            )
+            if const_expr(elem_vec_width == _PARTIAL_VEC_WIDTH):
+                dw_f32 = acc_lo
+            else:
+                dw_f32 = acc_lo.shuffle(acc_hi, [0, 1, 2, 3, 4, 5, 6, 7])
+            dw_e = _to_elem_vec(
+                dtype_str, elem_dtype, use_hw_cvt_bf16, dw_f32
+            )
+            _store_vec(
+                copy_atom_out,
+                elem_vec_width,
+                elem_dtype,
+                dweight_div,
+                vec_idx,
+                dw_e,
+            )
+
+        def reduce_tail(tail_idx):
+            tail_acc = c_zero_f
+            for split_i in range_constexpr(_DWEIGHT_SPLITS):
+                tail_acc = tail_acc + partial_buf[split_i, tail_idx]
+            tail_out = _to_elem_scalar(dtype_str, elem_dtype, tail_acc)
+            dweight_buf[tail_idx] = elem_dtype(tail_out)
+
+        vec_idx = col_tile * _K3_BLOCK_THREADS + tid
+        if const_expr(n % k3_tile_cols == 0):
+            reduce_vec(vec_idx)
+        else:
+            if vec_idx < full_vecs:
+                reduce_vec(vec_idx)
+            if const_expr(scalar_tail_elems > 0):
+                tail_block = k3_col_tiles - 1
+                tail_idx = scalar_tail_start + tid
+                if col_tile == tail_block:
+                    if tid < scalar_tail_elems:
+                        reduce_tail(tail_idx)
+
+    @flyc.jit
+    def launch_rmsnorm_bwd(
+        Input: fx.Tensor,
+        Gamma: fx.Tensor,
+        DY: fx.Tensor,
+        Rstd: fx.Tensor,
+        RowK: fx.Tensor,
+        DX: fx.Tensor,
+        DWeightPartial: fx.Tensor,
+        DWeight: fx.Tensor,
+        m_in: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        rmsnorm_bwd_row_reduce_kernel(
+            Input, Gamma, DY, Rstd, RowK
+        ).launch(
+            grid=(m_in, 1, 1),
+            block=(_K1_BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+        rmsnorm_bwd_dx_partial_kernel(
+            Input,
+            Gamma,
+            DY,
+            Rstd,
+            RowK,
+            DX,
+            DWeightPartial,
+            m_in,
+        ).launch(
+            grid=(k2_col_tiles, _DWEIGHT_SPLITS, 1),
+            block=(k2_block_threads, 1, 1),
+            stream=stream,
+        )
+        rmsnorm_bwd_dweight_reduce_kernel(
+            DWeightPartial, DWeight
+        ).launch(
+            grid=(k3_col_tiles, 1, 1),
+            block=(_K3_BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    return launch_rmsnorm_bwd
+
+
+def _make_compile_arg(tensor: torch.Tensor):
+    """Make only the row dimension dynamic across M values."""
+
+    return flyc.from_torch_tensor(tensor).mark_shape_dynamic(0)
+
+
+@functools.cache
+def _compile_environment(device_index: int) -> tuple[str, str]:
+    del device_index
+    return str(get_rocm_arch()), flyc.compile_backend_name()
+
+
+@jit_cache
+def _compile_rmsnorm_bwd(
+    n: int,
+    dtype: str,
+    arch: str,
+    backend: str,
+    device_index: int,
+    *,
+    compile_args,
+) -> flyc.CompiledFunction:
+    del backend, device_index
+    (
+        input_2d,
+        weight,
+        grad_2d,
+        rstd,
+        row_k,
+        grad_input,
+        dweight_partial,
+        grad_weight,
+        rows_m,
+        stream,
+    ) = compile_args
+    launch = _build_rmsnorm_bwd_module(n, dtype, arch)
+    return flyc.compile(
+        launch,
+        _make_compile_arg(input_2d),
+        flyc.from_torch_tensor(weight),
+        _make_compile_arg(grad_2d),
+        _make_compile_arg(rstd),
+        _make_compile_arg(row_k),
+        _make_compile_arg(grad_input),
+        flyc.from_torch_tensor(dweight_partial),
+        flyc.from_torch_tensor(grad_weight),
+        rows_m,
+        stream,
+    )
+
+
+def rmsnorm_bwd(
+    grad_out: torch.Tensor,
+    input: torch.Tensor,
+    rstd: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    need_grad_weight: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Run the three-kernel backward pipeline."""
+
+    n = input.shape[-1]
+    rows_m = input.numel() // n
+    input_2d = input.view(rows_m, n)
+    grad_2d = grad_out.view(rows_m, n)
+    rstd_flat = rstd.view(rows_m)
+    grad_input = torch.empty_like(input)
+    grad_input_2d = grad_input.view(rows_m, n)
+    row_k = torch.empty(rows_m, device=input.device, dtype=torch.float32)
+    partial_stride = (
+        (n + _PARTIAL_VEC_WIDTH - 1) // _PARTIAL_VEC_WIDTH
+    ) * _PARTIAL_VEC_WIDTH
+    dweight_partial = torch.empty(
+        (_DWEIGHT_SPLITS, partial_stride),
+        device=input.device,
+        dtype=torch.float32,
+    )
+    # K3 overwrites every element, so neither zero_ nor a post-kernel cast is
+    # required. The buffer is still allocated when output_mask omits dweight;
+    # DX is computed unconditionally; the PyTorch impl honors output_mask at return.
+    grad_weight_out = torch.empty_like(weight)
+
+    stream = torch.cuda.current_stream(input.device)
+    device_index = input.get_device()
+    arch, backend = _compile_environment(device_index)
+    compiled = _compile_rmsnorm_bwd(
+        n,
+        _dtype_str(input.dtype),
+        arch,
+        backend,
+        device_index,
+        compile_args=(
+            input_2d,
+            weight,
+            grad_2d,
+            rstd_flat,
+            row_k,
+            grad_input_2d,
+            dweight_partial,
+            grad_weight_out,
+            rows_m,
+            stream,
+        ),
+    )
+    compiled(
+        input_2d,
+        weight,
+        grad_2d,
+        rstd_flat,
+        row_k,
+        grad_input_2d,
+        dweight_partial,
+        grad_weight_out,
+        rows_m,
+        stream,
+    )
+    return grad_input, grad_weight_out if need_grad_weight else None
+
+
+def clear_rmsnorm_bwd_caches() -> None:
+    _compile_rmsnorm_bwd.cache_clear()
+    _compile_environment.cache_clear()
+
+
+def rmsnorm_bwd_cache_info():
+    return _compile_rmsnorm_bwd.cache_info()

--- a/torch/_native/ops/norm/flydsl_rmsnorm_bwd_impl.py
+++ b/torch/_native/ops/norm/flydsl_rmsnorm_bwd_impl.py
@@ -1,0 +1,203 @@
+"""FlyDSL override for ATen's internal fused RMSNorm backward operator."""
+
+# mypy: allow-untyped-defs
+
+from __future__ import annotations
+
+import torch
+
+from ... import flydsl_utils as fu
+
+
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+# CDNA raw-buffer copies use 32-bit byte offsets; exactly 4 GiB wraps to zero.
+_RMSNORM_BWD_BUFFER_ADDRESS_LIMIT_BYTES = 1 << 32
+
+_HIP_AVAILABLE = torch.version.hip is not None
+_is_cow_tensor = torch._C._is_cow_tensor  # pyrefly: ignore[missing-attribute]
+_rmsnorm_bwd = None
+
+
+def _normalized_shape_1d(normalized_shape) -> int | None:
+    """Return N for the one-dimensional normalization supported by the kernel."""
+
+    if isinstance(normalized_shape, int):
+        return normalized_shape
+    if isinstance(normalized_shape, (tuple, list, torch.Size)):
+        if len(normalized_shape) != 1:
+            return None
+        try:
+            return int(normalized_shape[0])
+        except (TypeError, ValueError):
+            return None
+
+    try:
+        shape = tuple(int(x) for x in normalized_shape)
+    except TypeError:
+        try:
+            shape = (int(normalized_shape),)
+        except (TypeError, ValueError):
+            return None
+    except ValueError:
+        return None
+    return shape[0] if len(shape) == 1 else None
+
+
+def _common_supported(
+    input: torch.Tensor,
+    n: int,
+    weight: torch.Tensor | None,
+) -> bool:
+    """Cheap dispatcher predicate for supported inputs."""
+    if not _HIP_AVAILABLE or input.device.type != "cuda":
+        return False
+    if input.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if input.ndim < 1 or input.shape[-1] != n or input.numel() == 0:
+        return False
+    if not input.is_contiguous():
+        return False
+    if weight is None:
+        return False
+    if (
+        weight.shape != (n,)
+        or weight.dtype != input.dtype
+        or weight.device != input.device
+        or not weight.is_contiguous()
+    ):
+        return False
+    # Reshaping a copy-on-write tensor would materialize it. Let ATen preserve
+    # its normal semantics for these uncommon inputs.
+    if _is_cow_tensor(input) or _is_cow_tensor(weight):
+        return False
+    return True
+
+
+def _fused_rms_norm_bwd_perf_wins(input: torch.Tensor, n: int) -> bool:
+    rows_m = input.numel() // n
+    # Tuned on MI355X from the complete power-of-two M/N grid using
+    # synchronized wall-to-sync measurements. Near-crossover points stay on
+    # ATen, and every boundary is a power of two.
+    if input.dtype in (torch.float16, torch.bfloat16):
+        return (
+            (16 <= n < 64 and rows_m >= 8192)
+            or (1024 <= n < 2048 and rows_m >= 65536)
+            or (2048 <= n < 4096 and rows_m >= 32768)
+            or (4096 <= n < 8192 and rows_m >= 8192)
+            or (8192 <= n < 16384 and rows_m >= 2048)
+            or (16384 <= n < 32768 and rows_m >= 512)
+            or (32768 <= n <= 65536 and rows_m >= 16)
+        )
+    if input.dtype == torch.float32:
+        return (
+            (16 <= n < 64 and rows_m >= 16384)
+            or (256 <= n < 512 and rows_m >= 65536)
+            or (512 <= n < 2048 and rows_m >= 16384)
+            or (2048 <= n < 4096 and rows_m >= 8192)
+            or (4096 <= n < 8192 and rows_m >= 4096)
+            or (8192 <= n < 16384 and rows_m >= 2048)
+            or (16384 <= n < 32768 and rows_m >= 64)
+            or (32768 <= n <= 65536 and rows_m >= 16)
+        )
+    return False
+
+
+def _fused_rms_norm_bwd_buffer_addressable(input: torch.Tensor) -> bool:
+    """Return whether BWD raw-buffer copies can address the full matrix."""
+
+    return (
+        input.numel() * input.element_size() < _RMSNORM_BWD_BUFFER_ADDRESS_LIMIT_BYTES
+    )
+
+
+def _get_rmsnorm_bwd(input: torch.Tensor):
+    global _rmsnorm_bwd
+    if _rmsnorm_bwd is None:
+        # Import under the input device guard because the vendored builders query
+        # the active ROCm architecture while initializing wave-size constants.
+        with torch.cuda.device(input.device):
+            from .flydsl_rmsnorm_bwd import rmsnorm_bwd
+
+        _rmsnorm_bwd = rmsnorm_bwd
+    return _rmsnorm_bwd
+
+
+def _fused_rms_norm_backward_cond(
+    grad_out: torch.Tensor,
+    input: torch.Tensor,
+    normalized_shape,
+    rstd: torch.Tensor,
+    weight: torch.Tensor | None,
+    output_mask,
+) -> bool:
+    n = _normalized_shape_1d(normalized_shape)
+    if n is None:
+        return False
+    if not _common_supported(input, n, weight):
+        return False
+    if not _fused_rms_norm_bwd_buffer_addressable(input):
+        return False
+    if (
+        grad_out.shape != input.shape
+        or grad_out.dtype != input.dtype
+        or grad_out.device != input.device
+        or not grad_out.is_contiguous()
+    ):
+        return False
+    if (
+        rstd.device != input.device
+        or rstd.dtype != torch.float32
+        or rstd.shape != (*input.shape[:-1], 1)
+        or not rstd.is_contiguous()
+    ):
+        return False
+    try:
+        mask = tuple(bool(value) for value in output_mask)
+    except TypeError:
+        return False
+    # V2 always executes K1/K2/K3 and computes both outputs. Let ATen handle
+    # single-output calls so the override does not do avoidable work.
+    if mask != (True, True):
+        return False
+    assert weight is not None
+    if any(tensor.data_ptr() % 16 != 0 for tensor in (input, weight, grad_out)):
+        return False
+    if _is_cow_tensor(grad_out) or _is_cow_tensor(rstd):
+        return False
+    return _fused_rms_norm_bwd_perf_wins(input, n)
+
+
+def _fused_rms_norm_backward_impl(
+    grad_out: torch.Tensor,
+    input: torch.Tensor,
+    normalized_shape,
+    rstd: torch.Tensor,
+    weight: torch.Tensor | None,
+    output_mask,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    del normalized_shape
+    if weight is None:
+        raise RuntimeError("FlyDSL RMSNorm backward requires an explicit weight")
+
+    need_grad_input = bool(output_mask[0])
+    need_grad_weight = bool(output_mask[1])
+    with torch.cuda.device(input.device):
+        grad_input, grad_weight = _get_rmsnorm_bwd(input)(
+            grad_out,
+            input,
+            rstd,
+            weight,
+            need_grad_weight=need_grad_weight,
+        )
+    return grad_input if need_grad_input else None, grad_weight
+
+
+def register_op_override() -> None:
+    fu.register_op_override(
+        "aten",
+        "_fused_rms_norm_backward",
+        "CUDA",
+        cond=_fused_rms_norm_backward_cond,
+        impl=_fused_rms_norm_backward_impl,
+        allow_multiple_override=True,
+    )


### PR DESCRIPTION
## Add FlyDSL native RMSNorm backward override

### Motivation

Adds a ROCm FlyDSL override for `aten::_fused_rms_norm_backward`. It is enabled only for measured-profitable shapes and otherwise falls back transparently to ATen.

### Changes

- Adds a three-kernel FlyDSL backward pipeline: row reduction, `grad_input` plus partial `grad_weight` computation, then partial reduction.
- Registers the CUDA native-op override and conservative dispatch/performance gates.
- Adds parity, dispatch, fallback, cache, gate-boundary, and 4-GiB buffer-limit tests.

### Supported cases

Supports fp16, bf16, and fp32 ROCm tensors with contiguous input/weight/`grad_out`, a 1-D normalized shape, FP32 contiguous `rstd` shaped `(*batch, 1)`, and `output_mask == (True, True)`. Input, weight, and `grad_out` must be 16-byte aligned; copy-on-write tensors and matrices at or above 4 GiB fall back to ATen.

### Performance gates

| dtype | N range | minimum M |
|:---|:---|---:|
| fp16 / bf16 | `16 <= N < 64` | 8192 |
| fp16 / bf16 | `1024 <= N < 2048` | 65536 |
| fp16 / bf16 | `2048 <= N < 4096` | 32768 |
| fp16 / bf16 | `4096 <= N < 8192` | 8192 |
| fp16 / bf16 | `8192 <= N < 16384` | 2048 |
| fp16 / bf16 | `16384 <= N < 32768` | 512 |
| fp16 / bf16 | `32768 <= N <= 65536` | 16 |
| fp32 | `16 <= N < 64` | 16384 |
| fp32 | `256 <= N < 512` | 65536 |
| fp32 | `512 <= N < 2048` | 16384 |
| fp32 | `2048 <= N < 4096` | 8192 |
| fp32 | `4096 <= N < 8192` | 4096 |
| fp32 | `8192 <= N < 16384` | 2048 |
| fp32 | `16384 <= N < 32768` | 64 |
| fp32 | `32768 <= N <= 65536` | 16 |

All unlisted ranges fall back to ATen.

### Testing

```bash
python test/python_native/test_flydsl_rmsnorm_bwd.py -v
```

### Performance methodology

Latency is measured with CUDA events after 10 warmup iterations and over 50 timed iterations. The ATen baseline runs with FlyDSL disabled; the FlyDSL measurement uses the same operator call with the override enabled.

```python
def bench(fn, iters=50, warmup=10):
    for _ in range(warmup):
        fn()
    torch.cuda.synchronize()
    start = torch.cuda.Event(enable_timing=True)
    end = torch.cuda.Event(enable_timing=True)
    start.record()
    for _ in range(iters):
        fn()
    end.record()
    torch.cuda.synchronize()
    return start.elapsed_time(end) / iters

bwd = lambda: torch.ops.aten._fused_rms_norm_backward.default(
    grad_out, x, [N], rstd, weight, [True, True]
)

with pn.flydsl.disabled():
    aten_ms = bench(bwd)
flydsl_ms = bench(bwd)
speedup = aten_ms / flydsl_ms
```

### Performance
GPU: AMD 256-CU MI355X GPU.

| dtype | M | N | ATen (us) | FlyDSL (us) | speedup |
|:---|---:|---:|---:|---:|---:|
| fp16 | 8192 | 4096 | 119.5 | 79.1 | 1.51x |
| fp16 | 2048 | 8192 | 59.4 | 36.5 | 1.62x |
| fp16 | 512 | 16384 | 52.4 | 31.2 | 1.68x |
| fp16 | 32 | 32768 | 48.3 | 31.1 | 1.55x |
| bf16 | 2048 | 8192 | 60.0 | 36.4 | 1.65x |
| bf16 | 512 | 16384 | 49.2 | 32.3 | 1.52x |
| fp32 | 2048 | 8192 | 86.9 | 56.2 | 1.54x |
| fp32 | 4096 | 4096 | 89.1 | 56.8 | 1.57x |
| fp32 | 64 | 16384 | 34.3 | 30.6 | 1.12x |
| fp32 | 16 | 65536 | 92.8 | 30.9 | 3.00x |

Authored with assistance from Claude Code.