### PR TITLE
[Testcase Refactoring] Label test_fsdp_clip_grad_norm and decouple from hard-coded device list

### DIFF
--- a/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
+++ b/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
@@ -20,14 +20,15 @@ from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
     FSDPInitMode,
     FSDPTestContinuous,
-    get_devtype,
     NestedWrappedModule,
     TransformerWithSharedParams,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 
-
-device_type = torch.device(get_devtype())
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -42,6 +43,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 class TestClipGradNorm(FSDPTestContinuous):
     """Tests :meth:`FullyShardedDataParallel.clip_grad_norm_`."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @skip_if_lt_x_gpu(2)
     def test_non_root(self, device):
@@ -59,11 +62,11 @@ class TestClipGradNorm(FSDPTestContinuous):
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 return self.lin2(self.lin1(x))
 
-        model = Model().to(device_type.type)
+        model = Model().to(self.device_type)
         model.lin2 = FSDP(model.lin2)
         fsdp_model = FSDP(model)
-        # fsdp_model(torch.randn((2, 5), device=torch.device(self.device_type))).sum().backward()
-        fsdp_model(torch.randn((2, 5), device=device_type)).sum().backward()
+        inp = torch.randn((2, 5), device=self.device_type)
+        fsdp_model(inp).sum().backward()
         error_regex = "should only be called on the root FSDP instance"
         with self.assertRaisesRegex(RuntimeError, error_regex):
             fsdp_model.lin2.clip_grad_norm_(max_norm=2)
@@ -105,11 +108,11 @@ class TestClipGradNorm(FSDPTestContinuous):
             DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
-        ddp_model = DDP(local_model, device_ids=[device_type])
+        ddp_model = DDP(local_model, device_ids=[self.device_type])
         fsdp_kwargs = {
             "cpu_offload": CPUOffload(offload_params=offload_params),
             "use_orig_params": use_orig_params,
-            "device_id": device_type.type,
+            "device_id": self.device_type,
         }
         if sharding_strategy == "mixed_strategy":
             fsdp_model = TransformerWithSharedParams.init(
@@ -157,9 +160,8 @@ class TestClipGradNorm(FSDPTestContinuous):
         LR = 1e-2
         ddp_optim = torch.optim.Adam(ddp_model.parameters(), lr=LR)
         fsdp_optim = torch.optim.Adam(fsdp_model.parameters(), lr=LR)
-        device = torch.device(self.device_type)
         LARGE_FACTOR = 100
-        inp = ddp_model.module.get_input(device)
+        inp = ddp_model.module.get_input(self.device_type)
         for model in (ddp_model, fsdp_model):
             out = model(*inp)
             if isinstance(model, (DDP, FSDP)):
@@ -226,7 +228,7 @@ class TestClipGradNorm(FSDPTestContinuous):
             set_to_none = i % 2 == 0  # exercise both
             ddp_optim.zero_grad(set_to_none=set_to_none)
             fsdp_optim.zero_grad(set_to_none=set_to_none)
-            inp = ddp_model.module.get_input(device)
+            inp = ddp_model.module.get_input(self.device_type)
             for model in (ddp_model, fsdp_model):
                 out = model(*inp)
                 out.sum().backward()
@@ -275,7 +277,7 @@ class TestClipGradNorm(FSDPTestContinuous):
                 reduce_dtype=torch.float16,
                 keep_low_precision_grads=True,
             ),
-            "device_id": device_type.type,
+            "device_id": self.device_type,
         }
         fsdp_model = FSDP(
             NestedWrappedModule.init(
@@ -287,7 +289,7 @@ class TestClipGradNorm(FSDPTestContinuous):
             ),
             **fsdp_kwargs,
         )
-        inp = fsdp_model.module.get_input(torch.device(self.device_type))
+        inp = fsdp_model.module.get_input(self.device_type)
         out = fsdp_model(*inp)
         out.sum().backward()
         for param in fsdp_model.parameters():
@@ -327,7 +329,7 @@ class TestClipGradNorm(FSDPTestContinuous):
             lin_module,
             sharding_strategy=ShardingStrategy.SHARD_GRAD_OP,
             mixed_precision=mixed_precision_config,
-            device_id=device_type.type,
+            device_id=self.device_type,
             use_orig_params=use_orig_params,
         )
         inp = torch.randn(32, 24, device=self.device_type)
@@ -345,7 +347,7 @@ class TestClipGradNorm(FSDPTestContinuous):
     @skip_if_lt_x_gpu(2)
     def test_non_uniform_grad_dtype(self, device):
         """Tests clip_grad_norm_ with non-uniform gradient dtypes via MixedPrecision."""
-        device_type = torch.device(device).type
+        device_type = self.device_type
         model = nn.Sequential(nn.Linear(5, 5), nn.Linear(5, 5))
         # bf16 and fp32 params with low-precision grads kept
         model[0] = FSDP(
@@ -380,9 +382,8 @@ class TestClipGradNorm(FSDPTestContinuous):
         self.assertEqual(total_norm.dtype, torch.float32)
 
 
-devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(
-    TestClipGradNorm, globals(), only_for=devices, allow_xpu=True
+    TestClipGradNorm, globals(), except_for=("cpu",), allow_xpu=True
 )
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
+++ b/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
@@ -24,7 +24,11 @@ from torch.testing._internal.common_fsdp import (
     NestedWrappedModule,
     TransformerWithSharedParams,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 
 
 device_type = torch.device(get_devtype())
@@ -41,6 +45,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestClipGradNorm(FSDPTestContinuous):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     """Tests :meth:`FullyShardedDataParallel.clip_grad_norm_`."""
 
     @skip_if_lt_x_gpu(2)
@@ -380,9 +386,8 @@ class TestClipGradNorm(FSDPTestContinuous):
         self.assertEqual(total_norm.dtype, torch.float32)
 
 
-devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(
-    TestClipGradNorm, globals(), only_for=devices, allow_xpu=True
+    TestClipGradNorm, globals(), except_for=("cpu",), allow_xpu=True
 )
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

This PR labels `TestClipGradNorm` as `HardwareClassification.ACCELERATOR`, switches its `instantiate_device_type_tests` from a hard-coded `only_for=("cuda","hpu","xpu")` whitelist to `except_for=("cpu",)`, and completes the device-parameter migration in the test bodies — using `self.device_type` (the per-variant class attribute) for FSDP `device_id`, DDP `device_ids`, and all model/tensor creation including `get_input(...)` so each rank resolves to its own device (review feedback).

## Changes

- **`test/distributed/fsdp/test_fsdp_clip_grad_norm.py`**:
  - Added `hw_classification = HardwareClassification.ACCELERATOR` to `TestClipGradNorm`, plus the `HardwareClassification` import. All five `test_*` methods require an accelerator (`@skip_if_lt_x_gpu(2)`, `device` param) and exercise FSDP `clip_grad_norm_()` on the device-tensor path, so `ACCELERATOR` is the correct classification.
  - Replaced `devices = ("cuda", "hpu", "xpu")` + `only_for=devices` with `except_for=("cpu",)` in `instantiate_device_type_tests`, so any accelerator registered via `torch.accelerator` (including PrivateUse1-based out-of-tree backends) is admitted instead of a hard-coded whitelist. This aligns with the TEST_LINTER direction (PR #190173): `ACCELERATOR` classes must NOT use `only_for` (use `except_for` blacklist).
  - Completed the device-parameter migration in the test bodies: deleted the module-level `device_type = torch.device(get_devtype())` and the `get_devtype` import, and replaced every in-body reference (`device_type.type`, `self.device_type`, `device_ids=[device_type]`, `get_input(device)`) with `self.device_type` — the per-variant class attribute whose value equals the injected device's type-only string, matching the convention of the sibling FSDP test files (review feedback). FSDP `device_id`, DDP `device_ids`, `nn.Linear`, `torch.randn`, `.to()`, and `get_input()` all use it; this fixes the latent mismatch where the module-level constant was a single value that did not change per device variant.

## Motivation

`TestClipGradNorm` had no `hw_classification`, so it was silently dropped under `--hw-classification ACCELERATOR` filtering. Its `instantiate_device_type_tests` used `only_for=("cuda","hpu","xpu")`, excluding PrivateUse1-based out-of-tree accelerators even when available. Additionally, the test bodies read a module-level `device_type` constant — a single value that does not change across per-device variants — which under `instantiate_device_type_tests` would use the wrong device on non-default variants. Completing the migration to `self.device_type` (the per-variant class attribute, preserving per-rank device resolution) fixes this mismatch and aligns the file with the other FSDP test refactors.

## Test Plan

- Verified the FSDP test infra routes to the accelerator backend (not a gloo/CPU false pass):

```
python -c "from torch.testing._internal.common_fsdp import DEVICE_TYPE, DISTRIBUTED_BACKEND, DEVICE_COUNT; print(DEVICE_TYPE, DISTRIBUTED_BACKEND, DEVICE_COUNT)"
# <device> <backend> <count>  (e.g. an accelerator backend, not cpu gloo 1)
```

- End-to-end on an 8-card accelerator backend (with the `common_fsdp.py` accelerator branch from #187650 applied):

```
python test/distributed/fsdp/test_fsdp_clip_grad_norm.py --hw-classification ACCELERATOR
# 5/5 pass; FSDP warnings confirm per-rank device resolution
# (rank 0 -> device 0, rank 3 -> device 3, ...) — true multi-card
```

- `lintrunner` clean; `review-test-refactoring` skill review: no findings.

## Notes

- `TestClipGradNorm` retains `@skip_if_lt_x_gpu(2)` on all five methods unchanged. Making `skip_if_lt_x_gpu` recognize out-of-tree accelerators is a separate framework-level change to `common_distributed.py`, tracked in pytorch/pytorch#187650; this PR does not modify that helper.
- This is part of the test case refactoring initiative tracked in #185590.
