### PR TITLE
Fix editable CMake prefix path

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
@@ -36,7 +36,7 @@ def get_pytorch_dir():
     os.environ["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
     import torch
 
-    return os.path.dirname(os.path.realpath(torch.__file__))
+    return os.path.dirname(os.path.realpath(torch._C.__file__))
 
 
 def build_deps():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -961,6 +961,12 @@ instantiate_device_type_tests(TestDeviceUtils, globals())
 
 
 class TestCppExtensionUtils(TestCase):
+    @unittest.skipIf(IS_FBCODE, "CMake package files are not available in fbcode")
+    def test_cmake_prefix_path(self):
+        expected = os.path.join(os.path.dirname(torch._C.__file__), "share", "cmake")
+        self.assertEqual(torch.utils.cmake_prefix_path, expected)
+        self.assertTrue(os.path.isdir(torch.utils.cmake_prefix_path))
+
     def test_cpp_compiler_is_ok(self):
         self.assertTrue(torch.utils.cpp_extension.check_compiler_ok_for_platform("c++"))
 

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -29,7 +29,7 @@ def set_module(obj, mod):
     obj.__module__ = mod
 
 
-cmake_prefix_path = _osp.join(_osp.dirname(_osp.dirname(__file__)), "share", "cmake")
+cmake_prefix_path = _osp.join(_osp.dirname(torch._C.__file__), "share", "cmake")
 
 
 def swap_tensors(t1, t2):


### PR DESCRIPTION
I reproduced this issue while testing a local editable PyTorch build: OpenReg could not locate the installed CMake configuration files. This fix makes the development setup more reliable for contributors building C++ extensions.

> **AI-assisted summary**
>
> Editable installs load Python modules from the source tree while compiled modules and package data remain in the physical installation directory. Deriving package paths from Python module `__file__` values therefore makes `torch.utils.cmake_prefix_path` point to a source directory without the installed CMake metadata.
>
> The OpenReg extension setup used the same assumption, preventing its nested CMake build from finding `TorchConfig.cmake`. Derive both paths from `torch._C.__file__`, which remains in the physical package directory for regular and editable installs.
>
> Add regression coverage for the public CMake prefix path.
>
> **Test plan**
>
> ```bash
> PATH="$PWD/venv/bin:$PATH" python test/test_utils.py TestCppExtensionUtils
> PATH="$PWD/venv/bin:$PATH" python test/run_test.py --openreg
> PATH="$PWD/venv/bin:$PATH" lintrunner -a
> ```
>
> This summary was prepared with an AI coding assistant. I reviewed the implementation, test results, and PR text and take responsibility for the contribution.

cc @malfet @zklaus