### PR TITLE
[DTensor] Fix loss_parallel() giving wrong gradients for non-cross-entropy log_softmax consumers

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_examples.py
+++ b/test/distributed/tensor/parallel/test_tp_examples.py
@@ -551,7 +551,13 @@ class DistTensorParallelExampleTest(DTensorTestBase):
                             else:
                                 y.backward()
                                 dist_y.backward()
-                            self.assertEqual(comm_mode.get_total_counts(), 0)
+                            # 1 all_reduce from _log_softmax_backward_handler
+                            # (unfused from nll_loss backward for GH-190746)
+                            self.assertEqual(comm_mode.get_total_counts(), 1)
+                            self.assertEqual(
+                                comm_mode.get_comm_counts()[c10d_functional.all_reduce],
+                                1,
+                            )
                             self.assertTrue(
                                 dist_x.grad.placements[0].is_shard(shard_dim)
                             )
@@ -565,6 +571,116 @@ class DistTensorParallelExampleTest(DTensorTestBase):
                             dist_y = F.cross_entropy(
                                 dist_x, target, reduction=reduction
                             )
+
+    @with_comms
+    @skip_unless_torch_gpu
+    @parametrize(
+        "input_size, softmax_dim, dtype",
+        [
+            ((8, 16), 1, torch.float32),
+            ((8, 16), -1, torch.float32),
+            ((4, 16, 6), 1, torch.float32),
+            ((8, 16), 1, torch.float16),
+        ],
+    )
+    def test_loss_parallel_log_softmax_non_cross_entropy(
+        self, input_size, softmax_dim, dtype
+    ):
+        """Regression test for GH-190746: log_softmax inside loss_parallel() not
+        feeding into cross_entropy must still get the correct distributed backward."""
+        device_mesh = self.build_device_mesh()
+        channel_dim = softmax_dim % len(input_size)
+
+        x = torch.rand(
+            *input_size, device=self.device_type, dtype=dtype, requires_grad=True
+        )
+        c = torch.rand(*input_size, device=self.device_type, dtype=dtype)
+
+        dist_x = distribute_tensor(x, device_mesh, [Shard(channel_dim)])
+        dist_c = distribute_tensor(c, device_mesh, [Shard(channel_dim)])
+
+        x_ref = x.clone().detach().requires_grad_(True)
+        ref_dtype = torch.float32 if dtype == torch.float16 else None
+        (F.log_softmax(x_ref, dim=softmax_dim, dtype=ref_dtype) * c).sum().backward()
+
+        comm_mode = CommDebugMode()
+        with loss_parallel():
+            with comm_mode:
+                (
+                    F.log_softmax(dist_x, dim=softmax_dim, dtype=ref_dtype) * dist_c
+                ).sum().backward()
+            # 2 all_reduces in forward (max, sumexp) + 1 in backward (grad sum)
+            self.assertEqual(comm_mode.get_total_counts(), 3)
+            self.assertEqual(comm_mode.get_comm_counts()[c10d_functional.all_reduce], 3)
+
+        self.assertEqual(dist_x.grad.full_tensor(), x_ref.grad)
+
+    @with_comms
+    @skip_unless_torch_gpu
+    def test_loss_parallel_log_softmax_placement_mismatch(self):
+        """Exercise the redistribute guard in _log_softmax_backward_handler:
+        when grad_output arrives with placements different from the forward
+        output, the handler must redistribute before computing the backward."""
+        device_mesh = self.build_device_mesh()
+        channel_size, channel_dim = 16, 1
+
+        class _ForceGradPlacement(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, mesh, placements):
+                ctx.mesh = mesh
+                ctx.placements = tuple(placements)
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, grad):
+                return grad.redistribute(ctx.mesh, ctx.placements), None, None
+
+        x = torch.rand(8, channel_size, device=self.device_type, requires_grad=True)
+        c = torch.rand(8, channel_size, device=self.device_type)
+        dist_x = distribute_tensor(x, device_mesh, [Shard(channel_dim)])
+        dist_c = distribute_tensor(c, device_mesh, [Shard(channel_dim)])
+
+        x_ref = x.clone().detach().requires_grad_(True)
+        (F.log_softmax(x_ref, dim=channel_dim) * c).sum().backward()
+
+        with loss_parallel():
+            lsm = F.log_softmax(dist_x, dim=channel_dim)
+            lsm = _ForceGradPlacement.apply(lsm, device_mesh, [Replicate()])
+            (lsm * dist_c).sum().backward()
+
+        self.assertEqual(dist_x.grad.full_tensor(), x_ref.grad)
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    def test_loss_parallel_log_softmax_non_cross_entropy_multi_dim_mesh(self):
+        """Regression test for GH-190746 on a 2D mesh (dp=2, tp=2): standalone
+        log_softmax inside loss_parallel() must all_reduce over the TP dim only."""
+        mesh_2d = DeviceMesh(
+            self.device_type,
+            torch.arange(self.world_size).reshape(2, 2),
+            mesh_dim_names=("dp", "tp"),
+        )
+        comm_mode = CommDebugMode()
+        channel_size, channel_dim = 16, 1
+
+        x = torch.rand(8, channel_size, device=self.device_type, requires_grad=True)
+        c = torch.rand(8, channel_size, device=self.device_type)
+
+        dist_x = distribute_tensor(x, mesh_2d, [Shard(0), Shard(channel_dim)])
+        dist_c = distribute_tensor(c, mesh_2d, [Shard(0), Shard(channel_dim)])
+
+        x_ref = x.clone().detach().requires_grad_(True)
+        (F.log_softmax(x_ref, dim=channel_dim) * c).sum().backward()
+
+        with loss_parallel():
+            with comm_mode:
+                (F.log_softmax(dist_x, dim=channel_dim) * dist_c).sum().backward()
+            # 2 all_reduces in forward (max, sumexp) + 1 in backward (grad sum),
+            # all on the TP mesh dim only
+            self.assertEqual(comm_mode.get_total_counts(), 3)
+            self.assertEqual(comm_mode.get_comm_counts()[c10d_functional.all_reduce], 3)
+
+        self.assertEqual(dist_x.grad.full_tensor(), x_ref.grad)
 
     @with_comms
     @skip_if_lt_x_gpu(4)

--- a/test/distributed/tensor/parallel/test_tp_examples.py
+++ b/test/distributed/tensor/parallel/test_tp_examples.py
@@ -551,7 +551,11 @@ class DistTensorParallelExampleTest(DTensorTestBase):
                             else:
                                 y.backward()
                                 dist_y.backward()
-                            self.assertEqual(comm_mode.get_total_counts(), 0)
+                            self.assertEqual(comm_mode.get_total_counts(), 1)
+                            self.assertEqual(
+                                comm_mode.get_comm_counts()[c10d_functional.all_reduce],
+                                1,
+                            )
                             self.assertTrue(
                                 dist_x.grad.placements[0].is_shard(shard_dim)
                             )
@@ -565,6 +569,55 @@ class DistTensorParallelExampleTest(DTensorTestBase):
                             dist_y = F.cross_entropy(
                                 dist_x, target, reduction=reduction
                             )
+
+    @with_comms
+    def test_loss_parallel_log_softmax_non_cross_entropy(self):
+        """Regression test for GH-190746: log_softmax inside loss_parallel() not
+        feeding into cross_entropy must still get the correct distributed backward."""
+        device_mesh = self.build_device_mesh()
+        channel_size, channel_dim = 16, 1
+
+        x = torch.rand(8, channel_size, device=self.device_type, requires_grad=True)
+        c = torch.rand(8, channel_size, device=self.device_type)
+
+        dist_x = distribute_tensor(x, device_mesh, [Shard(channel_dim)])
+        dist_c = distribute_tensor(c, device_mesh, [Shard(channel_dim)])
+
+        # Reference gradient on the full (non-distributed) tensor
+        x_ref = x.clone().detach().requires_grad_(True)
+        (F.log_softmax(x_ref, dim=channel_dim) * c).sum().backward()
+
+        # Distributed backward — previously returned identity gradient (bug)
+        with loss_parallel():
+            (F.log_softmax(dist_x, dim=channel_dim) * dist_c).sum().backward()
+
+        self.assertEqual(dist_x.grad.full_tensor(), x_ref.grad)
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    def test_loss_parallel_log_softmax_non_cross_entropy_multi_dim_mesh(self):
+        """Regression test for GH-190746 on a 2D mesh (dp=2, tp=2): standalone
+        log_softmax inside loss_parallel() must all_reduce over the TP dim only."""
+        mesh_2d = DeviceMesh(
+            self.device_type,
+            torch.arange(self.world_size).reshape(2, 2),
+            mesh_dim_names=("dp", "tp"),
+        )
+        channel_size, channel_dim = 16, 1
+
+        x = torch.rand(8, channel_size, device=self.device_type, requires_grad=True)
+        c = torch.rand(8, channel_size, device=self.device_type)
+
+        dist_x = distribute_tensor(x, mesh_2d, [Shard(0), Shard(channel_dim)])
+        dist_c = distribute_tensor(c, mesh_2d, [Shard(0), Shard(channel_dim)])
+
+        x_ref = x.clone().detach().requires_grad_(True)
+        (F.log_softmax(x_ref, dim=channel_dim) * c).sum().backward()
+
+        with loss_parallel():
+            (F.log_softmax(dist_x, dim=channel_dim) * dist_c).sum().backward()
+
+        self.assertEqual(dist_x.grad.full_tensor(), x_ref.grad)
 
     @with_comms
     @skip_if_lt_x_gpu(4)

--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -254,16 +254,55 @@ def _log_softmax_handler(
     )
 
 
-# NOTE: As explained below at _nll_loss_and_log_softmax_backward, the
-# _log_softmax_backward_handler does not actually do any computation.
+# NOTE: Implements the distributed log_softmax backward, matching
+# torch._decomp.decompositions._log_softmax_backward_data but with all_reduce on
+# the sum term because the class dimension is sharded across TP ranks.
 def _log_softmax_backward_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
 ) -> object:
     grad_output = cast(DTensor, args[0])
+    output = cast(DTensor, args[1])
+    dim = cast(int, args[2])
     input_dtype = cast(torch.dtype, args[3])
-    return grad_output.to(input_dtype)
+
+    dim = normalize_dim(dim, output.dim())
+    spec = output._spec
+    mesh_dim = _find_all_reduce_mesh_dim(spec.placements, dim)
+
+    # Autograd may deliver grad_output with different placements than the
+    # forward output (see the analogous guard in _nll_loss_backward_handler).
+    if grad_output.placements != spec.placements:
+        grad_output = grad_output.redistribute(spec.mesh, spec.placements)
+
+    local_go = grad_output._local_tensor
+    local_out = output._local_tensor
+
+    computation_dtype, _ = utils.elementwise_dtypes(
+        local_go,
+        local_out,
+        type_promotion_kind=utils.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    )
+    local_go = local_go.to(computation_dtype)
+    local_softmax = torch.exp(local_out.to(computation_dtype))
+
+    local_sum = local_go.sum(dim, keepdim=True)
+    global_sum = funcol.all_reduce(
+        local_sum, reduceOp=c10d.ReduceOp.SUM.name, group=(spec.mesh, mesh_dim)
+    )
+    local_grad = (local_go - local_softmax * global_sum).to(input_dtype)
+
+    output_tensor_meta = _propagate_tensor_meta(op_call, args, kwargs)
+    out_spec = DTensorSpec(spec.mesh, spec.placements, tensor_meta=output_tensor_meta)
+    # pyrefly: ignore [bad-argument-type]
+    return DTensor(
+        # pyrefly: ignore [bad-argument-count]
+        local_grad,
+        out_spec,
+        # pyrefly: ignore [unexpected-keyword]
+        requires_grad=local_grad.requires_grad,
+    )
 
 
 # NOTE: The implementation follows torch._decomp.decomposition._nll_loss_forward,
@@ -441,14 +480,8 @@ def _nll_loss_forward_handler(
     )
 
 
-# NOTE: The backward computation of cross_entropy goes through two steps:
-# backward for nll_loss and then backward for log_softmax. In loss parallel,
-# the two steps are fused into the following function (called by _nll_loss_backward_handler)
-# to avoid communication when target contains class indices not class probabilities.
-# Also note that the _log_softmax_backward_handler does not perform computation.
-# The implementation resembles _nll_loss_backward and _log_softmax_backward_data
-# from torch._decomp.decomposition.
-def _nll_loss_and_log_softmax_backward(
+# NOTE: The implementation resembles torch._decomp.decompositions._nll_loss_backward.
+def _nll_loss_backward(
     grad_output: Tensor,
     x: Tensor,
     target: Tensor,
@@ -501,8 +534,6 @@ def _nll_loss_and_log_softmax_backward(
         new_shape = [1 for _ in range(x.dim())]
         new_shape[channel_dim] = weight.shape[0]
         weight = weight.reshape(new_shape)
-        # In order for fused computation to work, the following line is rewritten.
-        # grad_output = grad_output * weight
         new_shape = list(x.shape)
         new_shape[channel_dim] = -1
         w = weight.expand(new_shape)
@@ -511,11 +542,7 @@ def _nll_loss_and_log_softmax_backward(
 
     grad_output = torch.where(target != ignore_index, grad_output, 0)
 
-    # NOTE: Instead of directly returning the grad_input as grad_output for log_softmax,
-    # here we perform backward computation for log_softmax altogether to avoid the
-    # otherwise extra all_gather communication.
-    # return grad_input * grad_output
-    return (grad_input + torch.exp(x)) * grad_output
+    return grad_input * grad_output
 
 
 def _nll_loss_backward_handler(
@@ -565,7 +592,7 @@ def _nll_loss_backward_handler(
     args[6] = _cast_to_dtensor(total_weight, all_replicate_placements, spec.mesh)
     output_tensor_meta = _propagate_tensor_meta(op_call, tuple(args), kwargs)
 
-    result = _nll_loss_and_log_softmax_backward(
+    result = _nll_loss_backward(
         grad_output._local_tensor,
         x._local_tensor,
         target._local_tensor,

--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -254,16 +254,48 @@ def _log_softmax_handler(
     )
 
 
-# NOTE: As explained below at _nll_loss_and_log_softmax_backward, the
-# _log_softmax_backward_handler does not actually do any computation.
+# NOTE: Implements the distributed log_softmax backward, matching the non-distributed
+# decomposition at torch/_decomp/decompositions.py but with all_reduce on the sum term
+# because the class dimension is sharded across TP ranks.
 def _log_softmax_backward_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
 ) -> object:
     grad_output = cast(DTensor, args[0])
+    output = cast(DTensor, args[1])
+    dim = cast(int, args[2])
     input_dtype = cast(torch.dtype, args[3])
-    return grad_output.to(input_dtype)
+
+    dim = normalize_dim(dim, output.dim())
+    spec = output._spec
+    mesh_dim = _find_all_reduce_mesh_dim(spec.placements, dim)
+
+    local_go = grad_output._local_tensor
+    local_out = output._local_tensor
+
+    computation_dtype, _ = utils.elementwise_dtypes(
+        local_go, type_promotion_kind=utils.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
+    )
+    local_go = local_go.to(computation_dtype)
+    local_softmax = torch.exp(local_out.to(computation_dtype))
+
+    local_sum = local_go.sum(dim, keepdim=True)
+    global_sum = funcol.all_reduce(
+        local_sum, reduceOp=c10d.ReduceOp.SUM.name, group=(spec.mesh, mesh_dim)
+    )
+    local_grad = (local_go - local_softmax * global_sum).to(input_dtype)
+
+    output_tensor_meta = _propagate_tensor_meta(op_call, args, kwargs)
+    out_spec = DTensorSpec(spec.mesh, spec.placements, tensor_meta=output_tensor_meta)
+    # pyrefly: ignore [bad-argument-type]
+    return DTensor(
+        # pyrefly: ignore [bad-argument-count]
+        local_grad,
+        out_spec,
+        # pyrefly: ignore [unexpected-keyword]
+        requires_grad=local_grad.requires_grad,
+    )
 
 
 # NOTE: The implementation follows torch._decomp.decomposition._nll_loss_forward,
@@ -441,13 +473,10 @@ def _nll_loss_forward_handler(
     )
 
 
-# NOTE: The backward computation of cross_entropy goes through two steps:
-# backward for nll_loss and then backward for log_softmax. In loss parallel,
-# the two steps are fused into the following function (called by _nll_loss_backward_handler)
-# to avoid communication when target contains class indices not class probabilities.
-# Also note that the _log_softmax_backward_handler does not perform computation.
-# The implementation resembles _nll_loss_backward and _log_softmax_backward_data
-# from torch._decomp.decomposition.
+# NOTE: Implements the nll_loss backward only. The log_softmax backward is handled
+# separately by _log_softmax_backward_handler, which fires next in autograd's
+# topological order. The implementation resembles _nll_loss_backward from
+# torch._decomp.decomposition.
 def _nll_loss_and_log_softmax_backward(
     grad_output: Tensor,
     x: Tensor,
@@ -501,8 +530,6 @@ def _nll_loss_and_log_softmax_backward(
         new_shape = [1 for _ in range(x.dim())]
         new_shape[channel_dim] = weight.shape[0]
         weight = weight.reshape(new_shape)
-        # In order for fused computation to work, the following line is rewritten.
-        # grad_output = grad_output * weight
         new_shape = list(x.shape)
         new_shape[channel_dim] = -1
         w = weight.expand(new_shape)
@@ -511,11 +538,7 @@ def _nll_loss_and_log_softmax_backward(
 
     grad_output = torch.where(target != ignore_index, grad_output, 0)
 
-    # NOTE: Instead of directly returning the grad_input as grad_output for log_softmax,
-    # here we perform backward computation for log_softmax altogether to avoid the
-    # otherwise extra all_gather communication.
-    # return grad_input * grad_output
-    return (grad_input + torch.exp(x)) * grad_output
+    return grad_input * grad_output
 
 
 def _nll_loss_backward_handler(


### PR DESCRIPTION
`_log_softmax_backward_handler` was a deliberate no-op, relying on `_nll_loss_and_log_softmax_backward` to embed the log_softmax Jacobian in the fused nll_loss backward. This was only correct when log_softmax fed into nll_loss. Any other consumer inside `loss_parallel()` received identity gradients (`d/dx log_softmax(x) = I`) instead of the correct softmax Jacobian (`I - softmax(x) * 1^T`), silently producing wrong gradients with no exception or warning.

The fix unfuses the two backward passes: `_log_softmax_backward_handler` now computes the correct distributed backward (`grad_x = grad_y - softmax(output) * all_reduce(sum(grad_y, class_dim))`), and `_nll_loss_and_log_softmax_backward` returns only the nll_loss backward term. The extra all_reduce is over a `(batch_size, 1)` tensor — the same scale as the two all_reduces already in the forward — so the performance impact is negligible. The math for the cross_entropy path is algebraically identical to the old fused result.

Fixes: https://github.com/pytorch/pytorch/issues/190746