### PR TITLE
[DCP] Fail the write future when a FileSystemWriter thread raises

### DIFF
--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -1,7 +1,10 @@
 # Owner(s): ["oncall: distributed"]
 
+import os
 import sys
 import tempfile
+import threading
+from contextlib import contextmanager
 from typing import Any, IO
 
 import torch
@@ -23,6 +26,9 @@ from torch.distributed.checkpoint import (
     save_state_dict,
 )
 from torch.distributed.checkpoint._extension import ZStandard
+from torch.distributed.checkpoint.api import CheckpointException
+from torch.distributed.checkpoint.default_planner import DefaultSavePlanner
+from torch.distributed.checkpoint.filesystem import FileSystem
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -154,6 +160,70 @@ class TestDistributedStateDictSaveLoad(TestCase):
             )
 
             assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
+
+
+class _FailOnWriterThreadFileSystem(FileSystem):
+    """Raises from ``create_stream`` on the writer threads spawned by ``_write_data``.
+
+    The main thread blocks in its first ``create_stream`` until a spawned thread has
+    failed. That ordering is what makes the test deterministic: the main thread cannot
+    drain ``file_queue`` and starve the spawned thread of work.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.thread_failed = threading.Event()
+
+    @contextmanager
+    def create_stream(self, path, mode):
+        if threading.current_thread() is not threading.main_thread():
+            self.thread_failed.set()
+            raise OSError("injected create_stream failure")
+        if not self.thread_failed.wait(timeout=300):
+            raise AssertionError("writer thread never reached create_stream")
+        with super().create_stream(path, mode) as stream:
+            yield stream
+
+
+class TestFileSystemWriterThreadFailure(TestCase):
+    def _writer(self, path: str) -> FileSystemWriter:
+        # thread_count=2 spawns one writer thread alongside the main thread, and
+        # single_file_per_rank=False gives each write item its own file so both
+        # threads have work to pick up.
+        writer = FileSystemWriter(path=path, thread_count=2, single_file_per_rank=False)
+        writer.fs = _FailOnWriterThreadFileSystem()
+        return writer
+
+    def test_write_data_future_fails(self) -> None:
+        state_dict = {"a": torch.arange(4.0), "b": torch.arange(6.0)}
+
+        with tempfile.TemporaryDirectory() as path:
+            fs_writer = self._writer(path)
+            planner = DefaultSavePlanner()
+            planner.set_up_planner(state_dict, is_coordinator=True)
+            fs_writer.set_up_storage_writer(is_coordinator=True)
+
+            plan = fs_writer.prepare_local_plan(planner.create_local_plan())
+            plan = planner.finish_plan(fs_writer.prepare_global_plan([plan])[0])
+
+            fut = fs_writer.write_data(plan, planner)
+            with self.assertRaisesRegex(OSError, "injected create_stream failure"):
+                fut.wait()
+
+    def test_save_does_not_publish_metadata(self) -> None:
+        state_dict = {"a": torch.arange(4.0), "b": torch.arange(6.0)}
+
+        with tempfile.TemporaryDirectory() as path:
+            with self.assertRaisesRegex(
+                CheckpointException, "injected create_stream failure"
+            ):
+                save(
+                    state_dict=state_dict,
+                    storage_writer=self._writer(path),
+                    no_dist=True,
+                )
+
+            self.assertNotIn(".metadata", os.listdir(path))
 
 
 class TestDistributedStateDictSaveLoadRot13(TestCase):

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -715,49 +715,52 @@ class _FileSystemWriter(StorageWriter):
         file_queue: queue.Queue,
     ) -> Future[list[WriteResult]]:
         result_queue: queue.Queue = queue.Queue()
+        exception_queue: queue.Queue = queue.Queue()
+
+        def write_files() -> None:
+            try:
+                _write_files_from_queue(
+                    create_stream=self.fs.create_stream,
+                    file_queue=file_queue,
+                    result_queue=result_queue,
+                    planner=planner,
+                    transforms=self.transforms,
+                    inflight_threshhold=self.per_thread_copy_ahead,
+                    use_fsync=self.sync_files,
+                    thread_count=self.thread_count,
+                    serialization_format=self.serialization_format,
+                )
+            except Exception as e:
+                exception_queue.put(e)
 
         threads = []
         for _ in range(1, self.thread_count):
-            t = threading.Thread(
-                target=_write_files_from_queue,
-                args=(
-                    self.fs.create_stream,
-                    file_queue,
-                    result_queue,
-                    planner,
-                    self.transforms,
-                    self.per_thread_copy_ahead,
-                    self.sync_files,
-                    self.thread_count,
-                    self.serialization_format,
-                ),
-            )
+            t = threading.Thread(target=write_files)
             t.start()
             threads.append(t)
 
-        _write_files_from_queue(
-            create_stream=self.fs.create_stream,
-            file_queue=file_queue,
-            result_queue=result_queue,
-            planner=planner,
-            transforms=self.transforms,
-            inflight_threshhold=self.per_thread_copy_ahead,
-            use_fsync=self.sync_files,
-            thread_count=self.thread_count,
-            serialization_format=self.serialization_format,
-        )
+        write_files()
 
         for t in threads:
             t.join()
+
+        fut: Future[list[WriteResult]] = Future()
+
+        # A writer thread that died left its files unwritten, so the results in
+        # result_queue cover only part of the plan. Failing the future keeps the
+        # caller from publishing metadata for a partial checkpoint.
+        if not exception_queue.empty():
+            fut.set_exception(exception_queue.get_nowait())
+            return fut
 
         res = []
         try:
             while True:
                 res += result_queue.get_nowait()
         except queue.Empty:
-            fut: Future[list[WriteResult]] = Future()
-            fut.set_result(res)
-            return fut
+            pass
+        fut.set_result(res)
+        return fut
 
     def finish(self, metadata: Metadata, results: list[list[WriteResult]]) -> None:
         metadata.version = CURRENT_DCP_VERSION


### PR DESCRIPTION
Fixes #191391

### Problem

`FileSystemWriter._write_data()` runs `_write_files_from_queue()` on `thread_count - 1`
spawned threads plus the calling thread. That function only catches `queue.Empty`, its
normal loop-termination signal, so a real error propagates out of it.

On the calling thread that error reached the caller. On a spawned thread it only reached
`threading.excepthook`, because `Thread.join()` returns normally whether or not the thread
died. `_write_data()` then drained `result_queue` and returned a *successfully completed*
future holding however many `WriteResult`s happened to make it in.

The caller treats that as a complete write and calls `finish()`, which publishes
`.metadata` describing every planned item. So an I/O failure is reported as a successful
save, and the damage only surfaces at load time.

Minimal repro on `main` (inject `OSError` from `create_stream` on a spawned writer thread,
two tensors, `thread_count=2`):

```
dcp.save() returned WITHOUT raising -> reported success
keys the metadata claims are saved: ['a', 'b']
write results recorded in metadata: 1
files actually on disk: ['.metadata', '__0_1.distcp']

Now try to load the 'successful' checkpoint back:
load FAILED: CheckpointException: ...
  KeyError: MetadataIndex(fqn='a', offset=torch.Size([0]), index=0)
```

The `OSError` appears only as an unstructured background-thread traceback on stderr.

### Fix

Both call paths now go through a single `write_files()` closure that records any exception,
and `_write_data()` fails the returned future if a thread reported one. `save()` therefore
raises at `all_writes.wait()` and never reaches `finish()`, so no metadata is published for
a partial checkpoint.

Two incidental benefits: the duplicated argument list between the thread target and the
inline call is gone, and a failure on the calling thread no longer escapes before the
spawned threads are joined.

Notes on the choices here:

- The closure catches `Exception`, not `BaseException`. `Future.set_exception()` raises
  `AssertionError` for anything that is not an `Exception` instance, so catching
  `BaseException` would risk replacing the real error with an assertion failure, and would
  also swallow `KeyboardInterrupt` on the calling thread.
- Failing the future rather than raising inline keeps the documented
  `write_data() -> Future[list[WriteResult]]` contract, and matches what the issue asks
  for. The only caller (`state_dict_saver._save_state_dict`) waits on the future
  immediately, so the error surfaces in the same place either way.
- When several threads fail, the first recorded exception is reported.

### Testing

New `TestFileSystemWriterThreadFailure` in
`test/distributed/checkpoint/test_file_system_checkpoint_cpu.py` covers the future failing
and `.metadata` not being written. Both fail before this change and pass after:

```
python test/distributed/checkpoint/test_file_system_checkpoint_cpu.py TestFileSystemWriterThreadFailure
```

Making that deterministic needs the spawned thread to be guaranteed some work, so the test
filesystem blocks the calling thread inside its first `create_stream` until a spawned
thread has failed. Without that the calling thread can drain `file_queue` first and the
test would pass for the wrong reason.

The rest of the file plus the DCP suites sharing this write path (`hf_storage` reaches it
via `super()._write_data`):

```
python test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
python test/distributed/checkpoint/test_hf_safetensor_e2e.py
python test/distributed/checkpoint/test_quantized_hf_storage.py
python test/distributed/checkpoint/test_checkpoint.py
python test/distributed/checkpoint/test_fsspec.py
```

A save/load round trip was also verified byte-exact for `thread_count` 1, 2 and 4 with
`single_file_per_rank` both `True` and `False`.

Prepared with the assistance of an AI coding assistant.
