### PR TITLE
[inductor] Extract shared GEMM epilogue analysis

### DIFF
--- a/torch/_inductor/kernel/gemm_epilogue_analysis.py
+++ b/torch/_inductor/kernel/gemm_epilogue_analysis.py
@@ -1,0 +1,678 @@
+# mypy: allow-untyped-defs
+"""Shared FX analysis and output planning for grouped GEMM epilogues."""
+
+import dataclasses
+import operator
+from collections.abc import Sequence
+from typing import Any
+
+import torch
+from torch._inductor import inductor_prims
+from torch._inductor.kernel.flex_gemm.constraints import (
+    FLEX_GEMM_OUTPUT_PLAN_NODE_ERROR,
+    local_reduce_compressed_shape,
+    LOCAL_REDUCE_EXPLICIT_DTYPE_ERROR,
+    LOCAL_REDUCE_FEED_MAIN_AXIS1_FRAGMENT_ERROR,
+    LOCAL_REDUCE_FEED_MAIN_MIXED_MATCH_ERROR,
+    LOCAL_REDUCE_FRAGMENT_WIDTH,
+    LOCAL_REDUCE_INNERMOST_GROUPED_DIM_ERROR,
+    LOCAL_REDUCE_MATCH_NODE_ERROR,
+    LOCAL_REDUCE_MIXED_GROUPED_LAYOUT_ERROR,
+    LOCAL_REDUCE_MIXED_MATCH_ERROR,
+    LOCAL_REDUCE_ONE_PHYSICAL_VALUE_ERROR,
+    LOCAL_REDUCE_OUTPUT_PLAN_NODE_ERROR,
+    LOCAL_REDUCE_SOURCE_EXPRESSION_ERROR,
+    local_reduce_unsupported_tensorssa_error,
+    validate_local_reduce_feed_main_capability,
+    validate_local_reduce_tensorssa_group_size,
+)
+from torch._inductor.kernel.flex_gemm.quack_reductions import (
+    grouped_tensor_layout,
+    GroupedTensorSSALayout,
+    is_shape_preserving_pointwise_node,
+    reduction_from_node,
+    squeeze_source_node,
+    tensor_meta_shape,
+    unsupported_reduction_from_node,
+    view_or_reshape_args,
+)
+from torch._inductor.kernel.gemm_epilogue import (
+    GemmEpilogueGraph,
+    GemmReductionGeometry,
+    iter_fx_node_inputs,
+)
+from torch._inductor.kernel.gemm_epilogue_utils import statically_known_shape_equal
+from torch.utils._ordered_set import OrderedSet
+
+
+FEED_MAIN_BINARY_FUNCTIONS = frozenset(
+    (
+        torch.ops.aten.add.Tensor,
+        torch.ops.aten.add.Scalar,
+        torch.ops.aten.div.Tensor,
+        torch.ops.aten.mul.Tensor,
+        torch.ops.aten.mul.Scalar,
+        torch.ops.aten.sub.Tensor,
+        torch.ops.aten.sub.Scalar,
+    )
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmLocalReduceMatch:
+    """Describe a supported grouped local-reduction value found in the FX graph.
+
+    Attributes:
+        value_node: FX node that produces the matched local-reduction value.
+        geometry: Group size and GEMM output axis reduced by the value.
+    """
+
+    value_node: torch.fx.Node
+    geometry: GemmReductionGeometry
+    reduction_node: torch.fx.Node | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value_node, torch.fx.Node):
+            raise RuntimeError(LOCAL_REDUCE_MATCH_NODE_ERROR)
+        if self.reduction_node is None:
+            object.__setattr__(self, "reduction_node", self.value_node)
+
+    def to_plan(
+        self,
+        *,
+        store: "GemmLocalReduceStore | None",
+        feeds_main: bool,
+    ) -> "GemmOutputLocalReducePlan":
+        """Bind this matched value to its output consumers."""
+        return GemmOutputLocalReducePlan(self, store=store, feeds_main=feeds_main)
+
+    @property
+    def reduction_type(self) -> str | None:
+        """Return the primitive reduction kind represented by this match."""
+        reduction = (
+            reduction_from_node(self.reduction_node)
+            if self.reduction_node is not None
+            else None
+        )
+        return reduction[-1] if reduction is not None else None
+
+    @classmethod
+    def common(
+        cls,
+        matches: list["GemmLocalReduceMatch"],
+        mixed_match_error: str,
+    ) -> "GemmLocalReduceMatch | None":
+        """Return the common match when all values use one reduction geometry."""
+        if not matches:
+            return None
+        match = matches[0]
+        if any(item.geometry != match.geometry for item in matches):
+            raise NotImplementedError(mixed_match_error)
+        return match
+
+    @classmethod
+    def common_value(
+        cls,
+        matches: list["GemmLocalReduceMatch"],
+        mixed_match_error: str,
+    ) -> "GemmLocalReduceMatch | None":
+        """Return the common match when all consumers use one physical value."""
+        match = cls.common(matches, mixed_match_error)
+        if match is None:
+            return None
+        if any(item.value_node is not match.value_node for item in matches):
+            raise NotImplementedError(LOCAL_REDUCE_ONE_PHYSICAL_VALUE_ERROR)
+        return match
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmLocalReduceStore:
+    """Describe where a compressed local reduction appears in graph outputs.
+
+    Attributes:
+        node: FX node returned as the compressed local-reduction output.
+        aux_index: Position of that node among the graph's auxiliary outputs.
+    """
+
+    node: torch.fx.Node
+    aux_index: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.node, torch.fx.Node) or self.aux_index < 0:
+            raise RuntimeError(LOCAL_REDUCE_OUTPUT_PLAN_NODE_ERROR)
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmOutputLocalReducePlan:
+    """Bind a matched local reduction to store and/or main-output consumers.
+
+    Attributes:
+        match: Supported local-reduction value identified during FX analysis.
+        store: Compressed auxiliary output receiving the value, when requested.
+        feeds_main: Whether the reduced value is also consumed by the main output.
+    """
+
+    match: GemmLocalReduceMatch
+    store: GemmLocalReduceStore | None = None
+    feeds_main: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.match, GemmLocalReduceMatch) or (
+            self.store is None and not self.feeds_main
+        ):
+            raise RuntimeError(LOCAL_REDUCE_OUTPUT_PLAN_NODE_ERROR)
+
+    @property
+    def needs_physical_callbacks(self) -> bool:
+        return self.match.geometry.needs_physical_callbacks
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmOutputPlan:
+    """Classify the values returned by a FlexGEMM body.
+
+    Attributes:
+        output: FX node returned as the main GEMM result.
+        aux_outputs: Same-shape auxiliary FX outputs returned after the main result.
+        local_reduce: Compressed or feed-main local-reduction output behavior.
+    """
+
+    output: torch.fx.Node
+    aux_outputs: tuple[torch.fx.Node, ...] = ()
+    local_reduce: GemmOutputLocalReducePlan | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.output, torch.fx.Node) or not all(
+            isinstance(aux_output, torch.fx.Node) for aux_output in self.aux_outputs
+        ):
+            raise RuntimeError(FLEX_GEMM_OUTPUT_PLAN_NODE_ERROR)
+
+
+@dataclasses.dataclass
+class GemmLocalReduceAnalysis:
+    """Collect grouped TensorSSA layouts and supported local-reduction matches.
+
+    ``from_graph_module`` visits the FX graph in topological order. See
+    ``GroupedTensorSSALayout`` for the grouped layout attached to reshape and
+    pointwise nodes, and ``GemmLocalReduceMatch`` for each supported reduced
+    value found from those layouts.
+
+    Attributes:
+        graph: Dependency index used by recursive feed-main matching.
+        grouped_tensors: FX nodes whose values carry a grouped TensorSSA layout.
+        matches: FX values matched to a supported grouped local reduction.
+    """
+
+    graph: GemmEpilogueGraph
+    grouped_tensors: dict[torch.fx.Node, GroupedTensorSSALayout] = dataclasses.field(
+        default_factory=dict
+    )
+    matches: dict[torch.fx.Node, GemmLocalReduceMatch] = dataclasses.field(
+        default_factory=dict
+    )
+
+    @classmethod
+    def from_graph_module(
+        cls, graph_module: torch.fx.GraphModule
+    ) -> "GemmLocalReduceAnalysis":
+        """Build shared dependency and reduction state in one topological pass."""
+        nodes = tuple(graph_module.graph.nodes)
+        analysis = cls(GemmEpilogueGraph.from_nodes(nodes))
+        for node in nodes:
+            if node.op == "output":
+                break
+            analysis.visit_node(node)
+        return analysis
+
+    def visit_node(self, node: torch.fx.Node) -> None:
+        """Record grouped layouts and local-reduction matches for one FX node."""
+        if node.op != "call_function":
+            return
+        view_args = view_or_reshape_args(node)
+        if view_args is not None:
+            source_node, shape = view_args
+            if self.propagate_local_reduce_match(node, source_node):
+                return
+            if self.bind_grouped_layout(node, shape, source_node):
+                return
+        reduction = reduction_from_node(node)
+        if reduction is not None:
+            input_node, dim, _, dtype, _ = reduction
+            if self.bind_grouped_reduction(node, input_node, dim, dtype):
+                return
+        if node.target is inductor_prims.prepare_softmax_online:
+            input_node = node.args[0]
+            dim = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim")
+            if self.bind_grouped_reduction(
+                node, input_node, dim, raise_invalid_dims=False
+            ):
+                return
+        unsupported_reduction = unsupported_reduction_from_node(node)
+        if unsupported_reduction is not None:
+            input_node = node.args[0]
+            if (
+                isinstance(input_node, torch.fx.Node)
+                and input_node in self.grouped_tensors
+            ):
+                raise local_reduce_unsupported_tensorssa_error(unsupported_reduction)
+        if self.propagate_local_reduce_match(node, squeeze_source_node(node)):
+            return
+        if node.target is operator.getitem and self.propagate_local_reduce_match(
+            node, node.args[0]
+        ):
+            return
+        if is_shape_preserving_pointwise_node(node):
+            self.propagate_pointwise_match(node, LOCAL_REDUCE_MIXED_MATCH_ERROR)
+
+    def bind_grouped_layout(self, node: torch.fx.Node, shape: Any, source: Any) -> bool:
+        """Attach a grouped TensorSSA layout introduced by a reshape."""
+        source_shape = (
+            tensor_meta_shape(source) if isinstance(source, torch.fx.Node) else None
+        )
+        layout = grouped_tensor_layout(shape, source_shape)
+        if layout is None or not isinstance(source, torch.fx.Node):
+            return False
+        self.grouped_tensors[node] = layout
+        return True
+
+    def propagate_local_reduce_match(self, node: torch.fx.Node, source: Any) -> bool:
+        """Copy a matched local-reduction value through an FX wrapper."""
+        if not isinstance(source, torch.fx.Node):
+            return False
+        match = self.matches.get(source)
+        if match is None:
+            return False
+        self.matches[node] = match
+        return True
+
+    def bind_grouped_reduction(
+        self,
+        node: torch.fx.Node,
+        input_node: Any,
+        dim: Any,
+        dtype: Any = None,
+        *,
+        raise_invalid_dims: bool = True,
+    ) -> bool:
+        """Match and record a reduction over a grouped TensorSSA layout."""
+        if not isinstance(input_node, torch.fx.Node):
+            return False
+        layout = self.grouped_tensors.get(input_node)
+        if layout is None:
+            return False
+        if dtype is not None:
+            raise NotImplementedError(LOCAL_REDUCE_EXPLICIT_DTYPE_ERROR)
+        validate_local_reduce_tensorssa_group_size(layout.axis, layout.group_size)
+        if not layout.matches_reduction_dim(dim):
+            if not raise_invalid_dims:
+                return False
+            raise NotImplementedError(LOCAL_REDUCE_INNERMOST_GROUPED_DIM_ERROR)
+        self.matches[node] = GemmLocalReduceMatch(
+            node,
+            GemmReductionGeometry(layout.group_size, layout.axis),
+            reduction_node=node,
+        )
+        return True
+
+    def has_physical_grouped_input(self, value: Any) -> bool:
+        """Return whether a value depends on a grouped layout needing callbacks."""
+        active_geometries = OrderedSet(
+            match.geometry for match in self.matches.values()
+        )
+        physical_grouped_nodes = OrderedSet(
+            node
+            for node, layout in self.grouped_tensors.items()
+            if layout.needs_physical_combine
+            and GemmReductionGeometry(layout.group_size, layout.axis)
+            in active_geometries
+        )
+        return any(
+            node in physical_grouped_nodes
+            or any(
+                dependency in physical_grouped_nodes
+                for dependency in self.graph.dependencies.get(node, ())
+            )
+            for node in iter_fx_node_inputs(value)
+        )
+
+    def propagate_pointwise_match(
+        self, node: torch.fx.Node, mixed_match_error: str
+    ) -> bool:
+        """Propagate grouped layouts and local-reduction matches through pointwise ops."""
+        grouped_layouts = [
+            self.grouped_tensors[arg]
+            for arg in iter_fx_node_inputs((node.args, node.kwargs))
+            if arg in self.grouped_tensors
+        ]
+        if grouped_layouts:
+            grouped_layout = grouped_layouts[0]
+            if any(layout != grouped_layout for layout in grouped_layouts):
+                raise NotImplementedError(LOCAL_REDUCE_MIXED_GROUPED_LAYOUT_ERROR)
+            self.grouped_tensors[node] = grouped_layout
+        match = GemmLocalReduceMatch.common(
+            [
+                self.matches[arg]
+                for arg in iter_fx_node_inputs((node.args, node.kwargs))
+                if arg in self.matches
+            ],
+            mixed_match_error,
+        )
+        if match is None:
+            return False
+        self.matches[node] = dataclasses.replace(match, value_node=node)
+        return True
+
+    def match_feed_value(
+        self,
+        value: Any,
+        grouped_source: torch.fx.Node,
+        layout: GroupedTensorSSALayout,
+    ) -> GemmLocalReduceMatch | None:
+        """Find the grouped reduction that produces a broadcast value."""
+        if not isinstance(value, torch.fx.Node):
+            return None
+        reduction = reduction_from_node(value)
+        if reduction is not None:
+            input_node, dim, keepdim, dtype, _ = reduction
+            if input_node is not grouped_source:
+                if self.graph.depends_on(input_node, grouped_source):
+                    raise NotImplementedError(LOCAL_REDUCE_SOURCE_EXPRESSION_ERROR)
+                raise NotImplementedError(LOCAL_REDUCE_ONE_PHYSICAL_VALUE_ERROR)
+            if (
+                dtype is not None
+                or not keepdim
+                or not layout.matches_reduction_dim(dim)
+            ):
+                raise NotImplementedError(LOCAL_REDUCE_ONE_PHYSICAL_VALUE_ERROR)
+            return GemmLocalReduceMatch(
+                value,
+                GemmReductionGeometry(layout.group_size, layout.axis),
+                reduction_node=value,
+            )
+        if not is_shape_preserving_pointwise_node(value):
+            return None
+        matches = [
+            match
+            for arg in iter_fx_node_inputs((value.args, value.kwargs))
+            if (match := self.match_feed_value(arg, grouped_source, layout)) is not None
+        ]
+        return GemmLocalReduceMatch.common_value(
+            matches, LOCAL_REDUCE_ONE_PHYSICAL_VALUE_ERROR
+        )
+
+    def validate_hidden_feed_main_reduction_input(
+        self,
+        input_node: Any,
+        grouped_source: torch.fx.Node,
+    ) -> None:
+        """Reject reduction inputs that would need another physical feed-main value."""
+        if input_node is grouped_source:
+            raise NotImplementedError(LOCAL_REDUCE_ONE_PHYSICAL_VALUE_ERROR)
+        if not isinstance(input_node, torch.fx.Node):
+            return
+        if self.graph.depends_on(input_node, grouped_source):
+            raise NotImplementedError(LOCAL_REDUCE_SOURCE_EXPRESSION_ERROR)
+        if self.has_physical_grouped_input(input_node):
+            raise NotImplementedError(LOCAL_REDUCE_ONE_PHYSICAL_VALUE_ERROR)
+
+    def validate_feed_main_source_reductions(
+        self,
+        value: Any,
+        grouped_source: torch.fx.Node,
+        selected_reduction: torch.fx.Node,
+        seen: OrderedSet[torch.fx.Node] | None = None,
+    ) -> None:
+        """Reject hidden physical reductions outside the selected feed-main value."""
+        if not isinstance(value, torch.fx.Node):
+            for arg in iter_fx_node_inputs(value):
+                self.validate_feed_main_source_reductions(
+                    arg, grouped_source, selected_reduction, seen
+                )
+            return
+        if value is selected_reduction:
+            return
+        if seen is None:
+            seen = OrderedSet()
+        if value in seen:
+            return
+        seen.add(value)
+        reduction = reduction_from_node(value)
+        if reduction is not None:
+            self.validate_hidden_feed_main_reduction_input(reduction[0], grouped_source)
+        for arg in iter_fx_node_inputs((value.args, value.kwargs)):
+            self.validate_feed_main_source_reductions(
+                arg, grouped_source, selected_reduction, seen
+            )
+
+    def validate_feed_main_source_match(
+        self,
+        source: torch.fx.Node,
+        match: GemmLocalReduceMatch | None,
+    ) -> GemmLocalReduceMatch | None:
+        """Preserve the one-physical-value ABI across recursive source matching."""
+        if match is None:
+            return None
+        reduction = reduction_from_node(match.value_node)
+        if reduction is not None and isinstance(reduction[0], torch.fx.Node):
+            self.validate_feed_main_source_reductions(
+                source, reduction[0], match.value_node
+            )
+        return match
+
+    @staticmethod
+    def feed_main_binary_candidates(
+        source: torch.fx.Node,
+    ) -> tuple[tuple[Any, Any], ...]:
+        """Return operand orderings for supported binary feed-main expressions."""
+        if (
+            len(source.args) < 2
+            or source.op != "call_function"
+            or source.target not in FEED_MAIN_BINARY_FUNCTIONS
+        ):
+            return ()
+        lhs, rhs = source.args[:2]
+        return ((lhs, rhs), (rhs, lhs))
+
+    def feed_main_grouped_reduction(
+        self,
+        value: Any,
+        grouped_source: torch.fx.Node,
+        layout: GroupedTensorSSALayout,
+    ) -> bool:
+        """Return whether a candidate contains a grouped feed-main reduction."""
+        if not isinstance(value, torch.fx.Node):
+            return False
+        reduction = reduction_from_node(value)
+        if reduction is not None:
+            input_node, dim, keepdim, dtype, _ = reduction
+            return (
+                dtype is None
+                and bool(keepdim)
+                and layout.matches_reduction_dim(dim)
+                and (
+                    input_node is grouped_source
+                    or self.graph.depends_on(input_node, grouped_source)
+                )
+            )
+        if not is_shape_preserving_pointwise_node(value):
+            return False
+        return any(
+            self.feed_main_grouped_reduction(arg, grouped_source, layout)
+            for arg in iter_fx_node_inputs((value.args, value.kwargs))
+        )
+
+    def match_feed_main_candidate(
+        self,
+        grouped_source: Any,
+        value: Any,
+        output_meta: Any,
+    ) -> GemmLocalReduceMatch | None:
+        """Match one grouped-source and reduced-value operand ordering."""
+        if not isinstance(grouped_source, torch.fx.Node) or not isinstance(
+            value, torch.fx.Node
+        ):
+            return None
+        view_args = view_or_reshape_args(grouped_source)
+        if view_args is None:
+            return None
+        source_node, input_shape = view_args
+        if not isinstance(source_node, torch.fx.Node):
+            return None
+        layout = grouped_tensor_layout(input_shape, tensor_meta_shape(source_node))
+        if layout is None:
+            return None
+        if layout.axis != 0:
+            if not self.feed_main_grouped_reduction(value, grouped_source, layout):
+                return None
+            if layout.group_size <= LOCAL_REDUCE_FRAGMENT_WIDTH:
+                # Intentional fallthrough: axis-1 feeds within one TensorSSA
+                # fragment lower as plain generated TensorSSA without a feed plan.
+                return None
+            raise NotImplementedError(LOCAL_REDUCE_FEED_MAIN_AXIS1_FRAGMENT_ERROR)
+        validate_local_reduce_feed_main_capability(layout.axis, layout.group_size)
+        source_meta = source_node.meta.get("val")
+        if (
+            output_meta is not None
+            and source_meta is not None
+            and not statically_known_shape_equal(output_meta.shape, source_meta.shape)
+        ):
+            return None
+        return self.match_feed_value(value, grouped_source, layout)
+
+    def match_feed_main_source(
+        self,
+        source: torch.fx.Node,
+        output_meta: Any,
+    ) -> GemmLocalReduceMatch | None:
+        """Find one physical feed-main value inside a pointwise expression."""
+        matches = [
+            match
+            for grouped_source, value in self.feed_main_binary_candidates(source)
+            if (
+                match := self.match_feed_main_candidate(
+                    grouped_source, value, output_meta
+                )
+            )
+            is not None
+        ]
+        if matches:
+            return self.validate_feed_main_source_match(
+                source,
+                GemmLocalReduceMatch.common_value(
+                    matches, LOCAL_REDUCE_ONE_PHYSICAL_VALUE_ERROR
+                ),
+            )
+        if not is_shape_preserving_pointwise_node(source):
+            return None
+        matches = [
+            match
+            for arg in iter_fx_node_inputs((source.args, source.kwargs))
+            if isinstance(arg, torch.fx.Node)
+            if (match := self.match_feed_main_source(arg, output_meta)) is not None
+        ]
+        return self.validate_feed_main_source_match(
+            source,
+            GemmLocalReduceMatch.common_value(
+                matches, LOCAL_REDUCE_ONE_PHYSICAL_VALUE_ERROR
+            ),
+        )
+
+    def feed_main_plan(
+        self,
+        output: torch.fx.Node,
+    ) -> GemmLocalReduceMatch | None:
+        """Match feed-main reductions through trailing pointwise nodes."""
+        view_args = view_or_reshape_args(output)
+        if view_args is not None:
+            source, _ = view_args
+            if not isinstance(source, torch.fx.Node):
+                return None
+            return self.match_feed_main_source(source, output.meta.get("val"))
+        if not is_shape_preserving_pointwise_node(output):
+            return None
+        matches = [
+            match
+            for arg in iter_fx_node_inputs((output.args, output.kwargs))
+            if isinstance(arg, torch.fx.Node)
+            if (match := self.feed_main_plan(arg)) is not None
+        ]
+        return self.validate_feed_main_source_match(
+            output,
+            GemmLocalReduceMatch.common_value(
+                matches, LOCAL_REDUCE_ONE_PHYSICAL_VALUE_ERROR
+            ),
+        )
+
+    def common_feed_main_match(
+        self,
+        candidates: tuple[Any, ...],
+    ) -> GemmLocalReduceMatch | None:
+        """Find the physical reduction value shared by feed-main consumers."""
+        matches = [
+            match
+            for candidate in candidates
+            if isinstance(candidate, torch.fx.Node)
+            if (match := self.feed_main_plan(candidate)) is not None
+        ]
+        return GemmLocalReduceMatch.common_value(
+            matches, LOCAL_REDUCE_FEED_MAIN_MIXED_MATCH_ERROR
+        )
+
+    def common_reduction_dependency_match(
+        self, outputs: Sequence[torch.fx.Node]
+    ) -> GemmLocalReduceMatch | None:
+        """Return one physical reduction transitively consumed by the outputs."""
+        reachable = OrderedSet(outputs)
+        for output in outputs:
+            reachable.update(self.graph.dependencies.get(output, ()))
+        matches = [self.matches[node] for node in reachable if node in self.matches]
+        if not matches:
+            return None
+        reduction_node = matches[0].reduction_node
+        if reduction_node is None or any(
+            match.reduction_node is not reduction_node for match in matches
+        ):
+            return None
+        return matches[0]
+
+    def compressed_aux_plan(
+        self,
+        output: Any,
+        aux: torch.fx.Node,
+        aux_index: int,
+    ) -> GemmOutputLocalReducePlan | None:
+        """Plan a matched local reduction returned in compressed output shape."""
+        match = self.matches.get(aux)
+        output_meta = (
+            output.meta.get("val") if isinstance(output, torch.fx.Node) else None
+        )
+        aux_meta = aux.meta.get("val")
+        if match is None or aux_meta is None or output_meta is None:
+            return None
+        expected_aux_shape = local_reduce_compressed_shape(
+            output_meta.shape, match.geometry.group, match.geometry.axis
+        )
+        if not statically_known_shape_equal(expected_aux_shape, aux_meta.shape):
+            return None
+        return match.to_plan(
+            store=GemmLocalReduceStore(aux, aux_index), feeds_main=False
+        )
+
+    def feed_main_output_plan(
+        self,
+        output: torch.fx.Node,
+        aux_outputs: tuple[torch.fx.Node, ...] = (),
+        *,
+        allow_dependency_match: bool = False,
+    ) -> GemmOutputPlan | None:
+        """Plan one physical reduction value consumed by the main output."""
+        match = self.common_feed_main_match((output, *aux_outputs))
+        if match is None and allow_dependency_match:
+            match = self.common_reduction_dependency_match((output, *aux_outputs))
+        if match is None:
+            return None
+        return GemmOutputPlan(
+            output,
+            aux_outputs,
+            match.to_plan(store=None, feeds_main=True),
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Move backend-neutral FX dependency analysis and output planning into shared GEMM epilogue infrastructure before NVGEMM begins consuming them. Symbolic shape utilities already live in the earlier common-IR commit because physical grouped reduction lowering consumes them there.

Test Plan:

```
lintrunner -a
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo