### PR TITLE
[profiler][cupti] Add generic CUDA-graph lifecycle hooks

### DIFF
--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -115,6 +115,28 @@
     export_graph_data
 ```
 
+### CUDA graph lifecycle hooks
+
+Register callbacks that fire when any CUDA graph is instantiated or destroyed --
+for example, a profiler observing graph lifecycle without the graph code carrying
+any consumer knowledge. Registering a hook is the opt-in; with none registered
+both are no-ops. Live in `torch.cuda.graphs`.
+
+```{eval-rst}
+.. currentmodule:: torch.cuda.graphs
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    register_graph_instantiate_hook
+    run_graph_instantiate_hooks
+    register_graph_destroy_hook
+    run_graph_destroy_hooks
+    graph_destroy_hooks_active
+
+.. currentmodule:: torch.cuda
+```
+
 ## Graph Kernel Annotations (prototype)
 
 `torch.cuda.graph_annotations` annotates the kernels captured in a CUDA

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -847,6 +847,28 @@ class TestGraphInstantiateHooks(TestCase):
         cg.run_graph_instantiate_hooks(graph)  # first raises, second still runs
         self.assertEqual(seen, [graph])
 
+    @requires_cuda
+    def test_fires_once_on_real_graph_instantiate(self):
+        import torch.cuda.graphs as cg
+
+        seen = []
+        handle = cg.register_graph_instantiate_hook(lambda gr: seen.append(gr))
+        self.addCleanup(handle.remove)
+
+        x = torch.zeros(4, device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            _ = x + 1
+
+        # instantiate() ran once at capture_end and fired the hook with this graph.
+        self.assertEqual(seen, [g])
+        for _ in range(3):
+            g.replay()
+        torch.cuda.synchronize()
+        # replay does not re-instantiate, so the hook is not called again.
+        self.assertEqual(seen, [g])
+        g.reset()
+
 
 # Host-side test of the graph-destroy hook registry: consumers register per-resolver
 # cleanup hooks that a CUDAGraph invokes (gated on graph_destroy_hooks_active) via
@@ -893,6 +915,35 @@ class TestGraphDestroyHooks(TestCase):
         cg.register_graph_destroy_hook(lambda ids: seen.append(set(ids)))
         cg.run_graph_destroy_hooks({1})  # first raises, second still runs
         self.assertEqual(seen, [{1}])
+
+    @requires_cuda
+    def test_fires_with_recorded_exec_ids_on_teardown(self):
+        import torch.cuda.graphs as cg
+
+        exec_id = 0xABCD
+        seen = []
+        # Stand in for a consumer that records per-graph state at instantiate: stamp a
+        # known exec id onto the graph so teardown has something to hand the destroy hook.
+        inst = cg.register_graph_instantiate_hook(
+            lambda gr: gr._recorded_exec_ids.add(exec_id)
+        )
+        dh = cg.register_graph_destroy_hook(lambda ids: seen.append(set(ids)))
+        self.addCleanup(inst.remove)
+        self.addCleanup(dh.remove)
+
+        x = torch.zeros(4, device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            _ = x + 1
+        for _ in range(3):
+            g.replay()
+        torch.cuda.synchronize()
+
+        self.assertEqual(seen, [])  # not torn down yet
+        # reset() tears down this capture cycle and fires the armed destroy callback,
+        # handing the destroy hook the exec ids recorded on the graph.
+        g.reset()
+        self.assertEqual(seen, [{exec_id}])
 
 
 # Pure trace-JSON logic, no CUDA needed. Pins the canonical annotation key

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -801,6 +801,100 @@ class TestIsAvailable(TestCase):
         self.assertEqual(is_available(), expected)
 
 
+# Host-side test of the graph-instantiate hook registry: consumers register hooks that a
+# CUDAGraph fans out to via run_graph_instantiate_hooks at the end of instantiate(). The
+# registry just passes the graph through, so a sentinel stands in for it. No CUDA needed.
+class TestGraphInstantiateHooks(TestCase):
+    def tearDown(self):
+        import torch.cuda.graphs as cg
+
+        cg._global_instantiate_hooks.clear()
+        super().tearDown()
+
+    def test_register_run_unregister(self):
+        import torch.cuda.graphs as cg
+
+        seen = []
+        graph = object()
+        handle = cg.register_graph_instantiate_hook(lambda g: seen.append(g))
+        cg.run_graph_instantiate_hooks(graph)
+        self.assertEqual(seen, [graph])
+        handle.remove()
+        cg.run_graph_instantiate_hooks(graph)  # unregistered: not called again
+        self.assertEqual(seen, [graph])
+
+    def test_multiple_hooks_all_run(self):
+        import torch.cuda.graphs as cg
+
+        seen_a, seen_b = [], []
+        cg.register_graph_instantiate_hook(lambda g: seen_a.append(g))
+        cg.register_graph_instantiate_hook(lambda g: seen_b.append(g))
+        graph = object()
+        cg.run_graph_instantiate_hooks(graph)
+        self.assertEqual((seen_a, seen_b), ([graph], [graph]))
+
+    def test_run_swallows_hook_errors(self):
+        import torch.cuda.graphs as cg
+
+        seen = []
+
+        def boom(g):
+            raise RuntimeError("boom")
+
+        cg.register_graph_instantiate_hook(boom)
+        cg.register_graph_instantiate_hook(lambda g: seen.append(g))
+        graph = object()
+        cg.run_graph_instantiate_hooks(graph)  # first raises, second still runs
+        self.assertEqual(seen, [graph])
+
+
+# Host-side test of the graph-destroy hook registry: consumers register per-resolver
+# cleanup hooks that a CUDAGraph invokes (gated on graph_destroy_hooks_active) via
+# run_graph_destroy_hooks when a CUDA graph is destroyed. No CUDA needed.
+class TestGraphDestroyHooks(TestCase):
+    def tearDown(self):
+        import torch.cuda.graphs as cg
+
+        cg._global_destroy_hooks.clear()
+        super().tearDown()
+
+    def test_register_run_unregister(self):
+        import torch.cuda.graphs as cg
+
+        seen = []
+        self.assertFalse(cg.graph_destroy_hooks_active())
+        handle = cg.register_graph_destroy_hook(lambda ids: seen.append(set(ids)))
+        self.assertTrue(cg.graph_destroy_hooks_active())
+        cg.run_graph_destroy_hooks({7})
+        self.assertEqual(seen, [{7}])
+        handle.remove()
+        self.assertFalse(cg.graph_destroy_hooks_active())
+        cg.run_graph_destroy_hooks({8})  # unregistered: not called again
+        self.assertEqual(seen, [{7}])
+
+    def test_multiple_hooks_all_run(self):
+        import torch.cuda.graphs as cg
+
+        seen_a, seen_b = [], []
+        cg.register_graph_destroy_hook(lambda ids: seen_a.append(set(ids)))
+        cg.register_graph_destroy_hook(lambda ids: seen_b.append(set(ids)))
+        cg.run_graph_destroy_hooks({5})
+        self.assertEqual((seen_a, seen_b), ([{5}], [{5}]))
+
+    def test_run_swallows_hook_errors(self):
+        import torch.cuda.graphs as cg
+
+        seen = []
+
+        def boom(ids):
+            raise RuntimeError("boom")
+
+        cg.register_graph_destroy_hook(boom)
+        cg.register_graph_destroy_hook(lambda ids: seen.append(set(ids)))
+        cg.run_graph_destroy_hooks({1})  # first raises, second still runs
+        self.assertEqual(seen, [{1}])
+
+
 # Pure trace-JSON logic, no CUDA needed. Pins the canonical annotation key
 # ("name") and reader tolerance for the two legacy pickle spellings: dicts
 # keyed "str" and bare unwrapped strings.

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -155,6 +155,69 @@ class _RetainedCallbacks:
         self.objects.clear()
 
 
+# Global CUDA-graph lifecycle hooks (the module-level counterpart of the per-graph
+# _post_instantiate_hooks). A consumer (e.g. a profiler observer) registers a hook that fires
+# for every graph, so the graph code stays free of consumer knowledge; registering a hook is
+# the opt-in. Keyed by RemovableHandle id. Instantiate hooks run at the end of instantiate()
+# with the freshly instantiated graph.
+_global_instantiate_hooks: OrderedDict[int, Callable[[CUDAGraph], None]] = OrderedDict()
+
+
+def register_graph_instantiate_hook(
+    fn: Callable[[CUDAGraph], None],
+) -> RemovableHandle:
+    """Register a hook run with each CUDA graph right after it is instantiated. Returns a
+    RemovableHandle; call ``.remove()`` to unregister."""
+    from torch.utils.hooks import RemovableHandle
+
+    handle = RemovableHandle(_global_instantiate_hooks)
+    _global_instantiate_hooks[handle.id] = fn
+    return handle
+
+
+def run_graph_instantiate_hooks(torch_cuda_graph: CUDAGraph) -> None:
+    """Run every registered instantiate hook with the graph. Errors are swallowed so one
+    consumer cannot break instantiate() for another."""
+    for fn in list(_global_instantiate_hooks.values()):
+        try:
+            fn(torch_cuda_graph)
+        except Exception:
+            pass
+
+
+# Graph-destroy hooks, each handed the destroyed graph's exec ids (tools_id >> 32) so a
+# consumer can purge its per-graph state. A CUDAGraph arms a single destroy callback (only
+# while a hook is registered, see graph_destroy_hooks_active) that fans out here.
+_global_destroy_hooks: OrderedDict[int, Callable[[set[int]], None]] = OrderedDict()
+
+
+def register_graph_destroy_hook(fn: Callable[[set[int]], None]) -> RemovableHandle:
+    """Register ``fn(exec_ids)`` to run when a CUDA graph is destroyed. Returns a handle whose
+    ``remove()`` unregisters it."""
+    from torch.utils.hooks import RemovableHandle
+
+    handle = RemovableHandle(_global_destroy_hooks)
+    _global_destroy_hooks[handle.id] = fn
+    return handle
+
+
+def graph_destroy_hooks_active() -> bool:
+    """True when any graph-destroy hook is registered -- the gate a CUDAGraph checks before
+    arming its destroy callback."""
+    return bool(_global_destroy_hooks)
+
+
+def run_graph_destroy_hooks(exec_graph_ids: set[int]) -> None:
+    """Invoke every registered hook with the destroyed exec graph ids, swallowing per-hook
+    errors so one failure does not abort the rest (matching the destroy-callback fire
+    semantics). The single entry point a graph's destroy callback calls."""
+    for fn in list(_global_destroy_hooks.values()):
+        try:
+            fn(exec_graph_ids)
+        except Exception:
+            pass
+
+
 # Python shim helps Sphinx process docstrings more reliably.
 class CUDAGraph(_CUDAGraph):
     r"""Wrapper around a CUDA graph.
@@ -194,6 +257,10 @@ class CUDAGraph(_CUDAGraph):
     # before the first remap. Lets a re-instantiate (which produces a fresh exec
     # id) rekey annotations from the previous exec id to the new one.
     _remapped_exec_id: int | None
+    # Exec graph ids a consumer has recorded per-graph state under (one per
+    # instantiate). Handed to the graph-destroy hooks on destruction so consumers
+    # can purge that state and their maps do not grow across the run.
+    _recorded_exec_ids: set[int]
     _keep_graph: bool
     # User hooks fired by capture_end / instantiate (see register_*_hook).
     _capture_end_hooks: dict[int, Callable[[CUDAGraph], None]]
@@ -213,6 +280,7 @@ class CUDAGraph(_CUDAGraph):
         instance._tracker = None
         instance._capture_graph_id = None
         instance._remapped_exec_id = None
+        instance._recorded_exec_ids = set()
         instance._keep_graph = keep_graph
         # OrderedDict (not dict): RemovableHandle weak-references the mapping.
         instance._capture_end_hooks = OrderedDict()
@@ -231,6 +299,16 @@ class CUDAGraph(_CUDAGraph):
         # stream off it without pinning the graph.
         self._retained = _RetainedCallbacks()
         self._retained_finalizer = weakref.finalize(self, self._retained.fire)
+        # When a consumer (e.g. the CUPTI monitor) has registered graph-destroy
+        # hooks, arm the per-graph state purge for this capture cycle. The callback
+        # captures the exec-id SET OBJECT (empty now, filled as this graph
+        # records/instantiates) and the module fan-out function, never self and never
+        # a hook: a closure reachable to the graph would pin it past collection so it
+        # never fires. reset() re-arms a fresh holder, so this re-registers per cycle;
+        # a graph that records nothing just fires on an empty set (a no-op).
+        if graph_destroy_hooks_active():
+            exec_ids = self._recorded_exec_ids
+            self.register_destroy_callback(lambda: run_graph_destroy_hooks(exec_ids))
 
     def register_capture_end_hook(
         self, hook: Callable[[CUDAGraph], None]
@@ -479,6 +557,9 @@ class CUDAGraph(_CUDAGraph):
         """
         super().instantiate()
         self._maybe_remap_annotations()
+        # Fire registered instantiate hooks (e.g. a profiler observer inspecting the freshly
+        # instantiated graph). Registering a hook is the opt-in; no consumer -> a no-op.
+        run_graph_instantiate_hooks(self)
         for hook in list(self._post_instantiate_hooks.values()):
             hook(self)
 
@@ -517,6 +598,9 @@ class CUDAGraph(_CUDAGraph):
         self._retained.fire()
         if self._retained_finalizer is not None:
             self._retained_finalizer.detach()
+        # Start a fresh id set BEFORE re-arming: _arm_retained captures it into the
+        # next cycle's destroy callback. The just-fired holder dropped the old one.
+        self._recorded_exec_ids = set()
         self._arm_retained()
         # Reset-only state: scrubbed here because the object is reused after
         # reset(); on death these ints die with the object.

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -453,6 +453,11 @@ class CUDAGraph(_CUDAGraph):
         from torch.cuda._graph_annotations import remap_to_exec_graph
 
         remap_to_exec_graph(self)
+        # Record the exec id we remapped to so the destroy callback (armed in
+        # capture_end_post) hands it to the graph-destroy hooks for per-graph state
+        # cleanup. A re-instantiate mints a fresh exec id, so the set accumulates each.
+        if self._remapped_exec_id is not None:
+            self._recorded_exec_ids.add(self._remapped_exec_id)
 
     def _release_python_resources(self) -> None:
         # Single source of truth for GC-critical Python resources released by

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -45,6 +45,11 @@ __all__ = [
     "make_graphed_callables",
     "export_dot",
     "export_graph_data",
+    "register_graph_instantiate_hook",
+    "run_graph_instantiate_hooks",
+    "register_graph_destroy_hook",
+    "run_graph_destroy_hooks",
+    "graph_destroy_hooks_active",
 ]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187898
* #188939
* #190851
* #190850
* __->__ #191299

Add module-level hook registries to torch.cuda.graphs so consumers (e.g. the CUPTI
profiler observer) can observe CUDA-graph lifecycle events without the graph code
carrying any consumer knowledge:

  - register_graph_instantiate_hook / run_graph_instantiate_hooks: fired at the end
    of CUDAGraph.instantiate() with the freshly instantiated graph.
  - register_graph_destroy_hook / run_graph_destroy_hooks / graph_destroy_hooks_active:
    a graph arms a single destroy callback (only while a hook is registered) that hands
    each hook the graph's recorded exec ids (_recorded_exec_ids, tools_id >> 32) so
    consumers can purge per-graph state.

These are the module-level counterpart of the existing per-graph _post_instantiate_hooks
and destroy callbacks: keyed by RemovableHandle id, error-swallowing, and they never
capture the graph so they stay finalizer-safe. Registering a hook is the opt-in; with no
consumer both are no-ops. Graph-node dependency recording and graph-node registry cleanup
build on these in later commits.

Test Plan:
  python test/test_cuda_graph_utils.py TestGraphInstantiateHooks TestGraphDestroyHooks

Authored with the assistance of an AI coding assistant.

cc @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng