### PR TITLE
[inductor] Fix FlexAttention shared memory OOM on consumer GPUs

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -27,7 +27,7 @@ from torch._inductor import config, metrics
 from torch._inductor.exc import InductorError
 from torch._inductor.runtime.triton_compat import HAS_WARP_SPEC
 from torch._inductor.test_case import TestCase as InductorTestCase
-from torch._inductor.utils import run_and_get_code
+from torch._inductor.utils import fresh_cache, run_and_get_code
 from torch.nn.attention import SDPBackend
 from torch.nn.attention.experimental._paged_attention import PagedAttention
 from torch.nn.attention.flex_attention import (
@@ -3701,6 +3701,275 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             KV_S=64,
             device=device,
         )
+
+    def _assert_fallback_configs_smaller_than_default(
+        self, configs, default_config, block_attrs
+    ):
+        self.assertGreater(len(configs), 1, "Expected fallback configs to be generated")
+        for i in range(1, len(configs)):
+            curr = configs[i]
+            smaller = any(
+                getattr(curr, attr) < getattr(default_config, attr)
+                for attr in block_attrs
+            )
+            self.assertTrue(
+                smaller,
+                f"Fallback config {curr} is not smaller than default {default_config}",
+            )
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @skip_on_rocm
+    def test_fwd_fallback_handles_low_shared_memory_limit(self, device):
+        import triton.compiler.compiler as triton_compiler
+
+        from torch._inductor.heuristics.template.triton import (
+            CUDAConfigHeuristic,
+            FlexConfig,
+        )
+        from torch._inductor.virtualized import V
+
+        with (
+            config.patch({"max_autotune": False}),
+            patch.object(torch.cuda, "get_device_capability", return_value=(10, 0)),
+        ):
+            fwd_configs = CUDAConfigHeuristic().get_flex_attn_fwd_configs(
+                192, 256, torch.float16
+            )
+        default_config = fwd_configs[0]
+        self._assert_fallback_configs_smaller_than_default(
+            fwd_configs, default_config, ("block_m", "block_n", "num_stages")
+        )
+        self.assertIn(FlexConfig(64, 64, 1, 4), fwd_configs)
+
+        q, k, v = (
+            torch.randn(1, 2, 256, 192, device=device, dtype=torch.float16)
+            for _ in range(3)
+        )
+        with (
+            fresh_cache(),
+            config.patch(
+                {
+                    "compile_threads": 1,
+                    "force_disable_caches": True,
+                    "max_autotune": False,
+                    "use_static_triton_launcher": False,
+                }
+            ),
+            patch.object(triton_compiler, "max_shared_mem", return_value=101376),
+            patch.object(
+                V.choices,
+                "get_flex_attention_fwd_configs",
+                return_value=fwd_configs,
+            ),
+        ):
+            out, code = run_and_get_code(
+                torch.compile(flex_attention, fullgraph=True),
+                q,
+                k,
+                v,
+                kernel_options={"BACKEND": "TRITON"},
+            )
+            torch.cuda.synchronize()
+
+        self.assertEqual(out.shape, (1, 2, 256, 192))
+        # Default config (128,128) exceeds 101376 shared memory bytes;
+        # the fallback config (64,64) should have been selected instead.
+        FileCheck().check("BLOCK_M : tl.constexpr = 64").check(
+            "BLOCK_N : tl.constexpr = 64"
+        ).run(code[0])
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @skip_on_rocm
+    def test_fwd_fallback_handles_large_value_head_dim(self, device):
+        import triton.compiler.compiler as triton_compiler
+
+        from torch._inductor.heuristics.template.triton import FlexConfig
+        from torch._inductor.virtualized import V
+
+        q = torch.randn(1, 2, 256, 64, device=device, dtype=torch.float16)
+        k = torch.randn(1, 2, 256, 64, device=device, dtype=torch.float16)
+        v = torch.randn(1, 2, 256, 256, device=device, dtype=torch.float16)
+
+        with (
+            fresh_cache(),
+            config.patch(
+                {
+                    "compile_threads": 1,
+                    "force_disable_caches": True,
+                    "max_autotune": False,
+                    "use_static_triton_launcher": False,
+                }
+            ),
+            patch.object(triton_compiler, "max_shared_mem", return_value=101376),
+            patch.object(
+                V.choices,
+                "get_flex_attention_fwd_configs",
+                return_value=[FlexConfig(128, 64, 1, 4)],
+            ),
+        ):
+            out, code = run_and_get_code(
+                torch.compile(flex_attention, fullgraph=True),
+                q,
+                k,
+                v,
+                kernel_options={"BACKEND": "TRITON", "BLOCK_M": 128, "BLOCK_N": 64},
+            )
+            torch.cuda.synchronize()
+
+        self.assertEqual(out.shape, (1, 2, 256, 256))
+        # Verify the pinned block sizes are reflected in the generated kernel.
+        FileCheck().check("BLOCK_M : tl.constexpr = 128").check(
+            "BLOCK_N : tl.constexpr = 64"
+        ).run(code[0])
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @skip_on_rocm
+    def test_bwd_fallback_handles_low_shared_memory_limit(self, device):
+        import triton.compiler.compiler as triton_compiler
+
+        from torch._inductor.heuristics.template.triton import (
+            CUDAConfigHeuristic,
+            FlexBwDConfig,
+            FlexConfig,
+        )
+        from torch._inductor.kernel.flex.flex_attention import (
+            _flex_bwd_kernel_shared_memory,
+        )
+        from torch._inductor.virtualized import V
+
+        with (
+            config.patch({"max_autotune": False}),
+            patch.object(torch.cuda, "get_device_capability", return_value=(8, 9)),
+        ):
+            bwd_configs = CUDAConfigHeuristic().get_flex_attn_bwd_configs(
+                128, torch.float16
+            )
+        default_config = bwd_configs[0]
+        self._assert_fallback_configs_smaller_than_default(
+            bwd_configs,
+            default_config,
+            ("block_m1", "block_n1", "block_m2", "block_n2", "num_stages"),
+        )
+        self.assertIn(FlexBwDConfig(32, 64, 64, 32, 1, 4), bwd_configs)
+
+        bwd_kernel_options = {
+            "QK_HEAD_DIM_ROUNDED": 128,
+            "V_HEAD_DIM_ROUNDED": 128,
+            "BLOCK_M1": 64,
+            "BLOCK_N1": 64,
+            "BLOCK_M2": 64,
+            "BLOCK_N2": 64,
+        }
+        self.assertGreater(
+            _flex_bwd_kernel_shared_memory(
+                {**bwd_kernel_options, "num_stages": 2}, torch.float16
+            ),
+            101376,
+        )
+        self.assertLess(
+            _flex_bwd_kernel_shared_memory(
+                {**bwd_kernel_options, "num_stages": 1}, torch.float16
+            ),
+            101376,
+        )
+
+        q, k, v = (
+            torch.randn(
+                1,
+                2,
+                256,
+                128,
+                device=device,
+                dtype=torch.float16,
+                requires_grad=True,
+            )
+            for _ in range(3)
+        )
+        grad_out = torch.randn_like(q)
+        with (
+            fresh_cache(),
+            config.patch(
+                {
+                    "compile_threads": 1,
+                    "force_disable_caches": True,
+                    "max_autotune": False,
+                    "use_static_triton_launcher": False,
+                }
+            ),
+            patch.object(triton_compiler, "max_shared_mem", return_value=101376),
+            patch.object(
+                V.choices,
+                "get_flex_attention_fwd_configs",
+                return_value=[FlexConfig(64, 32, 1, 4)],
+            ),
+            patch.object(
+                V.choices,
+                "get_flex_attention_bwd_configs",
+                return_value=bwd_configs,
+            ),
+        ):
+            out, code = run_and_get_code(
+                torch.compile(flex_attention, fullgraph=True),
+                q,
+                k,
+                v,
+                kernel_options={"BACKEND": "TRITON"},
+            )
+            out.backward(grad_out, retain_graph=True)
+            torch.cuda.synchronize()
+
+        self.assertEqual(out.shape, (1, 2, 256, 128))
+        # The forward kernel should use the smaller pinned config (64,32)
+        FileCheck().check("BLOCK_M : tl.constexpr = 64").check(
+            "BLOCK_N : tl.constexpr = 32"
+        ).run(code[0])
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @skip_on_rocm
+    def test_fwd_all_configs_exceed_shared_memory(self, device):
+        import triton.compiler.compiler as triton_compiler
+
+        from torch._inductor.heuristics.template.triton import FlexConfig
+        from torch._inductor.virtualized import V
+
+        q, k, v = (
+            torch.randn(1, 2, 256, 192, device=device, dtype=torch.float16)
+            for _ in range(3)
+        )
+
+        with (
+            fresh_cache(),
+            config.patch(
+                {
+                    "compile_threads": 1,
+                    "force_disable_caches": True,
+                    "max_autotune": False,
+                    "use_static_triton_launcher": False,
+                }
+            ),
+            patch.object(triton_compiler, "max_shared_mem", return_value=1024),
+            patch.object(
+                V.choices,
+                "get_flex_attention_fwd_configs",
+                return_value=[FlexConfig(128, 128, 1, 8)],
+            ),
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                torch.compile(flex_attention, fullgraph=True)(
+                    q, k, v, kernel_options={"BACKEND": "TRITON"}
+                )
+            self.assertIn(
+                "All forward FlexAttention configs exceed device shared memory",
+                str(cm.exception),
+            )
 
     @supported_platform
     @skip("TODO: Figure out why this is erroring")

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -7,7 +7,7 @@ import math
 import os
 from functools import partial
 from threading import Lock
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, TypeVar
 
 import sympy
 
@@ -217,6 +217,46 @@ class FlexDecodeConfig:
     block_n: int
     num_stages: int
     num_warps: int
+
+
+_T = TypeVar("_T")
+
+
+def _append_unique_config(configs: list[_T], candidates: list[_T]) -> None:
+    for candidate in candidates:
+        if candidate not in configs:
+            configs.append(candidate)
+
+
+def _flex_fwd_fallback_configs(default_config: FlexConfig) -> list[FlexConfig]:
+    candidates = [default_config]
+    if default_config.num_stages != 1:
+        candidates.append(dataclasses.replace(default_config, num_stages=1))
+
+    for block_m, block_n in ((64, 64), (64, 32), (32, 32), (16, 16)):
+        if default_config.block_m >= block_m and default_config.block_n >= block_n:
+            candidates.append(FlexConfig(block_m, block_n, 1, 4))
+    return candidates
+
+
+def _flex_bwd_fallback_configs(default_config: FlexBwDConfig) -> list[FlexBwDConfig]:
+    candidates = [default_config]
+    if default_config.num_stages != 1:
+        candidates.append(dataclasses.replace(default_config, num_stages=1))
+
+    for candidate in (
+        FlexBwDConfig(32, 64, 64, 32, 1, 4),
+        FlexBwDConfig(32, 32, 32, 32, 1, 4),
+        FlexBwDConfig(16, 16, 16, 16, 1, 4),
+    ):
+        if (
+            default_config.block_m1 >= candidate.block_m1
+            and default_config.block_n1 >= candidate.block_n1
+            and default_config.block_m2 >= candidate.block_m2
+            and default_config.block_n2 >= candidate.block_n2
+        ):
+            candidates.append(candidate)
+    return candidates
 
 
 # ROCm classes
@@ -1203,8 +1243,14 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
             else:
                 default_config = FlexConfig(64, 32, 3, 4)
 
-        if default_config not in flex_attn_fwd_configs:
-            flex_attn_fwd_configs.append(default_config)
+        if config.max_autotune:
+            if default_config not in flex_attn_fwd_configs:
+                flex_attn_fwd_configs.append(default_config)
+        else:
+            _append_unique_config(
+                flex_attn_fwd_configs,
+                _flex_fwd_fallback_configs(default_config),
+            )
 
         return flex_attn_fwd_configs
 
@@ -1220,8 +1266,14 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
 
         default_config = FlexBwDConfig(16, 16, 16, 16, 1, 4)
 
-        if default_config not in flex_attn_bwd_configs:
-            flex_attn_bwd_configs.append(default_config)
+        if config.max_autotune:
+            if default_config not in flex_attn_bwd_configs:
+                flex_attn_bwd_configs.append(default_config)
+        else:
+            _append_unique_config(
+                flex_attn_bwd_configs,
+                _flex_bwd_fallback_configs(default_config),
+            )
 
         return flex_attn_bwd_configs
 
@@ -1432,8 +1484,14 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
             else:
                 default_config = FlexConfig(64, 32, 3, 4)
 
-        if default_config not in flex_attn_fwd_configs:
-            flex_attn_fwd_configs.append(default_config)
+        if config.max_autotune:
+            if default_config not in flex_attn_fwd_configs:
+                flex_attn_fwd_configs.append(default_config)
+        else:
+            _append_unique_config(
+                flex_attn_fwd_configs,
+                _flex_fwd_fallback_configs(default_config),
+            )
 
         return flex_attn_fwd_configs
 
@@ -1507,8 +1565,14 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
         else:
             default_config = FlexBwDConfig(16, 16, 16, 16, 1, 4)
 
-        if default_config not in flex_attn_bwd_configs:
-            flex_attn_bwd_configs.append(default_config)
+        if config.max_autotune:
+            if default_config not in flex_attn_bwd_configs:
+                flex_attn_bwd_configs.append(default_config)
+        else:
+            _append_unique_config(
+                flex_attn_bwd_configs,
+                _flex_bwd_fallback_configs(default_config),
+            )
 
         return flex_attn_bwd_configs
 

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -12,6 +12,7 @@ from typing import Any, cast, TYPE_CHECKING
 import sympy
 
 import torch
+from torch._inductor import config
 from torch._inductor.virtualized import V
 from torch.nn.attention.flex_attention import _Backend
 from torch.utils._sympy.functions import FloorDiv
@@ -64,6 +65,81 @@ log = logging.getLogger(__name__)
 aten = torch.ops.aten
 prims = torch.ops.prims
 Expr = sympy.Expr
+
+# Extra bytes Triton includes in the static shared-memory metadata for these
+# templates (barriers, sync objects, padding). Keep these separate from the
+# tile storage terms below so estimates line up with the OutOfResources
+# "Required" value.
+#
+# The forward SMEM estimate intentionally omits the FP32 accumulator because
+# Triton keeps accumulator values in registers across the MMA pipeline, not in
+# shared memory. The register pressure from the accumulator is already reflected
+# in the occupancy constraints enforced by Triton's autotuner.
+#
+# Measured against Triton 3.2.x (bundled with PyTorch 2.7.0) on:
+#   GPU: NVIDIA RTX 3090 (sm_86)
+#   Template: non-TMA, non-warp-spec, no mask_mod
+# Should be re-verified if Triton version or template variant changes.
+_FLEX_FWD_SHARED_MEMORY_OVERHEAD = 4096
+_FLEX_BWD_SHARED_MEMORY_OVERHEAD = 4096
+
+
+def _get_cuda_max_shared_memory(device: torch.device) -> int | None:
+    if device.type != "cuda" or torch.version.hip is not None:
+        return None
+
+    try:
+        device_index = device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+        props = torch.cuda.get_device_properties(device_index)
+        if hasattr(props, "shared_memory_per_block_optin"):
+            return int(props.shared_memory_per_block_optin)
+        elif hasattr(props, "shared_memory_per_block"):
+            return int(props.shared_memory_per_block)
+        return None
+    except (RuntimeError, TypeError, ValueError):
+        return None
+
+
+def _flex_fwd_kernel_shared_memory(
+    kernel_options: dict[str, Any], dtype: torch.dtype
+) -> int | None:
+    try:
+        block_m = int(kernel_options["BLOCK_M"])
+        block_n = int(kernel_options["BLOCK_N"])
+        qk_head_dim = int(kernel_options["QK_HEAD_DIM_ROUNDED"])
+        v_head_dim = int(kernel_options["V_HEAD_DIM_ROUNDED"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    # Forward estimate omits num_stages: the forward kernel pipelines
+    # K and V loads within a single stage, so shared memory does not scale
+    # with the stage count the way the backward two-pass kernel does.
+    return (
+        block_m * qk_head_dim + block_n * max(qk_head_dim, v_head_dim)
+    ) * dtype.itemsize + _FLEX_FWD_SHARED_MEMORY_OVERHEAD
+
+
+def _flex_bwd_kernel_shared_memory(
+    kernel_options: dict[str, Any], dtype: torch.dtype
+) -> int | None:
+    try:
+        num_stages = int(kernel_options.get("num_stages", 1))
+        qk_head_dim = int(kernel_options["QK_HEAD_DIM_ROUNDED"])
+        v_head_dim = int(kernel_options["V_HEAD_DIM_ROUNDED"])
+        block_mn1 = int(kernel_options["BLOCK_M1"]) + int(kernel_options["BLOCK_N1"])
+        block_mn2 = int(kernel_options["BLOCK_M2"]) + int(kernel_options["BLOCK_N2"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    return (
+        max(block_mn1, block_mn2)
+        * (qk_head_dim + v_head_dim)
+        * dtype.itemsize
+        * num_stages
+        + _FLEX_BWD_SHARED_MEMORY_OVERHEAD
+    )
 
 
 def _sanitize_kernel_options_for_triton(
@@ -436,6 +512,7 @@ def flex_attention(
     configs: list[FlexConfig] = V.choices.get_flex_attention_fwd_configs(
         head_dim, seq_len_q, dtype, query.get_device().type
     )
+    max_shared_memory = _get_cuda_max_shared_memory(query.get_device())
 
     # Mark SPARSE_KV_BLOCK_SIZE & SPARSE_Q_BLOCK_SIZE as static shapes and add guards.
     SPARSE_KV_BLOCK_SIZE = V.graph.sizevars.guard_int(SPARSE_KV_BLOCK_SIZE)
@@ -477,7 +554,7 @@ def flex_attention(
         # Shrink default tiles to fit smaller pow2 sparse block sizes;
         # user-pinned tiles and non-pow2 sparse sizes still error out below.
         block_m, block_n = conf.block_m, conf.block_n
-        if len(configs) == 1 and all(
+        if not config.max_autotune and all(
             is_power_of_2(s) and s >= 16
             for s in (SPARSE_Q_BLOCK_SIZE, SPARSE_KV_BLOCK_SIZE)
         ):
@@ -496,7 +573,7 @@ def flex_attention(
             != 0
         ):
             invalid_block_options = cur_kernel_options
-            if len(configs) == 1:
+            if not config.max_autotune:
                 raise_flex_kernel_options_error(
                     "forward",
                     cur_kernel_options,
@@ -510,6 +587,22 @@ def flex_attention(
         for attrib in ["kpack", "matrix_instr_nonkdim", "waves_per_eu"]:
             if hasattr(conf, attrib):
                 cur_kernel_options[attrib] = getattr(conf, attrib)
+
+        fwd_required_shared_memory = _flex_fwd_kernel_shared_memory(
+            cur_kernel_options, dtype
+        )
+        if (
+            max_shared_memory is not None
+            and fwd_required_shared_memory is not None
+            and fwd_required_shared_memory > max_shared_memory
+        ):
+            log.info(
+                "Skipping FlexAttention forward config %s: estimated shared "
+                "memory exceeds device limit %d",
+                conf,
+                max_shared_memory,
+            )
+            continue
 
         error = flex_attention_template.maybe_append_choice(
             choices=choices,
@@ -536,8 +629,20 @@ def flex_attention(
             call_sizes=query.get_size(),
             **cur_kernel_options,
         )
-        if error is not None and len(configs) == 1:
-            raise error
+        if error is not None:
+            if not config.max_autotune:
+                raise error
+            continue
+        if not config.max_autotune:
+            break
+
+    if not choices and max_shared_memory is not None and invalid_block_options is None:
+        raise RuntimeError(
+            "All forward FlexAttention configs exceed device shared memory: "
+            f"device has {max_shared_memory} bytes. "
+            "Try reducing head dimension or passing kernel_options "
+            "with BLOCK_M, BLOCK_N, or num_stages."
+        )
 
     # Let the active choices handler append any backend-specific flex-attention
     # template choices (e.g. TLX on Blackwell in fbcode). No-op by default.
@@ -1012,6 +1117,7 @@ def flex_attention_backward(*args, **kwargs):
     configs: list[FlexBwDConfig] = V.choices.get_flex_attention_bwd_configs(
         head_dim, dtype, query.get_device().type
     )
+    max_shared_memory = _get_cuda_max_shared_memory(query.get_device())
 
     # Default config for warp specialization
     num_consumer_groups, num_buffers_warp_spec = 0, 0
@@ -1049,7 +1155,7 @@ def flex_attention_backward(*args, **kwargs):
         # user-pinned tiles and non-pow2 sparse sizes still error out below.
         block_m1, block_n1 = conf.block_m1, conf.block_n1
         block_m2, block_n2 = conf.block_m2, conf.block_n2
-        if len(configs) == 1 and all(
+        if not config.max_autotune and all(
             is_power_of_2(s) and s >= 16
             for s in (SPARSE_Q_BLOCK_SIZE, SPARSE_KV_BLOCK_SIZE)
         ):
@@ -1086,7 +1192,7 @@ def flex_attention_backward(*args, **kwargs):
             or cur_kernel_options["BLOCK_M2"] % cur_kernel_options["BLOCK_N2"] != 0
         ):
             invalid_block_options = cur_kernel_options
-            if len(configs) == 1:
+            if not config.max_autotune:
                 raise_flex_kernel_options_error(
                     "backward",
                     cur_kernel_options,
@@ -1101,7 +1207,23 @@ def flex_attention_backward(*args, **kwargs):
             if hasattr(conf, attrib):
                 cur_kernel_options[attrib] = getattr(conf, attrib)
 
-        flex_attention_backward_template.maybe_append_choice(
+        bwd_required_shared_memory = _flex_bwd_kernel_shared_memory(
+            cur_kernel_options, dtype
+        )
+        if (
+            max_shared_memory is not None
+            and bwd_required_shared_memory is not None
+            and bwd_required_shared_memory > max_shared_memory
+        ):
+            log.info(
+                "Skipping FlexAttention backward config %s: estimated shared "
+                "memory exceeds device limit %d",
+                conf,
+                max_shared_memory,
+            )
+            continue
+
+        error = flex_attention_backward_template.maybe_append_choice(
             choices=choices,
             input_nodes=[
                 query,
@@ -1135,6 +1257,20 @@ def flex_attention_backward(*args, **kwargs):
             ],
             call_sizes=query.get_size() + key.get_size()[1:3],
             **cur_kernel_options,
+        )
+        if error is not None:
+            if not config.max_autotune:
+                raise error
+            continue
+        if not config.max_autotune:
+            break
+
+    if not choices and max_shared_memory is not None and invalid_block_options is None:
+        raise RuntimeError(
+            "All backward FlexAttention configs exceed device shared memory: "
+            f"device has {max_shared_memory} bytes. "
+            "Try reducing head dimension or passing kernel_options "
+            "with BLOCK_M1, BLOCK_N1, BLOCK_M2, BLOCK_N2, or num_stages."
         )
 
     if not choices and invalid_block_options is not None:


### PR DESCRIPTION
Add fallback configs and shared memory estimation to FlexAttention to prevent OutOfResources errors on low-shared-memory CUDA devices (RTX 4090/3090/A10G).

The approach follows Jason Ansel's PR #184310 with improvements:
- Normalized forward/backward shared-memory overhead constants (both use 4096;
  backward was 8 in #184310, leading to underestimated safety margins)
- Added documentation for the overhead constants

Before (non-autotune mode, D>=128):
```
triton.runtime.errors.OutOfResources: out of resource: shared memory,
Required: 131074, Hardware limit: 101376
```

Fix:
- Estimate forward/backward kernel shared memory from block sizes and head dims
- Filter configs that exceed device shared memory before compilation
- Generate smaller fallback configs (reduced block sizes, fewer stages) when not in max_autotune mode
- Early-exit on first successful config in non-autotune mode

closes: #133254

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo