### PR TITLE
[xpu][fix]Relax fp16 grad tolerance for native_group_norm on XPU

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -740,6 +740,13 @@ inductor_override_kwargs["xpu"] = {
     ("nn.functional.interpolate.trilinear", f64): {
         "check_gradient": False,
     },
+    # fp16 backward accumulates ~1e-3 rounding across the aten kernel and
+    # inductor decomposition; loosen tolerances to match the CUDA override
+    # added in pytorch/pytorch#190245.
+    ("native_group_norm", f16): {
+        "grad_atol": 2e-3,
+        "grad_rtol": 1e-3,
+    },
 }
 if TEST_WITH_ROCM:
     inductor_override_kwargs["cuda"].update(


### PR DESCRIPTION
## Motivation

pytorch/pytorch#190245 fixed missed upcasts in the CUDA `native_group_norm_backward` kernel/decomposition and replaced the previous `check_gradient: False` overrides with looser tolerances (`grad_atol=2e-3, grad_rtol=1e-3`). That PR left the CUDA override in place but removed the corresponding XPU override without adding anything back, leaving XPU on the default fp16 tolerance (`atol=1e-5, rtol=1e-3`) which is too tight for the residual 1-ULP rounding differences between the XPU aten backward kernel and the Inductor decomposition. Result: #185367 (`test_comprehensive_native_group_norm_xpu_float16`) has been disabled since May 2026.

## Root cause on the failing sample

Sample: `input=(1,6,3), groups=2, eps=0.5, fp16`

```
d_input:
  eager  vs ref-fp32: max_abs = 9.77e-04
  comp   vs ref-fp32: max_abs = 9.77e-04
  comp   vs eager   : max_abs = 9.77e-04    (>> default atol=1e-5)
```

Both eager and compiled backward stay within fp16 quantization of an fp32 reference, but they round to different fp16 values at some indices. The XPU aten kernel already accumulates in fp32 (`T_ACC`); the residual difference comes from the aten kernel executing as several TensorIterator launches vs Inductor materializing one fused fp32 graph. This is intrinsic fp16 rounding, not a correctness bug on either side, and matches the situation upstream addressed on CUDA in #190245.

## Fix

Align XPU with the CUDA precedent from the same PR by adding the same `(native_group_norm, f16)` override to `inductor_override_kwargs["xpu"]`.

## Test plan

Against nightly wheel `torch==2.14.0.dev20260728+xpu` on Intel Data Center GPU Max 1100:

```
python -m pytest test/inductor/test_torchinductor_opinfo.py -v \
    -k test_comprehensive_native_group_norm_xpu --timeout=600
# native_group_norm_xpu_float16  PASSED
# native_group_norm_xpu_float32  PASSED
# native_group_norm_xpu_float64  PASSED
# 3 passed, 7450 deselected
```

Fixes #185367

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @guangyey

_Note: authored with AI assistance._