### PR TITLE
Strict pyrefly checking: round 1 (5/N)

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -371,3 +371,13 @@ bad-param-name-override = false
 unannotated-return = true
 unannotated-parameter = true
 unannotated-attribute = true
+
+[[sub-config]]
+matches = "torch/_lazy/**"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true

--- a/torch/_lazy/__init__.py
+++ b/torch/_lazy/__init__.py
@@ -1,12 +1,21 @@
-# mypy: allow-untyped-defs
+import pickle
+from collections.abc import Sequence
+from types import ModuleType
+from typing import cast, TypeVar
 
+import torch
 import torch._C._lazy
+from torch.serialization import DEFAULT_PROTOCOL
+from torch.types import FileLike
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
 from .closure import add_step_closure, run_step_closures
 
 
-def mark_step(device: str = "", wait=False):
+_T = TypeVar("_T")
+
+
+def mark_step(device: str = "", wait: bool = False) -> None:
     """Triggers a mark step, which amounts to
     - collecting a group of 'live' lazy tensors to index into the compilation cache
       (lowering/compiling their IR graphs if not cached)
@@ -19,7 +28,7 @@ def mark_step(device: str = "", wait=False):
     run_step_closures()
 
 
-def wait_device_ops(devices=None):
+def wait_device_ops(devices: list[str] | None = None) -> None:
     """Waits for all the async operations on the given devices to complete.
     Args:
       devices (string..., optional): The devices whose async ops need to be waited
@@ -30,26 +39,40 @@ def wait_device_ops(devices=None):
     torch._C._lazy._wait_device_ops(devices=devices)
 
 
-def sync_multi(tensors, devices):
+def sync_multi(tensors: Sequence[torch.Tensor], devices: list[str]) -> None:
     """
     Sync the list of lazy tensors so there IR get lowered for the activate backend
     and the compiled computation graph get cached.
     """
-    torch._C._lazy._sync_multi(tensors, devices)
+    torch._C._lazy._sync_multi(list(tensors), devices)
 
 
-def get_tensor_id(tensor):
+def get_tensor_id(tensor: torch.Tensor) -> int:
     """Return a unique id of the lazy tensor maintained by LTC"""
     return torch._C._lazy._get_tensor_id(tensor)
 
 
-def to_cpu(tensors, devices=None):
+def to_cpu(tensors: _T, devices: list[str] | None = None) -> _T:
     devices = devices or ["lazy"]
 
     flattened, spec = tree_flatten(tensors)
     sync_multi(flattened, devices)
-    return tree_unflatten([t.to("cpu") for t in flattened], spec)
+    return cast(_T, tree_unflatten([t.to("cpu") for t in flattened], spec))
 
 
-def save(tensors, *args, **kwargs):
-    torch.save(to_cpu(tensors), *args, **kwargs)
+def save(
+    tensors: object,
+    f: FileLike,
+    pickle_module: ModuleType = pickle,
+    pickle_protocol: int = DEFAULT_PROTOCOL,
+    _use_new_zipfile_serialization: bool = True,
+    _disable_byteorder_record: bool = False,
+) -> None:
+    torch.save(
+        to_cpu(tensors),
+        f,
+        pickle_module=pickle_module,
+        pickle_protocol=pickle_protocol,
+        _use_new_zipfile_serialization=_use_new_zipfile_serialization,
+        _disable_byteorder_record=_disable_byteorder_record,
+    )

--- a/torch/_lazy/closure.py
+++ b/torch/_lazy/closure.py
@@ -1,16 +1,16 @@
-# mypy: allow-untyped-defs
 import os
 import threading
+from collections.abc import Callable, Iterable
 from queue import Empty as EmptyQueue, Queue
 
-from torch._lazy.device_context import get_device_context
+from torch._lazy.device_context import DeviceContext, get_device_context
 
 
 class ClosureHandler:
     def __init__(self) -> None:
         pass
 
-    def run(self, closure):
+    def run(self, closure: Callable[[], object]) -> None:
         """Run closure function
 
         Args:
@@ -18,7 +18,7 @@ class ClosureHandler:
         """
         closure()
 
-    def __call__(self, closures):
+    def __call__(self, closures: Iterable[Callable[[], object]]) -> None:
         for closure in closures:
             self.run(closure)
 
@@ -33,21 +33,21 @@ class AsyncClosureHandler(ClosureHandler):
         variable.
     """
 
-    def __init__(self, max_queue_size=100):
+    def __init__(self, max_queue_size: int = 100) -> None:
         super().__init__()
-        self._closure_queue: Queue = Queue(
+        self._closure_queue: Queue[Callable[[], object]] = Queue(
             int(os.environ.get("LTC_MAX_ASYNC_QUEUE", max_queue_size))
         )
-        self._closure_exception: Queue = Queue()
+        self._closure_exception: Queue[Exception] = Queue()
         self._closure_lock = threading.Lock()
         self._closure_event_loop_finished = threading.Event()
-        self._closure_event_loop = None
+        self._closure_event_loop: threading.Thread | None = None
 
-    def start_event_loop(self):
+    def start_event_loop(self) -> None:
         """Start closure event loop if not started"""
         if self._closure_event_loop is None:
 
-            def event_loop():
+            def event_loop() -> None:
                 # Run loop until closure event is set and closure queue is empty
                 while True:
                     try:
@@ -63,13 +63,10 @@ class AsyncClosureHandler(ClosureHandler):
                         self._closure_exception.put(e)
                         return
 
-            # pyrefly: ignore [bad-assignment]
-            self._closure_event_loop = threading.Thread(
-                target=event_loop
-            )  # pyrefly: ignore [bad-assignment]
-            self._closure_event_loop.start()  # pyrefly: ignore [missing-attribute]
+            self._closure_event_loop = threading.Thread(target=event_loop)
+            self._closure_event_loop.start()
 
-    def run(self, closure):
+    def run(self, closure: Callable[[], object]) -> None:
         with self._closure_lock:
             self._closure_queue.put(closure, block=True)
             if (
@@ -86,7 +83,11 @@ class AsyncClosureHandler(ClosureHandler):
                     self.start_event_loop()
 
 
-def add_step_closure(closure, args=(), run_async=False):
+def add_step_closure(
+    closure: Callable[..., object],
+    args: tuple[object, ...] = (),
+    run_async: bool = False,
+) -> None:
     """Adds a closure to the list of the ones to be run at the end of the step.
     Many times during model training there is the need to print/report (print to
     console, post to tensorboard, etc...) information which require the content of
@@ -109,14 +110,16 @@ def add_step_closure(closure, args=(), run_async=False):
     """
     devctx = get_device_context()
     closures_type = "async_step_closures" if run_async else "step_closures"
-    step_closures = getattr(devctx, closures_type, None)
+    step_closures: list[Callable[[], object]] | None = getattr(
+        devctx, closures_type, None
+    )
     if step_closures is None:
         step_closures = []
         setattr(devctx, closures_type, step_closures)
     step_closures.append(lambda a=args: closure(*a))
 
 
-def run_step_closures():
+def run_step_closures() -> DeviceContext:
     devctx = get_device_context()
     async_step_closures = getattr(devctx, "async_step_closures", None)
     if async_step_closures is not None:

--- a/torch/_lazy/closure.py
+++ b/torch/_lazy/closure.py
@@ -2,8 +2,13 @@ import os
 import threading
 from collections.abc import Callable, Iterable
 from queue import Empty as EmptyQueue, Queue
+from typing import overload
+from typing_extensions import TypeVarTuple, Unpack
 
 from torch._lazy.device_context import DeviceContext, get_device_context
+
+
+_Ts = TypeVarTuple("_Ts")
 
 
 class ClosureHandler:
@@ -83,6 +88,18 @@ class AsyncClosureHandler(ClosureHandler):
                     self.start_event_loop()
 
 
+@overload
+def add_step_closure(
+    closure: Callable[[], object],
+    args: tuple[()] = (),
+    run_async: bool = False,
+) -> None: ...
+@overload
+def add_step_closure(
+    closure: Callable[[Unpack[_Ts]], object],
+    args: tuple[Unpack[_Ts]],
+    run_async: bool = False,
+) -> None: ...
 def add_step_closure(
     closure: Callable[..., object],
     args: tuple[object, ...] = (),

--- a/torch/_lazy/computation.py
+++ b/torch/_lazy/computation.py
@@ -1,24 +1,28 @@
-# mypy: allow-untyped-defs
+from collections.abc import Sequence
+
+import torch
 import torch._C._lazy
 import torch._C._lazy_ts_backend
 
 
-def get_tensors_ts_device_data_node(tensors):
+def get_tensors_ts_device_data_node(
+    tensors: Sequence[torch.Tensor],
+) -> tuple[list[int], list[object]]:
     """Return tensor ids and eager tensors for DeviceData nodes in the
     IR for the passed in lazy tensors.
 
     TODO: This API is currently ts backend specific. We are working on
     generalizing it to all backends including XLA.
     """
-    return torch._C._lazy_ts_backend._get_tensors_ts_device_data_node(tensors)
+    return torch._C._lazy_ts_backend._get_tensors_ts_device_data_node(list(tensors))
 
 
-def get_graph_hash(tensors):
+def get_graph_hash(tensors: Sequence[torch.Tensor]) -> str:
     """Return the graph hash for the passed in lazy tensors"""
-    return torch._C._lazy._get_graph_hash(tensors)
+    return torch._C._lazy._get_graph_hash(list(tensors))
 
 
-def run_cached_graph(hash_str, graph_inputs):
+def run_cached_graph(hash_str: str, graph_inputs: list[object]) -> list[torch.Tensor]:
     """Running the cached computation graph with the given inputs
 
     TODO: This API is currently ts backend specific. We are working on

--- a/torch/_lazy/computation.py
+++ b/torch/_lazy/computation.py
@@ -22,10 +22,12 @@ def get_graph_hash(tensors: Sequence[torch.Tensor]) -> str:
     return torch._C._lazy._get_graph_hash(list(tensors))
 
 
-def run_cached_graph(hash_str: str, graph_inputs: list[object]) -> list[torch.Tensor]:
+def run_cached_graph(
+    hash_str: str, graph_inputs: Sequence[object]
+) -> list[torch.Tensor]:
     """Running the cached computation graph with the given inputs
 
     TODO: This API is currently ts backend specific. We are working on
     generalizing it to all backends including XLA.
     """
-    return torch._C._lazy_ts_backend._run_cached_graph(hash_str, graph_inputs)
+    return torch._C._lazy_ts_backend._run_cached_graph(hash_str, list(graph_inputs))

--- a/torch/_lazy/debug.py
+++ b/torch/_lazy/debug.py
@@ -1,22 +1,24 @@
-# mypy: allow-untyped-defs
+from collections.abc import Sequence
+
+import torch
 import torch._C._lazy
 
 
-def render_ir_graph(tensors):
+def render_ir_graph(tensors: Sequence[torch.Tensor]) -> str:
     """Return a text dump of the LTC IR graph in dot format for the tensors.
     The text can be processed by tools like dot to be rendered in pdf,png etc."""
-    return torch._C._lazy._get_tensors_dot(tensors)
+    return torch._C._lazy._get_tensors_dot(list(tensors))
 
 
-def dump_ir(tensors, ir_format):
+def dump_ir(tensors: Sequence[torch.Tensor], ir_format: str) -> str:
     """Return a dump of the tensors in the specified format.
     Valid format are
     - text: for LTC IR
     - backend: for the active backend IR
     """
     if ir_format == "text":
-        return torch._C._lazy._get_tensors_text(tensors)
+        return torch._C._lazy._get_tensors_text(list(tensors))
     elif ir_format == "backend":
-        return torch._C._lazy._get_tensors_backend(tensors)
+        return torch._C._lazy._get_tensors_backend(list(tensors))
     else:
         raise RuntimeError(f"Unrecognized IR format: {ir_format}")

--- a/torch/_lazy/device_context.py
+++ b/torch/_lazy/device_context.py
@@ -1,11 +1,10 @@
 import threading
-from typing import Any
 
 import torch._C._lazy
 
 
 class DeviceContext:
-    _CONTEXTS: dict[str, Any] = {}
+    _CONTEXTS: dict[str, "DeviceContext"] = {}
     _CONTEXTS_LOCK = threading.Lock()
 
     def __init__(self, device: str) -> None:

--- a/torch/_lazy/extract_compiled_graph.py
+++ b/torch/_lazy/extract_compiled_graph.py
@@ -1,10 +1,9 @@
-# mypy: allow-untyped-defs
 import copy
 import dataclasses
 import itertools
 import os
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Callable, Iterable, Sequence
+from typing import cast
 
 import torch
 import torch._lazy as lazy
@@ -36,10 +35,10 @@ class GraphInputMatcher:
     # most likely const tensors and we can get its content from graph_input_tensors
     # Category 2: those whose id are found in tensor_id_to_arg_idx. We should get
     #  the tensor from method arguments
-    graph_input_ivalues: list[Any]
+    graph_input_ivalues: list[object]
 
     # get the real graph input tensors
-    def __call__(self, args):
+    def __call__(self, args: Sequence[object]) -> list[object]:
         real_input = []
         for tensor_id, traced_ivalue in zip(
             self.graph_input_tensor_ids, self.graph_input_ivalues
@@ -71,7 +70,7 @@ class ReturnValueHandler:
     to duplicate the eager tensors later.
     """
 
-    def __init__(self, lazy_out_list):
+    def __init__(self, lazy_out_list: Sequence[torch.Tensor]) -> None:
         self.index: list[list[int]] = []
         self.total_count = len(lazy_out_list)
 
@@ -85,8 +84,10 @@ class ReturnValueHandler:
                 self.index.append([dup_idx])
                 tensor_id_to_idx[id(lazy_tensor)] = uniq_idx
 
-    def duplicate_eager_tensors(self, eager_tensor_list):
-        duplicated_list = [None] * self.total_count
+    def duplicate_eager_tensors(
+        self, eager_tensor_list: Sequence[torch.Tensor]
+    ) -> list[torch.Tensor]:
+        duplicated_list: list[torch.Tensor | None] = [None] * self.total_count
         if len(eager_tensor_list) != len(self.index):
             raise AssertionError(
                 f"eager_tensor_list length {len(eager_tensor_list)} != index length {len(self.index)}"
@@ -95,22 +96,22 @@ class ReturnValueHandler:
         for uniq_idx, eager_tensor in enumerate(eager_tensor_list):
             for dup_idx in self.index[uniq_idx]:
                 duplicated_list[dup_idx] = eager_tensor
-        return duplicated_list
+        return cast(list[torch.Tensor], duplicated_list)
 
 
-def force_lazy_device(model: fx.GraphModule):
+def force_lazy_device(model: fx.GraphModule) -> None:
     """
     Factory methods in a Fx graph may create tensors for a specific eager devices.
     If we take no actions, those eager tensors will be mixed with lazy tensors and
     cause crash. This method overwrite those eager device to lazy device.
     """
 
-    def tolazydevice(dev):
+    def tolazydevice(dev: object) -> object:
         if isinstance(dev, torch.device):
             return torch.device("lazy", index=dev.index)
         return dev
 
-    def hasDeviceArg(args, kwargs):
+    def hasDeviceArg(args: Iterable[object], kwargs: dict[str, object]) -> bool:
         return any(
             isinstance(arg, torch.device)
             for arg in itertools.chain(args, kwargs.values())
@@ -141,7 +142,7 @@ def force_lazy_device(model: fx.GraphModule):
     model.recompile()
 
 
-def get_fallback_ops():
+def get_fallback_ops() -> list[str]:
     fallback_ops = []
     for opname in metrics.counter_names():
         if "aten::" not in opname:
@@ -153,7 +154,9 @@ def get_fallback_ops():
     return fallback_ops
 
 
-def extract_compiled_graph(model: fx.GraphModule, example_inputs) -> Callable:
+def extract_compiled_graph(
+    model: fx.GraphModule, example_inputs: Sequence[torch.Tensor]
+) -> Callable[..., Sequence[torch.Tensor]]:
     """
     Optimize an eager model with LTC and returns a wrapper to execute the
     compiled graph directly without retracing. It depends on other mechanisms
@@ -213,7 +216,7 @@ def extract_compiled_graph(model: fx.GraphModule, example_inputs) -> Callable:
     # by graph hash later.
     lazy.sync_multi(args_and_out, [])
 
-    def optimized_mod(*args):
+    def optimized_mod(*args: torch.Tensor) -> Sequence[torch.Tensor]:
         if len(args_and_out) == 0:
             return ()
         graph_input = graph_input_matcher(args)

--- a/torch/_lazy/extract_compiled_graph.py
+++ b/torch/_lazy/extract_compiled_graph.py
@@ -2,8 +2,8 @@ import copy
 import dataclasses
 import itertools
 import os
-from collections.abc import Callable, Iterable, Sequence
-from typing import cast
+from collections.abc import Iterable, Mapping, Sequence
+from typing import cast, Protocol, TypeAlias, TypeVar
 
 import torch
 import torch._lazy as lazy
@@ -11,9 +11,20 @@ import torch._lazy.metrics as metrics
 from torch import fx
 from torch._lazy import computation, debug as lazy_debug
 from torch._lazy.tensor_factory_functions import tensor_factory_functions
+from torch.fx.node import Argument
 
 
 debug = os.environ.get("debug_extract_compiled_graph") is not None
+
+_T = TypeVar("_T")
+
+# A TorchScript graph-input IValue: concretely a const tensor, a device-data
+# node, or a runtime argument, none of which share a useful static type here.
+_IValue: TypeAlias = object
+
+
+class _CompiledFn(Protocol):
+    def __call__(self, *args: torch.Tensor) -> Sequence[torch.Tensor]: ...
 
 
 @dataclasses.dataclass
@@ -35,11 +46,11 @@ class GraphInputMatcher:
     # most likely const tensors and we can get its content from graph_input_tensors
     # Category 2: those whose id are found in tensor_id_to_arg_idx. We should get
     #  the tensor from method arguments
-    graph_input_ivalues: list[object]
+    graph_input_ivalues: list[_IValue]
 
     # get the real graph input tensors
-    def __call__(self, args: Sequence[object]) -> list[object]:
-        real_input = []
+    def __call__(self, args: Sequence[object]) -> list[_IValue]:
+        real_input: list[_IValue] = []
         for tensor_id, traced_ivalue in zip(
             self.graph_input_tensor_ids, self.graph_input_ivalues
         ):
@@ -70,7 +81,7 @@ class ReturnValueHandler:
     to duplicate the eager tensors later.
     """
 
-    def __init__(self, lazy_out_list: Sequence[torch.Tensor]) -> None:
+    def __init__(self, lazy_out_list: Sequence[object]) -> None:
         self.index: list[list[int]] = []
         self.total_count = len(lazy_out_list)
 
@@ -84,10 +95,8 @@ class ReturnValueHandler:
                 self.index.append([dup_idx])
                 tensor_id_to_idx[id(lazy_tensor)] = uniq_idx
 
-    def duplicate_eager_tensors(
-        self, eager_tensor_list: Sequence[torch.Tensor]
-    ) -> list[torch.Tensor]:
-        duplicated_list: list[torch.Tensor | None] = [None] * self.total_count
+    def duplicate_eager_tensors(self, eager_tensor_list: Sequence[_T]) -> list[_T]:
+        duplicated_list: list[_T | None] = [None] * self.total_count
         if len(eager_tensor_list) != len(self.index):
             raise AssertionError(
                 f"eager_tensor_list length {len(eager_tensor_list)} != index length {len(self.index)}"
@@ -96,7 +105,8 @@ class ReturnValueHandler:
         for uniq_idx, eager_tensor in enumerate(eager_tensor_list):
             for dup_idx in self.index[uniq_idx]:
                 duplicated_list[dup_idx] = eager_tensor
-        return cast(list[torch.Tensor], duplicated_list)
+        # every slot is filled: self.index partitions range(total_count).
+        return cast(list[_T], duplicated_list)
 
 
 def force_lazy_device(model: fx.GraphModule) -> None:
@@ -106,12 +116,12 @@ def force_lazy_device(model: fx.GraphModule) -> None:
     cause crash. This method overwrite those eager device to lazy device.
     """
 
-    def tolazydevice(dev: object) -> object:
+    def tolazydevice(dev: _T) -> _T:
         if isinstance(dev, torch.device):
-            return torch.device("lazy", index=dev.index)
+            return cast(_T, torch.device("lazy", index=dev.index))
         return dev
 
-    def hasDeviceArg(args: Iterable[object], kwargs: dict[str, object]) -> bool:
+    def hasDeviceArg(args: Iterable[Argument], kwargs: Mapping[str, Argument]) -> bool:
         return any(
             isinstance(arg, torch.device)
             for arg in itertools.chain(args, kwargs.values())
@@ -156,7 +166,7 @@ def get_fallback_ops() -> list[str]:
 
 def extract_compiled_graph(
     model: fx.GraphModule, example_inputs: Sequence[torch.Tensor]
-) -> Callable[..., Sequence[torch.Tensor]]:
+) -> _CompiledFn:
     """
     Optimize an eager model with LTC and returns a wrapper to execute the
     compiled graph directly without retracing. It depends on other mechanisms

--- a/torch/_lazy/ir_cache.py
+++ b/torch/_lazy/ir_cache.py
@@ -1,13 +1,12 @@
-# mypy: allow-untyped-defs
 import torch._C._lazy
 
 
-def dump(dot_file_name: str):
+def dump(dot_file_name: str) -> None:
     """Dump TrieCache in the dot format"""
     return torch._C._lazy._dump_ir_cache(dot_file_name)
 
 
-def reset():
+def reset() -> None:
     """Clear TrieCache. This is needed in testing to avoid
     node reusing between different tests.
     """

--- a/torch/_lazy/metrics.py
+++ b/torch/_lazy/metrics.py
@@ -1,22 +1,21 @@
-# mypy: allow-untyped-defs
 import torch._C._lazy
 
 
-def reset():
+def reset() -> None:
     """Resets all metric counters."""
     torch._C._lazy._reset_metrics()
 
 
-def counter_names():
+def counter_names() -> list[str]:
     """Retrieves all the currently active counter names."""
     return torch._C._lazy._counter_names()
 
 
-def counter_value(name: str):
+def counter_value(name: str) -> int:
     """Return the value of the counter with the specified name"""
     return torch._C._lazy._counter_value(name)
 
 
-def metrics_report():
+def metrics_report() -> str:
     """Return the combined (lazy core and backend) metric report"""
     return torch._C._lazy._metrics_report()

--- a/torch/_lazy/ts_backend.py
+++ b/torch/_lazy/ts_backend.py
@@ -1,7 +1,6 @@
-# mypy: allow-untyped-defs
 import torch._C._lazy_ts_backend
 
 
-def init():
+def init() -> None:
     """Initializes the lazy Torchscript backend"""
     torch._C._lazy_ts_backend._init()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191651

Annotates and turns on whole-file pyrefly checking for torch/_lazy/. Fifth batch
of the effort to enable annotation checking on non-public torch files.

Rather than one [[sub-config]] entry per file, this uses a single
matches = "torch/_lazy/**" glob: the whole subpackage now passes strict checking.
The 8 files that carried the "mypy: allow-untyped-defs" header are annotated here;
config.py, device_context.py and tensor_factory_functions.py were already
annotated and pass as-is. pyrefly's `matches` supports ** globs but not brace
expansion or list forms, so a glob is the way to cover a fully-annotated
subpackage in one entry.

Most functions are thin wrappers over the torch._C._lazy / _lazy_ts_backend
bindings, so their signatures mirror the binding stubs; tensor sequences are
typed Sequence[torch.Tensor] and converted with list() at the binding boundary
(which declares list[Tensor], and which pybind copies anyway). to_cpu is
structure-preserving (a _T -> _T TypeVar). No Any is introduced: TorchScript
IValues are typed `object`, and save mirrors torch.save's real signature instead
of forwarding *args/**kwargs. Typing _closure_event_loop as
threading.Thread | None also let three now-redundant "pyrefly: ignore" comments
be removed from closure.py.

Test Plan:

```
lintrunner -a torch/_lazy/*.py pyrefly.toml
pyrefly check   # whole project: 156 errors == baseline, no net-new
```

The changes are annotations plus outcome-neutral list() conversions at the
C-binding boundary; no behavioral change. Lazy-backend tests were not run here
because the local torch._C extension is stale (unrelated missing symbols); run
them after a rebuild.

Authored with Claude.