### PR TITLE
[dynamo] Support tracing datetime.datetime.now()

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -1,8 +1,10 @@
 # Owner(s): ["module: dynamo"]
 import contextlib
+import datetime
 import math
 import random
 import unittest
+import unittest.mock
 
 import numpy as np
 
@@ -175,6 +177,77 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
             res.append(fn(torch.ones(2)))
         for i in range(1, 5):
             self.assertFalse(same(res[i - 1], res[i]))
+
+    def test_datetime_now_fullgraph(self):
+        # Repro from https://github.com/pytorch/pytorch/issues/125171 :
+        # datetime.datetime.now() used to graph break / fail under
+        # fullgraph=True.
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            start_time = datetime.datetime.now()
+            return x + 1 + start_time.second
+
+        x = torch.randn(2, 3)
+        fn(x)  # must not raise
+
+    def test_datetime_now_fresh_each_call(self):
+        # datetime.datetime.now() must be re-evaluated on every invocation of
+        # the compiled function rather than baked in at trace time (this is
+        # the exact issue that sank the previous attempt, PR #165540).
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            return x + 1, datetime.datetime.now().microsecond
+
+        x = torch.ones(2)
+        _, us1 = fn(x)
+        _, us2 = fn(x)
+        _, us3 = fn(x)
+        # Extremely unlikely for all three microsecond readings to collide
+        # if now() is actually being called fresh each time.
+        self.assertFalse(us1 == us2 == us3)
+
+    def test_datetime_now_attrs_consistent(self):
+        # All attributes read off a single datetime.now() call within one
+        # invocation must come from that same call, not be independently
+        # recomputed (which could otherwise straddle a second/day boundary).
+        # datetime.datetime.now is a C-level immutable slot and can't be
+        # mocked directly, so instead bracket the compiled call with eager
+        # datetime.now() readings and check the returned fields reconstruct
+        # to a timestamp within that bracket.
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            now = datetime.datetime.now()
+            return (
+                x + 1,
+                now.year,
+                now.month,
+                now.day,
+                now.hour,
+                now.minute,
+                now.second,
+                now.microsecond,
+            )
+
+        x = torch.ones(2)
+        before = datetime.datetime.now()
+        _, year, month, day, hour, minute, second, microsecond = fn(x)
+        after = datetime.datetime.now()
+        reconstructed = datetime.datetime(
+            year, month, day, hour, minute, second, microsecond
+        )
+        self.assertTrue(before <= reconstructed <= after)
+
+    def test_datetime_now_with_tz_graph_breaks(self):
+        # v1 only supports the no-argument datetime.datetime.now(); passing
+        # tz= should graph break in a controlled way, not crash.
+        def fn(x):
+            return x + 1 + datetime.datetime.now(tz=datetime.timezone.utc).second
+
+        x = torch.randn(2, 3)
+        torch.compile(fn, backend="eager")(x)  # allowed to graph break, not fullgraph
+        torch._dynamo.reset()
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
 
     def test_random_call_with_while_loop(self):
         def fn(x):

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -5112,6 +5112,16 @@
       ]
     }
   ],
