### PR TITLE
[Inductor][FlyDSL] Add gfx950 FlyDSL Grouped GEMM and F.grouped_mm autotuning

### DIFF
--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import torch
+import torch.nn.functional as F
 from torch._inductor.codegen.flydsl import flydsl_utils
 from torch._inductor.codegen.flydsl.flydsl_kernel import FlyDSLTemplateKernel
 from torch._inductor.codegen.flydsl.flydsl_scheduling import (
@@ -18,6 +19,10 @@ from torch._inductor.codegen.flydsl.flydsl_template import FlyDSLTemplate
 from torch._inductor.runtime.flydsl_cache import run_cached_flydsl
 from torch._inductor.select_algorithm import PartialRender
 from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 
 
 class _CacheParam:
@@ -302,6 +307,21 @@ class TestFlyDSLTemplate(TestCase):
         self.assertEqual(result, fn(a, b), atol=3e-2, rtol=3e-2)
         return code
 
+    def _assert_compiled_grouped_mm(self, a, b, offs, *, expect_flydsl=True):
+        from torch._inductor.utils import run_and_get_code
+
+        def fn(a, b, offs):
+            return F.grouped_mm(a, b, offs=offs)
+
+        torch._dynamo.reset()
+        result, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor"), a, b, offs
+        )
+        assertion = self.assertIn if expect_flydsl else self.assertNotIn
+        assertion("async_compile.flydsl", code)
+        self.assertEqual(result, fn(a, b, offs), atol=3e-2, rtol=3e-2)
+        return code
+
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
     @unittest.skipIf(torch.version.hip is None, "requires ROCm")
     @torch._inductor.config.patch(
@@ -398,6 +418,160 @@ class TestFlyDSLTemplate(TestCase):
                     b = torch.randn(64, k, device="cuda", dtype=torch.bfloat16)
                     self._assert_compiled_mm(a, b)
 
+    @parametrize(
+        "dtype,k,n",
+        [
+            (torch.bfloat16, 128, 128),
+            (torch.bfloat16, 160, 256),
+        ],
+    )
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=False,
+    )
+    def test_flydsl_grouped_mm_e2e(self, dtype, k, n):
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        group_sizes = torch.tensor(
+            [0, 1, 67, 0, 130, 3], device="cuda", dtype=torch.int32
+        )
+        offs = group_sizes.cumsum(0).to(torch.int32)
+        a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=dtype)
+        b = torch.randn(group_sizes.numel(), k, n, device="cuda", dtype=dtype)
+        code = self._assert_compiled_grouped_mm(a, b, offs)
+        self.assertIn(".mark_layout_dynamic()", code)
+        self.assertIn("COMPILE_ONLY", code)
+        self.assertIn("_precompile", code)
+
+    @parametrize("k", (96, 192))
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        max_autotune_gemm_search_space="EXHAUSTIVE",
+        flydsl_enable_autotuning=True,
+        autotune_in_subproc=True,
+    )
+    def test_flydsl_grouped_mm_autotune_e2e(self, k):
+        from torch._inductor.template_heuristics import flydsl as flydsl_heuristics
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        configs = [
+            asdict(config)
+            for config in flydsl_heuristics.get_default_grouped_gemm_configs()
+        ]
+        configs = [
+            next(config for config in configs if not config["USE_HALF_TILE_INTERLEAVED"]),
+            next(config for config in configs if config["USE_HALF_TILE_INTERLEAVED"]),
+        ]
+        group_sizes = torch.tensor(
+            [0, 1, 67, 0, 130, 3], device="cuda", dtype=torch.int32
+        )
+        offs = group_sizes.cumsum(0).to(torch.int32)
+        a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(group_sizes.numel(), k, 128, device="cuda", dtype=torch.bfloat16)
+        with mock.patch.object(
+            flydsl_heuristics,
+            "get_grouped_gemm_configs",
+            return_value=configs,
+        ):
+            self._assert_compiled_grouped_mm(a, b, offs)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=True,
+        autotune_in_subproc=False,
+    )
+    def test_flydsl_grouped_mm_kernel_paths_e2e(self):
+        from torch._inductor.template_heuristics import flydsl as flydsl_heuristics
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        config_fields = (
+            "TILE_M",
+            "TILE_N",
+            "TILE_K",
+            "STAGES",
+            "BLOCK_M_WARPS",
+            "BLOCK_N_WARPS",
+            "GROUP_M",
+            "USE_HALF_TILE_INTERLEAVED",
+        )
+        cases = (
+            ("block_swizzle", 4096, 1024, 128, (128, 128, 64, 2, 1, 4, 4, False)),
+            ("deep_pipeline", 128, 128, 192, (64, 128, 64, 3, 1, 4, 0, False)),
+            ("large_tile", 1024, 256, 128, (256, 256, 64, 2, 2, 4, 0, True)),
+        )
+        configs = [
+            asdict(config)
+            for config in flydsl_heuristics.get_default_grouped_gemm_configs()
+        ]
+
+        for name, m, n, k, expected_values in cases:
+            with self.subTest(name=name):
+                config = next(
+                    config
+                    for config in configs
+                    if tuple(config[field] for field in config_fields)
+                    == expected_values
+                )
+                group_sizes = torch.tensor([m], device="cuda", dtype=torch.int32)
+                offs = group_sizes.cumsum(0).to(torch.int32)
+                a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+                b = torch.randn(1, k, n, device="cuda", dtype=torch.bfloat16)
+                with mock.patch.object(
+                    flydsl_heuristics,
+                    "get_grouped_gemm_configs",
+                    return_value=[config],
+                ):
+                    code = self._assert_compiled_grouped_mm(a, b, offs)
+                self.assertIn("launch_gemm_gfx950_grouped", code)
+                for field, value in zip(config_fields, expected_values):
+                    self.assertIn(f"{field}: fx.Constexpr = {value}", code)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="ATEN,FLYDSL",
+    )
+    def test_flydsl_grouped_mm_fallback_e2e(self):
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        group_sizes = torch.tensor([32, 64], device="cuda", dtype=torch.int32)
+        offs = group_sizes.cumsum(0).to(torch.int32)
+        k = 128
+        a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=torch.bfloat16)
+        cases = (
+            (
+                "b_transposed",
+                torch.randn(2, 256, k, device="cuda", dtype=torch.bfloat16).transpose(
+                    -1, -2
+                ),
+            ),
+            (
+                "n_not_tile_divisible",
+                torch.randn(2, k, 96, device="cuda", dtype=torch.bfloat16),
+            ),
+        )
+
+        for name, b in cases:
+            with self.subTest(name=name):
+                self._assert_compiled_grouped_mm(a, b, offs, expect_flydsl=False)
+
+instantiate_parametrized_tests(TestFlyDSLTemplate)
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import torch
+import torch.nn.functional as F
 from torch._inductor.codegen.flydsl import flydsl_utils
 from torch._inductor.codegen.flydsl.flydsl_kernel import FlyDSLTemplateKernel
 from torch._inductor.codegen.flydsl.flydsl_scheduling import (
@@ -421,6 +422,21 @@ class TestFlyDSLTemplate(TestCase):
         self.assertEqual(result, fn(a, b), atol=3e-2, rtol=3e-2)
         return code
 
+    def _assert_compiled_grouped_mm(self, a, b, offs, *, expect_flydsl=True):
+        from torch._inductor.utils import run_and_get_code
+
+        def fn(a, b, offs):
+            return F.grouped_mm(a, b, offs=offs)
+
+        torch._dynamo.reset()
+        result, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor"), a, b, offs
+        )
+        assertion = self.assertIn if expect_flydsl else self.assertNotIn
+        assertion("async_compile.flydsl", code)
+        self.assertEqual(result, fn(a, b, offs), atol=3e-2, rtol=3e-2)
+        return code
+
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
     @unittest.skipIf(torch.version.hip is None, "requires ROCm")
     @torch._inductor.config.patch(
@@ -522,6 +538,160 @@ class TestFlyDSLTemplate(TestCase):
                     b = torch.randn(64, k, device="cuda", dtype=torch.bfloat16)
                     self._assert_compiled_mm(a, b)
 
+    @parametrize(
+        "dtype,k,n",
+        [
+            (torch.bfloat16, 128, 128),
+            (torch.bfloat16, 160, 256),
+        ],
+    )
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=False,
+    )
+    def test_flydsl_grouped_mm_e2e(self, dtype, k, n):
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        group_sizes = torch.tensor(
+            [0, 1, 67, 0, 130, 3], device="cuda", dtype=torch.int32
+        )
+        offs = group_sizes.cumsum(0).to(torch.int32)
+        a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=dtype)
+        b = torch.randn(group_sizes.numel(), k, n, device="cuda", dtype=dtype)
+        code = self._assert_compiled_grouped_mm(a, b, offs)
+        self.assertIn(".mark_layout_dynamic()", code)
+        self.assertIn("COMPILE_ONLY", code)
+        self.assertIn("_precompile", code)
+
+    @parametrize("k", (96, 192))
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        max_autotune_gemm_search_space="EXHAUSTIVE",
+        flydsl_enable_autotuning=True,
+        autotune_in_subproc=True,
+    )
+    def test_flydsl_grouped_mm_autotune_e2e(self, k):
+        from torch._inductor.template_heuristics import flydsl as flydsl_heuristics
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        configs = [
+            asdict(config)
+            for config in flydsl_heuristics.get_default_grouped_gemm_configs()
+        ]
+        configs = [
+            next(config for config in configs if not config["USE_HALF_TILE_INTERLEAVED"]),
+            next(config for config in configs if config["USE_HALF_TILE_INTERLEAVED"]),
+        ]
+        group_sizes = torch.tensor(
+            [0, 1, 67, 0, 130, 3], device="cuda", dtype=torch.int32
+        )
+        offs = group_sizes.cumsum(0).to(torch.int32)
+        a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(group_sizes.numel(), k, 128, device="cuda", dtype=torch.bfloat16)
+        with mock.patch.object(
+            flydsl_heuristics,
+            "get_grouped_gemm_configs",
+            return_value=configs,
+        ):
+            self._assert_compiled_grouped_mm(a, b, offs)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=True,
+        autotune_in_subproc=False,
+    )
+    def test_flydsl_grouped_mm_kernel_paths_e2e(self):
+        from torch._inductor.template_heuristics import flydsl as flydsl_heuristics
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        config_fields = (
+            "TILE_M",
+            "TILE_N",
+            "TILE_K",
+            "STAGES",
+            "BLOCK_M_WARPS",
+            "BLOCK_N_WARPS",
+            "GROUP_M",
+            "USE_HALF_TILE_INTERLEAVED",
+        )
+        cases = (
+            ("block_swizzle", 4096, 1024, 128, (128, 128, 64, 2, 1, 4, 4, False)),
+            ("deep_pipeline", 128, 128, 192, (64, 128, 64, 3, 1, 4, 0, False)),
+            ("large_tile", 1024, 256, 128, (256, 256, 64, 2, 2, 4, 0, True)),
+        )
+        configs = [
+            asdict(config)
+            for config in flydsl_heuristics.get_default_grouped_gemm_configs()
+        ]
+
+        for name, m, n, k, expected_values in cases:
+            with self.subTest(name=name):
+                config = next(
+                    config
+                    for config in configs
+                    if tuple(config[field] for field in config_fields)
+                    == expected_values
+                )
+                group_sizes = torch.tensor([m], device="cuda", dtype=torch.int32)
+                offs = group_sizes.cumsum(0).to(torch.int32)
+                a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+                b = torch.randn(1, k, n, device="cuda", dtype=torch.bfloat16)
+                with mock.patch.object(
+                    flydsl_heuristics,
+                    "get_grouped_gemm_configs",
+                    return_value=[config],
+                ):
+                    code = self._assert_compiled_grouped_mm(a, b, offs)
+                self.assertIn("launch_gemm_gfx950_grouped", code)
+                for field, value in zip(config_fields, expected_values):
+                    self.assertIn(f"{field}: fx.Constexpr = {value}", code)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="ATEN,FLYDSL",
+    )
+    def test_flydsl_grouped_mm_fallback_e2e(self):
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        group_sizes = torch.tensor([32, 64], device="cuda", dtype=torch.int32)
+        offs = group_sizes.cumsum(0).to(torch.int32)
+        k = 128
+        a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=torch.bfloat16)
+        cases = (
+            (
+                "b_transposed",
+                torch.randn(2, 256, k, device="cuda", dtype=torch.bfloat16).transpose(
+                    -1, -2
+                ),
+            ),
+            (
+                "n_not_tile_divisible",
+                torch.randn(2, k, 96, device="cuda", dtype=torch.bfloat16),
+            ),
+        )
+
+        for name, b in cases:
+            with self.subTest(name=name):
+                self._assert_compiled_grouped_mm(a, b, offs, expect_flydsl=False)
+
+instantiate_parametrized_tests(TestFlyDSLTemplate)
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -422,7 +422,9 @@ class TestFlyDSLTemplate(TestCase):
         self.assertEqual(result, fn(a, b), atol=3e-2, rtol=3e-2)
         return code
 
-    def _assert_compiled_grouped_mm(self, a, b, offs, *, expect_flydsl=True):
+    def _assert_compiled_grouped_mm(
+        self, a, b, offs, *, expect_flydsl: bool | None = True
+    ):
         from torch._inductor.utils import run_and_get_code
 
         def fn(a, b, offs):
@@ -432,8 +434,9 @@ class TestFlyDSLTemplate(TestCase):
         result, (code,) = run_and_get_code(
             torch.compile(fn, backend="inductor"), a, b, offs
         )
-        assertion = self.assertIn if expect_flydsl else self.assertNotIn
-        assertion("async_compile.flydsl", code)
+        if expect_flydsl is not None:
+            assertion = self.assertIn if expect_flydsl else self.assertNotIn
+            assertion("async_compile.flydsl", code)
         self.assertEqual(result, fn(a, b, offs), atol=3e-2, rtol=3e-2)
         return code
 
@@ -538,11 +541,32 @@ class TestFlyDSLTemplate(TestCase):
                     b = torch.randn(64, k, device="cuda", dtype=torch.bfloat16)
                     self._assert_compiled_mm(a, b)
 
+    def test_flydsl_grouped_gemm_config_schema(self):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        with mock.patch.object(flydsl_heuristics, "_make_gemm_param"):
+            configs = flydsl_heuristics.get_default_grouped_gemm_configs()
+        self.assertEqual(
+            asdict(configs[0]),
+            {
+                "TILE_M": 16,
+                "TILE_N": 64,
+                "TILE_K": 64,
+                "STAGES": 2,
+                "BLOCK_M_WARPS": 1,
+                "BLOCK_N_WARPS": 2,
+                "GROUP_M": 0,
+                "USE_HALF_TILE_INTERLEAVED": False,
+            },
+        )
+        self.assertTrue(any(config.USE_HALF_TILE_INTERLEAVED for config in configs))
+
     @parametrize(
         "dtype,k,n",
         [
             (torch.bfloat16, 128, 128),
             (torch.bfloat16, 160, 256),
+            (torch.float16, 128, 128),
         ],
     )
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
@@ -564,7 +588,7 @@ class TestFlyDSLTemplate(TestCase):
         b = torch.randn(group_sizes.numel(), k, n, device="cuda", dtype=dtype)
         code = self._assert_compiled_grouped_mm(a, b, offs)
         self.assertIn(".mark_layout_dynamic()", code)
-        self.assertIn("COMPILE_ONLY", code)
+        self.assertIn("FLYDSL_COMPILE_ONLY", code)
         self.assertIn("_precompile", code)
 
     @parametrize("k", (96, 192))
@@ -578,7 +602,7 @@ class TestFlyDSLTemplate(TestCase):
         autotune_in_subproc=True,
     )
     def test_flydsl_grouped_mm_autotune_e2e(self, k):
-        from torch._inductor.template_heuristics import flydsl as flydsl_heuristics
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
 
         if not flydsl_utils.runtime_available():
             self.skipTest("FlyDSL runtime unavailable")
@@ -588,7 +612,9 @@ class TestFlyDSLTemplate(TestCase):
             for config in flydsl_heuristics.get_default_grouped_gemm_configs()
         ]
         configs = [
-            next(config for config in configs if not config["USE_HALF_TILE_INTERLEAVED"]),
+            next(
+                config for config in configs if not config["USE_HALF_TILE_INTERLEAVED"]
+            ),
             next(config for config in configs if config["USE_HALF_TILE_INTERLEAVED"]),
         ]
         group_sizes = torch.tensor(
@@ -596,7 +622,9 @@ class TestFlyDSLTemplate(TestCase):
         )
         offs = group_sizes.cumsum(0).to(torch.int32)
         a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=torch.bfloat16)
-        b = torch.randn(group_sizes.numel(), k, 128, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(
+            group_sizes.numel(), k, 128, device="cuda", dtype=torch.bfloat16
+        )
         with mock.patch.object(
             flydsl_heuristics,
             "get_grouped_gemm_configs",
@@ -613,7 +641,7 @@ class TestFlyDSLTemplate(TestCase):
         autotune_in_subproc=False,
     )
     def test_flydsl_grouped_mm_kernel_paths_e2e(self):
-        from torch._inductor.template_heuristics import flydsl as flydsl_heuristics
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
 
         if not flydsl_utils.runtime_available():
             self.skipTest("FlyDSL runtime unavailable")
@@ -629,16 +657,53 @@ class TestFlyDSLTemplate(TestCase):
             "USE_HALF_TILE_INTERLEAVED",
         )
         cases = (
-            ("block_swizzle", 4096, 1024, 128, (128, 128, 64, 2, 1, 4, 4, False)),
-            ("deep_pipeline", 128, 128, 192, (64, 128, 64, 3, 1, 4, 0, False)),
-            ("large_tile", 1024, 256, 128, (256, 256, 64, 2, 2, 4, 0, True)),
+            (
+                "block_swizzle",
+                1,
+                4096,
+                1024,
+                128,
+                (128, 128, 64, 2, 1, 4, 4, False),
+            ),
+            (
+                "deep_pipeline",
+                1,
+                128,
+                128,
+                192,
+                (64, 128, 64, 3, 1, 4, 0, False),
+            ),
+            (
+                "large_tile",
+                1,
+                1024,
+                256,
+                128,
+                (256, 256, 64, 2, 2, 4, 0, True),
+            ),
+            (
+                "hti_odd_k_tiles",
+                1,
+                128,
+                128,
+                192,
+                (128, 128, 64, 2, 2, 2, 0, True),
+            ),
+            (
+                "persistent_hti",
+                8,
+                512,
+                4352,
+                128,
+                (256, 256, 64, 2, 2, 4, 0, True),
+            ),
         )
         configs = [
             asdict(config)
             for config in flydsl_heuristics.get_default_grouped_gemm_configs()
         ]
 
-        for name, m, n, k, expected_values in cases:
+        for name, groups, m, n, k, expected_values in cases:
             with self.subTest(name=name):
                 config = next(
                     config
@@ -646,10 +711,10 @@ class TestFlyDSLTemplate(TestCase):
                     if tuple(config[field] for field in config_fields)
                     == expected_values
                 )
-                group_sizes = torch.tensor([m], device="cuda", dtype=torch.int32)
+                group_sizes = torch.full((groups,), m, device="cuda", dtype=torch.int32)
                 offs = group_sizes.cumsum(0).to(torch.int32)
-                a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
-                b = torch.randn(1, k, n, device="cuda", dtype=torch.bfloat16)
+                a = torch.randn(groups * m, k, device="cuda", dtype=torch.bfloat16)
+                b = torch.randn(groups, k, n, device="cuda", dtype=torch.bfloat16)
                 with mock.patch.object(
                     flydsl_heuristics,
                     "get_grouped_gemm_configs",
@@ -673,25 +738,70 @@ class TestFlyDSLTemplate(TestCase):
         group_sizes = torch.tensor([32, 64], device="cuda", dtype=torch.int32)
         offs = group_sizes.cumsum(0).to(torch.int32)
         k = 128
-        a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=torch.bfloat16)
+        total_m = int(group_sizes.sum())
+        a = torch.randn(total_m, k, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(2, k, 128, device="cuda", dtype=torch.bfloat16)
+        a_padded = torch.randn(total_m, k + 8, device="cuda", dtype=torch.bfloat16)[
+            :, :k
+        ]
+        a_unaligned = torch.as_strided(
+            torch.randn(
+                total_m * k + 1,
+                device="cuda",
+                dtype=torch.bfloat16,
+            ),
+            (total_m, k),
+            (k, 1),
+            storage_offset=1,
+        )
+        b_padded = torch.randn(2, k, 136, device="cuda", dtype=torch.bfloat16)[
+            ..., :128
+        ]
+        a_aligned = torch.as_strided(
+            torch.randn(total_m * k + 8, device="cuda", dtype=torch.bfloat16),
+            (total_m, k),
+            (k, 1),
+            storage_offset=8,
+        )
+        b_aligned = torch.as_strided(
+            torch.randn(2 * k * 128 + 8, device="cuda", dtype=torch.bfloat16),
+            (2, k, 128),
+            (k * 128, 128, 1),
+            storage_offset=8,
+        )
+        self._assert_compiled_grouped_mm(a_aligned, b_aligned, offs, expect_flydsl=None)
+        with torch._inductor.config.patch(max_autotune_gemm_backends="FLYDSL"):
+            self._assert_compiled_grouped_mm(a_aligned, b_aligned, offs)
+
         cases = (
             (
                 "b_transposed",
+                a,
                 torch.randn(2, 256, k, device="cuda", dtype=torch.bfloat16).transpose(
                     -1, -2
                 ),
             ),
             (
                 "n_not_tile_divisible",
+                a,
                 torch.randn(2, k, 96, device="cuda", dtype=torch.bfloat16),
+            ),
+            ("a_padded_stride", a_padded, b),
+            ("a_unaligned_offset", a_unaligned, b),
+            ("b_padded_stride", a, b_padded),
+            (
+                "k_not_tile_divisible",
+                torch.randn(total_m, 80, device="cuda", dtype=torch.bfloat16),
+                torch.randn(2, 80, 128, device="cuda", dtype=torch.bfloat16),
             ),
         )
 
-        for name, b in cases:
+        for name, case_a, case_b in cases:
             with self.subTest(name=name):
-                self._assert_compiled_grouped_mm(a, b, offs, expect_flydsl=False)
+                self._assert_compiled_grouped_mm(
+                    case_a, case_b, offs, expect_flydsl=False
+                )
 
-instantiate_parametrized_tests(TestFlyDSLTemplate)
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -546,22 +546,66 @@ class TestFlyDSLTemplate(TestCase):
 
         flydsl_heuristics.get_default_grouped_gemm_configs.cache_clear()
         self.addCleanup(flydsl_heuristics.get_default_grouped_gemm_configs.cache_clear)
-        with mock.patch.object(flydsl_heuristics, "_make_gemm_param"):
+        default_config = flydsl_heuristics.DEFAULT_GROUPED_GEMM_CONFIG
+        with (
+            mock.patch.object(flydsl_heuristics, "_make_gemm_param"),
+            torch._inductor.config.patch(flydsl_enable_autotuning=False),
+        ):
             configs = flydsl_heuristics.get_default_grouped_gemm_configs()
+            selected = flydsl_heuristics.get_grouped_gemm_configs()
         self.assertEqual(
-            asdict(configs[0]),
+            asdict(default_config),
             {
-                "TILE_M": 16,
-                "TILE_N": 64,
+                "TILE_M": 128,
+                "TILE_N": 128,
                 "TILE_K": 64,
                 "STAGES": 2,
                 "BLOCK_M_WARPS": 1,
-                "BLOCK_N_WARPS": 2,
+                "BLOCK_N_WARPS": 4,
                 "GROUP_M": 0,
                 "USE_HALF_TILE_INTERLEAVED": False,
             },
         )
+        # The baseline must stay reachable regardless of candidate ordering.
+        self.assertIn(default_config, configs)
+        self.assertEqual(selected, [asdict(default_config)])
         self.assertTrue(any(config.USE_HALF_TILE_INTERLEAVED for config in configs))
+
+    def test_flydsl_grouped_gemm_exhaustive_layout_filter(self):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        valid = flydsl_heuristics.DEFAULT_GROUPED_GEMM_CONFIG
+        small_n = flydsl_heuristics.FlyDSLGemmConfig(32, 32, 64, 2, 1, 2, 0)
+        invalid_cshuffle = flydsl_heuristics.FlyDSLGemmConfig(16, 96, 64, 2, 1, 2, 0)
+        with mock.patch.object(
+            flydsl_heuristics,
+            "get_exhaustive_gemm_configs",
+            return_value=[small_n, invalid_cshuffle, valid],
+        ):
+            configs = flydsl_heuristics.get_exhaustive_grouped_gemm_configs()
+        self.assertEqual(configs, [valid])
+
+    @parametrize(
+        "config_args,n,expected",
+        [
+            ((32, 32, 64, 2, 1, 2, 0), 32, False),
+            ((16, 96, 64, 2, 1, 2, 0), 96, False),
+            ((128, 128, 64, 2, 1, 4, 0), 128, True),
+        ],
+    )
+    def test_flydsl_grouped_gemm_layout_validation(self, config_args, n, expected):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        gemm_config = asdict(flydsl_heuristics.FlyDSLGemmConfig(*config_args))
+        with mock.patch.object(
+            flydsl_heuristics,
+            "is_gemm_config_valid_for_shape",
+            return_value=True,
+        ):
+            valid = flydsl_heuristics.is_grouped_gemm_config_valid_for_shape(
+                128, n, 128, 0, gemm_config
+            )
+        self.assertEqual(valid, expected)
 
     @parametrize(
         "dtype,k,n",

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -544,6 +544,8 @@ class TestFlyDSLTemplate(TestCase):
     def test_flydsl_grouped_gemm_config_schema(self):
         from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
 
+        flydsl_heuristics.get_default_grouped_gemm_configs.cache_clear()
+        self.addCleanup(flydsl_heuristics.get_default_grouped_gemm_configs.cache_clear)
         with mock.patch.object(flydsl_heuristics, "_make_gemm_param"):
             configs = flydsl_heuristics.get_default_grouped_gemm_configs()
         self.assertEqual(

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -369,6 +369,7 @@ class TestPublicBindings(TestCase):
             "torch._inductor.kernel.vendored_templates.cutedsl.wrappers",  # depends on cutlass_api
             "torch._inductor.kernel.vendored_templates.cutedsl.wrappers.dense_blockscaled_gemm_kernel",  # depends on cutlass_api
             "torch._inductor.kernel.vendored_templates.flydsl.kernels.gemm_gfx950",  # depends on flydsl
+            "torch._inductor.kernel.vendored_templates.flydsl.kernels.grouped_gemm_gfx950",  # depends on flydsl
             "torch._inductor.runtime.triton_helpers",
             "torch.ao.pruning._experimental.data_sparsifier.lightning.callbacks.data_sparsity",
             "torch.backends._coreml.preprocess",

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -225,3 +225,82 @@ def get_gemm_configs() -> list[dict[str, int | bool]]:
         log.warning("No valid FlyDSL GEMM configuration is available")
         return []
     return [asdict(gemm_config) for gemm_config in configs]
+
+
+def get_exhaustive_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
+    """Return exhaustive configs for the gfx950 FlyDSL grouped GEMM kernel."""
+    return get_exhaustive_gemm_configs()
+
+
+def get_default_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
+    """Return default configs for the gfx950 FlyDSL grouped GEMM kernel.
+
+    The grouped kernel always stages N-contiguous B vectors into LDS and reads
+    them back transposed.
+    """
+    config_tuples: list[FlyDSLGemmConfigArgs] = [
+        # Small-M grouped/decode configs.  These reduce wasted work when each
+        # group has far fewer than 32 rows.
+        (16, 64, 64, 2, 1, 1, 2, 1, 0, True),
+        (16, 128, 64, 2, 1, 1, 2, 1, 0, True),
+        (32, 64, 64, 2, 1, 1, 2, 1, 0, True),
+        (32, 256, 64, 2, 1, 1, 4, 1, 0, True),
+        (32, 128, 64, 2, 1, 1, 4, 1, 0, True),
+        (64, 128, 64, 2, 1, 1, 4, 1, 0, True),
+        (64, 256, 64, 2, 1, 1, 4, 1, 0, True),
+        (128, 128, 64, 2, 1, 1, 4, 1, 0, True),
+        (128, 256, 64, 2, 1, 1, 4, 1, 0, True),
+        # Deeper pipelines, autotuned for the multi-stage overlap.
+        (64, 128, 64, 3, 1, 1, 4, 1, 0, True),
+        (128, 128, 64, 3, 1, 1, 4, 1, 0, True),
+        (128, 256, 64, 3, 1, 1, 4, 1, 0, True),
+        # Swizzled group-M variant remaps sufficiently large per-group tile grids.
+        (128, 128, 64, 2, 1, 1, 4, 1, 4, True),
+    ]
+    hti_config_tuples: list[FlyDSLHTIGemmConfigArgs] = [
+        # 2x2 half-tile-interleaved variant (stages=2 only): four half-block
+        # accumulators + per-quadrant cshuffle store for better register tiling
+        # and MMA scheduling. Requires m_waves=2, n_waves>=2 and even tiles.
+        (64, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
+        (128, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
+        (128, 128, 64, 2, 1, 2, 2, 1, 4, True, True),
+        (128, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
+        (256, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
+        (256, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
+    ]
+    # Tuple order must match the FlyDSLGemmConfig field declaration order.
+    candidates = [FlyDSLGemmConfig(*args) for args in config_tuples]
+    candidates.extend(FlyDSLGemmConfig(*args) for args in hti_config_tuples)
+    return candidates
+
+
+def get_grouped_gemm_configs(m: int, n: int, k: int) -> list[dict[str, object]]:
+    """Return supported configs for the persistent multi-stage grouped kernel."""
+    if (
+        config.flydsl_enable_autotuning
+        and config.max_autotune_gemm_search_space == "EXHAUSTIVE"
+    ):
+        candidates = get_exhaustive_grouped_gemm_configs()
+    elif config.flydsl_enable_autotuning:
+        candidates = get_default_grouped_gemm_configs()
+    else:
+        candidates = get_default_grouped_gemm_configs()
+        candidates = candidates[:1]
+
+    configs: list[dict[str, object]] = []
+    for grouped_config in candidates:
+        if grouped_config.TILE_M > max(128, m):
+            continue
+        if n < grouped_config.TILE_N or n % grouped_config.TILE_N != 0:
+            continue
+        if (k // grouped_config.TILE_K) < grouped_config.STAGES:
+            continue
+        gemm_config = asdict(grouped_config)
+        try:
+            _make_gemm_param(gemm_config)
+        except Exception:
+            continue
+        configs.append(gemm_config)
+    if not configs:
+        log.warning("No valid FlyDSL grouped GEMM configuration is available")
+    return configs

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -234,40 +234,53 @@ def get_default_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
     config_tuples: list[FlyDSLGemmConfigArgs] = [
         # Small-M grouped/decode configs.  These reduce wasted work when each
         # group has far fewer than 32 rows.
-        (16, 64, 64, 2, 1, 1, 2, 1, 0, True),
-        (16, 128, 64, 2, 1, 1, 2, 1, 0, True),
-        (32, 64, 64, 2, 1, 1, 2, 1, 0, True),
-        (32, 256, 64, 2, 1, 1, 4, 1, 0, True),
-        (32, 128, 64, 2, 1, 1, 4, 1, 0, True),
-        (64, 128, 64, 2, 1, 1, 4, 1, 0, True),
-        (64, 256, 64, 2, 1, 1, 4, 1, 0, True),
-        (128, 128, 64, 2, 1, 1, 4, 1, 0, True),
-        (128, 256, 64, 2, 1, 1, 4, 1, 0, True),
+        (16, 64, 64, 2, 1, 2, 0),
+        (16, 128, 64, 2, 1, 2, 0),
+        (32, 64, 64, 2, 1, 2, 0),
+        (32, 256, 64, 2, 1, 4, 0),
+        (32, 128, 64, 2, 1, 4, 0),
+        (64, 128, 64, 2, 1, 4, 0),
+        (64, 256, 64, 2, 1, 4, 0),
+        (128, 128, 64, 2, 1, 4, 0),
+        (128, 256, 64, 2, 1, 4, 0),
         # Deeper pipelines, autotuned for the multi-stage overlap.
-        (64, 128, 64, 3, 1, 1, 4, 1, 0, True),
-        (128, 128, 64, 3, 1, 1, 4, 1, 0, True),
-        (128, 256, 64, 3, 1, 1, 4, 1, 0, True),
+        (64, 128, 64, 3, 1, 4, 0),
+        (128, 128, 64, 3, 1, 4, 0),
+        (128, 256, 64, 3, 1, 4, 0),
         # Swizzled group-M variant remaps sufficiently large per-group tile grids.
-        (128, 128, 64, 2, 1, 1, 4, 1, 4, True),
+        (128, 128, 64, 2, 1, 4, 4),
     ]
     hti_config_tuples: list[FlyDSLHTIGemmConfigArgs] = [
         # 2x2 half-tile-interleaved variant (stages=2 only): four half-block
         # accumulators + per-quadrant cshuffle store for better register tiling
         # and MMA scheduling. Requires m_waves=2, n_waves>=2 and even tiles.
-        (64, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
-        (128, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
-        (128, 128, 64, 2, 1, 2, 2, 1, 4, True, True),
-        (128, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
-        (256, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
-        (256, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
+        (64, 128, 64, 2, 2, 2, 0, True),
+        (128, 128, 64, 2, 2, 2, 0, True),
+        (128, 128, 64, 2, 2, 2, 4, True),
+        (128, 256, 64, 2, 2, 4, 0, True),
+        (256, 128, 64, 2, 2, 2, 0, True),
+        (256, 256, 64, 2, 2, 4, 0, True),
     ]
     # Tuple order must match the FlyDSLGemmConfig field declaration order.
     candidates = [FlyDSLGemmConfig(*args) for args in config_tuples]
     candidates.extend(FlyDSLGemmConfig(*args) for args in hti_config_tuples)
-    return candidates
+    valid_configs: list[FlyDSLGemmConfig] = []
+    for gemm_config in candidates:
+        try:
+            _make_gemm_param(asdict(gemm_config))
+            valid_configs.append(gemm_config)
+        except Exception as e:
+            log.debug(
+                "Skipping invalid default FlyDSL grouped config %s: %s",
+                gemm_config,
+                e,
+            )
+    return valid_configs
 
 
-def get_grouped_gemm_configs(m: int, n: int, k: int) -> list[dict[str, object]]:
+def get_grouped_gemm_configs(
+    m: int, n: int, k: int, dtype_id: int
+) -> list[dict[str, object]]:
     """Return supported configs for the persistent multi-stage grouped kernel."""
     if (
         config.flydsl_enable_autotuning
@@ -289,9 +302,7 @@ def get_grouped_gemm_configs(m: int, n: int, k: int) -> list[dict[str, object]]:
         if (k // grouped_config.TILE_K) < grouped_config.STAGES:
             continue
         gemm_config = asdict(grouped_config)
-        try:
-            _make_gemm_param(gemm_config)
-        except Exception:
+        if not is_gemm_config_valid_for_shape(m, n, k, dtype_id, gemm_config):
             continue
         configs.append(gemm_config)
     if not configs:

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -218,3 +218,82 @@ def get_gemm_configs() -> list[dict[str, int | bool]]:
         log.warning("No valid FlyDSL GEMM configuration is available")
         return []
     return [asdict(gemm_config) for gemm_config in configs]
+
+
+def get_exhaustive_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
+    """Return exhaustive configs for the gfx950 FlyDSL grouped GEMM kernel."""
+    return get_exhaustive_gemm_configs()
+
+
+def get_default_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
+    """Return default configs for the gfx950 FlyDSL grouped GEMM kernel.
+
+    The grouped kernel always stages N-contiguous B vectors into LDS and reads
+    them back transposed.
+    """
+    config_tuples: list[FlyDSLGemmConfigArgs] = [
+        # Small-M grouped/decode configs.  These reduce wasted work when each
+        # group has far fewer than 32 rows.
+        (16, 64, 64, 2, 1, 1, 2, 1, 0, True),
+        (16, 128, 64, 2, 1, 1, 2, 1, 0, True),
+        (32, 64, 64, 2, 1, 1, 2, 1, 0, True),
+        (32, 256, 64, 2, 1, 1, 4, 1, 0, True),
+        (32, 128, 64, 2, 1, 1, 4, 1, 0, True),
+        (64, 128, 64, 2, 1, 1, 4, 1, 0, True),
+        (64, 256, 64, 2, 1, 1, 4, 1, 0, True),
+        (128, 128, 64, 2, 1, 1, 4, 1, 0, True),
+        (128, 256, 64, 2, 1, 1, 4, 1, 0, True),
+        # Deeper pipelines, autotuned for the multi-stage overlap.
+        (64, 128, 64, 3, 1, 1, 4, 1, 0, True),
+        (128, 128, 64, 3, 1, 1, 4, 1, 0, True),
+        (128, 256, 64, 3, 1, 1, 4, 1, 0, True),
+        # Swizzled group-M variant remaps sufficiently large per-group tile grids.
+        (128, 128, 64, 2, 1, 1, 4, 1, 4, True),
+    ]
+    hti_config_tuples: list[FlyDSLHTIGemmConfigArgs] = [
+        # 2x2 half-tile-interleaved variant (stages=2 only): four half-block
+        # accumulators + per-quadrant cshuffle store for better register tiling
+        # and MMA scheduling. Requires m_waves=2, n_waves>=2 and even tiles.
+        (64, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
+        (128, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
+        (128, 128, 64, 2, 1, 2, 2, 1, 4, True, True),
+        (128, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
+        (256, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
+        (256, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
+    ]
+    # Tuple order must match the FlyDSLGemmConfig field declaration order.
+    candidates = [FlyDSLGemmConfig(*args) for args in config_tuples]
+    candidates.extend(FlyDSLGemmConfig(*args) for args in hti_config_tuples)
+    return candidates
+
+
+def get_grouped_gemm_configs(m: int, n: int, k: int) -> list[dict[str, object]]:
+    """Return supported configs for the persistent multi-stage grouped kernel."""
+    if (
+        config.flydsl_enable_autotuning
+        and config.max_autotune_gemm_search_space == "EXHAUSTIVE"
+    ):
+        candidates = get_exhaustive_grouped_gemm_configs()
+    elif config.flydsl_enable_autotuning:
+        candidates = get_default_grouped_gemm_configs()
+    else:
+        candidates = get_default_grouped_gemm_configs()
+        candidates = candidates[:1]
+
+    configs: list[dict[str, object]] = []
+    for grouped_config in candidates:
+        if grouped_config.TILE_M > max(128, m):
+            continue
+        if n < grouped_config.TILE_N or n % grouped_config.TILE_N != 0:
+            continue
+        if (k // grouped_config.TILE_K) < grouped_config.STAGES:
+            continue
+        gemm_config = asdict(grouped_config)
+        try:
+            _make_gemm_param(gemm_config)
+        except Exception:
+            continue
+        configs.append(gemm_config)
+    if not configs:
+        log.warning("No valid FlyDSL grouped GEMM configuration is available")
+    return configs

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -225,6 +225,7 @@ def get_exhaustive_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
     return get_exhaustive_gemm_configs()
 
 
+@functools.cache
 def get_default_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
     """Return default configs for the gfx950 FlyDSL grouped GEMM kernel.
 
@@ -278,33 +279,45 @@ def get_default_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
     return valid_configs
 
 
-def get_grouped_gemm_configs(
-    m: int, n: int, k: int, dtype_id: int
-) -> list[dict[str, object]]:
-    """Return supported configs for the persistent multi-stage grouped kernel."""
+def is_grouped_gemm_config_valid_for_shape(
+    m: int,
+    n: int,
+    k: int,
+    dtype_id: int,
+    gemm_config: dict[str, int | bool],
+) -> bool:
+    """Return whether a FlyDSL config supports this grouped GEMM shape."""
+    tile_m = int(gemm_config["TILE_M"])
+    tile_n = int(gemm_config["TILE_N"])
+    tile_k = int(gemm_config["TILE_K"])
+    stages = int(gemm_config["STAGES"])
+    use_half_tile_interleaved = bool(gemm_config["USE_HALF_TILE_INTERLEAVED"])
+    has_enough_k = use_half_tile_interleaved or k // tile_k >= stages
+    return (
+        tile_m <= max(128, m)
+        and n >= tile_n
+        and n % tile_n == 0
+        and has_enough_k
+        and is_gemm_config_valid_for_shape(m, n, k, dtype_id, gemm_config)
+    )
+
+
+def get_grouped_gemm_configs() -> list[dict[str, int | bool]]:
+    """Return configs for the persistent multi-stage grouped kernel.
+
+    Shape compatibility is checked in the lowering before this function is called.
+    """
     if (
         config.flydsl_enable_autotuning
         and config.max_autotune_gemm_search_space == "EXHAUSTIVE"
     ):
         candidates = get_exhaustive_grouped_gemm_configs()
-    elif config.flydsl_enable_autotuning:
-        candidates = get_default_grouped_gemm_configs()
     else:
         candidates = get_default_grouped_gemm_configs()
-        candidates = candidates[:1]
+        if not config.flydsl_enable_autotuning:
+            candidates = candidates[:1]
 
-    configs: list[dict[str, object]] = []
-    for grouped_config in candidates:
-        if grouped_config.TILE_M > max(128, m):
-            continue
-        if n < grouped_config.TILE_N or n % grouped_config.TILE_N != 0:
-            continue
-        if (k // grouped_config.TILE_K) < grouped_config.STAGES:
-            continue
-        gemm_config = asdict(grouped_config)
-        if not is_gemm_config_valid_for_shape(m, n, k, dtype_id, gemm_config):
-            continue
-        configs.append(gemm_config)
-    if not configs:
+    if not candidates:
         log.warning("No valid FlyDSL grouped GEMM configuration is available")
-    return configs
+        return []
+    return [asdict(gemm_config) for gemm_config in candidates]

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -220,9 +220,52 @@ def get_gemm_configs() -> list[dict[str, int | bool]]:
     return [asdict(gemm_config) for gemm_config in configs]
 
 
+def _is_grouped_gemm_layout_valid(
+    tile_m: int,
+    tile_n: int,
+    m_waves: int,
+    n_waves: int,
+    use_half_tile_interleaved: bool,
+) -> bool:
+    """Return whether a config satisfies grouped B-LDS and C-shuffle layouts."""
+    divisor = 2 if use_half_tile_interleaved else 1
+    effective_tile_m = tile_m // divisor
+    effective_tile_n = tile_n // divisor
+    if (
+        effective_tile_m <= 0
+        or effective_tile_n < 64
+        or effective_tile_n & (effective_tile_n - 1)
+        or m_waves <= 0
+        or n_waves <= 0
+    ):
+        return False
+
+    cshuffle_x_threads = effective_tile_n // 8
+    block_threads = m_waves * n_waves * 64
+    if block_threads % cshuffle_x_threads != 0:
+        return False
+    return effective_tile_m % (block_threads // cshuffle_x_threads) == 0
+
+
 def get_exhaustive_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
     """Return exhaustive configs for the gfx950 FlyDSL grouped GEMM kernel."""
-    return get_exhaustive_gemm_configs()
+    return [
+        gemm_config
+        for gemm_config in get_exhaustive_gemm_configs()
+        if _is_grouped_gemm_layout_valid(
+            gemm_config.TILE_M,
+            gemm_config.TILE_N,
+            gemm_config.BLOCK_M_WARPS,
+            gemm_config.BLOCK_N_WARPS,
+            gemm_config.USE_HALF_TILE_INTERLEAVED,
+        )
+    ]
+
+
+# Baseline used when FlyDSL autotuning is disabled. The dataclass defaults
+# describe the dense kernel, whose 4x4 wave split does not apply here, so the
+# grouped baseline is named explicitly; it must stay in the candidate list below.
+DEFAULT_GROUPED_GEMM_CONFIG = FlyDSLGemmConfig(128, 128, 64, 2, 1, 4, 0)
 
 
 @functools.cache
@@ -291,6 +334,8 @@ def is_grouped_gemm_config_valid_for_shape(
     tile_n = int(gemm_config["TILE_N"])
     tile_k = int(gemm_config["TILE_K"])
     stages = int(gemm_config["STAGES"])
+    m_waves = int(gemm_config["BLOCK_M_WARPS"])
+    n_waves = int(gemm_config["BLOCK_N_WARPS"])
     use_half_tile_interleaved = bool(gemm_config["USE_HALF_TILE_INTERLEAVED"])
     has_enough_k = use_half_tile_interleaved or k // tile_k >= stages
     return (
@@ -298,6 +343,9 @@ def is_grouped_gemm_config_valid_for_shape(
         and n >= tile_n
         and n % tile_n == 0
         and has_enough_k
+        and _is_grouped_gemm_layout_valid(
+            tile_m, tile_n, m_waves, n_waves, use_half_tile_interleaved
+        )
         and is_gemm_config_valid_for_shape(m, n, k, dtype_id, gemm_config)
     )
 
@@ -306,6 +354,7 @@ def get_grouped_gemm_configs() -> list[dict[str, int | bool]]:
     """Return configs for the persistent multi-stage grouped kernel.
 
     Shape compatibility is checked in the lowering before this function is called.
+    By default, autotuning is disabled and we return only a single baseline config.
     """
     if (
         config.flydsl_enable_autotuning
@@ -315,7 +364,7 @@ def get_grouped_gemm_configs() -> list[dict[str, int | bool]]:
     else:
         candidates = get_default_grouped_gemm_configs()
         if not config.flydsl_enable_autotuning:
-            candidates = candidates[:1]
+            candidates = [c for c in candidates if c == DEFAULT_GROUPED_GEMM_CONFIG]
 
     if not candidates:
         log.warning("No valid FlyDSL grouped GEMM configuration is available")

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -62,6 +62,7 @@ from ..utils import (
     use_triton_tma_template,
 )
 from .mm_common import (
+    _fits_int32_buffer_span,
     _is_static_problem,
     _use_small_mm_pointwise,
     load_kernel_template,
@@ -213,21 +214,6 @@ def check_supported_striding(mat_a, mat_b) -> None:
     torch._check(
         is_col_major(mat_b.get_stride()) or has_zero_dim(mat_b.get_size()),
         lambda: f"mat_b must be col_major, got stride {mat_b.get_stride()}",
-    )
-
-
-def _fits_int32_buffer_span(
-    rows: int, row_stride: int | None, cols: int, itemsize: int
-) -> bool:
-    # Descriptor fields are signed int32, but AMD buffer voffset is an unsigned
-    # 32-bit byte offset.
-    int32_max = (1 << 31) - 1
-    return (
-        0 < rows <= int32_max
-        and 0 < cols <= int32_max
-        and row_stride is not None
-        and 0 <= row_stride <= int32_max
-        and ((rows - 1) * row_stride + cols) * itemsize < 1 << 32
     )
 
 

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -214,6 +214,21 @@ def _use_small_mm_pointwise(m, k, n, layout) -> bool:
     return skt(m >= 64) and skt(k < 5) and skt(n < 5)
 
 
+def _fits_int32_buffer_span(
+    rows: int, row_stride: int | None, cols: int, itemsize: int
+) -> bool:
+    # Descriptor fields are signed int32, but AMD buffer voffset is an unsigned
+    # 32-bit byte offset.
+    int32_max = (1 << 31) - 1
+    return (
+        0 < rows <= int32_max
+        and 0 < cols <= int32_max
+        and row_stride is not None
+        and 0 <= row_stride <= int32_max
+        and ((rows - 1) * row_stride + cols) * itemsize < 1 << 32
+    )
+
+
 def _is_static_problem(layout: Layout) -> tuple[bool, bool]:
     """
     Check if input tensors and output layout have static shapes and non-zero sizes.

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -6,6 +6,7 @@ from typing import Any
 import torch
 from torch._dynamo.utils import counters
 from torch._inductor.codegen.cutedsl.cutedsl_template import CuteDSLTemplate
+from torch._inductor.codegen.flydsl.flydsl_template import FlyDSLTemplate
 from torch._inductor.heuristics.template.cutedsl import get_groupgemm_configs
 from torch._inductor.runtime.triton_compat import tl
 from torch._inductor.virtualized import V
@@ -25,6 +26,7 @@ from ..utils import (
     has_free_symbols,
     use_aten_gemm_kernels,
     use_blackwell_cutedsl_grouped_mm,
+    use_flydsl_gemm_template,
     use_nv_universal_gemm_template,
     use_triton_template,
 )
@@ -141,6 +143,79 @@ cutedsl_grouped_mm_template = CuteDSLTemplate(
     name="grouped_gemm_cutedsl",
     source=load_kernel_template("cutedsl_mm_grouped"),
 )
+
+flydsl_grouped_mm_template = FlyDSLTemplate(
+    name="grouped_gemm_flydsl",
+    source=load_kernel_template("flydsl_grouped_mm"),
+)
+
+
+def get_flydsl_grouped_mm_template_kwargs(
+    mat_a: TensorBox,
+    mat_b: TensorBox,
+    layout: Layout,
+    a_is_2d: bool,
+    b_is_2d: bool,
+    offs: TensorBox | None,
+    bias: TensorBox | None,
+    scale_result: TensorBox | None,
+    is_nonzero: bool,
+) -> list[dict[str, object]]:
+    from ..heuristics.template.flydsl import get_grouped_gemm_configs
+
+    if not is_nonzero or not use_flydsl_gemm_template(layout):
+        return []
+    # FlyDSL grouped GEMM only supports a 2D ragged A gathered by group offsets
+    # against a 3D [G, K, N] B; bias/scale fusion is not implemented.
+    if not (a_is_2d and not b_is_2d and offs is not None):
+        return []
+    if bias is not None or scale_result is not None:
+        return []
+    if mat_a.get_dtype() != mat_b.get_dtype() or layout.dtype != mat_a.get_dtype():
+        return []
+
+    sizevars = V.graph.sizevars
+    mat1_stride = mat_a.get_stride()
+    mat2_stride = mat_b.get_stride()
+    out_stride = layout.stride
+    if not sizevars.statically_known_equals(mat1_stride[-1], 1):
+        return []
+    if not sizevars.statically_known_equals(out_stride[-1], 1):
+        return []
+    # The grouped kernel consumes B as [G, K, N] with the N dimension contiguous.
+    if not sizevars.statically_known_equals(mat2_stride[-1], 1):
+        return []
+
+    dtype = mat_a.get_dtype()
+    if dtype not in (torch.float16, torch.bfloat16):
+        return []
+
+    n = mat_b.get_size()[-1]
+    k = mat_a.get_size()[-1]
+    try:
+        n_static = int(n)
+        k_static = int(k)
+        # Total M only prunes configs here; exact per-group sizes remain runtime
+        # values read from offs by the persistent kernel's on-device tile scan.
+        m_static = int(mat_a.get_size()[0])
+    except (TypeError, ValueError):
+        return []
+    if n_static % 32 != 0 or k_static % 32 != 0:
+        return []
+
+    from .vendored_templates.flydsl.kernels import GEMM_DTYPE_BF16, GEMM_DTYPE_FP16
+
+    dtype_id = GEMM_DTYPE_FP16 if dtype == torch.float16 else GEMM_DTYPE_BF16
+    return [
+        {
+            **gemm_config,
+            "GEMM_DTYPE_ID": dtype_id,
+            "GEMM_M": m_static,
+            "GEMM_N": n_static,
+            "GEMM_K": k_static,
+        }
+        for gemm_config in get_grouped_gemm_configs(m_static, n_static, k_static)
+    ]
 
 
 def has_grouped_mm_triton_support() -> bool:
@@ -484,6 +559,16 @@ def _tuned_grouped_mm_common(
                 **kwargs,
                 **asdict(config),
             )
+
+    for flydsl_kwargs in get_flydsl_grouped_mm_template_kwargs(
+        mat_a, mat_b, layout, a_is_2d, b_is_2d, offs, bias, scale_result, is_nonzero
+    ):
+        flydsl_grouped_mm_template.maybe_append_choice(
+            choices,
+            input_nodes=input_nodes,
+            layout=layout,
+            **flydsl_kwargs,
+        )
 
     if (
         is_nonzero

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -12,6 +12,7 @@ from torch._inductor.runtime.triton_compat import tl
 from torch._inductor.virtualized import V
 from torch.utils._triton import has_triton
 
+from ..codegen.wrapper import PythonWrapperCodegen
 from ..ir import ChoiceCaller, is_unaligned, Layout, TensorBox
 from ..lowering import register_lowering
 from ..select_algorithm import (
@@ -32,6 +33,7 @@ from ..utils import (
     use_triton_template,
 )
 from .mm_common import (
+    _fits_int32_buffer_span,
     _is_static_problem,
     check_supported_striding,
     load_kernel_template,
@@ -163,7 +165,10 @@ def get_flydsl_grouped_mm_template_kwargs(
     is_nonzero: bool,
 ) -> list[dict[str, object]]:
     """Return supported FlyDSL template configs for grouped matrix multiplication."""
-    from ..heuristics.template.flydsl import get_grouped_gemm_configs
+    from ..heuristics.template.flydsl import (
+        get_grouped_gemm_configs,
+        is_grouped_gemm_config_valid_for_shape,
+    )
 
     if not is_nonzero or not use_flydsl_gemm_template(layout):
         return []
@@ -219,27 +224,25 @@ def get_flydsl_grouped_mm_template_kwargs(
     ):
         return []
 
-    try:
-        n_static = int(n)
-        k_static = int(k)
-        g_static = int(g)
-        # Total M only prunes configs here; exact per-group sizes remain runtime
-        # values read from offs by the persistent kernel's on-device tile scan.
-        m_static = int(mat_a.get_size()[0])
-    except (TypeError, ValueError):
+    # Total M only prunes configs here; exact per-group sizes remain runtime
+    # values read from offs by the persistent kernel's on-device tile scan.
+    m_static = PythonWrapperCodegen.statically_known_int_or_none(mat_a.get_size()[0])
+    n_static = PythonWrapperCodegen.statically_known_int_or_none(n)
+    k_static = PythonWrapperCodegen.statically_known_int_or_none(k)
+    g_static = PythonWrapperCodegen.statically_known_int_or_none(g)
+    if m_static is None or n_static is None or k_static is None or g_static is None:
         return []
     if n_static % 32 != 0 or k_static % 32 != 0:
         return []
-    int32_max = (1 << 31) - 1
-    dimensions = (m_static, n_static, k_static, g_static)
-    if any(dim <= 0 or dim > int32_max for dim in dimensions):
-        return []
     tensor_spans = (
-        m_static * k_static,
-        g_static * k_static * n_static,
-        m_static * n_static,
+        (m_static, k_static, k_static),
+        (g_static, k_static * n_static, k_static * n_static),
+        (m_static, n_static, n_static),
     )
-    if any(span * itemsize >= 1 << 32 for span in tensor_spans):
+    if any(
+        not _fits_int32_buffer_span(rows, stride, cols, itemsize)
+        for rows, stride, cols in tensor_spans
+    ):
         return []
 
     from .vendored_templates.flydsl.kernels import GEMM_DTYPE_BF16, GEMM_DTYPE_FP16
@@ -253,8 +256,9 @@ def get_flydsl_grouped_mm_template_kwargs(
             "GEMM_N": n_static,
             "GEMM_K": k_static,
         }
-        for gemm_config in get_grouped_gemm_configs(
-            m_static, n_static, k_static, dtype_id
+        for gemm_config in get_grouped_gemm_configs()
+        if is_grouped_gemm_config_valid_for_shape(
+            m_static, n_static, k_static, dtype_id, gemm_config
         )
     ]
 

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -12,7 +12,7 @@ from torch._inductor.runtime.triton_compat import tl
 from torch._inductor.virtualized import V
 from torch.utils._triton import has_triton
 
-from ..ir import ChoiceCaller, Layout, TensorBox
+from ..ir import ChoiceCaller, is_unaligned, Layout, TensorBox
 from ..lowering import register_lowering
 from ..select_algorithm import (
     autotune_select_algorithm,
@@ -23,6 +23,7 @@ from ..select_algorithm import (
 from ..utils import (
     get_gpu_shared_memory,
     get_num_sms,
+    GPU_ALIGN_BYTES,
     has_free_symbols,
     use_aten_gemm_kernels,
     use_blackwell_cutedsl_grouped_mm,
@@ -161,6 +162,7 @@ def get_flydsl_grouped_mm_template_kwargs(
     scale_result: TensorBox | None,
     is_nonzero: bool,
 ) -> list[dict[str, object]]:
+    """Return supported FlyDSL template configs for grouped matrix multiplication."""
     from ..heuristics.template.flydsl import get_grouped_gemm_configs
 
     if not is_nonzero or not use_flydsl_gemm_template(layout):
@@ -192,15 +194,52 @@ def get_flydsl_grouped_mm_template_kwargs(
 
     n = mat_b.get_size()[-1]
     k = mat_a.get_size()[-1]
+    g = mat_b.get_size()[0]
+    if not sizevars.statically_known_equals(mat1_stride[-2], k):
+        return []
+    if not sizevars.statically_known_equals(mat2_stride[-2], n):
+        return []
+    if not sizevars.statically_known_equals(mat2_stride[-3], k * n):
+        return []
+    if not sizevars.statically_known_equals(out_stride[-2], n):
+        return []
+
+    itemsize = dtype.itemsize
+    aligned_byte_offsets = (
+        mat_a.get_layout().offset * itemsize,
+        mat_b.get_layout().offset * itemsize,
+    )
+    if (
+        is_unaligned(mat_a)
+        or is_unaligned(mat_b)
+        or any(
+            not sizevars.statically_known_multiple_of(offset, GPU_ALIGN_BYTES)
+            for offset in aligned_byte_offsets
+        )
+    ):
+        return []
+
     try:
         n_static = int(n)
         k_static = int(k)
+        g_static = int(g)
         # Total M only prunes configs here; exact per-group sizes remain runtime
         # values read from offs by the persistent kernel's on-device tile scan.
         m_static = int(mat_a.get_size()[0])
     except (TypeError, ValueError):
         return []
     if n_static % 32 != 0 or k_static % 32 != 0:
+        return []
+    int32_max = (1 << 31) - 1
+    dimensions = (m_static, n_static, k_static, g_static)
+    if any(dim <= 0 or dim > int32_max for dim in dimensions):
+        return []
+    tensor_spans = (
+        m_static * k_static,
+        g_static * k_static * n_static,
+        m_static * n_static,
+    )
+    if any(span * itemsize >= 1 << 32 for span in tensor_spans):
         return []
 
     from .vendored_templates.flydsl.kernels import GEMM_DTYPE_BF16, GEMM_DTYPE_FP16
@@ -214,7 +253,9 @@ def get_flydsl_grouped_mm_template_kwargs(
             "GEMM_N": n_static,
             "GEMM_K": k_static,
         }
-        for gemm_config in get_grouped_gemm_configs(m_static, n_static, k_static)
+        for gemm_config in get_grouped_gemm_configs(
+            m_static, n_static, k_static, dtype_id
+        )
     ]
 
 
@@ -560,15 +601,24 @@ def _tuned_grouped_mm_common(
                 **asdict(config),
             )
 
-    for flydsl_kwargs in get_flydsl_grouped_mm_template_kwargs(
-        mat_a, mat_b, layout, a_is_2d, b_is_2d, offs, bias, scale_result, is_nonzero
-    ):
-        flydsl_grouped_mm_template.maybe_append_choice(
-            choices,
-            input_nodes=input_nodes,
-            layout=layout,
-            **flydsl_kwargs,
-        )
+    if not scaled:
+        for flydsl_kwargs in get_flydsl_grouped_mm_template_kwargs(
+            mat_a,
+            mat_b,
+            layout,
+            a_is_2d,
+            b_is_2d,
+            offs,
+            bias,
+            scale_result,
+            is_nonzero,
+        ):
+            flydsl_grouped_mm_template.maybe_append_choice(
+                choices,
+                input_nodes=input_nodes,
+                layout=layout,
+                **flydsl_kwargs,
+            )
 
     if (
         is_nonzero

--- a/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
@@ -1,0 +1,206 @@
+import contextlib
+import os
+import threading
+
+from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+    get_grouped_gemm_persistent_grid_size,
+    infer_has_k_tail,
+    launch_gemm_gfx950_grouped,
+    make_gemm_param_and_validate,
+)
+from torch._inductor.runtime.flydsl_cache import (
+    ensure_flydsl_cache_dir,
+    run_cached_flydsl,
+)
+
+{{gen_defines()}}
+
+
+_grouped_param = None
+_grouped_executor = None
+_grouped_init_lock = threading.Lock()
+_grouped_grid_key = None
+_grouped_grid_size = None
+
+
+def _inductor_tensor_arg(tensor):
+    return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
+
+
+@contextlib.contextmanager
+def _temporary_env(updates):
+    old_values = {key: os.environ.get(key) for key in updates}
+    os.environ.update(
+        {key: value for key, value in updates.items() if value is not None}
+    )
+    try:
+        yield
+    finally:
+        for key, old_value in old_values.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+
+
+def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
+    global _grouped_executor, _grouped_grid_key, _grouped_grid_size, _grouped_param
+    group_count, k, n = mat2.shape
+    total_m = mat1.shape[0]
+    if total_m == 0:
+        return output
+
+    executor = _grouped_executor
+    param = _grouped_param
+    if executor is None and param is None:
+        with _grouped_init_lock:
+            param = _grouped_param
+            if param is None:
+                has_k_tail = infer_has_k_tail(GEMM_K, TILE_K, STAGES)
+                param = make_gemm_param_and_validate(
+                    GEMM_M,
+                    GEMM_N,
+                    GEMM_K,
+                    {
+                        "dtype_id": GEMM_DTYPE_ID,
+                        "block_m": TILE_M,
+                        "block_n": TILE_N,
+                        "block_k": TILE_K,
+                        "stages": STAGES,
+                        "m_waves": BLOCK_M_WARPS,
+                        "n_waves": BLOCK_N_WARPS,
+                        "group_m": GROUP_M,
+                        "use_half_tile_interleaved": USE_HALF_TILE_INTERLEAVED,
+                        "has_bias": False,
+                        "has_k_tail": has_k_tail,
+                    },
+                )
+                assert param is not None, "unsupported FlyDSL grouped GEMM shape/config"
+                _grouped_param = param
+                _grouped_grid_key = None
+    assert param is not None
+
+    group_count = int(group_count)
+    total_m = int(total_m)
+    n_int = int(n)
+    k_int = int(k)
+    if os.environ.get("COMPILE_ONLY"):
+        grid_size = 1
+    else:
+        grid_key = (total_m, n_int, group_count, mat1.device)
+        if grid_key != _grouped_grid_key:
+            _grouped_grid_size = get_grouped_gemm_persistent_grid_size(
+                param,
+                total_m,
+                n_int,
+                group_count,
+                torch.cuda.get_device_properties(mat1.device),
+            )
+            _grouped_grid_key = grid_key
+        grid_size = _grouped_grid_size
+    output_mn = output.view(-1, n)
+    mat1_mk = mat1.view(-1, k)
+    compile_args = (
+        _inductor_tensor_arg(output_mn),
+        _inductor_tensor_arg(mat1_mk),
+        _inductor_tensor_arg(mat2),
+        _inductor_tensor_arg(offs),
+        group_count,
+        n_int,
+        k_int,
+        grid_size,
+        param,
+        stream,
+    )
+    dispatch_args = (
+        output_mn,
+        mat1_mk,
+        mat2,
+        offs,
+        group_count,
+        n_int,
+        k_int,
+        grid_size,
+        param,
+        stream,
+    )
+    if executor is not None:
+        executor(*dispatch_args)
+        return output
+
+    with _grouped_init_lock:
+        executor = _grouped_executor
+        if executor is None:
+            ensure_flydsl_cache_dir()
+            if os.environ.get("COMPILE_ONLY"):
+                flyc.compile(launch_gemm_gfx950_grouped, *compile_args)
+            else:
+                executor = run_cached_flydsl(
+                    launch_gemm_gfx950_grouped,
+                    *compile_args,
+                    constexpr_param=param,
+                    compiler=flyc.compile,
+                    dispatch_args=dispatch_args,
+                )
+                _grouped_executor = executor
+            return output
+
+    executor(*dispatch_args)
+    return output
+
+
+{{def_kernel("mat1", "mat2", "offs")}}
+    output = {{get_output()}}
+    return _flydsl_grouped_mm(output, mat1, mat2, offs, stream)
+
+
+def {{kernel_name}}_precompile(
+    precompile_shapes,
+    precompile_strides,
+    precompile_dtypes,
+    device_index=0,
+    device_capability=None,
+    flydsl_gpu_arch=None,
+):
+    """Warm FlyDSL's disk cache using metadata-only fake tensors."""
+    dtype_mat1 = getattr(torch, precompile_dtypes["mat1"])
+    dtype_mat2 = getattr(torch, precompile_dtypes["mat2"])
+    dtype_offs = getattr(torch, precompile_dtypes["offs"])
+    dtype_output = getattr(torch, precompile_dtypes["output"])
+
+    shape_mat1 = tuple(precompile_shapes["mat1"])
+    shape_mat2 = tuple(precompile_shapes["mat2"])
+    shape_offs = tuple(precompile_shapes["offs"])
+    shape_output = tuple(precompile_shapes["output"])
+
+    stride_mat1 = tuple(precompile_strides["mat1"])
+    stride_mat2 = tuple(precompile_strides["mat2"])
+    stride_offs = tuple(precompile_strides["offs"])
+    stride_output = tuple(precompile_strides["output"])
+
+    env_updates = {"COMPILE_ONLY": "1"}
+    if flydsl_gpu_arch is not None:
+        env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
+
+    with _temporary_env(env_updates):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+
+            def _fake_proxy(shape, stride, dtype):
+                return torch.empty_strided(shape, stride, dtype=dtype, device="cpu")
+
+            mat1 = _fake_proxy(shape_mat1, stride_mat1, dtype_mat1)
+            mat2 = _fake_proxy(shape_mat2, stride_mat2, dtype_mat2)
+            offs = _fake_proxy(shape_offs, stride_offs, dtype_offs)
+            output = _fake_proxy(shape_output, stride_output, dtype_output)
+
+            try:
+                {{kernel_name}}_main(mat1, mat2, offs, output, stream=0)
+            finally:
+                global _grouped_executor, _grouped_grid_key, _grouped_grid_size, _grouped_param
+                with _grouped_init_lock:
+                    _grouped_executor = None
+                    _grouped_grid_key = None
+                    _grouped_grid_size = None
+                    _grouped_param = None

--- a/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
@@ -102,25 +102,11 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
             )
             _grouped_grid_key = grid_key
         grid_size = _grouped_grid_size
-    output_mn = output.view(-1, n)
-    mat1_mk = mat1.view(-1, k)
     compile_args = (
-        _inductor_tensor_arg(output_mn),
-        _inductor_tensor_arg(mat1_mk),
+        _inductor_tensor_arg(output),
+        _inductor_tensor_arg(mat1),
         _inductor_tensor_arg(mat2),
         _inductor_tensor_arg(offs),
-        group_count,
-        n_int,
-        k_int,
-        grid_size,
-        param,
-        stream,
-    )
-    dispatch_args = (
-        output_mn,
-        mat1_mk,
-        mat2,
-        offs,
         group_count,
         n_int,
         k_int,
@@ -137,7 +123,18 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
             *compile_args,
             constexpr_param=param,
             compiler=flyc.compile,
-            dispatch_args=dispatch_args,
+            dispatch_args=(
+                output,
+                mat1,
+                mat2,
+                offs,
+                group_count,
+                n_int,
+                k_int,
+                grid_size,
+                param,
+                stream,
+            ),
         )
     return output
 

--- a/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
@@ -18,8 +18,6 @@ from torch._inductor.runtime.flydsl_cache import (
 
 _grouped_param = None
 _grouped_param_lock = threading.Lock()
-_grouped_grid_key = None
-_grouped_grid_size = None
 
 
 def _inductor_tensor_arg(tensor):
@@ -43,7 +41,7 @@ def _temporary_env(updates):
 
 
 def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
-    global _grouped_grid_key, _grouped_grid_size, _grouped_param
+    global _grouped_param
     group_count, k, n = mat2.shape
     total_m = mat1.shape[0]
     if total_m == 0:
@@ -82,26 +80,25 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
                         f"tile=({TILE_M}, {TILE_N}, {TILE_K}), stages={STAGES}"
                     )
                 _grouped_param = param
-                _grouped_grid_key = None
 
     group_count = int(group_count)
     total_m = int(total_m)
     n_int = int(n)
     k_int = int(k)
-    if os.environ.get("FLYDSL_COMPILE_ONLY"):
+    compile_only = bool(os.environ.get("FLYDSL_COMPILE_ONLY"))
+    if compile_only:
+        # Precompilation runs on fake tensors that have no device to query, and
+        # the persistent kernel reads its grid from gridDim, so the size the disk
+        # cache is warmed with does not have to match the one used at runtime.
         grid_size = 1
     else:
-        grid_key = (total_m, n_int, group_count, mat1.device)
-        if grid_key != _grouped_grid_key:
-            _grouped_grid_size = get_grouped_gemm_persistent_grid_size(
-                param,
-                total_m,
-                n_int,
-                group_count,
-                torch.cuda.get_device_properties(mat1.device),
-            )
-            _grouped_grid_key = grid_key
-        grid_size = _grouped_grid_size
+        grid_size = get_grouped_gemm_persistent_grid_size(
+            param,
+            total_m,
+            n_int,
+            group_count,
+            torch.cuda.get_device_properties(mat1.device),
+        )
     compile_args = (
         _inductor_tensor_arg(output),
         _inductor_tensor_arg(mat1),
@@ -115,7 +112,7 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
         stream,
     )
     ensure_flydsl_cache_dir()
-    if os.environ.get("FLYDSL_COMPILE_ONLY"):
+    if compile_only:
         flyc.compile(launch_gemm_gfx950_grouped, *compile_args)
     else:
         run_cached_flydsl(

--- a/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
@@ -17,8 +17,7 @@ from torch._inductor.runtime.flydsl_cache import (
 
 
 _grouped_param = None
-_grouped_executor = None
-_grouped_init_lock = threading.Lock()
+_grouped_param_lock = threading.Lock()
 _grouped_grid_key = None
 _grouped_grid_size = None
 
@@ -44,19 +43,20 @@ def _temporary_env(updates):
 
 
 def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
-    global _grouped_executor, _grouped_grid_key, _grouped_grid_size, _grouped_param
+    global _grouped_grid_key, _grouped_grid_size, _grouped_param
     group_count, k, n = mat2.shape
     total_m = mat1.shape[0]
     if total_m == 0:
         return output
 
-    executor = _grouped_executor
     param = _grouped_param
-    if executor is None and param is None:
-        with _grouped_init_lock:
+    if param is None:
+        with _grouped_param_lock:
             param = _grouped_param
             if param is None:
                 has_k_tail = infer_has_k_tail(GEMM_K, TILE_K, STAGES)
+                if USE_HALF_TILE_INTERLEAVED:
+                    has_k_tail = has_k_tail or (((GEMM_K + TILE_K - 1) // TILE_K) % 2 != 0)
                 param = make_gemm_param_and_validate(
                     GEMM_M,
                     GEMM_N,
@@ -75,16 +75,20 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
                         "has_k_tail": has_k_tail,
                     },
                 )
-                assert param is not None, "unsupported FlyDSL grouped GEMM shape/config"
+                if param is None:
+                    raise RuntimeError(
+                        f"unsupported FlyDSL grouped GEMM shape/config: M={GEMM_M}, "
+                        f"N={GEMM_N}, K={GEMM_K}, "
+                        f"tile=({TILE_M}, {TILE_N}, {TILE_K}), stages={STAGES}"
+                    )
                 _grouped_param = param
                 _grouped_grid_key = None
-    assert param is not None
 
     group_count = int(group_count)
     total_m = int(total_m)
     n_int = int(n)
     k_int = int(k)
-    if os.environ.get("COMPILE_ONLY"):
+    if os.environ.get("FLYDSL_COMPILE_ONLY"):
         grid_size = 1
     else:
         grid_key = (total_m, n_int, group_count, mat1.device)
@@ -124,28 +128,17 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
         param,
         stream,
     )
-    if executor is not None:
-        executor(*dispatch_args)
-        return output
-
-    with _grouped_init_lock:
-        executor = _grouped_executor
-        if executor is None:
-            ensure_flydsl_cache_dir()
-            if os.environ.get("COMPILE_ONLY"):
-                flyc.compile(launch_gemm_gfx950_grouped, *compile_args)
-            else:
-                executor = run_cached_flydsl(
-                    launch_gemm_gfx950_grouped,
-                    *compile_args,
-                    constexpr_param=param,
-                    compiler=flyc.compile,
-                    dispatch_args=dispatch_args,
-                )
-                _grouped_executor = executor
-            return output
-
-    executor(*dispatch_args)
+    ensure_flydsl_cache_dir()
+    if os.environ.get("FLYDSL_COMPILE_ONLY"):
+        flyc.compile(launch_gemm_gfx950_grouped, *compile_args)
+    else:
+        run_cached_flydsl(
+            launch_gemm_gfx950_grouped,
+            *compile_args,
+            constexpr_param=param,
+            compiler=flyc.compile,
+            dispatch_args=dispatch_args,
+        )
     return output
 
 
@@ -178,7 +171,7 @@ def {{kernel_name}}_precompile(
     stride_offs = tuple(precompile_strides["offs"])
     stride_output = tuple(precompile_strides["output"])
 
-    env_updates = {"COMPILE_ONLY": "1"}
+    env_updates = {"FLYDSL_COMPILE_ONLY": "1"}
     if flydsl_gpu_arch is not None:
         env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
 
@@ -194,13 +187,4 @@ def {{kernel_name}}_precompile(
             mat2 = _fake_proxy(shape_mat2, stride_mat2, dtype_mat2)
             offs = _fake_proxy(shape_offs, stride_offs, dtype_offs)
             output = _fake_proxy(shape_output, stride_output, dtype_output)
-
-            try:
-                {{kernel_name}}_main(mat1, mat2, offs, output, stream=0)
-            finally:
-                global _grouped_executor, _grouped_grid_key, _grouped_grid_size, _grouped_param
-                with _grouped_init_lock:
-                    _grouped_executor = None
-                    _grouped_grid_key = None
-                    _grouped_grid_size = None
-                    _grouped_param = None
+            {{kernel_name}}_main(mat1, mat2, offs, output, stream=0)

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -4,20 +4,24 @@ import importlib
 from typing import Any
 
 
-__all__ = [
-    "GEMM_DTYPE_BF16",
-    "GEMM_DTYPE_FP16",
-    "infer_has_k_tail",
-    "make_gemm_gfx950_param",
-    "make_gemm_param_and_validate",
-]
+_EXPORT_MODULES = {
+    "GEMM_DTYPE_BF16": "gemm_gfx950",
+    "GEMM_DTYPE_FP16": "gemm_gfx950",
+    "infer_has_k_tail": "gemm_gfx950",
+    "make_gemm_gfx950_param": "gemm_gfx950",
+    "make_gemm_param_and_validate": "gemm_gfx950",
+    "get_grouped_gemm_persistent_grid_size": "grouped_gemm_gfx950",
+    "launch_gemm_gfx950_grouped": "grouped_gemm_gfx950",
+}
+__all__ = list(_EXPORT_MODULES)
 
 
 def __getattr__(name: str) -> Any:
-    if name not in __all__:
+    submodule = _EXPORT_MODULES.get(name)
+    if submodule is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-    module = importlib.import_module(f"{__name__}.gemm_gfx950")
+    module = importlib.import_module(f"{__name__}.{submodule}")
     value = getattr(module, name)
     globals()[name] = value
     return value

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
@@ -40,6 +40,18 @@ class GemmGfx950Param:
     mma_k: fx.Constexpr[int]
 
 
+def _gemm_gfx950_smem_bytes(
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    stages: int,
+    in_data_bytes: int,
+    out_data_bytes: int,
+) -> int:
+    staged_smem_bytes = stages * (block_m + block_n) * block_k * in_data_bytes
+    return max(staged_smem_bytes, block_m * block_n * out_data_bytes)
+
+
 def make_gemm_gfx950_param(
     dtype_id: int = GEMM_DTYPE_BF16,
     block_m: int = 256,
@@ -102,8 +114,9 @@ def make_gemm_gfx950_param(
     elif block_n % cshuffle_vec_size != 0:
         raise ValueError("block_n must be divisible by the c-shuffle vector size")
 
-    smem_bytes = stages * (block_m + block_n) * block_k * in_dbytes
-    smem_bytes = max(smem_bytes, block_m * block_n * out_dbytes)
+    smem_bytes = _gemm_gfx950_smem_bytes(
+        block_m, block_n, block_k, stages, in_dbytes, out_dbytes
+    )
     smem_capacity = {
         "gfx942": 65536,
         "gfx950": 163840,
@@ -281,6 +294,28 @@ def buffer_load_lds_inline(rsrc, lds_ptr, global_offset, dma_bytes):
 
 def _elem_dtype(param: GemmGfx950Param):
     return fx.Float16 if const_expr(param.dtype_id == GEMM_DTYPE_FP16) else fx.BFloat16
+
+
+def _make_gemm_gfx950_tiled_mma(param: GemmGfx950Param):
+    mma_atom = fx.make_mma_atom(
+        fx.rocdl.MFMA(param.mma_m, param.mma_n, param.mma_k, _elem_dtype(param))
+    )
+    k_per_mfma_group = param.mma_k // 4
+    return fx.make_tiled_mma(
+        mma_atom,
+        fx.make_layout(
+            (param.m_waves, param.n_waves, 1),
+            (param.n_waves, 1, 0),
+        ),
+        fx.make_tile(
+            None,
+            None,
+            fx.make_layout(
+                (k_per_mfma_group, 4),
+                (1, k_per_mfma_group),
+            ),
+        ),
+    )
 
 
 @flyc.kernel
@@ -973,26 +1008,7 @@ def gemm_gfx950(
     k = fx.Int32(fx.get_scalar(a.shape[1]))
     a_row_stride = fx.Int32(fx.get_scalar(a.stride[0]))
     b_row_stride = fx.Int32(fx.get_scalar(b.stride[0]))
-    elem_dtype = _elem_dtype(param)
-    mma_atom = fx.make_mma_atom(
-        fx.rocdl.MFMA(param.mma_m, param.mma_n, param.mma_k, elem_dtype)
-    )
-    k_per_mfma_group = param.mma_k // 4
-    tiled_mma = fx.make_tiled_mma(
-        mma_atom,
-        fx.make_layout(
-            (param.m_waves, param.n_waves, 1),
-            (param.n_waves, 1, 0),
-        ),
-        fx.make_tile(
-            None,
-            None,
-            fx.make_layout(
-                (k_per_mfma_group, 4),
-                (1, k_per_mfma_group),
-            ),
-        ),
-    )
+    tiled_mma = _make_gemm_gfx950_tiled_mma(param)
     num_pid_m = (m + param.block_m - 1) // param.block_m
     num_pid_n = (n + param.block_n - 1) // param.block_n
     kernel_impl = (

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
@@ -40,18 +40,6 @@ class GemmGfx950Param:
     mma_k: fx.Constexpr[int]
 
 
-def _gemm_gfx950_smem_bytes(
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    stages: int,
-    in_data_bytes: int,
-    out_data_bytes: int,
-) -> int:
-    staged_smem_bytes = stages * (block_m + block_n) * block_k * in_data_bytes
-    return max(staged_smem_bytes, block_m * block_n * out_data_bytes)
-
-
 def make_gemm_gfx950_param(
     dtype_id: int = GEMM_DTYPE_BF16,
     block_m: int = 256,
@@ -114,9 +102,8 @@ def make_gemm_gfx950_param(
     elif block_n % cshuffle_vec_size != 0:
         raise ValueError("block_n must be divisible by the c-shuffle vector size")
 
-    smem_bytes = _gemm_gfx950_smem_bytes(
-        block_m, block_n, block_k, stages, in_dbytes, out_dbytes
-    )
+    smem_bytes = stages * (block_m + block_n) * block_k * in_dbytes
+    smem_bytes = max(smem_bytes, block_m * block_n * out_dbytes)
     smem_capacity = {
         "gfx942": 65536,
         "gfx950": 163840,
@@ -1009,8 +996,8 @@ def gemm_gfx950(
     a_row_stride = fx.Int32(fx.get_scalar(a.stride[0]))
     b_row_stride = fx.Int32(fx.get_scalar(b.stride[0]))
     tiled_mma = _make_gemm_gfx950_tiled_mma(param)
-    num_pid_m = (m + param.block_m - 1) // param.block_m
-    num_pid_n = (n + param.block_n - 1) // param.block_n
+    num_pid_m = (m - 1) // param.block_m + 1
+    num_pid_n = (n - 1) // param.block_n + 1
     kernel_impl = (
         gemm_hti_gfx950_kernel
         if param.use_half_tile_interleaved

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
@@ -40,6 +40,18 @@ class GemmGfx950Param:
     mma_k: fx.Constexpr[int]
 
 
+def _gemm_gfx950_smem_bytes(
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    stages: int,
+    in_data_bytes: int,
+    out_data_bytes: int,
+) -> int:
+    staged_smem_bytes = stages * (block_m + block_n) * block_k * in_data_bytes
+    return max(staged_smem_bytes, block_m * block_n * out_data_bytes)
+
+
 def make_gemm_gfx950_param(
     dtype_id: int = GEMM_DTYPE_BF16,
     block_m: int = 256,
@@ -102,8 +114,9 @@ def make_gemm_gfx950_param(
     elif block_n % cshuffle_vec_size != 0:
         raise ValueError("block_n must be divisible by the c-shuffle vector size")
 
-    smem_bytes = stages * (block_m + block_n) * block_k * in_dbytes
-    smem_bytes = max(smem_bytes, block_m * block_n * out_dbytes)
+    smem_bytes = _gemm_gfx950_smem_bytes(
+        block_m, block_n, block_k, stages, in_dbytes, out_dbytes
+    )
     smem_capacity = {
         "gfx942": 65536,
         "gfx950": 163840,
@@ -281,6 +294,28 @@ def buffer_load_lds_inline(rsrc, lds_ptr, global_offset, dma_bytes):
 
 def _elem_dtype(param: GemmGfx950Param):
     return fx.Float16 if const_expr(param.dtype_id == GEMM_DTYPE_FP16) else fx.BFloat16
+
+
+def _make_gemm_gfx950_tiled_mma(param: GemmGfx950Param):
+    mma_atom = fx.make_mma_atom(
+        fx.rocdl.MFMA(param.mma_m, param.mma_n, param.mma_k, _elem_dtype(param))
+    )
+    k_per_mfma_group = param.mma_k // 4
+    return fx.make_tiled_mma(
+        mma_atom,
+        fx.make_layout(
+            (param.m_waves, param.n_waves, 1),
+            (param.n_waves, 1, 0),
+        ),
+        fx.make_tile(
+            None,
+            None,
+            fx.make_layout(
+                (k_per_mfma_group, 4),
+                (1, k_per_mfma_group),
+            ),
+        ),
+    )
 
 
 @flyc.kernel
@@ -973,28 +1008,9 @@ def gemm_gfx950(
     k = fx.Int32(fx.get_scalar(a.shape[1]))
     a_row_stride = fx.Int32(fx.get_scalar(a.stride[0]))
     b_row_stride = fx.Int32(fx.get_scalar(b.stride[0]))
-    elem_dtype = _elem_dtype(param)
-    mma_atom = fx.make_mma_atom(
-        fx.rocdl.MFMA(param.mma_m, param.mma_n, param.mma_k, elem_dtype)
-    )
-    k_per_mfma_group = param.mma_k // 4
-    tiled_mma = fx.make_tiled_mma(
-        mma_atom,
-        fx.make_layout(
-            (param.m_waves, param.n_waves, 1),
-            (param.n_waves, 1, 0),
-        ),
-        fx.make_tile(
-            None,
-            None,
-            fx.make_layout(
-                (k_per_mfma_group, 4),
-                (1, k_per_mfma_group),
-            ),
-        ),
-    )
-    num_pid_m = (m - 1) // param.block_m + 1
-    num_pid_n = (n - 1) // param.block_n + 1
+    tiled_mma = _make_gemm_gfx950_tiled_mma(param)
+    num_pid_m = (m + param.block_m - 1) // param.block_m
+    num_pid_n = (n + param.block_n - 1) // param.block_n
     kernel_impl = (
         gemm_hti_gfx950_kernel
         if param.use_half_tile_interleaved

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
@@ -1,0 +1,1010 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import const_expr, range_constexpr, rocdl
+
+from .gemm_gfx950 import (
+    __barrier,
+    __waitcnt,
+    _elem_dtype,
+    _gemm_gfx950_smem_bytes,
+    _make_gemm_gfx950_tiled_mma,
+    BlockSwizzle,
+    buffer_load_lds_inline,
+    GEMM_DTYPE_FP16,
+    GemmGfx950Param,
+    GFX950_DMA_BYTES,
+    GFX950_WAVE_SIZE,
+)
+
+
+def _grouped_swizzle_tile(param, num_pid_m, num_pid_n, local_tile):
+    bid_m = local_tile % num_pid_m
+    bid_n = local_tile // num_pid_m
+    if const_expr(param.group_m <= 0):
+        return bid_m, bid_n
+
+    block_swizzle = BlockSwizzle(
+        NUM_XCDS=8, NUM_PIDS_THRESHOLD=256, GROUP_M=param.group_m
+    )
+    swizzled_m, swizzled_n = block_swizzle.swizzle(num_pid_m, num_pid_n, local_tile)
+    num_workgroups = num_pid_m * num_pid_n
+    use_block_swizzle = (num_workgroups >= 256) & ((num_workgroups % 8) == 0)
+    if const_expr(isinstance(use_block_swizzle, bool)):
+        if const_expr(use_block_swizzle):
+            return swizzled_m, swizzled_n
+        return bid_m, bid_n
+    return (
+        use_block_swizzle.select(swizzled_m, bid_m),
+        use_block_swizzle.select(swizzled_n, bid_n),
+    )
+
+
+def get_grouped_gemm_persistent_grid_size(
+    param: GemmGfx950Param,
+    total_m: int,
+    n: int,
+    group_count: int,
+    device_properties,
+) -> int:
+    num_cus = int(getattr(device_properties, "multi_processor_count", 1) or 1)
+    if total_m <= 0 or n <= 0 or group_count <= 0:
+        return 1
+
+    smem_bytes = _gemm_gfx950_smem_bytes(
+        param.block_m,
+        param.block_n,
+        param.block_k,
+        param.stages,
+        param.in_data_bytes,
+        param.out_data_bytes,
+    )
+    shared_memory_per_cu = getattr(
+        device_properties, "shared_memory_per_multiprocessor", None
+    )
+    max_threads_per_cu = getattr(
+        device_properties, "max_threads_per_multi_processor", None
+    )
+    if shared_memory_per_cu is None or max_threads_per_cu is None:
+        resource_blocks_per_cu = 1
+    else:
+        resource_blocks_per_cu = min(
+            max(int(shared_memory_per_cu) // smem_bytes, 1),
+            max(int(max_threads_per_cu) // param.block_threads, 1),
+        )
+
+    light_tile = param.block_m <= 64 and param.block_n <= 128
+    n_tiles = (n + param.block_n - 1) // param.block_n
+    if light_tile:
+        for blocks_per_cu in (8, 4, 2, 1):
+            if blocks_per_cu <= resource_blocks_per_cu:
+                break
+        # The host only knows total M. This lower bound prevents empty CTAs
+        # for uniformly small groups, even though ragged inputs have more work.
+        task_floor = (total_m + param.block_m - 1) // param.block_m * n_tiles
+        return max(1, min(num_cus * blocks_per_cu, task_floor))
+
+    blocks_per_cu = 2 if resource_blocks_per_cu >= 2 else 1
+    nonempty_groups_upper = min(group_count, total_m)
+    m_tiles_upper = (
+        nonempty_groups_upper + (total_m - nonempty_groups_upper) // param.block_m
+    )
+    return max(1, min(num_cus * blocks_per_cu, m_tiles_upper * n_tiles))
+
+
+def make_grouped_gemm_gfx950_kernel_name(param: GemmGfx950Param) -> str:
+    dtype_str = "fp16" if param.dtype_id == GEMM_DTYPE_FP16 else "bf16"
+    name = (
+        f"grouped_gemm_{dtype_str}_"
+        f"t{param.block_m}x{param.block_n}x{param.block_k}x{param.stages}"
+    )
+    name += f"_w{param.m_waves}x{param.n_waves}"
+    name += f"_gm{param.group_m}"
+    name += f"_ktail{int(param.has_k_tail)}"
+    name += "_hti" if param.use_half_tile_interleaved else "_ft"
+    return name
+
+
+class _GroupedGemmGfx950Resources:
+    def __init__(
+        self,
+        a_buf,
+        b_buf,
+        out_buf,
+        offs_buf,
+        a_rsrc,
+        b_rsrc,
+        s2r_copy_atom,
+        r2g_copy_atom,
+        thr_mma,
+        thr_copy_A,
+        b_s2r_copy_atom,
+        thr_copy_B,
+    ):
+        self.a_buf = a_buf
+        self.b_buf = b_buf
+        self.out_buf = out_buf
+        self.offs_buf = offs_buf
+        self.a_rsrc = a_rsrc
+        self.b_rsrc = b_rsrc
+        self.s2r_copy_atom = s2r_copy_atom
+        self.r2g_copy_atom = r2g_copy_atom
+        self.thr_mma = thr_mma
+        self.thr_copy_A = thr_copy_A
+        self.b_s2r_copy_atom = b_s2r_copy_atom
+        self.thr_copy_B = thr_copy_B
+
+
+def _grouped_gemm_gfx950_resources(out, a, b, offs, tiled_mma, elem_dtype, tid):
+    a_buf = fx.rocdl.make_buffer_tensor(a, max_size=True)
+    b_buf = fx.rocdl.make_buffer_tensor(b, max_size=True)
+    out_buf = fx.rocdl.make_buffer_tensor(out, max_size=True)
+    offs_buf = fx.rocdl.make_buffer_tensor(offs, max_size=True)
+    a_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(a_buf))
+    b_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(b_buf))
+    s2r_copy_atom = fx.make_copy_atom(fx.UniversalCopy128b(), elem_dtype)
+    g2r_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_dtype)
+    r2g_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_dtype)
+    thr_mma = tiled_mma.thr_slice(tid)
+    thr_copy_A = fx.make_tiled_copy_A(g2r_copy_atom, tiled_mma).get_slice(tid)
+    b_s2r_copy_atom = fx.make_copy_atom(rocdl.cdna4.LDSReadTrans16_64b(), elem_dtype)
+    thr_copy_B = fx.make_tiled_copy_B(b_s2r_copy_atom, tiled_mma).get_slice(tid)
+    return _GroupedGemmGfx950Resources(
+        a_buf,
+        b_buf,
+        out_buf,
+        offs_buf,
+        a_rsrc,
+        b_rsrc,
+        s2r_copy_atom,
+        r2g_copy_atom,
+        thr_mma,
+        thr_copy_A,
+        b_s2r_copy_atom,
+        thr_copy_B,
+    )
+
+
+def _grouped_gemm_gfx950_allocate_shared_storage(
+    block_m, block_n, block_k, stages, elem_dtype
+):
+    @fx.struct
+    class SharedABStorage:
+        a: fx.Array[elem_dtype, stages * block_m * block_k, 16]
+        b: fx.Array[elem_dtype, stages * block_n * block_k, 16]
+
+    @fx.union
+    class SharedStorage:
+        ab: SharedABStorage
+        c: fx.Array[elem_dtype, block_m * block_n, 16]
+
+    storage = fx.SharedAllocator().allocate(SharedStorage)
+    return storage.ab.a.peek().ptr, storage.ab.b.peek().ptr, storage.c.peek().ptr
+
+
+class _GroupedGemmGfx950Ctx:
+    def __init__(
+        self,
+        param,
+        tid,
+        tiled_mma,
+        thr_mma,
+        smem_a,
+        smem_b,
+        a_rsrc,
+        b_rsrc,
+        a_buf,
+        b_buf,
+        out_buf,
+        offs_buf,
+        s2r_copy_atom,
+        r2g_copy_atom,
+        thr_copy_A,
+        thr_copy_B,
+        a_lds_layout,
+        b_lds_layout,
+        b_lds_s2r_layout,
+        sC,
+        frag_A,
+        frag_B,
+        frag_C,
+        frag_C_out,
+        frag_A_retile,
+        frag_B_retile,
+        thr_mma_cRow,
+        thr_mma_cCol,
+        thr_mma_bK,
+        b_s2r_copy_atom,
+        thr_copy_cshuffle,
+        thr_sC,
+        thr_cRow,
+        thr_cCol,
+        frag_C_cshuffle,
+        pred_C,
+        wave_offset,
+    ):
+        self.param = param
+        self.tid = tid
+        self.tiled_mma = tiled_mma
+        self.thr_mma = thr_mma
+        self.smem_a = smem_a
+        self.smem_b = smem_b
+        self.a_rsrc = a_rsrc
+        self.b_rsrc = b_rsrc
+        self.a_buf = a_buf
+        self.b_buf = b_buf
+        self.out_buf = out_buf
+        self.offs_buf = offs_buf
+        self.s2r_copy_atom = s2r_copy_atom
+        self.r2g_copy_atom = r2g_copy_atom
+        self.thr_copy_A = thr_copy_A
+        self.thr_copy_B = thr_copy_B
+        self.a_lds_layout = a_lds_layout
+        self.b_lds_layout = b_lds_layout
+        self.b_lds_s2r_layout = b_lds_s2r_layout
+        self.sC = sC
+        self.frag_A = frag_A
+        self.frag_B = frag_B
+        self.frag_C = frag_C
+        self.frag_C_out = frag_C_out
+        self.frag_A_retile = frag_A_retile
+        self.frag_B_retile = frag_B_retile
+        self.thr_mma_cRow = thr_mma_cRow
+        self.thr_mma_cCol = thr_mma_cCol
+        self.thr_mma_bK = thr_mma_bK
+        self.b_s2r_copy_atom = b_s2r_copy_atom
+        self.thr_copy_cshuffle = thr_copy_cshuffle
+        self.thr_sC = thr_sC
+        self.thr_cRow = thr_cRow
+        self.thr_cCol = thr_cCol
+        self.frag_C_cshuffle = frag_C_cshuffle
+        self.pred_C = pred_C
+        self.wave_offset = wave_offset
+
+
+def _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param):
+    block_m = param.block_m
+    block_n = param.block_n
+    block_k = param.block_k
+    stages = param.stages
+    block_threads = param.block_threads
+    elem_dtype = _elem_dtype(param)
+    tid = fx.thread_idx.x
+
+    smem_a, smem_b, smem_c = _grouped_gemm_gfx950_allocate_shared_storage(
+        block_m, block_n, block_k, stages, elem_dtype
+    )
+
+    rs = _grouped_gemm_gfx950_resources(out, a, b, offs, tiled_mma, elem_dtype, tid)
+
+    swizzle = fx.static(fx.SwizzleType.get(3, 3, 3))
+    a_lds_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_ordered_layout((block_m, block_k), (1, 0)),
+    )
+    b_lds_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_ordered_layout((block_k, block_n), (1, 0)),
+    )
+    b_lds_s2r_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_layout((block_n, block_k), (1, block_n)),
+    )
+    c_lds_layout = fx.make_layout((block_m, block_n), (block_n, 1))
+
+    sA = fx.make_view(smem_a, a_lds_layout)
+    sC = fx.make_view(smem_c, c_lds_layout)
+    frag_A = rs.thr_mma.make_fragment_A(sA)
+    bk_coords = fx.make_view(0, fx.make_layout((block_n, block_k), (0, 1)))
+    thr_mma_bK = rs.thr_mma.partition_B(bk_coords)
+    sB = fx.make_view(smem_b, b_lds_s2r_layout)
+    frag_B = rs.thr_mma.make_fragment_B(sB)
+    frag_B_retile = rs.thr_copy_B.retile(frag_B)
+
+    frag_C = rs.thr_mma.make_fragment_C(sC)
+    frag_C_out = fx.make_fragment_like(frag_C, elem_dtype)
+    frag_A_retile = rs.thr_copy_A.retile(frag_A)
+    row_coords = fx.make_view(0, fx.make_layout((block_m, block_n), (1, 0)))
+    col_coords = fx.make_view(0, fx.make_layout((block_m, block_n), (0, 1)))
+    thr_mma_cRow = rs.thr_mma.partition_C(row_coords)
+    thr_mma_cCol = rs.thr_mma.partition_C(col_coords)
+
+    cshuffle_vec_size = GFX950_DMA_BYTES // param.out_data_bytes
+    cshuffle_x_threads = block_n // cshuffle_vec_size
+    cshuffle_thr_layout = fx.make_layout(
+        (block_threads // cshuffle_x_threads, cshuffle_x_threads),
+        (cshuffle_x_threads, 1),
+    )
+    cshuffle_val_layout = fx.make_layout((1, cshuffle_vec_size), (1, 1))
+    cshuffle_tile, cshuffle_tv_layout = fx.make_layout_tv(
+        cshuffle_thr_layout,
+        cshuffle_val_layout,
+    )
+    tiled_copy_cshuffle = fx.make_tiled_copy(
+        rs.r2g_copy_atom,
+        cshuffle_tv_layout,
+        cshuffle_tile,
+    )
+    thr_copy_cshuffle = tiled_copy_cshuffle.get_slice(tid)
+    thr_sC = thr_copy_cshuffle.partition_S(sC)
+    thr_cRow = thr_copy_cshuffle.partition_S(row_coords)[(0, None), None, None]
+    thr_cCol = thr_copy_cshuffle.partition_S(col_coords)[(0, None), None, None]
+    frag_C_cshuffle = fx.make_fragment_like(thr_sC)
+    pred_C = fx.make_fragment_like(thr_cRow, dtype=fx.Boolean)
+    wave_offset = rocdl.readfirstlane(
+        fx.Int64.ir_type,
+        fx.Int64(tid // GFX950_WAVE_SIZE * GFX950_WAVE_SIZE * param.async_load_bytes),
+    )
+
+    return _GroupedGemmGfx950Ctx(
+        param,
+        tid,
+        tiled_mma,
+        rs.thr_mma,
+        smem_a,
+        smem_b,
+        rs.a_rsrc,
+        rs.b_rsrc,
+        rs.a_buf,
+        rs.b_buf,
+        rs.out_buf,
+        rs.offs_buf,
+        rs.s2r_copy_atom,
+        rs.r2g_copy_atom,
+        rs.thr_copy_A,
+        rs.thr_copy_B,
+        a_lds_layout,
+        b_lds_layout,
+        b_lds_s2r_layout,
+        sC,
+        frag_A,
+        frag_B,
+        frag_C,
+        frag_C_out,
+        frag_A_retile,
+        frag_B_retile,
+        thr_mma_cRow,
+        thr_mma_cCol,
+        thr_mma_bK,
+        rs.b_s2r_copy_atom,
+        thr_copy_cshuffle,
+        thr_sC,
+        thr_cRow,
+        thr_cCol,
+        frag_C_cshuffle,
+        pred_C,
+        wave_offset,
+    )
+
+
+def _grouped_tile_init(ctx, bid_m, bid_n, m, n, row_base):
+    param = ctx.param
+    block_m = param.block_m
+    block_n = param.block_n
+    tile_base = (row_base + bid_m * block_m) * n + bid_n * block_n
+    gC = fx.make_view(
+        fx.add_offset(fx.get_iter(ctx.out_buf), tile_base),
+        fx.make_layout((block_m, block_n), (n, 1)),
+    )
+    thr_gC = ctx.thr_copy_cshuffle.partition_D(gC)
+    ctx.frag_C.fill(0.0)
+
+    for i in range_constexpr(fx.size(ctx.pred_C.shape).unpack()):
+        local_row = fx.get_scalar(ctx.thr_cRow[i])
+        local_col = fx.get_scalar(ctx.thr_cCol[i])
+        row_idx = bid_m * block_m + local_row
+        col_idx = bid_n * block_n + local_col
+        ctx.pred_C[i] = (
+            (local_row < block_m)
+            & (local_col < block_n)
+            & (row_idx < m)
+            & (col_idx < n)
+        )
+    return thr_gC
+
+
+def _grouped_tile_store(ctx, thr_gC):
+    frag_C_out = ctx.frag_C_out
+    frag_C_out.store(ctx.frag_C.load().to(_elem_dtype(ctx.param)))
+
+    fx.gpu.barrier()
+    for i in range_constexpr(fx.size(frag_C_out.shape).unpack()):
+        row = fx.get_scalar(ctx.thr_mma_cRow[i])
+        col = fx.get_scalar(ctx.thr_mma_cCol[i])
+        ctx.sC[row, col] = frag_C_out[i]
+
+    fx.gpu.barrier()
+    fx.copy(ctx.s2r_copy_atom, ctx.thr_sC, ctx.frag_C_cshuffle)
+    fx.copy(ctx.r2g_copy_atom, ctx.frag_C_cshuffle, thr_gC, pred=ctx.pred_C)
+    fx.gpu.barrier()
+
+
+def _grouped_compute_stage_from_lds(ctx, read_stage, k_tile, k):
+    param = ctx.param
+    block_m = param.block_m
+    block_n = param.block_n
+    block_k = param.block_k
+    sA_stage = fx.make_view(
+        ctx.smem_a + read_stage * block_m * block_k,
+        ctx.a_lds_layout,
+    )
+    sB_stage = fx.make_view(
+        ctx.smem_b + read_stage * block_n * block_k,
+        ctx.b_lds_s2r_layout,
+    )
+    thr_sA_s2r = ctx.thr_copy_A.partition_S(sA_stage)
+    thr_sB_s2r = ctx.thr_copy_B.partition_S(sB_stage)
+
+    for block_k_iter in range_constexpr(block_k // param.mma_k):
+        fx.copy(
+            ctx.b_s2r_copy_atom,
+            thr_sB_s2r[None, None, block_k_iter],
+            ctx.frag_B_retile[None, None, block_k_iter],
+        )
+        if const_expr(param.has_k_tail):
+            frag_B_chunk = ctx.frag_B[None, None, block_k_iter]
+            bK_chunk = ctx.thr_mma_bK[None, None, block_k_iter]
+            for i in range_constexpr(fx.size(frag_B_chunk.shape).unpack()):
+                in_bounds = k_tile * block_k + fx.get_scalar(bK_chunk[i]) < k
+                frag_B_chunk[i] = in_bounds.select(
+                    frag_B_chunk[i], _elem_dtype(param)(0.0)
+                )
+        fx.copy(
+            ctx.s2r_copy_atom,
+            thr_sA_s2r[None, None, block_k_iter],
+            ctx.frag_A_retile[None, None, block_k_iter],
+        )
+        fx.gemm(
+            ctx.tiled_mma,
+            ctx.frag_C,
+            ctx.frag_A[None, None, block_k_iter],
+            ctx.frag_B[None, None, block_k_iter],
+            ctx.frag_C,
+            traversal_order=fx.GemmTraversalOrder.KNM,
+        )
+
+
+def _grouped_load_a_tile_async(ctx, row_base, bid_m, m, k, k_tile, stage):
+    param = ctx.param
+    block_m = param.block_m
+    block_k = param.block_k
+    async_load_bytes = param.async_load_bytes
+    in_data_bytes = param.in_data_bytes
+    async_load_vec_size = async_load_bytes // in_data_bytes
+    ldg_x_threads = param.ldg_x_threads
+    block_threads = param.block_threads
+    ldg_a_iters = param.ldg_a_iters
+    lds_ptr = fx.recast_iter(
+        fx.Int8, ctx.smem_a + stage * block_m * block_k
+    ) + fx.Int32(ctx.wave_offset)
+    for i in range_constexpr(ldg_a_iters):
+        global_tid = block_threads * i + ctx.tid
+        m_local_idx = global_tid // ldg_x_threads
+        k_local_idx = global_tid % ldg_x_threads * async_load_vec_size
+        in_bounds_m = bid_m * block_m + m_local_idx < m
+        global_m_idx = row_base + bid_m * block_m + m_local_idx
+        safe_global_m_idx = in_bounds_m.select(global_m_idx, 0)
+        col = (
+            fx.get_scalar(fx.crd2idx((m_local_idx, k_local_idx), ctx.a_lds_layout))
+            % block_k
+        )
+        global_k_idx = k_tile * block_k + col
+        if const_expr(param.has_k_tail):
+            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+        else:
+            safe_global_k_idx = global_k_idx
+        global_offset = (safe_global_m_idx * k + safe_global_k_idx) * in_data_bytes
+        buffer_load_lds_inline(ctx.a_rsrc, lds_ptr, global_offset, async_load_bytes)
+        if i < ldg_a_iters - 1:
+            lds_ptr = lds_ptr + block_threads * async_load_bytes
+
+
+def _grouped_load_b_tile_async(ctx, bid_n, n, k, group_idx, k_tile, stage):
+    param = ctx.param
+    block_n = param.block_n
+    block_k = param.block_k
+    async_load_bytes = param.async_load_bytes
+    in_data_bytes = param.in_data_bytes
+    async_load_vec_size = async_load_bytes // in_data_bytes
+    block_threads = param.block_threads
+    ldg_b_iters = param.ldg_b_iters
+    n_vectors = block_n // async_load_vec_size
+    lds_ptr = fx.recast_iter(
+        fx.Int8, ctx.smem_b + stage * block_n * block_k
+    ) + fx.Int32(ctx.wave_offset)
+
+    for i in range_constexpr(ldg_b_iters):
+        vector_idx = block_threads * i + ctx.tid
+        k_local_idx = vector_idx // n_vectors
+        n_local_idx = vector_idx % n_vectors * async_load_vec_size
+        global_k_idx = k_tile * block_k + k_local_idx
+        swizzled_n_idx = (
+            fx.get_scalar(fx.crd2idx((k_local_idx, n_local_idx), ctx.b_lds_layout))
+            % block_n
+        )
+        global_n_idx = bid_n * block_n + swizzled_n_idx
+        safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+        global_offset = (
+            group_idx * k * n + safe_global_k_idx * n + global_n_idx
+        ) * in_data_bytes
+        buffer_load_lds_inline(ctx.b_rsrc, lds_ptr, global_offset, async_load_bytes)
+        if i < ldg_b_iters - 1:
+            lds_ptr = lds_ptr + block_threads * async_load_bytes
+
+
+@flyc.kernel
+def gemm_gfx950_grouped_kernel(
+    out: fx.Tensor,
+    a: fx.Tensor,
+    b: fx.Tensor,
+    offs: fx.Tensor,
+    group_count: fx.Int32,
+    n: fx.Int32,
+    k: fx.Int32,
+    tiled_mma: fx.TiledMma,
+    param: GemmGfx950Param,
+):
+    ctx = _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param)
+    block_m = param.block_m
+    block_n = param.block_n
+    block_k = param.block_k
+    stages = param.stages
+    has_k_tail = param.has_k_tail
+    ldg_a_iters = param.ldg_a_iters
+    num_pid_n = (n + block_n - 1) // block_n
+    k_tiles = (k + block_k - 1) // block_k
+    grid = fx.Int32(fx.grid_dim.x)
+    work_idx = fx.Int32(fx.block_idx.x)
+    tiles_before = fx.Int32(0)
+    row_base = fx.Int32(0)
+    for g in range(0, group_count, 1):
+        row_end = fx.get_scalar(ctx.offs_buf[g])
+        m_g = row_end - row_base
+        num_pid_m = (m_g + block_m - 1) // block_m
+        tiles_after = tiles_before + num_pid_m * num_pid_n
+
+        for linear_tile in range(work_idx, tiles_after, grid):
+            local_tile = linear_tile - tiles_before
+            bid_m, bid_n = _grouped_swizzle_tile(
+                param, num_pid_m, num_pid_n, local_tile
+            )
+            thr_gC = _grouped_tile_init(ctx, bid_m, bid_n, m_g, n, row_base)
+            ldg_wait_count = ldg_a_iters + param.ldg_b_iters
+            for stage in range_constexpr(stages - 1):
+                _grouped_load_b_tile_async(ctx, bid_n, n, k, g, stage, stage)
+                _grouped_load_a_tile_async(ctx, row_base, bid_m, m_g, k, stage, stage)
+            rocdl.sched_barrier(0)
+            if const_expr(has_k_tail):
+                main_loop_end = (k_tiles > stages - 1).select(k_tiles - (stages - 1), 0)
+            else:
+                main_loop_end = k_tiles - (stages - 1)
+            for k_tile in range(0, main_loop_end, 1):
+                current_stage = k_tile % stages
+                write_stage = (current_stage + stages - 1) % stages
+                __barrier((stages - 2) * ldg_wait_count)
+                fx.gpu.barrier()
+                _grouped_load_b_tile_async(
+                    ctx, bid_n, n, k, g, k_tile + (stages - 1), write_stage
+                )
+                _grouped_load_a_tile_async(
+                    ctx, row_base, bid_m, m_g, k, k_tile + (stages - 1), write_stage
+                )
+                _grouped_compute_stage_from_lds(ctx, current_stage, k_tile, k)
+            current_stage = main_loop_end % stages
+            for s in range_constexpr(0, stages - 1):
+                __barrier((stages - 2 - s) * ldg_wait_count)
+                fx.gpu.barrier()
+                _grouped_compute_stage_from_lds(
+                    ctx, current_stage, main_loop_end + s, k
+                )
+                current_stage = (current_stage + 1) % stages
+            _grouped_tile_store(ctx, thr_gC)
+
+        remaining = (work_idx < tiles_after).select(tiles_after - work_idx, fx.Int32(0))
+        work_idx = work_idx + (remaining + grid - 1) // grid * grid
+        tiles_before = tiles_after
+        row_base = row_end
+
+
+@flyc.kernel
+def gemm_hti_gfx950_grouped_kernel(
+    out: fx.Tensor,
+    a: fx.Tensor,
+    b: fx.Tensor,
+    offs: fx.Tensor,
+    group_count: fx.Int32,
+    n: fx.Int32,
+    k: fx.Int32,
+    tiled_mma: fx.TiledMma,
+    param: GemmGfx950Param,
+):
+    block_m = param.block_m
+    block_n = param.block_n
+    block_k = param.block_k
+    half_block_m = block_m // 2
+    half_block_n = block_n // 2
+    async_load_bytes = param.async_load_bytes
+    in_data_bytes = param.in_data_bytes
+    async_load_vec_size = async_load_bytes // in_data_bytes
+    ldg_x_threads = param.ldg_x_threads
+    block_threads = param.block_threads
+    half_ldg_a_iters = param.ldg_a_iters // 2
+    half_ldg_b_iters = param.ldg_b_iters // 2
+    elem_dtype = _elem_dtype(param)
+
+    tid = fx.thread_idx.x
+    num_pid_n = (n + block_n - 1) // block_n
+    k_tiles = (k + block_k - 1) // block_k
+    has_odd_k_tiles = k_tiles % 2 != 0
+
+    smem_a, smem_b, smem_c = _grouped_gemm_gfx950_allocate_shared_storage(
+        block_m, block_n, block_k, 2, elem_dtype
+    )
+
+    rs = _grouped_gemm_gfx950_resources(out, a, b, offs, tiled_mma, elem_dtype, tid)
+
+    swizzle = fx.static(fx.SwizzleType.get(3, 3, 3))
+    a_lds_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_ordered_layout((half_block_m, block_k), (1, 0)),
+    )
+    b_half_lds_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_ordered_layout((block_k, half_block_n), (1, 0)),
+    )
+    b_half_lds_s2r_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_layout((half_block_n, block_k), (1, half_block_n)),
+    )
+    c_lds_layout = fx.make_layout((half_block_m, half_block_n), (half_block_n, 1))
+    wave_offset = rocdl.readfirstlane(
+        fx.Int64.ir_type,
+        fx.Int64(tid // GFX950_WAVE_SIZE * GFX950_WAVE_SIZE * async_load_bytes),
+    )
+
+    def make_wave_lds_ptr(ptr):
+        return fx.recast_iter(fx.Int8, ptr) + fx.Int32(wave_offset)
+
+    def swizzled_col_idx(row, col):
+        return fx.get_scalar(fx.crd2idx((row, col), a_lds_layout)) % block_k
+
+    def half_a_base(stage, m_part):
+        return smem_a + (stage * block_m + m_part * half_block_m) * block_k
+
+    def half_b_base(stage, n_part):
+        return smem_b + (stage * block_n + n_part * half_block_n) * block_k
+
+    def load_a_half(m_part, k_tile, stage, bid_m, m, row_base):
+        lds_ptr = make_wave_lds_ptr(half_a_base(stage, m_part))
+        for i in range_constexpr(half_ldg_a_iters):
+            global_tid = block_threads * i + tid
+            m_local_idx = global_tid // ldg_x_threads
+            k_local_idx = global_tid % ldg_x_threads * async_load_vec_size
+            m_tile_idx = bid_m * block_m + m_part * half_block_m + m_local_idx
+            in_bounds_m = m_tile_idx < m
+            safe_global_m_idx = in_bounds_m.select(row_base + m_tile_idx, 0)
+            global_k_idx = k_tile * block_k + swizzled_col_idx(m_local_idx, k_local_idx)
+            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            global_offset = (safe_global_m_idx * k + safe_global_k_idx) * in_data_bytes
+            buffer_load_lds_inline(rs.a_rsrc, lds_ptr, global_offset, async_load_bytes)
+            if i < half_ldg_a_iters - 1:
+                lds_ptr = lds_ptr + block_threads * async_load_bytes
+
+    def load_b_half(n_part, k_tile, stage, bid_n, group):
+        lds_ptr = make_wave_lds_ptr(half_b_base(stage, n_part))
+        n_vectors = half_block_n // async_load_vec_size
+        for i in range_constexpr(half_ldg_b_iters):
+            vector_idx = block_threads * i + tid
+            k_local_idx = vector_idx // n_vectors
+            n_local_idx = vector_idx % n_vectors * async_load_vec_size
+            global_k_idx = k_tile * block_k + k_local_idx
+            swizzled_n_idx = (
+                fx.get_scalar(fx.crd2idx((k_local_idx, n_local_idx), b_half_lds_layout))
+                % half_block_n
+            )
+            global_n_idx = bid_n * block_n + n_part * half_block_n + swizzled_n_idx
+            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            global_offset = (
+                group * k * n + safe_global_k_idx * n + global_n_idx
+            ) * in_data_bytes
+            buffer_load_lds_inline(rs.b_rsrc, lds_ptr, global_offset, async_load_bytes)
+            if i < half_ldg_b_iters - 1:
+                lds_ptr = lds_ptr + block_threads * async_load_bytes
+
+    def load_a_fragment(m_part, read_stage):
+        sA = fx.make_view(half_a_base(read_stage, m_part), a_lds_layout)
+        frag_A = rs.thr_mma.make_fragment_A(sA)
+        frag_A_retile = rs.thr_copy_A.retile(frag_A)
+        thr_sA_s2r = rs.thr_copy_A.partition_S(sA)
+        for block_k_iter in range_constexpr(block_k // param.mma_k):
+            fx.copy(
+                rs.s2r_copy_atom,
+                thr_sA_s2r[None, None, block_k_iter],
+                frag_A_retile[None, None, block_k_iter],
+            )
+        return frag_A
+
+    def load_b_fragment(n_part, read_stage, k_tile):
+        sB = fx.make_view(
+            half_b_base(read_stage, n_part),
+            b_half_lds_s2r_layout,
+        )
+        frag_B = rs.thr_mma.make_fragment_B(sB)
+        frag_B_retile = rs.thr_copy_B.retile(frag_B)
+        thr_sB_s2r = rs.thr_copy_B.partition_S(sB)
+        for block_k_iter in range_constexpr(block_k // param.mma_k):
+            fx.copy(
+                rs.b_s2r_copy_atom,
+                thr_sB_s2r[None, None, block_k_iter],
+                frag_B_retile[None, None, block_k_iter],
+            )
+            if const_expr(param.has_k_tail):
+                frag_B_chunk = frag_B[None, None, block_k_iter]
+                bK_chunk = thr_mma_bK[None, None, block_k_iter]
+                for i in range_constexpr(fx.size(frag_B_chunk.shape).unpack()):
+                    in_bounds = k_tile * block_k + fx.get_scalar(bK_chunk[i]) < k
+                    frag_B_chunk[i] = in_bounds.select(frag_B_chunk[i], elem_dtype(0.0))
+        return frag_B
+
+    def consume(frag_C, frag_A, frag_B):
+        rocdl.sched_barrier(0)
+        for block_k_iter in range_constexpr(block_k // param.mma_k):
+            fx.gemm(
+                tiled_mma,
+                frag_C,
+                frag_A[None, None, block_k_iter],
+                frag_B[None, None, block_k_iter],
+                frag_C,
+                traversal_order=fx.GemmTraversalOrder.KNM,
+            )
+        rocdl.sched_barrier(0)
+
+    def half_gC(m_part, n_part, bid_m, bid_n, row_base):
+        row = row_base + bid_m * block_m + m_part * half_block_m
+        col = bid_n * block_n + n_part * half_block_n
+        return fx.make_view(
+            fx.add_offset(fx.get_iter(rs.out_buf), row * n + col),
+            fx.make_layout((half_block_m, half_block_n), (n, 1)),
+        )
+
+    cshuffle_vec_size = GFX950_DMA_BYTES // param.out_data_bytes
+    cshuffle_x_threads = half_block_n // cshuffle_vec_size
+    cshuffle_thr_layout = fx.make_layout(
+        (block_threads // cshuffle_x_threads, cshuffle_x_threads),
+        (cshuffle_x_threads, 1),
+    )
+    cshuffle_val_layout = fx.make_layout((1, cshuffle_vec_size), (1, 1))
+    cshuffle_tile, cshuffle_tv_layout = fx.make_layout_tv(
+        cshuffle_thr_layout,
+        cshuffle_val_layout,
+    )
+    tiled_copy_cshuffle = fx.make_tiled_copy(
+        rs.r2g_copy_atom,
+        cshuffle_tv_layout,
+        cshuffle_tile,
+    )
+    thr_copy_cshuffle = tiled_copy_cshuffle.get_slice(tid)
+    row_coords = fx.make_view(0, fx.make_layout((half_block_m, half_block_n), (1, 0)))
+    col_coords = fx.make_view(0, fx.make_layout((half_block_m, half_block_n), (0, 1)))
+    thr_mma_cRow = rs.thr_mma.partition_C(row_coords)
+    thr_mma_cCol = rs.thr_mma.partition_C(col_coords)
+    thr_cRow = thr_copy_cshuffle.partition_S(row_coords)[(0, None), None, None]
+    thr_cCol = thr_copy_cshuffle.partition_S(col_coords)[(0, None), None, None]
+    bk_coords = fx.make_view(0, fx.make_layout((half_block_n, block_k), (0, 1)))
+    thr_mma_bK = rs.thr_mma.partition_B(bk_coords)
+
+    def store_half_tile(m_part, n_part, frag_C, bid_m, bid_n, m, row_base):
+        gC = half_gC(m_part, n_part, bid_m, bid_n, row_base)
+        sC = fx.make_view(smem_c, c_lds_layout)
+        thr_sC = thr_copy_cshuffle.partition_S(sC)
+        thr_gC = thr_copy_cshuffle.partition_D(gC)
+        frag_C_cshuffle = fx.make_fragment_like(thr_sC)
+        pred_C = fx.make_fragment_like(thr_cRow, dtype=fx.Boolean)
+
+        for i in range_constexpr(fx.size(pred_C.shape).unpack()):
+            local_row = fx.get_scalar(thr_cRow[i])
+            local_col = fx.get_scalar(thr_cCol[i])
+            row_idx = bid_m * block_m + m_part * half_block_m + local_row
+            col_idx = bid_n * block_n + n_part * half_block_n + local_col
+            pred_C[i] = (
+                (local_row < half_block_m)
+                & (local_col < half_block_n)
+                & (row_idx < m)
+                & (col_idx < n)
+            )
+
+        frag_C_out = fx.make_fragment_like(frag_C, elem_dtype)
+        for i in range_constexpr(fx.size(frag_C.shape).unpack()):
+            frag_C_out[i] = frag_C[i].to(elem_dtype)
+
+        fx.gpu.barrier()
+        for i in range_constexpr(fx.size(frag_C_out.shape).unpack()):
+            row = fx.get_scalar(thr_mma_cRow[i])
+            col = fx.get_scalar(thr_mma_cCol[i])
+            sC[row, col] = frag_C_out[i]
+
+        fx.gpu.barrier()
+        fx.copy(rs.s2r_copy_atom, thr_sC, frag_C_cshuffle)
+        fx.copy(rs.r2g_copy_atom, frag_C_cshuffle, thr_gC, pred=pred_C)
+        fx.gpu.barrier()
+
+    frag_shape = fx.make_view(
+        fx.get_iter(rs.out_buf),
+        fx.make_layout((half_block_m, half_block_n), (n, 1)),
+    )
+    c00 = rs.thr_mma.make_fragment_C(frag_shape)
+    c01 = rs.thr_mma.make_fragment_C(frag_shape)
+    c10 = rs.thr_mma.make_fragment_C(frag_shape)
+    c11 = rs.thr_mma.make_fragment_C(frag_shape)
+
+    def compute_double_tile(
+        k_tile,
+        prefetch_next,
+        bid_m,
+        bid_n,
+        m,
+        row_base,
+        group,
+    ):
+        next_k_tile = k_tile + 2
+
+        b0 = load_b_fragment(0, 0, k_tile)
+        a0 = load_a_fragment(0, 0)
+        load_a_half(1, k_tile + 1, 1, bid_m, m, row_base)
+        rocdl.s_barrier()
+        consume(c00, a0, b0)
+        rocdl.s_barrier()
+
+        b1 = load_b_fragment(1, 0, k_tile)
+        if const_expr(prefetch_next):
+            load_b_half(0, next_k_tile, 0, bid_n, group)
+            rocdl.s_barrier()
+        consume(c01, a0, b1)
+        rocdl.s_barrier()
+
+        a1 = load_a_fragment(1, 0)
+        if const_expr(prefetch_next):
+            load_a_half(0, next_k_tile, 0, bid_m, m, row_base)
+            rocdl.s_barrier()
+        consume(c10, a1, b0)
+        rocdl.s_barrier()
+
+        b0 = load_b_fragment(0, 1, k_tile + 1)
+        if const_expr(prefetch_next):
+            load_b_half(1, next_k_tile, 0, bid_n, group)
+            __barrier(2 * half_ldg_b_iters + half_ldg_a_iters)
+        consume(c11, a1, b1)
+        if const_expr(not prefetch_next):
+            __waitcnt(0)
+        rocdl.s_barrier()
+
+        a0 = load_a_fragment(0, 1)
+        if const_expr(prefetch_next):
+            load_a_half(1, next_k_tile, 0, bid_m, m, row_base)
+            rocdl.s_barrier()
+        consume(c00, a0, b0)
+        rocdl.s_barrier()
+
+        b1 = load_b_fragment(1, 1, k_tile + 1)
+        if const_expr(prefetch_next):
+            load_b_half(0, next_k_tile + 1, 1, bid_n, group)
+            rocdl.s_barrier()
+        consume(c01, a0, b1)
+        rocdl.s_barrier()
+
+        a1 = load_a_fragment(1, 1)
+        if const_expr(prefetch_next):
+            load_a_half(0, next_k_tile + 1, 1, bid_m, m, row_base)
+            rocdl.s_barrier()
+        consume(c10, a1, b0)
+        rocdl.s_barrier()
+
+        if const_expr(prefetch_next):
+            load_b_half(1, next_k_tile + 1, 1, bid_n, group)
+            __barrier(half_ldg_b_iters + half_ldg_a_iters)
+        consume(c11, a1, b1)
+        rocdl.s_barrier()
+
+    def compute_single_tile(k_tile, read_stage):
+        b0 = load_b_fragment(0, read_stage, k_tile)
+        b1 = load_b_fragment(1, read_stage, k_tile)
+        a0 = load_a_fragment(0, read_stage)
+        consume(c00, a0, b0)
+        consume(c01, a0, b1)
+        a1 = load_a_fragment(1, read_stage)
+        consume(c10, a1, b0)
+        consume(c11, a1, b1)
+
+    grid = fx.Int32(fx.grid_dim.x)
+    work_idx = fx.Int32(fx.block_idx.x)
+    tiles_before = fx.Int32(0)
+    row_base = fx.Int32(0)
+    for g in range(0, group_count, 1):
+        row_end = fx.get_scalar(rs.offs_buf[g])
+        m_g = row_end - row_base
+        num_pid_m = (m_g + block_m - 1) // block_m
+        tiles_after = tiles_before + num_pid_m * num_pid_n
+
+        for linear_tile in range(work_idx, tiles_after, grid):
+            local_tile = linear_tile - tiles_before
+            bid_m, bid_n = _grouped_swizzle_tile(
+                param, num_pid_m, num_pid_n, local_tile
+            )
+            c00.fill(0.0)
+            c01.fill(0.0)
+            c10.fill(0.0)
+            c11.fill(0.0)
+
+            load_b_half(0, 0, 0, bid_n, g)
+            load_a_half(0, 0, 0, bid_m, m_g, row_base)
+            load_b_half(1, 0, 0, bid_n, g)
+            load_a_half(1, 0, 0, bid_m, m_g, row_base)
+            rocdl.sched_barrier(0)
+            rocdl.s_barrier()
+            rocdl.sched_barrier(0)
+            load_b_half(0, 1, 1, bid_n, g)
+            load_a_half(0, 1, 1, bid_m, m_g, row_base)
+            load_b_half(1, 1, 1, bid_n, g)
+            __barrier(half_ldg_b_iters + half_ldg_a_iters)
+
+            if has_odd_k_tiles:
+                final_double_tile = k_tiles - 3
+                for k_tile in range(0, final_double_tile, 2):
+                    compute_double_tile(k_tile, True, bid_m, bid_n, m_g, row_base, g)
+                compute_double_tile(
+                    final_double_tile, False, bid_m, bid_n, m_g, row_base, g
+                )
+                load_b_half(0, k_tiles - 1, 0, bid_n, g)
+                load_a_half(0, k_tiles - 1, 0, bid_m, m_g, row_base)
+                load_b_half(1, k_tiles - 1, 0, bid_n, g)
+                load_a_half(1, k_tiles - 1, 0, bid_m, m_g, row_base)
+                __barrier(0)
+                fx.gpu.barrier()
+                compute_single_tile(k_tiles - 1, 0)
+            else:
+                main_loop_end = (k_tiles > 2).select(k_tiles - 2, 0)
+                for k_tile in range(0, main_loop_end, 2):
+                    compute_double_tile(k_tile, True, bid_m, bid_n, m_g, row_base, g)
+                compute_double_tile(
+                    main_loop_end, False, bid_m, bid_n, m_g, row_base, g
+                )
+
+            store_half_tile(0, 0, c00, bid_m, bid_n, m_g, row_base)
+            store_half_tile(0, 1, c01, bid_m, bid_n, m_g, row_base)
+            store_half_tile(1, 0, c10, bid_m, bid_n, m_g, row_base)
+            store_half_tile(1, 1, c11, bid_m, bid_n, m_g, row_base)
+
+        remaining = (work_idx < tiles_after).select(tiles_after - work_idx, fx.Int32(0))
+        work_idx = work_idx + (remaining + grid - 1) // grid * grid
+        tiles_before = tiles_after
+        row_base = row_end
+
+
+@flyc.jit
+def launch_gemm_gfx950_grouped(
+    out: fx.Tensor,
+    a: fx.Tensor,
+    b: fx.Tensor,
+    offs: fx.Tensor,
+    group_count: int,
+    n: fx.Int32,
+    k: fx.Int32,
+    grid_size: int,
+    param: GemmGfx950Param,
+    stream: fx.Stream = fx.Stream(None),
+):
+    tiled_mma = _make_gemm_gfx950_tiled_mma(param)
+    kernel_impl = (
+        gemm_hti_gfx950_grouped_kernel
+        if param.use_half_tile_interleaved
+        else gemm_gfx950_grouped_kernel
+    )
+    kernel_impl._known_block_size = [param.block_threads, 1, 1]
+    kernel_impl._func.__name__ = make_grouped_gemm_gfx950_kernel_name(param)
+    kernel_impl(out, a, b, offs, group_count, n, k, tiled_mma, param).launch(
+        grid=(grid_size, 1, 1),
+        block=(param.block_threads, 1, 1),
+        stream=stream,
+    )

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
+from dataclasses import dataclass
+from typing import Any
+
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl.expr import const_expr, range_constexpr, rocdl
@@ -30,7 +33,9 @@ def _grouped_swizzle_tile(param, num_pid_m, num_pid_n, local_tile):
     )
     swizzled_m, swizzled_n = block_swizzle.swizzle(num_pid_m, num_pid_n, local_tile)
     num_workgroups = num_pid_m * num_pid_n
-    use_block_swizzle = (num_workgroups >= 256) & ((num_workgroups % 8) == 0)
+    use_block_swizzle = (num_workgroups >= block_swizzle.NUM_PIDS_THRESHOLD) & (
+        (num_workgroups % block_swizzle.NUM_XCDS) == 0
+    )
     if const_expr(isinstance(use_block_swizzle, bool)):
         if const_expr(use_block_swizzle):
             return swizzled_m, swizzled_n
@@ -105,34 +110,20 @@ def make_grouped_gemm_gfx950_kernel_name(param: GemmGfx950Param) -> str:
     return name
 
 
+@dataclass
 class _GroupedGemmGfx950Resources:
-    def __init__(
-        self,
-        a_buf,
-        b_buf,
-        out_buf,
-        offs_buf,
-        a_rsrc,
-        b_rsrc,
-        s2r_copy_atom,
-        r2g_copy_atom,
-        thr_mma,
-        thr_copy_A,
-        b_s2r_copy_atom,
-        thr_copy_B,
-    ):
-        self.a_buf = a_buf
-        self.b_buf = b_buf
-        self.out_buf = out_buf
-        self.offs_buf = offs_buf
-        self.a_rsrc = a_rsrc
-        self.b_rsrc = b_rsrc
-        self.s2r_copy_atom = s2r_copy_atom
-        self.r2g_copy_atom = r2g_copy_atom
-        self.thr_mma = thr_mma
-        self.thr_copy_A = thr_copy_A
-        self.b_s2r_copy_atom = b_s2r_copy_atom
-        self.thr_copy_B = thr_copy_B
+    """Buffer descriptors, copy atoms and thread slices shared by both kernels."""
+
+    out_buf: Any
+    offs_buf: Any
+    a_rsrc: Any
+    b_rsrc: Any
+    s2r_copy_atom: Any
+    r2g_copy_atom: Any
+    thr_mma: Any
+    thr_copy_A: Any
+    b_s2r_copy_atom: Any
+    thr_copy_B: Any
 
 
 def _grouped_gemm_gfx950_resources(out, a, b, offs, tiled_mma, elem_dtype, tid):
@@ -150,18 +141,16 @@ def _grouped_gemm_gfx950_resources(out, a, b, offs, tiled_mma, elem_dtype, tid):
     b_s2r_copy_atom = fx.make_copy_atom(rocdl.cdna4.LDSReadTrans16_64b(), elem_dtype)
     thr_copy_B = fx.make_tiled_copy_B(b_s2r_copy_atom, tiled_mma).get_slice(tid)
     return _GroupedGemmGfx950Resources(
-        a_buf,
-        b_buf,
-        out_buf,
-        offs_buf,
-        a_rsrc,
-        b_rsrc,
-        s2r_copy_atom,
-        r2g_copy_atom,
-        thr_mma,
-        thr_copy_A,
-        b_s2r_copy_atom,
-        thr_copy_B,
+        out_buf=out_buf,
+        offs_buf=offs_buf,
+        a_rsrc=a_rsrc,
+        b_rsrc=b_rsrc,
+        s2r_copy_atom=s2r_copy_atom,
+        r2g_copy_atom=r2g_copy_atom,
+        thr_mma=thr_mma,
+        thr_copy_A=thr_copy_A,
+        b_s2r_copy_atom=b_s2r_copy_atom,
+        thr_copy_B=thr_copy_B,
     )
 
 
@@ -182,82 +171,48 @@ def _grouped_gemm_gfx950_allocate_shared_storage(
     return storage.ab.a.peek().ptr, storage.ab.b.peek().ptr, storage.c.peek().ptr
 
 
+@dataclass
 class _GroupedGemmGfx950Ctx:
-    def __init__(
-        self,
-        param,
-        tid,
-        tiled_mma,
-        thr_mma,
-        smem_a,
-        smem_b,
-        a_rsrc,
-        b_rsrc,
-        a_buf,
-        b_buf,
-        out_buf,
-        offs_buf,
-        s2r_copy_atom,
-        r2g_copy_atom,
-        thr_copy_A,
-        thr_copy_B,
-        a_lds_layout,
-        b_lds_layout,
-        b_lds_s2r_layout,
-        sC,
-        frag_A,
-        frag_B,
-        frag_C,
-        frag_C_out,
-        frag_A_retile,
-        frag_B_retile,
-        thr_mma_cRow,
-        thr_mma_cCol,
-        b_s2r_copy_atom,
-        thr_copy_cshuffle,
-        thr_sC,
-        thr_cRow,
-        thr_cCol,
-        frag_C_cshuffle,
-        pred_C,
-        wave_offset,
-    ):
-        self.param = param
-        self.tid = tid
-        self.tiled_mma = tiled_mma
-        self.thr_mma = thr_mma
-        self.smem_a = smem_a
-        self.smem_b = smem_b
-        self.a_rsrc = a_rsrc
-        self.b_rsrc = b_rsrc
-        self.a_buf = a_buf
-        self.b_buf = b_buf
-        self.out_buf = out_buf
-        self.offs_buf = offs_buf
-        self.s2r_copy_atom = s2r_copy_atom
-        self.r2g_copy_atom = r2g_copy_atom
-        self.thr_copy_A = thr_copy_A
-        self.thr_copy_B = thr_copy_B
-        self.a_lds_layout = a_lds_layout
-        self.b_lds_layout = b_lds_layout
-        self.b_lds_s2r_layout = b_lds_s2r_layout
-        self.sC = sC
-        self.frag_A = frag_A
-        self.frag_B = frag_B
-        self.frag_C = frag_C
-        self.frag_C_out = frag_C_out
-        self.frag_A_retile = frag_A_retile
-        self.frag_B_retile = frag_B_retile
-        self.thr_mma_cRow = thr_mma_cRow
-        self.thr_mma_cCol = thr_mma_cCol
-        self.b_s2r_copy_atom = b_s2r_copy_atom
-        self.thr_copy_cshuffle = thr_copy_cshuffle
-        self.thr_sC = thr_sC
-        self.thr_cRow = thr_cRow
-        self.thr_cCol = thr_cCol
-        self.frag_C_cshuffle = frag_C_cshuffle
-        self.pred_C = pred_C
-        self.wave_offset = wave_offset
+    """Per-workgroup state of the non-interleaved grouped kernel.
+
+    Everything here is tile-independent, so it is built once before the
+    persistent tile loop and reused by every tile the workgroup claims.
+    """
+
+    param: Any
+    tid: Any
+    tiled_mma: Any
+    thr_mma: Any
+    smem_a: Any
+    smem_b: Any
+    a_rsrc: Any
+    b_rsrc: Any
+    out_buf: Any
+    offs_buf: Any
+    s2r_copy_atom: Any
+    r2g_copy_atom: Any
+    thr_copy_A: Any
+    thr_copy_B: Any
+    a_lds_layout: Any
+    b_lds_layout: Any
+    b_lds_s2r_layout: Any
+    sC: Any
+    frag_A: Any
+    frag_B: Any
+    frag_C: Any
+    frag_C_out: Any
+    frag_A_retile: Any
+    frag_B_retile: Any
+    thr_mma_cRow: Any
+    thr_mma_cCol: Any
+    b_s2r_copy_atom: Any
+    thr_copy_cshuffle: Any
+    thr_sC: Any
+    thr_cRow: Any
+    thr_cCol: Any
+    frag_C_cshuffle: Any
+    pred_C: Any
+    wave_offset: Any
 
 
 def _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param):
@@ -333,42 +288,40 @@ def _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param):
     )
 
     return _GroupedGemmGfx950Ctx(
-        param,
-        tid,
-        tiled_mma,
-        rs.thr_mma,
-        smem_a,
-        smem_b,
-        rs.a_rsrc,
-        rs.b_rsrc,
-        rs.a_buf,
-        rs.b_buf,
-        rs.out_buf,
-        rs.offs_buf,
-        rs.s2r_copy_atom,
-        rs.r2g_copy_atom,
-        rs.thr_copy_A,
-        rs.thr_copy_B,
-        a_lds_layout,
-        b_lds_layout,
-        b_lds_s2r_layout,
-        sC,
-        frag_A,
-        frag_B,
-        frag_C,
-        frag_C_out,
-        frag_A_retile,
-        frag_B_retile,
-        thr_mma_cRow,
-        thr_mma_cCol,
-        rs.b_s2r_copy_atom,
-        thr_copy_cshuffle,
-        thr_sC,
-        thr_cRow,
-        thr_cCol,
-        frag_C_cshuffle,
-        pred_C,
-        wave_offset,
+        param=param,
+        tid=tid,
+        tiled_mma=tiled_mma,
+        thr_mma=rs.thr_mma,
+        smem_a=smem_a,
+        smem_b=smem_b,
+        a_rsrc=rs.a_rsrc,
+        b_rsrc=rs.b_rsrc,
+        out_buf=rs.out_buf,
+        offs_buf=rs.offs_buf,
+        s2r_copy_atom=rs.s2r_copy_atom,
+        r2g_copy_atom=rs.r2g_copy_atom,
+        thr_copy_A=rs.thr_copy_A,
+        thr_copy_B=rs.thr_copy_B,
+        a_lds_layout=a_lds_layout,
+        b_lds_layout=b_lds_layout,
+        b_lds_s2r_layout=b_lds_s2r_layout,
+        sC=sC,
+        frag_A=frag_A,
+        frag_B=frag_B,
+        frag_C=frag_C,
+        frag_C_out=frag_C_out,
+        frag_A_retile=frag_A_retile,
+        frag_B_retile=frag_B_retile,
+        thr_mma_cRow=thr_mma_cRow,
+        thr_mma_cCol=thr_mma_cCol,
+        b_s2r_copy_atom=rs.b_s2r_copy_atom,
+        thr_copy_cshuffle=thr_copy_cshuffle,
+        thr_sC=thr_sC,
+        thr_cRow=thr_cRow,
+        thr_cCol=thr_cCol,
+        frag_C_cshuffle=frag_C_cshuffle,
+        pred_C=pred_C,
+        wave_offset=wave_offset,
     )
 
 
@@ -414,6 +367,7 @@ def _grouped_tile_store(ctx, thr_gC):
     fx.gpu.barrier()
 
 
+@flyc.jit
 def _grouped_compute_stage_from_lds(ctx, read_stage, k_tile, k):
     param = ctx.param
     block_m = param.block_m

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
@@ -9,7 +9,6 @@ from .gemm_gfx950 import (
     __barrier,
     __waitcnt,
     _elem_dtype,
-    _gemm_gfx950_smem_bytes,
     _make_gemm_gfx950_tiled_mma,
     BlockSwizzle,
     buffer_load_lds_inline,
@@ -53,14 +52,13 @@ def get_grouped_gemm_persistent_grid_size(
     if total_m <= 0 or n <= 0 or group_count <= 0:
         return 1
 
-    smem_bytes = _gemm_gfx950_smem_bytes(
-        param.block_m,
-        param.block_n,
-        param.block_k,
-        param.stages,
-        param.in_data_bytes,
-        param.out_data_bytes,
+    smem_bytes = (
+        param.stages
+        * (param.block_m + param.block_n)
+        * param.block_k
+        * param.in_data_bytes
     )
+    smem_bytes = max(smem_bytes, param.block_m * param.block_n * param.out_data_bytes)
     shared_memory_per_cu = getattr(
         device_properties, "shared_memory_per_multiprocessor", None
     )

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
@@ -76,14 +76,14 @@ def get_grouped_gemm_persistent_grid_size(
         )
 
     light_tile = param.block_m <= 64 and param.block_n <= 128
-    n_tiles = (n + param.block_n - 1) // param.block_n
+    n_tiles = (n - 1) // param.block_n + 1
     if light_tile:
         for blocks_per_cu in (8, 4, 2, 1):
             if blocks_per_cu <= resource_blocks_per_cu:
                 break
         # The host only knows total M. This lower bound prevents empty CTAs
         # for uniformly small groups, even though ragged inputs have more work.
-        task_floor = (total_m + param.block_m - 1) // param.block_m * n_tiles
+        task_floor = ((total_m - 1) // param.block_m + 1) * n_tiles
         return max(1, min(num_cus * blocks_per_cu, task_floor))
 
     blocks_per_cu = 2 if resource_blocks_per_cu >= 2 else 1
@@ -215,7 +215,6 @@ class _GroupedGemmGfx950Ctx:
         frag_B_retile,
         thr_mma_cRow,
         thr_mma_cCol,
-        thr_mma_bK,
         b_s2r_copy_atom,
         thr_copy_cshuffle,
         thr_sC,
@@ -253,7 +252,6 @@ class _GroupedGemmGfx950Ctx:
         self.frag_B_retile = frag_B_retile
         self.thr_mma_cRow = thr_mma_cRow
         self.thr_mma_cCol = thr_mma_cCol
-        self.thr_mma_bK = thr_mma_bK
         self.b_s2r_copy_atom = b_s2r_copy_atom
         self.thr_copy_cshuffle = thr_copy_cshuffle
         self.thr_sC = thr_sC
@@ -297,8 +295,6 @@ def _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param):
     sA = fx.make_view(smem_a, a_lds_layout)
     sC = fx.make_view(smem_c, c_lds_layout)
     frag_A = rs.thr_mma.make_fragment_A(sA)
-    bk_coords = fx.make_view(0, fx.make_layout((block_n, block_k), (0, 1)))
-    thr_mma_bK = rs.thr_mma.partition_B(bk_coords)
     sB = fx.make_view(smem_b, b_lds_s2r_layout)
     frag_B = rs.thr_mma.make_fragment_B(sB)
     frag_B_retile = rs.thr_copy_B.retile(frag_B)
@@ -367,7 +363,6 @@ def _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param):
         frag_B_retile,
         thr_mma_cRow,
         thr_mma_cCol,
-        thr_mma_bK,
         rs.b_s2r_copy_atom,
         thr_copy_cshuffle,
         thr_sC,
@@ -437,20 +432,12 @@ def _grouped_compute_stage_from_lds(ctx, read_stage, k_tile, k):
     thr_sA_s2r = ctx.thr_copy_A.partition_S(sA_stage)
     thr_sB_s2r = ctx.thr_copy_B.partition_S(sB_stage)
 
-    for block_k_iter in range_constexpr(block_k // param.mma_k):
+    def compute_k_chunk(block_k_iter):
         fx.copy(
             ctx.b_s2r_copy_atom,
             thr_sB_s2r[None, None, block_k_iter],
             ctx.frag_B_retile[None, None, block_k_iter],
         )
-        if const_expr(param.has_k_tail):
-            frag_B_chunk = ctx.frag_B[None, None, block_k_iter]
-            bK_chunk = ctx.thr_mma_bK[None, None, block_k_iter]
-            for i in range_constexpr(fx.size(frag_B_chunk.shape).unpack()):
-                in_bounds = k_tile * block_k + fx.get_scalar(bK_chunk[i]) < k
-                frag_B_chunk[i] = in_bounds.select(
-                    frag_B_chunk[i], _elem_dtype(param)(0.0)
-                )
         fx.copy(
             ctx.s2r_copy_atom,
             thr_sA_s2r[None, None, block_k_iter],
@@ -464,6 +451,14 @@ def _grouped_compute_stage_from_lds(ctx, read_stage, k_tile, k):
             ctx.frag_C,
             traversal_order=fx.GemmTraversalOrder.KNM,
         )
+
+    for block_k_iter in range_constexpr(block_k // param.mma_k):
+        if const_expr(param.has_k_tail):
+            global_k_iter = k_tile * block_k + block_k_iter * param.mma_k
+            if global_k_iter < k:
+                compute_k_chunk(block_k_iter)
+        else:
+            compute_k_chunk(block_k_iter)
 
 
 def _grouped_load_a_tile_async(ctx, row_base, bid_m, m, k, k_tile, stage):
@@ -525,7 +520,10 @@ def _grouped_load_b_tile_async(ctx, bid_n, n, k, group_idx, k_tile, stage):
             % block_n
         )
         global_n_idx = bid_n * block_n + swizzled_n_idx
-        safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+        if const_expr(param.has_k_tail):
+            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+        else:
+            safe_global_k_idx = global_k_idx
         global_offset = (
             group_idx * k * n + safe_global_k_idx * n + global_n_idx
         ) * in_data_bytes
@@ -553,8 +551,8 @@ def gemm_gfx950_grouped_kernel(
     stages = param.stages
     has_k_tail = param.has_k_tail
     ldg_a_iters = param.ldg_a_iters
-    num_pid_n = (n + block_n - 1) // block_n
-    k_tiles = (k + block_k - 1) // block_k
+    num_pid_n = (n - 1) // block_n + 1
+    k_tiles = (k - 1) // block_k + 1
     grid = fx.Int32(fx.grid_dim.x)
     work_idx = fx.Int32(fx.block_idx.x)
     tiles_before = fx.Int32(0)
@@ -584,7 +582,6 @@ def gemm_gfx950_grouped_kernel(
                 current_stage = k_tile % stages
                 write_stage = (current_stage + stages - 1) % stages
                 __barrier((stages - 2) * ldg_wait_count)
-                fx.gpu.barrier()
                 _grouped_load_b_tile_async(
                     ctx, bid_n, n, k, g, k_tile + (stages - 1), write_stage
                 )
@@ -595,7 +592,6 @@ def gemm_gfx950_grouped_kernel(
             current_stage = main_loop_end % stages
             for s in range_constexpr(0, stages - 1):
                 __barrier((stages - 2 - s) * ldg_wait_count)
-                fx.gpu.barrier()
                 _grouped_compute_stage_from_lds(
                     ctx, current_stage, main_loop_end + s, k
                 )
@@ -625,6 +621,7 @@ def gemm_hti_gfx950_grouped_kernel(
     block_k = param.block_k
     half_block_m = block_m // 2
     half_block_n = block_n // 2
+    has_k_tail = param.has_k_tail
     async_load_bytes = param.async_load_bytes
     in_data_bytes = param.in_data_bytes
     async_load_vec_size = async_load_bytes // in_data_bytes
@@ -635,9 +632,8 @@ def gemm_hti_gfx950_grouped_kernel(
     elem_dtype = _elem_dtype(param)
 
     tid = fx.thread_idx.x
-    num_pid_n = (n + block_n - 1) // block_n
-    k_tiles = (k + block_k - 1) // block_k
-    has_odd_k_tiles = k_tiles % 2 != 0
+    num_pid_n = (n - 1) // block_n + 1
+    k_tiles = (k - 1) // block_k + 1
 
     smem_a, smem_b, smem_c = _grouped_gemm_gfx950_allocate_shared_storage(
         block_m, block_n, block_k, 2, elem_dtype
@@ -686,7 +682,10 @@ def gemm_hti_gfx950_grouped_kernel(
             in_bounds_m = m_tile_idx < m
             safe_global_m_idx = in_bounds_m.select(row_base + m_tile_idx, 0)
             global_k_idx = k_tile * block_k + swizzled_col_idx(m_local_idx, k_local_idx)
-            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            if const_expr(has_k_tail):
+                safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            else:
+                safe_global_k_idx = global_k_idx
             global_offset = (safe_global_m_idx * k + safe_global_k_idx) * in_data_bytes
             buffer_load_lds_inline(rs.a_rsrc, lds_ptr, global_offset, async_load_bytes)
             if i < half_ldg_a_iters - 1:
@@ -705,7 +704,10 @@ def gemm_hti_gfx950_grouped_kernel(
                 % half_block_n
             )
             global_n_idx = bid_n * block_n + n_part * half_block_n + swizzled_n_idx
-            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            if const_expr(has_k_tail):
+                safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            else:
+                safe_global_k_idx = global_k_idx
             global_offset = (
                 group * k * n + safe_global_k_idx * n + global_n_idx
             ) * in_data_bytes
@@ -713,17 +715,26 @@ def gemm_hti_gfx950_grouped_kernel(
             if i < half_ldg_b_iters - 1:
                 lds_ptr = lds_ptr + block_threads * async_load_bytes
 
-    def load_a_fragment(m_part, read_stage):
+    def load_a_fragment(m_part, read_stage, k_tile):
         sA = fx.make_view(half_a_base(read_stage, m_part), a_lds_layout)
         frag_A = rs.thr_mma.make_fragment_A(sA)
         frag_A_retile = rs.thr_copy_A.retile(frag_A)
         thr_sA_s2r = rs.thr_copy_A.partition_S(sA)
         for block_k_iter in range_constexpr(block_k // param.mma_k):
-            fx.copy(
-                rs.s2r_copy_atom,
-                thr_sA_s2r[None, None, block_k_iter],
-                frag_A_retile[None, None, block_k_iter],
-            )
+            if const_expr(has_k_tail):
+                global_k_iter = k_tile * block_k + block_k_iter * param.mma_k
+                if global_k_iter < k:
+                    fx.copy(
+                        rs.s2r_copy_atom,
+                        thr_sA_s2r[None, None, block_k_iter],
+                        frag_A_retile[None, None, block_k_iter],
+                    )
+            else:
+                fx.copy(
+                    rs.s2r_copy_atom,
+                    thr_sA_s2r[None, None, block_k_iter],
+                    frag_A_retile[None, None, block_k_iter],
+                )
         return frag_A
 
     def load_b_fragment(n_part, read_stage, k_tile):
@@ -735,30 +746,45 @@ def gemm_hti_gfx950_grouped_kernel(
         frag_B_retile = rs.thr_copy_B.retile(frag_B)
         thr_sB_s2r = rs.thr_copy_B.partition_S(sB)
         for block_k_iter in range_constexpr(block_k // param.mma_k):
-            fx.copy(
-                rs.b_s2r_copy_atom,
-                thr_sB_s2r[None, None, block_k_iter],
-                frag_B_retile[None, None, block_k_iter],
-            )
-            if const_expr(param.has_k_tail):
-                frag_B_chunk = frag_B[None, None, block_k_iter]
-                bK_chunk = thr_mma_bK[None, None, block_k_iter]
-                for i in range_constexpr(fx.size(frag_B_chunk.shape).unpack()):
-                    in_bounds = k_tile * block_k + fx.get_scalar(bK_chunk[i]) < k
-                    frag_B_chunk[i] = in_bounds.select(frag_B_chunk[i], elem_dtype(0.0))
+            if const_expr(has_k_tail):
+                global_k_iter = k_tile * block_k + block_k_iter * param.mma_k
+                if global_k_iter < k:
+                    fx.copy(
+                        rs.b_s2r_copy_atom,
+                        thr_sB_s2r[None, None, block_k_iter],
+                        frag_B_retile[None, None, block_k_iter],
+                    )
+            else:
+                fx.copy(
+                    rs.b_s2r_copy_atom,
+                    thr_sB_s2r[None, None, block_k_iter],
+                    frag_B_retile[None, None, block_k_iter],
+                )
         return frag_B
 
-    def consume(frag_C, frag_A, frag_B):
+    def consume(k_tile, frag_C, frag_A, frag_B):
         rocdl.sched_barrier(0)
         for block_k_iter in range_constexpr(block_k // param.mma_k):
-            fx.gemm(
-                tiled_mma,
-                frag_C,
-                frag_A[None, None, block_k_iter],
-                frag_B[None, None, block_k_iter],
-                frag_C,
-                traversal_order=fx.GemmTraversalOrder.KNM,
-            )
+            if const_expr(has_k_tail):
+                global_k_iter = k_tile * block_k + block_k_iter * param.mma_k
+                if global_k_iter < k:
+                    fx.gemm(
+                        tiled_mma,
+                        frag_C,
+                        frag_A[None, None, block_k_iter],
+                        frag_B[None, None, block_k_iter],
+                        frag_C,
+                        traversal_order=fx.GemmTraversalOrder.KNM,
+                    )
+            else:
+                fx.gemm(
+                    tiled_mma,
+                    frag_C,
+                    frag_A[None, None, block_k_iter],
+                    frag_B[None, None, block_k_iter],
+                    frag_C,
+                    traversal_order=fx.GemmTraversalOrder.KNM,
+                )
         rocdl.sched_barrier(0)
 
     def half_gC(m_part, n_part, bid_m, bid_n, row_base):
@@ -792,8 +818,6 @@ def gemm_hti_gfx950_grouped_kernel(
     thr_mma_cCol = rs.thr_mma.partition_C(col_coords)
     thr_cRow = thr_copy_cshuffle.partition_S(row_coords)[(0, None), None, None]
     thr_cCol = thr_copy_cshuffle.partition_S(col_coords)[(0, None), None, None]
-    bk_coords = fx.make_view(0, fx.make_layout((half_block_n, block_k), (0, 1)))
-    thr_mma_bK = rs.thr_mma.partition_B(bk_coords)
 
     def store_half_tile(m_part, n_part, frag_C, bid_m, bid_n, m, row_base):
         gC = half_gC(m_part, n_part, bid_m, bid_n, row_base)
@@ -851,71 +875,61 @@ def gemm_hti_gfx950_grouped_kernel(
         next_k_tile = k_tile + 2
 
         b0 = load_b_fragment(0, 0, k_tile)
-        a0 = load_a_fragment(0, 0)
+        a0 = load_a_fragment(0, 0, k_tile)
         load_a_half(1, k_tile + 1, 1, bid_m, m, row_base)
         rocdl.s_barrier()
-        consume(c00, a0, b0)
+        consume(k_tile, c00, a0, b0)
         rocdl.s_barrier()
 
         b1 = load_b_fragment(1, 0, k_tile)
         if const_expr(prefetch_next):
             load_b_half(0, next_k_tile, 0, bid_n, group)
             rocdl.s_barrier()
-        consume(c01, a0, b1)
+        consume(k_tile, c01, a0, b1)
         rocdl.s_barrier()
 
-        a1 = load_a_fragment(1, 0)
+        a1 = load_a_fragment(1, 0, k_tile)
         if const_expr(prefetch_next):
             load_a_half(0, next_k_tile, 0, bid_m, m, row_base)
             rocdl.s_barrier()
-        consume(c10, a1, b0)
+        consume(k_tile, c10, a1, b0)
         rocdl.s_barrier()
 
         b0 = load_b_fragment(0, 1, k_tile + 1)
         if const_expr(prefetch_next):
             load_b_half(1, next_k_tile, 0, bid_n, group)
             __barrier(2 * half_ldg_b_iters + half_ldg_a_iters)
-        consume(c11, a1, b1)
+        consume(k_tile, c11, a1, b1)
         if const_expr(not prefetch_next):
             __waitcnt(0)
         rocdl.s_barrier()
 
-        a0 = load_a_fragment(0, 1)
+        a0 = load_a_fragment(0, 1, k_tile + 1)
         if const_expr(prefetch_next):
             load_a_half(1, next_k_tile, 0, bid_m, m, row_base)
             rocdl.s_barrier()
-        consume(c00, a0, b0)
+        consume(k_tile + 1, c00, a0, b0)
         rocdl.s_barrier()
 
         b1 = load_b_fragment(1, 1, k_tile + 1)
         if const_expr(prefetch_next):
             load_b_half(0, next_k_tile + 1, 1, bid_n, group)
             rocdl.s_barrier()
-        consume(c01, a0, b1)
+        consume(k_tile + 1, c01, a0, b1)
         rocdl.s_barrier()
 
-        a1 = load_a_fragment(1, 1)
+        a1 = load_a_fragment(1, 1, k_tile + 1)
         if const_expr(prefetch_next):
             load_a_half(0, next_k_tile + 1, 1, bid_m, m, row_base)
             rocdl.s_barrier()
-        consume(c10, a1, b0)
+        consume(k_tile + 1, c10, a1, b0)
         rocdl.s_barrier()
 
         if const_expr(prefetch_next):
             load_b_half(1, next_k_tile + 1, 1, bid_n, group)
             __barrier(half_ldg_b_iters + half_ldg_a_iters)
-        consume(c11, a1, b1)
+        consume(k_tile + 1, c11, a1, b1)
         rocdl.s_barrier()
-
-    def compute_single_tile(k_tile, read_stage):
-        b0 = load_b_fragment(0, read_stage, k_tile)
-        b1 = load_b_fragment(1, read_stage, k_tile)
-        a0 = load_a_fragment(0, read_stage)
-        consume(c00, a0, b0)
-        consume(c01, a0, b1)
-        a1 = load_a_fragment(1, read_stage)
-        consume(c10, a1, b0)
-        consume(c11, a1, b1)
 
     grid = fx.Int32(fx.grid_dim.x)
     work_idx = fx.Int32(fx.block_idx.x)
@@ -949,27 +963,11 @@ def gemm_hti_gfx950_grouped_kernel(
             load_b_half(1, 1, 1, bid_n, g)
             __barrier(half_ldg_b_iters + half_ldg_a_iters)
 
-            if has_odd_k_tiles:
-                final_double_tile = k_tiles - 3
-                for k_tile in range(0, final_double_tile, 2):
-                    compute_double_tile(k_tile, True, bid_m, bid_n, m_g, row_base, g)
-                compute_double_tile(
-                    final_double_tile, False, bid_m, bid_n, m_g, row_base, g
-                )
-                load_b_half(0, k_tiles - 1, 0, bid_n, g)
-                load_a_half(0, k_tiles - 1, 0, bid_m, m_g, row_base)
-                load_b_half(1, k_tiles - 1, 0, bid_n, g)
-                load_a_half(1, k_tiles - 1, 0, bid_m, m_g, row_base)
-                __barrier(0)
-                fx.gpu.barrier()
-                compute_single_tile(k_tiles - 1, 0)
-            else:
-                main_loop_end = (k_tiles > 2).select(k_tiles - 2, 0)
-                for k_tile in range(0, main_loop_end, 2):
-                    compute_double_tile(k_tile, True, bid_m, bid_n, m_g, row_base, g)
-                compute_double_tile(
-                    main_loop_end, False, bid_m, bid_n, m_g, row_base, g
-                )
+            final_double_tile = ((k_tiles % 2) == 0).select(k_tiles - 2, k_tiles - 1)
+            main_loop_end = (k_tiles > 2).select(final_double_tile, 0)
+            for k_tile in range(0, main_loop_end, 2):
+                compute_double_tile(k_tile, True, bid_m, bid_n, m_g, row_base, g)
+            compute_double_tile(main_loop_end, False, bid_m, bid_n, m_g, row_base, g)
 
             store_half_tile(0, 0, c00, bid_m, bid_n, m_g, row_base)
             store_half_tile(0, 1, c01, bid_m, bid_n, m_g, row_base)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8711,8 +8711,9 @@ def _meta_grouped_mm_common(
 
     if mat_a.dtype == torch.float16:
         torch._check(
-            _grouped_mm_fp16_cublaslt_supported(mat_a, mat_b, offs),
-            lambda: "Float16 grouped_mm requires cuBLASLt grouped GEMM support.",
+            _grouped_mm_fp16_flydsl_supported(mat_a, mat_b, offs)
+            or _grouped_mm_fp16_cublaslt_supported(mat_a, mat_b, offs),
+            lambda: "Float16 grouped_mm requires cuBLASLt grouped GEMM or FlyDSL support.",
         )
 
     torch._check(
@@ -8733,6 +8734,27 @@ def _meta_grouped_mm_common(
         )
 
     return _create_grouped_mm_output_tensor(mat_a, mat_b, offs, out_dtype)
+
+
+def _grouped_mm_fp16_flydsl_supported(
+    mat_a: Tensor, mat_b: Tensor, offs: Tensor | None
+) -> bool:
+    if (
+        not torch.version.hip
+        or not torch.cuda.is_available()
+        or device_hint(mat_a) != "cuda"
+        or device_hint(mat_b) != "cuda"
+        or mat_a.dim() != 2
+        or mat_b.dim() != 3
+        or offs is None
+        or device_hint(offs) != "cuda"
+        or mat_a.device != mat_b.device
+        or mat_a.device != offs.device
+    ):
+        return False
+    device_index = mat_a.device.index if mat_a.device.index is not None else 0
+    arch = torch.cuda.get_device_properties(device_index).gcnArchName.split(":", 1)[0]
+    return arch == "gfx950"
 
 
 def _grouped_mm_fp16_cublaslt_supported(


### PR DESCRIPTION

## Summary
- Add a gfx950 FlyDSL backend for `F.grouped_mm` with ragged 2D A and grouped 3D B inputs.
- Reuse the dense FlyDSL configuration, caching, and lazy kernel-export infrastructure.
- Add grouped GEMM kernel selection and E2E coverage for persistent execution, HTI, and LDS-staged B.

## Test Plan
- `test/inductor/test_flydsl_template.py`

## Performance
Local `gfx950` / ROCm BF16 `F.grouped_mm` benchmark. FlyDSL, Triton, and ATen were each forced in an isolated process with a fresh cache per shape. Outputs were checked against eager results. Throughput is steady-state **TFLOPS**, excluding compilation time.
### Standard 14-shape
| Shape | FlyDSL (TFLOPS) | Triton (TFLOPS) | ATen (TFLOPS) | Fly/Tri (%) | Fly/ATen (%) |
|---|---:|---:|---:|---:|---:|
| g8x512x2048x8192 | 1016.4 | 737.9 | 530.7 | 137.7% | 191.5% |
| g8x1024x8192x8192 | 1189.0 | 849.0 | 1142.7 | 140.0% | 104.0% |
| g8x512x4096x4096 | 1072.7 | 785.2 | 543.8 | 136.6% | 197.2% |
| g16x512x4096x4096 | 1087.5 | 769.7 | 584.0 | 141.3% | 186.2% |
| g4x2048x8192x8192 | 1215.0 | 898.3 | 1362.6 | 135.3% | 89.2% |
| g2x2048x4096x4096 | 1164.6 | 882.2 | 759.1 | 132.0% | 153.4% |
| g8x256x8192x8192 | 1032.4 | 778.1 | 585.0 | 132.7% | 176.5% |
| g4x1024x2048x2048 | 897.8 | 737.6 | 321.6 | 121.7% | 279.1% |
| g8x512x8192x2048 | 913.2 | 769.7 | 426.6 | 118.6% | 214.1% |
| g4x512x4096x4096 | 865.1 | 762.8 | 489.6 | 113.4% | 176.7% |
| g16x256x2048x2048 | 566.5 | 536.6 | 127.4 | 105.6% | 444.7% |
| g8x128x4096x4096 | 398.3 | 392.1 | 150.5 | 101.6% | 264.7% |
| g16x128x4096x4096 | 496.8 | 536.1 | 166.3 | 92.7% | 298.8% |
| g32x64x2048x2048 | 185.2 | 189.2 | 32.6 | 97.9% | 567.9% |

Geometric mean: **120.8% vs Triton** and **212.1% vs ATen**. FlyDSL is the best measured backend in **11/14** cases.

### Dense K/N combinations (G=8, M=512/group)

| K x N | FlyDSL (TFLOPS) | Triton (TFLOPS) | ATen (TFLOPS) | Fly/Tri (%) | Fly/ATen (%) |
|---|---:|---:|---:|---:|---:|
| K4096 x N14336 (MoE up) | 1042.3 | 795.5 | 832.8 | 131.0% | 125.2% |
| K4096 x N28672 | 1118.2 | 796.8 | 1119.6 | 140.3% | 99.9% |
| K4096 x N256 (small N) | 242.8 | 302.5 | 54.0 | 80.2% | 449.3% |
| K8192 x N8192 | 1139.3 | 821.4 | 660.8 | 138.7% | 172.4% |
| K14336 x N4096 (MoE down) | 1135.1 | 812.3 | 699.7 | 139.7% | 162.2% |

Geometric mean: **123.4% vs Triton** and **173.5% vs ATen**. FlyDSL is the best measured backend in **3/5** cases; K4096 x N28672 is effectively tied with ATen in this sample.

### Ragged M combinations (G=8, K=N=4096)

| Per-group M | FlyDSL (TFLOPS) | Triton (TFLOPS) | ATen (TFLOPS) | Fly/Tri (%) | Fly/ATen (%) |
|---|---:|---:|---:|---:|---:|
| [1024,512,256,128,2048,64,512,1024] | 866.5 | 778.9 | 558.6 | 111.3% | 155.1% |
| [0,1024,0,512,2048,128,0,896] | 733.7 | 671.3 | 611.8 | 109.3% | 119.9% |
| [100,333,777,1,500,63,129,250] | 638.5 | 472.4 | 263.9 | 135.2% | 242.0% |
| [1,3,7,15,31,63,127,255] | 165.1 | 160.0 | 74.9 | 103.2% | 220.3% |
| [813,1200,47,999,512,256,88,1600] | 847.0 | 726.2 | 535.5 | 116.6% | 158.2% |

Geometric mean: **114.6% vs Triton** and **173.4% vs ATen**. FlyDSL is the best measured backend in **5/5** ragged-M cases.

> Authored with assistance from an AI coding agent.
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo