### PR TITLE
[DTensor] Fix CommDebugMode hook leak when a module runs twice

### DIFF
--- a/test/distributed/tensor/debug/test_comm_mode.py
+++ b/test/distributed/tensor/debug/test_comm_mode.py
@@ -223,5 +223,50 @@ class TestCommMode(TestCase):
         self.checksAssert(comm_mode, c10d_ops.alltoall_base_, 1, 1)
 
 
+class TestCommModeModuleReuse(TestCase):
+    """Tests that do not require a process group."""
+
+    def test_comm_mode_repeated_module_forward(self):
+        m = torch.nn.Linear(2, 2)
+        with CommDebugMode():
+            m(torch.ones(1, 2))
+            m(torch.ones(1, 2))
+
+        # After exiting, normal forward should still work
+        m(torch.ones(1, 2))
+
+        # No hooks should remain on the module from CommDebugMode
+        self.assertEqual(len(m._forward_hooks), 0)
+        self.assertEqual(len(m._forward_pre_hooks), 0)
+
+    def test_comm_mode_many_forwards(self):
+        m = torch.nn.Linear(2, 2)
+        with CommDebugMode():
+            for _ in range(10):
+                m(torch.ones(1, 2))
+
+        m(torch.ones(1, 2))
+        self.assertEqual(len(m._forward_hooks), 0)
+
+    def test_comm_mode_nested_modules_reuse(self):
+        class TwoLayerMLP(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fc1 = torch.nn.Linear(2, 2)
+                self.fc2 = torch.nn.Linear(2, 2)
+
+            def forward(self, x):
+                return self.fc2(torch.relu(self.fc1(x)))
+
+        m = TwoLayerMLP()
+        with CommDebugMode():
+            m(torch.ones(1, 2))
+            m(torch.ones(1, 2))
+
+        m(torch.ones(1, 2))
+        self.assertEqual(len(m.fc1._forward_hooks), 0)
+        self.assertEqual(len(m.fc2._forward_hooks), 0)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/tensor/debug/_comm_mode.py
+++ b/torch/distributed/tensor/debug/_comm_mode.py
@@ -168,6 +168,8 @@ class _CommModeModuleTracker(ModTracker):
             self.parent_dict[parent].append(self.name)
             self.parent_list.append(self.name)
 
+            if self.name in self.register_forward_hook_handles:
+                self.register_forward_hook_handles[self.name].remove()
             self.register_forward_hook_handles[self.name] = mod.register_forward_hook(
                 self._fw_set_module_hook
             )


### PR DESCRIPTION
Fixes #191392

## Summary

- `_CommModeModuleTracker._fw_pre_hook` registered a new forward hook on every module invocation, storing the handle by module name. On the second invocation of the same module, the new handle overwrote the old one without removing the stale hook, causing `IndexError` from a double-pop of `parent_list` and leaking hooks after context exit.
- Fix: remove the existing forward hook handle for a module name before registering a new one, ensuring only one hook is active per module at any time.

## Test plan

```
python test/distributed/tensor/debug/test_comm_mode.py -v
```

All 7 tests pass (4 existing + 3 new regression tests):
- `test_comm_mode_repeated_module_forward` — runs module twice, verifies no error and no leaked hooks
- `test_comm_mode_many_forwards` — runs module 10 times in a loop
- `test_comm_mode_nested_modules_reuse` — nested two-layer MLP run twice

cc @wanchaol @weifengpy @wz337