### PR TITLE
[Inductor][auto-TMA] Wire auto-TMA into Inductor fused kernel compilation (#191569)

### DIFF
--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import torch
+import torch._dynamo
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor.codecache import PyCodeCache
 from torch._inductor.runtime import triton_helpers
@@ -92,7 +93,9 @@ class TestStaticTritonLauncherUnit(TestCase):
         import types
 
         class FakeFastLauncher:
-            def __init__(self, func, num_warps, shared, arg_tys, n_scratch):
+            def __init__(
+                self, func, num_warps, shared, arg_tys, n_scratch, recipes=None
+            ):
                 self.func = func
 
         kernel = object.__new__(StaticallyLaunchedCudaKernel)
@@ -152,6 +155,55 @@ class TestStaticTritonLauncherUnit(TestCase):
         autotuner, result = self._autotuner_with_static_cubin(b"cubin")
         autotuner.prepare_for_caching()
         self.assertEqual(result.kernel.cubin_raw, b"cubin")
+
+    def test_auto_tma_recipes_stored_from_metadata(self):
+        """Verify auto_tma_recipes are picked up from kernel.metadata."""
+        recipe = {
+            "base_ptr_arg_index": 0,
+            "shape_arg_indices": [2],
+            "stride_arg_indices": [-1],
+            "block_shape": [64],
+            "swizzle": -1,
+            "elem_type": 7,  # CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+            "elem_size": 4,
+            "fp4_padded": 0,
+            "fill_mode": 0,
+        }
+
+        launcher = object.__new__(StaticallyLaunchedCudaKernel)
+        launcher.auto_tma_recipes = []
+        # Simulate what __init__ does for auto_tma_recipes
+        kernel = SimpleNamespace(metadata=SimpleNamespace(auto_tma_recipes=[recipe]))
+        if hasattr(kernel, "metadata"):
+            recipes = getattr(kernel.metadata, "auto_tma_recipes", None)
+            if recipes:
+                launcher.auto_tma_recipes = list(recipes)
+
+        self.assertEqual(len(launcher.auto_tma_recipes), 1)
+        self.assertEqual(launcher.auto_tma_recipes[0]["base_ptr_arg_index"], 0)
+        self.assertEqual(launcher.auto_tma_recipes[0]["block_shape"], [64])
+
+    def test_auto_tma_recipes_empty_when_absent(self):
+        """Verify auto_tma_recipes defaults to [] when metadata lacks the field."""
+        launcher = object.__new__(StaticallyLaunchedCudaKernel)
+        launcher.auto_tma_recipes = []
+        kernel = SimpleNamespace(metadata=SimpleNamespace())
+        if hasattr(kernel, "metadata"):
+            recipes = getattr(kernel.metadata, "auto_tma_recipes", None)
+            if recipes:
+                launcher.auto_tma_recipes = list(recipes)
+
+        self.assertEqual(launcher.auto_tma_recipes, [])
+
+    def test_launch_kernel_tma_method_exists(self):
+        """Verify _StaticCudaLauncher exposes _launch_kernel_tma."""
+        try:
+            from torch._C import _StaticCudaLauncher
+        except ImportError:
+            self.skipTest("_StaticCudaLauncher not available (no CUDA)")
+
+        self.assertTrue(hasattr(_StaticCudaLauncher, "_launch_kernel_tma"))
+        self.assertTrue(callable(_StaticCudaLauncher._launch_kernel_tma))
 
 
 @requires_gpu_and_triton
@@ -590,6 +642,195 @@ def kernel_many_args(out_tensor, {decl}):
         self.assertIsNone(owner_ref())
         self.assertEqual(unloaded_modules, [0xC0FFEE])
 
+    @skipIfRocm
+    @skipIfXpu
+    def test_auto_tma_recipe_launch_static(self):
+        """Verify _launch_kernel_tma correctly launches a kernel with a TMA recipe.
+
+        Compiles a 1D copy kernel, crafts a recipe that makes the launcher build
+        a CUtensorMap for the input pointer, and checks that the kernel produces
+        the correct output.
+        """
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        cap = torch.cuda.get_device_capability()
+        if cap < (9, 0):
+            self.skipTest(f"TMA requires sm_90+, got sm_{cap[0]}{cap[1]}")
+
+        @triton.jit
+        def copy_kernel(src, dst, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(src + offsets, mask=mask)
+            tl.store(dst + offsets, x, mask=mask)
+
+        N = 64
+        src = torch.randn(N, device="cuda")
+        dst = torch.zeros(N, device="cuda")
+        compiled = copy_kernel[(1,)](src, dst, N, BLOCK_SIZE=64)
+        launcher = self._make_launcher(compiled)
+
+        # Build a recipe for the src pointer (arg index 0)
+        # Shape = n_elements (arg index 2), contiguous stride (= -1)
+        recipe = {
+            "base_ptr_arg_index": 0,
+            "shape_arg_indices": [2],
+            "stride_arg_indices": [-1],
+            "block_shape": [64],
+            "swizzle": -1,
+            "elem_type": 7,  # CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+            "elem_size": 4,
+            "fp4_padded": 0,
+            "fill_mode": 0,
+        }
+
+        # Inject recipe and test the TMA launch path
+        launcher.auto_tma_recipes = [recipe]
+
+        new_src = torch.randn(N, device="cuda")
+        new_dst = torch.zeros(N, device="cuda")
+        device_interface = get_interface_for_device("cuda")
+        stream = device_interface.get_raw_stream(device_interface.current_device())
+
+        # The auto-TMA path passes user args only + recipes + nScratch to C++
+        n_scratch = int(launcher.has_global_scratch) + int(launcher.has_profile_scratch)
+        launcher.C_impl._launch_kernel_tma(
+            launcher.function,
+            1,  # grid_x
+            1,  # grid_y
+            1,  # grid_z
+            launcher.num_warps,
+            launcher.shared,
+            launcher.arg_tys,
+            (new_src, new_dst, N),
+            stream,
+            [recipe],
+            n_scratch,
+        )
+        self.assertEqual(new_dst, new_src)
+
+    @skipIfRocm
+    @skipIfXpu
+    def test_auto_tma_recipe_launch_via_run(self):
+        """Verify run() routes through the auto-TMA path when recipes present."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        cap = torch.cuda.get_device_capability()
+        if cap < (9, 0):
+            self.skipTest(f"TMA requires sm_90+, got sm_{cap[0]}{cap[1]}")
+
+        @triton.jit
+        def copy_kernel(src, dst, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(src + offsets, mask=mask)
+            tl.store(dst + offsets, x, mask=mask)
+
+        N = 64
+        src = torch.randn(N, device="cuda")
+        dst = torch.zeros(N, device="cuda")
+        compiled = copy_kernel[(1,)](src, dst, N, BLOCK_SIZE=64)
+        launcher = self._make_launcher(compiled)
+
+        recipe = {
+            "base_ptr_arg_index": 0,
+            "shape_arg_indices": [2],
+            "stride_arg_indices": [-1],
+            "block_shape": [64],
+            "swizzle": -1,
+            "elem_type": 7,  # CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+            "elem_size": 4,
+            "fp4_padded": 0,
+            "fill_mode": 0,
+        }
+        launcher.auto_tma_recipes = [recipe]
+
+        new_src = torch.randn(N, device="cuda")
+        new_dst = torch.zeros(N, device="cuda")
+        device_interface = get_interface_for_device("cuda")
+        stream = device_interface.get_raw_stream(device_interface.current_device())
+
+        # run() should detect auto_tma_recipes and route to _launch_kernel_tma
+        launcher.run(1, 1, 1, stream, new_src, new_dst, N)
+        self.assertEqual(new_dst, new_src)
+
+    @skipIfRocm
+    @skipIfXpu
+    def test_auto_tma_recipe_2d(self):
+        """Verify 2D TMA recipe (e.g. GEMM tile) constructs correctly."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        cap = torch.cuda.get_device_capability()
+        if cap < (9, 0):
+            self.skipTest(f"TMA requires sm_90+, got sm_{cap[0]}{cap[1]}")
+
+        # A kernel that copies a 2D tile: src[M, N] -> dst[M, N]
+        # arg layout: (src, dst, M, N, stride_m)
+        @triton.jit
+        def copy_2d_kernel(
+            src,
+            dst,
+            M,
+            N,
+            stride_m,
+            BLOCK_M: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            pid_m = tl.program_id(0)
+            pid_n = tl.program_id(1)
+            offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+            offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+            mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+            ptrs = src + offs_m[:, None] * stride_m + offs_n[None, :]
+            x = tl.load(ptrs, mask=mask)
+            out_ptrs = dst + offs_m[:, None] * stride_m + offs_n[None, :]
+            tl.store(out_ptrs, x, mask=mask)
+
+        M, N = 32, 64
+        src = torch.randn(M, N, device="cuda")
+        dst = torch.zeros(M, N, device="cuda")
+        compiled = copy_2d_kernel[(1, 1)](
+            src, dst, M, N, src.stride(0), BLOCK_M=32, BLOCK_N=64
+        )
+        launcher = self._make_launcher(compiled)
+
+        # 2D recipe for the src pointer (arg 0)
+        # shape: [M(arg 2), N(arg 3)], stride: [stride_m(arg 4), contiguous(-1)]
+        recipe = {
+            "base_ptr_arg_index": 0,
+            "shape_arg_indices": [2, 3],
+            "stride_arg_indices": [4, -1],
+            "block_shape": [32, 64],
+            "swizzle": -1,
+            "elem_type": 7,  # CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+            "elem_size": 4,
+            "fp4_padded": 0,
+            "fill_mode": 0,
+        }
+
+        new_src = torch.randn(M, N, device="cuda")
+        new_dst = torch.zeros(M, N, device="cuda")
+        device_interface = get_interface_for_device("cuda")
+        stream = device_interface.get_raw_stream(device_interface.current_device())
+
+        n_scratch = int(launcher.has_global_scratch) + int(launcher.has_profile_scratch)
+        launcher.C_impl._launch_kernel_tma(
+            launcher.function,
+            1,
+            1,
+            1,
+            launcher.num_warps,
+            launcher.shared,
+            launcher.arg_tys,
+            (new_src, new_dst, M, N, new_src.stride(0)),
+            stream,
+            [recipe],
+            n_scratch,
+        )
+        self.assertEqual(new_dst, new_src)
+
 
 @requires_gpu_and_triton
 @torch._inductor.config.patch(
@@ -727,6 +968,201 @@ class TestStaticTritonCompileResult(TestCase):
                 mocked.assert_not_called()
 
             self.assertEqual(result, torch.cat(((x * 4), y + 10)))
+
+
+@requires_gpu_and_triton
+@torch._inductor.config.patch(
+    {"use_static_triton_launcher": True, "strict_static_triton_launcher": True}
+)
+@skipIfRocm
+@skipIfXpu
+class TestAutoTmaE2E(TestCase):
+    """E2E tests: TRITON_AUTO_TMA=1 → torch.compile → inductor static launcher."""
+
+    def test_auto_tma_pointwise(self):
+        """Verify auto-TMA works end-to-end with torch.compile on a pointwise op."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        cap = torch.cuda.get_device_capability()
+        if cap < (9, 0):
+            self.skipTest(f"TMA requires sm_90+, got sm_{cap[0]}{cap[1]}")
+
+        torch._dynamo.reset()
+
+        @torch.compile
+        def foo(x, y):
+            return x + y
+
+        x = torch.randn(1024, device="cuda")
+        y = torch.randn(1024, device="cuda")
+
+        with mock.patch.dict(os.environ, {"TRITON_AUTO_TMA": "1"}):
+            result = foo(x, y)
+
+        self.assertEqual(result, x + y)
+
+    def test_auto_tma_elementwise_chain(self):
+        """Verify auto-TMA with a multi-op elementwise chain."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        cap = torch.cuda.get_device_capability()
+        if cap < (9, 0):
+            self.skipTest(f"TMA requires sm_90+, got sm_{cap[0]}{cap[1]}")
+
+        torch._dynamo.reset()
+
+        @torch.compile
+        def foo(x, y):
+            return (x * 2 + y) * 3
+
+        x = torch.randn(2048, device="cuda")
+        y = torch.randn(2048, device="cuda")
+
+        with mock.patch.dict(os.environ, {"TRITON_AUTO_TMA": "1"}):
+            result = foo(x, y)
+
+        self.assertEqual(result, (x * 2 + y) * 3)
+
+    def test_auto_tma_perf_no_regression(self):
+        """Benchmark auto-TMA vs baseline — verify no major regression."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        cap = torch.cuda.get_device_capability()
+        if cap < (9, 0):
+            self.skipTest(f"TMA requires sm_90+, got sm_{cap[0]}{cap[1]}")
+
+        N = 1048576  # 1M elements
+        x = torch.randn(N, device="cuda")
+        y = torch.randn(N, device="cuda")
+
+        def bench(fn, warmup=10, rep=50):
+            for _ in range(warmup):
+                fn(x, y)
+            torch.cuda.synchronize()
+            start = [torch.cuda.Event(enable_timing=True) for _ in range(rep)]
+            end = [torch.cuda.Event(enable_timing=True) for _ in range(rep)]
+            for i in range(rep):
+                start[i].record()
+                fn(x, y)
+                end[i].record()
+            torch.cuda.synchronize()
+            times = sorted(s.elapsed_time(e) for s, e in zip(start, end))
+            return times[len(times) // 2]
+
+        # Baseline
+        torch._dynamo.reset()
+        os.environ.pop("TRITON_AUTO_TMA", None)
+
+        @torch.compile
+        def baseline_add(a, b):
+            return a + b
+
+        t_base = bench(baseline_add)
+
+        # Auto-TMA
+        torch._dynamo.reset()
+        with mock.patch.dict(os.environ, {"TRITON_AUTO_TMA": "1"}):
+
+            @torch.compile
+            def auto_tma_add(a, b):
+                return a + b
+
+            t_tma = bench(auto_tma_add)
+
+        ratio = t_tma / t_base if t_base > 0 else float("inf")
+        print(
+            f"\nPerf: baseline={t_base:.4f}ms, auto-TMA={t_tma:.4f}ms, "
+            f"ratio={ratio:.3f}"
+        )
+        # Allow up to 20% regression — auto-TMA adds cuTensorMapEncodeTiled
+        # overhead per launch, but should not cause a major slowdown.
+        self.assertLess(
+            ratio,
+            1.2,
+            f"Auto-TMA is {ratio:.1%} of baseline — possible regression",
+        )
+
+    def test_host_side_tma_gemm_perf(self):
+        """Compare baseline vs auto-TMA vs enable_host_side_tma on a GEMM."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        cap = torch.cuda.get_device_capability()
+        if cap < (10, 0):
+            self.skipTest(
+                f"host-side TMA GEMM needs Blackwell, got sm_{cap[0]}{cap[1]}"
+            )
+
+        M, N, K = 2048, 2048, 2048
+        a = torch.randn(M, K, device="cuda", dtype=torch.float16)
+        b = torch.randn(K, N, device="cuda", dtype=torch.float16)
+
+        def bench_gemm(fn, warmup=20, rep=100):
+            for _ in range(warmup):
+                fn()
+            torch.cuda.synchronize()
+            start = [torch.cuda.Event(enable_timing=True) for _ in range(rep)]
+            end = [torch.cuda.Event(enable_timing=True) for _ in range(rep)]
+            for i in range(rep):
+                start[i].record()
+                fn()
+                end[i].record()
+            torch.cuda.synchronize()
+            times = sorted(s.elapsed_time(e) for s, e in zip(start, end))
+            return times[len(times) // 2]
+
+        gemm_cfg = {
+            "max_autotune": True,
+            "max_autotune_gemm_backends": "TRITON,ATEN",
+        }
+
+        # 1) Baseline
+        torch._dynamo.reset()
+        os.environ.pop("TRITON_AUTO_TMA", None)
+        with torch._inductor.config.patch(gemm_cfg):
+
+            @torch.compile
+            def baseline_mm(x, y):
+                return x @ y
+
+            baseline_mm(a, b)
+        t_baseline = bench_gemm(lambda: baseline_mm(a, b))
+
+        # 2) Auto-TMA (compiler pass)
+        torch._dynamo.reset()
+        with mock.patch.dict(os.environ, {"TRITON_AUTO_TMA": "1"}):
+            with torch._inductor.config.patch(gemm_cfg):
+
+                @torch.compile
+                def auto_tma_mm(x, y):
+                    return x @ y
+
+                auto_tma_mm(a, b)
+            t_auto_tma = bench_gemm(lambda: auto_tma_mm(a, b))
+
+        # 3) Host-side TMA (Inductor template)
+        torch._dynamo.reset()
+        with torch._inductor.config.patch(
+            {
+                **gemm_cfg,
+                "triton.enable_host_side_tma": True,
+                "triton.use_tensor_descriptor": True,
+                "assume_aligned_inputs": True,
+            }
+        ):
+
+            @torch.compile
+            def host_tma_mm(x, y):
+                return x @ y
+
+            host_tma_mm(a, b)
+        t_host = bench_gemm(lambda: host_tma_mm(a, b))
+
+        print(
+            f"\nGEMM Perf ({M}x{N}x{K} fp16, 100 reps median):"
+            f"\n  baseline (device TMA) = {t_baseline:.4f} ms"
+            f"\n  auto-TMA              = {t_auto_tma:.4f} ms (ratio={t_auto_tma / t_baseline:.3f})"
+            f"\n  host-side TMA         = {t_host:.4f} ms (ratio={t_host / t_baseline:.3f})"
+        )
 
 
 @requires_gpu_and_triton
@@ -873,6 +1309,117 @@ class TestFastCudaLauncher(TestCase):
         arg_tys = "O" * 130
         with self.assertRaises(ValueError):
             _FastCudaLauncher(0, 1, 0, arg_tys, 0)
+
+    def test_fast_launcher_accepts_recipes_arg(self):
+        """Verify _FastCudaLauncher constructor accepts optional 6th arg (recipes)."""
+
+        @triton.jit
+        def simple_kernel_recipes(arg0, arg1):
+            x = tl.load(arg0)
+            y = arg1
+            tl.store(arg0, x + y)
+
+        arg0 = torch.zeros(1, dtype=torch.int32, device=GPU_TYPE)
+        compiled_kernel = simple_kernel_recipes[(1,)](arg0, 5)
+        launcher = self._make_launcher(compiled_kernel)
+
+        n_scratch = 0
+        if getattr(launcher, "has_global_scratch", False):
+            n_scratch += 1
+        if getattr(launcher, "has_profile_scratch", False):
+            n_scratch += 1
+
+        from torch._C import _FastCudaLauncher
+
+        # 6-arg form with None (no recipes) — should work like 5-arg form
+        fast_none = _FastCudaLauncher(
+            launcher.function,
+            launcher.num_warps,
+            launcher.shared,
+            launcher.arg_tys,
+            n_scratch,
+            None,
+        )
+        device_interface = get_interface_for_device(GPU_TYPE)
+        stream = device_interface.get_raw_stream(device_interface.current_device())
+        new_arg0 = torch.zeros(1, dtype=torch.int32, device=GPU_TYPE)
+        fast_none(1, 1, 1, stream, new_arg0, 5)
+        self.assertEqual(
+            new_arg0, torch.tensor([5], dtype=torch.int32, device=GPU_TYPE)
+        )
+
+        # 6-arg form with empty list — should also work
+        fast_empty = _FastCudaLauncher(
+            launcher.function,
+            launcher.num_warps,
+            launcher.shared,
+            launcher.arg_tys,
+            n_scratch,
+            [],
+        )
+        new_arg0.zero_()
+        fast_empty(1, 1, 1, stream, new_arg0, 5)
+        self.assertEqual(
+            new_arg0, torch.tensor([5], dtype=torch.int32, device=GPU_TYPE)
+        )
+
+    def test_fast_launcher_auto_tma_launch(self):
+        """Verify _FastCudaLauncher with auto-TMA recipes launches correctly."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        cap = torch.cuda.get_device_capability()
+        if cap < (9, 0):
+            self.skipTest(f"TMA requires sm_90+, got sm_{cap[0]}{cap[1]}")
+
+        @triton.jit
+        def copy_kernel(src, dst, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(src + offsets, mask=mask)
+            tl.store(dst + offsets, x, mask=mask)
+
+        N = 64
+        src = torch.randn(N, device="cuda")
+        dst = torch.zeros(N, device="cuda")
+        compiled = copy_kernel[(1,)](src, dst, N, BLOCK_SIZE=64)
+        launcher = self._make_launcher(compiled)
+
+        recipe = {
+            "base_ptr_arg_index": 0,
+            "shape_arg_indices": [2],
+            "stride_arg_indices": [-1],
+            "block_shape": [64],
+            "swizzle": -1,
+            "elem_type": 7,  # CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+            "elem_size": 4,
+            "fp4_padded": 0,
+            "fill_mode": 0,
+        }
+
+        from torch._C import _FastCudaLauncher
+
+        n_scratch = 0
+        if getattr(launcher, "has_global_scratch", False):
+            n_scratch += 1
+        if getattr(launcher, "has_profile_scratch", False):
+            n_scratch += 1
+
+        fast = _FastCudaLauncher(
+            launcher.function,
+            launcher.num_warps,
+            launcher.shared,
+            launcher.arg_tys,
+            n_scratch,
+            [recipe],
+        )
+
+        new_src = torch.randn(N, device="cuda")
+        new_dst = torch.zeros(N, device="cuda")
+        device_interface = get_interface_for_device("cuda")
+        stream = device_interface.get_raw_stream(device_interface.current_device())
+        fast(1, 1, 1, stream, new_src, new_dst, N)
+        self.assertEqual(new_dst, new_src)
 
 
 @requires_gpu_and_triton

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -1082,6 +1082,68 @@ class TestAutoTmaE2E(TestCase):
             f"Auto-TMA is {ratio:.1%} of baseline — possible regression",
         )
 
+    def test_auto_tma_fusion_config_pointwise(self):
+        """Verify enable_auto_tma_fusion config drives auto-TMA on a pointwise kernel."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        cap = torch.cuda.get_device_capability()
+        if cap < (9, 0):
+            self.skipTest(f"TMA requires sm_90+, got sm_{cap[0]}{cap[1]}")
+
+        torch._dynamo.reset()
+        with torch._inductor.config.patch({"triton.enable_auto_tma_fusion": True}):
+
+            @torch.compile
+            def foo(x, y):
+                return x + y
+
+            x = torch.randn(1024, device="cuda")
+            y = torch.randn(1024, device="cuda")
+            result = foo(x, y)
+
+        self.assertEqual(result, x + y)
+
+    def test_auto_tma_fusion_config_reduction(self):
+        """Verify enable_auto_tma_fusion config works on a reduction kernel."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        cap = torch.cuda.get_device_capability()
+        if cap < (9, 0):
+            self.skipTest(f"TMA requires sm_90+, got sm_{cap[0]}{cap[1]}")
+
+        torch._dynamo.reset()
+        with torch._inductor.config.patch({"triton.enable_auto_tma_fusion": True}):
+
+            @torch.compile
+            def foo(x):
+                return x.sum(dim=-1)
+
+            x = torch.randn(128, 512, device="cuda")
+            result = foo(x)
+
+        self.assertEqual(result, x.sum(dim=-1))
+
+    def test_auto_tma_fusion_config_large_pointwise(self):
+        """Verify enable_auto_tma_fusion on a larger pointwise chain."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        cap = torch.cuda.get_device_capability()
+        if cap < (9, 0):
+            self.skipTest(f"TMA requires sm_90+, got sm_{cap[0]}{cap[1]}")
+
+        torch._dynamo.reset()
+        with torch._inductor.config.patch({"triton.enable_auto_tma_fusion": True}):
+
+            @torch.compile
+            def foo(x, y):
+                return torch.relu(x * 2 + y) * 3
+
+            x = torch.randn(4096, device="cuda", dtype=torch.float16)
+            y = torch.randn(4096, device="cuda", dtype=torch.float16)
+            result = foo(x, y)
+
+        self.assertEqual(result, torch.relu(x * 2 + y) * 3)
+
     def test_host_side_tma_gemm_perf(self):
         """Compare baseline vs auto-TMA vs enable_host_side_tma on a GEMM."""
         if not torch.cuda.is_available():

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7216,6 +7216,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             # requires cooperative-grid launches to avoid hanging.
             triton_meta["launch_cooperative_grid"] = True
 
+        if torch._inductor.config.triton.enable_auto_tma_fusion:
+            triton_meta["auto_tma"] = True
+
         # Skip memory optimization for forward of the training loop where we expect
         # every new node will increase the peak memory and our greedy approach would
         # introduce a lot of unnecessary cpu copies.

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2207,6 +2207,13 @@ class triton:
     # assume_aligned_inputs to also be enabled (no effect otherwise).
     enable_host_side_tma = os.environ.get("ENABLE_HOST_SIDE_TMA", "0") == "1"
 
+    # Auto-TMA for fused (non-template) kernels: let the Triton
+    # PromoteLoadToTMA pass promote eligible tl.load/tl.store into
+    # hardware TMA copies.  Requires fbTriton (sm_90+).
+    enable_auto_tma_fusion = (
+        os.environ.get("INDUCTOR_ENABLE_AUTO_TMA_FUSION", "0") == "1"
+    )
+
     # Skip L1 cache for buffers that are used only once.  Disabled by default
     skip_l1_cache = os.environ.get("TORCHINDUCTOR_SKIP_L1", "0") == "1"
 

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -125,6 +125,16 @@ class StaticallyLaunchedTritonKernel:
         # pyrefly: ignore [missing-attribute]
         self.tensordesc_meta = getattr(kernel.metadata, "tensordesc_meta", None)
         self._has_tensordesc = False
+
+        # Auto-TMA: the compiler may synthesize recipes that tell the launcher
+        # to build CUtensorMap descriptors at launch time from existing kernel
+        # args.  Recipes are plain dicts and already pickleable.
+        self.auto_tma_recipes: list[dict[str, Any]] = []
+        if hasattr(kernel, "metadata"):
+            recipes = getattr(kernel.metadata, "auto_tma_recipes", None)
+            if recipes:
+                self.auto_tma_recipes = list(recipes)
+
         # pyrefly: ignore [missing-attribute]
         self.arg_tys = self.arg_ty_from_signature(kernel.src)
         self.function: int | None = None  # Loaded by load_kernel(on the parent process)
@@ -348,6 +358,26 @@ class StaticallyLaunchedTritonKernel:
             args = self._expand_tma_args(args)
 
         arg_tys = self.arg_tys
+
+        if self.auto_tma_recipes and not is_rocm():
+            # Auto-TMA: pass user args only; C++ builds the full param layout
+            # [user_args, tma_descs, scratch] and constructs CUtensorMap at launch.
+            n_scratch = int(self.has_global_scratch) + int(self.has_profile_scratch)
+            # pyrefly: ignore [bad-argument-type]
+            self.C_impl._launch_kernel_tma(
+                self.function,
+                grid_x,
+                grid_y,
+                grid_z,
+                self.num_warps,
+                self.shared,
+                arg_tys,
+                args,
+                stream,
+                self.auto_tma_recipes,
+                n_scratch,
+            )
+            return
 
         if is_rocm():
             # ROCm/HIP kernel ABI: The Triton HIP backend ALWAYS includes both

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2628,7 +2628,12 @@ class CachingAutotuner(KernelInterface):
                 n_scratch = max(n_scratch, 2)
 
             fast_runner = _FastCudaLauncher(
-                cu_function, num_warps, shared, arg_tys, n_scratch
+                cu_function,
+                num_warps,
+                shared,
+                arg_tys,
+                n_scratch,
+                getattr(kernel, "auto_tma_recipes", None) or None,
             )
 
             new_globals = {**launcher.__globals__, "runner": fast_runner}

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1329,6 +1329,8 @@ class CachingAutotuner(KernelInterface):
             )
             if compile_meta.get("disable_ftz", False):
                 options["enable_reflect_ftz"] = False
+            if compile_meta.get("auto_tma", False):
+                options["auto_tma"] = True
             for k in tlx_only_cuda_options():
                 if v := getattr(cfg, k, None):
                     options[k] = v

--- a/torch/csrc/inductor/static_launcher/cuda.cpp
+++ b/torch/csrc/inductor/static_launcher/cuda.cpp
@@ -42,7 +42,6 @@
   triton_heuristics.py.
 
   TODO:
-  - Handle CutensorMap, NvtmDesc
   - Handle launch_enter and launch_exit hooks (in python maybe?)
  */
 
@@ -57,6 +56,250 @@ const at::cuda::NVRTC& nvrtc() {
 
 // 120 max args + 1 for global scratch size
 #define MAX_ARGS 121
+
+// Auto-TMA requires CUtensorMap (CUDA 12.0+) and is NVIDIA-only.
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+#define INDUCTOR_HAS_AUTO_TMA 1
+#else
+#define INDUCTOR_HAS_AUTO_TMA 0
+#endif
+
+#if INDUCTOR_HAS_AUTO_TMA
+// Auto-TMA recipe support: constructs CUtensorMap at launch time from
+// compiler-synthesized recipes.  Mirrors triton's launch.h logic but uses
+// ATen's NVRTC stub for cuTensorMapEncodeTiled.
+static constexpr int MAX_TMA_DESCS = 8;
+static constexpr int MAX_TMA_DIMS = 5;
+
+struct AutoTmaRecipe {
+  int ndim;
+  uint32_t blockShape[MAX_TMA_DIMS];
+  int swizzle;
+  int elemType;
+  int elemSize;
+  int fp4Padded;
+  int fillMode;
+  int basePtrArgIndex;
+  int shapeArgIndices[MAX_TMA_DIMS];
+  int strideArgIndices[MAX_TMA_DIMS]; // -1 = contiguous
+};
+
+inline int64_t readArgAsInt64(
+    const uint64_t* argStorage,
+    const char* argTypes,
+    int argIdx,
+    int numArgs) {
+  TORCH_CHECK(
+      argIdx >= 0 && argIdx < numArgs,
+      "TMA recipe: arg index ",
+      argIdx,
+      " out of bounds (numArgs=",
+      numArgs,
+      ")");
+  char t = argTypes[argIdx];
+  const void* slot = &argStorage[argIdx];
+  switch (t) {
+    case 'i':
+      return static_cast<int64_t>(*reinterpret_cast<const int32_t*>(slot));
+    case 'l':
+      return *reinterpret_cast<const int64_t*>(slot);
+    case 'I':
+      return static_cast<int64_t>(*reinterpret_cast<const uint32_t*>(slot));
+    case 'K':
+      return static_cast<int64_t>(*reinterpret_cast<const uint64_t*>(slot));
+    default:
+      TORCH_CHECK(
+          false, "TMA recipe: shape/stride arg has unsupported type '", t, "'");
+  }
+}
+
+// Mirrors triton_construct_tma_desc() from launch.h
+inline CUresult constructTmaDesc(
+    CUtensorMap* desc,
+    const AutoTmaRecipe& recipe,
+    const uint64_t* argStorage,
+    const char* argTypes,
+    int numArgs) {
+  int rank = recipe.ndim;
+  TORCH_CHECK(
+      recipe.basePtrArgIndex >= 0 && recipe.basePtrArgIndex < numArgs,
+      "TMA recipe: basePtrArgIndex ",
+      recipe.basePtrArgIndex,
+      " out of bounds (numArgs=",
+      numArgs,
+      ")");
+  CUdeviceptr basePtr;
+  std::memcpy(
+      &basePtr, &argStorage[recipe.basePtrArgIndex], sizeof(CUdeviceptr));
+
+  int64_t shp[MAX_TMA_DIMS] = {0};
+  int64_t strd[MAX_TMA_DIMS] = {0};
+  for (int j = 0; j < rank; j++) {
+    shp[j] = readArgAsInt64(
+        argStorage, argTypes, recipe.shapeArgIndices[j], numArgs);
+    if (recipe.strideArgIndices[j] >= 0)
+      strd[j] = readArgAsInt64(
+          argStorage, argTypes, recipe.strideArgIndices[j], numArgs);
+  }
+  if (recipe.fp4Padded && rank > 0)
+    shp[rank - 1] *= 2;
+
+  // Reverse row-major -> column-major for cuTensorMapEncodeTiled.
+  cuuint64_t globalDim[MAX_TMA_DIMS] = {0};
+  cuuint64_t globalStrides[MAX_TMA_DIMS] = {0};
+  cuuint32_t boxDim[MAX_TMA_DIMS] = {0};
+  cuuint32_t elemStrides[MAX_TMA_DIMS] = {1, 1, 1, 1, 1};
+  for (int j = 0; j < rank; j++) {
+    boxDim[rank - 1 - j] = recipe.blockShape[j];
+    globalDim[rank - 1 - j] = static_cast<cuuint64_t>(shp[j]);
+  }
+  for (int j = 0; j + 1 < rank; j++)
+    globalStrides[rank - 2 - j] = static_cast<cuuint64_t>(
+        static_cast<int64_t>(recipe.elemSize) * strd[j]);
+  if (rank > 0)
+    globalStrides[rank - 1] = globalDim[rank - 1] *
+        (rank == 1 ? static_cast<cuuint64_t>(recipe.elemSize)
+                   : globalStrides[rank - 2]);
+
+  CUtensorMapSwizzle swizzleMode = CU_TENSOR_MAP_SWIZZLE_NONE;
+  if (recipe.swizzle >= 0)
+    swizzleMode = static_cast<CUtensorMapSwizzle>(recipe.swizzle);
+  if (rank >= 2) {
+    int contigBytes = recipe.elemSize * static_cast<int>(boxDim[0]);
+    if (recipe.swizzle < 0) {
+      if (boxDim[1] < 8 || contigBytes < 32) {
+        swizzleMode = CU_TENSOR_MAP_SWIZZLE_NONE;
+      } else if (contigBytes >= 128) {
+        swizzleMode = CU_TENSOR_MAP_SWIZZLE_128B;
+      } else if (contigBytes >= 64) {
+        swizzleMode = CU_TENSOR_MAP_SWIZZLE_64B;
+      } else {
+        swizzleMode = CU_TENSOR_MAP_SWIZZLE_32B;
+      }
+    }
+    int swzBytes = (swizzleMode == CU_TENSOR_MAP_SWIZZLE_128B) ? 128
+        : (swizzleMode == CU_TENSOR_MAP_SWIZZLE_64B)           ? 64
+        : (swizzleMode == CU_TENSOR_MAP_SWIZZLE_32B)           ? 32
+                                                               : 0;
+    if (swzBytes > 0 && contigBytes > swzBytes)
+      boxDim[0] = static_cast<cuuint32_t>(swzBytes / recipe.elemSize);
+  }
+
+  CUtensorMapFloatOOBfill fill = recipe.fillMode
+      ? CU_TENSOR_MAP_FLOAT_OOB_FILL_NAN_REQUEST_ZERO_FMA
+      : CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE;
+
+  CUresult r = nvrtc().cuTensorMapEncodeTiled(
+      desc,
+      static_cast<CUtensorMapDataType>(recipe.elemType),
+      static_cast<cuuint32_t>(rank),
+      reinterpret_cast<void*>(static_cast<uintptr_t>(basePtr)),
+      globalDim,
+      globalStrides,
+      boxDim,
+      elemStrides,
+      CU_TENSOR_MAP_INTERLEAVE_NONE,
+      swizzleMode,
+      CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+      fill);
+  if (r != CUDA_SUCCESS)
+    return r;
+
+  // Small-tensor CUtensorMap workaround for driver <= 13010: clear bit 21
+  // of word 1 when the tensor fits in 128 KiB.  Mirrors launch.h.
+  // CUDA driver 13.0.10 and earlier have a CUtensorMap bug for small tensors.
+  static constexpr int kDriverVersionWithSmallTensorBug = 13010;
+  static constexpr int64_t kSmallTensorThresholdBytes = 128 * 1024;
+  static const int driverVersion = [] {
+    int v = 0;
+    cudaDriverGetVersion(&v);
+    return v;
+  }();
+  if (driverVersion <= kDriverVersionWithSmallTensorBug) {
+    int64_t maxByteIndex = 0;
+    for (int j = 0; j < rank; j++) {
+      int64_t bytesStride = (j == 0)
+          ? static_cast<int64_t>(recipe.elemSize)
+          : static_cast<int64_t>(globalStrides[j - 1]);
+      maxByteIndex += (static_cast<int64_t>(globalDim[j]) - 1) * bytesStride;
+    }
+    if (maxByteIndex + 1 < kSmallTensorThresholdBytes) {
+      auto* descU64 = reinterpret_cast<uint64_t*>(desc);
+      descU64[1] &= ~(1ull << 21);
+    }
+  }
+  return CUDA_SUCCESS;
+}
+
+int parseRecipesFromPython(PyObject* recipesList, AutoTmaRecipe* recipes) {
+  if (!recipesList || recipesList == Py_None || !PyList_Check(recipesList))
+    return 0;
+  int numRecipes = static_cast<int>(PyList_Size(recipesList));
+  TORCH_CHECK(
+      numRecipes <= MAX_TMA_DESCS,
+      "Too many TMA recipes: ",
+      numRecipes,
+      " > ",
+      MAX_TMA_DESCS);
+
+  for (int r = 0; r < numRecipes; r++) {
+    PyObject* dict = PyList_GetItem(recipesList, r);
+    TORCH_CHECK(PyDict_Check(dict), "TMA recipe must be a dict");
+
+    auto getInt = [&](const char* key) -> int {
+      PyObject* val = PyDict_GetItemString(dict, key);
+      TORCH_CHECK(val, "TMA recipe missing key: ", key);
+      return static_cast<int>(THPUtils_unpackLong(val));
+    };
+    auto getList = [&](const char* key) -> PyObject* {
+      PyObject* list = PyDict_GetItemString(dict, key);
+      TORCH_CHECK(
+          list && PyList_Check(list),
+          "TMA recipe key '",
+          key,
+          "' must be a list");
+      return list;
+    };
+
+    PyObject* blockList = getList("block_shape");
+    int ndim = static_cast<int>(PyList_Size(blockList));
+    TORCH_CHECK(ndim <= MAX_TMA_DIMS, "TMA recipe ndim too large: ", ndim);
+    recipes[r].ndim = ndim;
+    for (int i = 0; i < ndim; i++)
+      recipes[r].blockShape[i] = static_cast<uint32_t>(
+          THPUtils_unpackLong(PyList_GetItem(blockList, i)));
+
+    recipes[r].swizzle = getInt("swizzle");
+    recipes[r].elemType = getInt("elem_type");
+    recipes[r].elemSize = getInt("elem_size");
+    recipes[r].fp4Padded = getInt("fp4_padded");
+    recipes[r].fillMode = getInt("fill_mode");
+    recipes[r].basePtrArgIndex = getInt("base_ptr_arg_index");
+
+    PyObject* shapeList = getList("shape_arg_indices");
+    PyObject* strideList = getList("stride_arg_indices");
+    TORCH_CHECK(
+        PyList_Size(shapeList) >= ndim,
+        "TMA recipe: shape_arg_indices has ",
+        PyList_Size(shapeList),
+        " entries, need ",
+        ndim);
+    TORCH_CHECK(
+        PyList_Size(strideList) >= ndim,
+        "TMA recipe: stride_arg_indices has ",
+        PyList_Size(strideList),
+        " entries, need ",
+        ndim);
+    for (int i = 0; i < ndim; i++) {
+      recipes[r].shapeArgIndices[i] =
+          static_cast<int>(THPUtils_unpackLong(PyList_GetItem(shapeList, i)));
+      recipes[r].strideArgIndices[i] =
+          static_cast<int>(THPUtils_unpackLong(PyList_GetItem(strideList, i)));
+    }
+  }
+  return numRecipes;
+}
+#endif // INDUCTOR_HAS_AUTO_TMA
 
 CUdeviceptr getPointer(PyObject* obj) {
   CUdeviceptr data_ptr = 0;
@@ -658,7 +901,95 @@ PyObject* unload_kernel(PyObject* self, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
-std::array<PyMethodDef, 3> StaticCudaLauncherMethods = {
+#if INDUCTOR_HAS_AUTO_TMA
+// Launch a kernel with auto-TMA recipes.  Constructs CUtensorMap descriptors
+// at launch time and inserts them between user args and scratch in the kernel
+// param array: [user_args, tma_descs, scratch].
+PyObject* launch_kernel_tma(PyObject* self, PyObject* args) {
+  HANDLE_TH_ERRORS
+  uint64_t func_ptr = 0;
+  int gridX = 0, gridY = 0, gridZ = 0, numWarps = 0, sharedMemBytes = 0;
+  uint64_t stream = 0;
+  const char* argTypes = nullptr;
+  PyObject* varArgs = nullptr;
+  PyObject* recipesList = nullptr;
+  int nScratch = 0;
+
+  if (!PyArg_ParseTuple(
+          args,
+          "KiiiiisOKOi",
+          &func_ptr,
+          &gridX,
+          &gridY,
+          &gridZ,
+          &numWarps,
+          &sharedMemBytes,
+          &argTypes,
+          &varArgs,
+          &stream,
+          &recipesList,
+          &nScratch)) {
+    return nullptr;
+  }
+  if (gridX <= 0 || gridY <= 0 || gridZ <= 0)
+    Py_RETURN_NONE;
+
+  CUcontext pctx = nullptr;
+  AT_CUDA_DRIVER_CHECK(nvrtc().cuCtxGetCurrent(&pctx));
+  if (!pctx) {
+    CUdevice device = 0;
+    AT_CUDA_DRIVER_CHECK(nvrtc().cuDeviceGet(&device, 0));
+    AT_CUDA_DRIVER_CHECK(nvrtc().cuDevicePrimaryCtxRetain(&pctx, device));
+    AT_CUDA_DRIVER_CHECK(nvrtc().cuCtxSetCurrent(pctx));
+  }
+
+  CUfunction func = reinterpret_cast<CUfunction>(func_ptr); // NOLINT
+  cudaStream_t cudaStream = reinterpret_cast<cudaStream_t>(stream); // NOLINT
+
+  AutoTmaRecipe recipes[MAX_TMA_DESCS];
+  int numRecipes = parseRecipesFromPython(recipesList, recipes);
+
+  int numUserArgs = static_cast<int>(std::strlen(argTypes));
+  int numTotalParams = numUserArgs + numRecipes + nScratch;
+  TORCH_CHECK(
+      numTotalParams <= MAX_ARGS,
+      "Too many kernel params with TMA: ",
+      numTotalParams,
+      " > ",
+      MAX_ARGS);
+
+  std::array<uint64_t, MAX_ARGS> argStorage = {};
+  std::array<void*, MAX_ARGS> kernelArgs = {};
+  parseKernelArgs(varArgs, argTypes, argStorage.data(), kernelArgs.data());
+
+  CUtensorMap tmaDescs[MAX_TMA_DESCS];
+  for (int r = 0; r < numRecipes; r++) {
+    AT_CUDA_DRIVER_CHECK(constructTmaDesc(
+        &tmaDescs[r], recipes[r], argStorage.data(), argTypes, numUserArgs));
+    kernelArgs[numUserArgs + r] = &tmaDescs[r];
+  }
+
+  // Scratch slots (nullptr)
+  uint64_t scratchZero = 0;
+  for (int s = 0; s < nScratch; s++)
+    kernelArgs[numUserArgs + numRecipes + s] = &scratchZero;
+
+  launchKernel(
+      func,
+      gridX,
+      gridY,
+      gridZ,
+      numWarps,
+      sharedMemBytes,
+      kernelArgs.data(),
+      cudaStream);
+
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+#endif // INDUCTOR_HAS_AUTO_TMA
+
+std::array<PyMethodDef, 4> StaticCudaLauncherMethods = {
     PyMethodDef{
         "_launch_kernel",
         launch_kernel,
@@ -673,7 +1004,26 @@ std::array<PyMethodDef, 3> StaticCudaLauncherMethods = {
         "_unload_kernel",
         unload_kernel,
         METH_VARARGS,
-        "Unload CUDA/HIP module loaded by _load_kernel"}};
+        "Unload CUDA/HIP module loaded by _load_kernel"},
+#if INDUCTOR_HAS_AUTO_TMA
+    PyMethodDef{
+        "_launch_kernel_tma",
+        launch_kernel_tma,
+        METH_VARARGS,
+        "Launch triton kernel with auto-TMA recipe support"},
+#else
+    PyMethodDef{
+        "_launch_kernel_tma",
+        [](PyObject*, PyObject*) -> PyObject* {
+          PyErr_SetString(
+              PyExc_NotImplementedError,
+              "Auto-TMA is not supported on this platform");
+          return nullptr;
+        },
+        METH_VARARGS,
+        "Auto-TMA not supported"},
+#endif
+};
 
 // Define a minimal type for StaticCudaLauncher.
 // We don't implement __new__ or __init__ because we're using it only as a
@@ -790,6 +1140,14 @@ struct FastCudaLauncherObject {
   // they will corrupt argStorage/kernelArgs.  Revisit when nogil is stable.
   uint64_t argStorage[MAX_ARGS];
   void* kernelArgs[MAX_ARGS];
+
+#if INDUCTOR_HAS_AUTO_TMA
+  // Auto-TMA recipe support
+  int numRecipes;
+  int nScratch;
+  AutoTmaRecipe recipes[MAX_TMA_DESCS];
+  CUtensorMap tmaDescs[MAX_TMA_DESCS];
+#endif
 };
 
 static PyObject* fast_launcher_vectorcall(
@@ -811,8 +1169,16 @@ static PyObject* FastCudaLauncher_new(
   uint64_t func_ptr = 0;
   int numWarps = 0, shared = 0, nScratch = 0;
   const char* argTypes = nullptr;
+  PyObject* recipesList = nullptr;
   if (!PyArg_ParseTuple(
-          args, "Kiisi", &func_ptr, &numWarps, &shared, &argTypes, &nScratch)) {
+          args,
+          "Kiisi|O",
+          &func_ptr,
+          &numWarps,
+          &shared,
+          &argTypes,
+          &nScratch,
+          &recipesList)) {
     Py_DECREF(self);
     return nullptr;
   }
@@ -821,8 +1187,21 @@ static PyObject* FastCudaLauncher_new(
   self->numWarps = static_cast<uint32_t>(numWarps);
   self->sharedMemBytes = static_cast<uint32_t>(shared);
 
+#if INDUCTOR_HAS_AUTO_TMA
+  self->numRecipes = 0;
+  self->nScratch = nScratch;
+  if (recipesList && recipesList != Py_None && PyList_Check(recipesList) &&
+      PyList_Size(recipesList) > 0) {
+    self->numRecipes = parseRecipesFromPython(recipesList, self->recipes);
+  }
+#endif
+
   int nKernel = static_cast<int>(std::strlen(argTypes));
+#if INDUCTOR_HAS_AUTO_TMA
+  int nTotal = nKernel + self->numRecipes + nScratch;
+#else
   int nTotal = nKernel + nScratch;
+#endif
   if (nTotal > MAX_ARGS) {
     Py_DECREF(self);
     PyErr_Format(
@@ -836,17 +1215,26 @@ static PyObject* FastCudaLauncher_new(
   self->numKernelArgs = nKernel;
   self->numTotalArgs = nTotal;
   std::memcpy(self->argTypes, argTypes, nKernel);
-  // Scratch slots are pointer type ('O')
-  for (int i = nKernel; i < nTotal; ++i) {
-    self->argTypes[i] = 'O';
-  }
-  self->argTypes[nTotal] = '\0';
+  self->argTypes[nKernel] = '\0';
 
   // Pre-compute kernelArgs pointers and zero all storage.
   std::memset(self->argStorage, 0, sizeof(self->argStorage));
-  for (int i = 0; i < nTotal; ++i) {
+  for (int i = 0; i < nKernel; ++i) {
     self->kernelArgs[i] = &self->argStorage[i];
   }
+
+#if INDUCTOR_HAS_AUTO_TMA
+  // TMA desc slots are set at launch time; scratch slots are nullptr.
+  for (int i = nKernel + self->numRecipes;
+       i < nKernel + self->numRecipes + nScratch;
+       ++i) {
+    self->kernelArgs[i] = &self->argStorage[i];
+  }
+#else
+  for (int i = nKernel; i < nTotal; ++i) {
+    self->kernelArgs[i] = &self->argStorage[i];
+  }
+#endif
 
   // Set vectorcall function pointer.
   self->vectorcall = fast_launcher_vectorcall;
@@ -954,20 +1342,46 @@ static PyObject* fast_launcher_vectorcall(
             false, "_FastCudaLauncher: unknown arg type '", typeChar, "'");
     }
   }
-  // Scratch slots already zeroed at construction time and stay zero.
-  // Invariant: inductor codegen always passes None for scratch args, so the
-  // pre-zeroed nullptr values remain valid across launches.  If scratch
-  // semantics ever require non-null per-launch values, re-zero here.
 
-  launchKernel(
-      self->func,
-      static_cast<uint32_t>(gridX),
-      static_cast<uint32_t>(gridY),
-      static_cast<uint32_t>(gridZ),
-      self->numWarps,
-      self->sharedMemBytes,
-      self->kernelArgs,
-      reinterpret_cast<cudaStream_t>(stream)); // NOLINT
+#if INDUCTOR_HAS_AUTO_TMA
+  if (self->numRecipes > 0) {
+    // Auto-TMA: build CUtensorMap for each recipe, insert between user args
+    // and scratch.
+    for (int r = 0; r < self->numRecipes; r++) {
+      AT_CUDA_DRIVER_CHECK(constructTmaDesc(
+          &self->tmaDescs[r],
+          self->recipes[r],
+          self->argStorage,
+          self->argTypes,
+          self->numKernelArgs));
+      self->kernelArgs[self->numKernelArgs + r] = &self->tmaDescs[r];
+    }
+    // Scratch slots: kernelArgs already point to zeroed argStorage slots
+    // (set at init time).
+
+    launchKernel(
+        self->func,
+        static_cast<uint32_t>(gridX),
+        static_cast<uint32_t>(gridY),
+        static_cast<uint32_t>(gridZ),
+        self->numWarps,
+        self->sharedMemBytes,
+        self->kernelArgs,
+        reinterpret_cast<cudaStream_t>(stream)); // NOLINT
+  } else
+#endif
+  {
+    // Scratch slots already zeroed at construction time and stay zero.
+    launchKernel(
+        self->func,
+        static_cast<uint32_t>(gridX),
+        static_cast<uint32_t>(gridY),
+        static_cast<uint32_t>(gridZ),
+        self->numWarps,
+        self->sharedMemBytes,
+        self->kernelArgs,
+        reinterpret_cast<cudaStream_t>(stream)); // NOLINT
+  }
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS


### PR DESCRIPTION
Summary:

## Background

Auto-TMA (`PromoteLoadToTMA`) is an fbTriton compiler pass (D110948918 stack)
that promotes plain `tl.load`/`tl.store` into hardware TMA copies automatically.
D112968242 added launcher-side support for the `auto_tma_recipes` metadata in
Inductor's static and fast Triton launchers. However, the pass was never
activated for Inductor's fused (non-template) kernels — it could only be
triggered via the `TRITON_AUTO_TMA=1` environment variable directly.

This diff adds an Inductor config flag `triton.enable_auto_tma_fusion` that
wires `auto_tma=True` into the Triton compilation options for codegen'd kernels,
so the pass runs on pointwise, reduction, and other fused kernels on sm_90+.

## What this diff does

1. **`config.py`**: Adds `triton.enable_auto_tma_fusion` (default `False`,
   env `INDUCTOR_ENABLE_AUTO_TMA_FUSION`).

2. **`codegen/triton.py`**: Sets `triton_meta["auto_tma"] = True` when the
   config is enabled, so the flag flows into the compilation metadata.

3. **`runtime/triton_heuristics.py`**: In `_create_compile_options()`, reads
   `compile_meta["auto_tma"]` and passes `options["auto_tma"] = True` to
   `triton.compile()`, which enables the `PromoteLoadToTMA` pass in
   `compiler.py:make_ttir`.

## Data flow

```
config.triton.enable_auto_tma_fusion = True
  → codegen: triton_meta["auto_tma"] = True
    → compile_meta (deep copy of triton_meta)
      → _create_compile_options: options["auto_tma"] = True
        → triton.compile(options={"auto_tma": True})
          → Triton Options.auto_tma = True
            → make_ttir enables PromoteLoadToTMA pass (sm_90+)
              → eligible tl.load/tl.store → descriptor_load/descriptor_store
                → auto_tma_recipes metadata → launcher builds CUtensorMap
```

## Before / After: Concrete Example

Consider `torch.compile(lambda x, y: relu(x * 2 + y) * 3)` — Inductor fuses
the multiply, add, relu, and second multiply into **one** Triton kernel with
3 loads and 1 store:

**Before** (default, `enable_auto_tma_fusion = False`):

Inductor generates a single fused Triton kernel:
```python
triton.jit
def triton_fused_add_mul_relu(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK: tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.arange(0, XBLOCK)[:]
    xmask = xindex < xnumel
    tmp0 = tl.load(in_ptr0 + xindex, xmask)    # load x — plain cp.async
    tmp2 = tmp0 * 2                              # fused: x * 2
    tmp3 = tl.load(in_ptr1 + xindex, xmask)     # load y — plain cp.async
    tmp4 = tmp2 + tmp3                           # fused: + y
    tmp5 = tl.maximum(0, tmp4)                   # fused: relu
    tmp6 = tmp5 * 3                              # fused: * 3
    tl.store(out_ptr0 + xindex, tmp6, xmask)    # plain global store
```
All loads/stores compile to per-thread `cp.async` / vectorized global memory
ops. The `PromoteLoadToTMA` pass is NOT invoked.

**After** (`enable_auto_tma_fusion = True`):

The same fused kernel source is compiled with `options["auto_tma"] = True`.
The `PromoteLoadToTMA` pass runs at TTIR level and, for each eligible load:
- Decomposes `in_ptr0 + xindex` → base=`in_ptr0`, 1D contiguous, extent=`xnumel`
- Rewrites `tl.load` → `tt.descriptor_load` against a synthesized host descriptor
- Records a recipe: `{base_arg=0, shape_args=[3], block=[XBLOCK], dtype=fp16}`

The compute fusion (mul, add, relu, mul) is unchanged — only the memory ops
are promoted. At launch, the static launcher (D112968242) builds a `CUtensorMap`
per recipe via `cuTensorMapEncodeTiled` and injects them as hidden kernel args.

TTIR diff (conceptual, per load):
```
- %val = tt.load %ptr, %mask             // per-thread cp.async
+ %val = tt.descriptor_load %desc[%off]   // hardware TMA bulk copy
+ // recipe: {base=in_ptr0, shape=[xnumel], stride=contiguous, block=[XBLOCK]}
```

For a reduction kernel like `(x * y).sum(dim=-1)` on a 2D tensor, the fused
multiply-then-reduce kernel's inner (contiguous) dimension loads are similarly
promotable if the stride is 16B-aligned.

Non-eligible patterns (indirect indexing, non-contiguous inner dim) are silently
skipped — the kernel compiles and runs correctly either way.

## Limitations

- **1D flat indexing**: Inductor emits `tl.load(ptr + flat_offset)` for most
  fused kernels. The `decomposePointer` analysis in `PromoteLoadToTMA` handles
  1D contiguous patterns, but 2D reductions with inlined stride constants may
  not be promotable (the pass needs strides as kernel args to build host
  recipes).

- **No warp specialization**: TMA's real performance win comes from WS overlap.
  This diff only enables TMA promotion; fused kernels don't yet emit
  `warp_specialize=True` loops (future work).

- **fbTriton-only**: The pass is an fbTriton extension; OSS Triton does not
  have `PromoteLoadToTMA`. The config defaults to `False`, so OSS is unaffected.

Test Plan:
```
buck2 test --flagfile fbcode//mode/dev-nosan \
  -m ovr_config//triton:beta \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.nvcc_arch=b200a \
  -c fbcode.platform010_cuda_version=12.8 \
  fbcode//caffe2/test/inductor:static_triton_launcher \
  -- 'test_auto_tma_fusion_config'
```

Result: Pass 4. Fail 0. Skip 0.

NOTE: `--flagfile fbcode//mode/dev-nosan` (or `fbcode//mode/opt`) is required
because default ASAN build causes CUDA initialization OOM on GPU devservers.

Three new tests:
- `test_auto_tma_fusion_config_pointwise`: `torch.compile(x + y)` with config enabled, verifies correctness
- `test_auto_tma_fusion_config_reduction`: `torch.compile(x.sum(dim=-1))` on 2D tensor, verifies correctness
- `test_auto_tma_fusion_config_large_pointwise`: `torch.compile(relu(x*2+y)*3)` fp16, verifies correctness

Differential Revision: D114098037




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo