### PR TITLE
[inductor] Guard 3D attention key permutations (#191260)

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -913,6 +913,35 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             rtol=1e-2,
         )
 
+    def _test_sdpa_rewriter_13_non_transpose_permute(self, dtype):
+        def dot_prod_attention(
+            query: torch.Tensor,
+            key: torch.Tensor,
+            value: torch.Tensor,
+            training: bool,
+        ) -> torch.Tensor:
+            attn_weight = torch.bmm(query, key.permute(1, 2, 0)).softmax(dim=-1)
+            attn_weight = torch.nn.functional.dropout(
+                attn_weight, p=0.5, training=training
+            )
+            return torch.bmm(attn_weight, value)
+
+        args = [
+            torch.randn((8, 3, 4), device=self.device, dtype=dtype),
+            torch.randn((3, 8, 4), device=self.device, dtype=dtype),
+            torch.randn((8, 3, 4), device=self.device, dtype=dtype),
+        ]
+        self._check_common(
+            dot_prod_attention,
+            args1=args,
+            contains=False,
+            has_fuse_pattern=False,
+            has_dropout=True,
+            check_train=False,
+            override_check_equal=True,
+        )
+        self.assertEqual(counters["inductor"]["fuse_attention"], 0)
+
     def _test_sdpa_rewriter_14(self):
         def dot_prod_attention(
             query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
@@ -2012,6 +2041,13 @@ if HAS_CPU:
 
     class SDPAPatternRewriterCpuDynamicTests(SDPAPatternRewriterCpuTests):
         use_static_shapes = False
+
+    class SDPAPatternRewriterPatternGuardCpuTests(TestSDPAPatternRewriterTemplate):
+        device = "cpu"
+        test_sdpa_rewriter_13_non_transpose_permute_cpu = functools.partialmethod(
+            TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_13_non_transpose_permute,
+            dtype=torch.float32,
+        )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -992,6 +992,17 @@ def _sfdp_params_check(match):
     return True
 
 
+def _sfdp_pattern_13_check(match):
+    if not _sfdp_params_check(match):
+        return False
+    permutes = filter_nodes(match.nodes, aten.permute.default)
+    if len(permutes) != 1:
+        return False
+    # The serialized pattern wildcard-matches the permute dimensions.
+    permute_dims = permutes[0].args[1]
+    return isinstance(permute_dims, (list, tuple)) and tuple(permute_dims) == (0, 2, 1)
+
+
 def _sfdp_extra_check(scale_factor_op=None, disable_cuda=False):
     def fn(match):
         if (
@@ -1210,7 +1221,7 @@ def _get_sfdp_patterns(input_device: torch.device | None = None):
                 _sfdp_replacement_13,
                 [g_3d(), g_3d(), g_3d()],
                 d,
-                _sfdp_params_check,
+                _sfdp_pattern_13_check,
             ),
             (
                 _sfdp_pattern_14,


### PR DESCRIPTION
Summary:

The serialized SDPA pattern 13 wildcard-matches its key permute dimensions: pattern serialization records the permute `dims` argument as `Ignored()` (a match-anything placeholder), so the stored pattern accepts any key permutation, not only the `(0, 2, 1)` transpose it was traced from. See `torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_13.py:34`:

    permute_default = CallFunction(aten.permute.default, KeywordArg('key'), Ignored())

`_sfdp_pattern_13_check` now requires the exact `(0, 2, 1)` transpose so non-transpose 3D BMM attention stays unfused instead of failing while tracing the replacement. Convert the captured Full Inductor error into a positive memref regression.

Test Plan:
- Core false-match regression: pass (1 test), Buck 62f6d69b-82b3-45ea-b5fb-41724d95c04d
- Existing valid pattern 13 static and dynamic tests: pass (2 tests), Buck c5b99c37-c16b-43b1-96ce-33c78878cdb4
- Focused FBA positive regression: pass (1 test), Buck 67d08fca-f4ca-4cbb-b67e-a0bc90a94b0e
- Full Full-Inductor literal suite: pass (18 tests), Buck 171e8470-07a4-48ab-aab2-165d8fa695ee
- Production `2146720540_143`: all Full Inductor subgraphs compiled; execution reached MTIA and stopped on an unrelated device OOM
- `arc lint`
- Citrine
- `arc pyre check-owning-targets`

Reviewed By: blaine-rister

Differential Revision: D113828926




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo