### PR TITLE
[c10d][CFT] Expose NCCL CFT logical endpoints from symmetric memory

### DIFF
--- a/test/cpp/c10d/CMakeLists.txt
+++ b/test/cpp/c10d/CMakeLists.txt
@@ -79,6 +79,17 @@ if(USE_CUDA)
       NCCLDevCommManagerTest.cpp
       LINK_LIBRARIES torch_cpu c10d_cuda_test gtest_main __caffe2_nccl INSTALL_TEST ${INSTALL_TEST})
     target_compile_definitions(NCCLDevCommManagerTest PRIVATE USE_CUDA USE_NCCL)
+    # Links torch_cuda directly: the symmetric memory NCCL backend lives there,
+    # not in torch_cpu.
+    c10d_add_test(
+      NCCLSymmetricMemoryCftTest.cpp
+      LINK_LIBRARIES torch_cpu torch_cuda c10d_cuda_test gtest_main __caffe2_nccl INSTALL_TEST ${INSTALL_TEST})
+    target_compile_definitions(NCCLSymmetricMemoryCftTest PRIVATE USE_CUDA USE_NCCL)
+    # .cu because it drives the device-side ncclCft put from a real kernel.
+    c10d_add_test(
+      NCCLSymmetricMemoryCftDeviceTest.cu
+      LINK_LIBRARIES torch_cpu torch_cuda c10d_cuda_test gtest_main __caffe2_nccl INSTALL_TEST ${INSTALL_TEST})
+    target_compile_definitions(NCCLSymmetricMemoryCftDeviceTest PRIVATE USE_CUDA USE_NCCL)
     if(INSTALL_TEST)
       install(TARGETS c10d_cuda_test DESTINATION lib)
     endif()

--- a/test/cpp/c10d/NCCLSymmetricMemoryCftDeviceTest.cu
+++ b/test/cpp/c10d/NCCLSymmetricMemoryCftDeviceTest.cu
@@ -1,0 +1,281 @@
+#include <gtest/gtest.h>
+
+// Include nccl_dev_cap.hpp first to define NCCL_HAS_HOST_CFT
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp>
+
+#ifdef NCCL_HAS_HOST_CFT
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/Logging.h>
+#include <c10/util/irange.h>
+#include <torch/csrc/distributed/c10d/FileStore.hpp>
+#include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
+
+#include "TestUtils.hpp"
+
+#include <condition_variable>
+#include <cstdlib>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace symm_mem = c10d::symmetric_memory;
+
+namespace {
+
+// One 256-byte slot per source rank. CFT transfers are 16-byte granular, so
+// both the slot size and the per-source offset stay 16-byte aligned.
+constexpr int kSlotWords = 64;
+constexpr size_t kSlotBytes = kSlotWords * sizeof(uint32_t);
+constexpr int kThreads = 64;
+constexpr const char* kGroupName = "nccl_cft_device_test_group";
+
+// Distinct payload per (src, dst) pair so a handle that addresses the wrong
+// peer or the wrong offset shows up as a mismatch rather than passing by luck.
+uint32_t valueBase(int src, int dst, int size) {
+  return static_cast<uint32_t>((src * size + dst) * kSlotWords + 1);
+}
+
+// Push kSlotBytes into the logical endpoint `leId` at `leOffset`. Everything
+// this kernel needs to reach peer memory is the (leId, leOffset) pair the host
+// query returned -- no ncclDevComm is constructed anywhere in this test, which
+// is the entire point of the host-side CFT API.
+// NCCL's own NCCL_CFT_ENABLE cannot be used to gate this: cft__funcs.h ends
+// with an unconditional `#undef NCCL_CFT_ENABLE`, so it always reads as 0 in
+// consumer code and would silently compile the put away. Replicate NCCL's
+// arch condition instead (nccl_device/impl/cft__funcs.h).
+#define CFT_DEVICE_SUPPORTED \
+  (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000 && CUDART_VERSION >= 13030)
+
+__global__ void cftPutKernel(uint32_t leId, size_t leOffset, uint32_t base) {
+#if CFT_DEVICE_SUPPORTED
+  __shared__ uint32_t payload[kSlotWords];
+  __shared__ ncclCftSmem cftSmem;
+
+  ncclCoopCta coop;
+  ncclCft<ncclCoopCta> cft{coop, cftSmem};
+
+  for (int w = threadIdx.x; w < kSlotWords; w += blockDim.x) {
+    payload[w] = base + w;
+  }
+  // Publish the smem payload to the fabric proxy before handing it to CFT.
+  ncclMemFence(
+      coop,
+      cuda::memory_order_release,
+      ncclMemProxyType::Generic,
+      ncclMemProxyType::Fabric,
+      ncclMemFenceScope::Cta);
+
+  cft.put(coop, leId, leOffset, payload, kSlotBytes);
+  cft.submit(coop);
+  // flushSmem waits only until the fabric engine has read `payload`; flush
+  // waits for the transfer to land. Both are cheap here (one put, no buffer
+  // reuse) and together they document the two distinct dependencies.
+  cft.flushSmem(coop);
+  cft.flush(coop);
+#endif
+}
+
+// Rendezvous barrier for the rank threads. The ranks live in one process, so a
+// plain host barrier is enough to order "everyone has put" against "everyone
+// reads back"; there is no separate process to synchronize with.
+class ThreadBarrier {
+ public:
+  explicit ThreadBarrier(int count) : threshold_(count), remaining_(count) {}
+
+  void wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    const auto gen = generation_;
+    if (--remaining_ == 0) {
+      remaining_ = threshold_;
+      ++generation_;
+      cv_.notify_all();
+    } else {
+      cv_.wait(lock, [&] { return generation_ != gen; });
+    }
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  int threshold_;
+  int remaining_;
+  uint64_t generation_{0};
+};
+
+struct RankFixture {
+  c10::intrusive_ptr<c10d::ProcessGroup> pg;
+  at::Tensor tensor;
+  c10::intrusive_ptr<symm_mem::SymmetricMemory> hdl;
+
+  symm_mem::NCCLSymmetricMemory* nccl() const {
+    return dynamic_cast<symm_mem::NCCLSymmetricMemory*>(hdl.get());
+  }
+};
+
+RankFixture setUpRank(const std::string& path, int rank, int size) {
+  at::Device device(at::kCUDA, static_cast<c10::DeviceIndex>(rank));
+  c10::cuda::CUDAGuard guard(device);
+
+  auto store = c10::make_intrusive<c10d::FileStore>(path, size);
+  auto opts = c10::make_intrusive<c10d::ProcessGroupNCCL::Options>();
+  opts->group_name = kGroupName;
+  opts->config.hostCftMode = ncclHostCftFallback;
+  auto backend =
+      c10::make_intrusive<c10d::ProcessGroupNCCL>(store, rank, size, opts);
+
+  auto pg = c10::make_intrusive<c10d::ProcessGroup>(store, rank, size);
+  pg->setDefaultBackend(c10d::ProcessGroup::BackendType::NCCL);
+  pg->setBackend(
+      at::kCUDA,
+      c10d::ProcessGroup::BackendType::NCCL,
+      c10::static_intrusive_pointer_cast<c10d::Backend>(backend));
+  c10d::register_process_group(kGroupName, pg);
+  backend->eagerConnectSingleDevice(device);
+
+  // One slot per source rank, so every peer can write without colliding.
+  auto tensor = symm_mem::empty_strided_p2p(
+      {static_cast<int64_t>(size) * kSlotWords},
+      {1},
+      at::kInt,
+      device,
+      std::nullopt,
+      std::nullopt);
+  tensor.zero_();
+  RankFixture fixture{pg, tensor, symm_mem::rendezvous(tensor, kGroupName)};
+  EXPECT_NE(fixture.nccl(), nullptr)
+      << "expected the NCCL symmetric memory backend to be active";
+  return fixture;
+}
+
+// Querying our own rank is the only reliable probe for host-side CFT: it fails
+// both on hardware without CFT and on a comm built without it, and neither is
+// visible from the handle. The answer is uniform across ranks.
+bool cftAvailable(symm_mem::NCCLSymmetricMemory* hdl) {
+  try {
+    (void)hdl->get_handler(hdl->get_rank());
+    return true;
+  } catch (const c10::Error& e) {
+    LOG(WARNING) << "Skipping: host-side CFT unavailable: " << e.what();
+    return false;
+  }
+}
+
+// Each rank pushes its signature into every peer's slot `rank`, then checks
+// that its own buffer holds exactly what the other ranks sent. This is what
+// proves the (le_id, le_offset) pair actually addresses the peer's copy of the
+// buffer -- the query returning success does not.
+void testDevicePutCft(
+    const std::string& path,
+    int rank,
+    int size,
+    ThreadBarrier* barrier) {
+  at::Device device(at::kCUDA, static_cast<c10::DeviceIndex>(rank));
+  c10::cuda::CUDAGuard guard(device);
+
+  auto fixture = setUpRank(path, rank, size);
+  auto* hdl = fixture.nccl();
+  if (hdl == nullptr || !cftAvailable(hdl)) {
+    barrier->wait();
+    c10d::unregister_process_group(kGroupName);
+    return;
+  }
+
+  auto stream = at::cuda::getCurrentCUDAStream(rank);
+  for (const auto peer : c10::irange(size)) {
+    if (peer == rank) {
+      continue;
+    }
+    const auto handle = hdl->get_handler(peer);
+    cftPutKernel<<<1, kThreads, 0, stream>>>(
+        handle.le_id,
+        handle.le_offset + static_cast<size_t>(rank) * kSlotBytes,
+        valueBase(rank, peer, size));
+    C10_CUDA_CHECK(cudaGetLastError());
+  }
+  AT_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+  barrier->wait();
+
+  const auto host = fixture.tensor.cpu();
+  const auto* data = host.const_data_ptr<int32_t>();
+  for (const auto src : c10::irange(size)) {
+    for (const auto w : c10::irange(kSlotWords)) {
+      const auto got = static_cast<uint32_t>(data[src * kSlotWords + w]);
+      // Nobody writes into their own slot, so it must still read zero.
+      const uint32_t want =
+          src == rank ? 0u : valueBase(src, rank, size) + static_cast<uint32_t>(w);
+      ASSERT_EQ(got, want) << "rank " << rank << " slot " << src << " word " << w;
+    }
+  }
+
+  c10d::unregister_process_group(kGroupName);
+}
+
+class NCCLSymmetricMemoryCftDeviceTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    c10::initLogging();
+    if (auto* sizeEnv = std::getenv("WORLD_SIZE")) {
+      size_ = std::stoi(std::string(sizeEnv));
+    }
+    c10d::set_thread_isolation_mode(true);
+    symm_mem::set_backend("NCCL");
+  }
+
+  void TearDown() override {
+    c10d::set_thread_isolation_mode(false);
+  }
+
+  bool skipTest() {
+    if (!at::cuda::is_available()) {
+      LOG(INFO) << "CUDA not available, skipping test";
+      return true;
+    }
+    if (at::cuda::device_count() < size_) {
+      LOG(INFO) << "Need " << size_ << " GPUs, skipping test";
+      return true;
+    }
+    if (size_ < 2) {
+      LOG(INFO) << "Need at least 2 ranks, skipping test";
+      return true;
+    }
+    return false;
+  }
+
+  int size_{1};
+};
+
+TEST_F(NCCLSymmetricMemoryCftDeviceTest, testDevicePutCft) {
+  if (skipTest()) {
+    return;
+  }
+  c10d::test::TemporaryFile file;
+  ThreadBarrier barrier(size_);
+  std::vector<std::thread> threads;
+  threads.reserve(size_);
+  for (const auto rank : c10::irange(size_)) {
+    threads.emplace_back(testDevicePutCft, file.path, rank, size_, &barrier);
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+}
+
+} // namespace
+
+#else // NCCL_HAS_HOST_CFT
+
+TEST(NCCLSymmetricMemoryCftDeviceTest, unsupported) {
+  GTEST_SKIP() << "Host-side CFT requires NCCL >= 2.31";
+}
+
+#endif // NCCL_HAS_HOST_CFT

--- a/test/cpp/c10d/NCCLSymmetricMemoryCftTest.cpp
+++ b/test/cpp/c10d/NCCLSymmetricMemoryCftTest.cpp
@@ -1,0 +1,217 @@
+#include <gtest/gtest.h>
+
+// Include nccl_dev_cap.hpp first to define NCCL_HAS_HOST_CFT
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp>
+
+#ifdef NCCL_HAS_HOST_CFT
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/Logging.h>
+#include <c10/util/irange.h>
+#include <torch/csrc/distributed/c10d/FileStore.hpp>
+#include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
+
+#include "TestUtils.hpp"
+
+#include <cstdlib>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace symm_mem = c10d::symmetric_memory;
+
+namespace {
+
+constexpr int64_t kNumel = 1024;
+constexpr const char* kGroupName = "nccl_cft_test_group";
+
+// Owns everything a rank needs alive for the duration of a test body: the
+// symmetric allocation, its handle, and the process group backing both.
+struct RankFixture {
+  c10::intrusive_ptr<c10d::ProcessGroup> pg;
+  at::Tensor tensor;
+  c10::intrusive_ptr<symm_mem::SymmetricMemory> hdl;
+
+  symm_mem::NCCLSymmetricMemory* nccl() const {
+    return dynamic_cast<symm_mem::NCCLSymmetricMemory*>(hdl.get());
+  }
+};
+
+// Build a process group whose communicator has host-side CFT turned on, then
+// rendezvous a symmetric memory tensor with it. `host_cft_mode` is opt-in and
+// has to be identical on every rank, otherwise NCCL fails the window
+// registration underneath rendezvous.
+RankFixture setUpRank(const std::string& path, int rank, int size) {
+  at::Device device(at::kCUDA, static_cast<c10::DeviceIndex>(rank));
+  c10::cuda::CUDAGuard guard(device);
+
+  auto store = c10::make_intrusive<c10d::FileStore>(path, size);
+  auto opts = c10::make_intrusive<c10d::ProcessGroupNCCL::Options>();
+  opts->group_name = kGroupName;
+  opts->config.hostCftMode = ncclHostCftFallback;
+  auto backend =
+      c10::make_intrusive<c10d::ProcessGroupNCCL>(store, rank, size, opts);
+
+  // Symmetric memory resolves rank/world size through the group registry and
+  // the communicator through NCCLDevCommManager, so the process group has to
+  // be registered and eagerly connected before rendezvous.
+  auto pg = c10::make_intrusive<c10d::ProcessGroup>(store, rank, size);
+  pg->setDefaultBackend(c10d::ProcessGroup::BackendType::NCCL);
+  pg->setBackend(
+      at::kCUDA,
+      c10d::ProcessGroup::BackendType::NCCL,
+      c10::static_intrusive_pointer_cast<c10d::Backend>(backend));
+  c10d::register_process_group(kGroupName, pg);
+  backend->eagerConnectSingleDevice(device);
+
+  auto tensor = symm_mem::empty_strided_p2p(
+      {kNumel}, {1}, at::kFloat, device, std::nullopt, std::nullopt);
+  RankFixture fixture{pg, tensor, symm_mem::rendezvous(tensor, kGroupName)};
+  EXPECT_NE(fixture.nccl(), nullptr)
+      << "expected the NCCL symmetric memory backend to be active";
+  return fixture;
+}
+
+// Whether this system can actually serve host-side CFT queries. Querying our
+// own rank is the only reliable probe: it fails both on hardware without CFT
+// support and on a communicator built without host-side CFT, and neither is
+// visible from the handle. The answer is a property of the hardware and the
+// config, so it is the same on every rank -- no rank can skip while others
+// proceed into a collective.
+bool cftAvailable(symm_mem::NCCLSymmetricMemory* hdl) {
+  try {
+    (void)hdl->get_handler(hdl->get_rank());
+    return true;
+  } catch (const c10::Error& e) {
+    LOG(WARNING) << "Skipping: host-side CFT unavailable: " << e.what();
+    return false;
+  }
+}
+
+// Unicast: one logical endpoint per peer over the same window.
+void testUnicastCft(const std::string& path, int rank, int size) {
+  auto fixture = setUpRank(path, rank, size);
+  auto* hdl = fixture.nccl();
+  if (hdl == nullptr || !cftAvailable(hdl)) {
+    c10d::unregister_process_group(kGroupName);
+    return;
+  }
+
+  const auto self = hdl->get_handler(rank);
+  std::set<uint32_t> le_ids;
+  for (int peer = 0; peer < size; ++peer) {
+    const auto handle = hdl->get_handler(peer);
+    EXPECT_TRUE(le_ids.insert(handle.le_id).second)
+        << "peer " << peer << " reuses le_id " << handle.le_id;
+    // Every rank maps the buffer at the same offset in the symmetric space, so
+    // only the endpoint varies from peer to peer.
+    EXPECT_EQ(handle.le_offset, self.le_offset);
+  }
+
+  EXPECT_THROW((void)hdl->get_handler(size), c10::Error);
+  EXPECT_THROW((void)hdl->get_handler(-1), c10::Error);
+
+  c10d::unregister_process_group(kGroupName);
+}
+
+// Multicast: the endpoint behind the device-side putMultimem / redMultimem.
+void testMulticastCft(const std::string& path, int rank, int size) {
+  auto fixture = setUpRank(path, rank, size);
+  auto* hdl = fixture.nccl();
+  if (hdl == nullptr || !cftAvailable(hdl)) {
+    c10d::unregister_process_group(kGroupName);
+    return;
+  }
+
+  const auto self = hdl->get_handler(rank);
+  try {
+    // Collective on first call unless the endpoint was created eagerly at
+    // window registration, so every rank has to reach this.
+    const auto mc = hdl->get_multimem_handler();
+    // The multicast endpoint is distinct from the unicast one, but it
+    // addresses the same window, hence the same offset.
+    EXPECT_EQ(mc.le_offset, self.le_offset);
+  } catch (const c10::Error& e) {
+    // NCCL disables CFT multicast when NVLS is unavailable. Uniform across
+    // ranks, so nobody is left waiting in the collective above.
+    LOG(WARNING) << "Skipping multicast CFT: " << e.what();
+  }
+
+  c10d::unregister_process_group(kGroupName);
+}
+
+using FuncType = void (*)(const std::string&, int, int);
+
+class NCCLSymmetricMemoryCftTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    c10::initLogging();
+    if (auto* sizeEnv = std::getenv("WORLD_SIZE")) {
+      size_ = std::stoi(std::string(sizeEnv));
+    }
+    // Ranks share this process, so give each thread its own group registry.
+    c10d::set_thread_isolation_mode(true);
+    symm_mem::set_backend("NCCL");
+  }
+
+  void TearDown() override {
+    c10d::set_thread_isolation_mode(false);
+  }
+
+  bool skipTest() {
+    if (!at::cuda::is_available()) {
+      LOG(INFO) << "CUDA not available, skipping test";
+      return true;
+    }
+    if (at::cuda::device_count() < size_) {
+      LOG(INFO) << "Need " << size_ << " GPUs, skipping test";
+      return true;
+    }
+    return false;
+  }
+
+  void multiThreadRun(FuncType testFunc) {
+    c10d::test::TemporaryFile file;
+    std::vector<std::thread> threads;
+    threads.reserve(size_);
+    for (const auto rank : c10::irange(size_)) {
+      threads.emplace_back(testFunc, file.path, rank, size_);
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  }
+
+  int size_{1};
+};
+
+TEST_F(NCCLSymmetricMemoryCftTest, testUnicastCft) {
+  if (skipTest()) {
+    return;
+  }
+  multiThreadRun(testUnicastCft);
+}
+
+TEST_F(NCCLSymmetricMemoryCftTest, testMulticastCft) {
+  if (skipTest()) {
+    return;
+  }
+  multiThreadRun(testMulticastCft);
+}
+
+} // namespace
+
+#else // NCCL_HAS_HOST_CFT
+
+TEST(NCCLSymmetricMemoryCftTest, unsupported) {
+  GTEST_SKIP() << "Host-side CFT requires NCCL >= 2.31";
+}
+
+#endif // NCCL_HAS_HOST_CFT

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4806,6 +4806,22 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         self.assertEqual(pg_opts.config.comm_name, comm_name.decode())
 
     @requires_nccl()
+    @requires_nccl_version(
+        (2, 31), "Need NCCL 2.31+ for testing host_cft_mode in ncclConfig_t"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_pass_nccl_options_config_host_cft_mode(self):
+        pg_opts = c10d.ProcessGroupNCCL.Options()
+        # The binding is gated on the same NCCL version as the decorator above.
+        self.assertTrue(hasattr(pg_opts.config, "host_cft_mode"))
+        # ncclHostCftFallback: create the CFT logical endpoints if possible,
+        # silently disable host-side CFT if the hardware can't.
+        pg_opts.config.host_cft_mode = 3
+        self.assertEqual(pg_opts.config.host_cft_mode, 3)
+        # Tests functionality when passing nccl config
+        self._test_pass_nccl_options(pg_opts)
+
+    @requires_nccl()
     @skip_if_lt_x_gpu(4)
     def test_nccl_barrier(self):
         store = c10d.FileStore(self.file_name, self.world_size)

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -855,6 +855,7 @@ class ProcessGroupNCCL(Backend):
         cga_cluster_size: int
         min_ctas: int
         max_ctas: int
+        host_cft_mode: int
         def unsafe_get_ptr(self) -> int: ...
 
     class Options(Backend.Options):

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -62,6 +62,15 @@ static_assert(
 #define NCCL_HAS_MAX_P2P_PEERS
 #endif
 
+// `ncclConfig_t::hostCftMode` asks NCCL to create the communicator's CFT
+// (Compute Fabric Transport) logical endpoints during the first
+// `ncclCommWindowRegister`, which is what makes the host-side LE queries
+// (`ncclGetPeerDeviceLeInfo` and friends) usable without first building a
+// `ncclDevComm`. See NCCLSymmetricMemory::get_handler.
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 31, 0)
+#define NCCL_HAS_HOST_CFT_MODE
+#endif
+
 // Macro to throw on a non-successful NCCL return value.
 #define C10D_NCCL_CHECK(cmd, failureReason)                                   \
   do {                                                                        \

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3797,6 +3797,14 @@ for details.
             self.commName = strdup(tmp);
           })
 #endif
+#ifdef NCCL_HAS_HOST_CFT_MODE
+      // ncclHostCftMode_t: 1 = enable, 2 = disable, 3 = fallback (try to
+      // create the CFT logical endpoints, disable host-side CFT on error).
+      // Opt-in: NCCL leaves host-side CFT off unless this is set, since the
+      // endpoints are a limited per-device resource. Must be identical on
+      // every rank of a communicator.
+      .def_readwrite("host_cft_mode", &ncclConfig_t::hostCftMode)
+#endif
       .def(
           "unsafe_get_ptr",
           [](const ncclConfig_t& self) {

--- a/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.cpp
@@ -158,6 +158,13 @@ void populateNcclConfigFromHints(
                    << config.nvlinkCentricSched;
     }
 #endif
+#ifdef NCCL_HAS_HOST_CFT_MODE
+    else if (key == "hostCftMode" || key == "host_cft_mode") {
+      config.hostCftMode = std::stoi(val);
+      TC_LOG(INFO) << "[comm=" << name
+                   << "] Setting config.hostCftMode=" << config.hostCftMode;
+    }
+#endif
     else {
       TC_LOG(WARNING)
           << "NCCL hint '" << key

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -475,6 +475,55 @@ size_t NCCLSymmetricMemory::get_window_offset() {
   return pai_->buffer_offset_ + offset_;
 }
 
+#ifdef NCCL_HAS_HOST_CFT
+// Both CFT queries only succeed once NCCL has created the communicator's
+// logical endpoints. With `hostCftMode` enabled that happens during the first
+// `ncclCommWindowRegister`, i.e. during rendezvous; otherwise the caller would
+// have had to build a CFT-enabled `ncclDevComm` first.
+static constexpr const char* kHostCftHint =
+    "Host-side CFT requires CFT-capable hardware and a process group whose "
+    "communicator was created with `host_cft_mode` enabled "
+    "(ProcessGroupNCCL.NCCLConfig.host_cft_mode).";
+#endif // NCCL_HAS_HOST_CFT
+
+NCCLCftHandle NCCLSymmetricMemory::get_handler(int peer) {
+#ifdef NCCL_HAS_HOST_CFT
+  TORCH_CHECK(
+      peer >= 0 && peer < world_size_,
+      "NCCLSymmetricMemory::get_handler: invalid peer ",
+      peer);
+  ncclCftLeId le_id = 0;
+  size_t le_offset = 0;
+  C10D_NCCL_CHECK(
+      ncclGetPeerDeviceLeInfo(
+          pai_->combined_win_, get_window_offset(), peer, &le_id, &le_offset),
+      c10::str(
+          "ncclGetPeerDeviceLeInfo failed for peer ", peer, ". ", kHostCftHint));
+  return NCCLCftHandle{le_id, le_offset};
+#else
+  TORCH_CHECK(
+      false, "NCCL host-side CFT is not supported. Requires NCCL >= 2.31.0");
+#endif
+}
+
+NCCLCftHandle NCCLSymmetricMemory::get_multimem_handler() {
+#ifdef NCCL_HAS_HOST_CFT
+  // Unlike the unicast query, this one may still have to bind the multicast
+  // team (and barrier over the group) if the endpoint wasn't created eagerly.
+  c10::cuda::CUDAGuard guard(device_idx_);
+  ncclCftLeId le_id = 0;
+  size_t le_offset = 0;
+  C10D_NCCL_CHECK(
+      ncclGetMultimemDeviceLeInfo(
+          pai_->combined_win_, get_window_offset(), &le_id, &le_offset),
+      c10::str("ncclGetMultimemDeviceLeInfo failed. ", kHostCftHint));
+  return NCCLCftHandle{le_id, le_offset};
+#else
+  TORCH_CHECK(
+      false, "NCCL host-side CFT is not supported. Requires NCCL >= 2.31.0");
+#endif
+}
+
 std::string NCCLSymmetricMemory::get_group_name() {
   return pai_->group_name_;
 }

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp
@@ -9,6 +9,22 @@ namespace symmetric_memory {
 
 class NCCLPeerAllocInfo;
 
+// Host-side CFT (Compute Fabric Transport) logical-endpoint coordinates.
+// `(le_id, le_offset)` is exactly the pair that the device-side `ncclCft`
+// put/get/red family takes, so a custom kernel can address peer memory over
+// CFT without building a `ncclDevComm`. `le_offset` is a plain byte offset:
+// advancing into the buffer is just `le_offset + n`.
+//
+// A handle is only valid for the group its NCCLSymmetricMemory belongs to.
+// Every process group registers its own window over the allocation and owns a
+// separate set of logical endpoints, so rendezvousing one tensor with two
+// groups yields two unrelated handles. Nothing checks this at use time --
+// crossing them silently addresses the wrong memory.
+struct NCCLCftHandle {
+  uint32_t le_id;
+  size_t le_offset;
+};
+
 class NCCLSymmetricMemory : public SymmetricMemory {
  public:
   NCCLSymmetricMemory(c10::intrusive_ptr<NCCLPeerAllocInfo> pai, size_t offset);
@@ -44,6 +60,17 @@ class NCCLSymmetricMemory : public SymmetricMemory {
   c10::Device get_device() override;
 
   ncclWindow_t get_window();
+
+  // CFT handle addressing `peer`'s copy of this buffer. Requires the group's
+  // communicator to have been created with `hostCftMode` enabled and the peer
+  // to be inside the flat CFT team.
+  NCCLCftHandle get_handler(int peer);
+
+  // CFT handle addressing the multicast (multimem) view of this buffer, for
+  // the `putMultimem` / `redMultimem` device ops. Unlike `get_handler`, the
+  // first call is collective over the group unless the multicast endpoint was
+  // already created at window-registration time (i.e. `hostCftMode` on).
+  NCCLCftHandle get_multimem_handler();
 
   size_t get_offset() override;
 

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
@@ -35,4 +35,15 @@
     NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 7)
 #define NCCL_DEVICE_HAS_REDUCE_COPY
 #endif
+
+// Host-side CFT (Compute Fabric Transport) logical-endpoint queries:
+// ncclGetPeerDeviceLeInfo / ncclGetMultimemDeviceLeInfo. They resolve a window
+// offset into the `(leId, leOffset)` pair that the device-side `ncclCft`
+// put/get/red family consumes, so a custom kernel can drive CFT without
+// building a ncclDevComm. The LEs only exist if the communicator was created
+// with `ncclConfig_t::hostCftMode` enabled (see NCCL_HAS_HOST_CFT_MODE).
+#if defined(NCCL_HAS_SYMMEM_DEVICE_SUPPORT) && \
+    NCCL_VERSION_CODE >= NCCL_VERSION(2, 31, 0)
+#define NCCL_HAS_HOST_CFT
+#endif
 #endif // USE_NCCL


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #191679

NCCL's Compute Fabric Transport addresses peer memory through logical
endpoints -- a (leId, leOffset) pair -- rather than raw pointers. NCCL 2.31
adds `ncclConfig_t::hostCftMode`, which makes NCCL create a communicator's
unicast and multicast LEs during the first `ncclCommWindowRegister`. That is
what lets the host-side LE queries work without first building a `ncclDevComm`.

This plumbs that config through PyTorch and exposes the resulting pair from
symmetric memory, so an extension author can drive CFT against a symm-mem
tensor from their own kernel.

Review in this order: `nccl_dev_cap.hpp` and `NCCLUtils.hpp` establish the two
version gates (the query API and the config field both land in 2.31 but are
gated separately, since only the former also requires symmem device support and
excludes ROCm); `NCCLSymmetricMemory.{hpp,cu}` add the handle type and the two
queries; `init.cpp` and `nccl2/NCCLBootstrap.cpp` expose `host_cft_mode`; the
rest is tests.

Four choices worth calling out.

Opt-in, rather than defaulted on whenever the NCCL symm-mem backend is active.
An earlier draft did the latter. LEs are a limited per-device resource reserved
per communicator -- `cuLogicalEndpointIdReserve` takes the flat CFT team size,
so every sub-PG would pay for a feature it may never use, which is why NCCL
ships the flag off. More importantly `hostCftMode` must be identical on every
rank or window registration hard-fails, and a default derived from
process-local mutable state (`symm_mem.set_backend`) can diverge between ranks
where an explicit config value cannot.

The handles are C++-only. A handle is valid only for the group its
`NCCLSymmetricMemory` came from: each process group registers its own window
over the allocation and owns a separate LE set, so one tensor rendezvous'd with
two groups yields two unrelated handles whose `le_offset` differs. Nothing
validates this at use time, so crossing them silently addresses the wrong
memory. Keeping it out of Python avoids handing users an easily-mixed-up pair
of ints.

`get_handler` uses `ncclGetPeerDeviceLeInfo` rather than
`ncclGetCftDeviceLeInfo` because it addresses peers by world rank, which maps
1:1 onto symm mem's rank space with no team plumbing. The tradeoff is that it
rejects peers outside the group's flat CFT team, so a group spanning nodes will
fail for most peers; switching to `ncclGetCftDeviceLeInfo` and threading an
`ncclTeam_t` through would lift that.

Both queries pass `get_window_offset()`, not `get_offset()`. The window starts
at the signal pad, so `offset_` alone resolves into the pad rather than the data
buffer. This matches every other window-offset consumer (`nccl_extension.cu`,
`ops/nccl_all_to_all_nd.cu`, `ops/nccl_reduce_scatter_offset.cu`).

Note for reviewers of the device test: it deliberately does not gate on NCCL's
own `NCCL_CFT_ENABLE`. `nccl_device/impl/cft__funcs.h` ends with an
unconditional `#undef NCCL_CFT_ENABLE`, so consumers always see it undefined,
which `#if` treats as 0 -- the put would compile away silently and the test
would pass against an all-zero buffer. It replicates NCCL's arch condition
instead.

Requires NCCL >= 2.31 built after "cft: add eager window register" (the field is
not in the v2.31.0-1 tag), CUDA 13.3+ with driver >= 13030, and a device
exposing LOGICAL_ENDPOINT_{UNICAST,MULTICAST}_SUPPORTED. Below any of those the
tests skip and the queries raise.

Test Plan:

Built against NCCL master on a 4x sm_107 node (CUDA 13.4, driver 13040) where
all CFT gates pass, so the tests exercise real endpoints rather than skipping:

```
USE_SYSTEM_NCCL=1 NCCL_ROOT=$NCCL/build NCCL_INCLUDE_DIR=$NCCL/build/include \
  NCCL_LIB_DIR=$NCCL/build/lib BUILD_TEST=1 TORCH_CUDA_ARCH_LIST=10.7 \
  pip install -e . -v --no-build-isolation
```

```
WORLD_SIZE=4 ./build/bin/NCCLSymmetricMemoryCftTest
WORLD_SIZE=4 ./build/bin/NCCLSymmetricMemoryCftDeviceTest
python test/distributed/test_c10d_nccl.py -k test_pass_nccl_options_config_host_cft_mode
```

`testUnicastCft` asserts a distinct `le_id` per peer and an identical
`le_offset` across peers, and that out-of-range peers throw. `testMulticastCft`
asserts the multicast endpoint reports that same offset. `testDevicePutCft` is
the end-to-end check: every rank pushes a distinct per-(src,dst) signature into
every peer's slot with the device-side `ncclCft::put`, addressing it with
nothing but the host-queried `(le_id, le_offset)` and building no `ncclDevComm`,
then verifies its own buffer holds exactly what each peer sent and that its own
slot is untouched. All pass; 3/3 test binaries green.

Regression: `WORLD_SIZE=4 ./build/bin/NCCLDevCommManagerTest` (7/7) and
`python test/distributed/test_symmetric_memory.py` (81 tests) still pass.

Authored with assistance from Claude (Anthropic).