### PR TITLE
[CI] Add configurable Claude effort

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -21,7 +21,19 @@ jobs:
       # "@claude fable review"); default stays Opus. Branch on event_name so an
       # issue/PR body mentioning "fable" doesn't affect an unrelated @claude comment.
       model: ${{ ((github.event_name == 'issue_comment' && contains(github.event.comment.body, 'fable')) || (github.event_name == 'issues' && contains(github.event.issue.body, 'fable'))) && 'global.anthropic.claude-fable-5' || 'global.anthropic.claude-opus-5' }}
-      additional_claude_args: '--allowedTools Skill'
+      # Keep the comment text out of claude_args: only these hardcoded effort
+      # values can reach the CLI. "effort=max" wins if multiple values appear.
+      additional_claude_args: >-
+        --allowedTools Skill --effort
+        ${{
+          ((github.event_name == 'issue_comment' && contains(github.event.comment.body, 'effort=max')) ||
+           (github.event_name == 'issues' && contains(github.event.issue.body, 'effort=max'))) && 'max' ||
+          ((github.event_name == 'issue_comment' && contains(github.event.comment.body, 'effort=high')) ||
+           (github.event_name == 'issues' && contains(github.event.issue.body, 'effort=high'))) && 'high' ||
+          ((github.event_name == 'issue_comment' && contains(github.event.comment.body, 'effort=low')) ||
+           (github.event_name == 'issues' && contains(github.event.issue.body, 'effort=low'))) && 'low' ||
+          'medium'
+        }}
       # Surface stalled Bedrock requests before the one-hour job timeout.
       settings: '{"alwaysThinkingEnabled":true,"env":{"API_TIMEOUT_MS":"180000","CLAUDE_CODE_MAX_RETRIES":"2","CLAUDE_ENABLE_STREAM_WATCHDOG":"1"}}'
       append_system_prompt: |


### PR DESCRIPTION
**Human Note**

experimenting with effort to seee if we can reduce the amount of timeouts

**Agent note**

> This PR was prepared with an AI assistant.
>
> Claude Code otherwise uses its implicit high effort for every request. This allows callers to select low, medium, high, or max effort while making medium the default. The workflow maps only hardcoded values into the CLI rather than forwarding comment text, and max takes precedence if multiple effort markers are present.
>
> The same routing was exercised with Opus 5 in CIForge. All four effort values reached Claude Code and completed successfully.

**Test Plan**

```bash
PATH="$HOME/.venvs/dev/bin:$PATH" lintrunner -a
git diff --check
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-code.yml"); puts "YAML OK"'
```
