### PR TITLE
[CUDA][ROCm] Remove unnecessary narrowing casts in CUDAGuard construction

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
@@ -507,8 +507,7 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
     const int seqlen_k_rounded = round_multiple(seqlen_k, 128);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{static_cast<signed char>(q.get_device())};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
 
@@ -728,8 +727,7 @@ mha_varlen_fwd(const at::Tensor &q,  // total_q x num_heads x head_size, total_q
     const int seqlen_k_rounded = round_multiple(max_seqlen_k, 128);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{static_cast<signed char>(q.get_device())};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
 
@@ -980,8 +978,7 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x head_si
     bool loop = true;
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{static_cast<signed char>(q.get_device())};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     auto softmax_d = at::empty({batch_size, num_heads, seqlen_q_rounded}, opts.dtype(at::kFloat));
@@ -1197,8 +1194,7 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
     bool loop = true;
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{static_cast<signed char>(q.get_device())};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     auto softmax_d = at::empty({num_heads, total_q + 128 * batch_size}, opts.dtype(at::kFloat));
@@ -1421,8 +1417,7 @@ mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_he
     const int seqlen_k_rounded = round_multiple(seqlen_k, 128);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{static_cast<signed char>(q.get_device())};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
 

--- a/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
@@ -332,7 +332,7 @@ mha_varlen_fwd_aot(const at::Tensor &q,  // total_q x num_heads x head_size, tot
   TORCH_CHECK(!paged_KV, "[ROCm] mha_varlen_fwd: block_table_ must be nullopt");
   TORCH_CHECK(!alibi_slopes_.has_value(), "[ROCm] mha_varlen_fwd: alibi_slopes_ must be nullopt");
 
-  at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+  at::cuda::CUDAGuard device_guard{q.get_device()};
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   check_gpu_arch(stream);
 
@@ -535,8 +535,7 @@ mha_bwd_aot(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x hea
         const at::Tensor& philox_seed,
         const at::Tensor& philox_offset) {
   // Otherwise the kernel will be launched from cuda:0 device
-  // Cast to char to avoid compiler warning about narrowing
-  at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+  at::cuda::CUDAGuard device_guard{q.get_device()};
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   check_gpu_arch(stream);
 
@@ -717,8 +716,7 @@ mha_varlen_bwd_aot(const at::Tensor &dout,  // total_q x num_heads, x head_size
   TORCH_CHECK(!alibi_slopes_.has_value(), "[ROCm] mha_varlen_fwd: alibi_slopes_ must be nullopt");
 
   // Otherwise the kernel will be launched from cuda:0 device
-  // Cast to char to avoid compiler warning about narrowing
-  at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+  at::cuda::CUDAGuard device_guard{q.get_device()};
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   check_gpu_arch(stream);
 

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
@@ -455,8 +455,7 @@ mha_bwd_ck(const at::Tensor &dout,                   // batch_size x seqlen_q x 
         dout_padded = dout;
     }
 
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     auto softmax_d = at::empty({batch_size, num_heads, seqlen_q}, opts.dtype(at::kFloat));

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -362,8 +362,7 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     const int head_size_8x = round_multiple(head_size, 8);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     bool has_lse = true;

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
@@ -473,8 +473,7 @@ mha_varlen_bwd_ck(const at::Tensor &dout,                   // total_q x num_hea
         dout_padded = dout;
     }
 
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     auto softmax_d = at::empty({batch_size, num_heads, max_seqlen_q}, opts.dtype(at::kFloat));

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
@@ -303,8 +303,7 @@ mha_varlen_fwd_ck(const at::Tensor &q,                   // total_q x num_heads 
     const int head_size_8x = round_multiple(head_size_og, 8);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     bool has_lse = true;


### PR DESCRIPTION
Tensor::get_device() already returns DeviceIndex (int8_t), which binds directly to CUDAGuard's DeviceIndex constructor. The (char)/static_cast casts predate this and were only needed to silence a narrowing warning when passing the int64_t-ish device value; they no longer apply and the accompanying "avoid narrowing" comments were removed as stale.

Verified c10::cuda::CUDAGuard(DeviceIndex) is equivalent to constructing a Device explicitly: InlineDeviceGuard(DeviceIndex) just delegates to InlineDeviceGuard(Device(kCUDA, device_index)) internally (c10/core/impl/InlineDeviceGuard.h), so passing DeviceIndex directly avoids the cast without any behavioral difference.

Test Plan: rebuilding locally via `pip install -e . --no-build-isolation` after this commit to confirm flash_api.cpp and the ROCm CK/AOT flash attention sources still compile.

This also fixes #191564

This commit was authored with the assistance of an AI agent (Claude Code).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil