### PR TITLE
[TEST] Refactor test_pointwise_ops.py and test_record_function.py with hw_classification

### DIFF
--- a/test/distributed/tensor/test_pointwise_ops.py
+++ b/test/distributed/tensor/test_pointwise_ops.py
@@ -22,6 +22,7 @@ from torch.distributed.tensor._ops._math_ops import _NormPartial
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -83,6 +84,8 @@ def deepcopy_convert_from_dtensor(val: Any) -> Any:
 
 
 class DistElementwiseOpsTest(DTensorOpTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _compare_pairwise_ops(
         self,
         *,
@@ -1343,6 +1346,7 @@ instantiate_parametrized_tests(DistElementwiseOpsTest)
 class TestPointwiseRuleValidation(TestCase):
     """Validate registered partial-placement rules via OpInfo samples."""
 
+    hw_classification = HardwareClassification.GENERIC
     world_size = 2
 
     def setUp(self):

--- a/test/profiler/test_record_function.py
+++ b/test/profiler/test_record_function.py
@@ -15,7 +15,11 @@ from torch.autograd import (
 )
 from torch.autograd.profiler import profile as _profile
 from torch.profiler import kineto_available, record_function
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 # if tqdm is not shutdown properly, it will leave the monitor thread alive.
@@ -35,6 +39,8 @@ Json = dict[str, Any]
 
 
 class TestRecordFunction(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _record_function_with_param(self):
         u = torch.randn(3, 4, 5, requires_grad=True)
         with _profile(


### PR DESCRIPTION
## Summary
Apply hardware classification to `test_pointwise_ops.py` and `test_record_function.py`.

### test_pointwise_ops.py
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `DistElementwiseOpsTest` (32 test methods) - distributed DTensor pointwise ops tested across accelerator types via `DTensorOpTestBase`/`MultiThreadedTestCase`, uses `self.device_type`
- Add `hw_classification = HardwareClassification.GENERIC` to `TestPointwiseRuleValidation` (1 test method, 10 subtests) — CPU-only rule validation using FakePG (`init_process_group("fake", ...)`)
- `DistElementwiseOpsTestWithLocalTensor` inherits `ACCELERATOR` automatically via `create_local_tensor_test_class` dict copy
- Add `HardwareClassification` to imports from `common_utils`
- No class splits, renames, or test logic changes

### test_record_function.py
- Add `hw_classification = HardwareClassification.GENERIC` to `TestRecordFunction` — all tests exercise CPU-side `record_function` API with no device dependencies
- Add `HardwareClassification` to imports from `common_utils`
- No class splits, renames, or test logic changes

(Consolidates #192235)

## Test Plan

```bash
python -m pytest test/distributed/tensor/test_pointwise_ops.py -v
python -m pytest test/distributed/tensor/test_pointwise_ops.py -v --hw-classification ACCELERATOR
python -m pytest test/distributed/tensor/test_pointwise_ops.py -v --hw-classification GENERIC

python test/profiler/test_record_function.py -v
python test/profiler/test_record_function.py -v --hw-classification GENERIC
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508
