### PR TITLE
[CPU] Fix fused SGD skipping fp16/bf16 vectorized param updates (#191…

### DIFF
--- a/aten/src/ATen/native/cpu/FusedSGDKernel.cpp
+++ b/aten/src/ATen/native/cpu/FusedSGDKernel.cpp
@@ -57,12 +57,14 @@ std::enable_if_t<
         momentum_vec1 = grad_vec1;
         momentum_vec2 = grad_vec2;
       } else {
-        momentum_vec1 = fVec::loadu(momentum_buf_ptr + d) * fVec(scalar_t(momentum));
-        momentum_vec2 = fVec::loadu(momentum_buf_ptr + d + fVec::size()) * fVec(scalar_t(momentum));
+        auto [momentum_buf_vec1, momentum_buf_vec2] =
+            vec::convert_to_float<scalar_t>(lpVec::loadu(momentum_buf_ptr + d));
+        momentum_vec1 = momentum_buf_vec1 * fVec(scalar_t(momentum));
+        momentum_vec2 = momentum_buf_vec2 * fVec(scalar_t(momentum));
         momentum_vec1 = vec::fmadd(fVec(scalar_t(1 - dampening)), grad_vec1, momentum_vec1);
         momentum_vec2 = vec::fmadd(fVec(scalar_t(1 - dampening)), grad_vec2, momentum_vec2);
       }
-      vec::convert_from_float<scalar_t>(momentum_vec1, momentum_vec2).store(momentum_buf_ptr + d);;
+      vec::convert_from_float<scalar_t>(momentum_vec1, momentum_vec2).store(momentum_buf_ptr + d);
       if (nesterov) {
         grad_vec1 = vec::fmadd(momentum_vec1, fVec(scalar_t(momentum)), grad_vec1);
         grad_vec2 = vec::fmadd(momentum_vec2, fVec(scalar_t(momentum)), grad_vec2);
@@ -71,6 +73,9 @@ std::enable_if_t<
         grad_vec2 = momentum_vec2;
       }
     }
+    param_vec1 = vec::fmadd(grad_vec1, fVec(opmath_t(-lr)), param_vec1);
+    param_vec2 = vec::fmadd(grad_vec2, fVec(opmath_t(-lr)), param_vec2);
+    vec::convert_from_float<scalar_t>(param_vec1, param_vec2).store(param_ptr + d);
   }
   for (; d < size; d++) {
     opmath_t grad_val = grad_ptr[d];

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1197,6 +1197,33 @@ class TestOptimRenewed(TestCase):
             optimizer = optim_cls(params, fused=True, **optim_input.kwargs)
             optimizer.step()
 
+    @onlyCPU
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    @parametrize("momentum", [0.0, 0.9])
+    def test_fused_sgd_cpu_lowp_updates_vectorized_blocks(
+        self, device, dtype, momentum
+    ):
+        # Regression for https://github.com/pytorch/pytorch/issues/191763:
+        # fused CPU SGD's Half/BFloat16 vectorized loop previously omitted the
+        # LR update/store (and mis-loaded momentum buffers as float), so
+        # complete SIMD blocks were left unchanged or wrong. Sizes are well
+        # above typical SIMD widths (8/16/32) so the vectorized path runs.
+        lr = 0.125
+        n_steps = 2 if momentum != 0.0 else 1
+        for size in (64, 65, 256, 257):
+            param_fused = torch.nn.Parameter(
+                torch.ones(size, dtype=dtype, device=device)
+            )
+            param_ref = torch.nn.Parameter(torch.ones(size, dtype=dtype, device=device))
+            opt_fused = SGD([param_fused], lr=lr, momentum=momentum, fused=True)
+            opt_ref = SGD([param_ref], lr=lr, momentum=momentum, fused=False)
+            for _ in range(n_steps):
+                param_fused.grad = torch.ones_like(param_fused)
+                param_ref.grad = torch.ones_like(param_ref)
+                opt_fused.step()
+                opt_ref.step()
+            self.assertEqual(param_fused, param_ref)
+
     @skipMPS  # MPS fused optimizer does not properly handle found_inf
     @onlyAccelerator
     @optims(


### PR DESCRIPTION
## Summary
- Fix fused CPU SGD Half/BFloat16 SIMD loop: apply LR update and store params (was silently skipped for full vector blocks; #191763).
- Load momentum buffers via `convert_to_float` instead of `fVec::loadu` through Half/BF16 pointers (matches FusedAdam; needed for correct multi-step momentum).
- Add CPU regression test comparing fused vs unfused SGD for fp16/bf16 at sizes that exercise the vectorized path.

## Test plan
- [ ] `python test/test_optim.py TestOptimRenewedCPU.test_fused_sgd_cpu_lowp_updates_vectorized_blocks`
- [ ] Confirm issue repro (fp16/bf16, sizes 8/9/64/65) updates all elements with `fused=True` after rebuild

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01