### PR TITLE
[inductor] Fuse complete template reduction chains

### DIFF
--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -110,6 +110,11 @@ class CUDACombinedScheduling(BaseScheduling):
     def can_fuse_horizontal(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:
+        if any(
+            self._nv_universal_gemm_scheduling.has_bool_output(node)
+            for node in (node1, node2)
+        ):
+            return False
         for node in (node1, node2):
             if self._cutlass_scheduling.is_cutlass_template(node):
                 return self._cutlass_scheduling.can_fuse_horizontal(
@@ -141,6 +146,21 @@ class CUDACombinedScheduling(BaseScheduling):
                 node1, node2
             )
         return False
+
+    def can_fuse_reduction_chain(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> bool:
+        return self._nv_universal_gemm_scheduling.can_fuse_reduction_chain(node1, node2)
+
+    def get_fusion_pair_priority(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> int:
+        priority = self._nv_universal_gemm_scheduling.get_fusion_pair_priority(
+            node1, node2
+        )
+        if priority < 2:
+            return priority
+        return self._triton_scheduling.get_fusion_pair_priority(node1, node2) + 2
 
     def group_fn(
         self, sizes: Sequence[Sequence[_IntLike]]

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -7974,9 +7974,15 @@ class Scheduler:
             node1.get_device()
         ).can_fuse_multi_outputs_template(node1, node2):
             return True
-        if node1.is_template() and self.get_backend(
+        if (
+            node1.is_template() or isinstance(node1, FusedSchedulerNode)
+        ) and self.get_backend(node1.get_device()).can_fuse_reduction_epilogue(
+            node1, node2
+        ):
+            return True
+        if any(node.is_reduction() for node in node1.get_nodes()) and self.get_backend(
             node1.get_device()
-        ).can_fuse_reduction_epilogue(node1, node2):
+        ).can_fuse_reduction_chain(node1, node2):
             return True
 
         if isinstance(node1, GroupedSchedulerNode) or isinstance(
@@ -10429,6 +10435,11 @@ class BaseScheduling:  # noqa: docstring_linter
         raise NotImplementedError
 
     def can_fuse_reduction_epilogue(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> bool:
+        return False
+
+    def can_fuse_reduction_chain(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:
         return False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191515
* #191514
* #191595
* __->__ #191594
* #191593
* #191592
* #191591
* #190813
* #191590
* #191513
* #191588
* #191587
* #191586
* #191585
* #191584
* #190809
* #190825
* #190824
* #190822
* #190821
* #190820
* #190819
* #190823
* #190817
* #190810

> Let backend scheduling claim a reduction together with its layout or pointwise finalizers as one fusion group. This prevents generic fusion from consuming only part of an NVGEMM reduction pattern before NVGEMM validates it.
>