### PR TITLE
 [fix]: Check GeneratorState device against current accelerator

### DIFF
--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -549,6 +549,28 @@ class TestKernelBenchmark(TestCase):
             f"print_performance(fn, times=times, repeat=repeat, device='{GPU_TYPE}')"
         ).run(src)
 
+    @unittest.skipIf(
+        GPU_TYPE != "cuda", "graph-safe RNG registry is seeded with cuda only"
+    )
+    def test_benchmark_harness_generator_state(self):
+        """The harness must resolve a GeneratorState input by its own device."""
+
+        def gn(x, y):
+            return torch.sigmoid(torch.rand_like(x) * y) * x
+
+        def fn(x, y):
+            x = torch.sin(x)
+            x = torch.utils.checkpoint.checkpoint(gn, x, y, use_reentrant=True)
+            return torch.sin(x)
+
+        x = torch.randn(4, 4, device=GPU_TYPE, requires_grad=True)
+        y = torch.randn(4, 4, device=GPU_TYPE, requires_grad=True)
+        _, codes = run_and_get_code(torch.compile(fn), x, y)
+
+        FileCheck().check(
+            f'torch.{GPU_TYPE}._get_generator(torch.device("{GPU_TYPE}", 0)).graphsafe_get_state()'
+        ).run("\n".join(codes))
+
 
 if __name__ == "__main__":
     if HAS_GPU:

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1250,6 +1250,9 @@ class TestCloneDefaultGeneratorState(TestCase):
     def test_registered_out_of_tree_device_is_admitted(self):
         # An out-of-tree backend that registered graph-safe RNG is admitted and
         # its generator is resolved by the GeneratorState's own device.
+        # A real backend calls rename_privateuse1_backend() and would report
+        # its own name here; the unrenamed type keeps this test from depending
+        # on any installed out-of-tree backend.
         fake_generator = mock.Mock()
         fake_generator.clone_state.return_value = "cloned-state"
         device = torch.device("privateuseone", 0)
@@ -1274,7 +1277,7 @@ class TestCloneDefaultGeneratorState(TestCase):
             {"cuda"},
         ):
             with self.assertRaisesRegex(
-                AssertionError, "not registered for graph-safe RNG"
+                AssertionError, "GraphSafe RNG operations not supported"
             ):
                 inductor_ir._clone_default_generator_state(
                     torch.device("privateuseone", 0)

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -17,7 +17,7 @@ from torch._dynamo.device_interface import DeviceInterface
 from torch._dynamo.exc import TritonUnavailableError
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._dynamo.utils import detect_fake_mode
-from torch._inductor import config as inductor_config
+from torch._inductor import config as inductor_config, ir as inductor_ir
 from torch._inductor.compile_fx import _get_subgraph_names
 from torch._inductor.fx_utils import (
     _is_fake_tensor_same,
@@ -1244,6 +1244,50 @@ class TestHasTriton(TestCase):
         # if the ordering regresses, _GPUTooOldForTriton escapes instead of False.
         iface = _make_triton_interface(capable=False, raise_exc=_GPUTooOldForTriton())
         self.assertFalse(self._run([("fake", iface)]))
+
+
+class TestCloneDefaultGeneratorState(TestCase):
+    def test_registered_out_of_tree_device_is_admitted(self):
+        # An out-of-tree backend that registered graph-safe RNG is admitted and
+        # its generator is resolved by the GeneratorState's own device.
+        fake_generator = mock.Mock()
+        fake_generator.clone_state.return_value = "cloned-state"
+        device = torch.device("privateuseone", 0)
+        with (
+            mock.patch(
+                "torch._functorch._aot_autograd.utils._GRAPHSAFE_RNG_DEVICE_TYPES",
+                {"cuda", "privateuseone"},
+            ),
+            mock.patch(
+                "torch._functorch._aot_autograd.utils.get_default_generator",
+                return_value=fake_generator,
+            ) as get_default_generator,
+        ):
+            result = inductor_ir._clone_default_generator_state(device)
+        self.assertEqual(result, "cloned-state")
+        get_default_generator.assert_called_once_with(device)
+
+    def test_unregistered_device_type_is_rejected(self):
+        # A device type outside the graph-safe RNG registry must fail loudly.
+        with mock.patch(
+            "torch._functorch._aot_autograd.utils._GRAPHSAFE_RNG_DEVICE_TYPES",
+            {"cuda"},
+        ):
+            with self.assertRaisesRegex(
+                AssertionError, "not registered for graph-safe RNG"
+            ):
+                inductor_ir._clone_default_generator_state(
+                    torch.device("privateuseone", 0)
+                )
+
+    def test_missing_device_index_is_rejected(self):
+        # "cuda" is registered by default, but an index-less device must fail.
+        with mock.patch(
+            "torch._functorch._aot_autograd.utils._GRAPHSAFE_RNG_DEVICE_TYPES",
+            {"cuda"},
+        ):
+            with self.assertRaisesRegex(AssertionError, "device index"):
+                inductor_ir._clone_default_generator_state(torch.device("cuda"))
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3335,7 +3335,9 @@ class PythonWrapperCodegen(CodeGen):
                     )
                     add_expr_input(
                         name,
-                        f"torch.cuda.default_generators[{gen_idx}].graphsafe_get_state()",
+                        f"torch.{value.device.type}._get_generator("
+                        f'torch.device("{value.device.type}", {gen_idx})'
+                        ").graphsafe_get_state()",
                     )
                 elif isinstance(value, ir.OpaqueObjectState):
                     output.writeline(f"{name} = None")

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3333,11 +3333,10 @@ class PythonWrapperCodegen(CodeGen):
                         if _coor_enabled()
                         else value.device.index
                     )
+                    dev_type = value.device.type
                     add_expr_input(
                         name,
-                        f"torch.{value.device.type}._get_generator("
-                        f'torch.device("{value.device.type}", {gen_idx})'
-                        ").graphsafe_get_state()",
+                        f'torch.{dev_type}._get_generator(torch.device("{dev_type}", {gen_idx})).graphsafe_get_state()',
                     )
                 elif isinstance(value, ir.OpaqueObjectState):
                     output.writeline(f"{name} = None")

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3232,7 +3232,7 @@ class PythonWrapperCodegen(CodeGen):
                 elif isinstance(value, ir.GeneratorState):
                     add_expr_input(
                         name,
-                        f"torch.cuda.default_generators[{value.device.index}].graphsafe_get_state()",
+                        f"torch._C._accelerator_getDefaultGenerator({value.device.index}).graphsafe_get_state()",
                     )
                 elif isinstance(value, ir.OpaqueObjectState):
                     output.writeline(f"{name} = None")

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7121,13 +7121,16 @@ class ProcessKernelResult:
     unbacked_bindings: dict[sympy.Symbol, pytree.KeyPath] | None
 
 
-def _clone_default_generator_state(device: torch.device) -> Any:
+def _clone_default_generator_state(device: torch.device) -> torch._C.Generator:
     """Clone the default generator state backing a GeneratorState graph input.
 
     Eligibility is gated on the graph-safe RNG registry (populated by
     ``torch._functorch._aot_autograd.utils.register_graphsafe_rng_device_type``)
     and the generator is resolved by the GeneratorState's own device, matching
-    the eager path in torch/_prims/rng_prims.py.
+    the eager path in torch/_prims/rng_prims.py. The device index is required
+    even though ``get_default_generator`` would fall back to the current
+    device, because silently cloning another device's generator is the bug
+    class this gate exists to prevent.
     """
     from torch._functorch._aot_autograd.utils import (
         get_default_generator,
@@ -7136,9 +7139,8 @@ def _clone_default_generator_state(device: torch.device) -> Any:
 
     if not supports_graphsafe_rng(device):
         raise AssertionError(
-            f"Device type '{device.type}' is not registered for graph-safe RNG "
-            "(see torch._functorch._aot_autograd.utils."
-            "register_graphsafe_rng_device_type)"
+            f"GraphSafe RNG operations not supported for device '{device}'. "
+            f"Call register_graphsafe_rng_device_type('{device.type}') to register."
         )
     if device.index is None:
         raise AssertionError(

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7121,6 +7121,32 @@ class ProcessKernelResult:
     unbacked_bindings: dict[sympy.Symbol, pytree.KeyPath] | None
 
 
+def _clone_default_generator_state(device: torch.device) -> Any:
+    """Clone the default generator state backing a GeneratorState graph input.
+
+    Eligibility is gated on the graph-safe RNG registry (populated by
+    ``torch._functorch._aot_autograd.utils.register_graphsafe_rng_device_type``)
+    and the generator is resolved by the GeneratorState's own device, matching
+    the eager path in torch/_prims/rng_prims.py.
+    """
+    from torch._functorch._aot_autograd.utils import (
+        get_default_generator,
+        supports_graphsafe_rng,
+    )
+
+    if not supports_graphsafe_rng(device):
+        raise AssertionError(
+            f"Device type '{device.type}' is not registered for graph-safe RNG "
+            "(see torch._functorch._aot_autograd.utils."
+            "register_graphsafe_rng_device_type)"
+        )
+    if device.index is None:
+        raise AssertionError(
+            f"Expected a GeneratorState device with a device index, got {device}"
+        )
+    return get_default_generator(device).clone_state()
+
+
 @ir_dataclass(frozen=False)
 class ExternKernel(InputsKernel):
     """
@@ -7385,22 +7411,8 @@ class ExternKernel(InputsKernel):
                 case GeneratorState():
                     args_flat_is_tensor.append(False)
                     non_tensor_args.append(arg)
-                    device_index = arg.device.index
-                    accelerator = torch.accelerator.current_accelerator()
-                    if not (
-                        accelerator is not None
-                        and arg.device.type == accelerator.type
-                        and device_index is not None
-                    ):
-                        raise AssertionError(
-                            "Expected arg.device to be on the current accelerator "
-                            "and arg.device.index is not None, got "
-                            f"{arg.device} (current accelerator: {accelerator})"
-                        )
                     real_non_tensor_args.append(
-                        torch._C._accelerator_getDefaultGenerator(
-                            device_index
-                        ).clone_state()
+                        _clone_default_generator_state(arg.device)
                     )
 
                 case OpaqueObjectState():
@@ -7479,23 +7491,7 @@ class ExternKernel(InputsKernel):
             elif isinstance(x, OpaqueMultiOutput):
                 example_args.append(x.opaque_example_value)
             elif isinstance(x, torch._inductor.ir.GeneratorState):
-                device_index = x.device.index
-                accelerator = torch.accelerator.current_accelerator()
-                if not (
-                    accelerator is not None
-                    and x.device.type == accelerator.type
-                    and device_index is not None
-                ):
-                    raise AssertionError(
-                        "Expected x.device to be on the current accelerator "
-                        "and x.device.index is not None, got "
-                        f"{x.device} (current accelerator: {accelerator})"
-                    )
-                example_args.append(
-                    torch._C._accelerator_getDefaultGenerator(
-                        device_index
-                    ).clone_state()
-                )
+                example_args.append(_clone_default_generator_state(x.device))
             else:
                 example_args.append(ir_node_to_tensor(x))
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7386,11 +7386,16 @@ class ExternKernel(InputsKernel):
                     args_flat_is_tensor.append(False)
                     non_tensor_args.append(arg)
                     device_index = arg.device.index
+                    accelerator = torch.accelerator.current_accelerator()
                     if not (
-                        arg.device.type in ["cuda", "xpu"] and device_index is not None
+                        accelerator is not None
+                        and arg.device.type == accelerator.type
+                        and device_index is not None
                     ):
                         raise AssertionError(
-                            'Expected arg.device.type in ["cuda", "xpu"] and device_index is not None'
+                            "Expected arg.device to be on the current accelerator "
+                            "and arg.device.index is not None, got "
+                            f"{arg.device} (current accelerator: {accelerator})"
                         )
                     real_non_tensor_args.append(
                         torch._C._accelerator_getDefaultGenerator(
@@ -7475,9 +7480,16 @@ class ExternKernel(InputsKernel):
                 example_args.append(x.opaque_example_value)
             elif isinstance(x, torch._inductor.ir.GeneratorState):
                 device_index = x.device.index
-                if not (x.device.type in ["cuda", "xpu"] and device_index is not None):
+                accelerator = torch.accelerator.current_accelerator()
+                if not (
+                    accelerator is not None
+                    and x.device.type == accelerator.type
+                    and device_index is not None
+                ):
                     raise AssertionError(
-                        'Expected x.device.type in ["cuda", "xpu"] and device_index is not None'
+                        "Expected x.device to be on the current accelerator "
+                        "and x.device.index is not None, got "
+                        f"{x.device} (current accelerator: {accelerator})"
                     )
                 example_args.append(
                     torch._C._accelerator_getDefaultGenerator(

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7277,11 +7277,16 @@ class ExternKernel(InputsKernel):
                     args_flat_is_tensor.append(False)
                     non_tensor_args.append(arg)
                     device_index = arg.device.index
+                    accelerator = torch.accelerator.current_accelerator()
                     if not (
-                        arg.device.type in ["cuda", "xpu"] and device_index is not None
+                        accelerator is not None
+                        and arg.device.type == accelerator.type
+                        and device_index is not None
                     ):
                         raise AssertionError(
-                            'Expected arg.device.type in ["cuda", "xpu"] and device_index is not None'
+                            "Expected arg.device to be on the current accelerator "
+                            "and arg.device.index is not None, got "
+                            f"{arg.device} (current accelerator: {accelerator})"
                         )
                     real_non_tensor_args.append(
                         torch._C._accelerator_getDefaultGenerator(
@@ -7366,9 +7371,16 @@ class ExternKernel(InputsKernel):
                 example_args.append(x.opaque_example_value)
             elif isinstance(x, torch._inductor.ir.GeneratorState):
                 device_index = x.device.index
-                if not (x.device.type in ["cuda", "xpu"] and device_index is not None):
+                accelerator = torch.accelerator.current_accelerator()
+                if not (
+                    accelerator is not None
+                    and x.device.type == accelerator.type
+                    and device_index is not None
+                ):
                     raise AssertionError(
-                        'Expected x.device.type in ["cuda", "xpu"] and device_index is not None'
+                        "Expected x.device to be on the current accelerator "
+                        "and x.device.index is not None, got "
+                        f"{x.device} (current accelerator: {accelerator})"
                     )
                 example_args.append(
                     torch._C._accelerator_getDefaultGenerator(


### PR DESCRIPTION
## Summary
Gate the two GeneratorState sites in inductor on `supports_graphsafe_rng()` —
the registry `register_graphsafe_rng_device_type()` writes to — and resolve
the generator by the GeneratorState's own device via
`get_default_generator()`, matching the eager path.

## Changes
- New module-level helper `_clone_default_generator_state(device)` in ir.py:
  gates on the graph-safe RNG registry and the device index (with distinct
  error messages for the two failure modes), then fetches via
  `get_default_generator(device).clone_state()`. Both `process_kernel` sites
  collapse to one call each.
- The generated benchmark harness emits device-based resolution
  (`torch.{type}._get_generator(...)`) instead of a private `torch._C._*`
  symbol, preserving the coordinate-descent `gen_idx` logic from main.
- Unit tests (`TestCloneDefaultGeneratorState`): a registered out-of-tree
  device is admitted and its generator is resolved by the GeneratorState's
  own device (pinned via mock); unregistered device type and missing device
  index are rejected with their respective messages. No GPU required.

## Motivation
The hardcoded `["cuda", "xpu"]` list disagreed both with the fetch logic
(which resolves against the current accelerator, ignoring the list) and with
every other consumer of graph-safe RNG — partitioners and rng_prims all gate
on `supports_graphsafe_rng`. Consulting the registry admits registered
out-of-tree backends (the exact trigger path is
`register_graphsafe_rng_device_type()`), rejects accelerators that never
registered, fixes the listed-but-mismatched-device case (previously the
wrong backend's generator was fetched silently), and is immune to
PrivateUse1 shadowing (e.g. a CUDA machine that imported torch_openreg).

## Test Plan
- CI: `python test/inductor/test_utils.py TestCloneDefaultGeneratorState`
- Existing CUDA graph-safe RNG suites (test_cudagraph_trees, aotdispatch RNG
  tests) are unchanged: on CUDA the helper resolves to the same per-device
  default generator object as before.

## Notes
- Follow-ups: a torch_openreg end-to-end test for the newly admitted path;
  the `register_graphsafe_rng_device_type` docstring omits the
  `default_generators` module attribute that the eager dispatch also
  requires of backends.
- Authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo