### PR TITLE
[AOTAutograd] Replay RNG state for memory-budget rematerialization

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -10182,6 +10182,109 @@ def forward(self, primals_1, tangents_1):
         out.sum().backward()
 
 
+class TestPartitioningRng(TestCase):
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    @torch._inductor.config.patch(fallback_random=True)
+    @parametrize("memory_budget,expected_wrappers", [(0.0, 2), (1.0, 0)])
+    def test_min_cut_partitioner_functionalizes_recomputed_rng(
+        self, device, memory_budget, expected_wrappers
+    ):
+        import torch._functorch.config as functorch_config
+
+        graphs = {}
+
+        def capture_graph(name):
+            def compiler(gm, _):
+                graphs[name] = gm
+                return make_boxed_func(gm.forward)
+
+            return compiler
+
+        def f(x):
+            x = torch.nn.functional.dropout(x, 0.5, True)
+            return torch.nn.functional.dropout(x, 0.75, True)
+
+        compiled = aot_function(
+            f,
+            fw_compiler=capture_graph("forward"),
+            bw_compiler=capture_graph("backward"),
+            partition_fn=min_cut_rematerialization_partition,
+        )
+        x = torch.ones(8, 8, device=device, requires_grad=True)
+        with functorch_config.patch(activation_memory_budget=memory_budget):
+            torch.manual_seed(42)
+            out = compiled(x)
+            out.sum().backward()
+
+        self.assertEqual(x.grad, out.detach())
+
+        fw_targets = [node.target for node in graphs["forward"].graph.nodes]
+        bw_targets = [node.target for node in graphs["backward"].graph.nodes]
+        self.assertEqual(
+            fw_targets.count(torch._prims.rng_prims.run_and_save_rng_state),
+            expected_wrappers,
+        )
+        self.assertEqual(
+            bw_targets.count(torch._prims.rng_prims.run_with_rng_state),
+            expected_wrappers,
+        )
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    @torch._inductor.config.patch(fallback_random=True)
+    @parametrize(
+        "partition_fn",
+        [default_partition, min_cut_rematerialization_partition],
+        name_fn=lambda partition_fn: partition_fn.__name__,
+    )
+    def test_backward_only_rng_stays_in_backward(self, device, partition_fn):
+        from torch._functorch.partitioners import is_rng_op
+
+        class RandomGrad(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.save_for_backward(x)
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                (x,) = ctx.saved_tensors
+                return torch.rand_like(x)
+
+        def f(x):
+            return RandomGrad.apply(x)
+
+        def run(fn):
+            torch.manual_seed(123)
+            x = torch.ones(8, device=device, requires_grad=True)
+            out = fn(x)
+            between = torch.rand_like(x)
+            out.sum().backward()
+            return between, x.grad
+
+        graphs = {}
+
+        def capture_graph(name):
+            def compiler(gm, _):
+                graphs[name] = gm
+                return make_boxed_func(gm.forward)
+
+            return compiler
+
+        compiled = aot_function(
+            f,
+            fw_compiler=capture_graph("forward"),
+            bw_compiler=capture_graph("backward"),
+            partition_fn=partition_fn,
+        )
+        expected_between, expected_grad = run(f)
+        actual_between, actual_grad = run(compiled)
+
+        self.assertEqual(actual_between, expected_between)
+        self.assertEqual(actual_grad, expected_grad)
+        self.assertFalse(any(is_rng_op(node) for node in graphs["forward"].graph.nodes))
+        self.assertTrue(any(is_rng_op(node) for node in graphs["backward"].graph.nodes))
+
+
 class TestAOTDispatch(AOTTestCase):
     # Tests to add cases for (non-exhaustive list, mostly for my notes):
     # - subclass / mode introduced in the middle of the compiled fn
@@ -12396,6 +12499,7 @@ class TestEagerFusionModuleInfo(AOTTestCase):
 
 instantiate_parametrized_tests(TestAOTAutograd)
 instantiate_parametrized_tests(TestAOTModuleSimplified)
+instantiate_device_type_tests(TestPartitioningRng, globals(), only_for=("cpu", "cuda"))
 only_for = "cpu"
 instantiate_device_type_tests(
     TestPythonKey,

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -754,7 +754,8 @@ def _must_be_in_backward(node: fx.Node) -> bool:
         isinstance(node.target, torch._ops.OpOverload)
         and node.target._schema.is_mutable
     )
-    return _has_tag_is_backward(node) and is_mutable
+    # DCE preserves RNG ops, so backward RNG must not enter forward extraction.
+    return _has_tag_is_backward(node) and (is_mutable or is_rng_op(node))
 
 
 def _iter_input_exprs_without_replacements(val: Any) -> Iterator[sympy.Basic]:
@@ -1640,7 +1641,6 @@ def default_partition(
         node.name for node in forward_nodes if node.op != "output"
     )
     graph_has_recomputable_ops = has_recomputable_ops(joint_module)
-    graph_has_recomputable_rng_ops = has_recomputable_rng_ops(joint_module)
     if graph_has_recomputable_ops:
         if _is_functional_graph(joint_module.graph)[0] is not None:
             # Fall-back to previous behavior to avoid bc-breaking, although can
@@ -1797,11 +1797,10 @@ def default_partition(
     fw_module.graph.eliminate_dead_code(is_impure_node=is_not_collective)
     bw_module.graph.eliminate_dead_code(is_impure_node=is_not_collective)
 
+    fw_module, bw_module = functionalize_rng_ops(
+        fw_module, bw_module, len(saved_sym_nodes)
+    )
     if graph_has_recomputable_ops:
-        if graph_has_recomputable_rng_ops:
-            fw_module, bw_module = functionalize_rng_ops(
-                joint_module, fw_module, bw_module, len(saved_sym_nodes)
-            )
         bw_module = reordering_to_mimic_autograd_engine(bw_module)
 
     # pyrefly: ignore [unbound-name]
@@ -2087,15 +2086,13 @@ def apply_graphsafe_rng_functionalization(
 
 
 def functionalize_rng_ops(
-    joint_module: fx.GraphModule,
     fw_module: fx.GraphModule,
     bw_module: fx.GraphModule,
     num_sym_nodes: int,
 ) -> tuple[fx.GraphModule, fx.GraphModule]:
-    # During user-driven activation checkpointing, we have to ensure that a rng
-    # op in fwd yields the same output as the recomputed rng op in the bwd.  To
-    # do this, we use functionalize wrappers to wrap the random ops and share
-    # rng state between the fwd and bwd graphs.
+    # When an RNG op is copied into both graphs, ensure that it yields the same
+    # output in the forward and backward. To do this, use functionalize wrappers
+    # to wrap the random ops and share RNG state between the graphs.
 
     # There are 3 main steps to do this
     # Step 1 - Construct a mapping of rng node between the fwd and its counterpart in bwd.
@@ -2150,21 +2147,16 @@ def functionalize_rng_ops(
             return fake_mode.from_tensor(torch.get_rng_state())
 
     # Step 1 - Construct a mapping of rng node between the fwd and its counterpart in bwd.
-    joint_graph_rng_ops = get_rng_ops(joint_module)
     fw_graph_rng_ops = get_rng_ops(fw_module)
     bw_graph_rng_ops = get_rng_ops(bw_module)
-    recomputable_rng_ops_map = {}
-    for node in joint_module.graph.nodes:
-        if must_recompute(node) and is_rng_op(node):
-            # Skip if the node doesn't exist in both forward and backward graphs.
-            # This can happen when the RNG op's output is not needed for gradient
-            # computation and gets eliminated by dead code elimination.
-            if node.name not in fw_graph_rng_ops or node.name not in bw_graph_rng_ops:
-                continue
-            base_node = joint_graph_rng_ops[node.name]
-            fw_node = fw_graph_rng_ops[node.name]
-            bw_node = bw_graph_rng_ops[node.name]
-            recomputable_rng_ops_map[base_node] = {"fwd": fw_node, "bwd": bw_node}
+    recomputable_rng_ops = [
+        (fw_node, bw_graph_rng_ops[name])
+        for name, fw_node in fw_graph_rng_ops.items()
+        if name in bw_graph_rng_ops
+    ]
+
+    if not recomputable_rng_ops:
+        return fw_module, bw_module
 
     run_and_save_rng = torch._prims.rng_prims.run_and_save_rng_state
     run_with_rng_state = torch._prims.rng_prims.run_with_rng_state
@@ -2184,9 +2176,7 @@ def functionalize_rng_ops(
     last_fwd_input = next(reversed(fw_module.graph.find_nodes(op="placeholder")))
     last_bwd_input = next(reversed(bw_module.graph.find_nodes(op="placeholder")))
 
-    devices = OrderedSet(
-        get_device(node_pair["fwd"]) for node_pair in recomputable_rng_ops_map.values()
-    )
+    devices = OrderedSet(get_device(fw_node) for fw_node, _ in recomputable_rng_ops)
     # pyrefly: ignore [unbound-name]
     devices.discard(torch.device("cpu"))
     # multiple graphsafe devices won't work with cudagraphs anyway,
@@ -2205,10 +2195,8 @@ def functionalize_rng_ops(
         )
     )
 
-    for rng_count, node_pair in enumerate(recomputable_rng_ops_map.values()):
+    for rng_count, (fw_node, bw_node) in enumerate(recomputable_rng_ops):
         # Step 2 - Modify the fwd pass such that
-        fw_node = node_pair["fwd"]
-        bw_node = node_pair["bwd"]
         device = get_device(fw_node)
 
         fw_graph = fw_module.graph
@@ -4157,7 +4145,6 @@ def min_cut_rematerialization_partition(
     joint_graph = joint_module.graph
 
     graph_has_recomputable_ops = has_recomputable_ops(joint_module)
-    graph_has_recomputable_rng_ops = has_recomputable_rng_ops(joint_module)
     if graph_has_recomputable_ops:
         joint_module = cleanup_recompute_tags(joint_module, is_default_partition=False)
     if not config.unsafe_allow_optimization_of_collectives:
@@ -4286,11 +4273,9 @@ def min_cut_rematerialization_partition(
         num_fwd_outputs=num_fwd_outputs,
         static_lifetime_input_nodes=node_info.static_lifetime_input_nodes,
     )
-    if graph_has_recomputable_ops:
-        if graph_has_recomputable_rng_ops:
-            fw_module, bw_module = functionalize_rng_ops(
-                joint_module, fw_module, bw_module, len(saved_sym_nodes)
-            )
+    fw_module, bw_module = functionalize_rng_ops(
+        fw_module, bw_module, len(saved_sym_nodes)
+    )
     bw_module = reordering_to_mimic_autograd_engine(bw_module)
 
     # pyrefly: ignore [unbound-name]


### PR DESCRIPTION
Alternative to #190759 for #190758.

## Problem

`activation_memory_budget < 1.0` can place an RNG operation in both the
partitioned forward and backward graphs. The backward copy draws fresh
randomness, so dropout and other sampled operations can use a value different
from the one used by the actual forward. This silently produces incorrect
gradients.

The existing `functionalize_rng_ops` pass already saves and replays RNG state
for explicit activation checkpointing, but both its invocation and its pair
selection require `MUST_RECOMPUTE`/`PREFER_RECOMPUTE` metadata. Memory-budget
rematerialization is expressed by the saved-value boundary and does not add
those annotations, so the pass is skipped.

## Approach

Run RNG functionalization after forward/backward extraction and identify actual
rematerialization from the extracted graphs. FX gives every joint-graph call
site a unique name and preserves that name when copying it into each graph, so
an RNG call present under the same name in both graphs is the pair to replay.
Iteration follows forward graph order to keep state outputs deterministic. If
there is no overlap, the pass returns without modifying either graph.

There is one phase-placement corner case: dead-code elimination retains RNG as
impure. A backward-only RNG depending on a saved primal could therefore survive
as a dead node in forward extraction and look duplicated. Backward-tagged RNG
is now treated like backward mutation by `_must_be_in_backward`, preventing
that wrong-phase copy.

This keeps the requested rematerialization instead of forcing RNG tensor
outputs into the saved-value boundary. The tradeoff depends on the path:

- For native RNG operations with large outputs or masks, saving RNG state can
  be substantially smaller.
- For the default Inductor path, saving the small `inductor_seeds` tensor can be
  smaller than saving a full RNG state.
- RNG state outputs are inserted after partition selection, so they are not
  currently included in memory-budget accounting, matching explicit
  activation-checkpoint RNG replay.

This draft is intended to make that tradeoff explicit relative to the
force-save approach in #190759.

## Tests

Added device-generic CPU/CUDA coverage for:

- two distinct dropout call sites at budget `0.0`, asserting two state
  save/replay pairs and forward-mask-consistent gradients;
- budget `1.0`, asserting no wrappers when RNG is saved rather than
  rematerialized;
- tangent-independent backward-only RNG under both default and min-cut
  partitioners, including an intervening random draw between forward and
  backward to verify phase ordering.

Local overlay validation also covered:

- existing explicit activation-checkpoint RNG tests on CUDA;
- `aot_eager`;
- Inductor with `fallback_random=True` and `False`;
- the fractional budget `0.005` dropout/`randn_like` knapsack reproducer.

The current-main worktree did not have matching compiled extensions or
generated stubs, so tests overlaid these Python changes on the existing local
`dfb9ebd` build. Targeted Ruff, Flake8, PYFMT, codespell, and test-main lint
passed; full Pyrefly was unavailable without matching generated build stubs.

This PR was authored with assistance from an AI coding assistant.
