### PR TITLE
[PyTorch] Add clang-compatible conversions between SVE and NEON (#191761)

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -22,10 +22,6 @@ C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-default")
 // However for now opting for STL, since we are not building
 // with Sleef for mobile yet.
 
-namespace at::vec {
-// See Note [CPU_CAPABILITY namespace]
-inline namespace CPU_CAPABILITY {
-
 // Right now contains only aarch64 implementation.
 // Due to follow two reasons aarch32 is not currently supported.
 // 1. Due to difference in ISA been aarch32 and aarch64, intrinsics
@@ -47,9 +43,25 @@ inline namespace CPU_CAPABILITY {
 #define USE_SLEEF(sleef_code, non_sleef_code) non_sleef_code
 #endif
 
-#if defined(CPU_CAPABILITY_SVE128)
+#if defined(__ARM_FEATURE_SVE)
+
+#include <arm_sve.h>
+
+#if defined(__clang__) && (__clang_major__ >= 16)
+
+#include <arm_neon_sve_bridge.h>
+
+static inline svfloat32_t neon_to_sve(float32x4_t v) {
+  return svset_neonq(svundef_f32(), v);
+}
+static inline float32x4_t sve_to_neon(svfloat32_t v) {
+  return svget_neonq(v);
+}
+
+#else
+
 // With -msve-vector-bits=128, svfloat32_t and float32x4_t have identical layout
-// so these conversions compile to zero instructions.
+// so these conversions compile to zero instructions on GCC.
 static inline svfloat32_t neon_to_sve(float32x4_t v) {
   svfloat32_t r;
   __builtin_memcpy(&r, &v, sizeof(v));
@@ -61,6 +73,12 @@ static inline float32x4_t sve_to_neon(svfloat32_t v) {
   return r;
 }
 #endif
+
+#endif
+
+namespace at::vec {
+// See Note [CPU_CAPABILITY namespace]
+inline namespace CPU_CAPABILITY {
 
 template <int index, bool mask_val>
 struct BlendRegs {


### PR DESCRIPTION
Summary:

The current translation method relying on memcpy is broken on clang-16 onwards: https://godbolt.org/z/dbnc5j4nv

It works on clang-11 to clang-15: https://godbolt.org/z/Gd7K1jTW5

Test Plan: test_ops.py

Differential Revision: D114374113


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01