### PR TITLE
Add --print-completion to torchrun

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -113,6 +113,7 @@ ignore-missing-imports = [
     "onnxscript.*",
     "redis.*",
     "tabulate.*",
+    "shtab.*",
 ]
 # By default, mypy does not check untyped definitions.
 # However, mypy has a configuration called check_untyped_defs which is used

--- a/test/distributed/test_run.py
+++ b/test/distributed/test_run.py
@@ -196,10 +196,15 @@ class RunTest(TestCase):
         self.assertIn("pip install shtab", err)
 
     def test_print_completion_rejects_unknown_shell(self):
-        """The shell choices are validated by argparse."""
+        """The shell choices are validated by argparse.
+
+        Deliberately not a real shell: the choices come from
+        shtab.SUPPORTED_SHELLS when shtab is installed, so naming one shtab
+        could plausibly add later would make this test fail on upgrade.
+        """
         with self.assertRaises(SystemExit):
             with redirect_stderr(io.StringIO()):
-                self._parse_args(["--print-completion=fish"])
+                self._parse_args(["--print-completion=notashell"])
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_run.py
+++ b/test/distributed/test_run.py
@@ -7,7 +7,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import io
 import os
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from importlib.util import find_spec
 from unittest.mock import MagicMock, patch
 
 import torch.distributed.run as run
@@ -159,6 +163,43 @@ class RunTest(TestCase):
                 )
             )
             self.assertEqual("${hostname}: ", config.log_line_prefix_template)
+
+    def _print_completion(self, shell):
+        """Run --print-completion, returning (exit_code, stdout, stderr)."""
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            with self.assertRaises(SystemExit) as cm:
+                # no training_script: the action must exit before argparse
+                # complains about the missing positional
+                self._parse_args([f"--print-completion={shell}"])
+        return cm.exception.code, out.getvalue(), err.getvalue()
+
+    @unittest.skipIf(find_spec("shtab") is None, "shtab is not installed")
+    def test_print_completion(self):
+        """--print-completion emits a completion script naming torchrun's options."""
+        for shell in ("bash", "zsh", "tcsh"):
+            with self.subTest(shell=shell):
+                code, out, _ = self._print_completion(shell)
+                self.assertEqual(0, code)
+                # tcsh lists options without the leading dashes
+                self.assertIn("nproc-per-node", out)
+                self.assertIn("rdzv-backend", out)
+                # completions must bind to `torchrun`, not to the module that
+                # happens to be running the parser
+                self.assertIn("torchrun", out)
+
+    @unittest.skipIf(find_spec("shtab") is not None, "shtab is installed")
+    def test_print_completion_without_shtab(self):
+        """Without shtab, the flag fails with an actionable message, not a traceback."""
+        code, _, err = self._print_completion("bash")
+        self.assertEqual(1, code)
+        self.assertIn("pip install shtab", err)
+
+    def test_print_completion_rejects_unknown_shell(self):
+        """The shell choices are validated by argparse."""
+        with self.assertRaises(SystemExit):
+            with redirect_stderr(io.StringIO()):
+                self._parse_args(["--print-completion=fish"])
 
 
 if __name__ == "__main__":

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -794,13 +794,20 @@ def get_args_parser() -> ArgumentParser:
     # Shell completion.
     #
 
+    try:
+        import shtab
+    except ImportError:
+        # shtab is optional; fall back to the shells it supports today so the
+        # flag still validates its argument when shtab is not installed
+        choices = ["bash", "zsh", "tcsh"]
+    else:
+        choices = shtab.SUPPORTED_SHELLS
+
     parser.add_argument(
         "--print-completion",
         "--print_completion",
         action=_PrintCompletionAction,
-        # mirrors shtab.SUPPORTED_SHELLS, which cannot be imported here since
-        # shtab is optional
-        choices=["bash", "zsh", "tcsh"],
+        choices=choices,
         help="Print a shell completion script for torchrun to stdout and exit "
         "(e.g. [--print-completion zsh > ~/.zsh/completions/_torchrun]). "
         "Requires the optional 'shtab' package.",

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -154,7 +154,7 @@ Shell completion
 
 ``torchrun`` can emit a completion script for ``bash``, ``zsh`` or ``tcsh``. The
 script is generated from the argument parser, so it stays in sync with the
-options above. This requires the optional `shtab <https://docs.iterative.ai/shtab>`_
+options above. This requires the optional `shtab <https://tqdm.github.io/shtab>`_
 package (``pip install shtab``); torchrun only imports it when the flag is used.
 
 ::
@@ -433,7 +433,7 @@ utility
 import os
 import sys
 import uuid
-from argparse import Action, ArgumentParser, REMAINDER
+from argparse import Action as _Action, ArgumentParser, REMAINDER
 from collections.abc import Callable
 from importlib import metadata
 
@@ -455,7 +455,7 @@ from torch.utils.backend_registration import _get_custom_mod_func
 logger = get_logger(__name__)
 
 
-class _PrintCompletionAction(Action):
+class _PrintCompletionAction(_Action):
     """Print a shell completion script for ``torchrun`` and exit.
 
     ``shtab`` derives the script from this parser, so completions stay in sync
@@ -471,12 +471,13 @@ class _PrintCompletionAction(Action):
                 1,
                 f"{option_string} requires the 'shtab' package: pip install shtab\n",
             )
-        # Completions are for the `torchrun` console script. parser.prog is
-        # `__main__.py` when invoked as `python -m torch.distributed.run`, which
-        # would bind the completion to the wrong command.
-        parser.prog = "torchrun"
-        print(shtab.complete(parser, shell=values))
-        parser.exit()
+        else:
+            # Completions are for the `torchrun` console script. parser.prog is
+            # `__main__.py` when invoked as `python -m torch.distributed.run`,
+            # which would bind the completion to the wrong command.
+            parser.prog = "torchrun"
+            print(shtab.complete(parser, shell=values))
+            parser.exit()
 
 
 def get_args_parser() -> ArgumentParser:

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -149,6 +149,25 @@ node in your training cluster, but ideally you should pick a node that has a hig
 .. note::
    If no port number is specified ``HOST_NODE_ADDR`` defaults to 29400.
 
+Shell completion
+----------------
+
+``torchrun`` can emit a completion script for ``bash``, ``zsh`` or ``tcsh``. The
+script is generated from the argument parser, so it stays in sync with the
+options above. This requires the optional `shtab <https://docs.iterative.ai/shtab>`_
+package (``pip install shtab``); torchrun only imports it when the flag is used.
+
+::
+
+    # zsh
+    torchrun --print-completion zsh > ~/.zsh/completions/_torchrun
+
+    # bash
+    torchrun --print-completion bash > ~/.local/share/bash-completion/completions/torchrun
+
+Refer to your shell's documentation for the directory it loads completions from;
+the paths above are the common defaults.
+
 Note on rendezvous backend
 --------------------------
 
@@ -414,7 +433,7 @@ utility
 import os
 import sys
 import uuid
-from argparse import ArgumentParser, REMAINDER
+from argparse import Action, ArgumentParser, REMAINDER
 from collections.abc import Callable
 from importlib import metadata
 
@@ -434,6 +453,30 @@ from torch.utils.backend_registration import _get_custom_mod_func
 
 
 logger = get_logger(__name__)
+
+
+class _PrintCompletionAction(Action):
+    """Print a shell completion script for ``torchrun`` and exit.
+
+    ``shtab`` derives the script from this parser, so completions stay in sync
+    with the options defined below. It is an optional dependency: torchrun only
+    imports it when this flag is used.
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        try:
+            import shtab
+        except ImportError:
+            parser.exit(
+                1,
+                f"{option_string} requires the 'shtab' package: pip install shtab\n",
+            )
+        # Completions are for the `torchrun` console script. parser.prog is
+        # `__main__.py` when invoked as `python -m torch.distributed.run`, which
+        # would bind the completion to the wrong command.
+        parser.prog = "torchrun"
+        print(shtab.complete(parser, shell=values))
+        parser.exit()
 
 
 def get_args_parser() -> ArgumentParser:
@@ -745,6 +788,22 @@ def get_args_parser() -> ArgumentParser:
         help="Enable virtual local rank mode for workers. When enabled, LOCAL_RANK is set to 0 "
         "for all workers and CUDA_VISIBLE_DEVICES is adjusted so each worker accesses its "
         "assigned GPU at device index 0.",
+    )
+
+    #
+    # Shell completion.
+    #
+
+    parser.add_argument(
+        "--print-completion",
+        "--print_completion",
+        action=_PrintCompletionAction,
+        # mirrors shtab.SUPPORTED_SHELLS, which cannot be imported here since
+        # shtab is optional
+        choices=["bash", "zsh", "tcsh"],
+        help="Print a shell completion script for torchrun to stdout and exit "
+        "(e.g. [--print-completion zsh > ~/.zsh/completions/_torchrun]). "
+        "Requires the optional 'shtab' package.",
     )
 
     #


### PR DESCRIPTION
Fixes #90509


### Problem

`torchrun` has no shell completion, so its options have to be typed from memory or looked up with `--help`.

### Approach

`shtab` derives a completion script from an `argparse` parser, and torchrun already exposes `get_args_parser()`. Generating on demand keeps completions in sync with the options automatically, unlike static scripts checked into the repo, which drift every time a flag is added:

```
torchrun --print-completion zsh > ~/.zsh/completions/_torchrun
```

**On the dependency question raised in the issue: shtab stays optional. Nothing is added to any requirements file, every import of it is guarded so torchrun works normally without it, and with shtab absent the flag exits 1 with an install hint rather than a traceback:

```
$ torchrun --print-completion zsh
--print-completion requires the 'shtab' package: pip install shtab
```

This follows @casperdcl's recommendation in the thread — that build-time generation cannot cover all shells and install paths, so the optional-dependency pattern is preferable — while respecting @remyleone's point about not enlarging PyTorch's dependency surface.

Two details worth flagging for review:

- The action sets `parser.prog` before generating. Without it, `python -m torch.distributed.run --print-completion zsh` emits a script bound to `__main__.py`, which would never fire.
- The accepted shells come from shtab.SUPPORTED_SHELLS when shtab is importable, with a literal fallback when it isn't, so the list stays accurate as shtab adds shells — per @casperdcl's review suggestion. His multi-line help text isn't carried over: torchrun's parser uses argparse's default HelpFormatter, which collapses newlines, so the examples ran together in --help; both live in the module docstring instead.


`pyrefly.toml` gets `shtab` in `ignore-missing-imports`, alongside the other optional third-party imports such as `tabulate`; without it the type checker cannot resolve an import that is deliberately absent from the environment.

### Testing

```
python -m pytest test/distributed/test_run.py -v
```

10 passed, 1 skipped, 3 subtests. The new tests cover the generated script (over bash, zsh and tcsh), the missing-`shtab` error path, and rejection of an unsupported shell. One of the first two always skips depending on whether `shtab` is installed, so both paths were exercised by uninstalling `shtab` and re-running.

Manual checks with `shtab` installed:

```
torchrun --print-completion zsh | head -1                          # #compdef torchrun
python -m torch.distributed.run --print-completion zsh | head -1   # #compdef torchrun
```

and that the flag is not taken from the training script's own arguments (`torchrun train.py --print-completion zsh` passes it through to `train.py`).

### Note on how this was written

>  I used AI to write code but reviewed every line of the code, tests and documentation before submitting, and I am responsible for its contents.

cc @d4l3k @Freed-Wu
