### PR TITLE
docs: add PyTorch version information

### DIFF
--- a/docs/source/pytorch-api.md
+++ b/docs/source/pytorch-api.md
@@ -89,6 +89,7 @@ torch.utils.tensorboard <tensorboard>
 torch.utils.module_tracker <module_tracker>
 type_info
 torch.__config__ <config_mod>
+torch.__version__ <torch>
 torch.__future__ <future_mod>
 logging
 torch_environment_variables

--- a/docs/source/torch.md
+++ b/docs/source/torch.md
@@ -35,22 +35,6 @@
     set_flush_denormal
 ```
 
-(version-information)=
-## Version information
-
-``torch.__version__`` reports the installed PyTorch version. The ``torch.version``
-module contains build metadata for optional backends, such as ``torch.version.cuda``
-and ``torch.version.hip``; these values can be ``None`` when the corresponding
-backend is not included in the build.
-
-.. code-block:: python
-
-    import torch
-
-    print(torch.__version__)
-    print(torch.version.cuda)
-    print(torch.version.hip)
-
 (tensor-creation-ops)=
 
 ### Creation Ops

--- a/docs/source/torch.md
+++ b/docs/source/torch.md
@@ -35,6 +35,22 @@
     set_flush_denormal
 ```
 
+(version-information)=
+## Version information
+
+``torch.__version__`` reports the installed PyTorch version. The ``torch.version``
+module contains build metadata for optional backends, such as ``torch.version.cuda``
+and ``torch.version.hip``; these values can be ``None`` when the corresponding
+backend is not included in the build.
+
+.. code-block:: python
+
+    import torch
+
+    print(torch.__version__)
+    print(torch.version.cuda)
+    print(torch.version.hip)
+
 (tensor-creation-ops)=
 
 ### Creation Ops


### PR DESCRIPTION
## Summary

- Add a discoverable version information section to the Python API docs.
- Document `torch.__version__` and backend build metadata such as `torch.version.cuda` and `torch.version.hip`.

Closes #32864