### PR TITLE
[cuDNN] Update errata filter for `sm120`

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -682,6 +682,7 @@ bool plan_errata_exception(
   // cuDNN engines 58 and 63 may dispatch to a cuBLASLt kernel that performs
   // illegal memory accesses on sm_120. Engine IDs are cuDNN-version-specific,
   // so restrict this workaround to the affected cuDNN and GPU versions.
+#if CUBLAS_VERSION < 130601
   static auto hardcoded_errata_json_handle_sm120 = nlohmann::json::parse(R"(
             { "version" : 1,
               "rules"   :
@@ -706,6 +707,7 @@ bool plan_errata_exception(
                     }
                 ]
             })");
+#endif
   static auto hardcoded_errata_json_handle_3d = nlohmann::json::parse(R"(
             { "version" : 1,
               "rules"   :
@@ -730,6 +732,7 @@ bool plan_errata_exception(
           })) {
     return true;
   }
+#if CUBLAS_VERSION < 130601
   if (cudnn_frontend::check_errata(
           hardcoded_errata_json_handle_sm120,
           executionPlanTag,
@@ -742,6 +745,7 @@ bool plan_errata_exception(
           })) {
     return true;
   }
+#endif
   if (!has_json && x.dim() > 4) {
     return cudnn_frontend::check_errata(
         hardcoded_errata_json_handle_3d, executionPlanTag, handle, []() {


### PR DESCRIPTION
the problematic cuDNN engines actually call into cuBLAS, and this issue should be fixed in cuBLAS in 13.6.1+

authored with codex

cc @csarofeen @ptrblck @nWEIdia