### PR TITLE
[Inductor][UT] Use dtype-aware tolerances instead of bitwise equivalence in TestOpInfoProperties

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -154,6 +154,12 @@ NUM_SAMPLES = 65536
 
 
 def _dtype_numerical_tolerances(dtype, rtol_multiplier=1.0):
+    """Return the baseline ``(rtol, atol)`` for a floating-point dtype.
+
+    The relative term is scaled for narrow per-case overrides. The absolute
+    term remains one minimum subnormal step so overrides do not weaken the
+    comparison around zero.
+    """
     finfo = torch.finfo(dtype)
     return rtol_multiplier * finfo.eps, finfo.smallest_normal * finfo.eps
 
@@ -180,7 +186,12 @@ def _get_numerical_tolerances(dtype, test_type, backend, op_name):
 
 
 def _ordered_float_ranks(tensor):
-    """Map finite fp16/bf16/fp32 values to monotonic integer ranks."""
+    """Map finite fp16/bf16/fp32 values to monotonic integer ranks.
+
+    IEEE sign-magnitude encodings are reflected across the sign boundary so
+    adjacent floating-point values receive adjacent ranks. Subtracting two
+    ranks therefore gives their ULP distance, including across signed zero.
+    """
     int_dtype = torch.int32 if tensor.dtype == torch.float32 else torch.int16
     width = tensor.element_size() * 8
     sign_mask = 1 << (width - 1)
@@ -195,6 +206,7 @@ def _ordered_float_ranks(tensor):
 
 
 def _unravel_index(flat_index, shape):
+    """Convert a row-major flat offset to an index tuple for diagnostics."""
     index = []
     for size in reversed(shape):
         index.append(flat_index % size)
@@ -203,6 +215,13 @@ def _unravel_index(flat_index, shape):
 
 
 def _tensor_ulp_diagnostic(actual, expected):
+    """Return the largest finite ULP difference for a compatible tensor pair.
+
+    The result contains the ULP distance, tensor index, actual value, and
+    expected value. Unsupported dtypes, mismatched tensors, empty tensors, and
+    pairs without any finite values return ``None``; the main assertion reports
+    those structural or nonfinite mismatches directly.
+    """
     if (
         actual.dtype != expected.dtype
         or actual.shape != expected.shape
@@ -231,6 +250,11 @@ def _tensor_ulp_diagnostic(actual, expected):
 
 
 def _format_ulp_diagnostics(actual, expected):
+    """Format maximum-ULP details for tensor leaves in matching output pytrees.
+
+    Non-tensor and unsupported leaves are omitted. An empty string is returned
+    when the output structures differ or no tensor leaf supports ULP analysis.
+    """
     actual_leaves, actual_spec = pytree.tree_flatten(actual)
     expected_leaves, expected_spec = pytree.tree_flatten(expected)
     if actual_spec != expected_spec:
@@ -732,11 +756,16 @@ class TestOpInfoProperties(TestCase):
     def _assert_compiled_matches_eager(
         self, compiled, eager, dtype, test_type, backend, op_name
     ):
-        """Assert bounded numerical parity while preserving structural checks."""
+        """Assert bounded numerical parity while preserving structure and dtype.
+
+        The test identity selects any narrow backend override. ``assertEqual``
+        still checks the complete output pytree and exact dtypes, while its
+        callable failure message computes per-leaf ULP details only on failure.
+        """
         rtol, atol = _get_numerical_tolerances(dtype, test_type, backend, op_name)
 
         def failure_message(message):
-            # ULP computation is diagnostic only and runs lazily on assertion failure.
+            """Append lazy per-leaf ULP details to the standard failure message."""
             diagnostics = _format_ulp_diagnostics(compiled, eager)
             return f"{message}\n{diagnostics}" if diagnostics else message
 

--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -6,7 +6,7 @@ Tests three properties:
 1. Batch invariance - output shouldn't change based on batch size
 2. Run-to-run determinism - same input should give same output across
    compilations, even with different autotuning choices
-3. Bitwise equivalence with torch eager mode
+3. Numerical equivalence with torch eager mode
 
 Tests three compilation backends:
 1. aot_eager_decomp_partition - AOT autograd with eager execution
@@ -64,6 +64,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.testing._internal.opinfo.core import _filter_unary_elementwise_tensor
+from torch.utils import _pytree as pytree
 
 
 # LLM-useful op names to filter from unary_ufuncs
@@ -150,6 +151,109 @@ DTYPES = [
 
 # Number of samples for numerical testing
 NUM_SAMPLES = 65536
+
+
+def _dtype_numerical_tolerances(dtype, rtol_multiplier=1.0):
+    finfo = torch.finfo(dtype)
+    return rtol_multiplier * finfo.eps, finfo.smallest_normal * finfo.eps
+
+
+def _get_numerical_tolerances(dtype, test_type, backend, op_name):
+    """Return a tight dtype-aware tolerance for compiled-vs-eager comparisons.
+
+    ``eps`` is the spacing above 1.0. Using it as rtol admits roughly 1-2 ULP
+    over the normal range because relative ULP spacing varies within each
+    binade. ``smallest_normal * eps`` is the smallest positive subnormal and
+    provides one representable step of absolute tolerance around zero.
+
+    This is intentionally much tighter near zero than torch.testing's general
+    defaults. It is an eager-parity bound, not a claim that eager is a
+    correctly-rounded mathematical oracle.
+    """
+    baseline = _dtype_numerical_tolerances(dtype)
+    if torch.version.hip is None:
+        return baseline
+
+    return ROCM_NUMERICAL_TOLERANCE_OVERRIDES.get(
+        (test_type, backend, op_name, dtype), baseline
+    )
+
+
+def _ordered_float_ranks(tensor):
+    """Map finite fp16/bf16/fp32 values to monotonic integer ranks."""
+    int_dtype = torch.int32 if tensor.dtype == torch.float32 else torch.int16
+    width = tensor.element_size() * 8
+    sign_mask = 1 << (width - 1)
+    bits = tensor.contiguous().view(int_dtype).to(torch.int64)
+    bits = torch.bitwise_and(bits, (1 << width) - 1)
+    magnitude = torch.bitwise_and(bits, sign_mask - 1)
+    return torch.where(
+        torch.bitwise_and(bits, sign_mask).bool(),
+        sign_mask - magnitude,
+        sign_mask + magnitude,
+    )
+
+
+def _unravel_index(flat_index, shape):
+    index = []
+    for size in reversed(shape):
+        index.append(flat_index % size)
+        flat_index //= size
+    return tuple(reversed(index))
+
+
+def _tensor_ulp_diagnostic(actual, expected):
+    if (
+        actual.dtype != expected.dtype
+        or actual.shape != expected.shape
+        or actual.dtype not in (torch.float16, torch.bfloat16, torch.float32)
+        or actual.numel() == 0
+    ):
+        return None
+
+    finite = torch.isfinite(actual) & torch.isfinite(expected)
+    if not finite.any():
+        return None
+
+    ulps = torch.zeros_like(actual, dtype=torch.int64)
+    actual_ranks = _ordered_float_ranks(actual)
+    expected_ranks = _ordered_float_ranks(expected)
+    ulps[finite] = (actual_ranks[finite] - expected_ranks[finite]).abs()
+
+    flat_index = int(torch.argmax(ulps).item())
+    index = _unravel_index(flat_index, actual.shape)
+    return (
+        int(ulps.flatten()[flat_index].item()),
+        index,
+        actual[index].item(),
+        expected[index].item(),
+    )
+
+
+def _format_ulp_diagnostics(actual, expected):
+    actual_leaves, actual_spec = pytree.tree_flatten(actual)
+    expected_leaves, expected_spec = pytree.tree_flatten(expected)
+    if actual_spec != expected_spec:
+        return ""
+
+    diagnostics = []
+    for leaf_index, (actual_leaf, expected_leaf) in enumerate(
+        zip(actual_leaves, expected_leaves, strict=True)
+    ):
+        if not isinstance(actual_leaf, torch.Tensor) or not isinstance(
+            expected_leaf, torch.Tensor
+        ):
+            continue
+        diagnostic = _tensor_ulp_diagnostic(actual_leaf, expected_leaf)
+        if diagnostic is None:
+            continue
+        max_ulps, index, actual_value, expected_value = diagnostic
+        diagnostics.append(
+            f"Output leaf {leaf_index}: max ULP distance {max_ulps} at {index}; "
+            f"compiled={actual_value!r}, eager={expected_value!r}"
+        )
+
+    return "\n".join(diagnostics)
 
 
 def generate_exhaustive_16bit(dtype, device):
@@ -356,13 +460,31 @@ def sample_operates_on_batch_dim(op_name, sample_input):
     return False
 
 
-# Expected failures for bitwise equivalence tests.
+# Expected failures for property tests.
 # Structure: backend -> op_name -> set of failing dtypes (None means all dtypes)
-# These track known numerical differences between eager and compiled execution.
-# The goal is to eventually fix these and remove entries.
+# Eager-equivalence and numerical xfails exceed the tight dtype-aware tolerance.
+# The goal is to understand or fix them, rather than silently widening the global bound.
 
 # Dtype shorthands
 fp32, fp16, bf16, ALL = torch.float32, torch.float16, torch.bfloat16, None
+
+# A one-epsilon rtol can reject a two-ULP difference at the bottom of a binade.
+# These ROCm cases measured at two ULP on MI250X (gfx90a) with ROCm 7.14.
+# Keep their two-epsilon envelopes local instead of weakening every comparison.
+ROCM_NUMERICAL_TOLERANCE_OVERRIDES = {
+    ("eager_equivalence", "inductor_default", "log1p", fp32): (
+        _dtype_numerical_tolerances(fp32, rtol_multiplier=2.0)
+    ),
+    ("eager_equivalence", "inductor_default", "tanh", fp32): (
+        _dtype_numerical_tolerances(fp32, rtol_multiplier=2.0)
+    ),
+    ("unary_numerical", "inductor_default", "cos", fp32): (
+        _dtype_numerical_tolerances(fp32, rtol_multiplier=2.0)
+    ),
+    ("unary_numerical", "inductor_default", "log1p", fp32): (
+        _dtype_numerical_tolerances(fp32, rtol_multiplier=2.0)
+    ),
+}
 
 EAGER_EQUIV_XFAILS = {
     "aot_eager_decomp_partition": {
@@ -444,24 +566,23 @@ XFAIL_DICTS = {
 
 ROCM_EAGER_EQUIV_XFAILS = {
     "aot_eager_decomp_partition": {
-        "nn.functional.gelu": {fp32},
         "nn.functional.layer_norm": {fp32},
         "nn.functional.rms_norm": {fp32},
         "softmax": {fp32},
         "log_softmax": {fp32},
     },
     "inductor_default": {
+        "exp": {fp32},
         "sigmoid": {fp32},
         "nn.functional.gelu": {fp32},
         "nn.functional.layer_norm": {fp32},
-        "nn.functional.silu": {fp16, fp32},
+        "nn.functional.silu": {fp32},
         "softmax": {fp32},
         "log_softmax": {fp32},
     },
     "inductor_numerics": {
         "sigmoid": {fp32},
         "sub": {ALL},
-        "nn.functional.gelu": {fp32},
         "nn.functional.layer_norm": {fp32},
         "softmax": {fp32},
         "log_softmax": {fp32},
@@ -485,11 +606,10 @@ ROCM_BATCH_INVARIANCE_XFAILS = {
 
 ROCM_UNARY_NUMERICAL_XFAILS = {
     "inductor_default": {
-        "rsqrt": {bf16, fp32},
+        "exp": {fp32},
         "sigmoid": {fp32},
         "sin": {fp32},
         "tan": {fp32},
-        "tanh": {fp32},
     },
     "inductor_numerics": {
         "log10": {fp16, fp32},
@@ -551,34 +671,10 @@ FBCODE_XFAIL_DICTS = {
     "binary_numerical": FBCODE_BINARY_NUMERICAL_XFAILS,
 }
 
-ROCM_RELAXED_PROPERTY_CASES = {
-    "eager_equivalence": {
-        "inductor_default": {
-            "exp": {fp32},
-            "log1p": {fp32},
-            "rsqrt": {fp32},
-            "tanh": {fp32},
-        },
-    },
-    "unary_numerical": {
-        "inductor_default": {
-            "cos": {fp32},
-            "exp": {fp32},
-            "log1p": {fp16, fp32},
-        },
-        "inductor_numerics": {
-            "rsqrt": {bf16},
-        },
-    },
-}
-
 if TEST_WITH_ROCM and getRocmVersion() >= (7, 14):
-    # ROCm 7.14 fixes log10 strict numerics but still needs default-mode tolerance.
+    # ROCm 7.14 fixes log10 strict numerics; the dtype-aware baseline handles
+    # the remaining default-mode numerical difference.
     del ROCM_UNARY_NUMERICAL_XFAILS["inductor_numerics"]["log10"]
-    ROCM_RELAXED_PROPERTY_CASES["unary_numerical"]["inductor_default"]["log10"] = {
-        fp16,
-        fp32,
-    }
 
 
 def is_expected_failure(device_type, op_name, backend, test_type, dtype=None):
@@ -594,19 +690,6 @@ def is_expected_failure(device_type, op_name, backend, test_type, dtype=None):
         )
         xfails = xfails | fbcode_xfails
     return dtype in xfails or ALL in xfails
-
-
-def is_relaxed_property_case(device_type, op_name, backend, test_type, dtype=None):
-    """Return True for the narrow ROCm op/dtype cases that use numeric tolerance."""
-    if device_type != "cuda" or torch.version.hip is None:
-        return False
-
-    allowed = (
-        ROCM_RELAXED_PROPERTY_CASES.get(test_type, {})
-        .get(backend, {})
-        .get(op_name, set())
-    )
-    return dtype in allowed or ALL in allowed
 
 
 def compile_fn(fn, backend):
@@ -649,6 +732,29 @@ class TestOpInfoProperties(TestCase):
         except Exception:
             samples = list(op.sample_inputs(device, dtype, requires_grad=False))
         return samples
+
+    def _assert_compiled_matches_eager(
+        self, compiled, eager, dtype, test_type, backend, op_name
+    ):
+        """Assert bounded numerical parity while preserving structural checks."""
+        rtol, atol = _get_numerical_tolerances(dtype, test_type, backend, op_name)
+
+        def failure_message(message):
+            # ULP computation is diagnostic only and runs lazily on assertion failure.
+            diagnostics = _format_ulp_diagnostics(compiled, eager)
+            return f"{message}\n{diagnostics}" if diagnostics else message
+
+        # Preserve structure and dtype exactly; only finite floating-point values
+        # receive the bounded numerical envelope, while NaN payloads may differ.
+        self.assertEqual(
+            compiled,
+            eager,
+            rtol=rtol,
+            atol=atol,
+            equal_nan=True,
+            exact_dtype=True,
+            msg=failure_message,
+        )
 
     def _run_with_expected_failure(
         self, device_type, op_name, backend, test_type, dtype, test_fn
@@ -890,7 +996,7 @@ class TestOpInfoProperties(TestCase):
             torch.use_deterministic_algorithms(prev_deterministic)
 
     # =========================================================================
-    # Bitwise Equivalence with Eager Mode Tests
+    # Numerical Equivalence with Eager Mode Tests
     # =========================================================================
 
     @onlyCUDA
@@ -898,15 +1004,7 @@ class TestOpInfoProperties(TestCase):
     @ops(llm_ops, allowed_dtypes=DTYPES)
     @parametrize("backend", BACKENDS)
     def test_eager_equivalence(self, device, dtype, op, backend):
-        """Test bitwise equivalence with eager execution."""
-        if (
-            op.name == "nn.functional.gelu"
-            and dtype == torch.float32
-            and backend == "inductor_default"
-        ):
-            # Disabled due to CI failures; see
-            # https://github.com/pytorch/pytorch/issues/190242
-            self.skipTest("disabled due to CI failures; see #190242")
+        """Test bounded numerical equivalence with eager execution."""
         torch._dynamo.reset()
         device_type = torch.device(device).type
 
@@ -928,13 +1026,14 @@ class TestOpInfoProperties(TestCase):
                 compiled_fn = compile_fn(fn, backend)
                 compiled_out = compiled_fn(*args, **kwargs)
 
-                # Zero-tolerance equality unless this ROCm case needs numeric tolerance.
-                if is_relaxed_property_case(
-                    device_type, op.name, backend, "eager_equivalence", dtype
-                ):
-                    self.assertEqual(eager_out, compiled_out)
-                else:
-                    self.assertEqual(eager_out, compiled_out, rtol=0, atol=0)
+                self._assert_compiled_matches_eager(
+                    compiled_out,
+                    eager_out,
+                    dtype,
+                    "eager_equivalence",
+                    backend,
+                    op.name,
+                )
 
         self._run_with_expected_failure(
             device_type, op.name, backend, "eager_equivalence", dtype, run_test
@@ -954,7 +1053,7 @@ class TestOpInfoProperties(TestCase):
         For fp16 and bf16: exhaustively tests all 65536 possible bit patterns.
         For fp32: tests 64k sampled random bit patterns.
 
-        Verifies bitwise equivalence between eager and compiled execution.
+        Verifies bounded numerical equivalence between eager and compiled execution.
         """
         torch._dynamo.reset()
         device_type = torch.device(device).type
@@ -982,13 +1081,14 @@ class TestOpInfoProperties(TestCase):
         compiled_out = compiled_fn(test_values)
 
         def run_test():
-            # Zero-tolerance equality unless this ROCm case needs numeric tolerance.
-            if is_relaxed_property_case(
-                device_type, op.name, backend, "unary_numerical", dtype
-            ):
-                self.assertEqual(eager_out, compiled_out)
-            else:
-                self.assertEqual(eager_out, compiled_out, rtol=0, atol=0)
+            self._assert_compiled_matches_eager(
+                compiled_out,
+                eager_out,
+                dtype,
+                "unary_numerical",
+                backend,
+                op.name,
+            )
 
         self._run_with_expected_failure(
             device_type, op.name, backend, "unary_numerical", dtype, run_test
@@ -1008,7 +1108,7 @@ class TestOpInfoProperties(TestCase):
         For fp32: samples random 32-bit patterns.
         For fp16/bf16: samples from all possible 16-bit values.
 
-        Verifies bitwise equivalence between eager and compiled execution.
+        Verifies bounded numerical equivalence between eager and compiled execution.
         """
         torch._dynamo.reset()
         device_type = torch.device(device).type
@@ -1026,8 +1126,14 @@ class TestOpInfoProperties(TestCase):
         compiled_out = compiled_fn(x, y)
 
         def run_test():
-            # Zero-tolerance equality.
-            self.assertEqual(eager_out, compiled_out, rtol=0, atol=0)
+            self._assert_compiled_matches_eager(
+                compiled_out,
+                eager_out,
+                dtype,
+                "binary_numerical",
+                backend,
+                op.name,
+            )
 
         self._run_with_expected_failure(
             device_type, op.name, backend, "binary_numerical", dtype, run_test

--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -488,19 +488,17 @@ ROCM_NUMERICAL_TOLERANCE_OVERRIDES = {
 
 EAGER_EQUIV_XFAILS = {
     "aot_eager_decomp_partition": {
-        "nn.functional.gelu": {fp32},
         "nn.functional.layer_norm": {fp32},
         "nn.functional.rms_norm": {fp32},
         "softmax": {fp32},
         "log_softmax": {fp32},
     },
     "inductor_default": {
-        "reciprocal": {fp32},
         "remainder": {ALL},
         "sigmoid": {fp32},
         "nn.functional.gelu": {fp32},
         "nn.functional.layer_norm": {fp32},
-        "nn.functional.silu": {fp16, fp32},
+        "nn.functional.silu": {fp32},
         "softmax": {fp32},
         "log_softmax": {fp32},
     },
@@ -508,7 +506,6 @@ EAGER_EQUIV_XFAILS = {
         "remainder": {ALL},
         "sigmoid": {fp32},
         "sub": {ALL},
-        "nn.functional.gelu": {fp32},
         "nn.functional.layer_norm": {fp32},
         "softmax": {fp32},
         "log_softmax": {fp32},
@@ -534,7 +531,6 @@ UNARY_NUMERICAL_XFAILS = {
         "exp2": {bf16, fp32},
         "expm1": {bf16, fp32},
         "log1p": {fp32},
-        "reciprocal": {fp32},
         "rsqrt": {bf16, fp32},
         "sigmoid": {fp32},
         "sin": {fp32},

--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -483,7 +483,6 @@ ROCM_BATCH_INVARIANCE_XFAILS = {
 
 ROCM_UNARY_NUMERICAL_XFAILS = {
     "inductor_default": {
-        "rsqrt": {bf16, fp32},
         "sigmoid": {fp32},
         "sin": {fp32},
         "tan": {fp32},

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13235,8 +13235,6 @@ op_db: list[OpInfo] = [
                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_large',
                                     device_type='xpu',
                                     dtypes=(torch.chalf,), active_if=IS_WINDOWS),
-                       # https://github.com/pytorch/pytorch/issues/180058
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_unary_ufunc_numerical", dtypes=(torch.float32,)),
                    )),
     UnaryUfuncInfo('cosh',
                    ref=np_unary_ufunc_integer_promotion_wrapper(np.cosh),
@@ -13484,10 +13482,6 @@ op_db: list[OpInfo] = [
                                     device_type='cpu', dtypes=[torch.cfloat, torch.cdouble], active_if=IS_WINDOWS),
                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_large',
                                     device_type='xpu', dtypes=(torch.chalf,), active_if=IS_WINDOWS),
-                       # https://github.com/pytorch/pytorch/issues/180041
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float32,)),
-                       # https://github.com/pytorch/pytorch/issues/180061
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_unary_ufunc_numerical", dtypes=(torch.float32,)),
                    ),
                    assert_autodiffed=True,
                    supports_forward_ad=True,
@@ -13987,10 +13981,6 @@ op_db: list[OpInfo] = [
                    skips=(
                        # https://github.com/pytorch/pytorch/issues/180040
                        DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_determinism", dtypes=(torch.float32,)),
-                       # https://github.com/pytorch/pytorch/issues/180043
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float32,)),
-                       # https://github.com/pytorch/pytorch/issues/180419
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_unary_ufunc_numerical", dtypes=(torch.float16,)),
                    ),
     ),
     BinaryUfuncInfo('ge',
@@ -14228,13 +14218,6 @@ op_db: list[OpInfo] = [
                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                     device_type='cpu', dtypes=[torch.cfloat, torch.cdouble],
                                     active_if=IS_WINDOWS),
-                       # https://github.com/pytorch/pytorch/issues/180044
-                       # https://github.com/pytorch/pytorch/issues/180045
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float16, torch.float32)),
-                       # https://github.com/pytorch/pytorch/issues/179942
-                       # https://github.com/pytorch/pytorch/issues/180066
-                       # https://github.com/pytorch/pytorch/issues/180067
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_unary_ufunc_numerical"),
                    ),
                    # log(z)->-inf for |z|->0
                    reference_numerics_filter=NumericsFilter(condition=lambda x: torch.abs(x) < 0.1, safe_val=1)),
@@ -14252,8 +14235,6 @@ op_db: list[OpInfo] = [
                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                     device_type='cpu', dtypes=[torch.cfloat, torch.cdouble],
                                     active_if=IS_WINDOWS),
-                       # https://github.com/pytorch/pytorch/issues/180042
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float32,)),
                    ),
                    # log10(z)->-inf for |z|->0
                    reference_numerics_filter=NumericsFilter(condition=lambda x: torch.abs(x) < 0.1, safe_val=1)),
@@ -18716,8 +18697,6 @@ op_db: list[OpInfo] = [
                                     'TestSparseUnaryUfuncs', 'test_sparse_fn_grad'),
                        DecorateInfo(toleranceOverride({torch.complex64: tol(atol=3e-5, rtol=7e-6)}),
                                     "TestConsistency", "test_output_match", device_type="mps"),
-                       # https://github.com/pytorch/pytorch/issues/180057
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float32,)),
                    ),
                    # tan(j * pi/2 * odd_number) is nan
                    reference_numerics_filter=NumericsFilter(
@@ -18897,12 +18876,6 @@ op_db: list[OpInfo] = [
                        # Greatest relative difference: nan at index (700,) (up to 0.001 allowed)
                        DecorateInfo(unittest.expectedFailure, 'TestUnaryUfuncs', 'test_reference_numerics_large',
                                     dtypes=(torch.chalf,), device_type='cuda'),
-                       # https://github.com/pytorch/pytorch/issues/180055
-                       # https://github.com/pytorch/pytorch/issues/180056
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float32,)),
-                       # https://github.com/pytorch/pytorch/issues/179940
-                       # https://github.com/pytorch/pytorch/issues/180071
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_unary_ufunc_numerical", dtypes=(torch.bfloat16, torch.float32)),
                    )),
     UnaryUfuncInfo('sqrt',
                    ref=np.sqrt,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13206,8 +13206,6 @@ op_db: list[OpInfo] = [
                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_large',
                                     device_type='xpu',
                                     dtypes=(torch.chalf,), active_if=IS_WINDOWS),
-                       # https://github.com/pytorch/pytorch/issues/180058
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_unary_ufunc_numerical", dtypes=(torch.float32,)),
                    )),
     UnaryUfuncInfo('cosh',
                    ref=np_unary_ufunc_integer_promotion_wrapper(np.cosh),
@@ -13455,10 +13453,14 @@ op_db: list[OpInfo] = [
                                     device_type='cpu', dtypes=[torch.cfloat, torch.cdouble], active_if=IS_WINDOWS),
                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_large',
                                     device_type='xpu', dtypes=(torch.chalf,), active_if=IS_WINDOWS),
