### PR TITLE
Validate lu_solve pivots on all backends to prevent CUDA OOB

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2199,6 +2199,17 @@ TORCH_IMPL_FUNC(linalg_lu_solve_out)(const Tensor& LU,
                      LU.is_complex() ? TransposeType::ConjTranspose
                                      : TransposeType::Transpose;
 
+  // Validate pivots for all backends before dispatch: the LAPACK/cuSOLVER
+  // kernels read out of bounds for out-of-range pivots, which is a clean error
+  // on CPU but an illegal memory access on CUDA.
+  // See https://github.com/pytorch/pytorch/issues/189669
+  TORCH_CHECK(pivots.gt(0).all().item<bool>(),
+              "Pivots given to lu_solve must all be greater or equal to 1. "
+              "Did you properly pass the result of lu_factor?");
+  TORCH_CHECK(pivots.le(LU.size(-2)).all().item<bool>(),
+              "Pivots given to lu_solve must all be smaller or equal to LU.size(-2). "
+              "Did you properly pass the result of lu_factor?");
+
   lu_solve_stub(LU_->device().type(), *LU_, *pivots_, result, trans);
 
   // Conj-transpose back in-place

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -1097,14 +1097,7 @@ void apply_lu_solve(const Tensor& LU, const Tensor& pivots, const Tensor& B, Tra
 
 // This is a type dispatching helper function for 'apply_lu_solve'
 void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
-  // Lapack will write into unrelated memory if pivots are not in the right range so we do
-  // some simple sanity checks here for the CPU version
-  TORCH_CHECK(pivots.gt(0).all().item<bool>(),
-              "Pivots given to lu_solve must all be greater or equal to 1. "
-              "Did you properly pass the result of lu_factor?");
-  TORCH_CHECK(pivots.le(LU.size(-2)).all().item<bool>(),
-              "Pivots given to lu_solve must all be smaller or equal to LU.size(-2). "
-              "Did you properly pass the result of lu_factor?");
+  // Pivot range is validated in the device-agnostic linalg_lu_solve_out.
 
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(LU.scalar_type(), "linalg.lu_solve_cpu", [&]{
     apply_lu_solve<scalar_t>(LU, pivots, B, trans);

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -8534,6 +8534,22 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @skipCPUIfNoLapack
     @skipCUDAIfNoCusolver
+    @dtypes(torch.float64)
+    def test_lu_solve_invalid_pivots(self, device, dtype):
+        # Out-of-range pivots must raise a clear error on all backends rather
+        # than reading out of bounds (an illegal memory access on CUDA).
+        # Regression test for https://github.com/pytorch/pytorch/issues/189669
+        LU = torch.eye(3, dtype=dtype, device=device).unsqueeze(0)
+        B = torch.ones((1, 3, 3), dtype=dtype, device=device)
+        too_large = torch.full((1, 3), 2147480000, dtype=torch.int32, device=device)
+        with self.assertRaisesRegex(RuntimeError, "smaller or equal to"):
+            torch.linalg.lu_solve(LU, too_large, B)
+        too_small = torch.zeros((1, 3), dtype=torch.int32, device=device)
+        with self.assertRaisesRegex(RuntimeError, "greater or equal to 1"):
+            torch.linalg.lu_solve(LU, too_small, B)
+
+    @skipCPUIfNoLapack
+    @skipCUDAIfNoCusolver
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})


### PR DESCRIPTION
Fixes #189669

### Summary

`torch.linalg.lu_solve` with out-of-range pivot indices raised a clean `RuntimeError` on **CPU** but caused an **illegal memory access** on **CUDA**:

```python
LU  = torch.full((1, 3, 3), -1, dtype=torch.cdouble, device="cuda")
piv = torch.full((1, 3), 2147480000, dtype=torch.int32, device="cuda")
B   = torch.full((1, 3, 3), -1, dtype=torch.cdouble, device="cuda")
torch.linalg.lu_solve(LU, piv, B, left=False)   # before: cudaErrorIllegalAddress
```

### Root cause

The pivot range checks lived in `lu_solve_kernel` in `BatchLinearAlgebraKernel.cpp` — the **CPU-only** stub implementation (the comment even says "for the CPU version"). The CUDA path never ran them, so the LAPACK/cuSOLVER kernels indexed into the matrix with out-of-range pivots and read out of bounds.

### Fix

The checks (`pivots.gt(0).all()`, `pivots.le(LU.size(-2)).all()`) are device-agnostic tensor ops. Move them into the device-agnostic `linalg_lu_solve_out` (the sole caller of `lu_solve_stub`), so **both CPU and CUDA** validate before dispatch. Removed the now-redundant CPU-only copy.

This adds two small device syncs on the CUDA path; `lu_solve` already synchronizes, and turning an illegal memory access into a catchable error is a clear win.

### Test Plan

Added `test_lu_solve_invalid_pivots` (device-generic — runs on CPU and CUDA).

```
python test/test_linalg.py -k test_lu_solve_invalid_pivots
python test/test_linalg.py -k lu_solve
```

Verified on an **A100**: out-of-range and zero pivots now raise the same `RuntimeError` as CPU instead of crashing; valid `lu_solve` results are unchanged (48 existing `lu_solve` tests pass).

> This PR was authored with the assistance of an AI coding agent (Claude Code).
