### PR TITLE
Fix SIGFPE from zero head counts in attention ops

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
@@ -306,7 +306,7 @@ _scaled_dot_product_fused_attention_overrideable_xpu(
       query.size(3) == key.size(3),
       "scaled_dot_product_fused_attention_overrideable_xpu: Q/K should have the same head_dim");
   TORCH_INTERNAL_ASSERT(
-      query.size(1) % key.size(1) == 0,
+      key.size(1) > 0 && query.size(1) % key.size(1) == 0,
       "scaled_dot_product_fused_attention_overrideable_xpu: number of heads in K/V must divide number of heads in Q");
   TORCH_INTERNAL_ASSERT(
       dropout_p == 0.0,

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -247,7 +247,7 @@ std::tuple<Tensor, Tensor, Tensor> transform_bias_rescale_qkv_cpu(
   auto T = qkv_->size(1);
   auto _3D = qkv_->size(2);
   auto D = _3D / 3;
-  TORCH_CHECK(D % num_head == 0);
+  TORCH_CHECK(num_head > 0 && D % num_head == 0, "`embed_dim` must divide evenly by `num_heads`");
   TORCH_CHECK(_3D % 3 == 0);
   const auto dim_per_head = D / num_head;
   auto q_k_v = at::empty({3, B, num_head, T, dim_per_head}, qkv_->options());
@@ -332,7 +332,7 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cpu(
   TORCH_CHECK(
       qkv_bias.sizes()[0] == 3 * D,
       "expected `qkv_bias` first dim and first dim of query to be equal");
-  TORCH_CHECK(D % num_head == 0, "`embed_dim` must divide evenly by `num_heads`");
+  TORCH_CHECK(num_head > 0 && D % num_head == 0, "`embed_dim` must divide evenly by `num_heads`");
 
 #ifndef NDEBUG
   const auto B = query.is_nested()
@@ -666,10 +666,15 @@ std::tuple<at::Tensor, at::Tensor> pre_process_group_query_attention_input(
   const auto v_num_heads = value.sym_size(-3);
 
   bool all_equal = q_num_heads == k_num_heads && k_num_heads == v_num_heads;
-  bool key_divisible = q_num_heads % k_num_heads == 0;
-  bool value_divisible = q_num_heads % v_num_heads == 0;
+  // A zero key/value head count divides nothing, so it has to be rejected before
+  // the divisibility math below, which would otherwise be integer division by
+  // zero (SIGFPE) rather than a catchable error.
+  bool kv_num_heads_nonzero = k_num_heads > 0 && v_num_heads > 0;
+  bool key_divisible = kv_num_heads_nonzero && q_num_heads % k_num_heads == 0;
+  bool value_divisible = kv_num_heads_nonzero && q_num_heads % v_num_heads == 0;
   TORCH_CHECK(all_equal || (key_divisible && value_divisible),
-              "Number of heads in key and value must divide the number of heads in ");
+              "Number of heads in key and value must divide the number of heads in query, but got ",
+              q_num_heads, " query heads, ", k_num_heads, " key heads and ", v_num_heads, " value heads.");
 
   if (all_equal){
     return std::make_tuple(key, value);
@@ -954,6 +959,11 @@ _scaled_dot_product_flash_attention_cpu(
     "scaled_dot_product_attention_flash_attention: Currently do not support dropout > 0");
   TORCH_CHECK((query.size(3) == value.size(3)) && (key.size(3) == value.size(3)),
     "scaled_dot_product_attention_flash_attention: Q/K/V should have the same head size");
+  // A zero head count would be integer division by zero (SIGFPE) in the kernel's
+  // query-head grouping.
+  TORCH_CHECK(key.size(1) > 0 && value.size(1) > 0,
+    "scaled_dot_product_attention_flash_attention: K/V should have a nonzero number of heads, but got ",
+    key.size(1), " key heads and ", value.size(1), " value heads");
   TORCH_CHECK(!attn_mask.has_value() ||
           attn_mask.value().scalar_type() == at::kFloat ||
           dtype == attn_mask.value().scalar_type(),
@@ -991,6 +1001,11 @@ _scaled_dot_product_flash_attention_cpu_backward(
   if (!grad_out.defined()) {
     return std::make_tuple(Tensor{}, Tensor{}, Tensor{});
   }
+  // A zero head count would be integer division by zero (SIGFPE) in the kernel's
+  // query-head grouping.
+  TORCH_CHECK(key.size(1) > 0 && value.size(1) > 0,
+    "scaled_dot_product_attention_flash_attention_backward: K/V should have a nonzero number of heads, but got ",
+    key.size(1), " key heads and ", value.size(1), " value heads");
   auto grad_out_t = grad_out.transpose(1, 2);
   auto q_t = query.transpose(1, 2);
   auto k_t = key.transpose(1, 2);

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -524,6 +524,12 @@ _flash_attention_forward_impl(
       cumulative_sequence_length_q.has_value() ==
           cumulative_sequence_length_k.has_value(),
       "cumulative_sequence_length_q and cumulative_sequence_length_k must be both set or both not set");
+  // Both paths lay key/value out as (..., num_heads, head_dim). A zero head count
+  // would be integer division by zero (SIGFPE) in the kernel's query-head grouping.
+  TORCH_CHECK(
+      key.size(-2) > 0 && value.size(-2) > 0,
+      "Key and Value must have a nonzero number of heads, but got ",
+      key.size(-2), " key heads and ", value.size(-2), " value heads");
   Tensor output, q_padded, k_padded, v_padded, logsumexp, output_shape,
       philox_seed, philox_offset, debug_attn_mask;
   if (cumulative_sequence_length_q.has_value()) {
@@ -631,7 +637,7 @@ __host__ std::tuple<Tensor, Tensor, Tensor> transform_bias_rescale_qkv_cuda(
   }
   auto _3D = qkv_bias.size(0);
   auto D = _3D / 3;
-  TORCH_CHECK(D % num_head == 0);
+  TORCH_CHECK(num_head > 0 && D % num_head == 0, "`embed_dim` must divide evenly by `num_heads`");
   const auto dim_per_head = D / num_head;
   auto q_k_v = at::empty({3, B, num_head, T, dim_per_head}, qkv_bias.options());
 #define CALL_KERNEL(assume_aligned)                                        \
@@ -775,7 +781,7 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cuda(
   TORCH_CHECK(
       qkv_bias.sizes()[0] == 3 * D,
       "expected `qkv_bias` first dim and first dim of query to be equal");
-  TORCH_CHECK(D % num_head == 0, "`embed_dim` must divide evenly by `num_heads`");
+  TORCH_CHECK(num_head > 0 && D % num_head == 0, "`embed_dim` must divide evenly by `num_heads`");
 
 #ifndef NDEBUG
   const auto B = query.is_nested()

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -118,6 +118,12 @@ std::tuple<Tensor, Tensor, Tensor> _flash_attention_backward(
     std::optional<int64_t> window_size_left,
     std::optional<int64_t> window_size_right) {
 #if defined(USE_FLASH_ATTENTION)
+  // key/value are (batch, seq_len, num_heads, head_dim) here. A zero head count
+  // would be integer division by zero (SIGFPE) in the kernel's query-head grouping.
+  TORCH_CHECK(
+      key.size(-2) > 0 && value.size(-2) > 0,
+      "Key and Value must have a nonzero number of heads, but got ",
+      key.size(-2), " key heads and ", value.size(-2), " value heads");
   const auto softmax_scale = sdp::calculate_scale(query, scale).expect_float();
   //  CUDA code assumes that dout is contiguous
   auto contiguous_grad_out = grad_out.contiguous();

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -374,6 +374,23 @@ inline bool check_grouped_query_attention(sdp_params const& params, bool debug) 
     }
     return false;
   }
+  // A zero key/value head count divides nothing, so it has to be rejected before
+  // the divisibility check below, which would otherwise be integer division by
+  // zero (SIGFPE).
+  if (k_num_heads == 0 || v_num_heads == 0) {
+    if (debug) {
+      TORCH_WARN(
+          "Both fused kernels require key and value to have a nonzero num_heads.",
+          "Got input Key sizes(): ",
+          params.key.sym_size(-3),
+          ", Value sizes(): ",
+          params.value.sym_size(-3),
+          ", Query sizes(): ",
+          params.query.sym_size(-3),
+          " instead.");
+    }
+    return false;
+  }
   // Check if grouped query attention is supported and validate the number of
   // heads
   if (q_num_heads % k_num_heads != 0 || (!requires_same_num_heads && (q_num_heads % v_num_heads != 0))) {

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1598,6 +1598,23 @@ class TestTransformers(NNTestCase):
 
         torch.jit.script(mha)
 
+    def test_multi_head_attention_zero_num_head(self, device):
+        # num_head is a plain argument, and dividing the embedding dim by it used
+        # to abort the process with SIGFPE rather than raise for num_head=0.
+        embed_dim = 16
+        make_tensor = partial(torch.rand, device=device, dtype=torch.float32)
+        qkv = make_tensor((2, 8, 3 * embed_dim))
+        qkv_bias = make_tensor((3 * embed_dim,))
+        with self.assertRaises(RuntimeError):
+            torch.ops.aten._transform_bias_rescale_qkv(qkv, qkv_bias, 0)
+
+        x = make_tensor((2, 8, embed_dim))
+        proj_weight, proj_bias = make_tensor((embed_dim, embed_dim)), make_tensor((embed_dim,))
+        with self.assertRaisesRegex(RuntimeError, "must divide evenly"):
+            torch.ops.aten._native_multi_head_attention(
+                x, x, x, embed_dim, 0, make_tensor((3 * embed_dim, embed_dim)), qkv_bias,
+                proj_weight, proj_bias, None, False, True, None)
+
     @unittest.skipIf(TEST_WITH_CROSSREF, 'Fastpath not available with crossref')
     @torch.no_grad()
     def test_disable_fastpath(self, device):
@@ -1895,6 +1912,35 @@ class TestSDPAFailureModes(NNTestCase):
                                            "key and value to have"):
                     F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0,
                                                    is_causal=False, enable_gqa=False)
+
+    @parametrize("key_heads", [0, 3])
+    def test_invalid_gqa_key_heads(self, device, key_heads):
+        # A zero key head count divides nothing, and used to reach an unguarded
+        # `q_num_heads % k_num_heads` that aborted the process with SIGFPE
+        # instead of raising. key_heads=3 is the ordinary non-divisible case.
+        make_tensor = partial(torch.rand, device=device, dtype=torch.float32)
+        q = make_tensor(SdpaShape(2, 4, 8, 16))
+        k = make_tensor(SdpaShape(2, key_heads, 8, 16))
+        v = make_tensor(SdpaShape(2, 4, 8, 16))
+        with self.assertRaisesRegex(RuntimeError, "must divide the number of heads in query"):
+            F.scaled_dot_product_attention(q, k, v, enable_gqa=True)
+
+    def test_gqa_empty_inputs_are_not_rejected(self, device):
+        # Rejecting zero key/value head counts must not reject shapes that are
+        # merely empty: all-zero head counts, and an empty key/value sequence.
+        make_tensor = partial(torch.rand, device=device, dtype=torch.float32)
+        empty_heads = make_tensor(SdpaShape(2, 0, 8, 16))
+        out = F.scaled_dot_product_attention(empty_heads, empty_heads, empty_heads, enable_gqa=True)
+        self.assertEqual(out.shape, torch.Size([2, 0, 8, 16]))
+
+        q = make_tensor(SdpaShape(2, 4, 8, 16))
+        empty_seq = make_tensor(SdpaShape(2, 4, 0, 16))
+        out = F.scaled_dot_product_attention(q, empty_seq, empty_seq, enable_gqa=True)
+        self.assertEqual(out, torch.zeros_like(out))
+
+        kv = make_tensor(SdpaShape(2, 2, 8, 16))
+        out = F.scaled_dot_product_attention(make_tensor(SdpaShape(2, 8, 8, 16)), kv, kv, enable_gqa=True)
+        self.assertEqual(out.shape, torch.Size([2, 8, 8, 16]))
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not flash_attention fused scaled dot product attention")
@@ -2526,6 +2572,20 @@ class TestSDPA(NNTestCase):
 
 class TestSDPACpuOnly(NNTestCase):
     """ Used to test CPU only functionality of scaled_dot_product_attention """
+
+    def test_flash_attention_for_cpu_zero_kv_heads(self, device):
+        # The ops are reachable directly, so they need their own guard: the kernel
+        # divides the query head count by the key/value head count.
+        make_tensor = partial(torch.rand, device=device, dtype=torch.float32)
+        q = make_tensor(SdpaShape(2, 4, 8, 16))
+        kv = make_tensor(SdpaShape(2, 0, 8, 16))
+        with self.assertRaisesRegex(RuntimeError, "nonzero number of heads"):
+            torch.ops.aten._scaled_dot_product_flash_attention_for_cpu(q, kv, kv)
+
+        logsumexp = make_tensor((2, 8, 4))
+        with self.assertRaisesRegex(RuntimeError, "nonzero number of heads"):
+            torch.ops.aten._scaled_dot_product_flash_attention_for_cpu_backward(
+                q, q, kv, kv, q, logsumexp, 0.0, False)
 
     @parametrize("type", ["dense", "nested"])
     @parametrize("dropout", [0.0, 0.7])
@@ -4382,6 +4442,47 @@ class TestSDPACudaOnly(NNTestCase):
         if TEST_WITH_ROCM:
             atol = 9e-4 if dtype == torch.float16 else 9e-3
         self.assertEqual(qkv.grad, qkv_lp.grad.to(torch.float64), atol=atol, rtol=rtol)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Platform does not support fused SDPA")
+    @parametrize("kv_heads", [(0, 0), (0, 4), (4, 0)])
+    def test_fused_kernel_eligibility_zero_kv_heads(self, device, kv_heads):
+        # Backend eligibility divides the query head count by the key/value head
+        # count, so a zero count used to abort the process with SIGFPE instead of
+        # reporting the backend as unusable.
+        key_heads, value_heads = kv_heads
+        make_tensor = partial(torch.rand, device=device, dtype=torch.float16)
+        q = make_tensor(SdpaShape(2, 4, 8, 16))
+        k = make_tensor(SdpaShape(2, key_heads, 8, 16))
+        v = make_tensor(SdpaShape(2, value_heads, 8, 16))
+        params = torch.backends.cuda.SDPAParams(q, k, v, None, 0.0, False, True)
+        self.assertFalse(torch.backends.cuda.can_use_flash_attention(params, False))
+        self.assertFalse(torch.backends.cuda.can_use_efficient_attention(params, False))
+        self.assertFalse(torch.backends.cuda.can_use_cudnn_attention(params, False))
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Platform does not support flash attention")
+    def test_flash_attention_zero_kv_heads(self, device):
+        # The ops are reachable directly, so they need their own guard: the kernel
+        # divides the query head count by the key/value head count.
+        make_tensor = partial(torch.rand, device=device, dtype=torch.float16)
+        with self.assertRaisesRegex(RuntimeError, "nonzero number of heads"):
+            torch.ops.aten._scaled_dot_product_flash_attention(
+                make_tensor(SdpaShape(2, 4, 8, 16)), make_tensor(SdpaShape(2, 0, 8, 16)),
+                make_tensor(SdpaShape(2, 0, 8, 16)))
+
+        # _flash_attention_forward takes (batch, seq_len, num_heads, head_dim) instead
+        with self.assertRaisesRegex(RuntimeError, "nonzero number of heads"):
+            torch.ops.aten._flash_attention_forward(
+                make_tensor((2, 8, 4, 16)), make_tensor((2, 8, 0, 16)), make_tensor((2, 8, 0, 16)),
+                None, None, 8, 8, 0.0, False, False)
+
+        q = make_tensor(SdpaShape(2, 4, 8, 16))
+        kv = make_tensor(SdpaShape(2, 0, 8, 16))
+        logsumexp = torch.rand(2, 4, 8, device=device)
+        philox = torch.zeros((), device=device, dtype=torch.int64)
+        cum_seq = torch.empty(0, device=device, dtype=torch.int32)
+        with self.assertRaisesRegex(RuntimeError, "nonzero number of heads"):
+            torch.ops.aten._scaled_dot_product_flash_attention_backward(
+                q, q, kv, kv, q, logsumexp, cum_seq, cum_seq, 8, 8, 0.0, False, philox, philox)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Platform does not support fused SDPA")
     @parametrize("type", ["dense", "nested"])


### PR DESCRIPTION
Several attention ops divide by a head count without checking that the divisor is nonzero. Integer division by zero raises SIGFPE, so instead of a catchable error these inputs abort the process, and nothing in Python can catch it:

```python
import torch
import torch.nn.functional as F

q = torch.randn(2, 4, 8, 16)
k = torch.randn(2, 0, 8, 16)   # zero key heads
v = torch.randn(2, 4, 8, 16)
F.scaled_dot_product_attention(q, k, v, enable_gqa=True)
# Floating point exception (core dumped)
```

Fixes #128690.

Fixes #141218 — the fuzzer reproducer in that issue stopped crashing once `scaled_dot_product_attention` grew its empty-output early return (which fires on `value.numel() == 0`), but every path where the key alone has zero heads still reached the unguarded modulus.

### Root cause

Two flavors of the same mistake.

The GQA/MQA paths compute `q_num_heads % k_num_heads` to decide whether the key/value heads divide the query heads. A zero head count divides nothing, but the modulus is evaluated before anything rejects it — including inside the `TORCH_CHECK`/`TORCH_WARN` conditions that were meant to report the invalid grouping, so the check that should have produced the error traps instead.

Separately, the native-MHA fast path computes `D % num_head`, where `num_head` is a plain integer argument, so `num_head=0` traps the same way.

### The fix

Each divisor is guarded before it is used. Where the result is a boolean eligibility answer, a zero head count now reports the backend as unusable; where it is an error check, the condition is strengthened so the intended error is raised instead of trapping; and where the divide happens inside the kernel, the op boundary validates first.

Suggested review order:

1. `sdp_utils_cpp.h` — backend eligibility, shared by CPU, CUDA and XPU selection and by the public `torch.backends.cuda.can_use_*_attention` APIs.
2. `transformers/attention.cpp` — the math GQA preprocess (including the truncated error message it was trying to raise), the CPU flash op boundaries, and the native-MHA head-count checks.
3. `cuda/attention.cu` and `cuda/attention_backward.cu` — CUDA flash op boundaries, placed in `_flash_attention_forward_impl` and `_flash_attention_backward` so one guard covers every op routed through them on both CUDA and ROCm.
4. `mkldnn/xpu/Attention.cpp` — the same one-line guard on the XPU override.

Only zero divisors are rejected. Inputs that are merely empty behave as before: all-zero head counts, zero key/value sequence lengths and zero-length queries still return their empty or zeroed outputs, and ordinary GQA/MQA is untouched.

Two alternatives I considered and rejected. Validating centrally in `validate_sdpa_input` is smaller but insufficient: the fused eligibility checks and the private flash ops are reachable directly (that is how several of these sites crash), and a central head-count check would also change the error raised for ordinary non-GQA head mismatches. Guarding inside `flash_api.cpp`, where the modulus literally sits, was rejected because that file and its five HIP mirrors are vendored kernel wrappers; the aten-level entry points cover CUDA and ROCm from one place.

The guard in `_flash_attention_backward` is defensive rather than a demonstrated crash fix: `cum_seq_q` is a non-optional `Tensor` in the schema, so a Python caller always takes the varlen path and gets "batch size must be positive" before the modulus, and the dense path is only reachable from C++ callers that pass an undefined `cum_seq` (autograd does, but its forward now rejects the input first). I kept it for symmetry with the forward guard and for those callers — happy to drop it if you would rather every line have a reproducer behind it.

Not addressed here: `_scaled_dot_product_flash_attention_for_cpu` also traps on a zero *sequence* length with valid head counts. That is a different divisor and reproduces on released 2.7.1, so I left it for a separate change rather than widen this one.

### Testing

A SIGFPE cannot be caught in-process, so each site was confirmed by running one case per subprocess and checking the exit code: 136 (128+SIGFPE) before, 0 with a `RuntimeError` after. Confirmed that way: the math GQA path (CPU and CUDA, forward, backward and under `torch.compile`), `can_use_flash_attention` and `can_use_cudnn_attention`, `_scaled_dot_product_flash_attention`, `_flash_attention_forward`, `_scaled_dot_product_flash_attention_for_cpu` and its backward, `_transform_bias_rescale_qkv`, and `_native_multi_head_attention`. The reproducers filed in both issues were run verbatim.

Inputs the guards must *not* act on were checked and are unchanged: zero sequence lengths through the flash ops, all-zero head counts, GQA 8/2, MQA 8/1, equal head counts, and the `nn.MultiheadAttention` fast path. The CPU flash op still matches the math reference and produces finite gradients for both MHA and GQA head counts. The meta and FakeTensor paths raise cleanly rather than trapping.

Dynamic shapes are unaffected: `dynamic=True` and a dynamic head dim both match eager. Unbacked head counts (from `.item()`) cannot be traced through GQA either way — with the new check satisfied via `torch._check`, the pre-existing divisibility guard one line later blocks the same input, so this adds no new specialization.

```
python test/test_transformers.py
python test/test_native_mha.py
python test/nn/test_multihead_attention.py
python test/export/test_export.py -k sdpa
```

`test/test_transformers.py` is 15979 tests with no failures attributable to this change. New tests are in `test/test_transformers.py`: `test_invalid_gqa_key_heads` and `test_gqa_empty_inputs_are_not_rejected` (device-generic), `test_fused_kernel_eligibility_zero_kv_heads` and `test_flash_attention_zero_kv_heads` (CUDA), `test_flash_attention_for_cpu_zero_kv_heads` (CPU), and `test_multi_head_attention_zero_num_head`.

Run on CPU and CUDA (RTX 3080, sm_86, CUDA 12.6). The XPU one-liner is compile-checked only — I have no XPU device — and the ROCm mirrors are covered by the shared aten-level guards but were not run locally.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01