### PR TITLE
[DTensor] Run metadata-only dispatch benchmarks on meta

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/dtensor.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/dtensor.py
@@ -8,10 +8,10 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
 class BenchmarkDTensorDispatch(BenchmarkBase):
-    def __init__(self, operator, world_size) -> None:
+    def __init__(self, operator, world_size, device="cuda") -> None:
         super().__init__(
             category=f"dtensor_dispatch_{operator}",
-            device="cuda",
+            device=device,
         )
         self.world_size = world_size
 
@@ -20,11 +20,11 @@ class BenchmarkDTensorDispatch(BenchmarkBase):
         return prefix
 
     def description(self) -> str:
-        return f"DTensor dispatch time for {self.category()}"
+        return f"DTensor dispatch instructions for {self.category()} on {self.device()}"
 
     def _prepare_once(self) -> None:
         self.mesh = torch.distributed.device_mesh.init_device_mesh(
-            "cuda", (self.world_size,), mesh_dim_names=("dp",)
+            self.device(), (self.world_size,), mesh_dim_names=("dp",)
         )
         self.a = DTensor.from_local(
             torch.ones(10, 10, device=self.device()), self.mesh, [Replicate()]
@@ -39,7 +39,7 @@ class BenchmarkDTensorDispatch(BenchmarkBase):
 
 class BenchmarkDetach(BenchmarkDTensorDispatch):
     def __init__(self, world_size) -> None:
-        super().__init__(operator="detach", world_size=world_size)
+        super().__init__(operator="detach", world_size=world_size, device="meta")
 
     def _work(self) -> None:
         self.a.detach()
@@ -47,7 +47,7 @@ class BenchmarkDetach(BenchmarkDTensorDispatch):
 
 class BenchmarkToFromLocal(BenchmarkDTensorDispatch):
     def __init__(self, world_size) -> None:
-        super().__init__(operator="to_from_local", world_size=world_size)
+        super().__init__(operator="to_from_local", world_size=world_size, device="meta")
 
     def _work(self) -> None:
         local = self.a.to_local()
@@ -109,7 +109,7 @@ class BenchmarkInplace(BenchmarkDTensorDispatch):
 
 class BenchmarkView(BenchmarkDTensorDispatch):
     def __init__(self, world_size) -> None:
-        super().__init__(operator="view", world_size=world_size)
+        super().__init__(operator="view", world_size=world_size, device="meta")
 
     def _work(self) -> None:
         self.a.view(100)
@@ -125,7 +125,9 @@ class BenchmarkRandom(BenchmarkDTensorDispatch):
 
 class BenchmarkCustomHandler(BenchmarkDTensorDispatch):
     def __init__(self, world_size) -> None:
-        super().__init__(operator="custom_handler", world_size=world_size)
+        super().__init__(
+            operator="custom_handler", world_size=world_size, device="meta"
+        )
 
     def _work(self) -> None:
         torch.ops.aten.is_same_size(self.a, self.b)

--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -90,35 +90,35 @@ basic_InlineMod_eager,compile_time_instruction_count,7964000000,0.1
 
 
 
-dtensor_dispatch_detach,instruction_count,58820,0.1
+dtensor_dispatch_detach,instruction_count,49920,0.1
 
 
 
-dtensor_dispatch_to_from_local,instruction_count,197400,0.1
+dtensor_dispatch_to_from_local,instruction_count,151700,0.1
 
 
 
-dtensor_dispatch_collectives,instruction_count,32510000,0.1
+dtensor_dispatch_collectives,instruction_count,27840000,0.1
 
 
 
-dtensor_dispatch_add_backward,instruction_count,371900,0.1
+dtensor_dispatch_add_backward,instruction_count,320300,0.1
 
 
 
-dtensor_dispatch_inplace,instruction_count,59860,0.1
+dtensor_dispatch_inplace,instruction_count,54060,0.1
 
 
 
-dtensor_dispatch_view,instruction_count,67940,0.1
+dtensor_dispatch_view,instruction_count,59190,0.1
 
 
 
-dtensor_dispatch_random,instruction_count,592800,0.1
+dtensor_dispatch_random,instruction_count,456600,0.1
 
 
 
-dtensor_dispatch_custom_handler,instruction_count,36750,0.1
+dtensor_dispatch_custom_handler,instruction_count,30940,0.1
 
 
 

--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -90,11 +90,11 @@ basic_InlineMod_eager,compile_time_instruction_count,7964000000,0.1
 
 
 
-dtensor_dispatch_detach,instruction_count,49920,0.1
+dtensor_dispatch_detach,instruction_count,57250,0.1
 
 
 
-dtensor_dispatch_to_from_local,instruction_count,151700,0.1
+dtensor_dispatch_to_from_local,instruction_count,197800,0.1
 
 
 
@@ -110,7 +110,7 @@ dtensor_dispatch_inplace,instruction_count,59860,0.1
 
 
 
-dtensor_dispatch_view,instruction_count,59190,0.1
+dtensor_dispatch_view,instruction_count,66880,0.1
 
 
 
@@ -118,7 +118,7 @@ dtensor_dispatch_random,instruction_count,592800,0.1
 
 
 
-dtensor_dispatch_custom_handler,instruction_count,30940,0.1
+dtensor_dispatch_custom_handler,instruction_count,35970,0.1
 
 
 

--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -98,15 +98,15 @@ dtensor_dispatch_to_from_local,instruction_count,151700,0.1
 
 
 
-dtensor_dispatch_collectives,instruction_count,27840000,0.1
+dtensor_dispatch_collectives,instruction_count,32510000,0.1
 
 
 
-dtensor_dispatch_add_backward,instruction_count,320300,0.1
+dtensor_dispatch_add_backward,instruction_count,371900,0.1
 
 
 
-dtensor_dispatch_inplace,instruction_count,54060,0.1
+dtensor_dispatch_inplace,instruction_count,59860,0.1
 
 
 
@@ -114,7 +114,7 @@ dtensor_dispatch_view,instruction_count,59190,0.1
 
 
 
-dtensor_dispatch_random,instruction_count,456600,0.1
+dtensor_dispatch_random,instruction_count,592800,0.1
 
 
 


### PR DESCRIPTION
The instruction counter measures every user-space instruction retired in the benchmark window. CUDA tensors therefore include CUDA runtime host instructions, making counts vary across toolkit versions even when DTensor dispatch is unchanged.

Use meta tensors for detach, to/from-local, view, and is_same_size. These operations only inspect or transform metadata, and CPU/meta measurements agree within 1%, so meta preserves benchmark coverage without executing device code. Keep collectives, backward, inplace, and random on CUDA because their dispatch paths or kernels are device-sensitive.

Per-CUDA baselines would encode runtime noise rather than DTensor behavior, so isolate these metadata-only benchmarks instead. The existing 10% baselines already contain the new results.

Fixes https://github.com/pytorch/pytorch/issues/190905

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98