### PR TITLE
Make check_hash reject filenames without a valid sha256 prefix in torch.hub

### DIFF
--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -10,7 +10,9 @@ from unittest.mock import patch
 import torch
 import torch.hub as hub
 from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
     IS_SANDCASTLE,
+    parametrize,
     retry,
     run_tests,
     skipIfTorchDynamo,
@@ -425,6 +427,49 @@ class TestHub(TestCase):
                     hub._safe_extract_zip(cached_zipfile, hub_dir)
 
                 self.assertIn("directory traversal", str(cm.exception))
+
+
+class TestHubHashValidation(TestCase):
+    def _load_mocked(self, filename, **kwargs):
+        with tempfile.TemporaryDirectory() as model_dir:
+            with (
+                patch("torch.hub.download_url_to_file") as mocked_download,
+                patch("torch.load", return_value={}),
+            ):
+                hub.load_state_dict_from_url(
+                    f"https://example.com/{filename}", model_dir=model_dir, **kwargs
+                )
+            return mocked_download
+
+    @parametrize("filename", ["weights.pth", "weights-.pth", "weights-0123456.pth"])
+    def test_check_hash_rejects_missing_or_short_prefix(self, filename):
+        with tempfile.TemporaryDirectory() as model_dir:
+            with patch("torch.hub.download_url_to_file") as mocked_download:
+                with self.assertRaisesRegex(ValueError, "filename-<sha256>"):
+                    hub.load_state_dict_from_url(
+                        f"https://example.com/{filename}",
+                        model_dir=model_dir,
+                        check_hash=True,
+                    )
+                mocked_download.assert_not_called()
+
+    @parametrize(
+        "filename,expected_prefix",
+        [
+            ("resnet18-f37072fd.pth", "f37072fd"),
+            ("my-model-abcd1234ef.pth", "abcd1234ef"),
+        ],
+    )
+    def test_check_hash_accepts_valid_prefix(self, filename, expected_prefix):
+        mocked_download = self._load_mocked(filename, check_hash=True)
+        self.assertEqual(mocked_download.call_args.args[2], expected_prefix)
+
+    def test_no_check_hash_allows_hashless_filename(self):
+        mocked_download = self._load_mocked("weights.pth", check_hash=False)
+        self.assertIsNone(mocked_download.call_args.args[2])
+
+
+instantiate_parametrized_tests(TestHubHashValidation)
 
 
 if __name__ == "__main__":

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -76,7 +76,7 @@ __all__ = [
 ]
 
 # matches bfd8deac from resnet18-bfd8deac.pth
-HASH_REGEX = re.compile(r"-([a-f0-9]*)\.")
+HASH_REGEX = re.compile(r"-([a-f0-9]{8,})\.")
 _PATH_SEP_PATTERN = re.compile(r"[/\\]")
 
 _TRUSTED_REPO_OWNERS = (
@@ -854,7 +854,9 @@ def load_state_dict_from_url(
         check_hash(bool, optional): If True, the filename part of the URL should follow the naming convention
             ``filename-<sha256>.ext`` where ``<sha256>`` is the first eight or more
             digits of the SHA256 hash of the contents of the file. The hash is used to
-            ensure unique names and to verify the contents of the file.
+            ensure unique names and to verify the contents of the file. A ``ValueError``
+            is raised if the filename does not contain a valid hash prefix of at least
+            eight hexadecimal digits.
             Default: False
         file_name (str, optional): name for the downloaded file. Filename from ``url`` will be used if not set.
         weights_only(bool, optional): If True, only weights will be loaded and no complex pickled objects.
@@ -886,11 +888,18 @@ def load_state_dict_from_url(
         filename = file_name
     cached_file = os.path.join(model_dir, filename)
     if not os.path.exists(cached_file):
-        sys.stdout.write(f'Downloading: "{url}" to {cached_file}\n')
         hash_prefix = None
         if check_hash:
-            r = HASH_REGEX.search(filename)  # r is Optional[Match[str]]
-            hash_prefix = r.group(1) if r else None
+            r = HASH_REGEX.search(filename)
+            if r is None:
+                raise ValueError(
+                    f'filename "{filename}" does not follow the naming convention '
+                    '"filename-<sha256>.ext" required by check_hash=True, where '
+                    "<sha256> is the first eight or more digits of the SHA256 hash "
+                    "of the file contents"
+                )
+            hash_prefix = r.group(1)
+        sys.stdout.write(f'Downloading: "{url}" to {cached_file}\n')
         download_url_to_file(url, cached_file, hash_prefix, progress=progress)
 
     if _is_legacy_zip_format(cached_file):


### PR DESCRIPTION
load_state_dict_from_url(check_hash=True) documents that the filename must end in -<sha256>.ext with at least the first eight hex digits of the file's SHA256, but nothing enforced it. HASH_REGEX matched with *, so empty and undersized prefixes were accepted (an empty prefix passes verification against every digest), and a filename with no match at all silently degraded to hash_prefix=None, which download_url_to_file treats as "no verification". 

The regex now requires at least 8 hex digits, and load_state_dict_from_url raises ValueError, spelling out the expected naming convention, when check_hash=True and the filename has no valid prefix, before any download starts. Filenames whose old match was already valid extract the identical prefix, and cache hits and check_hash=False are unaffected.

Fixes #191194

Test Plan:

New network-free TestHubHashValidation class in test/test_hub.py covering the rejected shapes (missing, empty, 7-digit prefix, each asserting no download attempt), prefix extraction for valid and multi-dash names, and the check_hash=False path. The rejection tests fail before the fix and pass after (verified by stashing torch/hub.py while keeping the tests).

```
python -m pytest test/test_hub.py -k TestHubHashValidation -v
python -m pytest test/test_hub.py
lintrunner -a torch/hub.py test/test_hub.py
```