### PR TITLE
[dynamo] Sever torch._guards runtime dependencies on torch._dynamo

### DIFF
--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -80,6 +80,13 @@ from .utils import (
 from .polyfills import loader as _  # usort: skip
 
 
+# torch._guards must not import torch._dynamo; register the live config getter it
+# needs here (used by GuardSource.is_specialized_nn_module).
+torch._guards.register_skip_fsdp_module_guards_getter(
+    lambda: config._unsafe_skip_fsdp_module_guards
+)
+
+
 __all__ = [
     "allow_c_slot",
     "allow_in_graph",

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1264,6 +1264,12 @@ def unsupported_guard_check_spec(fn):
     return fn
 
 
+def sorts_last(fn):
+    """Mark a guard method to sort after all others in Guard.sort_key."""
+    fn._guard_sorts_last = True
+    return fn
+
+
 class GuardBuilder(GuardBuilderBase):
     def __init__(
         self,
@@ -3142,6 +3148,7 @@ class GuardBuilder(GuardBuilderBase):
     # single source → value check.
     # TODO(voz): Deduplicate w/ AOTAutograd dupe input guards
     @skip_guard_check_spec
+    @sorts_last
     def DUPLICATE_INPUT(self, guard: Guard, source_b: Source) -> None:
         if is_from_skip_guard_source(
             guard.originating_source

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -1327,15 +1327,6 @@ def is_from_closure_source(source: Source) -> bool:
 
 
 @functools.lru_cache
-def is_from_source(source: Source, target: Source) -> bool:
-    if source == target:
-        return True
-    if isinstance(source, ChainedSource):
-        return is_from_source(source.base, target)
-    return False
-
-
-@functools.lru_cache
 def is_from_unspecialized_nn_module_source(source: Source) -> bool:
     if isinstance(source, UnspecializedNNModuleSource):
         return True

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -1159,7 +1159,7 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
         previously_installed_submodules = []
         if invoke_subgraph_cache:
             previously_installed_submodules = (
-                invoke_subgraph_cache.get_dynamo_installed_submodules(fn_code)
+                invoke_subgraph_cache.get_installed_submodules(fn_code)
             )
             current_mod = body_gmod
             # NB - reverse is more likely to cause a hit sooner because first
@@ -1194,7 +1194,7 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
             len(previously_installed_submodules) + 1,
         )
         if invoke_subgraph_cache:
-            invoke_subgraph_cache.add_dynamo_installed_submodule(fn_code, body_name)
+            invoke_subgraph_cache.add_installed_submodule(fn_code, body_name)
 
         return body_name
 

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import Any, Generic, NamedTuple, overload, TYPE_CHECKING, TypeVar
 from typing_extensions import dataclass_transform
 
-import torch
+import torch  # noqa: TC001
 from torch.utils import _pytree as pytree
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
@@ -143,6 +143,17 @@ class TraceId(NamedTuple):
             return f"{self.compile_id}_{self.attempt}"
 
 
+# Dependency inversion: torch._guards must not import torch._dynamo. Dynamo
+# registers a live getter for this config flag at import time; None (the default
+# when dynamo is not loaded) keeps behavior identical to the flag being off.
+_skip_fsdp_module_guards_getter: Callable[[], bool] | None = None
+
+
+def register_skip_fsdp_module_guards_getter(fn: Callable[[], bool]) -> None:
+    global _skip_fsdp_module_guards_getter
+    _skip_fsdp_module_guards_getter = fn
+
+
 class GuardSource(enum.Enum):
     LOCAL = 0
     GLOBAL = 1
@@ -166,9 +177,8 @@ class GuardSource(enum.Enum):
         return self in (GuardSource.GLOBAL_FSDP_MODULE, GuardSource.LOCAL_FSDP_MODULE)
 
     def is_specialized_nn_module(self) -> bool:
-        import torch._dynamo.config as config
-
-        if config._unsafe_skip_fsdp_module_guards:
+        getter = _skip_fsdp_module_guards_getter
+        if getter is not None and getter():
             return (
                 self
                 in (
@@ -291,10 +301,7 @@ class Guard:
         # Put the duplicate input guards at the end. The duplicate guards have
         # two sources while guard.name only considers one source.
 
-        is_duplicate_input = (
-            isinstance(self.create_fn, functools.partial)
-            and self.create_fn.func is torch._dynamo.guards.GuardBuilder.DUPLICATE_INPUT
-        )
+        is_duplicate_input = getattr(self.inner_create_fn(), "_guard_sorts_last", False)
         return (
             is_duplicate_input,
             self.source.value if self.source else -1,
@@ -699,8 +706,6 @@ class GuardsSet:
 
     def remove_guards_with_source(self, source: Source) -> None:
         """Delete all guards that contains a given source"""
-        from ._dynamo.source import is_from_source
-
         self.inner = OrderedSet(
             g for g in self.inner if not is_from_source(g.originating_source, source)
         )
@@ -746,12 +751,10 @@ class GuardsContext(Checkpointable[GuardsCheckpointState]):
 
 class HopSubgraphCache:
     @abstractmethod
-    def add_dynamo_installed_submodule(
-        self, fn_code: CodeType, identifier: str
-    ) -> None: ...
+    def add_installed_submodule(self, fn_code: CodeType, identifier: str) -> None: ...
 
     @abstractmethod
-    def get_dynamo_installed_submodules(self, fn_code: CodeType) -> list[str]: ...
+    def get_installed_submodules(self, fn_code: CodeType) -> list[str]: ...
 
     @abstractmethod
     def add_autograd_key_entry(self, identifier: str, key: Callable) -> None: ...
@@ -866,12 +869,10 @@ class InvokeSubgraphCache(HopSubgraphCache):
             CodeType, dict[int, InvokeSubgraphReuseEntry]
         ] = defaultdict(dict)
 
-    def add_dynamo_installed_submodule(
-        self, fn_code: CodeType, identifier: str
-    ) -> None:
+    def add_installed_submodule(self, fn_code: CodeType, identifier: str) -> None:
         self.dynamo_installed_submodules[fn_code].append(identifier)
 
-    def get_dynamo_installed_submodules(self, fn_code: CodeType) -> list[str]:
+    def get_installed_submodules(self, fn_code: CodeType) -> list[str]:
         return self.dynamo_installed_submodules.get(fn_code, [])
 
     def add_autograd_key_entry(self, identifier: str, key: Callable) -> None:
@@ -1511,6 +1512,15 @@ class ChainedSource(Source):
         if transform_fn is not None:
             result = transform_fn(result)
         return result
+
+
+@functools.lru_cache
+def is_from_source(source: Source, target: Source) -> bool:
+    if source == target:
+        return True
+    if isinstance(source, ChainedSource):
+        return is_from_source(source.base, target)
+    return False
 
 
 def detect_fake_mode(inputs: Any = None) -> FakeTensorMode | None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191525
* #191524
* #191522
* #191521
* #191520
* #191519
* __->__ #191518

torch._guards is meant to be the layer-neutral source of truth for guard
structures ("no dynamo notions here"), but it had three runtime back-references
into torch._dynamo that made it impossible to import or use the guard core
without pulling in all of dynamo (plus one method whose name merely carried the
word "dynamo"). This is the first step of extracting the guard machinery into an
independent package: make the guard core importable with zero torch._dynamo
dependencies, while remaining fully backward compatible.

The three runtime back-references and how each is removed:

(a) GuardSource.is_specialized_nn_module read torch._dynamo.config directly. The
    config read is inverted via a getter that torch._dynamo registers at import
    (register_skip_fsdp_module_guards_getter); the default (None) preserves
    current behavior and still respects config.patch because the getter reads live.
(b) Guard.sort_key compared create_fn against
    torch._dynamo.guards.GuardBuilder.DUPLICATE_INPUT. The "sorts last" property is
    now carried by a generic `_guard_sorts_last` marker on the guard method,
    read via getattr, so _guards no longer references GuardBuilder.
(c) GuardsSet.remove_guards_with_source imported is_from_source from
    torch._dynamo.source. is_from_source is a pure Source.base-chain walk with no
    dynamo dependency, so it moved to torch._guards (its only caller). It is a
    private symbol with no importers from torch._dynamo.source, so no re-export
    shim is needed.

Plus one cosmetic rename (name only; not an import dependency):

(d) HopSubgraphCache.{add,get}_dynamo_installed_submodule(s) carried "dynamo" in
    their names; renamed to {add,get}_installed_submodule(s) and the two callers in
    variables/invoke_subgraph.py updated.

After this change, `import torch._guards` (and base `import torch`) import no
torch._dynamo modules. No behavior change.

Test Plan:

Import isolation (the point of the change):

```
python -c "import torch._guards, sys; assert not [m for m in sys.modules if m == 'torch._dynamo' or m.startswith('torch._dynamo.')]"
python -c "import torch, sys; assert 'torch._guards' in sys.modules and not [m for m in sys.modules if m == 'torch._dynamo' or m.startswith('torch._dynamo.')]"
```

Guard machinery and guard-related unit tests:

```
python test/dynamo/test_guard_manager.py
python test/dynamo/test_misc.py -k test_guards_cse_pass_single
python test/dynamo/test_misc.py -k test_guard_function_builder_with_cse
python test/dynamo/test_misc.py -k test_guards_strip_function_call
```

End-to-end smokes for the two changed code paths:

```
# leak (b): duplicate-input guard (make_dupe_guard -> DUPLICATE_INPUT -> sort_key)
python -c "import torch; f=lambda a,b: a*2+b; cf=torch.compile(f, backend='eager', fullgraph=True); t=torch.randn(4); torch.testing.assert_close(cf(t,t), f(t,t))"
# leak (d): nested_compile_region identical-subgraph reuse (add/get_installed_submodule)
python -c "import torch; from torch.compiler import nested_compile_region as r; g=r(lambda x: x.sin()+1.0); f=lambda x,y: g(x)+g(y); a,b=torch.randn(8),torch.randn(8); torch.testing.assert_close(torch.compile(f, backend='eager', fullgraph=True)(a,b), f(a,b))"
```

lintrunner --take RUFF,PYFMT is clean on all touched files.

Authored with Claude.