### PR TITLE
flex_gemm: support packed NVFP4 main outputs

### DIFF
--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -3933,6 +3933,52 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         expected = pack_uint4(_f32_to_floatx_unpacked(values, 2, 1)).squeeze(-1)
         self.assertEqual(nvfp4_pack(values), expected)
 
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @unittest.skipIf(SM120OrLater, "grouped-N main outputs are not supported on SM120")
+    def test_mm_nvfp4_pack_matches_reference(self):
+        m = n = 128
+        k = 64
+        boundaries = torch.tensor(
+            [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0],
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        lower = torch.nextafter(boundaries, torch.full_like(boundaries, float("-inf")))
+        upper = torch.nextafter(boundaries, torch.full_like(boundaries, float("inf")))
+        values = torch.cat(
+            (
+                -upper,
+                -boundaries,
+                -lower,
+                torch.tensor(
+                    [float("-inf"), -0.0, 0.0, float("inf")],
+                    device="cuda",
+                    dtype=torch.bfloat16,
+                ),
+                lower,
+                boundaries,
+                upper,
+            )
+        ).repeat(4)[:n]
+        a = torch.zeros(m, k, device="cuda", dtype=torch.bfloat16)
+        b = torch.zeros(k, n, device="cuda", dtype=torch.bfloat16)
+        a[:, 0] = 1
+        b[0] = values
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                lambda acc: nvfp4_pack(acc.float().view(m, -1, 2)),
+                kernel_options={"backend": "QUACK"},
+            )
+
+        actual = torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
+        expected = nvfp4_pack((a @ b).float().view(m, -1, 2))
+        self.assertEqual(actual, expected)
+
     def test_quant_scale_fake_strides_match_eager(self):
         from torch._subclasses.fake_tensor import FakeTensorMode
 

--- a/torch/_inductor/kernel/flex_gemm/epilogue.py
+++ b/torch/_inductor/kernel/flex_gemm/epilogue.py
@@ -912,10 +912,47 @@ def grouped_main_output_transform(
         selected_indices.add(index % group)
         return True
 
+    def bind_all_lanes(
+        source: torch.fx.Node,
+        shape: tuple[Any, ...],
+        group: int,
+        chunked: bool,
+    ) -> bool:
+        """Bind a transform that consumes every lane without explicit selects."""
+        return all(
+            bind_lane(source, shape, group, chunked, index) for index in range(group)
+        )
+
     def visit(node: Any) -> bool:
         if not isinstance(node, torch.fx.Node) or node in seen:
             return True
         seen.add(node)
+        if (
+            node.op == "call_function"
+            and node.target is torch.ops.flex_gemm.nvfp4_pack.default
+            and len(node.args) == 1
+            and isinstance(node.args[0], torch.fx.Node)
+        ):
+            grouped = node.args[0]
+            grouped_args = view_or_reshape_args(grouped)
+            grouped_shape = tensor_meta_shape(grouped)
+            layout = FlexGemmLocalReduceGeometry(group=2, axis=1)
+            if (
+                grouped_args is not None
+                and isinstance(grouped_args[0], torch.fx.Node)
+                and grouped_shape is not None
+                and gemm_shape is not None
+                and len(grouped_shape) == 3
+                and grouped_shape[-1] == layout.group
+                and statically_known_shape_equal(
+                    (grouped_shape[0], grouped_shape[1] * layout.group),
+                    gemm_shape,
+                )
+                and local_reduce.graph.depends_on(grouped_args[0], gemm)
+                and bind_all_lanes(grouped_args[0], grouped_shape, layout.group, False)
+            ):
+                pending_grouped[grouped] = layout
+                return True
         if (
             node.op == "call_function"
             and node.target is operator.getitem
@@ -1502,6 +1539,7 @@ class FlexGemmEpilogueEmitter:
             "from cutlass._mlir_helpers import math as cutlass_math\n"
             "from torch._inductor.kernel.flex_gemm.quant_intrinsics import (\n"
             "    mx_e8m0_scale_intrinsic,\n"
+            "    nvfp4_pack_intrinsic,\n"
             ")\n\n"
             f"{local_reduce_source}"
             f"@cute.jit\ndef {name}({epilogue_params}):\n"

--- a/torch/_inductor/kernel/flex_gemm/quack_reductions.py
+++ b/torch/_inductor/kernel/flex_gemm/quack_reductions.py
@@ -323,6 +323,13 @@ def _cute_call(target: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> An
         raise NotImplementedError(f"unsupported FlexGEMM epilogue op: {target}")
     if op_name in ("mx_e8m0_scale", "nvfp4_e4m3_scale"):
         return _cute_scale_call(op_name, args, kwargs)
+    if op_name == "nvfp4_pack":
+        source = args[0]
+        return V.kernel.cse.generate(
+            V.kernel.body,
+            f"nvfp4_pack_intrinsic({source})",
+            dtype=torch.uint8,
+        )
     try:
         op = getattr(V.get_ops_handler(), op_name)
     except AttributeError:

--- a/torch/_inductor/kernel/flex_gemm/quant_intrinsics.py
+++ b/torch/_inductor/kernel/flex_gemm/quant_intrinsics.py
@@ -1,10 +1,9 @@
-"""Exact E8M0 conversion for FlexGEMM quantization epilogues.
+"""Packed low-precision conversions for FlexGEMM quantization epilogues.
 
-CuTeDSL's public conversion neither exposes FLOOR rounding nor handles every
-TensorSSA fragment width needed by FlexGEMM. These helpers emit the packed SM100
-instructions directly and rebuild the original fragment. Edge-case probes match
-the eager custom op and TorchAO's compiled RCEIL path bit-for-bit, while matched
-fused benchmarks showed no material performance regression.
+CuTeDSL's public E8M0 conversion neither exposes FLOOR rounding nor handles every
+TensorSSA fragment width needed by FlexGEMM. NVFP4 uses its native packed E2M1
+conversion directly; pre-rounding through pointwise selects produces equivalent
+finite values with substantially worse code generation.
 """
 
 import functools
@@ -23,6 +22,13 @@ from cutlass.cutlass_dsl import dsl_user_op, T
 def quant_intrinsics_cache_key() -> str:
     """Include this module's source in generated epilogue cache keys."""
     return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+@dsl_user_op
+def nvfp4_pack_intrinsic(source, *, loc=None, ip=None):
+    """Round paired Float32 values with SM100's packed E2M1 conversion."""
+    packed = source.to(cutlass.Float4E2M1FN).bitcast(cutlass.Uint8)
+    return packed.reshape((cute.size(packed.shape), 1, 1))
 
 
 def extract_vector_element(value: ir.Value, index: int) -> ir.Value:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Recognize terminal nvfp4_pack expressions over adjacent accumulator values as
a grouped main-output transform. Lower the pair through Blackwell's native
packed E2M1 conversion so the GEMM writes Uint8 NVFP4 storage without a
separate quantization kernel or a software compare/select rounding ladder.

The eager custom op in the base quant commit remains the precision-neutral
reference. Fused lowering matches its finite round-to-nearest-even boundaries,
signed zero, and saturating infinity behavior; NaN encoding remains
unspecified, consistent with the floatx conversion contract.

Test Plan:

```
python test/inductor/test_flex_gemm.py -k nvfp4_pack
python test/inductor/test_flex_gemm.py
spin lint
lintrunner -a
```

This change was prepared with assistance from an AI coding tool.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo