### PR TITLE
[TLX][AMD] Make split-K addmm work under AOTInductor

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3398,6 +3398,7 @@ class PythonWrapperCodegen(CodeGen):
             SizeArg,
             TensorArg,
             TMADescriptorArg,
+            WorkspaceArg,
         )
 
         original_name = kernel.__name__
@@ -3477,6 +3478,12 @@ class PythonWrapperCodegen(CodeGen):
                             dtype=dtype,
                         ),
                     )
+                elif isinstance(arg, WorkspaceArg):
+                    # A self-allocated scratch buffer (e.g. split-K partials).
+                    # Put it in the signature as a WorkspaceArg -- not a TensorArg
+                    # -- so config_of short-circuits it instead of resolving its
+                    # layout via scheduler.name_to_buf (which has no workspace).
+                    add_to_signature(idx, arg)
                 elif isinstance(arg, ir.Buffer):
                     add_arg(
                         idx,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3193,6 +3193,7 @@ class TritonTemplate(KernelTemplate):
             make_kernel_render,
             result.extra.strip("-").replace("-", ", "),
             bmreq,
+            split_k=kwargs.get("SPLIT_K", 1),
             log_info={
                 "tile_shape": str(
                     (
@@ -3363,9 +3364,14 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
         workspace_arg: WorkspaceArg | None = None,
         allowed_prologue_inps: OrderedSet[str] | None = None,
         hint_override: int | None = None,
+        split_k: int = 1,
     ) -> None:
         super().__init__(name, input_nodes, layout, description)
         self.make_kernel_render = make_kernel_render
+        # >1 for split-K templates whose reduction runs in a separate kernel
+        # (sum of partials + bias). Such a choice cannot host a fused epilogue,
+        # so a MultiTemplateBuffer containing one disables epilogue fusion.
+        self.split_k = split_k
         self.bmreq: TritonBenchmarkRequest = bmreq
         if log_info is None:
             log_info = {}
@@ -4195,16 +4201,26 @@ class AlgorithmSelectorCache(PersistentCache):
                     allowed_prologue_inps |= c.allowed_prologue_inps
 
             # No single winning choice yet; selection is deferred to benchmark fusion
+            multi_buf = torch._inductor.ir.MultiTemplateBuffer(
+                layout,
+                input_nodes,
+                get_timings,
+                choices,
+                allowed_prologue_inps,
+            )
+            # A split-K choice reduces in a separate kernel that only sums fp32
+            # partials + adds bias; it cannot host a fused epilogue -- store_output
+            # is bypassed, so the epilogue's output buffer ends up used-before-defined
+            # (buf### UnboundLocalError under JIT / "undeclared identifier" under AOTI).
+            # Disable epilogue fusion for this node so the epilogue runs as a separate
+            # kernel; split-K stays selectable for the raw GEMM.
+            if any(
+                isinstance(c, TritonTemplateCaller) and getattr(c, "split_k", 1) > 1
+                for c in choices
+            ):
+                multi_buf.allow_epilogue_fusion = False
             return (
-                torch._inductor.ir.TensorBox.create(
-                    torch._inductor.ir.MultiTemplateBuffer(
-                        layout,
-                        input_nodes,
-                        get_timings,
-                        choices,
-                        allowed_prologue_inps,
-                    )
-                ),
+                torch._inductor.ir.TensorBox.create(multi_buf),
                 None,
             )
 


### PR DESCRIPTION
Summary:
Two fixes on top of D113851999 let TLX split-K addmm compile and run correctly under AOTInductor (and JIT), flipping more addmm autotune selections from rocBLAS to TLX with no accuracy gap.

1. Workspace arg (`KeyError: 'workspace_1070'`): `emit_aoti_reduce_k_call` wrapped the split-K workspace in an `ir.Buffer`, which becomes a `TensorArg` in the kernel signature; on HIP `config_of` then resolves its layout via `scheduler.get_buffer_layout` -> `name_to_buf` and KeyErrors, because a `WorkspaceArg` is not a scheduler buffer. Pass the real `WorkspaceArg` from `emit_aoti_reduce_k_call`, and add a `WorkspaceArg` branch to `define_user_defined_triton_kernel` (`add_to_signature`) so `config_of` short-circuits it (as it does for template workspaces).

2. Split-K vs epilogue fusion (`buf693` / correctness): split-K bypasses `store_output` and reduces in a separate `_reduce_k_kernel` that only sums fp32 partials + re-adds bias. It cannot replay a fused pointwise epilogue (gelu, etc.), so fusing one onto a split-K choice leaves the epilogue's output buffer used-before-defined -- `UnboundLocalError` under the JIT Python wrapper, "use of undeclared identifier buf###" under the AOTI C++ wrapper -- and would silently drop the epilogue. This is not AOTI-specific. Fix: expose `SPLIT_K` on `TritonTemplateCaller`, and set `allow_epilogue_fusion = False` on a `MultiTemplateBuffer` when any of its choices is split-K; the existing `_is_epilogue_fusion_enabled` gate then blocks epilogue fusion onto split-K choices across both wrapper paths. The epilogue runs as a separate kernel; split-K stays selectable for the GEMM.

Net behavior: split-K addmm is now selectable under AOTInductor and wins more addmm over rocBLAS, but a split-K node does not additionally fuse an epilogue (the reduce kernel cannot replay it). No accuracy gap.

Follow-ups (T282209364): the gate is slightly over-broad (a split-K-offering node also loses epilogue fusion for its SK=1 choice); recovering that per-choice, or replaying the epilogue inside `_reduce_k_kernel` to keep split-K + epilogue fused, are perf follow-ups.

Authored with an AI coding assistant.

Test Plan:
New unit test `test_tlx_addmm_warppipe_split_k_epilogue_not_fused` (gfx950): addmm+gelu on a split-K shape under both the JIT and cpp_wrapper paths -- asserts numeric correctness vs eager and that `_reduce_k_kernel` is used.

E2E on the HI OC merge net (`1080674750_16`, submodule=merge, `TORCHINDUCTOR_TLX_MODE=allow`, `--lower-backend AOT_INDUCTOR`, production `--add_passes`, MI350X, BS=1024):
```
Accuracy: True (rtol=0.01), 26.31 ms/iter, 447 TFLOP/s, MTS_EXIT=0
```
On par with the 26.25 ms no-split-K baseline; split-K TLX now selected and `gelu + split-K` fused kernels = 0. Before this change the same run failed to compile (`buf693`). Full analysis and logs: P2437933905.

Differential Revision: D113910767




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo