### PR TITLE
[Testcase Refactoring] Make test_cuda_event_eq device-agnostic via instantiate_device_type_tests

### DIFF
--- a/test/dynamo/test_tp_richcompare.py
+++ b/test/dynamo/test_tp_richcompare.py
@@ -2,13 +2,14 @@
 """Tests for tp_richcompare_impl: unified comparison protocol in Dynamo."""
 
 import operator
-import unittest
 
 import torch
 import torch._dynamo
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._library.opaque_object import register_custom_class
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class _OpaqueVal(torch._custom_class_base.CustomClassBase):
@@ -34,6 +35,8 @@ register_custom_class(_OpaqueVal, typ="constant", hoist=True)
 
 
 class TpRichcompareTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _assert_cmp_equals(self, a, b, op, *, expect_type_error=None):
         """Assert Dynamo's op(a, b) matches eager Python's op(a, b).
 
@@ -1574,21 +1577,6 @@ class TpRichcompareTests(torch._dynamo.test_case.TestCase):
             torch.compile(fn, backend="eager", fullgraph=True)([1, 2])
 
     # =====================================================================
-    # Event comparison (EventVariable)
-    # =====================================================================
-
-    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
-    def test_cuda_event_eq(self):
-        def fn(e1, e2):
-            return e1 == e2, e1 != e2, e1 == e1
-
-        e1 = torch.cuda.Event()
-        e2 = torch.cuda.Event()
-        expected = fn(e1, e2)
-        result = torch.compile(fn, backend="eager", fullgraph=True)(e1, e2)
-        self.assertEqual(result, expected)
-
-    # =====================================================================
     # itertools module comparison (ItertoolsVariable)
     # =====================================================================
 
@@ -1925,6 +1913,38 @@ class TpRichcompareTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(len(expected), len(result))
         for e, r in zip(expected, result):
             self.assertIs(r, e)
+
+
+# =====================================================================
+# Event comparison (EventVariable)
+# =====================================================================
+
+
+class TestEventComparisonDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_accelerator_event_eq(self, device):
+        def fn(e1, e2):
+            return e1 == e2, e1 != e2, e1 == e1
+
+        # torch.Event(device=device) and torch.<device>.Event() are
+        # different classes; test both to ensure Dynamo handles them
+        # correctly.
+        def Event():
+            return torch.Event(device=device)
+
+        def DeviceEvent():
+            return torch.get_device_module(device).Event()
+
+        for EventFactory in (Event, DeviceEvent):
+            e1 = EventFactory()
+            e2 = EventFactory()
+            expected = fn(e1, e2)
+            result = torch.compile(fn, backend="eager", fullgraph=True)(e1, e2)
+            self.assertEqual(result, expected)
+
+
+instantiate_device_type_tests(TestEventComparisonDevice, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_tp_richcompare.py
+++ b/test/dynamo/test_tp_richcompare.py
@@ -2,13 +2,14 @@
 """Tests for richcompare_impl: unified comparison protocol in Dynamo."""
 
 import operator
-import unittest
 
 import torch
 import torch._dynamo
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._library.opaque_object import register_custom_class
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class _OpaqueVal(torch._custom_class_base.CustomClassBase):
@@ -34,6 +35,8 @@ register_custom_class(_OpaqueVal, typ="constant", hoist=True)
 
 
 class TpRichcompareTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _assert_cmp_equals(self, a, b, op, *, expect_type_error=None):
         """Assert Dynamo's op(a, b) matches eager Python's op(a, b).
 
@@ -1577,17 +1580,6 @@ class TpRichcompareTests(torch._dynamo.test_case.TestCase):
     # Event comparison (EventVariable)
     # =====================================================================
 
-    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
-    def test_cuda_event_eq(self):
-        def fn(e1, e2):
-            return e1 == e2, e1 != e2, e1 == e1
-
-        e1 = torch.cuda.Event()
-        e2 = torch.cuda.Event()
-        expected = fn(e1, e2)
-        result = torch.compile(fn, backend="eager", fullgraph=True)(e1, e2)
-        self.assertEqual(result, expected)
-
     # =====================================================================
     # itertools module comparison (ItertoolsVariable)
     # =====================================================================
@@ -1898,6 +1890,26 @@ class TpRichcompareTests(torch._dynamo.test_case.TestCase):
         expected = fn(ks1, ks2)
         result = torch.compile(fn, backend="eager", fullgraph=True)(ks1, ks2)
         self.assertEqual(result, expected)
+
+
+class TestEventComparisonDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_accelerator_event_eq(self, device):
+        def fn(e1, e2):
+            return e1 == e2, e1 != e2, e1 == e1
+
+        def Event():
+            return torch.Event(device=device)
+
+        e1 = Event()
+        e2 = Event()
+        expected = fn(e1, e2)
+        result = torch.compile(fn, backend="eager", fullgraph=True)(e1, e2)
+        self.assertEqual(result, expected)
+
+
+instantiate_device_type_tests(TestEventComparisonDevice, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Make `test_cuda_event_eq` device-agnostic by replacing `@unittest.skipUnless(torch.cuda.is_available())` + `torch.cuda.Event()` with `instantiate_device_type_tests` + `device` parameter, as part of #185590.

## Changes

- Remove `test_cuda_event_eq` from `TpRichcompareTests` (was CUDA-only with `@unittest.skipUnless`)
- Add `TestEventComparisonDevice` class with `test_accelerator_event_eq(self, device)`
- Test both `torch.Event(device=device)` and `torch.<device>.Event()` to ensure Dynamo handles both Event classes correctly (per review feedback from @fffrog)
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `TestEventComparisonDevice`
- Add `hw_classification = HardwareClassification.GENERIC` to `TpRichcompareTests` (existing device-agnostic tests)
- Add `instantiate_device_type_tests(TestEventComparisonDevice, globals(), except_for="cpu")` call
- Rename `test_cuda_event_eq` to `test_accelerator_event_eq` (no longer CUDA-specific)
- Remove `import unittest` (no longer used)

## Motivation

The original test used `@unittest.skipUnless(torch.cuda.is_available())` and `torch.cuda.Event()`, which skips on all non-CUDA accelerators. By using `instantiate_device_type_tests` with `except_for="cpu"`, the test runs on all non-CPU device types including out-of-tree backends (e.g., Ascend NPU via PrivateUse1).

Both `torch.Event(device=device)` and `torch.<device>.Event()` are tested since they are different classes (e.g., `torch.Event` vs `torch.cuda.Event` vs `torch.npu.Event`), and Dynamo should handle both correctly.

## Test Plan

Verified on CPU (no GPU):

```bash
python -m pytest test/dynamo/test_tp_richcompare.py -v --tb=short
# Result: 167 passed, 1 skipped (ACCELERATOR excluded by except_for="cpu")
```

Verified on NPU (Ascend 910B4):

```bash
python -m pytest test/dynamo/test_tp_richcompare.py -v --tb=short
# Result: 168 passed, 0 failed (167 GENERIC + 1 ACCELERATOR via PrivateUse1)
```

## Verification Report

### Verification Results

| Hardware | Cases | Passed | Failed | Skipped | Result |
|----------|-------|--------|--------|---------|--------|
| CPU (no GPU) | 168 | 167 | 0 | 1 | ACCELERATOR test excluded by `except_for="cpu"` |
| NPU (Ascend 910B4) | 168 | 168 | 0 | 0 | All passed (167 GENERIC + 1 ACCELERATOR via PrivateUse1) |

### Environment

| Item | Version |
|------|---------|
| PyTorch | 2.14.0.dev20260810+cpu |
| torch_npu | 2.14.0+gitc775ad3 |
| CANN | 9.1.0 GA |
| NPU | Ascend 910B4 |
| Python | 3.12.13 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98