### PR TITLE
[Testcase Refactoring] Add proper `hw_classification` attribute to test classes

### DIFF
--- a/test/inductor/test_minifier_utils.py
+++ b/test/inductor/test_minifier_utils.py
@@ -10,10 +10,16 @@ from torch._dynamo.repro.aoti import (
     get_module_string,
 )
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class MinifierUtilsTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_invalid_output_user_error_classification(self):
         class SimpleModel(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
## Summary

Adds hw_classification annotations to test classes and aligning test methods with their hardware classification.

## Changes

- Add `HardwareClassification `to imports from `common_utils`

- Added `hw_classification = HardwareClassification.GENERIC` to `MinifierUtilsTests` to mark the class as device-generic.

## Test plan

`python test/inductor/test_minifier_utils.py ` 
`python test/inductor/test_minifier_utils.py -v --hw-classification GENERIC` 


## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo