### PR TITLE
[DO NOT MERGE] Test CRCR L3 availability towards intra-repo contribution

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -46,6 +46,7 @@ L2:
   - TorchedHat/pytorch-redhat-ci
   - Ascend/pytorch
   - torch-spyre/torch-spyre
+  - abc/def
 
 L3:
   # Canonical test repos for CRCR.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #191313

