### PR TITLE
Prefer XPU Flash SDPA when head_dim <= 64

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
@@ -162,27 +162,43 @@ bool can_use_mem_efficient_attention(
   return true;
 }
 
-bool priority_order_init = false;
+// Prefer Flash for small heads where it wins on BMG A/B (esp. decode).
+// For larger heads (notably head_dim=128 decode), oneDNN overrideable is faster.
+// Symbolic head_dim: keep overrideable-first (conservative; avoids materializing).
+constexpr int64_t kXPUFlashPreferredMaxHeadDim = 64;
+
+bool prefer_flash_first(sdp::sdp_params const& params) {
+  const auto head_dim = params.query.sym_size(-1);
+  return !head_dim.is_symbolic() && head_dim.expect_int() <= kXPUFlashPreferredMaxHeadDim;
+}
 
 std::array<sdp::SDPBackend, sdp::num_backends> priority_order(
     sdp::sdp_params const& params) {
-  if (!priority_order_init) {
-    priority_order_init = true;
-    const std::vector<int64_t> priority_order = {
+  // efficient_attention is not implemented on XPU (maps to math).
+  std::vector<int64_t> order;
+  if (prefer_flash_first(params)) {
+    order = {
+        static_cast<int64_t>(at::SDPBackend::flash_attention),
+        static_cast<int64_t>(at::SDPBackend::overrideable),
+        static_cast<int64_t>(at::SDPBackend::math),
+        static_cast<int64_t>(at::SDPBackend::efficient_attention),
+        static_cast<int64_t>(at::SDPBackend::cudnn_attention)};
+  } else {
+    order = {
         static_cast<int64_t>(at::SDPBackend::overrideable),
         static_cast<int64_t>(at::SDPBackend::flash_attention),
         static_cast<int64_t>(at::SDPBackend::math),
         static_cast<int64_t>(at::SDPBackend::efficient_attention),
         static_cast<int64_t>(at::SDPBackend::cudnn_attention)};
-    at::globalContext().setSDPPriorityOrder(priority_order);
   }
+  // Keep Python introspection (_get_sdp_priority_order) in sync with this call.
+  at::globalContext().setSDPPriorityOrder(order);
   return at::globalContext().sDPPriorityOrder();
 }
 
 sdp::SDPBackend select_sdp_backend_xpu(sdp::sdp_params const& kernel_params) {
-  // This function defines the priority order of the different sdp backends
-  // 1. Flash Attention
-  // 2. Math fallback
+  // Priority: Flash first when head_dim <= 64; else overrideable then Flash;
+  // then math (efficient_attention is unsupported and falls back to math).
   auto& ctx = at::globalContext();
   // use overridable linked to onednn as overridable implementation
   if (!ctx.userEnabledMathSDP() && !ctx.userEnabledOverrideableSDP() &&

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -5500,11 +5500,26 @@ class TestSDPAXpuOnly(NNTestCase):
         make_tensor = partial(rand_sdpa_tensor, type=type, device=device, dtype=dtype)
         size = SdpaShape(2, 8, 128, 64)
         q, k, v = make_tensor(size), make_tensor(size), make_tensor(size)
+        choice = torch._fused_sdp_choice(q, k, v, dropout_p=dropout)
         if dropout > 0.0 or dtype not in [torch.float32, torch.bfloat16, torch.float16]:
-            if torch._fused_sdp_choice(q, k, v, dropout_p=dropout) != SDPBackend.MATH.value:
+            if choice != SDPBackend.MATH.value:
                 raise AssertionError("expected MATH backend")
+        elif dtype in (torch.bfloat16, torch.float16):
+            # head_dim=64: heuristic prefers Flash when viable.
+            if choice == SDPBackend.FLASH_ATTENTION.value:
+                pass
+            elif choice == SDPBackend.OVERRIDEABLE.value:
+                if PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU:
+                    raise AssertionError(
+                        "expected FLASH_ATTENTION backend on Flash-capable XPU (head_dim<=64)"
+                    )
+            else:
+                raise AssertionError(
+                    f"expected FLASH_ATTENTION or OVERRIDEABLE backend, got {choice}"
+                )
         else:
-            if torch._fused_sdp_choice(q, k, v, dropout_p=dropout) != SDPBackend.OVERRIDEABLE.value:
+            # fp32: Flash dtype gate fails; oneDNN Graph overrideable.
+            if choice != SDPBackend.OVERRIDEABLE.value:
                 raise AssertionError("expected OVERRIDEABLE backend")
 
     def test_backends_set_to_math(self, device):
@@ -5520,21 +5535,42 @@ class TestSDPAXpuOnly(NNTestCase):
             _ = F.scaled_dot_product_attention(q, k, v)
 
     def test_default_priority_order(self, device):
-        # The default priority order of xpu is overridable, math, flash, efficient, cudnn
-        # For xpu backend, we need to make sure that overridable > flash > math
+        # head_dim=1 (<=64): Flash preferred over overrideable.
         dtype = torch.bfloat16
         shape = SdpaShape(1, 1, 1, 1)
         make_tensor = partial(torch.rand, shape, device=device, dtype=dtype)
         t = make_tensor()
-        # run sdp_choice to make sure priority_order is set by XPU default priority_order
         torch._fused_sdp_choice(t, t, t)
         from torch.nn.attention import _cur_sdpa_kernel_backends
         default_priority = _cur_sdpa_kernel_backends(with_priority=True)
         flash_index = default_priority.index(SDPBackend.FLASH_ATTENTION)
         overrideable_index = default_priority.index(SDPBackend.OVERRIDEABLE)
         math_index = default_priority.index(SDPBackend.MATH)
-        self.assertTrue(overrideable_index < flash_index < math_index,
-                        lambda msg: f"{msg}\nExpected overrideable < flash < math, got {overrideable_index}, {flash_index}, {math_index}")
+        self.assertTrue(
+            flash_index < overrideable_index < math_index,
+            f"Expected flash < overrideable < math, got {flash_index}, {overrideable_index}, {math_index}",
+        )
+
+    def test_priority_order_large_head_dim(self, device):
+        # head_dim=128: prefer overrideable first (Flash slower on BMG decode A/B).
+        dtype = torch.bfloat16
+        shape = SdpaShape(2, 8, 128, 128)
+        make_tensor = partial(torch.rand, shape, device=device, dtype=dtype)
+        q, k, v = make_tensor(), make_tensor(), make_tensor()
+        choice = torch._fused_sdp_choice(q, k, v)
+        from torch.nn.attention import _cur_sdpa_kernel_backends
+        priority = _cur_sdpa_kernel_backends(with_priority=True)
+        flash_index = priority.index(SDPBackend.FLASH_ATTENTION)
+        overrideable_index = priority.index(SDPBackend.OVERRIDEABLE)
+        self.assertTrue(
+            overrideable_index < flash_index,
+            f"Expected overrideable < flash for head_dim=128, got {overrideable_index}, {flash_index}",
+        )
+        if PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU:
+            if choice != SDPBackend.OVERRIDEABLE.value:
+                raise AssertionError(
+                    "expected OVERRIDEABLE backend for head_dim=128 on Flash-capable XPU"
+                )
 
     def test_onednn_attention_different_dk_dv(self, device):
         dtype = torch.bfloat16


### PR DESCRIPTION
## Summary

XPU SDPA previously preferred oneDNN **overrideable** over Flash for all shapes. On Intel Arc Pro B70 (Xe2), Flash is substantially faster for common **head_dim ≤ 64** LLM shapes (especially decode), but **head_dim = 128 decode** is ~2–2.5× slower with Flash than overrideable.

This change selects backends with a simple heuristic:

- concrete `head_dim <= 64` → Flash first, then overrideable, then math
- otherwise (including symbolic head_dim) → overrideable first, then Flash, then math

Flash remains eligible as a fallback when overrideable cannot run.

```
Files:
- aten/src/ATen/native/mkldnn/xpu/Attention.cpp
- test/test_transformers.py
```

## Performance (A/B, same build)

Device: Intel Arc Pro B70 · torch `2.14.0a0+git25af31d` · bf16 · median ms (100 synced iters)

| Case | A overrideable-first | B flash-first | Speedup A/B |
|------|---------------------|---------------|-------------|
| micro d64 | 0.056 | **0.049** | **1.15×** |
| prefill s2048 d64 | 0.245 | **0.190** | **1.29×** |
| prefill s2048 d128 | 0.764 | **0.715** | **1.07×** |
| prefill s4096 d128 | **3.181** | 3.302 | 0.96× |
| decode kv2048 d64 | 0.098 | **0.059** | **1.65×** |
| decode kv2048 d128 | **0.057** | 0.126 | 0.45× |
| decode kv4096 d128 | **0.091** | 0.227 | 0.40× |

Heuristic keeps Flash for the d64 wins and avoids the d128 decode regression by leaving overrideable first when `head_dim > 64`.

## Test plan

- [x] Hal B70: after change, `_fused_sdp_choice` → FLASH for d64, OVERRIDEABLE for d128 / decode d128
- [x] `test_default_priority_order_xpu` (head_dim=1 → flash before overrideable)
- [x] `test_priority_order_large_head_dim_xpu` (head_dim=128 → overrideable before flash; choice OVERRIDEABLE on Flash-capable XPU)
- [x] `test_fused_sdp_choice_xpu` bf16 dense dropout=0 (head_dim=64)
- [ ] CI XPU SDPA / transformers shards

## AI disclosure

> This PR was authored with an AI assistant. A human reviewed the approach (head_dim heuristic vs blanket Flash-first), the Hal A/B numbers above, and the diff before opening this draft.


Made with [Cursor](https://cursor.com)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01