### PR TITLE
Fix nn docstrings that contradict the actual signatures

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1706,7 +1706,7 @@ def feature_alpha_dropout(
 
     Args:
         p: dropout probability of a channel to be zeroed. Default: 0.5
-        training: apply dropout if is ``True``. Default: ``True``
+        training: apply dropout if is ``True``. Default: ``False``
         inplace: If set to ``True``, will do this operation in-place. Default: ``False``
     """
     if has_torch_function_unary(input):
@@ -4058,7 +4058,7 @@ def smooth_l1_loss(
                                    'sum': the output will be summed. 'none': no reduction will be applied.
                                    Default: 'mean'.
         beta (float, optional): Specifies the threshold at which to change from the squared
-            term to the L1 term in the loss calculation. This value must be positive.
+            term to the L1 term in the loss calculation. This value must be non-negative.
             Default: 1.0.
 
     Returns:

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -661,7 +661,7 @@ class ParameterList(Module):
     method will convert any :class:`~torch.Tensor` into :class:`~torch.nn.Parameter`.
 
     Args:
-        parameters (iterable, optional): an iterable of elements to add to the list.
+        values (iterable, optional): an iterable of elements to add to the list.
 
     Example::
 
@@ -815,7 +815,7 @@ class ParameterDict(Module):
     :class:`~torch.nn.Parameter`.
 
     Args:
-        values (iterable, optional): a mapping (dictionary) of
+        parameters (iterable, optional): a mapping (dictionary) of
             (string : Any) or an iterable of key-value pairs
             of type (string, Any)
 

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -228,11 +228,11 @@ class LazyInstanceNorm1d(_LazyNormBase, _InstanceNorm):
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
         affine: a boolean value that when set to ``True``, this module has
             learnable affine parameters, initialized the same way as done for batch normalization.
-            Default: ``False``
+            Default: ``True``
         track_running_stats: a boolean value that when set to ``True``, this
             module tracks the running mean and variance, and when set to ``False``,
             this module does not track such statistics and always uses batch
-            statistics in both training and eval modes. Default: ``False``
+            statistics in both training and eval modes. Default: ``True``
         bias: If set to ``False``, the layer will not learn an additive bias (only relevant if
             :attr:`affine` is ``True``). Default: ``True``
 
@@ -349,11 +349,11 @@ class LazyInstanceNorm2d(_LazyNormBase, _InstanceNorm):
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
         affine: a boolean value that when set to ``True``, this module has
             learnable affine parameters, initialized the same way as done for batch normalization.
-            Default: ``False``
+            Default: ``True``
         track_running_stats: a boolean value that when set to ``True``, this
             module tracks the running mean and variance, and when set to ``False``,
             this module does not track such statistics and always uses batch
-            statistics in both training and eval modes. Default: ``False``
+            statistics in both training and eval modes. Default: ``True``
         bias: If set to ``False``, the layer will not learn an additive bias (only relevant if
             :attr:`affine` is ``True``). Default: ``True``
 
@@ -469,11 +469,11 @@ class LazyInstanceNorm3d(_LazyNormBase, _InstanceNorm):
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
         affine: a boolean value that when set to ``True``, this module has
             learnable affine parameters, initialized the same way as done for batch normalization.
-            Default: ``False``
+            Default: ``True``
         track_running_stats: a boolean value that when set to ``True``, this
             module tracks the running mean and variance, and when set to ``False``,
             this module does not track such statistics and always uses batch
-            statistics in both training and eval modes. Default: ``False``
+            statistics in both training and eval modes. Default: ``True``
         bias: If set to ``False``, the layer will not learn an additive bias (only relevant if
             :attr:`affine` is ``True``). Default: ``True``
 


### PR DESCRIPTION
Four places in `torch.nn` where the documented API contradicts the code. All four are reproducible in three lines against a stock build, and all four are documentation-only.

### 1. `LazyInstanceNorm{1,2,3}d` document the eager defaults

```python
>>> import inspect, torch.nn as nn
>>> inspect.signature(nn.LazyInstanceNorm2d.__init__).parameters['affine'].default
True
>>> # docstring says: affine ... Default: ``False``
```

All three lazy classes document `affine` and `track_running_stats` as `Default: ``False```. They derive from `_LazyNormBase`, which defaults both to `True`; the eager classes derive from `_InstanceNorm`, which really does default both to `False`. The docstrings look copied from the eager siblings.

This one has a visible consequence rather than being only cosmetic, because the lazy and eager variants then differ:

```python
>>> m = nn.LazyInstanceNorm2d(); m(torch.randn(2, 3, 4, 4))
>>> [n for n, _ in m.named_parameters()]
['weight', 'bias']
>>> [n for n, _ in nn.InstanceNorm2d(3).named_parameters()]
[]
```

A reader who takes the documented default at face value expects `LazyInstanceNorm2d()` to have no affine parameters and no running stats, and it has both.

### 2. `ParameterList` and `ParameterDict` document each other's keyword

```python
>>> inspect.signature(nn.ParameterList.__init__)
(self, values: 'Iterable[Any] | None' = None) -> 'None'      # doc says: parameters (iterable, optional)
>>> inspect.signature(nn.ParameterDict.__init__)
(self, parameters: 'Any' = None) -> 'None'                   # doc says: values (iterable, optional)
```

The two Args names are swapped relative to the signatures, so following either docstring is an error rather than a surprise:

```python
>>> nn.ParameterList(parameters=[nn.Parameter(torch.zeros(2))])
TypeError: ParameterList.__init__() got an unexpected keyword argument 'parameters'
>>> nn.ParameterDict(values={"a": nn.Parameter(torch.zeros(2))})
TypeError: ParameterDict.__init__() got an unexpected keyword argument 'values'
```

I changed the docs to match the signatures rather than the reverse, since the parameter names are public API.

### 3. `F.feature_alpha_dropout` documents `training` as `Default: ``True```

The signature defaults it to `False`, so the documented default call does nothing:

```python
>>> x = torch.ones(2, 3, 4, 4)
>>> torch.equal(F.feature_alpha_dropout(x, p=1.0), x)                  # p=1.0 makes this deterministic
True
>>> torch.equal(F.feature_alpha_dropout(x, p=1.0, training=True), x)
False
```

Checked the rest of the family so this is not a one-off patch on a shared pattern: `dropout`, `dropout1d`, `dropout2d` and `dropout3d` all document `Default: ``True``` and all really default to `True`, so they are correct and untouched. `alpha_dropout` also defaults to `False` but has no Args section at all, so there is nothing there to contradict. `feature_alpha_dropout` is the only one whose Args section disagrees with its signature.

### 4. `F.smooth_l1_loss` says beta "must be positive"

`nn.SmoothL1Loss` says "non-negative" and explicitly documents the boundary: "When beta is 0, Smooth L1 loss is equivalent to L1 loss." That value is accepted and behaves exactly as the class documents:

```python
>>> a, b = torch.tensor([1.0, 2.0]), torch.tensor([0.5, 3.0])
>>> F.smooth_l1_loss(a, b, beta=0.0).item(), F.l1_loss(a, b).item()
(0.75, 0.75)
```

So the functional docstring is the one that is wrong. Aligned it with the class wording.

## Scope

Docs only, 10 lines across three files, no code touched. Verified by re-reading each patched docstring and comparing it against `inspect.signature` of the real object, which now agree in all four cases; and all three files still parse.

I checked for prior art on each and found none open or closed that covers them. The nearest neighbour is #68558, closed in 2022, which produced the "non-negative" wording and the beta=0 note on `nn.SmoothL1Loss` but never touched the functional docstring, which is exactly why the two disagree today.

Filing without a linked issue because these are documentation corrections rather than behaviour changes, in line with the docstring fixes I have had merged previously (#188204, #188943, #189008, #190058). Happy to split this into four PRs if you would rather review them separately; I grouped them because they are one defect class, a docstring that states a default or a parameter name the signature does not have.
