### PR TITLE
[Testcase Refactoring] Split test_checkpoint_wrapper by hardware classification

### DIFF
--- a/test/distributed/fsdp/test_checkpoint_wrapper.py
+++ b/test/distributed/fsdp/test_checkpoint_wrapper.py
@@ -16,18 +16,22 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     OffloadWrapper,
 )
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
-from torch.testing._internal.common_fsdp import get_devtype
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.utils.checkpoint import checkpoint
 
 
 _SAVED_PREFIX = "_saved_"
 GRAD_FN_NEXT_FUNCTIONS = "next_functions"
 
-device_type = torch.device(get_devtype())
-
 
 class CheckpointWrapperTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_load_activation_checkpointed_module(self):
         lin = nn.Linear(10, 10, bias=False)
         lin = checkpoint_wrapper(
@@ -132,85 +136,6 @@ class CheckpointWrapperTest(TestCase):
         )
         m(torch.randn(2, 1)).sum().backward()
         self.assertEqual(2, count)
-
-    @unittest.skip
-    def test_checkpoint_wrapper_parity(self):
-        """
-        Tests that using checkpoint_wrapper or the functional
-        torch.utils.checkpoint (with the same reentrant config)
-        results in the same maximum memory usage, i.e. they are
-        equivalent memory usage wise.
-        """
-
-        class Model(nn.Module):
-            def __init__(
-                self,
-                n: int,
-                use_cp: bool,
-                use_wrapper: bool = False,
-                use_reentrant: bool = True,
-            ):
-                super().__init__()
-                self.layers = nn.ModuleList()
-                self.n = n
-                self.use_cp = use_cp
-                self.use_wrapper = use_wrapper
-                self.use_reentrant = use_reentrant
-                wrp = partial(
-                    checkpoint_wrapper,
-                    checkpoint_impl=(
-                        CheckpointImpl.REENTRANT
-                        if use_reentrant
-                        else CheckpointImpl.NO_REENTRANT
-                    ),
-                )
-                for _ in range(self.n):
-                    l = nn.Sequential(
-                        nn.Linear(256, 256), nn.Linear(256, 256), nn.Linear(256, 256)
-                    )
-                    use_checkpoint_wrapper = self.use_wrapper
-                    if use_checkpoint_wrapper:
-                        l = wrp(l)
-                    self.layers.append(l)
-
-            def forward(self, x):
-                for i in range(self.n):
-                    if self.use_wrapper or not self.use_cp:
-                        x = self.layers[i](x)
-                    else:
-                        x = checkpoint(
-                            self.layers[i], x, use_reentrant=self.use_reentrant
-                        )
-                return x
-
-        def test(use_checkpointing, use_wrapper, use_reentrant):
-            a = Model(
-                8,
-                use_checkpointing,
-                use_wrapper=use_wrapper,
-                use_reentrant=use_reentrant,
-            ).to(device_type.type)
-            x = torch.randn(10000, 256, requires_grad=True).to(device_type.type)
-            torch.get_device_module(device_type.type).reset_peak_memory_stats()
-            loss = a(x).sum()
-            loss.backward()
-            return torch.get_device_module(device_type.type).max_memory_allocated()
-
-        functional_no_reentrant = test(
-            use_checkpointing=True, use_wrapper=False, use_reentrant=False
-        )
-        wrapper_no_reentrant = test(
-            use_checkpointing=False, use_wrapper=True, use_reentrant=False
-        )
-        self.assertEqual(functional_no_reentrant, wrapper_no_reentrant)
-
-        functional_reentrant = test(
-            use_checkpointing=True, use_wrapper=False, use_reentrant=True
-        )
-        wrapper_reentrant = test(
-            use_checkpointing=False, use_wrapper=True, use_reentrant=True
-        )
-        self.assertEqual(functional_reentrant, wrapper_reentrant)
 
     def test_forward_missing_attributes(self):
         lin = nn.Linear(1, 1)
@@ -340,12 +265,95 @@ class CheckpointWrapperTest(TestCase):
                 fqn in state_dict, msg=lambda msg: f"{msg}\n{fqn} not in state_dict."
             )
 
-    def test_checkpoint_wrapper_cpu_offload(self):
+
+class CheckpointWrapperTestDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @unittest.skip
+    def test_checkpoint_wrapper_parity(self, device):
+        """
+        Tests that using checkpoint_wrapper or the functional
+        torch.utils.checkpoint (with the same reentrant config)
+        results in the same maximum memory usage, i.e. they are
+        equivalent memory usage wise.
+        """
+
+        class Model(nn.Module):
+            def __init__(
+                self,
+                n: int,
+                use_cp: bool,
+                use_wrapper: bool = False,
+                use_reentrant: bool = True,
+            ):
+                super().__init__()
+                self.layers = nn.ModuleList()
+                self.n = n
+                self.use_cp = use_cp
+                self.use_wrapper = use_wrapper
+                self.use_reentrant = use_reentrant
+                wrp = partial(
+                    checkpoint_wrapper,
+                    checkpoint_impl=(
+                        CheckpointImpl.REENTRANT
+                        if use_reentrant
+                        else CheckpointImpl.NO_REENTRANT
+                    ),
+                )
+                for _ in range(self.n):
+                    l = nn.Sequential(
+                        nn.Linear(256, 256), nn.Linear(256, 256), nn.Linear(256, 256)
+                    )
+                    use_checkpoint_wrapper = self.use_wrapper
+                    if use_checkpoint_wrapper:
+                        l = wrp(l)
+                    self.layers.append(l)
+
+            def forward(self, x):
+                for i in range(self.n):
+                    if self.use_wrapper or not self.use_cp:
+                        x = self.layers[i](x)
+                    else:
+                        x = checkpoint(
+                            self.layers[i], x, use_reentrant=self.use_reentrant
+                        )
+                return x
+
+        def test(use_checkpointing, use_wrapper, use_reentrant):
+            a = Model(
+                8,
+                use_checkpointing,
+                use_wrapper=use_wrapper,
+                use_reentrant=use_reentrant,
+            ).to(device)
+            x = torch.randn(10000, 256, requires_grad=True).to(device)
+            torch.get_device_module(device).reset_peak_memory_stats()
+            loss = a(x).sum()
+            loss.backward()
+            return torch.get_device_module(device).max_memory_allocated()
+
+        functional_no_reentrant = test(
+            use_checkpointing=True, use_wrapper=False, use_reentrant=False
+        )
+        wrapper_no_reentrant = test(
+            use_checkpointing=False, use_wrapper=True, use_reentrant=False
+        )
+        self.assertEqual(functional_no_reentrant, wrapper_no_reentrant)
+
+        functional_reentrant = test(
+            use_checkpointing=True, use_wrapper=False, use_reentrant=True
+        )
+        wrapper_reentrant = test(
+            use_checkpointing=False, use_wrapper=True, use_reentrant=True
+        )
+        self.assertEqual(functional_reentrant, wrapper_reentrant)
+
+    def test_checkpoint_wrapper_cpu_offload(self, device):
         model = nn.Sequential(
             nn.Linear(10, 10),
             nn.Linear(10, 10),
             nn.Linear(10, 10),
-        ).to(device_type.type)
+        ).to(device)
 
         # Patch saved_tensor_hooks to make the unpack keep the tensor on CPU for
         # testing, otherwise the tensor access during the DFS will cause orig
@@ -364,7 +372,7 @@ class CheckpointWrapperTest(TestCase):
 
         model = offload_wrapper(model)
 
-        inp = torch.randn(3, 10, device=device_type.type)
+        inp = torch.randn(3, 10, device=device)
         loss = model(inp).sum()
 
         # All autograd saved tensors should be offloaded to CPU.
@@ -391,8 +399,8 @@ class CheckpointWrapperTest(TestCase):
 
         torch.autograd.graph.saved_tensors_hooks.__init__ = orig_init
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
-    def test_checkpoint_wrapper_with_block_mask(self):
+    @unittest.skipIf(not torch.accelerator.is_available(), "requires accelerator")
+    def test_checkpoint_wrapper_with_block_mask(self, device):
         """Test that BlockMask can be passed through checkpoint_wrapper."""
         from torch.nn.attention.flex_attention import BlockMask, create_block_mask
         from torch.utils._pytree import register_pytree_node, SUPPORTED_NODES
@@ -414,11 +422,14 @@ class CheckpointWrapperTest(TestCase):
             def forward(self, x, mask):
                 return x * 2
 
-        model = checkpoint_wrapper(Block()).cuda()
-        x = torch.randn(4, 128, device="cuda")
+        model = checkpoint_wrapper(Block()).to(device)
+        x = torch.randn(4, 128, device=device)
         result = model(x, block_mask)
         self.assertEqual(result, x * 2)
 
 
+instantiate_device_type_tests(
+    CheckpointWrapperTestDevice, globals(), except_for=("cpu",), allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_checkpoint_wrapper.py
+++ b/test/distributed/fsdp/test_checkpoint_wrapper.py
@@ -1,7 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
 import contextlib
-import unittest
 from copy import deepcopy
 from functools import partial
 
@@ -16,18 +15,25 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     OffloadWrapper,
 )
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
-from torch.testing._internal.common_fsdp import get_devtype
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.utils.checkpoint import checkpoint
 
 
 _SAVED_PREFIX = "_saved_"
 GRAD_FN_NEXT_FUNCTIONS = "next_functions"
 
-device_type = torch.device(get_devtype())
-
 
 class CheckpointWrapperTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_load_activation_checkpointed_module(self):
         lin = nn.Linear(10, 10, bias=False)
         lin = checkpoint_wrapper(
@@ -132,85 +138,6 @@ class CheckpointWrapperTest(TestCase):
         )
         m(torch.randn(2, 1)).sum().backward()
         self.assertEqual(2, count)
-
-    @unittest.skip
-    def test_checkpoint_wrapper_parity(self):
-        """
-        Tests that using checkpoint_wrapper or the functional
-        torch.utils.checkpoint (with the same reentrant config)
-        results in the same maximum memory usage, i.e. they are
-        equivalent memory usage wise.
-        """
-
-        class Model(nn.Module):
-            def __init__(
-                self,
-                n: int,
-                use_cp: bool,
-                use_wrapper: bool = False,
-                use_reentrant: bool = True,
-            ):
-                super().__init__()
-                self.layers = nn.ModuleList()
-                self.n = n
-                self.use_cp = use_cp
-                self.use_wrapper = use_wrapper
-                self.use_reentrant = use_reentrant
-                wrp = partial(
-                    checkpoint_wrapper,
-                    checkpoint_impl=(
-                        CheckpointImpl.REENTRANT
-                        if use_reentrant
-                        else CheckpointImpl.NO_REENTRANT
-                    ),
-                )
-                for _ in range(self.n):
-                    l = nn.Sequential(
-                        nn.Linear(256, 256), nn.Linear(256, 256), nn.Linear(256, 256)
-                    )
-                    use_checkpoint_wrapper = self.use_wrapper
-                    if use_checkpoint_wrapper:
-                        l = wrp(l)
-                    self.layers.append(l)
-
-            def forward(self, x):
-                for i in range(self.n):
-                    if self.use_wrapper or not self.use_cp:
-                        x = self.layers[i](x)
-                    else:
-                        x = checkpoint(
-                            self.layers[i], x, use_reentrant=self.use_reentrant
-                        )
-                return x
-
-        def test(use_checkpointing, use_wrapper, use_reentrant):
-            a = Model(
-                8,
-                use_checkpointing,
-                use_wrapper=use_wrapper,
-                use_reentrant=use_reentrant,
-            ).to(device_type.type)
-            x = torch.randn(10000, 256, requires_grad=True).to(device_type.type)
-            torch.get_device_module(device_type.type).reset_peak_memory_stats()
-            loss = a(x).sum()
-            loss.backward()
-            return torch.get_device_module(device_type.type).max_memory_allocated()
-
-        functional_no_reentrant = test(
-            use_checkpointing=True, use_wrapper=False, use_reentrant=False
-        )
-        wrapper_no_reentrant = test(
-            use_checkpointing=False, use_wrapper=True, use_reentrant=False
-        )
-        self.assertEqual(functional_no_reentrant, wrapper_no_reentrant)
-
-        functional_reentrant = test(
-            use_checkpointing=True, use_wrapper=False, use_reentrant=True
-        )
-        wrapper_reentrant = test(
-            use_checkpointing=False, use_wrapper=True, use_reentrant=True
-        )
-        self.assertEqual(functional_reentrant, wrapper_reentrant)
 
     def test_forward_missing_attributes(self):
         lin = nn.Linear(1, 1)
