### PR TITLE
[TEST] Add 'skipIfNoAccelerator' in 'test/onnx/pytorch_test_common.py'

### DIFF
--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -10,6 +10,7 @@ import torch
 from torch.onnx._internal.exporter import _testing as onnx_testing
 from torch.onnx.ops import _impl, _symbolic_impl
 from torch.testing._internal import common_utils
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.utils._python_dispatch import TorchDispatchMode
 
 
@@ -496,7 +497,6 @@ class SymbolicOpsTest(common_utils.TestCase):
             )
 
 
-@common_utils.instantiate_parametrized_tests
 class NativeOnnxOpsTest(common_utils.TestCase):
     def export(self, model, args=(), kwargs=None, **options) -> torch.onnx.ONNXProgram:
         onnx_program = torch.onnx.export(
@@ -1581,7 +1581,8 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         )
 
         onnx_testing.assert_onnx_program(onnx_program)
-
+        
+instantiate_device_type_tests(NativeOnnxOpsTest, globals())
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -50,6 +50,10 @@ def _skipper(condition, reason):
 
 skipIfNoCuda = _skipper(lambda: not torch.cuda.is_available(), "CUDA is not available")
 
+skipIfNoAccelerator = _skipper(
+    lambda: not torch.accelerator.is_available(), "Accelerator is not available"
+)
+
 skipIfTravis = _skipper(lambda: os.getenv("TRAVIS"), "Skip In Travis")
 
 skipIfNoBFloat16Cuda = _skipper(


### PR DESCRIPTION
[TEST] Add 'skipIfNoAccelerator' in 'test/onnx/pytorch_test_common.py'

## Summary:
-Add a generic 'skipIfNoAccelerator' decorator.

## Changes:
-Add a generic 'skipIfNoAccelerator' decorator in  'test/onnx/pytorch_test_common.py'.

## Motivation:
-Some test cases need generic 'skipIfNoAccelerator' decorator that uses 'torch.accelerator.is_available()' to run on GPU XPU and NPU.