### PR TITLE
[CUDA][Triton] Use `codegen_block_ptr` in `store_reduction`

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6067,15 +6067,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self._handle_pdl_before_access(self.post_loop_store, var)
 
         if isinstance(indexing, (BlockPtrOptions, TensorDescriptorOptions)):
+            block_descriptor, other = self.codegen_block_ptr(name, var, indexing)
             self.post_loop_store.writeline(
                 DeferredLine(
                     name,
                     self.codegen_block_ptr_store_line(
                         name,
                         indexing,
-                        indexing.format(var),
+                        block_descriptor,
                         value,
-                        f", boundary_check={indexing.boundary_check()!r}",
+                        other,
                     ),
                 )
             )


### PR DESCRIPTION
Otherwise we seem to be dropping constraints like `tma_min_block_sizes={"XBLOCK": 4}` which caused e.g.,

```
torch._inductor.exc.InductorError: CompilationError: at 45:4:
        tmp13_mean_next, tmp13_m2_next, tmp13_weight_next = triton_helpers.welford_combine(
            tmp13_mean, tmp13_m2, tmp13_weight,
            tmp10, tmp11, tmp12
        )
        tmp13_mean = tl.where(r0_mask & xmask, tmp13_mean_next, tmp13_mean)
        tmp13_m2 = tl.where(r0_mask & xmask, tmp13_m2_next, tmp13_m2)
        tmp13_weight = tl.where(r0_mask & xmask, tmp13_weight_next, tmp13_weight)
    tmp14, tmp15, tmp16 = triton_helpers.welford(tmp13_mean, tmp13_m2, tmp13_weight, 1)
    tmp13 = tmp14[:, None]
    tmp17 = tmp15[:, None]
    tmp18 = tmp16[:, None]
    tl.make_tensor_descriptor(out_ptr0, shape=[10], strides=[1], block_shape=[XBLOCK]).store([xoffset], tl.reshape(tl.broadcast_to(tmp13, [XBLOCK, 1]), [XBLOCK]).to(tl.float32))
    ^
Descriptor block shape must have at least 16 bytes in the last dimension, but got 1 * 4 = 4 bytes

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"


To execute this test, run the following from the base repo dir:
    python test/inductor/test_torchinductor_strided_blocks.py TritonTensorDescriptorTestCUDA.test_welford_non_block_pointer_cuda
 ```
    



    to fail after #188579 exercised this path
    
    authored with codex

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo