### PR TITLE
[c10d] Normalize new_group ranks to Python integers

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -3429,6 +3429,29 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
     def test_gloo_rank_membership(self):
         self._test_rank_membership(backend="gloo")
 
+    @requires_gloo()
+    def test_new_group_rank_normalization(self):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        c10d.init_process_group(
+            backend="gloo", store=store, rank=self.rank, world_size=self.world_size
+        )
+
+        ranks = torch.arange(self.world_size)
+        group = c10d.new_group(ranks=ranks)
+        self.assertEqual(
+            c10d.get_process_group_ranks(group), list(range(self.world_size))
+        )
+
+        tensor = torch.tensor([self.rank])
+        c10d.broadcast(tensor, src=0, group=group)
+        self.assertEqual(tensor, torch.tensor([0]))
+
+        with self.assertRaisesRegex(TypeError, "ranks must be a sequence of integers"):
+            c10d.new_group(ranks=torch.arange(self.world_size, dtype=torch.float))
+
+        with self.assertRaisesRegex(ValueError, "must not contain duplicate entries"):
+            c10d.new_group(ranks=[0, torch.tensor(0)])
+
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_tensor_dtype_mismatch(self):

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -3429,29 +3429,6 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
     def test_gloo_rank_membership(self):
         self._test_rank_membership(backend="gloo")
 
-    @requires_gloo()
-    def test_new_group_rank_normalization(self):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        c10d.init_process_group(
-            backend="gloo", store=store, rank=self.rank, world_size=self.world_size
-        )
-
-        ranks = torch.arange(self.world_size)
-        group = c10d.new_group(ranks=ranks)
-        self.assertEqual(
-            c10d.get_process_group_ranks(group), list(range(self.world_size))
-        )
-
-        tensor = torch.tensor([self.rank])
-        c10d.broadcast(tensor, src=0, group=group)
-        self.assertEqual(tensor, torch.tensor([0]))
-
-        with self.assertRaisesRegex(TypeError, "ranks must be a sequence of integers"):
-            c10d.new_group(ranks=torch.arange(self.world_size, dtype=torch.float))
-
-        with self.assertRaisesRegex(ValueError, "must not contain duplicate entries"):
-            c10d.new_group(ranks=[0, torch.tensor(0)])
-
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_tensor_dtype_mismatch(self):

--- a/test/distributed/test_c10d_process_group.py
+++ b/test/distributed/test_c10d_process_group.py
@@ -21,6 +21,25 @@ from torch.testing._internal.common_utils import run_tests
 
 
 class AbstractProcessGroupTest(C10dBackendTest):
+    def test_new_group_rank_normalization(self):
+        self._init_pg()
+
+        ranks = torch.arange(self.world_size)
+        group = dist.new_group(ranks=ranks)
+        self.assertEqual(
+            dist.get_process_group_ranks(group), list(range(self.world_size))
+        )
+
+        tensor = torch.tensor([self.rank], device=self.device)
+        dist.broadcast(tensor, src=0, group=group)
+        self.assertEqual(tensor, torch.zeros_like(tensor))
+
+        with self.assertRaisesRegex(TypeError, "ranks must be a sequence of integers"):
+            dist.new_group(ranks=torch.arange(self.world_size, dtype=torch.float))
+
+        with self.assertRaisesRegex(ValueError, "must not contain duplicate entries"):
+            dist.new_group(ranks=[0, torch.tensor(0)])
+
     def test_sequence_numbers(self):
         self._init_pg()
         default_pg = dist.distributed_c10d._get_default_group()

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -10,6 +10,7 @@ import hashlib
 import io
 import itertools
 import logging
+import operator
 import os
 import pickle
 import sys
@@ -6819,6 +6820,12 @@ def _new_group_with_tag(
         timeout = _get_default_timeout(backend)
     _check_valid_timeout(timeout)
 
+    if ranks is not None:
+        try:
+            ranks = [operator.index(rank) for rank in ranks]
+        except TypeError as error:
+            raise TypeError("ranks must be a sequence of integers") from error
+
     if use_local_synchronization:
         # MPI backend doesn't have a way for us to perform a partial sync
         if backend == Backend.MPI:
@@ -6832,8 +6839,6 @@ def _new_group_with_tag(
     if ranks is not None:
         if sort_ranks:
             ranks = sorted(ranks)
-        else:
-            ranks = list(ranks)
         if len(set(ranks)) != len(ranks):
             raise ValueError(
                 f"ranks list must not contain duplicate entries, got {ranks}"


### PR DESCRIPTION
## Issue

Fixes #72346

## Summary

Normalize `new_group` rank inputs with `operator.index` before membership, sorting, and duplicate checks. This prevents integer scalar tensors from remaining as keys in internal rank mappings, which later makes collectives reject valid Python integer ranks. Non-integral inputs now fail early with a clear `TypeError`.

The Gloo regression test covers tensor rank input, a broadcast using the resulting group, non-integral ranks, and duplicates revealed by normalization.

## Testing

- PyTorch PYFMT and Ruff adapters on both changed files
- `compileall` and `git diff --check`
- Two-process Gloo behavioral reproducer using the new normalization logic

The source checkout was not built locally, so the added source-tree test is left to CI.

## Checklist

- [x] Targeted lint passes
- [x] Added/updated tests
- [x] Documentation is not applicable
- [x] Benchmarks are not applicable

## BC-breaking?

No. The documented input type is a sequence of integers; non-integral values now fail earlier with a clearer error.

## AI assistance disclosure

> Codex assisted with issue triage, implementation, test authoring, and local validation.

I reviewed the final diff and confirmed that `operator.index` is intentional: it accepts integer-like rank values without silently truncating non-integral values. I understand the implementation and take responsibility for the contribution.
