### PR TITLE
Fuse XPU _addmm_activation gelu/relu into oneDNN matmul

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -21,6 +21,32 @@
 namespace at::native {
 namespace xpu {
 
+namespace {
+
+enum class AddmmActivation {
+  None,
+  Relu,
+  GeluErf, // Match at::gelu_ default / XPU tests (CUDA _addmm_activation uses tanh).
+};
+
+void append_addmm_activation(onednn::Attr& attr, AddmmActivation activation) {
+  if (activation == AddmmActivation::GeluErf) {
+    attr.append_post_eltwise(1.f, 0.f, 0.f, attr.kind_with_gelu_erf);
+  } else if (activation == AddmmActivation::Relu) {
+    attr.append_post_eltwise(1.f, 0.f, 0.f, attr.kind_with_relu);
+  }
+}
+
+void apply_addmm_activation_inplace(Tensor& result, AddmmActivation activation) {
+  if (activation == AddmmActivation::GeluErf) {
+    at::gelu_(result);
+  } else if (activation == AddmmActivation::Relu) {
+    at::relu_(result);
+  }
+}
+
+} // namespace
+
 // result = beta * self + alpha * (mat1 * mat2)
 Tensor& addmm_out(
     const Tensor& self,
@@ -28,7 +54,8 @@ Tensor& addmm_out(
     const Tensor& mat2,
     const Scalar& beta,
     const Scalar& alpha,
-    Tensor& result) {
+    Tensor& result,
+    AddmmActivation activation = AddmmActivation::None) {
   checkBackend("addmm_out", {result, self, mat1, mat2}, Backend::XPU);
   TORCH_CHECK(
       mat1.dim() == 2, "mat1 must be a matrix, got ", mat1.dim(), "-D tensor");
@@ -58,7 +85,7 @@ Tensor& addmm_out(
   // complex case
   if (self.is_complex()) {
     at::native::addmm_complex_out_xpu(self, mat1, mat2, beta, alpha, result);
-
+    apply_addmm_activation_inplace(result, activation);
     return result;
   }
 
@@ -69,13 +96,16 @@ Tensor& addmm_out(
 
   if (mat1.numel() == 0) {
     if (beta.to<float>() == 0.f) {
-      return result.zero_();
+      result.zero_();
+    } else {
+      at::mul_out(
+          result,
+          self.expand(result.sizes()),
+          at::native::scalar_tensor(
+              beta, self.scalar_type(), std::nullopt, at::kCPU, std::nullopt));
     }
-    return at::mul_out(
-        result,
-        self.expand(result.sizes()),
-        at::native::scalar_tensor(
-            beta, self.scalar_type(), std::nullopt, at::kCPU, std::nullopt));
+    apply_addmm_activation_inplace(result, activation);
+    return result;
   }
 
   TORCH_CHECK(
@@ -115,10 +145,11 @@ Tensor& addmm_out(
       result.add_(is_inplace ? self_copy : self, beta);
     }
 
+    apply_addmm_activation_inplace(result, activation);
     return result;
   }
 
-  // general case
+  // general case: fuse activation as oneDNN post-op when requested
   Tensor bias = Tensor();
   onednn::Attr attr;
   float beta_ = beta.to<float>();
@@ -155,6 +186,7 @@ Tensor& addmm_out(
       attr.append_post_eltwise(1.f, beta_, 0.f, attr.kind_with_linear);
     }
   }
+  append_addmm_activation(attr, activation);
   onednn::matmul(result, mat1, mat2, bias, true, attr);
   return result;
 }
@@ -167,13 +199,14 @@ Tensor& _addmm_activation_out(
     const Scalar& alpha,
     bool use_gelu,
     at::Tensor& result) {
-  addmm_out(self, mat1, mat2, beta, alpha, result);
-  if (use_gelu) {
-    at::gelu_(result);
-  } else {
-    at::relu_(result);
-  }
-  return result;
+  return addmm_out(
+      self,
+      mat1,
+      mat2,
+      beta,
+      alpha,
+      result,
+      use_gelu ? AddmmActivation::GeluErf : AddmmActivation::Relu);
 }
 
 Tensor& mm_out(const Tensor& self, const Tensor& mat2, Tensor& result) {


### PR DESCRIPTION
## Summary

XPU `aten::_addmm_activation` previously ran `addmm_out` then a separate `gelu_` / `relu_` kernel. This fuses the activation into the oneDNN matmul via post-eltwise:

- `use_gelu=true` → `eltwise_gelu_erf` (matches `at::gelu_` default and existing XPU gemm tests; CUDA `_addmm_activation` uses tanh)
- `use_gelu=false` → `relu`

Complex / float64 / empty bypass paths still apply activation inplace after the matmul.

```
aten/src/ATen/native/mkldnn/xpu/Blas.cpp
```

## Performance (A/B, same build, Arc Pro B70)

A = `addmm` + `gelu(approximate=none)` / `relu`  
B = `torch._addmm_activation`  
bf16, median ms (50 synced iters)

| Case | A | B | Speedup |
|------|---|---|---------|
| decode m1 k4096 n11008 gelu | 0.197 | 0.196 | 1.00× |
| decode m1 k4096 n4096 gelu | 0.103 | 0.102 | 1.01× |
| prefill m2048 k4096 n11008 relu | 1.691 | 1.552 | **1.09×** |
| mlp m32 k768 n3072 gelu | 0.091 | 0.080 | **1.14×** |
| mlp m32 k768 n3072 relu | 0.091 | 0.079 | **1.14×** |
| mlp m128 k2048 n8192 relu | 0.115 | 0.101 | **1.14×** |

fp16 MLP similar (~1.06–1.15×). No M=1 regression. Full table available on request.

## Test plan

- [x] Hal: `TestBasicGEMMXPU` `test_addmm_gelu_*` / `test_addmm_relu_*` (8/8)
- [x] Hal A/B harness vs unfused reference (numerics + timing)
- [ ] CI XPU gemm shards

## AI disclosure

> This PR was authored with an AI assistant. A human reviewed the fusion approach (erf vs tanh), Hal A/B numbers, and the diff before opening this draft.


Made with [Cursor](https://cursor.com)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01