### PR TITLE
Add prototype virtual/fake ProcessGroup for distributed debugging

### DIFF
--- a/test/distributed/test_virtual_pg.py
+++ b/test/distributed/test_virtual_pg.py
@@ -1,0 +1,1253 @@
+# Owner(s): ["oncall: distributed"]
+
+import gc
+import tempfile
+import weakref
+
+import torch
+import torch.distributed as dist
+import torch.distributed._functional_collectives as funcol
+from torch._C._distributed_c10d import (
+    AllgatherOptions,
+    AllreduceOptions,
+    AllToAllOptions,
+    BroadcastOptions,
+    ReduceScatterOptions,
+    ScatterOptions,
+)
+from torch.distributed._virtual_pg import LocalProcessGroup, VirtualProcessGroup
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    requires_nccl,
+    skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_utils import run_tests, skipIfRocm, TestCase
+
+
+if not dist.is_available():
+    print("distributed package not available, skipping tests")
+    import sys
+
+    sys.exit(0)
+
+
+class TestLocalProcessGroup(TestCase):
+    def _make_pg(self, rank=1, world=4):
+        pg = LocalProcessGroup(rank, world)
+        self.addCleanup(pg.unregister)
+        return pg
+
+    def test_construction(self):
+        pg = self._make_pg(rank=3, world=8)
+        self.assertEqual(pg.rank(), 3)
+        self.assertEqual(pg.size(), 8)
+        self.assertFalse(dist.is_initialized())
+
+    def test_invalid_rank(self):
+        with self.assertRaisesRegex(ValueError, "invalid rank"):
+            LocalProcessGroup(4, 4)
+
+    def test_allreduce_identity(self):
+        pg = self._make_pg()
+        t = torch.arange(4.0)
+        work = pg.allreduce([t], AllreduceOptions())
+        self.assertTrue(work.wait())
+        self.assertEqual(t, torch.arange(4.0))
+
+    def test_broadcast_identity(self):
+        pg = self._make_pg()
+        t = torch.arange(4.0)
+        opts = BroadcastOptions()
+        opts.rootRank = 0
+        pg.broadcast([t], opts).wait()
+        self.assertEqual(t, torch.arange(4.0))
+
+    def test_all_gather_single_replicates(self):
+        pg = self._make_pg()
+        inp = torch.arange(2.0)
+        out = torch.zeros(8)
+        pg.all_gather_single(out, inp, AllgatherOptions()).wait()
+        self.assertEqual(out, inp.repeat(4))
+
+    def test_allgather_replicates(self):
+        pg = self._make_pg()
+        inp = torch.arange(3.0)
+        outs = [[torch.zeros(3) for _ in range(4)]]
+        pg.allgather(outs, [inp], AllgatherOptions()).wait()
+        for o in outs[0]:
+            self.assertEqual(o, inp)
+
+    def test_reduce_scatter_single_takes_own_chunk(self):
+        pg = self._make_pg(rank=1, world=4)
+        inp = torch.arange(8.0)
+        out = torch.zeros(2)
+        pg.reduce_scatter_single(out, inp, ReduceScatterOptions()).wait()
+        self.assertEqual(out, torch.tensor([2.0, 3.0]))
+
+    def test_scatter_root_takes_own_chunk(self):
+        pg = self._make_pg(rank=1, world=4)
+        ins = [[torch.full((2,), float(r)) for r in range(4)]]
+        out = torch.zeros(2)
+        opts = ScatterOptions()
+        opts.rootRank = 1
+        pg.scatter([out], ins, opts).wait()
+        self.assertEqual(out, torch.full((2,), 1.0))
+
+    def test_alltoall_identity(self):
+        pg = self._make_pg()
+        ins = [torch.full((2,), float(i)) for i in range(4)]
+        outs = [torch.zeros(2) for _ in range(4)]
+        pg.alltoall(outs, ins, AllToAllOptions()).wait()
+        for o, i in zip(outs, ins):
+            self.assertEqual(o, i)
+
+    def test_all_to_all_single_even(self):
+        pg = self._make_pg()
+        inp = torch.arange(8.0)
+        out = torch.zeros(8)
+        pg.all_to_all_single(out, inp, [], [], AllToAllOptions()).wait()
+        self.assertEqual(out, inp)
+
+    def test_requires_grad_input(self):
+        pg = self._make_pg()
+        inp = torch.ones(2, requires_grad=True)
+        out = torch.zeros(8)
+        pg.all_gather_single(out, inp, AllgatherOptions()).wait()
+        self.assertEqual(out, torch.ones(8))
+
+    def test_dist_all_reduce_group_kwarg(self):
+        pg = self._make_pg()
+        t = torch.ones(4)
+        dist.all_reduce(t, group=pg)
+        self.assertEqual(t, torch.ones(4))
+
+    def test_dist_all_reduce_async(self):
+        pg = self._make_pg()
+        t = torch.ones(4)
+        work = dist.all_reduce(t, group=pg, async_op=True)
+        self.assertTrue(work.wait())
+
+    def test_hook_sees_normalized_collective(self):
+        calls = []
+
+        class RecordingPG(LocalProcessGroup):
+            def run_collective(self, coll):
+                calls.append(
+                    (coll.op, [t.shape for t in coll.inputs], coll.reduce_op, coll.root)
+                )
+                return None
+
+        pg = RecordingPG(0, 2)
+        self.addCleanup(pg.unregister)
+        t = torch.ones(3)
+        opts = AllreduceOptions()
+        opts.reduceOp = dist.ReduceOp.MAX
+        pg.allreduce([t], opts).wait()
+        out = torch.zeros(6)
+        pg.all_gather_single(out, t, AllgatherOptions()).wait()
+        self.assertEqual(calls[0][0], "allreduce")
+        self.assertEqual(calls[0][1], [torch.Size([3])])
+        self.assertEqual(calls[0][2], dist.ReduceOp.MAX)
+        self.assertEqual(calls[1][0], "all_gather_single")
+
+    def test_funcol_by_name(self):
+        pg = self._make_pg()
+        y = funcol.wait_tensor(funcol.all_reduce(torch.ones(2), "sum", pg.group_name))
+        self.assertEqual(y, torch.ones(2))
+
+    def test_funcol_by_object(self):
+        pg = self._make_pg()
+        y = funcol.wait_tensor(funcol.all_gather_single(torch.ones(2), 0, pg))
+        self.assertEqual(y, torch.ones(8))
+
+    def test_funcol_reduce_scatter(self):
+        pg = self._make_pg(rank=1, world=4)
+        y = funcol.wait_tensor(
+            funcol.reduce_scatter_tensor(torch.arange(8.0), "sum", 0, pg.group_name)
+        )
+        self.assertEqual(y, torch.tensor([2.0, 3.0]))
+
+    def test_work_lifetime(self):
+        wrefs = []
+
+        class TrackedWorkPG(LocalProcessGroup):
+            def run_collective(self, coll):
+                work = super().run_collective(coll)
+                return work
+
+        pg = TrackedWorkPG(0, 2)
+        self.addCleanup(pg.unregister)
+        t = torch.ones(2)
+        work = pg.allreduce([t], AllreduceOptions())
+        wrefs.append(weakref.ref(work))
+        work.wait()
+        del work
+        gc.collect()
+        self.assertIsNone(wrefs[0]())
+
+    def test_pg_not_leaked_after_unregister(self):
+        pg = LocalProcessGroup(0, 2)
+        name = pg.group_name
+        pg.unregister()
+        wref = weakref.ref(pg)
+        del pg
+        gc.collect()
+        self.assertIsNone(wref())
+        with self.assertRaises(Exception):
+            torch._C._distributed_c10d._resolve_process_group(name)
+
+    def test_split_local(self):
+        pg = self._make_pg(rank=1, world=4)
+        sub = pg.split_local([1, 3])
+        self.addCleanup(sub.unregister)
+        self.assertEqual(sub.rank(), 0)
+        self.assertEqual(sub.size(), 2)
+        self.assertIsNone(pg.split_local([0, 2]))
+
+    def test_split_local_validation(self):
+        pg = self._make_pg()
+        with self.assertRaisesRegex(ValueError, "out of range"):
+            pg.split_local([1, 7])
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            pg.split_local([1, 1])
+
+    def test_split_group_virtual_method(self):
+        pg = self._make_pg(rank=1, world=4)
+        sub = pg.splitGroup([0, 1], None, None, "sub_name", "sub_desc", None)
+        self.addCleanup(sub.unregister)
+        self.assertEqual(sub.rank(), 1)
+        self.assertEqual(sub.size(), 2)
+        self.assertEqual(sub.group_name, "sub_name")
+        self.assertEqual(sub.group_desc, "sub_desc")
+
+    def test_nested_split(self):
+        pg = self._make_pg(rank=2, world=8)
+        sub = pg.split_local([0, 2, 4, 6])
+        self.addCleanup(sub.unregister)
+        self.assertEqual(sub.rank(), 1)
+        subsub = sub.split_local([1, 3])
+        self.addCleanup(subsub.unregister)
+        self.assertEqual(subsub.rank(), 0)
+        self.assertEqual(subsub.size(), 2)
+
+    def test_funcol_on_split_group(self):
+        pg = self._make_pg(rank=1, world=4)
+        sub = pg.split_local([1, 3])
+        self.addCleanup(sub.unregister)
+        y = funcol.wait_tensor(
+            funcol.all_gather_single(torch.ones(2), 0, sub.group_name)
+        )
+        self.assertEqual(y, torch.ones(4))
+
+    def test_compile_funcol(self):
+        pg = self._make_pg()
+
+        def f(x):
+            y = funcol.all_reduce(x * 3, "sum", pg.group_name)
+            return funcol.wait_tensor(y) + 1
+
+        x = torch.ones(4)
+        eager = f(x)
+        compiled = torch.compile(f, fullgraph=True)(x)
+        self.assertEqual(eager, compiled)
+
+    def test_compile_funcol_group_object(self):
+        pg = self._make_pg()
+
+        def f(x):
+            return funcol.wait_tensor(funcol.all_gather_single(x, 0, pg)).sum()
+
+        x = torch.ones(2)
+        eager = f(x)
+        compiled = torch.compile(f, fullgraph=True)(x)
+        self.assertEqual(eager, compiled)
+
+    def test_compile_bakes_logical_rank(self):
+        # dist.get_rank(pg) translates through the default group's global
+        # rank, so it cannot work for a standalone PG; pg.rank() is the
+        # logical-rank query that dynamo constant-folds.
+        pg = self._make_pg(rank=2, world=4)
+
+        def f(x):
+            return x + pg.rank()
+
+        compiled = torch.compile(f, fullgraph=True)(torch.zeros(2))
+        self.assertEqual(compiled, torch.full((2,), 2.0))
+
+
+class TestVirtualProcessGroup(TestCase):
+    def _make_phys(self):
+        f = tempfile.NamedTemporaryFile(delete=False)  # noqa: SIM115
+        store = dist.FileStore(f.name, 1)
+        return dist.ProcessGroupGloo(store, 0, 1)
+
+    def _make_pg(self, rank=1, world=4, **kwargs):
+        pg = VirtualProcessGroup(rank, world, self._make_phys(), **kwargs)
+        self.addCleanup(pg.unregister)
+        return pg
+
+    def test_logical_vs_physical_rank(self):
+        pg = self._make_pg(rank=2, world=4)
+        self.assertEqual(pg.rank(), 2)
+        self.assertEqual(pg.size(), 4)
+        self.assertEqual(pg.physical_group.size(), 1)
+
+    def test_wait_reaches_physical_work(self):
+        wait_counts = []
+
+        class PhysWork(dist._Work):
+            def __init__(self):
+                super().__init__()
+                self.waited = 0
+                wait_counts.append(self)
+
+            def wait(self, timeout=None):
+                self.waited += 1
+                return True
+
+        class CountingPhys(dist.ProcessGroup):
+            def __init__(self):
+                super().__init__(0, 1)
+
+            def getBackendName(self):
+                return "counting"
+
+            def allreduce(self, tensors, opts):
+                return PhysWork()
+
+        pg = VirtualProcessGroup(1, 4, CountingPhys())
+        self.addCleanup(pg.unregister)
+        t = torch.full((3,), 5.0)
+        work = pg.allreduce([t], AllreduceOptions())
+        self.assertEqual(len(wait_counts), 1)
+        self.assertEqual(wait_counts[0].waited, 0)
+        work.wait()
+        self.assertEqual(wait_counts[0].waited, 1)
+        self.assertEqual(t, torch.full((3,), 5.0))
+
+    def test_allgather_data_and_mirror(self):
+        pg = self._make_pg()
+        inp = torch.arange(3.0)
+        out = torch.zeros(12)
+        pg.all_gather_single(out, inp, AllgatherOptions()).wait()
+        self.assertEqual(out, inp.repeat(4))
+
+    def test_reduce_scatter_mirror(self):
+        pg = self._make_pg(rank=1, world=4)
+        inp = torch.arange(8.0)
+        out = torch.zeros(2)
+        pg.reduce_scatter_single(out, inp, ReduceScatterOptions()).wait()
+        self.assertEqual(out, torch.tensor([2.0, 3.0]))
+
+    def test_mirror_records_physical_collectives(self):
+        issued = []
+
+        class RecordingPhys(dist.ProcessGroup):
+            def __init__(self):
+                super().__init__(0, 1)
+
+            def getBackendName(self):
+                return "recording"
+
+            def allreduce(self, tensors, opts):
+                issued.append(("allreduce", tensors[0].numel()))
+                fut = torch.futures.Future()
+                fut.set_result(tensors)
+                return torch._C._distributed_c10d._create_work_from_future(fut)
+
+            def all_gather_single(self, out, inp, opts):
+                issued.append(("all_gather_single", inp.numel()))
+                fut = torch.futures.Future()
+                fut.set_result(out)
+                return torch._C._distributed_c10d._create_work_from_future(fut)
+
+        phys = RecordingPhys()
+        pg = VirtualProcessGroup(1, 4, phys)
+        self.addCleanup(pg.unregister)
+        t = torch.ones(5)
+        pg.allreduce([t], AllreduceOptions()).wait()
+        out = torch.zeros(8)
+        pg.all_gather_single(out, torch.ones(2), AllgatherOptions()).wait()
+        self.assertEqual(issued, [("allreduce", 5), ("all_gather_single", 2)])
+
+    def test_scratch_buffers_are_stable(self):
+        pg = self._make_pg()
+        t = torch.ones(4)
+        pg.allreduce([t], AllreduceOptions()).wait()
+        key = next(iter(pg._scratch))
+        buf_ptr = pg._scratch[key][0].data_ptr()
+        pg.allreduce([t], AllreduceOptions()).wait()
+        self.assertEqual(len(pg._scratch), 1)
+        self.assertEqual(pg._scratch[key][0].data_ptr(), buf_ptr)
+
+    def test_funcol_by_name(self):
+        pg = self._make_pg()
+        y = funcol.wait_tensor(funcol.all_reduce(torch.ones(2), "sum", pg.group_name))
+        self.assertEqual(y, torch.ones(2))
+
+    def test_split_reuses_physical_group(self):
+        pg = self._make_pg(rank=1, world=4)
+        sub = pg.split_local([1, 3])
+        self.addCleanup(sub.unregister)
+        self.assertEqual(sub.rank(), 0)
+        self.assertEqual(sub.size(), 2)
+        self.assertIs(sub.physical_group, pg.physical_group)
+        y = funcol.wait_tensor(
+            funcol.all_gather_single(torch.ones(2), 0, sub.group_name)
+        )
+        self.assertEqual(y, torch.ones(4))
+
+    def test_compile_funcol(self):
+        pg = self._make_pg()
+
+        def f(x):
+            return (
+                funcol.wait_tensor(funcol.all_reduce(x * 2, "sum", pg.group_name)) + 1
+            )
+
+        x = torch.ones(4)
+        eager = f(x)
+        compiled = torch.compile(f, fullgraph=True)(x)
+        self.assertEqual(eager, compiled)
+
+    def test_hook_normalization_unchanged(self):
+        seen = []
+        orig = VirtualProcessGroup.run_collective
+
+        class SpyPG(VirtualProcessGroup):
+            def run_collective(self, coll):
+                seen.append(coll.op)
+                return orig(self, coll)
+
+        pg = SpyPG(0, 4, self._make_phys())
+        self.addCleanup(pg.unregister)
+        t = torch.ones(2)
+        pg.allreduce([t], AllreduceOptions()).wait()
+        pg.barrier(torch._C._distributed_c10d.BarrierOptions()).wait()
+        self.assertEqual(seen, ["allreduce", "barrier"])
+
+
+class TestProjectedMode(TestCase):
+    """output_mode="projected": physical collective on views of app tensors."""
+
+    def _make_pg(self, rank=1, world=4, **kwargs):
+        f = tempfile.NamedTemporaryFile(delete=False)  # noqa: SIM115
+        store = dist.FileStore(f.name, 1)
+        phys = dist.ProcessGroupGloo(store, 0, 1)
+        kwargs.setdefault("output_mode", "projected")
+        pg = VirtualProcessGroup(rank, world, phys, **kwargs)
+        self.addCleanup(pg.unregister)
+        return pg
+
+    def test_invalid_output_mode(self):
+        with self.assertRaisesRegex(ValueError, "output_mode"):
+            self._make_pg(output_mode="bogus")
+
+    def test_allreduce_in_place_on_logical_tensor(self):
+        seen_ptrs = []
+
+        class SpyPhys(dist.ProcessGroup):
+            def __init__(self):
+                super().__init__(0, 1)
+
+            def getBackendName(self):
+                return "spy"
+
+            def allreduce(self, tensors, opts):
+                seen_ptrs.append(tensors[0].data_ptr())
+                fut = torch.futures.Future()
+                fut.set_result(tensors)
+                return torch._C._distributed_c10d._create_work_from_future(fut)
+
+        pg = VirtualProcessGroup(1, 4, SpyPhys(), output_mode="projected")
+        self.addCleanup(pg.unregister)
+        t = torch.ones(8)
+        pg.allreduce([t], AllreduceOptions()).wait()
+        self.assertEqual(seen_ptrs, [t.data_ptr()])
+
+    def test_all_gather_projects_onto_logical_buffers(self):
+        seen = {}
+
+        class SpyPhys(dist.ProcessGroup):
+            def __init__(self):
+                super().__init__(0, 1)
+
+            def getBackendName(self):
+                return "spy"
+
+            def all_gather_single(self, out, inp, opts):
+                seen["out_ptr"] = out.data_ptr()
+                seen["in_ptr"] = inp.data_ptr()
+                seen["out_numel"] = out.numel()
+                out.copy_(inp)  # physical world = 1
+                fut = torch.futures.Future()
+                fut.set_result(out)
+                return torch._C._distributed_c10d._create_work_from_future(fut)
+
+        pg = VirtualProcessGroup(1, 4, SpyPhys(), output_mode="projected")
+        self.addCleanup(pg.unregister)
+        inp = torch.arange(2.0)
+        out = torch.zeros(8)
+        pg.all_gather_single(out, inp, AllgatherOptions()).wait()
+        self.assertEqual(seen["in_ptr"], inp.data_ptr())
+        self.assertEqual(seen["out_ptr"], out.data_ptr())
+        # physical world 1 => reachable prefix is 1 * inp.numel()
+        self.assertEqual(seen["out_numel"], 2)
+        self.assertEqual(out[:2], inp)
+        # no local fake fill: the rest of the logical output was not written
+        self.assertEqual(out[2:], torch.zeros(6))
+        self.assertEqual(len(pg._scratch), 0)
+
+    def test_reduce_scatter_projects_onto_logical_buffers(self):
+        pg = self._make_pg()
+        inp = torch.arange(8.0)
+        out = torch.zeros(2)
+        pg.reduce_scatter_single(out, inp, ReduceScatterOptions()).wait()
+        # physical world 1: reduce_scatter over first 1*2 elements of input
+        self.assertEqual(out, torch.tensor([0.0, 1.0]))
+        self.assertEqual(len(pg._scratch), 0)
+
+    def test_projected_requires_contiguous(self):
+        from torch.distributed._virtual_pg import ProjectionError
+
+        pg = self._make_pg()
+        inp = torch.zeros(4, 4).t()  # non-contiguous
+        out = torch.zeros(4, 4)
+        with self.assertRaises(ProjectionError):
+            pg.all_gather_single(out, inp, AllgatherOptions())
+
+    def test_projected_rejects_undersized_output(self):
+        from torch.distributed._virtual_pg import ProjectionError
+
+        class TwoRankPhys(dist.ProcessGroup):
+            def __init__(self):
+                super().__init__(0, 2)
+
+            def getBackendName(self):
+                return "two"
+
+        pg = VirtualProcessGroup(0, 4, TwoRankPhys(), output_mode="projected")
+        self.addCleanup(pg.unregister)
+        # logical output sized for one physical rank only; needs 2*3=6
+        with self.assertRaises(ProjectionError):
+            pg.all_gather_single(torch.zeros(3), torch.zeros(3), AllgatherOptions())
+
+    def test_projected_never_falls_back_to_scratch(self):
+        from torch.distributed._virtual_pg import ProjectionError
+
+        pg = self._make_pg()
+        outs = [[torch.zeros(2) for _ in range(4)]]
+        with self.assertRaisesRegex(ProjectionError, "scratch"):
+            pg.allgather(outs, [torch.zeros(2)], AllgatherOptions())
+        self.assertEqual(len(pg._scratch), 0)
+
+    def test_scratch_mode_untouched_logical_output(self):
+        pg = self._make_pg(output_mode="scratch")
+        inp = torch.arange(2.0)
+        out = torch.full((8,), -1.0)
+        pg.all_gather_single(out, inp, AllgatherOptions()).wait()
+        # scratch mode: logical output not written at all
+        self.assertEqual(out, torch.full((8,), -1.0))
+        self.assertGreater(len(pg._scratch), 0)
+
+    def test_local_fake_mode_fills_output(self):
+        pg = self._make_pg(output_mode="local_fake")
+        inp = torch.arange(2.0)
+        out = torch.zeros(8)
+        pg.all_gather_single(out, inp, AllgatherOptions()).wait()
+        self.assertEqual(out, inp.repeat(4))
+
+    def test_split_inherits_output_mode(self):
+        pg = self._make_pg(rank=1, world=4)
+        sub = pg.split_local([1, 3])
+        self.addCleanup(sub.unregister)
+        self.assertEqual(sub.output_mode, "projected")
+
+    def test_p2p_requires_peer_map_in_projected(self):
+        from torch.distributed._virtual_pg import ProjectionError
+
+        pg = self._make_pg()
+        with self.assertRaisesRegex(ProjectionError, "physical_peer_map"):
+            pg.send([torch.ones(2)], 3, 0)
+
+    def test_p2p_mirrors_with_peer_map(self):
+        sent = []
+
+        class SpyPhys(dist.ProcessGroup):
+            def __init__(self):
+                super().__init__(0, 1)
+
+            def getBackendName(self):
+                return "spy"
+
+            def send(self, tensors, dst, tag):
+                sent.append((tensors[0].data_ptr(), dst, tag))
+                fut = torch.futures.Future()
+                fut.set_result(tensors)
+                return torch._C._distributed_c10d._create_work_from_future(fut)
+
+        pg = VirtualProcessGroup(
+            0, 4, SpyPhys(), output_mode="projected", physical_peer_map={3: 0}
+        )
+        self.addCleanup(pg.unregister)
+        t = torch.ones(2)
+        pg.send([t], 3, 7).wait()
+        self.assertEqual(sent, [(t.data_ptr(), 0, 7)])
+
+    def test_profiler_metadata_has_logical_name(self):
+        pg = self._make_pg()
+        inp, out = torch.ones(2), torch.zeros(8)
+        with torch.profiler.profile() as prof:
+            pg.all_gather_single(out, inp, AllgatherOptions()).wait()
+        names = [e.name for e in prof.events()]
+        self.assertTrue(
+            any(f"virtual_pg::{pg.group_name}::all_gather_single" in n for n in names),
+            names,
+        )
+
+
+class DeferredWork(dist._Work):
+    """Work that records when wait() happens; completes only on wait."""
+
+    log: list = []
+
+    def __init__(self, label):
+        super().__init__()
+        self.label = label
+        DeferredWork.log.append(("issue", label))
+
+    def wait(self, timeout=None):
+        DeferredWork.log.append(("wait", self.label))
+        return True
+
+
+class DeferredPhys(dist.ProcessGroup):
+    """Physical PG returning DeferredWork so wait placement is observable."""
+
+    def __init__(self):
+        super().__init__(0, 1)
+        self._name = ""
+
+    def getBackendName(self):
+        return "deferred"
+
+    def setGroupName(self, name):
+        self._name = name
+
+    def getGroupName(self):
+        return self._name
+
+    def allreduce(self, tensors, opts):
+        return DeferredWork("allreduce")
+
+    def all_gather_single(self, out, inp, opts):
+        out[: inp.numel()].copy_(inp)
+        return DeferredWork("all_gather")
+
+    def reduce_scatter_single(self, out, inp, opts):
+        out.copy_(inp[: out.numel()])
+        return DeferredWork("reduce_scatter")
+
+
+class TestWorkSemantics(TestCase):
+    """The physical Work is joined at the consumer, not at issue time."""
+
+    def setUp(self):
+        super().setUp()
+        DeferredWork.log = []
+
+    def _make_pg(self, rank=1, world=4):
+        pg = VirtualProcessGroup(rank, world, DeferredPhys(), output_mode="projected")
+        self.addCleanup(pg.unregister)
+        return pg
+
+    def test_no_wait_at_issue_eager_async(self):
+        pg = self._make_pg()
+        t = torch.ones(4)
+        work = dist.all_reduce(t, group=pg, async_op=True)
+        self.assertEqual(DeferredWork.log, [("issue", "allreduce")])
+        work.wait()
+        self.assertEqual(
+            DeferredWork.log, [("issue", "allreduce"), ("wait", "allreduce")]
+        )
+
+    def test_funcol_defers_wait_to_wait_tensor(self):
+        pg = self._make_pg()
+        y = funcol.all_reduce(torch.ones(2), "sum", pg.group_name)
+        self.assertEqual(DeferredWork.log, [("issue", "allreduce")])
+        # consuming via wait_tensor joins the physical work
+        funcol.wait_tensor(y)
+        self.assertEqual(
+            DeferredWork.log, [("issue", "allreduce"), ("wait", "allreduce")]
+        )
+
+    def test_funcol_registers_work_against_logical_output(self):
+        pg = self._make_pg()
+        before = torch._C._distributed_c10d._get_work_registry_size()
+        y = funcol.all_reduce(torch.ones(2), "sum", pg.group_name)
+        self.assertEqual(
+            torch._C._distributed_c10d._get_work_registry_size(), before + 1
+        )
+        funcol.wait_tensor(y)
+        self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), before)
+
+    def test_async_collective_tensor_waits_on_use(self):
+        pg = self._make_pg()
+        act = funcol.all_reduce(torch.ones(2), "sum", pg.group_name)
+        self.assertEqual([e[0] for e in DeferredWork.log], ["issue"])
+        # first real use of the AsyncCollectiveTensor triggers the wait
+        _ = act + 1
+        self.assertIn(("wait", "allreduce"), DeferredWork.log)
+
+    def test_work_gc_after_wait(self):
+        pg = self._make_pg()
+        t = torch.ones(4)
+        work = pg.allreduce([t], AllreduceOptions())
+        wref = weakref.ref(work)
+        work.wait()
+        del work
+        gc.collect()
+        self.assertIsNone(wref())
+
+    def test_compiled_funcol_defers_wait(self):
+        pg = self._make_pg()
+
+        def f(x):
+            y = funcol.all_reduce(x, "sum", pg.group_name)
+            return funcol.wait_tensor(y) + 1
+
+        compiled = torch.compile(f, fullgraph=True)
+        DeferredWork.log = []
+        compiled(torch.ones(2))
+        self.assertEqual(
+            DeferredWork.log, [("issue", "allreduce"), ("wait", "allreduce")]
+        )
+
+
+class TestInstallVirtualWorld(TestCase):
+    """install_virtual_world: unmodified apps see the logical world."""
+
+    def _install(self, rank=2, world=8, **kwargs):
+        from torch.distributed._virtual_pg import (
+            install_virtual_world,
+            uninstall_virtual_world,
+        )
+
+        f = tempfile.NamedTemporaryFile(delete=False)  # noqa: SIM115
+        phys = dist.ProcessGroupGloo(dist.FileStore(f.name, 1), 0, 1)
+        pg = VirtualProcessGroup(rank, world, phys, **kwargs)
+        install_virtual_world(pg)
+        self.addCleanup(uninstall_virtual_world)
+        self.addCleanup(pg.unregister)
+        return pg
+
+    def test_rank_and_world_size(self):
+        self._install(rank=2, world=8)
+        self.assertEqual(dist.get_rank(), 2)
+        self.assertEqual(dist.get_world_size(), 8)
+
+    def test_requires_uninitialized(self):
+        from torch.distributed._virtual_pg import install_virtual_world
+
+        pg = self._install()
+        with self.assertRaisesRegex(RuntimeError, "uninitialized"):
+            install_virtual_world(pg)
+
+    def test_default_group_collective(self):
+        self._install()
+        t = torch.ones(4)
+        dist.all_reduce(t)
+        self.assertEqual(t, torch.ones(4))
+
+    def test_new_group_creates_virtual_child(self):
+        self._install(rank=2, world=8)
+        sub = dist.new_group([0, 2, 4])
+        self.assertIsInstance(sub, VirtualProcessGroup)
+        self.assertEqual(sub.rank(), 1)
+        self.assertEqual(sub.size(), 3)
+        self.assertEqual(dist.new_group([1, 3]), dist.GroupMember.NON_GROUP_MEMBER)
+
+    def test_new_group_rank_translation(self):
+        self._install(rank=2, world=8)
+        sub = dist.new_group([0, 2, 4])
+        self.assertEqual(dist.get_group_rank(sub, 2), 1)
+        self.assertEqual(dist.get_global_rank(sub, 1), 2)
+        self.assertEqual(dist.get_rank(sub), 1)
+
+    def test_device_mesh_dim_groups_are_virtual(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        self._install(rank=2, world=8)
+        mesh = init_device_mesh("cpu", (2, 4), mesh_dim_names=("dp", "tp"))
+        dp, tp = mesh.get_group("dp"), mesh.get_group("tp")
+        self.assertIsInstance(dp, VirtualProcessGroup)
+        self.assertIsInstance(tp, VirtualProcessGroup)
+        self.assertEqual(dp.size(), 2)
+        self.assertEqual(tp.size(), 4)
+        y = funcol.wait_tensor(funcol.all_reduce(torch.ones(2), "sum", tp))
+        self.assertEqual(y, torch.ones(2))
+
+    def test_child_groups_share_physical_by_default(self):
+        pg = self._install(rank=2, world=8)
+        sub1 = dist.new_group([0, 2])
+        sub2 = dist.new_group([2, 4])
+        self.assertIs(sub1.physical_group, pg.physical_group)
+        self.assertIs(sub2.physical_group, pg.physical_group)
+
+    def test_new_group_called_by_all_for_physical_split(self):
+        # In mirror_split="split" mode the physical child is created before
+        # the logical membership check, so non-member processes still
+        # participate in the (deterministic-order) physical split.
+        split_calls = []
+
+        class SplitSpyPhys(dist.ProcessGroup):
+            def __init__(self):
+                super().__init__(0, 1)
+                self._name = ""
+
+            def getBackendName(self):
+                return "splitspy"
+
+            def setGroupName(self, name):
+                self._name = name
+
+            def getGroupName(self):
+                return self._name
+
+            def splitGroup(self, ranks, timeout, opts, name, desc, devices):
+                split_calls.append(list(ranks))
+                child = SplitSpyPhys()
+                return child
+
+        from torch.distributed._virtual_pg import (
+            install_virtual_world,
+            uninstall_virtual_world,
+        )
+
+        pg = VirtualProcessGroup(2, 8, SplitSpyPhys(), mirror_split="split")
+        install_virtual_world(pg)
+        self.addCleanup(uninstall_virtual_world)
+        self.addCleanup(pg.unregister)
+        member = dist.new_group([0, 2])
+        nonmember = dist.new_group([1, 3])
+        self.assertIsInstance(member, VirtualProcessGroup)
+        self.assertEqual(nonmember, dist.GroupMember.NON_GROUP_MEMBER)
+        # both calls split the physical parent over ALL physical ranks
+        self.assertEqual(split_calls, [[0], [0]])
+        self.assertIsNot(member.physical_group, pg.physical_group)
+
+
+class TestVirtualProcessGroupNccl(TestCase):
+    def _make_pg(self, rank=1, world=4):
+        if not TEST_CUDA or not dist.is_nccl_available():
+            self.skipTest("CUDA and NCCL required")
+        f = tempfile.NamedTemporaryFile(delete=False)  # noqa: SIM115
+        store = dist.FileStore(f.name, 1)
+        phys = dist.ProcessGroupNCCL(store, 0, 1)
+        pg = VirtualProcessGroup(rank, world, phys)
+        self.addCleanup(pg.unregister)
+        return pg
+
+    @skipIfRocm
+    def test_nccl_mirror_eager(self):
+        pg = self._make_pg()
+        t = torch.full((4,), 3.0, device="cuda")
+        work = pg.allreduce([t], AllreduceOptions())
+        work.wait()
+        torch.cuda.synchronize()
+        self.assertEqual(t, torch.full((4,), 3.0, device="cuda"))
+        out = torch.zeros(8, device="cuda")
+        pg.all_gather_single(
+            out, torch.ones(2, device="cuda"), AllgatherOptions()
+        ).wait()
+        torch.cuda.synchronize()
+        self.assertEqual(out, torch.ones(8, device="cuda"))
+
+    @skipIfRocm
+    def test_nccl_mirror_cuda_graph(self):
+        pg = self._make_pg()
+        t = torch.ones(4, device="cuda")
+        # warmup on a side stream (allocates scratch, inits communicator)
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(2):
+                pg.allreduce([t], AllreduceOptions()).wait()
+        torch.cuda.current_stream().wait_stream(s)
+
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            work = pg.allreduce([t], AllreduceOptions())
+            work.wait()
+            y = t * 2
+        t.fill_(3.0)
+        g.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(y, torch.full((4,), 6.0, device="cuda"))
+
+
+def _has_cuda_bindings():
+    try:
+        from cuda.bindings import runtime  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _collective_nodes(nodes):
+    """Graph nodes issued by NCCL: device kernels (multi-rank) or memcpys
+    (single-rank NCCL lowers self-collectives to copies)."""
+    out = []
+    for n in nodes:
+        name = n.get("kernel_name") or ""
+        if "nccl" in name.lower() or n["node_type"] == "memcpy":
+            out.append(n)
+    return out
+
+
+def _reaches(nodes, src_idx, dst_idx):
+    """Whether dst depends (transitively) on src in the captured graph."""
+    deps = {n["index"]: set(n["dependencies"]) for n in nodes}
+    seen, stack = set(), [dst_idx]
+    while stack:
+        i = stack.pop()
+        if i == src_idx:
+            return True
+        if i in seen:
+            continue
+        seen.add(i)
+        stack.extend(deps.get(i, ()))
+    return False
+
+
+class TestGraphStructureNccl(TestCase):
+    """Structural CUDA-graph fidelity: the mirrored NCCL collective must sit
+    on the application's producer->consumer dependency path, on views of the
+    application tensors, with distinct communicators per logical group."""
+
+    # One NCCL parent communicator per process: a second independent NCCL
+    # init on the same device deadlocks, and shutting a split parent down
+    # while children exist crashes later splits, so tests share the parent.
+    _phys = None
+
+    @classmethod
+    def _physical_parent(cls):
+        if cls._phys is None:
+            from torch.distributed._virtual_pg import create_physical_group
+
+            f = tempfile.NamedTemporaryFile(delete=False)  # noqa: SIM115
+            store = dist.FileStore(f.name, 1)
+            cls._phys = create_physical_group(store, 0, 1, torch.device("cuda:0"))
+        return cls._phys
+
+    def _make_world(self):
+        if not TEST_CUDA or not dist.is_nccl_available():
+            self.skipTest("CUDA and NCCL required")
+        device = torch.device("cuda:0")
+        phys = self._physical_parent()
+        vpg = VirtualProcessGroup(
+            1, 4, phys, mirror_split="split", output_mode="projected"
+        )
+        self.addCleanup(vpg.unregister)
+        return vpg, phys, device
+
+    @skipIfRocm
+    def test_projected_all_gather_uses_app_buffers_in_graph(self):
+        vpg, phys, device = self._make_world()
+        nccl = phys._get_backend(device)
+        splits_before = nccl.comm_split_count()
+        g1 = vpg.new_group([0, 1], group_name="lg1").register()
+        g2 = vpg.new_group([1, 3], group_name="lg2").register()
+        self.addCleanup(g1.unregister)
+        self.addCleanup(g2.unregister)
+        self.assertIsNot(g1.physical_group, g2.physical_group)
+        self.assertEqual(nccl.comm_split_count(), splits_before + 2)
+
+        x1 = torch.ones(4, device=device)
+        x2 = torch.ones(4, device=device)
+        out1 = torch.zeros(4, device=device)
+        out2 = torch.zeros(4, device=device)
+
+        def step():
+            p1 = x1 * 2
+            w1 = g1.all_gather_single(out1, p1, AllgatherOptions())
+            p2 = x2 * 3
+            w2 = g2.all_gather_single(out2, p2, AllgatherOptions())
+            w1.wait()
+            c1 = out1 + 1
+            w2.wait()
+            c2 = out2 + 1
+            return c1, c2
+
+        # warmup: communicators + allocations before capture
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(2):
+                step()
+        torch.cuda.current_stream().wait_stream(s)
+
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        with torch.cuda.graph(graph):
+            c1, c2 = step()
+        graph.instantiate()
+        graph.replay()
+        torch.cuda.synchronize()
+        # projected data: physical world 1 wrote the first chunk of out{1,2}
+        self.assertEqual(c1[:1], torch.tensor([3.0], device=device))
+        self.assertEqual(c2[:1], torch.tensor([4.0], device=device))
+        # no scratch was used: collectives ran on the app tensors
+        self.assertEqual(len(g1._scratch), 0)
+        self.assertEqual(len(g2._scratch), 0)
+
+        if not _has_cuda_bindings():
+            return
+        nodes = graph.get_graph_data()["nodes"]
+        colls = _collective_nodes(nodes)
+        self.assertEqual(len(colls), 2, nodes)
+        first, second = colls[0]["index"], colls[1]["index"]
+        kernels = [n["index"] for n in nodes if n["node_type"] == "kernel"]
+        producers, consumers = kernels[:2], kernels[-2:]
+        # producer -> NCCL -> consumer paths exist
+        self.assertTrue(_reaches(nodes, producers[0], first))
+        self.assertTrue(_reaches(nodes, first, consumers[0]))
+        self.assertTrue(_reaches(nodes, second, consumers[1]))
+        # the two collective branches are independent of each other
+        self.assertFalse(_reaches(nodes, first, second))
+        self.assertFalse(_reaches(nodes, second, first))
+
+    @skipIfRocm
+    def test_scratch_mode_detached_from_app_buffers_in_graph(self):
+        vpg, phys, device = self._make_world()
+        spg = VirtualProcessGroup(
+            1, 4, vpg.physical_group, group_name="scr", output_mode="scratch"
+        )
+        self.addCleanup(spg.unregister)
+        x = torch.ones(4, device=device)
+        out = torch.zeros(16, device=device)
+
+        def step():
+            p = x * 2
+            w = spg.all_gather_single(out, p, AllgatherOptions())
+            w.wait()
+            return out + 1
+
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(2):
+                step()  # grows scratch before capture
+        torch.cuda.current_stream().wait_stream(s)
+        self.assertGreater(len(spg._scratch), 0)
+
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        with torch.cuda.graph(graph):
+            c = step()
+        graph.instantiate()
+        graph.replay()
+        torch.cuda.synchronize()
+        # scratch mode: the logical output tensor was never written
+        self.assertEqual(c, torch.ones(16, device=device))
+
+    @skipIfRocm
+    def test_event_node_counts_recorded(self):
+        # Count NCCL-related event nodes so graph configurations can be
+        # compared; exact counts vary by NCCL version so only record shape.
+        if not _has_cuda_bindings():
+            self.skipTest("cuda-bindings required")
+        vpg, phys, device = self._make_world()
+        g1 = vpg.new_group([0, 1], group_name="ev1").register()
+        self.addCleanup(g1.unregister)
+        x = torch.ones(4, device=device)
+        out = torch.zeros(4, device=device)
+
+        def step():
+            w = g1.all_gather_single(out, x * 2, AllgatherOptions())
+            w.wait()
+            return out + 1
+
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            step()
+        torch.cuda.current_stream().wait_stream(s)
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        with torch.cuda.graph(graph):
+            step()
+        graph.instantiate()
+        nodes = graph.get_graph_data()["nodes"]
+        by_type: dict = {}
+        for n in nodes:
+            by_type[n["node_type"]] = by_type.get(n["node_type"], 0) + 1
+        # every node type observed must be accounted for; event/wait nodes
+        # appear only in some NCCL configurations
+        self.assertLessEqual(
+            set(by_type), {"kernel", "memcpy", "memset", "event_record", "wait_event"}
+        )
+
+
+class TestVirtualWorldTwoProcGloo(MultiProcessTestCase):
+    """Same two-physical-process topology as the NCCL test, on gloo/CPU, so
+    the install + new_group + projection flow runs in NCCL-less CI."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def test_two_proc_virtual_world_projected(self):
+        from torch.distributed._virtual_pg import (
+            create_physical_group,
+            install_virtual_world,
+            uninstall_virtual_world,
+        )
+
+        store = dist.FileStore(self.file_name, self.world_size)
+        phys = create_physical_group(store, self.rank, self.world_size)
+        pw = self.world_size
+        vpg = VirtualProcessGroup(2, 8, phys, output_mode="projected")
+        install_virtual_world(vpg)
+        try:
+            self.assertEqual(dist.get_rank(), 2)
+            self.assertEqual(dist.get_world_size(), 8)
+            g1 = dist.new_group([0, 2])
+            self.assertIsInstance(g1, VirtualProcessGroup)
+            self.assertEqual(g1.rank(), 1)
+
+            inp = torch.full((4,), float(self.rank + 1))
+            out = torch.zeros(g1.size() * 4)
+            w = g1.all_gather_single(out, inp, AllgatherOptions())
+            w.wait()
+            expect = torch.cat([torch.full((4,), float(r + 1)) for r in range(pw)])
+            self.assertEqual(out[: pw * 4], expect)
+            self.assertEqual(len(g1._scratch), 0)
+        finally:
+            uninstall_virtual_world()
+            vpg.unregister()
+
+
+class TestVirtualWorldTwoProcNccl(MultiProcessTestCase):
+    """End-to-end: two physical NCCL ranks hosting a logical world of 8.
+
+    Both processes present the SAME logical rank to the application (rank 2
+    of 8) while having distinct physical ranks, install the virtual PG as
+    the default world, create two logical subgroups through dist.new_group
+    with distinct ncclCommSplit child communicators, and capture
+    producer -> projected all-gather -> consumer in a CUDA graph on views of
+    the application tensors.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_two_proc_virtual_world_cuda_graph(self):
+        from torch.distributed._virtual_pg import (
+            create_physical_group,
+            install_virtual_world,
+            uninstall_virtual_world,
+        )
+
+        device = torch.device(f"cuda:{self.rank}")
+        torch.cuda.set_device(device)
+        store = dist.FileStore(self.file_name, self.world_size)
+        phys = create_physical_group(store, self.rank, self.world_size, device)
+        pw = self.world_size
+
+        # same logical rank on both physical processes, logical world of 8
+        vpg = VirtualProcessGroup(
+            2, 8, phys, mirror_split="split", output_mode="projected"
+        )
+        install_virtual_world(vpg)
+        try:
+            self.assertEqual(dist.get_rank(), 2)
+            self.assertEqual(dist.get_world_size(), 8)
+
+            # two logical subgroups -> two distinct physical split children;
+            # every physical process calls new_group in the same order
+            g1 = dist.new_group([0, 2])
+            g2 = dist.new_group([2, 5, 7])
+            self.assertIsInstance(g1, VirtualProcessGroup)
+            self.assertIsInstance(g2, VirtualProcessGroup)
+            self.assertIsNot(g1.physical_group, g2.physical_group)
+            self.assertIsNot(g1.physical_group, phys)
+            nccl = phys._get_backend(device)
+            self.assertEqual(nccl.comm_split_count(), 2)
+
+            x1 = torch.full((4,), float(self.rank + 1), device=device)
+            x2 = torch.full((4,), float(self.rank + 1), device=device)
+            out1 = torch.zeros(g1.size() * 4, device=device)
+            out2 = torch.zeros(g2.size() * 4, device=device)
+
+            def step():
+                p1 = x1 * 2
+                w1 = g1.all_gather_single(out1, p1, AllgatherOptions())
+                p2 = x2 * 3
+                w2 = g2.all_gather_single(out2, p2, AllgatherOptions())
+                w1.wait()
+                c1 = out1 + 1
+                w2.wait()
+                c2 = out2 + 1
+                return c1, c2
+
+            s = torch.cuda.Stream()
+            s.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(s):
+                for _ in range(2):
+                    step()
+            torch.cuda.current_stream().wait_stream(s)
+
+            graph = torch.cuda.CUDAGraph(keep_graph=True)
+            with torch.cuda.graph(graph):
+                c1, c2 = step()
+            graph.instantiate()
+            x1.fill_(float(self.rank + 10))
+            graph.replay()
+            torch.cuda.synchronize()
+
+            # projected: physical all-gather wrote the first pw*4 elements of
+            # the logical output from the app tensors (views, not scratch)
+            expect1 = torch.cat(
+                [torch.full((4,), (r + 10) * 2 + 1.0, device=device) for r in range(pw)]
+            )
+            self.assertEqual(c1[: pw * 4], expect1)
+            expect2 = torch.cat(
+                [torch.full((4,), (r + 1) * 3 + 1.0, device=device) for r in range(pw)]
+            )
+            self.assertEqual(c2[: pw * 4], expect2)
+            self.assertEqual(len(g1._scratch), 0)
+            self.assertEqual(len(g2._scratch), 0)
+
+            if _has_cuda_bindings():
+                nodes = graph.get_graph_data()["nodes"]
+                kernels = [n["index"] for n in nodes if n["node_type"] == "kernel"]
+                names = [
+                    (n["index"], (n.get("kernel_name") or "").lower()) for n in nodes
+                ]
+                nccl_nodes = [i for i, kn in names if "nccl" in kn]
+                # two collectives from two communicators inside the graph
+                self.assertEqual(len(nccl_nodes), 2, names)
+                first, second = nccl_nodes
+                # producer -> NCCL -> consumer, branches independent
+                self.assertTrue(_reaches(nodes, kernels[0], first))
+                self.assertTrue(_reaches(nodes, first, kernels[-2]))
+                self.assertFalse(_reaches(nodes, first, second))
+                self.assertFalse(_reaches(nodes, second, first))
+        finally:
+            uninstall_virtual_world()
+            vpg.unregister()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/_virtual_pg.py
+++ b/torch/distributed/_virtual_pg.py
@@ -1,0 +1,1018 @@
+"""Prototype virtual/fake ProcessGroups implemented in Python.
+
+This module provides two building blocks for running a large *logical*
+distributed topology inside a much smaller *physical* world:
+
+- ``LocalProcessGroup``: a reusable, all-Python fake ProcessGroup. It is
+  constructed standalone (no ``init_process_group``, no global ``_world``
+  state), has deterministic local semantics for every collective, and routes
+  every collective through a single normalized hook, ``run_collective``.
+
+- ``VirtualProcessGroup``: a ``LocalProcessGroup`` that additionally mirrors
+  every logical collective onto a real physical ProcessGroup (e.g. NCCL or
+  gloo) and returns the *physical* Work object so that ``wait()``
+  synchronizes with the real communication at the actual consumer. Three
+  fidelity levels via ``output_mode``: ``"projected"`` runs the physical
+  collective directly on views of the application tensors (true
+  producer -> collective -> consumer dependencies, CUDA-graph faithful),
+  ``"local_fake"`` fills logical outputs deterministically while mirroring
+  on scratch, and ``"scratch"`` exercises communication structure only.
+
+- ``install_virtual_world``: installs a VirtualProcessGroup as the default
+  process group so unmodified applications (``dist.get_rank``,
+  ``dist.new_group``, ``DeviceMesh``) observe the logical world, with
+  logical subgroups optionally backed by distinct physical split
+  communicators (``mirror_split="split"``).
+
+Both eager collectives (``pg.allreduce(...)``, ``dist.all_reduce(t, group=pg)``)
+and functional collectives (``_c10d_functional`` ops, by group name or PG
+object, eager or under torch.compile) dispatch through the same hook, because
+the interception happens at the ProcessGroup virtual-method boundary via the
+PyProcessGroup trampoline.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import torch
+import torch.distributed as dist
+from torch._C._distributed_c10d import (  # pyrefly: ignore[missing-module-attribute]
+    _create_work_from_future,
+    _register_process_group,
+    _unregister_process_group,
+    AllgatherOptions,
+    AllreduceOptions,
+    AllToAllOptions,
+    ReduceScatterOptions,
+)
+from torch.futures import Future
+
+
+__all__ = [
+    "Collective",
+    "LocalProcessGroup",
+    "ProjectionError",
+    "VirtualProcessGroup",
+    "create_physical_group",
+    "install_virtual_world",
+    "uninstall_virtual_world",
+]
+
+
+_local_pg_count = 0
+
+
+def _completed_work(result: Any) -> dist._Work:
+    fut: Future = Future()
+    fut.set_result(result)
+    return _create_work_from_future(fut)
+
+
+@dataclass
+class Collective:
+    """Normalized description of one collective call.
+
+    Every ProcessGroup entry point (eager and functional) is translated into
+    one of these before being passed to ``run_collective``. ``inputs`` and
+    ``outputs`` are flat tensor lists; ops with nested list signatures (e.g.
+    ``allgather``) keep their original structure in ``opts_args``.
+    """
+
+    op: str
+    inputs: list[torch.Tensor] = field(default_factory=list)
+    outputs: list[torch.Tensor] = field(default_factory=list)
+    reduce_op: dist.ReduceOp | None = None
+    root: int | None = None
+    peer: int | None = None
+    tag: int | None = None
+    input_splits: list[int] | None = None
+    output_splits: list[int] | None = None
+    # Original (unnormalized) positional args, for hooks that need full detail
+    opts_args: tuple = ()
+
+
+class LocalProcessGroup(dist.ProcessGroup):
+    """All-Python fake ProcessGroup with a logical rank/world size.
+
+    Standalone: does not require or touch ``init_process_group`` state. The
+    logical rank/world size are independent of any physical transport. All
+    collectives complete immediately with deterministic local semantics
+    (documented per-op in ``_default_semantics``); reductions degenerate to
+    identity because only this rank's data is available locally.
+
+    Subclasses customize behavior by overriding a single hook::
+
+        def run_collective(self, coll: Collective) -> Optional[dist._Work]
+
+    Returning ``None`` means "local semantics were applied; complete
+    immediately". Returning a Work defers completion to that Work (this is
+    how ``VirtualProcessGroup`` returns real physical Work objects).
+    """
+
+    def __init__(self, rank: int, world_size: int, group_name: str | None = None):
+        if not (0 <= rank < world_size):
+            raise ValueError(f"invalid rank {rank} for world size {world_size}")
+        # pyrefly: ignore[missing-argument, bad-argument-type]
+        super().__init__(rank, world_size)
+        global _local_pg_count
+        if group_name is None:
+            group_name = f"local_pg_{_local_pg_count}"
+            _local_pg_count += 1
+        # The base C++ getGroupName() requires a registered backend, which a
+        # pure-Python PG does not have, so keep the name Python-side.
+        self._name = group_name
+        self._desc = "undefined"
+        self._registered = False
+        self.register()
+
+    # -- registration in the C++ group registry (funcol name resolution) --
+
+    def register(self) -> "LocalProcessGroup":
+        if not self._registered:
+            # pyrefly: ignore[bad-argument-type]
+            _register_process_group(self._name, self)
+            self._registered = True
+        return self
+
+    def unregister(self) -> None:
+        if self._registered:
+            # pyrefly: ignore[bad-argument-type]
+            _unregister_process_group(self._name)
+            self._registered = False
+
+    # -- metadata overrides (trampoline dispatches these to Python) --
+
+    def getBackendName(self) -> str:
+        return "local-py"
+
+    def getGroupName(self) -> str:
+        return self._name
+
+    def setGroupName(self, name: str) -> None:
+        self._name = name
+
+    def getGroupDesc(self) -> str:
+        return self._desc
+
+    def setGroupDesc(self, desc: str) -> None:
+        self._desc = desc
+
+    # -- the single normalized hook --
+
+    def run_collective(self, coll: Collective) -> dist._Work | None:
+        return None
+
+    def _dispatch(self, coll: Collective) -> dist._Work:
+        if self._use_local_semantics(coll):
+            self._default_semantics(coll)
+        work = self.run_collective(coll)
+        if work is None:
+            work = _completed_work(coll.outputs if coll.outputs else coll.inputs)
+        return work
+
+    def _use_local_semantics(self, coll: Collective) -> bool:
+        """Whether ``_dispatch`` fills outputs with deterministic local data.
+
+        Subclasses that produce the logical output by other means (e.g. a
+        projected physical collective) return False so no extra fill kernels
+        are issued, which matters under CUDA graph capture.
+        """
+        return True
+
+    # -- deterministic local semantics --
+
+    def _default_semantics(self, coll: Collective) -> None:
+        """Apply deterministic local data semantics for ``coll`` in place.
+
+        Reductions are identity (only local data available); gather-like ops
+        replicate the local input; scatter-like ops select this rank's chunk.
+        Mirrors the C++ FakeProcessGroup semantics so outputs are never left
+        uninitialized. Copies run below autograd so requires_grad inputs work.
+        """
+        with torch.no_grad():
+            self._apply_semantics(coll)
+
+    def _apply_semantics(self, coll: Collective) -> None:
+        op = coll.op
+        if op in (
+            "allreduce",
+            "allreduce_coalesced",
+            "reduce",
+            "broadcast",
+            "barrier",
+            "send",
+            "recv",
+            "recv_anysource",
+        ):
+            return  # in-place identity or no local effect
+        if op == "allgather":
+            output_lists, input_tensors = coll.opts_args[0], coll.opts_args[1]
+            for outs, inp in zip(output_lists, input_tensors):
+                for o in outs:
+                    o.detach().copy_(inp)
+        elif op == "all_gather_single":
+            out, inp = coll.outputs[0], coll.inputs[0]
+            for chunk in out.detach().chunk(self.size()):
+                chunk.copy_(inp)
+        elif op == "all_gather_single_coalesced":
+            for out, inp in zip(coll.outputs, coll.inputs):
+                for chunk in out.detach().chunk(self.size()):
+                    chunk.copy_(inp)
+        elif op == "gather":
+            if coll.root == self.rank():
+                output_lists, input_tensors = coll.opts_args[0], coll.opts_args[1]
+                for outs, inp in zip(output_lists, input_tensors):
+                    for o in outs:
+                        o.detach().copy_(inp)
+        elif op == "scatter":
+            if coll.root == self.rank():
+                input_lists = coll.opts_args[1]
+                for out, ins in zip(coll.outputs, input_lists):
+                    out.detach().copy_(ins[self.rank()])
+        elif op == "reduce_scatter":
+            input_lists = coll.opts_args[1]
+            for out, ins in zip(coll.outputs, input_lists):
+                out.detach().copy_(ins[self.rank()])
+        elif op in ("reduce_scatter_single", "reduce_scatter_single_coalesced"):
+            for out, inp in zip(coll.outputs, coll.inputs):
+                out.detach().copy_(inp.chunk(self.size())[self.rank()])
+        elif op == "alltoall":
+            for out, inp in zip(coll.outputs, coll.inputs):
+                out.detach().copy_(inp)
+        elif op == "all_to_all_single":
+            out, inp = coll.outputs[0], coll.inputs[0]
+            if not coll.input_splits and not coll.output_splits:
+                out.detach().copy_(inp)
+            else:
+                # Uneven splits: this rank's contribution to itself is the
+                # only locally-knowable piece; fill the rest by repeating it.
+                in_splits = (
+                    coll.input_splits or [inp.size(0) // self.size()] * self.size()
+                )
+                start = sum(in_splits[: self.rank()])
+                chunk = inp[start : start + in_splits[self.rank()]]
+                out_splits = (
+                    coll.output_splits or [out.size(0) // self.size()] * self.size()
+                )
+                off = 0
+                for s in out_splits:
+                    n = min(s, chunk.size(0))
+                    if n > 0:
+                        out.detach()[off : off + n].copy_(chunk[:n])
+                    off += s
+        else:
+            raise NotImplementedError(f"LocalProcessGroup: unhandled op {op}")
+
+    # -- ProcessGroup virtual methods, normalized into Collective --
+
+    # pyrefly: ignore[bad-override]
+    def broadcast(self, tensors: list[torch.Tensor], opts: Any = None) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "broadcast",
+                inputs=list(tensors),
+                outputs=list(tensors),
+                root=opts.rootRank,
+                opts_args=(tensors, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def allreduce(self, tensors: list[torch.Tensor], opts: Any = None) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "allreduce",
+                inputs=list(tensors),
+                outputs=list(tensors),
+                reduce_op=opts.reduceOp,
+                opts_args=(tensors, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def allreduce_coalesced(
+        self, tensors: list[torch.Tensor], opts: Any = None
+    ) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "allreduce_coalesced",
+                inputs=list(tensors),
+                outputs=list(tensors),
+                reduce_op=opts.reduceOp,
+                opts_args=(tensors, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def reduce(self, tensors: list[torch.Tensor], opts: Any = None) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "reduce",
+                inputs=list(tensors),
+                outputs=list(tensors),
+                reduce_op=opts.reduceOp,
+                root=opts.rootRank,
+                opts_args=(tensors, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def allgather(
+        self,
+        output_lists: list[list[torch.Tensor]],
+        input_tensors: list[torch.Tensor],
+        opts: Any = None,
+    ) -> dist._Work:
+        flat_out = [o for outs in output_lists for o in outs]
+        return self._dispatch(
+            Collective(
+                "allgather",
+                inputs=list(input_tensors),
+                outputs=flat_out,
+                opts_args=(output_lists, input_tensors, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def all_gather_single(
+        self, output: torch.Tensor, input: torch.Tensor, opts: Any = None
+    ) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "all_gather_single",
+                inputs=[input],
+                outputs=[output],
+                opts_args=(output, input, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def all_gather_single_coalesced(
+        self, outputs: list[torch.Tensor], inputs: list[torch.Tensor], opts: Any = None
+    ) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "all_gather_single_coalesced",
+                inputs=list(inputs),
+                outputs=list(outputs),
+                opts_args=(outputs, inputs, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def gather(
+        self,
+        output_lists: list[list[torch.Tensor]],
+        input_tensors: list[torch.Tensor],
+        opts: Any = None,
+    ) -> dist._Work:
+        flat_out = [o for outs in output_lists for o in outs]
+        return self._dispatch(
+            Collective(
+                "gather",
+                inputs=list(input_tensors),
+                outputs=flat_out,
+                root=opts.rootRank,
+                opts_args=(output_lists, input_tensors, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def scatter(
+        self,
+        output_tensors: list[torch.Tensor],
+        input_lists: list[list[torch.Tensor]],
+        opts: Any = None,
+    ) -> dist._Work:
+        flat_in = [i for ins in input_lists for i in ins]
+        return self._dispatch(
+            Collective(
+                "scatter",
+                inputs=flat_in,
+                outputs=list(output_tensors),
+                root=opts.rootRank,
+                opts_args=(output_tensors, input_lists, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def reduce_scatter(
+        self,
+        output_tensors: list[torch.Tensor],
+        input_lists: list[list[torch.Tensor]],
+        opts: Any = None,
+    ) -> dist._Work:
+        flat_in = [i for ins in input_lists for i in ins]
+        return self._dispatch(
+            Collective(
+                "reduce_scatter",
+                inputs=flat_in,
+                outputs=list(output_tensors),
+                reduce_op=opts.reduceOp,
+                opts_args=(output_tensors, input_lists, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def reduce_scatter_single(
+        self, output: torch.Tensor, input: torch.Tensor, opts: Any = None
+    ) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "reduce_scatter_single",
+                inputs=[input],
+                outputs=[output],
+                reduce_op=opts.reduceOp,
+                opts_args=(output, input, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def reduce_scatter_single_coalesced(
+        self, outputs: list[torch.Tensor], inputs: list[torch.Tensor], opts: Any = None
+    ) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "reduce_scatter_single_coalesced",
+                inputs=list(inputs),
+                outputs=list(outputs),
+                reduce_op=opts.reduceOp,
+                opts_args=(outputs, inputs, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def alltoall(
+        self, outputs: list[torch.Tensor], inputs: list[torch.Tensor], opts: Any = None
+    ) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "alltoall",
+                inputs=list(inputs),
+                outputs=list(outputs),
+                opts_args=(outputs, inputs, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def all_to_all_single(
+        self,
+        output: torch.Tensor,
+        input: torch.Tensor,
+        output_splits: list[int],
+        input_splits: list[int],
+        opts: Any = None,
+    ) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "all_to_all_single",
+                inputs=[input],
+                outputs=[output],
+                input_splits=list(input_splits),
+                output_splits=list(output_splits),
+                opts_args=(output, input, output_splits, input_splits, opts),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def barrier(self, opts: Any = None) -> dist._Work:
+        return self._dispatch(Collective("barrier", opts_args=(opts,)))
+
+    # pyrefly: ignore[bad-override]
+    def send(self, tensors: list[torch.Tensor], dst_rank: int, tag: int) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "send",
+                inputs=list(tensors),
+                peer=dst_rank,
+                tag=tag,
+                opts_args=(tensors, dst_rank, tag),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def recv(self, tensors: list[torch.Tensor], src_rank: int, tag: int) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "recv",
+                outputs=list(tensors),
+                peer=src_rank,
+                tag=tag,
+                opts_args=(tensors, src_rank, tag),
+            )
+        )
+
+    # pyrefly: ignore[bad-override]
+    def recvAnysource(self, tensors: list[torch.Tensor], tag: int) -> dist._Work:
+        return self._dispatch(
+            Collective(
+                "recv_anysource",
+                outputs=list(tensors),
+                tag=tag,
+                opts_args=(tensors, tag),
+            )
+        )
+
+    # -- logical subgroup creation --
+
+    def split_local(
+        self, ranks: list[int], group_name: str | None = None
+    ) -> Optional["LocalProcessGroup"]:
+        """Create a logical subgroup of this group.
+
+        ``ranks`` are ranks of *this* group (parent-local, not global). The
+        new group's rank is this rank's position in ``ranks``. Returns None
+        if this rank is not a member. This is standalone splitting: it does
+        not require the default process group or ``_world`` registration,
+        unlike ``dist.split_group``.
+        """
+        for r in ranks:
+            if not (0 <= r < self.size()):
+                raise ValueError(f"rank {r} out of range for world size {self.size()}")
+        if len(set(ranks)) != len(ranks):
+            raise ValueError(f"duplicate ranks in {ranks}")
+        if self.rank() not in ranks:
+            return None
+        if group_name is None:
+            group_name = f"{self._name}:split:{'_'.join(map(str, ranks))}"
+        return type(self)._split_impl(self, ranks, group_name)
+
+    @classmethod
+    def _split_impl(
+        cls, parent: "LocalProcessGroup", ranks: list[int], group_name: str
+    ) -> "LocalProcessGroup":
+        return LocalProcessGroup(ranks.index(parent.rank()), len(ranks), group_name)
+
+    def splitGroup(
+        self,
+        ranks: list[int],
+        timeout: Any = None,
+        opts: Any = None,
+        group_name: str | None = None,
+        group_desc: str | None = None,
+        devices: Any = None,
+    ) -> Optional["LocalProcessGroup"]:
+        pg = self.split_local(list(ranks), group_name)
+        if pg is not None and group_desc is not None:
+            pg._desc = group_desc
+        return pg
+
+
+class ProjectionError(RuntimeError):
+    """Raised when ``output_mode="projected"`` cannot map a logical collective
+    onto views of the application tensors. Never silently falls back to
+    scratch buffers; callers that can tolerate structure-only mirroring must
+    opt into ``output_mode="scratch"`` explicitly."""
+
+
+class VirtualProcessGroup(LocalProcessGroup):
+    """Logical ProcessGroup mirrored onto a real physical ProcessGroup.
+
+    Presents a logical (rank, world_size) independent of the physical
+    transport, while every logical collective issues a *real* collective of
+    the same kind on ``physical_group`` and returns the physical Work, so
+    ``wait()`` at the consumer synchronizes with real communication.
+
+    ``output_mode`` selects how the physical collective relates to the
+    application's tensors:
+
+    - ``"projected"``: the physical collective executes directly on
+      contiguous views of the logical input/output tensors, creating true
+      producer-kernel -> NCCL -> consumer-kernel dependencies in the stream
+      (and thus in a captured CUDA graph). The physical collective writes the
+      reachable prefix of the logical output; logical-rank data beyond the
+      physical world size is undefined. No local fill kernels are issued.
+      Raises ProjectionError when a faithful view mapping is impossible.
+    - ``"local_fake"``: deterministic local semantics fill the logical
+      outputs (useful for ordinary tests); the physical collective runs on
+      private scratch buffers.
+    - ``"scratch"``: physical collective on private scratch buffers only;
+      logical outputs are left untouched. Exercises communication structure
+      but has NO tensor-data dependency on the application's producers or
+      consumers.
+
+    In ``"projected"`` mode there are no allocations at issue time (views
+    only); warm up once before CUDA graph capture so the physical
+    communicator is initialized. In scratch-based modes the scratch pool
+    grows on first use per (op, size, dtype, device) — warm up every shape
+    before capture.
+
+    ``physical_peer_map`` (logical rank -> physical rank) enables real
+    mirroring of send/recv; without it P2P is a local no-op.
+
+    Logical splits (``split_local``/``splitGroup``) produce a
+    ``VirtualProcessGroup`` sharing the same physical group by default, or a
+    physically split communicator with ``mirror_split="split"`` when the
+    physical backend supports splitting.
+    """
+
+    def __init__(
+        self,
+        rank: int,
+        world_size: int,
+        physical_group: dist.ProcessGroup,
+        group_name: str | None = None,
+        mirror_split: str = "reuse",
+        output_mode: str = "local_fake",
+        physical_peer_map: dict[int, int] | None = None,
+    ):
+        if mirror_split not in ("reuse", "split"):
+            raise ValueError(
+                f"mirror_split must be 'reuse' or 'split', got {mirror_split!r}"
+            )
+        if output_mode not in ("projected", "local_fake", "scratch"):
+            raise ValueError(
+                f"output_mode must be 'projected', 'local_fake' or 'scratch', "
+                f"got {output_mode!r}"
+            )
+        self.physical_group = physical_group
+        self.mirror_split = mirror_split
+        self.output_mode = output_mode
+        self.physical_peer_map = physical_peer_map
+        # keyed by (op, numel_per_rank, dtype, device); persistent so mirrored
+        # collectives have stable buffer addresses (CUDA-graph friendly)
+        self._scratch: dict[tuple, list[torch.Tensor]] = {}
+        super().__init__(rank, world_size, group_name)
+
+    def getBackendName(self) -> str:
+        return "virtual-py"
+
+    def _use_local_semantics(self, coll: Collective) -> bool:
+        return self.output_mode == "local_fake"
+
+    def run_collective(self, coll: Collective) -> dist._Work | None:
+        if coll.op in ("barrier", "recv_anysource"):
+            return None
+        with torch.profiler.record_function(f"virtual_pg::{self._name}::{coll.op}"):
+            if coll.op in ("send", "recv"):
+                return self._mirror_p2p(coll)
+            if self.output_mode == "projected":
+                return self._mirror_projected(coll)
+            return self._mirror_scratch(coll)
+
+    # -- P2P mirroring --
+
+    def _mirror_p2p(self, coll: Collective) -> dist._Work | None:
+        if self.physical_peer_map is None:
+            if self.output_mode == "projected":
+                raise ProjectionError(
+                    f"{coll.op} in projected mode requires physical_peer_map"
+                )
+            return None
+        if coll.peer is None:
+            raise ProjectionError(f"{coll.op} missing peer rank")
+        phys_peer = self.physical_peer_map.get(coll.peer)
+        if phys_peer is None:
+            raise ProjectionError(f"logical peer {coll.peer} not in physical_peer_map")
+        tensors = coll.inputs if coll.op == "send" else coll.outputs
+        # P2P operates directly on the application tensors: full fidelity.
+        if coll.op == "send":
+            return self.physical_group.send(tensors, phys_peer, coll.tag or 0)
+        return self.physical_group.recv(tensors, phys_peer, coll.tag or 0)
+
+    # -- projected mirroring: physical collective on views of logical tensors --
+
+    @staticmethod
+    def _flat_view(t: torch.Tensor, numel: int, what: str) -> torch.Tensor:
+        if not t.is_contiguous():
+            raise ProjectionError(f"{what} must be contiguous for projection")
+        if t.numel() < numel:
+            raise ProjectionError(
+                f"{what} has {t.numel()} elements, projection needs {numel}"
+            )
+        return t.detach().reshape(-1)[:numel]
+
+    def _mirror_projected(self, coll: Collective) -> dist._Work:
+        """Run the physical collective directly on views of the logical
+        tensors, so the collective inherits the application's producer
+        dependencies and its consumers depend on the collective.
+
+        Only single-buffer collective forms project faithfully; list-form ops
+        (allgather into separate output tensors, gather/scatter/alltoall
+        lists) raise ProjectionError because their outputs are not one
+        contiguous buffer.
+        """
+        pg = self.physical_group
+        pw = pg.size()
+        op = coll.op
+        work: dist._Work | None = None
+        if op in ("allreduce", "allreduce_coalesced"):
+            opts = AllreduceOptions()
+            if coll.reduce_op is not None:
+                opts.reduceOp = coll.reduce_op
+            for t in coll.inputs:
+                if not t.is_contiguous():
+                    raise ProjectionError("allreduce tensor must be contiguous")
+                work = pg.allreduce([t.detach()], opts)
+        elif op == "broadcast":
+            from torch._C._distributed_c10d import BroadcastOptions
+
+            opts = BroadcastOptions()
+            # physical root: logical root's data only exists physically when
+            # some physical rank holds it; fold into the physical namespace
+            opts.rootRank = (coll.root or 0) % pw
+            for t in coll.inputs:
+                if not t.is_contiguous():
+                    raise ProjectionError("broadcast tensor must be contiguous")
+                work = pg.broadcast([t.detach()], opts)
+        elif op in ("all_gather_single", "all_gather_single_coalesced"):
+            for out, inp in zip(coll.outputs, coll.inputs):
+                n = inp.numel()
+                in_view = self._flat_view(inp, n, "all_gather input")
+                out_view = self._flat_view(out, pw * n, "all_gather output")
+                work = pg.all_gather_single(out_view, in_view, AllgatherOptions())
+        elif op in ("reduce_scatter_single", "reduce_scatter_single_coalesced"):
+            opts = ReduceScatterOptions()
+            if coll.reduce_op is not None:
+                opts.reduceOp = coll.reduce_op
+            for out, inp in zip(coll.outputs, coll.inputs):
+                n = out.numel()
+                in_view = self._flat_view(inp, pw * n, "reduce_scatter input")
+                out_view = self._flat_view(out, n, "reduce_scatter output")
+                work = pg.reduce_scatter_single(out_view, in_view, opts)
+        elif op == "all_to_all_single":
+            if coll.input_splits or coll.output_splits:
+                raise ProjectionError(
+                    "all_to_all_single with uneven splits cannot be projected"
+                )
+            inp, out = coll.inputs[0], coll.outputs[0]
+            if inp.numel() % self.size() != 0:
+                raise ProjectionError(
+                    "all_to_all_single input not divisible by logical world"
+                )
+            n = inp.numel() // self.size()
+            in_view = self._flat_view(inp, pw * n, "all_to_all input")
+            out_view = self._flat_view(out, pw * n, "all_to_all output")
+            work = pg.all_to_all_single(out_view, in_view, [], [], AllToAllOptions())
+        else:
+            raise ProjectionError(
+                f"{op} cannot be projected onto model buffers; use "
+                f"output_mode='scratch' explicitly if communication "
+                f"structure alone is sufficient"
+            )
+        if work is None:
+            raise AssertionError(f"projection produced no work for {op}")
+        return work
+
+    # -- scratch mirroring: communication structure only --
+
+    def _scratch_for(
+        self, op: str, ref: torch.Tensor, numel_per_rank: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Persistent (input, output) scratch pair for one mirrored collective."""
+        pw = self.physical_group.size()
+        key = (op, numel_per_rank, ref.dtype, ref.device)
+        if key not in self._scratch:
+            inp = torch.empty(numel_per_rank * pw, dtype=ref.dtype, device=ref.device)
+            out = torch.empty(numel_per_rank * pw, dtype=ref.dtype, device=ref.device)
+            self._scratch[key] = [inp, out]
+        return self._scratch[key][0], self._scratch[key][1]
+
+    def _mirror_scratch(self, coll: Collective) -> dist._Work:
+        """Issue a real collective of the same kind on private scratch
+        buffers. Communication volume per physical rank approximates the
+        logical per-rank volume, but the collective has no tensor dependency
+        on the application's producers or consumers; only the returned Work
+        links it to the logical program.
+        """
+        ref = coll.inputs[0] if coll.inputs else coll.outputs[0]
+        pg = self.physical_group
+        pw = pg.size()
+        n = max(ref.numel(), 1)
+        op = coll.op
+        with torch.no_grad():
+            if op in ("allreduce", "allreduce_coalesced", "reduce", "broadcast"):
+                inp, _ = self._scratch_for("allreduce", ref, n)
+                buf = inp[:n]
+                buf.copy_(ref.detach().reshape(-1))
+                opts = AllreduceOptions()
+                if coll.reduce_op is not None and op != "broadcast":
+                    opts.reduceOp = coll.reduce_op
+                return pg.allreduce([buf], opts)
+            if op in (
+                "allgather",
+                "all_gather_single",
+                "all_gather_single_coalesced",
+                "gather",
+            ):
+                inp, out = self._scratch_for("all_gather", ref, n)
+                buf = inp[:n]
+                buf.copy_(ref.detach().reshape(-1))
+                return pg.all_gather_single(out, buf, AllgatherOptions())
+            if op in (
+                "reduce_scatter",
+                "reduce_scatter_single",
+                "reduce_scatter_single_coalesced",
+                "scatter",
+            ):
+                inp, out = self._scratch_for("reduce_scatter", ref, n)
+                inp.copy_(
+                    ref.detach().reshape(-1).expand(pw, n).reshape(-1)
+                    if ref.numel()
+                    else inp
+                )
+                opts = ReduceScatterOptions()
+                if coll.reduce_op is not None:
+                    opts.reduceOp = coll.reduce_op
+                return pg.reduce_scatter_single(out[:n], inp, opts)
+            if op in ("alltoall", "all_to_all_single"):
+                inp, out = self._scratch_for("all_to_all", ref, n)
+                inp[:n].copy_(ref.detach().reshape(-1))
+                return pg.all_to_all_single(out, inp, [], [], AllToAllOptions())
+        raise NotImplementedError(f"VirtualProcessGroup: unhandled op {op}")
+
+    @classmethod
+    def _split_impl(
+        cls, parent: "LocalProcessGroup", ranks: list[int], group_name: str
+    ) -> "LocalProcessGroup":
+        if not isinstance(parent, VirtualProcessGroup):
+            raise TypeError(f"expected VirtualProcessGroup, got {type(parent)}")
+        phys = parent.physical_group
+        if parent.mirror_split == "split":
+            new_phys = phys.split_group(
+                list(range(phys.size())),
+                None,
+                None,
+                # pyrefly: ignore[bad-argument-type]
+                f"{group_name}:phys",
+                None,
+                None,
+            )
+            if new_phys is None:
+                raise RuntimeError("physical split_group returned no group")
+            phys = new_phys
+        return VirtualProcessGroup(
+            ranks.index(parent.rank()),
+            len(ranks),
+            phys,
+            group_name,
+            parent.mirror_split,
+            parent.output_mode,
+            parent.physical_peer_map,
+        )
+
+    def new_group(
+        self,
+        ranks: list[int],
+        timeout: Any = None,
+        backend: Any = None,
+        pg_options: Any = None,
+        group_name: str | None = None,
+        group_desc: str | None = None,
+    ) -> Optional["VirtualProcessGroup"]:
+        """Hook for ``dist.new_group`` delegation when this group is the
+        default world (see ``_new_group_with_tag``): creates a virtual
+        logical child. ``ranks`` are logical ranks of this group. With
+        ``mirror_split="split"`` each logical child receives a distinct
+        physical child communicator, split deterministically from the
+        physical parent with ALL physical ranks (physical-parent-local rank
+        namespace; the logical namespace never leaks into the physical
+        split). All physical processes must therefore call ``new_group`` in
+        the same order, including for logical groups they are not members
+        of, mirroring the standard c10d contract.
+        """
+        # Physical child creation must happen on every physical process and
+        # in deterministic order, so do it before the membership early-out.
+        phys = self._physical_child(group_name)
+        if self.rank() not in ranks:
+            return None
+        child = VirtualProcessGroup(
+            ranks.index(self.rank()),
+            len(ranks),
+            phys,
+            group_name,
+            self.mirror_split,
+            self.output_mode,
+            self.physical_peer_map,
+        )
+        if group_desc is not None:
+            child._desc = group_desc
+        # The caller (_new_group_with_tag) registers the group in the C++
+        # registry via _register_pg_in_world; drop our ctor registration so
+        # the name is not claimed twice.
+        child.unregister()
+        return child
+
+    def _physical_child(self, group_name: str | None) -> dist.ProcessGroup:
+        if self.mirror_split != "split":
+            return self.physical_group
+        phys = self.physical_group
+        new_phys = phys.split_group(
+            list(range(phys.size())),
+            None,
+            None,
+            # pyrefly: ignore[bad-argument-type]
+            f"{group_name}:phys" if group_name else None,
+            None,
+            None,
+        )
+        if new_phys is None:
+            raise RuntimeError("physical split_group returned no group")
+        return new_phys
+
+
+def create_physical_group(
+    store: dist.Store,
+    rank: int,
+    world_size: int,
+    device: torch.device | None = None,
+    group_name: str = "virtual_pg_physical",
+) -> dist.ProcessGroup:
+    """Create a standalone physical ProcessGroup suitable as a mirror target.
+
+    Builds a ``ProcessGroup`` with an NCCL backend (if ``device`` is a CUDA
+    device) or gloo backend, without touching the default-group machinery.
+    For NCCL the communicator is eagerly connected so the group is
+    ``split_group``-capable (``ncclCommSplit``) and safe to use during CUDA
+    graph capture. This group lives in the *physical* rank namespace: its
+    rank/world size come from the transport, not from any logical topology.
+    """
+    pg = dist.ProcessGroup(store, rank, world_size)
+    # pyrefly: ignore[bad-argument-type]
+    pg._set_group_name(group_name)
+    if device is not None and device.type == "cuda":
+        opts = dist.ProcessGroupNCCL.Options()
+        nccl = dist.ProcessGroupNCCL(store, rank, world_size, opts)
+        nccl.eager_connect_single_device(device)
+        pg._register_backend(device, dist.ProcessGroup.BackendType.NCCL, nccl)
+        pg._set_default_backend(dist.ProcessGroup.BackendType.NCCL)
+    else:
+        gloo = dist.ProcessGroupGloo(store, rank, world_size)
+        pg._register_backend(
+            torch.device("cpu"), dist.ProcessGroup.BackendType.GLOO, gloo
+        )
+        pg._set_default_backend(dist.ProcessGroup.BackendType.GLOO)
+    return pg
+
+
+def install_virtual_world(
+    virtual_pg: VirtualProcessGroup, store: dist.Store | None = None
+) -> VirtualProcessGroup:
+    """Install ``virtual_pg`` as the default process group.
+
+    After this, an unmodified application sees the logical world:
+    ``dist.get_rank()``/``get_world_size()`` report logical values,
+    ``dist.new_group()`` creates virtual logical children via
+    ``VirtualProcessGroup.new_group`` (each optionally backed by a distinct
+    physical child communicator), and ``DeviceMesh`` builds its dimension
+    groups through the same path.
+
+    ``init_process_group`` must not already have been called. Undo with
+    ``uninstall_virtual_world``.
+    """
+    import torch.distributed.distributed_c10d as c10d
+
+    if c10d.is_initialized():
+        raise RuntimeError(
+            "install_virtual_world requires an uninitialized default group"
+        )
+    if store is None:
+        from torch.testing._internal.distributed.fake_pg import FakeStore
+
+        store = FakeStore()
+    # Register the backend name so BackendConfig in the new_group delegation
+    # path resolves it without warning. register_backend rejects duplicates,
+    # so only do it once per process.
+    name = virtual_pg.getBackendName()
+    if name.upper() not in c10d.Backend._plugins:
+        c10d.Backend.register_backend(
+            name,
+            lambda *a, **kw: (_ for _ in ()).throw(
+                RuntimeError("virtual PGs are constructed via new_group delegation")
+            ),
+            devices=["cpu", "cuda"],
+        )
+    c10d._update_default_pg(virtual_pg)
+    c10d._world.pg_map[virtual_pg] = (virtual_pg.getBackendName(), store)
+    c10d._world.pg_names[virtual_pg] = virtual_pg.group_name
+    c10d._world.pg_backend_config[virtual_pg] = virtual_pg.getBackendName()
+    c10d._world.pg_group_ranks[virtual_pg] = {i: i for i in range(virtual_pg.size())}
+    tag = f"ptd:{virtual_pg.group_name}"
+    c10d._world.tags_to_pg.setdefault("", []).append(virtual_pg)
+    c10d._world.tags_to_pg.setdefault(tag, []).append(virtual_pg)
+    c10d._world.pg_to_tag[virtual_pg] = tag
+    return virtual_pg
+
+
+def uninstall_virtual_world() -> None:
+    """Remove a virtual default world installed by ``install_virtual_world``.
+
+    Uses ``destroy_process_group`` teardown semantics for the ``_world``
+    dictionaries but leaves the physical group alive (the caller owns it).
+    """
+    import torch.distributed.distributed_c10d as c10d
+
+    default_pg = c10d._world.default_pg
+    if default_pg is not None:
+        for d in (
+            c10d._world.pg_map,
+            c10d._world.pg_names,
+            c10d._world.pg_backend_config,
+            c10d._world.pg_group_ranks,
+            c10d._world.pg_to_tag,
+        ):
+            d.pop(default_pg, None)
+        for pgs in c10d._world.tags_to_pg.values():
+            while default_pg in pgs:
+                pgs.remove(default_pg)
+    c10d._update_default_pg(None)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #191634
* #191633

Adds torch/distributed/_virtual_pg.py: Python process groups that present
a logical rank/world size independent of the physical transport, for
running a large logical distributed topology on a much smaller physical
world while preserving real collective kernels, communicator separation,
CUDA-graph dependencies, and consumer-placed Work.wait().

Review in this order:

1. LocalProcessGroup: a standalone, reusable all-Python fake PG. Every
   ProcessGroup virtual (including the coalesced variants functional
   collectives require) normalizes its arguments into one Collective
   dataclass and calls a single hook, run_collective(). The default hook
   applies deterministic FakeProcessGroup-style local semantics. Because
   interception happens at the ProcessGroup virtual-method boundary
   (PyProcessGroup trampoline), eager dist.* calls, functional collectives
   (by group name or PG object), and torch.compile'd graphs all dispatch
   identically. split_local()/splitGroup() give parent-local logical
   subgroups without touching the default group.

2. VirtualProcessGroup: composes LocalProcessGroup with a real physical
   ProcessGroup and returns the physical Work so synchronization happens at
   the actual consumer. output_mode selects fidelity: 'projected' runs the
   physical collective directly on contiguous views of the application
   tensors (true producer -> collective -> consumer stream/graph
   dependencies, no fill kernels, ProjectionError instead of silent scratch
   fallback), 'local_fake' fills logical outputs deterministically while
   mirroring on persistent scratch, 'scratch' exercises communication
   structure only. physical_peer_map enables real P2P mirroring.

