### PR TITLE
introduce make_fake_mode factory

### DIFF
--- a/torch/_dynamo/aot_compile_types.py
+++ b/torch/_dynamo/aot_compile_types.py
@@ -113,13 +113,13 @@ class GraphModuleSerializableCallable(SerializableCallable):
 
     @classmethod
     def deserialize_compile_artifacts(cls, data: bytes) -> Any:
-        from torch._subclasses import FakeTensorMode
+        from torch._subclasses import make_fake_mode
         from torch.fx._graph_pickler import GraphPickler
         from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
         state = pickle.loads(data)
 
-        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+        fake_mode = make_fake_mode(shape_env=ShapeEnv())
         state["graph_module"] = GraphPickler.loads(state["graph_module"], fake_mode)
         if not isinstance(state["graph_module"], torch.fx.GraphModule):
             raise AssertionError(

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -296,12 +296,12 @@ class AOTEagerOutputCode(OutputCode):
 
     def post_compile(self, *args: Any, **kwargs: Any) -> None:
         if self.gm is None and self._serialized_gm is not None:
-            from torch._subclasses import FakeTensorMode
+            from torch._subclasses import make_fake_mode
             from torch.fx._graph_pickler import GraphPickler
             from torch.fx.experimental.symbolic_shapes import ShapeEnv
             from torch.fx.graph import _BoxedCodeGen
 
-            fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+            fake_mode = make_fake_mode(shape_env=ShapeEnv())
             gm = GraphPickler.loads(self._serialized_gm, fake_mode)
             if not isinstance(gm, torch.fx.GraphModule):
                 raise AssertionError(f"Expected torch.fx.GraphModule, got {type(gm)}")

--- a/torch/_dynamo/backends/distributed.py
+++ b/torch/_dynamo/backends/distributed.py
@@ -632,7 +632,7 @@ class DDPOptimizer:
 
         fake_mode = detect_fake_mode(example_inputs)
         if fake_mode is None:
-            fake_mode = torch._subclasses.fake_tensor.FakeTensorMode()
+            fake_mode = torch._subclasses.make_fake_mode()
 
         submod_compiler = SubmodCompiler(
             split_gm, self.backend_compile_fn, fake_mode, **compiler_configs

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -47,7 +47,7 @@ from torch._functorch._aot_autograd.runtime_wrappers import (
 from torch._guards import compile_context, CompileContext, CompileId, Source
 from torch._logging import getArtifactLogger, trace_structured
 from torch._prims_common import clone_preserve_strides
-from torch._subclasses import FakeTensorMode
+from torch._subclasses import make_fake_mode
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx import GraphModule
 from torch.fx.experimental._backward_state import BackwardState
@@ -336,7 +336,7 @@ class AutogradCompilerInstance:
         self.stack = contextlib.ExitStack()
         self.close = self.stack.close
         self.shape_env = ShapeEnv()
-        self.fake_tensor_mode = FakeTensorMode(
+        self.fake_tensor_mode = make_fake_mode(
             allow_fallback_kernels=True,
             allow_non_fake_inputs=True,
             shape_env=self.shape_env,

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -2579,7 +2579,7 @@ def export(
             example_inputs = []
             graph_captured_input = ()
             graph_captured_result = ()
-            fake_mode = torch._subclasses.FakeTensorMode(
+            fake_mode = torch._subclasses.make_fake_mode(
                 shape_env=ShapeEnv(), export=True
             )
             if out_guards is None:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4055,7 +4055,7 @@ class GuardsStatePickler(pickle.Pickler):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.fake_mode = torch._subclasses.FakeTensorMode()
+        self.fake_mode = torch._subclasses.make_fake_mode()
         self.tensor_converter = torch._subclasses.fake_tensor.FakeTensorConverter()
         self.guard_tree_values = guard_tree_values
         self.empty_values = empty_values
@@ -4076,7 +4076,7 @@ class GuardsStatePickler(pickle.Pickler):
         dispatch_keys_raw: int,
         grad: torch.Tensor,
     ) -> torch.Tensor:
-        fake_mode = torch._subclasses.FakeTensorMode()
+        fake_mode = torch._subclasses.make_fake_mode()
         tensor_converter = torch._subclasses.fake_tensor.FakeTensorConverter()
         ret = tensor_converter.from_meta_and_device(
             fake_mode,

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -70,7 +70,7 @@ from torch._guards import (
 )
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import is_custom_class
-from torch._subclasses.fake_tensor import FakeTensor
+from torch._subclasses.fake_tensor import FakeTensor, make_fake_mode
 from torch._utils_internal import signpost_event
 from torch.export.dynamic_shapes import _ConstraintTarget
 from torch.fx._lazy_graph_module import _make_graph_module  # type: ignore[attr-defined]
@@ -857,7 +857,7 @@ class OutputGraph(OutputGraphCommon):
         import torch._functorch.config as _config
 
         with _config.patch(fake_tensor_allow_unsafe_data_ptr_access=False):
-            fake_mode = torch._subclasses.FakeTensorMode(
+            fake_mode = make_fake_mode(
                 shape_env=shape_env,
                 # TODO (tmanlaibaatar) Remove this once we always lift params and buffers
                 allow_non_fake_inputs=bool(self.export),
@@ -3022,7 +3022,7 @@ class OutputGraph(OutputGraphCommon):
                     # from scratch when we go to AOTAutograd. But the ShapeEnv must be preserved as
                     # Dynamo made decisions about what is dynamic or not / guards from the user code
                     # that is not in graph.
-                    backend_fake_mode = torch._subclasses.FakeTensorMode(
+                    backend_fake_mode = make_fake_mode(
                         shape_env=old_fake_mode.shape_env,
                     )
                 # TODO(voz): Ostensibly, this should be scoped and

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -300,7 +300,7 @@ def wrap_compiler_debug(
         compile_region_name: str | None = None,
         **kwargs: Unpack[_CompileFxKwargs],
     ) -> OutputCode:
-        from torch._subclasses import FakeTensorMode
+        from torch._subclasses import make_fake_mode
 
         compiler_fn = functools.partial(
             unconfigured_compiler_fn,
@@ -370,7 +370,7 @@ def wrap_compiler_debug(
             # Copy the tensor attrs like shape, stride etc by converting to Fake Tensor
             # because inductor clears the tensor list in its codegen. And example_inputs
             # are available only for the first invocation.
-            fake_mode = FakeTensorMode()
+            fake_mode = make_fake_mode()
             copy_tensor_attrs = [
                 fake_mode.from_tensor(x) if isinstance(x, torch.Tensor) else x
                 for x in real_inputs

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -26,7 +26,7 @@ from torch._export.utils import _fakify_params_buffers
 from torch._guards import Source
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import is_custom_class_obj
-from torch._subclasses.fake_tensor import FakeTensorMode
+from torch._subclasses.fake_tensor import FakeTensorMode, make_fake_mode
 from torch.export import Constraint
 from torch.export.dynamic_shapes import (
     _check_dynamic_shapes,
@@ -615,7 +615,7 @@ def make_fake_inputs(
             "co_firstlineno": code.co_firstlineno,
         }
         with _config.patch(fake_tensor_allow_unsafe_data_ptr_access=False):
-            fake_mode = FakeTensorMode(
+            fake_mode = make_fake_mode(
                 shape_env=ShapeEnv(
                     tracked_fakes=[],
                     co_fields=co_fields,

--- a/torch/_export/pass_base.py
+++ b/torch/_export/pass_base.py
@@ -15,6 +15,7 @@ from torch._subclasses import FakeTensor, UnsupportedFakeTensorException
 from torch._subclasses.fake_tensor import (
     FakeTensorMode,
     is_fake_tensor,
+    make_fake_mode,
     maybe_get_fake_constant,
     maybe_get_fake_mode,
 )
@@ -490,7 +491,7 @@ class _ExportPassBaseDeprecatedDoNotUse(PassBase):
                     raise AssertionError("Multiple fake tensor mode detected.")
                 fake_tensor_mode = maybe_get_fake_mode(i)
         if fake_tensor_mode is None:
-            self.tracer.fake_tensor_mode = FakeTensorMode(allow_non_fake_inputs=True)
+            self.tracer.fake_tensor_mode = make_fake_mode(allow_non_fake_inputs=True)
             fake_tensor_mode = nullcontext()  # type: ignore[assignment]
             dispatcher_mode = nullcontext()  # type: ignore[assignment]
         else:

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -29,7 +29,7 @@ import torch.export.exported_program as ep
 from torch._export.non_strict_utils import _enable_graph_inputs_of_type_nn_module
 from torch._export.verifier import load_verifier
 from torch._library.opaque_object import get_opaque_type_name, is_custom_class_obj
-from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode, make_fake_mode
 from torch.fx._symbolic_trace import _ConstantAttributeType
 from torch.fx.experimental import symbolic_shapes
 from torch.fx.traceback import NodeSource
@@ -2916,7 +2916,7 @@ class GraphModuleDeserializer(metaclass=Final):
         try:
             log.debug("\n[deserialize]")
             self.shape_env = symbolic_shapes.ShapeEnv(assume_static_by_default=True)
-            self.fake_tensor_mode = FakeTensorMode(
+            self.fake_tensor_mode = make_fake_mode(
                 allow_fallback_kernels=False,
                 allow_non_fake_inputs=True,
                 shape_env=self.shape_env,

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -714,14 +714,14 @@ def deserialize_bundled_cache_entry(
     # in case it needs to be serialized again
     serializable_copy = deepcopy(entry)
 
-    from torch._subclasses import FakeTensorMode
+    from torch._subclasses import make_fake_mode
     from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
     context = torch._guards.TracingContext.try_get()
     if context is None:
         # Create a clean environment when running fx graph post compile
         # if one is not available
-        context = torch._guards.TracingContext(FakeTensorMode(shape_env=ShapeEnv()))
+        context = torch._guards.TracingContext(make_fake_mode(shape_env=ShapeEnv()))
     with torch._guards.tracing(context):
         compiled_fn = entry.wrap_post_compile(
             [],

--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -10,7 +10,11 @@ from torch._custom_class_base import CustomClassBase
 from torch._guards import detect_fake_mode
 from torch._library.opaque_object import is_custom_class
 from torch._subclasses import FakeTensor, FakeTensorMode
-from torch._subclasses.fake_tensor import is_fake_tensor, maybe_get_fake_mode
+from torch._subclasses.fake_tensor import (
+    is_fake_tensor,
+    make_fake_mode,
+    maybe_get_fake_mode,
+)
 from torch.fx.experimental.proxy_tensor import _pytree_subclasses_that_lose_info
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
@@ -229,7 +233,7 @@ def construct_fake_mode(
     fake_mode = detect_fake_mode(flat_args)
     if fake_mode is None:
         shape_env = ShapeEnv() if aot_config.dynamic_shapes else None
-        fake_mode = FakeTensorMode(shape_env=shape_env)
+        fake_mode = make_fake_mode(shape_env=shape_env)
     else:
         shape_env = fake_mode.shape_env
     return (fake_mode, shape_env)

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -29,7 +29,7 @@ from torch._guards import detect_fake_mode
 from torch._inductor.codecache import resolve_pre_grad_pass_timing
 
 # Runtime annotation consumers still resolve BoxedBool from module globals.
-from torch._subclasses import FakeTensorMode
+from torch._subclasses import FakeTensorMode, make_fake_mode
 from torch._subclasses.fake_tensor import maybe_get_fake_mode
 from torch.export._tree_utils import reorder_kwargs
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -1859,7 +1859,7 @@ def aot_export_joint_simple(
         # Attempt to run the fw_module with the original user inputs
         fake_mode = detect_fake_mode(args)
         if fake_mode is None:
-            fake_mode = FakeTensorMode()
+            fake_mode = make_fake_mode()
         with fake_mode:
             fw_module(*args)
     return fx_g

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -654,7 +654,11 @@ def create_fw_bw_graph(
     from torch._dispatch.python import suspend_functionalization
     from torch._dynamo._trace_wrapped_higher_order_op import mod_index
     from torch._functorch.aot_autograd import AOTConfig, create_joint
-    from torch._subclasses.fake_tensor import FakeTensorMode, is_fake_tensor
+    from torch._subclasses.fake_tensor import (
+        FakeTensorMode,
+        is_fake_tensor,
+        make_fake_mode,
+    )
     from torch._subclasses.functional_tensor import disable_functional_mode
     from torch.fx.experimental.proxy_tensor import disable_proxy_modes_tracing
 
@@ -691,7 +695,7 @@ def create_fw_bw_graph(
 
             fake_mode = detect_fake_mode(index_values)
             if fake_mode is None:
-                fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
+                fake_mode = make_fake_mode(allow_non_fake_inputs=True)
 
             with fake_mode:
                 unwrapped_score_mod_indexes = pytree.tree_map(_from_fun, index_values)

--- a/torch/_higher_order_ops/local_map.py
+++ b/torch/_higher_order_ops/local_map.py
@@ -216,7 +216,7 @@ def create_hop_fw_bw(
     from torch._dispatch.python import suspend_functionalization
     from torch._functorch.aot_autograd import AOTConfig, create_joint
     from torch._guards import detect_fake_mode
-    from torch._subclasses.fake_tensor import FakeTensorMode
+    from torch._subclasses.fake_tensor import FakeTensorMode, make_fake_mode
     from torch._subclasses.functional_tensor import disable_functional_mode
     from torch.fx.experimental.proxy_tensor import disable_proxy_modes_tracing, make_fx
 
@@ -250,7 +250,7 @@ def create_hop_fw_bw(
 
             fake_mode = detect_fake_mode(_args)
             if fake_mode is None:
-                fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
+                fake_mode = make_fake_mode(allow_non_fake_inputs=True)
 
             with fake_mode:
                 fw_inputs = redistribute_fw_inputs(

--- a/torch/_higher_order_ops/switch.py
+++ b/torch/_higher_order_ops/switch.py
@@ -24,7 +24,7 @@ from torch._higher_order_ops.utils import (
     validate_subgraph_args_types,
 )
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
+from torch._subclasses.fake_tensor import FakeTensorMode, make_fake_mode
 from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
 from torch.utils._python_dispatch import _get_current_dispatch_mode
 
@@ -72,7 +72,7 @@ class SwitchOp(HigherOrderOperator):
 
         fake_mode = detect_fake_mode(operands)
         if fake_mode is None or fake_mode.shape_env is None:
-            fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+            fake_mode = make_fake_mode(shape_env=ShapeEnv())
         # pyrefly: ignore [missing-attribute]
         with fake_mode, fake_mode.shape_env.ignore_fresh_unbacked_symbols():
             merged_outputs = [

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -226,11 +226,11 @@ def _worker_nvgemm_autotuning_precompile(
     import torch
     from torch._inductor.runtime.cutedsl_cache import disk_cache_set
     from torch._inductor.utils import _ensure_fp4_dtype_registered
-    from torch._subclasses.fake_tensor import FakeTensorMode
+    from torch._subclasses.fake_tensor import make_fake_mode
 
     _ensure_fp4_dtype_registered()
 
-    with FakeTensorMode():
+    with make_fake_mode():
         input_tensors = tuple(
             torch.empty_strided(m.sizes, m.strides, device=m.device, dtype=m.dtype)
             for m in input_tensor_meta
@@ -636,7 +636,7 @@ def _nvgemm_precompile(
     """
     import torch
     from torch._inductor.runtime.cutedsl_cache import disk_cache_set
-    from torch._subclasses.fake_tensor import FakeTensorMode
+    from torch._subclasses.fake_tensor import make_fake_mode
 
     if max_active_clusters is None:
         return
@@ -647,7 +647,7 @@ def _nvgemm_precompile(
         return
 
     device = f"cuda:{device_index}"
-    with FakeTensorMode():
+    with make_fake_mode():
         tensors = {}
         for name in [*input_param_names, "output"]:
             tensors[name] = torch.empty_strided(

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -102,6 +102,7 @@ from torch._inductor.utils import (
 )
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import is_custom_class
+from torch._subclasses.fake_tensor import make_fake_mode
 from torch._logging import trace_structured
 from torch._utils_internal import compile_time_strobelight_meta
 from torch.fx import GraphModule
@@ -3114,7 +3115,7 @@ def _compile_fx_main(
 
         fake_mode = detect_fake_mode(
             example_inputs_
-        ) or torch._subclasses.FakeTensorMode(allow_non_fake_inputs=True)
+        ) or make_fake_mode(allow_non_fake_inputs=True)
         tracing_context = (
             torch._guards.TracingContext.try_get()
             or torch._guards.TracingContext(fake_mode)
@@ -3447,7 +3448,7 @@ def autograd_cache_key(
     #       torch._guards.tracing, compiled_autograd._disable,
     #       functorch_config.patch
 
-    fake_mode = detect_fake_mode(example_inputs) or torch._subclasses.FakeTensorMode(
+    fake_mode = detect_fake_mode(example_inputs) or make_fake_mode(
         allow_non_fake_inputs=True
     )
     tracing_context = (

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -24,7 +24,7 @@ from torch._inductor.output_code import (
     CompiledFxGraphConstantsWithGm,
     OutputCode,
 )
-from torch._subclasses import FakeTensorMode
+from torch._subclasses import FakeTensorMode, make_fake_mode
 from torch.utils._ordered_set import OrderedSet
 
 from . import config
@@ -241,7 +241,7 @@ def _current_fake_mode() -> FakeTensorMode:
         return fake_mode
 
     shape_env = torch.fx.experimental.symbolic_shapes.ShapeEnv()
-    return FakeTensorMode(shape_env=shape_env)
+    return make_fake_mode(shape_env=shape_env)
 
 
 @dataclass

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -951,11 +951,11 @@ class CompiledFxGraph(OutputCode):
         )
 
         if self._original_gm is None and self._serialized_original_gm is not None:
-            from torch._subclasses import FakeTensorMode
+            from torch._subclasses import make_fake_mode
             from torch.fx._graph_pickler import GraphPickler
             from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
-            fake_mode = FakeTensorMode(
+            fake_mode = make_fake_mode(
                 allow_non_fake_inputs=True,
                 shape_env=ShapeEnv(),
             )

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -78,7 +78,7 @@ from torch.utils._ordered_set import OrderedSet
 from .._functorch import config as functorch_config
 from .._functorch.aot_autograd import aot_function, make_boxed_func
 from .._functorch.partitioners import default_partition
-from .._subclasses import FakeTensor, FakeTensorMode
+from .._subclasses import FakeTensor, FakeTensorMode, make_fake_mode
 from ..fx import Transformer
 from . import config
 from .decomposition import select_decomp_table
@@ -2950,7 +2950,7 @@ def init_once_fakemode(fn: Callable[..., Any]) -> Callable[..., Any]:
         if "get_decomp_fn" in _fn_params:
             kwargs["get_decomp_fn"] = get_decomp_fn
 
-        with torch._guards.tracing(None), unset_fake_temporarily(), FakeTensorMode():
+        with torch._guards.tracing(None), unset_fake_temporarily(), make_fake_mode():
             result = fn(**kwargs)
 
         # clear view matches encountered during tracing

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -20,7 +20,7 @@ from torch._inductor.cpp_builder import normalize_path_separator
 from torch._inductor.cudagraph_utils import BoxedDeviceIndex
 from torch._inductor.runtime.cache_dir_utils import temporary_cache_dir
 from torch._inductor.utils import BoxedBool, InputType
-from torch._subclasses import FakeTensorMode
+from torch._subclasses import FakeTensorMode, make_fake_mode
 from torch._subclasses.fake_tensor import maybe_get_fake_mode
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.fx.graph_module import _share_torchbind_and_process_group_on_deepcopy
@@ -278,7 +278,7 @@ class CacheCompiledArtifact(CompiledArtifact):
                 boxed_forward_device_index=BoxedDeviceIndex(0),
             )
 
-            context = torch._guards.TracingContext(FakeTensorMode(shape_env=ShapeEnv()))
+            context = torch._guards.TracingContext(make_fake_mode(shape_env=ShapeEnv()))
             with torch._guards.tracing(context):
                 compiled_fn = entry.wrap_post_compile(
                     [], entry.sanitized_aot_config, fx_config
@@ -455,7 +455,7 @@ def _resolve_fake_mode(
                     'when `dynamic_shapes="from_example_inputs"`.'
                 )
             return fake_mode
-        return FakeTensorMode(shape_env=ShapeEnv())
+        return make_fake_mode(shape_env=ShapeEnv())
     elif fake_mode is not None:
         raise ValueError(
             "standalone_compile only supports passing `fake_mode` when "
@@ -501,7 +501,7 @@ def _resolve_fake_mode(
                 if maybe_fake_mode is not None:
                     return maybe_fake_mode
 
-        return FakeTensorMode(shape_env=ShapeEnv())
+        return make_fake_mode(shape_env=ShapeEnv())
     else:
         raise ValueError(
             f"standalone_compile got unsupported `dynamic_shapes` value: dynamic_shapes={dynamic_shapes}."

--- a/torch/_subclasses/__init__.py
+++ b/torch/_subclasses/__init__.py
@@ -3,6 +3,7 @@ from torch._subclasses.fake_tensor import (
     DynamicOutputShapeException,
     FakeTensor,
     FakeTensorMode,
+    make_fake_mode,
     UnsupportedFakeTensorException,
 )
 from torch._subclasses.fake_utils import CrossRefFakeMode
@@ -11,6 +12,7 @@ from torch._subclasses.fake_utils import CrossRefFakeMode
 __all__ = [
     "FakeTensor",
     "FakeTensorMode",
+    "make_fake_mode",
     "UnsupportedFakeTensorException",
     "DynamicOutputShapeException",
     "CrossRefFakeMode",

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -344,6 +344,30 @@ def maybe_get_fake_constant(x: object) -> Tensor | None:
     return None
 
 
+def make_fake_mode(
+    *,
+    shape_env: Any = None,
+    allow_non_fake_inputs: bool = False,
+    allow_fallback_kernels: bool = True,
+    export: bool = False,
+    static_shapes: bool | None = None,
+    converter: FakeTensorConverter | None = None,
+) -> FakeTensorMode:
+    """FakeTensorMode factory. The single place mode construction lives, so call
+    sites don't duplicate it.
+    """
+    kwargs: dict[str, Any] = {}
+    if static_shapes is not None:
+        kwargs["static_shapes"] = static_shapes
+    return FakeTensorMode(
+        shape_env=shape_env,
+        allow_non_fake_inputs=allow_non_fake_inputs,
+        allow_fallback_kernels=allow_fallback_kernels,
+        export=export,
+        **kwargs,
+    )
+
+
 @functools.cache
 def get_schema_info(func: OpOverload) -> torch._C._SchemaInfo:
     return torch._C._SchemaInfo(func._schema)

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -58,6 +58,7 @@ from torch._subclasses.fake_tensor import (
     get_plain_tensors,
     is_fake,
     is_fake_tensor,
+    make_fake_mode,
     maybe_get_fake_mode,
     unset_fake_temporarily,
 )
@@ -746,7 +747,7 @@ def extract_val(val: _ExtractValType, include_real: bool = False) -> _ExtractVal
 
             fake_tensor_mode = detect_fake_mode(val)
             if not fake_tensor_mode:
-                fake_tensor_mode = FakeTensorMode(allow_fallback_kernels=True)
+                fake_tensor_mode = make_fake_mode(allow_fallback_kernels=True)
             with fake_tensor_mode:
                 return torch.empty_strided(
                     val.shape, val.stride(), device=val.device, dtype=val.dtype
@@ -2933,7 +2934,7 @@ class _MakefxTracer:
                     import torch._functorch.config as _config
 
                     with _config.patch(fake_tensor_allow_unsafe_data_ptr_access=False):
-                        fake_tensor_mode = FakeTensorMode(
+                        fake_tensor_mode = make_fake_mode(
                             allow_fallback_kernels=True,
                             allow_non_fake_inputs=self._allow_non_fake_inputs,
                             shape_env=ShapeEnv(),
@@ -2962,7 +2963,7 @@ class _MakefxTracer:
                     import torch._functorch.config as _config
 
                     with _config.patch(fake_tensor_allow_unsafe_data_ptr_access=False):
-                        fake_tensor_mode = FakeTensorMode(
+                        fake_tensor_mode = make_fake_mode(
                             allow_fallback_kernels=False,
                             allow_non_fake_inputs=self._allow_non_fake_inputs,
                             shape_env=shape_env,


### PR DESCRIPTION
this is a no-op for now, but eventually make_fake_mode will return python faketensormode or cpp faketensormode depending on what the cpp faketensormode flag is flipped to

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191793
* #191792
* #190248
* #190247



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @xmfan @aditvenk