### PR TITLE
[dynamo] enable graph canonicalization in OSS only, and force it on in tests

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -928,7 +928,27 @@ invalidate_compile_context_weakrefs: bool | None = None
 # Reorder and rename output graph nodes into a canonical topological order so
 # that structurally equivalent graphs (e.g., same model traced with different
 # dict iteration orders across distributed ranks) produce identical FX graphs.
-canonicalize_output_graph_node_order: bool = True
+#
+# Scope: this covers INTERIOR nodes only. Placeholders keep their trace-order
+# position and names, because that layout is the graph's positional calling
+# convention (see `_canonicalize_graph` in output_graph.py). So two graphs that
+# differ only in the order their inputs were traced still canonicalize to the
+# same interior nodes but keep different placeholder layouts - do not rely on
+# whole-graph identity (e.g. graph hashing) across ranks.
+#
+# Nodes whose order is load-bearing are also left in place (in-place ops,
+# functional collectives, unbacked-symbol binders); see `_is_safe_to_reorder` in
+# torch/fx/passes/canonicalize.py.
+#
+# Enabled in OSS; gated by the justknob in fbcode so internal tests that depend
+# on the old node names can be migrated first. Tests force it on regardless (a
+# `config.patch` user override outranks the justknob) so the feature is
+# exercised on both - see `torch/_dynamo/test_case.py` and
+# `torch.testing._internal.common_utils.TestCase.setUp`.
+canonicalize_output_graph_node_order: bool = Config(
+    default=True,
+    justknob="pytorch/compiler:canonicalize_output_graph_node_order",
+)
 
 if TYPE_CHECKING:
     from torch.utils._config_typing import *  # noqa: F403

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -81,6 +81,9 @@ class TestCase(TorchTestCase):
                 raise_on_ctx_manager_usage=True,
                 suppress_errors=False,
                 log_compilation_metrics=False,
+                # Exercise canonicalization even where it is off by default
+                # (fbcode justknob); goldens assume canonical node names.
+                canonicalize_output_graph_node_order=True,
             ),
         )
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -3980,6 +3980,18 @@ class TestCase(expecttest.TestCase):
         self._prev_torch_function_state = torch._C._get_torch_function_state()
         self._prev_fp32_precision = _snapshot_fp32_precision()
 
+        # Graph canonicalization is off by default in fbcode (justknob), but the
+        # expecttest goldens in this repo assume canonical node names, so force it
+        # on for tests. Only checked when Dynamo is already imported: if it is
+        # not, nothing in this test can compile a graph, and importing it here
+        # would add ~1.4s to every test process.
+        if 'torch._dynamo' in sys.modules:
+            canonicalize = torch._dynamo.config.patch(
+                canonicalize_output_graph_node_order=True
+            )
+            canonicalize.__enter__()
+            self.addCleanup(canonicalize.__exit__, None, None, None)
+
     def tearDown(self):
         # There exists test cases that override TestCase.setUp
         # definition, so we cannot assume that _check_invariants


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Canonicalization is ready for OSS but internal tests still depend on the old
node names, so the default becomes `Config(default=True, justknob=...)`: OSS
takes the default and fbcode is gated on the justknob until those tests are
migrated.

That alone would stop exercising the feature wherever the knob is off, and the
expecttest goldens in this repo assume canonical names, so tests force it on
regardless. A `config.patch` user override outranks the justknob, so the two
test bases opt in: `torch._dynamo.test_case.TestCase` (restoring the patch that
the enablement commit removed) and `common_utils.TestCase`, which is what the
affected golden files - `test_control_flow.py`, `test_dynamic_shapes.py`,
`test_pass_infra.py`, `test_minifier_utils.py` - actually subclass.

The `common_utils` hook only acts when `torch._dynamo` is already imported. If
it is not, nothing in that test can compile a graph so the setting is
irrelevant, and importing Dynamo eagerly there would add ~1.4s to every test
process.

Test Plan:

```
python test/dynamo/test_dicts.py -k canonical
python test/export/test_pass_infra.py
```

To confirm the tests really are unconditional, each affected file was also run
with the resolved default forced off, simulating the justknob being off in
fbcode, via a wrapper that sets
`torch._dynamo.config.canonicalize_output_graph_node_order = False` before the
test module is imported and then runs it as `__main__`:

```
python <wrapper> test/functorch/test_control_flow.py TestControlFlow TestControlFlowTraced
python <wrapper> test/test_dynamic_shapes.py
python <wrapper> test/test_fx.py
python <wrapper> test/export/test_pass_infra.py
python <wrapper> test/inductor/test_minifier_utils.py
python <wrapper> test/dynamo/test_dicts.py -k canonical
```

All pass with the default off (control_flow 782, dynamic_shapes 473, test_fx
1880), confirming the goldens are asserted on both configurations.

This change was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98