### PR TITLE
[TEST] Refactor test_optimizers.py with hw_classification

### DIFF
--- a/test/distributed/tensor/test_optimizers.py
+++ b/test/distributed/tensor/test_optimizers.py
@@ -13,9 +13,11 @@ from torch.distributed.tensor import (
     Shard,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TestCase,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
@@ -53,7 +55,18 @@ def output_fn(mod, outputs, device_mesh):
     return outputs.redistribute(placements=[Replicate()] * device_mesh.ndim).to_local()
 
 
-class TestDTensorOptimizer(DTensorTestBase):
+class TestDTensorOptimizerGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_optimizer_foreach_supported_types_include_DTensor(self):
+        from torch.optim.optimizer import _foreach_supported_types
+
+        self.assertTrue(DTensor in _foreach_supported_types)
+
+
+class TestDTensorOptimizerAccelerator(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _assert_optimizer(
         self,
         mesh,
@@ -86,11 +99,6 @@ class TestDTensorOptimizer(DTensorTestBase):
                 p2 = p2.full_tensor()
                 # Default 'rtol' and 'atol' for attr:`~torch.float32` are ``1.3e-6`` and ``1e-5``
                 self.assertEqual(p1, p2, atol=atol, rtol=rtol)
-
-    def test_optimizer_foreach_supported_types_include_DTensor(self):
-        from torch.optim.optimizer import _foreach_supported_types
-
-        self.assertTrue(DTensor in _foreach_supported_types)
 
     @with_comms
     def test_adam_1d_sharding(self):
@@ -776,10 +784,10 @@ class TestDTensorOptimizer(DTensorTestBase):
         )
 
 
-instantiate_parametrized_tests(TestDTensorOptimizer)
+instantiate_parametrized_tests(TestDTensorOptimizerAccelerator)
 
 TestDTensorOptimizerWithLocalTensor = create_local_tensor_test_class(
-    TestDTensorOptimizer,
+    TestDTensorOptimizerAccelerator,
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Apply hardware classification for `test/distributed/tensor/test_optimizers.py`

Changes:
- Split `TestDTensorOptimizer` into `TestDTensorOptimizerGeneric` (hw_classification = GENERIC, 1 test) + `TestDTensorOptimizerAccelerator` (hw_classification = ACCELERATOR, 12 tests)
- `test_optimizer_foreach_supported_types_include_DTensor` moved to GENERIC — pure Python-level check with no device or distributed references
- All `@with_comms` distributed optimizer tests remain in ACCELERATOR — backend-agnostic DTensor tests using `self.device_type`
- `TestDTensorOptimizerWithLocalTensor` (dynamically created via `create_local_tensor_test_class`) inherits hw_classification = ACCELERATOR automatically

## Test Plan
```bash
python test/distributed/tensor/test_optimizers.py -v 
python test/distributed/tensor/test_optimizers.py -v --hw-classification GENERIC
python test/distributed/tensor/test_optimizers.py -v --hw-classification ACCELERATOR
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508 