### PR TITLE
Add nccl4py c10d backend

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -31,6 +31,7 @@ project-excludes = [
   "torch/include/**",
   "torch/csrc/**",
   "torch/distributed/elastic/agent/server/api.py",
+  "torch/distributed/nccl4py_backend.py",
   "torch/testing/_internal/**",
   "torch/distributed/fsdp/fully_sharded_data_parallel.py",
   "torch/ao/quantization/pt2e/_affine_quantization.py",

--- a/test/distributed/test_c10d_nccl4py.py
+++ b/test/distributed/test_c10d_nccl4py.py
@@ -247,6 +247,28 @@ class TestNCCL4PyBackendCollectives(MultiProcessTestCase):
         dist.barrier()
         self._destroy_pg()
 
+    @skip_if_lt_x_gpu(2)
+    def test_allreduce_rejects_noncontiguous(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        t = torch.ones(4, 4, device=device)[::2]
+        with self.assertRaises(ValueError):
+            dist.all_reduce(t)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_send_recv_rejects_noncontiguous(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        t = torch.ones(4, 4, device=device)[::2]
+        if self.rank == 0:
+            with self.assertRaises(ValueError):
+                dist.send(t, dst=1)
+        elif self.rank == 1:
+            with self.assertRaises(ValueError):
+                dist.recv(t, src=0)
+        self._destroy_pg()
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_c10d_nccl4py.py
+++ b/test/distributed/test_c10d_nccl4py.py
@@ -1,0 +1,252 @@
+# Owner(s): ["oncall: distributed"]
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+try:
+    import nccl.core  # noqa: F401
+
+    from torch.distributed.nccl4py_backend import (
+        _create_nccl4py_backend,
+        NCCL4PyBackend,
+    )
+
+    HAS_NCCL4PY = True
+except ImportError:
+    HAS_NCCL4PY = False
+
+HAS_CUDA = torch.cuda.is_available()
+
+
+def skip_unless_nccl4py(func):
+    return unittest.skipUnless(HAS_NCCL4PY and HAS_CUDA, "nccl4py and CUDA required")(
+        func
+    )
+
+
+@skip_unless_nccl4py
+class TestNCCL4PyBackendUnit(TestCase):
+    """Single-process smoke tests (no real NCCL communication)."""
+
+    def test_registration(self):
+        dist.Backend.register_backend(
+            "nccl4py_test", _create_nccl4py_backend, devices=["cuda"]
+        )
+        self.assertIn("nccl4py_test", dist.Backend.backend_list)
+
+    def test_backend_name(self):
+        store = dist.HashStore()
+        backend = NCCL4PyBackend(
+            store, 0, 1, timeout=torch.distributed.default_pg_timeout
+        )
+        self.assertEqual(backend.name(), "nccl4py")
+        self.assertEqual(backend.rank(), 0)
+        self.assertEqual(backend.size(), 1)
+        self.assertTrue(backend.supports_splitting)
+        self.assertEqual(backend.options.backend, "nccl4py")
+        backend.shutdown()
+
+
+@skip_unless_nccl4py
+class TestNCCL4PyBackendCollectives(MultiProcessTestCase):
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self):
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    @property
+    def world_size(self):
+        return 2
+
+    def _init_pg(self):
+        dist.Backend.register_backend(
+            "nccl4py", _create_nccl4py_backend, devices=["cuda"]
+        )
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            "nccl4py", store=store, rank=self.rank, world_size=self.world_size
+        )
+
+    def _destroy_pg(self):
+        dist.destroy_process_group()
+
+    @skip_if_lt_x_gpu(2)
+    def test_allreduce(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        t = torch.ones(4, device=device) * (self.rank + 1)
+        dist.all_reduce(t)
+        # SUM of [1,1,1,1] and [2,2,2,2] = [3,3,3,3]
+        expected = torch.full((4,), 3.0, device=device)
+        torch.cuda.synchronize(device)
+        self.assertEqual(t, expected)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_allreduce_async(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        t = torch.ones(4, device=device) * (self.rank + 1)
+        work = dist.all_reduce(t, async_op=True)
+        self.assertIsNotNone(work)
+        work.wait()
+        expected = torch.full((4,), 3.0, device=device)
+        torch.cuda.synchronize(device)
+        self.assertEqual(t, expected)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_broadcast(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        t = torch.ones(4, device=device) * (self.rank + 1)
+        dist.broadcast(t, src=0)
+        expected = torch.ones(4, device=device)
+        torch.cuda.synchronize(device)
+        self.assertEqual(t, expected)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_reduce(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        t = torch.ones(4, device=device) * (self.rank + 1)
+        dist.reduce(t, dst=0)
+        torch.cuda.synchronize(device)
+        if self.rank == 0:
+            expected = torch.full((4,), 3.0, device=device)
+            self.assertEqual(t, expected)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_allgather(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        inp = torch.ones(4, device=device) * (self.rank + 1)
+        out = [torch.zeros(4, device=device) for _ in range(self.world_size)]
+        dist.all_gather(out, inp)
+        torch.cuda.synchronize(device)
+        self.assertEqual(out[0], torch.ones(4, device=device))
+        self.assertEqual(out[1], torch.full((4,), 2.0, device=device))
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_all_gather_into_tensor(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        inp = torch.ones(4, device=device) * (self.rank + 1)
+        out = torch.zeros(8, device=device)
+        dist.all_gather_into_tensor(out, inp)
+        torch.cuda.synchronize(device)
+        expected = torch.cat(
+            [torch.ones(4, device=device), torch.full((4,), 2.0, device=device)]
+        )
+        self.assertEqual(out, expected)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_reduce_scatter_tensor(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        inp = torch.ones(8, device=device) * (self.rank + 1)
+        out = torch.zeros(4, device=device)
+        dist.reduce_scatter_tensor(out, inp)
+        torch.cuda.synchronize(device)
+        # SUM: each rank gets chunk of (1+2)=3
+        expected = torch.full((4,), 3.0, device=device)
+        self.assertEqual(out, expected)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_scatter(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        out = torch.zeros(4, device=device)
+        if self.rank == 0:
+            inp = [
+                torch.ones(4, device=device),
+                torch.full((4,), 2.0, device=device),
+            ]
+            dist.scatter(out, inp, src=0)
+        else:
+            dist.scatter(out, src=0)
+        torch.cuda.synchronize(device)
+        expected = torch.full((4,), float(self.rank + 1), device=device)
+        self.assertEqual(out, expected)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_gather(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        inp = torch.ones(4, device=device) * (self.rank + 1)
+        if self.rank == 0:
+            out = [torch.zeros(4, device=device) for _ in range(self.world_size)]
+            dist.gather(inp, out, dst=0)
+        else:
+            dist.gather(inp, dst=0)
+        torch.cuda.synchronize(device)
+        if self.rank == 0:
+            self.assertEqual(out[0], torch.ones(4, device=device))
+            self.assertEqual(out[1], torch.full((4,), 2.0, device=device))
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_all_to_all_single(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        inp = torch.ones(8, device=device) * (self.rank + 1)
+        out = torch.zeros(8, device=device)
+        dist.all_to_all_single(out, inp)
+        torch.cuda.synchronize(device)
+        expected = torch.cat(
+            [torch.ones(4, device=device), torch.full((4,), 2.0, device=device)]
+        )
+        self.assertEqual(out, expected)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_send_recv(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        peer = (self.rank + 1) % self.world_size
+        send_t = torch.ones(4, device=device) * (self.rank + 1)
+        recv_t = torch.zeros(4, device=device)
+
+        works = dist.batch_isend_irecv(
+            [
+                dist.P2POp(dist.isend, send_t, peer),
+                dist.P2POp(dist.irecv, recv_t, peer),
+            ]
+        )
+        for w in works:
+            w.wait()
+        torch.cuda.synchronize(device)
+        expected = torch.full((4,), float(peer + 1), device=device)
+        self.assertEqual(recv_t, expected)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_barrier(self):
+        self._init_pg()
+        dist.barrier()
+        self._destroy_pg()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/test_c10d_nccl4py.py
+++ b/test/distributed/test_c10d_nccl4py.py
@@ -248,6 +248,103 @@ class TestNCCL4PyBackendCollectives(MultiProcessTestCase):
         self._destroy_pg()
 
     @skip_if_lt_x_gpu(2)
+    def test_alltoall(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        inp = [
+            torch.full((4,), float(self.rank + 1), device=device)
+            for _ in range(self.world_size)
+        ]
+        out = [torch.zeros(4, device=device) for _ in range(self.world_size)]
+        dist.all_to_all(out, inp)
+        torch.cuda.synchronize(device)
+        for i in range(self.world_size):
+            self.assertEqual(out[i], torch.full((4,), float(i + 1), device=device))
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_reduce_scatter(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        inp = [
+            torch.ones(4, device=device) * (self.rank + 1)
+            for _ in range(self.world_size)
+        ]
+        out = torch.zeros(4, device=device)
+        dist.reduce_scatter(out, inp)
+        torch.cuda.synchronize(device)
+        expected = torch.full((4,), 3.0, device=device)
+        self.assertEqual(out, expected)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_all_to_all_single_uneven(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        if self.rank == 0:
+            inp = torch.tensor([1.0, 2.0, 3.0], device=device)
+            out = torch.zeros(2, device=device)
+            in_splits = [1, 2]
+            out_splits = [1, 1]
+        else:
+            inp = torch.tensor([4.0, 5.0, 6.0], device=device)
+            out = torch.zeros(4, device=device)
+            in_splits = [1, 2]
+            out_splits = [2, 2]
+        dist.all_to_all_single(out, inp, out_splits, in_splits)
+        torch.cuda.synchronize(device)
+        if self.rank == 0:
+            self.assertEqual(out, torch.tensor([1.0, 4.0], device=device))
+        else:
+            self.assertEqual(out, torch.tensor([2.0, 3.0, 5.0, 6.0], device=device))
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_coalescing(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        pg = dist.distributed_c10d._get_default_group()
+        backend = pg._get_backend(torch.device(device))
+        t1 = torch.ones(4, device=device) * (self.rank + 1)
+        t2 = torch.ones(4, device=device) * (self.rank + 1) * 10
+        backend.start_coalescing()
+        backend.allreduce([t1], dist.AllreduceOptions())
+        backend.allreduce([t2], dist.AllreduceOptions())
+        work = backend.end_coalescing()
+        work.wait()
+        torch.cuda.synchronize(device)
+        self.assertEqual(t1, torch.full((4,), 3.0, device=device))
+        self.assertEqual(t2, torch.full((4,), 30.0, device=device))
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_split(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        # Create a subgroup containing only rank 0
+        subgroup = dist.new_group([0])
+        if self.rank == 0:
+            t = torch.ones(4, device=device) * 42.0
+            dist.all_reduce(t, group=subgroup)
+            torch.cuda.synchronize(device)
+            self.assertEqual(t, torch.full((4,), 42.0, device=device))
+        dist.barrier()
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
+    def test_get_future(self):
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        t = torch.ones(4, device=device) * (self.rank + 1)
+        work = dist.all_reduce(t, async_op=True)
+        fut = work.get_future()
+        fut.wait()
+        torch.cuda.synchronize(device)
+        expected = torch.full((4,), 3.0, device=device)
+        self.assertEqual(t, expected)
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
     def test_allreduce_rejects_noncontiguous(self):
         self._init_pg()
         device = torch.device(f"cuda:{self.rank}")

--- a/torch/distributed/_watchdog.py
+++ b/torch/distributed/_watchdog.py
@@ -66,6 +66,7 @@ __all__ = [
     "init",
     "shutdown",
     "stream_timeout",
+    "stream_complete",
     "cpu_timeout",
     "op_timeout",
 ]
@@ -81,6 +82,7 @@ class _StreamMonitor:
     event: object  # torch.cuda.Event
     deadline: float
     callback: Callable[[], None]
+    on_complete: Callable[[], None] | None = None
     cancelled: bool = False
     monitor_id: int = field(default=0, init=False)
 
@@ -190,6 +192,23 @@ class _Watchdog:
         asyncio.set_event_loop(self._loop)
         self._loop.run_forever()
 
+    def stream_complete(
+        self, callback: Callable[[], None], event: object | None = None
+    ) -> _CancelHandle:
+        self._drain_del_queue()
+        handle = _CancelHandle()
+        if event is None:
+            event = torch.cuda.Event(enable_timing=False)
+            event.record()
+        monitor = _StreamMonitor(
+            event=event,
+            deadline=float("inf"),
+            callback=lambda: None,
+            on_complete=callback,
+        )
+        self._loop.call_soon_threadsafe(self._add_monitor, monitor, handle)
+        return handle
+
     def stream_timeout(
         self, timeout: float | timedelta, callback: Callable[[], None] | None = None
     ) -> _CancelHandle:
@@ -239,6 +258,13 @@ class _Watchdog:
                 pass
 
             if completed:
+                if monitor.on_complete is not None:
+                    try:
+                        monitor.on_complete()
+                    except Exception:
+                        logger.exception(
+                            "Exception in stream completion callback (id=%d)", mid
+                        )
                 to_remove.append(mid)
                 continue
 
@@ -410,6 +436,26 @@ def init(
         )
     if old is not None:
         old.shutdown()
+
+
+def stream_complete(
+    callback: Callable[[], None], event: object | None = None
+) -> _CancelHandle:
+    """Poll a CUDA event and fire callback when the stream work completes.
+
+    Args:
+        callback: Called when the CUDA event completes.
+        event: An already-recorded ``torch.cuda.Event``. If ``None``, a new
+            event is recorded on the current stream.
+
+    Example::
+
+        some_kernel_launch()
+        handle = stream_complete(lambda: fut.set_result(True))
+        # callback fires once the kernel finishes (detected by polling)
+        # handle.cancel() to suppress the callback
+    """
+    return _get_watchdog().stream_complete(callback, event)
 
 
 def stream_timeout(

--- a/torch/distributed/nccl4py_backend.py
+++ b/torch/distributed/nccl4py_backend.py
@@ -35,16 +35,19 @@ class _NcclWork(dist._Work):
     of ProcessGroupNCCL(nccl2)'s coalesceWorks)
     """
 
-    def __init__(self, events, device, wd_handles=None):
+    def __init__(self, events, device, wd_handles=None, is_barrier=False):
         super().__init__()
         self._events = list(events)
         self._device = device
         self._wd_handles = list(wd_handles) if wd_handles else []
+        self._is_barrier = is_barrier
 
     def wait(self, timeout=None):
         current = torch.cuda.current_stream(self._device)
         for event in self._events:
             event.wait(current)
+        if self._is_barrier:
+            current.synchronize()
         self._events = []
         for handle in self._wd_handles:
             handle.cancel()
@@ -144,7 +147,7 @@ class NCCL4PyBackend(C10DBackend):
         for t in tensors:
             t.record_stream(stream)
 
-    def _make_work(self, *streams):
+    def _make_work(self, *streams, is_barrier=False):
         # Inside a coalescing window the kernels are only enqueued at group_end,
         # so a per-op event here would be meaningless. Just record which streams
         # the op used; end_coalescing records the events after group_end.
@@ -159,7 +162,7 @@ class NCCL4PyBackend(C10DBackend):
             with torch.cuda.stream(stream):
                 wd_handles.append(stream_timeout(self._options._timeout))
             events.append(event)
-        return _NcclWork(events, self._device, wd_handles)
+        return _NcclWork(events, self._device, wd_handles, is_barrier=is_barrier)
 
     def _get_nccl_redop(self, reduce_op, tensor):
         """Returns (nccl_op, custom_op_or_None).
@@ -425,7 +428,7 @@ class NCCL4PyBackend(C10DBackend):
         self._comm.allreduce(
             self._barrier_tensor, self._barrier_tensor, nccl.SUM, stream=s
         )
-        return self._make_work(stream)
+        return self._make_work(stream, is_barrier=True)
 
     def split(self, store, ranks, opts):
         ranks_list = list(ranks)

--- a/torch/distributed/nccl4py_backend.py
+++ b/torch/distributed/nccl4py_backend.py
@@ -133,6 +133,17 @@ class NCCL4PyBackend(C10DBackend):
             return self._internal_stream
         return torch.cuda.current_stream(self._device)
 
+    def _record_stream(self, stream, *tensors):
+        # User tensors and temp buffers are allocated on the compute stream but
+        # consumed on the internal NCCL stream; recording the NCCL stream keeps
+        # the caching allocator from reusing those blocks before the collective
+        # finishes. Mirrors CUDACachingAllocator::recordStream in
+        # ProcessGroupNCCL.
+        if stream == torch.cuda.current_stream(self._device):
+            return
+        for t in tensors:
+            t.record_stream(stream)
+
     def _make_work(self, *streams):
         # Inside a coalescing window the kernels are only enqueued at group_end,
         # so a per-op event here would be meaningless. Just record which streams
@@ -214,6 +225,7 @@ class NCCL4PyBackend(C10DBackend):
         self._check_tensors(tensor_list)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
+        self._record_stream(stream, *tensor_list)
         with nccl.group():
             for t in tensor_list:
                 self._comm.broadcast(t, t, opts.rootRank, stream=s)
@@ -224,6 +236,7 @@ class NCCL4PyBackend(C10DBackend):
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         nccl_op, custom = self._get_nccl_redop(opts.reduceOp, tensor_list[0])
+        self._record_stream(stream, *tensor_list)
         try:
             with nccl.group():
                 for t in tensor_list:
@@ -238,6 +251,7 @@ class NCCL4PyBackend(C10DBackend):
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         nccl_op, custom = self._get_nccl_redop(opts.reduceOp, tensor_list[0])
+        self._record_stream(stream, *tensor_list)
         try:
             with nccl.group():
                 for t in tensor_list:
@@ -251,6 +265,7 @@ class NCCL4PyBackend(C10DBackend):
         self._check_tensors(input_tensors)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
+        self._record_stream(stream, *input_tensors)
         flats = []
         with nccl.group():
             for output_list, inp in zip(output_tensors, input_tensors):
@@ -259,10 +274,12 @@ class NCCL4PyBackend(C10DBackend):
                     dtype=inp.dtype,
                     device=self._device,
                 )
+                self._record_stream(stream, flat)
                 self._comm.allgather(inp, flat, stream=s)
                 flats.append((flat, output_list, inp.numel()))
         with torch.cuda.stream(stream):
             for flat, output_list, chunk in flats:
+                self._record_stream(stream, *output_list)
                 for i, out in enumerate(output_list):
                     out.copy_(flat.narrow(0, i * chunk, chunk).view_as(out))
         return self._make_work(stream)
@@ -271,6 +288,7 @@ class NCCL4PyBackend(C10DBackend):
         self._check_tensor(output)
         self._check_tensor(input)
         stream = self._op_stream(opts.asyncOp)
+        self._record_stream(stream, input, output)
         self._comm.allgather(input, output, stream=stream.cuda_stream)
         return self._make_work(stream)
 
@@ -279,6 +297,7 @@ class NCCL4PyBackend(C10DBackend):
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         root = opts.rootRank
+        self._record_stream(stream, *input_tensors)
         flats = []
         with nccl.group():
             for idx, inp in enumerate(input_tensors):
@@ -288,6 +307,7 @@ class NCCL4PyBackend(C10DBackend):
                         dtype=inp.dtype,
                         device=self._device,
                     )
+                    self._record_stream(stream, flat)
                     self._comm.gather(inp, flat, root=root, stream=s)
                     flats.append((flat, output_tensors[idx], inp.numel()))
                 else:
@@ -295,6 +315,7 @@ class NCCL4PyBackend(C10DBackend):
         if self.rank() == root:
             with torch.cuda.stream(stream):
                 for flat, output_list, chunk in flats:
+                    self._record_stream(stream, *output_list)
                     for i, out in enumerate(output_list):
                         out.copy_(flat.narrow(0, i * chunk, chunk).view_as(out))
         return self._make_work(stream)
@@ -304,10 +325,12 @@ class NCCL4PyBackend(C10DBackend):
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         root = opts.rootRank
+        self._record_stream(stream, *output_tensors)
         with torch.cuda.stream(stream):
             with nccl.group():
                 for idx, out in enumerate(output_tensors):
                     if self.rank() == root:
+                        self._record_stream(stream, *input_tensors[idx])
                         flat = torch.cat(
                             [t.contiguous().view(-1) for t in input_tensors[idx]]
                         )
@@ -321,10 +344,12 @@ class NCCL4PyBackend(C10DBackend):
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         nccl_op, custom = self._get_nccl_redop(opts.reduceOp, output_tensors[0])
+        self._record_stream(stream, *output_tensors)
         try:
             with torch.cuda.stream(stream):
                 with nccl.group():
                     for out, inp_list in zip(output_tensors, input_tensors):
+                        self._record_stream(stream, *inp_list)
                         flat = torch.cat([t.contiguous().view(-1) for t in inp_list])
                         self._comm.reduce_scatter(flat, out, nccl_op, stream=s)
         finally:
@@ -338,6 +363,7 @@ class NCCL4PyBackend(C10DBackend):
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         nccl_op, custom = self._get_nccl_redop(opts.reduceOp, output)
+        self._record_stream(stream, input, output)
         try:
             self._comm.reduce_scatter(input, output, nccl_op, stream=s)
         finally:
@@ -352,6 +378,7 @@ class NCCL4PyBackend(C10DBackend):
         self._check_tensor(input)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
+        self._record_stream(stream, input, output)
         if not output_split_sizes and not input_split_sizes:
             self._comm.alltoall(input, output, stream=s)
         else:
@@ -383,6 +410,7 @@ class NCCL4PyBackend(C10DBackend):
         self._check_tensors(input_tensors)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
+        self._record_stream(stream, *input_tensors, *output_tensors)
         with nccl.group():
             for i in range(self.size()):
                 self._comm.send(input_tensors[i], i, stream=s)

--- a/torch/distributed/nccl4py_backend.py
+++ b/torch/distributed/nccl4py_backend.py
@@ -28,30 +28,43 @@ except ModuleNotFoundError:
 
 
 class _NcclWork(dist._Work):
-    """Work handle backed by a CUDA event recorded after the NCCL operation."""
+    """Work handle backed by CUDA events recorded after the NCCL operation(s).
 
-    def __init__(self, event, device, wd_handle=None):
+    A single collective records one event. A coalesced window records one event
+    per distinct stream it ran on, and waiting joins all of them (the analog
+    of ProcessGroupNCCL(nccl2)'s coalesceWorks)
+    """
+
+    def __init__(self, events, device, wd_handles=None):
         super().__init__()
-        self._event = event
+        self._events = list(events)
         self._device = device
-        self._wd_handle = wd_handle
+        self._wd_handles = list(wd_handles) if wd_handles else []
 
     def wait(self, timeout=None):
-        if self._event is not None:
-            current = torch.cuda.current_stream(self._device)
-            self._event.wait(current)
-            self._event = None
-        if self._wd_handle is not None:
-            self._wd_handle.cancel()
-            self._wd_handle = None
+        current = torch.cuda.current_stream(self._device)
+        for event in self._events:
+            event.wait(current)
+        self._events = []
+        for handle in self._wd_handles:
+            handle.cancel()
+        self._wd_handles = []
         return True
 
     def get_future(self):
         fut = torch.futures.Future(devices=[self._device])
-        if self._event is not None:
-            stream_complete(lambda: fut.set_result(True), event=self._event)
-        else:
+        if not self._events:
             fut.set_result(True)
+            return fut
+        remaining = [len(self._events)]
+
+        def on_complete():
+            remaining[0] -= 1
+            if remaining[0] == 0:
+                fut.set_result(True)
+
+        for event in self._events:
+            stream_complete(on_complete, event=event)
         return fut
 
 
@@ -84,6 +97,8 @@ class NCCL4PyBackend(C10DBackend):
         self._comm = nccl.Communicator.init(nranks=size, rank=rank, unique_id=uid)
         self._internal_stream = torch.cuda.Stream(device=self._device)
         self._barrier_tensor = torch.zeros(1, dtype=torch.float32, device=self._device)
+        self._coalescing = False
+        self._coalesced_streams = set()
         _get_watchdog()
 
     @property
@@ -118,12 +133,22 @@ class NCCL4PyBackend(C10DBackend):
             return self._internal_stream
         return torch.cuda.current_stream(self._device)
 
-    def _make_work(self, stream):
-        event = torch.cuda.Event()
-        event.record(stream)
-        with torch.cuda.stream(stream):
-            wd_handle = stream_timeout(self._options._timeout)
-        return _NcclWork(event, self._device, wd_handle)
+    def _make_work(self, *streams):
+        # Inside a coalescing window the kernels are only enqueued at group_end,
+        # so a per-op event here would be meaningless. Just record which streams
+        # the op used; end_coalescing records the events after group_end.
+        if self._coalescing:
+            self._coalesced_streams.update(streams)
+            return _NcclWork((), self._device)
+        events = []
+        wd_handles = []
+        for stream in streams:
+            event = torch.cuda.Event()
+            event.record(stream)
+            with torch.cuda.stream(stream):
+                wd_handles.append(stream_timeout(self._options._timeout))
+            events.append(event)
+        return _NcclWork(events, self._device, wd_handles)
 
     def _get_nccl_redop(self, reduce_op, tensor):
         """Returns (nccl_op, custom_op_or_None).
@@ -154,12 +179,18 @@ class NCCL4PyBackend(C10DBackend):
         raise RuntimeError(f"nccl4py backend: unsupported reduce op {reduce_op}")
 
     def start_coalescing(self):
+        self._coalescing = True
+        self._coalesced_streams = set()
         nccl.group_start()
 
     def end_coalescing(self):
         nccl.group_end()
-        stream = torch.cuda.current_stream(self._device)
-        return self._make_work(stream)
+        self._coalescing = False
+        streams = self._coalesced_streams
+        self._coalesced_streams = set()
+        if not streams:
+            streams = {torch.cuda.current_stream(self._device)}
+        return self._make_work(*streams)
 
     def send(self, tensor_list, dst, tag=0):
         self._check_tensors(tensor_list)
@@ -390,6 +421,8 @@ class NCCL4PyBackend(C10DBackend):
         child._comm = new_comm
         child._internal_stream = torch.cuda.Stream(device=self._device)
         child._barrier_tensor = torch.zeros(1, dtype=torch.float32, device=self._device)
+        child._coalescing = False
+        child._coalescing_stream = None
         return child
 
     def shutdown(self):

--- a/torch/distributed/nccl4py_backend.py
+++ b/torch/distributed/nccl4py_backend.py
@@ -75,6 +75,7 @@ class NCCL4PyBackend(C10DBackend):
 
         self._comm = nccl.Communicator.init(nranks=size, rank=rank, unique_id=uid)
         self._internal_stream = torch.cuda.Stream(device=self._device)
+        self._barrier_tensor = torch.zeros(1, dtype=torch.float32, device=self._device)
 
     @property
     def options(self):
@@ -349,9 +350,10 @@ class NCCL4PyBackend(C10DBackend):
     def barrier(self, opts):
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
-        with torch.cuda.stream(stream):
-            scratch = torch.zeros(1, dtype=torch.float32, device=self._device)
-        self._comm.allreduce(scratch, scratch, nccl.SUM, stream=s)
+        self._barrier_tensor.zero_()
+        self._comm.allreduce(
+            self._barrier_tensor, self._barrier_tensor, nccl.SUM, stream=s
+        )
         return self._make_work(stream)
 
     def split(self, store, ranks, opts):
@@ -375,6 +377,7 @@ class NCCL4PyBackend(C10DBackend):
         child._device = self._device
         child._comm = new_comm
         child._internal_stream = torch.cuda.Stream(device=self._device)
+        child._barrier_tensor = torch.zeros(1, dtype=torch.float32, device=self._device)
         return child
 
     def shutdown(self):

--- a/torch/distributed/nccl4py_backend.py
+++ b/torch/distributed/nccl4py_backend.py
@@ -91,6 +91,16 @@ class NCCL4PyBackend(C10DBackend):
     def getBackendName(self):
         return "nccl4py"
 
+    def _check_tensor(self, tensor):
+        if not tensor.is_cuda:
+            raise ValueError(f"nccl4py: expected CUDA tensor, got {tensor.device}")
+        if not tensor.is_contiguous():
+            raise ValueError("nccl4py: expected contiguous tensor")
+
+    def _check_tensors(self, tensors):
+        for t in tensors:
+            self._check_tensor(t)
+
     def _op_stream(self, async_op):
         if async_op:
             current = torch.cuda.current_stream(self._device)
@@ -140,6 +150,7 @@ class NCCL4PyBackend(C10DBackend):
         return self._make_work(stream)
 
     def send(self, tensor_list, dst, tag=0):
+        self._check_tensors(tensor_list)
         stream = torch.cuda.current_stream(self._device)
         s = stream.cuda_stream
         with nccl.group():
@@ -148,6 +159,7 @@ class NCCL4PyBackend(C10DBackend):
         return self._make_work(stream)
 
     def recv(self, tensor_list, src, tag=0):
+        self._check_tensors(tensor_list)
         stream = torch.cuda.current_stream(self._device)
         s = stream.cuda_stream
         with nccl.group():
@@ -156,6 +168,7 @@ class NCCL4PyBackend(C10DBackend):
         return self._make_work(stream)
 
     def broadcast(self, tensor_list, opts):
+        self._check_tensors(tensor_list)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         with nccl.group():
@@ -164,6 +177,7 @@ class NCCL4PyBackend(C10DBackend):
         return self._make_work(stream)
 
     def allreduce(self, tensor_list, opts):
+        self._check_tensors(tensor_list)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         nccl_op, custom = self._get_nccl_redop(opts.reduceOp, tensor_list[0])
@@ -177,6 +191,7 @@ class NCCL4PyBackend(C10DBackend):
         return self._make_work(stream)
 
     def reduce(self, tensor_list, opts):
+        self._check_tensors(tensor_list)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         nccl_op, custom = self._get_nccl_redop(opts.reduceOp, tensor_list[0])
@@ -190,6 +205,7 @@ class NCCL4PyBackend(C10DBackend):
         return self._make_work(stream)
 
     def allgather(self, output_tensors, input_tensors, opts):
+        self._check_tensors(input_tensors)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         flats = []
@@ -209,11 +225,14 @@ class NCCL4PyBackend(C10DBackend):
         return self._make_work(stream)
 
     def all_gather_single(self, output, input, opts):
+        self._check_tensor(output)
+        self._check_tensor(input)
         stream = self._op_stream(opts.asyncOp)
         self._comm.allgather(input, output, stream=stream.cuda_stream)
         return self._make_work(stream)
 
     def gather(self, output_tensors, input_tensors, opts):
+        self._check_tensors(input_tensors)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         root = opts.rootRank
@@ -238,6 +257,7 @@ class NCCL4PyBackend(C10DBackend):
         return self._make_work(stream)
 
     def scatter(self, output_tensors, input_tensors, opts):
+        self._check_tensors(output_tensors)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         root = opts.rootRank
@@ -254,6 +274,7 @@ class NCCL4PyBackend(C10DBackend):
         return self._make_work(stream)
 
     def reduce_scatter(self, output_tensors, input_tensors, opts):
+        self._check_tensors(output_tensors)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         nccl_op, custom = self._get_nccl_redop(opts.reduceOp, output_tensors[0])
@@ -269,6 +290,8 @@ class NCCL4PyBackend(C10DBackend):
         return self._make_work(stream)
 
     def reduce_scatter_single(self, output, input, opts):
+        self._check_tensor(output)
+        self._check_tensor(input)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         nccl_op, custom = self._get_nccl_redop(opts.reduceOp, output)
@@ -282,6 +305,8 @@ class NCCL4PyBackend(C10DBackend):
     def all_to_all_single(
         self, output, input, output_split_sizes, input_split_sizes, opts
     ):
+        self._check_tensor(output)
+        self._check_tensor(input)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         if not output_split_sizes and not input_split_sizes:
@@ -311,6 +336,8 @@ class NCCL4PyBackend(C10DBackend):
         return self._make_work(stream)
 
     def alltoall(self, output_tensors, input_tensors, opts):
+        self._check_tensors(output_tensors)
+        self._check_tensors(input_tensors)
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
         with nccl.group():

--- a/torch/distributed/nccl4py_backend.py
+++ b/torch/distributed/nccl4py_backend.py
@@ -13,6 +13,8 @@ Or use
 
 # pyre-unsafe
 
+__all__ = ["NCCL4PyBackend"]
+
 import torch
 import torch.distributed as dist
 from torch._C._distributed_c10d import Backend as C10DBackend, ReduceOp

--- a/torch/distributed/nccl4py_backend.py
+++ b/torch/distributed/nccl4py_backend.py
@@ -11,11 +11,17 @@ Or use
     dist.init_process_group("nccl4py", ...)
 """
 
-import nccl.core as nccl  # pyrefly: ignore [missing-import]
+# pyre-unsafe
 
 import torch
 import torch.distributed as dist
 from torch._C._distributed_c10d import Backend as C10DBackend, ReduceOp
+
+
+try:
+    import nccl.core as nccl
+except ModuleNotFoundError:
+    nccl = None  # type: ignore[assignment]
 
 
 class _NcclWork(dist._Work):
@@ -45,6 +51,11 @@ class NCCL4PyBackend(C10DBackend):
     _UID_STORE_KEY = "nccl4py_uid"
 
     def __init__(self, store, rank, size, timeout):
+        if nccl is None:
+            raise RuntimeError(
+                "nccl4py backend requires the 'nccl4py' package. "
+                "Install it with: pip install nccl4py"
+            )
         super().__init__(rank, size)
         self._store = store
         self._options = C10DBackend.Options("nccl4py", timeout=timeout)
@@ -96,17 +107,16 @@ class NCCL4PyBackend(C10DBackend):
         The caller must close custom_op after the NCCL call is enqueued.
         """
         op_type = reduce_op.op
-        if op_type == ReduceOp.RedOpType.SUM:  # pyrefly: ignore [missing-attribute]
+        if op_type == ReduceOp.RedOpType.SUM:
             return nccl.SUM, None
-        if op_type == ReduceOp.RedOpType.PRODUCT:  # pyrefly: ignore [missing-attribute]
+        if op_type == ReduceOp.RedOpType.PRODUCT:
             return nccl.PROD, None
-        if op_type == ReduceOp.RedOpType.MIN:  # pyrefly: ignore [missing-attribute]
+        if op_type == ReduceOp.RedOpType.MIN:
             return nccl.MIN, None
-        if op_type == ReduceOp.RedOpType.MAX:  # pyrefly: ignore [missing-attribute]
+        if op_type == ReduceOp.RedOpType.MAX:
             return nccl.MAX, None
-        if op_type == ReduceOp.RedOpType.AVG:  # pyrefly: ignore [missing-attribute]
+        if op_type == ReduceOp.RedOpType.AVG:
             return nccl.AVG, None
-        # pyrefly: ignore [missing-attribute]
         if op_type == ReduceOp.RedOpType.PREMUL_SUM:
             factor = reduce_op.factor
             if isinstance(factor, torch.Tensor):

--- a/torch/distributed/nccl4py_backend.py
+++ b/torch/distributed/nccl4py_backend.py
@@ -1,0 +1,363 @@
+"""Pure Python c10d backend implemented on top of nccl4py (nccl.core)
+
+Wraps NVIDIA's official nccl4py bindings to provide a Python NCCL backend for
+torch.distributed. Uses the PyBackend trampoline so that ProcessGroup dispatches
+collective calls into Python overrides in this class.
+
+Register with
+    dist.Backend.register_backend("nccl4py", _create_nccl4py_backend, devices=["cuda"])
+
+Or use
+    dist.init_process_group("nccl4py", ...)
+"""
+
+import nccl.core as nccl
+
+import torch
+import torch.distributed as dist
+from torch._C._distributed_c10d import Backend as C10DBackend, ReduceOp
+
+
+class _NcclWork(dist._Work):
+    """Work handle backed by a CUDA event recorded after the NCCL operation."""
+
+    def __init__(self, event, device):
+        super().__init__()
+        self._event = event
+        self._device = device
+
+    def wait(self, timeout=None):
+        if self._event is not None:
+            current = torch.cuda.current_stream(self._device)
+            self._event.wait(current)
+            self._event = None
+        return True
+
+    def get_future(self):
+        fut = torch.futures.Future()
+        fut.set_result(True)
+        return fut
+
+
+class NCCL4PyBackend(C10DBackend):
+    """Python c10d Backend backed by NVIDIA's nccl4py bindings."""
+
+    _UID_STORE_KEY = "nccl4py_uid"
+
+    def __init__(self, store, rank, size, timeout):
+        super().__init__(rank, size)
+        self._store = store
+        self._options = C10DBackend.Options("nccl4py", timeout=timeout)
+
+        device_count = torch.cuda.device_count()
+        self._device = torch.device("cuda", rank % device_count)
+        torch.cuda.set_device(self._device)
+
+        if rank == 0:
+            uid = nccl.get_unique_id()
+            store.set(self._UID_STORE_KEY, bytes(uid))
+        else:
+            store.wait([self._UID_STORE_KEY])
+            uid = nccl.UniqueId.from_bytes(bytes(store.get(self._UID_STORE_KEY)))
+
+        self._comm = nccl.Communicator.init(nranks=size, rank=rank, unique_id=uid)
+        self._internal_stream = torch.cuda.Stream(device=self._device)
+
+    @property
+    def options(self):
+        return self._options
+
+    @property
+    def supports_splitting(self):
+        return True
+
+    @property
+    def supports_coalescing(self):
+        return True
+
+    def getBackendName(self):
+        return "nccl4py"
+
+    def _op_stream(self, async_op):
+        if async_op:
+            current = torch.cuda.current_stream(self._device)
+            self._internal_stream.wait_stream(current)
+            return self._internal_stream
+        return torch.cuda.current_stream(self._device)
+
+    def _make_work(self, stream):
+        event = torch.cuda.Event()
+        event.record(stream)
+        return _NcclWork(event, self._device)
+
+    def _get_nccl_redop(self, reduce_op, tensor):
+        """Returns (nccl_op, custom_op_or_None).
+
+        The caller must close custom_op after the NCCL call is enqueued.
+        """
+        op_type = reduce_op.op
+        if op_type == ReduceOp.RedOpType.SUM:
+            return nccl.SUM, None
+        if op_type == ReduceOp.RedOpType.PRODUCT:
+            return nccl.PROD, None
+        if op_type == ReduceOp.RedOpType.MIN:
+            return nccl.MIN, None
+        if op_type == ReduceOp.RedOpType.MAX:
+            return nccl.MAX, None
+        if op_type == ReduceOp.RedOpType.AVG:
+            return nccl.AVG, None
+        if op_type == ReduceOp.RedOpType.PREMUL_SUM:
+            factor = reduce_op.factor
+            if isinstance(factor, torch.Tensor):
+                scalar = factor
+            else:
+                scalar = torch.tensor(
+                    [float(factor)], dtype=tensor.dtype, device=self._device
+                )
+            custom = self._comm.create_pre_mul_sum(scalar)
+            return custom, custom
+        raise RuntimeError(f"nccl4py backend: unsupported reduce op {reduce_op}")
+
+    def start_coalescing(self):
+        nccl.group_start()
+
+    def end_coalescing(self):
+        nccl.group_end()
+        stream = torch.cuda.current_stream(self._device)
+        return self._make_work(stream)
+
+    def send(self, tensor_list, dst, tag=0):
+        stream = torch.cuda.current_stream(self._device)
+        s = stream.cuda_stream
+        with nccl.group():
+            for t in tensor_list:
+                self._comm.send(t, dst, stream=s)
+        return self._make_work(stream)
+
+    def recv(self, tensor_list, src, tag=0):
+        stream = torch.cuda.current_stream(self._device)
+        s = stream.cuda_stream
+        with nccl.group():
+            for t in tensor_list:
+                self._comm.recv(t, src, stream=s)
+        return self._make_work(stream)
+
+    def broadcast(self, tensor_list, opts):
+        stream = self._op_stream(opts.asyncOp)
+        s = stream.cuda_stream
+        with nccl.group():
+            for t in tensor_list:
+                self._comm.broadcast(t, t, opts.rootRank, stream=s)
+        return self._make_work(stream)
+
+    def allreduce(self, tensor_list, opts):
+        stream = self._op_stream(opts.asyncOp)
+        s = stream.cuda_stream
+        nccl_op, custom = self._get_nccl_redop(opts.reduceOp, tensor_list[0])
+        try:
+            with nccl.group():
+                for t in tensor_list:
+                    self._comm.allreduce(t, t, nccl_op, stream=s)
+        finally:
+            if custom is not None:
+                custom.close()
+        return self._make_work(stream)
+
+    def reduce(self, tensor_list, opts):
+        stream = self._op_stream(opts.asyncOp)
+        s = stream.cuda_stream
+        nccl_op, custom = self._get_nccl_redop(opts.reduceOp, tensor_list[0])
+        try:
+            with nccl.group():
+                for t in tensor_list:
+                    self._comm.reduce(t, t, nccl_op, root=opts.rootRank, stream=s)
+        finally:
+            if custom is not None:
+                custom.close()
+        return self._make_work(stream)
+
+    def allgather(self, output_tensors, input_tensors, opts):
+        stream = self._op_stream(opts.asyncOp)
+        s = stream.cuda_stream
+        flats = []
+        with nccl.group():
+            for output_list, inp in zip(output_tensors, input_tensors):
+                flat = torch.empty(
+                    inp.numel() * self.size(),
+                    dtype=inp.dtype,
+                    device=self._device,
+                )
+                self._comm.allgather(inp, flat, stream=s)
+                flats.append((flat, output_list, inp.numel()))
+        with torch.cuda.stream(stream):
+            for flat, output_list, chunk in flats:
+                for i, out in enumerate(output_list):
+                    out.copy_(flat.narrow(0, i * chunk, chunk).view_as(out))
+        return self._make_work(stream)
+
+    def all_gather_single(self, output, input, opts):
+        stream = self._op_stream(opts.asyncOp)
+        self._comm.allgather(input, output, stream=stream.cuda_stream)
+        return self._make_work(stream)
+
+    def gather(self, output_tensors, input_tensors, opts):
+        stream = self._op_stream(opts.asyncOp)
+        s = stream.cuda_stream
+        root = opts.rootRank
+        flats = []
+        with nccl.group():
+            for idx, inp in enumerate(input_tensors):
+                if self.rank() == root:
+                    flat = torch.empty(
+                        inp.numel() * self.size(),
+                        dtype=inp.dtype,
+                        device=self._device,
+                    )
+                    self._comm.gather(inp, flat, root=root, stream=s)
+                    flats.append((flat, output_tensors[idx], inp.numel()))
+                else:
+                    self._comm.gather(inp, inp, root=root, stream=s)
+        if self.rank() == root:
+            with torch.cuda.stream(stream):
+                for flat, output_list, chunk in flats:
+                    for i, out in enumerate(output_list):
+                        out.copy_(flat.narrow(0, i * chunk, chunk).view_as(out))
+        return self._make_work(stream)
+
+    def scatter(self, output_tensors, input_tensors, opts):
+        stream = self._op_stream(opts.asyncOp)
+        s = stream.cuda_stream
+        root = opts.rootRank
+        with torch.cuda.stream(stream):
+            with nccl.group():
+                for idx, out in enumerate(output_tensors):
+                    if self.rank() == root:
+                        flat = torch.cat(
+                            [t.contiguous().view(-1) for t in input_tensors[idx]]
+                        )
+                        self._comm.scatter(flat, out, root=root, stream=s)
+                    else:
+                        self._comm.scatter(out, out, root=root, stream=s)
+        return self._make_work(stream)
+
+    def reduce_scatter(self, output_tensors, input_tensors, opts):
+        stream = self._op_stream(opts.asyncOp)
+        s = stream.cuda_stream
+        nccl_op, custom = self._get_nccl_redop(opts.reduceOp, output_tensors[0])
+        try:
+            with torch.cuda.stream(stream):
+                with nccl.group():
+                    for out, inp_list in zip(output_tensors, input_tensors):
+                        flat = torch.cat([t.contiguous().view(-1) for t in inp_list])
+                        self._comm.reduce_scatter(flat, out, nccl_op, stream=s)
+        finally:
+            if custom is not None:
+                custom.close()
+        return self._make_work(stream)
+
+    def reduce_scatter_single(self, output, input, opts):
+        stream = self._op_stream(opts.asyncOp)
+        s = stream.cuda_stream
+        nccl_op, custom = self._get_nccl_redop(opts.reduceOp, output)
+        try:
+            self._comm.reduce_scatter(input, output, nccl_op, stream=s)
+        finally:
+            if custom is not None:
+                custom.close()
+        return self._make_work(stream)
+
+    def all_to_all_single(
+        self, output, input, output_split_sizes, input_split_sizes, opts
+    ):
+        stream = self._op_stream(opts.asyncOp)
+        s = stream.cuda_stream
+        if not output_split_sizes and not input_split_sizes:
+            self._comm.alltoall(input, output, stream=s)
+        else:
+            size = self.size()
+            in_row = input.numel() // input.size(0) if input.numel() else 1
+            out_row = output.numel() // output.size(0) if output.numel() else 1
+            if not input_split_sizes:
+                input_split_sizes = [input.size(0) // size] * size
+            if not output_split_sizes:
+                output_split_sizes = [output.size(0) // size] * size
+            flat_in = input.view(-1)
+            flat_out = output.view(-1)
+            in_off = 0
+            out_off = 0
+            with nccl.group():
+                for i in range(size):
+                    sc = input_split_sizes[i] * in_row
+                    rc = output_split_sizes[i] * out_row
+                    if sc > 0:
+                        self._comm.send(flat_in.narrow(0, in_off, sc), i, stream=s)
+                    if rc > 0:
+                        self._comm.recv(flat_out.narrow(0, out_off, rc), i, stream=s)
+                    in_off += sc
+                    out_off += rc
+        return self._make_work(stream)
+
+    def alltoall(self, output_tensors, input_tensors, opts):
+        stream = self._op_stream(opts.asyncOp)
+        s = stream.cuda_stream
+        with nccl.group():
+            for i in range(self.size()):
+                self._comm.send(input_tensors[i], i, stream=s)
+                self._comm.recv(output_tensors[i], i, stream=s)
+        return self._make_work(stream)
+
+    def barrier(self, opts):
+        stream = self._op_stream(opts.asyncOp)
+        s = stream.cuda_stream
+        with torch.cuda.stream(stream):
+            scratch = torch.zeros(1, dtype=torch.float32, device=self._device)
+        self._comm.allreduce(scratch, scratch, nccl.SUM, stream=s)
+        return self._make_work(stream)
+
+    def split(self, store, ranks, opts):
+        ranks_list = list(ranks)
+        if self.rank() in ranks_list:
+            color = min(ranks_list)
+            key = ranks_list.index(self.rank())
+        else:
+            color = None
+            key = 0
+
+        new_comm = self._comm.split(color=color, key=key)
+
+        if self.rank() not in ranks_list:
+            return None
+
+        child = NCCL4PyBackend.__new__(NCCL4PyBackend)
+        C10DBackend.__init__(child, key, len(ranks_list))
+        child._store = store
+        child._options = opts if opts is not None else C10DBackend.Options("nccl4py")
+        child._device = self._device
+        child._comm = new_comm
+        child._internal_stream = torch.cuda.Stream(device=self._device)
+        return child
+
+    def shutdown(self):
+        if self._comm is not None and self._comm.is_valid:
+            try:
+                self._comm.finalize()
+                self._comm.destroy()
+            except Exception:
+                pass
+            self._comm = None
+
+    def abort(self):
+        if self._comm is not None and self._comm.is_valid:
+            try:
+                self._comm.abort()
+            except Exception:
+                pass
+            self._comm = None
+
+
+def _create_nccl4py_backend(store, group_rank, group_size, timeout):
+    return NCCL4PyBackend(store, group_rank, group_size, timeout)
+
+
+def _register_nccl4py_backend():
+    dist.Backend.register_backend("nccl4py", _create_nccl4py_backend, devices=["cuda"])

--- a/torch/distributed/nccl4py_backend.py
+++ b/torch/distributed/nccl4py_backend.py
@@ -11,7 +11,7 @@ Or use
     dist.init_process_group("nccl4py", ...)
 """
 
-import nccl.core as nccl
+import nccl.core as nccl  # pyrefly: ignore [missing-import]
 
 import torch
 import torch.distributed as dist
@@ -96,16 +96,17 @@ class NCCL4PyBackend(C10DBackend):
         The caller must close custom_op after the NCCL call is enqueued.
         """
         op_type = reduce_op.op
-        if op_type == ReduceOp.RedOpType.SUM:
+        if op_type == ReduceOp.RedOpType.SUM:  # pyrefly: ignore [missing-attribute]
             return nccl.SUM, None
-        if op_type == ReduceOp.RedOpType.PRODUCT:
+        if op_type == ReduceOp.RedOpType.PRODUCT:  # pyrefly: ignore [missing-attribute]
             return nccl.PROD, None
-        if op_type == ReduceOp.RedOpType.MIN:
+        if op_type == ReduceOp.RedOpType.MIN:  # pyrefly: ignore [missing-attribute]
             return nccl.MIN, None
-        if op_type == ReduceOp.RedOpType.MAX:
+        if op_type == ReduceOp.RedOpType.MAX:  # pyrefly: ignore [missing-attribute]
             return nccl.MAX, None
-        if op_type == ReduceOp.RedOpType.AVG:
+        if op_type == ReduceOp.RedOpType.AVG:  # pyrefly: ignore [missing-attribute]
             return nccl.AVG, None
+        # pyrefly: ignore [missing-attribute]
         if op_type == ReduceOp.RedOpType.PREMUL_SUM:
             factor = reduce_op.factor
             if isinstance(factor, torch.Tensor):

--- a/torch/distributed/nccl4py_backend.py
+++ b/torch/distributed/nccl4py_backend.py
@@ -18,6 +18,7 @@ __all__ = ["NCCL4PyBackend"]
 import torch
 import torch.distributed as dist
 from torch._C._distributed_c10d import Backend as C10DBackend, ReduceOp
+from torch.distributed._watchdog import _get_watchdog, stream_complete, stream_timeout
 
 
 try:
@@ -29,21 +30,28 @@ except ModuleNotFoundError:
 class _NcclWork(dist._Work):
     """Work handle backed by a CUDA event recorded after the NCCL operation."""
 
-    def __init__(self, event, device):
+    def __init__(self, event, device, wd_handle=None):
         super().__init__()
         self._event = event
         self._device = device
+        self._wd_handle = wd_handle
 
     def wait(self, timeout=None):
         if self._event is not None:
             current = torch.cuda.current_stream(self._device)
             self._event.wait(current)
             self._event = None
+        if self._wd_handle is not None:
+            self._wd_handle.cancel()
+            self._wd_handle = None
         return True
 
     def get_future(self):
-        fut = torch.futures.Future()
-        fut.set_result(True)
+        fut = torch.futures.Future(devices=[self._device])
+        if self._event is not None:
+            stream_complete(lambda: fut.set_result(True), event=self._event)
+        else:
+            fut.set_result(True)
         return fut
 
 
@@ -76,6 +84,7 @@ class NCCL4PyBackend(C10DBackend):
         self._comm = nccl.Communicator.init(nranks=size, rank=rank, unique_id=uid)
         self._internal_stream = torch.cuda.Stream(device=self._device)
         self._barrier_tensor = torch.zeros(1, dtype=torch.float32, device=self._device)
+        _get_watchdog()
 
     @property
     def options(self):
@@ -112,7 +121,9 @@ class NCCL4PyBackend(C10DBackend):
     def _make_work(self, stream):
         event = torch.cuda.Event()
         event.record(stream)
-        return _NcclWork(event, self._device)
+        with torch.cuda.stream(stream):
+            wd_handle = stream_timeout(self._options._timeout)
+        return _NcclWork(event, self._device, wd_handle)
 
     def _get_nccl_redop(self, reduce_op, tensor):
         """Returns (nccl_op, custom_op_or_None).
@@ -350,7 +361,8 @@ class NCCL4PyBackend(C10DBackend):
     def barrier(self, opts):
         stream = self._op_stream(opts.asyncOp)
         s = stream.cuda_stream
-        self._barrier_tensor.zero_()
+        with torch.cuda.stream(stream):
+            self._barrier_tensor.zero_()
         self._comm.allreduce(
             self._barrier_tensor, self._barrier_tensor, nccl.SUM, stream=s
         )


### PR DESCRIPTION
### Summary
Adds Python c10d Backend using nccl4py bindings via `PyBackend` trampoline. `Nccl4PyBackend` wraps nccl4py to implement a Python-only NCCL backend for torch.distributed. Supports all core collectives, P2P, coalescing, splitting and PREMUL_SUM. 

### Test Plan

`python test/distributed/test_c10d_nccl4py.py`

PS - Watchdog hasn't been implemented for PyBackends so deadlocks/hangs possible. Plan to add in a future PR. 

Authored with AI assistance