### PR TITLE
[test/xpu] fix test_prepare_for_pickle_clears_benchmark_failure_reasons stream selection

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -4055,18 +4055,7 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         xnumel = 256
         inp = torch.randn(xnumel, device=GPU_TYPE)
         out = torch.empty_like(inp)
-        current_stream = torch.get_device_module(GPU_TYPE).current_stream()
-        stream = next(
-            filter(
-                lambda x: x is not None,
-                (
-                    getattr(current_stream, "cuda_stream", None),
-                    getattr(current_stream, "sycl_queue", None),
-                ),
-            ),
-            None,
-        )
-        autotuner.run(inp, out, xnumel, stream=stream)
+        autotuner.run(inp, out, xnumel, stream=torch.accelerator.current_stream().native_handle
         self.assertEqual(out, inp + 1.0)
 
         # Inject a launcher key into benchmark_failure_reasons — this is how

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -4055,7 +4055,7 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         xnumel = 256
         inp = torch.randn(xnumel, device=GPU_TYPE)
         out = torch.empty_like(inp)
-        autotuner.run(inp, out, xnumel, stream=torch.accelerator.current_stream().native_handle
+        autotuner.run(inp, out, xnumel, stream=torch.accelerator.current_stream().native_handle)
         self.assertEqual(out, inp + 1.0)
 
         # Inject a launcher key into benchmark_failure_reasons — this is how

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -65,7 +65,10 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_SLOW,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_triton
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.triton_utils import (
+    requires_cuda_and_triton,
+    requires_gpu_and_triton,
+)
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils.checkpoint import (
     checkpoint,
@@ -4004,7 +4007,7 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         ):
             AOTAutogradCache._pickle_entry(entry, remote=False)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_prepare_for_pickle_clears_benchmark_failure_reasons(self):
         """prepare_for_pickle clears benchmark_failure_reasons which can hold
         exec'd launcher keys that aren't picklable.
@@ -4052,7 +4055,18 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         xnumel = 256
         inp = torch.randn(xnumel, device=GPU_TYPE)
         out = torch.empty_like(inp)
-        autotuner.run(inp, out, xnumel, stream=torch.cuda.current_stream().cuda_stream)
+        current_stream = torch.get_device_module(GPU_TYPE).current_stream()
+        stream = next(
+            filter(
+                lambda x: x is not None,
+                (
+                    getattr(current_stream, "cuda_stream", None),
+                    getattr(current_stream, "sycl_queue", None),
+                ),
+            ),
+            None,
+        )
+        autotuner.run(inp, out, xnumel, stream=stream)
         self.assertEqual(out, inp + 1.0)
 
         # Inject a launcher key into benchmark_failure_reasons — this is how

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -4055,7 +4055,9 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         xnumel = 256
         inp = torch.randn(xnumel, device=GPU_TYPE)
         out = torch.empty_like(inp)
-        autotuner.run(inp, out, xnumel, stream=torch.accelerator.current_stream().native_handle)
+        autotuner.run(
+            inp, out, xnumel, stream=torch.accelerator.current_stream().native_handle
+        )
         self.assertEqual(out, inp + 1.0)
 
         # Inject a launcher key into benchmark_failure_reasons — this is how


### PR DESCRIPTION
## Summary

`test_prepare_for_pickle_clears_benchmark_failure_reasons` in `test/dynamo/test_aot_autograd_cache.py` hardcodes `torch.cuda.current_stream().cuda_stream` for the Triton launcher stream kwarg. On XPU this either raises `AssertionError` (no CUDA) or, when CUDA and XPU coexist, yields `cuda_stream=None` which fails at `_StaticXpuLauncher._launch_kernel` with `argument 9 must be int, not None`.

## Fix

Use `torch.accelerator.current_stream().native_handle`, the accelerator-agnostic API on the base `torch.Stream` that returns the raw stream handle as an `int` (equals `.cuda_stream` on CUDA and `.sycl_queue` on XPU). Widen `@requires_cuda_and_triton` to `@requires_gpu_and_triton` so the test actually runs on XPU.

Thanks to @guangyey for pointing out `torch.Stream.native_handle`.

## Test Plan

```
python test/dynamo/test_aot_autograd_cache.py -v \
    -k test_prepare_for_pickle_clears_benchmark_failure_reasons
# -> Ran 1 test in 1.287s: OK
```

Authored with assistance from an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
