### PR TITLE
[dynamo] update goldens for canonical node names

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1648,9 +1648,10 @@ def forward(self, pred_1, x_1):
                 """\
 class <lambda>(torch.nn.Module):
     def forward(self, arg0_1: "f32[4, 5]", arg1_1: "i64[1]"):
+        clamp: "i64[1]" = torch.ops.aten.clamp.default(arg1_1, 0, 1);  arg1_1 = None
+
         clone: "f32[4, 5]" = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
 
-        clamp: "i64[1]" = torch.ops.aten.clamp.default(arg1_1, 0, 1);  arg1_1 = None
         auto_functionalized_subgraph_0 = self.auto_functionalized_subgraph_0
         auto_functionalized_subgraph_1 = self.auto_functionalized_subgraph_1
         _tree_spec_constant0 = self._tree_spec_constant0
@@ -3817,9 +3818,9 @@ class GraphModule(torch.nn.Module):
         scan = torch.ops.higher_order.scan(scan_combine_fn_0, [l_init_0_, l_init_1_], [flip], []);  scan_combine_fn_0 = l_init_0_ = l_init_1_ = flip = None
         getitem: "f32[1, 10, 2]" = scan[0]
         getitem_1: "f32[1, 10, 2]" = scan[1]
-        out: "f32[3, 1, 10, 2]" = scan[2];  scan = None
-        out_1: "f32[3, 1, 10, 2]" = out.flip([0]);  out = None
-        return (getitem, getitem_1, out_1)
+        getitem_2: "f32[3, 1, 10, 2]" = scan[2];  scan = None
+        flip_1: "f32[3, 1, 10, 2]" = getitem_2.flip([0]);  getitem_2 = None
+        return (getitem, getitem_1, flip_1)
 
     class scan_combine_fn_0(torch.nn.Module):
         def forward(self, child: "f32[1, 10, 2]", child_1: "f32[1, 10, 2]", child_2: "f32[10, 2]"):
@@ -4568,10 +4569,10 @@ def forward(self, L_init_ : torch.Tensor, L_xs_ : torch.Tensor):
     flip = torch.flip(l_xs_, [0]);  l_xs_ = None
     scan_combine_fn_0 = self.scan_combine_fn_0
     scan = torch.ops.higher_order.scan(scan_combine_fn_0, [l_init_], [flip], []);  scan_combine_fn_0 = l_init_ = flip = None
-    carry = scan[0]
-    out = scan[1];  scan = None
-    out_1 = out.flip([0]);  out = None
-    return (carry, out_1)""",
+    getitem = scan[0]
+    getitem_1 = scan[1];  scan = None
+    flip_1 = getitem_1.flip([0]);  getitem_1 = None
+    return (getitem, flip_1)""",
         )
 
     @requires_cuda
@@ -6590,11 +6591,11 @@ class TestControlFlowTraced(TestCase):
 def forward(self, L_inp_x_ : torch.Tensor, L_idx_ : torch.Tensor):
     l_inp_x_ = L_inp_x_
     l_idx_ = L_idx_
-    index = l_idx_.clamp(0, 2);  l_idx_ = None
+    clamp = l_idx_.clamp(0, 2);  l_idx_ = None
     switch_branch0_0 = self.switch_branch0_0
     switch_branch1_0 = self.switch_branch1_0
     switch_branch2_0 = self.switch_branch2_0
-    switch = torch.ops.higher_order.switch(index, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_,));  index = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = None
+    switch = torch.ops.higher_order.switch(clamp, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_,));  clamp = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = None
     getitem = switch[0];  switch = None
     return (getitem,)""",
         )
@@ -6663,11 +6664,11 @@ def forward(self, L_inp_x_ : torch.Tensor, L_idx_ : torch.Tensor, L_branch0_clos
     l_branch0_closure_0_cell_contents = L_branch0_closure_0_cell_contents
     l_branch1_closure_0_cell_contents = L_branch1_closure_0_cell_contents
     l_branch2_closure_0_cell_contents = L_branch2_closure_0_cell_contents
-    index = l_idx_.clamp(0, 2);  l_idx_ = None
+    clamp = l_idx_.clamp(0, 2);  l_idx_ = None
     switch_branch0_0 = self.switch_branch0_0
     switch_branch1_0 = self.switch_branch1_0
     switch_branch2_0 = self.switch_branch2_0
-    switch = torch.ops.higher_order.switch(index, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_, l_branch0_closure_0_cell_contents, l_branch1_closure_0_cell_contents, l_branch2_closure_0_cell_contents));  index = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = l_branch0_closure_0_cell_contents = l_branch1_closure_0_cell_contents = l_branch2_closure_0_cell_contents = None
+    switch = torch.ops.higher_order.switch(clamp, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_, l_branch0_closure_0_cell_contents, l_branch1_closure_0_cell_contents, l_branch2_closure_0_cell_contents));  clamp = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = l_branch0_closure_0_cell_contents = l_branch1_closure_0_cell_contents = l_branch2_closure_0_cell_contents = None
     getitem = switch[0];  switch = None
     return (getitem,)""",
         )
@@ -6739,11 +6740,11 @@ def forward(self, L_inp_x_ : torch.Tensor, L_idx_ : torch.Tensor, L_branch0_clos
     l_branch0_closure_0_cell_contents = L_branch0_closure_0_cell_contents
     l_branch0_closure_1_cell_contents = L_branch0_closure_1_cell_contents
     l_branch1_closure_2_cell_contents = L_branch1_closure_2_cell_contents
-    index = l_idx_.clamp(0, 2);  l_idx_ = None
+    clamp = l_idx_.clamp(0, 2);  l_idx_ = None
     switch_branch0_0 = self.switch_branch0_0
     switch_branch1_0 = self.switch_branch1_0
     switch_branch2_0 = self.switch_branch2_0
-    switch = torch.ops.higher_order.switch(index, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_, l_branch0_closure_0_cell_contents, l_branch0_closure_1_cell_contents, l_branch1_closure_2_cell_contents));  index = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = l_branch0_closure_0_cell_contents = l_branch0_closure_1_cell_contents = l_branch1_closure_2_cell_contents = None
+    switch = torch.ops.higher_order.switch(clamp, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_, l_branch0_closure_0_cell_contents, l_branch0_closure_1_cell_contents, l_branch1_closure_2_cell_contents));  clamp = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = l_branch0_closure_0_cell_contents = l_branch0_closure_1_cell_contents = l_branch1_closure_2_cell_contents = None
     getitem = switch[0];  switch = None
     return (getitem,)""",
         )
@@ -6912,10 +6913,10 @@ def forward(self, L_inp_x_ : torch.Tensor, L_idx_ : torch.Tensor, L_linear0_para
     l_linear0_parameters_bias_ = L_linear0_parameters_bias_
     l_linear1_parameters_weight_ = L_linear1_parameters_weight_
     l_linear1_parameters_bias_ = L_linear1_parameters_bias_
-    index = l_idx_.clamp(0, 1);  l_idx_ = None
+    clamp = l_idx_.clamp(0, 1);  l_idx_ = None
     switch_branch0_0 = self.switch_branch0_0
     switch_branch1_0 = self.switch_branch1_0
-    switch = torch.ops.higher_order.switch(index, [switch_branch0_0, switch_branch1_0], (l_inp_x_, l_linear0_parameters_bias_, l_linear0_parameters_weight_, l_linear1_parameters_bias_, l_linear1_parameters_weight_));  index = switch_branch0_0 = switch_branch1_0 = l_inp_x_ = l_linear0_parameters_bias_ = l_linear0_parameters_weight_ = l_linear1_parameters_bias_ = l_linear1_parameters_weight_ = None
+    switch = torch.ops.higher_order.switch(clamp, [switch_branch0_0, switch_branch1_0], (l_inp_x_, l_linear0_parameters_bias_, l_linear0_parameters_weight_, l_linear1_parameters_bias_, l_linear1_parameters_weight_));  clamp = switch_branch0_0 = switch_branch1_0 = l_inp_x_ = l_linear0_parameters_bias_ = l_linear0_parameters_weight_ = l_linear1_parameters_bias_ = l_linear1_parameters_weight_ = None
     getitem = switch[0];  switch = None
     return (getitem,)""",
         )
@@ -6968,12 +6969,12 @@ def forward(self, l_inp_x_, l_linear0_parameters_bias__branch0, l_linear0_parame
 def forward(self, L_pred_ : torch.Tensor, L_x_ : torch.Tensor):
     l_pred_ = L_pred_
     l_x_ = L_x_
-    cond_true_0 = self.cond_true_0
     cond_false_0 = self.cond_false_0
+    cond_true_0 = self.cond_true_0
     cond = torch.ops.higher_order.cond(l_pred_, cond_true_0, cond_false_0, (l_x_,));  l_pred_ = cond_true_0 = cond_false_0 = None
-    result = cond[0];  cond = None
-    grad_out = torch.ones_like(result)
-    grad = torch.autograd.grad(result, (l_x_,), grad_out);  result = l_x_ = grad_out = None
+    getitem = cond[0];  cond = None
+    ones_like = torch.ones_like(getitem)
+    grad = torch.autograd.grad(getitem, (l_x_,), ones_like);  getitem = l_x_ = ones_like = None
     getitem_1 = grad[0];  grad = None
     return (getitem_1,)""",
         )
