### PR TITLE
Make c10::checked_convert strict for integers and migrate callers to safe_conv

### DIFF
--- a/aten/src/ATen/native/AveragePool2d.cpp
+++ b/aten/src/ATen/native/AveragePool2d.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/ScalarOps.h>
 #include <ATen/native/Pool.h>
+#include <c10/util/safe_conv.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -28,19 +29,19 @@ TORCH_PRECOMPUTE_META_FUNC(avg_pool2d)
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 2,
     "avg_pool2d: kernel_size must either be a single int, or a tuple of two ints");
-  const int kH = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kW = kernel_size.size() == 1 ? kH : c10::checked_convert<int>(kernel_size[1], "int");
+  const int kH = c10::safe_conv<int>(kernel_size[0]);
+  const int kW = kernel_size.size() == 1 ? kH : c10::safe_conv<int>(kernel_size[1]);
 
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 2,
     "avg_pool2d: stride must either be omitted, a single int, or a tuple of two ints");
-  const int dH = stride.empty() ? kH : c10::checked_convert<int>(stride[0], "int");
+  const int dH = stride.empty() ? kH : c10::safe_conv<int>(stride[0]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dH : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dH : c10::safe_conv<int>(stride[1]);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 2,
     "avg_pool2d: padding must either be a single int, or a tuple of two ints");
-  const int padH = c10::checked_convert<int>(padding[0], "int");
-  const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
+  const int padH = c10::safe_conv<int>(padding[0]);
+  const int padW = padding.size() == 1 ? padH : c10::safe_conv<int>(padding[1]);
 
   TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0,
     "divisor must be not zero");
@@ -113,19 +114,19 @@ TORCH_META_FUNC(avg_pool2d_backward) (
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 2,
     "avg_pool2d: kernel_size must either be a single int, or a tuple of two ints");
-  const int kH = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kW = kernel_size.size() == 1 ? kH : c10::checked_convert<int>(kernel_size[1], "int");
+  const int kH = c10::safe_conv<int>(kernel_size[0]);
+  const int kW = kernel_size.size() == 1 ? kH : c10::safe_conv<int>(kernel_size[1]);
 
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 2,
     "avg_pool2d: stride must either be omitted, a single int, or a tuple of two ints");
-  const int dH = stride.empty() ? kH : c10::checked_convert<int>(stride[0], "int");
+  const int dH = stride.empty() ? kH : c10::safe_conv<int>(stride[0]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dH : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dH : c10::safe_conv<int>(stride[1]);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 2,
     "avg_pool2d: padding must either be a single int, or a tuple of two ints");
-  const int padH = c10::checked_convert<int>(padding[0], "int");
-  const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
+  const int padH = c10::safe_conv<int>(padding[0]);
+  const int padW = padding.size() == 1 ? padH : c10::safe_conv<int>(padding[1]);
 
   TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0, "divisor must be not zero");
 
@@ -193,15 +194,15 @@ TORCH_IMPL_FUNC(avg_pool2d_backward_out_cpu) (
   std::optional<int64_t> divisor_override,
   const Tensor& gradInput
 ) {
-  const int kH = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kW = kernel_size.size() == 1 ? kH : c10::checked_convert<int>(kernel_size[1], "int");
+  const int kH = c10::safe_conv<int>(kernel_size[0]);
+  const int kW = kernel_size.size() == 1 ? kH : c10::safe_conv<int>(kernel_size[1]);
 
-  const int dH = stride.empty() ? kH : c10::checked_convert<int>(stride[0], "int");
+  const int dH = stride.empty() ? kH : c10::safe_conv<int>(stride[0]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dH : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dH : c10::safe_conv<int>(stride[1]);
 
-  const int padH = c10::checked_convert<int>(padding[0], "int");
-  const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
+  const int padH = c10::safe_conv<int>(padding[0]);
+  const int padW = padding.size() == 1 ? padH : c10::safe_conv<int>(padding[1]);
 
   TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0, "divisor must be not zero");
 

--- a/aten/src/ATen/native/AveragePool3d.cpp
+++ b/aten/src/ATen/native/AveragePool3d.cpp
@@ -5,6 +5,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/native/Pool.h>
 #include <c10/util/irange.h>
+#include <c10/util/safe_conv.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -29,23 +30,23 @@ TORCH_META_FUNC(avg_pool3d) (
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
     "avg_pool3d: kernel_size must be a single int, or a tuple of three ints");
-  const int kT = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
-  const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
+  const int kT = c10::safe_conv<int>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[2]);
 
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 3,
     "avg_pool3d: stride must be omitted, a single int, or a tuple of three ints");
-  const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
+  const int dT = stride.empty() ? kT : c10::safe_conv<int>(stride[0]);
   const int dH = stride.empty() ? kH :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[1]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[2], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[2]);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 3,
     "avg_pool3d: padding must be a single int, or a tuple of three ints");
-  const int padT = c10::checked_convert<int>(padding[0], "int");
-  const int padH = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[1], "int");
-  const int padW = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[2], "int");
+  const int padT = c10::safe_conv<int>(padding[0]);
+  const int padH = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[1]);
+  const int padW = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[2]);
 
   TORCH_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
     "non-empty 4D or 5D (batch mode) tensor expected for input");
@@ -98,23 +99,23 @@ TORCH_META_FUNC(avg_pool3d_backward) (
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
     "avg_pool3d: kernel_size must be a single int, or a tuple of three ints");
-  const int kT = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
-  const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
+  const int kT = c10::safe_conv<int>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[2]);
 
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 3,
     "avg_pool3d: stride must be omitted, a single int, or a tuple of three ints");
-  const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
+  const int dT = stride.empty() ? kT : c10::safe_conv<int>(stride[0]);
   const int dH = stride.empty() ? kH :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[1]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[2], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[2]);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 3,
     "avg_pool3d: padding must be a single int, or a tuple of three ints");
-  const int padT = c10::checked_convert<int>(padding[0], "int");
-  const int padH = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[1], "int");
-  const int padW = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[2], "int");
+  const int padT = c10::safe_conv<int>(padding[0]);
+  const int padH = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[1]);
+  const int padW = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[2]);
 
   TORCH_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
     "non-empty 4D or 5D (batch mode) tensor expected for input");
@@ -255,19 +256,19 @@ TORCH_IMPL_FUNC(avg_pool3d_out_cpu) (
   std::optional<int64_t> divisor_override,
   const Tensor& output
 ) {
-  const int kT = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
-  const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
+  const int kT = c10::safe_conv<int>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[2]);
 
-  const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
+  const int dT = stride.empty() ? kT : c10::safe_conv<int>(stride[0]);
   const int dH = stride.empty() ? kH :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[1]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[2], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[2]);
 
-  const int padT = c10::checked_convert<int>(padding[0], "int");
-  const int padH = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[1], "int");
-  const int padW = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[2], "int");
+  const int padT = c10::safe_conv<int>(padding[0]);
+  const int padH = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[1]);
+  const int padW = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[2]);
 
   const int64_t nslices = input_.size(-4);
   const int64_t itime = input_.size(-3);
@@ -428,19 +429,19 @@ TORCH_IMPL_FUNC(avg_pool3d_backward_out_cpu) (
   std::optional<int64_t> divisor_override,
   const Tensor& gradInput
 ) {
-  const int kT = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
-  const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
+  const int kT = c10::safe_conv<int>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[2]);
 
-  const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
+  const int dT = stride.empty() ? kT : c10::safe_conv<int>(stride[0]);
   const int dH = stride.empty() ? kH :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[1]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[2], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[2]);
 
-  const int padT = c10::checked_convert<int>(padding[0], "int");
-  const int padH = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[1], "int");
-  const int padW = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[2], "int");
+  const int padT = c10::safe_conv<int>(padding[0]);
+  const int padH = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[1]);
+  const int padW = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[2]);
 
   const int64_t nslices = input.size(-4);
   const int64_t itime = input.size(-3);

--- a/aten/src/ATen/native/DilatedMaxPool2d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool2d.cpp
@@ -3,6 +3,7 @@
 #include <ATen/ScalarOps.h>
 #include <ATen/TensorMeta.h>
 #include <ATen/native/Pool.h>
+#include <c10/util/safe_conv.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -24,26 +25,26 @@ bool ceil_mode) {
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 2,
     "max_pool2d: kernel_size must either be a single int, or a tuple of two ints")
-  const int kH = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kW = kernel_size.size() == 1 ? kH : c10::checked_convert<int>(kernel_size[1], "int");
+  const int kH = c10::safe_conv<int>(kernel_size[0]);
+  const int kW = kernel_size.size() == 1 ? kH : c10::safe_conv<int>(kernel_size[1]);
 
   // NB: stride default is not expressible as an integer constant, so we accept
   // empty stride for this case
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 2,
     "max_pool2d: stride must either be omitted, a single int, or a tuple of two ints")
-  const int dH = stride.empty() ? kH : c10::checked_convert<int>(stride[0], "int");
+  const int dH = stride.empty() ? kH : c10::safe_conv<int>(stride[0]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dH : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dH : c10::safe_conv<int>(stride[1]);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 2,
     "max_pool2d: padding must either be a single int, or a tuple of two ints");
-  const int padH = c10::checked_convert<int>(padding[0], "int");
-  const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
+  const int padH = c10::safe_conv<int>(padding[0]);
+  const int padW = padding.size() == 1 ? padH : c10::safe_conv<int>(padding[1]);
 
   TORCH_CHECK(dilation.size() == 1 || dilation.size() == 2,
     "max_pool2d: dilation must be either a single int, or a tuple of two ints");
-  const int dilationH = c10::checked_convert<int>(dilation[0], "int");
-  const int dilationW = dilation.size() == 1 ? dilationH : c10::checked_convert<int>(dilation[1], "int");
+  const int dilationH = c10::safe_conv<int>(dilation[0]);
+  const int dilationW = dilation.size() == 1 ? dilationH : c10::safe_conv<int>(dilation[1]);
 
   const auto memory_format = input.suggest_memory_format();
   if (memory_format == at::MemoryFormat::ChannelsLast) {
@@ -97,26 +98,26 @@ const Tensor& indices) {
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 2,
     "max_pool2d: kernel_size must either be a single int, or a tuple of two ints")
-  const int kH = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kW = kernel_size.size() == 1 ? kH : c10::checked_convert<int>(kernel_size[1], "int");
+  const int kH = c10::safe_conv<int>(kernel_size[0]);
+  const int kW = kernel_size.size() == 1 ? kH : c10::safe_conv<int>(kernel_size[1]);
 
   // NB: stride default is not expressible as an integer constant, so we accept
   // empty stride for this case
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 2,
     "max_pool2d: stride must either be omitted, a single int, or a tuple of two ints")
-  const int dH = stride.empty() ? kH : c10::checked_convert<int>(stride[0], "int");
+  const int dH = stride.empty() ? kH : c10::safe_conv<int>(stride[0]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dH : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dH : c10::safe_conv<int>(stride[1]);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 2,
     "max_pool2d: padding must either be a single int, or a tuple of two ints");
-  const int padH = c10::checked_convert<int>(padding[0], "int");
-  const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
+  const int padH = c10::safe_conv<int>(padding[0]);
+  const int padW = padding.size() == 1 ? padH : c10::safe_conv<int>(padding[1]);
 
   TORCH_CHECK(dilation.size() == 1 || dilation.size() == 2,
     "max_pool2d: dilation must be either a single int, or a tuple of two ints");
-  const int dilationH = c10::checked_convert<int>(dilation[0], "int");
-  const int dilationW = dilation.size() == 1 ? dilationH : c10::checked_convert<int>(dilation[1], "int");
+  const int dilationH = c10::safe_conv<int>(dilation[0]);
+  const int dilationW = dilation.size() == 1 ? dilationH : c10::safe_conv<int>(dilation[1]);
 
   TORCH_CHECK(input.dtype() == gradOutput.dtype(),
     "expected dtype ", input.dtype(), " for `gradOutput` but got dtype ", gradOutput.dtype());
@@ -167,18 +168,18 @@ bool ceil_mode,
 const Tensor& output,
 const Tensor& indices) {
 
-  const int kH = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kW = kernel_size.size() == 1 ? kH : c10::checked_convert<int>(kernel_size[1], "int");
+  const int kH = c10::safe_conv<int>(kernel_size[0]);
+  const int kW = kernel_size.size() == 1 ? kH : c10::safe_conv<int>(kernel_size[1]);
 
-  const int dH = stride.empty() ? kH : c10::checked_convert<int>(stride[0], "int");
+  const int dH = stride.empty() ? kH : c10::safe_conv<int>(stride[0]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dH : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dH : c10::safe_conv<int>(stride[1]);
 
-  const int padH = c10::checked_convert<int>(padding[0], "int");
-  const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
+  const int padH = c10::safe_conv<int>(padding[0]);
+  const int padW = padding.size() == 1 ? padH : c10::safe_conv<int>(padding[1]);
 
-  const int dilationH = c10::checked_convert<int>(dilation[0], "int");
-  const int dilationW = dilation.size() == 1 ? dilationH : c10::checked_convert<int>(dilation[1], "int");
+  const int dilationH = c10::safe_conv<int>(dilation[0]);
+  const int dilationW = dilation.size() == 1 ? dilationH : c10::safe_conv<int>(dilation[1]);
 
   max_pool2d_kernel(
       kCPU, output, indices, input,

--- a/aten/src/ATen/native/DilatedMaxPool3d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool3d.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/Dispatch.h>
 #include <ATen/native/Pool.h>
+#include <c10/util/safe_conv.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -30,29 +31,29 @@ void max_pool3d_with_indices_out_cpu_template(
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
     "max_pool3d: kernel_size must either be a single int, or a tuple of three ints")
-  const int kT = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
-  const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
+  const int kT = c10::safe_conv<int>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[2]);
 
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 3,
     "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
-  const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
+  const int dT = stride.empty() ? kT : c10::safe_conv<int>(stride[0]);
   const int dH = stride.empty() ? kH :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[1]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[2], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[2]);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 3,
     "max_pool3d: padding must either be a single int, or a tuple of three ints");
-  const int pT = c10::checked_convert<int>(padding[0], "int");
-  const int pH = padding.size() == 1 ? pT : c10::checked_convert<int>(padding[1], "int");
-  const int pW = padding.size() == 1 ? pT : c10::checked_convert<int>(padding[2], "int");
+  const int pT = c10::safe_conv<int>(padding[0]);
+  const int pH = padding.size() == 1 ? pT : c10::safe_conv<int>(padding[1]);
+  const int pW = padding.size() == 1 ? pT : c10::safe_conv<int>(padding[2]);
 
   TORCH_CHECK(dilation.size() == 1 || dilation.size() == 3,
     "max_pool3d: dilation must be either a single int, or a tuple of three ints");
-  const int dilationT = c10::checked_convert<int>(dilation[0], "int");
-  const int dilationH = dilation.size() == 1 ? dilationT : c10::checked_convert<int>(dilation[1], "int");
-  const int dilationW = dilation.size() == 1 ? dilationT : c10::checked_convert<int>(dilation[2], "int");
+  const int dilationT = c10::safe_conv<int>(dilation[0]);
+  const int dilationH = dilation.size() == 1 ? dilationT : c10::safe_conv<int>(dilation[1]);
+  const int dilationW = dilation.size() == 1 ? dilationT : c10::safe_conv<int>(dilation[2]);
 
   const auto memory_format = input.suggest_memory_format();
   if (memory_format == at::MemoryFormat::ChannelsLast3d) {
@@ -122,29 +123,29 @@ Tensor& max_pool3d_with_indices_backward_out_cpu_template(
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
     "max_pool3d: kernel_size must either be a single int, or a tuple of three ints")
-  const int kT = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
-  const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
+  const int kT = c10::safe_conv<int>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[2]);
 
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 3,
     "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
-  const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
+  const int dT = stride.empty() ? kT : c10::safe_conv<int>(stride[0]);
   const int dH = stride.empty() ? kH :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[1]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[2], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[2]);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 3,
     "max_pool3d: padding must either be a single int, or a tuple of three ints");
-  const int pT = c10::checked_convert<int>(padding[0], "int");
-  const int pH = padding.size() == 1 ? pT : c10::checked_convert<int>(padding[1], "int");
-  const int pW = padding.size() == 1 ? pT : c10::checked_convert<int>(padding[2], "int");
+  const int pT = c10::safe_conv<int>(padding[0]);
+  const int pH = padding.size() == 1 ? pT : c10::safe_conv<int>(padding[1]);
+  const int pW = padding.size() == 1 ? pT : c10::safe_conv<int>(padding[2]);
 
   TORCH_CHECK(dilation.size() == 1 || dilation.size() == 3,
     "max_pool3d: dilation must be either a single int, or a tuple of three ints");
-  const int dilationT = c10::checked_convert<int>(dilation[0], "int");
-  const int dilationH = dilation.size() == 1 ? dilationT : c10::checked_convert<int>(dilation[1], "int");
-  const int dilationW = dilation.size() == 1 ? dilationT : c10::checked_convert<int>(dilation[2], "int");
+  const int dilationT = c10::safe_conv<int>(dilation[0]);
+  const int dilationH = dilation.size() == 1 ? dilationT : c10::safe_conv<int>(dilation[1]);
+  const int dilationW = dilation.size() == 1 ? dilationT : c10::safe_conv<int>(dilation[2]);
 
   TORCH_CHECK(input.dtype() == gradOutput.dtype(),
     "expected dtype ", input.dtype(), " for `gradOutput` but got dtype ", gradOutput.dtype());

--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -4,6 +4,7 @@
 #include <ATen/native/DispatchStub.h>
 #include <c10/util/TypeCast.h>
 #include <c10/util/irange.h>
+#include <c10/util/safe_conv.h>
 
 #include <utility>
 
@@ -48,11 +49,13 @@ DECLARE_DISPATCH(max_pool3d_fn, max_pool3d_kernel)
 DECLARE_DISPATCH(max_pool3d_backward_fn, max_pool3d_backward_kernel)
 namespace {
 
+// Deprecated: use c10::safe_conv directly. Retained as a thin alias for
+// out-of-tree callers (e.g. third_party/torch-xpu-ops) that still reference
+// safe_downcast.
 template <typename dest_t, typename src_t>
-inline dest_t
-safe_downcast(src_t v)
-{
-  return c10::checked_convert<dest_t>(v, "dest_t");
+[[deprecated("use c10::safe_conv instead")]] inline dest_t safe_downcast(
+    src_t v) {
+  return c10::safe_conv<dest_t>(v);
 }
 
 template<typename T>

--- a/aten/src/ATen/native/cuda/AveragePool2d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool2d.cu
@@ -5,6 +5,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/Pool.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/util/safe_conv.h>
 #include <ATen/cuda/detail/TensorInfo.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/detail/KernelUtils.h>
@@ -257,14 +258,14 @@ TORCH_IMPL_FUNC(avg_pool2d_out_cuda)
 
   checkAllSameGPU("avg_pool2d_out_cuda", {output_arg, input_arg});
 
-  const int kH = c10::checked_convert<int>(kH_, "int");
-  const int kW = c10::checked_convert<int>(kW_, "int");
+  const int kH = c10::safe_conv<int>(kH_);
+  const int kW = c10::safe_conv<int>(kW_);
 
-  const int dH = c10::checked_convert<int>(dH_, "int");
-  const int dW = c10::checked_convert<int>(dW_, "int");
+  const int dH = c10::safe_conv<int>(dH_);
+  const int dW = c10::safe_conv<int>(dW_);
 
-  const int padH = c10::checked_convert<int>(padH_, "int");
-  const int padW = c10::checked_convert<int>(padW_, "int");
+  const int padH = c10::safe_conv<int>(padH_);
+  const int padW = c10::safe_conv<int>(padW_);
 
   /* sizes */
   const int64_t nInputPlane = input_.size(-3);
@@ -277,7 +278,7 @@ TORCH_IMPL_FUNC(avg_pool2d_out_cuda)
 
   Tensor input = input_.contiguous(memory_format);
 
-  const auto count = c10::checked_convert<int32_t>(output.numel(), "int32_t");
+  const auto count = c10::safe_conv<int32_t>(output.numel());
   const uint32_t num_threads = std::min(at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
   const uint32_t num_blocks = ceil_div<uint32_t>(count, num_threads);
 
@@ -372,15 +373,15 @@ TORCH_IMPL_FUNC(avg_pool2d_backward_out_cuda) (
   checkAllSameGPU("avg_pool2d_backward_out_cuda",
                   {gradInput_arg, gradOutput_arg, input_arg});
 
-  const int kH = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kW = kernel_size.size() == 1 ? kH : c10::checked_convert<int>(kernel_size[1], "int");
+  const int kH = c10::safe_conv<int>(kernel_size[0]);
+  const int kW = kernel_size.size() == 1 ? kH : c10::safe_conv<int>(kernel_size[1]);
 
-  const int dH = stride.empty() ? kH : c10::checked_convert<int>(stride[0], "int");
+  const int dH = stride.empty() ? kH : c10::safe_conv<int>(stride[0]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dH : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dH : c10::safe_conv<int>(stride[1]);
 
-  const int padH = c10::checked_convert<int>(padding[0], "int");
-  const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
+  const int padH = c10::safe_conv<int>(padding[0]);
+  const int padW = padding.size() == 1 ? padH : c10::safe_conv<int>(padding[1]);
 
   const auto memory_format = input_.suggest_memory_format();
   const Tensor input = input_.contiguous(memory_format);

--- a/aten/src/ATen/native/cuda/AveragePool3d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool3d.cu
@@ -5,6 +5,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/Pool.h>
 #include <ATen/cuda/Atomic.cuh>
+#include <c10/util/safe_conv.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/TensorInfo.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
@@ -359,19 +360,19 @@ TORCH_IMPL_FUNC(avg_pool3d_out_cuda) (
 
   checkAllSameGPU(__func__, {output_arg, input_arg});
 
-  const int kT = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
-  const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
+  const int kT = c10::safe_conv<int>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[2]);
 
-  const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
+  const int dT = stride.empty() ? kT : c10::safe_conv<int>(stride[0]);
   const int dH = stride.empty() ? kH :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[1]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[2], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[2]);
 
-  const int padT = c10::checked_convert<int>(padding[0], "int");
-  const int padH = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[1], "int");
-  const int padW = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[2], "int");
+  const int padT = c10::safe_conv<int>(padding[0]);
+  const int padH = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[1]);
+  const int padW = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[2]);
 
   // if divisor==0 then we will ignore it
   int64_t divisor = 0;
@@ -465,19 +466,19 @@ TORCH_IMPL_FUNC(avg_pool3d_backward_out_cuda) (
   checkAllSameGPU(__func__,
                   {gradInput_arg, gradOutput_arg, input_arg});
 
-  const int kT = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
-  const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
+  const int kT = c10::safe_conv<int>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[2]);
 
-  const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
+  const int dT = stride.empty() ? kT : c10::safe_conv<int>(stride[0]);
   const int dH = stride.empty() ? kH :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[1]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[2], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[2]);
 
-  const int padT = c10::checked_convert<int>(padding[0], "int");
-  const int padH = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[1], "int");
-  const int padW = padding.size() == 1 ? padT : c10::checked_convert<int>(padding[2], "int");
+  const int padT = c10::safe_conv<int>(padding[0]);
+  const int padH = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[1]);
+  const int padW = padding.size() == 1 ? padT : c10::safe_conv<int>(padding[2]);
 
   TORCH_CHECK((gradOutput.ndimension() == 4 || gradOutput.ndimension() == 5),
     "non-empty 4D or 5D (batch mode) tensor expected for gradOutput");

--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -6,6 +6,7 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/native/Pool.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/util/safe_conv.h>
 #include <ATen/cuda/NumericLimits.cuh>
 #include <ATen/cuda/detail/TensorInfo.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
@@ -466,18 +467,18 @@ const Tensor& indices) {
     return;
   }
 
-  const int kH = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kW = kernel_size.size() == 1 ? kH : c10::checked_convert<int>(kernel_size[1], "int");
+  const int kH = c10::safe_conv<int>(kernel_size[0]);
+  const int kW = kernel_size.size() == 1 ? kH : c10::safe_conv<int>(kernel_size[1]);
 
-  const int dH = stride.empty() ? kH : c10::checked_convert<int>(stride[0], "int");
+  const int dH = stride.empty() ? kH : c10::safe_conv<int>(stride[0]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dH : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dH : c10::safe_conv<int>(stride[1]);
 
-  const int padH = c10::checked_convert<int>(padding[0], "int");
-  const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
+  const int padH = c10::safe_conv<int>(padding[0]);
+  const int padW = padding.size() == 1 ? padH : c10::safe_conv<int>(padding[1]);
 
-  const int dilationH = c10::checked_convert<int>(dilation[0], "int");
-  const int dilationW = dilation.size() == 1 ? dilationH : c10::checked_convert<int>(dilation[1], "int");
+  const int dilationH = c10::safe_conv<int>(dilation[0]);
+  const int dilationW = dilation.size() == 1 ? dilationH : c10::safe_conv<int>(dilation[1]);
 
   const auto memory_format = input_.suggest_memory_format();
 
@@ -526,17 +527,17 @@ const Tensor& indices) {
               in_stride_n, in_stride_c, in_stride_h, in_stride_w);
 
           int kernel_stride_C = ceil_div(
-              c10::checked_convert<int>(nInputPlane, "int"), block_x * 4);
+              c10::safe_conv<int>(nInputPlane), block_x * 4);
           int kernel_size_C = ceil_div(
-              c10::checked_convert<int>(nInputPlane, "int"), block_x * kernel_stride_C);
+              c10::safe_conv<int>(nInputPlane), block_x * kernel_stride_C);
 
           int grid_x = nbatch*kernel_stride_C;
           int grid_y = std::min<int>(
               at::cuda::getCurrentDeviceProperties()->maxGridSize[1],
-              ceil_div(c10::checked_convert<int>(outputWidth, "int"), block_y*BLOCK_STRIDE_FWD));
+              ceil_div(c10::safe_conv<int>(outputWidth), block_y*BLOCK_STRIDE_FWD));
           int grid_z = std::min<int>(
               at::cuda::getCurrentDeviceProperties()->maxGridSize[2],
-              ceil_div(c10::checked_convert<int>(outputHeight, "int"), block_z*BLOCK_STRIDE_FWD));
+              ceil_div(c10::safe_conv<int>(outputHeight), block_z*BLOCK_STRIDE_FWD));
           const dim3 grid(grid_x, grid_y, grid_z);
 
           size_t shmem_size;
@@ -645,18 +646,18 @@ const Tensor& gradInput) {
     return;
   }
 
-  const int kH = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kW = kernel_size.size() == 1 ? kH : c10::checked_convert<int>(kernel_size[1], "int");
+  const int kH = c10::safe_conv<int>(kernel_size[0]);
+  const int kW = kernel_size.size() == 1 ? kH : c10::safe_conv<int>(kernel_size[1]);
 
-  const int dH = stride.empty() ? kH : c10::checked_convert<int>(stride[0], "int");
+  const int dH = stride.empty() ? kH : c10::safe_conv<int>(stride[0]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dH : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dH : c10::safe_conv<int>(stride[1]);
 
-  const int padH = c10::checked_convert<int>(padding[0], "int");
-  const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
+  const int padH = c10::safe_conv<int>(padding[0]);
+  const int padW = padding.size() == 1 ? padH : c10::safe_conv<int>(padding[1]);
 
-  const int dilationH = c10::checked_convert<int>(dilation[0], "int");
-  const int dilationW = dilation.size() == 1 ? dilationH : c10::checked_convert<int>(dilation[1], "int");
+  const int dilationH = c10::safe_conv<int>(dilation[0]);
+  const int dilationW = dilation.size() == 1 ? dilationH : c10::safe_conv<int>(dilation[1]);
 
   const auto memory_format = input_.suggest_memory_format();
 
@@ -704,17 +705,17 @@ const Tensor& gradInput) {
           const dim3 block(block_x, block_y, block_z);
 
           int kernel_stride_C = ceil_div(
-              c10::checked_convert<int>(nInputPlane, "int"), block_x * 4);
+              c10::safe_conv<int>(nInputPlane), block_x * 4);
           int kernel_size_C = ceil_div(
-              c10::checked_convert<int>(nInputPlane, "int"), block_x * kernel_stride_C);
+              c10::safe_conv<int>(nInputPlane), block_x * kernel_stride_C);
 
           int grid_x = nbatch*kernel_stride_C;
           int grid_y = std::min<int>(
               at::cuda::getCurrentDeviceProperties()->maxGridSize[1],
-              ceil_div(c10::checked_convert<int>(inputWidth, "int"), block_y*BLOCK_STRIDE_BWD));
+              ceil_div(c10::safe_conv<int>(inputWidth), block_y*BLOCK_STRIDE_BWD));
           int grid_z = std::min<int>(
               at::cuda::getCurrentDeviceProperties()->maxGridSize[2],
-              ceil_div(c10::checked_convert<int>(inputHeight, "int"), block_z*BLOCK_STRIDE_BWD));
+              ceil_div(c10::safe_conv<int>(inputHeight), block_z*BLOCK_STRIDE_BWD));
           const dim3 grid(grid_x, grid_y, grid_z);
 
           size_t shmem_size = (kernel_size_C * block_x*block_y*block_z) * sizeof(accscalar_t);

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -6,6 +6,7 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/native/Pool.h>
 #include <ATen/cuda/Atomic.cuh>
+#include <c10/util/safe_conv.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/NumericLimits.cuh>
 #include <ATen/cuda/detail/TensorInfo.cuh>
@@ -299,29 +300,29 @@ void max_pool3d_with_indices_out_cuda_template(
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
     "max_pool3d: kernel_size must either be a single int, or a tuple of three ints")
