### PR TITLE
[Testcase Refactoring] Decouple test_fsdp_checkpoint from hard-coded devices and label ACCELERATOR classes

### DIFF
--- a/test/distributed/fsdp/test_fsdp_checkpoint.py
+++ b/test/distributed/fsdp/test_fsdp_checkpoint.py
@@ -344,9 +344,8 @@ class TestFSDPCheckpointSubmodule(FSDPTestContinuous):
             self.assertTrue(p1.grad.allclose(p2.grad))
 
 
-devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(
-    TestFSDPCheckpointSubmodule, globals(), only_for=devices, allow_xpu=True
+    TestFSDPCheckpointSubmodule, globals(), except_for=("cpu",), allow_xpu=True
 )
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_checkpoint.py
+++ b/test/distributed/fsdp/test_fsdp_checkpoint.py
@@ -22,18 +22,15 @@ from torch.testing._internal.common_fsdp import (
     _maybe_wrap_fsdp,
     FSDPTest,
     FSDPTestContinuous,
-    get_devtype,
 )
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
 )
 from torch.utils.checkpoint import checkpoint
 
-
-device_type = torch.device(get_devtype())
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -77,20 +74,23 @@ def patch_save_on_cpu(new_save_on_cpu):
 
 
 class TestFSDPCheckpoint(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     class SequentialModule(nn.Module):
         def __init__(
             self,
             checkpoint_layer=False,
             offload_activations=False,
             wrap_fsdp=False,
+            device=None,
             *fsdp_args,
             **fsdp_kwargs,
         ):
             torch.manual_seed(0)
             super().__init__()
-            l1 = nn.Linear(3, 3).to(device_type.type)
-            l2 = nn.Linear(3, 3).to(device_type.type)
-            l3 = nn.Linear(3, 3).to(device_type.type)
+            l1 = nn.Linear(3, 3).to(torch.device(device).type)
+            l2 = nn.Linear(3, 3).to(torch.device(device).type)
+            l3 = nn.Linear(3, 3).to(torch.device(device).type)
             if checkpoint_layer:
                 if offload_activations:
                     ckpt_wrapper = offload_wrapper
@@ -140,6 +140,7 @@ class TestFSDPCheckpoint(FSDPTest):
     @parametrize("use_orig_params", [False, True])
     def test_checkpoint_fsdp_wrapping(
         self,
+        device,
         cpu_offload: CPUOffload,
         offload_activations: bool,
         use_orig_params: bool,
@@ -151,25 +152,28 @@ class TestFSDPCheckpoint(FSDPTest):
             wrapper_to_use = checkpoint_wrapper
         fsdp_kwargs = {"cpu_offload": cpu_offload, "use_orig_params": use_orig_params}
         ckpt_sequential_wrapped_fsdp = wrapper_to_use(
-            TestFSDPCheckpoint.SequentialModule(
+            self.SequentialModule(
                 wrap_fsdp=True,
+                device=torch.device(device).type,
                 **fsdp_kwargs,
             ),
         )
         # Test FSDP(checkpoint(layer1)), FSDP(checkpoint(layer2)), ....
-        inner_ckpt = TestFSDPCheckpoint.SequentialModule(
+        inner_ckpt = self.SequentialModule(
             checkpoint_layer=True,
             offload_activations=offload_activations,
             wrap_fsdp=True,
+            device=torch.device(device).type,
             **fsdp_kwargs,
         )
-        baseline = TestFSDPCheckpoint.SequentialModule(
+        baseline = self.SequentialModule(
             wrap_fsdp=True,
+            device=torch.device(device).type,
             **fsdp_kwargs,
         )
         # note that reentrant-based checkpointing requires inputs to have grad
         # flag set.
-        inp = torch.randn(10, 3, device=device_type.type, requires_grad=True)
+        inp = torch.randn(10, 3, device=torch.device(device).type, requires_grad=True)
         global _save_on_cpu_called
         models = [ckpt_sequential_wrapped_fsdp, inner_ckpt, baseline]
         with patch_save_on_cpu(get_patched_save_on_cpu()):
@@ -200,6 +204,7 @@ class TestFSDPCheckpoint(FSDPTest):
     @parametrize("use_orig_params", [False, True])
     def test_basic_checkpoint_end_to_end(
         self,
+        device,
         cpu_offload: CPUOffload,
         offload_activations: bool,
         use_orig_params: bool,
@@ -207,7 +212,7 @@ class TestFSDPCheckpoint(FSDPTest):
         fsdp_kwargs = {"cpu_offload": cpu_offload, "use_orig_params": use_orig_params}
         global _save_on_cpu_called
         with patch_save_on_cpu(get_patched_save_on_cpu()):
-            seq = TestFSDPCheckpoint.SequentialModule().to(device_type.type)
+            seq = self.SequentialModule(device=torch.device(device).type)
             # Runs FSDP with no checkpointing
             fsdp_only_seq = FSDP(deepcopy(seq), **fsdp_kwargs)
             # Runs checkpoint-wrapped FSDP
@@ -227,7 +232,9 @@ class TestFSDPCheckpoint(FSDPTest):
             fsdp_call_checkpoint = FSDP(deepcopy(seq), **fsdp_kwargs)
             # note that reentrant-based checkpointing requires inputs to have grad
             # flag set.
-            inp = torch.randn(10, 3, device=device_type.type, requires_grad=True)
+            inp = torch.randn(
+                10, 3, device=torch.device(device).type, requires_grad=True
+            )
             models = [
                 fsdp_only_seq,
                 checkpointed_fsdp,
@@ -268,7 +275,9 @@ class TestFSDPCheckpoint(FSDPTest):
         dist.barrier()
 
 
-instantiate_parametrized_tests(TestFSDPCheckpoint)
+instantiate_device_type_tests(
+    TestFSDPCheckpoint, globals(), except_for=("cpu",), allow_xpu=True
+)
 
 
 class CheckpointModule(nn.Module):
@@ -313,11 +322,13 @@ class TestModel(nn.Module):
 
 
 class TestFSDPCheckpointSubmodule(FSDPTestContinuous):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     # TODO: grad value checks occasionally fails when use_reentrant = True
     @skip_if_lt_x_gpu(2)
     @parametrize("use_reentrant", [False])
     def test_checkpoint_submodule(self, device, use_reentrant: bool):
-        model = TestModel(use_reentrant=use_reentrant).to(device_type.type)
+        model = TestModel(use_reentrant=use_reentrant).to(torch.device(device).type)
         model_ac = deepcopy(model)
         for _, m in model_ac.named_modules():
             if isinstance(m, CheckpointModule):
@@ -325,7 +336,7 @@ class TestFSDPCheckpointSubmodule(FSDPTestContinuous):
         self.assertTrue(model_ac.checkpoint1.s1.checkpoint)
         self.assertTrue(model_ac.checkpoint2.s2.checkpoint)
         fsdp_kwargs = {
-            "device_id": device_type.type,
+            "device_id": torch.device(device).type,
             "sharding_strategy": ShardingStrategy.NO_SHARD,
         }
         # Wrap no checkpointing model submodules with FSDP
@@ -334,7 +345,7 @@ class TestFSDPCheckpointSubmodule(FSDPTestContinuous):
         # Wrap checkpointing model submodules with FSDP
         model_ac.checkpoint1 = FSDP(module=model_ac.checkpoint1, **fsdp_kwargs)
         model_ac.checkpoint2 = FSDP(module=model_ac.checkpoint2, **fsdp_kwargs)
-        x = torch.randn(2, 100, device=self.device_type)
+        x = torch.randn(2, 100, device=torch.device(device).type)
         model(x).sum().backward()
         model_ac(x).sum().backward()
         for (n1, p1), (n2, p2) in zip(


### PR DESCRIPTION
## Summary

This PR labels `TestFSDPCheckpoint` and `TestFSDPCheckpointSubmodule` as `HardwareClassification.ACCELERATOR`, switches both to `instantiate_device_type_tests(except_for=("cpu",))`, and completes the device-parameter migration in the test bodies — including using `torch.device(device).type` (type-only) for FSDP `device_id` and all model/tensor creation so each rank resolves to its own device instead of degenerating to device 0.

## Changes

- **`test/distributed/fsdp/test_fsdp_checkpoint.py`**:
  - Added `hw_classification = HardwareClassification.ACCELERATOR` to both `TestFSDPCheckpoint` and `TestFSDPCheckpointSubmodule`, plus the `HardwareClassification` import. Both classes' `test_*` methods require an accelerator (`@skip_if_lt_x_gpu(2)`, `device` param) and exercise FSDP checkpoint behavior on the device-tensor path.
  - Switched `TestFSDPCheckpoint` from `@instantiate_parametrized_tests` to `instantiate_device_type_tests(except_for=("cpu",), allow_xpu=True)`, and changed `TestFSDPCheckpointSubmodule`'s `only_for=("cuda","hpu","xpu")` to `except_for=("cpu",)` (dropping the hard-coded `devices` variable). This aligns with the TEST_LINTER direction (PR #190173): ACCELERATOR classes must NOT use `only_for`.
  - Migrated every test method to the injected `device` parameter: added `device` to both class-1 methods and to `SequentialModule.__init__`, deleted the module-level `device_type = torch.device(get_devtype())` and the `get_devtype` import, and replaced all `device_type.type` / `self.device_type` references in the bodies with `device`.
  - Replaced 4 `TestFSDPCheckpoint.SequentialModule(...)` references with `self.SequentialModule(...)`. `instantiate_device_type_tests` removes the original class name from scope (replaces it with per-device variants), so a test body referencing the original class name raises `NameError` at runtime; the variants inherit from the original class, so `self.SequentialModule` resolves correctly. This was latent until the c10d backend-type lookup for PrivateUse1 was fixed (#187650 / Ascend/pytorch#3947), because workers previously exited at `dist.barrier(device_ids=)` before reaching this code.
  - Used `torch.device(device).type` (type-only) for FSDP `device_id`, `nn.Linear().to(...)`, `torch.randn(device=...)`, and `SequentialModule(device=...)`. The injected `device` parameter is indexed (e.g. `"npu:0"`); passing it bare to FSDP `device_id` forces all ranks to device 0 (single-card degeneration — no error but loses multi-card verification). `torch.device(device).type` strips the index, so FSDP's `_get_device_from_device_id` resolves each rank to its own current device (true multi-card distribution).

## Motivation

`TestFSDPCheckpoint` / `TestFSDPCheckpointSubmodule` had no `hw_classification` (silently dropped under `--hw-classification ACCELERATOR` filtering) and used `only_for=("cuda","hpu","xpu")`, excluding PrivateUse1-based out-of-tree accelerators. The test bodies read a module-level `device_type` constant — a single value that does not change across per-device variants — which under `instantiate_device_type_tests` would use the wrong device on non-default variants. Additionally, passing the indexed `device` directly to FSDP `device_id` silently degenerated multi-rank tests to single-card, masking real multi-card behavior.

## Test Plan

- Verified the FSDP test infra routes to the accelerator backend (not a gloo/CPU false pass):

```
python -c "from torch.testing._internal.common_fsdp import DEVICE_TYPE, DISTRIBUTED_BACKEND, DEVICE_COUNT; print(DEVICE_TYPE, DISTRIBUTED_BACKEND, DEVICE_COUNT)"
# <device> <backend> <count>  (e.g. an accelerator backend, not cpu gloo 1)
```

- End-to-end on an 8-card accelerator backend (with the `common_fsdp.py` accelerator branch from #187650 applied):

```
python test/distributed/fsdp/test_fsdp_checkpoint.py --hw-classification ACCELERATOR
# 17/17 pass; FSDP warnings confirm per-rank device resolution
# (rank 0 -> device 0, rank 3 -> device 3, ...) — true multi-card, not single-card degeneration
```

- `lintrunner` clean; `review-test-refactoring` skill review: no findings.

## Notes

- Both classes retain `@skip_if_lt_x_gpu(2)` unchanged. Making `skip_if_lt_x_gpu` recognize out-of-tree accelerators is a separate framework-level change to `common_distributed.py`, tracked in pytorch/pytorch#187650; this PR does not modify that helper.
- This is part of the test case refactoring initiative tracked in #185590.
