### PR TITLE
Verify in-process rerun passes in a fresh process

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -411,6 +411,19 @@ class StepcurrentPlugin:
         self.made_failing_xml_location = f"{directory}/made_failing_xml"
         self.cache.set(self.made_failing_xml_location, False)
 
+        # Tests that pytest-rerunfailures reran, accumulated across the pytest
+        # invocations sharing this stepcurrent key. run_test.py re-verifies any
+        # that ultimately passed in a fresh process, since an in-process rerun
+        # can be poisoned by state the first failure left behind (e.g. warm
+        # compile caches).
+        self.reruns_location = f"{directory}/reruns"
+        self.rerun_nodeids: list[str] = self.cache.get(self.reruns_location, [])
+
+    def pytest_runtest_logreport(self, report) -> None:
+        if report.outcome == "rerun" and report.nodeid not in self.rerun_nodeids:
+            self.rerun_nodeids.append(report.nodeid)
+            self.cache.set(self.reruns_location, self.rerun_nodeids)
+
     def pytest_collection_modifyitems(self, config: Config, items: list[Any]) -> None:
         if not self.lastrun:
             self.report_status = "Cannot find last run test, not skipping"

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -860,6 +860,51 @@ def run_test_retries(
             print_to_file("Retrying single test...")
         print_items = []  # do not continue printing them, massive waste of space
 
+    # A test that failed and then passed on an in-process rerun
+    # (pytest-rerunfailures) is not trustworthy: the first failure can leave
+    # behind state (e.g. warm compile caches) that changes the retry's
+    # behavior, making a deterministic bug look flaky. Re-verify each such
+    # test in a fresh process, with in-process reruns disabled so the
+    # verification cannot be poisoned the same way.
+    reruns_raw = read_pytest_cache("reruns")
+    rerun_passed = json.loads(reruns_raw) if reruns_raw else []
+    verify_command = [
+        "--reruns=0" if re.fullmatch(r"--reruns=\d+", arg) else arg for arg in command
+    ]
+    for nodeid in rerun_passed:
+        key = json.dumps(nodeid)  # num_failures keys keep their JSON quotes
+        if num_failures[key] > 0:
+            # Already went through the fresh-process retry loop above
+            continue
+        print_to_file(f"Verifying in-process rerun pass in a new process: {nodeid}")
+        while num_failures[key] < 3:
+            lastrun_file = (
+                REPO_ROOT
+                / ".pytest_cache/v/cache/stepcurrent"
+                / stepcurrent_key
+                / "lastrun"
+            )
+            lastrun_file.parent.mkdir(parents=True, exist_ok=True)
+            lastrun_file.write_text(key)
+            verify_ret, _ = retry_shell(
+                verify_command + [f"--rs={stepcurrent_key}"],
+                test_directory,
+                stdout=output,
+                stderr=output,
+                env=env,
+                timeout=timeout,
+                retries=0,
+            )
+            if verify_ret == 0 or verify_ret == 5:
+                print_to_file("Test succeeded in new process")
+                break
+            num_failures[key] += 1
+            print_to_file(f"Got exit code {verify_ret}, retrying single test...")
+        if num_failures[key] >= 3:
+            print_to_file(f"FAILED CONSISTENTLY: {nodeid}")
+            if IS_CI and options.upload_artifacts_while_running:
+                upload_adhoc_failure_json(test_file, nodeid)
+
     consistent_failures = [x[1:-1] for x in num_failures if num_failures[x] >= 3]
     flaky_failures = [x[1:-1] for x in num_failures if 0 < num_failures[x] < 3]
     if len(flaky_failures) > 0:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191437

run_test.py has two retry layers: pytest-rerunfailures retries a failed
test immediately in the same process (--reruns=2), and run_test_retries
retries in a fresh process, declaring FAILED CONSISTENTLY after 3
fresh-process failures. The fresh-process layer is the one that can
actually distinguish a flaky test from a deterministic bug, but the
in-process layer runs first and consumes everything it can: a test that
fails and then passes in-process is reported as flaky-passed and never
reaches the fresh-process arbiter.

That is unsound because the first failure executes in the same process
as the retry and can poison the retry's behavior. Concretely, in
issue #191283 a meta kernel bug mutated fake tensor metadata only on a
FakeTensorMode dispatch cache miss; the in-process retry hit the cache,
skipped the buggy path, and passed. CI classified 94 deterministic
failures as flaky and auto-disabled the tests instead of blocking the
bug. Distributed tests already disabled in-process reruns entirely for
this reason (#163025).

This keeps the fast in-process rerun but makes its passes subject to
fresh-process verification: the stepcurrent plugin records every test
pytest-rerunfailures reran (a "reruns" file in the stepcurrent cache),
and after the main loop run_test_retries re-runs each such test that
ultimately passed in a new process via the existing --rs single-test
mechanism, with --reruns=0 so the verification cannot be poisoned the
same way. Pass -> flaky as before; 3 fresh-process failures -> FAILED
CONSISTENTLY, exactly matching the semantics the fresh-process loop
already applies to tests that exhausted their in-process reruns.

Cost is paid only on flake events: a verification run is one extra
process launch (~10s for test_torch.py, dominated by collection) per
test that flaked in-process, and zero for the failure-free happy path.

Alternative considered: setting --reruns=0 globally so every failure
goes straight to the fresh-process loop. Simpler, but under
continue-through-error a file with many real failures would restart
pytest per failure, and it gives up the cheap in-process triage for
genuinely flaky tests. This change preserves the existing fast path
and only adds scrutiny where the current system is provably blind.

Test Plan:

All scenarios run through the real entrypoint. With the #191283 meta
kernel bug temporarily restored (fix reverted, #182972 cherry-picked),
the previously "flaky" test is now correctly identified as a
consistent failure (exit 1, FAILED CONSISTENTLY, previously exit 0):

```
PYTORCH_TEST_WITH_DYNAMO=1 python test/run_test.py --include test_torch -k "test_broadcast_fn_pow_cpu"
```

Happy path (clean tree, same command): exit 0, no verification runs.

Genuinely flaky test (fails once via a tempfile flag, then passes):
exit 0, log shows "Verifying in-process rerun pass in a new process"
followed by "Test succeeded in new process".

Consistently failing test: exit 1 with FAILED CONSISTENTLY via the
pre-existing path, no extra verification runs.

Authored with Claude Code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>