### PR TITLE
[inductor] Allow CUDA Graph Trees warmup retries

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -26,6 +26,7 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
      set_stance
      set_enable_guard_collectives
      cudagraph_mark_step_begin
+     cudagraph_mark_warmup_incomplete
      is_compiling
      is_dynamo_compiling
      is_exporting

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -151,7 +151,6 @@ class TestCase(InductorTestCase):
 
 
 class CUDAGraphAPIOnlyTests(TestCase):
-    @config.patch({"triton.cudagraphs": False, "triton.cudagraph_trees": False})
     def test_mark_warmup_incomplete_without_cudagraphs(self):
         cudagraph_trees = torch._inductor.cudagraph_trees
         containers = cudagraph_trees.get_obj(

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -150,6 +150,18 @@ class TestCase(InductorTestCase):
         torch._dynamo.reset()
 
 
+class CUDAGraphAPIOnlyTests(TestCase):
+    @config.patch({"triton.cudagraphs": False, "triton.cudagraph_trees": False})
+    def test_mark_warmup_incomplete_without_cudagraphs(self):
+        cudagraph_trees = torch._inductor.cudagraph_trees
+        containers = cudagraph_trees.get_obj(
+            cudagraph_trees.local, "tree_manager_containers"
+        )
+        existing_devices = tuple(containers)
+        torch.compiler.cudagraph_mark_warmup_incomplete()
+        self.assertEqual(tuple(containers), existing_devices)
+
+
 if HAS_CUDA_AND_TRITON:
 
     def get_all_cudagraph_segments():
@@ -3149,6 +3161,61 @@ if HAS_CUDA_AND_TRITON:
             foo_cg([3, x])  # record
             foo_cg([3, x])  # replay
             self.assertEqual(COUNTER, 4)
+
+        def test_mark_warmup_incomplete(self):
+            mark_warmup_incomplete = torch.compiler.cudagraph_mark_warmup_incomplete
+            mark_warmup_incomplete()
+            self.assertIsNone(self.get_manager())
+
+            def stable(inps):
+                x = inps[0]
+                inps.clear()
+                return (x + 1,)
+
+            x = torch.randn(2, device="cuda")
+            stable_cg = self.cudagraphify_impl(stable, [x], ())
+            stable_out = stable_cg([x])
+            manager = self.get_manager()
+            stable_functions = manager.warmed_up_functions.copy()
+            self.assertEqual(len(stable_functions), 1)
+            del stable_out
+
+            calls = 0
+
+            def f(inps):
+                nonlocal calls
+                calls += 1
+                x = inps[0]
+                inps.clear()
+                if calls < 3 or calls == 4:
+                    mark_warmup_incomplete()
+                return (x + 1,)
+
+            foo_cg = self.cudagraphify_impl(f, [x], ())
+
+            for _ in range(2):
+                out = foo_cg([x])
+                self.assertEqual(manager.warmed_up_functions, stable_functions)
+                del out
+
+            out = foo_cg([x])
+            warmed_functions = manager.warmed_up_functions.copy()
+            self.assertEqual(len(warmed_functions), 2)
+            mark_warmup_incomplete()
+            self.assertEqual(manager.warmed_up_functions, warmed_functions)
+            del out
+
+            out = foo_cg([x])
+            self.assertEqual(manager.path_state, ExecutionState.RECORDING)
+            self.assertEqual(manager.warmed_up_functions, warmed_functions)
+            del out
+
+            out = foo_cg([x])
+            self.assertEqual(manager.path_state, ExecutionState.EXECUTION)
+            self.assertEqual(calls, 4)
+            mark_warmup_incomplete()
+            self.assertEqual(manager.warmed_up_functions, warmed_functions)
+            del out
 
         def test_forward_generation(self):
             def foo(x):

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -354,13 +354,9 @@ def mark_warmup_incomplete() -> None:
     This is a no-op unless called synchronously from a function currently running
     in CUDA Graph Trees warmup.
     """
-    if not torch._C._is_key_in_tls("tree_manager_containers"):
-        return
-
-    for container in get_obj(local, "tree_manager_containers").values():
-        manager = container.tree_manager
-        if manager is not None:
-            manager.mark_warmup_incomplete()
+    manager = get_manager(create_if_none_exists=False)
+    if manager is not None:
+        manager.mark_warmup_incomplete()
 
 
 def reset_cudagraph_trees() -> None:
@@ -408,11 +404,18 @@ def get_container(device_index: int) -> TreeManagerContainer:
 
 
 def get_manager(
-    device_index: int, create_if_none_exists: bool = True
+    device_index: int | None = None, create_if_none_exists: bool = True
 ) -> CUDAGraphTreeManager | None:
+    if device_index is None:
+        if not torch.cuda.is_initialized():
+            return None
+        device_index = torch.cuda.current_device()
+
     if create_if_none_exists:
         return get_container(device_index).get_tree_manager()
-    return get_container(device_index).tree_manager
+
+    container = get_obj(local, "tree_manager_containers").get(device_index)
+    return None if container is None else container.tree_manager
 
 
 def is_cudagraph_capture_sizes(int_key: int | tuple[int, ...]) -> bool:

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -348,6 +348,21 @@ def mark_step_begin() -> None:
     MarkStepBox.mark_step_counter -= 1
 
 
+def mark_warmup_incomplete() -> None:
+    """Request another warmup for the active CUDA Graph Trees function.
+
+    This is a no-op unless called synchronously from a function currently running
+    in CUDA Graph Trees warmup.
+    """
+    if not torch._C._is_key_in_tls("tree_manager_containers"):
+        return
+
+    for container in get_obj(local, "tree_manager_containers").values():
+        manager = container.tree_manager
+        if manager is not None:
+            manager.mark_warmup_incomplete()
+
+
 def reset_cudagraph_trees() -> None:
     "Clear all cudagraph trees"
     # see shutdown below for why this is necessary
@@ -2331,6 +2346,7 @@ class CUDAGraphTreeManager:
         # whether we the current node is in a state of warmup, recording, execution. If
         # there is no current node the state will be ExecutionState.None.
         self.path_state = ExecutionState.NONE
+        self.active_warmup_function: FunctionID | None = None
         self.device_index = device_index
 
         # the most recently invoked cudagraph wrapping of a function. Will be None
@@ -2702,7 +2718,14 @@ class CUDAGraphTreeManager:
         self.current_node = node
         self.path_state = ExecutionState.WARMUP
         self.update_generation()
-        return node.run(new_inputs)
+        self.active_warmup_function = function_id
+        result = node.run(new_inputs)
+        self.active_warmup_function = None
+        return result
+
+    def mark_warmup_incomplete(self) -> None:
+        if self.active_warmup_function is not None:
+            self.warmed_up_functions.discard(self.active_warmup_function)
 
     def new_graph_id(self) -> GraphID:
         return GraphID(next(self.graph_counter))

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -44,6 +44,7 @@ __all__ = [
     "set_stance",
     "set_enable_guard_collectives",
     "cudagraph_mark_step_begin",
+    "cudagraph_mark_warmup_incomplete",
     "load_compiled_function",
     "precompile",
     "PrecompileError",
@@ -526,6 +527,20 @@ def cudagraph_mark_step_begin():
     from torch._inductor import cudagraph_trees
 
     cudagraph_trees.mark_step_begin()
+
+
+def cudagraph_mark_warmup_incomplete():
+    """Request another warmup for the active CUDA Graph Trees function.
+
+    Call this synchronously from an autotuner or other code running during CUDA
+    Graph Trees warmup when the current function needs another warmup iteration.
+    The function will run eagerly again on its next invocation instead of being
+    recorded. This is a no-op outside CUDA Graph Trees warmup, including during
+    recording and replay or when CUDA Graph Trees are disabled.
+    """
+    from torch._inductor import cudagraph_trees
+
+    cudagraph_trees.mark_warmup_incomplete()
 
 
 def wrap_numpy(fn):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191386

Human context from the author: "we have an out of tree autotuner, that takes more than one iteration to warmup for cudagraphs."

> Codex-generated implementation summary:
>
> Add `torch.compiler.cudagraph_mark_warmup_incomplete()` so code running during CUDA Graph Trees warmup can request another eager warmup iteration. Calls outside active warmup are no-ops.
>
> Track the active function on the existing tree manager and remove only that function from `warmed_up_functions`.
>
> Test Plan:
>
> ```bash
> python test/inductor/test_cudagraph_trees.py CUDAGraphAPIOnlyTests.test_mark_warmup_incomplete_without_cudagraphs CudaGraphTreeTests.test_mark_warmup_incomplete CudaGraphTreeTests.test_dynamic_warmup CudaGraphTreeTests.test_multithreaded_cudagraph_trees
> lintrunner -a
> ```
>
> Authored with assistance from Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo