### PR TITLE
[PrivateUse1] Query registered hooks for accumulate type, fall back to CPU with a o…

### DIFF
--- a/aten/src/ATen/AccumulateType.cpp
+++ b/aten/src/ATen/AccumulateType.cpp
@@ -1,4 +1,6 @@
 #include <ATen/AccumulateType.h>
+#include <ATen/detail/PrivateUse1HooksInterface.h>
+#include <c10/util/Exception.h>
 
 namespace at {
 
@@ -9,6 +11,18 @@ c10::ScalarType toAccumulateType(c10::ScalarType type, c10::DeviceType device) {
       switch (device) {                                                                            \
         case DeviceType::CUDA:                                                                     \
           return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::CUDA>>::value; \
+        case DeviceType::PrivateUse1: {                                                            \
+          if (at::isPrivateUse1HooksRegistered()) {                                               \
+            if (auto acc = at::detail::getPrivateUse1Hooks().toAccumulateType(type)) {             \
+              return *acc;                                                                         \
+            }                                                                                      \
+          }                                                                                        \
+          TORCH_WARN_ONCE(                                                                         \
+              "PrivateUse1 backend has not registered an accumulate-type mapping; ",               \
+              "falling back to the CPU accumulation type. Override ",                              \
+              "`toAccumulateType` in a `PrivateUse1HooksInterface` subclass to silence this.");   \
+          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::CPU>>::value;  \
+        }                                                                                          \
         case DeviceType::XPU:                                                                      \
           return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::XPU>>::value;  \
         case DeviceType::MPS:                                                                      \
@@ -28,4 +42,4 @@ c10::ScalarType toAccumulateType(c10::ScalarType type, bool is_cuda) {
   return is_cuda ? toAccumulateType(type, c10::DeviceType::CUDA) : toAccumulateType(type, c10::DeviceType::CPU);
 }
 
-}
+} // namespace at

--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -5,8 +5,11 @@
 
 #include <c10/core/Allocator.h>
 #include <c10/core/Device.h>
+#include <c10/core/ScalarType.h>
 #include <c10/core/Storage.h>
 #include <c10/util/Exception.h>
+
+#include <optional>
 
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-parameter")
 
@@ -66,6 +69,17 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
       const c10::Storage& storage,
       size_t newsize) const {
     FAIL_PRIVATEUSE1HOOKS_FUNC(__func__);
+  }
+
+  // Accumulation type for the given input dtype on this PrivateUse1 backend.
+  // Returns `std::nullopt` to defer to the CPU accumulation type (PyTorch
+  // default for unregistered / unequipped backends). Override in a subclass
+  // to publish the backend's own accumulation table. Intended to host
+  // similar optional metadata queries in the future (reduce-accumulator
+  // dtype, low-precision intermediate strategy, ...).
+  virtual std::optional<c10::ScalarType> toAccumulateType(
+      c10::ScalarType /*type*/) const {
+    return std::nullopt;
   }
 
 #undef FAIL_PRIVATEUSE1HOOKS_FUNC

--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -43,6 +43,7 @@ set(TORCH_API_TEST_SOURCES
   ${TORCH_API_TEST_DIR}/grad_mode.cpp
   ${TORCH_API_TEST_DIR}/operations.cpp
   ${TORCH_API_TEST_DIR}/nested_int.cpp
+  ${TORCH_API_TEST_DIR}/privateuse1_test.cpp
 )
 if(USE_CUDA OR USE_ROCM)
   list(APPEND TORCH_API_TEST_SOURCES ${TORCH_API_TEST_DIR}/parallel.cpp)

--- a/test/cpp/api/privateuse1_test.cpp
+++ b/test/cpp/api/privateuse1_test.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+
+#include <ATen/AccumulateType.h>
+#include <ATen/detail/PrivateUse1HooksInterface.h>
+#include <c10/core/ScalarType.h>
+#include <c10/util/Exception.h>
+#include <test/cpp/api/support.h>
+#include <torch/types.h>
+#include <torch/utils.h>
+
+#include <optional>
+
+// Exercises the "registered but unequipped" path: a `PrivateUse1HooksInterface`
+// subclass that leaves `toAccumulateType` to the base-class default (returns
+// `std::nullopt` for every dtype). Every dtype should defer to the CPU
+// accumulation type and emit `TORCH_WARN_ONCE`.
+//
+// `RegisterPrivateUse1HooksInterface` is process-global and one-shot, so the
+// registration is guarded by `isPrivateUse1HooksRegistered()`: if another test
+// in the `test_api` binary has already registered hooks, this test skips
+// rather than tripping the one-shot `TORCH_CHECK`.
+
+namespace {
+
+c10::ScalarType cpu_acc_type(c10::ScalarType t) {
+  return at::toAccumulateType(t, c10::DeviceType::CPU);
+}
+
+// Registered hooks that do NOT override `toAccumulateType`. The base-class
+// default returns `std::nullopt` for every dtype, so every query should defer
+// to the CPU accumulation type and emit `TORCH_WARN_ONCE`.
+struct DefaultAccTypeHooks final : at::PrivateUse1HooksInterface {
+  bool hasPrimaryContext(c10::DeviceIndex) const override {
+    return true;
+  }
+};
+
+} // namespace
+
+TEST(PrivateUse1Test, RegisteredWithoutOverrideDefersToCpuAndWarnsOnce) {
+  if (at::isPrivateUse1HooksRegistered()) {
+    GTEST_SKIP()
+        << "PrivateUse1 hooks already registered by another test; one-shot "
+        << "registration prevents the unequipped-default path from running.";
+  }
+
+  at::RegisterPrivateUse1HooksInterface(new DefaultAccTypeHooks());
+
+  // kFloat is the canary: CPU default is kDouble, so a buggy implementation
+  // that didn't actually take the fallback would be caught here.
+  for (auto t : {
+           c10::ScalarType::Half,
+           c10::ScalarType::BFloat16,
+           c10::ScalarType::Float,
+           c10::ScalarType::Double,
+           c10::ScalarType::Int,
+           c10::ScalarType::Long,
+       }) {
+    EXPECT_EQ(
+        at::toAccumulateType(t, c10::DeviceType::PrivateUse1), cpu_acc_type(t));
+  }
+
+  // WarnOnce fires per-process; with WarnAlways(true) every call warns, so the
+  // captured log records at least one warning after multiple calls and
+  // contains the documented substr.
+  torch::test::WarningCapture capture;
+  c10::WarningUtils::WarnAlways warn_always(true);
+  EXPECT_EQ(
+      at::toAccumulateType(
+          c10::ScalarType::Float, c10::DeviceType::PrivateUse1),
+      cpu_acc_type(c10::ScalarType::Float));
+  EXPECT_FALSE(capture.messages().empty());
+  EXPECT_NE(capture.str().find("accumulate-type mapping"), std::string::npos);
+}


### PR DESCRIPTION
**at::toAccumulateType(ScalarType, DeviceType)** previously hard-coded the CPU accumulation type for PrivateUse1 regardless of any registered backend. Out-of-tree accelerators whose accumulation semantics differ from CPU (e.g. fp16/bf16 accumulating in fp16, or int8 in int32) had no way to advertise that through the existing PrivateUse1HooksInterface, and were silently given the wrong intermediate dtype in normalization / reduce / autograd kernels that consult toAccumulateType.

Fix: add a virtual std::optional<c10::ScalarType> toAccumulateType( ScalarType) const to PrivateUse1HooksInterface (default nullopt).The PrivateUse1 arm in AccumulateType.cpp now consults the registered hooks (if any) and returns the override when present; on nullopt or unregistered, it falls back to the CPU accumulation type and emits TORCH_WARN_ONCE pointing the backend author at the override. The std::optional return (rather than a sentinel like Undefined) makes "not handled" explicit and generalizes to future optional metadata queries on the same interface.

Test plan:
$ cd build && ninja test_api
$ ./bin/test_api --gtest_filter='PrivateUse1Test*'
expect: 1 PASSED, with TORCH_WARN_ONCE lines from AccumulateType.cpp
under WarnAlways(true); dtype-by-dtype EXPECT_EQ against the CPU accumulation type (kFloat -> kDouble is the canary).

fixes #189046