### PR TITLE
Fix silent fake tensor resize in _make_inplace decompositions

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -151,6 +151,19 @@ class FakeTensorTest(TestCase):
             self.assertEqual(z.device, torch.device("cpu"))
             self.assertTrue(is_fake_tensor(z))
 
+    def test_inplace_non_broadcastable_raises(self):
+        # Ops decomposed via _make_inplace used to silently resize the fake
+        # self tensor to the broadcast shape instead of raising like eager.
+        # See https://github.com/pytorch/pytorch/issues/191283
+        with FakeTensorMode():
+            for name in ["pow_", "atan2_", "eq_", "fmod_", "remainder_", "add_"]:
+                a = torch.empty(1)
+                b = torch.empty(2, 1, 2, 1)
+                msg = "doesn't match the broadcast shape"
+                with self.assertRaisesRegex(RuntimeError, msg):
+                    getattr(a, name)(b)
+                self.assertEqual(a.shape, (1,))
+
     def test_mm_out_dtype(self):
         # The out_dtype dtype restriction in mm/bmm/baddbmm is a property of the
         # in-tree CUDA/XPU backends. Out-of-tree backends may support arbitrary

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -604,6 +604,22 @@ def _make_inplace(fn):
     # nb. We use the name of the first argument used in the unary references
     @wraps(fn)
     def _fn(a, *args, **kwargs):
+        # In-place ops never resize `a`, but out_wrapper would resize `out=a`
+        # if the broadcasted result shape were larger. Reject the mismatch up
+        # front with the same error eager (TensorIterator) raises. Otherwise
+        # fake/meta tensors silently change shape here, which corrupts shape
+        # metadata recorded before the op (e.g. dynamo's tracked fakes).
+        shapes = [
+            t.shape
+            for t in itertools.chain(args, kwargs.values())
+            if isinstance(t, TensorLike)
+        ]
+        if shapes:
+            broadcasted_shape = tuple(_broadcast_shapes(a.shape, *shapes))
+            torch._check(
+                broadcasted_shape == a.shape,
+                lambda: f"output with shape {a.shape} doesn't match the broadcast shape {broadcasted_shape}",
+            )
         return fn(a, *args, out=a, **kwargs)
 
     inplace_name = f"{fn.__name__}_"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191373

In-place ops whose meta behavior comes from _make_inplace in
torch/_refs/__init__.py (pow_, atan2_, eq_, fmod_, ge_, gt_, le_, lt_,
ne_, remainder_, and ~90 others) decompose a.pow_(b) into
pow(a, b, out=a). When b does not broadcast into a's shape, eager raises
"output with shape ... doesn't match the broadcast shape ...", but
out_wrapper's _maybe_resize_out instead resizes out to the broadcast
shape, so fake/meta tensors silently change rank.

Under torch.compile this corrupts dynamo's guard metadata: the resized
fake is in shape_env.tracked_fakes, whose symbolic_context
constraint_sizes was built at wrap time for the original rank, so
produce_guards_verbose later dies with IndexError: list index out of
range (constraint_size[i] with i >= wrap-time rank). This is the root
cause of the flaky-bot issue #191283 (test_broadcast_fn_{atan2,eq,fmod,
ge,gt,le,lt,ne,pow,remainder}_cpu under PYTORCH_TEST_WITH_DYNAMO=1);
deterministic repro:

    torch.compile(lambda a, b: a.pow_(b), backend="eager")(
        torch.randn(1), torch.randn(2, 1, 2, 1))

The fix checks up front in _make_inplace that the broadcast of all
tensor argument shapes equals self's shape and raises the same
RuntimeError eager raises, mirroring check_inplace_broadcast in
_meta_registrations.py (which is what already protects add_, mul_,
div_, etc. -- exactly why only the _make_inplace ops flaked).
Alternatives considered: tolerating rank mismatch in
produce_guards_verbose would paper over corrupted tracking metadata,
and per-op meta registrations would duplicate this check ~100 times.

The 10 tests disabled in #191283 can be re-enabled once this lands.

Test Plan:

New regression test (fake mode raises and shape is unchanged):

```
python -m pytest test/test_fake_tensor.py -k test_inplace_non_broadcastable_raises
```

The previously flaky tests, isolated and as a family:

```
for t in pow atan2 eq fmod ge gt le lt ne remainder; do
  PYTORCH_TEST_WITH_DYNAMO=1 python test/test_torch.py TestTorchDeviceTypeCPU.test_broadcast_fn_${t}_cpu
done
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_torch.py -k test_broadcast_fn
```

Also verified with #182972 cherry-picked on top (the upstream state
where the flake actually fires) that all 10 tests pass fully.

No new failures in:

```
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_torch.py TestTorchDeviceTypeCPU
python test/test_fake_tensor.py
python test/test_dynamic_shapes.py
python -m pytest test/test_meta.py -k "pow or atan2 or fmod or remainder or eq_ or ne_"
python -m pytest test/test_decomp.py -k "pow or atan2 or fmod or remainder"
python -m pytest test/test_ops.py -k "test_python_ref_meta and (pow or atan2 or fmod or remainder or add or mul)"
python -m pytest test/test_ops.py -k "test_out and (pow or fmod or remainder or atan2)"
python -m pytest test/test_proxy_tensor.py -k "pow or fmod or remainder or atan2"
```

Broadcast-down (self larger than other), scalar args, tensor kwargs
(clamp_(min=t)), 3-arg ops (addcmul_, lerp_), and dynamic=True compile
were hand-checked in fake mode.

Authored with Claude Code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>