### PR TITLE
[ROCm] Drop redundant (char) cast in flash attention CUDAGuard

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
@@ -332,7 +332,7 @@ mha_varlen_fwd_aot(const at::Tensor &q,  // total_q x num_heads x head_size, tot
   TORCH_CHECK(!paged_KV, "[ROCm] mha_varlen_fwd: block_table_ must be nullopt");
   TORCH_CHECK(!alibi_slopes_.has_value(), "[ROCm] mha_varlen_fwd: alibi_slopes_ must be nullopt");
 
-  at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+  at::cuda::CUDAGuard device_guard{q.get_device()};
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   check_gpu_arch(stream);
 
@@ -535,8 +535,7 @@ mha_bwd_aot(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x hea
         const at::Tensor& philox_seed,
         const at::Tensor& philox_offset) {
   // Otherwise the kernel will be launched from cuda:0 device
-  // Cast to char to avoid compiler warning about narrowing
-  at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+  at::cuda::CUDAGuard device_guard{q.get_device()};
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   check_gpu_arch(stream);
 
@@ -717,8 +716,7 @@ mha_varlen_bwd_aot(const at::Tensor &dout,  // total_q x num_heads, x head_size
   TORCH_CHECK(!alibi_slopes_.has_value(), "[ROCm] mha_varlen_fwd: alibi_slopes_ must be nullopt");
 
   // Otherwise the kernel will be launched from cuda:0 device
-  // Cast to char to avoid compiler warning about narrowing
-  at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+  at::cuda::CUDAGuard device_guard{q.get_device()};
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   check_gpu_arch(stream);
 

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
@@ -455,8 +455,7 @@ mha_bwd_ck(const at::Tensor &dout,                   // batch_size x seqlen_q x 
         dout_padded = dout;
     }
 
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     auto softmax_d = at::empty({batch_size, num_heads, seqlen_q}, opts.dtype(at::kFloat));

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -362,8 +362,7 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     const int head_size_8x = round_multiple(head_size, 8);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     bool has_lse = true;

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
@@ -473,8 +473,7 @@ mha_varlen_bwd_ck(const at::Tensor &dout,                   // total_q x num_hea
         dout_padded = dout;
     }
 
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     auto softmax_d = at::empty({batch_size, num_heads, max_seqlen_q}, opts.dtype(at::kFloat));

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
@@ -303,8 +303,7 @@ mha_varlen_fwd_ck(const at::Tensor &q,                   // total_q x num_heads 
     const int head_size_8x = round_multiple(head_size_og, 8);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     bool has_lse = true;


### PR DESCRIPTION
Fixes #191564

`at::TensorBase::get_device()` already returns `c10::DeviceIndex` (`int8_t`, i.e.
`signed char`), so the `(char)` cast in
`at::cuda::CUDAGuard device_guard{(char)q.get_device()};` does nothing useful. On
ppc64le and aarch64, where plain `char` is unsigned, it turns an exact-type
argument into a narrowing conversion of a non-constant expression inside a
braced-init-list, which clang rejects with `-Wc++11-narrowing`. On x86-64 plain
`char` is signed, the conversion is the identity, and nothing fires, so this only
breaks ppc64le builds.

This drops the cast at all 7 sites in the 5 ROCm flash-attention sources, plus
the 6 `// Cast to char to avoid compiler warning about narrowing` comments that
document it. `{q.get_device()}` binds the same `CUDAGuard(DeviceIndex)` overload
the code already intended, so there is no behavior change.

The issue proposed `{q.device()}`, which is also correct, but that switches to
the `CUDAGuard(Device)` overload and picks up an extra device-type `TORCH_CHECK`.
Removing a redundant cast is narrower. `transformers/cuda/flash_attn/flash_api.cpp`
has 5 similar `static_cast<signed char>(q.get_device())` casts that are equally
redundant but not broken, since `signed char` is `DeviceIndex`. Left alone.

Verified: I do not have ROCm or ppc64le, so I checked the language rule directly.
A harness extracts all 7 `CUDAGuard device_guard{...}` statements verbatim from
the five files, compiles them against the real `<c10/cuda/CUDAGuard.h>` with gcc
15.2 and `-funsigned-char -Werror=narrowing` (the ppc64le plain-`char` default),
and reports the diagnostic before the change and nothing after. The four CK line
numbers it flags, 366 / 459 / 307 / 477, match the ones @ameilkumar-ibm got from
AMD clang 23. Without `-funsigned-char` it is clean before and after, which
matches this being ppc64le-only. The `.lintrunner.toml` linters that match these
paths are clean.

Not verified: I did not build the actual HIP translation units and did not run
ROCm flash attention. @ameilkumar-ibm did, on 2x MI210 with ROCm 7.14 and AMD
clang 23: all five TUs compiled clean, the full build succeeded, and a two-GPU
smoke test passed. Thanks for the report and the root-cause analysis.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang