### PR TITLE
[TEST] Refactor test_op_schema.py and test_xpu_profiler.py with hw_classification

### DIFF
--- a/test/distributed/tensor/test_op_schema.py
+++ b/test/distributed/tensor/test_op_schema.py
@@ -5,10 +5,12 @@ import random
 
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import OpSchema, RuntimeSchemaInfo
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
 
 
 class TestOpSchema(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_equality_checks_lists_of_dtensor_spec(self):
         """If x == y, then we must have h(x) == h(y)."""
         dts = DTensorSpec(mesh=None, placements=tuple(), tensor_meta=None)

--- a/test/profiler/test_xpu_profiler.py
+++ b/test/profiler/test_xpu_profiler.py
@@ -9,13 +9,20 @@ from collections import defaultdict
 
 import torch
 from torch.profiler import DeviceType
-from torch.testing._internal.common_utils import run_tests, TEST_XPU, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_XPU,
+    TestCase,
+)
 
 
 Verbose = False
 
 
 class XpuProfilerTest(TestCase):
+    hw_classification = HardwareClassification.XPU
+
     @unittest.skipIf(not TEST_XPU, "test requires XPU")
     def test_profiler(self):
         t = torch.empty(1000, dtype=torch.int, device="xpu")


### PR DESCRIPTION
## Summary
Apply hardware classification to `test_op_schema.py` and `test_xpu_profiler.py`.

### test_op_schema.py
- Add `hw_classification = HardwareClassification.GENERIC` to `TestOpSchema` — all 3 test methods verify pure CPU-side schema logic (equality, hashing, weakref behavior) with no device dependencies

### test_xpu_profiler.py
- Add `hw_classification = HardwareClassification.XPU` to `TestProfiler` — all 7 test methods use `@unittest.skipIf(not TEST_XPU, ...)` and exercise XPU-specific profiling with `torch.xpu` APIs
- Add `HardwareClassification` to imports from `common_utils`
- No class splits, renames, or test logic changes

(Consolidates #192241)

## Test Plan

```bash
python test/distributed/tensor/test_op_schema.py -v
Ran 3 tests in 0.950s — OK

python test/distributed/tensor/test_op_schema.py -v --hw-classification GENERIC
Ran 3 tests in 0.938s — OK

python test/profiler/test_xpu_profiler.py -v
python test/profiler/test_xpu_profiler.py -v --hw-classification XPU
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508
