### PR TITLE
[TEST] Add `hw_classification` to `test_dtensor_dispatch_overhead.py`

### DIFF
--- a/test/distributed/tensor/test_dtensor_dispatch_overhead.py
+++ b/test/distributed/tensor/test_dtensor_dispatch_overhead.py
@@ -11,7 +11,7 @@ import torch
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Shard
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -62,6 +62,8 @@ class TimeCaptureMode(TorchDispatchMode):
 
 
 class DistOpDispatchOverHead(DTensorTestBase):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def world_size(self) -> int:
         return 4


### PR DESCRIPTION
## Summary

Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.CUDA` to `DistOpDispatchOverHead` — 1 test method, hardcodes `init_device_mesh("cuda", ...)` and `device="cuda"` with `@skip_if_lt_x_gpu(4)`

Test benchmarks DTensor dispatch overhead on CUDA. Uses hardcoded CUDA device mesh and requires 4 GPUs — cannot run on other accelerators.

Depends on: #186918

## Test Plan
```
python test/distributed/tensor/test_dtensor_dispatch_overhead.py -v Ran 1 test in 3.332s — OK (skipped=1)
```


(Skipped: needs 4 CUDA devices, test machine has 1)

cc: @vishalgoyal316 @mansiag05 @RiyaP2508