### PR TITLE
Fix AOT guard serialization for torch.func transforms

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -819,15 +819,15 @@ class TestAOTCompile(torch._inductor.test_case.TestCase):
         ).aot_compile(  # noqa: UNSPECIFIED_BACKEND
             ((x,), {})
         )
-        expected = batched_grad((x,))
-        actual = compiled_fn((x,))
+        expected = batched_grad(x)
+        actual = compiled_fn(x)
         self.assertEqual(expected, actual)
         compiled_fn.save_compiled_function(self.path())
         torch._dynamo.reset()
         with torch.compiler.set_stance("fail_on_recompile"):
             with open(self.path(), "rb") as f:
                 loaded_fn = torch.compiler.load_compiled_function(f)
-            actual = loaded_fn((x,))
+            actual = loaded_fn(x)
             self.assertEqual(expected, actual)
 
     def test_aot_compile_source_info(self):

--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -806,6 +806,30 @@ class TestAOTCompile(torch._inductor.test_case.TestCase):
     def test_aot_compile_grad_mode_after_prior_compile(self):
         _run_in_subprocess(_subprocess_grad_mode_after_prior_compile)
 
+    def test_aot_compile_torch_func_vmap_grad(self):
+        import torch.func as tf
+
+        def value(pos):
+            return torch.linalg.norm(pos[1] - pos[0])
+
+        batched_grad = tf.vmap(tf.grad(value, argnums=0), in_dims=(0,))
+        x = torch.randn(64, 2, 3, dtype=torch.float64)
+        compiled_fn = torch.compile(
+            batched_grad, fullgraph=True, dynamic=False
+        ).aot_compile(  # noqa: UNSPECIFIED_BACKEND
+            ((x,), {})
+        )
+        expected = batched_grad((x,))
+        actual = compiled_fn((x,))
+        self.assertEqual(expected, actual)
+        compiled_fn.save_compiled_function(self.path())
+        torch._dynamo.reset()
+        with torch.compiler.set_stance("fail_on_recompile"):
+            with open(self.path(), "rb") as f:
+                loaded_fn = torch.compiler.load_compiled_function(f)
+            actual = loaded_fn((x,))
+            self.assertEqual(expected, actual)
+
     def test_aot_compile_source_info(self):
         from torch._dynamo.package import SourceInfo
 

--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -980,6 +980,33 @@ class TestGuardSerialization(TestGuardSerializationBase):
         self._test_check_fn(ref, loaded, {"x": {"t": torch.randn(3)}}, True)
         self._test_check_fn(ref, loaded, {"x": {}}, False)
 
+        # Sticky flag must survive pickling so load keeps keys-match instead of
+        # re-promoting SUPPORTED_NODES to DICT_VERSION.
+        guards_state = torch._dynamo.package.load_guards_state(
+            self._cached_guards_state
+        )
+        self.assertTrue(
+            any(g._force_dict_keys_match for g in guards_state.output_graph.guards)
+        )
+
+        # Loaded keys-match guard must observe SUPPORTED_NODES key changes, not
+        # only changes to the user input dict.
+        class _TmpPytreeNode:
+            def __init__(self, x):
+                self.x = x
+
+        inputs = {"x": {"t": torch.randn(3)}}
+        self.assertTrue(loaded.check(inputs))
+        try:
+            pytree.register_pytree_node(
+                _TmpPytreeNode,
+                lambda n: ([n.x], None),
+                lambda xs, _: _TmpPytreeNode(xs[0]),
+            )
+            self.assertFalse(loaded.check(inputs))
+        finally:
+            pytree._deregister_pytree_node(_TmpPytreeNode)
+
     def test_dict_contains(self):
         def fn(x):
             if x.__contains__("t"):

--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -970,14 +970,15 @@ class TestGuardSerialization(TestGuardSerializationBase):
             ref, loaded, {"x": x, "counter": itertools.count(2, 4)}, False
         )
 
-    def test_dict_version(self):
+    def test_supported_nodes_dict_keys_match(self):
         def fn(x):
             return pytree.tree_leaves(x)[0] + 1
 
-        with self.assertRaisesRegex(
-            PackageError, "DICT_VERSION guard cannot be serialized."
-        ):
-            self._test_serialization("DICT_VERSION", fn, {"t": torch.randn(3)})
+        ref, loaded = self._test_serialization(
+            "DICT_KEYS_MATCH", fn, {"t": torch.randn(3)}
+        )
+        self._test_check_fn(ref, loaded, {"x": {"t": torch.randn(3)}}, True)
+        self._test_check_fn(ref, loaded, {"x": {}}, False)
 
     def test_dict_contains(self):
         def fn(x):

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3225,14 +3225,17 @@ class GuardBuilder(GuardBuilderBase):
         ref = self.arg_ref(guard)
         value = self.get(guard)
 
-        if value is torch.utils._pytree.SUPPORTED_NODES and not self.save_guards:
-            # For SUPPORTED_NODES, we can guard on the dictionary version (PEP509).
-            # DICT_VERSION is not serializable, so fall back to a keys match when
-            # guards are being serialized. Deserialization rebuilds guards without
-            # save_guards, so a loaded artifact still gets DICT_VERSION here,
-            # re-baselined on the loading process's dict.
-            self.DICT_VERSION(guard)
-            return
+        # SUPPORTED_NODES normally uses DICT_VERSION (PEP 509) as an O(1) fast
+        # path. That guard cannot be serialized, so when saving we fall through
+        # to keys-match and stick the choice on the Guard. Load rebuilds with
+        # save_guards=False but sees the pickled flag, so it keeps keys-match
+        # instead of re-promoting to DICT_VERSION.
+        if value is torch.utils._pytree.SUPPORTED_NODES:
+            if self.save_guards:
+                guard._force_dict_keys_match = True
+            if not guard._force_dict_keys_match:
+                self.DICT_VERSION(guard)
+                return
 
         self.SEQUENCE_LENGTH(guard)
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4918,6 +4918,16 @@ class CheckFunctionManager:
         )
 
         for guard in sorted_guards:
+            # guard_types/code_list are per-build export info, but they
+            # accumulate on the shared Guard objects across builds. Reset them
+            # so results from a previous build (e.g. the pre-filtering build or
+            # an earlier non-save CheckFunctionManager) don't leak into this
+            # build; serialize_guards relies on them to detect unserializable
+            # guards, and a non-save build may derive different guards (e.g.
+            # DICT_VERSION for SUPPORTED_NODES) than a save build.
+            guard.guard_types = None
+            guard.code_list = None
+
             if (
                 not guard_on_nn_modules
                 and guard.is_specialized_nn_module()

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3225,8 +3225,12 @@ class GuardBuilder(GuardBuilderBase):
         ref = self.arg_ref(guard)
         value = self.get(guard)
 
-        if value is torch.utils._pytree.SUPPORTED_NODES:
+        if value is torch.utils._pytree.SUPPORTED_NODES and not self.save_guards:
             # For SUPPORTED_NODES, we can guard on the dictionary version (PEP509).
+            # DICT_VERSION is not serializable, so fall back to a keys match when
+            # guards are being serialized. Deserialization rebuilds guards without
+            # save_guards, so a loaded artifact still gets DICT_VERSION here,
+            # re-baselined on the loading process's dict.
             self.DICT_VERSION(guard)
             return
 

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -281,6 +281,7 @@ class Guard:
     user_stack: traceback.StackSummary | None = None
     _hash: int | None = None
     _unserializable: bool = False
+    _force_dict_keys_match: bool = False
 
     def __hash__(self) -> int:
         if self._hash is None:


### PR DESCRIPTION
Fixes #191378 


First, when guards are serialized for AOT compile, fall back from DICT_VERSION
to DICT_KEYS_MATCH for SUPPORTED_NODES. DICT_VERSION is only used on the
SUPPORTED_NODES fast path and cannot be serialized, which broke
aot_compile for any function using torch.func transforms (vmap/grad/jvp).

Second, Guard.guard_types/code_list accumulate on the
shared Guard objects across guard builds, and guards are built more than
once (CheckFunctionManager does a throwaway save_guards=False build for
guard_filter_fn, and the AOT flow builds runtime guards before the save
build). The non-save build derives DICT_VERSION and poisons guard_types, so
serialize_guards raised even though the save build emitted a keys match.
build_guards now resets these per-build export fields at the start of each
build, matching their documented semantics. 

## Test plan
- [ ] `python test/dynamo/test_guard_serialization.py TestGuardSerialization.test_supported_nodes_dict_keys_match`
- [ ] `python test/dynamo/test_aot_compile.py TestAOTCompile.test_aot_compile_torch_func_vmap_grad`


 Tests and comments by AI assistant. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98