### PR TITLE
Check qparam sizes in fake_quantize_per_tensor cachemask op

### DIFF
--- a/aten/src/ATen/native/quantized/FakeQuantPerTensorAffine.cpp
+++ b/aten/src/ATen/native/quantized/FakeQuantPerTensorAffine.cpp
@@ -100,6 +100,10 @@ std::tuple<Tensor, Tensor> _fake_quantize_per_tensor_affine_cachemask_tensor_qpa
       quant_min <= quant_max,
       "`quant_min` should be less than or \
         equal to `quant_max`.");
+  TORCH_CHECK(
+      scale.numel() == 1 && zero_point.numel() == 1 && fake_quant_enabled.numel() == 1,
+      "`scale`, `zero_point` and `fake_quant_enabled` should each have exactly one element, but got ",
+      scale.numel(), ", ", zero_point.numel(), " and ", fake_quant_enabled.numel(), " elements.");
   auto Y = at::empty_like(self, self.options(), MemoryFormat::Preserve);
   auto mask = at::empty_like(self, at::kBool, MemoryFormat::Preserve);
   fake_quant_tensor_cachemask_tensor_qparams_stub(

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -1098,6 +1098,19 @@ class TestFakeQuantizeOps(TestCase):
         ref_result = torch.Tensor([ref_result]).to(dtype).to(device)
         self.assertEqual(result, ref_result)
 
+    @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
+    def test_fake_quantize_per_tensor_affine_empty_qparams(self):
+        # https://github.com/pytorch/pytorch/issues/191570
+        devices = ['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']
+        for device, empty_arg in itertools.product(devices, range(3)):
+            X = torch.randn(4, device=device)
+            qparams = [torch.tensor([0.1], device=device),
+                       torch.zeros(1, dtype=torch.int32, device=device),
+                       torch.ones(1, dtype=torch.long, device=device)]
+            qparams[empty_arg] = torch.empty(0, dtype=qparams[empty_arg].dtype, device=device)
+            with self.assertRaisesRegex(RuntimeError, "should each have exactly one element"):
+                torch._fake_quantize_per_tensor_affine_cachemask_tensor_qparams(X, *qparams, 0, 255)
+
 
 class TestFusedObsFakeQuant(TestCase):
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),


### PR DESCRIPTION
Fixes #191570

`fake_quantize_tensor_cachemask_tensor_qparams_kernel_cuda` grabs raw device pointers
for `scale`, `zero_point` and `fake_quant_enabled` and dereferences element 0 inside
the kernel. For a 0-element tensor that pointer is null, so passing an empty qparam
tensor to `_fake_quantize_per_tensor_affine_cachemask_tensor_qparams` gives an illegal
read at address 0. The op never checked the qparam sizes. The CPU kernel for the same
op reads them with `.item()`, so it already raised a clean error, which is why this
only bit CUDA.

This adds the missing size check to the shared op. "Exactly one element" is the
contract the CPU kernel already enforces and what the docs describe for the tensor
form of `scale`/`zero_point`, so the two backends now agree. All in-tree callers
already pass single-element tensors.

Verified on 1x A40 (sm_86), CUDA 12.6, source build of this branch:

- The repro from the issue used to report `Invalid __global__ read of size 4 bytes` /
  `Address 0x0 is out of bounds` under `compute-sanitizer memcheck`. It now raises
  `RuntimeError: scale, zero_point and fake_quant_enabled should each have exactly one
  element, but got 1, 0 and 1 elements.` with 0 sanitizer errors.
- New test `TestFakeQuantizeOps.test_fake_quantize_per_tensor_affine_empty_qparams`
  covers all three qparam tensors on cpu and cuda. It fails without the C++ change
  and passes with it.
- `python test/test_quantization.py TestFakeQuantizeOps TestFusedObsFakeQuant` and
  `TestFakeQuantize TestObserver TestDistributed TestFusedObsFakeQuantModule` are
  unchanged by the patch. `test_learnable_forward_per_channel_cpu` fails on my machine
  both with and without the patch (it also fails on the 2.13 wheel), and a few
  quantized-engine and LAPACK tests error because my build has `USE_FBGEMM=0`,
  `USE_QNNPACK=0` and no LAPACK.

Not addressed here: `fused_moving_avg_obs_fake_quant_cuda` has a separate null
dereference of the same kind one call earlier. It passes `scale.data_ptr<float>()` /
`zero_point.data_ptr<int32_t>()` to `ChooseQuantizationParamsKernelImpl`, which writes
element 0 when `fake_quant_on == 1`, so empty qparams with `per_row_fq=False` give an
illegal write at 0x0 before this check runs. CPU raises `IndexError` there. The repro
in the issue does not reach it because its `fake_quant_on` is not 1. That path needs a
different check, since an empty `scale` is legitimate for `per_row_fq=True` (it gets
resized), so I kept it out of this PR.

Thanks to @kokol16 for the report and the minimal repro.

Authored with the assistance of an AI coding agent; the change and the test runs were
reviewed by me.