### PR TITLE
[dynamo] Fix nested_compile_region on transposed buffers and specialized symints

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -3792,6 +3792,80 @@ class GraphModule(torch.nn.Module):
 """,
             )
 
+    def test_subgraph_reuse_transposed_buffer_dynamic(self):
+        """Reuse must work when a region reads a transposed view of a buffer.
+
+        `w.T` is desugared into an aten op traced into the subgraph, so the
+        region only lifts `w` itself. With dynamic shapes the region also lifts
+        the symint for the (specialized) feature dim.
+        """
+
+        class Layer(torch.nn.Module):
+            def __init__(self, d):
+                super().__init__()
+                self.register_buffer("w", torch.randn(d, d))
+
+            @nested_compile_region
+            def forward(self, x):
+                return torch.matmul(x, self.w.T)
+
+        class Model(torch.nn.Module):
+            def __init__(self, d, n):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Layer(d) for _ in range(n)])
+
+            def forward(self, x):
+                for layer in self.layers:
+                    x = layer(x)
+                return x
+
+        model = Model(8, 3)
+        x = torch.randn(4, 8)
+        ref = model(x)
+
+        backend = EagerAndRecordGraphs()
+        compiled = torch.compile(model, backend=backend, fullgraph=True, dynamic=True)
+        with self._count_speculate_calls() as count:
+            res = compiled(x)
+
+        self.assertEqual(ref, res)
+        self.assertEqual(count(), 1)
+
+        # A different batch size must not recompile.
+        x2 = torch.randn(9, 8)
+        self.assertEqual(model(x2), compiled(x2))
+
+        self.assertEqual(len(backend.graphs), 1)
+        if not TEST_WITH_CROSSREF:
+            self.assertExpectedInline(
+                normalize_gm(backend.graphs[0].print_readable(print_output=False)),
+                """\
+class GraphModule(torch.nn.Module):
+    def forward(self, s77: "Sym(s77)", s27: "Sym(8)", L_x_: "f32[s77, 8]", L_self_modules_layers_modules_0_buffers_w_: "f32[8, 8]", L_self_modules_layers_modules_1_buffers_w_: "f32[8, 8]", L_self_modules_layers_modules_2_buffers_w_: "f32[8, 8]"):
+        l_x_ = L_x_
+        l_self_modules_layers_modules_0_buffers_w_ = L_self_modules_layers_modules_0_buffers_w_
+        l_self_modules_layers_modules_1_buffers_w_ = L_self_modules_layers_modules_1_buffers_w_
+        l_self_modules_layers_modules_2_buffers_w_ = L_self_modules_layers_modules_2_buffers_w_
+
+        subgraph_0 = self.subgraph_0
+        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph_0, 'subgraph_0', l_self_modules_layers_modules_0_buffers_w_, s77, s27, l_x_);  subgraph_0 = l_self_modules_layers_modules_0_buffers_w_ = l_x_ = None
+        x: "f32[s77, 8]" = invoke_subgraph[0];  invoke_subgraph = None
+        subgraph_1 = self.subgraph_0
+        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_0', l_self_modules_layers_modules_1_buffers_w_, s77, s27, x);  subgraph_1 = l_self_modules_layers_modules_1_buffers_w_ = x = None
+        x_1: "f32[s77, 8]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
+        subgraph_2 = self.subgraph_0
+        invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(subgraph_2, 'subgraph_0', l_self_modules_layers_modules_2_buffers_w_, s77, s27, x_1);  subgraph_2 = l_self_modules_layers_modules_2_buffers_w_ = s77 = s27 = x_1 = None
+        x_2: "f32[s77, 8]" = invoke_subgraph_2[0];  invoke_subgraph_2 = None
+        return (x_2,)
+
+    class subgraph_0(torch.nn.Module):
+        def forward(self, l_self_modules_layers_modules_0_buffers_w_: "f32[8, 8]", s77: "Sym(s77)", s27: "Sym(8)", l_x_: "f32[s77, 8]"):
+            numpy_t: "f32[8, 8]" = torch.ops.aten.numpy_T(l_self_modules_layers_modules_0_buffers_w_);  l_self_modules_layers_modules_0_buffers_w_ = None
+            matmul: "f32[s77, 8]" = torch.matmul(l_x_, numpy_t);  l_x_ = numpy_t = None
+            return (matmul,)
+""",
+            )
+
     def test_subgraph_reuse_different_list_lengths(self):
         """Reuse must be skipped when list args have different lengths.
 

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -325,8 +325,29 @@ class LiftedBoundSymbol:
     expr: Any  # sympy.Expr
 
 
+@dataclass
+class LiftedSpecializedSymInt:
+    """Lifted arg for a SymInt that got specialized while tracing the body.
+
+    The symbol was free when the subgraph lifted it, and the body then pinned
+    it to a constant (e.g. matmul against a statically shaped weight). By the
+    time the entry is saved there is no symbol left to bind, so LiftedBoundSymbol
+    cannot look it up. Reuse the original call's proxy: the placeholder is still
+    an input of the same outer graph (the reuse cache lives on the tracing
+    context, which is per output graph). Passing the constant instead would make
+    the invoke_subgraph call sites disagree on that argument, which Inductor
+    rejects.
+    """
+
+    proxy: Proxy
+
+
 LiftedArgOrigin = (
-    LiftedUserArg | LiftedCapturedSource | LiftedSyntheticObject | LiftedBoundSymbol
+    LiftedUserArg
+    | LiftedCapturedSource
+    | LiftedSyntheticObject
+    | LiftedBoundSymbol
+    | LiftedSpecializedSymInt
 )
 
 
@@ -953,6 +974,8 @@ def stamp_out_subgraph(
     for subgraph_input in cached.subgraph_input_mapping:
         if isinstance(subgraph_input, LiftedUserArg):
             new_lifted_args.append(flat_proxies[subgraph_input.index])
+        elif isinstance(subgraph_input, LiftedSpecializedSymInt):
+            new_lifted_args.append(subgraph_input.proxy)
         elif isinstance(subgraph_input, LiftedBoundSymbol):
             from torch._dynamo.output_graph import LazyProxy
 
@@ -1085,7 +1108,11 @@ def build_subgraph_input_mapping(
                 else outer_proxy.node.meta.get("example_value", None)
             )
             if isinstance(example, torch.SymInt):
-                subgraph_input_mapping.append(LiftedBoundSymbol(example.node.expr))
+                expr = example.node.expr
+                if expr.is_number:
+                    subgraph_input_mapping.append(LiftedSpecializedSymInt(outer_proxy))
+                else:
+                    subgraph_input_mapping.append(LiftedBoundSymbol(expr))
                 continue
             if source is None:
                 raise AssertionError(

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -147,6 +147,15 @@ def is_bound_tensor_method(value: object) -> bool:
 # are common keys.
 all_tensor_attrs = torch._C.TensorBase.__dict__ | torch.Tensor.__dict__
 
+# Tensor attributes that are plain views of the tensor. Each maps to the aten op
+# that the C++ getter dispatches to, see native_functions.yaml.
+_VIEW_ATTR_TO_ATEN_OP = {
+    "T": torch.ops.aten.numpy_T,
+    "mT": torch.ops.aten.mT,
+    "H": torch.ops.aten.matrix_H,
+    "mH": torch.ops.aten.mH,
+}
+
 
 def _is_sym_arith_operand(vt: VariableTracker) -> bool:
     """True if vt can be the other operand of a SymNode arithmetic op
@@ -698,6 +707,18 @@ class TensorVariable(VariableTracker):
                     f"Unknown property {name} during speculating backward, dynamo will insert contiguous call ahead and speculate it again"
                 )
 
+        if name in _VIEW_ATTR_TO_ATEN_OP:
+            # Desugar view attributes into the aten op that the C++ getter calls
+            # (e.g. Tensor.T -> aten::numpy_T). The result is a derived tensor,
+            # not a captured value, so it is deliberately left sourceless: giving
+            # it an AttrSource makes it look like something the graph can take as
+            # an input, which breaks freevar lifting inside higher order ops.
+            from .torch import TorchInGraphFunctionVariable
+
+            return TorchInGraphFunctionVariable(
+                _VIEW_ATTR_TO_ATEN_OP[name]
+            ).call_function(tx, [self], {})
+
         if name == "__class__":
             # Carry provenance on the class, mirroring BuiltinVariable.call_type.
             # A sourced class self-guards when observed downstream (e.g.
@@ -754,7 +775,6 @@ class TensorVariable(VariableTracker):
 
             def try_generic_attr_handling() -> VariableTracker | None:
                 from .builder import wrap_fx_proxy
-                from .misc import GetAttrVariable
 
                 static_attr = all_tensor_attrs.get(name, None)
                 if static_attr is None:
@@ -769,7 +789,13 @@ class TensorVariable(VariableTracker):
                 if type(static_attr) is not types.GetSetDescriptorType:
                     return None
 
-                proxy = GetAttrVariable.create_getattr_proxy(self.as_proxy(), name)
+                # Create the node on the current tracer, not on the tracer that
+                # owns the base proxy. Otherwise, inside a higher order op, the
+                # node lands in the parent graph and has to be lifted back in as
+                # a subgraph input.
+                proxy = tx.output.current_tracer.create_proxy(
+                    "call_function", getattr, (self.as_proxy(), name), {}
+                )
                 if self.source is not None:
                     return wrap_fx_proxy(
                         tx=tx, proxy=proxy, source=AttrSource(self.source, name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191764

A nested compile region that reads a transposed view of a captured buffer
(`x @ self.w.T`, a common pattern in FairChem UMA) failed to compile:

    AssertionError: Freevar has no source: node.op=call_function
    node.name=getattr_1 -- this likely means a function argument was not
    included in the proxy matching

Two independent bugs were behind it.

First, `Tensor.T` fell through to Dynamo's generic getset-descriptor handling,
which built the FX node with `getattr(base_proxy, name)`. Instead of special casing the reuse path,
attribute access now desugars into the aten op the C++ getter dispatches to
(`T` -> `numpy_T`, `H` -> `matrix_H`, `mT`, `mH`), so the op is traced through
the normal path into the region itself and the result is an ordinary
intermediate rather than something carrying an `AttrSource` (which was wrong
because .T is just a transpose op, and therefore should not have any source). Deprecation
warnings and dimensionality errors keep coming from C++, unchanged. The
generic path keeps its remaining users (`real`, `imag`), so it now creates its
node on the current tracer, which is the same bug in miniature.

Second, with `dynamic=True` the region also lifts the symint for a dimension
that is still free at lift time and only gets specialized while tracing the
body (here, matmul against a statically shaped weight pins it to 8). By the
time the reuse entry is saved there is no symbol left to bind, so the
`LiftedBoundSymbol` lookup in `bound_symbols` raised `KeyError: 8`. Such args
are now recorded as `LiftedSpecializedSymInt`, which reuses the original call's
proxy. Passing the constant instead also works in eager but makes the
invoke_subgraph call sites disagree on that argument, which Inductor rejects
with "subgraph args must have consistent values!".

The lifted symint is a dead input to the subgraph; the tidier fix is for the
HOP tracer not to lift symbols that end up specialized, which is left as a
follow-up.

This PR was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98