### PR TITLE
Add typing overloads for torch.utils.checkpoint.checkpoint

### DIFF
--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -20,7 +20,7 @@ from torch.utils._pytree import tree_map
 from torch.testing._internal.logging_tensor import capture_logs, LoggingTensorMode
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch._C._autograd import _make_saved_tensor, SavedTensor
-from typing import NoReturn
+from typing import NoReturn, overload, ParamSpec, TypeVar
 
 __all__ = [
     "checkpoint",
@@ -43,6 +43,9 @@ __all__ = [
 ]
 
 _DEFAULT_DETERMINISM_MODE = "default"
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
 
 _checkpoint_debug_enabled: bool | None = None
 
@@ -374,6 +377,35 @@ class _CheckpointedFunction:
 
 def _make_checkpoint_wrapper(function, **checkpoint_kwargs):
     return _CheckpointedFunction(function, **checkpoint_kwargs)
+
+
+@overload
+def checkpoint(
+    function: Callable[..., _T],
+    *args: Any,
+    use_reentrant: bool | None = None,
+    preserve_rng_state: bool = True,
+    context_fn: Callable[[], Tuple[ContextManager, ContextManager]] = noop_context_fn,
+    determinism_check: str = _DEFAULT_DETERMINISM_MODE,
+    debug: bool = False,
+    early_stop: bool = True,
+    respect_saved_tensors_hooks: bool | None = None,
+    **kwargs: Any,
+) -> _T: ...
+
+
+@overload
+def checkpoint(
+    function: None = None,
+    *,
+    use_reentrant: bool | None = None,
+    preserve_rng_state: bool = True,
+    context_fn: Callable[[], Tuple[ContextManager, ContextManager]] = noop_context_fn,
+    determinism_check: str = _DEFAULT_DETERMINISM_MODE,
+    debug: bool = False,
+    early_stop: bool = True,
+    respect_saved_tensors_hooks: bool | None = None,
+) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]: ...
 
 
 # Note: [torch.compile and checkpoint]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #191795

The curried calling convention added in #189411 changed checkpoint()'s
inferred return type. checkpoint() has no return annotation, so type
checkers infer it from the union of its return statements; previously
every path was Any, but the new curried branch returns
functools.partial(_make_checkpoint_wrapper, ...), a concrete type. Under
pyright the result became partial[_CheckpointedFunction] | Any, so
downstream code that unpacks or indexes the result stopped typechecking,
forcing workarounds like cast(Tuple[Tensor, Dict[str, Tensor]],
checkpoint(...)). Pyrefly infers Unknown here, which is why PyTorch CI
did not catch it.

Fix by declaring two overloads: the direct call checkpoint(fn, *args)
returns the wrapped function's return type _T, and the curried call
checkpoint(**config) returns a ParamSpec-preserving decorator. The
@torch._disable_dynamo wrapper passes the overloads through intact since
it is typed with Callable[_P, _T]. An alternative was annotating the
direct-call overload as returning Any to exactly preserve the old
behavior, but returning _T is strictly more useful and matches the
runtime semantics.

overload, ParamSpec, and TypeVar are imported explicitly because ruff
cannot see overload through the existing star import and flags the
overload stubs as F811 redefinitions.

Test Plan:

Verified the failing pattern is fixed under pyright and clean under
pyrefly and mypy (no new errors; revealed types now match the wrapped
function for direct, curried, and decorator forms):

```
uvx pyright agent_space/verify_final.py
pyrefly check agent_space/verify_final.py torch/utils/checkpoint.py
uvx mypy --follow-imports=silent torch/utils/checkpoint.py
```

Runtime behavior unchanged:

```
python -m pytest test/test_autograd.py -k checkpoint -q
```

62 passed, 4 skipped.

Authored with assistance from Claude.