### PR TITLE
Avoid closure cycles in `cuda/memory.py` + copypasta

### DIFF
--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -42,6 +42,17 @@ def empty_host_cache() -> None:
     torch._C._accelerator_emptyHostCache()
 
 
+def _flatten_stats(
+    result: list[tuple[str, Any]], prefix: str, value: Any
+) -> None:
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            nested_prefix = f"{prefix}.{key}" if prefix else key
+            _flatten_stats(result, nested_prefix, nested_value)
+    else:
+        result.append((prefix, value))
+
+
 def memory_stats(device_index: _device_t = None, /) -> OrderedDict[str, Any]:
     r"""Return a dictionary of accelerator device memory allocator statistics for a given device index.
 
@@ -109,15 +120,7 @@ def memory_stats(device_index: _device_t = None, /) -> OrderedDict[str, Any]:
     stats = torch._C._accelerator_getDeviceStats(device_index)
     flat_stats = []
 
-    def flatten(prefix: str, value: Any) -> None:
-        if isinstance(value, dict):
-            for k, v in value.items():
-                nested_prefix = f"{prefix}.{k}" if prefix else k
-                flatten(nested_prefix, v)
-        else:
-            flat_stats.append((prefix, value))
-
-    flatten("", stats)
+    _flatten_stats(flat_stats, "", stats)
     flat_stats.sort()
     # pyrefly: ignore [no-matching-overload]
     return OrderedDict(flat_stats)

--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -42,9 +42,7 @@ def empty_host_cache() -> None:
     torch._C._accelerator_emptyHostCache()
 
 
-def _flatten_stats(
-    result: list[tuple[str, Any]], prefix: str, value: Any
-) -> None:
+def _flatten_stats(result: list[tuple[str, Any]], prefix: str, value: Any) -> None:
     if isinstance(value, dict):
         for key, nested_value in value.items():
             nested_prefix = f"{prefix}.{key}" if prefix else key

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -229,6 +229,16 @@ def empty_cache() -> None:
         torch._C._cuda_emptyCache()
 
 
+def _recurse_add_to_result(result, prefix, obj, format_key):
+    if isinstance(obj, dict):
+        if prefix:
+            prefix += "."
+        for key, value in obj.items():
+            _recurse_add_to_result(result, prefix + format_key(key), value, format_key)
+    else:
+        result.append((prefix, obj))
+
+
 def memory_stats(device: "Device" = None) -> dict[str, Any]:
     r"""Return a dictionary of CUDA memory allocator statistics for a given device.
 
@@ -333,18 +343,8 @@ def memory_stats(device: "Device" = None) -> dict[str, Any]:
             return "_".join(str(part) for part in key)
         return str(key)
 
-    def _recurse_add_to_result(prefix, obj):
-        if isinstance(obj, dict):
-            if len(prefix) > 0:
-                prefix += "."
-            for k, v in obj.items():
-                key = _format_key(k)
-                _recurse_add_to_result(prefix + key, v)
-        else:
-            result.append((prefix, obj))
-
     stats = memory_stats_as_nested_dict(device=device)
-    _recurse_add_to_result("", stats)
+    _recurse_add_to_result(result, "", stats, _format_key)
     result.sort()
 
     return collections.OrderedDict(result)
@@ -436,17 +436,8 @@ def host_memory_stats() -> dict[str, Any]:
     """
     result = []
 
-    def _recurse_add_to_result(prefix, obj):
-        if isinstance(obj, dict):
-            if len(prefix) > 0:
-                prefix += "."
-            for k, v in obj.items():
-                _recurse_add_to_result(prefix + k, v)
-        else:
-            result.append((prefix, obj))
-
     stats = host_memory_stats_as_nested_dict()
-    _recurse_add_to_result("", stats)
+    _recurse_add_to_result(result, "", stats, str)
     result.sort()
 
     return collections.OrderedDict(result)

--- a/torch/xpu/memory.py
+++ b/torch/xpu/memory.py
@@ -74,6 +74,18 @@ def memory_stats_as_nested_dict(device: Device = None) -> dict[str, Any]:
     return torch._C._xpu_memoryStats(device)
 
 
+def _recurse_add_to_result(
+    result: list[tuple[str, Any]], prefix: str, obj: Any
+) -> None:
+    if isinstance(obj, dict):
+        if prefix:
+            prefix += "."
+        for key, value in obj.items():
+            _recurse_add_to_result(result, prefix + key, value)
+    else:
+        result.append((prefix, obj))
+
+
 def memory_stats(device: Device = None) -> dict[str, Any]:
     r"""Return a dictionary of XPU memory allocator statistics for a given device.
 
@@ -114,17 +126,8 @@ def memory_stats(device: Device = None) -> dict[str, Any]:
     """
     result = []
 
-    def _recurse_add_to_result(prefix: str, obj: Any) -> None:
-        if isinstance(obj, dict):
-            if len(prefix) > 0:
-                prefix += "."
-            for k, v in obj.items():
-                _recurse_add_to_result(prefix + k, v)
-        else:
-            result.append((prefix, obj))
-
     stats = memory_stats_as_nested_dict(device=device)
-    _recurse_add_to_result("", stats)
+    _recurse_add_to_result(result, "", stats)
     result.sort()
 
     return collections.OrderedDict(result)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #191441

The recursive helpers in memory_stats and host_memory_stats captured their own
local bindings. Even this minimal pattern creates the same reference cycle:

```python
def outer():
    def recurse():
        recurse()
```

This is not a leak per se as GC eventually reclaims the memory, but still a poor precedent, which is exacerbated many times over when closure accumulates to a parent function local variable

Move the traversal to one module-level helper, whose recursive name is resolved through module globals and therefore does not create a closure.

Fix similar reference cycles in XPU/accelerator copy-pasted code

Authored with an AI assistant.