### PR TITLE
[2/N][Test] Refactor `TestFPGMPruner` in `torch_ao_sparsity.py`

### DIFF
--- a/test/ao/sparsity/test_structured_sparsifier.py
+++ b/test/ao/sparsity/test_structured_sparsifier.py
@@ -12,7 +12,7 @@ from torch.ao.pruning._experimental.pruner import (
     SaliencyPruner,
 )
 from torch.nn.utils import parametrize
-from torch.testing._internal.common_device_type import dtypes, onlyCPU
+from torch.testing._internal.common_device_type import dtypes
 from torch.testing._internal.common_pruning import (
     Conv2dActivation,
     Conv2dBias,
@@ -995,49 +995,49 @@ class TestBaseStructuredSparsifierDevice(TestCase):
             )
 
 
-class TestFPGMPruner(TestCase):
+class SimpleConvFPGM(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv2d1 = nn.Conv2d(
+            in_channels=1, out_channels=3, kernel_size=3, padding=1, bias=False
+        )
+        # Manually set the filter weights for demonstration purposes
+        """
+        Three filters' weight are manually set to values 3.0, 2.0, and 0.1.
+        Different from the norm-based decision that prunes filter with value 0.1,
+        FPGM will prune the one with value 2.0.
+        """
+        weights = torch.tensor([3.0, 2.0, 0.1])  # Weight weights for each filter
+        weights = weights[:, None, None, None]  # broadcasting
+        self.conv2d1.weight.data.copy_(torch.ones(self.conv2d1.weight.shape) * weights)
+
+        # Second Convolutional Layer
+        self.conv2d2 = nn.Conv2d(
+            in_channels=3, out_channels=4, kernel_size=3, padding=1, bias=False
+        )
+        weights = torch.tensor([6.0, 7.0, 0.4, 0.5])
+        weights = weights[:, None, None, None]
+        self.conv2d2.weight.data.copy_(torch.ones(self.conv2d2.weight.shape) * weights)
+
+    def forward(self, x):
+        x = self.conv2d1(x)
+        x = self.conv2d2(x)
+        return x
+
+
+class TestFPGMPrunerCPU(TestCase):
     """
     Test case for the implementation of paper:
     `Filter Pruning via Geometric Median for Deep Convolutional Neural Networks Acceleration <https://arxiv.org/abs/1811.00250>`_.
     """
 
-    class SimpleConvFPGM(nn.Module):
-        def __init__(self) -> None:
-            super().__init__()
-            self.conv2d1 = nn.Conv2d(
-                in_channels=1, out_channels=3, kernel_size=3, padding=1, bias=False
-            )
-            # Manually set the filter weights for demonstration purposes
-            """
-            Three filters' weight are manually set to values 3.0, 2.0, and 0.1.
-            Different from the norm-based decision that prunes filter with value 0.1,
-            FPGM will prune the one with value 2.0.
-            """
-            weights = torch.tensor([3.0, 2.0, 0.1])  # Weight weights for each filter
-            weights = weights[:, None, None, None]  # broadcasting
-            self.conv2d1.weight.data.copy_(
-                torch.ones(self.conv2d1.weight.shape) * weights
-            )
+    hw_classification = HardwareClassification.CPU
 
-            # Second Convolutional Layer
-            self.conv2d2 = nn.Conv2d(
-                in_channels=3, out_channels=4, kernel_size=3, padding=1, bias=False
-            )
-            weights = torch.tensor([6.0, 7.0, 0.4, 0.5])
-            weights = weights[:, None, None, None]
-            self.conv2d2.weight.data.copy_(
-                torch.ones(self.conv2d2.weight.shape) * weights
-            )
-
-        def forward(self, x):
-            x = self.conv2d1(x)
-            x = self.conv2d2(x)
-            return x
-
-    @onlyCPU
-    def test_compute_distance(self, device):
+    def test_compute_distance(self):
         """Test the distance computation function"""
-        model = TestFPGMPruner.SimpleConvFPGM().to(device)
+        device = "cpu"
+
+        model = SimpleConvFPGM().to(device)
         pruner = FPGMPruner(0.3)
         dist_conv1 = pruner._compute_distance(model.conv2d1.weight)
 
@@ -1098,10 +1098,19 @@ class TestFPGMPruner(TestCase):
         ).all():
             raise AssertionError("Distance computation does not match expected")
 
+
+class TestFPGMPrunerDevice(TestCase):
+    """
+    Test case for the implementation of paper:
+    `Filter Pruning via Geometric Median for Deep Convolutional Neural Networks Acceleration <https://arxiv.org/abs/1811.00250>`_.
+    """
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _test_update_mask_on_single_layer(self, expected_conv1, device):
         """Test that pruning is conducted based on the pair-wise distance measurement instead of absolute norm value"""
         # test pruning with one layer of conv2d
-        model = TestFPGMPruner.SimpleConvFPGM().to(device)
+        model = SimpleConvFPGM().to(device)
         x = torch.ones((1, 1, 32, 32), device=device)
         pruner = FPGMPruner(0.3)
         config = [{"tensor_fqn": "conv2d1.weight"}]
@@ -1140,7 +1149,7 @@ class TestFPGMPruner(TestCase):
         self, expected_conv1, expected_conv2, device
     ):
         # the second setting
-        model = TestFPGMPruner.SimpleConvFPGM().to(device)
+        model = SimpleConvFPGM().to(device)
         x = torch.ones((1, 1, 32, 32), device=device)
         pruner = FPGMPruner(0.3)
         config = [

--- a/test/ao/sparsity/test_structured_sparsifier.py
+++ b/test/ao/sparsity/test_structured_sparsifier.py
@@ -30,6 +30,7 @@ from torch.testing._internal.common_pruning import (
     SimpleLinear,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     raise_on_run_directly,
     skipIfTorchDynamo,
     TestCase,
@@ -164,7 +165,205 @@ class TestSaliencyPruner(TestCase):
                 raise AssertionError("Expected and pruned tensors are not close")
 
 
-class TestBaseStructuredSparsifier(TestCase):
+class TestBaseStructuredSparsifierCPU(TestCase):
+    hw_classification = HardwareClassification.CPU
+
+    def test_prune_lstm_linear_multiple_layer(self):
+        """
+        Test fusion support for LSTM(multi-layer) -> Linear
+        """
+        device = "cpu"
+
+        model = LSTMLinearModel(
+            input_dim=8,
+            hidden_dim=8,
+            output_dim=8,
+            num_layers=2,
+        ).to(device)
+
+        config = [
+            {"tensor_fqn": "lstm.weight_ih_l0"},
+            {"tensor_fqn": "lstm.weight_hh_l0"},
+            {"tensor_fqn": "lstm.weight_ih_l1"},
+            {"tensor_fqn": "lstm.weight_hh_l1"},
+        ]
+
+        lstm_input = torch.ones((1, 8), device=device)
+        fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
+        fx_pruner.prepare(model, config)
+
+        fx_pruner.enable_mask_update = True
+        fx_pruner.step()
+
+        model.eval()
+        _, _ = model(lstm_input)
+        pruned_model = fx_pruner.prune()
+        pruned_model.eval()
+        _, _ = pruned_model(lstm_input)
+
+        expected_params = dict(model.named_parameters())
+        for name, param in model.named_parameters():
+            if name not in expected_params:
+                raise AssertionError(f"Expected parameter '{name}' in expected_params")
+            # We cannot compare y_expected == y_pruned, as the 0 elements mess up the numerics
+            # Instead we check that the weights of the new LSTM are a subset of the weights of
+            # the old LSTM
+            if not rows_are_subset(param, expected_params[name]):
+                raise AssertionError(f"Parameter '{name}' rows are not a subset")
+            del expected_params[name]
+
+        # assert we haven't deleted any keys
+        if len(expected_params) != 0:
+            raise AssertionError(
+                f"Expected all params deleted, but {len(expected_params)} remain"
+            )
+
+    def test_prune_lstm_linear_single_layer(self):
+        """
+        Test fusion support for LSTM (single-layer) -> Linear
+        """
+        device = "cpu"
+
+        model = LSTMLinearModel(
+            input_dim=8,
+            hidden_dim=8,
+            output_dim=8,
+            num_layers=1,
+        ).to(device)
+
+        config = [
+            {"tensor_fqn": "lstm.weight_ih_l0"},
+            {"tensor_fqn": "lstm.weight_hh_l0"},
+        ]
+
+        lstm_input = torch.ones((1, 8), device=device)
+        fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
+        fx_pruner.prepare(model, config)
+        fx_pruner.enable_mask_update = True
+        fx_pruner.step()
+        model.eval()
+
+        out_expected, lstm_out_expected = model(lstm_input)
+        pruned_model = fx_pruner.prune()
+        pruned_model.eval()
+        out_pruned, lstm_out_pruned = pruned_model(lstm_input)
+        _, c = lstm_out_expected.size()
+
+        # We cannot check that y_expected == y_pruned as usual because
+        # zeros vs. missing elements yield different numerical results.
+        # Instead that we check that the pruned elements are the first half of the results
+        # since we are using a BottomHalfLSTMPruner
+        if not torch.isclose(
+            lstm_out_expected[:, : c // 2], lstm_out_pruned, rtol=1e-05, atol=1e-07
+        ).all():
+            raise AssertionError("LSTM outputs are not close")
+        # also check that output of linear is the same shape, this means we've resized
+        # linear columns correctly.
+        if out_expected.shape != out_pruned.shape:
+            raise AssertionError(
+                f"Expected shape {out_expected.shape}, got {out_pruned.shape}"
+            )
+
+    def test_prune_lstm_layernorm_linear_multiple_layer(self):
+        """
+        Test fusion support for LSTM(multi-layer) -> Linear
+        """
+        device = "cpu"
+
+        model = LSTMLayerNormLinearModel(
+            input_dim=8,
+            output_dim=8,
+            hidden_dim=8,
+            num_layers=2,
+        ).to(device)
+
+        config = [
+            {"tensor_fqn": "lstm.weight_ih_l0"},
+            {"tensor_fqn": "lstm.weight_hh_l0"},
+            {"tensor_fqn": "lstm.weight_ih_l1"},
+            {"tensor_fqn": "lstm.weight_hh_l1"},
+        ]
+
+        lstm_input = torch.ones((1, 8), device=device)
+        fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
+        fx_pruner.prepare(model, config)
+
+        fx_pruner.enable_mask_update = True
+        fx_pruner.step()
+
+        model.eval()
+        _, _ = model(lstm_input)
+        pruned_model = fx_pruner.prune()
+        pruned_model.eval()
+        _, _ = pruned_model(lstm_input)
+
+        expected_params = dict(model.named_parameters())
+        for name, param in model.named_parameters():
+            if name not in expected_params:
+                raise AssertionError(f"Expected parameter '{name}' in expected_params")
+            # We cannot compare y_expected == y_pruned, as the 0 elements mess up the numerics
+            # Instead we check that the weights of the new LSTM are a subset of the weights of
+            # the old LSTM
+            if not rows_are_subset(param, expected_params[name]):
+                raise AssertionError(f"Parameter '{name}' rows are not a subset")
+            del expected_params[name]
+
+        # assert we haven't deleted any keys
+        if len(expected_params) != 0:
+            raise AssertionError(
+                f"Expected all params deleted, but {len(expected_params)} remain"
+            )
+
+    def test_prune_lstm_layernorm_linear_single_layer(self):
+        """
+        Test fusion support for LSTM (single-layer) -> Linear
+        """
+        device = "cpu"
+
+        model = LSTMLinearModel(
+            input_dim=8,
+            hidden_dim=8,
+            output_dim=8,
+            num_layers=1,
+        ).to(device)
+
+        config = [
+            {"tensor_fqn": "lstm.weight_ih_l0"},
+            {"tensor_fqn": "lstm.weight_hh_l0"},
+        ]
+
+        lstm_input = torch.ones((1, 8), device=device)
+        fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
+        fx_pruner.prepare(model, config)
+        fx_pruner.enable_mask_update = True
+        fx_pruner.step()
+        model.eval()
+
+        out_expected, lstm_out_expected = model(lstm_input)
+        pruned_model = fx_pruner.prune()
+        pruned_model.eval()
+        out_pruned, lstm_out_pruned = pruned_model(lstm_input)
+        _, c = lstm_out_expected.size()
+
+        # We cannot check that y_expected == y_pruned as usual because
+        # zeros vs. missing elements yield different numerical results.
+        # Instead that we check that the pruned elements are the first half of the results
+        # since we are using a BottomHalfLSTMPruner
+        if not torch.isclose(
+            lstm_out_expected[:, : c // 2], lstm_out_pruned, rtol=1e-05, atol=1e-07
+        ).all():
+            raise AssertionError("LSTM outputs are not close")
+        # also check that output of linear is the same shape, this means we've resized
+        # linear columns correctly.
+        if out_expected.shape != out_pruned.shape:
+            raise AssertionError(
+                f"Expected shape {out_expected.shape}, got {out_pruned.shape}"
+            )
+
+
+class TestBaseStructuredSparsifierDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _check_pruner_prepared(self, model, pruner, device):
         for config in pruner.groups:
             module = config["module"]
@@ -793,194 +992,6 @@ class TestBaseStructuredSparsifier(TestCase):
                 shape,
                 torch.device(device),
                 also_prune_bias,
-            )
-
-    @onlyCPU
-    def test_prune_lstm_linear_multiple_layer(self, device):
-        """
-        Test fusion support for LSTM(multi-layer) -> Linear
-        """
-        model = LSTMLinearModel(
-            input_dim=8,
-            hidden_dim=8,
-            output_dim=8,
-            num_layers=2,
-        ).to(device)
-
-        config = [
-            {"tensor_fqn": "lstm.weight_ih_l0"},
-            {"tensor_fqn": "lstm.weight_hh_l0"},
-            {"tensor_fqn": "lstm.weight_ih_l1"},
-            {"tensor_fqn": "lstm.weight_hh_l1"},
-        ]
-
-        lstm_input = torch.ones((1, 8), device=device)
-        fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
-        fx_pruner.prepare(model, config)
-
-        fx_pruner.enable_mask_update = True
-        fx_pruner.step()
-
-        model.eval()
-        _, _ = model(lstm_input)
-        pruned_model = fx_pruner.prune()
-        pruned_model.eval()
-        _, _ = pruned_model(lstm_input)
-
-        expected_params = dict(model.named_parameters())
-        for name, param in model.named_parameters():
-            if name not in expected_params:
-                raise AssertionError(f"Expected parameter '{name}' in expected_params")
-            # We cannot compare y_expected == y_pruned, as the 0 elements mess up the numerics
-            # Instead we check that the weights of the new LSTM are a subset of the weights of
-            # the old LSTM
-            if not rows_are_subset(param, expected_params[name]):
-                raise AssertionError(f"Parameter '{name}' rows are not a subset")
-            del expected_params[name]
-
-        # assert we haven't deleted any keys
-        if len(expected_params) != 0:
-            raise AssertionError(
-                f"Expected all params deleted, but {len(expected_params)} remain"
-            )
-
-    @onlyCPU
-    def test_prune_lstm_linear_single_layer(self, device):
-        """
-        Test fusion support for LSTM (single-layer) -> Linear
-        """
-        model = LSTMLinearModel(
-            input_dim=8,
-            hidden_dim=8,
-            output_dim=8,
-            num_layers=1,
-        ).to(device)
-
-        config = [
-            {"tensor_fqn": "lstm.weight_ih_l0"},
-            {"tensor_fqn": "lstm.weight_hh_l0"},
-        ]
-
-        lstm_input = torch.ones((1, 8), device=device)
-        fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
-        fx_pruner.prepare(model, config)
-        fx_pruner.enable_mask_update = True
-        fx_pruner.step()
-        model.eval()
-
-        out_expected, lstm_out_expected = model(lstm_input)
-        pruned_model = fx_pruner.prune()
-        pruned_model.eval()
-        out_pruned, lstm_out_pruned = pruned_model(lstm_input)
-        _, c = lstm_out_expected.size()
-
-        # We cannot check that y_expected == y_pruned as usual because
-        # zeros vs. missing elements yield different numerical results.
-        # Instead that we check that the pruned elements are the first half of the results
-        # since we are using a BottomHalfLSTMPruner
-        if not torch.isclose(
-            lstm_out_expected[:, : c // 2], lstm_out_pruned, rtol=1e-05, atol=1e-07
-        ).all():
-            raise AssertionError("LSTM outputs are not close")
-        # also check that output of linear is the same shape, this means we've resized
-        # linear columns correctly.
-        if out_expected.shape != out_pruned.shape:
-            raise AssertionError(
-                f"Expected shape {out_expected.shape}, got {out_pruned.shape}"
-            )
-
-    @onlyCPU
-    def test_prune_lstm_layernorm_linear_multiple_layer(self, device):
-        """
-        Test fusion support for LSTM(multi-layer) -> Linear
-        """
-        model = LSTMLayerNormLinearModel(
-            input_dim=8,
-            output_dim=8,
-            hidden_dim=8,
-            num_layers=2,
-        ).to(device)
-
-        config = [
-            {"tensor_fqn": "lstm.weight_ih_l0"},
-            {"tensor_fqn": "lstm.weight_hh_l0"},
-            {"tensor_fqn": "lstm.weight_ih_l1"},
-            {"tensor_fqn": "lstm.weight_hh_l1"},
-        ]
-
-        lstm_input = torch.ones((1, 8), device=device)
-        fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
-        fx_pruner.prepare(model, config)
-
-        fx_pruner.enable_mask_update = True
-        fx_pruner.step()
-
-        model.eval()
-        _, _ = model(lstm_input)
-        pruned_model = fx_pruner.prune()
-        pruned_model.eval()
-        _, _ = pruned_model(lstm_input)
-
-        expected_params = dict(model.named_parameters())
-        for name, param in model.named_parameters():
-            if name not in expected_params:
-                raise AssertionError(f"Expected parameter '{name}' in expected_params")
-            # We cannot compare y_expected == y_pruned, as the 0 elements mess up the numerics
-            # Instead we check that the weights of the new LSTM are a subset of the weights of
-            # the old LSTM
-            if not rows_are_subset(param, expected_params[name]):
-                raise AssertionError(f"Parameter '{name}' rows are not a subset")
-            del expected_params[name]
-
-        # assert we haven't deleted any keys
-        if len(expected_params) != 0:
-            raise AssertionError(
-                f"Expected all params deleted, but {len(expected_params)} remain"
-            )
-
-    @onlyCPU
-    def test_prune_lstm_layernorm_linear_single_layer(self, device):
-        """
-        Test fusion support for LSTM (single-layer) -> Linear
-        """
-        model = LSTMLinearModel(
-            input_dim=8,
-            hidden_dim=8,
-            output_dim=8,
-            num_layers=1,
-        ).to(device)
-
-        config = [
-            {"tensor_fqn": "lstm.weight_ih_l0"},
-            {"tensor_fqn": "lstm.weight_hh_l0"},
-        ]
-
-        lstm_input = torch.ones((1, 8), device=device)
-        fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
-        fx_pruner.prepare(model, config)
-        fx_pruner.enable_mask_update = True
-        fx_pruner.step()
-        model.eval()
-
-        out_expected, lstm_out_expected = model(lstm_input)
-        pruned_model = fx_pruner.prune()
-        pruned_model.eval()
-        out_pruned, lstm_out_pruned = pruned_model(lstm_input)
-        _, c = lstm_out_expected.size()
-
-        # We cannot check that y_expected == y_pruned as usual because
-        # zeros vs. missing elements yield different numerical results.
-        # Instead that we check that the pruned elements are the first half of the results
-        # since we are using a BottomHalfLSTMPruner
-        if not torch.isclose(
-            lstm_out_expected[:, : c // 2], lstm_out_pruned, rtol=1e-05, atol=1e-07
-        ).all():
-            raise AssertionError("LSTM outputs are not close")
-        # also check that output of linear is the same shape, this means we've resized
-        # linear columns correctly.
-        if out_expected.shape != out_pruned.shape:
-            raise AssertionError(
-                f"Expected shape {out_expected.shape}, got {out_pruned.shape}"
             )
 
 

--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -24,7 +24,8 @@ from ao.sparsity.test_sparsifier import (  # noqa: F401
 from ao.sparsity.test_structured_sparsifier import (  # noqa: F401
     TestBaseStructuredSparsifierCPU,
     TestBaseStructuredSparsifierDevice,
-    TestFPGMPruner,
+    TestFPGMPrunerCPU,
+    TestFPGMPrunerDevice,
     TestSaliencyPruner,
 )
 
@@ -60,7 +61,7 @@ from ao.sparsity.test_sparsity_utils import TestSparsityUtilFunctions  # noqa: F
 
 instantiate_device_type_tests(TestSaliencyPruner, globals())
 instantiate_device_type_tests(TestBaseStructuredSparsifierDevice, globals())
-instantiate_device_type_tests(TestFPGMPruner, globals())
+instantiate_device_type_tests(TestFPGMPrunerDevice, globals())
 
 
 if __name__ == "__main__":

--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -21,8 +21,9 @@ from ao.sparsity.test_sparsifier import (  # noqa: F401
 )
 
 # Structured Pruning
-from ao.sparsity.test_structured_sparsifier import (
-    TestBaseStructuredSparsifier,
+from ao.sparsity.test_structured_sparsifier import (  # noqa: F401
+    TestBaseStructuredSparsifierCPU,
+    TestBaseStructuredSparsifierDevice,
     TestFPGMPruner,
     TestSaliencyPruner,
 )
@@ -58,7 +59,7 @@ from ao.sparsity.test_sparsity_utils import TestSparsityUtilFunctions  # noqa: F
 
 
 instantiate_device_type_tests(TestSaliencyPruner, globals())
-instantiate_device_type_tests(TestBaseStructuredSparsifier, globals())
+instantiate_device_type_tests(TestBaseStructuredSparsifierDevice, globals())
 instantiate_device_type_tests(TestFPGMPruner, globals())
 
 


### PR DESCRIPTION
Move `TestFPGMPruner` CPU-only test to separate class

- extract nested `SimpleConvFPGM` class to global scope
- move CPU-only test to class `TestFPGMPrunerCPU`
- rename old `TestFPGMPruner` class to `TestFPGMPrunerDevice`
- update imports in `test_ao_sparsity.py`
- refactor `TestFPGMPrunerCPU` to remove `instantiate_device_type_tests` call
- add hardware classification

No changes in test results -  just a single name change:
`TestFPGMPrunerCPU::test_update_mask_cpu -> TestFPGMPrunerDeviceCPU::test_update_mask_cpu`

---

Stack of following PRs:
- https://github.com/pytorch/pytorch/pull/191199
- -> https://github.com/pytorch/pytorch/pull/191200
- https://github.com/pytorch/pytorch/pull/191202