### PR TITLE
Validate input/hidden dimension consistency in RNN cells

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -700,9 +700,13 @@ void check_rnn_cell_forward_input(const Tensor& input, const c10::SymInt& input_
 
 void check_rnn_cell_forward_hidden(const Tensor& input, const Tensor& hx, const c10::SymInt& hidden_size, const c10::SymInt& hidden_label) {
   TORCH_CHECK(
-    input.dim() == hx.dim(),
-    "Expected input and hidden", hidden_label, " to have the same number of "
-    "dimensions, but got input.dim()=", input.dim(), " and hidden.dim()=", hx.dim());
+    input.dim() == 2,
+    "Expected 2D input (batch x feature), but got ", input.dim(), "D input");
+
+  TORCH_CHECK(
+    hx.dim() == 2,
+    "Expected 2D hidden", hidden_label, " (batch x hidden_size), but got ",
+    hx.dim(), "D tensor");
 
   TORCH_CHECK(
     input.sym_size(0) == hx.sym_size(0),

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -700,6 +700,11 @@ void check_rnn_cell_forward_input(const Tensor& input, const c10::SymInt& input_
 
 void check_rnn_cell_forward_hidden(const Tensor& input, const Tensor& hx, const c10::SymInt& hidden_size, const c10::SymInt& hidden_label) {
   TORCH_CHECK(
+    input.dim() == hx.dim(),
+    "Expected input and hidden", hidden_label, " to have the same number of "
+    "dimensions, but got input.dim()=", input.dim(), " and hidden.dim()=", hx.dim());
+
+  TORCH_CHECK(
     input.sym_size(0) == hx.sym_size(0),
     "Input batch size ", input.sym_size(0), " doesn't match hidden", hidden_label, " batch size ", hx.sym_size(0));
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2559,6 +2559,33 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertRaises(Exception, lambda: lstm(input, (cx, hx)))
 
 
+    def test_rnn_cell_input_hidden_dim_mismatch(self):
+        input_1d = torch.randn(5)
+        hx_2d = torch.randn(3, 3)
+        cx_2d = torch.randn(3, 3)
+
+        with self.assertRaisesRegex(ValueError, "same number of dimensions"):
+            nn.LSTMCell(5, 3)(input_1d, (hx_2d, cx_2d))
+
+        with self.assertRaisesRegex(ValueError, "same number of dimensions"):
+            nn.GRUCell(5, 3)(input_1d, hx_2d)
+
+        with self.assertRaisesRegex(ValueError, "same number of dimensions"):
+            nn.RNNCell(5, 3)(input_1d, hx_2d)
+
+        input_2d = torch.randn(3, 5)
+        hx_1d = torch.randn(3)
+        cx_1d = torch.randn(3)
+
+        with self.assertRaisesRegex(ValueError, "same number of dimensions"):
+            nn.LSTMCell(5, 3)(input_2d, (hx_1d, cx_1d))
+
+        with self.assertRaisesRegex(ValueError, "same number of dimensions"):
+            nn.GRUCell(5, 3)(input_2d, hx_1d)
+
+        with self.assertRaisesRegex(ValueError, "same number of dimensions"):
+            nn.RNNCell(5, 3)(input_2d, hx_1d)
+
     def test_Transformer_cell(self):
         # this is just a smoke test; these modules are implemented through
         # autograd so no Jacobian test is needed

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -1619,6 +1619,12 @@ class RNNCell(RNNCellBase):
             raise ValueError(
                 f"RNNCell: Expected hidden to be 1D or 2D, got {hx.dim()}D instead"
             )
+        if hx is not None and input.dim() != hx.dim():
+            raise ValueError(
+                f"RNNCell: Expected input and hidden to have the same number of "
+                f"dimensions, but got input.dim()={input.dim()} and "
+                f"hidden.dim()={hx.dim()}"
+            )
         is_batched = input.dim() == 2
         if not is_batched:
             input = input.unsqueeze(0)
@@ -1742,6 +1748,12 @@ class LSTMCell(RNNCellBase):
                     raise ValueError(
                         f"LSTMCell: Expected hx[{idx}] to be 1D or 2D, got {value.dim()}D instead"
                     )
+                if input.dim() != value.dim():
+                    raise ValueError(
+                        f"LSTMCell: Expected input and hx[{idx}] to have the same "
+                        f"number of dimensions, but got input.dim()={input.dim()} "
+                        f"and hx[{idx}].dim()={value.dim()}"
+                    )
         is_batched = input.dim() == 2
         if not is_batched:
             input = input.unsqueeze(0)
@@ -1849,6 +1861,12 @@ class GRUCell(RNNCellBase):
         if hx is not None and hx.dim() not in (1, 2):
             raise ValueError(
                 f"GRUCell: Expected hidden to be 1D or 2D, got {hx.dim()}D instead"
+            )
+        if hx is not None and input.dim() != hx.dim():
+            raise ValueError(
+                f"GRUCell: Expected input and hidden to have the same number of "
+                f"dimensions, but got input.dim()={input.dim()} and "
+                f"hidden.dim()={hx.dim()}"
             )
         is_batched = input.dim() == 2
         if not is_batched:


### PR DESCRIPTION
Fixes #175978

## Summary

LSTMCell, GRUCell, and RNNCell segfault when input and hidden state have different numbers of dimensions (e.g. 1D input with 2D hidden). The is_batched flag is determined solely from input.dim(), so when hidden states disagree on rank, they get incorrectly unsqueezed into 3D tensors that cause out-of-bounds memory access in GEMM.

## Changes

1. torch/nn/modules/rnn.py: Add dimension consistency checks in all three cell forward methods
2. aten/src/ATen/native/RNN.cpp: Add defense-in-depth dim check in check_rnn_cell_forward_hidden
3. test/test_nn.py: Test all 6 mismatch cases across all three cell types

Prior PR #176070 was approved in concept but went stale. This fix addresses the root cause (Python batching logic) across all three cell types and adds a centralized C++ check per the review suggestion on #176070.

cc @mikaylagawarecki @malfet