### PR TITLE
Add maximize support to LBFGS

### DIFF
--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -235,6 +235,8 @@ class LBFGS(Optimizer):
             value/parameter changes (default: 1e-9).
         history_size (int, optional): update history size (default: 100).
         line_search_fn (str, optional): either 'strong_wolfe' or None (default: None).
+        maximize (bool, optional): maximize the objective with respect to the
+            params, instead of minimizing (default: False)
     """
 
     def __init__(
@@ -247,6 +249,7 @@ class LBFGS(Optimizer):
         tolerance_change: float = 1e-9,
         history_size: int = 100,
         line_search_fn: str | None = None,
+        maximize: bool = False,
     ) -> None:
         if isinstance(lr, Tensor) and lr.numel() != 1:
             raise ValueError("Tensor lr must be 1-element")
@@ -262,6 +265,7 @@ class LBFGS(Optimizer):
             "tolerance_change": tolerance_change,
             "history_size": history_size,
             "line_search_fn": line_search_fn,
+            "maximize": maximize,
         }
         super().__init__(params, defaults)
 
@@ -272,6 +276,11 @@ class LBFGS(Optimizer):
 
         self._params = self.param_groups[0]["params"]
         self._numel_cache = None
+
+    def __setstate__(self, state) -> None:
+        super().__setstate__(state)
+        for group in self.param_groups:
+            group.setdefault("maximize", False)
 
     def _numel(self):
         if self._numel_cache is None:
@@ -315,11 +324,13 @@ class LBFGS(Optimizer):
         for p, pdata in zip(self._params, params_data, strict=True):
             p.copy_(pdata)
 
-    def _directional_evaluate(self, closure, x, t, d):
+    def _directional_evaluate(self, closure, x, t, d, maximize=False):
         self._add_grad(t, d)
         loss = float(closure())
         flat_grad = self._gather_flat_grad()
         self._set_param(x)
+        if maximize:
+            loss, flat_grad = -loss, flat_grad.neg()
         return loss, flat_grad
 
     @torch.no_grad()
@@ -346,6 +357,7 @@ class LBFGS(Optimizer):
         tolerance_change = group["tolerance_change"]
         line_search_fn = group["line_search_fn"]
         history_size = group["history_size"]
+        maximize = group["maximize"]
 
         # NOTE: LBFGS has only global state, but we register it as state for
         # the first param, because this helps with casting in load_state_dict
@@ -360,6 +372,10 @@ class LBFGS(Optimizer):
         state["func_evals"] += 1
 
         flat_grad = self._gather_flat_grad()
+        # Maximizing f is minimizing -f, so negate the value and gradient the
+        # algorithm works with. orig_loss is returned to the caller unchanged.
+        if maximize:
+            loss, flat_grad = -loss, flat_grad.neg()
         opt_cond = flat_grad.abs().max() <= tolerance_grad
 
         # optimal condition
@@ -466,7 +482,7 @@ class LBFGS(Optimizer):
                     x_init = self._clone_param()
 
                     def obj_func(x, t, d):
-                        return self._directional_evaluate(closure, x, t, d)
+                        return self._directional_evaluate(closure, x, t, d, maximize)
 
                     loss, flat_grad, t, ls_func_evals = _strong_wolfe(
                         obj_func,
@@ -491,6 +507,8 @@ class LBFGS(Optimizer):
                         loss = closure()
                     loss = float(loss)
                     flat_grad = self._gather_flat_grad()
+                    if maximize:
+                        loss, flat_grad = -loss, flat_grad.neg()
                     opt_cond = flat_grad.abs().max() <= tolerance_grad
                     ls_func_evals = 1
 

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -853,6 +853,12 @@ def optim_inputs_func_lbfgs(device, dtype=None):
             kwargs={"line_search_fn": "strong_wolfe"},
             desc="strong_wolfe",
         ),
+        OptimizerInput(params=None, kwargs={"maximize": True}, desc="maximize"),
+        OptimizerInput(
+            params=None,
+            kwargs={"line_search_fn": "strong_wolfe", "maximize": True},
+            desc="strong_wolfe, maximize",
+        ),
     ]
 
 


### PR DESCRIPTION
Fixes #86339

### Context

LBFGS is the last unchecked box on #68052 ("Add the `maximize` flag to all optimizers"),
which is otherwise closed. It is currently the only stable optimizer whose constructor
does not accept `maximize`:

```
ASGD Adadelta Adafactor Adagrad Adam AdamW Adamax NAdam RAdam RMSprop Rprop SGD SparseAdam  -> yes
LBFGS                                                                                        -> no
```

Without it, users maximizing an objective have to negate their closure and then
re-negate the value it returns.

### Implementation

Maximizing `f` is minimizing `-f`, so the objective value and gradient are negated at
the three points where they enter the algorithm: the initial evaluation in `step()`,
the re-evaluation on the no-line-search path, and `_directional_evaluate()`, which is
what the strong-Wolfe line search calls. Everything downstream — the convergence
checks, the two-loop recursion, the Wolfe conditions — is expressed in terms of those
two quantities, so nothing else changes.

`orig_loss` is deliberately left alone: `step()` returns the closure's own value so
callers see their real objective rather than the negated one used internally, matching
every other optimizer.

Two notes on the choices here:

- Wrapping the closure to return `-loss` does not work on its own. The closure's
  `backward()` populates `p.grad` with the gradient of `f`, not `-f`, so the gathered
  gradient would still need separate negation, and `orig_loss` would come back negated.
- LBFGS had no `__setstate__`, so one is added to default `maximize` to `False`.
  Without it, loading a checkpoint written before this change leaves the param group
  without the key and `step()` raises `KeyError` on `group["maximize"]`.

### Testing

`maximize` is added to the LBFGS entries in the optimizer info database, both alone and
combined with `strong_wolfe`, so the existing generic optimizer tests cover it. Before
this change those inputs fail with
`TypeError: LBFGS.__init__() got an unexpected keyword argument 'maximize'`
(75 failed, 3 passed); after, the suite is green (78 passed, 16 skipped):

```
python test/test_optim.py -k LBFGS
```

The state_dict and older-state-dict tests, which exercise the new `__setstate__`:

```
python test/test_optim.py -k "LBFGS and (older_state_dict or state_dict or deepcopy)"
```

Verified by hand that on `f(x) = -(x-3)^2 + 5`, `maximize=True` converges to the maximum
at `x=3` for both `line_search_fn=None` and `'strong_wolfe'`; that `maximize=False` still
minimizes; and that `step()` returns the true objective value rather than the negated one.

The strongest check was equivalence: on a small MLP regression the parameter trajectory
from `maximize=True` on `-L` is **bitwise identical** to `maximize=False` on `L` over six
steps, for both line-search settings. Loading a `state_dict` with the `maximize` key
removed, simulating an older checkpoint, also steps correctly.

Prepared with the assistance of an AI coding assistant.
