### PR TITLE
[ROCm] Fix MultiProcContinuousTest subclass hanging on its base class's dead workers

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1919,7 +1919,10 @@ class MultiProcContinuousTest(TestCase):
         This supports instantiate_device_type_tests which calls setUpClass during
         class creation (before any tests run), when spawning would be premature.
         """
-        if cls._processes_spawned:
+        # Check the class's own dict: a subclass must not inherit the flag from
+        # a base test class that already ran and tore down its workers, else it
+        # would dispatch tests to the base class's dead worker processes.
+        if cls.__dict__.get("_processes_spawned", False):
             return
 
         # Handle both method and string attribute for device_type
@@ -1960,8 +1963,10 @@ class MultiProcContinuousTest(TestCase):
         Class-scope test fixture. Run once for entire test class, after all tests finish.
         Tear down the process group if spawned.
         """
-        # If processes were never spawned (e.g., all tests were skipped), nothing to tear down
-        if not cls._processes_spawned:
+        # If processes were never spawned (e.g., all tests were skipped), nothing to tear down.
+        # Check the class's own dict to avoid tearing down an already-finished
+        # base class's workers (see _ensure_processes_spawned).
+        if not cls.__dict__.get("_processes_spawned", False):
             super().tearDownClass()
             return
 


### PR DESCRIPTION
Fix MultiProcContinuousTest subclass hanging on its base class's dead workers

A subclass of a concrete MultiProcContinuousTest test class inherits the base class's `_processes_spawned` flag through ordinary attribute lookup, so it never spawns its own workers and instead dispatches tests onto the base class's already torn-down queues, blocking forever in `completion_queue.get()`. Consult the class's own `__dict__` in both the spawn and the teardown guard so that every leaf class owns its worker pool.

This makes test_replicate.py order-independent. Under pytest the base class ReplicateTest runs before ReplicateFullyShardInit, which then hangs until the harness timeout; under unittest the subclass happens to sort first, which is why the bug stayed latent in CI.

Backport of the test-infra portion of #189362, which fixed this on main.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang