### PR TITLE
[cuDNN][SDPA] Declare the attn_mask dtype to cuDNN instead of inheriting the graph io dtype

### DIFF
--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -231,7 +231,7 @@ int roundup_power2(int dim) {
 // query (validate_sdpa_input allows float or query.dtype; bool masks are
 // converted to query.dtype before we get here), so the bias cannot inherit the
 // graph-wide io data type.
-fe::DataType_t bias_data_type(const Tensor& attn_bias) {
+static fe::DataType_t bias_data_type(const Tensor& attn_bias) {
   switch (attn_bias.scalar_type()) {
     case kHalf:
       return fe::DataType_t::HALF;

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -227,9 +227,32 @@ int roundup_power2(int dim) {
   return dim;
 }
 
+// scaled_dot_product_attention accepts an attn_mask whose dtype differs from
+// query (validate_sdpa_input allows float or query.dtype; bool masks are
+// converted to query.dtype before we get here), so the bias cannot inherit the
+// graph-wide io data type.
+fe::DataType_t bias_data_type(const Tensor& attn_bias) {
+  switch (attn_bias.scalar_type()) {
+    case kHalf:
+      return fe::DataType_t::HALF;
+    case kBFloat16:
+      return fe::DataType_t::BFLOAT16;
+    case kFloat:
+      return fe::DataType_t::FLOAT;
+    default:
+      TORCH_CHECK(
+          false,
+          "cuDNN SDPA got attn_bias of unsupported dtype ",
+          attn_bias.scalar_type(),
+          ", expected one of float, half, bfloat16.");
+  }
+}
+
 struct MHAParams {
   c10::DeviceIndex device_id;
   fe::DataType_t dataType;
+  // the mask dtype is not implied by dataType, and it selects a different graph
+  fe::DataType_t biasDataType;
   std::array<int, MAX_MHA_DIM> q_dim;
   std::array<int, MAX_MHA_DIM> k_dim;
   std::array<int, MAX_MHA_DIM> v_dim;
@@ -326,6 +349,7 @@ void setMHAParams(
   }
   // uninit is OK as the struct is memset 0'd
   if (params.has_attn_bias) {
+    params.biasDataType = bias_data_type(attn_bias.value());
     std::copy(
         attn_bias.value().sizes().begin(),
         attn_bias.value().sizes().end(),
@@ -577,12 +601,13 @@ std::unique_ptr<fe::graph::Graph> build_graph(
   auto V_ = mha_graph->tensor(
       fe::graph::Tensor_attributes().set_uid(V).set_name("V"));
   if (attn_bias.has_value()) {
-    scaled_dot_product_flash_attention_options.set_bias(
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(BIAS)
-                              .set_name("bias")
-                              .set_dim(attn_bias.value().sizes().vec())
-                              .set_stride(attn_bias.value().strides().vec())));
+    scaled_dot_product_flash_attention_options.set_bias(mha_graph->tensor(
+        fe::graph::Tensor_attributes()
+            .set_uid(BIAS)
+            .set_name("bias")
+            .set_dim(attn_bias.value().sizes().vec())
+            .set_stride(attn_bias.value().strides().vec())
+            .set_data_type(bias_data_type(attn_bias.value()))));
   }
 
   auto [O_, Stats] =
@@ -963,12 +988,13 @@ std::unique_ptr<fe::graph::Graph> build_graph_backward(
   auto V_ = mha_graph->tensor(
       fe::graph::Tensor_attributes().set_uid(V).set_name("V"));
   if (attn_bias.has_value()) {
-    sdpa_backward_options.set_bias(
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(BIAS)
-                              .set_name("bias")
-                              .set_dim(attn_bias.value().sizes().vec())
-                              .set_stride(attn_bias.value().strides().vec())));
+    sdpa_backward_options.set_bias(mha_graph->tensor(
+        fe::graph::Tensor_attributes()
+            .set_uid(BIAS)
+            .set_name("bias")
+            .set_dim(attn_bias.value().sizes().vec())
+            .set_stride(attn_bias.value().strides().vec())
+            .set_data_type(bias_data_type(attn_bias.value()))));
   }
   if (dropout_probability != 0.0f) {
     auto seed = mha_graph->tensor(fe::graph::Tensor_attributes()

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3913,6 +3913,57 @@ class TestSDPACudaOnly(NNTestCase):
             )
         self.assertEqual(attn_output_math, attn_output_cudnn, atol=5e-3, rtol=3e-3)
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_cudnn_attention_fp32_attn_mask(self, device, dtype):
+        # scaled_dot_product_attention accepts a float32 attn_mask alongside fp16/bf16 q, k, v,
+        # but the cuDNN graph used to declare the bias with the graph-wide io data type, so an
+        # fp32 mask was handed to cuDNN as half and reinterpreted -> silently wrong output and
+        # gradients.
+        batch, num_heads, seq_len, head_dim = 2, 8, 128, 64
+        make_tensor = partial(torch.randn, device=device, dtype=dtype, requires_grad=True)
+        shape = SdpaShape(batch, num_heads, seq_len, head_dim)
+        query, key, value = make_tensor(shape), make_tensor(shape), make_tensor(shape)
+        # one logical mask, expressed in two dtypes with identical values
+        mask = torch.randn(batch, 1, seq_len, seq_len, device=device, dtype=dtype)
+        mask_fp32 = mask.float()
+
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out = F.scaled_dot_product_attention(query, key, value, attn_mask=mask_fp32)
+        with sdpa_kernel(SDPBackend.MATH):
+            ref = F.scaled_dot_product_attention(query, key, value, attn_mask=mask)
+        atol, rtol = (5e-3, 5e-3) if dtype == torch.float16 else (2e-2, 2e-2)
+        self.assertTrue(out.isfinite().all())
+        self.assertEqual(out, ref, atol=atol, rtol=rtol)
+
+        grad_out = torch.randn_like(out)
+        grads = torch.autograd.grad(out, (query, key, value), grad_out)
+        grads_ref = torch.autograd.grad(ref, (query, key, value), grad_out)
+        for grad, grad_ref in zip(grads, grads_ref):
+            self.assertTrue(grad.isfinite().all())
+            self.assertEqual(grad, grad_ref, atol=4 * atol, rtol=4 * rtol)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
+    def test_cudnn_attention_attn_mask_dtype_cache_key(self, device):
+        # The graph cache is keyed on the bias sizes and strides only, so masks that differ
+        # just in dtype collide and the second call reuses a graph built for the first dtype.
+        dtype = torch.float16
+        batch, num_heads, seq_len, head_dim = 2, 8, 128, 64
+        make_tensor = partial(torch.randn, device=device, dtype=dtype)
+        shape = SdpaShape(batch, num_heads, seq_len, head_dim)
+        query, key, value = make_tensor(shape), make_tensor(shape), make_tensor(shape)
+        mask = torch.randn(batch, 1, seq_len, seq_len, device=device, dtype=dtype)
+        mask_fp32 = mask.float()
+        self.assertEqual(mask.stride(), mask_fp32.stride())
+
+        with sdpa_kernel(SDPBackend.MATH):
+            ref = F.scaled_dot_product_attention(query, key, value, attn_mask=mask)
+        # the first dtype seen builds the cached graph, so check both orderings
+        for m in (mask, mask_fp32, mask, mask_fp32):
+            with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                out = F.scaled_dot_product_attention(query, key, value, attn_mask=m)
+            self.assertEqual(out, ref, atol=5e-3, rtol=5e-3, msg=f"wrong result for a {m.dtype} mask")
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("mask_dim", [1, 2, 3, 4])
     def test_mem_efficient_attention_mask_variants(self, device, mask_dim: list[int]):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3929,23 +3929,30 @@ class TestSDPACudaOnly(NNTestCase):
         make_tensor = partial(torch.randn, device=device, dtype=dtype, requires_grad=True)
         shape = SdpaShape(batch, num_heads, seq_len, head_dim)
         query, key, value = make_tensor(shape), make_tensor(shape), make_tensor(shape)
-        # one logical mask, expressed in both dtypes with identical values and strides
         mask = torch.randn(batch, 1, seq_len, seq_len, device=device, dtype=dtype)
-        other = mask.float() if mask_dtype is torch.float32 else mask
-        self.assertEqual(mask.stride(), other.stride())
+        if mask_dtype is None:
+            masks = (mask,)   # control: the matched-dtype path must stay correct
+        else:
+            # the same logical mask in the other dtype, with identical sizes and strides, so
+            # before the dtype entered the key these two shared one cached plan. Alternate them
+            # so both orders are exercised regardless of the order pytest runs the variants in.
+            other = mask.to(mask_dtype)
+            self.assertEqual(mask.stride(), other.stride())
+            masks = (mask, other, mask, other)
 
         atol, rtol = (5e-3, 5e-3) if dtype == torch.float16 else (2e-2, 2e-2)
         with sdpa_kernel(SDPBackend.MATH):
             ref = F.scaled_dot_product_attention(query, key, value, attn_mask=mask)
 
-        # alternate the dtypes so the cached plan is exercised in both orders, independently of
-        # the order pytest happens to run the parametrized variants in
-        for m in (mask, other, mask, other):
+        for m in masks:
             with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
                 out = F.scaled_dot_product_attention(query, key, value, attn_mask=m)
             self.assertTrue(out.isfinite().all(), f"non-finite output for a {m.dtype} mask")
             self.assertEqual(out, ref, atol=atol, rtol=rtol, msg=f"wrong result for a {m.dtype} mask")
 
+        # autograd.grad is intentionally outside the sdpa_kernel context: the backward op is fixed
+        # by the autograd node recorded during the forward, so it still dispatches to
+        # _scaled_dot_product_cudnn_attention_backward.
         grad_out = torch.randn_like(out)
         grads = torch.autograd.grad(out, (query, key, value), grad_out)
         grads_ref = torch.autograd.grad(ref, (query, key, value), grad_out)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3915,26 +3915,36 @@ class TestSDPACudaOnly(NNTestCase):
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     @parametrize("dtype", [torch.float16, torch.bfloat16])
-    def test_cudnn_attention_fp32_attn_mask(self, device, dtype):
-        # scaled_dot_product_attention accepts a float32 attn_mask alongside fp16/bf16 q, k, v,
-        # but the cuDNN graph used to declare the bias with the graph-wide io data type, so an
-        # fp32 mask was handed to cuDNN as half and reinterpreted -> silently wrong output and
-        # gradients.
+    @parametrize("mask_dtype", [torch.float32, None])
+    def test_cudnn_attention_attn_mask_dtype(self, device, dtype, mask_dtype):
+        # scaled_dot_product_attention accepts an attn_mask that is float32 as well as one matching
+        # query's dtype. The cuDNN graph declared the bias with the graph-wide io data type, so an
+        # fp32 mask reached cuDNN described as half and was reinterpreted element by element:
+        # silently wrong output and gradients. mask_dtype=None is the matched-dtype control.
+        #
+        # Both dtypes are issued back to back at one shape. They have identical sizes and strides,
+        # so before the bias dtype was added to the execution-plan cache key they shared one
+        # cached plan and the result depended on which dtype the process saw first.
         batch, num_heads, seq_len, head_dim = 2, 8, 128, 64
         make_tensor = partial(torch.randn, device=device, dtype=dtype, requires_grad=True)
         shape = SdpaShape(batch, num_heads, seq_len, head_dim)
         query, key, value = make_tensor(shape), make_tensor(shape), make_tensor(shape)
-        # one logical mask, expressed in two dtypes with identical values
+        # one logical mask, expressed in both dtypes with identical values and strides
         mask = torch.randn(batch, 1, seq_len, seq_len, device=device, dtype=dtype)
-        mask_fp32 = mask.float()
+        other = mask.float() if mask_dtype is torch.float32 else mask
+        self.assertEqual(mask.stride(), other.stride())
 
-        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            out = F.scaled_dot_product_attention(query, key, value, attn_mask=mask_fp32)
+        atol, rtol = (5e-3, 5e-3) if dtype == torch.float16 else (2e-2, 2e-2)
         with sdpa_kernel(SDPBackend.MATH):
             ref = F.scaled_dot_product_attention(query, key, value, attn_mask=mask)
-        atol, rtol = (5e-3, 5e-3) if dtype == torch.float16 else (2e-2, 2e-2)
-        self.assertTrue(out.isfinite().all())
-        self.assertEqual(out, ref, atol=atol, rtol=rtol)
+
+        # alternate the dtypes so the cached plan is exercised in both orders, independently of
+        # the order pytest happens to run the parametrized variants in
+        for m in (mask, other, mask, other):
+            with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                out = F.scaled_dot_product_attention(query, key, value, attn_mask=m)
+            self.assertTrue(out.isfinite().all(), f"non-finite output for a {m.dtype} mask")
+            self.assertEqual(out, ref, atol=atol, rtol=rtol, msg=f"wrong result for a {m.dtype} mask")
 
         grad_out = torch.randn_like(out)
         grads = torch.autograd.grad(out, (query, key, value), grad_out)
@@ -3942,27 +3952,6 @@ class TestSDPACudaOnly(NNTestCase):
         for grad, grad_ref in zip(grads, grads_ref):
             self.assertTrue(grad.isfinite().all())
             self.assertEqual(grad, grad_ref, atol=4 * atol, rtol=4 * rtol)
-
-    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
-    def test_cudnn_attention_attn_mask_dtype_cache_key(self, device):
-        # The graph cache is keyed on the bias sizes and strides only, so masks that differ
-        # just in dtype collide and the second call reuses a graph built for the first dtype.
-        dtype = torch.float16
-        batch, num_heads, seq_len, head_dim = 2, 8, 128, 64
-        make_tensor = partial(torch.randn, device=device, dtype=dtype)
-        shape = SdpaShape(batch, num_heads, seq_len, head_dim)
-        query, key, value = make_tensor(shape), make_tensor(shape), make_tensor(shape)
-        mask = torch.randn(batch, 1, seq_len, seq_len, device=device, dtype=dtype)
-        mask_fp32 = mask.float()
-        self.assertEqual(mask.stride(), mask_fp32.stride())
-
-        with sdpa_kernel(SDPBackend.MATH):
-            ref = F.scaled_dot_product_attention(query, key, value, attn_mask=mask)
-        # the first dtype seen builds the cached graph, so check both orderings
-        for m in (mask, mask_fp32, mask, mask_fp32):
-            with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-                out = F.scaled_dot_product_attention(query, key, value, attn_mask=m)
-            self.assertEqual(out, ref, atol=5e-3, rtol=5e-3, msg=f"wrong result for a {m.dtype} mask")
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("mask_dim", [1, 2, 3, 4])


### PR DESCRIPTION
## The bug

`scaled_dot_product_attention` accepts an `attn_mask` whose dtype differs from `query` —
`validate_sdpa_input` allows `bool`, `float32`, or `query.dtype`. The cuDNN backend does not honour
that: `aten/src/ATen/native/cudnn/MHA.cpp` derives one graph-wide io data type from `query`, and
creates the bias tensor with dim and stride but no data type of its own, so an fp32 mask is
described to cuDNN as fp16/bf16 and reinterpreted element by element. Output and gradients are
silently wrong — no exception, no warning.

This is the default path on SM 9.0 / 10.x, where `check_prefer_cudnn_attention()` puts cuDNN first
when the runtime cuDNN is newer than 9.15.

It takes no unusual code to hit. `nn.Transformer.generate_square_subsequent_mask` returns float32
regardless of the module's dtype:

```python
S, E, H = 32, 64, 4
mask = nn.Transformer.generate_square_subsequent_mask(S, device="cuda")   # torch.float32
mha = nn.MultiheadAttention(E, H, batch_first=True).cuda().half().eval()
x = torch.randn(2, S, E, device="cuda", dtype=torch.float16)
out, _ = mha(x, x, x, attn_mask=mask, need_weights=False)
torch.isnan(out).float().mean()      # 0.969
```

The memory-efficient backend rejects the same input loudly
(`invalid dtype for bias - should match query's dtype`); cuDNN accepts it and misreads it.

With finite mask values rather than the `-inf` of a causal mask, the output is finite but
numerically wrong instead of NaN, which is easier to miss.

## The fix

Declare the bias with its actual dtype at the two live construction sites, forward and backward.
cuDNN supports a float bias with half io, so nothing is cast — keeping the mask in fp32 avoids both
an extra device-side copy of the largest tensor in the graph and the precision loss of folding
large-magnitude fp32 mask values into half.

The bias dtype also has to enter the execution-plan cache key. `MHAParams` records the bias sizes
and strides only and the cache hashes the struct byte-for-byte, so two calls differing only in mask
dtype currently share one plan; whichever dtype the process saw first wins, which is why this can
present as intermittent. `MHAParams` is `memset` to zero before use, so the no-bias case is a
deterministic value whatever enumerator happens to be zero, and the hash is stable. The new field
sits immediately after the existing `fe::DataType_t dataType`, so the struct grows by exactly four
bytes with no new padding hole — which matters because `ParamsHash` reads `sizeof(MHAParams)` bytes
raw.

## Evidence

A/B on one build — same commit, same cuDNN 9.26, only `MHA.cpp` differs:

| | forward/backward matrix (12 cases) | new tests, SM 10.0 | new tests, SM 9.0 |
|---|---|---|---|
| `origin/main` | **9 fail** | **3 failed** | **3 failed** |
| this PR | **0 fail** | **3 passed** | **3 passed** |

<details>
<summary>The failing cases on <code>origin/main</code>, output compared against the MATH backend in fp32</summary>

```
  fwd  qkv=float16  mask=float16    finite=True   max_abs_err=5.0e-04    OK    <- control
  fwd  qkv=float16  mask=float32    finite=False  max_abs_err=nan        FAIL
  fwd  qkv=bfloat16 mask=bfloat16   finite=True   max_abs_err=3.9e-03    OK    <- control
  fwd  qkv=bfloat16 mask=float32    finite=False  max_abs_err=nan        FAIL

  bwd  qkv=float16  mask=float32  dQ/dK/dV        all non-finite         FAIL
  bwd  qkv=bfloat16 mask=float32  dQ/dK/dV        all non-finite         FAIL

  cache  same-dtype mask first                    finite=True            OK
  cache  then fp32 mask, identical shape          finite=False           FAIL
```

The matched-dtype rows are controls and are unaffected either way. With finite mask values the
forward rows give max abs diff 2.986 over 99.1% of elements instead of NaN.
</details>

## Tests

Three tests in `test/test_transformers.py`, beside the existing cuDNN attention coverage: forward
across fp16/bf16 with matched and fp32 masks (matched cases are the control), backward checking
dQ/dK/dV, and one that issues both mask dtypes at the same shape in one process, which fails
without the cache-key change.

## Why existing tests did not catch it

The cuDNN mask tests in `test_transformers.py` use either bool masks — which
`native/transformers/attention.cpp` canonicalizes to an additive mask in `query`'s dtype before
dispatch, so they never reach cuDNN as bool — or floating masks already matching `query`'s dtype
(`torch.zeros_like(attn_mask, dtype=query.dtype)`). None covers an fp32 additive mask against
fp16/bf16 q, k, v.

## Not included

The backward graph also bakes `grad_output`'s layout into the cached plan without recording it in
the key. Different root cause, separate reproducer, separate PR; this one stays scoped to the bias
dtype.

## Caveats

- Verified on SM 9.0 and SM 10.0. The build used here targets those two architectures only, so the
  fix has not been *executed* on SM 8.0/8.9; on those the failure reproduces on `main` but cuDNN is
  not the preferred backend. SM 12.x was not available.
- No performance measurement yet. An fp32 bias may select a different engine and does read more
  bias data than a half one; that is a performance question to measure, not a reason to keep an
  incorrect dtype declaration.
- `bias_data_type` rejects dtypes other than half/bfloat16/float. Bool cannot reach it through
  `F.scaled_dot_product_attention`; a direct call to the raw ATen op can still pass one and will now
  get a clear error instead of a silently misread buffer.


## AI assistance disclosure

Per [`AI_POLICY.md`](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md): this change was
prepared with AI assistance (Claude Code). Concretely, the agent was used to investigate the cuDNN
SDPA integration layer, to draft the diff and the tests, and to run the measurements — the A/B table
and the failing-case matrix above are its output, reproduced on the hardware named beside them.

The parts that were not the agent's:

- The investigation turned up a second claim, that the cuDNN dropout guard needlessly rejects
  `dropout_p = 0.1`. That is wrong and was discarded: cuDNN's SDPA dropout uses a 4-bit RNG, so the
  realised probability is quantised to multiples of 1/16 and the guard is correct. The tool had only
  measured that the call succeeds, not the realised drop rate. Mentioning it because it is the
  reason I do not treat the rest of the output as self-certifying.
- An independent review pass before submitting produced two corrections that are already folded in:
  the original text misidentified why the existing tests miss this (bool masks are canonicalised to
  `query.dtype` in `native/transformers/attention.cpp`, so they never reach cuDNN as bool), and it
  asserted the fix "costs nothing in performance", which the evidence does not support — that claim
  is now stated as an open measurement in Caveats.

I have read the diff and the surrounding code, understand the change, and take responsibility for
it. Happy to walk through any part of the reasoning that would be easier to check in review than in
prose.


