### PR TITLE
fix: preserve socket errors in find_free_port

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -58,6 +58,7 @@ class EtcdServerTest(unittest.TestCase):
             find_free_port()
 
         self.assertEqual(2, mock_socket.call_count)
+
     def test_etcd_server_start_stop(self):
         server = EtcdServer()
         server.start()

--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -6,12 +6,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+import socket
 import sys
 import unittest
+from unittest import mock
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
 if os.getenv("CIRCLECI"):
@@ -20,6 +22,42 @@ if os.getenv("CIRCLECI"):
 
 
 class EtcdServerTest(unittest.TestCase):
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.etcd_server.socket.getaddrinfo"
+    )
+    @mock.patch("torch.distributed.elastic.rendezvous.etcd_server.socket.socket")
+    def test_find_free_port_skips_socket_creation_error(
+        self, mock_socket, mock_getaddrinfo
+    ):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("localhost", 0)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("localhost", 0)),
+        ]
+        expected_socket = mock.Mock()
+        mock_socket.side_effect = [OSError("socket failed"), expected_socket]
+
+        self.assertIs(find_free_port(), expected_socket)
+        self.assertEqual(2, mock_socket.call_count)
+        expected_socket.bind.assert_called_once_with(("localhost", 0))
+        expected_socket.listen.assert_called_once_with(0)
+
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.etcd_server.socket.getaddrinfo"
+    )
+    @mock.patch("torch.distributed.elastic.rendezvous.etcd_server.socket.socket")
+    def test_find_free_port_raises_runtime_error_when_all_attempts_fail(
+        self, mock_socket, mock_getaddrinfo
+    ):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("localhost", 0)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("localhost", 0)),
+        ]
+        mock_socket.side_effect = OSError("socket failed")
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to create a socket"):
+            find_free_port()
+
+        self.assertEqual(2, mock_socket.call_count)
     def test_etcd_server_start_stop(self):
         server = EtcdServer()
         server.start()

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,15 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s: socket.socket | None = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
Fixes #191395

你好，这个改动修复了 ind_free_port() 的一个边界情况：如果 socket.socket() 本身失败，异常处理逻辑不应再访问一个尚未赋值的 socket。

我让清理逻辑只关闭已经创建成功的 socket，并补了两个回归测试，覆盖后续地址成功和所有地址失败的情况。这样的话，原始的 socket 错误和最终的 RuntimeError 都能正常保留下来。