### PR TITLE
[CUDA graphs] Forward piecewise-cuda-graphs API under torch.cuda

### DIFF
--- a/test/test_piecewise_cuda_graph_forwarding.py
+++ b/test/test_piecewise_cuda_graph_forwarding.py
@@ -1,0 +1,50 @@
+# Owner(s): ["module: cuda"]
+import builtins
+import importlib.util
+from unittest import mock
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+_PCG_NAMES = ["CUDAGraphSequence", "piecewise_graph", "no_graph", "force_no_graph"]
+
+
+def _package_available() -> bool:
+    return importlib.util.find_spec("piecewise_cuda_graphs") is not None
+
+
+class TestPiecewiseCudaGraphForwarding(TestCase):
+    def test_names_in_all(self):
+        for name in _PCG_NAMES:
+            self.assertIn(name, torch.cuda.__all__)
+
+    def test_forwards_when_present(self):
+        if not _package_available():
+            self.skipTest("piecewise_cuda_graphs not installed")
+        import piecewise_cuda_graphs
+
+        for name in _PCG_NAMES:
+            self.assertIs(
+                getattr(torch.cuda, name), getattr(piecewise_cuda_graphs, name)
+            )
+
+    def test_raises_when_absent(self):
+        # Simulate the package being uninstalled: the name still resolves, but
+        # calling/instantiating it raises an ImportError with an install hint.
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name.split(".")[0] == "piecewise_cuda_graphs":
+                raise ImportError("simulated missing package")
+            return real_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            for name in _PCG_NAMES:
+                placeholder = getattr(torch.cuda, name)
+                with self.assertRaisesRegex(ImportError, "torchannex"):
+                    placeholder()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -43,6 +43,18 @@ from .green_contexts import GreenContext
 from .streams import Event, ExternalStream, Stream
 
 
+if TYPE_CHECKING:
+    # Forwarded lazily from the piecewise-cuda-graphs package (see __getattr__ at
+    # module end and _piecewise_graphs.py); declared here so type checkers and
+    # IDEs see the names.
+    from ._piecewise_graphs import (
+        CUDAGraphSequence,
+        force_no_graph,
+        no_graph,
+        piecewise_graph,
+    )
+
+
 try:
     from torch._C import _cudart  # type: ignore[attr-defined]
 except ImportError:
@@ -2135,6 +2147,7 @@ __all__ = [
     # pyrefly: ignore [bad-dunder-all]
     "ShortTensor",
     "CUDAGraph",
+    "CUDAGraphSequence",
     "CudaError",
     "DeferredCudaCallError",
     "Event",
@@ -2181,6 +2194,9 @@ __all__ = [
     "graph_annotations",
     "graph_pool_handle",
     "graphs",
+    "piecewise_graph",
+    "no_graph",
+    "force_no_graph",
     "has_half",
     "has_magma",
     "host_memory_stats",
@@ -2241,3 +2257,19 @@ __all__ = [
     "tunable",
     "utilization",
 ]
+
+
+_PIECEWISE_GRAPH_NAMES = frozenset(
+    {"CUDAGraphSequence", "piecewise_graph", "no_graph", "force_no_graph"}
+)
+
+
+def __getattr__(name: str) -> Any:
+    # Forward the piecewise-cuda-graphs public API lazily (see
+    # torch/cuda/_piecewise_graphs.py). Kept out of the eager import list so a
+    # torch.cuda import does not pull in the optional package.
+    if name in _PIECEWISE_GRAPH_NAMES:
+        from torch.cuda import _piecewise_graphs
+
+        return getattr(_piecewise_graphs, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torch/cuda/_piecewise_graphs.py
+++ b/torch/cuda/_piecewise_graphs.py
@@ -1,0 +1,62 @@
+"""Forward the piecewise-cuda-graphs public API into ``torch.cuda``.
+
+Piecewise CUDA graphs let a workload run under CUDA graphs while sections that
+cannot be captured (e.g. attention) run eagerly, by splitting capture into a
+sequence of graph and eager segments. The implementation lives in the standalone
+``piecewise_cuda_graphs`` package (shipped in ``torchannex``, also installable on
+its own); this module re-exports its public entry points so users reach them as
+``torch.cuda.piecewise_graph`` and friends, mirroring the core CUDA graph API.
+
+The package is imported lazily on first access: it imports ``torch``, so pulling
+it in while ``torch.cuda`` is still initializing would be an import cycle, and we
+do not want to pay its import cost for users who never touch the API. When the
+package is not installed the names still resolve, but using one raises a
+descriptive ImportError pointing at the install command.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+
+__all__ = [
+    "CUDAGraphSequence",
+    "force_no_graph",
+    "no_graph",
+    "piecewise_graph",
+]
+
+
+if TYPE_CHECKING:
+    from piecewise_cuda_graphs import (  # pyrefly: ignore[missing-import]
+        CUDAGraphSequence,
+        force_no_graph,
+        no_graph,
+        piecewise_graph,
+    )
+
+
+def _missing(name: str) -> Any:
+    # Placeholder returned when the package is absent: the name still resolves so
+    # the public API surface is stable, but using it raises with an actionable
+    # install hint (mirrors the _dummy_type raise-on-use pattern in graphs.py).
+    def raise_missing(*args: object, **kwargs: object) -> Any:
+        raise ImportError(
+            f"torch.cuda.{name} requires the piecewise-cuda-graphs package: "
+            "install torchannex with `pip install torchannex`, or the standalone "
+            "package with `pip install piecewise-cuda-graphs`."
+        )
+
+    raise_missing.__name__ = name
+    raise_missing.__qualname__ = name
+    return raise_missing
+
+
+def __getattr__(name: str) -> Any:
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    try:
+        import piecewise_cuda_graphs  # pyrefly: ignore[missing-import]
+    except ImportError:
+        return _missing(name)
+    return getattr(piecewise_cuda_graphs, name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191641

Piecewise CUDA graphs let a workload run under CUDA graphs while sections that
cannot be captured (e.g. attention) run eagerly. The implementation lives in the
standalone piecewise-cuda-graphs package (shipped in torchannex, also installable
on its own), so it stays decoupled from PyTorch's release cycle. Rather than
vendoring it into core, expose its public entry points -- piecewise_graph,
CUDAGraphSequence, no_graph, force_no_graph -- under torch.cuda.*, mirroring how
the core CUDA graph API is surfaced today.

The forwarding is lazy: the package imports torch, so pulling it in while
torch.cuda is still initializing would be an import cycle, and we do not want to
pay its import cost for users who never touch the API. A module-level __getattr__
resolves the four names on first access and returns the real objects, so they are
transparent aliases (identity and isinstance hold). When the package is not
installed the names still resolve, but using one raises an ImportError pointing at
the install command, keeping the public API surface stable regardless of whether
the optional package is present.

Test Plan:
piecewise-cuda-graphs is installed in the dev environment; the tests cover the
present path (forwarded object identity), the simulated-absent path (actionable
ImportError), and __all__ membership.

```
python -m pytest test/test_piecewise_cuda_graph_forwarding.py -v
```

Authored with Claude.