### PR TITLE
[distributed] Document reconfigure APIs

### DIFF
--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -434,6 +434,14 @@ check whether the process group has already been initialized use {func}`torch.di
 .. autofunction:: set_timeout
 ```
 
+### Fault-tolerant reconfiguration
+
+```{eval-rst}
+.. autofunction:: torch.distributed.distributed_c10d._supports_reconfigure
+.. autofunction:: torch.distributed.distributed_c10d._get_reconfigure_handle
+.. autofunction:: torch.distributed.distributed_c10d._reconfigure
+```
+
 ## Shutdown
 
 It is important to clean up resources on exit by calling {func}`destroy_process_group`.

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -7803,6 +7803,9 @@ def _supports_reconfigure(group: ProcessGroup | None = None) -> bool:
     """
     Return whether ``group`` supports the reconfigure-based fault tolerance API.
 
+    .. warning::
+        This API is experimental and subject to change or removal.
+
     Args:
         group (ProcessGroup, optional): The process group to query. If ``None``,
             the default process group is used.
@@ -7817,6 +7820,9 @@ def _get_reconfigure_handle(group: ProcessGroup | None = None) -> str:
 
     The handle encodes the information peers exchange out-of-band to
     (re)initialize the communicator via :func:`_reconfigure`.
+
+    .. warning::
+        This API is experimental and subject to change or removal.
 
     Args:
         group (ProcessGroup, optional): The process group to query. If ``None``,
@@ -7836,6 +7842,9 @@ def _reconfigure(
     """
     Reconfigure ``group`` with a new set of peers for fault tolerance.
 
+    .. warning::
+        This API is experimental and subject to change or removal.
+
     Args:
         uuid (int): Uniquely identifies this instance of the communicator. Pass
             a fresh value on every (re)initialization.
@@ -7850,6 +7859,13 @@ def _reconfigure(
 
     Returns:
         Work: An async work handle for the reconfigure operation.
+
+    Example::
+        >>> # xdoctest: +SKIP("requires out-of-band rendezvous")
+        >>> dist.init_process_group("gloo", enable_reconfigure=True)
+        >>> # Every peer receives the same fresh UUID and rank-ordered handles.
+        >>> uuid, handles = rendezvous_reconfigure(dist._get_reconfigure_handle())
+        >>> dist._reconfigure(uuid=uuid, handles=handles).wait()
     """
     pg = group or _get_default_group()
     opts = ReconfigureOptions()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191384

Human direction: "Add a short example of how to use _reconfigure to distributed_c10d.py"; "also add the reconfigure methods to distributed docs"; "add comments to docstrings marking the reconfigure APIs as experimental and subject to change/removal."

> AI-assisted summary:
>
> Add the three reconfiguration helpers to the distributed API reference. Include a short `_reconfigure` example that shows reconfiguration being enabled, peer handles and a shared fresh UUID being exchanged out of band, and the returned work being awaited.
>
> Mark each reconfiguration helper as experimental and subject to change or removal.
>
> Test Plan:
>
> ```bash
> BUILD_TEST=0 USE_FBGEMM=0 USE_NNPACK=0 USE_QNNPACK=0 USE_QNNPACk=0 USE_PYTORCH_QNNPACK=0 USE_XNNPACK=0 USE_FLASH_ATTENTION=0 USE_MEM_EFF_ATTENTION=0 USE_DISTRIBUTED=1 USE_CUDA=0 MAX_JOBS=144 .venv/bin/pip install -e . -v --no-build-isolation
> .venv/bin/python test/distributed/test_c10d_pypg.py -k reconfigure -v
> .venv/bin/python test/distributed/test_c10d_fault_tolerance.py -k reconfigure_basic -v
> spin quicklint -a -- --skip CLANGTIDY
> env PATH="/home/dev/pytorch3/.venv/bin:$PATH" .venv/bin/spin docs html 'O=-D katex_prerender=0'
> ```
>
> The build, lint, and focused tests passed. The full docs build rendered and verified `distributed.md`, then exited nonzero because `-W` promoted 22 pre-existing autosummary warnings in `fx.experimental.md`.
>
> This change was authored with assistance from an AI coding assistant.