### PR TITLE
[Testcase Refactoring] Decorator modification: added support for privateuse1 devices.

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -45,7 +45,7 @@ from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_inductor_cache
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
-    onlyCUDA,
+    onlyCUDAAndPRIVATEUSE1,
     ops,
 )
 from torch.testing._internal.common_methods_invocations import (
@@ -675,7 +675,7 @@ class TestOpInfoProperties(TestCase):
     # Batch Invariance Tests
     # =========================================================================
 
-    @onlyCUDA
+    @onlyCUDAAndPRIVATEUSE1
     @skipIfTorchDynamo("Test uses dynamo already")
     @ops(llm_ops, allowed_dtypes=DTYPES)
     @parametrize("backend", BACKENDS)
@@ -811,7 +811,7 @@ class TestOpInfoProperties(TestCase):
     # Run-to-Run Determinism Tests
     # =========================================================================
 
-    @onlyCUDA
+    @onlyCUDAAndPRIVATEUSE1
     @skipIfTorchDynamo("Test uses dynamo already")
     @ops(llm_ops, allowed_dtypes=DTYPES)
     @parametrize("backend", BACKENDS)
@@ -883,7 +883,7 @@ class TestOpInfoProperties(TestCase):
     # Bitwise Equivalence with Eager Mode Tests
     # =========================================================================
 
-    @onlyCUDA
+    @onlyCUDAAndPRIVATEUSE1
     @skipIfTorchDynamo("Test uses dynamo already")
     @ops(llm_ops, allowed_dtypes=DTYPES)
     @parametrize("backend", BACKENDS)
@@ -934,7 +934,7 @@ class TestOpInfoProperties(TestCase):
     # Exhaustive/Sampled Unary Ufunc Tests
     # =========================================================================
 
-    @onlyCUDA
+    @onlyCUDAAndPRIVATEUSE1
     @skipIfTorchDynamo("Test uses dynamo already")
     @ops(llm_unary_ops, allowed_dtypes=DTYPES)
     @parametrize("backend", BACKENDS)
@@ -988,7 +988,7 @@ class TestOpInfoProperties(TestCase):
     # Sampled Binary Ufunc Tests
     # =========================================================================
 
-    @onlyCUDA
+    @onlyCUDAAndPRIVATEUSE1
     @skipIfTorchDynamo("Test uses dynamo already")
     @ops(llm_binary_ops, allowed_dtypes=DTYPES)
     @parametrize("backend", BACKENDS)


### PR DESCRIPTION
##  Summary
This PR Modify test cases that previously supported only CUDA to support both CUDA and PRIVATEUSE1.

This is a step toward making inductor tests device-agnostic for out-of-tree backends.

## Changes
Change `onlyCUDA `to `onlyCUDAAndPRIVATEUSE1`.

## Motivation
Expand the scope of test case support. Modify test cases that only support CUDA to support both CUDA and privateuse1.

## Test Plan
CI: python test/inductor/test_torchinductor_opinfo_properties.py
Verified locally that the `privateuse1` device can execute test cases.

## Notes
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo