### PR TITLE
[Test] Generalize `autograd/test_functional.py` tests and enable on XPU

### DIFF
--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -97,7 +97,33 @@ vectorized_logging_tensor = parametrize(
 )
 
 
-class TestAutogradFunctional(TestCase):
+class _AutogradFunctionalHelpers:
+    def _test_construct_standard_basis_for(self, inputs):
+        numels = tuple(tensor.numel() for tensor in inputs)
+        results = autogradF._construct_standard_basis_for(inputs, numels)
+        for result, inp in zip(results, inputs):
+            self.assertEqual(result.dtype, inp.dtype)
+            self.assertEqual(result.device, inp.device)
+        results = torch.cat(
+            [result.to(device="cpu", dtype=torch.float) for result in results], dim=1
+        )
+        expected = torch.eye(results[0].shape[0], dtype=torch.float)
+        self.assertEqual(results, expected)
+
+
+    def _check_jacobian_vectorize_correctness(self, f, inputs, test_forward_ad=True):
+        expected = autogradF.jacobian(f, inputs, vectorize=False)
+        result_backward_mode = autogradF.jacobian(f, inputs, vectorize=True)
+        self.assertEqual(result_backward_mode, expected)
+
+        if test_forward_ad:
+            result_forward_mode = autogradF.jacobian(
+                f, inputs, strategy="forward-mode", vectorize=True
+            )
+            self.assertEqual(result_forward_mode, expected)
+
+
+class TestAutogradFunctional(_AutogradFunctionalHelpers, TestCase):
     def _assert_same_struct(self, res, base):
         # base and res should be Tensors or tuple of Tensors with the same size
         if isinstance(base, torch.Tensor):
@@ -621,18 +647,6 @@ class TestAutogradFunctional(TestCase):
         gradcheck(foo, inputs + v)
         gradgradcheck(foo, inputs + v)
 
-    def _test_construct_standard_basis_for(self, inputs):
-        numels = tuple(tensor.numel() for tensor in inputs)
-        results = autogradF._construct_standard_basis_for(inputs, numels)
-        for result, inp in zip(results, inputs):
-            self.assertEqual(result.dtype, inp.dtype)
-            self.assertEqual(result.device, inp.device)
-        results = torch.cat(
-            [result.to(device="cpu", dtype=torch.float) for result in results], dim=1
-        )
-        expected = torch.eye(results[0].shape[0], dtype=torch.float)
-        self.assertEqual(results, expected)
-
     @base_and_logging_tensor
     def test_construct_standard_basis_for(self, ctors):
         test_cases = [
@@ -644,17 +658,6 @@ class TestAutogradFunctional(TestCase):
             (ctors.randn(2), ctors.randn([]), ctors.randn(3)),
             (ctors.randn(2, 3), ctors.randn(3), ctors.randn(3, 4, 2)),
             (ctors.randn(2, dtype=torch.float64), ctors.randn(3, dtype=torch.float32)),
-        ]
-
-        for inputs in test_cases:
-            self._test_construct_standard_basis_for(inputs)
-
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
-    @base_and_logging_tensor
-    def test_construct_standard_basis_for_cuda(self, ctors):
-        test_cases = [
-            (ctors.randn(2), ctors.randn(3, device="cuda")),
-            (ctors.randn(3, device="cuda"), ctors.randn(2)),
         ]
 
         for inputs in test_cases:
@@ -893,17 +896,6 @@ class TestAutogradFunctional(TestCase):
         gradcheck(foo, inputs)
         gradgradcheck(foo, inputs)
 
-    def _check_jacobian_vectorize_correctness(self, f, inputs, test_forward_ad=True):
-        expected = autogradF.jacobian(f, inputs, vectorize=False)
-        result_backward_mode = autogradF.jacobian(f, inputs, vectorize=True)
-        self.assertEqual(result_backward_mode, expected)
-
-        if test_forward_ad:
-            result_forward_mode = autogradF.jacobian(
-                f, inputs, strategy="forward-mode", vectorize=True
-            )
-            self.assertEqual(result_forward_mode, expected)
-
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_simple(self, ctors):
         def f(x):
@@ -963,16 +955,6 @@ class TestAutogradFunctional(TestCase):
         x = ctors.randn([])
         y = ctors.randn(1)
         self._check_jacobian_vectorize_correctness(h, (x, y))
-
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
-    @base_and_logging_tensor
-    def test_jacobian_vectorize_correctness_different_devices(self, ctors):
-        def f(x, y):
-            return x * y, (x * y).cuda()
-
-        x = ctors.randn(3)
-        y = ctors.randn(3)
-        self._check_jacobian_vectorize_correctness(f, (x, y))
 
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_different_dtype(self, ctors):
@@ -1740,7 +1722,32 @@ class TestAutogradFunctional(TestCase):
         self.assertEqual(vhp, torch.mm(v.unsqueeze(0), hes).squeeze(0))
 
 
+class TestAutogradFunctionalDevice(_AutogradFunctionalHelpers, TestCase):
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @base_and_logging_tensor
+    def test_construct_standard_basis_for_cuda(self, ctors):
+        test_cases = [
+            (ctors.randn(2), ctors.randn(3, device="cuda")),
+            (ctors.randn(3, device="cuda"), ctors.randn(2)),
+        ]
+
+        for inputs in test_cases:
+            self._test_construct_standard_basis_for(inputs)
+
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @base_and_logging_tensor
+    def test_jacobian_vectorize_correctness_different_devices(self, ctors):
+        def f(x, y):
+            return x * y, (x * y).cuda()
+
+        x = ctors.randn(3)
+        y = ctors.randn(3)
+        self._check_jacobian_vectorize_correctness(f, (x, y))
+
+
 instantiate_parametrized_tests(TestAutogradFunctional)
+instantiate_parametrized_tests(TestAutogradFunctionalDevice)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -1753,7 +1753,7 @@ class TestAutogradFunctionalDevice(_AutogradFunctionalHelpers, TestCase):
 
 
 instantiate_parametrized_tests(TestAutogradFunctional)
-instantiate_device_type_tests(TestAutogradFunctionalDevice, globals())
+instantiate_device_type_tests(TestAutogradFunctionalDevice, globals(), allow_xpu=True)
 
 
 if __name__ == "__main__":

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_utils import (
     gradcheck,
     gradgradcheck,
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -113,7 +114,6 @@ class _AutogradFunctionalHelpers:
         expected = torch.eye(results[0].shape[0], dtype=torch.float)
         self.assertEqual(results, expected)
 
-
     def _check_jacobian_vectorize_correctness(self, f, inputs, test_forward_ad=True):
         expected = autogradF.jacobian(f, inputs, vectorize=False)
         result_backward_mode = autogradF.jacobian(f, inputs, vectorize=True)
@@ -127,6 +127,8 @@ class _AutogradFunctionalHelpers:
 
 
 class TestAutogradFunctional(_AutogradFunctionalHelpers, TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _assert_same_struct(self, res, base):
         # base and res should be Tensors or tuple of Tensors with the same size
         if isinstance(base, torch.Tensor):
@@ -1726,6 +1728,8 @@ class TestAutogradFunctional(_AutogradFunctionalHelpers, TestCase):
 
 
 class TestAutogradFunctionalDevice(_AutogradFunctionalHelpers, TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @onlyAccelerator
     @base_and_logging_tensor
     def test_construct_standard_basis(self, device, ctors):

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -97,6 +97,31 @@ vectorized_logging_tensor = parametrize(
 )
 
 
+def _test_construct_standard_basis_for(self, inputs):
+    numels = tuple(tensor.numel() for tensor in inputs)
+    results = autogradF._construct_standard_basis_for(inputs, numels)
+    for result, inp in zip(results, inputs):
+        self.assertEqual(result.dtype, inp.dtype)
+        self.assertEqual(result.device, inp.device)
+    results = torch.cat(
+        [result.to(device="cpu", dtype=torch.float) for result in results], dim=1
+    )
+    expected = torch.eye(results[0].shape[0], dtype=torch.float)
+    self.assertEqual(results, expected)
+
+
+def _check_jacobian_vectorize_correctness(self, f, inputs, test_forward_ad=True):
+    expected = autogradF.jacobian(f, inputs, vectorize=False)
+    result_backward_mode = autogradF.jacobian(f, inputs, vectorize=True)
+    self.assertEqual(result_backward_mode, expected)
+
+    if test_forward_ad:
+        result_forward_mode = autogradF.jacobian(
+            f, inputs, strategy="forward-mode", vectorize=True
+        )
+        self.assertEqual(result_forward_mode, expected)
+
+
 class TestAutogradFunctional(TestCase):
     def _assert_same_struct(self, res, base):
         # base and res should be Tensors or tuple of Tensors with the same size
@@ -621,18 +646,6 @@ class TestAutogradFunctional(TestCase):
         gradcheck(foo, inputs + v)
         gradgradcheck(foo, inputs + v)
 
-    def _test_construct_standard_basis_for(self, inputs):
-        numels = tuple(tensor.numel() for tensor in inputs)
-        results = autogradF._construct_standard_basis_for(inputs, numels)
-        for result, inp in zip(results, inputs):
-            self.assertEqual(result.dtype, inp.dtype)
-            self.assertEqual(result.device, inp.device)
-        results = torch.cat(
-            [result.to(device="cpu", dtype=torch.float) for result in results], dim=1
-        )
-        expected = torch.eye(results[0].shape[0], dtype=torch.float)
-        self.assertEqual(results, expected)
-
     @base_and_logging_tensor
     def test_construct_standard_basis_for(self, ctors):
         test_cases = [
@@ -647,18 +660,7 @@ class TestAutogradFunctional(TestCase):
         ]
 
         for inputs in test_cases:
-            self._test_construct_standard_basis_for(inputs)
-
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
-    @base_and_logging_tensor
-    def test_construct_standard_basis_for_cuda(self, ctors):
-        test_cases = [
-            (ctors.randn(2), ctors.randn(3, device="cuda")),
-            (ctors.randn(3, device="cuda"), ctors.randn(2)),
-        ]
-
-        for inputs in test_cases:
-            self._test_construct_standard_basis_for(inputs)
+            _test_construct_standard_basis_for(self, inputs)
 
     def _test_vectorize_raises_no_warnings(self, api, ctors):
         # vmap is an experimental prototype. When someone calls torch.vmap,
@@ -893,24 +895,13 @@ class TestAutogradFunctional(TestCase):
         gradcheck(foo, inputs)
         gradgradcheck(foo, inputs)
 
-    def _check_jacobian_vectorize_correctness(self, f, inputs, test_forward_ad=True):
-        expected = autogradF.jacobian(f, inputs, vectorize=False)
-        result_backward_mode = autogradF.jacobian(f, inputs, vectorize=True)
-        self.assertEqual(result_backward_mode, expected)
-
-        if test_forward_ad:
-            result_forward_mode = autogradF.jacobian(
-                f, inputs, strategy="forward-mode", vectorize=True
-            )
-            self.assertEqual(result_forward_mode, expected)
-
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_simple(self, ctors):
         def f(x):
             return 3 * x**2
 
         x = ctors.randn(2, 3, 5)
-        self._check_jacobian_vectorize_correctness(f, x)
+        _check_jacobian_vectorize_correctness(self, f, x)
 
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_multi_input(self, ctors):
@@ -919,7 +910,7 @@ class TestAutogradFunctional(TestCase):
 
         x = ctors.randn(2, 3)
         y = ctors.randn(3, 5)
-        self._check_jacobian_vectorize_correctness(f, (x, y))
+        _check_jacobian_vectorize_correctness(self, f, (x, y))
 
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_multi_input_multi_output(self, ctors):
@@ -928,7 +919,7 @@ class TestAutogradFunctional(TestCase):
 
         x = ctors.randn(5, 3)
         y = ctors.randn(3, 5)
-        self._check_jacobian_vectorize_correctness(f, (x, y))
+        _check_jacobian_vectorize_correctness(self, f, (x, y))
 
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_unrelated_outputs(self, ctors):
@@ -937,7 +928,7 @@ class TestAutogradFunctional(TestCase):
 
         x = ctors.randn(2)
         y = ctors.randn(3)
-        self._check_jacobian_vectorize_correctness(f, (x, y))
+        _check_jacobian_vectorize_correctness(self, f, (x, y))
 
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_zero_dim(self, ctors):
@@ -947,14 +938,14 @@ class TestAutogradFunctional(TestCase):
 
         x = ctors.randn(3)
         y = ctors.randn(3)
-        self._check_jacobian_vectorize_correctness(f, (x, y))
+        _check_jacobian_vectorize_correctness(self, f, (x, y))
 
         # zero-dim input
         def g(x):
             return torch.stack([x, x, x])
 
         x = ctors.randn([])
-        self._check_jacobian_vectorize_correctness(g, x)
+        _check_jacobian_vectorize_correctness(self, g, x)
 
         # Mixed zero-dim input / zero-dim output
         def h(x, y):
@@ -962,17 +953,7 @@ class TestAutogradFunctional(TestCase):
 
         x = ctors.randn([])
         y = ctors.randn(1)
-        self._check_jacobian_vectorize_correctness(h, (x, y))
-
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
-    @base_and_logging_tensor
-    def test_jacobian_vectorize_correctness_different_devices(self, ctors):
-        def f(x, y):
-            return x * y, (x * y).cuda()
-
-        x = ctors.randn(3)
-        y = ctors.randn(3)
-        self._check_jacobian_vectorize_correctness(f, (x, y))
+        _check_jacobian_vectorize_correctness(self, h, (x, y))
 
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_different_dtype(self, ctors):
@@ -983,7 +964,7 @@ class TestAutogradFunctional(TestCase):
         y = ctors.randn(3)
         # The Jacobian computed using forward AD has the dtype of the output
         # but the Jacobian computed with reverse AD has dtype of input
-        self._check_jacobian_vectorize_correctness(f, (x, y), test_forward_ad=False)
+        _check_jacobian_vectorize_correctness(self, f, (x, y), test_forward_ad=False)
 
     def _check_hessian_vectorize_correctness(self, f, inputs):
         expected = autogradF.hessian(f, inputs, vectorize=False)
@@ -1740,7 +1721,32 @@ class TestAutogradFunctional(TestCase):
         self.assertEqual(vhp, torch.mm(v.unsqueeze(0), hes).squeeze(0))
 
 
+class TestAutogradFunctionalDevice(TestCase):
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @base_and_logging_tensor
+    def test_construct_standard_basis_for_cuda(self, ctors):
+        test_cases = [
+            (ctors.randn(2), ctors.randn(3, device="cuda")),
+            (ctors.randn(3, device="cuda"), ctors.randn(2)),
+        ]
+
+        for inputs in test_cases:
+            _test_construct_standard_basis_for(self, inputs)
+
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @base_and_logging_tensor
+    def test_jacobian_vectorize_correctness_different_devices(self, ctors):
+        def f(x, y):
+            return x * y, (x * y).cuda()
+
+        x = ctors.randn(3)
+        y = ctors.randn(3)
+        _check_jacobian_vectorize_correctness(self, f, (x, y))
+
+
 instantiate_parametrized_tests(TestAutogradFunctional)
+instantiate_parametrized_tests(TestAutogradFunctionalDevice)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -6,7 +6,10 @@ import warnings
 
 import torch
 import torch.autograd.functional as autogradF
-from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     gradcheck,
     gradgradcheck,
@@ -1723,22 +1726,22 @@ class TestAutogradFunctional(_AutogradFunctionalHelpers, TestCase):
 
 
 class TestAutogradFunctionalDevice(_AutogradFunctionalHelpers, TestCase):
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @onlyAccelerator
     @base_and_logging_tensor
-    def test_construct_standard_basis_for_cuda(self, ctors):
+    def test_construct_standard_basis(self, device, ctors):
         test_cases = [
-            (ctors.randn(2), ctors.randn(3, device="cuda")),
-            (ctors.randn(3, device="cuda"), ctors.randn(2)),
+            (ctors.randn(2), ctors.randn(3, device=device)),
+            (ctors.randn(3, device=device), ctors.randn(2)),
         ]
 
         for inputs in test_cases:
             self._test_construct_standard_basis_for(inputs)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @onlyAccelerator
     @base_and_logging_tensor
-    def test_jacobian_vectorize_correctness_different_devices(self, ctors):
+    def test_jacobian_vectorize_correctness_different_devices(self, device, ctors):
         def f(x, y):
-            return x * y, (x * y).cuda()
+            return x * y, (x * y).to(device)
 
         x = ctors.randn(3)
         y = ctors.randn(3)
@@ -1746,7 +1749,7 @@ class TestAutogradFunctionalDevice(_AutogradFunctionalHelpers, TestCase):
 
 
 instantiate_parametrized_tests(TestAutogradFunctional)
-instantiate_parametrized_tests(TestAutogradFunctionalDevice)
+instantiate_device_type_tests(TestAutogradFunctionalDevice, globals())
 
 
 if __name__ == "__main__":

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -6,7 +6,10 @@ import warnings
 
 import torch
 import torch.autograd.functional as autogradF
-from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     gradcheck,
     gradgradcheck,
@@ -1722,22 +1725,22 @@ class TestAutogradFunctional(TestCase):
 
 
 class TestAutogradFunctionalDevice(TestCase):
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @onlyAccelerator
     @base_and_logging_tensor
-    def test_construct_standard_basis_for_cuda(self, ctors):
+    def test_construct_standard_basis_for_gpu(self, device, ctors):
         test_cases = [
-            (ctors.randn(2), ctors.randn(3, device="cuda")),
-            (ctors.randn(3, device="cuda"), ctors.randn(2)),
+            (ctors.randn(2), ctors.randn(3, device=device)),
+            (ctors.randn(3, device=device), ctors.randn(2)),
         ]
 
         for inputs in test_cases:
             _test_construct_standard_basis_for(self, inputs)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @onlyAccelerator
     @base_and_logging_tensor
-    def test_jacobian_vectorize_correctness_different_devices(self, ctors):
+    def test_jacobian_vectorize_correctness_different_devices(self, device, ctors):
         def f(x, y):
-            return x * y, (x * y).cuda()
+            return x * y, (x * y).to(device)
 
         x = ctors.randn(3)
         y = ctors.randn(3)
@@ -1745,7 +1748,7 @@ class TestAutogradFunctionalDevice(TestCase):
 
 
 instantiate_parametrized_tests(TestAutogradFunctional)
-instantiate_parametrized_tests(TestAutogradFunctionalDevice)
+instantiate_device_type_tests(TestAutogradFunctionalDevice, globals())
 
 
 if __name__ == "__main__":

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -1753,7 +1753,7 @@ class TestAutogradFunctionalDevice(TestCase):
 
 
 instantiate_parametrized_tests(TestAutogradFunctional)
-instantiate_device_type_tests(TestAutogradFunctionalDevice, globals())
+instantiate_device_type_tests(TestAutogradFunctionalDevice, globals(), allow_xpu=True)
 
 
 if __name__ == "__main__":

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_utils import (
     gradcheck,
     gradgradcheck,
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -126,6 +127,8 @@ def _check_jacobian_vectorize_correctness(self, f, inputs, test_forward_ad=True)
 
 
 class TestAutogradFunctional(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _assert_same_struct(self, res, base):
         # base and res should be Tensors or tuple of Tensors with the same size
         if isinstance(base, torch.Tensor):
@@ -1725,6 +1728,8 @@ class TestAutogradFunctional(TestCase):
 
 
 class TestAutogradFunctionalDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @onlyAccelerator
     @base_and_logging_tensor
     def test_construct_standard_basis_for_gpu(self, device, ctors):


### PR DESCRIPTION
This PR refactors and generalizes the `autograd/test_functional.py` tests to support multiple accelerator devices (CUDA, XPU, etc.) instead of being hard-coded to CUDA. The changes extract device-dependent tests into a separate class and parameterize them to run on all supported devices.

**Changes/Commits**:
1) Extract separate class for device-dependent tests
    - Separated device-specific tests from the main `TestAutogradFunctional` class into a new `TestAutogradFunctionalDevice` class
    - No functional changes in this commit (code reorganization only)
    - **review can be brief, focusing on code organization and readability**

2) Generalize device dependent tests
    - Replaced hard-coded CUDA checks (`TEST_CUDA`, `"cuda"`) with generic device parameters
    - Changed test decorators from `@unittest.skipIf(not TEST_CUDA, ...)` to `@onlyAccelerator`
    - Updated test methods to accept a `device` parameter instead of assuming CUDA
    - Replaced `.cuda()` calls with `.to(device)` for device-agnostic tensor operations

3) Add hardware classification

4) Enable `autograd/test_functional.py` on XPU
    - Added `allow_xpu=True` parameter to `instantiate_device_type_tests()` call