### PR TITLE
[dynamo] Fix Method.invoke typo in OrderedDict call_method dispatch

### DIFF
--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -919,7 +919,7 @@ class OrderedDictVariable(ConstDictVariable):
         # popitem(last=) handler.
         method = self.lookup_tp_method(name)
         if method is not None:
-            result = method.invoke(self, tx, name, args, kwargs)
+            result = method(self, tx, name, args, kwargs)
             if result is not None:
                 return result
         return super().call_method(tx, name, args, kwargs)


### PR DESCRIPTION

OrderedDictVariable.call_method called `method.invoke(self, tx, name, args,
kwargs)` on the tp_methods entry, but the Method class
(torch/_dynamo/variables/base.py) is invoked via __call__, not an `invoke`
method. The correct form -- already used by the generic tp_methods dispatch in
VariableTracker.call_method (base.py) -- is `method(self, tx, name, args,
kwargs)`. As written, tracing OrderedDict.move_to_end()/popitem() would raise
`AttributeError: 'Method' object has no attribute 'invoke'` at runtime, and
pyrefly failed lint with `missing-attribute: Object of class Method has no
attribute invoke`.

Introduced by #191365 ("[dynamo] Unify OrderedDict into a single
ConstDictVariable subclass"). Fix: drop `.invoke` and call the Method directly.

Test Plan:
This checkout has no lintrunner/pyrefly and a stale torch C-extension, so the
fix was verified by matching the call pattern already used in
torch/_dynamo/variables/base.py (VariableTracker.call_method) and a syntax
check:

```
python -m py_compile torch/_dynamo/variables/dicts.py
```

Authored with the assistance of an AI coding agent.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/191505).
* #190943
* __->__ #191505

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98