### PR TITLE
[export] match the incoming node-naming scheme in _ExportPassBaseDeprecatedDoNotUse

### DIFF
--- a/torch/_export/pass_base.py
+++ b/torch/_export/pass_base.py
@@ -318,7 +318,16 @@ class _ExportPassBaseDeprecatedDoNotUse(PassBase):
 
         name = None
         if isinstance(target, torch._ops.OpOverload):
-            name = self.tracer.graph._target_to_str(target.overloadpacket.__name__)
+            # Match whichever naming scheme produced the incoming graph, so a
+            # no-op transform preserves node names. Export's canonical naming is
+            # overload-qualified (`add_tensor`) but is config-gated (see
+            # `_canonicalize_export_graph` in torch/export/_trace.py); with the
+            # config off the graph carries overloadpacket names (`add`), and
+            # re-deriving the other scheme would rename every node on every pass.
+            if torch._dynamo.config.canonicalize_output_graph_node_order:
+                name = self.tracer.graph._target_to_str(target)
+            else:
+                name = self.tracer.graph._target_to_str(target.overloadpacket.__name__)
 
         res_proxy = self.tracer.create_proxy(
             kind, target, args_proxy, kwargs_proxy, name=name


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

`_fx` derived new node names from `target.overloadpacket.__name__` (`add`), but
export's canonical naming is overload-qualified (`add_tensor`). When export
canonicalizes, a no-op transform therefore renamed every node it visited, which
is what `test_pass_infra.py::test_node_name_stability` asserts must not happen.

Deriving the overload-qualified name unconditionally is not the fix either:
export canonicalization is gated on
`torch._dynamo.config.canonicalize_output_graph_node_order` (see
`_canonicalize_export_graph`), so with the flag off the incoming graph carries
overloadpacket names and forcing the qualified form just inverts the
instability. The naming choice is therefore gated on the same config as the
scheme it has to match, so a no-op transform is name-preserving either way.

Note for downstream: with canonicalization on, `call_function` nodes produced by
subclasses of this pass base change name (`add` -> `add_tensor`,
`clone` -> `clone_default`). In-tree consumers regenerate the graph signature
from the new graph and do not key on names, but out-of-tree subclasses with
name-bearing goldens (e.g. ExecuTorch's `ExportPass`) will need to regenerate.

Test Plan:

```
python test/export/test_pass_infra.py
python test/export/test_passes.py
```

Verified under both flag states, since only one of them was previously covered:

```
python -c "
import torch, unittest, importlib.util
import torch._dynamo.config as dcfg
for canon in (True, False):
    dcfg.canonicalize_output_graph_node_order = canon
    spec = importlib.util.spec_from_file_location('t', 'test/export/test_pass_infra.py')
    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
    s = unittest.TestSuite(); s.addTest(m.TestPassInfra('test_node_name_stability'))
    print(canon, unittest.TextTestRunner(verbosity=0).run(s).wasSuccessful())
"
```

This change was authored with the assistance of an AI coding agent.