### PR TITLE
[Testcase Refactoring] Device classification for mapping_ops, metrics_context, and model_output tests

### DIFF
--- a/test/dynamo/test_mapping_ops.py
+++ b/test/dynamo/test_mapping_ops.py
@@ -11,6 +11,7 @@ import collections
 import torch
 import torch._dynamo.test_case
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     make_dynamo_test,
     parametrize,
@@ -73,6 +74,8 @@ _MAPPING_TYPES = [
 
 class TestMpAssSubscript(torch._dynamo.test_case.TestCase):
     """All mapping __setitem__ tests in one class."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()

--- a/test/dynamo/test_metrics_context.py
+++ b/test/dynamo/test_metrics_context.py
@@ -2,9 +2,12 @@
 
 from torch._dynamo.metrics_context import MetricsContext, TopN
 from torch._dynamo.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestMetricsContext(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.metrics = {}

--- a/test/dynamo/test_model_output.py
+++ b/test/dynamo/test_model_output.py
@@ -7,6 +7,7 @@ import torch._dynamo.testing
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import same
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 try:
@@ -30,6 +31,8 @@ def maybe_skip(fn):
 
 
 class TestHFPretrained(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @maybe_skip
     def test_pretrained(self):
         def fn(a, tmp):
@@ -63,6 +66,8 @@ class TestHFPretrained(TestCase):
 
 
 class TestModelOutput(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @maybe_skip
     def test_mo_create(self):
         def fn(a, b):
@@ -280,6 +285,8 @@ class TestModelOutput(TestCase):
 
 
 class TestModelOutputBert(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @maybe_skip
     def test_HF_bert_model_output(self, device):
         class BertPooler(torch.nn.Module):


### PR DESCRIPTION
## Summary

This PR adds `HardwareClassification` (`GENERIC` / `ACCELERATOR`) class attributes to three Dynamo test files so that CI runners can route tests by hardware capability.

## Changes

- **test/dynamo/test_mapping_ops.py**
  - Import `HardwareClassification`; tag `TestMpAssSubscript` as `GENERIC`.

- **test/dynamo/test_metrics_context.py**
  - Import `HardwareClassification`; tag `TestMetricsContext` as `GENERIC`.

- **test/dynamo/test_model_output.py**
  - Import `HardwareClassification`.
  - Tag `TestHFPretrained` and `TestModelOutput` as `GENERIC`.
  - Tag `TestModelOutputBert` as `ACCELERATOR` (`instantiate_device_type_tests` already exists).

## Test plan

`python test/dynamo/test_mapping_ops.py --hw-classification GENERIC -v`
`python test/dynamo/test_metrics_context.py --hw-classification GENERIC -v`
`python test/dynamo/test_model_output.py --hw-classification GENERIC -v`
`python test/dynamo/test_model_output.py --hw-classification ACCELERATOR -v`
- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98