### PR TITLE
[ROCm][CI] Move manywheel binary test jobs to MI350 (gfx950) runners

### DIFF
--- a/.github/workflows/_binary-test-rocm-linux.yml
+++ b/.github/workflows/_binary-test-rocm-linux.yml
@@ -39,7 +39,7 @@ on:
       runs_on:
         required: false
         type: string
-        default: linux.rocm.gpu.gfx942.1
+        default: linux.rocm.gpu.gfx950.1
       timeout-minutes:
         required: false
         type: number


### PR DESCRIPTION
## Motivation

The ROCm manywheel binary test jobs currently run on MI300 (`gfx942`)
runners. We want these test jobs to run on MI350 (`gfx950`) hardware
instead, both to validate the manywheel binaries on the newer
architecture and to rebalance where this workload lands in the ROCm CI
fleet.

## Summary

- The matrix-driven `manywheel-test-rocm` job in
  `generated-linux-binary-manywheel-nightly.yml` calls the reusable
  `_binary-test-rocm-linux.yml` without overriding `runs_on`, so it uses
  that reusable workflow's default runner label.
- Change that default from `linux.rocm.gpu.gfx942.1` (MI300) to
  `linux.rocm.gpu.gfx950.1` (MI350). This reusable workflow is only
  consumed by the manywheel ROCm test job, so the change is scoped to
  those test jobs.

## Test plan

- Trigger the ROCm binary/manywheel CI on this PR and confirm the
  `manywheel-*-test` jobs schedule and run on the `gfx950` (MI350)
  runners instead of `gfx942`.

Made with Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang