### PR TITLE
[Inductor][CPU] Fix int8/uint8 min/max vectorized reductions polluted by inactive lanes

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -19,6 +19,7 @@ from torch._dynamo.testing import rand_strided
 from torch._dynamo.utils import same
 from torch._inductor import config, cpu_vec_isa, metrics, test_operators
 from torch._inductor.codegen.cpp import CppOverrides, CppVecOverrides
+from torch._inductor.codegen.cpp_utils import DTYPE_TO_CPP
 from torch._inductor.compile_fx import compile_fx, compile_fx_inner
 from torch._inductor.exc import InductorError
 from torch._inductor.graph import GraphLowering
@@ -7433,16 +7434,21 @@ class CPUReproTests(TestCase):
             )
 
         low, high = (5, 100) if dtype == torch.uint8 else (-100, -5)
-        with config.patch({"cpp.simdlen": None}):
-            for size in (4, 64, 129):
-                torch._dynamo.reset()
-                metrics.reset()
-                x = torch.randint(low, high, (size,), dtype=dtype)
-                self.common(fn, (x,))
-                # the number of tiled loop nests varies with size and ISA, so
-                # only assert that the reduction vectorized at all
-                if _can_check_vec_metrics():
-                    self.assertGreater(metrics.generated_cpp_vec_kernel_count, 0)
+        for simdlen in simd_lengths_to_test():
+            with config.patch({"cpp.simdlen": simdlen}):
+                for size in (4, 64, 129):
+                    torch._dynamo.reset()
+                    metrics.reset()
+                    x = torch.randint(low, high, (size,), dtype=dtype)
+                    self.common(fn, (x,))
+                    # the number of tiled loop nests varies with size and ISA,
+                    # so only assert that the reduction vectorized at all
+                    if _can_check_vec_metrics():
+                        self.assertGreater(metrics.generated_cpp_vec_kernel_count, 0)
+                        _, code = run_and_get_cpp_code(torch.compile(fn), x)
+                        # the min/max suffix must blend the inactive lanes back
+                        # to the reduction identity before vec_reduce_all
+                        FileCheck().check(f"{DTYPE_TO_CPP[dtype]}>::set(").run(code)
 
     def test_cpu_realization_thresholds(self):
         from torch._inductor.ir import Pointwise, StorageBox

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -7413,6 +7413,37 @@ class CPUReproTests(TestCase):
                 # inf or finite numbers, it shouldn't degrade into unexpected NaNs).
                 self.assertEqual(eager_out, compiled_out)
 
+    @requires_vectorization
+    @parametrize("dtype", (torch.uint8, torch.int8))
+    def test_int8_min_max_reduction(self, dtype):
+        # https://github.com/pytorch/pytorch/issues/191499
+        # Partial vector loads of int8/uint8 fill only the first tiling-factor
+        # lanes of the reduction accumulator; the inactive lanes used to leak
+        # zeros into the horizontal min/max, and argmin/argmax additionally
+        # read uninitialized index lanes.
+        def fn(x):
+            return (
+                torch.amin(x),
+                torch.amax(x),
+                torch.aminmax(x),
+                torch.argmin(x),
+                torch.argmax(x),
+                torch.min(x, 0),
+                torch.max(x, 0),
+            )
+
+        low, high = (5, 100) if dtype == torch.uint8 else (-100, -5)
+        with config.patch({"cpp.simdlen": None}):
+            for size in (4, 64, 129):
+                torch._dynamo.reset()
+                metrics.reset()
+                x = torch.randint(low, high, (size,), dtype=dtype)
+                self.common(fn, (x,))
+                # the number of tiled loop nests varies with size and ISA, so
+                # only assert that the reduction vectorized at all
+                if _can_check_vec_metrics():
+                    self.assertGreater(metrics.generated_cpp_vec_kernel_count, 0)
+
     def test_cpu_realization_thresholds(self):
         from torch._inductor.ir import Pointwise, StorageBox
         from torch._inductor.virtualized import ops

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3451,19 +3451,7 @@ class CppVecKernel(CppKernel):
                     f"{acc} = {reduction_combine(reduction_type, acc, masked_next_value)};"
                 )
             elif argmax_or_argmin:
-                # bool argmin/argmax values are computed in float
-                val_dtype = (
-                    torch.float
-                    if src_dtype == torch.bool
-                    else DTYPE_TO_COMPUTATION_DTYPE[src_dtype]
-                )
-                if self._get_raw_num_vectors(val_dtype) < 1:
-                    # Partial loads leave the lanes past num_elems inactive; keep
-                    # them out of the horizontal reduction (see the min/max
-                    # branch below).
-                    next_value = f"{reduction_type}_vec_reduce_all({acc_vec}, {cexpr_index(self.num_elems)})"
-                else:
-                    next_value = f"{reduction_type}_vec_reduce_all({acc_vec})"
+                next_value = f"{reduction_type}_vec_reduce_all({acc_vec})"
             elif is_bool:
                 if reduction_type in (
                     "any",
@@ -3492,13 +3480,13 @@ class CppVecKernel(CppKernel):
                         raise AssertionError('expected reduction_type == "sum"')
                     result_vec = f"{acc_vec} + {masked_acc_vec}"
                 if self._get_raw_num_vectors(vec_dtype) < 1:
-                    # Partial loads fill only num_elems lanes and zero the rest,
-                    # while vec_reduce_all reduces all lanes, so reset the
-                    # inactive lanes to the reduction identity first.
+                    # Partial loads fill at most tiling_factor lanes and zero the
+                    # rest, while vec_reduce_all reduces all lanes, so reset the
+                    # lanes past tiling_factor to the reduction identity first.
                     result_vec = (
                         f"{acc_type_vec}::set("
                         f"{self.reduction_init_vec(reduction_type, dtype)}, "
-                        f"{result_vec}, {cexpr_index(self.num_elems)})"
+                        f"{result_vec}, {self.tiling_factor})"
                     )
                 next_value = f"{vec_reduce_all_func}([]({vec}& x, {vec}& y) {reduce_all_body}, {result_vec})"
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3451,7 +3451,19 @@ class CppVecKernel(CppKernel):
                     f"{acc} = {reduction_combine(reduction_type, acc, masked_next_value)};"
                 )
             elif argmax_or_argmin:
-                next_value = f"{reduction_type}_vec_reduce_all({acc_vec})"
+                # bool argmin/argmax values are computed in float
+                val_dtype = (
+                    torch.float
+                    if src_dtype == torch.bool
+                    else DTYPE_TO_COMPUTATION_DTYPE[src_dtype]
+                )
+                if self._get_raw_num_vectors(val_dtype) < 1:
+                    # Partial loads leave the lanes past num_elems inactive; keep
+                    # them out of the horizontal reduction (see the min/max
+                    # branch below).
+                    next_value = f"{reduction_type}_vec_reduce_all({acc_vec}, {cexpr_index(self.num_elems)})"
+                else:
+                    next_value = f"{reduction_type}_vec_reduce_all({acc_vec})"
             elif is_bool:
                 if reduction_type in (
                     "any",
@@ -3479,6 +3491,15 @@ class CppVecKernel(CppKernel):
                     if reduction_type != "sum":
                         raise AssertionError('expected reduction_type == "sum"')
                     result_vec = f"{acc_vec} + {masked_acc_vec}"
+                if self._get_raw_num_vectors(vec_dtype) < 1:
+                    # Partial loads fill only num_elems lanes and zero the rest,
+                    # while vec_reduce_all reduces all lanes, so reset the
+                    # inactive lanes to the reduction identity first.
+                    result_vec = (
+                        f"{acc_type_vec}::set("
+                        f"{self.reduction_init_vec(reduction_type, dtype)}, "
+                        f"{result_vec}, {cexpr_index(self.num_elems)})"
+                    )
                 next_value = f"{vec_reduce_all_func}([]({vec}& x, {vec}& y) {reduce_all_body}, {result_vec})"
 
             self.reduction_suffix.writeline(

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -664,16 +664,21 @@ inline IndexValueVec<T, NV, NI>& argmax_combine_vec(
   return argmax_vec_impl(a, next_value, next_index, tail_size);
 }
 
+// For dtypes narrower than the vector lane width, only the first `len` value
+// lanes are active and the index vector has fewer lanes than the value vector,
+// so reducing the full width would read inactive values and uninitialized
+// indices.
 template <typename T, int NV, int NI>
 inline IndexValue<T> argmin_vec_reduce_all(
-    const IndexValueVec<T, NV, NI>& vec) {
-  constexpr int len = at::vec::VectorizedN<T, NV>::size();
-  __at_align__ T tmpval[len];
-  __at_align__ int64_t tmpidx[len];
+    const IndexValueVec<T, NV, NI>& vec,
+    int64_t len = at::vec::VectorizedN<T, NV>::size()) {
+  constexpr int max_len = at::vec::VectorizedN<T, NV>::size();
+  __at_align__ T tmpval[max_len];
+  __at_align__ int64_t tmpidx[max_len];
   vec.value.store(tmpval);
   vec.index.store(tmpidx);
   IndexValue res = IndexValue<T>(tmpidx[0], tmpval[0]);
-  for (int i = 1; i < len; i++) {
+  for (int64_t i = 1; i < len; i++) {
     res = argmin_combine(res, tmpval[i], tmpidx[i]);
   }
   return res;
@@ -681,14 +686,15 @@ inline IndexValue<T> argmin_vec_reduce_all(
 
 template <typename T, int NV, int NI>
 inline IndexValue<T> argmax_vec_reduce_all(
-    const IndexValueVec<T, NV, NI>& vec) {
-  constexpr int len = at::vec::VectorizedN<T, NV>::size();
-  __at_align__ T tmpval[len];
-  __at_align__ int64_t tmpidx[len];
+    const IndexValueVec<T, NV, NI>& vec,
+    int64_t len = at::vec::VectorizedN<T, NV>::size()) {
+  constexpr int max_len = at::vec::VectorizedN<T, NV>::size();
+  __at_align__ T tmpval[max_len];
+  __at_align__ int64_t tmpidx[max_len];
   vec.value.store(tmpval);
   vec.index.store(tmpidx);
   IndexValue res = IndexValue<T>(tmpidx[0], tmpval[0]);
-  for (int i = 1; i < len; i++) {
+  for (int64_t i = 1; i < len; i++) {
     res = argmax_combine(res, tmpval[i], tmpidx[i]);
   }
   return res;

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -664,21 +664,22 @@ inline IndexValueVec<T, NV, NI>& argmax_combine_vec(
   return argmax_vec_impl(a, next_value, next_index, tail_size);
 }
 
-// For dtypes narrower than the vector lane width, only the first `len` value
-// lanes are active and the index vector has fewer lanes than the value vector,
-// so reducing the full width would read inactive values and uninitialized
-// indices.
+// The index vector always has exactly one lane per active element, while for
+// dtypes narrower than the vector lane width the value vector has extra
+// (inactive) lanes past that, so reduce over the index lane count, not the
+// value lane count.
 template <typename T, int NV, int NI>
 inline IndexValue<T> argmin_vec_reduce_all(
-    const IndexValueVec<T, NV, NI>& vec,
-    int64_t len = at::vec::VectorizedN<T, NV>::size()) {
+    const IndexValueVec<T, NV, NI>& vec) {
   constexpr int max_len = at::vec::VectorizedN<T, NV>::size();
+  constexpr int len = at::vec::VectorizedN<int64_t, NI>::size();
+  static_assert(len <= max_len);
   __at_align__ T tmpval[max_len];
-  __at_align__ int64_t tmpidx[max_len];
+  __at_align__ int64_t tmpidx[len];
   vec.value.store(tmpval);
   vec.index.store(tmpidx);
   IndexValue res = IndexValue<T>(tmpidx[0], tmpval[0]);
-  for (int64_t i = 1; i < len; i++) {
+  for (int i = 1; i < len; i++) {
     res = argmin_combine(res, tmpval[i], tmpidx[i]);
   }
   return res;
@@ -686,15 +687,16 @@ inline IndexValue<T> argmin_vec_reduce_all(
 
 template <typename T, int NV, int NI>
 inline IndexValue<T> argmax_vec_reduce_all(
-    const IndexValueVec<T, NV, NI>& vec,
-    int64_t len = at::vec::VectorizedN<T, NV>::size()) {
+    const IndexValueVec<T, NV, NI>& vec) {
   constexpr int max_len = at::vec::VectorizedN<T, NV>::size();
+  constexpr int len = at::vec::VectorizedN<int64_t, NI>::size();
+  static_assert(len <= max_len);
   __at_align__ T tmpval[max_len];
-  __at_align__ int64_t tmpidx[max_len];
+  __at_align__ int64_t tmpidx[len];
   vec.value.store(tmpval);
   vec.index.store(tmpidx);
   IndexValue res = IndexValue<T>(tmpidx[0], tmpval[0]);
-  for (int64_t i = 1; i < len; i++) {
+  for (int i = 1; i < len; i++) {
     res = argmax_combine(res, tmpval[i], tmpidx[i]);
   }
   return res;


### PR DESCRIPTION
Fixes #191499

> [!NOTE]
> This PR (code and description) was authored with the assistance of an AI agent (Claude Code, model Claude Fable 5), per the repo [AI policy](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md). Opened as a draft pending human review.

The following analysis and fix description are AI-generated:

> ### Root cause
>
> For dtypes narrower than the vector lane width implied by the tiling factor (`uint8`/`int8` with a float-sized tiling factor), `CppVecKernel` loads fill only the first `tiling_factor` lanes of a `Vectorized<T>` and zero the rest, e.g. on NEON (tiling factor 4, 16 `uint8` lanes):
>
> ```cpp
> auto tmp0 = at::vec::Vectorized<uint8_t>::loadu(in_ptr0 + x0, 4);   // lanes 4..15 = 0
> tmp_acc0_vec = at::vec::minimum(tmp_acc0_vec, tmp0);                 // unmasked: identity lanes -> 0
> ...
> tmp_acc0 = min_propagate_nan(tmp_acc0, at::vec::vec_reduce_all<uint8_t, 1>(..., tmp_acc0_vec));  // reduces ALL 16 lanes
> ```
>
> The accumulator is initialized to the reduction identity in all lanes, but the unmasked combine in the main loop overwrites the inactive lanes (for `min`, `minimum(identity, 0) == 0`), and the horizontal `vec_reduce_all` in the reduction suffix then reduces across all lanes, leaking the polluted lanes into the result. So `torch.amin` of an all-positive `uint8` tensor compiles to `0`, and `torch.amax` of an all-negative `int8` tensor compiles to `0`, at any tensor length. The bug is ISA-independent (the tail loop is not the trigger; the main loop's partial loads are), and also affects `torch.min`/`torch.max`/`torch.aminmax`, and, through the same polluted value lanes, `argmin`/`argmax` (plus the indices of `torch.min/max(dim=)`). Reductions that promote (`sum`/`prod` to `int64`) compute in fully-utilized wider vectors and are unaffected; `bf16`/`fp16` compute in `float` and are likewise unaffected.
>
> ### Fix
>
> Two small pieces, one per reduction flavor:
>
> **min/max:** blend the inactive accumulator lanes back to the reduction identity right before the horizontal reduction, in the reduction suffix:
>
> ```cpp
> at::vec::vec_reduce_all<uint8_t, 1>(..., at::vec::Vectorized<uint8_t>::set(at::vec::Vectorized<uint8_t>(std::numeric_limits<uint8_t>::max()), tmp_acc0_vec, 4));
> ```
>
> gated on `_get_raw_num_vectors(dtype) < 1` (lane underutilization), mirroring the existing precedent in `CppVecOverrides.remainder`. The blend count is the tiling factor: the lanes past it are the ones the loads never fill. The alternative of masking every combine in the main loop (as the tail loop already does via `min_masked_reduce`) would cost a blend per loop iteration instead of a single blend in the suffix.
>
> **argmin/argmax:** `argmin/argmax_vec_reduce_all` iterated over the full value-vector width, reading polluted value lanes and index lanes that do not exist. Fixed entirely in `cpp_prefix.h`: the index vector always has exactly one lane per active element (`VectorizedN<int64_t, NI>::size()` equals the tiling factor on every ISA), so the horizontal reduce now derives its length from the index vector width instead of the value vector width. No codegen change; the emitted call is unchanged from upstream.
>
> ### Test plan
>
> New regression test covering `amin`/`amax`/`aminmax`/`argmin`/`argmax`/`min(dim=)`/`max(dim=)` over `uint8`/`int8`, swept across `simd_lengths_to_test()` and sizes hitting tail-only/main-only/main+tail loops, asserting the kernel vectorizes and FileChecking the generated identity blend:
>
> ```
> python -m pytest test/inductor/test_cpu_repro.py -k test_int8_min_max_reduction
> ```
>
> Verified on an Apple M-series machine (Inductor CPU, NEON) by patching the fix into the torch 2.14.0.dev20260703 nightly wheel: the issue reproducer returns 5 for all four variants; a sweep of `amin`/`amax`/`min`/`max`/`aminmax`/`sum`/`prod` (1D and 2D dims, static and dynamic shapes, sizes 4-100) over `uint8`/`int8`/`int16`/`int32`/`float32`/`bfloat16`/`float16` matches eager (359 checks); a 296-case argmin/argmax unique-extremum stress test and a 272-case tie/duplicated-extremum suite (inputs made entirely of the reduction identity, the adversarial case for tail-only kernels) all match eager. The AVX512/AVX2 template instantiations were syntax-checked via cross-compile.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
