### PR TITLE
[RNG] Add stateful root key reservation

### DIFF
--- a/test/test_stateless_rng.py
+++ b/test/test_stateless_rng.py
@@ -403,6 +403,73 @@ class TestStatelessRNGKeyFoldIn(TestCase):
         )
 
 
+class TestStatefulPRNG(TestCase):
+    def test_take_key_matches_manual_split(self, device):
+        rng = random.StatefulPRNG(42, device=torch.device(device))
+        expected_state = random.key(42, device=device)
+
+        for _ in range(3):
+            expected_key, expected_state = random.split(expected_state, 2)
+            self.assertEqual(rng.take_key(), expected_key)
+            self.assertEqual(rng.get_state(), expected_state)
+
+    def test_get_set_state_replays(self, device):
+        rng = random.StatefulPRNG(42, device=torch.device(device))
+        rng.take_key()
+        checkpoint = rng.get_state()
+        expected = tuple(rng.take_key() for _ in range(3))
+
+        rng.set_state(checkpoint)
+        actual = tuple(rng.take_key() for _ in range(3))
+        self.assertEqual(actual, expected)
+
+    def test_state_copies_do_not_alias(self, device):
+        rng = random.StatefulPRNG(42, device=torch.device(device))
+        expected_key, expected_state = random.split(rng.get_state(), 2)
+
+        returned_key = rng.take_key()
+        returned_key.zero_()
+        self.assertEqual(rng.get_state(), expected_state)
+
+        state_copy = rng.get_state()
+        state_copy.zero_()
+        self.assertEqual(rng.get_state(), expected_state)
+
+        restore_state = expected_state.clone()
+        rng.set_state(restore_state)
+        restore_state.zero_()
+        self.assertEqual(rng.get_state(), expected_state)
+        self.assertNotEqual(expected_key, returned_key)
+
+    def test_set_state_validates_before_mutation(self, device):
+        rng = random.StatefulPRNG(42, device=torch.device(device))
+        expected_state = rng.get_state()
+        bad_states = (
+            None,
+            torch.zeros((2,), dtype=torch.int64, device=device),
+            torch.zeros((3,), dtype=torch.uint64, device=device),
+        )
+
+        for bad_state in bad_states:
+            expected_error = TypeError if bad_state is None else ValueError
+            with self.assertRaises(expected_error):
+                rng.set_state(bad_state)
+            self.assertEqual(rng.get_state(), expected_state)
+
+    @onlyAccelerator
+    def test_state_is_device_portable(self, device):
+        cpu_rng = random.StatefulPRNG(42)
+        device_rng = random.StatefulPRNG(0, device=torch.device(device))
+
+        device_rng.set_state(cpu_rng.get_state())
+        self.assertEqual(device_rng.device, torch.device(device))
+        self.assertEqual(device_rng.take_key().cpu(), cpu_rng.take_key())
+
+        cpu_rng.set_state(device_rng.get_state())
+        self.assertEqual(cpu_rng.device, torch.device("cpu"))
+        self.assertEqual(cpu_rng.take_key(), device_rng.take_key().cpu())
+
+
 class TestStatelessRNGDistribution(TestCase):
     def _gen(self, gen_fn_name, *args, **kwargs):
         return getattr(random, gen_fn_name)(*args, **kwargs)
@@ -1178,6 +1245,7 @@ instantiate_device_type_tests(
 instantiate_device_type_tests(
     TestStatelessRNGKeyFoldIn, globals(), only_for=("cpu", "cuda")
 )
+instantiate_device_type_tests(TestStatefulPRNG, globals(), only_for=("cpu", "cuda"))
 instantiate_device_type_tests(
     TestStatelessRNGDistribution, globals(), only_for=("cpu", "cuda")
 )

--- a/torch/func/_random.py
+++ b/torch/func/_random.py
@@ -132,6 +132,60 @@ def fold_in(key: torch.Tensor, data: int | torch.Tensor) -> torch.Tensor:
     return torch.ops.aten._philox_key_fold_in(key, data)
 
 
+class StatefulPRNG:
+    r"""Own a mutable root key for stateless random operations.
+
+    ``take_key()`` splits the current state into two independent keys, returns
+    the first, and stores the second as the next state. One call therefore
+    represents one state transition regardless of how much work consumes the
+    returned key.
+
+    Args:
+        seed (int): Seed used to create the initial key.
+        device (:class:`torch.device`, optional): Device on which to store the
+            key. Default: ``cpu``.
+
+    .. note::
+
+        Mutating state-owner methods are intended for single-threaded host
+        control flow outside ``torch.compile`` and accelerator graph capture.
+        The keys returned by :meth:`take_key` may be consumed by compiled or
+        captured stateless operations.
+    """
+
+    def __init__(self, seed: int, *, device: torch.device | None = None) -> None:
+        self._state = key(seed, device=device)
+
+    @property
+    def device(self) -> torch.device:
+        """Return the device storing this PRNG's state."""
+        return self._state.device
+
+    def take_key(self) -> torch.Tensor:
+        """Return one child key and advance to the other child."""
+        children = split(self._state, 2)
+        self._state = children[1].clone()
+        return children[0]
+
+    def get_state(self) -> torch.Tensor:
+        """Return a copy of the current key state."""
+        return self._state.clone()
+
+    def set_state(self, state: torch.Tensor) -> "StatefulPRNG":
+        """Restore state, copying it onto this PRNG's construction device."""
+        if not isinstance(state, torch.Tensor):
+            raise TypeError(
+                f"StatefulPRNG state must be a torch.Tensor, got {type(state).__name__}"
+            )
+        if state.dtype != torch.uint64 or state.shape != (2,):
+            raise ValueError("StatefulPRNG state must be a uint64 tensor of shape (2,)")
+        if state.layout != torch.strided:
+            raise ValueError("StatefulPRNG state must have strided layout")
+        new_state = state.to(device=self.device, copy=True)
+        self._state = new_state
+        return self
+
+
 def normal_(
     key: torch.Tensor,
     result: torch.Tensor,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191645
* #191644
* #191643
* #191642

Add a small mutable owner around stateless Philox keys. Each take_key call returns the first split child and stores an isolated copy of the second child, so one model initialization transaction advances state exactly once regardless of local work.

Support cloned get/set state with cross-device checkpoint restore and test ordering, replay, alias isolation, validation atomicity, and CPU/CUDA portability.