### PR TITLE
[GHF] Add ability to actually merge PRs

### DIFF
--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -183,6 +183,34 @@ def gh_close_pr(org: str, repo: str, pr_num: int, dry_run: bool = False) -> None
         gh_fetch_url(url, method="PATCH", data={"state": "closed"})
 
 
+def gh_merge_pr(
+    org: str,
+    repo: str,
+    pr_num: int,
+    *,
+    merge_method: str = "squash",
+    commit_title: str | None = None,
+    commit_message: str | None = None,
+    sha: str | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Merge a PR via GitHub's merge API and return the resulting merge commit sha."""
+    url = f"{GITHUB_API_URL}/repos/{org}/{repo}/pulls/{pr_num}/merge"
+    data: dict[str, Any] = {"merge_method": merge_method}
+    if commit_title is not None:
+        data["commit_title"] = commit_title
+    if commit_message is not None:
+        data["commit_message"] = commit_message
+    if sha is not None:
+        data["sha"] = sha
+    if dry_run:
+        print(f"[dry_run] Merging PR {pr_num} via GitHub API with {data}")
+        return ""
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    resp = gh_fetch_url(url, headers=headers, data=data, method="PUT", reader=json.load)
+    return cast(str, resp["sha"])
+
+
 def gh_delete_comment(org: str, repo: str, comment_id: int) -> None:
     url = f"{GITHUB_API_URL}/repos/{org}/{repo}/issues/comments/{comment_id}"
     gh_fetch_url(url, method="DELETE", reader=lambda x: x.read())

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -23,6 +23,7 @@ from github_utils import (
     gh_fetch_merge_base,
     gh_fetch_url,
     gh_graphql,
+    gh_merge_pr,
     gh_post_commit_comment,
     gh_post_pr_comment,
     gh_update_pr_state,
@@ -949,6 +950,9 @@ class GitHubPR:
     def get_pr_creator_login(self) -> str:
         return cast(str, self.info["author"]["login"])
 
+    def is_dependabot_pr(self) -> bool:
+        return self.get_pr_creator_login() == "dependabot[bot]"
+
     def _fetch_authors(self) -> list[tuple[str, str]]:
         if self._authors is not None:
             return self._authors
@@ -1286,19 +1290,25 @@ class GitHubPR:
             skip_internal_checks=can_skip_internal_checks(self, comment_id),
             ignore_current_checks=ignore_current_checks,
         )
-        additional_merged_prs = self.merge_changes_locally(
-            repo, skip_mandatory_checks, comment_id
-        )
+        # Dependabot commits are authored/signed by the bot; merge them through
+        # GitHub's squash+merge API so that signature is preserved and dependabot
+        # can track the merge, instead of re-authoring a squash commit locally.
+        if self.is_dependabot_pr():
+            additional_merged_prs: list[GitHubPR] = []
+            merge_commit_sha = self.merge_via_github_api(dry_run)
+        else:
+            additional_merged_prs = self.merge_changes_locally(
+                repo, skip_mandatory_checks, comment_id
+            )
+            repo.push(self.default_branch(), dry_run)
+            # When the merge process reaches this part, we can assume that the
+            # commit has been successfully pushed to trunk
+            merge_commit_sha = repo.rev_parse(name=self.default_branch())
 
-        repo.push(self.default_branch(), dry_run)
         if not dry_run:
             self.add_numbered_label(MERGE_COMPLETE_LABEL, dry_run)
             for pr in additional_merged_prs:
                 pr.add_numbered_label(MERGE_COMPLETE_LABEL, dry_run)
-
-        # When the merge process reaches this part, we can assume that the commit
-        # has been successfully pushed to trunk
-        merge_commit_sha = repo.rev_parse(name=self.default_branch())
 
         if comment_id and self.pr_num:
             # Finally, upload the record to s3. The list of pending and failed
@@ -1333,6 +1343,22 @@ class GitHubPR:
             pr=self,
             additional_merged_prs=additional_merged_prs,
             merge_commit_sha=merge_commit_sha,
+            dry_run=dry_run,
+        )
+
+    def merge_via_github_api(self, dry_run: bool = False) -> str:
+        """Squash-and-merge this PR through GitHub's merge API, pinned to the
+        commit that was reviewed, and return the resulting merge commit sha."""
+        msg = self.gen_commit_message()
+        title, _, body = msg.partition("\n\n")
+        return gh_merge_pr(
+            self.org,
+            self.project,
+            self.pr_num,
+            merge_method="squash",
+            commit_title=title,
+            commit_message=body,
+            sha=self.last_commit_sha(),
             dry_run=dry_run,
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #191487

But restrict it initially to dependabot, which uses "Closed" status as indication that they should not longer track updates of a given package