### PR TITLE
[Testcase Refactoring]Make sharded embedding tests device-agnostic with hw_classification

### DIFF
--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
@@ -6,11 +6,12 @@ import torch
 import torch.distributed as dist
 from torch.distributed._shard import shard_parameter
 from torch.testing._internal.common_device_type import (
+    Capability,
     instantiate_device_type_tests,
     onlyAccelerator,
+    requires_capabilities,
 )
 from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
@@ -138,7 +139,7 @@ class TestShardedEmbedding(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
+    @requires_capabilities(Capability.distributed.backend)
     @onlyAccelerator
     def test_sharded_embedding_colwise(self, device):
         for spec in generate_chunk_sharding_specs_for_test(1):
@@ -178,7 +179,7 @@ class TestShardedEmbedding(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
+    @requires_capabilities(Capability.distributed.backend)
     @onlyAccelerator
     def test_sharded_embedding_rowwise(self, device):
         for spec in generate_chunk_sharding_specs_for_test(0):

--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
@@ -54,7 +54,7 @@ class TestShardedEmbedding(ShardedTensorTestBase):
             max_norm=max_norm,
             norm_type=norm_type,
             padding_idx=padding_idx,
-        ).to(self.rank)
+        ).to(torch.device(self.device_type, self.rank))
 
         sharded_embedding = torch.nn.Embedding(
             num_embeddings,
@@ -72,7 +72,7 @@ class TestShardedEmbedding(ShardedTensorTestBase):
 
         # Run sharded computation
         torch.manual_seed(self.rank)  # inputs different on each rank
-        inp = torch.randint(0, num_embeddings, tuple(input_size)).to(self.rank)
+        inp = torch.randint(0, num_embeddings, tuple(input_size)).to(torch.device(self.device_type, self.rank))
         sharded_output = sharded_embedding(inp)
 
         # If max_norm is set, we need to ensure that the renorm has been applied across
@@ -122,7 +122,7 @@ class TestShardedEmbedding(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_sharded_embedding_colwise(self):
         for spec in generate_chunk_sharding_specs_for_test(1):
             self._run_sharded_embedding(spec, [5, 4], 17, 12)
@@ -158,7 +158,7 @@ class TestShardedEmbedding(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_sharded_embedding_rowwise(self):
         for spec in generate_chunk_sharding_specs_for_test(0):
             # Test even split.

--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
@@ -5,11 +5,19 @@ import sys
 import torch
 import torch.distributed as dist
 from torch.distributed._shard import shard_parameter
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     TEST_GPU_NUM,
@@ -36,16 +44,22 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestShardedEmbedding(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _run_sharded_embedding(
         self,
         spec,
         input_size,
         num_embeddings,
         embedding_dim,
+        device,
         max_norm=None,
         norm_type=2.0,
         padding_idx=None,
     ):
+        # Extract bare device type to avoid PrivateUse1 indexed-device pitfall
+        device_type = torch.device(device).type
+
         # Use same seed.
         torch.manual_seed(0)
         local_embedding = torch.nn.Embedding(
@@ -54,7 +68,7 @@ class TestShardedEmbedding(ShardedTensorTestBase):
             max_norm=max_norm,
             norm_type=norm_type,
             padding_idx=padding_idx,
-        ).to(torch.device(self.device_type, self.rank))
+        ).to(torch.device(device_type, self.rank))
 
         sharded_embedding = torch.nn.Embedding(
             num_embeddings,
@@ -72,7 +86,9 @@ class TestShardedEmbedding(ShardedTensorTestBase):
 
         # Run sharded computation
         torch.manual_seed(self.rank)  # inputs different on each rank
-        inp = torch.randint(0, num_embeddings, tuple(input_size)).to(torch.device(self.device_type, self.rank))
+        inp = torch.randint(0, num_embeddings, tuple(input_size)).to(
+            torch.device(device_type, self.rank)
+        )
         sharded_output = sharded_embedding(inp)
 
         # If max_norm is set, we need to ensure that the renorm has been applied across
@@ -123,20 +139,22 @@ class TestShardedEmbedding(ShardedTensorTestBase):
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_sharded_embedding_colwise(self):
+    @onlyAccelerator
+    def test_sharded_embedding_colwise(self, device):
         for spec in generate_chunk_sharding_specs_for_test(1):
-            self._run_sharded_embedding(spec, [5, 4], 17, 12)
-            self._run_sharded_embedding(spec, [6, 7, 6], 21, 11)
-            self._run_sharded_embedding(spec, [8, 6, 5, 4], 23, 13)
-            self._run_sharded_embedding(spec, [8, 6, 5, 4, 7], 23, 16)
-            self._run_sharded_embedding(spec, [4], 15, 14)
-            self._run_sharded_embedding(spec, [34], 15, 14, padding_idx=10)
-            self._run_sharded_embedding(spec, [8, 6, 5, 4], 23, 13, padding_idx=12)
+            self._run_sharded_embedding(spec, [5, 4], 17, 12, device)
+            self._run_sharded_embedding(spec, [6, 7, 6], 21, 11, device)
+            self._run_sharded_embedding(spec, [8, 6, 5, 4], 23, 13, device)
+            self._run_sharded_embedding(spec, [8, 6, 5, 4, 7], 23, 16, device)
+            self._run_sharded_embedding(spec, [4], 15, 14, device)
+            self._run_sharded_embedding(spec, [34], 15, 14, device, padding_idx=10)
+            self._run_sharded_embedding(spec, [8, 6, 5, 4], 23, 13, device, padding_idx=12)
             self._run_sharded_embedding(
                 spec,
                 [4, 5, 6],
                 23,
                 13,
+                device,
                 max_norm=2.5,
             )
             self._run_sharded_embedding(
@@ -144,6 +162,7 @@ class TestShardedEmbedding(ShardedTensorTestBase):
                 [12, 7, 16],
                 23,
                 13,
+                device,
                 max_norm=2.5,
             )
             self._run_sharded_embedding(
@@ -151,49 +170,57 @@ class TestShardedEmbedding(ShardedTensorTestBase):
                 [8, 16, 20],
                 12,
                 12,
+                device,
                 max_norm=1.25,
                 norm_type=1.0,
             )
-            self._run_sharded_embedding(spec, [30], 15, 14, max_norm=2.0)
+            self._run_sharded_embedding(spec, [30], 15, 14, device, max_norm=2.0)
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_sharded_embedding_rowwise(self):
+    @onlyAccelerator
+    def test_sharded_embedding_rowwise(self, device):
         for spec in generate_chunk_sharding_specs_for_test(0):
             # Test even split.
-            self._run_sharded_embedding(spec, [5, 12], 16, 22)
-            self._run_sharded_embedding(spec, [5, 4], 32, 12)
-            self._run_sharded_embedding(spec, [6, 7, 6], 64, 11)
+            self._run_sharded_embedding(spec, [5, 12], 16, 22, device)
+            self._run_sharded_embedding(spec, [5, 4], 32, 12, device)
+            self._run_sharded_embedding(spec, [6, 7, 6], 64, 11, device)
             self._run_sharded_embedding(
                 spec,
                 [5, 12],
                 16,
                 22,
+                device,
                 max_norm=2.5,
             )
-            self._run_sharded_embedding(spec, [6, 7, 6], 64, 11, padding_idx=30)
+            self._run_sharded_embedding(spec, [6, 7, 6], 64, 11, device, padding_idx=30)
             self._run_sharded_embedding(
                 spec,
                 [6, 5, 3],
                 26,
                 11,
+                device,
                 max_norm=2.0,
             )
 
             # Test uneven split.
-            self._run_sharded_embedding(spec, [8, 6, 5, 4], 19, 11)
-            self._run_sharded_embedding(spec, [6, 7, 6], 21, 11)
-            self._run_sharded_embedding(spec, [4], 21, 11)
-            self._run_sharded_embedding(spec, [8, 6, 5, 4], 21, 11, padding_idx=10)
+            self._run_sharded_embedding(spec, [8, 6, 5, 4], 19, 11, device)
+            self._run_sharded_embedding(spec, [6, 7, 6], 21, 11, device)
+            self._run_sharded_embedding(spec, [4], 21, 11, device)
+            self._run_sharded_embedding(spec, [8, 6, 5, 4], 21, 11, device, padding_idx=10)
             self._run_sharded_embedding(
                 spec,
                 [6, 5, 8],
                 28,
                 5,
+                device,
                 max_norm=2.0,
             )
-            self._run_sharded_embedding(spec, [4], 14, 11, max_norm=2.5)
+            self._run_sharded_embedding(spec, [4], 14, 11, device, max_norm=2.5)
+
+
+instantiate_device_type_tests(TestShardedEmbedding, globals())
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
@@ -8,7 +8,6 @@ from torch.distributed._shard import shard_parameter
 from torch.testing._internal.common_device_type import (
     Capability,
     instantiate_device_type_tests,
-    onlyAccelerator,
     requires_capabilities,
 )
 from torch.testing._internal.common_distributed import (
@@ -140,7 +139,6 @@ class TestShardedEmbedding(ShardedTensorTestBase):
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_capabilities(Capability.distributed.backend)
-    @onlyAccelerator
     def test_sharded_embedding_colwise(self, device):
         for spec in generate_chunk_sharding_specs_for_test(1):
             self._run_sharded_embedding(spec, [5, 4], 17, 12, device)
@@ -180,7 +178,6 @@ class TestShardedEmbedding(ShardedTensorTestBase):
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_capabilities(Capability.distributed.backend)
-    @onlyAccelerator
     def test_sharded_embedding_rowwise(self, device):
         for spec in generate_chunk_sharding_specs_for_test(0):
             # Test even split.
@@ -221,7 +218,7 @@ class TestShardedEmbedding(ShardedTensorTestBase):
             self._run_sharded_embedding(spec, [4], 14, 11, device, max_norm=2.5)
 
 
-instantiate_device_type_tests(TestShardedEmbedding, globals())
+instantiate_device_type_tests(TestShardedEmbedding, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
@@ -10,9 +10,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     requires_capabilities,
 )
-from torch.testing._internal.common_distributed import (
-    skip_if_lt_x_gpu,
-)
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -147,7 +145,9 @@ class TestShardedEmbedding(ShardedTensorTestBase):
             self._run_sharded_embedding(spec, [8, 6, 5, 4, 7], 23, 16, device)
             self._run_sharded_embedding(spec, [4], 15, 14, device)
             self._run_sharded_embedding(spec, [34], 15, 14, device, padding_idx=10)
-            self._run_sharded_embedding(spec, [8, 6, 5, 4], 23, 13, device, padding_idx=12)
+            self._run_sharded_embedding(
+                spec, [8, 6, 5, 4], 23, 13, device, padding_idx=12
+            )
             self._run_sharded_embedding(
                 spec,
                 [4, 5, 6],
@@ -206,7 +206,9 @@ class TestShardedEmbedding(ShardedTensorTestBase):
             self._run_sharded_embedding(spec, [8, 6, 5, 4], 19, 11, device)
             self._run_sharded_embedding(spec, [6, 7, 6], 21, 11, device)
             self._run_sharded_embedding(spec, [4], 21, 11, device)
-            self._run_sharded_embedding(spec, [8, 6, 5, 4], 21, 11, device, padding_idx=10)
+            self._run_sharded_embedding(
+                spec, [8, 6, 5, 4], 21, 11, device, padding_idx=10
+            )
             self._run_sharded_embedding(
                 spec,
                 [6, 5, 8],
@@ -218,7 +220,9 @@ class TestShardedEmbedding(ShardedTensorTestBase):
             self._run_sharded_embedding(spec, [4], 14, 11, device, max_norm=2.5)
 
 
-instantiate_device_type_tests(TestShardedEmbedding, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestShardedEmbedding, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR refactors `test_embedding.py` to make it fully device-agnostic for out-of-tree backends (e.g., PrivateUse1-based accelerators like NPU). The changes include device placement decoupling, backend admission extension, hardware classification labeling, and device-type instantiation.

## Changes
- Added `hw_classification = HardwareClassification.ACCELERATOR` to `TestShardedEmbedding` class.
  - This label is required for CI pipeline filtering (`--hw-classification ACCELERATOR`).
  - Without this label, the test class will not be executed in CI.
- Added `instantiate_device_type_tests(TestShardedEmbedding, globals(), except_for="cpu", allow_xpu=True)` at file end.
  - This generates device-specific variants (e.g., `TestShardedEmbeddingPRIVATEUSE1` for NPU, `TestShardedEmbeddingXPU` for XPU).
  - `except_for="cpu"` excludes CPU variants — this test requires accelerator-resident tensors (the comm backend is an accelerator backend, e.g., NCCL/HCCL), so CPU variants are meaningless.
  - `allow_xpu=True` preserves the original XPU(xccl) coverage — without this, XPU variants are silently dropped.
  - Works in combination with `spawn` mechanism from `ShardedTensorTestBase` (multi-process distributed testing).
- Added `device` parameter to test methods (`test_sharded_embedding_colwise`, `test_sharded_embedding_rowwise`).
  - Device is injected by `instantiate_device_type_tests` framework.
- Refactored device placement from `.to(self.rank)` to `.to(torch.device(device_type, self.rank))`.
  - Extracts bare device type at method start: `device_type = torch.device(device).type`.
  - Avoids PrivateUse1 indexed-device pitfall (e.g., `"npu:0"` causing RuntimeError on double indexing).
- Replaced `@requires_accelerator_dist_backend(["nccl", "xccl"])` with `@requires_capabilities(Capability.distributed.backend)`.
  - Uses the capability registration mechanism (device-agnostic, upstream-preferred approach).
  - `distributed.backend` is one of the registered capability constants; backends declare support via `_capabilities()`.
  - On backends that do not declare the capability, tests are gracefully skipped (not failed).

## Motivation
The original test had multiple device coupling issues:
1. **Device placement**: `.to(self.rank)` relies on default device context, which may not map correctly on non-CUDA accelerators.
2. **Backend admission**: `@requires_accelerator_dist_backend(["nccl", "xccl"])` excluded PrivateUse1 backends.
3. **Missing CI label**: No `hw_classification` attribute means the test won't be executed in CI pipeline.
4. **Missing instantiation**: No `instantiate_device_type_tests` means no device-specific variants are generated.

This PR addresses all these issues to enable the test to run on out-of-tree backends.

## Depends on

This PR is based on a branch that includes the following upstream PRs (the base commit must include them, otherwise `Capability`/`requires_capabilities` will not be available):

- **#190528**: Fix `init_pg` to dynamically detect backend for `set_device_index`
  - Fixes hccl backend's `set_device_index` omission — without this, all spawned processes default to device 0, causing HCCL "same physical device ID" errors on NPU.
- **#191919**: Add `Capability` class and `requires_capabilities` decorator
  - This PR uses `@requires_capabilities(Capability.distributed.backend)` for device-agnostic backend admission.
- **#193080**: Add `PrivateUse1TestBase._capabilities()` override (depends on #191919)
  - Required for PrivateUse1-based backends (e.g., NPU) to declare the `distributed.backend` capability, so tests run (rather than skip) on those backends.

Without these dependencies, `Capability`/`requires_capabilities` are unavailable (import error) or PrivateUse1 backends will skip the tests (capability not declared).

## Test plan
- `python test/distributed/_shard/sharded_tensor/ops/test_embedding.py` on NPU (PrivateUse1 backend, 4× Ascend 910B3, torch 2.13.0a0+gitfad7424 / torch_npu 2.13.0+git45fbeae / CANN 9.1.0-beta.1, with PR #190528 + #191919 + #193080 applied): 2 PRIVATEUSE1 variants passed, no CPU variants generated → `Ran 2 tests ... OK`
- `python test/distributed/_shard/sharded_tensor/ops/test_embedding.py` on CUDA (A100): 2 CUDA variants passed, no CPU variants generated → `Ran 2 tests ... OK`
- `python test/distributed/_shard/sharded_tensor/ops/test_embedding.py` on CPU: no variants generated (except_for + no accelerator) → `NO TESTS RAN`
- CI: Distributed test suite with `--hw-classification ACCELERATOR` filter
- XPU: `allow_xpu=True` preserves XPU(xccl) variant generation (matching original `@requires_accelerator_dist_backend(["nccl", "xccl"])` coverage)