### PR TITLE
[Testcase Refactoring]  1. Add proper hw_classification attribute to test classes.  2. Add instantiate_device_type_tests to generalize device types.

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -26,6 +26,7 @@ from torch._inductor.utils import (
     run_and_get_code,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
 )
@@ -102,6 +103,8 @@ def _nvgemm_config(**overrides):
 @instantiate_parametrized_tests
 class TestNVUniversalGemm(TestCase):
     """Test cases for NVIDIA Universal GEMM functionality."""
+
+    hw_classification = HardwareClassification.CUDA
 
     @parametrize("dtype", (torch.float16, torch.bfloat16))
     @parametrize(
@@ -771,6 +774,8 @@ class TestNVUniversalGemm(TestCase):
 class TestNVUniversalGemmHeuristics(TestCase):
     """Unit tests for NVUniversalGemmHeuristics without requiring actual libraries."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_grouped_reduction_conversion_contract(self):
         from torch._inductor.kernel.loop_ir_epilogue_lowering import (
             GemmEpilogueIRExpression as Expr,
@@ -938,6 +943,8 @@ class TestNVUniversalGemmHeuristics(TestCase):
 class TestNVUniversalGemmHeuristicsIntegration(TestCase):
     """Integration tests for nvMatmulHeuristics with real library calls."""
 
+    hw_classification = HardwareClassification.CUDA
+
     def test_fp4_heuristic_configs(self):
         """Test that nvMatmulHeuristics returns configs for FP4 blockscaled GEMM."""
         heuristics = NVUniversalGemmHeuristics()
@@ -999,6 +1006,8 @@ class TestNVUniversalGemmHeuristicsIntegration(TestCase):
 )
 class TestNVUniversalGemmDynamicShapes(TestCase):
     """Test cases for NVIDIA Universal GEMM with dynamic shapes."""
+
+    hw_classification = HardwareClassification.CUDA
 
     @torch._dynamo.config.patch({"capture_dynamic_output_shape_ops": True})
     def test_unbacked_symint_rejected(self):
@@ -1068,6 +1077,8 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
     generated code for epilogue markers. Benchmarks are mocked to ensure
     deterministic fusion decisions independent of GPU noise.
     """
+
+    hw_classification = HardwareClassification.CUDA
 
     M, N, K = 512, 512, 512
 

--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -25,10 +25,10 @@ from torch._inductor.utils import (
     ensure_nvmatmul_heuristics_available,
     run_and_get_code,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     dtype_name,
     HardwareClassification,
-    instantiate_parametrized_tests,
     parametrize,
 )
 from torch.utils._ordered_set import OrderedSet
@@ -102,7 +102,6 @@ def _nvgemm_config(**overrides):
     not (ensure_nv_universal_gemm_available() and is_datacenter_blackwell_arch()),
     "NVIDIA Universal GEMM (cutlass_api) library not available or not on Blackwell",
 )
-@instantiate_parametrized_tests
 class TestNVUniversalGemm(TestCase):
     """Test cases for NVIDIA Universal GEMM functionality."""
 
@@ -121,7 +120,7 @@ class TestNVUniversalGemm(TestCase):
             ("contiguous", "padded"),
         ),
     )
-    def test_matmul(self, dtype, layout_a, layout_b):
+    def test_matmul(self, device, dtype, layout_a, layout_b):
         """Test matmul with various dtypes and tensor layouts.
 
         M=513 tests that non-divisible M dimension works
@@ -132,8 +131,8 @@ class TestNVUniversalGemm(TestCase):
         def matmul(a, b):
             return a @ b
 
-        a = _create_tensor_with_layout(layout_a, m, k, dtype)
-        b = _create_tensor_with_layout(layout_b, k, n, dtype)
+        a = _create_tensor_with_layout(layout_a, m, k, dtype, device)
+        b = _create_tensor_with_layout(layout_b, k, n, dtype, device)
         expected = matmul(a, b)
 
         torch._dynamo.reset()
@@ -144,7 +143,7 @@ class TestNVUniversalGemm(TestCase):
 
         torch.testing.assert_close(result, expected)
 
-    def test_arch_filter_rejects_min_cc_only_kernels(self):
+    def test_arch_filter_rejects_min_cc_only_kernels(self, device):
         """designed_for_min_cc <= device cc is insufficient: an arch-conditional
         sm90 kernel reports min_cc=90 but only lists a cc=90 target and won't
         compile on sm100. The exact-arch filter (via _device_target) must reject
@@ -152,7 +151,7 @@ class TestNVUniversalGemm(TestCase):
         """
         from torch._inductor.codegen.nv_universal_gemm import kernel_cache
 
-        major, minor = torch.cuda.get_device_capability()
+        major, minor = torch.cuda.get_device_capability(device)
         cc = major * 10 + minor
         device_target = kernel_cache._device_target(cc)
 
@@ -173,7 +172,7 @@ class TestNVUniversalGemm(TestCase):
         )
 
     @parametrize("dtype", (torch.float16, torch.bfloat16))
-    def test_matmul_swap_ab(self, dtype):
+    def test_matmul_swap_ab(self, device, dtype):
         """swap_ab computes (B^T @ A^T)^T so the large N lands on the M-axis,
         improving tile utilization for small-M shapes. Verify a small-M matmul
         stays numerically correct with swap_ab enabled (the swapped operands and
@@ -184,8 +183,8 @@ class TestNVUniversalGemm(TestCase):
         def matmul(a, b):
             return a @ b
 
-        a = _create_tensor_with_layout("contiguous", m, k, dtype)
-        b = _create_tensor_with_layout("contiguous", k, n, dtype)
+        a = _create_tensor_with_layout("contiguous", m, k, dtype, device)
+        b = _create_tensor_with_layout("contiguous", k, n, dtype, device)
         expected = matmul(a, b)
 
         torch._dynamo.reset()
@@ -196,7 +195,7 @@ class TestNVUniversalGemm(TestCase):
 
         torch.testing.assert_close(result, expected)
 
-    def test_cudagraphs_intermediate_addmm(self):
+    def test_cudagraphs_intermediate_addmm(self, device):
         """An NVGEMM addmm whose bias-epilogue output is an intermediate consumed
         downstream must not leave that output retained by the cached EFC kernel,
         or CUDA graph capture fails ("tensor(s) in the cudagraph pool not tracked
@@ -207,9 +206,9 @@ class TestNVUniversalGemm(TestCase):
         dtype = torch.bfloat16
         m, k = 512, 512
         # Scaled down so the chained bf16 matmul stays well-conditioned.
-        bias = torch.randn(k, dtype=dtype, device="cuda") * 0.1
-        x = torch.randn(m, k, dtype=dtype, device="cuda") * 0.1
-        w = torch.randn(k, k, dtype=dtype, device="cuda") * 0.1
+        bias = torch.randn(k, dtype=dtype, device=device) * 0.1
+        x = torch.randn(m, k, dtype=dtype, device=device) * 0.1
+        w = torch.randn(k, k, dtype=dtype, device=device) * 0.1
 
         def chain(bias, x, w):
             # h is an NVGEMM addmm output consumed downstream (not the graph's
@@ -230,7 +229,7 @@ class TestNVUniversalGemm(TestCase):
 
         torch.testing.assert_close(result, expected, rtol=1.6e-2, atol=1e-1)
 
-    def test_efc_epilogue_lookup_no_deadlock(self):
+    def test_efc_epilogue_lookup_no_deadlock(self, device):
         """get_efc_kernel_with_epilogue holds _cache_lock and, when the base EFC
         kernel is not pre-resolved and misses the args cache, calls
         get_kernel_by_name -> _ensure_caches, which re-acquires _cache_lock on the
@@ -261,7 +260,7 @@ class TestNVUniversalGemm(TestCase):
         )
         self.assertIsNone(result[0])
 
-    def test_unaligned_base_pointer_rejected(self):
+    def test_unaligned_base_pointer_rejected(self, device):
         """Test that matmul with unaligned base pointer is rejected.
 
         cutlass_api requires 16-byte aligned base pointers. Since alignment
@@ -270,7 +269,6 @@ class TestNVUniversalGemm(TestCase):
         """
         m, n, k = 512, 512, 512
         dtype = torch.bfloat16
-        device = "cuda"
 
         def matmul(a, b):
             return a @ b
@@ -290,14 +288,13 @@ class TestNVUniversalGemm(TestCase):
                 compiled_fn(a, b)
 
     @parametrize("dtype", (torch.float16, torch.bfloat16))
-    def test_reinterpret_view_from_slice(self, dtype):
+    def test_reinterpret_view_from_slice(self, device, dtype):
         """Test that sliced tensors (creating ReinterpretViews) work correctly.
 
         When tensors are slices of a shared buffer (e.g., from a fused projection),
         they become ReinterpretViews with non-contiguous strides.
         """
         m, n, k = 512, 512, 512
-        device = "cuda"
 
         def fn(x, weight):
             projected = x @ weight  # (m, 2*n)
@@ -316,7 +313,7 @@ class TestNVUniversalGemm(TestCase):
 
         torch.testing.assert_close(result, expected)
 
-    def test_workspace_allocation(self):
+    def test_workspace_allocation(self, device):
         """Test that workspace allocation works correctly.
 
         Since no current CUTLASS kernels require a workspace, we mock the
@@ -324,7 +321,6 @@ class TestNVUniversalGemm(TestCase):
         """
         m, n, k = 512, 512, 512
         dtype = torch.bfloat16
-        device = "cuda"
 
         def matmul(a, b):
             return a @ b
@@ -356,10 +352,9 @@ class TestNVUniversalGemm(TestCase):
         torch.testing.assert_close(result, expected)
 
     @parametrize("dtype", (torch.float16, torch.bfloat16))
-    def test_bmm_non_standard_batch_stride(self, dtype):
+    def test_bmm_non_standard_batch_stride(self, device, dtype):
         """Test BMM path with non-standard batch strides."""
         batch, m, n, k = 8, 64, 256, 128
-        device = "cuda"
 
         def bmm(a, b):
             return torch.bmm(a, b)
@@ -403,7 +398,7 @@ class TestNVUniversalGemm(TestCase):
             (512, 256, 1024),
         ),
     )
-    def test_scaled_gemm_mxfp8(self, layout_a, m, n, k):
+    def test_scaled_gemm_mxfp8(self, device, layout_a, m, n, k):
         """Test MXFP8 scaled GEMM with NVGEMM backend."""
         block_size = 32
 
@@ -412,13 +407,13 @@ class TestNVUniversalGemm(TestCase):
                 a, b, scale_a=scale_a, scale_b=scale_b, out_dtype=torch.float32
             )
 
-        a_fp8 = _create_tensor_with_layout(layout_a, m, k, torch.float8_e4m3fn)
-        b_fp8 = torch.randint(-1, 2, (n, k), device="cuda").to(torch.float8_e4m3fn).T
+        a_fp8 = _create_tensor_with_layout(layout_a, m, k, torch.float8_e4m3fn, device)
+        b_fp8 = torch.randint(-1, 2, (n, k), device=device).to(torch.float8_e4m3fn).T
 
-        scale_a = torch.rand(m, _prep_k(k, block_size), device="cuda").to(
+        scale_a = torch.rand(m, _prep_k(k, block_size), device=device).to(
             torch.float8_e8m0fnu
         )
-        scale_b = torch.rand(_prep_k(k, block_size), n, device="cuda").to(
+        scale_b = torch.rand(_prep_k(k, block_size), n, device=device).to(
             torch.float8_e8m0fnu
         )
 
@@ -441,7 +436,7 @@ class TestNVUniversalGemm(TestCase):
             (64, 64, 512),
         ),
     )
-    def test_scaled_gemm_nvf4_padded_scales(self, m, n, k):
+    def test_scaled_gemm_nvf4_padded_scales(self, device, m, n, k):
         """Test NVF4 with padded scales (M or N < 128).
 
         torch._scaled_mm creates scales with block_size_mn=128 padding,
@@ -456,10 +451,10 @@ class TestNVUniversalGemm(TestCase):
             )
 
         a_fp4 = _create_tensor_with_layout(
-            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2, device
         )
         b_fp4 = torch.randint(
-            0, 256, (n, packed_k), device="cuda", dtype=torch.uint8
+            0, 256, (n, packed_k), device=device, dtype=torch.uint8
         ).view(torch.float4_e2m1fn_x2)
         b_fp4_t = b_fp4.T
 
@@ -468,8 +463,8 @@ class TestNVUniversalGemm(TestCase):
         scale_a_numel = _round_up(m, 128) * padded_k_blocks
         scale_b_numel = _round_up(n, 128) * padded_k_blocks
 
-        scale_a = torch.rand(scale_a_numel, device="cuda").to(torch.float8_e4m3fn)
-        scale_b = torch.rand(scale_b_numel, device="cuda").to(torch.float8_e4m3fn)
+        scale_a = torch.rand(scale_a_numel, device=device).to(torch.float8_e4m3fn)
+        scale_b = torch.rand(scale_b_numel, device=device).to(torch.float8_e4m3fn)
 
         expected = scaled_mm(a_fp4, b_fp4_t, scale_a, scale_b)
 
@@ -485,7 +480,7 @@ class TestNVUniversalGemm(TestCase):
 
         torch.testing.assert_close(result, expected, equal_nan=True)
 
-    def test_scaled_gemm_grouped_n_reduce_provider(self):
+    def test_scaled_gemm_grouped_n_reduce_provider(self, device):
         from cutlass import Float32
         from cutlass.operators import ScaleMode, ScaleSwizzleMode
 
@@ -499,22 +494,22 @@ class TestNVUniversalGemm(TestCase):
         m, n, k = 128, 128, 512
         packed_k = k // 2
         a = _create_tensor_with_layout(
-            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2, device
         )
-        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+        b = torch.randint(0, 256, (n, packed_k), device=device, dtype=torch.uint8).view(
             torch.float4_e2m1fn_x2
         )
         b = b.T
         padded_k_blocks = _round_up(ceildiv(k, 16), 4)
-        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        out = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
+        out = torch.empty((m, n), device=device, dtype=torch.bfloat16)
         group = 32
-        reduce_out = torch.empty((m, n // group), device="cuda", dtype=torch.float32)
+        reduce_out = torch.empty((m, n // group), device=device, dtype=torch.float32)
         mode = ScaleMode.Blockwise1x16
         swizzle = ScaleSwizzleMode.Swizzle32x4x4
         args = _create_gemm_arguments(
@@ -548,7 +543,7 @@ class TestNVUniversalGemm(TestCase):
             out.float().view(m, -1, group).sum(-1),
         )
 
-    def test_scaled_gemm_unit_dim_epilogue_non_current_stream(self):
+    def test_scaled_gemm_unit_dim_epilogue_non_current_stream(self, device):
         from cutlass import Float32
         from cutlass.operators import ScaleMode, ScaleSwizzleMode
         from cutlass.operators.arguments import EpilogueArguments
@@ -563,21 +558,21 @@ class TestNVUniversalGemm(TestCase):
         m, n, k = 1, 128, 512
         packed_k = k // 2
         a = _create_tensor_with_layout(
-            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2, device
         )
-        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+        b = torch.randint(0, 256, (n, packed_k), device=device, dtype=torch.uint8).view(
             torch.float4_e2m1fn_x2
         )
         b = b.T
         padded_k_blocks = _round_up(ceildiv(k, 16), 4)
-        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        bias = torch.randn((1, 1), device="cuda", dtype=torch.bfloat16)
-        out = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
+        bias = torch.randn((1, 1), device=device, dtype=torch.bfloat16)
+        out = torch.empty((m, n), device=device, dtype=torch.bfloat16)
         expected = (
             torch._scaled_mm(
                 a,
@@ -643,7 +638,7 @@ class TestNVUniversalGemm(TestCase):
             (512, 256, 1024),
         ),
     )
-    def test_scaled_gemm_nvf4(self, out_dtype, layout_a, m, n, k):
+    def test_scaled_gemm_nvf4(self, device, out_dtype, layout_a, m, n, k):
         """Test NVF4 (Float4 + Float8E4M3FN scales, block_size=16) with NVGEMM backend."""
         packed_k = k // 2
         block_size = 16
@@ -654,10 +649,10 @@ class TestNVUniversalGemm(TestCase):
             )
 
         a_fp4 = _create_tensor_with_layout(
-            layout_a, m, packed_k, torch.float4_e2m1fn_x2
+            layout_a, m, packed_k, torch.float4_e2m1fn_x2, device
         )
         b_fp4 = torch.randint(
-            0, 256, (n, packed_k), device="cuda", dtype=torch.uint8
+            0, 256, (n, packed_k), device=device, dtype=torch.uint8
         ).view(torch.float4_e2m1fn_x2)
         b_fp4_t = b_fp4.T
 
@@ -667,8 +662,8 @@ class TestNVUniversalGemm(TestCase):
         scale_a_numel = block_size_mn * ceildiv(m, block_size_mn) * padded_k_blocks
         scale_b_numel = block_size_mn * ceildiv(n, block_size_mn) * padded_k_blocks
 
-        scale_a = torch.rand(scale_a_numel, device="cuda").to(torch.float8_e4m3fn)
-        scale_b = torch.rand(scale_b_numel, device="cuda").to(torch.float8_e4m3fn)
+        scale_a = torch.rand(scale_a_numel, device=device).to(torch.float8_e4m3fn)
+        scale_b = torch.rand(scale_b_numel, device=device).to(torch.float8_e4m3fn)
 
         expected = scaled_mm(a_fp4, b_fp4_t, scale_a, scale_b)
 
@@ -689,14 +684,13 @@ class TestNVUniversalGemm(TestCase):
         "layout_a",
         ("contiguous", "aligned_offset", "view", "padded"),
     )
-    def test_grouped_gemm(self, layout_a):
+    def test_grouped_gemm(self, device, layout_a):
         """Test grouped GEMM with NVGEMM backend and various A layouts.
 
         GroupedGemm currently only supports TN layout (column-major B).
         """
         g, k, n = 4, 256, 256
         dtype = torch.bfloat16
-        device = "cuda"
 
         def grouped_mm(a, b, offsets):
             return torch._grouped_mm(a, b, offs=offsets)
@@ -722,7 +716,7 @@ class TestNVUniversalGemm(TestCase):
 
         torch.testing.assert_close(result, expected)
 
-    def test_grouped_gemm_varying_offsets(self):
+    def test_grouped_gemm_varying_offsets(self, device):
         """Test that different offset distributions produce correct results.
 
         Runs the same compiled function with two different offset distributions
@@ -730,7 +724,6 @@ class TestNVUniversalGemm(TestCase):
         """
         g, k, n = 4, 256, 256
         dtype = torch.bfloat16
-        device = "cuda"
 
         def grouped_mm(a, b, offsets):
             return torch._grouped_mm(a, b, offs=offsets)
@@ -778,7 +771,7 @@ class TestNVUniversalGemmHeuristics(TestCase):
 
     hw_classification = HardwareClassification.CUDA
 
-    def test_grouped_reduction_conversion_contract(self):
+    def test_grouped_reduction_conversion_contract(self, device):
         from torch._inductor.kernel.loop_ir_epilogue_lowering import (
             GemmEpilogueIRExpression as Expr,
             GemmEpilogueIRStore,
@@ -803,7 +796,7 @@ class TestNVUniversalGemmHeuristics(TestCase):
         bitcast = Expr("to_dtype_bitcast", (load, torch.bfloat16, torch.bfloat16))
         self.assertIsNone(classify(Expr("to_dtype", (bitcast, torch.float32))))
 
-    def test_grouped_reduction_ir_normalizes_loop_representation(self):
+    def test_grouped_reduction_ir_normalizes_loop_representation(self, device):
         from torch._inductor.kernel.gemm_epilogue import GemmReductionConfig
         from torch._inductor.kernel.loop_ir_epilogue_lowering import (
             GemmEpilogueIRAnalysis,
@@ -820,7 +813,7 @@ class TestNVUniversalGemmHeuristics(TestCase):
             GemmReductionConfig("out", 4, 1, "sum", "identity"),
         )
 
-    def test_grouped_reduction_rejects_ambiguous_composite(self):
+    def test_grouped_reduction_rejects_ambiguous_composite(self, device):
         from torch._inductor.kernel.loop_ir_epilogue_lowering import (
             GemmEpilogueIRExpression as Expr,
             GemmEpilogueIRStore,
@@ -838,7 +831,7 @@ class TestNVUniversalGemmHeuristics(TestCase):
         store = GemmEpilogueIRStore(0, Expr("add", (summed, maximum)))
         self.assertIsNone(grouped_reduction_ir(store, "gemm", 4, torch.float32))
 
-    def test_epilogue_ir_preserves_empty_tuple_argument(self):
+    def test_epilogue_ir_preserves_empty_tuple_argument(self, device):
         from torch._inductor.kernel.loop_ir_epilogue_lowering import (
             GemmEpilogueIRExpression,
         )
@@ -864,7 +857,7 @@ class TestNVUniversalGemmHeuristics(TestCase):
         inputs.strides_hinted.return_value = ((k, 1), (n, 1))
         return inputs
 
-    def test_fallback_when_heuristics_unavailable(self):
+    def test_fallback_when_heuristics_unavailable(self, device):
         """Test that filter_kernels returns first N kernels when heuristics unavailable."""
         heuristics = NVUniversalGemmHeuristics()
 
@@ -877,7 +870,7 @@ class TestNVUniversalGemmHeuristics(TestCase):
         self.assertEqual(len(result), 3)
         self.assertEqual(result, kernels[:3])
 
-    def test_fallback_when_no_configs_extracted(self):
+    def test_fallback_when_no_configs_extracted(self, device):
         """Test fallback when kernel configs cannot be extracted."""
         heuristics = NVUniversalGemmHeuristics()
 
@@ -895,7 +888,7 @@ class TestNVUniversalGemmHeuristics(TestCase):
         self.assertEqual(len(result), 2)
         self.assertEqual(result, kernels[:2])
 
-    def test_filter_kernels_sorts_by_runtime(self):
+    def test_filter_kernels_sorts_by_runtime(self, device):
         """Test that filter_kernels returns kernels sorted by estimated runtime and respects count."""
         heuristics = NVUniversalGemmHeuristics()
 
@@ -947,7 +940,7 @@ class TestNVUniversalGemmHeuristicsIntegration(TestCase):
 
     hw_classification = HardwareClassification.CUDA
 
-    def test_fp4_heuristic_configs(self):
+    def test_fp4_heuristic_configs(self, device):
         """Test that nvMatmulHeuristics returns configs for FP4 blockscaled GEMM."""
         heuristics = NVUniversalGemmHeuristics()
 
@@ -974,7 +967,7 @@ class TestNVUniversalGemmHeuristicsIntegration(TestCase):
             self.assertGreater(cfg.tile_n, 0)
             self.assertGreater(cfg.estimated_runtime, 0)
 
-    def test_fp8_heuristic_configs(self):
+    def test_fp8_heuristic_configs(self, device):
         """Test that nvMatmulHeuristics returns configs for FP8 GEMM."""
         heuristics = NVUniversalGemmHeuristics()
 
@@ -1012,7 +1005,7 @@ class TestNVUniversalGemmDynamicShapes(TestCase):
     hw_classification = HardwareClassification.CUDA
 
     @torch._dynamo.config.patch({"capture_dynamic_output_shape_ops": True})
-    def test_unbacked_symint_rejected(self):
+    def test_unbacked_symint_rejected(self, device):
         """Test that NVGEMM rejects unbacked symbolic integers."""
 
         def fn(x, w):
@@ -1020,8 +1013,8 @@ class TestNVUniversalGemmDynamicShapes(TestCase):
             a = torch.ones(nz.size(0), w.size(0), dtype=w.dtype, device=w.device)
             return a @ w
 
-        x = torch.tensor([1.0, 0.0, 1.0, 0.0, 1.0], device="cuda")
-        w = torch.randn(64, 64, dtype=torch.bfloat16, device="cuda")
+        x = torch.tensor([1.0, 0.0, 1.0, 0.0, 1.0], device=device)
+        w = torch.randn(64, 64, dtype=torch.bfloat16, device=device)
 
         torch._dynamo.reset()
 
@@ -1032,7 +1025,7 @@ class TestNVUniversalGemmDynamicShapes(TestCase):
             ):
                 compiled_fn(x, w)
 
-    def test_dynamic_shapes(self):
+    def test_dynamic_shapes(self, device):
         """Stress test dynamic shapes with extreme variations."""
 
         def matmul(a, b):
@@ -1055,8 +1048,8 @@ class TestNVUniversalGemmDynamicShapes(TestCase):
             ]
 
             for m, n, k, supported in shapes:
-                a = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
-                b = torch.randn(k, n, dtype=torch.bfloat16, device="cuda")
+                a = torch.randn(m, k, dtype=torch.bfloat16, device=device)
+                b = torch.randn(k, n, dtype=torch.bfloat16, device=device)
                 if not supported:
                     with self.assertRaisesRegex(
                         Exception, "NoValidChoicesError|no valid choice"
@@ -1071,7 +1064,6 @@ class TestNVUniversalGemmDynamicShapes(TestCase):
     not (ensure_nv_universal_gemm_available() and is_datacenter_blackwell_arch()),
     "NVIDIA Universal GEMM (cutlass_api) library not available or not on Blackwell",
 )
-@instantiate_parametrized_tests
 class TestNVUniversalGemmEpilogueFusion(TestCase):
     """Test cases for NVIDIA Universal GEMM epilogue fusion.
 
@@ -1112,10 +1104,10 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         return result, code, epilogue_fused
 
     @parametrize("dtype", (torch.float16, torch.bfloat16))
-    def test_matmul_pointwise_epilogue_fusion(self, dtype):
+    def test_matmul_pointwise_epilogue_fusion(self, device, dtype):
         """Pointwise op (relu) is fused into the GEMM epilogue."""
-        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+        a = torch.randn(self.M, self.K, device=device, dtype=dtype)
+        b = torch.randn(self.K, self.N, device=device, dtype=dtype)
 
         def fn(a, b):
             return torch.relu(a @ b)
@@ -1124,9 +1116,9 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         torch.testing.assert_close(result, fn(a, b), atol=1e-2, rtol=1e-2)
         self.assertTrue(epilogue_fused, "pointwise op was NOT fused into epilogue")
 
-    def test_matmul_multi_store_epilogue_fusion(self):
-        a = torch.randn(self.M, self.K, device="cuda", dtype=torch.bfloat16)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=torch.bfloat16)
+    def test_matmul_multi_store_epilogue_fusion(self, device):
+        a = torch.randn(self.M, self.K, device=device, dtype=torch.bfloat16)
+        b = torch.randn(self.K, self.N, device=device, dtype=torch.bfloat16)
 
         def fn(a, b):
             result = (a @ b).float()
@@ -1137,10 +1129,10 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         self.assertTrue(epilogue_fused)
         self.assertIn("out_ptr1", code)
 
-    def test_flex_gemm_pointwise_epilogue_fusion(self):
+    def test_flex_gemm_pointwise_epilogue_fusion(self, device):
         dtype = torch.bfloat16
-        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+        a = torch.randn(self.M, self.K, device=device, dtype=dtype)
+        b = torch.randn(self.K, self.N, device=device, dtype=dtype)
 
         def fn(a, b):
             return flex_gemm(
@@ -1154,10 +1146,10 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         torch.testing.assert_close(result, torch.relu(a @ b), atol=1e-2, rtol=1e-2)
         self.assertTrue(epilogue_fused, "FlexGEMM body was NOT fused into epilogue")
 
-    def test_flex_gemm_preserves_output_for_unfused_reduction(self):
+    def test_flex_gemm_preserves_output_for_unfused_reduction(self, device):
         dtype = torch.bfloat16
-        a = torch.randn(128, 64, device="cuda", dtype=dtype)
-        b = torch.randn(64, 128, device="cuda", dtype=dtype)
+        a = torch.randn(128, 64, device=device, dtype=dtype)
+        b = torch.randn(64, 128, device=device, dtype=dtype)
 
         def fn(a, b):
             def epilogue(acc):
@@ -1179,22 +1171,22 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         self.assertIn("out_ptr1", code)
 
     @parametrize("operation", ("mul", "sigmoid", "gelu"))
-    def test_scaled_mm_pointwise_epilogue_fusion(self, operation):
+    def test_scaled_mm_pointwise_epilogue_fusion(self, device, operation):
         """Unary pointwise op is fused into an NVFP4 scaled GEMM epilogue."""
         m, n, k = self.M, self.N, self.K
         packed_k = k // 2
         a = _create_tensor_with_layout(
-            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2, device
         )
-        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+        b = torch.randint(0, 256, (n, packed_k), device=device, dtype=torch.uint8).view(
             torch.float4_e2m1fn_x2
         )
         b = b.T
         padded_k_blocks = _round_up(ceildiv(k, 16), 4)
-        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
 
@@ -1220,9 +1212,9 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
             epilogue_fused, f"{operation} was NOT fused into scaled epilogue"
         )
 
-    def test_matmul_single_store_epilogue_chain(self):
-        a = torch.randn(self.M, self.K, device="cuda", dtype=torch.bfloat16)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=torch.bfloat16)
+    def test_matmul_single_store_epilogue_chain(self, device):
+        a = torch.randn(self.M, self.K, device=device, dtype=torch.bfloat16)
+        b = torch.randn(self.K, self.N, device=device, dtype=torch.bfloat16)
 
         def fn(a, b):
             return torch.relu((a @ b).float()) + 1.0
@@ -1232,21 +1224,21 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         self.assertTrue(epilogue_fused)
         self.assertNotIn("out_ptr1", code)
 
-    def test_scaled_mm_multi_store_epilogue_fusion(self):
+    def test_scaled_mm_multi_store_epilogue_fusion(self, device):
         m, n, k = self.M, self.N, self.K
         packed_k = k // 2
         a = _create_tensor_with_layout(
-            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2, device
         )
-        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+        b = torch.randint(0, 256, (n, packed_k), device=device, dtype=torch.uint8).view(
             torch.float4_e2m1fn_x2
         )
         b = b.T
         padded_k_blocks = _round_up(ceildiv(k, 16), 4)
-        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
 
@@ -1284,26 +1276,26 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
             f"{'x'.join(map(str, sh))}_{dtype_name(dt)}" for sh, dt in case[0]
         ),
     )
-    def test_scaled_mm_broadcast_epilogue_fusion(self, case):
+    def test_scaled_mm_broadcast_epilogue_fusion(self, device, case):
         bias_specs, expected_fused = case
         m, n, k = self.M, self.N, self.K
         packed_k = k // 2
         a = _create_tensor_with_layout(
-            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2, device
         )
-        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+        b = torch.randint(0, 256, (n, packed_k), device=device, dtype=torch.uint8).view(
             torch.float4_e2m1fn_x2
         )
         b = b.T
         padded_k_blocks = _round_up(ceildiv(k, 16), 4)
-        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
         biases = tuple(
-            torch.randn(shape, device="cuda", dtype=dtype)
+            torch.randn(shape, device=device, dtype=dtype)
             for shape, dtype in bias_specs
         )
 
@@ -1329,24 +1321,24 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         )
 
     @parametrize("bias_shape", ((1,), (1, 1)))
-    def test_scaled_mm_unit_dim_broadcast_epilogue_fusion(self, bias_shape):
+    def test_scaled_mm_unit_dim_broadcast_epilogue_fusion(self, device, bias_shape):
         m, n, k = 1, 128, self.K
         packed_k = k // 2
         a = _create_tensor_with_layout(
-            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2, device
         )
-        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+        b = torch.randint(0, 256, (n, packed_k), device=device, dtype=torch.uint8).view(
             torch.float4_e2m1fn_x2
         )
         b = b.T
         padded_k_blocks = _round_up(ceildiv(k, 16), 4)
-        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        bias = torch.randn(bias_shape, device="cuda", dtype=torch.bfloat16)
+        bias = torch.randn(bias_shape, device=device, dtype=torch.bfloat16)
 
         def fn(a, b, scale_a, scale_b, bias):
             result = torch._scaled_mm(
@@ -1395,22 +1387,22 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         ),
         name_fn=lambda case: f"axis_{case[0]}_{case[1]}_group_{case[2]}",
     )
-    def test_scaled_mm_grouped_reduce_fusion(self, case):
+    def test_scaled_mm_grouped_reduce_fusion(self, device, case):
         axis, reduction, group = case
         m, n, k = 128, 256 if group > 32 else 128, 512
         packed_k = k // 2
         a = _create_tensor_with_layout(
-            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2, device
         )
-        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+        b = torch.randint(0, 256, (n, packed_k), device=device, dtype=torch.uint8).view(
             torch.float4_e2m1fn_x2
         )
         b = b.T
         padded_k_blocks = _round_up(ceildiv(k, 16), 4)
-        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
 
@@ -1454,21 +1446,21 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
             self.assertNotIn("'local_reduce_out'", strict_code)
             self.assertIn("ReductionOrdering.INNER_TREE", strict_code)
 
-    def test_scaled_mm_grouped_reduce_source_fusion(self):
+    def test_scaled_mm_grouped_reduce_source_fusion(self, device):
         m, n, k, group = 128, 128, 512, 32
         packed_k = k // 2
         a = _create_tensor_with_layout(
-            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2, device
         )
-        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+        b = torch.randint(0, 256, (n, packed_k), device=device, dtype=torch.uint8).view(
             torch.float4_e2m1fn_x2
         )
         b = b.T
         padded_k_blocks = _round_up(ceildiv(k, 16), 4)
-        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
 
@@ -1491,21 +1483,21 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         self.assertIn("'local_reduce_source': 'square'", code)
 
     @config.patch(emulate_precision_casts=True)
-    def test_scaled_mm_grouped_reduce_rejects_intermediate_fp16(self):
+    def test_scaled_mm_grouped_reduce_rejects_intermediate_fp16(self, device):
         m, n, k, group = 128, 128, 512, 32
         packed_k = k // 2
         a = _create_tensor_with_layout(
-            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2, device
         )
-        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+        b = torch.randint(0, 256, (n, packed_k), device=device, dtype=torch.uint8).view(
             torch.float4_e2m1fn_x2
         )
         b = b.T
         padded_k_blocks = _round_up(ceildiv(k, 16), 4)
-        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
 
@@ -1524,21 +1516,21 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         self.assertEqual(result, fn(a, b, scale_a, scale_b))
         self.assertNotIn("'local_reduce_out'", code)
 
-    def test_scaled_mm_grouped_reduce_feeds_main(self):
+    def test_scaled_mm_grouped_reduce_feeds_main(self, device):
         m, n, k, group = 128, 128, 512, 4
         packed_k = k // 2
         a = _create_tensor_with_layout(
-            "contiguous", m, packed_k, torch.float4_e2m1fn_x2
+            "contiguous", m, packed_k, torch.float4_e2m1fn_x2, device
         )
-        b = torch.randint(0, 256, (n, packed_k), device="cuda", dtype=torch.uint8).view(
+        b = torch.randint(0, 256, (n, packed_k), device=device, dtype=torch.uint8).view(
             torch.float4_e2m1fn_x2
         )
         b = b.T
         padded_k_blocks = _round_up(ceildiv(k, 16), 4)
-        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device="cuda").to(
+        scale_a = torch.rand(_round_up(m, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
-        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device="cuda").to(
+        scale_b = torch.rand(_round_up(n, 128) * padded_k_blocks, device=device).to(
             torch.float8_e4m3fn
         )
 
@@ -1558,13 +1550,13 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         self.assertEqual(result, fn(a, b, scale_a, scale_b))
         self.assertIn("'local_reduce_feeds_main': True", code)
 
-    def test_matmul_add_relu_chained(self):
+    def test_matmul_add_relu_chained(self, device):
         """Multi-op pointwise chain (a@b + bias → relu) collapses to one
         ComputedBuffer and is fused as a single epilogue."""
         dtype = torch.bfloat16
-        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
-        bias = torch.randn(self.M, self.N, device="cuda", dtype=dtype)
+        a = torch.randn(self.M, self.K, device=device, dtype=dtype)
+        b = torch.randn(self.K, self.N, device=device, dtype=dtype)
+        bias = torch.randn(self.M, self.N, device=device, dtype=dtype)
 
         def fn(a, b, bias):
             return torch.relu((a @ b) + bias)
@@ -1573,11 +1565,11 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         torch.testing.assert_close(result, fn(a, b, bias), atol=1e-2, rtol=1e-2)
         self.assertTrue(epilogue_fused, "bias+relu chain was NOT fused into epilogue")
 
-    def test_matmul_cast_dtype(self):
+    def test_matmul_cast_dtype(self, device):
         """Output-dtype cast in the epilogue."""
         dtype = torch.bfloat16
-        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+        a = torch.randn(self.M, self.K, device=device, dtype=dtype)
+        b = torch.randn(self.K, self.N, device=device, dtype=dtype)
 
         def fn(a, b):
             return (a @ b).to(torch.float32)
@@ -1586,11 +1578,11 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         torch.testing.assert_close(result, fn(a, b), atol=1e-2, rtol=1e-2)
         self.assertTrue(epilogue_fused, "dtype cast was NOT fused into epilogue")
 
-    def test_plain_matmul_no_epilogue(self):
+    def test_plain_matmul_no_epilogue(self, device):
         """Test that plain matmul does NOT produce epilogue fusion markers."""
         dtype = torch.bfloat16
-        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+        a = torch.randn(self.M, self.K, device=device, dtype=dtype)
+        b = torch.randn(self.K, self.N, device=device, dtype=dtype)
 
         def fn(a, b):
             return a @ b
@@ -1605,11 +1597,11 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         "Disabled due to CI failures; see "
         "https://github.com/pytorch/pytorch/issues/190235"
     )
-    def test_reduction_not_fused(self):
+    def test_reduction_not_fused(self, device):
         """Test that reductions after GEMM are NOT fused into the epilogue."""
         dtype = torch.bfloat16
-        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+        a = torch.randn(self.M, self.K, device=device, dtype=dtype)
+        b = torch.randn(self.K, self.N, device=device, dtype=dtype)
 
         def fn(a, b):
             return (a @ b).sum(dim=-1)
@@ -1624,7 +1616,7 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
             "reduction after GEMM should NOT be fused into NVGEMM epilogue",
         )
 
-    def test_epilogue_fusion_eliminates_intermediate(self):
+    def test_epilogue_fusion_eliminates_intermediate(self, device):
         """Verify that epilogue fusion eliminates the intermediate GEMM buffer.
 
         When relu is fused, the GEMM output should not be allocated separately.
@@ -1632,8 +1624,8 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         only one output buffer is allocated for the fused kernel, not two
         (one for GEMM + one for relu)."""
         dtype = torch.bfloat16
-        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+        a = torch.randn(self.M, self.K, device=device, dtype=dtype)
+        b = torch.randn(self.K, self.N, device=device, dtype=dtype)
 
         def fn(a, b):
             return torch.relu(a @ b)
@@ -1651,12 +1643,12 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
                     lambda msg: f"{msg}\nUnexpected kernel signature: {line.strip()}",
                 )
 
-    def test_epilogue_with_aux_input(self):
+    def test_epilogue_with_aux_input(self, device):
         """Epilogue that reads an auxiliary tensor (bias) gets it as a kernel arg."""
         dtype = torch.bfloat16
-        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
-        bias = torch.randn(self.M, self.N, device="cuda", dtype=dtype)
+        a = torch.randn(self.M, self.K, device=device, dtype=dtype)
+        b = torch.randn(self.K, self.N, device=device, dtype=dtype)
+        bias = torch.randn(self.M, self.N, device=device, dtype=dtype)
 
         def fn(a, b, bias):
             return torch.relu((a @ b) + bias)
@@ -1670,11 +1662,11 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         ((N,), (1, N), (M, 1)),
         name_fn=lambda shape: "x".join(map(str, shape)),
     )
-    def test_epilogue_with_broadcast_aux_input(self, bias_shape):
+    def test_epilogue_with_broadcast_aux_input(self, device, bias_shape):
         dtype = torch.bfloat16
-        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
-        bias = torch.randn(bias_shape, device="cuda", dtype=dtype)
+        a = torch.randn(self.M, self.K, device=device, dtype=dtype)
+        b = torch.randn(self.K, self.N, device=device, dtype=dtype)
+        bias = torch.randn(bias_shape, device=device, dtype=dtype)
 
         def fn(a, b, bias):
             return torch.relu((a @ b) + bias)
@@ -1683,7 +1675,7 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         torch.testing.assert_close(result, fn(a, b, bias), atol=1e-2, rtol=1e-2)
         self.assertTrue(epilogue_fused, "broadcast bias+relu was not fused")
 
-    def test_efc_disk_cache_round_trip(self):
+    def test_efc_disk_cache_round_trip(self, device):
         """Verify that EFC kernel compiled artifacts can be serialized to disk
         and reloaded correctly.
 
@@ -1717,9 +1709,9 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         import cutlass_api
         from cutlass_api.artifact import CompiledArtifact
 
-        a = torch.randn(self.M, self.K, device="cuda", dtype=torch.bfloat16)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=torch.bfloat16)
-        out = torch.empty(self.M, self.N, device="cuda", dtype=torch.bfloat16)
+        a = torch.randn(self.M, self.K, device=device, dtype=torch.bfloat16)
+        b = torch.randn(self.K, self.N, device=device, dtype=torch.bfloat16)
+        out = torch.empty(self.M, self.N, device=device, dtype=torch.bfloat16)
 
         args = cutlass_api.arguments.GemmArguments(
             a, b, out, accumulator_type=torch.float32
@@ -1743,7 +1735,7 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         reloaded_artifact = CompiledArtifact(rewrapped, efc_kernel)
 
         # Run with reloaded artifact and verify correctness
-        out2 = torch.empty(self.M, self.N, device="cuda", dtype=torch.bfloat16)
+        out2 = torch.empty(self.M, self.N, device=device, dtype=torch.bfloat16)
         args2 = cutlass_api.arguments.GemmArguments(
             a, b, out2, accumulator_type=torch.float32
         )
@@ -1762,7 +1754,7 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         "Disabled due to CI failures; see "
         "https://github.com/pytorch/pytorch/issues/190234"
     )
-    def test_workspace_runtime_integration(self):
+    def test_workspace_runtime_integration(self, device):
         """End-to-end: mock the chosen kernel's workspace_size to non-zero and
         actually let benchmark_codegened_module run, exercising the runtime
         path that consumes the generated get_args()/call() helpers.
@@ -1780,8 +1772,8 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
             CUDACombinedScheduling,
         )
 
-        a = torch.randn(self.M, self.K, device="cuda", dtype=torch.bfloat16)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=torch.bfloat16)
+        a = torch.randn(self.M, self.K, device=device, dtype=torch.bfloat16)
+        b = torch.randn(self.K, self.N, device=device, dtype=torch.bfloat16)
 
         def fn(a, b):
             return torch.relu(a @ b)
@@ -1820,6 +1812,23 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
             lambda msg: f"{msg}\nAll NVGEMM benchmarks returned inf — workspace handling likely "
             f"broken. Results: {bench_results}",
         )
+
+
+instantiate_device_type_tests(
+    TestNVUniversalGemm, globals(), only_for=("cuda",)
+)
+instantiate_device_type_tests(
+    TestNVUniversalGemmHeuristics, globals(), only_for=("cuda",)
+)
+instantiate_device_type_tests(
+    TestNVUniversalGemmHeuristicsIntegration, globals(), only_for=("cuda",)
+)
+instantiate_device_type_tests(
+    TestNVUniversalGemmDynamicShapes, globals(), only_for=("cuda",)
+)
+instantiate_device_type_tests(
+    TestNVUniversalGemmEpilogueFusion, globals(), only_for=("cuda",)
+)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -27,6 +27,7 @@ from torch._inductor.utils import (
 )
 from torch.testing._internal.common_utils import (
     dtype_name,
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
 )
@@ -104,6 +105,8 @@ def _nvgemm_config(**overrides):
 @instantiate_parametrized_tests
 class TestNVUniversalGemm(TestCase):
     """Test cases for NVIDIA Universal GEMM functionality."""
+
+    hw_classification = HardwareClassification.CUDA
 
     @parametrize("dtype", (torch.float16, torch.bfloat16))
     @parametrize(
@@ -773,6 +776,8 @@ class TestNVUniversalGemm(TestCase):
 class TestNVUniversalGemmHeuristics(TestCase):
     """Unit tests for NVUniversalGemmHeuristics without requiring actual libraries."""
 
+    hw_classification = HardwareClassification.CUDA
+
     def test_grouped_reduction_conversion_contract(self):
         from torch._inductor.kernel.loop_ir_epilogue_lowering import (
             GemmEpilogueIRExpression as Expr,
@@ -940,6 +945,8 @@ class TestNVUniversalGemmHeuristics(TestCase):
 class TestNVUniversalGemmHeuristicsIntegration(TestCase):
     """Integration tests for nvMatmulHeuristics with real library calls."""
 
+    hw_classification = HardwareClassification.CUDA
+
     def test_fp4_heuristic_configs(self):
         """Test that nvMatmulHeuristics returns configs for FP4 blockscaled GEMM."""
         heuristics = NVUniversalGemmHeuristics()
@@ -1001,6 +1008,8 @@ class TestNVUniversalGemmHeuristicsIntegration(TestCase):
 )
 class TestNVUniversalGemmDynamicShapes(TestCase):
     """Test cases for NVIDIA Universal GEMM with dynamic shapes."""
+
+    hw_classification = HardwareClassification.CUDA
 
     @torch._dynamo.config.patch({"capture_dynamic_output_shape_ops": True})
     def test_unbacked_symint_rejected(self):
@@ -1070,6 +1079,8 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
     generated code for epilogue markers. Benchmarks are mocked to ensure
     deterministic fusion decisions independent of GPU noise.
     """
+
+    hw_classification = HardwareClassification.CUDA
 
     M, N, K = 512, 512, 512
 


### PR DESCRIPTION
## Summary

Adds hw_classification annotations to test classes and aligning test methods with their hardware classification.
Add instantiate_device_type_tests to generalize device types.

## Changes

-Add HardwareClassification to imports from common_utils
-Add instantiate_device_type_tests is used to generate test classes for different devices.
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.


## Test plan

`python test/inductor/test_nv_universal_gemm.py ` 
`python test/inductor/test_nv_universal_gemm.py -v --hw-classification CUDA` 

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo