### PR TITLE
Fix max_pool double backward under vmap for channels_last inputs

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -990,14 +990,6 @@ class TestOperators(TestCase):
                 xfail(
                     "nn.functional.layer_norm"
                 ),  # vmap: inplace into a regular tensor
-                # RuntimeError: NYI: Tensor.clone(memory_format) inside vmap is only
-                # supported with memory_format torch.preserve_format or
-                # torch.contiguous_format (got ChannelsLast)
-                xfail("nn.functional.max_unpool2d"),
-                # RuntimeError: NYI: Tensor.clone(memory_format) inside vmap is only
-                # supported with memory_format torch.preserve_format
-                # or torch.contiguous_format (got ChannelsLast)s
-                xfail("nn.functional.max_unpool2d", "grad"),
                 xfail(
                     "nn.functional.rrelu"
                 ),  # RuntimeError: vmap: we do not yet support aten::rrelu_with_noise.
@@ -1156,9 +1148,6 @@ class TestOperators(TestCase):
             xfail("scatter_reduce", "prod"),  # item call
             # Batching rule not implemented for aten::_use_cudnn_ctc_loss.Tensor
             xfail("nn.functional.ctc_loss", device_type="cuda"),
-            # NYI: querying is_contiguous inside of vmap for memory_format other than torch.contiguous_format
-            xfail("nn.functional.max_unpool2d"),
-            xfail("nn.functional.max_unpool2d", "grad"),
             xfail("sparse.sampled_addmm", ""),
             xfail("sparse.mm", "reduce"),
             xfail("as_strided_scatter", ""),  # calls as_strided
@@ -1944,10 +1933,6 @@ class TestOperators(TestCase):
                 # running_mean or running_var, which will be updated in place,
                 # were not batched.
                 xfail("nn.functional.instance_norm"),
-                # NYI: Tensor.clone(memory_format) inside vmap is only supported with
-                # memory_format torch.preserve_format or torch.contiguous_format (got ChannelsLast)
-                xfail("nn.functional.max_unpool2d"),
-                xfail("nn.functional.max_unpool2d", "grad"),
                 xfail(
                     "nn.functional.multi_margin_loss"
                 ),  # Forward AD not implemented and no decomposition
@@ -2290,8 +2275,6 @@ class TestOperators(TestCase):
         {
             # The size of tensor a (4) must match the size of tensor b (10) at non-singleton dimension 0
             xfail("masked_select"),
-            xfail("nn.functional.max_unpool2d", "grad"),  # contiguous call
-            xfail("nn.functional.max_unpool2d"),  # contiguous call
             xfail("to_sparse"),  # dispatch key issue
             xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
             # https://github.com/pytorch/pytorch/issues/96560#issuecomment-2151063723

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -990,9 +990,6 @@ class TestOperators(TestCase):
                 xfail(
                     "nn.functional.layer_norm"
                 ),  # vmap: inplace into a regular tensor
-                # RuntimeError: NYI: querying is_contiguous inside of vmap
-                # for memory_format other than torch.contiguous_formats
-                xfail("nn.functional.max_pool2d"),
                 # RuntimeError: NYI: Tensor.clone(memory_format) inside vmap is only
                 # supported with memory_format torch.preserve_format or
                 # torch.contiguous_format (got ChannelsLast)

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -2487,9 +2487,7 @@ Tensor max_pool_double_backward(
     auto size = indices.sym_sizes().slice(0, indices.dim() - dim).vec();
     size.emplace_back(-1);
     auto indices_view = indices.view_symint(size);
-    const auto memory_format = indices.suggest_memory_format();
-    return grad.contiguous(memory_format)
-        .view_symint(size)
+    return grad.reshape_symint(size)
         .gather(-1, indices_view)
         .view_symint(indices.sym_sizes());
   }

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3643,6 +3643,12 @@ def sample_inputs_adaptive_max_pool2d(op_info, device, dtype, requires_grad, **k
         # Unbatched
         yield SampleInput(make_arg(shapes[0][1:]), args=(shapes[1], return_idx))
 
+    for return_idx in (True, False):
+        yield SampleInput(
+            make_arg((2, 3, 7, 7), memory_format=torch.channels_last),
+            args=((4, 4), return_idx),
+        )
+
 def error_inputs_adaptive_max_pool2d(opinfo, device, **kwargs):
     make_arg = partial(make_tensor, device=device, dtype=torch.float32)
 
@@ -16673,8 +16679,6 @@ op_db: list[OpInfo] = [
            aten_name='max_pool2d',
            # Runs very slowly on slow gradcheck - alternatively reduce input sizes
            gradcheck_fast_mode=True,
-           # Vmap is not happy with non-contiguous (channels_last) inputs
-           check_batched_gradgrad=False,
            supports_out=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3645,7 +3645,7 @@ def sample_inputs_adaptive_max_pool2d(op_info, device, dtype, requires_grad, **k
 
     for return_idx in (True, False):
         yield SampleInput(
-            make_arg((2, 3, 7, 7), memory_format=torch.channels_last),
+            make_arg((2, 3, 8, 8), memory_format=torch.channels_last),
             args=((4, 4), return_idx),
         )
 


### PR DESCRIPTION
Discovered through #189659.
`max_pool_double_backward` called `grad.contiguous(indices.suggest_memory_format())`, which throws `NYI: querying is_contiguous inside of vmap` for channels_last inputs. 

Use `reshape` instead. Re-enables xfailed max_pool2d batched-grad tests, adds a channels_last adaptive_max_pool2d sample.