### PR TITLE
[RNG] Fuse keyed logical shard distributions

### DIFF
--- a/aten/src/ATen/native/PhiloxShardMetadata.cpp
+++ b/aten/src/ATen/native/PhiloxShardMetadata.cpp
@@ -1,0 +1,182 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
+#include <ATen/MemoryOverlap.h>
+#include <ATen/native/PhiloxShardMetadata.h>
+#include <c10/util/irange.h>
+#include <c10/util/overflows.h>
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+namespace at::native::detail {
+namespace {
+
+bool rectangles_overlap(
+    IntArrayRef offsets,
+    IntArrayRef sizes,
+    size_t first,
+    size_t second,
+    size_t ndim) {
+  for (const auto dim : c10::irange(ndim)) {
+    const auto first_offset = offsets[first * ndim + dim];
+    const auto second_offset = offsets[second * ndim + dim];
+    const auto first_size = sizes[first * ndim + dim];
+    const auto second_size = sizes[second * ndim + dim];
+    if (first_offset >= second_offset + second_size ||
+        second_offset >= first_offset + first_size) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+ValidatedPhiloxShardMetadata validate_philox_shard_metadata(
+    const TensorBase& self,
+    IntArrayRef global_shape,
+    IntArrayRef global_offsets,
+    IntArrayRef local_offsets,
+    IntArrayRef local_sizes,
+    int64_t chunk_count,
+    const char* op_name) {
+  TORCH_CHECK(
+      self.layout() == kStrided,
+      op_name,
+      ": self must be a strided tensor, got ",
+      self.layout());
+  TORCH_CHECK(
+      static_cast<size_t>(self.dim()) == global_shape.size(),
+      op_name,
+      ": global_shape and self must have the same number of dimensions");
+  TORCH_CHECK(
+      chunk_count >= 0, op_name, ": chunk_count must be non-negative");
+
+  const size_t ndim = global_shape.size();
+  if (ndim == 0) {
+    TORCH_CHECK(
+        chunk_count <= 1,
+        op_name,
+        ": a scalar tensor can have at most one shard");
+  } else {
+    TORCH_CHECK(
+        static_cast<uint64_t>(chunk_count) <=
+            std::numeric_limits<size_t>::max() / ndim,
+        op_name,
+        ": shard metadata is too large");
+  }
+  const size_t expected_metadata_size =
+      static_cast<size_t>(chunk_count) * ndim;
+  TORCH_CHECK(
+      global_offsets.size() == expected_metadata_size &&
+          local_offsets.size() == expected_metadata_size &&
+          local_sizes.size() == expected_metadata_size,
+      op_name,
+      ": flattened shard metadata arrays must contain chunk_count * ndim values");
+
+  for (const auto size : global_shape) {
+    TORCH_CHECK(
+        size >= 0, op_name, ": global_shape must contain non-negative sizes");
+  }
+  int64_t global_numel = 0;
+  if (std::none_of(global_shape.begin(), global_shape.end(), [](int64_t size) {
+        return size == 0;
+      })) {
+    global_numel = 1;
+    for (const auto size : global_shape) {
+      TORCH_CHECK(
+          !c10::mul_overflows(global_numel, size, &global_numel),
+          op_name,
+          ": global tensor has more than int64 elements");
+    }
+  }
+
+  std::vector<int64_t> chunk_numels(static_cast<size_t>(chunk_count));
+  int64_t mapped_numel = 0;
+  for (const auto chunk : c10::irange(static_cast<size_t>(chunk_count))) {
+    bool empty_chunk = false;
+    for (const auto dim : c10::irange(ndim)) {
+      const size_t index = chunk * ndim + dim;
+      const int64_t global_offset = global_offsets[index];
+      const int64_t local_offset = local_offsets[index];
+      const int64_t local_size = local_sizes[index];
+      const int64_t global_size = global_shape[dim];
+      const int64_t tensor_size = self.size(static_cast<int64_t>(dim));
+      TORCH_CHECK(
+          global_offset >= 0 && local_size >= 0 &&
+              local_size <= global_size &&
+              global_offset <= global_size - local_size,
+          op_name,
+          ": global shard ",
+          chunk,
+          " dimension ",
+          dim,
+          " is outside global_shape");
+      TORCH_CHECK(
+          local_offset >= 0 && local_size <= tensor_size &&
+              local_offset <= tensor_size - local_size,
+          op_name,
+          ": local shard ",
+          chunk,
+          " dimension ",
+          dim,
+          " is outside self shape");
+      empty_chunk |= local_size == 0;
+    }
+
+    int64_t chunk_numel = empty_chunk ? 0 : 1;
+    if (!empty_chunk) {
+      for (const auto dim : c10::irange(ndim)) {
+        const int64_t size = local_sizes[chunk * ndim + dim];
+        TORCH_CHECK(
+            !c10::mul_overflows(chunk_numel, size, &chunk_numel),
+            op_name,
+            ": shard ",
+            chunk,
+            " has more than int64 elements");
+      }
+    }
+    TORCH_CHECK(
+        chunk_numel <= self.numel() - mapped_numel,
+        op_name,
+        ": local shard metadata describes more than self.numel() elements");
+    mapped_numel += chunk_numel;
+    chunk_numels[chunk] = chunk_numel;
+  }
+
+  for (size_t first = 0; first < static_cast<size_t>(chunk_count); ++first) {
+    if (chunk_numels[first] == 0) {
+      continue;
+    }
+    for (size_t second = first + 1;
+         second < static_cast<size_t>(chunk_count);
+         ++second) {
+      if (chunk_numels[second] == 0) {
+        continue;
+      }
+      TORCH_CHECK(
+          !rectangles_overlap(
+              global_offsets, local_sizes, first, second, ndim),
+          op_name,
+          ": global shards ",
+          first,
+          " and ",
+          second,
+          " must not overlap");
+      TORCH_CHECK(
+          !rectangles_overlap(local_offsets, local_sizes, first, second, ndim),
+          op_name,
+          ": local shards ",
+          first,
+          " and ",
+          second,
+          " must not overlap");
+    }
+  }
+  at::assert_no_internal_overlap(self);
+
+  return {global_numel, std::move(chunk_numels)};
+}
+
+} // namespace at::native::detail

--- a/aten/src/ATen/native/PhiloxShardMetadata.h
+++ b/aten/src/ATen/native/PhiloxShardMetadata.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <ATen/core/TensorBase.h>
+#include <c10/util/ArrayRef.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace at::native::detail {
+
+struct ValidatedPhiloxShardMetadata {
+  int64_t global_numel;
+  std::vector<int64_t> chunk_numels;
+};
+
+TORCH_API ValidatedPhiloxShardMetadata validate_philox_shard_metadata(
+    const TensorBase& self,
+    IntArrayRef global_shape,
+    IntArrayRef global_offsets,
+    IntArrayRef local_offsets,
+    IntArrayRef local_sizes,
+    int64_t chunk_count,
+    const char* op_name);
+
+} // namespace at::native::detail

--- a/aten/src/ATen/native/cuda/PhiloxDistribution.cu
+++ b/aten/src/ATen/native/cuda/PhiloxDistribution.cu
@@ -1,18 +1,25 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 
+#include <ATen/MemoryOverlap.h>
 #include <ATen/core/Tensor.h>
+#include <ATen/core/TransformationHelper.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/StatelessPhilox4x32.cuh>
+#include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/native/PhiloxShardMetadata.h>
 #include <ATen/native/cuda/MemoryAccess.cuh>
-#include <ATen/core/TransformationHelper.h>
+#include <c10/util/irange.h>
+
+#include <algorithm>
 #include <type_traits>
+#include <vector>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_philox_keyed_distribution_shards_native.h>
 #include <ATen/ops/_philox_normal_native.h>
 #include <ATen/ops/_philox_uniform_native.h>
 #endif
@@ -62,6 +69,57 @@ __device__ __forceinline__ double2 box_muller_double(uint4 r) {
   ::sincos(TWO_PI * u2, &s, &c);
   return {radius * c, radius * s};
 }
+
+template <typename scalar_t>
+struct UniformSampler {
+  __device__ auto operator()(uint64_t seed, uint64_t offset) const {
+    uint4 r = philox_4x32(seed, offset);
+    if constexpr (std::is_same_v<scalar_t, double>) {
+      ulonglong2 packed;
+      packed.x = (static_cast<unsigned long long>(r.x) << 32) | r.y;
+      packed.y = (static_cast<unsigned long long>(r.z) << 32) | r.w;
+      return packed;
+    } else {
+      return r;
+    }
+  }
+};
+
+template <typename scalar_t>
+struct NormalSampler {
+  __device__ auto operator()(uint64_t seed, uint64_t offset) const {
+    if constexpr (std::is_same_v<scalar_t, double>) {
+      return box_muller_double(philox_4x32(seed, offset));
+    } else {
+      return box_muller_float(philox_4x32(seed, offset));
+    }
+  }
+};
+
+template <typename scalar_t>
+struct UniformTransform {
+  scalar_t low;
+  scalar_t high;
+
+  template <typename random_t>
+  __device__ scalar_t operator()(random_t random) const {
+    return static_cast<scalar_t>(
+        at::transformation::uniform_real(random, low, high));
+  }
+};
+
+template <typename scalar_t>
+struct NormalTransform {
+  using compute_t =
+      std::conditional_t<std::is_same_v<scalar_t, double>, double, float>;
+
+  compute_t mean;
+  compute_t stddev;
+
+  __device__ scalar_t operator()(compute_t random) const {
+    return static_cast<scalar_t>(random * stddev + mean);
+  }
+};
 
 // Single-key kernel: one thread per chunk of elements, where each chunk
 // comes from a single Philox 4x32 call. Uses vectorized stores for full
@@ -255,37 +313,173 @@ void philox_distribution_kernel(
   }
 }
 
+enum class KeyedDistributionKind : int64_t {
+  Normal = 0,
+  Uniform = 1,
+};
+
+struct KeyedShardOffsets {
+  int64_t global;
+  int64_t local;
+};
+
+struct KeyedShardOffsetCalculator {
+  __device__ KeyedShardOffsets get(int64_t linear_index) const {
+    KeyedShardOffsets offsets{0, 0};
+    for (int dim = 0; dim < dims; ++dim) {
+      const int64_t coordinate = linear_index % sizes[dim];
+      linear_index /= sizes[dim];
+      offsets.global += coordinate * global_strides[dim];
+      offsets.local += coordinate * local_strides[dim];
+    }
+    return offsets;
+  }
+
+  int dims{0};
+  int64_t sizes[MAX_DIMS];
+  int64_t global_strides[MAX_DIMS];
+  int64_t local_strides[MAX_DIMS];
+};
+
+struct KeyedShardLaunch {
+  int64_t numel{0};
+  int64_t global_base{0};
+  int64_t local_base{0};
+  KeyedShardOffsetCalculator offset_calculator;
+};
+
+std::vector<KeyedShardLaunch> build_keyed_shard_launches(
+    const Tensor& self,
+    IntArrayRef global_shape,
+    IntArrayRef global_offsets,
+    IntArrayRef local_offsets,
+    IntArrayRef local_sizes,
+    int64_t chunk_count,
+    const detail::ValidatedPhiloxShardMetadata& metadata,
+    const char* op_name) {
+  TORCH_CHECK(
+      self.dim() <= MAX_DIMS,
+      op_name,
+      ": tensors with more than ",
+      MAX_DIMS,
+      " dimensions are not supported");
+  if (metadata.global_numel == 0) {
+    return {};
+  }
+
+  const size_t ndim = global_shape.size();
+  std::vector<int64_t> global_strides(ndim);
+  int64_t stride = 1;
+  for (size_t dim = ndim; dim > 0; --dim) {
+    global_strides[dim - 1] = stride;
+    stride *= global_shape[dim - 1];
+  }
+
+  std::vector<KeyedShardLaunch> launches;
+  launches.reserve(static_cast<size_t>(chunk_count));
+  for (const auto chunk : c10::irange(static_cast<size_t>(chunk_count))) {
+    if (metadata.chunk_numels[chunk] == 0) {
+      continue;
+    }
+    KeyedShardLaunch launch;
+    launch.numel = metadata.chunk_numels[chunk];
+    launch.offset_calculator.dims = static_cast<int>(ndim);
+    for (const auto dim : c10::irange(ndim)) {
+      const size_t metadata_index = chunk * ndim + dim;
+      launch.global_base +=
+          global_offsets[metadata_index] * global_strides[dim];
+      launch.local_base += local_offsets[metadata_index] *
+          self.stride(static_cast<int64_t>(dim));
+
+      const size_t calculator_dim = ndim - 1 - dim;
+      launch.offset_calculator.sizes[calculator_dim] =
+          local_sizes[metadata_index];
+      launch.offset_calculator.global_strides[calculator_dim] =
+          global_strides[dim];
+      launch.offset_calculator.local_strides[calculator_dim] =
+          self.stride(static_cast<int64_t>(dim));
+    }
+    launches.push_back(launch);
+  }
+  return launches;
+}
+
+template <typename scalar_t, typename sample_t, typename transform_t>
+__global__ void philox_keyed_shard_kernel(
+    scalar_t* __restrict__ output,
+    const uint64_t* __restrict__ key,
+    KeyedShardLaunch launch,
+    sample_t sample_func,
+    transform_t transform_func) {
+  const uint64_t draw_seed = key[0];
+  const uint64_t draw_offset = key[1];
+  const int64_t thread_index =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t thread_stride =
+      static_cast<int64_t>(blockDim.x) * gridDim.x;
+
+  for (int64_t local_index = thread_index; local_index < launch.numel;
+       local_index += thread_stride) {
+    const auto offsets = launch.offset_calculator.get(local_index);
+    const int64_t global_index = launch.global_base + offsets.global;
+    const int64_t output_index = launch.local_base + offsets.local;
+
+    const uint4 folded = philox_4x32(
+        draw_seed, draw_offset + static_cast<uint64_t>(global_index));
+    const uint64_t element_seed = static_cast<uint64_t>(folded.x) |
+        (static_cast<uint64_t>(folded.y) << 32);
+    const uint64_t element_offset = static_cast<uint64_t>(folded.z) |
+        (static_cast<uint64_t>(folded.w) << 32);
+    const auto sample = sample_func(element_seed, element_offset);
+    output[output_index] = transform_func(sample.x);
+  }
+}
+
+template <typename scalar_t, typename sample_t, typename transform_t>
+void run_keyed_shard_kernels(
+    Tensor& self,
+    const Tensor& key,
+    ArrayRef<KeyedShardLaunch> launches,
+    const sample_t& sample_func,
+    const transform_t& transform_func) {
+  if (launches.empty()) {
+    return;
+  }
+
+  auto key_contiguous = key.contiguous();
+  constexpr int block_size = 256;
+  const int max_blocks =
+      at::cuda::getCurrentDeviceProperties()->multiProcessorCount * 4;
+  auto* output = self.mutable_data_ptr<scalar_t>();
+  for (const auto& launch : launches) {
+    const int64_t required_blocks =
+        (launch.numel + block_size - 1) / block_size;
+    const int blocks = static_cast<int>(std::min<int64_t>(
+        required_blocks, static_cast<int64_t>(max_blocks)));
+    philox_keyed_shard_kernel<scalar_t>
+        <<<blocks, block_size, 0, at::cuda::getCurrentCUDAStream()>>>(
+            output,
+            key_contiguous.const_data_ptr<uint64_t>(),
+            launch,
+            sample_func,
+            transform_func);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
 } // anonymous namespace
 
 Tensor& _philox_uniform_cuda_(
     Tensor& self, const Tensor& key, double low, double high) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf, kBFloat16, self.scalar_type(), "_philox_uniform_", [&] {
-    auto sample_func = []() {
-      if constexpr (std::is_same_v<scalar_t, double>) {
-        return [] __device__ (uint64_t seed, uint64_t offset) {
-          uint4 r = philox_4x32(seed, offset);
-          ulonglong2 packed;
-          packed.x = (static_cast<unsigned long long>(r.x) << 32) | r.y;
-          packed.y = (static_cast<unsigned long long>(r.z) << 32) | r.w;
-          return packed;
-        };
-      } else {
-        return [] __device__ (uint64_t seed, uint64_t offset) {
-          return philox_4x32(seed, offset);
-        };
-      }
-    }();
-
-    auto lo = static_cast<scalar_t>(low);
-    auto hi = static_cast<scalar_t>(high);
-    auto param_func = [lo, hi] __device__ (auto rand) {
-      return static_cast<scalar_t>(
-          at::transformation::uniform_real(rand, lo, hi));
-    };
-
     philox_distribution_kernel<scalar_t>(
-        "_philox_uniform_", self, key, sample_func, param_func);
+        "_philox_uniform_",
+        self,
+        key,
+        UniformSampler<scalar_t>{},
+        UniformTransform<scalar_t>{
+            static_cast<scalar_t>(low), static_cast<scalar_t>(high)});
   });
   return self;
 }
@@ -294,27 +488,129 @@ Tensor& _philox_normal_cuda_(
     Tensor& self, const Tensor& key, double mean, double stddev) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf, kBFloat16, self.scalar_type(), "_philox_normal_", [&] {
-    using compute_t = std::conditional_t<std::is_same_v<scalar_t, double>, double, float>;
-    auto sample_func = []() {
-      if constexpr (std::is_same_v<scalar_t, double>) {
-        return [] __device__ (uint64_t seed, uint64_t offset) {
-          return box_muller_double(philox_4x32(seed, offset));
-        };
-      } else {
-        return [] __device__ (uint64_t seed, uint64_t offset) {
-          return box_muller_float(philox_4x32(seed, offset));
-        };
-      }
-    }();
-
-    auto mu = static_cast<compute_t>(mean);
-    auto sigma = static_cast<compute_t>(stddev);
-    auto param_func = [mu, sigma] __device__ (compute_t rand) {
-      return static_cast<scalar_t>(rand * sigma + mu);
-    };
-
+    using transform_t = NormalTransform<scalar_t>;
     philox_distribution_kernel<scalar_t>(
-        "_philox_normal_", self, key, sample_func, param_func);
+        "_philox_normal_",
+        self,
+        key,
+        NormalSampler<scalar_t>{},
+        transform_t{
+            static_cast<typename transform_t::compute_t>(mean),
+            static_cast<typename transform_t::compute_t>(stddev)});
+  });
+  return self;
+}
+
+Tensor& _philox_keyed_distribution_shards_cuda_(
+    Tensor& self,
+    const Tensor& key,
+    IntArrayRef global_shape,
+    IntArrayRef global_offsets,
+    IntArrayRef local_offsets,
+    IntArrayRef local_sizes,
+    int64_t chunk_count,
+    int64_t distribution,
+    ArrayRef<Scalar> params) {
+  constexpr const char* op_name = "_philox_keyed_distribution_shards_";
+  TORCH_CHECK(
+      self.is_floating_point(),
+      op_name,
+      ": self must be a floating point tensor, got ",
+      self.scalar_type());
+  TORCH_CHECK(
+      key.scalar_type() == kUInt64,
+      op_name,
+      ": key must have dtype uint64, got ",
+      key.scalar_type());
+  TORCH_CHECK(
+      key.dim() == 1 && key.size(0) == 2,
+      op_name,
+      ": key must have shape (2,), got ",
+      key.sizes());
+  TORCH_CHECK(
+      self.device() == key.device(),
+      op_name,
+      ": self and key must be on the same device, got ",
+      self.device(),
+      " and ",
+      key.device());
+  at::assert_no_overlap(self, key);
+
+  const auto distribution_kind =
+      static_cast<KeyedDistributionKind>(distribution);
+  TORCH_CHECK(
+      distribution_kind == KeyedDistributionKind::Normal ||
+          distribution_kind == KeyedDistributionKind::Uniform,
+      op_name,
+      ": unsupported distribution kind ",
+      distribution);
+  TORCH_CHECK(
+      params.size() == 2,
+      op_name,
+      ": distribution kind ",
+      distribution,
+      " expects 2 parameters, got ",
+      params.size());
+  TORCH_CHECK(
+      !params[0].isComplex() && !params[1].isComplex(),
+      op_name,
+      ": parameters must be real");
+  const double first_param = params[0].toDouble();
+  const double second_param = params[1].toDouble();
+  if (distribution_kind == KeyedDistributionKind::Normal) {
+    TORCH_CHECK(
+        second_param >= 0.0,
+        "normal expects std >= 0.0, but found std ",
+        second_param);
+  } else {
+    TORCH_CHECK(
+        first_param <= second_param,
+        "uniform expects low <= high, but found ",
+        first_param,
+        " > ",
+        second_param);
+  }
+
+  const auto metadata = detail::validate_philox_shard_metadata(
+      self,
+      global_shape,
+      global_offsets,
+      local_offsets,
+      local_sizes,
+      chunk_count,
+      op_name);
+  const auto launches = build_keyed_shard_launches(
+      self,
+      global_shape,
+      global_offsets,
+      local_offsets,
+      local_sizes,
+      chunk_count,
+      metadata,
+      op_name);
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      kHalf, kBFloat16, self.scalar_type(), op_name, [&] {
+    if (distribution_kind == KeyedDistributionKind::Normal) {
+      using transform_t = NormalTransform<scalar_t>;
+      run_keyed_shard_kernels<scalar_t>(
+          self,
+          key,
+          launches,
+          NormalSampler<scalar_t>{},
+          transform_t{
+              static_cast<typename transform_t::compute_t>(first_param),
+              static_cast<typename transform_t::compute_t>(second_param)});
+    } else {
+      run_keyed_shard_kernels<scalar_t>(
+          self,
+          key,
+          launches,
+          UniformSampler<scalar_t>{},
+          UniformTransform<scalar_t>{
+              static_cast<scalar_t>(first_param),
+              static_cast<scalar_t>(second_param)});
+    }
   });
   return self;
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6638,6 +6638,12 @@
     CUDA: _philox_uniform_cuda_
   autogen: _philox_uniform, _philox_uniform.out
 
+- func: _philox_keyed_distribution_shards_(Tensor(a!) self, Tensor key, SymInt[] global_shape, SymInt[] global_offsets, SymInt[] local_offsets, SymInt[] local_sizes, int chunk_count, int distribution, Scalar[] params) -> Tensor(a!)
+  variants: function
+  dispatch:
+    CUDA: _philox_keyed_distribution_shards_cuda_
+  autogen: _philox_keyed_distribution_shards, _philox_keyed_distribution_shards.out
+
 - func: _dirichlet_grad(Tensor x, Tensor alpha, Tensor total) -> Tensor
   dispatch:
     CPU: _dirichlet_grad_cpu

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -1488,6 +1488,7 @@ aten_native_source_non_codegen_list = [
     "aten/src/ATen/native/Normalization.cpp",
     "aten/src/ATen/native/Onehot.cpp",
     "aten/src/ATen/native/PackedSequence.cpp",
+    "aten/src/ATen/native/PhiloxShardMetadata.cpp",
     "aten/src/ATen/native/PixelShuffle.cpp",
     "aten/src/ATen/native/PointwiseOps.cpp",
     "aten/src/ATen/native/Pooling.cpp",

--- a/test/test_stateless_rng.py
+++ b/test/test_stateless_rng.py
@@ -897,8 +897,154 @@ class TestStatelessRNGLogicalShards(TestCase):
                 local_sizes=((2, 2),),
             )
 
+    @parametrize("distribution", ["normal", "uniform"])
+    def test_parameter_validation_precedes_writes(self, device, distribution):
+        key = random.key(123, device=device)
+        metadata = dict(
+            global_shape=(2, 2),
+            global_offsets=((0, 0),),
+            local_offsets=((0, 0),),
+            local_sizes=((2, 2),),
+        )
+        invalid_params = (
+            ({"std": -1.0}, {"std": float("nan")})
+            if distribution == "normal"
+            else ({"low": 1.0, "high": -1.0}, {"low": float("nan")})
+        )
+
+        for params in invalid_params:
+            result = torch.full((2, 2), 17.0, device=device)
+            with self.assertRaisesRegex(ValueError, "expects"):
+                getattr(random, f"{distribution}_shards_")(
+                    key, result, **params, **metadata
+                )
+            self.assertEqual(result, torch.full_like(result, 17.0))
+
+    @onlyCUDA
+    def test_cuda_fused_path_is_stateless(self, device):
+        key = random.key(123, device=device)
+        result = torch.empty((3, 4), device=device)
+        state = torch.cuda.get_rng_state(device)
+
+        random.normal_shards_(
+            key,
+            result,
+            global_shape=(3, 4),
+            global_offsets=((0, 0),),
+            local_offsets=((0, 0),),
+            local_sizes=((3, 4),),
+        )
+
+        self.assertEqual(torch.cuda.get_rng_state(device), state)
+
+    @onlyCUDA
+    def test_cuda_fused_path_graph_replay_reads_key(self, device):
+        key = random.key(123, device=device)
+        result = torch.empty((3, 4), device=device)
+        metadata = dict(
+            global_shape=(3, 4),
+            global_offsets=((0, 0),),
+            local_offsets=((0, 0),),
+            local_sizes=((3, 4),),
+        )
+
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                random.normal_shards_(key, result, mean=1.25, std=0.75, **metadata)
+        torch.cuda.current_stream().wait_stream(stream)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            random.normal_shards_(key, result, mean=1.25, std=0.75, **metadata)
+
+        for seed in (456, 789):
+            replay_key = random.key(seed, device=device)
+            key.copy_(replay_key)
+            graph.replay()
+            torch.cuda.synchronize()
+            self.assertEqual(
+                result,
+                self._dense_reference(replay_key, (3, 4), torch.float32, "normal"),
+                atol=0,
+                rtol=0,
+            )
+
+    @onlyCUDA
+    def test_cuda_native_validation_precedes_writes(self, device):
+        key = random.key(123, device=device)
+        result = torch.full((2, 2), 17.0, device=device)
+
+        with self.assertRaisesRegex(RuntimeError, "outside global_shape"):
+            torch.ops.aten._philox_keyed_distribution_shards_(
+                result,
+                key,
+                (2, 2),
+                (0, 0, 2, 0),
+                (0, 0, 1, 0),
+                (1, 2, 1, 2),
+                2,
+                0,
+                (0.0, 1.0),
+            )
+        self.assertEqual(result, torch.full_like(result, 17.0))
+
+    def test_native_meta(self, device):
+        key = torch.empty((2,), dtype=torch.uint64, device="meta")
+        result = torch.empty((2, 3), device="meta")
+
+        output = torch.ops.aten._philox_keyed_distribution_shards_(
+            result,
+            key,
+            (2, 3),
+            (0, 0),
+            (0, 0),
+            (2, 3),
+            1,
+            0,
+            (0.0, 1.0),
+        )
+        self.assertEqual(output.shape, result.shape)
+
+        with self.assertRaisesRegex(RuntimeError, "outside global_shape"):
+            torch.ops.aten._philox_keyed_distribution_shards_(
+                result,
+                key,
+                (2, 3),
+                (2, 0),
+                (0, 0),
+                (1, 3),
+                1,
+                0,
+                (0.0, 1.0),
+            )
+
 
 class TestStatelessRNGCompile(TestCase):
+    @onlyCUDA
+    def test_keyed_shards_fullgraph(self, device):
+        key = random.key(42, device=device)
+        sentinel = 17.0
+
+        def fill(key, result):
+            result = result.clone()
+            return torch.ops.aten._philox_keyed_distribution_shards_(
+                result,
+                key,
+                (3, 4),
+                (1, 0),
+                (1, 2),
+                (2, 4),
+                1,
+                0,
+                (1.25, 0.75),
+            )
+
+        result = torch.full((4, 8), sentinel, device=device)
+        compiled = torch.compile(fill, backend="aot_eager", fullgraph=True)
+        self.assertEqual(compiled(key, result), fill(key, result), atol=0, rtol=0)
+
     def test_split_fullgraph(self, device):
         key = random.key(42, device=device)
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -659,6 +659,163 @@ def meta_philox_uniform_(self, key, low=0.0, high=1.0):
     return self
 
 
+@register_meta(aten._philox_keyed_distribution_shards_.default)
+def meta_philox_keyed_distribution_shards_(
+    self,
+    key,
+    global_shape,
+    global_offsets,
+    local_offsets,
+    local_sizes,
+    chunk_count,
+    distribution,
+    params,
+):
+    op_name = "_philox_keyed_distribution_shards_"
+    _check_philox_distribution_args(op_name, self, key)
+    torch._check(
+        key.dim() == 1,
+        lambda: f"{op_name}: key must be unbatched, got shape {key.shape}",
+    )
+    torch._check(
+        len(global_shape) == self.dim(),
+        lambda: f"{op_name}: global_shape and self must have the same rank",
+    )
+    max_dims = 16 if torch.version.hip else 25
+    torch._check(
+        self.dim() <= max_dims,
+        lambda: f"{op_name}: tensors with more than {max_dims} dimensions are not supported",
+    )
+    torch._check(
+        chunk_count >= 0,
+        lambda: f"{op_name}: chunk_count must be non-negative",
+    )
+    if self.dim() == 0:
+        torch._check(
+            chunk_count <= 1,
+            lambda: f"{op_name}: a scalar tensor can have at most one shard",
+        )
+    metadata_size = chunk_count * self.dim()
+    torch._check(
+        len(global_offsets) == metadata_size
+        and len(local_offsets) == metadata_size
+        and len(local_sizes) == metadata_size,
+        lambda: (
+            f"{op_name}: flattened shard metadata arrays must contain "
+            "chunk_count * ndim values"
+        ),
+    )
+    torch._check(
+        distribution in (0, 1),
+        lambda: f"{op_name}: unsupported distribution kind {distribution}",
+    )
+    torch._check(
+        len(params) == 2,
+        lambda: f"{op_name}: distribution kind {distribution} expects 2 parameters",
+    )
+
+    global_numel = 1
+    for size in global_shape:
+        torch._check(
+            size >= 0,
+            lambda: f"{op_name}: global_shape must contain non-negative sizes",
+        )
+        global_numel *= size
+    torch._check(
+        global_numel <= torch.iinfo(torch.int64).max,
+        lambda: f"{op_name}: global tensor has more than int64 elements",
+    )
+
+    ndim = self.dim()
+    mapped_numel = 0
+    for chunk in range(chunk_count):
+        chunk_numel = 1
+        for dim in range(ndim):
+            index = chunk * ndim + dim
+            global_offset = global_offsets[index]
+            local_offset = local_offsets[index]
+            local_size = local_sizes[index]
+            torch._check(
+                (global_offset >= 0)
+                & (local_size >= 0)
+                & (local_size <= global_shape[dim])
+                & (global_offset <= global_shape[dim] - local_size),
+                lambda: f"{op_name}: global shard {chunk} dimension {dim} is outside global_shape",
+            )
+            torch._check(
+                (local_offset >= 0)
+                & (local_size <= self.shape[dim])
+                & (local_offset <= self.shape[dim] - local_size),
+                lambda: f"{op_name}: local shard {chunk} dimension {dim} is outside self shape",
+            )
+            chunk_numel *= local_size
+        mapped_numel += chunk_numel
+    torch._check(
+        mapped_numel <= self.numel(),
+        lambda: f"{op_name}: local shard metadata describes more than self.numel() elements",
+    )
+
+    for first in range(chunk_count):
+        for second in range(first + 1, chunk_count):
+            first_empty = False
+            second_empty = False
+            global_separated = False
+            local_separated = False
+            for dim in range(ndim):
+                first_index = first * ndim + dim
+                second_index = second * ndim + dim
+                first_size = local_sizes[first_index]
+                second_size = local_sizes[second_index]
+                first_empty = first_empty | (first_size == 0)
+                second_empty = second_empty | (second_size == 0)
+                global_separated = (
+                    global_separated
+                    | (
+                        global_offsets[first_index]
+                        >= global_offsets[second_index] + second_size
+                    )
+                    | (
+                        global_offsets[second_index]
+                        >= global_offsets[first_index] + first_size
+                    )
+                )
+                local_separated = (
+                    local_separated
+                    | (
+                        local_offsets[first_index]
+                        >= local_offsets[second_index] + second_size
+                    )
+                    | (
+                        local_offsets[second_index]
+                        >= local_offsets[first_index] + first_size
+                    )
+                )
+            torch._check(
+                first_empty | second_empty | global_separated,
+                lambda: f"{op_name}: global shards {first} and {second} must not overlap",
+            )
+            torch._check(
+                first_empty | second_empty | local_separated,
+                lambda: f"{op_name}: local shards {first} and {second} must not overlap",
+            )
+
+    torch._check(
+        not any(isinstance(param, complex) for param in params),
+        lambda: f"{op_name}: parameters must be real",
+    )
+    if distribution == 0:
+        torch._check(
+            params[1] >= 0,
+            lambda: f"normal expects std >= 0.0, but found std {params[1]}",
+        )
+    else:
+        torch._check(
+            params[0] <= params[1],
+            lambda: f"uniform expects low <= high, but found {params[0]} > {params[1]}",
+        )
+    return self
+
+
 @register_meta([aten._fft_c2r.default, aten._fft_c2r.out])
 @out_wrapper()
 def meta_fft_c2r(self: Tensor, dim: list[int], normalization: int, lastdim: int):

--- a/torch/func/_random.py
+++ b/torch/func/_random.py
@@ -446,10 +446,10 @@ def _materialized_shards_(
         local_sizes,
     )
     if distribution == "normal":
-        if params[1] < 0:
+        if not params[1] >= 0:
             raise ValueError(f"normal expects std >= 0.0, but found std {params[1]}")
     elif distribution == "uniform":
-        if params[0] > params[1]:
+        if not params[0] <= params[1]:
             raise ValueError(
                 f"uniform expects low <= high, but found {params[0]} > {params[1]}"
             )
@@ -491,6 +491,51 @@ def _materialized_shards_(
     return result
 
 
+def _fused_shards_(
+    key: torch.Tensor,
+    result: torch.Tensor,
+    *,
+    global_shape: Sequence[int],
+    global_offsets: Sequence[Sequence[int]],
+    local_offsets: Sequence[Sequence[int]],
+    local_sizes: Sequence[Sequence[int]],
+    distribution: str,
+    params: tuple[float, float],
+) -> torch.Tensor:
+    shape, global_rects, local_rects, sizes = _validate_shard_metadata(
+        key,
+        result,
+        global_shape,
+        global_offsets,
+        local_offsets,
+        local_sizes,
+    )
+    if distribution == "normal":
+        if not params[1] >= 0:
+            raise ValueError(f"normal expects std >= 0.0, but found std {params[1]}")
+        distribution_id = 0
+    elif distribution == "uniform":
+        if not params[0] <= params[1]:
+            raise ValueError(
+                f"uniform expects low <= high, but found {params[0]} > {params[1]}"
+            )
+        distribution_id = 1
+    else:
+        raise ValueError(f"unsupported distribution: {distribution}")
+
+    return torch.ops.aten._philox_keyed_distribution_shards_(
+        result,
+        key,
+        shape,
+        tuple(value for rectangle in global_rects for value in rectangle),
+        tuple(value for rectangle in local_rects for value in rectangle),
+        tuple(value for rectangle in sizes for value in rectangle),
+        len(sizes),
+        distribution_id,
+        params,
+    )
+
+
 def normal_shards_(
     key: torch.Tensor,
     result: torch.Tensor,
@@ -509,7 +554,10 @@ def normal_shards_(
     placed in ``result``. Padding and holes outside the rectangles are not
     modified.
     """
-    return _materialized_shards_(
+    implementation = (
+        _fused_shards_ if result.device.type == "cuda" else _materialized_shards_
+    )
+    return implementation(
         key,
         result,
         global_shape=global_shape,
@@ -539,7 +587,10 @@ def uniform_shards_(
     placed in ``result``. Padding and holes outside the rectangles are not
     modified.
     """
-    return _materialized_shards_(
+    implementation = (
+        _fused_shards_ if result.device.type == "cuda" else _materialized_shards_
+    )
+    return implementation(
         key,
         result,
         global_shape=global_shape,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191645
* __->__ #191644
* #191643
* #191642

Generate each local value directly from its draw key and global logical index without materializing per-element keys. Share the existing stateless normal and uniform samplers, validate all shard rectangles before launch, and retain the materialized implementation as the CPU reference.

Test bitwise equivalence across dtypes and shard layouts, CUDA graph replay, generator-state isolation, Meta validation, and AOT functionalization.