+  "GB7947": [
+    {
+      "Gb_type": "datetime.datetime.now() with arguments",
+      "Context": "args={args} kwargs={kwargs}",
+      "Explanation": "Dynamo only supports datetime.datetime.now() called with no arguments (e.g. no tz=...).",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
   "GB6815": [
     {
       "Gb_type": "ContextVar mutation not supported",

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -937,6 +937,13 @@ class OutputGraph(OutputGraphCommon):
         ] = []
         self.random_values_var: Any = None
 
+        # Same mechanism as random_calls/random_values_var, but for
+        # datetime.datetime.now() calls (see DatetimeVariable).
+        self.datetime_calls: list[
+            tuple[Callable[..., object], tuple[object, ...], dict[str, object]]
+        ] = []
+        self.datetime_values_var: Any = None
+
         # Bytecode to insert right before we call the graph
         self.pregraph_bytecode: list[Instruction] = []
 
@@ -2127,6 +2134,27 @@ class OutputGraph(OutputGraphCommon):
                 codegen.create_store(self.random_values_var),
             )
             self.add_output_instructions(random_calls_instructions)
+
+        # to handle datetime.datetime.now() calls, same mechanism as above
+        if len(self.datetime_calls) > 0:
+            datetime_calls_instructions = []
+            self.datetime_values_var = self.new_var("datetime_values")
+            datetime_fn = disable(
+                _get_gen_rand_values_fn(self.datetime_calls),
+                reason="do not trace into Dynamo datetime recovery function",
+            )
+            datetime_fn_name = self.install_global("__gen_datetime_values", datetime_fn)
+            codegen = PyCodegen(
+                self.root_tx, root, overridden_sources=overridden_sources
+            )
+            datetime_calls_instructions.extend(
+                codegen.load_function_name(datetime_fn_name, True)
+            )
+            datetime_calls_instructions.extend(create_call_function(0, False))
+            datetime_calls_instructions.append(
+                codegen.create_store(self.datetime_values_var),
+            )
+            self.add_output_instructions(datetime_calls_instructions)
 
         # Codegen stack convention before the unsupported instruction
         # NOTE: in these comment blocks, "locals" EXCLUDE free and cell vars.

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -245,6 +245,29 @@ class RandomValueSource(Source):
 
 
 @dataclass_with_cached_hash(frozen=True)
+class DateTimeValueSource(Source):
+    datetime_call_index: int
+
+    @property
+    def guard_source(self) -> GuardSource:
+        # Reuses RANDOM_VALUE: like random calls, this value is expected to
+        # change on every invocation, so no equality/type guard is installed
+        # for it (see wrap_unspecialized_primitive).
+        return GuardSource.RANDOM_VALUE
+
+    def reconstruct(self, codegen: "PyCodegen") -> None:
+        codegen.append_output(
+            codegen.create_load(codegen.tx.output.datetime_values_var)
+        )
+        codegen.append_output(codegen.create_load_const(self.datetime_call_index))
+        codegen.append_output(create_binary_subscr())
+
+    @functools.cached_property
+    def _name_template(self) -> str:
+        return f"datetime_value_{_esc_str(self.datetime_call_index)}"
+
+
+@dataclass_with_cached_hash(frozen=True)
 class GlobalSource(Source):
     global_name: str
 

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -137,6 +137,8 @@ from .misc import (
     CallMethodVariable,
     CellVariable,
     ContextVarVariable,
+    DatetimeNowFunctionVariable,
+    DatetimeVariable,
     DeletedVariable,
     ExceptionVariable,
     GetAttrVariable,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -61,7 +61,7 @@ from torch._dynamo.utils import (
     set_feature_use,
 )
 from torch._functorch._aot_autograd.utils import is_async_collective_tensor_type
-from torch._guards import TracingContext
+from torch._guards import GuardSource, TracingContext
 from torch._higher_order_ops.flat_apply import flat_apply
 from torch._higher_order_ops.torchbind import call_torchbind
 from torch._library.opaque_object import (
@@ -3622,7 +3622,10 @@ class VariableBuilder:
             return self.tx.output.unspec_variable_map[self.name]
 
         wrapped_value = torch.tensor(value)
-        if not isinstance(self.get_source(), RandomValueSource):
+        # Values sourced from RandomValueSource (or an attribute access
+        # chained on top of one, e.g. DateTimeValueSource) are expected to
+        # change on every invocation, so no equality/type guard applies.
+        if self.get_source().guard_source != GuardSource.RANDOM_VALUE:
             install_guard(self.get_source().make_guard(GuardBuilder.TYPE_MATCH))
 
         options = {"source": self.get_source()}

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -18,6 +18,7 @@ Key classes include:
 import builtins
 import contextvars
 import dataclasses
+import datetime
 import enum
 import functools
 import inspect
@@ -58,6 +59,7 @@ from ..guards import GuardBuilder, install_guard
 from ..mutation_guard import unpatched_nn_module_init
 from ..source import (
     AttrSource,
+    DateTimeValueSource,
     GenericAttrSource,
     GetItemSource,
     TypeMROSource,
@@ -73,7 +75,12 @@ from ..utils import (
     raise_args_mismatch,
     unpack_iterable,
 )
-from .base import AsPythonConstantNotImplementedError, NO_SUCH_SUBOBJ, VariableTracker
+from .base import (
+    AsPythonConstantNotImplementedError,
+    GetSet,
+    NO_SUCH_SUBOBJ,
+    VariableTracker,
+)
 from .constant import ConstantVariable
 from .functions import NestedUserFunctionVariable, UserFunctionVariable
 from .object_protocol import generic_str
@@ -2879,6 +2886,95 @@ class RandomVariable(VariableTracker):
         codegen(self.wrap_state(self.random.getstate()))
         codegen.call_function(1, True)
         codegen.pop_top()
+
+
+def _make_datetime_attr_getter(
+    attr_name: str,
+) -> Callable[["DatetimeVariable", "InstructionTranslatorBase"], VariableTracker]:
+    def getter(
+        self: "DatetimeVariable", tx: "InstructionTranslatorBase"
+    ) -> VariableTracker:
+        from .builder import VariableBuilder
+
+        source = AttrSource(DateTimeValueSource(self.datetime_call_index), attr_name)
+        example_value = getattr(self.example_value, attr_name)
+        return VariableBuilder(tx, source).wrap_unspecialized_primitive(example_value)
+
+    return getter
+
+
+class DatetimeVariable(VariableTracker):
+    """datetime.datetime.now()
+
+    Represents the result of a single datetime.datetime.now() call. Reading
+    one of the supported integer fields (year/month/.../microsecond) routes
+    through the same "recompute on every invocation" mechanism dynamo uses
+    for random.random() (see OutputGraph.datetime_calls), so the underlying
+    now() call is re-executed fresh each time the compiled function runs
+    instead of being baked in at trace time.
+
+    Deliberately narrow scope: only reading these plain integer fields is
+    supported. Arithmetic, comparisons, or other methods on the datetime
+    object itself are not, and fall through to a graph break.
+    """
+
+    _supported_attrs = (
+        "year",
+        "month",
+        "day",
+        "hour",
+        "minute",
+        "second",
+        "microsecond",
+    )
+
+    tp_getset = {
+        attr: GetSet(_make_datetime_attr_getter(attr), None)
+        for attr in _supported_attrs
+    }
+
+    def __init__(
+        self,
+        datetime_call_index: int,
+        example_value: datetime.datetime,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.datetime_call_index = datetime_call_index
+        self.example_value = example_value
+
+
+class DatetimeNowFunctionVariable(VariableTracker):
+    """Represents the datetime.datetime.now callable itself.
+
+    Calling it (with no arguments) registers a fresh datetime.now() call in
+    tx.output.datetime_calls and returns a DatetimeVariable handle. See
+    DatetimeVariable for what's supported on the result.
+    """
+
+    def call_function(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        if args or kwargs:
+            unimplemented(
+                gb_type="datetime.datetime.now() with arguments",
+                context=f"args={args} kwargs={kwargs}",
+                explanation=(
+                    "Dynamo only supports datetime.datetime.now() called "
+                    "with no arguments (e.g. no tz=...)."
+                ),
+                hints=[*graph_break_hints.SUPPORTABLE],
+            )
+        example_value = datetime.datetime.now()
+        datetime_call_index = len(tx.output.datetime_calls)
+        tx.output.datetime_calls.append((datetime.datetime.now, (), {}))
+        return DatetimeVariable(
+            datetime_call_index=datetime_call_index,
+            example_value=example_value,
+        )
 
 
 class WeakRefVariable(VariableTracker):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -26,6 +26,7 @@ import builtins
 import collections
 import contextlib
 import dataclasses
+import datetime
 import enum
 import functools
 import inspect
@@ -1074,6 +1075,10 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 args[0],
                 init_args,
                 tx=tx,
+            )
+        elif self.value is datetime.datetime and name == "now":
+            return variables.DatetimeNowFunctionVariable().call_function(
+                tx, args, kwargs
             )
         elif name == "__setattr__" and self.ban_mutation:
             unimplemented(


### PR DESCRIPTION
Fixes #125171

`datetime.datetime.now()` was unsupported by Dynamo, graph-breaking under
`torch.compile(fullgraph=True)`. A prior attempt, #165540, was closed
unmerged because it baked the timestamp in at trace time, reusing a
stale value on every later execution of the compiled artifact.

This reuses the mechanism Dynamo already has for `random.random()`:
calls are registered in a new `OutputGraph.datetime_calls` list and
re-executed via a generated helper on every invocation of the compiled
function, so the value is fresh each time instead of frozen at trace
time. A new `DateTimeValueSource` (parallel to `RandomValueSource`) is
exempt from the usual equality/type guard, since the value is expected
to change every call.

Unlike `random.random()`, one `datetime.now()` call exposes several
attributes that must come from the same underlying call, not be
recomputed independently. `DatetimeVariable` captures one `now()` call
per call-site and exposes its integer attributes as reads chained on
top of that captured value.

**Scope (v1):** only no-arg `datetime.datetime.now()` and its integer
fields. `now(tz=...)`, `utcnow()`, arithmetic on the datetime object,
and `torch.export.export(strict=True)` (like `random.random()`, rejects
non-local graph inputs) remain unsupported and graph-break cleanly.

Prepared with AI assistance (Claude); reviewed by me before submission.

**Test plan:**
```
python test/dynamo/test_unspec.py -k datetime   # new tests
python test/dynamo/test_unspec.py               # 65 passed, no regressions
python test/dynamo/test_misc.py                 # 828 passed, no regressions
```
Manually confirmed the exact repro from #125171 now works with both
`torch.compile(fullgraph=True)` and `torch.export.export(strict=False)`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98