### PR TITLE
Restore MemoryTracker operation count on load

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,6 +1,10 @@
 # Owner(s): ["oncall: distributed"]
+import io
 import os
+import tempfile
 import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
 
 import torch
 import torch.nn as nn
@@ -9,6 +13,37 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestMemoryTracker(TestCase):
+    def test_load_restores_op_index(self):
+        with patch.object(torch, "get_device_module"):
+            tracker = MemoryTracker()
+            loaded_tracker = MemoryTracker()
+
+        tracker.memories_allocated = {
+            0: ("initial", 1.0),
+            1: ("aten.mm", 3.0),
+        }
+        tracker.memories_active = {
+            0: ("initial", 1.0),
+            1: ("aten.mm", 2.0),
+        }
+        tracker.memories_reserved = {
+            0: ("initial", 2.0),
+            1: ("aten.mm", 4.0),
+        }
+        tracker._op_index = 2
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "memory.trace")
+            tracker.save_stats(path)
+            loaded_tracker.load(path)
+
+        self.assertEqual(loaded_tracker._op_index, tracker._op_index)
+        with redirect_stdout(io.StringIO()) as expected_output:
+            tracker.summary()
+        with redirect_stdout(io.StringIO()) as actual_output:
+            loaded_tracker.summary()
+        self.assertEqual(actual_output.getvalue(), expected_output.getvalue())
+
     @unittest.skipIf(not torch.accelerator.is_available(), "no accelerator")
     def test_local_model(self):
         """

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -227,6 +227,7 @@ class MemoryTracker:
         self.memories_reserved = stats["memories_reserved"]
         self._markers = stats["markers"]
         self._num_alloc_retries = stats["num_alloc_retries"]
+        self._op_index = len(self.memories_allocated)
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """Prefix operator name with current module and 'forward', and insert 'fw_start' marker at forward pass start."""


### PR DESCRIPTION
Fixes #191397

## Summary

- reconstruct `MemoryTracker._op_index` from the loaded allocation records
- keep the existing pickle format unchanged so previously saved stats files remain compatible
- add a CPU-compatible round-trip test that loads stats into a fresh tracker and compares the restored operation count and summary output

## Root cause

`save_stats()` persists the recorded memory dictionaries, but `load()` did not restore the operation count used by `summary()`. A fresh tracker therefore retained `_op_index == 0` even though its loaded records were present.

## Testing

Using Python 3.12 and `torch==2.14.0.dev20260728+cpu`, with the modified module copied into the nightly wheel environment:

- `python -m pytest -q test/distributed/_tools/test_memory_tracker.py`
  - `1 passed, 1 skipped`
  - the existing accelerator test was skipped because the environment used a CPU-only wheel

This was a wheel-based validation of the Python changes rather than a full source build; repository CI will provide source-integration coverage.

## AI assistance disclosure

This change was developed with assistance from OpenAI Codex. I reviewed the code and test changes and ran the test reported above.
