### PR TITLE
[TEST] Add hw_classification to test_experimental_ops.py and test_nvshmem.py

### DIFF
--- a/test/distributed/tensor/test_experimental_ops.py
+++ b/test/distributed/tensor/test_experimental_ops.py
@@ -5,7 +5,8 @@
 import torch
 import torch.distributed as dist
 from torch.distributed.tensor import distribute_tensor, Replicate
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -18,6 +19,8 @@ LR = 0.001
 
 
 class DistOtherOpsTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         # hard code world size to 2
@@ -194,6 +197,8 @@ DistOtherOpsTestWithLocalTensor = create_local_tensor_test_class(
     # Send / recv ops are not supported
     skipped_tests=["test_bernoulli"],
 )
+
+instantiate_device_type_tests(DistOtherOpsTest, globals())
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_experimental_ops.py
+++ b/test/distributed/tensor/test_experimental_ops.py
@@ -5,7 +5,7 @@
 import torch
 import torch.distributed as dist
 from torch.distributed.tensor import distribute_tensor, Replicate
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -18,6 +18,8 @@ LR = 0.001
 
 
 class DistOtherOpsTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         # hard code world size to 2

--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_rocm_multiprocess,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     requires_cuda_p2p_access,
@@ -79,6 +80,8 @@ device_module = torch.get_device_module(device_type)
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -426,6 +429,8 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMSignalNegativeTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
@@ -566,6 +571,8 @@ class NVSHMEMSignalNegativeTest(MultiProcessTestCase):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMAll2AllTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -967,6 +974,8 @@ def dispatch_then_combine(device, align: int, group) -> None:
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class DispatchCombineTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -992,6 +1001,8 @@ class DispatchCombineTest(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class DispatchCombineInSubgroups(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -1024,6 +1035,8 @@ class DispatchCombineInSubgroups(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMTileCommTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `DistOtherOpsTest` (3 test methods, no structural changes)
- `DistOtherOpsTestWithLocalTensor` inherits classification from parent via `create_local_tensor_test_class`
- Added `instantiate_device_type_tests(DistOtherOpsTest, globals())` — no accelerator-only gate on this class, so explicit per-backend variants add real coverage instead of relying on whatever hardware happens to be on the runner

## Test Plan

```
python test/distributed/tensor/test_experimental_ops.py -v
Ran 6 tests in 12.758s — OK (skipped=1)
```

```
python test/distributed/tensor/test_experimental_ops.py -v --hw-classification ACCELERATOR
Ran 6 tests in 12.900s — OK (skipped=1)
```

---

Combined with #190376 into a single PR covering 2 test files:
- test/distributed/tensor/test_experimental_ops.py
- test/distributed/test_nvshmem.py

Each adds hw_classification per the device-agnostic testing initiative.
