### PR TITLE
Name the test that timed out in run_test.py logs

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -532,6 +532,11 @@ def run_test(
     maybe_set_hip_visible_devies()
     unittest_args = options.additional_args.copy()
     test_file = test_module.name
+    # Stable identifier for CI logs, e.g. "test_ops 3/8". Deliberately built
+    # from .name rather than str(test_module), which also embeds the pytest
+    # filter for partial runs ("test_ops, not (TestA or TestB) 3/8") and would
+    # fragment the log classifier's grouping key.
+    test_label = f"{test_file} {test_module.shard}/{test_module.num_shards}"
     stepcurrent_key = test_file
 
     is_distributed_test = test_file.startswith(DISTRIBUTED_TEST_PREFIX)
@@ -692,6 +697,7 @@ def run_test(
                 options.continue_through_error,
                 test_file,
                 options,
+                test_label,
             )
         else:
             command.extend([f"--sc={stepcurrent_key}", "--print-items"])
@@ -703,6 +709,7 @@ def run_test(
                 env=env,
                 timeout=timeout,
                 retries=0,
+                label=test_label,
             )
 
             # Pytest return code 5 means no test is collected. Exit code 4 is
@@ -780,6 +787,7 @@ def run_test_retries(
     continue_through_error,
     test_file,
     options,
+    test_label="",
 ):
     # Run the test with -x to stop at first failure.  Rerun the test by itself.
     # If it succeeds, move on to the rest of the tests in a new process.  If it
@@ -819,6 +827,7 @@ def run_test_retries(
             env=env,
             timeout=timeout,
             retries=0,  # no retries here, we do it ourselves, this is because it handles timeout exceptions well
+            label=test_label,
         )
         ret_code = 0 if ret_code == 5 else ret_code
         if ret_code == 0 and not sc_command.startswith("--rs="):
@@ -843,6 +852,18 @@ def run_test_retries(
         env = try_set_cpp_stack_traces(env, command, set=False)
         if ret_code != 0:
             num_failures[current_failure] += 1
+
+        if ret_code == 124:
+            # A timeout where we know which test was in flight. This is for the
+            # log classifier, same as FAILED CONSISTENTLY below: without it the
+            # only evidence of a timeout is retry_shell's "Command took >Nmin"
+            # line, which cannot name the test, so every hang in the fleet
+            # collapses into one group and a single hanging test is invisible.
+            # [1:-1] to remove quotes. NB when the hang happens during import
+            # or collection no test has started, there is no stepcurrent entry,
+            # and we never get here -- that case is covered by the file-level
+            # label on the "Command took" line instead.
+            print_to_file(f"TIMED OUT: {current_failure[1:-1]}")
 
         if ret_code == 0:
             # Rerunning the previously failing test succeeded, so now we can

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1243,6 +1243,7 @@ def retry_shell(
     timeout=None,
     retries=1,
     was_rerun=False,
+    label="",
 ) -> tuple[int, bool]:
     # Returns exicode + whether it was rerun
     if not (retries >= 0):
@@ -1262,8 +1263,14 @@ def retry_shell(
         )
     except subprocess.TimeoutExpired:
         if retries == 0:
+            # NB: the "Command took >Nmin, returning 124" prefix is load
+            # bearing -- the CI log classifier matches on it, so only ever
+            # append here. The label names what timed out, so that timeouts
+            # group per test file on HUD instead of collapsing into a single
+            # fleet-wide bucket (which makes an uptick in one file invisible).
             print(
-                f"Command took >{timeout // 60}min, returning 124",
+                f"Command took >{timeout // 60}min, returning 124"
+                + (f" ({label})" if label else ""),
                 file=stdout,
                 flush=True,
             )
@@ -1282,6 +1289,7 @@ def retry_shell(
         timeout=timeout,
         retries=retries - 1,
         was_rerun=True,
+        label=label,
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191754

When a test times out, CI logs today contain no way to tell *what* timed out
on a line that also says it timed out. `retry_shell` prints

    Command took >30min, returning 124

which names nothing, so the log classifier -- which picks a single line and
uses its capture as the HUD grouping key -- collapses every timeout in the
fleet into one bucket. A single test file that starts hanging is invisible;
it looks identical to unrelated infra flakiness. The file name is on the
neighbouring `PRINTING LOG FILE of <file>` / `Finished <file> ...` lines, but
those are printed for ordinary failures too, so the classifier cannot key on
them without mislabelling every normal failure as a timeout.

Two cases, handled separately:

- A specific test hangs. `run_test_retries` already reads the culprit from the
  stepcurrent cache into `current_failure`, but only prints it after three
  failures (`FAILED CONSISTENTLY`). At 30min per retry a job is usually killed
  first, so the name is read and thrown away. Print `TIMED OUT: <nodeid>` as
  soon as we have it, in the same idiom as the existing FAILED CONSISTENTLY
  line and for the same stated reason.

- The hang is during import or collection. No test started, so there is no
  stepcurrent entry and no test name exists. Thread an optional `label` into
  `retry_shell` so the existing line gains the file and shard:

      Command took >30min, returning 124 (test_segment_reductions 1/1)

  In a sample of 7 real timeouts from a week of `main`, all 7 were this case.

The `Command took >Nmin, returning 124` prefix is preserved byte-for-byte,
because the deployed classifier regex is anchored on it and release branches
will keep emitting the bare form for a long time. The label is appended only.

`label` is an optional trailing kwarg, so the existing positional and keyword
callers of `retry_shell` (including downstream users of
torch.testing._internal.common_utils) are unaffected. The label is built from
`ShardedTest.name` rather than `str(test_module)`, which for filtered runs
renders "test_ops, not (TestA or TestB) 3/8" and would fragment the group key.