### PR TITLE
[dcp] Fix async checkpoint memory retention by releasing staged data on the caller thread

### DIFF
--- a/test/distributed/checkpoint/test_async_executor.py
+++ b/test/distributed/checkpoint/test_async_executor.py
@@ -1,0 +1,90 @@
+# Owner(s): ["oncall: distributed checkpointing"]
+
+import os
+import tempfile
+import threading
+import weakref
+from unittest.mock import patch
+
+import torch
+from torch.distributed.checkpoint._async_executor import _OwnedStateDictFuture
+from torch.distributed.checkpoint._async_thread_executor import (
+    _ThreadBasedAsyncCheckpointExecutor,
+)
+from torch.distributed.checkpoint.state_dict_saver import async_save
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class _Payload:
+    pass
+
+
+class TestOwnedStateDictFuture(TestCase):
+    def test_result_releases_state_dict_on_caller(self) -> None:
+        save_started = threading.Event()
+        allow_save = threading.Event()
+        callback_started = threading.Event()
+        allow_callback = threading.Event()
+        release_threads = []
+        cleanup_threads = []
+
+        payload = _Payload()
+        payload_ref = weakref.ref(payload)
+        weakref.finalize(
+            payload,
+            lambda: release_threads.append(threading.current_thread().name),
+        )
+        cache = {"payload": payload}
+
+        def cleanup() -> None:
+            cleanup_threads.append(threading.current_thread().name)
+            cache.clear()
+
+        def fake_save(state_dict, **kwargs):
+            save_started.set()
+            self.assertTrue(allow_save.wait(5))
+            return "saved"
+
+        future = _OwnedStateDictFuture({"payload": payload}, cleanup)
+        del payload
+        executor = _ThreadBasedAsyncCheckpointExecutor()
+
+        with patch(
+            "torch.distributed.checkpoint.state_dict_saver.save",
+            new=fake_save,
+        ):
+            self.assertIs(executor.execute_save(future), future)
+            self.assertTrue(save_started.wait(5))
+
+            def block_worker(completed_future):
+                callback_started.set()
+                allow_callback.wait(5)
+
+            future.add_done_callback(block_worker)
+            allow_save.set()
+            self.assertTrue(callback_started.wait(5))
+            try:
+                self.assertEqual(future.result(timeout=5), "saved")
+            finally:
+                allow_callback.set()
+
+        caller_thread = threading.current_thread().name
+        self.assertEqual(len(cleanup_threads), 1)
+        self.assertTrue(cleanup_threads[0].startswith("AsyncCheckpointExecutor"))
+        self.assertEqual(release_threads, [caller_thread])
+        self.assertIsNone(payload_ref())
+
+    def test_async_save_uses_owned_state_dict_future(self) -> None:
+        with tempfile.TemporaryDirectory() as checkpoint_dir:
+            future = async_save(
+                {"value": torch.ones(2)},
+                checkpoint_id=os.path.join(checkpoint_dir, "checkpoint"),
+                no_dist=True,
+            )
+            self.assertIsInstance(future, _OwnedStateDictFuture)
+            self.assertIsNotNone(future.result(timeout=30))
+            self.assertIsNone(future._state_dict)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/checkpoint/_async_executor.py
+++ b/torch/distributed/checkpoint/_async_executor.py
@@ -1,8 +1,13 @@
 # pyre-strict
 # mypy: allow-untyped-defs
 import abc
+import logging
 import os
+import threading
+import traceback
+from collections.abc import Callable
 from concurrent.futures import Future
+from typing import Any
 
 import torch.distributed as dist
 from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE
@@ -10,11 +15,83 @@ from torch.distributed.checkpoint.planner import SavePlanner
 from torch.distributed.checkpoint.storage import StorageWriter
 
 
+logger = logging.getLogger(__name__)
+
+
+class _OwnedStateDictFuture(Future[Any]):
+    def __init__(
+        self,
+        state_dict: STATE_DICT_TYPE,
+        cleanup: Callable[[], None],
+    ) -> None:
+        super().__init__()
+        self._state_dict: STATE_DICT_TYPE | None = state_dict
+        self._cleanup: Callable[[], None] | None = cleanup
+        self._release_lock = threading.Lock()
+
+    def run(self, save_fn: Callable[..., Any]) -> None:
+        if not self.set_running_or_notify_cancel():
+            return
+
+        state_dict = self._state_dict
+        if state_dict is None:
+            raise AssertionError("staged state dictionary was released before save")
+        try:
+            result = save_fn(staging_future_or_state_dict=state_dict)
+        except BaseException as error:
+            state_dict = None
+            traceback.clear_frames(error.__traceback__)
+            self._close()
+            self.set_exception(error)
+            return
+        state_dict = None
+        self._close()
+        self.set_result(result)
+
+    def _close(self) -> None:
+        with self._release_lock:
+            cleanup = self._cleanup
+            self._cleanup = None
+        try:
+            if cleanup is not None:
+                cleanup()
+        except Exception:
+            logger.exception("Failed to close internally owned async stager")
+
+    def _release(self) -> None:
+        with self._release_lock:
+            self._state_dict = None
+
+    def cancel(self) -> bool:
+        cancelled = super().cancel()
+        if cancelled:
+            self._close()
+            self._release()
+        return cancelled
+
+    def result(self, timeout: float | None = None) -> Any:
+        try:
+            return super().result(timeout)
+        finally:
+            if self.done():
+                self._release()
+
+    def exception(self, timeout: float | None = None) -> BaseException | None:
+        try:
+            return super().exception(timeout)
+        finally:
+            if self.done():
+                self._release()
+
+
+_STAGING_INPUT = STATE_DICT_TYPE | Future[STATE_DICT_TYPE] | _OwnedStateDictFuture
+
+
 class _AsyncCheckpointExecutor(abc.ABC):
     @abc.abstractmethod
     def execute_save(
         self,
-        staging_future_or_state_dict: STATE_DICT_TYPE | Future[STATE_DICT_TYPE],
+        staging_future_or_state_dict: _STAGING_INPUT,
         *,
         checkpoint_id: str | os.PathLike | None = None,
         storage_writer: StorageWriter | None = None,

--- a/torch/distributed/checkpoint/_async_process_executor.py
+++ b/torch/distributed/checkpoint/_async_process_executor.py
@@ -6,13 +6,18 @@ import os
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum
+from functools import partial
 from typing import Any
 from uuid import uuid4
 
 import torch.distributed as dist
 import torch.multiprocessing as mp
 from torch.distributed import PrefixStore, TCPStore
-from torch.distributed.checkpoint._async_executor import _AsyncCheckpointExecutor
+from torch.distributed.checkpoint._async_executor import (
+    _AsyncCheckpointExecutor,
+    _OwnedStateDictFuture,
+    _STAGING_INPUT,
+)
 from torch.distributed.checkpoint.logger import _dcp_method_logger, _init_logger
 from torch.distributed.checkpoint.metadata import Metadata, STATE_DICT_TYPE
 from torch.distributed.checkpoint.planner import SavePlanner
@@ -360,7 +365,7 @@ class _ProcessBasedAsyncCheckpointExecutor(_AsyncCheckpointExecutor):
     def _execute_save_impl(
         *,
         pg_init_info: _ProcessGroupInitInfo | None,
-        staging_future_or_state_dict: Future[STATE_DICT_TYPE] | STATE_DICT_TYPE,
+        staging_future_or_state_dict: _STAGING_INPUT,
         checkpoint_id: str | os.PathLike | None = None,
         storage_writer: StorageWriter | None = None,
         planner: SavePlanner | None = None,
@@ -407,7 +412,7 @@ class _ProcessBasedAsyncCheckpointExecutor(_AsyncCheckpointExecutor):
 
     def execute_save(
         self,
-        staging_future_or_state_dict: Future[STATE_DICT_TYPE] | STATE_DICT_TYPE,
+        staging_future_or_state_dict: _STAGING_INPUT,
         *,
         checkpoint_id: str | os.PathLike | None = None,
         storage_writer: StorageWriter | None = None,
@@ -438,16 +443,23 @@ class _ProcessBasedAsyncCheckpointExecutor(_AsyncCheckpointExecutor):
             # to all ranks.
             pg_init_info = _ProcessGroupInitInfo(process_group)
 
-        f: Future = self._executor.submit(
+        save_fn = partial(
             self._execute_save_impl,
             pg_init_info=pg_init_info,
-            staging_future_or_state_dict=staging_future_or_state_dict,
             checkpoint_id=checkpoint_id,
             storage_writer=storage_writer,
             planner=planner,
             no_dist=no_dist,
             use_collectives=use_collectives,
         )
-        f.add_done_callback(lambda f: self._executor.shutdown(wait=False))
-
-        return f
+        if isinstance(staging_future_or_state_dict, _OwnedStateDictFuture):
+            future = staging_future_or_state_dict
+            work = self._executor.submit(future.run, save_fn)
+        else:
+            future = self._executor.submit(
+                save_fn,
+                staging_future_or_state_dict=staging_future_or_state_dict,
+            )
+            work = future
+        work.add_done_callback(lambda _: self._executor.shutdown(wait=False))
+        return future

--- a/torch/distributed/checkpoint/_async_thread_executor.py
+++ b/torch/distributed/checkpoint/_async_thread_executor.py
@@ -2,9 +2,14 @@
 # mypy: allow-untyped-defs
 import os
 from concurrent.futures import Future, ThreadPoolExecutor
+from functools import partial
 
 import torch.distributed as dist
-from torch.distributed.checkpoint._async_executor import _AsyncCheckpointExecutor
+from torch.distributed.checkpoint._async_executor import (
+    _AsyncCheckpointExecutor,
+    _OwnedStateDictFuture,
+    _STAGING_INPUT,
+)
 from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE
 from torch.distributed.checkpoint.planner import SavePlanner
 from torch.distributed.checkpoint.storage import StorageWriter
@@ -46,7 +51,7 @@ class _ThreadBasedAsyncCheckpointExecutor(_AsyncCheckpointExecutor):
 
     def execute_save(
         self,
-        staging_future_or_state_dict: Future[STATE_DICT_TYPE] | STATE_DICT_TYPE,
+        staging_future_or_state_dict: _STAGING_INPUT,
         *,
         checkpoint_id: str | os.PathLike | None = None,
         storage_writer: StorageWriter | None = None,
@@ -55,9 +60,8 @@ class _ThreadBasedAsyncCheckpointExecutor(_AsyncCheckpointExecutor):
         no_dist: bool = False,
         use_collectives: bool = True,
     ) -> Future:
-        f: Future = self._executor.submit(
+        save_fn = partial(
             save_wrapper,
-            staging_future_or_state_dict=staging_future_or_state_dict,
             checkpoint_id=checkpoint_id,
             storage_writer=storage_writer,
             planner=planner,
@@ -65,6 +69,14 @@ class _ThreadBasedAsyncCheckpointExecutor(_AsyncCheckpointExecutor):
             no_dist=no_dist,
             use_collectives=use_collectives,
         )
-        f.add_done_callback(lambda f: self._executor.shutdown(wait=False))
-
-        return f
+        if isinstance(staging_future_or_state_dict, _OwnedStateDictFuture):
+            future = staging_future_or_state_dict
+            work = self._executor.submit(future.run, save_fn)
+        else:
+            future = self._executor.submit(
+                save_fn,
+                staging_future_or_state_dict=staging_future_or_state_dict,
+            )
+            work = future
+        work.add_done_callback(lambda _: self._executor.shutdown(wait=False))
+        return future

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -7,12 +7,16 @@ import warnings
 from concurrent.futures import Future
 from dataclasses import dataclass
 from enum import Enum
-from typing import cast, TYPE_CHECKING
+from typing import cast
 from typing_extensions import deprecated
 
 import torch
 import torch.distributed as dist
 from torch.distributed._state_dict_utils import STATE_DICT_TYPE
+from torch.distributed.checkpoint._async_executor import (
+    _AsyncCheckpointExecutor,
+    _OwnedStateDictFuture,
+)
 from torch.distributed.checkpoint._async_process_executor import (
     _ProcessBasedAsyncCheckpointExecutor,
 )
@@ -34,10 +38,6 @@ from torch.distributed.checkpoint.storage import StorageWriter, WriteResult
 from torch.distributed.distributed_c10d import _get_default_group
 
 from .utils import _api_bc_check, _DistWrapper, _profile
-
-
-if TYPE_CHECKING:
-    from torch.distributed.checkpoint._async_executor import _AsyncCheckpointExecutor
 
 
 __all__ = [
@@ -275,6 +275,8 @@ def async_save(
 
     Returns:
         Future: A future holding the resultant Metadata object from `save`.
+        Calling `result()` or `exception()` releases buffers owned by the
+        default stager.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -346,8 +348,19 @@ def async_save(
             else _ThreadBasedAsyncCheckpointExecutor()
         )
 
+        upload_input = staging_future_or_state_dict
+        if owned_async_stager is not None:
+            if isinstance(staging_future_or_state_dict, Future):
+                raise AssertionError(
+                    "internally owned default stager must stage synchronously"
+                )
+            upload_input = _OwnedStateDictFuture(
+                staging_future_or_state_dict,
+                cleanup=maybe_close_owned_async_stager,
+            )
+
         upload_future: Future = upload_executor.execute_save(
-            staging_future_or_state_dict,
+            upload_input,
             checkpoint_id=checkpoint_id,
             storage_writer=storage_writer,
             planner=planner,
@@ -357,7 +370,6 @@ def async_save(
         )
 
         if owned_async_stager is not None:
-            upload_future.add_done_callback(lambda _: maybe_close_owned_async_stager())
             # in the success path transfer cleanup ownership to the upload future
             stack.pop_all()
 


### PR DESCRIPTION
This PR fixes the [TestDTensorStateDictStager.test_async_save_no_memory_leak](https://github.com/pytorch/pytorch/blob/2d1925b5057e633e0ed134bdfc279c193332beb6/test/distributed/checkpoint/test_state_dict_stager.py#L912-L948) [GB200 failure](https://github.com/pytorch/pytorch/issues/187996), where CPU buffers are created on the caller thread but their final reference can be released by the upload worker, causing AArch64’s memory allocator to retain about one buffer per save. 

Unlike the previous fix attempt in [PR #188434](https://github.com/pytorch/pytorch/pull/188434), which relies on a finalizer that may still run on the worker, this change makes the returned Future own the staged data, requires the worker to drop its reference before completion, and releases the data when the caller consumes the result. 

The original test failed 3/3 times with 662–680 MiB growth on GB200, while this fix passed 3/3 times with at most 9.2 MiB growth.

Collaborated with Codex.