### PR TITLE
[Testcase Refactoring] 1. Add proper hw_classification attribute to test classes.  2. Add instantiate_device_type_tests to generalize device types.

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -12,7 +12,6 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    instantiate_parametrized_tests,
     MACOS_VERSION,
     parametrize,
 )

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -10,6 +10,7 @@ import torch
 from torch.testing import FileCheck, make_tensor
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     MACOS_VERSION,
     parametrize,
@@ -40,6 +41,8 @@ from inductor.test_torchinductor import (  # @manual=fbcode//caffe2/test/inducto
 @unittest.skipUnless(torch.backends.mps.is_available(), "MPS not available")
 @instantiate_parametrized_tests
 class MPSBasicTests(TestCase):
+    hw_classification = HardwareClassification.MPS
+
     is_dtype_supported = CommonTemplate.is_dtype_supported
     common = check_model_gpu
     device = "mps"
@@ -357,6 +360,8 @@ class MPSBasicTests(TestCase):
 
 @unittest.skipUnless(torch.backends.mps.is_available(), "MPS not available")
 class MPSBasicTestsAOTI(TestCase):
+    hw_classification = HardwareClassification.MPS
+
     def check_model(self, m, inp, dynamic_shapes=None):
         res2 = m(*inp)
         ep = torch.export.export(m, inp, dynamic_shapes=dynamic_shapes)

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import torch
 from torch.testing import FileCheck, make_tensor
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -39,57 +40,55 @@ from inductor.test_torchinductor import (  # @manual=fbcode//caffe2/test/inducto
 
 
 @unittest.skipUnless(torch.backends.mps.is_available(), "MPS not available")
-@instantiate_parametrized_tests
 class MPSBasicTests(TestCase):
     hw_classification = HardwareClassification.MPS
 
     is_dtype_supported = CommonTemplate.is_dtype_supported
     common = check_model_gpu
-    device = "mps"
 
     @parametrize("dtype", MPS_DTYPES)
-    def test_add(self, dtype):
+    def test_add(self, device, dtype):
         self.common(
             lambda a, b: a + b,
             (
-                make_tensor(1024, dtype=dtype, device=self.device),
-                make_tensor(1024, dtype=dtype, device=self.device),
+                make_tensor(1024, dtype=dtype, device=device),
+                make_tensor(1024, dtype=dtype, device=device),
             ),
             check_lowp=False,
         )
 
-    def test_log(self):
+    def test_log(self, device):
         self.common(lambda x: x.log(), (torch.rand(1024),))
 
-    def test_acos(self):
+    def test_acos(self, device):
         self.common(lambda x: x.acos(), (torch.rand(1024),))
 
-    def test_atanh(self):
+    def test_atanh(self, device):
         self.common(lambda x: x.atanh(), (torch.rand(1024),))
 
-    def test_tanh(self):
+    def test_tanh(self, device):
         self.common(lambda x: x.tanh(), (torch.rand(1024),))
 
-    def test_tanh_large_values(self):
+    def test_tanh_large_values(self, device):
         # Test that tanh handles large values correctly (should saturate to ±1)
-        x = torch.tensor([-100.0, -50.0, -15.0, 0.0, 15.0, 50.0, 100.0], device="mps")
+        x = torch.tensor([-100.0, -50.0, -15.0, 0.0, 15.0, 50.0, 100.0], device=device)
 
         @torch.compile
         def fn(x):
             return x.tanh()
 
         result = fn(x)
-        if not torch.allclose(result[0], torch.tensor(-1.0, device="mps")):
+        if not torch.allclose(result[0], torch.tensor(-1.0, device=device)):
             raise AssertionError("tanh(-100) should be -1")
-        if not torch.allclose(result[-1], torch.tensor(1.0, device="mps")):
+        if not torch.allclose(result[-1], torch.tensor(1.0, device=device)):
             raise AssertionError("tanh(100) should be +1")
         if torch.isnan(result).any():
             raise AssertionError("tanh should not produce NaN for large values")
 
-    def test_erfc_tail_accuracy(self):
+    def test_erfc_tail_accuracy(self, device):
         # gh-187806: compiled erfc must lower to c10::metal::erfc, not the
         # 1 - erf fallback that flushes the tail to zero past x ~ 3.9
-        x = torch.arange(-9.0, 9.0, 2**-10, device="mps")
+        x = torch.arange(-9.0, 9.0, 2**-10, device=device)
 
         @torch.compile
         def fn(x):
@@ -102,22 +101,22 @@ class MPSBasicTests(TestCase):
         # erfc rounds to exactly 0/2 in fp32 well before the clamp
         inf, nan = float("inf"), float("nan")
         vals = [0.0, inf, -inf, nan, 10.5, -10.5, 1e30, -1e30]
-        sp = torch.tensor(vals, device="mps")
+        sp = torch.tensor(vals, device=device)
         expected_sp = torch.tensor([1.0, 0.0, 2.0, nan, 0.0, 2.0, 0.0, 2.0])
         self.assertEqual(fn(sp).cpu(), expected_sp, rtol=0, atol=0)
 
-    def test_floor(self):
+    def test_floor(self, device):
         self.common(lambda x: x.floor(), (torch.rand(1024),))
 
-    def test_sign(self):
+    def test_sign(self, device):
         self.common(lambda x: x.sign(), (torch.rand(1024),))
 
-    def test_sliced_input(self):
+    def test_sliced_input(self, device):
         self.common(
             lambda x: x[:, ::2].sin() + x[:, 1::2].cos(), (torch.rand(32, 1024),)
         )
 
-    def test_where(self):
+    def test_where(self, device):
         def foo(x):
             rc = x.abs().sqrt()
             rc[x < 0] = -5
@@ -126,20 +125,20 @@ class MPSBasicTests(TestCase):
         self.common(foo, (torch.rand(1024),))
 
     @parametrize("dtype", MPS_DTYPES)
-    def test_cast(self, dtype):
+    def test_cast(self, device, dtype):
         self.common(lambda a: a.to(dtype), (torch.rand(1024),))
 
-    def test_broadcast(self):
+    def test_broadcast(self, device):
         self.common(torch.add, (torch.rand(32, 1024), torch.rand(1024)))
 
-    def test_inplace(self):
+    def test_inplace(self, device):
         def inc_(x):
             x += 1
             return x
 
         self.common(inc_, (torch.rand(1024),))
 
-    def test_rms_norm_nograd(self):
+    def test_rms_norm_nograd(self, device):
         # Regression test for https://github.com/pytorch/pytorch/issues/150629
         def fn(x, w):
             with torch.no_grad():
@@ -147,32 +146,32 @@ class MPSBasicTests(TestCase):
 
         self.common(fn, (torch.rand(10), torch.ones(10)))
 
-    def test_batchnorm_train_running_stats(self):
+    def test_batchnorm_train_running_stats(self, device):
         # Regression test: missing closing threadgroup_barrier in
         # threadgroup_welford_{reduce,combine}
         torch.manual_seed(0)
         xs = [torch.randn(16, 8, 4, 4) for _ in range(10)]
 
-        def run(device, compile_):
+        def run(dev, compile_):
             torch.manual_seed(0)
-            bn = torch.nn.BatchNorm2d(8).to(device).train()
+            bn = torch.nn.BatchNorm2d(8).to(dev).train()
             f = torch.compile(bn) if compile_ else bn
             for x in xs:
-                f(x.to(device))
+                f(x.to(dev))
             return bn.running_mean.cpu(), bn.running_var.cpu()
 
         m_ref, v_ref = run("cpu", False)
-        m_mps, v_mps = run("mps", True)
+        m_mps, v_mps = run(device, True)
         self.assertEqual(m_mps, m_ref)
         self.assertEqual(v_mps, v_ref)
 
-    def test_compile_numpy_scalar(self):
+    def test_compile_numpy_scalar(self, device):
         def fn(x, y):
             return x / y
 
         self.common(fn, (torch.rand(10), np.exp(0.3)))
 
-    def test_conv_transpose_channels_last(self):
+    def test_conv_transpose_channels_last(self, device):
         def fn(x, y):
             return torch.nn.functional.conv_transpose2d(x, y, stride=1, padding=1)
 
@@ -184,7 +183,7 @@ class MPSBasicTests(TestCase):
             ),
         )
 
-    def test_conv_train(self):
+    def test_conv_train(self, device):
         # Regression test for https://github.com/pytorch/pytorch/issues/161905
         def fn(x, y):
             return torch.nn.functional.conv2d(x, y, None, 1, 1, 1)
@@ -198,7 +197,7 @@ class MPSBasicTests(TestCase):
             check_gradient=True,
         )
 
-    def test_cholesky(self):
+    def test_cholesky(self, device):
         def fn(x):
             return (
                 torch.linalg.cholesky(x, upper=False),
@@ -207,23 +206,23 @@ class MPSBasicTests(TestCase):
 
         self.common(fn, (torch.eye(64),), check_lowp=False)
 
-    def test_reduced_max(self):
+    def test_reduced_max(self, device):
         # inductor test do not validate that max of say 16K half elements can be computed
         self.common(torch.max, (torch.rand(16384, dtype=torch.half),), check_lowp=False)
 
-    def test_linalg_inv(self):
+    def test_linalg_inv(self, device):
         def fn(x):
             return torch.linalg.inv(torch.linalg.cholesky(x))
 
         A = torch.diag(torch.tensor([20.0, 0.5, 5.0], dtype=torch.float32) ** 2)
         self.common(fn, (A,), check_lowp=False)
 
-    def test_large_reduction(self):
+    def test_large_reduction(self, device):
         def fn(a, b):
             return (a[:, None] - b[None, :]).sum()
 
-        a = torch.randn(32, device="mps")
-        b = torch.randn(64, device="mps")
+        a = torch.randn(32, device=device)
+        b = torch.randn(64, device=device)
         self.common(
             fn,
             (
@@ -233,7 +232,7 @@ class MPSBasicTests(TestCase):
         )
 
     @parametrize("shape", [(4, 5000), (3, 1023), (7, 1025), (5, 32), (1, 30000)])
-    def test_welford_reduction_dynamic_shape(self, shape):
+    def test_welford_reduction_dynamic_shape(self, device, shape):
         # (5, 32): single-stage welford_reduce
         # (3, 1023), (4, 5000), (7, 1025): multistage welford_reduce
         # (1, 30000): split reduction -> welford_combine
@@ -241,11 +240,11 @@ class MPSBasicTests(TestCase):
         def fn(x):
             return x.var(dim=-1)
 
-        x = torch.randn(*shape, device=self.device)
+        x = torch.randn(*shape, device=device)
         torch._dynamo.mark_dynamic(x, 1)
         self.assertEqual(fn(x), x.var(dim=-1))
 
-    def test_while_loop_kernel_naming(self):
+    def test_while_loop_kernel_naming(self, device):
         # Regression test for https://github.com/pytorch/pytorch/issues/187852
         # while_loop compiles cond and body as separate MetalScheduling instances,
         # each of which used to reset _kernel_fn_counter to 0, producing duplicate
@@ -258,16 +257,16 @@ class MPSBasicTests(TestCase):
                 return (i + 2,)
 
             (out_i,) = torch._higher_order_ops.while_loop(
-                cond, body, (torch.tensor(0, dtype=torch.int32, device=self.device),)
+                cond, body, (torch.tensor(0, dtype=torch.int32, device=device),)
             )
             return out_i
 
-        iters = torch.tensor(4, dtype=torch.int32, device=self.device)
+        iters = torch.tensor(4, dtype=torch.int32, device=device)
         compiled_fn = torch.compile(fn, backend="inductor")
         result = compiled_fn(iters)
-        self.assertEqual(result, torch.tensor(4, dtype=torch.int32, device=self.device))
+        self.assertEqual(result, torch.tensor(4, dtype=torch.int32, device=device))
 
-    def test_welford_multistage_sibling_redeclare(self):
+    def test_welford_multistage_sibling_redeclare(self, device):
         # Regression test: BatchNorm2d-train emits two codegen passes on
         # the same multistage reduction root (welford + running-stats
         # update). Sibling indices (r0_1, r0_2) declared via the
@@ -276,19 +275,19 @@ class MPSBasicTests(TestCase):
         # "use of undeclared identifier 'r0_2'".
         torch.manual_seed(0)
         bn_ref = torch.nn.BatchNorm2d(8).train()
-        bn_mps = torch.nn.BatchNorm2d(8).to(self.device).train()
+        bn_mps = torch.nn.BatchNorm2d(8).to(device).train()
         bn_mps.load_state_dict(bn_ref.state_dict())
         x = torch.randn(4, 8, 32, 32)
         y_ref = bn_ref(x)
-        y_mps = torch.compile(bn_mps)(x.to(self.device))
+        y_mps = torch.compile(bn_mps)(x.to(device))
         self.assertEqual(y_mps.cpu(), y_ref)
 
-    def test_sdpa_split_qkv(self):
+    def test_sdpa_split_qkv(self, device):
         # regression test for metal compiler bug where fused (x / A) % B
         # produces wrong results, causing incorrect reads from non-contiguous.
         n_head, n_embd, seq_len = 6, 384, 1024
-        x = torch.randn(16, seq_len, n_embd, device="mps")
-        c_attn = torch.nn.Linear(n_embd, 3 * n_embd).to("mps").eval()
+        x = torch.randn(16, seq_len, n_embd, device=device)
+        c_attn = torch.nn.Linear(n_embd, 3 * n_embd).to(device).eval()
         qkv = c_attn(x)
         q, k, v = qkv.split(n_embd, dim=2)
         q = q.view(16, seq_len, n_head, n_embd // n_head).transpose(1, 2)
@@ -303,7 +302,7 @@ class MPSBasicTests(TestCase):
         self.common(fn, (q, k, v), atol=1e-4, rtol=1e-4, check_lowp=False)
 
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-    def test_sdpa_prefill_strided(self, dtype):
+    def test_sdpa_prefill_strided(self, device, dtype):
         torch.manual_seed(0)
         B, H, S, D = 1, 16, 1179, 128
 
@@ -314,12 +313,12 @@ class MPSBasicTests(TestCase):
             )
 
         q, k, v = (
-            torch.randn(B, S, H, D, device=self.device, dtype=dtype) for _ in range(3)
+            torch.randn(B, S, H, D, device=device, dtype=dtype) for _ in range(3)
         )
-        mask = torch.zeros(B, 1, S, S, device=self.device, dtype=dtype)
+        mask = torch.zeros(B, 1, S, S, device=device, dtype=dtype)
         self.assertEqual(torch.compile(fn)(q, k, v, mask), fn(q, k, v, mask))
 
-    def test_nested_masked_cat(self):
+    def test_nested_masked_cat(self, device):
         # Regression test for YOLOv3 compilation failure on MPS.
         # See https://github.com/pytorch/pytorch/actions/runs/23477894502
         # YOLOv3 detection heads do view/permute/clone, then in-place slice
@@ -348,12 +347,12 @@ class MPSBasicTests(TestCase):
         self.common(
             fn,
             (
-                torch.randn(1, na * no, 4, 4, device="mps"),
-                torch.randn(1, na * no, 8, 8, device="mps"),
-                torch.randn(1, 1, 4, 4, 2, device="mps"),
-                torch.randn(1, 1, 8, 8, 2, device="mps"),
-                torch.randn(1, na, 1, 1, 2, device="mps"),
-                torch.randn(1, na, 1, 1, 2, device="mps"),
+                torch.randn(1, na * no, 4, 4, device=device),
+                torch.randn(1, na * no, 8, 8, device=device),
+                torch.randn(1, 1, 4, 4, 2, device=device),
+                torch.randn(1, 1, 8, 8, 2, device=device),
+                torch.randn(1, na, 1, 1, 2, device=device),
+                torch.randn(1, na, 1, 1, 2, device=device),
             ),
         )
 
@@ -371,22 +370,22 @@ class MPSBasicTestsAOTI(TestCase):
         if not torch.allclose(res, res2):
             raise AssertionError
 
-    def test_add_mps(self):
+    def test_add_mps(self, device):
         class M(torch.nn.Module):
             def forward(self, x, y):
                 return x + y
 
-        inp = (torch.ones(3, 3, device="mps"), torch.ones(3, 3, device="mps"))
-        m = M().to("mps")
+        inp = (torch.ones(3, 3, device=device), torch.ones(3, 3, device=device))
+        m = M().to(device)
         self.check_model(m, inp)
 
-    def test_tanh_codegen(self):
+    def test_tanh_codegen(self, device):
         # Verify that tanh uses metal::precise::tanh in generated Metal shader
         class Model(torch.nn.Module):
             def forward(self, x):
                 return x.tanh()
 
-        example_inputs = (torch.randn(1024, device="mps"),)
+        example_inputs = (torch.randn(1024, device=device),)
         model = Model()
 
         ep = torch.export.export(model, example_inputs)
@@ -397,19 +396,19 @@ class MPSBasicTestsAOTI(TestCase):
             # Verify metal::precise::tanh is used (not clamped version)
             FileCheck().check("metal::precise::tanh").run(src_code)
 
-    def test_fallback_mps(self):
+    def test_fallback_mps(self, device):
         class M(torch.nn.Module):
             def forward(self, x, y):
                 return torch.nn.functional.linear(x, y)
 
         inp = (
-            torch.randn(10, 10, device="mps"),
-            torch.randn(10, 10, device="mps"),
+            torch.randn(10, 10, device=device),
+            torch.randn(10, 10, device=device),
         )
-        m = M().to("mps")
+        m = M().to(device)
         self.check_model(m, inp)
 
-    def test_c10(self):
+    def test_c10(self, device):
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -417,25 +416,25 @@ class MPSBasicTestsAOTI(TestCase):
             def forward(self, x):
                 return torch.cat(tensors=torch.split(x, 4, dim=1), dim=-2)
 
-        inp = (torch.randn(2, 8, device="mps"),)
-        m = M().to("mps")
+        inp = (torch.randn(2, 8, device=device),)
+        m = M().to(device)
         self.check_model(m, inp)
 
-    def test_two_const(self):
+    def test_two_const(self, device):
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.y = torch.ones(3, 3, device="mps")
-                self.z = torch.full((3, 3), 2, device="mps")
+                self.y = torch.ones(3, 3, device=device)
+                self.z = torch.full((3, 3), 2, device=device)
 
             def forward(self, x):
                 return x + self.y + self.z
 
-        inp = (torch.ones(3, 3, device="mps"),)
-        m = Model().to(device="mps")
+        inp = (torch.ones(3, 3, device=device),)
+        m = Model().to(device=device)
         self.check_model(m, inp)
 
-    def test_simple_dynamic(self):
+    def test_simple_dynamic(self, device):
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -444,17 +443,17 @@ class MPSBasicTestsAOTI(TestCase):
                 add_0 = x + y
                 return torch.nn.functional.relu(input=add_0, inplace=False)
 
-        x = torch.randn(128, 2048, device="mps")
-        y = torch.randn(128, 2048, device="mps")
+        x = torch.randn(128, 2048, device=device)
+        y = torch.randn(128, 2048, device=device)
         inp = (x, y)
 
-        m = Model().to(device="mps")
+        m = Model().to(device=device)
         dim0_x = torch.export.Dim("dim0_x", min=1, max=2048)
         dynamic_shapes = {"x": {0: dim0_x}, "y": {0: dim0_x}}
 
         self.check_model(m, inp, dynamic_shapes)
 
-    def test_dynamic_cat(self):
+    def test_dynamic_cat(self, device):
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -462,17 +461,17 @@ class MPSBasicTestsAOTI(TestCase):
             def forward(self, a, b):
                 return torch.cat([a, b], dim=0)
 
-        a = torch.randn(2, 4, device="mps")
-        b = torch.randn(3, 4, device="mps")
+        a = torch.randn(2, 4, device=device)
+        b = torch.randn(3, 4, device=device)
         inp = (a, b)
-        m = Model().to(device="mps")
+        m = Model().to(device=device)
 
         dim0_a = torch.export.Dim("dim0_a", min=1, max=10)
         dim0_b = torch.export.Dim("dim0_b", min=1, max=20)
         dynamic_shapes = {"a": {0: dim0_a}, "b": {0: dim0_b}}
         self.check_model(m, inp, dynamic_shapes)
 
-    def test_reuse_kernel(self):
+    def test_reuse_kernel(self, device):
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -485,8 +484,8 @@ class MPSBasicTestsAOTI(TestCase):
                 return d
 
         example_inputs = (
-            torch.randn(87, 87, device="mps"),
-            torch.randn(87, 87, device="mps"),
+            torch.randn(87, 87, device=device),
+            torch.randn(87, 87, device=device),
         )
         model = Model()
 
@@ -503,6 +502,14 @@ class MPSBasicTestsAOTI(TestCase):
                 target_count,
                 exactly=True,
             ).run(src_code)
+
+
+instantiate_device_type_tests(
+    MPSBasicTests, globals(), only_for=("mps",), allow_mps=True
+)
+instantiate_device_type_tests(
+    MPSBasicTestsAOTI, globals(), only_for=("mps",), allow_mps=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds hw_classification annotations to test classes and aligning test methods with their hardware classification.
Add instantiate_device_type_tests to generalize device types.

## Changes

- Add `HardwareClassification `to imports from `common_utils`

- Add  `instantiate_device_type_tests` is used to generate test classes for different devices.
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.

## Test plan

`python test/inductor/test_mps_basic.py ` 
`python test/inductor/test_mps_basic.py -v --hw-classification MPS` 


## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo