### PR TITLE
[ROCm] Enable FP8 FNUZ sparse semi-structured support on ROCm MI300+

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -309,6 +309,15 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       break;
   }
   ScalarType out_dtype = dense_B.scalar_type();
+#ifdef USE_ROCM
+  // The fp8 cases above force output_type/C_type to CUDA_R_32F because
+  // hipSparseLt only produces fp32 for fp8 inputs. Without matching out_dtype
+  // here, an omitted out_dtype leaves the result tensor allocated as fp8 while
+  // cusparseLtMatmul writes fp32 into it, overrunning it by 4x.
+  if (input_type == CUDA_R_8F_E4M3 || input_type == HIP_R_8F_E4M3_FNUZ) {
+    out_dtype = at::ScalarType::Float;
+  }
+#endif
   // special check for mixed dtype support for 8 bit dtypes
   // cslt 0.5.2+: int8 int8 -> {fp16, bf16, int32} support
   if (out_dtype_opt.has_value()) {

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -135,6 +135,11 @@ at::Tensor _cslt_compress(const Tensor& sparse_input) {
     case at::ScalarType::Float8_e4m3fn:
       type = CUDA_R_8F_E4M3;
       break;
+#ifdef USE_ROCM
+    case at::ScalarType::Float8_e4m3fnuz:
+      type = HIP_R_8F_E4M3_FNUZ;
+      break;
+#endif
 #endif
     default:
       TORCH_CHECK(
@@ -267,6 +272,14 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
 #endif
       compute_type = CUSPARSE_COMPUTE_32F;
       break;
+#ifdef USE_ROCM
+    case at::ScalarType::Float8_e4m3fnuz:
+      input_type = HIP_R_8F_E4M3_FNUZ;
+      output_type = CUDA_R_32F;
+      C_type = CUDA_R_32F;
+      compute_type = CUSPARSE_COMPUTE_32F;
+      break;
+#endif
 #endif
 // cuSPARSELt <= v0.5.2 uses CUSPARSE_COMPUTE_TF32, CUSPARSE_COMPUTE_16F
 #else
@@ -324,7 +337,11 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
 // cslt 0.6.2+ or hipSparseLt: fp8 output dtype support
 #if defined(CUSPARSELT_VERSION) && CUSPARSELT_VERSION >= 602 || \
     defined(USE_ROCM)
-    else if (input_type == CUDA_R_8F_E4M3) {
+    else if (input_type == CUDA_R_8F_E4M3
+#ifdef USE_ROCM
+             || input_type == HIP_R_8F_E4M3_FNUZ
+#endif
+    ) {
       switch (out_dtype) {
 #ifndef USE_ROCM
         case at::ScalarType::Float8_e4m3fn:

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -126,6 +126,11 @@ at::Tensor _cslt_compress(const Tensor& sparse_input) {
     case at::ScalarType::Float8_e4m3fn:
       type = CUDA_R_8F_E4M3;
       break;
+#ifdef USE_ROCM
+    case at::ScalarType::Float8_e4m3fnuz:
+      type = HIP_R_8F_E4M3_FNUZ;
+      break;
+#endif
 #endif
     default:
       TORCH_CHECK(
@@ -258,6 +263,14 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
 #endif
       compute_type = CUSPARSE_COMPUTE_32F;
       break;
+#ifdef USE_ROCM
+    case at::ScalarType::Float8_e4m3fnuz:
+      input_type = HIP_R_8F_E4M3_FNUZ;
+      output_type = CUDA_R_32F;
+      C_type = CUDA_R_32F;
+      compute_type = CUSPARSE_COMPUTE_32F;
+      break;
+#endif
 #endif
 // cuSPARSELt <= v0.5.2 uses CUSPARSE_COMPUTE_TF32, CUSPARSE_COMPUTE_16F
 #else
@@ -315,7 +328,11 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
 // cslt 0.6.2+ or hipSparseLt: fp8 output dtype support
 #if defined(CUSPARSELT_VERSION) && CUSPARSELT_VERSION >= 602 || \
     defined(USE_ROCM)
-    else if (input_type == CUDA_R_8F_E4M3) {
+    else if (input_type == CUDA_R_8F_E4M3
+#ifdef USE_ROCM
+             || input_type == HIP_R_8F_E4M3_FNUZ
+#endif
+    ) {
       switch (out_dtype) {
 #ifndef USE_ROCM
         case at::ScalarType::Float8_e4m3fn:

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1385,8 +1385,12 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
     )
     @unittest.skipIf(
+        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
+        "HIPSPARSELt is not available for ROCm versions < 7.12",
+    )
+    @unittest.skipIf(
         TEST_WITH_ROCM and not PLATFORM_SUPPORTS_FP8_SPARSE,
-        "Only supported on ROCm MI300 or newer",
+        "FP8 sparse requires MI300+ on ROCm 7.12+",
     )
     @xfailIfSM89PreCUDA13
     @parametrize("dense_input_shape", [(256, 128)])
@@ -1411,8 +1415,12 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
     )
     @unittest.skipIf(
+        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
+        "HIPSPARSELt is not available for ROCm versions < 7.12",
+    )
+    @unittest.skipIf(
         TEST_WITH_ROCM and not PLATFORM_SUPPORTS_FP8_SPARSE,
-        "Only supported on ROCm MI300 or newer",
+        "FP8 sparse requires MI300+ on ROCm 7.12+",
     )
     @xfailIfSM89PreCUDA13
     def test_sparse_semi_structured_scaled_mm_fp8(self, device) -> None:
@@ -1442,8 +1450,12 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
     )
     @unittest.skipIf(
+        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
+        "HIPSPARSELt is not available for ROCm versions < 7.12",
+    )
+    @unittest.skipIf(
         TEST_WITH_ROCM and not PLATFORM_SUPPORTS_FP8_SPARSE,
-        "Only supported on ROCm MI300 or newer",
+        "FP8 sparse requires MI300+ on ROCm 7.12+",
     )
     @xfailIfSM89PreCUDA13
     @parametrize(
@@ -1773,8 +1785,12 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
 
 
     @unittest.skipIf(
+        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
+        "HIPSPARSELt is not available for ROCm versions < 7.12",
+    )
+    @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8_SPARSE,
-        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ (gfx942/gfx950) on ROCm",
+        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ on ROCm 7.12+",
     )
     def test_cslt_compress_fp8(self, device):
         A = rand_sparse_semi_structured_mask(256, 128, dtype=torch.float16)
@@ -1784,8 +1800,12 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         self.assertEqual(compressed.dtype, fp8_dtype)
 
     @unittest.skipIf(
+        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
+        "HIPSPARSELt is not available for ROCm versions < 7.12",
+    )
+    @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8_SPARSE,
-        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ (gfx942/gfx950) on ROCm",
+        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ on ROCm 7.12+",
     )
     @parametrize("dense_input_shape", [(256, 128)])
     def test_cslt_sparse_mm_fp8_to_fp32(self, dense_input_shape, device):
@@ -1804,8 +1824,12 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         torch.testing.assert_close(sparse_result, dense_result, rtol=1e-1, atol=1e-1)
 
     @unittest.skipIf(
+        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
+        "HIPSPARSELt is not available for ROCm versions < 7.12",
+    )
+    @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8_SPARSE,
-        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ (gfx942/gfx950) on ROCm",
+        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ on ROCm 7.12+",
     )
     @unittest.skipIf(not TEST_WITH_ROCM, "ROCm-specific out_dtype restriction")
     @parametrize(

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1838,6 +1838,7 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         dense_result = torch.mm(A_fp8.to(torch.float32), B_fp8.to(torch.float32))
         torch.testing.assert_close(sparse_result, dense_result, rtol=1e-1, atol=1e-1)
 
+    @unittest.skipIf(IS_WINDOWS, "torch.compile not supported on windows")
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8_SPARSE,
         "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ on ROCm 7.12+",

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1842,6 +1842,33 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         not PLATFORM_SUPPORTS_FP8_SPARSE,
         "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ on ROCm 7.12+",
     )
+    def test_cslt_sparse_mm_fp8_compile(self, device):
+        # Exercises meta__cslt_sparse_mm with fp8 inputs (e4m3fnuz on gfx942),
+        # including the omitted-out_dtype path where the fake tensor must be
+        # fp32 on ROCm to match the eager result.
+        A = rand_sparse_semi_structured_mask(256, 128, dtype=torch.float16)
+        B = torch.rand(128, 128, device=device).to(torch.float16).t()
+
+        A_fp8, _ = to_float8(A)
+        B_fp8, _ = to_float8(B)
+        compressed = torch._cslt_compress(A_fp8)
+
+        def mm_fp32_out(compressed_A, dense_B):
+            return torch._cslt_sparse_mm(compressed_A, dense_B, out_dtype=torch.float32)
+
+        def mm_default_out(compressed_A, dense_B):
+            return torch._cslt_sparse_mm(compressed_A, dense_B)
+
+        for fn in (mm_fp32_out, mm_default_out):
+            ref = fn(compressed, B_fp8)
+            res = torch.compile(fn, fullgraph=True)(compressed, B_fp8)
+            self.assertEqual(res.dtype, ref.dtype)
+            self.assertEqual(res.to(torch.float32), ref.to(torch.float32))
+
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FP8_SPARSE,
+        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ on ROCm 7.12+",
+    )
     @unittest.skipIf(not TEST_WITH_ROCM, "ROCm-specific out_dtype restriction")
     # e4m3_type is named explicitly so the generated test id does not change
     # between gfx942 (fnuz) and gfx950 (fn).

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -24,6 +24,8 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_FP8_SPARSE,
+    ROCM_VERSION,
+    evaluate_gfx_arch_within,
     xfailIfSM89PreCUDA13,
 )
 from torch.testing._internal.common_device_type import (
@@ -46,6 +48,7 @@ SEMI_STRUCTURED_SUPPORTED_BACKENDS = dict()
 _IS_SM8X = False
 _IS_SM9X = False
 _IS_HIPSPARSELT_AVAILABLE = False
+_IS_HIPSPARSELT_DEVICE_SUPPORTED = False
 if torch.cuda.is_available():
     _IS_SM8X = torch.version.cuda is not None and (
         torch.cuda.get_device_capability(0)[0] == 8
@@ -56,6 +59,13 @@ if torch.cuda.is_available():
     _IS_HIPSPARSELT_AVAILABLE = torch.version.hip is not None and tuple(
         int(v) for v in torch.version.hip.split(".")[:2]
     ) >= (7, 12)
+    if _IS_HIPSPARSELT_AVAILABLE:
+        hipsparselt_archs = ["gfx942", "gfx950"]
+        if ROCM_VERSION >= (7, 14):
+            hipsparselt_archs.append("gfx1250")
+        _IS_HIPSPARSELT_DEVICE_SUPPORTED = evaluate_gfx_arch_within(
+            hipsparselt_archs
+        )
     # CUTLASS kernels only work for Ampere
     if _IS_SM8X:
         SEMI_STRUCTURED_SUPPORTED_BACKENDS["cutlass"] = (
@@ -64,7 +74,7 @@ if torch.cuda.is_available():
 
     # add cuSPASRELt tests if available
     if torch.backends.cusparselt.is_available() and (
-        _IS_SM8X or _IS_SM9X or _IS_HIPSPARSELT_AVAILABLE
+        _IS_SM8X or _IS_SM9X or _IS_HIPSPARSELT_DEVICE_SUPPORTED
     ):
         SEMI_STRUCTURED_SUPPORTED_BACKENDS["cusparselt"] = (
             SparseSemiStructuredTensorCUSPARSELT

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1371,7 +1371,10 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         not PLATFORM_SUPPORTS_FP8,
         "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
     )
-    @unittest.skipIf(TEST_WITH_ROCM, "Not supported on ROCm")
+    @unittest.skipIf(
+        TEST_WITH_ROCM and not PLATFORM_SUPPORTS_FP8_SPARSE,
+        "Only supported on ROCm MI350 or newer",
+    )
     @xfailIfSM89PreCUDA13
     @parametrize("dense_input_shape", [(256, 128)])
     def test_sparse_fp8fp8_mm(self, dense_input_shape, device):

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -25,11 +25,12 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_FP8_SPARSE,
     ROCM_VERSION,
-    evaluate_gfx_arch_within,
+    evaluate_platform_supports_hipsparselt,
     xfailIfSM89PreCUDA13,
 )
 from torch.testing._internal.common_device_type import (
     dtypes,
+    e4m3_type,
     instantiate_device_type_tests,
 )
 from torch.testing._internal.common_dtype import all_types_and_complex
@@ -56,16 +57,8 @@ if torch.cuda.is_available():
     _IS_SM9X = torch.version.cuda is not None and (
         torch.cuda.get_device_capability(0)[0] == 9
     )
-    _IS_HIPSPARSELT_AVAILABLE = torch.version.hip is not None and tuple(
-        int(v) for v in torch.version.hip.split(".")[:2]
-    ) >= (7, 12)
-    if _IS_HIPSPARSELT_AVAILABLE:
-        hipsparselt_archs = ["gfx942", "gfx950"]
-        if ROCM_VERSION >= (7, 14):
-            hipsparselt_archs.append("gfx1250")
-        _IS_HIPSPARSELT_DEVICE_SUPPORTED = evaluate_gfx_arch_within(
-            hipsparselt_archs
-        )
+    _IS_HIPSPARSELT_AVAILABLE = bool(torch.version.hip) and ROCM_VERSION >= (7, 12)
+    _IS_HIPSPARSELT_DEVICE_SUPPORTED = evaluate_platform_supports_hipsparselt()
     # CUTLASS kernels only work for Ampere
     if _IS_SM8X:
         SEMI_STRUCTURED_SUPPORTED_BACKENDS["cutlass"] = (
@@ -1351,20 +1344,9 @@ class TestSparseSemiStructuredCUTLASS(TestCase):
 CUSPARSELT_MIXED_DTYPE_SUPPORT = [torch.float16, torch.bfloat16, torch.int32]
 
 
-def fp8_e4m3_dtype():
-    # gfx942 (MI300) uses hardware-native FNUZ FP8; gfx950/CUDA use OCP e4m3fn.
-    if (
-        TEST_WITH_ROCM
-        and torch.cuda.is_available()
-        and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
-    ):
-        return torch.float8_e4m3fnuz
-    return torch.float8_e4m3fn
-
-
-def to_float8(x, dtype=None):
-    if dtype is None:
-        dtype = fp8_e4m3_dtype()
+# e4m3_type is float8_e4m3fnuz on gfx942 (MI300 has hardware-native FNUZ FP8)
+# and float8_e4m3fn on gfx950/CUDA.
+def to_float8(x, dtype=e4m3_type):
     finfo = torch.finfo(dtype)
     # Calculate the scale as dtype max divided by absmax
     scale = finfo.max / x.abs().max().clamp(min=1e-12)
@@ -1395,10 +1377,6 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
     )
     @unittest.skipIf(
-        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
-        "HIPSPARSELt is not available for ROCm versions < 7.12",
-    )
-    @unittest.skipIf(
         TEST_WITH_ROCM and not PLATFORM_SUPPORTS_FP8_SPARSE,
         "FP8 sparse requires MI300+ on ROCm 7.12+",
     )
@@ -1425,24 +1403,18 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
     )
     @unittest.skipIf(
-        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
-        "HIPSPARSELt is not available for ROCm versions < 7.12",
-    )
-    @unittest.skipIf(
         TEST_WITH_ROCM and not PLATFORM_SUPPORTS_FP8_SPARSE,
         "FP8 sparse requires MI300+ on ROCm 7.12+",
     )
     @xfailIfSM89PreCUDA13
     def test_sparse_semi_structured_scaled_mm_fp8(self, device) -> None:
         (k, l, m) = (32, 64, 32)
-        fp8_dtype = fp8_e4m3_dtype()
-        x = rand_sparse_semi_structured_mask(
-            k, l, dtype=fp8_dtype, device=device
-        )
-        y = torch.full((m, l), 0.25, device=device, dtype=fp8_dtype).t()
+        x = rand_sparse_semi_structured_mask(k, l, dtype=e4m3_type, device=device)
+        y = torch.full((m, l), 0.25, device=device, dtype=e4m3_type).t()
         scale_a = torch.tensor(1.0, device=device)
         scale_b = torch.tensor(1.0, device=device)
-        out_dtype = torch.float32 if TEST_WITH_ROCM else fp8_dtype
+        # hipSparseLt only produces fp32 output for fp8 inputs
+        out_dtype = torch.float32 if TEST_WITH_ROCM else e4m3_type
         out_fp8 = torch._scaled_mm(
             x, y, scale_a=scale_a, scale_b=scale_b, out_dtype=out_dtype
         )
@@ -1455,29 +1427,50 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         out_fp32_sparse = out_fp8_sparse.to(torch.float32)
         torch.testing.assert_close(out_fp32, out_fp32_sparse, rtol=1e-1, atol=1e-1)
 
+    # Gated on FP8_SPARSE, not FP8: this compresses an fp8 tensor, which needs
+    # cuSPARSELt v0.6.2+. No xfailIfSM89PreCUDA13 either -- the dtype mismatch
+    # is rejected before any matmul runs, so the test passes on SM89 and an
+    # expectedFailure would turn into an unexpected success.
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FP8_SPARSE,
+        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ on ROCm 7.12+",
+    )
+    def test_sparse_semi_structured_scaled_mm_mixed_fp8_dtypes(self, device) -> None:
+        # e4m3fn and e4m3fnuz have different exponent biases, so a mismatched
+        # pair must be rejected rather than silently reinterpreted.
+        other_type = (
+            torch.float8_e4m3fn
+            if e4m3_type is torch.float8_e4m3fnuz
+            else torch.float8_e4m3fnuz
+        )
+        (k, l, m) = (32, 64, 32)
+        x = rand_sparse_semi_structured_mask(k, l, dtype=e4m3_type, device=device)
+        y = torch.full((m, l), 0.25, device=device, dtype=other_type).t()
+        scale = torch.tensor(1.0, device=device)
+        x_sparse = to_sparse_semi_structured(x)
+        with self.assertRaisesRegex(
+            AssertionError, "expected A and B to have the same dtype"
+        ):
+            torch._scaled_mm(
+                x_sparse, y, scale_a=scale, scale_b=scale, out_dtype=torch.float32
+            )
+
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8,
         "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
-    )
-    @unittest.skipIf(
-        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
-        "HIPSPARSELt is not available for ROCm versions < 7.12",
     )
     @unittest.skipIf(
         TEST_WITH_ROCM and not PLATFORM_SUPPORTS_FP8_SPARSE,
         "FP8 sparse requires MI300+ on ROCm 7.12+",
     )
     @xfailIfSM89PreCUDA13
-    @parametrize(
-        "out_dtype",
-        [torch.float32]
-        if TEST_WITH_ROCM
-        else [torch.float16, torch.bfloat16, torch.float32],
-    )
+    @parametrize("out_dtype", [torch.float16, torch.bfloat16, torch.float32])
     @parametrize("dense_input_shape", [(256, 128)])
     def test_sparse_semi_structured_scaled_mm(
         self, dense_input_shape, device, out_dtype
     ):
+        if TEST_WITH_ROCM and out_dtype is not torch.float32:
+            self.skipTest("hipSparseLt only supports float32 output for fp8 inputs")
         A = rand_sparse_semi_structured_mask(256, 128, dtype=torch.float16)
         B = torch.rand(dense_input_shape, device=device).to(torch.float16).t()
 
@@ -1795,24 +1788,15 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
 
 
     @unittest.skipIf(
-        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
-        "HIPSPARSELt is not available for ROCm versions < 7.12",
-    )
-    @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8_SPARSE,
         "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ on ROCm 7.12+",
     )
     def test_cslt_compress_fp8(self, device):
         A = rand_sparse_semi_structured_mask(256, 128, dtype=torch.float16)
-        fp8_dtype = fp8_e4m3_dtype()
-        A_fp8, _ = to_float8(A, dtype=fp8_dtype)
+        A_fp8, _ = to_float8(A)
         compressed = torch._cslt_compress(A_fp8)
-        self.assertEqual(compressed.dtype, fp8_dtype)
+        self.assertEqual(compressed.dtype, e4m3_type)
 
-    @unittest.skipIf(
-        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
-        "HIPSPARSELt is not available for ROCm versions < 7.12",
-    )
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8_SPARSE,
         "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ on ROCm 7.12+",
@@ -1834,17 +1818,36 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         torch.testing.assert_close(sparse_result, dense_result, rtol=1e-1, atol=1e-1)
 
     @unittest.skipIf(
-        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
-        "HIPSPARSELt is not available for ROCm versions < 7.12",
+        not PLATFORM_SUPPORTS_FP8_SPARSE,
+        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ on ROCm 7.12+",
     )
+    @unittest.skipIf(not TEST_WITH_ROCM, "ROCm-specific out_dtype restriction")
+    def test_cslt_sparse_mm_fp8_default_out_dtype_rocm(self, device):
+        # hipSparseLt writes fp32 for fp8 inputs, so an omitted out_dtype must
+        # still allocate the result as fp32 rather than inheriting fp8 from B.
+        A = rand_sparse_semi_structured_mask(256, 128, dtype=torch.float16)
+        B = torch.rand(128, 128, device=device).to(torch.float16).t()
+
+        A_fp8, _ = to_float8(A)
+        B_fp8, _ = to_float8(B)
+
+        compressed = torch._cslt_compress(A_fp8)
+        sparse_result = torch._cslt_sparse_mm(compressed, B_fp8)
+
+        self.assertEqual(sparse_result.dtype, torch.float32)
+        dense_result = torch.mm(A_fp8.to(torch.float32), B_fp8.to(torch.float32))
+        torch.testing.assert_close(sparse_result, dense_result, rtol=1e-1, atol=1e-1)
+
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8_SPARSE,
         "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ on ROCm 7.12+",
     )
     @unittest.skipIf(not TEST_WITH_ROCM, "ROCm-specific out_dtype restriction")
+    # e4m3_type is named explicitly so the generated test id does not change
+    # between gfx942 (fnuz) and gfx950 (fn).
     @parametrize(
         "out_dtype",
-        [torch.float16, torch.bfloat16, fp8_e4m3_dtype()],
+        [torch.float16, torch.bfloat16, subtest(e4m3_type, name="fp8")],
     )
     def test_cslt_sparse_mm_fp8_unsupported_out_dtype_rocm(self, out_dtype, device):
         A = rand_sparse_semi_structured_mask(256, 128, dtype=torch.float16)

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1341,7 +1341,20 @@ class TestSparseSemiStructuredCUTLASS(TestCase):
 CUSPARSELT_MIXED_DTYPE_SUPPORT = [torch.float16, torch.bfloat16, torch.int32]
 
 
-def to_float8(x, dtype=torch.float8_e4m3fn):
+def fp8_e4m3_dtype():
+    # gfx942 (MI300) uses hardware-native FNUZ FP8; gfx950/CUDA use OCP e4m3fn.
+    if (
+        TEST_WITH_ROCM
+        and torch.cuda.is_available()
+        and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+    ):
+        return torch.float8_e4m3fnuz
+    return torch.float8_e4m3fn
+
+
+def to_float8(x, dtype=None):
+    if dtype is None:
+        dtype = fp8_e4m3_dtype()
     finfo = torch.finfo(dtype)
     # Calculate the scale as dtype max divided by absmax
     scale = finfo.max / x.abs().max().clamp(min=1e-12)
@@ -1373,7 +1386,7 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
     )
     @unittest.skipIf(
         TEST_WITH_ROCM and not PLATFORM_SUPPORTS_FP8_SPARSE,
-        "Only supported on ROCm MI350 or newer",
+        "Only supported on ROCm MI300 or newer",
     )
     @xfailIfSM89PreCUDA13
     @parametrize("dense_input_shape", [(256, 128)])
@@ -1393,40 +1406,52 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         ):
             dense_result = torch.mm(A_fp8_sparse, B_fp8)
 
-    @unittest.skipIf(TEST_WITH_ROCM, "Not supported on ROCm")
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8,
         "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
+    )
+    @unittest.skipIf(
+        TEST_WITH_ROCM and not PLATFORM_SUPPORTS_FP8_SPARSE,
+        "Only supported on ROCm MI300 or newer",
     )
     @xfailIfSM89PreCUDA13
     def test_sparse_semi_structured_scaled_mm_fp8(self, device) -> None:
         (k, l, m) = (32, 64, 32)
+        fp8_dtype = fp8_e4m3_dtype()
         x = rand_sparse_semi_structured_mask(
-            k, l, dtype=torch.float8_e4m3fn, device=device
+            k, l, dtype=fp8_dtype, device=device
         )
-        y = torch.full((m, l), 0.25, device=device, dtype=torch.float8_e4m3fn).t()
+        y = torch.full((m, l), 0.25, device=device, dtype=fp8_dtype).t()
         scale_a = torch.tensor(1.0, device=device)
         scale_b = torch.tensor(1.0, device=device)
+        out_dtype = torch.float32 if TEST_WITH_ROCM else fp8_dtype
         out_fp8 = torch._scaled_mm(
-            x, y, scale_a=scale_a, scale_b=scale_b, out_dtype=torch.float8_e4m3fn
+            x, y, scale_a=scale_a, scale_b=scale_b, out_dtype=out_dtype
         )
 
         x_sparse = to_sparse_semi_structured(x)
         out_fp8_sparse = torch._scaled_mm(
-            x_sparse, y, scale_a=scale_a, scale_b=scale_b, out_dtype=torch.float8_e4m3fn
+            x_sparse, y, scale_a=scale_a, scale_b=scale_b, out_dtype=out_dtype
         )
