### PR TITLE
[inductor][FlexGEMM] Decompose additive GEMMs for NVGEMM

### DIFF
--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -34,6 +34,41 @@ from .constraints import (
 )
 
 
+def decompose_nvgemm_additive_gemm(graph_module: torch.fx.GraphModule) -> None:
+    graph = graph_module.graph
+    changed = False
+    for node in list(graph.nodes):
+        if node.target not in (
+            torch.ops.aten.addmm.default,
+            torch.ops.aten.baddbmm.default,
+        ):
+            continue
+        bias, mat1, mat2 = node.args[:3]
+        alpha = node.kwargs.get("alpha", 1.0)
+        beta = node.kwargs.get("beta", 1.0)
+        gemm_target = (
+            torch.ops.aten.mm.default
+            if node.target is torch.ops.aten.addmm.default
+            else torch.ops.aten.bmm.default
+        )
+        with graph.inserting_before(node):
+            result = graph.call_function(gemm_target, (mat1, mat2))
+            if alpha != 1:
+                result = graph.call_function(torch.ops.aten.mul.Tensor, (result, alpha))
+            if beta != 0:
+                if beta != 1:
+                    bias = graph.call_function(torch.ops.aten.mul.Tensor, (bias, beta))
+                result = graph.call_function(torch.ops.aten.add.Tensor, (result, bias))
+        result.meta = node.meta
+        node.replace_all_uses_with(result)
+        graph.erase_node(node)
+        changed = True
+    if changed:
+        graph.eliminate_dead_code()
+        graph.lint()
+        graph_module.recompile()
+
+
 def flex_gemm_tensor_placeholders(
     graph_module: torch.fx.GraphModule,
 ) -> list[torch.fx.Node]:
@@ -477,6 +512,7 @@ def flex_gemm_lowering(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
     """Dispatch FlexGEMM to ordinary Inductor lowering or the QUACK template."""
     backend = kernel_options.get("backend", "TRITON")
     if backend == "NVGEMM":
+        decompose_nvgemm_additive_gemm(subgraph.graph_module)
         with config.patch(
             max_autotune=True,
             max_autotune_gemm_backends="NVGEMM",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191515
* #191514
* #191595
* #191594
* #191593
* #191592
* #191591
* #190813
* __->__ #191590
* #191513
* #191588
* #191587
* #191586
* #191585
* #191584
* #190809
* #190825
* #190824
* #190822
* #190821
* #190820
* #190819
* #190823
* #190817
* #190810

> Before lowering a FlexGEMM subgraph with NVGEMM, rewrite addmm and baddbmm as mm or bmm followed by explicit alpha, beta, and bias operations. Omit the bias operation when beta is zero.
>