### PR TITLE
[inductor] Fix CUDA graph output storage reallocation

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -26,6 +26,7 @@ from torch._inductor.cudagraph_trees import (
     AliasesPriorGraphOutput,
     cudagraphify_impl as tree_cudagraphify_impl,
     ExecutionState,
+    StorageWeakRefWrapper,
 )
 from torch._inductor.cudagraph_utils import PlaceholderInfo
 from torch._inductor.test_case import TestCase as InductorTestCase
@@ -151,6 +152,17 @@ class TestCase(InductorTestCase):
 
 
 class CUDAGraphAPIOnlyTests(TestCase):
+    def test_storage_weakref_expires_after_reallocation(self):
+        tensor = torch.empty(1)
+        storage_ref = StorageWeakRefWrapper(tensor)
+        old_data_ptr = tensor.untyped_storage().data_ptr()
+
+        tensor.resize_(1024 * 1024)
+
+        self.assertNotEqual(tensor.untyped_storage().data_ptr(), old_data_ptr)
+        self.assertTrue(storage_ref.data_ptr_changed())
+        self.assertTrue(storage_ref.expired())
+
     def test_mark_warmup_incomplete_without_cudagraphs(self):
         cudagraph_trees = torch._inductor.cudagraph_trees
         containers = cudagraph_trees.get_obj(
@@ -558,6 +570,29 @@ if HAS_CUDA_AND_TRITON:
             )
             self.assertEqual(counters["inductor"]["cudagraph_skips"], 1)
             self.assertIsNone(self.get_manager())
+
+        def test_resize_intermediate_storage_across_graph_break(self):
+            def resize_tensor(x):
+                value = x[0].clone()
+                x.resize_(5)
+                x.zero_()
+                x[0] = value
+                return x
+
+            def fn(x, weight):
+                y = torch.mv(weight, x)
+                y = resize_tensor(y)
+                return y.square()
+
+            x = torch.randn(32, device="cuda")
+            weight = torch.randn(1, 32, device="cuda")
+            compiled_fn = torch.compile(fn, mode="reduce-overhead")
+            for _ in range(3):
+                expected = fn(x, weight)
+                actual = compiled_fn(x, weight)
+                self.assertEqual(actual, expected)
+                x = torch.randn_like(x)
+                weight = torch.randn_like(weight)
 
         @parametrize("backend", ("inductor", "cudagraphs"))
         @torch._dynamo.config.patch("cudagraph_backend_keep_input_mutation", True)

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -613,6 +613,12 @@ class StorageWeakRefWrapper:
     def remove_extra_reference(self) -> None:
         self.extra_ref_check = None
 
+    def data_ptr_changed(self) -> bool:
+        if torch._C._storage_Use_Count(self.ref.cdata) == 0:
+            return False
+        stor = torch.UntypedStorage._new_with_weak_ptr(self.ref.cdata)
+        return stor.data_ptr() != self._data_ptr
+
     def expired(self) -> bool:
         if self.extra_ref_check is not None and not self.extra_ref_check():
             return False
@@ -625,7 +631,14 @@ class StorageWeakRefWrapper:
             stor_count -= 2
         if stor_count < 0:
             raise AssertionError(f"expected stor_count >= 0, got {stor_count}")
-        return stor_count == 0
+        if stor_count == 0:
+            return True
+
+        # Storage metadata mutations such as resize_() can preserve the
+        # StorageImpl while replacing its allocation. This wrapper represents
+        # the allocation that existed when it was created, so it is no longer
+        # live once the storage points at a different address.
+        return self.data_ptr_changed()
 
     def __repr__(self) -> str:
         if self.ref is None or self.ref.expired():
@@ -2371,6 +2384,7 @@ class CUDAGraphTreeManager:
 
         self.id_to_mode: dict[FunctionID, CompilationMode] = {}
         self.id_to_compile_id: dict[FunctionID, CompileId | None] = {}
+        self.storage_reallocated_function_ids: set[FunctionID] = set()
         self.has_live_user_visible_output_cloning = False
 
         # Note: [Backward Generation Handling]
@@ -2461,11 +2475,31 @@ class CUDAGraphTreeManager:
             > torch._inductor.config.triton.cudagraph_unexpected_rerecord_limit
         )
 
+    def _check_for_reallocated_output_storage(self) -> None:
+        if self.current_node is None:
+            return
+
+        for node in self.current_node._path_from_root:
+            function_id = node.wrapped_function.id
+            if function_id in self.storage_reallocated_function_ids:
+                continue
+            if any(
+                output is not None and output.data_ptr_changed()
+                for output in node.outputs_weakrefs
+            ):
+                self.storage_reallocated_function_ids.add(function_id)
+                log_cudagraph_skip_and_bump_counter(
+                    "skipping cudagraphs because an output storage was "
+                    "reallocated outside the compiled graph"
+                )
+
     def _run(self, new_inputs: list[InputType], function_id: FunctionID) -> OutputType:
         # we will try to end the current execution lazily, since
         # we don't want to do unnecessary checking of the existing outputs
         # on the hot path, but both recording and warmup only happen once
         # so we check up front
+        self._check_for_reallocated_output_storage()
+
         if self.in_recording:
             self.try_end_curr_recording(function_id)
 
@@ -2493,9 +2527,11 @@ class CUDAGraphTreeManager:
         # Early exit if the function mutates inputs which are neither parameters/buffers nor
         # cudagraph recorded tensors. This check should happen after `try_end_curr_recording`
         # and `try_end_curr_warmup` which may change self.current_node.
-        if self.non_cudagraph_managed_mutation_hint[node_id][
-            function_id
-        ] or self.exceed_rerecord_limit(node_id, function_id):
+        if (
+            self.non_cudagraph_managed_mutation_hint[node_id][function_id]
+            or self.exceed_rerecord_limit(node_id, function_id)
+            or function_id in self.storage_reallocated_function_ids
+        ):
             return self.ids_to_funcs[function_id].model(new_inputs)
 
         # warming up a function and subsequentally recording may use different memory addresses

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 CUDA graph trees are a safety abstraction over CUDAGraphs, similar to make_graph_callables,
 which share the same memory pool.  Sharing a memory pool is an extremely
 important optimization when chaining multiple CUDA graphs together, as it
@@ -2384,7 +2384,7 @@ class CUDAGraphTreeManager:
 
         self.id_to_mode: dict[FunctionID, CompilationMode] = {}
         self.id_to_compile_id: dict[FunctionID, CompileId | None] = {}
-        self.storage_reallocated_function_ids: set[FunctionID] = set()
+        self.storage_reallocated_function_ids: OrderedSet[FunctionID] = OrderedSet()
         self.has_live_user_visible_output_cloning = False
 
         # Note: [Backward Generation Handling]

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 CUDA graph trees are a safety abstraction over CUDAGraphs, similar to make_graph_callables,
 which share the same memory pool.  Sharing a memory pool is an extremely
 important optimization when chaining multiple CUDA graphs together, as it


### PR DESCRIPTION
Fixes #191589

## Summary

CUDA Graph Trees tracked outputs by their `StorageImpl` lifetime. An eager
`resize_()` across a Dynamo graph break can preserve the `StorageImpl` while
replacing its allocation, leaving the tree with a stale graph-pool data
pointer. Subsequent compiled invocations could then fail memory-pool checks or
attempt to resize non-resizable graph output storage.

This change:

- detects when a tracked output's storage data pointer has changed;
- treats the old allocation reference as expired;
- runs the producing partition without CUDA graphs after an external output
  storage reallocation; and
- adds unit and CUDA regression coverage for repeated calls across the
  `resize_()` graph break.

## Test plan

Tested on an RTX 4090 with a PyTorch nightly build:

- `CUDAGraphAPIOnlyTests.test_storage_weakref_expires_after_reallocation`
- `CudaGraphTreeTests.test_resize_intermediate_storage_across_graph_break`
- five nearby CUDA Graph Trees mutation tests
- original reproducer for 10 iterations with `reduce-overhead`
- original reproducer for 10 iterations with `max-autotune`

All tests and stress iterations passed.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo