### PR TITLE
[Inductor] Guard loop reindexing against coalescing loss

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -764,6 +764,42 @@ class LoopOrderingTest(TestCase):
         # variance reduction + block reduction = 2 kernels
         self.assertEqual(2, metrics.generated_kernel_count)
 
+    def test_upsample_into_reduction_keeps_coalesced_loops(self):
+        """
+        Nearest-neighbour upsample into a conv feeding a GroupNorm. The
+        pointwise leaves ahead of the GroupNorm reduction can be reindexed
+        onto the reduction's split, but doing so makes their reads
+        uncoalesced, and the fusion it unlocks does not pay for that.
+
+        Expected: the reindex is rolled back, so the upsample keeps its
+        coalesced loop order.
+
+        Regression test for https://github.com/pytorch/pytorch/issues/189488
+        """
+
+        class Mod(nn.Module):
+            def __init__(self, channels, groups):
+                super().__init__()
+                self.conv = nn.Conv2d(channels, channels, 3, padding=1)
+                self.norm = nn.GroupNorm(groups, channels, eps=1e-6)
+                self.skip = nn.Conv2d(channels, channels, 1)
+
+            def forward(self, x, residual):
+                x = (x + residual) / 1.41421356237
+                x = F.interpolate(x, scale_factor=2.0, mode="nearest")
+                x = self.conv(x)
+                y = F.silu(self.norm(x))
+                return y + (self.skip(x) * 0.01)
+
+        channels = 128
+        mod = Mod(channels, 32).eval()
+        x = torch.randn(8, channels, 32, 32)
+        residual = torch.randn_like(x)
+
+        with torch.no_grad():
+            self.do_acc_test(mod, x, residual)
+        self.assertEqual(6, metrics.generated_kernel_count)
+
     @inductor_config.patch(
         {
             "assert_indirect_indexing": False,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -4186,6 +4186,17 @@ class _LoopMutationTracker:
         self.state.restore()
 
 
+def _uncoalesced_memory_score(nodes: Sequence[BaseSchedulerNode]) -> int | None:
+    # None means the analysis was unavailable, which is distinct from a score of 0
+    total = 0
+    for node in nodes:
+        coalesce_analysis = node.get_coalesce_analysis()
+        if coalesce_analysis is None:
+            return None
+        total += sum(coalesce_analysis.uncoalesced_addrs.values())
+    return total
+
+
 class Scheduler:
     """
     A Scheduler is a graph of BaseSchedulerNodes. It is responsible for
@@ -7520,6 +7531,7 @@ class Scheduler:
         # failed reindex attempt returns -1 and the caller may keep evaluating
         # fusion within the same can_fuse() call.
         rollback_snapshot = _LoopStateSnapshot.create((pw_node,))
+        uncoalesced_before = _uncoalesced_memory_score(snodes)
 
         for sn in snodes:
             sn.apply_loop_reindexing([red_numel, red_rnumel])
@@ -7541,6 +7553,24 @@ class Scheduler:
         if not has_benefit:
             rollback_snapshot.restore()
             return False
+
+        # score_fusion_memory() intersects deps exactly, so it is 0 when the deps
+        # only match after normalization, making this zero-tolerance for that case
+        # and proportional elsewhere. uncoalesced_addrs weights writes 2x, so the
+        # comparison errs toward rolling back.
+        uncoalesced_after = _uncoalesced_memory_score(snodes)
+        if uncoalesced_before is not None and uncoalesced_after is not None:
+            uncoalesced_added = uncoalesced_after - uncoalesced_before
+            shared_bytes = self.score_fusion_memory(node1, node2)
+            if uncoalesced_added > shared_bytes:
+                loop_ordering_log.debug(
+                    "rolling back reindex of %s: uncoalesced +%d > shared %d",
+                    pw_node.get_name(),
+                    uncoalesced_added,
+                    shared_bytes,
+                )
+                rollback_snapshot.restore()
+                return False
 
         # When loop ordering is disabled, re-extract deps with
         # normalize=True so variable names are canonical. This is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo