### PR TITLE
[distributed] Complete expired FSDP deprecations

### DIFF
--- a/test/distributed/checkpoint/fsdp/test_fsdp_dsd.py
+++ b/test/distributed/checkpoint/fsdp/test_fsdp_dsd.py
@@ -147,7 +147,7 @@ class TestFullyShardWithDistributedStateDict(FSDPTest):
         with FSDP.state_dict_type(fsdp1_model, state_dict_type):
             fsdp1_state_dict = {
                 "model": fsdp1_model.state_dict(),
-                "optim": FSDP.sharded_optim_state_dict(fsdp1_model, fsdp1_optim),
+                "optim": FSDP.optim_state_dict(fsdp1_model, fsdp1_optim),
             }
             dcp.save(
                 fsdp1_state_dict,

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -2,7 +2,6 @@
 
 import bisect
 import sys
-from collections.abc import Callable
 from copy import deepcopy
 from enum import auto, Enum
 from typing import Any
@@ -57,15 +56,6 @@ if TEST_WITH_DEV_DBG_ASAN:
         file=sys.stderr,
     )
     sys.exit(0)
-
-
-class _OSDCommMethod(Enum):
-    """Method for communicating the optimizer state dict for internal tests."""
-
-    BROADCAST_OBJECT_LIST = auto()
-    SCATTER_FULL_OSD = auto()
-    FLATTEN_SHARDED_OSD = auto()
-    OPTIM_STATE_DICT = auto()
 
 
 class _ModelClass(Enum):
@@ -543,9 +533,8 @@ class TestFSDPOptimState(FSDPTest):
         use_diff_optim_inputs: bool,
     ) -> None:
         """
-        Tests :meth:`full_optim_state_dict` and meth:`sharded_optim_state_dict`
-        by comparing the returned dict for an FSDP-wrapped model with that of
-        an equivalent non-wrapped model.
+        Tests :meth:`optim_state_dict` by comparing the returned dict for an
+        FSDP-wrapped model with that of an equivalent non-wrapped model.
 
         The test checks the equivalence excluding the parameter keys since the
         FSDP and normal optimizer state dicts key by names and IDs,
@@ -553,48 +542,25 @@ class TestFSDPOptimState(FSDPTest):
         are incorrectly mapped to values. Their correct mapping is tested in
         other tests that exercise the save/load workflow.
         """
-        self.run_subtests(
-            {"use_optim_input": [False, True]},
-            self._test_optim_state_dict_nested,
-            state_dict_type=state_dict_type,
-            use_multiple_param_groups=use_multiple_param_groups,
-            rank0_only=rank0_only,
-            use_diff_optim_inputs=use_diff_optim_inputs,
-        )
-
-    def _test_optim_state_dict_nested(
-        self,
-        state_dict_type: StateDictType,
-        use_multiple_param_groups: bool,
-        rank0_only: bool,
-        use_diff_optim_inputs: bool,
-        use_optim_input: bool,
-    ) -> None:
         if rank0_only and state_dict_type == StateDictType.SHARDED_STATE_DICT:
             return  # not supported
         NUM_ITERS = 3
-        model1, optim1, optim_input = self._init_nested_model(
+        model1, optim1, _ = self._init_nested_model(
             wrap=True,
             use_multiple_param_groups=use_multiple_param_groups,
             use_diff_optim_inputs=use_diff_optim_inputs,
         )
         losses1 = self._step_model(model1, optim1, num_iters=NUM_ITERS)
         if state_dict_type == StateDictType.FULL_STATE_DICT:
-            if use_optim_input:
-                fsdp_osd = FSDP.full_optim_state_dict(
-                    model1,
-                    optim1,
-                    optim_input,
-                    rank0_only=rank0_only,
-                )
-            else:
-                fsdp_osd = FSDP.full_optim_state_dict(
-                    model1,
-                    optim1,
-                    rank0_only=rank0_only,
-                )
+            config = FullOptimStateDictConfig(rank0_only=rank0_only)
+            FSDP.set_state_dict_type(
+                model1,
+                StateDictType.FULL_STATE_DICT,
+                optim_state_dict_config=config,
+            )
         else:
-            fsdp_osd = FSDP.sharded_optim_state_dict(model1, optim1)
+            FSDP.set_state_dict_type(model1, StateDictType.SHARDED_STATE_DICT)
+        fsdp_osd = FSDP.optim_state_dict(model1, optim1)
         # Non-target ranks get an empty state dict
         if rank0_only and self.rank != 0:
             self.assertEqual(len(fsdp_osd), 0)
@@ -610,9 +576,8 @@ class TestFSDPOptimState(FSDPTest):
         for i, (l1, l2) in enumerate(zip(losses1, losses2)):
             if l1 != l2:
                 raise AssertionError(f"Losses differ on iter {i}: {l1:.5f} {l2:.5f}")
-        # Do not check the parameter keys since the full/sharded optimizer state
-        # dict uses parameter names, while the non-wrapped equivalent uses
-        # parameter IDs
+        # Do not check the parameter keys since the optimizer state dict uses
+        # parameter names, while the non-wrapped equivalent uses parameter IDs
         check_same_param_keys = False
         self._check_same_param_groups(
             fsdp_osd,
@@ -626,11 +591,10 @@ class TestFSDPOptimState(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2)
-    def test_full_optim_state_dict_keys(self):
-        """Tests that the parameter keys returned by
-        :meth:`full_optim_state_dict` match those of :meth:`state_dict` with
-        full ``state_dict_type`` for a non-FSDP-root model with nested FSDP
-        instances and ignored modules."""
+    def test_optim_state_dict_keys(self):
+        """Tests that the parameter keys returned by :meth:`optim_state_dict`
+        match those of :meth:`state_dict` with full ``state_dict_type`` for a
+        non-FSDP-root model with nested FSDP instances and ignored modules."""
         device = torch.device(device_type)
         model = NestedModel().to(device)
         wrapped_model = NestedModel.wrap(model, ignore_modules=True)
@@ -641,10 +605,8 @@ class TestFSDPOptimState(FSDPTest):
         )
         optim = torch.optim.Adam(wrapped_model.parameters(), lr=1e-3)
         self._step_model(model, optim, device)
-        optim_state_dict = FSDP.full_optim_state_dict(
-            wrapped_model, optim, rank0_only=False
-        )
         with FSDP.state_dict_type(wrapped_model, StateDictType.FULL_STATE_DICT):
+            optim_state_dict = FSDP.optim_state_dict(wrapped_model, optim)
             state_dict = wrapped_model.state_dict()
         self.assertEqual(optim_state_dict["state"].keys(), state_dict.keys())
         # Check that checkpointing prefix was indeed stripped.
@@ -652,8 +614,8 @@ class TestFSDPOptimState(FSDPTest):
             self.assertNotIn(_CHECKPOINT_WRAPPED_MODULE, key)
 
     @skip_if_lt_x_gpu(2)
-    def test_full_optim_state_dict_nested_invalid(self):
-        """Tests that :meth:`full_optim_state_dict` raises an error when
+    def test_optim_state_dict_nested_invalid(self):
+        """Tests that :meth:`optim_state_dict` raises an error when
         nonzero ranks are missing the optimizer state for parameters on rank
         0."""
         device = torch.device(device_type)
@@ -670,67 +632,21 @@ class TestFSDPOptimState(FSDPTest):
             "are missing some of those states"
         )
         with self.assertRaisesRegex(RuntimeError, error_regex):
-            FSDP.full_optim_state_dict(model, optim)
+            FSDP.optim_state_dict(model, optim)
 
     @skip_if_lt_x_gpu(2)
     @parametrize("use_multiple_param_groups", [False, True])
     @parametrize("wrap_alt", [False, True])
     @parametrize("use_diff_optim_inputs", [False, True])
-    def test_shard_full_optim_state_dict_nested(
+    def test_load_optim_state_full_nested(
         self,
         use_multiple_param_groups: bool,
         wrap_alt: bool,
         use_diff_optim_inputs: bool,
     ):
-        """Tests :meth:`shard_full_optim_state_dict` for a non-FSDP-root model
-        with nested FSDP instances."""
-        self.run_subtests(
-            {"use_optim_input": [False, True]},
-            self._test_load_optim_state,
-            model_class=_ModelClass.NESTED,
-            use_multiple_param_groups=use_multiple_param_groups,
-            halve_world_size=False,
-            osd_comm_method=_OSDCommMethod.BROADCAST_OBJECT_LIST,
-            use_diff_optim_inputs=use_diff_optim_inputs,
-            wrap_alt=wrap_alt,
-            num_iters=3,
-        )
-
-        self._test_load_optim_state_with_optim_state_dict(
-            _ModelClass.NESTED,
-            state_dict_settings=StateDictSettings(
-                StateDictType.FULL_STATE_DICT,
-                FullStateDictConfig(),
-                FullOptimStateDictConfig(),
-            ),
-            use_multiple_param_groups=False,
-            halve_world_size=False,
-            use_diff_optim_inputs=use_diff_optim_inputs,
-            wrap_alt=wrap_alt,
-            num_iters=3,
-        )
-
-    @skip_if_lt_x_gpu(2)
-    def test_shard_full_optim_state_dict_nested_halve_world_size(self):
-        """Tests :meth:`shard_full_optim_state_dict` for a non-FSDP-root model
-        with nested FSDP instances when loading into a new process group with
-        halved world size."""
-        # To save CI costs, we test with the "harder" settings:
-        use_multiple_param_groups = True
-        use_diff_optim_inputs = True
-        wrap_alt = True
-        self.run_subtests(
-            {"use_optim_input": [False, True]},
-            self._test_load_optim_state,
-            model_class=_ModelClass.NESTED,
-            use_multiple_param_groups=use_multiple_param_groups,
-            halve_world_size=True,
-            osd_comm_method=_OSDCommMethod.BROADCAST_OBJECT_LIST,
-            use_diff_optim_inputs=use_diff_optim_inputs,
-            wrap_alt=wrap_alt,
-            num_iters=3,
-        )
-
+        """Tests :meth:`optim_state_dict` / :meth:`optim_state_dict_to_load`
+        with full state dict for a non-FSDP-root model with nested FSDP
+        instances."""
         self._test_load_optim_state_with_optim_state_dict(
             _ModelClass.NESTED,
             state_dict_settings=StateDictSettings(
@@ -739,156 +655,117 @@ class TestFSDPOptimState(FSDPTest):
                 FullOptimStateDictConfig(),
             ),
             use_multiple_param_groups=use_multiple_param_groups,
-            halve_world_size=True,
+            halve_world_size=False,
             use_diff_optim_inputs=use_diff_optim_inputs,
             wrap_alt=wrap_alt,
             num_iters=3,
         )
 
     @skip_if_lt_x_gpu(2)
-    def test_shard_full_optim_state_dict_transformer(self) -> None:
-        """Tests :meth:`shard_full_optim_state_dict` for an FSDP-root
-        transformer model with shared parameters."""
-        self.run_subtests(
-            {"use_optim_input": [False, True]},
-            self._test_load_optim_state,
-            model_class=_ModelClass.TRANSFORMER,
-            use_multiple_param_groups=False,
-            halve_world_size=True,
-            osd_comm_method=_OSDCommMethod.BROADCAST_OBJECT_LIST,
-            use_diff_optim_inputs=False,
-            num_iters=3,
-        )
-
+    def test_load_optim_state_full_nested_halve_world_size(self):
+        """Tests :meth:`optim_state_dict` / :meth:`optim_state_dict_to_load`
+        with full state dict for a non-FSDP-root model with nested FSDP
+        instances when loading into a new process group with halved world
+        size."""
         self._test_load_optim_state_with_optim_state_dict(
-            _ModelClass.TRANSFORMER,
+            _ModelClass.NESTED,
             state_dict_settings=StateDictSettings(
                 StateDictType.FULL_STATE_DICT,
                 FullStateDictConfig(),
                 FullOptimStateDictConfig(),
             ),
-            use_multiple_param_groups=False,
+            use_multiple_param_groups=True,
             halve_world_size=True,
-            use_diff_optim_inputs=False,
-            num_iters=3,
-        )
-
-    @skip_if_lt_x_gpu(2)
-    @parametrize("use_multiple_param_groups", [False, True])
-    @parametrize("wrap_alt", [False, True])
-    @parametrize("use_diff_optim_inputs", [False, True])
-    def test_scatter_full_optim_state_dict_nested(
-        self,
-        use_multiple_param_groups: bool,
-        wrap_alt: bool,
-        use_diff_optim_inputs: bool,
-    ):
-        """Tests :meth:`scatter_full_optim_state_dict` for a non-FSDP-root
-        model with nested FSDP instances."""
-        self.run_subtests(
-            {"use_optim_input": [False, True]},
-            self._test_load_optim_state,
-            model_class=_ModelClass.NESTED,
-            use_multiple_param_groups=use_multiple_param_groups,
-            halve_world_size=False,
-            osd_comm_method=_OSDCommMethod.SCATTER_FULL_OSD,
-            use_diff_optim_inputs=use_diff_optim_inputs,
-            wrap_alt=wrap_alt,
-            num_iters=3,
-        )
-
-        self._test_load_optim_state_with_optim_state_dict(
-            _ModelClass.NESTED,
-            state_dict_settings=StateDictSettings(
-                StateDictType.FULL_STATE_DICT,
-                FullStateDictConfig(),
-                FullOptimStateDictConfig(rank0_only=True),
-            ),
-            use_multiple_param_groups=use_multiple_param_groups,
-            halve_world_size=False,
-            use_diff_optim_inputs=use_diff_optim_inputs,
-            wrap_alt=wrap_alt,
-            num_iters=3,
-        )
-
-    @skip_if_lt_x_gpu(2)
-    def test_scatter_full_optim_state_dict_nested_halve_world_size(self):
-        """Tests :meth:`scatter_full_optim_state_dict` for a non-FSDP-root
-        model with nested FSDP instances when loading into a new process group
-        with halved world size."""
-        # To save CI costs, we test with the "harder" settings:
-        use_multiple_param_groups = True
-        use_diff_optim_inputs = True
-        wrap_alt = True
-        self.run_subtests(
-            {"use_optim_input": [False, True]},
-            self._test_load_optim_state,
-            model_class=_ModelClass.NESTED,
-            use_multiple_param_groups=use_multiple_param_groups,
-            halve_world_size=True,
-            osd_comm_method=_OSDCommMethod.SCATTER_FULL_OSD,
-            use_diff_optim_inputs=use_diff_optim_inputs,
-            wrap_alt=wrap_alt,
-            num_iters=3,
-        )
-
-        self._test_load_optim_state_with_optim_state_dict(
-            _ModelClass.NESTED,
-            state_dict_settings=StateDictSettings(
-                StateDictType.FULL_STATE_DICT,
-                FullStateDictConfig(),
-                FullOptimStateDictConfig(rank0_only=True),
-            ),
-            use_multiple_param_groups=use_multiple_param_groups,
-            halve_world_size=True,
-            use_diff_optim_inputs=use_diff_optim_inputs,
-            wrap_alt=wrap_alt,
-            num_iters=3,
-        )
-
-    @skip_if_lt_x_gpu(2)
-    def test_scatter_full_optim_state_dict_transformer(self) -> None:
-        """Tests :meth:`scatter_full_optim_state_dict` for an FSDP-root
-        transformer model with shared parameters."""
-        self.run_subtests(
-            {"use_optim_input": [False, True]},
-            self._test_load_optim_state,
-            model_class=_ModelClass.TRANSFORMER,
-            use_multiple_param_groups=False,
-            halve_world_size=True,
-            osd_comm_method=_OSDCommMethod.SCATTER_FULL_OSD,
-            use_diff_optim_inputs=False,
-            num_iters=3,
-        )
-
-        self._test_load_optim_state_with_optim_state_dict(
-            _ModelClass.TRANSFORMER,
-            state_dict_settings=StateDictSettings(
-                StateDictType.FULL_STATE_DICT,
-                FullStateDictConfig(),
-                FullOptimStateDictConfig(rank0_only=True),
-            ),
-            use_multiple_param_groups=False,
-            halve_world_size=True,
-            use_diff_optim_inputs=False,
-            num_iters=3,
-        )
-
-    @skip_if_lt_x_gpu(2)
-    def test_flatten_sharded_optim_state_dict_nested(self) -> None:
-        """Tests :meth:`flatten_sharded_optim_state_dict` for an FSDP-root
-        nested model."""
-        self._test_load_optim_state(
-            _ModelClass.NESTED,
-            use_multiple_param_groups=False,
-            halve_world_size=False,
-            osd_comm_method=_OSDCommMethod.FLATTEN_SHARDED_OSD,
-            use_diff_optim_inputs=False,
-            use_optim_input=False,
+            use_diff_optim_inputs=True,
             wrap_alt=True,
             num_iters=3,
         )
 
+    @skip_if_lt_x_gpu(2)
+    def test_load_optim_state_full_transformer(self) -> None:
+        """Tests :meth:`optim_state_dict` / :meth:`optim_state_dict_to_load`
+        with full state dict for an FSDP-root transformer model with shared
+        parameters."""
+        self._test_load_optim_state_with_optim_state_dict(
+            _ModelClass.TRANSFORMER,
+            state_dict_settings=StateDictSettings(
+                StateDictType.FULL_STATE_DICT,
+                FullStateDictConfig(),
+                FullOptimStateDictConfig(),
+            ),
+            use_multiple_param_groups=False,
+            halve_world_size=True,
+            use_diff_optim_inputs=False,
+            num_iters=3,
+        )
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("use_multiple_param_groups", [False, True])
+    @parametrize("wrap_alt", [False, True])
+    @parametrize("use_diff_optim_inputs", [False, True])
+    def test_load_optim_state_rank0_only_nested(
+        self,
+        use_multiple_param_groups: bool,
+        wrap_alt: bool,
+        use_diff_optim_inputs: bool,
+    ):
+        """Tests :meth:`optim_state_dict` / :meth:`optim_state_dict_to_load`
+        with rank0_only full state dict for a non-FSDP-root model with nested
+        FSDP instances."""
+        self._test_load_optim_state_with_optim_state_dict(
+            _ModelClass.NESTED,
+            state_dict_settings=StateDictSettings(
+                StateDictType.FULL_STATE_DICT,
+                FullStateDictConfig(),
+                FullOptimStateDictConfig(rank0_only=True),
+            ),
+            use_multiple_param_groups=use_multiple_param_groups,
+            halve_world_size=False,
+            use_diff_optim_inputs=use_diff_optim_inputs,
+            wrap_alt=wrap_alt,
+            num_iters=3,
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_load_optim_state_rank0_only_nested_halve_world_size(self):
+        """Tests :meth:`optim_state_dict` / :meth:`optim_state_dict_to_load`
+        with rank0_only full state dict for a non-FSDP-root model with nested
+        FSDP instances when loading into a halved world size."""
+        self._test_load_optim_state_with_optim_state_dict(
+            _ModelClass.NESTED,
+            state_dict_settings=StateDictSettings(
+                StateDictType.FULL_STATE_DICT,
+                FullStateDictConfig(),
+                FullOptimStateDictConfig(rank0_only=True),
+            ),
+            use_multiple_param_groups=True,
+            halve_world_size=True,
+            use_diff_optim_inputs=True,
+            wrap_alt=True,
+            num_iters=3,
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_load_optim_state_rank0_only_transformer(self) -> None:
+        """Tests :meth:`optim_state_dict` / :meth:`optim_state_dict_to_load`
+        with rank0_only full state dict for an FSDP-root transformer model."""
+        self._test_load_optim_state_with_optim_state_dict(
+            _ModelClass.TRANSFORMER,
+            state_dict_settings=StateDictSettings(
+                StateDictType.FULL_STATE_DICT,
+                FullStateDictConfig(),
+                FullOptimStateDictConfig(rank0_only=True),
+            ),
+            use_multiple_param_groups=False,
+            halve_world_size=True,
+            use_diff_optim_inputs=False,
+            num_iters=3,
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_load_optim_state_sharded_nested(self) -> None:
+        """Tests :meth:`optim_state_dict` / :meth:`optim_state_dict_to_load`
+        with sharded state dict for an FSDP-root nested model."""
         self._test_load_optim_state_with_optim_state_dict(
             _ModelClass.NESTED,
             state_dict_settings=StateDictSettings(
@@ -904,19 +781,9 @@ class TestFSDPOptimState(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2)
-    def test_flatten_sharded_optim_state_dict_transformer(self) -> None:
-        """Tests :meth:`flatten_sharded_optim_state_dict` for an FSDP-root
-        transformer model."""
-        self._test_load_optim_state(
-            _ModelClass.TRANSFORMER,
-            use_multiple_param_groups=False,
-            halve_world_size=False,
-            osd_comm_method=_OSDCommMethod.FLATTEN_SHARDED_OSD,
-            use_diff_optim_inputs=False,
-            use_optim_input=False,
-            num_iters=3,
-        )
-
+    def test_load_optim_state_sharded_transformer(self) -> None:
+        """Tests :meth:`optim_state_dict` / :meth:`optim_state_dict_to_load`
+        with sharded state dict for an FSDP-root transformer model."""
         self._test_load_optim_state_with_optim_state_dict(
             _ModelClass.TRANSFORMER,
             state_dict_settings=StateDictSettings(
@@ -988,180 +855,16 @@ class TestFSDPOptimState(FSDPTest):
             fsdp_kwargs={"use_orig_params": True},
         )
 
-    def _test_load_optim_state(
-        self,
-        model_class: _ModelClass,
-        use_multiple_param_groups: bool,
-        halve_world_size: bool,
-        osd_comm_method: _OSDCommMethod,
-        use_diff_optim_inputs: bool,
-        use_optim_input: bool,
-        num_iters: int,
-        **new_model_kwargs,
-    ):
-        """
-        (1) Runs a model with full world size for K iterations to generate a
-        full/sharded optimizer state dict;
-        (2) initializes a model with halved world size and possibly different
-        FSDP wrapping scheme (based on ``new_model_kwargs``);
-        (3) loads the full/sharded optimizer state dict from (1) according to the
-        halved-world-size model;
-        (4) runs the halved-world-size model for K iterations; and
-        (5) checks that the sharded optimizer state dict from (3) matches the
-        halved-world-size model's local optimizer state dict, meaning that the
-        former could have equivalently been loaded into the local optimizer.
-        """
-        initializer = self._model_class[model_class]
-        if osd_comm_method == _OSDCommMethod.OPTIM_STATE_DICT:
-            osd_method = FSDP.optim_state_dict
-        elif osd_comm_method == _OSDCommMethod.FLATTEN_SHARDED_OSD:
-            osd_method = FSDP.sharded_optim_state_dict
-        else:
-            osd_method = FSDP.full_optim_state_dict
-
-        # First, run a wrapped model with full world size for a few iterations
-        model1, optim1, optim_input1 = initializer(
-            wrap=True,
-            use_multiple_param_groups=use_multiple_param_groups,
-        )
-        self._step_model(model1, optim1, num_iters=num_iters)
-        fsdp_osd1 = (
-            osd_method(model1, optim1, optim_input1)
-            if use_optim_input
-            else osd_method(model1, optim1)
-        )
-        if halve_world_size:
-            # Create a new process group with halved world size
-            new_group_ranks = [r for r in range(self.world_size) if r % 2 == 0]
-            new_group = dist.new_group(ranks=new_group_ranks)
-            if self.rank not in new_group_ranks:
-                return
-        else:
-            # Continue using the same group and hence world size
-            new_group = dist.distributed_c10d._get_default_group()
-        # Second, run a wrapped model with (possibly) halved world size and
-        # (possibly) differing `optim_input` across ranks
-        model2, optim2, optim_input2 = initializer(
-            wrap=True,
-            group=new_group,
-            use_multiple_param_groups=use_multiple_param_groups,
-            use_diff_optim_inputs=use_diff_optim_inputs,
-            **new_model_kwargs,  # specify `wrap_alt` to change wrapping
-        )
-        self._step_model(model2, optim2, num_iters=num_iters)
-        fsdp_osd2 = (
-            osd_method(model2, optim2, optim_input2, group=new_group)
-            if use_optim_input
-            else osd_method(model2, optim2, group=new_group)
-        )
-        # Compute two sharded optim state dicts: (1) for the first model
-        # according to the second model and (2) for the second model according
-        # to the second model
-        if osd_comm_method == _OSDCommMethod.BROADCAST_OBJECT_LIST:
-            fsdp_osd1 = self._broadcast_full_osd(fsdp_osd1, group=new_group)
-            sharded_osd1 = (
-                FSDP.shard_full_optim_state_dict(
-                    fsdp_osd1, model2, optim_input=optim_input2
-                )
-                if use_optim_input
-                else FSDP.shard_full_optim_state_dict(fsdp_osd1, model2, optim=optim2)
-            )
-            fsdp_osd2 = self._broadcast_full_osd(fsdp_osd2, group=new_group)
-            sharded_osd2 = (
-                FSDP.shard_full_optim_state_dict(
-                    fsdp_osd2, model2, optim_input=optim_input2
-                )
-                if use_optim_input
-                else FSDP.shard_full_optim_state_dict(fsdp_osd2, model2, optim=optim2)
-            )
-        elif osd_comm_method == _OSDCommMethod.SCATTER_FULL_OSD:
-            sharded_osd1 = (
-                FSDP.scatter_full_optim_state_dict(
-                    fsdp_osd1 if self.rank == 0 else None,
-                    model2,
-                    optim_input=optim_input2,
-                    group=new_group,
-                )
-                if use_optim_input
-                else FSDP.scatter_full_optim_state_dict(
-                    fsdp_osd1 if self.rank == 0 else None,
-                    model2,
-                    optim=optim2,
-                    group=new_group,
-                )
-            )
-            sharded_osd2 = (
-                FSDP.scatter_full_optim_state_dict(
-                    fsdp_osd2 if self.rank == 0 else None,
-                    model2,
-                    optim_input=optim_input2,
-                    group=new_group,
-                )
-                if use_optim_input
-                else FSDP.scatter_full_optim_state_dict(
-                    fsdp_osd2 if self.rank == 0 else None,
-                    model2,
-                    optim=optim2,
-                    group=new_group,
-                )
-            )
-        elif osd_comm_method == _OSDCommMethod.FLATTEN_SHARDED_OSD:
-            sharded_osd1 = FSDP.flatten_sharded_optim_state_dict(
-                fsdp_osd1,
-                model2,
-                optim=optim2,
-            )
-            sharded_osd2 = FSDP.flatten_sharded_optim_state_dict(
-                fsdp_osd2,
-                model2,
-                optim=optim2,
-            )
-        elif osd_comm_method == _OSDCommMethod.OPTIM_STATE_DICT:
-            sharded_osd1 = FSDP.optim_state_dict_to_load(model2, optim2, fsdp_osd1)
-            sharded_osd2 = FSDP.optim_state_dict_to_load(model2, optim2, fsdp_osd2)
-
-        # As a sanity check, check that sharding the second model's full/sharded
-        # optimizer state dict according to itself is equivalent to its local
-        # optimizer's state dict
-        local_osd2 = optim2.state_dict()
-        check_same_param_keys = True  # should all have matching parameter IDs
-        self._check_same_param_groups(
-            sharded_osd2,
-            local_osd2,
-            check_same_param_keys=check_same_param_keys,
-        )
-        self._check_same_state(
-            sharded_osd2,
-            local_osd2,
-            check_same_param_keys=check_same_param_keys,
-        )
-        # Check that sharding the first model's full/sharded optimizer state dict
-        # according to the second model is equivalent to the second model's
-        # local optimizer state dict
-        self._check_same_param_groups(
-            sharded_osd1,
-            local_osd2,
-            check_same_param_keys=check_same_param_keys,
-        )
-        self._check_same_state(
-            sharded_osd1,
-            local_osd2,
-            check_same_param_keys=check_same_param_keys,
-        )
-        # As a sanity check, check that we can load and run a few iterations
-        optim2.load_state_dict(sharded_osd2)
-        self._step_model(model2, optim2, num_iters=num_iters)
-
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", STATE_DICT_TYPES)
     @parametrize("add_to_fsdp_module", [False, True])
-    def test_shard_full_optim_state_dict_unmanaged_params(
+    def test_optim_state_dict_unmanaged_params(
         self,
         state_dict_type: StateDictType,
         add_to_fsdp_module: bool,
     ):
         """
-        Tests :meth:`shard_full_optim_state_dict` when there are unmanaged
+        Tests :meth:`optim_state_dict_to_load` when there are unmanaged
         parameters.
           - If ``add_to_fsdp_module=True``, then the unmanaged parameters are
           added to a module to be wrapped with FSDP, in which case there should
@@ -1172,41 +875,13 @@ class TestFSDPOptimState(FSDPTest):
           added to a module not to be wrapped with FSDP, in which case there
           should be no error (emulating model parallel use cases where some
           parameters may be managed externally to FSDP).
-        We do not separately test unmanaged parameters for
-        :meth:`scatter_full_optim_state_dict` and `flatten_sharded_optim_state_dict`
-        to save CI cost since it call into the same subroutine
-        :meth:`_flatten_optim_state_dict`.
         """
-        if state_dict_type == StateDictType.SHARDED_STATE_DICT:
-            use_optim_input = [False]
-        else:
-            use_optim_input = [False, True]
-        self.run_subtests(
-            {"use_optim_input": use_optim_input},
-            self._test_shard_full_optim_state_dict_unmanaged_params,
-            state_dict_type=state_dict_type,
-            add_to_fsdp_module=add_to_fsdp_module,
-        )
-
-    def _test_shard_full_optim_state_dict_unmanaged_params(
-        self,
-        state_dict_type: StateDictType,
-        add_to_fsdp_module: bool,
-        use_optim_input: bool,
-    ):
         NUM_ITERS = 1
         # Create a normal wrapped model
-        model, optim, optim_input = self._init_nested_model(wrap=True)
+        model, optim, _ = self._init_nested_model(wrap=True)
+        FSDP.set_state_dict_type(model, state_dict_type)
         self._step_model(model, optim, num_iters=NUM_ITERS)
-
-        if state_dict_type == StateDictType.FULL_STATE_DICT:
-            fsdp_osd = (
-                FSDP.full_optim_state_dict(model, optim, optim_input, rank0_only=False)
-                if use_optim_input
-                else FSDP.full_optim_state_dict(model, optim, rank0_only=False)
-            )  # save on all ranks to avoid having to broadcast from rank 0
-        else:
-            fsdp_osd = FSDP.sharded_optim_state_dict(model, optim)
+        fsdp_osd = FSDP.optim_state_dict(model, optim)
         # Create a new model with the same structure but additional unmanaged
         # parameters, representing the model for which we want to load
         device = torch.device(device_type)
@@ -1215,49 +890,18 @@ class TestFSDPOptimState(FSDPTest):
             model,
             add_to_fsdp_module,
         )
-        optim_input = list(model.parameters())
-        optim = torch.optim.Adam(optim_input, lr=1e-3)
+        FSDP.set_state_dict_type(model, state_dict_type)
+        optim = torch.optim.Adam(model.parameters(), lr=1e-3)
         if add_to_fsdp_module:
-            # If we add the unmanaged parameters to a module wrapped with FSDP,
-            # then the flat parameter will be comprised of some unflattened
-            # parameters with zero-dimensional tensor state (i.e. Adam "step")
-            # and others without (i.e. the unmanaged parameters), which
-            # triggers an error that we have to ensure correctness
             error_prefix = (
                 "^(All unflattened parameters comprising a "
                 "single flat parameter must have scalar state with the "
                 "same value and dtype)"
             )
             with self.assertRaisesRegex(ValueError, error_prefix):
-                if state_dict_type == StateDictType.FULL_STATE_DICT:
-                    (
-                        FSDP.shard_full_optim_state_dict(
-                            fsdp_osd, model, optim_input=optim_input
-                        )
-                        if use_optim_input
-                        else FSDP.shard_full_optim_state_dict(
-                            fsdp_osd, model, optim=optim
-                        )
-                    )
-                else:
-                    FSDP.flatten_sharded_optim_state_dict(fsdp_osd, model, optim=optim)
+                FSDP.optim_state_dict_to_load(model, optim, fsdp_osd)
         else:
-            # If we add the unmanaged parameters to a module not wrapped with
-            # FSDP, then we simply ignore them without erroring to enable
-            # model parallelism use cases, where some parameters are managed
-            # externally to FSDP
-            if state_dict_type == StateDictType.FULL_STATE_DICT:
-                flattened_osd = (
-                    FSDP.shard_full_optim_state_dict(
-                        fsdp_osd, model, optim_input=optim_input
-                    )
-                    if use_optim_input
-                    else FSDP.shard_full_optim_state_dict(fsdp_osd, model, optim=optim)
-                )
-            else:
-                flattened_osd = FSDP.flatten_sharded_optim_state_dict(
-                    fsdp_osd, model, optim=optim
-                )
+            flattened_osd = FSDP.optim_state_dict_to_load(model, optim, fsdp_osd)
             # Add entries for the unmanaged parameters to be able to load
             for unmanaged_param in unmanaged_params:
                 NestedModel.add_unmanaged_param_entry(
@@ -1265,7 +909,6 @@ class TestFSDPOptimState(FSDPTest):
                     unmanaged_param,
                     NUM_ITERS,
                 )
-            # Check that we can load the optimizer state dict
             optim.load_state_dict(flattened_osd)
 
     @skip_if_lt_x_gpu(2)
@@ -1280,13 +923,7 @@ class TestFSDPOptimState(FSDPTest):
         parameter IDs by checking that a wrapped model (i.e. with FSDP modules)
         can rekey its optimizer state dict to match that of an equivalent
         non-wrapped model (i.e. without FSDP modules)."""
-        if state_dict_type == StateDictType.SHARDED_STATE_DICT:
-            use_optim_input = [False]
-        else:
-            use_optim_input = [False, True]
-        self.run_subtests(
-            {"use_optim_input": use_optim_input},
-            self._test_rekey_optim_state_dict_to_ids,
+        self._test_rekey_optim_state_dict_to_ids(
             state_dict_type=state_dict_type,
             use_multiple_param_groups=use_multiple_param_groups,
         )
@@ -1296,48 +933,33 @@ class TestFSDPOptimState(FSDPTest):
         self,
         state_dict_type: StateDictType,
         use_multiple_param_groups: bool,
-        use_optim_input: bool,
     ):
         NUM_ITERS = 3
         # Run a wrapped model for a few iterations
-        model1, optim1, optim_input1 = self._init_nested_model(
+        model1, optim1, _ = self._init_nested_model(
             wrap=True,
             use_multiple_param_groups=use_multiple_param_groups,
         )
         self._step_model(model1, optim1, num_iters=NUM_ITERS)
+        FSDP.set_state_dict_type(model1, state_dict_type)
+        fsdp_osd = FSDP.optim_state_dict(model1, optim1)
         if state_dict_type == StateDictType.FULL_STATE_DICT:
-            fsdp_osd = (
-                FSDP.full_optim_state_dict(model1, optim1, optim_input1)
-                if use_optim_input
-                else FSDP.full_optim_state_dict(model1, optim1)
-            )
             # Broadcast instead of `torch.save()`/`torch.load()` so that all ranks
             # have the full state dict
             fsdp_osd = self._broadcast_full_osd(fsdp_osd)
-        else:
-            fsdp_osd = FSDP.sharded_optim_state_dict(model1, optim1)
         # Run a non-wrapped model for a few iterations
-        model2, optim2, optim_input2 = self._init_nested_model(
+        model2, optim2, _ = self._init_nested_model(
             wrap=False,
             use_multiple_param_groups=use_multiple_param_groups,
         )
         self._step_model(model2, optim2, num_iters=NUM_ITERS)
         # Re-key the wrapped model's optimizer state dict using parameter IDs
         # according to the non-wrapped model
-        rekeyed_osd = (
-            FSDP.rekey_optim_state_dict(
-                fsdp_osd,
-                OptimStateKeyType.PARAM_ID,
-                model2,
-                optim_input=optim_input2,
-            )
-            if use_optim_input
-            else FSDP.rekey_optim_state_dict(
-                fsdp_osd,
-                OptimStateKeyType.PARAM_ID,
-                model2,
-                optim=optim2,
-            )
+        rekeyed_osd = FSDP.rekey_optim_state_dict(
+            fsdp_osd,
+            OptimStateKeyType.PARAM_ID,
+            model2,
+            optim=optim2,
         )
         # Check that the re-keyed dict and actual dict are the same
         osd = optim2.state_dict()
@@ -1362,29 +984,24 @@ class TestFSDPOptimState(FSDPTest):
         """Tests :meth:`rekey_optim_state_dict` with the new keys being
         parameter names by checking that a non-wrapped model (i.e. without FSDP
         modules) can rekey its optimizer state dict to match the expected
-        output of :meth:`full_optim_state_dict`, hence be sharded using
-        :meth:`shard_full_optim_state_dict`, and finally match the per-rank
+        output of :meth:`optim_state_dict`, hence be loaded using
+        :meth:`optim_state_dict_to_load`, and finally match the per-rank
         optimizer state dict of a wrapped model (i.e. with FSDP modules)."""
-        self.run_subtests(
-            {"use_optim_input": [False, True]},
-            self._test_rekey_optim_state_dict_to_names,
-            use_multiple_param_groups=False,
-        )
+        self._test_rekey_optim_state_dict_to_names(use_multiple_param_groups=False)
 
     def _test_rekey_optim_state_dict_to_names(
         self,
         use_multiple_param_groups: bool,
-        use_optim_input: bool,
     ):
         NUM_ITERS = 3
         # Run a wrapped model for a few iterations
-        model1, optim1, optim_input1 = self._init_nested_model(
+        model1, optim1, _ = self._init_nested_model(
             wrap=True,
             use_multiple_param_groups=use_multiple_param_groups,
         )
         self._step_model(model1, optim1, num_iters=NUM_ITERS)
         # Run a non-wrapped model for a few iterations
-        model2, optim2, optim_input2 = self._init_nested_model(
+        model2, optim2, _ = self._init_nested_model(
             wrap=False,
             use_multiple_param_groups=use_multiple_param_groups,
         )
@@ -1392,36 +1009,14 @@ class TestFSDPOptimState(FSDPTest):
         # Re-key the non-wrapped model's optimizer state dict using parameter
         # names (still according to itself)
         osd2 = optim2.state_dict()
-        rekeyed_osd = (
-            FSDP.rekey_optim_state_dict(
-                osd2,
-                OptimStateKeyType.PARAM_NAME,
-                model2,
-                optim_input=optim_input2,
-            )
-            if use_optim_input
-            else FSDP.rekey_optim_state_dict(
-                osd2,
-                OptimStateKeyType.PARAM_NAME,
-                model2,
-                optim=optim2,
-            )
+        rekeyed_osd = FSDP.rekey_optim_state_dict(
+            osd2,
+            OptimStateKeyType.PARAM_NAME,
+            model2,
+            optim=optim2,
         )
-        # Shard the non-wrapped model's re-keyed optimizer state dict, which
-        # maps back to (flattened) parameter IDs
-        sharded_osd = (
-            FSDP.shard_full_optim_state_dict(
-                rekeyed_osd,
-                model1,
-                optim_input=optim_input1,
-            )
-            if use_optim_input
-            else FSDP.shard_full_optim_state_dict(
-                rekeyed_osd,
-                model1,
-                optim=optim1,
-            )
-        )
+        # Load the re-keyed optimizer state dict into the wrapped model
+        sharded_osd = FSDP.optim_state_dict_to_load(model1, optim1, rekeyed_osd)
         # Check that this sharded optimizer state dict matches the wrapped
         # model's per-rank optimizer state dict
         osd1 = optim1.state_dict()
@@ -1441,109 +1036,33 @@ class TestFSDPOptimState(FSDPTest):
         self._step_model(model1, optim1, num_iters=NUM_ITERS)
 
     @skip_if_lt_x_gpu(2)
-    def test_optim_input_warning(self):
-        """Tests that passing the ``optim_input`` argument into optimizer state
-        checkpointing APIs issues a warning."""
-
-        def should_check_method(method_name: str):
-            # Check every method since they all accept `optim_input`
-            return method_name not in (
-                "sharded_optim_state_dict",
-                "flatten_sharded_optim_state_dict",
-            )
-
-        def get_warning_context():
-            warning_regex = "`optim_input` argument is deprecated"
-            return self.assertWarnsRegex(
-                expected_warning=FutureWarning, expected_regex=warning_regex
-            )
-
-        self._run_on_all_optim_state_apis(
-            should_check_method, get_warning_context, fsdp_kwargs=None
-        )
-
-    def _run_on_all_optim_state_apis(
-        self,
-        should_check_method_fn: Callable[[str], bool],
-        context_fn: Callable,
-        fsdp_kwargs: dict[str, Any] | None,
-    ):
-        """
-        Runs through all optimizer state checkpointing APIs with a context
-        manager instantiated by ``context_fn``. Certain APIs can be skipped
-        via ``should_check_method_fn``, which gets passed the string name of
-        the method.
-        """
-        wrapped_model, wrapped_optim, wrapped_optim_input = self._init_nested_model(
+    def test_deprecated_optim_apis_raise(self):
+        """Tests that removed optimizer state dict APIs raise NotImplementedError
+        and that passing ``optim_input`` to ``rekey_optim_state_dict`` raises
+        ValueError."""
+        model, optim, optim_input = self._init_nested_model(
             wrap=True,
             use_multiple_param_groups=False,
-            fsdp_kwargs=fsdp_kwargs,
         )
-        self._step_model(wrapped_model, wrapped_optim, num_iters=2)
+        self._step_model(model, optim, num_iters=2)
 
-        # Sharded optim state dict
-        if should_check_method_fn("sharded_optim_state_dict"):
-            with context_fn():
-                fsdp_osd = FSDP.sharded_optim_state_dict(
-                    wrapped_model,
-                    wrapped_optim,
-                )
-        if "fsdp_osd" not in locals():
-            fsdp_osd = {}  # may not be defined due to previous method erroring
-        if should_check_method_fn("flatten_sharded_optim_state_dict"):
-            with context_fn():
-                FSDP.flatten_sharded_optim_state_dict(
-                    fsdp_osd,
-                    wrapped_model,
-                    wrapped_optim,
-                )
-        # Full optim state dict
-        if should_check_method_fn("full_optim_state_dict"):
-            with context_fn():
-                fsdp_osd = FSDP.full_optim_state_dict(
-                    wrapped_model,
-                    wrapped_optim,
-                    optim_input=wrapped_optim_input,
-                    rank0_only=False,
-                )
-        if should_check_method_fn("shard_full_optim_state_dict"):
-            with context_fn():
-                FSDP.shard_full_optim_state_dict(
-                    fsdp_osd,
-                    wrapped_model,
-                    optim_input=wrapped_optim_input,
-                )
-        if should_check_method_fn("scatter_full_optim_state_dict"):
-            with context_fn():
-                FSDP.scatter_full_optim_state_dict(
-                    fsdp_osd,
-                    wrapped_model,
-                    optim_input=wrapped_optim_input,
-                )
-        # Rekey optim state dict
-        (
-            nonwrapped_model,
-            nonwrapped_optim,
-            nonwrapped_optim_input,
-        ) = self._init_nested_model(wrap=False, use_multiple_param_groups=False)
-        if should_check_method_fn("rekey_optim_state_dict"):
-            with context_fn():
-                FSDP.rekey_optim_state_dict(
-                    fsdp_osd,  # from `full_optim_state_dict()`
-                    OptimStateKeyType.PARAM_ID,
-                    nonwrapped_model,
-                    optim_input=nonwrapped_optim_input,
-                )
-        self._step_model(nonwrapped_model, nonwrapped_optim, num_iters=2)
-        osd = nonwrapped_optim.state_dict()
-        if should_check_method_fn("rekey_optim_state_dict"):
-            with context_fn():
-                FSDP.rekey_optim_state_dict(
-                    osd,
-                    OptimStateKeyType.PARAM_NAME,
-                    nonwrapped_model,
-                    optim_input=nonwrapped_optim_input,
-                )
+        with self.assertRaises(NotImplementedError):
+            FSDP.full_optim_state_dict(model, optim)
+        with self.assertRaises(NotImplementedError):
+            FSDP.sharded_optim_state_dict(model, optim)
+        with self.assertRaises(NotImplementedError):
+            FSDP.shard_full_optim_state_dict({}, model, optim=optim)
+        with self.assertRaises(NotImplementedError):
+            FSDP.flatten_sharded_optim_state_dict({}, model, optim)
+        with self.assertRaises(NotImplementedError):
+            FSDP.scatter_full_optim_state_dict(None, model, optim=optim)
+        with self.assertRaises(ValueError):
+            FSDP.rekey_optim_state_dict(
+                {},
+                OptimStateKeyType.PARAM_ID,
+                model,
+                optim_input=optim_input,
+            )
 
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", STATE_DICT_TYPES)
@@ -1583,14 +1102,9 @@ class TestFSDPOptimState(FSDPTest):
         optim.step()
 
         # Check that save and load does not error
-        if state_dict_type == StateDictType.FULL_STATE_DICT:
-            fsdp_osd = FSDP.full_optim_state_dict(fsdp_model, optim, rank0_only=False)
-            flattened_osd = FSDP.shard_full_optim_state_dict(fsdp_osd, fsdp_model)
-        elif state_dict_type == StateDictType.SHARDED_STATE_DICT:
-            fsdp_osd = FSDP.sharded_optim_state_dict(fsdp_model, optim)
-            flattened_osd = FSDP.flatten_sharded_optim_state_dict(
-                fsdp_osd, fsdp_model, optim
-            )
+        FSDP.set_state_dict_type(fsdp_model, state_dict_type)
+        fsdp_osd = FSDP.optim_state_dict(fsdp_model, optim)
+        flattened_osd = FSDP.optim_state_dict_to_load(fsdp_model, optim, fsdp_osd)
         optim.load_state_dict(flattened_osd)
         # `__setstate__()` will check the 0th parameter to see if "step" is
         # represented as a tensor or float, so it is imperative that its state

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -3,7 +3,7 @@ import copy
 import functools
 import logging
 import warnings
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterator, Sequence
 from contextlib import ExitStack
 from dataclasses import dataclass, field
 from itertools import chain
@@ -876,8 +876,6 @@ def _rekey_sharded_optim_state_dict(
     sharded_osd: dict[str, Any],
     model: nn.Module,
     optim: torch.optim.Optimizer,
-    optim_input: list[dict[str, Any]] | Iterable[nn.Parameter] | None,
-    using_optim_input: bool,
     is_named_optimizer: bool = False,
 ) -> dict[str, Any]:
     """
@@ -890,12 +888,8 @@ def _rekey_sharded_optim_state_dict(
     flat_param_to_fqn = _get_flat_param_to_fqn(model)
     param_to_param_key: dict[nn.Parameter, int | str] = cast(
         dict[nn.Parameter, int | str],
-        (
-            _get_param_to_param_id_from_optim_input(model, optim_input)
-            if using_optim_input
-            else _get_param_to_param_key(
-                optim, model, is_named_optimizer, param_to_fqns, flat_param_to_fqn
-            )
+        _get_param_to_param_key(
+            optim, model, is_named_optimizer, param_to_fqns, flat_param_to_fqn
         ),
     )
     # All parameter keys in `param_to_param_key` should be in
@@ -947,78 +941,6 @@ def _rekey_sharded_optim_state_dict(
         return {"state": rekeyed_osd_state, "param_groups": rekeyed_osd_param_groups}
     else:
         return {"state": rekeyed_osd_state}
-
-
-def _get_param_id_to_param_from_optim_input(
-    model: nn.Module,
-    optim_input: list[dict[str, Any]] | Iterable[nn.Parameter] | None = None,
-) -> dict[int, nn.Parameter]:
-    """
-    Constructs a mapping from parameter IDs to parameters. This may be used
-    both for models with ``FlatParameter`` s and without.
-
-    NOTE: This method is only preserved for backward compatibility. The method
-    :meth:`_get_param_key_to_param` is the preferred code path that does not
-    rely on ``optim_input``.
-
-    NOTE: We critically assume that, whether the optimizer input is a list of
-    parameters or a list of parameter groups, :class:`torch.optim.Optimizer`
-    enumerates the parameter IDs in order. In other words, for a parameter list
-    input, the parameter IDs should be in that list order, and for a parameter
-    groups input, the parameter IDs should be in order within each parameter
-    group and in order across parameter groups.
-
-    Args:
-        model (nn.Module): Model whose parameters are passed into the
-            optimizer.
-        optim_input (Optional[Union[List[Dict[str, Any]],
-        Iterable[nn.Parameter]]]): Input passed into the optimizer
-            representing either a :class:`list` of parameter groups or an
-            iterable of parameters; if ``None``, then this method assumes the
-            input was ``model.parameters()``. (Default: ``None``)
-
-    Returns:
-        List[nn.Parameter]: Mapping from parameter IDs to parameters,
-        where the parameter ID is implicitly the index in the :class:`list`.
-    """
-    # Assume the standard case of passing `model.parameters()` to the optimizer
-    # if `optim_input` is not specified
-    if optim_input is None:
-        return dict(enumerate(model.parameters()))
-    try:
-        # pyrefly: ignore [redundant-cast]
-        params = cast(list[nn.Parameter], list(optim_input))
-    except TypeError as e:
-        raise TypeError(
-            "Optimizer input should be an iterable of Tensors or dicts, "
-            f"but got {optim_input}"
-        ) from e
-    if len(params) == 0:
-        raise ValueError("Optimizer input should not be empty")
-
-    # Check if the optimizer input represents tensors or parameter groups
-    all_tensors = True
-    all_dicts = True
-    for param in params:
-        all_tensors &= isinstance(param, torch.Tensor)
-        all_dicts &= isinstance(param, dict)
-    if not all_tensors and not all_dicts:
-        raise TypeError("Optimizer input should be an iterable of Tensors or dicts")
-    if all_tensors:
-        return dict(enumerate(params))
-    if not all_dicts:
-        raise AssertionError(f"Expected all_dicts to be True, got {all_dicts}")
-    param_id_to_param: list[nn.Parameter] = []
-    for param_group in params:
-        has_params_key = "params" in param_group  # type: ignore[operator]
-        if not has_params_key:
-            raise AssertionError(
-                'A parameter group should map "params" to a list of the parameters in the group'
-            )
-        # Implicitly map `flat_param_id` (current length of the list) to
-        # `param`
-        param_id_to_param.extend(param_group["params"])  # type: ignore[index]
-    return dict(enumerate(param_id_to_param))
 
 
 def _get_flat_param_to_fqn(model: torch.nn.Module) -> dict[FlatParameter, str]:
@@ -1135,15 +1057,6 @@ def _get_param_to_param_key(
     param_id_to_param = _get_param_key_to_param(
         optim, model, is_named_optimizer, param_to_fqns, flat_param_to_fqn
     )
-    return {param: param_id for param_id, param in param_id_to_param.items()}
-
-
-def _get_param_to_param_id_from_optim_input(
-    model: nn.Module,
-    optim_input: list[dict[str, Any]] | Iterable[nn.Parameter] | None = None,
-) -> dict[nn.Parameter, int]:
-    """Constructs the inverse mapping of :func:`_get_param_id_to_param_from_optim_input`."""
-    param_id_to_param = _get_param_id_to_param_from_optim_input(model, optim_input)
     return {param: param_id for param_id, param in param_id_to_param.items()}
 
 
@@ -1890,11 +1803,9 @@ def _optim_state_dict(
     model: nn.Module,
     optim: torch.optim.Optimizer,
     optim_state_dict: dict[str, Any],
-    optim_input: list[dict[str, Any]] | Iterable[nn.Parameter] | None,
     rank0_only: bool,
     shard_state: bool,
     group: dist.ProcessGroup | None,
-    using_optim_input: bool,
     use_orig_params: bool = False,
     cpu_offload: bool = True,
 ) -> dict[str, Any]:
@@ -1908,9 +1819,7 @@ def _optim_state_dict(
     Parameter keys are not well-defined. For a regular optimizer, the optimizer
     state_dict contains a mapping from parameter IDs to parameter states.
     Parameter IDs are the order of parameters in ``optim.param_groups()`` across
-    all the groups. This API also allows user to pass ``optim_input`` for the
-    mapping between parameters and parameter IDs. Using ``optim_input`` is being
-    deprecated.
+    all the groups.
 
     If the optimizer is a ``NamedOptimizer``, the optimizer state_dict does not
     contain parameter IDs mapping but a mapping from parameter FQNs to parameter
@@ -1959,12 +1868,8 @@ def _optim_state_dict(
 
         param_key_to_param = cast(
             dict[int | str, nn.Parameter],
-            (
-                _get_param_id_to_param_from_optim_input(model, optim_input)
-                if using_optim_input
-                else _get_param_key_to_param(
-                    optim, model, is_named_optimizer, param_to_fqns, flat_param_to_fqn
-                )
+            _get_param_key_to_param(
+                optim, model, is_named_optimizer, param_to_fqns, flat_param_to_fqn
             ),
         )
         fqn_to_fsdp_param_info = _get_fqn_to_fsdp_param_info(model)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -80,9 +80,7 @@ from torch.utils._typing_utils import copy_method_params, copy_method_sig
 from ._flat_param import FlatParameter, FlatParamHandle
 from ._optim_utils import (
     _flatten_optim_state_dict,
-    _get_param_id_to_param_from_optim_input,
     _get_param_key_to_param,
-    _get_param_to_param_id_from_optim_input,
     _get_param_to_param_key,
     _optim_state_dict,
     _rekey_sharded_optim_state_dict,
@@ -1222,48 +1220,14 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         return total_norm.to(total_norm_dtype)
 
     @staticmethod
-    def _warn_optim_input(optim_input, *, stacklevel: int = 1):
-        if optim_input is not None:
-            warnings.warn(
-                "The `optim_input` argument is deprecated and will be removed after PyTorch 1.13. "
-                "You may remove it from your code without changing its functionality.",
-                FutureWarning,
-                stacklevel=stacklevel + 1,
-            )
-
-    @staticmethod
-    def _is_using_optim_input(optim_input, optim) -> bool:
-        if optim_input is None and optim is None:
-            # Use the default behavior of `optim_input``
-            return True
-        if optim_input is not None:
-            # Use the `optim_input` code path
-            return True
-        # Use the `optim` code path
-        return False
-
-    @staticmethod
-    def _warn_legacy_optim_state_dict(curr: str, new: str, *, stacklevel: int = 1):
-        warnings.warn(
-            f"``FullyShardedDataParallel.{curr}``is being deprecated and is "
-            f"replaced by ``FullyShardedDataParallel.{new}``. "
-            f"``FullyShardedDataParallel.{curr}`` may be removed after PyTorch 2.2.",
-            FutureWarning,
-            stacklevel=stacklevel + 1,
-        )
-
-    @staticmethod
     def _optim_state_dict_impl(
         model: torch.nn.Module,
         optim: torch.optim.Optimizer,
         optim_state_dict: dict[str, Any],
-        optim_input: list[dict[str, Any]] | Iterable[torch.nn.Parameter] | None = None,
         rank0_only: bool = True,
         full_state_dict: bool = True,
         group: dist.ProcessGroup | None = None,
         cpu_offload: bool = True,
-        *,
-        _stacklevel: int = 1,
     ) -> dict[str, Any]:
         """Transform the state-dict of an optimizer corresponding to a sharded model.
 
@@ -1271,21 +1235,11 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         Given model, optim, the original optim_state_dict, this API removes the
         FSDP internal information and internal sharding from the optim_state_dict.
         """
-        if full_state_dict:
-            FullyShardedDataParallel._warn_optim_input(
-                optim_input, stacklevel=_stacklevel + 1
+        if not full_state_dict and rank0_only:
+            raise AssertionError(
+                f"Expected rank0_only to be False for non-full state dict, "
+                f"got rank0_only={rank0_only}"
             )
-            using_optim_input = FullyShardedDataParallel._is_using_optim_input(
-                optim_input,
-                optim,
-            )
-        else:
-            using_optim_input = False
-            if optim_input is not None or rank0_only:
-                raise AssertionError(
-                    f"Expected optim_input to be None and rank0_only to be False, "
-                    f"got optim_input={optim_input}, rank0_only={rank0_only}"
-                )
 
         use_orig_params = FullyShardedDataParallel.fsdp_modules(model)[
             0
@@ -1302,11 +1256,9 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             model=model,
             optim=optim,
             optim_state_dict=optim_state_dict,
-            optim_input=optim_input,
             rank0_only=rank0_only,
             shard_state=not full_state_dict,
             group=group,
-            using_optim_input=using_optim_input,
             use_orig_params=use_orig_params,
             cpu_offload=cpu_offload,
         )
@@ -1315,7 +1267,6 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
     def _optim_state_dict_to_load_impl(
         optim_state_dict: dict[str, Any],
         model: torch.nn.Module,
-        optim_input: list[dict[str, Any]] | Iterable[torch.nn.Parameter] | None = None,
         optim: torch.optim.Optimizer | None = None,
         full_state_dict: bool = True,
         rank0_only: bool = False,
@@ -1329,19 +1280,11 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         Given model, optim, and the saved optim_state_dict, this API adds the FSDP
         internal information and internal sharding to the optim_state_dict.
         """
-        if full_state_dict:
-            FullyShardedDataParallel._warn_optim_input(optim_input)
-            using_optim_input = FullyShardedDataParallel._is_using_optim_input(
-                optim_input,
-                optim,
+        if not full_state_dict and rank0_only:
+            raise AssertionError(
+                f"Expected rank0_only to be False for non-full state dict, "
+                f"got rank0_only={rank0_only}"
             )
-        else:
-            using_optim_input = False
-            if optim_input is not None or rank0_only:
-                raise AssertionError(
-                    f"Expected optim_input to be None and rank0_only to be False, "
-                    f"got optim_input={optim_input}, rank0_only={rank0_only}"
-                )
 
         use_orig_params = FullyShardedDataParallel.fsdp_modules(model)[
             0
@@ -1368,8 +1311,6 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             sharded_osd,
             model=model,
             optim=optim,
-            optim_input=optim_input,
-            using_optim_input=using_optim_input,
             is_named_optimizer=is_named_optimizer,
         )
 
@@ -1381,67 +1322,10 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         rank0_only: bool = True,
         group: dist.ProcessGroup | None = None,
     ) -> dict[str, Any]:
-        """Return the full optimizer state-dict.
-
-        Consolidates the full optimizer state on rank 0 and returns it
-        as a :class:`dict` following the convention of
-        :meth:`torch.optim.Optimizer.state_dict`, i.e. with keys ``"state"``
-        and ``"param_groups"``. The flattened parameters in ``FSDP`` modules
-        contained in ``model`` are mapped back to their unflattened parameters.
-
-        This needs to be called on all ranks since it uses
-        collective communications. However, if ``rank0_only=True``, then
-        the state dict is only populated on rank 0, and all other ranks
-        return an empty :class:`dict`.
-
-        Unlike ``torch.optim.Optimizer.state_dict()``, this method
-        uses full parameter names as keys instead of parameter IDs.
-
-        Like in :meth:`torch.optim.Optimizer.state_dict`, the tensors
-        contained in the optimizer state dict are not cloned, so there may
-        be aliasing surprises. For best practices, consider saving the
-        returned optimizer state dict immediately, e.g. using
-        ``torch.save()``.
-
-        Args:
-            model (torch.nn.Module): Root module (which may or may not be a
-                :class:`FullyShardedDataParallel` instance) whose parameters
-                were passed into the optimizer ``optim``.
-            optim (torch.optim.Optimizer): Optimizer for ``model`` 's
-                parameters.
-            optim_input (Optional[Union[List[Dict[str, Any]], Iterable[torch.nn.Parameter]]]):
-                Input passed into the optimizer ``optim`` representing either a
-                :class:`list` of parameter groups or an iterable of parameters;
-                if ``None``, then this method assumes the input was
-                ``model.parameters()``. This argument is deprecated, and there
-                is no need to pass it in anymore. (Default: ``None``)
-            rank0_only (bool): If ``True``, saves the populated :class:`dict`
-                only on rank 0; if ``False``, saves it on all ranks. (Default:
-                ``True``)
-            group (dist.ProcessGroup): Model's process group or ``None`` if using
-                the default process group. (Default: ``None``)
-
-        Returns:
-            Dict[str, Any]: A :class:`dict` containing the optimizer state for
-            ``model`` 's original unflattened parameters and including keys
-            "state" and "param_groups" following the convention of
-            :meth:`torch.optim.Optimizer.state_dict`. If ``rank0_only=True``,
-            then nonzero ranks return an empty :class:`dict`.
-        """
-        FullyShardedDataParallel._warn_legacy_optim_state_dict(
-            "full_optim_state_dict",
-            "optim_state_dict",
-            stacklevel=2,
-        )
-        return FullyShardedDataParallel._optim_state_dict_impl(
-            model=model,
-            optim=optim,
-            optim_state_dict=optim.state_dict(),
-            optim_input=optim_input,
-            rank0_only=rank0_only,
-            group=group,
-            full_state_dict=True,
-            _stacklevel=2,
+        """Removed. Use :meth:`optim_state_dict` instead."""
+        raise NotImplementedError(
+            "FullyShardedDataParallel.full_optim_state_dict has been removed. "
+            "Use FullyShardedDataParallel.optim_state_dict instead."
         )
 
     @staticmethod
@@ -1450,32 +1334,10 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         optim: torch.optim.Optimizer,
         group: dist.ProcessGroup | None = None,
     ) -> dict[str, Any]:
-        """Return the optimizer state-dict in its sharded form.
-
-        The API is similar to :meth:`full_optim_state_dict` but this API chunks
-        all non-zero-dimension states to :class:`ShardedTensor` to save memory.
-        This API should only be used when the model ``state_dict`` is derived
-        with the context manager ``with state_dict_type(SHARDED_STATE_DICT):``.
-
-        For the detailed usage, refer to :meth:`full_optim_state_dict`.
-
-        .. warning:: The returned state dict contains ``ShardedTensor`` and
-            cannot be directly used by the regular ``optim.load_state_dict``.
-        """
-        FullyShardedDataParallel._warn_legacy_optim_state_dict(
-            "sharded_optim_state_dict",
-            "optim_state_dict",
-            stacklevel=2,
-        )
-        return FullyShardedDataParallel._optim_state_dict_impl(
-            model=model,
-            optim=optim,
-            optim_state_dict=optim.state_dict(),
-            optim_input=None,
-            rank0_only=False,
-            full_state_dict=False,
-            group=group,
-            _stacklevel=2,
+        """Removed. Use :meth:`optim_state_dict` instead."""
+        raise NotImplementedError(
+            "FullyShardedDataParallel.sharded_optim_state_dict has been removed. "
+            "Use FullyShardedDataParallel.optim_state_dict instead."
         )
 
     @staticmethod
@@ -1485,71 +1347,10 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         optim_input: list[dict[str, Any]] | Iterable[torch.nn.Parameter] | None = None,
         optim: torch.optim.Optimizer | None = None,
     ) -> dict[str, Any]:
-        """Shard a full optimizer state-dict.
-
-        Remaps the state in ``full_optim_state_dict`` to flattened parameters instead of unflattened
-        parameters and restricts to only this rank's part of the optimizer state.
-        The first argument should be the return value of :meth:`full_optim_state_dict`.
-
-        Example::
-
-            >>> # xdoctest: +SKIP("undefined variables")
-            >>> from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-            >>> model, optim = ...
-            >>> full_osd = FSDP.full_optim_state_dict(model, optim)
-            >>> torch.save(full_osd, PATH)
-            >>> # Define new model with possibly different world size
-            >>> new_model, new_optim = ...
-            >>> full_osd = torch.load(PATH)
-            >>> sharded_osd = FSDP.shard_full_optim_state_dict(full_osd, new_model)
-            >>> new_optim.load_state_dict(sharded_osd)
-
-        .. note:: Both :meth:`shard_full_optim_state_dict` and
-            :meth:`scatter_full_optim_state_dict` may be used to get the
-            sharded optimizer state dict to load. Assuming that the full
-            optimizer state dict resides in CPU memory, the former requires
-            each rank to have the full dict in CPU memory, where each rank
-            individually shards the dict without any communication, while the
-            latter requires only rank 0 to have the full dict in CPU memory,
-            where rank 0 moves each shard to GPU memory (for NCCL) and
-            communicates it to ranks appropriately. Hence, the former has
-            higher aggregate CPU memory cost, while the latter has higher
-            communication cost.
-
-        Args:
-            full_optim_state_dict (Dict[str, Any]): Optimizer state dict
-                corresponding to the unflattened parameters and holding the
-                full non-sharded optimizer state.
-            model (torch.nn.Module): Root module (which may or may not be a
-                :class:`FullyShardedDataParallel` instance) whose parameters
-                correspond to the optimizer state in ``full_optim_state_dict``.
-            optim_input (Optional[Union[List[Dict[str, Any]], Iterable[torch.nn.Parameter]]]):
-                Input passed into the optimizer representing either a
-                :class:`list` of parameter groups or an iterable of parameters;
-                if ``None``, then this method assumes the input was
-                ``model.parameters()``. This argument is deprecated, and there
-                is no need to pass it in anymore. (Default: ``None``)
-            optim (Optional[torch.optim.Optimizer]): Optimizer that will load
-                the state dict returned by this method. This is the preferred
-                argument to use over ``optim_input``. (Default: ``None``)
-
-        Returns:
-            Dict[str, Any]: The full optimizer state dict now remapped to
-            flattened parameters instead of unflattened parameters and
-            restricted to only include this rank's part of the optimizer state.
-        """
-        FullyShardedDataParallel._warn_legacy_optim_state_dict(
-            "shard_full_optim_state_dict",
-            "optim_state_dict_to_load",
-            stacklevel=2,
-        )
-        return FullyShardedDataParallel._optim_state_dict_to_load_impl(
-            optim_state_dict=full_optim_state_dict,
-            model=model,
-            optim_input=optim_input,
-            optim=optim,
-            full_state_dict=True,
-            is_named_optimizer=False,
+        """Removed. Use :meth:`optim_state_dict_to_load` instead."""
+        raise NotImplementedError(
+            "FullyShardedDataParallel.shard_full_optim_state_dict has been removed. "
+            "Use FullyShardedDataParallel.optim_state_dict_to_load instead."
         )
 
     @staticmethod
@@ -1558,37 +1359,10 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         model: torch.nn.Module,
         optim: torch.optim.Optimizer,
     ) -> dict[str, Any]:
-        """Flatten a sharded optimizer state-dict.
-
-        The API is similar to :meth:`shard_full_optim_state_dict`. The only
-        difference is that the input ``sharded_optim_state_dict`` should be
-        returned from :meth:`sharded_optim_state_dict`. Therefore, there will
-        be all-gather calls on each rank to gather ``ShardedTensor`` s.
-
-        Args:
-            sharded_optim_state_dict (Dict[str, Any]): Optimizer state dict
-                corresponding to the unflattened parameters and holding the
-                sharded optimizer state.
-            model (torch.nn.Module):
-                Refer to :meth:`shard_full_optim_state_dict`.
-            optim (torch.optim.Optimizer): Optimizer for ``model`` 's
-                parameters.
-
-        Returns:
-            Refer to :meth:`shard_full_optim_state_dict`.
-        """
-        FullyShardedDataParallel._warn_legacy_optim_state_dict(
-            "flatten_sharded_optim_state_dict",
-            "optim_state_dict_to_load",
-            stacklevel=2,
-        )
-        return FullyShardedDataParallel._optim_state_dict_to_load_impl(
-            optim_state_dict=sharded_optim_state_dict,
-            model=model,
-            optim_input=None,
-            optim=optim,
-            full_state_dict=False,
-            is_named_optimizer=False,
+        """Removed. Use :meth:`optim_state_dict_to_load` instead."""
+        raise NotImplementedError(
+            "FullyShardedDataParallel.flatten_sharded_optim_state_dict has been removed. "
+            "Use FullyShardedDataParallel.optim_state_dict_to_load instead."
         )
 
     @staticmethod
@@ -1599,75 +1373,10 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         optim: torch.optim.Optimizer | None = None,
         group: Any | None = None,
     ) -> dict[str, Any]:
-        """Scatter the full optimizer state dict from rank 0 to all other ranks.
-
-        Returns the sharded optimizer state dict on each rank.
-        The return value is the same as :meth:`shard_full_optim_state_dict`, and on rank
-        0, the first argument should be the return value of
-        :meth:`full_optim_state_dict`.
-
-        Example::
-
-            >>> # xdoctest: +SKIP("undefined variables")
-            >>> from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-            >>> model, optim = ...
-            >>> full_osd = FSDP.full_optim_state_dict(model, optim)  # only non-empty on rank 0
-            >>> # Define new model with possibly different world size
-            >>> new_model, new_optim, new_group = ...
-            >>> sharded_osd = FSDP.scatter_full_optim_state_dict(full_osd, new_model, group=new_group)
-            >>> new_optim.load_state_dict(sharded_osd)
-
-        .. note:: Both :meth:`shard_full_optim_state_dict` and
-            :meth:`scatter_full_optim_state_dict` may be used to get the
-            sharded optimizer state dict to load. Assuming that the full
-            optimizer state dict resides in CPU memory, the former requires
-            each rank to have the full dict in CPU memory, where each rank
-            individually shards the dict without any communication, while the
-            latter requires only rank 0 to have the full dict in CPU memory,
-            where rank 0 moves each shard to GPU memory (for NCCL) and
-            communicates it to ranks appropriately. Hence, the former has
-            higher aggregate CPU memory cost, while the latter has higher
-            communication cost.
-
-        Args:
-            full_optim_state_dict (Optional[Dict[str, Any]]): Optimizer state
-                dict corresponding to the unflattened parameters and holding
-                the full non-sharded optimizer state if on rank 0; the argument
-                is ignored on nonzero ranks.
-            model (torch.nn.Module): Root module (which may or may not be a
-                :class:`FullyShardedDataParallel` instance) whose parameters
-                correspond to the optimizer state in ``full_optim_state_dict``.
-            optim_input (Optional[Union[List[Dict[str, Any]], Iterable[torch.nn.Parameter]]]):
-                Input passed into the optimizer representing either a
-                :class:`list` of parameter groups or an iterable of parameters;
-                if ``None``, then this method assumes the input was
-                ``model.parameters()``. This argument is deprecated, and there
-                is no need to pass it in anymore. (Default: ``None``)
-            optim (Optional[torch.optim.Optimizer]): Optimizer that will load
-                the state dict returned by this method. This is the preferred
-                argument to use over ``optim_input``. (Default: ``None``)
-            group (dist.ProcessGroup): Model's process group or ``None`` if
-                using the default process group. (Default: ``None``)
-
-        Returns:
-            Dict[str, Any]: The full optimizer state dict now remapped to
-            flattened parameters instead of unflattened parameters and
-            restricted to only include this rank's part of the optimizer state.
-        """
-        FullyShardedDataParallel._warn_legacy_optim_state_dict(
-            "scatter_full_optim_state_dict",
-            "optim_state_dict_to_load",
-            stacklevel=2,
-        )
-        return FullyShardedDataParallel._optim_state_dict_to_load_impl(
-            optim_state_dict=full_optim_state_dict,
-            model=model,
-            optim_input=optim_input,
-            optim=optim,
-            full_state_dict=True,
-            rank0_only=True,
-            is_named_optimizer=False,
-            group=group,
+        """Removed. Use :meth:`optim_state_dict_to_load` instead."""
+        raise NotImplementedError(
+            "FullyShardedDataParallel.scatter_full_optim_state_dict has been removed. "
+            "Use FullyShardedDataParallel.optim_state_dict_to_load instead."
         )
 
     @staticmethod
@@ -1683,37 +1392,18 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         This can be used to achieve compatibility between optimizer state dicts from models with FSDP
         instances and ones without.
 
-        To re-key an FSDP full optimizer state dict (i.e. from
-        :meth:`full_optim_state_dict`) to use parameter IDs and be loadable to
-        a non-wrapped model::
-
-            >>> # xdoctest: +SKIP("undefined variables")
-            >>> wrapped_model, wrapped_optim = ...
-            >>> full_osd = FSDP.full_optim_state_dict(wrapped_model, wrapped_optim)
-            >>> nonwrapped_model, nonwrapped_optim = ...
-            >>> rekeyed_osd = FSDP.rekey_optim_state_dict(full_osd, OptimStateKeyType.PARAM_ID, nonwrapped_model)
-            >>> nonwrapped_optim.load_state_dict(rekeyed_osd)
-
-        To re-key a normal optimizer state dict from a non-wrapped model to be
-        loadable to a wrapped model::
-
-            >>> # xdoctest: +SKIP("undefined variables")
-            >>> nonwrapped_model, nonwrapped_optim = ...
-            >>> osd = nonwrapped_optim.state_dict()
-            >>> rekeyed_osd = FSDP.rekey_optim_state_dict(osd, OptimStateKeyType.PARAM_NAME, nonwrapped_model)
-            >>> wrapped_model, wrapped_optim = ...
-            >>> sharded_osd = FSDP.shard_full_optim_state_dict(rekeyed_osd, wrapped_model)
-            >>> wrapped_optim.load_state_dict(sharded_osd)
+        .. note:: The ``optim_input`` argument has been removed. Pass the
+            ``optim`` argument instead.
 
         Returns:
             Dict[str, Any]: The optimizer state dict re-keyed using the
             parameter keys specified by ``optim_state_key_type``.
         """
-        FullyShardedDataParallel._warn_optim_input(optim_input)
-        using_optim_input = FullyShardedDataParallel._is_using_optim_input(
-            optim_input,
-            optim,
-        )
+        if optim_input is not None:
+            raise ValueError(
+                "The `optim_input` argument has been removed from "
+                "rekey_optim_state_dict. Use the `optim` argument instead."
+            )
         if optim_state_key_type not in (
             OptimStateKeyType.PARAM_NAME,
             OptimStateKeyType.PARAM_ID,
@@ -1742,11 +1432,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         # Otherwise, actually perform the re-keying
         new_osd = {}
         if optim_state_key_type == OptimStateKeyType.PARAM_NAME:  # ID -> name
-            param_id_to_param = (
-                _get_param_id_to_param_from_optim_input(model, optim_input)
-                if using_optim_input
-                else _get_param_key_to_param(optim)
-            )
+            param_id_to_param = _get_param_key_to_param(optim)
             param_to_param_name = _get_param_to_fqn(model)
             param_id_to_param_name: list[str] = [
                 param_to_param_name[param] for param in param_id_to_param.values()
@@ -1766,11 +1452,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             return new_osd
         elif optim_state_key_type == OptimStateKeyType.PARAM_ID:  # name -> ID
             param_name_to_param = _get_fqn_to_param(model)
-            param_to_param_id = (
-                _get_param_to_param_id_from_optim_input(model, optim_input)
-                if using_optim_input
-                else _get_param_to_param_key(optim)
-            )
+            param_to_param_id = _get_param_to_param_key(optim)
             # Because not all model parameters may be passed as the optimizer
             # input, we may need to drop some parameters from this mapping
             param_name_to_param_id = {
@@ -1876,7 +1558,6 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             model=model,
             optim=optim,
             optim_state_dict=optim_state_dict,
-            optim_input=None,
             rank0_only=getattr(
                 state_dict_settings.optim_state_dict_config, "rank0_only", False
             ),
@@ -1886,7 +1567,6 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             cpu_offload=getattr(
                 state_dict_settings.optim_state_dict_config, "offload_to_cpu", True
             ),
-            _stacklevel=2,
         )
 
     @staticmethod
@@ -1964,7 +1644,6 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         result = FullyShardedDataParallel._optim_state_dict_to_load_impl(
             optim_state_dict=optim_state_dict,
             model=model,
-            optim_input=None,
             optim=optim,
             full_state_dict=(
                 state_dict_settings.state_dict_type == StateDictType.FULL_STATE_DICT

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -125,7 +125,7 @@ def _rewrite_spec_if_needed(
     """
     Rewrite ``spec`` to match the device of ``tensor``.
 
-    FSDP.sharded_optim_state_dict sneakily ships optimizer state to CPU so if the original ShardingSpec
+    FSDP optimizer state dict APIs may ship optimizer state to CPU so if the original ShardingSpec
     produces CUDA metadata, ST construction bombs.
     """
     if not isinstance(spec, ChunkShardingSpec):


### PR DESCRIPTION
## Summary

Complete FSDP deprecations whose advertised removal versions have long passed (current main is at 2.14):

- `optim_input` parameter (deprecated after 1.13): removed from internal methods. `rekey_optim_state_dict` raises `ValueError` if passed.
- Legacy optimizer state dict methods (deprecated after 2.2): `full_optim_state_dict`, `sharded_optim_state_dict`, `shard_full_optim_state_dict`, `flatten_sharded_optim_state_dict`, and `scatter_full_optim_state_dict` now raise `NotImplementedError` with migration guidance to `optim_state_dict`/`optim_state_dict_to_load`.
- Dead helpers `_get_param_id_to_param_from_optim_input` and `_get_param_to_param_id_from_optim_input` removed.

Partially fixes https://github.com/pytorch/pytorch/issues/191398

## Test plan

- [x] `python test/distributed/fsdp/test_fsdp_optim_state.py -v` — 60 tests OK
- [x] `lintrunner -a` — No lint issues