### PR TITLE
[ROCm][Windows] Add missing native header includes for more ATen ops

### DIFF
--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -42,6 +42,7 @@
 #include <ATen/ops/_addmm_activation_native.h>
 #include <ATen/ops/_efficientzerotensor.h>
 #include <ATen/ops/_grouped_mm_native.h>
+#include <ATen/ops/_scaled_grouped_mm_native.h>
 #include <ATen/ops/_scaled_grouped_mm_v2_native.h>
 #include <ATen/ops/_scaled_mm_native.h>
 #include <ATen/ops/_unsafe_view_native.h>

--- a/aten/src/ATen/native/cudnn/BatchNorm.cpp
+++ b/aten/src/ATen/native/cudnn/BatchNorm.cpp
@@ -11,6 +11,13 @@
 
 #if !AT_CUDNN_ENABLED()
 
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/cudnn_batch_norm_backward_native.h>
+#include <ATen/ops/cudnn_batch_norm_native.h>
+#endif
+
 namespace at {
 namespace native {
 

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -5,6 +5,15 @@
 #include <unordered_map>
 #include <vector>
 #include <c10/util/StringUtil.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_cslt_compress_native.h>
+#include <ATen/ops/_cslt_sparse_mm_native.h>
+#include <ATen/ops/_cslt_sparse_mm_search_native.h>
+#endif
+
 #if AT_CUSPARSELT_ENABLED()
 
 namespace at::native {

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.h
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.h
@@ -29,8 +29,6 @@
 
 namespace at::native {
 
-at::Tensor _cslt_compress(const Tensor& sparse_input);
-
 TORCH_CUDA_CPP_API std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     const Tensor& compressed_A,
     const Tensor& dense_B,
@@ -42,27 +40,6 @@ TORCH_CUDA_CPP_API std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _c
     int split_k,
     int split_k_mode,
     bool search_alg_id
-);
-
-at::Tensor _cslt_sparse_mm(
-    const Tensor& compressed_A,
-    const Tensor& dense_B,
-    const std::optional<Tensor>& bias_opt,
-    const std::optional<Tensor>& alpha_opt,
-    const std::optional<c10::ScalarType> out_dtype_opt,
-    bool transpose_result,
-    int64_t alg_id,
-    int64_t split_k,
-    int64_t split_k_mode
-);
-
-int64_t _cslt_sparse_mm_search(
-    const Tensor& compressed_A,
-    const Tensor& dense_B,
-    const std::optional<Tensor>& bias_opt,
-    const std::optional<Tensor>& alpha_opt,
-    const std::optional<c10::ScalarType> out_dtype_opt,
-    bool transpose_result
 );
 
 } // namespace at::native


### PR DESCRIPTION
Resolves https://github.com/ROCm/TheRock/issues/6942.
 
Extension of https://github.com/pytorch/pytorch/pull/179138 which covered _int_mm / _grouped_mm / _scaled_mm_v2.
 
Remaining ops that are covered here _scaled_grouped_mm, cudnn_batch_norm, cudnn_batch_norm_backward, _cslt_compress, _cslt_sparse_mm, _cslt_sparse_mm_search. Their source files never include the corresponding _native.h, so the functions ship as null pointers in torch_hip.dll's dispatch table and crash with 0xC0000005 when called.
 
Verified above ops crash with `0xC0000005` using nightly Windows torch builds. Same ops raise clean not supported errors on Linux builds. This PR will align behaviours across both OSes. Tested changes locally with a gfx1100/7900XT, all previously crashing ops now raise clean errors `hipSPARSELt not supported`, `not compiled with cuDNN support`.etc.
 
Fixes:
- GroupedBlas.cpp: add _scaled_grouped_mm_native.h / _scaled_grouped_mm_v2_native.h
- BatchNorm.cpp: add cudnn_batch_norm{,_backward}_native.h to the !AT_CUDNN_ENABLED() stub branch (the enabled branch already had them)
- cuSPARSELtOps.cpp: add the three _cslt_*_native.h headers

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang