### PR TITLE
[dynamo] preserve placeholder order and names during graph canonicalization

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -2151,9 +2151,13 @@ class DictTests(torch._dynamo.test_case.TestCase):
         self.assertNotEqual(structure1, structure2)
 
     def _get_graph_node_names(self, model, inp):
+        # Exclude placeholders: their order is the graph's positional calling
+        # convention and is preserved (not canonicalized), so it legitimately
+        # varies with dict iteration order. Canonicalization only makes the
+        # interior computation deterministic.
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
         torch.compile(model, backend=backend)(inp)
-        return [n.name for n in backend.graphs[0].graph.nodes]
+        return [n.name for n in backend.graphs[0].graph.nodes if n.op != "placeholder"]
 
     def test_dict_order_canonical_graph(self):
         class Model(torch.nn.Module):
@@ -2179,10 +2183,60 @@ class DictTests(torch._dynamo.test_case.TestCase):
         d1 = {"a": torch.randn(4, 8), "b": torch.randn(4, 8)}
         d2 = {"b": torch.randn(4, 8), "a": torch.randn(4, 8)}
 
+        # Different dict iteration orders feed inputs in different orders, so the
+        # placeholder layout differs, but canonicalization gives the interior
+        # computation identical node names.
         names1 = self._get_graph_node_names(model, d1)
         torch._dynamo.reset()
         names2 = self._get_graph_node_names(model, d2)
         self.assertEqual(names1, names2)
+
+    def test_canonical_graph_placeholders_are_out_of_scope(self):
+        # Pins the documented scope limit: canonicalization normalizes interior
+        # nodes only. Placeholders keep their trace-order position and names
+        # (that layout is the positional calling convention), so graphs that
+        # differ only in input discovery order are NOT identical overall.
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.deep = torch.nn.Sequential(
+                    torch.nn.Linear(8, 16),
+                    torch.nn.ReLU(),
+                    torch.nn.Linear(16, 16),
+                )
+                self.shallow = torch.nn.Linear(8, 16)
+
+            def forward(self, d):
+                results = []
+                for key, val in d.items():
+                    if key == "a":
+                        results.append(self.deep(val))
+                    else:
+                        results.append(self.shallow(val))
+                return torch.cat(results, dim=-1)
+
+        def placeholders(model, inp):
+            backend = torch._dynamo.testing.EagerAndRecordGraphs()
+            torch.compile(model, backend=backend)(inp)
+            graph = backend.graphs[0].graph
+            return [n.name for n in graph.nodes if n.op == "placeholder"]
+
+        model = Model()
+        d1 = {"a": torch.randn(4, 8), "b": torch.randn(4, 8)}
+        d2 = {"b": torch.randn(4, 8), "a": torch.randn(4, 8)}
+
+        ph1 = placeholders(model, d1)
+        torch._dynamo.reset()
+        ph2 = placeholders(model, d2)
+
+        # Names are preserved verbatim (never rewritten to canonical names), so
+        # they still carry their source-derived form.
+        self.assertTrue(all(n.startswith("l_") for n in ph1), ph1)
+        self.assertEqual(sorted(ph1), sorted(ph2))
+        # ...and order follows trace order, so the two layouts differ. If this
+        # ever starts passing, placeholders became order-canonical and the
+        # docstring in output_graph._canonicalize_graph must be updated.
+        self.assertNotEqual(ph1, ph2)
 
     def test_dict_order_canonical_graph_correctness(self):
         class Model(torch.nn.Module):
@@ -2344,19 +2398,28 @@ class DictTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(len(mul_after) >= 1)
 
     def test_canonical_graph_config_gating(self):
+        # With canonicalization off, differing dict orders yield differently
+        # named interior nodes; with it on, the interior names match. (Compares
+        # interior nodes only -- placeholder order is the calling convention and
+        # is preserved regardless.) The branches must be asymmetric (deep vs
+        # shallow) so the interior naming actually differs by trace order.
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.linear_a = torch.nn.Linear(8, 16)
-                self.linear_b = torch.nn.Linear(8, 16)
+                self.deep = torch.nn.Sequential(
+                    torch.nn.Linear(8, 16),
+                    torch.nn.ReLU(),
+                    torch.nn.Linear(16, 16),
+                )
+                self.shallow = torch.nn.Linear(8, 16)
 
             def forward(self, d):
                 results = []
                 for key, val in d.items():
                     if key == "a":
-                        results.append(self.linear_a(val))
+                        results.append(self.deep(val))
                     else:
-                        results.append(self.linear_b(val))
+                        results.append(self.shallow(val))
                 return torch.cat(results, dim=-1)
 
         model = Model()

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -545,33 +545,48 @@ class ExportMetaData:
     ] = dc_field(default_factory=dict)
 
 
-def _canonical_key(node: fx.Node, canonical_idx: dict[fx.Node, int]) -> object:
-    """Canonical heap key for Dynamo output graph nodes.
-
-    Placeholders are sorted by grapharg source name; all other ops delegate
-    to the shared ``_canonical_node_key``.
-    """
-    if node.op == "placeholder":
-        grapharg = node.meta.get("grapharg")
-        if grapharg is not None and grapharg.source is not None:
-            source_name = grapharg.source.name
-        else:
-            source_name = ""
-        return (0, source_name)
-    from torch.fx.passes.canonicalize import _canonical_node_key
-
-    return _canonical_node_key(node, canonical_idx)
-
-
 def _canonicalize_graph(graph: fx.Graph) -> None:
     """Canonicalize a Dynamo output graph's node order and names.
 
     Delegates to ``torch.fx.passes.canonicalize.canonicalize_graph`` with
     Dynamo-specific key generation and barrier detection.
-    """
-    from torch.fx.passes.canonicalize import _is_safe_to_reorder, canonicalize_graph
 
-    canonicalize_graph(graph, _canonical_key, _is_safe_to_reorder)
+    Placeholders keep their original insertion order and names: the placeholder
+    layout is the graph's positional calling convention, relied on by codegen,
+    AOTAutograd, and graph-break resume functions. Reordering them corrupts
+    those callers (e.g. a runtime-assert on a symint input receiving a tensor,
+    or a version-counter bump landing on the wrong local). Only interior
+    computation nodes are reordered/renamed. This mirrors the export path in
+    ``torch.export._trace._canonicalize_export_graph``.
+
+    Consequence - placeholder layout is deliberately OUT OF SCOPE of the
+    determinism guarantee. Two ranks that trace the same model but discover
+    inputs in different orders (rank-dependent dict/set iteration, differing
+    graph-break points) still get identical interior nodes but different
+    placeholder layouts, so callers must not assume whole-graph identity across
+    ranks (e.g. hashing the printed graph). Canonicalizing within the
+    symint/tensor placeholder partitions would tighten this, at the cost of
+    reordering ``graphargs``/``example_inputs`` coherently.
+    """
+    from torch.fx.passes.canonicalize import (
+        _canonical_node_key,
+        _is_safe_to_reorder,
+        canonicalize_graph,
+    )
+
+    placeholder_ord = itertools.count()
+
+    def _key(node: fx.Node, canonical_idx: dict[fx.Node, int]) -> object:
+        if node.op == "placeholder":
+            return (0, next(placeholder_ord))
+        return _canonical_node_key(node, canonical_idx)
+
+    canonicalize_graph(
+        graph,
+        _key,
+        _is_safe_to_reorder,
+        skip_rename_ops=frozenset({"placeholder"}),
+    )
 
 
 def get_builtins_dict(global_scope: Scope) -> dict[str, Any]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Placeholder layout is the graph's positional calling convention: codegen,
AOTAutograd and graph-break resume functions all pass inputs by position, and
`graphargs` / `example_inputs` are derived from graph node order. Canonicalizing
placeholders by grapharg source name reordered them across that contract, which
also interleaved symint and tensor placeholders (AOTAutograd expects symints
first). A graph whose inputs were `(symint, tensor)` could come back as
`(tensor, symint)`, so a positional call fed a Tensor where a Scalar was
required and `aten::_assert_scalar` rejected it.

Placeholders now keep their trace-order position (an insertion counter) and
their original names (`skip_rename_ops`), matching what
`torch.export._trace._canonicalize_export_graph` already does, so the two paths
no longer disagree. Only interior computation nodes are reordered and renamed.

The consequence is that placeholder layout is deliberately outside the
determinism guarantee: two ranks that trace the same model but discover inputs
in different orders get identical interior nodes and different placeholder
layouts, so callers must not assume whole-graph identity across ranks. That
limit is stated on `_canonicalize_graph` and in the config comment rather than
left implicit, and `test_canonical_graph_placeholders_are_out_of_scope` pins it
so the contract cannot drift silently. Tightening it later means canonicalizing
within the symint/tensor partitions and reordering `graphargs` coherently.

Test Plan:

```
python test/dynamo/test_dicts.py -k canonical
python test/test_dynamic_shapes.py -k test_user_check_input_shape_bound_preserved_in_aot_graph
python test/test_dynamic_shapes.py
python test/test_fx.py
```

`_get_graph_node_names` now compares interior nodes only, since placeholder
order legitimately varies with input discovery order;
`test_canonical_graph_config_gating` needed an asymmetric model because with
placeholders excluded a symmetric one no longer discriminates on/off.

This change was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98