### PR TITLE
Size the jitted CUDA reduction accumulation buffer by the accumulator dtype

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -1330,10 +1330,10 @@ inline void jitted_gpu_reduce_kernel(TensorIterator& iter, const std::string& fu
         output_memory_size = std::max(output_memory_size, iter.shape()[dim] * iter.strides(0)[dim]);
       }
       output_memory_size /= iter.element_size(0); //iter.strides is in bytes
-      owned_buf_ptr.reset(new AccumulationBuffer(sizeof(out_scalar_t), //TODO
+      owned_buf_ptr.reset(new AccumulationBuffer(sizeof(arg_t),
                                                  sizeof(out_scalar_t),
                                                  (char*) iter.data_ptr(0),
-                                                 output_memory_size * sizeof(out_scalar_t))); //TODO
+                                                 output_memory_size * sizeof(arg_t)));
     } else {
       owned_buf_ptr.reset(new AccumulationBuffer());
     }

--- a/aten/src/ATen/native/cuda/ReduceSumProdKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceSumProdKernel.cu
@@ -95,6 +95,19 @@ struct prod_functor {
   // Ref: https://github.com/pytorch/pytorch/issues/77305
   #if AT_USE_JITERATOR() && !defined(_MSC_VER)
   void operator()(TensorIterator& iter) {
+    // The jiterated reduction path overflows 32-bit indexing for 16-bit dtypes
+    // on tensors with more than 2^31 elements (see
+    // https://github.com/pytorch/pytorch/issues/190964). Route 16-bit types
+    // through the vectorized gpu_reduce_kernel path (as sum_functor does),
+    // which splits large reductions into 32-bit-indexable sub-iterations.
+    constexpr bool is_16_bits = sizeof(scalar_t) == 2;
+    if constexpr (is_16_bits) {
+      gpu_reduce_kernel<scalar_t, out_t, /*vt0=*/4, /*input_vec_size=*/8>(
+          iter, func_wrapper<out_t>([] GPU_LAMBDA(acc_t a, acc_t b) -> acc_t {
+            return a * b;
+          }), 1.);
+      return;
+    }
     std::string func = jiterator_stringify(
     arg_t combine(arg_t a, arg_t b) {
       return a * b;

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -436,6 +436,22 @@ class TestReductions(TestCase):
         """Compares op against reference for a very large input tensor that requires 64 bit indexing"""
         self._test_ref(op, make_tensor((275000000,), dtype=dtype, device=device, low=-1, high=1, exclude_zero=True))
 
+    @onlyCUDA
+    @largeTensorTest("10GB")
+    def test_prod_large_input_16bit(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/190964:
+        # prod over a reduced dim of a >2**31-element 16-bit tensor triggered an
+        # illegal memory access due to 32-bit indexing overflow in the jiterated
+        # reduction path.
+        for dtype in (torch.float16, torch.bfloat16):
+            x = torch.ones((2, 2**31 // 2 + 1024), device=device, dtype=dtype)
+            self.assertEqual(
+                torch.prod(x, dim=0),
+                torch.ones(x.size(1), device=device, dtype=dtype),
+            )
+            del x
+            torch.cuda.empty_cache()
+
     @skipIfMPS
     @ops(filter(lambda op: op.ref is not None, reduction_ops),
          allowed_dtypes=all_types_and_complex_and(torch.half, torch.bool))

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -436,6 +436,38 @@ class TestReductions(TestCase):
         """Compares op against reference for a very large input tensor that requires 64 bit indexing"""
         self._test_ref(op, make_tensor((275000000,), dtype=dtype, device=device, low=-1, high=1, exclude_zero=True))
 
+    @onlyCUDA
+    @largeTensorTest("16GB")
+    def test_prod_large_input_16bit(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/190964:
+        # jitted_gpu_reduce_kernel sized its accumulation buffer with the output
+        # dtype instead of the accumulator dtype, so dtypes that cannot
+        # accumulate in the output overflowed the buffer once the input needed
+        # 64-bit indexing. Reducing dim=0 leaves a large output, which is what
+        # made the overflow fault rather than just corrupt.
+        for dtype in (torch.float16, torch.bfloat16):
+            x = torch.ones((2, 2**31 // 2 + 1024), device=device, dtype=dtype)
+            self.assertEqual(
+                torch.prod(x, dim=0),
+                torch.ones(x.size(1), device=device, dtype=dtype),
+            )
+            del x
+            torch.cuda.empty_cache()
+
+    @onlyCUDA
+    @largeTensorTest("12GB")
+    def test_prod_large_input_complex_half(self, device):
+        # Same accumulation buffer bug as test_prod_large_input_16bit, for
+        # complex32, whose accumulator (complex<float>) is twice the width of the
+        # output. Reducing to a two-element output keeps this affordable: with the
+        # buffer mis-sized the two accumulators overlap, so the result is wrong
+        # even where the overflow does not fault.
+        x = torch.ones((2**31 // 2 + 1024, 2), device=device, dtype=torch.complex32)
+        self.assertEqual(
+            torch.prod(x, dim=0),
+            torch.ones(2, device=device, dtype=torch.complex32),
+        )
+
     @skipIfMPS
     @ops(filter(lambda op: op.ref is not None, reduction_ops),
          allowed_dtypes=all_types_and_complex_and(torch.half, torch.bool))


### PR DESCRIPTION
Fixes #190964

### Summary

`torch.prod` over a reduced dimension of a CUDA tensor with more than `2**31` elements aborted with an illegal memory access (`cudaErrorIllegalAddress`) for `float16` and `bfloat16`. `float32` `prod` and `sum` of the same size worked.

### Root cause

Not a 64-bit indexing gap — that was my original diagnosis and it was wrong.

`jitted_gpu_reduce_kernel` sizes its `AccumulationBuffer` with `sizeof(out_scalar_t)` for *both* the accumulator size and the output element size, while the kernel it launches accumulates in `arg_t = opmath_type<scalar_t>`, as the `setReduceConfig<arg_t, ...>` call just below it shows. `gpu_reduce_kernel` passes `sizeof(arg_t)` in that position; two `//TODO` markers were sitting on the wrong arguments.

For `Half` this makes `out_t_size >= acc_t_size` true, so `AccumulationBuffer` reuses the output tensor for accumulation — precisely the case that `can_accumulate_in_output=false` exists to exclude — and the kernel then writes 4-byte `float` accumulators into 2-byte output slots. Adjacent accumulators alias, and the last one runs past the end of the output allocation. This is reached once the buffer path is taken, i.e. `!can_accumulate_in_output && !can_use_32bit_indexing`.

### Fix

Pass `sizeof(arg_t)` as the accumulator size and scale the allocation by it, matching `gpu_reduce_kernel`. Two lines.

This also covers `complex<Half>`, whose `complex<float>` accumulator is twice the output width, so it repairs the complex32 `sum`, `nansum` and `prod` specializations that route through the jitted path. Every other dtype configuration reaches the same buffer-reuse decision as before, so behavior changes only where it was already overflowing.

### Testing

```
python test/test_reductions.py -k "test_prod_large_input_16bit or test_prod_large_input_complex_half"
python test/test_reductions.py -k prod
```

- `test_prod_large_input_16bit` reproduces the reported crash; reducing `dim=0` leaves a large output so the overflow faults. Memory gate raised 10GB -> 16GB because peak usage is roughly 14GiB.
- `test_prod_large_input_complex_half` reduces to a two-element output, where the aliased accumulators give a wrong result even where the overflow does not fault, which keeps complex32 coverage affordable at 12GB.

Both large-tensor tests need a CUDA GPU and have not been re-run since the fix moved from the earlier routing workaround to the buffer sizing.

### Previous revision

An earlier version of this PR routed 16-bit `prod` through `gpu_reduce_kernel` instead. That masked the fault for `float16`/`bfloat16` only, left complex32 broken, and added a kernel instantiation. It has been reverted, so `ReduceSumProdKernel.cu` is no longer touched.
