### PR TITLE
Remove unreachable duplicate return in fallback is_torchdynamo_compiling

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -33,8 +33,6 @@ except Exception:
 
     def is_torchdynamo_compiling():  # type: ignore[misc]
         return False
-        # pyrefly: ignore [unreachable]
-        return False
 
 
 """


### PR DESCRIPTION
## Summary

Fixes a small dead-code issue in `torch/distributed/_functional_collectives.py`: the fallback definition of `is_torchdynamo_compiling()` (used when `from torch.compiler import is_dynamo_compiling` fails) contained two consecutive `return False` statements. The second one, and its `# pyrefly: ignore [unreachable]` suppression comment, is unreachable dead code.

This removes the unreachable statement and the now-unnecessary suppression comment. No runtime behavior change.

This is a first-good-issue reported on GitHub; the fix itself is a one-line dead-code removal, verified by inspection and by parsing the resulting function body with `ast`.

## Test plan

- Confirmed via `ast.parse` that the function body now consists of a single `return False` statement.
- No behavior change; existing import/fallback coverage remains sufficient.

---
Note: this PR description was drafted with AI assistance; the change itself is a two-line deletion that I reviewed and take responsibility for.