### PR TITLE
Fix SobolEngine.fast_forward(0) regression after Sobol input validation

### DIFF
--- a/torch/quasirandom.py
+++ b/torch/quasirandom.py
@@ -174,6 +174,8 @@ class SobolEngine:
         Args:
             n (Int): The number of steps to fast-forward by.
         """
+        if n == 0:
+            return self
         if self.num_generated == 0:
             torch._sobol_engine_ff_(
                 self.quasi, n - 1, self.sobolstate, self.dimension, self.num_generated


### PR DESCRIPTION
Summary:
D113877973 added `TORCH_CHECK_VALUE(n >= 0, ...)` to the native Sobol ops. On a fresh engine, `SobolEngine.fast_forward(n)` passes `n - 1` (the first Sobol point needs no update), so `fast_forward(0)` sends `-1` — previously a silent no-op, now rejected with `ValueError: n must be non-negative`. Ax's `SobolGenerator.init_engine` calls `fast_forward(0)`.

Fix: guard the no-op so `fast_forward(0)` returns early instead of passing a negative `n`; the C++ validation is left intact. Applied to both caffe2 mirrors.

Authored with an AI assistant.

Test Plan: `buck2 test fbcode//fblearner/flow/projects/optics_design/tests:sampling_tests` — failed with the ValueError before, passes now.

Differential Revision: D113987657


