### PR TITLE
[profiler][cupti] Python .pftrace export from the columnar window

### DIFF
--- a/torch/profiler/_cupti/monitor.py
+++ b/torch/profiler/_cupti/monitor.py
@@ -1185,6 +1185,17 @@ class CuptiMonitor:
                 # .copy() so the column is writable and owns its memory (the
                 # frombuffer view is read-only over the transient bytes).
                 cols[fid] = np.frombuffer(raw, dtype=ctype.numpy(size)).copy()
+            elif size > 8:
+                # Oversized field (the 20-byte CUpti_ActivityEnvironment union): keep its
+                # first 8 bytes as u8 -- the primary metric pair (power+powerLimit / smClock+
+                # memoryClock / temperature / fanSpeed), split downstream by ENVIRONMENT_KIND.
+                cols[fid] = (
+                    np.frombuffer(raw, dtype=np.uint8)
+                    .reshape(-1, size)[:, :8]
+                    .copy()
+                    .view("<u8")
+                    .ravel()
+                )
         return cols
 
     def _maybe_warn_backpressure(self) -> None:

--- a/torch/profiler/_cupti/monitor_trace.py
+++ b/torch/profiler/_cupti/monitor_trace.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 import gzip
 import json
 import math
+import os
+import sys
 import time as _time
-from typing import Any, cast, TYPE_CHECKING
+from typing import Any, cast
 
 import numpy as np
+
+import torch
 
 
 # orjson serializes ~3-8x faster than stdlib json on large traces and emits bytes; not a
@@ -17,9 +21,6 @@ try:
 except ImportError:
     _orjson = None  # type: ignore[assignment]
 
-
-if TYPE_CHECKING:
-    import os
 
 from cupti.cupti import (  # pyrefly: ignore[missing-import]
     Driver_api_trace_cbid,
@@ -276,6 +277,31 @@ def _graph_dependency_flow_events(
     return events
 
 
+# Eager kernel/transfer launches (NOT cudaGraphLaunch). These 1:1 correlate to an eager GPU
+# op, so they drive the host-launch -> render-stage gpu_correlation link (event_id == corr).
+# Syncs are excluded -- they correlate to no kernel, so a link on them would point nowhere
+# pointing nowhere.
+_RUNTIME_LAUNCH_NAMES = {
+    "cudaLaunchKernel",
+    "cudaLaunchCooperativeKernel",
+    "cudaLaunchCooperativeKernelMultiDevice",
+    "cudaLaunchKernelExC",
+}
+
+
+def _runtime_is_eager_launch(name: str) -> bool:
+    return name in _RUNTIME_LAUNCH_NAMES or name.startswith(
+        ("cudaMemcpy", "cudaMemset")
+    )
+
+
+def _runtime_is_launch(name: str) -> bool:
+    # The set for the gpu_correlation channel link: eager launches plus cudaGraphLaunch
+    # (links to the replayed kernels; gpu_correlation is a per-selection details link, so the
+    # fan-out does not spiderweb).
+    return _runtime_is_eager_launch(name) or name == "cudaGraphLaunch"
+
+
 def _trace_window_entries(
     trace_window: dict[str, object],
     *,
@@ -335,7 +361,7 @@ def _trace_window_entries(
         if linked is not None and linked[0] == process_id:
             return linked[1]
         process_map = thread_resource_map.get(process_id, {})
-        return int(process_map.get(normalized_thread_id, normalized_thread_id))
+        return process_map.get(normalized_thread_id, normalized_thread_id)
 
     # Drop the trailing "Activity Buffer Request" overhead that lands after the last
     # real activity: the cutoff is the max non-overhead end (converted ns).
@@ -896,6 +922,506 @@ def _gpu_user_annotation_events(
     return gpu_user_events
 
 
+# --- Perfetto-native (.pftrace) encoding -------------------------------------
+# The wire encoding is done natively (protozero via the perfetto SDK) in
+# torch/csrc/profiler/cupti/monitor_pftrace.cpp; here we only shape the window into the
+# flat arrays + track list it consumes.
+
+
+def _nest_track_slices(groups: list, track_uuids: set) -> None:
+    """Make each track's slices nest, so Perfetto can pair them.
+
+    Perfetto's TrackEvent model pairs SLICE_BEGIN/SLICE_END per track with a stack, so a
+    track cannot represent partially-overlapping (non-nested) slices. CUPTI reports serial
+    GPU-stream slices whose start/end can jitter into ~ns overlaps; left as-is the viewer's
+    stack pairing mis-pairs them into 0-duration / inflated slices. For each track in
+    ``track_uuids`` (GPU stream tracks, whose slices are serial), walk its slices in start
+    order and truncate any still-open slice that a later overlapping slice extends past --
+    serial slices become adjacent, genuine nesting is preserved. Only ``end`` is mutated
+    (in place), so per-slice annotation/flow alignment is untouched."""
+    if not track_uuids:
+        return
+    want = np.fromiter(
+        (np.uint64(u) for u in track_uuids), dtype=np.uint64, count=len(track_uuids)
+    )
+    ts_p, end_p, uu_p, gi_p, li_p = [], [], [], [], []
+    for gi, g in enumerate(groups):
+        idx = np.nonzero(np.isin(g["uuid"], want))[0]
+        if not len(idx):
+            continue
+        ts_p.append(g["ts"][idx])
+        end_p.append(g["end"][idx])
+        uu_p.append(g["uuid"][idx])
+        gi_p.append(np.full(len(idx), gi, dtype=np.int64))
+        li_p.append(idx.astype(np.int64))
+    if not ts_p:
+        return
+    ts, end, uu = np.concatenate(ts_p), np.concatenate(end_p), np.concatenate(uu_p)
+    gi, li = np.concatenate(gi_p), np.concatenate(li_p)
+    # Per track, parents before nested children: sort by (track, start asc, end desc).
+    order = np.lexsort((-end, ts, uu))
+    tsl, endl, uul = ts[order].tolist(), end[order].tolist(), uu[order].tolist()
+    stack: list = []
+    prev = None
+    for k in range(len(tsl)):
+        if uul[k] != prev:
+            stack.clear()
+            prev = uul[k]
+        s_ts, s_end = tsl[k], endl[k]
+        while stack:
+            p = stack[-1]
+            if endl[p] <= s_ts:
+                stack.pop()
+            elif endl[p] < s_end:
+                # partial overlap: truncate the open parent to this slice's start so the
+                # two serialize instead of mis-pairing.
+                endl[p] = s_ts
+                stack.pop()
+            else:
+                break  # endl[p] >= s_end: this slice nests within the parent
+        stack.append(k)
+    new_end = np.empty(len(endl), dtype=np.int64)
+    new_end[order] = np.asarray(endl, dtype=np.int64)  # undo the sort permutation
+    for gv in np.unique(gi):
+        m = gi == gv
+        groups[int(gv)]["end"][li[m]] = new_end[m]
+
+
+# GPU render-stage definitions: (column key, stage iid, stage name, RenderStageCategory).
+# COMPUTE == 2 (matches the reference); the rest are OTHER (0). Stage iids are small and
+# share the gpu_specifications iid space with the hardware-queue lanes below.
+_RENDER_STAGES = (
+    ("kernel", 1, "Kernel", 2),
+    ("gpu_memcpy", 2, "Memcpy", 0),
+    ("gpu_memset", 3, "Memset", 0),
+    # GPU-side user annotations (collective/phase ranges) on the stream lane; not a kernel
+    # (no launch), so they render as a range nesting over the kernels they span.
+    ("gpu_annotation", 4, "Annotation", 0),
+)
+_HW_QUEUE_IID_BASE = 100  # hardware-queue iids start past the stage iids
+
+# Chrome-trace categories NOT rendered as CPU track_event slices: "Trace" metadata, and the
+# GPU-side kinds we emit from the columnar window instead (kernels/transfers as GPU Render
+# Stages, runtime/driver remapped onto their CPU thread). gpu_user_annotation in particular
+# is a GPU-stream-side mirror of a CPU user_annotation -- rendering it here would put duplicate
+# stream-named tracks (forward_backward, all_reduce, ...) under the CPU process.
+_NON_CPU_CATS = frozenset(
+    {
+        "Trace",
+        "kernel",
+        "gpu_memcpy",
+        "gpu_memset",
+        "gpu_user_annotation",
+        "cuda_runtime",
+        "cuda_driver",
+        "cuda_sync",
+        "overhead",
+    }
+)
+
+# ComputeKernelLaunch.args, interned as InternedComputeArgName (field 1001 on InternedData).
+# Stable iids + the names the viewer's GPU Compute panel joins on (ExtraComputeArg.name_iid ->
+# InternedComputeArgName.name). value getter maps a kind's column dict to the per-event column
+# (None -> 0 / skipped, e.g. on memcpy/memset).
+_COMPUTE_ARGS = (
+    (1, "registers_per_thread", lambda c: c.get("registers_per_thread")),
+    (2, "shared_mem_dynamic", lambda c: c.get("dynamic_shared_memory")),
+    (
+        3,
+        "thread_count",
+        lambda c: (
+            c["block_x"] * c["block_y"] * c["block_z"] if "block_x" in c else None
+        ),
+    ),
+)
+
+
+# Per-event GpuRenderStageEvent.extra_data: the scalar args that used to live on the
+# track_event GPU slices, now that the render stage is the single GPU representation.
+# (key, getter, skip_zero); skip_zero drops 0 for fields where 0 means absent (so kernel-
+# only / memcpy-only fields don't show up on the other kinds). grid/block/registers/shared/
+# thread_count ride the structured ComputeKernelLaunch instead; collective metadata is
+# carried separately as JSON extra_data.
+# NB: device/stream/context are kept under " id"-suffixed keys, not the bare names. The
+# GPU-by-process viewer plugin reads extract_arg(arg_set, 'device'/'stream') and requires
+# them to be NUM, but GpuRenderStageEvent.extra_data.value is always a string -- the bare
+# names would collide with that numeric expectation and crash the plugin. (device == the
+# render stage's gpu_id and stream == the lane, so this is detail-panel only.)
+def _lower_node_id(c: dict):
+    # graphNodeId packs the graph id in its upper 32 bits (emitted separately as "graph id");
+    # keep only the lower 32-bit node id, matching the chrome export.
+    gnid = c.get("graph_node_id")
+    return None if gnid is None else gnid & 0xFFFFFFFF
+
+
+_RENDER_EXTRA = (
+    ("device id", lambda c: c.get("device_id"), False),
+    ("context id", lambda c: c.get("context_id"), False),
+    ("stream id", lambda c: c.get("stream_id"), False),
+    ("correlation", lambda c: c.get("correlation_id"), True),
+    ("priority", lambda c: c.get("priority"), True),
+    ("queued", lambda c: c.get("queued"), True),
+    ("channel", lambda c: c.get("channel"), True),
+    ("channel_type", lambda c: c.get("channel_type"), True),
+    ("graph id", lambda c: c.get("graph_id"), True),
+    ("graph node id", _lower_node_id, True),
+    ("bytes", lambda c: c.get("bytes"), True),
+    ("value", lambda c: c.get("value"), True),
+    ("memory kind", lambda c: c.get("memory_kind"), True),
+)
+# Grid + workgroup dimension columns (kernels only; 0 elsewhere -> no launch emitted).
+_LAUNCH_DIMS = ("grid_x", "grid_y", "grid_z", "block_x", "block_y", "block_z")
+
+
+def _process_name() -> str:
+    try:
+        with open("/proc/self/comm") as f:
+            return f.read().strip() or "python"
+    except OSError:
+        return os.path.basename(sys.executable) or "python"
+
+
+def _gpu_panel_const_extra(gpu: np.ndarray) -> list[tuple[str, str]]:
+    """Trace-wide string args the GPU Compute panel reads off each kernel slice
+    (extract_arg 'arch'/'process_id'/'process_name'): the traced device's arch
+    (compute capability) plus the owning process. Constant across the trace, so
+    emitted once per event rather than per-kernel-profiled."""
+    out: list[tuple[str, str]] = []
+    try:
+        dev = int(gpu[0]) if len(gpu) else torch.cuda.current_device()
+        major, minor = torch.cuda.get_device_capability(dev)
+        out.append(("arch", f"sm_{major}{minor}"))
+    except Exception:
+        pass
+    out.append(("process_id", str(os.getpid())))
+    out.append(("process_name", _process_name()))
+    return out
+
+
+def _merge_annotation_metadata(annotation: Any, metadata: Any) -> str | None:
+    """Merge a row's graph annotation(s) and collective-metadata blob into one JSON object whose
+    top-level fields the native encoder spreads onto the render stage as extra_data -- the
+    pftrace analog of the chrome path's per-arg spread (``_annotation_to_args``). ``annotation``
+    is the resolved graph annotation (a list of dicts, a dict, or a str, from the graph
+    annotation registry); ``metadata`` is the collective-descriptor JSON blob (str, from the
+    eager external-metadata join). Returns None when neither contributes anything.
+
+    Without this the render stage carried only the collective ``metadata`` column, so
+    graph-node annotations (``mark_kernels`` regions, e.g. a collective's process-group name
+    recorded at capture) never reached the .pftrace GPU rows even though the chrome path spread
+    them -- a chrome/pftrace parity gap."""
+    merged: dict[str, Any] = {}
+    if annotation is not None:
+        items = annotation if isinstance(annotation, list) else [annotation]
+        for it in items:
+            if isinstance(it, dict):
+                for k, v in it.items():
+                    merged[str(k)] = v
+            elif isinstance(it, str):
+                merged.setdefault("annotation", it)
+    if metadata is not None:
+        try:
+            decoded = (
+                json.loads(metadata) if isinstance(metadata, (str, bytes)) else metadata
+            )
+        except (json.JSONDecodeError, TypeError):
+            decoded = None
+        if isinstance(decoded, dict):
+            for k, v in decoded.items():
+                merged[str(k)] = v
+    return json.dumps(merged) if merged else None
+
+
+def _lists_to_csr(lists: list, dtype) -> tuple:
+    """Flatten a list-of-lists into a CSR: an int32 offsets array (length n + 1) and a flat
+    values array of ``dtype``; slice i is values[offsets[i]:offsets[i + 1]]."""
+    lengths = np.fromiter((len(x) for x in lists), dtype=np.int32, count=len(lists))
+    offsets = np.zeros(len(lists) + 1, dtype=np.int32)
+    np.cumsum(lengths, out=offsets[1:])
+    flat = np.fromiter(
+        (v for x in lists for v in x), dtype=dtype, count=int(offsets[-1])
+    )
+    return offsets, flat
+
+
+def _render_stage_cols(render_columns: dict) -> list:
+    """Authoritative surviving-stage selection: ``(ks, iid, name, cat, c)`` for each stage in
+    ``_RENDER_STAGES`` order whose column is present and nonempty. Row ordering across the render
+    stages is defined once here, so ``_assign_render_event_ids`` and ``_build_render_stages``
+    emit rows in the same order (event_id[i] aligns with render-stage row i)."""
+    out = []
+    for ks, iid, name, cat in _RENDER_STAGES:
+        c = render_columns.get(ks)
+        if not c or not len(c.get("start_ns", ())):
+            continue
+        out.append((ks, iid, name, cat, c))
+    return out
+
+
+def _assign_render_event_ids(render_columns: dict, graph_deps: dict) -> tuple | None:
+    """Assign a unique event_id per GPU render-stage row and derive the host-launch link and the
+    graph node->node dependency arrows. Iterates :func:`_render_stage_cols` (which defines the
+    render-stage row order shared with :func:`_build_render_stages`), so ``event_id[i]`` aligns
+    with render-stage row i. Returns ``None`` when there are no render-stage rows, else a tuple
+    of:
+
+    - ``event_id``: uint64 arange(n) + 1 (0 stays reserved for "none").
+    - ``corr_to_event_ids``: correlation_id -> [event_id, ...] grouping, for the CPU launch
+      slice's gpu_correlation (an eager launch -> 1 id, a graph replay -> its ROOT node ids).
+      When graph deps are known the launch links only to the graph's roots (nodes with no
+      recorded predecessor); the rest are reached through the node->node dependency arrows.
+    - ``(wait_offsets, wait_ids)``: the event_wait_ids CSR. Each graphed row (graph_node_id != 0)
+      resolves ``graph_deps[graph_node_id]`` predecessor tools_ids to the event_ids of the nodes
+      in the SAME replay (grouped by correlation_id), skipping predecessors absent from it.
+    """
+    corr_p, gnid_p = [], []
+    for _ks, _iid, _name, _cat, c in _render_stage_cols(render_columns):
+        n = len(c["start_ns"])
+        z = np.zeros(n, dtype=np.int64)
+        corr_p.append(np.ascontiguousarray(c.get("correlation_id", z), dtype=np.int64))
+        gnid_p.append(np.ascontiguousarray(c.get("graph_node_id", z), dtype=np.int64))
+    if not corr_p:
+        return None
+    corr = np.concatenate(corr_p)
+    gnid = np.concatenate(gnid_p)
+    n = len(corr)
+    event_id = np.arange(n, dtype=np.uint64) + np.uint64(1)
+    # correlation_id -> event_ids, grouped vectorized (event_id[i] == i + 1). A launch's
+    # gpu_correlation reads this: eager -> one id, a graph replay (one shared correlation) ->
+    # its root node ids. When graph deps are known, drop non-root graphed nodes (those present
+    # as a graph_deps key, i.e. with a recorded predecessor) so the launch links only to the
+    # roots; the rest are reached through the node->node dependency arrows. Eager kernels
+    # (graph_node_id 0) are never a graph_deps key, so they always link.
+    if graph_deps:
+        dep_keys = np.fromiter(graph_deps.keys(), dtype=np.int64, count=len(graph_deps))
+        link = ~np.isin(gnid, dep_keys)
+        corr_l, eid_l = corr[link], event_id[link]
+    else:
+        corr_l, eid_l = corr, event_id
+    order = np.argsort(corr_l, kind="stable")
+    uniq_corr, starts = np.unique(corr_l[order], return_index=True)
+    groups = np.split(eid_l[order], starts[1:])
+    corr_to_event_ids = dict(zip(uniq_corr.tolist(), groups))
+    # event_wait_ids: only graphed replays carry node dependencies, so build the per-row CSR
+    # only when deps exist; otherwise every render stage waits on nothing.
+    if graph_deps:
+        corr_l, gnid_l = corr.tolist(), gnid.tolist()
+        # Per-replay graph_node_id -> event_id (a correlation is one replay), to resolve each
+        # graphed row's predecessors to node event_ids within its own replay.
+        node_map_by_corr: dict[int, dict[int, int]] = {}
+        for i, g in enumerate(gnid_l):
+            if g:
+                node_map_by_corr.setdefault(corr_l[i], {})[g] = i + 1
+        wait_lists: list[list[int]] = []
+        for i, g in enumerate(gnid_l):
+            node_map = node_map_by_corr.get(corr_l[i]) if g else None
+            wait_lists.append(
+                [node_map[p] for p in graph_deps.get(g, ()) if p in node_map]
+                if node_map
+                else []
+            )
+        wait_offsets, wait_ids = _lists_to_csr(wait_lists, np.uint64)
+    else:
+        wait_offsets = np.zeros(n + 1, dtype=np.int32)
+        wait_ids = np.empty(0, dtype=np.uint64)
+    return event_id, corr_to_event_ids, wait_offsets, wait_ids
+
+
+def _build_render_stages(
+    columns: dict,
+    gfx_pid: int,
+    iid_of: dict,
+    name_table: list,
+    event_id: Any,
+    event_wait: tuple,
+):
+    """Build the GpuRenderStageEvent payload (gpu_specs, gfx_contexts, stage_cols, extra,
+    launch, tables) for the native GPU Render Stages hardware-queue lanes, or None if there are
+    no GPU ops. Each GPU op becomes one event on a (gpu_id, hardware-queue) lane tagged by stage
+    (kind). Compute kernels additionally carry kernel_iid -> InternedComputeKernel (which names
+    the slice) and a structured ComputeKernelLaunch (grid/workgroup Dim3 + args named via
+    name_iid -> InternedComputeArgName) -> the viewer's GPU Compute "Launch Statistics" panel;
+    memcpy/memset carry their byte count as generic extra_data. The hardware queue is the CUDA
+    stream (one lane per stream), so all streams are preserved; the scalar kernel args
+    (device/stream/correlation/channel/...) ride along as extra_data. Each event has its own
+    duration -- no stack pairing -- so durations are exact (no nesting)."""
+    ts_p, dur_p, gpu_p, stage_p, kname_p = [], [], [], [], []
+    dim_p: dict[str, list] = {k: [] for k in _LAUNCH_DIMS}
+    arg_p: dict[int, list] = {iid: [] for iid, _n, _g in _COMPUTE_ARGS}
+    extra_p: dict[str, list] = {k: [] for k, _g, _s in _RENDER_EXTRA}
+    meta_p: list = []  # per-row spread blob (graph annotation + collective descriptor)
+    stream_p: list = []
+    lane_names_by_id: dict[int, str] = {}  # reassigned logical lane -> resolver name
+    for _ks, stage_iid, _name, _cat, c in _render_stage_cols(columns):
+        n = len(c["start_ns"])
+        z = np.zeros(n, dtype=np.int64)
+        ts_p.append(np.ascontiguousarray(c["start_ns"], dtype=np.int64))
+        dur_p.append(np.maximum(c["end_ns"] - c["start_ns"], 0).astype(np.int64))
+        gpu_p.append(np.ascontiguousarray(c["device_id"], dtype=np.int64))
+        # One lane per stream (the hardware queue); preserves all streams (channel is
+        # 0/unpopulated in many captures, which would otherwise collapse every stream
+        # into a single lane). The CUPTI channel is kept as extra_data instead.
+        # Reassign graphed ops onto their logical lane (mirrors the chrome path): CUPTI piles
+        # graph-replay ops on the one replay stream, so on that stream's lane they overlap;
+        # the resolver-assigned lane (+ its name) spreads them out. Absent a resolver the
+        # logical_lane column defaults to the CUDA stream, so this is a no-op.
+        stream_col = np.ascontiguousarray(c["stream_id"], dtype=np.int64)
+        lane_col = c.get("logical_lane")
+        if lane_col is not None:
+            reassign = lane_col != stream_col
+            gnid_col = c.get("graph_node_id")
+            if gnid_col is not None:
+                reassign &= gnid_col != 0
+            lname_col = c.get("lane_name")
+            if lname_col is not None:
+                for lv, nm, rs in zip(
+                    lane_col.tolist(), lname_col.tolist(), reassign.tolist()
+                ):
+                    if rs and nm is not None:
+                        lane_names_by_id[int(lv)] = str(nm)
+            stream_p.append(np.where(reassign, lane_col, stream_col).astype(np.int64))
+        else:
+            stream_p.append(stream_col)
+        stage_p.append(np.full(n, stage_iid, dtype=np.uint64))
+        # Per-event kernel name (only kernels have one) -> InternedComputeKernel + kernel_iid.
+        nm = c.get("name")
+        kname_p.append(nm if nm is not None else np.full(n, "", dtype=object))
+        for k in _LAUNCH_DIMS:
+            dim_p[k].append(np.ascontiguousarray(c.get(k, z), dtype=np.int64))
+        for iid, _n, getter in _COMPUTE_ARGS:
+            v = getter(c)
+            arg_p[iid].append(z if v is None else np.ascontiguousarray(v, np.int64))
+        for key, getter, _skip in _RENDER_EXTRA:
+            v = getter(c)
+            extra_p[key].append(z if v is None else np.ascontiguousarray(v, np.int64))
+        # Per-row spread blob: the graph annotation (mark_kernels regions -- e.g. a collective's
+        # process-group name) merged with the collective-descriptor metadata, spread onto the
+        # render stage as extra_data below. Fast path when a kind has neither.
+        mc = c.get("metadata")
+        ac = c.get("annotation")
+        has_ann = ac is not None and bool(ac.astype(bool).any())
+        if mc is None and not has_ann:
+            meta_p.append([None] * n)
+        else:
+            ml = mc.tolist() if mc is not None else [None] * n
+            al = ac.tolist() if has_ann else [None] * n
+            meta_p.append([_merge_annotation_metadata(a, m) for a, m in zip(al, ml)])
+    if not ts_p:
+        return None
+    ts, dur, gpu = np.concatenate(ts_p), np.concatenate(dur_p), np.concatenate(gpu_p)
+    stream, stage = np.concatenate(stream_p), np.concatenate(stage_p)
+    # Serialize overlapping kernel/memcpy/memset render stages per lane. A CUDA stream is
+    # serial, but CUPTI graph-replay timestamps overlap ~13%, which renders as messy multi-depth
+    # kernels instead of a clean depth-1 row beneath the spanning Annotation (which is the depth-0
+    # parent and must keep its full extent -- so it is excluded). Clamp each op's end to the next
+    # op's start on the same (gpu, stream) lane.
+    ann_iid = next(i for ks, i, _n, _c in _RENDER_STAGES if ks == "gpu_annotation")
+    end = ts + dur
+    sub = np.nonzero(stage != ann_iid)[0]
+    if len(sub):
+        lane = (gpu.astype(np.int64) << np.int64(32)) | (stream & 0xFFFFFFFF)
+        order = sub[np.lexsort((ts[sub], lane[sub]))]
+        nxt_ts = np.empty(len(order), dtype=np.int64)
+        nxt_ts[:-1] = ts[order][1:]
+        nxt_ts[-1] = np.iinfo(np.int64).max
+        same = np.zeros(len(order), dtype=bool)
+        same[:-1] = lane[order][1:] == lane[order][:-1]
+        cap = np.where(same, nxt_ts, np.iinfo(np.int64).max)
+        end[order] = np.maximum(ts[order], np.minimum(end[order], cap))
+        dur = end - ts
+    # One hardware-queue lane per stream; lanes are split per gpu_id by Perfetto from
+    # (gpu_id, hw_queue_iid). The spanning annotation and its kernels share the lane and the
+    # viewer depth-nests them (annotation at depth 0, kernels at depth 1) once the kernels are
+    # clamped to not overlap each other. Perfetto sorts lanes lexicographically by name, so
+    # prefix every lane (resolver-named or "stream N") with a bracketed zero-padded lane id ->
+    # the lane order matches the chrome path's numeric lane-id order (otherwise "stream 7" sorts
+    # after "stream 26674", and resolver-named lanes like "DP" interleave alphabetically). The
+    # "[" is a constant leading char, so the padded digits still decide the order.
+    uniq, inv = np.unique(stream, return_inverse=True)
+    width = len(str(int(uniq.max()))) if len(uniq) else 1
+    labels = [lane_names_by_id.get(int(k), f"stream {int(k)}") for k in uniq.tolist()]
+    specs = [(iid, name, cat) for _ks, iid, name, cat in _RENDER_STAGES]
+    specs += [
+        (_HW_QUEUE_IID_BASE + j, f"[{int(k):0{width}d}] {labels[j]}", 0)
+        for j, k in enumerate(uniq.tolist())
+    ]
+    hw_queue_iid = (inv + _HW_QUEUE_IID_BASE).astype(np.uint64)
+    # event_id is a unique per-row id (assigned by _assign_render_event_ids and passed in, in
+    # this exact row order). The CPU launch's gpu_correlation lists the event_ids of the
+    # render stages it launched (a graph replay -> all its nodes); event_wait_ids (below) draw
+    # the graph node->node dependency arrows between those render stages.
+    event_id = np.ascontiguousarray(event_id, dtype=np.uint64)
+    # Graphics context 1 -> gfx_pid (the owning process), matching the reference traces
+    # (context_id 1 / upid 1). This also makes the GpuByProcess plugin label its per-process
+    # container "<proc> / GPU" rather than "Process 0"; disable that plugin in Perfetto if the
+    # native "GPU / Hardware Queues" view alone is wanted.
+    context = np.ones(len(ts), dtype=np.uint64)
+    # Per kernel: kernel_iid -> InternedComputeKernel (launch panel) and name_iid ->
+    # EventName (the timeline slice label). Both 0 for memcpy/memset (they fall back to
+    # the stage name). name_iid reuses the global interning so kernel names are shared
+    # with the track_event slices.
+    kernel_iid = np.zeros(len(ts), dtype=np.uint64)
+    name_iid = np.zeros(len(ts), dtype=np.uint64)
+    name_to_iid: dict[str, int] = {}
+    compute_kernels: list = []
+    for i, name in enumerate(np.concatenate(kname_p).tolist()):
+        if not name:
+            continue
+        kid = name_to_iid.get(name)
+        if kid is None:
+            kid = name_to_iid[name] = len(name_to_iid) + 1
+            compute_kernels.append((kid, name))
+        kernel_iid[i] = kid
+        j = iid_of.get(name)
+        if j is None:
+            j = iid_of[name] = len(name_table)
+            name_table.append(name)
+        name_iid[i] = j + 1
+    stage_cols = (
+        ts,
+        dur,
+        event_id,
+        gpu,
+        hw_queue_iid,
+        stage,
+        context,
+        name_iid,
+        event_wait,
+    )
+    extra = [(k, np.concatenate(extra_p[k]), s) for k, _g, s in _RENDER_EXTRA]
+    dims = tuple(np.concatenate(dim_p[k]) for k in _LAUNCH_DIMS)
+    launch_args = [
+        (iid, np.concatenate(arg_p[iid]), True) for iid, _n, _g in _COMPUTE_ARGS
+    ]
+    launch = (*dims, kernel_iid, launch_args)
+    arg_names = [(iid, name) for iid, name, _g in _COMPUTE_ARGS]
+    # CSR of the per-row spread blobs (offsets int32 length n+1 + concatenated bytes;
+    # empty slice = nothing to spread), mirroring the CPU json_anno column. The native encoder
+    # spreads each blob's top-level fields onto the render stage as extra_data.
+    meta_l = [b for sub in meta_p for b in sub]
+    meta_enc = [
+        b"" if b is None else (b if isinstance(b, bytes) else b.encode())
+        for b in meta_l
+    ]
+    meta_offsets = np.zeros(len(meta_enc) + 1, dtype=np.int32)
+    np.cumsum(
+        np.fromiter((len(b) for b in meta_enc), dtype=np.int32, count=len(meta_enc)),
+        out=meta_offsets[1:],
+    )
+    return (
+        specs,
+        [
+            (1, gfx_pid)
+        ],  # graphics context 1 -> gfx_pid (the lanes' owning process, upid 1)
+        stage_cols,
+        extra,
+        launch,
+        (compute_kernels, arg_names),
+        _gpu_panel_const_extra(gpu),
+        (meta_offsets, b"".join(meta_enc)),
+    )
+
+
 # GPU counter specs over the environment union's first 8 bytes (data, u64): (name,
 # environment_kind, value-from-data). POWER/SPEED pack two u32s (low | high<<32); TEMPERATURE/
 # COOLING are a single u32. powerLimit (the constant high half of POWER) is omitted. Descriptor
@@ -1174,6 +1700,509 @@ def _build_chrome_counters(counters, base_ns: int) -> list[dict]:
     return meta + out
 
 
+def _gpu_annotation_render_column(
+    trace_window: dict, base_ns: int
+) -> dict[str, Any] | None:
+    """Synthetic ``gpu_annotation`` render-stage column for the pftrace GPU hardware queues,
+    built from the columnar window via the same synthesizer as the chrome gpu_user_annotation
+    events -- so it lands on the kernels' capture stream, never a reassigned logical lane.
+    None when there are no GPU annotations. Kineto emits no gpu_user_annotation in
+    cupti_monitor mode, so cpu_data cannot be the source (the chrome path synthesizes them too)."""
+    gua = _gpu_user_annotation_events(trace_window, base_ns=base_ns)
+    if not gua:
+        return None
+    ts_us = np.asarray([e["ts"] for e in gua], dtype=np.float64)
+    dur_us = np.asarray([e["dur"] for e in gua], dtype=np.float64)
+    a_ts = base_ns + np.round(ts_us * 1000.0).astype(np.int64)
+    a_dur = np.maximum(np.round(dur_us * 1000.0).astype(np.int64), 0)
+    return {
+        "start_ns": a_ts,
+        "end_ns": a_ts + a_dur,
+        "device_id": np.asarray([cast(int, e["pid"]) for e in gua], dtype=np.int64),
+        "stream_id": np.asarray([cast(int, e["tid"]) for e in gua], dtype=np.int64),
+        "name": np.asarray([str(e["name"]) for e in gua], dtype=object),
+    }
+
+
+def _window_to_pftrace(
+    cpu_data: dict, trace_window: dict, base_ns: int, output_path: str
+) -> None:
+    """Encode the monitor's columnar window straight to a Perfetto-native trace (.pftrace),
+    concatenated with the Kineto CPU events -- NO chrome-dict materialization. Full parity with
+    the chrome path's per-event args, ac2g flows, and collective metadata, emitted as
+    TrackEvent debug_annotations + flow_ids by the native encoder. The GPU kinds are assembled
+    vectorized from their numpy columns into per-kind groups; runtime/driver use a per-record
+    CPU-thread join (as the chrome path does)."""
+    columns = cast("dict[str, dict[str, Any]]", trace_window.get("columns", {}))
+    thread_resource_map = cast(
+        "dict[int, dict[int, int]]", trace_window.get("thread_resource_map", {})
+    )
+    uuids: dict = {}
+    pid_ints: dict = {}
+    proc_name: dict = {}
+    thr_name: dict = {}
+    tracks: list = []
+    groups: list = []  # raw group dicts; name_iid filled in after global name interning
+    gpu_track_uuids: set = set()  # stream tracks to nest post-assembly (serial slices)
+
+    def _col(ks):
+        c = columns.get(ks)
+        return c if c and len(next(iter(c.values()))) else None
+
+    def pid_int(pid):
+        # int32 descriptor id (cosmetic); map any id to a stable NON-negative value.
+        if isinstance(pid, int):
+            return pid & 0x7FFFFFFF
+        return pid_ints.setdefault(pid, len(pid_ints) + 1)
+
+    def add_track(uuid, parent, is_proc, pid, tid, name):
+        tracks.append((uuid, parent, is_proc, pid_int(pid), pid_int(tid), str(name)))
+
+    def track_for(pid, tid, proc_label="", thr_label=""):
+        if ("p", pid) not in uuids:
+            uuids[("p", pid)] = len(uuids) + 1
+            add_track(
+                uuids[("p", pid)],
+                0,
+                True,
+                pid,
+                0,
+                str(proc_name.get(pid) or proc_label or pid),
+            )
+        key = ("t", pid, tid)
+        if key not in uuids:
+            uuids[key] = len(uuids) + 1
+            add_track(
+                uuids[key],
+                uuids[("p", pid)],
+                False,
+                pid,
+                tid,
+                str(thr_name.get(key) or thr_label or tid),
+            )
+        return uuids[key]
+
+    def gpu_uuids(pid_arr, tid_arr, proc_fmt, thr_fmt, is_gpu=True):
+        # (pid, tid) -> uuid for whole columns: unique pairs (packed into one int64 key) each
+        # register a track; map back via the inverse index (no per-event Python). is_gpu marks
+        # GPU stream tracks (serial slices) for the post-assembly overlap nesting.
+        key = (pid_arr.astype(np.int64) << np.int64(32)) | (
+            tid_arr.astype(np.int64) & 0xFFFFFFFF
+        )
+        uniq, inv = np.unique(key, return_inverse=True)
+        ids = np.empty(len(uniq), dtype=np.uint64)
+        for j, k in enumerate(uniq.tolist()):
+            pid = int(k >> 32)
+            tid = int(k & 0xFFFFFFFF)
+            if tid >= 0x80000000:  # sign-extend the packed int32 tid
+                tid -= 0x100000000
+            ids[j] = track_for(pid, tid, proc_fmt.format(pid), thr_fmt.format(tid))
+            if is_gpu:
+                gpu_track_uuids.add(int(ids[j]))
+        return ids[inv]
+
+    def int_anno(key, col, skip_zero=False, present=None):
+        # present: optional per-slice uint8 mask (emit the int only where set).
+        return (
+            key,
+            np.ascontiguousarray(col, dtype=np.int64),
+            skip_zero,
+            None if present is None else np.ascontiguousarray(present, dtype=np.uint8),
+        )
+
+    def json_anno(blobs):
+        # blobs: per-slice str/bytes/None -> a CSR (offsets, buffer) varlen column; empty None.
+        enc = [
+            b"" if b is None else (b if isinstance(b, bytes) else b.encode())
+            for b in blobs
+        ]
+        lengths = np.fromiter((len(b) for b in enc), dtype=np.int32, count=len(enc))
+        offsets = np.zeros(len(enc) + 1, dtype=np.int32)
+        np.cumsum(lengths, out=offsets[1:])
+        return (offsets, b"".join(enc))
+
+    def add_group(
+        ts,
+        end,
+        uu,
+        names,
+        ints=(),
+        strs=(),
+        arrs=(),
+        jsons=(),
+        flow=None,
+        gpu_corr=None,
+        cats=None,
+    ):
+        # cats: per-slice category strings (or None), interned into category_iids so
+        # the viewer distinguishes cpu_op / cuda_runtime / cuda_driver / user_annotation.
+        groups.append(
+            {
+                "ts": np.ascontiguousarray(ts, dtype=np.int64),
+                "end": np.ascontiguousarray(end, dtype=np.int64),
+                "uuid": np.ascontiguousarray(uu, dtype=np.uint64),
+                "names": names,
+                "ints": list(ints),
+                "strs": list(strs),
+                "arrs": list(arrs),
+                "jsons": list(jsons),
+                "flow": None
+                if flow is None
+                else np.ascontiguousarray(flow, dtype=np.int64),
+                # gpu_corr: per-slice list of render-stage event_ids this slice launched
+                # (empty for non-launch slices), stored as a CSR (offsets, ids) for the native
+                # GpuCorrelation.render_stage_submission_event_ids. None when no gpu_corr given.
+                "gpu_corr": None
+                if gpu_corr is None
+                else _lists_to_csr(gpu_corr, np.int64),
+                "cats": cats,
+            }
+        )
+
+    # --- joins shared with the chrome path ---
+    context_to_device: dict = {}
+    for ks in ("kernel", "gpu_memcpy", "gpu_memset", "cuda_event"):
+        c = _col(ks)
+        if c is None or "context_id" not in c:
+            continue
+        for ctx, dev in zip(c["context_id"].tolist(), c["device_id"].tolist()):
+            context_to_device.setdefault(ctx, dev)
+    event_sync_to_corr: dict = {}
+    ce = _col("cuda_event")
+    if ce is not None:
+        event_sync_to_corr = {
+            sid: corr
+            for sid, corr in zip(
+                ce["cuda_event_sync_id"].tolist(), ce["correlation_id"].tolist()
+            )
+            if sid
+        }
+
+    # --- CPU side: Kineto chrome events (M names + X slices with their args) ---
+    for e in cpu_data.get("traceEvents", []):
+        if isinstance(e, dict) and e.get("ph") == "M":
+            a = e.get("args") or {}
+            if e.get("name") == "process_name":
+                proc_name[e.get("pid")] = a.get("name", "")
+            elif e.get("name") == "thread_name":
+                thr_name[("t", e.get("pid"), e.get("tid"))] = a.get("name", "")
+    cpu_thread_by_external_id: dict = {}
+    cpu_ts_raw: list = []
+    cpu_dur_raw: list = []
+    cpu_uuid: list = []
+    cpu_names: list = []
+    cpu_cats: list = []
+    cpu_args: list = []
+    has_args = False
+    for e in cpu_data.get("traceEvents", []):
+        if (
+            not isinstance(e, dict)
+            or e.get("ph") != "X"
+            or e.get("cat") in _NON_CPU_CATS
+        ):
+            continue
+        a = e.get("args") if isinstance(e.get("args"), dict) else {}
+        if e.get("cat") in ("cpu_op", "user_annotation") and "External id" in a:
+            try:
+                cpu_thread_by_external_id[int(a["External id"])] = (
+                    e.get("pid"),
+                    e.get("tid"),
+                )
+            except (TypeError, ValueError):
+                pass
+        cpu_ts_raw.append(e.get("ts", 0.0))
+        cpu_dur_raw.append(e.get("dur", 0.0))
+        cpu_uuid.append(track_for(e.get("pid"), e.get("tid")))
+        cpu_names.append(str(e.get("name", "")))
+        cpu_cats.append(str(e.get("cat", "")))
+        # orjson (when present) emits bytes ~5x faster than stdlib json; json_anno takes
+        # either. The native side parses the blob, so this avoids a slow per-event dumps.
+        cpu_args.append(
+            (_orjson.dumps(a) if _orjson is not None else json.dumps(a)) if a else None
+        )
+        has_args = has_args or bool(a)
+    if cpu_ts_raw:
+        ts_arr = base_ns + np.round(
+            np.asarray(cpu_ts_raw, dtype=np.float64) * 1000.0
+        ).astype(np.int64)
+        end_arr = ts_arr + np.round(
+            np.asarray(cpu_dur_raw, dtype=np.float64) * 1000.0
+        ).astype(np.int64)
+        jsons = [json_anno(cpu_args)] if has_args else ()
+        add_group(ts_arr, end_arr, cpu_uuid, cpu_names, jsons=jsons, cats=cpu_cats)
+
+    # corr -> CPU thread, for the runtime/driver thread remap (via the external-corr column).
+    cpu_thread_by_correlation_id: dict = {}
+    ext = _col("external_correlation")
+    if ext is not None:
+        for corr, eid in zip(
+            ext["correlation_id"].tolist(), ext["external_id"].tolist()
+        ):
+            if corr and eid in cpu_thread_by_external_id:
+                cpu_thread_by_correlation_id[corr] = cpu_thread_by_external_id[eid]
+
+    # GPU ops (kernel / memcpy / memset) are emitted only as native GPU Render Stages
+    # (one lane per stream, with launch stats + scalar args + collective metadata) by
+    # _build_render_stages -- not as duplicate track_event slices here.
+
+    # Pre-pass: assign a unique event_id per GPU render-stage row (row order matches
+    # _build_render_stages) and derive the host-launch link (corr_to_event_ids) + the graph
+    # node->node dependency arrows (the event_wait CSR). Done before the runtime/driver group so
+    # its gpu_correlation can list the per-replay node event_ids; _build_render_stages is still
+    # called later with these.
+    graph_deps = {int(k): v for k, v in (trace_window.get("graph_deps") or {}).items()}
+    # GPU-side user annotations (gpu_user_annotation): a synthetic "Annotation" render stage on
+    # the kernels' capture-stream lane -- never a reassigned logical lane (matching the chrome
+    # path). Added to render_columns before event-id assignment so the annotation rows share the
+    # render-stage row order. Synthesized from the columnar window (kineto emits no
+    # gpu_user_annotation in monitor mode; the chrome path builds them the same way).
+    render_columns = columns
+    ann_col = _gpu_annotation_render_column(trace_window, base_ns)
+    if ann_col is not None:
+        render_columns = {**columns, "gpu_annotation": ann_col}
+    render_event = _assign_render_event_ids(render_columns, graph_deps)
+    if render_event is not None:
+        render_event_id, corr_to_event_ids, wait_offsets, wait_ids = render_event
+    else:
+        render_event_id, corr_to_event_ids = None, {}
+        wait_offsets, wait_ids = None, None
+
+    # --- runtime / driver API: registered names only, remapped onto their CPU thread ---
+    for ks in ("cuda_runtime", "cuda_driver"):
+        c = _col(ks)
+        if c is None:
+            continue
+        is_rt = ks == "cuda_runtime"
+        namer = _runtime_cbid_name if is_rt else _driver_cbid_name
+        is_reg = _runtime_is_registered if is_rt else _driver_is_registered
+        # gpu_correlation (host launch -> its GPU render-stage kernel) on launches, by the
+        # kernel whose event_id == this correlation. Eager launches pair 1:1; cudaGraphLaunch
+        # shares one correlation across all of a graph's replayed kernels, so it links to the
+        # whole graph at once -- fine here because gpu_correlation only draws on selection (no
+        # spiderweb, unlike always-on flow_ids). Syncs are excluded (they match no kernel).
+        launch_pred = _runtime_is_launch if is_rt else _driver_requires_flow
+        uniq_cb, inv = np.unique(c["cbid"], return_inverse=True)
+        names_u = [namer(int(x)) for x in uniq_cb.tolist()]
+        reg_u = np.array([is_reg(nm) for nm in names_u], dtype=bool)
+        corr_u = np.array([launch_pred(nm) for nm in names_u], dtype=bool)
+        keep = np.nonzero(reg_u[inv])[0]
+        if not len(keep):
+            continue
+        pid = c["process_id"][keep].tolist()
+        corr = c["correlation_id"][keep]
+        normtid = (
+            c["thread_id"][keep].astype(np.uint32).astype(np.int32).astype(np.int64)
+        )
+        tid = np.fromiter(
+            (
+                cpu_thread_by_correlation_id[cc][1]
+                if cc in cpu_thread_by_correlation_id
+                and cpu_thread_by_correlation_id[cc][0] == p
+                else thread_resource_map.get(p, {}).get(nt, nt)
+                for p, cc, nt in zip(pid, corr.tolist(), normtid.tolist())
+            ),
+            dtype=np.int64,
+            count=len(keep),
+        )
+        uu = gpu_uuids(
+            c["process_id"][keep], tid, "process {}", "thread {}", is_gpu=False
+        )
+        names = [names_u[i] for i in inv[keep].tolist()]
+        # Per launch slice, the render-stage event_ids it links to (a graph launch -> its
+        # replay's ROOT node event_ids, an eager launch -> the one kernel's). Non-launch slices
+        # get an empty list. Links the CPU launch to its GPU render stages via gpu_correlation.
+        launch_mask = corr_u[inv[keep]].tolist()
+        gpu_corr = [
+            corr_to_event_ids.get(int(cc), []) if lm else []
+            for cc, lm in zip(corr.tolist(), launch_mask)
+        ]
+        ints = [int_anno("cbid", c["cbid"][keep]), int_anno("correlation", corr)]
+        add_group(
+            c["start_ns"][keep],
+            c["end_ns"][keep],
+            uu,
+            names,
+            ints,
+            gpu_corr=gpu_corr,
+            cats=[ks] * len(keep),
+        )
+
+    # --- overhead (own lane), dropping the trailing buffer-request artifact ---
+    c = _col("overhead")
+    if c is not None:
+        max_non_overhead_end = 0
+        for ks, col in columns.items():
+            if ks in ("overhead", "external_correlation", "cuda_event"):
+                continue
+            if col and "end_ns" in col and len(col["end_ns"]):
+                max_non_overhead_end = max(
+                    max_non_overhead_end, int(col["end_ns"].max())
+                )
+        name_l = c["name"].tolist()
+        starts = c["start_ns"]
+        keep = np.array(
+            [
+                not (
+                    nm == "Activity Buffer Request"
+                    and max_non_overhead_end > 0
+                    and int(starts[i]) > max_non_overhead_end
+                )
+                for i, nm in enumerate(name_l)
+            ],
+            dtype=bool,
+        )
+        idx = np.nonzero(keep)[0]
+        if len(idx):
+            u = track_for(_OVERHEAD_PID, 0, "Overhead", "Overhead")
+            uu = np.full(len(idx), u, dtype=np.uint64)
+            add_group(
+                starts[idx], c["end_ns"][idx], uu, [name_l[i] for i in idx.tolist()]
+            )
+
+    # --- cuda_sync: device via context, stream via the sync record, wait_on join ---
+    c = _col("cuda_sync")
+    if c is not None:
+        st = c["sync_type"]
+        ctx = c["context_id"]
+        device = np.fromiter(
+            (context_to_device.get(int(x), 0) for x in ctx.tolist()),
+            dtype=np.int64,
+            count=len(ctx),
+        )
+        stream = np.where(c["stream_id"] == _SYNC_INVALID, -1, c["stream_id"]).astype(
+            np.int64
+        )
+        corr = c["correlation_id"]
+        # Split on wait-bearing sync types (Event Sync / Stream Wait Event) so only those rows
+        # carry the wait_on_* annotations, matching the chrome path.
+        wait = np.isin(st, (1, 2))
+        for sub in (np.nonzero(~wait)[0], np.nonzero(wait)[0]):
+            if not len(sub):
+                continue
+            uu = gpu_uuids(device[sub], stream[sub], "GPU {}", "stream {}")
+            names = [
+                _SYNC_TYPE_NAMES.get(int(s), f"sync_{int(s)}") for s in st[sub].tolist()
+            ]
+            ints = [
+                int_anno("stream", stream[sub]),
+                int_anno("correlation", corr[sub]),
+                int_anno("device", device[sub]),
+                int_anno("context", ctx[sub]),
+            ]
+            # cuda_sync_kind is the slice name (string, with the sync_<n> fallback) -- not
+            # the raw-int fallback the copy/memory enums use.
+            uniqn, name_inv = np.unique(
+                np.asarray(names, dtype=object), return_inverse=True
+            )
+            strs = [
+                (
+                    "cuda_sync_kind",
+                    name_inv.astype(np.int64),
+                    [str(n) for n in uniqn.tolist()],
+                )
+            ]
+            if np.isin(st[sub], (1, 2)).all():
+                rec_corr = np.fromiter(
+                    (
+                        event_sync_to_corr.get(int(s), -1)
+                        for s in c["cuda_event_sync_id"][sub].tolist()
+                    ),
+                    dtype=np.int64,
+                    count=len(sub),
+                )
+                ints += [
+                    int_anno("wait_on_stream", np.full(len(sub), -1, dtype=np.int64)),
+                    int_anno("wait_on_cuda_event_id", c["cuda_event_id"][sub]),
+                    int_anno("wait_on_cuda_event_record_corr_id", rec_corr),
+                ]
+            add_group(c["start_ns"][sub], c["end_ns"][sub], uu, names, ints, strs)
+
+    _nest_track_slices(groups, gpu_track_uuids)
+
+    # Global name interning: one EventName table across all groups; each slice carries a
+    # name_iid into it. A first-seen dict intern (O(n) hashes) beats np.unique here, whose
+    # argsort over the object-array of names is the dominant assembly cost.
+    iid_of: dict = {}
+    name_table: list = []
+    # Categories are interned in their own iid space (EventCategory), referenced
+    # per-slice by cat_iid; a "" category maps to 0 (no category emitted).
+    cat_iid_of: dict = {}
+    cat_table: list = []
+    group_tuples = []
+    for g in groups:
+        names = g["names"]
+        names = names.tolist() if isinstance(names, np.ndarray) else names
+        ids = []
+        for nm in names:
+            j = iid_of.get(nm)
+            if j is None:
+                j = iid_of[nm] = len(name_table)
+                name_table.append(nm)
+            ids.append(j + 1)
+        cats = g["cats"]
+        if cats is None:
+            cat_ids = None
+        else:
+            cids = []
+            for ct in cats:
+                if not ct:
+                    cids.append(0)
+                    continue
+                j = cat_iid_of.get(ct)
+                if j is None:
+                    j = cat_iid_of[ct] = len(cat_table)
+                    cat_table.append(ct)
+                cids.append(j + 1)
+            cat_ids = np.asarray(cids, dtype=np.uint64)
+        group_tuples.append(
+            (
+                g["ts"],
+                g["end"],
+                g["uuid"],
+                np.asarray(ids, dtype=np.uint64),
+                g["ints"],
+                g["strs"],
+                g["arrs"],
+                g["jsons"],
+                g["flow"],
+                g["gpu_corr"],
+                cat_ids,
+            )
+        )
+    # render_columns and the per-row event_id / event_wait CSR were built in the pre-pass above.
+    # Graphics context attaches the render stages to the main (first-registered => upid 1)
+    # process, matching the reference traces.
+    gfx_pid = next((k[1] for k in uuids if isinstance(k, tuple) and k[0] == "p"), 0)
+    render = (
+        _build_render_stages(
+            render_columns,
+            gfx_pid,
+            iid_of,
+            name_table,
+            render_event_id,
+            (wait_offsets, wait_ids),
+        )
+        if render_event_id is not None
+        else None
+    )
+    active_devices = _active_devices(columns)
+    # GPU counters (power/temp/clocks) -> GpuCounterEvents: the viewer renders them under
+    # "GPU / Counters / <gpu>", a sibling of the render-stage hardware queues, keyed by gpu_id.
+    counters = _merge_counters(
+        _build_gpu_counters(columns.get("environment"), active_devices),
+        _build_pm_counters(columns.get("pm_sampling"), active_devices),
+        _build_cycle_counters(
+            columns.get("kernel"), columns.get("environment"), active_devices
+        ),
+    )
+    # encode_pftrace returns gzip-compressed bytes (compressed in C++), so write as-is.
+    out = torch._C._profiler._cupti_monitor.encode_pftrace(
+        base_ns, tracks, name_table, cat_table, group_tuples, render, counters
+    )
+    with open(output_path, "wb") as f:
+        f.write(out)
+
+
 def merge_trace_window_into_chrome_trace(
     cpu_trace_path: str | os.PathLike[str],
     output_path: str | os.PathLike[str],
@@ -1189,6 +2218,11 @@ def merge_trace_window_into_chrome_trace(
     data = _orjson.loads(raw) if _orjson is not None else json.loads(raw)
 
     base_ns = int(data.get("baseTimeNanoseconds", _default_base_ns()))
+    # Perfetto-native output: encode straight from the columnar window (skip building the
+    # chrome event dicts entirely -- that build dominates the JSON path).
+    if ".pftrace" in output_path:
+        _window_to_pftrace(data, trace_window, base_ns, output_path)
+        return
     original_events = list(data.get("traceEvents", []))
     cpu_thread_by_external_id: dict[int, tuple[int, int]] = {}
     for event in original_events:
@@ -1305,12 +2339,13 @@ def merge_trace_window_into_chrome_trace(
     data["traceEvents"] = events
     data["traceName"] = trace_name or output_path
 
-    # Encode once and write the whole buffer (json.dump streaming through gzip's text wrapper
-    # is ~3-5x slower on large traces). compresslevel=1 favors throughput over file size.
+    # (.pftrace is handled earlier, straight from the columnar window.)
     if _orjson is not None:
         payload = _orjson.dumps(data)
     else:
         payload = json.dumps(data, separators=(",", ":")).encode()
+    # Encode once and write the whole buffer, gzipped when the path ends .gz (compresslevel=1
+    # favors throughput over size).
     if output_path.endswith(".gz"):
         with gzip.open(output_path, "wb", compresslevel=1) as f:
             f.write(payload)

--- a/torch/profiler/_cupti/observers/profiler.py
+++ b/torch/profiler/_cupti/observers/profiler.py
@@ -27,6 +27,7 @@ from torch.profiler._cupti.observers.observation_window import WindowFinalizerMi
 from torch.profiler._cupti.records import (
     Api,
     CudaEvent,
+    Environment,
     ExternalCorrelation,
     Field,
     Kernel,
@@ -169,6 +170,14 @@ PROFILER_FIELDS: dict[ActivityKind, set[Field]] = {
         Overhead.START,
         Overhead.END,
         Overhead.CORRELATION_ID,
+    },
+    # Periodically-sampled GPU environment (power/clock/thermal/cooling). Always on; rendered
+    # as counter tracks. DATA is the 20-byte metric union, split by ENVIRONMENT_KIND.
+    ActivityKind.ENVIRONMENT: {
+        Environment.DEVICE_ID,
+        Environment.TIMESTAMP,
+        Environment.ENVIRONMENT_KIND,
+        Environment.ENVIRONMENT_KIND_DATA,
     },
 }
 
@@ -429,7 +438,8 @@ class ProfilerObserver(WindowFinalizerMixin, CuptiMonitorObserver):
             if w is None:
                 return
             w["cpu"] = os.fspath(cpu_trace_path)
-            # Monitor traces are always gzipped; the writer keys gzip off the .gz suffix.
+            # Monitor traces are always gzipped (chrome JSON or .pftrace alike); the writer
+            # keys gzip + format off the suffix.
             out = os.fspath(output_path)
             w["out"] = out if out.endswith(".gz") else out + ".gz"
         self._maybe_write(window_id)
@@ -853,6 +863,19 @@ def _cuda_event_columns(cols, convert, resolver):
     }
 
 
+def _environment_columns(cols, convert, resolver):
+    del resolver
+    # DATA is the union's first 8 bytes (u64): the primary metric pair (e.g. POWER ->
+    # power | powerLimit<<32, SPEED -> smClock | memoryClock<<32). Split by environment_kind
+    # in the consumer (monitor_trace) into the counter tracks.
+    return {
+        "start_ns": convert(cols[Environment.TIMESTAMP.id]),
+        "device_id": cols[Environment.DEVICE_ID.id].astype(np.int64),
+        "environment_kind": cols[Environment.ENVIRONMENT_KIND.id].astype(np.int64),
+        "data": cols[Environment.ENVIRONMENT_KIND_DATA.id].astype(np.uint64),
+    }
+
+
 # kind -> (chrome-trace tag, column builder, is_timed). Timed kinds bucket into windows;
 # untimed kinds (external_correlation, cuda_event) are join inputs that ride along.
 _COLUMN_BUILDERS: dict[int, tuple[str, Any, bool]] = {
@@ -870,4 +893,5 @@ _COLUMN_BUILDERS: dict[int, tuple[str, Any, bool]] = {
     int(ActivityKind.OVERHEAD): ("overhead", _overhead_columns, True),
     int(ActivityKind.SYNCHRONIZATION): ("cuda_sync", _sync_columns, True),
     int(ActivityKind.CUDA_EVENT): ("cuda_event", _cuda_event_columns, False),
+    int(ActivityKind.ENVIRONMENT): ("environment", _environment_columns, True),
 }

--- a/torch/profiler/_cupti/records.py
+++ b/torch/profiler/_cupti/records.py
@@ -26,6 +26,7 @@ from cupti.cupti import ActivityKind  # pyrefly: ignore[missing-import]
 from torch.profiler._cupti._cupti_stubs import (
     Api,
     CudaEvent,
+    Environment,
     ExternalCorrelation,
     Kernel,
     Memcpy,
@@ -46,6 +47,7 @@ __all__ = [
     "Field",
     "Api",
     "CudaEvent",
+    "Environment",
     "ExternalCorrelation",
     "Kernel",
     "Memcpy",
@@ -86,6 +88,7 @@ _CATALOGS: dict[int, type] = {
     ActivityKind.OVERHEAD: Overhead,
     ActivityKind.CUDA_EVENT: CudaEvent,
     ActivityKind.SYNCHRONIZATION: Synchronization,
+    ActivityKind.ENVIRONMENT: Environment,
 }
 
 # kind -> the fields the v2 monitor selects: all decodable fields of the generated catalog


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Drive the native pftrace encoder (parent commit) from Python: when
export_chrome_trace() is given a .pftrace path, monitor_trace.py encodes the observer's
columnar window straight into a Perfetto trace instead of building the chrome JSON dict,
with the monitor/records/profiler glue to route the window there. The .pftrace output is
a drop-in alternative to the existing chrome JSON export.

Stacked on the native encoder (#187898).

This PR was authored with the assistance of an AI coding assistant.