### PR TITLE
[inductor] Skip SDPA fusion when the matched scale is a Tensor

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -750,6 +750,25 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                 model, args1=args, contains=False, atol=1e-3, has_fuse_pattern=False
             )
 
+    def _test_pattern_fails_with_tensor_scale(self):
+        # https://github.com/pytorch/pytorch/issues/191203
+        def model(query, key, value, attn_mask, scale):
+            scores = query @ key.transpose(-2, -1) / scale
+            weights = torch.softmax(scores + attn_mask, dim=-1)
+            return weights @ value
+
+        tensor_shape = (2, 4, 4, 4)
+        args = [
+            torch.randn(tensor_shape, device=self.device),
+            torch.randn(tensor_shape, device=self.device),
+            torch.randn(tensor_shape, device=self.device),
+            torch.randn((1, 1, 4, 4), device=self.device),
+            torch.tensor(0.5, device=self.device),
+        ]
+        self._check_common(
+            model, args1=args, contains=False, atol=1e-4, has_fuse_pattern=False
+        )
+
     def _test_pattern_fails_with_unsupported_mask(self):
         if not self.use_static_shapes:
             self.skipTest("Causes shape specialization. TODO: investigate")
@@ -1811,6 +1830,9 @@ if HAS_XPU_AND_TRITON or (HAS_CUDA_AND_TRITON and PLATFORM_SUPPORTS_FUSED_ATTENT
         test_pattern_fails_with_tensor_factor_gpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_tensor_factor
         )
+        test_pattern_fails_with_tensor_scale_gpu = (
+            TestSDPAPatternRewriterTemplate._test_pattern_fails_with_tensor_scale
+        )
         test_pattern_fails_with_unsupported_mask_gpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_unsupported_mask
         )
@@ -1945,6 +1967,9 @@ if HAS_CPU:
         test_sdpa_rewriter_5_cpu = TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_5
         test_pattern_fails_with_tensor_factor_cpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_tensor_factor
+        )
+        test_pattern_fails_with_tensor_scale_cpu = (
+            TestSDPAPatternRewriterTemplate._test_pattern_fails_with_tensor_scale
         )
         test_pattern_fails_with_unsupported_mask_cpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_unsupported_mask

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -769,6 +769,52 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             model, args1=args, contains=False, atol=1e-4, has_fuse_pattern=False
         )
 
+    def _test_pattern_fuses_with_symint_scale(self):
+        def model(query, key, value, attn_mask):
+            scale = query.size(-1) // 2
+            scores = query @ key.transpose(-2, -1) / scale
+            weights = torch.softmax(scores + attn_mask, dim=-1)
+            return weights @ value
+
+        tensor_shape = (2, 4, 4, 4)
+        args = [
+            torch.randn(tensor_shape, device=self.device),
+            torch.randn(tensor_shape, device=self.device),
+            torch.randn(tensor_shape, device=self.device),
+            torch.randn((1, 1, 4, 4), device=self.device),
+        ]
+        expected = model(*args)
+        for tensor in args[:3]:
+            torch._dynamo.mark_dynamic(tensor, -1)
+        counters.clear()
+        actual = torch.compile(model, fullgraph=True, dynamic=True)(*args)
+        self.assertEqual(expected, actual, atol=1e-4, rtol=0.2)
+        self.assertGreaterEqual(counters["inductor"]["fuse_attention"], 1)
+
+    def _test_pattern_fails_with_symfloat_scale(self):
+        # tensorify_python_scalars turns this into a 0-d tensor before the
+        # pattern check. See https://github.com/pytorch/pytorch/issues/191203.
+        def model(query, key, value, attn_mask):
+            scale = query.size(-1) ** 0.5
+            scores = query @ key.transpose(-2, -1) / scale
+            weights = torch.softmax(scores + attn_mask, dim=-1)
+            return weights @ value
+
+        tensor_shape = (2, 4, 4, 4)
+        args = [
+            torch.randn(tensor_shape, device=self.device),
+            torch.randn(tensor_shape, device=self.device),
+            torch.randn(tensor_shape, device=self.device),
+            torch.randn((1, 1, 4, 4), device=self.device),
+        ]
+        expected = model(*args)
+        for tensor in args[:3]:
+            torch._dynamo.mark_dynamic(tensor, -1)
+        counters.clear()
+        actual = torch.compile(model, fullgraph=True, dynamic=True)(*args)
+        self.assertEqual(expected, actual, atol=1e-4, rtol=0.2)
+        self.assertEqual(counters["inductor"]["fuse_attention"], 0)
+
     def _test_pattern_fails_with_unsupported_mask(self):
         if not self.use_static_shapes:
             self.skipTest("Causes shape specialization. TODO: investigate")
@@ -1833,6 +1879,12 @@ if HAS_XPU_AND_TRITON or (HAS_CUDA_AND_TRITON and PLATFORM_SUPPORTS_FUSED_ATTENT
         test_pattern_fails_with_tensor_scale_gpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_tensor_scale
         )
+        test_pattern_fuses_with_symint_scale_gpu = (
+            TestSDPAPatternRewriterTemplate._test_pattern_fuses_with_symint_scale
+        )
+        test_pattern_fails_with_symfloat_scale_gpu = (
+            TestSDPAPatternRewriterTemplate._test_pattern_fails_with_symfloat_scale
+        )
         test_pattern_fails_with_unsupported_mask_gpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_unsupported_mask
         )
@@ -1970,6 +2022,12 @@ if HAS_CPU:
         )
         test_pattern_fails_with_tensor_scale_cpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_tensor_scale
+        )
+        test_pattern_fuses_with_symint_scale_cpu = (
+            TestSDPAPatternRewriterTemplate._test_pattern_fuses_with_symint_scale
+        )
+        test_pattern_fails_with_symfloat_scale_cpu = (
+            TestSDPAPatternRewriterTemplate._test_pattern_fails_with_symfloat_scale
         )
         test_pattern_fails_with_unsupported_mask_cpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_unsupported_mask

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -753,6 +753,8 @@ class TestSDPAPatternRewriterTemplate(TestCase):
     def _test_pattern_fails_with_tensor_scale(self):
         # https://github.com/pytorch/pytorch/issues/191203
         def model(query, key, value, attn_mask, scale):
+            # Dividing by scale makes the scale gradients very unstable
+            scale = scale.detach()
             scores = query @ key.transpose(-2, -1) / scale
             weights = torch.softmax(scores + attn_mask, dim=-1)
             return weights @ value
@@ -766,53 +768,86 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             torch.tensor(0.5, device=self.device),
         ]
         self._check_common(
-            model, args1=args, contains=False, atol=1e-4, has_fuse_pattern=False
+            model, args1=args, contains=False, atol=1e-3, has_fuse_pattern=False
         )
+        self.assertEqual(counters["inductor"]["fuse_attention"], 0)
 
     def _test_pattern_fuses_with_symint_scale(self):
-        def model(query, key, value, attn_mask):
-            scale = query.size(-1) // 2
+        # A SymInt scale is a scalar the fused kernel accepts. _check_common
+        # only marks dim 0 dynamic, so the scale is taken from that dim.
+        if self.use_static_shapes:
+            self.skipTest("the scale is only symbolic under dynamic shapes")
+
+        # The mask is built inside the model: a mask input would require grad
+        # in the training run, which blocks the fusion for any scale.
+        def model(query, key, value):
+            scale = query.size(0) // 2
+            attn_mask = torch.ones(
+                query.size(-2), key.size(-2), dtype=torch.bool, device=query.device
+            ).tril(diagonal=0)
+            attn_mask = attn_mask.masked_fill(
+                torch.logical_not(attn_mask), -float("inf")
+            )
             scores = query @ key.transpose(-2, -1) / scale
             weights = torch.softmax(scores + attn_mask, dim=-1)
             return weights @ value
 
-        tensor_shape = (2, 4, 4, 4)
+        tensor_shape = (8, 4, 4, 4)
         args = [
             torch.randn(tensor_shape, device=self.device),
             torch.randn(tensor_shape, device=self.device),
             torch.randn(tensor_shape, device=self.device),
-            torch.randn((1, 1, 4, 4), device=self.device),
         ]
-        expected = model(*args)
-        for tensor in args[:3]:
-            torch._dynamo.mark_dynamic(tensor, -1)
-        counters.clear()
-        actual = torch.compile(model, fullgraph=True, dynamic=True)(*args)
-        self.assertEqual(expected, actual, atol=1e-4, rtol=0.2)
-        self.assertGreaterEqual(counters["inductor"]["fuse_attention"], 1)
+        self._check_common(model, args1=args, contains=False)
+
+    def _test_pattern_fuses_with_symint_scale_div(self):
+        # Same SymInt scale, reaching the guard through _sfdp_extra_check
+        # instead of _sfdp_params_check.
+        if self.use_static_shapes:
+            self.skipTest("the scale is only symbolic under dynamic shapes")
+
+        def model(query, key, value):
+            scale = query.size(0) // 2
+            return (
+                torch.matmul(query, key.transpose(-2, -1))
+                .div(scale)
+                .softmax(dim=-1)
+                .matmul(value)
+            )
+
+        tensor_shape = (8, 4, 4, 4)
+        args = [
+            torch.randn(tensor_shape, device=self.device),
+            torch.randn(tensor_shape, device=self.device),
+            torch.randn(tensor_shape, device=self.device),
+        ]
+        self._check_common(model, args1=args)
 
     def _test_pattern_fails_with_symfloat_scale(self):
-        # tensorify_python_scalars turns this into a 0-d tensor before the
-        # pattern check. See https://github.com/pytorch/pytorch/issues/191203.
+        # tensorify_python_scalars turns the SymFloat scale into a 0-d tensor
+        # before the pattern check, so the fusion is skipped.
+        # TODO: the scalar behind a tensorified SymFloat scale (e.g.
+        # head_dim**0.5 under dynamic shapes) could be recovered from the
+        # aten.scalar_tensor node to keep the fusion - tracked in #194444.
+        if self.use_static_shapes:
+            self.skipTest("the scale is only symbolic under dynamic shapes")
+
         def model(query, key, value, attn_mask):
-            scale = query.size(-1) ** 0.5
+            scale = query.size(0) ** 0.5
             scores = query @ key.transpose(-2, -1) / scale
             weights = torch.softmax(scores + attn_mask, dim=-1)
             return weights @ value
 
-        tensor_shape = (2, 4, 4, 4)
+        tensor_shape = (8, 4, 4, 4)
         args = [
             torch.randn(tensor_shape, device=self.device),
             torch.randn(tensor_shape, device=self.device),
             torch.randn(tensor_shape, device=self.device),
             torch.randn((1, 1, 4, 4), device=self.device),
         ]
-        expected = model(*args)
-        for tensor in args[:3]:
-            torch._dynamo.mark_dynamic(tensor, -1)
-        counters.clear()
-        actual = torch.compile(model, fullgraph=True, dynamic=True)(*args)
-        self.assertEqual(expected, actual, atol=1e-4, rtol=0.2)
+        self._check_common(
+            model, args1=args, contains=False, atol=1e-3, has_fuse_pattern=False
+        )
         self.assertEqual(counters["inductor"]["fuse_attention"], 0)
 
     def _test_pattern_fails_with_unsupported_mask(self):
@@ -1882,6 +1917,9 @@ if HAS_XPU_AND_TRITON or (HAS_CUDA_AND_TRITON and PLATFORM_SUPPORTS_FUSED_ATTENT
         test_pattern_fuses_with_symint_scale_gpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fuses_with_symint_scale
         )
+        test_pattern_fuses_with_symint_scale_div_gpu = (
+            TestSDPAPatternRewriterTemplate._test_pattern_fuses_with_symint_scale_div
+        )
         test_pattern_fails_with_symfloat_scale_gpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_symfloat_scale
         )
@@ -2025,6 +2063,9 @@ if HAS_CPU:
         )
         test_pattern_fuses_with_symint_scale_cpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fuses_with_symint_scale
+        )
+        test_pattern_fuses_with_symint_scale_div_cpu = (
+            TestSDPAPatternRewriterTemplate._test_pattern_fuses_with_symint_scale_div
         )
         test_pattern_fails_with_symfloat_scale_cpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_symfloat_scale

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -946,10 +946,13 @@ def _warn_tf32_disabled() -> None:
 def _sfdp_params_check(match):
     if not all(k in match.kwargs for k in ("query", "key", "value")):
         raise AssertionError("expected query, key, value in match.kwargs")
-    if "inv_scale" in match.kwargs and not isinstance(
-        match.kwargs["inv_scale"], (float, int)
-    ):
-        return False
+    if "inv_scale" in match.kwargs:
+        inv_scale = match.kwargs["inv_scale"]
+        # Non-constant FX arguments store their value type in node metadata.
+        if isinstance(inv_scale, torch.fx.Node):
+            inv_scale = inv_scale.meta.get("val")
+        if not isinstance(inv_scale, (float, int, torch.SymInt, torch.SymFloat)):
+            return False
     query = match.kwargs["query"].meta["val"]
     key = match.kwargs["key"].meta["val"]
     value = match.kwargs["value"].meta["val"]

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -946,6 +946,10 @@ def _warn_tf32_disabled() -> None:
 def _sfdp_params_check(match):
     if not all(k in match.kwargs for k in ("query", "key", "value")):
         raise AssertionError("expected query, key, value in match.kwargs")
+    if "inv_scale" in match.kwargs and not isinstance(
+        match.kwargs["inv_scale"], (float, int)
+    ):
+        return False
     query = match.kwargs["query"].meta["val"]
     key = match.kwargs["key"].meta["val"]
     value = match.kwargs["value"].meta["val"]

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -943,16 +943,27 @@ def _warn_tf32_disabled() -> None:
         )
 
 
+def _is_supported_scale(scale) -> bool:
+    # The matcher may bind the scale to a graph node, whose value lives in
+    # meta["val"]; a node carrying no "val" leaves the scale unknown, so we
+    # conservatively skip the fusion. The fused kernel takes a scalar scale, so
+    # a tensor scale is rejected here. SymFloat scales are tensorified into 0-d
+    # tensors before the joint graph passes run, so they arrive as tensors too;
+    # an untensorified one would land in the same conservative skip.
+    # TODO: the scalar behind a tensorified SymFloat scale (e.g. head_dim**0.5
+    # under dynamic shapes) could be recovered from the aten.scalar_tensor node
+    # to keep the fusion - tracked in #194444.
+    if isinstance(scale, torch.fx.Node):
+        scale = scale.meta.get("val")
+    return isinstance(scale, (float, int, torch.SymInt))
+
+
 def _sfdp_params_check(match):
     if not all(k in match.kwargs for k in ("query", "key", "value")):
         raise AssertionError("expected query, key, value in match.kwargs")
-    if "inv_scale" in match.kwargs:
-        inv_scale = match.kwargs["inv_scale"]
-        # Non-constant FX arguments store their value type in node metadata.
-        if isinstance(inv_scale, torch.fx.Node):
-            inv_scale = inv_scale.meta.get("val")
-        if not isinstance(inv_scale, (float, int, torch.SymInt, torch.SymFloat)):
-            return False
+    inv_scale = match.kwargs.get("inv_scale")
+    if inv_scale is not None and not _is_supported_scale(inv_scale):
+        return False
     query = match.kwargs["query"].meta["val"]
     key = match.kwargs["key"].meta["val"]
     value = match.kwargs["value"].meta["val"]
@@ -1010,9 +1021,7 @@ def _sfdp_extra_check(scale_factor_op=None, disable_cuda=False):
         if scale_factor_op is not None:
             scale_factor_node = filter_nodes(match.nodes, scale_factor_op)[0]
             # Note: args[1] of the scale_factor_node is always the scale_factor for the current patterns.
-            scale_factor = scale_factor_node.args[1]
-            # make sure the scale_factor a float/int. SymInt?
-            if not isinstance(scale_factor, (float, int)):
+            if not _is_supported_scale(scale_factor_node.args[1]):
                 return False
         return _sfdp_params_check(match)
 


### PR DESCRIPTION
Fixes #191203

## What happens

Writing attention as `q @ k.transpose(-2, -1) / scale` with a 0-d tensor scale works in eager but crashes under torch.compile:

```
RuntimeError: aten::scaled_dot_product_attention() Expected a value of type
'Optional[float]' for argument 'scale' but instead found type 'FakeTensor'.
Cast error details: cannot extract float from tensor with meta storage
```

fuse_attention.py has two families of sfdp patterns. Patterns 1-4, 11-17 and 28-30 go through `_sfdp_extra_check`, which inspects the div/mul node that produces the scale and rejects the match when it is not a float or int. Patterns 5-10 and 18-20 instead capture the scale through the scalar_workaround mechanism as `match.kwargs["inv_scale"]`, and nothing ever type checks it. So the pattern matches, the replacement builds `1.0 / inv_scale` with a tensor in it, and forwards that into scaled_dot_product_attention's `float? scale` argument, which fails during fake tensor tracing.

## The fix

`_sfdp_params_check` is the one check every sfdp pattern runs (the second family uses it directly as its extra_check, and `_sfdp_extra_check` calls it as its last step), so the guard lives there:

```python
if "inv_scale" in match.kwargs and not isinstance(
    match.kwargs["inv_scale"], (float, int)
):
    return False
```

With a real scalar scale nothing changes and the fusion fires as before. With a tensor scale the match is rejected, no rewrite happens, and the model compiles as the unfused graph, which is the same fallback the `_sfdp_extra_check` family already uses for non scalar scales.

## Testing

- New regression test (cpu and gpu registrations): the issue's repro shape with a tensor scale compiles, matches eager, and asserts no fusion fired. Without the fix it fails with the exact error above.
- All 58 CPU tests in test/inductor/test_fused_attention.py pass (1 pre-existing skip). lintrunner clean.
- Patterns 6-10 only have GPU-side positive tests, so a CUDA run of test_sdpa_rewriter_6 to 10 would be a welcome extra check that scalar scale fusion there is unaffected.

P.S. Claude Assisted, all changes reviewed and tested by me.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jansel @zou3519  