### PR TITLE
[TEST] Refactor test/distributed/tensor/test_xla_integration.py with hw_classification

### DIFF
--- a/test/distributed/tensor/test_xla_integration.py
+++ b/test/distributed/tensor/test_xla_integration.py
@@ -18,7 +18,11 @@ from torch.distributed.tensor import (
     Replicate,
     Shard,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 # wrapper to check xla test requirements
@@ -46,6 +50,8 @@ def with_xla(func: Callable) -> Callable:
 
 
 class DTensorXLAIntegrationTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     class SimpleLinear(nn.Module):
         def __init__(self) -> None:
             super(DTensorXLAIntegrationTest.SimpleLinear, self).__init__()
@@ -149,7 +155,7 @@ class DTensorXLAIntegrationTest(TestCase):
                     self.assertTrue(dist_tensor.is_leaf)
 
     @with_xla
-    def text_xla_distribute_module(self):
+    def test_xla_distribute_module(self):
         import torch_xla  # type:ignore[import]
         import torch_xla.core.xla_model as xm  # type:ignore[import]
         import torch_xla.runtime as xr  # type:ignore[import]


### PR DESCRIPTION
## Summary

Adds `hw_classification` to `test/distributed/tensor/test_xla_integration.py` following the community test refactoring initiative (#186918).

## Changes

**Classification**

- **`DTensorXLAIntegrationTest`** → `GENERIC`: All 4 test methods are guarded by the `@with_xla` decorator, which auto-skips when `torch_xla` is not installed and sets `self.device_type = "xla"`. `HardwareClassification` has no XLA enum value; GENERIC is the least-harmful choice since the decorator already handles all hardware routing — these tests are invisible to non-XLA CI runs regardless of the classification label.

**Pre-existing bug fixed during audit:**

- `test_xla_distribute_module` had a `text_` prefix typo that silently prevented the test runner from ever discovering the method. Renamed to `test_` to restore it to the suite (net effect: 3 → 4 discovered test methods).

## Test Plan

```
python -m pytest test/distributed/tensor/test_xla_integration.py -v
# 4 tests skipped (torch_xla not installed in this environment)

python test/distributed/tensor/test_xla_integration.py --hw-classification GENERIC -v
# 4 tests skipped OK
```

## Notes

`HardwareClassification` currently has no XLA enum value (only GENERIC, ACCELERATOR, CPU, CUDA, MPS, XPU). XLA registers itself as a downstream extension via `TORCH_TEST_DEVICES` and manages its own test routing in the `pytorch/xla` repo. Adding `HardwareClassification.XLA` to core is not warranted given only one dedicated XLA test file exists in this repo.

cc: @mansiag05 