### PR TITLE
[Sigrid][AOTI][KR1] Serving-path module-load + weight-byte telemetry (#191243)

### DIFF
--- a/torch/csrc/inductor/static_launcher/cuda.cpp
+++ b/torch/csrc/inductor/static_launcher/cuda.cpp
@@ -3,8 +3,11 @@
 #include <ATen/Context.h>
 #include <ATen/cuda/Exceptions.h>
 #include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
+#include <c10/util/Logging.h>
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/inductor/static_launcher/cuda.h>
+#include <torch/csrc/inductor/static_launcher/module_load_stats.h>
+#include <chrono>
 #include <cstdint>
 
 #include <torch/csrc/utils/python_numbers.h>
@@ -181,18 +184,48 @@ std::pair<CUmodule, CUfunction> loadKernel(
   CUmodule mod = nullptr;
   CUfunction func = nullptr;
 
+  // Module-load telemetry: count + time each driver module load, rate-limited.
+  // Shared by the ROCm/CUDA branches so the two stay in sync; the only
+  // per-platform bits are the driver call (passed as loadFn) and platform tag.
+  auto timedModuleLoad = [](const char* platform, auto&& loadFn) {
+    constexpr int64_t kModuleLoadLogEveryN = 100;
+    constexpr int64_t kModuleLoadSlowUs = 100000; // 100 ms
+    const auto loadStart = std::chrono::steady_clock::now();
+    loadFn();
+    const int64_t loadUs =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - loadStart)
+            .count();
+    // Count only successful loads: a throw from loadFn() leaves the counter
+    // unbumped and emits no marker for the failed attempt.
+    const int64_t loadIndex = facebook::aoti::moduleLoadCounter().fetch_add(
+                                  1, std::memory_order_relaxed) +
+        1;
+    if (loadIndex == 1 || loadIndex % kModuleLoadLogEveryN == 0 ||
+        loadUs > kModuleLoadSlowUs) {
+      LOG(INFO) << "[ModuleLoad] cumulative_count=" << loadIndex
+                << " this_load_us=" << loadUs << " elapsed_s="
+                << facebook::aoti::secondsSinceFirstObservedLoad()
+                << " platform=" << platform;
+    }
+  };
+
 #if defined(USE_ROCM)
   // Unlike cuModuleLoad, hipModuleLoad keeps a file descriptor for the loaded
   // HSACO. Load from memory to avoid retaining one FD per static launcher.
   auto image = readKernelImage(filePath);
-  AT_CUDA_DRIVER_CHECK(hipModuleLoadData(&mod, image.data()));
+  timedModuleLoad("AMD", [&] {
+    AT_CUDA_DRIVER_CHECK(hipModuleLoadData(&mod, image.data()));
+  });
   AT_CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
   int shared_optin = 0;
   AT_CUDA_DRIVER_CHECK(hipDeviceGetAttribute(
       &shared_optin, hipDeviceAttributeMaxSharedMemoryPerBlock, device));
 
 #else
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuModuleLoad(&mod, filePath.c_str()));
+  timedModuleLoad("NV", [&] {
+    AT_CUDA_DRIVER_CHECK(nvrtc().cuModuleLoad(&mod, filePath.c_str()));
+  });
   AT_CUDA_DRIVER_CHECK(
       nvrtc().cuModuleGetFunction(&func, mod, funcName.c_str()));
   int shared_optin = 0;

--- a/torch/csrc/inductor/static_launcher/module_load_stats.h
+++ b/torch/csrc/inductor/static_launcher/module_load_stats.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+
+// Header-only telemetry counters for AOTInductor module-load observability.
+//
+// All counters are DSO-local: each inline function's function-local static has
+// one instance per DSO that links it (vague linkage does not unify statics
+// across separately-linked DSOs). Read a counter from the same DSO that
+// increments it, otherwise the read resolves to that DSO's zero.
+//
+//  - aotiEngineLoadCounter: AOTInductor engines materialized when a lowered
+//    module is loaded. Increment and read from the same TU so the read is
+//    same-DSO by construction.
+//  - moduleLoadCounter: cu/hipModuleLoad calls issued by the inductor static
+//    launcher (static_launcher/cuda.cpp), which compiles into the torch._C
+//    Python extension. Reads from a DSO that does not link cuda.cpp resolve to
+//    zero -- use aotiEngineLoadCounter there instead.
+//  - dtlBytesCounter: bytes copied by the deferred tensor loader (increment and
+//    read live in the same TU), for weight-traffic accounting.
+//
+// Header-only inline so consumers need no link-time dep on the USE_CUDA-gated
+// cuda.cpp translation unit; purely additive.
+
+namespace facebook::aoti {
+
+// AOTInductor engine loads (incremented when a lowered module is loaded).
+inline std::atomic<int64_t>& aotiEngineLoadCounter() {
+  // NOLINTNEXTLINE(facebook-hte-InlinedStaticLocalVariableWarning)
+  static std::atomic<int64_t> count{0};
+  return count;
+}
+
+inline void addAotiEngineLoads(int64_t n) {
+  if (n > 0) {
+    aotiEngineLoadCounter().fetch_add(n, std::memory_order_relaxed);
+  }
+}
+
+inline int64_t getCumulativeAotiEngineLoadCount() {
+  return aotiEngineLoadCounter().load(std::memory_order_relaxed);
+}
+
+// cu/hipModuleLoad count (incremented in static_launcher/cuda.cpp). Reads from
+// a DSO that does not link cuda.cpp resolve to zero -- use
+// aotiEngineLoadCounter there instead.
+inline std::atomic<int64_t>& moduleLoadCounter() {
+  // NOLINTNEXTLINE(facebook-hte-InlinedStaticLocalVariableWarning)
+  static std::atomic<int64_t> count{0};
+  return count;
+}
+
+inline int64_t getCumulativeModuleLoadCount() {
+  return moduleLoadCounter().load(std::memory_order_relaxed);
+}
+
+// Seconds since the FIRST observed load in this DSO. The static initializes on
+// first call, not at process start, so this is elapsed-since-first-load, not
+// process uptime -- named accordingly to avoid the misread. Consequently the
+// log emitted on that first observed load reports 0; the value grows
+// monotonically on subsequent loads.
+inline int64_t secondsSinceFirstObservedLoad() {
+  static const auto first = std::chrono::steady_clock::now();
+  return std::chrono::duration_cast<std::chrono::seconds>(
+             std::chrono::steady_clock::now() - first)
+      .count();
+}
+
+// Cumulative bytes loaded via the deferred tensor loader's per-tensor copy
+// path (increment and read live in the same TU).
+inline std::atomic<int64_t>& dtlBytesCounter() {
+  // NOLINTNEXTLINE(facebook-hte-InlinedStaticLocalVariableWarning)
+  static std::atomic<int64_t> bytes{0};
+  return bytes;
+}
+
+inline int64_t getCumulativeDtlBytes() {
+  return dtlBytesCounter().load(std::memory_order_relaxed);
+}
+
+inline void addDtlBytes(int64_t n) {
+  if (n > 0) {
+    dtlBytesCounter().fetch_add(n, std::memory_order_relaxed);
+  }
+}
+
+} // namespace facebook::aoti


### PR DESCRIPTION
Summary:

Part of AOTI Observability & Runtime Improvements (RecSys Runtime Q3'26) - KR1 (in-place update / load-path phases observable). One-pager: https://docs.google.com/document/d/1if3TbMHGLDZIf9BFbgS4GQgxcxIHef8GOl3Etgw3E8Y

Additive telemetry for the AOTI serving load / weight-load path. All diagnostic; no behavior change to the load path.

- `module_load_stats.h` (fbcode + xplat mirror): DSO-local header-only counters. `aotiEngineLoadCounter` counts AOTI engines materialized on the serving load path; `dtlBytesCounter` counts bytes copied by the deferred tensor loader; `moduleLoadCounter` counts cu/hipModuleLoad in the torch._C static launcher.
- `PyTorchLoweredModuleLoading.cpp`: count + time the AOTI engines actually loaded on the serving path (`[AotiEngineLoad]`), so the serving-side counter is meaningful in the serving binary.
- `PyTorchDeferredTensorLoader.cpp`: per-tensor `[DTLPerTensor]` markers (rate-limited: every Nth tensor + any slow load) and exception-safe `[DeferredTensorLoader]` full-snapshot entry/exit via `SCOPE_EXIT`.
- `static_launcher/cuda.cpp` (fbcode + xplat): `[ModuleLoad]` timing for the Python/JIT static-launcher path.
- `InplaceModelUpdate.cpp`: `[Transition Dispatch]` entry/exit markers at the snapshot-transition dispatch point.
- `PyTorchPredictorContainer.cpp`: `[Dense Weights Update Phase]` per-phase timing in `updateDenseWeightsTGIF`.

Prior review addressed: the serving-side counter now reads the real serving-path engine-load count (not a torch._C-only counter that resolved to 0); `[DTLPerTensor]` is rate-limited; entry/exit markers are exception-safe; the misleading process-uptime field is renamed to `secondsSinceFirstObservedLoad`.

Test Plan:
- `buck2 build fbcode//caffe2/caffe2/fb/predictor/lowered_module:pytorch_lowered_module fbcode//caffe2/caffe2/fb/predictor:PyTorchDeferredTensorLoader` passes on current master.
- Telemetry-only, additive; load-path functional behavior unchanged. The `[AotiEngineLoad]`, `[DTLPerTensor]` (rate-limited), `[DeferredTensorLoader]`, `[Transition Dispatch]`, `[Dense Weights Update Phase]`, and `[ModuleLoad]` lines appear during model loads / snapshot transitions. Empirical validation of the serving-path counter (one serving load) to confirm before publish.

Differential Revision: D112915823


