### PR TITLE
Restore caller's GC state in flight recorder read_dir

### DIFF
--- a/test/distributed/flight_recorder/test_fr_analysis.py
+++ b/test/distributed/flight_recorder/test_fr_analysis.py
@@ -1,11 +1,17 @@
 # Owner(s): ["oncall: distributed"]
 
+import argparse
 import copy
+import gc
 import math
+import os
+import pickle
+import tempfile
 from typing import Any
 
 from torch.distributed.flight_recorder.components.builder import build_db
 from torch.distributed.flight_recorder.components.config_manager import JobConfig
+from torch.distributed.flight_recorder.components.loader import read_dir
 from torch.distributed.flight_recorder.components.types import (
     COLLECTIVES,
     MatchInfo,
@@ -424,6 +430,38 @@ class FlightRecorderE2ETest(TestCase):
         self.assertEqual(db.collectives[1].collective_name, "nccl:_reduce_oop")
         self.assertEqual(db.collectives[1].record_id, 1)
         self.assertEqual(db.collectives[1].pass_check, True)
+
+
+class FlightRecorderLoaderGCTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        was_enabled = gc.isenabled()
+        self.addCleanup(gc.enable if was_enabled else gc.disable)
+
+    def _write_trace_dir(self, tmpdir):
+        dump = {"entries": [], "version": "2.4", "pg_config": {}}
+        with open(os.path.join(tmpdir, "trace_0"), "wb") as f:
+            pickle.dump(dump, f)
+        return argparse.Namespace(trace_dir=tmpdir, prefix="trace_")
+
+    def test_gc_restored_on_success(self):
+        gc.enable()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            read_dir(self._write_trace_dir(tmpdir))
+        self.assertTrue(gc.isenabled())
+
+    def test_gc_restored_on_failure(self):
+        gc.enable()
+        args = argparse.Namespace(trace_dir="/does/not/exist", prefix=None)
+        with self.assertRaises(AssertionError):
+            read_dir(args)
+        self.assertTrue(gc.isenabled())
+
+    def test_gc_left_disabled_when_caller_disabled_it(self):
+        gc.disable()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            read_dir(self._write_trace_dir(tmpdir))
+        self.assertFalse(gc.isenabled())
 
 
 if __name__ == "__main__":

--- a/torch/distributed/flight_recorder/components/loader.py
+++ b/torch/distributed/flight_recorder/components/loader.py
@@ -73,28 +73,33 @@ def _determine_prefix(files: list[str]) -> str:
 
 
 def read_dir(args: argparse.Namespace) -> tuple[dict[str, dict[str, Any]], str]:
+    gc_was_enabled = gc.isenabled()
     gc.disable()
-    prefix = args.prefix
-    details = {}
-    t0 = time.time()
-    version = ""
-    filecount = 0
-    if not os.path.isdir(args.trace_dir):
-        raise AssertionError(f"folder {args.trace_dir} does not exist")
-    for root, _, files in os.walk(args.trace_dir):
-        if prefix is None:
-            prefix = _determine_prefix(files)
-        for f in files:
-            if (offset := f.find(prefix)) == -1:
-                continue
-            details[f] = read_dump(f[:offset] + prefix, os.path.join(root, f))
-            filecount += 1
-            if not version:
-                version = str(details[f]["version"])
-    tb = time.time()
-    if len(details) <= 0:
-        raise AssertionError(
-            f"no files loaded from {args.trace_dir} with prefix {prefix}"
-        )
-    logger.debug("loaded %s files in %ss", filecount, tb - t0)
-    return details, version
+    try:
+        prefix = args.prefix
+        details = {}
+        t0 = time.time()
+        version = ""
+        filecount = 0
+        if not os.path.isdir(args.trace_dir):
+            raise AssertionError(f"folder {args.trace_dir} does not exist")
+        for root, _, files in os.walk(args.trace_dir):
+            if prefix is None:
+                prefix = _determine_prefix(files)
+            for f in files:
+                if (offset := f.find(prefix)) == -1:
+                    continue
+                details[f] = read_dump(f[:offset] + prefix, os.path.join(root, f))
+                filecount += 1
+                if not version:
+                    version = str(details[f]["version"])
+        tb = time.time()
+        if len(details) <= 0:
+            raise AssertionError(
+                f"no files loaded from {args.trace_dir} with prefix {prefix}"
+            )
+        logger.debug("loaded %s files in %ss", filecount, tb - t0)
+        return details, version
+    finally:
+        if gc_was_enabled:
+            gc.enable()


### PR DESCRIPTION
Fixes #191396

### Problem

`torch.distributed.flight_recorder.components.loader.read_dir()` calls
`gc.disable()` and never restores the collector. There is no `gc.enable()`
anywhere in the module, so cyclic garbage collection is left permanently
disabled for the calling process — on the success path as well as the
exception paths (`trace_dir` missing, no files loaded, or anything raised
by `read_dump`).

### Fix

Capture `gc.isenabled()` on entry and restore it in a `finally` block.
The restore is conditional: if the caller had already disabled GC, it stays
disabled, so the function never turns collection on for a caller who wanted
it off.

### Tests

Adds `FlightRecorderLoaderGCTest` to
`test/distributed/flight_recorder/test_fr_analysis.py`:

- `test_gc_restored_on_success` — GC enabled, successful read
- `test_gc_restored_on_failure` — GC enabled, `trace_dir` does not exist
- `test_gc_left_disabled_when_caller_disabled_it` — GC already disabled

`setUp` records the ambient GC state and restores it via `addCleanup`, so a
failing test cannot leak a disabled collector into the rest of the suite.

Verified that the first two tests fail against the unpatched `read_dir`, and
that the third fails against a naive fix that calls `gc.enable()`
unconditionally. Tested without a source build by loading the patched module
into an installed torch; `lintrunner` is clean on both changed files.