### PR TITLE
[BugFix] Fix operator precedence bug in check_channel signal pad validation

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1316,6 +1316,27 @@ class SymmMemNegativeTest(MultiProcessTestCase):
         # impossible to terminate the process in this state.
         os._exit(0)
 
+    @skip_if_rocm_multiprocess
+    @skip_if_lt_x_gpu(2)
+    def test_barrier_channel_out_of_bounds(self) -> None:
+        self._init_process()
+
+        t = symm_mem.empty(64, device="cuda")
+        symm_mem_hdl = symm_mem.rendezvous(t, group=dist.group.WORLD)
+
+        num_slots = symm_mem_hdl.signal_pad_size // 4
+        max_channel = num_slots // self.world_size
+
+        # channel == max_channel must be rejected
+        with self.assertRaisesRegex(RuntimeError, "maximum supported channel"):
+            symm_mem_hdl.barrier(channel=max_channel)
+        torch.cuda.synchronize()
+
+        # channel == max_channel - 1 must be accepted
+        if max_channel > 1:
+            symm_mem_hdl.barrier(channel=max_channel - 1)
+        torch.cuda.synchronize()
+
 
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh
@@ -120,7 +120,7 @@ inline void check_channel(int channel, int world_size, size_t signal_pad_size) {
       channel,
       ")");
   const size_t num_channels =
-      signal_pad_size / sizeof(uint32_t) * world_size;
+      signal_pad_size / (sizeof(uint32_t) * world_size);
   TORCH_CHECK(
       static_cast<size_t>(channel) < num_channels,
       "The maximum supported channel for barrier(), put_signal() and wait_signal() is ",


### PR DESCRIPTION
### Problem

`check_channel()` computes the channel upper bound as:

```cpp
signal_pad_size / sizeof(uint32_t) * world_size
```

Due to C++ operator precedence (`/` and `*` have equal precedence and are
left-associative), this is evaluated as:

```
(signal_pad_size / sizeof(uint32_t)) * world_size  =  N * world_size
```

The signal slot address used by `barrier`/`put_signal`/`wait_signal` is:

```
signal_pads[target] + world_size * channel + rank
```

i.e. the pad is indexed as `pad[channel][peer]` with a row length of
`world_size`.  The no-OOB condition at `rank = world_size - 1` is:

```
world_size * channel + (world_size - 1) < N
⟺ (channel + 1) * world_size <= N
⟺ channel < N / world_size
```

The bound should therefore be `N / world_size`, not `N * world_size`.  As
written the check is `world_size^2` times too permissive and does not
prevent out-of-bounds access past the end of the signal pad.

With default settings (`signal_pad_size = 32 * 72 * 4 = 9216` → `N = 2304`,
`world_size = 8`): correct max channel = 288, but the buggy check allows up
to 18432.

### Consequences

An out-of-bounds `channel` argument can:

- Land on an unmapped page → **CUDA error: an illegal memory access**
- Land inside an adjacent allocation → **silent memory corruption** (worse)

### Fix

Add parentheses to enforce the intended evaluation order:

```diff
- signal_pad_size / sizeof(uint32_t) * world_size;
+ signal_pad_size / (sizeof(uint32_t) * world_size);
```

This only tightens the bound to exactly what's safe — every channel value
that was legal before remains legal after the fix.

### Repro

```python
import torch
import torch.distributed as dist
import torch.distributed._symmetric_memory as symm_mem

# 2-GPU repro
dist.init_process_group("nccl")
torch.cuda.set_device(dist.get_rank())

t = symm_mem.empty(64, device="cuda")
hdl = symm_mem.rendezvous(t, group=dist.group.WORLD)

# N = 2304, ws = 2 → max valid channel = 1152
# channel=2000 → offset = 2*2000 + rank >= 4000 > 2304 → OOB
hdl.barrier(channel=2000)
torch.cuda.synchronize()
```

### Test

`test_barrier_channel_out_of_bounds` verifies that:

- `channel == N / world_size` is rejected with a RuntimeError
- `channel == N / world_size - 1` is accepted

### References

- Previous attempt (stale-closed without review): #170848
- The same operator-precedence bug existed in the file's previous location
  (`CUDASymmetricMemory.cu`) and survived the refactor into
  `CUDASymmetricMemory-inl.cuh`.