### PR TITLE
[PyTorch][profiler] Release GIL while saving Kineto traces (#191699)

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -442,6 +442,49 @@ class TestProfilerITT(TestCase):
 
 @instantiate_parametrized_tests
 class TestProfiler(TestCase):
+    @unittest.skipUnless(IS_LINUX, "FIFO is required")
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_export_chrome_trace_releases_gil(self):
+        with profile(activities=[ProfilerActivity.CPU]) as prof:
+            torch.ones(1) + torch.ones(1)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trace_path = os.path.join(tmpdir, "trace.json")
+            os.mkfifo(trace_path)
+            reader = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys,time; time.sleep(1); open(sys.argv[1], 'rb').read()",
+                    trace_path,
+                ]
+            )
+            started = threading.Event()
+            export_error = []
+
+            def export_trace():
+                started.set()
+                try:
+                    prof.export_chrome_trace(trace_path)
+                except Exception as error:
+                    export_error.append(error)
+
+            export_thread = threading.Thread(target=export_trace)
+            start_time = time.monotonic()
+            export_thread.start()
+            try:
+                self.assertTrue(started.wait(timeout=1))
+                time.sleep(0.1)
+                self.assertLess(time.monotonic() - start_time, 0.5)
+            finally:
+                export_thread.join(timeout=5)
+                if reader.poll() is None:
+                    reader.terminate()
+                reader.wait(timeout=5)
+
+            self.assertFalse(export_thread.is_alive())
+            self.assertEqual(export_error, [])
+
     @unittest.skipIf(
         TEST_WITH_CROSSREF, "crossref intercepts calls and changes the callsite."
     )

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -410,7 +410,10 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .def("events", &ProfilerResult::events)
       .def("experimental_event_tree", &ProfilerResult::event_tree)
 #ifdef USE_KINETO
-      .def("save", &ProfilerResult::save)
+      .def(
+          "save",
+          &ProfilerResult::save,
+          py::call_guard<py::gil_scoped_release>())
       .def(
           "trace_activities",
           [](py::object self) {


### PR DESCRIPTION
Summary:

**Problem**

`_ProfilerResult.save()` holds the Python GIL while Kineto serializes and writes a completed trace. This is a long-running native operation, so holding the GIL prevents unrelated Python threads from progressing without protecting any Python state.

**Solution**

Release the GIL for the duration of `ProfilerResult::save()` with `py::call_guard<py::gil_scoped_release>()`.

This follows existing PyTorch precedent:

- Autograd backward releases the GIL around `PythonEngine::execute()` because the expensive native execution does not require it.
- Profiler `_prepare_profiler` already uses `py::gil_scoped_release` for the same native-operation boundary.
- `ProfilerResult::save()` calls `ActivityTraceWrapper::save()`, which delegates to the native Kineto trace and does not access Python objects.

`save()` remains destructive and one-shot. Concurrent invocation on the same profiler result is outside its documented contract, so this change does not add a mutex or redefine it as a thread-safe API.

The regression test blocks native trace output on a FIFO and verifies that another Python thread continues running. A downstream TorchTNT change uses this capability to serialize Zoomer traces on a worker.

Test Plan:
- `buck2 test fbcode//caffe2/test:profiler -- test_export_chrome_trace_releases_gil --timeout=300`: 1 passed ([TestInfra](https://www.internalfb.com/intern/testinfra/testrun/13792274044911948)).
- `buck2 test fbcode//torchtnt/tests/framework/callbacks/meta:test_zoomer_profiler -- --timeout=300`: 12 passed ([TestInfra](https://www.internalfb.com/intern/testinfra/testrun/3096225071155651)), covering synchronized lifecycle calls, prior-failure behavior, and rejection of async export with `repeat > 1`.
- `buck2 test fbcode//content_understanding/framework/training/callbacks/tests:test_default_callbacks -- --timeout=300`: 14 passed ([TestInfra](https://www.internalfb.com/intern/testinfra/testrun/30117822530501820)).
- Full profiler/callback run: 174 passed and 75 skipped. The existing `test_kineto_profiler_with_environment_variable_cpu` ASAN crash remained the sole failure ([TestInfra](https://www.internalfb.com/intern/testinfra/testrun/17732923721745095)); the same failure reproduces outside this change.
- `arc lint -a`, Citrine lint, `arc pyre check-changed-targets`, and `arc pyre check-owning-targets`: clean.
- Existing matched Train and Predict MAST A/B matrices completed without OOMs or restarts and measured lower profile-boundary stalls.

Differential Revision: D114153717


