### PR TITLE
[inductor][ROCm] Skip GEMM configs where BLOCK_K underfills the packed MFMA

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -757,6 +757,49 @@ class TestTritonHeuristics(TestCase):
                         self.assertNotEqual(configs, fallback, msg=arch)
 
     @skipUnless(HAS_GPU_AND_TRITON, "requires gpu and triton")
+    def test_rocm_prune_block_k_underfills_mfma(self):
+        # A config that declares kpack > 1 but whose block_k is smaller than
+        # kpack * kdim underfills the packed MFMA operand and is miscompiled,
+        # so it must be pruned.
+        if not torch.version.hip:
+            self.skipTest("ROCm-specific MFMA config pruning")
+        from torch._inductor.heuristics.template.triton import (
+            GemmConfig,
+            ROCmConfigHeuristic,
+            ROCmGemmConfig,
+        )
+
+        def count(mm_configs, dsize):
+            h = ROCmConfigHeuristic()
+            h.should_scale_configs = False
+            h.mm_configs = mm_configs
+            return len(
+                list(h.get_mm_configs()(1, 256, 128, dtype_size=dsize, op_name="mm"))
+            )
+
+        underfilled = ROCmGemmConfig(
+            16, 64, 16, 2, 4, group_m=8, matrix_instr_nonkdim=16, kpack=2
+        )
+        valid = ROCmGemmConfig(
+            16, 64, 32, 2, 4, group_m=8, matrix_instr_nonkdim=16, kpack=2
+        )
+        # f16 (dtype_size=2, kdim=16): block_k=16 < kpack(2) * 16 -> pruned;
+        # block_k=32 -> kept.
+        self.assertEqual(count([underfilled], 2), 0)
+        self.assertEqual(count([valid], 2), 1)
+
+        # Unknown dtype kdim: fp64 (dtype_size=8) is not in the CDNA MFMA table,
+        # so mfma_kdim returns None. Policy is to skip the underfill prune rather
+        # than guess, so the same config is kept instead of over-pruned.
+        self.assertEqual(count([underfilled], 8), 1)
+
+        # Plain GemmConfig lists (int8 / scaled_mm) never declare kpack. They
+        # inherit the arch default, which is clamped down to 1 when block_k cannot
+        # fill kpack * kdim, so a valid config is emitted instead of being pruned.
+        int8_configs = [GemmConfig(64, 64, 32, 2, 4), GemmConfig(128, 128, 32, 2, 8)]
+        self.assertEqual(count(int8_configs, 1), len(int8_configs))
+
+    @skipUnless(HAS_GPU_AND_TRITON, "requires gpu and triton")
     def test_compile_time_autotune_not_repeated_at_runtime(self):
         def fn(x):
             return (x + 1).sum(dim=1)

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -37,6 +37,7 @@ from ...utils import (
     get_default_kpack,
     get_num_sms,
     get_tma_workspace_arg,
+    mfma_kdim,
     TMA_DESCRIPTOR_SIZE,
     triton_type,
     using_b200,
@@ -842,6 +843,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
     def _finalize_mm_configs(
         self,
         configs: list[BaseConfig],
+        dtype_size: int = 0,
     ) -> Generator[TritonConfig, None, None]:
         """
         Finalizes configs after scaling, applying additional constraints.
@@ -1140,7 +1142,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
 
         if config.max_autotune_gemm_search_space == "EXHAUSTIVE":
             scaled_configs = self._prune_reg_spill_configs(scaled_configs)
-        return self._finalize_mm_configs(scaled_configs)
+        return self._finalize_mm_configs(scaled_configs, dtype_size=dtype_size)
 
     def triton_config(
         self, num_stages: int, num_warps: int, **kwargs: Any
@@ -1789,6 +1791,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
     def _finalize_mm_configs(
         self,
         configs: list[BaseConfig],
+        dtype_size: int = 0,
     ) -> Generator[TritonConfig, None, None]:
         """
         Finalizes configs after scaling, applying additional constraints.
@@ -1807,12 +1810,16 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             # Use explicit kpack if set, otherwise determine optimal value based on
             # architecture and BLOCK_K
             kpack: int = getattr(conf, "kpack", get_default_kpack(conf.block_k))
+            kdim = mfma_kdim(dtype_size, matrix_instr_nonkdim) or matrix_instr_nonkdim
 
             if matrix_instr_nonkdim != 0 and (
                 conf.block_m % matrix_instr_nonkdim != 0
                 or conf.block_n % matrix_instr_nonkdim != 0
+                or conf.block_k < kpack * kdim
             ):
                 #  block_m and block_n must be a multiple of matrix_instr_nonkdim
+                #  block_k must supply at least `kpack` whole MFMA K-steps
+                #  (kpack * kdim) to avoid miscompiled operand packing
                 continue
 
             # Construct key for finding duplicate configs

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -45,6 +45,7 @@ from ...utils import (
     get_tma_workspace_arg,
     rocm_gfx_arch,
     tdm_descriptor_row_major,
+    mfma_kdim,
     TMA_DESCRIPTOR_SIZE,
     tma_inner_dim,
     triton_type,
@@ -962,6 +963,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
     def _finalize_mm_configs(
         self,
         configs: list[BaseConfig],
+        dtype_size: int = 0,
     ) -> Generator[TritonConfig, None, None]:
         """
         Finalizes configs after scaling, applying additional constraints.
@@ -1270,7 +1272,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
 
         if config.max_autotune_gemm_search_space == "EXHAUSTIVE":
             scaled_configs = self._prune_reg_spill_configs(scaled_configs)
-        return self._finalize_mm_configs(scaled_configs)
+        return self._finalize_mm_configs(scaled_configs, dtype_size=dtype_size)
 
     def triton_config(
         self, num_stages: int, num_warps: int, **kwargs: Any
@@ -2052,6 +2054,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
     def _finalize_mm_configs(
         self,
         configs: list[BaseConfig],
+        dtype_size: int = 0,
     ) -> Generator[TritonConfig, None, None]:
         """
         Finalizes configs after scaling, applying additional constraints.
@@ -2070,12 +2073,16 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             # Use explicit kpack if set, otherwise determine optimal value based on
             # architecture and BLOCK_K
             kpack: int = getattr(conf, "kpack", get_default_kpack(conf.block_k))
+            kdim = mfma_kdim(dtype_size, matrix_instr_nonkdim) or matrix_instr_nonkdim
 
             if matrix_instr_nonkdim != 0 and (
                 conf.block_m % matrix_instr_nonkdim != 0
                 or conf.block_n % matrix_instr_nonkdim != 0
+                or conf.block_k < kpack * kdim
             ):
                 #  block_m and block_n must be a multiple of matrix_instr_nonkdim
+                #  block_k must supply at least `kpack` whole MFMA K-steps
+                #  (kpack * kdim) to avoid miscompiled operand packing
                 continue
 
             # Construct key for finding duplicate configs

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -43,9 +43,10 @@ from ...utils import (
     get_default_kpack,
     get_num_sms,
     get_tma_workspace_arg,
+    kpack_supported,
+    mfma_kdim,
     rocm_gfx_arch,
     tdm_descriptor_row_major,
-    mfma_kdim,
     TMA_DESCRIPTOR_SIZE,
     tma_inner_dim,
     triton_type,
@@ -1684,6 +1685,8 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
 
         self.default_num_stages = get_backend_num_stages()
 
+        kpack_choices = [1, 2] if kpack_supported() else [1]
+
         self.mm_configs: list[BaseConfig] = [
             ROCmGemmConfig(
                 16, 16, 256, self.default_num_stages, 4, group_m=4, waves_per_eu=2
@@ -1763,7 +1766,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             for group_m in [4, 8, 16]
             for matrix_instr_nonkdim in [0, 16]
             for waves_per_eu in [0, 2]
-            for kpack in [1, 2]
+            for kpack in kpack_choices
         ]
 
         # Architecture-aware default kpack for flex configs
@@ -1883,7 +1886,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             for num_warps in [2, 4, 8]
             for mfma in [0, 16]
             for wpeu in [0, int(8 // num_warps)]
-            for kpack in [1, 2]
+            for kpack in kpack_choices
         ]
 
         self.exhaustive_flex_attn_bwd_configs: list[FlexBwDConfig] = [
@@ -1907,7 +1910,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             for num_warps in [2, 4, 8]
             for mfma in [0, 16]
             for wpeu in [0, int(8 // num_warps)]
-            for kpack in [1, 2]
+            for kpack in kpack_choices
             if BLOCK_N1 % BLOCK_M1 == 0
             and BLOCK_M2 % BLOCK_N2 == 0  # kernel static assertions
         ]
@@ -2024,25 +2027,6 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                 b_row_major,
             )
 
-    def _prune_exhaustive_configs(
-        self,
-        configs: list[BaseConfig],
-        dtype_size: int,
-    ) -> list[BaseConfig]:
-        # these cause AMD compile to crash
-        pruned_configs = [
-            c
-            for c in configs
-            if not (
-                (
-                    getattr(c, "matrix_instr_nonkdim", 0) == 2
-                    and getattr(c, "kpack", 0) == 2
-                )
-                or (c.block_k <= 16 and getattr(c, "kpack", 0) == 2)
-            )
-        ]
-        return pruned_configs
-
     def _filter_configs(self, configs: list[BaseConfig]) -> list[BaseConfig]:
         """
         ROCm specific filtering
@@ -2072,17 +2056,35 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             waves_per_eu: int = getattr(conf, "waves_per_eu", 0)
             # Use explicit kpack if set, otherwise determine optimal value based on
             # architecture and BLOCK_K
-            kpack: int = getattr(conf, "kpack", get_default_kpack(conf.block_k))
-            kdim = mfma_kdim(dtype_size, matrix_instr_nonkdim) or matrix_instr_nonkdim
+            explicit_kpack = getattr(conf, "kpack", None)
+            kpack: int = explicit_kpack or get_default_kpack(conf.block_k)
+            kdim = mfma_kdim(dtype_size, matrix_instr_nonkdim)
+
+            # Policy: mfma_kdim returns None for a dtype not in the CDNA MFMA
+            # table (e.g. fp64, or an unspecified dtype_size=0). Without the true
+            # MFMA K-extent we cannot decide whether a kpack pack underfills the
+            # operand, so we skip the kpack underfill check rather than guessing
+            # from matrix_instr_nonkdim (which over-prunes small-kdim dtypes).
+            if kdim is None:
+                underfills_mfma = False
+            else:
+                underfills_mfma = kpack > 1 and conf.block_k < kpack * kdim
+
+            # A default kpack that would underfill is dropped to 1
+            # so a valid config is emitted instead of being pruned. An explicitly
+            # requested kpack that underfills is left to be pruned below.
+            if explicit_kpack is None and underfills_mfma:
+                kpack = 1
+                underfills_mfma = False
 
             if matrix_instr_nonkdim != 0 and (
                 conf.block_m % matrix_instr_nonkdim != 0
                 or conf.block_n % matrix_instr_nonkdim != 0
-                or conf.block_k < kpack * kdim
+                or underfills_mfma
             ):
                 #  block_m and block_n must be a multiple of matrix_instr_nonkdim
-                #  block_k must supply at least `kpack` whole MFMA K-steps
-                #  (kpack * kdim) to avoid miscompiled operand packing
+                #  an explicitly requested kpack > 1 must supply kpack whole MFMA
+                #  K-steps (kpack * kdim) or packing miscompiles
                 continue
 
             # Construct key for finding duplicate configs
@@ -2136,9 +2138,10 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                 return self.exhaustive_flex_attn_fwd_configs
             flex_attn_fwd_configs += self.flex_attn_fwd_autotune_configs
 
-        default_kpack = get_default_kpack()
-
+        # The attention MFMAs contract over head_dim (Q.K^T) and BLOCK_N (P.V), so
+        # the effective block_k for the kpack default is the smaller of the two.
         if head_dim <= 256:
+            default_kpack = get_default_kpack(min(head_dim, 64))  # BLOCK_N == 64
             if dtype == torch.float32:
                 default_config = ROCmFlexConfig(64, 64, 1, 4, kpack=default_kpack)
             else:
@@ -2163,8 +2166,10 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                 ).get((dtype, head_dim), default_config)
         else:
             if dtype == torch.float32:
+                default_kpack = get_default_kpack(min(head_dim, 16))  # BLOCK_N == 16
                 default_config = ROCmFlexConfig(32, 16, 1, 4, kpack=default_kpack)
             else:
+                default_kpack = get_default_kpack(min(head_dim, 32))  # BLOCK_N == 32
                 default_config = ROCmFlexConfig(64, 32, 1, 4, kpack=default_kpack)
 
         if default_config not in flex_attn_fwd_configs:
@@ -2182,32 +2187,33 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                 return self.exhaustive_flex_attn_bwd_configs
             flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs
 
-        default_kpack = get_default_kpack()
+        # block_k for the bwd attention MFMAs is bounded by head_dim and the KV
+        # block (block_n1); use the smaller as the kpack default's block_k.
         arch_bwd_config = self.flex_bwd_config_by_arch.get(rocm_gfx_arch(), {}).get(
             (dtype, head_dim)
         )
         if dtype == torch.float32:
             default_config = ROCmFlexBwDConfig(
-                16, 16, 16, 16, 1, 4, kpack=default_kpack
+                16, 16, 16, 16, 1, 4, kpack=get_default_kpack(min(head_dim, 16))
             )
         elif arch_bwd_config is not None:
             default_config = arch_bwd_config
         elif head_dim <= 256:
             if head_dim == 64:
                 default_config = ROCmFlexBwDConfig(
-                    64, 64, 64, 64, 1, 4, kpack=default_kpack
+                    64, 64, 64, 64, 1, 4, kpack=get_default_kpack(min(head_dim, 64))
                 )
             elif head_dim == 128:
                 default_config = ROCmFlexBwDConfig(
-                    64, 128, 128, 64, 1, 4, kpack=default_kpack
+                    64, 128, 128, 64, 1, 4, kpack=get_default_kpack(min(head_dim, 128))
                 )
             else:
                 default_config = ROCmFlexBwDConfig(
-                    64, 64, 64, 64, 1, 4, kpack=default_kpack
+                    64, 64, 64, 64, 1, 4, kpack=get_default_kpack(min(head_dim, 64))
                 )
         else:
             default_config = ROCmFlexBwDConfig(
-                16, 16, 16, 16, 1, 4, kpack=default_kpack
+                16, 16, 16, 16, 1, 4, kpack=get_default_kpack(min(head_dim, 16))
             )
 
         if default_config not in flex_attn_bwd_configs:
@@ -2225,7 +2231,8 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                 return self.exhaustive_flex_decode_configs
             flex_decode_configs += self.flex_decode_autotune_configs
 
-        default_kpack = get_default_kpack()
+        # block_k is bounded by head_dim (Q.K^T) and BLOCK_N (P.V); use the smaller.
+        default_kpack = get_default_kpack(min(head_dim, 64))  # BLOCK_N == 64
         default_config = ROCmFlexDecodeConfig(64, 1, 4, kpack=default_kpack)
 
         if default_config not in flex_decode_configs:
@@ -2362,13 +2369,6 @@ class XPUConfigHeuristic(BaseConfigHeuristic):
             flex_decode_configs.append(default_config)
 
         return flex_decode_configs
-
-    def _prune_exhaustive_configs(
-        self,
-        configs: list[BaseConfig],
-        dtype_size: int,
-    ) -> list[BaseConfig]:
-        return configs
 
 
 class MTIAConfigHeuristic(BaseConfigHeuristic):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1865,6 +1865,32 @@ def get_default_kpack(block_k: int = 16) -> int:
     return 2
 
 
+# MFMA K-extent (kdim) for the CDNA "16x16" and "32x32" MMA families, keyed by
+# (element_byte_width, matrix_instr_nonkdim). Values from the gfx942/gfx950
+# V_MFMA_* ISA table. 
+_MFMA_KDIM = {
+    # nonkdim == 16 : 16x16x{K}
+    (4, 16): 4,  # f32      -> 16x16x4
+    (2, 16): 16,  # f16/bf16 -> 16x16x16
+    (1, 16): 32,  # f8/i8    -> 16x16x32
+    # nonkdim == 32 : 32x32x{K}
+    (4, 32): 2,  # f32      -> 32x32x2
+    (2, 32): 8,  # f16/bf16 -> 32x32x8
+    (1, 32): 16,  # f8/i8    -> 32x32x16
+}
+
+
+def mfma_kdim(dtype_size: int, matrix_instr_nonkdim: int) -> int | None:
+    """K-extent of the selected MFMA instruction.
+
+    Returns None if the (dtype_size, matrix_instr_nonkdim) pair is unknown, so
+    callers can fall back to a conservative bound. Byte width disambiguates every
+    supported case except tf32/xf32 (both 4-byte); callers that care about tf32
+    must key on the real dtype instead.
+    """
+    return _MFMA_KDIM.get((dtype_size, matrix_instr_nonkdim))
+
+
 def _use_template_for_gpu(
     layout: Layout, allowed_layout_dtypes: list[torch.dtype]
 ) -> bool:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1867,7 +1867,7 @@ def get_default_kpack(block_k: int = 16) -> int:
 
 # MFMA K-extent (kdim) for the CDNA "16x16" and "32x32" MMA families, keyed by
 # (element_byte_width, matrix_instr_nonkdim). Values from the gfx942/gfx950
-# V_MFMA_* ISA table. 
+# V_MFMA_* ISA table.
 _MFMA_KDIM = {
     # nonkdim == 16 : 16x16x{K}
     (4, 16): 4,  # f32      -> 16x16x4

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2194,18 +2194,32 @@ def get_tma_workspace_arg(
     )
 
 
+def kpack_supported() -> bool:
+    """Whether to enable default kpack > 1 for the current ROCm arch.
+
+    Enabled on gfx908 (CDNA1), gfx90a (CDNA2) and gfx942 (CDNA3): the archs whose
+    MFMA K-extents are modeled by the dtype_size-keyed _MFMA_KDIM tables, so a
+    kpack > 1 pack can be checked against block_k for underfill. gfx950 (CDNA4)
+    is excluded because the Triton compiler forces kpack to 1 regardless
+    (triton/backends/amd/compiler.py), so a kpack > 1 default is a no-op.
+    """
+    if not torch.version.hip:
+        return False
+    arch = torch.cuda.get_device_properties(0).gcnArchName
+    return "gfx908" in arch or "gfx90a" in arch or "gfx942" in arch
+
+
 def get_default_kpack(block_k: int = 16) -> int:
     if not torch.version.hip:
         return 0
-    if "gfx942" in torch.cuda.get_device_properties(0).gcnArchName and block_k <= 16:
-        return 1
-    return 2
+    if kpack_supported() and block_k >= 16:
+        return 2
+    return 1
 
 
-# MFMA K-extent (kdim) for the CDNA "16x16" and "32x32" MMA families, keyed by
-# (element_byte_width, matrix_instr_nonkdim). Values from the gfx942/gfx950
-# V_MFMA_* ISA table.
-_MFMA_KDIM = {
+# K-extent (kdim) of the CDNA MFMA instruction Triton selects, keyed by
+# (element_byte_width, matrix_instr_nonkdim).
+_MFMA_KDIM_CDNA3 = {
     # nonkdim == 16 : 16x16x{K}
     (4, 16): 4,  # f32      -> 16x16x4
     (2, 16): 16,  # f16/bf16 -> 16x16x16
@@ -2216,16 +2230,41 @@ _MFMA_KDIM = {
     (1, 32): 16,  # f8/i8    -> 32x32x16
 }
 
+# CDNA1 (gfx908) and CDNA2 (gfx90a) share this table: every (dtype_size, nonkdim)
+# entry resolves to the same K-extent on both, so they are merged.
+#   - CDNA2 is exact -- its bf16 MFMA (bf16_1k) matches f16 (16x16x16 / 32x32x8)
+#     and int8 is 16x16x16 / 32x32x8.
+#   - CDNA1 is exact for f16/int8/f32, but its bf16 MFMA is smaller (16x16x8 /
+#     32x32x4). dtype_size=2 cannot distinguish bf16 from f16, so it is keyed to
+#     the larger f16 extent: the underfill check stays conservative for CDNA1
+#     bf16 (may over-prune, never under-validate -> no packing garbage).
+# fp8 has no native instruction on either and is emulated with f16, landing on
+# the same K-extent as int8.
+_MFMA_KDIM_CDNA1_CDNA2 = {
+    # nonkdim == 16 : 16x16x{K}
+    (4, 16): 4,  # f32      -> 16x16x4
+    (2, 16): 16,  # f16/bf16 -> 16x16x16
+    (1, 16): 16,  # f8/i8    -> 16x16x16
+    # nonkdim == 32 : 32x32x{K}
+    (4, 32): 2,  # f32      -> 32x32x2
+    (2, 32): 8,  # f16/bf16 -> 32x32x8
+    (1, 32): 8,  # f8/i8    -> 32x32x8
+}
+
 
 def mfma_kdim(dtype_size: int, matrix_instr_nonkdim: int) -> int | None:
-    """K-extent of the selected MFMA instruction.
-
-    Returns None if the (dtype_size, matrix_instr_nonkdim) pair is unknown, so
-    callers can fall back to a conservative bound. Byte width disambiguates every
-    supported case except tf32/xf32 (both 4-byte); callers that care about tf32
-    must key on the real dtype instead.
-    """
-    return _MFMA_KDIM.get((dtype_size, matrix_instr_nonkdim))
+    """MFMA K-extent for the current CDNA arch, None for an unknown
+    (dtype_size, nonkdim) pair. Only gfx908/gfx90a/gfx942 are distinguished since
+    kpack > 1 (the sole consumer) is limited to those archs."""
+    if not torch.version.hip:
+        return None
+    arch = torch.cuda.get_device_properties(0).gcnArchName
+    if "gfx908" in arch or "gfx90a" in arch:
+        return _MFMA_KDIM_CDNA1_CDNA2.get((dtype_size, matrix_instr_nonkdim))
+    elif "gfx942" in arch:
+        return _MFMA_KDIM_CDNA3.get((dtype_size, matrix_instr_nonkdim))
+    else:
+        return None
 
 
 def _use_template_for_gpu(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2202,6 +2202,32 @@ def get_default_kpack(block_k: int = 16) -> int:
     return 2
 
 
+# MFMA K-extent (kdim) for the CDNA "16x16" and "32x32" MMA families, keyed by
+# (element_byte_width, matrix_instr_nonkdim). Values from the gfx942/gfx950
+# V_MFMA_* ISA table.
+_MFMA_KDIM = {
+    # nonkdim == 16 : 16x16x{K}
+    (4, 16): 4,  # f32      -> 16x16x4
+    (2, 16): 16,  # f16/bf16 -> 16x16x16
+    (1, 16): 32,  # f8/i8    -> 16x16x32
+    # nonkdim == 32 : 32x32x{K}
+    (4, 32): 2,  # f32      -> 32x32x2
+    (2, 32): 8,  # f16/bf16 -> 32x32x8
+    (1, 32): 16,  # f8/i8    -> 32x32x16
+}
+
+
+def mfma_kdim(dtype_size: int, matrix_instr_nonkdim: int) -> int | None:
+    """K-extent of the selected MFMA instruction.
+
+    Returns None if the (dtype_size, matrix_instr_nonkdim) pair is unknown, so
+    callers can fall back to a conservative bound. Byte width disambiguates every
+    supported case except tf32/xf32 (both 4-byte); callers that care about tf32
+    must key on the real dtype instead.
+    """
+    return _MFMA_KDIM.get((dtype_size, matrix_instr_nonkdim))
+
+
 def _use_template_for_gpu(
     layout: Layout, allowed_layout_dtypes: list[torch.dtype]
 ) -> bool:


### PR DESCRIPTION
`ROCmConfigHeuristic` possibly emits GEMM configs with `matrix_instr_nonkdim=16` and `kpack=2`, meanwhile a tile with small `BLOCK_K` which may <= 32 may underfill the packed MMA operand for `mfma_16x16x16`. 

This PR aims to avoid generate the incorrect config, for example, ... `BLOCK_K=16`, `matrix_instr_nonkdim=16` and `kpack=2`. Otherwise, garbage data would be packed and got incorrect mfma results.
It validates `BLOCK_K >= kpack * kdim` via a per-arch `mfma_kdim` table.                                                                                                                                                                                                                         
                                                                  
The Default `kpack` behavior will be:
- `kpack>1` by defaults only on gfx908/gfx90a/gfx942; arch since gfx950 will be 1(Triton forces 1).
- Underfilling pruning works with explicit `kpack>1`; a *defaulted* `kpack` is clamped to 1 so a valid config is still emitted (no `NoValidChoicesError` for small-K).
- Flex attention gets default `kpack` with arg `block_k = min(head_dim, BLOCK_N)`, since attention uses head_dim (QK dot) and BLOCK_N (PV dot) as the MFMA K dim. Use their smaller value as the block_k to avoid any underfilling cases as the conservative solution.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben