### PR TITLE
[Inductor] reject epilogue fusion if blocks_unfused <= 0 (#191311)

### DIFF
--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -14,7 +14,9 @@ from torch._dynamo.utils import counters
 from torch._inductor.dependencies import Dep, MemoryDep, ReadWrites
 from torch._inductor.ir import GraphPartitionSignature
 from torch._inductor.loop_body import MemoryEntry, MemoryUsageType
+from torch._inductor.runtime.hints import DeviceProperties
 from torch._inductor.scheduler import (
+    _fuse_epilogue,
     _get_benchmarkable_extern_fn,
     BaseSchedulerNode,
     ExternKernelSchedulerNode,
@@ -198,6 +200,28 @@ class TestScheduler(TestCase):
 
         self.assertEqual(
             groups, [[pool_node1, pool_node2], [default_node], [other_pool_node]]
+        )
+
+    def test_fuse_epilogue_rejects_zero_unfused_occupancy(self):
+        device_props = DeviceProperties(
+            type="hip",
+            index=0,
+            multi_processor_count=1,
+            cc=0,
+            regs_per_multiprocessor=65536,
+            warp_size=32,
+        )
+
+        self.assertFalse(
+            _fuse_epilogue(
+                ms1=0.1,
+                ms2=0.3,
+                unfused_n_regs=1024,
+                fused_n_regs=1024,
+                fused_n_spills=0,
+                num_warps=4,
+                device_props=device_props,
+            )
         )
 
     def test_snode_args_kwargs_removes_filled_positional_kwargs(self):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3907,6 +3907,10 @@ def _fuse_epilogue(
         unfused_n_regs, fused_n_regs, fused_n_spills, num_warps, device_props
     )
 
+    # Reject fusion when the occupancy ratio is undefined.
+    if blocks_unfused <= 0:
+        return False
+
     epilogue_dominated_with_sufficient_occupancy = ms2 > 2 * ms1 and blocks_fused > 1
 
     # fuse if no major register spills


### PR DESCRIPTION
Summary:

We observed `ZeroDivisionError` in some offline ads training models when blocks_unfused == 0. This happens in the code when estimate occupancy ratio for fusions with `blocks_fused / blocks_unfused`

`blocks_unfused` is calculated with floor division which can end up becoming 0 in some cases

Adding extra guard here to return early if we detect the value is 0

Test Plan:
```
arc f fbcode/caffe2/torch/_inductor/scheduler.py xplat/caffe2/torch/_inductor/scheduler.py fbcode/caffe2/test/inductor/test_inductor_scheduler.py xplat/caffe2/test/inductor/test_inductor_scheduler.py fbcode/caffe2/test/inductor/test_max_autotune.py xplat/caffe2/test/inductor/test_max_autotune.py
arc lint fbcode/caffe2/torch/_inductor/scheduler.py xplat/caffe2/torch/_inductor/scheduler.py fbcode/caffe2/test/inductor/test_inductor_scheduler.py xplat/caffe2/test/inductor/test_inductor_scheduler.py fbcode/caffe2/test/inductor/test_max_autotune.py xplat/caffe2/test/inductor/test_max_autotune.py
```

```
buck2 test --test-executor-stdout=- --test-executor-stderr=- fbcode//caffe2/test/inductor:inductor_scheduler -- test_fuse_epilogue_rejects_zero_unfused_occupancy
```

Differential Revision: D112582639


