### PR TITLE
[dynamo] pin ordering of load-bearing nodes during graph canonicalization

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -2421,6 +2421,41 @@ class DictTests(torch._dynamo.test_case.TestCase):
         remove_batch = graph.call_function(torch._remove_batch_dim, (x, x, x, x))
         self.assertFalse(_is_safe_to_reorder(remove_batch))
 
+        # Nodes binding unbacked symbols are barriers: reordering them changes
+        # the order the ShapeEnv resolves replacements (compile-time blowup).
+        # Checked before the call_method branch, since Dynamo emits item() as a
+        # call_method that would otherwise be reported safe.
+        unbacked_method = graph.call_method("item", (x,))
+        self.assertTrue(_is_safe_to_reorder(unbacked_method))
+        unbacked_method.meta["unbacked_bindings"] = {"u0": ()}
+        self.assertFalse(_is_safe_to_reorder(unbacked_method))
+
+        # Functional collectives are barriers (comm/compute overlap + Inductor's
+        # in-place collective reuse). Dynamo graphs hold OpOverloadPackets,
+        # aten graphs hold OpOverloads, so both dispatch forms must be covered.
+        collective_overload = graph.call_function(
+            torch.ops._c10d_functional.all_reduce.default, (x, "sum", "0")
+        )
+        self.assertFalse(_is_safe_to_reorder(collective_overload))
+        collective_packet = graph.call_function(
+            torch.ops._c10d_functional.all_reduce, (x, "sum", "0")
+        )
+        self.assertFalse(_is_safe_to_reorder(collective_packet))
+        self.assertTrue(
+            _is_safe_to_reorder(graph.call_function(torch.ops.aten.add.Tensor, (x, x)))
+        )
+
+        # increment_version bumps a version counter in place; matched by
+        # identity, so the torch._C alias (different __name__) is covered too.
+        self.assertFalse(
+            _is_safe_to_reorder(
+                graph.call_function(torch.autograd.graph.increment_version, (x,))
+            )
+        )
+        self.assertFalse(
+            _is_safe_to_reorder(graph.call_function(torch._C._increment_version, (x,)))
+        )
+
 
 instantiate_parametrized_tests(DictTests)
 

--- a/torch/fx/passes/canonicalize.py
+++ b/torch/fx/passes/canonicalize.py
@@ -10,13 +10,16 @@ Provides two passes:
 """
 
 import collections
+import functools
 import heapq
+import importlib
 import itertools
 import operator
 from collections.abc import Callable
 
 import torch
 import torch.fx as fx
+from torch.fx._compatibility import compatibility
 
 
 __all__ = ["canonicalize_graph", "rename_nodes_to_canonical"]
@@ -40,6 +43,34 @@ _IN_PLACE_OPERATORS = frozenset(
         "ixor",
     }
 )
+
+
+# Operator namespaces whose ordering relative to surrounding compute is
+# load-bearing (comm/compute overlap, in-place collective reuse). Deliberately
+# limited to functional collectives; `symm_mem` and `_dtensor` have similar
+# concerns but are not covered yet.
+_ORDER_SENSITIVE_NAMESPACES = frozenset(
+    {"_c10d_functional", "_c10d_functional_autograd"}
+)
+
+
+@functools.lru_cache(None)
+def _version_mutating_functions() -> frozenset[object]:
+    """Functions that bump a tensor's version counter in place.
+
+    Resolved lazily: importing ``torch._library`` at module scope would create an
+    import cycle.
+    """
+    fns: list[object] = [torch.autograd.graph.increment_version]
+    for mod, attr in (
+        ("torch._C", "_increment_version"),
+        ("torch._library.custom_ops", "increment_version"),
+    ):
+        try:
+            fns.append(getattr(importlib.import_module(mod), attr))
+        except (ImportError, AttributeError):
+            pass
+    return frozenset(fns)
 
 
 def _computation_node_key(
@@ -72,7 +103,21 @@ def _is_safe_to_reorder(node: fx.Node) -> bool:
     Builds on Node.is_impure() (used by DCE) with two additional checks for
     cases it doesn't cover: in-place call_method nodes and non-OpOverload
     state-changing functions detected by a no-node-arguments heuristic.
+
+    Returning False is a graph-scale decision, not a node-scale one: barriers
+    partition the graph into segments (see ``canonicalize_graph``) and pure nodes
+    are confined to their segment, so each barrier trades determinism for
+    ordering safety across the whole graph. A graph with N barriers only
+    canonicalizes within N+1 segments, which for data-dependent graphs degrades
+    toward trace order. Add barriers only where ordering is load-bearing.
     """
+    # Nodes that bind unbacked symbols (item()/_local_scalar_dense, nonzero,
+    # ...) keep their trace-order position. Reordering them changes the order
+    # the ShapeEnv resolves symbol replacements, which can blow up compile time
+    # (superlinear SymNode.expr / _find work) even though the graph is
+    # value-equivalent. Trace order is already deterministic across ranks.
+    if node.meta.get("unbacked_bindings"):
+        return False
     if node.op == "call_method":
         return not node.target.endswith("_")  # pyrefly: ignore[missing-attribute]
     if node.op == "call_module":
@@ -80,6 +125,32 @@ def _is_safe_to_reorder(node: fx.Node) -> bool:
     if node.op != "call_function":
         return True
     if node.is_impure():
+        return False
+    # Functional collectives (all_reduce, wait_tensor, ...) keep their
+    # trace-order position. Reordering a collective relative to surrounding
+    # compute changes comm/compute overlap and defeats Inductor's in-place
+    # collective reuse. Trace order is already deterministic across ranks
+    # (identical SPMD code), so canonicalization loses nothing here. In Dynamo
+    # output graphs these appear as OpOverloadPackets, in aten graphs as
+    # OpOverloads, so check both. OpOverloadPacket has no public namespace
+    # accessor, hence _qualified_op_name (test_canonical_graph_is_safe_to_reorder
+    # covers both dispatch forms, so a rename there fails loudly).
+    if isinstance(node.target, torch._ops.OpOverload):
+        collective_namespace = node.target.namespace
+    elif isinstance(node.target, torch._ops.OpOverloadPacket):
+        collective_namespace = node.target._qualified_op_name.split("::", 1)[0]
+    else:
+        collective_namespace = None
+    if collective_namespace in _ORDER_SENSITIVE_NAMESPACES:
+        return False
+    # increment_version bumps a tensor's version counter in place. It takes the
+    # tensor as an FX Node arg (so the no-input heuristic below misses it) and
+    # is not an OpOverload, so is_impure() doesn't flag it. Reordering it
+    # relative to version reads (prims._tensor_version) corrupts
+    # version-counter semantics. Matched by identity, not __name__:
+    # torch._C._increment_version is exposed under a different name and is in
+    # Dynamo's in-graph allowlist (trace_rules.torch_c_binding_in_graph_functions).
+    if node.target in _version_mutating_functions():
         return False
     if not isinstance(node.target, torch._ops.OpOverload):
         name = getattr(node.target, "__name__", "")
@@ -110,6 +181,7 @@ def _is_safe_to_reorder(node: fx.Node) -> bool:
     return True
 
 
+@compatibility(is_backward_compatible=False)
 def rename_nodes_to_canonical(
     graph: fx.Graph,
     skip_ops: frozenset[str] = frozenset(),
@@ -229,6 +301,7 @@ def _group_getitem_nodes(order: list[fx.Node]) -> None:
     order[:] = new_order
 
 
+@compatibility(is_backward_compatible=False)
 def canonicalize_graph(
     graph: fx.Graph,
     canonical_key_fn: Callable[[fx.Node, dict[fx.Node, int]], object],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Canonical node ordering must not move nodes whose position carries meaning
beyond dataflow. Three such cases were being reordered, each with a distinct
symptom, and all three are now barriers in `_is_safe_to_reorder`.

`torch.autograd.graph.increment_version` bumps a tensor's version counter in
place. It takes the tensor as an FX Node argument, so the "no Node inputs"
heuristic misses it, and it is not an OpOverload, so `is_impure()` does not flag
it. Canonicalization hoisted it above the `prims._tensor_version` read, so the
bump was lost and `a._version` read back as 0 instead of 1. It is matched by
identity rather than by `__name__`, because `torch._C._increment_version` is
exposed under a different name and is in Dynamo's in-graph allowlist, so a
name match silently missed it.

Functional collectives must keep their position relative to surrounding compute.
Moving `all_reduce` above the `relu` that reads the same buffer made Inductor
copy the buffer and reduce the copy, replacing an in-place collective with
copy-then-collective. Both `OpOverload` and `OpOverloadPacket` spellings are
checked, since Dynamo graphs hold packets and aten graphs hold overloads.

Nodes that bind unbacked symbols (`item()` / `_local_scalar_dense`) change the
order the ShapeEnv resolves symbol replacements when moved. On the
`symint_sum_loop` benchmark that doubled `SymNode.expr` -> `_find` work from
41,397 to 81,394 calls, showing up as a 27% compile-time instruction count
regression. This check runs before the `call_method` branch because Dynamo
emits `item()` as a `call_method`, which would otherwise report safe.

Barriers are segment-wide rather than pairwise, so each one trades determinism
for ordering safety across the whole graph; `_is_safe_to_reorder` now says so.
The two public entry points also gain the
`@compatibility(is_backward_compatible=False)` classification that
`test_fx.py::test_public_api_surface` requires for new public FX APIs.

Test Plan:

```
python test/dynamo/test_dicts.py -k canonical
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_autograd.py -k test_increment_version
python test/distributed/test_compute_comm_reordering.py TestComputeCommReorderingMultiProc.test_raise_comms
python test/distributed/test_inductor_compile_collectives.py
```

`test_canonical_graph_is_safe_to_reorder` gains a case per barrier, including
both collective dispatch forms and both `increment_version` aliases, and
asserts `item()` is safe until `unbacked_bindings` is set so the ordering
against the `call_method` branch is pinned.

This change was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98