### PR TITLE
[dynamo, nested graph breaks] fix mark_static_input crash on non-tensor VTs

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1701,6 +1701,46 @@ class SubclassTests(_SubclassCompileCheckMixin, torch._dynamo.test_case.TestCase
             # Recompile 2 times, first with dim 0 become Dynamic, second with dim 1 becomes Dynamic.
             test_automatic_dynamic(f, [x, b, z], dim_dynamic, 3, 3)
 
+    def test_parametrized_subclass_param_nested_graph_break(self):
+        # Regression test: under nested graph breaks, realizing the value stack
+        # for a partial subgraph routes a module with a tensor-subclass parameter
+        # through wrap_module -> mark_static_input. The subclass param is tracked
+        # as a UserDefinedObjectVariable (no graph proxy node), which previously
+        # crashed with "'UserDefinedObjectVariable' object has no attribute 'proxy'".
+        from torch.nn.utils.parametrize import (
+            register_parametrization,
+            remove_parametrizations,
+        )
+        from torch.testing._internal.common_subclass import (
+            subclass_db,
+            WrapperTensorWithCustomSizes,
+        )
+
+        create_fn = subclass_db[WrapperTensorWithCustomSizes].create_fn
+
+        def body():
+            class MyModule(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.weight = torch.nn.Parameter(create_fn((3, 3)))
+
+                def forward(self, x):
+                    return self.weight + x
+
+            class MyParametrization(torch.nn.Module):
+                def forward(self, X):
+                    return -X
+
+            m = MyModule()
+            register_parametrization(m, "weight", MyParametrization())
+            out = m(create_fn((3, 3)))
+            remove_parametrizations(m, "weight", leave_parametrized=True)
+            return out
+
+        self.assertTrue(torch._dynamo.config.nested_graph_breaks)
+        out = torch._dynamo.optimize("eager")(body)()
+        self.assertIsInstance(out, WrapperTensorWithCustomSizes)
+
     def test_compile_with_functionalization(self):
         x = torch.randn([3, 4])
         x_clone = x.clone()

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2557,11 +2557,14 @@ class VariableBuilder:
         # As long as this runs before AOT this is sound
         if value in self.tx.output.side_effects:
             var = self.tx.output.side_effects[value]
-            # type: ignore[attr-defined]
-            var.proxy.node.meta["tensor_dict"]["_dynamo_static_input_type"] = (
-                # type: ignore[attr-defined]
-                value._dynamo_static_input_type
-            )
+            # A tensor-subclass parameter (e.g. under torch.nn.utils.parametrize)
+            # can be tracked as a UserDefinedObjectVariable, which has no graph
+            # proxy node to annotate. mark_static_address above still marks it,
+            # so only stamp the metadata when there is a real tensor proxy node.
+            if isinstance(var, TensorVariable):
+                var.proxy.node.meta["tensor_dict"]["_dynamo_static_input_type"] = (
+                    value._dynamo_static_input_type  # type: ignore[attr-defined]
+                )
 
     def wrap_module(self, value: torch.nn.Module) -> VariableTracker:
         from ..eval_frame import OptimizedModule


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Under nested_graph_breaks, `compile_subgraph`'s `_get_stack_values_to_restore`
realizes all lazy VTs on the value stack when compiling a partial subgraph for a
nested break. That late realization can route a module whose parameter is a
tensor subclass (e.g. under `torch.nn.utils.parametrize`) through `wrap_module`
-> `VariableBuilder.mark_static_input`, where `side_effects[value]`
(`id_to_variable[id(value)]`) is a `UserDefinedObjectVariable` -- the subclass
param is tracked as a UDOV, which has no graph proxy node -- so
`var.proxy.node.meta[...]` raised `AttributeError: 'UserDefinedObjectVariable'
object has no attribute 'proxy'`, wrapped as `InternalTorchDynamoError`. This is
the dominant dynamo_wrapped failure once `nested_graph_breaks` is enabled by
default (PR #186100).

Guard the metadata stamp with `isinstance(var, TensorVariable)`: only tensor VTs
carry the proxy node to annotate. `mark_static_address` above still marks the
value, and the normal plain-`Parameter` path (a `TensorVariable`) is unchanged,
so this is a pure crash->skip for the UDOV case.

Test Plan:

```
python test/dynamo/test_subclasses.py SubclassTests.test_parametrized_subclass_param_nested_graph_break
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_subclass.py TestSubclass.test_parametrization_wrapper_with_custom_sizes_leave_parametrized_True
```

Authored with assistance from Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98