### PR TITLE
Support CUDA device linking in JIT cpp extensions

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -196,6 +196,36 @@ class TestCppExtensionJIT(common.TestCase):
         # 2 * sigmoid(0) = 2 * 0.5 = 1
         self.assertEqual(z, torch.ones_like(z))
 
+    @common.skipIfRocm
+    @unittest.skipIf(IS_WINDOWS, "Windows not supported")
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_jit_cuda_extension_with_dlink(self):
+        temp_dir = tempfile.mkdtemp()
+        try:
+            module = torch.utils.cpp_extension.load(
+                name="torch_test_cuda_dlink_extension",
+                sources=[
+                    "cpp_extensions/cuda_dlink_extension.cpp",
+                    "cpp_extensions/cuda_dlink_extension_kernel.cu",
+                    "cpp_extensions/cuda_dlink_extension_add.cu",
+                ],
+                extra_cuda_cflags=["-O2", "-rdc=true"],
+                build_directory=temp_dir,
+                verbose=True,
+                dlink=True,
+            )
+
+            x = torch.randn(8, device="cuda", dtype=torch.float32)
+            y = torch.randn(8, device="cuda", dtype=torch.float32)
+            self.assertEqual(module.add(x, y), x + y)
+
+            with open(os.path.join(temp_dir, "build.ninja")) as f:
+                ninja_file = f.read()
+            self.assertIn("cuda_devlink", ninja_file)
+            self.assertIn("-dlink", ninja_file)
+        finally:
+            shutil.rmtree(temp_dir)
+
     def _test_jit_xpu_extension(self, extra_sycl_cflags):
         # randomizing extension name and names of extension methods
         # for the case when we test building few extensions in a row

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1833,7 +1833,9 @@ def load(name,
          with_sycl: bool | None = None,
          is_python_module=True,
          is_standalone=False,
-         keep_intermediates=True):
+         keep_intermediates=True,
+         dlink=False,
+         dlink_libraries=None):
     """
     Load a PyTorch C++ extension just-in-time (JIT).
 
@@ -1907,6 +1909,11 @@ def load(name,
         is_standalone: If ``False`` (default) loads the constructed extension
             into the process as a plain dynamic library. If ``True``, build a
             standalone executable.
+        dlink: If ``True``, performs CUDA device linking before the final host
+            link step. This is required when linking CUDA sources compiled with
+            relocatable device code (e.g. ``-rdc=true``).
+        dlink_libraries: optional list of libraries to link during the CUDA
+            device linking step. Specifying any libraries enables ``dlink``.
 
     Returns:
         If ``is_python_module`` is ``True``:
@@ -1943,7 +1950,9 @@ def load(name,
         with_sycl,
         is_python_module,
         is_standalone,
-        keep_intermediates=keep_intermediates)
+        keep_intermediates=keep_intermediates,
+        dlink=dlink,
+        dlink_libraries=dlink_libraries)
 
 @deprecated("PyBind11 ABI handling is internal to PyBind11; this will be removed after PyTorch 2.9.0")
 def _get_pybind11_abi_build_flags() -> list[str]:
@@ -2120,7 +2129,9 @@ def load_inline(name,
                 with_pytorch_error_handling=True,
                 keep_intermediates=True,
                 use_pch=False,
-                no_implicit_headers=False):
+                no_implicit_headers=False,
+                dlink=False,
+                dlink_libraries=None):
     r'''
     Load a PyTorch C++ extension just-in-time (JIT) from string sources.
 
@@ -2194,6 +2205,11 @@ def load_inline(name,
             ``#include <torch/extension.h>`` and ``#include <torch/types.h>`` lines.
             Use this option to improve cold start times when you
             already include the necessary headers in your source code. Default: ``False``.
+        dlink: If ``True``, performs CUDA device linking before the final host
+            link step. This is required when linking CUDA sources compiled with
+            relocatable device code (e.g. ``-rdc=true``).
+        dlink_libraries: optional list of libraries to link during the CUDA
+            device linking step. Specifying any libraries enables ``dlink``.
 
     Example:
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CPP_EXT)
@@ -2301,7 +2317,9 @@ def load_inline(name,
         with_sycl,
         is_python_module,
         is_standalone=False,
-        keep_intermediates=keep_intermediates)
+        keep_intermediates=keep_intermediates,
+        dlink=dlink,
+        dlink_libraries=dlink_libraries)
 
 
 def _jit_compile(name,
@@ -2317,7 +2335,9 @@ def _jit_compile(name,
                  with_sycl: bool | None,
                  is_python_module,
                  is_standalone,
-                 keep_intermediates=True) -> types.ModuleType | str:
+                 keep_intermediates=True,
+                 dlink=False,
+                 dlink_libraries=None) -> types.ModuleType | str:
     if is_python_module and is_standalone:
         raise ValueError("`is_python_module` and `is_standalone` are mutually exclusive.")
 
@@ -2330,11 +2350,22 @@ def _jit_compile(name,
         raise AssertionError(
             "cannot have both SYCL and CUDA files in the same extension"
         )
+
+    dlink_libraries = dlink_libraries or []
+    dlink = dlink or bool(dlink_libraries)
+
     old_version = JIT_EXTENSION_VERSIONER.get_version(name)
     version = JIT_EXTENSION_VERSIONER.bump_version_if_changed(
         name,
         sources,
-        build_arguments=[extra_cflags, extra_cuda_cflags, extra_ldflags, extra_include_paths],
+        build_arguments=[
+            extra_cflags,
+            extra_cuda_cflags,
+            extra_ldflags,
+            extra_include_paths,
+            [dlink],
+            dlink_libraries,
+        ],
         build_directory=build_directory,
         with_cuda=with_cuda,
         with_sycl=with_sycl,
@@ -2401,7 +2432,9 @@ def _jit_compile(name,
                     verbose=verbose,
                     with_cuda=with_cuda,
                     with_sycl=with_sycl,
-                    is_standalone=is_standalone)
+                    is_standalone=is_standalone,
+                    dlink=dlink,
+                    dlink_libraries=dlink_libraries)
         elif verbose:
             logger.debug('No modifications detected for re-loaded extension module %s, skipping build step...', name)
 
@@ -2498,7 +2531,9 @@ def _write_ninja_file_and_build_library(
         verbose: bool,
         with_cuda: bool | None,
         with_sycl: bool | None,
-        is_standalone: bool = False) -> None:
+        is_standalone: bool = False,
+        dlink=False,
+        dlink_libraries=None) -> None:
     verify_ninja_availability()
 
     compiler = get_cxx_compiler()
@@ -2542,7 +2577,9 @@ def _write_ninja_file_and_build_library(
         extra_include_paths=extra_include_paths or [],
         with_cuda=with_cuda,
         with_sycl=with_sycl,
-        is_standalone=is_standalone)
+        is_standalone=is_standalone,
+        dlink=dlink,
+        dlink_libraries=dlink_libraries)
 
     if verbose:
         logger.info('Building extension module %s...', name)
@@ -2955,7 +2992,9 @@ def _write_ninja_file_to_build_library(path,
                                        extra_include_paths,
                                        with_cuda,
                                        with_sycl,
-                                       is_standalone) -> None:
+                                       is_standalone,
+                                       dlink,
+                                       dlink_libraries) -> None:
     extra_cflags = [flag.strip() for flag in extra_cflags]
     extra_cuda_cflags = [flag.strip() for flag in extra_cuda_cflags]
     extra_sycl_cflags = [flag.strip() for flag in extra_sycl_cflags]
@@ -3072,13 +3111,29 @@ def _write_ninja_file_to_build_library(path,
     ext = EXEC_EXT if is_standalone else LIB_EXT
     library_target = f'{name}{ext}'
 
+    cuda_dlink_post_cflags = None
+
+    if dlink:
+        cuda_dlink_post_cflags = ['-dlink'] + COMMON_NVCC_FLAGS + _get_cuda_arch_flags(extra_cuda_cflags)
+        if not IS_WINDOWS:
+            cuda_dlink_post_cflags += ['--compiler-options', "'-fPIC'"]
+        cuda_dlink_post_cflags += [f'-L{x}' for x in library_paths(device_type="cuda")]
+        cuda_dlink_post_cflags += [f'-l{x}' for x in dlink_libraries]
+
+        if (
+            (torch.version.cuda is not None)
+            and TorchVersion(torch.version.cuda) >= '11.2'
+            and any('-dlto' in flag for flag in extra_cuda_cflags)
+        ):
+            cuda_dlink_post_cflags += ['-dlto']
+
     _write_ninja_file(
         path=path,
         cflags=cflags,
         post_cflags=None,
         cuda_cflags=cuda_flags,
         cuda_post_cflags=None,
-        cuda_dlink_post_cflags=None,
+        cuda_dlink_post_cflags=cuda_dlink_post_cflags,
         sycl_cflags=sycl_cflags,
         sycl_post_cflags=[],
         sycl_dlink_post_cflags=sycl_dlink_post_cflags,


### PR DESCRIPTION
Closes #180762

Summary:
- Add dlink and dlink_libraries options to cpp_extension.load and load_inline.
- Forward the options through the JIT extension build path into the generated ninja file.
- Generate a CUDA device-link step before the final host link when dlink is enabled.
- Include dlink options in the JIT extension version cache key.
- Add a CUDA JIT extension test using existing RDC test sources.

Test Plan:
- python test/test_cpp_extensions_jit.py TestCppExtensionJIT.test_jit_cuda_extension_with_dlink
- python test/test_cpp_extensions_jit.py TestCppExtensionJIT.test_jit_cuda_extension