### PR TITLE
[CI][CUDA] Fix scipy kstest compatibility with newer SciPy versions

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2328,7 +2328,7 @@ class TestTorchDeviceType(TestCase):
             for to_ in [-4.2, 0, 42]:
                 if to_ > from_:
                     t = torch.empty(size, dtype=dtype, device=device).uniform_(from_, to_)
-                    res = stats.kstest(t.cpu().to(torch.double), 'uniform', args=(from_, (to_ - from_)))
+                    res = stats.kstest(t.cpu().to(torch.double), stats.uniform(from_, (to_ - from_)).cdf)
                     self.assertTrue(res.statistic < 0.1)
 
     @skipIfNoSciPy
@@ -2339,7 +2339,7 @@ class TestTorchDeviceType(TestCase):
         for mean in [-10, 0, 50]:
             for std in [1, 5, 10]:
                 t = torch.empty(size, dtype=dtype, device=device).normal_(mean=mean, std=std)
-                res = stats.kstest(t.cpu().to(torch.double), 'norm', args=(mean, std))
+                res = stats.kstest(t.cpu().to(torch.double), stats.norm(mean, std).cdf)
                 self.assertTrue(res.statistic < 0.1)
 
     @skipIfNoSciPy
@@ -2349,7 +2349,7 @@ class TestTorchDeviceType(TestCase):
         size = 50000
         for std in [0.005, 0.01]:
             t = torch.empty(size, dtype=dtype, device=device).normal_(mean=0, std=std)
-            res = stats.kstest(t.cpu().to(torch.double), 'norm', args=(0, std))
+            res = stats.kstest(t.cpu().to(torch.double), stats.norm(0, std).cdf)
             self.assertTrue(
                 res.statistic < 0.01,
                 msg=lambda msg: f"{msg}\nKS statistic {res.statistic:.4f} for {dtype} std={std}",


### PR DESCRIPTION
Newer SciPy versions (e.g. scipy==1.18.0) broke `stats.kstest(data, 'norm', args=(mean, std))` because the `args` tuple is incorrectly forwarded to internal functions like `ndtr()`, causing `TypeError: ndtr() takes from 1 to 2 positional arguments but 3 were given`. This is a SciPy API change in how string distribution names with `args=` are dispatched internally.

Replace all three string-based kstest calls in test_uniform_kstest, test_normal_kstest, and test_normal_small_std_kstest with frozen distribution `.cdf` methods, which work across all SciPy versions.

Test Plan:

Manually verified that the three affected tests pass on CUDA with float32, float16, and bfloat16 dtypes.

python test/test_torch.py TestTorchDeviceTypeCUDA.test_normal_small_std_kstest_cuda_bfloat16


Co-authored-by: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>

cc @atalman @malfet @ptrblck @tinglvv @eqy @Skylion007 


