### PR TITLE
[Distributed] Remove unreachable return in functional collectives fallback

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -33,8 +33,6 @@ except Exception:
 
     def is_torchdynamo_compiling():  # type: ignore[misc]
         return False
-        # pyrefly: ignore [unreachable]
-        return False
 
 
 """


### PR DESCRIPTION
## Summary

- Remove duplicate unreachable `return False` and its `# pyrefly: ignore [unreachable]` suppression comment from the fallback `is_torchdynamo_compiling()` in `torch/distributed/_functional_collectives.py`
- No runtime behavior change — pure dead code cleanup

Fixes #191400

## Test plan
- [x] Verified file parses correctly
- [x] Verified fallback function returns expected value
- [x] `lintrunner -a torch/distributed/_functional_collectives.py` passes cleanly