### PR TITLE
[Test] Generalize `test_functional_autograd_benchmark.py`

### DIFF
--- a/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
+++ b/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
@@ -2,6 +2,7 @@ import time
 from argparse import ArgumentParser
 from collections import defaultdict
 from collections.abc import Callable
+from functools import partial
 from typing import Any, NamedTuple
 
 import torch
@@ -237,8 +238,8 @@ def run_model(
 
         do_sync = noop
     else:
-        device = torch.device(f"cuda:{args.gpu}")
-        do_sync = torch.cuda.synchronize
+        device = torch.device(torch.accelerator.current_accelerator().type, args.gpu)
+        do_sync = partial(torch.accelerator.synchronize, device)
 
     model, inp = model_getter(device)
 
@@ -301,7 +302,7 @@ def main():
     torch.manual_seed(args.seed)
 
     if args.gpu == -2:
-        args.gpu = 0 if torch.cuda.is_available() else -1
+        args.gpu = 0 if torch.accelerator.is_available() else -1
 
     for name, model_getter, recommended_tasks, unsupported_tasks in MODELS:
         if args.model_filter and name not in args.model_filter:

--- a/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
+++ b/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
@@ -237,8 +237,9 @@ def run_model(
 
         do_sync = noop
     else:
-        device = torch.device(f"cuda:{args.gpu}")
-        do_sync = torch.cuda.synchronize
+        device = torch.device(torch.accelerator.current_accelerator().type, args.gpu)
+        torch.accelerator.set_device_index(args.gpu)
+        do_sync = torch.accelerator.synchronize
 
     model, inp = model_getter(device)
 
@@ -301,7 +302,7 @@ def main():
     torch.manual_seed(args.seed)
 
     if args.gpu == -2:
-        args.gpu = 0 if torch.cuda.is_available() else -1
+        args.gpu = 0 if torch.accelerator.is_available() else -1
 
     for name, model_getter, recommended_tasks, unsupported_tasks in MODELS:
         if args.model_filter and name not in args.model_filter:

--- a/test/test_functional_autograd_benchmark.py
+++ b/test/test_functional_autograd_benchmark.py
@@ -1,11 +1,12 @@
 # Owner(s): ["module: autograd"]
 
 import os
-
+import pathlib
 import subprocess
 import unittest
 
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_WINDOWS,
     run_tests,
     slowTest,
@@ -18,16 +19,21 @@ PYTORCH_COLLECT_COVERAGE = bool(os.environ.get("PYTORCH_COLLECT_COVERAGE"))
 
 # This is a very simple smoke test for the functional autograd benchmarking script.
 class TestFunctionalAutogradBenchmark(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _test_runner(self, model, disable_gpu=False):
         # Note about windows:
         # The temporary file is exclusively open by this process and the child process
         # is not allowed to open it again. As this is a simple smoke test, we choose for now
         # not to run this on windows and keep the code here simple.
+        benchmark_script = str(
+            pathlib.Path(__file__).resolve().parent.parent
+            / "benchmarks"
+            / "functional_autograd_benchmark"
+            / "functional_autograd_benchmark.py"
+        )
         with TemporaryFileName() as out_file:
-            cmd = [
-                "python3",
-                "../benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py",
-            ]
+            cmd = ["python3", benchmark_script]
             if IS_WINDOWS:
                 cmd[0] = "python"
             # Only run the warmup


### PR DESCRIPTION
This test cases executes the `functional_autograd_benchmark.py`, which had CUDA hardcoded as the GPU device. This commit generalizes it to the `torch.accelerator` API

- Replace hardcoded cuda references with torch.accelerator API:
  - `torch.device("cuda:N")` -> `torch.device(accelerator.type, N)`
  - `torch.cuda.synchronize` -> `torch.accelerator.synchronize`
  - `torch.cuda.is_available` -> `torch.accelerator.is_available`
- Fix test to use absolute path via pathlib so it runs from any directory
- Add hardware classification