### PR TITLE
[CI][ROCm] Add soft per-shard deadline to exit before job timeout

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -201,6 +201,7 @@ jobs:
           TEST_SHOWLOCALS: ${{ steps.keep-going.outputs.ci-test-showlocals }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           NO_TD: ${{ steps.keep-going.outputs.ci-no-td }}
+          TEST_STEP_TIMEOUT: ${{ steps.test-timeout.outputs.timeout }}
           DOCKER_IMAGE: ${{ inputs.docker-image }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
@@ -209,6 +210,16 @@ jobs:
         timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
         run: |
           set -x
+
+          # Soft per-shard deadline: exit run_test.py cleanly a margin before the
+          # step-timeout wall (preserving test reports) instead of being SIGKILLed.
+          # Skipped for rerun-disabled shards, which run long by design and don't
+          # fail on the recorded failure. See run_test.py.
+          if [[ "${PYTORCH_TEST_RERUN_DISABLED_TESTS}" != "1" ]]; then
+            margin_min=25
+            PYTORCH_SHARD_DEADLINE_EPOCH=$(( $(date +%s) + (TEST_STEP_TIMEOUT - margin_min) * 60 ))
+            export PYTORCH_SHARD_DEADLINE_EPOCH
+          fi
 
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
             TEST_COMMAND=.ci/pytorch/multigpu-test.sh
@@ -249,6 +260,7 @@ jobs:
             -e TEST_SHOWLOCALS \
             -e NO_TEST_TIMEOUT \
             -e NO_TD \
+            -e PYTORCH_SHARD_DEADLINE_EPOCH \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e PYTORCH_TEST_RERUN_DISABLED_TESTS \
             -e TESTS_TO_INCLUDE \

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -118,6 +118,15 @@ INDUCTOR_TEST_PREFIX = "inductor"
 IS_SLOW = "slow" in TEST_CONFIG or "slow" in BUILD_ENVIRONMENT
 IS_S390X = platform.machine() == "s390x"
 
+# Absolute epoch deadline for the whole shard (set by the ROCm workflow a margin
+# before the GHA step timeout). Past it, run_tests() stops launching new files and
+# exits cleanly instead of being SIGKILLed at the wall. Unset/malformed -> no-op.
+try:
+    SHARD_DEADLINE_EPOCH = float(os.environ["PYTORCH_SHARD_DEADLINE_EPOCH"])
+except (KeyError, ValueError):
+    SHARD_DEADLINE_EPOCH = None
+SHARD_DEADLINE_FAILURE_PREFIX = "TIMED OUT SHARD:"
+
 
 # Note [ROCm parallel CI testing]
 # https://github.com/pytorch/pytorch/pull/85770 added file-granularity parallel testing.
@@ -2101,14 +2110,40 @@ def run_test_module(
         return TestFailure(test.test, f"{str(test)} failed! {e}")
 
 
+def shard_deadline_exceeded() -> bool:
+    return SHARD_DEADLINE_EPOCH is not None and time.time() >= SHARD_DEADLINE_EPOCH
+
+
 def run_tests(
     selected_tests: list[ShardedTest],
     test_directory: str,
     options,
     failures: list[TestFailure],
-) -> None:
+) -> str | None:
     if len(selected_tests) == 0:
-        return
+        return None
+
+    if SHARD_DEADLINE_EPOCH is not None:
+        print_to_stderr(
+            "Shard soft deadline active: stopping new test files "
+            f"{max(0.0, (SHARD_DEADLINE_EPOCH - time.time()) / 60):.1f} min from now"
+        )
+
+    def stop_for_shard_deadline(
+        next_test: ShardedTest, not_run: list[ShardedTest]
+    ) -> str:
+        # Shard-level abort (ran out of budget), distinct from a test failure --
+        # surfaced via run_tests' return, not the failures list, so it doesn't
+        # pollute TD/stats. The prefix is load-bearing: the log classifier keys
+        # on it.
+        remaining = [str(t) for t in not_run]
+        message = (
+            f"{SHARD_DEADLINE_FAILURE_PREFIX} soft deadline reached before "
+            f"{next_test} ({len(remaining)} file(s) not run)"
+        )
+        print_to_stderr(message)
+        print_to_stderr(f"Not run due to shard deadline: {remaining}")
+        return message
 
     # parallel = in parallel with other files
     # serial = this file on it's own.  The file might still be run in parallel with itself (ex test_ops)
@@ -2167,8 +2202,13 @@ def run_tests(
     )
 
     pool = None
+    shard_deadline_msg: str | None = None
     try:
-        for test in selected_tests_serial:
+        for i, test in enumerate(selected_tests_serial):
+            if shard_deadline_exceeded():
+                return stop_for_shard_deadline(
+                    test, selected_tests_serial[i:] + selected_tests_parallel
+                )
             options_clone = copy.deepcopy(options)
             if can_run_in_pytest(test):
                 options_clone.pytest = True
@@ -2183,7 +2223,9 @@ def run_tests(
                 raise RuntimeError(failure.message + keep_going_message)
 
         # Run tests marked as serial first
-        for test in selected_tests_parallel:
+        for i, test in enumerate(selected_tests_parallel):
+            if shard_deadline_exceeded():
+                return stop_for_shard_deadline(test, selected_tests_parallel[i:])
             options_clone = copy.deepcopy(options)
             if can_run_in_pytest(test):
                 options_clone.pytest = True
@@ -2215,7 +2257,13 @@ def run_tests(
             ):
                 pool.terminate()
 
-        for test in selected_tests_parallel:
+        for i, test in enumerate(selected_tests_parallel):
+            if shard_deadline_exceeded():
+                # Stop submitting; in-flight files drain in pool.join() below.
+                shard_deadline_msg = stop_for_shard_deadline(
+                    test, selected_tests_parallel[i:]
+                )
+                break
             options_clone = copy.deepcopy(options)
             if can_run_in_pytest(test):
                 options_clone.pytest = True
@@ -2234,7 +2282,7 @@ def run_tests(
             pool.terminate()
             pool.join()
 
-    return
+    return shard_deadline_msg
 
 
 def check_pip_packages() -> None:
@@ -2356,10 +2404,11 @@ def main():
     if not options.no_translation_validation:
         os.environ["PYTORCH_TEST_WITH_TV"] = "1"
 
+    shard_deadline_msg: str | None = None
     try:
         # Actually run the tests
         start_time = time.time()
-        run_tests(
+        shard_deadline_msg = run_tests(
             test_batch.sharded_tests, test_directory, options, test_batch.failures
         )
         elapsed_time = time.time() - start_time
@@ -2398,13 +2447,17 @@ def main():
                 [test.test_file for test, _ in all_failures]
             )
 
-    if len(all_failures):
+    if all_failures:
         for _, err in all_failures:
             print_to_stderr(err)
 
-        # A disabled test is expected to fail, so there is no need to report a failure here
-        if not RERUN_DISABLED_TESTS:
-            sys.exit(1)
+    # A shard that stopped at the soft deadline did not finish its work -> fail red.
+    if shard_deadline_msg is not None:
+        sys.exit(1)
+
+    # A disabled test is expected to fail, so there is no need to report a failure here
+    if all_failures and not RERUN_DISABLED_TESTS:
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
ROCm mi350 shards often hit the 270-min GHA step timeout and get SIGKILLed, losing all test-report data and leaving only an opaque "timed out" classification. run_test.py now reads an absolute deadline (PYTORCH_SHARD_DEADLINE_EPOCH, set by _rocm-test.yml to 25 min before the wall); once it passes, run_tests() stops launching new files, drains any in-flight ones, and returns a "TIMED OUT SHARD" reason so main() prints it and exits 1. This is a shard-level abort (not a synthetic test failure), so it stays out of the TD "previously failed" set and failure metrics. ROCm-only; a no-op when unset.

An absolute epoch (not a duration) because the wall starts at step start, before container setup and any multi-invocation configs. Best-effort: it does not interrupt a file already running (the per-file timeout bounds that) and does not cover a wedged/D-state process. Not armed for rerun-disabled shards (which run long by design); a malformed/unset env value parses to no-op.

Test Plan:

```
# stops early, exits 1
PYTORCH_SHARD_DEADLINE_EPOCH=$(($(date +%s)+30)) \
  python test/run_test.py -i test_nn test_ops --verbose
# unset -> runs unchanged
```

py_compile + lintrunner (incl. actionlint) clean.

Authored with assistance from Claude Code.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang