### PR TITLE
[dynamo] Route AOTAutograd guards through TracingContext.add_aotautograd_guard

### DIFF
--- a/torch/_functorch/_aot_autograd/input_output_analysis.py
+++ b/torch/_functorch/_aot_autograd/input_output_analysis.py
@@ -398,7 +398,7 @@ def compute_overlapping_inputs(
             aot_config.aot_autograd_arg_pos_to_source[i] for i in no_overlap_indices
         ]
 
-        tracing_context.guards_context.aotautograd_guards.append(
+        tracing_context.add_aotautograd_guard(
             StorageOverlap(overlapping_sources, non_overlapping_sources)
         )
 

--- a/torch/_guards/__init__.py
+++ b/torch/_guards/__init__.py
@@ -1156,6 +1156,12 @@ class TracingContext:
         self.previously_cleaned_instructions.clear()
         self.inlined_code_cache.clear()
 
+    def add_aotautograd_guard(self, guard: GuardEnvExpr) -> None:
+        """Record an AOTAutograd relational guard (e.g. DuplicateInputs,
+        StorageOverlap) on this tracing context. Prefer this over reaching into
+        ``guards_context.aotautograd_guards`` directly."""
+        self.guards_context.aotautograd_guards.append(guard)
+
     @staticmethod
     @contextmanager
     def patch(**kwargs: Any) -> Generator[None, None, None]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191525
* __->__ #191524
* #191522
* #191521
* #191520
* #191519
* #191518

Add TracingContext.add_aotautograd_guard(guard) so external modules record
AOTAutograd relational guards through a method instead of reaching into
tracing_context.guards_context.aotautograd_guards directly, and migrate the
StorageOverlap site in _aot_autograd/input_output_analysis.py to it. This is the
external-writer rewiring step of the guard extraction; AOTAutograd's StorageOverlap
/ DuplicateInputs and ShapeEnv's ShapeGuard / SLoc / Source / TracingContext all
already import from torch._guards, so the remainder is confirmation.

The DuplicateInputs site in _aot_autograd/runtime_wrappers.py is intentionally
NOT migrated. It has a pre-existing walrus-precedence bug --
`tracing_context := TracingContext.try_get() and aot_config.aot_autograd_arg_pos_to_source`
binds tracing_context to the list, not the TracingContext -- so migrating it is
entangled with a bug whose fix would change behavior. It is left byte-identical
(with its existing type: ignore) and tracked for a separate, test-first fix.

Test Plan:

```
python -c "import torch._guards as g; assert hasattr(g.TracingContext, 'add_aotautograd_guard')"
# StorageOverlap path routes through the new helper (dynamic=True makes shapes
# symbolic so the storage-overlap guard is actually emitted)
python -c "
import torch
def g(a, b): return a.sum() + b.sum()
cg = torch.compile(g, backend='aot_eager', fullgraph=True, dynamic=True)
base = torch.randn(8); a = base.narrow(0, 0, 5); b = base.narrow(0, 3, 5)
torch.testing.assert_close(cg(a, b), g(a, b))
"
# torch._guards stays importable without torch._dynamo
python -c "import torch._guards, sys; assert not [m for m in sys.modules if m == 'torch._dynamo' or m.startswith('torch._dynamo.')]"
```

lintrunner (including pyrefly) is clean on both files.

Authored with Claude.