### PR TITLE
Strict pyrefly checking: round 1 (4/N)

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -341,3 +341,33 @@ bad-param-name-override = false
 unannotated-return = true
 unannotated-parameter = true
 unannotated-attribute = true
+
+[[sub-config]]
+matches = "torch/optim/optimizer.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true
+
+[[sub-config]]
+matches = "torch/optim/adamw.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true
+
+[[sub-config]]
+matches = "torch/optim/_functional.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true

--- a/torch/optim/_adafactor.py
+++ b/torch/optim/_adafactor.py
@@ -413,7 +413,7 @@ def _single_tensor_adafactor(
         update = var_estimate.clamp_(min=eps1 * eps1).rsqrt_()
         update.mul_(grad)
         denom = max(1.0, update.norm(2).item() / ((update.numel() ** 0.5) * d))
-        param.add_(update, alpha=-alpha / denom)
+        param.add_(update, alpha=-alpha / denom)  # type: ignore[arg-type]
 
 
 def _group_tensors_by_device_dtype_and_is_multidim(
@@ -592,7 +592,7 @@ def _multi_tensor_adafactor(
             -a / (max(1.0, update.norm(2).item() / ((update.numel() ** 0.5) * d)))
             for a, update in zip(alphas, updates, strict=True)
         ]
-        torch._foreach_mul_(updates, alphas)
+        torch._foreach_mul_(updates, alphas)  # type: ignore[arg-type]
         torch._foreach_add_(device_params, updates)
 
 

--- a/torch/optim/_functional.py
+++ b/torch/optim/_functional.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 r"""Functional interface."""
 
 import math
@@ -53,7 +52,7 @@ def sparse_adam(
         exp_avg_sq = exp_avg_sqs[i]
         step = state_steps[i]
 
-        def make_sparse(values):
+        def make_sparse(values: Tensor) -> Tensor:
             constructor = grad.new
             if grad_indices.dim() == 0 or values.dim() == 0:
                 return constructor().resize_as_(grad)

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -249,7 +249,7 @@ def _single_tensor_adadelta(
     acc_deltas: list[Tensor],
     state_steps: list[Tensor],
     *,
-    lr: float,
+    lr: float | Tensor,
     rho: float,
     eps: float,
     weight_decay: float,
@@ -299,7 +299,7 @@ def _single_tensor_adadelta(
 
         if torch.is_complex(param):
             delta = torch.view_as_complex(delta)
-        param.add_(delta, alpha=-lr)
+        param.add_(delta, alpha=-lr)  # type: ignore[arg-type]
 
 
 def _multi_tensor_adadelta(
@@ -309,7 +309,7 @@ def _multi_tensor_adadelta(
     acc_deltas: list[Tensor],
     state_steps: list[Tensor],
     *,
-    lr: float,
+    lr: float | Tensor,
     rho: float,
     eps: float,
     weight_decay: float,
@@ -405,7 +405,7 @@ def _multi_tensor_adadelta(
             torch._foreach_mul_(deltas, -lr)
             torch._foreach_add_(device_params, deltas)
         else:
-            torch._foreach_add_(device_params, deltas, alpha=-lr)
+            torch._foreach_add_(device_params, deltas, alpha=-lr)  # type: ignore[arg-type]
 
 
 @_disable_dynamo_if_unsupported(single_tensor_fn=_single_tensor_adadelta)
@@ -422,7 +422,7 @@ def adadelta(
     differentiable: bool = False,
     has_complex: bool = False,
     *,
-    lr: float,
+    lr: float | Tensor,
     rho: float,
     eps: float,
     weight_decay: float,

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -297,7 +297,7 @@ def adagrad(
     differentiable: bool = False,
     has_complex: bool = False,
     *,
-    lr: float,
+    lr: float | Tensor,
     weight_decay: float,
     lr_decay: float,
     eps: float,
@@ -369,7 +369,7 @@ def _single_tensor_adagrad(
     grad_scale: Tensor | None,
     found_inf: Tensor | None,
     *,
-    lr: float,
+    lr: float | Tensor,
     weight_decay: float,
     lr_decay: float,
     eps: float,
@@ -410,7 +410,8 @@ def _single_tensor_adagrad(
             std = state_sum.sparse_mask(grad)
             std_values = std._values().sqrt_().add_(eps)
             param.add_(
-                _make_sparse(grad, grad_indices, grad_values / std_values), alpha=-clr
+                _make_sparse(grad, grad_indices, grad_values / std_values),
+                alpha=-clr,  # type: ignore[arg-type]
             )
         else:
             is_complex = torch.is_complex(param)
@@ -423,7 +424,7 @@ def _single_tensor_adagrad(
                 std = state_sum.sqrt() + eps
             else:
                 std = state_sum.sqrt().add_(eps)
-            param.addcdiv_(grad, std, value=-clr)
+            param.addcdiv_(grad, std, value=-clr)  # type: ignore[arg-type]
             if is_complex:
                 param = torch.view_as_complex(param)
                 state_sum = torch.view_as_complex(state_sum)
@@ -437,7 +438,7 @@ def _multi_tensor_adagrad(
     grad_scale: Tensor | None,
     found_inf: Tensor | None,
     *,
-    lr: float,
+    lr: float | Tensor,
     weight_decay: float,
     lr_decay: float,
     eps: float,

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -84,7 +84,7 @@ class Adam(Optimizer):
                 )
             if betas[1].numel() != 1:
                 raise ValueError("Tensor betas[1] must be 1-element")
-        betas = tuple(map(_to_scalar, betas))
+        betas = (_to_scalar(betas[0]), _to_scalar(betas[1]))
 
         defaults = {
             "lr": lr,
@@ -791,11 +791,11 @@ def _multi_tensor_adam(
 
             torch._foreach_div_(exp_avg_sq_sqrt, bias_correction2_sqrt)
             torch._foreach_add_(exp_avg_sq_sqrt, eps)
-            torch._foreach_addcdiv_(
+            torch._foreach_addcdiv_(  # type: ignore[arg-type]
                 device_params,
                 device_exp_avgs,
                 exp_avg_sq_sqrt,
-                step_size,  # type: ignore[arg-type]
+                step_size,
             )
 
 

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -233,7 +233,7 @@ def _single_tensor_adamax(
     eps: float,
     beta1: float,
     beta2: float,
-    lr: float,
+    lr: float | Tensor,
     weight_decay: float,
     maximize: bool,
     differentiable: bool,
@@ -300,7 +300,7 @@ def _single_tensor_adamax(
             bias_correction = 1 - beta1 ** _get_value(step_t)
             clr = lr / bias_correction
 
-            param.addcdiv_(exp_avg, exp_inf, value=-clr)
+            param.addcdiv_(exp_avg, exp_inf, value=-clr)  # type: ignore[arg-type]
 
 
 def _multi_tensor_adamax(
@@ -313,7 +313,7 @@ def _multi_tensor_adamax(
     eps: float,
     beta1: float,
     beta2: float,
-    lr: float,
+    lr: float | Tensor,
     weight_decay: float,
     maximize: bool,
     differentiable: bool,
@@ -416,7 +416,7 @@ def _multi_tensor_adamax(
                 1 - beta1 ** _get_value(step) for step in grouped_state_steps
             ]
             step_size = [(_get_value(lr) / bc) * -1 for bc in bias_corrections]
-            torch._foreach_addcdiv_(
+            torch._foreach_addcdiv_(  # type: ignore[arg-type]
                 grouped_params, grouped_exp_avgs, grouped_exp_infs, step_size
             )
 
@@ -439,7 +439,7 @@ def adamax(
     eps: float,
     beta1: float,
     beta2: float,
-    lr: float,
+    lr: float | Tensor,
     weight_decay: float,
 ) -> None:
     r"""Functional API that performs adamax algorithm computation.

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from torch import Tensor
 
 from .adam import Adam, adam
@@ -11,6 +9,7 @@ from .optimizer import (
     _maximize_doc,
     _params_doc,
     ParamsT,
+    StateDict,
 )
 
 
@@ -51,7 +50,7 @@ class AdamW(Adam):
     # Preserve decoupled_weight_decay from AdamW for backwards compatibility. The following
     # guarantees that decoupled_weight_decay will always be True for loading any state into
     # AdamW
-    def __setstate__(self, state: dict[str, Any]) -> None:
+    def __setstate__(self, state: StateDict) -> None:
         super().__setstate__(state)
         for group in self.param_groups:
             group["decoupled_weight_decay"] = True

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -1,4 +1,4 @@
-# mypy: allow-untyped-defs
+from typing import Any
 
 from torch import Tensor
 
@@ -51,7 +51,7 @@ class AdamW(Adam):
     # Preserve decoupled_weight_decay from AdamW for backwards compatibility. The following
     # guarantees that decoupled_weight_decay will always be True for loading any state into
     # AdamW
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, Any]) -> None:
         super().__setstate__(state)
         for group in self.param_groups:
             group["decoupled_weight_decay"] = True

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -203,7 +203,7 @@ def _single_tensor_asgd(
     state_steps: list[Tensor],
     *,
     lambd: float,
-    lr: float,
+    lr: float | Tensor,
     t0: float,
     alpha: float,
     weight_decay: float,
@@ -255,7 +255,7 @@ def _single_tensor_asgd(
         else:
             eta_value = _get_value(eta)
             param.mul_(1 - lambd * eta_value)  # decay term
-            param.add_(grad, alpha=-eta_value)  # update parameter
+            param.add_(grad, alpha=-eta_value)  # type: ignore[arg-type]  # update parameter
 
         # averaging
         if capturable or mu.item() != 1:
@@ -283,7 +283,7 @@ def _multi_tensor_asgd(
     state_steps: list[Tensor],
     *,
     lambd: float,
-    lr: float,
+    lr: float | Tensor,
     t0: float,
     alpha: float,
     weight_decay: float,
@@ -437,7 +437,7 @@ def asgd(
     has_complex: bool = False,
     *,
     lambd: float,
-    lr: float,
+    lr: float | Tensor,
     t0: float,
     alpha: float,
     weight_decay: float,

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -288,7 +288,7 @@ def _single_tensor_nadam(
     *,
     beta1: float,
     beta2: float,
-    lr: float,
+    lr: float | Tensor,
     weight_decay: float,
     momentum_decay: float,
     eps: float,
@@ -369,7 +369,9 @@ def _single_tensor_nadam(
             mu_product_next = _get_value(mu_product) * mu_next
             denom.add_(eps)
             param.addcdiv_(
-                grad, denom, value=(-lr * (1.0 - mu) / (1.0 - _get_value(mu_product)))
+                grad,
+                denom,
+                value=(-lr * (1.0 - mu) / (1.0 - _get_value(mu_product))),  # type: ignore[arg-type]
             )
             param.addcdiv_(
                 exp_avg,
@@ -388,7 +390,7 @@ def _multi_tensor_nadam(
     *,
     beta1: float,
     beta2: float,
-    lr: float,
+    lr: float | Tensor,
     weight_decay: float,
     momentum_decay: float,
     eps: float,
@@ -587,17 +589,17 @@ def _multi_tensor_nadam(
                 ]
             )
 
-            torch._foreach_addcdiv_(
+            torch._foreach_addcdiv_(  # type: ignore[arg-type]
                 grouped_params,
                 grouped_grads,
                 exp_avg_sq_sqrt,
-                step_size_grads,  # type: ignore[arg-type]
+                step_size_grads,
             )
-            torch._foreach_addcdiv_(
+            torch._foreach_addcdiv_(  # type: ignore[arg-type]
                 grouped_params,
                 grouped_exp_avgs,
                 exp_avg_sq_sqrt,
-                step_size_expavg,  # type: ignore[arg-type]
+                step_size_expavg,
             )
 
 
@@ -620,7 +622,7 @@ def nadam(
     *,
     beta1: float,
     beta2: float,
-    lr: float,
+    lr: float | Tensor,
     weight_decay: float,
     momentum_decay: float,
     eps: float,

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -3,7 +3,7 @@
 import functools
 import warnings
 from collections import defaultdict, OrderedDict
-from collections.abc import Callable, Hashable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from copy import deepcopy
 from itertools import chain
 from typing import Any, cast, overload, TypeAlias, TypeVar
@@ -86,7 +86,15 @@ def _use_grad_for_differentiable(func: Callable[_P, _T]) -> Callable[_P, _T]:
     return _use_grad
 
 
-def _get_value(x: torch.Tensor | float) -> Any:
+@overload
+def _get_value(x: torch.Tensor) -> torch.Tensor: ...
+
+
+@overload
+def _get_value(x: float) -> float: ...
+
+
+def _get_value(x: torch.Tensor | float) -> torch.Tensor | float:
     # item is significantly faster than a cpu tensor in eager mode
     if not torch.jit.is_scripting() and torch.compiler.is_compiling():
         return x
@@ -94,7 +102,9 @@ def _get_value(x: torch.Tensor | float) -> Any:
         return x.item() if isinstance(x, torch.Tensor) else x
 
 
-def _stack_if_compiling(x: list[torch.Tensor | float]) -> Any:
+def _stack_if_compiling(
+    x: Sequence[torch.Tensor | float],
+) -> torch.Tensor | Sequence[torch.Tensor | float]:
     if not torch.jit.is_scripting() and torch.compiler.is_compiling():
         return torch.stack(cast(list[torch.Tensor], x))
     else:
@@ -226,7 +236,15 @@ def _get_capturable_supported_devices(supports_xla: bool = True) -> list[str]:
     return capturable_supported_devices
 
 
-def _to_scalar(x: float | torch.Tensor) -> Any:
+@overload
+def _to_scalar(x: torch.Tensor) -> torch.Tensor: ...
+
+
+@overload
+def _to_scalar(x: float) -> float: ...
+
+
+def _to_scalar(x: torch.Tensor | float) -> torch.Tensor | float:
     r"""This function converts a hyperparameter to a 0-dimension (scalar) tensor
     if it is a nonzero-dimensions 1-element tensor. If it is not a tensor, it is
     kept as is.
@@ -776,8 +794,8 @@ class Optimizer:
         param: torch.Tensor,
         value: torch.Tensor,
         param_id: int,
-        param_groups: list[dict[Any, Any]],
-        key: Hashable = None,
+        param_groups: list[dict[str, Any]],
+        key: str | None = None,
     ) -> torch.Tensor:
         # Floating-point types are a bit special here. They are the only ones
         # that are assumed to always match the type of params.
@@ -964,36 +982,35 @@ class Optimizer:
 
         def _cast(
             param: torch.Tensor,
-            value: Any,
-            param_id: int | None = None,
-            param_groups: list[dict[str, Any]] | None = None,
-            key: Hashable = None,
-        ) -> Any:
+            value: _T,
+            param_id: int,
+            param_groups: list[dict[str, Any]],
+            key: str | None = None,
+        ) -> _T:
             r"""Make a deep copy of value, casting all tensors to device of param."""
             if isinstance(value, torch.Tensor):
-                return Optimizer._process_value_according_to_param_policy(
-                    param,
-                    value,
-                    # pyrefly: ignore [bad-argument-type]
-                    param_id,
-                    # pyrefly: ignore [bad-argument-type]
-                    param_groups,
-                    key,
+                return cast(
+                    _T,
+                    Optimizer._process_value_according_to_param_policy(
+                        param, value, param_id, param_groups, key
+                    ),
                 )
             elif isinstance(value, dict):
-                return {
+                casted = {
                     k: _cast(
                         param, v, param_id=param_id, param_groups=param_groups, key=k
                     )
                     for k, v in value.items()
                 }
+                return cast(_T, casted)
             elif isinstance(value, Iterable):
                 # pyrefly: ignore [bad-instantiation]
-                return type(value)(
+                rebuilt = type(value)(
                     # pyrefly: ignore [bad-argument-count]
                     _cast(param, v, param_id=param_id, param_groups=param_groups)
                     for v in value
                 )  # type: ignore[call-arg]
+                return cast(_T, rebuilt)
             else:
                 return value
 

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 """Base optimizer."""
 
 import functools
@@ -87,7 +86,7 @@ def _use_grad_for_differentiable(func: Callable[_P, _T]) -> Callable[_P, _T]:
     return _use_grad
 
 
-def _get_value(x):
+def _get_value(x: torch.Tensor | float) -> Any:
     # item is significantly faster than a cpu tensor in eager mode
     if not torch.jit.is_scripting() and torch.compiler.is_compiling():
         return x
@@ -95,9 +94,9 @@ def _get_value(x):
         return x.item() if isinstance(x, torch.Tensor) else x
 
 
-def _stack_if_compiling(x):
+def _stack_if_compiling(x: list[torch.Tensor | float]) -> Any:
     if not torch.jit.is_scripting() and torch.compiler.is_compiling():
-        return torch.stack(x)
+        return torch.stack(cast(list[torch.Tensor], x))
     else:
         return x
 
@@ -129,7 +128,7 @@ def _disable_dynamo_if_unsupported(
         # but this only occurs in the rare case that the user explicitly deletes
         # the capturable flag. If capturable=True, this is not a problem.
         @functools.wraps(func)
-        def maybe_fallback(*args: _P.args, **kwargs: _P.kwargs):
+        def maybe_fallback(*args: _P.args, **kwargs: _P.kwargs) -> _T:
             if torch.compiler.is_compiling() and (
                 not kwargs.get("capturable", False)
                 and has_state_steps
@@ -199,7 +198,9 @@ def _device_dtype_check_for_fused(
         )
 
 
-def _view_as_real(params, *state_and_grads) -> None:
+def _view_as_real(
+    params: list[torch.Tensor], *state_and_grads: list[torch.Tensor]
+) -> None:
     for i, p in enumerate(params):
         if torch.is_complex(p):
             params[i] = torch.view_as_real(params[i])
@@ -207,7 +208,7 @@ def _view_as_real(params, *state_and_grads) -> None:
                 s[i] = torch.view_as_real(s[i])
 
 
-def _get_scalar_dtype(is_fused=None):
+def _get_scalar_dtype(is_fused: bool | None = None) -> torch.dtype:
     if is_fused:
         return torch.float32
     return (
@@ -225,7 +226,7 @@ def _get_capturable_supported_devices(supports_xla: bool = True) -> list[str]:
     return capturable_supported_devices
 
 
-def _to_scalar(x: float | torch.Tensor):
+def _to_scalar(x: float | torch.Tensor) -> Any:
     r"""This function converts a hyperparameter to a 0-dimension (scalar) tensor
     if it is a nonzero-dimensions 1-element tensor. If it is not a tensor, it is
     kept as is.
@@ -402,7 +403,7 @@ class Optimizer:
             param_groups = [{"params": param_groups}]
 
         for param_group in param_groups:
-            self.add_param_group(cast(dict, param_group))
+            self.add_param_group(cast(dict[str, Any], param_group))
 
         # Allows _accelerator_graph_capture_health_check to rig a poor man's TORCH_WARN_ONCE in python,
         # which I don't think exists
@@ -961,7 +962,13 @@ class Optimizer:
             )
         )
 
-        def _cast(param, value, param_id=None, param_groups=None, key=None):
+        def _cast(
+            param: torch.Tensor,
+            value: Any,
+            param_id: int | None = None,
+            param_groups: list[dict[str, Any]] | None = None,
+            key: Hashable = None,
+        ) -> Any:
             r"""Make a deep copy of value, casting all tensors to device of param."""
             if isinstance(value, torch.Tensor):
                 return Optimizer._process_value_according_to_param_policy(
@@ -1124,8 +1131,8 @@ class Optimizer:
         else:
             param_group["params"] = list(params)
 
-        extracted_param_tensors = []
-        extracted_param_names = []
+        extracted_param_tensors: list[torch.Tensor] = []
+        extracted_param_names: list[str] = []
         for param in param_group["params"]:
             if isinstance(param, tuple):
                 param_name = param[0]

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -270,7 +270,7 @@ def _single_tensor_rmsprop(
     momentum_buffer_list: list[Tensor],
     state_steps: list[Tensor],
     *,
-    lr: float,
+    lr: float | Tensor,
     alpha: float,
     eps: float,
     weight_decay: float,
@@ -334,9 +334,9 @@ def _single_tensor_rmsprop(
             if is_complex_param:
                 buf = torch.view_as_real(buf)
             buf.mul_(momentum).addcdiv_(grad, avg)
-            param.add_(buf, alpha=-lr)
+            param.add_(buf, alpha=-lr)  # type: ignore[arg-type]
         else:
-            param.addcdiv_(grad, avg, value=-lr)
+            param.addcdiv_(grad, avg, value=-lr)  # type: ignore[arg-type]
 
 
 def _multi_tensor_rmsprop(
@@ -347,7 +347,7 @@ def _multi_tensor_rmsprop(
     momentum_buffer_list: list[Tensor],
     state_steps: list[Tensor],
     *,
-    lr: float,
+    lr: float | Tensor,
     alpha: float,
     eps: float,
     weight_decay: float,
@@ -460,7 +460,7 @@ def _multi_tensor_rmsprop(
                 momentum_lr = torch._foreach_mul(grouped_momentum_buffer_list, -lr)
                 torch._foreach_add_(grouped_params, momentum_lr)
             else:
-                torch._foreach_add_(
+                torch._foreach_add_(  # type: ignore[arg-type]
                     grouped_params, grouped_momentum_buffer_list, alpha=-lr
                 )
         else:
@@ -470,7 +470,9 @@ def _multi_tensor_rmsprop(
                 torch._foreach_div_(avg, -lr)
                 torch._foreach_addcdiv_(grouped_params, grouped_grads, avg)
             else:
-                torch._foreach_addcdiv_(grouped_params, grouped_grads, avg, value=-lr)
+                torch._foreach_addcdiv_(  # type: ignore[arg-type]
+                    grouped_params, grouped_grads, avg, value=-lr
+                )
 
 
 @_disable_dynamo_if_unsupported(single_tensor_fn=_single_tensor_rmsprop)
@@ -489,7 +491,7 @@ def rmsprop(
     capturable: bool = False,
     has_complex: bool = False,
     *,
-    lr: float,
+    lr: float | Tensor,
     alpha: float,
     eps: float,
     weight_decay: float,

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -263,7 +263,7 @@ def sgd(
     *,
     weight_decay: float,
     momentum: float,
-    lr: float,
+    lr: float | Tensor,
     dampening: float,
     nesterov: bool,
     maximize: bool,
@@ -328,7 +328,7 @@ def _single_tensor_sgd(
     *,
     weight_decay: float,
     momentum: float,
-    lr: float,
+    lr: float | Tensor,
     dampening: float,
     nesterov: bool,
     maximize: bool,
@@ -388,7 +388,7 @@ def _multi_tensor_sgd(
     *,
     weight_decay: float,
     momentum: float,
-    lr: float,
+    lr: float | Tensor,
     dampening: float,
     nesterov: bool,
     maximize: bool,
@@ -469,11 +469,11 @@ def _multi_tensor_sgd(
                 grads_x_lr = torch._foreach_mul(device_grads, -lr)
                 torch._foreach_add_(device_params, grads_x_lr)
             else:
-                torch._foreach_add_(device_params, device_grads, alpha=-lr)
+                torch._foreach_add_(device_params, device_grads, alpha=-lr)  # type: ignore[arg-type]
         else:
             # foreach APIs don't support sparse
             for i in range(len(device_params)):
-                device_params[i].add_(device_grads[i], alpha=-lr)
+                device_params[i].add_(device_grads[i], alpha=-lr)  # type: ignore[arg-type]
 
 
 def _fused_sgd(
@@ -485,7 +485,7 @@ def _fused_sgd(
     *,
     weight_decay: float,
     momentum: float,
-    lr: float,
+    lr: float | Tensor,
     dampening: float,
     nesterov: bool,
     maximize: bool,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191253

Annotates and turns on whole-file pyrefly checking (per-file [[sub-config]]
entries) for torch/optim/{optimizer,adamw,_functional}.py. Fourth batch of the
effort to enable annotation checking on non-public torch files.

These are the only three optim files that qualify: the concrete optimizers
(adam, sgd, ...) and Adafactor/Muon expose a public step() re-exported via
torch.optim.__all__, so turning on strict checking for them is out of scope.

Most of the diff gives optimizer.py's shared numeric helpers real types instead
of Any: _get_value and _to_scalar are overloaded (Tensor->Tensor / float->float),
_stack_if_compiling returns torch.Tensor | Sequence[torch.Tensor | float], and
_cast is a structure-preserving _T -> _T TypeVar.

Typing them surfaced a latent annotation bug: several _single_tensor_*/
_multi_tensor_* helpers declared lr: float even though tensor LR is supported
(the code branches on isinstance(lr, torch.Tensor)) -- the Any returns had
masked it. Those params are widened to float | Tensor to match the convention
adam.py already uses. Where a possibly-tensor lr then reaches a scalar-only
Tensor API (add_ alpha=, addcdiv_ value=, _foreach_*), a scoped
`# type: ignore[arg-type]` documents the eager/compile duality (scalar in eager,
tensor under torch.compile) that no static type expresses -- again the pattern
adam.py already uses.

Test Plan:

```
lintrunner -a torch/optim/*.py
pyrefly check   # whole project: 156 errors == baseline, no net-new
```

The changes are type-only (annotations, casts, # type: ignore comments, and a
semantically-identical rewrite of adam's betas tuple construction) with no
runtime behavior change. test/test_optim.py was not run here because the local
torch._C extension is stale (unrelated missing symbols); run it after a rebuild.

Authored with Claude.