### PR TITLE
[Testcase Refactoring]Decouple test_sharding_spec.py from CUDA/NCCL with capability registration and hw_classification

### DIFF
--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -24,12 +24,18 @@ from torch.distributed._shard.sharding_spec._internals import (
     get_split_size,
     validate_non_overlapping_shards_metadata,
 )
-from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
-    skip_if_lt_x_gpu,
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    onlyAccelerator,
+    requires_capabilities,
 )
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    TEST_MULTIACCELERATOR,
     run_tests,
+    skip_but_pass_in_sandcastle_if,
     TestCase,
 )
 from torch.testing._internal.distributed._shard.sharded_tensor import (
@@ -42,236 +48,7 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common i
 
 
 class TestShardingSpec(TestCase):
-    @skip_if_lt_x_gpu(2)
-    
-    def test_device_placement(self):
-        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
-    
-        # valid devices
-        DevicePlacementSpec(f"{device_type}:0")
-        DevicePlacementSpec(torch.device(0))
-        DevicePlacementSpec(torch.device(f"{device_type}:0"))
-        DevicePlacementSpec(f"rank:0/{device_type}:0")
-        DevicePlacementSpec("rank:0/cpu")
-        DevicePlacementSpec("rank:0")
-
-        # invalid devices
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            DevicePlacementSpec("cuda:foo")
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            DevicePlacementSpec("foo:0")
-        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
-            DevicePlacementSpec("rank:0/cuda:foo")
-        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
-            DevicePlacementSpec("rank:0/cpu2")
-
-    @skip_if_lt_x_gpu(2)
-
-    def test_chunked_sharding_spec(self):
-        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
-    
-        # Test valid specs
-        ChunkShardingSpec(0, [torch.device(0), torch.device(1)])
-        ChunkShardingSpec(0, [torch.device(f"{device_type}:0"), torch.device(f"{device_type}:1")])
-        ChunkShardingSpec(-1, [f"{device_type}:0", f"{device_type}:1"])
-        ChunkShardingSpec(0, [f"rank:0/{device_type}:0", f"rank:0/{device_type}:1"])
-        ChunkShardingSpec(0, ["rank:0", "rank:1"])
-        ChunkShardingSpec(0, ["rank:0/cpu", "rank:1/cpu"])
-
-        # Test unimplemented error
-        with self.assertRaisesRegex(NotImplementedError, "not support named dimension"):
-            # Named dimension.
-            ChunkShardingSpec("N", ["cuda:0", "cuda:1"])
-
-        # Test invalid specs
-        with self.assertRaisesRegex(ValueError, "needs to be an integer"):
-            ChunkShardingSpec(None, ["cuda:0", "cuda:1"])
-        with self.assertRaisesRegex(ValueError, "needs to be an integer"):
-            ChunkShardingSpec({}, ["cuda:0", "cuda:1"])
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["random:0", "cuda:1"])
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["cuda:foo", "cuda:1"])
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["rank:foo", "cuda:1"])
-        with self.assertRaisesRegex(RuntimeError, "Expected one of"):
-            ChunkShardingSpec(0, ["rank:0/foo", "cuda:1"])
-        with self.assertRaisesRegex(RuntimeError, "Expected one of"):
-            ChunkShardingSpec(0, ["rank:0/random:0", "cuda:1"])
-        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
-            ChunkShardingSpec(0, ["rank:0/cuda:foo", "cuda:1"])
-
-    @skip_if_lt_x_gpu(2)
-    def test_enumerable_sharding_spec(self):
-        # test valid specs
-
-        # test row-wise sharding
-        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement=f"{device_type}:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement=f"{device_type}:1",
-                ),
-            ]
-        )
-
-        
-        check_tensor(spec.shards, torch.rand(10, 5).size())
-
-        # test row and column sharding
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[3, 3],
-                    placement=f"{device_type}:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 3],
-                    shard_sizes=[3, 3],
-                    placement=f"{device_type}:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[3, 0],
-                    shard_sizes=[3, 3],
-                    placement=f"{device_type}:2",
-                ),
-                ShardMetadata(
-                    shard_offsets=[3, 3],
-                    shard_sizes=[3, 3],
-                    placement=f"{device_type}:3",
-                ),
-            ]
-        )
-        check_tensor(spec.shards, torch.Size([6, 6]))
-
-        # test uneven shard sizes.
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[2, 4],
-                    placement=f"{device_type}:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 4],
-                    shard_sizes=[4, 2],
-                    placement=f"{device_type}:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[2, 0],
-                    shard_sizes=[4, 4],
-                    placement=f"{device_type}:2",
-                ),
-                ShardMetadata(
-                    shard_offsets=[4, 4],
-                    shard_sizes=[2, 2],
-                    placement=f"{device_type}:3",
-                ),
-            ]
-        )
-        check_tensor(spec.shards, torch.Size([6, 6]))
-
-        # test invalid sharding
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ShardMetadata(shard_offsets=[0], shard_sizes=[1], placement="cuda:foo")
-
-        with self.assertRaisesRegex(ValueError, "same number of elements"):
-            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[1], placement="cuda:0")
-
-        with self.assertRaisesRegex(ValueError, "shard_offsets should be >=0"):
-            ShardMetadata(shard_offsets=[-1, 0], shard_sizes=[1, 1], placement="cuda:0")
-
-        with self.assertRaisesRegex(ValueError, "shard_sizes should be >= 0"):
-            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[-1, 1], placement="cuda:0")
-
-        with self.assertRaisesRegex(ValueError, "Empty shard list provided"):
-            EnumerableShardingSpec([])
-
-        with self.assertRaisesRegex(ValueError, "Found inconsistent ranks for shards"):
-            EnumerableShardingSpec(
-                [
-                    ShardMetadata(
-                        shard_offsets=[0, 0], shard_sizes=[1, 1], placement="cpu"
-                    ),
-                    ShardMetadata(
-                        shard_offsets=[0, 0, 0], shard_sizes=[1, 1, 1], placement="cpu"
-                    ),
-                ]
-            )
-
-        with self.assertRaisesRegex(ValueError, "Shards.*overlap"):
-            EnumerableShardingSpec(
-                [
-                    ShardMetadata(
-                        shard_offsets=[0, 0], shard_sizes=[3, 3], placement="cpu"
-                    ),
-                    ShardMetadata(
-                        shard_offsets=[2, 0], shard_sizes=[3, 3], placement="cpu"
-                    ),
-                ]
-            )
-
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement=f"{device_type}:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement=f"{device_type}:1",
-                ),
-            ]
-        )
-
-        with self.assertRaisesRegex(ValueError, "Rank of tensor is.*but shards rank"):
-            check_tensor(spec.shards, torch.Size([10, 10, 10]))
-
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement=f"{device_type}:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement=f"{device_type}:1",
-                ),
-            ]
-        )
-
-        with self.assertRaisesRegex(ValueError, "exceeds tensor dim"):
-            check_tensor(spec.shards, torch.Size([10, 3]))
-
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement=f"{device_type}:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 5],
-                    shard_sizes=[5, 5],
-                    placement=f"{device_type}:1",
-                ),
-            ]
-        )
-
-        with self.assertRaisesRegex(ValueError, "does not match tensor volume"):
-            check_tensor(spec.shards, torch.Size([10, 10]))
+    hw_classification = HardwareClassification.GENERIC
 
     def test_get_split_size(self):
         self.assertEqual(3, get_split_size(11, 4))
@@ -290,7 +67,11 @@ class TestShardingSpec(TestCase):
         self.assertEqual(0, get_chunked_dim_size(5, 2, 3))
 
     def test_get_chunk_sharding_params(self):
-        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
+        device_type = (
+            torch.accelerator.current_accelerator().type
+            if torch.accelerator.is_available()
+            else "cpu"
+        )
         ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
         spec = ChunkShardingSpec(
             dim=0,
@@ -313,7 +94,11 @@ class TestShardingSpec(TestCase):
         self.assertEqual(6, result[1])
 
     def _infer_enum_sharding_spec_case(self):
-        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
+        device_type = (
+            torch.accelerator.current_accelerator().type
+            if torch.accelerator.is_available()
+            else "cpu"
+        )
         shards_metadata = [
             ShardMetadata(
                 shard_offsets=[0, 0],
@@ -408,7 +193,11 @@ class TestShardingSpec(TestCase):
             )
 
     def test_check_overlapping(self):
-        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
+        device_type = (
+            torch.accelerator.current_accelerator().type
+            if torch.accelerator.is_available()
+            else "cpu"
+        )
         shards = [
             ShardMetadata(
                 shard_offsets=[0, 0],
@@ -506,7 +295,7 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 5],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:1",
+                placement=f"{device_type}:2",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
@@ -559,6 +348,271 @@ class TestShardingSpec(TestCase):
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
             validate_non_overlapping_shards_metadata(shards)
+
+
+class TestShardingSpecDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "2 accelerators are needed"
+    )
+    def test_device_placement(self, device):
+        device_type = torch.device(device).type
+
+        # valid devices
+        DevicePlacementSpec(f"{device_type}:0")
+        DevicePlacementSpec(torch.device(0))
+        DevicePlacementSpec(torch.device(f"{device_type}:0"))
+        DevicePlacementSpec(f"rank:0/{device_type}:0")
+        DevicePlacementSpec("rank:0/cpu")
+        DevicePlacementSpec("rank:0")
+
+        # invalid devices
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            DevicePlacementSpec("cuda:foo")
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            DevicePlacementSpec("foo:0")
+        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
+            DevicePlacementSpec("rank:0/cuda:foo")
+        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
+            DevicePlacementSpec("rank:0/cpu2")
+
+    @onlyAccelerator
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "2 accelerators are needed"
+    )
+    def test_chunked_sharding_spec(self, device):
+        device_type = torch.device(device).type
+
+        # Test valid specs
+        ChunkShardingSpec(0, [torch.device(0), torch.device(1)])
+        ChunkShardingSpec(
+            0,
+            [
+                torch.device(f"{device_type}:0"),
+                torch.device(f"{device_type}:1"),
+            ],
+        )
+        ChunkShardingSpec(-1, [f"{device_type}:0", f"{device_type}:1"])
+        ChunkShardingSpec(
+            0, [f"rank:0/{device_type}:0", f"rank:0/{device_type}:1"]
+        )
+        ChunkShardingSpec(0, ["rank:0", "rank:1"])
+        ChunkShardingSpec(0, ["rank:0/cpu", "rank:1/cpu"])
+
+        # Test unimplemented error
+        with self.assertRaisesRegex(
+            NotImplementedError, "not support named dimension"
+        ):
+            # Named dimension.
+            ChunkShardingSpec("N", ["cuda:0", "cuda:1"])
+
+        # Test invalid specs
+        with self.assertRaisesRegex(ValueError, "needs to be an integer"):
+            ChunkShardingSpec(None, ["cuda:0", "cuda:1"])
+        with self.assertRaisesRegex(ValueError, "needs to be an integer"):
+            ChunkShardingSpec({}, ["cuda:0", "cuda:1"])
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            ChunkShardingSpec(0, ["random:0", "cuda:1"])
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            ChunkShardingSpec(0, ["cuda:foo", "cuda:1"])
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            ChunkShardingSpec(0, ["rank:foo", "cuda:1"])
+        with self.assertRaisesRegex(RuntimeError, "Expected one of"):
+            ChunkShardingSpec(0, ["rank:0/foo", "cuda:1"])
+        with self.assertRaisesRegex(RuntimeError, "Expected one of"):
+            ChunkShardingSpec(0, ["rank:0/random:0", "cuda:1"])
+        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
+            ChunkShardingSpec(0, ["rank:0/cuda:foo", "cuda:1"])
+
+    @onlyAccelerator
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "2 accelerators are needed"
+    )
+    def test_enumerable_sharding_spec(self, device):
+        device_type = torch.device(device).type
+
+        # test valid specs
+
+        # test row-wise sharding
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:1",
+                ),
+            ]
+        )
+
+        check_tensor(spec.shards, torch.Size([10, 5]))
+
+        # test row and column sharding
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[3, 3],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 3],
+                    shard_sizes=[3, 3],
+                    placement=f"{device_type}:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[3, 0],
+                    shard_sizes=[3, 3],
+                    placement=f"{device_type}:2",
+                ),
+                ShardMetadata(
+                    shard_offsets=[3, 3],
+                    shard_sizes=[3, 3],
+                    placement=f"{device_type}:3",
+                ),
+            ]
+        )
+        check_tensor(spec.shards, torch.Size([6, 6]))
+
+        # test uneven shard sizes.
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[2, 4],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 4],
+                    shard_sizes=[4, 2],
+                    placement=f"{device_type}:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[2, 0],
+                    shard_sizes=[4, 4],
+                    placement=f"{device_type}:2",
+                ),
+                ShardMetadata(
+                    shard_offsets=[4, 4],
+                    shard_sizes=[2, 2],
+                    placement=f"{device_type}:3",
+                ),
+            ]
+        )
+        check_tensor(spec.shards, torch.Size([6, 6]))
+
+        # test invalid sharding
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            ShardMetadata(shard_offsets=[0], shard_sizes=[1], placement="cuda:foo")
+
+        with self.assertRaisesRegex(ValueError, "same number of elements"):
+            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[1], placement="cuda:0")
+
+        with self.assertRaisesRegex(ValueError, "shard_offsets should be >=0"):
+            ShardMetadata(
+                shard_offsets=[-1, 0], shard_sizes=[1, 1], placement="cuda:0"
+            )
+
+        with self.assertRaisesRegex(ValueError, "shard_sizes should be >= 0"):
+            ShardMetadata(
+                shard_offsets=[0, 0], shard_sizes=[-1, 1], placement="cuda:0"
+            )
+
+        with self.assertRaisesRegex(ValueError, "Empty shard list provided"):
+            EnumerableShardingSpec([])
+
+        with self.assertRaisesRegex(
+            ValueError, "Found inconsistent ranks for shards"
+        ):
+            EnumerableShardingSpec(
+                [
+                    ShardMetadata(
+                        shard_offsets=[0, 0], shard_sizes=[1, 1], placement="cpu"
+                    ),
+                    ShardMetadata(
+                        shard_offsets=[0, 0, 0],
+                        shard_sizes=[1, 1, 1],
+                        placement="cpu",
+                    ),
+                ]
+            )
+
+        with self.assertRaisesRegex(ValueError, "Shards.*overlap"):
+            EnumerableShardingSpec(
+                [
+                    ShardMetadata(
+                        shard_offsets=[0, 0], shard_sizes=[3, 3], placement="cpu"
+                    ),
+                    ShardMetadata(
+                        shard_offsets=[2, 0], shard_sizes=[3, 3], placement="cpu"
+                    ),
+                ]
+            )
+
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:1",
+                ),
+            ]
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "Rank of tensor is.*but shards rank"
+        ):
+            check_tensor(spec.shards, torch.Size([10, 10, 10]))
+
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:1",
+                ),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "exceeds tensor dim"):
+            check_tensor(spec.shards, torch.Size([10, 3]))
+
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 5],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:1",
+                ),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "does not match tensor volume"):
+            check_tensor(spec.shards, torch.Size([10, 10]))
+
+
+instantiate_device_type_tests(TestShardingSpecDevice, globals())
 
 
 # Custom ShardingSpec, an simple example to do grid sharding
@@ -620,8 +674,14 @@ class GridShardingSpec(ShardingSpec):
 
 
 class TestCustomShardingSpec(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_custom_sharding_spec(self):
-        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
+        device_type = (
+            torch.accelerator.current_accelerator().type
+            if torch.accelerator.is_available()
+            else "cpu"
+        )
         ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
 
         grid_spec = GridShardingSpec(grid_size=4, placements=ranks)
@@ -637,15 +697,18 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         meta = grid_spec.build_metadata(torch.Size((8, 8)), tensor_properties)
         check_tensor(meta.shards_metadata, torch.Size((8, 8)))
 
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "Multi-accelerator required"
+    )
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
+    @requires_capabilities(Capability.distributed.backend)
     def test_custom_sharding_spec_tensor_ctor(self):
         """Test sharded_tensor.ones(...) with the custom
         grid sharding spec.
         """
 
-        device_type = self.device_type 
+        device_type = self.device_type
         ranks = [
             f"rank:0/{device_type}:0",
             f"rank:1/{device_type}:1",
@@ -661,13 +724,18 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         local_shards = st.local_shards()
         self.assertEqual(1, len(local_shards))
         local_shard = local_shards[0].tensor
-        self.assertEqual(torch.device(f"{device_type}:{self.rank}"), local_shard.device)
+        self.assertEqual(
+            torch.device(f"{device_type}:{self.rank}"), local_shard.device
+        )
         self.assertEqual((2, 2), local_shard.size())
         self.assertEqual(local_shard, torch.ones(2, 2))
 
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "Multi-accelerator required"
+    )
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
+    @requires_capabilities(Capability.distributed.backend)
     def test_custom_sharding_spec_shard_tensor(self):
         """Test custom spec can be invoked from the
         _shard_tensor callsite.

--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -24,11 +24,12 @@ from torch.distributed._shard.sharding_spec._internals import (
     get_split_size,
     validate_non_overlapping_shards_metadata,
 )
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
-from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import (
+    requires_accelerator_dist_backend,
+    skip_if_lt_x_gpu,
+)
 from torch.testing._internal.common_utils import (
     run_tests,
-    skip_but_pass_in_sandcastle_if,
     TestCase,
 )
 from torch.testing._internal.distributed._shard.sharded_tensor import (
@@ -41,13 +42,16 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common i
 
 
 class TestShardingSpec(TestCase):
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")
+    @skip_if_lt_x_gpu(2)
+    
     def test_device_placement(self):
+        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
+    
         # valid devices
-        DevicePlacementSpec("cuda:0")
+        DevicePlacementSpec(f"{device_type}:0")
         DevicePlacementSpec(torch.device(0))
-        DevicePlacementSpec(torch.device("cuda:0"))
-        DevicePlacementSpec("rank:0/cuda:0")
+        DevicePlacementSpec(torch.device(f"{device_type}:0"))
+        DevicePlacementSpec(f"rank:0/{device_type}:0")
         DevicePlacementSpec("rank:0/cpu")
         DevicePlacementSpec("rank:0")
 
@@ -61,13 +65,16 @@ class TestShardingSpec(TestCase):
         with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
             DevicePlacementSpec("rank:0/cpu2")
 
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")
+    @skip_if_lt_x_gpu(2)
+
     def test_chunked_sharding_spec(self):
-        # Test valid specs.
+        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
+    
+        # Test valid specs
         ChunkShardingSpec(0, [torch.device(0), torch.device(1)])
-        ChunkShardingSpec(0, [torch.device("cuda:0"), torch.device("cuda:1")])
-        ChunkShardingSpec(-1, ["cuda:0", "cuda:1"])
-        ChunkShardingSpec(0, ["rank:0/cuda:0", "rank:0/cuda:1"])
+        ChunkShardingSpec(0, [torch.device(f"{device_type}:0"), torch.device(f"{device_type}:1")])
+        ChunkShardingSpec(-1, [f"{device_type}:0", f"{device_type}:1"])
+        ChunkShardingSpec(0, [f"rank:0/{device_type}:0", f"rank:0/{device_type}:1"])
         ChunkShardingSpec(0, ["rank:0", "rank:1"])
         ChunkShardingSpec(0, ["rank:0/cpu", "rank:1/cpu"])
 
@@ -94,26 +101,29 @@ class TestShardingSpec(TestCase):
         with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
             ChunkShardingSpec(0, ["rank:0/cuda:foo", "cuda:1"])
 
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")
+    @skip_if_lt_x_gpu(2)
     def test_enumerable_sharding_spec(self):
         # test valid specs
 
         # test row-wise sharding
+        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
         spec = EnumerableShardingSpec(
             [
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:0",
+                    placement=f"{device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:1",
+                    placement=f"{device_type}:1",
                 ),
             ]
         )
-        check_tensor(spec.shards, torch.Size([10, 5]))
+
+        
+        check_tensor(spec.shards, torch.rand(10, 5).size())
 
         # test row and column sharding
         spec = EnumerableShardingSpec(
@@ -121,22 +131,22 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[3, 3],
-                    placement="cuda:0",
+                    placement=f"{device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[0, 3],
                     shard_sizes=[3, 3],
-                    placement="cuda:1",
+                    placement=f"{device_type}:1",
                 ),
                 ShardMetadata(
                     shard_offsets=[3, 0],
                     shard_sizes=[3, 3],
-                    placement="cuda:2",
+                    placement=f"{device_type}:2",
                 ),
                 ShardMetadata(
                     shard_offsets=[3, 3],
                     shard_sizes=[3, 3],
-                    placement="cuda:3",
+                    placement=f"{device_type}:3",
                 ),
             ]
         )
@@ -148,22 +158,22 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[2, 4],
-                    placement="cuda:0",
+                    placement=f"{device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[0, 4],
                     shard_sizes=[4, 2],
-                    placement="cuda:1",
+                    placement=f"{device_type}:1",
                 ),
                 ShardMetadata(
                     shard_offsets=[2, 0],
                     shard_sizes=[4, 4],
-                    placement="cuda:2",
+                    placement=f"{device_type}:2",
                 ),
                 ShardMetadata(
                     shard_offsets=[4, 4],
                     shard_sizes=[2, 2],
-                    placement="cuda:3",
+                    placement=f"{device_type}:3",
                 ),
             ]
         )
@@ -214,12 +224,12 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:0",
+                    placement=f"{device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:1",
+                    placement=f"{device_type}:1",
                 ),
             ]
         )
@@ -232,12 +242,12 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:0",
+                    placement=f"{device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:1",
+                    placement=f"{device_type}:1",
                 ),
             ]
         )
@@ -250,12 +260,12 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:0",
+                    placement=f"{device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 5],
                     shard_sizes=[5, 5],
-                    placement="cuda:1",
+                    placement=f"{device_type}:1",
                 ),
             ]
         )
@@ -280,12 +290,8 @@ class TestShardingSpec(TestCase):
         self.assertEqual(0, get_chunked_dim_size(5, 2, 3))
 
     def test_get_chunk_sharding_params(self):
-        ranks = [
-            "rank:0/cuda:0",
-            "rank:1/cuda:1",
-            "rank:2/cuda:2",
-            "rank:3/cuda:3",
-        ]
+        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
+        ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
         spec = ChunkShardingSpec(
             dim=0,
             placements=ranks,
@@ -307,16 +313,17 @@ class TestShardingSpec(TestCase):
         self.assertEqual(6, result[1])
 
     def _infer_enum_sharding_spec_case(self):
+        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
         shards_metadata = [
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement=f"{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[10, 5],
-                placement="cuda:1",
+                placement=f"{device_type}:1",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -327,12 +334,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0],
                 shard_sizes=[16],
-                placement="cuda:0",
+                placement=f"{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[16],
                 shard_sizes=[9],
-                placement="cuda:1",
+                placement=f"{device_type}:1",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -343,22 +350,22 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
+                placement=f"rank:0/{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
+                placement=f"rank:1/{device_type}:1",
             ),
             ShardMetadata(
                 shard_offsets=[0, 5],
                 shard_sizes=[5, 5],
-                placement="rank:2/cuda:2",
+                placement=f"rank:2/{device_type}:2",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement="rank:3/cuda:3",
+                placement=f"rank:3/{device_type}:3",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -401,16 +408,17 @@ class TestShardingSpec(TestCase):
             )
 
     def test_check_overlapping(self):
+        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
         shards = [
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement=f"{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement=f"{device_type}:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -419,12 +427,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement=f"{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[4, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement=f"{device_type}:0",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -434,12 +442,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement=f"{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[0, 4],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement=f"{device_type}:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -449,12 +457,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:0",
+                placement=f"{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:1",
+                placement=f"{device_type}:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -463,12 +471,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:0",
+                placement=f"{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 4, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:1",
+                placement=f"{device_type}:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -478,12 +486,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:0",
+                placement=f"{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 4, 9],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:1",
+                placement=f"{device_type}:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -493,22 +501,22 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement=f"{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[0, 5],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement=f"{device_type}:1",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:2",
+                placement=f"{device_type}:2",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement="cuda:3",
+                placement=f"{device_type}:3",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -517,12 +525,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement=f"{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement=f"{device_type}:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -531,22 +539,22 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0, 0],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:0",
+                placement=f"{device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0, 0],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:1",
+                placement=f"{device_type}:1",
             ),
             ShardMetadata(
                 shard_offsets=[10, 0, 0],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:2",
+                placement=f"{device_type}:2",
             ),
             ShardMetadata(
                 shard_offsets=[10, 3, 0],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:3",
+                placement=f"{device_type}:3",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -613,12 +621,8 @@ class GridShardingSpec(ShardingSpec):
 
 class TestCustomShardingSpec(ShardedTensorTestBase):
     def test_custom_sharding_spec(self):
-        ranks = [
-            "rank:0/cuda:0",
-            "rank:1/cuda:1",
-            "rank:2/cuda:2",
-            "rank:3/cuda:3",
-        ]
+        device_type = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
+        ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
 
         grid_spec = GridShardingSpec(grid_size=4, placements=ranks)
 
@@ -635,17 +639,18 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_custom_sharding_spec_tensor_ctor(self):
         """Test sharded_tensor.ones(...) with the custom
         grid sharding spec.
         """
 
+        device_type = self.device_type 
         ranks = [
-            "rank:0/cuda:0",
-            "rank:1/cuda:1",
-            "rank:2/cuda:2",
-            "rank:3/cuda:3",
+            f"rank:0/{device_type}:0",
+            f"rank:1/{device_type}:1",
+            f"rank:2/{device_type}:2",
+            f"rank:3/{device_type}:3",
         ]
 
         grid_spec = GridShardingSpec(grid_size=2, placements=ranks)
@@ -656,24 +661,19 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         local_shards = st.local_shards()
         self.assertEqual(1, len(local_shards))
         local_shard = local_shards[0].tensor
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.device)
+        self.assertEqual(torch.device(f"{device_type}:{self.rank}"), local_shard.device)
         self.assertEqual((2, 2), local_shard.size())
         self.assertEqual(local_shard, torch.ones(2, 2))
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_custom_sharding_spec_shard_tensor(self):
         """Test custom spec can be invoked from the
         _shard_tensor callsite.
         """
-
-        ranks = [
-            "rank:0/cuda:0",
-            "rank:1/cuda:1",
-            "rank:2/cuda:2",
-            "rank:3/cuda:3",
-        ]
+        device_type = self.device_type
+        ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
 
         grid_spec = GridShardingSpec(grid_size=2, placements=ranks)
 

--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -205,7 +205,7 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[4, 0],
                 shard_sizes=[5, 5],
-                placement="cpu:0",
+                placement="cpu:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -279,12 +279,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 5],
                 shard_sizes=[5, 5],
-                placement="cpu:2",
+                placement="cpu:1",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement="cpu:2",
+                placement="cpu:1",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],

--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -3,7 +3,6 @@ import copy
 from dataclasses import dataclass
 
 import torch
-import torch.distributed as dist
 from torch.distributed._shard import _shard_tensor, sharded_tensor
 from torch.distributed._shard.sharded_tensor import (
     ShardedTensor,
@@ -47,11 +46,6 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common i
 )
 
 
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
-
-
 class TestShardingSpec(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
@@ -72,7 +66,7 @@ class TestShardingSpec(TestCase):
         self.assertEqual(0, get_chunked_dim_size(5, 2, 3))
 
     def test_get_chunk_sharding_params(self):
-        ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
+        ranks = [f"rank:{i}/cpu:{i}" for i in range(4)]
         spec = ChunkShardingSpec(
             dim=0,
             placements=ranks,
@@ -98,12 +92,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[10, 5],
-                placement=f"{device_type}:1",
+                placement="cpu:1",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -114,12 +108,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0],
                 shard_sizes=[16],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[16],
                 shard_sizes=[9],
-                placement=f"{device_type}:1",
+                placement="cpu:1",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -130,22 +124,22 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"rank:0/{device_type}:0",
+                placement="rank:0/cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement=f"rank:1/{device_type}:1",
+                placement="rank:1/cpu:1",
             ),
             ShardMetadata(
                 shard_offsets=[0, 5],
                 shard_sizes=[5, 5],
-                placement=f"rank:2/{device_type}:2",
+                placement="rank:2/cpu:2",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement=f"rank:3/{device_type}:3",
+                placement="rank:3/cpu:3",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -192,12 +186,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:1",
+                placement="cpu:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -206,12 +200,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[4, 0],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -221,12 +215,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[0, 4],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:1",
+                placement="cpu:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -236,12 +230,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5, 5],
                 shard_sizes=[5, 5, 5],
-                placement=f"{device_type}:1",
+                placement="cpu:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -250,12 +244,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 4, 5],
                 shard_sizes=[5, 5, 5],
-                placement=f"{device_type}:1",
+                placement="cpu:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -265,12 +259,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 4, 9],
                 shard_sizes=[5, 5, 5],
-                placement=f"{device_type}:1",
+                placement="cpu:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -280,22 +274,22 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[0, 5],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:2",
+                placement="cpu:2",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:2",
+                placement="cpu:2",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:3",
+                placement="cpu:3",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -304,12 +298,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement=f"{device_type}:1",
+                placement="cpu:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -318,29 +312,29 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0, 0],
                 shard_sizes=[5, 5, 5],
-                placement=f"{device_type}:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0, 0],
                 shard_sizes=[5, 5, 5],
-                placement=f"{device_type}:1",
+                placement="cpu:1",
             ),
             ShardMetadata(
                 shard_offsets=[10, 0, 0],
                 shard_sizes=[5, 5, 5],
-                placement=f"{device_type}:2",
+                placement="cpu:2",
             ),
             ShardMetadata(
                 shard_offsets=[10, 3, 0],
                 shard_sizes=[5, 5, 5],
-                placement=f"{device_type}:3",
+                placement="cpu:3",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
             validate_non_overlapping_shards_metadata(shards)
 
     def test_custom_sharding_spec(self):
-        ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
+        ranks = [f"rank:{i}/cpu:{i}" for i in range(4)]
 
         grid_spec = GridShardingSpec(grid_size=4, placements=ranks)
 
@@ -609,9 +603,6 @@ class TestShardingSpecDevice(TestCase):
             check_tensor(spec.shards, torch.Size([10, 10]))
 
 
-instantiate_device_type_tests(TestShardingSpecDevice, globals(), except_for="cpu")
-
-
 # Custom ShardingSpec, an simple example to do grid sharding
 @dataclass
 class GridShardingSpec(ShardingSpec):
@@ -670,16 +661,10 @@ class GridShardingSpec(ShardingSpec):
         raise NotImplementedError("GridShardingSpec.shard not implemented yet!")
 
 
-backend = dist.get_default_backend_for_device(device_type)
-
-
 class TestCustomShardingSpec(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "Multi-accelerator required"
-    )
-    @with_comms(backend=backend)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_custom_sharding_spec_tensor_ctor(self, device):
@@ -707,10 +692,7 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         self.assertEqual((2, 2), local_shard.size())
         self.assertEqual(local_shard, torch.ones(2, 2))
 
-    @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "Multi-accelerator required"
-    )
-    @with_comms(backend=backend)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_custom_sharding_spec_shard_tensor(self, device):
@@ -726,6 +708,7 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
             _shard_tensor(torch.randn(8, 8), grid_spec)
 
 
+instantiate_device_type_tests(TestShardingSpecDevice, globals(), except_for="cpu")
 instantiate_device_type_tests(TestCustomShardingSpec, globals(), except_for="cpu")
 
 

--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -676,12 +676,9 @@ class GridShardingSpec(ShardingSpec):
 class TestCustomShardingSpec(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    def test_custom_sharding_spec(self):
-        device_type = (
-            torch.accelerator.current_accelerator().type
-            if torch.accelerator.is_available()
-            else "cpu"
-        )
+    @onlyAccelerator
+    def test_custom_sharding_spec(self, device):
+        device_type = torch.device(device).type
         ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
 
         grid_spec = GridShardingSpec(grid_size=4, placements=ranks)
@@ -697,18 +694,19 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         meta = grid_spec.build_metadata(torch.Size((8, 8)), tensor_properties)
         check_tensor(meta.shards_metadata, torch.Size((8, 8)))
 
+    @onlyAccelerator
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "Multi-accelerator required"
     )
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
-    def test_custom_sharding_spec_tensor_ctor(self):
+    def test_custom_sharding_spec_tensor_ctor(self, device):
         """Test sharded_tensor.ones(...) with the custom
         grid sharding spec.
         """
 
-        device_type = self.device_type
+        device_type = torch.device(device).type
         ranks = [
             f"rank:0/{device_type}:0",
             f"rank:1/{device_type}:1",
@@ -730,23 +728,27 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         self.assertEqual((2, 2), local_shard.size())
         self.assertEqual(local_shard, torch.ones(2, 2))
 
+    @onlyAccelerator
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "Multi-accelerator required"
     )
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
-    def test_custom_sharding_spec_shard_tensor(self):
+    def test_custom_sharding_spec_shard_tensor(self, device):
         """Test custom spec can be invoked from the
         _shard_tensor callsite.
         """
-        device_type = self.device_type
+        device_type = torch.device(device).type
         ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
 
         grid_spec = GridShardingSpec(grid_size=2, placements=ranks)
 
         with self.assertRaisesRegex(NotImplementedError, "not implemented"):
             _shard_tensor(torch.randn(8, 8), grid_spec)
+
+
+instantiate_device_type_tests(TestCustomShardingSpec, globals())
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -658,11 +658,10 @@ class GridShardingSpec(ShardingSpec):
         raise NotImplementedError("GridShardingSpec.shard not implemented yet!")
 
 
-BACKEND = (
-    dist.get_default_backend_for_device(torch.accelerator.current_accelerator().type)
-    if torch.accelerator.is_available()
-    else "gloo"
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
 )
+backend = dist.get_default_backend_for_device(device_type)
 
 
 class TestCustomShardingSpec(ShardedTensorTestBase):
@@ -688,7 +687,7 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "Multi-accelerator required"
     )
-    @with_comms(backend=BACKEND)
+    @with_comms(backend=backend)
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_custom_sharding_spec_tensor_ctor(self, device):
@@ -719,7 +718,7 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "Multi-accelerator required"
     )
-    @with_comms(backend=BACKEND)
+    @with_comms(backend=backend)
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_custom_sharding_spec_shard_tensor(self, device):

--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -658,6 +658,13 @@ class GridShardingSpec(ShardingSpec):
         raise NotImplementedError("GridShardingSpec.shard not implemented yet!")
 
 
+BACKEND = (
+    dist.get_default_backend_for_device(torch.accelerator.current_accelerator().type)
+    if torch.accelerator.is_available()
+    else "gloo"
+)
+
+
 class TestCustomShardingSpec(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
@@ -681,13 +688,7 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "Multi-accelerator required"
     )
-    @with_comms(
-        backend=dist.get_default_backend_for_device(
-            torch.accelerator.current_accelerator().type
-        )
-        if torch.accelerator.is_available()
-        else "gloo"
-    )
+    @with_comms(backend=BACKEND)
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_custom_sharding_spec_tensor_ctor(self, device):
@@ -718,13 +719,7 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "Multi-accelerator required"
     )
-    @with_comms(
-        backend=dist.get_default_backend_for_device(
-            torch.accelerator.current_accelerator().type
-        )
-        if torch.accelerator.is_available()
-        else "gloo"
-    )
+    @with_comms(backend=BACKEND)
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_custom_sharding_spec_shard_tensor(self, device):

--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -3,6 +3,7 @@ import copy
 from dataclasses import dataclass
 
 import torch
+import torch.distributed as dist
 from torch.distributed._shard import _shard_tensor, sharded_tensor
 from torch.distributed._shard.sharded_tensor import (
     ShardedTensor,
@@ -27,15 +28,14 @@ from torch.distributed._shard.sharding_spec._internals import (
 from torch.testing._internal.common_device_type import (
     Capability,
     instantiate_device_type_tests,
-    onlyAccelerator,
     requires_capabilities,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    TEST_MULTIACCELERATOR,
     run_tests,
     skip_but_pass_in_sandcastle_if,
+    TEST_MULTIACCELERATOR,
     TestCase,
 )
 from torch.testing._internal.distributed._shard.sharded_tensor import (
@@ -353,7 +353,6 @@ class TestShardingSpec(TestCase):
 class TestShardingSpecDevice(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @onlyAccelerator
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "2 accelerators are needed"
     )
@@ -378,7 +377,6 @@ class TestShardingSpecDevice(TestCase):
         with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
             DevicePlacementSpec("rank:0/cpu2")
 
-    @onlyAccelerator
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "2 accelerators are needed"
     )
@@ -395,16 +393,12 @@ class TestShardingSpecDevice(TestCase):
             ],
         )
         ChunkShardingSpec(-1, [f"{device_type}:0", f"{device_type}:1"])
-        ChunkShardingSpec(
-            0, [f"rank:0/{device_type}:0", f"rank:0/{device_type}:1"]
-        )
+        ChunkShardingSpec(0, [f"rank:0/{device_type}:0", f"rank:0/{device_type}:1"])
         ChunkShardingSpec(0, ["rank:0", "rank:1"])
         ChunkShardingSpec(0, ["rank:0/cpu", "rank:1/cpu"])
 
         # Test unimplemented error
-        with self.assertRaisesRegex(
-            NotImplementedError, "not support named dimension"
-        ):
+        with self.assertRaisesRegex(NotImplementedError, "not support named dimension"):
             # Named dimension.
             ChunkShardingSpec("N", ["cuda:0", "cuda:1"])
 
@@ -426,7 +420,6 @@ class TestShardingSpecDevice(TestCase):
         with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
             ChunkShardingSpec(0, ["rank:0/cuda:foo", "cuda:1"])
 
-    @onlyAccelerator
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "2 accelerators are needed"
     )
@@ -515,21 +508,15 @@ class TestShardingSpecDevice(TestCase):
             ShardMetadata(shard_offsets=[0, 0], shard_sizes=[1], placement="cuda:0")
 
         with self.assertRaisesRegex(ValueError, "shard_offsets should be >=0"):
-            ShardMetadata(
-                shard_offsets=[-1, 0], shard_sizes=[1, 1], placement="cuda:0"
-            )
+            ShardMetadata(shard_offsets=[-1, 0], shard_sizes=[1, 1], placement="cuda:0")
 
         with self.assertRaisesRegex(ValueError, "shard_sizes should be >= 0"):
-            ShardMetadata(
-                shard_offsets=[0, 0], shard_sizes=[-1, 1], placement="cuda:0"
-            )
+            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[-1, 1], placement="cuda:0")
 
         with self.assertRaisesRegex(ValueError, "Empty shard list provided"):
             EnumerableShardingSpec([])
 
-        with self.assertRaisesRegex(
-            ValueError, "Found inconsistent ranks for shards"
-        ):
+        with self.assertRaisesRegex(ValueError, "Found inconsistent ranks for shards"):
             EnumerableShardingSpec(
                 [
                     ShardMetadata(
@@ -570,9 +557,7 @@ class TestShardingSpecDevice(TestCase):
             ]
         )
 
-        with self.assertRaisesRegex(
-            ValueError, "Rank of tensor is.*but shards rank"
-        ):
+        with self.assertRaisesRegex(ValueError, "Rank of tensor is.*but shards rank"):
             check_tensor(spec.shards, torch.Size([10, 10, 10]))
 
         spec = EnumerableShardingSpec(
@@ -612,7 +597,7 @@ class TestShardingSpecDevice(TestCase):
             check_tensor(spec.shards, torch.Size([10, 10]))
 
 
-instantiate_device_type_tests(TestShardingSpecDevice, globals())
+instantiate_device_type_tests(TestShardingSpecDevice, globals(), except_for="cpu")
 
 
 # Custom ShardingSpec, an simple example to do grid sharding
@@ -676,7 +661,6 @@ class GridShardingSpec(ShardingSpec):
 class TestCustomShardingSpec(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @onlyAccelerator
     def test_custom_sharding_spec(self, device):
         device_type = torch.device(device).type
         ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
@@ -694,11 +678,16 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         meta = grid_spec.build_metadata(torch.Size((8, 8)), tensor_properties)
         check_tensor(meta.shards_metadata, torch.Size((8, 8)))
 
-    @onlyAccelerator
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "Multi-accelerator required"
     )
-    @with_comms
+    @with_comms(
+        backend=dist.get_default_backend_for_device(
+            torch.accelerator.current_accelerator().type
+        )
+        if torch.accelerator.is_available()
+        else "gloo"
+    )
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_custom_sharding_spec_tensor_ctor(self, device):
@@ -722,17 +711,20 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         local_shards = st.local_shards()
         self.assertEqual(1, len(local_shards))
         local_shard = local_shards[0].tensor
-        self.assertEqual(
-            torch.device(f"{device_type}:{self.rank}"), local_shard.device
-        )
+        self.assertEqual(torch.device(f"{device_type}:{self.rank}"), local_shard.device)
         self.assertEqual((2, 2), local_shard.size())
         self.assertEqual(local_shard, torch.ones(2, 2))
 
-    @onlyAccelerator
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "Multi-accelerator required"
     )
-    @with_comms
+    @with_comms(
+        backend=dist.get_default_backend_for_device(
+            torch.accelerator.current_accelerator().type
+        )
+        if torch.accelerator.is_available()
+        else "gloo"
+    )
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_custom_sharding_spec_shard_tensor(self, device):
@@ -748,7 +740,7 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
             _shard_tensor(torch.randn(8, 8), grid_spec)
 
 
-instantiate_device_type_tests(TestCustomShardingSpec, globals())
+instantiate_device_type_tests(TestCustomShardingSpec, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -47,6 +47,11 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common i
 )
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 class TestShardingSpec(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
@@ -67,11 +72,6 @@ class TestShardingSpec(TestCase):
         self.assertEqual(0, get_chunked_dim_size(5, 2, 3))
 
     def test_get_chunk_sharding_params(self):
-        device_type = (
-            torch.accelerator.current_accelerator().type
-            if torch.accelerator.is_available()
-            else "cpu"
-        )
         ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
         spec = ChunkShardingSpec(
             dim=0,
@@ -94,11 +94,6 @@ class TestShardingSpec(TestCase):
         self.assertEqual(6, result[1])
 
     def _infer_enum_sharding_spec_case(self):
-        device_type = (
-            torch.accelerator.current_accelerator().type
-            if torch.accelerator.is_available()
-            else "cpu"
-        )
         shards_metadata = [
             ShardMetadata(
                 shard_offsets=[0, 0],
@@ -193,11 +188,6 @@ class TestShardingSpec(TestCase):
             )
 
     def test_check_overlapping(self):
-        device_type = (
-            torch.accelerator.current_accelerator().type
-            if torch.accelerator.is_available()
-            else "cpu"
-        )
         shards = [
             ShardMetadata(
                 shard_offsets=[0, 0],
@@ -349,6 +339,22 @@ class TestShardingSpec(TestCase):
         with self.assertRaisesRegex(ValueError, "overlap"):
             validate_non_overlapping_shards_metadata(shards)
 
+    def test_custom_sharding_spec(self):
+        ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
+
+        grid_spec = GridShardingSpec(grid_size=4, placements=ranks)
+
+        tensor_properties = TensorProperties(
+            dtype=torch.get_default_dtype(),
+            layout=torch.strided,
+            requires_grad=False,
+            memory_format=torch.contiguous_format,
+            pin_memory=False,
+        )
+
+        meta = grid_spec.build_metadata(torch.Size((8, 8)), tensor_properties)
+        check_tensor(meta.shards_metadata, torch.Size((8, 8)))
+
 
 class TestShardingSpecDevice(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
@@ -400,25 +406,25 @@ class TestShardingSpecDevice(TestCase):
         # Test unimplemented error
         with self.assertRaisesRegex(NotImplementedError, "not support named dimension"):
             # Named dimension.
-            ChunkShardingSpec("N", ["cuda:0", "cuda:1"])
+            ChunkShardingSpec("N", [f"{device_type}:0", f"{device_type}:1"])
 
         # Test invalid specs
         with self.assertRaisesRegex(ValueError, "needs to be an integer"):
-            ChunkShardingSpec(None, ["cuda:0", "cuda:1"])
+            ChunkShardingSpec(None, [f"{device_type}:0", f"{device_type}:1"])
         with self.assertRaisesRegex(ValueError, "needs to be an integer"):
-            ChunkShardingSpec({}, ["cuda:0", "cuda:1"])
+            ChunkShardingSpec({}, [f"{device_type}:0", f"{device_type}:1"])
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["random:0", "cuda:1"])
+            ChunkShardingSpec(0, ["random:0", f"{device_type}:1"])
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["cuda:foo", "cuda:1"])
+            ChunkShardingSpec(0, ["cuda:foo", f"{device_type}:1"])
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["rank:foo", "cuda:1"])
+            ChunkShardingSpec(0, ["rank:foo", f"{device_type}:1"])
         with self.assertRaisesRegex(RuntimeError, "Expected one of"):
-            ChunkShardingSpec(0, ["rank:0/foo", "cuda:1"])
+            ChunkShardingSpec(0, ["rank:0/foo", f"{device_type}:1"])
         with self.assertRaisesRegex(RuntimeError, "Expected one of"):
-            ChunkShardingSpec(0, ["rank:0/random:0", "cuda:1"])
+            ChunkShardingSpec(0, ["rank:0/random:0", f"{device_type}:1"])
         with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
-            ChunkShardingSpec(0, ["rank:0/cuda:foo", "cuda:1"])
+            ChunkShardingSpec(0, ["rank:0/cuda:foo", f"{device_type}:1"])
 
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "2 accelerators are needed"
@@ -505,13 +511,19 @@ class TestShardingSpecDevice(TestCase):
             ShardMetadata(shard_offsets=[0], shard_sizes=[1], placement="cuda:foo")
 
         with self.assertRaisesRegex(ValueError, "same number of elements"):
-            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[1], placement="cuda:0")
+            ShardMetadata(
+                shard_offsets=[0, 0], shard_sizes=[1], placement=f"{device_type}:0"
+            )
 
         with self.assertRaisesRegex(ValueError, "shard_offsets should be >=0"):
-            ShardMetadata(shard_offsets=[-1, 0], shard_sizes=[1, 1], placement="cuda:0")
+            ShardMetadata(
+                shard_offsets=[-1, 0], shard_sizes=[1, 1], placement=f"{device_type}:0"
+            )
 
         with self.assertRaisesRegex(ValueError, "shard_sizes should be >= 0"):
-            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[-1, 1], placement="cuda:0")
+            ShardMetadata(
+                shard_offsets=[0, 0], shard_sizes=[-1, 1], placement=f"{device_type}:0"
+            )
 
         with self.assertRaisesRegex(ValueError, "Empty shard list provided"):
             EnumerableShardingSpec([])
@@ -658,31 +670,11 @@ class GridShardingSpec(ShardingSpec):
         raise NotImplementedError("GridShardingSpec.shard not implemented yet!")
 
 
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
 backend = dist.get_default_backend_for_device(device_type)
 
 
 class TestCustomShardingSpec(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
-
-    def test_custom_sharding_spec(self, device):
-        device_type = torch.device(device).type
-        ranks = [f"rank:{i}/{device_type}:{i}" for i in range(4)]
-
-        grid_spec = GridShardingSpec(grid_size=4, placements=ranks)
-
-        tensor_properties = TensorProperties(
-            dtype=torch.get_default_dtype(),
-            layout=torch.strided,
-            requires_grad=False,
-            memory_format=torch.contiguous_format,
-            pin_memory=False,
-        )
-
-        meta = grid_spec.build_metadata(torch.Size((8, 8)), tensor_properties)
-        check_tensor(meta.shards_metadata, torch.Size((8, 8)))
 
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "Multi-accelerator required"


### PR DESCRIPTION
## Summary

`test/distributed/_shard/sharding_spec/test_sharding_spec.py` has three categories
of CUDA/NCCL hardcoding that prevent it from running on out-of-tree accelerator
backends (e.g. PrivateUse1 backends):

1. **Admission gating**: `TestShardingSpec` gates three tests with
   `@skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")`,
   a CUDA-only whitelist. `TestCustomShardingSpec` gates two distributed tests
   with `@requires_nccl()`, which skips any backend whose process-group backend
   is not NCCL.

2. **Hardcoded device strings**: Test bodies use literal `"cuda:0"`, `"cuda:1"`,
   etc. in `DevicePlacementSpec`, `ChunkShardingSpec`, `ShardMetadata`, and
   `GridShardingSpec` constructions, which are invalid on non-CUDA backends.

3. **No `hw_classification` labels**: Neither `TestShardingSpec` nor
   `TestCustomShardingSpec` had `hw_classification` class attributes, so they
   would not be selected by the `--hw-classification` CI filter.

This PR addresses all three issues with accelerator-agnostic equivalents.

## Changes

- Replaced `@skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")`
  with `@skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "2 accelerators are needed")`
  (`TEST_MULTIACCELERATOR` was introduced by #167196, checks
  `torch.accelerator.device_count() >= 2`; preserves `pass_in_sandcastle` CI semantics).
- Replaced `@requires_nccl()` with `@requires_capabilities(Capability.distributed.backend)`
  (capability-based admission, PR #191919; replaces hardcoded NCCL backend requirement).
- Removed the now-unused `TEST_MULTIGPU` and `requires_nccl` imports.
- Moved the `device_type` lookup to module level so it's shared across all classes,
  using `acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"`.
  Removed the repeated `device_type` definitions inside individual GENERIC test methods.
- Replaced all hardcoded `"cuda:N"` device strings with `f"{device_type}:N"` where
  `device_type` is the module-level variable (with `"cpu"` fallback) for GENERIC
  class, or `torch.device(device).type` for ACCELERATOR class (framework-injected
  via `instantiate_device_type_tests`).
- Replaced hardcoded `"cuda:0"` / `"cuda:1"` in invalid-device test cases with
  dynamic `f"{device_type}:0"` / `f"{device_type}:1"`. Cases that intentionally
  test parser errors (e.g. `"cuda:foo"`, `"rank:0/foo"`) are kept as-is — `"cuda"`
  is a valid device type name for parsing tests regardless of backend.
- Split `TestShardingSpec` into two classes:
  - `TestShardingSpec` (GENERIC): retains 6 pure-logic tests including
    `test_custom_sharding_spec` (moved from `TestCustomShardingSpec` — it only
    constructs spec objects and calls `check_tensor`, no accelerator needed).
  - `TestShardingSpecDevice` (ACCELERATOR): contains the 3 device tests,
    refactored to use `instantiate_device_type_tests` with `device` parameter
    injection and `except_for="cpu"` to skip CPU variants.
- Refactored `TestCustomShardingSpec` (ACCELERATOR) with
  `instantiate_device_type_tests` + `device` parameter + `except_for="cpu"`
  (skips CPU variants). Device acquisition changed from `self.device_type` to
  `torch.device(device).type` (takes bare device type to avoid the
  injected-`device`-with-index pitfall in spawn + per-rank placement scenarios).
- Added a module-level `backend` variable that dynamically resolves the
  distributed backend via `dist.get_default_backend_for_device()` and is passed
  to `@with_comms(backend=backend)` on the 2 distributed tests instead of
  relying on the hardcoded `"nccl"` default.
- Added `hw_classification` class attributes:
  - `TestShardingSpec`: `HardwareClassification.GENERIC`
  - `TestShardingSpecDevice`: `HardwareClassification.ACCELERATOR`
  - `TestCustomShardingSpec`: `HardwareClassification.ACCELERATOR`
- Added `instantiate_device_type_tests(TestShardingSpecDevice, globals(), except_for="cpu")` and
  `instantiate_device_type_tests(TestCustomShardingSpec, globals(), except_for="cpu")` at file end.
- Added `@skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "Multi-accelerator required")`
  above `@with_comms` on the 2 distributed tests in `TestCustomShardingSpec` to
  prevent `@with_comms` from executing `init_rpc` when no accelerator is available.
- Changed `torch.rand(...).size()` to `torch.Size([...])` (avoid creating tensors
  just for size comparison).

## Not changed

- Test assertion logic is unchanged; only device string construction, admission
  gating, and class structure are modified.
- The invalid-device test cases that intentionally test parser errors (e.g.
  `DevicePlacementSpec("cuda:foo")`, `ChunkShardingSpec(0, ["rank:0/foo", ...])`)
  are kept as-is — these test the error-handling path of the device string parser
  and `"cuda"` is a valid device type name for parsing tests regardless of backend.
- `GridShardingSpec` (custom ShardingSpec dataclass) is unchanged in structure;
  only its placement list construction uses dynamic `device_type`.

## Dependencies

This PR depends on the following infrastructure PRs (all submitted, not
yet merged into upstream main):

| Infrastructure | Source PR | Status |
|---|---|---|
| `Capability` class + `requires_capabilities` decorator | #191919 | Submitted |
| `PrivateUse1TestBase._capabilities()` override | #193080 | Submitted (depends on #191919) |

No dependency on unmerged PRs for correctness — `@requires_capabilities` degrades
to `skipped` (not `failed`) when the backend has not declared the capability, so
this PR can merge before #191919 and #193080. Without the dependency patches
applied, out-of-tree accelerator variants are skipped (expected); with the patches
applied, they execute and pass.

## Test plan

- `python test/distributed/_shard/sharding_spec/test_sharding_spec.py` on an
  out-of-tree accelerator backend (PrivateUse1, torch_npu on
  PyTorch 2.13.0a0, Ascend 910B3):
  `TestShardingSpec` (GENERIC) 6 pure-logic tests pass;
  `TestShardingSpecDevicePRIVATEUSE1` (NPU variant) 3 device tests pass;
  `TestCustomShardingSpecNPU` (NPU variant) 2 distributed tests pass.
  Result: 11 tests, `OK`.
- `python test/distributed/_shard/sharding_spec/test_sharding_spec.py` on CPU
  (no accelerator):
  `TestShardingSpec` (GENERIC) 6 pure-logic tests pass.
  ACCELERATOR classes excluded via `except_for="cpu"`.
  Result: 6 tests, `OK`.
- `python test/distributed/_shard/sharding_spec/test_sharding_spec.py` on CUDA
  (A100, CUDA 12.8, 4 cards):
  `TestShardingSpec` (GENERIC) 6 pure-logic tests pass;
  `TestShardingSpecDeviceCUDA` 3 device tests pass;
  `TestCustomShardingSpecCUDA` 2 distributed tests pass.
  Result: 11 tests, `OK`. This confirms the refactoring does not break
  existing CUDA behavior.