### PR TITLE
[TEST] Refactor test_redistribute.py with hw_classification

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -45,8 +45,8 @@ from torch.distributed.tensor._redistribute import (
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _MaskPartial, _StridedShard
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,
@@ -3158,6 +3158,7 @@ DistributeWithDeviceOrderTestWithLocalTensor = create_local_tensor_test_class(
     base_class=LocalDTensorContinuousTestBase,
 )
 
+
 class _CollectiveDtypeTracer(torch.utils._python_dispatch.TorchDispatchMode):
     """Records the dtype of the first tensor argument for each _c10d_functional op."""
 
@@ -3242,7 +3243,9 @@ class RedistributeBackwardDtypeTest(TestCase):
 
 
 instantiate_device_type_tests(MultiDimRedistributeTest, globals(), except_for="cpu")
-instantiate_device_type_tests(DistributeWithDeviceOrderTest, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    DistributeWithDeviceOrderTest, globals(), except_for="cpu"
+)
 instantiate_device_type_tests(
     DistributeWithStridedShardTest, globals(), except_for="cpu"
 )

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -46,7 +46,9 @@ from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _MaskPartial, _StridedShard
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -71,6 +73,7 @@ funcol = torch.ops.c10d_functional
 
 
 class RedistributeTest(DTensorContinuousTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
     world_size = 4
 
     @parametrize("dtype", [torch.float32, torch.cfloat])
@@ -1119,6 +1122,7 @@ instantiate_parametrized_tests(RedistributeTest)
 
 
 class MultiDimRedistributeTest(DTensorContinuousTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
     world_size = 8
 
     def test_multi_dim_mesh(self):
@@ -1207,6 +1211,7 @@ class MultiDimRedistributeTest(DTensorContinuousTestBase):
 
 
 class DistributeWithDeviceOrderTest(DTensorContinuousTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
     world_size = 8
 
     def _extract_redistribute_trace_from_debug_mode(self, s: str) -> str:
@@ -1767,6 +1772,7 @@ class DistributeWithDeviceOrderTest(DTensorContinuousTestBase):
 
 
 class DistributeWithStridedShardTest(DTensorContinuousTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
     world_size = 8
 
     def _extract_redistribute_trace_from_debug_mode(self, s: str) -> str:
@@ -2029,6 +2035,8 @@ class DistributeWithStridedShardTest(DTensorContinuousTestBase):
 class TransformInfoTest(TestCase):
     """Tests for _TransformInfo._comm_type_key method."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_comm_type_key(self):
         """Test _comm_type_key returns correct keys for different placement transforms."""
         # Comm ops: return comm type string
@@ -2077,6 +2085,8 @@ class OptimizeFlattenedReductionsTest(TestCase):
 
     Uses fake process group since these tests don't perform actual communications.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     @classmethod
     def setUpClass(cls):
@@ -2694,6 +2704,7 @@ class MultiDimRedistributeOptimizationTest(DTensorContinuousTestBase):
     on multi-dimensional meshes, including the flattened mesh optimization.
     """
 
+    hw_classification = HardwareClassification.ACCELERATOR
     world_size = 8
 
     def test_multi_dim_redistribute(self):
@@ -2944,6 +2955,7 @@ class FlattenedReductionIntegrationTest(DTensorContinuousTestBase):
     when flattened meshes are available.
     """
 
+    hw_classification = HardwareClassification.ACCELERATOR
     world_size = 8
 
     def test_merging_reductions(self):
@@ -3049,6 +3061,7 @@ class UnevenFlattenedReduceScatterTest(DTensorContinuousTestBase):
     optimization doesn't properly handle padding/unpadding.
     """
 
+    hw_classification = HardwareClassification.ACCELERATOR
     world_size = 6  # 2 x 3 mesh
 
     def test_partial_partial_to_shard_shard_uneven(self):
@@ -3145,7 +3158,6 @@ DistributeWithDeviceOrderTestWithLocalTensor = create_local_tensor_test_class(
     base_class=LocalDTensorContinuousTestBase,
 )
 
-
 class _CollectiveDtypeTracer(torch.utils._python_dispatch.TorchDispatchMode):
     """Records the dtype of the first tensor argument for each _c10d_functional op."""
 
@@ -3171,6 +3183,8 @@ class RedistributeBackwardDtypeTest(TestCase):
     A fake process group lets us run this single-process; a TorchDispatchMode
     tracer captures the dtype of each ``_c10d_functional`` collective.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     @classmethod
     def setUpClass(cls):
@@ -3226,6 +3240,21 @@ class RedistributeBackwardDtypeTest(TestCase):
         self.assertEqual(tracer.dtypes_for("reduce_scatter_tensor"), [torch.float32])
         self.assertEqual(local.grad.dtype, torch.float32)
 
+
+instantiate_device_type_tests(MultiDimRedistributeTest, globals(), except_for="cpu")
+instantiate_device_type_tests(DistributeWithDeviceOrderTest, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    DistributeWithStridedShardTest, globals(), except_for="cpu"
+)
+instantiate_device_type_tests(
+    MultiDimRedistributeOptimizationTest, globals(), except_for="cpu"
+)
+instantiate_device_type_tests(
+    FlattenedReductionIntegrationTest, globals(), except_for="cpu"
+)
+instantiate_device_type_tests(
+    UnevenFlattenedReduceScatterTest, globals(), except_for="cpu"
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
Apply hardware classification to `test/distributed/tensor/test_redistribute.py`.

Changes:
- Add hw_classification = ACCELERATOR to RedistributeTest (24 tests, uses instantiate_parametrized_tests)
- Add hw_classification = ACCELERATOR to MultiDimRedistributeTest (2 tests)
- Add hw_classification = ACCELERATOR to DistributeWithDeviceOrderTest (11 tests)
- Add hw_classification = ACCELERATOR to DistributeWithStridedShardTest (4 tests)
- Add hw_classification = GENERIC to TransformInfoTest (2 tests) — pure unit tests with no distributed communication
- Add hw_classification = GENERIC to OptimizeFlattenedReductionsTest (16 tests) — pure unit tests with no distributed communication
- Add hw_classification = ACCELERATOR to MultiDimRedistributeOptimizationTest (2 tests)
- Add hw_classification = ACCELERATOR to FlattenedReductionIntegrationTest (1 test)
- Add hw_classification = ACCELERATOR to UnevenFlattenedReduceScatterTest (1 test)
- Add hw_classification = GENERIC to RedistributeBackwardDtypeTest (2 tests) — pure unit tests with no distributed communication
- Add instantiate_device_type_tests(except_for="cpu") for all ACCELERATOR classes except RedistributeTest (which uses instantiate_parametrized_tests)

`except_for="cpu"` is used because these distributed tests require accelerator devices via DTensorContinuousTestBase, so a CPU-instantiated class would have all tests skipped.

## Test Plan

python -m pytest test/distributed/tensor/test_redistribute.py -v
115 passed, 3 skipped, 11 subtests passed

python -m pytest test/distributed/tensor/test_redistribute.py -v --hw-classification ACCELERATOR
95 passed, 3 skipped, 11 subtests passed

python -m pytest test/distributed/tensor/test_redistribute.py -v --hw-classification GENERIC
20 passed