### PR TITLE
[Test] Make test_foreach device-agnostic for OOT backends

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -15,12 +15,12 @@ from torch.testing import make_tensor
 from torch.testing._comparison import default_tolerances
 from torch.testing._internal.common_cuda import _get_torch_cuda_version, SM90OrLater
 from torch.testing._internal.common_device_type import (
+    deviceCountAtLeast,
     dtypes,
     dtypesIfXPU,
     instantiate_device_type_tests,
     largeTensorTest,
     onlyAccelerator,
-    onlyCUDA,
     OpDTypes,
     ops,
     skipXPU,
@@ -41,13 +41,13 @@ from torch.testing._internal.common_methods_invocations import (
 )
 from torch.testing._internal.common_utils import (
     gradcheck,
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
     serialTest,
     skipIfNoNvmath,
     skipIfTorchDynamo,
-    TEST_MULTIACCELERATOR,
     TEST_WITH_ROCM,
     TestCase,
 )
@@ -87,24 +87,36 @@ class ForeachFuncWrapper:
         # Some foreach functions don't have in-place implementations.
         self.is_inplace = False if func is None else func.__name__.endswith("_")
 
-    def __call__(self, inputs, is_cuda, expect_fastpath, **kwargs):
+    def __call__(self, inputs, device_type, expect_fastpath, **kwargs):
         actual = None
         zero_size = kwargs.pop("zero_size", False)
 
         # Skip profiler check for CUDA 12.6, 12.8 as the upgrade makes profiler results flaky
         # https://github.com/pytorch/pytorch/issues/148681. TODO: ADD IT BACK!!!
-        skip_profiler_check = _get_torch_cuda_version() in [(12, 6), (12, 8)]
+        skip_profiler_check = device_type == "cuda" and _get_torch_cuda_version() in [
+            (12, 6),
+            (12, 8),
+        ]
+        if device_type in ("cpu", "meta"):
+            profiler_activity = None
+        elif device_type == torch._C._get_privateuse1_backend_name():
+            profiler_activity = torch.profiler.ProfilerActivity.PrivateUse1
+        else:
+            profiler_activity = getattr(
+                torch.profiler.ProfilerActivity, device_type.upper(), None
+            )
         if (
-            is_cuda
+            profiler_activity is not None
             and not skip_profiler_check
             and torch.autograd.kineto_available()
-            and torch.profiler.ProfilerActivity.CUDA
-            in torch.profiler.supported_activities()
+            and profiler_activity in torch.profiler.supported_activities()
         ):
-            with torch.profiler.profile() as p:
+            with torch.profiler.profile(
+                activities=[torch.profiler.ProfilerActivity.CPU, profiler_activity]
+            ) as p:
                 actual = self.func(*inputs, **kwargs)
                 # synchronize within the profiler context to make sure events happen before exiting
-                torch.cuda.synchronize()
+                torch.accelerator.synchronize(device_type)
             keys = tuple([e.key for e in p.key_averages()])
             mta_kernel_called = any("multi_tensor_apply_kernel" in k for k in keys)
             # Explicitly track MTA launch on ROCm via RECORD_FUNCTION in
@@ -168,9 +180,7 @@ def get_transform_func(num_tensors, dtype, device, is_fastpath):
 # as the pair would go through `multi_tensor_apply_kernel` if inputs are not zero size.
 @unittest.mock.patch.dict(os.environ, {"KINETO_LOG_LEVEL": "5"})
 class TestForeach(TestCase):
-    @property
-    def is_cuda(self):
-        return self.device_type == "cuda"
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _get_funcs(self, op):
         return (
@@ -198,7 +208,7 @@ class TestForeach(TestCase):
             if op.method_variant is not None:
                 wrapped_op(
                     (sample.input, *sample.args),
-                    is_cuda=self.is_cuda,
+                    device_type=self.device_type,
                     expect_fastpath=True,
                     zero_size=True,
                 )
@@ -207,7 +217,7 @@ class TestForeach(TestCase):
                 with InplaceForeachVersionBumpCheck(self, sample.input):
                     inplace_op(
                         (sample.input, *sample.args),
-                        is_cuda=self.is_cuda,
+                        device_type=self.device_type,
                         expect_fastpath=True,
                         zero_size=True,
                     )
@@ -249,7 +259,7 @@ class TestForeach(TestCase):
                 with ctxmgr:
                     actual = func(
                         [foreach_input, *sample.args],
-                        self.is_cuda,
+                        self.device_type,
                         expect_fastpath,
                         **sample.kwargs,
                     )
@@ -285,7 +295,7 @@ class TestForeach(TestCase):
                 if op.is_inplace
                 else nullcontext()
             ):
-                actual = op(inputs, self.is_cuda, is_fastpath)
+                actual = op(inputs, self.device_type, is_fastpath)
         except RuntimeError as e:
             with self.assertRaisesRegex(type(e), re.escape(str(e).splitlines()[0])):
                 if not scalar_self_arg:
@@ -310,7 +320,7 @@ class TestForeach(TestCase):
                     if op.is_inplace
                     else nullcontext()
                 ):
-                    actual = op(inputs, self.is_cuda, is_fastpath, **op_kwargs)
+                    actual = op(inputs, self.device_type, is_fastpath, **op_kwargs)
             except RuntimeError as e:
                 with self.assertRaisesRegex(type(e), re.escape(str(e).splitlines()[0])):
                     ref(ref_inputs, **kwargs)
@@ -368,7 +378,7 @@ class TestForeach(TestCase):
                     ref_tensors, ref_rhs_arg = clone(tensors), clone(rhs_arg)
                     sum(
                         wrapped_op(
-                            [rhs_arg, tensors], is_cuda=False, expect_fastpath=False
+                            [rhs_arg, tensors], device_type="cpu", expect_fastpath=False
                         )
                     ).mean().backward()
                     sum(ref.func(ref_rhs_arg, t) for t in ref_tensors).mean().backward()
@@ -434,15 +444,15 @@ class TestForeach(TestCase):
                         custom_values_err="Expected packed scalar Tensor to be of dimension 1. Got 0 instead.",
                         **kwargs,
                     )
-                    if self.is_cuda:
+                    if self.device_type != "cpu":
                         self._pointwise_test(
                             op_,
                             ref_,
                             inputs,
                             is_fastpath and not disable_fastpath,
                             is_inplace,
-                            scalars=tensor_values.cuda(),
-                            custom_values_err="Expected scalars to be on CPU, got cuda:0 instead.",
+                            scalars=tensor_values.to(device),
+                            custom_values_err=f"Expected scalars to be on CPU, got {device} instead.",
                             **kwargs,
                         )
                     self._pointwise_test(
@@ -539,7 +549,7 @@ class TestForeach(TestCase):
                 if is_inplace
                 else nullcontext()
             ):
-                actual = op(inputs, self.is_cuda, is_fastpath, **kwargs)
+                actual = op(inputs, self.device_type, is_fastpath, **kwargs)
         except RuntimeError as e:
             with self.assertRaisesRegex(type(e), re.escape(str(e).splitlines()[0])):
                 ref(ref_inputs, **kwargs)
@@ -550,7 +560,7 @@ class TestForeach(TestCase):
             kwargs = kwargs.copy()
             kwargs["value"] = scalars
             try:
-                actual = op(inputs, self.is_cuda, is_fastpath, **kwargs)
+                actual = op(inputs, self.device_type, is_fastpath, **kwargs)
             except RuntimeError as e:
                 # Match with error messages from regular non-foreach reference if no
                 # custom error message was provided.
@@ -595,7 +605,9 @@ class TestForeach(TestCase):
         compare_result = tensor + strided_tensor
         foreach_add_check_ = ForeachFuncWrapper(torch.foreach.add)
         out = foreach_add_check_(
-            (left_inputs, right_inputs), is_cuda=self.is_cuda, expect_fastpath=True
+            (left_inputs, right_inputs),
+            device_type=self.device_type,
+            expect_fastpath=True,
         )
         for res in out:
             self.assertEqual(res, compare_result)
@@ -725,7 +737,7 @@ class TestForeach(TestCase):
                 ):
                     foreach_op_([tensor1], [tensor2])
 
-    @unittest.skipIf(not torch.accelerator.is_available(), "CUDA/XPU not found")
+    @onlyAccelerator
     @ops(
         filter(lambda op: op.supports_out, foreach_binary_op_db),
         dtypes=OpDTypes.supported,
@@ -895,7 +907,7 @@ class TestForeach(TestCase):
         tensors[1] = tensors[1].to("cpu")
 
         try:
-            actual = method((tensors,), False, False, zero_size=False)
+            actual = method((tensors,), "cpu", False, zero_size=False)
         except RuntimeError as e:
             with self.assertRaisesRegex(type(e), str(e).splitlines()[0]):
                 ref((tensors,))
@@ -909,7 +921,7 @@ class TestForeach(TestCase):
             self.assertIsNone(ref_inplace.func)
         else:
             try:
-                inplace_method((tensors,), False, False, zero_size=False)
+                inplace_method((tensors,), "cpu", False, zero_size=False)
             except RuntimeError as e:
                 with self.assertRaisesRegex(type(e), str(e).splitlines()[0]):
                     ref_inplace((tensors,))
@@ -1034,7 +1046,11 @@ class TestForeach(TestCase):
         self.assertTrue(scaler * scaler * N > max_value)
         fn, ref_fn, *_ = self._get_funcs(op)
         actual = fn(
-            inputs, is_cuda=self.is_cuda, expect_fastpath=True, ord=ord, zero_size=False
+            inputs,
+            device_type=self.device_type,
+            expect_fastpath=True,
+            ord=ord,
+            zero_size=False,
         )
         expect = ref_fn(inputs, ord=ord)
 
@@ -1105,19 +1121,19 @@ class TestForeach(TestCase):
             if not use_cuda_graph:
                 actual = fn(
                     inputs=[tensorlist],
-                    is_cuda=self.is_cuda,
+                    device_type=self.device_type,
                     expect_fastpath=True,
                     zero_size=False,
                     **kwargs,
                 )
-            elif "cuda" not in device:
-                self.skipTest("only CUDA support CUDAGraph")
+            elif self.device_type != "cuda":
+                self.skipTest("only CUDA supports graph capture")
             else:
                 # When using CUDA graphs and the tensor metadata doesn't fit in
                 # the static kernel argument space, multi_tensor_apply creates
-                # the launch arguments once, uses cudaUserObject_t to tie its
-                # lifetime to the graph, and reuses it throughout replays. This
-                # test verifies multi_tensor_apply's behavior in the scenario.
+                # the launch arguments once, tying their lifetime to the graph
+                # with cudaUserObject_t, and reuses them throughout replays.
+                # This test verifies that scenario.
                 g = torch.cuda.CUDAGraph()
                 with torch.cuda.graph(g):
                     actual = fn.func(tensorlist, **kwargs)
@@ -1126,7 +1142,7 @@ class TestForeach(TestCase):
 
             self.assertEqual(expect, actual, equal_nan=True)
 
-    @onlyCUDA
+    @onlyAccelerator
     @dtypes(torch.complex128)
     def test_foreach_scalarlist_complex_double_many_tensors(self, device, dtype):
         # Prevent regressions for complex double MTA chunking, see #189827
@@ -1177,7 +1193,11 @@ class TestForeach(TestCase):
         self.assertEqual(
             ref(inputs, **kwargs),
             wrapped_op(
-                inputs, self.is_cuda, not disable_fastpath, zero_size=False, **kwargs
+                inputs,
+                self.device_type,
+                not disable_fastpath,
+                zero_size=False,
+                **kwargs,
             ),
         )
 
@@ -1294,7 +1314,7 @@ class TestForeach(TestCase):
         self.assertTrue(all(t.requires_grad for t in sample.input))
         (out1, out2) = func(
             [sample.input, *sample.args],
-            is_cuda=False,
+            device_type="cpu",
             expect_fastpath=False,
             **sample.kwargs,
         )
@@ -1319,7 +1339,7 @@ class TestForeach(TestCase):
 
             out = func(
                 (sample.input, *sample.args),
-                is_cuda=False,
+                device_type="cpu",
                 expect_fastpath=False,
                 **sample.kwargs,
             )
@@ -1359,16 +1379,16 @@ class TestForeach(TestCase):
                     sample.args = new_args
             _test(func, sample)
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, "multi-GPU not supported")
-    def test_tensors_grouping(self):
+    @onlyAccelerator
+    @deviceCountAtLeast(2)
+    def test_tensors_grouping(self, devices):
         num_tensors_per_list = 10
-        num_devices = torch.accelerator.device_count()
         dtypes = (torch.float16, torch.float32, torch.float64)
         list1 = [
             torch.tensor(
                 i,
                 device=torch.device(
-                    self.device_type, random.randint(0, num_devices - 1)
+                    self.device_type, random.randint(0, len(devices) - 1)
                 ),
                 dtype=dtypes[random.randint(0, 2)],
             )
@@ -1439,7 +1459,7 @@ class TestForeach(TestCase):
             foreach_addcmul = ForeachFuncWrapper(torch.foreach.addcmul)
             actual_addcmul = foreach_addcmul(
                 [inputs, t1_args, t2_args],
-                is_cuda=self.is_cuda,
+                device_type=self.device_type,
                 expect_fastpath=True,
                 value=alpha,
             )
@@ -1454,7 +1474,7 @@ class TestForeach(TestCase):
                 foreach_addcdiv = ForeachFuncWrapper(torch.foreach.addcdiv)
                 actual_addcdiv = foreach_addcdiv(
                     [inputs, t1_args, t2_args],
-                    is_cuda=self.is_cuda,
+                    device_type=self.device_type,
                     expect_fastpath=True,
                     value=alpha,
                 )
@@ -1469,7 +1489,7 @@ class TestForeach(TestCase):
             foreach_addcmul_inplace = ForeachFuncWrapper(torch.foreach.addcmul_)
             foreach_addcmul_inplace(
                 [inputs_copy, t1_args, t2_args],
-                is_cuda=self.is_cuda,
+                device_type=self.device_type,
                 expect_fastpath=True,
                 value=alpha,
             )
@@ -1480,7 +1500,7 @@ class TestForeach(TestCase):
                 foreach_addcdiv_inplace = ForeachFuncWrapper(torch.foreach.addcdiv_)
                 foreach_addcdiv_inplace(
                     [inputs_copy, t1_args, t2_args],
-                    is_cuda=self.is_cuda,
+                    device_type=self.device_type,
                     expect_fastpath=True,
                     value=alpha,
                 )
@@ -1643,7 +1663,7 @@ class TestForeach(TestCase):
                 src_tensors = [t.to(src_dtype) for t in self_tensors]
                 out = foreach_copy_(
                     (self_tensors, src_tensors),
-                    is_cuda=self.is_cuda,
+                    device_type=self.device_type,
                     expect_fastpath=True,
                 )
                 ref_out = [
@@ -1674,7 +1694,7 @@ class TestForeach(TestCase):
             uniform_dst = [torch.empty_like(t) for t in uniform_tensors]
             out = foreach_copy_(
                 (uniform_dst, mixed_tensors),
-                is_cuda=self.is_cuda,
+                device_type=self.device_type,
                 expect_fastpath=False,
             )
             out_ref = [
@@ -1687,7 +1707,7 @@ class TestForeach(TestCase):
             mixed_dst = [torch.empty_like(t) for t in mixed_tensors]
             out = foreach_copy_(
                 (mixed_dst, uniform_tensors),
-                is_cuda=self.is_cuda,
+                device_type=self.device_type,
                 expect_fastpath=False,
             )
             out_ref = [
@@ -1711,6 +1731,7 @@ class TestForeach(TestCase):
         ref_out = torch.empty_like(self_tensor).copy_(src_tensor)
         self.assertEqual(self_tensor, ref_out)
 
+    @onlyAccelerator
     @requires_gpu_and_triton
     @ops(filter(lambda op: op.name == "_foreach_copy", foreach_binary_op_db))
     def test_foreach_copy_with_different_device_inputs(self, device, dtype, op):
@@ -1952,10 +1973,9 @@ def check_autodiff_sample(op, sample, dtype, is_inplace):
     return True, ""
 
 
-instantiate_device_type_tests(TestForeach, globals(), allow_xpu=True)
-
-
 class TestForeachPublicAPI(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize("op", foreach_op_db, name_fn=lambda op: op.name)
     @skipIfTorchDynamo("torch.compile does not work with foreach torch function")
     def test_private_compatibility(self, op):
@@ -2141,9 +2161,6 @@ class TestForeachPublicAPI(TestCase):
         self.assertEqual(seen, [op_packet.Tensor])
 
 
-instantiate_parametrized_tests(TestForeachPublicAPI)
-
-
 _FOREACH_MM_SHAPES = [
     # (label, [(M, N, K)] * G)
     ("single_group", [(64, 64, 64)]),
@@ -2158,7 +2175,24 @@ _FOREACH_MM_SHAPES = [
 ]
 
 
+def _foreach_mm_check(test_case, shapes, dtype, device):
+    A = [torch.randn(M, K, dtype=dtype, device=device) for M, _, K in shapes]
+    B = [torch.randn(K, N, dtype=dtype, device=device) for _, N, K in shapes]
+    ref = [torch.mm(a, b) for a, b in zip(A, B)]
+    out = torch._foreach_mm(A, B)
+    test_case.assertEqual(len(out), len(ref))
+    # Grouped GEMM backends may use different accumulation order than
+    # torch.mm, so fp32 needs relaxed tolerances.
+    kwargs = {"atol": 2e-4, "rtol": 2e-4} if dtype == torch.float32 else {}
+    for i, (r, o) in enumerate(zip(ref, out)):
+        test_case.assertEqual(
+            o, r, msg=lambda msg: f"{msg}\nmismatch at group {i}", **kwargs
+        )
+
+
 class TestForeachMM(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _check(self, shapes, dtype, device):
         A = [torch.randn(M, K, dtype=dtype, device=device) for M, _, K in shapes]
         B = [torch.randn(K, N, dtype=dtype, device=device) for _, N, K in shapes]
@@ -2179,17 +2213,7 @@ class TestForeachMM(TestCase):
         name_fn=lambda label, shapes: label,
     )
     def test_foreach_mm_cpu(self, label, shapes):
-        self._check(shapes, torch.float32, "cpu")
-
-    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
-    @parametrize(
-        "label,shapes",
-        _FOREACH_MM_SHAPES,
-        name_fn=lambda label, shapes: label,
-    )
-    @parametrize("dtype", [torch.bfloat16, torch.float32])
-    def test_foreach_mm_cuda(self, label, shapes, dtype):
-        self._check(shapes, dtype, "cuda")
+        _foreach_mm_check(self, shapes, torch.float32, "cpu")
 
     def test_foreach_mm_gradcheck(self):
         G = 4
@@ -2289,9 +2313,25 @@ class TestForeachMM(TestCase):
         ):
             self.assertEqual(impl._foreach_mm_route(A, B), expected)
 
-    @unittest.skipUnless(
-        torch.cuda.is_available() and SM90OrLater, "requires CUDA SM90+"
+
+class TestForeachMMDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    @parametrize(
+        "label,shapes",
+        _FOREACH_MM_SHAPES,
+        name_fn=lambda label, shapes: label,
     )
+    @dtypes(torch.bfloat16, torch.float32)
+    def test_foreach_mm(self, device, label, shapes, dtype):
+        _foreach_mm_check(self, shapes, dtype, device)
+
+
+class TestForeachMMCudaOnly(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @unittest.skipUnless(SM90OrLater, "requires CUDA SM90+")
     @parametrize(
         "label,a_shape,b_shape,a_dtype,b_dtype",
         [
@@ -2305,16 +2345,16 @@ class TestForeachMM(TestCase):
         ],
         name_fn=lambda label, *_: label,
     )
-    def test_foreach_mm_cond_rejects(self, label, a_shape, b_shape, a_dtype, b_dtype):
+    def test_foreach_mm_cond_rejects(
+        self, device, label, a_shape, b_shape, a_dtype, b_dtype
+    ):
         from torch._native.ops.foreach_mm.impl import _foreach_mm_cond
 
-        A = [torch.randn(*a_shape, dtype=a_dtype, device="cuda") for _ in range(2)]
-        B = [torch.randn(*b_shape, dtype=b_dtype, device="cuda") for _ in range(2)]
+        A = [torch.randn(*a_shape, dtype=a_dtype, device=device) for _ in range(2)]
+        B = [torch.randn(*b_shape, dtype=b_dtype, device=device) for _ in range(2)]
         self.assertFalse(_foreach_mm_cond(A, B))
 
-    @unittest.skipUnless(
-        torch.cuda.is_available() and SM90OrLater, "requires CUDA SM90+"
-    )
+    @unittest.skipUnless(SM90OrLater, "requires CUDA SM90+")
     @parametrize(
         "label,shapes",
         [
@@ -2326,15 +2366,15 @@ class TestForeachMM(TestCase):
         ],
         name_fn=lambda label, shapes: label,
     )
-    def test_foreach_mm_fallback_correctness(self, label, shapes):
+    def test_foreach_mm_fallback_correctness(self, device, label, shapes):
         from torch._native.ops.foreach_mm import impl
 
         A = [
-            torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+            torch.randn(M, K, dtype=torch.bfloat16, device=device)
             for (M, N, K) in shapes
         ]
         B = [
-            torch.randn(K, N, dtype=torch.bfloat16, device="cuda")
+            torch.randn(K, N, dtype=torch.bfloat16, device=device)
             for (M, N, K) in shapes
         ]
         ref = [torch.mm(a, b) for a, b in zip(A, B)]
@@ -2346,9 +2386,7 @@ class TestForeachMM(TestCase):
             self.assertEqual(o, r)
 
     @skipIfNoNvmath
-    @unittest.skipUnless(
-        torch.cuda.is_available() and SM90OrLater, "requires CUDA SM90+"
-    )
+    @unittest.skipUnless(SM90OrLater, "requires CUDA SM90+")
     @parametrize(
         "label,shapes",
         [
@@ -2371,7 +2409,7 @@ class TestForeachMM(TestCase):
         ],
         name_fn=lambda label, shapes: label,
     )
-    def test_foreach_mm_nvmath(self, label, shapes):
+    def test_foreach_mm_nvmath(self, device, label, shapes):
         from torch._native.ops.foreach_mm.impl import _check_nvmath_cublaslt
 
         if not _check_nvmath_cublaslt():
@@ -2379,11 +2417,15 @@ class TestForeachMM(TestCase):
                 "cuBLASLt grouped GEMM unavailable (nvmath present but "
                 "cublasLtGroupedMatrixLayoutCreate missing)"
             )
-        self._check(shapes, torch.bfloat16, "cuda")
+        _foreach_mm_check(self, shapes, torch.bfloat16, device)
 
 
+instantiate_device_type_tests(TestForeach, globals(), allow_xpu=True)
 instantiate_parametrized_tests(TestForeachMM)
+instantiate_device_type_tests(TestForeachMMDevice, globals())
+instantiate_device_type_tests(TestForeachMMCudaOnly, globals(), only_for="cuda")
 
+instantiate_parametrized_tests(TestForeachPublicAPI)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -20,7 +20,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     largeTensorTest,
     onlyAccelerator,
-    onlyCUDA,
     OpDTypes,
     ops,
     skipXPU,
@@ -40,6 +39,7 @@ from torch.testing._internal.common_methods_invocations import (
 )
 from torch.testing._internal.common_utils import (
     gradcheck,
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -165,6 +165,8 @@ def get_transform_func(num_tensors, dtype, device, is_fastpath):
 # as the pair would go through `multi_tensor_apply_kernel` if inputs are not zero size.
 @unittest.mock.patch.dict(os.environ, {"KINETO_LOG_LEVEL": "5"})
 class TestForeach(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def is_cuda(self):
         return self.device_type == "cuda"
@@ -1124,7 +1126,7 @@ class TestForeach(TestCase):
 
             self.assertEqual(expect, actual, equal_nan=True)
 
-    @onlyCUDA
+    @onlyAccelerator
     @dtypes(torch.complex128)
     def test_foreach_scalarlist_complex_double_many_tensors(self, device, dtype):
         # Prevent regressions for complex double MTA chunking, see #189827
@@ -1971,20 +1973,23 @@ _FOREACH_MM_SHAPES = [
 ]
 
 
+def _foreach_mm_check(test_case, shapes, dtype, device):
+    A = [torch.randn(M, K, dtype=dtype, device=device) for M, _, K in shapes]
+    B = [torch.randn(K, N, dtype=dtype, device=device) for _, N, K in shapes]
+    ref = [torch.mm(a, b) for a, b in zip(A, B)]
+    out = torch._foreach_mm(A, B)
+    test_case.assertEqual(len(out), len(ref))
+    # Grouped GEMM backends may use different accumulation order than
+    # torch.mm, so fp32 needs relaxed tolerances.
+    kwargs = {"atol": 2e-4, "rtol": 2e-4} if dtype == torch.float32 else {}
+    for i, (r, o) in enumerate(zip(ref, out)):
+        test_case.assertEqual(
+            o, r, msg=lambda msg: f"{msg}\nmismatch at group {i}", **kwargs
+        )
+
+
 class TestForeachMM(TestCase):
-    def _check(self, shapes, dtype, device):
-        A = [torch.randn(M, K, dtype=dtype, device=device) for M, _, K in shapes]
-        B = [torch.randn(K, N, dtype=dtype, device=device) for _, N, K in shapes]
-        ref = [torch.mm(a, b) for a, b in zip(A, B)]
-        out = torch._foreach_mm(A, B)
-        self.assertEqual(len(out), len(ref))
-        # Grouped GEMM backends may use different accumulation order than
-        # torch.mm, so fp32 needs relaxed tolerances.
-        kwargs = {"atol": 2e-4, "rtol": 2e-4} if dtype == torch.float32 else {}
-        for i, (r, o) in enumerate(zip(ref, out)):
-            self.assertEqual(
-                o, r, msg=lambda msg: f"{msg}\nmismatch at group {i}", **kwargs
-            )
+    hw_classification = HardwareClassification.GENERIC
 
     @parametrize(
         "label,shapes",
@@ -1992,17 +1997,7 @@ class TestForeachMM(TestCase):
         name_fn=lambda label, shapes: label,
     )
     def test_foreach_mm_cpu(self, label, shapes):
-        self._check(shapes, torch.float32, "cpu")
-
-    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
-    @parametrize(
-        "label,shapes",
-        _FOREACH_MM_SHAPES,
-        name_fn=lambda label, shapes: label,
-    )
-    @parametrize("dtype", [torch.bfloat16, torch.float32])
-    def test_foreach_mm_cuda(self, label, shapes, dtype):
-        self._check(shapes, dtype, "cuda")
+        _foreach_mm_check(self, shapes, torch.float32, "cpu")
 
     def test_foreach_mm_gradcheck(self):
         G = 4
@@ -2102,9 +2097,21 @@ class TestForeachMM(TestCase):
         ):
             self.assertEqual(impl._foreach_mm_route(A, B), expected)
 
-    @unittest.skipUnless(
-        torch.cuda.is_available() and SM90OrLater, "requires CUDA SM90+"
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires cuda")
+class TestForeachMMOnCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @parametrize(
+        "label,shapes",
+        _FOREACH_MM_SHAPES,
+        name_fn=lambda label, shapes: label,
     )
+    @parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_foreach_mm_cuda(self, device, label, shapes, dtype):
+        _foreach_mm_check(self, shapes, dtype, device)
+
+    @unittest.skipUnless(SM90OrLater, "requires CUDA SM90+")
     @parametrize(
         "label,a_shape,b_shape,a_dtype,b_dtype",
         [
@@ -2125,9 +2132,7 @@ class TestForeachMM(TestCase):
         B = [torch.randn(*b_shape, dtype=b_dtype, device="cuda") for _ in range(2)]
         self.assertFalse(_foreach_mm_cond(A, B))
 
-    @unittest.skipUnless(
-        torch.cuda.is_available() and SM90OrLater, "requires CUDA SM90+"
-    )
+    @unittest.skipUnless(SM90OrLater, "requires CUDA SM90+")
     @parametrize(
         "label,shapes",
         [
@@ -2159,9 +2164,7 @@ class TestForeachMM(TestCase):
             self.assertEqual(o, r)
 
     @skipIfNoNvmath
-    @unittest.skipUnless(
-        torch.cuda.is_available() and SM90OrLater, "requires CUDA SM90+"
-    )
+    @unittest.skipUnless(SM90OrLater, "requires CUDA SM90+")
     @parametrize(
         "label,shapes",
         [
@@ -2196,6 +2199,7 @@ class TestForeachMM(TestCase):
 
 
 instantiate_parametrized_tests(TestForeachMM)
+instantiate_parametrized_tests(TestForeachMMOnCUDA)
 
 
 if __name__ == "__main__":

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -97,26 +97,25 @@ class ForeachFuncWrapper:
             (12, 6),
             (12, 8),
         ]
-        if device_type in ("cpu", "meta"):
-            profiler_activity = None
-        elif device_type == torch._C._get_privateuse1_backend_name():
-            profiler_activity = torch.profiler.ProfilerActivity.PrivateUse1
-        else:
-            profiler_activity = getattr(
-                torch.profiler.ProfilerActivity, device_type.upper(), None
-            )
+        # Only CUDA/ROCm expose a reliable fastpath profiler key
+        # (multi_tensor_apply_kernel, or the _foreach_mta_launch marker on
+        # ROCm), so the check below is CUDA-only; other accelerators skip it.
         if (
-            profiler_activity is not None
+            device_type == "cuda"
             and not skip_profiler_check
             and torch.autograd.kineto_available()
-            and profiler_activity in torch.profiler.supported_activities()
+            and torch.profiler.ProfilerActivity.CUDA
+            in torch.profiler.supported_activities()
         ):
             with torch.profiler.profile(
-                activities=[torch.profiler.ProfilerActivity.CPU, profiler_activity]
+                activities=[
+                    torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA,
+                ]
             ) as p:
                 actual = self.func(*inputs, **kwargs)
                 # synchronize within the profiler context to make sure events happen before exiting
-                torch.accelerator.synchronize(device_type)
+                torch.get_device_module(device_type).synchronize()
             keys = tuple([e.key for e in p.key_averages()])
             mta_kernel_called = any("multi_tensor_apply_kernel" in k for k in keys)
             # Explicitly track MTA launch on ROCm via RECORD_FUNCTION in
@@ -444,7 +443,7 @@ class TestForeach(TestCase):
                         custom_values_err="Expected packed scalar Tensor to be of dimension 1. Got 0 instead.",
                         **kwargs,
                     )
-                    if self.device_type != "cpu":
+                    if self.device_type not in ("cpu", "meta"):
                         self._pointwise_test(
                             op_,
                             ref_,
@@ -2179,7 +2178,7 @@ def _foreach_mm_check(test_case, shapes, dtype, device):
     A = [torch.randn(M, K, dtype=dtype, device=device) for M, _, K in shapes]
     B = [torch.randn(K, N, dtype=dtype, device=device) for _, N, K in shapes]
     ref = [torch.mm(a, b) for a, b in zip(A, B)]
-    out = torch._foreach_mm(A, B)
+    out = torch.foreach.mm(A, B)
     test_case.assertEqual(len(out), len(ref))
     # Grouped GEMM backends may use different accumulation order than
     # torch.mm, so fp32 needs relaxed tolerances.
@@ -2192,20 +2191,6 @@ def _foreach_mm_check(test_case, shapes, dtype, device):
 
 class TestForeachMM(TestCase):
     hw_classification = HardwareClassification.GENERIC
-
-    def _check(self, shapes, dtype, device):
-        A = [torch.randn(M, K, dtype=dtype, device=device) for M, _, K in shapes]
-        B = [torch.randn(K, N, dtype=dtype, device=device) for _, N, K in shapes]
-        ref = [torch.mm(a, b) for a, b in zip(A, B)]
-        out = torch.foreach.mm(A, B)
-        self.assertEqual(len(out), len(ref))
-        # Grouped GEMM backends may use different accumulation order than
-        # torch.mm, so fp32 needs relaxed tolerances.
-        kwargs = {"atol": 2e-4, "rtol": 2e-4} if dtype == torch.float32 else {}
-        for i, (r, o) in enumerate(zip(ref, out)):
-            self.assertEqual(
-                o, r, msg=lambda msg: f"{msg}\nmismatch at group {i}", **kwargs
-            )
 
     @parametrize(
         "label,shapes",
@@ -2422,7 +2407,7 @@ class TestForeachMMCudaOnly(TestCase):
 
 instantiate_device_type_tests(TestForeach, globals(), allow_xpu=True)
 instantiate_parametrized_tests(TestForeachMM)
-instantiate_device_type_tests(TestForeachMMDevice, globals())
+instantiate_device_type_tests(TestForeachMMDevice, globals(), allow_xpu=True)
 instantiate_device_type_tests(TestForeachMMCudaOnly, globals(), only_for="cuda")
 
 instantiate_parametrized_tests(TestForeachPublicAPI)


### PR DESCRIPTION
Decouple TestForeachMM into two classes to separate CPU-only routing tests from CUDA-specific grouped GEMM tests. Add `hw_classification` annotations to all test classes.