### PR TITLE
Log SAC usage with active saved tensor hooks

### DIFF
--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1702,6 +1702,14 @@ def _checkpoint_without_reentrant_generator(
         yield
         return
 
+    if (
+        isinstance(forward_context, _CachingTorchDispatchMode)
+        and torch._C._autograd._top_saved_tensors_default_hooks(False) is not None
+    ):
+        torch._C._log_api_usage_once(
+            "torch.utils.checkpoint.sac_with_saved_tensors_hooks"
+        )
+
     new_frame.save_inputs(*args)
 
     forward_context_suppressed_exc = False


### PR DESCRIPTION
Summary:
Selective activation checkpointing installs its own saved tensor hooks inside any surrounding user hooks, replacing the user pair. Before changing this behavior, record how often SAC is invoked while saved tensor hooks are already active so we can assess the backward-compatibility risk.

The instrumentation remains entirely in Python. Immediately before checkpoint input saving, SAC checks the existing hook stack through `_top_saved_tensors_default_hooks(False)` and emits `torch.utils.checkpoint.sac_with_saved_tensors_hooks` through the existing `_log_api_usage_once` entry point.

Authored with assistance from an AI coding assistant.

Test Plan:
Ran the full selective activation checkpoint test class after removing the instrumentation-specific unit test; it passed 12 tests with one expected CUDA-only skip and no failures, timeouts, infrastructure failures, or build failures.

```
buck2 test fbcode//caffe2/test:autograd -- TestSelectiveActivationCheckpoint
```

Ran changed-file Python lint; it reported no issues.

```
arc lint -a fbcode/caffe2/torch/utils/checkpoint.py
```

For end-to-end logging verification, temporarily removed the devserver `EnvironmentInfo::isSandbox()` dispatcher early return and forced the per-process sampling predicate locally, then ran an SAC checkpoint under `saved_tensors_hooks` through `ifbpy`. `PYTORCH_API_USAGE_STDERR=1` reported `PYTORCH_API_USAGE Sampling rate: 1`. An exact query of `caffe2_pytorch_usage_stats/sandbox` constrained to `event = torch.utils.checkpoint.sac_with_saved_tensors_hooks` and `unix_user = ezyang` returned `Hits: 1, Samples: 1`. Both temporary bypasses were reverted. Since the configured denominator was already `1`, forcing the sampling predicate did not affect selection; only sandbox suppression had to be bypassed to reach the sandbox table.

Differential Revision: D113556010


