### PR TITLE
FakeTensor._normalize_fake_device skips GPU context init for PrivateUse1 backends (#191293)

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -932,7 +932,10 @@ class FakeTensor(Tensor):
     @staticmethod
     def _normalize_fake_device(device: torch.device) -> torch.device:
         """Normalize device by initializing GPU context and setting device index."""
-        if device.type in ("cuda", "xpu"):
+        if (
+            device.type in ("cuda", "xpu")
+            or device.type == torch._C._get_privateuse1_backend_name()
+        ):
             init_gpu_context(device)
 
         if _is_indexed_device_type(device.type) and device.index is None:


### PR DESCRIPTION
## Bug description

`FakeTensor._normalize_fake_device` (torch/_subclasses/fake_tensor.py, L935)
hardcodes a `("cuda", "xpu")` whitelist to decide whether to call
`init_gpu_context(device)`. PrivateUse1 backends (e.g. MLU, NPU) that register
via `torch.utils.rename_privateuse1_backend()` are silently skipped, causing
`FakeTensor` creation to fail or produce incorrect results when the backend
requires GPU context initialization before fake tensor operations.

## Reproduction

```python
import torch

# Register a PrivateUse1 backend (e.g. MLU)
torch.utils.rename_privateuse1_backend("mlu")

# Any path that creates FakeTensors on the MLU device will skip
# init_gpu_context, because "mlu" is not in ("cuda", "xpu")
from torch._subclasses.fake_tensor import FakeTensorMode
mode = FakeTensorMode()
with mode:
    t = torch.empty(4, device="mlu")  # no init_gpu_context called
```

## Root cause

```python
# torch/_subclasses/fake_tensor.py L935
if device.type in ("cuda", "xpu"):
    init_gpu_context(device)
```

The check should also cover the renamed PrivateUse1 backend.

## Proposed fix

```python
if device.type in ("cuda", "xpu") or device.type == torch._C._get_privateuse1_backend_name():
    init_gpu_context(device)
```

`torch._C._get_privateuse1_backend_name()` returns the current PrivateUse1
backend name (default `"privateuseone"`, or the renamed value after
`rename_privateuse1_backend()`). When no custom backend is registered it
returns `"privateuseone"`, which will never match a real device type, so
the default behavior is unchanged.

## Impact

All PrivateUse1 backends that need GPU context initialization (MLU, NPU, etc.)
hit this when using FakeTensor / torch.compile / Dynamo tracing. Downstream
vendors currently work around this with monkey-patches in their own repos.