### PR TITLE
[Test] Add HardwareClassification to TestModule and TestJitReplaceSubmodule

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -11,7 +11,7 @@ import torch
 from torch._subclasses.meta_utils import assert_metadata_eq
 from torch.testing._internal.common_cuda import with_tf32_off
 from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests, onlyCPU, onlyAccelerator, toleranceOverride, tol, skipMeta, skipMPS)
+    instantiate_device_type_tests, onlyAccelerator, toleranceOverride, tol, skipMeta, skipMPS)
 from torch.testing._internal.common_modules import module_db, modules, ModuleErrorEnum, TrainEvalMode
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, freeze_rng_state, mock_wrapper, get_tensors_from, gradcheck,
@@ -833,34 +833,6 @@ class TestModule(TestCase):
                     raise e
 
 
-    @onlyCPU
-    @modules(module_db)
-    def test_device_ctx_init(self, device, dtype, module_info, training):
-        module_cls = module_info.module_cls
-        module_inputs = module_info.module_inputs_func(module_info, device=device, dtype=dtype,
-                                                       requires_grad=False, training=training)
-        with torch.device('meta'):
-            module_inputs_meta = module_info.module_inputs_func(module_info, device=None, dtype=dtype,
-                                                                requires_grad=False, training=training)
-
-        for module_input, module_input_meta in zip(module_inputs, module_inputs_meta):
-            c_args, c_kwargs = module_input.constructor_input.args, module_input.constructor_input.kwargs
-
-            c_args_meta, c_kwargs_meta = module_input_meta.constructor_input.args, module_input_meta.constructor_input.kwargs
-
-            m_cpu = module_cls(*c_args, **c_kwargs)
-
-            with torch.device('meta'):
-                m = module_cls(*c_args_meta, **c_kwargs_meta)
-
-            for (p_meta, p_cpu) in chain(zip(m.parameters(), m_cpu.parameters()),
-                                         zip(m.buffers(), m_cpu.buffers())):
-                if torch.nn.parameter.is_lazy(p_meta):
-                    continue
-                self.assertTrue(p_meta.is_meta)
-                assert_metadata_eq(self.assertEqual, p_meta, p_cpu)
-
-
     @modules([module for module in module_db if module.module_error_inputs_func is not None])
     def test_errors(self, device, dtype, module_info, training):
         module_cls = module_info.module_cls
@@ -1010,6 +982,36 @@ class TestModule(TestCase):
                 # parameter and assign it to the module
                 self.assertTrue(all(a != b for a, b in zip(p_ids_before, p_ids_after)))
                 self.assertTrue(all(a != b for a, b in zip(p_cdatas_before, p_cdatas_after)))
+
+
+class TestModuleCPUOnly(TestCase):
+    hw_classification = HardwareClassification.CPU
+
+    @modules(module_db)
+    def test_device_ctx_init(self, dtype, module_info, training):
+        module_cls = module_info.module_cls
+        module_inputs = module_info.module_inputs_func(module_info, device="cpu", dtype=dtype,
+                                                       requires_grad=False, training=training)
+        with torch.device('meta'):
+            module_inputs_meta = module_info.module_inputs_func(module_info, device=None, dtype=dtype,
+                                                                requires_grad=False, training=training)
+
+        for module_input, module_input_meta in zip(module_inputs, module_inputs_meta):
+            c_args, c_kwargs = module_input.constructor_input.args, module_input.constructor_input.kwargs
+
+            c_args_meta, c_kwargs_meta = module_input_meta.constructor_input.args, module_input_meta.constructor_input.kwargs
+
+            m_cpu = module_cls(*c_args, **c_kwargs)
+
+            with torch.device('meta'):
+                m = module_cls(*c_args_meta, **c_kwargs_meta)
+
+            for (p_meta, p_cpu) in chain(zip(m.parameters(), m_cpu.parameters()),
+                                         zip(m.buffers(), m_cpu.buffers())):
+                if torch.nn.parameter.is_lazy(p_meta):
+                    continue
+                self.assertTrue(p_meta.is_meta)
+                assert_metadata_eq(self.assertEqual, p_meta, p_cpu)
 
 
 class TestJitReplaceSubmodule(TestCase):
@@ -1285,6 +1287,7 @@ class TestJitReplaceSubmodule(TestCase):
 
 
 instantiate_device_type_tests(TestModule, globals(), allow_mps=True, allow_xpu=True)
+instantiate_device_type_tests(TestModuleCPUOnly, globals(), only_for="cpu")
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -15,7 +15,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_modules import module_db, modules, ModuleErrorEnum, TrainEvalMode
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, freeze_rng_state, mock_wrapper, get_tensors_from, gradcheck,
-    gradgradcheck, parametrize, wrapSwapTensorsTest, TEST_WITH_ROCM)
+    gradgradcheck, parametrize, wrapSwapTensorsTest, TEST_WITH_ROCM, HardwareClassification)
 from unittest.mock import patch, call
 
 
@@ -25,6 +25,7 @@ if TEST_WITH_ROCM:
     os.environ["PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM"] = "1"
 
 class TestModule(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
     precision = 1e-5
@@ -1012,6 +1013,8 @@ class TestModule(TestCase):
 
 
 class TestJitReplaceSubmodule(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_jit_replace_submodule(self):
         from torch.jit._recursive import wrap_cpp_module
 


### PR DESCRIPTION
## Summary

#186918 introduced `hw_classification` (`GENERIC`/`ACCELERATOR`/`CPU`/`CUDA`/`MPS`/`XPU`) so tests can opt into `--hw-classification` filtering. `test_modules.py` predates that rollout and its two test classes were left unclassified. This annotates them, following the same convention already applied to other files (e.g. #190991).

`TestModule` is instantiated via `instantiate_device_type_tests`, so it gets `ACCELERATOR`. `TestJitReplaceSubmodule` has no device/dtype parametrization and never touches an accelerator, so it gets `GENERIC`.