### PR TITLE
[TEST] Refactor test_placement_types.py with hw_classification

### DIFF
--- a/test/distributed/tensor/test_placement_types.py
+++ b/test/distributed/tensor/test_placement_types.py
@@ -24,11 +24,17 @@ from torch.fx.experimental.symbolic_shapes import (
     optimization_hint,
     ShapeEnv,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 # Basic functionality test for Placement types.
 class PlacementTypesTestCase(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_type_identification(self):
         shard = Shard(3)
         strided_shard = _StridedShard(dim=3, split_factor=7)


### PR DESCRIPTION
## Summary

Adds `hw_classification` to `test/distributed/tensor/test_placement_types.py`
following the community test refactoring initiative (#186918).

## Changes

**Classification**

- **`PlacementTypesTestCase`** (`GENERIC`): All 12 methods test placement-type
  data structures (`Shard`, `Replicate`, `Partial`, `_StridedShard`) via
  equality, hashing, repr, and `FakeTensorMode` symbolic shapes. The only
  `DeviceMesh` usage is `DeviceMesh("cpu", ..., _init_backend=False)` — pure
  metadata, no process group init, no real collective dispatch.

No class splits needed. No `instantiate_device_type_tests` needed.

## Test Plan

```
python test/distributed/tensor/test_placement_types.py -v
# Ran 12 tests -- OK

python test/distributed/tensor/test_placement_types.py --hw-classification GENERIC -v
# Ran 12 tests -- OK
```