### PR TITLE
[dynamo] Move install_guard into torch._guards

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -82,6 +82,7 @@ from torch._guards import (
     Source,
     StorageOverlap,
 )
+from torch._guards.install import install_guard  # noqa: F401
 from torch._guards.manager import (  # noqa: F401
     DeletedGuardManagerWrapper,
     dunder_attrs_assumed_constants,
@@ -5139,32 +5140,6 @@ def make_dupe_guard(
             # However, this should always be a sound guard to add here.
             return functools.partial(GuardBuilder.DUPLICATE_INPUT, source_b=dupe_source)
     return None
-
-
-def install_guard(*guards: Guard, skip: int = 0) -> None:
-    """
-    Add dynamo guards to the current tracing context.
-
-    Args:
-        guards: guard(s) to add
-        skip: number of stack frames to ignore for debug stack trace
-    """
-    from torch._guards import TracingContext
-
-    guards_context = TracingContext.get().guards_context
-    if guards_context.skip_install:
-        return
-
-    collect_debug_stack = guards_log.isEnabledFor(
-        logging.DEBUG
-    ) or verbose_guards_log.isEnabledFor(logging.DEBUG)
-    add = guards_context.dynamo_guards.add
-    for guard in guards:
-        if not isinstance(guard, Guard):
-            raise AssertionError(f"Expected Guard, got {type(guard)}")
-        if is_from_skip_guard_source(guard.originating_source):
-            continue
-        add(guard, collect_debug_stack=collect_debug_stack, skip=skip + 1)
 
 
 # ---------------------------------------------------------------------------

--- a/torch/_guards/__init__.py
+++ b/torch/_guards/__init__.py
@@ -1614,11 +1614,14 @@ def active_fake_mode() -> FakeTensorMode | None:
 
 
 def __getattr__(name: str) -> object:
-    # Lazily expose the guard-dispatch facade so it is importable as
-    # torch._guards.Guards / torch._guards.FuncDispatch without eagerly importing
-    # the dispatch module.
+    # Lazily expose the guard-dispatch facade and install_guard so they are
+    # importable as torch._guards.<name> without eagerly importing those modules.
     if name in ("FuncDispatch", "Guards"):
         from torch._guards import dispatch
 
         return getattr(dispatch, name)
+    if name == "install_guard":
+        from torch._guards.install import install_guard
+
+        return install_guard
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torch/_guards/install.py
+++ b/torch/_guards/install.py
@@ -1,0 +1,43 @@
+"""Guard installation.
+
+``install_guard`` records guards on the current ``TracingContext`` during
+tracing. It lives in ``torch._guards`` (rather than ``torch._dynamo``) because it
+writes only to package-owned state (``TracingContext.guards_context``) and has no
+dynamo dependency; it is the guard write-path used throughout Dynamo's tracer.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch._logging
+from torch._guards import Guard, TracingContext
+from torch._guards.source import is_from_skip_guard_source
+
+
+guards_log = torch._logging.getArtifactLogger(__name__, "guards")
+verbose_guards_log = torch._logging.getArtifactLogger(__name__, "verbose_guards")
+
+
+def install_guard(*guards: Guard, skip: int = 0) -> None:
+    """
+    Add dynamo guards to the current tracing context.
+
+    Args:
+        guards: guard(s) to add
+        skip: number of stack frames to ignore for debug stack trace
+    """
+    guards_context = TracingContext.get().guards_context
+    if guards_context.skip_install:
+        return
+
+    collect_debug_stack = guards_log.isEnabledFor(
+        logging.DEBUG
+    ) or verbose_guards_log.isEnabledFor(logging.DEBUG)
+    add = guards_context.dynamo_guards.add
+    for guard in guards:
+        if not isinstance(guard, Guard):
+            raise AssertionError(f"Expected Guard, got {type(guard)}")
+        if is_from_skip_guard_source(guard.originating_source):
+            continue
+        add(guard, collect_debug_stack=collect_debug_stack, skip=skip + 1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191525
* #191524
* #191522
* #191521
* #191520
* #191519
* #191518

install_guard -- the guard write-path API that records guards on the current
TracingContext during tracing -- moves from torch/_dynamo/guards.py into a new
torch/_guards/install.py, with a BC re-export from torch/_dynamo/guards.py and
lazy exposure as torch._guards.install_guard.

install_guard has no dynamo dependency: its body touches only TracingContext and
Guard (torch._guards) and is_from_skip_guard_source (torch._guards.source), so it
belongs in the independent guard package that owns the state it writes to.
`import torch._guards.install` pulls no torch._dynamo. The ~15 dynamo modules that
do `from ..guards import install_guard` keep working via the shim.

This is the clean, self-contained slice of the "extract the guard compiler" work
(2B.1 in GUARDS_PLAN.md). The guard *compiler* (GuardBuilder/CheckFunctionManager)
and its internal helpers stay in torch._dynamo -- they consume dynamo's
OutputGraph and are only relocatable as a larger, scaffolded refactor.

Test Plan:

```
python -c "import torch._guards.install, sys; assert not [m for m in sys.modules if m == 'torch._dynamo' or m.startswith('torch._dynamo.')]"
python -c "import torch._guards as g, torch._guards.install as gi, torch._dynamo.guards as dg; assert g.install_guard is gi.install_guard is dg.install_guard"
python -c "import torch, sys; assert not [m for m in sys.modules if m == 'torch._dynamo' or m.startswith('torch._dynamo.')]"
# install_guard installs a working guard end to end (compile, cache-hit, recompile on type change)
python -c "
import torch
from torch._dynamo.testing import CompileCounter
cnt = CompileCounter()
@torch.compile(backend=cnt)
def f(x): return x + 1
f(torch.randn(4)); assert cnt.frame_count == 1
f(torch.randn(4)); assert cnt.frame_count == 1
f(5);              assert cnt.frame_count == 2
"
python test/dynamo/test_guard_manager.py
```

Full lintrunner (including pyrefly) is clean on all three files.

Authored with Claude.