### PR TITLE
[CI] Bound Claude Bedrock request retries

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -19,6 +19,8 @@ jobs:
     with:
       model: global.anthropic.claude-opus-5
       additional_claude_args: '--allowedTools Skill'
+      # Surface stalled Bedrock requests before the one-hour job timeout.
+      settings: '{"alwaysThinkingEnabled":true,"env":{"API_TIMEOUT_MS":"180000","CLAUDE_CODE_MAX_RETRIES":"2","CLAUDE_ENABLE_STREAM_WATCHDOG":"1"}}'
       append_system_prompt: |
         When asked to review a PR, always use the /pr-review skill first.
         It contains PyTorch-specific review guidelines, output format, and critical checks.


### PR DESCRIPTION
A stalled Bedrock request can currently remain silent until the Claude workflow hits its one-hour job timeout. Claude Code defaults to a 10-minute API timeout and up to 10 retries, so its request-level retry window can outlive the job.

Set a 3-minute API timeout with two retries and explicitly enable the stream watchdog. This should surface a useful SDK failure after roughly nine minutes plus backoff instead of losing the run at the job timeout.

Validated the same settings in pytorch/ciforge run 30305320300: Opus 5 initialized and completed successfully in 12.8 seconds over 3 turns.