### PR TITLE
[inductor] Gate cudagraph eligibility via DeviceInterface capability

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -46,6 +46,8 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
 )
 from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
     run_tests,
     TestCase,
     xfailIfNoAcceleratorTriton,
@@ -1249,55 +1251,84 @@ class TestHasTriton(TestCase):
         # if the ordering regresses, _GPUTooOldForTriton escapes instead of False.
         iface = _make_triton_interface(capable=False, raise_exc=_GPUTooOldForTriton())
         self.assertFalse(self._run([("fake", iface)]))
-class _FakeDevice:
-    """Duck-typed stand-in for torch.device: the cudagraph eligibility gate
-    only reads ``.type`` on the mapping keys, and out-of-tree device types
-    cannot be constructed via torch.device() without renaming the PrivateUse1
-    backend."""
-
-    def __init__(self, device_type: str) -> None:
-        self.type = device_type
 
 
-class _AccInterface(DeviceInterface):
+class _CapturableInterface(DeviceInterface):
     """Fake out-of-tree accelerator interface that opts into graph capture."""
 
     @classmethod
-    def is_graph_capture_supported(cls) -> bool:
+    def is_graph_capture_supported(cls, device: torch.types.Device = None) -> bool:
         return True
 
 
+@instantiate_parametrized_tests
 class TestCheckMultipleDevicesOrAnyCpuNodes(TestCase):
+    def setUp(self):
+        super().setUp()
+        # Force lazy registry initialization before any mock.patch.dict on
+        # device_interfaces: patch.dict restores the dict but not the module
+        # flag init_device_reg sets, so initializing inside a patched dict
+        # would leave the registry permanently empty for later tests.
+        device_interface.get_interface_for_device("cpu")
+
     def test_single_cuda_device_is_eligible(self):
         # No CUDA runtime needed: the gate only consults the capability bit.
         mapping = {torch.device("cuda"): None}
         self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
 
-    def test_single_device_without_capability_is_skipped(self):
+    @parametrize("device_type", ("xpu", "mps"))
+    def test_single_device_without_capability_is_skipped(self, device_type):
         # Registered in-tree interfaces inherit the safe default (False).
-        for device_type in ("xpu", "mps"):
-            mapping = {torch.device(device_type): None}
-            msg = check_multiple_devices_or_any_cpu_nodes(mapping)
-            self.assertIsNotNone(msg)
-            self.assertIn("multiple devices", msg)
-
-    def test_out_of_tree_backend_with_capability_is_eligible(self):
-        register_interface_for_device("acc", _AccInterface)
-        try:
-            mapping = {_FakeDevice("acc"): None}
-            self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
-        finally:
-            # There is no unregister API; drop the throwaway entry directly.
-            device_interface.device_interfaces.pop("acc", None)
-
-    def test_unregistered_device_is_skipped_without_raising(self):
-        # "acc" is not registered here: get_interface_for_device raises
-        # NotImplementedError internally, which the gate must swallow and
-        # turn into the same skip message as before.
-        mapping = {_FakeDevice("acc"): None}
+        mapping = {torch.device(device_type): None}
         msg = check_multiple_devices_or_any_cpu_nodes(mapping)
         self.assertIsNotNone(msg)
-        self.assertIn("multiple devices", msg)
+        self.assertIn(f"device type '{device_type}' does not support", msg)
+
+    def test_out_of_tree_backend_with_capability_is_eligible(self):
+        with mock.patch.dict(device_interface.device_interfaces):
+            register_interface_for_device("privateuseone", _CapturableInterface)
+            mapping = {torch.device("privateuseone", 0): None}
+            self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
+
+    def test_unregistered_device_is_skipped_without_raising(self):
+        # An unregistered device type must produce a skip message, not leak
+        # the NotImplementedError from get_interface_for_device.
+        with mock.patch.dict(device_interface.device_interfaces):
+            device_interface.device_interfaces.pop("privateuseone", None)
+            mapping = {torch.device("privateuseone", 0): None}
+            msg = check_multiple_devices_or_any_cpu_nodes(mapping)
+        self.assertIsNotNone(msg)
+        self.assertIn("does not support graph capture", msg)
+
+    def test_cudagraphs_backend_skips_capable_non_cuda_device(self):
+        # A backend that declares the capability must get a graceful skip from
+        # the dynamo cudagraphs backend, not an AssertionError: its capture
+        # path is still CUDA-specific.
+        from torch._dynamo.backends import cudagraphs as cudagraphs_backend
+
+        device = torch.device("privateuseone", 0)
+        with (
+            mock.patch.dict(device_interface.device_interfaces),
+            mock.patch.object(
+                cudagraphs_backend,
+                "get_device_node_mapping",
+                return_value={device: None},
+            ),
+            mock.patch.object(
+                cudagraphs_backend,
+                "check_for_mutation_ignore_cuda_graph_managed_tensor",
+                return_value=None,
+            ),
+            mock.patch.object(
+                cudagraphs_backend,
+                "get_first_incompatible_cudagraph_node",
+                return_value=None,
+            ),
+        ):
+            register_interface_for_device("privateuseone", _CapturableInterface)
+            skip = cudagraphs_backend.check_for_skip(mock.Mock(), 0)
+            self.assertIsNotNone(skip)
+            self.assertIn("not supported by the cudagraphs backend", skip)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -13,9 +13,15 @@ from unittest import mock
 from sympy import I, Max, Min, Symbol, sympify
 
 import torch
