### PR TITLE
[test/distributions] make test_laplace scale_1d positive

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3516,7 +3516,7 @@ class TestDistributions(DistributionsTestCase):
         loc = torch.randn(5, 5, requires_grad=True)
         scale = torch.randn(5, 5).abs().requires_grad_()
         loc_1d = torch.randn(1, requires_grad=True)
-        scale_1d = torch.randn(1, requires_grad=True)
+        scale_1d = torch.randn(1).abs().requires_grad_()
         loc_delta = torch.tensor([1.0, 0.0])
         scale_delta = torch.tensor([1e-5, 1e-5])
         self.assertEqual(Laplace(loc, scale).sample().size(), (5, 5))


### PR DESCRIPTION
## Summary

`Laplace`'s scale parameter must be positive:

```python
class Laplace(Distribution):
    arg_constraints = {"loc": constraints.real, "scale": constraints.positive}
```

but `test_laplace` builds `scale_1d` from raw `torch.randn`:

```python
scale_1d = torch.randn(1, requires_grad=True)
```

`torch.randn` draws from a standard normal, so ~50% of CPU runs produce a negative value and the `Distribution` `validate_args` check raises `ValueError`. Under a non-CPU default device this shows up as a deterministic failure because the pre-seeded generator happens to draw a negative sample.

All the other `scale_*` tensors in this test already go through `.abs()` and `requires_grad_()`; make `scale_1d` follow the same pattern.

## Test Plan

```
python test/distributions/test_distributions.py -v -k test_laplace
```

Authored with assistance from an AI coding agent.