### PR TITLE
[RNG] Add keyed logical shard distribution reference

### DIFF
--- a/test/test_stateless_rng.py
+++ b/test/test_stateless_rng.py
@@ -677,6 +677,227 @@ class TestStatelessRNGDistribution(TestCase):
         )
 
 
+class TestStatelessRNGLogicalShards(TestCase):
+    def _dense_reference(self, key, shape, dtype, distribution):
+        indices = torch.arange(
+            torch.Size(shape).numel(), dtype=torch.int64, device=key.device
+        ).reshape(shape)
+        element_keys = random.fold_in(key, indices.to(torch.uint64))
+        if distribution == "normal":
+            return random.normal(element_keys, shape, mean=1.25, std=0.75, dtype=dtype)
+        return random.uniform(element_keys, shape, low=-2.0, high=3.0, dtype=dtype)
+
+    def _fill(self, key, result, distribution, **metadata):
+        if distribution == "normal":
+            return random.normal_shards_(key, result, mean=1.25, std=0.75, **metadata)
+        return random.uniform_shards_(key, result, low=-2.0, high=3.0, **metadata)
+
+    @parametrize("distribution", ["normal", "uniform"])
+    @dtypes(*all_floating_dtypes)
+    def test_layouts_match_dense(self, device, dtype, distribution):
+        key = random.key(123, device=device)
+        global_shape = (5, 7)
+        expected = self._dense_reference(key, global_shape, dtype, distribution)
+
+        full = torch.empty(global_shape, dtype=dtype, device=device)
+        self._fill(
+            key,
+            full,
+            distribution,
+            global_shape=global_shape,
+            global_offsets=((0, 0),),
+            local_offsets=((0, 0),),
+            local_sizes=(global_shape,),
+        )
+        self.assertEqual(full, expected, atol=0, rtol=0)
+
+        reconstructed = torch.empty_like(expected)
+        for start, end in ((0, 2), (2, 5)):
+            local = torch.empty((end - start, 7), dtype=dtype, device=device)
+            self._fill(
+                key,
+                local,
+                distribution,
+                global_shape=global_shape,
+                global_offsets=((start, 0),),
+                local_offsets=((0, 0),),
+                local_sizes=((end - start, 7),),
+            )
+            reconstructed[start:end] = local
+        self.assertEqual(reconstructed, expected, atol=0, rtol=0)
+
+        reconstructed = torch.empty_like(expected)
+        for start, end in ((0, 3), (3, 7)):
+            local = torch.empty((5, end - start), dtype=dtype, device=device)
+            self._fill(
+                key,
+                local,
+                distribution,
+                global_shape=global_shape,
+                global_offsets=((0, start),),
+                local_offsets=((0, 0),),
+                local_sizes=((5, end - start),),
+            )
+            reconstructed[:, start:end] = local
+        self.assertEqual(reconstructed, expected, atol=0, rtol=0)
+
+        sentinel = 123.0
+        padded = torch.full((8, 10), sentinel, dtype=dtype, device=device)
+        self._fill(
+            key,
+            padded,
+            distribution,
+            global_shape=global_shape,
+            global_offsets=((0, 0), (2, 0)),
+            local_offsets=((1, 2), (5, 2)),
+            local_sizes=((2, 7), (3, 7)),
+        )
+        expected_padded = torch.full_like(padded, sentinel)
+        expected_padded[1:3, 2:9] = expected[:2]
+        expected_padded[5:8, 2:9] = expected[2:]
+        self.assertEqual(padded, expected_padded, atol=0, rtol=0)
+
+        backing = torch.full((5, 14), sentinel, dtype=dtype, device=device)
+        noncontiguous = backing[:, ::2]
+        self.assertFalse(noncontiguous.is_contiguous())
+        self._fill(
+            key,
+            noncontiguous,
+            distribution,
+            global_shape=global_shape,
+            global_offsets=((0, 0),),
+            local_offsets=((0, 0),),
+            local_sizes=(global_shape,),
+        )
+        self.assertEqual(noncontiguous, expected, atol=0, rtol=0)
+        self.assertEqual(backing[:, 1::2], torch.full_like(backing[:, 1::2], sentinel))
+
+        empty = torch.empty((0, 7), dtype=dtype, device=device)
+        self._fill(
+            key,
+            empty,
+            distribution,
+            global_shape=global_shape,
+            global_offsets=((5, 0),),
+            local_offsets=((0, 0),),
+            local_sizes=((0, 7),),
+        )
+        self.assertEqual(empty.shape, (0, 7))
+
+    def test_partition_invariance_with_empty_owners(self, device):
+        key = random.key(321, device=device)
+        global_shape = (3, 4)
+        expected = self._dense_reference(key, global_shape, torch.float32, "normal")
+        reconstructed = torch.empty_like(expected)
+
+        for rank in range(5):
+            owns_row = rank < global_shape[0]
+            local_rows = 1 if owns_row else 0
+            global_row = rank if owns_row else global_shape[0]
+            local = torch.empty((local_rows, 4), device=device)
+            random.normal_shards_(
+                key,
+                local,
+                global_shape=global_shape,
+                global_offsets=((global_row, 0),),
+                local_offsets=((0, 0),),
+                local_sizes=((local_rows, 4),),
+                mean=1.25,
+                std=0.75,
+            )
+            if owns_row:
+                reconstructed[rank] = local[0]
+
+        self.assertEqual(reconstructed, expected, atol=0, rtol=0)
+
+    def test_metadata_validation_precedes_writes(self, device):
+        key = random.key(123, device=device)
+        sentinel = 17.0
+
+        cases = (
+            (
+                "same length",
+                dict(
+                    global_shape=(2, 2),
+                    global_offsets=((0, 0),),
+                    local_offsets=(),
+                    local_sizes=((1, 2),),
+                ),
+            ),
+            (
+                "must have 2 dimensions",
+                dict(
+                    global_shape=(2, 2),
+                    global_offsets=((0,),),
+                    local_offsets=((0, 0),),
+                    local_sizes=((1, 2),),
+                ),
+            ),
+            (
+                "outside global_shape",
+                dict(
+                    global_shape=(2, 2),
+                    global_offsets=((0, 0), (2, 0)),
+                    local_offsets=((0, 0), (1, 0)),
+                    local_sizes=((1, 2), (1, 2)),
+                ),
+            ),
+            (
+                "global rectangles",
+                dict(
+                    global_shape=(3, 2),
+                    global_offsets=((0, 0), (1, 0)),
+                    local_offsets=((0, 0), (2, 0)),
+                    local_sizes=((2, 2), (2, 2)),
+                ),
+            ),
+            (
+                "local rectangles",
+                dict(
+                    global_shape=(4, 2),
+                    global_offsets=((0, 0), (2, 0)),
+                    local_offsets=((0, 0), (0, 0)),
+                    local_sizes=((2, 2), (2, 2)),
+                ),
+            ),
+            (
+                "int64 elements",
+                dict(
+                    global_shape=(1 << 62, 4),
+                    global_offsets=(),
+                    local_offsets=(),
+                    local_sizes=(),
+                ),
+            ),
+            (
+                "outside global_shape",
+                dict(
+                    global_shape=(2, 2),
+                    global_offsets=((3, 0),),
+                    local_offsets=((0, 0),),
+                    local_sizes=((0, 2),),
+                ),
+            ),
+        )
+
+        for error, metadata in cases:
+            result = torch.full((4, 2), sentinel, device=device)
+            with self.subTest(error=error), self.assertRaisesRegex(ValueError, error):
+                random.normal_shards_(key, result, **metadata)
+            self.assertEqual(result, torch.full_like(result, sentinel))
+
+        overlapping = torch.zeros((1, 2), device=device).expand(2, 2)
+        with self.assertRaisesRegex(ValueError, "internal overlap"):
+            random.normal_shards_(
+                key,
+                overlapping,
+                global_shape=(2, 2),
+                global_offsets=((0, 0),),
+                local_offsets=((0, 0),),
+                local_sizes=((2, 2),),
+            )
+
+
 class TestStatelessRNGCompile(TestCase):
     def test_split_fullgraph(self, device):
         key = random.key(42, device=device)
@@ -813,6 +1034,9 @@ instantiate_device_type_tests(
 )
 instantiate_device_type_tests(
     TestStatelessRNGDistribution, globals(), only_for=("cpu", "cuda")
+)
+instantiate_device_type_tests(
+    TestStatelessRNGLogicalShards, globals(), only_for=("cpu", "cuda")
 )
 instantiate_device_type_tests(
     TestStatelessRNGCompile, globals(), only_for=("cpu", "cuda")

--- a/torch/func/_random.py
+++ b/torch/func/_random.py
@@ -4,6 +4,8 @@ These are experimental and subject to change without notice.
 Access via ``torch.func._random``.
 """
 
+import math
+import operator
 from collections.abc import Sequence
 
 import torch
@@ -288,3 +290,262 @@ def uniform(
     # pyrefly: ignore [no-matching-overload]
     result = torch.empty(shape, dtype=dtype, device=key.device)
     return uniform_(key, result, low=low, high=high)
+
+
+def _as_index_tuple(values: Sequence[int], name: str) -> tuple[int, ...]:
+    try:
+        return tuple(operator.index(value) for value in values)
+    except TypeError as error:
+        raise TypeError(f"{name} must contain integers") from error
+
+
+def _rectangles_overlap(
+    first_offset: tuple[int, ...],
+    first_size: tuple[int, ...],
+    second_offset: tuple[int, ...],
+    second_size: tuple[int, ...],
+) -> bool:
+    return all(
+        first < second + second_extent and second < first + first_extent
+        for first, first_extent, second, second_extent in zip(
+            first_offset,
+            first_size,
+            second_offset,
+            second_size,
+        )
+    )
+
+
+def _validate_shard_metadata(
+    key: torch.Tensor,
+    result: torch.Tensor,
+    global_shape: Sequence[int],
+    global_offsets: Sequence[Sequence[int]],
+    local_offsets: Sequence[Sequence[int]],
+    local_sizes: Sequence[Sequence[int]],
+) -> tuple[
+    tuple[int, ...],
+    tuple[tuple[int, ...], ...],
+    tuple[tuple[int, ...], ...],
+    tuple[tuple[int, ...], ...],
+]:
+    op_name = "stateless shard distribution"
+    if key.dtype != torch.uint64 or key.shape != (2,):
+        raise ValueError(
+            f"{op_name}: key must be an unbatched uint64 key of shape (2,)"
+        )
+    if key.device != result.device:
+        raise ValueError(
+            f"{op_name}: key and result must be on the same device, "
+            f"got {key.device} and {result.device}"
+        )
+    if result.layout != torch.strided:
+        raise ValueError(f"{op_name}: result must have strided layout")
+    if not result.is_floating_point():
+        raise ValueError(f"{op_name}: result must have a floating point dtype")
+    if torch._debug_has_internal_overlap(result) == 1:
+        raise ValueError(f"{op_name}: result must not have internal overlap")
+    if torch._C._overlaps(key, result):
+        raise ValueError(f"{op_name}: key and result must not overlap")
+
+    shape = _as_index_tuple(global_shape, "global_shape")
+    if len(shape) != result.ndim:
+        raise ValueError(f"{op_name}: global_shape and result must have the same rank")
+    if any(size < 0 for size in shape):
+        raise ValueError(f"{op_name}: global_shape must be non-negative")
+    if math.prod(shape) > torch.iinfo(torch.int64).max:
+        raise ValueError(f"{op_name}: global tensor has more than int64 elements")
+
+    global_rects = tuple(
+        _as_index_tuple(offset, f"global_offsets[{index}]")
+        for index, offset in enumerate(global_offsets)
+    )
+    local_rects = tuple(
+        _as_index_tuple(offset, f"local_offsets[{index}]")
+        for index, offset in enumerate(local_offsets)
+    )
+    sizes = tuple(
+        _as_index_tuple(size, f"local_sizes[{index}]")
+        for index, size in enumerate(local_sizes)
+    )
+    if len(global_rects) != len(local_rects) or len(global_rects) != len(sizes):
+        raise ValueError(
+            f"{op_name}: global_offsets, local_offsets, and local_sizes "
+            "must have the same length"
+        )
+
+    local_shape = tuple(result.shape)
+    nonempty: list[int] = []
+    for index, (global_offset, local_offset, size) in enumerate(
+        zip(global_rects, local_rects, sizes)
+    ):
+        if len(global_offset) != result.ndim:
+            raise ValueError(
+                f"{op_name}: global_offsets[{index}] must have {result.ndim} dimensions"
+            )
+        if len(local_offset) != result.ndim:
+            raise ValueError(
+                f"{op_name}: local_offsets[{index}] must have {result.ndim} dimensions"
+            )
+        if len(size) != result.ndim:
+            raise ValueError(
+                f"{op_name}: local_sizes[{index}] must have {result.ndim} dimensions"
+            )
+        for dim, (offset, extent, bound) in enumerate(zip(global_offset, size, shape)):
+            if offset < 0 or extent < 0 or offset > bound - extent:
+                raise ValueError(
+                    f"{op_name}: global rectangle {index} dimension {dim} "
+                    "is outside global_shape"
+                )
+        for dim, (offset, extent, bound) in enumerate(
+            zip(local_offset, size, local_shape)
+        ):
+            if offset < 0 or offset > bound - extent:
+                raise ValueError(
+                    f"{op_name}: local rectangle {index} dimension {dim} "
+                    "is outside result shape"
+                )
+        if all(extent > 0 for extent in size):
+            nonempty.append(index)
+
+    for position, first in enumerate(nonempty):
+        for second in nonempty[position + 1 :]:
+            if _rectangles_overlap(
+                global_rects[first], sizes[first], global_rects[second], sizes[second]
+            ):
+                raise ValueError(
+                    f"{op_name}: global rectangles {first} and {second} overlap"
+                )
+            if _rectangles_overlap(
+                local_rects[first], sizes[first], local_rects[second], sizes[second]
+            ):
+                raise ValueError(
+                    f"{op_name}: local rectangles {first} and {second} overlap"
+                )
+
+    return shape, global_rects, local_rects, sizes
+
+
+def _materialized_shards_(
+    key: torch.Tensor,
+    result: torch.Tensor,
+    *,
+    global_shape: Sequence[int],
+    global_offsets: Sequence[Sequence[int]],
+    local_offsets: Sequence[Sequence[int]],
+    local_sizes: Sequence[Sequence[int]],
+    distribution: str,
+    params: tuple[float, float],
+) -> torch.Tensor:
+    shape, global_rects, local_rects, sizes = _validate_shard_metadata(
+        key,
+        result,
+        global_shape,
+        global_offsets,
+        local_offsets,
+        local_sizes,
+    )
+    if distribution == "normal":
+        if params[1] < 0:
+            raise ValueError(f"normal expects std >= 0.0, but found std {params[1]}")
+    elif distribution == "uniform":
+        if params[0] > params[1]:
+            raise ValueError(
+                f"uniform expects low <= high, but found {params[0]} > {params[1]}"
+            )
+    else:
+        raise ValueError(f"unsupported distribution: {distribution}")
+
+    global_strides = [0] * len(shape)
+    stride = 1
+    for dim in range(len(shape) - 1, -1, -1):
+        global_strides[dim] = stride
+        stride *= shape[dim]
+
+    for global_offset, local_offset, size in zip(global_rects, local_rects, sizes):
+        if any(extent == 0 for extent in size):
+            continue
+        indices = torch.zeros(size, dtype=torch.int64, device=result.device)
+        for dim, (offset, extent, global_stride) in enumerate(
+            zip(global_offset, size, global_strides)
+        ):
+            coordinate = torch.arange(
+                offset,
+                offset + extent,
+                dtype=torch.int64,
+                device=result.device,
+            )
+            coordinate_shape = [1] * len(size)
+            coordinate_shape[dim] = extent
+            indices.add_(coordinate.reshape(coordinate_shape), alpha=global_stride)
+
+        element_keys = fold_in(key, indices.to(torch.uint64))
+        local_slices = tuple(
+            slice(offset, offset + extent) for offset, extent in zip(local_offset, size)
+        )
+        local_result = result[local_slices]
+        if distribution == "normal":
+            normal_(element_keys, local_result, mean=params[0], std=params[1])
+        else:
+            uniform_(element_keys, local_result, low=params[0], high=params[1])
+    return result
+
+
+def normal_shards_(
+    key: torch.Tensor,
+    result: torch.Tensor,
+    *,
+    global_shape: Sequence[int],
+    global_offsets: Sequence[Sequence[int]],
+    local_offsets: Sequence[Sequence[int]],
+    local_sizes: Sequence[Sequence[int]],
+    mean: float = 0.0,
+    std: float = 1.0,
+) -> torch.Tensor:
+    r"""Fill logical tensor shards with values from a stateless normal distribution.
+
+    Each local element is keyed by its row-major index in ``global_shape``, so
+    the logical values are independent of how rectangles are partitioned or
+    placed in ``result``. Padding and holes outside the rectangles are not
+    modified.
+    """
+    return _materialized_shards_(
+        key,
+        result,
+        global_shape=global_shape,
+        global_offsets=global_offsets,
+        local_offsets=local_offsets,
+        local_sizes=local_sizes,
+        distribution="normal",
+        params=(mean, std),
+    )
+
+
+def uniform_shards_(
+    key: torch.Tensor,
+    result: torch.Tensor,
+    *,
+    global_shape: Sequence[int],
+    global_offsets: Sequence[Sequence[int]],
+    local_offsets: Sequence[Sequence[int]],
+    local_sizes: Sequence[Sequence[int]],
+    low: float = 0.0,
+    high: float = 1.0,
+) -> torch.Tensor:
+    r"""Fill logical tensor shards with values from a stateless uniform distribution.
+
+    Each local element is keyed by its row-major index in ``global_shape``, so
+    the logical values are independent of how rectangles are partitioned or
+    placed in ``result``. Padding and holes outside the rectangles are not
+    modified.
+    """
+    return _materialized_shards_(
+        key,
+        result,
+        global_shape=global_shape,
+        global_offsets=global_offsets,
+        local_offsets=local_offsets,
+        local_sizes=local_sizes,
+        distribution="uniform",
+        params=(low, high),
+    )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191645
* #191644
* __->__ #191643
* #191642

Add correctness-first normal and uniform shard fills keyed by each element's row-major global index. Validate raw rectangle metadata before writes and cover uneven, dimension-1, padded, multi-rectangle, noncontiguous, and empty-owner layouts.

Test: python test/test_stateless_rng.py TestStatelessRNGLogicalShardsCPU TestStatelessRNGLogicalShardsCUDA -v