### PR TITLE
[ROCm][CI] Remove orphaned amd-do runner-determinator experiment references

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -115,10 +115,6 @@ runner_mapping:
   linux.rocm.gpu.gfx950.1: linux.rocm.gpu.gfx950.1
   linux.rocm.gpu.gfx950.2: linux.rocm.gpu.gfx950.2
   linux.rocm.gpu.gfx1100: linux.rocm.gpu.gfx1100
-  # amd-do experiment routes mi350 tests to AMD's dedicated runners via this
-  # prefix; kept as passthrough so the OSDC build's runner mapping preserves it.
-  amd-do-linux.rocm.gpu.gfx950.1: amd-do-linux.rocm.gpu.gfx950.1
-  amd-do-linux.rocm.gpu.gfx950.2: amd-do-linux.rocm.gpu.gfx950.2
   # amd-sandbox experiment routes trunk-rocm-sandbox gfx942 tests to AMD's dedicated
   # runners via this prefix; passthrough so the OSDC build's runner mapping keeps it.
   amd-sandbox-linux.rocm.gpu.gfx942.1: amd-sandbox-linux.rocm.gpu.gfx942.1

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -60,13 +60,6 @@ on:
       amd-sandbox-label-type:
         description: Runner prefix for the "amd-sandbox" experiment (empty when not enabled)
         value: ${{ jobs.runner-determinator.outputs.amd-sandbox-label-type }}
-      # Deprecated empty-string alias kept only so the MI350/gfx950 workflows that
-      # still reference amd-do-label-type resolve to a bare (unprefixed) label,
-      # matching the old inactive amd-do experiment. Removed once #191249 drops
-      # those references.
-      amd-do-label-type:
-        description: Deprecated no-op alias; removed by the amd-do cleanup PR.
-        value: ${{ '' }}
       ci-docker-hash:
         description: "Git tree hash of .ci/docker, used as the suffix of CI docker image tags"
         value: ${{ jobs.runner-determinator.outputs.ci-docker-hash }}

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
@@ -81,7 +81,6 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
       opt_out_experiments: lf
-      check_experiments: amd-do
 
   linux-jammy-rocm-py3_10-inductor-benchmark-build:
     if: github.repository_owner == 'pytorch'
@@ -95,27 +94,27 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |
         { include: [
-          { config: "inductor_huggingface_perf_rocm_mi350", shard: 1, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_huggingface_perf_rocm_mi350", shard: 2, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_huggingface_perf_rocm_mi350", shard: 3, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_huggingface_perf_rocm_mi350", shard: 4, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_huggingface_perf_rocm_mi350", shard: 5, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_timm_perf_rocm_mi350", shard: 1, num_shards: 7, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_timm_perf_rocm_mi350", shard: 2, num_shards: 7, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_timm_perf_rocm_mi350", shard: 3, num_shards: 7, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_timm_perf_rocm_mi350", shard: 4, num_shards: 7, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_timm_perf_rocm_mi350", shard: 5, num_shards: 7, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_timm_perf_rocm_mi350", shard: 6, num_shards: 7, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_timm_perf_rocm_mi350", shard: 7, num_shards: 7, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_torchbench_perf_rocm_mi350", shard: 1, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_torchbench_perf_rocm_mi350", shard: 2, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_torchbench_perf_rocm_mi350", shard: 3, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_torchbench_perf_rocm_mi350", shard: 4, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_torchbench_perf_rocm_mi350", shard: 5, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_torchbench_perf_rocm_mi350", shard: 6, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_torchbench_perf_rocm_mi350", shard: 7, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_torchbench_perf_rocm_mi350", shard: 8, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor_torchbench_perf_rocm_mi350", shard: 9, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_huggingface_perf_rocm_mi350", shard: 1, num_shards: 5, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_huggingface_perf_rocm_mi350", shard: 2, num_shards: 5, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_huggingface_perf_rocm_mi350", shard: 3, num_shards: 5, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_huggingface_perf_rocm_mi350", shard: 4, num_shards: 5, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_huggingface_perf_rocm_mi350", shard: 5, num_shards: 5, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_timm_perf_rocm_mi350", shard: 1, num_shards: 7, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_timm_perf_rocm_mi350", shard: 2, num_shards: 7, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_timm_perf_rocm_mi350", shard: 3, num_shards: 7, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_timm_perf_rocm_mi350", shard: 4, num_shards: 7, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_timm_perf_rocm_mi350", shard: 5, num_shards: 7, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_timm_perf_rocm_mi350", shard: 6, num_shards: 7, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_timm_perf_rocm_mi350", shard: 7, num_shards: 7, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_torchbench_perf_rocm_mi350", shard: 1, num_shards: 9, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_torchbench_perf_rocm_mi350", shard: 2, num_shards: 9, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_torchbench_perf_rocm_mi350", shard: 3, num_shards: 9, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_torchbench_perf_rocm_mi350", shard: 4, num_shards: 9, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_torchbench_perf_rocm_mi350", shard: 5, num_shards: 9, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_torchbench_perf_rocm_mi350", shard: 6, num_shards: 9, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_torchbench_perf_rocm_mi350", shard: 7, num_shards: 9, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_torchbench_perf_rocm_mi350", shard: 8, num_shards: 9, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor_torchbench_perf_rocm_mi350", shard: 9, num_shards: 9, runner: "linux.rocm.gpu.gfx950.1" },
         ]}
     secrets: inherit
 

--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -31,7 +31,6 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
-      check_experiments: amd-do
       opt_out_experiments: lf
 
   periodic-dynamo-benchmarks-build:
@@ -94,16 +93,16 @@ jobs:
       ci-docker-hash: ${{ needs.get-default-label-prefix.outputs.ci-docker-hash }}
       test-matrix: |
         { include: [
-          { config: "dynamic_inductor_huggingface", shard: 1, num_shards: 1, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "dynamic_inductor_timm", shard: 1, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "dynamic_inductor_timm", shard: 2, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "dynamic_inductor_torchbench", shard: 1, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "dynamic_inductor_torchbench", shard: 2, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "aot_inductor_huggingface", shard: 1, num_shards: 1, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "aot_inductor_timm", shard: 1, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "aot_inductor_timm", shard: 2, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "aot_inductor_torchbench", shard: 1, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "aot_inductor_torchbench", shard: 2, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
+          { config: "dynamic_inductor_huggingface", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "dynamic_inductor_timm", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "dynamic_inductor_timm", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "dynamic_inductor_torchbench", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "dynamic_inductor_torchbench", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "aot_inductor_huggingface", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "aot_inductor_timm", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "aot_inductor_timm", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "aot_inductor_torchbench", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "aot_inductor_torchbench", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
         ]}
       build-additional-packages: "fbgemm"
     secrets: inherit

--- a/.github/workflows/inductor-rocm-mi350.yml
+++ b/.github/workflows/inductor-rocm-mi350.yml
@@ -38,7 +38,6 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
       opt_out_experiments: lf
-      check_experiments: amd-do
 
   linux-noble-rocm-py3_12-inductor-build:
     name: linux-noble-rocm-py3.12-mi350
@@ -51,8 +50,8 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "inductor", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
+          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
         ]}
     secrets: inherit
 

--- a/.github/workflows/periodic-rocm-mi350.yml
+++ b/.github/workflows/periodic-rocm-mi350.yml
@@ -44,7 +44,6 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
-      check_experiments: amd-do
 
   linux-noble-rocm-py3_12-build:
     name: linux-noble-rocm-py3.12-mi350
@@ -57,9 +56,9 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
         ]}
     secrets: inherit
 

