### PR TITLE
[BE][MPS] Fix unused parameters warnings in Unique.metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Unique.metal
+++ b/aten/src/ATen/native/mps/kernels/Unique.metal
@@ -7,7 +7,6 @@ template <typename T>
 kernel void unique_mark_boundaries(
     constant T* sorted [[buffer(0)]],
     device int* mask [[buffer(1)]],
-    constant ulong& numel [[buffer(2)]],
     uint tid [[thread_position_in_grid]]) {
   if (tid == 0) {
     mask[0] = 1;
@@ -29,7 +28,6 @@ kernel void unique_emit(
     constant SCAN_T* scan [[buffer(2)]],
     device T* unique_values [[buffer(3)]],
     device long* bound_pos [[buffer(4)]],
-    constant ulong& numel [[buffer(5)]],
     uint tid [[thread_position_in_grid]]) {
   if (mask[tid]) {
     long k = long(scan[tid]) - 1;
@@ -56,7 +54,6 @@ kernel void unique_inverse(
     constant long* sort_idx [[buffer(0)]],
     constant SCAN_T* scan [[buffer(1)]],
     device long* inverse [[buffer(2)]],
-    constant ulong& numel [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
   inverse[sort_idx[tid]] = long(scan[tid]) - 1;
 }
@@ -66,7 +63,6 @@ kernel void unique_inverse(
   unique_mark_boundaries<T>(                                          \
       constant T * sorted [[buffer(0)]],                              \
       device int* mask [[buffer(1)]],                                 \
-      constant ulong& numel [[buffer(2)]],                            \
       uint tid [[thread_position_in_grid]]);                          \
   template [[host_name("unique_emit_" #NAME "_32")]] kernel void      \
   unique_emit<T, int>(                                                \
@@ -75,7 +71,6 @@ kernel void unique_inverse(
       constant int* scan [[buffer(2)]],                               \
       device T* unique_values [[buffer(3)]],                          \
       device long* bound_pos [[buffer(4)]],                           \
-      constant ulong& numel [[buffer(5)]],                            \
       uint tid [[thread_position_in_grid]]);                          \
   template [[host_name("unique_emit_" #NAME "_64")]] kernel void      \
   unique_emit<T, long>(                                               \
@@ -84,7 +79,6 @@ kernel void unique_inverse(
       constant long* scan [[buffer(2)]],                              \
       device T* unique_values [[buffer(3)]],                          \
       device long* bound_pos [[buffer(4)]],                           \
-      constant ulong& numel [[buffer(5)]],                            \
       uint tid [[thread_position_in_grid]]);
 
 REGISTER_UNIQUE_FOR_T(float, float)
@@ -101,12 +95,10 @@ template [[host_name("unique_inverse_32")]] kernel void unique_inverse<int>(
     constant long* sort_idx [[buffer(0)]],
     constant int* scan [[buffer(1)]],
     device long* inverse [[buffer(2)]],
-    constant ulong& numel [[buffer(3)]],
     uint tid [[thread_position_in_grid]]);
 
 template [[host_name("unique_inverse_64")]] kernel void unique_inverse<long>(
     constant long* sort_idx [[buffer(0)]],
     constant long* scan [[buffer(1)]],
     device long* inverse [[buffer(2)]],
-    constant ulong& numel [[buffer(3)]],
     uint tid [[thread_position_in_grid]]);

--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -327,7 +327,7 @@ static std::tuple<Tensor, Tensor, Tensor> _unique_flat_mps_fast(const Tensor& se
           lib.getPipelineStateForFunc(fmt::format("unique_mark_boundaries_{}", type_name));
       getMPSProfiler().beginProfileKernel(pso, "unique_mark_boundaries", false);
       [encoder setComputePipelineState:pso];
-      mtl_setArgs(encoder, sorted_values, mask, static_cast<uint64_t>(numel));
+      mtl_setArgs(encoder, sorted_values, mask);
       mtl_dispatch1DJob(encoder, pso, numel);
       getMPSProfiler().endProfileKernel(pso);
     }
@@ -360,7 +360,7 @@ static std::tuple<Tensor, Tensor, Tensor> _unique_flat_mps_fast(const Tensor& se
             lib.getPipelineStateForFunc(fmt::format("unique_emit_{}_{}", type_name, scan_suffix));
         getMPSProfiler().beginProfileKernel(pso, "unique_emit", false);
         [encoder setComputePipelineState:pso];
-        mtl_setArgs(encoder, sorted_values, mask, scan, unique_values, bound_pos, static_cast<uint64_t>(numel));
+        mtl_setArgs(encoder, sorted_values, mask, scan, unique_values, bound_pos);
         mtl_dispatch1DJob(encoder, pso, numel);
         getMPSProfiler().endProfileKernel(pso);
       }
@@ -381,7 +381,7 @@ static std::tuple<Tensor, Tensor, Tensor> _unique_flat_mps_fast(const Tensor& se
         id<MTLComputePipelineState> pso = lib.getPipelineStateForFunc(fmt::format("unique_inverse_{}", scan_suffix));
         getMPSProfiler().beginProfileKernel(pso, "unique_inverse", false);
         [encoder setComputePipelineState:pso];
-        mtl_setArgs(encoder, sort_idx, scan, inverse, static_cast<uint64_t>(numel));
+        mtl_setArgs(encoder, sort_idx, scan, inverse);
         mtl_dispatch1DJob(encoder, pso, numel);
         getMPSProfiler().endProfileKernel(pso);
       }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #191640
* __->__ #191636

Namely
```
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/Unique.metal:10:21: warning: unused parameter 'numel' [-Wunused-parameter]
    constant ulong& numel [[buffer(2)]],
                    ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/Unique.metal:32:21: warning: unused parameter 'numel' [-Wunused-parameter]
    constant ulong& numel [[buffer(5)]],
                    ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/Unique.metal:59:21: warning: unused parameter 'numel' [-Wunused-parameter]
    constant ulong& numel [[buffer(3)]],
                    ^
3 warnings generated.
```

And remove this argument when passing kernel from CPU side