### PR TITLE
[inductor] xfail test_index_propagation_to_dtype_inf on CPU dynamic shapes

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -72,10 +72,11 @@ test_failures = {
     "test_index_propagation_abs_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_floordiv_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_remainder_dynamic_shapes": TestFailure(("mps",)),
-    # inf/nan cast to int can't be constant-folded under dynamic shapes, so the
-    # cast is emitted by codegen and evaluates to INT_MIN instead of 0 on CPU.
-    # Mirrors the xfail added in test_torchinductor_codegen_dynamic_shapes.py (#190427).
-    "test_index_propagation_to_dtype_inf_dynamic_shapes": TestFailure(("cpu",)),
+    # This fails on periodic CPU shards but passes on other CPU configurations,
+    # so skip it instead of producing unexpected successes.
+    "test_index_propagation_to_dtype_inf_dynamic_shapes": TestFailure(
+        ("cpu",), is_skip=True
+    ),
     "test_roll_dynamic_shapes": TestFailure(("mps",)),
     "test_reflection_pad2d_backward_dynamic_shapes": TestFailure(
         ("mps",), is_skip=True

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -72,6 +72,10 @@ test_failures = {
     "test_index_propagation_abs_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_floordiv_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_remainder_dynamic_shapes": TestFailure(("mps",)),
+    # inf/nan cast to int can't be constant-folded under dynamic shapes, so the
+    # cast is emitted by codegen and evaluates to INT_MIN instead of 0 on CPU.
+    # Mirrors the xfail added in test_torchinductor_codegen_dynamic_shapes.py (#190427).
+    "test_index_propagation_to_dtype_inf_dynamic_shapes": TestFailure(("cpu",)),
     "test_roll_dynamic_shapes": TestFailure(("mps",)),
     "test_reflection_pad2d_backward_dynamic_shapes": TestFailure(
         ("mps",), is_skip=True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191248

#190427 skipped folding inf/nan to int in index propagation, which leaves
the dynamic-shapes CPU path failing (the cast is emitted by codegen and
evaluates to INT_MIN instead of 0). That PR registered the expected failure
in test_torchinductor_codegen_dynamic_shapes.py but missed the parallel
test_torchinductor_dynamic_shapes.py, whose auto-generated
test_index_propagation_to_dtype_inf_dynamic_shapes_cpu variant has been red
on the periodic nogpu shards ever since.

Add the matching TestFailure(("cpu",)) entry.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo