### PR TITLE
[Test][Refactor] Decouple custom_ops device tests from CUDA to be accelerator-agnostic

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -40,7 +40,6 @@ from torch._utils_internal import get_file_path_2  # @manual
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing._internal import custom_op_db
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     OpDTypes,
@@ -64,7 +63,6 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
     TEST_WITH_TORCHDYNAMO,
-    TEST_XPU,
     TestCase,
 )
 from torch.testing._internal.custom_op_db import numpy_nonzero
@@ -2047,7 +2045,7 @@ TORCH_LIBRARY(_test_pyobject_dispatch_cpp_fallback_torch_function, m) {
             op(x)
 
     @skipIfXpu(msg="Deprecated torch.custom_ops API")
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "requires CUDA or XPU")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_separate(self):
         @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
         def foo(x: torch.Tensor) -> torch.Tensor:
@@ -2072,7 +2070,7 @@ TORCH_LIBRARY(_test_pyobject_dispatch_cpp_fallback_torch_function, m) {
         self.assertEqual(result, foo_cuda(x_cuda))
 
     @skipIfXpu(msg="Deprecated torch.custom_ops API")
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "requires CUDA or XPU")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_multiple(self):
         @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
         def foo(x: torch.Tensor) -> torch.Tensor:
@@ -2675,7 +2673,7 @@ Dynamic shape operator
         self._test_impl_device("foo3", ["cpu", "cuda"], "cpu")
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "requires cuda or xpu")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_device_cuda(self):
         self._test_impl_device("foo4", "default", device_type)
         self._test_impl_device("foo5", [device_type], device_type)
@@ -5361,10 +5359,10 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(y, x.cos())
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_split_device(self):
         cpu_call_count = 0
-        cuda_call_count = 0
+        acc_call_count = 0
 
         @torch.library.custom_op(
             "_torch_testing::f", mutates_args=(), device_types="cpu"
@@ -5376,10 +5374,10 @@ Please use `add.register_fake` to add an fake impl.""",
             out_np = np.sin(x_np)
             return torch.from_numpy(out_np)
 
-        @f.register_kernel("cuda")
+        @f.register_kernel(device_type)
         def _(x: Tensor) -> Tensor:
-            nonlocal cuda_call_count
-            cuda_call_count += 1
+            nonlocal acc_call_count
+            acc_call_count += 1
             x_np = x.cpu().numpy()
             out_np = np.sin(x_np)
             return torch.from_numpy(out_np).to(x.device)
@@ -5388,19 +5386,19 @@ Please use `add.register_fake` to add an fake impl.""",
         y = f(x)
         self.assertEqual(y, x.sin())
         self.assertEqual(cpu_call_count, 1)
-        self.assertEqual(cuda_call_count, 0)
+        self.assertEqual(acc_call_count, 0)
 
-        x = x.cuda()
+        x = x.to(device_type)
         y = f(x)
         self.assertEqual(y, x.sin())
         self.assertEqual(cpu_call_count, 1)
-        self.assertEqual(cuda_call_count, 1)
+        self.assertEqual(acc_call_count, 1)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_multi_types(self):
         @torch.library.custom_op(
-            "_torch_testing::f", mutates_args=(), device_types=("cpu", "cuda")
+            "_torch_testing::f", mutates_args=(), device_types=("cpu", device_type)
         )
         def f(x: Tensor) -> Tensor:
             x_np = x.cpu().numpy()
@@ -5410,7 +5408,7 @@ Please use `add.register_fake` to add an fake impl.""",
         x = torch.randn(3)
         y = f(x)
         self.assertEqual(y, x.sin())
-        x = x.cuda()
+        x = x.to(device_type)
         y = f(x)
         self.assertEqual(y, x.sin())
 
@@ -6324,7 +6322,7 @@ opcheck(op, args, kwargs, test_utils="test_schema")
             },
         )
 
-    @unittest.skipIf(not TEST_CUDA, "pinned CPU memory requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "pinned CPU memory requires an accelerator")
     @unittest.skipIf(
         PYTORCH_CUDA_MEMCHECK, "is_pinned uses failure to detect pointer property"
     )
@@ -6343,7 +6341,7 @@ opcheck(op, args, kwargs, test_utils="test_schema")
         x = torch.arange(12, dtype=torch.float32, pin_memory=True).view(3, 4)
         torch.library.opcheck(op, (x,), test_utils="test_schema")
 
-    @unittest.skipIf(not TEST_CUDA, "pinned CPU memory requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "pinned CPU memory requires an accelerator")
     @unittest.skipIf(
         PYTORCH_CUDA_MEMCHECK, "is_pinned uses failure to detect pointer property"
     )
@@ -6406,7 +6404,7 @@ opcheck(op, args, kwargs, test_utils="test_schema")
         self.assertEqual(cloned.elem, x.elem)
         self.assertNotEqual(cloned.elem.data_ptr(), x.elem.data_ptr())
 
-    @unittest.skipIf(not TEST_CUDA, "pinned CPU memory requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "pinned CPU memory requires an accelerator")
     @unittest.skipIf(
         PYTORCH_CUDA_MEMCHECK, "is_pinned uses failure to detect pointer property"
     )
@@ -6442,11 +6440,11 @@ opcheck(op, args, kwargs, test_utils="test_schema")
             (torch.randn(3),),
             (torch.randn(3, requires_grad=True),),
         ]
-        if torch.cuda.is_available():
+        if torch.accelerator.is_available():
             sample_inputs.extend(
                 [
-                    (torch.randn(3, device="cuda"),),
-                    (torch.randn(3, device="cuda", requires_grad=True),),
+                    (torch.randn(3, device=device_type),),
+                    (torch.randn(3, device=device_type, requires_grad=True),),
                 ]
             )
         for args in sample_inputs:


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, We will port accelerator-guarded custom_ops cases to Intel GPU by making the tests accelerator-agnostic. We could enable Intel GPU with the following methods and try the best to keep the original code styles:

- Replace CUDA/XPU-specific skip guards with `TEST_ACCELERATOR`

- Replace hardcoded cuda device literals and `.cuda()` calls with `device_type`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98


## Summary

Refactor `test/test_custom_ops.py` so device-guarded tests run on any accelerator (CUDA/XPU) instead of being hardcoded to CUDA. No test logic changed; only device guards and device literals were generalized.

## Changes

- Replaced `not TEST_CUDA (and not TEST_XPU)` skip guards with `not TEST_ACCELERATOR` (accelerator-agnostic).
- Replaced hardcoded `"cuda"` execution device / `.cuda()` / `device="cuda"` with the module-level `device_type` (current accelerator).
- `test_split_device` / `test_multi_types`: register kernels on `device_type`, renamed `cuda_call_count` -> `acc_call_count`.
- Removed now-unused imports: `TEST_CUDA` (`common_cuda`), `TEST_XPU` (`common_utils`).
- Kept `@skipIfXpu(msg="Deprecated torch.custom_ops API")` and the deprecated-API `cpu`/`cuda` registration lists unchanged, since that deprecated API only supports `cpu`/`cuda`.

## Test count preserved

```
test/test_custom_ops.py: 258 -> 258 (unchanged)

$ grep -c 'def test_' test/test_custom_ops.py
258
```
