### PR TITLE
[Testcase Refactoring]Make test_binary_cmp device-generic and add hw_classification labels

### DIFF
--- a/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
@@ -24,11 +24,6 @@ from torch.testing._internal.distributed._shard.sharded_tensor import (
 )
 
 
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
-backend = torch.distributed.get_default_backend_for_device(device_type)
-
 if TEST_WITH_DEV_DBG_ASAN:
     print(
         "Skip dev-asan as torch + multiprocessing spawn have known issues",
@@ -134,13 +129,13 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
         ):
             cmp_op(st1, st2)
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms()
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_torch_equal_tensor_specs(self, device):
         self._test_common_failures(torch.equal, device)
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms()
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_torch_equal(self, device):
@@ -150,13 +145,13 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
         st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
         self.assertTrue(torch.equal(st1, st2))
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms()
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_torch_allclose_tensor_specs(self, device):
         self._test_common_failures(torch.allclose, device)
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms()
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_torch_allclose(self, device):
@@ -175,7 +170,9 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
         self.assertTrue(torch.allclose(st1, st2, atol=1))
 
 
-instantiate_device_type_tests(TestShardedTensorBinaryOps, globals(), except_for=["cpu"])
+instantiate_device_type_tests(
+    TestShardedTensorBinaryOps, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
@@ -49,7 +49,7 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
         TestShardedTensorBinaryOps.seed += 1
         return st1, st2
 
-    def get_gpu_specs(self):
+    def get_device_specs(self):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
@@ -72,7 +72,7 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
         return spec, alt_spec
 
     def _test_common_failures(self, cmp_op):
-        spec, alt_spec = self.get_gpu_specs()
+        spec, alt_spec = self.get_device_specs()
 
         st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
         if self.rank == 0:
@@ -127,33 +127,33 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
 
     @with_comms(backend=backend)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_torch_equal_tensor_specs(self):
         self._test_common_failures(torch.equal)
 
     @with_comms(backend=backend)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_torch_equal(self):
         """Test torch.equal(ShardedTensor, ShardedTensor)"""
 
-        spec, _ = self.get_gpu_specs()
+        spec, _ = self.get_device_specs()
         st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
         self.assertTrue(torch.equal(st1, st2))
 
     @with_comms(backend=backend)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_torch_allclose_tensor_specs(self):
         self._test_common_failures(torch.allclose)
 
     @with_comms(backend=backend)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_torch_allclose(self):
         """Test torch.allclose(ShardedTensor, ShardedTensor)"""
 
-        spec, _ = self.get_gpu_specs()
+        spec, _ = self.get_device_specs()
 
         st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
         self.assertTrue(torch.allclose(st1, st2))

--- a/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
@@ -57,7 +57,8 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
         type(self).seed += 1
         return st1, st2
 
-    def get_device_specs(self):
+    def get_device_specs(self, device):
+        device_type = torch.device(device).type
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
@@ -79,8 +80,8 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
         )
         return spec, alt_spec
 
-    def _test_common_failures(self, cmp_op):
-        spec, alt_spec = self.get_device_specs()
+    def _test_common_failures(self, cmp_op, device):
+        spec, alt_spec = self.get_device_specs(device)
 
         st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
         if self.rank == 0:
@@ -137,7 +138,7 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_torch_equal_tensor_specs(self, device):
-        self._test_common_failures(torch.equal)
+        self._test_common_failures(torch.equal, device)
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
@@ -145,7 +146,7 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
     def test_torch_equal(self, device):
         """Test torch.equal(ShardedTensor, ShardedTensor)"""
 
-        spec, _ = self.get_device_specs()
+        spec, _ = self.get_device_specs(device)
         st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
         self.assertTrue(torch.equal(st1, st2))
 
@@ -153,7 +154,7 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(Capability.distributed.backend)
     def test_torch_allclose_tensor_specs(self, device):
-        self._test_common_failures(torch.allclose)
+        self._test_common_failures(torch.allclose, device)
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
@@ -161,7 +162,7 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
     def test_torch_allclose(self, device):
         """Test torch.allclose(ShardedTensor, ShardedTensor)"""
 
-        spec, _ = self.get_device_specs()
+        spec, _ = self.get_device_specs(device)
 
         st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
         self.assertTrue(torch.allclose(st1, st2))

--- a/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
@@ -12,9 +12,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     requires_capabilities,
 )
-from torch.testing._internal.common_distributed import (
-    skip_if_lt_x_gpu,
-)
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -176,7 +174,7 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
         self.assertTrue(torch.allclose(st1, st2, atol=1))
 
 
-instantiate_device_type_tests(TestShardedTensorBinaryOps, globals())
+instantiate_device_type_tests(TestShardedTensorBinaryOps, globals(), except_for=["cpu"])
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
@@ -7,11 +7,19 @@ import torch.distributed as dist
 from torch.distributed._shard import sharded_tensor
 from torch.distributed._shard.sharding_spec import ChunkShardingSpec
 from torch.distributed.distributed_c10d import _get_default_group
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     with_comms,
@@ -34,6 +42,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 class TestShardedTensorBinaryOps(ShardedTensorTestBase):
     """Test base for binary comparison functions such as torch.equal, torch.allclose etc. for ShardedTensor"""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     seed = 42
 
     def get_random_tensors(
@@ -41,12 +51,12 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
     ):
         pg1 = _get_default_group() if pg1 is None else pg1
         pg2 = _get_default_group() if pg2 is None else pg2
-        torch.manual_seed(TestShardedTensorBinaryOps.seed)
+        torch.manual_seed(type(self).seed)
         st1 = sharded_tensor.rand(spec1, sizes, process_group=pg1)
-        torch.manual_seed(TestShardedTensorBinaryOps.seed + seed_offset)
+        torch.manual_seed(type(self).seed + seed_offset)
         st2 = sharded_tensor.rand(spec2, sizes, process_group=pg2)
 
-        TestShardedTensorBinaryOps.seed += 1
+        type(self).seed += 1
         return st1, st2
 
     def get_device_specs(self):
@@ -125,32 +135,32 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
         ):
             cmp_op(st1, st2)
 
-    @with_comms(backend=backend)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_torch_equal_tensor_specs(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_torch_equal_tensor_specs(self, device):
         self._test_common_failures(torch.equal)
 
-    @with_comms(backend=backend)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_torch_equal(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_torch_equal(self, device):
         """Test torch.equal(ShardedTensor, ShardedTensor)"""
 
         spec, _ = self.get_device_specs()
         st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
         self.assertTrue(torch.equal(st1, st2))
 
-    @with_comms(backend=backend)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_torch_allclose_tensor_specs(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_torch_allclose_tensor_specs(self, device):
         self._test_common_failures(torch.allclose)
 
-    @with_comms(backend=backend)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_torch_allclose(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_torch_allclose(self, device):
         """Test torch.allclose(ShardedTensor, ShardedTensor)"""
 
         spec, _ = self.get_device_specs()
@@ -164,6 +174,9 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
         self.assertFalse(torch.allclose(st1, st2))
         # sharded_tensor.rand produces uniform values in the [0,1] range.
         self.assertTrue(torch.allclose(st1, st2, atol=1))
+
+
+instantiate_device_type_tests(TestShardedTensorBinaryOps, globals())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py` tests
ShardedTensor binary comparison operations (torch.equal, torch.allclose)
on distributed backends. Three issues prevent out-of-tree backends from
running these tests:

1. `@requires_accelerator_dist_backend(["nccl", "xccl"])` only allows
   NCCL and XCCL backends — out-of-tree PrivateUse1 backends are
   wrongly skipped.
2. Module-level `device_type` and `backend` global variables are used
   instead of the framework-injected `device` parameter — the
   instantiation framework cannot route to the correct device variant.
3. `TestShardedTensorBinaryOps` lacks `hw_classification` label and
   `instantiate_device_type_tests` instantiation — unlabeled tests are
   not filtered in CI pipelines (effectively dead code).

This PR addresses all three issues by switching to capability-based
admission, removing module-level globals in favor of
`ShardedTensorTestBase.backend` (PR #194992), adding
`instantiate_device_type_tests` + spawn combination, and adding the
`hw_classification` label.

## Changes

- Replaced `@requires_accelerator_dist_backend(["nccl", "xccl"])` with
  `@requires_capabilities(Capability.distributed.backend)` in all 4 test
  methods. This switches from a hardcoded backend name list to
  capability-based admission — device-agnostic, degrades to skipped
  (not failed) when the capability is not declared.
- Removed module-level `device_type` and `backend` global variables.
  Backend is now resolved at runtime via `ShardedTensorTestBase.backend`
  property (PR #194992) through `@with_comms()` default `backend=None`.
- Changed `@with_comms(backend=backend)` to `@with_comms()` in all 4
  test methods. With PR #194992, `with_comms` default `backend=None`
  resolves to `self.backend` at runtime via
  `dist.get_default_backend_for_device(self.device_type)`, where
  `self.device_type` is set by `instantiate_device_type_tests` per
  device variant.
- Added `device` parameter to all 4 test methods (framework injection
  via `instantiate_device_type_tests`). The `device` parameter is
  passed through to `get_device_specs(self, device)` and
  `_test_common_failures(self, cmp_op, device)`, which derive
  `device_type` via `torch.device(device).type` for sharding spec
  construction.
- Renamed `get_gpu_specs` to `get_device_specs` (definition + 3 call
  sites) — the method name contained "gpu" but the implementation was
  already device-agnostic via `f"rank:0/{device_type}:0"` patterns.
- Replaced `TestShardedTensorBinaryOps.seed` with `type(self).seed` (3
  references in `get_random_tensors`). `instantiate_device_type_tests`
  removes the template class name from `globals()`, so hardcoded class
  name references raise `NameError` at runtime.
- Added `instantiate_device_type_tests` import and file-end call with
  `except_for="cpu"` and `allow_xpu=True` — the test bodies require
  accelerators, so generating a CPU subclass is unnecessary.
- Added `hw_classification = HardwareClassification.ACCELERATOR` class
  attribute.
- Removed the now-unused `requires_accelerator_dist_backend` import;
  added `Capability`, `requires_capabilities`, and
  `instantiate_device_type_tests` imports from `common_device_type`;
  added `HardwareClassification` import from `common_utils`.

## Not changed

- The test logic remains unchanged; only decorators, method signatures,
  method names, and class attributes are modified.
- `get_random_tensors` does not receive `device` — it only uses
  process groups and `torch.manual_seed`, not device-specific APIs.
- `@skip_if_lt_x_gpu(4)` is preserved (already hardware-agnostic).
- Assertions and sharding spec construction logic are unchanged.

## Depends on

This PR relies on the following upstream PRs (submitted but not yet merged):

- **#191919**: `Capability` mechanism + `requires_capabilities` decorator
  — provides the capability-based admission infrastructure.
- **#193080**: `PrivateUse1TestBase._capabilities()` override
  — declares `Capability.distributed.backend` for PrivateUse1 backends.
- **#194992**: `ShardedTensorTestBase.backend` property +
  `with_comms` default `backend=None`
  — enables runtime backend resolution from `self.device_type` instead
  of module-level global variables.

Without these, the test will be skipped on PrivateUse1 backends (graceful
degradation — skipped, not failed). The test PR can merge before the
common PRs due to this safe degradation behavior.

## Test plan

- `python test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py`
  on an out-of-tree accelerator backend (PrivateUse1, torch_npu
  2.13.0+git45fbeae on PyTorch 2.13.0a0+gitfad7424, Ascend 910B3,
  CANN 9.1.0-beta.1): `OK` — all 4 tests pass
  (`TestShardedTensorBinaryOpsPRIVATEUSE1` NPU variant).
- `python test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py`
  on CPU (no accelerator): `OK (skipped=4)` — all skipped by
  `@skip_if_lt_x_gpu(4)`.
- `python test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py`
  on CUDA (NVIDIA A100-SXM4-80GB, CUDA 12.8): `OK` — all 4 tests pass
  (`TestShardedTensorBinaryOpsCUDA` CUDA variant). Confirms no
  regression on CUDA.