### PR TITLE
[inductor] Skip flex flash scalar capture test without FA4 support

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -14,6 +14,7 @@ from torch._inductor.kernel.flex.flex_flash_attention import (
     _flash_attention_unavailable_message,
     _hierarchical_indexer_cute,
     ensure_flash_available,
+    flash_supports_aux_scalars,
     HierarchicalIndex,
 )
 from torch._inductor.test_case import TestCase as InductorTestCase
@@ -2972,6 +2973,11 @@ class TestFlexFlashDynamicShapes(InductorTestCase):
         )
 
     def test_dynamic_scalar_closure_in_mask_mod(self):
+        if not flash_supports_aux_scalars():
+            self.skipTest(
+                "Flash attention (CUTE) scalar capture support is not available"
+            )
+
         major, _ = torch.cuda.get_device_capability()
         if SM120OrLater:
             self.skipTest("block sparse mask_mod is not supported on SM120")


### PR DESCRIPTION
Summary:
Fix T280747090 by skipping `test_dynamic_scalar_closure_in_mask_mod` when the installed FA4 package does not expose scalar-capture support.

D112337695 added `flash-attn-cute` to the internal `flex_flash` dependency closure, and D112823454 moved the suite to H100. That exposed the scalar-capture coverage added by D108776392: the test now reaches FA4's `aux_scalars` capability check instead of being skipped because FA4 is absent or the GPU is older than SM90.

Reviewed By: drisspg

Differential Revision: D113845162




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo