### PR TITLE
[inductor] Skip relational SymBool inputs in Python wrapper

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -157,6 +157,28 @@ if HAS_CPU:
                 self.assertEqual(actual[0], expected[0])
                 self.assertEqual(actual[1], expected[1])
 
+        @config.patch("graph_partition", False)
+        def test_relational_symbool_graph_input_codegen(self):
+            class AssertModel(torch.nn.Module):
+                def forward(self, x):
+                    torch._check(x.shape[0] <= 128)
+                    return x.relu() + x
+
+            class IntModel(torch.nn.Module):
+                def forward(self, x):
+                    a = x.shape[0] <= 128
+                    return x.relu() + x + int(a)
+
+            for model_cls, batch_sizes in (
+                (AssertModel, (8,)),
+                (IntModel, (8, 160)),
+            ):
+                model = model_cls()
+                opt_model = torch.compile(model, fullgraph=True, dynamic=True)
+                for batch_size in batch_sizes:
+                    inp = torch.randn(batch_size, 4, dtype=torch.float32)
+                    self.assertEqual(opt_model(inp), model(inp))
+
     copy_tests(DynamicShapesCommonTemplate, DynamicShapesCpuTests, "cpu", test_failures)
 
 

--- a/test/inductor/test_wrapper_codegen.py
+++ b/test/inductor/test_wrapper_codegen.py
@@ -96,6 +96,20 @@ s0 = arg1_1""",
         self.assertEqual(wrapper.prefix.getvalue(), "")
         self.assertEqual(list(bound_vars), [])
 
+    def test_relational_symbool_input_does_not_bind_symbol(self):
+        wrapper = self._new_wrapper()
+        bound_vars = OrderedSet()
+        s0 = sympy.Symbol("s0")
+        symbool = sympy.LessThan(s0, 128)
+
+        self.assertIsInstance(symbool, sympy.logic.boolalg.Boolean)
+        self.assertNotIsInstance(symbool, sympy.Expr)
+
+        wrapper.codegen_input_symbol_assignment("arg0_1", symbool, bound_vars)
+
+        self.assertEqual(wrapper.prefix.getvalue(), "")
+        self.assertEqual(list(bound_vars), [])
+
     def test_record_symbolic_input_source_ignores_non_input_tensorbox(self):
         s0 = sympy.Symbol("s0")
         tensor = ir.Pointwise.create(

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2637,10 +2637,17 @@ class PythonWrapperCodegen(CodeGen):
     def codegen_input_symbol_assignment(
         self,
         name: str,
-        value: ir.TensorBox | sympy.Expr,
+        value: ir.TensorBox | sympy.Expr | sympy.logic.boolalg.Boolean,
         bound_vars: OrderedSet[sympy.Symbol],
         deferred_symbol_assignments=None,
     ):
+        # SymInt/SymFloat placeholders are SymPy Exprs. Relational SymBool
+        # placeholders are SymPy booleans instead, and do not define a symbol
+        # assignment for the wrapper.
+        if isinstance(value, sympy.logic.boolalg.Boolean) and not isinstance(
+            value, sympy.Expr
+        ):
+            return
         if isinstance(value, sympy.Expr):
             raw_value = value
             value = V.graph.sizevars.simplify(raw_value)


### PR DESCRIPTION
Summary:
## Problem

PT2 traces dynamic tensor dimensions as symbolic shape values. A runtime shape check such as `x.shape[0] <= 128` is input-shape-dependent, not tensor-data-dependent: `x.shape[0]` is a `SymInt` like `s72`, and the comparison is a scalar `SymBool` represented by SymPy as a relational boolean such as `LessThan(s72, 128)`.

This becomes visible when graph partitioning or piecewise compilation exposes that predicate at a graph boundary. One compiled graph can produce or carry `s72 <= 128`, while a later compiled graph receives that predicate as a real FX placeholder and consumes it in `aten._assert_scalar`.

## Solution

Inductor's Python wrapper already handles tensors and numeric symbolic scalar inputs. Numeric `SymInt`/`SymFloat` placeholders are `sympy.Expr` values, and wrapper code may generate local numeric bindings such as `s72 = arg1_1` so later generated Python can use `s72` for allocation, size checks, and stride logic.

A relational `SymBool` input is different. The wrapper still receives and unpacks the graph input, but the relation itself is not a numeric shape symbol that can be assigned. There is no meaningful generated binding like `s72 <= 128 = arg...`; the numeric symbol inside the relation, such as `s72`, is bound separately through the normal `SymInt` or tensor-shape path.

On master, when a relational `SymBool` becomes a compiled graph input, shared wrapper codegen tries to classify it as an input symbol assignment and fails before backend execution with:

```
Unknown value type: <class 'sympy.core.relational.LessThan'>
```

The DeepSeek/MTIA repro hits this with an AOT graph input like `arg11_1: "Sym(s72 <= 262144)"` consumed by `aten._assert_scalar.default(arg11_1, ...)`. Without this change, compilation stops in `codegen_input_symbol_assignment`; with this change, generated Python still unpacks `arg11_1`, emits numeric bindings such as `s72 = arg1_1`, and proceeds through wrapper/kernel generation.

## Change

Teach shared Python wrapper input-symbol codegen to recognize relational `SymBool` inputs represented as SymPy booleans. These inputs are intentionally skipped by `codegen_input_symbol_assignment` because they do not define wrapper-local numeric shape-symbol assignments.

This preserves existing tensor and numeric `SymInt`/`SymFloat` handling while covering the scalar shape-predicate case. The fix belongs in common wrapper code rather than an MTIA-specific wrapper because CPU, GPU, and MTIA can all reach this wrapper failure when a relational `SymBool` predicate crosses a compiled graph boundary.

Tests cover both levels of the behavior: a wrapper-codegen unit test verifies a SymPy relation emits no symbol binding, and a CPU dynamic-shapes regression covers the original `_check`/`_assert_scalar` path plus the reviewer-suggested `int(a)` use. The `keepdim=a` variant is not included because it is rejected earlier by Dynamo/fake tensor validation (`keepdim` must be a concrete bool), before wrapper codegen.

Test Plan:
python3 -m py_compile test/inductor/test_torchinductor_dynamic_shapes.py

Result: pass.

buck test --overall-timeout 600s --test-executor-stdout=- --test-executor-stderr=- fbcode//caffe2/test/inductor:torchinductor_dynamic_shapes_cpu -- test_relational_symbool_graph_input_codegen

Result: pass. TestInfra run https://www.internalfb.com/intern/testinfra/testrun/31806672389990334 reported `Pass 1`.

buck test --overall-timeout 300s --test-executor-stdout=- --test-executor-stderr=- fbcode//caffe2/test/inductor:wrapper_codegen -- test_relational_symbool_input_does_not_bind_symbol

Result: not complete. TestInfra run https://www.internalfb.com/intern/testinfra/testrun/34058472203669073 exceeded the provided deadline during listing and omitted the target; no tests ran.

Differential Revision: D113483473




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo