### PR TITLE
[Testcase Refactoring] Make test_nativert.py device-agnostic via instantiate + device/label/capability gate

### DIFF
--- a/test/export/test_nativert.py
+++ b/test/export/test_nativert.py
@@ -396,9 +396,7 @@ class TestNativeRTAccelerator(TestNativeRT):
 
 
 instantiate_device_type_tests(TestNativeRT, globals(), only_for="cpu")
-instantiate_device_type_tests(
-    TestNativeRTAccelerator, globals(), except_for="cpu", allow_xpu=True
-)
+instantiate_device_type_tests(TestNativeRTAccelerator, globals(), except_for="cpu")
 
 
 @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")

--- a/test/export/test_nativert.py
+++ b/test/export/test_nativert.py
@@ -20,7 +20,11 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     requires_capabilities,
 )
-from torch.testing._internal.common_utils import HardwareClassification, IS_WINDOWS, parametrize
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_WINDOWS,
+    parametrize,
+)
 from torch.utils import _pytree as pytree
 
 
@@ -216,80 +220,86 @@ def make_dynamic_cls(cls, strict=False):
     test_class.__module__ = __name__
 
 
+def _nativert_aoti_basic_module():
+    class M(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(4, 4)
+            self.relu = torch.nn.ReLU()
+
+        def forward(self, x):
+            return self.relu(self.linear(x))
+
+    return M()
+
+
+def _nativert_aoti_multi_output_module():
+    class MMultiOutput(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(4, 4)
+            self.relu = torch.nn.ReLU()
+
+        def forward(self, x):
+            return (self.relu(self.linear(x)), x)
+
+    return MMultiOutput()
+
+
+def _nativert_aoti_pytree_module():
+    class M(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear1 = torch.nn.Linear(4, 4)
+            self.linear2 = torch.nn.Linear(4, 4)
+
+        def forward(self, x):
+            x1, (x2, x3) = x
+            y1 = self.linear1(x1)
+            y2 = self.linear2(x2)
+            y3 = self.linear2(x3)
+            return (y1, (y2, y3))
+
+    return M()
+
+
+NATIVERT_AOTI_CASES = ("basic", "multi_output", "pytree")
+
+
+def _nativert_aoti_case(device, case):
+    if case == "basic":
+        return _nativert_aoti_basic_module().to(device), (
+            torch.randn(4, 4, device=device),
+        )
+    if case == "multi_output":
+        return (
+            _nativert_aoti_multi_output_module().to(device),
+            (torch.randn(4, 4, device=device),),
+        )
+    if case == "pytree":
+        return (
+            _nativert_aoti_pytree_module().to(device),
+            (
+                (
+                    torch.randn(4, 4, device=device),
+                    (
+                        torch.randn(4, 4, device=device),
+                        torch.randn(4, 4, device=device),
+                    ),
+                ),
+            ),
+        )
+    raise AssertionError(f"unknown aoti case: {case}")
+
+
 @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 @unittest.skipIf(not is_fbcode(), "FBcode only for now")
 class TestNativeRT(TestCase):
     hw_classification = HardwareClassification.CPU
 
-    @staticmethod
-    def get_module():
-        class M(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.linear = torch.nn.Linear(4, 4)
-                self.relu = torch.nn.ReLU()
-
-            def forward(self, x):
-                return self.relu(self.linear(x))
-
-        return M()
-
-    @staticmethod
-    def get_module_multi_output():
-        class MMultiOutput(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.linear = torch.nn.Linear(4, 4)
-                self.relu = torch.nn.ReLU()
-
-            def forward(self, x):
-                return (self.relu(self.linear(x)), x)
-
-        return MMultiOutput()
-
-    @staticmethod
-    def get_model_pytree():
-        class M(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.linear1 = torch.nn.Linear(4, 4)
-                self.linear2 = torch.nn.Linear(4, 4)
-
-            def forward(self, x):
-                x1, (x2, x3) = x
-                y1 = self.linear1(x1)
-                y2 = self.linear2(x2)
-                y3 = self.linear2(x3)
-                return (y1, (y2, y3))
-
-        return M()
-
-    def _aoti_case(self, device, case):
-        if case == "basic":
-            return self.get_module().to(device), (torch.randn(4, 4, device=device),)
-        if case == "multi_output":
-            return (
-                self.get_module_multi_output().to(device),
-                (torch.randn(4, 4, device=device),),
-            )
-        if case == "pytree":
-            return (
-                self.get_model_pytree().to(device),
-                (
-                    (
-                        torch.randn(4, 4, device=device),
-                        (
-                            torch.randn(4, 4, device=device),
-                            torch.randn(4, 4, device=device),
-                        ),
-                    ),
-                ),
-            )
-        raise AssertionError(f"unknown aoti case: {case}")
-
     def _test_aoti(self, device, case):
-        m, sample_inputs = self._aoti_case(device, case)
+        m, sample_inputs = _nativert_aoti_case(device, case)
         MODEL_NAME = "model"
         BACKEND_ID = "aoti"
 
@@ -371,7 +381,7 @@ class TestNativeRT(TestCase):
                 else:
                     raise e
 
-    @parametrize("case", ["basic", "multi_output", "pytree"])
+    @parametrize("case", NATIVERT_AOTI_CASES)
     def test_aoti(self, device, case):
         self._test_aoti(device, case)
 
@@ -383,7 +393,7 @@ class TestNativeRTTriton(TestNativeRT):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @requires_capabilities(Capability.lib.triton)
-    @parametrize("case", ["basic", "multi_output", "pytree"])
+    @parametrize("case", NATIVERT_AOTI_CASES)
     def test_aoti(self, device, case):
         self._test_aoti(device, case)
 

--- a/test/export/test_nativert.py
+++ b/test/export/test_nativert.py
@@ -16,7 +16,7 @@ from torch.nativert.backends._lower_utils import (
     package_nativert_with_aoti_delegate,
 )
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import IS_WINDOWS, parametrize
+from torch.testing._internal.common_utils import HardwareClassification, IS_WINDOWS, parametrize
 from torch.utils._triton import has_triton, has_triton_package
 from torch.utils import _pytree as pytree
 
@@ -217,6 +217,8 @@ def make_dynamic_cls(cls, strict=False):
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 @unittest.skipIf(not is_fbcode(), "FBcode only for now")
 class TestNativeRT(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @staticmethod
     def get_module():
         class M(torch.nn.Module):
@@ -378,6 +380,8 @@ instantiate_device_type_tests(TestNativeRT, globals())
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 @unittest.skipIf(not is_fbcode(), "FBcode only for now")
 class TestSelectScalarOverload(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_floor_divide_default_scalar(self) -> None:
         # PT2 export lowers `x // 10` to aten.floor_divide.default with a scalar
         # Int argument (the #90923 Scalar->Tensor broadcast).  Its default

--- a/test/export/test_nativert.py
+++ b/test/export/test_nativert.py
@@ -15,9 +15,12 @@ from torch.nativert.backends._lower_utils import (
     lower_exported_program,
     package_nativert_with_aoti_delegate,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_utils import HardwareClassification, IS_WINDOWS, parametrize
-from torch.utils._triton import has_triton, has_triton_package
 from torch.utils import _pytree as pytree
 
 
@@ -285,11 +288,9 @@ class TestNativeRT(TestCase):
             )
         raise AssertionError(f"unknown aoti case: {case}")
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("case", ["basic", "multi_output", "pytree"])
     def test_aoti(self, device, case):
-        if torch.device(device).type != "cpu":
-            if not has_triton_package() or not has_triton():
-                self.skipTest("requires triton")
         m, sample_inputs = self._aoti_case(device, case)
         MODEL_NAME = "model"
         BACKEND_ID = "aoti"

--- a/test/export/test_nativert.py
+++ b/test/export/test_nativert.py
@@ -220,7 +220,7 @@ def make_dynamic_cls(cls, strict=False):
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 @unittest.skipIf(not is_fbcode(), "FBcode only for now")
 class TestNativeRT(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
+    hw_classification = HardwareClassification.CPU
 
     @staticmethod
     def get_module():
@@ -288,9 +288,7 @@ class TestNativeRT(TestCase):
             )
         raise AssertionError(f"unknown aoti case: {case}")
 
-    @requires_capabilities(Capability.lib.triton)
-    @parametrize("case", ["basic", "multi_output", "pytree"])
-    def test_aoti(self, device, case):
+    def _test_aoti(self, device, case):
         m, sample_inputs = self._aoti_case(device, case)
         MODEL_NAME = "model"
         BACKEND_ID = "aoti"
@@ -373,8 +371,25 @@ class TestNativeRT(TestCase):
                 else:
                     raise e
 
+    @parametrize("case", ["basic", "multi_output", "pytree"])
+    def test_aoti(self, device, case):
+        self._test_aoti(device, case)
 
-instantiate_device_type_tests(TestNativeRT, globals())
+
+@unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
+@unittest.skipIf(not is_fbcode(), "FBcode only for now")
+class TestNativeRTTriton(TestNativeRT):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_capabilities(Capability.lib.triton)
+    @parametrize("case", ["basic", "multi_output", "pytree"])
+    def test_aoti(self, device, case):
+        self._test_aoti(device, case)
+
+
+instantiate_device_type_tests(TestNativeRT, globals(), only_for="cpu")
+instantiate_device_type_tests(TestNativeRTTriton, globals(), except_for="cpu")
 
 
 @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
@@ -421,6 +436,4 @@ if is_fbcode():
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 
-    # nativert has not been supported on XPU yet.
-    if not torch.xpu.is_available():
-        run_tests()
+    run_tests()

--- a/test/export/test_nativert.py
+++ b/test/export/test_nativert.py
@@ -5,8 +5,6 @@ import copy
 import tempfile
 import unittest
 
-from parameterized import parameterized
-
 import torch
 import torch._dynamo as torchdynamo
 from torch._C._nativert import PyModelRunner
@@ -17,8 +15,9 @@ from torch.nativert.backends._lower_utils import (
     lower_exported_program,
     package_nativert_with_aoti_delegate,
 )
-from torch.testing._internal.common_utils import IS_WINDOWS
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import IS_WINDOWS, parametrize
+from torch.utils._triton import has_triton, has_triton_package
 from torch.utils import _pytree as pytree
 
 
@@ -261,39 +260,35 @@ class TestNativeRT(TestCase):
 
         return M()
 
-    parameters = []
-    for device in ["cpu", "cuda"]:
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            continue
-        for module, sample_inputs in [
-            (get_module.__func__().to(device), (torch.randn(4, 4).to(device),)),
-            (
-                get_module_multi_output.__func__().to(device),
-                (torch.randn(4, 4).to(device),),
-            ),
-            (
-                get_model_pytree.__func__().to(device),
+    def _aoti_case(self, device, case):
+        if case == "basic":
+            return self.get_module().to(device), (torch.randn(4, 4, device=device),)
+        if case == "multi_output":
+            return (
+                self.get_module_multi_output().to(device),
+                (torch.randn(4, 4, device=device),),
+            )
+        if case == "pytree":
+            return (
+                self.get_model_pytree().to(device),
                 (
                     (
-                        torch.randn(4, 4).to(device),
+                        torch.randn(4, 4, device=device),
                         (
-                            torch.randn(4, 4).to(device),
-                            torch.randn(4, 4).to(device),
+                            torch.randn(4, 4, device=device),
+                            torch.randn(4, 4, device=device),
                         ),
                     ),
                 ),
-            ),
-        ]:
-            parameters.append(
-                (
-                    device,
-                    module,
-                    sample_inputs,
-                )
             )
+        raise AssertionError(f"unknown aoti case: {case}")
 
-    @parameterized.expand(parameters)
-    def test_aoti(self, device, m, sample_inputs):
+    @parametrize("case", ["basic", "multi_output", "pytree"])
+    def test_aoti(self, device, case):
+        if torch.device(device).type != "cpu":
+            if not has_triton_package() or not has_triton():
+                self.skipTest("requires triton")
+        m, sample_inputs = self._aoti_case(device, case)
         MODEL_NAME = "model"
         BACKEND_ID = "aoti"
 
@@ -374,6 +369,9 @@ class TestNativeRT(TestCase):
                     pass
                 else:
                     raise e
+
+
+instantiate_device_type_tests(TestNativeRT, globals())
 
 
 @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")

--- a/test/export/test_nativert.py
+++ b/test/export/test_nativert.py
@@ -8,6 +8,7 @@ import unittest
 import torch
 import torch._dynamo as torchdynamo
 from torch._C._nativert import PyModelRunner
+from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.test_case import TestCase
 from torch._environment import is_fbcode
 from torch._subclasses.fake_tensor import FakeTensor
@@ -15,17 +16,14 @@ from torch.nativert.backends._lower_utils import (
     lower_exported_program,
     package_nativert_with_aoti_delegate,
 )
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     IS_WINDOWS,
     parametrize,
 )
 from torch.utils import _pytree as pytree
+from torch.utils._triton import has_triton_package
 
 
 try:
@@ -266,6 +264,15 @@ def _nativert_aoti_pytree_module():
 NATIVERT_AOTI_CASES = ("basic", "multi_output", "pytree")
 
 
+def _ensure_triton(test_case, device):
+    if not has_triton_package():
+        test_case.skipTest("requires triton")
+    torch_device = torch.device(device)
+    get_interface_for_device(torch_device.type).raise_if_triton_unavailable(
+        torch_device
+    )
+
+
 def _nativert_aoti_case(device, case):
     if case == "basic":
         return _nativert_aoti_basic_module().to(device), (
@@ -389,17 +396,19 @@ class TestNativeRT(TestCase):
 @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 @unittest.skipIf(not is_fbcode(), "FBcode only for now")
-class TestNativeRTTriton(TestNativeRT):
+class TestNativeRTAccelerator(TestNativeRT):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @requires_capabilities(Capability.lib.triton)
     @parametrize("case", NATIVERT_AOTI_CASES)
     def test_aoti(self, device, case):
+        _ensure_triton(self, device)
         self._test_aoti(device, case)
 
 
 instantiate_device_type_tests(TestNativeRT, globals(), only_for="cpu")
-instantiate_device_type_tests(TestNativeRTTriton, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestNativeRTAccelerator, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")

--- a/test/export/test_nativert.py
+++ b/test/export/test_nativert.py
@@ -8,7 +8,6 @@ import unittest
 import torch
 import torch._dynamo as torchdynamo
 from torch._C._nativert import PyModelRunner
-from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.test_case import TestCase
 from torch._environment import is_fbcode
 from torch._subclasses.fake_tensor import FakeTensor
@@ -22,8 +21,8 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     parametrize,
 )
+from torch.testing._internal.inductor_utils import HAS_TRITON
 from torch.utils import _pytree as pytree
-from torch.utils._triton import has_triton_package
 
 
 try:
@@ -264,15 +263,6 @@ def _nativert_aoti_pytree_module():
 NATIVERT_AOTI_CASES = ("basic", "multi_output", "pytree")
 
 
-def _ensure_triton(test_case, device):
-    if not has_triton_package():
-        test_case.skipTest("requires triton")
-    torch_device = torch.device(device)
-    get_interface_for_device(torch_device.type).raise_if_triton_unavailable(
-        torch_device
-    )
-
-
 def _nativert_aoti_case(device, case):
     if case == "basic":
         return _nativert_aoti_basic_module().to(device), (
@@ -396,12 +386,12 @@ class TestNativeRT(TestCase):
 @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 @unittest.skipIf(not is_fbcode(), "FBcode only for now")
+@unittest.skipUnless(HAS_TRITON, "requires triton")
 class TestNativeRTAccelerator(TestNativeRT):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @parametrize("case", NATIVERT_AOTI_CASES)
     def test_aoti(self, device, case):
-        _ensure_triton(self, device)
         self._test_aoti(device, case)
 
 

--- a/test/export/test_nativert.py
+++ b/test/export/test_nativert.py
@@ -289,12 +289,7 @@ def _nativert_aoti_case(device, case):
     raise AssertionError(f"unknown aoti case: {case}")
 
 
-@unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
-@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
-@unittest.skipIf(not is_fbcode(), "FBcode only for now")
-class TestNativeRT(TestCase):
-    hw_classification = HardwareClassification.CPU
-
+class _NativeRTAOTI:
     def _test_aoti(self, device, case):
         m, sample_inputs = _nativert_aoti_case(device, case)
         MODEL_NAME = "model"
@@ -378,16 +373,28 @@ class TestNativeRT(TestCase):
                 else:
                     raise e
 
-    @parametrize("case", NATIVERT_AOTI_CASES)
-    def test_aoti(self, device, case):
-        self._test_aoti(device, case)
+
+@unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
+@unittest.skipIf(not is_fbcode(), "FBcode only for now")
+class TestNativeRT(_NativeRTAOTI, TestCase):
+    hw_classification = HardwareClassification.CPU
+
+    def test_aoti_basic(self):
+        self._test_aoti("cpu", "basic")
+
+    def test_aoti_multi_output(self):
+        self._test_aoti("cpu", "multi_output")
+
+    def test_aoti_pytree(self):
+        self._test_aoti("cpu", "pytree")
 
 
 @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 @unittest.skipIf(not is_fbcode(), "FBcode only for now")
 @unittest.skipUnless(HAS_TRITON, "requires triton")
-class TestNativeRTAccelerator(TestNativeRT):
+class TestNativeRTAccelerator(_NativeRTAOTI, TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @parametrize("case", NATIVERT_AOTI_CASES)
@@ -395,7 +402,6 @@ class TestNativeRTAccelerator(TestNativeRT):
         self._test_aoti(device, case)
 
 
-instantiate_device_type_tests(TestNativeRT, globals(), only_for="cpu")
 instantiate_device_type_tests(TestNativeRTAccelerator, globals(), except_for="cpu")
 
 


### PR DESCRIPTION
## Summary
This PR migrates NativeRT AOTI coverage in `test/export/test_nativert.py` from `parameterized.expand(["cpu", "cuda"])` to a CPU suite that is always collected plus `instantiate_device_type_tests` for accelerators (injected `device`), so CUDA / privateuse1 can be generated without using `GPU_TYPE` / `HAS_GPU` as the entry path.

This is **instantiate groundwork**. The existing `@skipIf(not is_fbcode())` gate is unchanged. OSS / NPU hosts still skip these classes. fbcode's `get_device_type_test_bases()` never adds `PrivateUse1TestBase`, so NPU does not run in either environment until that gate is lifted separately.

## Changes
- `TestNativeRT` (`HardwareClassification.CPU`) is **not** passed to `instantiate_device_type_tests`. fbcode GPU hosts only expose `CUDATestBase`; `only_for="cpu"` would delete the class and silently drop the three CPU AOTI cases that `parameterized.expand(["cpu", "cuda"])` always emitted. CPU cases stay as `test_aoti_basic` / `test_aoti_multi_output` / `test_aoti_pytree`.
- `TestNativeRTAccelerator` (`HardwareClassification.ACCELERATOR`, `except_for="cpu"`) is instantiated. Triton gating stays `@unittest.skipUnless(HAS_TRITON, ...)` (unchanged; not switched to `DeviceInterface.raise_if_triton_unavailable`).
- Shared helper lives on `_NativeRTAOTI` so the accelerator class does not inherit the CPU `test_aoti_*` methods (instantiate subclasses the generic class).
- `TestSelectScalarOverload`: `HardwareClassification.GENERIC`.
- XPU is not instantiated (`allow_xpu` is not set). The file-level `if not torch.xpu.is_available()` guard was already dropped in a prior commit on this PR; remaining suites in this file are still fbcode-gated.

## Test Plan
No Meta/fbcode host. `is_fbcode()` is False here, so these skip at runtime; the check is that the generated names exist (not 0 tests).

```bash
python3 -m py_compile test/export/test_nativert.py

# CPU-only host: 4 skipped (fbcode). Classes: TestNativeRT, TestSelectScalarOverload.
/home/y00839695/npu-pytorch-214/run_test.sh cpu test/export/test_nativert.py -v

# NPU: run_test.sh imports torch_npu and sets PYTORCH_TESTING_DEVICE_ONLY_FOR=npu.
# 7 skipped. Extra class TestNativeRTAcceleratorPRIVATEUSE1.
/home/y00839695/npu-pytorch-214/run_test.sh npu \
  test/export/test_nativert.py -v
```

Collected names:

- CPU: `TestNativeRT.test_aoti_{basic,multi_output,pytree}`
- NPU: same three, plus `TestNativeRTAcceleratorPRIVATEUSE1.test_aoti_case_{basic,multi_output,pytree}_npu`

Do not use `-k TestNativeRTAccelerator` (generic name is deleted by instantiate).
