### PR TITLE
Re-search allocator pool after release_cached_blocks to avoid spurious CUDA OOM (#189504)

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1791,7 +1791,17 @@ class DeviceCachingAllocator {
             // should be able to reclaim cached memory.
             || (C10_LIKELY(!is_capture_context()) &&
                 release_cached_blocks(context, {0, 0}) &&
-                alloc_block(params, true, context, lock));
+                // release_cached_blocks() runs synchronize_and_free_events(),
+                // which waits on pending stream events (e.g. from
+                // record_stream) and returns those blocks to the pool. A block
+                // large enough to satisfy this request may now be available in
+                // the pool even though a fresh cudaMalloc is still impossible
+                // (its segment is pinned by a live block and the device is
+                // full). Re-search the pool before attempting another
+                // cudaMalloc so we do not raise a spurious OOM on a request the
+                // pool can already satisfy. See pytorch/pytorch#189504.
+                (get_free_block(params) ||
+                 alloc_block(params, true, context, lock)));
       }
     }
 
@@ -3759,6 +3769,10 @@ class DeviceCachingAllocator {
       return false;
     p.block = *it;
     pool.erase_from_blocks(p.block);
+    // A pool hit is a successful allocation. Clear any stale error left by a
+    // prior failed alloc_block() in the same malloc() retry chain, so callers
+    // (e.g. alloc_found_block) see params.err == cudaSuccess. See #189504.
+    p.err = cudaSuccess;
     return true;
   }
 

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1821,7 +1821,17 @@ class DeviceCachingAllocator {
             // should be able to reclaim cached memory.
             || (C10_LIKELY(!is_capture_context()) &&
                 release_cached_blocks(context, {0, 0}) &&
-                alloc_block(params, true, context, lock));
+                // release_cached_blocks() runs synchronize_and_free_events(),
+                // which waits on pending stream events (e.g. from
+                // record_stream) and returns those blocks to the pool. A block
+                // large enough to satisfy this request may now be available in
+                // the pool even though a fresh cudaMalloc is still impossible
+                // (its segment is pinned by a live block and the device is
+                // full). Re-search the pool before attempting another
+                // cudaMalloc so we do not raise a spurious OOM on a request the
+                // pool can already satisfy. See pytorch/pytorch#189504.
+                (get_free_block(params) ||
+                 alloc_block(params, true, context, lock)));
       }
     }
 
@@ -3842,6 +3852,10 @@ class DeviceCachingAllocator {
       return false;
     p.block = *it;
     pool.erase_from_blocks(p.block);
+    // A pool hit is a successful allocation. Clear any stale error left by a
+    // prior failed alloc_block() in the same malloc() retry chain, so callers
+    // (e.g. alloc_found_block) see params.err == cudaSuccess. See #189504.
+    p.err = cudaSuccess;
     return true;
   }
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1867,6 +1867,73 @@ print(t.is_pinned())
         # cached blocks in case it affects future tests.
         torch.cuda.empty_cache()
 
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC or IS_JETSON,
+        "test exercises the native CUDACachingAllocator OOM-recovery ladder",
+    )
+    @serialTest()
+    def test_caching_allocator_oom_pending_free_in_pool(self):
+        """A large-enough block whose free is pending on a stream event (via
+        record_stream) is returned to the pool by release_cached_blocks() ->
+        synchronize_and_free_events() during OOM recovery. The allocator must
+        re-search the pool and reuse that block instead of raising OOM.
+        Regression test for https://github.com/pytorch/pytorch/issues/189504."""
+        gc.collect()
+        torch.cuda.empty_cache()
+        device = torch.device("cuda:0")
+        MiB = 1024 * 1024
+
+        def alloc(mib):
+            return torch.empty(mib * MiB, dtype=torch.uint8, device=device)
+
+        # Build one segment holding [small live pin | big block]: seed a 1228
+        # MiB segment, free it (segment stays cached), then carve a 100 MiB pin
+        # and a 1024 MiB block out of the same cached segment. The pin keeps the
+        # segment from being cudaFree'd for the rest of the test.
+        seg_seed = alloc(1228)
+        del seg_seed
+        pin = alloc(100)  # noqa: F841
+        big = alloc(1024)
+
+        # Exhaust the rest of the device so no fresh 1 GiB segment can be
+        # cudaMalloc'd. If the device is too small to even set this up, skip.
+        filler = []
+        try:
+            for chunk in (512, 128, 32):
+                while True:
+                    free_b, _ = torch.cuda.mem_get_info(device)
+                    if free_b < (chunk + 64) * MiB:
+                        break
+                    filler.append(alloc(chunk))
+            free_b, _ = torch.cuda.mem_get_info(device)
+            if free_b >= 1024 * MiB:
+                self.skipTest("could not fill device below a 1 GiB free segment")
+
+            # Make big's free PEND on a side stream: enqueue a long sleep,
+            # mark big as used by the stream, then free it. Until the GPU
+            # reaches the tail event, the block is neither live nor reusable.
+            sleep_ms = 2000
+            side = torch.cuda.Stream(device)
+            with torch.cuda.stream(side):
+                torch.cuda._sleep(int(sleep_ms * get_cycles_per_ms()))
+            big.record_stream(side)
+            del big
+
+            # Request an allocation only the pending block can satisfy. Before
+            # the fix this raised OutOfMemoryError even though the failing call
+            # itself blocks in synchronize_and_free_events and returns the block
+            # to the pool; after the fix the allocator re-searches the pool and
+            # succeeds.
+            c = alloc(1024)
+            self.assertEqual(c.numel(), 1024 * MiB)
+            del c
+        finally:
+            del filler
+            torch.cuda.synchronize()
+            gc.collect()
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats()
+
     # Tests for historic illegal memory access, see #17040.
     def test_reduction_gpu_memory_accessing(self):
         x = torch.ones(512, 8, dtype=torch.float32, device="cuda")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1872,6 +1872,73 @@ print(t.is_pinned())
         # cached blocks in case it affects future tests.
         torch.cuda.empty_cache()
 
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC or IS_JETSON,
+        "test exercises the native CUDACachingAllocator OOM-recovery ladder",
+    )
+    @serialTest()
+    def test_caching_allocator_oom_pending_free_in_pool(self):
+        """A large-enough block whose free is pending on a stream event (via
+        record_stream) is returned to the pool by release_cached_blocks() ->
+        synchronize_and_free_events() during OOM recovery. The allocator must
+        re-search the pool and reuse that block instead of raising OOM.
+        Regression test for https://github.com/pytorch/pytorch/issues/189504."""
+        gc.collect()
+        torch.cuda.empty_cache()
+        device = torch.device("cuda:0")
+        MiB = 1024 * 1024
+
+        def alloc(mib):
+            return torch.empty(mib * MiB, dtype=torch.uint8, device=device)
+
+        # Build one segment holding [small live pin | big block]: seed a 1228
+        # MiB segment, free it (segment stays cached), then carve a 100 MiB pin
+        # and a 1024 MiB block out of the same cached segment. The pin keeps the
+        # segment from being cudaFree'd for the rest of the test.
+        seg_seed = alloc(1228)
+        del seg_seed
+        pin = alloc(100)
+        big = alloc(1024)
+
+        # Exhaust the rest of the device so no fresh 1 GiB segment can be
+        # cudaMalloc'd. If the device is too small to even set this up, skip.
+        filler = []
+        try:
+            for chunk in (512, 128, 32):
+                while True:
+                    free_b, _ = torch.cuda.mem_get_info(device)
+                    if free_b < (chunk + 64) * MiB:
+                        break
+                    filler.append(alloc(chunk))
+            free_b, _ = torch.cuda.mem_get_info(device)
+            if free_b >= 1024 * MiB:
+                self.skipTest("could not fill device below a 1 GiB free segment")
+
+            # Make big's free PEND on a side stream: enqueue a long sleep,
+            # mark big as used by the stream, then free it. Until the GPU
+            # reaches the tail event, the block is neither live nor reusable.
+            sleep_ms = 2000
+            side = torch.cuda.Stream(device)
+            with torch.cuda.stream(side):
+                torch.cuda._sleep(int(sleep_ms * get_cycles_per_ms()))
+            big.record_stream(side)
+            del big
+
+            # Request an allocation only the pending block can satisfy. Before
+            # the fix this raised OutOfMemoryError even though the failing call
+            # itself blocks in synchronize_and_free_events and returns the block
+            # to the pool; after the fix the allocator re-searches the pool and
+            # succeeds.
+            c = alloc(1024)
+            self.assertEqual(c.numel(), 1024 * MiB)
+            del c
+        finally:
+            del filler
+            torch.cuda.synchronize()
+            gc.collect()
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats()
+
     # Tests for historic illegal memory access, see #17040.
     def test_reduction_gpu_memory_accessing(self):
         x = torch.ones(512, 8, dtype=torch.float32, device="cuda")


### PR DESCRIPTION
Fixes #189504

## Summary

`DeviceCachingAllocator::malloc` can raise `OutOfMemoryError` even when a large-enough block has just been returned to the pool by `release_cached_blocks()` → `synchronize_and_free_events()`. This happens when a block's free is *pending on a stream event* — for example a cross-stream `record_stream()` free — and the device is otherwise full.

In that state the allocator's retry chain, after the blocking event sync, only re-attempts a fresh `cudaMalloc` (`alloc_block`) and never re-searches the pool. So the failing call raises OOM, while an **identical retry issued immediately afterward from Python succeeds** — because the failed call already completed the pending free and its block now sits in the pool. That surprising "fails once, succeeds on immediate retry with no cleanup" behavior is the user-visible symptom in the issue.

## Fix

Two changes, both in `c10/cuda/CUDACachingAllocator.cpp`:

1. In the `malloc` retry chain, after `release_cached_blocks(context, {0,0})` (which runs `synchronize_and_free_events()` and returns pending-event blocks to the pool), re-run `get_free_block(params)` before the final `cudaMalloc`:

   ```cpp
   || (C10_LIKELY(!is_capture_context()) &&
       release_cached_blocks(context, {0, 0}) &&
       (get_free_block(params) ||
        alloc_block(params, true, context, lock)));
   ```

   The re-search is `||`-short-circuited with `alloc_block`, so we never double-allocate. It is kept inside the existing `C10_LIKELY(!is_capture_context())` guard, so behavior during CUDA-graph capture is unchanged.

2. Reset `params.err = cudaSuccess` on `get_free_block()`'s success (pool-hit) path. A prior failed `alloc_block()` in the same `malloc()` leaves `params.err == cudaErrorMemoryAllocation`; without this reset, a successful re-search trips `TORCH_INTERNAL_ASSERT(params.err == cudaSuccess)` in `alloc_found_block`. A pool hit is unambiguously a success, so clearing the stale error there is correct for all callers (at the earlier `get_free_block` call sites `params.err` is already `cudaSuccess`, so this is a no-op for them).

## Validation

Built and tested on an NVIDIA H20 (sm_90, CUDA 13.1), single GPU.

**Before/after with the reproducer from the issue (rebuilt for each):**

- **Baseline (fix reverted):** `OOM raised (the failing call blocked 4.4s in the allocator's event sync first)` → `immediate identical retry: SUCCESS in 0.000s` — bug reproduced.
- **With fix:** `no OOM after 4.3s -- bug NOT reproduced (allocator found the block)`.

**Regression test** added: `test/test_cuda.py::TestCuda::test_caching_allocator_oom_pending_free_in_pool` — reproduces the pending-free-in-pool case and asserts no spurious OOM. It passes with the fix. Sibling allocator tests `test_caching_allocator_record_stream_oom` and `test_caching_allocator_alloc_negative_size` also pass (no regression).

## Risks / notes for reviewers

- **The `params.err` reset was found only by running the code.** The initial one-line pool-retry looked correct on static review but hit the `alloc_found_block` assert at runtime because `get_free_block` sets `params.block` but not `params.err`. Reviewers should confirm they are comfortable with `get_free_block` mutating `params.err`; an alternative is to reset `params.err` at the malloc call site instead. I chose inside `get_free_block` because a pool hit is a success by definition.
- **Not tested with the async (`cudaMallocAsync`) allocator backend** or expandable segments — the change lives in the native `DeviceCachingAllocator` path; the async backend has its own allocator. Reviewers on `PYTORCH_CUDA_ALLOC_CONF=backend:cudaMallocAsync` should sanity-check.
- **Multi-GPU / MemPool interactions** were not exercised beyond the single-GPU repro and the existing allocator tests.
- The change was developed against commit 835c9cfc6b0; it matches the current retry-chain structure (`is_capture_context()` / `try_mempool_fallback`), not the older v2.12 snippet quoted in the issue.
- Build note (not part of the change): validated on a `USE_DISTRIBUTED=0` CUDA build; distributed was disabled only to speed the build and is unrelated to the allocator path.


