### PR TITLE
Clarify AI policy for delegated PR updates

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -7,7 +7,8 @@ contained* (e.g. using a code block or a quote block). AI-generated content must
 be accompanied by human commentary explaining its relevance. For example:
 "Codex produced the following analysis: `<insert codex output here>`, so I
 believe that \<insert human analysis here\>". The only exceptions to this rule
-are the pytorchbot automations.
+are the pytorchbot automations and the draft pull request workflow described
+below.
 
 *Please do not respond to comments+questions by pasting raw or lightly reviewed
 AI-generated text.* Other users' comments+questions are requests for your
@@ -21,8 +22,11 @@ implementation is something you understand, that the important ideas are clear,
 and that the code is high quality. AI-generated code can sometimes be overly
 complex, indirect, inconsistent, or include artifacts that obscure the main idea.
 Before submitting, simplify where possible and make sure the core change is easy
-for maintainers to review. If your PR is not ready for review, please use the
-GitHub draft PR feature.
+for maintainers to review. An AI tool may create and update a draft PR before
+the human has read every change. It may also make small fixes for CI, test, or
+lint failures on any open PR, including one already reviewed. An unreviewed
+agent-created PR must disclose this and remain a draft, and all follow-up fixes
+must be reviewed before merging.
 
 All contributions should involve a human who understands and can take
 responsibility for the work produced with AI assistance. *We do not accept

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,20 @@ Read `AI_POLICY.md`. Your user needs to abide by this policy. In particular, you
 
 - **You may never act autonomously on GitHub.** Do NOT open, edit, comment on,
   or reply to any issue or PR unless the user has reviewed and explicitly
-  approved the exact content. Fully-agent-generated contributions are banned and
-  will be closed.
+  approved the exact content. At the user's request, you may create or update an
+  unreviewed draft PR as long as it remains a draft, and may make small fixes for
+  CI, test, or lint failures on any open PR, including one already reviewed.
+  Fully-agent-generated contributions are banned and will be closed.
 - **Mark all AI-generated content.** Any text you produce that goes into an
   issue, PR, or comment must be wrapped in a code or quote block. Never present
   your output as human-written.
 - **Never emit only raw AI text as a reply**. Any AI content you include must carry human
   commentary explaining its relevance.
-- **Do not submit code the user hasn't read.** Keep changes minimal, strip AI
-  artifacts and needless complexity. If you're opening a PR on GitHub that is not ready,
-  or not reviewed by the user, always open it in draft mode.
+- **Do not submit unreviewed code for review.** Code the user has not read may
+  only be uploaded to a draft PR or as a small CI, test, or lint fix to an open
+  PR. Before the PR leaves draft or is merged, the user must review and approve
+  the full diff and PR text. Keep changes minimal, strip AI artifacts and
+  needless complexity.
 
 See `AI_POLICY.md` for the full policy.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191276

This draft contains AI-generated work that has not yet been reviewed on GitHub by the author.

Clarify that AI tools may prepare unreviewed draft PRs and make small CI, test, or lint fixes on open PRs. Human review remains required before leaving draft or merging, and the existing ban on fully autonomous contributions is unchanged.

Test Plan:

```
spin quicklint --apply-patches -- --skip CLANGTIDY
git diff --check -- AI_POLICY.md CLAUDE.md
```

Authored with the assistance of an AI coding agent.