### PR TITLE
Back out "Back out "Release the GIL in the _disable_profiler pybind binding (#187594)""

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -440,7 +440,10 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       py::arg("config"),
       py::arg("activities"),
       py::arg("scopes") = std::unordered_set<at::RecordScope>());
-  m.def("_disable_profiler", disableProfiler);
+  m.def(
+      "_disable_profiler",
+      disableProfiler,
+      py::call_guard<py::gil_scoped_release>());
   m.def(
       "_prepare_profiler",
       prepareProfiler,


### PR DESCRIPTION
Summary:
Original commit changeset: eee0980fa314

Original Phabricator Diff: D113451484

Test Plan:
see test plan of D108962294

Also ran 114 jobs with this diff included + `sdd_pipeline_reordering` disabled + D113982725 baked into the torch pkg, and we observed ~5% IMA's (down from 15-20% IMA's originally with `sdd_pipeline_reordering` enabled and without D113982725)

Differential Revision: D114369278


