### PR TITLE
[Test] Make `test_numeric_suite_fx.py` tests generic and enable testing XPU.

### DIFF
--- a/test/quantization/fx/test_numeric_suite_fx.py
+++ b/test/quantization/fx/test_numeric_suite_fx.py
@@ -40,7 +40,11 @@ from torch.testing._internal.common_quantization import (
     skip_if_no_torchvision,
     TwoLayerLinearModel
 )
-from torch.testing._internal.common_utils import raise_on_run_directly, skipIfTorchDynamo
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    skipIfTorchDynamo,
+)
 from torch.ao.quantization.quantization_mappings import (
     get_default_static_quant_module_mappings,
     get_default_dynamic_quant_module_mappings,
@@ -313,6 +317,7 @@ def get_all_quant_patterns():
     return all_quant_patterns
 
 class TestFXGraphMatcher(QuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIfNoFBGEMM
     def test_simple_mod(self):
@@ -795,6 +800,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
 
 
 class TestFXGraphMatcherModels(QuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIfTorchDynamo("too slow")
     @skipIfNoFBGEMM
@@ -992,6 +998,7 @@ class FXNumericSuiteQuantizationTestCase(QuantizationTestCase):
 
 
 class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIfNoFBGEMM
     def test_extract_weights_mod_ptq(self):
@@ -2049,6 +2056,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
 
 
 class TestFXNumericSuiteCoreAPIsDevice(FXNumericSuiteQuantizationTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @onlyAccelerator
     def test_extract_weights_gpu(self, device):
@@ -2100,6 +2108,8 @@ class TestFXNumericSuiteNShadows(FXNumericSuiteQuantizationTestCase):
     """
     Tests the "n shadows" workflow.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def _test_impl(self, m, example_input, qconfig_mappings):
         backend_config = get_native_backend_config()
@@ -2777,6 +2787,8 @@ class TestFXNumericSuiteCoreAPIsModels(FXNumericSuiteQuantizationTestCase):
     """
     Tests numeric suite core APIs on non-toy models.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIfNoFBGEMM
     def test_compare_weights_conv(self):

--- a/test/quantization/fx/test_numeric_suite_fx.py
+++ b/test/quantization/fx/test_numeric_suite_fx.py
@@ -2950,7 +2950,12 @@ class TestFXNumericSuiteCoreAPIsModels(FXNumericSuiteQuantizationTestCase):
             should_log_inputs=False)
 
 
-instantiate_device_type_tests(TestFXNumericSuiteCoreAPIsDevice, globals(), only_for=("cuda",))
+instantiate_device_type_tests(
+    TestFXNumericSuiteCoreAPIsDevice,
+    globals(),
+    only_for=("cuda", "xpu"),
+    allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/quantization/fx/test_numeric_suite_fx.py
+++ b/test/quantization/fx/test_numeric_suite_fx.py
@@ -1964,50 +1964,6 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         ref_shadow = mc_shadows_mp(*example_inputs)
         self.assertEqual(ref_fp32, ref_shadow)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_extract_weights_cuda(self):
-        # Note: this is not using quantization because quantized kernels do not
-        # work on cuda yet.
-        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        results = extract_weights('a', m1, 'b', m2)
-        extend_logger_results_with_comparison(
-            results, 'a', 'b', compute_sqnr, 'sqnr')
-        self.assert_ns_compare_dict_valid(results)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_add_loggers_cuda(self):
-        # Note: this is not using quantization because quantized kernels do not
-        # work on cuda yet.
-        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        m1_ns, m2_ns = add_loggers('a', m1, 'b', m2, OutputLogger)
-        datum = torch.randn(1, 1, 1, 1)
-        datum = datum.cuda()
-
-        m1_ns(datum)
-        m2_ns(datum)
-
-        act_compare_dict = extract_logger_info(m1_ns, m2_ns, OutputLogger, 'b')
-        extend_logger_results_with_comparison(
-            act_compare_dict, 'a', 'b', compute_sqnr, 'sqnr')
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_add_shadow_loggers_cuda(self):
-        # Note: this is not using quantization because quantized kernels do not
-        # work on cuda yet.
-        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        m1_shadows_m2 = add_shadow_loggers('a', m1, 'b', m2, OutputLogger)
-        datum = torch.randn(1, 1, 1, 1)
-        datum = datum.cuda()
-
-        m1_shadows_m2(datum)
-
-        act_compare_dict = extract_shadow_logger_info(m1_shadows_m2, OutputLogger, 'b')
-        extend_logger_results_with_comparison(
-            act_compare_dict, 'a', 'b', compute_sqnr, 'sqnr')
-
     def test_fp16_shadows_fp32(self):
         m = LinearReluFunctional().eval()
         example_inputs = (torch.randn(1, 4),)
@@ -2088,6 +2044,51 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         act_compare_dict = extract_shadow_logger_info(
             mt_shadows_mt_copy, OutputLogger, 'b')
         self.assertTrue(len(act_compare_dict) == 1)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_extract_weights_cuda(self):
+        # Note: this is not using quantization because quantized kernels do not
+        # work on cuda yet.
+        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        results = extract_weights('a', m1, 'b', m2)
+        extend_logger_results_with_comparison(
+            results, 'a', 'b', compute_sqnr, 'sqnr')
+        self.assert_ns_compare_dict_valid(results)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_add_loggers_cuda(self):
+        # Note: this is not using quantization because quantized kernels do not
+        # work on cuda yet.
+        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        m1_ns, m2_ns = add_loggers('a', m1, 'b', m2, OutputLogger)
+        datum = torch.randn(1, 1, 1, 1)
+        datum = datum.cuda()
+
+        m1_ns(datum)
+        m2_ns(datum)
+
+        act_compare_dict = extract_logger_info(m1_ns, m2_ns, OutputLogger, 'b')
+        extend_logger_results_with_comparison(
+            act_compare_dict, 'a', 'b', compute_sqnr, 'sqnr')
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_add_shadow_loggers_cuda(self):
+        # Note: this is not using quantization because quantized kernels do not
+        # work on cuda yet.
+        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        m1_shadows_m2 = add_shadow_loggers('a', m1, 'b', m2, OutputLogger)
+        datum = torch.randn(1, 1, 1, 1)
+        datum = datum.cuda()
+
+        m1_shadows_m2(datum)
+
+        act_compare_dict = extract_shadow_logger_info(m1_shadows_m2, OutputLogger, 'b')
+        extend_logger_results_with_comparison(
+            act_compare_dict, 'a', 'b', compute_sqnr, 'sqnr')
+
 
 @skipIfNoQNNPACK
 class TestFXNumericSuiteNShadows(FXNumericSuiteQuantizationTestCase):

--- a/test/quantization/fx/test_numeric_suite_fx.py
+++ b/test/quantization/fx/test_numeric_suite_fx.py
@@ -4,7 +4,6 @@
 import copy
 import math
 import operator
-import unittest
 
 import torch
 import torch.nn as nn
@@ -21,6 +20,10 @@ from torch.ao.quantization.quantize_fx import (
     convert_to_reference_fx,
     prepare_fx,
     prepare_qat_fx,
+)
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
 )
 from torch.testing._internal.common_quantization import (
     ConvBnModel,
@@ -43,7 +46,6 @@ from torch.ao.quantization.quantization_mappings import (
     get_default_dynamic_quant_module_mappings,
     get_default_float_to_quantized_operator_mappings,
 )
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_quantization import NodeSpec as ns
 from torch.ao.quantization.fx.pattern_utils import get_default_quant_patterns
 import torch.ao.quantization.fx.quantize_handler as qh
@@ -2045,26 +2047,29 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             mt_shadows_mt_copy, OutputLogger, 'b')
         self.assertTrue(len(act_compare_dict) == 1)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_extract_weights_cuda(self):
+
+class TestFXNumericSuiteCoreAPIsDevice(FXNumericSuiteQuantizationTestCase):
+
+    @onlyAccelerator
+    def test_extract_weights_gpu(self, device):
         # Note: this is not using quantization because quantized kernels do not
         # work on cuda yet.
-        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
+        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
         results = extract_weights('a', m1, 'b', m2)
         extend_logger_results_with_comparison(
             results, 'a', 'b', compute_sqnr, 'sqnr')
         self.assert_ns_compare_dict_valid(results)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_add_loggers_cuda(self):
+    @onlyAccelerator
+    def test_add_loggers_gpu(self, device):
         # Note: this is not using quantization because quantized kernels do not
         # work on cuda yet.
-        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
+        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
         m1_ns, m2_ns = add_loggers('a', m1, 'b', m2, OutputLogger)
         datum = torch.randn(1, 1, 1, 1)
-        datum = datum.cuda()
+        datum = datum.to(device)
 
         m1_ns(datum)
         m2_ns(datum)
@@ -2073,15 +2078,15 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         extend_logger_results_with_comparison(
             act_compare_dict, 'a', 'b', compute_sqnr, 'sqnr')
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_add_shadow_loggers_cuda(self):
+    @onlyAccelerator
+    def test_add_shadow_loggers_gpu(self, device):
         # Note: this is not using quantization because quantized kernels do not
         # work on cuda yet.
-        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
+        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
         m1_shadows_m2 = add_shadow_loggers('a', m1, 'b', m2, OutputLogger)
         datum = torch.randn(1, 1, 1, 1)
-        datum = datum.cuda()
+        datum = datum.to(device)
 
         m1_shadows_m2(datum)
 
@@ -2931,6 +2936,10 @@ class TestFXNumericSuiteCoreAPIsModels(FXNumericSuiteQuantizationTestCase):
             m, (torch.randn(1, 3, 224, 224),),
             qconfig_dict=qconfig_dict,
             should_log_inputs=False)
+
+
+instantiate_device_type_tests(TestFXNumericSuiteCoreAPIsDevice, globals(), only_for=("cuda",))
+
 
 if __name__ == "__main__":
     raise_on_run_directly("test/test_quantization.py")

--- a/test/quantization/fx/test_numeric_suite_fx.py
+++ b/test/quantization/fx/test_numeric_suite_fx.py
@@ -4,7 +4,6 @@
 import copy
 import math
 import operator
-import unittest
 
 import torch
 import torch.nn as nn
@@ -21,6 +20,10 @@ from torch.ao.quantization.quantize_fx import (
     convert_to_reference_fx,
     prepare_fx,
     prepare_qat_fx,
+)
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
 )
 from torch.testing._internal.common_quantization import (
     ConvBnModel,
@@ -43,7 +46,6 @@ from torch.ao.quantization.quantization_mappings import (
     get_default_dynamic_quant_module_mappings,
     get_default_float_to_quantized_operator_mappings,
 )
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_quantization import NodeSpec as ns
 from torch.ao.quantization.fx.pattern_utils import get_default_quant_patterns
 import torch.ao.quantization.fx.quantize_handler as qh
@@ -2045,26 +2047,29 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             mt_shadows_mt_copy, OutputLogger, 'b')
         self.assertTrue(len(act_compare_dict) == 1)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_extract_weights_cuda(self):
+
+class TestFXNumericSuiteCoreAPIsDevice(FXNumericSuiteQuantizationTestCase):
+
+    @onlyAccelerator
+    def test_extract_weights_gpu(self, device):
         # Note: this is not using quantization because quantized kernels do not
         # work on cuda yet.
-        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
+        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
         results = extract_weights('a', m1, 'b', m2)
         extend_logger_results_with_comparison(
             results, 'a', 'b', compute_sqnr, 'sqnr')
         self.assert_ns_compare_dict_valid(results)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_add_loggers_cuda(self):
+    @onlyAccelerator
+    def test_add_loggers_gpu(self, device):
         # Note: this is not using quantization because quantized kernels do not
         # work on cuda yet.
-        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
+        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
         m1_ns, m2_ns = add_loggers('a', m1, 'b', m2, OutputLogger)
         datum = torch.randn(1, 1, 1, 1)
-        datum = datum.cuda()
+        datum = datum.to(device)
 
         m1_ns(datum)
         m2_ns(datum)
@@ -2073,15 +2078,15 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         extend_logger_results_with_comparison(
             act_compare_dict, 'a', 'b', compute_sqnr, 'sqnr')
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_add_shadow_loggers_cuda(self):
+    @onlyAccelerator
+    def test_add_shadow_loggers_gpu(self, device):
         # Note: this is not using quantization because quantized kernels do not
         # work on cuda yet.
-        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
-        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).cuda()
+        m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
+        m2 = nn.Sequential(nn.Conv2d(1, 1, 1)).to(device)
         m1_shadows_m2 = add_shadow_loggers('a', m1, 'b', m2, OutputLogger)
         datum = torch.randn(1, 1, 1, 1)