-  const int kT = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
-  const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
+  const int kT = c10::safe_conv<int>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[2]);
 
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 3,
     "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
-  const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
+  const int dT = stride.empty() ? kT : c10::safe_conv<int>(stride[0]);
   const int dH = stride.empty() ? kH :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[1]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[2], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[2]);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 3,
     "max_pool3d: padding must either be a single int, or a tuple of three ints");
-  const int pT = c10::checked_convert<int>(padding[0], "int");
-  const int pH = padding.size() == 1 ? pT : c10::checked_convert<int>(padding[1], "int");
-  const int pW = padding.size() == 1 ? pT : c10::checked_convert<int>(padding[2], "int");
+  const int pT = c10::safe_conv<int>(padding[0]);
+  const int pH = padding.size() == 1 ? pT : c10::safe_conv<int>(padding[1]);
+  const int pW = padding.size() == 1 ? pT : c10::safe_conv<int>(padding[2]);
 
   TORCH_CHECK(dilation.size() == 1 || dilation.size() == 3,
     "max_pool3d: dilation must be either a single int, or a tuple of three ints");
-  const int dilationT = c10::checked_convert<int>(dilation[0], "int");
-  const int dilationH = dilation.size() == 1 ? dilationT : c10::checked_convert<int>(dilation[1], "int");
-  const int dilationW = dilation.size() == 1 ? dilationT : c10::checked_convert<int>(dilation[2], "int");
+  const int dilationT = c10::safe_conv<int>(dilation[0]);
+  const int dilationH = dilation.size() == 1 ? dilationT : c10::safe_conv<int>(dilation[1]);
+  const int dilationW = dilation.size() == 1 ? dilationT : c10::safe_conv<int>(dilation[2]);
 
   const int64_t nbatch = input.ndimension() == 5 ? input.size(-5) : 1;
   const int64_t nslices = input.size(-4);
@@ -429,29 +430,29 @@ void max_pool3d_with_indices_backward_out_cuda_template(
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
     "max_pool3d: kernel_size must either be a single int, or a tuple of three ints")
-  const int kT = c10::checked_convert<int>(kernel_size[0], "int");
-  const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
-  const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
+  const int kT = c10::safe_conv<int>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : c10::safe_conv<int>(kernel_size[2]);
 
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 3,
     "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
-  const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
+  const int dT = stride.empty() ? kT : c10::safe_conv<int>(stride[0]);
   const int dH = stride.empty() ? kH :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[1], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[1]);
   const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dT : c10::checked_convert<int>(stride[2], "int");
+                 stride.size() == 1 ? dT : c10::safe_conv<int>(stride[2]);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 3,
     "max_pool3d: padding must either be a single int, or a tuple of three ints");
-  const int pT = c10::checked_convert<int>(padding[0], "int");
-  const int pH = padding.size() == 1 ? pT : c10::checked_convert<int>(padding[1], "int");
-  const int pW = padding.size() == 1 ? pT : c10::checked_convert<int>(padding[2], "int");
+  const int pT = c10::safe_conv<int>(padding[0]);
+  const int pH = padding.size() == 1 ? pT : c10::safe_conv<int>(padding[1]);
+  const int pW = padding.size() == 1 ? pT : c10::safe_conv<int>(padding[2]);
 
   TORCH_CHECK(dilation.size() == 1 || dilation.size() == 3,
     "max_pool3d: dilation must be either a single int, or a tuple of three ints");
-  const int dilationT = c10::checked_convert<int>(dilation[0], "int");
-  const int dilationH = dilation.size() == 1 ? dilationT : c10::checked_convert<int>(dilation[1], "int");
-  const int dilationW = dilation.size() == 1 ? dilationT : c10::checked_convert<int>(dilation[2], "int");
+  const int dilationT = c10::safe_conv<int>(dilation[0]);
+  const int dilationH = dilation.size() == 1 ? dilationT : c10::safe_conv<int>(dilation[1]);
+  const int dilationW = dilation.size() == 1 ? dilationT : c10::safe_conv<int>(dilation[2]);
 
   TORCH_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
     "max_pool2d_with_indices_backward_out_cuda_template(): ",

