### PR TITLE
[TorchElastic] handle EADDRINUSE message of libuv

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -393,7 +393,7 @@ class TCPStoreTest(TestCase, StoreTestBase):
         addr = DEFAULT_HOSTNAME
         port = common.find_free_port()
 
-        err_msg_reg = f"^The server socket has failed to listen on any local .*{ADDRESS_IN_USE}"
+        err_msg_reg = "^The server socket has failed to listen on any local .*(?i:address already in use)"
         with self.assertRaisesRegex(dist.DistNetworkError, err_msg_reg):
             # Use noqa to silence flake8.
             # Need to store in an unused variable here to ensure the first

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -393,7 +393,7 @@ class TCPStoreTest(TestCase, StoreTestBase):
         addr = DEFAULT_HOSTNAME
         port = common.find_free_port()
 
-        err_msg_reg = f"^The server socket has failed to listen on any local .*{port}"
+        err_msg_reg = f"^The server socket has failed to listen on any local .*{ADDRESS_IN_USE}"
         with self.assertRaisesRegex(dist.DistNetworkError, err_msg_reg):
             # Use noqa to silence flake8.
             # Need to store in an unused variable here to ensure the first

--- a/torch/distributed/elastic/utils/distributed.py
+++ b/torch/distributed/elastic/utils/distributed.py
@@ -20,7 +20,7 @@ __all__ = ["create_c10d_store", "get_free_port", "get_socket_with_port"]
 
 logger = get_logger(__name__)
 
-_ADDRESS_IN_USE = "Address already in use"
+_ADDRESS_IN_USE = "address already in use"
 _SOCKET_TIMEOUT = "Socket Timeout"
 
 _TCP_STORE_INIT = "_tcp_store/num_members"
@@ -91,13 +91,8 @@ def create_c10d_store(
                 _check_full_rank(store, world_size, timeout=timeout)
             logger.info("Successfully created c10d store")
             return store
-        except RuntimeError as e:
-            # this is brittle, but the underlying exception type is not properly pybinded
-            # so we parse the error msg for now, interestingly this is how torch itself
-            # detects timeouts and port conflicts in their own unittests
-            # see - caffe2/torch/testing/_internal/common_utils.py
-            # TODO properly map the exceptions in pybind (c10d/init.cpp)
-            if _ADDRESS_IN_USE[1:] in str(e):  # this will only happen on the server
+        except dist.DistNetworkError as e:
+            if _ADDRESS_IN_USE in str(e).lower():  # this will only happen on the server
                 if attempt < retries:
                     logger.warning(
                         "port: %s already in use, attempt: [%s/%s]",
@@ -107,7 +102,7 @@ def create_c10d_store(
                     )
                     attempt += 1
                 else:
-                    raise RuntimeError(
+                    raise dist.DistNetworkError(
                         f"on {server_addr}, port: {port} already in use"
                     ) from e
             else:

--- a/torch/distributed/elastic/utils/distributed.py
+++ b/torch/distributed/elastic/utils/distributed.py
@@ -97,7 +97,7 @@ def create_c10d_store(
             # detects timeouts and port conflicts in their own unittests
             # see - caffe2/torch/testing/_internal/common_utils.py
             # TODO properly map the exceptions in pybind (c10d/init.cpp)
-            if str(e) == _ADDRESS_IN_USE:  # this will only happen on the server
+            if _ADDRESS_IN_USE[1:] in str(e):  # this will only happen on the server
                 if attempt < retries:
                     logger.warning(
                         "port: %s already in use, attempt: [%s/%s]",

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5279,7 +5279,7 @@ def find_free_port():
         return port
 
 # Errors that we can get in c10d initialization for which we should retry tests for.
-ADDRESS_IN_USE = "ddress already in use"
+ADDRESS_IN_USE = "address already in use"
 CONNECT_TIMEOUT = "connect() timed out."
 
 def retry_on_connect_failures(func=None, connect_errors=(ADDRESS_IN_USE)):
@@ -5297,7 +5297,7 @@ def retry_on_connect_failures(func=None, connect_errors=(ADDRESS_IN_USE)):
             try:
                 return func(*args, **kwargs)
             except RuntimeError as error:
-                if any(connect_error in str(error) for connect_error in connect_errors):
+                if any(ce in str(error) or ce in str(error).lower() for ce in connect_errors):
                     tries_remaining -= 1
                     if tries_remaining == 0:
                         raise RuntimeError(f"Failing after {n_retries} retries with error: {str(error)}") from error

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5279,7 +5279,7 @@ def find_free_port():
         return port
 
 # Errors that we can get in c10d initialization for which we should retry tests for.
-ADDRESS_IN_USE = "Address already in use"
+ADDRESS_IN_USE = "ddress already in use"
 CONNECT_TIMEOUT = "connect() timed out."
 
 def retry_on_connect_failures(func=None, connect_errors=(ADDRESS_IN_USE)):


### PR DESCRIPTION
The libuv TCPStore backend reports EADDRINUSE as `address already in use`, while the existing handling expects `Address already in use`. Normalize matching so both forms are handled, update regression coverage, and preserve `DistNetworkError` after retry exhaustion.

Fixes https://github.com/pytorch/pytorch/issues/191560

Test plan:
- `uvx --python 3.10 --managed-python lintrunner@0.12.7 --skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT,PYREFLY test/distributed/elastic/utils/distributed_test.py test/distributed/test_store.py torch/distributed/elastic/utils/distributed.py torch/testing/_internal/common_utils.py`
- CPU-only distributed build with `BUILD_TEST=0`, `USE_DISTRIBUTED=1`, and `USE_CUDA=0`
- `uv run --active --python 3.13 --managed-python --no-sync python test/distributed/elastic/utils/distributed_test.py`
- `uv run --active --python 3.13 --managed-python --no-sync python test/distributed/test_store.py -k test_address_already_in_use`