### PR TITLE
[aotautograd] Cache graphs containing autocast/inference_mode context managers

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3277,6 +3277,68 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
             )
         compile_fx.compile_fx(gm, [[fake_x, fake_y]])
 
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_autocast_in_graph_cache_hit(self):
+        """
+        An autocast region *inside* the compiled function traces
+        _enter_autocast/_exit_autocast nodes into the graph. These must not
+        bypass AOTAutogradCache, otherwise AMP models never cache. See #191106.
+        """
+
+        def fn(x):
+            with torch.autocast("cpu", dtype=torch.bfloat16):
+                return (x @ x).relu().sum()
+
+        x = torch.randn(8, 8, requires_grad=True)
+        compiled_fn = torch.compile(fn, backend="inductor")
+
+        # First call misses and saves (no bypass).
+        compiled_fn(x).backward()
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_bypass"], 0)
+
+        # Second call hits after clearing in-memory state.
+        self._clear_dynamo_and_codecache()
+        compiled_fn(x).backward()
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_inference_mode_in_graph_cache_hit(self):
+        """
+        Same as test_autocast_in_graph_cache_hit, but for torch.inference_mode,
+        which traces _enter_inference_mode/_exit_inference_mode nodes. See
+        #191106.
+        """
+
+        def fn(x):
+            with torch.inference_mode():
+                return (x @ x).relu().sum()
+
+        x = torch.randn(8, 8)
+        compiled_fn = torch.compile(fn, backend="inductor")
+
+        # First call misses and saves (no bypass).
+        compiled_fn(x)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_bypass"], 0)
+
+        # Second call hits after clearing in-memory state.
+        self._clear_dynamo_and_codecache()
+        compiled_fn(x)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+
     @unittest.skipIf(not HAS_GPU, "requires accelerator")
     @functorch_config.patch({"enable_autograd_cache": True})
     @inductor_config.patch("fx_graph_cache", True)
@@ -3682,6 +3744,33 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
             self.assertRaises(
                 BypassAOTAutogradCache, lambda: self.gen_cache_key(fn, config)
             )
+
+    def test_autocast_in_graph_is_cacheable(self):
+        # torch.autocast used *inside* a compiled region traces
+        # _enter_autocast/_exit_autocast nodes into the graph. Their behavior is
+        # fully determined by their args (device type, dtype, enabled), which are
+        # hashed into the cache key, so they must be cacheable rather than
+        # bypassing AMP models wholesale. See issue #191106.
+        def fn(x):
+            with torch.autocast("cpu", dtype=torch.bfloat16):
+                return (x @ x).relu().sum()
+
+        config = self.default_config()
+        # Should not raise BypassAOTAutogradCache
+        self.gen_cache_key(fn, config, inputs=[torch.randn(4, 4)])
+
+    def test_inference_mode_in_graph_is_cacheable(self):
+        # torch.inference_mode used *inside* a compiled region traces
+        # _enter_inference_mode/_exit_inference_mode nodes into the graph. Same
+        # bug class as autocast (see #191106): behavior is fully determined by
+        # the enabled arg, which is hashed into the cache key.
+        def fn(x):
+            with torch.inference_mode():
+                return (x @ x).relu().sum()
+
+        config = self.default_config()
+        # Should not raise BypassAOTAutogradCache
+        self.gen_cache_key(fn, config, inputs=[torch.randn(4, 4)])
 
     @torch._inductor.config.patch({"freezing": True})
     def test_freezing(self):

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3759,6 +3759,23 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         # Should not raise BypassAOTAutogradCache
         self.gen_cache_key(fn, config, inputs=[torch.randn(4, 4)])
 
+    def test_autocast_no_dtype_in_graph_bypasses(self):
+        # torch.autocast(device) with no explicit dtype traces to
+        # _enter_autocast(device, None, ...): the effective dtype is resolved
+        # at runtime from ambient torch.get_autocast_dtype, which is not part
+        # of the cache key when autocast is entered inside the graph. Caching
+        # this form would collide artifacts compiled under different ambient
+        # defaults, so it must bypass. See #191106.
+        def fn(x):
+            with torch.autocast("cpu"):
+                return (x @ x).relu().sum()
+
+        config = self.default_config()
+        with self.assertRaisesRegex(
+            BypassAOTAutogradCache, "_enter_autocast with a non-constant dtype"
+        ):
+            self.gen_cache_key(fn, config, inputs=[torch.randn(4, 4)])
+
     def test_inference_mode_in_graph_is_cacheable(self):
         # torch.inference_mode used *inside* a compiled region traces
         # _enter_inference_mode/_exit_inference_mode nodes into the graph. Same

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -172,6 +172,14 @@ def check_node_safe(node: Node) -> None:
         "torch.sym_sum",
         "torch.autograd.grad",
         "torch.distributed.tensor._api.from_local",