--- a/aten/src/ATen/native/mps/kernels/GridSampler.h
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.h
@@ -18,6 +18,7 @@ enum class GridSamplerPadding : int32_t {
 #else
 #include <ATen/native/GridSamplerUtils.h>
 #include <ATen/native/Pool.h>
+#include <c10/util/safe_conv.h>
 using at::native::GridSamplerInterpolation;
 using at::native::GridSamplerPadding;
 #endif
@@ -41,17 +42,12 @@ struct GridSamplerParams {
       bool align_corners_)
       : sampler_dims(N - 2), align_corners(align_corners_) {
     for (unsigned dim = 0; dim < N; dim++) {
-      output_sizes[dim] =
-          c10::checked_convert<idx_t>(output.size(dim), "int32_t");
-      output_strides[dim] =
-          c10::checked_convert<idx_t>(output.stride(dim), "int32_t");
-      input_sizes[dim] =
-          c10::checked_convert<idx_t>(input.size(dim), "int32_t");
-      input_strides[dim] =
-          c10::checked_convert<idx_t>(input.stride(dim), "int32_t");
-      grid_sizes[dim] = c10::checked_convert<idx_t>(grid.size(dim), "int32_t");
-      grid_strides[dim] =
-          c10::checked_convert<idx_t>(grid.stride(dim), "int32_t");
+      output_sizes[dim] = c10::safe_conv<idx_t>(output.size(dim));
+      output_strides[dim] = c10::safe_conv<idx_t>(output.stride(dim));
+      input_sizes[dim] = c10::safe_conv<idx_t>(input.size(dim));
+      input_strides[dim] = c10::safe_conv<idx_t>(input.stride(dim));
+      grid_sizes[dim] = c10::safe_conv<idx_t>(grid.size(dim));
+      grid_strides[dim] = c10::safe_conv<idx_t>(grid.stride(dim));
     }
   }
 #endif
@@ -85,13 +81,11 @@ struct GridSamplerBackwardParams {
         compute_grad_grid(
             interpolation_mode_ != GridSamplerInterpolation::Nearest) {
     for (unsigned dim = 0; dim < N; dim++) {
-      grad_output_strides[dim] =
-          c10::checked_convert<idx_t>(grad_output.stride(dim), "int32_t");
+      grad_output_strides[dim] = c10::safe_conv<idx_t>(grad_output.stride(dim));
       grad_input_strides[dim] = grad_input.defined()
-          ? c10::checked_convert<idx_t>(grad_input.stride(dim), "int32_t")
+          ? c10::safe_conv<idx_t>(grad_input.stride(dim))
           : 0;
-      grad_grid_strides[dim] =
-          c10::checked_convert<idx_t>(grad_grid.stride(dim), "int32_t");
+      grad_grid_strides[dim] = c10::safe_conv<idx_t>(grad_grid.stride(dim));
     }
   }
 #endif

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -8,6 +8,7 @@
 #include <ATen/native/TensorFactories.h>
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <c10/util/safe_conv.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -95,7 +96,7 @@ static void distribution_kernel_mps_impl(TensorIteratorBase& iter,
   // After `with_32bit_indexing` decomposition `iter.numel()` fits in uint32,
   // but `checked_convert` keeps us honest if anything ever reaches the kernel
   // with a count that would silently truncate.
-  const uint32_t numel = c10::checked_convert<uint32_t>(iter.numel(), "uint32_t");
+  const uint32_t numel = c10::safe_conv<uint32_t>(iter.numel());
   const int64_t threads = at::ceil_div<int64_t>(numel, elements_per_thread);
 
   auto mps_gen = get_generator_or_default<MPSGeneratorImpl>(gen, at::mps::detail::getDefaultMPSGenerator());
@@ -189,7 +190,7 @@ static Tensor& bernoulli_tensor_mps_impl(Tensor& self, const Tensor& p_, std::op
       @autoreleasepool {
         auto computeEncoder = stream->commandEncoder();
         [computeEncoder setComputePipelineState:pso];
-        const auto numel = c10::checked_convert<uint32_t>(output.numel(), "uint32_t");
+        const auto numel = c10::safe_conv<uint32_t>(output.numel());
         mtl_setArgs(
             computeEncoder, output, p_float, std::array<long, 2>{seed, base_offset}, numel, stream->getErrorBuffer());
         mtl_dispatch1DJob(computeEncoder, pso, at::ceil_div(numel, 4u));

--- a/aten/src/ATen/native/mps/operations/Embedding.mm
+++ b/aten/src/ATen/native/mps/operations/Embedding.mm
@@ -4,6 +4,7 @@
 #include <ATen/native/Pool.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/Embedding.h>
+#include <c10/util/safe_conv.h>
 
 #include <fmt/format.h>
 
@@ -66,11 +67,11 @@ Tensor embedding_dense_backward_mps(const Tensor& grad_,
   EmbeddingDenseBackwardParams<uint32_t> params{};
   params.outer_ndim = static_cast<uint32_t>(outer_ndim);
   for (auto d = 0; d < outer_ndim; ++d) {
-    params.outer_sizes[d] = safe_downcast<uint32_t, int64_t>(indices.size(d));
-    params.indices_strides[d] = safe_downcast<uint32_t, int64_t>(indices.stride(d));
-    params.grad_outer_strides[d] = safe_downcast<uint32_t, int64_t>(grad_.stride(d));
+    params.outer_sizes[d] = c10::safe_conv<uint32_t, int64_t>(indices.size(d));
+    params.indices_strides[d] = c10::safe_conv<uint32_t, int64_t>(indices.stride(d));
+    params.grad_outer_strides[d] = c10::safe_conv<uint32_t, int64_t>(grad_.stride(d));
   }
-  params.grad_feature_stride = safe_downcast<uint32_t, int64_t>(grad_.stride(-1));
+  params.grad_feature_stride = c10::safe_conv<uint32_t, int64_t>(grad_.stride(-1));
   params.feature_size = static_cast<uint32_t>(D);
   params.padding_idx = padding_idx;
   params.scale_grad_by_freq = scale_grad_by_freq;

--- a/aten/src/ATen/native/mps/operations/EmbeddingBag.mm
+++ b/aten/src/ATen/native/mps/operations/EmbeddingBag.mm
@@ -6,6 +6,7 @@
 #include <ATen/native/Pool.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/EmbeddingBag.h>
+#include <c10/util/safe_conv.h>
 
 #include <fmt/format.h>
 
@@ -88,11 +89,11 @@ static std::tuple<Tensor, Tensor, Tensor, Tensor> _embedding_bag_mps_impl(
   EmbeddingBagParams<uint32_t> params;
 
   for (const auto dim : c10::irange(weight.dim())) {
-    params.weight_strides[dim] = safe_downcast<uint32_t, int64_t>(weight.stride(dim));
-    params.output_strides[dim] = safe_downcast<uint32_t, int64_t>(output.stride(dim));
+    params.weight_strides[dim] = c10::safe_conv<uint32_t>(weight.stride(dim));
+    params.output_strides[dim] = c10::safe_conv<uint32_t>(output.stride(dim));
 
     if (mode == EmbeddingBagMode::MAX) {
-      params.max_indices_strides[dim] = safe_downcast<uint32_t, int64_t>(max_indices.stride(dim));
+      params.max_indices_strides[dim] = c10::safe_conv<uint32_t>(max_indices.stride(dim));
     }
   }
 
@@ -207,7 +208,7 @@ Tensor _embedding_bag_dense_backward_mps(const Tensor& output_grad,
     params.weight_grad_strides[dim] = weight_grad.stride(dim);
 
     if (mode == EmbeddingBagMode::MAX) {
-      params.max_indices_strides[dim] = safe_downcast<uint32_t, int64_t>(max_indices.stride(dim));
+      params.max_indices_strides[dim] = c10::safe_conv<uint32_t>(max_indices.stride(dim));
     }
   }
 

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -59,6 +59,7 @@
 #endif
 
 #include <c10/util/env.h>
+#include <c10/util/safe_conv.h>
 #include <algorithm>
 #include <string>
 #include <string_view>
@@ -1653,9 +1654,9 @@ static void unpack_pivots_stub_impl(TensorIterator& iter, const int64_t dim_size
   MPSStream* stream = getCurrentMPSStream();
 
   UnpackPivotsParams params;
-  params.perm_batch_stride = safe_downcast<uint32_t, int64_t>((perm.dim() > 1) ? perm.stride(-2) : 0);
-  params.pivots_batch_stride = safe_downcast<uint32_t, int64_t>((pivots.dim() > 1) ? pivots.stride(-2) : 0);
-  params.dim_size = safe_downcast<uint32_t, int64_t>(dim_size);
+  params.perm_batch_stride = c10::safe_conv<uint32_t, int64_t>((perm.dim() > 1) ? perm.stride(-2) : 0);
+  params.pivots_batch_stride = c10::safe_conv<uint32_t, int64_t>((pivots.dim() > 1) ? pivots.stride(-2) : 0);
+  params.dim_size = c10::safe_conv<uint32_t, int64_t>(dim_size);
 
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -2,6 +2,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <c10/util/safe_conv.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -355,14 +356,12 @@ static void replication_pad1d_kernel_mps(const Tensor& input_, IntArrayRef paddi
   }
   TORCH_INTERNAL_ASSERT(input.dim() == 3 && output_c.dim() == 3);
 
-  const auto nbatch = c10::checked_convert<int32_t>(input.size(0), "int32_t");
-  const auto nplane = c10::checked_convert<int32_t>(input.size(1), "int32_t");
-  const auto input_W = c10::checked_convert<int32_t>(input.size(2), "int32_t");
-  const auto output_W = c10::checked_convert<int32_t>(output_c.size(2), "int32_t");
-  const std::array<int32_t, 4> sizes_pad = {input_W,
-                                            output_W,
-                                            c10::checked_convert<int32_t>(padding[0], "int32_t"),
-                                            c10::checked_convert<int32_t>(padding[1], "int32_t")};
+  const auto nbatch = c10::safe_conv<int32_t>(input.size(0));
+  const auto nplane = c10::safe_conv<int32_t>(input.size(1));
+  const auto input_W = c10::safe_conv<int32_t>(input.size(2));
+  const auto output_W = c10::safe_conv<int32_t>(output_c.size(2));
+  const std::array<int32_t, 4> sizes_pad = {
+      input_W, output_W, c10::safe_conv<int32_t>(padding[0]), c10::safe_conv<int32_t>(padding[1])};
 
   auto pso = lib.getPipelineStateForFunc("replication_pad1d_forward_" + scalarToMetalTypeString(input));
   auto stream = getCurrentMPSStream();
@@ -399,14 +398,12 @@ static void replication_pad1d_backward_kernel_mps(const Tensor& grad_output_,
   }
   TORCH_INTERNAL_ASSERT(grad_output.dim() == 3 && grad_input_c.dim() == 3);
 
-  const auto nbatch = c10::checked_convert<int32_t>(grad_input_c.size(0), "int32_t");
-  const auto nplane = c10::checked_convert<int32_t>(grad_input_c.size(1), "int32_t");
-  const auto input_W = c10::checked_convert<int32_t>(grad_input_c.size(2), "int32_t");
-  const auto output_W = c10::checked_convert<int32_t>(grad_output.size(2), "int32_t");
-  const std::array<int32_t, 4> sizes_pad = {input_W,
-                                            output_W,
-                                            c10::checked_convert<int32_t>(padding[0], "int32_t"),
-                                            c10::checked_convert<int32_t>(padding[1], "int32_t")};
+  const auto nbatch = c10::safe_conv<int32_t>(grad_input_c.size(0));
+  const auto nplane = c10::safe_conv<int32_t>(grad_input_c.size(1));
+  const auto input_W = c10::safe_conv<int32_t>(grad_input_c.size(2));
+  const auto output_W = c10::safe_conv<int32_t>(grad_output.size(2));
+  const std::array<int32_t, 4> sizes_pad = {
+      input_W, output_W, c10::safe_conv<int32_t>(padding[0]), c10::safe_conv<int32_t>(padding[1])};
 
   auto pso = lib.getPipelineStateForFunc("replication_pad1d_backward_" + scalarToMetalTypeString(grad_input_c));
   auto stream = getCurrentMPSStream();

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -4,6 +4,7 @@
 #include <ATen/native/Pool.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/Pooling.h>
+#include <c10/util/safe_conv.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -100,14 +101,14 @@ static void pool2d_template(const Tensor& input,
     TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
   }
 
-  int padH = safe_downcast<int, int64_t>(padding[0]);
-  int padW = padding.size() == 1 ? padH : safe_downcast<int, int64_t>(padding[1]);
-  const int kH = safe_downcast<int, int64_t>(kernel_size[0]);
-  const int kW = kernel_size.size() == 1 ? kH : safe_downcast<int, int64_t>(kernel_size[1]);
-  const int dH = stride.empty() ? kH : safe_downcast<int, int64_t>(stride[0]);
-  const int dW = stride.empty() ? kW : stride.size() == 1 ? dH : safe_downcast<int, int64_t>(stride[1]);
-  const int dilationH = safe_downcast<int, int64_t>(dilation[0]);
-  const int dilationW = dilation.size() == 1 ? dilationH : safe_downcast<int, int64_t>(dilation[1]);
+  int padH = c10::safe_conv<int, int64_t>(padding[0]);
+  int padW = padding.size() == 1 ? padH : c10::safe_conv<int, int64_t>(padding[1]);
+  const int kH = c10::safe_conv<int, int64_t>(kernel_size[0]);
+  const int kW = kernel_size.size() == 1 ? kH : c10::safe_conv<int, int64_t>(kernel_size[1]);
+  const int dH = stride.empty() ? kH : c10::safe_conv<int, int64_t>(stride[0]);
+  const int dW = stride.empty() ? kW : stride.size() == 1 ? dH : c10::safe_conv<int, int64_t>(stride[1]);
+  const int dilationH = c10::safe_conv<int, int64_t>(dilation[0]);
+  const int dilationW = dilation.size() == 1 ? dilationH : c10::safe_conv<int, int64_t>(dilation[1]);
   const int64_t nbatch = ndims == 4 ? input.size(-4) : 1;
   const int64_t nInputPlane = input.size(-3);
   const int64_t inputHeight = input.size(-2);
@@ -270,7 +271,7 @@ static void pool2d_template(const Tensor& input,
 static std::vector<int32_t> copy_and_maybe_expand(IntArrayRef a, int32_t pooling_dims) {
   std::vector<int32_t> b(pooling_dims);
   for (const auto dim : c10::irange(pooling_dims)) {
-    b[dim] = safe_downcast<int32_t, int64_t>(a[a.size() == 1 ? 0 : dim]);
+    b[dim] = c10::safe_conv<int32_t, int64_t>(a[a.size() == 1 ? 0 : dim]);
   }
   return b;
 }
@@ -455,13 +456,13 @@ static void fill_pool_size_strides(PoolingParams<5>& params,
                                    const std::optional<Tensor>& indices_opt) {
   const Tensor& indices = *(at::borrow_from_optional_tensor(indices_opt));
   for (const auto dim : c10::irange(input.dim())) {
-    params.input_sizes[dim] = safe_downcast<int32_t, int64_t>(input.size(dim));
-    params.input_strides[dim] = safe_downcast<int32_t, int64_t>(input.stride(dim));
-    params.output_sizes[dim] = safe_downcast<int32_t, int64_t>(output.size(dim));
-    params.output_strides[dim] = safe_downcast<int32_t, int64_t>(output.stride(dim));
+    params.input_sizes[dim] = c10::safe_conv<int32_t, int64_t>(input.size(dim));
+    params.input_strides[dim] = c10::safe_conv<int32_t, int64_t>(input.stride(dim));
+    params.output_sizes[dim] = c10::safe_conv<int32_t, int64_t>(output.size(dim));
+    params.output_strides[dim] = c10::safe_conv<int32_t, int64_t>(output.stride(dim));
     if (indices.defined()) {
-      params.indices_sizes[dim] = safe_downcast<int32_t, int64_t>(indices.size(dim));
-      params.indices_strides[dim] = safe_downcast<int32_t, int64_t>(indices.stride(dim));
+      params.indices_sizes[dim] = c10::safe_conv<int32_t, int64_t>(indices.size(dim));
+      params.indices_strides[dim] = c10::safe_conv<int32_t, int64_t>(indices.stride(dim));
     }
   }
 }
@@ -579,11 +580,11 @@ static void max_pool_backward_out_mps_template(Tensor& grad_input,
   params.pooling_dims = pooling_dims;
 
   for (const auto dim : c10::irange(dims)) {
-    params.grad_input_sizes[dim] = safe_downcast<int32_t, int64_t>(grad_input.size(dim));
-    params.grad_input_strides[dim] = safe_downcast<int32_t, int64_t>(grad_input.stride(dim));
-    params.grad_output_sizes[dim] = safe_downcast<int32_t, int64_t>(grad_output.size(dim));
-    params.grad_output_strides[dim] = safe_downcast<int32_t, int64_t>(grad_output.stride(dim));
-    params.indices_strides[dim] = safe_downcast<int32_t, int64_t>(indices.stride(dim));
+    params.grad_input_sizes[dim] = c10::safe_conv<int32_t, int64_t>(grad_input.size(dim));
+    params.grad_input_strides[dim] = c10::safe_conv<int32_t, int64_t>(grad_input.stride(dim));
+    params.grad_output_sizes[dim] = c10::safe_conv<int32_t, int64_t>(grad_output.size(dim));
+    params.grad_output_strides[dim] = c10::safe_conv<int32_t, int64_t>(grad_output.stride(dim));
+    params.indices_strides[dim] = c10::safe_conv<int32_t, int64_t>(indices.stride(dim));
   }
 
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
@@ -684,11 +685,11 @@ static void max_unpool_out_mps_template(const Tensor& input,
   params.pooling_dims = pooling_dims;
 
   for (const auto dim : c10::irange(dims)) {
-    params.output_sizes[dim] = safe_downcast<int32_t, int64_t>(output.size(dim));
-    params.output_strides[dim] = safe_downcast<int32_t, int64_t>(output.stride(dim));
-    params.input_sizes[dim] = safe_downcast<int32_t, int64_t>(input.size(dim));
-    params.input_strides[dim] = safe_downcast<int32_t, int64_t>(input.stride(dim));
-    params.indices_strides[dim] = safe_downcast<int32_t, int64_t>(indices.stride(dim));
+    params.output_sizes[dim] = c10::safe_conv<int32_t, int64_t>(output.size(dim));
+    params.output_strides[dim] = c10::safe_conv<int32_t, int64_t>(output.stride(dim));
+    params.input_sizes[dim] = c10::safe_conv<int32_t, int64_t>(input.size(dim));
+    params.input_strides[dim] = c10::safe_conv<int32_t, int64_t>(input.stride(dim));
+    params.indices_strides[dim] = c10::safe_conv<int32_t, int64_t>(indices.stride(dim));
   }
 
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
@@ -856,14 +857,14 @@ static void avg_pool_out_mps_template(const Tensor& output,
   params.count_include_pad = count_include_pad;
   params.has_divisor_override = divisor_override.has_value();
   if (divisor_override.has_value()) {
-    params.divisor_override = safe_downcast<int32_t, int64_t>(divisor_override.value());
+    params.divisor_override = c10::safe_conv<int32_t, int64_t>(divisor_override.value());
   }
 
   for (const auto dim : c10::irange(dims)) {
-    params.input_sizes[dim] = safe_downcast<int32_t, int64_t>(input.size(dim));
-    params.input_strides[dim] = safe_downcast<int32_t, int64_t>(input.stride(dim));
-    params.output_sizes[dim] = safe_downcast<int32_t, int64_t>(output.size(dim));
-    params.output_strides[dim] = safe_downcast<int32_t, int64_t>(output.stride(dim));
+    params.input_sizes[dim] = c10::safe_conv<int32_t, int64_t>(input.size(dim));
+    params.input_strides[dim] = c10::safe_conv<int32_t, int64_t>(input.stride(dim));
+    params.output_sizes[dim] = c10::safe_conv<int32_t, int64_t>(output.size(dim));
+    params.output_strides[dim] = c10::safe_conv<int32_t, int64_t>(output.stride(dim));
   }
 
   memcpy(params.kernel_size.data(), kernel_size.data(), pooling_dims * sizeof(int32_t));
@@ -915,14 +916,14 @@ static void avg_pool_backward_out_mps_template(const Tensor& grad_input,
   params.count_include_pad = count_include_pad;
   params.has_divisor_override = divisor_override.has_value();
   if (divisor_override.has_value()) {
-    params.divisor_override = safe_downcast<int32_t, int64_t>(divisor_override.value());
+    params.divisor_override = c10::safe_conv<int32_t, int64_t>(divisor_override.value());
   }
 
   for (const auto dim : c10::irange(dims)) {
-    params.output_sizes[dim] = safe_downcast<int32_t, int64_t>(grad_output.size(dim));
-    params.output_strides[dim] = safe_downcast<int32_t, int64_t>(grad_output.stride(dim));
-    params.input_sizes[dim] = safe_downcast<int32_t, int64_t>(grad_input.size(dim));
-    params.input_strides[dim] = safe_downcast<int32_t, int64_t>(grad_input.stride(dim));
+    params.output_sizes[dim] = c10::safe_conv<int32_t, int64_t>(grad_output.size(dim));
+    params.output_strides[dim] = c10::safe_conv<int32_t, int64_t>(grad_output.stride(dim));
+    params.input_sizes[dim] = c10::safe_conv<int32_t, int64_t>(grad_input.size(dim));
+    params.input_strides[dim] = c10::safe_conv<int32_t, int64_t>(grad_input.stride(dim));
   }
 
   memcpy(params.kernel_size.data(), kernel_size.data(), pooling_dims * sizeof(int32_t));

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -11,6 +11,7 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/ReduceOps.h>
 #include <c10/util/irange.h>
+#include <c10/util/safe_conv.h>
 #include <algorithm>
 #include <bit>
 #include <numeric>
@@ -1188,12 +1189,12 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
       if (collapsed_ndim <= 2 || (collapsed_ndim == 3 && collapsed_dim == 1)) {
         const auto has_outer = collapsed_dim > 0;
         const auto has_inner = collapsed_dim < collapsed_ndim - 1;
-        const auto outer_size = has_outer ? safe_downcast<uint32_t, int64_t>(sizes[0]) : 1u;
-        const auto dim_size = safe_downcast<uint32_t, int64_t>(sizes[collapsed_dim]);
-        const auto inner_size = has_inner ? safe_downcast<uint32_t, int64_t>(sizes[collapsed_dim + 1]) : 1u;
-        const auto dim_stride = safe_downcast<uint32_t, int64_t>(strides[collapsed_dim]);
-        const auto inner_stride = has_inner ? safe_downcast<uint32_t, int64_t>(strides[collapsed_dim + 1]) : 0u;
-        const auto outer_stride = has_outer ? safe_downcast<uint32_t, int64_t>(strides[0]) : 0u;
+        const auto outer_size = has_outer ? c10::safe_conv<uint32_t, int64_t>(sizes[0]) : 1u;
+        const auto dim_size = c10::safe_conv<uint32_t, int64_t>(sizes[collapsed_dim]);
+        const auto inner_size = has_inner ? c10::safe_conv<uint32_t, int64_t>(sizes[collapsed_dim + 1]) : 1u;
+        const auto dim_stride = c10::safe_conv<uint32_t, int64_t>(strides[collapsed_dim]);
+        const auto inner_stride = has_inner ? c10::safe_conv<uint32_t, int64_t>(strides[collapsed_dim + 1]) : 0u;
+        const auto outer_stride = has_outer ? c10::safe_conv<uint32_t, int64_t>(strides[0]) : 0u;
         const auto natural_tgs = outer_size * c10::metal::ceil_div(inner_size, OUTER_TG_WIDTH);
         const auto use_small_dim = dim_size <= OUTER_SMALL_DIM_MAX_SIZE && natural_tgs >= SPLIT_MIN_TGS;
         // Only the sum family has narrow_strided kernels; value ops fall
@@ -1273,10 +1274,10 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
     const auto non_innermost = num_reduced == 1 && reduced_dim != nd - 1 && canUse32BitIndexMath(input_orig);
     if (non_innermost) {
       const auto outer_size =
-          safe_downcast<uint32_t, int64_t>(c10::multiply_integers(input_orig.sizes().slice(0, reduced_dim)));
-      const auto dim_size = safe_downcast<uint32_t, int64_t>(input_orig.size(reduced_dim));
+          c10::safe_conv<uint32_t, int64_t>(c10::multiply_integers(input_orig.sizes().slice(0, reduced_dim)));
+      const auto dim_size = c10::safe_conv<uint32_t, int64_t>(input_orig.size(reduced_dim));
       const auto inner_size =
-          safe_downcast<uint32_t, int64_t>(input_orig.numel() / (static_cast<int64_t>(outer_size) * dim_size));
+          c10::safe_conv<uint32_t, int64_t>(input_orig.numel() / (static_cast<int64_t>(outer_size) * dim_size));
       const auto natural_tgs = outer_size * c10::metal::ceil_div(inner_size, OUTER_TG_WIDTH);
       const auto use_small_dim = dim_size <= OUTER_SMALL_DIM_MAX_SIZE && natural_tgs >= SPLIT_MIN_TGS;
       // inner_size narrower than a threadgroup row: the narrow layout is the
@@ -1360,8 +1361,8 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
     }
     // The inner kernels index in 32 bits.
     if (num_reduced == 1 && reduced_dim == input_orig.dim() - 1 && canUse32BitIndexMath(input_orig)) {
-      const auto row_len = safe_downcast<uint32_t, int64_t>(input_orig.size(-1));
-      const auto num_rows = safe_downcast<uint32_t, int64_t>(input_orig.numel() / row_len);
+      const auto row_len = c10::safe_conv<uint32_t, int64_t>(input_orig.size(-1));
+      const auto num_rows = c10::safe_conv<uint32_t, int64_t>(input_orig.numel() / row_len);
       // Tensors too small to fill the GPU gain nothing from packing rows
       // into simdgroups; keep them on the inner kernel below (the pre-chunk
       // routing, whose enqueue floor measures ~10% lower there).

--- a/aten/src/ATen/native/mps/operations/Shape.mm
+++ b/aten/src/ATen/native/mps/operations/Shape.mm
@@ -9,6 +9,7 @@
 #include <ATen/native/mps/Copy.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/Shape.h>
+#include <c10/util/safe_conv.h>
 
 #include <fmt/format.h>
 
@@ -96,8 +97,8 @@ static void cat_out_mps_impl(const ITensorListRef& inputs, int64_t dimension, co
   shared_params.cat_dim = dimension;
 
   for (const auto dim : c10::irange(output.dim())) {
-    shared_params.output_strides[dim] = safe_downcast<idx_type_t, int64_t>(output.stride(dim));
-    shared_params.output_sizes[dim] = safe_downcast<idx_type_t, int64_t>(output.size(dim));
+    shared_params.output_strides[dim] = c10::safe_conv<idx_type_t, int64_t>(output.stride(dim));
+    shared_params.output_sizes[dim] = c10::safe_conv<idx_type_t, int64_t>(output.size(dim));
   }
 
   idx_type_t cat_dim_offset = 0;
@@ -122,12 +123,12 @@ static void cat_out_mps_impl(const ITensorListRef& inputs, int64_t dimension, co
       auto num_threads = std::min(max_num_threads, numel_remaining);
       CatInputParams<idx_type_t> input_params;
 
-      input_params.cat_dim_offset = safe_downcast<idx_type_t, int64_t>(cat_dim_offset);
-      input_params.input_element_offset = safe_downcast<idx_type_t, int64_t>(input.numel() - numel_remaining);
+      input_params.cat_dim_offset = c10::safe_conv<idx_type_t, int64_t>(cat_dim_offset);
+      input_params.input_element_offset = c10::safe_conv<idx_type_t, int64_t>(input.numel() - numel_remaining);
 
       for (const auto dim : c10::irange(input.dim())) {
-        input_params.input_strides[dim] = safe_downcast<idx_type_t, int64_t>(input.stride(dim));
-        input_params.input_sizes[dim] = safe_downcast<idx_type_t, int64_t>(input.size(dim));
+        input_params.input_strides[dim] = c10::safe_conv<idx_type_t, int64_t>(input.stride(dim));
+        input_params.input_sizes[dim] = c10::safe_conv<idx_type_t, int64_t>(input.size(dim));
       }
 
       dispatch_sync_with_rethrow(stream->queue(), ^() {

--- a/aten/src/ATen/native/mps/operations/Sort.mm
+++ b/aten/src/ATen/native/mps/operations/Sort.mm
@@ -13,6 +13,7 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <c10/metal/common.h>
 #include <c10/util/TypeCast.h>
+#include <c10/util/safe_conv.h>
 #include <fmt/format.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -637,7 +638,7 @@ static std::tuple<Tensor&, Tensor&> median_with_indices_impl_mps(Tensor& values,
 // Global median via radix selection (see Sort.metal); no sort materialized.
 static void median_radix_select(const Tensor& flat, const Tensor& out_val, bool ignore_nan) {
   const int n_passes = static_cast<int>(flat.element_size());
-  const auto numel = c10::checked_convert<uint32_t>(flat.numel(), "uint32_t");
+  const auto numel = c10::safe_conv<uint32_t>(flat.numel());
   auto state = at::zeros({3}, flat.options().dtype(kLong));
   auto hist = at::zeros({257}, flat.options().dtype(kInt));
   const auto n_tgs = std::min<uint32_t>(at::ceil_div(numel, 256u), 256u);

--- a/aten/src/ATen/native/quantized/cpu/AveragePool2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/AveragePool2d.cpp
@@ -18,6 +18,7 @@
 #endif
 
 #include <c10/util/irange.h>
+#include <c10/util/safe_conv.h>
 
 #include <algorithm>
 #include <cmath>
@@ -120,10 +121,10 @@ inline std::pair<int, int> get_kernel(IntArrayRef kernel_size) {
   TORCH_CHECK(
       kernel_size.size() == 1 || kernel_size.size() == 2,
       "avg_pool2d: kernel_size must either be a single int, or a tuple of two ints");
-  const int kH = c10::checked_convert<int>(kernel_size[0], "int");
+  const int kH = c10::safe_conv<int>(kernel_size[0]);
   const int kW = kernel_size.size() == 1
       ? kH
-      : c10::checked_convert<int>(kernel_size[1], "int");
+      : c10::safe_conv<int>(kernel_size[1]);
   return std::make_pair(kW, kH);
 }
 
@@ -131,10 +132,10 @@ inline std::pair<int, int> get_stride(IntArrayRef stride, int kW, int kH) {
   TORCH_CHECK(
       stride.empty() || stride.size() == 1 || stride.size() == 2,
       "avg_pool2d: stride must either be omitted, a single int, or a tuple of two ints");
-  const int dH = stride.empty() ? kH : c10::checked_convert<int>(stride[0], "int");
+  const int dH = stride.empty() ? kH : c10::safe_conv<int>(stride[0]);
   const int dW = stride.empty()
       ? kW
-      : stride.size() == 1 ? dH : c10::checked_convert<int>(stride[1], "int");
+      : stride.size() == 1 ? dH : c10::safe_conv<int>(stride[1]);
   return std::make_pair(dW, dH);
 }
 
@@ -142,9 +143,9 @@ inline std::pair<int, int> get_padding(IntArrayRef padding) {
   TORCH_CHECK(
       padding.size() == 1 || padding.size() == 2,
       "avg_pool2d: padding must either be a single int, or a tuple of two ints");
-  const int padH = c10::checked_convert<int>(padding[0], "int");
+  const int padH = c10::safe_conv<int>(padding[0]);
   const int padW =
-      padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
+      padding.size() == 1 ? padH : c10::safe_conv<int>(padding[1]);
   return std::make_pair(padW, padH);
 }
 

--- a/aten/src/ATen/native/quantized/cpu/AveragePool3d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/AveragePool3d.cpp
@@ -3,6 +3,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/Pool.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
+#include <c10/util/safe_conv.h>
 #include <ATen/native/quantized/cpu/QnnpackUtils.h>
 #include <ATen/native/quantized/cpu/QuantizedOps.h>
 
@@ -26,13 +27,13 @@ inline std::tuple<int, int, int> get_kernel(IntArrayRef kernel_size) {
   TORCH_CHECK(
       kernel_size.size() == 1 || kernel_size.size() == 3,
       "avg_pool3d: kernel_size must either be a single int, or a tuple of three ints");
-  const int kD = c10::checked_convert<int>(kernel_size[0], "int");
+  const int kD = c10::safe_conv<int>(kernel_size[0]);
   const int kH = kernel_size.size() == 1
       ? kD
-      : c10::checked_convert<int>(kernel_size[1], "int");
+      : c10::safe_conv<int>(kernel_size[1]);
   const int kW = kernel_size.size() == 1
       ? kD
-      : c10::checked_convert<int>(kernel_size[2], "int");
+      : c10::safe_conv<int>(kernel_size[2]);
   return std::make_tuple(kW, kH, kD);
 }
 
@@ -40,13 +41,13 @@ inline std::tuple<int, int, int> get_stride(IntArrayRef stride, int kW, int kH, 
   TORCH_CHECK(
       stride.empty() || stride.size() == 1 || stride.size() == 3,
       "avg_pool3d: stride must either be omitted, a single int, or a tuple of three ints");
-  const int dD = stride.empty() ? kD : c10::checked_convert<int>(stride[0], "int");
+  const int dD = stride.empty() ? kD : c10::safe_conv<int>(stride[0]);
   const int dH = stride.empty()
       ? kH
-      : stride.size() == 1 ? dD : c10::checked_convert<int>(stride[1], "int");
+      : stride.size() == 1 ? dD : c10::safe_conv<int>(stride[1]);
   const int dW = stride.empty()
       ? kW
-      : stride.size() == 1 ? dD : c10::checked_convert<int>(stride[2], "int");
+      : stride.size() == 1 ? dD : c10::safe_conv<int>(stride[2]);
   return std::make_tuple(dW, dH, dD);
 }
 
@@ -54,11 +55,11 @@ inline std::tuple<int, int, int> get_padding(IntArrayRef padding) {
   TORCH_CHECK(
       padding.size() == 1 || padding.size() == 3,
       "avg_pool3d: padding must either be a single int, or a tuple of three ints");
-  const int padD = c10::checked_convert<int>(padding[0], "int");
+  const int padD = c10::safe_conv<int>(padding[0]);
   const int padH =
-      padding.size() == 1 ? padD : c10::checked_convert<int>(padding[1], "int");
+      padding.size() == 1 ? padD : c10::safe_conv<int>(padding[1]);
   const int padW =
-      padding.size() == 1 ? padD : c10::checked_convert<int>(padding[2], "int");
+      padding.size() == 1 ? padD : c10::safe_conv<int>(padding[2]);
   return std::make_tuple(padW, padH, padD);
 }
 

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -127,14 +127,14 @@ class C10_API Scalar {
     if (Tag::HAS_b == tag) {                                          \
       return checked_convert<type, bool>(v.i, #type);                 \
     } else if (Tag::HAS_i == tag) {                                   \
-      return checked_convert<type, int64_t>(v.i, #type);              \
+      return unsafe_wrapping_convert<type, int64_t>(v.i, #type);      \
     } else if (Tag::HAS_u == tag) {                                   \
       return checked_convert<type, uint64_t>(v.u, #type);             \
     } else if (Tag::HAS_si == tag) {                                  \
-      return checked_convert<type, int64_t>(                          \
+      return unsafe_wrapping_convert<type, int64_t>(                  \
           toSymInt().guard_int(__FILE__, __LINE__), #type);           \
     } else if (Tag::HAS_sb == tag) {                                  \
-      return checked_convert<type, int64_t>(                          \
+      return unsafe_wrapping_convert<type, int64_t>(                  \
           toSymBool().guard_bool(__FILE__, __LINE__), #type);         \
     }                                                                 \
     TORCH_CHECK(false)                                                \

--- a/c10/test/util/safe_conv_test.cpp
+++ b/c10/test/util/safe_conv_test.cpp
@@ -60,7 +60,7 @@ TEST(safeConvTest, UnsignedToSignedOverflowThrows) {
 }
 
 // unsafe_wrapping_convert preserves the historical signed->unsigned
-// two's-complement wrap that safe_conv rejects.
+// two's-complement wrap that safe_conv/checked_convert reject.
 TEST(safeConvTest, UnsafeWrappingConvertPreservesWrap) {
   EXPECT_EQ(unsafe_wrapping_convert<uint8_t>(int64_t{-1}, "uint8_t"), 255);
   EXPECT_EQ(unsafe_wrapping_convert<uint16_t>(int64_t{-1}, "uint16_t"), 65535);
@@ -70,6 +70,17 @@ TEST(safeConvTest, UnsafeWrappingConvertPreservesWrap) {
   constexpr int64_t tooBig = int64_t{std::numeric_limits<int32_t>::max()} + 1;
   EXPECT_THROW(
       unsafe_wrapping_convert<int32_t>(tooBig, "int32_t"), std::runtime_error);
+}
+
+// checked_convert delegates integer->integer to safe_conv (strict), and
+// range-checks floating-point sources while allowing a lossy-but-in-range cast.
+TEST(safeConvTest, CheckedConvertStrictForIntegers) {
+  EXPECT_THROW(
+      checked_convert<uint8_t>(int64_t{-1}, "uint8_t"), std::runtime_error);
+  EXPECT_EQ(checked_convert<int32_t>(int64_t{5}, "int32_t"), 5);
+  EXPECT_EQ(
+      checked_convert<int32_t>(3.9, "int32_t"), 3); // truncation is allowed
+  EXPECT_THROW(checked_convert<int32_t>(1e18, "int32_t"), std::runtime_error);
 }
 
 } // namespace

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -327,20 +327,11 @@ C10_HOST_DEVICE To convert(From f) {
 // Define separately to avoid being inlined and prevent code-size bloat
 [[noreturn]] C10_API void report_overflow(const char* name);
 
-template <typename To, typename From>
-To checked_convert(From f, const char* name) {
-  // Converting to bool can't overflow so we exclude this case from checking.
-  if (!std::is_same_v<To, bool> && overflows<To, From>(f)) {
-    report_overflow(name);
-  }
-  return convert<To, From>(f);
-}
-
 // Range-checked conversion that PERMITS signed->unsigned two's-complement
 // wraparound (via overflows() with its default strict_unsigned=false). Retained
 // only to preserve the historical behavior of the few call sites that relied on
 // the wrap. DO NOT use in new code: use c10::safe_conv (strict integer
-// narrowing, c10/util/safe_conv.h) or c10::checked_convert (general, above).
+// narrowing, c10/util/safe_conv.h) or c10::checked_convert (general, below).
 template <typename To, typename From>
 To unsafe_wrapping_convert(From f, const char* name) {
   // Converting to bool can't overflow so we exclude this case from checking.
@@ -348,6 +339,29 @@ To unsafe_wrapping_convert(From f, const char* name) {
     report_overflow(name);
   }
   return convert<To, From>(f);
+}
+
+// Range-checked narrowing conversion.
+//
+// For integer->integer this delegates to the strict c10::safe_conv, which
+// rejects ANY value not representable in To (including negative->unsigned;
+// there is no two's-complement wraparound). For floating-point/complex sources
+// it range-checks via c10::overflows and then converts (a lossy-but-in-range
+// cast such as 3.9 -> 3 is permitted). If you deliberately want modular wrap,
+// use c10::unsafe_wrapping_convert.
+template <typename To, typename From>
+To checked_convert(From f, const char* name) {
+  if constexpr (
+      std::is_integral_v<From> && !std::is_same_v<From, bool> &&
+      std::is_integral_v<To> && !std::is_same_v<To, bool>) {
+    return safe_conv<To, From>(f, name);
+  } else {
+    // Converting to bool can't overflow so we exclude this case from checking.
+    if (!std::is_same_v<To, bool> && overflows<To, From>(f)) {
+      report_overflow(name);
+    }
+    return convert<To, From>(f);
+  }
 }
 
 } // namespace c10

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -708,7 +708,9 @@ class TestPoolingNNDeviceType(NNTestCase):
 
     def test_MaxPool3d_errors(self, device):
         samples = torch.randn(1, 3, 10, 10, 10)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
+        with self.assertRaisesRegex(
+            RuntimeError, "value cannot be safely converted without overflow"
+        ):
             nn.MaxPool3d(
                 kernel_size=9223372036854775803,
             )(samples)
@@ -941,7 +943,9 @@ torch.cuda.synchronize()
         ).to(device)
         inp = torch.randn(3, 15, device=device)
 
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
+        with self.assertRaisesRegex(
+            RuntimeError, "value cannot be safely converted without overflow"
+        ):
             avgpool(inp)
 
     def test_lp_pool_norm_type_zero(self, device):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2292,7 +2292,9 @@ if __name__ == '__main__':
     def test_cuda_kernel_loop_overflow_large(self):
         # Make sure input.numel() > INT_MAX is handled:
         x = torch.randn(1, 1, 1, 2**31, dtype=torch.float16, device="cuda")
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
+        with self.assertRaisesRegex(
+            RuntimeError, "value cannot be safely converted without overflow"
+        ):
             y = torch.nn.functional.avg_pool2d(x, kernel_size=1)
 
         # Issue #24309: In extreme cases, the loop variable could overflow and continue

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8022,7 +8022,9 @@ class TestNNDeviceType(NNTestCase):
         x = torch.randn(1, 2, 4, 4, device=device, dtype=torch.float32)
 
         # Extremely large kernel_size (would overflow int)
-        with self.assertRaisesRegex(RuntimeError, r"value cannot be converted to type"):
+        with self.assertRaisesRegex(
+            RuntimeError, r"value cannot be safely converted without overflow"
+        ):
             torch.nn.functional.avg_pool2d(
                 x,
                 kernel_size=(9223372036854775807, 100),  # INT64_MAX
@@ -8049,7 +8051,9 @@ class TestNNDeviceType(NNTestCase):
             )
 
         # Extremely large stride (would overflow int)
-        with self.assertRaisesRegex(RuntimeError, r"value cannot be converted to type"):
+        with self.assertRaisesRegex(
+            RuntimeError, r"value cannot be safely converted without overflow"
+        ):
             torch.nn.functional.avg_pool2d(
                 x,
                 kernel_size=2,
@@ -8067,7 +8071,9 @@ class TestNNDeviceType(NNTestCase):
             )
 
         # Extremely large padding (would overflow int)
-        with self.assertRaisesRegex(RuntimeError, r"value cannot be converted to type"):
+        with self.assertRaisesRegex(
+            RuntimeError, r"value cannot be safely converted without overflow"
+        ):
             torch.nn.functional.avg_pool2d(
                 x,
                 kernel_size=2,
@@ -8076,7 +8082,9 @@ class TestNNDeviceType(NNTestCase):
             )
 
         # Combined invalid parameters
-        with self.assertRaisesRegex(RuntimeError, r"value cannot be converted to type"):
+        with self.assertRaisesRegex(
+            RuntimeError, r"value cannot be safely converted without overflow"
+        ):
             torch.nn.functional.avg_pool2d(
                 x,
                 kernel_size=(9223372036854775807, 5868783964474102731),

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -14,6 +14,7 @@
 #include <torch/csrc/copy_utils.h>
 
 #include <c10/util/intrusive_ptr.h>
+#include <c10/util/safe_conv.h>
 #include <fmt/format.h>
 
 #include <torch/csrc/Storage.h>
@@ -446,8 +447,8 @@ static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
   ptrdiff_t storage_offset_bytes =
       static_cast<ptrdiff_t>(THPUtils_unpackLong(_offset_bytes));
 
-  const auto device = c10::checked_convert<c10::DeviceIndex>(
-      THPUtils_unpackLong(_device), "c10::DeviceIndex");
+  const auto device =
+      c10::safe_conv<c10::DeviceIndex>(THPUtils_unpackLong(_device));
   at::cuda::CUDAGuard device_guard(device);
 
   if (PyObject_IsTrue(_event_sync_required)) {

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -16,7 +16,7 @@ inline T unpackIntegral(PyObject* obj, const char* type) {
   if (PyFloat_Check(obj)) {
     return c10::checked_convert<T>(THPUtils_unpackDouble(obj), type);
   }
-  return c10::checked_convert<T>(THPUtils_unpackLong(obj), type);
+  return c10::unsafe_wrapping_convert<T>(THPUtils_unpackLong(obj), type);
 }
 
 inline void store_scalar(void* data, at::ScalarType scalarType, PyObject* obj) {


### PR DESCRIPTION
`c10::checked_convert` was misnamed: for integer->integer it delegated to
 `c10::overflows` with `strict_unsigned=false`, silently wrapping negative
 sources into unsigned targets (`-1 -> 255`) instead of rejecting them. As
 discussed on #190092, this wrap on the value-ingestion paths is a latent bug,
 not a contract (inconsistent by width, contradicts `Scalar::equal()`, diverges
 from NumPy). The real modular-wrap contract lives on the `c10::convert`
 arithmetic path, untouched here.

 - Make `checked_convert` delegate integer->integer to the strict `safe_conv`;
   keep the `overflows` path for float/complex sources.
 - Preserve the historical wrap only where relied upon, via the explicit
   `unsafe_wrapping_convert`: `Scalar::to*()` and `python_scalars.h` (BC-preserving).
 - Migrate strict-wanting callers to `safe_conv` (pooling CPU/CUDA/quantized,
   MPS, `StorageSharing.cpp`); `Pool.h::safe_downcast` becomes a `[[deprecated]]`
   alias.

</details>


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01