### PR TITLE
[Testcase Refactoring] Generalize fault-tolerance tests to device-agnostic

### DIFF
--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -15,13 +15,25 @@ if not dist.is_available():
 
 import torch.distributed.distributed_c10d as c10d
 from torch.testing._internal.common_distributed import MultiProcessTestCase
-from torch.testing._internal.common_utils import run_tests, TEST_CUDA, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TestCase,
+    TEST_PRIVATEUSE1,
+    TEST_PRIVATEUSE1_DEVICE_TYPE,
+)
 
+_pu1_backend = (
+    dist.get_default_backend_for_device(TEST_PRIVATEUSE1_DEVICE_TYPE)
+    if TEST_PRIVATEUSE1
+    else None
+)
 
 FAULT_TOLERANCE_BACKENDS = [
     ("gloo", "cpu"),
     ("nccl2", "cuda"),
 ]
+if _pu1_backend is not None:
+    FAULT_TOLERANCE_BACKENDS.append((_pu1_backend, TEST_PRIVATEUSE1_DEVICE_TYPE))
 
 
 class AbstractFaultToleranceTest:
@@ -31,8 +43,8 @@ class AbstractFaultToleranceTest:
 
     @property
     def device(self):
-        if self.device_type == "cuda":
-            return f"cuda:{self.rank}"
+        if self.device_type != "cpu":
+            return torch.device(self.device_type, self.rank)
         return self.device_type
 
     def setUp(self):
@@ -53,8 +65,8 @@ class AbstractFaultToleranceTest:
 
     def _init_reconfigurable_pg(self):
         self.store = self._create_store()
-        if self.device_type == "cuda":
-            torch.cuda.set_device(self.rank)
+        if self.device_type != "cpu":
+            torch.get_device_module(self.device_type).set_device(self.rank)
         dist.init_process_group(
             self.backend_name,
             world_size=self.world_size,
@@ -258,10 +270,11 @@ def _make_fault_tolerance_test_class(backend_name, device_type):
         not dist.is_backend_available(backend_name),
         f"{backend_name} backend is not available",
     )(FaultToleranceTest)
-    if device_type == "cuda":
+    if device_type != "cpu":
+        _device_module = torch.get_device_module(device_type)
         cls = unittest.skipIf(
-            not TEST_CUDA or torch.cuda.device_count() < 3,
-            "fault tolerance CUDA tests require at least 3 GPUs",
+            not _device_module.is_available() or _device_module.device_count() < 3,
+            "fault tolerance tests require at least 3 accelerators",
         )(cls)
     return cls
 


### PR DESCRIPTION
## Summary
Enable the c10d fault-tolerance (reconfigure) tests to run on out-of-tree PrivateUse1 accelerators. The test hardcoded CUDA in its device property, device setup, and device-count skip guard, and only registered the gloo/cpu and nccl2/cuda backend entries, so it could not run on a PrivateUse1 host.

## Changes
- Generalize the `device` property to `torch.device(device_type, rank)` for non-CPU device types (was `f"cuda:{self.rank}"`).
- Generalize device setup in `_init_reconfigurable_pg` to `torch.get_device_module(device_type).set_device(self.rank)` (was `torch.cuda.set_device`).
- Generalize the device-count skip guard to `torch.get_device_module(device_type).is_available()` / `device_count()` (was `TEST_CUDA` / `torch.cuda.device_count()`).
- Append the PrivateUse1 device's default communication backend (resolved via `dist.get_default_backend_for_device`) to `FAULT_TOLERANCE_BACKENDS` when a PrivateUse1 backend is registered. On hosts without one, the entry is absent and behavior is unchanged.

## Motivation
Part of decoupling distributed tests from hard-coded CUDA/NCCL dependencies so they can execute on any PrivateUse1 accelerator with an out-of-tree communication backend.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.

## Test Plan
```
python test/distributed/test_c10d_fault_tolerance.py -v
```
On a CPU-only host the gloo fault-tolerance tests pass and the nccl2/PrivateUse1 variants are skipped.
