### PR TITLE
[dynamo] Snapshot dict items in get_items_from_dict to avoid mutation race

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -341,6 +341,24 @@ class TestUtils(TestCase):
         self.assertIsInstance(parsed, dict)
         self.assertNotIn("ignore_logging_functions", parsed)
 
+    def test_enumerate_items_with_dict_position_snapshots(self):
+        # VariableBuilder wraps a dict by consuming this generator lazily inside
+        # dict(...). When the dict is a frame-globals dict, Dynamo can add or
+        # drop generated globals (e.g. __resume_at removed by a CleanupHook) on
+        # it mid-iteration. A live items view would raise "dictionary changed
+        # size during iteration"; the snapshot must tolerate the mutation.
+        d = {f"k{i}": i for i in range(8)}
+        d["__resume_at_stale"] = -1
+
+        out = {}
+        for idx, (_, k, v) in enumerate(utils.enumerate_items_with_dict_position(d)):
+            if idx == 1:
+                del d["__resume_at_stale"]
+            out[k] = v
+
+        self.assertEqual(out["k0"], 0)
+        self.assertEqual(len(out), 9)
+
 
 class TestModel(torch.nn.Module):
     def __init__(self):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3118,7 +3118,13 @@ def get_items_from_dict(obj: dict[K, V]) -> Iterable[tuple[K, V | Any]]:
     if not isinstance(obj, dict):
         raise AssertionError(f"Expected obj to be a dict, got {type(obj)}")
     if istype(obj, (dict, OrderedDict)):
-        return obj.items()
+        # Snapshot into a list rather than returning the live items view. Callers
+        # consume this lazily while building VariableTrackers, and when obj is a
+        # frame-globals dict Dynamo may add or drop its own generated globals
+        # (e.g. __compiled_fn / __resume_at, removed by a CleanupHook firing at
+        # GC time) on that same dict mid-iteration, which a live view would turn
+        # into "dictionary changed size during iteration".
+        return list(obj.items())
     elif isinstance(obj, OrderedDict):
         return [(k, OrderedDict.__getitem__(obj, k)) for k in OrderedDict.keys(obj)]
     else:


### PR DESCRIPTION
Fixes #190612

`test_trace_return_dataclass` is flaky under `PYTORCH_TEST_WITH_DYNAMO=1`: it defines a `@dataclass` inline, which on Python 3.14 makes `dataclasses._process_class` pass the defining module's `globals()` dict into `_FuncBuilder`. Dynamo realizes that dict argument in `VariableBuilder._wrap`, draining it lazily via a generator inside `dict(...)`. `get_items_from_dict`'s exact-dict branch returned the live `.items()` view instead of a list (unlike its other two branches, which already materialize lists). That globals dict is the same one Dynamo writes its own generated `__compiled_fn_*`/`__resume_at_*` names into and removes via `CleanupHook` weakref callbacks fired at GC time. If a callback fires mid-iteration, CPython raises `RuntimeError: dictionary changed size during iteration`, surfacing as `InternalTorchDynamoError`.

The fix makes the exact-dict branch return `list(obj.items())`, consistent with the function's other branches. This narrows the vulnerable window from hundreds of Python bytecode steps (the full `VariableTracker` construction) to a single C-level loop; it is not a theoretically airtight fix against the free-threaded race (a GC pass could in principle still land mid-`list()`-call), but it eliminates the observed flake in practice. A provably atomic fix would need to live in the `CleanupHook`/`CleanupManager` layer instead (deferring or gating the `del`), which is a materially larger change than warranted for what is currently a disabled flaky test; that layer is also touched by the separate, still-open #191128 for a different (name-reuse) bug in the same area, so I left it alone here to keep this change minimal and low-risk.

## Test Plan

Regression test added at `test/dynamo/test_utils.py::TestUtils::test_enumerate_items_with_dict_position_snapshots`, verified in both directions:

```
cd /tmp && python -m pytest test/dynamo/test_utils.py -k test_enumerate_items_with_dict_position_snapshots -v
# with fix: 1 passed
# git stash; same command: 1 failed with RuntimeError: dictionary changed
#   size during iteration (the exact CI error); git stash pop restores fix
```

Original failing test, both a CPython 3.12 and a free-threaded 3.14t build:

```
cd /tmp && PYTORCH_TEST_WITH_DYNAMO=1 python test/test_fx.py TestFX.test_trace_return_dataclass TestFX.test_trace_return_dataclass_nested
# OK (2 tests) on both builds
```

Full `test/dynamo/test_utils.py` on 3.14t, compared against baseline:

```
cd /tmp && python -m pytest test/dynamo/test_utils.py
# baseline (fix stashed): 10 failed, 16 passed, 1 skipped
# with fix:               10 failed, 17 passed, 1 skipped
# same 10 pre-existing failures (TestDynamoTimed/inductor, need a C++
#   compiler unavailable in this environment), plus the one new passing test.
```

`lintrunner -a`: no findings on the two changed files.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98