### PR TITLE
Replace unsafe flight recorder rank parsing

### DIFF
--- a/test/distributed/flight_recorder/test_fr_analysis.py
+++ b/test/distributed/flight_recorder/test_fr_analysis.py
@@ -452,9 +452,7 @@ class FlightRecorderRankParsingTest(TestCase):
                 details = {
                     "rank_2": {
                         "rank": 2,
-                        "pg_config": {
-                            "0": {"desc": "default_pg", "ranks": value}
-                        },
+                        "pg_config": {"0": {"desc": "default_pg", "ranks": value}},
                     }
                 }
 

--- a/test/distributed/flight_recorder/test_fr_analysis.py
+++ b/test/distributed/flight_recorder/test_fr_analysis.py
@@ -4,7 +4,11 @@ import copy
 import math
 from typing import Any
 
-from torch.distributed.flight_recorder.components.builder import build_db
+from torch.distributed.flight_recorder.components.builder import (
+    build_db,
+    build_groups_memberships,
+    transform_ft,
+)
 from torch.distributed.flight_recorder.components.config_manager import JobConfig
 from torch.distributed.flight_recorder.components.types import (
     COLLECTIVES,
@@ -424,6 +428,63 @@ class FlightRecorderE2ETest(TestCase):
         self.assertEqual(db.collectives[1].collective_name, "nccl:_reduce_oop")
         self.assertEqual(db.collectives[1].record_id, 1)
         self.assertEqual(db.collectives[1].pass_check, True)
+
+
+class FlightRecorderRankParsingTest(TestCase):
+    def test_build_groups_memberships_parses_rank_lists(self):
+        for value in ("[0, 1]", "'[0, 1]'"):
+            with self.subTest(value=value):
+                pg_config = {0: {"0": {"desc": "default_pg", "ranks": value}}}
+
+                groups, _, memberships, member_sets, _ = build_groups_memberships(
+                    pg_config
+                )
+
+                self.assertEqual(groups[0].size, 2)
+                self.assertEqual(
+                    [membership.global_rank for membership in memberships], [0, 1]
+                )
+                self.assertEqual(next(iter(member_sets.values())), {0, 1})
+
+    def test_transform_ft_parses_rank_lists(self):
+        for value in ("[0, 1]", "'[0, 1]'"):
+            with self.subTest(value=value):
+                details = {
+                    "rank_2": {
+                        "rank": 2,
+                        "pg_config": {
+                            "0": {"desc": "default_pg", "ranks": value}
+                        },
+                    }
+                }
+
+                transformed = transform_ft(details, group_world_size=2)
+
+                self.assertEqual(
+                    transformed["rank_2"]["pg_config"]["0"]["ranks"], "[2, 3]"
+                )
+
+    def test_build_groups_memberships_rejects_invalid_rank_lists(self):
+        for value in ("__import__('os').system('echo unsafe')", "[0, '1']"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                build_groups_memberships(
+                    {0: {"0": {"desc": "default_pg", "ranks": value}}}
+                )
+
+    def test_transform_ft_rejects_invalid_rank_lists(self):
+        for value in ("__import__('os').system('echo unsafe')", "[0, '1']"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                transform_ft(
+                    {
+                        "rank_0": {
+                            "rank": 0,
+                            "pg_config": {
+                                "0": {"desc": "default_pg", "ranks": value}
+                            },
+                        }
+                    },
+                    group_world_size=2,
+                )
 
 
 if __name__ == "__main__":

--- a/test/distributed/flight_recorder/test_fr_analysis.py
+++ b/test/distributed/flight_recorder/test_fr_analysis.py
@@ -478,9 +478,7 @@ class FlightRecorderRankParsingTest(TestCase):
                     {
                         "rank_0": {
                             "rank": 0,
-                            "pg_config": {
-                                "0": {"desc": "default_pg", "ranks": value}
-                            },
+                            "pg_config": {"0": {"desc": "default_pg", "ranks": value}},
                         }
                     },
                     group_world_size=2,

--- a/torch/distributed/flight_recorder/components/builder.py
+++ b/torch/distributed/flight_recorder/components/builder.py
@@ -65,6 +65,19 @@ Flat DB builder
 """
 
 
+def _parse_ranks(value: Any) -> list[int]:
+    try:
+        ranks = ast.literal_eval(value)
+        if isinstance(ranks, str):
+            ranks = ast.literal_eval(ranks)
+    except (SyntaxError, TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid process group ranks: {value!r}") from exc
+
+    if not isinstance(ranks, list) or any(type(rank) is not int for rank in ranks):
+        raise ValueError(f"Process group ranks must be a list of integers: {value!r}")
+    return ranks
+
+
 def build_groups_memberships(
     pg_config: Any,
 ) -> tuple[
@@ -108,15 +121,12 @@ def build_groups_memberships(
     for global_rank in pg_config:
         for pg_uid in pg_config[global_rank]:
             desc = pg_config[global_rank][pg_uid]["desc"]
-            ranks = ast.literal_eval(pg_config[global_rank][pg_uid]["ranks"])
+            ranks = _parse_ranks(pg_config[global_rank][pg_uid]["ranks"])
             # With the adoption of the split_group API, we can have multiple PGs with the same pg_guid (PG Name)
             # So we need to add the hash of all its ranks within the PG as well.
             # Also guid must be a string because `_process_group_name` returns a string.
             pg_guid = pg_uid + str(hash(frozenset(ranks)))
             _pg_guids[(pg_uid, global_rank)] = pg_guid
-            if isinstance(ranks, str):
-                # TODO Bug in FR data format? ranks is '[0, 1,...]'
-                ranks = eval(ranks)
 
             if pg_guid not in _groups:
                 groups.append(Group(id=pg_guid, desc=desc, size=len(ranks)))
@@ -398,7 +408,7 @@ def transform_ft(
         rank = dump["rank"]
         for key, pg_config in dump["pg_config"].items():
             if pg_config["desc"] == "default_pg":
-                ranks = eval(pg_config["ranks"])
+                ranks = _parse_ranks(pg_config["ranks"])
                 replica_id = rank // group_world_size
                 first_rank = replica_id * group_world_size
                 new_ranks = [r + first_rank for r in ranks]


### PR DESCRIPTION
Fixes #191399

## Summary

- replace both raw `eval` calls used for process-group ranks with a shared `ast.literal_eval` parser
- preserve support for ordinary and double-encoded rank lists
- validate that parsed ranks are a list of integers before using them
- parse ranks before computing the process-group identifier
- add coverage for both parsing paths, supported encodings, malformed literals, and invalid element types

## Testing

Using Python 3.12 and `torch==2.14.0.dev20260728+cpu`, with the modified builder copied into the nightly wheel environment:

- `python -m pytest -q test/distributed/flight_recorder/test_fr_analysis.py -k FlightRecorderRankParsingTest`
  - `4 passed, 9 deselected, 8 subtests passed`
- `python -m pytest -q test/distributed/flight_recorder/test_fr_analysis.py`
  - `13 passed, 8 subtests passed`

This was a wheel-based validation of the Python changes rather than a full source build; repository CI will provide source-integration coverage.

## AI assistance disclosure

This change was developed with assistance from OpenAI Codex. I reviewed the code and test changes and ran the tests reported above.
