### PR TITLE
[inductor] Eliminate singleton one-hot reductions

### DIFF
--- a/test/inductor/test_singleton_reduction.py
+++ b/test/inductor/test_singleton_reduction.py
@@ -1,0 +1,373 @@
+# Owner(s): ["module: inductor"]
+
+from unittest import mock
+
+import torch
+from torch._dynamo.utils import counters
+from torch._inductor import config
+from torch._inductor.fx_passes import singleton_reduction
+from torch._inductor.fx_passes.singleton_reduction import (
+    eliminate_singleton_reductions,
+)
+from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import run_and_get_code
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing import FileCheck
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import parametrize, TEST_CUDA
+
+
+LIVE_VOCAB = 4096
+
+
+class SingletonReductionTests(TestCase):
+    def _run_and_check(self, fn, args, expected_fold, patches=None):
+        patches = patches or {}
+        with config.patch(
+            singleton_reduction_elimination=False,
+            pattern_matcher=False,
+        ):
+            expected = torch.compile(fn, fullgraph=True)(*args)
+
+        torch._dynamo.reset()
+        counters.clear()
+        with config.patch(
+            force_disable_caches=True,
+            pattern_matcher=False,
+            **patches,
+        ):
+            actual, codes = run_and_get_code(
+                torch.compile(fn, fullgraph=True), *args
+            )
+
+        self.assertEqual(actual, expected, equal_nan=True)
+        self.assertEqual(
+            counters["inductor"]["singleton_reduction_elimination"],
+            int(expected_fold),
+        )
+        checker = FileCheck()
+        if expected_fold:
+            checker.check_not("rnumel")
+        else:
+            checker.check("rnumel")
+        checker.run("\n".join(codes))
+        return actual, expected
+
+    def _make_pass_graph(self, device):
+        def fn(target, scale):
+            iota = torch.ops.prims.iota.default(
+                LIVE_VOCAB,
+                start=0,
+                step=1,
+                dtype=torch.int64,
+                device=torch.device(device),
+                requires_grad=False,
+            ).view(1, LIVE_VOCAB)
+            hit = torch.ops.aten.full.default(
+                [], -1.0, dtype=torch.float32, device=torch.device(device)
+            )
+            miss = torch.ops.aten.full.default(
+                [], 0.0, dtype=torch.float32, device=torch.device(device)
+            )
+            selected = torch.ops.aten.where.self(target == iota, hit, miss)
+            dense = torch.ops.aten.mul.Tensor(selected, scale)
+            dense = torch.ops.prims.convert_element_type.default(
+                dense, torch.bfloat16
+            )
+            dense = torch.ops.prims.convert_element_type.default(dense, torch.float32)
+            row_sum = torch.ops.aten.sum.dim_IntList(dense, [1], True)
+            return torch.ops.aten.sub.Tensor(dense, row_sum)
+
+        target = torch.tensor([[0], [LIVE_VOCAB]], device=device)
+        scale = torch.randn(2, 1, device=device)
+        return make_fx(fn)(target, scale).graph
+
+    @parametrize("force_shape_pad,expected_fold", ((False, True), (True, False)))
+    @parametrize("bf16_roundtrip", (False, True))
+    def test_cross_entropy_row_sum(
+        self, device, force_shape_pad, expected_fold, bf16_roundtrip
+    ):
+        def fn(target, scale):
+            iota = torch.arange(LIVE_VOCAB, device=target.device).view(
+                1, LIVE_VOCAB
+            )
+            selected = torch.where(target == iota, -1.0, 0.0)
+            dense = selected * scale
+            if bf16_roundtrip:
+                dense = dense.to(torch.bfloat16).to(torch.float32)
+            row_sum = dense.sum(dim=1, keepdim=True)
+            return dense, dense - row_sum
+
+        targets = [-100, -1, 0, LIVE_VOCAB - 1, LIVE_VOCAB, LIVE_VOCAB + 2]
+        scales = [0.0, -0.0, 0.3333, float("inf"), -float("inf"), float("nan")]
+        target = torch.tensor(targets, device=device).repeat_interleave(
+            len(scales)
+        )[:, None]
+        scale = torch.tensor(scales, device=device).repeat(len(targets))[:, None]
+
+        actual, expected = self._run_and_check(
+            fn,
+            (target, scale),
+            expected_fold and bf16_roundtrip,
+            {"force_shape_pad": force_shape_pad},
+        )
+        self.assertEqual(torch.signbit(actual[1]), torch.signbit(expected[1]))
+
+    @parametrize(
+        "variant", ("explicit_expand", "reversed_mask", "reversed_mul", "reshape")
+    )
+    def test_equivalent_graph_forms(self, device, variant):
+        def fn(target, scale):
+            iota = torch.arange(LIVE_VOCAB, device=target.device)
+            iota = (
+                iota.reshape(1, LIVE_VOCAB)
+                if variant == "reshape"
+                else iota.view(1, LIVE_VOCAB)
+            )
+            expanded = (
+                target.expand(target.shape[0], LIVE_VOCAB)
+                if variant == "explicit_expand"
+                else target
+            )
+            mask = expanded == iota
+            if variant == "reversed_mask":
+                mask = iota == expanded
+            selected = torch.where(mask, -1.0, 0.0)
+            product = selected * scale
+            if variant == "reversed_mul":
+                product = scale * selected
+            dense = product.to(torch.bfloat16).to(torch.float32)
+            row_sum = dense.sum(dim=1, keepdim=True)
+            return dense - row_sum
+
+        target = torch.tensor([[0], [LIVE_VOCAB - 1]], device=device)
+        scale = torch.randn(2, 1, device=device)
+        self._run_and_check(fn, (target, scale), True)
+
+    def test_dynamic_batch(self, device):
+        def fn(target, scale):
+            iota = torch.arange(LIVE_VOCAB, device=target.device).view(
+                1, LIVE_VOCAB
+            )
+            dense = torch.where(target == iota, -1.0, 0.0) * scale
+            dense = dense.to(torch.bfloat16).to(torch.float32)
+            row_sum = dense.sum(dim=1, keepdim=True)
+            return dense - row_sum
+
+        inputs = []
+        for batch in (3, 7):
+            target = torch.randint(0, LIVE_VOCAB, (batch, 1), device=device)
+            scale = torch.randn(batch, 1, device=device)
+            inputs.append((target, scale))
+        with config.patch(singleton_reduction_elimination=False):
+            expected_fn = torch.compile(fn, fullgraph=True, dynamic=True)
+            expected = [expected_fn(*args) for args in inputs]
+        torch._dynamo.reset()
+        counters.clear()
+        compiled = torch.compile(fn, fullgraph=True, dynamic=True)
+        for index, args in enumerate(inputs):
+            actual = compiled(*args)
+            self.assertEqual(actual, expected[index])
+            if index == 0:
+                self.assertEqual(
+                    counters["inductor"]["singleton_reduction_elimination"], 1
+                )
+
+    @parametrize(
+        "case",
+        (
+            "nonzero_miss",
+            "negative_zero_miss",
+            "varying_hit",
+            "shifted_iota",
+            "float16_rounding",
+            "int32_index",
+            "noncanonical_mul_hit",
+            "second_mul",
+            "extra_cast",
+        ),
+    )
+    def test_rejects_unsupported_semantics(self, device, case):
+        def fn(target, scale, varying):
+            iota = torch.arange(
+                LIVE_VOCAB,
+                device=target.device,
+                dtype=torch.int32 if case == "int32_index" else torch.int64,
+            ).view(1, LIVE_VOCAB)
+            if case == "shifted_iota":
+                iota = iota + 1
+            miss = -0.0 if case == "negative_zero_miss" else 0.0
+            if case == "nonzero_miss":
+                miss = 0.5
+            if case == "varying_hit":
+                hit = varying
+            elif case == "noncanonical_mul_hit":
+                hit = 2.0
+            else:
+                hit = -1.0
+            dense = torch.where(target == iota, hit, miss) * scale
+            if case == "second_mul":
+                dense = dense * scale
+            low_dtype = (
+                torch.float16 if case == "float16_rounding" else torch.bfloat16
+            )
+            dense = dense.to(low_dtype).to(torch.float32)
+            if case == "extra_cast":
+                dense = dense.to(torch.bfloat16).to(torch.float32)
+            row_sum = dense.sum(dim=1, keepdim=True)
+            return dense - row_sum
+
+        index_dtype = torch.int32 if case == "int32_index" else torch.int64
+        target = torch.tensor([[0], [LIVE_VOCAB]], device=device, dtype=index_dtype)
+        scale = torch.randn(2, 1, device=device)
+        varying = torch.randn(2, LIVE_VOCAB, device=device)
+        self._run_and_check(fn, (target, scale, varying), False)
+
+    @parametrize(
+        "case",
+        (
+            "small_row",
+            "no_expanding_user",
+            "downstream_sum",
+            "transitive_sum",
+            "cat_sum",
+            "split_sum",
+        ),
+    )
+    def test_live_reuse_profitability(self, device, case):
+        vocab = 128 if case == "small_row" else LIVE_VOCAB
+
+        def fn(target, scale):
+            iota = torch.arange(vocab, device=target.device).view(1, vocab)
+            dense = torch.where(target == iota, -1.0, 0.0) * scale
+            dense = dense.to(torch.bfloat16).to(torch.float32)
+            row_sum = dense.sum(dim=1, keepdim=True)
+            if case == "no_expanding_user":
+                return dense, row_sum
+            output = dense - row_sum
+            if case == "downstream_sum":
+                return output, dense.sum(dim=0, keepdim=True)
+            if case == "transitive_sum":
+                return output, (dense + 1).transpose(0, 1).sum(dim=1)
+            if case == "cat_sum":
+                return output, torch.cat((dense, dense), dim=0).sum(dim=0)
+            if case == "split_sum":
+                return output, torch.split(dense, (1, vocab - 1), dim=1)[0].sum()
+            return output
+
+        target = torch.tensor([[0], [vocab]], device=device)
+        scale = torch.randn(2, 1, device=device)
+        self._run_and_check(fn, (target, scale), False)
+
+    def test_dynamic_reduction_extent(self, device):
+        def fn(target, scale, dense):
+            iota = torch.arange(dense.shape[1], device=dense.device).view(
+                1, dense.shape[1]
+            )
+            selected = torch.where(target == iota, -1.0, 0.0) * scale
+            selected = selected.to(torch.bfloat16).to(torch.float32)
+            row_sum = selected.sum(dim=1, keepdim=True)
+            return selected - row_sum
+
+        target = torch.tensor([[0], [7]], device=device)
+        scale = torch.randn(2, 1, device=device)
+        dense = torch.randn(2, 8, device=device)
+        torch._dynamo.mark_dynamic(dense, 1)
+        with config.patch(singleton_reduction_elimination=False):
+            expected = torch.compile(fn, fullgraph=True)(target, scale, dense)
+        torch._dynamo.reset()
+        counters.clear()
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, fullgraph=True), target, scale, dense
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(counters["inductor"]["singleton_reduction_elimination"], 0)
+        FileCheck().check("rnumel").run(code)
+
+    def test_rank3_rejected(self, device):
+        def fn(target, scale):
+            iota = torch.arange(LIVE_VOCAB, device=target.device).view(
+                1, 1, LIVE_VOCAB
+            )
+            dense = torch.where(target == iota, -1.0, 0.0) * scale
+            dense = dense.to(torch.bfloat16).to(torch.float32)
+            row_sum = dense.sum(dim=2, keepdim=True)
+            return dense - row_sum
+
+        target = torch.tensor([[[0]], [[LIVE_VOCAB]]], device=device)
+        scale = torch.randn(2, 1, 1, device=device)
+        self._run_and_check(fn, (target, scale), False)
+
+    def test_analysis_limit(self, device):
+        graph = self._make_pass_graph(device)
+        with mock.patch.object(singleton_reduction, "_MAX_ANALYSIS_NODES", 1):
+            self.assertEqual(eliminate_singleton_reductions(graph), 0)
+
+    def test_downstream_reduction_analysis_is_cached(self, device):
+        graph = self._make_pass_graph(device)
+        reduction = next(
+            node
+            for node in graph.nodes
+            if node.target is torch.ops.aten.sum.dim_IntList
+        )
+        consumer = next(iter(reduction.users))
+        output = next(node for node in graph.nodes if node.op == "output")
+        with graph.inserting_before(output):
+            extra_reduction = graph.node_copy(reduction, lambda node: node)
+            graph.node_copy(
+                consumer,
+                lambda node: extra_reduction if node is reduction else node,
+            )
+
+        find_reductions = singleton_reduction._find_downstream_reductions
+        with mock.patch.object(
+            singleton_reduction,
+            "_find_downstream_reductions",
+            wraps=find_reductions,
+        ) as find:
+            self.assertEqual(eliminate_singleton_reductions(graph), 0)
+        self.assertEqual(find.call_count, 1)
+
+    def test_unknown_downstream_node_rejected(self, device):
+        def opaque(value):
+            return value
+
+        graph = self._make_pass_graph(device)
+        reduction = next(
+            node
+            for node in graph.nodes
+            if node.target is torch.ops.aten.sum.dim_IntList
+        )
+        dense = reduction.args[0]
+        output = next(node for node in graph.nodes if node.op == "output")
+        with graph.inserting_before(output):
+            graph.call_function(opaque, (dense,))
+
+        self.assertEqual(eliminate_singleton_reductions(graph), 0)
+
+    def test_hip_rejected(self, device):
+        graph = self._make_pass_graph(device)
+        with mock.patch.object(torch.version, "hip", "test"):
+            self.assertEqual(eliminate_singleton_reductions(graph), 0)
+
+    def test_does_not_run_global_dce(self, device):
+        graph = self._make_pass_graph(device)
+        placeholder = next(node for node in graph.nodes if node.op == "placeholder")
+        output = next(node for node in graph.nodes if node.op == "output")
+        with graph.inserting_before(output):
+            dead = graph.call_function(torch.ops.aten.neg.default, (placeholder,))
+
+        self.assertEqual(eliminate_singleton_reductions(graph), 1)
+        self.assertIn(dead, graph.nodes)
+
+
+devices = ("cuda",) if TEST_CUDA else ()
+instantiate_device_type_tests(
+    SingletonReductionTests,
+    globals(),
+    only_for=devices,
+)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_singleton_reduction.py
+++ b/test/inductor/test_singleton_reduction.py
@@ -6,18 +6,16 @@ import torch
 from torch._dynamo.utils import counters
 from torch._inductor import config
 from torch._inductor.fx_passes import singleton_reduction
-from torch._inductor.fx_passes.singleton_reduction import (
-    eliminate_singleton_reductions,
-)
+from torch._inductor.fx_passes.singleton_reduction import eliminate_singleton_reductions
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import parametrize, TEST_CUDA
+from torch.testing._internal.common_utils import parametrize
 
 
-LIVE_VOCAB = 4096
+LIVE_VOCAB = 8000
 
 
 class SingletonReductionTests(TestCase):
@@ -36,9 +34,7 @@ class SingletonReductionTests(TestCase):
             pattern_matcher=False,
             **patches,
         ):
-            actual, codes = run_and_get_code(
-                torch.compile(fn, fullgraph=True), *args
-            )
+            actual, codes = run_and_get_code(torch.compile(fn, fullgraph=True), *args)
 
         self.assertEqual(actual, expected, equal_nan=True)
         self.assertEqual(
@@ -71,9 +67,7 @@ class SingletonReductionTests(TestCase):
             )
             selected = torch.ops.aten.where.self(target == iota, hit, miss)
             dense = torch.ops.aten.mul.Tensor(selected, scale)
-            dense = torch.ops.prims.convert_element_type.default(
-                dense, torch.bfloat16
-            )
+            dense = torch.ops.prims.convert_element_type.default(dense, torch.bfloat16)
             dense = torch.ops.prims.convert_element_type.default(dense, torch.float32)
             row_sum = torch.ops.aten.sum.dim_IntList(dense, [1], True)
             return torch.ops.aten.sub.Tensor(dense, row_sum)
@@ -88,9 +82,7 @@ class SingletonReductionTests(TestCase):
         self, device, force_shape_pad, expected_fold, bf16_roundtrip
     ):
         def fn(target, scale):
-            iota = torch.arange(LIVE_VOCAB, device=target.device).view(
-                1, LIVE_VOCAB
-            )
+            iota = torch.arange(LIVE_VOCAB, device=target.device).view(1, LIVE_VOCAB)
             selected = torch.where(target == iota, -1.0, 0.0)
             dense = selected * scale
             if bf16_roundtrip:
@@ -100,9 +92,9 @@ class SingletonReductionTests(TestCase):
 
         targets = [-100, -1, 0, LIVE_VOCAB - 1, LIVE_VOCAB, LIVE_VOCAB + 2]
         scales = [0.0, -0.0, 0.3333, float("inf"), -float("inf"), float("nan")]
-        target = torch.tensor(targets, device=device).repeat_interleave(
-            len(scales)
-        )[:, None]
+        target = torch.tensor(targets, device=device).repeat_interleave(len(scales))[
+            :, None
+        ]
         scale = torch.tensor(scales, device=device).repeat(len(targets))[:, None]
 
         actual, expected = self._run_and_check(
@@ -146,9 +138,7 @@ class SingletonReductionTests(TestCase):
 
     def test_dynamic_batch(self, device):
         def fn(target, scale):
-            iota = torch.arange(LIVE_VOCAB, device=target.device).view(
-                1, LIVE_VOCAB
-            )
+            iota = torch.arange(LIVE_VOCAB, device=target.device).view(1, LIVE_VOCAB)
             dense = torch.where(target == iota, -1.0, 0.0) * scale
             dense = dense.to(torch.bfloat16).to(torch.float32)
             row_sum = dense.sum(dim=1, keepdim=True)
@@ -208,9 +198,7 @@ class SingletonReductionTests(TestCase):
             dense = torch.where(target == iota, hit, miss) * scale
             if case == "second_mul":
                 dense = dense * scale
-            low_dtype = (
-                torch.float16 if case == "float16_rounding" else torch.bfloat16
-            )
+            low_dtype = torch.float16 if case == "float16_rounding" else torch.bfloat16
             dense = dense.to(low_dtype).to(torch.float32)
             if case == "extra_cast":
                 dense = dense.to(torch.bfloat16).to(torch.float32)
@@ -229,6 +217,7 @@ class SingletonReductionTests(TestCase):
             "small_row",
             "no_expanding_user",
             "downstream_sum",
+            "row_sum_downstream_sum",
             "transitive_sum",
             "cat_sum",
             "split_sum",
@@ -247,6 +236,8 @@ class SingletonReductionTests(TestCase):
             output = dense - row_sum
             if case == "downstream_sum":
                 return output, dense.sum(dim=0, keepdim=True)
+            if case == "row_sum_downstream_sum":
+                return output, row_sum.expand(2, vocab).sum(dim=1, keepdim=True)
             if case == "transitive_sum":
                 return output, (dense + 1).transpose(0, 1).sum(dim=1)
             if case == "cat_sum":
@@ -286,9 +277,7 @@ class SingletonReductionTests(TestCase):
 
     def test_rank3_rejected(self, device):
         def fn(target, scale):
-            iota = torch.arange(LIVE_VOCAB, device=target.device).view(
-                1, 1, LIVE_VOCAB
-            )
+            iota = torch.arange(LIVE_VOCAB, device=target.device).view(1, 1, LIVE_VOCAB)
             dense = torch.where(target == iota, -1.0, 0.0) * scale
             dense = dense.to(torch.bfloat16).to(torch.float32)
             row_sum = dense.sum(dim=2, keepdim=True)
@@ -314,10 +303,11 @@ class SingletonReductionTests(TestCase):
         output = next(node for node in graph.nodes if node.op == "output")
         with graph.inserting_before(output):
             extra_reduction = graph.node_copy(reduction, lambda node: node)
-            graph.node_copy(
+            extra_consumer = graph.node_copy(
                 consumer,
                 lambda node: extra_reduction if node is reduction else node,
             )
+        output.args = ((output.args[0], extra_consumer),)
 
         find_reductions = singleton_reduction._find_downstream_reductions
         with mock.patch.object(
@@ -341,7 +331,8 @@ class SingletonReductionTests(TestCase):
         dense = reduction.args[0]
         output = next(node for node in graph.nodes if node.op == "output")
         with graph.inserting_before(output):
-            graph.call_function(opaque, (dense,))
+            unknown = graph.call_function(opaque, (dense,))
+        output.args = ((output.args[0], unknown),)
 
         self.assertEqual(eliminate_singleton_reductions(graph), 0)
 
@@ -352,20 +343,49 @@ class SingletonReductionTests(TestCase):
 
     def test_does_not_run_global_dce(self, device):
         graph = self._make_pass_graph(device)
-        placeholder = next(node for node in graph.nodes if node.op == "placeholder")
+        reduction = next(
+            node
+            for node in graph.nodes
+            if node.target is torch.ops.aten.sum.dim_IntList
+        )
+        dense = reduction.args[0]
         output = next(node for node in graph.nodes if node.op == "output")
         with graph.inserting_before(output):
-            dead = graph.call_function(torch.ops.aten.neg.default, (placeholder,))
+            dead = graph.call_function(
+                torch.ops.aten.sum.dim_IntList, (dense, [0], True)
+            )
 
         self.assertEqual(eliminate_singleton_reductions(graph), 1)
         self.assertIn(dead, graph.nodes)
 
+    def test_dead_reuse_does_not_trigger(self, device):
+        graph = self._make_pass_graph(device)
+        reduction = next(
+            node
+            for node in graph.nodes
+            if node.target is torch.ops.aten.sum.dim_IntList
+        )
+        dense = reduction.args[0]
+        consumer = next(iter(reduction.users))
+        output = next(node for node in graph.nodes if node.op == "output")
+        with graph.inserting_before(consumer):
+            independent = graph.call_function(
+                torch.ops.aten.full.default,
+                ([2, LIVE_VOCAB], 0.0),
+                {"dtype": torch.float32, "device": torch.device(device)},
+            )
+        consumer.replace_input_with(dense, independent)
+        with graph.inserting_before(output):
+            dead = graph.call_function(torch.ops.aten.neg.default, (dense,))
 
-devices = ("cuda",) if TEST_CUDA else ()
+        self.assertEqual(eliminate_singleton_reductions(graph), 0)
+        self.assertIn(dead, graph.nodes)
+
+
 instantiate_device_type_tests(
     SingletonReductionTests,
     globals(),
-    only_for=devices,
+    only_for="cuda",
 )
 
 

--- a/test/inductor/test_singleton_reduction.py
+++ b/test/inductor/test_singleton_reduction.py
@@ -82,10 +82,13 @@ class SingletonReductionTests(TestCase):
             scale = torch.randn(2, 1, device=device)
             return make_fx(fn, tracing_mode="fake")(target, scale).graph
 
-    @parametrize("force_shape_pad,expected_fold", ((False, True), (True, False)))
+    @parametrize("force_shape_pad", (False, True))
     @parametrize("bf16_roundtrip", (False, True))
     def test_cross_entropy_row_sum(
-        self, device, force_shape_pad, expected_fold, bf16_roundtrip
+        self,
+        device,
+        force_shape_pad,
+        bf16_roundtrip,
     ):
         def fn(target, scale):
             iota = torch.arange(LIVE_VOCAB, device=target.device).view(1, LIVE_VOCAB)
@@ -114,7 +117,7 @@ class SingletonReductionTests(TestCase):
         actual, expected = self._run_and_check(
             fn,
             (target, scale),
-            expected_fold and bf16_roundtrip,
+            bf16_roundtrip,
             {"force_shape_pad": force_shape_pad},
         )
         self.assertEqual(torch.signbit(actual[1]), torch.signbit(expected[1]))

--- a/test/inductor/test_singleton_reduction.py
+++ b/test/inductor/test_singleton_reduction.py
@@ -4,11 +4,15 @@ from unittest import mock
 
 import torch
 from torch._dynamo.utils import counters
+from torch._guards import detect_fake_mode
 from torch._inductor import config
 from torch._inductor.fx_passes import singleton_reduction
 from torch._inductor.fx_passes.singleton_reduction import eliminate_singleton_reductions
+from torch._inductor.fx_utils import FakeTensorUpdater, get_fake
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
+from torch._inductor.virtualized import V
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
@@ -72,9 +76,11 @@ class SingletonReductionTests(TestCase):
             row_sum = torch.ops.aten.sum.dim_IntList(dense, [1], True)
             return torch.ops.aten.sub.Tensor(dense, row_sum)
 
-        target = torch.tensor([[0], [LIVE_VOCAB]], device=device)
-        scale = torch.randn(2, 1, device=device)
-        return make_fx(fn)(target, scale).graph
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
+        with fake_mode:
+            target = torch.tensor([[0], [LIVE_VOCAB]], device=device)
+            scale = torch.randn(2, 1, device=device)
+            return make_fx(fn, tracing_mode="fake")(target, scale).graph
 
     @parametrize("force_shape_pad,expected_fold", ((False, True), (True, False)))
     @parametrize("bf16_roundtrip", (False, True))
@@ -88,10 +94,18 @@ class SingletonReductionTests(TestCase):
             if bf16_roundtrip:
                 dense = dense.to(torch.bfloat16).to(torch.float32)
             row_sum = dense.sum(dim=1, keepdim=True)
-            return dense, dense - row_sum
+            return dense, row_sum, dense - row_sum
 
         targets = [-100, -1, 0, LIVE_VOCAB - 1, LIVE_VOCAB, LIVE_VOCAB + 2]
-        scales = [0.0, -0.0, 0.3333, float("inf"), -float("inf"), float("nan")]
+        scales = [
+            0.0,
+            -0.0,
+            0.3333,
+            -0.3333,
+            float("inf"),
+            -float("inf"),
+            float("nan"),
+        ]
         target = torch.tensor(targets, device=device).repeat_interleave(len(scales))[
             :, None
         ]
@@ -106,7 +120,14 @@ class SingletonReductionTests(TestCase):
         self.assertEqual(torch.signbit(actual[1]), torch.signbit(expected[1]))
 
     @parametrize(
-        "variant", ("explicit_expand", "reversed_mask", "reversed_mul", "reshape")
+        "variant",
+        (
+            "constant_pad",
+            "explicit_expand",
+            "reversed_mask",
+            "reversed_mul",
+            "reshape",
+        ),
     )
     def test_equivalent_graph_forms(self, device, variant):
         def fn(target, scale):
@@ -130,7 +151,12 @@ class SingletonReductionTests(TestCase):
                 product = scale * selected
             dense = product.to(torch.bfloat16).to(torch.float32)
             row_sum = dense.sum(dim=1, keepdim=True)
-            return dense - row_sum
+            output = dense - row_sum
+            return (
+                torch.constant_pad_nd(output, (0, 1))
+                if variant == "constant_pad"
+                else output
+            )
 
         target = torch.tensor([[0], [LIVE_VOCAB - 1]], device=device)
         scale = torch.randn(2, 1, device=device)
@@ -214,17 +240,19 @@ class SingletonReductionTests(TestCase):
     @parametrize(
         "case",
         (
-            "small_row",
+            "below_row_threshold",
+            "constant_pad_sum",
             "no_expanding_user",
             "downstream_sum",
             "row_sum_downstream_sum",
+            "untagged_reduction",
             "transitive_sum",
             "cat_sum",
             "split_sum",
         ),
     )
     def test_live_reuse_profitability(self, device, case):
-        vocab = 128 if case == "small_row" else LIVE_VOCAB
+        vocab = LIVE_VOCAB - 1 if case == "below_row_threshold" else LIVE_VOCAB
 
         def fn(target, scale):
             iota = torch.arange(vocab, device=target.device).view(1, vocab)
@@ -238,6 +266,12 @@ class SingletonReductionTests(TestCase):
                 return output, dense.sum(dim=0, keepdim=True)
             if case == "row_sum_downstream_sum":
                 return output, row_sum.expand(2, vocab).sum(dim=1, keepdim=True)
+            if case == "constant_pad_sum":
+                return output, torch.constant_pad_nd(dense, (0, 1)).sum(
+                    dim=1, keepdim=True
+                )
+            if case == "untagged_reduction":
+                return output, torch.cumsum(dense, dim=1)
             if case == "transitive_sum":
                 return output, (dense + 1).transpose(0, 1).sum(dim=1)
             if case == "cat_sum":
@@ -249,6 +283,78 @@ class SingletonReductionTests(TestCase):
         target = torch.tensor([[0], [vocab]], device=device)
         scale = torch.randn(2, 1, device=device)
         self._run_and_check(fn, (target, scale), False)
+
+    def test_unbacked_batch(self, device):
+        def fn(target, scale):
+            iota = torch.arange(LIVE_VOCAB, device=target.device).view(1, LIVE_VOCAB)
+            dense = torch.where(target == iota, -1.0, 0.0) * scale
+            dense = dense.to(torch.bfloat16).to(torch.float32)
+            row_sum = dense.sum(dim=1, keepdim=True)
+            return dense - row_sum
+
+        target = torch.randint(0, LIVE_VOCAB, (3, 1), device=device)
+        scale = torch.randn((), device=device)
+        torch._dynamo.decorators.mark_unbacked(target, 0)
+        self._run_and_check(fn, (target, scale), True)
+
+    def test_metadata_update(self, device):
+        graph = self._make_pass_graph(device)
+        gm = torch.fx.GraphModule({}, graph)
+        fake_mode = detect_fake_mode(get_fake(next(iter(graph.nodes)), gm))
+        if fake_mode is None:
+            raise AssertionError("expected fake mode")
+        updater = FakeTensorUpdater(gm)
+        original_nodes = set(graph.nodes)
+        reduction = next(
+            node
+            for node in graph.nodes
+            if node.target is torch.ops.aten.sum.dim_IntList
+        )
+        consumer = next(iter(reduction.users))
+
+        self.assertEqual(eliminate_singleton_reductions(graph), 1)
+        inserted = set(graph.nodes) - original_nodes
+        with V.set_fake_mode(fake_mode):
+            updated = updater.incremental_update()
+
+        self.assertGreater(updated, 0)
+        for node in inserted:
+            if node.op == "call_function":
+                self.assertIn("val", node.meta)
+        replayed_casts = [
+            node
+            for node in inserted
+            if node.target is torch.ops.prims.convert_element_type.default
+        ]
+        self.assertEqual(len(replayed_casts), 4)
+        for node in replayed_casts:
+            self.assertEqual(node.meta["val"].shape, (2, 1))
+        replacement = consumer.args[1]
+        self.assertEqual(replacement.meta["val"].shape, (2, 1))
+        self.assertEqual(replacement.meta["val"].dtype, torch.float32)
+        graph.lint()
+
+    def test_post_grad_metadata_update(self, device):
+        def fn(target, scale):
+            iota = torch.arange(LIVE_VOCAB, device=target.device).view(1, LIVE_VOCAB)
+            dense = torch.where(target == iota, -1.0, 0.0) * scale
+            dense = dense.to(torch.bfloat16).to(torch.float32)
+            row_sum = dense.sum(dim=1, keepdim=True)
+            return dense - row_sum
+
+        def assert_metadata(graph):
+            for node in graph.nodes:
+                if node.op == "call_function":
+                    self.assertIn("val", node.meta)
+
+        target = torch.tensor([[0], [LIVE_VOCAB]], device=device)
+        scale = torch.randn(2, 1, device=device)
+        self._run_and_check(
+            fn,
+            (target, scale),
+            True,
+            {"post_grad_custom_post_pass": assert_metadata},
+        )
 
     def test_dynamic_reduction_extent(self, device):
         def fn(target, scale, dense):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -293,6 +293,9 @@ epilogue_fusion_user_defined_triton_kernel = False
 # enable pattern match+replace optimizations
 pattern_matcher = True
 
+# Eliminate reductions over values selected by an at-most-one-hot mask.
+singleton_reduction_elimination = True
+
 # set to True to enable the back-to-back GEMM pass
 b2b_gemm_pass = False
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -67,6 +67,7 @@ from .micro_pipeline_tp import micro_pipeline_tp_pass
 from .pre_grad import is_same_dict, save_inductor_dict
 from .reduced_atomic_contention import partitioned_scatter_optimization_pass
 from .reinplace import reinplace_inplaceable_ops
+from .singleton_reduction import eliminate_singleton_reductions
 from .split_cat import POST_GRAD_PATTERNS
 
 
@@ -223,6 +224,13 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
     GraphTransformObserver(gm, "reject_current_device").apply_graph_pass(
         reject_current_device_nodes
     )
+
+    if config.singleton_reduction_elimination:
+        singleton_reductions = GraphTransformObserver(
+            gm, "eliminate_singleton_reductions"
+        ).apply_graph_pass(eliminate_singleton_reductions)
+        if singleton_reductions:
+            fake_tensor_updater.incremental_update()
 
     if config.pattern_matcher:
         lazy_init()

--- a/torch/_inductor/fx_passes/singleton_reduction.py
+++ b/torch/_inductor/fx_passes/singleton_reduction.py
@@ -1,0 +1,543 @@
+"""Eliminate expensive live row sums selected by a one-hot mask.
+
+The analysis proves that equality with an iota selects at most one value per
+row, then tracks that value through multiplication and floating-point casts.
+The sum can then be replayed at row shape instead of reduction shape.
+"""
+
+import dataclasses
+import math
+import operator
+from typing import Any
+
+import torch
+from torch._dynamo.utils import counters
+from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
+from torch.utils._ordered_set import OrderedSet
+
+from .. import config
+
+
+aten = torch.ops.aten
+prims = torch.ops.prims
+_RESHAPE_OPS = (aten.reshape.default, aten.view.default)
+_MAX_ANALYSIS_NODES = 64
+_MIN_LIVE_REDUCTION_ROW_BYTES = 16 * 1024
+_Scalar = int | float
+
+
+@dataclasses.dataclass(frozen=True)
+class _Uniform:
+    expr: torch.fx.Node
+    scalar: _Scalar | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class _Iota:
+    length: int
+
+
+@dataclasses.dataclass(frozen=True)
+class _OneHotMask:
+    index: torch.fx.Node
+    length: int
+
+
+@dataclasses.dataclass(frozen=True)
+class _OneHotRow:
+    index: torch.fx.Node
+    length: int
+    select: torch.fx.Node
+    hit_scalar: _Scalar | None
+    multiplier: torch.fx.Node | None = None
+    steps: tuple[torch.fx.Node, ...] = ()
+
+    @property
+    def tail(self) -> torch.fx.Node:
+        return self.steps[-1] if self.steps else self.select
+
+
+_Value = _Uniform | _Iota | _OneHotMask | _OneHotRow | None
+
+
+def _tensor_val(node: torch.fx.Node) -> torch.Tensor | None:
+    value = node.meta.get("val")
+    return value if isinstance(value, torch.Tensor) else None
+
+
+class _RowAnalyzer:
+    def __init__(self, length: int) -> None:
+        self.length = length
+        self.memo: dict[torch.fx.Node, _Value] = {}
+
+    def _is_uniform_shape(self, node: torch.fx.Node) -> bool:
+        value = _tensor_val(node)
+        if value is None or value.dim() > 2:
+            return False
+        return value.dim() == 0 or statically_known_true(
+            value.shape[-1] == 1
+        )
+
+    @staticmethod
+    def _constructor_scalar(node: torch.fx.Node) -> _Scalar | None:
+        if node.target is aten.full.default and len(node.args) >= 2:
+            scalar = node.args[1]
+        elif node.target is aten.scalar_tensor.default and node.args:
+            scalar = node.args[0]
+        else:
+            return None
+        value = _tensor_val(node)
+        if type(scalar) not in (int, float) or value is None:
+            return None
+        try:
+            return torch.tensor(scalar, dtype=value.dtype, device="cpu").item()
+        except (RuntimeError, TypeError, ValueError, OverflowError):
+            return None
+
+    def _uniform(self, node: torch.fx.Node) -> _Uniform:
+        return _Uniform(node, self._constructor_scalar(node))
+
+    def _view_iota(self, node: torch.fx.Node, iota: _Iota) -> _Iota | None:
+        value = _tensor_val(node)
+        if (
+            value is not None
+            and value.dim() == 2
+            and statically_known_true(value.shape[0] == 1)
+            and statically_known_true(value.shape[1] == iota.length)
+        ):
+            return iota
+        return None
+
+    def _matches_reduction_shape(
+        self, node: torch.fx.Node, index: torch.fx.Node
+    ) -> bool:
+        node_val = _tensor_val(node)
+        index_val = _tensor_val(index)
+        return (
+            node_val is not None
+            and index_val is not None
+            and node_val.dim() == index_val.dim() == 2
+            and statically_known_true(node_val.shape[1] == self.length)
+            and statically_known_true(sym_eq(node_val.shape[0], index_val.shape[0]))
+        )
+
+    def _branch_is_compatible(
+        self, where: torch.fx.Node, index: torch.fx.Node, branch: _Uniform
+    ) -> bool:
+        where_val = _tensor_val(where)
+        index_val = _tensor_val(index)
+        branch_val = _tensor_val(branch.expr)
+        return (
+            where_val is not None
+            and index_val is not None
+            and branch_val is not None
+            and branch_val.device == where_val.device
+            and len(branch_val.shape) <= len(index_val.shape)
+            and all(
+                statically_known_true(a == 1) or statically_known_true(sym_eq(a, b))
+                for a, b in zip(
+                    reversed(branch_val.shape), reversed(index_val.shape)
+                )
+            )
+        )
+
+    @staticmethod
+    def _is_positive_zero(value: _Scalar | None) -> bool:
+        return (
+            isinstance(value, (int, float))
+            and value == 0
+            and math.copysign(1.0, value) > 0
+        )
+
+    def _dependencies(self, node: torch.fx.Node) -> tuple[torch.fx.Node, ...]:
+        if node.op != "call_function" or not isinstance(
+            node.target, torch._ops.OpOverload
+        ):
+            return ()
+        if node.target is prims.iota.default or self._is_uniform_shape(node):
+            return ()
+        if node.target is aten.expand.default or node.target in _RESHAPE_OPS:
+            source = node.args[0] if node.args else None
+            return (source,) if isinstance(source, torch.fx.Node) else ()
+        if node.target in (
+            aten.eq.Tensor,
+            aten.where.self,
+            aten.mul.Tensor,
+            prims.convert_element_type.default,
+        ):
+            return tuple(node.all_input_nodes)
+        return ()
+
+    def _value(self, value: Any) -> Any:
+        return self.memo.get(value) if isinstance(value, torch.fx.Node) else value
+
+    def _analyze_mul(self, node: torch.fx.Node) -> _OneHotRow | None:
+        args = tuple(self._value(arg) for arg in node.args)
+        rows = [value for value in args if isinstance(value, _OneHotRow)]
+        if len(rows) != 1:
+            return None
+        row = rows[0]
+        other: torch.fx.Node | None = None
+        for original, value in zip(node.args, args):
+            if value is row:
+                continue
+            if (
+                not isinstance(original, torch.fx.Node)
+                or not isinstance(value, _Uniform)
+                or value.expr is not original
+            ):
+                return None
+            other = original
+        node_val = _tensor_val(node)
+        other_val = _tensor_val(other) if other is not None else None
+        if (
+            row.steps
+            or row.hit_scalar != -1
+            or node_val is None
+            or other_val is None
+            or not node_val.dtype.is_floating_point
+            or node_val.dtype != other_val.dtype
+            or node_val.device != other_val.device
+            or not self._matches_reduction_shape(node, row.index)
+        ):
+            return None
+        return dataclasses.replace(
+            row,
+            multiplier=other,
+            steps=(*row.steps, node),
+        )
+
+    def _analyze_convert(self, node: torch.fx.Node) -> _OneHotRow | None:
+        source = self._value(node.args[0]) if node.args else None
+        node_val = _tensor_val(node)
+        if (
+            not isinstance(source, _OneHotRow)
+            or source.multiplier is None
+            or node_val is None
+            or not self._matches_reduction_shape(node, source.index)
+        ):
+            return None
+        source_val = _tensor_val(source.tail)
+        if (
+            len(source.steps) == 1
+            and source_val is not None
+            and source_val.dtype is torch.float32
+        ):
+            expected_dtype = torch.bfloat16
+        elif (
+            len(source.steps) == 2
+            and source_val is not None
+            and source_val.dtype is torch.bfloat16
+        ):
+            expected_dtype = torch.float32
+        else:
+            return None
+        if node_val.dtype is not expected_dtype:
+            return None
+        return dataclasses.replace(source, steps=(*source.steps, node))
+
+    def analyze(self, node: torch.fx.Node) -> _Value:
+        """Compute a node's abstract value from its analyzed dependencies."""
+        if node in self.memo:
+            return self.memo[node]
+
+        result: _Value = None
+        if node.op != "call_function" or not isinstance(
+            node.target, torch._ops.OpOverload
+        ):
+            if self._is_uniform_shape(node):
+                result = self._uniform(node)
+        elif node.target is prims.iota.default:
+            length = node.args[0] if node.args else None
+            value = _tensor_val(node)
+            if (
+                isinstance(length, int)
+                and node.kwargs.get("start", 0) == 0
+                and node.kwargs.get("step", 1) == 1
+                and value is not None
+                and value.dtype is torch.int64
+            ):
+                result = _Iota(length)
+        elif node.target is aten.expand.default:
+            source = self._value(node.args[0])
+            value = _tensor_val(node)
+            if (
+                isinstance(source, _Uniform)
+                and value is not None
+                and value.dim() == 2
+                and statically_known_true(value.stride()[1] == 0)
+            ):
+                result = source
+        elif node.target in _RESHAPE_OPS:
+            source = self._value(node.args[0])
+            if isinstance(source, _Iota):
+                result = self._view_iota(node, source)
+        elif node.target is aten.eq.Tensor:
+            lhs = self._value(node.args[0])
+            rhs = self._value(node.args[1])
+            if isinstance(lhs, _Iota) and isinstance(rhs, _Uniform):
+                iota, index = lhs, rhs
+            elif isinstance(rhs, _Iota) and isinstance(lhs, _Uniform):
+                iota, index = rhs, lhs
+            else:
+                iota = index = None
+            if (
+                isinstance(iota, _Iota)
+                and isinstance(index, _Uniform)
+                and iota.length == self.length
+            ):
+                index_val = _tensor_val(index.expr)
+                if index_val is not None and index_val.dtype is torch.int64:
+                    result = _OneHotMask(index.expr, iota.length)
+        elif node.target is aten.where.self:
+            mask = self._value(node.args[0])
+            hit = self._value(node.args[1])
+            miss = self._value(node.args[2])
+            node_val = _tensor_val(node)
+            if (
+                isinstance(mask, _OneHotMask)
+                and isinstance(hit, _Uniform)
+                and isinstance(miss, _Uniform)
+                and node_val is not None
+                and node_val.dtype.is_floating_point
+                and self._is_positive_zero(miss.scalar)
+                and self._matches_reduction_shape(node, mask.index)
+                and self._branch_is_compatible(node, mask.index, hit)
+                and self._branch_is_compatible(node, mask.index, miss)
+            ):
+                result = _OneHotRow(
+                    mask.index,
+                    mask.length,
+                    node,
+                    hit.scalar,
+                )
+        elif node.target is aten.mul.Tensor:
+            result = self._analyze_mul(node)
+        elif node.target is prims.convert_element_type.default:
+            result = self._analyze_convert(node)
+
+        if result is None and self._is_uniform_shape(node):
+            result = self._uniform(node)
+        self.memo[node] = result
+        return result
+
+    def analyze_subgraph(self, node: torch.fx.Node) -> _Value:
+        order: list[torch.fx.Node] = []
+        seen = OrderedSet[torch.fx.Node]()
+        pending = [(node, False)]
+        while pending:
+            current, ready = pending.pop()
+            if current in self.memo:
+                continue
+            if ready:
+                order.append(current)
+                continue
+            if current in seen:
+                continue
+            seen.add(current)
+            if len(seen) > _MAX_ANALYSIS_NODES:
+                return None
+            pending.append((current, True))
+            pending.extend(
+                (dependency, False) for dependency in self._dependencies(current)
+            )
+        for current in order:
+            self.analyze(current)
+        return self.memo.get(node)
+
+
+def _has_expanding_pointwise_consumer(reduction: torch.fx.Node) -> bool:
+    reduction_val = _tensor_val(reduction)
+    if reduction_val is None:
+        return False
+    for user in reduction.users:
+        if user.op != "call_function" or not isinstance(
+            user.target, torch._ops.OpOverload
+        ):
+            continue
+        user_val = _tensor_val(user)
+        if (
+            torch.Tag.pointwise in user.target.tags
+            and user_val is not None
+            and statically_known_true(user_val.numel() > reduction_val.numel())
+        ):
+            return True
+    return False
+
+
+def _find_downstream_reductions(
+    dense: torch.fx.Node,
+) -> OrderedSet[torch.fx.Node] | None:
+    reductions = OrderedSet[torch.fx.Node]()
+    pending = list(dense.users)
+    seen = OrderedSet[torch.fx.Node]()
+    while pending:
+        user = pending.pop()
+        if user in seen:
+            continue
+        seen.add(user)
+        if len(seen) > _MAX_ANALYSIS_NODES:
+            return None
+        if user.op == "output":
+            continue
+        if user.op != "call_function":
+            return None
+        if isinstance(user.target, torch._ops.OpOverload):
+            if torch.Tag.reduction in user.target.tags:
+                reductions.add(user)
+            else:
+                pending.extend(user.users)
+        elif user.target is operator.getitem:
+            pending.extend(user.users)
+        else:
+            return None
+    return reductions
+
+
+def _expand_to_index(
+    graph: torch.fx.Graph, value: torch.fx.Node, index: torch.fx.Node
+) -> torch.fx.Node:
+    index_val = _tensor_val(index)
+    if index_val is None:
+        raise AssertionError("expected tensor metadata")
+    shape = [
+        size if isinstance(size, int) else graph.create_size_node(index, dim)
+        for dim, size in enumerate(index_val.shape)
+    ]
+    return graph.call_function(aten.expand.default, (value, shape))
+
+
+def _replay_branch(
+    graph: torch.fx.Graph,
+    row: _OneHotRow,
+    hit: bool,
+) -> torch.fx.Node:
+    if row.multiplier is None:
+        raise AssertionError("expected row multiplier")
+    if hit:
+        value = graph.call_function(aten.neg.default, (row.multiplier,))
+    else:
+        # Only the zero-or-NaN property matters for unselected lanes.
+        value = graph.call_function(
+            aten.sub.Tensor, (row.multiplier, row.multiplier)
+        )
+    value = _expand_to_index(graph, value, row.index)
+    replacements = {row.select: value, row.steps[0]: value}
+    for step in row.steps[1:]:
+        value = graph.node_copy(step, lambda node: replacements.get(node, node))
+        replacements[step] = _expand_to_index(graph, value, row.index)
+    return replacements[row.tail]
+
+
+def _sum_args(node: torch.fx.Node) -> tuple[torch.fx.Node, int] | None:
+    if node.target is not aten.sum.dim_IntList or len(node.args) < 3:
+        return None
+    dense, dims, keepdim = node.args[:3]
+    if (
+        not isinstance(dense, torch.fx.Node)
+        or not isinstance(dims, (list, tuple))
+        or len(dims) != 1
+        or keepdim is not True
+        or len(node.args) > 3
+        or node.kwargs.get("dtype") is not None
+    ):
+        return None
+    dense_val = _tensor_val(dense)
+    if dense_val is None or dense_val.dim() == 0 or not isinstance(dims[0], int):
+        return None
+    return dense, dims[0] % dense_val.dim()
+
+
+def eliminate_singleton_reductions(graph: torch.fx.Graph) -> int:
+    """Replace profitable live one-hot row sums with compact expressions."""
+    count = 0
+    analysis_cache: dict[tuple[torch.fx.Node, int], _Value] = {}
+    reduction_cache: dict[
+        torch.fx.Node, OrderedSet[torch.fx.Node] | None
+    ] = {}
+    for reduction in list(graph.nodes):
+        if reduction.op != "call_function":
+            continue
+        sum_args = _sum_args(reduction)
+        if sum_args is None:
+            continue
+        dense, dim = sum_args
+        dense_val = _tensor_val(dense)
+        output_val = _tensor_val(reduction)
+        if (
+            dense_val is None
+            or output_val is None
+            or torch.version.hip is not None
+            or dense_val.device.type != "cuda"
+            or dense_val.dtype is not torch.float32
+            or output_val.dtype is not torch.float32
+            or dense_val.dim() != 2
+            or dim != 1
+            or not isinstance(dense_val.shape[dim], int)
+            or dense_val.shape[dim] <= 1
+            or len(dense.users) <= 1
+            or config.force_shape_pad
+        ):
+            continue
+
+        length = dense_val.shape[dim]
+        key = (dense, length)
+        if key not in analysis_cache:
+            analysis_cache[key] = _RowAnalyzer(length).analyze_subgraph(dense)
+        row = analysis_cache[key]
+        if (
+            not isinstance(row, _OneHotRow)
+            or len(row.steps) != 3
+            or length * dense_val.element_size() < _MIN_LIVE_REDUCTION_ROW_BYTES
+            or not _has_expanding_pointwise_consumer(reduction)
+        ):
+            continue
+        if dense not in reduction_cache:
+            reduction_cache[dense] = _find_downstream_reductions(dense)
+        downstream_reductions = reduction_cache[dense]
+        if (
+            downstream_reductions is None
+            or len(downstream_reductions) != 1
+            or reduction not in downstream_reductions
+        ):
+            continue
+
+        index_val = _tensor_val(row.index)
+        if (
+            index_val is None
+            or index_val.dtype is not torch.int64
+            or index_val.device != dense_val.device
+            or not statically_known_true(sym_eq(index_val.shape, output_val.shape))
+        ):
+            continue
+
+        with graph.inserting_before(reduction):
+            ge_zero = graph.call_function(aten.ge.Scalar, (row.index, 0))
+            in_range = graph.call_function(
+                aten.le.Scalar, (row.index, row.length - 1)
+            )
+            valid = graph.call_function(aten.bitwise_and.Tensor, (ge_zero, in_range))
+            hit = _replay_branch(graph, row, True)
+            miss = _replay_branch(graph, row, False)
+            zero = graph.call_function(
+                aten.full.default,
+                ([], 0.0),
+                {"dtype": dense_val.dtype, "device": dense_val.device},
+            )
+            # Match sum's signed-zero normalization and preserve NaNs produced
+            # when an unselected zero is multiplied by a nonfinite value.
+            normalized_hit = graph.call_function(aten.add.Tensor, (hit, zero))
+            valid_hit = graph.call_function(
+                aten.where.self, (valid, normalized_hit, zero)
+            )
+            miss_is_zero = graph.call_function(aten.eq.Scalar, (miss, 0))
+            replacement = graph.call_function(
+                aten.where.self, (miss_is_zero, valid_hit, miss)
+            )
+
+        reduction.replace_all_uses_with(replacement)
+        graph.erase_node(reduction)
+        counters["inductor"]["singleton_reduction_elimination"] += 1
+        count += 1
+
+    return count

--- a/torch/_inductor/fx_passes/singleton_reduction.py
+++ b/torch/_inductor/fx_passes/singleton_reduction.py
@@ -16,11 +16,14 @@ from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
 from torch.utils._ordered_set import OrderedSet
 
 from .. import config
+from ..utils import is_view
 
 
 aten = torch.ops.aten
 prims = torch.ops.prims
 _RESHAPE_OPS = (aten.reshape.default, aten.view.default)
+# Non-aggregating lowerings without Tag.pointwise.
+_DOWNSTREAM_NON_AGGREGATING_OPS = (aten.constant_pad_nd.default,)
 _MAX_ANALYSIS_NODES = 64
 _MIN_LIVE_REDUCTION_ROW_BYTES = 32_000
 _Scalar = int | float
@@ -360,10 +363,27 @@ def _has_expanding_pointwise_consumer(
         if (
             torch.Tag.pointwise in user.target.tags
             and user_val is not None
-            and statically_known_true(user_val.numel() > reduction_val.numel())
+            and _shape_expands(user_val.shape, reduction_val.shape)
         ):
             return True
     return False
+
+
+def _shape_expands(user_shape: torch.Size, source_shape: torch.Size) -> bool:
+    if len(user_shape) < len(source_shape):
+        return False
+    source_shape = (1,) * (len(user_shape) - len(source_shape)) + tuple(source_shape)
+    expanded = False
+    for user_size, source_size in zip(user_shape, source_shape):
+        if statically_known_true(sym_eq(user_size, source_size)):
+            continue
+        if not (
+            statically_known_true(source_size == 1)
+            and statically_known_true(user_size > 1)
+        ):
+            return False
+        expanded = True
+    return expanded
 
 
 def _find_downstream_reductions(
@@ -386,6 +406,12 @@ def _find_downstream_reductions(
         if isinstance(user.target, torch._ops.OpOverload):
             if torch.Tag.reduction in user.target.tags:
                 reductions.add(user)
+            elif (
+                torch.Tag.pointwise not in user.target.tags
+                and not is_view(user.target)
+                and user.target not in _DOWNSTREAM_NON_AGGREGATING_OPS
+            ):
+                return None
             pending.extend(user.users)
         elif user.target is operator.getitem:
             pending.extend(user.users)

--- a/torch/_inductor/fx_passes/singleton_reduction.py
+++ b/torch/_inductor/fx_passes/singleton_reduction.py
@@ -350,8 +350,10 @@ def _has_expanding_pointwise_consumer(
     if reduction_val is None:
         return False
     for user in reduction.users:
-        if user not in live or user.op != "call_function" or not isinstance(
-            user.target, torch._ops.OpOverload
+        if (
+            user not in live
+            or user.op != "call_function"
+            or not isinstance(user.target, torch._ops.OpOverload)
         ):
             continue
         user_val = _tensor_val(user)

--- a/torch/_inductor/fx_passes/singleton_reduction.py
+++ b/torch/_inductor/fx_passes/singleton_reduction.py
@@ -372,9 +372,11 @@ def _has_expanding_pointwise_consumer(
 def _shape_expands(user_shape: torch.Size, source_shape: torch.Size) -> bool:
     if len(user_shape) < len(source_shape):
         return False
-    source_shape = (1,) * (len(user_shape) - len(source_shape)) + tuple(source_shape)
+    aligned_source_shape = (1,) * (len(user_shape) - len(source_shape)) + tuple(
+        source_shape
+    )
     expanded = False
-    for user_size, source_size in zip(user_shape, source_shape):
+    for user_size, source_size in zip(user_shape, aligned_source_shape):
         if statically_known_true(sym_eq(user_size, source_size)):
             continue
         if not (

--- a/torch/_inductor/fx_passes/singleton_reduction.py
+++ b/torch/_inductor/fx_passes/singleton_reduction.py
@@ -15,7 +15,6 @@ from torch._dynamo.utils import counters
 from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
 from torch.utils._ordered_set import OrderedSet
 
-from .. import config
 from ..utils import is_view
 
 
@@ -500,7 +499,6 @@ def eliminate_singleton_reductions(graph: torch.fx.Graph) -> int:
             or dim != 1
             or not isinstance(dense_val.shape[dim], int)
             or dense_val.shape[dim] <= 1
-            or config.force_shape_pad
         ):
             continue
 

--- a/torch/_inductor/fx_passes/singleton_reduction.py
+++ b/torch/_inductor/fx_passes/singleton_reduction.py
@@ -22,7 +22,7 @@ aten = torch.ops.aten
 prims = torch.ops.prims
 _RESHAPE_OPS = (aten.reshape.default, aten.view.default)
 _MAX_ANALYSIS_NODES = 64
-_MIN_LIVE_REDUCTION_ROW_BYTES = 16 * 1024
+_MIN_LIVE_REDUCTION_ROW_BYTES = 32_000
 _Scalar = int | float
 
 
@@ -47,14 +47,8 @@ class _OneHotMask:
 class _OneHotRow:
     index: torch.fx.Node
     length: int
-    select: torch.fx.Node
-    hit_scalar: _Scalar | None
     multiplier: torch.fx.Node | None = None
     steps: tuple[torch.fx.Node, ...] = ()
-
-    @property
-    def tail(self) -> torch.fx.Node:
-        return self.steps[-1] if self.steps else self.select
 
 
 _Value = _Uniform | _Iota | _OneHotMask | _OneHotRow | None
@@ -74,9 +68,7 @@ class _RowAnalyzer:
         value = _tensor_val(node)
         if value is None or value.dim() > 2:
             return False
-        return value.dim() == 0 or statically_known_true(
-            value.shape[-1] == 1
-        )
+        return value.dim() == 0 or statically_known_true(value.shape[-1] == 1)
 
     @staticmethod
     def _constructor_scalar(node: torch.fx.Node) -> _Scalar | None:
@@ -135,9 +127,7 @@ class _RowAnalyzer:
             and len(branch_val.shape) <= len(index_val.shape)
             and all(
                 statically_known_true(a == 1) or statically_known_true(sym_eq(a, b))
-                for a, b in zip(
-                    reversed(branch_val.shape), reversed(index_val.shape)
-                )
+                for a, b in zip(reversed(branch_val.shape), reversed(index_val.shape))
             )
         )
 
@@ -192,7 +182,6 @@ class _RowAnalyzer:
         other_val = _tensor_val(other) if other is not None else None
         if (
             row.steps
-            or row.hit_scalar != -1
             or node_val is None
             or other_val is None
             or not node_val.dtype.is_floating_point
@@ -217,7 +206,7 @@ class _RowAnalyzer:
             or not self._matches_reduction_shape(node, source.index)
         ):
             return None
-        source_val = _tensor_val(source.tail)
+        source_val = _tensor_val(source.steps[-1])
         if (
             len(source.steps) == 1
             and source_val is not None
@@ -300,17 +289,13 @@ class _RowAnalyzer:
                 and isinstance(miss, _Uniform)
                 and node_val is not None
                 and node_val.dtype.is_floating_point
+                and hit.scalar == -1
                 and self._is_positive_zero(miss.scalar)
                 and self._matches_reduction_shape(node, mask.index)
                 and self._branch_is_compatible(node, mask.index, hit)
                 and self._branch_is_compatible(node, mask.index, miss)
             ):
-                result = _OneHotRow(
-                    mask.index,
-                    mask.length,
-                    node,
-                    hit.scalar,
-                )
+                result = _OneHotRow(mask.index, mask.length)
         elif node.target is aten.mul.Tensor:
             result = self._analyze_mul(node)
         elif node.target is prims.convert_element_type.default:
@@ -346,12 +331,26 @@ class _RowAnalyzer:
         return self.memo.get(node)
 
 
-def _has_expanding_pointwise_consumer(reduction: torch.fx.Node) -> bool:
+def _find_live_nodes(graph: torch.fx.Graph) -> OrderedSet[torch.fx.Node]:
+    live = OrderedSet[torch.fx.Node]()
+    pending = [node for node in graph.nodes if node.op == "output"]
+    while pending:
+        node = pending.pop()
+        if node in live:
+            continue
+        live.add(node)
+        pending.extend(node.all_input_nodes)
+    return live
+
+
+def _has_expanding_pointwise_consumer(
+    reduction: torch.fx.Node, live: OrderedSet[torch.fx.Node]
+) -> bool:
     reduction_val = _tensor_val(reduction)
     if reduction_val is None:
         return False
     for user in reduction.users:
-        if user.op != "call_function" or not isinstance(
+        if user not in live or user.op != "call_function" or not isinstance(
             user.target, torch._ops.OpOverload
         ):
             continue
@@ -366,14 +365,14 @@ def _has_expanding_pointwise_consumer(reduction: torch.fx.Node) -> bool:
 
 
 def _find_downstream_reductions(
-    dense: torch.fx.Node,
+    dense: torch.fx.Node, live: OrderedSet[torch.fx.Node]
 ) -> OrderedSet[torch.fx.Node] | None:
     reductions = OrderedSet[torch.fx.Node]()
     pending = list(dense.users)
     seen = OrderedSet[torch.fx.Node]()
     while pending:
         user = pending.pop()
-        if user in seen:
+        if user not in live or user in seen:
             continue
         seen.add(user)
         if len(seen) > _MAX_ANALYSIS_NODES:
@@ -385,8 +384,7 @@ def _find_downstream_reductions(
         if isinstance(user.target, torch._ops.OpOverload):
             if torch.Tag.reduction in user.target.tags:
                 reductions.add(user)
-            else:
-                pending.extend(user.users)
+            pending.extend(user.users)
         elif user.target is operator.getitem:
             pending.extend(user.users)
         else:
@@ -418,15 +416,13 @@ def _replay_branch(
         value = graph.call_function(aten.neg.default, (row.multiplier,))
     else:
         # Only the zero-or-NaN property matters for unselected lanes.
-        value = graph.call_function(
-            aten.sub.Tensor, (row.multiplier, row.multiplier)
-        )
+        value = graph.call_function(aten.sub.Tensor, (row.multiplier, row.multiplier))
     value = _expand_to_index(graph, value, row.index)
-    replacements = {row.select: value, row.steps[0]: value}
+    replacements = {row.steps[0]: value}
     for step in row.steps[1:]:
         value = graph.node_copy(step, lambda node: replacements.get(node, node))
         replacements[step] = _expand_to_index(graph, value, row.index)
-    return replacements[row.tail]
+    return replacements[row.steps[-1]]
 
 
 def _sum_args(node: torch.fx.Node) -> tuple[torch.fx.Node, int] | None:
@@ -452,9 +448,8 @@ def eliminate_singleton_reductions(graph: torch.fx.Graph) -> int:
     """Replace profitable live one-hot row sums with compact expressions."""
     count = 0
     analysis_cache: dict[tuple[torch.fx.Node, int], _Value] = {}
-    reduction_cache: dict[
-        torch.fx.Node, OrderedSet[torch.fx.Node] | None
-    ] = {}
+    reduction_cache: dict[torch.fx.Node, OrderedSet[torch.fx.Node] | None] = {}
+    live: OrderedSet[torch.fx.Node] | None = None
     for reduction in list(graph.nodes):
         if reduction.op != "call_function":
             continue
@@ -475,7 +470,6 @@ def eliminate_singleton_reductions(graph: torch.fx.Graph) -> int:
             or dim != 1
             or not isinstance(dense_val.shape[dim], int)
             or dense_val.shape[dim] <= 1
-            or len(dense.users) <= 1
             or config.force_shape_pad
         ):
             continue
@@ -489,11 +483,16 @@ def eliminate_singleton_reductions(graph: torch.fx.Graph) -> int:
             not isinstance(row, _OneHotRow)
             or len(row.steps) != 3
             or length * dense_val.element_size() < _MIN_LIVE_REDUCTION_ROW_BYTES
-            or not _has_expanding_pointwise_consumer(reduction)
         ):
             continue
+        if live is None:
+            live = _find_live_nodes(graph)
+        if not any(user is not reduction and user in live for user in dense.users):
+            continue
+        if not _has_expanding_pointwise_consumer(reduction, live):
+            continue
         if dense not in reduction_cache:
-            reduction_cache[dense] = _find_downstream_reductions(dense)
+            reduction_cache[dense] = _find_downstream_reductions(dense, live)
         downstream_reductions = reduction_cache[dense]
         if (
             downstream_reductions is None
@@ -513,9 +512,7 @@ def eliminate_singleton_reductions(graph: torch.fx.Graph) -> int:
 
         with graph.inserting_before(reduction):
             ge_zero = graph.call_function(aten.ge.Scalar, (row.index, 0))
-            in_range = graph.call_function(
-                aten.le.Scalar, (row.index, row.length - 1)
-            )
+            in_range = graph.call_function(aten.le.Scalar, (row.index, row.length - 1))
             valid = graph.call_function(aten.bitwise_and.Tensor, (ge_zero, in_range))
             hit = _replay_branch(graph, row, True)
             miss = _replay_branch(graph, row, False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191379

Decomposed cross-entropy backward graphs can build an at-most-one-hot row, multiply it by a uniform row value, round through BF16, and then reduce the full vocabulary dimension back to one value per row. Inductor does not recover that singleton property, so live dense values can force an otherwise redundant full-width reduction and materialization.

Add a bounded post-grad abstract interpretation that proves the iota/equality/where/multiply/cast semantics and replaces profitable row sums with compact row expressions. The replacement preserves invalid-index behavior, signed-zero normalization, and NaNs from nonfinite multipliers. Profitability remains conservative: the dense row must be at least 32,000 bytes and have output-live reuse, the reduction must feed an output-live expanding pointwise consumer, and bounded dependency analysis must prove it is the only reachable live reduction. Downstream analysis follows pointwise, view, and known non-aggregating operations, and rejects unclassified operations. Reachability results are cached per dense value to keep shared-reduction analysis linear.

This uses semantic transfer analysis instead of an FX pattern so equivalent broadcasts, views, and commuted operands remain supported. Direct FP32 reductions and multi-reduction graphs are deliberately deferred: corpus measurements found no meaningful default benefit for the former, while the latter require scheduler-aware realization placement.

Using A/B ratios measured locally on H100 and projecting them onto B200 dashboard model times, the retained cases estimate +0.237% default and +0.267% coordinate-descent geomean across the 155-model oracle rollup. The eight activated shape points improve by 6.4-42.1% with default scheduling and 0.4-39.4% with coordinate descent.

Test Plan:

```bash
PYTHONPATH="$PWD" python -c 'import runpy; runpy.run_path("test/inductor/test_singleton_reduction.py", run_name="__main__")' -v
```

```bash
python agent_space/scan_singleton_reduction_pass.py --pytorch-root agent_space/pr_ce_singleton_26cc --better-benchmark-root agent_space/better-benchmark --output agent_space/ce_pr191379_no_padding_gate_final_scan_20260729.json --log agent_space/ce_pr191379_no_padding_gate_final_scan_20260729.log
```

```bash
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=agent_space/ce_simplified_overlay_site python agent_space/check_singleton_activation_correctness.py agent_space/ce_pr191379_no_padding_gate_final_scan_20260729.json agent_space/better-benchmark agent_space/ce_pr191379_no_padding_gate_final_correctness_20260729.json
```

```bash
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=agent_space/ce_simplified_overlay_site python scripts/bench_parallel.py --gpus 0 --max-workers 1 --workers-per-gpu 1 --all-shapes --strict-gpu-lock --n-warmup 100 --n-rep 500 --inductor-config singleton_reduction_elimination=False --output /data/users/eellison/pytorch/agent_space/ce_round3_final_highrep_off_20260728.json repros/canonical/sum_0551250469f2/repro.py repros/canonical/sum_561404c238b3/repro.py repros/canonical/sum_6119d597d188/repro.py repros/canonical/sum_81b4fd73f8d1/repro.py repros/canonical/sum_89a9de6a6901/repro.py repros/canonical/sum_c540b7439b72/repro.py
```

```bash
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=agent_space/ce_simplified_overlay_site python scripts/bench_parallel.py --gpus 0 --max-workers 1 --workers-per-gpu 1 --all-shapes --strict-gpu-lock --n-warmup 100 --n-rep 500 --inductor-config singleton_reduction_elimination=True --output /data/users/eellison/pytorch/agent_space/ce_round3_final_highrep_on_20260728.json repros/canonical/sum_0551250469f2/repro.py repros/canonical/sum_561404c238b3/repro.py repros/canonical/sum_6119d597d188/repro.py repros/canonical/sum_81b4fd73f8d1/repro.py repros/canonical/sum_89a9de6a6901/repro.py repros/canonical/sum_c540b7439b72/repro.py
```

```bash
lintrunner -a --take FLAKE8,PYFMT,RUFF,DOCSTRING_LINTER torch/_inductor/fx_passes/singleton_reduction.py test/inductor/test_singleton_reduction.py
```

`lintrunner -a` was also run; without initialized local lint metadata, PYREFLY reported environment-wide missing attributes unrelated to these files. The targeted linters above passed. The CI Pyrefly diagnostic was fixed by keeping the aligned tuple separate from the `torch.Size` parameter.

Authored with assistance from an AI coding assistant.