### PR TITLE
[AOTI] Fix proxy executor handling of scalar-bound Tensor args and omitted kwarg-only defaults

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -8653,6 +8653,73 @@ class AOTInductorTestsTemplate:
                 M(), list_example_inputs, dynamic_shapes=({0: Dim.DYNAMIC},)
             )
 
+    def test_proxy_executor_omitted_kwarg_only_defaults(self):
+        # serialize_inputs omits kwarg-only arguments that were not explicitly
+        # provided (the proxy executor fills them from schema defaults), so the
+        # generated call-site arrays must skip them too; passing their
+        # filled-in default values desyncs the executor's argument count
+        # ("Mismatch between ints consumed and num_ints"). The post-grad
+        # mm+add fusion emits addmm without explicit beta/alpha, which is such
+        # a node. Routing it through the proxy executor requires an op without
+        # a torchgen'd C shim; simulate that (the situation of out-of-tree
+        # backends, where no per-device C shim exists at all) by removing
+        # addmm from the C-shim list and forcing fallback lowering.
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = torch.nn.Parameter(torch.randn(4, 4))
+                self.b = torch.nn.Parameter(torch.randn(4))
+
+            def forward(self, x):
+                return x @ self.w + self.b
+
+        example_inputs = (torch.randn(4, 4, device=self.device),)
+
+        from torchgen.aoti import fallback_ops
+
+        patched_fallback_ops = {
+            k: v
+            for k, v in fallback_ops.inductor_fallback_ops.items()
+            if k != "aten.addmm.default"
+        }
+        with (
+            patch.object(
+                fallback_ops, "inductor_fallback_ops", patched_fallback_ops
+            ),
+            config.patch(fallback_by_default=True),
+        ):
+            self.check_model(M(), example_inputs)
+
+    def test_proxy_executor_scalar_bound_to_tensor_arg(self):
+        # FX graphs allow a python scalar to bind to a Tensor-typed parameter
+        # (aten.add.Tensor(x, 1)). The extern kernel node serializes it by
+        # value (as_int); the proxy executor must materialize the 0-d tensor
+        # instead of rejecting it expecting as_tensor. Routing an op with such
+        # an argument through the proxy executor requires an op without a
+        # torchgen'd C shim; simulate that (the situation of out-of-tree
+        # backends, where no per-device C shim exists at all) by removing
+        # add.Tensor from the C-shim list and forcing fallback lowering.
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        example_inputs = (torch.randn(4, 4, device=self.device),)
+
+        from torchgen.aoti import fallback_ops
+
+        patched_fallback_ops = {
+            k: v
+            for k, v in fallback_ops.inductor_fallback_ops.items()
+            if k != "aten.add.Tensor"
+        }
+        with (
+            patch.object(
+                fallback_ops, "inductor_fallback_ops", patched_fallback_ops
+            ),
+            config.patch(fallback_by_default=True),
+        ):
+            self.check_model(M(), example_inputs)
+
     def test_clamp_decomposition(self):
         class Model1(torch.nn.Module):
             def forward(self, x):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3054,6 +3054,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
             )
 
             if isinstance(arg_type, torch.TensorType):
+                if isinstance(arg, (bool, float, int)):
+                    # A scalar bound to a Tensor-typed parameter is serialized
+                    # by value in the extern kernel node; the proxy executor
+                    # materializes the tensor, so nothing is passed here.
+                    return
                 if not isinstance(arg, inductor_tensor_buffers):
                     raise AssertionError(f"got {type(arg)}")
                 new_tensor_args.append(f"{arg.codegen_reference()}")

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -9764,6 +9764,17 @@ class FallbackKernel(ExternKernelAlloc):
 
         V.extern_kernel_nodes.append(node)
 
+        # serialize_inputs only emits kwarg-only arguments that were
+        # explicitly provided; the proxy executor fills schema defaults for
+        # the omitted ones. Return None for those so the generated call
+        # arrays line up with the serialized node (None args are skipped).
+        omittable = OrderedSet(self.ordered_kwargs_for_cpp_kernel) - OrderedSet(
+            kwargs.keys()
+        )
+        ordered_kwargs = [
+            None if key in omittable else self.get_kwargs_value(key, **kwargs)
+            for key in self.ordered_kwargs_for_cpp_kernel
+        ]
         return [*args, *ordered_kwargs]
 
     @override

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <vector>
 
+#include <ATen/ops/scalar_tensor.h>
 #include <c10/util/Exception.h>
 #include <c10/util/FileSystem.h>
 #include <torch/csrc/inductor/aoti_torch/generated_enum_converters.h>
@@ -68,6 +69,23 @@ void OSSProxyExecutor::prefill_stack_with_static_arguments(
       break;
     }
     case c10::TypeKind::TensorType: {
+      // FX graphs allow a python scalar to bind to a Tensor-typed parameter.
+      // Materialize it the same way the direct C-shim call path does
+      // (aoti_torch_scalar_to_tensor_*): a 0-d CPU tensor of the canonical
+      // dtype for the scalar type.
+      if (serialized_arg_type == "as_int") {
+        stack.at(index) = at::scalar_tensor(
+            serialized_arg_val.get<int64_t>(), c10::ScalarType::Long);
+        break;
+      } else if (serialized_arg_type == "as_float") {
+        stack.at(index) = at::scalar_tensor(
+            serialized_arg_val.get<double>(), c10::ScalarType::Double);
+        break;
+      } else if (serialized_arg_type == "as_bool") {
+        stack.at(index) = at::scalar_tensor(
+            serialized_arg_val.get<bool>(), c10::ScalarType::Bool);
+        break;
+      }
       TORCH_CHECK(
           serialized_arg_type == "as_tensor",
           "Expected extern kernel ",


### PR DESCRIPTION
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo