### PR TITLE
[dynamo_wrapped] Skip test_sum_all under TorchDynamo (fixes #158664)

### DIFF
--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1465,6 +1465,7 @@ class TestReductions(TestCase):
 
     @onlyCPU
     @dtypes(torch.bool, torch.double)
+    @skipIfTorchDynamo("tracing sum() over a 200k-element .tolist() takes ~10 min/run")
     def test_sum_all(self, device, dtype) -> None:
         def check_sum_all(tensor: torch.Tensor) -> None:
             pylist = tensor.reshape(-1).tolist()


### PR DESCRIPTION
test_sum_all is a generic eager reduction test that dynamo_wrapped re-runs through torch.compile. Its float64 path checks tensor.sum() against sum(tensor.reshape(-1).tolist()) on a 200k-element tensor -- trivial in eager, but under the wrapper Dynamo traces the 200k-element Python sum() with super-linear trace time (~10 min/run; it's compile time, not the math), and compiling sum(giant.tolist()) has no real coverage value.

It's already disabled on `dynamo` (#158664), so the daily rerun-disabled cron runs it 50x via flake-finder -> ~500 min vs a 210-min timeout -> ~6 red dynamo_wrapped jobs/day and ~21 wasted runner-hours/day, mislabeled as "custom container implementation failed". The timeout also means results never upload, so the flakiness pipeline gets zero samples and it can never auto-recover.
- Example timeout job: https://github.com/pytorch/pytorch/actions/runs/30196013117/job/89778524919

@skipIfTorchDynamo is the sanctioned way to opt a generic test out of the wrapper (per .ci/pytorch/test.sh) and matches the existing disable scope, so eager coverage is unchanged. With the skip explicit in code, #158664 can close.

Authored with assistance from an AI coding assistant (Claude Code).