-        datum = datum.cuda()
+        datum = datum.to(device)
 
         m1_shadows_m2(datum)
 
@@ -2931,6 +2936,10 @@ class TestFXNumericSuiteCoreAPIsModels(FXNumericSuiteQuantizationTestCase):
             m, (torch.randn(1, 3, 224, 224),),
             qconfig_dict=qconfig_dict,
             should_log_inputs=False)
+
+
+instantiate_device_type_tests(TestFXNumericSuiteCoreAPIsDevice, globals())
+
 
 if __name__ == "__main__":
     raise_on_run_directly("test/test_quantization.py")


### PR DESCRIPTION
This PR refactors the `test_numeric_suite_fx.py` test file to be generic and enables testing XPU.

## Important review notes

For easier review, I separated changes into several commits:
| Commit | Changes |
| - | - |
| **Just change functions order.** | This commit only moves the test functions to sort them by `device-unrelated` and `device-agnostic` groups. **NO FUNCTIONAL CHANGES AT ALL** |
| **Refactor.** | This commit applies the real refactor and changes required to make code generic. |
| Add HardwareClassification to all test classes. | As commit title. |
| Enable XPU testing. | Enable testing XPU by adding `allow_xpu=True` |
- The rest of the changes are addressing review comments.

So for easier review, it is better to check all the commits except the **Just change functions order.**. They contain the real refactor changes while the **Just change functions order.** is just changing order.

## Changes

### Splitting test classes
- Split `TestFXNumericSuiteCoreAPIs` test class into device-unrelated `TestFXNumericSuiteCoreAPIs` and device-agnostic `TestFXNumericSuiteCoreAPIsDevice`.

### General changes
- Removed the @unittest.skipIf(not TEST_CUDA, "CUDA unavailable") in favor of `@onlyAccelerator`.
- Added `@onlyAccelerator` gating decorator for tests that should not be launched with `cpu` device.
- Changed hardcoded `.cuda()` calls to generic `.to(device)`.
- Added `instantiate_device_type_tests()` instantiation for this newly extracted, device-agnostic test class `TestFXNumericSuiteCoreAPIsDevice`.
- Add `HardwareClassification` to all test classes.
- Enable testing XPU.

## Test statistics

Moved 3 tests from  `TestFXNumericSuiteCoreAPIs` to `TestFXNumericSuiteCoreAPIsDevice`. The overall number of test functions stays the same.
