### PR TITLE
[symm_mem] Warn on multi-stream use of collective ops

### DIFF
--- a/docs/source/symmetric_memory.md
+++ b/docs/source/symmetric_memory.md
@@ -517,6 +517,14 @@ them directly via `torch.ops.symm_mem.<op_name>`.
     requires hardware support for multimem operations. On NVIDIA GPUs, NVLink
     SHARP is required.
 
+    .. warning::
+        All symm_mem collectives for a given group must be issued from a single
+        CUDA stream. The kernels synchronize ranks using a shared signal pad
+        indexed by block ID with no per-stream isolation; issuing concurrent
+        launches from different streams on the same group will cause a deadlock.
+        To use symm_mem collectives from multiple streams, serialize them onto
+        one dedicated stream using ``stream.wait_stream()`` / ``current_stream.wait_stream()``.
+
     :param Tensor input: Input tensor to perform all-reduce on. Must be symmetric.
     :param str reduce_op: Reduction operation to perform. Currently only "sum" is supported.
     :param str group_name: Name of the group to perform all-reduce on.
@@ -525,6 +533,10 @@ them directly via `torch.ops.symm_mem.<op_name>`.
 .. py:function:: multimem_all_gather_out(input: Tensor, group_name: str, out: Tensor) -> Tensor
 
     Performs a multimem all-gather operation on the input tensor. This operation requires hardware support for multimem operations. On NVIDIA GPUs, NVLink SHARP is required.
+
+    .. warning::
+        All symm_mem collectives for a given group must be issued from a single
+        CUDA stream. See :func:`multimem_all_reduce_` for details.
 
     :param Tensor input: Input tensor to perform all-gather on.
     :param str group_name: Name of the group to perform all-gather on.
@@ -535,6 +547,10 @@ them directly via `torch.ops.symm_mem.<op_name>`.
 
     Performs a one-shot all-reduce operation on the input tensor.
 
+    .. warning::
+        All symm_mem collectives for a given group must be issued from a single
+        CUDA stream. See :func:`multimem_all_reduce_` for details.
+
     :param Tensor input: Input tensor to perform all-reduce on. Must be symmetric.
     :param str reduce_op: Reduction operation to perform. Currently only "sum" is supported.
     :param str group_name: Name of the group to perform all-reduce on.
@@ -543,6 +559,10 @@ them directly via `torch.ops.symm_mem.<op_name>`.
 .. py:function:: one_shot_all_reduce_out(input: Tensor, reduce_op: str, group_name: str, out: Tensor) -> Tensor
 
     Performs a one-shot all-reduce operation based on the input tensor and writes the result to the output tensor.
+
+    .. warning::
+        All symm_mem collectives for a given group must be issued from a single
+        CUDA stream. See :func:`multimem_all_reduce_` for details.
 
     :param Tensor input: Input tensor to perform all-reduce on. Must be symmetric.
     :param str reduce_op: Reduction operation to perform. Currently only "sum" is supported.
@@ -553,6 +573,10 @@ them directly via `torch.ops.symm_mem.<op_name>`.
 .. py:function:: two_shot_all_reduce_(input: Tensor, reduce_op: str, group_name: str) -> Tensor
 
     Performs a two-shot all-reduce operation on the input tensor.
+
+    .. warning::
+        All symm_mem collectives for a given group must be issued from a single
+        CUDA stream. See :func:`multimem_all_reduce_` for details.
 
     :param Tensor input: Input tensor to perform all-reduce on. Must be symmetric.
     :param str reduce_op: Reduction operation to perform. Currently only "sum" is supported.

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -70,6 +70,35 @@ namespace {
 
 using namespace c10d::symmetric_memory;
 
+// Warns once if the current CUDA stream differs from the stream that last
+// issued a symm_mem collective for the same group. The all-reduce kernels
+// use signal pad slots indexed by blockIdx.x with no per-stream isolation,
+// so concurrent launches from different streams on the same group will
+// trample each other's barrier slots and deadlock. Callers must serialize
+// all symm_mem collectives for a given group onto a single CUDA stream.
+static std::unordered_map<std::string, cudaStream_t> g_group_stream_map;
+static std::mutex g_group_stream_mutex;
+
+void warn_if_multi_stream(const std::string& group_name, const char* op_name) {
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  std::lock_guard<std::mutex> lock(g_group_stream_mutex);
+  auto it = g_group_stream_map.find(group_name);
+  if (it == g_group_stream_map.end()) {
+    g_group_stream_map[group_name] = stream;
+  } else if (it->second != stream) {
+    TORCH_WARN_ONCE(
+        op_name,
+        ": detected multiple CUDA streams issuing symm_mem collectives "
+        "for group \"",
+        group_name,
+        "\". symm_mem collectives use a shared signal pad indexed by "
+        "blockIdx.x with no per-stream isolation; concurrent launches "
+        "from different streams on the same group will deadlock. "
+        "Serialize all symm_mem collectives for a group onto a single "
+        "dedicated CUDA stream.");
+  }
+}
+
 size_t get_and_verify_alignment(const at::Tensor& input, const char* op_name) {
   const size_t min_alignment = std::max(4l, input.element_size());
   // Only check the offset since the multicast address is always at least
@@ -191,6 +220,7 @@ at::Tensor multimem_all_reduce_(
   TORCH_CHECK(
       symm_mem->has_multicast_support(),
       "multimem_all_reduce_: multicast support is required.");
+  warn_if_multi_stream(group_name, "multimem_all_reduce_");
 
   const size_t alignment =
       get_and_verify_alignment(input, "multimem_all_reduce_");
@@ -411,6 +441,7 @@ at::Tensor multimem_all_gather_out(
   TORCH_CHECK(
       symm_mem->has_multicast_support(),
       "multimem_all_gather_out: output must have multicast support.");
+  warn_if_multi_stream(group_name, "multimem_all_gather_out");
 
   TORCH_CHECK(
       input.is_contiguous(),
@@ -621,6 +652,7 @@ at::Tensor one_shot_all_reduce_out_impl(
   TORCH_CHECK(
       symm_mem != nullptr,
       "one_shot_all_reduce: input must be allocated with empty_strided_p2p().");
+  warn_if_multi_stream(group_name, "one_shot_all_reduce");
 
   const size_t alignment =
       get_and_verify_alignment(input, "one_shot_all_reduce");
@@ -873,6 +905,7 @@ at::Tensor two_shot_all_reduce_impl(
   TORCH_CHECK(
       symm_mem != nullptr,
       "two_shot_all_reduce: input must be allocated with empty_strided_p2p().");
+  warn_if_multi_stream(group_name, "two_shot_all_reduce_");
 
   const size_t alignment =
       get_and_verify_alignment(input, "two_shot_all_reduce");
@@ -1010,6 +1043,7 @@ at::Tensor reduce_scatter_out(
   TORCH_CHECK(
       symm_mem != nullptr,
       "reduce_scatter: input must be allocated with empty_strided_p2p().");
+  warn_if_multi_stream(group_name, "reduce_scatter_out");
 
   const size_t alignment = get_and_verify_alignment(input, "reduce_scatter");
 


### PR DESCRIPTION
Collective kernels synchronize via a shared signal pad indexed by blockIdx.x. Concurrent launches from different streams on the same group deadlock silently.

Add warn_if_multi_stream() and wire it into the affected ops. Document the single-stream-per-group contract in symmetric_memory.md.

Fixes: https://github.com/pytorch/pytorch/issues/189228