### PR TITLE
[TEST] Refactor test_dtensor_resharding.py with hw_classification

### DIFF
--- a/test/distributed/checkpoint/test_dtensor_resharding.py
+++ b/test/distributed/checkpoint/test_dtensor_resharding.py
@@ -19,7 +19,9 @@ from torch.distributed.checkpoint.planner import (
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard, zeros
 from torch.distributed.tensor._shards_wrapper import LocalShardsWrapper
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -68,6 +70,8 @@ class TestDTensorReshardPlacementChange(DTensorTestBase):
     """
     Test DCP reshard for DTensor with placements changes and without world_size change and mesh_tensor change.
     """
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @with_comms
     @skip_if_lt_x_gpu(2)
@@ -178,6 +182,8 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
     """
     Test DCP reshard for DTensor with placements changes and mesh_tensor change.
     """
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @with_comms
     @with_temp_dir
@@ -438,6 +444,8 @@ class TestCheckpointableReshard(DTensorTestBase):
     Test DCP reshard loads when shard sizes are uneven across the ranks.
     """
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms
     @with_temp_dir
     @skip_if_lt_x_gpu(4)
@@ -597,6 +605,10 @@ class TestCheckpointableReshard(DTensorTestBase):
                 "Expected loading_local_tensor to equal expected_loaded_local_val_tensor"
             )
         dist.barrier()
+
+
+instantiate_device_type_tests(TestDTensorReshardMeshChange, globals())
+instantiate_device_type_tests(TestCheckpointableReshard, globals())
 
 
 # TODO: Add dtensor resharding test when world size changes.

--- a/test/distributed/checkpoint/test_dtensor_resharding.py
+++ b/test/distributed/checkpoint/test_dtensor_resharding.py
@@ -22,7 +22,6 @@ from torch.distributed.tensor._shards_wrapper import LocalShardsWrapper
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    instantiate_parametrized_tests,
     parametrize,
     run_tests,
 )
@@ -65,7 +64,6 @@ for p1 in TWO_D_PLACEMENTS:
             TWO_D_TO_TWO_D_PLACEMENTS.append((p1, p2))
 
 
-@instantiate_parametrized_tests
 class TestDTensorReshardPlacementChange(DTensorTestBase):
     """
     Test DCP reshard for DTensor with placements changes and without world_size change and mesh_tensor change.
@@ -607,6 +605,7 @@ class TestCheckpointableReshard(DTensorTestBase):
         dist.barrier()
 
 
+instantiate_device_type_tests(TestDTensorReshardPlacementChange, globals())
 instantiate_device_type_tests(TestDTensorReshardMeshChange, globals())
 instantiate_device_type_tests(TestCheckpointableReshard, globals())
 


### PR DESCRIPTION
## Summary
Apply hardware classification to `test/distributed/checkpoint/test_dtensor_resharding.py`.

## Changes:

- Add `hw_classification = ACCELERATOR` to `TestDTensorReshardPlacementChange` (2 tests, uses `instantiate_parametrized_tests` with `@with_comms`)
- Add `hw_classification = ACCELERATOR` to `TestDTensorReshardMeshChange` (4 tests, uses DTensorTestBase with `@with_comms`)
- Add `hw_classification = ACCELERATOR` to `TestCheckpointableReshard` (2 tests, uses DTensorTestBase with `@with_comms`)
- Add `instantiate_device_type_tests` for `TestDTensorReshardMeshChange` and `TestCheckpointableReshard`
- `TestDTensorReshardPlacementChange` excluded from `instantiate_device_type_tests` (uses `instantiate_parametrized_tests`)
- 1 non-test class skipped (`CheckpointableDistTensor` helper) — no test methods

## Test Plan

```
python -m pytest test/distributed/checkpoint/test_dtensor_resharding.py -v
16 passed

python -m pytest test/distributed/checkpoint/test_dtensor_resharding.py -v --hw-classification ACCELERATOR
16 passed

python -m pytest test/distributed/checkpoint/test_dtensor_resharding.py -v --hw-classification GENERIC
no tests ran
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508 