### PR TITLE
[dynamo] Add check_positional/no_positional arg helpers mirroring CPython

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3319,11 +3319,15 @@ def check_positional(
     if nargs < min_args:
         rel = "" if min_args == max_args else "at least "
         s = "" if min_args == 1 else "s"
-        raise_type_error(tx, f"{funcname} expected {rel}{min_args} argument{s}, got {nargs}")
+        raise_type_error(
+            tx, f"{funcname} expected {rel}{min_args} argument{s}, got {nargs}"
+        )
     if nargs > max_args:
         rel = "" if min_args == max_args else "at most "
         s = "" if max_args == 1 else "s"
-        raise_type_error(tx, f"{funcname} expected {rel}{max_args} argument{s}, got {nargs}")
+        raise_type_error(
+            tx, f"{funcname} expected {rel}{max_args} argument{s}, got {nargs}"
+        )
 
 
 def no_positional(

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3303,6 +3303,51 @@ def raise_args_mismatch(
     )
 
 
+def check_positional(
+    tx: InstructionTranslatorBase,
+    funcname: str,
+    nargs: int,
+    min_args: int,
+    max_args: int,
+) -> None:
+    # Mirrors CPython _PyArg_CheckPositional (Python/getargs.c): enforce
+    # min_args <= nargs <= max_args with CPython's exact TypeError text. Used
+    # for METH_FASTCALL methods, whose positional count MethodFlags (derived
+    # from ml_flags) cannot check.
+    from torch._dynamo.exc import raise_type_error
+
+    if nargs < min_args:
+        rel = "" if min_args == max_args else "at least "
+        s = "" if min_args == 1 else "s"
+        raise_type_error(tx, f"{funcname} expected {rel}{min_args} argument{s}, got {nargs}")
+    if nargs > max_args:
+        rel = "" if min_args == max_args else "at most "
+        s = "" if max_args == 1 else "s"
+        raise_type_error(tx, f"{funcname} expected {rel}{max_args} argument{s}, got {nargs}")
+
+
+def no_positional(
+    tx: InstructionTranslatorBase, funcname: str, args: list[VariableTracker]
+) -> None:
+    # Mirrors CPython _PyArg_NoPositional (Python/getargs.c).
+    from torch._dynamo.exc import raise_type_error
+
+    if args:
+        raise_type_error(tx, f"{funcname}() takes no positional arguments")
+
+
+def no_keywords(
+    tx: InstructionTranslatorBase, funcname: str, kwargs: dict[str, VariableTracker]
+) -> None:
+    # Mirrors CPython _PyArg_NoKeywords / _PyArg_NoKwnames (Python/getargs.c).
+    # For methods reached via tp_methods, MethodFlags already rejects kwargs;
+    # use this only where MethodFlags does not run (e.g. tp_init constructors).
+    from torch._dynamo.exc import raise_type_error
+
+    if kwargs:
+        raise_type_error(tx, f"{funcname}() takes no keyword arguments")
+
+
 def iter_contains(
     items: Iterable[VariableTracker],
     search: VariableTracker,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189431
* #189430
* #189429
* #189909
* #189435
* #189434
* #189433
* #189432
* #189910
* #191365
* __->__ #191361
* #190971

Introduce check_positional and no_positional in torch/_dynamo/utils.py, the
Python analogs of CPython's _PyArg_CheckPositional and _PyArg_NoPositional
(Python/getargs.c). tp_methods arity is otherwise enforced by MethodFlags
derived from a method's ml_flags, but METH_FASTCALL carries no positional
min/max (it maps to VARARGS), so handlers hand-rolled those checks via
raise_args_mismatch, whose message diverges from eager. These helpers raise
CPython's exact TypeError text and are consumed by the FASTCALL handlers
migrated in the following commits.

Test Plan:

```
pixi run -w pytorch -e pytorch313 python test/dynamo/test_dicts.py
pixi run -w pytorch -e pytorch313 python test/dynamo/test_functions.py
```

Verified byte-for-byte message parity with eager for dict.get/pop/setdefault
and list.index/pop/insert/sort positional-count violations.

Authored with assistance from Claude Code.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98