### PR TITLE
Add torch.autograd.graph.AutogradContextVar

### DIFF
--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -434,6 +434,10 @@ to avoid a reference cycle when the saved tensor is a graph output; see
 ```
 
 ```{eval-rst}
+.. autoclass:: torch.autograd.graph.AutogradContextVar
+```
+
+```{eval-rst}
 .. autoclass:: torch.autograd.graph.allow_mutation_on_saved_tensors
 ```
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11482,6 +11482,39 @@ for shape in [(1,), ()]:
         self.assertEqual(len(func_nodes), 1)
         self.assertIs(func_nodes[0], out.grad_fn)
 
+    def test_autograd_context_var_api(self):
+        cv = torch.autograd.graph.AutogradContextVar("cv", default="d")
+        self.assertEqual(cv.name, "cv")
+        self.assertEqual(cv.get(), "d")
+        self.assertEqual(cv.get("arg"), "arg")
+        token = cv.set("v")
+        self.assertEqual(cv.get(), "v")
+        self.assertEqual(cv.get("arg"), "v")
+        cv.reset(token)
+        self.assertEqual(cv.get(), "d")
+
+        cv2 = torch.autograd.graph.AutogradContextVar("cv2")
+        self.assertRaises(LookupError, cv2.get)
+        self.assertEqual(cv2.get("arg"), "arg")
+
+    def test_autograd_context_var_thread_set_takes_precedence(self):
+        cv = torch.autograd.graph.AutogradContextVar("cv", default="d")
+        seen = []
+
+        def hook(g):
+            seen.append(cv.get())
+            cv.set("mutated")
+            seen.append(cv.get())
+            return g
+
+        x = torch.randn(2, requires_grad=True)
+        y = (x * 2).sum()
+        x.register_hook(hook)
+        token = cv.set("caller")
+        y.backward()
+        cv.reset(token)
+        self.assertEqual(seen, ["caller", "mutated"])
+
     def test_node_creation_hook_inplace(self):
         nodes = []
         a = torch.randn(2, requires_grad=True)
@@ -13365,6 +13398,53 @@ class TestAutogradForwardMode(TestCase):
 
 # Generic device type autograd tests.
 class TestAutogradDeviceType(TestCase):
+    def test_autograd_context_var_visible_in_hooks(self, device):
+        # On non-CPU devices backward hooks run on autograd worker threads,
+        # where plain ContextVars set by the caller are not visible.
+        cv = torch.autograd.graph.AutogradContextVar("cv", default="default")
+        plain = contextvars.ContextVar("plain", default="default")
+        seen = {}
+
+        class Func(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x * 2
+
+            @staticmethod
+            def backward(ctx, gO):
+                seen["function_backward"] = cv.get()
+                return gO
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        y = Func.apply(x).sum()
+        y.grad_fn.register_prehook(lambda gO: seen.__setitem__("prehook", cv.get()))
+        y.grad_fn.register_hook(lambda gI, gO: seen.__setitem__("posthook", cv.get()))
+        x.register_hook(lambda g: seen.__setitem__("tensor_hook", cv.get()))
+        x.register_post_accumulate_grad_hook(
+            lambda t: seen.__setitem__("post_acc_grad", cv.get())
+        )
+
+        cv_token = cv.set("caller")
+        plain_token = plain.set("caller")
+        try:
+            y.backward()
+        finally:
+            cv.reset(cv_token)
+            plain.reset(plain_token)
+
+        expected = [
+            "function_backward",
+            "post_acc_grad",
+            "posthook",
+            "prehook",
+            "tensor_hook",
+        ]
+        self.assertEqual(sorted(seen.keys()), expected)
+        for site, value in seen.items():
+            self.assertEqual(value, "caller", msg=f"site: {site}")
+        # After backward, no stashed state should leak into get().
+        self.assertEqual(cv.get(), "default")
+
     def test_min_max_aminmax_median_backprops_to_all_values(self, device):
         # 1) Test min/max/median/nanmedian on both a non NaN and all NaN tensor
         for f in [torch.min, torch.max, torch.median, torch.nanmedian]:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11488,9 +11488,11 @@ for shape in [(1,), ()]:
         self.assertEqual(cv.get(), "d")
         self.assertEqual(cv.get("arg"), "arg")
         token = cv.set("v")
-        self.assertEqual(cv.get(), "v")
-        self.assertEqual(cv.get("arg"), "v")
-        cv.reset(token)
+        try:
+            self.assertEqual(cv.get(), "v")
+            self.assertEqual(cv.get("arg"), "v")
+        finally:
+            cv.reset(token)
         self.assertEqual(cv.get(), "d")
 
         cv2 = torch.autograd.graph.AutogradContextVar("cv2")
@@ -11511,8 +11513,10 @@ for shape in [(1,), ()]:
         y = (x * 2).sum()
         x.register_hook(hook)
         token = cv.set("caller")
-        y.backward()
-        cv.reset(token)
+        try:
+            y.backward()
+        finally:
+            cv.reset(token)
         self.assertEqual(seen, ["caller", "mutated"])
 
     def test_node_creation_hook_inplace(self):

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -16,11 +16,13 @@ from collections.abc import (
 from typing import (
     Any,
     cast,
+    Generic,
     Literal,
     NamedTuple,
     Optional,
     TYPE_CHECKING,
     TypeAlias,
+    TypeVar,
     Union,
 )
 from weakref import WeakKeyDictionary, WeakValueDictionary
@@ -36,6 +38,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "AutogradContextVar",
     "saved_tensors_hooks",
     "save_on_cpu",
     "disable_saved_tensors_hooks",
@@ -53,6 +56,73 @@ __all__ = [
 
 
 log = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+_UNSET: Any = object()
+
+
+class AutogradContextVar(Generic[_T]):
+    """A :class:`contextvars.ContextVar` wrapper whose value is visible in autograd hooks during backward.
+
+    The autograd engine may run backward hooks (:class:`Node` pre/post hooks,
+    tensor hooks, :meth:`torch.autograd.Function.backward`, saved-tensor
+    hooks, etc.) on device worker threads. Plain :class:`~contextvars.ContextVar`
+    values set on the thread calling :func:`torch.autograd.backward` are not
+    visible on those threads. ``AutogradContextVar`` mirrors the
+    :class:`~contextvars.ContextVar` API, but :meth:`get` returns the value
+    the variable had when backward was launched, on whatever thread the hook
+    runs on.
+
+    During backward, values are read from a snapshot taken at backward launch:
+    calling :meth:`set` inside a hook running on an autograd worker thread
+    only affects that worker thread and does not propagate back to the calling
+    thread.
+
+    Example::
+
+        >>> import torch
+        >>> cv = torch.autograd.graph.AutogradContextVar("cv", default="unset")
+        >>> x = torch.randn(2, requires_grad=True)
+        >>> y = (x * 2).sum()
+        >>> _ = x.register_hook(lambda g: print(cv.get()))
+        >>> token = cv.set("hello")
+        >>> y.backward()  # prints "hello" even if hooks run on a worker thread
+        hello
+        >>> cv.reset(token)
+    """
+
+    def __init__(self, name: str, *, default: _T = _UNSET) -> None:
+        if default is _UNSET:
+            self._var: contextvars.ContextVar[_T] = contextvars.ContextVar(name)
+        else:
+            self._var = contextvars.ContextVar(name, default=default)
+
+    @property
+    def name(self) -> str:
+        return self._var.name
+
+    def get(self, default: _T = _UNSET) -> _T:
+        # A value set on the current thread (including mutations made by
+        # earlier hooks on this thread) takes precedence over the snapshot.
+        if self._var in contextvars.copy_context():
+            return self._var.get()
+        # The engine stashes the caller's contextvars.Context in ATen TLS at
+        # backward launch (see _engine_run_backward); GraphTask propagates
+        # that TLS to worker threads before any hook runs.
+        if torch._C._is_key_in_tls("context"):
+            ctx = torch._C._get_obj_in_tls("context")
+            if ctx is not None and self._var in ctx:
+                return ctx[self._var]
+        if default is _UNSET:
+            return self._var.get()
+        return self._var.get(default)
+
+    def set(self, value: _T) -> "contextvars.Token[_T]":
+        return self._var.set(value)
+
+    def reset(self, token: "contextvars.Token[_T]") -> None:
+        self._var.reset(token)
 
 
 class Node(abc.ABC):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #191777

Backward hooks (Node pre/post hooks, tensor hooks, autograd.Function.backward,
post-accumulate-grad hooks) run on autograd worker threads when the graph has
device nodes, so Python ContextVar values set on the thread calling backward()
are not visible inside them: contextvars are per-OS-thread interpreter state,
and nothing enters the caller's context on the worker thread. Meanwhile
_engine_run_backward already stashes contextvars.copy_context() in ATen TLS
(for AOTAutograd's compiled backward) and GraphTask propagates that TLS to
worker threads via the standard ThreadLocalState snapshot/restore before any
hook fires - the snapshot arrives, it is just never consulted by user code.

AutogradContextVar makes that snapshot usable: it mirrors the ContextVar API,
but get() falls back to a mapping lookup on the stashed backward-launch
Context when the variable has no value in the current thread's context. This
is opt-in and pure Python: no engine changes, no BC break for existing
ContextVars, no GIL games (Context supports mapping access without being
entered). get() precedence: current-thread value (preserving intra-thread
mutation semantics for CPU backward and for earlier hooks on the same worker
thread) > backward-launch snapshot > get(default) argument > constructor
default.

Alternatives considered: propagating the full Context by entering it around
every Python callback boundary (jansel's #186583) is BC-breaking (hooks that
today see defaults would start seeing caller values, and worker-thread
mutations would stop leaking across backward calls) and forces a semantics
decision (copy-per-callback vs copy-per-graph-task) that stdlib precedent
does not settle; a register_contextvar(cv) API for existing ContextVars
cannot be done in pure Python (ContextVar.get is a C-level type you cannot
interpose on) and needs the same C++ boundary plumbing. AutogradContextVar
gives the visibility fix with none of that, and stays forward-compatible with
a registration mechanism if we later want one.

Authored with an AI assistant.

Test Plan:

New tests: API semantics and same-thread precedence in TestAutograd, plus a
device-generic test in TestAutogradDeviceType covering all five hook sites
(Function.backward, node prehook/posthook, tensor hook, post-accumulate-grad
hook); on CUDA these run on a worker thread, which is the case plain
ContextVars get wrong.

```
python -m pytest test/test_autograd.py -k "autograd_context_var" -q  # 4 passed (CUDA machine)
python -m pytest test/test_autograd.py -k "hook or context_var" -q   # 94 passed
lintrunner
```

Also verified a torch.compile backward tensor hook sees the caller value on
CUDA.