### PR TITLE
Fix __torch_function__ dispatch for leading objects in var-args int lists

### DIFF
--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -850,6 +850,65 @@ class TestTorchFunctionOverride(TestCase):
         self.assertTrue(obj_last.torch_function_called,
                         "torch_function should be called when object is last in list")
 
+    def test_torch_function_leading_in_varargs_intlist(self):
+        """Test dispatch when a torch_function object leads a var-args int list"""
+        # https://github.com/pytorch/pytorch/issues/191275
+
+        class SizeLike:
+            def __init__(self):
+                self.dispatched_args = None
+                self.dispatched_kwargs = None
+
+            def __torch_function__(self, func, types, args=(), kwargs=None):
+                self.dispatched_args = args
+                self.dispatched_kwargs = kwargs
+                return torch.tensor(42.0)
+
+        t = torch.zeros(1, 4)
+
+        # Leading position in the var-args spelling used to raise
+        # "takes 1 positional argument but 2 were given" for signatures
+        # with keyword-only parameters after the int list; view has a bare
+        # signature and is included to lock in its dispatch behavior.
+        for call, expected_args in [
+            (lambda o: t.expand(o, 4), lambda o: (t, o, 4)),
+            (lambda o: t.new_zeros(o, 4), lambda o: (t, o, 4)),
+            (lambda o: torch.zeros(o, 4), lambda o: (o, 4)),
+            (lambda o: torch.rand(o, 4), lambda o: (o, 4)),
+            (lambda o: t.view(o, 4), lambda o: (t, o, 4)),
+        ]:
+            obj = SizeLike()
+            call(obj)
+            self.assertEqual(obj.dispatched_args, expected_args(obj))
+
+        # Controls: non-leading and packed spellings keep dispatching.
+        obj = SizeLike()
+        t.expand(4, obj)
+        self.assertEqual(obj.dispatched_args, (t, 4, obj))
+        obj = SizeLike()
+        t.expand((obj, 4))
+        self.assertEqual(obj.dispatched_args, (t, (obj, 4)))
+
+        # Keyword arguments after a leading object are forwarded intact.
+        obj = SizeLike()
+        torch.zeros(obj, 4, dtype=torch.float64)
+        self.assertEqual(obj.dispatched_args, (obj, 4))
+        self.assertEqual(obj.dispatched_kwargs, {"dtype": torch.float64})
+
+    def test_fx_trace_expand_leading_symbolic_dim(self):
+        """Test fx.symbolic_trace of expand with the traced dim leading"""
+        # https://github.com/pytorch/pytorch/issues/191275
+        import torch.fx as fx
+
+        const = torch.zeros(1, 4)
+
+        def f(x):
+            return const.expand(x.shape[0], *const.shape[1:])
+
+        gm = fx.symbolic_trace(f)
+        x = torch.randn(3, 2)
+        self.assertEqual(gm(x), f(x))
+
     def test_torch_function_nested_tuple_getitem(self):
         """Test that torch_function is called with getitem for TF objects inside nested tuples"""
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7865,6 +7865,11 @@ class TestTorch(TestCase):
         # ensure ones() throws an error when extra positional (non-keyword) arguments are given.
         self.assertRaises(TypeError, lambda: torch.ones((3, 3), torch.float32))
 
+        # the var-args intlist collapse also applies when the leading int would
+        # broadcast via a sized int list (IntArrayRef[1]), see gh-191275
+        t = torch.arange(6).reshape(2, 3)
+        self.assertEqual(t.hash_tensor(0, 1), t.hash_tensor((0, 1)))
+
     def test_from_buffer(self):
         a = bytearray([1, 2, 3, 4])
         self.assertEqual(torch.ByteStorage.from_buffer(a).tolist(), [1, 2, 3, 4])

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7765,6 +7765,11 @@ class TestTorch(TestCase):
         # ensure ones() throws an error when extra positional (non-keyword) arguments are given.
         self.assertRaises(TypeError, lambda: torch.ones((3, 3), torch.float32))
 
+        # the var-args intlist collapse also applies when the leading int would
+        # broadcast via a sized int list (IntArrayRef[1]), see gh-191275
+        t = torch.arange(6).reshape(2, 3)
+        self.assertEqual(t.hash_tensor(0, 1), t.hash_tensor((0, 1)))
+
     def test_from_buffer(self):
         a = bytearray([1, 2, 3, 4])
         self.assertEqual(torch.ByteStorage.from_buffer(a).tolist(), [1, 2, 3, 4])

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1708,6 +1708,12 @@ bool FunctionSignature::parse(
 
     py::object failed_item;
     bool varargs_eligible = allow_varargs_intlist && arg_pos == 0 && !is_kwd;
+    // With extra positional args after a single int-list parameter, the
+    // var-args collapse below is the only valid parse; param.check would let
+    // a leading __torch_function__ object or a broadcastable int greedily
+    // consume one slot and fail on the leftover args (#191275).
+    bool must_collapse =
+        varargs_eligible && static_cast<size_t>(nargs) > max_pos_args;
     if ((!obj && param.optional) || (Py_IsNone(obj) && param.allow_none)) {
       dst[i++] = nullptr;
     } else if (!obj) {
@@ -1716,7 +1722,8 @@ bool FunctionSignature::parse(
         missing_args(*this, i);
       }
       return false;
-    } else if (param.check(obj, overloaded_args, i, &failed_item)) {
+    } else if (
+        !must_collapse && param.check(obj, overloaded_args, i, &failed_item)) {
       dst[i++] = obj;
       // XXX: the Variable check is necessary because sizes become tensors when
       // tracer is enabled. This behavior easily leads to ambiguities, and we

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1716,6 +1716,12 @@ bool FunctionSignature::parse(
 
     py::object failed_item;
     bool varargs_eligible = allow_varargs_intlist && arg_pos == 0 && !is_kwd;
+    // With extra positional args after a single int-list parameter, the
+    // var-args collapse below is the only valid parse; param.check would let
+    // a leading __torch_function__ object or a broadcastable int greedily
+    // consume one slot and fail on the leftover args (#191275).
+    bool must_collapse =
+        varargs_eligible && static_cast<size_t>(nargs) > max_pos_args;
     if ((!obj && param.optional) || (Py_IsNone(obj) && param.allow_none)) {
       dst[i++] = nullptr;
     } else if (!obj) {
@@ -1724,7 +1730,8 @@ bool FunctionSignature::parse(
         missing_args(*this, i);
       }
       return false;
-    } else if (param.check(obj, overloaded_args, i, &failed_item)) {
+    } else if (
+        !must_collapse && param.check(obj, overloaded_args, i, &failed_item)) {
       dst[i++] = obj;
       // XXX: the Variable check is necessary because sizes become tensors when
       // tracer is enabled. This behavior easily leads to ambiguities, and we


### PR DESCRIPTION
A non-Tensor __torch_function__ implementer (e.g. torch.fx.Proxy) in the leading position of a var-args int-list call raised TypeError instead of dispatching whenever the signature has trailing keyword-only parameters: t.expand(B, 4) failed while t.expand((B, 4)), t.expand(4, B) and t.expand(B) all dispatched. Affected: Tensor.expand, new_zeros/new_empty/new_ones, torch.zeros/ones/empty/rand/randn; this also broke fx.symbolic_trace on CONST.expand(x.shape[0], *CONST.shape[1:]).

Root cause: FunctionSignature::parse only tries the var-args collapse (expand(5, 3) -> expand((5, 3))) when param.check(args[0]) fails, and FunctionParameter::check's generic torch-function fallback accepts the leading object as the whole int-list parameter. The object consumes one positional slot and the leftover args then trip the keyword-only check. The allow_varargs_intlist precheck already validates the full positional tuple (including torch-function elements), so when there are extra positional args the collapse is the only parse that can succeed; skip param.check in that case and fall into the existing collapse branch.

The alternative of retrying the collapse at the keyword-only error site was rejected: parser state is already advanced by then, and it would not cover bare signatures (view/reshape/permute), which previously dispatched only because leftover positional args were silently ignored.

Behavior note: t.hash_tensor(0, 1) (the only single-positional signature with a sized int list, IntArrayRef[1]) changes from TypeError to matching t.hash_tensor((0, 1)), consistent with the documented var-args intent; locked in by a test. The #163081 error cases (junk trailing args after a packed list) still raise.

Fixes #191275

Test Plan:

New tests fail before the fix and pass after (verified by stashing the parser change and rebuilding):

    python -m pytest test/test_overrides.py -k "leading_in_varargs or fx_trace_expand"
    python -m pytest test/test_torch.py -k test_parsing_intlist

Broader suites on the fixed build:

    python -m pytest test/test_overrides.py
    python -m pytest test/test_view_ops.py -k "test_reshape or test_view or test_broadcast_to"
    python -m pytest test/test_torch.py -k test_new
    lintrunner test/test_overrides.py test/test_torch.py torch/csrc/utils/python_arg_parser.cpp

test_overrides: 10906 passed, 1 pre-existing sm_75 bf16 hardware failure (needs compute capability >= 8.0), unrelated. Others green. Lint clean.