### PR TITLE
[CI] Improve XPU CI robustness

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -42,7 +42,7 @@ declare -f -t trap_add
 function assert_git_not_dirty() {
     # TODO: we should add an option to `build_amd.py` that reverts the repo to
     #       an unmodified state.
-    if [[ "$BUILD_ENVIRONMENT" != *rocm* ]] && [[ "$BUILD_ENVIRONMENT" != *xla* ]] ; then
+    if [[ "$BUILD_ENVIRONMENT" != *rocm* ]] && [[ "$BUILD_ENVIRONMENT" != *xla* ]] && [[ "$BUILD_ENVIRONMENT" != *xpu* ]] ; then
         git_status=$(git status --porcelain | grep -v '?? third_party' || true)
         if [[ $git_status ]]; then
             echo "Build left local git repository checkout dirty"

--- a/.github/actions/setup-xpu/action.yml
+++ b/.github/actions/setup-xpu/action.yml
@@ -83,7 +83,7 @@ runs:
       run: |
         # Add render group for container creation.
         render_gid=`cat /etc/group | grep render | cut -d: -f3`
-        echo "GPU_FLAG=--device=/dev/mem --device=/dev/dri --group-add video --group-add $render_gid" >> "${GITHUB_ENV}"
+        echo "GPU_FLAG=--device=/dev/mem --device=/dev/dri --group-add video --group-add $render_gid -e ZE_AFFINITY_MASK" >> "${GITHUB_ENV}"
 
     - name: Login to ECR
       uses: pytorch/pytorch/.github/actions/ecr-login@main

--- a/.github/actions/teardown-xpu/action.yml
+++ b/.github/actions/teardown-xpu/action.yml
@@ -10,11 +10,8 @@ runs:
       shell: bash
       run: |
         # Prune all stopped containers.
-        # If other runner is pruning on this node, will skip.
-        nprune=$(ps -ef | grep -c "docker container prune")
-        if [[ $nprune -eq 1 ]]; then
-          docker container prune -f
-        fi
+        # Ignore errors if another runner is already pruning on this node.
+        docker container prune -f || true
     - name: Runner diskspace health check
       uses: pytorch/pytorch/.github/actions/diskspace-cleanup@main
       if: always()

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -244,7 +244,6 @@ jobs:
             -e XLA_CLANG_CACHE_S3_BUCKET_NAME \
             -e PYTORCH_TEST_RERUN_DISABLED_TESTS \
             -e TESTS_TO_INCLUDE \
-            -e ZE_AFFINITY_MASK \
             -e HUGGING_FACE_HUB_TOKEN \
             -e DASHBOARD_TAG \
             --env-file="${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}" \

--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -3,6 +3,8 @@ name: xpu
 
 on:
   push:
+    branches:
+      - viable/strict
     tags:
       - ciflow/xpu/*
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Improve the robustness of XPU CI test status through three changes:

- Add `viable/strict` branch push trigger to XPU workflow, enabling post-merge XPU testing to detect and skip new failures early, so PRs rebasing to viable/strict get clean XPU test results
- Fix docker container prune race condition in XPU teardown by replacing unreliable ps/grep check with `|| true` to address random failure like https://github.com/pytorch/pytorch/actions/runs/30564970308/job/90952916231#step:25:49
- Skip git assert dirty check in XPU CI environment

## Test Plan

CI will validate workflow syntax. Changes will be validated on next XPU CI run.
