### PR TITLE
Fix UnboundLocalError in find_free_port when socket creation fails

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -8,10 +8,11 @@
 import os
 import sys
 import unittest
+from unittest.mock import MagicMock, patch
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
 if os.getenv("CIRCLECI"):
@@ -58,3 +59,45 @@ class EtcdServerTest(unittest.TestCase):
             self.assertEqual(1, rdzv_info.world_size)
         finally:
             server.stop()
+
+
+class FindFreePortTest(unittest.TestCase):
+    @patch("torch.distributed.elastic.rendezvous.etcd_server.socket.getaddrinfo")
+    @patch("torch.distributed.elastic.rendezvous.etcd_server.socket.socket")
+    def test_all_sockets_fail_no_unbound_local_error(
+        self, mock_socket, mock_getaddrinfo
+    ):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+            (10, 1, 6, "", ("::1", 0)),
+        ]
+        mock_socket.side_effect = OSError("socket failed")
+        with self.assertRaises(RuntimeError):
+            find_free_port()
+
+    @patch("torch.distributed.elastic.rendezvous.etcd_server.socket.getaddrinfo")
+    @patch("torch.distributed.elastic.rendezvous.etcd_server.socket.socket")
+    def test_first_fails_second_succeeds(self, mock_socket, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+        ]
+        mock_sock = MagicMock()
+        mock_socket.side_effect = [OSError("socket failed"), mock_sock]
+        result = find_free_port()
+        self.assertEqual(result, mock_sock)
+        mock_sock.bind.assert_called_once_with(("localhost", 0))
+        mock_sock.listen.assert_called_once_with(0)
+
+    @patch("torch.distributed.elastic.rendezvous.etcd_server.socket.getaddrinfo")
+    @patch("torch.distributed.elastic.rendezvous.etcd_server.socket.socket")
+    def test_all_fail_raises_runtime_error_not_unbound_local(
+        self, mock_socket, mock_getaddrinfo
+    ):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+        ]
+        mock_socket.side_effect = OSError("address family not supported")
+        with self.assertRaises(RuntimeError) as ctx:
+            find_free_port()
+        self.assertIn("Failed to create a socket", str(ctx.exception))

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,15 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
## Description
When `socket.socket()` raises `OSError` on the first address in `find_free_port()`, the variable `s` is never assigned. The `except` block unconditionally calls `s.close()`, which raises `UnboundLocalError` instead of the real socket error.

## Fix
- Initialize `s = None` before the `try` block
- Guard `s.close()` with `if s is not None:` so only successfully created sockets are closed on failure
- Remove the `# type: ignore[possibly-undefined]` comment since mypy will no longer flag this

## Changes
- `torch/distributed/elastic/rendezvous/etcd_server.py`: 3 lines changed in `find_free_port()`
- `test/distributed/elastic/rendezvous/etcd_server_test.py`: Added `FindFreePortTest` class with 3 unit tests

## Test Coverage
- `test_all_sockets_fail_no_unbound_local_error`: All socket constructors raise → should get `RuntimeError`, not `UnboundLocalError`
- `test_first_fails_second_succeeds`: First address fails, second succeeds → returns second socket
- `test_all_fail_raises_runtime_error_not_unbound_local`: Single address fails → correct `RuntimeError` message

## Impact
Purely defensive fix. No behavior change on the success path. Error path now surfaces the original `OSError` diagnostics instead of masking them with `UnboundLocalError`.

Fixes #191395