### PR TITLE
[tests] #191343 followup - missing delete to trigger unmap

### DIFF
--- a/test/distributed/test_p2p_ipc.py
+++ b/test/distributed/test_p2p_ipc.py
@@ -123,6 +123,9 @@ class P2PIpcTest(MultiProcContinuousTest):
         if self.rank == 0 or is_consumer:
             expected = torch.ones_like(tensor)
             self.assertEqual(tensor, expected, atol=0.0, rtol=0.0)
+            # Drop the comparison tensor so it doesn't pin the segment that the
+            # producer is about to free below.
+            del expected
 
         if free_producer_segment:
             # Release the consumer's import (ref-counter 1 -> 0), then free the


### PR DESCRIPTION
I botched my attempt at landing #191343 while trying to reuse existing test. this should fix it. 

## Testing

Locally revert the fix landed in #190860 to test failure 

```diff --git a/c10/cuda/CUDACachingAllocator.cpp b/c10/cuda/CUDACachingAllocator.cpp
index cffd65103ee..12c87caa941 100644
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -954,11 +954,7 @@ struct ExpandableSegment {
 #endif
       if (h.shareable_handle) {
 #ifndef _WIN32
-        // shareable_handle also holds CUmemFabricHandle for fabric segments;
-        // std::get_if skips those (no fd to close) instead of throwing.
-        if (auto* fd = std::get_if<int>(&*h.shareable_handle)) {
-          close(*fd);
-        }
+        close(std::get<int>(*h.shareable_handle));
 #endif
       }
 #ifdef USE_ROCM
```

Without Change in Trunk

```shell
TEST_CONFIG=h100-fabric pytest test/distributed/test_p2p_ipc.py -vvs -k expandable
```


```
PASSED [0.0989s]
[W729 03:21:03.339692727 CudaIPCTypes.cpp:16] Producer process has been terminated before all shared CUDA tensors released. See Note [Sharing CUDA tensors]
I0729 03:21:04.084000 2539954 torch/testing/_internal/common_distributed.py:2128] Class P2PIpcTest finished
```

With Change

```
-> % TEST_CONFIG=h100-fabric pytest test/distributed/test_p2p_ipc.py -vvs -k expandable
========================================================================================================================================================================== test session starts ==========================================================================================================================================================================
platform linux -- Python 3.12.13+meta, pytest-9.1.1, pluggy-1.6.0 -- /home/sharmakapil/dev/git/pytorch/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/sharmakapil/dev/git/pytorch
configfile: pytest.ini
collected 2 items / 1 deselected / 1 selected
Running 1 items in this shard

test/distributed/test_p2p_ipc.py::P2PIpcTest::test_p2p_ipc_expandable_segments I0729 03:28:41.296000 2869894 torch/testing/_internal/common_distributed.py:2093] Testing class P2PIpcTest on 8 cuda

W0729 03:28:47.547000 2869894 torch/testing/_internal/common_distributed.py:2173] Detected failure from Rank 0 in: test_p2p_ipc.P2PIpcTest.test_p2p_ipc_expandable_segments, skipping rest of tests in Test class: P2PIpcTest
FAILED 
I0729 03:30:49.015000 2869894 torch/testing/_internal/common_distributed.py:2128] Class P2PIpcTest finished

```