### PR TITLE
[Inductor] Add combo-kernel / uniform-dispatch toggles to H100 perf dashboard

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -865,6 +865,17 @@ test_perf_for_dashboard() {
   if [[ "$DASHBOARD_TAG" == *inference-true* ]]; then
     modes+=(inference)
   fi
+
+  # Global inductor config toggles applied across every benchmark config below.
+  # Driven by the inductor-perf-test-nightly-h100 workflow_dispatch inputs so the
+  # perf dashboard can A/B combo kernels and combo-kernel uniform dispatch.
+  if [[ "$DASHBOARD_TAG" == *combo_kernels-true* ]]; then
+    export TORCHINDUCTOR_COMBO_KERNELS=1
+  fi
+  if [[ "$DASHBOARD_TAG" == *combo_kernel_uniform_dispatch-true* ]]; then
+    export TORCHINDUCTOR_COMBO_KERNEL_UNIFORM_DISPATCH=1
+  fi
+
   # TODO: All the accuracy tests can be skipped once the CI accuracy checking is stable enough
   local targets=(accuracy performance)
 

--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -62,6 +62,16 @@ on:
         required: false
         type: boolean
         default: false
+      combo_kernels:
+        description: Run with combo kernels enabled?
+        required: false
+        type: boolean
+        default: false
+      combo_kernel_uniform_dispatch:
+        description: Run with combo kernel uniform dispatch enabled?
+        required: false
+        type: boolean
+        default: false
       benchmark_configs:
         description: The list of configs used the benchmark
         required: false
@@ -199,7 +209,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
-      dashboard-tag: training-${{ inputs.training || 'true' }}-inference-${{ inputs.inference || 'true' }}-default-${{ inputs.default || 'true' }}-dynamic-${{ inputs.dynamic || 'true' }}-cudagraphs-${{ inputs.cudagraphs || 'true' }}-cppwrapper-${{ inputs.cppwrapper || 'false' }}-aotinductor-${{ inputs.aotinductor || 'false' }}-maxautotune-${{ inputs.maxautotune || 'false' }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs || 'false' }}-deterministic_perf-${{ inputs.deterministic_perf || 'false' }}-batch_invariant_accuracy-${{ inputs.batch_invariant_accuracy || 'false' }}
+      dashboard-tag: training-${{ inputs.training || 'true' }}-inference-${{ inputs.inference || 'true' }}-default-${{ inputs.default || 'true' }}-dynamic-${{ inputs.dynamic || 'true' }}-cudagraphs-${{ inputs.cudagraphs || 'true' }}-cppwrapper-${{ inputs.cppwrapper || 'false' }}-aotinductor-${{ inputs.aotinductor || 'false' }}-maxautotune-${{ inputs.maxautotune || 'false' }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs || 'false' }}-deterministic_perf-${{ inputs.deterministic_perf || 'false' }}-batch_invariant_accuracy-${{ inputs.batch_invariant_accuracy || 'false' }}-combo_kernels-${{ inputs.combo_kernels || 'false' }}-combo_kernel_uniform_dispatch-${{ inputs.combo_kernel_uniform_dispatch || 'false' }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       timeout-minutes: 720

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -379,6 +379,90 @@ class ComboKernelTests(TestCase):
         self.assertTrue(torch._inductor.metrics.generated_kernel_count <= 2)
 
     @requires_gpu_and_triton
+    def test_uniform_dispatch_identical_reductions(self):
+        # Uniform dispatch collapses N structurally-identical persistent-reduction
+        # sub-kernels into a single body dispatched via a pointer table. The
+        # sub-kernels are matched by comparing their structured op traces, so
+        # this verifies that path produces numerically correct results.
+        def ln_silu(x):
+            mean = x.mean(dim=-1, keepdim=True)
+            var = x.var(dim=-1, keepdim=True, unbiased=False)
+            ln = (x - mean) * torch.rsqrt(var + 1e-5)
+            return ln * torch.sigmoid(ln)
+
+        def fn(a, b, c, d):
+            return ln_silu(a), ln_silu(b), ln_silu(c), ln_silu(d)
+
+        # Identical shapes/dtypes so all four sub-kernels are structurally
+        # identical and eligible for uniform dispatch.
+        inps = [torch.rand(64, 512, device=GPU_TYPE) for _ in range(4)]
+
+        with torch._inductor.config.patch({"combo_kernel_uniform_dispatch": True}):
+            out_eager = fn(*inps)
+            out_compiled, code = run_and_get_code(torch.compile(fn), *inps)
+
+        self.assertEqual(out_eager, out_compiled)
+
+        # Correctness alone is vacuous here: if the pass silently bailed (op-trace
+        # mismatch, structural pre-check failure, fallback to sequential dispatch)
+        # the output would still be correct. So assert the generated code actually
+        # contains the codegen patterns that ONLY the uniform-dispatch path emits.
+        full_code = "\n".join(code)
+
+        # Locate the generated kernel that took the uniform path via a token that
+        # no other dispatch strategy produces.
+        uniform_srcs = [
+            c for c in code if "kernel_idx = pid // num_blocks_per_kernel" in c
+        ]
+        self.assertEqual(
+            len(uniform_srcs),
+            1,
+            "expected exactly one generated kernel using uniform dispatch",
+        )
+        src = uniform_srcs[0]
+
+        # (a) Runtime pointer-table dispatch scaffolding. A single program id is
+        #     split into (kernel_idx, pid_offset); kernel_idx selects the
+        #     sub-kernel's buffers from a pointer table. These pid // and pid %
+        #     forms are emitted unconditionally by UniformDispatch and by no
+        #     other strategy (Sequential/RoundRobin use num_xblocks_N + if/elif).
+        self.assertIn("num_blocks_per_kernel =", src)
+        self.assertIn("kernel_idx = pid // num_blocks_per_kernel", src)
+        self.assertIn("pid_offset = pid % num_blocks_per_kernel", src)
+
+        # (b) The branch chain is gone: the whole point of the pass is to replace
+        #     the per-sub-kernel `if pid < .../elif pid < ...` dispatch with one
+        #     shared body. Its absence proves the N bodies collapsed into one.
+        self.assertNotIn("elif pid", src)
+
+        # (c) Every buffer is loaded indirectly from its slot table and cast to a
+        #     typed pointer -- the defining transform of uniform dispatch.
+        loaded_slots = sorted(
+            int(i)
+            for i in re.findall(
+                r"tl\.load\(_slot_(\d+)_ptrs \+ kernel_idx\)\.to\(tl\.pointer_type\(",
+                src,
+            )
+        )
+        self.assertTrue(loaded_slots, "expected pointer-table indirection loads")
+
+        # (d) Structural invariant: every slot table declared as a kernel
+        #     parameter is consumed by exactly one indirection load, and slots
+        #     are numbered contiguously from 0.
+        declared_slots = sorted(
+            {int(i) for i in re.findall(r"(?<!_uniform)_slot_(\d+)_ptrs", src)}
+        )
+        self.assertEqual(loaded_slots, declared_slots)
+        self.assertEqual(loaded_slots, list(range(len(loaded_slots))))
+
+        # (e) Wrapper side (may be emitted in a separate code object): the pointer
+        #     tables are int64 GPU tensors built from each sub-kernel buffer's
+        #     data_ptr(). `_uniform_slot_*` is unique to this pass.
+        self.assertIn("_uniform_slot_0_ptrs", full_code)
+        self.assertIn(".data_ptr()", full_code)
+        self.assertIn("dtype=torch.int64", full_code)
+
+    @requires_gpu_and_triton
     def test_mutated_args(self):
         def test_mutated(a, b, c, d):
             a.add_(1)

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -3006,6 +3006,7 @@ class CSEProxy(DefaultHandler):
     def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
         self.kernel.store_buffer_names.add(name)
         self._update_store_cache(name, value)
+        self.kernel.record_op_trace("store_reduction", (name, index, value), {})
 
         if name not in V.graph.removed_buffers:
             self.kernel.num_store += 1
@@ -3019,7 +3020,11 @@ class CSEProxy(DefaultHandler):
         value: CSEVariable | tuple[CSEVariable, ...],
     ) -> CSEVariable | tuple[CSEVariable, ...]:
         self.kernel.num_reduction += 1
-        return self.kernel.reduction(dtype, src_dtype, reduction_type, value)
+        result = self.kernel.reduction(dtype, src_dtype, reduction_type, value)
+        self.kernel.record_op_trace(
+            "reduction", (dtype, src_dtype, reduction_type, value), {}, result
+        )
+        return result
 
     def scan(
         self,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3472,6 +3472,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 self._normalize_trace_value(value),
                 self._normalize_trace_value(mode),
             )
+        elif name == "store_reduction":
+            # Uniform dispatch targets reduction kernels, so reduction stores
+            # must be captured (buffer-agnostic) like regular stores.
+            buffer_name, index, value = args
+            normalized_args = (
+                self._trace_buffer(buffer_name, store=True),
+                self._normalize_trace_value(index),
+                self._normalize_trace_value(value),
+            )
         else:
             normalized_args = tuple(self._normalize_trace_value(arg) for arg in args)
 

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -34,6 +34,7 @@ from ..utils import (
     clear_on_fresh_cache,
     DeferredLineBase,
     Placeholder,
+    triton_type,
     triton_version_uses_attrs_dict,
 )
 from ..virtualized import V
@@ -578,6 +579,28 @@ class ComboKernel(Kernel):
             with code.indent():
                 code.splice(f"pid_offset = pid // {num_kernels}")
 
+    class UniformDispatch:
+        """
+        Dispatch strategy for combo kernels where all sub-kernels have
+        identical computation (same ops, same shapes, just different buffer
+        pointers). Instead of if/elif branching, generates a single body
+        with pointer-array indexing:
+            kernel_idx = pid // num_blocks_per_kernel
+            pid_offset = pid % num_blocks_per_kernel
+            ptr = tl.load(ptr_array + kernel_idx).to(tl.pointer_type(dtype))
+        This eliminates register pressure from duplicated code paths.
+        """
+
+        grid_expr = SequentialComboKernelGrid
+
+        @classmethod
+        def codegen_pid_range(
+            cls, kernel: "ComboKernel", num: int, code: IndentedBuffer  # noqa: F841
+        ) -> None:
+            # UniformDispatch does not use pid_range codegen;
+            # the uniform path in codegen_kernel() handles dispatch directly.
+            pass
+
     def __init__(
         self,
         triton_kernel_cls: type[TritonKernel],
@@ -601,6 +624,7 @@ class ComboKernel(Kernel):
                 ComboKernel.SequentialDispatch
                 | ComboKernel.SequentialFlattenGridDispatch
                 | ComboKernel.RoundRobinDispatch
+                | ComboKernel.UniformDispatch
             ]
             | None
         ) = None
@@ -617,6 +641,7 @@ class ComboKernel(Kernel):
         self.stitched_block_config: dict[str, int] | None = None
         # Distinct winner launch configs across the subkernels; seeds the combo's kernel-level autotune.
         self.combo_launch_candidates: list[ComboLaunchConfig] = []
+        self._uniform_dispatch_info: dict[str, Any] | None = None
 
     @property
     def bake_blocks(self) -> bool:
@@ -851,8 +876,152 @@ class ComboKernel(Kernel):
                     mutated_args.add(arg)
         return sorted(mutated_args)
 
+    def _detect_uniform_subkernels(self) -> bool:
+        """
+        Detect whether all sub-kernels are structurally identical (same ops,
+        same shapes, differing only in buffer pointers). If so, store the
+        mapping info in self._uniform_dispatch_info and return True.
+
+        This performs a structural check without generating bodies:
+        - All sub-kernels must have the same range tree structure
+        - All sub-kernels must have the same reduction/no_x_dim flags
+        - Must have at least 2 sub-kernels
+        - No dynamic shapes (simplifies the initial implementation)
+        - No per-subkernel blocks mode
+        """
+        if len(self.sub_kernels) < 2:
+            log.debug("uniform dispatch: skipped (< 2 sub-kernels)")
+            return False
+
+        # Bail on per-subkernel blocks
+        if config.combo_kernel_per_subkernel_blocks:
+            log.debug("uniform dispatch: skipped (per_subkernel_blocks)")
+            return False
+
+        # Check for dynamic shapes directly (can't rely on dynamic_shape_args
+        # as it may not be populated yet at detection time)
+        for sub in self.sub_kernels:
+            for tree in sub.range_trees:
+                if not isinstance(
+                    V.graph.sizevars.simplify(tree.numel), (Integer, int)
+                ):
+                    log.debug("uniform dispatch: skipped (dynamic shape in %s)", tree.prefix)
+                    return False
+
+        ref = self.sub_kernels[0]
+        ref_trees = [(t.prefix, t.is_reduction, V.graph.sizevars.simplify(t.numel))
+                     for t in ref.range_trees]
+
+        for idx, sub in enumerate(self.sub_kernels[1:], 1):
+            # Must have same flags
+            if sub.no_x_dim != ref.no_x_dim:
+                log.debug("uniform dispatch: skipped (no_x_dim mismatch at sub %d)", idx)
+                return False
+            if sub.inside_reduction != ref.inside_reduction:
+                log.debug("uniform dispatch: skipped (inside_reduction mismatch at sub %d)", idx)
+                return False
+            if sub.persistent_reduction != ref.persistent_reduction:
+                log.debug("uniform dispatch: skipped (persistent_reduction mismatch at sub %d)", idx)
+                return False
+
+            # Must have same range tree structure
+            sub_trees = [(t.prefix, t.is_reduction, V.graph.sizevars.simplify(t.numel))
+                         for t in sub.range_trees]
+            if sub_trees != ref_trees:
+                log.debug("uniform dispatch: skipped (range tree mismatch at sub %d: %s vs %s)", idx, sub_trees, ref_trees)
+                return False
+
+        # All structural checks passed
+        log.debug("uniform dispatch: structural check PASSED for %d sub-kernels", len(self.sub_kernels))
+        self._uniform_dispatch_info = {}
+        return True
+
+    def _build_uniform_dispatch_info(self) -> bool:
+        """
+        After bodies are generated, verify all sub-kernels share an identical
+        structured op trace and build the slot mapping for pointer arrays.
+
+        The op trace is recorded during body codegen (see
+        ``TritonKernel.record_op_trace``) with buffer names, CSE temporaries and
+        range symbols normalized to positional placeholders.  Structural
+        equality of the traces therefore means the sub-kernel bodies are
+        identical up to their buffer pointers -- exactly the condition uniform
+        dispatch requires -- without depending on the textual form of the
+        generated Triton code.
+
+        Returns True if uniform dispatch can proceed, False to fall back.
+        """
+        first_trace = self.sub_kernels[0].op_trace
+        if not first_trace:
+            log.debug("uniform dispatch build: FAILED - empty op trace")
+            return False
+        if any(sub.op_trace != first_trace for sub in self.sub_kernels[1:]):
+            log.debug("uniform dispatch build: FAILED - op trace mismatch")
+            return False
+
+        # Resolve inner buffer arg name -> outer call arg + dtype from the
+        # shared combo-kernel args namespace.
+        argdefs, call_args, precompile_args, _ = self.args.python_argdefs()
+        inner_to_outer: dict[str, str] = {}
+        inner_to_dtype: dict[str, Any] = {}
+        for argdef, call_arg, precompile_arg in zip(argdefs, call_args, precompile_args):
+            inner_to_outer[argdef.name] = call_arg
+            if hasattr(precompile_arg, "dtype"):
+                inner_to_dtype[argdef.name] = precompile_arg.dtype
+
+        # Per sub-kernel, the ordered pointer args referenced by the body taken
+        # from the structured trace (first-appearance order).  Filtering to
+        # real kernel args drops removed/intermediate buffers that never appear
+        # in the emitted body.
+        buf_refs_per_kernel: list[list[str]] = [
+            [name for name in sub.op_trace_buffer_arg_names if name in inner_to_outer]
+            for sub in self.sub_kernels
+        ]
+
+        ref_count = len(buf_refs_per_kernel[0])
+        if ref_count == 0:
+            log.debug("uniform dispatch build: FAILED - no buffer refs in body")
+            return False
+        if any(len(refs) != ref_count for refs in buf_refs_per_kernel[1:]):
+            log.debug("uniform dispatch build: FAILED - buffer ref count mismatch")
+            return False
+
+        # Build slot info: for each slot position, record the buffer inner name
+        # used in sub-kernel 0's body plus the outer (call_arg) names and dtype.
+        # Op-trace equality guarantees the buffers correspond positionally
+        # across sub-kernels.
+        slots: list[dict[str, Any]] = []
+        ref_buf_refs = buf_refs_per_kernel[0]
+        for slot_idx in range(ref_count):
+            slot_call_args = []
+            slot_dtype = None
+            for refs in buf_refs_per_kernel:
+                inner_name = refs[slot_idx]
+                outer = inner_to_outer.get(inner_name)
+                if outer is None:
+                    return False  # can't resolve buffer
+                slot_call_args.append(outer)
+                if slot_dtype is None:
+                    slot_dtype = inner_to_dtype.get(inner_name)
+
+            slots.append({
+                "inner_name": ref_buf_refs[slot_idx],  # name used in the body
+                "call_args": slot_call_args,  # outer buffer names per sub-kernel
+                "dtype": slot_dtype,  # torch dtype for pointer cast
+            })
+
+        self._uniform_dispatch_info = {
+            "slots": slots,
+            "body": self.sub_kernels[0].body,
+            "buf_refs": buf_refs_per_kernel,
+        }
+        return True
+
     def select_dispatch_strategy(self) -> None:
         if self.dispatch_class is not None:
+            return
+        if config.combo_kernel_uniform_dispatch and self._detect_uniform_subkernels():
+            self.dispatch_class = ComboKernel.UniformDispatch
             return
         if self.per_subkernel_blocks:
             self.dispatch_class = ComboKernel.SequentialFlattenGridDispatch
@@ -891,12 +1060,19 @@ class ComboKernel(Kernel):
         for i, sub in enumerate(self.sub_kernels):
             self.min_x_blocks_sub_kernel(sub, i)
         self.select_dispatch_strategy()
+        sig_meta = signature_to_meta(
+            signature, size_dtype=size_dtype, argdefs=argdefs
+        )
+        # Slot pointer-table args are int64 tensors of GPU addresses but modeled
+        # as SizeArg for config_of compatibility.  Override their signature type
+        # from scalar (i32/i64) to pointer (*i64) so Triton treats them correctly.
+        for argdef in argdefs:
+            if argdef.name.startswith("_slot_") and argdef.name.endswith("_ptrs"):
+                sig_meta[argdef.name] = "*i64"
         triton_meta: TritonMeta = cast(
             TritonMeta,
             {
-                "signature": signature_to_meta(
-                    signature, size_dtype=size_dtype, argdefs=argdefs
-                ),
+                "signature": sig_meta,
                 "device": DeviceProperties.create(
                     V.graph.get_current_device_or_throw()
                 ),
@@ -1454,6 +1630,41 @@ class ComboKernel(Kernel):
             if heuristics == "pointwise_with_reduction"
             else (False, heuristics)
         )
+
+        # Early detection for uniform dispatch (before jit_line/select_dispatch_strategy)
+        if (
+            self.dispatch_class is None
+            and config.combo_kernel_uniform_dispatch
+            and self._detect_uniform_subkernels()
+        ):
+            self.dispatch_class = ComboKernel.UniformDispatch
+
+        # Attempt uniform dispatch path
+        if self.dispatch_class is ComboKernel.UniformDispatch:
+            result = self._codegen_uniform_kernel(
+                name,
+                heuristics,
+                size_hints,
+                selected_kernel,
+                pointwise_with_reduction,
+                size_hints_list,
+            )
+            if result is not None:
+                return result
+            # Verification failed, fall back to sequential dispatch.
+            # Reset state that may have been modified during the uniform attempt.
+            self.dispatch_class = ComboKernel.SequentialDispatch
+            self.min_x_blocks_list = []
+            self.x_numels_list = []
+            self.y_tree_list = []
+            self.block_args = []
+            self.dynamic_shape_args = []
+            self._uniform_dispatch_info = None
+            log.debug(
+                "ComboKernel: uniform dispatch verification failed, "
+                "falling back to sequential dispatch"
+            )
+
         code = IndentedBuffer()
 
         code.splice(self.triton_kernel_cls.gen_common_triton_imports())
@@ -1512,6 +1723,172 @@ class ComboKernel(Kernel):
                 code.splice("else:")
                 with code.indent():
                     code.splice("pass")
+            if config.triton.proton_profiling:
+                code.writeline(f'pl.exit_scope("{kernel_name}")')
+
+        if config.benchmark_combo_kernel:
+            code.splice(self.codegen_kernel_benchmark(num_gb=self._kernel_num_gb))
+
+        return code.getvalue()
+
+    def _codegen_uniform_kernel(
+        self,
+        name: str | None,
+        heuristics: str,
+        size_hints: dict[str, int],
+        selected_kernel: TritonKernel,
+        pointwise_with_reduction: bool,
+        size_hints_list: list[dict[str, int]],
+    ) -> str | None:
+        """
+        Generate the kernel code for uniform dispatch.
+        Returns the kernel source string, or None if body verification fails.
+        """
+        # Step 1: Generate bodies for all sub-kernels
+        for sub_kernel in self.sub_kernels:
+            sub_kernel.codegen_body()
+            sub_kernel._filter_pdl(sub_kernel.body)
+
+        # Step 2: Verify bodies are truly identical and build slot mapping
+        if not self._build_uniform_dispatch_info():
+            return None
+
+        assert self._uniform_dispatch_info is not None
+        slots = self._uniform_dispatch_info["slots"]
+        body_buf = self._uniform_dispatch_info["body"]
+
+        # Step 3: Build modified argdefs/signature
+        # Replace individual buffer args with slot pointer-table args
+        orig_argdefs, _, orig_signature, _ = self.args.python_argdefs()
+
+        # Collect all inner buffer names that are part of slots
+        slot_inner_names: set[str] = set()
+        for slot in slots:
+            for refs in self._uniform_dispatch_info["buf_refs"]:
+                for ref_name in refs:
+                    slot_inner_names.add(ref_name)
+
+        # Build new argdefs: slot pointer-table args + non-buffer args
+        new_argdefs: list[ArgName] = []
+        new_signature: list[Any] = []
+        for slot_idx, slot in enumerate(slots):
+            slot_arg_name = f"_slot_{slot_idx}_ptrs"
+            new_argdefs.append(ArgName(slot_arg_name))
+            # Signature entry for pointer arg (int64 tensor / pointer)
+            new_signature.append(
+                SizeArg(slot_arg_name, Integer(0))  # placeholder for signature_to_meta
+            )
+
+        # Add non-buffer args (size args, etc.)
+        for argdef, sig_entry in zip(orig_argdefs, orig_signature):
+            if argdef.name not in slot_inner_names:
+                new_argdefs.append(argdef)
+                new_signature.append(sig_entry)
+
+        # Add numel args and block args
+        new_argdefs = self.add_numel_to_args(new_argdefs, new_signature)
+        block_args = self.get_block_args()
+        if self.enable_autotune:
+            new_argdefs.extend(
+                [ArgName(x.name, is_constexpr=True) for x in block_args]
+            )
+            if triton_version_uses_attrs_dict():
+                new_signature.extend(block_args)
+
+        # Step 4: Generate the kernel code
+        code = IndentedBuffer()
+        code.splice(self.triton_kernel_cls.gen_common_triton_imports())
+        if config.benchmark_combo_kernel:
+            code.splice(self.imports_for_benchmark_kernel())
+
+        seen_helpers: OrderedSet[str] = OrderedSet()
+        for sub_kernel in self.sub_kernels:
+            for helper in sub_kernel.helper_functions:
+                if helper not in seen_helpers:
+                    code.writeline("")
+                    code.splice(helper)
+                    seen_helpers.add(helper)
+
+        code.splice(
+            self.jit_line(
+                heuristics,
+                size_hints,
+                selected_kernel,
+                pointwise_with_reduce=pointwise_with_reduction,
+                signature=new_signature,
+                argdefs=new_argdefs,
+                size_hints_list=size_hints_list,
+            )
+        )
+        kernel_name = name or str(Placeholder.KERNEL_NAME)
+        code.writeline(
+            f"def {kernel_name}({', '.join(x.full_name() for x in new_argdefs)}):"
+        )
+
+        with code.indent():
+            if config.triton.proton_profiling:
+                code.writeline(f'pl.enter_scope("{kernel_name}")')
+            code.splice("pid = tl.program_id(0)")
+            if not self.enable_autotune:
+                self.codegen_blocks(code)
+
+            # Compute dispatch indices
+            ref_sub = self.sub_kernels[0]
+            # Get xnumel for computing blocks per kernel
+            xnumel_expr: int | str = 0
+            for tree in ref_sub.range_trees:
+                if tree.prefix == "x":
+                    simplified = V.graph.sizevars.simplify(tree.numel)
+                    if isinstance(simplified, (Integer, int)):
+                        xnumel_expr = int(simplified)
+                    else:
+                        xnumel_expr = f"xnumel_0"
+                    break
+
+            if ref_sub.no_x_dim:
+                code.writeline(
+                    f"num_blocks_per_kernel = {xnumel_expr}"
+                )
+            else:
+                code.writeline(
+                    f"num_blocks_per_kernel = tl.cdiv({xnumel_expr}, XBLOCK)"
+                )
+            code.writeline(
+                "kernel_idx = pid // num_blocks_per_kernel"
+            )
+            code.writeline(
+                "pid_offset = pid % num_blocks_per_kernel"
+            )
+
+            # Emit pointer loads from slot arrays
+            for slot_idx, slot in enumerate(slots):
+                inner_name = slot["inner_name"]
+                dtype = slot["dtype"]
+                tl_type = triton_type(dtype) if dtype is not None else "tl.int64"
+                code.writeline(
+                    f"{inner_name} = tl.load(_slot_{slot_idx}_ptrs + kernel_idx)"
+                    f".to(tl.pointer_type({tl_type}))"
+                )
+
+            # Emit static numels for sub-kernel 0
+            for tree in ref_sub.range_trees:
+                simplified = V.graph.sizevars.simplify(tree.numel)
+                if isinstance(simplified, (Integer, int)):
+                    code.writeline(f"{tree.prefix}numel = {int(simplified)}")
+
+            # Emit reduction block size constexpr if needed (persistent reductions)
+            for tree in ref_sub.range_trees:
+                if tree.is_reduction:
+                    simplified = V.graph.sizevars.simplify(tree.numel)
+                    if isinstance(simplified, (Integer, int)):
+                        rblock_size = next_power_of_2(int(simplified))
+                        code.writeline(
+                            f"R0_BLOCK: tl.constexpr = {rblock_size}"
+                        )
+
+            # Emit the single body (from sub-kernel 0)
+            code.splice(body_buf)
+
             if config.triton.proton_profiling:
                 code.writeline(f'pl.exit_scope("{kernel_name}")')
 
@@ -1670,6 +2047,14 @@ class ComboKernel(Kernel):
         wrapper = V.graph.wrapper_code
         if self.dispatch_class is None:
             raise AssertionError("dispatch_class must not be None")
+
+        if (
+            self.dispatch_class is ComboKernel.UniformDispatch
+            and self._uniform_dispatch_info is not None
+        ):
+            self._call_kernel_uniform(name, call_args, arg_types)
+            return
+
         if self.dynamic_shape_args:
             self.add_numel_to_call_args(name, call_args, arg_types)
 
@@ -1678,6 +2063,91 @@ class ComboKernel(Kernel):
             call_args,
             triton=True,
             arg_types=arg_types,
+            triton_meta=self.triton_meta,
+            inductor_meta=self.inductor_meta,
+        )
+
+    def _call_kernel_uniform(
+        self, name: str, call_args: list[Any], arg_types: list[Any]
+    ) -> None:
+        """
+        Emit the wrapper code for uniform dispatch: build pointer-table tensors
+        and call the kernel with them.
+        """
+        assert self._uniform_dispatch_info is not None
+        slots = self._uniform_dispatch_info["slots"]
+        wrapper = V.graph.wrapper_code
+
+        # Build the set of buffer call_args that are replaced by slots
+        argdefs, _, _, _ = self.args.python_argdefs()
+        # Map inner_name -> call_arg (outer buffer name)
+        inner_to_call_arg: dict[str, str] = {}
+        for argdef, call_arg in zip(argdefs, call_args):
+            inner_to_call_arg[argdef.name] = call_arg
+
+        # Determine device from first buffer in first slot
+        first_buf = slots[0]["call_args"][0]
+        device_expr = f"{first_buf}.device"
+
+        # Emit pointer-table tensor allocations with caching.
+        # Simple integer-key cache: built on first call (warmup), reused on
+        # subsequent calls. Since input buffers don't change addresses within
+        # a single do_bench_cudagraph session, this is safe.
+        slot_var_names: list[str] = []
+        cache_dict_name = f"_upc_{name}"
+        wrapper.writeline(
+            f"if '{cache_dict_name}' not in globals(): globals()['{cache_dict_name}'] = {{}}"
+        )
+        for slot_idx, slot in enumerate(slots):
+            var_name = f"_uniform_slot_{slot_idx}_ptrs"
+            buf_names = slot["call_args"]
+            n = len(buf_names)
+            data_ptr_exprs = [f"{buf}.data_ptr()" for buf in buf_names]
+            wrapper.writeline(
+                f"if {slot_idx} not in globals()['{cache_dict_name}']:"
+            )
+            wrapper.writeline(
+                f"    _cpu = torch.tensor("
+                f"[{', '.join(data_ptr_exprs)}], "
+                f"dtype=torch.int64).pin_memory()"
+            )
+            wrapper.writeline(
+                f"    globals()['{cache_dict_name}'][{slot_idx}] = torch.empty("
+                f"{n}, dtype=torch.int64, device={device_expr})"
+            )
+            wrapper.writeline(
+                f"    globals()['{cache_dict_name}'][{slot_idx}].copy_(_cpu, non_blocking=True)"
+            )
+            wrapper.writeline(
+                f"{var_name} = globals()['{cache_dict_name}'][{slot_idx}]"
+            )
+            slot_var_names.append(var_name)
+
+        # Build the new call_args: slot pointer tables + non-buffer args
+        slot_inner_names: set[str] = set()
+        for slot in slots:
+            for refs in self._uniform_dispatch_info["buf_refs"]:
+                for ref_name in refs:
+                    slot_inner_names.add(ref_name)
+
+        new_call_args: list[Any] = list(slot_var_names)
+        new_arg_types: list[Any] = [None] * len(slot_var_names)  # tensor types
+
+        # Add non-buffer args (size vars, workspace args, etc.)
+        for argdef, call_arg, arg_type in zip(argdefs, call_args, arg_types):
+            if argdef.name not in slot_inner_names:
+                new_call_args.append(call_arg)
+                new_arg_types.append(arg_type)
+
+        # Add numel args if needed
+        if self.dynamic_shape_args:
+            self.add_numel_to_call_args(name, new_call_args, new_arg_types)
+
+        wrapper.generate_kernel_call(
+            name,
+            new_call_args,
+            triton=True,
+            arg_types=new_arg_types,
             triton_meta=self.triton_meta,
             inductor_meta=self.inductor_meta,
         )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1081,7 +1081,9 @@ compute_all_bounds = False
 
 # enable the combo kernel that combines data-independent kernels (additional
 # to foreach kernels) into a single one (Experimental)
-combo_kernels = False
+# Can be forced on via the TORCHINDUCTOR_COMBO_KERNELS=1 env var, which the
+# inductor perf dashboard CI uses to A/B combo kernels.
+combo_kernels: bool = os.environ.get("TORCHINDUCTOR_COMBO_KERNELS", "0") == "1"
 # benchmark combo kernels and only allow ones with perf gains
 benchmark_combo_kernel = False
 # combo_kernel autotuning options: 0 - disable, 1 - enable except for foreach,
@@ -1130,7 +1132,11 @@ combo_kernel_max_distance: int = -1
 # When True, detect identical sub-kernels in combo groups and generate a single
 # code body with pointer-array indexing instead of if/elif branching.
 # This eliminates register pressure and branching overhead for uniform sub-kernels.
-combo_kernel_uniform_dispatch = False
+# Can be forced on via the TORCHINDUCTOR_COMBO_KERNEL_UNIFORM_DISPATCH=1 env var,
+# which the inductor perf dashboard CI uses to A/B uniform dispatch.
+combo_kernel_uniform_dispatch: bool = (
+    os.environ.get("TORCHINDUCTOR_COMBO_KERNEL_UNIFORM_DISPATCH", "0") == "1"
+)
 
 # constant folding on the joint graph
 joint_graph_constant_folding = True

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1127,6 +1127,10 @@ combo_kernel_peak_memory_pct_threshold: float | None = 0.05
 # sub-windows. Set to -1 (or any negative value) to disable splitting
 # and treat each parallel group as one window.
 combo_kernel_max_distance: int = -1
+# When True, detect identical sub-kernels in combo groups and generate a single
+# code body with pointer-array indexing instead of if/elif branching.
+# This eliminates register pressure and branching overhead for uniform sub-kernels.
+combo_kernel_uniform_dispatch = False
 
 # constant folding on the joint graph
 joint_graph_constant_folding = True


### PR DESCRIPTION
Summary:
Adds CI plumbing so the inductor-perf-test-nightly-h100 workflow can A/B combo
kernels and combo-kernel uniform dispatch on the perf dashboard. Split out of
D104781566 so the feature diff stays free of CI/workflow changes.

- config.py: make combo_kernels and combo_kernel_uniform_dispatch overridable
  via TORCHINDUCTOR_COMBO_KERNELS / TORCHINDUCTOR_COMBO_KERNEL_UNIFORM_DISPATCH
  env vars (default False, unchanged).
- inductor-perf-test-nightly-h100.yml: add combo_kernels and
  combo_kernel_uniform_dispatch workflow_dispatch boolean inputs and thread them
  into the test job dashboard-tag.
- test.sh: export the two env vars globally in test_perf_for_dashboard when the
  dashboard tag has combo_kernels-true / combo_kernel_uniform_dispatch-true, so
  the toggles apply across all benchmark configs.

Test Plan:
- arc lint -a: no issues.
- bash -n on test.sh (both mirrors): OK.
- py_compile on config.py: OK.
- Will trigger the workflow twice from this branch (uniform dispatch off then on,
  combo kernels on in both) and compare on the CI perf dashboard.

Differential Revision: D113835213