### PR TITLE
Fix EmbeddingBag SEGV when include_last_offset has too few offsets

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -912,6 +912,12 @@ void check_arguments(
     TORCH_CHECK(
         offsets.size(0) >= 1,
         "include_last_offset: number of offset should be at least 1");
+    TORCH_CHECK(
+        offsets.size(0) >= 2 || indices.numel() == 0,
+        "embedding_bag: When include_last_offset is True and there are indices, "
+        "offsets must have at least 2 elements to define at least one bag, "
+        "but got offsets of size ", offsets.size(0),
+        " with ", indices.numel(), " indices");
   }
 }
 

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -912,6 +912,11 @@ void check_arguments(
     TORCH_CHECK(
         offsets.size(0) >= 1,
         "include_last_offset: number of offset should be at least 1");
+    TORCH_CHECK(
+        offsets.size(0) >= 2 || indices.numel() == 0,
+        "embedding_bag: when include_last_offset is True and indices are non-empty, "
+        "offsets must have at least 2 elements to define at least one bag, but got "
+        "offsets of size ", offsets.size(0), " with ", indices.numel(), " indices");
   }
 }
 

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -375,6 +375,15 @@ _embedding_bag_cuda(const Tensor &weight, const Tensor &indices_,
     // implementation even this flag is enabled.
     TORCH_CHECK(
         numBags >= 1, "include_last_offset: numBags should be at least 1");
+    // Reject the combination that produces 0 bags with non-empty indices,
+    // which previously caused OOB access. See
+    // https://github.com/pytorch/pytorch/issues/190044.
+    TORCH_CHECK(
+        numBags >= 2 || numIndices == 0,
+        "embedding_bag: When include_last_offset is True and there are indices, "
+        "offsets must have at least 2 elements to define at least one bag, "
+        "but got offsets of size ", numBags,
+        " with ", numIndices, " indices");
     numBags -= 1;
   }
   int64_t featureSize = weight.size(1);

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -365,6 +365,8 @@ _embedding_bag_cuda(const Tensor &weight, const Tensor &indices_,
   auto weight_arg = TensorArg(weight, "weight", 1);
   checkSameGPU("embedding_bag_cuda", weight_arg, indices_arg);
   checkSameGPU("embedding_bag_cuda", weight_arg, offsets_arg);
+  check_arguments(
+      weight, indices, offsets, mode, per_sample_weights_opt, include_last_offset);
 
   int64_t numIndices = indices.size(0);
   int64_t numBags = offsets.size(0);
@@ -373,8 +375,6 @@ _embedding_bag_cuda(const Tensor &weight, const Tensor &indices_,
     // We plan to add one more element in offsets, which is equal to the size of
     // indices. Currently for cuda devices, we still use the legacy
     // implementation even this flag is enabled.
-    TORCH_CHECK(
-        numBags >= 1, "include_last_offset: numBags should be at least 1");
     numBags -= 1;
   }
   int64_t featureSize = weight.size(1);

--- a/aten/src/ATen/native/mps/operations/EmbeddingBag.mm
+++ b/aten/src/ATen/native/mps/operations/EmbeddingBag.mm
@@ -64,11 +64,12 @@ static std::tuple<Tensor, Tensor, Tensor, Tensor> _embedding_bag_mps_impl(
   checkScalarTypes("embedding_bag_mps", offsets_arg, {kLong, kInt});
   checkSameType("embedding_bag_mps", indices_arg, offsets_arg);
   auto weight_arg = TensorArg(weight, "weight", 1);
+  check_arguments(
+      weight, indices, offsets, mode, per_sample_weights_opt, include_last_offset);
 
   int64_t num_indices = indices.size(0);
   int64_t num_bags = offsets.size(0);
   if (include_last_offset) {
-    TORCH_CHECK(num_bags >= 1, "include_last_offset: number of offsets should be at least 1");
     num_bags -= 1;
   }
   int64_t feature_size = weight.size(1);

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -296,6 +296,26 @@ class TestEmbeddingNN(NNTestCase):
 
 
 class TestEmbeddingNNDeviceType(NNTestCase):
+    def test_embedding_bag_include_last_offset_invalid_offsets(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/190044
+        # Call torch.embedding_bag directly with include_last_offset=True and a
+        # single-element offsets tensor plus non-empty indices — the combination
+        # that previously SEGV'd on CPU (and could OOB on CUDA).
+        weight = torch.randn(5, 3, dtype=torch.float64, device=device)
+        indices = torch.tensor([0, 1, 2], dtype=torch.int64, device=device)
+        offsets = torch.tensor([0], dtype=torch.int64, device=device)
+        with self.assertRaisesRegex(RuntimeError, "include_last_offset"):
+            torch.embedding_bag(
+                weight, indices, offsets, False, 0, False, None, True, None
+            )
+
+        # Verify that 0 bags with 0 indices is fine
+        empty_indices = torch.tensor([], dtype=torch.int64, device=device)
+        result = torch.embedding_bag(
+            weight, empty_indices, offsets, False, 0, False, None, True, None
+        )
+        self.assertEqual(result[0].shape, (0, 3))
+
     def test_embedding_dense_grad(self, device):
         with set_default_dtype(torch.double):
             embd = nn.Embedding(20, 20).to(device)

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -296,6 +296,46 @@ class TestEmbeddingNN(NNTestCase):
 
 
 class TestEmbeddingNNDeviceType(NNTestCase):
+    def test_embedding_bag_include_last_offset_invalid_offsets(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/190044
+        error_msg = (
+            r"embedding_bag: when include_last_offset is True and indices are non-empty, "
+            r"offsets must have at least 2 elements"
+        )
+        indices = torch.tensor([0, 1, 2], dtype=torch.int64, device=device)
+        offsets = torch.tensor([0], dtype=torch.int64, device=device)
+
+        for dtype in (torch.float32, torch.float64):
+            weight = torch.randn(5, 3, dtype=dtype, device=device)
+            for mode in (0, 2):  # SUM and MAX
+                with self.assertRaisesRegex(RuntimeError, error_msg):
+                    torch.embedding_bag(
+                        weight,
+                        indices,
+                        offsets,
+                        False,
+                        mode,
+                        False,
+                        None,
+                        True,
+                        None,
+                    )
+
+        # nn.EmbeddingBag with explicit offsets
+        embeddingbag = nn.EmbeddingBag(
+            5, 3, include_last_offset=True
+        ).to(device=device, dtype=torch.float64)
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            embeddingbag(indices, offsets)
+
+        # 0 bags with 0 indices is still valid
+        empty_indices = torch.tensor([], dtype=torch.int64, device=device)
+        weight = torch.randn(5, 3, dtype=torch.float64, device=device)
+        result = torch.embedding_bag(
+            weight, empty_indices, offsets, False, 0, False, None, True, None
+        )
+        self.assertEqual(result[0].shape, (0, 3))
+
     def test_embedding_dense_grad(self, device):
         with set_default_dtype(torch.double):
             embd = nn.Embedding(20, 20).to(device)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4480,6 +4480,15 @@ def meta_embedding_bag(
             num_bags >= 1,
             lambda: "include_last_offset: numBags should be at least 1",
         )
+        torch._check(
+            num_bags >= 2 or indices.numel() == 0,
+            lambda: (
+                "embedding_bag: when include_last_offset is True and indices are "
+                f"non-empty, offsets must have at least 2 elements to define at "
+                f"least one bag, but got offsets of size {num_bags} with "
+                f"{indices.numel()} indices"
+            ),
+        )
         num_bags -= 1
 
     output = weight.new_empty(num_bags, weight.size(1))
@@ -4541,6 +4550,15 @@ def meta_embedding_bag(
                 torch._check(
                     numBags >= 1,
                     lambda: "include_last_offset: numBags should be at least 1",
+                )
+                torch._check(
+                    numBags >= 2 or indices.numel() == 0,
+                    lambda: (
+                        "embedding_bag: when include_last_offset is True and indices "
+                        f"are non-empty, offsets must have at least 2 elements to "
+                        f"define at least one bag, but got offsets of size {numBags} "
+                        f"with {indices.numel()} indices"
+                    ),
                 )
                 numBags -= 1
             max_indices = offsets.new_empty(numBags, weight.shape[1])


### PR DESCRIPTION
## Summary
- Reject `include_last_offset=True` when offsets has fewer than 2 elements and indices are non-empty (CPU + CUDA)
- Turns ASan SEGV / OOB into a clear `RuntimeError`
- Adds a regression test via direct `torch.embedding_bag` call

Fixes #190044

## Test plan
- `python -m pytest test/nn/test_embedding.py -q`
- CI on this PR

Note: Re-opened after accidental fork deletion (previously #190775)