### PR TITLE
[BE][CUDA] Migrate deprecated `thrust::` function objects to `cuda::std::`

### DIFF
--- a/aten/src/ATen/native/cuda/SortImpl.cu
+++ b/aten/src/ATen/native/cuda/SortImpl.cu
@@ -2,7 +2,12 @@
 #include <ATen/core/Tensor.h>
 #include <thrust/execution_policy.h>
 #include <thrust/sort.h>
+#if defined(USE_ROCM)
+namespace TORCH_CUDA_STD = ::thrust;
+#else
 #include <cuda/std/functional>
+namespace TORCH_CUDA_STD = ::cuda::std;
+#endif
 
 namespace at::native {
 
@@ -18,7 +23,7 @@ std::vector<int64_t> infer_dense_strides_dim_last(const Tensor & self, int64_t d
   }
   thrust::stable_sort_by_key(
     thrust::host, strides.data(), strides.data() + ndim, original_dim.data(),
-    ::cuda::std::greater<int64_t>()
+    TORCH_CUDA_STD::greater<int64_t>()
   );
   // generate contiguous strides on permuted dims
   std::vector<int64_t> new_strides(ndim);

--- a/aten/src/ATen/native/cuda/SortImpl.cu
+++ b/aten/src/ATen/native/cuda/SortImpl.cu
@@ -18,7 +18,7 @@ std::vector<int64_t> infer_dense_strides_dim_last(const Tensor & self, int64_t d
   }
   thrust::stable_sort_by_key(
     thrust::host, strides.data(), strides.data() + ndim, original_dim.data(),
-    cuda::std::greater<int64_t>()
+    ::cuda::std::greater<int64_t>()
   );
   // generate contiguous strides on permuted dims
   std::vector<int64_t> new_strides(ndim);

--- a/aten/src/ATen/native/cuda/SortImpl.cu
+++ b/aten/src/ATen/native/cuda/SortImpl.cu
@@ -2,6 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <thrust/execution_policy.h>
 #include <thrust/sort.h>
+#include <cuda/std/functional>
 
 namespace at::native {
 
@@ -17,7 +18,7 @@ std::vector<int64_t> infer_dense_strides_dim_last(const Tensor & self, int64_t d
   }
   thrust::stable_sort_by_key(
     thrust::host, strides.data(), strides.data() + ndim, original_dim.data(),
-    thrust::greater<int64_t>()
+    cuda::std::greater<int64_t>()
   );
   // generate contiguous strides on permuted dims
   std::vector<int64_t> new_strides(ndim);

--- a/aten/src/ATen/native/cuda/TensorModeKernel.cu
+++ b/aten/src/ATen/native/cuda/TensorModeKernel.cu
@@ -51,8 +51,8 @@ struct ModeImpl {
                     iter_end - 1,
                     iter_begin + 1,
                     0,
-                    cuda::std::plus<int>(),
-                    cuda::std::not_equal_to<scalar_t>());
+                    ::cuda::std::plus<int>(),
+                    ::cuda::std::not_equal_to<scalar_t>());
 
     // Count frequency of each element
     auto keys = c10::DeviceArray<scalar_t>(*cuda_allocator, unique);

--- a/aten/src/ATen/native/cuda/TensorModeKernel.cu
+++ b/aten/src/ATen/native/cuda/TensorModeKernel.cu
@@ -17,6 +17,7 @@
 #include <thrust/inner_product.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
+#include <cuda/std/functional>
 
 namespace at::native {
 
@@ -50,8 +51,8 @@ struct ModeImpl {
                     iter_end - 1,
                     iter_begin + 1,
                     0,
-                    thrust::plus<int>(),
-                    thrust::not_equal_to<scalar_t>());
+                    cuda::std::plus<int>(),
+                    cuda::std::not_equal_to<scalar_t>());
 
     // Count frequency of each element
     auto keys = c10::DeviceArray<scalar_t>(*cuda_allocator, unique);

--- a/aten/src/ATen/native/cuda/TensorModeKernel.cu
+++ b/aten/src/ATen/native/cuda/TensorModeKernel.cu
@@ -17,7 +17,12 @@
 #include <thrust/inner_product.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
+#if defined(USE_ROCM)
+namespace TORCH_CUDA_STD = ::thrust;
+#else
 #include <cuda/std/functional>
+namespace TORCH_CUDA_STD = ::cuda::std;
+#endif
 
 namespace at::native {
 
@@ -51,8 +56,8 @@ struct ModeImpl {
                     iter_end - 1,
                     iter_begin + 1,
                     0,
-                    ::cuda::std::plus<int>(),
-                    ::cuda::std::not_equal_to<scalar_t>());
+                    TORCH_CUDA_STD::plus<int>(),
+                    TORCH_CUDA_STD::not_equal_to<scalar_t>());
 
     // Count frequency of each element
     auto keys = c10::DeviceArray<scalar_t>(*cuda_allocator, unique);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #191152
* __->__ #191196

I vaguely remember someone tried doing it, but may be things can changed and it can finally be landed, though `cuda::std::` exists since 10.2

Have to keep ugly namespace workaround for ROCM

Authored with the assistance of an AI coding assistant.