### PR TITLE
[Distributed Tools] Persist and restore _op_index in MemoryTracker save/load

### DIFF
--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -212,6 +212,7 @@ class MemoryTracker:
             "memories_reserved": self.memories_reserved,
             "markers": self._markers,
             "num_alloc_retries": self._num_alloc_retries,
+            "_op_index": self._op_index,
         }
 
         with open(path, "wb") as f:
@@ -227,6 +228,7 @@ class MemoryTracker:
         self.memories_reserved = stats["memories_reserved"]
         self._markers = stats["markers"]
         self._num_alloc_retries = stats["num_alloc_retries"]
+        self._op_index = stats.get("_op_index", len(self.memories_allocated))
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """Prefix operator name with current module and 'forward', and insert 'fw_start' marker at forward pass start."""


### PR DESCRIPTION
## Summary

Fixes #191397

## Problem

`MemoryTracker.save_stats()` persists memory traces but not `_op_index`. When `load()` restores the traces, `_op_index` remains at its initial value (0), causing `summary()` to print no operation deltas despite the trace entries being present.

A save/load round trip silently omits the operator summary, one of the primary outputs of `MemoryTracker`.

## Fix

1. **save_stats**: Added `"_op_index"` to the pickled stats dict
2. **load**: Restores `_op_index` from saved stats, with a backward-compatible fallback to `len(self.memories_allocated)` for old stats files that don't contain this field

The `stats.get("_op_index", len(self.memories_allocated))` pattern in load ensures existing stats files continue to work, reconstructing a reasonable estimate from the available data.

## Impact

Offline analysis of saved memory traces now produces the correct operator summary output, matching the original tracker behavior.

## Related

- Closes #191397

cc @awgu @wanchaol @fegin @fduwjj

🤖 Generated with [Claude Code](https://claude.com/claude-code)