### PR TITLE
[CUDA] Simplify alpha_ptr setup in scaled_gemm

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1909,8 +1909,8 @@ void scaled_gemm(
   }
 
   // Handle user-passed alpha
-  float *alpha_ptr = &alpha_val;
-  float *beta_ptr = &beta_val;
+  const float* alpha_ptr = &alpha_val;
+  const float* beta_ptr = &beta_val;
 
   if (alpha.has_value()) {
     auto& a = alpha.value();
@@ -1920,8 +1920,7 @@ void scaled_gemm(
       // Tell cublasLt we're using device-side pointers for alpha/beta
       auto pointer_mode = CUBLASLT_POINTER_MODE_DEVICE;
       computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_POINTER_MODE, pointer_mode);
-      // The allocator delays reuse until work on the allocation stream completes.
-      alpha_ptr = a.data_ptr<float>();
+      alpha_ptr = a.const_data_ptr<float>();
       beta_ptr = at::cuda::detail::get_cublas_device_zero();
     } else {
       alpha_val = a.item<float>();

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1917,18 +1917,11 @@ void scaled_gemm(
 
     // if device-tensor
     if (a.is_cuda()) {
-      // NOTE: there are lifetime requirements on device-side pointers for alpha/beta -- the value must be
-      //       valid & correct until the cublas call finishes (not is scheduled like host-side values). Thus
-      //       we need to use allocations for alpha/beta that have some guarantees on lifetime - a statically
-      //       managed 4B buffer for alpha that we'll copy the passed alpha value into, and constant memory
-      //       for beta respectively.
-      float *user_alpha_ptr = at::cuda::detail::get_user_alpha_ptr();
-      at::Tensor user_alpha = at::from_blob(user_alpha_ptr, {1}, TensorOptions().device(kCUDA).dtype(kFloat));
-      user_alpha.copy_(a);
       // Tell cublasLt we're using device-side pointers for alpha/beta
       auto pointer_mode = CUBLASLT_POINTER_MODE_DEVICE;
       computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_POINTER_MODE, pointer_mode);
-      alpha_ptr = user_alpha.data_ptr<float>();
+      // The allocator delays reuse until work on the allocation stream completes.
+      alpha_ptr = a.data_ptr<float>();
       beta_ptr = at::cuda::detail::get_cublas_device_zero();
     } else {
       alpha_val = a.item<float>();

--- a/aten/src/ATen/cuda/detail/BLASConstants.cu
+++ b/aten/src/ATen/cuda/detail/BLASConstants.cu
@@ -31,15 +31,4 @@ float *get_cublas_device_zero() {
   return ptr;
 }
 
-float *get_user_alpha_ptr() {
-  static float *alpha_ptr;
-
-  static bool init_flag [[maybe_unused]] = []() {
-    AT_CUDA_CHECK(cudaMalloc(&alpha_ptr, sizeof(float)));
-    return true;
-  }();
-
-  return alpha_ptr;
-}
-
 } // namespace at::cuda::detail

--- a/aten/src/ATen/cuda/detail/BLASConstants.h
+++ b/aten/src/ATen/cuda/detail/BLASConstants.h
@@ -6,6 +6,5 @@ namespace at::cuda::detail {
 
 float *get_cublas_device_one();
 float *get_cublas_device_zero();
-float *get_user_alpha_ptr();
 
 } // namespace at::cuda::detail

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -1416,10 +1416,13 @@ TORCH_IMPL_FUNC(_scaled_mm_cuda_v2_out)(
   }
   {
     auto bias_ = bias.has_value() ? *bias : Tensor();
+    auto global_scale_a = scale_a.size() > 1 ? scale_a[1] : Tensor();
+    auto global_scale_b = scale_b.size() > 1 ? scale_b[1] : Tensor();
 
     // NOLINTNEXTLINE(*c-array*)
     TensorArg targs[]{{out, "out", 0}, {mat_a, "mat_a", 1}, {mat_b, "mat_b", 2},
-                      {bias_, "bias", 3}, {scale_a[0], "scale_a", 4}, {scale_b[0], "scale_b", 5}};
+                      {bias_, "bias", 3}, {scale_a[0], "scale_a", 4}, {scale_b[0], "scale_b", 5},
+                      {global_scale_a, "global_scale_a", 6}, {global_scale_b, "global_scale_b", 7}};
     checkAllSameGPU(__func__, targs);
   }
 


### PR DESCRIPTION
NVFP4 scaled_mm with global scales currently calls two tiny kernels to map the two global scales into the single alpha value used by cublasLt: a `mul` followed by a `copy` into a statically allocated alpha buffer. The `mul` is unavoidable given the API, but the `copy` can be avoided, saving 1-2us per call and removing the static alpha (which is not stream-safe). This PR just removes the static alpha and uses the data_ptr from the Tensor created when combining the global scales. It also adds checks for the global scale Tensors to confirm they are on the same device as everything else.

I'm pretty sure using the Tensor created by the `mul` is sufficient for alpha's lifetime requirement because the allocator protects this memory from being accessed by other streams, and it can't be reused on the allocator's stream until after the cublasLt kernel completes, but please correct me if I've missed something.

https://github.com/pytorch/pytorch/blob/2e0a2d0a746d7960091b25c010412befe9c31cce/aten/src/ATen/native/cuda/ScaledBlas.cpp#L1221-L1230

cc @eqy @slayton58 