### PR TITLE
Fix data errors by enforcing contiguous tensors

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -2616,7 +2616,9 @@ dist.init_process_group(rank=0, world_size=1, store=dist.HashStore())
         dist.all_to_all_single(output_tensor, input_tensor)
 
         input_tensor = input_tensor.t()
-        with self.assertRaisesRegex((ValueError, RuntimeError), "Tensors must be contiguous"):
+        with self.assertRaisesRegex(
+            (ValueError, RuntimeError), "Tensors must be contiguous"
+        ):
             dist.all_to_all_single(output_tensor, input_tensor)
 
 

--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -2616,7 +2616,7 @@ dist.init_process_group(rank=0, world_size=1, store=dist.HashStore())
         dist.all_to_all_single(output_tensor, input_tensor)
 
         input_tensor = input_tensor.t()
-        with self.assertRaisesRegex(ValueError, "Tensors must be contiguous"):
+        with self.assertRaisesRegex((ValueError, RuntimeError), "Tensors must be contiguous"):
             dist.all_to_all_single(output_tensor, input_tensor)
 
 

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -1480,7 +1480,9 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
     def test_allgather_noncontiguous_input(self):
         # Take a column of 2D tensor, such that memory is not dense
         with self.assertRaisesRegex(RuntimeError, "tensor is not contiguous"):
-            self._test_allgather_basics(lambda t: t.expand(2, 2).tril().contiguous()[:, 0])
+            self._test_allgather_basics(
+                lambda t: t.expand(2, 2).tril().contiguous()[:, 0]
+            )
 
     @requires_gloo()
     def test_allgather_inference_mode(self):

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -1345,7 +1345,6 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         with self.assertRaisesRegex(RuntimeError, "tensor is not contiguous"):
             self._test_gather_basics(lambda t: t.expand(2, 2).tril().contiguous()[:, 0])
 
-
     def _test_gather_stress(self, inputs, fn):
         store = c10d.FileStore(self.file_name, self.world_size)
         pg = self._create_process_group_gloo(

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -1342,7 +1342,9 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
     @requires_gloo()
     def test_gather_noncontiguous_input(self):
         # Take a column of 2D tensor, such that memory is not dense
-        self._test_gather_basics(lambda t: t.expand(2, 2).tril().contiguous()[:, 0])
+        with self.assertRaisesRegex(RuntimeError, "tensor is not contiguous"):
+            self._test_gather_basics(lambda t: t.expand(2, 2).tril().contiguous()[:, 0])
+
 
     def _test_gather_stress(self, inputs, fn):
         store = c10d.FileStore(self.file_name, self.world_size)
@@ -1478,7 +1480,8 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
     @requires_gloo()
     def test_allgather_noncontiguous_input(self):
         # Take a column of 2D tensor, such that memory is not dense
-        self._test_allgather_basics(lambda t: t.expand(2, 2).tril().contiguous()[:, 0])
+        with self.assertRaisesRegex(RuntimeError, "tensor is not contiguous"):
+            self._test_allgather_basics(lambda t: t.expand(2, 2).tril().contiguous()[:, 0])
 
     @requires_gloo()
     def test_allgather_inference_mode(self):

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -982,6 +982,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::broadcast(
   assertRootTensor(
       invalidArgument, opts.rootTensor, static_cast<int64_t>(inputs.size()));
   assertDense(invalidArgument, inputs);
+  assertContiguous(invalidArgument, inputs);
   assertTypeAndSizesMatch(invalidArgument, inputs);
 
   const auto& device = inputs[0].device();
@@ -1339,6 +1340,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::reduce(
       invalidArgument, opts.rootTensor, static_cast<int64_t>(inputs.size()));
   assertSingleElement(invalidArgument, inputs);
   assertDense(invalidArgument, inputs);
+  assertContiguous(invalidArgument, inputs);
 
   const auto& device = inputs[0].device();
   switch (device.type()) {
@@ -1630,6 +1632,8 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::allgather(
   }
 
   assertDense(invalidArgument, inputs);
+  assertContiguous(invalidArgument, inputs);
+  assertContiguous(invalidArgument, outputs[0]);
 
   // Expect all input/output tensors to have the same type and sizes
   const auto& options = inputs[0].options();
@@ -1785,6 +1789,8 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::allgather_coalesced(
   }
 
   assertDense(invalidArgument, input_list);
+  assertContiguous(invalidArgument, input_list);
+  assertContiguous(invalidArgument, output_lists[0]);
 
   auto tag = nextTag();
   auto context = getContext(tag);
@@ -1975,10 +1981,10 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::gather(
   assertRootRank(invalidArgument, opts.rootRank, size_);
   assertSingleElementInput(invalidArgument, inputs);
   assertDense(invalidArgument, inputs);
-
+  assertContiguous(invalidArgument, inputs);
   if (getRank() == opts.rootRank) {
     assertGatherOutputTensorList(invalidArgument, outputs, getSize());
-
+    assertContiguous(invalidArgument, outputs[0]);
     const auto& options = inputs[0].options();
     const auto& sizes = inputs[0].sizes();
     assertTypeAndSizesMatch(invalidArgument, outputs[0], options, sizes);
@@ -2175,9 +2181,11 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::scatter(
   assertRootRank(invalidArgument, opts.rootRank, size_);
   assertSingleElementOutput(invalidArgument, outputs);
   assertDense(invalidArgument, outputs);
+  assertContiguous(invalidArgument, outputs);
 
   if (getRank() == opts.rootRank) {
     assertScatterInputTensorList(invalidArgument, inputs, getSize());
+    assertContiguous(invalidArgument, inputs[0]);
     const auto& options = outputs[0].options();
     const auto& sizes = outputs[0].sizes();
     assertTypeAndSizesMatch(invalidArgument, inputs[0], options, sizes);
@@ -2428,7 +2436,9 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::all_to_all_single(
       outputTensor.device() == inputTensor.device(),
       "output tensor and input tensor must be on the same type of device");
   assertDense(invalidArgument, {outputTensor});
+  assertContiguous(invalidArgument, {outputTensor});
   assertDense(invalidArgument, {inputTensor});
+  assertContiguous(invalidArgument, {inputTensor});
 
   if (!inputTensor.is_contiguous(inputTensor.suggest_memory_format())) {
     C10_THROW_ERROR(ValueError, "Tensors must be contiguous");
@@ -2621,7 +2631,9 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::alltoall(
       invalidArgument, outputTensors.size(), inputTensors.size(), getSize());
 
   assertDense(invalidArgument, inputTensors);
+  assertContiguous(invalidArgument, inputTensors);
   assertDense(invalidArgument, outputTensors);
+  assertContiguous(invalidArgument, outputTensors);
 
   // Check that all tensors are on the same device
   assertSameDevice(invalidArgument, inputTensors);

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -451,13 +451,12 @@ inline void assertDense(
 inline void assertContiguous(
     const std::function<void(const std::string&)>& fn,
     const at::ArrayRef<at::Tensor> tensors) {
-    for (const auto& tensor : tensors) {
-      if (!tensor.is_contiguous(tensor.suggest_memory_format())) {
-        fn("tensor is not contiguous");
+  for (const auto& tensor : tensors) {
+    if (!tensor.is_contiguous(tensor.suggest_memory_format())) {
+      fn("tensor is not contiguous");
     }
   }
 }
-
 
 inline void assertCPU(
     const std::function<void(const std::string&)>& fn,

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -448,6 +448,17 @@ inline void assertDense(
   }
 }
 
+inline void assertContiguous(
+    const std::function<void(const std::string&)>& fn,
+    const at::ArrayRef<at::Tensor> tensors) {
+    for (const auto& tensor : tensors) {
+      if (!tensor.is_contiguous(tensor.suggest_memory_format())) {
+        fn("tensor is not contiguous");
+    }
+  }
+}
+
+
 inline void assertCPU(
     const std::function<void(const std::string&)>& fn,
     const at::ArrayRef<at::Tensor> tensors) {


### PR DESCRIPTION
Fixes #129337

### Description
Fix issue where the `c10d` Gloo backend's operations attempts to process non-contiguous tensors, which leads to incorrect data being gathered or silent memory corruption.
The fix was done by adding a check which ensures the tensors are contiguous after every location where `assertdense` was used as it stores data in standard memory and can be non-contiguous which can cause silent failures.