### PR TITLE
[TEST] Add hw_classification to test_op_coverage.py

### DIFF
--- a/test/distributed/tensor/debug/test_op_coverage.py
+++ b/test/distributed/tensor/debug/test_op_coverage.py
@@ -3,7 +3,11 @@
 import torch
 import torch.nn as nn
 from torch.distributed.tensor.debug._op_coverage import get_inductor_decomp_graphs
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class SimpleMLP(nn.Module):
@@ -18,6 +22,8 @@ class SimpleMLP(nn.Module):
 
 
 class TestOpCoverage(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_trace_with_inductor_decomp(self):
         model = SimpleMLP()
         args = (torch.randn(8, 50),)


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.GENERIC` to `TestOpCoverage` — 1 test that exercises FX graph tracing via `get_inductor_decomp_graphs`, pure framework logic with no device-specific code

## Test Plan

```
python test/distributed/tensor/debug/test_op_coverage.py -v --hw-classification GENERIC
HW classification mode active (['GENERIC']): total=1, passed=1, unclassified=0, mismatched=0
test_trace_with_inductor_decomp (__main__.TestOpCoverage) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.370s

OK
```

cc: @vishalgoyal316