--- a/.github/workflows/rocm-mi350.yml
+++ b/.github/workflows/rocm-mi350.yml
@@ -36,7 +36,6 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
-      check_experiments: amd-do
 
   linux-noble-rocm-py3_12-build:
     if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
@@ -50,12 +49,12 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 2, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 3, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 4, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 5, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 6, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
         ]}
     secrets: inherit
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -60,17 +60,14 @@ jobs:
 
   get-label-type:
     name: get-label-type
-    # TEMPORARY (PR validation only): use the PR's own _runner-determinator.yml so
-    # the new amd-do-label-type output propagates. Revert to
-    # pytorch/pytorch/.github/workflows/_runner-determinator.yml@main before merge.
-    uses: ./.github/workflows/_runner-determinator.yml
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
-      check_experiments: lf,amd-do
+      check_experiments: lf
 
   libtorch-linux-jammy-cuda13_0-py3_10-gcc11-debug-build:
     if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' libtorch-linux-jammy-cuda13.0-py3.10-gcc11-debug ') }}
@@ -460,19 +457,19 @@ jobs:
       # sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 2, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 3, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 4, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 5, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 6, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2" },
+          { config: "default", shard: 1, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 2, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 3, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 4, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 5, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 6, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 7, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 8, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2" },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2" },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2" },
         ]}
       python-version: "3.10"
     secrets: inherit


### PR DESCRIPTION
## Summary
The `amd-do` runner-determinator experiment (test-infra#5132) is being repurposed into `amd-sandbox` for the `trunk-rocm-sandbox` workflow in #191031. `amd-do` was inactive (`rollout_perc: 0`, `default: false`, no opt-in users), so its dedicated `amd-do-label-type` output already resolved to empty and the MI350/gfx950 test shards already ran on the canonical `linux.rocm.gpu.gfx950.*` labels. This PR removes the now-unused `amd-do` wiring from its consumers:

- `trunk.yml`, `rocm-mi350.yml`, `periodic-rocm-mi350.yml`, `inductor-rocm-mi350.yml`, `inductor-perf-test-nightly-rocm-mi350.yml`, `inductor-periodic.yml`: drop `amd-do` from `check_experiments` and revert the gfx950 test-matrix runners from the `amd-do-label-type` prefix back to the plain `linux.rocm.gpu.gfx950.*` labels (identical to the value they resolve to today; matches the `rocm-mi300` default path).
- `trunk.yml`: revert the `get-label-type` job's leftover **temporary** local `_runner-determinator.yml` reference back to `@main`.
- `arc.yaml`: remove the orphaned `amd-do-linux.rocm.gpu.gfx950.{1,2}` passthrough entries.

This is a behavior-preserving cleanup: every affected shard resolves to the same runner label it uses today. Other experiments (`lf`, `arc`) are untouched. The `amd-do` experiment definition in `runner_determinator.py` / `_runner-determinator.yml` is repurposed to `amd-sandbox` in #191031 (not touched here to avoid overlap).

## Test plan
- [x] `actionlint` clean on all 6 changed workflows
- [x] No `amd-do` references remain in the changed workflows (determinator scripts are handled by #191031)
- [ ] `ciflow/trunk` + `ciflow/rocm-mi350` validation on this head SHA (this PR touches trunk + the MI350 workflows)

Made with Cursor


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang