### PR TITLE
Fix mse_loss and smooth_l1_loss allocating oversized storage for scal…

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -76,26 +76,32 @@ namespace at::meta {
 TORCH_META_FUNC(smooth_l1_loss)
 (const Tensor& input, const Tensor& target, const int64_t reduction, double beta) {
   TORCH_CHECK(beta >= 0, "smooth_l1_loss does not support negative values for beta.")
-  // TODO: Reduce this extra TensorIterator construction for Reduction::Mean & Sum.
-  // We do another TensorIterator construction in the IMPL for the two cases.
+  // build_borrowing_binary_op is needed even for mean/sum to properly
+  // configure dtype promotion and dispatch for tensor subclasses.
   build_borrowing_binary_op(maybe_get_output(), input, target);
-  if (reduction == Reduction::None) {
-    return;
+  if (reduction != Reduction::None) {
+    TORCH_INTERNAL_ASSERT(reduction == Reduction::Mean || reduction == Reduction::Sum);
+    auto& output = maybe_get_output();
+    output.resize_({});
+    // Shrink storage to match scalar output size instead of keeping
+    // the full input-sized allocation (fixes #185647).
+    auto itemsize = output.dtype().itemsize();
+    output.storage().set_nbytes(itemsize);
   }
-
-  TORCH_INTERNAL_ASSERT(reduction == Reduction::Mean || reduction == Reduction::Sum);
-  maybe_get_output().resize_({});
 }
 
 TORCH_META_FUNC(mse_loss)
 (const Tensor& input, const Tensor& target, const int64_t reduction) {
   build_borrowing_binary_op(maybe_get_output(), input, target);
-  if (reduction == Reduction::None) {
-    return;
+  if (reduction != Reduction::None) {
+    TORCH_INTERNAL_ASSERT(reduction == Reduction::Mean || reduction == Reduction::Sum);
+    auto& output = maybe_get_output();
+    output.resize_({});
+    // Shrink storage to match scalar output size instead of keeping
+    // the full input-sized allocation (fixes #185647).
+    auto itemsize = output.dtype().itemsize();
+    output.storage().set_nbytes(itemsize);
   }
-
-  TORCH_INTERNAL_ASSERT(reduction == Reduction::Mean || reduction == Reduction::Sum);
-  maybe_get_output().resize_({});
 }
 
 } // namespace at::meta

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2388,6 +2388,20 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.assertEqual(len(w), 1)
             self.assertIn('Please ensure they have the same size.', str(w[0]))
 
+    def test_loss_reduction_storage_size(self):
+        # https://github.com/pytorch/pytorch/issues/185647
+        x = torch.rand(3, 256, 256)
+        y = torch.rand(3, 256, 256)
+        scalar_bytes = x.element_size()
+        for reduction in ("mean", "sum"):
+            mse = F.mse_loss(x, y, reduction=reduction)
+            self.assertEqual(mse.shape, torch.Size([]))
+            self.assertEqual(mse.untyped_storage().nbytes(), scalar_bytes)
+
+            sl1 = F.smooth_l1_loss(x, y, reduction=reduction)
+            self.assertEqual(sl1.shape, torch.Size([]))
+            self.assertEqual(sl1.untyped_storage().nbytes(), scalar_bytes)
+
     def test_weighted_mse_loss(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
         targets = torch.tensor([1.5, 2.5, 3.5, 4.5])


### PR DESCRIPTION
…ar output

When reduction is 'mean' or 'sum', the meta function called build_borrowing_binary_op() which allocated full input-sized storage, then resize_({}) which only changed shape metadata without shrinking storage. This caused scalar loss outputs to hold storage equal to the full input tensor size.

Fix by keeping build_borrowing_binary_op() for proper dispatch/metadata configuration, then calling storage().set_nbytes(itemsize) after resize_({}) to shrink the reported storage to scalar size.

Fixes pytorch#185647