### PR TITLE
[Testcase Refactoring] Make test cases in 'test_pytorch_onnx_onnxruntime_cuda.py'  hardware-agnostic and cross-platform

### DIFF
--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -10,6 +10,7 @@ import torch
 from torch.onnx._internal.exporter import _testing as onnx_testing
 from torch.onnx.ops import _impl, _symbolic_impl
 from torch.testing._internal import common_utils
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.utils._python_dispatch import TorchDispatchMode
 
 
@@ -496,7 +497,6 @@ class SymbolicOpsTest(common_utils.TestCase):
             )
 
 
-@common_utils.instantiate_parametrized_tests
 class NativeOnnxOpsTest(common_utils.TestCase):
     def export(self, model, args=(), kwargs=None, **options) -> torch.onnx.ONNXProgram:
         onnx_program = torch.onnx.export(
@@ -1581,7 +1581,8 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         )
 
         onnx_testing.assert_onnx_program(onnx_program)
-
+        
+instantiate_device_type_tests(NativeOnnxOpsTest, globals())
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -50,6 +50,10 @@ def _skipper(condition, reason):
 
 skipIfNoCuda = _skipper(lambda: not torch.cuda.is_available(), "CUDA is not available")
 
+skipIfNoAccelerator = _skipper(
+    lambda: not torch.accelerator.is_available(), "Accelerator is not available"
+)
+
 skipIfTravis = _skipper(lambda: os.getenv("TRAVIS"), "Skip In Travis")
 
 skipIfNoBFloat16Cuda = _skipper(

--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -8,7 +8,7 @@ import parameterized
 from onnx_test_common import MAX_ONNX_OPSET_VERSION, MIN_ONNX_OPSET_VERSION
 from pytorch_test_common import (
     skipIfNoBFloat16Cuda,
-    skipIfNoCuda,
+    skipIfNoAccelerator,
     skipIfUnsupportedMinOpsetVersion,
     skipScriptTest,
 )
@@ -17,7 +17,9 @@ from test_pytorch_onnx_onnxruntime import _parameterized_class_attrs_and_values
 import torch
 from torch.cuda.amp import autocast
 from torch.testing._internal import common_utils
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
+device_type = getattr(torch.accelerator.current_accelerator(), "type", None)
 
 @parameterized.parameterized_class(
     **_parameterized_class_attrs_and_values(
@@ -35,7 +37,7 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
             raise unittest.SkipTest(f"onnxruntime {cls.ort_backend} is not available")
 
     @skipIfUnsupportedMinOpsetVersion(9)
-    @skipIfNoCuda
+    @skipIfNoAccelerator
     def test_gelu_fp16(self):
         class GeluModel(torch.nn.Module):
             def forward(self, x):
@@ -48,12 +50,12 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
             6,
             requires_grad=True,
             dtype=torch.float16,
-            device=torch.device("cuda"),
+            device=device_type,
         )
         self.run_test(GeluModel(), x, rtol=1e-3, atol=1e-5)
 
     @skipIfUnsupportedMinOpsetVersion(9)
-    @skipIfNoCuda
+    @skipIfNoAccelerator
     @skipScriptTest()
     def test_layer_norm_fp16(self):
         class LayerNormModel(torch.nn.Module):
@@ -72,12 +74,12 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
             10,
             requires_grad=True,
             dtype=torch.float16,
-            device=torch.device("cuda"),
+            device=device_type,
         )
         self.run_test(LayerNormModel().cuda(), x, rtol=1e-3, atol=1e-5)
 
     @skipIfUnsupportedMinOpsetVersion(12)
-    @skipIfNoCuda
+    @skipIfNoAccelerator
     @skipScriptTest()
     def test_softmaxCrossEntropy_fusion_fp16(self):
         class FusionModel(torch.nn.Module):
@@ -92,8 +94,8 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
                 return output
 
         N, C = 5, 4
-        input = torch.randn(N, 16, dtype=torch.float16, device=torch.device("cuda"))
-        target = torch.empty(N, dtype=torch.long, device=torch.device("cuda")).random_(
+        input = torch.randn(N, 16, dtype=torch.float16, device=device_type)
+        target = torch.empty(N, dtype=torch.long, device=device_type).random_(
             0, C
         )
 
@@ -101,7 +103,7 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
         target[target == 1] = -100
         self.run_test(FusionModel(), (input, target))
 
-    @skipIfNoCuda
+    @skipIfNoAccelerator
     @skipScriptTest()
     def test_apex_o2(self):
         class LinearModel(torch.nn.Module):
@@ -116,7 +118,7 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
             from apex import amp
         except Exception as e:
             raise unittest.SkipTest("Apex is not available") from e
-        input = torch.randn(3, 3, device=torch.device("cuda"))
+        input = torch.randn(3, 3, device=device_type)
         model = amp.initialize(LinearModel(), opt_level="O2")
         self.run_test(model, input)
 
@@ -127,18 +129,18 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
     def test_arithmetic_bfp16(self):
         class MyModule(torch.nn.Module):
             def forward(self, x):
-                y = torch.ones(3, 4, dtype=torch.bfloat16, device=torch.device("cuda"))
+                y = torch.ones(3, 4, dtype=torch.bfloat16, device=device_type)
                 x = x.type_as(y)
                 return torch.mul(torch.add(x, y), torch.sub(x, y)).to(
                     dtype=torch.float16
                 )
 
         x = torch.ones(
-            3, 4, requires_grad=True, dtype=torch.float16, device=torch.device("cuda")
+            3, 4, requires_grad=True, dtype=torch.float16, device=device_type
         )
         self.run_test(MyModule(), x, rtol=1e-3, atol=1e-5)
 
-    @skipIfNoCuda
+    @skipIfNoAccelerator
     def test_deduplicate_initializers_diff_devices(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:
@@ -146,15 +148,16 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
                 self.w = torch.nn.Parameter(
                     torch.ones(2, 3, device=torch.device("cpu"))
                 )
-                self.b = torch.nn.Parameter(torch.ones(3, device=torch.device("cuda")))
+                self.b = torch.nn.Parameter(torch.ones(3, device=device_type))
 
             def forward(self, x, y):
                 return torch.matmul(self.w, x), y + self.b
 
         x = torch.randn(3, 3, device=torch.device("cpu"))
-        y = torch.randn(3, 3, device=torch.device("cuda"))
+        y = torch.randn(3, 3, device=device_type)
         self.run_test(Model(), (x, y))
 
+instantiate_device_type_tests(TestONNXRuntime_cuda, globals())
 
 if __name__ == "__main__":
     common_utils.run_tests()


### PR DESCRIPTION
[TEST] Make test cases in 'test_pytorch_onnx_onnxruntime_cuda.py'  hardware-agnostic and cross-platform

Summary:
-This PR makes test cases in 'test_pytorch_onnx_onnxruntime_cuda.py'  hardware-agnostic and cross-platform by using accelerator abstraction 'device_type' instead of hardcoding 'cuda'.

## Changes:
- Import instantiate_device_type_tests from common_device_type and call instantiate_device_type_tests(TestONNXRuntime_cuda, globals()) at module level so the test class is instantiated per device type.
- Replace hardcoded "cuda" device strings with a device_type variable derived from torch.accelerator.current_accelerator(), allowing the tests to run on any available accelerator (CUDA, XPU, NPU, etc.).
- Replace skipIfNoCuda with skipIfNoAccelerator for tests that require an accelerator but are not CUDA-specific (e.g. test_gelu_fp16, test_layer_norm_fp16, test_softmaxCrossEntropy_fusion_fp16, test_apex_o2, test_deduplicate_initializers_diff_devices).

## Motivation:
The ONNX Runtime CUDA tests were tightly coupled to CUDA via hardcoded device strings and skipIfNoCuda decorators. By adopting instantiate_device_type_tests and the accelerator abstraction, the same test suite can be reused across different accelerator backends without duplicating test code. This aligns with PyTorch's broader effort to support multiple accelerator backends and reduces device-specific test maintenance burden.