@@ -7403,14 +7404,14 @@ def forward(self, L_it_ : torch.Tensor, L_pytree_input_0_0_ : torch.Tensor, L_py
     l_pytree_input_0_0_ = L_pytree_input_0_0_
     l_pytree_input_1_x_ = L_pytree_input_1_x_
     l_pytree_input_1_y_ = L_pytree_input_1_y_
-    cond_fn_0 = self.cond_fn_0
     body_fn_0 = self.body_fn_0
+    cond_fn_0 = self.cond_fn_0
     while_loop = torch.ops.higher_order.while_loop(cond_fn_0, body_fn_0, (l_it_, l_pytree_input_0_0_, l_pytree_input_1_x_, l_pytree_input_1_y_), ());  cond_fn_0 = body_fn_0 = l_it_ = l_pytree_input_0_0_ = l_pytree_input_1_x_ = l_pytree_input_1_y_ = None
     getitem = while_loop[0]
     getitem_1 = while_loop[1]
-    value = while_loop[2]
-    value_1 = while_loop[3];  while_loop = None
-    return (getitem, getitem_1, value, value_1)""",
+    getitem_2 = while_loop[2]
+    getitem_3 = while_loop[3];  while_loop = None
+    return (getitem, getitem_1, getitem_2, getitem_3)""",
             )
 
     def _wrap_with_functionalize(self, fn, func_type):
@@ -7610,24 +7611,24 @@ class GraphModule(torch.nn.Module):
         l_self_modules_linear_parameters_weight_ = L_self_modules_linear_parameters_weight_
         l_self_modules_linear_parameters_bias_ = L_self_modules_linear_parameters_bias_
 
-        cond_fn_0 = self.cond_fn_0
         body_fn_0 = self.body_fn_0
+        cond_fn_0 = self.cond_fn_0
         while_loop = torch.ops.higher_order.while_loop(cond_fn_0, body_fn_0, (l_iter_, l_x_), (l_self_buffers_dec_, l_self_modules_linear_parameters_bias_, l_self_modules_linear_parameters_weight_));  cond_fn_0 = body_fn_0 = l_iter_ = l_x_ = l_self_buffers_dec_ = l_self_modules_linear_parameters_bias_ = l_self_modules_linear_parameters_weight_ = None
         getitem: "i64[]" = while_loop[0]
         getitem_1: "f32[2, 2]" = while_loop[1];  while_loop = None
         return (getitem, getitem_1)
-
-    class cond_fn_0(torch.nn.Module):
-        def forward(self, child: "i64[]", child_1: "f32[2, 2]", l_self_buffers_dec__cond_fn: "i64[]", l_self_modules_linear_parameters_bias__body_fn: "f32[2]", l_self_modules_linear_parameters_weight__body_fn: "f32[2, 2]"):
-            sub: "i64[]" = child - l_self_buffers_dec__cond_fn;  child = l_self_buffers_dec__cond_fn = None
-            gt: "b8[]" = sub > 0;  sub = None
-            return gt
 
     class body_fn_0(torch.nn.Module):
         def forward(self, child_2: "i64[]", child_3: "f32[2, 2]", l_self_buffers_dec__cond_fn: "i64[]", l_self_modules_linear_parameters_bias__body_fn: "f32[2]", l_self_modules_linear_parameters_weight__body_fn: "f32[2, 2]"):
             child: "i64[]" = child_2 - 1;  child_2 = None
             child_4: "f32[2, 2]" = torch._C._nn.linear(child_3, l_self_modules_linear_parameters_weight__body_fn, l_self_modules_linear_parameters_bias__body_fn);  child_3 = l_self_modules_linear_parameters_weight__body_fn = l_self_modules_linear_parameters_bias__body_fn = None
             return (child, child_4)
+
+    class cond_fn_0(torch.nn.Module):
+        def forward(self, child: "i64[]", child_1: "f32[2, 2]", l_self_buffers_dec__cond_fn: "i64[]", l_self_modules_linear_parameters_bias__body_fn: "f32[2]", l_self_modules_linear_parameters_weight__body_fn: "f32[2, 2]"):
+            sub: "i64[]" = child - l_self_buffers_dec__cond_fn;  child = l_self_buffers_dec__cond_fn = None
+            gt: "b8[]" = sub > 0;  sub = None
+            return gt
 """,
         )
 
@@ -9808,8 +9809,8 @@ def forward(self, s97 : torch.SymInt, L_a_ : torch.Tensor, L_b_ : torch.Tensor):
     l_a_ = L_a_
     l_b_ = L_b_
     tensor = torch.tensor([True])
-    cond_true_0 = self.cond_true_0
     cond_false_0 = self.cond_false_0
+    cond_true_0 = self.cond_true_0
     cond = torch.ops.higher_order.cond(tensor, cond_true_0, cond_false_0, (l_a_, l_b_, s97));  tensor = cond_true_0 = cond_false_0 = l_a_ = l_b_ = s97 = None
     getitem = cond[0];  cond = None
     return (getitem,)""",
@@ -9988,9 +9989,9 @@ def forward(self, L_init_ : torch.Tensor, L_xs_ : torch.Tensor, L_add_closure_0_
     l_add_closure_0_cell_contents_1_0_ = L_add_closure_0_cell_contents_1_0_
     scan_combine_fn_0 = self.scan_combine_fn_0
     scan = torch.ops.higher_order.scan(scan_combine_fn_0, [l_init_], [l_xs_], [l_add_closure_0_cell_contents_0_param_, l_add_closure_0_cell_contents_1_0_]);  scan_combine_fn_0 = l_init_ = l_xs_ = l_add_closure_0_cell_contents_0_param_ = l_add_closure_0_cell_contents_1_0_ = None
-    carry = scan[0]
-    out = scan[1];  scan = None
-    return (carry, out)""",
+    getitem = scan[0]
+    getitem_1 = scan[1];  scan = None
+    return (getitem, getitem_1)""",
             )
         self.assertEqual(eager_out, exp_out)
         self.assertEqual(compiled_out, exp_out)
@@ -10266,44 +10267,44 @@ class GraphModule(torch.nn.Module):
 
         x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
         _guards_fn = self._guards_fn(x);  _guards_fn = None
-        sym_size_int_1: "Sym(s77)" = torch.ops.aten.sym_size.int(x, 0)
+        sym_size_int: "Sym(s77)" = torch.ops.aten.sym_size.int(x, 0)
 
-        while_loop_cond_graph_0 = self.while_loop_cond_graph_0
         while_loop_body_graph_0 = self.while_loop_body_graph_0
+        while_loop_cond_graph_0 = self.while_loop_cond_graph_0
         while_loop = torch.ops.higher_order.while_loop(while_loop_cond_graph_0, while_loop_body_graph_0, (0, x), ());  while_loop_cond_graph_0 = while_loop_body_graph_0 = x = None
-        getitem_2: "Sym(u1)" = while_loop[0]
-        ge: "Sym(u1 >= 1)" = getitem_2 >= 1
-        _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge, "Runtime assertion failed for expression u1 >= 1 on node 'ge'");  ge = _assert_scalar_default = None
-        gt_1: "Sym(u1 > 0)" = getitem_2 > 0
-        _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(gt_1, "Runtime assertion failed for expression 0 < u1 on node 'gt_1'");  gt_1 = _assert_scalar_default_1 = None
+        getitem: "Sym(u1)" = while_loop[0]
         getitem_1: "f32[s77, 3]" = while_loop[1];  while_loop = None
+        ge: "Sym(u1 >= 1)" = getitem >= 1
+        _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge, "Runtime assertion failed for expression u1 >= 1 on node 'ge'");  ge = _assert_scalar_default = None
+        gt: "Sym(u1 > 0)" = getitem > 0
+        _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(gt, "Runtime assertion failed for expression 0 < u1 on node 'gt_1'");  gt = _assert_scalar_default_1 = None
 
-        add: "Sym(u1 + 1)" = getitem_2 + 1
+        add: "Sym(u1 + 1)" = getitem + 1
 
-        add_1: "f32[s77, 3]" = torch.ops.aten.add.Tensor(getitem_1, getitem_2);  getitem_1 = None
+        add_tensor: "f32[s77, 3]" = torch.ops.aten.add.Tensor(getitem_1, getitem);  getitem_1 = None
 
-        lt: "Sym(u1 < s77)" = getitem_2 < sym_size_int_1;  sym_size_int_1 = None
+        lt: "Sym(u1 < s77)" = getitem < sym_size_int;  sym_size_int = None
 
-        mul: "Sym(2*u1)" = getitem_2 * 2;  getitem_2 = None
-        ones: "f32[2*u1]" = torch.ops.aten.ones.default([mul], device = device(type='cpu'), pin_memory = False);  mul = None
-        return pytree.tree_unflatten((add, add_1, lt, ones), self._out_spec)
-
-    class while_loop_cond_graph_0(torch.nn.Module):
-        def forward(self, it_1: "Sym(u0)", x_1: "f32[s77, 3]"):
-            sym_size_int_1: "Sym(s77)" = torch.ops.aten.sym_size.int(x_1, 0);  x_1 = None
-
-            lt: "Sym(u0 < s77)" = it_1 < sym_size_int_1;  it_1 = sym_size_int_1 = None
-            return lt
+        mul: "Sym(2*u1)" = getitem * 2;  getitem = None
+        ones_default: "f32[2*u1]" = torch.ops.aten.ones.default([mul], device = device(type='cpu'), pin_memory = False);  mul = None
+        return pytree.tree_unflatten((add, add_tensor, lt, ones_default), self._out_spec)
 
     class while_loop_body_graph_0(torch.nn.Module):
         def forward(self, it_1: "Sym(u0)", x_1: "f32[s77, 3]"):
-            clone: "f32[s77, 3]" = torch.ops.aten.clone.default(x_1);  x_1 = None
-            select: "f32[3]" = torch.ops.aten.select.int(clone, 0, it_1)
-            select_1: "f32[3]" = torch.ops.aten.select.int(clone, 0, it_1)
-            add: "f32[3]" = torch.ops.aten.add.Tensor(select_1, it_1);  select_1 = None
-            copy_: "f32[3]" = torch.ops.aten.copy_.default(select, add);  select = add = copy_ = None
-            add_1: "Sym(u0 + 1)" = it_1 + 1;  it_1 = None
-            return (add_1, clone)
+            clone_default: "f32[s77, 3]" = torch.ops.aten.clone.default(x_1);  x_1 = None
+            select_int: "f32[3]" = torch.ops.aten.select.int(clone_default, 0, it_1)
+            select_int_1: "f32[3]" = torch.ops.aten.select.int(clone_default, 0, it_1)
+            add_tensor: "f32[3]" = torch.ops.aten.add.Tensor(select_int_1, it_1);  select_int_1 = None
+            copy__default: "f32[3]" = torch.ops.aten.copy_.default(select_int, add_tensor);  select_int = add_tensor = copy__default = None
+            add: "Sym(u0 + 1)" = it_1 + 1;  it_1 = None
+            return (add, clone_default)
+
+    class while_loop_cond_graph_0(torch.nn.Module):
+        def forward(self, it_1: "Sym(u0)", x_1: "f32[s77, 3]"):
+            sym_size_int: "Sym(s77)" = torch.ops.aten.sym_size.int(x_1, 0);  x_1 = None
+
+            lt: "Sym(u0 < s77)" = it_1 < sym_size_int;  it_1 = sym_size_int = None
+            return lt
 """,
             )
 
@@ -10328,39 +10329,28 @@ class GraphModule(torch.nn.Module):
     def forward(self, s77: "Sym(s77)", s27: "Sym(s27)", L_x_: "f32[s77, s27]"):
         l_x_ = L_x_
 
-        cond_fn_0 = self.cond_fn_0
         body_fn_0 = self.body_fn_0
+        cond_fn_0 = self.cond_fn_0
         while_loop = torch.ops.higher_order.while_loop(cond_fn_0, body_fn_0, (0, l_x_), (s27, s77));  cond_fn_0 = body_fn_0 = l_x_ = s27 = None
-        getitem_4: "Sym(u2)" = while_loop[0]
-        ge: "Sym(u2 >= 1)" = getitem_4 >= 1
+        getitem: "Sym(u2)" = while_loop[0]
+        ge: "Sym(u2 >= 1)" = getitem >= 1
         _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge, "Runtime assertion failed for expression u2 >= 1 on node 'ge'");  ge = _assert_scalar_default = None
-        gt_1: "Sym(u2 > 0)" = getitem_4 > 0
-        _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(gt_1, "Runtime assertion failed for expression 0 < u2 on node 'gt_1'");  gt_1 = _assert_scalar_default_1 = None
-        out_x: "f32[s77, s27]" = while_loop[1];  while_loop = None
+        gt: "Sym(u2 > 0)" = getitem > 0
+        _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(gt, "Runtime assertion failed for expression 0 < u2 on node 'gt_1'");  gt = _assert_scalar_default_1 = None
+        getitem_1: "f32[s77, s27]" = while_loop[1];  while_loop = None
 
-        gt: "Sym(u2 > 0)" = getitem_4 > 0
-        _assert_scalar_default_2 = torch.ops.aten._assert_scalar.default(gt, "Runtime assertion failed for expression u2 > 0 on node 'gt'");  gt = _assert_scalar_default_2 = None
+        gt_1: "Sym(u2 > 0)" = getitem > 0
+        _assert_scalar_default_2 = torch.ops.aten._assert_scalar.default(gt_1, "Runtime assertion failed for expression u2 > 0 on node 'gt'");  gt_1 = _assert_scalar_default_2 = None
 
-        add: "Sym(u2 + 1)" = getitem_4 + 1
+        add: "Sym(u2 + 1)" = getitem + 1
 
-        add_1: "f32[s77, s27]" = getitem_4 + out_x;  out_x = None
+        add_1: "f32[s77, s27]" = getitem + getitem_1;  getitem_1 = None
 
-        lt: "Sym(u2 < s77)" = getitem_4 < s77;  s77 = None
+        lt: "Sym(u2 < s77)" = getitem < s77;  s77 = None
 
-        mul: "Sym(2*u2)" = getitem_4 * 2;  getitem_4 = None
+        mul: "Sym(2*u2)" = getitem * 2;  getitem = None
         ones: "f32[2*u2]" = torch.ones(mul);  mul = None
         return (add, add_1, lt, ones)
-
-    class cond_fn_0(torch.nn.Module):
-        def forward(self, unbacked_symint: "Sym(u0)", child: "f32[s77, s27]", s27: "Sym(s27)", s77: "Sym(s77)"):
-            s27_1 = s27
-            s77_1 = s77
-
-            sym_size_int: "Sym(s77)" = torch.ops.aten.sym_size.int(child, 0)
-
-            size = child.size();  child = size = None
-            lt: "Sym(u0 < s77)" = unbacked_symint < sym_size_int;  unbacked_symint = sym_size_int = None
-            return lt
 
     class body_fn_0(torch.nn.Module):
         def forward(self, unbacked_symint_0: "Sym(u1)", child_1: "f32[s77, s27]", s27: "Sym(s27)", s77: "Sym(s77)"):
@@ -10385,6 +10375,17 @@ class GraphModule(torch.nn.Module):
 
             add_1: "Sym(u1 + 1)" = unbacked_symint_0 + 1;  unbacked_symint_0 = None
             return (add_1, x_clone)
+
+    class cond_fn_0(torch.nn.Module):
+        def forward(self, unbacked_symint: "Sym(u0)", child: "f32[s77, s27]", s27: "Sym(s27)", s77: "Sym(s77)"):
+            s27_1 = s27
+            s77_1 = s77
+
+            sym_size_int: "Sym(s77)" = torch.ops.aten.sym_size.int(child, 0)
+
+            size = child.size();  child = size = None
+            lt: "Sym(u0 < s77)" = unbacked_symint < sym_size_int;  unbacked_symint = sym_size_int = None
+            return lt
 """,
             )
 
@@ -10408,56 +10409,70 @@ class GraphModule(torch.nn.Module):
         t, = fx_pytree.tree_flatten_spec(([t], {}), self._in_spec)
         _guards_fn = self._guards_fn(t);  _guards_fn = None
 
-        sum_1: "f32[]" = torch.ops.aten.sum.default(t)
-        _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(sum_1, dtype = torch.float32, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default = None
-        to: "i64[]" = torch.ops.aten.to.dtype(sum_1, torch.int64);  sum_1 = None
-        item: "Sym(u0)" = torch.ops.aten.item.default(to);  to = None
-        sin: "f32[2, 3]" = torch.ops.aten.sin.default(t)
+        sum_default: "f32[]" = torch.ops.aten.sum.default(t)
+        _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(sum_default, dtype = torch.float32, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default = None
+        to_dtype: "i64[]" = torch.ops.aten.to.dtype(sum_default, torch.int64);  sum_default = None
+        item_default: "Sym(u0)" = torch.ops.aten.item.default(to_dtype);  to_dtype = None
+        sin_default: "f32[2, 3]" = torch.ops.aten.sin.default(t)
 
-        while_loop_cond_graph_0 = self.while_loop_cond_graph_0
         while_loop_body_graph_0 = self.while_loop_body_graph_0
-        while_loop = torch.ops.higher_order.while_loop(while_loop_cond_graph_0, while_loop_body_graph_0, (2, 3, 1, 1, 1, 3, item, sin), ());  while_loop_cond_graph_0 = while_loop_body_graph_0 = item = sin = None
-        getitem_8: "Sym(u8)" = while_loop[0]
-        getitem_9: "Sym(u9)" = while_loop[1]
-        getitem_10: "Sym(u10)" = while_loop[2]
-        getitem_11: "Sym(u11)" = while_loop[3]
-        getitem_12: "Sym(u12)" = while_loop[4]
-        getitem_13: "Sym(u13)" = while_loop[5]
-        getitem_14: "Sym(u14)" = while_loop[6]
+        while_loop_cond_graph_0 = self.while_loop_cond_graph_0
+        while_loop = torch.ops.higher_order.while_loop(while_loop_cond_graph_0, while_loop_body_graph_0, (2, 3, 1, 1, 1, 3, item_default, sin_default), ());  while_loop_cond_graph_0 = while_loop_body_graph_0 = item_default = sin_default = None
+        getitem: "Sym(u8)" = while_loop[0]
+        getitem_1: "Sym(u9)" = while_loop[1]
+        getitem_2: "Sym(u10)" = while_loop[2]
+        getitem_3: "Sym(u11)" = while_loop[3]
+        getitem_4: "Sym(u12)" = while_loop[4]
+        getitem_5: "Sym(u13)" = while_loop[5]
+        getitem_6: "Sym(u14)" = while_loop[6]
         getitem_7: "f32[2, 3]" = while_loop[7];  while_loop = None
 
-        add: "Sym(u8 + 1)" = getitem_8 + 1
-        add_1: "Sym(u9 + 1)" = getitem_9 + 1
-        add_2: "Sym(u10 + 1)" = getitem_10 + 1
-        add_3: "Sym(u11 + 1)" = getitem_11 + 1
-        add_4: "Sym(u12 + 1)" = getitem_12 + 1
-        add_5: "Sym(u13 + 1)" = getitem_13 + 1
-        add_6: "Sym(u14 + 1)" = getitem_14 + 1
-        add_7: "f32[2, 3]" = torch.ops.aten.add.Tensor(getitem_7, 1)
+        add: "Sym(u8 + 1)" = getitem + 1
 
-        add_8: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_8);  getitem_8 = None
-        add_9: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_9);  getitem_9 = None
-        add_10: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_10);  getitem_10 = None
-        add_11: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_11);  getitem_11 = None
-        add_12: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_12);  getitem_12 = None
-        add_13: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_13);  getitem_13 = None
-        add_14: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_14);  getitem_14 = None
-        add_15: "f32[2, 3]" = torch.ops.aten.add.Tensor(getitem_7, t);  getitem_7 = t = None
-        return pytree.tree_unflatten((add, add_1, add_2, add_3, add_4, add_5, add_6, add_7, add_8, add_9, add_10, add_11, add_12, add_13, add_14, add_15), self._out_spec)
+        add_tensor: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem);  getitem = None
 
-    class while_loop_cond_graph_0(torch.nn.Module):
-        def forward(self, a_1: "Sym(u1)", b_1: "Sym(u2)", c1_1: "Sym(u3)", c2_1: "Sym(u4)", c3_1: "Sym(u5)", c0_1: "Sym(u6)", u0_1: "Sym(u7)", x_1: "f32[2, 3]"):
-            mul: "Sym(u3*u4)" = c1_1 * c2_1;  c1_1 = c2_1 = None
-            mul_1: "Sym(u3*u4*u5)" = mul * c3_1;  mul = c3_1 = None
-            mul_2: "Sym(u1*u2)" = a_1 * b_1;  a_1 = b_1 = None
-            lt: "Sym(u3*u4*u5 < u1*u2)" = mul_1 < mul_2;  mul_1 = mul_2 = None
-            return lt
+        add_1: "Sym(u9 + 1)" = getitem_1 + 1
+
+        add_tensor_1: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_1);  getitem_1 = None
+
+        add_2: "Sym(u10 + 1)" = getitem_2 + 1
+
+        add_tensor_2: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_2);  getitem_2 = None
+
+        add_3: "Sym(u11 + 1)" = getitem_3 + 1
+
+        add_tensor_3: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_3);  getitem_3 = None
+
+        add_4: "Sym(u12 + 1)" = getitem_4 + 1
+
+        add_tensor_4: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_4);  getitem_4 = None
+
+        add_5: "Sym(u13 + 1)" = getitem_5 + 1
+
+        add_tensor_5: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_5);  getitem_5 = None
+
+        add_6: "Sym(u14 + 1)" = getitem_6 + 1
+
+        add_tensor_6: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_6);  getitem_6 = None
+
+        add_tensor_7: "f32[2, 3]" = torch.ops.aten.add.Tensor(getitem_7, 1)
+
+        add_tensor_8: "f32[2, 3]" = torch.ops.aten.add.Tensor(getitem_7, t);  getitem_7 = t = None
+        return pytree.tree_unflatten((add, add_1, add_2, add_3, add_4, add_5, add_6, add_tensor_7, add_tensor, add_tensor_1, add_tensor_2, add_tensor_3, add_tensor_4, add_tensor_5, add_tensor_6, add_tensor_8), self._out_spec)
 
     class while_loop_body_graph_0(torch.nn.Module):
         def forward(self, a_1: "Sym(u1)", b_1: "Sym(u2)", c1_1: "Sym(u3)", c2_1: "Sym(u4)", c3_1: "Sym(u5)", c0_1: "Sym(u6)", u0_1: "Sym(u7)", x_1: "f32[2, 3]"):
             add: "Sym(u7 + 1)" = u0_1 + 1;  u0_1 = None
-            add_1: "f32[2, 3]" = torch.ops.aten.add.Tensor(x_1, 1);  x_1 = None
-            return (b_1, c1_1, c2_1, c3_1, a_1, 0, add, add_1)
+            add_tensor: "f32[2, 3]" = torch.ops.aten.add.Tensor(x_1, 1);  x_1 = None
+            return (b_1, c1_1, c2_1, c3_1, a_1, 0, add, add_tensor)
+
+    class while_loop_cond_graph_0(torch.nn.Module):
+        def forward(self, a_1: "Sym(u1)", b_1: "Sym(u2)", c1_1: "Sym(u3)", c2_1: "Sym(u4)", c3_1: "Sym(u5)", c0_1: "Sym(u6)", u0_1: "Sym(u7)", x_1: "f32[2, 3]"):
+            mul: "Sym(u3*u4)" = c1_1 * c2_1;  c1_1 = c2_1 = None
+            mul_1: "Sym(u1*u2)" = a_1 * b_1;  a_1 = b_1 = None
+            mul_2: "Sym(u3*u4*u5)" = mul * c3_1;  mul = c3_1 = None
+            lt: "Sym(u3*u4*u5 < u1*u2)" = mul_2 < mul_1;  mul_2 = mul_1 = None
+            return lt
 """,
             )
 
@@ -10489,36 +10504,63 @@ class GraphModule(torch.nn.Module):
         item: "Sym(u0)" = to.item();  to = None
         sin: "f32[2, 3]" = l_t_.sin()
 
-        cond_fn_0 = self.cond_fn_0
         body_fn_0 = self.body_fn_0
+        cond_fn_0 = self.cond_fn_0
         while_loop = torch.ops.higher_order.while_loop(cond_fn_0, body_fn_0, (2, 3, 1, 1, 1, 3, item, sin), ());  cond_fn_0 = body_fn_0 = item = sin = None
-        getitem_8: "Sym(u15)" = while_loop[0]
-        getitem_9: "Sym(u16)" = while_loop[1]
-        getitem_10: "Sym(u17)" = while_loop[2]
-        getitem_11: "Sym(u18)" = while_loop[3]
-        getitem_12: "Sym(u19)" = while_loop[4]
-        getitem_13: "Sym(u20)" = while_loop[5]
-        getitem_14: "Sym(u21)" = while_loop[6]
+        getitem: "Sym(u15)" = while_loop[0]
+
+        add: "Sym(u15 + 1)" = getitem + 1
+
+        add_1: "f32[2, 3]" = getitem + l_t_;  getitem = None
+
+        getitem_1: "Sym(u16)" = while_loop[1]
+
+        add_2: "Sym(u16 + 1)" = getitem_1 + 1
+
+        add_3: "f32[2, 3]" = getitem_1 + l_t_;  getitem_1 = None
+
+        getitem_2: "Sym(u17)" = while_loop[2]
+
+        add_4: "Sym(u17 + 1)" = getitem_2 + 1
+
+        add_5: "f32[2, 3]" = getitem_2 + l_t_;  getitem_2 = None
+
+        getitem_3: "Sym(u18)" = while_loop[3]
+
+        add_6: "Sym(u18 + 1)" = getitem_3 + 1
+
+        add_7: "f32[2, 3]" = getitem_3 + l_t_;  getitem_3 = None
+
+        getitem_4: "Sym(u19)" = while_loop[4]
+
+        add_8: "Sym(u19 + 1)" = getitem_4 + 1
+
+        add_9: "f32[2, 3]" = getitem_4 + l_t_;  getitem_4 = None
+
+        getitem_5: "Sym(u20)" = while_loop[5]
+
+        add_10: "Sym(u20 + 1)" = getitem_5 + 1
+
+        add_11: "f32[2, 3]" = getitem_5 + l_t_;  getitem_5 = None
+
+        getitem_6: "Sym(u21)" = while_loop[6]
+
+        add_12: "Sym(u21 + 1)" = getitem_6 + 1
+
+        add_13: "f32[2, 3]" = getitem_6 + l_t_;  getitem_6 = None
+
         getitem_7: "f32[2, 3]" = while_loop[7];  while_loop = None
 
-        add: "Sym(u15 + 1)" = getitem_8 + 1
-        add_1: "Sym(u16 + 1)" = getitem_9 + 1
-        add_2: "Sym(u17 + 1)" = getitem_10 + 1
-        add_3: "Sym(u18 + 1)" = getitem_11 + 1
-        add_4: "Sym(u19 + 1)" = getitem_12 + 1
-        add_5: "Sym(u20 + 1)" = getitem_13 + 1
-        add_6: "Sym(u21 + 1)" = getitem_14 + 1
-        add_7: "f32[2, 3]" = getitem_7 + 1
+        add_14: "f32[2, 3]" = getitem_7 + 1
 
-        add_8: "f32[2, 3]" = getitem_8 + l_t_;  getitem_8 = None
-        add_9: "f32[2, 3]" = getitem_9 + l_t_;  getitem_9 = None
-        add_10: "f32[2, 3]" = getitem_10 + l_t_;  getitem_10 = None
-        add_11: "f32[2, 3]" = getitem_11 + l_t_;  getitem_11 = None
-        add_12: "f32[2, 3]" = getitem_12 + l_t_;  getitem_12 = None
-        add_13: "f32[2, 3]" = getitem_13 + l_t_;  getitem_13 = None
-        add_14: "f32[2, 3]" = getitem_14 + l_t_;  getitem_14 = None
         add_15: "f32[2, 3]" = getitem_7 + l_t_;  getitem_7 = l_t_ = None
-        return (add, add_1, add_2, add_3, add_4, add_5, add_6, add_7, add_8, add_9, add_10, add_11, add_12, add_13, add_14, add_15)
+        return (add, add_2, add_4, add_6, add_8, add_10, add_12, add_14, add_1, add_3, add_5, add_7, add_9, add_11, add_13, add_15)
+
+    class body_fn_0(torch.nn.Module):
+        def forward(self, unbacked_symint_6: "Sym(u8)", unbacked_symint_7: "Sym(u9)", unbacked_symint_8: "Sym(u10)", unbacked_symint_9: "Sym(u11)", unbacked_symint_10: "Sym(u12)", unbacked_symint_11: "Sym(u13)", unbacked_symint_12: "Sym(u14)", child_1: "f32[2, 3]"):
+            add: "Sym(u14 + 1)" = unbacked_symint_12 + 1;  unbacked_symint_12 = None
+            child: "f32[2, 3]" = child_1 + 1;  child_1 = None
+            return (unbacked_symint_7, unbacked_symint_8, unbacked_symint_9, unbacked_symint_10, unbacked_symint_6, 0, add, child)
 
     class cond_fn_0(torch.nn.Module):
         def forward(self, unbacked_symint: "Sym(u1)", unbacked_symint_0: "Sym(u2)", unbacked_symint_1: "Sym(u3)", unbacked_symint_2: "Sym(u4)", unbacked_symint_3: "Sym(u5)", unbacked_symint_4: "Sym(u6)", unbacked_symint_5: "Sym(u7)", child: "f32[2, 3]"):
@@ -10527,12 +10569,6 @@ class GraphModule(torch.nn.Module):
             mul_2: "Sym(u1*u2)" = unbacked_symint * unbacked_symint_0;  unbacked_symint = unbacked_symint_0 = None
             lt: "Sym(u3*u4*u5 < u1*u2)" = mul_1 < mul_2;  mul_1 = mul_2 = None
             return lt
-
-    class body_fn_0(torch.nn.Module):
-        def forward(self, unbacked_symint_6: "Sym(u8)", unbacked_symint_7: "Sym(u9)", unbacked_symint_8: "Sym(u10)", unbacked_symint_9: "Sym(u11)", unbacked_symint_10: "Sym(u12)", unbacked_symint_11: "Sym(u13)", unbacked_symint_12: "Sym(u14)", child_1: "f32[2, 3]"):
-            add: "Sym(u14 + 1)" = unbacked_symint_12 + 1;  unbacked_symint_12 = None
-            child: "f32[2, 3]" = child_1 + 1;  child_1 = None
-            return (unbacked_symint_7, unbacked_symint_8, unbacked_symint_9, unbacked_symint_10, unbacked_symint_6, 0, add, child)
 """,
             )
 
@@ -10553,36 +10589,28 @@ class GraphModule(torch.nn.Module):
 
         x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
         _guards_fn = self._guards_fn(x);  _guards_fn = None
-        sym_size_int_1: "Sym(s6)" = torch.ops.aten.sym_size.int(x, 0)
+        sym_size_int: "Sym(s6)" = torch.ops.aten.sym_size.int(x, 0)
 
-        sin: "f32[s6, 3]" = torch.ops.aten.sin.default(x);  x = None
+        sin_default: "f32[s6, 3]" = torch.ops.aten.sin.default(x);  x = None
 
-        while_loop_cond_graph_0 = self.while_loop_cond_graph_0
         while_loop_body_graph_0 = self.while_loop_body_graph_0
-        while_loop = torch.ops.higher_order.while_loop(while_loop_cond_graph_0, while_loop_body_graph_0, (sym_size_int_1, 3, 2, 2, 3, sin), ());  while_loop_cond_graph_0 = while_loop_body_graph_0 = sym_size_int_1 = sin = None
-        getitem_6: "Sym(u10)" = while_loop[0]
-        getitem_7: "Sym(u11)" = while_loop[1]
-        getitem_8: "Sym(u12)" = while_loop[2]
-        getitem_9: "Sym(u13)" = while_loop[3]
-        getitem_10: "Sym(u14)" = while_loop[4]
+        while_loop_cond_graph_0 = self.while_loop_cond_graph_0
+        while_loop = torch.ops.higher_order.while_loop(while_loop_cond_graph_0, while_loop_body_graph_0, (sym_size_int, 3, 2, 2, 3, sin_default), ());  while_loop_cond_graph_0 = while_loop_body_graph_0 = sym_size_int = sin_default = None
+        getitem: "Sym(u10)" = while_loop[0]
+        getitem_1: "Sym(u11)" = while_loop[1]
+        getitem_2: "Sym(u12)" = while_loop[2]
+        getitem_3: "Sym(u13)" = while_loop[3]
+        getitem_4: "Sym(u14)" = while_loop[4]
         getitem_5: "f32[s6, 3]" = while_loop[5];  while_loop = None
 
-        add: "Sym(u12 + 1)" = getitem_8 + 1
-        add_1: "Sym(u13 + 1)" = getitem_9 + 1
-        add_2: "Sym(u14 + 1)" = getitem_10 + 1
+        add: "Sym(u12 + 1)" = getitem_2 + 1
+        add_1: "Sym(u13 + 1)" = getitem_3 + 1
+        add_2: "Sym(u14 + 1)" = getitem_4 + 1
 
-        add_3: "f32[s6, 3]" = torch.ops.aten.add.Tensor(getitem_5, getitem_8);  getitem_8 = None
-        add_4: "f32[s6, 3]" = torch.ops.aten.add.Tensor(getitem_5, getitem_9);  getitem_9 = None
-        add_5: "f32[s6, 3]" = torch.ops.aten.add.Tensor(getitem_5, getitem_10);  getitem_10 = None
-        return pytree.tree_unflatten((getitem_6, getitem_7, add, add_1, add_2, add_3, add_4, add_5, getitem_5), self._out_spec)
-
-    class while_loop_cond_graph_0(torch.nn.Module):
-        def forward(self, arg0_1: "Sym(u15)", arg1_1: "Sym(u16)", arg2_1: "Sym(u17)", arg3_1: "Sym(u18)", arg4_1: "Sym(u19)", arg5_1: "f32[s6, 3]"):
-            mul: "Sym(u17*u18)" = arg2_1 * arg3_1;  arg2_1 = arg3_1 = None
-            mul_1: "Sym(u17*u18*u19)" = mul * arg4_1;  mul = arg4_1 = None
-            mul_2: "Sym(u15*u16)" = arg0_1 * arg1_1;  arg0_1 = arg1_1 = None
-            lt: "Sym(u17*u18*u19 < u15*u16)" = mul_1 < mul_2;  mul_1 = mul_2 = None
-            return lt
+        add_tensor: "f32[s6, 3]" = torch.ops.aten.add.Tensor(getitem_5, getitem_2);  getitem_2 = None
+        add_tensor_1: "f32[s6, 3]" = torch.ops.aten.add.Tensor(getitem_5, getitem_3);  getitem_3 = None
+        add_tensor_2: "f32[s6, 3]" = torch.ops.aten.add.Tensor(getitem_5, getitem_4);  getitem_4 = None
+        return pytree.tree_unflatten((getitem, getitem_1, add, add_1, add_2, add_tensor, add_tensor_1, add_tensor_2, getitem_5), self._out_spec)
 
     class while_loop_body_graph_0(torch.nn.Module):
         def forward(self, arg0_1: "Sym(u15)", arg1_1: "Sym(u16)", arg2_1: "Sym(u17)", arg3_1: "Sym(u18)", arg4_1: "Sym(u19)", arg5_1: "f32[s6, 3]"):
@@ -10593,8 +10621,16 @@ class GraphModule(torch.nn.Module):
             add_3: "Sym(u18 + 1)" = arg3_1 + 1;  arg3_1 = None
             add_4: "Sym(u19 + 1)" = arg4_1 + 1;  arg4_1 = None
 
-            add_5: "f32[s6, 3]" = torch.ops.aten.add.Tensor(arg5_1, 1);  arg5_1 = None
-            return (add, add_1, add_2, add_3, add_4, add_5)
+            add_tensor: "f32[s6, 3]" = torch.ops.aten.add.Tensor(arg5_1, 1);  arg5_1 = None
+            return (add, add_1, add_2, add_3, add_4, add_tensor)
+
+    class while_loop_cond_graph_0(torch.nn.Module):
+        def forward(self, arg0_1: "Sym(u15)", arg1_1: "Sym(u16)", arg2_1: "Sym(u17)", arg3_1: "Sym(u18)", arg4_1: "Sym(u19)", arg5_1: "f32[s6, 3]"):
+            mul: "Sym(u17*u18)" = arg2_1 * arg3_1;  arg2_1 = arg3_1 = None
+            mul_1: "Sym(u15*u16)" = arg0_1 * arg1_1;  arg0_1 = arg1_1 = None
+            mul_2: "Sym(u17*u18*u19)" = mul * arg4_1;  mul = arg4_1 = None
+            lt: "Sym(u17*u18*u19 < u15*u16)" = mul_2 < mul_1;  mul_2 = mul_1 = None
+            return lt
 """,
             )
 
@@ -10619,37 +10655,31 @@ class GraphModule(torch.nn.Module):
     def forward(self, s77: "Sym(s77)", s27: "Sym(s27)", L_x_: "f32[s77, s27]"):
         l_x_ = L_x_
 
-        child: "f32[s77, s27]" = l_x_.sin();  l_x_ = None
+        sin: "f32[s77, s27]" = l_x_.sin();  l_x_ = None
 
-        cond_fn_0 = self.cond_fn_0
         body_fn_0 = self.body_fn_0
-        while_loop = torch.ops.higher_order.while_loop(cond_fn_0, body_fn_0, (s77, s27, 2, 2, 3, child), (s27, s77));  cond_fn_0 = body_fn_0 = s77 = s27 = child = None
-        getitem_10: "Sym(u10)" = while_loop[0]
-        getitem_11: "Sym(u11)" = while_loop[1]
-        getitem_12: "Sym(u12)" = while_loop[2]
-        getitem_13: "Sym(u13)" = while_loop[3]
-        getitem_14: "Sym(u14)" = while_loop[4]
-        out_x: "f32[s77, s27]" = while_loop[5];  while_loop = None
+        cond_fn_0 = self.cond_fn_0
+        while_loop = torch.ops.higher_order.while_loop(cond_fn_0, body_fn_0, (s77, s27, 2, 2, 3, sin), (s27, s77));  cond_fn_0 = body_fn_0 = s77 = s27 = sin = None
+        getitem: "Sym(u10)" = while_loop[0]
+        getitem_1: "Sym(u11)" = while_loop[1]
+        getitem_2: "Sym(u12)" = while_loop[2]
 
-        add: "Sym(u12 + 1)" = getitem_12 + 1
-        add_1: "Sym(u13 + 1)" = getitem_13 + 1
-        add_2: "Sym(u14 + 1)" = getitem_14 + 1
+        add: "Sym(u12 + 1)" = getitem_2 + 1
 
-        add_3: "f32[s77, s27]" = getitem_12 + out_x;  getitem_12 = None
-        add_4: "f32[s77, s27]" = getitem_13 + out_x;  getitem_13 = None
-        add_5: "f32[s77, s27]" = getitem_14 + out_x;  getitem_14 = None
-        return (getitem_10, getitem_11, add, add_1, add_2, add_3, add_4, add_5, out_x)
+        getitem_3: "Sym(u13)" = while_loop[3]
 
-    class cond_fn_0(torch.nn.Module):
-        def forward(self, unbacked_symint: "Sym(u0)", unbacked_symint_0: "Sym(u1)", unbacked_symint_1: "Sym(u2)", unbacked_symint_2: "Sym(u3)", unbacked_symint_3: "Sym(u4)", child_1: "f32[s77, s27]", s27: "Sym(s27)", s77: "Sym(s77)"):
-            s27_1 = s27
-            s77_1 = s77
+        add_1: "Sym(u13 + 1)" = getitem_3 + 1
 
-            mul: "Sym(u2*u3)" = unbacked_symint_1 * unbacked_symint_2;  unbacked_symint_1 = unbacked_symint_2 = None
-            mul_1: "Sym(u2*u3*u4)" = mul * unbacked_symint_3;  mul = unbacked_symint_3 = None
-            mul_2: "Sym(u0*u1)" = unbacked_symint * unbacked_symint_0;  unbacked_symint = unbacked_symint_0 = None
-            lt: "Sym(u2*u3*u4 < u0*u1)" = mul_1 < mul_2;  mul_1 = mul_2 = None
-            return lt
+        getitem_4: "Sym(u14)" = while_loop[4]
+
+        add_2: "Sym(u14 + 1)" = getitem_4 + 1
+
+        getitem_5: "f32[s77, s27]" = while_loop[5];  while_loop = None
+
+        add_3: "f32[s77, s27]" = getitem_2 + getitem_5;  getitem_2 = None
+        add_4: "f32[s77, s27]" = getitem_3 + getitem_5;  getitem_3 = None
+        add_5: "f32[s77, s27]" = getitem_4 + getitem_5;  getitem_4 = None
+        return (getitem, getitem_1, add, add_1, add_2, add_3, add_4, add_5, getitem_5)
 
     class body_fn_0(torch.nn.Module):
         def forward(self, unbacked_symint_4: "Sym(u5)", unbacked_symint_5: "Sym(u6)", unbacked_symint_6: "Sym(u7)", unbacked_symint_7: "Sym(u8)", unbacked_symint_8: "Sym(u9)", child_2: "f32[s77, s27]", s27: "Sym(s27)", s77: "Sym(s77)"):
@@ -10665,6 +10695,17 @@ class GraphModule(torch.nn.Module):
 
             child: "f32[s77, s27]" = child_2 + 1;  child_2 = None
             return (add, add_1, add_2, add_3, add_4, child)
+
+    class cond_fn_0(torch.nn.Module):
+        def forward(self, unbacked_symint: "Sym(u0)", unbacked_symint_0: "Sym(u1)", unbacked_symint_1: "Sym(u2)", unbacked_symint_2: "Sym(u3)", unbacked_symint_3: "Sym(u4)", child_1: "f32[s77, s27]", s27: "Sym(s27)", s77: "Sym(s77)"):
+            s27_1 = s27
+            s77_1 = s77
+
+            mul: "Sym(u2*u3)" = unbacked_symint_1 * unbacked_symint_2;  unbacked_symint_1 = unbacked_symint_2 = None
+            mul_1: "Sym(u2*u3*u4)" = mul * unbacked_symint_3;  mul = unbacked_symint_3 = None
+            mul_2: "Sym(u0*u1)" = unbacked_symint * unbacked_symint_0;  unbacked_symint = unbacked_symint_0 = None
+            lt: "Sym(u2*u3*u4 < u0*u1)" = mul_1 < mul_2;  mul_1 = mul_2 = None
+            return lt
 """,
             )
 
@@ -10761,6 +10802,10 @@ class GraphModule(torch.nn.Module):
             1,
         )
         if not TEST_WITH_CROSSREF:
+            # ignore_empty_lines: the AOT partitioner nondeterministically
+            # annotates recomputed backward nodes with "# Backward of forward
+            # node" source comments; normalize_gm strips the comment but leaves
+            # an orphan blank line, which would make this comparison flaky.
             self.assertExpectedInline(
                 normalize_gm(backend.fw_graphs[0].print_readable(print_output=False)),
                 """\
@@ -10771,18 +10816,15 @@ class GraphModule(torch.nn.Module):
         while_loop_stack_output = torch.ops.higher_order.while_loop_stack_output(while_loop_cond_graph_0, while_loop_body_graph_0, (primals_1,), (primals_3, primals_2));  while_loop_cond_graph_0 = while_loop_body_graph_0 = None
         getitem: "f32[u2, 3, 3]" = while_loop_stack_output[0];  while_loop_stack_output = None
         select: "f32[3, 3]" = torch.ops.aten.select.int(getitem, 0, -1)
-
         unsqueeze: "f32[1, 3, 3]" = torch.ops.aten.unsqueeze.default(primals_1, 0);  primals_1 = None
         slice_1: "f32[u2 - 1, 3, 3]" = torch.ops.aten.slice.Tensor(getitem, 0, 0, -1);  getitem = None
         cat: "f32[u2, 3, 3]" = torch.ops.aten.cat.default([unsqueeze, slice_1]);  unsqueeze = slice_1 = None
         return (select, primals_2, primals_3, cat)
-
     class while_loop_cond_graph_0(torch.nn.Module):
         def forward(self, arg0_1: "f32[3, 3]", arg1_1: "f32[3]", arg2_1: "f32[3, 3]"):
             sum_1: "f32[]" = torch.ops.aten.sum.default(arg0_1);  arg0_1 = None
             lt: "b8[]" = torch.ops.aten.lt.Scalar(sum_1, 2);  sum_1 = None
             return lt
-
     class while_loop_body_graph_0(torch.nn.Module):
         def forward(self, arg0_1: "f32[3, 3]", arg1_1: "f32[3]", arg2_1: "f32[3, 3]"):
             mul: "f32[3, 3]" = torch.ops.aten.mul.Tensor(arg0_1, arg0_1)
@@ -10790,8 +10832,8 @@ class GraphModule(torch.nn.Module):
             t: "f32[3, 3]" = torch.ops.aten.t.default(arg2_1);  arg2_1 = None
             addmm: "f32[3, 3]" = torch.ops.aten.addmm.default(arg1_1, arg0_1, t);  arg1_1 = arg0_1 = t = None
             add_1: "f32[3, 3]" = torch.ops.aten.add.Tensor(add, addmm);  add = addmm = None
-            return (add_1,)
-""",
+            return (add_1,)""",
+                ignore_empty_lines=True,
             )
 
             self.assertExpectedInline(
@@ -10810,18 +10852,14 @@ class GraphModule(torch.nn.Module):
         getitem_3: "f32[3]" = while_loop[2]
         getitem_4: "f32[3, 3]" = while_loop[3];  while_loop = None
         return (getitem_2, getitem_4, getitem_3)
-
     class while_loop_cond_graph_1(torch.nn.Module):
         def forward(self, arg0_1: "i64[]", arg1_1: "f32[3, 3]", arg2_1: "f32[3]", arg3_1: "f32[3, 3]", arg4_1: "f32[u2, 3, 3]", arg5_1: "f32[3]", arg6_1: "f32[3, 3]"):
             sym_size_int_1: "Sym(u2)" = torch.ops.aten.sym_size.int(arg4_1, 0);  arg4_1 = None
-
             lt: "b8[]" = torch.ops.aten.lt.Scalar(arg0_1, sym_size_int_1);  arg0_1 = sym_size_int_1 = None
             return lt
-
     class while_loop_body_graph_1(torch.nn.Module):
         def forward(self, arg0_1: "i64[]", arg1_1: "f32[3, 3]", arg2_1: "f32[3]", arg3_1: "f32[3, 3]", arg4_1: "f32[u2, 3, 3]", arg5_1: "f32[3]", arg6_1: "f32[3, 3]"):
             sym_size_int_1: "Sym(u2)" = torch.ops.aten.sym_size.int(arg4_1, 0)
-
             rsub: "i64[]" = torch.ops.aten.rsub.Scalar(arg0_1, sym_size_int_1);  sym_size_int_1 = None
             sub_1: "i64[]" = torch.ops.aten.sub.Tensor(rsub, 1);  rsub = None
             _local_scalar_dense: "Sym(u7)" = torch.ops.aten._local_scalar_dense.default(sub_1);  sub_1 = None
@@ -10842,8 +10880,8 @@ class GraphModule(torch.nn.Module):
             add_9: "i64[]" = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
             add_10: "f32[3]" = torch.ops.aten.add.Tensor(view, arg2_1);  view = arg2_1 = None
             add_11: "f32[3, 3]" = torch.ops.aten.add.Tensor(t_4, arg3_1);  t_4 = arg3_1 = None
-            return (add_9, add_8, add_10, add_11)
-""",
+            return (add_9, add_8, add_10, add_11)""",
+                ignore_empty_lines=True,
             )
 
     def test_input_output_alias(self):
@@ -10996,27 +11034,27 @@ class GraphModule(torch.nn.Module):
         a, b1, b2, c, = fx_pytree.tree_flatten_spec(([a, b1, b2, c], {}), self._in_spec)
         _guards_fn = self._guards_fn(a, b1, b2, c);  _guards_fn = None
 
-        true_graph_0 = self.true_graph_0
         false_graph_0 = self.false_graph_0
+        true_graph_0 = self.true_graph_0
         cond = torch.ops.higher_order.cond(a, true_graph_0, false_graph_0, (c, b1, b2));  a = true_graph_0 = false_graph_0 = c = b1 = b2 = None
         getitem: "f32[10]" = cond[0];  cond = None
 
-        mul: "f32[10]" = torch.ops.aten.mul.Tensor(getitem, 2);  getitem = None
-        return pytree.tree_unflatten((mul,), self._out_spec)
-
-    class true_graph_0(torch.nn.Module):
-        def forward(self, c: "f32[10]", b1: "i64[1]", b2: "i64[1]"):
-            item: "Sym(u0)" = torch.ops.aten.item.default(b1);  b1 = None
-
-            mul: "f32[10]" = torch.ops.aten.mul.Tensor(c, item);  c = item = None
-            return (mul,)
+        mul_tensor: "f32[10]" = torch.ops.aten.mul.Tensor(getitem, 2);  getitem = None
+        return pytree.tree_unflatten((mul_tensor,), self._out_spec)
 
     class false_graph_0(torch.nn.Module):
         def forward(self, c: "f32[10]", b1: "i64[1]", b2: "i64[1]"):
-            item: "Sym(u1)" = torch.ops.aten.item.default(b2);  b2 = None
+            item_default: "Sym(u1)" = torch.ops.aten.item.default(b2);  b2 = None
 
-            mul: "f32[10]" = torch.ops.aten.mul.Tensor(c, item);  c = item = None
-            return (mul,)
+            mul_tensor: "f32[10]" = torch.ops.aten.mul.Tensor(c, item_default);  c = item_default = None
+            return (mul_tensor,)
+
+    class true_graph_0(torch.nn.Module):
+        def forward(self, c: "f32[10]", b1: "i64[1]", b2: "i64[1]"):
+            item_default: "Sym(u0)" = torch.ops.aten.item.default(b1);  b1 = None
+
+            mul_tensor: "f32[10]" = torch.ops.aten.mul.Tensor(c, item_default);  c = item_default = None
+            return (mul_tensor,)
 """,
         )
 
@@ -11079,28 +11117,28 @@ class GraphModule(torch.nn.Module):
 
         x, y, z, = fx_pytree.tree_flatten_spec(([x, y, z], {}), self._in_spec)
         _guards_fn = self._guards_fn(x, y, z);  _guards_fn = None
-        sym_size_int_4: "Sym(s17)" = torch.ops.aten.sym_size.int(y, 0);  y = None
-        sym_size_int_5: "Sym(s68)" = torch.ops.aten.sym_size.int(z, 0)
+        sym_size_int: "Sym(s17)" = torch.ops.aten.sym_size.int(y, 0);  y = None
+        sym_size_int_1: "Sym(s68)" = torch.ops.aten.sym_size.int(z, 0)
 
-        gt: "Sym(s68 > 5)" = sym_size_int_5 > 5
+        gt: "Sym(s68 > 5)" = sym_size_int_1 > 5
 
-        true_graph_0 = self.true_graph_0
         false_graph_0 = self.false_graph_0
-        cond = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, (x, sym_size_int_4, sym_size_int_5, z));  gt = true_graph_0 = false_graph_0 = x = sym_size_int_4 = sym_size_int_5 = z = None
+        true_graph_0 = self.true_graph_0
+        cond = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, (x, sym_size_int, sym_size_int_1, z));  gt = true_graph_0 = false_graph_0 = x = sym_size_int = sym_size_int_1 = z = None
         getitem: "f32[s68, 3]" = cond[0];  cond = None
         return pytree.tree_unflatten((getitem,), self._out_spec)
 
-    class true_graph_0(torch.nn.Module):
-        def forward(self, x: "f32[s68, 3]", sym_size_int_4: "Sym(s17)", sym_size_int_5: "Sym(s68)", z: "f32[s68, 3]"):
-            add: "f32[s68, 3]" = torch.ops.aten.add.Tensor(x, sym_size_int_4);  x = sym_size_int_4 = None
-            return (add,)
-
     class false_graph_0(torch.nn.Module):
         def forward(self, x: "f32[s68, 3]", sym_size_int_4: "Sym(s17)", sym_size_int_5: "Sym(s68)", z: "f32[s68, 3]"):
-            mul: "f32[s68, 3]" = torch.ops.aten.mul.Tensor(z, sym_size_int_5);  z = sym_size_int_5 = None
+            mul_tensor: "f32[s68, 3]" = torch.ops.aten.mul.Tensor(z, sym_size_int_5);  z = sym_size_int_5 = None
 
