### PR TITLE
[ci] Persist CI Advisor per-job input and reasoning trace

### DIFF
--- a/.github/workflows/claude-autorevert-advisor.yml
+++ b/.github/workflows/claude-autorevert-advisor.yml
@@ -167,6 +167,78 @@ jobs:
           aws s3 cp /tmp/advisor_verdict.json \
             "s3://ossci-raw-job-status/autorevert_advisor_verdicts/${{ github.repository }}/${{ github.run_id }}_${{ github.run_attempt }}.json"
 
+      # --- Debug observability: persist the exact per-job input and the full
+      # reasoning trace so a disputed verdict can be diagnosed after the fact
+      # (confabulation vs. a wrong/truncated input feed). Runs on always() so the
+      # pathological runs (empty/failed verdict) are the ones we can inspect.
+      # continue-on-error keeps logging from ever failing the advisor itself.
+      - name: Save advisor input payload
+        if: always()
+        continue-on-error: true
+        env:
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SUSPECT_COMMIT: ${{ inputs.suspect_commit }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          SIGNAL_PATTERN: ${{ inputs.signal_pattern }}
+        run: |
+          mkdir -p /tmp/advisor_input
+          # Verbatim per-job payload the advisor was dispatched with.
+          printf '%s' "$SIGNAL_PATTERN" > /tmp/advisor_input/signal_pattern.json
+          jq -n \
+            --arg repo "$REPO" \
+            --arg run_id "$RUN_ID" \
+            --arg run_attempt "$RUN_ATTEMPT" \
+            --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%S.000)" \
+            --arg suspect_commit "$SUSPECT_COMMIT" \
+            --arg pr_number "$PR_NUMBER" \
+            '{
+              repo: $repo,
+              run_id: ($run_id | tonumber),
+              run_attempt: ($run_attempt | tonumber),
+              timestamp: $timestamp,
+              suspect_commit: $suspect_commit,
+              pr_number: $pr_number
+            }' > /tmp/advisor_input/meta.json
+          aws s3 cp --recursive /tmp/advisor_input \
+            "s3://ossci-raw-job-status/autorevert_advisor_inputs/$REPO/${RUN_ID}_${RUN_ATTEMPT}/"
+
+      - name: Upload advisor input payload artifact
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: advisor-input
+          path: /tmp/advisor_input/
+          retention-days: 30
+
+      - name: Save advisor reasoning trace
+        if: always() && steps.claude.outputs.execution_file != ''
+        continue-on-error: true
+        env:
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        run: |
+          mkdir -p /tmp/advisor_trace
+          # Full turn-by-turn trace: thinking (alwaysThinkingEnabled), every tool
+          # call (git show / gh pr view / log fetches) and its result, and the
+          # final output — i.e. everything the model saw and reasoned over.
+          cp "$EXECUTION_FILE" /tmp/advisor_trace/execution.json
+          aws s3 cp /tmp/advisor_trace/execution.json \
+            "s3://ossci-raw-job-status/autorevert_advisor_traces/$REPO/${RUN_ID}_${RUN_ATTEMPT}.json"
+
+      - name: Upload advisor reasoning trace artifact
+        if: always() && steps.claude.outputs.execution_file != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: advisor-reasoning-trace
+          path: /tmp/advisor_trace/execution.json
+          retention-days: 30
+
       - name: Upload usage metrics
         if: always()
         uses: pytorch/test-infra/.github/actions/upload-claude-usage@main

--- a/.github/workflows/claude-autorevert-advisor.yml
+++ b/.github/workflows/claude-autorevert-advisor.yml
@@ -204,15 +204,6 @@ jobs:
           aws s3 cp --recursive /tmp/advisor_input \
             "s3://ossci-raw-job-status/autorevert_advisor_inputs/$REPO/${RUN_ID}_${RUN_ATTEMPT}/"
 
-      - name: Upload advisor input payload artifact
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: advisor-input
-          path: /tmp/advisor_input/
-          retention-days: 30
-
       - name: Save advisor reasoning trace
         if: always() && steps.claude.outputs.execution_file != ''
         continue-on-error: true
@@ -229,15 +220,6 @@ jobs:
           cp "$EXECUTION_FILE" /tmp/advisor_trace/execution.json
           aws s3 cp /tmp/advisor_trace/execution.json \
             "s3://ossci-raw-job-status/autorevert_advisor_traces/$REPO/${RUN_ID}_${RUN_ATTEMPT}.json"
-
-      - name: Upload advisor reasoning trace artifact
-        if: always() && steps.claude.outputs.execution_file != ''
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: advisor-reasoning-trace
-          path: /tmp/advisor_trace/execution.json
-          retention-days: 30
 
       - name: Upload usage metrics
         if: always()


### PR DESCRIPTION
## Summary

When the CI Advisor renders a disputed verdict, today we can only recover the final verdict JSON — not what the model was actually given, nor how it reasoned to that verdict. That makes it impossible to tell a genuine confabulation apart from a wrong/truncated input feed after the run is over.

This adds two debug-observability captures to the advisor workflow:

1. **Per-job input payload** — the exact dispatch inputs (`suspect_commit`, `pr_number`, and the verbatim `signal_pattern`) are saved as an `advisor-input` artifact and uploaded to `s3://ossci-raw-job-status/autorevert_advisor_inputs/<repo>/<run_id>_<run_attempt>/`.
2. **Full reasoning trace** — the `claude-code-action` `execution_file` output (the turn-by-turn log: thinking, every tool call and its result, final output) is saved as an `advisor-reasoning-trace` artifact and uploaded to `s3://ossci-raw-job-status/autorevert_advisor_traces/<repo>/<run_id>_<run_attempt>.json`.

Both steps run on `always()` with `continue-on-error: true`, so:
- the pathological runs (empty/failed verdict) are exactly the ones we can inspect, and
- debug logging can never gate or fail the advisor itself.

Keyed by `run_id`/`run_attempt`, mirroring the existing verdict upload and reusing the OIDC creds already configured earlier in the job. No change to the advisor's verdict or decision path.

Refs pytorch/test-infra#8378.

## Test plan

- `lintrunner` on the workflow file is clean; YAML parses.
- Steps only add artifact/S3 uploads; the verdict pipeline is unchanged.
- On the next dispatch, confirm the `advisor-input` and `advisor-reasoning-trace` artifacts appear on the run and the corresponding S3 objects land under `autorevert_advisor_inputs/` and `autorevert_advisor_traces/`.