### PR TITLE
Add ${hostname} macro to torchrun log line prefixes

### DIFF
--- a/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
+++ b/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
@@ -29,6 +29,7 @@ import torch.distributed.elastic.rendezvous.registry as rdzv_registry
 import torch.distributed.rpc as rpc
 from torch.distributed.elastic.agent.server.api import (
     RunResult,
+    WorkerGroup,
     WorkerSpec,
     WorkerState,
 )
@@ -813,7 +814,7 @@ class LocalElasticAgentTest(unittest.TestCase):
         )
 
     def test_run_with_custom_log_lines(self):
-        log_line_prefix_template = "[${role_name}-${local_rank}:${rank}]:"
+        log_line_prefix_template = "[${hostname}-${role_name}-${local_rank}:${rank}]:"
         self.run_test_with_backend(
             backend="c10d",
             test_to_run=lambda: self.run_distributed_sum_homogeneous(
@@ -1752,6 +1753,74 @@ class LocalElasticAgentTest(unittest.TestCase):
                     del os.environ[healthcheck_port_env_name]
             else:
                 os.environ[healthcheck_port_env_name] = original_healthcheck
+
+
+class LocalElasticAgentLogPrefixTest(unittest.TestCase):
+    """Unit tests for ``log_line_prefix_template`` macro substitution.
+
+    These tests do not require etcd or a real rendezvous; they mock out
+    ``start_processes`` and inspect the prefixes the agent hands to it.
+    """
+
+    def _make_agent(self, log_line_prefix_template: str) -> LocalElasticAgent:
+        rdzv_handler = Mock()
+        rdzv_handler.get_backend.return_value = "c10d"
+        spec = WorkerSpec(
+            role="default",
+            local_world_size=2,
+            entrypoint=_happy_function,
+            args=(),
+            rdzv_handler=rdzv_handler,
+            max_restarts=0,
+            monitor_interval=0.01,
+        )
+        log_dir = tempfile.mkdtemp(prefix="LocalElasticAgentLogPrefixTest")
+        self.addCleanup(shutil.rmtree, log_dir, ignore_errors=True)
+        return LocalElasticAgent(
+            spec,
+            start_method="spawn",
+            exit_barrier_timeout=5,
+            logs_specs=DefaultLogsSpecs(log_dir=log_dir),
+            log_line_prefix_template=log_line_prefix_template,
+        )
+
+    @staticmethod
+    def _captured_prefixes(agent: LocalElasticAgent) -> dict[int, str]:
+        """Run ``_start_workers`` with the spawn mocked out, return the prefixes."""
+        spec = agent._worker_group.spec
+        worker_group = WorkerGroup(spec)
+        worker_group.store = Mock()
+        worker_group.group_rank = 0
+        worker_group.group_world_size = 1
+        worker_group.master_addr = "localhost"
+        worker_group.master_port = 0
+        for global_rank, worker in enumerate(worker_group.workers):
+            worker.global_rank = global_rank
+            worker.role_rank = global_rank
+            worker.world_size = spec.local_world_size
+            worker.role_world_size = spec.local_world_size
+
+        with patch(
+            "torch.distributed.elastic.agent.server.local_elastic_agent.start_processes"
+        ) as mock_start_processes:
+            agent._start_workers(worker_group)
+        return mock_start_processes.call_args.kwargs["log_line_prefixes"]
+
+    def test_hostname_macro(self):
+        """``${hostname}`` expands to the name of the node the agent runs on."""
+        agent = self._make_agent("${hostname}:${rank}: ")
+        hostname = socket.gethostname()
+        self.assertEqual(
+            {0: f"{hostname}:0: ", 1: f"{hostname}:1: "},
+            self._captured_prefixes(agent),
+        )
+
+    def test_preexisting_macros_unchanged(self):
+        """Adding ${hostname} must not alter how existing templates render."""
+        agent = self._make_agent("[${role_name}${local_rank}]:")
+        self.assertEqual(
+            {0: "[default0]:", 1: "[default1]:"}, self._captured_prefixes(agent)
+        )
 
 
 class LocalElasticAgentUninterruptibleStateTest(unittest.TestCase):

--- a/test/distributed/test_run.py
+++ b/test/distributed/test_run.py
@@ -123,6 +123,43 @@ class RunTest(TestCase):
         self.assertEqual(args.rdzv_backend, "c10d")
         self.assertEqual(args.rdzv_endpoint, "localhost:0")
 
+    def _log_line_prefix_template(self, args):
+        """config_from_args' template, with the prefix env vars under our control."""
+        with patch.dict(os.environ):
+            os.environ.pop("TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE", None)
+            os.environ.pop("PET_LOG_LINE_PREFIX_TEMPLATE", None)
+            config, _, _ = run.config_from_args(self._parse_args(args))
+        return config.log_line_prefix_template
+
+    def test_log_line_prefix_template_from_args(self):
+        """--log-line-prefix-template is passed through to LaunchConfig."""
+        template = "${hostname}:${rank}: "
+        self.assertEqual(
+            template,
+            self._log_line_prefix_template(
+                [f"--log-line-prefix-template={template}", "dummy_script.py"]
+            ),
+        )
+
+    def test_log_line_prefix_template_unset(self):
+        """Unset, the template stays None so the default [role_name][local_rank] prefix is kept."""
+        self.assertIsNone(self._log_line_prefix_template(["dummy_script.py"]))
+
+    def test_log_line_prefix_template_env_var(self):
+        """TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE still works, and the flag overrides it."""
+        with patch.dict(
+            os.environ, {"TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE": "[${rank}]:"}
+        ):
+            config, _, _ = run.config_from_args(self._parse_args(["dummy_script.py"]))
+            self.assertEqual("[${rank}]:", config.log_line_prefix_template)
+
+            config, _, _ = run.config_from_args(
+                self._parse_args(
+                    ["--log-line-prefix-template=${hostname}: ", "dummy_script.py"]
+                )
+            )
+            self.assertEqual("${hostname}: ", config.log_line_prefix_template)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -156,8 +156,13 @@ class LocalElasticAgent(SimpleElasticAgent):
     <https://docs.python.org/3/library/string.html#template-strings>`_ as the
     ``log_line_prefix_template`` argument.
     The following macros (identifiers) are substituted at runtime:
-    ``${role_name}, ${local_rank}, ${rank}``. For example, to prefix each log line with
+    ``${role_name}, ${local_rank}, ${rank}, ${hostname}``.
+    For example, to prefix each log line with
     global rank instead of the local rank, set ``log_line_prefix_template = "[${rank}]:``.
+    ``${hostname}`` expands to the name of the node the agent runs on, which
+    identifies the offending node in a multi-node job; for example
+    ``log_line_prefix_template = "${hostname}:${rank}: "`` renders as
+    ``r12i0n8:3: foobar``.
 
 
     Example launching function
@@ -410,6 +415,10 @@ class LocalElasticAgent(SimpleElasticAgent):
         log_line_prefixes: dict[int, str] | None = (
             {} if self._log_line_prefix_template else None
         )
+        # Short name (e.g. "r12i0n8") rather than _get_fq_hostname(): the fq name
+        # eats horizontal space in every log line, and degrades to an unhelpful
+        # reverse-DNS record (e.g. "...ip6.arpa") when the node has no PTR entry.
+        hostname = socket.gethostname() if self._log_line_prefix_template else ""
         for worker in worker_group.workers:
             local_rank = worker.local_rank
             worker_env = {
@@ -442,6 +451,7 @@ class LocalElasticAgent(SimpleElasticAgent):
                     role_name=spec.role,
                     rank=worker.global_rank,
                     local_rank=local_rank,
+                    hostname=hostname,
                 )
                 # pyrefly: ignore [unsupported-operation]
                 log_line_prefixes[local_rank] = log_line_prefix

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -240,6 +240,35 @@ The following environment variables are made available to you in your script:
 13. ``PYTHON_EXEC`` - System executable override. If provided, the python user script will
     use the value of ``PYTHON_EXEC`` as executable. The `sys.executable` is used by default.
 
+Logging
+-------
+
+By default each worker's ``stdout``/``stderr`` go to the console unchanged, which
+interleaves the output of every rank with no way to tell them apart.
+
+``--redirects`` writes the streams to log files under ``--log-dir`` instead of the
+console; ``--tee`` writes them to log files *and* echoes them to the console. Both
+take the same format: a single value applies to all workers (``3`` for both
+streams, ``1`` for stdout, ``2`` for stderr), or a per-local-rank mapping such as
+``0:1,1:2``. For example ``--tee 3`` tees both streams for every worker.
+
+Tee'd console lines are prefixed with ``[${role_name}${local_rank}]:`` (e.g.
+``[default3]: foobar``). Use ``--log-line-prefix-template`` to change that; the
+macros ``${role_name}``, ``${local_rank}``, ``${rank}`` and ``${hostname}`` are
+substituted per worker. ``${hostname}`` is the name of the node the worker runs
+on, which is what identifies the offending host in a multi-node job::
+
+    torchrun --nnodes 2 --nproc-per-node 8 --tee 3 \
+             --log-line-prefix-template "${hostname}:${rank}: " train.py
+
+    r12i0n8:3: python: src/psm2_nccl_net.c:756: Assertion `r->used' failed.
+    r12i0n8:3: Fatal Python error: Segmentation fault
+
+The template may also be set with the ``TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE``
+environment variable; the command line option takes precedence.
+``--local-ranks-filter`` restricts which ranks reach the console, without
+affecting the log files written by ``--redirects``/``--tee``.
+
 Deployment
 ----------
 
@@ -580,6 +609,18 @@ def get_args_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
+        "--log-line-prefix-template",
+        "--log_line_prefix_template",
+        action=env,
+        type=str,
+        default="",
+        help="Template for the prefix prepended to each console log line of a tee'd stream "
+        "(e.g. [--log-line-prefix-template '${hostname}:${rank}: '] renders as 'r12i0n8:3: '). "
+        "Available macros: ${role_name}, ${local_rank}, ${rank}, ${hostname}. Defaults to "
+        "'[${role_name}${local_rank}]:'.",
+    )
+
+    parser.add_argument(
         "--local-ranks-filter",
         "--local_ranks_filter",
         action=env,
@@ -883,7 +924,9 @@ def config_from_args(args) -> tuple[LaunchConfig, Callable | str, list[str]]:
         # This env variable will be passed down to the subprocesses
         os.environ["OMP_NUM_THREADS"] = str(omp_num_threads)
 
-    log_line_prefix_template = os.getenv("TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE")
+    log_line_prefix_template = args.log_line_prefix_template or os.getenv(
+        "TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE"
+    )
 
     rdzv_configs = _parse_rendezvous_config(args.rdzv_conf)
 


### PR DESCRIPTION
Fixes #75087

### Problem

`--tee` prefixes every console line with `[default<local_rank>]:`. On a multi-node job that does not say *which* node produced the line, so a crash cannot be traced back to a host. The reporter hit this debugging a segfault where no other logging survived.

### Approach

The prefix is already templated per worker: `LocalElasticAgent` expands `TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE` with `${role_name}`, `${local_rank}` and `${rank}`. This adds **`${hostname}`** to that macro set rather than changing the default prefix, since changing it would silently break anyone parsing `[default3]:` today. The issue explicitly accepts delivering this "via a new flag or the existing one".

To make it reachable from the command line the reporter actually uses, this also adds **`--log-line-prefix-template`**. The existing environment variable keeps working; the flag takes precedence when both are set.

```
torchrun --nnodes 2 --nproc-per-node 8 --tee 3 \
         --log-line-prefix-template "${hostname}:${rank}: " train.py

r12i0n8:3: python: src/psm2_nccl_net.c:756: Assertion `r->used' failed.
r12i0n8:3: Fatal Python error: Segmentation fault
```

which is the format requested in the issue, trailing space included.

`${hostname}` is `socket.gethostname()` rather than the fully qualified name from `_get_fq_hostname()`. The fq name costs horizontal space on every line — one of the issue's complaints — and on a node with no PTR record `getfqdn()` degrades to a reverse-DNS string such as `1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa`.

Finally, this documents `--tee` and `--redirects`, the issue's bonus request. They had no documentation outside their `--help` strings; `docs/source/elastic/run.md` renders the `torch.distributed.run` module docstring, so the new "Logging" section is what appears at pytorch.org/docs/stable/elastic/run.html.

### Testing

`LocalElasticAgentLogPrefixTest` is a new etcd-free test class (mirroring `LocalElasticAgentUninterruptibleStateTest`) that mocks out `start_processes` and asserts on the prefixes the agent produces:

```
python -m pytest test/distributed/elastic/agent/server/test/local_elastic_agent_test.py::LocalElasticAgentLogPrefixTest -v
```

Both pass. `test_hostname_macro` was confirmed to fail without the change (the prefix comes back as the literal `${hostname}:0: `), and `test_preexisting_macros_unchanged` pins the no-BC-break claim.

The flag is covered in `test/distributed/test_run.py`, alongside the existing `config_from_args` tests:

```
python -m pytest test/distributed/test_run.py -k log_line_prefix -v
```

Three tests: the flag reaches `LaunchConfig`; `TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE` is still honored and the flag overrides it; and with nothing set the template stays `None`, so `[default3]:` is unchanged. The first two fail against unpatched `run.py`. The rest of that file still passes (13 tests total with the agent tests above).

### Note on how this was written

> This change was developed with the help of an AI coding assistant (Claude Code). I reviewed every line of the code, tests and documentation before submitting, and I am responsible for its contents.

cc @d4l3k
