### PR TITLE
[ONNX] Fix silently wrong weight_norm export for 1-D weights

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5694,6 +5694,13 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         x = torch.randn(3, 3, 5, requires_grad=True)
         self.run_test(model, x)
 
+        # 1-D weight reduces over no axes, so the norm is an elementwise abs
+        class WeightNorm1d(torch.nn.Module):
+            def forward(self, v, g):
+                return torch._weight_norm(v, g, 0)
+
+        self.run_test(WeightNorm1d(), (torch.randn(5), torch.randn(5)))
+
     @skipScriptTest()
     def test_weight_norm_nodim(self):
         # addmm for 3-d inputs converts to onnx::MatMul

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
@@ -5745,7 +5745,9 @@ def _weight_norm(g: jit_utils.GraphContext, weight_v, weight_g, dim):
                 dim += rank
             if dim != -1:
                 axes.remove(dim)
-        norm_v = norm(g, weight_v, 2, axes, 1)
+        # ReduceL2 treats an empty axes list as "reduce all dims", but an empty
+        # reduction (1-D weight) must be an elementwise abs instead
+        norm_v = norm(g, weight_v, 2, axes, 1) if axes else g.op("Abs", weight_v)
         div = g.op("Div", weight_v, norm_v)
         return g.op("Mul", div, weight_g)
     raise errors.SymbolicValueError(


### PR DESCRIPTION
## Issue

Fixes #130644

## Summary

This PR originally added a new `aten::_weight_norm_interface` symbolic to
the TorchScript exporter. @justinchuby pointed out that exporter is
deprecated and can be removed at any time, so it's not worth review
bandwidth for new op support there — torch-mlir should use the
`dynamo=True` exporter instead, which already handles this op via its
core ATen decomposition (verified manually). I've dropped that symbolic
from this PR; see my comment below and the issue for the redirect.

What's left is a real, narrowly-scoped bug I found while writing the
original tests, in the existing (non-deprecated-in-the-same-sense)
`aten::_weight_norm` symbolic:

> For a 1-D `v` with `dim=0`, the "reduce over every dim except dim"
> axes list is empty. ONNX's `ReduceL2` treats an empty axes list as
> "reduce over all dims" rather than "reduce over none", so the exported
> graph silently computed a single scalar norm for the whole vector
> instead of an elementwise abs, at every opset (max error ~1 vs eager).
> Fixed by falling back to `Abs` when the axes list is empty.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (n/a)
- [ ] Included benchmark results (n/a, export-time only)

## BC-breaking?

No. Pure correctness fix for exports that were silently wrong.
