### PR TITLE
[MPS] nonzero: recompute intra-block prefixes in scatter, drop per-element scratch

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -954,9 +954,9 @@ INSTANTIATE_INDEX_FILL_FROM_MASK(half2)
 
 // Nonzero kernel implementation using prefix-sum + scatter approach.
 //
-// Step 1 (count_nonzero_prefix_sum): Each threadgroup computes an exclusive
-// prefix sum of the nonzero flags over its chunk. Per-threadgroup totals are
-// written to block_sums.
+// Step 1 (count_nonzero_prefix_sum): Each threadgroup computes a block-local
+// prefix sum of the nonzero flags over its chunk and writes its per-block
+// total to block_sums.
 //
 // Step 2 (prefix_sum_blocks_uint): A single threadgroup computes the exclusive
 // prefix sum of block_sums → block_offsets and writes the total nonzero count
@@ -965,7 +965,8 @@ INSTANTIATE_INDEX_FILL_FROM_MASK(half2)
 //
 // Step 3 (scatter_nonzero_indices): Each thread with a nonzero element writes
 // its multi-dimensional indices into the output at the position determined by
-// block_offsets[tgid] + prefix[tid].
+// block_offsets[tgid] plus an intra-block prefix recomputed in threadgroup
+// memory.
 
 template <typename T, enable_if_t<!is_complex_v<T>, bool> = true>
 inline bool is_nonzero(T val) {
@@ -989,14 +990,14 @@ inline bool is_nonzero(T val) {
 // (Metal 3.x cannot simd_shuffle 64-bit integers, so the i64 path scans in
 // threadgroup memory.) The input flat index is a separate concern, widened via
 // the index_t template parameter (see scatter_nonzero_indices).
+
 template <typename T, typename index_t>
 [[max_total_threads_per_threadgroup(1024)]]
 kernel void count_nonzero_prefix_sum(
     const device T* input [[buffer(0)]],
-    device uint* prefix [[buffer(1)]],
-    device uint* block_sums [[buffer(2)]],
-    constant ulong& flat_base [[buffer(3)]],
-    constant uint& block_base [[buffer(4)]],
+    device uint* block_sums [[buffer(1)]],
+    constant ulong& flat_base [[buffer(2)]],
+    constant uint& block_base [[buffer(3)]],
     uint tid [[thread_position_in_grid]],
     uint lid [[thread_position_in_threadgroup]],
     uint tgsize [[threads_per_threadgroup]],
@@ -1015,6 +1016,7 @@ kernel void count_nonzero_prefix_sum(
 
   // Inclusive prefix sum within SIMD group using shuffle
   uint val = flag;
+
   for (uint offset = 1; offset < simdgroup_size; offset <<= 1) {
     uint other = simd_shuffle_and_fill_up(val, 0u, static_cast<ushort>(offset));
     val += other;
@@ -1051,10 +1053,6 @@ kernel void count_nonzero_prefix_sum(
     simdgroup_offsets[simd_lane_id] = exclusive;
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  uint exclusive_val = val - flag + simdgroup_offsets[simd_group_id];
-
-  prefix[gid] = exclusive_val;
 
   if (lid == tgsize - 1) {
     block_sums[block_base + tgid] =
@@ -1203,27 +1201,74 @@ kernel void prefix_sum_blocks_ulong(
 // The output position and its address arithmetic are 64-bit: the nonzero count
 // (hence pos) can exceed UINT32_MAX for a large dense input, and pos * ndim can
 // exceed it even when pos and ndim individually fit in uint32.
+
 template <typename T, typename index_t>
 [[max_total_threads_per_threadgroup(1024)]]
 kernel void scatter_nonzero_indices(
     const device T* input [[buffer(0)]],
-    const device uint* prefix [[buffer(1)]],
-    device int64_t* output [[buffer(2)]],
-    constant int& ndim [[buffer(3)]],
-    constant int64_t* sizes [[buffer(4)]],
-    constant long* block_offsets [[buffer(5)]],
-    constant long& max_entries [[buffer(6)]],
-    constant ulong& flat_base [[buffer(7)]],
-    constant uint& block_base [[buffer(8)]],
+    device int64_t* output [[buffer(1)]],
+    constant int& ndim [[buffer(2)]],
+    constant int64_t* sizes [[buffer(3)]],
+    constant long* block_offsets [[buffer(4)]],
+    constant long& max_entries [[buffer(5)]],
+    constant ulong& flat_base [[buffer(6)]],
+    constant uint& block_base [[buffer(7)]],
     uint tid [[thread_position_in_grid]],
-    uint tgid [[threadgroup_position_in_grid]]) {
+    uint tgid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
+  uint num_simds = (tgsize + simdgroup_size - 1) / simdgroup_size;
   // Chunked dispatch: map chunk-local tid/tgid to the global element/block.
   ulong gid = flat_base + tid;
-  if (!is_nonzero(input[gid]))
+  uint flag = is_nonzero(input[gid]) ? 1u : 0u;
+
+  // Recompute the intra-block exclusive prefix (same scan as step 1) instead
+  // of loading it from a numel-sized device buffer. All threads participate —
+  // zero elements contribute 0-flags and must reach both barriers before any
+  // early exit.
+  uint val = flag;
+  for (uint offset = 1; offset < simdgroup_size; offset <<= 1) {
+    uint other = simd_shuffle_and_fill_up(val, 0u, static_cast<ushort>(offset));
+    val += other;
+  }
+
+  threadgroup uint simdgroup_totals[32];
+  bool is_last_lane_in_simd;
+  if (simd_group_id < num_simds - 1) {
+    is_last_lane_in_simd = (simd_lane_id == simdgroup_size - 1);
+  } else {
+    uint lanes_in_last = tgsize - simd_group_id * simdgroup_size;
+    is_last_lane_in_simd = (simd_lane_id == lanes_in_last - 1);
+  }
+  if (is_last_lane_in_simd) {
+    simdgroup_totals[simd_group_id] = val;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  threadgroup uint simdgroup_offsets[32];
+  if (simd_group_id == 0) {
+    uint sg_val =
+        (simd_lane_id < num_simds) ? simdgroup_totals[simd_lane_id] : 0u;
+    for (uint offset = 1; offset < simdgroup_size; offset <<= 1) {
+      uint other =
+          simd_shuffle_and_fill_up(sg_val, 0u, static_cast<ushort>(offset));
+      sg_val += other;
+    }
+    uint exclusive =
+        simd_shuffle_and_fill_up(sg_val, 0u, static_cast<ushort>(1));
+    simdgroup_offsets[simd_lane_id] = exclusive;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Past both barriers — zero elements may now leave.
+  if (flag == 0u)
     return;
 
+  uint exclusive_val = val - flag + simdgroup_offsets[simd_group_id];
   ulong pos =
-      static_cast<ulong>(block_offsets[block_base + tgid]) + prefix[gid];
+      static_cast<ulong>(block_offsets[block_base + tgid]) + exclusive_val;
   if (pos >= static_cast<ulong>(max_entries))
     return;
 
@@ -1240,17 +1285,16 @@ kernel void scatter_nonzero_indices(
 }
 
 // IDX (uint/ulong) is the flat-index width; it also names the registered
-// kernel. The buffers themselves are IDX-independent (prefix/block_sums stay
+// kernel. The buffers themselves are IDX-independent (block_sums stays
 // uint32, block_offsets/output stay int64), so only the template arg varies.
 #define REGISTER_NONZERO_KERNELS_FOR_IDX(DTYPE, IDX)          \
   template [[host_name("count_nonzero_prefix_sum_" #DTYPE     \
                        "_" #IDX)]] [[kernel]] void            \
   count_nonzero_prefix_sum<DTYPE, IDX>(                       \
       const device DTYPE* input [[buffer(0)]],                \
-      device uint* prefix [[buffer(1)]],                      \
-      device uint* block_sums [[buffer(2)]],                  \
-      constant ulong& flat_base [[buffer(3)]],                \
-      constant uint& block_base [[buffer(4)]],                \
+      device uint* block_sums [[buffer(1)]],                  \
+      constant ulong& flat_base [[buffer(2)]],                \
+      constant uint& block_base [[buffer(3)]],                \
       uint tid [[thread_position_in_grid]],                   \
       uint lid [[thread_position_in_threadgroup]],            \
       uint tgsize [[threads_per_threadgroup]],                \
@@ -1262,16 +1306,19 @@ kernel void scatter_nonzero_indices(
                        "_" #IDX)]] [[kernel]] void            \
   scatter_nonzero_indices<DTYPE, IDX>(                        \
       const device DTYPE* input [[buffer(0)]],                \
-      const device uint* prefix [[buffer(1)]],                \
-      device int64_t* output [[buffer(2)]],                   \
-      constant int& ndim [[buffer(3)]],                       \
-      constant int64_t* sizes [[buffer(4)]],                  \
-      constant long* block_offsets [[buffer(5)]],             \
-      constant long& max_entries [[buffer(6)]],               \
-      constant ulong& flat_base [[buffer(7)]],                \
-      constant uint& block_base [[buffer(8)]],                \
+      device int64_t* output [[buffer(1)]],                   \
+      constant int& ndim [[buffer(2)]],                       \
+      constant int64_t* sizes [[buffer(3)]],                  \
+      constant long* block_offsets [[buffer(4)]],             \
+      constant long& max_entries [[buffer(5)]],               \
+      constant ulong& flat_base [[buffer(6)]],                \
+      constant uint& block_base [[buffer(7)]],                \
       uint tid [[thread_position_in_grid]],                   \
-      uint tgid [[threadgroup_position_in_grid]])
+      uint tgid [[threadgroup_position_in_grid]],             \
+      uint lid [[thread_position_in_threadgroup]],            \
+      uint tgsize [[threads_per_threadgroup]],                \
+      uint simd_lane_id [[thread_index_in_simdgroup]],        \
+      uint simd_group_id [[simdgroup_index_in_threadgroup]])
 
 #define REGISTER_NONZERO_KERNELS(DTYPE)          \
   REGISTER_NONZERO_KERNELS_FOR_IDX(DTYPE, uint); \

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -346,7 +346,7 @@ static inline const char* index_kernel_suffix(bool use_32bit_index) {
 }
 
 // Metal kernel-based nonzero using prefix-sum + scatter.
-// Step 1: Per-element exclusive prefix sum of nonzero flags + block totals.
+// Step 1: Per-block nonzero totals (block-local prefix scan).
 // Step 2: GPU prefix sum of block totals → block offsets + total count.
 // Host (optional):   Read back total count, allocate output, unless max_element is provided
 // Step 3: Scatter multi-dimensional indices into the output.
@@ -368,7 +368,7 @@ static void nonzero_impl_mps(const Tensor& self, Tensor& out_, std::optional<int
   const auto type_str = scalarToMetalTypeString(input);
   MPSStream* stream = getCurrentMPSStream();
 
-  // Count (step 1) indexes input/prefix by the flat element id, which is
+  // Count (step 1) indexes input by the flat element id, which is
   // bounded by numel, so its index width depends only on the input. Scatter
   // (step 3) also indexes the output, so it recomputes the width including out.
   const bool count_use_32bit_index = canUse32BitIndexMath(input);
@@ -396,13 +396,12 @@ static void nonzero_impl_mps(const Tensor& self, Tensor& out_, std::optional<int
   // with base 0, identical to the unchunked path.
   const uint64_t chunk_elems = (static_cast<uint64_t>(1) << 31) / threads_per_group * threads_per_group;
 
-  // Scratch buffers. prefix (intra-block, <= threadgroup size) and block_sums
-  // (per-block totals, likewise bounded) fit in uint32. block_offsets (the
-  // running cumulative count) and total_nonzero can exceed 2^32 for a large
-  // dense input, so they are int64, matching CUDA's int64 aggregate.
-  auto tmp32 = at::empty({numel + num_blocks_u32}, input.options().dtype(kInt));
-  Tensor prefix_buf = tmp32.slice(0, 0, numel);
-  Tensor block_sums_buf = tmp32.slice(0, numel, numel + num_blocks_u32);
+  // Scratch buffers. block_sums (per-block totals, bounded by the threadgroup
+  // size) fits in uint32. block_offsets (the running cumulative count) and
+  // total_nonzero can exceed 2^32 for a large dense input, so they are int64,
+  // matching CUDA's int64 aggregate. The per-element intra-block prefixes are
+  // not stored: the scatter kernel recomputes them in threadgroup memory.
+  Tensor block_sums_buf = at::empty({num_blocks_u32}, input.options().dtype(kInt));
   auto tmp64 = at::empty({num_blocks_u32 + 1}, input.options().dtype(kLong));
   Tensor block_offsets_buf = tmp64.slice(0, 0, num_blocks_u32);
   Tensor total_nonzero_buf = tmp64.slice(0, num_blocks_u32, num_blocks_u32 + 1);
@@ -416,7 +415,7 @@ static void nonzero_impl_mps(const Tensor& self, Tensor& out_, std::optional<int
       for (uint64_t base = 0; base < static_cast<uint64_t>(numel); base += chunk_elems) {
         uint64_t this_chunk = std::min(chunk_elems, static_cast<uint64_t>(numel) - base);
         uint32_t block_base = static_cast<uint32_t>(base / threads_per_group);
-        mtl_setArgs(computeEncoder, input, prefix_buf, block_sums_buf, base, block_base);
+        mtl_setArgs(computeEncoder, input, block_sums_buf, base, block_base);
         mtl_dispatch1DJob(computeEncoder, pso_step1, this_chunk);
       }
 
@@ -467,16 +466,8 @@ static void nonzero_impl_mps(const Tensor& self, Tensor& out_, std::optional<int
       for (uint64_t base = 0; base < static_cast<uint64_t>(numel); base += chunk_elems) {
         uint64_t this_chunk = std::min(chunk_elems, static_cast<uint64_t>(numel) - base);
         uint32_t block_base = static_cast<uint32_t>(base / threads_per_group);
-        mtl_setArgs(computeEncoder,
-                    input,
-                    prefix_buf,
-                    out,
-                    ndim_int,
-                    input.sizes(),
-                    block_offsets_buf,
-                    max_entries,
-                    base,
-                    block_base);
+        mtl_setArgs(
+            computeEncoder, input, out, ndim_int, input.sizes(), block_offsets_buf, max_entries, base, block_base);
         mtl_dispatch1DJob(computeEncoder, pso_step3, this_chunk);
       }
     }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10293,10 +10293,11 @@ class TestMPS(TestCaseMPS):
     # Generic nonzero correctness (baseline, empty, dtypes, N-D) is covered by
     # the nonzero OpInfo; only the large-tensor paths are MPS-specific and can't
     # be reached through OpInfo, so they live here.
-    # ~11 GiB unified memory needed: the input bool tensor is ~2.2 GiB and the
-    # int32 prefix-sum temporary buffer is ~8 GiB (numel * 4 bytes).
+    # ~3 GiB unified memory needed: the input bool tensor is ~2.2 GiB; the
+    # intra-block prefixes are recomputed in the scatter kernel rather than
+    # stored, so there is no per-element scratch buffer.
     @serialTest()
-    @largeTensorTest("11GB", device="mps")
+    @largeTensorTest("3GB", device="mps")
     def test_nonzero_multichunk_above_int32(self):
         # (1<<31)+1024 elements: above INT_MAX, and above the 2^31 per-dispatch
         # chunk size, so it exercises the multi-chunk count/scatter path and the
@@ -10308,10 +10309,10 @@ class TestMPS(TestCaseMPS):
         out = x.nonzero().squeeze(-1)
         self.assertEqual(out, positions.sort().values.to(torch.int64))
 
-    # ~22 GiB unified memory needed (input bool ~4 GiB + int32 prefix ~16 GiB);
+    # ~5 GiB unified memory needed (input bool ~4 GiB; no per-element scratch);
     # skips on machines/CI without enough memory.
     @serialTest()
-    @largeTensorTest("22GB", device="mps")
+    @largeTensorTest("5GB", device="mps")
     def test_nonzero_above_uint32(self):
         # More than 2^32 elements: the flat index and the count/scatter dispatch
         # both exceed Metal's 32-bit thread_position_in_grid, so this exercises


### PR DESCRIPTION
The MPS nonzero implementation stored each element's intra-block prefix in a fused int32 scratch buffer of (numel + num_blocks) * 4 bytes so the scatter pass could compute output positions. For n = (1 << 31) + 1024 that is a single 8.01 GiB Metal buffer regardless of nonzero count, which exceeds what smaller CI runners can grant ("RuntimeError: Invalid buffer size: 8.01 GiB") and is why test_nonzero_multichunk_above_int32 presented as flaky: pass/fail tracked runner capacity, not code behavior (#190881).

Instead, the scatter kernel recomputes the intra-block exclusive prefix with the same threadgroup-memory scan step 1 already uses (all threads participate in the scan; zero elements exit after the barriers). Per-element scratch drops to zero; only the per-block arrays (a few MB) remain. Chunked dispatch and the
>2^31 / >2^32 element support are unchanged.

Benchmarks (M4, 24 GB), before -> after:
- n = 2^31+1024, 6 nonzeros: 172.6 -> 115.6 ms, driver mem 12.01 -> 3.76 GiB
- n = 2^31+1024, 1% dense:   198.7 -> 141.8 ms, 11.32 -> 3.07 GiB
- n = 1e9, 50% dense:        300.3 -> 211.3 ms, peak memory -3.75 GiB
- 1M and 100M cases: unchanged-to-slightly-faster (no regression)

largeTensorTest requirements drop 11GB -> 3GB (multichunk) and 22GB -> 5GB (above_uint32); both pass locally, the latter now exercising the 64-bit block-scan path on-device.

Fixes #190881