-        # this fails on ROCm currently because hipblaslt doesn't have amax op
         out_fp32 = out_fp8.to(torch.float32)
         out_fp32_sparse = out_fp8_sparse.to(torch.float32)
         torch.testing.assert_close(out_fp32, out_fp32_sparse, rtol=1e-1, atol=1e-1)
 
-    @unittest.skipIf(TEST_WITH_ROCM, "Not supported on ROCm")
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8,
         "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
     )
+    @unittest.skipIf(
+        TEST_WITH_ROCM and not PLATFORM_SUPPORTS_FP8_SPARSE,
+        "Only supported on ROCm MI300 or newer",
+    )
     @xfailIfSM89PreCUDA13
-    @parametrize("out_dtype", [torch.float16, torch.bfloat16, torch.float32])
+    @parametrize(
+        "out_dtype",
+        [torch.float32]
+        if TEST_WITH_ROCM
+        else [torch.float16, torch.bfloat16, torch.float32],
+    )
     @parametrize("dense_input_shape", [(256, 128)])
     def test_sparse_semi_structured_scaled_mm(
         self, dense_input_shape, device, out_dtype
@@ -1749,17 +1774,18 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
 
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8_SPARSE,
-        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI350+ (gfx950) on ROCm",
+        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ (gfx942/gfx950) on ROCm",
     )
     def test_cslt_compress_fp8(self, device):
         A = rand_sparse_semi_structured_mask(256, 128, dtype=torch.float16)
-        A_fp8, _ = to_float8(A)
+        fp8_dtype = fp8_e4m3_dtype()
+        A_fp8, _ = to_float8(A, dtype=fp8_dtype)
         compressed = torch._cslt_compress(A_fp8)
-        self.assertEqual(compressed.dtype, torch.float8_e4m3fn)
+        self.assertEqual(compressed.dtype, fp8_dtype)
 
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8_SPARSE,
-        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI350+ (gfx950) on ROCm",
+        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ (gfx942/gfx950) on ROCm",
     )
     @parametrize("dense_input_shape", [(256, 128)])
     def test_cslt_sparse_mm_fp8_to_fp32(self, dense_input_shape, device):
@@ -1779,10 +1805,13 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
 
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8_SPARSE,
-        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI350+ (gfx950) on ROCm",
+        "FP8 sparse requires cuSPARSELt v0.6.2+ on SM 8.9+ or MI300+ (gfx942/gfx950) on ROCm",
     )
     @unittest.skipIf(not TEST_WITH_ROCM, "ROCm-specific out_dtype restriction")
-    @parametrize("out_dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
+    @parametrize(
+        "out_dtype",
+        [torch.float16, torch.bfloat16, fp8_e4m3_dtype()],
+    )
     def test_cslt_sparse_mm_fp8_unsupported_out_dtype_rocm(self, out_dtype, device):
         A = rand_sparse_semi_structured_mask(256, 128, dtype=torch.float16)
         B = torch.rand(128, 128, device=device).to(torch.float16).t()

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -899,9 +899,10 @@ def meta__cslt_sparse_mm(
         torch.bfloat16,
         torch.int8,
         torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
     }:
         raise AssertionError(
-            f"_cslt_sparse_mm only supports fp16, bf16, int8, and fp8e4m3, got {dense_B.dtype}"
+            f"_cslt_sparse_mm only supports fp16, bf16, int8, fp8e4m3, and fp8e4m3fnuz, got {dense_B.dtype}"
         )
     if compressed_A.dtype != dense_B.dtype:
         raise AssertionError(
@@ -912,7 +913,11 @@ def meta__cslt_sparse_mm(
             f"_cslt_sparse_mm only supports 2d inputs, got {len(dense_B.shape)}D"
         )
 
-    is_8bit_input_type = compressed_A.dtype in [torch.int8, torch.float8_e4m3fn]
+    is_fp8_input_type = compressed_A.dtype in [
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+    ]
+    is_8bit_input_type = compressed_A.dtype == torch.int8 or is_fp8_input_type
 
     n = dense_B.size(1)
     m = compressed_A.size(0)
@@ -937,6 +942,10 @@ def meta__cslt_sparse_mm(
             raise AssertionError(
                 f"out_dtype is not supported for {compressed_A.dtype} x {dense_B.dtype} -> {out_dtype} matmul!"
             )
+    if out_dtype is None and is_fp8_input_type and torch.version.hip:
+        # hipSparseLt only produces fp32 for fp8 inputs, so _cslt_sparse_mm
+        # forces the result dtype to fp32 when out_dtype is omitted.
+        out_dtype = torch.float32
     output_shape = (n, m) if transpose_result else (m, n)
     return dense_B.new_empty(output_shape, dtype=out_dtype)
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -942,6 +942,12 @@ def meta__cslt_sparse_mm(
             raise AssertionError(
                 f"out_dtype is not supported for {compressed_A.dtype} x {dense_B.dtype} -> {out_dtype} matmul!"
             )
+        if is_fp8_input_type and torch.version.hip and out_dtype != torch.float32:
+            # Match the eager TORCH_CHECK in _cslt_sparse_mm_impl so compile
+            # rejects at trace time what eager rejects at call time.
+            raise AssertionError(
+                f"out_dtype must be float32 for fp8 inputs on ROCm, got {out_dtype}"
+            )
     if out_dtype is None and is_fp8_input_type and torch.version.hip:
         # hipSparseLt only produces fp32 for fp8 inputs, so _cslt_sparse_mm
         # forces the result dtype to fp32 when out_dtype is omitted.

--- a/torch/sparse/_semi_structured_ops.py
+++ b/torch/sparse/_semi_structured_ops.py
@@ -193,15 +193,26 @@ def semi_sparse_linear(func, types, args=(), kwargs=None) -> torch.Tensor:
     return res.view(*shape[:-1], -1)
 
 
+_FP8_E4M3_DTYPES = (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+
+
 def semi_sparse_scaled_mm(func, types, args=(), kwargs=None) -> torch.Tensor:
     # pull all args, excluding use_fast_accum flag if set.
     A, B, A_scale, B_scale, bias, scale_result, out_dtype = args[:7]
 
-    if A.dtype != torch.float8_e4m3fn:
-        raise AssertionError(f"expected A.dtype float8_e4m3fn, got {A.dtype}")
-    if B.dtype != torch.float8_e4m3fn:
-        raise AssertionError(f"expected B.dtype float8_e4m3fn, got {B.dtype}")
-    # only cuSPARSELt supports float8_e4m3fn currently
+    if A.dtype not in _FP8_E4M3_DTYPES:
+        raise AssertionError(
+            f"expected A.dtype float8_e4m3fn or float8_e4m3fnuz, got {A.dtype}"
+        )
+    if B.dtype not in _FP8_E4M3_DTYPES:
+        raise AssertionError(
+            f"expected B.dtype float8_e4m3fn or float8_e4m3fnuz, got {B.dtype}"
+        )
+    if A.dtype != B.dtype:
+        raise AssertionError(
+            f"expected A and B to have the same dtype, got {A.dtype} and {B.dtype}"
+        )
+    # only cuSPARSELt supports float8_e4m3fn/float8_e4m3fnuz currently
     if not isinstance(A, torch.sparse.SparseSemiStructuredTensorCUSPARSELT):
         raise AssertionError(
             f"expected SparseSemiStructuredTensorCUSPARSELT, got {type(A).__name__}"

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -560,6 +560,7 @@ class SparseSemiStructuredTensorCUSPARSELT(SparseSemiStructuredTensor):
     BACKEND = "cusparselt"
     _DTYPE_SHAPE_CONSTRAINTS = {
         torch.float8_e4m3fn: _SEMI_STRUCTURED_SPARSE_CONFIG(32, 32, 16, 16),
+        torch.float8_e4m3fnuz: _SEMI_STRUCTURED_SPARSE_CONFIG(32, 32, 16, 16),
         torch.int8: _SEMI_STRUCTURED_SPARSE_CONFIG(32, 32, 16, 16),
         torch.float16: _SEMI_STRUCTURED_SPARSE_CONFIG(16, 16, 8, 8),
         torch.bfloat16: _SEMI_STRUCTURED_SPARSE_CONFIG(16, 16, 8, 8),
@@ -679,11 +680,11 @@ class SparseSemiStructuredTensorCUSPARSELT(SparseSemiStructuredTensor):
                 "This operation is only supported when A, B and C have the same data type."
             )
         # Force fp8 mm to error to be consistent with torch
-        if self.dtype == torch.float8_e4m3fn:
+        if self.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
             raise NotImplementedError(
                 f"`{self.__class__.__name__}` matmul: trying to do `A={tuple(self.shape)} @ B={tuple(B.shape)}`, "
                 f"with A.dtype=B.dtype={self.dtype}. "
-                "mm is not supported for float8_e4m3fn, please use `torch._scaled_mm` instead."
+                "mm is not supported for float8_e4m3fn/float8_e4m3fnuz, please use `torch._scaled_mm` instead."
             )
         if self.packed is None:
             raise NotImplementedError(

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -10,6 +10,7 @@ from torch.sparse._semi_structured_conversions import (
     sparse_semi_structured_to_dense_cutlass,
 )
 from torch.sparse._semi_structured_ops import (
+    _FP8_E4M3_DTYPES,
     fallback_dispatcher,
     semi_sparse_addmm,
     semi_sparse_clone,
@@ -680,7 +681,7 @@ class SparseSemiStructuredTensorCUSPARSELT(SparseSemiStructuredTensor):
                 "This operation is only supported when A, B and C have the same data type."
             )
         # Force fp8 mm to error to be consistent with torch
-        if self.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
+        if self.dtype in _FP8_E4M3_DTYPES:
             raise NotImplementedError(
                 f"`{self.__class__.__name__}` matmul: trying to do `A={tuple(self.shape)} @ B={tuple(B.shape)}`, "
                 f"with A.dtype=B.dtype={self.dtype}. "

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -298,7 +298,7 @@ def evaluate_platform_supports_mxfp8_grouped_gemm():
 def evaluate_platform_supports_fp8_sparse():
     if torch.cuda.is_available():
         if torch.version.hip:
-            return 'gfx950' in torch.cuda.get_device_properties(0).gcnArchName
+            return evaluate_gfx_arch_within(["gfx950", "gfx1250"])
         else:
             return (
                 (SM90OrLater or torch.cuda.get_device_capability() == (8, 9))

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -298,7 +298,10 @@ def evaluate_platform_supports_mxfp8_grouped_gemm():
 def evaluate_platform_supports_fp8_sparse():
     if torch.cuda.is_available():
         if torch.version.hip:
-            return evaluate_gfx_arch_within(["gfx942", "gfx950", "gfx1250"])
+            return (
+                evaluate_gfx_arch_within(["gfx942", "gfx950", "gfx1250"])
+                and ROCM_VERSION >= (7, 12)
+            )
         else:
             return (
                 (SM90OrLater or torch.cuda.get_device_capability() == (8, 9))

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -295,13 +295,23 @@ def evaluate_platform_supports_mxfp8_grouped_gemm():
         return built_with_mslk and IS_SM100
     return False
 
+def hipsparselt_supported_archs():
+    # Keep in sync with hipSparseLtSupportedArchs() in
+    # aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp. Gating on a wider set
+    # than the runtime supports turns a skip into a hard TORCH_CHECK failure.
+    if ROCM_VERSION >= (7, 14):
+        return ['gfx942', 'gfx950', 'gfx1250']
+    elif ROCM_VERSION >= (7, 12):
+        return ['gfx942', 'gfx950']
+    return []
+
+def evaluate_platform_supports_hipsparselt():
+    return bool(torch.version.hip) and evaluate_gfx_arch_within(hipsparselt_supported_archs())
+
 def evaluate_platform_supports_fp8_sparse():
     if torch.cuda.is_available():
         if torch.version.hip:
-            return (
-                evaluate_gfx_arch_within(["gfx942", "gfx950", "gfx1250"])
-                and ROCM_VERSION >= (7, 12)
-            )
+            return evaluate_platform_supports_hipsparselt()
         else:
             return (
                 (SM90OrLater or torch.cuda.get_device_capability() == (8, 9))

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -276,7 +276,10 @@ def evaluate_platform_supports_mxfp8_grouped_gemm():
 def evaluate_platform_supports_fp8_sparse():
     if torch.cuda.is_available():
         if torch.version.hip:
-            return evaluate_gfx_arch_within(["gfx942", "gfx950", "gfx1250"])
+            return (
+                evaluate_gfx_arch_within(["gfx942", "gfx950", "gfx1250"])
+                and ROCM_VERSION >= (7, 12)
+            )
         else:
             return (
                 (SM90OrLater or torch.cuda.get_device_capability() == (8, 9))

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -298,7 +298,7 @@ def evaluate_platform_supports_mxfp8_grouped_gemm():
 def evaluate_platform_supports_fp8_sparse():
     if torch.cuda.is_available():
         if torch.version.hip:
-            return evaluate_gfx_arch_within(["gfx950", "gfx1250"])
+            return evaluate_gfx_arch_within(["gfx942", "gfx950", "gfx1250"])
         else:
             return (
                 (SM90OrLater or torch.cuda.get_device_capability() == (8, 9))

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -276,7 +276,7 @@ def evaluate_platform_supports_mxfp8_grouped_gemm():
 def evaluate_platform_supports_fp8_sparse():
     if torch.cuda.is_available():
         if torch.version.hip:
-            return 'gfx950' in torch.cuda.get_device_properties(0).gcnArchName
+            return evaluate_gfx_arch_within(["gfx950", "gfx1250"])
         else:
             return (
                 (SM90OrLater or torch.cuda.get_device_capability() == (8, 9))

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -276,7 +276,7 @@ def evaluate_platform_supports_mxfp8_grouped_gemm():
 def evaluate_platform_supports_fp8_sparse():
     if torch.cuda.is_available():
         if torch.version.hip:
-            return evaluate_gfx_arch_within(["gfx950", "gfx1250"])
+            return evaluate_gfx_arch_within(["gfx942", "gfx950", "gfx1250"])
         else:
             return (
                 (SM90OrLater or torch.cuda.get_device_capability() == (8, 9))


### PR DESCRIPTION
- This PR enables FP8 sparse semi-structured support on ROCm by adding hardware-native float8_e4m3fnuz (FNUZ) support to the hipSparseLt path. MI300 (gfx942) uses FNUZ FP8 natively, while MI350 (gfx950) and CUDA use OCP float8_e4m3fn.

- It also expands PLATFORM_SUPPORTS_FP8_SPARSE to cover gfx942 (MI300) in addition to gfx950, and un-skips the relevant FP8 sparse unit tests on ROCm MI300 and newer.

- Following tests are enabled on MI300+ and ROCm >= 7.12

```
test_cslt_compress_fp8_cuda
test_cslt_sparse_mm_fp8_to_fp32_dense_input_shape0_cuda
test_cslt_sparse_mm_fp8_unsupported_out_dtype_rocm_bfloat16_cuda
test_cslt_sparse_mm_fp8_unsupported_out_dtype_rocm_float16_cuda
test_cslt_sparse_mm_fp8_unsupported_out_dtype_rocm_float8_e4m3fn_cuda
test_sparse_fp8fp8_mm_dense_input_shape0_cuda
test_sparse_semi_structured_scaled_mm_float32_dense_input_shape0_cuda
test_sparse_semi_structured_scaled_mm_fp8_cuda
```

- The below two UTs won't be running on ROCm as only float32 output is valid for FP8 sparse _scaled_mm. hipSparseLt does not support float16 or bfloat16 output for FP8 inputs on ROCm.

```
test_sparse_semi_structured_scaled_mm_bfloat16_dense_input_shape0_cuda
test_sparse_semi_structured_scaled_mm_float16_dense_input_shape0_cuda
```



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang