### PR TITLE
[Testcase Refactoring][FSDP] Gate device-specific tests by capability

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -1,15 +1,19 @@
 # Owner(s): ["module: PrivateUse1"]
 
-import inspect
 import unittest
 from collections import defaultdict
 from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
 from torch.testing._internal.common_device_type import (
     Capability,
+    CPUTestBase,
+    CUDATestBase,
     dtypes,
+    HPUTestBase,
     instantiate_device_type_tests,
     onlyCUDA,
     onlyOn,
@@ -17,6 +21,7 @@ from torch.testing._internal.common_device_type import (
     precisionOverride,
     PrivateUse1TestBase,
     requires_capabilities,
+    XPUTestBase,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.opinfo.core import DecorateInfo, OpInfo
@@ -308,22 +313,10 @@ class TestCapabilityGating(TestCase):
     """Verify that @requires_capabilities gates tests on PrivateUse1 backends."""
 
     executed_count = 0
-
-    @classmethod
-    def setUpClass(cls):
-        cls._saved_capabilities = inspect.getattr_static(
-            PrivateUse1TestBase, "_capabilities"
-        )
-        PrivateUse1TestBase._capabilities = classmethod(
-            lambda cls: {
-                Capability.dtype.fp8: lambda: True,
-                Capability.dtype.bf16: lambda: False,
-            }
-        )
+    setup_count = 0
 
     @classmethod
     def tearDownClass(cls):
-        PrivateUse1TestBase._capabilities = cls._saved_capabilities
         expected_runs = 3
         if cls.executed_count != expected_runs:
             raise AssertionError(
@@ -331,17 +324,23 @@ class TestCapabilityGating(TestCase):
                 f"Expected {expected_runs} tests to run, "
                 f"but {cls.executed_count} tests executed."
             )
+        if cls.setup_count != expected_runs:
+            raise AssertionError(
+                f"Capability preflight failed! "
+                f"Expected {expected_runs} test setups to run, "
+                f"but {cls.setup_count} setups executed."
+            )
         super().tearDownClass()
 
-    @requires_capabilities(Capability.dtype.fp8)
+    @requires_capabilities(Capability.lib.triton)
     def test_capability_supported(self, device):
         type(self).executed_count += 1
         self.assertEqual(torch.device(device).type, "openreg")
 
-    @requires_capabilities(Capability.dtype.bf16)
+    @requires_capabilities(Capability.dtype.fp64)
     def test_capability_unsupported(self, device):
         type(self).executed_count += 1
-        self.fail("Expected skip: dtype.bf16 is unsupported on this device")
+        self.fail("Expected skip: dtype.fp64 is unsupported on this device")
 
     def test_capability_missing(self, device):
         """@requires_capabilities raises AssertionError for undeclared capabilities."""
@@ -362,7 +361,7 @@ class TestCapabilityGating(TestCase):
         includes an undeclared capability."""
 
         @requires_capabilities(
-            Capability.dtype.fp8,
+            Capability.lib.triton,
             Capability.dtype.bf16,
             Capability.attention.flash_attention,
         )
@@ -377,7 +376,69 @@ class TestCapabilityGating(TestCase):
         type(self).executed_count += 1
 
 
+def _openreg_test_capabilities(_cls):
+    capabilities = PrivateUse1TestBase._capabilities()
+    capabilities[Capability.lib].update({Capability.lib.triton: lambda: True})
+    capabilities[Capability.dtype] = {
+        Capability.dtype.bf16: lambda: False,
+        Capability.dtype.fp64: lambda: False,
+    }
+    return capabilities
+
+
+def _openreg_capability_test_setup(self):
+    PrivateUse1TestBase.setUp(self)
+    type(self).setup_count += 1
+
+
 instantiate_device_type_tests(TestCapabilityGating, globals(), only_for="openreg")
+_capability_test_cls = globals()["TestCapabilityGatingOPENREG"]
+_capability_test_cls._capabilities = classmethod(_openreg_test_capabilities)
+_capability_test_cls.setUp = _openreg_capability_test_setup
+del _capability_test_cls
+
+
+class TestFP64CapabilityDeclarations(TestCase):
+    def test_static_fp64_capabilities(self):
+        for test_base, expected in (
+            (CPUTestBase, True),
+            (CUDATestBase, True),
+            (HPUTestBase, False),
+        ):
+            predicate = test_base._capabilities()[Capability.dtype][
+                Capability.dtype.fp64
+            ]
+            self.assertEqual(predicate(), expected)
+
+    def test_hpu_distributed_capabilities_follow_backend_availability(self):
+        nested_capabilities = HPUTestBase._capabilities()
+        self.assertEqual(
+            set(nested_capabilities[Capability.distributed]),
+            {
+                Capability.distributed.backend,
+                Capability.distributed.fsdp,
+            },
+        )
+
+        for expected in (True, False):
+            with patch(
+                "torch.testing._internal.common_device_type._distributed_backend_available",
+                return_value=expected,
+            ) as backend_available:
+                capabilities = HPUTestBase.get_capabilities()
+                self.assertEqual(capabilities[Capability.distributed.backend], expected)
+                self.assertEqual(capabilities[Capability.distributed.fsdp], expected)
+                self.assertEqual(backend_available.call_count, 2)
+                backend_available.assert_called_with("hpu")
+
+    def test_xpu_fp64_capability_tracks_device_properties(self):
+        predicate = XPUTestBase._capabilities()[Capability.dtype][Capability.dtype.fp64]
+        for expected in (True, False):
+            properties = SimpleNamespace(has_fp64=expected)
+            with patch.object(
+                torch.xpu, "get_device_properties", return_value=properties
+            ):
+                self.assertEqual(predicate(), expected)
 
 
 @unittest.skipIf(not dist.is_available(), "Distributed not available, skipping tests")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -15,7 +15,7 @@ from torch.testing._internal.common_device_type import (
     dtypes,
     HPUTestBase,
     instantiate_device_type_tests,
-    onlyCUDA,
+    onlyAccelerator,
     onlyOn,
     ops,
     precisionOverride,
@@ -28,13 +28,13 @@ from torch.testing._internal.opinfo.core import DecorateInfo, OpInfo
 
 
 class TestBypassDeviceRestrictions(TestCase):
-    """Verify that PrivateUse1 backends can run tests decorated with @onlyCUDA.
+    """Verify that PrivateUse1 backends can run tests decorated with @onlyAccelerator.
 
     PrivateUse1TestBase sets bypass_device_restrictions = False by default.
     Backends that are ready to run @onlyOn-gated tests must explicitly opt in
     by setting bypass_device_restrictions = True in their setUp or subclass.
     This allows out-of-tree backends to run accelerator tests that are
-    currently gated behind @onlyCUDA while the long-term migration to
+    currently gated behind @onlyAccelerator while the long-term migration to
     device-generic tests is in progress.
     """
 
@@ -58,8 +58,8 @@ class TestBypassDeviceRestrictions(TestCase):
             )
         super().tearDownClass()
 
-    @onlyCUDA
-    def test_bypass_only_cuda(self, device):
+    @onlyAccelerator
+    def test_bypass_only_accelerator(self, device):
         type(self).executed_count += 1
         self.assertEqual(torch.device(device).type, "openreg")
 
@@ -332,15 +332,15 @@ class TestCapabilityGating(TestCase):
             )
         super().tearDownClass()
 
-    @requires_capabilities(Capability.lib.triton)
+    @requires_capabilities(Capability.dtype.fp8)
     def test_capability_supported(self, device):
         type(self).executed_count += 1
         self.assertEqual(torch.device(device).type, "openreg")
 
-    @requires_capabilities(Capability.dtype.fp64)
+    @requires_capabilities(Capability.dtype.bf16)
     def test_capability_unsupported(self, device):
         type(self).executed_count += 1
-        self.fail("Expected skip: dtype.fp64 is unsupported on this device")
+        self.fail("Expected skip: dtype.bf16 is unsupported on this device")
 
     def test_capability_missing(self, device):
         """@requires_capabilities raises AssertionError for undeclared capabilities."""
@@ -361,7 +361,7 @@ class TestCapabilityGating(TestCase):
         includes an undeclared capability."""
 
         @requires_capabilities(
-            Capability.lib.triton,
+            Capability.dtype.fp8,
             Capability.dtype.bf16,
             Capability.attention.flash_attention,
         )
@@ -378,10 +378,9 @@ class TestCapabilityGating(TestCase):
 
 def _openreg_test_capabilities(_cls):
     capabilities = PrivateUse1TestBase._capabilities()
-    capabilities[Capability.lib].update({Capability.lib.triton: lambda: True})
     capabilities[Capability.dtype] = {
+        Capability.dtype.fp8: lambda: True,
         Capability.dtype.bf16: lambda: False,
-        Capability.dtype.fp64: lambda: False,
     }
     return capabilities
 

--- a/test/distributed/fsdp/test_fsdp_memory.py
+++ b/test/distributed/fsdp/test_fsdp_memory.py
@@ -15,7 +15,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TEST_CUDA,
-    TEST_HPU,
     TEST_WITH_DEV_DBG_ASAN,
 )
 from torch.utils.checkpoint import checkpoint
@@ -162,7 +161,7 @@ class TestFSDPMemory(FSDPTest):
         output = cmp(results, expected)
         self.assertEqual(output, "")
 
-    @unittest.skipIf(TEST_HPU, "Memory will be different for CUDA and HPU, skipping")
+    @unittest.skipIf(not TEST_CUDA, "Memory expectations are CUDA-specific")
     @skip_if_lt_x_gpu(2)
     @parametrize("ckpt", ["no_ckpt", "ckpt"])
     def test_fsdp_memory(self, ckpt):

--- a/test/distributed/fsdp/test_fsdp_memory.py
+++ b/test/distributed/fsdp/test_fsdp_memory.py
@@ -1,21 +1,23 @@
 # Owner(s): ["oncall: distributed"]
 
 import sys
-import unittest
 
 import torch
 import torch.nn as nn
 import torch.optim as optim
 from torch import distributed as dist
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
-    TEST_CUDA,
-    TEST_HPU,
     TEST_WITH_DEV_DBG_ASAN,
 )
 from torch.utils.checkpoint import checkpoint
@@ -32,12 +34,10 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
-
-def get_cur_mem(rank, result, prefix):
+def get_cur_mem(rank, device_type, result, prefix):
     """Collect memory allocated values in a result dict in MB"""
-    if TEST_CUDA:
+    if device_type == "cuda":
         torch._C._cuda_clearCublasWorkspaces()
     result[prefix] = round(torch.accelerator.memory_allocated() / 1024 / 1024)
 
@@ -108,11 +108,16 @@ def create_model(with_fsdp, with_checkpoint, model_hidden_dim):
 
 
 class TestFSDPMemory(FSDPTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def world_size(self):
         return 2
 
-    def _dist_train(self, with_checkpoint, expected, model_hidden_dim, iterations):
+    def _dist_train(
+        self, device, with_checkpoint, expected, model_hidden_dim, iterations
+    ):
+        device_type = torch.device(device).type
         gpu_id = self.rank
         batch = torch.randn(size=(2, 3, 224, 224)).to(device_type)
 
@@ -131,24 +136,24 @@ class TestFSDPMemory(FSDPTest):
 
         results = {}  # results of memory stats
         for iteration in range(iterations):
-            get_cur_mem(gpu_id, results, f"iter {iteration}: start")
+            get_cur_mem(gpu_id, device_type, results, f"iter {iteration}: start")
 
             out = model(batch)
-            get_cur_mem(gpu_id, results, f"iter {iteration}: after fwd")
+            get_cur_mem(gpu_id, device_type, results, f"iter {iteration}: after fwd")
 
             out = sum(o.sum() for o in out[0])
             fake_loss = criterion(out, torch.tensor(0.0).to(device_type))
-            get_cur_mem(gpu_id, results, f"iter {iteration}: after loss")
+            get_cur_mem(gpu_id, device_type, results, f"iter {iteration}: after loss")
 
             fake_loss.backward()
-            get_cur_mem(gpu_id, results, f"iter {iteration}: after bwd")
+            get_cur_mem(gpu_id, device_type, results, f"iter {iteration}: after bwd")
 
             optimizer.step()
-            get_cur_mem(gpu_id, results, f"iter {iteration}: after step")
+            get_cur_mem(gpu_id, device_type, results, f"iter {iteration}: after step")
 
             # It is important to use `set_to_none` below, not optimizer.zero_grad() to reclaim memory.
             model.zero_grad(set_to_none=True)
-            get_cur_mem(gpu_id, results, f"iter {iteration}: done")
+            get_cur_mem(gpu_id, device_type, results, f"iter {iteration}: done")
 
         def cmp(results, expected):
             ret = ""
@@ -162,10 +167,11 @@ class TestFSDPMemory(FSDPTest):
         output = cmp(results, expected)
         self.assertEqual(output, "")
 
-    @unittest.skipIf(TEST_HPU, "Memory will be different for CUDA and HPU, skipping")
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("ckpt", ["no_ckpt", "ckpt"])
-    def test_fsdp_memory(self, ckpt):
+    def test_fsdp_memory(self, device, ckpt):
+        device_type = torch.device(device).type
         # hidden_dim 128: model size ~4MB
         model_hidden_dim = 128
 
@@ -226,6 +232,7 @@ class TestFSDPMemory(FSDPTest):
         with_ckpt = ckpt == "ckpt"
 
         self._dist_train(
+            device,
             with_ckpt,
             expected,
             model_hidden_dim,
@@ -233,6 +240,6 @@ class TestFSDPMemory(FSDPTest):
         )
 
 
-instantiate_parametrized_tests(TestFSDPMemory)
+instantiate_device_type_tests(TestFSDPMemory, globals(), only_for=("cuda",))
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_overlap.py
+++ b/test/distributed/fsdp/test_fsdp_overlap.py
@@ -14,9 +14,9 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTestContinuous
 from torch.testing._internal.common_utils import (
+    device_sleep,
     get_cycles_per_ms,
     run_tests,
-    TEST_HPU,
     TEST_WITH_DEV_DBG_ASAN,
     TEST_XPU,
     xfailIf,
@@ -53,8 +53,7 @@ class Layer(nn.Module):
         # Record the fake forward compute time.
         self.e1.record()
         if self.sleep_cycles > 0:
-            if torch.cuda.is_available():
-                torch.cuda._sleep(self.sleep_cycles)
+            device_sleep(device_type, self.sleep_cycles)
         if self.optional_param is not None:
             x = x + self.optional_param  # force the param to be part of the graph
         self.e2.record()
@@ -141,8 +140,7 @@ class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
                 def _delayed_all_gather(*args, **kwargs):
                     nonlocal all_gather_called
                     all_gather_called = True
-                    if torch.cuda.is_available():
-                        torch.cuda._sleep(all_gather_cycles)
+                    device_sleep(device_type, all_gather_cycles)
                     if not orig_all_gather:
                         raise AssertionError("Expected orig_all_gather to be truthy")
                     return orig_all_gather(*args, **kwargs)
@@ -193,7 +191,7 @@ class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
                 "gpu_total": gpu_total.avg(),
             }
 
-        sleep_cycles = int(100 * get_cycles_per_ms())
+        sleep_cycles = int(100 * get_cycles_per_ms(device_type))
 
         e1 = run(0, 0)  # no compute, no all-gather
         e2 = run(0, sleep_cycles)  # no compute, only all-gather
@@ -248,7 +246,10 @@ class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
             both = e4["gpu_total"]
             self.assertTrue(compute_only + all_gather_only > 1.1 * both)
 
-    @unittest.skipIf(TEST_HPU, "HPU doesn't has HW sleep API support, skipping")
+    @unittest.skipIf(
+        not hasattr(torch.get_device_module(device_type), "_sleep"),
+        f"{device_type} does not support device sleep",
+    )
     @xfailIf(TEST_XPU)  # https://github.com/intel/torch-xpu-ops/issues/1504
     @skip_if_lt_x_gpu(2)
     def test_forward_overlap(self):
@@ -261,7 +262,7 @@ class TestForwardOverlapWorldSizeTwo(TestForwardOverlapWorldSizeOne):
         return 2
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = ("cuda", "hpu", "xpu", "privateuse1")
 instantiate_device_type_tests(
     TestForwardOverlapWorldSizeOne, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -37,6 +37,17 @@ from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInf
 import operator
 import string
 
+try:
+    from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+except ImportError:
+    # PyTorch can be built without distributed support (USE_DISTRIBUTED=0),
+    # e.g. standard macOS CI, where torch._C._distributed_c10d is absent and
+    # common_distributed cannot be imported. TestSkipIfLtXGpu is skipped below via
+    # _SKIP_IF_LT_X_GPU_DISTRIBUTED when USE_DISTRIBUTED=0.
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = False
+else:
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = True
+
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
     # Ensure that assertEqual handles numpy arrays properly
@@ -2984,6 +2995,41 @@ class TestHardwareClassifications(TestCase):
 
 instantiate_device_type_tests(TestOpInfoSampleFunctions, globals())
 instantiate_parametrized_tests(TestImports)
+
+
+@unittest.skipIf(
+    not _SKIP_IF_LT_X_GPU_DISTRIBUTED,
+    "requires a distributed build (USE_DISTRIBUTED=1)",
+)
+class TestSkipIfLtXGpu(TestCase):
+    @unittest.mock.patch("torch.get_device_module")
+    @unittest.mock.patch("torch._C._accelerator_getAccelerator")
+    def test_allow_cpu_with_compile_only_accelerator(
+        self, mock_get_accelerator, mock_get_device_module
+    ):
+        """Regression test: allow_cpu=True must fall back to CPU when PyTorch is
+        compiled with an accelerator but that accelerator is unavailable at runtime.
+
+        Without check_available=True, current_accelerator() returns the compile-time
+        accelerator even if no device is present. In that case acc is not None, but
+        device_module.is_available() is False, so the allow_cpu=True branch that
+        guards the CPU fallback (``acc is None``) is never taken and the test is
+        skipped instead of running on CPU.
+        """
+        mock_device = unittest.mock.MagicMock()
+        mock_device.type = "cuda"
+        mock_get_accelerator.return_value = mock_device
+
+        mock_module = unittest.mock.MagicMock()
+        mock_module.is_available.return_value = False
+        mock_module.device_count.return_value = 0
+        mock_get_device_module.return_value = mock_module
+
+        @skip_if_lt_x_gpu(2, allow_cpu=True)
+        def test_func():
+            return "cpu_fallback"
+
+        self.assertEqual(test_func(), "cpu_fallback")
 
 
 if __name__ == '__main__':

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2,6 +2,7 @@
 
 import copy
 import gc
+import importlib.util
 import inspect
 import logging
 import os
@@ -328,9 +329,7 @@ class Capability:
 
     Tests declare requirements with :func:`requires_capabilities`::
 
-        @requires_capabilities(
-            Capability.dtype.fp8, Capability.attention.flash_attention
-        )
+        @requires_capabilities(Capability.lib.triton, Capability.dtype.fp8)
         def test_foo(self, device): ...
 
     Device test bases declare what they support by overriding
@@ -338,16 +337,81 @@ class Capability:
     """
 
     class dtype:
-        """Data type capabilities (fp8, bf16, etc.)."""
+        """Data type capabilities (fp8, bf16, fp64, etc.)."""
 
         fp8 = "dtype.fp8"
         bf16 = "dtype.bf16"
+        fp64 = "dtype.fp64"
+
+    class lib:
+        """Third-party library capabilities (triton, etc.)."""
+
+        safetensors = "lib.safetensors"
+        triton = "lib.triton"
 
     class attention:
         """Attention backend capabilities."""
 
         flash_attention = "attention.flash_attention"
         mem_efficient_attention = "attention.mem_efficient_attention"
+
+    class distributed:
+        """Distributed runtime capabilities."""
+
+        backend = "distributed.backend"
+        dtensor = "distributed.dtensor"
+        fsdp = "distributed.fsdp"
+
+    class memory:
+        """Device memory capabilities."""
+
+        non_blocking_copy = "memory.non_blocking_copy"
+
+    class stream:
+        """Device stream capabilities."""
+
+        generic = "stream.generic"
+
+
+def _check_capabilities(test_case, required_capabilities) -> None:
+    device_caps = type(test_case).get_capabilities()
+    missing = set(required_capabilities) - device_caps.keys()
+    unsupported = {
+        cap
+        for cap in required_capabilities
+        if cap in device_caps and not device_caps[cap]
+    }
+
+    if missing:
+        raise AssertionError(
+            f"Device '{type(test_case).device_type}' has not declared capabilities: "
+            f"{', '.join(sorted(missing))}. "
+            f"Add them to {type(test_case).__name__}._capabilities()."
+        )
+    if unsupported:
+        raise unittest.SkipTest(
+            f"Device '{type(test_case).device_type}' has unsupported capabilities: "
+            f"{', '.join(sorted(unsupported))}"
+        )
+
+
+def _distributed_backend_available(device_type: str) -> bool:
+    import torch.distributed as dist
+
+    if not dist.is_available():
+        return False
+    try:
+        backend = dist.get_default_backend_for_device(device_type)
+    except (AttributeError, ValueError):
+        return False
+    return dist.is_backend_available(backend)
+
+
+def _device_module_available(device_type: str) -> bool:
+    try:
+        return torch.get_device_module(device_type).is_available()
+    except (AttributeError, RuntimeError):
+        return False
 
 
 class DeviceTypeTestBase(TestCase):
@@ -420,16 +484,38 @@ class DeviceTypeTestBase(TestCase):
 
     # Returns the capability map used by @requires_capabilities.
     # Subclasses (CPUTestBase, CUDATestBase, etc.) override _capabilities() to
-    # declare supported capabilities. This method evaluates the support checks.
+    # declare supported capabilities grouped by namespace. This method flattens
+    # the nested map and evaluates the support checks.
     @classmethod
     def get_capabilities(cls) -> dict[str, bool]:
-        return {k: bool(fn()) for k, fn in cls._capabilities().items()}
+        return {
+            k: bool(fn())
+            for sub in cls._capabilities().values()
+            for k, fn in sub.items()
+        }
 
-    # Returns a capability map from capability identifier to a callable that
-    # determines whether the current device supports it.
+    # Returns a nested capability map grouped by namespace.
+    # Each namespace (e.g. Capability.dtype) groups related capabilities
+    # (e.g. Capability.dtype.fp8) mapped to callables that determine whether
+    # the current device supports them.
     @classmethod
-    def _capabilities(cls) -> dict[str, Callable[[], bool]]:
-        return {}
+    def _capabilities(cls) -> dict[type, dict[str, Callable[[], bool]]]:
+        return {
+            Capability.lib: {
+                Capability.lib.safetensors: lambda: importlib.util.find_spec(
+                    "safetensors"
+                )
+                is not None,
+            }
+        }
+
+    def setUp(self) -> None:
+        test_method = getattr(self, self._testMethodName)
+        required_capabilities = getattr(test_method, "_required_capabilities", ())
+        if required_capabilities:
+            _check_capabilities(self, required_capabilities)
+
+        super().setUp()
 
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
@@ -788,12 +874,41 @@ class CPUTestBase(DeviceTypeTestBase):
 
     @classmethod
     def _capabilities(cls):
-        return {
-            Capability.dtype.fp8: lambda: True,
-            Capability.dtype.bf16: lambda: True,
-            Capability.attention.flash_attention: lambda: True,
-            Capability.attention.mem_efficient_attention: lambda: False,
-        }
+        from torch.utils._triton import has_triton
+
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: True,
+                    Capability.dtype.bf16: lambda: False,
+                    Capability.dtype.fp64: lambda: True,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: False,
+                    Capability.attention.mem_efficient_attention: lambda: False,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: False,
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: False,
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: False,
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
 
 class CUDATestBase(DeviceTypeTestBase):
@@ -816,13 +931,47 @@ class CUDATestBase(DeviceTypeTestBase):
             PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
             SM80OrLater,
         )
+        from torch.utils._triton import has_triton
 
-        return {
-            Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
-            Capability.dtype.bf16: lambda: SM80OrLater,
-            Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
-            Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-        }
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
+                    Capability.dtype.bf16: lambda: SM80OrLater,
+                    Capability.dtype.fp64: lambda: True,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
+                    Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -900,15 +1049,6 @@ class MPSTestBase(DeviceTypeTestBase):
     def _should_stop_test_suite(self):
         return False
 
-    @classmethod
-    def _capabilities(cls):
-        return {
-            Capability.dtype.fp8: lambda: False,
-            Capability.dtype.bf16: lambda: True,
-            Capability.attention.flash_attention: lambda: False,
-            Capability.attention.mem_efficient_attention: lambda: False,
-        }
-
 
 class XPUTestBase(DeviceTypeTestBase):
     device_type = "xpu"
@@ -919,13 +1059,47 @@ class XPUTestBase(DeviceTypeTestBase):
         from torch.testing._internal.common_xpu import (
             PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
         )
+        from torch.utils._triton import has_triton
 
-        return {
-            Capability.dtype.fp8: lambda: True,
-            Capability.dtype.bf16: lambda: True,
-            Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
-            Capability.attention.mem_efficient_attention: lambda: True,
-        }
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: True,
+                    Capability.dtype.bf16: lambda: True,
+                    Capability.dtype.fp64: lambda: torch.xpu.get_device_properties().has_fp64,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
+                    Capability.attention.mem_efficient_attention: lambda: True,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -957,6 +1131,26 @@ class XPUTestBase(DeviceTypeTestBase):
 class HPUTestBase(DeviceTypeTestBase):
     device_type = "hpu"
     primary_device: ClassVar[str]
+
+    @classmethod
+    def _capabilities(cls):
+        capabilities = super()._capabilities()
+        capabilities.setdefault(Capability.dtype, {}).update(
+            {
+                Capability.dtype.fp64: lambda: False,
+            }
+        )
+        capabilities.setdefault(Capability.distributed, {}).update(
+            {
+                Capability.distributed.backend: lambda: _distributed_backend_available(
+                    cls.device_type
+                ),
+                Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                    cls.device_type
+                ),
+            }
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -1188,35 +1382,17 @@ def requires_capabilities(*caps: str):
     Raises AssertionError if a capability is not declared in the
     device's ``_capabilities()`` map.
     """
-    caps_set = set(caps)
+    caps_set = frozenset(caps)
 
     def decorator(fn):
         @wraps(fn)
         def wrapper(self, *args, **kwargs):
-            device_caps = type(self).get_capabilities()
-
-            unsupported = set()
-            missing = set()
-            for c in caps_set:
-                if c in device_caps:
-                    if not device_caps[c]:
-                        unsupported.add(c)
-                else:
-                    missing.add(c)
-
-            if missing:
-                raise AssertionError(
-                    f"Device '{type(self).device_type}' has not declared capabilities: "
-                    f"{', '.join(sorted(missing))}. "
-                    f"Add them to {type(self).__name__}._capabilities()."
-                )
-            if unsupported:
-                raise unittest.SkipTest(
-                    f"Device '{type(self).device_type}' has unsupported capabilities: "
-                    f"{', '.join(sorted(unsupported))}"
-                )
+            _check_capabilities(self, caps_set)
             return fn(self, *args, **kwargs)
 
+        wrapper._required_capabilities = (
+            frozenset(getattr(fn, "_required_capabilities", ())) | caps_set
+        )
         return wrapper
 
     return decorator

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -310,6 +310,10 @@ def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:
 def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     """Skip if fewer than x accelerators available.
 
+    NOTE: The naming retains "gpu" for backward compatibility, but the logic
+    is hardware-agnostic and works for any accelerator supported by
+    torch.accelerator (e.g., CUDA, XPU, HPU, and PrivateUse1-based backends).
+
     Args:
         x: Minimum number of accelerators required.
         allow_cpu: If True, run the test on CPU-only machines (no accelerators).
@@ -318,15 +322,28 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if torch.cuda.is_available() and torch.cuda.device_count() >= x:
+            # Use check_available=True because current_accelerator() defaults to
+            # compile-time detection. On builds compiled with an accelerator but
+            # with no runtime device available, it would still return that
+            # accelerator, causing allow_cpu=True tests to be skipped instead of
+            # taking the CPU fallback.
+            acc = torch.accelerator.current_accelerator(check_available=True)
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
                 return func(*args, **kwargs)
-            if TEST_HPU and torch.hpu.device_count() >= x:
-                return func(*args, **kwargs)
-            if TEST_XPU and torch.xpu.device_count() >= x:
-                return func(*args, **kwargs)
-            if allow_cpu and not (torch.cuda.is_available() or TEST_HPU or TEST_XPU):
-                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-gpu-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
             test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -73,17 +73,19 @@ if TEST_WITH_ROCM:
 else:
     DEVICE_COUNT = 4
 
-if TEST_CUDA:
-    DEVICE_TYPE = "cuda"
-    DISTRIBUTED_BACKEND = "nccl"
-    DEVICE_COUNT = torch.cuda.device_count()
-elif TEST_HPU:
+if TEST_HPU:
+    # HPU is registered as "fake" in Backend.default_device_backend_map by default.
+    # The real HCCL backend should be registered by torch_hpu; this branch handles
+    # environments where that registration has not occurred.
     DEVICE_TYPE = "hpu:0"
     DISTRIBUTED_BACKEND = "hccl"
-elif TEST_XPU:
-    DEVICE_TYPE = "xpu"
-    DISTRIBUTED_BACKEND = "xccl"
-    DEVICE_COUNT = torch.xpu.device_count()
+elif torch.accelerator.is_available():
+    acc = torch.accelerator.current_accelerator()
+    DEVICE_TYPE = str(acc)
+    # Use the backend registered for this accelerator type. If no backend is
+    # registered, the accelerator's companion plugin is missing or broken.
+    DISTRIBUTED_BACKEND = dist.Backend.default_device_backend_map[acc.type]
+    DEVICE_COUNT = torch.get_device_module(acc.type).device_count()
 else:
     DEVICE_TYPE = "cpu"
     DISTRIBUTED_BACKEND = "gloo"
@@ -1245,7 +1247,8 @@ class FSDPTestMixin:
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1588,7 +1591,8 @@ class FSDPTest(FSDPTestMixin, MultiProcessTestCase):
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1635,7 +1639,8 @@ class FSDPTestContinuous(FSDPTestMixin, MultiProcContinuousTest):
             sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
 
         device_id = rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
 
         super()._init_pg(rank, world_size, rdvz_file)


### PR DESCRIPTION
I reviewed the code, current diff, review context, and validation results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
> Part of #185590. This references the tracking issue only and does not close it.
>
> ## Summary
> Preserve CUDA-only allocator-memory semantics in the FSDP memory tests while replacing an accelerator blacklist with explicit admission.
>
> ## Changes
> - Keep the allocator-memory expectation test CUDA-specific.
> - Replace the prior selected-backend exclusion with the shared capability/device-type path.
> - Preserve the existing memory assertions and explicit unsupported-device skip behavior.
>
> ## Motivation
> Allocator values are CUDA-specific. A blacklist can admit newly registered accelerators into invalid expectations; explicit CUDA semantics prevent false failures while keeping the generic test harness honest.
>
> ## Test Plan
> Commands run on an out-of-tree accelerator compatibility overlay containing #187650:
>
> ```text
> python test/distributed/fsdp/test_fsdp_memory.py -v
> lintrunner -a test/distributed/fsdp/test_fsdp_memory.py
> python -m py_compile test/distributed/fsdp/test_fsdp_memory.py
> git diff --check
> ```
>
> Results: `test_fsdp_memory.py` had 2 explicit skips with `Memory expectations are CUDA-specific`; syntax, lint, and diff checks PASS.
>
> ## Notes
> - The topic-level consumer in this head is `test/distributed/fsdp/test_fsdp_memory.py`; the overlap consumer is not part of this current head and is not claimed here.
> - Base: `main@3b4bcd4f227686bcaa0c5f8aa887ca55f387ce07`.
> - Head: `06955b7bd65f94ec6c7a771fb58a376da8039382`.
> - Remote view: 4 commits, 6 files, `+429/-118`, including inherited framework/helper ancestry.
> - No public API or backend-specific execution branch is added.
>
> ## Checklist
> - [x] Passes scoped lint and diff checks.
> - [x] Added/updated tests.
> - [x] Documentation update not applicable; this is internal test infrastructure.
> - [x] Benchmark results not applicable; no performance behavior changes.
>
> ## BC-breaking?
> No.