### PR TITLE
[aotautograd] Cache graphs containing torch._refs.tensor nodes

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3339,6 +3339,37 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
         self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
         self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
 
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_refs_tensor_in_graph_cache_hit(self):
+        """
+        torch.tensor(data) with a data-dependent scalar traces a raw
+        torch._refs.tensor node, which must not bypass AOTAutogradCache. See
+        #191106.
+        """
+
+        def fn(x):
+            return torch.tensor([x.sum().item(), 2.0, 3.0])
+
+        x = torch.randn(8)
+        compiled_fn = torch.compile(fn, backend="inductor")
+
+        # First call misses and saves (no bypass).
+        compiled_fn(x)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_bypass"], 0)
+
+        # Second call hits after clearing in-memory state.
+        self._clear_dynamo_and_codecache()
+        compiled_fn(x)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+
     @unittest.skipIf(not HAS_GPU, "requires accelerator")
     @functorch_config.patch({"enable_autograd_cache": True})
     @inductor_config.patch("fx_graph_cache", True)
@@ -3788,6 +3819,20 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         config = self.default_config()
         # Should not raise BypassAOTAutogradCache
         self.gen_cache_key(fn, config, inputs=[torch.randn(4, 4)])
+
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_refs_tensor_in_graph_is_cacheable(self):
+        # torch.tensor(data) with a data-dependent scalar in `data` traces a raw
+        # torch._refs.tensor node instead of decomposing (see
+        # torch/_dynamo/variables/torch.py). Its behavior is fully determined by
+        # its args (the data list, whose scalars are graph nodes/constants), so
+        # it must be cacheable. See #191106.
+        def fn(x):
+            return torch.tensor([x.sum().item(), 2.0, 3.0])
+
+        config = self.default_config()
+        # Should not raise BypassAOTAutogradCache
+        self.gen_cache_key(fn, config, inputs=[torch.randn(4)])
 
     @torch._inductor.config.patch({"freezing": True})
     def test_freezing(self):

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -180,6 +180,11 @@ def check_node_safe(node: Node) -> None:
         "torch.amp.autocast_mode._exit_autocast",
         "torch.autograd.grad_mode._enter_inference_mode",
         "torch.autograd.grad_mode._exit_inference_mode",
+        # torch.tensor(data) with a data-dependent scalar in `data` traces a raw
+        # torch._refs.tensor node instead of decomposing. Its behavior is fully
+        # determined by its args (the data list), which are in the graph and
+        # hashed into the cache key. See #191106.
+        "torch._refs.tensor",
     )
     SAFE_NON_TORCH_FUNCTIONS = (
         "einops.einops.rearrange",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191409
* #191363

torch.tensor(data) is normally traced into (decomposed to
scalar_tensor/stack), but when `data` contains a data-dependent/unspec scalar
Dynamo instead emits a raw torch._refs.tensor call_function node
(torch/_dynamo/variables/torch.py). torch._refs.tensor was not on the
AOTAutogradCache cacheability allowlist in check_node_safe, so check_cacheable
raised BypassAOTAutogradCache and AOTAutograd caching was disabled for the
whole graph. Scuba shows this is one of the largest remaining allowlist-gap
cache bypasses in prod.

Like the autocast/inference_mode nodes, this is an allowlist gap rather than a
fundamental limitation: the node's behavior is fully determined by its args
(the data list, whose scalars are graph nodes or constants), which are present
in the graph and hashed into the cache key. Adding torch._refs.tensor to
SAFE_TORCH_FUNCTIONS makes these graphs cacheable.

Test Plan:

```
python -m pytest test/dynamo/test_aot_autograd_cache.py -k \
  "test_refs_tensor_in_graph_is_cacheable or test_refs_tensor_in_graph_cache_hit"
python -m pytest test/dynamo/test_aot_autograd_cache.py::AOTAutogradCachePicklerTests
```

Authored with Claude.