+from torch._dynamo import device_interface
+from torch._dynamo.device_interface import (
+    DeviceInterface,
+    register_interface_for_device,
+)
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._dynamo.utils import detect_fake_mode
 from torch._inductor.compile_fx import _get_subgraph_names
+from torch._inductor.cudagraph_utils import check_multiple_devices_or_any_cpu_nodes
 from torch._inductor.fx_utils import (
     _is_fake_tensor_same,
     count_flops_fx,
@@ -1144,6 +1150,57 @@ class TestFakeTensorUpdater(TestCase):
 
         self.assertEqual(tuple(neg_replacement.meta["val"].shape), (4, 5))
         self.assertEqual(tuple(lowered.meta["val"].shape), (2, 3))
+
+
+class _FakeDevice:
+    """Duck-typed stand-in for torch.device: the cudagraph eligibility gate
+    only reads ``.type`` on the mapping keys, and out-of-tree device types
+    cannot be constructed via torch.device() without renaming the PrivateUse1
+    backend."""
+
+    def __init__(self, device_type: str) -> None:
+        self.type = device_type
+
+
+class _AccInterface(DeviceInterface):
+    """Fake out-of-tree accelerator interface that opts into graph capture."""
+
+    @classmethod
+    def is_graph_capture_supported(cls) -> bool:
+        return True
+
+
+class TestCheckMultipleDevicesOrAnyCpuNodes(TestCase):
+    def test_single_cuda_device_is_eligible(self):
+        # No CUDA runtime needed: the gate only consults the capability bit.
+        mapping = {torch.device("cuda"): None}
+        self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
+
+    def test_single_device_without_capability_is_skipped(self):
+        # Registered in-tree interfaces inherit the safe default (False).
+        for device_type in ("xpu", "mps"):
+            mapping = {torch.device(device_type): None}
+            msg = check_multiple_devices_or_any_cpu_nodes(mapping)
+            self.assertIsNotNone(msg)
+            self.assertIn("multiple devices", msg)
+
+    def test_out_of_tree_backend_with_capability_is_eligible(self):
+        register_interface_for_device("acc", _AccInterface)
+        try:
+            mapping = {_FakeDevice("acc"): None}
+            self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
+        finally:
+            # There is no unregister API; drop the throwaway entry directly.
+            device_interface.device_interfaces.pop("acc", None)
+
+    def test_unregistered_device_is_skipped_without_raising(self):
+        # "acc" is not registered here: get_interface_for_device raises
+        # NotImplementedError internally, which the gate must swallow and
+        # turn into the same skip message as before.
+        mapping = {_FakeDevice("acc"): None}
+        msg = check_multiple_devices_or_any_cpu_nodes(mapping)
+        self.assertIsNotNone(msg)
+        self.assertIn("multiple devices", msg)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -13,12 +13,17 @@ from unittest import mock
 from sympy import I, Max, Min, Symbol, sympify
 
 import torch
-from torch._dynamo.device_interface import DeviceInterface
+from torch._dynamo import device_interface
+from torch._dynamo.device_interface import (
+    DeviceInterface,
+    register_interface_for_device,
+)
 from torch._dynamo.exc import TritonUnavailableError
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._dynamo.utils import detect_fake_mode
 from torch._inductor import config as inductor_config
 from torch._inductor.compile_fx import _get_subgraph_names
+from torch._inductor.cudagraph_utils import check_multiple_devices_or_any_cpu_nodes
 from torch._inductor.fx_utils import (
     _is_fake_tensor_same,
     count_flops_fx,
@@ -1244,6 +1249,55 @@ class TestHasTriton(TestCase):
         # if the ordering regresses, _GPUTooOldForTriton escapes instead of False.
         iface = _make_triton_interface(capable=False, raise_exc=_GPUTooOldForTriton())
         self.assertFalse(self._run([("fake", iface)]))
+class _FakeDevice:
+    """Duck-typed stand-in for torch.device: the cudagraph eligibility gate
+    only reads ``.type`` on the mapping keys, and out-of-tree device types
+    cannot be constructed via torch.device() without renaming the PrivateUse1
+    backend."""
+
+    def __init__(self, device_type: str) -> None:
+        self.type = device_type
+
+
+class _AccInterface(DeviceInterface):
+    """Fake out-of-tree accelerator interface that opts into graph capture."""
+
+    @classmethod
+    def is_graph_capture_supported(cls) -> bool:
+        return True
+
+
+class TestCheckMultipleDevicesOrAnyCpuNodes(TestCase):
+    def test_single_cuda_device_is_eligible(self):
+        # No CUDA runtime needed: the gate only consults the capability bit.
+        mapping = {torch.device("cuda"): None}
+        self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
+
+    def test_single_device_without_capability_is_skipped(self):
+        # Registered in-tree interfaces inherit the safe default (False).
+        for device_type in ("xpu", "mps"):
+            mapping = {torch.device(device_type): None}
+            msg = check_multiple_devices_or_any_cpu_nodes(mapping)
+            self.assertIsNotNone(msg)
+            self.assertIn("multiple devices", msg)
+
+    def test_out_of_tree_backend_with_capability_is_eligible(self):
+        register_interface_for_device("acc", _AccInterface)
+        try:
+            mapping = {_FakeDevice("acc"): None}
+            self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
+        finally:
+            # There is no unregister API; drop the throwaway entry directly.
+            device_interface.device_interfaces.pop("acc", None)
+
+    def test_unregistered_device_is_skipped_without_raising(self):
+        # "acc" is not registered here: get_interface_for_device raises
+        # NotImplementedError internally, which the gate must swallow and
+        # turn into the same skip message as before.
+        mapping = {_FakeDevice("acc"): None}
+        msg = check_multiple_devices_or_any_cpu_nodes(mapping)
+        self.assertIsNotNone(msg)
+        self.assertIn("multiple devices", msg)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -46,6 +46,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -1263,6 +1264,8 @@ class _CapturableInterface(DeviceInterface):
 
 @instantiate_parametrized_tests
 class TestCheckMultipleDevicesOrAnyCpuNodes(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # Force lazy registry initialization before any mock.patch.dict on

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -123,10 +123,18 @@ def check_for_skip(aot_model: torch.fx.GraphModule, num_fixed: int) -> str | Non
         ):
             return mut_skip
 
-    if skip := check_multiple_devices_or_any_cpu_nodes(
-        get_device_node_mapping(aot_model)
-    ):
+    device_node_mapping = get_device_node_mapping(aot_model)
+    if skip := check_multiple_devices_or_any_cpu_nodes(device_node_mapping):
         return skip
+
+    device = next(iter(device_node_mapping))
+    if device.type != "cuda":
+        # The capability bit admits any backend that supports graph capture,
+        # but this backend's capture path is still CUDA-specific: skip
+        # gracefully instead of crashing in get_device_index below.
+        return format_default_skip_message(
+            f"device type '{device.type}' not supported by the cudagraphs backend"
+        )
 
     if node := get_first_incompatible_cudagraph_node(aot_model):
         return format_default_skip_message(f"incompatible op ({node.name})")
@@ -135,9 +143,15 @@ def check_for_skip(aot_model: torch.fx.GraphModule, num_fixed: int) -> str | Non
 
 
 def get_device_index(gm: torch.fx.GraphModule) -> int:
-    device = next(iter(get_device_node_mapping(gm)))
-    if device.type != "cuda":
-        raise AssertionError(f"Expected CUDA device, got {device.type}")
+    # check_for_skip only lets single-cuda-device graphs through; pick the
+    # cuda entry rather than iteration order (the mapping may also contain
+    # meta devices, which the eligibility gate filters out on its own copy).
+    device = next((d for d in get_device_node_mapping(gm) if d.type == "cuda"), None)
+    if device is None:
+        raise AssertionError(
+            "get_device_index expects a graph admitted by check_for_skip "
+            "(single cuda device)"
+        )
     return device.index
 
 

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -178,6 +178,17 @@ class DeviceInterface:
                 "This device is not capable of supporting Triton"
             )
 
+    @classmethod
+    def is_graph_capture_supported(cls) -> bool:
+        """
+        Returns True if the device supports CUDA-graph-style graph capture.
+        This capability bit gates the cudagraph eligibility checks in Inductor
+        and the standalone dynamo "cudagraphs" backend. Defaults to False so
+        that backends which have not been adapted for graph capture are safely
+        skipped.
+        """
+        return False
+
 
 class DeviceGuard:
     """
@@ -304,6 +315,12 @@ class CudaInterface(DeviceInterface):
                 raise TritonUnavailableError("triton not built with the 'amd' backend")
         elif "nvidia" not in triton.backends.backends:
             raise TritonUnavailableError("triton not built with the 'nvidia' backend")
+
+    @classmethod
+    def is_graph_capture_supported(cls) -> bool:
+        # CUDA implements graph capture through its own torch.cuda.CUDAGraph
+        # path, so the capability is declared unconditionally here.
+        return True
 
 
 get_mtia_stream: Callable[[int], int] | None

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -170,6 +170,17 @@ class DeviceInterface:
         if not cls.is_triton_capable():
             raise RuntimeError("This device is not capable of supporting Triton")
 
+    @classmethod
+    def is_graph_capture_supported(cls) -> bool:
+        """
+        Returns True if the device supports CUDA-graph-style graph capture.
+        This capability bit gates the cudagraph eligibility checks in Inductor
+        and the standalone dynamo "cudagraphs" backend. Defaults to False so
+        that backends which have not been adapted for graph capture are safely
+        skipped.
+        """
+        return False
+
 
 class DeviceGuard:
     """
@@ -291,6 +302,12 @@ class CudaInterface(DeviceInterface):
                 raise RuntimeError("triton not built with the 'amd' backend")
         elif "nvidia" not in triton.backends.backends:
             raise RuntimeError("triton not built with the 'nvidia' backend")
+
+    @classmethod
+    def is_graph_capture_supported(cls) -> bool:
+        # CUDA implements graph capture through its own torch.cuda.CUDAGraph
+        # path, so the capability is declared unconditionally here.
+        return True
 
 
 get_mtia_stream: Callable[[int], int] | None

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -179,13 +179,17 @@ class DeviceInterface:
             )
 
     @classmethod
-    def is_graph_capture_supported(cls) -> bool:
+    def is_graph_capture_supported(cls, device: torch.types.Device = None) -> bool:
         """
         Returns True if the device supports CUDA-graph-style graph capture.
+
         This capability bit gates the cudagraph eligibility checks in Inductor
-        and the standalone dynamo "cudagraphs" backend. Defaults to False so
-        that backends which have not been adapted for graph capture are safely
-        skipped.
+        and the standalone dynamo "cudagraphs" backend. It is necessary but
+        not sufficient: the capture path itself must also support the device
+        (today the in-tree capture code is still CUDA-specific, so declaring
+        True only makes a backend eligible, it does not make capture work).
+        Defaults to False so that backends which have not been adapted for
+        graph capture are safely skipped.
         """
         return False
 
@@ -317,7 +321,7 @@ class CudaInterface(DeviceInterface):
             raise TritonUnavailableError("triton not built with the 'nvidia' backend")
 
     @classmethod
-    def is_graph_capture_supported(cls) -> bool:
+    def is_graph_capture_supported(cls, device: torch.types.Device = None) -> bool:
         # CUDA implements graph capture through its own torch.cuda.CUDAGraph
         # path, so the capability is declared unconditionally here.
         return True

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -360,15 +360,19 @@ def check_multiple_devices_or_any_cpu_nodes(
         return format_default_skip_message(msg)
 
     if len(device_node_mapping) == 1:
-        device = next(iter(device_node_mapping.keys()))
+        device_type = next(iter(device_node_mapping.keys())).type
         try:
-            interface = get_interface_for_device(device.type)
+            if get_interface_for_device(device_type).is_graph_capture_supported(
+                device_type
+            ):
+                return None
         except NotImplementedError:
-            # Devices without a registered DeviceInterface fall through to the
-            # skip message below, matching the previous hardcoded behavior.
-            interface = None
-        if interface is not None and interface.is_graph_capture_supported():
-            return None
+            # Devices without a registered DeviceInterface get the same skip
+            # message as registered ones without the capability.
+            pass
+        return format_default_skip_message(
+            f"device type '{device_type}' does not support graph capture"
+        )
 
     keys_repr = (repr(key) for key in device_node_mapping)
     return format_default_skip_message(f"multiple devices: {', '.join(keys_repr)}")

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any, Literal, TYPE_CHECKING, TypeVar
 
 import torch
+from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import counters, get_metrics_context
 from torch._inductor.utils import GraphPartitionMap, InputType
 from torch._subclasses.fake_tensor import get_plain_tensors, is_fake
@@ -358,11 +359,16 @@ def check_multiple_devices_or_any_cpu_nodes(
 
         return format_default_skip_message(msg)
 
-    if (
-        len(device_node_mapping) == 1
-        and next(iter(device_node_mapping.keys())).type == "cuda"
-    ):
-        return None
+    if len(device_node_mapping) == 1:
+        device = next(iter(device_node_mapping.keys()))
+        try:
+            interface = get_interface_for_device(device.type)
+        except NotImplementedError:
+            # Devices without a registered DeviceInterface fall through to the
+            # skip message below, matching the previous hardcoded behavior.
+            interface = None
+        if interface is not None and interface.is_graph_capture_supported():
+            return None
 
     keys_repr = (repr(key) for key in device_node_mapping)
     return format_default_skip_message(f"multiple devices: {', '.join(keys_repr)}")


### PR DESCRIPTION
## Summary
Add an `is_graph_capture_supported()` capability bit to `DeviceInterface`
(default False; CUDA declares True) and make the cudagraph single-device
eligibility gate query it instead of comparing `device.type == "cuda"`, so
accelerator backends that implement graph capture can become eligible. The
standalone dynamo "cudagraphs" backend skips gracefully for any non-CUDA
device that opts in.

## Changes
- `DeviceInterface`: new `is_graph_capture_supported(device: torch.types.Device
  = None)` classmethod (signature aligned with `is_triton_capable`), default
  `False`. The docstring states the bit is necessary but not sufficient: the
  capture path itself must also support the device.
- `CudaInterface`: override returning `True` — CUDA implements capture
  through its own `torch.cuda.CUDAGraph` path.
- `check_multiple_devices_or_any_cpu_nodes`: the single-device check queries
  the device's interface capability (passing the device type through).
  A single device without the capability — including device types with no
  registered interface — now gets its own skip message
  (`device type 'xpu' does not support graph capture`); "multiple devices"
  is only emitted when there is more than one device.
- dynamo "cudagraphs" backend: `check_for_skip` reuses the gate-filtered
  device mapping and returns a graceful skip for non-CUDA devices (this
  backend's capture path is CUDA-specific), so an opting-in backend can no
  longer reach the former `get_device_index` assertion; `get_device_index`
  picks the cuda entry explicitly, which also fixes a latent meta-device
  iteration-order hazard.

## Motivation
The eligibility gate hardcodes the `"cuda"` literal, so an out-of-tree
accelerator (e.g. an NPU integrated via PrivateUse1) that implements graph
capture can never pass it; the only workaround today is monkeypatching
Inductor internals at import time. Routing the check through the existing
`DeviceInterface` contract lets a backend opt in from its own interface,
while the safe default keeps every unadapted backend skipped exactly as
before.

## Test Plan
- CI: `python test/inductor/test_utils.py TestCheckMultipleDevicesOrAnyCpuNodes`
  — single cuda device admitted; xpu/mps skipped with the new message
  (`@parametrize`); a registered `privateuseone` interface declaring the
  capability is admitted (registry patched via `mock.patch.dict`, with a
  setUp forcing lazy registry initialization first); unregistered device
  types skip without leaking `NotImplementedError`; an opting-in non-CUDA
  interface gets the graceful backend skip instead of an assertion.
- CI: `python test/inductor/test_cudagraph_trees.py` — existing tests pin
  only the multi-device "multiple devices" message, which is unchanged.

## Notes
- Behavior note: skip-reason strings feeding `cudagraph_skip_reason` metrics
  gain new values for the single-device-without-capability cases.
- Companion PR #191906 makes the Inductor capture path itself
  device-agnostic; the two are independent and mergeable in any order (until
  a backend both declares the bit and has a device-agnostic capture path,
  nothing changes for it). A follow-up push here will add the
  registry-derived source for the bit
  (`torch._C._accelerator_hasGraphImpl` + the XPU override), moved from
  #191906 per its review so the binding lands next to its consumer.
- Part of enabling `torch.compile` graph capture for out-of-tree
  (PrivateUse1/NPU) accelerator backends.
- Authored with the assistance of an AI coding assistant.