### PR TITLE
[MPS] Reject bool inputs to mm

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -942,6 +942,7 @@ static Tensor& mm_out_mps_impl(const Tensor& self, const Tensor& other, Tensor& 
               self.dtype(),
               " != ",
               other.dtype())
+  TORCH_CHECK(self.scalar_type() != kBool, "mm: not implemented for 'Bool' on MPS");
   TensorArg args[]{{output, "out", 0}, {self, "mat1", 1}, {other, "mat2", 2}};
   checkAllSameGPU("mm", args);
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1196,6 +1196,16 @@ def sample_inputs_mm(op_info, device, dtype, requires_grad, **kwargs):
     yield SampleInput(make_arg((S, 0)), args=(make_arg(0, M),))
 
 
+def error_inputs_mm(op_info, device, **kwargs):
+    make_arg = partial(make_tensor, device=device, dtype=torch.bool, requires_grad=False)
+
+    yield ErrorInput(
+        SampleInput(make_arg((S, M)), args=(make_arg((M, S)),)),
+        error_type=RuntimeError,
+        error_regex="not implemented for 'Bool'",
+    )
+
+
 def sample_inputs_addmm(op_info, device, dtype, requires_grad, **kwargs):
     alpha_val = kwargs.get('alpha', 2 + 3j if dtype.is_complex else 0.6 if dtype.is_floating_point else 2)
     beta_val = kwargs.get('beta', 1 + 2j if dtype.is_complex else 0.2 if dtype.is_floating_point else 3)
@@ -17809,6 +17819,7 @@ op_db: list[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            sample_inputs_func=sample_inputs_mm,
+           error_inputs_func=error_inputs_mm,
            skips=(
                # Issue with conj and torch dispatch, see https://github.com/pytorch/pytorch/issues/82479
                DecorateInfo(


### PR DESCRIPTION
## Issue

Fixes #191693

## Summary

Reject bool operands in the MPS `mm` implementation before dispatching to Metal, replacing the opaque `matmul_bool` function-state failure with a clear unsupported-dtype error. Add shared OpInfo error coverage without introducing a backend-specific test in `test_mps.py`.

## Testing

- `python test/test_mps.py -v TestErrorInputsMPS.test_error_inputs_mm_mps`
- `python test/test_ops.py TestCommonCPU.test_errors_mm_cpu`
- Direct MPS smoke tests for the bool error and successful float32/int32 multiplication
- `spin lint` scoped to the modified files

## Checklist

- [x] Passes lint (`spin lint`)
- [x] Added/updated tests
- [x] Updated documentation (not applicable)
- [x] Included benchmark results (not applicable; no performance impact)

## BC-breaking?

No.