### PR TITLE
fix compatibility with SciPy >= 1.18 in test_linalg_lstsq

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -366,7 +366,8 @@ class TestLinalg(TestCase):
                 import scipy.linalg
 
                 def scipy_ref(a, b):
-                    return scipy.linalg.lstsq(a, b, lapack_driver=driver, cond=cond)
+                    scipy_cond = None if cond is not None and cond < 0 else cond
+                    return scipy.linalg.lstsq(a, b, lapack_driver=driver, cond=scipy_cond)
                 check_correctness_ref(a, b, res, scipy_ref, driver=driver)
 
         def check_correctness_numpy(a, b, res, driver, rcond):


### PR DESCRIPTION
In SciPy >= 1.18, `scipy.linalg.lstsq` migrated to a batched C++ implementation that enforces strict validation on the cutoff condition parameter (`cond >= 0`), raising a `ValueError: Expected rcond >= 0` when passed a negative number. The PyTorch test suite previously passed `rcond=-1` directly to SciPy's reference function when verifying that negative cutoff values instruct underlying LAPACK routines (`gelsd`/`gelss`) to use machine precision tolerance.

To restore compatibility without changing test coverage, this update maps negative `cond` values (such as `-1`) to `None` before calling `scipy.linalg.lstsq` in `check_correctness_scipy`. Because `cond=None` is documented across all SciPy versions to use the default machine precision cutoff threshold, this change maintains backwards compatibility with older versions of SciPy while resolving test failures on SciPy 1.18+.

For reference:
- https://github.com/scipy/scipy/commit/9392c2abf4de5180c7c125356f0383854611b733