### PR TITLE
[inductor] Fuse a q-by-kv contraction in flex_attention score_mod into a tl.dot

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2069,6 +2069,230 @@ class TestFlexAttention(InductorTestCase):
 
     @supported_platform
     @skip_on_cpu
+    @skip_on_mps
+    # Wider R coverage lives in test_score_mod_contraction_matches_unfused, which
+    # does not need the eager reference's [B, H, M, N, R] intermediate.
+    @common_utils.parametrize("R", [16, 17])
+    @common_utils.parametrize("causal", [False, True])
+    # Only the fused forward computes the contraction with a tl.dot; the backward
+    # still unrolls it, so it needs the threshold above the contracted extent.
+    @torch._inductor.config.patch(unroll_reductions_threshold=129)
+    def test_score_mod_contraction(self, device, R: int, causal: bool):
+        """MLA's decoupled rope term: score + dot(q_rope[b, h, m], k_rope[b, h, n])."""
+        dtype = torch.float16
+        Sq = 128
+        # float32 operands: the fused dot accumulates in float32 while the eager
+        # reference the golden is measured against would sum in the capture dtype,
+        # so float16 operands would make the golden the least accurate of the three.
+        # They also pin the dot's input_precision, which tf32 would degrade.
+        scale = R**-0.25
+        q_rope = torch.randn(B, H, Sq, R, device=device) * scale
+        k_rope = torch.randn(B, H, Sq, R, device=device) * scale
+
+        # Spelled as mul + sum rather than torch.dot so the eager reference, which
+        # calls score_mod with broadcast index tensors, can run it too.
+        def rope_bias(score, b, h, m, n):
+            return score + (q_rope[b, h, m] * k_rope[b, h, n]).sum(-1)
+
+        block_mask = None
+        if causal:
+            block_mask = create_block_mask(
+                lambda b, h, m, n: m >= n, B, H, Sq, Sq, device=device
+            )
+        self.run_test(
+            rope_bias, dtype, device=device, Q_S=Sq, KV_S=Sq, block_mask=block_mask
+        )
+
+    def _contraction_score_mod(self, device, R, spelling):
+        dtype = torch.float16
+        # Scaled like a real rope term, so the bias stays O(1) instead of O(sqrt(R))
+        # and does not drive the softmax somewhere unrepresentative.
+        scale = R**-0.25
+        q_rope = torch.randn(B, H, S, R, device=device, dtype=dtype) * scale
+        k_rope = torch.randn(B, H, S, R, device=device, dtype=dtype) * scale
+
+        def dot(score, b, h, m, n):
+            return score + torch.dot(q_rope[b, h, m], k_rope[b, h, n])
+
+        def mul_sum(score, b, h, m, n):
+            return score + (q_rope[b, h, m] * k_rope[b, h, n]).sum(-1)
+
+        return dot if spelling == "dot" else mul_sum
+
+    def _contraction_qkv(self, device, Sq):
+        q = torch.randn(B, H, Sq, D, device=device, dtype=torch.float16)
+        k, v = (
+            torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+            for _ in range(2)
+        )
+        return q, k, v
+
+    def _compile_flex(self, qkv, score_mod, fuse, **kwargs):
+        q, k, v = qkv
+        torch._dynamo.reset()
+        with torch.no_grad(), config.patch(flex_fuse_score_mod_contraction=fuse):
+            out, code = run_and_get_code(
+                torch.compile(flex_attention), q, k, v, score_mod=score_mod, **kwargs
+            )
+        return out, "\n".join(code)
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_mps
+    # R below tl.dot's minimum contracted extent, not a power of two, and above
+    # BLOCK_N; both spellings of the dot.
+    @common_utils.parametrize(
+        "R,spelling", [(8, "dot"), (48, "mul_sum"), (64, "dot"), (128, "dot")]
+    )
+    @torch._inductor.config.patch(unroll_reductions_threshold=129)
+    def test_score_mod_contraction_matches_unfused(self, device, R: int, spelling: str):
+        score_mod = self._contraction_score_mod(device, R, spelling)
+        qkv = self._contraction_qkv(device, S)
+        fused_out, fused_code = self._compile_flex(qkv, score_mod, True)
+        unfused_out, unfused_code = self._compile_flex(qkv, score_mod, False)
+
+        self.assertIn("qk_extra = tl.dot", fused_code)
+        self.assertNotIn("qk_extra = tl.dot", unfused_code)
+        # One dot for qk, one for the contraction, one for the pv accumulation.
+        self.assertEqual(fused_code.count("tl.dot"), 3)
+        # The unrolled form loads every contracted element separately.
+        self.assertLess(fused_code.count("tl.load"), unfused_code.count("tl.load"))
+        torch.testing.assert_close(fused_out, unfused_out, atol=2e-3, rtol=2e-3)
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_mps
+    # Two of these still hold a reduction after the detector rejects them, so they
+    # only compile at all with the threshold above the contracted extent.
+    @torch._inductor.config.patch(unroll_reductions_threshold=17)
+    def test_score_mod_contraction_not_fused_when_unsupported(self, device):
+        dtype = torch.float16
+        R = 16
+        q_rope = torch.randn(B, H, S, R, device=device, dtype=dtype)
+        k_rope = torch.randn(B, H, S, R, device=device, dtype=dtype)
+        bias = torch.randn(B, H, S, S, device=device, dtype=dtype)
+        head_scale = torch.randn(H, device=device, dtype=dtype)
+
+        # Both operands indexed by the query position: not a q-by-kv term.
+        def q_by_q(s, b, h, m, n):
+            return s + torch.dot(q_rope[b, h, m], k_rope[b, h, m])
+
+        # A transformed head index would need its own broadcast handling.
+        def shared_heads(s, b, h, m, n):
+            return s + torch.dot(q_rope[b, h, m], k_rope[b, h // 2, n])
+
+        unsupported = {
+            "full bias": lambda s, b, h, m, n: s + bias[b, h, m, n],
+            "scalar capture": lambda s, b, h, m, n: s + head_scale[h],
+            "no capture": lambda s, b, h, m, n: s * 2.0,
+            "q by q": q_by_q,
+            "shared heads": shared_heads,
+        }
+        qkv = self._contraction_qkv(device, S)
+        for name, score_mod in unsupported.items():
+            with self.subTest(score_mod=name):
+                fused_out, fused_code = self._compile_flex(qkv, score_mod, True)
+                unfused_out, _ = self._compile_flex(qkv, score_mod, False)
+                self.assertNotIn("qk_extra", fused_code, f"{name} should not fuse")
+                self.assertEqual(fused_out, unfused_out)
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_mps  # uses Triton max_autotune (no autotuning on MPS)
+    @patch.object(torch._inductor.config, "max_autotune", True)
+    @torch._inductor.config.patch(unroll_reductions_threshold=17)
+    def test_score_mod_contraction_max_autotune(self, device):
+        """Autotuning benchmarks each choice with materialized tensors, so it is
+        the path that would catch the operands being passed in the wrong order."""
+        R = 16
+        # A capture that is not part of the contraction, and comes before the two
+        # that are, so the operand order cannot come out right by accident.
+        head_scale = torch.rand(H, device=device, dtype=torch.float16) + 0.5
+        q_rope = torch.randn(B, H, S, R, device=device, dtype=torch.float16)
+        k_rope = torch.randn(B, H, S, R, device=device, dtype=torch.float16)
+
+        def rope_bias(score, b, h, m, n):
+            return score * head_scale[h] + torch.dot(q_rope[b, h, m], k_rope[b, h, n])
+
+        qkv = self._contraction_qkv(device, S)
+        fused_out, fused_code = self._compile_flex(qkv, rope_bias, True)
+        unfused_out, _ = self._compile_flex(qkv, rope_bias, False)
+        self.assertIn("qk_extra = tl.dot", fused_code)
+        torch.testing.assert_close(fused_out, unfused_out, atol=2e-3, rtol=2e-3)
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_mps
+    @torch._inductor.config.patch(unroll_reductions_threshold=17)
+    def test_score_mod_contraction_short_query_falls_back(self, device):
+        """A decode tile spans several query heads, so the kv operand differs per
+        row of the tile and the contraction is not a single matmul there."""
+        dtype = torch.float16
+        R, Sq = 16, 8
+        q_rope = torch.randn(B, H, Sq, R, device=device, dtype=dtype)
+        k_rope = torch.randn(B, H, S, R, device=device, dtype=dtype)
+
+        def rope_bias(score, b, h, m, n):
+            return score + torch.dot(q_rope[b, h, m], k_rope[b, h, n])
+
+        qkv = self._contraction_qkv(device, Sq)
+        outs = []
+        for fuse in (True, False):
+            out, code = self._compile_flex(qkv, rope_bias, fuse)
+            self.assertNotIn("qk_extra", code)
+            outs.append(out)
+        self.assertEqual(outs[0], outs[1])
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_mps
+    @torch._inductor.config.patch(unroll_reductions_threshold=17)
+    def test_score_mod_contraction_backward_unchanged(self, device):
+        """Fusing the forward must not change what the backward does, including
+        for captures that require grad (which the backward cannot handle yet)."""
+        dtype = torch.float16
+        R = 16
+
+        def outcome(fuse: bool, captures_require_grad: bool):
+            torch.manual_seed(0)
+            rope = functools.partial(
+                torch.randn,
+                B,
+                H,
+                S,
+                R,
+                device=device,
+                dtype=dtype,
+                requires_grad=captures_require_grad,
+            )
+            q_rope, k_rope = rope(), rope()
+            qkv = functools.partial(
+                torch.randn, B, H, S, D, device=device, dtype=dtype, requires_grad=True
+            )
+            q, k, v = qkv(), qkv(), qkv()
+
+            def rope_bias(score, b, h, m, n):
+                return score + torch.dot(q_rope[b, h, m], k_rope[b, h, n])
+
+            torch._dynamo.reset()
+            with config.patch(flex_fuse_score_mod_contraction=fuse):
+                try:
+                    out = torch.compile(flex_attention)(q, k, v, score_mod=rope_bias)
+                    out.sum().backward()
+                except Exception as e:
+                    return type(e).__name__, None
+            return None, (q.grad, k.grad, v.grad)
+
+        for captures_require_grad in (False, True):
+            with self.subTest(captures_require_grad=captures_require_grad):
+                fused_exc, fused_grads = outcome(True, captures_require_grad)
+                ref_exc, ref_grads = outcome(False, captures_require_grad)
+                self.assertEqual(fused_exc, ref_exc)
+                if fused_grads is not None:
+                    self.assertEqual(fused_grads, ref_grads, atol=2e-3, rtol=2e-3)
+
+    @supported_platform
+    @skip_on_cpu
     @expected_not_implemented_on_mps
     def test_bf16_score_mod_captured_grad_dtype(self, device):
         """

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1034,6 +1034,11 @@ force_pointwise_cat = False
 # replace small reductions with pointwise, disable with `= 1`
 unroll_reductions_threshold = 8
 
+# In flex attention, compute a q-by-kv contraction in score_mod (MLA's decoupled
+# rope term, say) with an extra tl.dot on the score tile instead of unrolling it
+# into one multiply-add per contracted element.
+flex_fuse_score_mod_contraction = True
+
 # Add extra comments to output code (causes compile cache misses)
 comment_origin = False
 

--- a/torch/_inductor/kernel/flex/contraction.py
+++ b/torch/_inductor/kernel/flex/contraction.py
@@ -1,0 +1,239 @@
+"""Detection of q-by-kv contractions inside a score_mod subgraph.
+
+A score_mod may contract a query-indexed vector against a key-indexed vector, as
+MLA's decoupled RoPE term does:
+
+    score + dot(query_rope[b, h, q_idx], key_rope[b, h, kv_idx])
+
+Lowered naively this is a reduction per score element, which the pointwise
+subgraph lowering cannot represent at all; the only way to compile it today is to
+raise unroll_reductions_threshold above the contracted extent so it expands into
+that many pointwise multiply-adds per element of the score tile.
+
+Such a contraction factorizes over the score tile: the [BLOCK_M, BLOCK_N, R]
+intermediate the unrolled form materializes is just
+    A_tile[BLOCK_M, R] @ B_tile[R, BLOCK_N]
+so the template can compute it with one extra tl.dot and never form the rank-3
+intermediate. This module recognizes the pattern; the lowering hands the operands
+to the template as tiles.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+aten = torch.ops.aten
+prims = torch.ops.prims
+
+# score, b, h, q_idx, kv_idx -- everything after these is a captured tensor.
+NUM_SCORE_MOD_FIXED_ARGS = 5
+
+_Q_IDX_ARG = 3
+_KV_IDX_ARG = 4
+
+# Name of the placeholder that replaces the contraction; the template supplies a
+# [BLOCK_M, BLOCK_N] tile for it, exactly like the "score" placeholder.
+CONTRACTION_INPUT_NAME = "qk_extra"
+
+# tl.dot needs a contracted extent of at least 16.
+MIN_CONTRACT_EXTENT_ROUNDED = 16
+
+
+@dataclass(frozen=True)
+class ScoreModContraction:
+    """One recognized dot(A[b, h, q_idx], B[b, h, kv_idx]) term.
+
+    ``sum_node`` is the node whose value the template supplies instead, as a
+    [BLOCK_M, BLOCK_N] tile. ``q_arg`` / ``kv_arg`` are placeholder positions in
+    the subgraph argument list, so the lowering can pick the matching operands
+    out of the captured tensors it already has.
+    """
+
+    sum_node: torch.fx.Node
+    q_arg: int
+    kv_arg: int
+    contract_extent: int
+    out_dtype: torch.dtype
+
+    @property
+    def contract_extent_rounded(self) -> int:
+        return max(
+            MIN_CONTRACT_EXTENT_ROUNDED,
+            1 << (self.contract_extent - 1).bit_length(),
+        )
+
+
+def _strip_converts(node: Any) -> tuple[Any, torch.dtype | None]:
+    """Peel convert_element_type wrappers, returning the widest dtype seen."""
+    dtype: torch.dtype | None = None
+    while (
+        isinstance(node, torch.fx.Node)
+        and node.op == "call_function"
+        and node.target is prims.convert_element_type.default
+    ):
+        if dtype is None and isinstance(node.args[1], torch.dtype):
+            dtype = node.args[1]
+        node = node.args[0]
+    return node, dtype
+
+
+def _placeholder_position(node: Any, placeholders: list[torch.fx.Node]) -> int | None:
+    if not isinstance(node, torch.fx.Node) or node.op != "placeholder":
+        return None
+    return placeholders.index(node)
+
+
+def _match_indexed_capture(
+    node: Any,
+    placeholders: list[torch.fx.Node],
+    seq_arg: int,
+) -> tuple[int, int] | None:
+    """Match ``capture[b, h, <seq_arg>]`` -> (capture arg position, extent).
+
+    Requires the batch and head indices to be the score_mod's own b/h arguments.
+    A transformed head index (GQA's ``h // n``, say) is deliberately rejected:
+    the template loads whole tiles, so a head index that is not the raw argument
+    would need its own broadcast handling.
+    """
+    if not isinstance(node, torch.fx.Node) or node.op != "call_function":
+        return None
+    if node.target is not aten.index.Tensor:
+        return None
+    if len(node.args) != 2:
+        return None
+
+    base, indices = node.args
+    if not isinstance(indices, (list, tuple)) or len(indices) != 3:
+        return None
+
+    base_pos = _placeholder_position(base, placeholders)
+    if base_pos is None or base_pos < NUM_SCORE_MOD_FIXED_ARGS:
+        return None
+
+    if [_placeholder_position(i, placeholders) for i in indices] != [1, 2, seq_arg]:
+        return None
+
+    val = placeholders[base_pos].meta.get("val")
+    if val is None or val.dim() != 4:
+        return None
+    extent = val.shape[-1]
+    # A symbolic trailing extent would make the tile shape dynamic; bail.
+    if not isinstance(extent, int):
+        return None
+
+    return base_pos, extent
+
+
+def detect_score_mod_contraction(
+    graph_module: torch.fx.GraphModule,
+) -> ScoreModContraction | None:
+    """Recognize a single q-by-kv contraction in a score_mod subgraph.
+
+    Returns None whenever the graph is not exactly the supported shape. Bailing
+    is always safe: the caller keeps today's unroll-or-fail behaviour.
+    """
+    graph = graph_module.graph
+    placeholders = [n for n in graph.nodes if n.op == "placeholder"]
+    if len(placeholders) <= NUM_SCORE_MOD_FIXED_ARGS:
+        return None
+
+    found: list[ScoreModContraction] = []
+    for node in graph.nodes:
+        if node.op != "call_function":
+            continue
+        # torch.dot over the trailing dim arrives as mul + full sum.
+        keepdim = len(node.args) > 2 and node.args[2]
+        if node.target is aten.sum.default:
+            mul, accum_dtype = _strip_converts(node.args[0])
+        elif (
+            node.target is aten.sum.dim_IntList
+            and node.args[1] in ([-1], [0])
+            and not keepdim
+        ):
+            mul, accum_dtype = _strip_converts(node.args[0])
+        else:
+            continue
+
+        if (
+            not isinstance(mul, torch.fx.Node)
+            or mul.op != "call_function"
+            or mul.target is not aten.mul.Tensor
+        ):
+            continue
+
+        lhs, lhs_dtype = _strip_converts(mul.args[0])
+        rhs, rhs_dtype = _strip_converts(mul.args[1])
+
+        q_match = _match_indexed_capture(lhs, placeholders, _Q_IDX_ARG)
+        kv_match = _match_indexed_capture(rhs, placeholders, _KV_IDX_ARG)
+        if q_match is None or kv_match is None:
+            # Operands may appear in either order.
+            q_match = _match_indexed_capture(rhs, placeholders, _Q_IDX_ARG)
+            kv_match = _match_indexed_capture(lhs, placeholders, _KV_IDX_ARG)
+        if q_match is None or kv_match is None:
+            continue
+
+        (q_arg, q_extent), (kv_arg, kv_extent) = q_match, kv_match
+        if q_extent != kv_extent or q_arg == kv_arg:
+            continue
+
+        out_val = node.meta.get("val")
+        found.append(
+            ScoreModContraction(
+                sum_node=node,
+                q_arg=q_arg,
+                kv_arg=kv_arg,
+                contract_extent=q_extent,
+                out_dtype=(
+                    out_val.dtype
+                    if out_val is not None
+                    else (accum_dtype or lhs_dtype or rhs_dtype or torch.float32)
+                ),
+            )
+        )
+
+    # More than one contraction would need several extra tl.dots and a matching
+    # number of template operands; not handled yet.
+    if len(found) != 1:
+        return None
+    return found[0]
+
+
+def rewrite_score_mod_for_contraction(
+    graph_module: torch.fx.GraphModule,
+) -> tuple[torch.fx.GraphModule, ScoreModContraction] | None:
+    """Replace a recognized contraction with a trailing placeholder.
+
+    The returned module is a copy: the caller's graph is shared with the
+    backward lowering and with the other flex backends, none of which know about
+    the fused input. The new placeholder goes last, so it maps onto one extra
+    argument appended after the captured tensors.
+    """
+    if detect_score_mod_contraction(graph_module) is None:
+        return None
+
+    # Detected again on the copy so the returned node belongs to the graph the
+    # caller gets; detection is much cheaper than copying every score_mod graph.
+    fused = torch.fx.GraphModule(graph_module, copy.deepcopy(graph_module.graph))
+    contraction = detect_score_mod_contraction(fused)
+    if contraction is None:
+        raise AssertionError("contraction detection is not stable under graph copy")
+
+    graph = fused.graph
+    placeholders = [n for n in graph.nodes if n.op == "placeholder"]
+    with graph.inserting_after(placeholders[-1]):
+        tile = graph.placeholder(CONTRACTION_INPUT_NAME)
+    tile.meta.update(contraction.sum_node.meta)
+
+    contraction.sum_node.replace_all_uses_with(tile)
+    graph.erase_node(contraction.sum_node)
+    # Drops the now-dead index/mul nodes. Placeholders are impure to fx, so the
+    # operands stay and the argument positions the caller was given hold.
+    graph.eliminate_dead_code()
+    fused.recompile()
+    return fused, contraction

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -16,6 +16,7 @@ from torch._inductor.virtualized import V
 from torch.nn.attention.flex_attention import _Backend
 from torch.utils._sympy.functions import FloorDiv
 
+from ... import config
 from ...ir import ComputedBuffer, ExternKernel, FixedLayout, TensorBox
 from ...lowering import empty, empty_strided, lowerings, register_lowering, to_dtype
 from ...runtime.runtime_utils import is_power_of_2
@@ -29,6 +30,7 @@ from .common import (
     _flex_kernel_options_example,
     _flex_kernel_tuning_options,
     build_subgraph_buffer,
+    build_subgraph_module_buffer,
     can_skip_boundary_checks,
     create_indices_fake,
     create_num_blocks_fake_generator,
@@ -42,6 +44,11 @@ from .common import (
     realize_captures_for_cutedsl,
     set_head_dim_values,
     SubgraphResults,
+)
+from .contraction import (
+    CONTRACTION_INPUT_NAME,
+    NUM_SCORE_MOD_FIXED_ARGS,
+    rewrite_score_mod_for_contraction,
 )
 from .flex_cpu import lower_cpu
 from .flex_decoding import _use_flex_decoding, create_flex_decoding_kernel
@@ -115,6 +122,58 @@ def _check_flash_supported_scalar_captures(
             "Workarounds: use BACKEND='TRITON' or pass the value as a tensor "
             "on device instead of capturing a CPU scalar tensor."
         )
+
+
+def _fuse_score_mod_contraction(
+    subgraph,
+    score_mod_other_buffers,
+    placeholder_inps,
+    query,
+) -> tuple[SubgraphResults, list[TensorBox], dict[str, Any]] | None:
+    """Lift a q-by-kv contraction out of score_mod and into an extra tl.dot.
+
+    Returns the subgraph buffer rebuilt around a tile-valued input, the two
+    operands the template contracts, and the kernel options describing them.
+    None means the score_mod has no contraction we can fuse, in which case the
+    caller keeps the subgraph it already built.
+    """
+    rewritten = rewrite_score_mod_for_contraction(subgraph.graph_module)
+    if rewritten is None:
+        return None
+    fused_graph_module, contraction = rewritten
+
+    q_operand, kv_operand = maybe_realize(
+        [
+            score_mod_other_buffers[arg - NUM_SCORE_MOD_FIXED_ARGS]
+            for arg in (contraction.q_arg, contraction.kv_arg)
+        ]
+    )
+    # tl.dot wants one floating point dtype for both operands, and the two have to
+    # be distinct buffers to arrive as two distinct template arguments.
+    dtype = q_operand.get_dtype()
+    if dtype != kv_operand.get_dtype() or not dtype.is_floating_point:
+        return None
+    if q_operand.get_name() == kv_operand.get_name():
+        return None
+
+    tile = create_placeholder(
+        CONTRACTION_INPUT_NAME, contraction.out_dtype, query.get_device()
+    )
+    subgraph_buffer = build_subgraph_module_buffer(
+        placeholder_inps + list(score_mod_other_buffers) + [tile],
+        fused_graph_module,
+    )
+    freeze_irnodes(subgraph_buffer)
+
+    return (
+        subgraph_buffer,
+        [q_operand, kv_operand],
+        {
+            "HAS_QK_CONTRACTION": True,
+            "CONTRACT_EXTENT": contraction.contract_extent,
+            "CONTRACT_EXTENT_ROUNDED": contraction.contract_extent_rounded,
+        },
+    )
 
 
 @SymbolicGridFn
@@ -250,10 +309,31 @@ def flex_attention(
             ("n", torch.int32),
         ]
     ]
-    subgraph_buffer = build_subgraph_buffer(
-        placeholder_inps + list(score_mod_other_buffers), subgraph
+
+    def build_unfused_score_mod_buffer() -> SubgraphResults:
+        buffer = build_subgraph_buffer(
+            placeholder_inps + list(score_mod_other_buffers), subgraph
+        )
+        freeze_irnodes(buffer)
+        return buffer
+
+    # The contraction has to be lifted out before the subgraph is lowered: as a
+    # reduction it has no pointwise lowering at all, so lowering it is what fails
+    # today. Only the main Triton template has the mod point for it, so the paths
+    # dispatched to below rebuild the original subgraph.
+    contraction_operands: list[TensorBox] = []
+    contraction_options: dict[str, Any] = {}
+    fused = (
+        _fuse_score_mod_contraction(
+            subgraph, score_mod_other_buffers, placeholder_inps, query
+        )
+        if config.flex_fuse_score_mod_contraction
+        else None
     )
-    freeze_irnodes(subgraph_buffer)
+    if fused is not None:
+        subgraph_buffer, contraction_operands, contraction_options = fused
+    else:
+        subgraph_buffer = build_unfused_score_mod_buffer()
 
     mask_graph_placeholder_inps = [
         create_placeholder(name, dtype, query.get_device())
@@ -274,6 +354,9 @@ def flex_attention(
         for k, v in kernel_options.items()
     }
     kernel_options.setdefault("FLOAT32_PRECISION", get_float32_precision())
+    # Only the main Triton forward template can fuse a score_mod contraction, but
+    # the decode template shares the same block body, so define the flag for both.
+    kernel_options.setdefault("HAS_QK_CONTRACTION", False)
     enable_gqa = V.graph.sizevars.evaluate_expr(
         sympy.Ne(query.get_size()[1], key.get_size()[1]),
     )
@@ -290,6 +373,8 @@ def flex_attention(
         )
 
     if use_decode:
+        if contraction_operands:
+            subgraph_buffer = build_unfused_score_mod_buffer()
         return create_flex_decoding_kernel(
             query,
             key,
@@ -338,6 +423,8 @@ def flex_attention(
         num_score_mod_placeholders=len(placeholder_inps),
         backend=backend,
     ):
+        if contraction_operands:
+            subgraph_buffer = build_unfused_score_mod_buffer()
         return create_flex_flash_attention_kernel(
             query,
             key,
@@ -364,6 +451,8 @@ def flex_attention(
 
     freeze_irnodes(score_mod_other_buffers)
     freeze_irnodes(mask_mod_other_buffers)
+
+    kernel_options.update(contraction_options)
 
     Bq, Hq, seq_len_q, qk_head_dim = query.get_size()
     Bkv, Hkv, seq_len_kv, v_head_dim = value.get_size()
@@ -523,6 +612,7 @@ def flex_attention(
                 kv_indices,
                 full_kv_num_blocks,
                 full_kv_indices,
+                *contraction_operands,
             ],
             layout=layout,
             subgraphs=[
@@ -541,26 +631,29 @@ def flex_attention(
 
     # Let the active choices handler append any backend-specific flex-attention
     # template choices (e.g. TLX on Blackwell in fbcode). No-op by default.
-    choices = V.choices.append_flex_attention_choices(
-        choices,
-        configs,
-        [
-            query,
-            key,
-            value,
-            logsumexp,
-            max_scores,
-            kv_num_blocks,
-            kv_indices,
-            full_kv_num_blocks,
-            full_kv_indices,
-        ],
-        [subgraph_buffer, mask_graph_buffer],
-        layout,
-        original_kernel_options,
-        SPARSE_Q_BLOCK_SIZE,
-        SPARSE_KV_BLOCK_SIZE,
-    )
+    # Those templates do not carry the contraction mod point, so a fused
+    # subgraph buffer would not be renderable against them.
+    if not contraction_operands:
+        choices = V.choices.append_flex_attention_choices(
+            choices,
+            configs,
+            [
+                query,
+                key,
+                value,
+                logsumexp,
+                max_scores,
+                kv_num_blocks,
+                kv_indices,
+                full_kv_num_blocks,
+                full_kv_indices,
+            ],
+            [subgraph_buffer, mask_graph_buffer],
+            layout,
+            original_kernel_options,
+            SPARSE_Q_BLOCK_SIZE,
+            SPARSE_KV_BLOCK_SIZE,
+        )
 
     if not choices and invalid_block_options is not None:
         raise_flex_kernel_options_error(
@@ -571,6 +664,8 @@ def flex_attention(
             SPARSE_KV_BLOCK_SIZE,
         )
 
+    # Deduplicated by buffer name downstream, so the contraction operands have to
+    # come in their kernel argument order: template inputs, then captures.
     inputs_for_autotuning = (
         [
             query,
@@ -582,6 +677,7 @@ def flex_attention(
             kv_indices,
             full_kv_num_blocks,
             full_kv_indices,
+            *contraction_operands,
         ]
         + list(score_mod_other_buffers)
         + list(mask_mod_other_buffers)

--- a/torch/_inductor/kernel/flex/templates/common.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/common.py.jinja
@@ -16,6 +16,10 @@ def forward_block_mn(
     # Strides for K and V
     stride_kk, stride_kn, stride_vn, stride_vk,
     IS_FULL_BLOCKS, CHECK_BLOCK_BOUNDARY=False,
+    {%- if HAS_QK_CONTRACTION %}
+    # Operands of a contraction lifted out of score_mod
+    CONTRACT_Q=None, CONTRACT_KV=None,
+    {%- endif %}
 
 ):
     # Redefines all kernel parameters (BLOCK_M, etc.) so we don't need to plumb them all through
@@ -50,6 +54,34 @@ def forward_block_mn(
     m = get_bounded_indices(offs_m, Q_LEN if CHECK_BLOCK_BOUNDARY else None)
     n = get_bounded_indices(offs_n, KV_LEN if CHECK_BLOCK_BOUNDARY else None)
 
+    {%- if HAS_QK_CONTRACTION %}
+    # -- compute a contraction the score_mod asked for over a trailing dim,
+    # dot(CONTRACT_Q[z, h, m, :], CONTRACT_KV[z, h, n, :]), as a tile matmul --
+    stride_cqz, stride_cqh, stride_cqm, stride_cqr = {{stride("CONTRACT_Q")}}
+    stride_ckz, stride_ckh, stride_ckn, stride_ckr = {{stride("CONTRACT_KV")}}
+    offs_r = tl.arange(0, CONTRACT_EXTENT_ROUNDED)
+    offs_cn = kv_base_offset + tl.arange(0, BLOCK_N)
+    # The rounded extent pads with masked-off lanes, which contribute 0 to the dot.
+    r_valid = offs_r[None, :] < CONTRACT_EXTENT
+    cq = tl.load(
+        CONTRACT_Q + off_z * stride_cqz + off_h * stride_cqh
+        + offs_m.to(INDEX_DTYPE) * stride_cqm + offs_r[None, :].to(INDEX_DTYPE) * stride_cqr,
+        mask=r_valid & (offs_m < Q_LEN),
+        other=0.0,
+    )
+    ck = tl.load(
+        CONTRACT_KV + off_z * stride_ckz + off_h * stride_ckh
+        + offs_cn[:, None].to(INDEX_DTYPE) * stride_ckn + offs_r[None, :].to(INDEX_DTYPE) * stride_ckr,
+        mask=r_valid & (offs_cn[:, None] < KV_LEN),
+        other=0.0,
+    )
+    # Not FLOAT32_PRECISION: score_mod spelled this as a reduction, not a matmul,
+    # so float32 operands must not silently lose mantissa bits to tf32.
+    qk_extra = tl.dot(cq, tl.trans(ck), input_precision="ieee")
+    {%- endif %}
+
+    {# qk_extra is only loaded by a score_mod whose contraction was fused, so it
+       costs nothing to hand it to every kernel. #}
     {{ modification(
         subgraph_number=0,
         output_name="post_mod_scores",
@@ -58,9 +90,11 @@ def forward_block_mn(
         h="off_h",
         m="m",
         n="n",
+        qk_extra="qk_extra",
         out="qk",
         input_shapes={
             "score": ("BLOCK_M", "BLOCK_N"),
+            "qk_extra": ("BLOCK_M", "BLOCK_N"),
             "m": ("BLOCK_M", "1"),
             "n": ("1", "BLOCK_N"),
         },
@@ -161,6 +195,10 @@ def forward_inner(
     # Strides for K and V
     stride_kk, stride_kn, stride_vn, stride_vk,
     IS_FULL_BLOCKS,
+    {%- if HAS_QK_CONTRACTION %}
+    # Operands of a contraction lifted out of score_mod
+    CONTRACT_Q=None, CONTRACT_KV=None,
+    {%- endif %}
 ):
     # Redefines all kernel parameters (BLOCK_M, etc.) so we don't need to plumb them all through
     {{gen_defines() | indent_except_first(1)}}
@@ -191,6 +229,9 @@ def forward_inner(
                 # Strides for K and V
                 stride_kk, stride_kn, stride_vn, stride_vk,
                 IS_FULL_BLOCKS,
+                {%- if HAS_QK_CONTRACTION %}
+                CONTRACT_Q=CONTRACT_Q, CONTRACT_KV=CONTRACT_KV,
+                {%- endif %}
             )
         else:
             # Benchmark shows even we applied mod & mask to each block for non divisible seqlen,
@@ -211,6 +252,9 @@ def forward_inner(
                 # Strides for K and V
                 stride_kk, stride_kn, stride_vn, stride_vk,
                 IS_FULL_BLOCKS, CHECK_BLOCK_BOUNDARY=True,
+                {%- if HAS_QK_CONTRACTION %}
+                CONTRACT_Q=CONTRACT_Q, CONTRACT_KV=CONTRACT_KV,
+                {%- endif %}
             )
 
 

--- a/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
@@ -1,4 +1,8 @@
+{%- if HAS_QK_CONTRACTION %}
+{{def_kernel("Q", "K", "V", "LSE", "MAX", "KV_NUM_BLKS", "KV_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX", "CONTRACT_Q", "CONTRACT_KV")}}
+{%- else %}
 {{def_kernel("Q", "K", "V", "LSE", "MAX", "KV_NUM_BLKS", "KV_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX")}}
+{%- endif %}
     # Sub notation for this kernel:
     #
     # Q: Query, K: Key, V: Value
@@ -161,6 +165,9 @@
         MATMUL_PRECISION,
         stride_kk, stride_kn, stride_vn, stride_vk,
         IS_FULL_BLOCKS=False,
+        {%- if HAS_QK_CONTRACTION %}
+        CONTRACT_Q=CONTRACT_Q, CONTRACT_KV=CONTRACT_KV,
+        {%- endif %}
     )
 
     # ~~~~~~~~~~~~~~ "full" blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -187,6 +194,9 @@
             MATMUL_PRECISION,
             stride_kk, stride_kn, stride_vn, stride_vk,
             IS_FULL_BLOCKS=True,
+            {%- if HAS_QK_CONTRACTION %}
+            CONTRACT_Q=CONTRACT_Q, CONTRACT_KV=CONTRACT_KV,
+            {%- endif %}
         )
 
 


### PR DESCRIPTION
### What

An MLA-style `score_mod` contracts a query-indexed vector against a key-indexed one:
```python
score + torch.dot(query_rope[b, h, q_idx], key_rope[b, h, kv_idx])
```
This PR recognizes that term in the `score_mod` subgraph and computes it in the template with one extra `tl.dot` on the score tile, instead of unrolling it into R multiply-adds per score element. Forward only, gated by `torch._inductor.config.flex_fuse_score_mod_contraction` (default on).

### Why

`score_mod` subgraphs are pointwise by construction: the renderer evaluates them at the empty index and all tile-ness comes from Triton broadcasting the inputs, so a reduction must be realized into a buffer, which `PointwiseSubgraphLowering.register_buffer` refuses. Two workarounds exist today, and both are bad:

1. Raise `unroll_reductions_threshold` above R so the dot expands into R pointwise multiply-adds per element of the `[BLOCK_M, BLOCK_N]` tile. This is what `attention-gym`'s MLA example does.
2. Precompute `query_rope @ key_rope.T` into a `[B, H, S, S]` score bias, which costs O(S^2) memory and defeats the point of FlexAttention.

The memory argument needs no stopwatch, and it is the one that matters: the bias is O(S^2) while the operands are O(S*R), so at real MLA context lengths option 2 stops fitting and option 1 is what you are left with. See the memory columns below.

The key point is that this contraction **factorizes**. The `[BLOCK_M, BLOCK_N, R]` intermediate the unrolled form materializes is exactly `A_tile[BLOCK_M, R] @ B_tile[R, BLOCK_N]`, so the template can compute it with one `tl.dot` and never form the rank-3 intermediate - which is how FlashMLA does it. Generic reductions in `score_mod` (#141627) are infeasible as framed (at 128x128x64 the intermediate is a million elements), but this subset is tractable and is the one real workloads want.

Measured on an RTX 3080 (sm_86), B=1 H=8 D=128 R=64 fp16, one fresh process per measurement, median of 5 batches x 20 reps, best over `{default, 64x64, 128x64}` block sizes, with a profiler check that a Triton flex kernel actually ran and a checksum anchor:

| | time S=1024 | time S=4096 | extra memory S=4096 | extra memory S=8192 |
|---|---|---|---|---|
| no rope term at all (floor) | 0.152 ms | 1.420 ms | - | - |
| hoisted `[B, H, S, S]` bias | 0.149 ms | 1.807 ms | 256 MiB | 1 GiB |
| unrolled dot in `score_mod` | 0.649 ms | 9.032 ms | 8 MiB | 16 MiB |
| **fused (this PR)** | **0.150 ms** | **1.79 ms** | **8 MiB (32x less)** | **16 MiB (64x less)** |

The two memory columns are allocation sizes - exact arithmetic, not measurements - and count only what the rope term adds on top of q/k/v. S=8192 was not benchmarked for time; it is in the table because the quadratic-versus-linear divergence is the whole argument. The S=4096 fused time is the median of three separate runs (1.74 / 1.79 / 1.87); run-to-run spread on this box is around 5%, so treat differences smaller than that as noise.

So the fused form is **4.3x faster at S=1024 and 5.0x faster at S=4096** than the unrolled path. Against the hoisted bias it is level on time and uses 32x less extra memory at S=4096, widening to 64x at S=8192. At S=1024 it lands on the no-rope floor - the contraction is essentially free - and at S=4096 it sits about 25% above the floor, because the operand tiles are re-read over a kv loop that is 4x longer.

That last point invites an obvious optimization: the q-side tile is loop invariant, so it could be loaded once in the kernel body and passed into the block loop. I implemented that and measured it as a wash (1.78 / 1.89 against 1.74 / 1.79 / 1.87), presumably trading the reload, which hits cache, for register pressure. So this PR keeps the simpler version with both loads inside the block function.

### Design question

The part I would most like guidance on: **should this be pattern recognition on `score_mod`, or a first-class API?**

This PR recognizes a contraction out of the graph the user already writes, so existing MLA code gets faster with no API change and no `unroll_reductions_threshold` hack. The alternative is to expose an explicit mod point - a `qk_mod` or an MLA-shaped argument - and have the template contract declared operands. That is a bigger change and a user-visible API, but it is honest about what the kernel can do instead of relying on the compiler to spot a shape.

The forward is the shared prefix of either design, which is why it is what this PR contains.

### Scope

Not included, deliberately:

- **The backward, so this does not close #148112.** Learnable rope needs gradients for the captured operands, which arrive as `flex_lib.zeros_and_scatter` calls that are partially indexed with vector payloads - the case that trips `select_algorithm.py`'s scatter store. The joint graph also reaches the Inductor lowering already traced, so a forward-side rewrite cannot touch it. A fused backward needs its own joint-graph pattern (`dqr = ds @ kr_tile`, `dkr = ds^T @ qr_tile`; the math does factorize) plus that scatter fix.
- **Decode.** A decode tile spans several query heads, so the kv-side operand differs per row of the tile and the term is not a single matmul there. Decode shapes keep today's behaviour; there is a test for that.
- Generic reductions in `score_mod`/`mask_mod`, transformed head indices (GQA's `h // n`), more than one contraction per `score_mod`, and a symbolic contracted extent. All bail to today's path. A dynamic sequence length is fine and stays fused; it is only a symbolic *extent* that bails, since the tile shape has to be a compile-time constant, so `dynamic=True` (which marks every dim) turns the fusion off.

One numerics note: the contraction dot uses `input_precision="ieee"` rather than the kernel's `FLOAT32_PRECISION`. `score_mod` spelled this as a reduction, not a matmul, and letting float32 operands fall to tf32 made the output 3.4x and the gradients up to 28x less accurate than the unrolled form.

### Testing

New tests in `test/inductor/test_flex_attention.py`: numerics against the float64 golden for R in {16, 17} x {full, causal} including gradients; fused-versus-unrolled A/B for R in {8, 48, 64, 128} and both spellings of the dot; a codegen check that exactly one extra `tl.dot` appears; five score_mods the detector must reject staying unfused; the `max_autotune` path (the one that materializes benchmark tensors, so it would catch a wrong operand order) with a decoy capture ahead of the two operands; decode shapes falling back; and the backward being unchanged with the flag on.

Verified separately on the same box: 22 shape/dtype combinations against an einsum reference (fp16/bf16/fp32, R from 8 to 128 including non-powers of two, non-divisible sequence lengths, Sq != Skv, GQA, H=1, a sliced-view capture with a nonzero storage offset, and a dynamic sequence length), and byte-identical generated code with the flag on and off for every score_mod the detector rejects.

Not validated locally: sm_86 has 99 KiB of shared memory, so large-R with large blocks (H100 territory) is untested here. Leaving that, and the full flex suites on other backends, to CI.
