### PR TITLE
[elastic] Fix find_free_port UnboundLocalError when socket creation fails

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -6,12 +6,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+import socket
 import sys
 import unittest
+from unittest import mock
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
 if os.getenv("CIRCLECI"):
@@ -58,3 +60,49 @@ class EtcdServerTest(unittest.TestCase):
             self.assertEqual(1, rdzv_info.world_size)
         finally:
             server.stop()
+
+
+class FindFreePortTest(unittest.TestCase):
+    ADDRS = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+        (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 0, 0, 0)),
+    ]
+
+    def test_retries_next_address_when_socket_creation_fails(self):
+        # socket() raising on the first address must not leak an
+        # UnboundLocalError from the cleanup path; the next address is tried.
+        good_sock = mock.MagicMock()
+        with (
+            mock.patch("socket.getaddrinfo", return_value=self.ADDRS),
+            mock.patch(
+                "socket.socket", side_effect=[OSError("socket failed"), good_sock]
+            ) as mock_socket,
+        ):
+            result = find_free_port()
+
+        self.assertIs(result, good_sock)
+        self.assertEqual(mock_socket.call_count, 2)
+        good_sock.bind.assert_called_once_with(("localhost", 0))
+
+    def test_closes_socket_when_bind_fails(self):
+        # A successfully created socket whose bind() fails must be closed.
+        bad_sock = mock.MagicMock()
+        bad_sock.bind.side_effect = OSError("bind failed")
+        with (
+            mock.patch("socket.getaddrinfo", return_value=self.ADDRS[:1]),
+            mock.patch("socket.socket", return_value=bad_sock),
+        ):
+            with self.assertRaises(RuntimeError):
+                find_free_port()
+
+        bad_sock.close.assert_called_once()
+
+    def test_raises_runtime_error_when_all_attempts_fail(self):
+        # Every address failing at socket() creation ends in the documented
+        # RuntimeError rather than an UnboundLocalError.
+        with (
+            mock.patch("socket.getaddrinfo", return_value=self.ADDRS),
+            mock.patch("socket.socket", side_effect=OSError("socket failed")),
+        ):
+            with self.assertRaises(RuntimeError):
+                find_free_port()

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,15 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
## Summary

`find_free_port()` in `torch/distributed/elastic/rendezvous/etcd_server.py` called `s.close()` from its `except OSError` block even when `socket.socket()` itself raised. In that case `s` was never assigned, so cleanup raised an `UnboundLocalError` that masked the real socket error and stopped the loop from trying the remaining addresses.

This change initializes `s` to `None` before the `try` and only closes it when a socket was actually created. As a result:

- The original `OSError` diagnostics are preserved (via the existing print), instead of being replaced by a misleading local-variable error.
- The loop continues through the remaining addresses returned by `getaddrinfo()`.
- The function still ends in its documented `RuntimeError("Failed to create a socket")` when every attempt fails.

The now-unnecessary `# type: ignore[possibly-undefined]` comment is removed since `s` is always bound.

Fixes #191395

## Test plan

Added `FindFreePortTest` in `test/distributed/elastic/rendezvous/etcd_server_test.py` with mocked sockets:

- [x] `socket.socket()` fails on the first address, succeeds on the second: asserts the second address is tried and no `UnboundLocalError` escapes.
- [x] `bind()` fails on a successfully created socket: asserts that socket is closed.
- [x] Every address fails at `socket()`: asserts `RuntimeError` (not `UnboundLocalError`).

Locally validated the fix and the three scenarios against the edited source; `ruff check`, `ruff format --check`, and `flake8` pass on both changed files.
