### PR TITLE
[inductor] Statically launch device-side TMA (global-scratch) Triton kernels

### DIFF
--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -713,6 +713,12 @@ class TestStaticTritonCompileResult(TestCase):
         # can't be statically launched raises CannotStaticallyLaunchKernel, so a
         # clean run proves the TMA kernel was statically launched *and* that the
         # allocated scratch makes it produce correct results.
+        #
+        # We launch repeatedly: the _FastCudaLauncher is built after the first
+        # launch and used for subsequent ones. It pre-zeros scratch slots and
+        # never fills them, so it must NOT be used for kernels that need a real
+        # global-scratch workspace -- otherwise later launches get a null TMA
+        # workspace (illegal memory access / wrong results).
         # Regression test for https://github.com/pytorch/pytorch/issues/191124.
         @torch.compile
         def mm(a, b):
@@ -720,7 +726,9 @@ class TestStaticTritonCompileResult(TestCase):
 
         a = torch.randn(1024, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
         b = torch.randn(1024, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
-        self.assertEqual(mm(a, b), a @ b)
+        expected = a @ b
+        for _ in range(3):
+            self.assertEqual(mm(a, b), expected)
 
     def test_any(self):
         def fn(x):

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -3,6 +3,7 @@ import gc
 import os
 import random
 import tempfile
+import unittest
 import weakref
 from types import SimpleNamespace
 from unittest import mock
@@ -31,6 +32,7 @@ from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import IS_WINDOWS, skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_XPU_AND_TRITON
 from torch.testing._internal.triton_utils import requires_gpu_and_triton
+from torch.utils._triton import has_triton_tma_device
 
 
 if HAS_XPU_AND_TRITON:
@@ -691,6 +693,34 @@ class TestStaticTritonCompileResult(TestCase):
         y = torch.rand(20, device=GPU_TYPE)
         result = foo(x, y)
         self.assertEqual(result, torch.cat(((x * 4), y + 10)))
+
+    @unittest.skipUnless(has_triton_tma_device(), "Requires device-side TMA (sm90+)")
+    @torch._inductor.config.patch(
+        {
+            # Surface CannotStaticallyLaunchKernel in-process (strict raises).
+            "compile_threads": 1,
+            "max_autotune": True,
+            "max_autotune_gemm_backends": "TRITON",
+            "triton.enable_persistent_tma_matmul": True,
+            # The persistent-TMA template rarely wins autotuning, so force it to
+            # be the only GEMM choice.
+            "test_configs.autotune_choice_name_regex": "persistent_tma",
+        }
+    )
+    def test_device_tma_matmul_static_launch(self):
+        # Device-side TMA GEMM kernels (tl.make_tensor_descriptor) need a global
+        # scratch workspace. Under strict_static_triton_launcher a kernel that
+        # can't be statically launched raises CannotStaticallyLaunchKernel, so a
+        # clean run proves the TMA kernel was statically launched *and* that the
+        # allocated scratch makes it produce correct results.
+        # Regression test for https://github.com/pytorch/pytorch/issues/191124.
+        @torch.compile
+        def mm(a, b):
+            return a @ b
+
+        a = torch.randn(1024, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
+        b = torch.randn(1024, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
+        self.assertEqual(mm(a, b), a @ b)
 
     def test_any(self):
         def fn(x):

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -448,8 +448,10 @@ class StaticallyLaunchedTritonKernel:
 
 
 class StaticallyLaunchedCudaKernel(StaticallyLaunchedTritonKernel):
-    # ROCm/HIP allocates global scratch itself at launch (see run()), so only
-    # enable explicit workspace allocation for CUDA.
+    # A non-empty global-scratch workspace comes from device-side TMA, which is
+    # NVIDIA-only; Triton's AMD backend has no global_scratch in its launch ABI,
+    # so it can't arise on ROCm. Keep the conservative bail there rather than
+    # shipping an untested, unreachable allocation path.
     supports_global_scratch: bool = not is_rocm()
 
     @cached_property

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -50,6 +50,13 @@ class StaticallyLaunchedTritonKernel:
     to how it handles constants in 3.3, so there's some special logic necessary to handle both versions.
     """
 
+    # Whether run() can allocate a real device-side global-scratch workspace for
+    # kernels that need one (e.g. device-side TMA / tl.make_tensor_descriptor).
+    # When False, such kernels bail out of static launch. Overridden per-backend.
+    supports_global_scratch: bool = False
+    # torch device type used to allocate that workspace.
+    scratch_device_type: str = "cuda"
+
     @cached_property
     def C_impl(self):
         raise NotImplementedError
@@ -104,23 +111,30 @@ class StaticallyLaunchedTritonKernel:
             kernel.shared if hasattr(kernel, "shared") else kernel.metadata.shared
         )
 
-        def needs_scratch_arg(scratch_name: str, param_name: str) -> bool:
-            # pyrefly: ignore [missing-attribute]
-            if hasattr(kernel.metadata, param_name):
-                # pyrefly: ignore [missing-attribute]
-                if getattr(kernel.metadata, param_name) > 0:
-                    raise NotImplementedError(
-                        f"{scratch_name} scratch not yet supported"
-                    )
-                return True
-            return False
+        # Newer triton versions pass extra scratch parameters (global, then
+        # profile) after the kernel's declared args. A parameter is present in
+        # the compiled kernel's ABI iff the corresponding metadata field exists;
+        # at launch we pass either a real workspace pointer or a nullptr (None).
+        # pyrefly: ignore [missing-attribute]
+        metadata = kernel.metadata
 
-        # Newer triton versions pass an extra global scratch parameter to the compiled cuda kernel.
-        # Inductor never uses this field or enables it, but we still have to pass
-        # an extra None into the set of params if its enabled
-        self.has_global_scratch = needs_scratch_arg("Global", "global_scratch_size")
-        # same situation for profile scratch - triton-lang/triton#7258
-        self.has_profile_scratch = needs_scratch_arg("Profile", "profile_scratch_size")
+        def scratch_size(param_name: str) -> int:
+            return getattr(metadata, param_name, 0) or 0
+
+        self.has_global_scratch = hasattr(metadata, "global_scratch_size")
+        self.global_scratch_size = scratch_size("global_scratch_size")
+        self.global_scratch_align = getattr(metadata, "global_scratch_align", 1) or 1
+        self.has_profile_scratch = hasattr(metadata, "profile_scratch_size")
+
+        # A non-empty global scratch workspace (e.g. device-side TMA descriptor
+        # kernels) is allocated at launch time in run(); only CUDA supports this.
+        # Otherwise bail so the kernel falls back to the normal launch path.
+        if self.global_scratch_size > 0 and not self.supports_global_scratch:
+            raise NotImplementedError("Global scratch not yet supported")
+        # Profiling instrumentation scratch (triton-lang/triton#7258) is never
+        # enabled by inductor.
+        if scratch_size("profile_scratch_size") > 0:
+            raise NotImplementedError("Profile scratch not yet supported")
 
         # pyrefly: ignore [missing-attribute]
         self.tensordesc_meta = getattr(kernel.metadata, "tensordesc_meta", None)
@@ -129,6 +143,7 @@ class StaticallyLaunchedTritonKernel:
         self.arg_tys = self.arg_ty_from_signature(kernel.src)
         self.function: int | None = None  # Loaded by load_kernel(on the parent process)
         self.module: int | None = None  # Owns the HIP/CUDA module loaded for function
+        self.device: int = 0  # Set by load_kernel; used to allocate global scratch
         num_ctas = 1
         if hasattr(kernel, "num_ctas"):
             num_ctas = kernel.num_ctas
@@ -139,6 +154,7 @@ class StaticallyLaunchedTritonKernel:
             raise NotImplementedError(
                 "Static cuda launcher only supports num_ctas == 1"
             )
+        self.num_ctas = num_ctas
 
     def reload_cubin_from_raw(self, filepath: str) -> str:
         """
@@ -155,6 +171,7 @@ class StaticallyLaunchedTritonKernel:
         return self.cubin_path
 
     def load_kernel(self, device: int) -> None:
+        self.device = device
         if self.function is not None:
             return
 
@@ -325,6 +342,24 @@ class StaticallyLaunchedTritonKernel:
                 out.append(arg)
         return tuple(out)
 
+    def _allocate_global_scratch(self, grid_x: int, grid_y: int, grid_z: int):
+        """Allocate the device-side global-scratch workspace some kernels need
+        (e.g. device-side TMA descriptor kernels). Mirrors triton's
+        CudaLauncher.allocate_scratch: one ``global_scratch_size``-byte slot per
+        program. Returns None when no workspace is required."""
+        if self.global_scratch_size <= 0:
+            return None
+        import torch
+
+        n = grid_x * grid_y * grid_z * self.num_ctas * self.global_scratch_size
+        # The caching allocator returns >=512B-aligned storage, which covers
+        # global_scratch_align (128 for TMA descriptors).
+        return torch.empty(
+            n,
+            dtype=torch.uint8,
+            device=torch.device(self.scratch_device_type, self.device),
+        )
+
     def run(
         self,
         grid_x: int,
@@ -379,10 +414,20 @@ class StaticallyLaunchedTritonKernel:
             args = (*args, None, None)
 
         else:
-            for has_scratch in [self.has_global_scratch, self.has_profile_scratch]:
-                if has_scratch:
-                    arg_tys = arg_tys + "O"
-                    args = (*args, None)
+            if self.has_global_scratch:
+                arg_tys = arg_tys + "O"
+                # Device-side TMA descriptor kernels need a real workspace; keep
+                # the tensor alive (via `global_scratch`) until after the launch
+                # below -- the caching allocator's stream ordering then makes it
+                # safe to free.
+                global_scratch = self._allocate_global_scratch(grid_x, grid_y, grid_z)
+                args = (
+                    *args,
+                    global_scratch.data_ptr() if global_scratch is not None else None,
+                )
+            if self.has_profile_scratch:
+                arg_tys = arg_tys + "O"
+                args = (*args, None)
         # pyrefly: ignore [bad-argument-type]
         if len(args) != len(arg_tys):
             raise AssertionError(f"Expected {len(arg_tys)} args, got {len(args)}")
@@ -403,6 +448,10 @@ class StaticallyLaunchedTritonKernel:
 
 
 class StaticallyLaunchedCudaKernel(StaticallyLaunchedTritonKernel):
+    # ROCm/HIP allocates global scratch itself at launch (see run()), so only
+    # enable explicit workspace allocation for CUDA.
+    supports_global_scratch: bool = not is_rocm()
+
     @cached_property
     def C_impl(self):
         from torch._C import _StaticCudaLauncher

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2618,6 +2618,14 @@ class CachingAutotuner(KernelInterface):
             if cu_function is None or num_warps is None:
                 return None
 
+            # The _FastCudaLauncher pre-zeros scratch slots and never fills them
+            # per launch, so it can only handle kernels whose scratch args are
+            # always null. Kernels that need a real global-scratch workspace
+            # (e.g. device-side TMA) must use the regular static launcher, which
+            # allocates it in run().
+            if getattr(kernel, "global_scratch_size", 0) > 0:
+                return None
+
             n_scratch = sum(
                 [
                     getattr(kernel, "has_global_scratch", False),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191368

Device-side TMA GEMM kernels (Inductor's persistent-matmul template that
builds descriptors on-device via tl.make_tensor_descriptor) need a
device-side global-scratch workspace. StaticCudaLauncher rejected any kernel
whose Triton metadata reports global_scratch_size > 0, so these kernels were
never statically launchable. Because TritonBundler only bundles
statically-launchable kernels into the FX graph cache, device-side TMA GEMMs
were excluded from the bundle and re-sent to a compile worker (recompiled) on
every warm FX-graph-cache hit whose process had a cold local Triton cache --
tens of seconds/rank of pure, avoidable recompilation on matmul-heavy models.

Root cause: the launcher only knew how to pass a null global-scratch pointer
(valid only when the workspace is empty) and raised NotImplementedError
otherwise. The fix allocates the workspace at launch time --
grid_x*grid_y*grid_z * num_ctas * global_scratch_size bytes, mirroring
triton's CudaLauncher.allocate_scratch -- and passes its device pointer. The
C++ launcher already accepts a device-pointer int for pointer ("O") args, so
no C++/ABI change is needed.

Making these kernels statically launchable also makes them eligible for the
_FastCudaLauncher, which pre-zeros scratch slots and never fills them per
launch (it relies on inductor always passing null scratch). That would hand a
device-TMA kernel a null workspace on its second and later launches (the
steady-state fast path), causing an illegal memory access. So the fast
launcher now bails for kernels with global_scratch_size > 0; they fall back
to the regular static launcher, which allocates the workspace in run().

This is CUDA-only. On ROCm and XPU, kernels needing a global-scratch
workspace still bail out of static launch (unchanged): device-side TMA is
NVIDIA-only, and Triton's AMD backend has no global_scratch in its launch
ABI, so the case does not arise there.

Alternative considered: a separate non-static bundling path that ships and
reloads the cubins of non-static kernels. Rejected in favor of making the
kernels first-class statically-launchable, which is a smaller change and
reuses the existing static-launch + bundling machinery so device-side TMA
kernels are cached exactly like every other kernel.

Fixes #191124

Test Plan:

New regression test forces a device-side TMA GEMM under
strict_static_triton_launcher (so "not statically launchable" becomes a hard
error) and launches it repeatedly to exercise the steady-state fast path. It
fails before this change -- first with "CannotStaticallyLaunchKernel: Global
scratch not yet supported", and, once the launcher allocates scratch, with a
CUDA illegal memory access on the second launch via the fast launcher -- and
passes after. Run on an H100 (device-side TMA requires sm90+):

```
python test/inductor/test_static_triton_launcher.py TestStaticTritonCompileResult.test_device_tma_matmul_static_launch
python test/inductor/test_static_triton_launcher.py
```

The targeted test passes; the full file passes as well.

Authored with Claude.