### PR TITLE
[pipelining] Decide metadata mode locally when using a fake process group

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -19,7 +19,10 @@ from torch.distributed.pipelining import (
     ScheduleLoopedBFS,
     ScheduleZBVZeroBubble,
 )
-from torch.distributed.pipelining._utils import generate_stage_to_rank_mapping
+from torch.distributed.pipelining._utils import (
+    generate_stage_to_rank_mapping,
+    InferenceMode,
+)
 from torch.distributed.pipelining.schedules import (
     _Action,
     _add_reduce_grad,
@@ -350,6 +353,42 @@ class ScheduleTest(TestCase):
             for _ in range(2):
                 losses = []
                 schedule.step(x, target=target, losses=losses)
+        finally:
+            torch.distributed.destroy_process_group()
+
+    @parametrize("rank", [0, 1])
+    def test_fake_pg_cross_rank_uses_static_metadata(self, rank):
+        """
+        With a fake process group, the cross-rank warm-up vote cannot exchange
+        real data, so the schedule must infer the metadata mode locally:
+        STATIC when complete metadata is supplied, and a clear error when
+        dynamic inference would be required.
+        """
+        store = FakeStore()
+        torch.distributed.init_process_group(
+            backend="fake", rank=rank, world_size=2, store=store
+        )
+        d_hid, batch_size = 16, 8
+        n_stages, num_microbatches = 2, 2
+        device = torch.device("cpu")
+        mod = MultiMLP(d_hid, n_layers=n_stages).get_submodule(f"layers.{rank}")
+
+        x = torch.randn(batch_size, d_hid, device=device)
+        mb = torch.randn(batch_size // num_microbatches, d_hid, device=device)
+        try:
+            stage = PipelineStage(
+                mod, rank, n_stages, device, input_args=mb, output_args=mod(mb)
+            )
+            schedule = ScheduleGPipe(stage, num_microbatches)
+            schedule.step(x) if rank == 0 else schedule.step()
+            self.assertEqual(stage._inference_mode, InferenceMode.STATIC)
+
+            # Without static metadata, dynamic inference is required, which
+            # cannot work over a fake group and must fail loudly.
+            stage_dyn = PipelineStage(mod, rank, n_stages, device)
+            schedule_dyn = ScheduleGPipe(stage_dyn, num_microbatches)
+            with self.assertRaisesRegex(RuntimeError, "fake process group"):
+                schedule_dyn.step(x) if rank == 0 else schedule_dyn.step()
         finally:
             torch.distributed.destroy_process_group()
 

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -358,6 +358,40 @@ class _PipelineSchedule(ABC):
                 (avoids redundant init on eval↔train mode switches).
         """
         if all(isinstance(stage, PipelineStage) for stage in stages):
+            # A fake process group cannot exchange real data: a cross-rank
+            # vote recv reads zeros and selects DYNAMIC, which then fails in
+            # `_recv_meta` (nothing was actually sent). Since dynamic
+            # inference can never work across ranks of a fake group, decide
+            # locally in that case: STATIC if every local stage has complete
+            # metadata, else error. Same-rank-only pipelines (e.g. a
+            # single-rank fake world) don't communicate, so the normal vote
+            # still works and DYNAMIC remains usable there.
+            pp_stages = cast(list[PipelineStage], stages)
+            has_cross_rank = any(
+                (not st.is_first and not st._is_same_rank(st.stage_index - 1))
+                or (not st.is_last and not st._is_same_rank(st.stage_index + 1))
+                for st in pp_stages
+            )
+            if has_cross_rank and any(
+                dist.get_backend(st.group) == "fake" for st in pp_stages
+            ):
+                for st in pp_stages:
+                    if InferenceMode.needs_dynamic(st._user_meta, has_backward):
+                        raise RuntimeError(
+                            f"Stage {st.stage_index} requires dynamic shape "
+                            "inference, which is not supported with a fake "
+                            "process group. Provide complete static metadata "
+                            "(inputs/outputs, plus input_grads/output_grads "
+                            "for DTensors with backward) to the PipelineStage "
+                            "constructor."
+                        )
+                    st._inference_mode = InferenceMode.STATIC
+                logger.debug(
+                    "Fake process group detected; set inference_mode=static "
+                    "for %d stage(s) without voting",
+                    len(stages),
+                )
+                return
             acc: torch.Tensor | None = None
             for stage in cast(list[PipelineStage], stages):
                 acc = stage._warmup_forward_vote(has_backward, received_acc=acc)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #191538

With a FakeProcessGroup (e.g. TorchTitan simulating one rank at a time),
the warm-up vote protocol in _warmup_p2p is broken: fake recv leaves the
vote buffer as zeros, so the accumulated product is always 0 and DYNAMIC
mode is selected even when every stage has complete static metadata.
Dynamic inference then fails in _recv_meta because recv_object_list
unpickles an empty fake buffer.

Since a fake process group can never exchange real data, dynamic
cross-rank metadata inference is fundamentally impossible over it -- so
instead of adding a public metadata_mode option, detect the fake backend
and decide locally: if any stage has a cross-rank neighbor and the group
backend is "fake", set STATIC on all local stages when their user-supplied
metadata is complete, and raise a clear error pointing at the PipelineStage
metadata arguments otherwise. The guard only fires when a cross-rank
neighbor exists: single-rank fake worlds (used widely in existing tests)
never communicate during the vote, so DYNAMIC mode still works there and
keeps working.

An alternative was a public schedule-level metadata_mode="static" knob (as
requested in the original report), but auto-detection needs no new API and
is correct by construction: STATIC is the only mode that can possibly work
in this regime. This lets TorchTitan drop its _warmup_forward_vote /
_warmup_backward_result overrides.

Test Plan:

New regression test simulating each rank of a 2-rank fake world, checking
STATIC is chosen with complete metadata and that incomplete metadata gives
the new error:

```
python -m pytest test/distributed/pipelining/test_schedule.py -k fake_pg_cross_rank
```

Full schedule and stage suites (both use fake PG heavily, including the
single-rank DYNAMIC paths that must keep voting):

```
python -m pytest test/distributed/pipelining/test_schedule.py
python -m pytest test/distributed/pipelining/test_stage.py
```

59 passed / 146 subtests, and 1 passed / 8 skipped (accelerator-gated)
respectively. Also verified the pre-fix failure reproduces at the base
commit (rank 1 fails with "_pickle.UnpicklingError: invalid load key" from
recv_object_list) and is fixed after.

Authored with Claude Code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>