### PR TITLE
[ROCm][CI] Use python image for ROCm binary wheel tests

### DIFF
--- a/.ci/pytorch/binary_linux_test.sh
+++ b/.ci/pytorch/binary_linux_test.sh
@@ -22,17 +22,14 @@ fi
 
 python_nodot="\$(echo $DESIRED_PYTHON | tr -d m.u)"
 
-# Set up Python. Manylinux test images ship /opt/python/cpXY; official python
-# images expose the requested interpreter on PATH already.
+# Set up Python
 if [[ "$PACKAGE_TYPE" != libtorch ]]; then
   python_path="/opt/python/cp\$python_nodot-cp\${python_nodot}"
   if [[ "\$python_nodot" = *t ]]; then
     python_digits="\$(echo $DESIRED_PYTHON | tr -cd [:digit:])"
     python_path="/opt/python/cp\$python_digits-cp\${python_digits}t"
   fi
-  if [[ -d "\$python_path" ]]; then
-    export PATH="\${python_path}/bin:\$PATH"
-  fi
+  export PATH="\${python_path}/bin:\$PATH"
 fi
 
 # Move debug wheels out of the package dir so they don't get installed

--- a/.ci/pytorch/binary_linux_test.sh
+++ b/.ci/pytorch/binary_linux_test.sh
@@ -22,14 +22,17 @@ fi
 
 python_nodot="\$(echo $DESIRED_PYTHON | tr -d m.u)"
 
-# Set up Python
+# Set up Python. Manylinux test images ship /opt/python/cpXY; official python
+# images expose the requested interpreter on PATH already.
 if [[ "$PACKAGE_TYPE" != libtorch ]]; then
   python_path="/opt/python/cp\$python_nodot-cp\${python_nodot}"
   if [[ "\$python_nodot" = *t ]]; then
     python_digits="\$(echo $DESIRED_PYTHON | tr -cd [:digit:])"
     python_path="/opt/python/cp\$python_digits-cp\${python_digits}t"
   fi
-  export PATH="\${python_path}/bin:\$PATH"
+  if [[ -d "\$python_path" ]]; then
+    export PATH="\${python_path}/bin:\$PATH"
+  fi
 fi
 
 # Move debug wheels out of the package dir so they don't get installed

--- a/.github/workflows/_binary-test-rocm-linux.yml
+++ b/.github/workflows/_binary-test-rocm-linux.yml
@@ -1,10 +1,14 @@
 # Owner(s): ["module: rocm"]
 name: linux-binary-test-rocm
 
-# Reusable workflow that runs the ROCm binary test (setup-rocm, GPU device
-# passthrough, ECR docker pull, test-pytorch-binary, teardown-rocm). Called
-# from the matrix-driven manywheel-test-rocm job in
-# generated-linux-binary-manywheel-nightly.yml.
+# Reusable workflow that runs the ROCm binary test (GPU device passthrough,
+# test-pytorch-binary). Called from the matrix-driven manywheel-test-rocm job
+# in generated-linux-binary-manywheel-nightly.yml.
+#
+# Uses the official python:${{ inputs.DESIRED_PYTHON }} image instead of the
+# manylinux builder image so unbundled library dependencies are visible. The
+# manylinux test image ships the same system libraries as the build image and
+# can mask missing RPATH entries in shipped wheels.
 
 on:
   workflow_call:
@@ -57,7 +61,7 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     container:
-      image: pytorch/${{ inputs.DOCKER_IMAGE }}:${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
+      image: python:${{ inputs.DESIRED_PYTHON }}
       options: --device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
@@ -105,7 +109,7 @@ jobs:
             echo "DESIRED_CUDA=${DESIRED_CUDA}"
             echo "GPU_ARCH_VERSION=${GPU_ARCH_VERSION}"
             echo "GPU_ARCH_TYPE=${GPU_ARCH_TYPE}"
-            echo "DOCKER_IMAGE=pytorch/${{ inputs.DOCKER_IMAGE }}:${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}"
+            echo "DOCKER_IMAGE=python:${{ inputs.DESIRED_PYTHON }}"
             echo "SKIP_ALL_TESTS=${SKIP_ALL_TESTS}"
             echo "DESIRED_PYTHON=${DESIRED_PYTHON}"
             echo "ALPINE_IMAGE=${ALPINE_IMAGE}"


### PR DESCRIPTION
## Summary

ROCm manywheel binary tests currently run in the same `manylinux2_28-builder:rocm*` image used for builds. That image ships the system libraries wheels may depend on, so `check_binary.sh` can pass even when a wheel is missing bundled RPATH entries.

This PR switches the ROCm binary test container to `python:${{ inputs.DESIRED_PYTHON }}` and updates `binary_linux_test.sh` to only prepend `/opt/python/...` when that path exists. The goal is to surface unbundled-library issues that manylinux-based testing currently masks.

## Test plan

- [ ] Add `ciflow/binaries` label and confirm `manywheel-test-rocm` jobs run with the `python:` container
- [ ] Verify failing cases (if any) show missing bundled deps in `ldd` / import errors rather than passing under manylinux

Authored with assistance from Cursor

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang