### PR TITLE
[Testcase Refactoring] Make test_sharded_tensor_reshard device-agnostic with capability gating

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor_reshard.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor_reshard.py
@@ -6,8 +6,17 @@ from itertools import product
 import torch
 from torch.distributed._shard import _shard_tensor, sharded_tensor
 from torch.distributed._shard.sharding_spec import EnumerableShardingSpec, ShardMetadata
-from torch.testing._internal.common_distributed import requires_accelerator_dist_backend, skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     with_comms,
@@ -26,9 +35,11 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestReshard(ShardedTensorTestBase):
-    def _run_sharded_tensor_reshard(self, sharding_spec, reshard_spec, input_size):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def _run_sharded_tensor_reshard(self, sharding_spec, reshard_spec, input_size, device):
         torch.manual_seed(0)
-        local_tensor = torch.rand(*input_size).to(self.device_type)
+        local_tensor = torch.rand(*input_size).to(device)
         st = _shard_tensor(local_tensor, sharding_spec)
         st_compare = _shard_tensor(local_tensor, reshard_spec)
         st.reshard(reshard_spec)
@@ -45,36 +56,37 @@ class TestReshard(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_sharded_tensor_reshard(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_sharded_tensor_reshard(self, device):
         dims = [0, 1]
         for sharding_dim, reshard_dim in product(dims, dims):
             specs = _chunk_sharding_specs_list_for_test(
-                [sharding_dim, reshard_dim], seed=5
+                [sharding_dim, reshard_dim], seed=5, device_type=torch.device(device).type
             )
             spec, reshard_spec = specs[0], specs[1]
-            self._run_sharded_tensor_reshard(spec, reshard_spec, [13, 21])
-            self._run_sharded_tensor_reshard(spec, reshard_spec, [14, 23])
-            self._run_sharded_tensor_reshard(spec, reshard_spec, [15, 26])
-            self._run_sharded_tensor_reshard(spec, reshard_spec, [12, 24])
+            self._run_sharded_tensor_reshard(spec, reshard_spec, [13, 21], device)
+            self._run_sharded_tensor_reshard(spec, reshard_spec, [14, 23], device)
+            self._run_sharded_tensor_reshard(spec, reshard_spec, [15, 26], device)
+            self._run_sharded_tensor_reshard(spec, reshard_spec, [12, 24], device)
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_sharded_tensor_reshard_errors(self):
-        specs = _chunk_sharding_specs_list_for_test([0, 1], seed=6)
+    @requires_capabilities(Capability.distributed.backend)
+    def test_sharded_tensor_reshard_errors(self, device):
+        specs = _chunk_sharding_specs_list_for_test([0, 1], seed=6, device_type=torch.device(device).type)
         spec, reshard_spec = specs[0], specs[1]
+        device_type = torch.device(device).type
         enumerable_sharding_spec = EnumerableShardingSpec(
             [
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement=f"rank:0/{self.device_type}:0",
+                    placement=f"rank:0/{device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement=f"rank:1/{self.device_type}:1",
+                    placement=f"rank:1/{device_type}:1",
                 ),
             ]
         )
@@ -89,6 +101,8 @@ class TestReshard(ShardedTensorTestBase):
         ):
             st.reshard(reshard_spec)
 
+
+instantiate_device_type_tests(TestReshard, globals())
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor_reshard.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor_reshard.py
@@ -6,7 +6,7 @@ from itertools import product
 import torch
 from torch.distributed._shard import _shard_tensor, sharded_tensor
 from torch.distributed._shard.sharding_spec import EnumerableShardingSpec, ShardMetadata
-from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import requires_accelerator_dist_backend, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
@@ -28,7 +28,7 @@ if TEST_WITH_DEV_DBG_ASAN:
 class TestReshard(ShardedTensorTestBase):
     def _run_sharded_tensor_reshard(self, sharding_spec, reshard_spec, input_size):
         torch.manual_seed(0)
-        local_tensor = torch.rand(*input_size).cuda(self.rank)
+        local_tensor = torch.rand(*input_size).to(self.device_type)
         st = _shard_tensor(local_tensor, sharding_spec)
         st_compare = _shard_tensor(local_tensor, reshard_spec)
         st.reshard(reshard_spec)
@@ -45,7 +45,7 @@ class TestReshard(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_sharded_tensor_reshard(self):
         dims = [0, 1]
         for sharding_dim, reshard_dim in product(dims, dims):
@@ -60,7 +60,7 @@ class TestReshard(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_sharded_tensor_reshard_errors(self):
         specs = _chunk_sharding_specs_list_for_test([0, 1], seed=6)
         spec, reshard_spec = specs[0], specs[1]
@@ -69,12 +69,12 @@ class TestReshard(ShardedTensorTestBase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
+                    placement=f"rank:0/{self.device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
+                    placement=f"rank:1/{self.device_type}:1",
                 ),
             ]
         )

--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor_reshard.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor_reshard.py
@@ -37,7 +37,9 @@ if TEST_WITH_DEV_DBG_ASAN:
 class TestReshard(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    def _run_sharded_tensor_reshard(self, sharding_spec, reshard_spec, input_size, device):
+    def _run_sharded_tensor_reshard(
+        self, sharding_spec, reshard_spec, input_size, device
+    ):
         torch.manual_seed(0)
         local_tensor = torch.rand(*input_size).to(device)
         st = _shard_tensor(local_tensor, sharding_spec)
@@ -58,10 +60,13 @@ class TestReshard(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_sharded_tensor_reshard(self, device):
+        device_type = torch.device(device).type
         dims = [0, 1]
         for sharding_dim, reshard_dim in product(dims, dims):
             specs = _chunk_sharding_specs_list_for_test(
-                [sharding_dim, reshard_dim], seed=5, device_type=torch.device(device).type
+                [sharding_dim, reshard_dim],
+                seed=5,
+                device_type=device_type,
             )
             spec, reshard_spec = specs[0], specs[1]
             self._run_sharded_tensor_reshard(spec, reshard_spec, [13, 21], device)
@@ -73,9 +78,11 @@ class TestReshard(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_sharded_tensor_reshard_errors(self, device):
-        specs = _chunk_sharding_specs_list_for_test([0, 1], seed=6, device_type=torch.device(device).type)
-        spec, reshard_spec = specs[0], specs[1]
         device_type = torch.device(device).type
+        specs = _chunk_sharding_specs_list_for_test(
+            [0, 1], seed=6, device_type=device_type
+        )
+        spec, reshard_spec = specs[0], specs[1]
         enumerable_sharding_spec = EnumerableShardingSpec(
             [
                 ShardMetadata(
@@ -102,7 +109,7 @@ class TestReshard(ShardedTensorTestBase):
             st.reshard(reshard_spec)
 
 
-instantiate_device_type_tests(TestReshard, globals())
+instantiate_device_type_tests(TestReshard, globals(), except_for="cpu", allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

`TestReshard` in `test/distributed/_shard/sharded_tensor/test_sharded_tensor_reshard.py` verifies `ShardedTensor.reshard()` functionality — generic distributed sharding logic that is not CUDA-specific. However, the test hardcodes CUDA device strings, uses `@requires_nccl()` for admission, and calls `.cuda(self.rank)`, preventing out-of-tree accelerator backends (e.g. PrivateUse1 backends such as NPU with HCCL) from reusing the tests.

This PR replaces all CUDA-specific patterns with device-generic equivalents using the capability registration mechanism, adds `instantiate_device_type_tests` with `except_for="cpu"` for per-device variant generation, relies on `ShardedTensorTestBase.backend` property (from PR #194992) for dynamic backend resolution in `@with_comms`, and adds the `hw_classification = HardwareClassification.ACCELERATOR` label.

## Changes

- Replaced `@requires_nccl()` with `@requires_capabilities(Capability.distributed.backend)` on both test methods. Uses capability gating instead of hardcoded backend names — any accelerator declaring `distributed.backend` capability can run the test.
- Uses `@with_comms(init_rpc=False)` without explicit backend — `with_comms` dynamically resolves `self.backend` from the `ShardedTensorTestBase.backend` property (PR #194992), which handles `privateuse1` → actual device name conversion and calls `dist.get_default_backend_for_device()`. No module-level `device_type`/`backend` globals — the backend is resolved per-variant at runtime via the `self.device_type` attribute set by `instantiate_device_type_tests`.
- Replaced `.cuda(self.rank)` with `.to(device)` — uses framework-injected `device` parameter from `instantiate_device_type_tests`.
- Replaced hardcoded `"rank:0/cuda:0"` placement strings with dynamic `f"rank:0/{torch.device(device).type}:0"` — generates device-agnostic placements for `ShardMetadata`. Uses `torch.device(device).type` (not `self.device_type`) to avoid `privateuse1` vs actual device name mismatch before `setUpClass`.
- Added `device` parameter to both test method signatures (`test_xxx(self)` → `test_xxx(self, device)`, framework injection).
- Added `device_type` parameter to `_chunk_sharding_specs_list_for_test` calls, passing `torch.device(device).type` for dynamic placement generation (requires common PR #193531 for `_test_st_common.py`).
- Added `instantiate_device_type_tests(TestReshard, globals(), except_for="cpu")` at file end — generates CUDA / XPU / PrivateUse1 variants but skips CPU (ShardedTensor distributed tests require an accelerator; `with_comms` + `skip_if_lt_x_gpu` enforce this at runtime).
- Added `hw_classification = HardwareClassification.ACCELERATOR` to `TestReshard`.

## Not changed

- `@skip_if_lt_x_gpu(4)` is intentionally kept as-is. The decorator already supports accelerators via `torch.accelerator` API after PR #187650.
- `with_comms` decorator and `ShardedTensorTestBase` are not modified in this PR — backend resolution is handled by the `backend` property added in PR #194992.
- The numerical assertions and test logic are unchanged.

## Depends on

This PR relies on the following upstream PRs (submitted but not yet merged):

- **#187650**: `skip_if_lt_x_gpu` hardware-agnostic implementation
- **#190528**: `init_pg` hccl device binding
- **#191919**: `Capability` class + `requires_capabilities` decorator
- **#193080**: `PrivateUse1TestBase._capabilities()` override
- **#193531**: `_test_st_common.py` dynamic placement generation
- **#194992**: `ShardedTensorTestBase.backend` property + `with_comms` dynamic resolution

Without #191919 + #193080, `@requires_capabilities` is not available. Without #194992, `self.backend` property does not exist and `with_comms` cannot dynamically resolve the backend. Without #193531, `_chunk_sharding_specs_list_for_test()` does not accept the `device_type` parameter.

## Test plan

- `python test/distributed/_shard/sharded_tensor/test_sharded_tensor_reshard.py` on PrivateUse1 (torch_npu 2.13.0+git45fbeae, PyTorch 2.13.0a0+gitfad7424, Ascend 910B3, NPU host): 2 tests pass (`OK`). Backend correctly resolved to `hccl` via `self.backend` property.
- `python test/distributed/_shard/sharded_tensor/test_sharded_tensor_reshard.py` on CUDA (A100, PyTorch 2.13.0a0): 2 tests pass (`OK`). Backend correctly resolved to `nccl`.
- CPU host: `Ran 0 tests` — `except_for="cpu"` correctly excludes CPU variants.