### PR TITLE
[TEST] Refactor test_single_dim_strategy.py with hw_classification

### DIFF
--- a/test/distributed/tensor/test_single_dim_strategy.py
+++ b/test/distributed/tensor/test_single_dim_strategy.py
@@ -52,7 +52,11 @@ from torch.distributed.tensor.placement_types import (
     _StridedShard,
     Placement,
 )
-from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 

--- a/test/distributed/tensor/test_single_dim_strategy.py
+++ b/test/distributed/tensor/test_single_dim_strategy.py
@@ -52,7 +52,7 @@ from torch.distributed.tensor.placement_types import (
     _StridedShard,
     Placement,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
@@ -93,6 +93,8 @@ def _get_mm_specs(
 
 
 class TestExpandPlaceholder(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.world_size = 64
@@ -1300,6 +1302,8 @@ class TestExpandPlaceholder(TestCase):
 
 
 class TestDijkstraExpandSingleDimStrategy(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         store = FakeStore()
@@ -1949,6 +1953,8 @@ def _dummy_check_fake(x):
 class TestCommonPointwiseSingleDimStrategy(TestCase):
     """Unit tests for _common_pointwise_single_dim_strategy raw rule generation."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def _meta(self, *dims: int) -> TensorMeta:
         shape = torch.Size(dims)
         stride = torch.empty(shape).stride()
@@ -2042,6 +2048,8 @@ class TestCommonPointwiseSingleDimStrategy(TestCase):
 
 
 class TestSingleDimStrategyRegistration(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.world_size = 4


### PR DESCRIPTION
## Summary
Apply hardware classification structure following `test_single_dim_strategy.py`.

Changes:
- Add hw_classification = GENERIC to TestExpandPlaceholder (18 tests) — uses FakePG with DeviceMesh("cpu"), no actual distributed communication
- Add hw_classification = GENERIC to TestDijkstraExpandSingleDimStrategy (11 tests) — uses FakePG with DeviceMesh("cpu"), no actual distributed communication
- Add hw_classification = GENERIC to TestCommonPointwiseSingleDimStrategy (5 tests) — pure unit tests with no distributed communication
- Add hw_classification = GENERIC to TestSingleDimStrategyRegistration (2 tests) — uses FakePG with DeviceMesh("cpu"), no actual distributed communication

## Test Plan
```bash
python test/distributed/tensor/test_single_dim_strategy.py -v --hw-classification GENERIC
36 passed

python test/distributed/tensor/test_single_dim_strategy.py -v
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508 