### PR TITLE
[inductor] Enable the Triton grouped GEMM template on pre-Hopper

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -739,8 +739,7 @@ class TestMatmulCuda(InductorTestCase):
                 start = offs_cpu[i]
             self.grouped_mm_helper(a, blist, gOlist, agradlist, bgradlist, outlist)
 
-    # TODO(future PR): enable compile for torch.nn.functional.grouped_mm fallback path
-    @unittest.skipIf(not SM90OrLater, "Grouped gemm with compile supported on SM90")
+    @unittest.skipIf(not SM80OrLater, "Grouped gemm with compile supported on SM80 or greater")
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
     @parametrize("a_row_major", [False, True])
     @parametrize("b_row_major", [False, True])

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -9,7 +9,7 @@ from torch._inductor.codegen.cutedsl.cutedsl_template import CuteDSLTemplate
 from torch._inductor.heuristics.template.cutedsl import get_groupgemm_configs
 from torch._inductor.runtime.triton_compat import tl
 from torch._inductor.virtualized import V
-from torch.utils._triton import has_triton
+from torch.utils._triton import _device_supports_tensor_descriptor, has_triton
 
 from ..ir import ChoiceCaller, Layout, TensorBox
 from ..lowering import register_lowering
@@ -150,7 +150,9 @@ def has_grouped_mm_triton_support() -> bool:
         # The grouped GEMM Triton template is supported on ROCm too. ATen
         # remains a separate autotune choice when fallback kernels are enabled.
         return True
-    return torch.cuda.get_device_capability() >= (9, 0)
+    # The template has a non-TMA load path, so it is not restricted to the
+    # architectures that support tensor descriptors.
+    return torch.cuda.get_device_capability() >= (8, 0)
 
 
 def _rocm_gcn_arch() -> str:
@@ -443,7 +445,7 @@ def _tuned_grouped_mm_common(
         use_tma_load = (
             triton_has_make_tensor_descriptor
             or triton_has_experimental_make_tensor_descriptor
-        )
+        ) and _device_supports_tensor_descriptor()
         kwargs = {
             "SCALED": scaled,
             "A_IS_2D": a_is_2d,


### PR DESCRIPTION
Fixes the pre-Hopper grouped GEMM path discussed in #186620, where @drisspg confirmed that letting Inductor dispatch to the template on pre-Hopper is fine.

`torch._grouped_mm` backs the expert FFN in MoE models. Below sm_90 it lands in `_grouped_mm_fallback`, which copies `offs` to the host, reads one offset per group with `.item()`, then issues a serial `at::mm` per expert. Inductor cannot improve on that today because `has_grouped_mm_triton_support()` declines to offer the Triton grouped GEMM template below sm_90 — even though the template already carries a non-TMA load path (#163895).

Relaxing the architecture gate by itself is not sufficient. `use_tma_load` in `_tuned_grouped_mm_common` is derived purely from the installed Triton version, so the template would still be instantiated with `USE_TMA_LOAD=True` and emit tensor descriptor code that pre-Hopper hardware cannot run. Gating it additionally on `_device_supports_tensor_descriptor()` selects the non-TMA path on older architectures while leaving the sm_90+ decision unchanged, since that predicate is `capability >= (9, 0) and not hip` and so is true wherever the old expression was true on CUDA.

The alternative was a fused ATen grouped GEMM for Ampere, which is what #186620 originally requested and which was declined. Reusing the existing template needs no new kernel, and ATen remains an autotune choice, so the tuner can still select the fallback on geometries where it wins.

## Measurements

RTX 3080 (sm_86), bf16, one process per configuration, ATEN and TRITON both offered to the autotuner:

| experts | tokens/expert | K x N | ATen fallback | with template | speedup |
|---------|---------------|-----------|-----------------|---------------|---------|
| 128 | 64 | 2048x768 | 3.168 ms (8 TF) | 0.694 ms | 4.57x |
| 128 | 256 | 2048x768 | 4.023 ms | 2.079 ms | 1.93x |
| 256 | 128 | 2048x1024 | 5.775 ms | 2.796 ms | 2.07x |
| 8 | 1024 | 4096x3584 | 4.568 ms | 4.829 ms | 0.95x |

The template sustains roughly 50 TFLOPS almost independently of geometry, while the fallback degrades as the per-expert GEMMs shrink. Device-to-host memcpys drop from 1 to 0 and CUDA events from 3853 to 11 at 256 experts; the sync removal may also bear on #169970. The 8-expert row is a wash, within the autotuner's own benchmarking noise.

## Test coverage

`test_grouped_gemm_compiled` was skipped below sm_90, so the compiled grouped GEMM path was covered only on H100 — even though CI's ordinary GPU runners are A10G (sm_86), A100 (sm_80) and L4 (sm_89), and `config: "default"` (which includes `test_matmul_cuda.py`) runs on `linux.g5.4xlarge.nvidia.gpu`. Relaxing that skip to `SM80OrLater` runs its 32 existing parametrizations on that hardware, covering all four operand layouts, both row-major orientations, empty groups and unaligned group sizes.

```
$ python test/test_matmul_cuda.py -k test_grouped_gemm_compiled -v
Ran 32 tests in 40.968s
OK
```

The autotune logs for every case report `USE_TMA_LOAD=False`, confirming the non-TMA path is the one selected. Surrounding eager tests are unaffected:

```
$ python test/test_matmul_cuda.py -k grouped_gemm
Ran 325 tests in 40.599s
OK (skipped=196)
```

The skips are the cuBLASLt cases, which require CUDA >= 13.3 and capability 9.0-11.0.

Correctness was additionally checked against a float32 per-group reference across routing patterns that stress the group bookkeeping: balanced, imbalanced, one empty expert, several empty experts, all-but-one empty, group sizes that are not multiples of the block size, and single-token groups. Forward, `grad_a` and `grad_b` match the ATen path in every case.

## Note for ROCm reviewers

`_device_supports_tensor_descriptor()` is false under HIP, so if ROCm's Triton exposes `make_tensor_descriptor` then the ROCm lowering added in #188600 moves from the TMA path to the non-TMA path. I do not have AMD hardware to verify this. It may be a fix, since AMD has no TMA, and the currently disabled `test_grouped_gemm_compiled_op_*` tests (#190782, #190140, #189987) are all disabled on `Platforms: rocm` — but that connection is speculation on my part and needs confirmation from someone who can run it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @drisspg @jianyuh @eellison
