### PR TITLE
[caffe2][test] Treat MTIA like CUDA in test_float_to_int_conversion_finite

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1076,10 +1076,10 @@ class TestTensorCreation(TestCase):
         min = torch.finfo(torch.float).min
         max = torch.finfo(torch.float).max
 
-        # Note: CUDA max float -> integer conversion is divergent on some dtypes
+        # Note: CUDA/MTIA max float -> integer conversion is divergent on some dtypes
         vals = (min, -2, -1.5, -.5, 0, .5, 1.5, 2, max)
         refs = None
-        if self.device_type == 'cuda':
+        if self.device_type in ('cuda', 'mtia'):
             if torch.version.hip:
                 # HIP min float -> int64 conversion is divergent
                 vals = (-2, -1.5, -.5, 0, .5, 1.5, 2)


### PR DESCRIPTION
Summary:
MTIA runs `test_float_to_int_conversion_finite` through the same device-generic machinery as CUDA, and its float->unsigned conversion follows RISC-V vector (RVV) unsigned semantics: negative and out-of-range floats saturate to the unsigned min/max rather than wrapping like the numpy CPU reference. This is the same divergent (and technically UB) behavior CUDA already has, which is why the CUDA branch restricts `uint8` to in-range non-negative values and drops the out-of-range extremes for `int8`/`int16`.

Before this change the MTIA path fell through to the CPU-reference branch and compared negative `float`->`uint8` against numpy wraparound values (`-2 -> 254`, `-1.5 -> 255`), which are explicitly undefined (see #97794). Grouping MTIA with CUDA makes the test exercise the same well-defined value range. The change is a no-op for every backend other than MTIA.

This diff was authored with the assistance of an AI coding assistant and reviewed by me.

Test Plan:
Context: follow-up to D112831999, which fixed the Athena/Iris float->uint saturation and exposed the stale numpy-wraparound reference in this test.

```lang=bash
buck test fbcode//mode/opt fbcode//mtia/host_runtime/torch_mtia/tests/torch_tests:test_tensor_creation_ops -- --exact 'fbcode//mtia/host_runtime/torch_mtia/tests/torch_tests:test_tensor_creation_ops - test_float_to_int_conversion_finite_mtia_uint8 (mtia.host_runtime.torch_mtia.tests.torch_tests.test_tensor_creation_ops.TestTensorCreationMTIA)'
```
https://www.internalfb.com/intern/testinfra/testrun/36028797041274907

```lang=bash
buck test fbcode//mode/opt fbcode//mtia/host_runtime/torch_mtia/tests/torch_tests:test_tensor_creation_ops -- --regex 'test_float_to_int_conversion_finite_mtia_(bool|int8|int16)'
```
https://www.internalfb.com/intern/testinfra/testrun/5910974889591184

Reviewed By: xingye8

Differential Revision: D114217981


