### PR TITLE
[inductor] Supply CPU GEMM template reindexers to support multiple buffer users in BMM

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -2968,6 +2968,30 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
 
     @patches
     @torch.no_grad
+    @requires_mkl
+    @dtypes(torch.float32, torch.bfloat16, torch.half)
+    def test_bmm_with_template_buffer_other_users(self, dtype):
+        # https://github.com/pytorch/pytorch/issues/185405
+        # The BMM output is returned raw *and* consumed by an epilogue, so the
+        # GEMM output buffer has users outside of the fused epilogue. That makes
+        # the template emit an extra local-to-global copy epilogue, which works on
+        # the 3D ranges of the GEMM output buffer while the template stores 2D
+        # tiles, so it needs the batch reindexer.
+        class M(torch.nn.Module):
+            def forward(self, q, k):
+                matmul = torch.matmul(q, k.transpose(-2, -1))
+                return matmul, torch.mul(matmul, 0.35355339059327373)
+
+        counters.clear()
+        q = torch.randn(2, 8, 4, 8).to(dtype=dtype)
+        k = torch.randn(2, 8, 4, 8).to(dtype=dtype)
+        mod = M().to(dtype=dtype).eval()
+        with verify(dtype) as (atol, rtol):
+            self.common(mod, (q, k), atol=atol, rtol=rtol)
+        self.assertEqual(counters["inductor"]["cpp_templated_kernel_counter"], 1)
+
+    @patches
+    @torch.no_grad
     @parametrize("bs", (1, 50))
     @parametrize("Mdim", (192,))
     @parametrize("Kdim", (196,))

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -2972,11 +2972,9 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
     @dtypes(torch.float32, torch.bfloat16, torch.half)
     def test_bmm_with_template_buffer_other_users(self, dtype):
         # https://github.com/pytorch/pytorch/issues/185405
-        # The BMM output is returned raw *and* consumed by an epilogue, so the
-        # GEMM output buffer has users outside of the fused epilogue. That makes
-        # the template emit an extra local-to-global copy epilogue, which works on
-        # the 3D ranges of the GEMM output buffer while the template stores 2D
-        # tiles, so it needs the batch reindexer.
+        # The BMM output is returned raw *and* consumed by an epilogue, so the GEMM
+        # output buffer gets an extra local-to-global copy epilogue whose ranges are
+        # 3D while the template stores 2D tiles, hence it needs the batch reindexer.
         class M(torch.nn.Module):
             def forward(self, q, k):
                 matmul = torch.matmul(q, k.transpose(-2, -1))
@@ -2989,6 +2987,9 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         with verify(dtype) as (atol, rtol):
             self.common(mod, (q, k), atol=atol, rtol=rtol)
         self.assertEqual(counters["inductor"]["cpp_templated_kernel_counter"], 1)
+        # The bug requires the mul to actually be fused into the template, since
+        # template_buffer_has_other_users is False when there are no epilogue nodes.
+        self.assertEqual(counters["inductor"]["cpp_epilogue_fusion_counter"], 1)
 
     @patches
     @torch.no_grad

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -173,12 +173,12 @@ class CppBmmTemplate(CppGemmTemplate):
         kernel.render_hooks[placeholder] = hook
         return placeholder
 
-    def get_default_reindexers(self, epilogue_nodes):
+    def get_default_reindexers(self, epilogues):
         def reindexer(args):
             # if epilogue nodes exist, they have 3D ranges but args are 2D, so add 0 index
             return [self.b_index] + args
 
-        return [reindexer] * len(epilogue_nodes)
+        return [reindexer] * len(epilogues)
 
     def get_options(
         self,

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -1601,6 +1601,12 @@ class CppGemmTemplate(CppTemplate):
                 layout=template_buffer.layout,
             )
             current_input_buffer = gemm_output_buffer
+            # The in-template epilogues are created over the ranges of the GEMM output
+            # buffer, whose rank may be higher than the 2D tiles the template stores into
+            # (e.g. for the BMM template the GEMM output buffer keeps a leading batch dim).
+            # Ask the template for the reindexers that map the 2D template indices onto the
+            # ranges of these epilogues.
+            creator_reindexers = self.get_default_reindexers(epilogue_creators)
             for i, creator in enumerate(epilogue_creators):
                 if i == len(epilogue_creators) - 1:
                     buffer_name = template_buffer.get_name()
@@ -1616,7 +1622,7 @@ class CppGemmTemplate(CppTemplate):
                 )
                 fake_buffers.append(current_input_buffer)
                 Y_aliases.add(current_input_buffer.get_name())
-                reindexers.append(None)
+                reindexers.append(creator_reindexers[i])
                 if i < len(epilogue_creators) - 1:
                     current_input_buffer = ir.Buffer(
                         name=buffer_name,

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -1449,8 +1449,8 @@ class CppGemmTemplate(CppTemplate):
             W = W.as_strided(W.shape, new_stride)
             return W
 
-    def get_default_reindexers(self, epilogue_nodes):
-        return [None] * len(epilogue_nodes)
+    def get_default_reindexers(self, epilogues):
+        return [None] * len(epilogues)
 
     def get_options(
         self,
@@ -1601,11 +1601,10 @@ class CppGemmTemplate(CppTemplate):
                 layout=template_buffer.layout,
             )
             current_input_buffer = gemm_output_buffer
-            # The in-template epilogues are created over the ranges of the GEMM output
-            # buffer, whose rank may be higher than the 2D tiles the template stores into
-            # (e.g. for the BMM template the GEMM output buffer keeps a leading batch dim).
-            # Ask the template for the reindexers that map the 2D template indices onto the
-            # ranges of these epilogues.
+            # In-template epilogues are built over the GEMM output buffer's ranges,
+            # whose rank can exceed that of the 2D tiles the template stores into
+            # (the BMM template keeps a leading batch dim). Let the template supply
+            # the reindexers mapping the 2D tile indices onto those ranges.
             creator_reindexers = self.get_default_reindexers(epilogue_creators)
             for i, creator in enumerate(epilogue_creators):
                 if i == len(epilogue_creators) - 1:


### PR DESCRIPTION
Fixes #185405

## Summary

Compiling a batched matmul whose result is both returned raw and consumed by a
pointwise op fails during Inductor final codegen with:
```
torch._inductor.exc.InductorError: AssertionError: Expected stride is not None and len(index) == len(stride)
```

Partial repro:
```python
def f(q, k):
    matmul = torch.matmul(q, k.transpose(-2, -1))
    return matmul, torch.mul(matmul, 0.35355339059327373)`
```

Full repro:

<details><summary>Details</summary>
<p>

```python
import traceback

import torch
import torch._inductor.config as inductor_config
import torch._inductor.select_algorithm as select_algorithm


def _force_cpp_template_over_aten():
    """Make ATen kernels look ~1e6x slower so the CPP template is always chosen."""
    orig_lookup = select_algorithm.AlgorithmSelectorCache.lookup

    def skip_cache(self, choices, name, key, benchmark, *args, **kwargs):
        if benchmark is None:
            return {}
        timings = benchmark(choices)
        for choice, timing in timings.items():
            if isinstance(choice, select_algorithm.ExternKernelCaller):
                # Intentionally penalize the ATen fallback so the cpp
                # template wins autotuning on every CPU (incl. AMX Xeons).
                timings[choice] = timing * 1_000_000
        return timings

    select_algorithm.AlgorithmSelectorCache.lookup = skip_cache
    return orig_lookup


def target_function(q, k):
    matmul = torch.matmul(q, k.transpose(-2, -1))
    scores = torch.mul(matmul, 0.35355339059327373)
    # Returning `matmul` raw *and* `scores` is what gives the GEMM output
    # buffer a user outside the fused epilogue (template_buffer_has_other_users),
    # which triggers the buggy copy_from_local_to_global_buffer epilogue.
    return matmul, scores


def main():
    from torch._inductor import cpu_vec_isa

    print("pick_vec_isa:", cpu_vec_isa.pick_vec_isa())

    inductor_config.max_autotune = True
    inductor_config.max_autotune_gemm_backends = "CPP,ATEN"
    inductor_config.epilogue_fusion = True

    _force_cpp_template_over_aten()

    torch.manual_seed(2077)
    q = torch.randn(2, 8, 4, 8, dtype=torch.float32)
    k = torch.randn(2, 8, 4, 8, dtype=torch.float32)

    eager = target_function(q, k)
    print("Eager passed:", eager[0].shape, eager[1].shape)

    compiled = torch.compile(
        target_function, mode="max-autotune", dynamic=False, fullgraph=True
    )
    try:
        out = compiled(q, k)
        print("Compiled PASSED (bug NOT triggered):", out[0].shape, out[1].shape)
    except Exception as exc:
        traceback.print_exc()
        print(f"\n[CRASH] {type(exc).__name__}: {str(exc)[:120]}")


if __name__ == "__main__":
    main()
```

</p>
</details> 

## Root cause
Because `matmul` has a user outside the fused epilogue, `template_buffer_has_other_users` is True and the GEMM template appends an extra `copy_from_local_to_global_buffer_epilogue` to copy the localized
accumulator out to the global buffer.

In `CppGemmTemplate.get_options`, every epilogue produced was registered with a `None` reindexer.  This encodes the assumption that in-template epilogues never need reindexing, which only holds when the GEMM output buffer has the same rank as the tiles the template stores. That is true for the 2D GEMM template but not for `CppBmmTemplate`.

## Fix
Let the template supply the reindexers for its own in-template epilogues instead of hardcoding `None`.

## Test plan
Added `test_bmm_with_template_buffer_other_users` to `test/inductor/test_cpu_select_algorithm.py`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo