### PR TITLE
Fix B017 violations in selective build tooling

### DIFF
--- a/tools/code_analyzer/gen_oplist.py
+++ b/tools/code_analyzer/gen_oplist.py
@@ -38,7 +38,7 @@ def throw_if_any_op_includes_overloads(selective_builder: SelectiveBuilder) -> N
         if op.include_all_overloads:
             ops.append(op_name)
     if ops:
-        raise Exception(  # noqa: TRY002
+        raise ValueError(
             (
                 "Operators that include all overloads are "
                 + "not allowed since --allow-include-all-overloads "

--- a/tools/test/gen_oplist_test.py
+++ b/tools/test/gen_oplist_test.py
@@ -20,9 +20,10 @@ class GenOplistTest(unittest.TestCase):
             ("op3", MagicMock(include_all_overloads=True)),
         ]
 
-        self.assertRaises(
-            Exception, throw_if_any_op_includes_overloads, selective_builder
-        )
+        with self.assertRaisesRegex(
+            ValueError, "Operators that include all overloads are not allowed"
+        ):
+            throw_if_any_op_includes_overloads(selective_builder)
 
         selective_builder.operators.items.return_value = [
             ("op1", MagicMock(include_all_overloads=False)),

--- a/tools/test/test_create_alerts.py
+++ b/tools/test/test_create_alerts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 from unittest import main, TestCase
 
@@ -64,11 +65,8 @@ class TestGitHubPR(TestCase):
             ["pytorch_linux_xenial_py3_6_gcc5_4_test2"],
         )
         self.assertListEqual(filter_job_names(job_names, ".*xenial.*test3"), [])
-        self.assertRaises(
-            Exception,
-            lambda: filter_job_names(job_names, "["),
-            msg="malformed regex should throw exception",
-        )
+        with self.assertRaisesRegex(re.error, "unterminated character set"):
+            filter_job_names(job_names, "[")
 
 
 if __name__ == "__main__":

--- a/tools/test/test_selective_build.py
+++ b/tools/test/test_selective_build.py
@@ -72,7 +72,10 @@ operators:
         def gen():
             return SelectiveBuilder.from_yaml_str(yaml_config_invalid)
 
-        self.assertRaises(Exception, gen)
+        with self.assertRaisesRegex(
+            ValueError, "Got unexpected top level keys: invalid"
+        ):
+            gen()
 
         selector_all = SelectiveBuilder.from_yaml_str(yaml_config_all)
 
@@ -178,7 +181,11 @@ operators:
         def gen_new_op():
             return combine_operators(op1, op3)
 
-        self.assertRaises(Exception, gen_new_op)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expected both arguments to have the same name",
+        ):
+            gen_new_op()
 
     def test_training_op_fetch(self) -> None:
         yaml_config = """

--- a/torchgen/selective_build/operator.py
+++ b/torchgen/selective_build/operator.py
@@ -148,7 +148,7 @@ def combine_operators(
     lhs: SelectiveBuildOperator, rhs: SelectiveBuildOperator
 ) -> SelectiveBuildOperator:
     if str(lhs.name) != str(rhs.name):
-        raise Exception(  # noqa: TRY002
+        raise ValueError(
             f"Expected both arguments to have the same name, but got '{str(lhs.name)}' and '{str(rhs.name)}' instead"
         )
 

--- a/torchgen/selective_build/selector.py
+++ b/torchgen/selective_build/selector.py
@@ -85,7 +85,7 @@ class SelectiveBuilder:
         }
         top_level_keys = set(data.keys())
         if len(top_level_keys - valid_top_level_keys) > 0:
-            raise Exception(  # noqa: TRY002
+            raise ValueError(
                 "Got unexpected top level keys: {}".format(
                     ",".join(top_level_keys - valid_top_level_keys),
                 )


### PR DESCRIPTION
The final code and modifications were produced by me, a contributor.

> AI-assisted wording; the implementation was primarily written by the
> contributor:
>
> I wrote and prepared most of this change and reviewed the final diff. AI
> assistance was limited to verification and polishing this PR description.
>
> ## Issue
>
> Addresses part of #106571.
>
> ## Summary
>
> Replace broad exception assertions in selective build tooling tests with
> checks for the specific exception types and messages. Where the production
> code raised a generic `Exception`, use `ValueError` so the tests can avoid
> B017 without weakening their assertions.
>
> ## Checklist
>
> - [x] Passes lint (`spin quicklint`)
> - [x] Added/updated tests
> - [x] Documentation not applicable
> - [x] Benchmark results not applicable (no performance impact)
>
> ## BC-breaking?
>
> No. `ValueError` remains a subclass of `Exception`; existing callers that
> catch `Exception` continue to work.
>
> ## Test Plan
>
> ```text
> .venv/bin/python -m unittest tools.test.gen_oplist_test tools.test.test_create_alerts tools.test.test_selective_build
> ```
>
> ```text
> .venv/bin/spin quicklint
> ```
