### PR TITLE
[c10d] Fix WorkNCCL::logPrefix() reporting stale rank across process groups

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -500,3 +500,14 @@ TEST_F(ProcessGroupNCCLWatchdogTimeoutTest, testNCCLTimedoutDebugInfoStuck) {
 
   // Communicators might be aborted here, further operations would fail.
 }
+
+TEST_F(ProcessGroupNCCLErrorsTest, testWorkNCCLLogPrefixPerInstance) {
+  at::Device dev(at::kCUDA, 0);
+  // Two WorkNCCL instances with different ranks and PG UIDs should produce
+  // different log prefixes (verifies the static-local bug is fixed).
+  WorkNCCLSimulateErrors w0(dev, false, 0, c10d::OpType::ALLREDUCE, 1, false);
+  WorkNCCLSimulateErrors w1(dev, false, 1, c10d::OpType::ALLREDUCE, 2, false);
+  EXPECT_NE(w0.logPrefix(), w1.logPrefix());
+  EXPECT_NE(w0.logPrefix().find("Rank 0"), std::string::npos);
+  EXPECT_NE(w1.logPrefix().find("Rank 1"), std::string::npos);
+}

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -561,6 +561,12 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(
       isP2P_(isP2P),
       timingEnabled_(enableTiming),
       distDebugLevel_(distDebugLevel) {
+  if (pgDesc_.empty() || pgDesc_ == "undefined") {
+    logPrefix_ = c10::str("[PG GUID ", pgUID_, " Rank ", rank_, "] ");
+  } else {
+    logPrefix_ =
+        c10::str("[PG GUID ", pgUID_, "(", pgDesc_, ") Rank ", rank_, "] ");
+  }
   // Creates the CUDA event wrappers
   // Note: The actual events are lazily created when first recorded to with
   // DEFAULT_FLAGS = cudaEventDisableTiming.
@@ -610,7 +616,8 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(const WorkNCCL& w)
       timingEnabled_(w.timingEnabled_),
       trace_id_(w.trace_id_),
       trace_reset_epoch_(w.trace_reset_epoch_),
-      distDebugLevel_(w.distDebugLevel_) {
+      distDebugLevel_(w.distDebugLevel_),
+      logPrefix_(w.logPrefix_) {
   exception_ = w.exception_;
 }
 
@@ -655,8 +662,7 @@ void ProcessGroupNCCL::WorkNCCL::checkAndSetException() {
 }
 
 const std::string& ProcessGroupNCCL::WorkNCCL::logPrefix() const {
-  static std::string prefix = c10::str("[Rank ", rank_, "] ");
-  return prefix;
+  return logPrefix_;
 }
 
 void ProcessGroupNCCL::WorkNCCL::setException(

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -505,6 +505,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     std::optional<uint64_t> trace_id_;
     std::optional<uint64_t> trace_reset_epoch_;
     DebugLevel distDebugLevel_;
+    std::string logPrefix_;
     friend class ProcessGroupNCCL;
   };
 


### PR DESCRIPTION
## Summary

Fixes #191305

- `WorkNCCL::logPrefix()` used a function-local `static` string, so the prefix was initialized once from the first `WorkNCCL` instance to call it and cached for the lifetime of the process. When a process participated in multiple NCCL process groups with different local ranks, all error and timeout logs incorrectly reported the rank from the first group.
- Replace the static with a per-instance `logPrefix_` member initialized in the constructor from the instance's own `rank_`, `pgUID_`, and `pgDesc_`. The prefix now also includes the PG GUID for disambiguation, matching the style of `ProcessGroupNCCL::createLogPrefix()`.

**Before (bug):** group_b timeout logs `[Rank 1]` instead of `[Rank 0]`
```
[global rank 1] timing out group_b; expected WorkNCCL prefix rank = 0
[Rank 1] Watchdog caught collective operation timeout: ...
```

**After (fix):** each WorkNCCL reports its own group-local rank and PG GUID
```
[global rank 1] timing out group_a; expected WorkNCCL prefix rank = 1
[PG GUID 1 Rank 1] Watchdog caught collective operation timeout: ...

[global rank 1] timing out group_b; expected WorkNCCL prefix rank = 0
[PG GUID 2 Rank 0] Watchdog caught collective operation timeout: ...
```

## Test plan

- Added `testWorkNCCLLogPrefixPerInstance` to `ProcessGroupNCCLErrorsTest` verifying two `WorkNCCL` instances with different ranks produce different log prefixes containing the correct rank.
- Ran the reproducer script from #191305 on a 3-GPU node and confirmed both timeouts now report the correct group-local rank and PG GUID.

```
TORCH_NCCL_BLOCKING_WAIT=1 \
TORCH_CPP_LOG_LEVEL=ERROR \
NCCL_DEBUG=WARN \
torchrun --standalone --nproc-per-node=3 repro_191305.py
```

cc @AndyZzzZzzZzz