### PR TITLE
[Inductor][Triton] Enable TF32 for dynamic-shape GEMMs

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2382,6 +2382,28 @@ class TestMaxAutotune(TestCase):
             ):
                 torch.compile(func_test1, dynamic=False)(a, b, a, b)
 
+    @unittest.skipIf(TEST_WITH_ROCM, "TF32 disabled on ROCm in this module")
+    @config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    def test_allow_tf32_dynamic_shape(self):
+        # A symbolic M that is large by hint must still enable TF32; the gate
+        # previously used statically_known_true, which is False for dynamic M.
+        def mm(x, w):
+            return x @ w
+
+        def gen_code(m):
+            x = torch.rand(m, 2048, device=GPU_TYPE)
+            w = torch.rand(2048, 2048, device=GPU_TYPE)
+            torch._dynamo.mark_dynamic(x, 0)
+            with fresh_cache():
+                _, code = run_and_get_code(torch.compile(mm), x, w)
+            return code[0]
+
+        # setUpModule sets float32_matmul_precision("high") -> fp32_precision tf32.
+        # Large hint clears m >= 16, so TF32 is enabled on the symbolic-M GEMM.
+        self.assertIn("ALLOW_TF32 : tl.constexpr = True", gen_code(4096))
+        # Small hint fails m >= 16, so TF32 stays disabled.
+        self.assertIn("ALLOW_TF32 : tl.constexpr = False", gen_code(8))
+
     @config.patch(
         {
             "max_autotune": True,

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -2145,13 +2145,13 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
             # XPU eager matmul takes TF32 from the oneDNN flag, not the CUDA one.
             allow_tf32 = torch.backends.mkldnn.allow_tf32
         elif device_type == "cuda":
-            # allow_tf32 alignment heuristics based on reverse engineering
-            # H100 CUDA 12.8 behavior
-            size_threshold = V.graph.sizevars.statically_known_true(
-                sympy.And(sympy.Ge(m, 16), sympy.Ge(Min(n, k), 512))
-            )
+            # Use the size hint (statically_known_true is False for symbolic
+            # dims) so dynamic-but-large GEMMs still enable TF32.
+            m_hint, min_nk_hint = V.graph.sizevars.optimization_hints((m, Min(n, k)))
             allow_tf32 = (
-                torch.backends.cuda.matmul.fp32_precision == "tf32" and size_threshold
+                torch.backends.cuda.matmul.fp32_precision == "tf32"
+                and m_hint >= 16
+                and min_nk_hint >= 512
             )
         else:
             allow_tf32 = False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191376

The TF32 gate in MMTemplateConfigMixin.get_extra_kwargs used statically_known_true(m >= 16 and min(n, k) >= 512). For dynamic
  shapes that predicate is never statically provable, so it returned False even when the runtime shape is large, baking
  ALLOW_TF32 = False and forcing the Triton template to run true FP32. The aten/cuBLAS path uses TF32 for the same shapes,
  causing silent FP32 runs for Triton kernels (e.g. ~3.4x slower than the TF32 template for a 4096x2048x2048 matmul).

  Evaluate the same thresholds with optimization_hints, which is guard-free and returns the size hint for symbolic dims (and
  the exact value for static dims). Static-shape behavior is unchanged; dynamic-but-large GEMMs now enable TF32, matching the
  aten path. The thresholds (from #183355) are unchanged.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo