### PR TITLE
[TEST] Add hw_classification to DTensor init test classes

### DIFF
--- a/test/distributed/tensor/test_init.py
+++ b/test/distributed/tensor/test_init.py
@@ -12,7 +12,7 @@ from torch.distributed.tensor import (
     Shard,
     zeros,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -21,6 +21,8 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 
 class DTensorInitOpsTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _run_init_op(self, init_op, *args, **kwargs):
         device_mesh = self.build_device_mesh()
         shard_spec = [Shard(0)]
@@ -56,6 +58,8 @@ class DTensorInitOpsTest(DTensorTestBase):
 
 
 class DTensorConstructorTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 4


### PR DESCRIPTION
## Summary
Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `DTensorInitOpsTest` — 2 test methods, all use `self.device_type` via `DTensorTestBase`
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `DTensorConstructorTest` — 8 test methods, all use `self.device_type` via `DTensorTestBase`

Both classes test DTensor init/constructor operations that work identically across accelerator backends with no hardcoded device references.

## Test Plan

```
python test/distributed/tensor/test_init.py -v --hw-classification ACCELERATOR
Ran 18 tests in 36.175s — OK (skipped=1)
```

cc: @vishalgoyal316 