### PR TITLE
[dynamo] Route ctx.needs_input_grad through side_effects mutation tracking

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -1285,6 +1285,38 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(cnt.frame_count, 1)
         self.assertEqual(cnt.op_count, 2)
 
+    def test_needs_input_grad_setter_roundtrip(self):
+        # When backward is traced by Dynamo, a store to ctx.needs_input_grad
+        # must be honored on subsequent reads. Regression test for the read
+        # short-circuiting to the construction-time value and dropping the store.
+        sentinel = ([False, True],)
+        seen = {}
+
+        class Foo(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, y):
+                return x + y
+
+            @staticmethod
+            @torch.compile(backend="eager", fullgraph=True)
+            def backward(ctx, grad_output):
+                seen["original"] = ctx.needs_input_grad
+                ctx.needs_input_grad = sentinel
+                seen["after_set"] = ctx.needs_input_grad
+                ctx.needs_input_grad = None
+                seen["after_none"] = ctx.needs_input_grad
+                ctx.needs_input_grad = seen["original"]
+                seen["after_restore"] = ctx.needs_input_grad
+                return grad_output, None
+
+        x = torch.randn(3, requires_grad=True)
+        Foo.apply(x, torch.randn(3)).sum().backward()
+        self.assertEqual(seen["original"], (True, False))
+        self.assertIs(seen["after_set"], sentinel)
+        self.assertIsNone(seen["after_none"])
+        self.assertIs(seen["after_restore"], seen["original"])
+        self.assertEqual(x.grad, torch.ones_like(x))
+
     def test_repeated_save_for_backward_calls(self):
         from torch.autograd import Function
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1291,7 +1291,6 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
         value_type: type | None = None,
         inference: bool = False,
         saved_tensors: Any | None = None,
-        needs_input_grad: tuple[bool, ...] | None = None,
         non_differentiable: Any | None = None,
         dirty_tensors: list[VariableTracker] | None = None,
         **kwargs: Any,
@@ -1299,7 +1298,6 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
         super().__init__(value=value, value_type=value_type, **kwargs)
         self.inference = inference
         self.saved_tensors = saved_tensors
-        self.needs_input_grad = needs_input_grad
         self.non_differentiable = non_differentiable
         self.dirty_tensors = dirty_tensors
 
@@ -1309,10 +1307,6 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
         args: list[VariableTracker] | None = None,
         kwargs: dict[str, VariableTracker] | None = None,
     ) -> VariableTracker:
-        needs_input_grad = None
-        if args and not kwargs:
-            # type: ignore[attr-defined]
-            needs_input_grad = tuple(x.is_tensor() and x.requires_grad for x in args)
         out = tx.output.side_effects.track_object_new(
             None,
             torch.autograd.function.FunctionCtx,
@@ -1320,10 +1314,18 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
                 AutogradFunctionContextVariable,
                 inference=True,
                 saved_tensors=SavedTensorBox(),
-                needs_input_grad=needs_input_grad,
             ),
             {},
         )
+        if args and not kwargs:
+            # The real apply() populates ctx.needs_input_grad; mirror it as a
+            # regular attribute store so reads and user writes both flow
+            # through the generic side_effects machinery.
+            # pyrefly: ignore [missing-attribute]
+            needs_input_grad = tuple(x.is_tensor() and x.requires_grad for x in args)
+            tx.output.side_effects.store_instance_dict_attr(
+                out, "needs_input_grad", ConstantVariable.create(needs_input_grad)
+            )
         return out
 
     def as_proxy(self) -> Any:
@@ -1421,13 +1423,6 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
             return variables.TupleVariable(list(self.dirty_tensors))
         if name == "saved_tensors" and self.saved_tensors is not None:
             return variables.TupleVariable(list(self.saved_tensors.tensors))
-        if name == "needs_input_grad":
-            if self.needs_input_grad is not None:
-                return variables.ConstantVariable.create(self.needs_input_grad)
-            if self.source:
-                source = AttrSource(self.source, "needs_input_grad")
-                # type: ignore[attr-defined]
-                return VariableTracker.build(tx, self.value.needs_input_grad, source)
 
         return super().getattro_impl(tx, name)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #191492

Root cause: AutogradFunctionContextVariable carried needs_input_grad as
state on the VariableTracker itself, set at create() time, and
getattro_impl short-circuited reads to that cached value. A traced store
(ctx.needs_input_grad = x in a Dynamo-traced backward) lands in
side_effects, so a subsequent read returned the stale construction-time
tuple and the store was silently dropped. This surfaced as
test_needs_input_grad_setter_roundtrip failing under
PYTORCH_TEST_WITH_DYNAMO with compiled autograd whenever the backward
body was traced by Dynamo.

Fix: create() now seeds the tuple with store_instance_dict_attr, i.e.
through the same mutation model user writes go through, and the
needs_input_grad special cases in getattro_impl are deleted. Reads on a
created FunctionCtx resolve via the generic instance-dict path; reads on
a sourced real ctx (BackwardCFunction) resolve via the generic
GetSetDescriptorType handling in resolve_data_descriptor, which already
consults pending mutations and installs the same guards.

Alternative considered: keep the VT field and add a pending-mutation
check in front of it. Rejected as it patches around parallel state
rather than removing it. The VT field dates to #123700 (Apr 2024), when
generic getattr had no C getset-descriptor modeling, so an explicit
read-through branch was required; that infrastructure exists now, making
the special cases pure duplication. Verified guard trees on
ctx.needs_input_grad reads are byte-identical before/after, and the
motivating cases of #123700 (needs_input_grad reads in traced forward on
a created ctx, reads in compiled backward on a real ctx, test_hook_none
under the Dynamo test harness) all still pass.

Test Plan:

New regression test compiles the backward with fullgraph so the store
and read of ctx.needs_input_grad are both traced; it fails before this
change (read returns the stale tuple) and passes after:

```
python -m pytest test/dynamo/test_autograd_function.py -k test_needs_input_grad_setter_roundtrip -q
```

Suites covering both create() callers and the descriptor read path:

```
python -m pytest test/dynamo/test_autograd_function.py -q
python -m pytest test/dynamo/test_higher_order_ops.py -q
python -m pytest test/dynamo/test_aot_autograd.py -q
python -m pytest test/inductor/test_compiled_autograd.py -k custom_function -q
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_autograd.py TestAutograd.test_needs_input_grad_setter_roundtrip_num_inputs_2 TestAutograd.test_needs_input_grad_setter_roundtrip_num_inputs_25
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_autograd.py TestAutograd.test_hook_none
python -m pytest test/test_autograd.py -k test_needs_input_grad_setter_roundtrip -q
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98