### PR TITLE
[dynamo] Add torch._guards.dispatch: Guards facade + FuncDispatch model

### DIFF
--- a/torch/_guards/__init__.py
+++ b/torch/_guards/__init__.py
@@ -1605,3 +1605,14 @@ def active_fake_mode() -> FakeTensorMode | None:
             return m
 
     return None
+
+
+def __getattr__(name: str) -> object:
+    # Lazily expose the guard-dispatch facade so it is importable as
+    # torch._guards.Guards / torch._guards.FuncDispatch without eagerly importing
+    # the dispatch module.
+    if name in ("FuncDispatch", "Guards"):
+        from torch._guards import dispatch
+
+        return getattr(dispatch, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torch/_guards/dispatch.py
+++ b/torch/_guards/dispatch.py
@@ -1,0 +1,95 @@
+"""Explicit guard-dispatch API.
+
+Dynamo turns a function into a table of ``(guards, compiled_code)`` entries and,
+on each call, runs the first entry whose guards pass, otherwise it traces a new
+one. That dispatch loop runs in C++ (``torch/csrc/dynamo``: ``extra_state.cpp``
+walks the cache and ``RootGuardManager::check_nopybind`` evaluates guards),
+driven by the PEP 523 frame hook. This module gives that model an explicit
+Python surface: ``Guards`` pairs accumulated guards with their compiled matcher,
+and ``FuncDispatch`` documents the dispatch loop.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from torch._guards import GuardsSet
+    from torch._guards.manager import GuardManagerWrapper
+
+
+class Guards:
+    """Accumulated guards paired with their compiled runtime matcher.
+
+    This is the guard half of a dispatch-table entry: ``guards_set`` holds the
+    ``Guard`` objects accumulated while tracing, and ``guard_manager`` is the
+    compiled ``GuardManagerWrapper`` (wrapping a C++ ``RootGuardManager``) that
+    checks them at runtime.
+    """
+
+    def __init__(
+        self,
+        guards_set: GuardsSet | None = None,
+        guard_manager: GuardManagerWrapper | None = None,
+    ) -> None:
+        self.guards_set = guards_set
+        self.guard_manager = guard_manager
+
+    def matches(self, f_locals: dict[str, object]) -> bool:
+        """Return whether the guards pass for the given frame locals.
+
+        Delegates to the compiled matcher. Note this is the debug-grade Python
+        check; ``torch.compile``'s production hot path evaluates guards in C++
+        (``RootGuardManager.check_nopybind``) directly over the frame's
+        ``localsplus``.
+        """
+        if self.guard_manager is None:
+            return False
+        return self.guard_manager.check(f_locals)
+
+
+class FuncDispatch:
+    """Reference model of Dynamo's function dispatch.
+
+    A compiled function is a table of ``(guards, compiled_fn)`` entries; each call
+    runs the first entry whose guards pass, otherwise it traces a new entry. The
+    production dispatch loop lives in C++ (``torch/csrc/dynamo``) and is driven by
+    the PEP 523 frame hook; this class expresses the same model in Python and is
+    NOT wired into ``torch.compile``.
+
+    The trace-on-miss step needs ``torch._dynamo.run_and_trace`` (the seam that
+    traces a function and returns its compiled form plus a populated ``Guards``),
+    which is not yet provided; until then ``__call__`` raises on a cache miss.
+    Populate ``dispatch_table`` directly to exercise the match loop.
+    """
+
+    # Set by functools.update_wrapper in __init__.
+    __wrapped__: Callable[..., object]
+
+    def __init__(self, fn: Callable[..., object]) -> None:
+        functools.update_wrapper(self, fn)
+        self.dispatch_table: list[tuple[Guards, Callable[..., object]]] = []
+
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        f_locals = self._bind_f_locals(args, kwargs)
+        for guards, fn in self.dispatch_table:
+            if guards.matches(f_locals):
+                return fn(*args, **kwargs)
+        raise NotImplementedError(
+            "FuncDispatch trace-on-miss is not wired: torch._dynamo.run_and_trace "
+            "is not yet provided. FuncDispatch documents Dynamo's dispatch model; "
+            "the production dispatcher is the C++ guard cache."
+        )
+
+    def _bind_f_locals(
+        self, args: tuple[object, ...], kwargs: dict[str, object]
+    ) -> dict[str, object]:
+        import inspect
+
+        bound = inspect.signature(self.__wrapped__).bind(*args, **kwargs)
+        bound.apply_defaults()
+        return dict(bound.arguments)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191525
* #191524
* __->__ #191522
* #191521
* #191520
* #191519
* #191518

Add the explicit guard-dispatch API in torch/_guards/dispatch.py, exposed lazily
as torch._guards.Guards / torch._guards.FuncDispatch via a module __getattr__.
This is the additive facade layer of the guard extraction: it makes Dynamo's
guard-dispatch model explicit without touching any hot path.

- Guards pairs a GuardsSet with its compiled GuardManagerWrapper; matches(f_locals)
  delegates to the matcher (the debug-grade Python check; production dispatch stays
  in C++ RootGuardManager.check_nopybind).
- FuncDispatch documents Dynamo's dispatch model (a table of (guards, compiled_fn)
  entries; the first entry whose guards pass runs, otherwise a new one is traced).
  The match loop is real; the trace-on-miss step needs torch._dynamo.run_and_trace,
  which is not yet provided, so __call__ raises NotImplementedError on a cache miss.
  It is not wired into torch.compile, which keeps using the C++ dispatcher. Because
  __wrapped__ is set at runtime by functools.update_wrapper (which pyrefly does not
  track), FuncDispatch declares a class-level __wrapped__ annotation.

dispatch.py imports no torch._dynamo, so `import torch._guards.dispatch` and
touching torch._guards.Guards / FuncDispatch stay dynamo-free.

Deferred (only needed for a runnable FuncDispatch, which has no production consumer
yet): torch._dynamo.run_and_trace (an extract-method seam from convert_frame's
compile path) and re-homing GuardedCode / GuardFn.

Test Plan:

```
python -c "
from torch._guards import Guards, FuncDispatch
from torch._guards.manager import GuardManagerWrapper
assert Guards().matches({}) is False
assert Guards(guard_manager=GuardManagerWrapper()).matches({}) is True
def f(x): return x + 1
fd = FuncDispatch(f); assert fd.__wrapped__ is f
try:
    fd(3); raise AssertionError
except NotImplementedError:
    pass
fd.dispatch_table.append((Guards(guard_manager=GuardManagerWrapper()), lambda x: x * 10))
assert fd(3) == 30
"
python -c "import torch._guards, sys; torch._guards.Guards; torch._guards.FuncDispatch; assert not [m for m in sys.modules if m == 'torch._dynamo' or m.startswith('torch._dynamo.')]"
python -c "import torch, sys; assert not [m for m in sys.modules if m == 'torch._dynamo' or m.startswith('torch._dynamo.')]"
```

Full lintrunner (including pyrefly) is clean on both files.

Authored with Claude.