### PR TITLE
Fix CPU/CUDA precision mismatch in linspace for integer dtypes

### DIFF
--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -128,8 +128,9 @@ Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps,
     AT_DISPATCH_INTEGRAL_TYPES(r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
-      // Cast `end` and `start` to `float`, since range can be larger than scalar_t for integral types
-      float step = (static_cast<float>(scalar_end) - static_cast<float>(scalar_start)) / (steps - 1);
+      // Match CPU (RangeFactoriesKernel.cpp): use double for the step so integer
+      // linspace produces identical results on every device.
+      double step = (static_cast<double>(scalar_end) - static_cast<double>(scalar_start)) / (steps - 1);
       const int64_t halfway = steps / 2;
       gpu_kernel_with_index(r, [scalar_start, scalar_end, steps, step, halfway]GPU_LAMBDA(int64_t ind) -> scalar_t {
         if (ind < halfway) {

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3128,6 +3128,19 @@ class TestTensorCreation(TestCase):
         # Test deduction from input parameters.
         self._test_linspace_logspace_deduction_helper(torch.logspace, device)
 
+    @dtypes(torch.int16, torch.int32, torch.int64)
+    def test_linspace_integral(self, device, dtype):
+        cases = [
+            (3.7, -3, 10),
+            (0, 100, 2),
+            (-50, 50, 1000),
+            (0, 2**31, 500),
+        ]
+        for start, end, steps in cases:
+            cpu = torch.linspace(start, end, steps, dtype=dtype, device="cpu")
+            dev = torch.linspace(start, end, steps, dtype=dtype, device=device)
+            self.assertEqual(cpu, dev.cpu())
+
     # The implementation of linspace+logspace goes through a different path
     # when the steps arg is equal to 0 or 1. For other values of `steps`
     # they call specialized linspace (or logspace) kernels.


### PR DESCRIPTION
The CUDA linspace kernel used float for the step computation when the output dtype is integral, while the CPU kernel uses double. This causes CPU and CUDA to produce different int64 results for the same inputs.

Use double for the integral CUDA path to match RangeFactoriesKernel.cpp.

Fixes: https://github.com/pytorch/pytorch/issues/181807