### PR TITLE
Don't flag input-input aliasing in while_loop's subgraph checks

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -7656,6 +7656,39 @@ def forward(self, arg0_1):
         fn, inp = WHILE_LOOP_TESTS[while_loop_test]
         self._check_compile(fn, inp, backend=backend)
 
+    def test_while_loop_carried_input_is_also_additional_input(self):
+        def f(x):
+            captured = x
+
+            def cond_fn(i, v):
+                return i < 3
+
+            def body_fn(i, v):
+                return i + 1, v + captured
+
+            return while_loop(cond_fn, body_fn, (torch.tensor(0), x))[1]
+
+        self._check_compile(f, (torch.randn(4, 4),), backend="aot_eager")
+
+    def test_while_loop_body_fn_output_alias_input(self):
+        def cond_fn(i, v, a):
+            return i < 3
+
+        def body_fn(i, v, a):
+            return i + 1, v.view(v.shape)
+
+        # x is passed as a carried input and as an additional input, which is allowed,
+        # but body_fn's output still must not alias its input.
+        def f(x):
+            return torch.ops.higher_order.while_loop(
+                cond_fn, body_fn, (torch.tensor(0), x), (x,)
+            )[1]
+
+        with self.assertRaisesRegex(
+            RuntimeError, "body_fn might be aliasing the input or the output!"
+        ):
+            make_fx(torch.func.functionalize(f))(torch.randn(4, 4))
+
     @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
     @skipIfCrossRef  # Arg order changes with cross ref
     def test_while_loop_simple_with_linear_compile_check_graph(self):

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -419,7 +419,9 @@ def _has_potential_branch_input_mutation(gm, inputs, pre_dispatch=False):
     return len(inp_mutation) > 0
 
 
-def has_potential_input_alias_or_mutation(gm, inputs, pre_dispatch=False):
+def has_potential_input_alias_or_mutation(
+    gm, inputs, pre_dispatch=False, check_input_input_alias=True
+):
     (
         (
             inp_inp_alias_map,
@@ -431,7 +433,7 @@ def has_potential_input_alias_or_mutation(gm, inputs, pre_dispatch=False):
     return (
         any(
             (
-                len(inp_inp_alias_map) > 0,
+                check_input_input_alias and len(inp_inp_alias_map) > 0,
                 len(inp_out_alias_map) > 0,
                 len(out_out_alias_map) > 0,
             )
@@ -496,9 +498,14 @@ def _collect_fake_inputs(inputs):
     return inputs_fake
 
 
-def _check_alias_and_mutation(graph_module, inputs_fake, name, pre_dispatch):
+def _check_alias_and_mutation(
+    graph_module, inputs_fake, name, pre_dispatch, check_input_input_alias=True
+):
     aliases, inp_mutation = has_potential_input_alias_or_mutation(
-        graph_module, inputs_fake, pre_dispatch=pre_dispatch
+        graph_module,
+        inputs_fake,
+        pre_dispatch=pre_dispatch,
+        check_input_input_alias=check_input_input_alias,
     )
     if aliases:
         raise RuntimeError(f"{name} might be aliasing the input or the output!")

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -650,7 +650,17 @@ def while_loop_func(
             (cond_fn, "cond_fn"),
             (body_fn, "body_fn"),
         ]:
-            _check_alias_and_mutation(fn, unwrapped_inputs, fn_name, pre_dispatch)
+            # Tensor closures of cond_fn and body_fn are lifted into additional_inputs,
+            # so an additional input can be the same tensor as a carried input. This is
+            # not something the subgraphs do, and while_loop only requires that they
+            # don't mutate their inputs or return aliases of them.
+            _check_alias_and_mutation(
+                fn,
+                unwrapped_inputs,
+                fn_name,
+                pre_dispatch,
+                check_input_input_alias=False,
+            )
         op_kwargs = {}
         if not stack_output and mutated_arg_indices:
             op_kwargs["mutated_arg_indices"] = mutated_arg_indices


### PR DESCRIPTION
Fixes #191582

Dynamo lifts tensor closures of `cond_fn`/`body_fn` into `while_loop`'s
`additional_inputs`, so a tensor that is already a carried input gets passed a
second time as an additional input (`while_loop(cond_fn, body_fn, (i, x), (index, x))`
in the issue). That graph is correct and the two arguments cannot be merged: the
carry is rebound every iteration while the additional input stays pinned to the
original tensor. But `while_loop_func` checks each subgraph with
`_check_alias_and_mutation(fn, carried + additional, ...)`, which counts aliasing
between two inputs as a violation, so the duplicated tensor tripped the check on
`cond_fn` - the first subgraph checked - even though `cond_fn` was just `i < 2`
and never touched a tensor.

Input-input aliasing is a property of the arguments the caller passed, not of
`cond_fn` or `body_fn`. It is also not one of `while_loop`'s documented
restrictions: the subgraphs must not mutate their inputs and must not return
aliases of them, and both of those are still checked. So `while_loop_func` now
passes `check_input_input_alias=False`. No other HOP's behavior changes.

Verified:

- The issue's repro, plus a variant with non-degenerate numerics
  (`body_fn` returning `v + captured`), now compiles and matches eager under
  `aot_eager` on CPU and under `inductor` on CUDA (A40, sm_86, CUDA 12.6).
  Gradients through the `requires_grad` version also match a plain Python loop.
- A `body_fn` that returns a view of its input is still rejected, and the error
  is now attributed to `body_fn` instead of `cond_fn`. That is the second new
  test.
- Both new tests fail before this change with
  `RuntimeError: cond_fn might be aliasing the input or the output!` and pass
  after.

Not verified: I could not build this checkout (local g++ is too old for
`-std=c++20`), so the runtime checks above were run by applying the identical
patch to an installed 2.13.0 wheel, where the three touched code regions are
byte for byte the same as here. CPU inductor also cannot compile in this
environment, so the inductor check is CUDA only. `lintrunner`/`spin` are not
installed here; `ruff check` and `ruff format --check` on the three files report
exactly the same 13 pre-existing findings as on `HEAD`, none on the new lines.

Thanks to @xyt66665000 for the report and for pinpointing that the captured
`source = x` was being attributed to `cond_fn`.