### PR TITLE
[dynamo] Fix undefined name cell_and_freevars in _call_frame_locals_snapshot

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1468,7 +1468,8 @@ class BuiltinVariable(BaseBuiltinVariable):
     def _call_frame_locals_snapshot(tx: "InstructionTranslatorBase") -> VariableTracker:
         from .builder import VariableBuilder
 
-        frame_local_names = set(tx.f_code.co_varnames) | set(tx.cell_and_freevars())
+        cell_and_freevars = set(tx.cell_and_freevars())
+        frame_local_names = set(tx.f_code.co_varnames) | cell_and_freevars
         frame_locals = {}
         # symbolic_cellvars registers all of the frame's cells; listing it
         # second makes cell contents take precedence over a (shadowing)


### PR DESCRIPTION

BuiltinVariable._call_frame_locals_snapshot referenced a bare name
`cell_and_freevars` that was never bound. The set of cell/free variable names
was only ever computed inline as `set(tx.cell_and_freevars())` while building
`frame_local_names`, so the later pruned-locals loop
(`if name in frame_locals or name in cell_and_freevars`) raised
`NameError: name 'cell_and_freevars' is not defined` whenever locals() or
vars() was traced with an input that had been pruned from symbolic_locals.

The bug was introduced by #187782 ("[dynamo] Skip guard creation for unused
function inputs"), which added that loop. It broke a large swath of CI: dynamo,
cpython, and any test that traces locals()/vars() failed with
InternalTorchDynamoError, and lint failed on ruff F821 / pyrefly unknown-name.

Fix: bind the set once to a local `cell_and_freevars` and reuse it both for
`frame_local_names` and the loop membership check.

Test Plan:
This checkout has no lintrunner and a stale torch C-extension, so only ruff
could be run locally; it confirms the F821 is resolved:

```
ruff check torch/_dynamo/variables/builtin.py
```

The runtime failure this fixes reproduces (before the fix) via:

```
python test/dynamo/test_misc.py MiscTests.test_locals_alias_access_of_unused_param_works
```

which previously raised
`InternalTorchDynamoError: NameError: name 'cell_and_freevars' is not defined`.

Authored with the assistance of an AI coding agent.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/191371).
* #190943
* __->__ #191371

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98