### PR TITLE
[Testcase Refactoring] Decouple test_symm_mem_registry.py from CUDA-specific

### DIFF
--- a/test/inductor/test_symm_mem_registry.py
+++ b/test/inductor/test_symm_mem_registry.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import torch
 from torch._library.simple_registry import singleton, SymmMemArgsHolder
 from torch.library import Library  # noqa: SCOPED_LIBRARY
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
 
@@ -239,7 +240,7 @@ class TestFunctionalOpCompile(TestCase):
         super().tearDown()
 
     @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA and Triton")
-    def test_functional_op_compiles_with_symm_mem_args(self):
+    def test_functional_op_compiles_with_symm_mem_args(self, device):
         """Test that a functional op with registered symm_mem_args compiles and runs."""
         lib = Library("test_func_symm", "DEF")  # noqa: SCOPED_LIBRARY
         lib.define("my_functional_op(Tensor input, str group_name) -> Tensor")
@@ -260,7 +261,7 @@ class TestFunctionalOpCompile(TestCase):
         def f_compiled(x):
             return torch.ops.test_func_symm.my_functional_op(x, "test_group")
 
-        x = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
 
         eager_result = f_eager(x.clone())
         compiled_result = f_compiled(x.clone())
@@ -276,7 +277,7 @@ class TestFunctionalOpCompile(TestCase):
         self.assertFalse(entry.symm_mem_args.is_symm_mem_arg("group_name"))
 
     @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA and Triton")
-    def test_functional_op_with_multiple_symm_mem_args(self):
+    def test_functional_op_with_multiple_symm_mem_args(self, device):
         """Test that multiple symm_mem args are registered and visible during compilation."""
         lib = Library("test_func_multi", "DEF")  # noqa: SCOPED_LIBRARY
         lib.define(
@@ -300,8 +301,8 @@ class TestFunctionalOpCompile(TestCase):
         def f_compiled(x, y):
             return torch.ops.test_func_multi.my_multi_arg_op(x, y, "test_group")
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         eager_result = f_eager(x.clone(), y.clone())
         compiled_result = f_compiled(x.clone(), y.clone())
@@ -400,6 +401,12 @@ class TestFunctionalOpCompile(TestCase):
         self.assertIn("SYMM_MEM", realize_log[0][0])
         self.assertEqual(realize_log[0][1], "test_group")
 
+
+instantiate_device_type_tests(
+    TestFunctionalOpCompile,
+    globals(),
+    except_for="cpu",
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
##  Summary
This PR Use the function parameter (device) instead of the hard-coded "cuda".

This is a step toward making inductor tests device-agnostic for out-of-tree backends.

## Changes

-  Added `instantiate_device_type_tests(TestFunctionalOpCompile, globals(),  except_for="cpu",)` in `test_symm_mem_registry.py`
-  Use the function parameter (device) instead of the hard-coded "cuda".


## Motivation
After `HAS_CUDA_AND_TRITON` is decoupled, see https://github.com/pytorch/pytorch/issues/189138.
The instantiate_device_type_tests function can be added to generate subclasses for each available device type of `TestFunctionalOpCompile`, thereby supporting multiple accelerators.

## Test Plan
CI: python test/inductor/test_symm_mem_registry.py
Verified locally that the `device` parameter can be correctly generalized.

## Notes
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo