### PR TITLE
[ONNX] Fix signed right shift export in the TorchScript exporter

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3737,6 +3737,29 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         input = torch.arange(24, dtype=torch.int64).reshape(3, 4, 2)
         self.run_test(BitshiftModel(), input)
 
+    @common_utils.parametrize(
+        "dtype", [torch.int8, torch.int16, torch.int32, torch.int64]
+    )
+    def test_bitshift_signed(self, dtype):
+        class RightShiftModel(torch.nn.Module):
+            def forward(self, input):
+                return input >> 1, input >> 3
+
+        input = torch.tensor([-128, -7, -4, -1, 0, 1, 3, 127], dtype=dtype)
+        self.run_test(RightShiftModel(), input)
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    @common_utils.parametrize(
+        "dtype", [torch.int8, torch.int16, torch.int32, torch.int64]
+    )
+    def test_bitwise_right_shift_signed(self, dtype):
+        class BitwiseRightShiftModel(torch.nn.Module):
+            def forward(self, input):
+                return torch.bitwise_right_shift(input, 2)
+
+        input = torch.tensor([-128, -7, -4, -1, 0, 1, 3, 127], dtype=dtype)
+        self.run_test(BitwiseRightShiftModel(), input)
+
     @skipIfUnsupportedMinOpsetVersion(18)
     def test_bitwise_and(self):
         class BitwiseAndModel(torch.nn.Module):

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset11.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset11.py
@@ -992,20 +992,10 @@ def __rshift_(g: jit_utils.GraphContext, self, other):
         _type_utils.JitScalarType.from_value(self, _type_utils.JitScalarType.UNDEFINED)
         == _type_utils.JitScalarType.UINT8
     ):
+        # shifting an unsigned integer right is a logical shift
         return g.op("BitShift", self, other, direction_s="RIGHT")
 
-    two = g.op("Constant", value_t=torch.tensor(2, dtype=torch.float32))
-    # exponent (same type as self) has to be float or double in onnx::Pow
-    if not symbolic_helper._is_fp(self):
-        other = g.op("Cast", other, to_i=_C_onnx.TensorProtoDataType.FLOAT)
-    two_pow = g.op("Pow", two, other)
-    two_pow = g.op(
-        "Cast",
-        two_pow,
-        to_i=_type_utils.JitScalarType.from_value(self).onnx_type(),
-    )
-    rshift = g.op("Div", self, two_pow)
-    return rshift
+    return opset9.__rshift_(g, self, other)
 
 
 @_onnx_symbolic("aten::bitwise_left_shift")

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
@@ -2154,6 +2154,31 @@ def logical_not(g: jit_utils.GraphContext, input):
     return g.op("Not", g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.BOOL))
 
 
+def _arithmetic_rshift(g: jit_utils.GraphContext, self, two_pow, self_scalar_type):
+    is_narrow = self_scalar_type in (
+        _type_utils.JitScalarType.INT8,
+        _type_utils.JitScalarType.INT16,
+    )
+    compute_scalar_type = (
+        _type_utils.JitScalarType.INT if is_narrow else self_scalar_type
+    )
+    if is_narrow:
+        self = g.op("Cast", self, to_i=compute_scalar_type.onnx_type())
+    two_pow = g.op("Cast", two_pow, to_i=compute_scalar_type.onnx_type())
+
+    zero = g.op("Constant", value_t=torch.tensor(0, dtype=compute_scalar_type.dtype()))
+    negative = g.op(
+        "Cast",
+        symbolic_helper._lt_helper(g, self, zero),
+        to_i=compute_scalar_type.onnx_type(),
+    )
+    rshift = g.op("Sub", g.op("Div", g.op("Add", self, negative), two_pow), negative)
+
+    if is_narrow:
+        rshift = g.op("Cast", rshift, to_i=self_scalar_type.onnx_type())
+    return rshift
+
+
 @_onnx_symbolic("aten::__rshift_")
 def __rshift_(g: jit_utils.GraphContext, self, other):
     # make sure to cast other to self's type
@@ -2174,6 +2199,15 @@ def __rshift_(g: jit_utils.GraphContext, self, other):
     if not symbolic_helper._is_fp(self):
         other = g.op("Cast", other, to_i=_C_onnx.TensorProtoDataType.FLOAT)
     two_pow = g.op("Pow", two, other)
+
+    if self_scalar_type in (
+        _type_utils.JitScalarType.INT8,
+        _type_utils.JitScalarType.INT16,
+        _type_utils.JitScalarType.INT,
+        _type_utils.JitScalarType.INT64,
+    ):
+        return _arithmetic_rshift(g, self, two_pow, self_scalar_type)
+
     two_pow = g.op(
         "Cast",
         two_pow,


### PR DESCRIPTION
Fixes #191014

### Fix
The exporter lowered signed right shifts to `onnx::Div` by `2**n`, which truncates toward zero, so negative inputs were wrong (e.g. `-7 >> 1` exported as `-3` instead of `-4`). `symbolic_opset9` now computes `(x + m) / 2**n - m`, where `m` is 1 for negative elements and 0 otherwise, rounding toward negative infinity to match PyTorch. int8 and int16 are computed as int32 (the narrowest integer type `onnx::Add` and `onnx::Div` accept before opset 14) and narrowed back losslessly. The unsigned `BitShift` path is unchanged.

cc @justinchuby @titaiwangms