### PR TITLE
[Inductor] Fix NVGemm pickle test skip predicate

### DIFF
--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -96,7 +96,10 @@ def {{kernel_name}}_precompile(precompile_shapes, precompile_strides=None,
 
 
 class TestNVGemmPickling(TestCase):
-    @skipIfNoCuteDSL
+    @unittest.skipIf(
+        not ensure_nv_universal_gemm_available(),
+        "NVIDIA Universal GEMM (cutlass_api) library not available",
+    )
     def test_scaled_operand_constraints_pickle_round_trip(self):
         import cutlass
         from cutlass.operators import ScaleMode, ScaleSwizzleMode


### PR DESCRIPTION
## Why

- `skipIfNoCuteDSL` checks for cutedsl, but the test imports `cutlass.operators`, so it fails on B200 instead of skipping

## How

- Gate on `ensure_nv_universal_gemm_available()`, matching the sibling NVGemm test

Split out of #191127 per review comments. Part of #191130: NVGemm stays disabled.

This PR was authored with the assistance of Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
