### PR TITLE
[MPS] Use int32 scan in flat unique when counts fit (faster on Apple GPU)

### DIFF
--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -333,9 +333,13 @@ static std::tuple<Tensor, Tensor, Tensor> _unique_flat_mps_fast(const Tensor& se
     }
   });
 
-  // cumsum runs as a separate dispatch on MPS; that's fine.
-  scan = at::cumsum(mask, /*dim=*/0);
-  // cumsum of int32 may upcast to int64 on some paths; track the scan dtype.
+  // cumsum runs as a separate dispatch on MPS; that's fine. at::cumsum promotes
+  // the int32 mask to int64 by default, but 32-bit math is much faster on Apple
+  // GPUs, so force an int32 scan when the counts are guaranteed to fit (every
+  // scan value is <= numel), and fall back to int64 otherwise. scan_suffix then
+  // selects the matching _32 / _64 emit/inverse kernel.
+  scan = (numel < std::numeric_limits<int32_t>::max()) ? at::cumsum(mask, /*dim=*/0, /*dtype=*/kInt)
+                                                       : at::cumsum(mask, /*dim=*/0);
   const auto scan_dtype = scan.scalar_type();
   TORCH_CHECK(scan_dtype == kInt || scan_dtype == kLong, "unique: unexpected cumsum output dtype ", scan_dtype);
   const auto scan_suffix = std::to_string(c10::elementSize(scan_dtype) * 8);


### PR DESCRIPTION
Follow-up to #184780 (the flat `torch.unique` MPS fast path), addressing @aorenste's `[cleanup]` note and @kurtamohler's review.

## What & why

The flat unique fast path scans the boundary mask with `at::cumsum`, which promotes the int32 mask to **int64** by default — so the int32 (`_32`) emit/inverse kernel variants were never selected. 64-bit math is much slower on Apple GPUs, so this forces an **int32 cumsum when `numel < INT32_MAX`** (every scan value is bounded by `numel`), using the already-present `_32` kernels; int64 stays as the fallback for larger inputs. It also fixes the misleading comment @aorenste flagged (the scan was described as possibly-int32 when the code always produced int64).

> This replaces the earlier version of this PR, which removed the `_32` path as dead code. @kurtamohler pointed out the better fix is to make it *live* — and the measurements below confirm it.

## Perf (M4 Max, n=200/case)

int32 scan vs the int64 default. Every case is faster, all statistically significant (Mann-Whitney p < 1e-9, large effect sizes):

| case | int64 | int32 | speedup |
|---|---:|---:|---:|
| skewed 2M, counts | 1.659 ms | 1.535 ms | **1.08×** |
| skewed 2M, inverse+counts | 1.765 ms | 1.671 ms | **1.06×** |
| uniform 1M / 1024-unique | 1.035 ms | 1.007 ms | 1.03× |
| all-distinct 100K int32 | 0.387 ms | 0.323 ms | **1.20×** |
| bool 2M, inverse+counts | 0.724 ms | 0.577 ms | **1.26×** |

## Testing

```
python test/test_mps.py TestMPS.test_unique TestMPS.test_unique_consecutive
python test/test_ops.py TestCommonMPS -k "unique"
```

All green (OpInfo: 20 passed, 8 pre-existing skips). Correctness also spot-checked vs CPU across int64, bool, int32-distinct, and int8-with-negatives for the inverse+counts variant.

Authored with Claude Code.
