### PR TITLE
flex_gemm: support bool main outputs

### DIFF
--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -2547,6 +2547,72 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize("extra_output", ("none", "aux", "local_reduce"))
+    @parametrize("swap_ab", (False, True))
+    def test_mm_bool_main_output(self, extra_output, swap_ab):
+        m, k, n = 256, 64, 256
+
+        def epilogue_fn(acc):
+            value = acc.float()
+            main = value > 0
+            match extra_output:
+                case "none":
+                    return main
+                case "aux":
+                    return main, value * 0.5
+                case "local_reduce":
+                    return main, value.view(m, -1, 16).sum(-1)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={
+                    "backend": "QUACK",
+                    "config": {"swap_ab": swap_ab},
+                },
+            )
+
+        a = torch.eye(m, k, device="cuda", dtype=torch.bfloat16)
+        rows = torch.arange(k, device="cuda")[:, None]
+        cols = torch.arange(n, device="cuda")[None, :]
+        b = (((rows + cols) % 17) - 8).to(torch.bfloat16)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        self.assertEqual(actual, epilogue_fn(a @ b))
+        self.assertNotIn("extern_kernels.mm", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize(
+        "dtype",
+        (torch.uint8, torch.int32),
+        name_fn=lambda dtype: str(dtype).removeprefix("torch."),
+    )
+    def test_mm_generic_integer_main_output_rejected(self, dtype):
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                lambda acc: acc.to(dtype),
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            (InductorError, NotImplementedError),
+            "generic main outputs support only floating-point and bool dtypes",
+        ):
+            torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
     @parametrize(
         "tuned",
         (False, True),

--- a/tools/vendoring/quack/flex_gemm_patches/0014-flex-gemm-bool-main-output.patch
+++ b/tools/vendoring/quack/flex_gemm_patches/0014-flex-gemm-bool-main-output.patch
@@ -1,0 +1,22 @@
+diff --git a/gemm_act.py b/gemm_act.py
+index bc3b5b3..fe29a6e 100644
+--- a/gemm_act.py
++++ b/gemm_act.py
+@@ -489 +489 @@ class GemmActMixin(ComposableEpiMixin):
+-                tRS_rD.store(epilogue_result[0])
++                tRS_rD.store(epilogue_result[0].to(self.acc_dtype))
+@@ -512,10 +512,9 @@ class GemmActMixin(ComposableEpiMixin):
+                     main_result = epilogue_result[0]
+                     if const_expr(self.grouped_n_contract_group == 1):
+-                        tRS_rD.store(main_result)
+-                result_dtype = self.acc_dtype
+-                if const_expr(self.grouped_n_contract_group != 1):
+-                    result_dtype = main_result.element_type
+-                tRS_rAuxOut = cute.make_rmem_tensor(main_result.shape, result_dtype)
++                        tRS_rD.store(main_result.to(self.acc_dtype))
++                tRS_rAuxOut = cute.make_rmem_tensor(
++                    main_result.shape, main_result.element_type
++                )
+                 tRS_rAuxOut.store(main_result)
+         elif const_expr(params.act_fn is not None):
+             tRS_rAuxOut = cute.make_rmem_tensor(tRS_rD.layout.shape, self.acc_dtype)

--- a/tools/vendoring/quack/flex_gemm_patches/series
+++ b/tools/vendoring/quack/flex_gemm_patches/series
@@ -16,3 +16,4 @@
 0011-flex-gemm-local-reduce-layout-assert.patch
 0012-flex-gemm-grouped-main-output.patch
 0013-flex-gemm-output-storage-layouts.patch
+0014-flex-gemm-bool-main-output.patch

--- a/torch/_inductor/kernel/flex_gemm/runtime.py
+++ b/torch/_inductor/kernel/flex_gemm/runtime.py
@@ -500,6 +500,7 @@ def dispatch_gemm_act(
     # QuACK expects a leading batch dim; 2-D (non-batched) operands get one here.
     quack_a = quack_a.unsqueeze(0) if quack_a.ndim == 2 else quack_a
     quack_b = quack_b.unsqueeze(0) if quack_b.ndim == 2 else quack_b
+    quack_out = quack_epilogue_arg(quack_out)
     quack_out = quack_out.unsqueeze(0) if quack_out.ndim == 2 else quack_out
     quack_aux_outs = tuple(quack_epilogue_arg(aux_out) for aux_out in quack_aux_outs)
     quack_aux_outs = tuple(
@@ -637,6 +638,14 @@ def gemm_epilogue(
     expected_dtype = out_dtype
     if expected_dtype is None:
         expected_dtype = out.dtype if out is not None else a.dtype
+    if (
+        main_transform is None
+        and not expected_dtype.is_floating_point
+        and expected_dtype != torch.bool
+    ):
+        raise NotImplementedError(
+            "FlexGEMM generic main outputs support only floating-point and bool dtypes"
+        )
     effective_C = normalize_c(C, physical_output_shape, beta)
     if out is not None:
         check_matrix("out", out)

--- a/torch/_vendor/quack/gemm_act.py
+++ b/torch/_vendor/quack/gemm_act.py
@@ -486,7 +486,7 @@ class GemmActMixin(ComposableEpiMixin):
                 tRS_rEpilogueIn.load(), *tuple(epilogue_aux_values)
             )
             if const_expr(params.tensor_epilogue_returns_aux):
-                tRS_rD.store(epilogue_result[0])
+                tRS_rD.store(epilogue_result[0].to(self.acc_dtype))
                 aux_results = []
                 for i, _ in enumerate(params.mAuxOut):
                     aux_result = epilogue_result[i + 1]
@@ -511,11 +511,10 @@ class GemmActMixin(ComposableEpiMixin):
                     tDrLocalReduce.store(epilogue_result[1])
                     main_result = epilogue_result[0]
                     if const_expr(self.grouped_n_contract_group == 1):
-                        tRS_rD.store(main_result)
-                result_dtype = self.acc_dtype
-                if const_expr(self.grouped_n_contract_group != 1):
-                    result_dtype = main_result.element_type
-                tRS_rAuxOut = cute.make_rmem_tensor(main_result.shape, result_dtype)
+                        tRS_rD.store(main_result.to(self.acc_dtype))
+                tRS_rAuxOut = cute.make_rmem_tensor(
+                    main_result.shape, main_result.element_type
+                )
                 tRS_rAuxOut.store(main_result)
         elif const_expr(params.act_fn is not None):
             tRS_rAuxOut = cute.make_rmem_tensor(tRS_rD.layout.shape, self.acc_dtype)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

QuACK consumes boolean tensors through uint8 physical storage, but FlexGEMM
passed the main output directly and allocated ordinary result registers with
the accumulator dtype. Tuple and local-reduction epilogues also route the main
value through the Float32 D channel, so storing a boolean value there without
an explicit conversion fails type checking.

Use the existing epilogue storage adapter for the main output, convert values
entering D to the accumulator dtype, and retain the generated result dtype for
direct output stores. Generic integer main outputs remain unsupported because
Float32 D staging can lose integer precision and unsigned conversion semantics
do not match eager conversion; grouped packed outputs keep their existing
specialized path.

Test Plan:

```bash
python test/inductor/test_flex_gemm.py -k bool_main_output
python test/inductor/test_flex_gemm.py -k generic_integer_main_output_rejected
python test/inductor/test_flex_gemm.py
tools/vendoring/quack/vendor.sh --check
spin lint
```

This change was prepared with assistance from an AI coding tool.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo