### PR TITLE
[DO NOT MERGE][ROCm][CI] Test trunk on linux.rocm.gpu.gfx950.1.test-control runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -68,6 +68,7 @@ self-hosted-runner:
     - linux.rocm.gpu.gfx942.1
     - linux.rocm.gpu.gfx942.4
     # gfx950 runners
+    - linux.rocm.gpu.gfx950.1.test-control
     - linux.rocm.gpu.gfx950.1
     - linux.rocm.gpu.gfx950.4
     # Org wise AWS `mac2.metal` runners (2020 Mac mini hardware powered by Apple silicon M1 processors)

--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -114,6 +114,8 @@ runner_mapping:
   linux.rocm.gpu.gfx942.4: linux.rocm.gpu.gfx942.4
   linux.rocm.gpu.gfx950.1: linux.rocm.gpu.gfx950.1
   linux.rocm.gpu.gfx950.2: linux.rocm.gpu.gfx950.2
+  # AMD-dedicated gfx950 CPU-isolation control runner; not OSDC-managed, so passthrough.
+  linux.rocm.gpu.gfx950.1.test-control: linux.rocm.gpu.gfx950.1.test-control
   linux.rocm.gpu.gfx1100: linux.rocm.gpu.gfx1100
   # amd-do experiment routes mi350 tests to AMD's dedicated runners via this
   # prefix; kept as passthrough so the OSDC build's runner mapping preserves it.

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -39,6 +39,13 @@ on:
         default: ""
         description: |
           List of tests to include (empty string implies default list)
+      repro-probe:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          [AIPYTORCH-894 A/B only] When true, emit greppable REPRO_PROBE lines into the job log
+          (one-shot CPU-affinity/parallel_info probe + background compile-worker sampler). Inert by default.
       dashboard-tag:
         required: false
         type: string
@@ -204,6 +211,7 @@ jobs:
           DOCKER_IMAGE: ${{ inputs.docker-image }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
+          REPRO_PROBE: ${{ inputs.repro-probe && '1' || '0' }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
         timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
@@ -282,7 +290,16 @@ jobs:
           if [[ "${TEST_CONFIG}" == *distributed* ]]; then
             PREFLIGHT="timeout 180 python .ci/pytorch/rocm_preflight.py && "
           fi
-          docker exec -t "${container_name}" sh -c "pip install dist/*.whl && ${PREFLIGHT}${TEST_COMMAND}"
+          # [AIPYTORCH-894 A/B] In-log reproduction evidence (gated on repro-probe). Non-fatal.
+          if [[ "${REPRO_PROBE}" == "1" ]]; then
+            docker exec -t "${container_name}" bash -lc 'echo "REPRO_PROBE affinity=$(python -c "import os;print(len(os.sched_getaffinity(0)))") nproc=$(nproc) parallel_info:"; python -c "import torch;print(torch.__config__.parallel_info())"' || true
+          fi
+          # [AIPYTORCH-894 A/B] Background compile-worker sampler (gated). Non-fatal; dies with container.
+          SAMPLER=""
+          if [[ "${REPRO_PROBE}" == "1" ]]; then
+            SAMPLER='{ ( for i in $(seq 1 60); do echo "REPRO_PROBE workers=$(pgrep -fc "compile_worker|async_compile|torch/_inductor/compile_worker" 2>/dev/null || echo 0) ts=$(date +%s)"; sleep 30; done ) & } && '
+          fi
+          docker exec -t "${container_name}" sh -c "pip install dist/*.whl && ${PREFLIGHT}${SAMPLER}${TEST_COMMAND}"
 
       - name: Restore workspace owner
         if: always()

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -486,6 +486,9 @@ jobs:
       docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
+      # [AIPYTORCH-894 A/B] Capture in-log CPU-affinity/compile-worker evidence on the
+      # un-isolated control runner to confirm the oversubscription that kills the shard.
+      repro-probe: true
     secrets: inherit
 
   inductor-build:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -460,19 +460,16 @@ jobs:
       # sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 2, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 3, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 4, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 5, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 6, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2" },
+          { config: "default", shard: 1, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 2, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 3, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 4, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 5, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 6, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 7, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "default", shard: 8, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1.test-control" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1.test-control" },
         ]}
       python-version: "3.10"
     secrets: inherit


### PR DESCRIPTION
## Motivation

We need to validate that the dedicated gfx950 CPU-isolation **control** runner
label picks up and runs `trunk` ROCm jobs before wiring it into any
runner-determinator experiment. This is a throwaway validation PR (DO NOT MERGE).

## Summary

- Route the `trunk` `linux-jammy-rocm-py3.10-mi350` test-matrix (default +
  inductor shards) to the `linux.rocm.gpu.gfx950.1.test-control` runner label.
- Register `linux.rocm.gpu.gfx950.1.test-control` in `.github/actionlint.yaml`.
- Add an `.github/arc.yaml` passthrough mapping for the label (AMD-dedicated,
  not OSDC-managed).
- Distributed shards (which require a 2-GPU runner) are dropped for this
  single-GPU control-runner validation.

## Test plan

- [ ] `ciflow/trunk` runs and the `linux-jammy-rocm-py3.10-mi350` test shards are
      scheduled on and executed by `linux.rocm.gpu.gfx950.1.test-control`.
- [ ] The ROCm test shards complete on the control runner.

Made with Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang