### PR TITLE
[Test] Make test_masked device-agnostic for OOT backends

### DIFF
--- a/test/test_masked.py
+++ b/test/test_masked.py
@@ -12,11 +12,12 @@ from torch.testing._internal.common_utils import skipIfTorchDynamo
 
 
 from torch.testing._internal.common_utils import \
-    (TestCase, parametrize, suppress_warnings, _TestParametrizer, run_tests)
+    (TestCase, parametrize, suppress_warnings, _TestParametrizer, run_tests,
+     instantiate_parametrized_tests, HardwareClassification)
 from torch.testing._internal.common_methods_invocations import \
     (op_db, SampleInput)
 from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, ops, onlyNativeDeviceTypes, precisionOverride)
+    (instantiate_device_type_tests, ops, precisionOverride)
 
 
 def apply_masked_reduction_along_dim(op, input, *args, **kwargs):
@@ -264,6 +265,7 @@ class mask_layouts(_TestParametrizer):
 
 
 class TestMasked(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def assertEqualMasked(self, actual, expected, mask):
         strided = to_strided(actual)
@@ -272,7 +274,6 @@ class TestMasked(TestCase):
             expected = torch.where(mask, expected, expected.new_zeros([]))
         self.assertEqual(strided, expected, exact_device=False)
 
-    @onlyNativeDeviceTypes
     @suppress_warnings
     @ops(masked_ops_with_references)
     @precisionOverride({torch.bfloat16: 5e-4, torch.float16: 5e-4})
@@ -294,7 +295,6 @@ class TestMasked(TestCase):
             self.assertEqualMasked(actual, expected, outmask)
 
     @mask_layouts()
-    @onlyNativeDeviceTypes
     @suppress_warnings
     @ops(masked_ops_with_non_strided_support)
     @precisionOverride({torch.bfloat16: 5e-3, torch.float16: 5e-3})
@@ -316,6 +316,12 @@ class TestMasked(TestCase):
                 outmask = torch.masked._output_mask(op.op, r_inp, *r_args, **r_kwargs)
             expected = op.op(r_inp, *r_args, **r_kwargs)
             self.assertEqualMasked(actual, expected, outmask)
+
+
+
+
+class TestMaskedGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIfTorchDynamo("https://github.com/pytorch/torchdynamo/issues/1992")
     @parametrize("sparse_kind,fill_value", [('coo', 0), ('hybrid_coo', 0),
@@ -432,6 +438,7 @@ class TestMasked(TestCase):
 
 
 instantiate_device_type_tests(TestMasked, globals(), except_for='meta')
+instantiate_parametrized_tests(TestMaskedGeneric)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Separate `test_where` out to a new test class `TestMaskedGeneric` that doesn't need device.
Add `HardwareClassification` labels.