### PR TITLE
[inductor][NVGEMM] Lower grouped reductions across epilogue fragments

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -7,6 +7,7 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import torch
+from torch._higher_order_ops import flex_gemm
 from torch._inductor import config
 from torch._inductor.codegen.cuda.cuda_env import is_datacenter_blackwell_arch
 from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_scheduling import (
@@ -479,6 +480,150 @@ class TestNVUniversalGemm(TestCase):
 
         torch.testing.assert_close(result, expected, equal_nan=True)
 
+    def test_scaled_gemm_grouped_n_reduce_provider(self):
+        from cutlass import Float32
+        from cutlass.operators import ScaleMode, ScaleSwizzleMode
+
+        from torch._inductor.codegen.nv_universal_gemm.kernel_cache import (
+            _scaled_candidates,
+        )
+        from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_kernel import (
+            _create_gemm_arguments,
+        )
+
+        m, n, k = 128, 128, 512
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+            torch.float4_e2m1fn_x2
+        )
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        out = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
+        group = 32
+        reduce_out = torch.empty((m, n // group), device="cuda", dtype=torch.float32)
+        mode = ScaleMode.Blockwise1x16
+        swizzle = ScaleSwizzleMode.Swizzle32x4x4
+        args = _create_gemm_arguments(
+            "SCALED_GEMM",
+            (a, b, scale_a, scale_b),
+            out,
+            Float32,
+            scale_mode_a=mode,
+            swizzle_mode_a=swizzle,
+            scale_mode_b=mode,
+            swizzle_mode_b=swizzle,
+            local_reduce_out=reduce_out,
+            local_reduce_group=group,
+            local_reduce_axis=1,
+        )
+        kernel = next(
+            candidate
+            for candidate in _scaled_candidates(args, 100, efc_only=True)
+            if candidate.metadata.design.tile_shape[1] == n
+        )
+        artifact = kernel.compile(args)
+        kernel.run(
+            args,
+            artifact,
+            stream=torch.cuda.current_stream(),
+            assume_supported_args=True,
+        )
+        torch.cuda.synchronize()
+        self.assertEqual(
+            reduce_out,
+            out.float().view(m, -1, group).sum(-1),
+        )
+
+    def test_scaled_gemm_unit_dim_epilogue_non_current_stream(self):
+        from cutlass import Float32
+        from cutlass.operators import ScaleMode, ScaleSwizzleMode
+        from cutlass.operators.arguments import EpilogueArguments
+
+        from torch._inductor.codegen.nv_universal_gemm.kernel_cache import (
+            _scaled_candidates,
+        )
+        from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_kernel import (
+            _create_gemm_arguments,
+        )
+
+        m, n, k = 1, 128, 512
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+            torch.float4_e2m1fn_x2
+        )
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        bias = torch.randn((1, 1), device="cuda", dtype=torch.bfloat16)
+        out = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
+        expected = (
+            torch._scaled_mm(
+                a,
+                b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                out_dtype=torch.bfloat16,
+            )
+            + bias
+        )
+        epilogue = EpilogueArguments(
+            epilogue_fn="def epilogue(accum, bias):\n    D = accum + bias\n    return D\n",
+            bias=bias,
+            D=out,
+        )
+        mode = ScaleMode.Blockwise1x16
+        swizzle = ScaleSwizzleMode.Swizzle32x4x4
+        args = _create_gemm_arguments(
+            "SCALED_GEMM",
+            (a, b, scale_a, scale_b),
+            out,
+            Float32,
+            scale_mode_a=mode,
+            swizzle_mode_a=swizzle,
+            scale_mode_b=mode,
+            swizzle_mode_b=swizzle,
+            epilogue=epilogue,
+        )
+        selection_args = _create_gemm_arguments(
+            "SCALED_GEMM",
+            (a, b, scale_a, scale_b),
+            out,
+            Float32,
+            scale_mode_a=mode,
+            swizzle_mode_a=swizzle,
+            scale_mode_b=mode,
+            swizzle_mode_b=swizzle,
+        )
+        kernel = next(
+            candidate
+            for candidate in _scaled_candidates(selection_args, 100, efc_only=True)
+            if candidate.metadata.design.tile_shape[1] == n
+        )
+        artifact = kernel.compile(args)
+        torch.cuda.synchronize()
+        torch.cuda._sleep(10_000_000)
+        stream = torch.cuda.Stream()
+        kernel.run(args, artifact, stream=stream, assume_supported_args=True)
+        stream.synchronize()
+        self.assertEqual(out, expected)
+
     @parametrize("out_dtype", (torch.float32, torch.bfloat16))
     @parametrize(
         "layout_a",
@@ -625,6 +770,31 @@ class TestNVUniversalGemm(TestCase):
 
 class TestNVUniversalGemmHeuristics(TestCase):
     """Unit tests for NVUniversalGemmHeuristics without requiring actual libraries."""
+
+    def test_grouped_reduction_conversion_contract(self):
+        from torch._inductor.kernel.gemm_epilogue_ir import (
+            GemmEpilogueIRExpression as Expr,
+            GemmEpilogueIRStore,
+            grouped_reduction_ir,
+        )
+
+        load = Expr("load", ("gemm", 0, None))
+
+        def classify(value):
+            square = Expr("mul", (value, value))
+            reduction = Expr("reduction", (torch.float32, torch.float32, "sum", square))
+            return grouped_reduction_ir(
+                GemmEpilogueIRStore(0, reduction), "gemm", 4, torch.bfloat16
+            )
+
+        fp32 = Expr("to_dtype", (load, torch.float32))
+        self.assertEqual(classify(fp32), ("sum", "square"))
+        fp16_then_fp32 = Expr(
+            "to_dtype", (Expr("to_dtype", (load, torch.float16)), torch.float32)
+        )
+        self.assertIsNone(classify(fp16_then_fp32))
+        bitcast = Expr("to_dtype_bitcast", (load, torch.bfloat16, torch.bfloat16))
+        self.assertIsNone(classify(Expr("to_dtype", (bitcast, torch.float32))))
 
     def _create_mock_kernel(self, tile_m, tile_n, tile_k, cluster_m, cluster_n):
         """Create a mock kernel with the given tile/cluster configuration."""
@@ -910,7 +1080,49 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         self.assertTrue(epilogue_fused)
         self.assertIn("out_ptr1", code)
 
-    def test_scaled_mm_pointwise_epilogue_fusion(self):
+    def test_flex_gemm_pointwise_epilogue_fusion(self):
+        dtype = torch.bfloat16
+        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
+        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                torch.relu,
+                kernel_options={"backend": "NVGEMM"},
+            )
+
+        result, code, epilogue_fused = self._compile_and_check(fn, a, b)
+        torch.testing.assert_close(result, torch.relu(a @ b), atol=1e-2, rtol=1e-2)
+        self.assertTrue(epilogue_fused, "FlexGEMM body was NOT fused into epilogue")
+
+    def test_flex_gemm_preserves_output_for_unfused_reduction(self):
+        dtype = torch.bfloat16
+        a = torch.randn(128, 64, device="cuda", dtype=dtype)
+        b = torch.randn(64, 128, device="cuda", dtype=dtype)
+
+        def fn(a, b):
+            def epilogue(acc):
+                grouped = acc.float().view(128, -1, 32)
+                return acc.relu(), grouped.sum(-1)
+
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue,
+                kernel_options={"backend": "NVGEMM"},
+            )
+
+        result, code, epilogue_fused = self._compile_and_check(fn, a, b)
+        expected = fn(a, b)
+        torch.testing.assert_close(result[0], expected[0], atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(result[1], expected[1], atol=1e-1, rtol=1e-2)
+        self.assertTrue(epilogue_fused, "pointwise consumer was NOT fused")
+        self.assertIn("out_ptr1", code)
+
+    @parametrize("operation", ("mul", "sigmoid", "gelu"))
+    def test_scaled_mm_pointwise_epilogue_fusion(self, operation):
         """Unary pointwise op is fused into an NVFP4 scaled GEMM epilogue."""
         m, n, k = self.M, self.N, self.K
         packed_k = k // 2
@@ -937,13 +1149,19 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
                 scale_b=scale_b,
                 out_dtype=torch.bfloat16,
             )
+            if operation == "sigmoid":
+                return torch.sigmoid(result)
+            if operation == "gelu":
+                return torch.nn.functional.gelu(result)
             return result * 0.5
 
         result, code, epilogue_fused = self._compile_and_check(
             fn, a, b, scale_a, scale_b
         )
         torch.testing.assert_close(result, fn(a, b, scale_a, scale_b), equal_nan=True)
-        self.assertTrue(epilogue_fused, "multiply was NOT fused into scaled epilogue")
+        self.assertTrue(
+            epilogue_fused, f"{operation} was NOT fused into scaled epilogue"
+        )
 
     def test_matmul_single_store_epilogue_chain(self):
         a = torch.randn(self.M, self.K, device="cuda", dtype=torch.bfloat16)
@@ -956,6 +1174,323 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         self.assertEqual(result, fn(a, b), atol=1e-2, rtol=1e-2)
         self.assertTrue(epilogue_fused)
         self.assertNotIn("out_ptr1", code)
+
+    def test_scaled_mm_multi_store_epilogue_fusion(self):
+        m, n, k = self.M, self.N, self.K
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+            torch.float4_e2m1fn_x2
+        )
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+
+        def fn(a, b, scale_a, scale_b):
+            result = torch._scaled_mm(
+                a,
+                b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                out_dtype=torch.bfloat16,
+            )
+            result_fp32 = result.float()
+            return result, torch.relu(result_fp32), result_fp32 * 0.5
+
+        result, code, epilogue_fused = self._compile_and_check(
+            fn, a, b, scale_a, scale_b
+        )
+        expected = fn(a, b, scale_a, scale_b)
+        self.assertEqual(result, expected)
+        self.assertTrue(epilogue_fused)
+        self.assertIn("out_ptr1", code)
+        self.assertIn("out_ptr2", code)
+
+    @parametrize(
+        "case",
+        (
+            ((((M, N), torch.bfloat16),), True),
+            ((((N,), torch.bfloat16),), True),
+            ((((1, N), torch.bfloat16),), True),
+            ((((M, 1), torch.bfloat16),), True),
+            ((((N,), torch.bfloat16), ((M, 1), torch.bfloat16)), True),
+            ((((N,), torch.float32),), True),
+        ),
+        name_fn=lambda case: "_and_".join(
+            f"{'x'.join(map(str, shape))}_{dtype}" for shape, dtype in case[0]
+        ),
+    )
+    def test_scaled_mm_broadcast_epilogue_fusion(self, case):
+        bias_specs, expected_fused = case
+        m, n, k = self.M, self.N, self.K
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+            torch.float4_e2m1fn_x2
+        )
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        biases = tuple(
+            torch.randn(shape, device="cuda", dtype=dtype)
+            for shape, dtype in bias_specs
+        )
+
+        def fn(a, b, scale_a, scale_b, *biases):
+            result = torch._scaled_mm(
+                a,
+                b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                out_dtype=torch.bfloat16,
+            )
+            for bias in biases:
+                result = result + bias
+            return torch.relu(result)
+
+        result, code, epilogue_fused = self._compile_and_check(
+            fn, a, b, scale_a, scale_b, *biases
+        )
+        self.assertEqual(epilogue_fused, expected_fused)
+        torch.testing.assert_close(
+            result, fn(a, b, scale_a, scale_b, *biases), equal_nan=True
+        )
+
+    @parametrize("bias_shape", ((1,), (1, 1)))
+    def test_scaled_mm_unit_dim_broadcast_epilogue_fusion(self, bias_shape):
+        m, n, k = 1, 128, self.K
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+            torch.float4_e2m1fn_x2
+        )
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        bias = torch.randn(bias_shape, device="cuda", dtype=torch.bfloat16)
+
+        def fn(a, b, scale_a, scale_b, bias):
+            result = torch._scaled_mm(
+                a,
+                b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                out_dtype=torch.bfloat16,
+            )
+            return torch.relu(result + bias)
+
+        result, _, epilogue_fused = self._compile_and_check(
+            fn, a, b, scale_a, scale_b, bias
+        )
+        self.assertTrue(epilogue_fused)
+        self.assertEqual(result, fn(a, b, scale_a, scale_b, bias))
+
+    @parametrize(
+        "case",
+        (
+            (0, "sum", 4),
+            (0, "mean", 4),
+            (0, "prod", 4),
+            (0, "amax", 4),
+            (0, "amin", 4),
+            (0, "sum", 8),
+            (0, "mean", 8),
+            (0, "prod", 8),
+            (0, "amax", 8),
+            (0, "amin", 8),
+            (0, "sum", 16),
+            (0, "mean", 16),
+            (0, "prod", 16),
+            (0, "amax", 16),
+            (0, "amin", 16),
+            (1, "sum", 32),
+            (1, "mean", 32),
+            (1, "prod", 32),
+            (1, "amax", 32),
+            (1, "amin", 32),
+            (1, "sum", 64),
+            (1, "mean", 64),
+            (1, "prod", 64),
+            (1, "amax", 64),
+            (1, "amin", 64),
+        ),
+        name_fn=lambda case: f"axis_{case[0]}_{case[1]}_group_{case[2]}",
+    )
+    def test_scaled_mm_grouped_reduce_fusion(self, case):
+        axis, reduction, group = case
+        m, n, k = 128, 256 if group > 32 else 128, 512
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+            torch.float4_e2m1fn_x2
+        )
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+
+        def fn(a, b, scale_a, scale_b):
+            result = torch._scaled_mm(
+                a,
+                b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                out_dtype=torch.bfloat16,
+            )
+            grouped = (
+                result.float().view(-1, group, n)
+                if axis == 0
+                else result.float().view(m, -1, group)
+            )
+            dim = 1 if axis == 0 else -1
+            if reduction == "sum":
+                reduced = grouped.sum(dim)
+            elif reduction == "mean":
+                reduced = grouped.mean(dim)
+            elif reduction == "prod":
+                reduced = grouped.prod(dim)
+            elif reduction == "amax":
+                reduced = grouped.amax(dim)
+            else:
+                reduced = grouped.amin(dim)
+            return result, reduced
+
+        result, code, _ = self._compile_and_check(fn, a, b, scale_a, scale_b)
+        expected = fn(a, b, scale_a, scale_b)
+        self.assertEqual(result[0], expected[0])
+        self.assertEqual(result[1], expected[1])
+        self.assertIn("'local_reduce_out'", code)
+
+    def test_scaled_mm_grouped_reduce_source_fusion(self):
+        m, n, k, group = 128, 128, 512, 32
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+            torch.float4_e2m1fn_x2
+        )
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+
+        def fn(a, b, scale_a, scale_b):
+            result = torch._scaled_mm(
+                a,
+                b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                out_dtype=torch.bfloat16,
+            )
+            grouped = result.float().view(m, -1, group)
+            return torch.relu(result), grouped.square().mean(-1)
+
+        result, code, _ = self._compile_and_check(fn, a, b, scale_a, scale_b)
+        expected = fn(a, b, scale_a, scale_b)
+        self.assertEqual(result[0], expected[0])
+        self.assertEqual(result[1], expected[1])
+        self.assertIn("'local_reduce_out'", code)
+        self.assertIn("'local_reduce_source': 'square'", code)
+
+    @config.patch(emulate_precision_casts=True)
+    def test_scaled_mm_grouped_reduce_rejects_intermediate_fp16(self):
+        m, n, k, group = 128, 128, 512, 32
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+            torch.float4_e2m1fn_x2
+        )
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+
+        def fn(a, b, scale_a, scale_b):
+            result = torch._scaled_mm(
+                a,
+                b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                out_dtype=torch.bfloat16,
+            )
+            grouped = result.half().float().view(m, -1, group)
+            return torch.relu(result), grouped.square().mean(-1)
+
+        result, code, _ = self._compile_and_check(fn, a, b, scale_a, scale_b)
+        self.assertEqual(result, fn(a, b, scale_a, scale_b))
+        self.assertNotIn("'local_reduce_out'", code)
+
+    def test_scaled_mm_grouped_reduce_feeds_main(self):
+        m, n, k, group = 128, 128, 512, 4
+        packed_k = k // 2
+        a = _create_tensor_with_layout(
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+        )
+        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+            torch.float4_e2m1fn_x2
+        )
+        b = b.T
+        padded_k_blocks = _round_up(ceildiv(k, 16), 4)
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+            torch.float8_e4m3fn
+        )
+
+        def fn(a, b, scale_a, scale_b):
+            result = torch._scaled_mm(
+                a,
+                b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                out_dtype=torch.bfloat16,
+            )
+            grouped = result.float().view(-1, group, n)
+            mean = grouped.mean(1, keepdim=True).expand(-1, group, -1)
+            return result.float() - mean.reshape(m, n)
+
+        result, code, _ = self._compile_and_check(fn, a, b, scale_a, scale_b)
+        self.assertEqual(result, fn(a, b, scale_a, scale_b))
+        self.assertIn("'local_reduce_feeds_main': True", code)
 
     def test_matmul_add_relu_chained(self):
         """Multi-op pointwise chain (a@b + bias → relu) collapses to one
@@ -1063,6 +1598,24 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         result, code, epilogue_fused = self._compile_and_check(fn, a, b, bias)
         torch.testing.assert_close(result, fn(a, b, bias), atol=1e-2, rtol=1e-2)
         self.assertTrue(epilogue_fused, "bias+relu was NOT fused into epilogue")
+
+    @parametrize(
+        "bias_shape",
+        ((N,), (1, N), (M, 1)),
+        name_fn=lambda shape: "x".join(map(str, shape)),
+    )
+    def test_epilogue_with_broadcast_aux_input(self, bias_shape):
+        dtype = torch.bfloat16
+        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
+        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+        bias = torch.randn(bias_shape, device="cuda", dtype=dtype)
+
+        def fn(a, b, bias):
+            return torch.relu((a @ b) + bias)
+
+        result, code, epilogue_fused = self._compile_and_check(fn, a, b, bias)
+        torch.testing.assert_close(result, fn(a, b, bias), atol=1e-2, rtol=1e-2)
+        self.assertTrue(epilogue_fused, "broadcast bias+relu was not fused")
 
     def test_efc_disk_cache_round_trip(self):
         """Verify that EFC kernel compiled artifacts can be serialized to disk

--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -129,6 +129,15 @@ class CUDACombinedScheduling(BaseScheduling):
                 )  # always False at the moment
         return self._triton_scheduling.can_fuse_horizontal(node1, node2)
 
+    def can_fuse_reduction_epilogue(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> bool:
+        if self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(node1):
+            return self._nv_universal_gemm_scheduling.can_fuse_reduction_epilogue(
+                node1, node2
+            )
+        return False
+
     def group_fn(
         self, sizes: Sequence[Sequence[_IntLike]]
     ) -> tuple[tuple[_IntLike, ...], ...]:

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
@@ -567,6 +567,7 @@ class NVUniversalGemmCaller(ChoiceCaller):
                 epilogue_reads=epilogue_reads,
                 epilogue_writes=epilogue_writes,
                 epilogue_var_renames=epilogue_var_renames,
+                local_reduce=local_reduce,
                 swap_ab=swap_ab,
                 # pyrefly: ignore [bad-argument-type]
                 bias_node=bias_node,

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -39,6 +39,7 @@ from torch._inductor.virtualized import V
 
 if TYPE_CHECKING:
     from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm import GemmVariant
+    from torch._inductor.kernel.gemm_epilogue import GemmReductionPlan
 
 
 log = logging.getLogger(__name__)
@@ -401,8 +402,41 @@ def _create_gemm_arguments(
     scale_mode_b: Any | None = None,
     swizzle_mode_b: Any | None = None,
     epilogue: Any | None = None,
+    local_reduce_out: Any | None = None,
+    local_reduce_group: int = 0,
+    local_reduce_axis: int = 1,
+    local_reduce_type: str = "sum",
+    local_reduce_source: str = "identity",
+    local_reduce_feeds_main: bool = False,
 ):
     import cutlass.operators
+
+    has_local_reduce = local_reduce_out is not None or local_reduce_feeds_main
+    if has_local_reduce and variant_name != "SCALED_GEMM":
+        raise NotImplementedError(
+            "NVGEMM local reductions currently require scaled GEMM"
+        )
+    if has_local_reduce and (
+        local_reduce_axis not in (0, 1) or local_reduce_group <= 1
+    ):
+        raise NotImplementedError(
+            "NVGEMM local reductions require an M- or N-axis group greater than 1"
+        )
+
+    def with_local_reduce(args):
+        if not has_local_reduce:
+            return args
+        from cutlass.operators.utils.tensor import TensorWrapper
+
+        args.local_reduce_out = (
+            TensorWrapper(local_reduce_out) if local_reduce_out is not None else None
+        )
+        args.local_reduce_group = local_reduce_group
+        args.local_reduce_axis = local_reduce_axis
+        args.local_reduce_type = local_reduce_type
+        args.local_reduce_source = local_reduce_source
+        args.local_reduce_feeds_main = local_reduce_feeds_main
+        return args
 
     if epilogue is not None and variant_name == "GROUPED_GEMM":
         raise NotImplementedError(
@@ -429,11 +463,13 @@ def _create_gemm_arguments(
             kwargs: dict[str, Any] = {"accumulator_type": accumulator_type}
             if epilogue is not None:
                 kwargs["epilogue"] = epilogue
-            return cutlass.operators.arguments.GemmArguments(
-                scaled_a,
-                scaled_b,
-                out,
-                **kwargs,
+            return with_local_reduce(
+                cutlass.operators.arguments.GemmArguments(
+                    scaled_a,
+                    scaled_b,
+                    out,
+                    **kwargs,
+                )
             )
 
         case "GEMM":
@@ -441,7 +477,9 @@ def _create_gemm_arguments(
             kwargs: dict[str, Any] = {"accumulator_type": accumulator_type}
             if epilogue is not None:
                 kwargs["epilogue"] = epilogue
-            return cutlass.operators.arguments.GemmArguments(a, b, out, **kwargs)
+            return with_local_reduce(
+                cutlass.operators.arguments.GemmArguments(a, b, out, **kwargs)
+            )
 
         case _:
             raise NotImplementedError(f"Unsupported NVGEMM variant: {variant_name}")
@@ -506,13 +544,14 @@ def _create_gemm_cache_key(
     *,
     has_epilogue: bool = False,
     aux_tensors: tuple = (),
+    epilogue_specialization: tuple = (),
 ):
     cache_key = tuple(s for t in input_tensors for s in _tensor_sig(t))
     cache_key = (*cache_key, *_tensor_sig(out))
 
     if has_epilogue:
         aux_sig = tuple(_tensor_sig(t) for t in aux_tensors)
-        return (*cache_key, "epilogue", aux_sig)
+        return (*cache_key, "epilogue", aux_sig, epilogue_specialization)
     return cache_key
 
 
@@ -583,7 +622,7 @@ def _rewrap_efc_compiled_obj(compiled_fn, kernel, epilogue_args=None):
 
 
 def _update_reuse_args_tensors(
-    variant_name, args, input_tensors, out, epilogue_args
+    variant_name, args, input_tensors, out, epilogue_args, args_kwargs=None
 ) -> bool:
     """Redirect the cached args at this call's runtime tensors.
 
@@ -613,6 +652,10 @@ def _update_reuse_args_tensors(
         for name, wrapper in epilogue.tensors.items():
             val = epilogue_args.tensors[name]
             wrapper._runtime_tensor = getattr(val, "runtime_tensor", val)
+    local_reduce = getattr(args, "local_reduce_out", None)
+    if local_reduce is not None:
+        assert args_kwargs is not None  # noqa: S101
+        local_reduce._runtime_tensor = args_kwargs["local_reduce_out"]
     return True
 
 
@@ -653,6 +696,9 @@ def _clear_reuse_args_tensors(variant_name, args, epilogue_args):
                     example_inputs[name] = torch.empty_strided(
                         val.shape, val.stride(), dtype=val.dtype, device="meta"
                     )
+    local_reduce = getattr(args, "local_reduce_out", None)
+    if local_reduce is not None:
+        local_reduce._runtime_tensor = None
 
 
 def _nvgemm_run(
@@ -690,11 +736,17 @@ def _nvgemm_run(
 
     from torch._inductor.runtime.cutedsl_cache import disk_cache_get, disk_cache_set
 
+    epilogue_specialization = tuple(
+        (key, variant_kwargs[key])
+        for key in ("local_reduce_type", "local_reduce_source")
+        if variant_kwargs is not None and key in variant_kwargs
+    )
     cache_key = _create_gemm_cache_key(
         input_tensors,
         out,
         has_epilogue=has_epilogue,
         aux_tensors=aux_tensors,
+        epilogue_specialization=epilogue_specialization,
     )
     dev_idx = input_tensors[0].device.index or 0
     mem_key = (cache_key, dev_idx)
@@ -714,7 +766,12 @@ def _nvgemm_run(
             # stomp each other's runtime tensor pointers.
             with reuse_lock:
                 if _update_reuse_args_tensors(
-                    variant_name, args, input_tensors, out, epilogue_args
+                    variant_name,
+                    args,
+                    input_tensors,
+                    out,
+                    epilogue_args,
+                    variant_kwargs,
                 ):
                     try:
                         kernel.run(
@@ -789,7 +846,12 @@ def _nvgemm_run(
     # GROUPED_GEMM, where _update_reuse_args_tensors returns False). This runs
     # for both the disk-loaded rebuild branch and the fresh-compile branch.
     reuse_supported = _update_reuse_args_tensors(
-        variant_name, args, input_tensors, out, epilogue_args
+        variant_name,
+        args,
+        input_tensors,
+        out,
+        epilogue_args,
+        variant_kwargs,
     )
     if reuse_supported:
         # Publish and launch under the lock so a concurrent reuse-path caller
@@ -1017,6 +1079,7 @@ class NVUniversalGemmKernel(Kernel):
         epilogue_reads: list[str] | None = None,
         epilogue_writes: list[str] | None = None,
         epilogue_var_renames: dict[str, Any] | None = None,
+        local_reduce: GemmReductionPlan | None = None,
         swap_ab: bool = False,
         bias_node: Buffer | None = None,
     ) -> None:
@@ -1036,6 +1099,7 @@ class NVUniversalGemmKernel(Kernel):
         self.epilogue_reads = epilogue_reads or []
         self.epilogue_writes = epilogue_writes or []
         self.epilogue_var_renames = epilogue_var_renames or {}
+        self.local_reduce = local_reduce
         self.swap_ab = swap_ab
 
         # An addmm bias baked into the choice becomes a bias-add epilogue. With
@@ -1091,7 +1155,7 @@ class NVUniversalGemmKernel(Kernel):
             input_tensors_expr = f"({', '.join(input_tensor_names)})"
 
         workspace_arg = "workspace" if self.workspace_size > 0 else "None"
-        has_epilogue = bool(self.epilogue_fn_code)
+        has_epilogue = bool(self.epilogue_fn_code) or self.local_reduce is not None
 
         # Build variant_kwargs dict expression for SCALED_GEMM
         variant_kwargs_expr = "None"
@@ -1179,8 +1243,8 @@ class NVUniversalGemmKernel(Kernel):
             # Build epilogue args if needed (user-specific variable names)
             epi_args_expr = "None"
             epi_source_expr = '""'
-            aux_tensors_expr = "()"
-            if has_epilogue:
+            aux_tensors: list[str] = []
+            if self.epilogue_fn_code:
                 epilogue_kwargs = self._render_epilogue_kwargs()
                 epi_kwargs_str = "epilogue_fn=_EPILOGUE_FN_SRC"
                 if epilogue_kwargs:
@@ -1188,8 +1252,31 @@ class NVUniversalGemmKernel(Kernel):
                 code.writeline(f"epi_args = EpilogueArguments({epi_kwargs_str})")
                 epi_args_expr = "epi_args"
                 epi_source_expr = "_EPILOGUE_FN_SOURCE"
-                if self.epilogue_reads:
-                    aux_tensors_expr = "(" + ", ".join(self.epilogue_reads) + ",)"
+                aux_tensors.extend(self.epilogue_reads)
+
+            run_variant_kwargs = "_VARIANT_KWARGS"
+            if self.local_reduce is not None:
+                reduction = self.local_reduce
+                feed_main = reduction.feeds_main
+                reduce_ptr = (
+                    "None"
+                    if reduction.reduction_output is None
+                    else f"out_ptr{output_buffers.index(reduction.reduction_output)}"
+                )
+                run_variant_kwargs = (
+                    "_VARIANT_KWARGS | {"
+                    f"'local_reduce_out': {reduce_ptr}, "
+                    f"'local_reduce_group': {reduction.group}, "
+                    f"'local_reduce_axis': {reduction.axis}, "
+                    f"'local_reduce_type': {reduction.reduction_type!r}, "
+                    f"'local_reduce_source': {reduction.source_type!r}"
+                    f", 'local_reduce_feeds_main': {feed_main!r}"
+                    "}"
+                )
+                if not feed_main:
+                    aux_tensors.append(reduce_ptr)
+
+            aux_tensors_expr = f"({', '.join(aux_tensors)},)" if aux_tensors else "()"
 
             code.writeline("_nvgemm_run(")
             with code.indent():
@@ -1199,7 +1286,7 @@ class NVUniversalGemmKernel(Kernel):
                     "_compiled_cache, _disk_fn_cache, __file__, _DISK_CACHE_CONFIG_KEY,"
                 )
                 code.writeline(f"stream=stream, workspace={workspace_arg},")
-                code.writeline("variant_kwargs=_VARIANT_KWARGS,")
+                code.writeline(f"variant_kwargs={run_variant_kwargs},")
                 code.writeline(f"epilogue_args={epi_args_expr},")
                 code.writeline(f"epilogue_source={epi_source_expr},")
                 code.writeline(f"has_epilogue={has_epilogue},")
@@ -1247,7 +1334,15 @@ class NVUniversalGemmKernel(Kernel):
         order as out_ptr1, out_ptr2, ...
         """
         if not self.epilogue_writes:
-            return [self.output_node.get_name()]
+            primary_output = (
+                self.local_reduce.primary_output
+                if self.local_reduce is not None
+                else self.output_node.get_name()
+            )
+            ordered = [primary_output]
+            if self.local_reduce is not None:
+                ordered.extend(self.local_reduce.auxiliary_outputs)
+            return ordered
         d_buf = (self.epilogue_var_renames or {}).get("D")
         ordered: list[str] = []
         if d_buf is not None:
@@ -1255,6 +1350,12 @@ class NVUniversalGemmKernel(Kernel):
         for w in self.epilogue_writes:
             if w != d_buf and w not in ordered:
                 ordered.append(w)
+        if self.local_reduce is not None:
+            ordered.extend(
+                output
+                for output in self.local_reduce.auxiliary_outputs
+                if output not in ordered
+            )
         return ordered
 
     def _render_epilogue_kwargs(self) -> str:
@@ -1294,6 +1395,16 @@ class NVUniversalGemmKernel(Kernel):
         Includes epilogue input tensors when epilogue fusion is enabled.
         """
         wrapper = V.graph.wrapper_code
+
+        if self.local_reduce is not None:
+            primary_name = self.local_reduce.primary_output
+            V.graph.removed_buffers.discard(primary_name)
+            primary_output = V.graph.get_buffer(primary_name)
+            wrapper.codegen_allocation(
+                primary_output
+                if isinstance(primary_output, Buffer)
+                else self.output_node
+            )
 
         call_args: list[str] = []
         arg_types: list[Any] = []

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
@@ -3,6 +3,7 @@
 NVIDIA Universal GEMM scheduling for PyTorch Inductor.
 """
 
+import dataclasses
 import hashlib
 import logging
 from collections.abc import Sequence
@@ -24,6 +25,14 @@ from ...ir import (
     MultiTemplateBuffer,
     NVUniversalGemmBuffer,
     Pointwise,
+    Reduction,
+)
+from ...kernel.gemm_epilogue import GemmReductionConfig, GemmReductionPlan
+from ...kernel.gemm_epilogue_ir import (
+    centered_mean_consumer_type_unrolled_ir,
+    GemmEpilogueIRAnalysis,
+    grouped_reduction_ir,
+    single_source_affine_ir,
 )
 from ...scheduler import (
     BaseSchedulerNode,
@@ -33,7 +42,7 @@ from ...scheduler import (
 )
 from ...virtualized import V
 from ..common import BackendFeature, IndentedBuffer
-from ..cutlass.python_evt import CutlassEVTCodegen
+from ..cutlass.python_evt import _ACCUMULATOR_ARG_NAME, CutlassEVTCodegen
 from .nv_universal_gemm import NVUniversalGemmCaller
 
 
@@ -42,6 +51,20 @@ log = logging.getLogger(__name__)
 MAIN_SUFFIX = "main"
 _BENCHMARK_KERNEL_PREFIX = "nv_gemm_"
 EPILOGUE_FN_NAME = "_epilogue_fn"
+
+
+@dataclasses.dataclass(frozen=True)
+class NVGemmEpiloguePlan:
+    nodes: tuple[BaseSchedulerNode, ...]
+    reductions: tuple[GemmReductionConfig, ...]
+    reduction_nodes: tuple[BaseSchedulerNode, ...]
+    candidate_reduction: GemmReductionConfig | None = None
+    feed_main: GemmReductionConfig | None = None
+
+    @property
+    def evt_nodes(self) -> list[BaseSchedulerNode]:
+        owned = OrderedSet(self.reduction_nodes)
+        return [node for node in self.nodes if node not in owned]
 
 
 class NVUniversalGemmScheduling(BaseScheduling):
@@ -189,6 +212,214 @@ class NVUniversalGemmScheduling(BaseScheduling):
                 epilogue_nodes.append(node)
         return epilogue_nodes
 
+    @classmethod
+    def _grouped_reduce_config(
+        cls, gemm_node: Buffer, scheduler_node: BaseSchedulerNode
+    ) -> GemmReductionConfig | None:
+        nodes = scheduler_node.get_nodes()
+        if len(nodes) not in (1, 2):
+            return None
+        buffers = [snode.node for snode in nodes]
+        if not all(isinstance(buffer, ComputedBuffer) for buffer in buffers):
+            return None
+        buffers = [cast(ComputedBuffer, buffer) for buffer in buffers]
+        node = buffers[0]
+        access_node = scheduler_node
+        output_name = node.get_name()
+        if len(node.data.ranges) != 2 or len(gemm_node.get_size()) != 2:
+            return None
+        try:
+            m, n = (V.graph.sizevars.optimization_hint(v) for v in gemm_node.get_size())
+            out_m, out_n = (
+                V.graph.sizevars.optimization_hint(v) for v in node.data.ranges
+            )
+        except Exception:
+            return None
+
+        if isinstance(node.data, Reduction):
+            reduction = node.data
+            if len(reduction.reduction_ranges) != 1:
+                return None
+            group = V.graph.sizevars.optimization_hint(reduction.reduction_ranges[0])
+            if m == out_m and n % group == 0 and out_n == n // group:
+                axis = 1
+                expected_strides = [n, group, 1]
+                max_group = n
+            elif n == out_n and m % group == 0 and out_m == m // group:
+                axis = 0
+                expected_strides = [group * n, 1, n]
+                max_group = 16
+            else:
+                return None
+        elif isinstance(node.data, Pointwise):
+            if n != out_n or out_m <= 0 or m % out_m != 0:
+                return None
+            group = m // out_m
+            axis = 0
+            max_group = 16
+            expected_strides = [group * n, 1]
+        else:
+            return None
+        if group <= 1 or group > max_group:
+            return None
+
+        store = GemmEpilogueIRAnalysis.store_from_buffer(node)
+        classified = (
+            grouped_reduction_ir(
+                store,
+                gemm_node.get_name(),
+                group,
+            )
+            if store is not None
+            else None
+        )
+        if classified is None:
+            return None
+        reduction_type, source_type = classified
+        if reduction_type not in (
+            "sum",
+            "mean",
+            "prod",
+            "max",
+            "min",
+        ) or source_type not in ("identity", "square"):
+            return None
+        if (
+            isinstance(node.data, Reduction)
+            and node.data.reduction_type != reduction_type
+        ):
+            return None
+        if len(buffers) == 2:
+            finalizer = buffers[1]
+            finalizer_store = GemmEpilogueIRAnalysis.store_from_buffer(finalizer)
+            finalizer_reads = list(nodes[1].read_writes.reads)
+            if (
+                reduction_type != "sum"
+                or not isinstance(node.data, Reduction)
+                or not isinstance(finalizer.data, Pointwise)
+                or not finalizer_reads
+                or any(read.name != node.get_name() for read in finalizer_reads)
+                or not V.graph.sizevars.statically_known_list_equals(
+                    node.get_size(), finalizer.get_size()
+                )
+                or finalizer_store is None
+                or single_source_affine_ir(finalizer_store, node.get_name())
+                != (1.0 / group, 0.0)
+            ):
+                return None
+            reduction_type = "mean"
+            access_node = nodes[0]
+            output_name = finalizer.get_name()
+
+        reads = list(access_node.read_writes.reads)
+        if not reads or any(read.name != gemm_node.get_name() for read in reads):
+            return None
+        range_vars = access_node.read_writes.range_vars
+        if range_vars is None:
+            return None
+        if not range_vars:
+            return GemmReductionConfig(
+                output_name, group, axis, reduction_type, source_type
+            )
+        if isinstance(node.data, Reduction):
+            if len(reads) != 1:
+                return None
+            strides = V.graph.sizevars.stride_vars(reads[0].index, range_vars)
+            if list(strides) != expected_strides:
+                return None
+        else:
+            if len(reads) != group:
+                return None
+            expected_base = group * n * range_vars[0] + range_vars[1]
+            offsets = []
+            for read in reads:
+                strides = V.graph.sizevars.stride_vars(read.index, range_vars)
+                if list(strides) != expected_strides:
+                    return None
+                offsets.append(V.graph.sizevars.simplify(read.index - expected_base))
+            expected_offsets = OrderedSet(offset * n for offset in range(group))
+            if OrderedSet(offsets) != expected_offsets:
+                return None
+        return GemmReductionConfig(
+            output_name, group, axis, reduction_type, source_type
+        )
+
+    @classmethod
+    def _grouped_reduce_feeds_main_config(
+        cls, gemm_node: Buffer, scheduler_node: BaseSchedulerNode
+    ) -> GemmReductionConfig | None:
+        nodes = scheduler_node.get_nodes()
+        if len(nodes) != 1 or not isinstance(nodes[0].node, ComputedBuffer):
+            return None
+        node = cast(ComputedBuffer, nodes[0].node)
+        if not isinstance(node.data, Pointwise):
+            return None
+        reads = list(scheduler_node.read_writes.reads)
+        range_vars = scheduler_node.read_writes.range_vars
+        if range_vars is None or len(reads) <= 2:
+            return None
+        try:
+            _, n = map(V.graph.sizevars.optimization_hint, gemm_node.get_size())
+        except Exception:
+            return None
+        group = len(reads) - 1
+        if group <= 1 or group > 4:
+            return None
+        store = GemmEpilogueIRAnalysis.store_from_buffer(node)
+        if (
+            store is None
+            or centered_mean_consumer_type_unrolled_ir(
+                store, gemm_node.get_name(), group
+            )
+            != "mean_linear:1:-1:0"
+        ):
+            return None
+        if any(read.name != gemm_node.get_name() for read in reads):
+            return None
+        grouped_base = reads[1].index
+        if any(
+            V.graph.sizevars.simplify(read.index - grouped_base) != i * n
+            for i, read in enumerate(reads[1:])
+        ):
+            return None
+        return GemmReductionConfig(node.get_name(), group, 0, "mean", "identity")
+
+    @classmethod
+    def _epilogue_plan(
+        cls,
+        gemm_node: Buffer,
+        epilogue_nodes: Sequence[BaseSchedulerNode],
+        candidate: BaseSchedulerNode | None = None,
+    ) -> NVGemmEpiloguePlan:
+        reductions: list[GemmReductionConfig] = []
+        reduction_nodes: list[BaseSchedulerNode] = []
+        candidate_reduction = None
+        for node in epilogue_nodes:
+            config = cls._grouped_reduce_config(gemm_node, node)
+            if config is None:
+                continue
+            reductions.append(config)
+            reduction_nodes.extend(node.get_nodes())
+            if node is candidate:
+                candidate_reduction = config
+        nodes = tuple(
+            scheduler_node
+            for node in epilogue_nodes
+            for scheduler_node in node.get_nodes()
+        )
+        feed_main = (
+            cls._grouped_reduce_feeds_main_config(gemm_node, epilogue_nodes[0])
+            if len(epilogue_nodes) == 1
+            else None
+        )
+        return NVGemmEpiloguePlan(
+            nodes,
+            tuple(reductions),
+            tuple(reduction_nodes),
+            candidate_reduction,
+            feed_main,
+        )
+
     def _can_fuse_epilogue_impl(
         self,
         gemm_template_node: SchedulerNode,
@@ -239,19 +470,48 @@ class NVUniversalGemmScheduling(BaseScheduling):
                 log.debug("NVGEMM epilogue fusion: no EFC kernel available in choices")
                 return False
 
-        scheduler_nodes_to_fuse = node_to_fuse.get_nodes()
+        plan = self._epilogue_plan(
+            ir_node, (*existing_epilogue_nodes, node_to_fuse), node_to_fuse
+        )
+        reduction_nodes = OrderedSet(plan.reduction_nodes)
+        local_reduce = plan.candidate_reduction
+        feed_main = plan.feed_main
+        variants = (
+            (ir_node.variant,)
+            if isinstance(ir_node, NVUniversalGemmBuffer)
+            else tuple(
+                choice.variant
+                for choice in ir_node._choices
+                if isinstance(choice, NVUniversalGemmCaller)
+                and choice.supports_epilogue_fusion
+            )
+        )
+        scaled_epilogue = bool(variants) and all(
+            variant == GemmVariant.SCALED_GEMM for variant in variants
+        )
+        if local_reduce is not None:
+            if not scaled_epilogue:
+                return False
 
-        for s_node in scheduler_nodes_to_fuse:
+        for s_node in plan.nodes:
             node = s_node.node
             if not isinstance(node, ComputedBuffer):
                 log.debug("NVGEMM epilogue fusion: %s is not a ComputedBuffer", node)
                 return False
-            if not isinstance(node.data, Pointwise):
+            if (
+                feed_main is None
+                and not isinstance(node.data, Pointwise)
+                and s_node not in reduction_nodes
+            ):
                 log.debug("NVGEMM epilogue fusion: %s is not a Pointwise op", node)
                 return False
 
-            if not V.graph.sizevars.statically_known_list_equals(
-                node.get_size(), ir_node.get_size()
+            if (
+                feed_main is None
+                and s_node not in reduction_nodes
+                and not V.graph.sizevars.statically_known_list_equals(
+                    node.get_size(), ir_node.get_size()
+                )
             ):
                 log.debug(
                     "NVGEMM epilogue fusion: size mismatch %s vs %s",
@@ -259,16 +519,20 @@ class NVUniversalGemmScheduling(BaseScheduling):
                     ir_node.get_size(),
                 )
                 return False
-
-        # EFC kernels don't support broadcast. Reject conservatively when a read
-        # can't be resolved — folded constants (weights/biases) aren't in
-        # name_to_buf, and silently skipping them would let a stride-0 bias through.
+        # cutlass.operators' EVT supports matrix, row, and column loads here.
+        # Reject unresolved inputs and shapes outside those broadcast patterns;
+        # the trial EVT trace below remains the final capability check.
         gemm_size = ir_node.get_size()
         name_to_buf = V.graph.name_to_buffer | V.graph.graph_inputs
-        for s_node in scheduler_nodes_to_fuse:
+        internal_names = OrderedSet([ir_node.get_name()]) | OrderedSet(
+            [s_node.get_name() for s_node in plan.nodes]
+        )
+        epilogue_inputs: OrderedSet[str] = OrderedSet()
+        for s_node in plan.nodes:
             for rd in s_node.read_writes.reads:
-                if rd.name == ir_node.get_name():
+                if rd.name in internal_names:
                     continue
+                epilogue_inputs.add(rd.name)
                 read_buf = name_to_buf.get(rd.name)
                 if read_buf is None:
                     log.debug(
@@ -277,24 +541,35 @@ class NVUniversalGemmScheduling(BaseScheduling):
                     )
                     return False
                 read_size = read_buf.get_size()
-                if not V.graph.sizevars.statically_known_list_equals(
-                    read_size, gemm_size
+                if not read_size or len(read_size) > len(gemm_size):
+                    log.debug(
+                        "NVGEMM epilogue fusion: read buffer %s has unsupported rank",
+                        rd.name,
+                    )
+                    return False
+                padded_size = [1] * (len(gemm_size) - len(read_size)) + list(read_size)
+                supported_shapes = (
+                    gemm_size,
+                    [1, gemm_size[1]],
+                    [gemm_size[0], 1],
+                )
+                if not any(
+                    V.graph.sizevars.statically_known_list_equals(padded_size, shape)
+                    for shape in supported_shapes
                 ):
                     log.debug(
-                        "NVGEMM epilogue fusion: read buffer %s size %s != GEMM size %s (broadcast not supported)",
+                        "NVGEMM epilogue fusion: read buffer %s size %s is not broadcastable to GEMM size %s",
                         rd.name,
                         read_size,
                         gemm_size,
                     )
                     return False
-                if hasattr(read_buf, "get_stride"):
-                    for s in read_buf.get_stride():
-                        if s == 0:
-                            log.debug(
-                                "NVGEMM epilogue fusion: read buffer %s has zero stride (broadcast not supported)",
-                                rd.name,
-                            )
-                            return False
+        if scaled_epilogue and len(epilogue_inputs) > 4:
+            log.debug(
+                "NVGEMM scaled epilogue has %d captured tensors; at most four are supported",
+                len(epilogue_inputs),
+            )
+            return False
 
         if not existing_epilogue_nodes:
             reads = OrderedSet(rd.name for rd in node_to_fuse.read_writes.reads)
@@ -307,27 +582,48 @@ class NVUniversalGemmScheduling(BaseScheduling):
         if node_to_fuse.has_aliasing_or_mutation():
             log.debug("NVGEMM epilogue fusion: node has aliasing or mutation")
             return False
-        elif node_to_fuse.is_reduction():
+        elif node_to_fuse.is_reduction() and local_reduce is None:
             log.debug("NVGEMM epilogue fusion: reductions not supported")
             return False
 
-        all_epilogue_nodes = list(existing_epilogue_nodes) + list(
-            node_to_fuse.get_nodes()
+        all_epilogue_nodes = list(plan.nodes)
+        fused_buffer_names = OrderedSet(
+            n.get_name() for n in [gemm_template_node, *all_epilogue_nodes]
         )
-
-        # Multi-store epilogues (the GEMM output feeding >1 graph output) are
-        # supported: each output store is wired to its own out_ptr (see
-        # NVUniversalGemmKernel._ordered_output_buffers). The trial EVT codegen
-        # below still gates any chain cutlass can't express.
-        trial_removed_buffers = V.graph.removed_buffers | OrderedSet(
-            [ir_node.get_name()]
-        )
-        try:
-            CutlassEVTCodegen.ir_to_evt_python_code(
-                ir_node.get_name(),
-                all_epilogue_nodes,
-                trial_removed_buffers,
+        preserve_gemm_output = (
+            not V.graph.scheduler.can_buffer_be_removed_through_fusion(
+                ir_node.get_name(), fused_buffer_names
             )
+        )
+        # Multi-store epilogues wire each output to its own destination tensor.
+        trial_removed_buffers = V.graph.removed_buffers.copy()
+        if not preserve_gemm_output:
+            trial_removed_buffers.add(ir_node.get_name())
+        try:
+            evt_nodes = plan.evt_nodes
+            trial_reads: list[str] = []
+            trial_writes: list[str] = []
+            if feed_main is not None:
+                evt_nodes = []
+            if evt_nodes:
+                trial_reads, trial_writes, _, _ = (
+                    CutlassEVTCodegen.ir_to_evt_python_code(
+                        ir_node.get_name(),
+                        evt_nodes,
+                        trial_removed_buffers,
+                    )
+                )
+            if scaled_epilogue:
+                if len(trial_reads) > 4 or len(trial_writes) > 4:
+                    return False
+                for read_name in trial_reads:
+                    read_buf = name_to_buf.get(read_name)
+                    if read_buf is None:
+                        log.debug(
+                            "NVGEMM scaled EVT input %s cannot be resolved",
+                            read_name,
+                        )
+                        return False
         except (NotImplementedError, AssertionError) as e:
             log.debug("NVGEMM epilogue fusion: trial EVT codegen failed: %s", e)
             return False
@@ -339,6 +635,15 @@ class NVUniversalGemmScheduling(BaseScheduling):
     ) -> bool:
         # NVIDIA Universal GEMM templates don't support horizontal fusion yet
         return False
+
+    def can_fuse_reduction_epilogue(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> bool:
+        template = node1.get_template_node()
+        return isinstance(template, Buffer) and (
+            self._grouped_reduce_config(template, node2) is not None
+            or self._grouped_reduce_feeds_main_config(template, node2) is not None
+        )
 
     def define_kernel(
         self, src_code: str, node_schedule, precompile_metadata=None
@@ -433,39 +738,75 @@ class NVUniversalGemmScheduling(BaseScheduling):
         epilogue_reads: list[str] = []
         epilogue_writes: list[str] = []
         epilogue_var_renames: dict[str, Any] = {}
+        local_reduce: GemmReductionPlan | None = None
 
         if epilogue_nodes:
+            scheduler = V.graph.scheduler
             try:
-                removed_buffers_with_gemm = V.graph.removed_buffers | OrderedSet(
-                    [original_buffer_name]
-                )
-
-                reads, writes, var_renames, evt_code = (
-                    CutlassEVTCodegen.ir_to_evt_python_code(
-                        original_buffer_name,
-                        list(epilogue_nodes),
-                        removed_buffers_with_gemm,
-                        fn_name=EPILOGUE_FN_NAME,
-                        as_standalone_function=True,
+                plan = self._epilogue_plan(original_ir_node, epilogue_nodes)
+                if len(plan.reductions) > 1:
+                    raise NotImplementedError(
+                        "NVGEMM supports one grouped local reduction"
                     )
+                if plan.reductions:
+                    reduction = plan.reductions[0]
+                    local_reduce = GemmReductionPlan(
+                        reduction_output=reduction.output_name,
+                        group=reduction.group,
+                        axis=reduction.axis,
+                        reduction_type=reduction.reduction_type,
+                        source_type=reduction.source_type,
+                        primary_output=original_buffer_name,
+                    )
+                feed_main = plan.feed_main
+                if feed_main is not None:
+                    local_reduce = GemmReductionPlan(
+                        reduction_output=None,
+                        group=feed_main.group,
+                        axis=feed_main.axis,
+                        reduction_type=feed_main.reduction_type,
+                        source_type=feed_main.source_type,
+                        primary_output=feed_main.output_name,
+                        feeds_main=True,
+                    )
+                    epilogue_fn_code = (
+                        f"def {EPILOGUE_FN_NAME}(accum):\n    D = accum\n    return D"
+                    )
+                    epilogue_writes = [feed_main.output_name]
+                    epilogue_var_renames = {
+                        _ACCUMULATOR_ARG_NAME: original_buffer_name,
+                        "D": feed_main.output_name,
+                    }
+                evt_nodes = [] if feed_main is not None else plan.evt_nodes
+                fused_buffer_names: OrderedSet[str] = OrderedSet(
+                    n.get_name() for n in epilogue_nodes
                 )
-                epilogue_fn_code = evt_code
-                epilogue_reads = reads
-                epilogue_writes = writes
-                epilogue_var_renames = var_renames
+                fused_buffer_names.add(original_buffer_name)
+                removed_buffers_with_gemm = V.graph.removed_buffers.copy()
+                if scheduler.can_buffer_be_removed_through_fusion(
+                    original_buffer_name, fused_buffer_names
+                ):
+                    removed_buffers_with_gemm.add(original_buffer_name)
+
+                if evt_nodes and feed_main is None:
+                    reads, writes, var_renames, evt_code = (
+                        CutlassEVTCodegen.ir_to_evt_python_code(
+                            original_buffer_name,
+                            evt_nodes,
+                            removed_buffers_with_gemm,
+                            fn_name=EPILOGUE_FN_NAME,
+                            as_standalone_function=True,
+                        )
+                    )
+                    epilogue_fn_code = evt_code
+                    epilogue_reads = reads
+                    epilogue_writes = writes
+                    epilogue_var_renames = var_renames
 
                 if not only_gen_src_code:
-                    fused_buffer_names: OrderedSet[str] = OrderedSet(
-                        n.get_name() for n in epilogue_nodes
-                    )
-                    fused_buffer_names.add(original_buffer_name)
-                    scheduler = V.graph.scheduler
                     write_bufs = OrderedSet(epilogue_writes)
-                    # Must add to removed_buffers BEFORE mark_run: mark_run emits
-                    # AllocateLine eagerly, and codegen_allocation only skips it
-                    # when the name is already in removed_buffers. Keep every output
-                    # store (each is written as an out_ptr, incl. all outputs of a
-                    # multi-store epilogue); only intermediate nodes are removed.
+                    if local_reduce is not None:
+                        write_bufs.update(local_reduce.auxiliary_outputs)
                     for node in epilogue_nodes:
                         node_name = node.get_name()
                         if node_name in write_bufs:
@@ -485,10 +826,11 @@ class NVUniversalGemmScheduling(BaseScheduling):
                         node.mark_run()
 
                 log.debug(
-                    "NVGEMM epilogue fusion: %d nodes, reads=%s, writes=%s",
+                    "NVGEMM epilogue fusion: %d nodes, reads=%s, writes=%s, local_reduce=%s",
                     len(epilogue_nodes),
                     epilogue_reads,
                     epilogue_writes,
+                    local_reduce,
                 )
             except (NotImplementedError, AssertionError) as e:
                 log.warning("NVGEMM epilogue codegen failed unexpectedly: %s", e)
@@ -501,6 +843,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
             epilogue_reads=epilogue_reads,
             epilogue_writes=epilogue_writes,
             epilogue_var_renames=epilogue_var_renames,
+            local_reduce=local_reduce,
         )
 
         if not only_gen_src_code:
@@ -520,7 +863,7 @@ class NVUniversalGemmScheduling(BaseScheduling):
 
         with V.set_kernel_handler(kernel):
             node_schedule: list[BaseSchedulerNode] = [template_node]
-            if epilogue_fn_code and epilogue_nodes:
+            if epilogue_nodes:
                 node_schedule.extend(epilogue_nodes)
             kernel_name = self.define_kernel(
                 src_code, node_schedule, precompile_metadata
@@ -624,22 +967,33 @@ class NVUniversalGemmScheduling(BaseScheduling):
             template_sn = cast(SchedulerNode, template)
             assert isinstance(template_sn.node, Buffer)  # noqa: S101
             original_buffer_name = template_sn.node.get_name()
-            removed_buffers_with_gemm = V.graph.removed_buffers | OrderedSet(
-                [original_buffer_name]
-            )
+            plan = self._epilogue_plan(template_sn.node, epilogue)
+            evt_nodes = [] if plan.feed_main is not None else plan.evt_nodes
+            removed_buffers_with_gemm = V.graph.removed_buffers.copy()
+            if not plan.reductions:
+                removed_buffers_with_gemm.add(original_buffer_name)
             try:
-                reads, writes, var_renames, _ = CutlassEVTCodegen.ir_to_evt_python_code(
-                    original_buffer_name,
-                    list(epilogue),
-                    removed_buffers_with_gemm,
-                )
-                epilogue_reads = reads
-                # Output stores in out_ptr order (D first, then multi-store extras),
-                # matching NVUniversalGemmKernel._ordered_output_buffers.
-                d_buf = var_renames.get("D")
-                output_bufs = ([d_buf] if d_buf else []) + [
-                    w for w in writes if w != d_buf
-                ]
+                if evt_nodes:
+                    reads, writes, var_renames, _ = (
+                        CutlassEVTCodegen.ir_to_evt_python_code(
+                            original_buffer_name,
+                            evt_nodes,
+                            removed_buffers_with_gemm,
+                        )
+                    )
+                    epilogue_reads = reads
+                    d_buf = var_renames.get("D")
+                    output_bufs = ([d_buf] if d_buf else []) + [
+                        w for w in writes if w != d_buf
+                    ]
+                if plan.reductions:
+                    output_bufs = [
+                        original_buffer_name,
+                        *output_bufs,
+                        plan.reductions[0].output_name,
+                    ]
+                elif plan.feed_main is not None:
+                    output_bufs = [plan.feed_main.output_name]
             except (NotImplementedError, AssertionError) as e:
                 log.warning("NVGEMM benchmark epilogue codegen failed: %s", e)
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -146,6 +146,7 @@ if TYPE_CHECKING:
     from .codegen.cutlass.template import CUTLASSTemplate
     from .codegen.wrapper import PythonWrapperCodegen
     from .graph import GraphLowering
+    from .kernel.gemm_epilogue import GemmReductionPlan
     from .utils import IndentedBuffer
 
 else:
@@ -6592,7 +6593,7 @@ class NVUniversalGemmBuffer(TemplateBuffer):
         epilogue_reads: list[str] | None = None,
         epilogue_writes: list[str] | None = None,
         epilogue_var_renames: dict[str, Any] | None = None,
-        local_reduce: tuple[str, int, int, str, str] | None = None,
+        local_reduce: GemmReductionPlan | None = None,
     ) -> tuple[Any, Any]:
         """
         Create a kernel renderer for code generation.
@@ -6644,6 +6645,7 @@ class NVUniversalGemmBuffer(TemplateBuffer):
             epilogue_reads=epilogue_reads,
             epilogue_writes=epilogue_writes,
             epilogue_var_renames=epilogue_var_renames,
+            local_reduce=local_reduce,
             swap_ab=self.swap_ab,
             bias_node=bias_node,
         )

--- a/torch/_inductor/kernel/flex_gemm/constraints.py
+++ b/torch/_inductor/kernel/flex_gemm/constraints.py
@@ -5,11 +5,10 @@ import dataclasses
 from collections.abc import Sequence
 from typing import Any, Final
 
-import sympy
-
-from torch._inductor.virtualized import V
-from torch.fx.experimental.symbolic_shapes import (
-    statically_known_true as fx_statically_known_true,
+from torch._inductor.kernel.gemm_epilogue import GemmReductionGeometry
+from torch._inductor.kernel.gemm_epilogue_utils import (
+    statically_known,
+    statically_known_shape_equal,
 )
 
 
@@ -129,33 +128,9 @@ LOCAL_REDUCE_CALLBACKS_REQUIRED_ERROR = (
 )
 
 
-def statically_known(expr: Any) -> bool:
-    """Return whether a symbolic predicate is known true without adding guards."""
-    if isinstance(expr, bool):
-        return expr
-    if isinstance(expr, sympy.Basic):
-        return V.graph.sizevars.statically_known_true(expr)
-    return fx_statically_known_true(expr)
-
-
-def statically_known_equal(lhs: Any, rhs: Any) -> bool:
-    """Return whether symbolic shape values are known equal without adding guards."""
-    return statically_known(lhs == rhs)
-
-
 def statically_known_multiple(value: Any, divisor: int) -> bool:
     """Return whether a symbolic shape value is known divisible without guards."""
     return statically_known(value % divisor == 0)
-
-
-def statically_known_shape_equal(
-    actual_shape: Sequence[Any], expected_shape: Sequence[Any]
-) -> bool:
-    """Compare possibly symbolic shape tuples without adding guards."""
-    return len(actual_shape) == len(expected_shape) and all(
-        statically_known_equal(actual, expected)
-        for actual, expected in zip(actual_shape, expected_shape)
-    )
 
 
 def is_flex_gemm_partial_reduction_shape(
@@ -409,25 +384,7 @@ def flex_gemm_local_reduce_config_error(
     )
 
 
-@dataclasses.dataclass(frozen=True)
-class FlexGemmLocalReduceGeometry:
-    """Describe the grouped output axis shared by local-reduce consumers.
-
-    Attributes:
-        group: Number of contiguous M or N elements in each local group.
-        axis: GEMM output axis being grouped: 0 for M, 1 for N.
-    """
-
-    group: int
-    axis: int
-
-    def __post_init__(self) -> None:
-        """Reject geometry outside the GEMM tile's M/N grouping model."""
-        validate_local_reduce_group_axis(self.group, self.axis)
-
-    @property
-    def needs_physical_callbacks(self) -> bool:
-        return local_reduce_needs_physical_callbacks(self.axis, self.group)
+FlexGemmLocalReduceGeometry = GemmReductionGeometry
 
 
 @dataclasses.dataclass(frozen=True)

--- a/torch/_inductor/kernel/flex_gemm/quack_reductions.py
+++ b/torch/_inductor/kernel/flex_gemm/quack_reductions.py
@@ -35,8 +35,12 @@ from torch._inductor.kernel.flex_gemm.constraints import (
     LOCAL_REDUCE_INNERMOST_GROUPED_DIM_ERROR,
     local_reduce_needs_physical_callbacks,
     LOCAL_REDUCE_PARTIAL_OUTPUT_CONTRACT_ERROR,
-    statically_known_equal,
 )
+from torch._inductor.kernel.gemm_epilogue import (
+    GemmReductionGeometry,
+    iter_fx_node_inputs,
+)
+from torch._inductor.kernel.gemm_epilogue_utils import statically_known_equal
 from torch._inductor.ops_handler import ReductionType
 from torch._inductor.shape_propagation import get_broadcasted_shape
 from torch._inductor.virtualized import V
@@ -48,25 +52,13 @@ def normalize_shape(shape: Any) -> Any:
 
 
 @dataclasses.dataclass(frozen=True)
-class GroupedTensorSSALayout:
+class GroupedTensorSSALayout(GemmReductionGeometry):
     """Describe a grouped M/N TensorSSA view inside the generated epilogue.
 
     Attributes:
         axis: GEMM output dimension being grouped: 0 for M, 1 for N.
         group_size: Number of contiguous output elements reduced as one group.
     """
-
-    axis: int
-    group_size: int
-
-    @property
-    def reduce_dims(self) -> tuple[int, ...]:
-        return (-1, 2) if self.axis == 1 else (-2, 1)
-
-    def matches_reduction_dim(self, dim: Any) -> bool:
-        """Return whether an FX reduction selects this layout's grouped dimension."""
-        dims = tuple(dim) if isinstance(dim, (list, tuple)) else (dim,)
-        return len(dims) == 1 and dims[0] in self.reduce_dims
 
     def fragment_group_size_expr(self, source: Any) -> str:
         """Return the local group size available in this epilogue fragment."""
@@ -110,9 +102,9 @@ def _syntactic_grouped_tensor_layout(
     if len(shape) not in (3, 4):
         return None
     if isinstance(shape[-1], int) and shape[-1] > 0 and shape[-2] == -1:
-        return GroupedTensorSSALayout(axis=1, group_size=shape[-1])
+        return GroupedTensorSSALayout(group=shape[-1], axis=1)
     if shape[-3] == -1 and isinstance(shape[-2], int) and shape[-2] > 0:
-        return GroupedTensorSSALayout(axis=0, group_size=shape[-2])
+        return GroupedTensorSSALayout(group=shape[-2], axis=0)
     return None
 
 
@@ -166,10 +158,10 @@ def grouped_tensor_layout(
             candidates = []
             match shape:
                 case (*_, int(group)) if group > 0:
-                    candidates.append(GroupedTensorSSALayout(axis=1, group_size=group))
+                    candidates.append(GroupedTensorSSALayout(group=group, axis=1))
             match shape:
                 case (*_, int(group), _) if group > 0:
-                    candidates.append(GroupedTensorSSALayout(axis=0, group_size=group))
+                    candidates.append(GroupedTensorSSALayout(group=group, axis=0))
             for layout in candidates:
                 if _grouped_layout_matches_source_shape(shape, source_shape, layout):
                     return layout
@@ -332,13 +324,6 @@ def is_pointwise_node(node: torch.fx.Node) -> bool:
 
 def is_shape_preserving_pointwise_node(node: torch.fx.Node) -> bool:
     return is_pointwise_node(node) and node_preserves_tensor_shapes(node)
-
-
-def iter_fx_node_inputs(value: Any):
-    """Yield FX node inputs nested in args/kwargs-style containers."""
-    result: list[torch.fx.Node] = []
-    torch.fx.map_arg(value, lambda node: result.append(node))
-    yield from result
 
 
 def view_or_reshape_args(node: torch.fx.Node) -> tuple[Any, tuple[Any, ...]] | None:

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
+# ruff: noqa: S101
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -43,6 +44,10 @@ from cutlass.cute.runtime import from_dlpack
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 
 import torch
+from torch._inductor.kernel.vendored_templates.cutedsl.reduction_utils import (
+    get_lane_warp_layouts,
+    partition_for_epilogue,
+)
 
 
 """
@@ -416,7 +421,27 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         max_active_clusters: cutlass.Constexpr,
         stream: cuda.CUstream,
         epilogue_op: cutlass.Constexpr = lambda x: x,
+        epilogue_input_dtype: cutlass.Constexpr = cutlass.Float32,
         alpha_tensor: cute.Tensor = None,
+        epilogue_tensor0: cute.Tensor = None,
+        epilogue_tensor1: cute.Tensor = None,
+        epilogue_tensor2: cute.Tensor = None,
+        epilogue_tensor3: cute.Tensor = None,
+        epilogue_tensor_kind0: cutlass.Constexpr = 0,
+        epilogue_tensor_kind1: cutlass.Constexpr = 0,
+        epilogue_tensor_kind2: cutlass.Constexpr = 0,
+        epilogue_tensor_kind3: cutlass.Constexpr = 0,
+        epilogue_output0: cute.Tensor = None,
+        epilogue_output1: cute.Tensor = None,
+        epilogue_output2: cute.Tensor = None,
+        epilogue_output_count: cutlass.Constexpr = 1,
+        primary_epilogue_output: cutlass.Constexpr = 0,
+        local_reduce_tensor: cute.Tensor = None,
+        local_reduce_group: cutlass.Constexpr = 0,
+        local_reduce_axis: cutlass.Constexpr = 1,
+        local_reduce_type: cutlass.Constexpr = "sum",
+        local_reduce_source: cutlass.Constexpr = "identity",
+        local_reduce_feeds_main: cutlass.Constexpr = False,
     ):
         """Execute the GEMM operation in steps:
         - Setup static attributes before smem/grid/tma computation
@@ -456,6 +481,19 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         a_tensor = add_batch_mode(a_tensor)
         b_tensor = add_batch_mode(b_tensor)
         c_tensor = add_batch_mode(c_tensor)
+        if cutlass.const_expr(local_reduce_tensor is not None):
+            local_reduce_tensor = add_batch_mode(local_reduce_tensor)
+
+        self.local_reduce_group = local_reduce_group
+        self.local_reduce_axis = local_reduce_axis
+        self.local_reduce_type = local_reduce_type
+        self.local_reduce_source = local_reduce_source
+        self.local_reduce_feeds_main = local_reduce_feeds_main
+        self.has_cross_warp_local_reduce = cutlass.const_expr(
+            local_reduce_tensor is not None
+            and local_reduce_axis == 0
+            and local_reduce_group > 4
+        )
 
         a_tensor = cute.make_tensor(
             a_tensor.iterator, cute.select(a_tensor.layout, [1, 2, 0])
@@ -466,6 +504,30 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         c_tensor = cute.make_tensor(
             c_tensor.iterator, cute.select(c_tensor.layout, [1, 2, 0])
         )
+
+        def epilogue_tensor_to_mnl(tensor: cute.Tensor) -> cute.Tensor:
+            tensor = add_batch_mode(tensor)
+            return cute.make_tensor(
+                tensor.iterator, cute.select(tensor.layout, [1, 2, 0])
+            )
+
+        if cutlass.const_expr(epilogue_tensor0 is not None):
+            epilogue_tensor0 = epilogue_tensor_to_mnl(epilogue_tensor0)
+        if cutlass.const_expr(epilogue_tensor1 is not None):
+            epilogue_tensor1 = epilogue_tensor_to_mnl(epilogue_tensor1)
+        if cutlass.const_expr(epilogue_tensor2 is not None):
+            epilogue_tensor2 = epilogue_tensor_to_mnl(epilogue_tensor2)
+        if cutlass.const_expr(epilogue_tensor3 is not None):
+            epilogue_tensor3 = epilogue_tensor_to_mnl(epilogue_tensor3)
+        if cutlass.const_expr(epilogue_output0 is not None):
+            epilogue_output0 = epilogue_tensor_to_mnl(epilogue_output0)
+        if cutlass.const_expr(epilogue_output1 is not None):
+            epilogue_output1 = epilogue_tensor_to_mnl(epilogue_output1)
+        if cutlass.const_expr(epilogue_output2 is not None):
+            epilogue_output2 = epilogue_tensor_to_mnl(epilogue_output2)
+
+        self.epilogue_output_count = epilogue_output_count
+        self.primary_epilogue_output = primary_epilogue_output
 
         # Setup static attributes before smem/grid/tma computation
         self.a_dtype: Type[cutlass.Numeric] = a_tensor.element_type
@@ -672,6 +734,15 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 ],
                 self.buffer_align_bytes,
             ]
+            sLocalReduce: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Float32,
+                    self.cta_tile_shape_mnk[1] * 3
+                    if self.has_cross_warp_local_reduce
+                    else 1,
+                ],
+                16,
+            ]
 
         self.shared_storage = SharedStorage
 
@@ -699,7 +770,20 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.epi_tile,
             self.tile_sched_params,
             epilogue_op,
+            epilogue_input_dtype,
             alpha_tensor,
+            epilogue_tensor0,
+            epilogue_tensor1,
+            epilogue_tensor2,
+            epilogue_tensor3,
+            epilogue_tensor_kind0,
+            epilogue_tensor_kind1,
+            epilogue_tensor_kind2,
+            epilogue_tensor_kind3,
+            epilogue_output0,
+            epilogue_output1,
+            epilogue_output2,
+            local_reduce_tensor,
         ).launch(
             grid=grid,
             block=[self.threads_per_cta, 1, 1],
@@ -735,7 +819,20 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         epi_tile: cute.Tile,
         tile_sched_params: utils.PersistentTileSchedulerParams,
         epilogue_op: cutlass.Constexpr,
+        epilogue_input_dtype: cutlass.Constexpr,
         alpha_tensor: cute.Tensor,
+        epilogue_tensor0: cute.Tensor,
+        epilogue_tensor1: cute.Tensor,
+        epilogue_tensor2: cute.Tensor,
+        epilogue_tensor3: cute.Tensor,
+        epilogue_tensor_kind0: cutlass.Constexpr,
+        epilogue_tensor_kind1: cutlass.Constexpr,
+        epilogue_tensor_kind2: cutlass.Constexpr,
+        epilogue_tensor_kind3: cutlass.Constexpr,
+        epilogue_output0: cute.Tensor,
+        epilogue_output1: cute.Tensor,
+        epilogue_output2: cute.Tensor,
+        local_reduce_tensor: cute.Tensor,
     ):
         """
         GPU device kernel performing the Persistent batched GEMM computation.
@@ -779,6 +876,11 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         #
         smem = utils.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
+        sLocalReduce = storage.sLocalReduce.get_tensor(
+            cute.make_layout((self.cta_tile_shape_mnk[1], 3))
+            if self.has_cross_warp_local_reduce
+            else cute.make_layout(1)
+        )
 
         # Initialize mainloop ab_pipeline (barrier) and states
         ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
@@ -1231,6 +1333,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 )
 
                 # Get accumulator stage index
+                reverse_subtile = cutlass.Boolean(False)
                 if cutlass.const_expr(self.overlapping_accum):
                     acc_stage_index = acc_producer_state.phase ^ 1
                 else:
@@ -1498,6 +1601,15 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 #
                 subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
                 num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
+                local_reduce_partial = None
+                if cutlass.const_expr(
+                    (local_reduce_tensor is not None or self.local_reduce_feeds_main)
+                    and self.local_reduce_axis == 1
+                    and self.local_reduce_group > self.epi_tile_n
+                ):
+                    local_reduce_partial = cute.make_rmem_tensor(
+                        ((1, self.epi_tile_n, 1), 1, 1), self.acc_dtype
+                    )
                 for subtile_idx in cutlass.range(subtile_cnt):
                     real_subtile_idx = subtile_idx
                     if cutlass.const_expr(self.overlapping_accum):
@@ -1539,7 +1651,418 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                     # alpha_tensor is None) rather than device control flow.
                     if cutlass.const_expr(alpha_tensor is not None):
                         acc_vec = acc_vec * alpha_tensor[0].to(self.acc_dtype)
-                    acc_vec = epilogue_op(acc_vec.to(self.c_dtype)).to(self.c_dtype)
+                    has_epilogue_tensors = cutlass.const_expr(
+                        epilogue_tensor0 is not None
+                        or epilogue_tensor1 is not None
+                        or epilogue_tensor2 is not None
+                        or epilogue_tensor3 is not None
+                    )
+                    has_epilogue_outputs = cutlass.const_expr(
+                        self.epilogue_output_count > 1
+                    )
+                    if cutlass.const_expr(
+                        has_epilogue_tensors
+                        or has_epilogue_outputs
+                        or local_reduce_tensor is not None
+                    ):
+                        tDcC = partition_for_epilogue(
+                            cute.make_identity_tensor(self.cta_tile_shape_mnk[:2]),
+                            epi_tile=epi_tile,
+                            tiled_copy=tiled_copy_t2r,
+                            tidx=epi_tidx,
+                            reference_src=False,
+                        )
+                        tDcC = tDcC[(None, None, None, 0, real_subtile_idx)]
+                        coord_flt = cute.filter_zeros(tDcC)
+
+                    epilogue_values = []
+                    if cutlass.const_expr(has_epilogue_tensors or has_epilogue_outputs):
+                        output_m = cute.size(mC_mnl, mode=[0])
+                        output_n = cute.size(mC_mnl, mode=[1])
+                    if cutlass.const_expr(has_epilogue_tensors):
+                        for tensor, kind in (
+                            (epilogue_tensor0, epilogue_tensor_kind0),
+                            (epilogue_tensor1, epilogue_tensor_kind1),
+                            (epilogue_tensor2, epilogue_tensor_kind2),
+                            (epilogue_tensor3, epilogue_tensor_kind3),
+                        ):
+                            if cutlass.const_expr(tensor is not None):
+                                fragment = cute.make_rmem_tensor_like(
+                                    acc_vec, tensor.element_type
+                                )
+                                for i in cutlass.range(
+                                    cute.size(fragment), unroll_full=True
+                                ):
+                                    row_idx = coord_flt[i][0]
+                                    col_idx = coord_flt[i][1]
+                                    global_m = (
+                                        mma_tile_coord_mnl[0]
+                                        * self.cta_tile_shape_mnk[0]
+                                        + row_idx
+                                    )
+                                    global_n = (
+                                        mma_tile_coord_mnl[1]
+                                        * self.cta_tile_shape_mnk[1]
+                                        + col_idx
+                                    )
+                                    tensor_m = (
+                                        0 if cutlass.const_expr(kind == 2) else global_m
+                                    )
+                                    tensor_n = (
+                                        0 if cutlass.const_expr(kind == 3) else global_n
+                                    )
+                                    fragment[i] = tensor[0, 0, 0]
+                                    if global_m < output_m and global_n < output_n:
+                                        fragment[i] = tensor[
+                                            tensor_m,
+                                            tensor_n,
+                                            mma_tile_coord_mnl[2],
+                                        ]
+                                epilogue_values.append(fragment.load())
+                    if cutlass.const_expr(
+                        local_reduce_tensor is not None or self.local_reduce_feeds_main
+                    ):
+                        local_reduce_vec = acc_vec.to(epilogue_input_dtype).to(
+                            self.acc_dtype
+                        )
+                        if cutlass.const_expr(self.local_reduce_source == "square"):
+                            local_reduce_vec = local_reduce_vec * local_reduce_vec
+                        else:
+                            assert self.local_reduce_source == "identity"
+                    if cutlass.const_expr(self.local_reduce_feeds_main):
+                        group = cutlass.const_expr(self.local_reduce_group)
+                        lane_layout_mn, _ = get_lane_warp_layouts(
+                            tiled_copy_t2r, reference_src=False
+                        )
+                        lanes_in_m = cutlass.const_expr(
+                            cute.size(lane_layout_mn, mode=[0])
+                        )
+                        assert group <= lanes_in_m
+                        feed_value = cute.make_rmem_tensor_like(
+                            local_reduce_vec, self.acc_dtype
+                        )
+                        feed_value.store(local_reduce_vec)
+                        feed_flt = cute.filter_zeros(feed_value)
+                        for i in cutlass.range(cute.size(feed_flt), unroll_full=True):
+                            rows = group // 2
+                            while rows > 0:
+                                feed_flt[i] += cute.arch.shuffle_sync_bfly(
+                                    feed_flt[i],
+                                    offset=cute.crd2idx((rows, 0), lane_layout_mn),
+                                )
+                                rows //= 2
+                            if cutlass.const_expr(self.local_reduce_type == "mean"):
+                                feed_flt[i] /= group
+                        epilogue_result = (
+                            acc_vec.to(epilogue_input_dtype) - feed_value.load()
+                        )
+                    else:
+                        epilogue_result = epilogue_op(
+                            acc_vec.to(epilogue_input_dtype), *tuple(epilogue_values)
+                        )
+                    if cutlass.const_expr(has_epilogue_outputs):
+                        for output_index, tensor in enumerate(
+                            (epilogue_output0, epilogue_output1, epilogue_output2)
+                        ):
+                            if cutlass.const_expr(tensor is not None):
+                                result_index = cutlass.const_expr(
+                                    output_index
+                                    if output_index < self.primary_epilogue_output
+                                    else output_index + 1
+                                )
+                                output_vec = epilogue_result[result_index].to(
+                                    tensor.element_type
+                                )
+                                fragment = cute.make_rmem_tensor_like(
+                                    output_vec, tensor.element_type
+                                )
+                                fragment.store(output_vec)
+                                fragment_flt = cute.filter_zeros(fragment)
+                                for i in cutlass.range(
+                                    cute.size(fragment_flt), unroll_full=True
+                                ):
+                                    row_idx = coord_flt[i][0]
+                                    col_idx = coord_flt[i][1]
+                                    global_m = (
+                                        mma_tile_coord_mnl[0]
+                                        * self.cta_tile_shape_mnk[0]
+                                        + row_idx
+                                    )
+                                    global_n = (
+                                        mma_tile_coord_mnl[1]
+                                        * self.cta_tile_shape_mnk[1]
+                                        + col_idx
+                                    )
+                                    if global_m < output_m and global_n < output_n:
+                                        tensor[
+                                            global_m,
+                                            global_n,
+                                            mma_tile_coord_mnl[2],
+                                        ] = fragment_flt[i]
+                        acc_vec = epilogue_result[self.primary_epilogue_output].to(
+                            self.c_dtype
+                        )
+                    else:
+                        acc_vec = epilogue_result.to(self.c_dtype)
+
+                    if cutlass.const_expr(
+                        local_reduce_tensor is not None
+                        and not self.local_reduce_feeds_main
+                    ):
+                        group = cutlass.const_expr(self.local_reduce_group)
+                        mReduce = local_reduce_tensor[mma_tile_coord_mnl[2], None, None]
+                        if cutlass.const_expr(self.local_reduce_axis == 1):
+                            fragment_n = cutlass.const_expr(
+                                cute.size(acc_vec.shape, mode=[0])
+                            )
+                            assert group > 1 and group <= self.cta_tile_shape_mnk[1]
+                            fragment_group = cutlass.const_expr(min(group, fragment_n))
+                            assert group % fragment_group == 0
+                            assert fragment_n % fragment_group == 0
+                            repeats = cutlass.const_expr(fragment_n // fragment_group)
+                            grouped = local_reduce_vec.reshape(
+                                ((1, fragment_group, repeats), 1, 1)
+                            )
+                            if cutlass.const_expr(
+                                self.local_reduce_type in ("sum", "mean")
+                            ):
+                                reduce_op = cute.ReductionOp.ADD
+                                init_val = 0.0
+                            elif cutlass.const_expr(self.local_reduce_type == "prod"):
+                                reduce_op = cute.ReductionOp.MUL
+                                init_val = 1.0
+                            elif cutlass.const_expr(self.local_reduce_type == "max"):
+                                reduce_op = cute.ReductionOp.MAX
+                                init_val = -cutlass.Float32.inf
+                            else:
+                                assert self.local_reduce_type == "min"
+                                reduce_op = cute.ReductionOp.MIN
+                                init_val = cutlass.Float32.inf
+                            reduced = grouped.reduce(
+                                reduce_op,
+                                init_val=init_val,
+                                reduction_profile=((None, 1, None), 1, 1),
+                            )
+                            if cutlass.const_expr(
+                                self.local_reduce_type == "mean" and group <= fragment_n
+                            ):
+                                reduced = reduced / group
+                            reduced = reduced.reshape(((1, 1, repeats), 1, 1))
+                            reduced = reduced.broadcast_to(grouped.shape)
+                            should_store = cutlass.Boolean(True)
+                            store_offset = cutlass.Int32(0)
+                            if cutlass.const_expr(group > fragment_n):
+                                fragments_per_group = cutlass.const_expr(
+                                    group // fragment_n
+                                )
+                                partial = local_reduce_partial.load()
+                                if subtile_idx % fragments_per_group == 0:
+                                    partial = reduced
+                                elif cutlass.const_expr(
+                                    self.local_reduce_type in ("sum", "mean")
+                                ):
+                                    partial = partial + reduced
+                                elif cutlass.const_expr(
+                                    self.local_reduce_type == "prod"
+                                ):
+                                    partial = partial * reduced
+                                elif cutlass.const_expr(
+                                    self.local_reduce_type == "max"
+                                ):
+                                    partial = cute.math.max(partial, reduced)
+                                else:
+                                    assert self.local_reduce_type == "min"
+                                    partial = cute.math.min(partial, reduced)
+                                local_reduce_partial.store(partial)
+                                should_store = (
+                                    subtile_idx % fragments_per_group
+                                    == fragments_per_group - 1
+                                )
+                                if should_store:
+                                    reduced = partial
+                                    if cutlass.const_expr(
+                                        self.local_reduce_type == "mean"
+                                    ):
+                                        reduced = reduced / group
+                                    store_offset = (
+                                        real_subtile_idx * self.epi_tile_n
+                                    ) % group
+                            tDrReduce = cute.make_rmem_tensor(
+                                reduced.shape, self.acc_dtype
+                            )
+                            tDrReduce.store(reduced)
+                            reduced_flt = cute.filter_zeros(tDrReduce)
+                            groups_per_cta = cutlass.const_expr(
+                                self.cta_tile_shape_mnk[1] // group
+                            )
+                            gReduce = cute.local_tile(
+                                mReduce,
+                                (self.cta_tile_shape_mnk[0], groups_per_cta),
+                                mma_tile_coord_mnl[:2],
+                            )
+                            limit_m = min(
+                                cute.size(local_reduce_tensor, mode=[1])
+                                - mma_tile_coord_mnl[0] * self.cta_tile_shape_mnk[0],
+                                self.cta_tile_shape_mnk[0],
+                            )
+                            limit_groups = cute.size(local_reduce_tensor, mode=[2])
+                            for i in cutlass.range(
+                                cute.size(reduced_flt), unroll_full=True
+                            ):
+                                row_idx = coord_flt[i][0]
+                                n_idx = coord_flt[i][1]
+                                group_idx = n_idx // group
+                                global_group_idx = (
+                                    mma_tile_coord_mnl[1] * groups_per_cta + group_idx
+                                )
+                                if (
+                                    should_store
+                                    and n_idx % group == store_offset
+                                    and row_idx < limit_m
+                                    and global_group_idx < limit_groups
+                                ):
+                                    gReduce[row_idx, group_idx] = reduced_flt[i]
+                        else:
+                            tDrReduce = cute.make_rmem_tensor_like(
+                                local_reduce_vec, self.acc_dtype
+                            )
+                            tDrReduce.store(local_reduce_vec)
+                            reduced_flt = cute.filter_zeros(tDrReduce)
+                            lane_layout_mn, warp_layout_mn = get_lane_warp_layouts(
+                                tiled_copy_t2r, reference_src=False
+                            )
+                            lanes_in_m = cutlass.const_expr(
+                                cute.size(lane_layout_mn, mode=[0])
+                            )
+                            assert group > 1 and group <= self.cta_tile_shape_mnk[0]
+                            reduction_group = cutlass.const_expr(min(group, lanes_in_m))
+                            assert group % reduction_group == 0
+                            assert lanes_in_m % reduction_group == 0
+                            for i in cutlass.range(
+                                cute.size(reduced_flt), unroll_full=True
+                            ):
+                                rows = reduction_group // 2
+                                while rows > 0:
+                                    other = cute.arch.shuffle_sync_bfly(
+                                        reduced_flt[i],
+                                        offset=cute.crd2idx((rows, 0), lane_layout_mn),
+                                    )
+                                    if cutlass.const_expr(
+                                        self.local_reduce_type in ("sum", "mean")
+                                    ):
+                                        reduced_flt[i] += other
+                                    elif cutlass.const_expr(
+                                        self.local_reduce_type == "prod"
+                                    ):
+                                        reduced_flt[i] *= other
+                                    elif cutlass.const_expr(
+                                        self.local_reduce_type == "max"
+                                    ):
+                                        reduced_flt[i] = cute.arch.fmax(
+                                            reduced_flt[i], other
+                                        )
+                                    else:
+                                        assert self.local_reduce_type == "min"
+                                        reduced_flt[i] = cute.arch.fmin(
+                                            reduced_flt[i], other
+                                        )
+                                    rows = rows // 2
+                                if cutlass.const_expr(self.local_reduce_type == "mean"):
+                                    reduced_flt[i] /= group
+                            groups_per_cta = cutlass.const_expr(
+                                self.cta_tile_shape_mnk[0] // group
+                            )
+                            gReduce = cute.local_tile(
+                                mReduce,
+                                (groups_per_cta, self.cta_tile_shape_mnk[1]),
+                                mma_tile_coord_mnl[:2],
+                            )
+                            limit_n = min(
+                                cute.size(local_reduce_tensor, mode=[2])
+                                - mma_tile_coord_mnl[1] * self.cta_tile_shape_mnk[1],
+                                self.cta_tile_shape_mnk[1],
+                            )
+                            limit_groups = cute.size(local_reduce_tensor, mode=[1])
+                            group_warps = cutlass.const_expr(group // lanes_in_m)
+                            warp_m = warp_layout_mn[0]
+                            warps_in_m = cutlass.const_expr(cute.size(warp_m))
+                            assert group_warps <= warps_in_m
+                            warp_idx = cute.arch.make_warp_uniform(
+                                epi_tidx // cute.arch.WARP_SIZE
+                            )
+                            warp_m_idx = warp_layout_mn.get_hier_coord(warp_idx)[0]
+                            if cutlass.const_expr(group > lanes_in_m):
+                                for i in cutlass.range(
+                                    cute.size(reduced_flt), unroll_full=True
+                                ):
+                                    row_idx = coord_flt[i][0]
+                                    n_idx = coord_flt[i][1]
+                                    group_idx = row_idx // group
+                                    group_warp_start = group_idx * group_warps
+                                    group_warp_idx = warp_m_idx - group_warp_start
+                                    if (
+                                        row_idx % lanes_in_m == 0
+                                        and group_warp_idx > 0
+                                        and group_warp_idx < group_warps
+                                    ):
+                                        sLocalReduce[
+                                            n_idx, warp_m_idx - group_idx - 1
+                                        ] = reduced_flt[i]
+                                self.epilog_sync_barrier.arrive_and_wait()
+                            for i in cutlass.range(
+                                cute.size(reduced_flt), unroll_full=True
+                            ):
+                                row_idx = coord_flt[i][0]
+                                n_idx = coord_flt[i][1]
+                                group_idx = row_idx // group
+                                global_group_idx = (
+                                    mma_tile_coord_mnl[0] * groups_per_cta + group_idx
+                                )
+                                group_value = reduced_flt[i]
+                                group_warp_start = group_idx * group_warps
+                                if cutlass.const_expr(group > lanes_in_m):
+                                    if (
+                                        row_idx % group == 0
+                                        and warp_m_idx == group_warp_start
+                                    ):
+                                        for warp_offset in cutlass.range_constexpr(
+                                            1, group_warps
+                                        ):
+                                            other = sLocalReduce[
+                                                n_idx,
+                                                group_warp_start
+                                                + warp_offset
+                                                - group_idx
+                                                - 1,
+                                            ]
+                                            if cutlass.const_expr(
+                                                self.local_reduce_type
+                                                in ("sum", "mean")
+                                            ):
+                                                group_value += other
+                                            elif cutlass.const_expr(
+                                                self.local_reduce_type == "prod"
+                                            ):
+                                                group_value *= other
+                                            elif cutlass.const_expr(
+                                                self.local_reduce_type == "max"
+                                            ):
+                                                group_value = cute.arch.fmax(
+                                                    group_value, other
+                                                )
+                                            else:
+                                                assert self.local_reduce_type == "min"
+                                                group_value = cute.arch.fmin(
+                                                    group_value, other
+                                                )
+                                if (
+                                    row_idx % group == 0
+                                    and n_idx < limit_n
+                                    and global_group_idx < limit_groups
+                                ):
+                                    gReduce[group_idx, n_idx] = group_value
+                            if cutlass.const_expr(group > lanes_in_m):
+                                self.epilog_sync_barrier.arrive_and_wait()
                     tRS_rC.store(acc_vec)
 
                     #

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import ast
+import dataclasses
+import functools
 import itertools
 import logging
 from collections.abc import Callable, Generator  # noqa: TC003
@@ -34,6 +36,119 @@ log = logging.getLogger(__name__)
 _ONES_ALPHA: dict = {}
 
 
+@dataclasses.dataclass(frozen=True)
+class _EpilogueABI:
+    inputs: tuple
+    input_kinds: tuple[int, ...]
+    outputs: tuple
+    output_count: int
+    primary_output: int
+
+    @classmethod
+    def from_args(cls, args, tensor_attr: str) -> _EpilogueABI:
+        outputs, output_count, primary_output = _epilogue_outputs(args, tensor_attr)
+        return cls(
+            _epilogue_tensors(args, tensor_attr),
+            _epilogue_tensor_kinds(args),
+            outputs,
+            output_count,
+            primary_output,
+        )
+
+
+@functools.lru_cache(maxsize=256)
+def _epilogue_signature(epilogue_fn) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    from cutlass.operators.fusion import trace_in_out
+
+    inputs, outputs = trace_in_out(epilogue_fn)
+    return (
+        tuple(name for name in inputs if name != "accum"),
+        tuple(outputs),
+    )
+
+
+def _epilogue_input_names(epilogue_fn) -> tuple[str, ...]:
+    return _epilogue_signature(epilogue_fn)[0]
+
+
+def _epilogue_tensors(args, attr: str) -> tuple:
+    epilogue = getattr(args, "epilogue", None)
+    tensors = (
+        ()
+        if epilogue is None
+        else tuple(
+            getattr(_epilogue_abi_tensor(epilogue.tensors[name]), attr)
+            for name in _epilogue_input_names(epilogue.epilogue_fn)
+        )
+    )
+    if len(tensors) > 4:
+        raise NotImplementedError("NVGEMM scaled epilogues support up to four inputs")
+    return tensors + (None,) * (4 - len(tensors))
+
+
+def _epilogue_abi_tensor(tensor):
+    runtime_tensor = tensor.runtime_tensor
+    leading = runtime_tensor.shape[0]
+    if leading % 8 == 0:
+        return tensor
+    from cutlass.operators.utils.tensor import TensorWrapper
+
+    padded_shape = (leading + 7) // 8 * 8, *runtime_tensor.shape[1:]
+    import torch
+
+    padded = torch.empty(
+        padded_shape,
+        dtype=runtime_tensor.dtype,
+        device=runtime_tensor.device,
+    )
+    padded[:leading].copy_(runtime_tensor)
+    return TensorWrapper(padded)
+
+
+def _epilogue_tensor_kinds(args) -> tuple[int, ...]:
+    epilogue = getattr(args, "epilogue", None)
+    if epilogue is None:
+        return (0, 0, 0, 0)
+    kinds = []
+    output_m, output_n = args.out.shape[-2:]
+    for name in _epilogue_input_names(epilogue.epilogue_fn):
+        shape = epilogue.tensors[name].shape
+        if shape[-1] == 1 and (len(shape) == 1 or shape[-2] == 1):
+            if output_n == 1:
+                kinds.append(2)
+            elif output_m == 1:
+                kinds.append(3)
+            else:
+                raise NotImplementedError(
+                    "NVGEMM scaled epilogues do not support scalar tensor inputs"
+                )
+        elif len(shape) == 1 or shape[-2] == 1:
+            kinds.append(2)
+        elif shape[-1] == 1:
+            kinds.append(3)
+        else:
+            kinds.append(1)
+    return tuple(kinds) + (0,) * (4 - len(kinds))
+
+
+def _epilogue_outputs(args, attr: str) -> tuple[tuple, int, int]:
+    epilogue = getattr(args, "epilogue", None)
+    if epilogue is None:
+        return (None, None, None), 1, 0
+    output_names = _epilogue_signature(epilogue.epilogue_fn)[1]
+    if not output_names or len(output_names) > 4:
+        raise NotImplementedError("NVGEMM scaled epilogues support 1-4 outputs")
+    if len(output_names) > 1 and "D" not in output_names:
+        raise NotImplementedError("NVGEMM scaled multi-store requires a D output")
+    primary_index = output_names.index("D") if "D" in output_names else 0
+    tensors = tuple(
+        getattr(epilogue.tensors[name], attr)
+        for index, name in enumerate(output_names)
+        if index != primary_index
+    )
+    return tensors + (None,) * (3 - len(tensors)), len(output_names), primary_index
+
+
 def _ones_alpha():
     """Cached per-device (4,)-ones alpha TensorWrapper (identity global scale).
 
@@ -51,6 +166,27 @@ def _ones_alpha():
         tw = TensorWrapper(torch.ones(4, dtype=torch.float32, device=f"cuda:{dev}"))
         _ONES_ALPHA[dev] = tw
     return tw
+
+
+def _epilogue_op_scope(cute):
+    def relu(x):
+        return cute.math.max(x, cute.full_like(x, 0.0))
+
+    def sigmoid(x):
+        return 1.0 / (1.0 + cute.math.exp(-x))
+
+    def gelu(x):
+        return 0.5 * x * (1.0 + cute.math.erf(x * 0.7071067811865476))
+
+    return {
+        "erf": cute.math.erf,
+        "exp": cute.math.exp,
+        "gelu": gelu,
+        "relu": relu,
+        "sigmoid": sigmoid,
+        "silu": lambda x: x * sigmoid(x),
+        "tanh": cute.math.tanh,
+    }
 
 
 try:
@@ -86,6 +222,7 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
             use_prefetch=os.environ.get("TORCHINDUCTOR_NVGEMM_PREFETCH", "0") == "1",
         )
         self.cluster_shape_mn = cluster_shape_mn
+        self.mma_tiler_mn = mma_tiler_mn
 
     @staticmethod
     def _major_modes(args):
@@ -141,9 +278,42 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
                     for node in ast.parse(epilogue_op).body
                     if isinstance(node, ast.FunctionDef)
                 )
-                scope = {}
-                exec(epilogue_op, {}, scope)
+                scope = _epilogue_op_scope(cute)
+                exec(epilogue_op, scope)
                 epilogue_op = scope[fn_name]
+        epilogue = _EpilogueABI.from_args(args, "compile_time_tensor")
+        local_reduce_out = getattr(args, "local_reduce_out", None)
+        local_reduce_feeds_main = getattr(args, "local_reduce_feeds_main", False)
+        if local_reduce_out is not None or local_reduce_feeds_main:
+            return self.cute_compile(
+                self.impl,
+                args.A.tensor,
+                args.B.tensor,
+                args.A.scale.tensor,
+                args.B.scale.tensor,
+                args.out.tensor,
+                max_active_clusters,
+                stream,
+                epilogue_op,
+                self.metadata.operands.out.dtype,
+                alpha,
+                *epilogue.inputs,
+                *epilogue.input_kinds,
+                *epilogue.outputs,
+                epilogue.output_count,
+                epilogue.primary_output,
+                (
+                    local_reduce_out.compile_time_tensor
+                    if local_reduce_out is not None
+                    else None
+                ),
+                args.local_reduce_group,
+                args.local_reduce_axis,
+                args.local_reduce_type,
+                args.local_reduce_source,
+                local_reduce_feeds_main,
+                target_sm=target_sm,
+            )
         return self.cute_compile(
             self.impl,
             args.A.tensor,
@@ -154,7 +324,13 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
             max_active_clusters,
             stream,
             epilogue_op,
+            self.metadata.operands.out.dtype,
             alpha,
+            *epilogue.inputs,
+            *epilogue.input_kinds,
+            *epilogue.outputs,
+            epilogue.output_count,
+            epilogue.primary_output,
             target_sm=target_sm,
         )
 
@@ -178,6 +354,28 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
         alpha = getattr(args, "alpha", None)
         if alpha is None:
             alpha = _ones_alpha()
+        with torch.cuda.stream(stream):
+            epilogue = _EpilogueABI.from_args(args, "runtime_tensor")
+
+        local_reduce_out = getattr(args, "local_reduce_out", None)
+        local_reduce_feeds_main = getattr(args, "local_reduce_feeds_main", False)
+        if local_reduce_out is not None or local_reduce_feeds_main:
+            self.cute_run(  # pyrefly: ignore[missing-attribute]
+                compiled_gemm,
+                args.A.tensor,
+                args.B.tensor,
+                args.A.scale.tensor,
+                args.B.scale.tensor,
+                args.out.tensor,
+                stream,
+                alpha,
+                *epilogue.inputs,
+                *epilogue.outputs,
+                local_reduce_out.runtime_tensor
+                if local_reduce_out is not None
+                else None,
+            )
+            return
 
         self.cute_run(  # pyrefly: ignore[missing-attribute]
             compiled_gemm,
@@ -188,6 +386,9 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
             args.out.tensor,
             stream,
             alpha,
+            *epilogue.inputs,
+            *epilogue.outputs,
+            None,
         )
 
     def _supports(
@@ -198,6 +399,39 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
         # rather than re-inferring the layout (the old _infer_scale_swizzle_impl
         # check wrongly rejected valid NVFP4 args on the transposed B operand).
         from cutlass.operators.arguments import ScaledOperand
+
+        local_reduce_out = getattr(args, "local_reduce_out", None)
+        if local_reduce_out is not None or getattr(
+            args, "local_reduce_feeds_main", False
+        ):
+            group = args.local_reduce_group
+            axis = args.local_reduce_axis
+            m, n = args.out.shape[-2:]
+            selected_size = n if axis == 1 else m
+            max_group = self.mma_tiler_mn[axis] if axis == 1 else 16
+            if (
+                axis not in (0, 1)
+                or group <= 1
+                or group > max_group
+                or selected_size % group != 0
+            ):
+                return Status.fail(
+                    "Grouped reduction requires a supported M- or N-axis group "
+                    "that divides the selected dimension."
+                )
+            if local_reduce_out is not None:
+                expected_shape = (m, n // group) if axis == 1 else (m // group, n)
+                if local_reduce_out.shape != expected_shape:
+                    return Status.fail(
+                        "Grouped reduction output shape must be "
+                        f"{expected_shape}; got {local_reduce_out.shape}."
+                    )
+                if local_reduce_out.dtype is not cutlass.Float32 or tuple(
+                    local_reduce_out.stride
+                ) != (expected_shape[1], 1):
+                    return Status.fail(
+                        "Grouped reduction output must be contiguous Float32."
+                    )
 
         m, n = args.out.shape[-2:]
         k = args.A.shape[-1]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191515
* #191514
* #191595
* #191594
* #191593
* #191592
* #191591
* #190813
* #191590
* #191513
* #191588
* #191587
* #191586
* __->__ #191585
* #191584
* #190809
* #190825
* #190824
* #190822
* #190821
* #190820
* #190819
* #190823
* #190817
* #190810

> Map logical grouped reductions to the block-scaled provider accumulator layout. Combine N-axis partials across epilogue fragments in registers and M-axis partials across epilogue warps through shared memory. Support grouped sums and means consumed by centered GEMM outputs, with fallback when validation fails.
>