### PR TITLE
[Testcase Refactoring] Enable PrivateUse1 tests and add hw-classification in test_unflatten

### DIFF
--- a/test/distributed/pipelining/test_unflatten.py
+++ b/test/distributed/pipelining/test_unflatten.py
@@ -3,7 +3,11 @@
 import torch
 from torch.distributed.pipelining import pipe_split, pipeline
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 # Building block for model
@@ -41,6 +45,8 @@ class M(torch.nn.Module):
 
 
 class UnflattenTests(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_unflatten(self, device):
         x = torch.randn(1, 16, 256, 256, device=device)
         constant = torch.ones(1, 16, 256, 256, device=device)
@@ -76,6 +82,8 @@ class UnflattenTests(TestCase):
 
 class UnflattenPlaceholderOrderingTests(TestCase):
     """regression tests for https://github.com/pytorch/pytorch/issues/162898"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def _check(self, node_ops, expected_ops):
         from torch.distributed.pipelining._IR import _move_placeholders_to_front
@@ -125,10 +133,7 @@ class UnflattenPlaceholderOrderingTests(TestCase):
         )
 
 
-devices = ["cpu", "cuda", "hpu", "xpu"]
-instantiate_device_type_tests(
-    UnflattenTests, globals(), only_for=devices, allow_xpu=True
-)
+instantiate_device_type_tests(UnflattenTests, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

`test/distributed/pipelining/test_unflatten.py` had two device-coupling issues for out-of-tree PrivateUse1 accelerators:

1. `UnflattenTests` was instantiated with `only_for=["cpu", "cuda", "hpu", "xpu"]`, which excludes PrivateUse1 — so `test_unflatten` never generated a PrivateUse1 variant.
2. Neither test class carried a `HardwareClassification` label, so the file could not participate in `--hw-classification` filtering.

## Changes

- **Drop `only_for`** from `instantiate_device_type_tests(UnflattenTests, ...)` (keep `allow_xpu=True`). With `only_for` removed, `get_desired_device_type_test_bases` auto-registers `PrivateUse1TestBase` when `_is_privateuse1_backend_available()`, so the PrivateUse1 variant of `test_unflatten` is generated alongside the existing cpu/cuda/hpu/xpu variants. This is zero-loss: HPU is added unconditionally on `TEST_HPU`, XPU via `allow_xpu`, and the only addition is PrivateUse1.

- **Classify `UnflattenTests` as `HardwareClassification.ACCELERATOR`** — `test_unflatten` builds a model on `device`, runs `pipeline(...)`, and asserts the pipelined output matches eager; accelerator-generic behavior with no CUDA-specific paths.

- **Classify `UnflattenPlaceholderOrderingTests` as `HardwareClassification.GENERIC`** — this class is not instantiated via `instantiate_device_type_tests` and its methods test pure FX graph placeholder ordering (`_move_placeholders_to_front`) with no device dependency.

The classification is metadata: it only filters tests when `--hw-classification` is passed; normal discovery/execution is unchanged.

## Test plan

```
python test/distributed/pipelining/test_unflatten.py -v
python test/distributed/pipelining/test_unflatten.py -v --hw-classification ACCELERATOR
python test/distributed/pipelining/test_unflatten.py -v --hw-classification CPU
python test/distributed/pipelining/test_unflatten.py -v --hw-classification GENERIC
```

Verified on a PrivateUse1 host (8 devices): the PrivateUse1 variant of `test_unflatten` is auto-generated (`UnflattenTestsPRIVATEUSE1`) and passes alongside `test_unflatten_cpu` and the 5 `UnflattenPlaceholderOrderingTests` methods (normal run: Ran 7, OK). `--hw-classification ACCELERATOR` includes only the 2 `test_unflatten` variants (total=7, passed=2, mismatched=5); `--hw-classification GENERIC` includes only the 5 FX-ordering methods (passed=5, mismatched=2); `--hw-classification CPU` filters all out (mismatched=7, Ran 0). Every filter reports `unclassified=0`, confirming both classes are classified.
