### PR TITLE
[inductor] Add shared grouped GEMM reduction IR

### DIFF
--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
@@ -529,6 +529,7 @@ class NVUniversalGemmCaller(ChoiceCaller):
             epilogue_reads=None,
             epilogue_writes=None,
             epilogue_var_renames=None,
+            local_reduce=None,
         ):
             from torch._inductor.ir import StorageBox, TensorBox
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6592,6 +6592,7 @@ class NVUniversalGemmBuffer(TemplateBuffer):
         epilogue_reads: list[str] | None = None,
         epilogue_writes: list[str] | None = None,
         epilogue_var_renames: dict[str, Any] | None = None,
+        local_reduce: tuple[str, int, int, str, str] | None = None,
     ) -> tuple[Any, Any]:
         """
         Create a kernel renderer for code generation.

--- a/torch/_inductor/kernel/gemm_epilogue.py
+++ b/torch/_inductor/kernel/gemm_epilogue.py
@@ -1,0 +1,275 @@
+# mypy: allow-untyped-defs
+"""Backend-neutral FX graph helpers for GEMM epilogues."""
+
+import dataclasses
+from collections.abc import Iterator, Sequence
+from typing import Any, ClassVar
+
+import sympy
+
+import torch
+from torch._inductor.virtualized import V
+from torch.fx.experimental.symbolic_shapes import (
+    GuardOnDataDependentSymNode,
+    statically_known_true as fx_statically_known_true,
+)
+from torch.utils._ordered_set import OrderedSet
+
+
+def statically_known(expr: Any) -> bool:
+    """Return whether a symbolic predicate is known true without adding guards."""
+    if isinstance(expr, bool):
+        return expr
+    if isinstance(expr, sympy.Basic):
+        return V.graph.sizevars.statically_known_true(expr)
+    return fx_statically_known_true(expr)
+
+
+def statically_known_equal(lhs: Any, rhs: Any) -> bool:
+    """Return whether symbolic shape values are known equal without adding guards."""
+    return statically_known(lhs == rhs)
+
+
+def statically_known_shape_equal(
+    actual_shape: Sequence[Any], expected_shape: Sequence[Any]
+) -> bool:
+    """Compare possibly symbolic shape tuples without adding guards."""
+    return len(actual_shape) == len(expected_shape) and all(
+        statically_known_equal(actual, expected)
+        for actual, expected in zip(actual_shape, expected_shape)
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmReductionGeometry:
+    """Describe the grouped output axis shared by GEMM reduction consumers."""
+
+    group: int
+    axis: int
+
+    def __post_init__(self) -> None:
+        if self.group <= 0:
+            raise RuntimeError("local_reduce_group must be positive")
+        if self.axis not in (0, 1):
+            raise RuntimeError("local_reduce_axis must be 0 or 1")
+
+    @property
+    def needs_physical_callbacks(self) -> bool:
+        return self.axis == 0 or self.group > 32
+
+    @property
+    def group_size(self) -> int:
+        return self.group
+
+    @classmethod
+    def from_output_shape(
+        cls, output_shape: Sequence[Any], gemm_shape: Sequence[Any]
+    ) -> "GemmReductionGeometry | None":
+        if len(output_shape) != 3 or len(gemm_shape) != 2:
+            return None
+        for axis, group_dim in ((0, 1), (1, 2)):
+            try:
+                group = V.graph.sizevars.optimization_hint(output_shape[group_dim])
+            except (GuardOnDataDependentSymNode, TypeError, ValueError):
+                continue
+            geometry = cls(group=group, axis=axis)
+            if geometry.matches_output_shape(output_shape, gemm_shape):
+                return geometry
+        return None
+
+    @property
+    def reduce_dims(self) -> tuple[int, ...]:
+        return (-1, 2) if self.axis == 1 else (-2, 1)
+
+    def matches_reduction_dim(self, dim: Any) -> bool:
+        dims = tuple(dim) if isinstance(dim, (list, tuple)) else (dim,)
+        return len(dims) == 1 and dims[0] in self.reduce_dims
+
+    def matches_output_shape(
+        self, output_shape: Sequence[Any], gemm_shape: Sequence[Any]
+    ) -> bool:
+        if len(gemm_shape) != 2:
+            return False
+        m, n = gemm_shape
+        grouped = (
+            (m, n // self.group, self.group)
+            if self.axis == 1
+            else (m // self.group, self.group, n)
+        )
+        return statically_known_shape_equal(
+            output_shape, (m, n)
+        ) or statically_known_shape_equal(output_shape, grouped)
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmReductionExpression:
+    """Typed reduction kind and compile-time scalar parameters."""
+
+    kind: str
+    parameters: tuple[float, ...] = ()
+
+    @classmethod
+    def parse(cls, value: str) -> "GemmReductionExpression":
+        kind, *parameters = value.split(":")
+        return cls(kind, tuple(float(parameter) for parameter in parameters))
+
+    def serialize(self) -> str:
+        if not self.parameters:
+            return self.kind
+        return (
+            self.kind
+            + ":"
+            + ":".join(format(parameter, ".17g") for parameter in self.parameters)
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmReductionConfig:
+    """Describe a grouped reduction recognized during scheduler analysis."""
+
+    output_name: str
+    group: int
+    axis: int
+    reduction_type: str
+    source_type: str
+
+    @property
+    def geometry(self) -> GemmReductionGeometry:
+        return GemmReductionGeometry(self.group, self.axis)
+
+    @property
+    def contract(self) -> tuple[int, int, str, str]:
+        return self.group, self.axis, self.reduction_type, self.source_type
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmReductionPlan:
+    """Describe grouped reduction outputs passed from lowering to codegen."""
+
+    reduction_output: str | None
+    group: int
+    axis: int
+    reduction_type: str
+    source_type: str
+    primary_output: str
+    feeds_main: bool = False
+    feed_output: str | None = None
+    secondary_feed_output: str | None = None
+    secondary_feed_type: str | None = None
+
+    @property
+    def geometry(self) -> GemmReductionGeometry:
+        return GemmReductionGeometry(self.group, self.axis)
+
+    @property
+    def auxiliary_outputs(self) -> tuple[str, ...]:
+        return tuple(
+            OrderedSet(
+                output
+                for output in (
+                    self.reduction_output,
+                    self.feed_output,
+                    self.secondary_feed_output,
+                )
+                if output is not None and output != self.primary_output
+            )
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmReductionArguments:
+    """Typed view of grouped-reduction fields attached to GEMM arguments."""
+
+    output: Any | None
+    feed_output: Any | None
+    secondary_feed_output: Any | None
+    secondary_feed_type: str | None
+    group: int
+    axis: int
+    reduction_type: str
+    source_type: str
+    feeds_main: bool
+
+    SPECIALIZATION_KEYS: ClassVar[tuple[str, ...]] = (
+        "local_reduce_group",
+        "local_reduce_axis",
+        "local_reduce_type",
+        "local_reduce_source",
+        "local_reduce_feeds_main",
+        "local_reduce_secondary_feed_type",
+    )
+
+    @classmethod
+    def from_operator_args(cls, args: Any) -> "GemmReductionArguments":
+        return cls(
+            getattr(args, "local_reduce_out", None),
+            getattr(args, "local_reduce_feed_out", None),
+            getattr(args, "local_reduce_secondary_feed_out", None),
+            getattr(args, "local_reduce_secondary_feed_type", None),
+            getattr(args, "local_reduce_group", 0),
+            getattr(args, "local_reduce_axis", 1),
+            getattr(args, "local_reduce_type", "sum"),
+            getattr(args, "local_reduce_source", "identity"),
+            getattr(args, "local_reduce_feeds_main", False),
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return (
+            any(
+                value is not None
+                for value in (self.output, self.feed_output, self.secondary_feed_output)
+            )
+            or self.feeds_main
+        )
+
+    @property
+    def primary_enabled(self) -> bool:
+        return (
+            self.output is not None or self.feed_output is not None or self.feeds_main
+        )
+
+    @property
+    def expression(self) -> GemmReductionExpression:
+        return GemmReductionExpression.parse(self.reduction_type)
+
+    def tensors(self, attr: str) -> tuple[Any | None, Any | None, Any | None]:
+        def tensor(value: Any | None) -> Any | None:
+            return getattr(value, attr) if value is not None else None
+
+        return (
+            tensor(self.output),
+            tensor(self.feed_output),
+            tensor(self.secondary_feed_output),
+        )
+
+
+def iter_fx_node_inputs(value: Any) -> Iterator[torch.fx.Node]:
+    """Yield FX node inputs nested in args/kwargs-style containers."""
+    result: list[torch.fx.Node] = []
+    torch.fx.map_arg(value, lambda node: result.append(node))
+    yield from result
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmEpilogueGraph:
+    """Index transitive dependencies between nodes in an epilogue FX graph."""
+
+    dependencies: dict[torch.fx.Node, frozenset[torch.fx.Node]]
+
+    @classmethod
+    def from_nodes(cls, nodes: Sequence[torch.fx.Node]) -> "GemmEpilogueGraph":
+        dependencies: dict[torch.fx.Node, frozenset[torch.fx.Node]] = {}
+        for node in nodes:
+            node_dependencies: OrderedSet[torch.fx.Node] = OrderedSet()
+            for input_node in iter_fx_node_inputs((node.args, node.kwargs)):
+                node_dependencies.add(input_node)
+                node_dependencies.update(dependencies.get(input_node, ()))
+            dependencies[node] = frozenset(node_dependencies)
+        return cls(dependencies)
+
+    def depends_on(self, value: Any, target: torch.fx.Node) -> bool:
+        return any(
+            node is target or target in self.dependencies.get(node, ())
+            for node in iter_fx_node_inputs(value)
+        )

--- a/torch/_inductor/kernel/gemm_epilogue_ir.py
+++ b/torch/_inductor/kernel/gemm_epilogue_ir.py
@@ -1,0 +1,769 @@
+# mypy: allow-untyped-defs
+"""Semantic analysis helpers for lowered GEMM epilogue loop bodies."""
+
+import dataclasses
+import math
+from collections.abc import Sequence
+from typing import Any
+
+import sympy
+
+from torch._inductor.ir import ComputedBuffer
+from torch._inductor.ops_handler import DefaultHandler
+from torch._inductor.virtualized import V
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmEpilogueIRExpression:
+    op: str
+    args: tuple[Any, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmEpilogueIRStore:
+    index: sympy.Expr
+    value: GemmEpilogueIRExpression
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmEpilogueIROutputRole:
+    transitive_inputs: frozenset[str]
+    reduction_inputs: frozenset[str]
+
+
+class _GemmEpilogueIRHandler(DefaultHandler):
+    def __init__(self) -> None:
+        self.stores: dict[str, GemmEpilogueIRStore] = {}
+
+    def _default(
+        self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> GemmEpilogueIRExpression:
+        if kwargs:
+            args = (*args, tuple(sorted(kwargs.items())))
+        return GemmEpilogueIRExpression(name, args)
+
+    def indirect_indexing(self, x, size, check=True, wrap_neg=True):
+        return sympy.Symbol(f"indirect_{len(self.stores)}", integer=True)
+
+    def load(self, name: str, index: sympy.Expr) -> GemmEpilogueIRExpression:
+        stored = self.stores.get(name)
+        return GemmEpilogueIRExpression(
+            "load", (name, index, stored.value if stored is not None else None)
+        )
+
+    def reduction(self, dtype, src_dtype, reduction_type, value):
+        args = (dtype, src_dtype, reduction_type, value)
+        if reduction_type in ("online_softmax_reduce", "welford_reduce"):
+            count = 2 if reduction_type == "online_softmax_reduce" else 3
+            return tuple(
+                GemmEpilogueIRExpression("reduction", (*args, index))
+                for index in range(count)
+            )
+        return GemmEpilogueIRExpression("reduction", args)
+
+    def store(
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: GemmEpilogueIRExpression,
+        mode=None,
+    ) -> None:
+        self.stores[name] = GemmEpilogueIRStore(index, value)
+
+    def store_reduction(
+        self, name: str, index: sympy.Expr, value: GemmEpilogueIRExpression
+    ) -> None:
+        self.stores[name] = GemmEpilogueIRStore(index, value)
+
+
+def _loaded_names(expr: Any) -> frozenset[str]:
+    if not isinstance(expr, GemmEpilogueIRExpression):
+        return frozenset()
+    if expr.op == "load":
+        name, _, stored = expr.args
+        return frozenset((name,)) | _loaded_names(stored)
+    return frozenset().union(*(_loaded_names(arg) for arg in expr.args))
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmEpilogueIRAnalysis:
+    """Candidate-wide semantic view of existing lowered loop bodies."""
+
+    stores: dict[str, GemmEpilogueIRStore]
+
+    @classmethod
+    def from_buffers(
+        cls, buffers: Sequence[ComputedBuffer]
+    ) -> "GemmEpilogueIRAnalysis":
+        handler = _GemmEpilogueIRHandler()
+        with V.set_ops_handler(handler):
+            for buffer in buffers:
+                buffer.get_store_function()(*buffer.data.inner_fn_args())
+        return cls(handler.stores)
+
+    @classmethod
+    def store_from_buffer(cls, buffer: ComputedBuffer) -> GemmEpilogueIRStore | None:
+        return cls.from_buffers((buffer,)).store(buffer.get_name())
+
+    def store(self, name: str) -> GemmEpilogueIRStore | None:
+        return self.stores.get(name)
+
+    def output_role(self, name: str) -> GemmEpilogueIROutputRole | None:
+        store = self.store(name)
+        if store is None:
+            return None
+        transitive_inputs = _loaded_names(store.value)
+        return GemmEpilogueIROutputRole(
+            transitive_inputs,
+            transitive_inputs & self.reduction_stores,
+        )
+
+    @property
+    def reduction_stores(self) -> frozenset[str]:
+        return frozenset(
+            name
+            for name, store in self.stores.items()
+            if _contains_reduction(store.value)
+        )
+
+
+def _constant_value(expr: Any) -> Any | None:
+    if not isinstance(expr, GemmEpilogueIRExpression):
+        return None
+    if expr.op in ("constant", "index_expr") and expr.args:
+        return expr.args[0]
+    if expr.op in ("to_dtype", "to_dtype_bitcast") and expr.args:
+        return _constant_value(expr.args[0])
+    return None
+
+
+def _strip_conversions(expr: Any) -> Any:
+    while (
+        isinstance(expr, GemmEpilogueIRExpression)
+        and expr.op in ("to_dtype", "to_dtype_bitcast", "identity")
+        and expr.args
+    ):
+        expr = expr.args[0]
+    return expr
+
+
+def _walk(expr: Any):
+    if not isinstance(expr, GemmEpilogueIRExpression):
+        return
+    yield expr
+    for arg in expr.args:
+        yield from _walk(arg)
+
+
+def operation_names_ir(store: GemmEpilogueIRStore) -> frozenset[str]:
+    return frozenset(expr.op for expr in _walk(store.value))
+
+
+def _source_transform(expr: Any, source_name: str) -> str | None:
+    expr = _strip_conversions(expr)
+    if not isinstance(expr, GemmEpilogueIRExpression):
+        return None
+    if expr.op == "load":
+        return "identity" if expr.args[0] == source_name else None
+    if expr.op == "abs":
+        return (
+            "abs"
+            if _source_transform(expr.args[0], source_name) == "identity"
+            else None
+        )
+    if expr.op == "mul" and expr.args[0] == expr.args[1]:
+        return (
+            "square"
+            if _source_transform(expr.args[0], source_name) == "identity"
+            else None
+        )
+    if expr.op == "pow":
+        exponent = _constant_value(expr.args[1])
+        return (
+            "square"
+            if exponent == 2
+            and _source_transform(expr.args[0], source_name) == "identity"
+            else None
+        )
+    return None
+
+
+def _flatten_associative(expr: Any, op: str) -> list[Any]:
+    expr = _strip_conversions(expr)
+    if isinstance(expr, GemmEpilogueIRExpression) and expr.op == op:
+        return _flatten_associative(expr.args[0], op) + _flatten_associative(
+            expr.args[1], op
+        )
+    return [expr]
+
+
+def grouped_reduction_ir(
+    store: GemmEpilogueIRStore, source_name: str, group: int
+) -> tuple[str, str] | None:
+    """Classify a primitive or unrolled grouped reduction loop body."""
+    candidates = [expr for expr in _walk(store.value) if expr.op == "reduction"]
+    if candidates:
+        reduction = candidates[0]
+        reduction_type = str(reduction.args[2])
+        source_type = _source_transform(reduction.args[3], source_name)
+        if source_type is not None:
+            return reduction_type, source_type
+
+    root = _strip_conversions(store.value)
+    while isinstance(root, GemmEpilogueIRExpression) and root.op in (
+        "add",
+        "mul",
+        "truediv",
+    ):
+        if root.op == "truediv" and _constant_value(root.args[1]) == group:
+            terms = _flatten_associative(root.args[0], "add")
+            transforms = [_source_transform(term, source_name) for term in terms]
+            if (
+                len(terms) == group
+                and len(frozenset(transforms)) == 1
+                and transforms[0]
+            ):
+                return "mean", transforms[0]
+        terms = _flatten_associative(root, root.op)
+        transforms = [_source_transform(term, source_name) for term in terms]
+        if len(terms) == group and len(frozenset(transforms)) == 1 and transforms[0]:
+            return ("sum" if root.op == "add" else "prod"), transforms[0]
+        break
+    for op, reduction_type in (("maximum", "max"), ("minimum", "min")):
+        terms = _flatten_associative(root, op)
+        transforms = [_source_transform(term, source_name) for term in terms]
+        if len(terms) == group and len(frozenset(transforms)) == 1 and transforms[0]:
+            return reduction_type, transforms[0]
+    return None
+
+
+def is_direct_bool_gt_zero_ir(store: GemmEpilogueIRStore, source_name: str) -> bool:
+    """Match a direct comparison of one lowered buffer load against zero."""
+    expr = _strip_conversions(store.value)
+    if not isinstance(expr, GemmEpilogueIRExpression) or expr.op not in ("gt", "ge"):
+        return False
+    lhs, rhs = map(_strip_conversions, expr.args[:2])
+    return (
+        isinstance(lhs, GemmEpilogueIRExpression)
+        and lhs.op == "load"
+        and lhs.args[0] == source_name
+        and _constant_value(rhs) == 0
+    )
+
+
+def is_absmax_scale_finalizer_ir(store: GemmEpilogueIRStore, source_name: str) -> bool:
+    """Match clamp(source, 1e-12) / 448 used by FP8 absmax scaling."""
+    expr = _strip_conversions(store.value)
+    if not isinstance(expr, GemmEpilogueIRExpression):
+        return False
+    if expr.op == "truediv" and _constant_value(expr.args[1]) == 448.0:
+        clamped = expr.args[0]
+    elif expr.op == "mul":
+        lhs, rhs = expr.args[:2]
+        if _constant_value(lhs) == 1.0 / 448.0:
+            clamped = rhs
+        elif _constant_value(rhs) == 1.0 / 448.0:
+            clamped = lhs
+        else:
+            return False
+    else:
+        return False
+
+    clamped = _strip_conversions(clamped)
+    if not isinstance(clamped, GemmEpilogueIRExpression):
+        return False
+    if clamped.op in ("maximum", "clamp_min"):
+        lhs, rhs = clamped.args[:2]
+        return (
+            _source_transform(lhs, source_name) == "identity"
+            and _constant_value(rhs) == 1e-12
+        ) or (
+            _source_transform(rhs, source_name) == "identity"
+            and _constant_value(lhs) == 1e-12
+        )
+    if clamped.op == "clamp" and len(clamped.args) >= 2:
+        return (
+            _source_transform(clamped.args[0], source_name) == "identity"
+            and _constant_value(clamped.args[1]) == 1e-12
+            and (len(clamped.args) < 3 or clamped.args[2] is None)
+        )
+    return False
+
+
+def _contains_reduction(expr: Any) -> bool:
+    if not isinstance(expr, GemmEpilogueIRExpression):
+        return False
+    return expr.op == "reduction" or any(_contains_reduction(arg) for arg in expr.args)
+
+
+def _affine_scale(
+    value: tuple[float, float, float], scale: float
+) -> tuple[float, float, float]:
+    return value[0] * scale, value[1] * scale, value[2] * scale
+
+
+def _affine_add(
+    lhs: tuple[float, float, float], rhs: tuple[float, float, float]
+) -> tuple[float, float, float]:
+    return lhs[0] + rhs[0], lhs[1] + rhs[1], lhs[2] + rhs[2]
+
+
+def _affine_coefficients(
+    expr: Any, source_name: str, reduction_names: frozenset[str]
+) -> tuple[float, float, float] | None:
+    expr = _strip_conversions(expr)
+    if isinstance(expr, (int, float, sympy.Number)) and not isinstance(expr, bool):
+        return 0.0, 0.0, float(expr)
+    if not isinstance(expr, GemmEpilogueIRExpression):
+        return None
+    if expr.op == "load":
+        name, _, stored = expr.args
+        if name == source_name:
+            return 1.0, 0.0, 0.0
+        if name in reduction_names or _contains_reduction(stored):
+            return 0.0, 1.0, 0.0
+        return _affine_coefficients(stored, source_name, reduction_names)
+    if expr.op == "reduction":
+        return 0.0, 1.0, 0.0
+    constant = _constant_value(expr)
+    if isinstance(constant, (int, float, sympy.Number)) and not isinstance(
+        constant, bool
+    ):
+        return 0.0, 0.0, float(constant)
+    if expr.op == "neg":
+        value = _affine_coefficients(expr.args[0], source_name, reduction_names)
+        return None if value is None else _affine_scale(value, -1.0)
+    if expr.op in ("add", "sub"):
+        lhs = _affine_coefficients(expr.args[0], source_name, reduction_names)
+        rhs = _affine_coefficients(expr.args[1], source_name, reduction_names)
+        if lhs is None or rhs is None:
+            return None
+        scale = 1.0 if expr.op == "add" else -1.0
+        return _affine_add(lhs, _affine_scale(rhs, scale))
+    if expr.op in ("mul", "truediv"):
+        lhs = _affine_coefficients(expr.args[0], source_name, reduction_names)
+        rhs = _affine_coefficients(expr.args[1], source_name, reduction_names)
+        if lhs is None or rhs is None:
+            return None
+        if expr.op == "truediv":
+            if rhs[:2] != (0.0, 0.0) or rhs[2] == 0.0:
+                return None
+            return _affine_scale(lhs, 1.0 / rhs[2])
+        if lhs[:2] == (0.0, 0.0):
+            return _affine_scale(rhs, lhs[2])
+        if rhs[:2] == (0.0, 0.0):
+            return _affine_scale(lhs, rhs[2])
+    if expr.op == "fma":
+        lhs = _affine_coefficients(expr.args[0], source_name, reduction_names)
+        rhs = _affine_coefficients(expr.args[1], source_name, reduction_names)
+        addend = _affine_coefficients(expr.args[2], source_name, reduction_names)
+        if lhs is None or rhs is None or addend is None:
+            return None
+        if lhs[:2] == (0.0, 0.0):
+            product = _affine_scale(rhs, lhs[2])
+        elif rhs[:2] == (0.0, 0.0):
+            product = _affine_scale(lhs, rhs[2])
+        else:
+            return None
+        return _affine_add(product, addend)
+    return None
+
+
+def centered_mean_consumer_type_ir(
+    store: GemmEpilogueIRStore,
+    source_name: str,
+    reduction_names: frozenset[str],
+    reduction_scale: float = 1.0,
+) -> str | None:
+    """Classify an affine combination of a lowered value and grouped reduction."""
+    coefficients = _affine_coefficients(store.value, source_name, reduction_names)
+    if coefficients is not None:
+        coefficients = (
+            coefficients[0],
+            coefficients[1] * reduction_scale,
+            coefficients[2],
+        )
+    if (
+        coefficients is None
+        or coefficients[0] == 0.0
+        or coefficients[1] == 0.0
+        or not all(math.isfinite(value) for value in coefficients)
+    ):
+        return None
+    return "mean_linear:" + ":".join(format(value, ".17g") for value in coefficients)
+
+
+def single_source_affine_ir(
+    store: GemmEpilogueIRStore, source_name: str
+) -> tuple[float, float] | None:
+    """Return scale and bias for an affine expression of one lowered buffer."""
+    coefficients = _affine_coefficients(store.value, source_name, frozenset())
+    if coefficients is None or coefficients[1] != 0.0:
+        return None
+    return coefficients[0], coefficients[2]
+
+
+def _affine_around(expr: Any, basis) -> tuple[float, float] | None:
+    expr = _strip_conversions(expr)
+    if basis(expr):
+        return 1.0, 0.0
+    constant = _constant_value(expr)
+    if isinstance(constant, (int, float, sympy.Number)) and not isinstance(
+        constant, bool
+    ):
+        return 0.0, float(constant)
+    if not isinstance(expr, GemmEpilogueIRExpression):
+        return None
+    if expr.op == "neg":
+        value = _affine_around(expr.args[0], basis)
+        return None if value is None else (-value[0], -value[1])
+    if expr.op in ("add", "sub"):
+        lhs = _affine_around(expr.args[0], basis)
+        rhs = _affine_around(expr.args[1], basis)
+        if lhs is None or rhs is None:
+            return None
+        sign = 1.0 if expr.op == "add" else -1.0
+        return lhs[0] + sign * rhs[0], lhs[1] + sign * rhs[1]
+    if expr.op == "mul":
+        lhs = _affine_around(expr.args[0], basis)
+        rhs = _affine_around(expr.args[1], basis)
+        if lhs is None or rhs is None:
+            return None
+        if lhs[0] == 0.0:
+            return rhs[0] * lhs[1], rhs[1] * lhs[1]
+        if rhs[0] == 0.0:
+            return lhs[0] * rhs[1], lhs[1] * rhs[1]
+    return None
+
+
+def _is_source(expr: Any, source_name: str) -> bool:
+    return _source_transform(expr, source_name) == "identity"
+
+
+def _sum_terms(expr: Any, source_name: str, group: int) -> bool:
+    terms = _flatten_associative(expr, "add")
+    return len(terms) == group and all(_is_source(term, source_name) for term in terms)
+
+
+def _group_max(expr: Any, source_name: str, group: int) -> bool:
+    terms = _flatten_associative(expr, "maximum")
+    return len(terms) == group and all(_is_source(term, source_name) for term in terms)
+
+
+def _stable_group_max(expr: Any, source_name: str, group: int) -> bool:
+    """Match max(xs), including logsumexp's where(isinf(max), 0, max)."""
+    expr = _strip_conversions(expr)
+    if _group_max(expr, source_name, group):
+        return True
+    if not (
+        isinstance(expr, GemmEpilogueIRExpression)
+        and expr.op == "where"
+        and len(expr.args) >= 3
+        and _constant_value(expr.args[1]) == 0.0
+    ):
+        return False
+    condition = _strip_conversions(expr.args[0])
+    maximum = _strip_conversions(expr.args[2])
+    if not (
+        isinstance(condition, GemmEpilogueIRExpression)
+        and condition.op == "eq"
+        and _group_max(maximum, source_name, group)
+    ):
+        return False
+    for absolute, infinity in (condition.args[:2], reversed(condition.args[:2])):
+        absolute = _strip_conversions(absolute)
+        if (
+            isinstance(absolute, GemmEpilogueIRExpression)
+            and absolute.op == "abs"
+            and _strip_conversions(absolute.args[0]) == maximum
+            and _constant_value(infinity) == math.inf
+        ):
+            return True
+    return False
+
+
+def _shifted_exp(expr: Any, source_name: str) -> Any | None:
+    expr = _strip_conversions(expr)
+    if not (
+        isinstance(expr, GemmEpilogueIRExpression) and expr.op == "exp" and expr.args
+    ):
+        return None
+    shifted = _strip_conversions(expr.args[0])
+    if not (
+        isinstance(shifted, GemmEpilogueIRExpression)
+        and shifted.op == "sub"
+        and _is_source(shifted.args[0], source_name)
+    ):
+        return None
+    return _strip_conversions(shifted.args[1])
+
+
+def is_softmax_ir(
+    store: GemmEpilogueIRStore,
+    source_name: str,
+    group: int,
+    reduction_names: frozenset[str] = frozenset(),
+) -> bool:
+    """Match stable grouped softmax, either unrolled or reduction-backed."""
+    expr = _strip_conversions(store.value)
+    if not isinstance(expr, GemmEpilogueIRExpression) or expr.op != "truediv":
+        return False
+    numerator, denominator = expr.args[:2]
+    maximum = _shifted_exp(numerator, source_name)
+    if maximum is None:
+        return False
+    denominator = _strip_conversions(denominator)
+    if reduction_names:
+        return (
+            isinstance(maximum, GemmEpilogueIRExpression)
+            and maximum.op == "load"
+            and maximum.args[0] in reduction_names
+            and isinstance(denominator, GemmEpilogueIRExpression)
+            and denominator.op == "load"
+            and denominator.args[0] in reduction_names
+            and maximum.args[0] != denominator.args[0]
+        )
+    terms = _flatten_associative(denominator, "add")
+    return (
+        _group_max(maximum, source_name, group)
+        and len(terms) == group
+        and all(_shifted_exp(term, source_name) == maximum for term in terms)
+    )
+
+
+def is_absmax_normalize_ir(
+    store: GemmEpilogueIRStore,
+    source_name: str,
+    scale_names: str | frozenset[str],
+) -> bool:
+    """Match source * reciprocal(clamp(absmax, 1e-12) / 448)."""
+    if isinstance(scale_names, str):
+        scale_names = frozenset((scale_names,))
+    expr = _strip_conversions(store.value)
+    if not isinstance(expr, GemmEpilogueIRExpression) or expr.op != "mul":
+        return False
+    for source, reciprocal in (expr.args[:2], reversed(expr.args[:2])):
+        reciprocal = _strip_conversions(reciprocal)
+        if (
+            _is_source(source, source_name)
+            and isinstance(reciprocal, GemmEpilogueIRExpression)
+            and reciprocal.op == "reciprocal"
+            and any(
+                is_absmax_scale_finalizer_ir(
+                    GemmEpilogueIRStore(store.index, reciprocal.args[0]), scale_name
+                )
+                for scale_name in scale_names
+            )
+        ):
+            return True
+    return False
+
+
+def _sum_affine_ir(
+    expr: Any,
+    source_name: str,
+    reduction_names: frozenset[str],
+    group: int,
+) -> tuple[float, float] | None:
+    def is_sum(candidate: Any) -> bool:
+        candidate = _strip_conversions(candidate)
+        return (
+            isinstance(candidate, GemmEpilogueIRExpression)
+            and candidate.op == "load"
+            and candidate.args[0] in reduction_names
+        ) or _sum_terms(candidate, source_name, group)
+
+    return _affine_around(expr, is_sum)
+
+
+def sum_normalize_consumer_type_ir(
+    store: GemmEpilogueIRStore,
+    source_name: str,
+    reduction_names: frozenset[str],
+    group: int,
+) -> str | None:
+    """Classify normalization by a primitive or unrolled grouped sum."""
+    parameters: tuple[str, float, float] | None = None
+
+    def is_normalization(expr: Any) -> bool:
+        nonlocal parameters
+        expr = _strip_conversions(expr)
+        if not isinstance(expr, GemmEpilogueIRExpression):
+            return False
+        if expr.op == "truediv":
+            lhs, rhs = expr.args[:2]
+            if _is_source(lhs, source_name):
+                affine = _sum_affine_ir(rhs, source_name, reduction_names, group)
+                if affine is not None:
+                    parameters = "forward", *affine
+                    return True
+            if _is_source(rhs, source_name):
+                affine = _sum_affine_ir(lhs, source_name, reduction_names, group)
+                if affine is not None:
+                    parameters = "reverse", *affine
+                    return True
+        if expr.op == "mul":
+            for source, reciprocal in (expr.args[:2], reversed(expr.args[:2])):
+                reciprocal = _strip_conversions(reciprocal)
+                if (
+                    _is_source(source, source_name)
+                    and isinstance(reciprocal, GemmEpilogueIRExpression)
+                    and reciprocal.op == "reciprocal"
+                ):
+                    affine = _sum_affine_ir(
+                        reciprocal.args[0], source_name, reduction_names, group
+                    )
+                    if affine is not None:
+                        parameters = "forward", *affine
+                        return True
+        return False
+
+    affine = _affine_around(store.value, is_normalization)
+    if (
+        affine is None
+        or parameters is None
+        or affine[0] == 0.0
+        or not all(math.isfinite(value) for value in (*affine, *parameters[1:]))
+    ):
+        return None
+    kind = (
+        "normalize_sum_affine"
+        if parameters[0] == "forward"
+        else "normalize_sum_reverse_affine"
+    )
+    values = (*affine, *parameters[1:])
+    return kind + ":" + ":".join(format(value, ".17g") for value in values)
+
+
+def sum_multiply_consumer_type_ir(
+    store: GemmEpilogueIRStore,
+    source_name: str,
+    reduction_names: frozenset[str],
+    group: int,
+) -> str | None:
+    expr = _strip_conversions(store.value)
+    if not isinstance(expr, GemmEpilogueIRExpression) or expr.op != "mul":
+        return None
+    for source, reduction in (expr.args[:2], reversed(expr.args[:2])):
+        if not _is_source(source, source_name):
+            continue
+        affine = _sum_affine_ir(reduction, source_name, reduction_names, group)
+        if affine is not None and all(math.isfinite(value) for value in affine):
+            return "sum_mul_affine:" + ":".join(
+                format(value, ".17g") for value in affine
+            )
+    return None
+
+
+def variance_parameters_ir(
+    store: GemmEpilogueIRStore, source_name: str, group: int
+) -> tuple[float, float] | None:
+    """Match an unrolled grouped variance followed by an affine transform."""
+
+    def is_variance(expr: Any) -> bool:
+        expr = _strip_conversions(expr)
+        if not isinstance(expr, GemmEpilogueIRExpression) or expr.op != "truediv":
+            return False
+        if _constant_value(expr.args[1]) != group:
+            return False
+        squares = _flatten_associative(expr.args[0], "add")
+        if len(squares) != group:
+            return False
+        for square in squares:
+            square = _strip_conversions(square)
+            if not (
+                isinstance(square, GemmEpilogueIRExpression)
+                and square.op == "mul"
+                and square.args[0] == square.args[1]
+            ):
+                return False
+            centered = _strip_conversions(square.args[0])
+            if not (
+                isinstance(centered, GemmEpilogueIRExpression)
+                and centered.op == "sub"
+                and _is_source(centered.args[0], source_name)
+            ):
+                return False
+            mean = _strip_conversions(centered.args[1])
+            if not (
+                isinstance(mean, GemmEpilogueIRExpression)
+                and mean.op == "truediv"
+                and _constant_value(mean.args[1]) == group
+                and _sum_terms(mean.args[0], source_name, group)
+            ):
+                return False
+        return True
+
+    affine = _affine_around(store.value, is_variance)
+    return affine if affine is not None and affine[0] != 0.0 else None
+
+
+def centered_mean_consumer_type_unrolled_ir(
+    store: GemmEpilogueIRStore, source_name: str, group: int
+) -> str | None:
+    """Classify an affine source/mean expression after a small reduction unroll."""
+
+    def coefficients(expr: Any) -> tuple[float, float, float] | None:
+        expr = _strip_conversions(expr)
+        if isinstance(expr, GemmEpilogueIRExpression) and expr.op == "truediv":
+            if _constant_value(expr.args[1]) == group and _sum_terms(
+                expr.args[0], source_name, group
+            ):
+                return 0.0, 1.0, 0.0
+        if _is_source(expr, source_name):
+            return 1.0, 0.0, 0.0
+        constant = _constant_value(expr)
+        if isinstance(constant, (int, float, sympy.Number)) and not isinstance(
+            constant, bool
+        ):
+            return 0.0, 0.0, float(constant)
+        if not isinstance(expr, GemmEpilogueIRExpression):
+            return None
+        if expr.op in ("add", "sub"):
+            lhs, rhs = coefficients(expr.args[0]), coefficients(expr.args[1])
+            if lhs is None or rhs is None:
+                return None
+            return _affine_add(
+                lhs, _affine_scale(rhs, 1.0 if expr.op == "add" else -1.0)
+            )
+        if expr.op == "mul":
+            lhs, rhs = coefficients(expr.args[0]), coefficients(expr.args[1])
+            if lhs is None or rhs is None:
+                return None
+            if lhs[:2] == (0.0, 0.0):
+                return _affine_scale(rhs, lhs[2])
+            if rhs[:2] == (0.0, 0.0):
+                return _affine_scale(lhs, rhs[2])
+        return None
+
+    values = coefficients(store.value)
+    if (
+        values is None
+        or values[0] == 0.0
+        or values[1] == 0.0
+        or not all(math.isfinite(value) for value in values)
+    ):
+        return None
+    return "mean_linear:" + ":".join(format(value, ".17g") for value in values)
+
+
+def is_logsumexp_ir(store: GemmEpilogueIRStore, source_name: str, group: int) -> bool:
+    """Match max(xs) + log(sum(exp(xs - max(xs))))."""
+    expr = _strip_conversions(store.value)
+    if not isinstance(expr, GemmEpilogueIRExpression) or expr.op != "add":
+        return False
+    for maximum, logarithm in (expr.args[:2], reversed(expr.args[:2])):
+        maximum = _strip_conversions(maximum)
+        logarithm = _strip_conversions(logarithm)
+        if not (
+            _stable_group_max(maximum, source_name, group)
+            and isinstance(logarithm, GemmEpilogueIRExpression)
+            and logarithm.op == "log"
+        ):
+            continue
+        terms = _flatten_associative(logarithm.args[0], "add")
+        if len(terms) == group and all(
+            _shifted_exp(term, source_name) == maximum for term in terms
+        ):
+            return True
+    return False

