### PR TITLE
[Test] Add hw_classification and reorganize tests in test_view_ops/test_tensor_iterator

### DIFF
--- a/test/test_maskedtensor.py
+++ b/test/test_maskedtensor.py
@@ -2,7 +2,6 @@
 
 import torch
 from torch.testing._internal.common_utils import (
-    HardwareClassification,
     TestCase,
     run_tests,
     make_tensor,
@@ -117,8 +116,6 @@ def _fix_fn_name(fn_name):
 
 
 class TestBasics(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
-
     def test_invalid_tensor_inputs(self, device):
         data = torch.randn((3, 4), device=device)
         mask = _create_random_mask((3, 4), device=device)
@@ -429,8 +426,6 @@ class TestBasics(TestCase):
         self.assertEqual(now_contiguous_mt.is_contiguous(), True)
 
 class TestUnary(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     def _get_test_data(self, fn_name):
         data = torch.randn(10, 10)
         mask = torch.rand(10, 10) > 0.5
@@ -494,8 +489,6 @@ class TestUnary(TestCase):
         _compare_mt_t(mt_result, t_result)
 
 class TestBinary(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     def _get_test_data(self, fn_name):
         fn_name = _fix_fn_name(fn_name)
         data0 = torch.randn(10, 10)
@@ -572,8 +565,6 @@ class TestBinary(TestCase):
                 raise AssertionError(f"unexpected error message: {e}") from None
 
 class TestReductions(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     def test_max_not_implemented(self):
         d = torch.tensor([[0, 1, 2], [3, 4, 5.0]])
         m = torch.tensor([[True, False, False], [False, True, False]])
@@ -895,8 +886,6 @@ MASKEDTENSOR_FLOAT_TYPES = {
 }
 
 class TestOperators(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
-
     def _convert_mt_args(self, args, mask, layout):
         return [
             masked_tensor(

--- a/test/test_maskedtensor.py
+++ b/test/test_maskedtensor.py
@@ -2,6 +2,7 @@
 
 import torch
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     TestCase,
     run_tests,
     make_tensor,
@@ -116,6 +117,8 @@ def _fix_fn_name(fn_name):
 
 
 class TestBasics(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_invalid_tensor_inputs(self, device):
         data = torch.randn((3, 4), device=device)
         mask = _create_random_mask((3, 4), device=device)
@@ -426,6 +429,8 @@ class TestBasics(TestCase):
         self.assertEqual(now_contiguous_mt.is_contiguous(), True)
 
 class TestUnary(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _get_test_data(self, fn_name):
         data = torch.randn(10, 10)
         mask = torch.rand(10, 10) > 0.5
@@ -489,6 +494,8 @@ class TestUnary(TestCase):
         _compare_mt_t(mt_result, t_result)
 
 class TestBinary(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _get_test_data(self, fn_name):
         fn_name = _fix_fn_name(fn_name)
         data0 = torch.randn(10, 10)
@@ -565,6 +572,8 @@ class TestBinary(TestCase):
                 raise AssertionError(f"unexpected error message: {e}") from None
 
 class TestReductions(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_max_not_implemented(self):
         d = torch.tensor([[0, 1, 2], [3, 4, 5.0]])
         m = torch.tensor([[True, False, False], [False, True, False]])
@@ -886,6 +895,8 @@ MASKEDTENSOR_FLOAT_TYPES = {
 }
 
 class TestOperators(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _convert_mt_args(self, args, mask, layout):
         return [
             masked_tensor(

--- a/test/test_tensor_iterator.py
+++ b/test/test_tensor_iterator.py
@@ -17,11 +17,18 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
 )
-from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
 
 class TestTensorIteratorBuild(TestCase):
     """Build-pipeline tests that don't depend on a particular device type."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_lifetime_owns_operands(self):
         # Core claim: the iterator wraps operands with the *owning*
@@ -143,6 +150,8 @@ class TestTensorIteratorBuild(TestCase):
 
 
 class TestTensorIterator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @parametrize(
         "shape_a,shape_b,expected",
         [

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -12,7 +12,6 @@ from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfMPS,
     instantiate_device_type_tests,
-    onlyCPU,
     skipLazy,
     skipMeta,
     skipMPS,
@@ -30,6 +29,7 @@ from torch.testing._internal.common_dtype import (
 from torch.testing._internal.common_utils import (
     gradcheck,
     gradgradcheck,
+    HardwareClassification,
     IS_FBCODE,
     numpy_to_torch_dtype_dict,
     run_tests,
@@ -95,6 +95,7 @@ def _make_tensor(shape, dtype, device, fill_ones=False) -> torch.Tensor:
 # Tests ops and indexing to ensure they return views (and new tensors) as
 # appropriate.
 class TestViewOps(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
     exact_dtype = True
 
     def is_view_of(self, base, other):
@@ -1139,6 +1140,35 @@ class TestViewOps(TestCase):
 
 
 class TestOldViewOps(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    @skipIfTorchDynamo("conj bit not implemented in TensorVariable yet")
+    def test_conj_neg_view_numpy_error(self):
+        self.assertRaisesRegex(
+            RuntimeError,
+            "has conjugate bit set",
+            lambda: torch.tensor([1 + 2j]).conj().numpy(),
+        )
+        self.assertRaisesRegex(
+            RuntimeError,
+            "has negative bit set",
+            lambda: torch.tensor([1 + 2j]).conj().imag.numpy(),
+        )
+        self.assertRaisesRegex(
+            RuntimeError,
+            "not supported for conjugate view tensors",
+            lambda: torch.tensor([1 + 2j]).conj().view(torch.float64),
+        )
+        self.assertRaisesRegex(
+            RuntimeError,
+            "not supported for tensors with negative bit set",
+            lambda: torch.tensor([1 + 2j]).conj().imag.view(torch.int32),
+        )
+
+
+class TestOldViewOpsDeviceType(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @skipXPUIf(
         True,
         "NotImplementedError with test_ravel, https://github.com/intel/torch-xpu-ops/issues/2358",
@@ -2129,30 +2159,6 @@ class TestOldViewOps(TestCase):
             x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)
             self.assertEqual(x.view(6).shape, [6])
 
-    @skipIfTorchDynamo("conj bit not implemented in TensorVariable yet")
-    @onlyCPU
-    def test_conj_neg_view_numpy_error(self, device):
-        self.assertRaisesRegex(
-            RuntimeError,
-            "has conjugate bit set",
-            lambda: torch.tensor([1 + 2j]).conj().numpy(),
-        )
-        self.assertRaisesRegex(
-            RuntimeError,
-            "has negative bit set",
-            lambda: torch.tensor([1 + 2j]).conj().imag.numpy(),
-        )
-        self.assertRaisesRegex(
-            RuntimeError,
-            "not supported for conjugate view tensors",
-            lambda: torch.tensor([1 + 2j]).conj().view(torch.float64),
-        )
-        self.assertRaisesRegex(
-            RuntimeError,
-            "not supported for tensors with negative bit set",
-            lambda: torch.tensor([1 + 2j]).conj().imag.view(torch.int32),
-        )
-
     def test_crow_col_indices(self, device):
         crow_indices = (0, 1, 2)
         col_indices = (1, 0)
@@ -2170,7 +2176,7 @@ class TestOldViewOps(TestCase):
 instantiate_device_type_tests(
     TestViewOps, globals(), include_lazy=True, allow_mps=True, allow_xpu=True
 )
-instantiate_device_type_tests(TestOldViewOps, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestOldViewOpsDeviceType, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Adds `hw_classification` annotations to test classes and aligning test methods with their hardware classification.

## Changes

- **test_view_ops.py**:
  - Add `hw_classification = HardwareClassification.ACCELERATOR` to `TestViewOps`.
  - Rename `TestOldViewOps` → `TestOldViewOpsDeviceType` (`ACCELERATOR`).
  - Create `TestOldViewOps` (`GENERIC`) and move `test_conj_neg_view_numpy_error` out of the device-parameterized class, removing unnecessary `@onlyCPU`.
- **test_tensor_iterator.py**:
  - Add `hw_classification = HardwareClassification.GENERIC` to `TestTensorIteratorBuild`.
  - Add `hw_classification = HardwareClassification.ACCELERATOR` to `TestTensorIterator`.

## Test Plan

Verified on CUDA:  `pytest test/test_view_ops.py test/test_tensor_iterator.py -vvv `

- befor:  655 passed, 127 skipped in 30.74s
- after:  655 passed, 126 skipped in 33.65s



Test with `--hw-classification`:

```bash
pytest test/test_view_ops.py test/test_tensor_iterator.py -vvv --hw-classification generic
# 9 passed in 2.81s

pytest test/test_view_ops.py test/test_tensor_iterator.py -vvv --hw-classification accelerator
# 646 passed, 126 skipped in 30.55s
```

