### PR TITLE
[BE]: Update fmtlib to 12.2.1 with Clang module-scan fix

### DIFF
--- a/.ci/docker/common/install_clang.sh
+++ b/.ci/docker/common/install_clang.sh
@@ -15,7 +15,7 @@ if [ -n "$CLANG_VERSION" ]; then
 
   sudo apt-get update
   if [[ $CLANG_VERSION -ge 18 ]]; then
-    apt-get install -y --no-install-recommends libomp-${CLANG_VERSION}-dev libclang-rt-${CLANG_VERSION}-dev clang-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
+    apt-get install -y --no-install-recommends libomp-${CLANG_VERSION}-dev libclang-rt-${CLANG_VERSION}-dev clang-"$CLANG_VERSION" clang-tools-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
   else
     apt-get install -y --no-install-recommends clang-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
   fi


### PR DESCRIPTION
Updates the fmt submodule to 12.2.1 plus a focused CMake fix for Clang environments where `clang-scan-deps` is unavailable.

CMake 3.28's CMP0155 automatically scans ordinary C++20 sources for module dependencies. This is independent of fmt's explicit `FMT_MODULE` option. In PyTorch's Clang CI, CMake therefore generated a Ninja command invoking `CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS-NOTFOUND` for `src/format.cc`.

The fmt change disables `CXX_SCAN_FOR_MODULES` only for the regular `fmt` target when all of the following hold:

- CMake is 3.28 or newer
- the compiler is Clang
- `CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS` is unavailable

Scanning remains enabled for supported Clang installations, GCC, and MSVC.

Focused validation:

- CMake 3.31.6
- Ninja 1.12.1
- Clang 17
- C++20
- forced `CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS-NOTFOUND`
- unpatched target fails by invoking the NOTFOUND scanner
- patched target compiles and archives successfully

Upstream fmt branch: `Skylion007/fmtlib:fix-cxx20-scan-deps`
Upstream fmt commit: `7b1a776a66a12f38168da59b04106009fbc2ab4c`