### PR TITLE
Fix index_add_/index_reduce_ docs referring to a src argument

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2353,9 +2353,9 @@ match :attr:`self`, or an error will be raised.
 
 For a 3-D tensor the output is given as::
 
-    self[index[i], :, :] += alpha * src[i, :, :]  # if dim == 0
-    self[:, index[i], :] += alpha * src[:, i, :]  # if dim == 1
-    self[:, :, index[i]] += alpha * src[:, :, i]  # if dim == 2
+    self[index[i], :, :] += alpha * source[i, :, :]  # if dim == 0
+    self[:, index[i], :] += alpha * source[:, i, :]  # if dim == 1
+    self[:, :, index[i]] += alpha * source[:, :, i]  # if dim == 2
 
 Note:
     {forward_reproducibility_note}
@@ -2502,9 +2502,9 @@ match :attr:`self`, or an error will be raised.
 For a 3-D tensor with :obj:`reduce="prod"` and :obj:`include_self=True` the
 output is given as::
 
-    self[index[i], :, :] *= src[i, :, :]  # if dim == 0
-    self[:, index[i], :] *= src[:, i, :]  # if dim == 1
-    self[:, :, index[i]] *= src[:, :, i]  # if dim == 2
+    self[index[i], :, :] *= source[i, :, :]  # if dim == 0
+    self[:, index[i], :] *= source[:, i, :]  # if dim == 1
+    self[:, :, index[i]] *= source[:, :, i]  # if dim == 2
 
 Note:
     {forward_reproducibility_note}


### PR DESCRIPTION
Follow-up to @malfet's review comment on #189008: https://github.com/pytorch/pytorch/pull/189008#discussion_r3528898334

`Tensor.index_add_` and `Tensor.index_reduce_` both take an argument named `source`, and both docstrings use `source` throughout the prose. Their "output is given as" blocks index a `src` instead, which is not a parameter of either method:

```
index_add_(dim, index, source, *, alpha=1) -> Tensor
    self[index[i], :, :] += alpha * src[i, :, :]  # if dim == 0

index_reduce_(dim, index, source, reduce, *, include_self=True) -> Tensor
    self[index[i], :, :] *= src[i, :, :]  # if dim == 0
```

The `scatter_` / `scatter_add_` / `scatter_reduce_` family a few hundred lines below does take a `src` and uses it correctly, which is where the name looks to have leaked in from.

This renames the six lines to `source`. Docs only, no runtime change. `index_copy_` was checked and is already consistent (it takes `tensor` and its prose and Args both say `tensor`); `torch/_torch_docs.py` has no `src[` occurrences at all, so nothing to change there.
