### PR TITLE
Prefetch merge-base blob in stable-shim linters to avoid mid-diff lazy fetch

### DIFF
--- a/tools/linter/adapters/_stable_shim_utils.py
+++ b/tools/linter/adapters/_stable_shim_utils.py
@@ -10,6 +10,7 @@ Consumed by:
 from __future__ import annotations
 
 import functools
+import os
 import re
 import subprocess
 import sys
@@ -461,6 +462,60 @@ def _run_git_network_cmd(
             time.sleep(2**attempt)
     raise RuntimeError(
         f"`{' '.join(cmd)}` failed after {attempts} attempts: {last_err}"
+    )
+
+
+def ensure_diff_blob_local(commit: str, filename: str) -> None:
+    """
+    Prefetch the blob for `filename` at `commit` so a subsequent
+    `git diff commit..HEAD -- filename` runs entirely from local objects.
+
+    CI checks out a blobless partial clone (git clone --filter=blob:none), so
+    fetching a commit brings down its trees but not file contents. Left alone,
+    `git diff` notices the merge-base blob is missing and triggers an on-demand
+    lazy fetch in the middle of the diff -- an uncontrolled network round-trip
+    that races the diff's short timeout under the network contention of
+    lintrunner running adapters concurrently.
+
+    Trees are present locally under blob:none, so we resolve the blob's OID
+    offline and fetch exactly that one object through the retrying network
+    helper. In a full (non-partial) clone the blob is already present and this
+    is a no-op with no network access. GIT_NO_LAZY_FETCH keeps the local
+    resolution and presence checks from themselves triggering a fetch.
+    """
+    no_lazy = {**os.environ, "GIT_NO_LAZY_FETCH": "1"}
+
+    try:
+        rel = Path(filename).resolve().relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return  # path is outside the repo; nothing we can prefetch
+
+    rev = subprocess.run(
+        ["git", "rev-parse", f"{commit}:{rel}"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        env=no_lazy,
+    )
+    blob_oid = rev.stdout.strip()
+    if rev.returncode != 0 or not blob_oid:
+        # Path does not exist at `commit` (e.g. a newly added file), or the tree
+        # is unavailable (treeless clone). There is no merge-base blob to
+        # prefetch; the diff falls back to its own handling.
+        return
+
+    present = subprocess.run(
+        ["git", "cat-file", "-e", blob_oid],
+        capture_output=True,
+        timeout=5,
+        env=no_lazy,
+    )
+    if present.returncode == 0:
+        return
+
+    _run_git_network_cmd(
+        ["git", "fetch", "--no-write-fetch-head", "origin", blob_oid],
+        timeout=30,
     )
 
 

--- a/tools/linter/adapters/generated_shims_version_linter.py
+++ b/tools/linter/adapters/generated_shims_version_linter.py
@@ -22,6 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
 
 from tools.linter.adapters._stable_shim_utils import (
+    ensure_diff_blob_local,
     get_current_version,
     LintMessage,
     LintSeverity,
@@ -115,6 +116,10 @@ def _read_at_merge_base(filename: str) -> str | None:
     """
     merge_base = merge_base_with_main()
 
+    # Prefetch the merge-base blob so `git show` below stays fully local (CI uses
+    # a blobless partial clone; otherwise git lazily fetches it mid-command).
+    ensure_diff_blob_local(merge_base, filename)
+
     # `git show <ref>:<path>` requires <path> relative to the repo root;
     # lintrunner may pass `filename` as an absolute path.
     rel_path = Path(filename).resolve().relative_to(REPO_ROOT).as_posix()
@@ -122,9 +127,7 @@ def _read_at_merge_base(filename: str) -> str | None:
         ["git", "show", f"{merge_base}:{rel_path}"],
         capture_output=True,
         text=True,
-        # On a blobless partial clone (CI), the blob at merge-base is not local
-        # and git lazily fetches it over the network, which can exceed a few s.
-        timeout=60,
+        timeout=5,
     )
     if result.returncode != 0:
         # File didn't exist at merge-base; treat all current entries as new.

--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -20,6 +20,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
 
 from tools.linter.adapters._stable_shim_utils import (
+    ensure_diff_blob_local,
     get_current_version,
     LintMessage,
     LintSeverity,
@@ -79,6 +80,9 @@ def get_added_lines(filename: str) -> set[int]:
 
         # Get merge-base with origin/main to check all PR commits
         merge_base = merge_base_with_main()
+        # Prefetch the merge-base blob so the diff below stays fully local (CI
+        # uses a blobless partial clone; otherwise git lazily fetches mid-diff).
+        ensure_diff_blob_local(merge_base, filename)
         result = subprocess.run(
             ["git", "diff", f"{merge_base}..HEAD", filename],
             capture_output=True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191228

The STABLE_SHIM_VERSION linter intermittently fails in CI with
`subprocess.TimeoutExpired` on `git diff <merge_base>..HEAD -- shim.h`,
reported as an internal linter bug.

Root cause: CI checks out a blobless partial clone (`--filter=blob:none`, added
in #172544; see .github/actions/checkout-pytorch/action.yml). The 5s diff
timeout predates that (added with the linter in #166995) and was correct then --
the diff was purely local. `merge_base_with_main()` fetches the merge-base
*commit* ahead of time, but the blobless filter deliberately omits file contents
even for explicitly fetched commits, so the merge-base blob of the linted file
is never local. When `git diff` needs it, git triggers an on-demand lazy fetch
in the middle of the command -- an uncontrolled network round-trip that races
the 5s timeout under the network contention of lintrunner running adapters
concurrently.

This is the same partial-clone symptom #189419 already fixed for the sibling
`git cat-file` probe in `merge_base_with_main()`, which was simply never applied
to the `git diff`/`git show` paths. #189419 established the design: keep a short
timeout as a fast "is it local?" probe and, on absence, fall back to an
explicit, controlled `git fetch`. #189444 tried to instead bump the probe
timeout to wait the lazy fetch out; #189946 reverted that, on the grounds that a
timeout is the signal that the object is not present, not something to wait out.
So bumping the diff timeout (or wrapping the diff in the retrying fetch helper to
wait it out) would repeat the already-reverted mistake.

Fix: apply #189419's design to the missing blob. `ensure_diff_blob_local()`
resolves the blob OID offline (trees are present under blob:none) and, only if
it is missing locally, fetches that single object through the existing retrying
network helper; the diff/show then runs entirely from local objects with a
short, honest timeout. `GIT_NO_LAZY_FETCH=1` guards the resolution and presence
checks so they cannot themselves trigger a fetch -- a deterministic improvement
over the cat-file probe's timeout race. In a full clone the blob is already
present and this is a no-op with no network access. The generated-shims linter's
prior 60s `git show` workaround is replaced by the same prefetch + 5s timeout.

Test Plan:
Verified locally in a full clone that the helper is a no-op and the git command
stays local and fast:

```
python tools/linter/adapters/stable_shim_version_linter.py \
    torch/csrc/inductor/aoti_torch/c/shim.h
```

End-to-end validation on a blobless partial clone still needs to run (the
sandbox has no network); it must confirm the single-blob
`git fetch --no-write-fetch-head origin <oid>` succeeds against GitHub's
promisor endpoint. If the explicit single-object fetch is rejected there, the
fallback is to trigger git's native lazy fetch through the same retry wrapper
(e.g. `git cat-file -p <oid>`).

Authored-with: Claude (AI assistant)