### PR TITLE
Fix pickling of inverse distribution transforms

### DIFF
--- a/test/distributions/test_transforms.py
+++ b/test/distributions/test_transforms.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: distributions"]
 
+import copy
 import io
+import pickle
 from numbers import Number
 
 import pytest
@@ -641,6 +643,52 @@ def test_save_load_transform():
         other = torch.load(stream)
     if not torch.allclose(log_prob, other.log_prob(x)):
         raise AssertionError("Loaded distribution log_prob does not match original")
+
+
+def test_pickle_inverse_transform():
+    # https://github.com/pytorch/pytorch/issues/191197
+    # _InverseTransform stores the wrapped transform in _inv, which the
+    # inherited Transform.__getstate__ used to drop as if it were a cache.
+    transform = SigmoidTransform()
+    x = torch.linspace(0.1, 0.9, 5)
+    loaded = pickle.loads(pickle.dumps(transform.inv))
+    if not torch.allclose(loaded(x), transform.inv(x)):
+        raise AssertionError("Unpickled inverse transform computes wrong values")
+    if loaded.inv.inv is not loaded:
+        raise AssertionError("t.inv.inv is t does not hold after unpickling")
+
+    compose = ComposeTransform([ExpTransform(), AffineTransform(1.0, 2.0)])
+    y = torch.linspace(3.0, 9.0, 5)
+    loaded_inv = pickle.loads(pickle.dumps(compose.inv))
+    if not torch.allclose(loaded_inv(y), compose.inv(y)):
+        raise AssertionError("Unpickled inverse compose computes wrong values")
+    if loaded_inv.inv.inv is not loaded_inv:
+        raise AssertionError("t.inv.inv is t does not hold for unpickled compose")
+
+
+def test_save_load_transformed_distribution_with_inverse_transform():
+    dist = TransformedDistribution(Normal(0, 1), [SigmoidTransform().inv])
+    x = torch.linspace(-2.0, 2.0, 10)
+    log_prob = dist.log_prob(x)
+    stream = io.BytesIO()
+    torch.save(dist, stream)
+    stream.seek(0)
+    with torch.serialization.safe_globals(
+        [TransformedDistribution, SigmoidTransform, _InverseTransform, Normal]
+    ):
+        other = torch.load(stream)
+    if not torch.allclose(log_prob, other.log_prob(x)):
+        raise AssertionError("Loaded distribution log_prob does not match original")
+
+
+def test_deepcopy_inverse_transform():
+    transform = ExpTransform()
+    x = torch.linspace(0.5, 2.0, 5)
+    copied = copy.deepcopy(transform.inv)
+    if not torch.allclose(copied(x), transform.inv(x)):
+        raise AssertionError("Deepcopied inverse transform computes wrong values")
+    if copied.inv.inv is not copied:
+        raise AssertionError("t.inv.inv is t does not hold after deepcopy")
 
 
 @pytest.mark.parametrize("transform", ALL_TRANSFORMS, ids=transform_id)

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -221,6 +221,18 @@ class _InverseTransform(Transform):
         super().__init__(cache_size=transform._cache_size)
         self._inv: Transform | None = transform
 
+    def __getstate__(self):
+        # Unlike in the base class, _inv here is the wrapped transform
+        # itself rather than a droppable cache slot, so keep it.
+        return self.__dict__.copy()
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if self._inv is not None:
+            # Rebuild the wrapped transform's cache link so that
+            # `t.inv.inv is t` also holds for unpickled inverses.
+            self._inv._inv = self
+
     @constraints.dependent_property(is_discrete=False)
     # pyrefly: ignore [bad-override]
     def domain(self):


### PR DESCRIPTION
Pickling t.inv for a torch.distributions Transform returned a broken object: Transform.__getstate__ blanks the _inv attribute, which is a droppable cache slot on regular transforms but is the wrapped transform itself on _InverseTransform, so the loaded wrapper came back as Inverse(None) and raised "AssertionError: _inv must not be None" on any use. 



Fixes #191197
