### PR TITLE
Restore input layout after FakeTensorProp

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19074,6 +19074,29 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertEqual(out_eager, out_compiled)
         self.assertEqual(x_eager.device, x_compiled.device)
 
+    def test_tensor_set_data_non_contiguous(self):
+        def func(x, replacement, weight):
+            y = x * 2
+            x.data = replacement
+            weight.normal_()
+            return x, y
+
+        def inputs():
+            base = torch.arange(12, device=self.device, dtype=torch.float32).view(4, 3)
+            return (
+                base.t(),
+                torch.ones(3, 4, device=self.device),
+                torch.empty(3, 4, device=self.device),
+            )
+
+        out_eager = func(*inputs())
+        torch._dynamo.reset()
+        out_compiled = torch.compile(func, backend="inductor", fullgraph=True)(
+            *inputs()
+        )
+
+        self.assertEqual(out_eager, out_compiled)
+
     def test_jvp_compile_backward(self):
         def jvp_fn(f, x):
             return torch.func.jvp(f, (x.clone(),), (torch.ones_like(x),))[1]

--- a/torch/fx/passes/fake_tensor_prop.py
+++ b/torch/fx/passes/fake_tensor_prop.py
@@ -132,4 +132,7 @@ class FakeTensorProp(torch.fx.Interpreter):
                         # set_ also restores the storage, which a set_ in the
                         # graph may have swapped out for another input's.
                         with torch.no_grad():
+                            # set_ accepts a Tensor source, but only the Storage
+                            # overloads are in the generated stub.
+                            # pyrefly: ignore [bad-argument-type]
                             fake.set_(orig)

--- a/torch/fx/passes/fake_tensor_prop.py
+++ b/torch/fx/passes/fake_tensor_prop.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import torch.fx
+from torch._subclasses.fake_impls import fast_detach
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode, is_fake_tensor
 from torch.fx import Node
 from torch.fx._compatibility import compatibility
@@ -109,11 +110,11 @@ class FakeTensorProp(torch.fx.Interpreter):
         return self.propagate_dont_convert_inputs(*fake_args)
 
     def propagate_dont_convert_inputs(self, *args: object) -> Any:
-        # In-place ops like shallow_copy_data_ can mutate fake_device on
-        # input FakeTensors during propagation. Save and restore so the
-        # caller's inputs are not permanently corrupted.
-        saved_devices = [
-            (a, a.fake_device)
+        # In-place ops like shallow_copy_data_ and set_ can mutate fake_device
+        # and the storage/layout of input FakeTensors during propagation. Save
+        # and restore so the caller's inputs are not permanently corrupted.
+        saved_inputs = [
+            (a, a.fake_device, fast_detach(self._mode, a))
             for a in args
             if isinstance(a, FakeTensor)  # noqa: ISINSTANCE_FAKE_TENSOR
         ]
@@ -121,5 +122,14 @@ class FakeTensorProp(torch.fx.Interpreter):
             try:
                 return super().run(*args)
             finally:
-                for fake, device in saved_devices:
+                for fake, device, orig in saved_inputs:
                     fake.fake_device = device
+                    if (
+                        fake.shape != orig.shape
+                        or fake.stride() != orig.stride()
+                        or fake.storage_offset() != orig.storage_offset()
+                    ):
+                        # set_ also restores the storage, which a set_ in the
+                        # graph may have swapped out for another input's.
+                        with torch.no_grad():
+                            fake.set_(orig)


### PR DESCRIPTION
Fixes #191337

`FakeTensorProp` runs the graph on the caller's own fake tensors, so an
`aten.set_.source_Tensor` node (what `x.data = y` becomes) mutates the input
FakeTensor's sizes, strides and storage in place. Inductor calls this from
`compile_fx` and then lowers the graph using those same example inputs, so
`GraphLowering.placeholder` picks up the post-`set_` layout and codegens
`assert_size_stride(arg0_1, (3, 4), (4, 1), 'input')` for an input that is
actually `(1, 3)`.

`propagate_dont_convert_inputs` already saved and restored `fake_device` for
this exact reason. This extends that to the storage and layout: snapshot each
input with `fast_detach` up front, and if its layout changed by the end of the
run, `set_` it back. The snapshot also carries the original storage, so the
alias that `set_` introduced between the two inputs goes away too.

Note this is not only a spurious assertion. With `size_asserts` off and a use of
`x` before the `.data` assignment, inductor indexes that input with the wrong
strides and silently returns wrong values.

Verified on 8x A40 (sm_86), CUDA 12.6. The reproducer from the issue fails
before and passes after, and the new test
`test_tensor_set_data_non_contiguous` fails before and passes after on CUDA.

Not verified: CPU (the box's g++ is too old for inductor's `-std=c++20`, so all
CPU inductor compiles fail there), and the cpp_wrapper/AOTI instantiation of the
new test. I did not add a `skip_if_cpp_wrapper` since the adjacent test skips it
only for the cross-device shim gap, but if same-device `set_` is missing from the
AOTI shim that skip will be needed.

Thanks to @xyt66665000 for the report and the minimal reproducer.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo