### PR TITLE
[Test] Make test_device_context_semantics accelerator-agnostic in test_overrides.py

### DIFF
--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -1911,8 +1911,9 @@ class TestTorchFunctionMode(TestCase):
     def test_device_context_semantics(self):
         from torch._C import _len_torch_function_stack
         from torch.utils._device import DeviceContext
+        device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
         try:
-            torch.set_default_device("cuda")
+            torch.set_default_device(device_type)
 
             def get_stack():
                 return [torch._C._get_function_stack_at(i) for i in range(_len_torch_function_stack())]


### PR DESCRIPTION
Motivation
The test test_device_context_semantics in test/test_overrides.py hardcoded "cuda" as the default device via torch.set_default_device("cuda"). This causes the test to fail on non-CUDA environments (e.g., Ascend NPU, CPU-only builds) where CUDA is unavailable, even though the test logic itself is device-agnostic — it only verifies that DeviceContext is correctly pushed onto the __torch_function__ stack when the default device is changed.

**Work Done**
Two changes in test/test_overrides.py within test_device_context_semantics:

1- Added accelerator-aware device detection (line 1914)
This dynamically resolves the available accelerator type (e.g., "npu", "cuda", etc.) via torch.accelerator.current_accelerator(), falling back to "cpu" if no accelerator is present.
2- Replaced hardcoded "cuda" with device_type (line 1916)

**Impact**
The test now runs correctly on any hardware backend (CUDA, NPU, CPU-only).
No functional change to test semantics — the assertion logic (verifying DeviceContext stack behavior) remains identical.