### PR TITLE
Make uncaught doctest warnings a hard error, after quieting the noise

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2403,6 +2403,10 @@ def process_docstring(app, what_, name, obj, options, lines):
         # Remove all xdoctest directives
         re.compile(r"\s*>>>\s*#\s*x?doctest:\s*.*"),
         re.compile(r"\s*>>>\s*#\s*x?doc:\s*.*"),
+        # Remove lines marked `# docs: hide`. These run under the doctest
+        # runner but are hidden from rendered docs (e.g. a filterwarnings call
+        # that silences a warning an intentionally-deprecated example emits).
+        re.compile(r"\s*>>>.*#\s*docs:\s*hide\s*$"),
     ]
     filtered_lines = [
         line for line in lines if not any(pat.match(line) for pat in remove_directives)

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -28,6 +28,21 @@ _IS_WINDOWS = sys.platform == "win32"
 
 
 class TestUtils(TestCase):
+    def test_cleanup_hook_tolerates_missing_name(self):
+        # During interpreter shutdown the scope's module __dict__ may already be
+        # cleared before the weakref callback fires the hook. The hook must not
+        # raise KeyError (which would surface as an "Exception ignored in
+        # weakref callback").
+        scope = {}
+        hook = utils.CleanupHook.create(scope, "myglobal", object())
+        del scope["myglobal"]
+        hook()
+
+        # The normal path still removes the installed global.
+        hook2 = utils.CleanupHook.create(scope, "myglobal", object())
+        hook2()
+        self.assertNotIn("myglobal", scope)
+
     def test_nan(self):
         a = torch.Tensor([float("nan")])
         b = torch.Tensor([float("nan")])

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1240,6 +1240,10 @@ def run_doctests(test_module, test_directory, options):
                 "from torch import nn",
                 "import torch.nn.functional as F",
                 "import torch",
+                # So doctests can suppress a warning from an intentionally
+                # deprecated/prototype example via a `# docs: hide`-marked
+                # `warnings.filterwarnings(...)` line without a visible import.
+                "import warnings",
             ]
         ),
         "analysis": "static",  # set to "auto" to test doctests in compiled modules

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1259,8 +1259,18 @@ def run_doctests(test_module, test_directory, options):
         argv=[],
         exclude=exclude_module_list,
     )
-    result = 1 if run_summary.get("n_failed", 0) else 0
-    return result
+    n_failed = run_summary.get("n_failed", 0)
+    n_warned = run_summary.get("n_warned", 0)
+    if n_warned:
+        print_to_stderr(
+            f"ERROR: {n_warned} doctest(s) emitted run-time warnings. Doctests "
+            "must be warning-free: either fix the example to use the recommended "
+            "API, or if the warning is intrinsic to a deprecated/prototype API "
+            "being documented, suppress it with a `# docs: hide`-marked "
+            '`>>> warnings.filterwarnings("ignore", message=".*<substr>")` line '
+            "(executed by xdoctest, stripped from the rendered docs)."
+        )
+    return 1 if (n_failed or n_warned) else 0
 
 
 def sanitize_file_name(file: str):

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import time
 import unittest
+import warnings
 from collections import defaultdict, deque, namedtuple, OrderedDict, UserDict
 from dataclasses import dataclass, field
 from enum import auto
@@ -854,6 +855,21 @@ class TestGenericPytree(TestCase):
 
 
 class TestPythonPytree(TestCase):
+    def test_leafspec_copy_pickle_no_deprecation_warning(self):
+        # LeafSpec is @deprecated, so reconstructing it via copy/pickle used to
+        # re-invoke the constructor and leak a FutureWarning to users who never
+        # wrote an isinstance check. __reduce__ rebuilds via the factory, which
+        # both silences the warning and reuses the shared singleton.
+        leaf = python_pytree.treespec_leaf()
+        for reconstruct in (
+            lambda: copy.deepcopy(leaf),
+            lambda: pickle.loads(pickle.dumps(leaf)),
+        ):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", FutureWarning)
+                reconstructed = reconstruct()
+            self.assertIs(reconstructed, leaf)
+
     def test_deprecated_register_pytree_node(self):
         class DummyType:
             def __init__(self, x, y):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1642,6 +1642,7 @@ def is_storage(obj: object, /) -> _TypeGuard["TypedStorage | UntypedStorage"]:
         True
         >>>
         >>> # TypedStorage (legacy)
+        >>> warnings.filterwarnings("ignore", message=".*TypedStorage is deprecated")  # docs: hide
         >>> typed_storage = torch.TypedStorage(5, dtype=torch.float32)
         >>> torch.is_storage(typed_storage)
         True

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2479,7 +2479,10 @@ class CleanupHook:
         # Make sure we're not shutting down
         if CleanupManager is not None:
             CleanupManager.count -= 1
-        del self.scope[self.name]
+        # During interpreter shutdown the scope's module __dict__ may already
+        # have been cleared, so the name can be gone. Use pop to avoid a
+        # KeyError surfacing as an "Exception ignored in weakref callback".
+        self.scope.pop(self.name, None)
 
     @staticmethod
     def create(scope: dict[str, Any], name: str, val: Any) -> CleanupHook:

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -1133,6 +1133,9 @@ def jvp(
         >>> from torch.func import jvp
         >>> x = torch.randn([])
         >>> f = lambda x: x * torch.tensor([1.0, 2.0, 3])
+        >>> warnings.filterwarnings(
+        ...     "ignore", message=".*torch.jit.script"
+        ... )  # docs: hide
         >>> value, grad = jvp(f, (x,), (torch.tensor(1.0),))
         >>> assert torch.allclose(value, f(x))
         >>> assert torch.allclose(grad, torch.tensor([1.0, 2, 3]))
@@ -1847,6 +1850,7 @@ def linearize(
         >>> def fn(x):
         ...     return x.sin()
         ...
+        >>> warnings.filterwarnings("ignore", message=".*Attempted to insert a get_attr Node with no underlying reference")  # docs: hide
         >>> output, jvp_fn = linearize(fn, torch.zeros(3, 3))
         >>> jvp_fn(torch.ones(3, 3))
         tensor([[1., 1., 1.],

--- a/torch/ao/nn/quantized/functional.py
+++ b/torch/ao/nn/quantized/functional.py
@@ -209,6 +209,7 @@ def conv1d(
     Examples::
 
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_QENGINE)
+        >>> warnings.filterwarnings("ignore", message=".*quantized tensor creation functions")  # docs: hide
         >>> from torch.ao.nn.quantized import functional as qF
         >>> filters = torch.randn(33, 16, 3, dtype=torch.float)
         >>> inputs = torch.randn(20, 16, 50, dtype=torch.float)
@@ -281,6 +282,7 @@ def conv2d(
     Examples::
 
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_QENGINE)
+        >>> warnings.filterwarnings("ignore", message=".*quantized tensor creation functions")  # docs: hide
         >>> from torch.ao.nn.quantized import functional as qF
         >>> filters = torch.randn(8, 4, 3, 3, dtype=torch.float)
         >>> inputs = torch.randn(1, 4, 5, 5, dtype=torch.float)
@@ -357,6 +359,7 @@ def conv3d(
     Examples::
 
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_QENGINE)
+        >>> warnings.filterwarnings("ignore", message=".*quantized tensor creation functions")  # docs: hide
         >>> from torch.ao.nn.quantized import functional as qF
         >>> filters = torch.randn(8, 4, 3, 3, 3, dtype=torch.float)
         >>> inputs = torch.randn(1, 4, 5, 5, 5, dtype=torch.float)

--- a/torch/ao/nn/quantized/modules/embedding_ops.py
+++ b/torch/ao/nn/quantized/modules/embedding_ops.py
@@ -108,6 +108,7 @@ class Embedding(torch.nn.Module):
                          shape :math:`(\text{num\_embeddings}, \text{embedding\_dim})`.
 
     Examples::
+        >>> warnings.filterwarnings("ignore", message=".*quantized tensor creation functions")  # docs: hide
         >>> m = nn.quantized.Embedding(num_embeddings=10, embedding_dim=12)
         >>> indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8])
         >>> output = m(indices)

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -2180,6 +2180,7 @@ def _lu_impl(A, pivot=True, get_infos=False, out=None):
 
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_LAPACK)
         >>> # xdoctest: +IGNORE_WANT("non-deterministic")
+        >>> warnings.filterwarnings("ignore", message=".*torch.lu is deprecated")  # docs: hide
         >>> A = torch.randn(2, 3, 3)
         >>> A_LU, pivots = torch.lu(A)
         >>> A_LU

--- a/torch/library.py
+++ b/torch/library.py
@@ -405,6 +405,7 @@ class Library:
         Example::
 
             >>> my_lib = Library("aten", "IMPL")
+            >>> warnings.filterwarnings("ignore", message=".*other operators may also be overridden")  # docs: hide
             >>> my_lib._impl_with_aoti_compile("div.Tensor", "CPU")
         """
 

--- a/torch/nested/__init__.py
+++ b/torch/nested/__init__.py
@@ -61,17 +61,18 @@ def as_nested_tensor(
 
         >>> a = torch.arange(3, dtype=torch.float, requires_grad=True)
         >>> b = torch.arange(5, dtype=torch.float, requires_grad=True)
-        >>> nt = torch.nested.as_nested_tensor([a, b])
+        >>> nt = torch.nested.as_nested_tensor([a, b], layout=torch.jagged)
         >>> nt.is_leaf
         False
-        >>> fake_grad = torch.nested.nested_tensor([torch.ones_like(a), torch.zeros_like(b)])
+        >>> buffer = torch.cat([torch.ones_like(a), torch.zeros_like(b)])
+        >>> fake_grad = torch.nested.nested_tensor_from_jagged(buffer, nt.offsets())
         >>> nt.backward(fake_grad)
         >>> a.grad
         tensor([1., 1., 1.])
         >>> b.grad
         tensor([0., 0., 0., 0., 0.])
         >>> c = torch.randn(3, 5, requires_grad=True)
-        >>> nt2 = torch.nested.as_nested_tensor(c)
+        >>> nt2 = torch.nested.as_nested_tensor(c, layout=torch.jagged)
     """
     is_tensor_list = isinstance(ts, (list, tuple)) and all(
         isinstance(t, Tensor) for t in ts
@@ -244,7 +245,7 @@ def nested_tensor(
 
         >>> a = torch.arange(3, dtype=torch.float, requires_grad=True)
         >>> b = torch.arange(5, dtype=torch.float, requires_grad=True)
-        >>> nt = torch.nested.nested_tensor([a, b], requires_grad=True)
+        >>> nt = torch.nested.nested_tensor([a, b], layout=torch.jagged, requires_grad=True)
         >>> nt.is_leaf
         True
     """
@@ -411,8 +412,8 @@ def nested_tensor_from_jagged(
         >>> offsets = torch.tensor([0, 3, 5, 6, 10, 12])
         >>> nt = nested_tensor_from_jagged(values, offsets)
         >>> # 3D shape with the middle dimension jagged
-        >>> nt.shape
-        torch.Size([5, j2, 5])
+        >>> nt.shape  # xdoctest: +ELLIPSIS
+        torch.Size([5, j..., 5])
         >>> # Length of each item in the batch:
         >>> offsets.diff()
         tensor([3, 2, 1, 4, 2])
@@ -486,8 +487,8 @@ def masked_select(tensor: Tensor, mask: Tensor) -> Tensor:
         >>> tensor = torch.randn(3, 3)
         >>> mask = torch.tensor([[False, False, True], [True, False, True], [False, False, True]])
         >>> nt = torch.nested.masked_select(tensor, mask)
-        >>> nt.shape
-        torch.Size([3, j4])
+        >>> nt.shape  # xdoctest: +ELLIPSIS
+        torch.Size([3, j...])
         >>> # Length of each item in the batch:
         >>> nt.offsets().diff()
         tensor([1, 2, 1])
@@ -495,8 +496,8 @@ def masked_select(tensor: Tensor, mask: Tensor) -> Tensor:
         >>> tensor = torch.randn(6, 5)
         >>> mask = torch.tensor([False])
         >>> nt = torch.nested.masked_select(tensor, mask)
-        >>> nt.shape
-        torch.Size([6, j5])
+        >>> nt.shape  # xdoctest: +ELLIPSIS
+        torch.Size([6, j...])
         >>> # Length of each item in the batch:
         >>> nt.offsets().diff()
         tensor([0, 0, 0, 0, 0, 0])

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -88,9 +88,11 @@ class Transformer(Module):
             bias. Default: ``True``.
 
     Examples:
-        >>> transformer_model = nn.Transformer(nhead=16, num_encoder_layers=12)
-        >>> src = torch.rand((10, 32, 512))
-        >>> tgt = torch.rand((20, 32, 512))
+        >>> transformer_model = nn.Transformer(
+        ...     nhead=16, num_encoder_layers=12, batch_first=True
+        ... )
+        >>> src = torch.rand((32, 10, 512))
+        >>> tgt = torch.rand((32, 20, 512))
         >>> out = transformer_model(src, tgt)
 
     Note: A full example to apply nn.Transformer module for the word language model is available in
@@ -340,9 +342,11 @@ class TransformerEncoder(Module):
             TransformerEncoder when padding rate is high. Default: ``True`` (enabled).
 
     Examples:
-        >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        >>> encoder_layer = nn.TransformerEncoderLayer(
+        ...     d_model=512, nhead=8, batch_first=True
+        ... )
         >>> transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=6)
-        >>> src = torch.rand(10, 32, 512)
+        >>> src = torch.rand(32, 10, 512)
         >>> out = transformer_encoder(src)
     """
 

--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -132,6 +132,7 @@ def weight_norm(module: T_module, name: str = "weight", dim: int = 0) -> T_modul
 
     Example::
 
+        >>> warnings.filterwarnings("ignore", message=".*torch.nn.utils.weight_norm")  # docs: hide
         >>> m = weight_norm(nn.Linear(20, 40), name='weight')
         >>> m
         Linear(in_features=20, out_features=40, bias=True)
@@ -153,6 +154,9 @@ def remove_weight_norm(module: T_module, name: str = "weight") -> T_module:
         name (str, optional): name of weight parameter
 
     Example:
+        >>> warnings.filterwarnings(
+        ...     "ignore", message=".*torch.nn.utils.weight_norm"
+        ... )  # docs: hide
         >>> m = weight_norm(nn.Linear(20, 40))
         >>> remove_weight_norm(m)
     """

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -244,7 +244,8 @@ def sum(input: Tensor, dim: DimOrDims = None, dtype: DType | None = None) -> Ten
         >>> V = torch.randn(nnz, dims[2], dims[3])
         >>> size = torch.Size(dims)
         >>> # xdoctest: +IGNORE_WANT("non-deterministic")
-        >>> S = torch.sparse_coo_tensor(I, V, size)
+        >>> with torch.sparse.check_sparse_tensor_invariants():
+        ...     S = torch.sparse_coo_tensor(I, V, size)
         >>> S
         tensor(indices=tensor([[2, 0, 3],
                                [2, 4, 1]]),
@@ -575,6 +576,9 @@ def as_sparse_gradcheck(gradcheck):
 
     For example:
 
+    >>> warnings.filterwarnings(
+    ...     "ignore", message=".*Sparse CSR tensor support is in beta state"
+    ... )  # docs: hide
     >>> gradcheck = torch.sparse.as_sparse_gradcheck(torch.autograd.gradcheck)
     >>> x = (
     ...     torch.tensor([[0, 1], [2, 3]], dtype=torch.float64)

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -1387,6 +1387,12 @@ class LeafSpec(TreeSpec):
     def __repr__(self, indent: int = 0) -> str:
         return "*"
 
+    def __reduce__(self) -> tuple[Callable[[], "LeafSpec"], tuple[()]]:
+        # Reconstruct via the factory rather than the deprecated LeafSpec
+        # constructor, so copy/pickle round-trips don't emit the FutureWarning
+        # and reuse the shared singleton.
+        return (treespec_leaf, ())
+
 
 # All leaves are equivalent, so represent with a single object to save on
 # object construction time


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191416

Human: I got annoyed that Dr. CI kept misclassifying doctest problems. Part of it is a huge amount of suppressed error and warning spam. This makes doctests warning clean and then makes warnings in doctest a hard error.

AI summary:

The doctest CI job's log is cluttered with warning/exception noise that
obscures real failures, and nothing prevents new noise from creeping in.
This first quiets every warning the job emits, then flips uncaught doctest
warnings from silently-reported to a hard failure so the log stays clean.

Review in three parts.

Part 1 -- self-inflicted warnings (PyTorch's own code trips its own warning,
unrelated to what the example demonstrates):

- CleanupHook.__call__ did `del self.scope[self.name]`. During interpreter
  shutdown the module __dict__ holding the installed global is often already
  torn down, so the del raises KeyError inside a GC weakref callback where it
  cannot propagate; CPython then prints it via the unraisable hook as
  "Exception ignored in weakref callback". The method already guards for
  shutdown (`if CleanupManager is not None`) but not the delete, so switch to
  `scope.pop(name, None)`.

- LeafSpec is deprecated(FutureWarning), so copy.deepcopy/pickle round-trips
  re-invoke its constructor and leak the "isinstance(treespec, LeafSpec) is
  deprecated" FutureWarning to code that never wrote an isinstance check (it
  fired from copyreg during a doctest). Add __reduce__ returning
  (treespec_leaf, ()) so round-trips rebuild via the factory and reuse the
  shared singleton, emitting no warning.

Part 2 -- by-design warnings, where the example itself exercises a
deprecated/prototype/beta API. The rule applied per docstring: if the example
documents a deprecated API, silence just its own warning inline; if it
documents a legit feature that happens to reach for a discouraged path, fix
the example instead. Inline suppression uses a
`>>> warnings.filterwarnings(...)  # docs: hide` line: xdoctest executes it (so
the warning leaves its run-time warning report) but the existing
process_docstring hook in conf.py strips `# docs: hide` lines from Sphinx
output, exactly as it already strips `# xdoctest:` directives. Suppression is
scoped per-doctest by xdoctest's own catch_warnings, so it does not leak.
`import warnings` is added to the doctest prologue so hidden lines need no
visible import.

  Suppressed (deprecated/prototype/beta API is the point of the example):
  library.Library._impl_with_aoti_compile, quantized Embedding and
  functional.conv{1,2,3}d (eager-quant quint8 creation), nn.utils.weight_norm /
  remove_weight_norm (the documented fn is itself deprecated),
  functorch jvp / linearize (benign internal leaks), sparse.as_sparse_gradcheck
  (CSR beta), functional._lu_impl (torch.lu deprecation).

  Fixed to use the recommended path: nested.as_nested_tensor and nested_tensor
  (rewritten to layout=torch.jagged), sparse.sum (wrapped in
  check_sparse_tensor_invariants, the opt-in the warning points to),
  nn.Transformer / TransformerEncoder (batch_first=True to silence the
  enable_nested_tensor notice). The jagged rewrite bumps the process-global
  ragged-dim counter, so three sibling `jN` wants in torch/nested were made
  robust with `# xdoctest: +ELLIPSIS` and `j...`.

Part 3 -- the gate. run_test.py::run_doctests only failed on n_failed; a
doctest that passed but emitted a run-time warning returned success. It now
also fails when run_summary reports n_warned > 0, printing a message that
points the next contributor at both remedies (fix the example, or add a
`# docs: hide` suppression). With Parts 1-2 landed the CI-executed doctest set
reports n_warned == 0, so the gate passes today and only trips on regressions.

Test Plan:

```
python test/test_pytree.py TestPythonPytree.test_leafspec_copy_pickle_no_deprecation_warning
python test/dynamo/test_utils.py TestUtils.test_cleanup_hook_tolerates_missing_name
python test/test_pytree.py
python test/dynamo/test_utils.py
```

The two source-fix tests fail without their fix (KeyError from the hook;
FutureWarning from the LeafSpec round-trip) and pass with it.

For the doctest sweep and the gate, xdoctest.runner.doctest_module was invoked
directly with run_doctests's exact config (global_exec of nn/F/torch/warnings,
analysis="static", +IGNORE_WHITESPACE, and cuda/lapack/qengine gated off just
as the CI job hardcodes them). The full run reports 387 passed, 0 failed,
n_warned == 0, and emits no run-time warning report. A temporary module whose
doctest raises FutureWarning was used to confirm the gate: it yields
n_warned == 1 and the new code returns failure where it previously returned
success; adding the `# docs: hide` filterwarnings line returns it to clean.

Note the CI doctest job hardcodes the cuda/lapack/qengine feature gates off, so
the quantized-functional and _lu_impl suppressions above do not execute there;
they are included so the examples stay warning-free if those gates are ever
enabled.

Authored with the assistance of an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98