### PR TITLE
Reserve issue status labels for human reviewers

### DIFF
--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -70,7 +70,7 @@ Use these GitHub MCP tools for triage:
 | `ci-*`, `ci:*` | CI infrastructure controls |
 | `sev*` | Severity labels require human decision |
 | `merge blocking` | Requires human decision |
-| `actionable` | Requires human decision |
+| `actionable`, `needs design`, `needs reproduction`, `needs research` | Reserved for human reviewers after they have reviewed the issue |
 | Any label containing "deprecated" | Obsolete |
 | `oncall: releng` | Not a triage redirect target. Use `module: ci` instead |
 
@@ -101,7 +101,7 @@ That issue belongs to the sub-oncall team. They own their queue.
 - If it is a question (not a bug report or feature request): close and use the `redirect_to_forum` template from `templates.json`.
 - If unclear whether it is a bug/feature vs a question: request additional information using the `request_more_info` template and stop.
 
-### 1.5) Needs Reproduction — External Files
+### 1.5) External Files
 
 Check if the issue body contains links to external files that users would need to download to reproduce.
 
@@ -113,13 +113,12 @@ Check if the issue body contains links to external files that users would need t
 **Action:**
 1. **Edit the issue body** to remove/redact the download links
    - Replace with: `[Link removed - external file downloads are not permitted for security reasons]`
-2. Add `needs reproduction` label
-3. Use the `needs_reproduction` template from `templates.json` to request a self-contained reproduction
-4. Do NOT add `triaged` — wait for the user to provide a reproducible example
+2. Use the `request_self_contained_reproduction` template from `templates.json`
+3. Do NOT add `triaged` — wait for the user to provide a reproducible example
 
-### 1.55) Needs Reproduction — Other Cases
+### 1.55) Missing Reproduction — Other Cases
 
-Also add `needs reproduction` when:
+Request a self-contained reproduction and stop when:
 - The user reports a hardware-specific issue (e.g., specific GPU model) without a self-contained repro script
 - The user references a specific model/checkpoint/dataset that is not publicly runnable in a few lines
 - The issue describes version-upgrade breakage but only provides a high-level description without a minimal script

--- a/.claude/skills/triaging-issues/labels.json
+++ b/.claude/skills/triaging-issues/labels.json
@@ -1016,18 +1016,6 @@
       "description": "Intel XPU related issues"
     },
     {
-      "name": "needs design",
-      "description": "We want to add this feature but we need to figure out how first"
-    },
-    {
-      "name": "needs reproduction",
-      "description": "Ensure you have actionable steps to reproduce the issue. Someone else needs to confirm the repro. Add when issue requires downloading external files (.zip, .pt, .pth, .pkl, .safetensors) or links to external storage (Google Drive, Dropbox) to reproduce."
-    },
-    {
-      "name": "needs research",
-      "description": "We need to decide whether or not this merits inclusion, based on research world"
-    },
-    {
       "name": "newcomer",
       "description": ""
     },

--- a/.claude/skills/triaging-issues/scripts/validate_labels.py
+++ b/.claude/skills/triaging-issues/scripts/validate_labels.py
@@ -43,6 +43,9 @@ FORBIDDEN_PATTERNS = [
 FORBIDDEN_EXACT = [
     "actionable",
     "merge blocking",
+    "needs design",
+    "needs reproduction",
+    "needs research",
     "oncall: releng",  # Not a triage redirect target; use module: ci instead
 ]
 

--- a/.claude/skills/triaging-issues/templates.json
+++ b/.claude/skills/triaging-issues/templates.json
@@ -11,8 +11,8 @@
       "use_when": "Classification is unclear and more details are needed to decide between question vs bug/feature",
       "comment": "Thanks for the report. To triage this, could you share:\n\n- A minimal repro (small script or steps)\n- Full error logs / stack trace\n- Output of `python -m torch.utils.collect_env`\n\nOnce we have that, we can classify and route this properly."
     },
-    "needs_reproduction": {
-      "action": "Edit issue to remove external links, add label 'needs reproduction', and comment",
+    "request_self_contained_reproduction": {
+      "action": "Edit issue to remove external links, request a self-contained reproduction, and stop",
       "use_when": "Issue requires downloading external files (.zip, .pt, .pth, .pkl, .safetensors, .onnx, .bin) or links to external storage (Google Drive, Dropbox, OneDrive, Mega, WeTransfer, Hugging Face Hub model files) to reproduce",
       "comment": "Thanks for the report! To help us investigate:\n\n1. Can you reproduce this without the external files? (e.g., using random weights or synthetic data)\n2. Are there any extreme or special values in the weights/inputs? (e.g., very large values, NaN, inf)\n\nA self-contained script that doesn't require downloading files helps maintainers reproduce and debug the issue faster."
     },


### PR DESCRIPTION
## Author Notes

Follow up from the actionable change. As we're leaning towards these labels being more explicit of human intent.

## Agent Notes

> This AI-assisted change prevents the issue triage bot from adding `actionable`, `needs design`, `needs reproduction`, or `needs research`. It removes the three previously allowed labels from the bot catalog, enforces the restriction in the validation hook, and preserves reproduction requests without applying a reserved label.
>
> Testing: focused hook assertions and targeted `spin lint` pass. Full `spin lint` encounters unrelated Pyrefly failures on current `main`.
