### PR TITLE
[MPS] Fix MPP prefill attention for macos 26 machines

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -930,7 +930,10 @@ if(USE_MPS)
                 cmake_path(GET SHADER STEM TGT_STEM)
                 string(CONCAT TGT_40 ${TGT_STEM} "_40.air")
                 list(APPEND AIR_40 ${TGT_40})
-                metal_to_air(${SHADER} ${TGT_40} "-std=metal4.0")
+                # MetalPerformancePrimitives switches the cooperative-tensor ABI on the
+                # deployment target (__TENSOR_OPS_SUPPORT_DEPLOYMENT_TARGET_26_2); the
+                # MPP kernels assume the 26.2+ layout, so pin the target explicitly.
+                metal_to_air(${SHADER} ${TGT_40} "-std=metal4.0;-mmacos-version-min=26.2")
             endforeach()
             air_to_metallib(kernels_40.metallib ${AIR_40})
             list(APPEND METALLIB_DEPS kernels_40.metallib)

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -955,7 +955,9 @@ class BundledShaderLibrary : public MetalShaderLibrary {
       auto device = MPSDevice::getInstance()->device();
       NSError* error = nil;
 #ifdef CAN_BUILD_METAL_4
-      const auto section_name = is_macos_at_least(MacOSVersion::MACOS_26_0) ? "metal_40" : "metal_basic";
+      // kernels_40.metallib is built with -mmacos-version-min=26.2 (MPP
+      // cooperative-tensor ABI), so only load it on 26.2+.
+      const auto section_name = is_macos_at_least(MacOSVersion::MACOS_26_2) ? "metal_40" : "metal_basic";
 #else
       const auto section_name = "metal_basic";
 #endif

--- a/aten/src/ATen/native/mps/kernels/MppAttention.h
+++ b/aten/src/ATen/native/mps/kernels/MppAttention.h
@@ -1,6 +1,6 @@
 // MPP cooperative-tensor flash-attention prefill for MPS, on
 // mpp::tensor_ops::matmul2d. Adapted from MLX. Emitted only with the
-// Metal 4 SDK; runtime dispatch gates on macOS 26.0+.
+// Metal 4 SDK; runtime dispatch gates on macOS 26.2+.
 #pragma once
 
 #include <ATen/native/mps/kernels/PrefillAttention.h>


### PR DESCRIPTION
Initially when I landed the PR, I tested on a machine with macOS 27 which didn't have this problem. Turns out macOS 26 does have this problem, namely, the metal4.0 lib compiled without an explicit deployment target and macOS 26 toolchains default to 26.0 which selected MPP's legacy cooperative-tensor ABI, whose lane layout doesn't match the attention kernel's fragment formulas  so P@V output scrambled. macOS 27 defaults past 26.2.