### PR TITLE
[PyTorch][Inductor] Avoid expanded cat materialization in BMM (#191581)

### DIFF
--- a/test/inductor/test_cat_expand_bmm.py
+++ b/test/inductor/test_cat_expand_bmm.py
@@ -1,0 +1,827 @@
+# Owner(s): ["module: inductor"]
+
+import warnings
+
+import torch
+import torch._inductor.config as inductor_config
+from torch._dynamo.utils import counters
+from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import is_big_gpu, run_and_get_code
+from torch._subclasses.fake_tensor import unset_fake_temporarily
+from torch.testing import FileCheck
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+
+
+aten = torch.ops.aten
+_REJECTION_PREDICATES = (
+    "backend",
+    "topology",
+    "rank",
+    "batch_one_base",
+    "cat_dimension",
+    "shape_stride_identity",
+    "users",
+    "unsupported_dtype",
+    "unsupported_device",
+    "dtype_device_layout",
+    "bmm_compatibility",
+)
+_RANK_REJECTION_DETAILS = ("cat_rhs", "expand", "base")
+
+
+@instantiate_parametrized_tests
+class CatExpandBmmTest(TestCase):
+    def _assert_rejection_counters(self, expected, expected_rank_detail=None):
+        """Assert that validation recorded only the expected rejection."""
+
+        for predicate in _REJECTION_PREDICATES:
+            self.assertEqual(
+                counters["inductor"][f"cat_expand_bmm_rejected_{predicate}"],
+                int(predicate == expected),
+            )
+        for detail in _RANK_REJECTION_DETAILS:
+            self.assertEqual(
+                counters["inductor"][f"cat_expand_bmm_rejected_rank_{detail}"],
+                int(detail == expected_rank_detail),
+            )
+
+    def _run_admission_case(
+        self,
+        dtype,
+        backends,
+        *,
+        device="cpu",
+        rows=2,
+        reduction=8,
+        columns=4,
+        batch=3,
+        max_autotune=False,
+    ):
+        """Compile one backend-admission case and capture its BMM LHS stride."""
+
+        def fn(weights, rhs):
+            lhs = torch.cat(
+                [weight.expand(rhs.shape[0], -1, -1) for weight in weights], dim=1
+            )
+            return torch.bmm(lhs, rhs)
+
+        weights = [
+            torch.randn(1, rows, reduction, device=device, dtype=dtype)
+            for _ in range(2)
+        ]
+        rhs = torch.randn(batch, reduction, columns, device=device, dtype=dtype)
+        lhs_strides = []
+
+        def record_bmm_lhs_stride(graph):
+            bmm = next(
+                iter(graph.find_nodes(op="call_function", target=aten.bmm.default))
+            )
+            lhs_strides.append(bmm.args[0].meta["val"].stride())
+
+        torch._dynamo.reset()
+        counters.clear()
+        expected = fn(weights, rhs)
+        with inductor_config.patch(
+            cat_expand_bmm_rewrite=True,
+            max_autotune=max_autotune,
+            max_autotune_gemm_backends=backends,
+            post_grad_custom_post_pass=record_bmm_lhs_stride,
+        ):
+            actual = torch.compile(fn, fullgraph=True)(weights, rhs)
+        return actual, expected, lhs_strides
+
+    @parametrize("cat_dim", [1, 2])
+    @parametrize("outer_expand", [False, True])
+    @parametrize("direct_rank3", [False, True])
+    def test_rewrite(self, cat_dim, outer_expand, direct_rank3):
+        def fn(weights, rhs):
+            lhs = torch.cat(
+                [
+                    (weight if direct_rank3 else weight.unsqueeze(0)).expand(
+                        rhs.shape[0], -1, -1
+                    )
+                    for weight in weights
+                ],
+                dim=cat_dim,
+            )
+            if outer_expand:
+                lhs = lhs.expand(rhs.shape[0], lhs.shape[1], lhs.shape[2])
+            return torch.bmm(lhs, rhs)
+
+        if cat_dim == 1:
+            weight_shapes = [(index % 3 + 1, 8) for index in range(15)]
+        else:
+            weight_shapes = [(4, 2), (4, 3), (4, 3)]
+        if direct_rank3:
+            weight_shapes = [(1, *shape) for shape in weight_shapes]
+        weights = [
+            torch.randn(shape, device="cpu", dtype=torch.float16)
+            for shape in weight_shapes
+        ]
+        rhs = torch.randn(4, 8, 6, device="cpu", dtype=torch.float16)
+        lhs_strides = []
+
+        def record_bmm_lhs_stride(graph):
+            for node in graph.find_nodes(op="call_function", target=aten.bmm.default):
+                lhs_strides.append(node.args[0].meta["val"].stride())
+
+        torch._dynamo.reset()
+        counters.clear()
+        expected = fn(weights, rhs)
+        with inductor_config.patch(
+            cat_expand_bmm_rewrite=True,
+            max_autotune_gemm_backends="ATEN",
+            post_grad_custom_post_pass=record_bmm_lhs_stride,
+        ):
+            actual = torch.compile(fn, fullgraph=True)(weights, rhs)
+
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 1)
+        self.assertEqual(
+            counters["inductor"]["cat_expand_outer_to_batch_stride_zero"],
+            int(outer_expand),
+        )
+        self.assertEqual(len(lhs_strides), 1)
+        self.assertEqual(lhs_strides[0][0], 0)
+
+    def test_production_topology(self):
+        def fn(weights, rhs):
+            lhs = torch.cat(
+                [weight.expand(rhs.shape[0], -1, -1) for weight in weights], dim=1
+            )
+            lhs = lhs.expand(rhs.shape[0], lhs.shape[1], lhs.shape[2])
+            return torch.bmm(lhs, rhs)
+
+        weights = [
+            torch.randn(1, 10, 1890, device="cpu", dtype=torch.float16)
+            for _ in range(15)
+        ]
+        rhs = torch.randn(2, 1890, 256, device="cpu", dtype=torch.float16)
+        lhs_metadata = []
+
+        def record_bmm_lhs_metadata(graph):
+            for node in graph.find_nodes(op="call_function", target=aten.bmm.default):
+                lhs = node.args[0].meta["val"]
+                lhs_metadata.append((lhs.shape, lhs.stride()))
+
+        torch._dynamo.reset()
+        counters.clear()
+        torch._dynamo.mark_dynamic(rhs, 0)
+        compiled = torch.compile(fn, fullgraph=True)
+        with inductor_config.patch(
+            cat_expand_bmm_rewrite=True,
+            max_autotune_gemm_backends="ATEN",
+            post_grad_custom_post_pass=record_bmm_lhs_metadata,
+        ):
+            actual, (code,) = run_and_get_code(compiled, weights, rhs)
+            second_rhs = torch.randn(3, 1890, 256, device="cpu", dtype=torch.float16)
+            second_actual = compiled(weights, second_rhs)
+
+        torch.testing.assert_close(actual, fn(weights, rhs))
+        torch.testing.assert_close(second_actual, fn(weights, second_rhs))
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 1)
+        self.assertEqual(
+            counters["inductor"]["cat_expand_outer_to_batch_stride_zero"], 1
+        )
+        self.assertEqual(len(lhs_metadata), 1)
+        self.assertEqual(lhs_metadata[0][0][1:], (150, 1890))
+        self.assertEqual(lhs_metadata[0][1], (0, 1890, 1))
+        self._assert_rejection_counters(None)
+        FileCheck().check_regex(r"reinterpret_tensor\([^\n]*\(0, 1890, 1\), 0\)").run(
+            code
+        )
+
+    def test_production_topology_rank2_base(self):
+        def fn(weights, rhs):
+            lhs = torch.cat(
+                [weight.expand(rhs.shape[0], -1, -1) for weight in weights], dim=1
+            )
+            lhs = lhs.expand(rhs.shape[0], lhs.shape[1], lhs.shape[2])
+            rhs = rhs.expand(rhs.shape[0], rhs.shape[1], rhs.shape[2])
+            return torch.bmm(lhs, rhs)
+
+        weights = [
+            torch.randn(10, 1890, device="cpu", dtype=torch.float16) for _ in range(15)
+        ]
+        rhs = torch.randn(2, 1890, 256, device="cpu", dtype=torch.float16)
+        graph_metadata = []
+        rewritten_lhs_metadata = []
+
+        def record_graph_metadata(graph):
+            bmm = next(
+                iter(graph.find_nodes(op="call_function", target=aten.bmm.default))
+            )
+            outer_expand = bmm.args[0]
+            cat = outer_expand.args[0]
+            expands = cat.args[0]
+            bases = [expand.args[0] for expand in expands]
+            graph_metadata.append(
+                {
+                    "bases": [
+                        (tuple(base.meta["val"].shape), base.meta["val"].stride())
+                        for base in bases
+                    ],
+                    "expands": [
+                        (
+                            tuple(expand.meta["val"].shape[1:]),
+                            expand.meta["val"].stride(),
+                        )
+                        for expand in expands
+                    ],
+                    "cat": (
+                        tuple(cat.meta["val"].shape[1:]),
+                        cat.meta["val"].stride(),
+                    ),
+                    "outer_expand": (
+                        tuple(outer_expand.meta["val"].shape[1:]),
+                        outer_expand.meta["val"].stride(),
+                    ),
+                    "rhs": (
+                        bmm.args[1].target,
+                        tuple(bmm.args[1].meta["val"].shape[1:]),
+                        bmm.args[1].meta["val"].stride(),
+                    ),
+                    "bmm": (
+                        tuple(bmm.meta["val"].shape[1:]),
+                        bmm.meta["val"].stride(),
+                    ),
+                }
+            )
+
+        def record_rewritten_lhs_metadata(graph):
+            bmm = next(
+                iter(graph.find_nodes(op="call_function", target=aten.bmm.default))
+            )
+            lhs = bmm.args[0].meta["val"]
+            rewritten_lhs_metadata.append((tuple(lhs.shape[1:]), lhs.stride()))
+
+        torch._dynamo.reset()
+        counters.clear()
+        expected = fn(weights, rhs)
+        torch._dynamo.mark_dynamic(rhs, 0)
+        with inductor_config.patch(
+            cat_expand_bmm_rewrite=True,
+            max_autotune_gemm_backends="ATEN",
+            post_grad_custom_pre_pass=record_graph_metadata,
+            post_grad_custom_post_pass=record_rewritten_lhs_metadata,
+        ):
+            actual = torch.compile(fn, fullgraph=True)(weights, rhs)
+
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 1)
+        self.assertEqual(
+            counters["inductor"]["cat_expand_outer_to_batch_stride_zero"], 1
+        )
+        self._assert_rejection_counters(None)
+        self.assertEqual(len(graph_metadata), 1)
+        metadata = graph_metadata[0]
+        self.assertEqual(
+            metadata["bases"], [((10, 1890), (1890, 1)) for _ in range(15)]
+        )
+        self.assertEqual(
+            metadata["expands"],
+            [((10, 1890), (0, 1890, 1)) for _ in range(15)],
+        )
+        self.assertEqual(metadata["cat"], ((150, 1890), (283500, 1890, 1)))
+        self.assertEqual(metadata["outer_expand"], ((150, 1890), (283500, 1890, 1)))
+        self.assertEqual(
+            metadata["rhs"],
+            (aten.expand.default, (1890, 256), (483840, 256, 1)),
+        )
+        self.assertEqual(metadata["bmm"], ((150, 256), (38400, 256, 1)))
+        self.assertEqual(rewritten_lhs_metadata, [((150, 1890), (0, 1890, 1))])
+
+    def test_rewrite_disabled(self):
+        def fn(weights, rhs):
+            lhs = torch.cat(
+                [
+                    weight.unsqueeze(0).expand(rhs.shape[0], -1, -1)
+                    for weight in weights
+                ],
+                dim=1,
+            )
+            return torch.bmm(lhs, rhs)
+
+        weights = [
+            torch.randn(rows, 8, device="cpu", dtype=torch.float16) for rows in (2, 3)
+        ]
+        rhs = torch.randn(4, 8, 6, device="cpu", dtype=torch.float16)
+        lhs_strides = []
+
+        def record_bmm_lhs_stride(graph):
+            bmm = next(
+                iter(graph.find_nodes(op="call_function", target=aten.bmm.default))
+            )
+            lhs_strides.append(bmm.args[0].meta["val"].stride())
+
+        torch._dynamo.reset()
+        counters.clear()
+        expected = fn(weights, rhs)
+        with inductor_config.patch(
+            cat_expand_bmm_rewrite=False,
+            max_autotune_gemm_backends="ATEN",
+            post_grad_custom_post_pass=record_bmm_lhs_stride,
+        ):
+            actual = torch.compile(fn, fullgraph=True)(weights, rhs)
+
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 0)
+        self.assertEqual(lhs_strides, [(40, 8, 1)])
+        self._assert_rejection_counters(None)
+
+    def test_rewrite_rejected_ck_backend(self):
+        actual, expected, lhs_strides = self._run_admission_case(
+            torch.float16, "ATEN,CK"
+        )
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 0)
+        self.assertNotEqual(lhs_strides[0][0], 0)
+        self._assert_rejection_counters("backend")
+
+    @parametrize("backend", ["CKTILE", "NVGEMM", "CUTEDSL", "FUTURE_BACKEND"])
+    def test_rewrite_rejected_unsupported_backend(self, backend):
+        actual, expected, lhs_strides = self._run_admission_case(
+            torch.float16, f"ATEN,{backend}"
+        )
+
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 0)
+        self.assertNotEqual(lhs_strides[0][0], 0)
+        self._assert_rejection_counters("backend")
+
+    @parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_rewrite_rejected_unsupported_dtype(self, dtype):
+        actual, expected, lhs_strides = self._run_admission_case(
+            dtype, "ATEN,TRITON,CPP,CUTLASS"
+        )
+
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 0)
+        self.assertNotEqual(lhs_strides[0][0], 0)
+        self._assert_rejection_counters("unsupported_dtype")
+
+    def test_rewrite_allowed_backend_set(self):
+        if not HAS_GPU:
+            self.skipTest("CUDA backend admission requires a GPU")
+
+        actual, expected, lhs_strides = self._run_admission_case(
+            torch.float16,
+            "ATEN,TRITON,CPP,CUTLASS",
+            device=GPU_TYPE,
+        )
+
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 1)
+        self.assertEqual(lhs_strides[0][0], 0)
+        self._assert_rejection_counters(None)
+
+    def test_rewrite_rejected_cpp_backend_on_cpu(self):
+        actual, expected, lhs_strides = self._run_admission_case(
+            torch.float16,
+            "CPP",
+            rows=96,
+            reduction=196,
+            columns=84,
+            batch=2,
+            max_autotune=True,
+        )
+
+        torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 0)
+        self.assertNotEqual(lhs_strides[0][0], 0)
+        self.assertEqual(counters["inductor"]["cpp_templated_kernel_counter"], 1)
+        self._assert_rejection_counters("backend")
+
+    def _run_safe_gpu_backend(self, backend):
+        """Compile and verify the rewrite for one GPU BMM backend."""
+
+        if not HAS_GPU:
+            self.skipTest("GPU is unavailable")
+        if backend != "ATEN" and not is_big_gpu():
+            self.skipTest(f"{backend} templates require a big GPU")
+
+        def fn(weights, rhs):
+            lhs = torch.cat(
+                [weight.expand(rhs.shape[0], -1, -1) for weight in weights], dim=1
+            )
+            return torch.bmm(lhs, rhs)
+
+        weights = [
+            torch.randn(1, 32, 64, device=GPU_TYPE, dtype=torch.float16)
+            for _ in range(2)
+        ]
+        rhs = torch.randn(2, 64, 64, device=GPU_TYPE, dtype=torch.float16)
+        lhs_strides = []
+
+        def record_bmm_lhs_stride(graph):
+            bmm = next(
+                iter(graph.find_nodes(op="call_function", target=aten.bmm.default))
+            )
+            lhs_strides.append(bmm.args[0].meta["val"].stride())
+
+        torch._dynamo.reset()
+        counters.clear()
+        expected = fn(weights, rhs)
+        with inductor_config.patch(
+            cat_expand_bmm_rewrite=True,
+            max_autotune=True,
+            max_autotune_gemm_backends=backend,
+            post_grad_custom_post_pass=record_bmm_lhs_stride,
+        ):
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, fullgraph=True), weights, rhs
+            )
+
+        torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 1)
+        self.assertEqual(lhs_strides[0][0], 0)
+        expected_code = {
+            "ATEN": "extern_kernels.bmm",
+            "TRITON": "triton_tem_fused_bmm",
+            "CUTLASS": "cutlass_",
+        }[backend]
+        FileCheck().check(expected_code).run(code)
+
+    @parametrize("backend", ["ATEN", "TRITON"])
+    def test_rewrite_safe_common_gpu_backend(self, backend):
+        self._run_safe_gpu_backend(backend)
+
+    def test_rewrite_safe_cuda_cutlass_backend(self):
+        if GPU_TYPE != "cuda" or torch.version.hip:
+            self.skipTest("CUTLASS is unavailable on this GPU backend")
+        from torch._inductor.codegen.cutlass.utils import try_import_cutlass
+
+        if not try_import_cutlass():
+            self.skipTest("CUTLASS is unavailable in this test environment")
+        self._run_safe_gpu_backend("CUTLASS")
+
+    @parametrize("device", [GPU_TYPE, "cpu"])
+    @parametrize("direct_rank3", [False, True])
+    def test_dynamic_batch(self, device, direct_rank3):
+        if device != "cpu" and not HAS_GPU:
+            self.skipTest("GPU is unavailable")
+
+        def fn(weights, rhs):
+            lhs = torch.cat(
+                [
+                    (weight if direct_rank3 else weight.unsqueeze(0)).expand(
+                        rhs.shape[0], -1, -1
+                    )
+                    for weight in weights
+                ],
+                dim=1,
+            )
+            return torch.bmm(lhs, rhs)
+
+        weight_shapes = [(rows, 8) for rows in (2, 3, 4)]
+        if direct_rank3:
+            weight_shapes = [(1, *shape) for shape in weight_shapes]
+        weights = [
+            torch.randn(shape, device=device, dtype=torch.float16)
+            for shape in weight_shapes
+        ]
+        rhs = torch.randn(3, 8, 6, device=device, dtype=torch.float16)
+        lhs_strides = []
+
+        def record_bmm_lhs_stride(graph):
+            for node in graph.find_nodes(op="call_function", target=aten.bmm.default):
+                lhs_strides.append(node.args[0].meta["val"].stride())
+
+        torch._dynamo.reset()
+        counters.clear()
+        torch._dynamo.mark_dynamic(rhs, 0)
+        compiled = torch.compile(fn, fullgraph=True)
+        with inductor_config.patch(
+            cat_expand_bmm_rewrite=True,
+            max_autotune_gemm_backends="ATEN",
+            post_grad_custom_post_pass=record_bmm_lhs_stride,
+        ):
+            actual, (code,) = run_and_get_code(compiled, weights, rhs)
+            second_rhs = torch.randn(5, 8, 6, device=device, dtype=torch.float16)
+            second_actual = compiled(weights, second_rhs)
+
+        torch.testing.assert_close(actual, fn(weights, rhs))
+        torch.testing.assert_close(second_actual, fn(weights, second_rhs))
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 1)
+        self.assertEqual(len(lhs_strides), 1)
+        self.assertEqual(lhs_strides[0][0], 0)
+        FileCheck().check_regex(r"reinterpret_tensor\([^\n]*\(0, 8, 1\), 0\)").run(code)
+
+    @parametrize("outer_expand", [False, True])
+    def test_rewrite_rejected_rhs_alias(self, outer_expand):
+        def fn(weights):
+            lhs = torch.cat(
+                [weight.unsqueeze(0).expand(3, -1, -1) for weight in weights],
+                dim=1,
+            )
+            if outer_expand:
+                lhs = lhs.expand(3, lhs.shape[1], lhs.shape[2])
+            return torch.bmm(lhs, lhs)
+
+        weights = [
+            torch.randn(2, 4, device="cpu", dtype=torch.float16) for _ in range(2)
+        ]
+
+        torch._dynamo.reset()
+        counters.clear()
+        expected = fn(weights)
+        with inductor_config.patch(
+            cat_expand_bmm_rewrite=True,
+            max_autotune_gemm_backends="ATEN",
+        ):
+            actual = torch.compile(fn, fullgraph=True)(weights)
+
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 0)
+        self.assertEqual(
+            counters["inductor"]["cat_expand_outer_to_batch_stride_zero"], 0
+        )
+        self._assert_rejection_counters("users")
+
+    def test_rewrite_rejected_duplicate_expand(self):
+        def fn(weight, rhs):
+            expands = [
+                weight.unsqueeze(0).expand(rhs.shape[0], -1, -1) for _ in range(2)
+            ]
+            lhs = torch.cat(expands, dim=1)
+            return torch.bmm(lhs, rhs)
+
+        weight = torch.randn(2, 4, device="cpu", dtype=torch.float16)
+        rhs = torch.randn(3, 4, 5, device="cpu", dtype=torch.float16)
+        duplicate_inputs = []
+
+        def force_duplicate_expand(graph):
+            bmm = next(
+                iter(graph.find_nodes(op="call_function", target=aten.bmm.default))
+            )
+            cat = bmm.args[0]
+            expands = cat.args[0]
+            cat.update_arg(0, [expands[0], expands[0]])
+            duplicate_inputs.append(cat.args[0][0] is cat.args[0][1])
+
+        torch._dynamo.reset()
+        counters.clear()
+        expected = fn(weight, rhs)
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            with inductor_config.patch(
+                cat_expand_bmm_rewrite=True,
+                max_autotune_gemm_backends="ATEN",
+                post_grad_custom_pre_pass=force_duplicate_expand,
+            ):
+                actual = torch.compile(fn, fullgraph=True)(weight, rhs)
+
+        erase_warnings = [
+            str(warning.message)
+            for warning in caught_warnings
+            if "on an already erased node" in str(warning.message)
+        ]
+        self.assertEqual(duplicate_inputs, [True])
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(erase_warnings, [])
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 0)
+        self._assert_rejection_counters("users")
+
+    @parametrize(
+        "case",
+        [
+            "batch_cat",
+            "non_batch_expand",
+            "non_batch_unsqueeze",
+            "multiple_consumers",
+            "expand_multiple_consumers",
+            "outer_expand_broadcast",
+            "outer_expand_multiple_consumers",
+            "non_bmm_consumer",
+        ],
+    )
+    def test_rewrite_rejected(self, case):
+        expected_rejection = {
+            "batch_cat": None,
+            "non_batch_expand": "shape_stride_identity",
+            "non_batch_unsqueeze": "batch_one_base",
+            "multiple_consumers": None,
+            "outer_expand_broadcast": "shape_stride_identity",
+            "outer_expand_multiple_consumers": None,
+            "expand_multiple_consumers": None,
+            "non_bmm_consumer": None,
+        }[case]
+        if case == "batch_cat":
+            weights = [
+                torch.randn(2, 5, device="cpu", dtype=torch.float16) for _ in range(2)
+            ]
+            rhs = torch.randn(4, 5, 3, device="cpu", dtype=torch.float16)
+
+            def fn(weights, rhs):
+                batch = rhs.shape[0] // len(weights)
+                lhs = torch.cat(
+                    [weight.unsqueeze(0).expand(batch, -1, -1) for weight in weights],
+                    dim=0,
+                )
+                return torch.bmm(lhs, rhs)
+
+        elif case == "non_batch_expand":
+            weights = [
+                torch.randn(1, 5, device="cpu", dtype=torch.float16) for _ in range(2)
+            ]
+            rhs = torch.randn(3, 5, 4, device="cpu", dtype=torch.float16)
+
+            def fn(weights, rhs):
+                lhs = torch.cat(
+                    [
+                        weight.unsqueeze(0).expand(rhs.shape[0], 2, -1)
+                        for weight in weights
+                    ],
+                    dim=1,
+                )
+                return torch.bmm(lhs, rhs)
+
+        elif case == "non_batch_unsqueeze":
+            weights = [
+                torch.randn(3, 5, device="cpu", dtype=torch.float16) for _ in range(2)
+            ]
+            rhs = torch.randn(3, 5, 4, device="cpu", dtype=torch.float16)
+
+            def fn(weights, rhs):
+                lhs = torch.cat(
+                    [weight.unsqueeze(1).expand(-1, 2, -1) for weight in weights],
+                    dim=1,
+                )
+                return torch.bmm(lhs, rhs)
+
+        elif case == "outer_expand_broadcast":
+            weights = [
+                torch.randn(2, 5, device="cpu", dtype=torch.float16) for _ in range(2)
+            ]
+            rhs = torch.randn(3, 5, 4, device="cpu", dtype=torch.float16)
+
+            def fn(weights, rhs):
+                lhs = torch.cat(
+                    [weight.unsqueeze(0).expand(1, -1, -1) for weight in weights],
+                    dim=1,
+                )
+                lhs = lhs.expand(rhs.shape[0], lhs.shape[1], lhs.shape[2])
+                return torch.bmm(lhs, rhs)
+
+        else:
+            weights = [
+                torch.randn(2, 5, device="cpu", dtype=torch.float16) for _ in range(2)
+            ]
+            rhs = torch.randn(3, 5, 4, device="cpu", dtype=torch.float16)
+
+            def fn(weights, rhs):
+                expands = [
+                    weight.unsqueeze(0).expand(rhs.shape[0], -1, -1)
+                    for weight in weights
+                ]
+                lhs = torch.cat(expands, dim=1)
+                if case == "multiple_consumers":
+                    return torch.bmm(lhs, rhs), lhs
+                if case == "expand_multiple_consumers":
+                    return torch.bmm(lhs, rhs), expands[0]
+                if case == "outer_expand_multiple_consumers":
+                    lhs = lhs.expand(rhs.shape[0], lhs.shape[1], lhs.shape[2])
+                    return torch.bmm(lhs, rhs), lhs
+                return lhs + 1
+
+        torch._dynamo.reset()
+        counters.clear()
+        expected = fn(weights, rhs)
+        with inductor_config.patch(
+            cat_expand_bmm_rewrite=True,
+            max_autotune_gemm_backends="ATEN",
+        ):
+            actual = torch.compile(fn, fullgraph=True)(weights, rhs)
+
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 0)
+        self._assert_rejection_counters(expected_rejection)
+
+    @parametrize(
+        "metadata_case",
+        [
+            "missing",
+            "rank",
+            "rank_expand",
+            "rank_base",
+            "dtype",
+            "layout",
+            "unsupported_device",
+            "cat_dimension",
+            "bmm_compatibility",
+        ],
+    )
+    def test_rewrite_rejected_metadata(self, metadata_case):
+        def fn(weights, rhs):
+            lhs = torch.cat(
+                [weight.expand(rhs.shape[0], -1, -1) for weight in weights], dim=1
+            )
+            return torch.bmm(lhs, rhs)
+
+        weights = [
+            torch.randn(1, 2, 5, device="cpu", dtype=torch.float16) for _ in range(2)
+        ]
+        rhs = torch.randn(3, 5, 4, device="cpu", dtype=torch.float16)
+        saved_args = {}
+        saved_values = {}
+
+        def mutate_metadata(graph):
+            bmm = next(
+                iter(graph.find_nodes(op="call_function", target=aten.bmm.default))
+            )
+            if metadata_case == "unsupported_device":
+                cat = bmm.args[0]
+                expands = cat.args[0]
+                matched_nodes = [
+                    cat,
+                    bmm.args[1],
+                    *expands,
+                    *(expand.args[0] for expand in expands),
+                ]
+                with unset_fake_temporarily():
+                    for matched_node in matched_nodes:
+                        value = matched_node.meta["val"]
+                        saved_values[matched_node] = value
+                        matched_node.meta["val"] = torch.empty_strided(
+                            tuple(value.shape),
+                            tuple(value.stride()),
+                            dtype=value.dtype,
+                            device="meta",
+                        )
+                return
+            node = bmm.args[1] if metadata_case == "bmm_compatibility" else bmm.args[0]
+            if metadata_case in ("rank_expand", "rank_base"):
+                node = node.args[0][0]
+            if metadata_case == "rank_base":
+                node = node.args[0]
+            if metadata_case == "cat_dimension":
+                saved_args[node] = node.args
+                node.update_arg(1, 0)
+                return
+            saved_values[node] = node.meta["val"]
+            value = saved_values[node]
+            if metadata_case == "missing":
+                del node.meta["val"]
+            elif metadata_case in ("rank", "rank_expand"):
+                node.meta["val"] = value[0]
+            elif metadata_case == "rank_base":
+                node.meta["val"] = value[0, 0]
+            elif metadata_case == "dtype":
+                node.meta["val"] = value.to(torch.float64)
+            elif metadata_case == "layout":
+                with unset_fake_temporarily():
+                    node.meta["val"] = torch.empty(
+                        tuple(value.shape),
+                        dtype=value.dtype,
+                        device=value.device,
+                        layout=torch.sparse_coo,
+                    )
+            else:
+                node.meta["val"] = value.new_empty(
+                    (value.shape[0], value.shape[1] + 1, value.shape[2])
+                )
+
+        def restore_metadata(_graph):
+            for node, args in saved_args.items():
+                node.args = args
+            for node, value in saved_values.items():
+                node.meta["val"] = value
+
+        expected_rejection = {
+            "missing": "topology",
+            "rank": "rank",
+            "rank_expand": "rank",
+            "rank_base": "rank",
+            "dtype": "dtype_device_layout",
+            "layout": "dtype_device_layout",
+            "unsupported_device": "unsupported_device",
+            "cat_dimension": "cat_dimension",
+            "bmm_compatibility": "bmm_compatibility",
+        }[metadata_case]
+        expected_rank_detail = {
+            "rank": "cat_rhs",
+            "rank_expand": "expand",
+            "rank_base": "base",
+        }.get(metadata_case)
+        torch._dynamo.reset()
+        counters.clear()
+        expected = fn(weights, rhs)
+        with inductor_config.patch(
+            cat_expand_bmm_rewrite=True,
+            max_autotune_gemm_backends="ATEN",
+            post_grad_custom_pre_pass=mutate_metadata,
+            post_grad_custom_post_pass=restore_metadata,
+        ):
+            actual = torch.compile(fn, fullgraph=True)(weights, rhs)
+
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["cat_expand_to_batch_stride_zero"], 0)
+        self._assert_rejection_counters(expected_rejection, expected_rank_detail)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -222,6 +222,10 @@ apply_gumbel_max_trick = (
     os.environ.get("TORCHINDUCTOR_APPLY_GUMBEL_MAX_TRICK", "1") == "1"
 )
 
+cat_expand_bmm_rewrite = (
+    os.environ.get("TORCHINDUCTOR_CAT_EXPAND_BMM_REWRITE", "1") == "1"
+)
+
 # dead code elimination
 dce = False
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -6,7 +6,8 @@ import logging
 import operator
 from collections import Counter, defaultdict
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar
+from dataclasses import dataclass
+from typing import Any, cast, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -962,6 +963,549 @@ def register_lowering_pattern(
 #   - later output nodes first
 #   - order patterns are defined in
 ################################################################################
+
+
+# These backends have been audited for zero batch strides. CK is excluded because
+# its generated batched wrapper hardcodes dense strides. CPP remains in the
+# configuration allowlist for mixed CUDA settings, but CPU FP16 is rejected below.
+_CAT_EXPAND_BMM_ALLOWED_BACKENDS = ("ATEN", "TRITON", "CPP", "CUTLASS")
+_CAT_EXPAND_BMM_ALLOWED_DEVICE_TYPES = ("cpu", "cuda")
+
+
+@dataclass
+class _CatExpandBmmMatchNodes:
+    """FX nodes captured by a cat-expand-BMM pattern."""
+
+    bmm_node: torch.fx.Node
+    outer_expand_node: torch.fx.Node | None
+    cat_node: torch.fx.Node
+    rhs_node: torch.fx.Node
+    expand_nodes: list[torch.fx.Node]
+    base_nodes: list[torch.fx.Node]
+
+
+@dataclass
+class _CatExpandBmmRewritePlan:
+    """Validated data needed to rewrite a cat-expand-BMM match."""
+
+    match_nodes: _CatExpandBmmMatchNodes
+    tensor_values: dict[torch.fx.Node, torch.Tensor]
+    cat_dim: int
+    expand_size: list[Any]
+
+
+def _normalize_dim(dim: Any, rank: int) -> int | None:
+    """Normalize an integer dimension, returning None when it is invalid."""
+
+    if not isinstance(dim, int) or dim < -rank or dim >= rank:
+        return None
+    return dim % rank
+
+
+def _get_tensor_value(node: Any) -> torch.Tensor | None:
+    """Return tensor-valued ``val`` metadata from an FX node."""
+
+    if not isinstance(node, torch.fx.Node):
+        return None
+    value = node.meta.get("val")
+    return value if isinstance(value, torch.Tensor) else None
+
+
+def _are_statically_equal(left: Any, right: Any) -> bool:
+    """Return whether symbolic equality can be proven statically."""
+
+    return statically_known_true(sym_eq(left, right))
+
+
+def _sequences_are_statically_equal(left: Sequence[Any], right: Sequence[Any]) -> bool:
+    """Return whether two symbolic sequences are statically equal."""
+
+    return len(left) == len(right) and all(
+        _are_statically_equal(left_value, right_value)
+        for left_value, right_value in zip(left, right, strict=True)
+    )
+
+
+def _extract_cat_expand_bmm_match(
+    match: Match,
+) -> _CatExpandBmmMatchNodes | None:
+    """Extract the direct or outer-expand cat topology from a pattern match."""
+
+    bmm_node = match.output_node()
+    lhs_node = bmm_node.args[0]
+    rhs_node = bmm_node.args[1]
+    if not isinstance(lhs_node, torch.fx.Node) or not isinstance(
+        rhs_node, torch.fx.Node
+    ):
+        return None
+    outer_expand_node: torch.fx.Node | None = None
+    cat_node = lhs_node
+    if lhs_node.target == aten.expand.default:
+        candidate = get_arg_value(lhs_node, 0, "self")
+        if not isinstance(candidate, torch.fx.Node):
+            return None
+        outer_expand_node = lhs_node
+        cat_node = candidate
+    expand_nodes = get_arg_value(cat_node, 0, "tensors")
+    if not isinstance(expand_nodes, (list, tuple)) or not expand_nodes:
+        return None
+    if not all(isinstance(expand_node, torch.fx.Node) for expand_node in expand_nodes):
+        return None
+    base_nodes = [get_arg_value(expand_node, 0, "self") for expand_node in expand_nodes]
+    if not all(isinstance(base_node, torch.fx.Node) for base_node in base_nodes):
+        return None
+    return _CatExpandBmmMatchNodes(
+        bmm_node=bmm_node,
+        outer_expand_node=outer_expand_node,
+        cat_node=cat_node,
+        rhs_node=rhs_node,
+        expand_nodes=cast(list[torch.fx.Node], list(expand_nodes)),
+        base_nodes=cast(list[torch.fx.Node], base_nodes),
+    )
+
+
+def _reject_cat_expand_bmm(predicate: str) -> bool:
+    """Record a rejection predicate and return False for ``extra_check``."""
+
+    if predicate.startswith("rank_"):
+        counters["inductor"]["cat_expand_bmm_rejected_rank"] += 1
+    counters["inductor"][f"cat_expand_bmm_rejected_{predicate}"] += 1
+    return False
+
+
+def _cat_expand_bmm_matched_nodes(
+    match_nodes: _CatExpandBmmMatchNodes,
+) -> list[torch.fx.Node]:
+    """Return every node whose tensor metadata participates in validation."""
+
+    matched_nodes = [
+        match_nodes.cat_node,
+        match_nodes.rhs_node,
+        *match_nodes.expand_nodes,
+        *match_nodes.base_nodes,
+    ]
+    if match_nodes.outer_expand_node is not None:
+        matched_nodes.append(match_nodes.outer_expand_node)
+    return matched_nodes
+
+
+def _cat_expand_bmm_rank_rejection(
+    match_nodes: _CatExpandBmmMatchNodes,
+    tensor_values: dict[torch.fx.Node, torch.Tensor],
+) -> str | None:
+    """Return the rejection for an unsupported matched tensor rank."""
+
+    if (
+        tensor_values[match_nodes.cat_node].ndim != 3
+        or tensor_values[match_nodes.rhs_node].ndim != 3
+    ):
+        return "rank_cat_rhs"
+    if any(tensor_values[node].ndim != 3 for node in match_nodes.expand_nodes):
+        return "rank_expand"
+    if any(tensor_values[node].ndim not in (2, 3) for node in match_nodes.base_nodes):
+        return "rank_base"
+    return None
+
+
+def _cat_expand_bmm_tensor_property_rejection(
+    match_nodes: _CatExpandBmmMatchNodes,
+    tensor_values: dict[torch.fx.Node, torch.Tensor],
+) -> str | None:
+    """Require a common strided layout, dtype, and device across the match."""
+
+    cat_value = tensor_values[match_nodes.cat_node]
+    if any(
+        value.layout != torch.strided
+        or value.dtype != cat_value.dtype
+        or value.device != cat_value.device
+        for value in tensor_values.values()
+    ):
+        return "dtype_device_layout"
+    return None
+
+
+def _cat_expand_bmm_tensor_values(
+    match_nodes: _CatExpandBmmMatchNodes,
+) -> tuple[dict[torch.fx.Node, torch.Tensor] | None, str | None]:
+    """Collect tensor metadata and return the first metadata rejection."""
+
+    optional_values = {
+        node: _get_tensor_value(node)
+        for node in _cat_expand_bmm_matched_nodes(match_nodes)
+    }
+    if any(value is None for value in optional_values.values()):
+        return None, "topology"
+    tensor_values = cast(dict[torch.fx.Node, torch.Tensor], optional_values)
+    rejection = _cat_expand_bmm_rank_rejection(match_nodes, tensor_values)
+    if rejection is not None:
+        return None, rejection
+    rejection = _cat_expand_bmm_tensor_property_rejection(match_nodes, tensor_values)
+    if rejection is not None:
+        return None, rejection
+    return tensor_values, None
+
+
+def _outer_expand_is_metadata_identity(
+    match_nodes: _CatExpandBmmMatchNodes,
+    tensor_values: dict[torch.fx.Node, torch.Tensor],
+) -> bool:
+    """Return whether the optional outer expand preserves shape and strides."""
+
+    if match_nodes.outer_expand_node is None:
+        return True
+    outer_value = tensor_values[match_nodes.outer_expand_node]
+    cat_value = tensor_values[match_nodes.cat_node]
+    return (
+        outer_value.ndim == cat_value.ndim
+        and _sequences_are_statically_equal(outer_value.shape, cat_value.shape)
+        and _sequences_are_statically_equal(outer_value.stride(), cat_value.stride())
+    )
+
+
+def _batch_aligned_base_shapes(
+    match_nodes: _CatExpandBmmMatchNodes,
+    tensor_values: dict[torch.fx.Node, torch.Tensor],
+) -> list[Sequence[Any]]:
+    """Return base shapes with the implicit rank-2 batch dimension restored."""
+
+    return [
+        (1, *tensor_values[node].shape)
+        if tensor_values[node].ndim == 2
+        else tensor_values[node].shape
+        for node in match_nodes.base_nodes
+    ]
+
+
+def _expanded_shape_matches_base(
+    expand_shape: Sequence[Any],
+    base_shape: Sequence[Any],
+    batch_size: Any,
+) -> bool:
+    """Return whether an expand changes only the batch-one dimension."""
+
+    return _are_statically_equal(
+        expand_shape[0], batch_size
+    ) and _sequences_are_statically_equal(expand_shape[1:], base_shape[1:])
+
+
+def _cat_expand_source_shape_rejection(
+    cat_shape: Sequence[Any],
+    expand_shapes: Sequence[Sequence[Any]],
+    base_shapes: Sequence[Sequence[Any]],
+) -> str | None:
+    """Validate that every base is batch-invariant and expanded only in batch."""
+
+    if any(not _are_statically_equal(shape[0], 1) for shape in base_shapes):
+        return "batch_one_base"
+    if any(
+        not _expanded_shape_matches_base(expand_shape, base_shape, cat_shape[0])
+        for expand_shape, base_shape in zip(expand_shapes, base_shapes, strict=True)
+    ):
+        return "shape_stride_identity"
+    return None
+
+
+def _expand_shapes_match_non_cat_dimensions(
+    expand_shapes: Sequence[Sequence[Any]], cat_dim: int
+) -> bool:
+    """Return whether all expanded inputs agree outside the cat dimension."""
+
+    reference_shape = expand_shapes[0]
+    return all(
+        _are_statically_equal(shape[dim], reference_shape[dim])
+        for shape in expand_shapes[1:]
+        for dim in range(3)
+        if dim != cat_dim
+    )
+
+
+def _cat_result_shape_rejection(
+    cat_shape: Sequence[Any],
+    expand_shapes: Sequence[Sequence[Any]],
+    cat_dim: int,
+) -> str | None:
+    """Validate the concatenated shape implied by expanded inputs."""
+
+    expected_cat_shape = list(expand_shapes[0])
+    expected_cat_shape[cat_dim] = sum(shape[cat_dim] for shape in expand_shapes)
+    if not _sequences_are_statically_equal(cat_shape, expected_cat_shape):
+        return "shape_stride_identity"
+    if not _expand_shapes_match_non_cat_dimensions(expand_shapes, cat_dim):
+        return "shape_stride_identity"
+    return None
+
+
+def _cat_expand_bmm_shape_rejection(
+    match_nodes: _CatExpandBmmMatchNodes,
+    cat_dim: int,
+    tensor_values: dict[torch.fx.Node, torch.Tensor],
+) -> str | None:
+    """Return the first rejection from the cat/expand/BMM shape algebra."""
+
+    if not _outer_expand_is_metadata_identity(match_nodes, tensor_values):
+        return "shape_stride_identity"
+    cat_shape = tensor_values[match_nodes.cat_node].shape
+    rhs_shape = tensor_values[match_nodes.rhs_node].shape
+    expand_shapes = [tensor_values[node].shape for node in match_nodes.expand_nodes]
+    base_shapes = _batch_aligned_base_shapes(match_nodes, tensor_values)
+    rejection = _cat_expand_source_shape_rejection(
+        cat_shape, expand_shapes, base_shapes
+    )
+    if rejection is not None:
+        return rejection
+    rejection = _cat_result_shape_rejection(cat_shape, expand_shapes, cat_dim)
+    if rejection is not None:
+        return rejection
+    if not _are_statically_equal(
+        cat_shape[0], rhs_shape[0]
+    ) or not _are_statically_equal(cat_shape[2], rhs_shape[1]):
+        return "bmm_compatibility"
+    return None
+
+
+def _cat_expand_bmm_admission_rejection(
+    match_nodes: _CatExpandBmmMatchNodes,
+    tensor_values: dict[torch.fx.Node, torch.Tensor],
+) -> str | None:
+    """Return the dtype, device, or backend admission rejection."""
+
+    cat_value = tensor_values[match_nodes.cat_node]
+    # Restrict admission to the measured FP16 path. BF16 ATEN may route to CK,
+    # whose batched wrapper does not preserve the input batch stride.
+    if cat_value.dtype != torch.float16:
+        return "unsupported_dtype"
+    if cat_value.device.type not in _CAT_EXPAND_BMM_ALLOWED_DEVICE_TYPES:
+        return "unsupported_device"
+
+    backends = tuple(
+        backend.strip().upper()
+        for backend in config.max_autotune_gemm_backends.split(",")
+        if backend.strip()
+    )
+    # New BMM backends must prove zero-batch-stride support before admission.
+    if not backends or any(
+        backend not in _CAT_EXPAND_BMM_ALLOWED_BACKENDS for backend in backends
+    ):
+        return "backend"
+    # CPP only admits a zero batch stride for FP32, while this pass is FP16-only.
+    if cat_value.device.type == "cpu" and "CPP" in backends:
+        return "backend"
+    return None
+
+
+def _cat_expand_bmm_user_rejection(
+    match_nodes: _CatExpandBmmMatchNodes,
+) -> str | None:
+    """Validate node ownership required for safe graph erasure."""
+
+    cat_user = (
+        match_nodes.outer_expand_node
+        if match_nodes.outer_expand_node is not None
+        else match_nodes.bmm_node
+    )
+    if (
+        len(match_nodes.cat_node.users) != 1
+        or cat_user not in match_nodes.cat_node.users
+    ):
+        return "users"
+    if match_nodes.outer_expand_node is not None:
+        if (
+            len(match_nodes.outer_expand_node.users) != 1
+            or match_nodes.bmm_node not in match_nodes.outer_expand_node.users
+        ):
+            return "users"
+
+    # Node.users counts user nodes, not use-sites. Reject duplicate expand
+    # operands and RHS aliases explicitly before erasing the original chain.
+    if len(OrderedSet(match_nodes.expand_nodes)) != len(match_nodes.expand_nodes):
+        return "users"
+    nodes_to_erase = OrderedSet([match_nodes.cat_node, *match_nodes.expand_nodes])
+    if match_nodes.outer_expand_node is not None:
+        nodes_to_erase.add(match_nodes.outer_expand_node)
+    if match_nodes.rhs_node in nodes_to_erase:
+        return "users"
+    if any(len(expand_node.users) != 1 for expand_node in match_nodes.expand_nodes):
+        return "users"
+    return None
+
+
+def _cat_expand_bmm_expand_argument_rejection(
+    match_nodes: _CatExpandBmmMatchNodes,
+) -> str | None:
+    """Validate the rank of every expand size argument in the match."""
+
+    if match_nodes.outer_expand_node is not None:
+        outer_size = get_arg_value(match_nodes.outer_expand_node, 1, "size")
+        if not isinstance(outer_size, (list, tuple)) or len(outer_size) != 3:
+            return "topology"
+    if any(
+        not isinstance(size := get_arg_value(expand_node, 1, "size"), (list, tuple))
+        or len(size) != 3
+        for expand_node in match_nodes.expand_nodes
+    ):
+        return "topology"
+    return None
+
+
+def _build_cat_expand_bmm_rewrite_plan(
+    match: Match,
+) -> tuple[_CatExpandBmmRewritePlan | None, str | None]:
+    """Build a complete rewrite plan or return its rejection predicate."""
+
+    match_nodes = _extract_cat_expand_bmm_match(match)
+    if match_nodes is None:
+        return None, "topology"
+    tensor_values, rejection = _cat_expand_bmm_tensor_values(match_nodes)
+    if tensor_values is None:
+        return None, rejection
+    rejection = _cat_expand_bmm_admission_rejection(match_nodes, tensor_values)
+    if rejection is not None:
+        return None, rejection
+    cat_dim = _normalize_dim(get_arg_value(match_nodes.cat_node, 1, "dim"), 3)
+    if cat_dim is None or cat_dim == 0:
+        return None, "cat_dimension"
+    rejection = _cat_expand_bmm_user_rejection(match_nodes)
+    if rejection is not None:
+        return None, rejection
+    rejection = _cat_expand_bmm_expand_argument_rejection(match_nodes)
+    if rejection is not None:
+        return None, rejection
+    rejection = _cat_expand_bmm_shape_rejection(match_nodes, cat_dim, tensor_values)
+    if rejection is not None:
+        return None, rejection
+    first_expand_size = get_arg_value(match_nodes.expand_nodes[0], 1, "size")
+    if not isinstance(first_expand_size, (list, tuple)) or len(first_expand_size) != 3:
+        return None, "topology"
+    return (
+        _CatExpandBmmRewritePlan(
+            match_nodes=match_nodes,
+            tensor_values=tensor_values,
+            cat_dim=cat_dim,
+            expand_size=[first_expand_size[0], -1, -1],
+        ),
+        None,
+    )
+
+
+def _is_valid_cat_expand_bmm(match: Match) -> bool:
+    """Return whether a match has a complete, admitted rewrite plan."""
+
+    if not config.cat_expand_bmm_rewrite:
+        return False
+    rewrite_plan, rejection = _build_cat_expand_bmm_rewrite_plan(match)
+    if rewrite_plan is not None:
+        return True
+    if rejection is None:
+        log.debug("Cat-expand-BMM validation failed without a rejection predicate")
+    return _reject_cat_expand_bmm(rejection or "topology")
+
+
+_batch_broadcast_cat = CallFunction(
+    aten.cat.default,
+    ListOf(
+        CallFunction(
+            aten.expand.default,
+            Ignored(),
+            Ignored(),
+        )
+    ),
+    Ignored(),
+)
+
+_identity_expand_batch_broadcast_cat = CallFunction(
+    aten.expand.default,
+    _batch_broadcast_cat,
+    Ignored(),
+)
+
+
+@register_graph_pattern(
+    CallFunction(aten.bmm.default, _identity_expand_batch_broadcast_cat, Ignored()),
+    # pyrefly: ignore [bad-argument-type]
+    pass_dict=pass_patterns[1],
+    extra_check=_is_valid_cat_expand_bmm,
+)
+@register_graph_pattern(
+    CallFunction(aten.bmm.default, _batch_broadcast_cat, Ignored()),
+    # pyrefly: ignore [bad-argument-type]
+    pass_dict=pass_patterns[1],
+    extra_check=_is_valid_cat_expand_bmm,
+)
+def cat_expand_to_batch_stride_zero(match: Match) -> None:
+    """Move batch broadcast after cat so BMM reads a zero-batch-stride LHS.
+
+    Before: ``bmm(optional_expand(cat([expand(base_i)])), rhs)``
+    After:  ``bmm(expand(cat([unsqueeze_batch(base_i)])), rhs)``
+    """
+
+    if not config.cat_expand_bmm_rewrite:
+        log.debug("Skipping cat-expand-BMM rewrite after the feature was disabled")
+        return
+    rewrite_plan, rejection = _build_cat_expand_bmm_rewrite_plan(match)
+    if rewrite_plan is None:
+        log.debug(
+            "Skipping cat-expand-BMM rewrite after validation: %s",
+            rejection or "topology",
+        )
+        # Keep callback-phase rejections observable in the same counters as the
+        # extra_check phase, in case validation diverges after another pass ran.
+        _reject_cat_expand_bmm(rejection or "topology")
+        return
+
+    match_nodes = rewrite_plan.match_nodes
+    base_values = [
+        rewrite_plan.tensor_values[base_node] for base_node in match_nodes.base_nodes
+    ]
+    with match.graph.inserting_before(match_nodes.cat_node):
+        normalized_base_nodes: list[torch.fx.Node] = []
+        normalized_base_values: list[torch.Tensor] = []
+        for base_node, base_value in zip(
+            match_nodes.base_nodes, base_values, strict=True
+        ):
+            if base_value.ndim == 2:
+                # Removing rank-2 expand also removes its implicit batch dimension.
+                source_stack_trace = base_node.meta.get(
+                    "stack_trace", match_nodes.cat_node.meta.get("stack_trace")
+                )
+                base_node = match.graph.call_function(
+                    aten.unsqueeze.default, args=(base_node, 0)
+                )
+                base_value = aten.unsqueeze.default(base_value, 0)
+                base_node.meta["val"] = base_value
+                if source_stack_trace is not None:
+                    base_node.meta["stack_trace"] = source_stack_trace
+            normalized_base_nodes.append(base_node)
+            normalized_base_values.append(base_value)
+        batch_one_cat = match.graph.call_function(
+            aten.cat.default, args=(normalized_base_nodes, rewrite_plan.cat_dim)
+        )
+        zero_batch_stride_lhs = match.graph.call_function(
+            aten.expand.default, args=(batch_one_cat, rewrite_plan.expand_size)
+        )
+
+    batch_one_cat.meta["val"] = aten.cat.default(
+        normalized_base_values, rewrite_plan.cat_dim
+    )
+    zero_batch_stride_lhs.meta["val"] = aten.expand.default(
+        batch_one_cat.meta["val"],
+        list(rewrite_plan.tensor_values[match_nodes.cat_node].shape),
+    )
+    if "stack_trace" in match_nodes.cat_node.meta:
+        for node in (
+            batch_one_cat,
+            zero_batch_stride_lhs,
+        ):
+            node.meta["stack_trace"] = match_nodes.cat_node.meta["stack_trace"]
+
+    match_nodes.bmm_node.update_arg(0, zero_batch_stride_lhs)
+    if match_nodes.outer_expand_node is not None:
+        match.graph.erase_node(match_nodes.outer_expand_node)
+    match.graph.erase_node(match_nodes.cat_node)
+    for expand_node in match_nodes.expand_nodes:
+        match.graph.erase_node(expand_node)
+    counters["inductor"]["cat_expand_to_batch_stride_zero"] += 1
+    if match_nodes.outer_expand_node is not None:
+        counters["inductor"]["cat_expand_outer_to_batch_stride_zero"] += 1
 
 
 def is_valid_mm_plus_mm(match: Match):


### PR DESCRIPTION
Summary:

**Why**

- The production graph expands fifteen batch-invariant matrices, concatenates the expanded values, and feeds that dense result to `aten.bmm`. Each `aten.expand` is a view, but `aten.cat` still materializes the full `[B, 150, 1890]` left operand.
- Concatenating the batch-one sources first and expanding the combined result stores one `[1, 150, 1890]` allocation. `aten.bmm` sees the same logical `[B, 150, 1890]` tensor through stride `[0, 1890, 1]`, avoiding the batch-multiplied cat reads, writes, allocation, and lifetime.

**Graph transformation**

```lang=mermaid
flowchart LR
  subgraph before["Before"]
    direction LR
    E1["expand each base"] --> B1["dense cat + bmm"]
  end
  subgraph after["After"]
    direction LR
    C2["cat at batch 1"] --> B2["expand once + bmm<br/>batch stride 0"]
  end
  before ~~~ after
```

- The matcher accepts both `bmm(cat([expand(base_i)]), rhs)` and the production form with an additional metadata-identity `expand` between `cat` and `bmm`.
- Rank-2 bases require an explicit `unsqueeze(0)` after their implicit batch-creating expands are removed. Rank-3 batch-one bases flow directly into the new cat.

**Defensive admission**

- `_build_cat_expand_bmm_rewrite_plan` in `fbsource/fbcode/caffe2/torch/_inductor/fx_passes/post_grad.py:1345` validates typed metadata, ranks, devices, layouts, symbolic shapes, cat and BMM dimensions, backend support, and every graph node before mutation. The rewrite callback rebuilds that plan and logs and returns if it is no longer available; validation failures do not raise assertions.
- Erasure safety rejects shared nodes, duplicate expand entries, and a BMM RHS that aliases the cat, an inner expand, or the optional outer expand. This is explicit because `torch.fx.Node.users` counts distinct user nodes rather than use-sites.
- The rewrite is restricted to FP16 on CPU or CUDA with configured backends drawn from `ATEN`, `TRITON`, `CPP`, and `CUTLASS`. CK and unknown backends are rejected. CPU configurations containing `CPP` are rejected because its FP16 BMM path requires a dense batch stride; BF16 is rejected because ATEN can dispatch to CK.
- `TORCHINDUCTOR_CAT_EXPAND_BMM_REWRITE=0`, defined at `fbsource/fbcode/caffe2/torch/_inductor/config.py:225`, disables the rewrite. Rejection and application counters make admission decisions observable.

**Internal:** 

*Measured impact*

- A fresh alternating-order MI350 HIM IG CTR benchmark compared source base `4336d74cdd51` with candidate `80415e68d2b1`. All four MTS cells favored the candidate: QPS improved by 2.35%, 2.89%, 2.61%, and 2.30% across two thread counts and both execution orders.
- Three repeats per arm and all nine cross-arm output comparisons passed at `rtol=atol=0.01`. The generated-source audit confirmed that only the BMM LHS changed from a dense full-batch allocation to the batch-one backing allocation plus zero batch stride; RHS and output metadata were unchanged. P2437629314

Test Plan:
**Focused fail-closed regressions**

```sh
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:cat_expand_bmm -- --regex 'test_rewrite_disabled|test_rewrite_rejected_rhs_alias|test_rewrite_rejected_duplicate_expand|test_rewrite_rejected_metadata|test_rewrite_rejected_unsupported_dtype'
```

https://www.internalfb.com/intern/testinfra/testrun/22799473148211566

- Exact-current target: Pass 16, Fail 0, Skip 0. This covers the rollback flag, missing/invalid metadata, direct and outer RHS aliases, the graph-forced duplicate-expand case, and unconditional FP32/BF16 rejection.

**Dedicated H100 target: ATEN, TRITON, CUTLASS**

```sh
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:cat_expand_bmm
```

https://www.internalfb.com/intern/testinfra/testrun/2533275173957038

- Exact-current target: Pass 48, Fail 0, Skip 0. RE metadata reported `platform=gpu-remote-execution`, `subplatform=H100`, and an H100 executor.
- The FP16 ATEN, TRITON, and CUTLASS cases each compiled, executed, checked numerical output, observed BMM LHS batch stride zero, and matched backend-specific generated code.

**Dedicated MI300 target: ATEN, TRITON**

```sh
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:cat_expand_bmm_amd
```

https://www.internalfb.com/intern/testinfra/testrun/34902897133879439

- TestInfra status: Success. Buck reported Pass 46, Fail 0, Skip 1; the only skip was the CUDA-only CUTLASS case. RE metadata reported `platform=amd-gpu`, `subplatform=MI300`, and an AMD executor.
- The FP16 ATEN and TRITON cases compiled, executed, checked numerical output, observed BMM LHS batch stride zero, and matched backend-specific generated code.


**CK coverage boundary**

- The MI300 target exercises the FP16 ATEN and TRITON paths, but not CK. The fbcode Buck build does not set `USE_ROCM_CK_GEMM` (documented at `fbsource/fbcode/m10n_hw_codesign/inference/model_analyzer/experiments/bench_kernel.py:1433`), and runtime CK support is compile-time gated at `fbsource/fbcode/caffe2/aten/src/ATen/cuda/detail/CUDAHooks.cpp:191`. Safety does not depend on executing CK: the rewrite rejects BF16 before backend selection, and the focused fail-closed run directly verifies that behavior. This revision does not claim CK runtime coverage.

**Internal:** 

*Fresh MI350 model benchmark*

```sh
HIP_VISIBLE_DEVICES=7 TORCHINDUCTOR_FX_GRAPH_CACHE=0 /data/users/rahulagr/fbsource-cat-expand-bmm/buck-out/v2/art/fbcode/78b8947625309b8a/m10n_hw_codesign/inference/model_analyzer/__benchmark_comparison__/benchmark_comparison-inplace.par --model-type ads_mtml_adfinder_heavyweight_ctr_instagram_model --model-id 1087773826 --snapshot-id 1026 --batch-size 1024 --num-ads-per-request 45 --gpu-device 0 --mode comparison --configs D112773682-CAND-4336D74-APR45 D112773682-BASE-4336D74-APR45 --import-candidates /home/rahulagr/persistent/public-90d/mi350_pointwise_reduction/20260724_d112773682_fresh_benchmark/candidate_configs.json --num-threads 2 3 --gpu-max-hw-queues 16 --model-analyzer-iters 10000 --model-analyzer-warmups 1000 --mts-gpu-iters 10000 --mts-gpu-warmups 1000 --skip-load-net-predictor --num-runtimes 3 --reuse-lowered
```

P2437629314

- Both orders completed with 1,000 warmups and 10,000 measured iterations per timing cell. All eight Model Analyzer/MTS cells favored the candidate; observed QPS improvement was 2.30%-3.82% across methods, thread counts, and orders.

Differential Revision: D112773682