--- a/torch/_inductor/kernel/gemm_epilogue_utils.py
+++ b/torch/_inductor/kernel/gemm_epilogue_utils.py
@@ -1,0 +1,36 @@
+# mypy: allow-untyped-defs
+"""Symbolic shape helpers shared by GEMM epilogue frontends."""
+
+from collections.abc import Sequence
+from typing import Any
+
+import sympy
+
+from torch._inductor.virtualized import V
+from torch.fx.experimental.symbolic_shapes import (
+    statically_known_true as fx_statically_known_true,
+)
+
+
+def statically_known(expr: Any) -> bool:
+    """Return whether a symbolic predicate is known true without adding guards."""
+    if isinstance(expr, bool):
+        return expr
+    if isinstance(expr, sympy.Basic):
+        return V.graph.sizevars.statically_known_true(expr)
+    return fx_statically_known_true(expr)
+
+
+def statically_known_equal(lhs: Any, rhs: Any) -> bool:
+    """Return whether symbolic shape values are known equal without adding guards."""
+    return statically_known(lhs == rhs)
+
+
+def statically_known_shape_equal(
+    actual_shape: Sequence[Any], expected_shape: Sequence[Any]
+) -> bool:
+    """Compare possibly symbolic shape tuples without adding guards."""
+    return len(actual_shape) == len(expected_shape) and all(
+        statically_known_equal(actual, expected)
+        for actual, expected in zip(actual_shape, expected_shape)
+    )

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/reduction_utils.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/reduction_utils.py
@@ -1,0 +1,40 @@
+"""CuTeDSL geometry helpers shared by NVGEMM reduction kernels."""
+
+__all__ = ["get_lane_warp_layouts", "partition_for_epilogue"]
+
+
+def get_lane_warp_layouts(tiled_copy, reference_src=True):
+    """Derive two-dimensional lane and warp layouts for an epilogue copy."""
+    import cutlass.cute as cute
+
+    from torch._vendor.quack import layout_utils
+
+    layout_tv = (
+        tiled_copy.layout_src_tv_tiled
+        if reference_src
+        else tiled_copy.layout_dst_tv_tiled
+    )
+    ref_layout = cute.right_inverse(layout_tv)
+    tile_m = cute.size(tiled_copy.tiler_mn[0])
+    tile_n = cute.size(tiled_copy.tiler_mn[1])
+    ref_layout_mn = cute.composition(ref_layout, cute.make_layout((tile_m, tile_n)))
+
+    num_warps = cute.size(tiled_copy) // cute.arch.WARP_SIZE
+    tv_to_lane = cute.make_layout((cute.arch.WARP_SIZE, num_warps, 1), stride=(1, 0, 0))
+    ref_to_lane = cute.composition(tv_to_lane, ref_layout_mn)
+    lane_m = cute.filter(cute.select(ref_to_lane, [0]))
+    lane_n = cute.filter(cute.select(ref_to_lane, [1]))
+    lane_layout_mn = layout_utils.concat_layout(lane_m, lane_n)
+
+    tv_to_warp = cute.make_layout((cute.arch.WARP_SIZE, num_warps, 1), stride=(0, 1, 0))
+    ref_to_warp = cute.composition(tv_to_warp, ref_layout_mn)
+    warp_m = cute.filter(cute.select(ref_to_warp, [0]))
+    warp_n = cute.filter(cute.select(ref_to_warp, [1]))
+    warp_layout_mn = layout_utils.concat_layout(warp_m, warp_n)
+    return lane_layout_mn, warp_layout_mn
+
+
+def partition_for_epilogue(*args, **kwargs):
+    from torch._vendor.quack.sm90_utils import partition_for_epilogue as partition
+
+    return partition(*args, **kwargs)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -7974,6 +7974,10 @@ class Scheduler:
             node1.get_device()
         ).can_fuse_multi_outputs_template(node1, node2):
             return True
+        if node1.is_template() and self.get_backend(
+            node1.get_device()
+        ).can_fuse_reduction_epilogue(node1, node2):
+            return True
 
         if isinstance(node1, GroupedSchedulerNode) or isinstance(
             node2, GroupedSchedulerNode
@@ -8148,9 +8152,13 @@ class Scheduler:
             atomic_add_mutation_epilogue = _can_fuse_atomic_add_template_epilogue(
                 node1, node2
             )
+            backend = self.get_backend(node1.get_device())
             if (
                 (node2.has_aliasing_or_mutation() and not atomic_add_mutation_epilogue)
-                or node2.is_reduction()
+                or (
+                    node2.is_reduction()
+                    and not backend.can_fuse_reduction_epilogue(node1, node2)
+                )
                 or not _is_epilogue_fusion_enabled(node1)
             ):
                 why("template epilogue not satisfied")
@@ -10419,6 +10427,11 @@ class BaseScheduling:  # noqa: docstring_linter
         Check whether node1 and node2 can be horizontally fused or not.
         """
         raise NotImplementedError
+
+    def can_fuse_reduction_epilogue(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> bool:
+        return False
 
     def can_fuse_multi_outputs_template(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191515
* #191514
* #191595
* #191594
* #191593
* #191592
* #191591
* #190813
* #191590
* #191513
* #191588
* #191587
* #191586
* #191585
* __->__ #191584
* #190809
* #190825
* #190824
* #190822
* #190821
* #190820
* #190819
* #190823
* #190817
* #190810

> Add backend-neutral representations and loop-IR analysis for grouped GEMM reductions. Define reduction geometry, recognized expressions, output plans, and runtime arguments so backend scheduling can decide whether a reduction epilogue is legal.
>