### PR TITLE
Run descr_check when binding wrapper/method descriptors in Dynamo (#190755)

### DIFF
--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -547,6 +547,76 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)()
         self.assertEqual(sorted(result), ["a", "b"])
 
+    def test_method_descriptor_bind_wrong_type_raises(self):
+        """Binding a method_descriptor (list.append) to a wrong-type object
+        raises TypeError at bind time (descr_check), matching eager."""
+
+        class Borrower:
+            append = list.append
+
+        def fn(x, obj):
+            try:
+                _ = obj.append
+                return x + 1
+            except TypeError:
+                return x + 2
+
+        x = torch.randn(4)
+        obj = Borrower()
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x, obj)
+        self.assertEqual(compiled, fn(x, obj))
+
+    def test_method_descriptor_bind_subclass_ok(self):
+        """Binding a method_descriptor to a subclass instance does not raise."""
+
+        class SubList(list):
+            pass
+
+        class Holder(SubList):
+            append = list.append
+
+        def fn(obj):
+            obj.append(9)
+            return obj
+
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)(Holder([1, 2]))
+        self.assertEqual(compiled, fn(Holder([1, 2])))
+
+    def test_wrapper_descriptor_bind_wrong_type_raises(self):
+        """Binding a wrapper_descriptor (list.__add__) to a wrong-type object
+        raises TypeError at bind time (descr_check), matching eager."""
+
+        class Borrower:
+            add = list.__add__
+
+        def fn(x, obj):
+            try:
+                _ = obj.add
+                return x + 1
+            except TypeError:
+                return x + 2
+
+        x = torch.randn(4)
+        obj = Borrower()
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x, obj)
+        self.assertEqual(compiled, fn(x, obj))
+
+    def test_wrapper_descriptor_bind_subclass_ok(self):
+        """Binding a wrapper_descriptor to a subclass instance does not raise."""
+
+        class SubList(list):
+            pass
+
+        class Holder(SubList):
+            add = list.__add__
+
+        def fn(obj):
+            return obj.add([9])
+
+        obj = Holder([1, 2])
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)(obj)
+        self.assertEqual(compiled, fn(obj))
+
     def test_classmethod_descriptor_dict_fromkeys(self):
         """dict.fromkeys is a classmethod_descriptor."""
 

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -4024,6 +4024,20 @@ class WrapperDescriptorVariable(VariableTracker):
         # a bound method-wrapper.
         # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L203-L213
         # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L1489-L1505
+        # descr_check: wrapperdescr_get rejects binding to an object that is
+        # not an instance of the descriptor's owning type.
+        # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L79-L91
+        try:
+            obj_type = obj.python_type()
+            if not issubclass(obj_type, self.descriptor.__objclass__):
+                raise_type_error(
+                    tx,
+                    f"descriptor '{self.descriptor.__name__}' for "
+                    f"'{self.descriptor.__objclass__.__name__}' objects "
+                    f"doesn't apply to a '{obj_type.__name__}' object",
+                )
+        except NotImplementedError:
+            pass
         return MethodWrapperVariable(self.descriptor, obj, source=self.source)
 
 
@@ -4216,6 +4230,20 @@ class MethodDescriptorVariable(VariableTracker):
         # bound builtin_function_or_method.
         # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L137-L159
         # https://github.com/python/cpython/blob/3.13/Objects/methodobject.c#L40
+        # descr_check: method_get rejects binding to an object that is not an
+        # instance of the descriptor's owning type.
+        # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L79-L91
+        try:
+            obj_type = obj.python_type()
+            if not issubclass(obj_type, self.descriptor.__objclass__):
+                raise_type_error(
+                    tx,
+                    f"descriptor '{self.descriptor.__name__}' for "
+                    f"'{self.descriptor.__objclass__.__name__}' objects "
+                    f"doesn't apply to a '{obj_type.__name__}' object",
+                )
+        except NotImplementedError:
+            pass
         return BoundBuiltinMethodVariable(self.descriptor, obj, source=self.source)
 
 


### PR DESCRIPTION
## Issue

Fixes #190755

## Summary

CPython's descriptor `__get__` slots run `descr_check`, which raises TypeError when a descriptor is bound to an object that isn't an instance of its owning type. Dynamo's `tp_descr_get_impl` (the bind path) skipped this for `wrapper_descriptor` and `method_descriptor`. So under `torch.compile`, a bind like `obj.append` (with `list.append` borrowed onto a non-list class) succeeded silently instead of raising, and the traced program took the wrong branch. This PR adds the check to `WrapperDescriptorVariable.tp_descr_get_impl` and `MethodDescriptorVariable.tp_descr_get_impl`, reusing the `issubclass` pattern already in `MethodDescriptorVariable.call_function`: raise for a wrong-type instance, accept subclasses, skip when the type isn't statically known.

Scope is limited to those two. Notes on the rest:
- `property` and `staticmethod`: CPython doesn't call `descr_check` for them (property binds to any instance, staticmethod ignores the instance), so there's nothing to add.
- `classmethod_descriptor`: binds against the type rather than the instance, so its check semantics differ. Left out here.
- `MemberDescriptor`/`GetSetDescriptor`: already delegate to the real `__get__` (which runs `descr_check`), but wrap it in `except (AttributeError, TypeError): raise_observed_exception(AttributeError, ...)`, which turns the TypeError into an AttributeError. That's a separate bug (wrong exception type, not a missing check) and isn't addressed here.

## Checklist

- [ ] Passes lint (`spin fixlint`) — full lintrunner won't run locally on Windows (its clang-format bootstrap is unsupported there); the change is ASCII, short lines, and copies an existing lint-passing block, so CI lint should cover it
- [x] Added/updated tests
- [ ] Updated documentation (if applicable) — N/A
- [ ] Included benchmark results (for PRs impacting perf) — N/A

## BC-breaking?

No.

---

_This change was prepared with the help of an AI coding assistant and reviewed by me before submission._


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98