### PR TITLE
[Testcase Refactoring] Enable PrivateUse1 and add hw-classification in test_backward

### DIFF
--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -14,7 +14,11 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     skipXPUIf,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 d_hid = 512
@@ -22,6 +26,8 @@ batch_size = 256
 
 
 class StageBackwardTests(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/1682")
     def test_stage_backward(self, device):
         # MLP as a stage module
@@ -324,10 +330,7 @@ class StageBackwardTests(TestCase):
             torch.testing.assert_close(p.grad, ref_p.grad)
 
 
-devices = ["cpu", "cuda", "hpu", "xpu"]
-instantiate_device_type_tests(
-    StageBackwardTests, globals(), only_for=devices, allow_xpu=True
-)
+instantiate_device_type_tests(StageBackwardTests, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
Enable the `StageBackwardTests` device-type variants for out-of-tree PrivateUse1 accelerators in `test/distributed/pipelining/test_backward.py`, and classify `StageBackwardTests` as `HardwareClassification.ACCELERATOR`.

## Changes
- Drop the `only_for=["cpu", "cuda", "hpu", "xpu"]` argument (and the now-unused `devices` list) from `instantiate_device_type_tests`, keeping `allow_xpu=True`. With `only_for` removed, `get_desired_device_type_test_bases` auto-registers `PrivateUse1TestBase` when `_is_privateuse1_backend_available()`, so the PrivateUse1 variants of the `test_stage_backward_*` methods are generated alongside the existing cpu/cuda/hpu/xpu variants. Zero-loss: HPU is added unconditionally on `TEST_HPU`, XPU via `allow_xpu`, and the only addition is PrivateUse1.
- Set `hw_classification = HardwareClassification.ACCELERATOR` on `StageBackwardTests`. The `test_stage_backward_*` methods run backward (`stage_backward_input`/`stage_backward_weight`) on `device` and assert gradient correctness -- accelerator-generic behavior with no CUDA-specific paths. The classification is metadata: it only filters tests when `--hw-classification` is passed; normal discovery/execution is unchanged.

## Motivation
The `test_stage_backward_*` methods were never generated for out-of-tree PrivateUse1 accelerators because the explicit `only_for` list excluded PrivateUse1. Dropping it lets the framework's existing PrivateUse1 infrastructure (`PrivateUse1TestBase`, `_is_privateuse1_backend_available`) discover the backend automatically. The `HardwareClassification.ACCELERATOR` tag participates in the hardware-classification filtering initiative, so `--hw-classification ACCELERATOR` selects these tests across every accelerator backend.

## Test Plan
```
python test/distributed/pipelining/test_backward.py -v
python test/distributed/pipelining/test_backward.py -v --hw-classification ACCELERATOR
python test/distributed/pipelining/test_backward.py -v --hw-classification CPU
python test/distributed/pipelining/test_backward.py -v --hw-classification GENERIC
```
Verified on a PrivateUse1 host (8 devices): PrivateUse1 variants of all 8 `test_stage_backward_*` methods are auto-generated (16 tests = 8 methods across cpu + PrivateUse1); all 16 pass. `--hw-classification ACCELERATOR` includes all 16 (total=16); `--hw-classification CPU`/`GENERIC` filter them out (mismatched=16, Ran 0). 

## Notes
This is part of the test case refactoring initiative tracked in #185590.
