### PR TITLE
Add CUDA 13.2 B200 smoke tests

### DIFF
--- a/.github/workflows/test-b200.yml
+++ b/.github/workflows/test-b200.yml
@@ -4,7 +4,7 @@
 # This workflow runs smoke tests on B200 hardware
 #
 # Flow:
-# 1. Builds PyTorch with CUDA 13.0+ and sm100 architecture for B200
+# 1. Builds PyTorch with CUDA 13.0 and 13.2 for B200's sm100 architecture
 # 2. Runs smoke tests on linux.dgx.b200 runner
 # 3. Tests executed are defined in .ci/pytorch/test.sh -> test_python_smoke_b200() function
 #    - Includes matmul, scaled_matmul, FP8, and FlashAttention CuTe tests
@@ -85,4 +85,40 @@ jobs:
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"
+    secrets: inherit
+
+  linux-jammy-cuda13_2-py3_12-gcc11-sm100-build:
+    name: linux-jammy-cuda13.2-py3.12-gcc11-sm100
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner: linux.r7i.4xlarge
+      build-environment: linux-jammy-cuda13.2-py3.12-gcc11-sm100
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.2-cudnn9-py3.12-gcc11
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      cuda-arch-list: '10.0'
+      test-matrix: |
+        { include: [
+          { config: "smoke_b200", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+        ]}
+      # config: "smoke_b200" maps to test_python_smoke_b200() in .ci/pytorch/test.sh
+      python-version: "3.12"
+      compiler: gcc11
+      cuda-version: "13.2"
+    secrets: inherit
+
+  linux-jammy-cuda13_2-py3_12-gcc11-sm100-test:
+    name: linux-jammy-cuda13.2-py3.12-gcc11-sm100
+    uses: ./.github/workflows/_linux-test.yml
+    needs:
+      - linux-jammy-cuda13_2-py3_12-gcc11-sm100-build
+      - get-label-type
+    with:
+      build-environment: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.test-matrix }}
+      python-version: "3.12"
+      compiler: gcc11
+      cuda-version: "13.2"
     secrets: inherit


### PR DESCRIPTION
We are in process of adding more CI test for CUDA 13.2, B200 smoke-test currently just runs for CUDA 13.0.
cc @atalman @malfet @ptrblck @eqy @tinglvv 
> Codex-generated summary:
>
> This adds CUDA 13.2 build and test jobs to the B200 smoke-test workflow while retaining the existing CUDA 13.0 coverage. The new jobs use the published Python 3.12 CUDA 13.2 CI image.
>
> Test plan:
>
> - `git diff --check`
> - `spin quicklint`
>
> Authored with Codex.
