### PR TITLE
[TEST] Refactor distributed/tensor/test_view_ops with hw_classification

### DIFF
--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -33,7 +33,7 @@ from torch.distributed.tensor._ops._view_ops import (
 )
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard, Placement
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorContinuousTestBase,
@@ -43,6 +43,7 @@ from torch.utils import _pytree as pytree
 
 
 class TestViewOps(DTensorContinuousTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
     world_size = 6
 
     @staticmethod


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `TestViewOps`  47 tests for distributed tensor view/sharding propagation

No structural changes needed — single class, no split. The distributed test infrastructure (`MultiProcContinuousTest`) handles device selection at runtime, so `instantiate_device_type_tests` is not applicable.

## Test Plan

```
python test/distributed/tensor/test_view_ops.py -v --hw-classification ACCELERATOR
Ran 94 tests in 214.160s — OK (skipped=52)
```

cc @vishalgoyal316