### PR TITLE
 Fix mismatch of stringifying with python function (#191661) (#191661)

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -2150,6 +2150,98 @@ class DictTests(torch._dynamo.test_case.TestCase):
         }
         self.assertNotEqual(structure1, structure2)
 
+    def test_stable_target_str(self):
+        # A call_function whose target is a plain Python function (e.g.
+        # torch.sym_not) must stringify to its qualified name, not its repr,
+        # which bakes in the per-process memory address and so differs across
+        # ranks (poisoning the cross-rank node_str hash).
+        from torch._functorch.partitioners import _stable_target_str
+
+        # Plain Python function: qualified name, no memory address.
+        self.assertEqual(_stable_target_str(torch.sym_not), "torch.sym_not")
+        self.assertNotIn("0x", _stable_target_str(torch.sym_not))
+        self.assertIn("0x", str(torch.sym_not))  # the behavior being fixed
+
+        # OpOverload targets: stable qualified name (matches the FX printer),
+        # never an address.
+        from torch.fx.node import _get_qualified_name
+
+        add = torch.ops.aten.add.Tensor
+        self.assertEqual(_stable_target_str(add), _get_qualified_name(add))
+        self.assertNotIn("0x", _stable_target_str(add))
+
+        # Non-callable targets (e.g. get_attr names) fall through to str().
+        self.assertEqual(_stable_target_str("_param_constant0"), "_param_constant0")
+
+        # Callables _get_qualified_name cannot resolve fall back to str().
+        class NoName:
+            def __call__(self):
+                return None
+
+        obj = NoName()
+        self.assertEqual(_stable_target_str(obj), str(obj))
+
+    def test_canonical_node_str_invariant_to_function_target_address(self):
+        # Regression test: two ranks tracing the same graph reference the same
+        # torch.sym_not function, but the function object lives at a different
+        # memory address in each process. The old code stringified the target
+        # with str(), baking that address into the cross-rank hash, so
+        # structurally identical graphs looked different and the sync was
+        # skipped. Simulate two ranks with two distinct function objects that
+        # share a qualified name but differ in repr (address).
+        import hashlib
+
+        from torch._functorch.partitioners import (
+            _canonical_node_names,
+            _stable_target_str,
+        )
+
+        def _make_sym_not():
+            def sym_not(x):
+                return not x
+
+            return sym_not
+
+        fn_rank0 = _make_sym_not()
+        fn_rank1 = _make_sym_not()
+        # Same qualified name, different repr (mimics differing addresses).
+        self.assertNotEqual(str(fn_rank0), str(fn_rank1))
+        self.assertEqual(_stable_target_str(fn_rank0), _stable_target_str(fn_rank1))
+
+        def build_graph(fn):
+            g = torch.fx.Graph()
+            p = g.placeholder("x")
+            p.meta["val"] = torch.tensor(True)
+            n = g.create_node("call_function", fn, (p,))
+            n.meta["val"] = torch.tensor(False)
+            g.output((n,))
+            return g
+
+        graph0 = build_graph(fn_rank0)
+        graph1 = build_graph(fn_rank1)
+
+        # Reconstruct the node_str hash the way _sync_decision_cross_ranks does.
+        def node_str(graph, stringify):
+            canonical = _canonical_node_names(graph)
+
+            def hash_str(n):
+                if n.op == "placeholder":
+                    return f"{canonical[n]}:{n.op}"
+                return f"{canonical[n]}:{n.op}:{stringify(n.target)}"
+
+            joined = "/".join(
+                hash_str(n) for n in sorted(graph.nodes, key=lambda n: canonical[n])
+            )
+            return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+        # Old behavior: str(target) bakes in the address -> hashes diverge.
+        self.assertNotEqual(node_str(graph0, str), node_str(graph1, str))
+        # Fixed behavior: _stable_target_str -> identical hashes.
+        self.assertEqual(
+            node_str(graph0, _stable_target_str),
+            node_str(graph1, _stable_target_str),
+        )
+
     def _get_graph_node_names(self, model, inp):
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
         torch.compile(model, backend=backend)(inp)

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -3708,6 +3708,24 @@ def choose_saved_values_set(
     )[0]
 
 
+def _stable_target_str(target: Any) -> str:
+    """Stringify a node target stably across processes.
+
+    ``str()`` on a plain Python-function target (e.g. ``torch.sym_not``) renders
+    its ``repr`` including the object's memory address (``<function sym_not at
+    0x...>``), which differs per process. That poisons cross-rank graph hashing.
+    Use FX's qualified name for callables so equal graphs hash equally.
+    """
+    from torch.fx.node import _get_qualified_name
+
+    if callable(target):
+        try:
+            return _get_qualified_name(target)
+        except Exception:
+            return str(target)
+    return str(target)
+
+
 def _cone_hashes(graph: torch.fx.Graph) -> dict[torch.fx.Node, str]:
     """Compute a forward-looking structural hash for each node.
 
@@ -3737,7 +3755,7 @@ def _cone_hashes(graph: torch.fx.Graph) -> dict[torch.fx.Node, str]:
         elif node.op == "output":
             self_key = ("output",)
         else:
-            self_key = (node.op, str(node.target))
+            self_key = (node.op, _stable_target_str(node.target))
 
         user_hashes = tuple(sorted(hashes[u] for u in node.users))
         hashes[node] = hashlib.sha256(
@@ -3787,7 +3805,7 @@ def _canonical_node_names(graph: torch.fx.Graph) -> dict[torch.fx.Node, str]:
             return (3,)
         else:
             input_indices = tuple(canonical_idx[n] for n in node.all_input_nodes)
-            return (2, str(node.target), input_indices)
+            return (2, _stable_target_str(node.target), input_indices)
 
     # Seed the heap with nodes that have no dependencies.
     # The counter ensures deterministic ordering when keys are equal.
@@ -3849,7 +3867,7 @@ def _sync_decision_cross_ranks(
             # ranks. Use only the canonical name and op for these.
             if n.op == "placeholder":
                 return f"{canonical[n]}:{n.op}"
-            return f"{canonical[n]}:{n.op}:{n.target}"
+            return f"{canonical[n]}:{n.op}:{_stable_target_str(n.target)}"
 
         node_str = "/".join(
             _node_hash_str(n)


### PR DESCRIPTION
Summary:
When `target` is a function using `str` to stringify it will introduces the address of the function e.g., <function sym_not at 0x…> and the address is different in different ranks, so it will cause the hash value different. This is not correct, because what we care is whether two graph structure are the same. The address will cause a false alarm. We solved this by using `_get_qualified_name` to stringify functions which gets rid of the address.


Test Plan:
buck2 test @//mode/opt //caffe2/test/dynamo:test_dynamo -- \
  'test_dicts.py::DictTests::test_stable_target_str' \
  'test_dicts.py::DictTests::test_canonical_node_str_invariant_to_function_target_address'

https://www.internalfb.com/intern/testinfra/testrun/34058472204353342

Differential Revision: D114239949

Pulled By: Microve




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98