### PR TITLE
[RNG] Support tensor data in stateless fold_in

### DIFF
--- a/aten/src/ATen/native/PhiloxStatelessRNG.cpp
+++ b/aten/src/ATen/native/PhiloxStatelessRNG.cpp
@@ -4,7 +4,9 @@
 #include <ATen/cpu/StatelessPhilox4x32.h>
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
+#include <ATen/TensorIterator.h>
 #include <ATen/core/TransformationHelper.h>
+#include <ATen/native/cpu/Loops.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -220,15 +222,45 @@ Tensor _philox_key_fold_in_cpu(const Tensor& key, int64_t data) {
 }
 
 Tensor _philox_key_fold_in_tensor_cpu(const Tensor& key, const Tensor& data) {
+  TORCH_CHECK(key.dim() >= 1 && key.size(-1) == 2,
+      "_philox_key_fold_in: key must have shape (*batch, 2), got shape ",
+      key.sizes());
+  TORCH_CHECK(key.scalar_type() == kUInt64,
+      "_philox_key_fold_in: key must have dtype uint64, got ",
+      key.scalar_type());
   TORCH_CHECK(data.scalar_type() == kUInt64,
       "_philox_key_fold_in: data must have dtype uint64, got ",
       data.scalar_type());
-  // TODO: Relax this and allow for arbitrary data shape that broadcasts with
-  // batched keys?
-  TORCH_CHECK(data.numel() == 1,
-      "_philox_key_fold_in: data must be a single value, got ",
-      data.numel(), " elements");
-  return philox_key_fold_in_impl(key, data.const_data_ptr<uint64_t>()[0]);
+
+  auto output_shape = at::infer_size_dimvector(
+      key.sizes().slice(0, key.dim() - 1), data.sizes());
+  output_shape.push_back(2);
+  Tensor output = at::empty(output_shape, key.options());
+  Tensor output_seed = output.select(-1, 0);
+  Tensor output_offset = output.select(-1, 1);
+  Tensor key_seed = key.select(-1, 0);
+  Tensor key_offset = key.select(-1, 1);
+
+  auto iter = TensorIteratorConfig()
+      .set_check_mem_overlap(false)
+      .add_output(output_seed)
+      .add_output(output_offset)
+      .add_const_input(key_seed)
+      .add_const_input(key_offset)
+      .add_const_input(data)
+      .build();
+  cpu_kernel_multiple_outputs(
+      iter,
+      [](uint64_t seed, uint64_t offset, uint64_t fold)
+          -> std::tuple<uint64_t, uint64_t> {
+        auto r = philox_4x32(seed, offset + fold);
+        return {
+            static_cast<uint64_t>(r[0]) |
+                (static_cast<uint64_t>(r[1]) << 32),
+            static_cast<uint64_t>(r[2]) |
+                (static_cast<uint64_t>(r[3]) << 32)};
+      });
+  return output;
 }
 
 Tensor& _philox_uniform_cpu_(Tensor& self, const Tensor& key, double low, double high) {

--- a/aten/src/ATen/native/cuda/PhiloxKeySplit.cu
+++ b/aten/src/ATen/native/cuda/PhiloxKeySplit.cu
@@ -1,8 +1,12 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 
 #include <ATen/core/Tensor.h>
+#include <ATen/core/PhiloxRNGEngine.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/StatelessPhilox4x32.cuh>
+#include <ATen/ExpandUtils.h>
+#include <ATen/TensorIterator.h>
+#include <ATen/native/cuda/Loops.cuh>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -76,15 +80,6 @@ __global__ void philox_key_fold_in_scalar_kernel(
     int64_t num_keys,
     uint64_t data) {
   philox_key_fold_in_impl(input, output, num_keys, data);
-}
-
-// data read from device (CUDA graph safe: not baked into the launch).
-__global__ void philox_key_fold_in_tensor_kernel(
-    const uint64_t* __restrict__ input,
-    uint64_t* __restrict__ output,
-    int64_t num_keys,
-    const uint64_t* __restrict__ data) {
-  philox_key_fold_in_impl(input, output, num_keys, data[0]);
 }
 
 } // anonymous namespace
@@ -167,33 +162,37 @@ Tensor _philox_key_fold_in_tensor_cuda(const Tensor& key, const Tensor& data) {
   TORCH_CHECK(data.scalar_type() == kUInt64,
       "_philox_key_fold_in: data must have dtype uint64, got ",
       data.scalar_type());
-  // TODO: Relax this and allow for arbitrary data shape that broadcasts with
-  // batched keys?
-  TORCH_CHECK(data.numel() == 1,
-      "_philox_key_fold_in: data must be a single value, got ",
-      data.numel(), " elements");
 
-  Tensor output = at::empty_like(key);
-  int64_t num_keys = key.numel() / 2;
-  if (num_keys == 0) {
-    return output;
-  }
+  auto output_shape = at::infer_size_dimvector(
+      key.sizes().slice(0, key.dim() - 1), data.sizes());
+  output_shape.push_back(2);
+  Tensor output = at::empty(output_shape, key.options());
+  Tensor output_seed = output.select(-1, 0);
+  Tensor output_offset = output.select(-1, 1);
+  Tensor key_seed = key.select(-1, 0);
+  Tensor key_offset = key.select(-1, 1);
 
-  auto key_contig = key.contiguous();
-
-  constexpr int block_size = 256;
-  int num_blocks = std::min(
-      static_cast<int>((num_keys + block_size - 1) / block_size),
-      at::cuda::getCurrentDeviceProperties()->multiProcessorCount * 4);
-
-  philox_key_fold_in_tensor_kernel<<<num_blocks, block_size, 0,
-      at::cuda::getCurrentCUDAStream()>>>(
-      key_contig.data_ptr<uint64_t>(),
-      output.data_ptr<uint64_t>(),
-      num_keys,
-      data.const_data_ptr<uint64_t>());
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
-
+  auto iter = TensorIteratorConfig()
+      .set_check_mem_overlap(false)
+      .add_output(output_seed)
+      .add_output(output_offset)
+      .add_const_input(key_seed)
+      .add_const_input(key_offset)
+      .add_const_input(data)
+      .build();
+  gpu_kernel_multiple_outputs(
+      iter,
+      [] GPU_LAMBDA(uint64_t seed, uint64_t offset, uint64_t fold)
+          -> thrust::tuple<uint64_t, uint64_t> {
+        at::Philox4_32 engine(seed, 0, offset + fold);
+        const uint64_t r0 = engine();
+        const uint64_t r1 = engine();
+        const uint64_t r2 = engine();
+        const uint64_t r3 = engine();
+        return {
+            r0 | (r1 << 32),
+            r2 | (r3 << 32)};
+      });
   return output;
 }
 

--- a/test/test_stateless_rng.py
+++ b/test/test_stateless_rng.py
@@ -280,9 +280,12 @@ class TestStatelessRNGKeyFoldIn(TestCase):
         # tensor with the wrong dtype
         with self.assertRaisesRegex(RuntimeError, "data must have dtype uint64"):
             random.fold_in(key, torch.tensor(7, dtype=torch.int64, device=device))
-        # tensor with more than one value
-        with self.assertRaisesRegex(RuntimeError, "data must be a single value"):
-            random.fold_in(key, torch.tensor([1, 2], dtype=torch.uint64, device=device))
+        # tensor data whose shape does not broadcast with the key batch
+        keys = random.split(key, 2)
+        with self.assertRaisesRegex(RuntimeError, "must match the size"):
+            random.fold_in(
+                keys, torch.tensor([1, 2, 3], dtype=torch.uint64, device=device)
+            )
 
     @onlyAccelerator
     def test_error_data_wrong_device(self, device):
@@ -311,12 +314,55 @@ class TestStatelessRNGKeyFoldIn(TestCase):
         self.assertEqual(random.fold_in(key, scalar), expected)
         self.assertEqual(random.fold_in(key, one_d), expected)
 
+    def test_tensor_data_broadcasts(self, device):
+        base_key = random.key(42, device=device)
+        data = torch.tensor([[0, 1, 2], [3, 4, 5]], dtype=torch.uint64, device=device)
+        result = random.fold_in(base_key, data)
+        self.assertEqual(result.shape, (2, 3, 2))
+        self.assertEqual(result.stride(-1), 1)
+        for i in range(2):
+            for j in range(3):
+                self.assertEqual(result[i, j], random.fold_in(base_key, data[i, j]))
+
+        keys = random.split(base_key, 2).reshape(2, 1, 2)
+        row_data = data[:1]
+        result = random.fold_in(keys, row_data)
+        self.assertEqual(result.shape, (2, 3, 2))
+        for i in range(2):
+            for j in range(3):
+                self.assertEqual(
+                    result[i, j], random.fold_in(keys[i, 0], row_data[0, j])
+                )
+
+        keys = random.split(base_key, 6).reshape(2, 3, 2).transpose(0, 1)
+        data = data.transpose(0, 1)
+        self.assertFalse(keys.is_contiguous())
+        self.assertFalse(data.is_contiguous())
+        result = random.fold_in(keys, data)
+        for i in range(3):
+            for j in range(2):
+                self.assertEqual(result[i, j], random.fold_in(keys[i, j], data[i, j]))
+
+    def test_tensor_data_empty(self, device):
+        key = random.key(42, device=device)
+        data = torch.empty((0, 3), dtype=torch.uint64, device=device)
+        self.assertEqual(random.fold_in(key, data).shape, (0, 3, 2))
+
+    def test_tensor_data_meta(self, device):
+        key = torch.empty((3, 1, 2), dtype=torch.uint64, device="meta")
+        data = torch.empty((1, 4), dtype=torch.uint64, device="meta")
+        self.assertEqual(random.fold_in(key, data).shape, (3, 4, 2))
+
     @onlyCUDA
     def test_tensor_data_cuda_graph(self, device):
         # A tensor data is not baked into the graph: mutating it and replaying
         # produces the result for the new value.
         key = random.key(42, device=device)
-        data = torch.zeros((), dtype=torch.uint64, device=device)
+        data = torch.zeros((2, 3), dtype=torch.uint64, device=device)
+        replay_values = (
+            torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.uint64, device=device),
+            torch.tensor([[9, 8, 7], [6, 5, 4]], dtype=torch.uint64, device=device),
+        )
 
         s = torch.cuda.Stream()
         s.wait_stream(torch.cuda.current_stream())
@@ -329,8 +375,8 @@ class TestStatelessRNGKeyFoldIn(TestCase):
         with torch.cuda.graph(g):
             out = random.fold_in(key, data)
 
-        for value in (5, 99):
-            data.fill_(value)
+        for value in replay_values:
+            data.copy_(value)
             g.replay()
             torch.cuda.synchronize()
             self.assertEqual(out, random.fold_in(key, value))
@@ -651,9 +697,9 @@ class TestStatelessRNGCompile(TestCase):
         self.assertEqual(f(key), random.fold_in(key, 7))
 
     def test_fold_in_tensor_fullgraph(self, device):
-        key = random.key(42, device=device)
-        # data as a graph input (not a constant) exercises the Tensor overload.
-        data = torch.tensor(7, dtype=torch.uint64, device=device)
+        key = random.split(random.key(42, device=device), 2).reshape(2, 1, 2)
+        # Tensor data as a graph input exercises broadcast shape inference.
+        data = torch.tensor([[1, 2, 3]], dtype=torch.uint64, device=device)
 
         @torch.compile(backend="aot_eager", fullgraph=True)
         def f(key, data):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -603,11 +603,8 @@ def meta_philox_key_fold_in_tensor(key, data):
         data.dtype == torch.uint64,
         lambda: f"_philox_key_fold_in: data must have dtype uint64, got {data.dtype}",
     )
-    torch._check(
-        data.numel() == 1,
-        lambda: f"_philox_key_fold_in: data must be a single value, got {data.numel()} elements",
-    )
-    return torch.empty_like(key)
+    batch_shape = _broadcast_shapes(key.shape[:-1], data.shape)
+    return key.new_empty((*batch_shape, 2))
 
 
 def _check_philox_distribution_args(op_name, self, key):

--- a/torch/func/_random.py
+++ b/torch/func/_random.py
@@ -75,17 +75,21 @@ def split(key: torch.Tensor, num: int = 2) -> torch.Tensor:
 def fold_in(key: torch.Tensor, data: int | torch.Tensor) -> torch.Tensor:
     r"""Deterministically derive a new key by folding in an integer value.
 
-    ``data`` may be a Python ``int`` or a single-item ``uint64`` tensor on the
-    same device as ``key``. Note that passing ``data`` as a tensor prevents it
-    from being baked into a captured CUDA graph, so the graph can be replayed
-    with a different value without recapture.
+    ``data`` may be a Python ``int`` or a ``uint64`` tensor on the same device
+    as ``key``. Tensor data is broadcast against the key's batch dimensions,
+    deriving one key for each broadcasted ``(key, data)`` pair. Passing
+    ``data`` as a tensor also prevents it from being baked into a captured CUDA
+    graph, so the graph can be replayed with different values without
+    recapture.
 
-    Equivalent to ``split(key, data + 1)[data]``, but more efficient when
-    only a single derived key is needed. Useful for associating a key with
-    a loop iteration, layer index, or other integer identifier.
+    For scalar ``data``, this is equivalent to
+    ``split(key, data + 1)[data]``, but more efficient when only a single
+    derived key is needed. Useful for associating a key with a loop iteration,
+    layer index, or other integer identifier.
 
-    Supports batched keys: if ``key`` has shape ``(*batch, K)``, ``data`` is
-    folded into each key independently.
+    Supports batched keys and tensor data. If ``key`` has shape
+    ``(*key_batch, K)`` and tensor ``data`` has shape ``*data_batch``, the
+    result has shape ``(*broadcast_shapes(key_batch, data_batch), K)``.
 
     Args:
         key (Tensor): A PRNG key returned by :func:`key`, :func:`split`, or
@@ -95,11 +99,13 @@ def fold_in(key: torch.Tensor, data: int | torch.Tensor) -> torch.Tensor:
             ``[-0x8000_0000_0000_0000, 0xffff_ffff_ffff_ffff]``. Negative inputs
             are remapped to positive values with the formula
             ``0x1_0000_0000_0000_0000 + data``. A tensor must have dtype
-            ``uint64``, contain a single value, and reside on the same device
-            as ``key``.
+            ``uint64`` and reside on the same device as ``key``. Tensor data is
+            broadcast against the key's batch dimensions.
 
     Returns:
-        A new key tensor with the same shape as ``key``.
+        A new key tensor. Python integer data preserves the shape of ``key``;
+        tensor data produces the broadcasted batch shape followed by the key
+        dimension.
 
     Example::
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191645
* #191644
* #191643
* __->__ #191642

Allow uint64 tensor data to broadcast against PRNG key batch dimensions. Implement vectorized CPU and CUDA paths with TensorIterator and update meta, compile, noncontiguous, and CUDA graph coverage.

Test: python test/test_stateless_rng.py TestStatelessRNGKeyFoldInCPU TestStatelessRNGKeyFoldInCUDA -v

Test: python test/test_stateless_rng.py TestStatelessRNGCompileCPU.test_fold_in_tensor_fullgraph_cpu TestStatelessRNGCompileCUDA.test_fold_in_tensor_fullgraph_cuda -v