@@ -340,12 +267,101 @@ class CheckpointWrapperTest(TestCase):
                 fqn in state_dict, msg=lambda msg: f"{msg}\n{fqn} not in state_dict."
             )
 
-    def test_checkpoint_wrapper_cpu_offload(self):
+
+class CheckpointWrapperTestDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    def test_checkpoint_wrapper_parity(self, device):
+        """
+        Tests that using checkpoint_wrapper or the functional
+        torch.utils.checkpoint (with the same reentrant config)
+        results in the same maximum memory usage, i.e. they are
+        equivalent memory usage wise.
+        """
+
+        class Model(nn.Module):
+            def __init__(
+                self,
+                n: int,
+                use_cp: bool,
+                use_wrapper: bool = False,
+                use_reentrant: bool = True,
+            ):
+                super().__init__()
+                self.layers = nn.ModuleList()
+                self.n = n
+                self.use_cp = use_cp
+                self.use_wrapper = use_wrapper
+                self.use_reentrant = use_reentrant
+                wrp = partial(
+                    checkpoint_wrapper,
+                    checkpoint_impl=(
+                        CheckpointImpl.REENTRANT
+                        if use_reentrant
+                        else CheckpointImpl.NO_REENTRANT
+                    ),
+                )
+                for _ in range(self.n):
+                    l = nn.Sequential(
+                        nn.Linear(256, 256), nn.Linear(256, 256), nn.Linear(256, 256)
+                    )
+                    use_checkpoint_wrapper = self.use_wrapper
+                    if use_checkpoint_wrapper:
+                        l = wrp(l)
+                    self.layers.append(l)
+
+            def forward(self, x):
+                for i in range(self.n):
+                    if self.use_wrapper or not self.use_cp:
+                        x = self.layers[i](x)
+                    else:
+                        x = checkpoint(
+                            self.layers[i], x, use_reentrant=self.use_reentrant
+                        )
+                return x
+
+        def test(use_checkpointing, use_wrapper, use_reentrant):
+            a = Model(
+                8,
+                use_checkpointing,
+                use_wrapper=use_wrapper,
+                use_reentrant=use_reentrant,
+            ).to(device)
+            x = torch.randn(10000, 256, requires_grad=True).to(device)
+            torch.accelerator.reset_peak_memory_stats(device)
+            loss = a(x).sum()
+            loss.backward()
+            return torch.accelerator.max_memory_allocated(device)
+
+        functional_no_reentrant = test(
+            use_checkpointing=True, use_wrapper=False, use_reentrant=False
+        )
+        wrapper_no_reentrant = test(
+            use_checkpointing=False, use_wrapper=True, use_reentrant=False
+        )
+        # Guard against vacuous passes: max_memory_allocated() returns 0 when
+        # the allocator is uninitialized, which would make the equality below
+        # trivially true.
+        self.assertGreater(functional_no_reentrant, 0)
+        self.assertEqual(functional_no_reentrant, wrapper_no_reentrant)
+
+        functional_reentrant = test(
+            use_checkpointing=True, use_wrapper=False, use_reentrant=True
+        )
+        wrapper_reentrant = test(
+            use_checkpointing=False, use_wrapper=True, use_reentrant=True
+        )
+        self.assertGreater(functional_reentrant, 0)
+        self.assertEqual(functional_reentrant, wrapper_reentrant)
+
+    @onlyAccelerator
+    def test_checkpoint_wrapper_cpu_offload(self, device):
         model = nn.Sequential(
             nn.Linear(10, 10),
             nn.Linear(10, 10),
             nn.Linear(10, 10),
-        ).to(device_type.type)
+        ).to(device)
 
         # Patch saved_tensor_hooks to make the unpack keep the tensor on CPU for
         # testing, otherwise the tensor access during the DFS will cause orig
@@ -364,7 +380,7 @@ class CheckpointWrapperTest(TestCase):
 
         model = offload_wrapper(model)
 
-        inp = torch.randn(3, 10, device=device_type.type)
+        inp = torch.randn(3, 10, device=device)
         loss = model(inp).sum()
 
         # All autograd saved tensors should be offloaded to CPU.
@@ -391,8 +407,8 @@ class CheckpointWrapperTest(TestCase):
 
         torch.autograd.graph.saved_tensors_hooks.__init__ = orig_init
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
-    def test_checkpoint_wrapper_with_block_mask(self):
+    @onlyAccelerator
+    def test_checkpoint_wrapper_with_block_mask(self, device):
         """Test that BlockMask can be passed through checkpoint_wrapper."""
         from torch.nn.attention.flex_attention import BlockMask, create_block_mask
         from torch.utils._pytree import register_pytree_node, SUPPORTED_NODES
@@ -407,18 +423,19 @@ class CheckpointWrapperTest(TestCase):
             )
 
         block_mask = create_block_mask(
-            lambda b, h, q, kv: q >= kv, B=1, H=1, Q_LEN=128, KV_LEN=128
+            lambda b, h, q, kv: q >= kv, B=1, H=1, Q_LEN=128, KV_LEN=128, device=device
         )
 
         class Block(nn.Module):
             def forward(self, x, mask):
                 return x * 2
 
-        model = checkpoint_wrapper(Block()).cuda()
-        x = torch.randn(4, 128, device="cuda")
+        model = checkpoint_wrapper(Block()).to(device)
+        x = torch.randn(4, 128, device=device)
         result = model(x, block_mask)
         self.assertEqual(result, x * 2)
 
 
+instantiate_device_type_tests(CheckpointWrapperTestDevice, globals(), allow_xpu=True)
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

This PR splits `test_checkpoint_wrapper.py` into a GENERIC pure-CPU class (`CheckpointWrapperTest`) and an ACCELERATOR device-dependent class (`CheckpointWrapperTestDevice`), labels both with `HardwareClassification`, and migrates the device-dependent tests to the `device` parameter injected by `instantiate_device_type_tests`. Review-feedback updates: `test_checkpoint_wrapper_parity` is un-skipped (its `@unittest.skip` is removed and it now runs and passes), its memory-stat calls use `torch.accelerator.*`, and `test_checkpoint_wrapper_with_block_mask` gets the standard `@onlyAccelerator` gate.

## Changes

- **`test/distributed/fsdp/test_checkpoint_wrapper.py`**:
  - Labeled `CheckpointWrapperTest` `hw_classification = HardwareClassification.GENERIC` (6 CPU-only checkpoint-wrapper logic methods: `test_load_activation_checkpointed_module`, `test_checkpoint_wrapper_kwarg_support`, `test_checkpoint_wrapper_args_kwargs`, `test_forward_missing_attributes`, `test_apply_activation_checkpointing`, `test_fqn` — all use unqualified CPU tensors, no accelerator dependency).
  - Extracted the 3 device-dependent methods (`test_checkpoint_wrapper_parity`, `test_checkpoint_wrapper_cpu_offload`, `test_checkpoint_wrapper_with_block_mask`) into a new `CheckpointWrapperTestDevice(TestCase)` labeled `hw_classification = HardwareClassification.ACCELERATOR`, instantiated via `instantiate_device_type_tests(..., except_for=("cpu",), allow_xpu=True)`.
  - Migrated all in-body device usage from the module-level `device_type = torch.device(get_devtype())` string to the injected `device` parameter: `.to(device_type.type)` → `.to(device)`, `randn(device=device_type.type)` → `randn(device=device)`, `torch.get_device_module(device_type.type)` → `torch.get_device_module(device)`. `CheckpointWrapperTestDevice` is a single-process `TestCase` (not `MultiProcessTestCase`), so bare indexed `device` is correct here (the type-only rule applies to multi-process per-rank classes only).
  - Decoupled `test_checkpoint_wrapper_with_block_mask` from hard-coded CUDA: `.cuda()` / `device="cuda"` use the injected `device`, and the old `@unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")` is replaced by the standard method-level `@onlyAccelerator` gate (review feedback).
  - Removed the `@unittest.skip` on `test_checkpoint_wrapper_parity` so the test actually runs (review feedback) — verified passing on an 8-device accelerator backend; it was an unconditional, reason-less skip in the original file.
  - `test_checkpoint_wrapper_parity` now calls `torch.accelerator.reset_peak_memory_stats()` / `torch.accelerator.max_memory_allocated()` instead of `torch.get_device_module(device).<api>()` (review feedback).
  - Removed the now-unused module-level `device_type` / `get_devtype` import (and the `unittest` import once the skip decorators are gone).

## Motivation

An unclassified `TestCase` is silently dropped when `--hw-classification GENERIC ACCELERATOR` is passed. `CheckpointWrapperTest` was a mixed class: 6 CPU-only methods alongside 3 device-dependent methods. A single class cannot be labeled correctly when its methods span two classifications, so the device-dependent methods are split into `CheckpointWrapperTestDevice`. The `except_for=("cpu",)` mechanism replaces the hard-coded `only_for=("cuda","hpu","xpu")` whitelist so any accelerator registered via `torch.accelerator` (including PrivateUse1-based out-of-tree backends) is admitted. The ACCELERATOR class is structured to align with the TEST_LINTER direction (PR #190173): instantiated, `device` param on every `test_*`, no `only_for`.

## Test Plan

Verified on an 8-device accelerator backend (the `HardwareClassification` infrastructure from #186918 and the `skip_if_lt_x_gpu` device-agnostic rewrite from #187650 are pre-applied on the verify host):

```bash
python test/distributed/fsdp/test_checkpoint_wrapper.py
# Ran 9 tests in 1.238s — OK (9 passed; includes the now-un-skipped
# test_checkpoint_wrapper_parity_npu and the flex-attention BlockMask test
# test_checkpoint_wrapper_with_block_mask_npu, both passing on-device)

python test/distributed/fsdp/test_checkpoint_wrapper.py --hw-classification GENERIC ACCELERATOR
# total=9, passed=9, unclassified=0, mismatched=0
```

`CheckpointWrapperTestDevice` runs on-device via the injected `device` param; `CheckpointWrapperTest` (GENERIC) runs on CPU. `lintrunner` reports no lint issues.

## Notes

- `except_for=("cpu",)` is kept (not dropped) on `CheckpointWrapperTestDevice` because `test_checkpoint_wrapper_cpu_offload` has no per-method guard and tests "offload to CPU" — if the CPU variant were generated, it would pass vacuously (model already on CPU, offload is a no-op, `saved.device == cpu` is trivially true). `except_for=("cpu",)` excludes the CPU variant to keep that test meaningful. The `@onlyAccelerator` on `test_checkpoint_wrapper_with_block_mask` is the method-level equivalent of this gate (defensive/semantic — it keeps the accelerator requirement explicit at the method level).
- This is part of the test case refactoring initiative tracked in #185590.
