### PR TITLE
Make LBFGS.step a no-op on an empty param group

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -189,6 +189,20 @@ class TestOptimRenewed(TestCase):
             else:
                 raise NotImplementedError(f"Unknown error type {error_input.error_on}")
 
+    @onlyCPU
+    @optims(optim_db, dtypes=[torch.float32])
+    def test_step_with_empty_param_group(self, device, dtype, optim_info):
+        # An empty param group means there is nothing to optimize, so step() should
+        # be a no-op rather than raising. See https://github.com/pytorch/pytorch/issues/70352
+        optim_cls = optim_info.optim_cls
+        optimizer = optim_cls([{"params": []}])
+
+        if optim_info.step_requires_closure:
+            loss = torch.tensor(3.0, device=device, dtype=dtype)
+            self.assertEqual(optimizer.step(lambda: loss), loss)
+        else:
+            self.assertIsNone(optimizer.step())
+
     @parametrize("contiguous", [True, False])
     @parametrize("with_lrsched", [True, False])
     @optims(optim_db, dtypes=[torch.float32])

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -338,6 +338,13 @@ class LBFGS(Optimizer):
         # Make sure the closure is always called with grad enabled
         closure = torch.enable_grad()(closure)
 
+        # There is nothing to optimize, so skip the step like the other optimizers
+        # do, but still evaluate the closure so the caller gets a loss back. The
+        # rest of the step cannot run anyway: the global state below is keyed on
+        # the first parameter, and the flat gradient would be empty.
+        if len(self._params) == 0:
+            return closure()
+
         group = self.param_groups[0]
         lr = _to_scalar(group["lr"])
         max_iter = group["max_iter"]


### PR DESCRIPTION
Fixes #70352

### Problem

Every optimizer except `LBFGS` already tolerates a param group with no parameters —
the per-group loop does no work and `step()` returns the closure's loss. `LBFGS`
raises instead:

```python
import torch
torch.optim.Adam([{"params": []}]).step(lambda: torch.tensor(3.5))   # tensor(3.5)
torch.optim.SGD([{"params": []}]).step(lambda: torch.tensor(3.5))    # tensor(3.5)
torch.optim.LBFGS([{"params": []}]).step(lambda: torch.tensor(3.5))  # IndexError
```

```
  File "torch/optim/lbfgs.py", line 352, in step
    state = self.state[self._params[0]]
IndexError: list index out of range
```

LBFGS keeps its global state under the first parameter (per the existing `NOTE` in
`step()`), so an empty group makes that subscript fail.

This is reachable in practice the way the issue reports it: reassigning a module's
parameters after building the optimizer (`layer.weight = ...`) can leave the
optimizer holding a group with nothing in it.

### Fix

Return early when the group is empty.

Guarding only the state lookup is not sufficient — `_gather_flat_grad()` would then
produce an empty tensor and the `opt_cond` check would raise
`max(): Expected reduction dim to be specified for input.numel() == 0`. Neither the
state nor the gradient exists, so there is no meaningful step to take.

The closure is still evaluated once before returning. That matches the other
optimizers, whose `step(closure)` evaluates the closure up front and returns its
loss whether or not any parameter was updated, and it avoids silently handing back
`None` to callers that use the return value.

### On the issue

#70352 asked that optimizers behave sensibly when a param group ends up empty, and
@albanD's guidance there was to skip the whole step in that case. The `Rprop`
`UnboundLocalError` originally reported has since been fixed incidentally — `step()`
now reads `group["step_sizes"]` outside the parameter loop, so the local is always
bound. LBFGS is the last optimizer still failing, which is what this PR addresses.

### Testing

The new test covers **every** optimizer in `optim_db`, not just LBFGS, so this
cannot regress elsewhere. Before this change LBFGS is the only failure; the other 14
optimizers already pass:

```
python test/test_optim.py -k test_step_with_empty_param_group
```

Full LBFGS coverage and the surrounding suites:

```
python test/test_optim.py -k LBFGS
python test/optim/test_optim.py
python test/optim/test_lrscheduler.py
```

Also verified by hand that a normal LBFGS run still converges (a one-parameter
quadratic reaches its minimum) and that the closure is invoked exactly once on the
empty-group path.

Prepared with the assistance of an AI coding assistant.
