### PR TITLE
[inductor] Add a precompile screen for combo kernels

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -2450,6 +2450,89 @@ class ComboKernelCompileTimeAutotuneTests(TestCase):
         torch._inductor.metrics.reset()
         super().tearDown()
 
+    def test_precompile_screen_cost_model(self):
+        from torch._inductor.codegen.simd import (
+            _combo_kernel_may_exceed_precompile_threshold,
+            _combo_kernel_min_waves,
+        )
+        from torch._inductor.runtime.hints import DeviceProperties, TRITON_MAX_BLOCK
+
+        props = DeviceProperties(
+            type="cuda",
+            index=0,
+            multi_processor_count=1,
+            cc=80,
+            max_threads_per_multi_processor=32,
+            warp_size=32,
+        )
+        numels = {
+            "x": TRITON_MAX_BLOCK["X"] + 1,
+            "y": TRITON_MAX_BLOCK["Y"] + 1,
+        }
+        self.assertEqual(_combo_kernel_min_waves(numels, props), 4)
+        self.assertIsNone(
+            _combo_kernel_min_waves(
+                numels, props._replace(max_threads_per_multi_processor=None)
+            )
+        )
+
+        # The model credits one average final wave per member.
+        self.assertFalse(
+            _combo_kernel_may_exceed_precompile_threshold([(1000.0, 64)] * 2)
+        )
+        self.assertTrue(
+            _combo_kernel_may_exceed_precompile_threshold([(1000.0, 32)] * 2)
+        )
+        self.assertTrue(
+            _combo_kernel_may_exceed_precompile_threshold([(1000.0, 100), (0.0, 100)])
+        )
+
+    @requires_cuda_and_triton
+    @skipIfRocm
+    @parametrize("estimated_ms, expected_screened", [(1.0, 2), (0.1, 0)])
+    def test_precompile_screen(self, estimated_ms, expected_screened):
+        from torch._inductor.runtime.hints import DeviceProperties, TRITON_MAX_BLOCK
+        from torch._inductor.scheduler import BaseSchedulerNode
+
+        def fn(a, b):
+            return a + 1, b * 2
+
+        numel = TRITON_MAX_BLOCK["X"] * 64
+        inputs = [torch.randn(numel, device=GPU_TYPE) for _ in range(2)]
+        real_props = DeviceProperties.create(torch.device(GPU_TYPE))
+        warp_size = real_props.warp_size_or_default
+        test_props = real_props._replace(
+            multi_processor_count=1,
+            max_threads_per_multi_processor=warp_size,
+            warp_size=warp_size,
+        )
+        counters.clear()
+        with (
+            fresh_cache(),
+            torch._inductor.config.patch(combo_kernel_precompile_screen=True),
+            patch.object(
+                BaseSchedulerNode,
+                "get_estimated_runtime",
+                return_value=estimated_ms,
+            ),
+            patch.object(DeviceProperties, "create", return_value=test_props),
+        ):
+            out, (code,) = run_and_get_code(torch.compile(fn), *inputs)
+
+        self.assertEqual(out, fn(*inputs))
+        self.assertEqual(
+            counters["inductor"]["combo_precompile_screened"], expected_screened
+        )
+        processed = (
+            counters["inductor"]["combo_subkernel_autotune"]
+            + counters["inductor"]["combo_subkernel_autotune_cached"]
+        )
+        self.assertEqual(processed, 0 if expected_screened else 2)
+        if expected_screened:
+            FileCheck().check_not("'num_kernels': 2").run(code)
+        else:
+            FileCheck().check("'num_kernels': 2").run(code)
+
     @requires_gpu_and_triton
     @parametrize("mode", ["default", "cdt"])
     def test_compile_time_autotune(self, mode):
@@ -2560,23 +2643,49 @@ class ComboKernelCompileTimeAutotuneTests(TestCase):
 
     @requires_gpu_and_triton
     def test_compile_time_autotune_dynamic_shapes(self):
+        from torch._inductor.runtime.hints import DeviceProperties, TRITON_MAX_BLOCK
+        from torch._inductor.scheduler import BaseSchedulerNode
+
         def f(a, b):
             return a + 1.0, b * 2.0
 
-        a = torch.randn(4096, device=GPU_TYPE)
-        b = torch.randn(6144, device=GPU_TYPE)
+        block = TRITON_MAX_BLOCK["X"]
+        a = torch.randn(block * 64, device=GPU_TYPE)
+        b = torch.randn(block * 80, device=GPU_TYPE)
         torch._dynamo.mark_dynamic(a, 0)
         torch._dynamo.mark_dynamic(b, 0)
+        real_props = DeviceProperties.create(torch.device(GPU_TYPE))
+        warp_size = real_props.warp_size_or_default
+        test_props = real_props._replace(
+            multi_processor_count=1,
+            max_threads_per_multi_processor=warp_size,
+            warp_size=warp_size,
+        )
         counters.clear()
-        with fresh_cache():
+        with (
+            fresh_cache(),
+            torch._inductor.config.patch(combo_kernel_precompile_screen=True),
+            patch.object(
+                BaseSchedulerNode,
+                "get_estimated_runtime",
+                return_value=1.0,
+            ),
+            patch.object(DeviceProperties, "create", return_value=test_props),
+        ):
             fn_c = torch.compile(f, dynamic=True)
             out = fn_c(a, b)
         self.assertEqual(out, f(a, b))
         # recompile-free on new dynamic sizes
-        a2 = torch.randn(5000, device=GPU_TYPE)
-        b2 = torch.randn(7000, device=GPU_TYPE)
+        a2 = torch.randn(block * 64 + 17, device=GPU_TYPE)
+        b2 = torch.randn(block * 80 + 33, device=GPU_TYPE)
         self.assertEqual(fn_c(a2, b2), f(a2, b2))
         self.assertEqual(counters["inductor"]["combo_subkernel_autotune_fallback"], 0)
+        self.assertEqual(counters["inductor"]["combo_precompile_screened"], 0)
+        processed = (
+            counters["inductor"]["combo_subkernel_autotune"]
+            + counters["inductor"]["combo_subkernel_autotune_cached"]
+        )
+        self.assertEqual(processed, 2)
 
     @requires_gpu_and_triton
     def test_compile_time_autotune_sort_forces_persistent(self):

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -49,7 +49,7 @@ from ..optimize_indexing import (
     indexing_dtype_strength_reduction,
 )
 from ..runtime.coordinate_descent_tuner import CoordescTuner
-from ..runtime.hints import DeviceProperties, InductorMeta
+from ..runtime.hints import DeviceProperties, InductorMeta, TRITON_MAX_BLOCK
 from ..runtime.runtime_utils import (
     green_text,
     last_power_of_2,
@@ -512,6 +512,64 @@ class NodeInfo(NamedTuple):
     rnumel: Any
     features: SIMDKernelFeatures
     is_persistent_reduction: bool
+
+
+_COMBO_PRECOMPILE_LAUNCH_CREDIT_US = 8.0
+_COMBO_PRECOMPILE_MIN_GAIN = 0.03
+
+
+def _combo_kernel_min_waves(
+    numel_hints: dict[str, int], device_props: DeviceProperties
+) -> int | None:
+    max_threads = device_props.max_threads_per_multi_processor
+    warp_size = device_props.warp_size
+    if (
+        not numel_hints
+        or not device_props.multi_processor_count
+        or not max_threads
+        or not warp_size
+    ):
+        return None
+
+    max_blocks_per_mp = max_threads // warp_size
+    if not max_blocks_per_mp:
+        return None
+
+    min_blocks = 1
+    for prefix, numel in numel_hints.items():
+        max_block = TRITON_MAX_BLOCK.get(prefix.upper())
+        if not max_block or numel <= 0:
+            return None
+        min_blocks *= (numel + max_block - 1) // max_block
+
+    max_resident_blocks = device_props.multi_processor_count * max_blocks_per_mp
+    return (min_blocks + max_resident_blocks - 1) // max_resident_blocks
+
+
+def _combo_kernel_may_exceed_precompile_threshold(
+    member_costs: list[tuple[float, int]],
+) -> bool:
+    """Return whether the modeled gain may reach the precompile threshold.
+
+    For estimated runtime ``E`` and minimum wave count ``W``, the model credits
+    fusion with at most ``E / W`` for the member's final wave. It also credits
+    one launch for every removed kernel. The comparison below is the rearranged
+    form of ``launches + sum(E / W) < min_gain * sum(E)``.
+    """
+    if len(member_costs) < 2:
+        return True
+
+    margin_us = 0.0
+    for estimated_us, min_waves in member_costs:
+        if estimated_us <= 0 or not math.isfinite(estimated_us) or min_waves <= 0:
+            return True
+        tail_fraction = 1 / min_waves
+        if tail_fraction >= _COMBO_PRECOMPILE_MIN_GAIN:
+            return True
+        margin_us += (_COMBO_PRECOMPILE_MIN_GAIN - tail_fraction) * estimated_us
+
+    launch_credit_us = (len(member_costs) - 1) * _COMBO_PRECOMPILE_LAUNCH_CREDIT_US
+    return margin_us <= launch_credit_us
 
 
 class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
@@ -3671,6 +3729,43 @@ class SIMDScheduling(BaseScheduling):
             num_stages=int(winner_cfg.num_stages),
         )
 
+    def _precompile_combo_has_potential(
+        self, group: list[Any], node_schedule_map: dict[Any, NodeInfo]
+    ) -> bool:
+        if not config.combo_kernel_precompile_screen:
+            return True
+
+        device_props = DeviceProperties.create(V.graph.get_current_device_or_throw())
+        if device_props.type != "cuda":
+            return True
+        member_costs: list[tuple[float, int]] = []
+        for pn in group:
+            numel_hints: dict[str, int] = {}
+            for prefix, numel in node_schedule_map[pn].tiling.items():
+                if prefix_is_reduction(prefix):
+                    continue
+                numel_hint = V.graph.sizevars.optimization_hint(numel, fallback=0)
+                if not numel_hint or not V.graph.sizevars.statically_known_equals(
+                    numel, numel_hint
+                ):
+                    return True
+                numel_hints[prefix] = int(numel_hint)
+
+            min_waves = _combo_kernel_min_waves(numel_hints, device_props)
+            if min_waves is None:
+                return True
+            member_costs.append((pn.get_estimated_runtime() * 1e3, min_waves))
+
+        may_exceed = _combo_kernel_may_exceed_precompile_threshold(member_costs)
+        if not may_exceed:
+            counters["inductor"]["combo_precompile_screened"] += len(group)
+            log.debug(
+                "ComboKernels: precompile screen rejected %d sub-kernels with costs %s",
+                len(group),
+                member_costs,
+            )
+        return may_exceed
+
     def _autotune_subkernels_compile_time(
         self, group: list[Any], node_schedule_map: dict[Any, NodeInfo]
     ) -> list[Any | None]:
@@ -3996,13 +4091,19 @@ class SIMDScheduling(BaseScheduling):
                     # Deterministic mode falls through to no_bench_mode below: it bans timing-based
                     # benchmarking, so we pick block sizes from heuristics instead of autotuning.
                     group = list(node_group)
-                    tuned = self._autotune_subkernels_compile_time(
-                        group, node_schedule_map
-                    )
-                    # A None winner means its compile/benchmark failed; carve it out to
-                    # run standalone rather than stitch a bogus config or fail compile.
-                    fusable = [(pn, w) for pn, w in zip(group, tuned) if w is not None]
-                    carve_out = [pn for pn, w in zip(group, tuned) if w is None]
+                    if self._precompile_combo_has_potential(group, node_schedule_map):
+                        tuned = self._autotune_subkernels_compile_time(
+                            group, node_schedule_map
+                        )
+                        # A None winner means its compile/benchmark failed; carve it out to
+                        # run standalone rather than stitch a bogus config or fail compile.
+                        fusable = [
+                            (pn, w) for pn, w in zip(group, tuned) if w is not None
+                        ]
+                        carve_out = [pn for pn, w in zip(group, tuned) if w is None]
+                    else:
+                        fusable = []
+                        carve_out = group
                     if len(fusable) >= 2:
                         fusable_pns = [pn for pn, _ in fusable]
                         winners = [w for _, w in fusable]

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1113,6 +1113,13 @@ combo_kernel_compile_time_autotune: bool = Config(
     env_name_force="TORCHINDUCTOR_COMBO_KERNEL_COMPILE_TIME_AUTOTUNE",
     default=True,
 )
+# Experimental CUDA-only screen for combo groups whose launch and
+# wave-quantization cost model cannot reach the profitability threshold.
+combo_kernel_precompile_screen: bool = Config(
+    justknob="pytorch/inductor:combo_kernel_precompile_screen",
+    env_name_force="TORCHINDUCTOR_COMBO_KERNEL_PRECOMPILE_SCREEN",
+    default=False,
+)
 # When True, combo-kernel autotuning groups sub-kernels that share the same
 # candidate config set and kernel-analysis signature. Disabled by default.
 combo_kernel_autotune_grouping = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191727
* #188119
* #190383
* #189724
* #189003
* #189002
* #189001
* #188203

Combo compile-time autotuning currently generates and precompiles benchmark kernels for every candidate group before determining whether fusion has enough launch or wave-quantization benefit to justify that work.

Add a default-off CUDA precompile screen using information available after NodeInfo construction and horizontal partitioning. For each member, calculate the minimum grid size from the maximum legal Triton block sizes, then calculate the minimum wave count using the device's maximum thread-derived block capacity. The model credits fusion with one average tail wave per member and 8 us for every removed launch. A group is emitted standalone when this total modeled gain is below 3% of its estimated runtime.

Dynamic shapes, unavailable estimates or device properties, and unsupported backends retain the existing autotuning path. Policy rejection happens before autotuning and remains distinct from compile or benchmark failures.

This commit was authored with assistance from an AI coding assistant.

Test Plan:

```
conda run -n pt-pr-188119 python test/inductor/test_combo_kernels.py ComboKernelCompileTimeAutotuneTests
conda run -n pt-pr-188119 spin quicklint
```