### PR TITLE
[MPS] Drain in-flight work before stopping metal capture

### DIFF
--- a/aten/src/ATen/mps/MPSProfiler.mm
+++ b/aten/src/ATen/mps/MPSProfiler.mm
@@ -812,17 +812,28 @@ void MPSProfiler::startCapture(const std::string& name, MPSStream* stream) {
 }
 
 void MPSProfiler::stopCapture(MPSStream* stream) {
-  // Drain in-flight GPU work before stopping the capture, otherwise
-  // stopCapture can race with command buffers still executing on the captured
-  // object while Metal serializes the trace, which can crash natively.
+  // Metal only requires command buffers to be committed (not completed)
+  // before stopCapture, but stopping while work is still in flight
+  // intermittently segfaults in capture teardown on some macOS versions
+  // (suspected Metal capture race, see #191362). Defensively drain first.
   // A null stream means the capture was started on the whole device (see
   // startCapture), so drain every stream created so far.
-  if (stream) {
-    stream->synchronize(SyncType::COMMIT_AND_WAIT);
-  } else {
-    synchronizeAllMPSStreams(SyncType::COMMIT_AND_WAIT);
+  // The drain can surface a device-side error from captured kernels
+  // (checkLastError); always close the capture before propagating it.
+  std::exception_ptr drain_error;
+  try {
+    if (stream) {
+      stream->synchronize(SyncType::COMMIT_AND_WAIT);
+    } else {
+      synchronizeAllMPSStreams(SyncType::COMMIT_AND_WAIT);
+    }
+  } catch (...) {
+    drain_error = std::current_exception();
   }
   [captureManager stopCapture];
+  if (drain_error) {
+    std::rethrow_exception(drain_error);
+  }
 }
 
 } // namespace Profiler

--- a/aten/src/ATen/mps/MPSProfiler.mm
+++ b/aten/src/ATen/mps/MPSProfiler.mm
@@ -812,9 +812,13 @@ void MPSProfiler::startCapture(const std::string& name, MPSStream* stream) {
 }
 
 void MPSProfiler::stopCapture(MPSStream* stream) {
-  if (stream) {
-    stream->synchronize(SyncType::COMMIT);
+  // Drain all in-flight GPU work before stopping the capture, otherwise
+  // stopCapture races with command buffers still executing on the captured
+  // device/queue while Metal serializes the trace, which can crash natively
+  if (!stream) {
+    stream = getDefaultMPSStream();
   }
+  stream->synchronize(SyncType::COMMIT_AND_WAIT);
   [captureManager stopCapture];
 }
 

--- a/aten/src/ATen/mps/MPSProfiler.mm
+++ b/aten/src/ATen/mps/MPSProfiler.mm
@@ -812,13 +812,16 @@ void MPSProfiler::startCapture(const std::string& name, MPSStream* stream) {
 }
 
 void MPSProfiler::stopCapture(MPSStream* stream) {
-  // Drain all in-flight GPU work before stopping the capture, otherwise
-  // stopCapture races with command buffers still executing on the captured
-  // device/queue while Metal serializes the trace, which can crash natively
-  if (!stream) {
-    stream = getDefaultMPSStream();
+  // Drain in-flight GPU work before stopping the capture, otherwise
+  // stopCapture can race with command buffers still executing on the captured
+  // object while Metal serializes the trace, which can crash natively.
+  // A null stream means the capture was started on the whole device (see
+  // startCapture), so drain every stream created so far.
+  if (stream) {
+    stream->synchronize(SyncType::COMMIT_AND_WAIT);
+  } else {
+    synchronizeAllMPSStreams(SyncType::COMMIT_AND_WAIT);
   }
-  stream->synchronize(SyncType::COMMIT_AND_WAIT);
   [captureManager stopCapture];
 }
 

--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -163,6 +163,11 @@ TORCH_API MPSStream* getDefaultMPSStream();
  */
 TORCH_API MPSStream* getStreamFromPool();
 
+/**
+ * Synchronize the default stream and any pool streams created so far.
+ */
+TORCH_API void synchronizeAllMPSStreams(SyncType syncType);
+
 //-----------------------------------------------------------------
 //  MPSStreamImpl
 //-----------------------------------------------------------------

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -311,18 +311,35 @@ constexpr int kMPSStreamsPerPool = 32;
 std::array<MPSStream*, kMPSStreamsPerPool> stream_pool{};
 c10::once_flag stream_pool_flag;
 std::atomic<uint32_t> stream_pool_counter{0};
+std::atomic<bool> stream_pool_initialized{false};
 
 void initStreamPool() {
   // Pool ids start at 1; id 0 is reserved for the default stream.
   for (const auto i : c10::irange(kMPSStreamsPerPool)) {
     stream_pool[i] = new MPSStream(Stream(Stream::UNSAFE, c10::Device(DeviceType::MPS, 0), i + 1));
   }
+  stream_pool_initialized.store(true, std::memory_order_release);
 }
 } // namespace
 
 MPSStream* getStreamFromPool() {
   c10::call_once(stream_pool_flag, initStreamPool);
   return stream_pool[stream_pool_counter++ % kMPSStreamsPerPool];
+}
+
+void synchronizeAllMPSStreams(SyncType syncType) {
+  auto sync = [syncType](MPSStream* stream) {
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      stream->synchronize(syncType);
+    });
+  };
+  sync(getDefaultMPSStream());
+  // don't eagerly create the pool just to synchronize it
+  if (stream_pool_initialized.load(std::memory_order_acquire)) {
+    for (auto* stream : stream_pool) {
+      sync(stream);
+    }
+  }
 }
 
 // Helper methods

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: mps"]
 # ruff: noqa: F841
 import contextlib
+import glob
 import io
 import sys
 import math
@@ -16970,6 +16971,40 @@ class TestMetalLibrary(TestCaseMPS):
         shutil.rmtree(capture_dirname)
         self.assertGreater(len(capture_listdir), 3,
                            lambda msg: f"{msg}\nCapture file {capture_dirname} contains only metadata, i.e. {capture_listdir}")
+
+    @unittest.skipIf(not torch.mps.profiler.is_metal_capture_enabled(), "Set MTL_CAPTURE_ENABLED and try again")
+    def test_metal_capture_nondefault_stream(self):
+        # stopCapture of a device-wide capture must drain pool streams too,
+        # not just the default stream
+        capture_name = f"stream_full{''.join(random.choice('0123456789') for i in range(5))}"
+        stream = torch._C._MPSStreamBase()
+        try:
+            with torch.mps.profiler.metal_capture(capture_name):
+                torch._C._mps_setStream(stream)
+                mps_tensor = torch.zeros(32, device="mps")
+                mps_tensor += 1
+            self.assertFalse(torch.mps.profiler.is_capturing_metal())
+            self.assertEqual(mps_tensor.sum().item(), mps_tensor.numel())
+        finally:
+            torch._C._mps_setStream(None)
+        capture_dirnames = glob.glob(f"*-{capture_name}.gputrace")
+        for dirname in capture_dirnames:
+            shutil.rmtree(dirname)
+        self.assertEqual(len(capture_dirnames), 1)
+
+    @unittest.skipIf(not torch.mps.profiler.is_metal_capture_enabled(), "Set MTL_CAPTURE_ENABLED and try again")
+    def test_metal_capture_exception(self):
+        # stopCapture must drain in-flight work even when the body raises
+        capture_name = f"raise_full{''.join(random.choice('0123456789') for i in range(5))}"
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            with torch.mps.profiler.metal_capture(capture_name):
+                mps_tensor = torch.zeros(32, device="mps")
+                mps_tensor += 1
+                raise RuntimeError("boom")
+        self.assertFalse(torch.mps.profiler.is_capturing_metal())
+        self.assertEqual(mps_tensor.sum().item(), mps_tensor.numel())
+        for dirname in glob.glob(f"*-{capture_name}.gputrace"):
+            shutil.rmtree(dirname)
 
     def test_metal_lambda_expressions(self):
         # Lambda expressions require Metal 3.2 (macOS 15+)

