### PR TITLE
[CD] Enable content-addressed docker tags for any ciflow/binaries* label

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -190,7 +190,7 @@ jobs:
           set -euo pipefail
           suffix=""
           registry_host=""
-          if [[ "${GITHUB_REF}" == refs/tags/ciflow/binaries/* ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/ciflow/binaries* ]]; then
             # PR test run: the content-addressed image lives in ECR.
             suffix="-$(git rev-parse HEAD:.ci/docker)"
             registry_host="308535385114.dkr.ecr.us-east-1.amazonaws.com/"
@@ -205,11 +205,11 @@ jobs:
       # on the same PR. Log in (read-only) and wait for the content-addressed
       # tags to appear before the build/test jobs try to pull them.
       - name: Login to ECR
-        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries') }}
         uses: pytorch/pytorch/.github/actions/ecr-login@main
 {%- if ns.groups %}
       - name: Wait for content-addressed builder image in ECR
-        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries') }}
         env:
           DOCKER_IMAGE_SUFFIX: ${{ steps.calc.outputs.docker_image_suffix }}
         shell: bash

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -93,7 +93,7 @@ jobs:
           set -euo pipefail
           suffix=""
           registry_host=""
-          if [[ "${GITHUB_REF}" == refs/tags/ciflow/binaries/* ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/ciflow/binaries* ]]; then
             # PR test run: the content-addressed image lives in ECR.
             suffix="-$(git rev-parse HEAD:.ci/docker)"
             registry_host="308535385114.dkr.ecr.us-east-1.amazonaws.com/"
@@ -108,10 +108,10 @@ jobs:
       # on the same PR. Log in (read-only) and wait for the content-addressed
       # tags to appear before the build/test jobs try to pull them.
       - name: Login to ECR
-        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries') }}
         uses: pytorch/pytorch/.github/actions/ecr-login@main
       - name: Wait for content-addressed builder image in ECR
-        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries') }}
         env:
           DOCKER_IMAGE_SUFFIX: ${{ steps.calc.outputs.docker_image_suffix }}
         shell: bash

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -94,7 +94,7 @@ jobs:
           set -euo pipefail
           suffix=""
           registry_host=""
-          if [[ "${GITHUB_REF}" == refs/tags/ciflow/binaries/* ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/ciflow/binaries* ]]; then
             # PR test run: the content-addressed image lives in ECR.
             suffix="-$(git rev-parse HEAD:.ci/docker)"
             registry_host="308535385114.dkr.ecr.us-east-1.amazonaws.com/"
@@ -109,10 +109,10 @@ jobs:
       # on the same PR. Log in (read-only) and wait for the content-addressed
       # tags to appear before the build/test jobs try to pull them.
       - name: Login to ECR
-        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries') }}
         uses: pytorch/pytorch/.github/actions/ecr-login@main
       - name: Wait for content-addressed builder image in ECR
-        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries/') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/ciflow/binaries') }}
         env:
           DOCKER_IMAGE_SUFFIX: ${{ steps.calc.outputs.docker_image_suffix }}
         shell: bash


### PR DESCRIPTION
PRs with `ciflow/binaries_wheel` or `ciflow/binaries_libtorch` labels still use the dockerhub images instead of the content-addressed docker tags as intended by https://github.com/pytorch/pytorch/pull/190985 and https://github.com/pytorch/pytorch/pull/190749.

This leads to some confusing behavior on PRs, like it did on PR [190276](https://github.com/pytorch/pytorch/pull/190276): [this 7.14 build](https://github.com/pytorch/pytorch/actions/runs/30318185296/job/90151385132?pr=190276) successfully used the ECR images (due to ciflow/binaries trigger), but [this 7.14 build](https://github.com/pytorch/pytorch/actions/runs/30318190306/job/90148362471?pr=190276) failed because it tried to use dockerhub images (due to ciflow/binaries_wheel trigger). If the dockerhub images are present, this would lead to even more confusion, as the build jobs wouldn't fail, but wouldn't test the PR changes either.

## Validation

Triggered binary manywheel jobs using `ciflow/binaries_libtorch` and `ciflow/binaries_wheel`. The [wheel build job](https://github.com/pytorch/pytorch/actions/runs/30396124811/job/90456295394) picked up the ECR docker image: `308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/manylinux2_28-builder:rocm7.1-919863eb8675cbd1effd9844e75ba81e3bd2de27`.