### PR TITLE
[DO NOT MERGE][ROCm][CI] MI350: cap Inductor compile-worker count to fix KFD runlist oversubscription

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -114,11 +114,13 @@ runner_mapping:
   linux.rocm.gpu.gfx942.4: linux.rocm.gpu.gfx942.4
   linux.rocm.gpu.gfx950.1: linux.rocm.gpu.gfx950.1
   linux.rocm.gpu.gfx950.2: linux.rocm.gpu.gfx950.2
+  linux.rocm.gpu.gfx950.1.test: linux.rocm.gpu.gfx950.1.test
   linux.rocm.gpu.gfx1100: linux.rocm.gpu.gfx1100
   # amd-do experiment routes mi350 tests to AMD's dedicated runners via this
   # prefix; kept as passthrough so the OSDC build's runner mapping preserves it.
   amd-do-linux.rocm.gpu.gfx950.1: amd-do-linux.rocm.gpu.gfx950.1
   amd-do-linux.rocm.gpu.gfx950.2: amd-do-linux.rocm.gpu.gfx950.2
+  amd-do-linux.rocm.gpu.gfx950.1.test: amd-do-linux.rocm.gpu.gfx950.1.test
   # amd-sandbox experiment routes trunk-rocm-sandbox gfx942 tests to AMD's dedicated
   # runners via this prefix; passthrough so the OSDC build's runner mapping keeps it.
   amd-sandbox-linux.rocm.gpu.gfx942.1: amd-sandbox-linux.rocm.gpu.gfx942.1

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -47,6 +47,13 @@ on:
           If non-empty, pins TORCHINDUCTOR_COMPILE_THREADS for the test container
           so the Inductor compile-worker fan-out is fixed instead of derived from
           the visible CPU count. Empty leaves the default behavior.
+      repro-probe:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          [AIPYTORCH-894 A/B only] When true, emit greppable REPRO_PROBE lines into the job log
+          (one-shot CPU-affinity/parallel_info probe + background compile-worker sampler). Inert by default.
       dashboard-tag:
         required: false
         type: string
@@ -213,6 +220,7 @@ jobs:
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
           TORCHINDUCTOR_COMPILE_THREADS: ${{ inputs.compile-threads }}
+          REPRO_PROBE: ${{ inputs.repro-probe && '1' || '0' }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
         timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
@@ -300,7 +308,16 @@ jobs:
           if [[ "${TEST_CONFIG}" == *distributed* ]]; then
             PREFLIGHT="timeout 180 python .ci/pytorch/rocm_preflight.py && "
           fi
-          docker exec -t "${container_name}" sh -c "pip install dist/*.whl && ${PREFLIGHT}${TEST_COMMAND}"
+          # [AIPYTORCH-894 A/B] In-log reproduction evidence (gated on repro-probe). Non-fatal.
+          if [[ "${REPRO_PROBE}" == "1" ]]; then
+            docker exec -t "${container_name}" bash -lc 'echo "REPRO_PROBE affinity=$(python -c "import os;print(len(os.sched_getaffinity(0)))") nproc=$(nproc) parallel_info:"; python -c "import torch;print(torch.__config__.parallel_info())"' || true
+          fi
+          # [AIPYTORCH-894 A/B] Background compile-worker sampler (gated). Non-fatal; dies with container.
+          SAMPLER=""
+          if [[ "${REPRO_PROBE}" == "1" ]]; then
+            SAMPLER='{ ( for i in $(seq 1 60); do echo "REPRO_PROBE workers=$(pgrep -fc "compile_worker|async_compile|torch/_inductor/compile_worker" 2>/dev/null || echo 0) ts=$(date +%s)"; sleep 30; done ) & } && '
+          fi
+          docker exec -t "${container_name}" sh -c "pip install dist/*.whl && ${PREFLIGHT}${SAMPLER}${TEST_COMMAND}"
 
       - name: Restore workspace owner
         if: always()
@@ -345,7 +362,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: coredumps-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}
+          name: coredumps-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
           retention-days: 14
           if-no-files-found: ignore
           path: ./**/core.[1-9]*

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -39,6 +39,14 @@ on:
         default: ""
         description: |
           List of tests to include (empty string implies default list)
+      compile-threads:
+        required: false
+        type: string
+        default: ""
+        description: |
+          If non-empty, pins TORCHINDUCTOR_COMPILE_THREADS for the test container
+          so the Inductor compile-worker fan-out is fixed instead of derived from
+          the visible CPU count. Empty leaves the default behavior.
       dashboard-tag:
         required: false
         type: string
@@ -204,6 +212,7 @@ jobs:
           DOCKER_IMAGE: ${{ inputs.docker-image }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
+          TORCHINDUCTOR_COMPILE_THREADS: ${{ inputs.compile-threads }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
         timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
@@ -218,12 +227,21 @@ jobs:
             TEST_COMMAND=.ci/pytorch/test.sh
           fi
 
+          # Optionally forward a pinned Inductor compile-worker count into the
+          # container. Only forward when non-empty: an empty value would be parsed
+          # as int("") and crash decide_compile_threads().
+          COMPILE_THREADS_FLAG=""
+          if [[ -n "${TORCHINDUCTOR_COMPILE_THREADS}" ]]; then
+            COMPILE_THREADS_FLAG="-e TORCHINDUCTOR_COMPILE_THREADS"
+          fi
+
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice
           # shellcheck disable=SC2086,SC2090
           container_name=$(docker run \
             ${GPU_FLAG:-} \
+            ${COMPILE_THREADS_FLAG:-} \
             -e BUILD_ENVIRONMENT \
             -e PR_NUMBER \
             -e GITHUB_ACTIONS \

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -458,21 +458,13 @@ jobs:
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       # TODO (huydhn): Add this back once other workflow migrates
       # sync-tag: rocm-build
+      # [DO NOT MERGE][experiment] Reduced 2-shard matrix so the CPU-core
+      # isolation experiment is fast and focused on the inductor compile tests
+      # (especially max_autotune). Restored to the full 8+2+3 matrix before merge.
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 2, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 3, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 4, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 5, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 6, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2" },
+          { config: "default", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
         ]}
       python-version: "3.10"
     secrets: inherit
@@ -488,7 +480,14 @@ jobs:
       build-environment: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
-      tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
+      # [DO NOT MERGE][experiment] Restrict to just the inductor compile tests
+      # (especially max_autotune) so the CPU-isolation run is fast and focused.
+      tests-to-include: "inductor/test_torchinductor inductor/test_torchinductor_opinfo inductor/test_max_autotune inductor/test_cpu_repro"
+      # Cap the Inductor compile-worker count so the number of GPU-attached
+      # compile clients stays bounded for the KFD runlist instead of scaling with
+      # the visible CPU count. Only this MI350 job passes it; other ROCm callers
+      # pass nothing and keep the default behavior. Sweeping {16,8,4,2}.
+      compile-threads: "16"
     secrets: inherit
 
   inductor-build:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -476,24 +476,59 @@ jobs:
       python-version: "3.10"
     secrets: inherit
 
-  linux-jammy-rocm-py3_10-test:
-    name: linux-jammy-rocm-py3.10-mi350
+  # [DO NOT MERGE][AIPYTORCH-894 A/B] CONTROL: reproduce oversubscription (vanilla dind, uncapped).
+  linux-jammy-rocm-py3_10-test-oversub:
+    name: linux-jammy-rocm-py3.10-mi350-oversub
     uses: ./.github/workflows/_rocm-test.yml
     needs:
       - linux-jammy-rocm-py3_10-build
       - target-determination
       - job-filter
+      - get-label-type
     with:
       build-environment: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
-      # [DO NOT MERGE][experiment] Full-scope run: no tests-to-include restriction,
-      # so the default config runs the complete ROCm default test suite (like
-      # production trunk), exercising every per-GPU compile path across 8 shards.
-      # Cap the Inductor compile-worker count so the number of GPU-attached
-      # compile clients stays bounded for the KFD runlist instead of scaling with
-      # the visible CPU count. Only this MI350 job passes it; other ROCm callers
-      # pass nothing and keep the default behavior. Sweeping {16,8,4,2}.
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 1, id: 1, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 1, num_shards: 1, id: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 1, num_shards: 1, id: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 1, num_shards: 1, id: 4, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 1, num_shards: 1, id: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 1, num_shards: 1, id: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 1, num_shards: 1, id: 7, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 1, num_shards: 1, id: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test-control" },
+        ]}
+      tests-to-include: "inductor/test_max_autotune inductor/test_torchinductor inductor/test_torchinductor_opinfo inductor/test_cpu_repro inductor/test_aot_inductor"
+      repro-probe: true
+      # CONTROL is UNCAPPED: do NOT pass compile-threads.
+    secrets: inherit
+
+  # [DO NOT MERGE][AIPYTORCH-894 A/B] TREATMENT: demonstrate the fix (isolated dind + compile-threads cap).
+  linux-jammy-rocm-py3_10-test-isolated:
+    name: linux-jammy-rocm-py3.10-mi350-isolated
+    uses: ./.github/workflows/_rocm-test.yml
+    needs:
+      - linux-jammy-rocm-py3_10-build
+      - target-determination
+      - job-filter
+      - get-label-type
+    with:
+      build-environment: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 1, id: 1, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 1, num_shards: 1, id: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 1, num_shards: 1, id: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 1, num_shards: 1, id: 4, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 1, num_shards: 1, id: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 1, num_shards: 1, id: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 1, num_shards: 1, id: 7, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 1, num_shards: 1, id: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+        ]}
+      tests-to-include: "inductor/test_max_autotune inductor/test_torchinductor inductor/test_torchinductor_opinfo inductor/test_cpu_repro inductor/test_aot_inductor"
+      repro-probe: true
       compile-threads: "16"
     secrets: inherit
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -458,13 +458,20 @@ jobs:
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       # TODO (huydhn): Add this back once other workflow migrates
       # sync-tag: rocm-build
-      # [DO NOT MERGE][experiment] Reduced 2-shard matrix so the CPU-core
-      # isolation experiment is fast and focused on the inductor compile tests
-      # (especially max_autotune). Restored to the full 8+2+3 matrix before merge.
+      # [DO NOT MERGE][experiment] 8-shard full-scope matrix on the .test scale
+      # set to validate that compile-threads=16 prevents per-GPU KFD timeouts and
+      # to observe whether the 8 runner pods co-locate on the same DOKS node.
+      # Restored to the full 8+2+3 matrix before merge.
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
-          { config: "default", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 1, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 2, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 3, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 4, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 5, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 6, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1.test" },
         ]}
       python-version: "3.10"
     secrets: inherit
@@ -480,9 +487,9 @@ jobs:
       build-environment: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
-      # [DO NOT MERGE][experiment] Restrict to just the inductor compile tests
-      # (especially max_autotune) so the CPU-isolation run is fast and focused.
-      tests-to-include: "inductor/test_torchinductor inductor/test_torchinductor_opinfo inductor/test_max_autotune inductor/test_cpu_repro"
+      # [DO NOT MERGE][experiment] Full-scope run: no tests-to-include restriction,
+      # so the default config runs the complete ROCm default test suite (like
+      # production trunk), exercising every per-GPU compile path across 8 shards.
       # Cap the Inductor compile-worker count so the number of GPU-attached
       # compile clients stays bounded for the KFD runlist instead of scaling with
       # the visible CPU count. Only this MI350 job passes it; other ROCm callers

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -206,6 +206,7 @@ ROCM_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
     "distributed/pipelining/test_dtensor_pp_integration",
+    "inductor/test_cpu_repro",  # excessive runtimes compared to CUDA
 ]
 
 # Add architecture-specific blocklist entries

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -206,7 +206,6 @@ ROCM_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
     "distributed/pipelining/test_dtensor_pp_integration",
-    "inductor/test_cpu_repro",  # excessive runtimes compared to CUDA
 ]
 
 # Add architecture-specific blocklist entries


### PR DESCRIPTION
## Motivation

**Do not merge yet — sweeping the compile-worker value.** On the MI350 (gfx950) trunk test jobs, `inductor/test_max_autotune` has been hitting the per-file 30-min timeout (`exit 124`), which can push a shard toward the 270-min Test-step cap.

### Root cause

Inductor sizes its compile-worker pool as `min(32, cpu_count)`, and the workers are **forked** so they inherit the HIP context and are **GPU-attached**. When the visible CPU count is large, that fans out to many GPU-attached compile clients on the shard's single GPU and **oversubscribes the KFD runlist**, causing GPU thrash and the `max_autotune` hang.

## Fix

Cap the Inductor compile-worker count directly via `TORCHINDUCTOR_COMPILE_THREADS`, so the GPU-client count stays bounded regardless of the visible CPU count:

- New optional `compile-threads` input on `_rocm-test.yml`, forwarded into the test container **only when non-empty** (an empty value would be parsed as `int("")` and crash `decide_compile_threads()`).
- Only the MI350 trunk job sets it (`compile-threads: "16"`); other ROCm callers pass nothing and keep the default behavior.
- A moderate value (**16**) keeps enough compile parallelism to finish `max_autotune` under the 30-min cap while staying under the runlist. This PR is sweeping `{16, 8, 4, 2}` to lock in the largest safe value.

### Complementary half handled separately

The other half of the problem — the test container seeing the **full host CPU count** (which also inflates the worker fan-out and CPU/NUMA contention) — is **handled separately by our infra**. This compile-worker cap is an app-level fix that stands on its own: it is **safe to merge ahead of that work and must not be gated on it**. `sched_getaffinity`/`nproc` are unchanged by this PR.

## Scope of changes

- **`_rocm-test.yml`**: add the optional `compile-threads` input; forward `TORCHINDUCTOR_COMPILE_THREADS` into the `docker run` only when non-empty.
- **`trunk.yml`** (MI350 job only): pass `compile-threads: "16"`; route the test shards to the `linux.rocm.gpu.gfx950.1.test` canary scale set.

## Validation status (experimental scaffolding — kept for the sweep)

**Current experiment config (8-shard, full-scope — experiment-only, must be reverted before merge):** the MI350 `test-matrix` is set to **8 `default` shards**, each routed to the `linux.rocm.gpu.gfx950.1.test` canary scale set, and the experimental `tests-to-include` restriction has been **removed** so the default config runs the **full ROCm default test suite** (like production trunk). This validates that `TORCHINDUCTOR_COMPILE_THREADS=16` prevents the per-GPU KFD timeouts across the whole suite and lets us observe whether the 8 runner pods co-locate on the same DOKS node. `inductor/test_cpu_repro` has been **re-added** to `ROCM_BLOCKLIST` (`test/run_test.py`) to drop unrelated CPU-codegen assertion noise. The uncapped production trunk `linux-jammy-rocm-py3.10-mi350` runs are the control — no uncapped arm is run here.

**Pass criteria:** `test_max_autotune` (and the rest of the suite) complete within the per-file 30-min limit (no `exit 124`) and each shard finishes well under the 270-min cap, with `TORCHINDUCTOR_COMPILE_THREADS` set to the swept value.

## Restore before merge

- [ ] Restore the full MI350 `test-matrix` (8 `default` + 2 `inductor` + 3 `distributed` shards) — **note:** the current 8-`default`-shard / `.test`-scale-set / full-scope matrix is experiment-only and must be reverted to the production topology.
- [ ] Re-add the experimental `tests-to-include` restriction was already removed for full-scope; confirm the default (empty) `tests-to-include` is the intended production behavior.
- [ ] Revert the `ROCM_BLOCKLIST` re-add of `inductor/test_cpu_repro` in `test/run_test.py` if it is decided to enable it on ROCm/MI350 (decision point).
- [ ] Remove `[DO NOT MERGE]` from the title/body.
- [ ] Keep only the `compile-threads` plumbing and the chosen value.
- [ ] Decide whether to keep the shards on `linux.rocm.gpu.gfx950.1.test` or return them to the standard pool.
- [ ] Remove the experiment-only `.test` ARC runner entries added to `.github/arc.yaml` (`linux.rocm.gpu.gfx950.1.test` and `amd-do-linux.rocm.gpu.gfx950.1.test` passthroughs) — these were added solely to make the canary `.test` scale set routable through the runner-mapping step and should be removed/revisited before merge.

- [ ] **[AIPYTORCH-894 A/B validation-only]** Remove the two split A/B test jobs (`linux-jammy-rocm-py3_10-test-oversub` and `linux-jammy-rocm-py3_10-test-isolated`) in `trunk.yml` and restore the single production `linux-jammy-rocm-py3_10-test` job. These were added only to run the A/B repro (CONTROL = uncapped oversub on `.test-control`; TREATMENT = `compile-threads: "16"` isolated on `.test`), each fanning out 8 replicate pods running the full payload (`num_shards: 1, shard: 1`).
- [ ] **[AIPYTORCH-894 A/B validation-only]** Remove the `.test-control` scale-set routing (`linux.rocm.gpu.gfx950.1.test-control`) — provisioned by the separate INFRA track for the CONTROL arm only.
- [ ] **[AIPYTORCH-894 A/B validation-only]** Remove the gated `repro-probe` diagnostic in `_rocm-test.yml` (the `repro-probe` input, the `REPRO_PROBE` env, the one-shot affinity/`parallel_info` probe, and the background compile-worker `REPRO_PROBE` sampler). Inert by default; kept only to emit greppable in-log evidence for the A/B run.
- [ ] **[AIPYTORCH-894 A/B validation-only]** The coredump artifact `name:` in `_rocm-test.yml` now appends `_${{ steps.get-job-id.outputs.job-id }}` so the 8 replicate pods don't collide on upload-artifact v4 (duplicate-name failure). Decide whether to keep this hardening or revert with the rest of the A/B scaffolding.

Made with Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

