### PR TITLE
[cuDNN][cuDNN V8 API] Share benchmarked conv plans across threads

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -27,6 +27,8 @@ C10_DIAGNOSTIC_POP()
 #include <c10/util/env.h>
 
 #include <list>
+#include <mutex>
+#include <string>
 #include <unordered_map>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -289,16 +291,14 @@ struct BenchmarkCache {
   std::list<KeyType> engine_cache_order;
   std::unordered_map<
       KeyType,
-      std::pair<
-          cudnn_frontend::ExecutionPlan,
-          typename std::list<KeyType>::iterator>,
+      std::pair<T, typename std::list<KeyType>::iterator>,
       ParamsWrapperHash<KeyType>>
       engine_cache;
 
   // no mutexes here as caches are now thread local for v8, can also return a
   // pointer to the Execution Plan if we know it will not be invalidated by
   // another thread
-  cudnn_frontend::ExecutionPlan* find(const KeyType& key) {
+  T* find(const KeyType& key) {
     const int lru_cache_limit = getLRUCacheLimit();
     if (lru_cache_limit < 0) {
       return nullptr;
@@ -368,6 +368,61 @@ _get_benchmark_cache_fused() {
       CacheKeyFusedWrapper>* benchmark_cache_fused =
       new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>();
   return benchmark_cache_fused;
+}
+
+// cuDNN Execution Plans are not thread safe, so share their JSON instead
+template <typename KeyType>
+struct SerializedPlanCache {
+  // TODO: Use something less heavy duty than a big honking mutex
+  std::mutex mutex;
+  BenchmarkCache<std::string, KeyType> engine_cache;
+
+  bool find(const KeyType& key, std::string* results) {
+    std::lock_guard<std::mutex> guard(mutex);
+    auto search = engine_cache.find(key);
+    if (!search) {
+      return false;
+    }
+    *results = *search;
+    return true;
+  }
+
+  void insert(const KeyType& key, const cudnn_frontend::ExecutionPlan& plan) {
+    if (getLRUCacheLimit() < 0) {
+      return;
+    }
+    {
+      std::lock_guard<std::mutex> guard(mutex);
+      if (engine_cache.find(key)) {
+        return;
+      }
+    }
+    std::string results;
+    try {
+      results = plan.getJsonRepresentation();
+    } catch (cudnn_frontend::cudnnException&) {
+      return;
+    }
+    if (results.empty()) {
+      return;
+    }
+    std::lock_guard<std::mutex> guard(mutex);
+    engine_cache.update(key, results);
+  }
+};
+
+// We also leak the caches to workaround potential teardown race issues.
+SerializedPlanCache<CacheKeyWrapper>* _get_serialized_plan_cache() {
+  static SerializedPlanCache<CacheKeyWrapper>* serialized_plan_cache =
+      new SerializedPlanCache<CacheKeyWrapper>();
+  return serialized_plan_cache;
+}
+
+SerializedPlanCache<CacheKeyFusedWrapper>* _get_serialized_plan_cache_fused() {
+  static SerializedPlanCache<CacheKeyFusedWrapper>*
+      serialized_plan_cache_fused =
+          new SerializedPlanCache<CacheKeyFusedWrapper>();
+  return serialized_plan_cache_fused;
 }
 } // namespace
 
@@ -1011,6 +1066,7 @@ void try_plans(
     try {
       run_conv_plan(handle, x, y, w, plan, operation);
       _get_benchmark_cache()->update(key, plan);
+      _get_serialized_plan_cache()->insert(key, plan);
       return;
     } catch (cudnn_frontend::cudnnException&) {
     } catch (CuDNNError&) {
@@ -1035,6 +1091,7 @@ void try_plans_fused(
     try {
       run_conv_plan_fused(handle, x, y, w, z, b, plan);
       _get_benchmark_cache_fused()->update(key, plan);
+      _get_serialized_plan_cache_fused()->insert(key, plan);
       return;
     } catch (cudnn_frontend::cudnnException&) {
     } catch (CuDNNError&) {
@@ -1069,6 +1126,7 @@ bool try_configs(
       }
       run_conv_plan(handle, x, y, w, plan, operation);
       _get_benchmark_cache()->update(key, plan);
+      _get_serialized_plan_cache()->insert(key, plan);
       return true;
     } catch (cudnn_frontend::cudnnException&) {
     } catch (CuDNNError&) {
@@ -1103,6 +1161,7 @@ bool try_configs_fused(
       }
       run_conv_plan_fused(handle, x, y, w, z, b, plan);
       _get_benchmark_cache_fused()->update(key, plan);
+      _get_serialized_plan_cache_fused()->insert(key, plan);
       return true;
     } catch (cudnn_frontend::cudnnException&) {
     } catch (CuDNNError&) {
@@ -1148,6 +1207,59 @@ bool try_configs_fused(
       configs.begin(), configs.end(), opgraph_tag, key, handle, x, y, w, z, b);
 }
 
+bool try_serialized_plan(
+    const CacheKeyWrapper& key,
+    const cudnnHandle_t handle,
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const cudnnBackendDescriptorType_t operation) {
+  std::string serialized_plan;
+  if (!_get_serialized_plan_cache()->find(key, &serialized_plan)) {
+    return false;
+  }
+  try {
+    auto plan =
+        cudnn_frontend::ExecutionPlanBuilder().setHandle(handle).loadFromJson(
+            serialized_plan);
+    run_conv_plan(handle, x, y, w, plan, operation);
+    _get_benchmark_cache()->update(key, plan);
+    return true;
+  } catch (cudnn_frontend::cudnnException&) {
+  } catch (CuDNNError&) {
+  } catch (c10::OutOfMemoryError&) {
+    std::ignore = cudaGetLastError(); // clear CUDA error
+  }
+  return false;
+}
+
+bool try_serialized_plan_fused(
+    const CacheKeyFusedWrapper& key,
+    const cudnnHandle_t handle,
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const Tensor& z,
+    const Tensor& b) {
+  std::string serialized_plan;
+  if (!_get_serialized_plan_cache_fused()->find(key, &serialized_plan)) {
+    return false;
+  }
+  try {
+    auto plan =
+        cudnn_frontend::ExecutionPlanBuilder().setHandle(handle).loadFromJson(
+            serialized_plan);
+    run_conv_plan_fused(handle, x, y, w, z, b, plan);
+    _get_benchmark_cache_fused()->update(key, plan);
+    return true;
+  } catch (cudnn_frontend::cudnnException&) {
+  } catch (CuDNNError&) {
+  } catch (c10::OutOfMemoryError&) {
+    std::ignore = cudaGetLastError(); // clear CUDA error
+  }
+  return false;
+}
+
 void run_single_conv(
     const cudnnBackendDescriptorType_t operation,
     const Tensor& x,
@@ -1181,6 +1293,8 @@ void run_single_conv(
     } catch (c10::OutOfMemoryError&) {
       std::ignore = cudaGetLastError(); // clear CUDA error
     }
+  } else if (try_serialized_plan(key, handle, x, y, w, operation)) {
+    return;
   }
   if (!benchmark) {
     std::string opgraph_tag; // extra data needed for errata filter
@@ -1336,6 +1450,8 @@ void run_fused_conv(
     } catch (c10::OutOfMemoryError&) {
       std::ignore = cudaGetLastError(); // clear CUDA error
     }
+  } else if (try_serialized_plan_fused(key, handle, x, y, w, z, b)) {
+    return;
   }
   if (!benchmark) {
     std::string opgraph_tag; // extra data needed for errata filter

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -2,6 +2,7 @@
 import itertools
 import math
 import os
+import threading
 import unittest
 import warnings
 from itertools import product
@@ -4122,6 +4123,59 @@ class TestConvolutionNNCUDA(NNTestCase):
         self.assertTrue(x.grad.isfinite().all())
         self.assertTrue(conv.weight.grad.isfinite().all())
         self.assertTrue(conv.bias.grad.isfinite().all())
+
+    @skipCUDAIfNoCudnn
+    @skipCUDAIfRocm
+    def test_cudnn_benchmark_plan_reuse_across_threads(self, device):
+        # See https://github.com/pytorch/pytorch/issues/191617
+        torch.manual_seed(0)
+        num_threads = 3
+        args = []
+        for dtype, memory_format, batch in product(
+            (torch.float, torch.half),
+            (torch.contiguous_format, torch.channels_last),
+            (8, 3),
+        ):
+            x = torch.randn(batch, 32, 28, 28, device=device, dtype=dtype)
+            w = torch.randn(32, 32, 3, 3, device=device, dtype=dtype)
+            x = x.to(memory_format=memory_format)
+            w = w.to(memory_format=memory_format)
+            args.append((x, w))
+        results = {}
+
+        def _run():
+            out = [torch.conv2d(x, w, None, (1, 1), (1, 1), (1, 1), 1) for x, w in args]
+            out += [
+                torch.cudnn_convolution_relu(x, w, None, (1, 1), (1, 1), (1, 1), 1)
+                for x, w in args
+            ]
+            return out
+
+        with cudnn.flags(enabled=True, benchmark=True):
+            with torch.no_grad():
+                expected = _run()
+
+                def _worker(t):
+                    try:
+                        results[t] = _run()
+                    except Exception as e:
+                        results[t] = e
+                    torch.cuda.synchronize()
+
+                threads = [
+                    threading.Thread(target=_worker, args=(t,))
+                    for t in range(num_threads)
+                ]
+
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+        for t in range(num_threads):
+            if isinstance(results[t], Exception):
+                raise results[t]
+            self.assertEqual(results[t], expected, atol=0.0, rtol=0)
 
     @skipCUDAIfNoCudnn
     def test_cudnn_non_contiguous(self, device):


### PR DESCRIPTION
### What does this PR do?

→ Originally surfaced by #191617, but this PR <ins>does **not** fix</ins> that issue (that case is `benchmark=False` and already fast on Linux); it stands on its own as a `benchmark=True` improvement.
→ <ins>TLDR</ins>: With `benchmark=True`, before this PR Thread 1 had to run its own cuDNN benchmarking search (~50.4 ms and ~48.0 ms) because cuDNN execution plan caches were thread local and could not be shared across threads. With this change Thread 0 does the search (~373.3 ms) and Thread 1 now reuses the serialized execution plan cached by Thread 0 and we see its execution times drop to 1.3 ms and 0.4 ms :)

cc @csarofeen @ptrblck @eqy @nWEIdia @albanD @pragupta @Skylion007

### Verification and Testing

→ <ins>Locally</ins>: `benchmark=True` cross-thread repro linked [here](https://gist.github.com/harshaljanjani/3d33f7c3fac7fe6116c620d0587f456a), tests ran across `test/nn/test_convolution.py` with no new failures. Introduced a regression test as shown in the command below.

```
python test/nn/test_convolution.py TestConvolutionNNCUDACUDA.test_cudnn_benchmark_plan_reuse_across_threads_cuda
```

**Before**

<img src="https://github.com/user-attachments/assets/ce8709ae-5db4-4faa-8418-516be83e4476" /><br>

**After**

<img src="https://github.com/user-attachments/assets/32fe72ca-368f-4ae1-aeed-429c1fe8ffac" /><br>

### Environment

* `torch` version: `2.14.0a0+git3380bd9` (source build, `USE_CUDA=1 USE_CUDNN=1`, CUDA 13.0, cuDNN 9.24.0)
* Platform: `Linux-6.8.0-1063-gcp-x86_64-with-glibc2.35`, GPU: NVIDIA L4 (sm_89)
* Python version: `3.10.12`