### PR TITLE
[ROCm][CI] Set Inductor compile threads to 16 on ROCm test jobs

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -84,6 +84,18 @@ export TORCH_SERIALIZATION_DEBUG=1
 # any legitimately long compile on those backends.
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     export TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT=300
+    # Cap Inductor compile-worker fan-out on the ROCm test jobs. They run in a
+    # multi-pod-per-node ROCm runner fleet where the nested test container sees
+    # the host CPU count (nproc=192) instead of the pod's CPU allocation (no
+    # cpuset/quota is inherited), so decide_compile_threads() defaults
+    # compile_threads to min(32, cpu_count()) = 32 per test process and
+    # async_compile forks that many GPU-attached compile workers onto the single
+    # visible GPU. That oversubscribes the KFD runlist and can thrash/hang a
+    # shard until the 270-min job cap. Pinning to 16 halves the fan-out
+    # (32 -> 16) to cut the oversubscription while keeping some compile
+    # parallelism; it does NOT eliminate the SubprocPool (only =1 would). Drop
+    # to 1 if 16 proves insufficient.
+    export TORCHINDUCTOR_COMPILE_THREADS=16
 fi
 
 export VALGRIND=ON

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -84,16 +84,18 @@ export TORCH_SERIALIZATION_DEBUG=1
 # any legitimately long compile on those backends.
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     export TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT=300
-    # Disable Inductor compile-worker fan-out on the ROCm test jobs. They run in a
+    # Cap Inductor compile-worker fan-out on the ROCm test jobs. They run in a
     # multi-pod-per-node ROCm runner fleet where the nested test container sees
     # the host CPU count (nproc=192) instead of the pod's CPU allocation (no
     # cpuset/quota is inherited), so decide_compile_threads() defaults
     # compile_threads to min(32, cpu_count()) = 32 per test process and
     # async_compile forks that many GPU-attached compile workers onto the single
-    # visible GPU. That oversubscribes the KFD runlist and can thrash/hang a
-    # shard until its timeout. Use one compile thread to avoid creating the
-    # GPU-attached SubprocPool on these jobs.
-    export TORCHINDUCTOR_COMPILE_THREADS=1
+    # visible GPU. That oversubscribes the accelerator scheduler runlist and can
+    # thrash/hang a shard until its timeout. Cap the fan-out to a small pool of 4
+    # workers: this still creates a GPU-attached SubprocPool (unlike a single
+    # thread, which runs compilation inline with no pool) but bounds the number of
+    # concurrent GPU-attached workers well below the oversubscription threshold.
+    export TORCHINDUCTOR_COMPILE_THREADS=4
 fi
 
 export VALGRIND=ON

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -84,18 +84,16 @@ export TORCH_SERIALIZATION_DEBUG=1
 # any legitimately long compile on those backends.
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     export TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT=300
-    # Cap Inductor compile-worker fan-out on the ROCm test jobs. They run in a
+    # Disable Inductor compile-worker fan-out on the ROCm test jobs. They run in a
     # multi-pod-per-node ROCm runner fleet where the nested test container sees
     # the host CPU count (nproc=192) instead of the pod's CPU allocation (no
     # cpuset/quota is inherited), so decide_compile_threads() defaults
     # compile_threads to min(32, cpu_count()) = 32 per test process and
     # async_compile forks that many GPU-attached compile workers onto the single
     # visible GPU. That oversubscribes the KFD runlist and can thrash/hang a
-    # shard until the 270-min job cap. Pinning to 16 halves the fan-out
-    # (32 -> 16) to cut the oversubscription while keeping some compile
-    # parallelism; it does NOT eliminate the SubprocPool (only =1 would). Drop
-    # to 1 if 16 proves insufficient.
-    export TORCHINDUCTOR_COMPILE_THREADS=16
+    # shard until its timeout. Use one compile thread to avoid creating the
+    # GPU-attached SubprocPool on these jobs.
+    export TORCHINDUCTOR_COMPILE_THREADS=1
 fi
 
 export VALGRIND=ON

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -91,11 +91,11 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     # compile_threads to min(32, cpu_count()) = 32 per test process and
     # async_compile forks that many GPU-attached compile workers onto the single
     # visible GPU. That oversubscribes the accelerator scheduler runlist and can
-    # thrash/hang a shard until its timeout. Cap the fan-out to a small pool of 4
-    # workers: this still creates a GPU-attached SubprocPool (unlike a single
+    # thrash/hang a shard until its timeout. Cap the fan-out to a bounded pool of
+    # 16 workers: this still creates a GPU-attached SubprocPool (unlike a single
     # thread, which runs compilation inline with no pool) but bounds the number of
-    # concurrent GPU-attached workers well below the oversubscription threshold.
-    export TORCHINDUCTOR_COMPILE_THREADS=4
+    # concurrent GPU-attached workers below the oversubscription threshold.
+    export TORCHINDUCTOR_COMPILE_THREADS=16
 fi
 
 export VALGRIND=ON


### PR DESCRIPTION
## Motivation

The ROCm trunk test jobs (e.g. `linux-jammy-rocm-py3.10-mi350` / gfx950) have been hitting the 270-minute GitHub Actions step cap on Inductor shards. Root cause is compile-worker oversubscription of the single visible GPU:

- These jobs run in a multi-pod-per-node ROCm runner fleet. The nested test container sees the **host** CPU count (`nproc` = 192) instead of the pod's CPU allocation, because no cpuset/CPU quota is inherited by the container.
- Inductor's `decide_compile_threads()` (`torch/_inductor/config.py`) defaults `compile_threads` to `min(32, cpu_count())`. With `cpu_count()` = 192 this pins to **32 per test process**.
- `async_compile` then builds a `SubprocPool` and forks that many GPU-attached compile workers onto the **single** GPU visible to the shard. The AMD accelerator scheduler uses a fixed runlist, so 32 contexts oversubscribe it and the shard thrashes/hangs until the 270-min cap.

### Why CUDA CI never needs this and ROCm does

| Dimension | CUDA/NVIDIA CI | ROCm CI |
|---|---|---|
| CPU visible to test container | instance-bounded (bounded per-VM vCPU count, e.g. ~16) | 192 (host); no cpuset, escapes quota |
| Runners per box | 1 per VM | multiple runner pods share one 192-core node |
| NUM_PROCS / GPU sharing | 2-3 files/GPU on purpose | 1 file/GPU forced (post #90940) |
| inductor `compile_threads` default | `min(32,16)` = 16 | `min(32,192)` = 32 per test proc |
| `TORCHINDUCTOR_COMPILE_THREADS` in CI | not set (fine; instance-bounded) | not set (default explodes to 32) |
| GPU driver tolerance | NVIDIA time-slices contexts (+MPS) | AMD fixed runlist -> thrash/hang |

On NVIDIA CI the container reads a bounded per-instance CPU count, so `min(32, ~16)` = 16 is naturally safe, and the NVIDIA driver time-slices GPU contexts (optionally via MPS) so mild oversubscription degrades gracefully. ROCm's nested container instead reads the host `nproc` = 192, yielding 32 forked GPU-attached workers on one GPU, which the AMD fixed runlist cannot absorb -> oversubscription -> 270-min cap. Bounding the fan-out explicitly makes the ROCm test env match CUDA's naturally bounded `min(32, ~16)` = 16 case.

## Summary

Set `TORCHINDUCTOR_COMPILE_THREADS=16` for the ROCm test environment by folding the export into the existing `BUILD_ENVIRONMENT == *rocm*` block in `.ci/pytorch/test.sh` (alongside the existing `TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT` export). This applies to all ROCm test jobs.

This pins the compile-worker fan-out to the same **16** that a bounded NVIDIA CI container reaches by default, rather than the 32 the ROCm container explodes to. `decide_compile_threads()` honors the `TORCHINDUCTOR_COMPILE_THREADS` override and short-circuits **before** reading `cpu_count()`, so the fan-out is pinned to 16 rather than 32. Unlike a single thread (`=1`, which runs compilation inline with **no** pool), `=16` still builds a `SubprocPool` and forks 16 GPU-attached workers, halving the oversubscription while retaining compile parallelism. `=4` and `=1` remain the fallbacks if 16 proves insufficient.

## Test plan

- `ciflow/trunk` runs `trunk.yml` on MI350, exercising the `linux-jammy-rocm-py3.10-mi350` build + test jobs on `linux.rocm.gpu.gfx950.1` runners; `ciflow/rocm` exercises the broader ROCm test set.
- Confirm the Inductor default shards complete well under the 270-min cap (no oversubscription hang).
- Specifically confirm `inductor/test_max_autotune 2/2` completes within its per-file limit at `=16`, and record its runtime.
- Confirm `compile_threads set to 16 via env` appears in the Inductor logs for these jobs.

Made with Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
