### PR TITLE
[Torch] Preserve non-persistent buffers in fx.GraphModule (#191708)

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -4144,6 +4144,37 @@ def forward(self, x : _torch_Tensor_) -> _torch_Tensor_:
     def test_graph_module_init_buffer_param_copied_mod_init(self):
         self._test_graph_module_init_buffer_param_copied(use_dict_init=False)
 
+    def test_graph_module_init_preserves_non_persistent_buffers(self):
+        class Child(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("nested", torch.ones(1), persistent=False)
+
+        class MyModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("top_level", torch.ones(1), persistent=False)
+                self.child = Child()
+
+            def forward(self, x):
+                return x + self.top_level + self.child.nested
+
+        module = MyModule()
+        graph_module = GraphModule(module, symbolic_trace(module).graph)
+
+        self.assertEqual(torch.full((1,), 2.0), graph_module(torch.zeros(1)))
+        self.assertEqual(
+            {"top_level", "child.nested"},
+            {name for name, _ in graph_module.named_buffers()},
+        )
+        self.assertEqual(
+            {"top_level"}, graph_module._non_persistent_buffers_set
+        )
+        self.assertEqual(
+            {"nested"}, graph_module.child._non_persistent_buffers_set
+        )
+        self.assertEqual({}, graph_module.state_dict())
+
     def test_annotations_with_no_forward_references(self):
         class A:
             def __call__(self, x: torch.Tensor):

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -305,7 +305,8 @@ def _copy_attr(
     # If it is a tensor and not a parameter attribute of a module, it should be a named buffer.
     # So, we register it as a named buffer in the target module.
     if isinstance(orig, torch.Tensor) and not isinstance(orig, torch.nn.Parameter):
-        to_module.register_buffer(field, orig)
+        persistent = field not in from_module._non_persistent_buffers_set
+        to_module.register_buffer(field, orig, persistent=persistent)
     else:
         setattr(to_module, field, orig)
 


### PR DESCRIPTION
Summary:

Preserve each source module buffer registration when `GraphModule` copies attributes referenced by `get_attr`. Non-persistent buffers now remain excluded from `state_dict`, including buffers on copied child-module paths.

Test Plan: - `buck test fbcode//mode/dev fbcode//caffe2/test:fx -- test_graph_module_init_preserves_non_persistent_buffers`

Differential Revision: D113826709


