### PR TITLE
[ROCm] Bundle librocm_smi64.so for ROCm <= 7.2 wheels

### DIFF
--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -145,6 +145,7 @@ ROCM_SO_FILES: list[str] = [
     "librccl.so",
     "librocblas.so",
     "librocfft.so",
+    "libamd_smi.so",
     "librocrand.so",
     "librocsolver.so",
     "librocsparse.so",
@@ -159,31 +160,6 @@ ROCM_SO_FILES: list[str] = [
     "librocm-core.so",
     "librocroller.so",
 ]
-
-
-def _rocm_version_tuple(version: str) -> tuple[int, int]:
-    parts = version.split(".")
-    nums = [int(p) for p in parts[:2] if p.isdigit()]
-    while len(nums) < 2:
-        nums.append(0)
-    return nums[0], nums[1]
-
-
-def rocm_smi_lib(gpu_arch_version: str, desired_cuda: str) -> str:
-    """ROCm <= 7.2 ships librocm_smi64; newer releases use libamd_smi."""
-    version = gpu_arch_version
-    if not version and desired_cuda.startswith("rocm"):
-        version = desired_cuda.removeprefix("rocm")
-    if version and _rocm_version_tuple(version) <= (7, 2):
-        return "librocm_smi64.so"
-    return "libamd_smi.so"
-
-
-def rocm_so_files(gpu_arch_version: str, desired_cuda: str) -> list[str]:
-    files = list(ROCM_SO_FILES)
-    smi_idx = files.index("librocfft.so") + 1
-    files.insert(smi_idx, rocm_smi_lib(gpu_arch_version, desired_cuda))
-    return files
 
 
 def rocm_os_deps() -> list[Path]:
@@ -247,7 +223,7 @@ def rocm_lib_kernels(
 
 
 def rocm_bundle(
-    rocm_home: Path, gpu_arch_version: str, desired_cuda: str
+    rocm_home: Path, gpu_arch_version: str
 ) -> tuple[list[BundledLib], list[AuxFile]]:
     """Build the ROCm bundle spec: shared libs and auxiliary kernel/db files.
 
@@ -257,7 +233,10 @@ def rocm_bundle(
     rewritten to the renamed copies via patchelf in repair_wheel().
     """
     libs: list[BundledLib] = []
-    for stem in rocm_so_files(gpu_arch_version, desired_cuda):
+    so_files = list(ROCM_SO_FILES)
+    if gpu_arch_version and float(gpu_arch_version) <= 7.2:
+        so_files.append("librocm_smi64.so")
+    for stem in so_files:
         path = find_rocm_lib(rocm_home, stem)
         if path is None:
             sys.exit(f"Required ROCm library not found: {stem}")
@@ -434,9 +413,7 @@ def main() -> None:
         force_rpath = True
     elif is_rocm:
         rocm_home = Path(os.environ.get("ROCM_HOME", "/opt/rocm"))
-        bundled_libs, aux_files = rocm_bundle(
-            rocm_home, gpu_arch_version, os.environ.get("DESIRED_CUDA", "")
-        )
+        bundled_libs, aux_files = rocm_bundle(rocm_home, gpu_arch_version)
         c_so_rpath = "$ORIGIN:$ORIGIN/lib"
         lib_so_rpath = "$ORIGIN"
         force_rpath = True

--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -145,7 +145,6 @@ ROCM_SO_FILES: list[str] = [
     "librccl.so",
     "librocblas.so",
     "librocfft.so",
-    "libamd_smi.so",
     "librocrand.so",
     "librocsolver.so",
     "librocsparse.so",
@@ -160,6 +159,31 @@ ROCM_SO_FILES: list[str] = [
     "librocm-core.so",
     "librocroller.so",
 ]
+
+
+def _rocm_version_tuple(version: str) -> tuple[int, int]:
+    parts = version.split(".")
+    nums = [int(p) for p in parts[:2] if p.isdigit()]
+    while len(nums) < 2:
+        nums.append(0)
+    return nums[0], nums[1]
+
+
+def rocm_smi_lib(gpu_arch_version: str, desired_cuda: str) -> str:
+    """ROCm <= 7.2 ships librocm_smi64; newer releases use libamd_smi."""
+    version = gpu_arch_version
+    if not version and desired_cuda.startswith("rocm"):
+        version = desired_cuda.removeprefix("rocm")
+    if version and _rocm_version_tuple(version) <= (7, 2):
+        return "librocm_smi64.so"
+    return "libamd_smi.so"
+
+
+def rocm_so_files(gpu_arch_version: str, desired_cuda: str) -> list[str]:
+    files = list(ROCM_SO_FILES)
+    smi_idx = files.index("librocfft.so") + 1
+    files.insert(smi_idx, rocm_smi_lib(gpu_arch_version, desired_cuda))
+    return files
 
 
 def rocm_os_deps() -> list[Path]:
@@ -222,7 +246,9 @@ def rocm_lib_kernels(
     return files
 
 
-def rocm_bundle(rocm_home: Path) -> tuple[list[BundledLib], list[AuxFile]]:
+def rocm_bundle(
+    rocm_home: Path, gpu_arch_version: str, desired_cuda: str
+) -> tuple[list[BundledLib], list[AuxFile]]:
     """Build the ROCm bundle spec: shared libs and auxiliary kernel/db files.
 
     Versioned ROCm sonames (libfoo.so.6) get renamed to bare .so to match the
@@ -231,7 +257,7 @@ def rocm_bundle(rocm_home: Path) -> tuple[list[BundledLib], list[AuxFile]]:
     rewritten to the renamed copies via patchelf in repair_wheel().
     """
     libs: list[BundledLib] = []
-    for stem in ROCM_SO_FILES:
+    for stem in rocm_so_files(gpu_arch_version, desired_cuda):
         path = find_rocm_lib(rocm_home, stem)
         if path is None:
             sys.exit(f"Required ROCm library not found: {stem}")
@@ -408,7 +434,9 @@ def main() -> None:
         force_rpath = True
     elif is_rocm:
         rocm_home = Path(os.environ.get("ROCM_HOME", "/opt/rocm"))
-        bundled_libs, aux_files = rocm_bundle(rocm_home)
+        bundled_libs, aux_files = rocm_bundle(
+            rocm_home, gpu_arch_version, os.environ.get("DESIRED_CUDA", "")
+        )
         c_so_rpath = "$ORIGIN:$ORIGIN/lib"
         lib_so_rpath = "$ORIGIN"
         force_rpath = True

--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -234,7 +234,8 @@ def rocm_bundle(
     """
     libs: list[BundledLib] = []
     so_files = list(ROCM_SO_FILES)
-    if gpu_arch_version and float(gpu_arch_version) <= 7.2:
+    # librocm_smi64.so is only needed for ROCm7.2 and earlier
+    if gpu_arch_version and tuple(map(int, gpu_arch_version.split(".")[:2])) <= (7, 2):
         so_files.append("librocm_smi64.so")
     for stem in so_files:
         path = find_rocm_lib(rocm_home, stem)


### PR DESCRIPTION
## Summary

PR #190014 migrated wheel repair from `librocm_smi64.so` to `libamd_smi.so` as part of the rocm_smi to amd_smi transition. ROCm 7.2 wheels still depend on `librocm_smi64.so`, so wheel repair fails when that library is not bundled.

The [latest ROCm7.2 binary test job from 07/28](https://github.com/pytorch/pytorch/actions/runs/30341928221/job/90282176024) shows that `librocm_smi64.so` is not bundled:
```
	librocm_smi64.so.1 => /opt/rocm-7.2.1/lib/librocm_smi64.so.1 (0x00007b4be5737000)
```

This shows up in downstream projects such as torchtitan CI: https://github.com/pytorch/torchtitan/actions/runs/30294524429/job/90072157024#step:16:474
```
from torch._C import *  # noqa: F403
    ^^^^^^^^^^^^^^^^^^^^^^
ImportError: librocm_smi64.so.1: cannot open shared object file: No such file or directory
```

This change bundles the rocm-smi library based on `GPU_ARCH_VERSION`:
- ROCm <= 7.2: bundle `librocm_smi64.so`

## Test plan

- [x] ROCm 7.2 manywheel build completes wheel repair successfully, and [the binary test job](https://github.com/pytorch/pytorch/actions/runs/30409907599/job/90479153330?pr=191366) shows that librocm_smi64.so is being picked up from torch/lib installation path instead of /opt/rocm
```
	librocm_smi64.so => /opt/python/cp312-cp312/bin/../lib/python3.12/site-packages/torch/lib/librocm_smi64.so (0x00007fc6c1f5e000)
```

Authored with assistance from Cursor

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang