### PR TITLE
[Elastic] Close file descriptor from mkstemp() in FileStore rendezvous to prevent FD leak

### DIFF
--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,7 +192,8 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."


### PR DESCRIPTION
## Summary

Fixes #191394

## Problem

`_create_file_store()` in `c10d_rendezvous_backend.py` calls `tempfile.mkstemp()` to generate a temporary path for the FileStore, but discards the returned file descriptor using `_`:

```python
_, path = tempfile.mkstemp()
```

`FileStore` opens the path independently, so the descriptor created by `mkstemp()` remains owned by the Python process and is never closed. Each call to `_create_file_store()` without an endpoint leaks one file descriptor.

## Fix

Capture and immediately close the file descriptor:

```python
fd, path = tempfile.mkstemp()
os.close(fd)
```

`os` is already imported in the module.

## Impact

- Prevents file descriptor exhaustion from repeated FileStore rendezvous creation
- No behavioral change — the temporary file and path are unaffected
- The file persists on disk (intended — `FileStore` opens it independently)

## Related

- Closes #191394

cc @dzhulgakov @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab

🤖 Generated with [Claude Code](https://claude.com/claude-code)