### PR TITLE
[inductor][NVGEMM] Generalize block-scaled GEMM reduction epilogues

### DIFF
--- a/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
@@ -44,6 +44,7 @@ from cutlass.cute.runtime import from_dlpack
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 
 import torch
+from torch._inductor.kernel.gemm_epilogue import GemmReductionExpression
 from torch._inductor.kernel.vendored_templates.cutedsl.reduction_utils import (
     get_lane_warp_layouts,
     partition_for_epilogue,
@@ -437,11 +438,17 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         epilogue_output_count: cutlass.Constexpr = 1,
         primary_epilogue_output: cutlass.Constexpr = 0,
         local_reduce_tensor: cute.Tensor = None,
+        local_reduce_feed_tensor: cute.Tensor = None,
         local_reduce_group: cutlass.Constexpr = 0,
         local_reduce_axis: cutlass.Constexpr = 1,
         local_reduce_type: cutlass.Constexpr = "sum",
         local_reduce_source: cutlass.Constexpr = "identity",
         local_reduce_feeds_main: cutlass.Constexpr = False,
+        local_reduce_op: cutlass.Constexpr = cute.ReductionOp.ADD,
+        local_reduce_init: cutlass.Constexpr = 0.0,
+        local_reduce_combine: cutlass.Constexpr = lambda lhs, rhs: lhs + rhs,
+        local_reduce_source_op: cutlass.Constexpr = lambda value: value,
+        local_reduce_finalize: cutlass.Constexpr = lambda value, group: value,
     ):
         """Execute the GEMM operation in steps:
         - Setup static attributes before smem/grid/tma computation
@@ -486,9 +493,54 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
         self.local_reduce_group = local_reduce_group
         self.local_reduce_axis = local_reduce_axis
+        self.local_reduce_input_coefficient = 1.0
+        self.local_reduce_result_coefficient = 0.0
+        self.local_reduce_bias = 0.0
+        self.local_reduce_affine_scale = 1.0
+        self.local_reduce_affine_bias = 0.0
+        self.local_reduce_denominator_scale = 1.0
+        self.local_reduce_denominator_bias = 0.0
+        reduction_expression = GemmReductionExpression.parse(local_reduce_type)
+        local_reduce_type = reduction_expression.kind
+        if cutlass.const_expr(local_reduce_type == "mean_linear"):
+            input_coefficient, result_coefficient, bias = (
+                reduction_expression.parameters
+            )
+            self.local_reduce_input_coefficient = float(input_coefficient)
+            self.local_reduce_result_coefficient = float(result_coefficient)
+            self.local_reduce_bias = float(bias)
+        if cutlass.const_expr(local_reduce_type == "normalize_sum_affine"):
+            (
+                affine_scale,
+                affine_bias,
+                denominator_scale,
+                denominator_bias,
+            ) = reduction_expression.parameters
+            local_reduce_type = "normalize_sum"
+            self.local_reduce_affine_scale = float(affine_scale)
+            self.local_reduce_affine_bias = float(affine_bias)
+            self.local_reduce_denominator_scale = float(denominator_scale)
+            self.local_reduce_denominator_bias = float(denominator_bias)
+        if cutlass.const_expr(local_reduce_type == "normalize_sum_reverse_affine"):
+            (
+                affine_scale,
+                affine_bias,
+                denominator_scale,
+                denominator_bias,
+            ) = reduction_expression.parameters
+            local_reduce_type = "normalize_sum_reverse"
+            self.local_reduce_affine_scale = float(affine_scale)
+            self.local_reduce_affine_bias = float(affine_bias)
+            self.local_reduce_denominator_scale = float(denominator_scale)
+            self.local_reduce_denominator_bias = float(denominator_bias)
         self.local_reduce_type = local_reduce_type
         self.local_reduce_source = local_reduce_source
         self.local_reduce_feeds_main = local_reduce_feeds_main
+        self.local_reduce_op = local_reduce_op
+        self.local_reduce_init = local_reduce_init
+        self.local_reduce_combine = local_reduce_combine
+        self.local_reduce_source_op = local_reduce_source_op
+        self.local_reduce_finalize = local_reduce_finalize
         self.has_cross_warp_local_reduce = cutlass.const_expr(
             local_reduce_tensor is not None
             and local_reduce_axis == 0
@@ -525,6 +577,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             epilogue_output1 = epilogue_tensor_to_mnl(epilogue_output1)
         if cutlass.const_expr(epilogue_output2 is not None):
             epilogue_output2 = epilogue_tensor_to_mnl(epilogue_output2)
+        if cutlass.const_expr(local_reduce_feed_tensor is not None):
+            local_reduce_feed_tensor = epilogue_tensor_to_mnl(local_reduce_feed_tensor)
 
         self.epilogue_output_count = epilogue_output_count
         self.primary_epilogue_output = primary_epilogue_output
@@ -784,6 +838,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             epilogue_output1,
             epilogue_output2,
             local_reduce_tensor,
+            local_reduce_feed_tensor,
         ).launch(
             grid=grid,
             block=[self.threads_per_cta, 1, 1],
@@ -833,6 +888,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         epilogue_output1: cute.Tensor,
         epilogue_output2: cute.Tensor,
         local_reduce_tensor: cute.Tensor,
+        local_reduce_feed_tensor: cute.Tensor,
     ):
         """
         GPU device kernel performing the Persistent batched GEMM computation.
