### PR TITLE
[DTensor] Answer as_strided when it is a permutation of the base dims

### DIFF
--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -1503,6 +1503,36 @@ class DTensorMeshTest(DTensorTestBase):
         self.assertEqual(result.stride(), dtensor.stride())
         self.assertEqual(result.to_local(), dtensor.to_local())
 
+    @with_comms
+    def test_as_strided_permutation(self):
+        # AOTAutograd regenerates an output aliasing an input with as_strided,
+        # so a compiled function returning a transposed view lands here.
+        device_mesh = self.build_device_mesh()
+        dtensor = distribute_tensor(
+            torch.randn(4, 6, 8, device=self.device_type), device_mesh, [Shard(0)]
+        )
+
+        for dims in ((1, 0, 2), (2, 1, 0), (0, 2, 1)):
+            expected = dtensor.permute(dims)
+            result = dtensor.as_strided(
+                expected.size(), expected.stride(), expected.storage_offset()
+            )
+            self.assertEqual(result.placements, expected.placements)
+            self.assertEqual(result.full_tensor(), expected.full_tensor())
+
+    @with_comms
+    def test_as_strided_non_permutation_errors(self):
+        device_mesh = self.build_device_mesh()
+        dtensor = distribute_tensor(
+            torch.randn(4, 6, device=self.device_type), device_mesh, [Shard(0)]
+        )
+
+        # Not reachable by permuting the base dims.
+        with self.assertRaisesRegex(RuntimeError, "as_strided not supported"):
+            dtensor.as_strided((4, 3), (6, 1), 0)
+        with self.assertRaisesRegex(RuntimeError, "as_strided not supported"):
+            dtensor.as_strided((4, 6), (6, 1), 1)
+
 
 DTensorMeshTestWithLocalTensor = create_local_tensor_test_class(
     DTensorMeshTest,

--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -234,8 +234,11 @@ dtensor_compiled_fails = {
     xfail("reshape_as"),
     xfail("view"),
     xfail("view_as"),
+    # No sharding strategy for aten.transpose_copy.int on 0-d inputs.
+    xfail("transpose_copy"),
     # View-type ops that decompose into as_strided (at autograd level).
-    # DTensor doesn't have a sharding strategy for as_strided.
+    # DTensor only answers as_strided when it is a permutation of the base
+    # dims, which these are not.
     xfail("atleast_1d"),
     xfail("atleast_2d"),
     xfail("atleast_3d"),
@@ -247,15 +250,11 @@ dtensor_compiled_fails = {
     xfail("expand_as"),
     xfail("hsplit"),
     xfail("linalg.diagonal"),
-    xfail("movedim"),
     xfail("narrow"),
-    xfail("permute"),
     xfail("select"),
     xfail("slice"),
     xfail("squeeze"),
     xfail("squeeze", "multiple"),
-    xfail("t"),
-    xfail("transpose_copy"),
     xfail("unsqueeze"),
     xfail("vsplit"),
     # Decompositions that use plain tensor constructors (e.g. arange),

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -77,6 +77,40 @@ def _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
     return _ignore_fresh_unbacked_symbols_tls_context()
 
 
+def _as_strided_permutation(
+    tensor: "dtensor.DTensor",
+    size: Sequence[int],
+    stride: Sequence[int],
+) -> list[int] | None:
+    """Return dims such that ``tensor.permute(dims)`` has the requested layout.
+
+    AOTAutograd regenerates an output that aliases an input by calling
+    as_strided on the input, which a sharded tensor cannot answer in general --
+    it has no single global storage to index into. A permutation of the base
+    dims (transpose, t, permute, Tensor.T) is the exception: it maps onto
+    aten.permute, which does have a sharding strategy.
+
+    Returns None when the request is not a permutation, or when two dims have
+    the same (size, stride) and the permutation is therefore ambiguous -- the
+    layouts would be identical but the placements need not be.
+    """
+    if len(size) != tensor.dim():
+        return None
+
+    base = list(zip(tensor.size(), tensor.stride()))
+    dims = []
+    used = [False] * len(base)
+    for target in zip(size, stride):
+        candidates = [
+            i for i, b in enumerate(base) if not used[i] and tuple(b) == tuple(target)
+        ]
+        if len(candidates) != 1:
+            return None
+        used[candidates[0]] = True
+        dims.append(candidates[0])
+    return dims
+
+
 def as_strided_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
@@ -86,12 +120,12 @@ def as_strided_handler(
     if kwargs:
         raise AssertionError
     tensor, size, stride, storage_offset = args
-    if (
-        tensor.size() == tuple(size)
-        and tensor.stride() == tuple(stride)
-        and (storage_offset is None or tensor.storage_offset() == storage_offset)
-    ):
-        return torch.ops.aten.alias.default(tensor)
+    if storage_offset is None or tensor.storage_offset() == storage_offset:
+        if tensor.size() == tuple(size) and tensor.stride() == tuple(stride):
+            return torch.ops.aten.alias.default(tensor)
+        dims = _as_strided_permutation(tensor, size, stride)
+        if dims is not None:
+            return torch.ops.aten.permute.default(tensor, dims)
     raise RuntimeError("as_strided not supported with DTensor")
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #191806
* #191785
* __->__ #191784

Returning a view of an input from a compiled function fails for DTensor:

    RuntimeError: as_strided not supported with DTensor

AOTAutograd regenerates an output that aliases an input by calling as_strided
on the input with the output's size/stride/offset. Its two view-replay paths
are both unavailable for a tensor subclass: collect_metadata_analysis only
records a ViewMetaSequence when the output is itself a FunctionalTensor (for
DTensor the functional wrapper sits inside the subclass), and the subclass
output has no `_base` to replay a view func off of. That leaves as_strided,
which DTensor answered only for the identity case. This is why transpose, t,
permute and friends are xfailed in the DTensor op db.

A sharded tensor cannot answer as_strided in general: it has no single global
storage to index into, and an arbitrary strided view can cross shard
boundaries. But when the request is just a permutation of the base dims --
which covers transpose, t, permute, movedim and Tensor.T -- it maps onto
aten.permute, whose sharding strategy already moves the shard dim to follow
the permuted dims. Match the requested (size, stride) pairs against the base's
and delegate; anything else, including an ambiguous match where two dims share
the same (size, stride), keeps raising as before.

transpose_copy keeps its xfail: it fails for an unrelated reason, no sharding
strategy for aten.transpose_copy.int on 0-d inputs.

This PR was authored with the assistance of an AI coding agent.