### PR TITLE
[c10d] Fix data race in groupRanks() under free-threading

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2661,9 +2661,9 @@ const c10::intrusive_ptr<Store>& ProcessGroupNCCL::globalStore() const {
   return globalStore_;
 }
 
-const std::vector<uint64_t>& ProcessGroupNCCL::groupRanks() const {
+std::vector<uint64_t> ProcessGroupNCCL::groupRanks() const {
   if (options_->global_ranks_in_group.empty() && local_id_ == 0) {
-    static std::vector<uint64_t> globalRanks(size_);
+    std::vector<uint64_t> globalRanks(size_);
     std::iota(globalRanks.begin(), globalRanks.end(), 0);
     return globalRanks;
   }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1334,9 +1334,10 @@ c10::intrusive_ptr<Backend> ProcessGroupNCCL::split(
   TORCH_CHECK(ncclOpts != nullptr, "opts not a ProcessGroupNCCL::Options.");
 
   // TODO: we need to get rid of globalRanksInGroup eventually.
+  auto allRanks = groupRanks();
   std::vector<uint64_t> globalRanksInGroup;
   for (auto rank : ranks) {
-    globalRanksInGroup.emplace_back(groupRanks()[rank]);
+    globalRanksInGroup.emplace_back(allRanks[rank]);
   }
   ncclOpts->split_from =
       c10::intrusive_ptr<ProcessGroupNCCL>::unsafe_reclaim_from_nonowning(this);

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1240,7 +1240,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   const c10::intrusive_ptr<Store>& globalStore() const;
 
   // Returns the global ranks of a PG.
-  const std::vector<uint64_t>& groupRanks() const;
+  std::vector<uint64_t> groupRanks() const;
 
   // Util function to assign timeout to each work.
   void assignTimeoutToWork(


### PR DESCRIPTION
ProcessGroupNCCL::groupRanks() used a function-local static std::vector that was rewritten on every call via std::iota. Under free-threading, concurrent calls could read the vector while another thread was writing it.

Return the vector by value to eliminate the shared mutable state.