### PR TITLE
[BE][CUDA] Centralize cuda::std compatibility alias

### DIFF
--- a/aten/src/ATen/native/cuda/SortImpl.cu
+++ b/aten/src/ATen/native/cuda/SortImpl.cu
@@ -1,13 +1,8 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
+#include <ATen/native/cuda/thrust_compat.h>
 #include <thrust/execution_policy.h>
 #include <thrust/sort.h>
-#if defined(USE_ROCM)
-namespace TORCH_CUDA_STD = ::thrust;
-#else
-#include <cuda/std/functional>
-namespace TORCH_CUDA_STD = ::cuda::std;
-#endif
 
 namespace at::native {
 
@@ -23,7 +18,7 @@ std::vector<int64_t> infer_dense_strides_dim_last(const Tensor & self, int64_t d
   }
   thrust::stable_sort_by_key(
     thrust::host, strides.data(), strides.data() + ndim, original_dim.data(),
-    TORCH_CUDA_STD::greater<int64_t>()
+    TORCH_CUDA_STD_NS::greater<int64_t>()
   );
   // generate contiguous strides on permuted dims
   std::vector<int64_t> new_strides(ndim);

--- a/aten/src/ATen/native/cuda/TensorModeKernel.cu
+++ b/aten/src/ATen/native/cuda/TensorModeKernel.cu
@@ -6,6 +6,7 @@
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/ThrustAllocator.h>
 #include <ATen/cuda/cub.cuh>
+#include <ATen/native/cuda/thrust_compat.h>
 #include <c10/core/DeviceArray.h>
 
 #include <thrust/count.h>
@@ -17,12 +18,6 @@
 #include <thrust/inner_product.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
-#if defined(USE_ROCM)
-namespace TORCH_CUDA_STD = ::thrust;
-#else
-#include <cuda/std/functional>
-namespace TORCH_CUDA_STD = ::cuda::std;
-#endif
 
 namespace at::native {
 
@@ -56,8 +51,8 @@ struct ModeImpl {
                     iter_end - 1,
                     iter_begin + 1,
                     0,
-                    TORCH_CUDA_STD::plus<int>(),
-                    TORCH_CUDA_STD::not_equal_to<scalar_t>());
+                    TORCH_CUDA_STD_NS::plus<int>(),
+                    TORCH_CUDA_STD_NS::not_equal_to<scalar_t>());
 
     // Count frequency of each element
     auto keys = c10::DeviceArray<scalar_t>(*cuda_allocator, unique);

--- a/aten/src/ATen/native/cuda/thrust_compat.h
+++ b/aten/src/ATen/native/cuda/thrust_compat.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#if defined(USE_ROCM)
+#include <thrust/distance.h>
+#include <thrust/functional.h>
+namespace TORCH_CUDA_STD_NS = ::thrust;
+#else
+#include <cuda/std/functional>
+#include <cuda/std/iterator>
+namespace TORCH_CUDA_STD_NS = ::cuda::std;
+#endif

--- a/aten/src/ATen/native/sparse/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/sparse/cuda/SoftMax.cu
@@ -9,6 +9,7 @@
 #include <ATen/cuda/ThrustAllocator.h>
 #include <ATen/native/sparse/SparseTensorMath.h>
 #include <ATen/native/SparseTensorUtils.h>
+#include <ATen/native/cuda/thrust_compat.h>
 #include <ATen/native/sparse/ParamUtils.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh>
@@ -316,13 +317,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> compute_pool_max(
       [offsets_ptr] __device__(int64_t x, int64_t y) {
         return offsets_ptr[x] == offsets_ptr[y];
       });
-#if !defined(USE_ROCM)
-  auto new_sz = ::cuda::std::distance(
+  auto new_sz = TORCH_CUDA_STD_NS::distance(
       thrust_ptr(pool_sizes.template data_ptr<int64_t>()), new_end.second);
-#else
-  auto new_sz = thrust::distance(
-      thrust_ptr(pool_sizes.template data_ptr<int64_t>()), new_end.second);
-#endif
   pool_sizes.resize_({new_sz});
 
   auto pool_offsets = pool_sizes.clone();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #191491

Add `thrust_compat.h` that defines `TORCH_CUDA_STD_NS` to `::cuda::std::` if compiling for CUDA, but to `thrust::` if for ROCM
Replace all usage of this trick with unified header ane namespace macro

Authored with the assistance of an AI coding assistant.