### PR TITLE
register interface for PrivateUse1

### DIFF
--- a/test/dynamo/test_device_interface_registration.py
+++ b/test/dynamo/test_device_interface_registration.py
@@ -2,6 +2,7 @@
 from unittest.mock import MagicMock, patch
 
 import torch
+import torch.utils.backend_registration
 from torch._dynamo.device_interface import (
     DeviceInterface,
     get_interface_for_device,
@@ -41,22 +42,43 @@ class TestPrivateuse1DeviceInterface(TestCase):
         mod = MagicMock()
         mod.get_device_interface = get_device_interface_fn
         mod.device_count = device_count_fn
+        _pu1_patch = patch.object(
+            torch._C,
+            "_get_privateuse1_backend_name",
+            return_value="fakebackend",
+        )
+        _pu1_br_patch = patch.object(
+            torch.utils.backend_registration,
+            "_get_privateuse1_backend_name",
+            return_value="fakebackend",
+        )
+        return (
+            _pu1_patch,
+            _pu1_br_patch,
+            patch.object(torch, "fakebackend", mod, create=True),
+        )
+
+    def _patch_no_backend(self, backend_name="privateuseone"):
+        """Patch both _get_privateuse1_backend_name references."""
         return (
             patch.object(
                 torch._C,
                 "_get_privateuse1_backend_name",
-                return_value="fakebackend",
+                return_value=backend_name,
             ),
-            patch.object(torch, "fakebackend", mod, create=True),
+            patch.object(
+                torch.utils.backend_registration,
+                "_get_privateuse1_backend_name",
+                return_value=backend_name,
+            ),
         )
 
     def test_no_backend_registered(self):
         """When no privateuse1 backend is set, get_interface_for_device should
         raise NotImplementedError for the privateuse1 device."""
         self._reset_device_reg()
-        with patch.object(
-            torch._C, "_get_privateuse1_backend_name", return_value="privateuseone"
-        ):
+        p1, p2 = self._patch_no_backend()
+        with p1, p2:
             with self.assertRaises(NotImplementedError):
                 get_interface_for_device("privateuseone")
 
@@ -68,11 +90,11 @@ class TestPrivateuse1DeviceInterface(TestCase):
 
         self._reset_device_reg()
         try:
-            p1, p2 = self._setup_fakebackend(
+            p1, p2, p3 = self._setup_fakebackend(
                 get_device_interface_fn=lambda: DummyInterface,
                 device_count_fn=lambda: 1,
             )
-            with p1, p2:
+            with p1, p2, p3:
                 self.assertIs(get_interface_for_device("fakebackend"), DummyInterface)
                 self.assertIs(
                     get_interface_for_device("fakebackend:0"), DummyInterface
@@ -84,11 +106,8 @@ class TestPrivateuse1DeviceInterface(TestCase):
         """When the backend name is set but no module is registered on torch,
         get_interface_for_device should raise NotImplementedError."""
         self._reset_device_reg()
-        with patch.object(
-            torch._C,
-            "_get_privateuse1_backend_name",
-            return_value="fakebackend",
-        ):
+        p1, p2 = self._patch_no_backend("fakebackend")
+        with p1, p2:
             with patch.object(torch, "fakebackend", None, create=True):
                 with self.assertRaises(NotImplementedError):
                     get_interface_for_device("fakebackend")
@@ -100,11 +119,8 @@ class TestPrivateuse1DeviceInterface(TestCase):
         del mod.get_device_interface
 
         self._reset_device_reg()
-        with patch.object(
-            torch._C,
-            "_get_privateuse1_backend_name",
-            return_value="fakebackend",
-        ):
+        p1, p2 = self._patch_no_backend("fakebackend")
+        with p1, p2:
             with patch.object(torch, "fakebackend", mod, create=True):
                 with self.assertRaises(NotImplementedError):
                     get_interface_for_device("fakebackend")
@@ -113,10 +129,10 @@ class TestPrivateuse1DeviceInterface(TestCase):
         """When get_device_interface returns None,
         get_interface_for_device should raise NotImplementedError."""
         self._reset_device_reg()
-        p1, p2 = self._setup_fakebackend(
+        p1, p2, p3 = self._setup_fakebackend(
             get_device_interface_fn=lambda: None,
         )
-        with p1, p2:
+        with p1, p2, p3:
             with self.assertRaises(NotImplementedError):
                 get_interface_for_device("fakebackend")
 
@@ -125,15 +141,14 @@ class TestPrivateuse1DeviceInterface(TestCase):
         to the caller of get_interface_for_device; it should raise
         NotImplementedError instead."""
         self._reset_device_reg()
-        p1, p2 = self._setup_fakebackend(
+        p1, p2, p3 = self._setup_fakebackend(
             get_device_interface_fn=MagicMock(
                 side_effect=RuntimeError("driver missing")
             ),
         )
-        with p1, p2:
-            with self.assertLogs("torch._dynamo.device_interface", level="WARNING"):
-                with self.assertRaises(NotImplementedError):
-                    get_interface_for_device("fakebackend")
+        with p1, p2, p3:
+            with self.assertRaises(NotImplementedError):
+                get_interface_for_device("fakebackend")
 
     def test_backend_device_count_raises(self):
         """When device_count raises, the main device is already registered
@@ -141,24 +156,23 @@ class TestPrivateuse1DeviceInterface(TestCase):
         DummyInterface = self._make_dummy_interface()
 
         self._reset_device_reg()
-        p1, p2 = self._setup_fakebackend(
+        p1, p2, p3 = self._setup_fakebackend(
             get_device_interface_fn=lambda: DummyInterface,
             device_count_fn=MagicMock(side_effect=RuntimeError("driver error")),
         )
-        with p1, p2:
-            with self.assertLogs("torch._dynamo.device_interface", level="WARNING"):
-                self.assertIs(get_interface_for_device("fakebackend"), DummyInterface)
-                with self.assertRaises(NotImplementedError):
-                    get_interface_for_device("fakebackend:0")
+        with p1, p2, p3:
+            self.assertIs(get_interface_for_device("fakebackend"), DummyInterface)
+            with self.assertRaises(NotImplementedError):
+                get_interface_for_device("fakebackend:0")
 
     def test_backend_returns_non_device_interface(self):
         """When get_device_interface returns a non-DeviceInterface subclass,
         get_interface_for_device should raise NotImplementedError."""
         self._reset_device_reg()
-        p1, p2 = self._setup_fakebackend(
+        p1, p2, p3 = self._setup_fakebackend(
             get_device_interface_fn=lambda: str,  # not a DeviceInterface subclass
         )
-        with p1, p2:
+        with p1, p2, p3:
             with self.assertRaises(NotImplementedError):
                 get_interface_for_device("fakebackend")
 

--- a/test/dynamo/test_device_interface_registration.py
+++ b/test/dynamo/test_device_interface_registration.py
@@ -1,0 +1,169 @@
+# Owner(s): ["module: dynamo"]
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch._dynamo.device_interface import (
+    DeviceInterface,
+    get_interface_for_device,
+)
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
+
+
+class TestPrivateuse1DeviceInterface(TestCase):
+    """
+    Integration tests for privateuse1 device interface registration.
+
+    These tests verify that when a privateuse1 backend is configured,
+    get_interface_for_device() returns the correct interface, and various
+    failure modes in the backend module do not crash the system.
+    """
+
+    hw_classification = HardwareClassification.GENERIC
+
+    def _make_dummy_interface(self):
+        """Create a dummy DeviceInterface subclass for testing."""
+
+        class DummyInterface(DeviceInterface):
+            pass
+
+        return DummyInterface
+
+    def _reset_device_reg(self):
+        """Reset device registration state so init_device_reg() re-runs."""
+        import torch._dynamo.device_interface as di
+
+        di._device_initialized = False
+        di.device_interfaces.clear()
+
+    def _setup_fakebackend(self, get_device_interface_fn, device_count_fn=lambda: 0):
+        """Set up a fake backend module on torch with the given get_device_interface
+        and device_count, and patch _get_privateuse1_backend_name to return its name."""
+        mod = MagicMock()
+        mod.get_device_interface = get_device_interface_fn
+        mod.device_count = device_count_fn
+        return (
+            patch.object(
+                torch._C,
+                "_get_privateuse1_backend_name",
+                return_value="fakebackend",
+            ),
+            patch.object(torch, "fakebackend", mod, create=True),
+        )
+
+    def test_no_backend_registered(self):
+        """When no privateuse1 backend is set, get_interface_for_device should
+        raise NotImplementedError for the privateuse1 device."""
+        self._reset_device_reg()
+        with patch.object(
+            torch._C, "_get_privateuse1_backend_name", return_value="privateuseone"
+        ):
+            with self.assertRaises(NotImplementedError):
+                get_interface_for_device("privateuseone")
+
+    def test_backend_registers_interface(self):
+        """When a privateuse1 backend is properly configured,
+        get_interface_for_device should return the correct interface for both
+        the device name and device:index."""
+        DummyInterface = self._make_dummy_interface()
+
+        self._reset_device_reg()
+        try:
+            p1, p2 = self._setup_fakebackend(
+                get_device_interface_fn=lambda: DummyInterface,
+                device_count_fn=lambda: 1,
+            )
+            with p1, p2:
+                self.assertIs(get_interface_for_device("fakebackend"), DummyInterface)
+                self.assertIs(
+                    get_interface_for_device("fakebackend:0"), DummyInterface
+                )
+        finally:
+            self._reset_device_reg()
+
+    def test_backend_missing_module(self):
+        """When the backend name is set but no module is registered on torch,
+        get_interface_for_device should raise NotImplementedError."""
+        self._reset_device_reg()
+        with patch.object(
+            torch._C,
+            "_get_privateuse1_backend_name",
+            return_value="fakebackend",
+        ):
+            with patch.object(torch, "fakebackend", None, create=True):
+                with self.assertRaises(NotImplementedError):
+                    get_interface_for_device("fakebackend")
+
+    def test_backend_missing_get_device_interface(self):
+        """When the backend module exists but lacks get_device_interface,
+        get_interface_for_device should raise NotImplementedError."""
+        mod = MagicMock(spec=[])
+        del mod.get_device_interface
+
+        self._reset_device_reg()
+        with patch.object(
+            torch._C,
+            "_get_privateuse1_backend_name",
+            return_value="fakebackend",
+        ):
+            with patch.object(torch, "fakebackend", mod, create=True):
+                with self.assertRaises(NotImplementedError):
+                    get_interface_for_device("fakebackend")
+
+    def test_backend_get_device_interface_returns_none(self):
+        """When get_device_interface returns None,
+        get_interface_for_device should raise NotImplementedError."""
+        self._reset_device_reg()
+        p1, p2 = self._setup_fakebackend(
+            get_device_interface_fn=lambda: None,
+        )
+        with p1, p2:
+            with self.assertRaises(NotImplementedError):
+                get_interface_for_device("fakebackend")
+
+    def test_backend_get_device_interface_raises(self):
+        """When get_device_interface raises, the exception should not propagate
+        to the caller of get_interface_for_device; it should raise
+        NotImplementedError instead."""
+        self._reset_device_reg()
+        p1, p2 = self._setup_fakebackend(
+            get_device_interface_fn=MagicMock(
+                side_effect=RuntimeError("driver missing")
+            ),
+        )
+        with p1, p2:
+            with self.assertLogs("torch._dynamo.device_interface", level="WARNING"):
+                with self.assertRaises(NotImplementedError):
+                    get_interface_for_device("fakebackend")
+
+    def test_backend_device_count_raises(self):
+        """When device_count raises, the main device is already registered
+        but indexed devices are not; the exception should not propagate."""
+        DummyInterface = self._make_dummy_interface()
+
+        self._reset_device_reg()
+        p1, p2 = self._setup_fakebackend(
+            get_device_interface_fn=lambda: DummyInterface,
+            device_count_fn=MagicMock(side_effect=RuntimeError("driver error")),
+        )
+        with p1, p2:
+            with self.assertLogs("torch._dynamo.device_interface", level="WARNING"):
+                self.assertIs(get_interface_for_device("fakebackend"), DummyInterface)
+                with self.assertRaises(NotImplementedError):
+                    get_interface_for_device("fakebackend:0")
+
+    def test_backend_returns_non_device_interface(self):
+        """When get_device_interface returns a non-DeviceInterface subclass,
+        get_interface_for_device should raise NotImplementedError."""
+        self._reset_device_reg()
+        p1, p2 = self._setup_fakebackend(
+            get_device_interface_fn=lambda: str,  # not a DeviceInterface subclass
+        )
+        with p1, p2:
+            with self.assertRaises(NotImplementedError):
+                get_interface_for_device("fakebackend")
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -16,7 +16,6 @@ specialized implementations for each hardware backend's unique features.
 """
 
 import inspect
-import logging
 import time
 from collections import namedtuple
 from collections.abc import Callable, Iterable
@@ -25,8 +24,6 @@ from typing import Any, Literal
 
 import torch
 from torch.utils._pallas import has_torch_tpu
-
-log = logging.getLogger(__name__)
 
 
 get_cuda_stream: Callable[[int], int] | None
@@ -666,18 +663,19 @@ def _register_interface_for_privateuse1() -> None:
     backend = torch._C._get_privateuse1_backend_name()
     if not backend or backend == "privateuseone":
         return
-    mod = getattr(torch, backend, None)
-    if mod is None or not hasattr(mod, "get_device_interface"):
-        return
+    from torch.utils.backend_registration import _get_custom_mod_func
     try:
-        interface = mod.get_device_interface()
+        get_device_interface_fn = _get_custom_mod_func("get_device_interface")
+        interface = get_device_interface_fn()
         if interface is None or not issubclass(interface, DeviceInterface):
             return
         register_interface_for_device(backend, interface)
-        for i in range(mod.device_count()):
-            register_interface_for_device(f"{backend}:{i}", interface)
-    except Exception:
-        log.warning("Failed to register device interface for %s", backend, exc_info=True)
+        device_count_fn = _get_custom_mod_func("device_count")
+        if device_count_fn is not None:
+            for i in range(device_count_fn()):
+                register_interface_for_device(f"{backend}:{i}", interface)
+    except RuntimeError:
+        pass
 
 
 def init_device_reg() -> None:

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -16,6 +16,7 @@ specialized implementations for each hardware backend's unique features.
 """
 
 import inspect
+import logging
 import time
 from collections import namedtuple
 from collections.abc import Callable, Iterable
@@ -24,6 +25,8 @@ from typing import Any, Literal
 
 import torch
 from torch.utils._pallas import has_torch_tpu
+
+log = logging.getLogger(__name__)
 
 
 get_cuda_stream: Callable[[int], int] | None
@@ -659,6 +662,23 @@ def get_registered_device_interfaces() -> Iterable[tuple[str, type[DeviceInterfa
         init_device_reg()
     return device_interfaces.items()
 
+def _register_interface_for_privateuse1() -> None:
+    backend = torch._C._get_privateuse1_backend_name()
+    if not backend or backend == "privateuseone":
+        return
+    mod = getattr(torch, backend, None)
+    if mod is None or not hasattr(mod, "get_device_interface"):
+        return
+    try:
+        interface = mod.get_device_interface()
+        if interface is None or not issubclass(interface, DeviceInterface):
+            return
+        register_interface_for_device(backend, interface)
+        for i in range(mod.device_count()):
+            register_interface_for_device(f"{backend}:{i}", interface)
+    except Exception:
+        log.warning("Failed to register device interface for %s", backend, exc_info=True)
+
 
 def init_device_reg() -> None:
     global _device_initialized
@@ -677,5 +697,7 @@ def init_device_reg() -> None:
     register_interface_for_device("cpu", CpuInterface)
     register_interface_for_device("mps", MpsInterface)
     register_interface_for_device("tpu", TpuInterface)
+
+    _register_interface_for_privateuse1()
 
     _device_initialized = True

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -659,6 +659,7 @@ def get_registered_device_interfaces() -> Iterable[tuple[str, type[DeviceInterfa
         init_device_reg()
     return device_interfaces.items()
 
+
 def _register_interface_for_privateuse1() -> None:
     backend = torch._C._get_privateuse1_backend_name()
     if not backend or backend == "privateuseone":

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -640,6 +640,25 @@ def get_registered_device_interfaces() -> Iterable[tuple[str, type[DeviceInterfa
         init_device_reg()
     return device_interfaces.items()
 
+def register_interface_for_privateuse1() -> None:
+    backend = torch._C._get_privateuse1_backend_name()
+    necessary_funcs = ["get_pu1_interface"]
+    if hasattr(torch, backend):
+        custom_device_mod = getattr(torch, backend)
+        all_funcs_exist = True
+        for func_name in necessary_funcs:
+            if not hasattr(custom_device_mod, func_name):
+                all_funcs_exist = False
+                break
+        if all_funcs_exist:
+            interface = custom_device_mod.get_pu1_interface()
+            if interface:
+                register_interface_for_device(backend, interface)
+                module = getattr(torch, backend, None)
+                if module and hasattr(module, "device_count"):
+                    for i in range(module.device_count()):
+                        register_interface_for_device(f"{backend}:{i}", interface)
+
 
 def init_device_reg() -> None:
     global _device_initialized
@@ -658,5 +677,7 @@ def init_device_reg() -> None:
     register_interface_for_device("cpu", CpuInterface)
     register_interface_for_device("mps", MpsInterface)
     register_interface_for_device("tpu", TpuInterface)
+
+    register_interface_for_privateuse1()
 
     _device_initialized = True


### PR DESCRIPTION
Fix #191314 
Downstream PrivateUse1 backends do not want `import torch` to trigger `import torch._dynamo.*` — dynamo is a heavy module whose import carries non-trivial side effects and latency — yet they still need to register their `DeviceInterface` into the `torch._dynamo.device_interface.device_interfaces` registry so dynamo can look it up the first time it is actually used.
Therefore a custom interface registration forPrivateUse1 is add in  `init_device_reg()`.
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98