-                       # https://github.com/pytorch/pytorch/issues/180041
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float32,)),
                        # https://github.com/pytorch/pytorch/issues/180061
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_unary_ufunc_numerical", dtypes=(torch.float32,)),
+                       DecorateInfo(
+                           skipIfRocm,
+                           "TestOpInfoProperties",
+                           "test_unary_ufunc_numerical",
+                           dtypes=(torch.float32,),
+                           active_if=lambda kwargs: kwargs.get("backend") == "inductor_default",
+                       ),
                    ),
                    assert_autodiffed=True,
                    supports_forward_ad=True,
@@ -13952,11 +13954,13 @@ op_db: list[OpInfo] = [
                    promotes_int_to_float=True,
                    skips=(
                        # https://github.com/pytorch/pytorch/issues/180040
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_determinism", dtypes=(torch.float32,)),
-                       # https://github.com/pytorch/pytorch/issues/180043
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float32,)),
-                       # https://github.com/pytorch/pytorch/issues/180419
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_unary_ufunc_numerical", dtypes=(torch.float16,)),
+                       DecorateInfo(
+                           skipIfRocm,
+                           "TestOpInfoProperties",
+                           "test_determinism",
+                           dtypes=(torch.float32,),
+                           active_if=lambda kwargs: kwargs.get("backend") == "inductor_default",
+                       ),
                    ),
     ),
     BinaryUfuncInfo('ge',
@@ -14202,11 +14206,23 @@ op_db: list[OpInfo] = [
                                     active_if=IS_WINDOWS),
                        # https://github.com/pytorch/pytorch/issues/180044
                        # https://github.com/pytorch/pytorch/issues/180045
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float16, torch.float32)),
+                       DecorateInfo(
+                           skipIfRocm,
+                           "TestOpInfoProperties",
+                           "test_eager_equivalence",
+                           dtypes=(torch.float16, torch.float32),
+                           active_if=lambda kwargs: kwargs.get("backend") == "inductor_default",
+                       ),
                        # https://github.com/pytorch/pytorch/issues/179942
                        # https://github.com/pytorch/pytorch/issues/180066
                        # https://github.com/pytorch/pytorch/issues/180067
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_unary_ufunc_numerical"),
+                       DecorateInfo(
+                           skipIfRocm,
+                           "TestOpInfoProperties",
+                           "test_unary_ufunc_numerical",
+                           dtypes=(torch.float16, torch.float32),
+                           active_if=lambda kwargs: kwargs.get("backend") == "inductor_default",
+                       ),
                    ),
                    # log(z)->-inf for |z|->0
                    reference_numerics_filter=NumericsFilter(condition=lambda x: torch.abs(x) < 0.1, safe_val=1)),
@@ -14225,7 +14241,13 @@ op_db: list[OpInfo] = [
                                     device_type='cpu', dtypes=[torch.cfloat, torch.cdouble],
                                     active_if=IS_WINDOWS),
                        # https://github.com/pytorch/pytorch/issues/180042
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float32,)),
+                       DecorateInfo(
+                           skipIfRocm,
+                           "TestOpInfoProperties",
+                           "test_eager_equivalence",
+                           dtypes=(torch.float32,),
+                           active_if=lambda kwargs: kwargs.get("backend") == "inductor_default",
+                       ),
                    ),
                    # log10(z)->-inf for |z|->0
                    reference_numerics_filter=NumericsFilter(condition=lambda x: torch.abs(x) < 0.1, safe_val=1)),
@@ -18673,8 +18695,6 @@ op_db: list[OpInfo] = [
                                     'TestSparseUnaryUfuncs', 'test_sparse_fn_grad'),
                        DecorateInfo(toleranceOverride({torch.complex64: tol(atol=3e-5, rtol=7e-6)}),
                                     "TestConsistency", "test_output_match", device_type="mps"),
-                       # https://github.com/pytorch/pytorch/issues/180057
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float32,)),
                    ),
                    # tan(j * pi/2 * odd_number) is nan
                    reference_numerics_filter=NumericsFilter(
@@ -18856,10 +18876,23 @@ op_db: list[OpInfo] = [
                                     dtypes=(torch.chalf,), device_type='cuda'),
                        # https://github.com/pytorch/pytorch/issues/180055
                        # https://github.com/pytorch/pytorch/issues/180056
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_eager_equivalence", dtypes=(torch.float32,)),
+                       DecorateInfo(
+                           skipIfRocm,
+                           "TestOpInfoProperties",
+                           "test_eager_equivalence",
+                           dtypes=(torch.float32,),
+                           active_if=lambda kwargs: kwargs.get("backend") == "inductor_numerics",
+                       ),
                        # https://github.com/pytorch/pytorch/issues/179940
                        # https://github.com/pytorch/pytorch/issues/180071
-                       DecorateInfo(skipIfRocm, "TestOpInfoProperties", "test_unary_ufunc_numerical", dtypes=(torch.bfloat16, torch.float32)),
+                       DecorateInfo(
+                           skipIfRocm,
+                           "TestOpInfoProperties",
+                           "test_unary_ufunc_numerical",
+                           dtypes=(torch.float32,),
+                           active_if=lambda kwargs: kwargs.get("backend")
+                           in ("inductor_default", "inductor_numerics"),
+                       ),
                    )),
     UnaryUfuncInfo('sqrt',
                    ref=np.sqrt,


### PR DESCRIPTION
## Summary
- replace bitwise eager-vs-compiled assertions in the eager-equivalence, unary-numerical, and binary-numerical property families with a tight dtype-aware baseline: `rtol = finfo.eps` and `atol = finfo.smallest_normal * finfo.eps`
- preserve exact output structure and dtype, equal-NaN handling, and the bitwise contracts for batch invariance and determinism
- add failure-only ULP diagnostics plus four narrowly scoped ROCm two-epsilon overrides for cases measured at two ULP on MI250X; keep larger differences as explicit XFAILs
- remove obsolete broad `skipIfRocm` decorators so passing backend/dtype combinations execute
- improve CUDA coverage as well: five combinations now pass under the bounded policy, so remove or narrow their stale XFAIL entries observed on CUDA 13.0 and 13.2 Jammy runners

This treats eager as the parity reference, not as a correctly rounded mathematical oracle, and follows the incremental test-design direction in [#188670](https://github.com/pytorch/pytorch/issues/188670).

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben