### PR TITLE
Error on missing or short hash prefix with torch.hub check_hash=True

### DIFF
--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: hub"]
 
+import hashlib
 import os
+import shutil
 import tempfile
 import unittest
 import warnings
@@ -157,6 +159,41 @@ class TestHub(TestCase):
             TORCHHUB_EXAMPLE_RELEASE_URL, weights_only=True
         )
         self.assertEqual(sum_of_state_dict(loaded_state), SUM_OF_HUB_EXAMPLE)
+
+    def test_load_state_dict_from_url_check_hash_prefix(self):
+        # filenames without a >= 8 hex digit prefix must not slip past check_hash
+        for filename in ("weights.pth", "weights-.pth", "weights-0123456.pth"):
+            with self.subTest(filename=filename), tempfile.TemporaryDirectory() as tmpdir:
+                with self.assertRaisesRegex(RuntimeError, "check_hash"):
+                    hub.load_state_dict_from_url(
+                        f"https://example.com/{filename}",
+                        model_dir=tmpdir,
+                        check_hash=True,
+                    )
+
+        # a conforming prefix verifies fine, and check_hash=False stays untouched
+        with tempfile.TemporaryDirectory() as tmpdir:
+            payload = os.path.join(tmpdir, "payload")
+            torch.save({"w": torch.ones(3)}, payload)
+            with open(payload, "rb") as f:
+                prefix = hashlib.sha256(f.read()).hexdigest()[:8]
+
+            def fake_download(url, dst, hash_prefix=None, progress=True):
+                shutil.copy(payload, dst)
+
+            with patch("torch.hub.download_url_to_file", side_effect=fake_download):
+                loaded_state = hub.load_state_dict_from_url(
+                    f"https://example.com/weights-{prefix}.pth",
+                    model_dir=tmpdir,
+                    check_hash=True,
+                )
+                self.assertEqual(sum_of_state_dict(loaded_state), 3)
+                loaded_state = hub.load_state_dict_from_url(
+                    "https://example.com/weights-nohash.pth",
+                    model_dir=tmpdir,
+                    check_hash=False,
+                )
+                self.assertEqual(sum_of_state_dict(loaded_state), 3)
 
     @retry(Exception, tries=3)
     def test_load_legacy_zip_checkpoint(self):

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -886,11 +886,18 @@ def load_state_dict_from_url(
         filename = file_name
     cached_file = os.path.join(model_dir, filename)
     if not os.path.exists(cached_file):
-        sys.stdout.write(f'Downloading: "{url}" to {cached_file}\n')
         hash_prefix = None
         if check_hash:
             r = HASH_REGEX.search(filename)  # r is Optional[Match[str]]
             hash_prefix = r.group(1) if r else None
+            # A missing or short prefix would silently skip or weaken verification
+            if hash_prefix is None or len(hash_prefix) < 8:
+                raise RuntimeError(
+                    "check_hash=True requires the filename to follow the "
+                    f"'filename-<sha256>.ext' convention with at least eight "
+                    f"hex digits of the SHA256 hash, got {filename!r}"
+                )
+        sys.stdout.write(f'Downloading: "{url}" to {cached_file}\n')
         download_url_to_file(url, cached_file, hash_prefix, progress=progress)
 
     if _is_legacy_zip_format(cached_file):


### PR DESCRIPTION
## Summary

Fixes #191194. With `check_hash=True`, `load_state_dict_from_url` accepted filenames that carry no usable hash prefix. `HASH_REGEX` pulls `-<hex>.` out of the filename, but three shapes slipped through:

- no match at all (`weights.pth`) leaves `hash_prefix=None`, which turns verification off inside `download_url_to_file`
- an empty match (`weights-.pth`) produces a zero length prefix, and every digest starts with the empty string
- fewer than eight hex digits (`weights-0123456.pth`) falls short of the documented `filename-<sha256>.ext` contract and weakens the check

`check_hash=True` is an explicit request for content verification, so quietly skipping it is the worst possible outcome here. The function now raises `RuntimeError` when the filename does not contain at least eight hex digits, which is what the docstring has always promised. `check_hash=False` is untouched, and full length sha256 filenames keep working.

## Test plan

- New test `test_load_state_dict_from_url_check_hash_prefix` in `test/test_hub.py`: the three non conforming filenames raise before any download starts, a conforming prefix loads fine with a mocked `download_url_to_file`, and `check_hash=False` still accepts a hashless filename.
- Verified on this machine (arm64 macOS, torch 2.13.0 wheel) by patching the wheel's `torch/hub.py` in place and running the new test method from the in tree test file: `Ran 1 test ... OK`. A standalone matrix also covered full length sha256 filenames and wrong prefixes (still rejected by the downloader's digest comparison). A full source build was not run on macOS; the remaining hub tests need network access.
