### PR TITLE
[DTensor] Reject non-chunk uneven shards in from_local when run_check=True

### DIFF
--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -419,12 +419,33 @@ class DTensorTest(DTensorTestBase):
             map_local_tensor_for_rank(tensor_list, self.rank, lambda tl, r: tl[r]),
             device_mesh,
             (Shard(0),),
+            run_check=True,
             shape=global_tensor.size(),
             stride=global_tensor.stride(),
         )
 
         self.assertEqual(dtensor.size(), global_tensor.size())
         self.assertEqual(dtensor.stride(), global_tensor.stride())
+
+    @with_comms
+    def test_from_local_run_check_rejects_non_chunk_uneven(self):
+        device_mesh = self.build_device_mesh()
+        # Global size is uneven; give every rank a local width that is NOT the
+        # torch.chunk expectation so all ranks raise under run_check=True.
+        global_w = self.world_size + 1
+        expected, _ = Shard.local_shard_size_and_offset(
+            global_w, device_mesh.size(mesh_dim=0), self.rank
+        )
+        local = torch.randn(2, expected + 1, device=self.device_type)
+        with self.assertRaisesRegex(RuntimeError, "Local tensor size on shard dim"):
+            DTensor.from_local(
+                local,
+                device_mesh,
+                (Shard(1),),
+                run_check=True,
+                shape=torch.Size([2, global_w]),
+                stride=(global_w, 1),
+            )
 
     @with_comms
     def test_from_local_uneven_sharding_raise_error(self):

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -264,8 +264,24 @@ class _FromTorchTensor(torch.autograd.Function):
             check_tensor_meta(input, check_shape_stride=check_shape_stride)
             # TODO: See if we need to make this run_check logic
             # have a corresponding backward.
+            my_coordinate = device_mesh.get_coordinate()
             for idx, placement in enumerate(placements):
-                if placement.is_replicate():
+                if type(placement) is Shard:
+                    dim = placement.dim
+                    mesh_dim_size = device_mesh.size(mesh_dim=idx)
+                    mesh_dim_rank = my_coordinate[idx]  # type: ignore[index]
+                    expected_size, _ = Shard.local_shard_size_and_offset(
+                        tensor_shape[dim], mesh_dim_size, mesh_dim_rank
+                    )
+                    actual_size = input.size(dim)
+                    if actual_size != expected_size:
+                        raise RuntimeError(
+                            f"Local tensor size on shard dim {dim} is {actual_size}, "
+                            f"but DTensor Shard expects size {expected_size} for "
+                            f"rank {mesh_dim_rank} (global size {tensor_shape[dim]}, "
+                            f"mesh size {mesh_dim_size})"
+                        )
+                elif placement.is_replicate():
                     # broadcast rank 0 tensor to all ranks
                     # only broadcast if run_check is True
                     input = input.contiguous()


### PR DESCRIPTION
Fail fast in DTensor.from_local(..., run_check=True) when Shard local sizes do not match torch.chunk expectations.
- Validate each Shard local size against Shard.local_shard_size_and_offset for that rank.
- Raise a clear RuntimeError on mismatch instead of silently accepting arbitrary uneven layouts that later produce incorrect full_tensor() results.
- Does not add support for arbitrary uneven sharding; only fail-fast validation under run_check=True.

Fixes #144109.


cc @wanchaol @tianyu-l @wz337 @XilunWu @pragupta @SherlockNoMad @ppwwyyxx @weifengpy