### PR TITLE
[Elastic] Fix UnboundLocalError when socket creation fails in find_free_port

### DIFF
--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,15 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
## Summary

Fixes #191395

## Problem

`find_free_port()` in `etcd_server.py` assigns `s` inside a `try` block but unconditionally calls `s.close()` in the `except OSError` handler. If `socket.socket()` itself raises on the first address, `s` is never assigned and the cleanup raises `UnboundLocalError`, masking the actual socket error.

The existing `# type: ignore[possibly-undefined]` comment confirms this was a known issue.

## Fix

Initialize `s = None` before the try block and guard `s.close()` with a null check. This correctly handles both cases:

- **socket() fails**: `s` is `None`, close is skipped, original error propagates
- **bind()/listen() fails**: `s` is a valid socket, it is closed before continuing to the next address

## Impact

Socket creation/bind/listen errors now retain their useful diagnostics instead of being replaced by a misleading `UnboundLocalError`.

## Related

- Closes #191395

cc @dzhulgakov @awgu @wanchaol @fegin

🤖 Generated with [Claude Code](https://claude.com/claude-code)