--- a/torch/csrc/mps/Module.cpp
+++ b/torch/csrc/mps/Module.cpp
@@ -564,7 +564,12 @@ void initModule(PyObject* module) {
   m.def("_mps_startCapture", [](const std::string& fileName) {
     at::mps::getMPSProfiler().startCapture(fileName);
   });
-  m.def("_mps_stopCapture", []() { at::mps::getMPSProfiler().stopCapture(); });
+  m.def("_mps_stopCapture", []() {
+    // See MPSModule_deviceSynchronize: stopCapture drains the stream, so the
+    // GIL must be released while waiting on GPU work
+    pybind11::gil_scoped_release no_gil;
+    at::mps::getMPSProfiler().stopCapture();
+  });
   m.def("_mps_get_name", []() {
     return at::mps::MPSDevice::getInstance()->getName();
   });

--- a/torch/mps/profiler.py
+++ b/torch/mps/profiler.py
@@ -94,7 +94,7 @@ def metal_capture(fname: str) -> Iterator[None]:
     try:
         torch._C._mps_startCapture(fname)  # type: ignore[attr-defined]
         yield
-        # Drain all the work that were enqueued during the context call
-        torch.mps.synchronize()
     finally:
+        # _mps_stopCapture drains all work enqueued during the context call
+        # before stopping the capture, even if the body raised
         torch._C._mps_stopCapture()  # type: ignore[attr-defined]

--- a/torch/mps/profiler.py
+++ b/torch/mps/profiler.py
@@ -95,6 +95,6 @@ def metal_capture(fname: str) -> Iterator[None]:
         torch._C._mps_startCapture(fname)  # type: ignore[attr-defined]
         yield
     finally:
-        # _mps_stopCapture drains all work enqueued during the context call
-        # before stopping the capture, even if the body raised
+        # _mps_stopCapture waits for work enqueued on MPS streams before
+        # stopping the capture, even if the body raised
         torch._C._mps_stopCapture()  # type: ignore[attr-defined]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191362

Works around an intermittent SIGSEGV in test_metal_capture on the
macos-m2-15 trunk runner (~4% of runs, never on macos-m1-14).

Hypothesis (code-reading only; no crash log or repro was available):
MPSProfiler::stopCapture(stream) only synchronized the stream when a
stream was explicitly passed, and the Python binding _mps_stopCapture
passes none, so [MTLCaptureManager stopCapture] could tear down the
device-wide capture while command buffers were still executing and
completion handlers (e.g. MPSAllocator buffer-free handlers) were still
running on Metal's dispatch threads. Note Metal's documented contract
only requires command buffers to be committed (not completed) before
stopCapture - Apple's own programmatic-capture example commits and
immediately stops - so if this overlap is indeed the trigger, the
underlying defect is a Metal capture-teardown race (or a PyTorch
object-lifetime race it exposes), not a violated API precondition.
Draining first is defensive: it removes the only overlap we could
identify by reading the code, and the timing/OS-version dependence
matches the flake. Confirmation has to come from watching trunk
macos-m2-15 after landing; a standalone Metal reproducer isolating
whether scheduling, GPU completion, or completion handlers matter
would be the ideal follow-up.

The workaround: stopCapture now drains with COMMIT_AND_WAIT (COMMIT
alone only enqueues) before stopping. Since the no-stream overload
captures the whole MTLDevice, it must drain more than the default
stream: a new synchronizeAllMPSStreams() waits on the default stream
plus any pool streams created so far (without eagerly instantiating
the pool), each through its serial dispatch queue since command-buffer
state is only serialized by that queue. Because the drain can surface
a deferred device-side error from checkLastError, stopCapture closes
the capture before propagating such an error, so a failed capture is
never left open. The binding releases the GIL since stopCapture now
blocks on GPU work (same rationale as MPSModule_deviceSynchronize),
and the Python context manager drops its now-redundant happy-path-only
synchronize so the exception path is covered too.

Alternatives considered: capturing the stream's commandQueue instead
of the device would shrink the capture surface but changes what the
trace contains (work on other queues would vanish), and keeping the
drain in the Python context manager instead of native stopCapture
would leave the C++-only capture users (#144560) unprotected; both
rejected.

Test Plan:

Two new tests cover the previously-unguarded paths: a capture with work
enqueued on a non-default (pool) stream, and a capture whose body
raises. Both run under MTL_CAPTURE_ENABLED=1 in the trunk mps job via
the existing -k test_metal_capture filter:

```
MTL_CAPTURE_ENABLED=1 python3 test/test_mps.py --verbose -k test_metal_capture
```

No macOS machine was available in this environment, so verified the
Python parses and the diff is lint-clean; the flake fix itself can only
be confirmed by watching trunk macos-m2-15 runs after landing:

```
python3 -c "import ast; ast.parse(open('test/test_mps.py').read())"
lintrunner -a torch/mps/profiler.py torch/csrc/mps/Module.cpp aten/src/ATen/mps/MPSProfiler.mm aten/src/ATen/mps/MPSStream.mm aten/src/ATen/mps/MPSStream.h test/test_mps.py
```

Authored with Claude Code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>