### PR TITLE
[PU1] Remove skip decorator from test_backend_simple due to resolved CI issues

### DIFF
--- a/test/test_privateuseone_python_backend.py
+++ b/test/test_privateuseone_python_backend.py
@@ -38,6 +38,13 @@ def wrap(arr, shape, dtype):
     return MyDeviceTensor(shape, dtype, arr)
 
 
+def wrap_view(source, arr, shape, strides, storage_offset=0):
+    res = torch._C._acc.create_view_tensor(source, shape, strides, storage_offset)
+    res.__class__ = MyDeviceTensor
+    res.raw_data = arr
+    return res
+
+
 def unwrap(arr):
     return arr.raw_data
 
@@ -113,7 +120,14 @@ def ones_like(
 @torch.library.impl("aten::expand", "privateuseone")
 def expand(self, size, *, implicit=False):
     ans = np.broadcast_to(self.raw_data, size)
-    return wrap(ans, ans.shape, torch.float32)
+    offset = len(size) - self.dim()
+    in_shape, in_strides = list(self.shape), list(self.stride())
+    strides = [0] * len(size)
+    for j in range(len(size)):
+        i = j - offset
+        if i >= 0 and not (in_shape[i] == 1 and size[j] != 1):
+            strides[j] = in_strides[i]
+    return wrap_view(self, ans, tuple(size), tuple(strides), self.storage_offset())
 
 
 @torch.library.impl("aten::as_strided", "privateuseone")

--- a/test/test_privateuseone_python_backend.py
+++ b/test/test_privateuseone_python_backend.py
@@ -1,6 +1,4 @@
 # Owner(s): ["module: PrivateUse1"]
-import unittest
-
 import numpy as np
 
 import torch
@@ -140,10 +138,6 @@ class PrivateUse1BackendTest(TestCase):
         # Assert this don't throw:
         _ = a_cpu.is_pinned()
 
-    @unittest.skip(
-        "Disabled due to CI failures; see "
-        "https://github.com/pytorch/pytorch/issues/190232"
-    )
     def test_backend_simple(self):
         a_cpu = torch.randn((2, 2))
         b_cpu = torch.randn((2, 2))

--- a/torch/csrc/acc/Module.cpp
+++ b/torch/csrc/acc/Module.cpp
@@ -165,6 +165,21 @@ at::Tensor createEmptyTensor(
   tensor.unsafeGetTensorImpl()->set_sizes_and_strides(shape, strides, 0);
   return tensor;
 }
+
+at::Tensor createViewTensor(
+    const at::Tensor& source,
+    const std::vector<int64_t>& size,
+    const std::vector<int64_t>& stride,
+    int64_t storage_offset) {
+  at::Tensor tensor = at::detail::make_tensor<at::TensorImpl>(
+      at::TensorImpl::VIEW,
+      c10::Storage(source.storage()),
+      source.key_set(),
+      source.dtype());
+  tensor.unsafeGetTensorImpl()->set_sizes_and_strides(
+      size, stride, storage_offset);
+  return tensor;
+}
 } // namespace
 
 void initModule(PyObject* module) {
@@ -192,6 +207,7 @@ void initModule(PyObject* module) {
       "register_python_privateuseone_device_guard",
       &registerPythonPrivateUse1DeviceGuard);
   _acc.def("create_empty_tensor", &createEmptyTensor);
+  _acc.def("create_view_tensor", &createViewTensor);
 }
 
 } // namespace torch::acc


### PR DESCRIPTION
Fixes #188688


## Summary

`test_backend_simple` was failing in PyTorch's debug-build CI jobs (e.g. `linux-jammy-cuda13.2-py3.10-gcc11-debug`) because the test's custom PrivateUse1 backend implementation of `expand` returned a freshly-allocated tensor instead of one that shares its input's storage. Sample error output is shown below.

````txt
2026-07-31T07:04:13.9383211Z =================================== FAILURES ===================================
2026-07-31T07:04:13.9383700Z __________________ PrivateUse1BackendTest.test_backend_simple __________________
2026-07-31T07:04:13.9384143Z Traceback (most recent call last):
2026-07-31T07:04:13.9384736Z   File "/__w/pytorch/pytorch/test/test_privateuseone_python_backend.py", line 151, in test_backend_simple
2026-07-31T07:04:13.9385272Z     c.backward()
2026-07-31T07:04:13.9385743Z   File "/opt/python-3.10-venv/lib/python3.10/site-packages/torch/_tensor.py", line 614, in backward
2026-07-31T07:04:13.9386265Z     return handle_torch_function(
2026-07-31T07:04:13.9386856Z   File "/opt/python-3.10-venv/lib/python3.10/site-packages/torch/overrides.py", line 1796, in handle_torch_function
2026-07-31T07:04:13.9387515Z     result = torch_func_method(public_api, types, args, kwargs)
2026-07-31T07:04:13.9388177Z   File "/opt/python-3.10-venv/lib/python3.10/site-packages/torch/_tensor.py", line 1540, in __torch_function__
2026-07-31T07:04:13.9388735Z     ret = func(*args, **kwargs)
2026-07-31T07:04:13.9389237Z   File "/opt/python-3.10-venv/lib/python3.10/site-packages/torch/_tensor.py", line 623, in backward
2026-07-31T07:04:13.9389764Z     torch.autograd.backward(
2026-07-31T07:04:13.9390308Z   File "/opt/python-3.10-venv/lib/python3.10/site-packages/torch/autograd/__init__.py", line 395, in backward
2026-07-31T07:04:13.9390860Z     _engine_run_backward(
2026-07-31T07:04:13.9391786Z   File "/opt/python-3.10-venv/lib/python3.10/site-packages/torch/autograd/graph.py", line 1066, in _engine_run_backward
2026-07-31T07:04:13.9392637Z     return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
2026-07-31T07:04:13.9393916Z RuntimeError: self__storage_saved.value().is_alias_of(result.storage()) INTERNAL ASSERT FAILED at "/__w/pytorch/pytorch/torch/csrc/autograd/generated/VariableType_3.cpp":5944, please report a bug to PyTorch.
````

`sum()`'s backward formula calls `expand` on the incoming gradient (e.g. broadcasting a 0-d gradient up to a `(2, 2)` tensor). PyTorch's autograd codegen has a debug-build-only invariant check (`torch/csrc/autograd/generated/VariableType_N.cpp`, compiled only when `NDEBUG` is not defined) asserting that any view op's output aliases the same storage as its input. Since the old `expand` kernel allocated a brand-new `Storage` via `create_empty_tensor`, this assertion failed in debug builds, while release builds silently passed since the check is compiled out there — which is why this went unnoticed until a debug-build periodic run caught it.
```cpp
  #ifndef NDEBUG
  if (self__storage_saved.has_value() &&
      !at::impl::dispatch_mode_enabled() &&
      !at::impl::tensor_has_dispatch(self_) &&
      !at::impl::tensor_has_dispatch(self_))
    TORCH_INTERNAL_ASSERT(self__storage_saved.value().is_alias_of(self_.storage()));
```

## Fix

Added `create_view_tensor` to the `_acc` C++ extension module (`torch/csrc/acc/Module.cpp`), which constructs a new `TensorImpl` sharing the source tensor's `Storage` instead of allocating a fresh one. Rewrote the test's `expand` kernel to use it, computing the correct broadcast strides. Removed the `@unittest.skip` now that the underlying bug is fixed.

## Test Plan

```bash
python test/test_privateuseone_python_backend.py -v
```
