### PR TITLE
[Flight Recorder] Replace raw eval() with ast.literal_eval() for parsing process-group ranks

### DIFF
--- a/torch/distributed/flight_recorder/components/builder.py
+++ b/torch/distributed/flight_recorder/components/builder.py
@@ -116,7 +116,7 @@ def build_groups_memberships(
             _pg_guids[(pg_uid, global_rank)] = pg_guid
             if isinstance(ranks, str):
                 # TODO Bug in FR data format? ranks is '[0, 1,...]'
-                ranks = eval(ranks)
+                ranks = ast.literal_eval(ranks)
 
             if pg_guid not in _groups:
                 groups.append(Group(id=pg_guid, desc=desc, size=len(ranks)))
@@ -398,7 +398,7 @@ def transform_ft(
         rank = dump["rank"]
         for key, pg_config in dump["pg_config"].items():
             if pg_config["desc"] == "default_pg":
-                ranks = eval(pg_config["ranks"])
+                ranks = ast.literal_eval(pg_config["ranks"])
                 replica_id = rank // group_world_size
                 first_rank = replica_id * group_world_size
                 new_ranks = [r + first_rank for r in ranks]


### PR DESCRIPTION
## Summary

Fixes #191399

## Problem

The Flight Recorder's `builder.py` uses raw `eval()` in two places to parse serialized process-group rank lists, but the same parser already uses `ast.literal_eval()` immediately above the first call. The data format is explicitly a Python literal (rank list), so unrestricted evaluation is unnecessary.

## Fix

Replaced `eval()` with `ast.literal_eval()` in both locations:

- **Line 119** (`ranks = eval(ranks)`): Handles double-encoded rank strings
- **Line 401** (`ranks = eval(pg_config["ranks"])`): Parses rank list from default PG config

`ast.literal_eval()` is already imported and used in the same file (line 111), so no additional imports are needed.

## Impact

- Parsing behavior is identical for valid Python literal inputs
- Malformed or non-literal expressions are safely rejected with a `ValueError` instead of being evaluated
- No change to the supported data format

## Related

- Closes #191400

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab

🤖 Generated with [Claude Code](https://claude.com/claude-code)