### PR TITLE
Prevent TorchTitan CI from replacing the PyTorch wheel under test

### DIFF
--- a/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
+++ b/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
@@ -1,6 +1,4 @@
 import logging
-import sys
-from pathlib import Path
 from typing import Any
 
 from cli.lib.common.cli_helper import BaseRunner
@@ -15,23 +13,6 @@ from cli.lib.core.torchtitan.lib import (
 
 logger = logging.getLogger(__name__)
 
-# generate_binary_build_matrix.py is not importable as a package (it lives in
-# .github/scripts, outside the cli package), so add that dir to sys.path the
-# same way .github/scripts/get_ci_variable.py does.
-_SCRIPTS_DIR = Path(__file__).resolve().parents[6] / ".github" / "scripts"
-
-
-def _nightly_index_url() -> str:
-    # torchao and torchcomms nightlies must match the CUDA toolchain of the
-    # build, so reuse CUDA_STABLE from generate_binary_build_matrix.py (the
-    # single source of truth for the stable CUDA version, e.g. "13.0" -> cu130)
-    # rather than hardcoding the wheel channel here.
-    if str(_SCRIPTS_DIR) not in sys.path:
-        sys.path.insert(0, str(_SCRIPTS_DIR))
-    from generate_binary_build_matrix import CUDA_STABLE
-
-    return f"https://download.pytorch.org/whl/nightly/cu{CUDA_STABLE.replace('.', '')}"
-
 
 class TorchtitanTestRunner(BaseRunner):
     def __init__(self, args: Any):
@@ -40,16 +21,6 @@ class TorchtitanTestRunner(BaseRunner):
 
     def prepare(self):
         clone_torchtitan(dst=self.work_directory)
-        # torchao and torchcomms nightlies are required by torchtitan
-        pip_install_packages(
-            packages=[
-                "--pre",
-                "torchao",
-                "torchcomms",
-                "--index-url",
-                _nightly_index_url(),
-            ],
-        )
         pip_install_packages(packages=["helion"])
         with working_directory(self.work_directory):
             pip_install_packages(packages=["-e", "."])

--- a/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
+++ b/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any
 
 from cli.lib.common.cli_helper import BaseRunner
-from cli.lib.common.pip_helper import pip_install_packages
+from cli.lib.common.pip_helper import first_matching_pkg, pip_install_packages
 from cli.lib.common.utils import working_directory
 from cli.lib.core.torchtitan.lib import (
     clone_torchtitan,
@@ -14,6 +14,16 @@ from cli.lib.core.torchtitan.lib import (
 logger = logging.getLogger(__name__)
 
 
+def _install_built_torchtitan_dependency_wheels() -> None:
+    wheels = [
+        first_matching_pkg("dist/ao/torchao*.whl"),
+        first_matching_pkg("dist/torchcomms/torchcomms*.whl"),
+    ]
+    # These wheels are built against the PyTorch wheel under test. Avoid
+    # dependency resolution so pip cannot replace that PyTorch wheel.
+    pip_install_packages(packages=["--no-index", "--no-deps", *wheels])
+
+
 class TorchtitanTestRunner(BaseRunner):
     def __init__(self, args: Any):
         self.work_directory = "torchtitan"
@@ -21,6 +31,7 @@ class TorchtitanTestRunner(BaseRunner):
 
     def prepare(self):
         clone_torchtitan(dst=self.work_directory)
+        _install_built_torchtitan_dependency_wheels()
         pip_install_packages(packages=["helion"])
         with working_directory(self.work_directory):
             pip_install_packages(packages=["-e", "."])

--- a/.ci/lumen_cli/tests/test_torchtitan_test.py
+++ b/.ci/lumen_cli/tests/test_torchtitan_test.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+
+def test_prepare_installs_built_dependency_wheels_without_deps(monkeypatch):
+    module = importlib.import_module("cli.lib.core.torchtitan.torchtitan_test")
+
+    clone_torchtitan = MagicMock(name="clone_torchtitan")
+    first_matching_pkg = MagicMock(
+        name="first_matching_pkg",
+        side_effect=[
+            "dist/ao/torchao-test.whl",
+            "dist/torchcomms/torchcomms-test.whl",
+        ],
+    )
+    pip_install_packages = MagicMock(name="pip_install_packages")
+
+    monkeypatch.setattr(module, "clone_torchtitan", clone_torchtitan)
+    monkeypatch.setattr(module, "first_matching_pkg", first_matching_pkg)
+    monkeypatch.setattr(module, "pip_install_packages", pip_install_packages)
+    monkeypatch.setattr(module, "working_directory", lambda _: nullcontext())
+
+    runner = module.TorchtitanTestRunner(
+        SimpleNamespace(test_plan="torchtitan_features_integration")
+    )
+    runner.prepare()
+
+    clone_torchtitan.assert_called_once_with(dst="torchtitan")
+    first_matching_pkg.assert_has_calls(
+        [
+            call("dist/ao/torchao*.whl"),
+            call("dist/torchcomms/torchcomms*.whl"),
+        ]
+    )
+    assert pip_install_packages.call_args_list[0] == call(
+        packages=[
+            "--no-index",
+            "--no-deps",
+            "dist/ao/torchao-test.whl",
+            "dist/torchcomms/torchcomms-test.whl",
+        ]
+    )

--- a/.github/workflows/torchtitan.yml
+++ b/.github/workflows/torchtitan.yml
@@ -65,6 +65,7 @@ jobs:
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       cuda-arch-list: '8.0 8.9 9.0 10.0'
       runner: linux.24xlarge.memory
+      build-additional-packages: "torchao torchcomms"
       # torchtitan_h100_integration disabled pending runner availability
       test-matrix: |
         { include: [


### PR DESCRIPTION
Summary:
- Keep TorchTitan CI from replacing the PyTorch wheel built by the current CI job.
- Install TorchTitan companion packages `torchao` and `torchcomms` through PyTorch CI's pinned source helpers (`install_torchao`, `install_torchcomms`) so their extensions are built/installed against the torch wheel under test instead of exact nightly torch pins.

Why:
- PyTorch TorchTitan CI first installs the locally built PyTorch wheel, then previously installed `torchao`/`torchcomms` from the CUDA nightly index.
- The prebuilt `torchcomms` wheel metadata pins an exact torch nightly, so pip replaced the wheel under test.
- Example from a completed main TorchTitan run:
  https://github.com/pytorch/pytorch/actions/runs/30149496451/job/89659764246
  - installed local wheel: `torch-2.14.0a0+gita4116fb`
  - then ran: `python -m pip install --pre torchao torchcomms --index-url https://download.pytorch.org/whl/nightly/cu130`
  - resolved: `Collecting torch==2.14.0.dev20260723 (from torchcomms)`
  - uninstalled local wheel and installed `torch-2.14.0.dev20260723+cu130`
- Same pattern occurred on pytorch/pytorch#190402 TorchTitan jobs:
  https://github.com/pytorch/pytorch/actions/runs/30284846234/job/90045622547
  https://github.com/pytorch/pytorch/actions/runs/30284846234/job/90045622521
  The PR-built `torch-2.14.0a0+git857cdea` wheel was replaced by `torch-2.14.0.dev20260726+cu130` before TorchTitan tests ran.
- After blocking dependency resolution with `--no-deps`, the prebuilt `torchcomms` nightly failed to load against the PR torch wheel because it was built/pinned for `torch==2.14.0.dev20260728`. That confirms these companion packages should follow the source-built CI helper path for this workflow.

Fix:
- Remove the Lumen TorchTitan setup's binary nightly install of `torchao`/`torchcomms`.
- Call `install_torchao` and `install_torchcomms` from `.ci/pytorch/test.sh` before running the TorchTitan Lumen test runner. This reuses PyTorch CI's pinned source-build paths and keeps the companion extensions aligned with the current torch wheel.

Test Plan:
- `git diff --check`
- `python3 -m py_compile .ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py`
- `ciflow/torchtitan`: https://github.com/pytorch/pytorch/actions/runs/30548984515
