### PR TITLE
[Distributed] Remove duplicate unreachable return in functional collectives fallback

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -33,8 +33,6 @@ except Exception:
 
     def is_torchdynamo_compiling():  # type: ignore[misc]
         return False
-        # pyrefly: ignore [unreachable]
-        return False
 
 
 """


### PR DESCRIPTION
## Summary

Fixes #191400

## Problem

The fallback definition of `is_torchdynamo_compiling()` in `torch/distributed/_functional_collectives.py` contains two consecutive `return False` statements. The second return and its suppression comment are unreachable:

```python
def is_torchdynamo_compiling():  # type: ignore[misc]
    return False
    # pyrefly: ignore [unreachable]
    return False
```

## Fix

Removed the unreachable second `return False` and the associated linter suppression comment.

```python
def is_torchdynamo_compiling():  # type: ignore[misc]
    return False
```

## Impact

No runtime behavior change. Removes dead code and lint suppression noise from a widely imported distributed module.

## Related

- Closes #191400

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab

🤖 Generated with [Claude Code](https://claude.com/claude-code)