-            add: "f32[s68, 3]" = torch.ops.aten.add.Tensor(x, mul);  x = mul = None
-            return (add,)
+            add_tensor: "f32[s68, 3]" = torch.ops.aten.add.Tensor(x, mul_tensor);  x = mul_tensor = None
+            return (add_tensor,)
+
+    class true_graph_0(torch.nn.Module):
+        def forward(self, x: "f32[s68, 3]", sym_size_int_4: "Sym(s17)", sym_size_int_5: "Sym(s68)", z: "f32[s68, 3]"):
+            add_tensor: "f32[s68, 3]" = torch.ops.aten.add.Tensor(x, sym_size_int_4);  x = sym_size_int_4 = None
+            return (add_tensor,)
 """,
         )
 
@@ -11267,28 +11305,18 @@ class GraphModule(torch.nn.Module):
 
         sum_1: "f32[]" = l_x_.sum()
         gt: "b8[]" = sum_1 > 0;  sum_1 = None
-        cond_true_0 = self.cond_true_0
         cond_false_0 = self.cond_false_0
+        cond_true_0 = self.cond_true_0
         cond = torch.ops.higher_order.cond(gt, cond_true_0, cond_false_0, (l_x_, s94, s17, s17, l_z_));  gt = cond_true_0 = cond_false_0 = l_x_ = s94 = s17 = l_z_ = None
-        getitem_5: "f32[u0, s94]" = cond[0]
-        sym_size_int: "Sym(u0)" = torch.ops.aten.sym_size.int(getitem_5, 0);  getitem_5 = None
+        getitem: "f32[u0, s94]" = cond[0]
+        sym_size_int: "Sym(u0)" = torch.ops.aten.sym_size.int(getitem, 0);  getitem = None
         ge: "Sym(u0 >= 0)" = sym_size_int >= 0;  sym_size_int = None
         _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge, "Runtime assertion failed for expression u0 >= 0 on node 'ge'");  ge = _assert_scalar_default = None
-        ret: "f32[u0, s94]" = cond[0];  cond = None
+        getitem_1: "f32[u0, s94]" = cond[0];  cond = None
 
         sum_2: "f32[]" = l_y_.sum();  l_y_ = None
-        sub: "f32[u0, s94]" = sum_2 - ret;  sum_2 = ret = None
+        sub: "f32[u0, s94]" = sum_2 - getitem_1;  sum_2 = getitem_1 = None
         return (sub,)
-
-    class cond_true_0(torch.nn.Module):
-        def forward(self, l_x_: "f32[s17, s94]", s94: "Sym(s94)", s17_true_branch: "Sym(s17)", getitem_2_false_branch: "Sym(s17)", l_z__false_branch: "f32[s17, s94]"):
-            l_x__1 = l_x_
-            s94_1 = s94
-
-            add: "f32[s17, s94]" = l_x__1 + s17_true_branch;  l_x__1 = s17_true_branch = None
-            getitem: "f32[s17 - 2, s94]" = add[slice(2, None, None)];  add = None
-            clone: "f32[s17 - 2, s94]" = getitem.clone();  getitem = None
-            return (clone,)
 
     class cond_false_0(torch.nn.Module):
         def forward(self, l_x_: "f32[s17, s94]", s94: "Sym(s94)", s17_true_branch: "Sym(s17)", getitem_2_false_branch: "Sym(s17)", l_z__false_branch: "f32[s17, s94]"):
@@ -11299,6 +11327,16 @@ class GraphModule(torch.nn.Module):
             add: "f32[s17, s94]" = l_x__1 + mul;  l_x__1 = mul = None
             getitem: "f32[2, s94]" = add[slice(None, 2, None)];  add = None
             clone: "f32[2, s94]" = getitem.clone();  getitem = None
+            return (clone,)
+
+    class cond_true_0(torch.nn.Module):
+        def forward(self, l_x_: "f32[s17, s94]", s94: "Sym(s94)", s17_true_branch: "Sym(s17)", getitem_2_false_branch: "Sym(s17)", l_z__false_branch: "f32[s17, s94]"):
+            l_x__1 = l_x_
+            s94_1 = s94
+
+            add: "f32[s17, s94]" = l_x__1 + s17_true_branch;  l_x__1 = s17_true_branch = None
+            getitem: "f32[s17 - 2, s94]" = add[slice(2, None, None)];  add = None
+            clone: "f32[s17 - 2, s94]" = getitem.clone();  getitem = None
             return (clone,)
 """,
             )

--- a/test/fx/test_source_matcher_utils.py
+++ b/test/fx/test_source_matcher_utils.py
@@ -480,7 +480,7 @@ class TestSourceMatcher(JitTestCase):
         self.assertEqual(len(module_partitions), 1)
         self.assertEqual(len(module_partitions[k]), 1)
         self.assertEqual(len(module_partitions[k][0].output_nodes), 1)
-        self.assertEqual(module_partitions[k][0].output_nodes[0].name, "linear")
+        self.assertEqual(module_partitions[k][0].output_nodes[0].name, "linear_default")
         input_node_names = {node.name for node in module_partitions[k][0].input_nodes}
         self.assertEqual(input_node_names, {"x"})
 

--- a/test/inductor/test_minifier_utils.py
+++ b/test/inductor/test_minifier_utils.py
@@ -95,42 +95,42 @@ class MinifierUtilsTests(TestCase):
             model_string.strip(),
             """\
 # from torch.nn import *
-# class true_graph_0_0(torch.nn.Module):
+# class false_graph_0_0(torch.nn.Module):
 #     def __init__(self) -> None:
 #         super().__init__()
 
 
 
 #     def forward(self, x):
-#         clone = torch.ops.aten.clone.default(x);  x = None
-#         return (clone,)
+#         clone_default = torch.ops.aten.clone.default(x);  x = None
+#         return (clone_default,)
 
 
-# class false_graph_0_1(torch.nn.Module):
+# class true_graph_0_1(torch.nn.Module):
 #     def __init__(self) -> None:
 #         super().__init__()
 
 
 
 #     def forward(self, x):
-#         clone = torch.ops.aten.clone.default(x);  x = None
-#         return (clone,)
+#         clone_default = torch.ops.aten.clone.default(x);  x = None
+#         return (clone_default,)
 
 
 # class Repro(torch.nn.Module):
 #     def __init__(self) -> None:
 #         super().__init__()
-#         self.true_graph_0 = true_graph_0_0()
-#         self.false_graph_0 = false_graph_0_1()
+#         self.false_graph_0 = false_graph_0_0()
+#         self.true_graph_0 = true_graph_0_1()
 
 
 
 #     def forward(self, x, flag):
 #         x, flag, = fx_pytree.tree_flatten_spec(([x, flag], {}), self._in_spec)
-#         item = torch.ops.aten.item.default(flag);  flag = None
-#         gt = item > 0;  item = None
-#         true_graph_0 = self.true_graph_0
+#         item_default = torch.ops.aten.item.default(flag);  flag = None
+#         gt = item_default > 0;  item_default = None
 #         false_graph_0 = self.false_graph_0
+#         true_graph_0 = self.true_graph_0
 #         cond = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, (x,));  gt = true_graph_0 = false_graph_0 = x = None
 #         getitem = cond[0];  cond = None
 #         return pytree.tree_unflatten((getitem,), self._out_spec)""",

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4292,12 +4292,12 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "Sym(s7)", 
         eq: "Sym(Eq(u1, u0**2))" = arg1_1 == pow_1;  arg1_1 = pow_1 = None
         _assert_scalar_2 = torch.ops.aten._assert_scalar.default(eq, "Runtime assertion failed for expression Eq(u1, u0**2) on node 'eq'");  eq = _assert_scalar_2 = None
         view: "i64[u0, u0][s7*u0, s7]cpu" = torch.ops.aten.view.default(arg3_1, [_local_scalar_dense, _local_scalar_dense])
+        mul_6: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
         view_1: "i64[u0, u0][s7*u0, s7]cpu" = torch.ops.aten.view.default(arg3_1, [_local_scalar_dense, _local_scalar_dense])
+        mul_12: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view_1, 10);  view_1 = None
         view_2: "i64[u0, u0][s7*u0, s7]cpu" = torch.ops.aten.view.default(arg3_1, [_local_scalar_dense, _local_scalar_dense]);  arg3_1 = _local_scalar_dense = None
         clone: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.clone.default(view_2);  view_2 = None
-        mul_11: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
-        mul_14: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view_1, 10);  view_1 = None
-        return (mul_11, mul_14, clone)""",
+        return (mul_12, mul_6, clone)""",
             ignore_comments=True,
             ignore_empty_lines=True,
         )
@@ -4333,12 +4333,12 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
         eq: "Sym(Eq(u1, u0**2))" = arg1_1 == pow_1;  arg1_1 = pow_1 = None
         _assert_scalar_2 = torch.ops.aten._assert_scalar.default(eq, "Runtime assertion failed for expression Eq(u1, u0**2) on node 'eq'");  eq = _assert_scalar_2 = None
         view: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.view.default(arg2_1, [_local_scalar_dense, _local_scalar_dense])
+        mul_2: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
         view_1: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.view.default(arg2_1, [_local_scalar_dense, _local_scalar_dense])
+        mul_7: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view_1, 10);  view_1 = None
         view_2: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.view.default(arg2_1, [_local_scalar_dense, _local_scalar_dense]);  arg2_1 = _local_scalar_dense = None
         clone: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.clone.default(view_2);  view_2 = None
-        mul_6: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
-        mul_9: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view_1, 10);  view_1 = None
-        return (mul_6, mul_9, clone)""",
+        return (mul_7, mul_2, clone)""",
             ignore_comments=True,
             ignore_empty_lines=True,
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Mechanical golden refresh for the canonical naming/ordering produced by the
preceding commits: overload-qualified renames (`add` -> `add_tensor`,
`clone` -> `clone_default`, `linear` -> `linear_default`), getitem naming, and
`mul` nodes grouped after the `view` that produces them.

None of these change graph semantics. Canonicalization never rewrites the
`output` node's argument tuple, so where a golden's `return (...)` appears
reordered it is the node *names* that were reassigned, not the values; the
`cond` subgraph suffix swap in the minifier golden is likewise cosmetic, both
branches having identical bodies.

Two are not pure golden churn. `test_source_matcher_utils` compares a node name
with a hardcoded string rather than an expecttest golden, so it is updated by
hand. `test_while_loop_autograd_simple` was flaky in isolation: the AOT
partitioner nondeterministically annotates recomputed backward nodes with
"# Backward of forward node" comments, and `normalize_gm` strips the comment but
leaves an orphan blank line, so it now compares with
`assertExpectedInline(..., ignore_empty_lines=True)`.

Test Plan:

```
python test/functorch/test_control_flow.py TestControlFlow TestControlFlowTraced
python test/test_dynamic_shapes.py
python test/inductor/test_minifier_utils.py
python test/test_fx.py
```

Run `test_control_flow.py` with explicit class arguments; running the whole file
spends its budget in the combinatorial `AssociativeScanTests` block before
reaching the cond/scan/while_loop tests these goldens cover.

This change was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo