### PR TITLE
[AOTAutograd] Fix CSE to deduplicate NaN constant tensors by normalizing float/complex hashing and comparison

### DIFF
--- a/test/functorch/test_memory_efficient_fusion.py
+++ b/test/functorch/test_memory_efficient_fusion.py
@@ -431,7 +431,7 @@ class ReduceTestCase(TestCase):
             return a + b
 
         t = torch.randn(2, 2)
-        check(f, t, 0, check_val=False)
+        check(f, t, 0)
 
     def test_nan_dedup_non_factory_op(self):
         def f(x):
@@ -442,7 +442,7 @@ class ReduceTestCase(TestCase):
         t = torch.randn(2, 2)
         check(f, t, 1, check_val=False)
 
-    def test_nan_dedup_list_arg(self):
+    def test_nan_dedup_constant_pad(self):
         def f(x):
             a = torch.nn.functional.pad(x, (1, 1, 1, 1), value=float("nan"))
             b = torch.nn.functional.pad(x, (1, 1, 1, 1), value=float("nan"))

--- a/test/functorch/test_memory_efficient_fusion.py
+++ b/test/functorch/test_memory_efficient_fusion.py
@@ -424,6 +424,33 @@ class ReduceTestCase(TestCase):
         t = torch.randn(2, 2)
         check(f, t, 0, check_val=False)
 
+    def test_neg_zero_not_merged(self):
+        def f(x):
+            a = torch.full_like(x, 0.0)
+            b = torch.full_like(x, -0.0)
+            return a + b
+
+        t = torch.randn(2, 2)
+        check(f, t, 0, check_val=False)
+
+    def test_nan_dedup_non_factory_op(self):
+        def f(x):
+            a = x.clamp(min=float("nan"))
+            b = x.clamp(min=float("nan"))
+            return a + b
+
+        t = torch.randn(2, 2)
+        check(f, t, 1, check_val=False)
+
+    def test_nan_dedup_list_arg(self):
+        def f(x):
+            a = torch.nn.functional.pad(x, (1, 1, 1, 1), value=float("nan"))
+            b = torch.nn.functional.pad(x, (1, 1, 1, 1), value=float("nan"))
+            return a + b
+
+        t = torch.randn(2, 2)
+        check(f, t, 1, check_val=False)
+
 
 class RandomOpTestCase(TestCase):
     def test_random(self):

--- a/test/functorch/test_memory_efficient_fusion.py
+++ b/test/functorch/test_memory_efficient_fusion.py
@@ -309,6 +309,34 @@ class NoChangeTestCase(TestCase):
         fx_g = gms[0]
         check(fx_g, None, 0, check_val=False, graph_input=True)
 
+    def test_neg_nan_not_merged(self):
+        def f(x):
+            a = torch.full_like(x, float("nan"))
+            b = torch.full_like(x, -float("nan"))
+            return a + b
+
+        t = torch.randn(2, 2)
+        check(f, t, 0, check_val=False)
+
+    def test_neg_zero_not_merged(self):
+        def f(x):
+            a = torch.full_like(x, 0.0)
+            b = torch.full_like(x, -0.0)
+            return torch.stack([a.reciprocal(), b.reciprocal()])
+
+        t = torch.randn(2, 2)
+        check(f, t, 0)
+
+    def test_complex_neg_zero_not_merged(self):
+        def f(x):
+            y = x.to(torch.cfloat)
+            a = torch.full_like(y, complex(0.0, 0.0))
+            b = torch.full_like(y, complex(-0.0, 0.0))
+            return torch.stack([a.real.reciprocal(), b.real.reciprocal()])
+
+        t = torch.randn(2, 2)
+        check(f, t, 0)
+
 
 class ReduceTestCase(TestCase):
     def test_immutable_list_type(self):
@@ -415,24 +443,6 @@ class ReduceTestCase(TestCase):
         t = torch.randn(2, 2)
         check(f, t, 1, check_val=False)
 
-    def test_neg_nan_not_merged(self):
-        def f(x):
-            a = torch.full_like(x, float("nan"))
-            b = torch.full_like(x, -float("nan"))
-            return a + b
-
-        t = torch.randn(2, 2)
-        check(f, t, 0, check_val=False)
-
-    def test_neg_zero_not_merged(self):
-        def f(x):
-            a = torch.full_like(x, 0.0)
-            b = torch.full_like(x, -0.0)
-            return a + b
-
-        t = torch.randn(2, 2)
-        check(f, t, 0)
-
     def test_nan_dedup_non_factory_op(self):
         def f(x):
             a = x.clamp(min=float("nan"))
@@ -446,6 +456,16 @@ class ReduceTestCase(TestCase):
         def f(x):
             a = torch.nn.functional.pad(x, (1, 1, 1, 1), value=float("nan"))
             b = torch.nn.functional.pad(x, (1, 1, 1, 1), value=float("nan"))
+            return a + b
+
+        t = torch.randn(2, 2)
+        check(f, t, 1, check_val=False)
+
+    def test_complex_nan_full_deduplication(self):
+        def f(x):
+            y = x.to(torch.cfloat)
+            a = torch.full_like(y, complex(float("nan"), 0.0))
+            b = torch.full_like(y, complex(float("nan"), 0.0))
             return a + b
 
         t = torch.randn(2, 2)

--- a/test/functorch/test_memory_efficient_fusion.py
+++ b/test/functorch/test_memory_efficient_fusion.py
@@ -406,6 +406,24 @@ class ReduceTestCase(TestCase):
         t = torch.randn(2, 2)
         check(f, t, 1)
 
+    def test_nan_full_deduplication(self):
+        def f(x):
+            a = torch.full_like(x, float("nan"))
+            b = torch.full_like(x, float("nan"))
+            return a + b
+
+        t = torch.randn(2, 2)
+        check(f, t, 1, check_val=False)
+
+    def test_neg_nan_not_merged(self):
+        def f(x):
+            a = torch.full_like(x, float("nan"))
+            b = torch.full_like(x, -float("nan"))
+            return a + b
+
+        t = torch.randn(2, 2)
+        check(f, t, 0, check_val=False)
+
 
 class RandomOpTestCase(TestCase):
     def test_random(self):

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -24,9 +24,9 @@ aten = torch.ops.aten
 
 
 def _normalize_cse_arg(val: Any) -> Any:
+    """Key floats and complex by IEEE 754 bit pattern for consistent hashing."""
     # Python float hash/eq is not value-identity: nan != nan (hash(nan) is
     # id-based) while -0.0 == 0.0 and hashes equal. Key by bit pattern instead.
-    """Key floats and complex by IEEE 754 bit pattern for consistent hashing."""
     if isinstance(val, float):
         return ("__CSE_FLOAT__", struct.pack(">d", val))
     if isinstance(val, complex):

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import math
 import operator
+import struct
 from typing import Any, TYPE_CHECKING
 
 import sympy
@@ -24,14 +24,17 @@ aten = torch.ops.aten
 
 
 def _normalize_cse_arg(val: Any) -> Any:
-    """Replace NaN float values with a sign-preserving sentinel that compares equal to itself.
+    """Key floats and complex by IEEE 754 bit pattern for consistent hashing.
 
-    IEEE 754 NaN values do not compare equal (nan != nan), which prevents CSE from
-    deduplicating identical NaN-filled tensors. Replace NaN floats with a sign-preserving
-    sentinel so the token equality check passes.
+    Python float hash/eq is not value-identity: nan != nan (and hash(nan)
+    is id-based), while -0.0 == 0.0 and hashes equal.  Key by bit pattern
+    so truly identical values deduplicate, while values that differ only in
+    the sign bit (nan vs -nan, 0.0 vs -0.0) do not merge.
     """
-    if isinstance(val, float) and math.isnan(val):
-        return ("__CSE_NAN__", math.copysign(1.0, val))
+    if isinstance(val, float):
+        return ("__CSE_FLOAT__", struct.pack(">d", val))
+    if isinstance(val, complex):
+        return ("__CSE_COMPLEX__", struct.pack(">dd", val.real, val.imag))
     return val
 
 
@@ -209,6 +212,7 @@ def fx_graph_cse(
                         arg_list[i] = env[v]
                     if isinstance(v, (torch.SymBool, torch.SymInt, torch.SymFloat)):
                         arg_list[i] = v.node
+                    arg_list[i] = _normalize_cse_arg(arg_list[i])
                 return tuple(arg_list), spec
 
             args, args_spec = substitute(n.args)
@@ -220,9 +224,9 @@ def fx_graph_cse(
             token = {
                 "target": n.target,
                 "extra_key": extra_key,
-                "args": tuple(_normalize_cse_arg(a) for a in args),
+                "args": args,
                 "args_spec": args_spec,
-                "kwargs": tuple(_normalize_cse_arg(a) for a in kwargs),
+                "kwargs": kwargs,
                 "kwargs_spec": kwargs_spec,
                 "custom_context": custom_context_key(n),
             }
@@ -230,12 +234,10 @@ def fx_graph_cse(
             # hash substituted args to a number, do not hash specs because specs are not hashable
             # We need to add type into hash to avoid situations like:
             # hash((primals_2, 1.0)) == hash((primals_2, 1))
-            # Normalize args with _normalize_cse_arg to ensure NaN values hash consistently --
-            # different float('nan') instances have different hashes in CPython.
             hash_arg = hash(
                 (
-                    tuple((_normalize_cse_arg(a), type(a)) for a in args),
-                    tuple((_normalize_cse_arg(a), type(a)) for a in kwargs),
+                    tuple((a, type(a)) for a in args),
+                    tuple((a, type(a)) for a in kwargs),
                 )
             )
             hash_val = (n.target, extra_key, hash_arg)

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -24,13 +24,9 @@ aten = torch.ops.aten
 
 
 def _normalize_cse_arg(val: Any) -> Any:
-    """Key floats and complex by IEEE 754 bit pattern for consistent hashing.
-
-    Python float hash/eq is not value-identity: nan != nan (and hash(nan)
-    is id-based), while -0.0 == 0.0 and hashes equal.  Key by bit pattern
-    so truly identical values deduplicate, while values that differ only in
-    the sign bit (nan vs -nan, 0.0 vs -0.0) do not merge.
-    """
+    # Python float hash/eq is not value-identity: nan != nan (hash(nan) is
+    # id-based) while -0.0 == 0.0 and hashes equal. Key by bit pattern instead.
+    """Key floats and complex by IEEE 754 bit pattern for consistent hashing."""
     if isinstance(val, float):
         return ("__CSE_FLOAT__", struct.pack(">d", val))
     if isinstance(val, complex):

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -231,10 +231,7 @@ def fx_graph_cse(
             # We need to add type into hash to avoid situations like:
             # hash((primals_2, 1.0)) == hash((primals_2, 1))
             hash_arg = hash(
-                (
-                    tuple((a, type(a)) for a in args),
-                    tuple((a, type(a)) for a in kwargs),
-                )
+                (tuple((a, type(a)) for a in args), tuple((a, type(a)) for a in kwargs))
             )
             hash_val = (n.target, extra_key, hash_arg)
 

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -33,9 +33,9 @@ class _ScalarKey:
 def _normalize_cse_arg(val: Any) -> Any:
     # Python float hash/eq is not value-identity: nan != nan (hash(nan) is
     # id-based) while -0.0 == 0.0 and hashes equal. Key by bit pattern instead.
-    if isinstance(val, float):
+    if type(val) is float:
         return _ScalarKey("float", struct.pack(">d", val))
-    if isinstance(val, complex):
+    if type(val) is complex:
         return _ScalarKey("complex", struct.pack(">dd", val.real, val.imag))
     return val
 

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import operator
 import struct
 from typing import Any, TYPE_CHECKING
@@ -23,14 +24,19 @@ if TYPE_CHECKING:
 aten = torch.ops.aten
 
 
+@dataclasses.dataclass(frozen=True)
+class _ScalarKey:
+    tag: str
+    bits: bytes
+
+
 def _normalize_cse_arg(val: Any) -> Any:
-    """Key floats and complex by IEEE 754 bit pattern for consistent hashing."""
     # Python float hash/eq is not value-identity: nan != nan (hash(nan) is
     # id-based) while -0.0 == 0.0 and hashes equal. Key by bit pattern instead.
     if isinstance(val, float):
-        return ("__CSE_FLOAT__", struct.pack(">d", val))
+        return _ScalarKey("float", struct.pack(">d", val))
     if isinstance(val, complex):
-        return ("__CSE_COMPLEX__", struct.pack(">dd", val.real, val.imag))
+        return _ScalarKey("complex", struct.pack(">dd", val.real, val.imag))
     return val
 
 

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import operator
 from typing import Any, TYPE_CHECKING
 
@@ -20,6 +21,18 @@ if TYPE_CHECKING:
     from torch.utils._pytree import TreeSpec
 
 aten = torch.ops.aten
+
+
+def _normalize_cse_arg(val: Any) -> Any:
+    """Replace NaN float values with a sign-preserving sentinel that compares equal to itself.
+
+    IEEE 754 NaN values do not compare equal (nan != nan), which prevents CSE from
+    deduplicating identical NaN-filled tensors. Replace NaN floats with a sign-preserving
+    sentinel so the token equality check passes.
+    """
+    if isinstance(val, float) and math.isnan(val):
+        return ("__CSE_NAN__", math.copysign(1.0, val))
+    return val
 
 
 def get_aten_target(node: fx.Node) -> OpOverloadPacket | Callable[..., Any] | str:
@@ -207,9 +220,9 @@ def fx_graph_cse(
             token = {
                 "target": n.target,
                 "extra_key": extra_key,
-                "args": args,
+                "args": tuple(_normalize_cse_arg(a) for a in args),
                 "args_spec": args_spec,
-                "kwargs": kwargs,
+                "kwargs": tuple(_normalize_cse_arg(a) for a in kwargs),
                 "kwargs_spec": kwargs_spec,
                 "custom_context": custom_context_key(n),
             }
@@ -217,8 +230,13 @@ def fx_graph_cse(
             # hash substituted args to a number, do not hash specs because specs are not hashable
             # We need to add type into hash to avoid situations like:
             # hash((primals_2, 1.0)) == hash((primals_2, 1))
+            # Normalize args with _normalize_cse_arg to ensure NaN values hash consistently --
+            # different float('nan') instances have different hashes in CPython.
             hash_arg = hash(
-                (tuple((a, type(a)) for a in args), tuple((a, type(a)) for a in kwargs))
+                (
+                    tuple((_normalize_cse_arg(a), type(a)) for a in args),
+                    tuple((_normalize_cse_arg(a), type(a)) for a in kwargs),
+                )
             )
             hash_val = (n.target, extra_key, hash_arg)
 


### PR DESCRIPTION
Fixes #191013

## TL;DR
Fix CSE to deduplicate NaN constant tensors by normalizing float/complex hashing and comparison using their IEEE 754 bit patterns.

## Problem
The AOTAutograd CSE pass (`fx_graph_cse`) was failing to deduplicate identical constant tensors (e.g., multiple `torch.full_like(x, float("nan"))` calls) because Python float semantics break both the hash lookup and the token equality check used by CSE:

- NaN: `float("nan") != float("nan")` (IEEE 754), and `hash(float("nan"))` is id-based in CPython, so two NaN instances hash differently.
- Negative zero: `float(-0.0) == float(0.0)` (IEEE 754), so distinct constants incorrectly merge.

## Solution
The fix adds `_normalize_cse_arg()`, which replaces float and complex values with a `_ScalarKey` dataclass tagged by their IEEE 754 bit pattern (via `struct.pack`). This gives consistent hashing and equality for NaN values while preserving distinct bit patterns (NaN sign, negative zero).

A `_ScalarKey(tag, bits)` tuple is used rather than the raw bit pattern alone to avoid collisions between float and complex values that happen to have the same byte representation.

## Test Plan
```
python test/functorch/test_memory_efficient_fusion.py
```

New tests cover:
- NaN deduplication (identical +nan constants merged)
- NaN preservation (sign-preserving: +nan and -nan not merged)
- Negative zero not merged with positive zero (different bit pattern)
- Complex NaN deduplication
- Complex negative zero preservation
- NaN deduplication via non-factory ops (e.g., `clamp`)
- NaN deduplication via constant pad

Generated by my agent