### PR TITLE
[elastic] Assign rendezvous ranks in natural node-address order

### DIFF
--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -37,6 +37,7 @@ from torch.distributed.elastic.rendezvous.dynamic_rendezvous import (
     _DistributedRendezvousOpExecutor,
     _NodeDesc,
     _NodeDescGenerator,
+    _natural_sort_key,
     _RendezvousCloseOp,
     _RendezvousContext,
     _RendezvousExitOp,
@@ -117,6 +118,55 @@ class NodeDescTest(TestCase):
 
         self.assertIn(desc1, descs)
         self.assertIn(desc2, descs)
+
+
+class NodeDescNaturalSortKeyTest(TestCase):
+    def test_ranks_follow_numeric_host_order(self) -> None:
+        addrs = ["node66", "node7", "node70", "node8"]
+        nodes = [_NodeDesc(addr, 1, 1) for addr in addrs]
+
+        ordered = sorted(nodes, key=_natural_sort_key)
+
+        self.assertEqual(
+            [node.addr for node in ordered], ["node7", "node8", "node66", "node70"]
+        )
+
+    def test_zero_padded_hostnames_keep_lexicographic_order(self) -> None:
+        addrs = ["node070", "node007", "node066", "node008"]
+        nodes = [_NodeDesc(addr, 1, 1) for addr in addrs]
+
+        self.assertEqual(sorted(nodes, key=_natural_sort_key), sorted(nodes))
+
+    def test_heterogeneous_addresses_do_not_raise(self) -> None:
+        addrs = ["10.0.0.7", "10.0.0.66", "gpu-a", "gpu-10", "gpu-2", "ip-10-0-1-5"]
+        nodes = [_NodeDesc(addr, 1, 1) for addr in addrs]
+
+        ordered = [node.addr for node in sorted(nodes, key=_natural_sort_key)]
+
+        self.assertEqual(
+            ordered,
+            ["10.0.0.7", "10.0.0.66", "gpu-2", "gpu-10", "gpu-a", "ip-10-0-1-5"],
+        )
+
+    def test_processes_on_same_host_stay_grouped_and_ordered(self) -> None:
+        nodes = [
+            _NodeDesc("node9", 7, 1),
+            _NodeDesc("node10", 3, 1),
+            _NodeDesc("node9", 3, 2),
+            _NodeDesc("node9", 3, 1),
+        ]
+
+        ordered = sorted(nodes, key=_natural_sort_key)
+
+        self.assertEqual(
+            ordered,
+            [
+                _NodeDesc("node9", 3, 1),
+                _NodeDesc("node9", 3, 2),
+                _NodeDesc("node9", 7, 1),
+                _NodeDesc("node10", 3, 1),
+            ],
+        )
 
 
 class NodeDescGeneratorTest(TestCase):

--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -148,6 +148,15 @@ class NodeDescNaturalSortKeyTest(TestCase):
             ["10.0.0.7", "10.0.0.66", "gpu-2", "gpu-10", "gpu-a", "ip-10-0-1-5"],
         )
 
+    def test_non_decimal_digit_characters_do_not_raise(self) -> None:
+        # str.isdigit() is True for characters such as superscripts that int()
+        # rejects, hence the key checks str.isdecimal().
+        nodes = [_NodeDesc("node1²2", 1, 1), _NodeDesc("node3", 1, 1)]
+
+        ordered = [node.addr for node in sorted(nodes, key=_natural_sort_key)]
+
+        self.assertEqual(ordered, ["node1²2", "node3"])
+
     def test_processes_on_same_host_stay_grouped_and_ordered(self) -> None:
         nodes = [
             _NodeDesc("node9", 7, 1),
@@ -789,6 +798,36 @@ class DistributedRendezvousOpExecutorTest(TestCase, CustomAssertMixin):
                     self._assert_action(_Action.ADD_TO_PARTICIPANTS, expected_state)
 
                     self._mock_state_holder.reset_mock()
+
+    def test_run_assigns_ranks_in_natural_host_order(self) -> None:
+        # Hostnames whose lexicographic order differs from their numeric order.
+        # With a plain sort the ranks would be node10=0, node2=1, node9=2, i.e.
+        # they would not follow the node numbering (see gh-191190).
+        self._node = _NodeDesc("node2", 1, 1)
+
+        self._state = _RendezvousState()
+
+        for addr in ["node10", "node9"]:
+            node = _NodeDesc(addr, 1, 1)
+
+            self._state.participants[node] = 0
+            self._state.last_heartbeats[node] = self._now
+
+        self._state.wait_list.add(self._node)
+
+        self._state.deadline = self._now + self._timeout.last_call
+
+        self._min_nodes = 3
+        self._max_nodes = 3
+
+        self._run_action(_Action.ADD_TO_PARTICIPANTS)
+
+        self.assertTrue(self._state.complete)
+
+        self.assertEqual(
+            {node.addr: rank for node, rank in self._state.participants.items()},
+            {"node2": 0, "node9": 1, "node10": 2},
+        )
 
     def test_run_adds_to_waitlist(self) -> None:
         expected_state = _RendezvousState()

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -9,6 +9,7 @@ import inspect
 import logging
 import os
 import pickle
+import re
 import socket
 import threading
 import time
@@ -240,6 +241,24 @@ class _NodeDesc:
 
     def __repr__(self) -> str:
         return f"{self.addr}_{self.pid}_{self.local_id}"
+
+
+def _natural_sort_key(node: _NodeDesc) -> tuple:
+    """Return a key that sorts nodes by the natural order of their address.
+
+    Digit runs in the address compare numerically, so that ``node9`` sorts
+    before ``node66`` and rank assignment follows the numeric node order that
+    operators expect. For fleets whose hostnames use equal-width (zero-padded)
+    numbering the resulting order is identical to plain lexicographic order.
+    Ties on the address fall back to the previous ``(addr, pid, local_id)``
+    ordering, so processes on the same host stay grouped exactly as before.
+    """
+    chunks = tuple(
+        (0, int(chunk), "") if chunk.isdigit() else (1, 0, chunk)
+        for chunk in re.split(r"(\d+)", node.addr)
+        if chunk
+    )
+    return (chunks, node.addr, node.pid, node.local_id)
 
 
 class _NodeDescGenerator:
@@ -829,8 +848,10 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
         state.complete = True
         state.deadline = None
 
-        # Assign the ranks.
-        for rank, node in enumerate(sorted(state.participants)):
+        # Assign the ranks in natural order of the node addresses, so that
+        # ranks follow the numeric node order on clusters whose hostnames or
+        # addresses embed unpadded numbers (see gh-191190).
+        for rank, node in enumerate(sorted(state.participants, key=_natural_sort_key)):
             state.participants[node] = rank
 
     def _mark_rendezvous_closed(self) -> None:

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -254,7 +254,7 @@ def _natural_sort_key(node: _NodeDesc) -> tuple:
     ordering, so processes on the same host stay grouped exactly as before.
     """
     chunks = tuple(
-        (0, int(chunk), "") if chunk.isdigit() else (1, 0, chunk)
+        (0, int(chunk), "") if chunk.isdecimal() else (1, 0, chunk)
         for chunk in re.split(r"(\d+)", node.addr)
         if chunk
     )


### PR DESCRIPTION
Fixes #191190.

Implements the change suggested by @d4l3k in #191190: assign global ranks by **natural** order of the node address instead of plain lexicographic order.

### Why

Ranks are assigned by sorting `_NodeDesc`, whose first ordering field is the FQDN string. On clusters whose hostnames or addresses embed unpadded numbers, string order diverges from numeric order:

```
input   : node7  node66  node8  node70
today   : node66 node7   node70 node8
this PR : node7  node8   node66 node70
```

Ring-based collectives derive neighbor relations from global rank order, so the permutation silently de-localizes them — adjacent ranks land on physically distant nodes (measured +8.4–9.3% step time on a 16-node MoE RL job from an equivalent permutation; details in the issue).

### What

`_natural_sort_key(node)`: digit runs in `addr` compare numerically, everything else keeps string comparison. The key is type-safe — digit and non-digit chunks are tagged so they never compare against each other. Ties on the address fall back to the previous `(addr, pid, local_id)` ordering, so multiple processes on the same host stay grouped and ordered exactly as before.

### No regression for zero-padded fleets

With equal-width numbering (`node007…node070`), natural order is identical to the current lexicographic order (covered by a test) — matching the observation in the issue that the current behavior is only optimal with zero-padded names.

Static rendezvous and explicit `--node_rank` are unaffected (they bypass this sorting).

### Tests

`NodeDescNaturalSortKeyTest` in `test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py`:
- numeric host order (`node7 < node8 < node66 < node70`)
- zero-padded fleet ⇒ byte-identical to lexicographic order
- heterogeneous addresses (dotted IPs, `gpu-2/gpu-10/gpu-a`, `ip-10-0-1-5`) sort without `TypeError`
- same-host processes stay grouped, tie-broken by `(pid, local_id)`

cc @d4l3k @wconstab
