### PR TITLE
[DTensor] Fix loss_parallel log_softmax backward for non-cross-entropy consumers

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_examples.py
+++ b/test/distributed/tensor/parallel/test_tp_examples.py
@@ -551,7 +551,13 @@ class DistTensorParallelExampleTest(DTensorTestBase):
                             else:
                                 y.backward()
                                 dist_y.backward()
-                            self.assertEqual(comm_mode.get_total_counts(), 0)
+                            # The log_softmax backward now performs one
+                            # all-reduce (sum of grad_output over the class dim).
+                            self.assertEqual(comm_mode.get_total_counts(), 1)
+                            self.assertEqual(
+                                comm_mode.get_comm_counts()[c10d_functional.all_reduce],
+                                1,
+                            )
                             self.assertTrue(
                                 dist_x.grad.placements[0].is_shard(shard_dim)
                             )
@@ -565,6 +571,72 @@ class DistTensorParallelExampleTest(DTensorTestBase):
                             dist_y = F.cross_entropy(
                                 dist_x, target, reduction=reduction
                             )
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    def test_loss_parallel_standalone_log_softmax_backward(self):
+        """Regression test for https://github.com/pytorch/pytorch/issues/190746.
+
+        A ``log_softmax`` inside ``loss_parallel()`` that does NOT feed
+        ``nll_loss`` (e.g. the DPO/ORPO log-probability term
+        ``(log_softmax(logits) * weights).sum()``) must receive the correct
+        ``log_softmax`` Jacobian (``I - softmax(x) 1^T``), not the identity
+        gradient that the fused cross-entropy path relies on.
+        """
+        device_mesh = self.build_device_mesh()
+
+        # Class dim = -1 (last), sharded across the TP mesh.
+        x = torch.randn(4, 8, 512, device=self.device_type, requires_grad=True)
+        c = torch.randn(4, 8, 512, device=self.device_type)
+
+        dist_x = distribute_tensor(x, device_mesh, [Shard(2)]).requires_grad_(True)
+        dist_c = distribute_tensor(c, device_mesh, [Shard(2)])
+
+        # Reference: plain (non-distributed) log_softmax backward.
+        ref = (F.log_softmax(x, dim=-1) * c).sum()
+        ref.backward()
+        x_grad_ref = x.grad.clone()
+
+        dist_x._local_tensor.requires_grad_(True)
+        with loss_parallel():
+            (F.log_softmax(dist_x, dim=-1) * dist_c).sum().backward()
+
+        dist_grad = dist_x.grad.full_tensor()
+
+        # The buggy no-op backward returns grad_output (== c) unchanged; the
+        # true gradient differs from c by softmax(x) * c.sum(class_dim).
+        self.assertFalse(
+            torch.equal(dist_grad, c),
+            "log_softmax backward must not be the identity (grad_output) - "
+            "the fused no-op backward leaked into a non-cross-entropy consumer.",
+        )
+        self.assertEqual(dist_grad, x_grad_ref)
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    def test_loss_parallel_cross_entropy_still_correct(self):
+        """Cross-entropy backward must remain correct after the log_softmax
+        backward fix (it now goes through the unfused Jacobian path)."""
+        device_mesh = self.build_device_mesh()
+        channel_size, channel_dim = 16, 1
+        x = torch.rand(8, channel_size, device=self.device_type, requires_grad=True)
+        target = torch.randint(channel_size, (8,), device=self.device_type)
+        weight = torch.rand(channel_size, device=self.device_type)
+
+        for reduction in ("none", "mean", "sum"):
+            dist_x = distribute_tensor(x, device_mesh, [Shard(channel_dim)])
+            y = F.cross_entropy(x, target, weight, reduction=reduction)
+            with loss_parallel():
+                dist_y = F.cross_entropy(dist_x, target, weight, reduction=reduction)
+                if reduction == "none":
+                    y.sum().backward()
+                    dist_y.sum().backward()
+                else:
+                    y.backward()
+                    dist_y.backward()
+                self.assertEqual(dist_x.grad.full_tensor(), x.grad)
+            x.grad = None
+            dist_x.grad = None
 
     @with_comms
     @skip_if_lt_x_gpu(4)

--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -254,16 +254,61 @@ def _log_softmax_handler(
     )
 
 
-# NOTE: As explained below at _nll_loss_and_log_softmax_backward, the
-# _log_softmax_backward_handler does not actually do any computation.
+# NOTE: This computes the true distributed log_softmax backward for ALL consumers
+# (not just the fused cross-entropy path). The standard log_softmax backward is
+#   grad_input = grad_output - softmax(output) * grad_output.sum(dim, keepdim=True)
+# where output = log_softmax(x) and softmax(output) = exp(output). In the
+# distributed case the reduction over the sharded class dim is partial on each
+# rank, so an all-reduce (sum) across the TP mesh dim is required to make it
+# globally correct. The fused cross-entropy backward in
+# _nll_loss_and_log_softmax_backward now returns only the nll_loss contribution
+# (grad_input * grad_output); this handler then applies the log_softmax Jacobian
+# to it, which yields the same result as the previous fully-fused formula while
+# also being correct for standalone log_softmax consumers (e.g. DPO/ORPO) that
+# do not feed nll_loss.
 def _log_softmax_backward_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
 ) -> object:
     grad_output = cast(DTensor, args[0])
+    output = cast(DTensor, args[1])
+    dim = cast(int, args[2])
     input_dtype = cast(torch.dtype, args[3])
-    return grad_output.to(input_dtype)
+
+    spec = grad_output._spec
+    dim = normalize_dim(dim, grad_output.dim())
+    mesh_dim = _find_all_reduce_mesh_dim(spec.placements, dim)
+
+    output_tensor_meta = _propagate_tensor_meta(op_call, args, kwargs)
+
+    grad_output_local = grad_output._local_tensor
+    output_local = output._local_tensor
+
+    # grad_input = grad_output - softmax(output) * grad_output.sum(dim, keepdim=True)
+    # The sum over the sharded class dim is partial on each rank, so all-reduce
+    # (sum) across the TP mesh dim to make it globally correct.
+    grad_output_sum = grad_output_local.sum(dim, keepdim=True)
+    grad_output_sum = funcol.all_reduce(
+        grad_output_sum, reduceOp=c10d.ReduceOp.SUM.name, group=(spec.mesh, mesh_dim)
+    )
+    grad_input_local = grad_output_local - torch.exp(output_local) * grad_output_sum
+    grad_input_local = grad_input_local.to(input_dtype)
+
+    res_spec = DTensorSpec(
+        spec.mesh,
+        spec.placements,
+        tensor_meta=output_tensor_meta,
+    )
+
+    # pyrefly: ignore [bad-argument-type]
+    return DTensor(
+        # pyrefly: ignore [bad-argument-count]
+        grad_input_local,
+        res_spec,
+        # pyrefly: ignore [unexpected-keyword]
+        requires_grad=grad_input_local.requires_grad,
+    )
 
 
 # NOTE: The implementation follows torch._decomp.decomposition._nll_loss_forward,
@@ -511,11 +556,14 @@ def _nll_loss_and_log_softmax_backward(
 
     grad_output = torch.where(target != ignore_index, grad_output, 0)
 
-    # NOTE: Instead of directly returning the grad_input as grad_output for log_softmax,
-    # here we perform backward computation for log_softmax altogether to avoid the
-    # otherwise extra all_gather communication.
-    # return grad_input * grad_output
-    return (grad_input + torch.exp(x)) * grad_output
+    # NOTE: The log_softmax backward is now applied separately by
+    # _log_softmax_backward_handler (which computes the correct distributed
+    # Jacobian for all consumers, not just cross-entropy). Here we return only
+    # the nll_loss contribution (grad_input * grad_output); the log_softmax
+    # Jacobian term is applied by the log_softmax backward handler. This adds
+    # one all-reduce to the cross-entropy backward but makes standalone
+    # log_softmax consumers correct.
+    return grad_input * grad_output
 
 
 def _nll_loss_backward_handler(


### PR DESCRIPTION
## Problem

loss_parallel() in torch/distributed/tensor/parallel/loss.py registers a process-wide no-op _log_softmax_backward_handler that returns grad_output unchanged (identity). This is only correct for the fused cross-entropy path, where _nll_loss_and_log_softmax_backward computes the full gradient (grad_input + exp(x)) * grad_output (including the log_softmax Jacobian) and the no-op just passes it through.

Any other consumer inside loss_parallel() — e.g. DPO/ORPO's (log_softmax(logits) * weights).sum() which has no nll_loss in the graph — silently gets the identity gradient instead of the correct (I - softmax(x) * 1^T) Jacobian.

## Fix

1. _log_softmax_backward_handler now computes the true distributed log_softmax Jacobian:
   grad_input = grad_output - softmax(output) * all_reduce(grad_output.sum(dim, keepdim=True))
   (one all_reduce(SUM) across the TP mesh dim, since the class dim is sharded).

2. _nll_loss_and_log_softmax_backward now returns only grad_input * grad_output (the nll_loss contribution), dropping the fused + torch.exp(x) term. The log_softmax Jacobian is applied separately by the backward handler — same result for cross-entropy, correct for all consumers.

Cost: one extra all_reduce on the cross-entropy backward (a small batch-sized tensor).

## Validation (4x H20 GPUs)

- Repro: standalone log_softmax gradient is not the identity (bug fixed), max err vs true grad = 3.17e-07. Cross-entropy backward correct for none/mean/sum reductions (err < 1e-7).
- Regression tests: all 18 test_loss_parallel* tests pass (251s, exit code 0), including the new test_loss_parallel_standalone_log_softmax_backward and test_loss_parallel_cross_entropy_still_correct.

## Tests

- test_loss_parallel_standalone_log_softmax_backward (new)
- test_loss_parallel_cross_entropy_still_correct (new)
- Updated comm count assertion 0 -> 1 for log_softmax backward all_reduce.

Fixes #190746