### PR TITLE
Preserve GC state in flight recorder read_dir

### DIFF
--- a/test/distributed/flight_recorder/test_loader.py
+++ b/test/distributed/flight_recorder/test_loader.py
@@ -1,0 +1,64 @@
+# Owner(s): ["oncall: distributed"]
+
+import argparse
+import gc
+import os
+import pickle
+import tempfile
+
+from torch.distributed.flight_recorder.components.loader import read_dir
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class FlightRecorderLoaderTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        restore_gc = gc.enable if gc.isenabled() else gc.disable
+        self.addCleanup(restore_gc)
+
+    def _write_dump(self, trace_dir):
+        path = os.path.join(trace_dir, "dump0")
+        with open(path, "wb") as output:
+            pickle.dump(
+                {
+                    "entries": [],
+                    "version": "2.8",
+                    "pg_config": {},
+                },
+                output,
+            )
+
+    def test_read_dir_restores_enabled_gc_after_success(self):
+        with tempfile.TemporaryDirectory() as trace_dir:
+            self._write_dump(trace_dir)
+            gc.enable()
+
+            read_dir(argparse.Namespace(trace_dir=trace_dir, prefix="dump"))
+
+            self.assertTrue(gc.isenabled())
+
+    def test_read_dir_restores_enabled_gc_after_failure(self):
+        gc.enable()
+
+        with self.assertRaisesRegex(AssertionError, "does not exist"):
+            read_dir(
+                argparse.Namespace(
+                    trace_dir="missing-flight-recorder-dir",
+                    prefix=None,
+                )
+            )
+
+        self.assertTrue(gc.isenabled())
+
+    def test_read_dir_preserves_disabled_gc(self):
+        with tempfile.TemporaryDirectory() as trace_dir:
+            self._write_dump(trace_dir)
+            gc.disable()
+
+            read_dir(argparse.Namespace(trace_dir=trace_dir, prefix="dump"))
+
+            self.assertFalse(gc.isenabled())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/flight_recorder/components/loader.py
+++ b/torch/distributed/flight_recorder/components/loader.py
@@ -73,28 +73,33 @@ def _determine_prefix(files: list[str]) -> str:
 
 
 def read_dir(args: argparse.Namespace) -> tuple[dict[str, dict[str, Any]], str]:
+    was_gc_enabled = gc.isenabled()
     gc.disable()
-    prefix = args.prefix
-    details = {}
-    t0 = time.time()
-    version = ""
-    filecount = 0
-    if not os.path.isdir(args.trace_dir):
-        raise AssertionError(f"folder {args.trace_dir} does not exist")
-    for root, _, files in os.walk(args.trace_dir):
-        if prefix is None:
-            prefix = _determine_prefix(files)
-        for f in files:
-            if (offset := f.find(prefix)) == -1:
-                continue
-            details[f] = read_dump(f[:offset] + prefix, os.path.join(root, f))
-            filecount += 1
-            if not version:
-                version = str(details[f]["version"])
-    tb = time.time()
-    if len(details) <= 0:
-        raise AssertionError(
-            f"no files loaded from {args.trace_dir} with prefix {prefix}"
-        )
-    logger.debug("loaded %s files in %ss", filecount, tb - t0)
-    return details, version
+    try:
+        prefix = args.prefix
+        details = {}
+        t0 = time.time()
+        version = ""
+        filecount = 0
+        if not os.path.isdir(args.trace_dir):
+            raise AssertionError(f"folder {args.trace_dir} does not exist")
+        for root, _, files in os.walk(args.trace_dir):
+            if prefix is None:
+                prefix = _determine_prefix(files)
+            for f in files:
+                if (offset := f.find(prefix)) == -1:
+                    continue
+                details[f] = read_dump(f[:offset] + prefix, os.path.join(root, f))
+                filecount += 1
+                if not version:
+                    version = str(details[f]["version"])
+        tb = time.time()
+        if len(details) <= 0:
+            raise AssertionError(
+                f"no files loaded from {args.trace_dir} with prefix {prefix}"
+            )
+        logger.debug("loaded %s files in %ss", filecount, tb - t0)
+        return details, version
+    finally:
+        if was_gc_enabled:
+            gc.enable()

--- a/torch/distributed/flight_recorder/components/loader.py
+++ b/torch/distributed/flight_recorder/components/loader.py
@@ -11,6 +11,8 @@ import pickle
 import re
 import time
 from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 from torch.distributed.flight_recorder.components.fr_logger import FlightRecorderLogger
@@ -72,10 +74,19 @@ def _determine_prefix(files: list[str]) -> str:
         )
 
 
-def read_dir(args: argparse.Namespace) -> tuple[dict[str, dict[str, Any]], str]:
-    was_gc_enabled = gc.isenabled()
+@contextmanager
+def _disable_gc() -> Iterator[None]:
+    was_enabled = gc.isenabled()
     gc.disable()
     try:
+        yield
+    finally:
+        if was_enabled:
+            gc.enable()
+
+
+def read_dir(args: argparse.Namespace) -> tuple[dict[str, dict[str, Any]], str]:
+    with _disable_gc():
         prefix = args.prefix
         details = {}
         t0 = time.time()
@@ -100,6 +111,3 @@ def read_dir(args: argparse.Namespace) -> tuple[dict[str, dict[str, Any]], str]:
             )
         logger.debug("loaded %s files in %ss", filecount, tb - t0)
         return details, version
-    finally:
-        if was_gc_enabled:
-            gc.enable()


### PR DESCRIPTION
## Issue

Fixes #191396

## Summary

`read_dir()` disabled cyclic garbage collection without restoring the caller's state. This captures the entry state and restores it in `finally`, including when loading raises, while preserving an intentionally disabled collector. Regression tests cover successful loading, validation failure, and an initially disabled collector.

## Prior claim and overlap

I reproduced the issue and stated my intent to work on it in [this issue comment](https://github.com/pytorch/pytorch/issues/191396#issuecomment-5111710103) at 2026-07-29 01:32 UTC. That predates the later claim and the opening of #191439 and #191468. This patch was implemented and validated independently before those overlapping PRs were found during the final pre-publication duplicate check; the links are included here so maintainers can triage the overlap transparently.

## Validation

- New loader regression tests: 3 passed
- Existing Flight Recorder analysis tests: 9 passed
- Targeted `spin lint` passed all available checks; `PYREFLY` could not run in the sparse checkout because it scans missing repository modules
- `py_compile` and whitespace checks passed

## Checklist

- [ ] Passes full lint (`PYREFLY` unavailable in the sparse checkout; other targeted checks passed)
- [x] Added/updated tests
- [x] Documentation not applicable
- [x] Benchmark results not applicable; no performance-sensitive behavior changed

## BC-breaking?

No.

Codex assisted with coding for this change.
