### PR TITLE
Fix FX codegen for module names that are keywords or need escaping

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1159,6 +1159,67 @@ class TestFX(JitTestCase):
         for node in m_g.graph.nodes:
             self.assertTrue(node.name != "getattr")
 
+    def test_format_target_unsafe_names(self):
+        """`_format_target` must emit valid Python for any legal module name."""
+        from torch.fx.graph import _format_target
+
+        # Keywords pass `str.isidentifier()` but are not usable with dot syntax.
+        self.assertEqual(_format_target("self", "class"), 'getattr(self, "class")')
+        self.assertEqual(
+            _format_target("self", "seq.class"), 'getattr(self.seq, "class")'
+        )
+        self.assertEqual(_format_target("self", "None"), 'getattr(self, "None")')
+        # Soft keywords are legal attribute names and stay on the dot path.
+        self.assertEqual(_format_target("self", "match"), "self.match")
+        # Names needing escapes must not be spliced into a double-quoted literal.
+        self.assertEqual(
+            _format_target("self", 'quote"key'), "getattr(self, 'quote\"key')"
+        )
+        self.assertEqual(
+            _format_target("self", "back\\slash"), "getattr(self, 'back\\\\slash')"
+        )
+        self.assertEqual(_format_target("self", "a\nb"), "getattr(self, 'a\\nb')")
+        # The common, safe cases keep their historical spelling unchanged.
+        self.assertEqual(_format_target("self", "seq.0"), 'getattr(self.seq, "0")')
+        self.assertEqual(_format_target("self", "a.b"), "self.a.b")
+
+    def test_trace_module_name_is_keyword(self):
+        """A submodule named after a keyword must not emit `self.seq.class`."""
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.seq = torch.nn.Sequential()
+                self.seq.add_module("class", torch.nn.Identity())
+
+            def forward(self, x):
+                return self.seq(x)
+
+        m = M()
+        m_g = symbolic_trace(m)
+        m_g.graph.lint()
+        self.assertIn('getattr(self.seq, "class")', m_g.code)
+        x = torch.ones(1)
+        torch.testing.assert_close(m_g(x), m(x))
+
+    def test_trace_module_name_needs_escape(self):
+        """A submodule name containing a quote must be escaped, not spliced."""
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.add_module('quote"key', torch.nn.Identity())
+
+            def forward(self, x):
+                return getattr(self, 'quote"key')(x)
+
+        m = M()
+        m_g = symbolic_trace(m)
+        m_g.graph.lint()
+        self.assertIn("getattr(self, 'quote\"key')", m_g.code)
+        x = torch.ones(1)
+        torch.testing.assert_close(m_g(x), m(x))
+
     @unittest.skip("https://github.com/pytorch/pytorch/issues/74208")
     @unittest.skip("Hotfix for SEV remediation")
     def test_trace_buffer_slice(self):

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -258,14 +258,31 @@ class PythonCode:
     _prologue_start: int = 0
 
 
+def _format_attr_literal(name: str) -> str:
+    """Return a Python string literal that evaluates to exactly ``name``.
+
+    Historically this emitted ``"{name}"`` unconditionally, which produces
+    invalid source when ``name`` contains a quote, a backslash, or a
+    non-printable character. Keep the double-quoted spelling whenever it is
+    safe -- it is by far the common case (e.g. ``nn.Sequential`` children are
+    addressed as ``"0"``, ``"1"``, ...) and preserving it keeps generated code
+    unchanged -- and fall back to ``repr`` otherwise.
+    """
+    if '"' not in name and "\\" not in name and name.isprintable():
+        return f'"{name}"'
+    return repr(name)
+
+
 def _format_target(base: str, target: str) -> str:
     elems = target.split(".")
     r = base
     for e in elems:
-        if not e.isidentifier():
-            r = f'getattr({r}, "{e}")'
-        else:
+        # Keywords satisfy ``str.isidentifier()`` but cannot be used with dot
+        # syntax, so they have to go through ``getattr`` as well.
+        if e.isidentifier() and not keyword.iskeyword(e):
             r = f"{r}.{e}"
+        else:
+            r = f"getattr({r}, {_format_attr_literal(e)})"
     return r
 
 


### PR DESCRIPTION
## Issue

Fixes #188538

## Summary

`_format_target` chose between dot syntax and `getattr()` using
`str.isidentifier()` alone, and built the `getattr()` argument by splicing the
name into a hand-written double-quoted string. Both steps can emit invalid
Python for module names that work fine in eager mode and trace fine through
`torch.export`: keywords like `class` pass `isidentifier()` and produced
`self.seq.class(x)`, and a name containing `"` produced
`getattr(self, "quote"key")(x)`. Backslashes and non-printable characters had
the same problem.

This routes keywords through `getattr()` as well, and emits the name via a
helper that keeps the double-quoted spelling when it is exactly equivalent,
falling back to `repr` otherwise. Keeping the double-quoted form is deliberate:
`nn.Sequential` addresses its children as `"0"`, `"1"`, ..., which is the most
common `getattr()` case in generated code, so using `repr` unconditionally
(as the issue suggests) would rewrite it as `'0'` and churn expected output
across the test suite for no behavioural gain. Soft keywords (`match`, `case`,
`type`) are legal attribute names and stay on the dot path.

No currently-passing test changes behaviour: the only inputs whose output
differs are the ones that previously generated invalid Python.

## Checklist

- [x] Passes lint (ran `lintrunner` on the changed files)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.