3. install_virtual_world()/create_physical_group(): installs a virtual PG
   as the default world so unmodified applications observe the logical
   topology (dist.get_rank/get_world_size, dist.new_group -> virtual
   children via the existing new_group delegation hook, DeviceMesh dim
   groups). With mirror_split='split' each logical child gets a distinct
   ncclCommSplit child communicator, split in the physical rank namespace
   before the logical membership check so all physical processes
   participate in deterministic order.

No core changes were needed: the PyProcessGroup trampoline, the C++
GroupRegistry, the new_group delegation hook, and per-device backend
registration were sufficient. Alternatives considered: extending the C++
FakeProcessGroup (its constructor is deliberately sealed and per-op C++
semantics are not extensible from Python) and a dispatcher-level
TorchDispatchMode interceptor like LocalTensor (cannot drive real backends
or return real Work objects); the ProcessGroup-boundary approach was chosen
because it is the one place where eager, functional, and compiled paths
already converge.

Test Plan:

test/distributed/test_virtual_pg.py: 71 tests covering eager collectives
and data semantics, funcol by name/object, Work lifetime and gc, logical
splits, torch.compile parity (string and object groups), projected-mode
buffer identity (data_ptr assertions) and rejection paths, install +
new_group + DeviceMesh integration, deferred-Work consumer-join semantics,
CUDA-graph capture/replay with two ncclCommSplit communicators and
get_graph_data() assertions on producer->NCCL->consumer reachability and
branch independence, and a two-process NCCL end-to-end test (skips without
2 GPUs; its gloo twin runs everywhere).

```
NCCL_SOCKET_IFNAME=lo python test/distributed/test_virtual_pg.py
```

70 pass + 1 skip (2-GPU NCCL) on a 1x H100 box. Regression-checked:

```
python test/distributed/test_fake_pg.py     # 72 OK
python test/distributed/test_c10d_pypg.py   # 64 OK (36 skipped)
```

Authored with Claude Code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>