### PR TITLE
[docs] Link guard-overhead page to the devlog and add profiler-based measurement

### DIFF
--- a/docs/source/user_guide/torch_compiler/compile/programming_model.recompilation.md
+++ b/docs/source/user_guide/torch_compiler/compile/programming_model.recompilation.md
@@ -98,6 +98,45 @@ for i in range(5):
     gn(torch.ones(3, 3))
 ```
 
+## Unspecializing Integer Attributes on `nn.Module`s
+
+By default, Dynamo specializes on (guards the exact value of) integer attributes of an `nn.Module`.
+An integer that changes every call -- such as a step counter incremented inside `forward` --
+therefore triggers a recompilation on each call, quickly hitting the recompilation limit and falling back to eager.
+
+```{code-cell}
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.c = 0
+
+    def forward(self, x):
+        self.c += 1  # specialized on -> recompiles every call
+        return x * self.c
+
+mod = Mod()
+opt_mod = torch.compile(mod, backend="eager")
+for _ in range(5):
+    opt_mod(torch.randn(4))
+```
+
+If you do not need the integer specialized, set the flag below so Dynamo treats it as dynamic instead of recompiling.
+See {ref}`dynamic_shapes_advanced_control_options` for related static/dynamic control flags.
+
+```{code-cell}
+:tags: [remove-cell]
+torch._dynamo.reset()
+```
+
+```{code-cell}
+torch._dynamo.config.allow_unspec_int_on_nn_module = True
+mod = Mod()
+opt_mod = torch.compile(mod, backend="eager")
+for _ in range(5):
+    opt_mod(torch.randn(4))
+torch._dynamo.config.allow_unspec_int_on_nn_module = False
+```
+
 (programming_model.recompilation.changing_cache_size_limit)=
 ## Changing the Cache Size Limit
 

--- a/docs/source/user_guide/torch_compiler/compile/programming_model.reducing_guard_overhead.md
+++ b/docs/source/user_guide/torch_compiler/compile/programming_model.reducing_guard_overhead.md
@@ -26,8 +26,21 @@ stale compiled artifact and produce **incorrect results**. Only enable them once
 you understand the assumption each one makes.
 ```
 
-You can inspect which guards are being evaluated using tlparse or
-`TORCH_LOGS=guards`; see [tlparse / TORCH_TRACE](programming_model.observability).
+To see *which* guards are generated, use tlparse or `TORCH_LOGS=guards`; see
+[tlparse / TORCH_TRACE](programming_model.observability). To measure how much
+guard evaluation *costs*, profile the compiled function and look for the
+`TorchDynamo Cache Lookup` event, which times guard evaluation on each call:
+
+```python
+from torch.profiler import profile, ProfilerActivity
+
+with profile(activities=[ProfilerActivity.CPU]) as prof:
+    opt_mod(x)
+prof.export_chrome_trace("trace.json")  # inspect in chrome://tracing
+```
+
+Compare that time against the compiled function's total run time to decide
+whether the overhead is worth reducing.
 
 ## 1. Reduce pre-graph bytecode time with `install_free_tensors`
 
@@ -134,3 +147,10 @@ arrives), there is a risk of silently producing incorrect results, hence the
   the other keeps that saving from reappearing as pre-graph bytecode overhead.
 - For steady-state serving after warmup, consider
   `set_stance(skip_guard_eval_unsafe=True)`.
+
+## Further reading
+
+For a deeper mental model of guards — compile units (a graph plus its guard set),
+why the guard set is large, and worked profiler benchmarks for each of the
+techniques above — see the developer blog post
+[Inside torch.compile Guards](https://docs.pytorch.org/devlogs/dynamo/2025-06-04-inside-torch-compile-guards/).


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191387

Follow-up to the programming-model "Reducing Guard Overhead" page. Adds a
doc-friendly, profiler-based way to *measure* guard overhead (the
`TorchDynamo Cache Lookup` event) alongside the existing tlparse/TORCH_LOGS
pointer for inspecting which guards run, and a "Further reading" link to the
new developer blog post "Inside torch.compile Guards" for the deeper mental
model and worked benchmarks.

Authored with AI assistance.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98