@@ -1664,6 +1720,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         has_epilogue_tensors
                         or has_epilogue_outputs
                         or local_reduce_tensor is not None
+                        or local_reduce_feed_tensor is not None
+                        or self.local_reduce_feeds_main
                     ):
                         tDcC = partition_for_epilogue(
                             cute.make_identity_tensor(self.cta_tile_shape_mnk[:2]),
@@ -1676,7 +1734,11 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         coord_flt = cute.filter_zeros(tDcC)
 
                     epilogue_values = []
-                    if cutlass.const_expr(has_epilogue_tensors or has_epilogue_outputs):
+                    if cutlass.const_expr(
+                        has_epilogue_tensors
+                        or has_epilogue_outputs
+                        or local_reduce_feed_tensor is not None
+                    ):
                         output_m = cute.size(mC_mnl, mode=[0])
                         output_n = cute.size(mC_mnl, mode=[1])
                     if cutlass.const_expr(has_epilogue_tensors):
@@ -1725,41 +1787,135 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         local_reduce_vec = acc_vec.to(epilogue_input_dtype).to(
                             self.acc_dtype
                         )
-                        if cutlass.const_expr(self.local_reduce_source == "square"):
-                            local_reduce_vec = local_reduce_vec * local_reduce_vec
-                        else:
-                            assert self.local_reduce_source == "identity"
+                        local_reduce_vec = self.local_reduce_source_op(local_reduce_vec)
                     if cutlass.const_expr(self.local_reduce_feeds_main):
                         group = cutlass.const_expr(self.local_reduce_group)
-                        lane_layout_mn, _ = get_lane_warp_layouts(
-                            tiled_copy_t2r, reference_src=False
-                        )
-                        lanes_in_m = cutlass.const_expr(
-                            cute.size(lane_layout_mn, mode=[0])
-                        )
-                        assert group <= lanes_in_m
-                        feed_value = cute.make_rmem_tensor_like(
-                            local_reduce_vec, self.acc_dtype
-                        )
-                        feed_value.store(local_reduce_vec)
-                        feed_flt = cute.filter_zeros(feed_value)
-                        for i in cutlass.range(cute.size(feed_flt), unroll_full=True):
-                            rows = group // 2
-                            while rows > 0:
-                                feed_flt[i] += cute.arch.shuffle_sync_bfly(
-                                    feed_flt[i],
-                                    offset=cute.crd2idx((rows, 0), lane_layout_mn),
+                        if cutlass.const_expr(
+                            self.local_reduce_axis == 1
+                            and self.local_reduce_type
+                            in (
+                                "normalize_absmax",
+                                "normalize_sum",
+                                "normalize_sum_reverse",
+                                "online_softmax",
+                            )
+                        ):
+                            fragment_n = cutlass.const_expr(
+                                cute.size(local_reduce_vec.shape, mode=[0])
+                            )
+                            assert fragment_n % group == 0
+                            repeats = cutlass.const_expr(fragment_n // group)
+                            grouped = local_reduce_vec.reshape(
+                                ((1, group, repeats), 1, 1)
+                            )
+                            numerator = grouped
+                            if cutlass.const_expr(
+                                self.local_reduce_type == "normalize_absmax"
+                            ):
+                                numerator = acc_vec.to(epilogue_input_dtype).reshape(
+                                    grouped.shape
                                 )
-                                rows //= 2
-                            if cutlass.const_expr(self.local_reduce_type == "mean"):
-                                feed_flt[i] /= group
-                        epilogue_result = (
-                            acc_vec.to(epilogue_input_dtype) - feed_value.load()
-                        )
+                            if cutlass.const_expr(
+                                self.local_reduce_type == "online_softmax"
+                            ):
+                                max_value = grouped.reduce(
+                                    cute.ReductionOp.MAX,
+                                    init_val=-cutlass.Float32.inf,
+                                    reduction_profile=((None, 1, None), 1, 1),
+                                ).reshape(((1, 1, repeats), 1, 1))
+                                max_value = max_value.broadcast_to(grouped.shape)
+                                numerator = cute.math.exp(grouped - max_value)
+                            denominator_input = (
+                                grouped
+                                if cutlass.const_expr(
+                                    self.local_reduce_type == "normalize_absmax"
+                                )
+                                else numerator
+                            )
+                            denominator_op = (
+                                cute.ReductionOp.MAX
+                                if cutlass.const_expr(
+                                    self.local_reduce_type == "normalize_absmax"
+                                )
+                                else cute.ReductionOp.ADD
+                            )
+                            denominator_init = (
+                                -cutlass.Float32.inf
+                                if cutlass.const_expr(
+                                    self.local_reduce_type == "normalize_absmax"
+                                )
+                                else 0.0
+                            )
+                            denominator = denominator_input.reduce(
+                                denominator_op,
+                                init_val=denominator_init,
+                                reduction_profile=((None, 1, None), 1, 1),
+                            ).reshape(((1, 1, repeats), 1, 1))
+                            denominator = denominator.broadcast_to(grouped.shape)
+                            if cutlass.const_expr(
+                                self.local_reduce_type
+                                in ("normalize_sum", "normalize_sum_reverse")
+                            ):
+                                denominator = (
+                                    denominator * self.local_reduce_denominator_scale
+                                    + self.local_reduce_denominator_bias
+                                )
+                            if cutlass.const_expr(
+                                self.local_reduce_type == "normalize_sum_reverse"
+                            ):
+                                epilogue_result = (denominator / numerator).reshape(
+                                    local_reduce_vec.shape
+                                )
+                            else:
+                                epilogue_result = (numerator / denominator).reshape(
+                                    local_reduce_vec.shape
+                                )
+                            if cutlass.const_expr(
+                                self.local_reduce_type
+                                in ("normalize_sum", "normalize_sum_reverse")
+                            ):
+                                epilogue_result = (
+                                    epilogue_result * self.local_reduce_affine_scale
+                                    + self.local_reduce_affine_bias
+                                )
+                        else:
+                            assert self.local_reduce_axis == 0
+                            epilogue_result = acc_vec.to(epilogue_input_dtype)
                     else:
                         epilogue_result = epilogue_op(
                             acc_vec.to(epilogue_input_dtype), *tuple(epilogue_values)
                         )
+                    if cutlass.const_expr(
+                        local_reduce_feed_tensor is not None
+                        and self.local_reduce_axis == 1
+                    ):
+                        feed_vec = epilogue_result.to(
+                            local_reduce_feed_tensor.element_type
+                        )
+                        feed_fragment = cute.make_rmem_tensor_like(
+                            feed_vec, local_reduce_feed_tensor.element_type
+                        )
+                        feed_fragment.store(feed_vec)
+                        feed_fragment_flt = cute.filter_zeros(feed_fragment)
+                        for i in cutlass.range(
+                            cute.size(feed_fragment_flt), unroll_full=True
+                        ):
+                            row_idx = coord_flt[i][0]
+                            col_idx = coord_flt[i][1]
+                            global_m = (
+                                mma_tile_coord_mnl[0] * self.cta_tile_shape_mnk[0]
+                                + row_idx
+                            )
+                            global_n = (
+                                mma_tile_coord_mnl[1] * self.cta_tile_shape_mnk[1]
+                                + col_idx
+                            )
+                            if global_m < output_m and global_n < output_n:
+                                local_reduce_feed_tensor[
+                                    global_m,
+                                    global_n,
+                                    mma_tile_coord_mnl[2],
+                                ] = feed_fragment_flt[i]
                     if cutlass.const_expr(has_epilogue_outputs):
                         for output_index, tensor in enumerate(
                             (epilogue_output0, epilogue_output1, epilogue_output2)
@@ -1807,10 +1963,16 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
                     if cutlass.const_expr(
                         local_reduce_tensor is not None
-                        and not self.local_reduce_feeds_main
+                        or (
+                            self.local_reduce_feeds_main and self.local_reduce_axis == 0
+                        )
                     ):
                         group = cutlass.const_expr(self.local_reduce_group)
-                        mReduce = local_reduce_tensor[mma_tile_coord_mnl[2], None, None]
+                        mReduce = None
+                        if cutlass.const_expr(local_reduce_tensor is not None):
+                            mReduce = local_reduce_tensor[
+                                mma_tile_coord_mnl[2], None, None
+                            ]
                         if cutlass.const_expr(self.local_reduce_axis == 1):
                             fragment_n = cutlass.const_expr(
                                 cute.size(acc_vec.shape, mode=[0])
@@ -1823,30 +1985,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             grouped = local_reduce_vec.reshape(
                                 ((1, fragment_group, repeats), 1, 1)
                             )
-                            if cutlass.const_expr(
-                                self.local_reduce_type in ("sum", "mean")
-                            ):
-                                reduce_op = cute.ReductionOp.ADD
-                                init_val = 0.0
-                            elif cutlass.const_expr(self.local_reduce_type == "prod"):
-                                reduce_op = cute.ReductionOp.MUL
-                                init_val = 1.0
-                            elif cutlass.const_expr(self.local_reduce_type == "max"):
-                                reduce_op = cute.ReductionOp.MAX
-                                init_val = -cutlass.Float32.inf
-                            else:
-                                assert self.local_reduce_type == "min"
-                                reduce_op = cute.ReductionOp.MIN
-                                init_val = cutlass.Float32.inf
                             reduced = grouped.reduce(
-                                reduce_op,
-                                init_val=init_val,
+                                self.local_reduce_op,
+                                init_val=self.local_reduce_init,
                                 reduction_profile=((None, 1, None), 1, 1),
                             )
-                            if cutlass.const_expr(
-                                self.local_reduce_type == "mean" and group <= fragment_n
-                            ):
-                                reduced = reduced / group
+                            if cutlass.const_expr(group <= fragment_n):
+                                reduced = self.local_reduce_finalize(reduced, group)
                             reduced = reduced.reshape(((1, 1, repeats), 1, 1))
                             reduced = reduced.broadcast_to(grouped.shape)
                             should_store = cutlass.Boolean(True)
@@ -1858,21 +2003,10 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                 partial = local_reduce_partial.load()
                                 if subtile_idx % fragments_per_group == 0:
                                     partial = reduced
-                                elif cutlass.const_expr(
-                                    self.local_reduce_type in ("sum", "mean")
-                                ):
-                                    partial = partial + reduced
-                                elif cutlass.const_expr(
-                                    self.local_reduce_type == "prod"
-                                ):
-                                    partial = partial * reduced
-                                elif cutlass.const_expr(
-                                    self.local_reduce_type == "max"
-                                ):
-                                    partial = cute.math.max(partial, reduced)
                                 else:
-                                    assert self.local_reduce_type == "min"
-                                    partial = cute.math.min(partial, reduced)
+                                    partial = self.local_reduce_combine(
+                                        partial, reduced
+                                    )
                                 local_reduce_partial.store(partial)
                                 should_store = (
                                     subtile_idx % fragments_per_group
@@ -1880,10 +2014,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                 )
                                 if should_store:
                                     reduced = partial
-                                    if cutlass.const_expr(
-                                        self.local_reduce_type == "mean"
-                                    ):
-                                        reduced = reduced / group
+                                    reduced = self.local_reduce_finalize(reduced, group)
                                     store_offset = (
                                         real_subtile_idx * self.epi_tile_n
                                     ) % group
@@ -1947,42 +2078,32 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                         reduced_flt[i],
                                         offset=cute.crd2idx((rows, 0), lane_layout_mn),
                                     )
-                                    if cutlass.const_expr(
-                                        self.local_reduce_type in ("sum", "mean")
-                                    ):
-                                        reduced_flt[i] += other
-                                    elif cutlass.const_expr(
-                                        self.local_reduce_type == "prod"
-                                    ):
-                                        reduced_flt[i] *= other
-                                    elif cutlass.const_expr(
-                                        self.local_reduce_type == "max"
-                                    ):
-                                        reduced_flt[i] = cute.arch.fmax(
-                                            reduced_flt[i], other
-                                        )
-                                    else:
-                                        assert self.local_reduce_type == "min"
-                                        reduced_flt[i] = cute.arch.fmin(
-                                            reduced_flt[i], other
-                                        )
+                                    reduced_flt[i] = self.local_reduce_combine(
+                                        reduced_flt[i], other
+                                    )
                                     rows = rows // 2
-                                if cutlass.const_expr(self.local_reduce_type == "mean"):
-                                    reduced_flt[i] /= group
+                                reduced_flt[i] = self.local_reduce_finalize(
+                                    reduced_flt[i], group
+                                )
                             groups_per_cta = cutlass.const_expr(
                                 self.cta_tile_shape_mnk[0] // group
                             )
-                            gReduce = cute.local_tile(
-                                mReduce,
-                                (groups_per_cta, self.cta_tile_shape_mnk[1]),
-                                mma_tile_coord_mnl[:2],
-                            )
-                            limit_n = min(
-                                cute.size(local_reduce_tensor, mode=[2])
-                                - mma_tile_coord_mnl[1] * self.cta_tile_shape_mnk[1],
-                                self.cta_tile_shape_mnk[1],
-                            )
-                            limit_groups = cute.size(local_reduce_tensor, mode=[1])
+                            gReduce = None
+                            limit_n = 0
+                            limit_groups = 0
+                            if cutlass.const_expr(local_reduce_tensor is not None):
+                                gReduce = cute.local_tile(
+                                    mReduce,
+                                    (groups_per_cta, self.cta_tile_shape_mnk[1]),
+                                    mma_tile_coord_mnl[:2],
+                                )
+                                limit_n = min(
+                                    cute.size(local_reduce_tensor, mode=[2])
+                                    - mma_tile_coord_mnl[1]
+                                    * self.cta_tile_shape_mnk[1],
+                                    self.cta_tile_shape_mnk[1],
+                                )
+                                limit_groups = cute.size(local_reduce_tensor, mode=[1])
                             group_warps = cutlass.const_expr(group // lanes_in_m)
                             warp_m = warp_layout_mn[0]
                             warps_in_m = cutlass.const_expr(cute.size(warp_m))
@@ -2035,35 +2156,113 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                                 - group_idx
                                                 - 1,
                                             ]
-                                            if cutlass.const_expr(
-                                                self.local_reduce_type
-                                                in ("sum", "mean")
-                                            ):
-                                                group_value += other
-                                            elif cutlass.const_expr(
-                                                self.local_reduce_type == "prod"
-                                            ):
-                                                group_value *= other
-                                            elif cutlass.const_expr(
-                                                self.local_reduce_type == "max"
-                                            ):
-                                                group_value = cute.arch.fmax(
-                                                    group_value, other
-                                                )
-                                            else:
-                                                assert self.local_reduce_type == "min"
-                                                group_value = cute.arch.fmin(
-                                                    group_value, other
-                                                )
-                                if (
-                                    row_idx % group == 0
-                                    and n_idx < limit_n
-                                    and global_group_idx < limit_groups
-                                ):
-                                    gReduce[group_idx, n_idx] = group_value
+                                            group_value = self.local_reduce_combine(
+                                                group_value, other
+                                            )
+                                        if cutlass.const_expr(
+                                            self.local_reduce_feeds_main
+                                        ):
+                                            sLocalReduce[n_idx, group_idx] = group_value
+                                if cutlass.const_expr(local_reduce_tensor is not None):
+                                    if (
+                                        row_idx % group == 0
+                                        and n_idx < limit_n
+                                        and global_group_idx < limit_groups
+                                    ):
+                                        gReduce[group_idx, n_idx] = group_value
                             if cutlass.const_expr(group > lanes_in_m):
                                 self.epilog_sync_barrier.arrive_and_wait()
-                    tRS_rC.store(acc_vec)
+                            if cutlass.const_expr(self.local_reduce_feeds_main):
+                                if cutlass.const_expr(
+                                    local_reduce_feed_tensor is not None
+                                ):
+                                    primary_acc_vec = acc_vec
+                                if cutlass.const_expr(group > lanes_in_m):
+                                    for i in cutlass.range(
+                                        cute.size(reduced_flt), unroll_full=True
+                                    ):
+                                        row_idx = coord_flt[i][0]
+                                        n_idx = coord_flt[i][1]
+                                        reduced_flt[i] = sLocalReduce[
+                                            n_idx, row_idx // group
+                                        ]
+                                    self.epilog_sync_barrier.arrive_and_wait()
+                                if cutlass.const_expr(
+                                    self.local_reduce_type == "normalize_sum"
+                                ):
+                                    acc_vec = (
+                                        acc_vec.to(self.acc_dtype)
+                                        / (
+                                            tDrReduce.load()
+                                            * self.local_reduce_denominator_scale
+                                            + self.local_reduce_denominator_bias
+                                        )
+                                        * self.local_reduce_affine_scale
+                                        + self.local_reduce_affine_bias
+                                    )
+                                elif cutlass.const_expr(
+                                    self.local_reduce_type == "normalize_sum_reverse"
+                                ):
+                                    acc_vec = (
+                                        (
+                                            tDrReduce.load()
+                                            * self.local_reduce_denominator_scale
+                                            + self.local_reduce_denominator_bias
+                                        )
+                                        / acc_vec.to(self.acc_dtype)
+                                        * self.local_reduce_affine_scale
+                                        + self.local_reduce_affine_bias
+                                    )
+                                elif cutlass.const_expr(
+                                    self.local_reduce_type == "mean_linear"
+                                ):
+                                    acc_vec = (
+                                        acc_vec.to(self.acc_dtype)
+                                        * self.local_reduce_input_coefficient
+                                        + tDrReduce.load()
+                                        * self.local_reduce_result_coefficient
+                                        + self.local_reduce_bias
+                                    )
+                                else:
+                                    assert self.local_reduce_type == "mean"
+                                    acc_vec = (
+                                        acc_vec.to(self.acc_dtype) - tDrReduce.load()
+                                    )
+                            if cutlass.const_expr(
+                                local_reduce_feed_tensor is not None
+                                and self.local_reduce_axis == 0
+                            ):
+                                feed_vec = acc_vec.to(
+                                    local_reduce_feed_tensor.element_type
+                                )
+                                feed_fragment = cute.make_rmem_tensor_like(
+                                    feed_vec, local_reduce_feed_tensor.element_type
+                                )
+                                feed_fragment.store(feed_vec)
+                                feed_fragment_flt = cute.filter_zeros(feed_fragment)
+                                for i in cutlass.range(
+                                    cute.size(feed_fragment_flt), unroll_full=True
+                                ):
+                                    row_idx = coord_flt[i][0]
+                                    col_idx = coord_flt[i][1]
+                                    global_m = (
+                                        mma_tile_coord_mnl[0]
+                                        * self.cta_tile_shape_mnk[0]
+                                        + row_idx
+                                    )
+                                    global_n = (
+                                        mma_tile_coord_mnl[1]
+                                        * self.cta_tile_shape_mnk[1]
+                                        + col_idx
+                                    )
+                                    if global_m < output_m and global_n < output_n:
+                                        local_reduce_feed_tensor[
+                                            global_m,
+                                            global_n,
+                                            mma_tile_coord_mnl[2],
+                                        ] = feed_fragment_flt[i]
+                                acc_vec = primary_acc_vec
+                    tRS_rC.store(acc_vec.to(self.c_dtype))
 
                     #
                     # Store C to shared memory
@@ -2398,7 +2597,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
             + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
         )
-        mbar_helpers_bytes = 1024
+        mbar_helpers_bytes = 2048
         c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
         c_bytes = c_bytes_per_stage * num_c_stage
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191515
* #191514
* #191595
* #191594
* #191593
* __->__ #191592
* #191591
* #190813
* #191590
* #191513
* #191588
* #191587
* #191586
* #191585
* #191584
* #190809
* #190825
* #190824
* #190822
* #190821
* #190820
* #190819
* #190823
* #190817
* #190810

> Supply reduction source transforms, identities, combine operations, and finalizers through wrapper callbacks instead of hard-coding them in the kernel. Add parameterized mean and normalization expressions, a separate full-shape feed output, and axis-aware handling across fragments and warps.
>