### PR TITLE
rename the functions to follow a specific naming convention

### DIFF
--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -3,7 +3,7 @@ Dynamo implementations of CPython's PyObject_* default slot algorithms.
 
 Analogous to CPython's Objects/object.c, this module holds the general
 dispatch machinery that is independent of any specific type.
-Per-type hook implementations (bool_impl, richcompare_impl, getattro_impl,
+Per-type hook implementations (bool_impl, tp_richcompare_impl, tp_getattro_impl,
 etc.) live in their respective VT files.
 """
 
@@ -141,7 +141,7 @@ def type_implements_mp_slot(obj_type: type, slot: int) -> bool:
 
 # PySequenceSlots
 type_implements_sq_item = partial(type_implements_sq_slot, slot=PySequenceSlots.SQ_ITEM)
-type_implements_sq_length = partial(
+type_implements_sq_length_impl = partial(
     type_implements_sq_slot, slot=PySequenceSlots.SQ_LENGTH
 )
 type_implements_sq_concat = partial(
@@ -150,7 +150,7 @@ type_implements_sq_concat = partial(
 type_implements_sq_inplace_concat = partial(
     type_implements_sq_slot, slot=PySequenceSlots.SQ_INPLACE_CONCAT
 )
-type_implements_sq_contains = partial(
+type_implements_sq_contains_impl = partial(
     type_implements_sq_slot, slot=PySequenceSlots.SQ_CONTAINS
 )
 type_implements_sq_ass_item = partial(
@@ -165,7 +165,7 @@ type_implements_sq_inplace_repeat = partial(
 )
 
 # PyMappingSlots
-type_implements_mp_length = partial(
+type_implements_mp_length_implh = partial(
     type_implements_mp_slot, slot=PyMappingSlots.MP_LENGTH
 )
 type_implements_mp_subscript = partial(
@@ -173,9 +173,6 @@ type_implements_mp_subscript = partial(
 )
 type_implements_mp_ass_subscript = partial(
     type_implements_mp_slot, slot=PyMappingSlots.MP_ASS_SUBSCRIPT
-)
-type_implements_mp_length = partial(
-    type_implements_mp_slot, slot=PyMappingSlots.MP_LENGTH
 )
 
 
@@ -350,10 +347,10 @@ def pymapping_size(
     tx: "InstructionTranslatorBase", obj: "VariableTracker"
 ) -> "VariableTracker":
     # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/abstract.c#L2308-L2330
-    if obj.tp_as_mapping.mp_length:
-        return obj.mp_length(tx)
+    if obj.tp_as_mapping.mp_length_impl:
+        return obj.mp_length_impl(tx)
 
-    if obj.tp_as_sequence.sq_length is not None:
+    if obj.tp_as_sequence.sq_length_impl is not None:
         raise_type_error(tx, f"{obj.python_type_name()} is not a mapping")
 
     raise_type_error(tx, f"object of type {obj.python_type_name()} has no len()")
@@ -365,11 +362,11 @@ def generic_size(
     # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/abstract.c#L53-L69
     """
     Implements PyObject_Size/PyObject_Length semantics for VariableTracker objects.
-    Dispatches to sq_length (sequences) or mp_length (mappings) depending on the VT type.
+    Dispatches to sq_length_impl (sequences) or mp_length_impl (mappings) depending on the VT type.
     """
 
-    if obj.tp_as_sequence.sq_length:
-        return obj.sq_length(tx)
+    if obj.tp_as_sequence.sq_length_impl:
+        return obj.sq_length_impl(tx)
     return pymapping_size(tx, obj)
 
 
@@ -380,7 +377,7 @@ def generic_is_true(
 
     https://github.com/python/cpython/blob/c09ccd9c429/Objects/object.c#L2135-L2158
 
-    Resolution order: constants → nb_bool → mp_length/sq_length → truthy.
+    Resolution order: constants → nb_bool → mp_length_impl/sq_length_impl → truthy.
     """
     from .constant import ConstantVariable
 
@@ -391,7 +388,7 @@ def generic_is_true(
             raise_observed_exception(type(e), tx, args=[str(e)])
 
     if obj.tp_as_number.nb_bool:
-        result = obj.bool_impl(tx)
+        result = obj.nb_bool_impl(tx)
         if result is not None:
             return result
 
@@ -435,7 +432,7 @@ def generic_repr(
             return ConstantVariable.create(sentinel.get(obj_type, "..."))
         _repr_running.add(obj_id)
         try:
-            result = obj.repr_impl(tx)
+            result = obj.tp_repr_impl(tx)
         finally:
             _repr_running.discard(obj_id)
         result_type = maybe_get_python_type(result)
@@ -456,7 +453,7 @@ def generic_str(
 
     https://github.com/python/cpython/blob/v3.13.3/Objects/object.c#L781-L829
 
-    Resolution order: str identity check -> tp_str (str_impl) -> tp_repr fallback.
+    Resolution order: str identity check -> tp_str (tp_str_impl) -> tp_repr fallback.
     """
     from ..exc import TorchDynamoException
 
@@ -464,8 +461,8 @@ def generic_str(
         return obj
 
     try:
-        if obj.tp_str and type(obj).str_impl is not VariableTracker.str_impl:
-            result = obj.str_impl(tx)
+        if obj.tp_str and type(obj).tp_str_impl is not VariableTracker.tp_str_impl:
+            result = obj.tp_str_impl(tx)
         else:
             result = generic_repr(tx, obj)
     except TorchDynamoException:
@@ -535,7 +532,7 @@ def pysequence_getitem(
     ref: https://github.com/python/cpython/blob/v3.13.3/Objects/abstract.c#L1874-L1902
 
     Called by PyObject_GetItem branch 2, reversed() fallback, and the old
-    iteration protocol.  Wraps negative indices via sq_length before
+    iteration protocol.  Wraps negative indices via sq_length_impl before
     dispatching to sq_item.
     """
     sq_item = obj.tp_as_sequence.sq_item
@@ -544,8 +541,8 @@ def pysequence_getitem(
         if isinstance(index, ConstantVariable):
             index_val = index.as_python_constant()
             if isinstance(index_val, int) and index_val < 0:
-                if obj.tp_as_sequence.sq_length is not None:
-                    length = obj.sq_length(tx)
+                if obj.tp_as_sequence.sq_length_impl is not None:
+                    length = obj.sq_length_impl(tx)
                     index = ConstantVariable.create(
                         index_val + length.as_python_constant()
                     )
@@ -570,8 +567,8 @@ def pysequence_setitem(
         if isinstance(i, ConstantVariable):
             index_val = i.as_python_constant()
             if isinstance(index_val, int) and index_val < 0:
-                if s.tp_as_sequence.sq_length is not None:
-                    length = s.sq_length(tx)
+                if s.tp_as_sequence.sq_length_impl is not None:
+                    length = s.sq_length_impl(tx)
                     i = ConstantVariable.create(index_val + length.as_python_constant())
         return s.sq_ass_item_impl(tx, i, o)
 
@@ -619,8 +616,8 @@ def pysequence_delitem(
         if isinstance(i, ConstantVariable):
             idx = i.as_python_constant()
             if idx < 0:
-                if s.tp_as_sequence.sq_length is not None:
-                    length = s.sq_length(tx)
+                if s.tp_as_sequence.sq_length_impl is not None:
+                    length = s.sq_length_impl(tx)
                     i = pynumber_add(tx, i, length)
         return s.sq_ass_item_impl(tx, i, None)
 
@@ -1610,29 +1607,29 @@ def slot_wrapper_iadd(
 #
 # Dynamo implementation:
 #
-#   richcompare_impl(self, tx, other, op) -- per-VT slot, analogous to
+#   tp_richcompare_impl(self, tx, other, op) -- per-VT slot, analogous to
 #     tp_richcompare.  Returns ConstantVariable(NotImplemented) when the
 #     type does not handle the comparison.
 #
 #   generic_richcompare(tx, lhs, rhs, op) -- analogous to do_richcompare.
-#     Implements the 4-step algorithm directly using richcompare_impl
+#     Implements the 4-step algorithm directly using tp_richcompare_impl
 #     slots.  If a user comparison method graph-breaks, the Unsupported
 #     exception propagates to COMPARE_OP (which has
 #     @break_graph_if_unsupported) and runs the comparison eagerly.
-#     UDOV.richcompare_impl disables nested graph breaks on the resolved
+#     UDOV.tp_richcompare_impl disables nested graph breaks on the resolved
 #     funcvar so the InliningInstructionTranslator does not try to split
 #     the inlined user method mid-function.
 #
-# Two entry points converge on richcompare_impl:
+# Two entry points converge on tp_richcompare_impl:
 #
 #   COMPARE_OP (a == b):
 #     -> BuiltinVariable dispatch -> generic_richcompare
-#       -> richcompare_impl (4-step: subclass priority, forward, reflected, fallback)
+#       -> tp_richcompare_impl (4-step: subclass priority, forward, reflected, fallback)
 #
 #   call_method("__eq__") (a.__eq__(b) in user code):
-#     -> base.py call_method -> richcompare_impl directly
+#     -> base.py call_method -> tp_richcompare_impl directly
 #
-# The call_method path calls richcompare_impl directly (not
+# The call_method path calls tp_richcompare_impl directly (not
 # generic_richcompare) to match CPython semantics: a.__eq__(b) invokes
 # the type's tp_richcompare slot without do_richcompare's reflected-
 # operand protocol, and may return NotImplemented.
@@ -1664,7 +1661,7 @@ def object_richcompare(
         # https://github.com/python/cpython/blob/e76aa128fe/Objects/typeobject.c#L6279-L6298
         # Safe to call as_python_constant(): only identity-based types use
         # object_richcompare, so eq_result is always True or NotImplemented.
-        eq_result = self.richcompare_impl(tx, other, "__eq__")
+        eq_result = self.tp_richcompare_impl(tx, other, "__eq__")
         if is_richcompare_not_implemented(eq_result):
             return eq_result
         return ConstantVariable.create(not eq_result.as_python_constant())
@@ -1672,7 +1669,7 @@ def object_richcompare(
         return ConstantVariable.create(NotImplemented)
 
 
-def python_constant_richcompare_impl(
+def python_constant_tp_richcompare_impl(
     self: VariableTracker,
     tx: "InstructionTranslatorBase",
     other: VariableTracker,
@@ -1720,9 +1717,9 @@ def generic_richcompare(
 
     https://github.com/python/cpython/blob/e76aa128fe/Objects/object.c#L994-L1039
 
-    Implements the 4-step algorithm directly using richcompare_impl slots.
+    Implements the 4-step algorithm directly using tp_richcompare_impl slots.
     Graph breaks inside user comparison methods propagate to COMPARE_OP
-    (which runs eagerly) because UDOV.richcompare_impl disables nested
+    (which runs eagerly) because UDOV.tp_richcompare_impl disables nested
     graph breaks on the resolved funcvar.
     """
     reflected = _REFLECTED_OP[op]
@@ -1746,18 +1743,18 @@ def generic_richcompare(
         and issubclass(w_type, v_type)
     ):
         checked_reverse = True
-        result = w.richcompare_impl(tx, v, reflected)
+        result = w.tp_richcompare_impl(tx, v, reflected)
         if not is_richcompare_not_implemented(result):
             return result
 
     # Step 2: forward
-    result = v.richcompare_impl(tx, w, op)
+    result = v.tp_richcompare_impl(tx, w, op)
     if not is_richcompare_not_implemented(result):
         return result
 
     # Step 3: reflected (if not already tried)
     if not checked_reverse:
-        result = w.richcompare_impl(tx, v, reflected)
+        result = w.tp_richcompare_impl(tx, v, reflected)
         if not is_richcompare_not_implemented(result):
             return result
 
@@ -1842,13 +1839,13 @@ def pysequence_contains(
     """
     Implements PySequence_Contains semantics for VariableTracker objects.
 
-    If the object has sq_contains (i.e., __contains__), calls obj.sq_contains(tx, item).
+    If the object has sq_contains_impl (i.e., __contains__), calls obj.sq_contains_impl(tx, item).
     Otherwise falls back to iterating over obj and comparing each element.
     """
     # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/abstract.c#L2272-L2283
-    sq_contains = obj.tp_as_sequence.sq_contains
-    if sq_contains is not None:
-        return obj.sq_contains(tx, item)
+    sq_contains_impl = obj.tp_as_sequence.sq_contains_impl
+    if sq_contains_impl is not None:
+        return obj.sq_contains_impl(tx, item)
     else:
         # iter fallback handles both __iter__ and __getitem__ sequence protocol cases
         it = generic_getiter(tx, obj)
@@ -1984,16 +1981,16 @@ def generic_issubclass(
 #
 # Dispatch path:
 #     LOAD_ATTR / getattr() -> GetAttrBuiltinVariable -> generic_getattr
-#         -> obj.getattro_impl(tx, name)
+#         -> obj.tp_getattro_impl(tx, name)
 #
-# The base VariableTracker.getattro_impl tries object_generic_getattr()
+# The base VariableTracker.tp_getattro_impl tries object_generic_getattr()
 # first (MRO walk + descriptor protocol), falling back to const_getattr
 # on _UnhandledDescriptorError.  Callers of object_generic_getattr
 # directly must handle _UnhandledDescriptorError at every step (2, 4,
 # and 7), not just for unrecognized descriptor types.
 #
 # VTs with custom tp_getattro (TensorVariable, NNModuleVariable,
-# UserDefinedClassVariable, SuperVariable) override getattro_impl.
+# UserDefinedClassVariable, SuperVariable) override tp_getattro_impl.
 
 _NO_DEFAULT = object()
 
@@ -2184,7 +2181,7 @@ def generic_getattr(
     """Dynamo's PyObject_GetAttr: attribute access dispatch.
 
     Checks side effects for pending attribute mutations, then dispatches
-    to obj.getattro_impl(tx, name).  On NotImplementedError, falls back
+    to obj.tp_getattro_impl(tx, name).  On NotImplementedError, falls back
     to GetAttrVariable (deferred resolution).
     """
     from .user_defined import is_data_descriptor
@@ -2218,17 +2215,17 @@ def generic_getattr(
             return default  # type: ignore[return-value]
 
     # tp_getset/tp_members are data descriptors: resolve ahead of the VT's
-    # tp_getattro so a getattro_impl override need not repeat the consult.
+    # tp_getattro so a tp_getattro_impl override need not repeat the consult.
     getset = obj.lookup_tp_getset_member(name)
     if getset is not None:
         result = getset.getter(obj, tx)
         if result is not None:
             return result
 
-    # Core dispatch: call the VT's getattro_impl (tp_getattro).
+    # Core dispatch: call the VT's tp_getattro_impl (tp_getattro).
     source = obj.source and AttrSource(obj.source, name)
     try:
-        return obj.getattro_impl(tx, name)
+        return obj.tp_getattro_impl(tx, name)
     except AsPythonConstantNotImplementedError:
         raise
     except NotImplementedError:


### PR DESCRIPTION
fix #190841
enhancement

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98