### PR TITLE
Include TheRock _rocm_init.py via scikit-build wheel.exclude negation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,10 @@ exclude = [
     # torch/lib/libshm_windows/libshm.h).
     "torch/nativert/**",
     "!torch/nativert/**/*.py",
+    # TheRock generates torch/_rocm_init.py before ROCm wheel builds; it is
+    # gitignored (see .gitignore) so scikit-build-core's package walk drops it.
+    # Un-exclude when present (same negation pattern as nativert .py above).
+    "!torch/_rocm_init.py",
     "torch/headeronly/**",
     "torch/lib/libshm/**",
     "!torch/lib/libshm/**/*.h",


### PR DESCRIPTION
## Problem

scikit-build-core (the wheel backend after #180247) uses `.gitignore` to decide which files to collect into the wheel. [TheRock](https://github.com/ROCm/TheRock) generates `torch/_rocm_init.py` immediately before building ROCm wheels, but that path is `.gitignore`d, so the new backend silently drops it from the wheel.

On Windows this initializer is what preloads the ROCm runtime (via `rocm_sdk.initialize_process()`) before the native extensions load; without it `import torch` fails with `OSError: [WinError 126] ... c10_hip.dll or one of its dependencies`.

## Changes

Un-exclude the generated file via a `wheel.exclude` negation in `pyproject.toml`:

```toml
"!torch/_rocm_init.py",
```

This follows the existing `nativert` negation pattern already used a few lines above, so `_rocm_init.py` is included in the wheel whenever TheRock has generated it and is a no-op otherwise (safe on non-ROCm builds, unlike `wheel.force-include`).

This is an alternative to the CMake `install(FILES ...)` approach in #191625 — same outcome (the file lands in the wheel), expressed as a packaging/config rule rather than a build-step install.

## Companion PR — both are required for Windows `import torch`

Getting `_rocm_init.py` into the wheel is necessary but not sufficient on Windows. `torch_hip.dll` links `rocblas.dll`/`rocsolver.dll` directly, and the initializer must preload them. That preload is added by:

- **ROCm/TheRock#7027** — registers `rocblas`/`rocsolver` in `rocm_sdk` and adds them to the Windows preload list in the generated `_rocm_init.py`.

Neither PR is sufficient alone on Windows: this PR gets the file into the wheel, #7027 makes the file preload `rocblas`/`rocsolver`. Both must be present for `import torch` to succeed.

## Validation

This PR and its companion ROCm/TheRock#7027 are validated **together** in one Windows build, since a green `import torch` needs both the file shipped (this PR) and `rocblas`/`rocsolver` preloaded (#7027):

- A throwaway TheRock test branch (`users/ethanwee/test-combined-7027-191632`) carries #7027's preload change and injects the `rocblas`/`rocsolver` registrations into the installed `rocm_sdk` (simulating a nightly built after #7027 lands, which is when that registration would normally ship).
- The workflow's nightly checkout path builds this PR's branch (`ethanwee1/pytorch @ ew/pyproject-wheel-rocm-init`), so `_rocm_init.py` is included in the wheel.
- Combined validation run: [30920031348](https://github.com/ROCm/TheRock/actions/runs/30920031348) (gfx1100, py3.12, torch nightly). Success criterion: the in-build `import torch; torch.cuda.is_available()` sanity check passes with no WinError 126.

Earlier run [30866436372](https://github.com/ROCm/TheRock/actions/runs/30866436372) confirmed this PR's half in isolation: `_rocm_init.py` is included in the wheel, but `import torch` still failed with WinError 126 without #7027's preload — establishing that both are required.

Fixes ROCm/TheRock#6965

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
