### PR TITLE
[BE][Ez]: Optimize autograd using std::move

### DIFF
--- a/torch/csrc/autograd/autograd_meta.cpp
+++ b/torch/csrc/autograd/autograd_meta.cpp
@@ -242,7 +242,7 @@ void AutogradMeta::set_fw_grad(
             }
 
             new_fw_grad_value.copy_(new_grad);
-            new_grad = new_fw_grad_value;
+            new_grad = std::move(new_fw_grad_value);
           }
 
           base._set_fw_grad(new_base_fw_grad, level, /* is_inplace_op */ false);
@@ -262,10 +262,10 @@ void AutogradMeta::set_fw_grad(
       res._set_conj(self.is_conj());
       res._set_neg(self.is_neg());
       res.copy_(new_grad);
-      new_grad = res;
+      new_grad = std::move(res);
     }
 
-    fw_grad_->set_value(new_grad, level);
+    fw_grad_->set_value(std::move(new_grad), level);
   }
 }
 
@@ -308,7 +308,7 @@ const Variable& AutogradMeta::fw_grad(
               self.sizes(), self.strides(), self.storage_offset());
         }
 
-        const_view_meta->fw_grad_->set_value(new_val, level);
+        const_view_meta->fw_grad_->set_value(std::move(new_val), level);
         return const_view_meta->fw_grad_->value(level);
       }
     }

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -462,7 +462,7 @@ static optional_variable_list _process_backward_mode_ad(
     if (maybe_output_impls) {
       maybe_output_impls->insert(out_tensor_impl);
     }
-    outputs.emplace_back(var);
+    outputs.emplace_back(std::move(var));
   }
 
   // If multiple differentiable outputs are returned, we do not allow views to

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -269,7 +269,7 @@ inline variable_list CppNode_apply_functional(
           ", std the corresponding forward input was not a Variable");
       continue;
     }
-    results.emplace_back(outputs[i]);
+    results.emplace_back(std::move(outputs[i]));
   }
 
   return results;

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1675,7 +1675,7 @@ auto Engine::start_device_threads() -> void {
   }
 }
 
-void Engine::add_thread_pool_task(const std::weak_ptr<GraphTask>& graph_task) {
+void Engine::add_thread_pool_task(std::weak_ptr<GraphTask> graph_task) {
   std::unique_lock<std::mutex> lck(thread_pool_shared_->mutex_);
   // There may already be some items on the graphtasks_queue_ added by other
   // threads but not enough workers to get to the new task that will be
@@ -1683,7 +1683,7 @@ void Engine::add_thread_pool_task(const std::weak_ptr<GraphTask>& graph_task) {
   bool create_thread =
       (thread_pool_shared_->num_workers_ <=
        thread_pool_shared_->graphtasks_queue_.size());
-  thread_pool_shared_->graphtasks_queue_.push(graph_task);
+  thread_pool_shared_->graphtasks_queue_.push(std::move(graph_task));
   // Don't need to be holding the lock while actually creating the thread
   lck.unlock();
   if (create_thread) {

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -238,7 +238,7 @@ struct TORCH_API Engine {
   void decrement_non_reentrant_thread_count();
   virtual void thread_main(const std::shared_ptr<GraphTask>& task);
   void reentrant_thread_init();
-  void add_thread_pool_task(const std::weak_ptr<GraphTask>& graph_task);
+  void add_thread_pool_task(std::weak_ptr<GraphTask> graph_task);
 
   // Safe to read device_ready_queues_ without synchronization after
   // initialization

--- a/torch/csrc/autograd/forward_grad.h
+++ b/torch/csrc/autograd/forward_grad.h
@@ -115,9 +115,9 @@ struct TORCH_API ForwardADLevel {
     grads_.erase(grad);
   }
 
-  void insert(const std::shared_ptr<ForwardGrad>& grad) {
+  void insert(std::shared_ptr<ForwardGrad> grad) {
     std::lock_guard<std::mutex> lock(mutex_);
-    grads_.insert(grad);
+    grads_.insert(std::move(grad));
   }
 
  private:
@@ -161,14 +161,14 @@ struct TORCH_API ForwardGrad : std::enable_shared_from_this<ForwardGrad> {
     }
   }
 
-  void set_value(const at::Tensor& value, uint64_t level) {
+  void set_value(at::Tensor value, uint64_t level) {
     // Owning reference to ensure the forward_level is not destroyed
     // while we are updating our internal state
     auto forward_level = ForwardADLevel::get_by_idx(level);
     forward_level->insert(shared_from_this());
 
     std::lock_guard<std::mutex> lock(mutex_);
-    content_.insert({level, value});
+    content_.try_emplace(level, std::move(value));
   }
 
   // This function removes the tangent for a given level from this ForwardGrad
@@ -180,14 +180,14 @@ struct TORCH_API ForwardGrad : std::enable_shared_from_this<ForwardGrad> {
     }
 
     std::unique_lock<std::mutex> lock(mutex_);
-    const auto& it = content_.find(level);
+    const auto it = content_.find(level);
     TORCH_INTERNAL_ASSERT(
         it != content_.end(), "Resetting a non-existent level.");
     // Keep the Tensor alive until we have released the lock
     // This is needed as we can be in a case where this function is called by
     // ForwardADLevel destructor
-    auto t = (*it).second;
-    content_.erase(level);
+    auto t = std::move(it->second);
+    content_.erase(it);
     lock.unlock();
   }
 

--- a/torch/csrc/autograd/profiler_legacy.cpp
+++ b/torch/csrc/autograd/profiler_legacy.cpp
@@ -506,7 +506,7 @@ void LegacyEvent::record(bool record_cuda) {
     for (const auto j : c10::irange(curShapesList.size())) {
       s.emplace_back(curShapesList.get(j).toInt());
     }
-    shapes.emplace_back(s);
+    shapes.emplace_back(std::move(s));
   }
 
   LegacyEvent evt(
@@ -557,10 +557,10 @@ at::IValue LegacyEvent::toIValue() const {
     for (const auto& k : shape) {
       s.emplace_back(k);
     }
-    shapesList.emplace_back(s);
+    shapesList.emplace_back(std::move(s));
   }
-  eventIValueList.emplace_back(shapesList);
-  return at::IValue(eventIValueList);
+  eventIValueList.emplace_back(std::move(shapesList));
+  return at::IValue(std::move(eventIValueList));
 }
 
 double LegacyEvent::cudaElapsedUs(const LegacyEvent& e) const {


### PR DESCRIPTION
Noticed some unnecessary refcounts in hotpaths in autograd and updated them to use pass by value and std::move calls to reduce unnecessary refcounts, make it more idiomatic, and demonstrate cleaner ownership semantics.