+        # Autocast/inference_mode regions inside a compiled function trace these
+        # _enter_*/_exit_* nodes into the graph. Their behavior is fully
+        # determined by their args (device type, dtype, enabled), which are
+        # hashed into the cache key. See #191106.
+        "torch.amp.autocast_mode._enter_autocast",
+        "torch.amp.autocast_mode._exit_autocast",
+        "torch.autograd.grad_mode._enter_inference_mode",
+        "torch.autograd.grad_mode._exit_inference_mode",
     )
     SAFE_NON_TORCH_FUNCTIONS = (
         "einops.einops.rearrange",

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -255,6 +255,26 @@ def check_node_safe(node: Node) -> None:
             raise BypassAOTAutogradCache(
                 f"Unsupported call_function target {node.target}. \n Function module: {module}, \nFunction name: {name}"
             )
+        # torch.autocast(device) with no explicit dtype traces to
+        # _enter_autocast(device, None, ...): the effective dtype is resolved at
+        # runtime from ambient torch.get_autocast_dtype(device). That ambient
+        # default is only folded into the cache key when autocast is already
+        # enabled (see #181564), which it is not when the autocast region is
+        # entered inside the compiled function. A non-constant dtype (a Node) is
+        # likewise not pinned in the key. Refuse to cache either form so we
+        # don't reuse an artifact compiled under a different effective dtype.
+        if (
+            getattr(node.target, "__module__", None) == "torch.amp.autocast_mode"
+            and getattr(node.target, "__name__", None) == "_enter_autocast"
+        ):
+            # _enter_autocast args: (device_type, dtype, enabled, cache_enabled)
+            dtype_arg = node.args[1] if len(node.args) > 1 else None
+            if dtype_arg is None or isinstance(dtype_arg, Node):
+                raise BypassAOTAutogradCache(
+                    "_enter_autocast with a non-constant dtype (dtype=None resolves "
+                    "from ambient torch.get_autocast_dtype, which is not in the cache "
+                    "key unless autocast is already enabled)"
+                )
     elif node.op == "call_method":
         method_name = node.target
         method_target = node.args[0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191409
* __->__ #191363

When a torch.autocast or torch.inference_mode region is inside a
torch.compile'd function, Dynamo traces _enter_autocast/_exit_autocast (or
_enter_inference_mode/_exit_inference_mode) nodes into the FX graph. These
functions were not on the AOTAutogradCache cacheability allowlist in
check_node_safe, so check_cacheable raised BypassAOTAutogradCache on the
first such node and AOTAutograd caching was disabled for the entire graph.

Because AMP/autocast is ubiquitous in training, this meant a large class of
real models got no AOTAutograd caching at all: every process re-traced the
joint forward+backward graph and re-ran the partitioner on every run/restart,
even with a warm remote cache (FxGraphCache still worked, so Inductor stayed
cached, but the trace+partition cost was paid every time). Scuba shows
_enter_autocast is the single largest allowlist-gap cache bypass in prod.

The bypass is an allowlist gap, not a fundamental limitation: each node's
behavior is fully determined by its args (device type, dtype, enabled/mode),
which are present in the graph and hashed into the cache key (#181564 already
folds the ambient autocast dtype into the key). Adding the four functions to
SAFE_TORCH_FUNCTIONS makes these graphs cacheable. Both _enter and _exit must
be allowlisted for each: check_node_safe stops at the first unsupported node,
so allowlisting only _enter would just move the bypass to _exit.

Fixes #191106.

Test Plan:

```
python -m pytest test/dynamo/test_aot_autograd_cache.py -k \
  "test_autocast_in_graph_is_cacheable or test_inference_mode_in_graph_is_cacheable or \
   test_autocast_in_graph_cache_hit or test_inference_mode_in_graph_cache_hit"
python -m pytest test/dynamo/test_aot_autograd_cache.py::AOTAutogradCachePicklerTests
```

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98