### PR TITLE
[do-not-merge] Test for upstreaming Kineto

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,9 +85,6 @@
 [submodule "third_party/cudnn_frontend"]
 	path = third_party/cudnn_frontend
 	url = https://github.com/NVIDIA/cudnn-frontend.git
-[submodule "third_party/kineto"]
-    path = third_party/kineto
-    url = https://github.com/pytorch/kineto
 [submodule "third_party/pocketfft"]
 	path = third_party/pocketfft
 	url = https://github.com/mreineck/pocketfft

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -536,6 +536,7 @@ include_patterns = [
 ]
 exclude_patterns = [
     'torch/headeronly/macros/Macros.h',
+    'third_party/kineto/**',
 ]
 command = [
     'python3',
@@ -559,6 +560,7 @@ include_patterns = [
 ]
 exclude_patterns = [
     'torch/headeronly/macros/Macros.h',
+    'third_party/kineto/**',
 ]
 command = [
     'python3',
@@ -613,6 +615,7 @@ exclude_patterns = [
     'torch/headeronly/**',
     'torch/lib/**',
     'torch/nativert/**',
+    'third_party/kineto/**',
 ]
 command = [
     'python3',
@@ -673,6 +676,7 @@ exclude_patterns = [
     'torch/csrc/utils/pybind.h',
     'torch/utils/benchmark/utils/valgrind_wrapper/compat_bindings.cpp',
     'caffe2/**/*',
+    'third_party/kineto/**',
 ]
 command = [
     'python3',
@@ -769,6 +773,7 @@ exclude_patterns = [
     '**/fb/**',
     # These are safe to exclude as they do not have Python
     'c10/**/*',
+    'third_party/kineto/**',
 ]
 command = [
     'python3',
@@ -988,6 +993,7 @@ exclude_patterns = [
     'cmake/cmake_uninstall.cmake.i',
     'fb/**',
     '**/fb/**',
+    'third_party/kineto/**',
 ]
 command = [
     'uv',
@@ -1607,6 +1613,9 @@ include_patterns = [
     "**/*requirements*.txt",
     "**/*requirements*.in",
 ]
+exclude_patterns = [
+    'third_party/kineto/**',
+]
 
 [[linter]]
 code = 'COPYRIGHT'
@@ -1615,6 +1624,7 @@ exclude_patterns = [
     '.lintrunner.toml',
     'fb/**',
     '**/fb/**',
+    'third_party/kineto/**',
 ]
 command = [
     'python3',
@@ -1636,6 +1646,7 @@ include_patterns = ['**']
 exclude_patterns = [
     'fb/**',
     '**/fb/**',
+    'third_party/kineto/**',
 ]
 command = [
     'python3',

--- a/third_party/kineto/LICENSE
+++ b/third_party/kineto/LICENSE
@@ -1,0 +1,33 @@
+BSD License
+
+For Kineto software
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+All contributions by Microsoft:
+Copyright (c) Microsoft Corporation. (The Azure AI Platform team)
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Meta nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/kineto/libkineto/CMakeLists.txt
+++ b/third_party/kineto/libkineto/CMakeLists.txt
@@ -1,0 +1,346 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+project(kineto VERSION 0.1 LANGUAGES CXX C)
+
+#install libraries into correct locations on all platforms
+include(GNUInstallDirs)
+
+# function to extract filelists from libkineto_defs.bzl file
+find_package(Python3 COMPONENTS Interpreter)
+function(get_filelist name outputvar)
+  execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -c
+            "exec(open('libkineto_defs.bzl').read());print(';'.join(${name}))"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE _tempvar)
+  string(REPLACE "\n" "" _tempvar "${_tempvar}")
+  set(${outputvar} ${_tempvar} PARENT_SCOPE)
+endfunction()
+
+set(KINETO_LIBRARY_TYPE "default" CACHE STRING
+  "Type of library (default, static or shared) to build")
+set_property(CACHE KINETO_LIBRARY_TYPE PROPERTY STRINGS default shared static)
+option(KINETO_BUILD_TESTS "Build kineto unit tests" ON)
+option(KINETO_BUILD_BENCHMARKS "Build kineto benchmarks" OFF)
+
+set(LIBKINETO_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(LIBKINETO_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
+set(LIBKINETO_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+set(LIBKINETO_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(LIBKINETO_THIRDPARTY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+#We should default to a Release build
+if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+endif()
+
+if(DEFINED CUDA_SOURCE_DIR AND NOT DEFINED CUDAToolkit_ROOT)
+  set(CUDAToolkit_ROOT "${CUDA_SOURCE_DIR}")
+  message(STATUS " CUDA_SOURCE_DIR = ${CUDA_SOURCE_DIR}")
+endif()
+
+if(NOT ROCM_SOURCE_DIR)
+  set(ROCM_SOURCE_DIR "$ENV{ROCM_SOURCE_DIR}")
+  message(STATUS " ROCM_SOURCE_DIR = ${ROCM_SOURCE_DIR}")
+endif()
+
+# --- Backend selection ---
+# KINETO_BACKEND selects the GPU backend (or "cpu" for no GPU profiling).
+# Selection is explicit: if the chosen toolkit isn't available, configuration
+# fails. Use KINETO_BACKEND=cpu to build without GPU support.
+
+# Track whether the user explicitly set KINETO_BACKEND before the default
+# fires below, so we can warn when we fall back to cpu.
+set(_kineto_backend_explicit ON)
+if(NOT DEFINED CACHE{KINETO_BACKEND} AND NOT DEFINED KINETO_BACKEND)
+  set(_kineto_backend_explicit OFF)
+endif()
+
+set(KINETO_BACKEND "cpu" CACHE STRING
+    "Kineto GPU backend: cpu, cuda, rocm, or xpu")
+set_property(CACHE KINETO_BACKEND PROPERTY STRINGS cpu cuda rocm xpu)
+
+set(_KINETO_BACKEND_VALID cpu cuda rocm xpu)
+if(NOT KINETO_BACKEND IN_LIST _KINETO_BACKEND_VALID)
+  message(FATAL_ERROR
+    "KINETO_BACKEND=${KINETO_BACKEND} is invalid. "
+    "Must be one of: ${_KINETO_BACKEND_VALID}")
+endif()
+unset(_KINETO_BACKEND_VALID)
+message(STATUS "KINETO_BACKEND = ${KINETO_BACKEND}")
+
+if(NOT _kineto_backend_explicit)
+  message(WARNING
+    "KINETO_BACKEND was not set; defaulting to 'cpu'. "
+    "Pass -DKINETO_BACKEND={cpu,cuda,rocm,xpu} explicitly to silence this warning.")
+endif()
+unset(_kineto_backend_explicit)
+
+# Per-backend configure-time setup.
+if(KINETO_BACKEND STREQUAL "cuda")
+  # CUDA / CUPTI detection
+  find_package(CUDAToolkit REQUIRED)
+  if(NOT TARGET CUDA::cupti)
+    message(FATAL_ERROR
+      "KINETO_BACKEND=cuda but CUPTI was not found. "
+      "Install the CUDA Toolkit with CUPTI, set CUDAToolkit_ROOT, "
+      "or set KINETO_BACKEND=cpu.")
+  endif()
+  message(STATUS "Found CUPTI")
+elseif(KINETO_BACKEND STREQUAL "rocm")
+  # ROCm prerequisites and version detection
+  if(NOT ROCM_SOURCE_DIR)
+    message(FATAL_ERROR
+      "KINETO_BACKEND=rocm but ROCM_SOURCE_DIR is not set. "
+      "Set ROCM_SOURCE_DIR (or the ROCM_SOURCE_DIR environment variable) "
+      "or set KINETO_BACKEND=cpu.")
+  endif()
+  if(NOT ROCM_INCLUDE_DIRS)
+    set(ROCM_INCLUDE_DIRS "${ROCM_SOURCE_DIR}/include")
+  endif()
+
+  find_file(ROCM_VERSION_HEADER_PATH
+    NAMES rocm-core/rocm_version.h
+    NO_DEFAULT_PATH
+    PATHS ${ROCM_INCLUDE_DIRS}
+  )
+  if(NOT EXISTS ${ROCM_VERSION_HEADER_PATH})
+    message(FATAL_ERROR
+      "KINETO_BACKEND=rocm but rocm-core/rocm_version.h was not found in "
+      "${ROCM_INCLUDE_DIRS}. Check ROCM_SOURCE_DIR / ROCM_INCLUDE_DIRS or "
+      "set KINETO_BACKEND=cpu.")
+  endif()
+  set(ROCM_HEADER_FILE ${ROCM_VERSION_HEADER_PATH})
+
+  message(STATUS "Reading ROCM version from: ${ROCM_HEADER_FILE}")
+  file(READ "${ROCM_HEADER_FILE}" ROCM_HEADER_CONTENT)
+
+  string(REGEX MATCH "ROCM_VERSION_MAJOR[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+  string(REPLACE "ROCM_VERSION_MAJOR" "" TEMP2 ${TEMP1})
+  string(STRIP ${TEMP2} ROCM_VERSION_DEV_MAJOR)
+  string(REGEX MATCH "ROCM_VERSION_MINOR[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+  string(REPLACE "ROCM_VERSION_MINOR" "" TEMP2 ${TEMP1})
+  string(STRIP ${TEMP2} ROCM_VERSION_DEV_MINOR)
+  string(REGEX MATCH "ROCM_VERSION_PATCH[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+  string(REPLACE "ROCM_VERSION_PATCH" "" TEMP2 ${TEMP1})
+  string(STRIP ${TEMP2} ROCM_VERSION_DEV_PATCH)
+
+  message(STATUS "ROCM major: ${ROCM_VERSION_DEV_MAJOR}")
+  message(STATUS "ROCM minor: ${ROCM_VERSION_DEV_MINOR}")
+  message(STATUS "ROCM patch: ${ROCM_VERSION_DEV_PATCH}")
+
+  # Kineto uses rocprofiler-sdk, which is supported on ROCm 7.0 and later.
+  # roctracer was the only pre-7.0 path and has been removed, so older ROCm
+  # versions are no longer supported.
+  if(ROCM_VERSION_DEV_MAJOR LESS 7)
+    message(FATAL_ERROR
+      "KINETO_BACKEND=rocm requires ROCm >= 7.0 (rocprofiler-sdk); detected "
+      "ROCm ${ROCM_VERSION_DEV_MAJOR}.${ROCM_VERSION_DEV_MINOR}. "
+      "Upgrade ROCm or set KINETO_BACKEND=cpu.")
+  endif()
+  message(STATUS "Building with: rocprofiler-sdk")
+elseif(KINETO_BACKEND STREQUAL "xpu")
+  # XPU plugin
+  add_subdirectory(src/plugin/xpupti)
+endif()
+
+# Define file lists. Backends are mutually exclusive — exactly one (or none)
+# is active per build, gated on KINETO_BACKEND.
+if(KINETO_BACKEND STREQUAL "cpu")
+  get_filelist("get_libkineto_cpu_only_srcs(with_api=False)" LIBKINETO_SRCS)
+  message(STATUS " Building CPU-only profilers")
+elseif(KINETO_BACKEND STREQUAL "cuda")
+  get_filelist("get_libkineto_cupti_srcs(with_api=False)" LIBKINETO_SRCS)
+  message(STATUS " Building with cupti")
+elseif(KINETO_BACKEND STREQUAL "rocm")
+  get_filelist("get_libkineto_rocprofiler_srcs(with_api=False)" LIBKINETO_SRCS)
+  message(STATUS " Building with rocprofiler-sdk")
+elseif(KINETO_BACKEND STREQUAL "xpu")
+  get_filelist("get_libkineto_xpupti_srcs(with_api=False)" LIBKINETO_SRCS)
+  message(STATUS " Building with xpupti")
+endif()
+get_filelist("get_libkineto_public_headers()" LIBKINETO_PUBLIC_HEADERS)
+get_filelist("get_libkineto_api_srcs()" LIBKINETO_API_SRCS)
+
+add_library(kineto_base OBJECT ${LIBKINETO_SRCS})
+add_library(kineto_api OBJECT ${LIBKINETO_API_SRCS})
+
+# Make libraries depend on libkineto_defs.bzl
+add_custom_target(libkineto_defs.bzl DEPENDS libkineto_defs.bzl)
+add_dependencies(kineto_base libkineto_defs.bzl)
+
+set(KINETO_DEFINITIONS "KINETO_NAMESPACE=libkineto")
+list(APPEND KINETO_DEFINITIONS "ENABLE_IPC_FABRIC")
+set(KINETO_COMPILE_OPTIONS)
+if(MSVC)
+  list(APPEND KINETO_COMPILE_OPTIONS "/utf-8")
+endif()
+if(KINETO_BACKEND STREQUAL "cuda")
+  list(APPEND KINETO_DEFINITIONS "HAS_CUPTI")
+elseif(KINETO_BACKEND STREQUAL "rocm")
+  list(APPEND KINETO_DEFINITIONS "HAS_ROCTRACER")
+  target_compile_definitions(kineto_base PRIVATE "__HIP_PLATFORM_HCC__")
+  target_compile_definitions(kineto_base PRIVATE "__HIP_PLATFORM_AMD__")
+elseif(KINETO_BACKEND STREQUAL "xpu")
+  if(MSVC)
+    # MSVC reports __cplusplus as 199711L unless /Zc:__cplusplus is set, which
+    # breaks SYCL headers that static_assert __cplusplus >= 201703L.
+    list(APPEND KINETO_COMPILE_OPTIONS "/Zc:__cplusplus")
+  endif()
+
+  list(APPEND KINETO_COMPILE_OPTIONS ${XPUPTI_BUILD_FLAG})
+  if(KINETO_BUILD_TESTS)
+    set_target_properties(kineto_base PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    set_target_properties(kineto_api PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  endif()
+endif()
+
+target_compile_definitions(kineto_base PUBLIC "${KINETO_DEFINITIONS}")
+target_compile_options(kineto_base PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_compile_definitions(kineto_api PUBLIC "${KINETO_DEFINITIONS}")
+target_compile_options(kineto_api PRIVATE "${KINETO_COMPILE_OPTIONS}")
+
+# dynolog's ipcfabric is header-only and vendored under third_party/dynolog_headers
+# (pinned in version.txt), so only its include paths are needed below -- there
+# is no library to build or link.
+set(DYNOLOG_INCLUDE_DIR "${LIBKINETO_THIRDPARTY_DIR}/dynolog_headers/")
+set(IPCFABRIC_INCLUDE_DIR "${DYNOLOG_INCLUDE_DIR}/dynolog/src/ipcfabric/")
+
+if(NOT TARGET fmt::fmt-header-only)
+  if(NOT FMT_SOURCE_DIR)
+    set(FMT_SOURCE_DIR "${LIBKINETO_THIRDPARTY_DIR}/fmt"
+      CACHE STRING "fmt source directory from submodules")
+  endif()
+
+  # Build FMT.
+  # FMT and some other libraries use BUILD_SHARED_LIBS to control
+  # the library type.
+  # Save and restore the value after configuring FMT
+  set(FMT_INSTALL OFF)
+  add_subdirectory("${FMT_SOURCE_DIR}" "${LIBKINETO_BINARY_DIR}/fmt")
+  message(STATUS "Kineto: FMT_SOURCE_DIR = ${FMT_SOURCE_DIR}")
+endif()
+
+message(STATUS " DYNOLOG_INCLUDE_DIR = ${DYNOLOG_INCLUDE_DIR}")
+message(STATUS " IPCFABRIC_INCLUDE_DIR = ${IPCFABRIC_INCLUDE_DIR}")
+
+target_include_directories(kineto_base PUBLIC
+      $<BUILD_INTERFACE:${LIBKINETO_INCLUDE_DIR}>
+      $<BUILD_INTERFACE:${LIBKINETO_SOURCE_DIR}>)
+target_include_directories(kineto_base SYSTEM PUBLIC
+      $<BUILD_INTERFACE:${DYNOLOG_INCLUDE_DIR}>
+      $<BUILD_INTERFACE:${IPCFABRIC_INCLUDE_DIR}>)
+target_link_libraries(kineto_base PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>)
+
+target_include_directories(kineto_api PUBLIC
+      $<BUILD_INTERFACE:${LIBKINETO_DIR}>
+      $<BUILD_INTERFACE:${LIBKINETO_INCLUDE_DIR}>)
+target_link_libraries(kineto_api PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>)
+
+if(KINETO_LIBRARY_TYPE STREQUAL "static")
+  set(BUILD_SHARED_LIBS OFF)
+elseif(KINETO_LIBRARY_TYPE STREQUAL "shared")
+  set(BUILD_SHARED_LIBS ON)
+  set(WINDOWS_EXPORT_ALL_SYMBOLS ON)
+elseif(NOT KINETO_LIBRARY_TYPE STREQUAL "default")
+  message(FATAL_ERROR "Unsupported library type ${KINETO_LIBRARY_TYPE}")
+endif()
+
+add_library(kineto $<TARGET_OBJECTS:kineto_base> $<TARGET_OBJECTS:kineto_api>)
+if(BUILD_SHARED_LIBS)
+  set_property(TARGET kineto_base PROPERTY POSITION_INDEPENDENT_CODE ON)
+  set_property(TARGET kineto_api PROPERTY POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(kineto PROPERTIES CXX_VISIBILITY_PRESET hidden)
+endif()
+
+# Strict, pedantic compilation with warnings-as-errors.
+# Only enabled for platforms covered by Kineto's CI (CPU-only, CUDA, ROCm on
+# Linux). Disabled for Windows, macOS, and XPU builds which lack CI coverage.
+if(NOT WIN32 AND NOT APPLE AND NOT KINETO_BACKEND STREQUAL "xpu")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Werror")
+endif()
+
+set_target_properties(kineto kineto_base kineto_api PROPERTIES
+      CXX_STANDARD 20
+      CXX_STANDARD_REQUIRED YES
+      CXX_EXTENSIONS NO)
+
+target_include_directories(kineto PUBLIC
+      $<BUILD_INTERFACE:${LIBKINETO_INCLUDE_DIR}>
+      $<BUILD_INTERFACE:${LIBKINETO_SOURCE_DIR}>)
+
+# Attach backend-specific includes and libraries — at most one backend active.
+# Each backend dependency is attached to BOTH `kineto_base` (the OBJECT
+# library, so its own .cpp files compile against the dependency's headers)
+# AND `kineto` (the wrapper library, so downstream consumers link the
+# dependency). This dual-attach is required because $<TARGET_OBJECTS:> does
+# not propagate INTERFACE properties from kineto_base to kineto.
+if(KINETO_BACKEND STREQUAL "cuda")
+  target_link_libraries(kineto PUBLIC CUDA::cupti CUDA::cudart)
+  target_link_libraries(kineto_base PUBLIC CUDA::cupti CUDA::cudart)
+elseif(KINETO_BACKEND STREQUAL "rocm")
+  target_include_directories(kineto_base SYSTEM PUBLIC
+        $<BUILD_INTERFACE:${ROCM_INCLUDE_DIRS}>)
+  find_library(ROCPROF_LIBRARY NAMES librocprofiler-sdk.so HINTS
+    ${ROCM_SOURCE_DIR}/lib)
+  target_link_libraries(kineto "${ROCPROF_LIBRARY}")
+  target_link_libraries(kineto_base PUBLIC "${ROCPROF_LIBRARY}")
+  find_library(KINETO_HIP_LIBRARY NAMES libamdhip64.so HINTS
+    ${ROCM_SOURCE_DIR}/lib)
+  target_link_libraries(kineto "${KINETO_HIP_LIBRARY}")
+  target_link_libraries(kineto_base PUBLIC "${KINETO_HIP_LIBRARY}")
+elseif(KINETO_BACKEND STREQUAL "xpu")
+  # Bare form, not $<BUILD_INTERFACE:...>, because XPUPTI_INCLUDE_DIR is a
+  # multi-path semicolon list (SYCL + PTI). Wrapping a list in a single
+  # generator expression mangles paths after the first. kineto_base is not
+  # installed, so the install-interface concern that motivates BUILD_INTERFACE
+  # elsewhere doesn't apply here.
+  target_include_directories(kineto_base SYSTEM PUBLIC ${XPUPTI_INCLUDE_DIR})
+  target_link_libraries(kineto PRIVATE "${XPU_xpupti_LIBRARY}")
+endif()
+target_compile_definitions(kineto PUBLIC "${KINETO_DEFINITIONS}")
+
+if(KINETO_BUILD_TESTS)
+  if(NOT TARGET gtest)
+    set(INSTALL_GTEST OFF)
+    set(TMP_BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS}")
+    set(BUILD_SHARED_LIBS OFF)
+    add_subdirectory("${LIBKINETO_THIRDPARTY_DIR}/googletest")
+    set(BUILD_SHARED_LIBS "${TMP_BUILD_SHARED_LIBS}")
+    if(KINETO_BACKEND STREQUAL "xpu")
+      set_property(TARGET gtest PROPERTY POSITION_INDEPENDENT_CODE ON)
+    endif()
+  endif()
+  if(NOT TARGET nlohmann_json)
+    set(JSON_BuildTests OFF CACHE INTERNAL "")
+    set(JSON_Install OFF CACHE INTERNAL "")
+    add_subdirectory(
+      "${LIBKINETO_THIRDPARTY_DIR}/json"
+      "${LIBKINETO_BINARY_DIR}/json")
+  endif()
+  enable_testing()
+  add_subdirectory(test)
+endif()
+
+if(KINETO_BUILD_BENCHMARKS)
+  add_subdirectory(
+    "${CMAKE_CURRENT_SOURCE_DIR}/../benchmarks"
+    "${CMAKE_CURRENT_BINARY_DIR}/benchmarks"
+  )
+endif()
+
+install(TARGETS kineto
+  EXPORT kinetoLibraryConfig
+  DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(FILES ${LIBKINETO_PUBLIC_HEADERS}
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kineto")
+
+install(EXPORT kinetoLibraryConfig DESTINATION share/cmake/kineto
+  FILE kinetoLibraryConfig.cmake)

--- a/third_party/kineto/libkineto/README.md
+++ b/third_party/kineto/libkineto/README.md
@@ -1,0 +1,81 @@
+# Libkineto
+
+Libkineto is an in-process profiling library, part of the Kineto performance
+tools project.
+
+The library provides a way to collect GPU traces and metrics from the host
+process, either via the library public API or by sending a signal, if enabled. It also
+provides subroutines to output traces into various formats, including a JSON which
+can be used to visualize the traces in Perfetto/Chrome Trace Viewer.
+
+Currently, tracing on NVIDIA and AMD GPUs are supported as well as XPU and HPU.
+
+## Build Notes
+Libkineto uses the standard CMAKE-based build flow.
+
+### Dependencies
+Libkineto requires gcc 5+ and:
+
+- NVIDIA CUPTI: used to collect traces and metrics from NVIDIA GPUs.
+- fmt: used for its convenient and lightweight string formatting functionality.
+- googletest: required to build and run Kineto's tests.
+  - **googletest is not required** if you don't want to run Kineto tests.
+By default, building of tests is **on**. Turn it off by setting `KINETO_BUILD_TESTS` to **off**.
+
+You can download [NVIDIA CUPTI][1], [fmt][2], [googletest][3] and set
+`CUDA_SOURCE_DIR`, `FMT_SOURCE_DIR`, `GOOGLETEST_SOURCE_DIR` respectively for
+cmake to find these libraries. If the fmt and googletest variables are not set, cmake will
+build the git submodules found in the `third_party` directory.
+If `CUDA_SOURCE_DIR` is not set, libkineto will fail to build.
+
+### Building Libkineto
+
+```
+# Check out repo and sub modules
+git clone --recursive https://github.com/pytorch/kineto.git
+# Build libkineto with cmake
+cd kineto/libkineto
+mkdir build && cd build
+cmake ..
+make
+```
+
+To run the tests after building libkineto (if tests are built), use the following
+command:
+```
+make test
+```
+
+### Installing Libkineto
+```
+make install
+```
+
+## How Libkineto works
+
+### Hardware Abstraction
+
+![Kineto Interconnect](./docs/source/_static/img/kineto_interconnect.png)
+
+Libkineto is a C++ library designed to collect GPU traces and metrics. It serves as an abstraction layer between the application and the underlying GPU tracing libraries, providing a simple API for executing tracing and collecting metrics. Depending on the platform and build options, it can utilize different libraries to gather traces and metrics. For instance, on NVIDIA GPUs, it uses CUPTI to retrieve GPU telemetry, while on AMD GPUs, it employs AMD's Roctracer/Rocprofiler-sdk. The set of enabled activities during profiling can be observed in the `<Platform>ActivityApi.cpp` files. These activities are enabled upon the `prepare` call to effectively "warm up" and avoid profile distortion caused by module initialization when collection begins. In the context of the PyTorch Profiler and Kineto, `prepare` is equivalent to `warmup`, and `collect` is equivalent to `start`.
+
+### On-Demand Profiling
+
+Libkineto can be used to collect Kineto + PyTorch Profiler events on-demand, allowing users to decide when to start and stop profiling asynchronously based on a time duration. Users can also specify several other options, such as the output format, the activities to be collected, and the output file path, among others.
+
+Unlike auto-trace, which is initiated via the profiler.py in the PyTorch Profiler, on-demand profiling is directly invoked through libkineto, which is part of the C++ backend. This signal is created via [Dynolog](https://github.com/facebookincubator/dynolog). Once Kineto receives the signal, it creates a session via the `ActivityProfilerController` instance and then initializes a finite state machine that steps through the following states: `WaitForRequest`, `Warmup`, `CollectTrace`, and `ProcessTrace`. This finite state machine is used for all subsequent profiling requests. The logic for `WaitForRequest` is defined in `ActivityProfilerController` whereas the other states are defined in  `CuptiActivityProfiler::performRunLoopStep`.
+
+To collect PyTorch Profiler events (torch ops, Python stack, etc.), Kineto has an instance of the PyTorch Profiler in the form of a `ClientInterface` pointer. This pointer is passed to the `CuptiActivityProfiler`, which is then called in the finite state machine when collection is to begin. Once collection has ended, the Profiler sends its events to Kineto so that the total trace can be outputted to a JSON file. In this way, on-demand profiling has an inverted relationship between Kineto and the PyTorch Profiler. In auto-trace, the PyTorch Profiler is the entry point, and Kineto is invoked as a result of the `ProfilerStep` call. In on-demand profiling, Kineto is the entry point, and the PyTorch Profiler is invoked as a result of the `CuptiActivityProfiler` instance.
+
+For more information on how to run on-demand profiling, please refer to the Dynolog tutorial [here](https://github.com/facebookincubator/dynolog/blob/main/docs/pytorch_profiler.md#running-the-pytorch-program).
+
+### Trace Output
+
+The default trace output is a JSON file that can be visualized in Chrome Trace Viewer or Perfetto. The trace output is generated by the `ChromeTraceLogger` instance. The `ChromeTraceLogger` writes to a JSON file using `std::ofstream` in `output_json.cpp` to maximize performance during export. This instance is created by the `ActivityProfilerController` and is stored in the `ActivityLoggerFactory` alongside its protocol. Using this schema, Kineto supports multiple trace output formats. There is a public API extension for registering a user defined Logger with a protocol via `libkineto::registerLoggerFactory`. When calling `ActivityTrace::save` with `protocol://file`, the Logger registered against the protocol will be used to save the events traced.
+
+## License
+Libkineto is BSD licensed, as detailed in the [LICENSE](../LICENSE) file.
+
+[1]:https://developer.nvidia.com/CUPTI-CTK10_2
+[2]:https://github.com/fmtlib/fmt
+[3]:https://github.com/google/googletest

--- a/third_party/kineto/libkineto/include/AbstractConfig.h
+++ b/third_party/kineto/libkineto/include/AbstractConfig.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace libkineto {
+
+class AbstractConfig {
+ public:
+  AbstractConfig& operator=(const AbstractConfig&) = delete;
+  AbstractConfig(AbstractConfig&&) = delete;
+  AbstractConfig& operator=(AbstractConfig&&) = delete;
+
+  virtual ~AbstractConfig() {
+    for (const auto& p : featureConfigs_) {
+      delete p.second;
+    }
+  }
+
+  // Return a copy of the full derived class
+  virtual AbstractConfig* cloneDerived(AbstractConfig& parent) const = 0;
+
+  // Returns true if successfully parsed the config string
+  bool parse(const std::string& conf);
+
+  // Default setup for client-triggered profiling
+  virtual void setClientDefaults() {
+    for (auto& p : featureConfigs_) {
+      p.second->setClientDefaults();
+    }
+  }
+
+  // Time config was created / updated
+  [[nodiscard]] std::chrono::time_point<std::chrono::system_clock> timestamp()
+      const {
+    return timestamp_;
+  }
+
+  // Source config string that this was parsed from
+  [[nodiscard]] const std::string& source() const {
+    return source_;
+  }
+
+  [[nodiscard]] AbstractConfig& feature(const std::string& name) const {
+    const auto& pos = featureConfigs_.find(name);
+    return *pos->second;
+  }
+
+  // Transfers ownership of cfg arg
+  void addFeature(const std::string& name, AbstractConfig* cfg) {
+    featureConfigs_[name] = cfg;
+  }
+
+ protected:
+  AbstractConfig() = default;
+  AbstractConfig(const AbstractConfig& other) = default;
+
+  // Return true if the option was recognized and successfully parsed.
+  // Throw std::invalid_argument if val is invalid.
+  virtual bool handleOption(const std::string& name, std::string& val);
+
+  // Perform post-validation checks, typically conditons involving
+  // multiple options.
+  // Throw std::invalid_argument if automatic correction can not be made.
+  //
+  // @param fallbackProfileStartTime Specify a fallback profile start timestamp
+  // in case it was never specified by the client
+  virtual void validate(
+      const std::chrono::time_point<std::chrono::system_clock>&
+          fallbackProfileStartTime) = 0;
+
+  // TODO: Separate out each profiler type into features?
+  virtual void printActivityProfilerConfig(std::ostream& s) const;
+  virtual void setActivityDependentConfig();
+
+  // Helpers for use in handleOption
+  // Split a string by delimiter and remove external white space
+  [[nodiscard]] std::vector<std::string> splitAndTrim(
+      const std::string& s,
+      char delim) const;
+  // Lowercase for case-insensitive comparisons
+  std::string toLower(std::string& s) const;
+  // Does string end with suffix.
+  // New code should prefer std::string::ends_with directly (C++20). This
+  // wrapper is kept only for existing callers; do not add new ones.
+  [[nodiscard]] bool endsWith(const std::string& s, const std::string& suffix)
+      const;
+  // Conversions
+  [[nodiscard]] int64_t toIntRange(
+      const std::string& val,
+      int64_t min,
+      int64_t max) const;
+  [[nodiscard]] int32_t toInt32(const std::string& val) const;
+  [[nodiscard]] int64_t toInt64(const std::string& val) const;
+  bool toBool(std::string& val) const;
+
+  void cloneFeaturesInto(AbstractConfig& cfg) const {
+    for (const auto& feature : featureConfigs_) {
+      cfg.featureConfigs_[feature.first] = feature.second->cloneDerived(cfg);
+    }
+  }
+
+ private:
+  // Time config was created / updated
+  std::chrono::time_point<std::chrono::system_clock> timestamp_;
+
+  // Original configuration string, used for comparison
+  std::string source_;
+
+  // Configuration objects for optional features
+  std::map<std::string, AbstractConfig*> featureConfigs_;
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/ActivityProfilerInterface.h
+++ b/third_party/kineto/libkineto/include/ActivityProfilerInterface.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include "ActivityTraceInterface.h"
+#include "ActivityType.h"
+#include "IActivityProfiler.h"
+
+namespace libkineto {
+
+class ActivityProfilerController;
+struct CpuTraceBuffer;
+class Config;
+
+class ActivityProfilerInterface {
+ public:
+  virtual ~ActivityProfilerInterface() = default;
+
+  virtual void init() {}
+  virtual bool isInitialized() {
+    return false;
+  }
+  virtual bool isActive() {
+    return false;
+  }
+  virtual bool isStopped() const {
+    return false;
+  }
+
+  // *** Asynchronous API ***
+  // Instead of starting and stopping the trace manually, provide a start time
+  // and duration and / or iteration stop criterion.
+  // Tracing terminates when either condition is met.
+  virtual void scheduleTrace([[maybe_unused]] const std::string& configStr) {}
+
+  // Re-evaluate internal state to allow for triggering operations based
+  // on number of iteration. each implicitly increments the iteration count
+  virtual void step() {}
+
+  // *** Synchronous API ***
+  // These must be called in order:
+  // prepareTrace -> startTrace -> stopTrace.
+
+  // Many tracing structures are lazily initialized during trace collection,
+  // with potentially high overhead.
+  // Call prepareTrace to enable tracing, then run the region to trace
+  // at least once (and ideally run the same code that is to be traced) to
+  // allow tracing structures to be initialized.
+  virtual void prepareTrace(
+      [[maybe_unused]] const std::set<ActivityType>& activityTypes,
+      [[maybe_unused]] const std::string& configStr = "") {}
+
+  // Toggle GPU tracing as a trace is running to omit certain parts of a graph
+  virtual void toggleCollectionDynamic([[maybe_unused]] const bool enable) {}
+
+  // Start recording, potentially reusing any buffers allocated since
+  // prepareTrace was called.
+  virtual void startTrace() {}
+
+  // Stop and process trace, producing an in-memory list of trace records.
+  // The processing will be done synchronously (using the calling thread.)
+  virtual std::unique_ptr<ActivityTraceInterface> stopTrace() {
+    return nullptr;
+  }
+
+  // *** TraceActivity API ***
+  // FIXME: Pass activityProfiler interface into clientInterface?
+  virtual void pushCorrelationId([[maybe_unused]] uint64_t id) {}
+  virtual void popCorrelationId() {}
+  virtual void transferCpuTrace(
+      [[maybe_unused]] std::unique_ptr<CpuTraceBuffer> traceBuffer) {}
+
+  // Correlation ids for user defined spans
+  virtual void pushUserCorrelationId([[maybe_unused]] uint64_t id) {}
+  virtual void popUserCorrelationId() {}
+
+  // Saves information for the current thread to be used in profiler output
+  // Client must record any new kernel thread where the activity has occured.
+  virtual void recordThreadInfo() {}
+
+  // Record trace metadata, currently supporting only string key and values,
+  // values with the same key are overwritten
+  virtual void addMetadata(
+      const std::string& key,
+      const std::string& value) = 0;
+
+  // Add a child activity profiler, this enables frameworks in the application
+  // to enable custom framework events.
+  virtual void addChildActivityProfiler(
+      [[maybe_unused]] std::unique_ptr<IActivityProfiler> profiler) {}
+
+  // Log Invariant Violation to factories enabled. This helps record
+  // instances when the profiler behaves unexpectedly.
+  virtual void logInvariantViolation(
+      [[maybe_unused]] const std::string& profile_id,
+      [[maybe_unused]] const std::string& assertion,
+      [[maybe_unused]] const std::string& error,
+      [[maybe_unused]] const std::string& group_profile_id = "") {}
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/ActivityTraceInterface.h
+++ b/third_party/kineto/libkineto/include/ActivityTraceInterface.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace libkineto {
+
+struct ITraceActivity;
+
+class ActivityTraceInterface {
+ public:
+  virtual ~ActivityTraceInterface() = default;
+  virtual const std::vector<const ITraceActivity*>* activities() {
+    return nullptr;
+  }
+  virtual void save([[maybe_unused]] const std::string& path) {}
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/ActivityType.h
+++ b/third_party/kineto/libkineto/include/ActivityType.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <array>
+#include <set>
+#include <string>
+
+namespace libkineto {
+
+// Note : All activity types are not enabled by default. Please add them
+// at correct position in the enum
+enum class ActivityType {
+  // Activity types enabled by default
+  CPU_OP = 0, // cpu side ops
+  USER_ANNOTATION = 1,
+  GPU_USER_ANNOTATION = 2,
+  GPU_MEMCPY = 3,
+  GPU_MEMSET = 4,
+  CONCURRENT_KERNEL = 5, // on-device kernels
+  EXTERNAL_CORRELATION = 6,
+  CUDA_RUNTIME = 7, // host side cuda runtime events
+  CUDA_DRIVER = 8, // host side cuda driver events
+  CPU_INSTANT_EVENT = 9, // host side point-like events
+  PYTHON_FUNCTION = 10,
+  OVERHEAD = 11, // CUPTI induced overhead events sampled from its overhead API.
+  MTIA_RUNTIME = 12, // host side MTIA runtime events
+  MTIA_CCP_EVENTS = 13, // MTIA ondevice CCP events
+  MTIA_INSIGHT = 14, // MTIA Insight Events
+  CUDA_SYNC = 15, // synchronization events between runtime and kernels
+  CUDA_EVENT = 16, // CUDA event activities (cudaEventRecord, etc.)
+  MTIA_COUNTERS = 17, // MTIA hardware counter events (HBM, cache, DPE, SFU)
+
+  // Optional Activity types
+  GLOW_RUNTIME = 18, // host side glow runtime events
+  // Reserved and no longer produced: the CUPTI range profiler that emitted this
+  // activity was removed. The value stays fixed so existing traces and other
+  // tools that share this serialized integer keep deserializing correctly.
+  CUDA_PROFILER_RANGE = 19,
+  HPU_OP = 20, // HPU host side runtime event
+  XPU_RUNTIME = 21, // host side xpu runtime events
+  XPU_DRIVER = 22, // host side xpu driver events
+  COLLECTIVE_COMM = 23, // collective communication
+
+  // PRIVATEUSE1 Activity types are used for custom backends.
+  // The corresponding device type is `DeviceType::PrivateUse1` in PyTorch.
+  PRIVATEUSE1_RUNTIME = 24, // host side privateUse1 runtime events
+  PRIVATEUSE1_DRIVER = 25, // host side privateUse1 driver events
+
+  XPU_SCOPE_PROFILER = 26, // XPUPTI Profiler scope for performance metrics
+  XPU_SYNC = 27, // XPU synchronization events
+
+  ENUM_COUNT =
+      28, // This is to add buffer and not used for any profiling logic. Add
+  // your new type before it.
+  OPTIONAL_ACTIVITY_TYPE_START = GLOW_RUNTIME,
+};
+
+// Return an array of all activity types except COUNT
+constexpr int activityTypeCount = (int)ActivityType::ENUM_COUNT;
+constexpr int defaultActivityTypeCount =
+    (int)ActivityType::OPTIONAL_ACTIVITY_TYPE_START;
+
+// These definitions are not part of the public Kineto API. They are inlined
+// here because some build configurations include this header
+// without linking libkineto, and toString() must resolve at compile time.
+struct _ActivityTypeName {
+  const char* name;
+  ActivityType type;
+};
+
+inline constexpr std::array<_ActivityTypeName, activityTypeCount + 1>
+    _activityTypeNames{{
+        {"cpu_op", ActivityType::CPU_OP},
+        {"user_annotation", ActivityType::USER_ANNOTATION},
+        {"gpu_user_annotation", ActivityType::GPU_USER_ANNOTATION},
+        {"gpu_memcpy", ActivityType::GPU_MEMCPY},
+        {"gpu_memset", ActivityType::GPU_MEMSET},
+        {"kernel", ActivityType::CONCURRENT_KERNEL},
+        {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
+        {"cuda_runtime", ActivityType::CUDA_RUNTIME},
+        {"cuda_driver", ActivityType::CUDA_DRIVER},
+        {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
+        {"python_function", ActivityType::PYTHON_FUNCTION},
+        {"overhead", ActivityType::OVERHEAD},
+        {"mtia_runtime", ActivityType::MTIA_RUNTIME},
+        {"mtia_ccp_events", ActivityType::MTIA_CCP_EVENTS},
+        {"mtia_insight", ActivityType::MTIA_INSIGHT},
+        {"cuda_sync", ActivityType::CUDA_SYNC},
+        {"cuda_event", ActivityType::CUDA_EVENT},
+        {"mtia_counters", ActivityType::MTIA_COUNTERS},
+        {"glow_runtime", ActivityType::GLOW_RUNTIME},
+        {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
+        {"hpu_op", ActivityType::HPU_OP},
+        {"xpu_runtime", ActivityType::XPU_RUNTIME},
+        {"xpu_driver", ActivityType::XPU_DRIVER},
+        {"collective_comm", ActivityType::COLLECTIVE_COMM},
+        {"privateuse1_runtime", ActivityType::PRIVATEUSE1_RUNTIME},
+        {"privateuse1_driver", ActivityType::PRIVATEUSE1_DRIVER},
+        {"xpu_scope_profiler", ActivityType::XPU_SCOPE_PROFILER},
+        {"xpu_sync", ActivityType::XPU_SYNC},
+        {"ENUM_COUNT", ActivityType::ENUM_COUNT},
+    }};
+
+inline const char* toString(ActivityType t) {
+  return _activityTypeNames[static_cast<int>(t)].name;
+}
+
+ActivityType toActivityType(const std::string& str);
+
+std::array<ActivityType, activityTypeCount> activityTypes();
+std::array<ActivityType, defaultActivityTypeCount> defaultActivityTypes();
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/ClientInterface.h
+++ b/third_party/kineto/libkineto/include/ClientInterface.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+namespace libkineto {
+
+class ClientInterface {
+ public:
+  virtual ~ClientInterface() = default;
+  virtual void init() = 0;
+  virtual void prepare(bool, bool, bool, bool, bool) = 0;
+  virtual void start() = 0;
+  virtual void stop() = 0;
+  virtual void start_memory_profile() = 0;
+  virtual void stop_memory_profile() = 0;
+  virtual void export_memory_profile(const std::string&) = 0;
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/Config.h
+++ b/third_party/kineto/libkineto/include/Config.h
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "AbstractConfig.h"
+#include "ActivityType.h"
+
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace libkineto {
+
+class Config : public AbstractConfig {
+ public:
+  Config();
+  Config& operator=(const Config&) = delete;
+  Config(Config&&) = delete;
+  Config& operator=(Config&&) = delete;
+  ~Config() override = default;
+
+  // Return a full copy including feature config object
+  [[nodiscard]] std::unique_ptr<Config> clone() const {
+    auto cfg = std::unique_ptr<Config>(new Config(*this));
+    cloneFeaturesInto(*cfg);
+    return cfg;
+  }
+
+  bool handleOption(const std::string& name, std::string& val) override;
+
+  void setClientDefaults() override;
+
+  [[nodiscard]] bool activityProfilerEnabled() const {
+    return activityProfilerEnabled_ ||
+        activitiesOnDemandTimestamp_.time_since_epoch().count() > 0;
+  }
+
+  // Log activitiy trace to this file
+  [[nodiscard]] const std::string& activitiesLogFile() const {
+    return activitiesLogFile_;
+  }
+
+  // Log activitiy trace to this url
+  [[nodiscard]] const std::string& activitiesLogUrl() const {
+    return activitiesLogUrl_;
+  }
+
+  void setActivitiesLogUrl(const std::string& url) {
+    activitiesLogUrl_ = url;
+  }
+
+  // Called for configs from the daemon IPC path. See onDemand_.
+  void setOnDemand(bool onDemand) {
+    onDemand_ = onDemand;
+  }
+
+  [[nodiscard]] bool activitiesLogToMemory() const {
+    return activitiesLogToMemory_;
+  }
+
+  // The types of activities selected in the configuration file
+  [[nodiscard]] const std::set<ActivityType>& selectedActivityTypes() const {
+    return selectedActivityTypes_;
+  }
+
+  // Set the types of activities to be traced
+  [[nodiscard]] bool perThreadBufferEnabled() const {
+    return perThreadBufferEnabled_;
+  }
+
+  void setSelectedActivityTypes(const std::set<ActivityType>& types) {
+    selectedActivityTypes_ = types;
+  }
+
+  [[nodiscard]] bool isReportInputShapesEnabled() const {
+    return enableReportInputShapes_;
+  }
+
+  [[nodiscard]] bool isProfileMemoryEnabled() const {
+    return enableProfileMemory_;
+  }
+
+  [[nodiscard]] bool isWithStackEnabled() const {
+    return enableWithStack_;
+  }
+
+  [[nodiscard]] bool isWithFlopsEnabled() const {
+    return enableWithFlops_;
+  }
+
+  [[nodiscard]] bool isWithModulesEnabled() const {
+    return enableWithModules_;
+  }
+
+  // Trace for this long
+  [[nodiscard]] std::chrono::milliseconds activitiesDuration() const {
+    return activitiesDuration_;
+  }
+
+  // Trace for this many iterations, determined by external API
+  [[nodiscard]] int activitiesRunIterations() const {
+    return activitiesRunIterations_;
+  }
+
+  [[nodiscard]] int64_t activitiesMaxGpuBufferSize() const {
+    return activitiesMaxGpuBufferSize_;
+  }
+
+  [[nodiscard]] std::chrono::seconds activitiesWarmupDuration() const {
+    return activitiesWarmupDuration_;
+  }
+
+  [[nodiscard]] int activitiesWarmupIterations() const {
+    return activitiesWarmupIterations_;
+  }
+
+  // Show CUDA Synchronization Stream Wait Events
+  [[nodiscard]] bool activitiesCudaSyncWaitEvents() const {
+    return activitiesCudaSyncWaitEvents_;
+  }
+
+  void setActivitiesCudaSyncWaitEvents(bool enable) {
+    activitiesCudaSyncWaitEvents_ = enable;
+  }
+
+  [[nodiscard]] std::chrono::time_point<std::chrono::system_clock>
+  requestTimestamp() const {
+    return profileStartTime_;
+  }
+
+  [[nodiscard]] bool hasProfileStartTime() const {
+    return profileStartTime_.time_since_epoch().count() > 0;
+  }
+
+  [[nodiscard]] int profileStartIteration() const {
+    return profileStartIteration_;
+  }
+
+  [[nodiscard]] bool hasProfileStartIteration() const {
+    return profileStartIteration_ >= 0 && activitiesRunIterations_ > 0;
+  }
+
+  void setProfileStartIteration(int iter) {
+    profileStartIteration_ = iter;
+  }
+
+  [[nodiscard]] int profileStartIterationRoundUp() const {
+    return profileStartIterationRoundUp_;
+  }
+
+  // calculate the start iteration accounting for warmup
+  [[nodiscard]] int startIterationIncludingWarmup() const {
+    if (!hasProfileStartIteration()) {
+      return -1;
+    }
+    return profileStartIteration_ - activitiesWarmupIterations_;
+  }
+
+  [[nodiscard]] std::chrono::seconds maxRequestAge() const;
+
+  // All VLOG* macros will log if the verbose log level is >=
+  // the verbosity specified for the verbose log message.
+  // Default value is -1, so messages with log level 0 will log by default.
+  [[nodiscard]] int verboseLogLevel() const {
+    return verboseLogLevel_;
+  }
+
+  // Modules for which verbose logging is enabled.
+  // If empty, logging is enabled for all modules.
+  [[nodiscard]] const std::vector<std::string>& verboseLogModules() const {
+    return verboseLogModules_;
+  }
+
+  [[nodiscard]] bool ipcFabricEnabled() const {
+    return enableIpcFabric_;
+  }
+
+  [[nodiscard]] std::chrono::seconds onDemandConfigUpdateIntervalSecs() const {
+    return onDemandConfigUpdateIntervalSecs_;
+  }
+
+  static std::chrono::milliseconds alignUp(
+      std::chrono::milliseconds duration,
+      std::chrono::milliseconds alignment) {
+    duration += alignment;
+    return duration - (duration % alignment);
+  }
+
+  [[nodiscard]] std::chrono::time_point<std::chrono::system_clock>
+  activityProfilerRequestReceivedTime() const {
+    return activitiesOnDemandTimestamp_;
+  }
+
+  static constexpr std::chrono::milliseconds kControllerIntervalMsecs{1000};
+
+  // Users may request and set trace id and group trace id.
+  [[nodiscard]] const std::string& requestTraceID() const {
+    return requestTraceID_;
+  }
+
+  void setRequestTraceID(const std::string& tid) {
+    requestTraceID_ = tid;
+  }
+
+  [[nodiscard]] const std::string& requestGroupTraceID() const {
+    return requestGroupTraceID_;
+  }
+
+  void setRequestGroupTraceID(const std::string& gtid) {
+    requestGroupTraceID_ = gtid;
+  }
+
+  [[nodiscard]] size_t cuptiDeviceBufferSize() const {
+    return cuptiDeviceBufferSize_;
+  }
+
+  [[nodiscard]] size_t cuptiDeviceBufferPoolLimit() const {
+    return cuptiDeviceBufferPoolLimit_;
+  }
+
+  [[nodiscard]] bool memoryProfilerEnabled() const {
+    return memoryProfilerEnabled_;
+  }
+
+  [[nodiscard]] int profileMemoryDuration() const {
+    return profileMemoryDuration_;
+  }
+  void updateActivityProfilerRequestReceivedTime();
+
+  void printActivityProfilerConfig(std::ostream& s) const override;
+  void setActivityDependentConfig() override;
+
+  void validate(const std::chrono::time_point<std::chrono::system_clock>&
+                    fallbackProfileStartTime) override;
+
+  static void addConfigFactory(
+      std::string name,
+      std::function<AbstractConfig*(Config&)> factory);
+
+  void print(std::ostream& s) const;
+
+  // Config relies on some state with global static lifetime. If other
+  // threads are using the config, it's possible that the global state
+  // is destroyed before the threads stop. By hanging onto this handle,
+  // correct destruction order can be ensured.
+  static std::shared_ptr<void> getStaticObjectsLifetimeHandle();
+
+  [[nodiscard]] bool getTSCTimestampFlag() const {
+    return useTSCTimestamp_;
+  }
+
+  void setTSCTimestampFlag(bool flag) {
+    useTSCTimestamp_ = flag;
+  }
+
+  [[nodiscard]] const std::string& getCustomConfig() const {
+    return customConfig_;
+  }
+
+  [[nodiscard]] uint32_t maxEvents() const {
+    return maxEvents_;
+  }
+
+ private:
+  explicit Config(const Config& other) = default;
+
+  AbstractConfig* cloneDerived(
+      [[maybe_unused]] AbstractConfig& parent) const override {
+    // Clone from AbstractConfig not supported
+    assert(false);
+    return nullptr;
+  }
+
+  // Adds valid activity types from the user defined string list in the
+  // configuration file
+  void setActivityTypes(const std::vector<std::string>& selected_activities);
+
+  // Sets the default activity types to be traced
+  void selectDefaultActivityTypes() {
+    // If the user has not specified an activity list, add all types
+    for (ActivityType t : defaultActivityTypes()) {
+      selectedActivityTypes_.insert(t);
+    }
+  }
+
+  int verboseLogLevel_;
+  std::vector<std::string> verboseLogModules_;
+
+  // Activity profiler
+  bool activityProfilerEnabled_;
+
+  // Enable per-thread buffer
+  bool perThreadBufferEnabled_;
+  std::set<ActivityType> selectedActivityTypes_;
+
+  // The activity profiler settings are all on-demand
+  std::string activitiesLogFile_;
+
+  std::string activitiesLogUrl_;
+
+  // Log activities to memory buffer
+  bool activitiesLogToMemory_{false};
+
+  // Restricts trace output path when set (untrusted on-demand config).
+  bool onDemand_{false};
+
+  int64_t activitiesMaxGpuBufferSize_;
+  std::chrono::seconds activitiesWarmupDuration_;
+  int activitiesWarmupIterations_;
+  bool activitiesCudaSyncWaitEvents_;
+
+  // Enable Profiler Config Options
+  // Temporarily disable shape collection until we re-roll out the feature for
+  // on-demand cases
+  bool enableReportInputShapes_{false};
+  bool enableProfileMemory_{false};
+  bool enableWithStack_{false};
+  bool enableWithFlops_{false};
+  bool enableWithModules_{false};
+
+  // Profile for specified iterations and duration
+  std::chrono::milliseconds activitiesDuration_;
+  int activitiesRunIterations_;
+
+  // Below are not used
+  // Use this net name for iteration count
+  std::string activitiesExternalAPIIterationsTarget_;
+  // Only profile nets that includes this in the name
+  std::vector<std::string> activitiesExternalAPIFilter_;
+  // Only profile nets with at least this many operators
+  int activitiesExternalAPINetSizeThreshold_;
+  // Only profile nets with at least this many GPU operators
+  int activitiesExternalAPIGpuOpCountThreshold_;
+  // Last activity profiler request
+  std::chrono::time_point<std::chrono::system_clock>
+      activitiesOnDemandTimestamp_;
+
+  // ActivityProfilers are triggered by either:
+  // Synchronized start timestamps
+  std::chrono::time_point<std::chrono::system_clock> profileStartTime_;
+  // Or start iterations.
+  int profileStartIteration_;
+  int profileStartIterationRoundUp_;
+
+  // Enable IPC Fabric instead of thrift communication
+  bool enableIpcFabric_;
+  std::chrono::seconds onDemandConfigUpdateIntervalSecs_;
+
+  // Logger Metadata
+  std::string requestTraceID_;
+  std::string requestGroupTraceID_;
+
+  // CUPTI Device Buffer
+  size_t cuptiDeviceBufferSize_;
+  size_t cuptiDeviceBufferPoolLimit_;
+
+  // CUPTI Timestamp Format
+  bool useTSCTimestamp_{true};
+
+  // Memory Profiler
+  bool memoryProfilerEnabled_{false};
+  int profileMemoryDuration_{1000};
+
+  // Used to flexibly configure some custom options, especially for custom
+  // backends. How to parse this string is handled by the custom backend.
+  std::string customConfig_;
+
+  // Roctracer settings
+  uint32_t maxEvents_{5000000};
+};
+
+constexpr char kUseDaemonEnvVar[] = "KINETO_USE_DAEMON";
+
+bool isDaemonEnvVarSet();
+
+// Returns a reference to the protobuf trace enabled flag.
+// This allows the flag to be set externally by downstream consumers
+// and read in trace output components.
+bool& get_protobuf_trace_enabled();
+
+// Returns a reference to the Perfetto trace enabled flag.
+// When true, a consumer writes a Perfetto-native trace via the
+// Perfetto SDK alongside other output formats.
+bool& get_perfetto_trace_enabled();
+
+// Returns a reference to the Perfetto packet compression enabled flag.
+// When true, in-process Perfetto SDK tracing sessions configure
+// `TraceConfig.compression_type = COMPRESSION_TYPE_DEFLATE`, producing
+// a smaller .pftrace at the cost of some CPU. The Perfetto UI and
+// trace_processor decompress transparently.
+bool& get_perfetto_packet_compression_enabled();
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/EnvMetadata.h
+++ b/third_party/kineto/libkineto/include/EnvMetadata.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fmt/core.h>
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <unordered_map>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#pragma comment(lib, "ws2_32.lib")
+#else
+#include <unistd.h>
+#endif
+
+namespace libkineto {
+
+enum class EnvVar : std::uint8_t {
+  PT_PROFILER_JOB_NAME,
+  PT_PROFILER_JOB_VERSION,
+  PT_PROFILER_JOB_ATTEMPT_INDEX,
+};
+
+inline const std::unordered_map<EnvVar, const char*> K_ENV_VAR_MAP = {
+    {EnvVar::PT_PROFILER_JOB_NAME, "PT_PROFILER_JOB_NAME"},
+    {EnvVar::PT_PROFILER_JOB_VERSION, "PT_PROFILER_JOB_VERSION"},
+    {EnvVar::PT_PROFILER_JOB_ATTEMPT_INDEX, "PT_PROFILER_JOB_ATTEMPT_INDEX"},
+};
+
+// Returns a map of (env_var_name, env_value) for all environment variables
+// that are currently set. Also captures the hostname of the current machine.
+inline std::unordered_map<std::string, std::string> getEnvMetadata() {
+  std::unordered_map<std::string, std::string> result;
+  for (const auto& [key, name] : K_ENV_VAR_MAP) {
+    if (const char* val = std::getenv(name)) {
+      result[name] = fmt::format("\"{}\"", val);
+    }
+  }
+
+  // Capture hostname for per-rank host identification in distributed training.
+  // $HOSTNAME is not guaranteed in non-interactive or containerized
+  // environments, so we use gethostname() which reads the kernel hostname
+  // directly.
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) == 0) {
+    hostname.back() = '\0';
+    if (hostname[0] != '\0') {
+      result["host_name"] = fmt::format("\"{}\"", hostname.data());
+    }
+  }
+
+  return result;
+}
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/GenericTraceActivity.h
+++ b/third_party/kineto/libkineto/include/GenericTraceActivity.h
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "ITraceActivity.h"
+#include "ThreadUtil.h"
+#include "TraceSpan.h"
+#include "TypedMetadata.h"
+
+namespace libkineto {
+
+// Link type, used in GenericTraceActivity.flow.type
+constexpr unsigned int kLinkFwdBwd = 1;
+constexpr unsigned int kLinkAsyncCpuGpu = 2;
+
+// @lint-ignore-every CLANGTIDY
+// cppcoreguidelines-non-private-member-variables-in-classes
+// @lint-ignore-every CLANGTIDY cppcoreguidelines-pro-type-member-init
+class GenericTraceActivity : public ITraceActivity {
+ public:
+  GenericTraceActivity()
+      : activityType(ActivityType::ENUM_COUNT), traceSpan_(nullptr) {}
+
+  GenericTraceActivity(
+      const TraceSpan& trace,
+      ActivityType type,
+      const std::string& name)
+      : activityType(type), activityName(name), traceSpan_(&trace) {}
+
+  int64_t deviceId() const override {
+    return device;
+  }
+
+  int64_t resourceId() const override {
+    return resource;
+  }
+
+  void setDevice(int32_t newDevice) {
+    device = newDevice;
+  }
+
+  int32_t getThreadId() const override {
+    return threadId;
+  }
+
+  int64_t timestamp() const override {
+    return startTime;
+  }
+
+  int64_t duration() const override {
+    return endTime - startTime;
+  }
+
+  int64_t correlationId() const override {
+    return id;
+  }
+
+  ActivityType type() const override {
+    return activityType;
+  }
+
+  const ITraceActivity* linkedActivity() const override {
+    return linked;
+  }
+
+  int flowType() const override {
+    return flow.type;
+  }
+
+  int64_t flowId() const override {
+    return flow.id;
+  }
+
+  bool flowStart() const override {
+    return flow.start;
+  }
+
+  const std::string name() const override {
+    return activityName;
+  }
+
+  const TraceSpan* traceSpan() const override {
+    return traceSpan_;
+  }
+
+  void log(ActivityLogger& logger) const override;
+
+  // Encode client side metadata as a key/value (as a JSON fragment)
+  template <typename ValType>
+  void addMetadata(const std::string& key, const ValType& value) {
+    metadataMap_.emplace(key, RawJson{fmt::format("{}", value)});
+  }
+
+  // Typed metadata: the value is stored as the field's declared type
+  template <typename T, typename V>
+  void addMetadata(const MetadataField<T>& field, const V& value) {
+    static_assert(
+        std::is_same_v<T, std::decay_t<V>>,
+        "value type must match field's declared type");
+    metadataMap_.emplace(std::string{field.name}, TypedValue{value});
+  }
+
+  // Adds typed metadata dynamically by key. Catalog registration is not
+  // required.
+  void addTypedMetadata(std::string_view key, TypedValue value) {
+    metadataMap_.emplace(std::string{key}, std::move(value));
+  }
+
+  // The value is a plain string to be emitted quoted in JSON.
+  void addMetadataQuoted(const std::string& key, const std::string& value) {
+    metadataMap_.emplace(key, value);
+  }
+
+  // Store a typed counter value. Preferred over addMetadata for counter
+  // activities — preserves full double precision and avoids the JSON
+  // serialize/deserialize round-trip in output backends.
+  void addCounterValue(const std::string& name, double value) {
+    counterValues_.emplace_back(name, value);
+  }
+
+  const std::vector<std::pair<std::string, double>>& counterValues()
+      const override {
+    return counterValues_;
+  }
+
+  // Return the metadata value in string format
+  const std::string getMetadataValue(const std::string& key) const override;
+
+  // Typed read-back
+  template <typename T>
+  std::optional<T> getMetadataValue(const MetadataField<T>& field) const {
+    const auto it = metadataMap_.find(std::string{field.name});
+    if (it != metadataMap_.end()) {
+      if (const T* value = std::get_if<T>(&it->second)) {
+        return *value;
+      }
+    }
+    return std::nullopt;
+  }
+
+  const std::string metadataJson() const override;
+
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override {
+    // Dynamically build a MetadataField during visit
+    for (const auto& kv : metadataMap_) {
+      std::visit(
+          [&](const auto& v) {
+            visitor.visit(
+                MetadataField<std::decay_t<decltype(v)>>{kv.first}, v);
+          },
+          kv.second);
+    }
+  }
+
+  virtual ~GenericTraceActivity() override {}
+
+  int64_t startTime{0};
+  int64_t endTime{0};
+  int32_t id{0};
+  int32_t device{0};
+  int64_t resource{0};
+  int32_t threadId{0};
+  ActivityType activityType;
+  std::string activityName;
+  struct Flow {
+    Flow() : id(0), type(0), start(0) {}
+    // Ids must be unique within each type
+    uint32_t id;
+    // Type will be used to connect flows between profilers, as
+    // well as look up flow information (name etc)
+    uint32_t type : 4;
+    uint32_t start : 1;
+  } flow;
+  const ITraceActivity* linked{nullptr};
+
+ private:
+  const TraceSpan* traceSpan_;
+  std::unordered_map<std::string, TypedValue> metadataMap_;
+  // Typed counter values: (name, double) to avoid round-tripping though string
+  std::vector<std::pair<std::string, double>> counterValues_;
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/IActivityProfiler.h
+++ b/third_party/kineto/libkineto/include/IActivityProfiler.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "Config.h"
+#include "GenericTraceActivity.h"
+
+/* This file includes an abstract base class for an activity profiler
+ * that can be implemented by multiple tracing agents in the application.
+ * The high level Kineto profiler can co-ordinate start and end of tracing
+ * and combine together events from multiple such activity profilers.
+ */
+
+namespace libkineto {
+
+struct CpuTraceBuffer;
+
+#ifdef _MSC_VER
+// workaround for the predefined ERROR macro on Windows
+#undef ERROR
+#endif // _MSC_VER
+
+enum class TraceStatus {
+  READY, // Accepting trace requests
+  WARMUP, // Performing trace warmup
+  RECORDING, // Actively collecting activities
+  PROCESSING, // Recording is complete, preparing results
+  ERROR, // One or more errors (and possibly also warnings) occurred.
+  WARNING, // One or more warnings occurred.
+};
+
+/* DeviceInfo:
+ *   Can be used to specify process name, sort order, PID and device label.
+ *   The sort order is determined by the sortIndex field to handle ordering of
+ *   processes and gpu rows in the trace viewer.
+ */
+struct DeviceInfo {
+  int64_t id; // process id
+  int64_t sortIndex; // position in trace view
+  const std::string name; // process name
+  const std::string label; // device label
+};
+
+/* ResourceInfo:
+ *   Can be used to specify resource inside device
+ */
+struct ResourceInfo {
+  int64_t id; // resource id
+  int64_t sortIndex; // position in trace view
+  int64_t deviceId; // id of device which owns this resource (specified in
+                    // DeviceInfo.id)
+  const std::string name; // resource name
+};
+
+using getLinkedActivityCallback = std::function<const ITraceActivity*(int32_t)>;
+
+/* IActivityProfilerSession:
+ *   an opaque object that can be used by a high level profiler to
+ *   start/stop and return trace events.
+ */
+class IActivityProfilerSession {
+ public:
+  virtual ~IActivityProfilerSession() = default;
+
+  // start the trace collection synchronously
+  virtual void start() = 0;
+
+  // stop the trace collection synchronously
+  virtual void stop() = 0;
+
+  TraceStatus status() {
+    return status_;
+  }
+
+  // returns errors with this trace
+  virtual std::vector<std::string> errors() = 0;
+
+  // processes trace activities using logger
+  virtual void processTrace(ActivityLogger& logger) = 0;
+
+  virtual void processTrace(
+      ActivityLogger& logger,
+      [[maybe_unused]] getLinkedActivityCallback getLinkedActivity,
+      [[maybe_unused]] int64_t startTime,
+      [[maybe_unused]] int64_t endTime) {
+    processTrace(logger);
+  }
+
+  // returns device info used in this trace, could be nullptr
+  virtual std::unique_ptr<DeviceInfo> getDeviceInfo() = 0;
+
+  // returns resource info used in this trace, could be empty
+  virtual std::vector<ResourceInfo> getResourceInfos() = 0;
+
+  // release ownership of the trace events and metadata
+  virtual std::unique_ptr<CpuTraceBuffer> getTraceBuffer() = 0;
+
+  // XXX define trace formats
+  // virtual save(string name, TraceFormat format)
+
+  virtual void pushCorrelationId([[maybe_unused]] uint64_t id) {}
+  virtual void popCorrelationId() {}
+
+  virtual void pushUserCorrelationId([[maybe_unused]] uint64_t id) {}
+  virtual void popUserCorrelationId() {}
+
+  virtual void toggleCollectionDynamic([[maybe_unused]] bool enable) {}
+
+  virtual std::string getDeviceProperties() {
+    return "";
+  }
+
+  virtual std::unordered_map<std::string, std::string> getMetadata() {
+    return {};
+  }
+
+ protected:
+  TraceStatus status_ = TraceStatus::READY;
+};
+
+/* Activity Profiler Plugins:
+ *   These allow other frameworks to integrate into Kineto's primariy
+ *   activity profiler. While the primary activity profiler handles
+ *   timing the trace collections and correlating events the plugins
+ *   can become source of new trace activity types.
+ */
+class IActivityProfiler {
+ public:
+  virtual ~IActivityProfiler() = default;
+
+  // name of profiler
+  [[nodiscard]] virtual const std::string& name() const = 0;
+
+  // returns activity types this profiler supports
+  [[nodiscard]] virtual const std::set<ActivityType>& availableActivities()
+      const = 0;
+
+  // Calls prepare() on registered tracer providers passing in the relevant
+  // activity types. Returns a profiler session handle
+  virtual std::unique_ptr<IActivityProfilerSession> configure(
+      const std::set<ActivityType>& activity_types,
+      const Config& config) = 0;
+
+  // asynchronous version of the above with future timestamp and duration.
+  virtual std::unique_ptr<IActivityProfilerSession> configure(
+      int64_t ts_ms,
+      int64_t duration_ms,
+      const std::set<ActivityType>& activity_types,
+      const Config& config) = 0;
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/ILoggerObserver.h
+++ b/third_party/kineto/libkineto/include/ILoggerObserver.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#define NOGDI
+#include <string>
+
+// Stages in libkineto used when pushing logs to UST Logger.
+// Emitted when a trace request is cancelled: rejected before it runs
+// (busy/pending/can't-start) or an in-flight trace preempted by a
+// higher-priority request.
+constexpr char kCancellationStage[] = "Cancellation";
+constexpr char kWarmUpStage[] = "Warm Up";
+constexpr char kCollectionStage[] = "Collection";
+constexpr char kPostProcessingStage[] = "Post Processing";
+
+// Special string in UST for determining if traces are empty
+constexpr char kEmptyTrace[] =
+    "No Valid Trace Events (CPU/GPU) found. Outputting empty trace.";
+
+#if !USE_GOOGLE_LOG
+
+#include <map>
+#include <vector>
+
+#include <cstdint>
+
+#ifdef _MSC_VER
+// unset a predefined ERROR (windows)
+#undef ERROR
+#endif // _MSC_VER
+
+namespace libkineto {
+
+enum LoggerOutputType {
+  VERBOSE = 0,
+  INFO = 1,
+  WARNING = 2,
+  STAGE = 3,
+  ERROR = 4,
+  USDT = 5,
+  ENUM_COUNT = 6
+};
+
+const char* toString(LoggerOutputType t);
+LoggerOutputType toLoggerOutputType(const std::string& str);
+
+constexpr int LoggerTypeCount = (int)LoggerOutputType::ENUM_COUNT;
+
+class ILoggerObserver {
+ public:
+  virtual ~ILoggerObserver() = default;
+  virtual void write(const std::string& message, LoggerOutputType ot) = 0;
+  virtual const std::map<LoggerOutputType, std::vector<std::string>>
+  extractCollectorMetadata() = 0;
+  virtual void reset() = 0;
+  virtual void addDevice(int64_t device) = 0;
+  virtual void setTraceDurationMS(int64_t duration) = 0;
+  virtual void addEventCount(int64_t count) = 0;
+  virtual void setTraceID([[maybe_unused]] const std::string& traceID) {}
+  virtual void setGroupTraceID(
+      [[maybe_unused]] const std::string& groupTraceID) {}
+  virtual void addDestination(const std::string& dest) = 0;
+  virtual void setTriggerOnDemand() {}
+  virtual void addMetadata(
+      const std::string& key,
+      const std::string& value) = 0;
+  // Metadata that is constant for the process lifetime (e.g. GPU/driver
+  // versions). Unlike addMetadata, this is NOT cleared by reset(), so it
+  // survives across traces and must not be used for per-trace values.
+  virtual void addPersistentMetadata(
+      [[maybe_unused]] const std::string& key,
+      [[maybe_unused]] const std::string& value) {}
+  // Emit a standalone record that an on-demand trace request was cancelled,
+  // attributed to the cancelled request's trace id. Stateless: does not read or
+  // mutate the observer's per-trace state (a trace may be active).
+  virtual void writeStageCancellation(
+      [[maybe_unused]] const std::string& trace_id,
+      [[maybe_unused]] const std::string& group_trace_id,
+      [[maybe_unused]] const std::string& reason) {}
+};
+
+} // namespace libkineto
+
+#endif // !USE_GOOGLE_LOG

--- a/third_party/kineto/libkineto/include/ITraceActivity.h
+++ b/third_party/kineto/libkineto/include/ITraceActivity.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ActivityType.h"
+#include "TypedMetadata.h"
+
+namespace libkineto {
+
+class ActivityLogger;
+struct TraceSpan;
+
+// Generic activity interface is borrowed from tensorboard protobuf format.
+struct ITraceActivity {
+  virtual ~ITraceActivity() = default;
+  // Device is a physical or logical entity, e.g. CPU, GPU or process
+  [[nodiscard]] virtual int64_t deviceId() const = 0;
+  // A resource is something on the device, h/w thread,
+  // functional units etc.
+  [[nodiscard]] virtual int64_t resourceId() const = 0;
+  // s/w thread
+  [[nodiscard]] virtual int32_t getThreadId() const = 0;
+  // Start timestamp in nanoseconds
+  [[nodiscard]] virtual int64_t timestamp() const = 0;
+  // Duration in nanoseconds
+  [[nodiscard]] virtual int64_t duration() const = 0;
+  // Used to link up async activities
+  [[nodiscard]] virtual int64_t correlationId() const = 0;
+  // Part of a flow, identified by flow id and type
+  [[nodiscard]] virtual int flowType() const = 0;
+  [[nodiscard]] virtual int64_t flowId() const = 0;
+  [[nodiscard]] virtual bool flowStart() const = 0;
+  [[nodiscard]] virtual ActivityType type() const = 0;
+  [[nodiscard]] virtual const std::string name() const = 0;
+  // Optional linked activity
+  [[nodiscard]] virtual const ITraceActivity* linkedActivity() const = 0;
+  // Optional containing trace object
+  [[nodiscard]] virtual const TraceSpan* traceSpan() const = 0;
+  // Log activity
+  virtual void log(ActivityLogger& logger) const = 0;
+  // Return json formatted metadata
+  // FIXME: Return iterator to dynamic type map here instead
+  [[nodiscard]] virtual const std::string metadataJson() const = 0;
+  // Write structured metadata to a consumer.
+  virtual void visitTypedMetadata(
+      [[maybe_unused]] ITypedMetadataVisitor& visitor) const {}
+  // Return the metadata value in string format with key
+  // @lint-ignore CLANGTIDY: clang-diagnostic-unused-parameter
+  [[nodiscard]] virtual const std::string getMetadataValue(
+      [[maybe_unused]] const std::string& key) const {
+    return "";
+  }
+  // Return typed counter values (name, value) for activities with
+  // floating-point metadata that should not be round-tripped through strings.
+  [[nodiscard]] virtual const std::vector<std::pair<std::string, double>>&
+  counterValues() const {
+    static const std::vector<std::pair<std::string, double>> kEmpty;
+    return kEmpty;
+  }
+
+  static int64_t nsToUs(int64_t ns) {
+    // It's important that this conversion is the same everywhere.
+    // No rounding!
+    return ns / 1000;
+  }
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/LoggingAPI.h
+++ b/third_party/kineto/libkineto/include/LoggingAPI.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace libkineto {
+int getLogSeverityLevel();
+void setLogSeverityLevel(int level);
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/MetadataFieldCatalog.h
+++ b/third_party/kineto/libkineto/include/MetadataFieldCatalog.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "TypedMetadata.h"
+
+// Catalog of typed metadata field keys, grouped by producer domain.
+
+namespace libkineto::GenericMetadataFields {
+inline constexpr MetadataField<InputShapes> kInputDims{"Input Dims"};
+inline constexpr MetadataField<InputShapes> kInputStrides{"Input Strides"};
+inline constexpr MetadataField<std::vector<std::string>> kInputType{
+    "Input type"};
+inline constexpr MetadataField<int64_t> kSequenceNumber{"Sequence number"};
+inline constexpr MetadataField<uint64_t> kFwdThreadId{"Fwd thread id"};
+inline constexpr MetadataField<uint64_t> kRecordFunctionId{
+    "Record function id"};
+inline constexpr MetadataField<int64_t> kEvIdx{"Ev Idx"};
+inline constexpr MetadataField<uint64_t> kAddr{"Addr"};
+inline constexpr MetadataField<int64_t> kBytes{"Bytes"};
+inline constexpr MetadataField<uint64_t> kTotalAllocated{"Total Allocated"};
+inline constexpr MetadataField<uint64_t> kTotalReserved{"Total Reserved"};
+inline constexpr MetadataField<int64_t> kDeviceType{"Device Type"};
+inline constexpr MetadataField<int64_t> kDeviceId{"Device Id"};
+inline constexpr MetadataField<uint64_t> kPythonId{"Python id"};
+inline constexpr MetadataField<uint64_t> kPythonParentId{"Python parent id"};
+inline constexpr MetadataField<uint64_t> kPythonModuleId{"Python module id"};
+inline constexpr MetadataField<uint64_t> kPythonThread{"Python thread"};
+inline constexpr MetadataField<std::string> kBackend{"Backend"};
+inline constexpr MetadataField<std::string> kCallFrom{"CallFrom"};
+inline constexpr MetadataField<std::string> kCallStack{"Call stack"};
+inline constexpr MetadataField<std::string> kModuleHierarchy{
+    "Module Hierarchy"};
+inline constexpr MetadataField<std::vector<std::string>> kConcreteInputs{
+    "Concrete Inputs"};
+} // namespace libkineto::GenericMetadataFields
+
+namespace libkineto::CollectiveMetadataFields {
+inline constexpr MetadataField<std::string> kCollectiveName{"Collective name"};
+inline constexpr MetadataField<std::string> kDtype{"dtype"};
+inline constexpr MetadataField<int64_t> kInMsgNelems{"In msg nelems"};
+inline constexpr MetadataField<int64_t> kOutMsgNelems{"Out msg nelems"};
+inline constexpr MetadataField<std::string> kInSplit{"In split size"};
+inline constexpr MetadataField<std::string> kOutSplit{"Out split size"};
+inline constexpr MetadataField<int64_t> kGlobalRankStart{"Global rank start"};
+inline constexpr MetadataField<int64_t> kGlobalRankStride{"Global rank stride"};
+inline constexpr MetadataField<int64_t> kGroupSize{"Group size"};
+inline constexpr MetadataField<std::string> kProcessGroupName{
+    "Process Group Name"};
+inline constexpr MetadataField<std::string> kProcessGroupDesc{
+    "Process Group Description"};
+inline constexpr MetadataField<std::string> kGroupRanks{"Process Group Ranks"};
+inline constexpr MetadataField<int64_t> kRank{"Rank"};
+inline constexpr MetadataField<int64_t> kP2pSrc{"Src Rank"};
+inline constexpr MetadataField<int64_t> kP2pDst{"Dst Rank"};
+inline constexpr MetadataField<int64_t> kSeqNum{"Seq"};
+inline constexpr MetadataField<std::string> kInTensorsStart{
+    "Input Tensors start"};
+inline constexpr MetadataField<std::string> kOutTensorsStart{
+    "Output Tensors start"};
+inline constexpr MetadataField<bool> kIsAsynchronizedOp{"Is asynchronized op"};
+inline constexpr MetadataField<uint64_t> kCommsId{"Comms Id"};
+} // namespace libkineto::CollectiveMetadataFields
+
+namespace libkineto::DevicePropertyMetadataFields {
+inline constexpr MetadataField<uint64_t> kId{"id"};
+inline constexpr MetadataField<std::string> kName{"name"};
+inline constexpr MetadataField<uint64_t> kTotalGlobalMem{"totalGlobalMem"};
+inline constexpr MetadataField<int64_t> kComputeMajor{"computeMajor"};
+inline constexpr MetadataField<int64_t> kComputeMinor{"computeMinor"};
+inline constexpr MetadataField<int64_t> kMaxThreadsPerBlock{
+    "maxThreadsPerBlock"};
+inline constexpr MetadataField<int64_t> kMaxThreadsPerMultiprocessor{
+    "maxThreadsPerMultiprocessor"};
+inline constexpr MetadataField<int64_t> kRegsPerBlock{"regsPerBlock"};
+inline constexpr MetadataField<int64_t> kWarpSize{"warpSize"};
+inline constexpr MetadataField<uint64_t> kSharedMemPerBlock{
+    "sharedMemPerBlock"};
+inline constexpr MetadataField<int64_t> kNumSms{"numSms"};
+inline constexpr MetadataField<int64_t> kRegsPerMultiprocessor{
+    "regsPerMultiprocessor"};
+inline constexpr MetadataField<uint64_t> kSharedMemPerBlockOptin{
+    "sharedMemPerBlockOptin"};
+inline constexpr MetadataField<uint64_t> kSharedMemPerMultiprocessor{
+    "sharedMemPerMultiprocessor"};
+inline constexpr MetadataField<uint64_t> kMaxSharedMemoryPerMultiProcessor{
+    "maxSharedMemoryPerMultiProcessor"};
+} // namespace libkineto::DevicePropertyMetadataFields
+
+namespace libkineto::CudaMetadataFields {
+inline constexpr MetadataDict kOccupancy{"occupancy"};
+inline constexpr MetadataField<int64_t> kActiveBlocksPerMultiprocessor{
+    "activeBlocksPerMultiprocessor"};
+inline constexpr MetadataField<int64_t> kAllocatedRegistersPerBlock{
+    "allocatedRegistersPerBlock"};
+inline constexpr MetadataField<uint64_t> kAllocatedSharedMemPerBlock{
+    "allocatedSharedMemPerBlock"};
+inline constexpr MetadataField<std::vector<int64_t>> kBlock{"block"};
+inline constexpr MetadataField<int64_t> kBlockLimitBarriers{
+    "blockLimitBarriers"};
+inline constexpr MetadataField<int64_t> kBlockLimitBlocks{"blockLimitBlocks"};
+inline constexpr MetadataField<int64_t> kBlockLimitRegs{"blockLimitRegs"};
+inline constexpr MetadataField<int64_t> kBlockLimitSharedMem{
+    "blockLimitSharedMem"};
+inline constexpr MetadataField<int64_t> kBlockLimitWarps{"blockLimitWarps"};
+inline constexpr MetadataField<double> kBlocksPerSm{"blocks per SM"};
+inline constexpr MetadataField<uint64_t> kBytes{"bytes"};
+inline constexpr MetadataField<uint64_t> kCbid{"cbid"};
+inline constexpr MetadataField<uint64_t> kChannel{"channel"};
+inline constexpr MetadataField<int64_t> kChannelType{"channel_type"};
+inline constexpr MetadataField<uint64_t> kContext{"context"};
+inline constexpr MetadataField<uint64_t> kCorrelation{"correlation"};
+inline constexpr MetadataField<std::string> kCudaSyncKind{"cuda_sync_kind"};
+inline constexpr MetadataField<int64_t> kDevice{"device"};
+inline constexpr MetadataField<int64_t> kEstAchievedOccupancyPercent{
+    "est. achieved occupancy %"};
+inline constexpr MetadataField<uint64_t> kEventId{"event_id"};
+inline constexpr MetadataField<uint64_t> kFromContext{"fromContext"};
+inline constexpr MetadataField<uint64_t> kFromDevice{"fromDevice"};
+inline constexpr MetadataField<uint64_t> kGraphId{"graph id"};
+inline constexpr MetadataField<uint64_t> kGraphNodeId{"graph node id"};
+inline constexpr MetadataField<std::vector<int64_t>> kGrid{"grid"};
+inline constexpr MetadataField<uint64_t> kInContext{"inContext"};
+inline constexpr MetadataField<uint64_t> kInDevice{"inDevice"};
+inline constexpr MetadataField<std::string> kLimitingFactors{"limitingFactors"};
+inline constexpr MetadataField<double> kMemoryBandwidthGbps{
+    "memory bandwidth (GB/s)"};
+inline constexpr MetadataField<int64_t> kPriority{"priority"};
+inline constexpr MetadataField<uint64_t> kQueued{"queued"};
+inline constexpr MetadataField<uint64_t> kRegistersPerThread{
+    "registers per thread"};
+inline constexpr MetadataField<int64_t> kSharedMemory{"shared memory"};
+inline constexpr MetadataField<int64_t> kStream{"stream"};
+inline constexpr MetadataField<uint64_t> kToContext{"toContext"};
+inline constexpr MetadataField<uint64_t> kToDevice{"toDevice"};
+inline constexpr MetadataField<uint64_t> kWaitOnCudaEventId{
+    "wait_on_cuda_event_id"};
+inline constexpr MetadataField<int64_t> kWaitOnCudaEventRecordCorrId{
+    "wait_on_cuda_event_record_corr_id"};
+inline constexpr MetadataField<int64_t> kWaitOnStream{"wait_on_stream"};
+inline constexpr MetadataField<double> kWarpsPerSm{"warps per SM"};
+} // namespace libkineto::CudaMetadataFields
+
+namespace libkineto::RocmMetadataFields {
+inline constexpr MetadataField<std::vector<int64_t>> kBlock{"block"};
+inline constexpr MetadataField<uint64_t> kBytes{"bytes"};
+inline constexpr MetadataField<uint64_t> kCid{"cid"};
+inline constexpr MetadataField<uint64_t> kCorrelation{"correlation"};
+inline constexpr MetadataField<int64_t> kDevice{"device"};
+inline constexpr MetadataField<std::string> kDst{"dst"};
+inline constexpr MetadataField<std::vector<int64_t>> kGrid{"grid"};
+inline constexpr MetadataField<uint64_t> kHsaQueue{"hsa_queue"};
+inline constexpr MetadataField<std::string> kKernel{"kernel"};
+inline constexpr MetadataField<std::string> kKind{"kind"};
+inline constexpr MetadataField<double> kMemoryBandwidthGbps{
+    "memory bandwidth (GB/s)"};
+inline constexpr MetadataField<std::string> kPtr{"ptr"};
+inline constexpr MetadataField<uint64_t> kSharedMemory{"shared memory"};
+inline constexpr MetadataField<std::string> kSrc{"src"};
+inline constexpr MetadataField<int64_t> kStream{"stream"};
+} // namespace libkineto::RocmMetadataFields

--- a/third_party/kineto/libkineto/include/ThreadUtil.h
+++ b/third_party/kineto/libkineto/include/ThreadUtil.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <sys/stat.h>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace libkineto {
+
+int32_t systemThreadId(bool cache = true);
+int32_t threadId();
+bool setThreadName(const std::string& name);
+std::string getThreadName();
+
+int32_t pidNamespace(ino_t& ns);
+int32_t processId(bool cache = true);
+std::string processName(int32_t pid);
+
+// Return a list of pids and process names for the current process
+// and its parents.
+std::vector<std::pair<int32_t, std::string>> pidCommandPairsOfAncestors();
+
+// Resets all cached Thread local state, this must be done on
+// forks to prevent stale values from being retained.
+void resetTLS();
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/TraceSpan.h
+++ b/third_party/kineto/libkineto/include/TraceSpan.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <string>
+#include <thread>
+
+namespace libkineto {
+
+struct TraceSpan {
+  TraceSpan() = delete;
+  TraceSpan(int64_t startTime, int64_t endTime, std::string name)
+      : startTime(startTime), endTime(endTime), name(std::move(name)) {}
+  TraceSpan(int opCount, int it, std::string name, std::string prefix)
+      : opCount(opCount),
+        iteration(it),
+        name(std::move(name)),
+        prefix(std::move(prefix)) {}
+
+  // FIXME: change to duration?
+  int64_t startTime{0};
+  int64_t endTime{0};
+  int opCount{0};
+  int iteration{-1};
+  // Name is used to identify timeline
+  std::string name;
+  // Prefix used to distinguish trace spans on the same timeline
+  std::string prefix;
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/TypedMetadata.h
+++ b/third_party/kineto/libkineto/include/TypedMetadata.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <concepts>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+namespace libkineto {
+
+template <typename T>
+struct MetadataField {
+  using FieldType = T;
+
+  std::string_view name;
+};
+
+struct MetadataDict {
+  std::string_view name;
+};
+
+// Used to identify JSON fields from normal strings.
+struct RawJson {
+  std::string value;
+};
+
+// For a TensorList op argument: the per-dimension shape of each tensor in the
+// list.
+using TensorListShapes = std::vector<std::vector<int64_t>>;
+
+// "Input Dims" / "Input Strides" payload: one entry per op argument, each
+// either a single tensor's shape or, for a TensorList argument, a list of
+// tensor shapes.
+using InputShapes =
+    std::vector<std::variant<std::vector<int64_t>, TensorListShapes>>;
+
+// The set of value types the typed-metadata system supports.
+using TypedValue = std::variant<
+    int64_t,
+    uint64_t,
+    double,
+    bool,
+    std::string,
+    std::vector<int64_t>,
+    std::vector<std::string>,
+    RawJson,
+    InputShapes>;
+
+/*
+ * ITypedMetadataVisitor is a per-activity visitor for structured metadata with
+ * field-level type checking.
+ *
+ * Usage:
+ *   // Declare each field once. FieldType is int64_t here, and visit() enforces
+ *   // that declared type.
+ *   inline constexpr MetadataField<int64_t> kCorrelation{"correlation"};
+ *
+ *   // Producer: emit metadata from ITraceActivity::visitTypedMetadata().
+ *   void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override {
+ *     visitor.visit(kCorrelation, int64_t{activity.correlationId});
+ *   }
+ *
+ *   // Consumer: implement visitValue() overloads for handled field types.
+ *   class MyVisitor : public ITypedMetadataVisitor {
+ *     ...
+ *   };
+ *
+ *   // Consumer: pass the visitor to an activity for generic output conversion.
+ *   MyVisitor visitor;
+ *   activity.visitTypedMetadata(visitor);
+ */
+class ITypedMetadataVisitor {
+ public:
+  virtual ~ITypedMetadataVisitor() = default;
+
+  template <typename T, typename V>
+  void visit(const MetadataField<T>& field, const V& value) {
+    using FieldType = typename MetadataField<T>::FieldType;
+    static_assert(
+        std::is_same_v<FieldType, std::decay_t<V>>,
+        "value type must match field's declared type");
+    visitValue(field, value);
+  }
+
+  // Visits a nested dict: everything `visitChildren` visits is grouped under
+  // dict.name. Example:
+  // visitor.visit(kStats, [](auto& d) { d.visit(kCount, int64_t{1}); });
+  void visit(
+      const MetadataDict& dict,
+      std::invocable<ITypedMetadataVisitor&> auto&& visitChildren) {
+    beginDict(dict.name);
+    visitChildren(*this);
+    endDict();
+  }
+
+ protected:
+  // beginDict/endDict bracket a nested dict and are always invoked as a
+  // pair by visit(MetadataDict, ...), with the dict's children visited in
+  // between.
+  virtual void beginDict(std::string_view name) = 0;
+  virtual void endDict() = 0;
+
+  virtual void visitUnsupported(std::string_view name) = 0;
+
+  template <typename T>
+  void visitValue(const MetadataField<T>& field, const T& /*value*/) {
+    visitUnsupported(field.name);
+  }
+
+  void visitValue(
+      const MetadataField<std::string>& field,
+      const std::string& value) {
+    visitValue(field, std::string_view{value});
+  }
+
+  virtual void visitValue(
+      const MetadataField<int64_t>& field,
+      int64_t value) = 0;
+
+  virtual void visitValue(const MetadataField<double>& field, double value) = 0;
+
+  virtual void visitValue(const MetadataField<bool>& field, bool value) = 0;
+
+  virtual void visitValue(
+      const MetadataField<std::string>& field,
+      std::string_view value) = 0;
+
+  virtual void visitValue(
+      const MetadataField<std::vector<int64_t>>& field,
+      const std::vector<int64_t>& value) = 0;
+
+  virtual void visitValue(
+      const MetadataField<std::vector<std::string>>& field,
+      const std::vector<std::string>& value) = 0;
+
+  virtual void visitValue(
+      const MetadataField<RawJson>& field,
+      const RawJson& value) = 0;
+
+  virtual void visitValue(
+      const MetadataField<uint64_t>& field,
+      uint64_t value) = 0;
+
+  virtual void visitValue(
+      const MetadataField<InputShapes>& field,
+      const InputShapes& value) = 0;
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/TypedMetadataJson.h
+++ b/third_party/kineto/libkineto/include/TypedMetadataJson.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "TypedMetadata.h"
+
+#include <fmt/format.h>
+
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+// Migration-only typed metadata -> metadataJson compatibility helpers.
+//
+// These helpers preserve legacy metadataJson formatting while Kineto producers
+// are migrated to typed metadata. Eventually, we want to decouple metadataJson
+// from ITraceActivity and rely only on typed metadata as the canonical Kineto
+// metadata output. We use these helpers to reduce the risk of drift during
+// migration.
+//
+// IMPORTANT: This file may change or go away once metadataJson is no longer
+// needed as an ITraceActivity output.
+
+namespace libkineto::internal {
+
+class JsonTypedMetadataVisitor final : public ITypedMetadataVisitor {
+ public:
+  JsonTypedMetadataVisitor() {
+    json_.reserve(kInitialJsonCapacity);
+  }
+
+  [[nodiscard]] std::string json() && {
+    return std::move(json_);
+  }
+
+  // Public so GenericTraceActivity's metadata serialization can render
+  // collections without duplicating this logic.
+  template <typename T>
+  static void appendArray(std::string& json, const std::vector<T>& values) {
+    json += '[';
+    bool first = true;
+    for (const auto& value : values) {
+      if (!first) {
+        json += ", ";
+      }
+      appendArrayValue(json, value);
+      first = false;
+    }
+    json += ']';
+  }
+
+ private:
+  // Sized to hold the largest common CUDA activity (kernels) in one allocation,
+  // with some buffer
+  static constexpr size_t kInitialJsonCapacity = 1024;
+
+  // Widest int64_t is "-9223372036854775808" (20 chars)
+  static constexpr size_t kMaxInt64Chars = 20;
+
+  void visitValue(const MetadataField<int64_t>& field, int64_t value) override {
+    appendField(field, [&](std::string& json) { appendIntValue(json, value); });
+  }
+
+  void visitValue(const MetadataField<double>& field, double value) override {
+    appendField(
+        field, [&](std::string& json) { appendDoubleValue(json, value); });
+  }
+
+  void visitValue(const MetadataField<bool>& field, bool value) override {
+    appendField(
+        field, [&](std::string& json) { json += value ? "true" : "false"; });
+  }
+
+  void visitValue(
+      const MetadataField<std::string>& field,
+      std::string_view value) override {
+    appendField(field, [&](std::string& json) { appendQuoted(json, value); });
+  }
+
+  void visitValue(
+      const MetadataField<std::vector<int64_t>>& field,
+      const std::vector<int64_t>& value) override {
+    appendField(field, [&](std::string& json) { appendArray(json, value); });
+  }
+
+  void visitValue(
+      const MetadataField<std::vector<std::string>>& field,
+      const std::vector<std::string>& value) override {
+    appendField(field, [&](std::string& json) { appendArray(json, value); });
+  }
+
+  void visitValue(const MetadataField<RawJson>& field, const RawJson& value)
+      override {
+    appendField(field, [&](std::string& json) { json += value.value; });
+  }
+
+  void visitValue(const MetadataField<uint64_t>& field, uint64_t value)
+      override {
+    appendField(
+        field, [&](std::string& json) { appendUIntValue(json, value); });
+  }
+
+  void visitValue(
+      const MetadataField<InputShapes>& field,
+      const InputShapes& value) override {
+    appendField(field, [&](std::string& json) { appendArray(json, value); });
+  }
+
+  // Emit a visible placeholder rather than silently dropping a metadata type
+  // the JSON serializer doesn't handle, so the gap shows up in the trace.
+  void visitUnsupported(std::string_view name) override {
+    appendKey(name);
+    appendQuoted(json_, "<unsupported metadata type>");
+  }
+
+  void beginDict(std::string_view name) override {
+    appendKey(name);
+    json_ += '{';
+    firstEntry_ = true;
+  }
+
+  void endDict() override {
+    json_ += '}';
+    firstEntry_ = false;
+  }
+
+  template <typename T, typename WriteValue>
+  void appendField(const MetadataField<T>& field, WriteValue writeValue) {
+    appendKey(field.name);
+    writeValue(json_);
+  }
+
+  void appendKey(std::string_view key) {
+    if (!firstEntry_) {
+      json_ += ", ";
+    }
+    firstEntry_ = false;
+    appendQuoted(json_, key);
+    json_ += ": ";
+  }
+
+  static void appendQuoted(std::string& json, std::string_view value) {
+    json += '"';
+    json += value;
+    json += '"';
+  }
+
+  static void appendIntValue(std::string& json, int64_t value) {
+    char buf[kMaxInt64Chars];
+    const auto result = std::to_chars(buf, buf + sizeof(buf), value);
+    json.append(buf, static_cast<size_t>(result.ptr - buf));
+  }
+
+  static void appendUIntValue(std::string& json, uint64_t value) {
+    char buf[kMaxInt64Chars];
+    const auto result = std::to_chars(buf, buf + sizeof(buf), value);
+    json.append(buf, static_cast<size_t>(result.ptr - buf));
+  }
+
+  static void appendDoubleValue(std::string& json, double value) {
+    if (std::isfinite(value)) {
+      fmt::format_to(std::back_inserter(json), "{}", value);
+      return;
+    }
+    appendQuoted(json, fmt::format("{}", value));
+  }
+
+  static void appendArrayValue(std::string& json, int64_t value) {
+    appendIntValue(json, value);
+  }
+
+  static void appendArrayValue(std::string& json, const std::string& value) {
+    appendQuoted(json, value);
+  }
+
+  // Nested-array entries so InputShapes serializes through the appendArray
+  // recursion
+  static void appendArrayValue(
+      std::string& json,
+      const std::vector<int64_t>& value) {
+    appendArray(json, value);
+  }
+
+  static void appendArrayValue(
+      std::string& json,
+      const std::variant<std::vector<int64_t>, TensorListShapes>& value) {
+    std::visit(
+        [&json](const auto& shapes) { appendArray(json, shapes); }, value);
+  }
+
+  std::string json_;
+  bool firstEntry_ = true;
+};
+
+} // namespace libkineto::internal

--- a/third_party/kineto/libkineto/include/libkineto.h
+++ b/third_party/kineto/libkineto/include/libkineto.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Mediator for initialization and profiler control
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ActivityProfilerInterface.h"
+#include "ActivityTraceInterface.h"
+#include "ActivityType.h"
+#include "ClientInterface.h"
+#include "GenericTraceActivity.h"
+#include "IActivityProfiler.h"
+#include "ILoggerObserver.h"
+#include "LoggingAPI.h"
+#include "TraceSpan.h"
+
+#include "ThreadUtil.h"
+
+extern "C" {
+void suppressLibkinetoLogMessages();
+int InitializeInjection(void);
+void libkineto_init(bool cpuOnly, bool logOnError);
+bool hasTestEnvVar();
+}
+
+namespace libkineto {
+
+class ActivityLogger;
+class Config;
+class ConfigLoader;
+
+struct CpuTraceBuffer {
+  template <class... Args>
+  void emplace_activity(Args&&... args) {
+    activities.emplace_back(
+        std::make_unique<GenericTraceActivity>(std::forward<Args>(args)...));
+  }
+
+  static GenericTraceActivity& toRef(
+      std::unique_ptr<GenericTraceActivity>& ref) {
+    return *ref;
+  }
+
+  static const GenericTraceActivity& toRef(
+      const std::unique_ptr<GenericTraceActivity>& ref) {
+    return *ref;
+  }
+
+  TraceSpan span{0, 0, "none"};
+  int gpuOpCount;
+  std::deque<std::unique_ptr<GenericTraceActivity>> activities;
+};
+
+using ChildActivityProfilerFactory =
+    std::function<std::unique_ptr<IActivityProfiler>()>;
+using LoggerFactory =
+    std::function<std::unique_ptr<ActivityLogger>(const std::string&)>;
+
+class LibkinetoApi {
+ public:
+  explicit LibkinetoApi(ConfigLoader& configLoader)
+      : configLoader_(configLoader) {}
+
+  // Called by client that supports tracing API.
+  // libkineto can still function without this.
+  void registerClient(ClientInterface* client);
+
+  // Called by libkineto on init
+  void registerProfiler(std::unique_ptr<ActivityProfilerInterface> profiler) {
+    activityProfiler_ = std::move(profiler);
+    initClientIfRegistered();
+  }
+
+  ActivityProfilerInterface& activityProfiler() {
+    return *activityProfiler_;
+  }
+
+  ClientInterface* client() {
+    return client_;
+  }
+
+  void initProfilerIfRegistered() {
+    static std::once_flag once;
+    if (activityProfiler_) {
+      std::call_once(once, [this] {
+        if (!activityProfiler_->isInitialized()) {
+          activityProfiler_->init();
+          initChildActivityProfilers();
+        }
+      });
+    }
+  }
+
+  [[nodiscard]] bool isProfilerInitialized() const {
+    return activityProfiler_ && activityProfiler_->isInitialized();
+  }
+
+  [[nodiscard]] bool isProfilerRegistered() const {
+    return activityProfiler_ != nullptr;
+  }
+
+  void suppressLogMessages() {
+    suppressLibkinetoLogMessages();
+  }
+
+  void resetKinetoTLS() {
+    resetTLS();
+  }
+
+  // Provides access to profier configuration manaegement
+  ConfigLoader& configLoader() {
+    return configLoader_;
+  }
+
+  void registerProfilerFactory(const ChildActivityProfilerFactory& factory) {
+    if (isProfilerInitialized()) {
+      activityProfiler_->addChildActivityProfiler(factory());
+    } else {
+      childProfilerFactories_.push_back(factory);
+    }
+  }
+
+ private:
+  void initChildActivityProfilers() {
+    if (!isProfilerInitialized()) {
+      return;
+    }
+    for (const auto& factory : childProfilerFactories_) {
+      activityProfiler_->addChildActivityProfiler(factory());
+    }
+    childProfilerFactories_.clear();
+  }
+
+  // Client is initialized once both it and libkineto has registered
+  void initClientIfRegistered();
+
+  ConfigLoader& configLoader_;
+  std::unique_ptr<ActivityProfilerInterface> activityProfiler_;
+  ClientInterface* client_{};
+  int32_t clientRegisterThread_{0};
+
+  std::vector<ChildActivityProfilerFactory> childProfilerFactories_;
+};
+
+// Singleton
+LibkinetoApi& api();
+
+// Register a custom output format logger with a protocol prefix.
+// Example: registerLoggerFactory("foo", [](const std::string& path) {
+//   return std::make_unique<FooLogger>(path);
+// });
+// Users can then call trace.save("foo:///tmp/trace.bar")
+void registerLoggerFactory(const std::string& protocol, LoggerFactory factory);
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/output_base.h
+++ b/third_party/kineto/libkineto/include/output_base.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fstream>
+#include <map>
+#include <ostream>
+#include <thread>
+#include <unordered_map>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "GenericTraceActivity.h"
+#include "IActivityProfiler.h"
+#include "ThreadUtil.h"
+#include "TraceSpan.h"
+
+namespace KINETO_NAMESPACE {
+struct ActivityBuffers;
+}
+
+namespace libkineto {
+
+using namespace KINETO_NAMESPACE;
+
+// Used by sortIndex to put GPU tracks at the bottom
+// of the trace timelines. The largest valid CPU PID is 4,194,304,
+// so 5000000 is enough to guarantee that GPU tracks are sorted after CPU.
+constexpr int64_t kExceedMaxPid = 5000000;
+
+class ActivityLogger {
+ public:
+  virtual ~ActivityLogger() = default;
+
+  struct OverheadInfo {
+    explicit OverheadInfo(const std::string& name) : name(name) {}
+    const std::string name;
+  };
+
+  virtual void handleDeviceInfo(const DeviceInfo& info, int64_t time) = 0;
+
+  virtual void handleResourceInfo(const ResourceInfo& info, int64_t time) = 0;
+
+  virtual void handleOverheadInfo(const OverheadInfo& info, int64_t time) = 0;
+
+  virtual void handleTraceSpan(const TraceSpan& span) = 0;
+
+  virtual void handleActivity(const libkineto::ITraceActivity& activity) = 0;
+  virtual void handleGenericActivity(
+      const libkineto::GenericTraceActivity& activity) = 0;
+
+  virtual void handleTraceStart(
+      const std::unordered_map<std::string, std::string>& metadata,
+      const std::string& device_properties) = 0;
+
+  void handleTraceStart() {
+    handleTraceStart(std::unordered_map<std::string, std::string>(), "");
+  }
+
+  virtual void finalizeMemoryTrace(const std::string&, const Config&) = 0;
+
+  virtual void finalizeTrace(
+      const Config& config,
+      std::unique_ptr<ActivityBuffers> buffers,
+      int64_t endTime) = 0;
+
+ protected:
+  ActivityLogger() = default;
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/include/time_since_epoch.h
+++ b/third_party/kineto/libkineto/include/time_since_epoch.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <chrono>
+
+namespace libkineto {
+template <class ClockT>
+inline int64_t timeSinceEpoch(const std::chrono::time_point<ClockT>& t) {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             t.time_since_epoch())
+      .count();
+}
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/libkineto_defs.bzl
+++ b/third_party/kineto/libkineto/libkineto_defs.bzl
@@ -1,0 +1,196 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# WARNING: the contents of this file must be BOTH valid Starlark (so Buck can
+# load() the lists below) AND valid Python (so the CMake build can read them by
+# exec()-ing this file; see get_filelist() in CMakeLists.txt). That means no
+# load() directives and no glob() calls here -- neither is valid Python. Keep
+# every source list an explicit list of string literals. Headers for the Buck
+# targets are globbed in BUCK itself, which is Starlark-only; only the curated
+# public-header install surface lives here.
+
+# Source lists are decomposed into fine-grained "atoms" so both build systems
+# draw from one source of truth: the Buck targets in BUCK compose the atoms they
+# need, and the coarse per-backend accessors below (which CMake calls) compose
+# the same atoms. A file appears in exactly one atom, so a rename on GitHub is a
+# single edit here that flows to every build.
+
+# --- Core (backend-independent) source atoms ---
+THREAD_UTIL_SRCS = [
+    "src/ThreadUtil.cpp",
+]
+
+LIBKINETO_API_SRCS = [
+    "src/libkineto_api.cpp",
+]
+
+LOGGER_SRCS = [
+    "src/ILoggerObserver.cpp",
+    "src/Logger.cpp",
+]
+
+LOGGING_API_SRCS = [
+    "src/LoggingAPI.cpp",
+]
+
+CONFIG_SRCS = [
+    "src/AbstractConfig.cpp",
+    "src/Config.cpp",
+]
+
+ACTIVITY_TYPE_SRCS = [
+    "src/ActivityType.cpp",
+]
+
+CONFIG_LOADER_SRCS = [
+    "src/ConfigLoader.cpp",
+    "src/DaemonConfigLoader.cpp",
+]
+
+CONFIG_CLIENT_SRCS = [
+    "src/IpcFabricConfigClient.cpp",
+]
+
+DEVICE_FUNCTIONS_SRCS = [
+    "src/DeviceProperties.cpp",
+    "src/DeviceUtil.cpp",
+]
+
+BASE_LOGGER_SRCS = [
+    "src/GenericTraceActivity.cpp",
+]
+
+DEMANGLE_SRCS = [
+    "src/Demangle.cpp",
+]
+
+APPROXIMATE_CLOCK_SRCS = [
+    "src/ApproximateClock.cpp",
+]
+
+KERNEL_REGISTRY_SRCS = [
+    "src/KernelRegistry.cpp",
+]
+
+OUTPUT_JSON_SRCS = [
+    "src/output_json.cpp",
+]
+
+ACTIVITY_PROFILER_CORE_SRCS = [
+    "src/ActivityProfilerController.cpp",
+    "src/ActivityProfilerProxy.cpp",
+    "src/GenericActivityProfiler.cpp",
+    "src/AsyncActivityProfilerHandler.cpp",
+    "src/SyncActivityProfilerHandler.cpp",
+]
+
+INIT_SRCS = [
+    "src/init.cpp",
+]
+
+# --- CUPTI (CUDA) source atoms ---
+CUPTI_API_SRCS = [
+    "src/CuptiActivityApi.cpp",
+    "src/CuptiCallbackApi.cpp",
+    "src/CuptiCbidRegistry.cpp",
+    "src/cupti_strings.cpp",
+]
+
+CUPTI_ACTIVITY_PROFILER_SRCS = [
+    "src/CuptiActivityProfiler.cpp",
+]
+
+WEAK_SYMBOLS_SRCS = [
+    "src/WeakSymbols.cpp",
+]
+
+# --- ROCm source atoms ---
+ROCM_API_SRCS = [
+    "src/RocLogger.cpp",
+    "src/RocprofActivityApi.cpp",
+    "src/RocprofLogger.cpp",
+]
+
+ROCM_ACTIVITY_PROFILER_SRCS = [
+    "src/RocmActivityProfiler.cpp",
+]
+
+# --- XPU (xpupti) source atoms ---
+XPUPTI_SRCS = [
+    "src/plugin/xpupti/XpuptiActivityApi.cpp",
+    "src/plugin/xpupti/XpuptiActivityHandlers.cpp",
+    "src/plugin/xpupti/XpuptiActivityProfiler.cpp",
+    "src/plugin/xpupti/XpuptiActivityProfilerSession.cpp",
+    "src/plugin/xpupti/XpuptiProfilerMacros.cpp",
+    "src/plugin/xpupti/XpuptiScopeProfilerApi.cpp",
+    "src/plugin/xpupti/XpuptiScopeProfilerConfig.cpp",
+    "src/plugin/xpupti/XpuptiScopeProfilerHandlers.cpp",
+    "src/plugin/xpupti/XpuptiScopeProfilerSession.cpp",
+]
+
+# --- Coarse per-backend accessors (composed from the atoms above) ---
+# CMake calls these; Buck targets compose the atoms directly.
+
+def get_libkineto_api_srcs():
+    return THREAD_UTIL_SRCS + LIBKINETO_API_SRCS
+
+def get_libkineto_cpu_only_srcs(with_api = True):
+    return (
+        CONFIG_SRCS
+        + ACTIVITY_TYPE_SRCS
+        + CONFIG_LOADER_SRCS
+        + CONFIG_CLIENT_SRCS
+        + LOGGER_SRCS
+        + LOGGING_API_SRCS
+        + DEMANGLE_SRCS
+        + DEVICE_FUNCTIONS_SRCS
+        + BASE_LOGGER_SRCS
+        + APPROXIMATE_CLOCK_SRCS
+        + ACTIVITY_PROFILER_CORE_SRCS
+        + INIT_SRCS
+        + OUTPUT_JSON_SRCS
+        + (get_libkineto_api_srcs() if with_api else [])
+    )
+
+def get_libkineto_cupti_srcs(with_api = True):
+    return CUPTI_API_SRCS + CUPTI_ACTIVITY_PROFILER_SRCS + KERNEL_REGISTRY_SRCS + WEAK_SYMBOLS_SRCS + get_libkineto_cpu_only_srcs(with_api)
+
+def get_libkineto_rocprofiler_srcs(with_api = True):
+    return ROCM_ACTIVITY_PROFILER_SRCS + ROCM_API_SRCS + get_libkineto_cpu_only_srcs(with_api)
+
+def get_libkineto_xpupti_srcs(with_api = True):
+    return XPUPTI_SRCS + get_libkineto_cpu_only_srcs(with_api)
+
+def get_libkineto_public_headers():
+    return [
+        "include/AbstractConfig.h",
+        "include/ActivityProfilerInterface.h",
+        "include/ActivityTraceInterface.h",
+        "include/ActivityType.h",
+        "include/Config.h",
+        "include/ClientInterface.h",
+        "include/GenericTraceActivity.h",
+        "include/IActivityProfiler.h",
+        "include/ILoggerObserver.h",
+        "include/ITraceActivity.h",
+        "include/LoggingAPI.h",
+        "include/MetadataFieldCatalog.h",
+        "include/TraceSpan.h",
+        "include/ThreadUtil.h",
+        "include/TypedMetadata.h",
+        "include/TypedMetadataJson.h",
+        "include/libkineto.h",
+        "include/time_since_epoch.h",
+        "include/output_base.h",
+    ]
+
+# kineto code should be updated to not have to
+# suppress these warnings.
+KINETO_COMPILER_FLAGS = [
+    "-fexceptions",
+    "-Wno-deprecated-declarations",
+    "-Wno-unused-function",
+    "-Wno-unused-private-field",
+]

--- a/third_party/kineto/libkineto/src/AbstractConfig.cpp
+++ b/third_party/kineto/libkineto/src/AbstractConfig.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "AbstractConfig.h"
+
+#include <fmt/format.h>
+#include <array>
+#include <limits>
+#include <sstream>
+
+#include "Logger.h"
+
+using namespace std::chrono;
+
+using std::string;
+using std::vector;
+
+namespace KINETO_NAMESPACE {
+
+constexpr char kWhitespace[] = "\t\n ";
+
+static bool isWhitespace(string& s) {
+  return s.find_first_not_of(kWhitespace) == string::npos;
+}
+
+// Remove whitespace from both end of string
+static inline string trim(string& s) {
+  if (s.empty()) {
+    return s;
+  } else if (isWhitespace(s)) {
+    return "";
+  }
+  auto start = s.find_first_not_of(kWhitespace);
+  auto end = s.find_last_not_of(kWhitespace);
+  return s.substr(start, end - start + 1);
+}
+
+// Helper function for split.
+// Return the index of char d in string s.
+// If not found, returns the length of the string.
+static int find(const char* s, char delim) {
+  int i = 0;
+  for (i = 0; s[i]; i++) {
+    if (s[i] == delim) {
+      break;
+    }
+  }
+  return i;
+}
+
+// Split a string by delimiter
+static vector<string> split(const string& s, char delim) {
+  vector<string> res;
+  const char* cs = s.c_str();
+  for (int i = find(cs, delim); cs[i]; cs += i + 1, i = find(cs, delim)) {
+    res.emplace_back(cs, i);
+  }
+  res.emplace_back(cs);
+  return res;
+}
+
+// Remove a trailing comment.
+static inline string stripComment(const string& s) {
+  std::size_t pos = s.find('#');
+  return s.substr(0, pos);
+}
+
+string AbstractConfig::toLower(string& s) const {
+  string res = s;
+  for (size_t i = 0; i < res.size(); i++) {
+    if (res[i] >= 'A' && res[i] <= 'Z') {
+      res[i] += ('a' - 'A');
+    }
+  }
+  return res;
+}
+
+bool AbstractConfig::endsWith(const string& s, const string& suffix) const {
+  return s.ends_with(suffix);
+}
+
+vector<string> AbstractConfig::splitAndTrim(const string& s, char delim) const {
+  auto res = split(s, delim);
+  for (string& x : res) {
+    x = trim(x);
+  }
+  return res;
+}
+
+int64_t AbstractConfig::toIntRange(const string& val, int64_t min, int64_t max)
+    const {
+  char* invalid = nullptr;
+  int64_t res = strtoll(val.c_str(), &invalid, 10);
+  if (val.empty() || *invalid) {
+    throw std::invalid_argument(fmt::format("Invalid integer: {}", val));
+  } else if (res < min || res > max) {
+    throw std::invalid_argument(fmt::format(
+        "Invalid argument: {} - expected range [{}, {}]", res, min, max));
+  }
+  return res;
+}
+
+int32_t AbstractConfig::toInt32(const string& val) const {
+  return static_cast<int32_t>(
+      toIntRange(val, 0, std::numeric_limits<int32_t>::max()));
+}
+
+int64_t AbstractConfig::toInt64(const string& val) const {
+  return toIntRange(val, 0, std::numeric_limits<int64_t>::max());
+}
+
+bool AbstractConfig::toBool(string& val) const {
+  const std::array<string, 10> bool_vals{
+      "n", "y", "no", "yes", "f", "t", "false", "true", "0", "1"};
+  const string lower_val = toLower(val);
+  for (size_t i = 0; i < bool_vals.size(); i++) {
+    if (lower_val == bool_vals[i]) {
+      return i % 2;
+    }
+  }
+  throw std::invalid_argument(fmt::format("Invalid bool argument: {}", val));
+}
+
+bool AbstractConfig::parse(const string& conf) {
+  std::istringstream iss(conf);
+  string line;
+
+  timestamp_ = system_clock::now();
+
+  // Read the string stream 1 line at a time to parse.
+  while (std::getline(iss, line)) {
+    line = stripComment(line);
+    if (isWhitespace(line)) {
+      continue;
+    }
+    vector<string> key_val = splitAndTrim(line, '=');
+    if (key_val.size() != 2) {
+      LOG(ERROR) << "Invalid config line: " << line;
+      return false;
+    } else {
+      bool handled = false;
+      try {
+        handled = handleOption(key_val[0], key_val[1]);
+        if (!handled) {
+          for (auto& feature_cfg : featureConfigs_) {
+            if (feature_cfg.second->handleOption(key_val[0], key_val[1])) {
+              handled = true;
+              break;
+            }
+          }
+        }
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to parse config: " << e.what()
+                   << " ; line: " << line;
+        return false;
+      }
+      if (!handled) {
+        // This might be due to using a newer config option on an
+        // older binary where it is not supported. In this case,
+        // print a warning message - but it is expected to work!
+        LOG(WARNING) << "Unrecognized config line: " << line;
+      }
+    }
+  }
+
+  validate(timestamp_);
+
+  // Store original text, used to detect updates
+  source_ = conf;
+  timestamp_ = system_clock::now();
+  return true;
+}
+
+bool AbstractConfig::handleOption(
+    const std::string& /* unused */,
+    std::string& /* unused */) {
+  // Unimplemented
+  return false;
+}
+
+void AbstractConfig::printActivityProfilerConfig(std::ostream& s) const {
+  for (const auto& feature_cfg : featureConfigs_) {
+    feature_cfg.second->printActivityProfilerConfig(s);
+  }
+}
+
+void AbstractConfig::setActivityDependentConfig() {
+  for (const auto& feature_cfg : featureConfigs_) {
+    feature_cfg.second->setActivityDependentConfig();
+  }
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/ActivityBuffers.h
+++ b/third_party/kineto/libkineto/src/ActivityBuffers.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <memory>
+
+#include "CuptiActivityBuffer.h"
+#include "libkineto.h"
+
+namespace KINETO_NAMESPACE {
+
+struct ActivityBuffers {
+  std::list<std::unique_ptr<libkineto::CpuTraceBuffer>> cpu;
+  std::unique_ptr<CuptiActivityBufferMap> gpu;
+
+  // Add a wrapper object to the underlying struct stored in the buffer
+  template <class T>
+  const ITraceActivity& addActivityWrapper(const T& act) {
+    wrappers_.push_back(std::make_unique<T>(act));
+    return *wrappers_.back().get();
+  }
+
+ private:
+  std::vector<std::unique_ptr<const ITraceActivity>> wrappers_;
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/ActivityLoggerFactory.h
+++ b/third_party/kineto/libkineto/src/ActivityLoggerFactory.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+#include <utility>
+
+namespace KINETO_NAMESPACE {
+
+class ActivityLogger;
+
+class ActivityLoggerFactory {
+ public:
+  using FactoryFunc =
+      std::function<std::unique_ptr<ActivityLogger>(const std::string& url)>;
+
+  // Add a logger factory for a protocol prefix. Returns true if a factory was
+  // already registered for the protocol and is being overwritten.
+  bool addProtocol(const std::string& protocol, FactoryFunc f) {
+    const std::string key = tolower(protocol);
+    std::lock_guard<std::mutex> guard(mutex_);
+    const bool overwritten = factories_.contains(key);
+    factories_[key] = std::move(f);
+    return overwritten;
+  }
+
+  // Create a logger, invoking the factory for the protocol specified in url
+  std::unique_ptr<ActivityLogger> makeLogger(const std::string& url) const {
+    const std::string protocol = extractProtocol(url);
+    FactoryFunc factory;
+    {
+      std::lock_guard<std::mutex> guard(mutex_);
+      auto it = factories_.find(tolower(protocol));
+      if (it != factories_.end()) {
+        factory = it->second;
+      }
+    }
+    // Invoke the factory outside the lock so a user-supplied callback cannot
+    // deadlock by re-entering the registry while mutex_ is held.
+    if (factory) {
+      return factory(stripProtocol(url));
+    }
+    throw std::invalid_argument(fmt::format(
+        "No logger registered for the {} protocol prefix", protocol));
+  }
+
+ private:
+  static std::string tolower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+      return std::tolower(c);
+    });
+    return s;
+  }
+
+  static std::string extractProtocol(const std::string& url) {
+    return url.substr(0, url.find("://"));
+  }
+
+  static std::string stripProtocol(const std::string& url) {
+    size_t pos = url.find("://");
+    return pos == url.npos ? url : url.substr(pos + 3);
+  }
+
+  std::map<std::string, FactoryFunc> factories_;
+  // registerLoggerFactory is public API and can run concurrently with trace
+  // saves that call makeLogger; serialize all access to factories_.
+  mutable std::mutex mutex_;
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/ActivityProfilerController.cpp
+++ b/third_party/kineto/libkineto/src/ActivityProfilerController.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ActivityProfilerController.h"
+
+#include <functional>
+#include <string>
+#include <utility>
+
+#include "ActivityLoggerFactory.h"
+// TODO DEVICE_AGNOSTIC: Move the device decision out of C++ files to be
+//                       determined entirely by the build process. For the
+//                       controller, we'll need some registration mechanism.
+#if defined(HAS_CUPTI)
+#include "CuptiActivityApi.h"
+#include "CuptiActivityProfiler.h"
+
+#elif defined(HAS_ROCTRACER)
+#include "RocmActivityProfiler.h"
+#include "RocprofActivityApi.h"
+
+#endif
+
+#include "output_json.h"
+#include "output_membuf.h"
+
+#include "Logger.h"
+
+using namespace std::chrono;
+
+namespace KINETO_NAMESPACE {
+
+static void logRequestCancellation(
+    const Config& config,
+    const std::string& reason) {
+  LOGGER_OBSERVER_WRITE_STAGE_CANCELLATION(
+      config.requestTraceID(), config.requestGroupTraceID(), reason);
+  LOG(WARNING) << reason;
+}
+
+#if !USE_GOOGLE_LOG
+namespace {
+std::vector<std::shared_ptr<LoggerCollector>>& loggerCollectors() {
+  static std::vector<std::shared_ptr<LoggerCollector>> collectors;
+  return collectors;
+}
+} // namespace
+
+void ActivityProfilerController::addLoggerCollectorFactory(
+    const std::function<std::shared_ptr<LoggerCollector>()>& factory) {
+  loggerCollectors().push_back(factory());
+}
+
+std::vector<std::shared_ptr<LoggerCollector>> ActivityProfilerController::
+    getLoggerCollectors() {
+  return loggerCollectors();
+}
+#endif // !USE_GOOGLE_LOG
+
+ActivityProfilerController::ActivityProfilerController(
+    ConfigLoader& configLoader,
+    bool cpuOnly)
+    : configLoader_(configLoader) {
+  // Initialize ChromeTraceBaseTime first of all.
+  ChromeTraceBaseTime::singleton().init();
+
+#if !USE_GOOGLE_LOG
+  // Initialize LoggerCollectors before ActivityProfiler to log
+  // CUPTI and CUDA driver versions.
+  // Keep a reference to handle safe static de-initialization.
+  loggerCollectors_ = loggerCollectors();
+  for (auto& collector : loggerCollectors_) {
+    Logger::addLoggerObserver(collector.get());
+  }
+#endif // !USE_GOOGLE_LOG
+
+#if defined(HAS_CUPTI)
+  profiler_ = std::make_unique<CuptiActivityProfiler>(
+      CuptiActivityApi::singleton(), cpuOnly);
+#elif defined(HAS_ROCTRACER)
+  profiler_ = std::make_unique<RocmActivityProfiler>(
+      RocprofActivityApi::singleton(), cpuOnly);
+#else
+  // CPU-only profiling without any GPU backends is handled
+  // directly by the GenericActivityProfiler.
+  profiler_ = std::make_unique<GenericActivityProfiler>(cpuOnly);
+#endif
+
+  syncHandler_ = std::make_unique<SyncActivityProfilerHandler>(*profiler_);
+  asyncHandler_ = std::make_unique<AsyncActivityProfilerHandler>(*profiler_);
+  configLoader_.addHandler(ConfigLoader::ConfigKind::ActivityProfiler, this);
+}
+
+ActivityProfilerController::~ActivityProfilerController() {
+  configLoader_.removeHandler(ConfigLoader::ConfigKind::ActivityProfiler, this);
+#if !USE_GOOGLE_LOG
+  for (auto& collector : loggerCollectors_) {
+    Logger::removeLoggerObserver(collector.get());
+  }
+#endif // !USE_GOOGLE_LOG
+}
+
+ActivityLoggerFactory& ActivityProfilerController::loggerFactory() {
+  static ActivityLoggerFactory factory;
+  // Technique to ensure we register the ChromeTraceLogger as the file
+  // protocol once and only once on the static instance.
+  [[maybe_unused]] static const bool kFileProtocolRegistered = [] {
+    factory.addProtocol("file", [](const std::string& url) {
+      return std::unique_ptr<ActivityLogger>(new ChromeTraceLogger(url));
+    });
+    return true;
+  }();
+  return factory;
+}
+
+void ActivityProfilerController::addLoggerFactory(
+    const std::string& protocol,
+    ActivityLoggerFactory::FactoryFunc factory) {
+  if (loggerFactory().addProtocol(protocol, std::move(factory))) {
+    LOG(WARNING) << "Overwriting logger factory for protocol: " << protocol;
+  }
+}
+
+std::unique_ptr<ActivityLogger> ActivityProfilerController::makeLogger(
+    const Config& config) {
+  if (config.activitiesLogToMemory()) {
+    return std::make_unique<MemoryTraceLogger>(config);
+  }
+  return loggerFactory().makeLogger(config.activitiesLogUrl());
+}
+
+static std::unique_ptr<InvariantViolationsLogger>&
+invariantViolationsLoggerFactory() {
+  static std::unique_ptr<InvariantViolationsLogger> factory = nullptr;
+  return factory;
+}
+
+void ActivityProfilerController::setInvariantViolationsLoggerFactory(
+    const std::function<std::unique_ptr<InvariantViolationsLogger>()>&
+        factory) {
+  invariantViolationsLoggerFactory() = factory();
+}
+
+bool ActivityProfilerController::isActive() {
+  return syncHandler_->isSyncActive() || asyncHandler_->isAsyncActive();
+}
+
+bool ActivityProfilerController::isStopped() const {
+  return profiler_->isStopped();
+}
+
+void ActivityProfilerController::transferCpuTrace(
+    std::unique_ptr<libkineto::CpuTraceBuffer> cpuTrace) {
+  profiler_->transferCpuTrace(std::move(cpuTrace));
+}
+
+void ActivityProfilerController::recordThreadInfo() {
+  profiler_->recordThreadInfo();
+}
+
+void ActivityProfilerController::addChildActivityProfiler(
+    std::unique_ptr<IActivityProfiler> profiler) {
+  profiler_->addChildActivityProfiler(std::move(profiler));
+}
+
+void ActivityProfilerController::pushCorrelationId(uint64_t id) {
+  profiler_->pushCorrelationId(id);
+}
+
+void ActivityProfilerController::popCorrelationId() {
+  profiler_->popCorrelationId();
+}
+
+void ActivityProfilerController::pushUserCorrelationId(uint64_t id) {
+  profiler_->pushUserCorrelationId(id);
+}
+
+void ActivityProfilerController::popUserCorrelationId() {
+  profiler_->popUserCorrelationId();
+}
+
+void ActivityProfilerController::addMetadata(
+    const std::string& key,
+    const std::string& value) {
+  profiler_->addMetadata(key, value);
+}
+
+void ActivityProfilerController::logInvariantViolation(
+    const std::string& profile_id,
+    const std::string& assertion,
+    const std::string& error,
+    const std::string& group_profile_id) {
+  if (invariantViolationsLoggerFactory()) {
+    invariantViolationsLoggerFactory()->logInvariantViolation(
+        profile_id, assertion, error, group_profile_id);
+  }
+}
+
+// ConfigLoader::ConfigHandler callback API.
+bool ActivityProfilerController::canAcceptConfig() {
+  return !isActive();
+}
+bool ActivityProfilerController::acceptConfig(const Config& config) {
+  if (isActive()) {
+    logRequestCancellation(config, "Ignored request - profiler busy");
+    return false;
+  }
+  return asyncHandler_->acceptConfig(config);
+}
+
+// These API are used for On-Demand Tracing.
+void ActivityProfilerController::asyncScheduleTrace(const Config& config) {
+  if (isActive()) {
+    logRequestCancellation(config, "Ignored request - profiler busy");
+    return;
+  }
+  asyncHandler_->scheduleTrace(config);
+}
+void ActivityProfilerController::asyncStep() {
+  asyncHandler_->step();
+}
+
+// These API are used for Synchronous Tracing.
+void ActivityProfilerController::syncPrepareTrace(const Config& config) {
+  // Sync-trace requests preempt any active trace.
+  asyncHandler_->cancel();
+  if (syncHandler_->isSyncActive()) {
+    syncHandler_->cancel();
+  }
+
+  syncHandler_->prepareTrace(config);
+}
+void ActivityProfilerController::syncToggleCollectionDynamic(
+    const bool enable) {
+  syncHandler_->toggleCollectionDynamic(enable);
+}
+void ActivityProfilerController::syncStartTrace() {
+  syncHandler_->startTrace();
+}
+std::unique_ptr<ActivityTraceInterface> ActivityProfilerController::
+    syncStopTrace() {
+  return syncHandler_->stopTrace();
+}
+
+} // namespace KINETO_NAMESPACE
+
+namespace libkineto {
+
+void registerLoggerFactory(const std::string& protocol, LoggerFactory factory) {
+  KINETO_NAMESPACE::ActivityProfilerController::addLoggerFactory(
+      protocol, std::move(factory));
+}
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/src/ActivityProfilerController.h
+++ b/third_party/kineto/libkineto/src/ActivityProfilerController.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ActivityLoggerFactory.h"
+#include "ActivityProfilerInterface.h"
+#include "ActivityTraceInterface.h"
+#include "AsyncActivityProfilerHandler.h"
+#include "ConfigLoader.h"
+#include "GenericActivityProfiler.h"
+#include "InvariantViolations.h"
+#include "LoggerCollector.h"
+#include "SyncActivityProfilerHandler.h"
+
+namespace KINETO_NAMESPACE {
+
+class Config;
+
+class ActivityProfilerController : public ConfigLoader::ConfigHandler {
+ public:
+  explicit ActivityProfilerController(ConfigLoader& configLoader, bool cpuOnly);
+  ActivityProfilerController(const ActivityProfilerController&) = delete;
+  ActivityProfilerController& operator=(const ActivityProfilerController&) =
+      delete;
+
+  ~ActivityProfilerController() override;
+
+#if !USE_GOOGLE_LOG
+  static void addLoggerCollectorFactory(
+      const std::function<std::shared_ptr<LoggerCollector>()>& factory);
+  static std::vector<std::shared_ptr<LoggerCollector>> getLoggerCollectors();
+#endif // !USE_GOOGLE_LOG
+
+  static void addLoggerFactory(
+      const std::string& protocol,
+      ActivityLoggerFactory::FactoryFunc factory);
+
+  static void setInvariantViolationsLoggerFactory(
+      const std::function<std::unique_ptr<InvariantViolationsLogger>()>&
+          factory);
+
+  // ConfigLoader::ConfigHandler callback API.
+  bool canAcceptConfig() override;
+  bool acceptConfig(const Config& config) override;
+
+  // These API are used for On-Demand Tracing.
+  void asyncScheduleTrace(const Config& config);
+  void asyncStep();
+
+  // These API are used for Synchronous Tracing.
+  void syncPrepareTrace(const Config& config);
+  void syncToggleCollectionDynamic(const bool enable);
+  void syncStartTrace();
+  std::unique_ptr<ActivityTraceInterface> syncStopTrace();
+
+  bool isActive();
+  bool isStopped() const;
+
+  void transferCpuTrace(std::unique_ptr<libkineto::CpuTraceBuffer> cpuTrace);
+
+  void recordThreadInfo();
+
+  void addChildActivityProfiler(std::unique_ptr<IActivityProfiler> profiler);
+
+  void addMetadata(const std::string& key, const std::string& value);
+
+  void logInvariantViolation(
+      const std::string& profile_id,
+      const std::string& assertion,
+      const std::string& error,
+      const std::string& group_profile_id = "");
+
+  void pushCorrelationId(uint64_t id);
+
+  void popCorrelationId();
+
+  void pushUserCorrelationId(uint64_t id);
+
+  void popUserCorrelationId();
+
+  static std::unique_ptr<ActivityLogger> makeLogger(const Config& config);
+
+  static ActivityLoggerFactory& loggerFactory();
+
+ private:
+  std::unique_ptr<GenericActivityProfiler> profiler_;
+  std::vector<std::shared_ptr<LoggerCollector>> loggerCollectors_;
+  ConfigLoader& configLoader_;
+
+  std::unique_ptr<SyncActivityProfilerHandler> syncHandler_;
+  std::unique_ptr<AsyncActivityProfilerHandler> asyncHandler_;
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/ActivityProfilerProxy.cpp
+++ b/third_party/kineto/libkineto/src/ActivityProfilerProxy.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ActivityProfilerProxy.h"
+
+#include <chrono>
+#include "ActivityProfilerController.h"
+#include "Config.h"
+#include "Logger.h"
+#include "ThreadUtil.h"
+
+namespace KINETO_NAMESPACE {
+
+ActivityProfilerProxy::ActivityProfilerProxy(
+    bool cpuOnly,
+    ConfigLoader& configLoader)
+    : cpuOnly_(cpuOnly), configLoader_(configLoader) {}
+
+ActivityProfilerProxy::~ActivityProfilerProxy() {
+  delete controller_;
+}
+
+void ActivityProfilerProxy::init() {
+  if (!controller_) {
+    controller_ = new ActivityProfilerController(configLoader_, cpuOnly_);
+  }
+}
+
+bool ActivityProfilerProxy::isActive() {
+  return controller_->isActive();
+}
+
+bool ActivityProfilerProxy::isStopped() const {
+  return controller_->isStopped();
+}
+
+// Async/on-demand tracing functions.
+void ActivityProfilerProxy::scheduleTrace(const std::string& configStr) {
+  resetTLS();
+  Config config;
+  if (!config.parse(configStr)) {
+    LOG(WARNING) << "Failed to parse config : " << configStr;
+  }
+  controller_->asyncScheduleTrace(config);
+}
+
+void ActivityProfilerProxy::scheduleTrace(const Config& config) {
+  controller_->asyncScheduleTrace(config);
+}
+
+void ActivityProfilerProxy::step() {
+  controller_->asyncStep();
+}
+
+// Sync/auto-trace tracing functions.
+void ActivityProfilerProxy::prepareTrace(
+    const std::set<ActivityType>& activityTypes,
+    const std::string& configStr) {
+  Config config;
+  bool validate_required = true;
+
+  // allow user provided config (ExperimentalConfig)to override default options
+  if (!configStr.empty()) {
+    if (!config.parse(configStr)) {
+      LOG(WARNING) << "Failed to parse config : " << configStr;
+    }
+    // parse also runs validate
+    validate_required = false;
+  }
+  // user provided config (KINETO_CONFIG) to override default options
+  auto loaded_config = configLoader_.getConfString();
+  if (!loaded_config.empty()) {
+    config.parse(loaded_config);
+  }
+
+  config.setClientDefaults();
+  config.setSelectedActivityTypes(activityTypes);
+
+  if (validate_required) {
+    config.validate(std::chrono::system_clock::now());
+  }
+
+  controller_->syncPrepareTrace(config);
+}
+
+void ActivityProfilerProxy::toggleCollectionDynamic(const bool enable) {
+  controller_->syncToggleCollectionDynamic(enable);
+}
+
+void ActivityProfilerProxy::startTrace() {
+  controller_->syncStartTrace();
+}
+
+std::unique_ptr<ActivityTraceInterface> ActivityProfilerProxy::stopTrace() {
+  return controller_->syncStopTrace();
+}
+
+// TraceActivity API.
+void ActivityProfilerProxy::pushCorrelationId(uint64_t id) {
+  controller_->pushCorrelationId(id);
+}
+
+void ActivityProfilerProxy::popCorrelationId() {
+  controller_->popCorrelationId();
+}
+
+void ActivityProfilerProxy::pushUserCorrelationId(uint64_t id) {
+  controller_->pushUserCorrelationId(id);
+}
+
+void ActivityProfilerProxy::popUserCorrelationId() {
+  controller_->popUserCorrelationId();
+}
+
+void ActivityProfilerProxy::transferCpuTrace(
+    std::unique_ptr<CpuTraceBuffer> traceBuffer) {
+  controller_->transferCpuTrace(std::move(traceBuffer));
+}
+
+void ActivityProfilerProxy::addMetadata(
+    const std::string& key,
+    const std::string& value) {
+  controller_->addMetadata(key, value);
+}
+
+void ActivityProfilerProxy::recordThreadInfo() {
+  controller_->recordThreadInfo();
+}
+
+void ActivityProfilerProxy::addChildActivityProfiler(
+    std::unique_ptr<IActivityProfiler> profiler) {
+  controller_->addChildActivityProfiler(std::move(profiler));
+}
+
+void ActivityProfilerProxy::logInvariantViolation(
+    const std::string& profile_id,
+    const std::string& assertion,
+    const std::string& error,
+    const std::string& group_profile_id) {
+  controller_->logInvariantViolation(
+      profile_id, assertion, error, group_profile_id);
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/ActivityProfilerProxy.h
+++ b/third_party/kineto/libkineto/src/ActivityProfilerProxy.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "ActivityProfilerInterface.h"
+
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "ActivityType.h"
+#include "ITraceActivity.h"
+
+namespace libkineto {
+// previous declaration is struct so this one must be too.
+struct CpuTraceBuffer;
+} // namespace libkineto
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+
+class ActivityProfilerController;
+class Config;
+class ConfigLoader;
+
+class ActivityProfilerProxy : public ActivityProfilerInterface {
+ public:
+  ActivityProfilerProxy(bool cpuOnly, ConfigLoader& configLoader);
+  ~ActivityProfilerProxy() override;
+  ActivityProfilerProxy(const ActivityProfilerProxy&) = delete;
+  ActivityProfilerProxy& operator=(const ActivityProfilerProxy&) = delete;
+  ActivityProfilerProxy(ActivityProfilerProxy&&) = delete;
+  ActivityProfilerProxy& operator=(ActivityProfilerProxy&&) = delete;
+
+  void init() override;
+  bool isInitialized() override {
+    return controller_ != nullptr;
+  }
+
+  bool isActive() override;
+  bool isStopped() const override;
+
+  // These API are used for async/on-demand tracing.
+  void scheduleTrace(const std::string& configStr) override;
+  void scheduleTrace(const Config& config);
+  void step() override;
+
+  // These API are used for sync/auto-trace tracing.
+  void prepareTrace(
+      const std::set<ActivityType>& activityTypes,
+      const std::string& configStr = "") override;
+
+  void toggleCollectionDynamic(const bool enable) override;
+
+  void startTrace() override;
+  std::unique_ptr<ActivityTraceInterface> stopTrace() override;
+
+  // TraceActivity API.
+  void pushCorrelationId(uint64_t id) override;
+  void popCorrelationId() override;
+
+  void pushUserCorrelationId(uint64_t id) override;
+  void popUserCorrelationId() override;
+
+  void transferCpuTrace(std::unique_ptr<CpuTraceBuffer> traceBuffer) override;
+
+  void recordThreadInfo() override;
+
+  void addMetadata(const std::string& key, const std::string& value) override;
+
+  void addChildActivityProfiler(
+      std::unique_ptr<IActivityProfiler> profiler) override;
+
+  void logInvariantViolation(
+      const std::string& profile_id,
+      const std::string& assertion,
+      const std::string& error,
+      const std::string& group_profile_id = "") override;
+
+ private:
+  bool cpuOnly_{true};
+  ConfigLoader& configLoader_;
+  ActivityProfilerController* controller_{nullptr};
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/ActivityTrace.h
+++ b/third_party/kineto/libkineto/src/ActivityTrace.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "ActivityLoggerFactory.h"
+#include "ActivityTraceInterface.h"
+#include "output_json.h"
+#include "output_membuf.h"
+
+namespace libkineto {
+
+class ActivityTrace : public ActivityTraceInterface {
+ public:
+  ActivityTrace(
+      std::unique_ptr<MemoryTraceLogger> tmpLogger,
+      const ActivityLoggerFactory& factory)
+      : memLogger_(std::move(tmpLogger)), loggerFactory_(factory) {}
+
+  const std::vector<const ITraceActivity*>* activities() override {
+    return memLogger_->traceActivities();
+  }
+
+  void save(const std::string& url) override {
+    std::string prefix;
+    // if no protocol is specified, default to file
+    if (url.find("://") == url.npos) {
+      prefix = "file://";
+    }
+    memLogger_->setChromeLogger(loggerFactory_.makeLogger(prefix + url));
+    memLogger_->log(*memLogger_->getChromeLogger());
+  }
+
+ private:
+  // Activities are logged into a buffer
+  std::unique_ptr<MemoryTraceLogger> memLogger_;
+
+  // Alternative logger used by save() if protocol prefix is specified
+  const ActivityLoggerFactory& loggerFactory_;
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/src/ActivityType.cpp
+++ b/third_party/kineto/libkineto/src/ActivityType.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ActivityType.h"
+
+#include <fmt/format.h>
+
+namespace libkineto {
+
+static constexpr bool matchingOrder(int idx = 0) {
+  return _activityTypeNames[idx].type == ActivityType::ENUM_COUNT ||
+      ((idx == static_cast<int>(_activityTypeNames[idx].type)) &&
+       matchingOrder(idx + 1));
+}
+static_assert(matchingOrder(), "ActivityTypeName map is out of order");
+
+ActivityType toActivityType(const std::string& str) {
+  for (int i = 0; i < activityTypeCount; i++) {
+    if (str == _activityTypeNames[i].name) {
+      return _activityTypeNames[i].type;
+    }
+  }
+  throw std::invalid_argument(fmt::format("Invalid activity type: {}", str));
+}
+
+std::array<ActivityType, activityTypeCount> activityTypes() {
+  std::array<ActivityType, activityTypeCount> res;
+  for (int i = 0; i < activityTypeCount; i++) {
+    res[i] = _activityTypeNames[i].type;
+  }
+  return res;
+}
+
+std::array<ActivityType, defaultActivityTypeCount> defaultActivityTypes() {
+  std::array<ActivityType, defaultActivityTypeCount> res;
+  for (int i = 0; i < defaultActivityTypeCount; i++) {
+    res[i] = _activityTypeNames[i].type;
+  }
+  return res;
+}
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/src/ApproximateClock.cpp
+++ b/third_party/kineto/libkineto/src/ApproximateClock.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ApproximateClock.h"
+#include <fmt/format.h>
+#include <algorithm>
+
+namespace libkineto {
+
+ApproximateClockToUnixTimeConverter::ApproximateClockToUnixTimeConverter()
+    : start_times_(measurePairs()) {}
+
+ApproximateClockToUnixTimeConverter::UnixAndApproximateTimePair
+ApproximateClockToUnixTimeConverter::measurePair() {
+  // Take a measurement on either side to avoid an ordering bias.
+  auto fast_0 = getApproximateTime();
+  auto wall = std::chrono::system_clock::now();
+  auto fast_1 = getApproximateTime();
+
+  auto t = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      wall.time_since_epoch());
+
+  // `x + (y - x) / 2` is a more numerically stable average than `(x + y) / 2`.
+  return {t.count(), fast_0 + ((fast_1 - fast_0) / 2)};
+}
+
+ApproximateClockToUnixTimeConverter::time_pairs
+ApproximateClockToUnixTimeConverter::measurePairs() {
+  static constexpr auto n_warmup = 5;
+  for (int i = 0; i < n_warmup; i++) {
+    getApproximateTime();
+    static_cast<void>(steady_clock_t::now());
+  }
+
+  time_pairs out;
+  for (auto& i : out) {
+    i = measurePair();
+  }
+  return out;
+}
+
+std::function<time_t(approx_time_t)> ApproximateClockToUnixTimeConverter::
+    makeConverter() {
+  auto end_times = measurePairs();
+
+  // Compute the real time that passes for each tick of the approximate clock.
+  std::array<long double, replicates> scale_factors{};
+  for (size_t i = 0; i < replicates; i++) {
+    auto delta_ns = end_times[i].t_ - start_times_[i].t_;
+    auto delta_approx = end_times[i].approx_t_ - start_times_[i].approx_t_;
+    scale_factors[i] =
+        static_cast<double>(delta_ns) / static_cast<double>(delta_approx);
+  }
+  std::ranges::sort(scale_factors);
+  long double scale_factor = scale_factors[(replicates / 2) + 1];
+
+  // We shift all times by `t0` for better numerics. Double precision only has
+  // 16 decimal digits of accuracy, so if we blindly multiply times by
+  // `scale_factor` we may suffer from precision loss. The choice of `t0` is
+  // mostly arbitrary; we just need a factor that is the correct order of
+  // magnitude to bring the intermediate values closer to zero. We are not,
+  // however, guaranteed that `t0_approx` is *exactly* the getApproximateTime
+  // equivalent of `t0`; it is only an estimate that we have to fine tune.
+  auto t0 = start_times_[0].t_;
+  auto t0_approx = start_times_[0].approx_t_;
+  std::array<double, replicates> t0_correction{};
+  for (size_t i = 0; i < replicates; i++) {
+    auto dt = start_times_[i].t_ - t0;
+    auto dt_approx =
+        static_cast<double>(start_times_[i].approx_t_ - t0_approx) *
+        scale_factor;
+    t0_correction[i] =
+        static_cast<double>(dt - static_cast<time_t>(dt_approx)); // NOLINT
+  }
+  t0 += static_cast<time_t>(
+      t0_correction[t0_correction.size() / 2 + 1]); // NOLINT
+
+  return [=](approx_time_t t_approx) {
+    // See above for why this is more stable than `A * t_approx + B`.
+    return t_approx > t0_approx
+        ? static_cast<time_t>(
+              static_cast<double>(t_approx - t0_approx) * scale_factor) +
+            t0
+        : 0;
+  };
+}
+
+// Sets the timestamp converter. If nothing is set then the converter just
+// returns the input. For this reason, until we add profiler impl of passing in
+// TSC converter we just need to guard the callback itself
+std::function<time_t(approx_time_t)>& get_time_converter() {
+  static std::function<time_t(approx_time_t)> _time_converter =
+      [](approx_time_t t) { return t; };
+  return _time_converter;
+}
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/src/ApproximateClock.h
+++ b/third_party/kineto/libkineto/src/ApproximateClock.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* The contents of this file was borrowed c10/util/ApproximateClock.h */
+
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+#include <functional>
+#include <type_traits>
+
+#if defined(__i386__) || defined(__x86_64__) || defined(__amd64__)
+#define KINETO_RDTSC
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif defined(__CUDACC__) || defined(__HIPCC__)
+#undef KINETO_RDTSC
+#elif defined(__clang__)
+// `__rdtsc` is available by default.
+// NB: This has to be first, because Clang will also define `__GNUC__`
+#elif defined(__GNUC__)
+#include <x86intrin.h>
+#else
+#undef KINETO_RDTSC
+#endif
+#elif defined(__aarch64__) && !defined(__CUDACC__) && !defined(__HIPCC__)
+#define KINETO_ARMTSC
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define KINETO_UNUSED __pragma(warning(suppress : 4100 4101))
+#else
+#define KINETO_UNUSED __attribute__((__unused__))
+#endif //_MSC_VER
+
+namespace libkineto {
+
+using time_t = int64_t;
+using steady_clock_t = std::conditional_t<
+    std::chrono::high_resolution_clock::is_steady,
+    std::chrono::high_resolution_clock,
+    std::chrono::steady_clock>;
+
+inline time_t getTime([[maybe_unused]] bool allow_monotonic = false) {
+#if defined(_WIN32) || defined(__MACH__)
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             steady_clock_t::now().time_since_epoch())
+      .count();
+#else
+  // clock_gettime is *much* faster than std::chrono implementation on Linux
+  struct timespec t{};
+  auto mode = CLOCK_REALTIME;
+  if (allow_monotonic) {
+    mode = CLOCK_MONOTONIC;
+  }
+  clock_gettime(mode, &t);
+  return (static_cast<time_t>(t.tv_sec) * 1000000000) +
+      static_cast<time_t>(t.tv_nsec);
+#endif
+}
+
+#if defined(KINETO_ARMTSC)
+inline uint64_t getArmApproximateTime() {
+  uint64_t val;
+  __asm__ __volatile__("mrs %0, cntvct_el0" : "=r"(val));
+  return val;
+}
+#endif
+
+// We often do not need to capture true wall times. If a fast mechanism such
+// as TSC is available we can use that instead and convert back to epoch time
+// during post processing. This greatly reduce the clock's contribution to
+// profiling.
+//   http://btorpey.github.io/blog/2014/02/18/clock-sources-in-linux/
+//   https://quick-bench.com/q/r8opkkGZSJMu9wM_XTbDouq-0Io
+// TODO: We should use
+// `https://github.com/google/benchmark/blob/main/src/cycleclock.h`
+inline auto getApproximateTime() {
+#if defined(KINETO_RDTSC)
+  return static_cast<uint64_t>(__rdtsc());
+#elif defined(KINETO_ARMTSC)
+  return getArmApproximateTime();
+#else
+  return getTime();
+#endif
+}
+
+using approx_time_t = decltype(getApproximateTime());
+static_assert(
+    std::is_same_v<approx_time_t, int64_t> ||
+        std::is_same_v<approx_time_t, uint64_t>,
+    "Expected either int64_t (`getTime`) or uint64_t (some TSC reads).");
+
+std::function<time_t(approx_time_t)>& get_time_converter();
+
+// Convert `getCount` results to Nanoseconds since unix epoch.
+class ApproximateClockToUnixTimeConverter final {
+ public:
+  ApproximateClockToUnixTimeConverter();
+  std::function<time_t(approx_time_t)> makeConverter();
+
+  struct UnixAndApproximateTimePair {
+    time_t t_;
+    approx_time_t approx_t_;
+  };
+  static UnixAndApproximateTimePair measurePair();
+
+ private:
+  static constexpr size_t replicates = 1001;
+  using time_pairs = std::array<UnixAndApproximateTimePair, replicates>;
+  time_pairs measurePairs();
+
+  time_pairs start_times_;
+};
+} // namespace libkineto

--- a/third_party/kineto/libkineto/src/AsyncActivityProfilerHandler.cpp
+++ b/third_party/kineto/libkineto/src/AsyncActivityProfilerHandler.cpp
@@ -1,0 +1,524 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "AsyncActivityProfilerHandler.h"
+
+#include <chrono>
+#include <exception>
+#include <string>
+
+#include "ActivityProfilerController.h"
+#include "Config.h"
+#include "GenericActivityProfiler.h"
+#include "Logger.h"
+#include "ThreadUtil.h"
+#include "output_membuf.h"
+
+using namespace std::chrono;
+
+namespace KINETO_NAMESPACE {
+
+static void logRequestCancellation(
+    const Config& config,
+    const std::string& reason) {
+  LOGGER_OBSERVER_WRITE_STAGE_CANCELLATION(
+      config.requestTraceID(), config.requestGroupTraceID(), reason);
+  LOG(WARNING) << reason;
+}
+
+AsyncActivityProfilerHandler::AsyncActivityProfilerHandler(
+    GenericActivityProfiler& profiler)
+    : profiler_(profiler) {}
+
+AsyncActivityProfilerHandler::~AsyncActivityProfilerHandler() {
+  for (auto& profilerThread : profilerThreads_) {
+    if (profilerThread != nullptr) {
+      // signaling termination of the profiler loop
+      stopRunloop_ = true;
+      profilerThread->join();
+      profilerThread.reset();
+    }
+  }
+  ensureCollectTraceDone();
+}
+
+bool AsyncActivityProfilerHandler::acceptConfig(const Config& config) {
+  VLOG(1) << "acceptConfig";
+  if (config.activityProfilerEnabled()) {
+    return scheduleTrace(config);
+  }
+  return false;
+}
+
+bool AsyncActivityProfilerHandler::scheduleTrace(const Config& config) {
+  VLOG(1) << "scheduleTrace";
+
+  int64_t currentIter = iterationCount_;
+  std::unique_ptr<Config> configToSchedule;
+
+  if (config.hasProfileStartIteration() && currentIter < 0) {
+    // Special case: daemon config with activitiesDuration set
+    if (config.activitiesDuration().count() > 0) {
+      LOG(INFO) << "Config with duration-based profiling, "
+                << "ignoring iteration count requirement";
+      // Continue with modified config - clone and set profileStartIteration to
+      // -1
+      configToSchedule = config.clone();
+      configToSchedule->setProfileStartIteration(-1);
+    } else {
+      logRequestCancellation(
+          config,
+          "Ignored profile iteration count based request as application is not updating iteration count");
+      return false;
+    }
+  } else {
+    configToSchedule = config.clone();
+  }
+
+  // Common scheduling logic
+  bool newConfigScheduled = false;
+  if (!asyncRequestConfig_) {
+    std::scoped_lock lock(asyncConfigLock_);
+    if (!asyncRequestConfig_) {
+      asyncRequestConfig_ = std::move(configToSchedule);
+      newConfigScheduled = true;
+    }
+  }
+  if (!newConfigScheduled) {
+    logRequestCancellation(
+        config, "Ignored request - another profile request is pending.");
+    return false;
+  }
+
+  // start a profilerLoop() thread to handle request
+
+  if (config.memoryProfilerEnabled()) {
+    auto thread_type = ThreadType::MEMORY_SNAPSHOT;
+    if (profilerThreads_[thread_type] == nullptr) {
+      profilerThreads_[thread_type] = std::make_unique<std::thread>(
+          &AsyncActivityProfilerHandler::memoryProfilerLoop, this);
+    }
+  } else {
+    auto thread_type = ThreadType::KINETO;
+    if (profilerThreads_[thread_type] == nullptr) {
+      profilerThreads_[thread_type] = std::make_unique<std::thread>(
+          &AsyncActivityProfilerHandler::profilerLoop, this);
+    }
+  }
+  return true;
+}
+
+void AsyncActivityProfilerHandler::step() {
+  // Snapshot the incremented iteration count once so this step invocation uses
+  // a consistent value for activation checks, logging, and run-loop stepping.
+  int64_t currentIter = ++iterationCount_;
+  VLOG(0) << "Step called , iteration  = " << currentIter;
+
+  // Perform Double-checked locking to reduce overhead of taking lock.
+  if (asyncRequestConfig_ && !isAsyncActive()) {
+    std::scoped_lock lock(asyncConfigLock_);
+    auto now = system_clock::now();
+    if (asyncRequestConfig_ && !isAsyncActive() &&
+        shouldActivateIterationConfig(currentIter)) {
+      activateConfig(now);
+    }
+  }
+  if (isAsyncActive() && !isCollectingMemorySnapshot()) {
+    auto now = system_clock::now();
+    auto next_wakeup_time = now + Config::kControllerIntervalMsecs;
+    performRunLoopStep(now, next_wakeup_time, currentIter);
+  }
+}
+
+bool AsyncActivityProfilerHandler::shouldActivateTimestampConfig(
+    const std::chrono::time_point<std::chrono::system_clock>& now) {
+  if (asyncRequestConfig_->hasProfileStartIteration()) {
+    return false;
+  }
+  if (asyncRequestConfig_->memoryProfilerEnabled()) {
+    return false;
+  }
+  // Note on now + Config::kControllerIntervalMsecs:
+  // Profiler interval does not align perfectly up to startTime - warmup.
+  // Waiting until the next tick won't allow sufficient time for the
+  // profiler to warm up. So check if we are very close to the warmup time
+  // and trigger warmup.
+  if (now + Config::kControllerIntervalMsecs >=
+      (asyncRequestConfig_->requestTimestamp() -
+       asyncRequestConfig_->activitiesWarmupDuration())) {
+    LOG(INFO)
+        << "Received on-demand activity trace request by "
+        << " profile timestamp = "
+        << asyncRequestConfig_->requestTimestamp().time_since_epoch().count();
+    return true;
+  }
+  return false;
+}
+
+bool AsyncActivityProfilerHandler::shouldActivateIterationConfig(
+    int64_t currentIter) {
+  if (!asyncRequestConfig_->hasProfileStartIteration()) {
+    return false;
+  }
+  if (asyncRequestConfig_->memoryProfilerEnabled()) {
+    return false;
+  }
+  auto rootIter = asyncRequestConfig_->startIterationIncludingWarmup();
+  // Keep waiting, it is not time to start yet.
+  if (currentIter < rootIter) {
+    return false;
+  }
+
+  LOG(INFO) << "Received on-demand activity trace request by "
+               " profile start iteration = "
+            << asyncRequestConfig_->profileStartIteration()
+            << ", current iteration = " << currentIter;
+  // Re-calculate the start iter if requested iteration is in the past.
+  if (currentIter > rootIter) {
+    int64_t newProfileStart =
+        currentIter + asyncRequestConfig_->activitiesWarmupIterations();
+    // Use Start Iteration Round Up if it is present.
+    if (asyncRequestConfig_->profileStartIterationRoundUp() > 0) {
+      // round up to nearest multiple
+      int64_t divisor = asyncRequestConfig_->profileStartIterationRoundUp();
+      int64_t rem = newProfileStart % divisor;
+      newProfileStart += ((rem == 0) ? 0 : divisor - rem);
+      LOG(INFO) << "Rounding up profiler start iteration to : "
+                << newProfileStart;
+      asyncRequestConfig_->setProfileStartIteration(
+          static_cast<int>(newProfileStart));
+      if (currentIter != asyncRequestConfig_->startIterationIncludingWarmup()) {
+        // Ex. Current 9, start 8, warmup 5, roundup 100. Resolves new start
+        // to 100, with warmup starting at 95. So don't start now.
+        return false;
+      }
+    } else {
+      LOG(INFO) << "Start iteration updated to : " << newProfileStart;
+      asyncRequestConfig_->setProfileStartIteration(
+          static_cast<int>(newProfileStart));
+    }
+  }
+  return true;
+}
+
+void AsyncActivityProfilerHandler::profilerLoop() {
+  setThreadName("Kineto Activity Profiler");
+  VLOG(0) << "Entering activity profiler loop";
+
+  auto now = system_clock::now();
+  auto next_wakeup_time = now + Config::kControllerIntervalMsecs;
+
+  while (!stopRunloop_) {
+    now = system_clock::now();
+
+    while (now < next_wakeup_time) {
+      /* sleep override */
+      std::this_thread::sleep_for(next_wakeup_time - now);
+      now = system_clock::now();
+    }
+
+    // Perform Double-checked locking to reduce overhead of taking lock.
+    if (asyncRequestConfig_ && !isAsyncActive()) {
+      std::scoped_lock lock(asyncConfigLock_);
+      if (asyncRequestConfig_ && !isAsyncActive() &&
+          shouldActivateTimestampConfig(now)) {
+        activateConfig(now);
+      }
+    }
+
+    while (next_wakeup_time < now) {
+      next_wakeup_time += Config::kControllerIntervalMsecs;
+    }
+
+    if (isAsyncActive() && !isCollectingMemorySnapshot()) {
+      next_wakeup_time = performRunLoopStep(now, next_wakeup_time);
+      VLOG(1) << "Profiler loop: "
+              << duration_cast<milliseconds>(system_clock::now() - now).count()
+              << "ms";
+    }
+  }
+
+  // On teardown the destructor sets stopRunloop_ and joins this thread; if
+  // collection reached ProcessTrace, finalize the pending trace before logger_
+  // is destroyed.
+  if (currentRunloopState_ == RunloopState::ProcessTrace) {
+    try {
+      completePendingTrace();
+    } catch (const std::exception& e) {
+      LOG(ERROR)
+          << "Failed to finalize pending trace on profiler loop teardown: "
+          << e.what();
+    } catch (...) {
+      LOG(ERROR)
+          << "Failed to finalize pending trace on profiler loop teardown: "
+          << "unknown exception";
+    }
+  }
+
+  VLOG(0) << "Exited activity profiling loop";
+}
+
+void AsyncActivityProfilerHandler::completePendingTrace() {
+  ensureCollectTraceDone();
+  profiler_.completeTrace(*logger_);
+  currentRunloopState_ = RunloopState::WaitForRequest;
+  VLOG(0) << "ProcessTrace -> WaitForRequest";
+}
+
+void AsyncActivityProfilerHandler::memoryProfilerLoop() {
+  while (!stopRunloop_) {
+    // Perform Double-checked locking to reduce overhead of taking lock.
+    if (asyncRequestConfig_ && !isAsyncActive()) {
+      std::scoped_lock lock(asyncConfigLock_);
+      if (asyncRequestConfig_ && !isAsyncActive() &&
+          asyncRequestConfig_->memoryProfilerEnabled()) {
+        logger_ = ActivityProfilerController::makeLogger(*asyncRequestConfig_);
+        auto path = asyncRequestConfig_->activitiesLogFile();
+        auto profile_time = asyncRequestConfig_->profileMemoryDuration();
+        auto config = asyncRequestConfig_->clone();
+        asyncRequestConfig_ = nullptr;
+        performMemoryLoop(path, profile_time, logger_.get(), *config);
+      }
+    }
+  }
+}
+
+void AsyncActivityProfilerHandler::configure(
+    const Config& config,
+    std::chrono::time_point<std::chrono::system_clock> now) {
+  if (!profiler_.canStart(config, now)) {
+    logRequestCancellation(
+        config, "Trace request could not start at the scheduled time");
+    return;
+  }
+  logger_ = ActivityProfilerController::makeLogger(config);
+  profiler_.setLogger(logger_.get());
+  LOGGER_OBSERVER_RESET();
+  LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND();
+  profiler_.configure(config, now);
+  VLOG(0) << "WaitForRequest -> Warmup";
+  currentRunloopState_ = RunloopState::Warmup;
+}
+
+// This function should only be called when holding the configLock_.
+void AsyncActivityProfilerHandler::activateConfig(
+    std::chrono::time_point<std::chrono::system_clock> now) {
+  configure(*asyncRequestConfig_, now);
+  asyncRequestConfig_ = nullptr;
+}
+
+time_point<system_clock> AsyncActivityProfilerHandler::performRunLoopStep(
+    const time_point<system_clock>& now,
+    const time_point<system_clock>& nextWakeupTime,
+    int64_t currentIter) {
+  auto new_wakeup_time = nextWakeupTime;
+
+  VLOG_IF(1, currentIter >= 0)
+      << "Run loop on application step(), iteration = " << currentIter;
+
+  switch (currentRunloopState_) {
+    case RunloopState::CollectMemorySnapshot:
+      LOG(WARNING)
+          << "Entered CollectMemorySnapshot in Kineto Loop Step, skipping loop";
+      break;
+    case RunloopState::WaitForRequest:
+      VLOG(1) << "State: WaitForRequest";
+      break;
+    case RunloopState::Cancelling:
+      // cancel() is tearing down the profiler on another thread.
+      // Do nothing — we must not drive the profiler concurrently.
+      VLOG(1) << "State: Cancelling";
+      break;
+
+    case RunloopState::Warmup: {
+      VLOG(1) << "State: Warmup";
+      profiler_.flushWarmupBuffers(currentIter, nextWakeupTime);
+
+      if (profiler_.isGpuCollectionStopped()) {
+        profiler_.cancelTrace(now);
+        LOG(ERROR)
+            << "State: Warmup stopped by GPU profiler. (Buffer size configured is "
+            << profiler_.activitiesMaxGpuBufferSizeMB() << "MB)";
+        UST_LOGGER_MARK_COMPLETED(kWarmUpStage);
+        VLOG(0) << "Warmup -> WaitForRequest";
+        currentRunloopState_ = RunloopState::WaitForRequest;
+        break;
+      }
+
+      if (profiler_.isWarmupDone(now, currentIter)) {
+        UST_LOGGER_MARK_COMPLETED(kWarmUpStage);
+        if (!profiler_.isProfilingByIteration() &&
+            (now > profiler_.profileStartTime() + milliseconds(10))) {
+          LOG(INFO) << "Tracing started "
+                    << duration_cast<milliseconds>(
+                           now - profiler_.profileStartTime())
+                           .count()
+                    << "ms late!";
+        } else {
+          LOG(INFO) << "Tracing started";
+        }
+        profiler_.startTrace(now);
+        // An extra check in case cancellation came in during startTrace
+        if (currentRunloopState_ == RunloopState::Cancelling) {
+          break;
+        }
+        VLOG(0) << "Warmup -> CollectTrace";
+        currentRunloopState_ = RunloopState::CollectTrace;
+        if (libkineto::api().client() != nullptr) {
+          libkineto::api().client()->start();
+        }
+        if (nextWakeupTime > profiler_.profileEndTime()) {
+          new_wakeup_time = profiler_.profileEndTime();
+        }
+      } else if (nextWakeupTime > profiler_.profileStartTime()) {
+        new_wakeup_time = profiler_.profileStartTime();
+      }
+      break;
+    }
+
+    case RunloopState::CollectTrace: {
+      VLOG(1) << "State: CollectTrace";
+      bool collection_done = profiler_.isCollectionDone(now, currentIter);
+
+      if (collection_done || profiler_.isGpuCollectionStopped()) {
+        LOG(INFO) << "Tracing complete.";
+        VLOG_IF(1, currentIter >= 0)
+            << "This state change was invoked by application's step() call";
+        // currentIter >= 0 means this is called from the step() api of
+        // the profiler in pytorch main thread, it should be executed in
+        // another thread in case pytorch main thread is blocked
+        if (currentIter >= 0) {
+          // if collectTraceThread_ is already running, there's no need to
+          // execute collectTrace twice.
+          // Do not call collectTrace when profilerThread_ is collecting
+          // Trace. Otherwise, libkineto::api().client()->stop will be called
+          // twice, which leads to an unrecoverable ::c10:Error at
+          // disableProfiler
+          if (!collectTraceThread_ && !getCollectTraceState()) {
+            std::scoped_lock guard(collectTraceStateMutex_);
+            collectTraceThread_ = std::make_unique<std::thread>(
+                &AsyncActivityProfilerHandler::collectTrace,
+                this,
+                collection_done,
+                now);
+          }
+          break;
+        }
+        // this is executed in profilerThread_
+        {
+          std::scoped_lock guard(collectTraceStateMutex_);
+          isCollectingTrace_ = true;
+        }
+        collectTrace(collection_done, now);
+        {
+          std::scoped_lock guard(collectTraceStateMutex_);
+          isCollectingTrace_ = false;
+        }
+      } else if (profiler_.isProfilingByIteration()) {
+        // nothing to do here
+      } else if (
+          now < profiler_.profileEndTime() &&
+          profiler_.profileEndTime() < nextWakeupTime) {
+        new_wakeup_time = profiler_.profileEndTime();
+      }
+      break;
+    }
+
+    case RunloopState::ProcessTrace: {
+      VLOG(1) << "State: ProcessTrace";
+      // skip this state transition if it called from the step() api
+      // of the profiler.
+      // else it could lead to a race between the profiler thread and an
+      // application thread calling step()
+      if (currentIter >= 0) {
+        return new_wakeup_time;
+      }
+
+      // FIXME: Probably want to allow interruption here
+      // for quickly handling trace request via synchronous API
+      completePendingTrace();
+      break;
+    }
+  }
+
+  return new_wakeup_time;
+}
+
+void AsyncActivityProfilerHandler::collectTrace(
+    bool collection_done,
+    const std::chrono::time_point<std::chrono::system_clock>& now) {
+  if (currentRunloopState_ == RunloopState::Cancelling) {
+    return;
+  }
+  profiler_.collectTrace(collection_done, now);
+  if (currentRunloopState_ == RunloopState::Cancelling) {
+    return;
+  }
+  VLOG(0) << "CollectTrace -> ProcessTrace";
+  currentRunloopState_ = RunloopState::ProcessTrace;
+}
+
+void AsyncActivityProfilerHandler::performMemoryLoop(
+    const std::string& path,
+    uint32_t profile_time,
+    ActivityLogger* logger,
+    Config& config) {
+  currentRunloopState_ = RunloopState::CollectMemorySnapshot;
+  if (libkineto::api().client() != nullptr) {
+    libkineto::api().client()->start_memory_profile();
+    LOG(INFO) << "Running memory profiling for " << profile_time << " ms";
+    std::this_thread::sleep_for(std::chrono::milliseconds(profile_time));
+    LOG(INFO) << "Exporting memory profiling results to " << path;
+    libkineto::api().client()->export_memory_profile(path);
+    libkineto::api().client()->stop_memory_profile();
+    LOG(INFO) << "Finalizing trace";
+    logger->finalizeMemoryTrace(path, config);
+  }
+  currentRunloopState_ = RunloopState::WaitForRequest;
+}
+
+bool AsyncActivityProfilerHandler::getCollectTraceState() {
+  std::scoped_lock guard(collectTraceStateMutex_);
+  return isCollectingTrace_;
+}
+
+void AsyncActivityProfilerHandler::ensureCollectTraceDone() {
+  if (collectTraceThread_ && collectTraceThread_->joinable()) {
+    collectTraceThread_->join();
+    collectTraceThread_.reset(nullptr);
+  }
+}
+
+void AsyncActivityProfilerHandler::cancel() {
+  {
+    std::scoped_lock lock(asyncConfigLock_);
+    asyncRequestConfig_ = nullptr;
+  }
+  if (!isAsyncActive()) {
+    return;
+  }
+
+  currentRunloopState_ = RunloopState::Cancelling;
+
+  LOG(ERROR) << "Cancelling current trace request in order to start "
+             << "higher priority synchronous request";
+  UST_LOGGER_MARK_COMPLETED(kCancellationStage);
+
+  ensureCollectTraceDone();
+  if (libkineto::api().client() != nullptr) {
+    libkineto::api().client()->stop();
+  }
+  profiler_.cancelTrace(std::chrono::system_clock::now());
+  VLOG(0) << "Cancelled from state == "
+          << static_cast<std::underlying_type_t<RunloopState>>(
+                 currentRunloopState_.load())
+          << " -> WaitForRequest";
+  currentRunloopState_ = RunloopState::WaitForRequest;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/AsyncActivityProfilerHandler.h
+++ b/third_party/kineto/libkineto/src/AsyncActivityProfilerHandler.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "ActivityLoggerFactory.h"
+#include "GenericActivityProfiler.h"
+
+namespace KINETO_NAMESPACE {
+
+enum ThreadType {
+  KINETO = 0,
+  MEMORY_SNAPSHOT,
+  THREAD_MAX_COUNT // Number of enum entries (used for array sizing)
+};
+
+class Config;
+
+class AsyncActivityProfilerHandler {
+ public:
+  explicit AsyncActivityProfilerHandler(GenericActivityProfiler& profiler);
+  AsyncActivityProfilerHandler(const AsyncActivityProfilerHandler&) = delete;
+  AsyncActivityProfilerHandler& operator=(const AsyncActivityProfilerHandler&) =
+      delete;
+  AsyncActivityProfilerHandler(AsyncActivityProfilerHandler&&) = delete;
+  AsyncActivityProfilerHandler& operator=(AsyncActivityProfilerHandler&&) =
+      delete;
+  ~AsyncActivityProfilerHandler();
+
+  // Returns true if the config enabled the activity profiler and the request
+  // was accepted (scheduled), false otherwise.
+  bool acceptConfig(const Config& config);
+  // Returns true if the request was accepted (scheduled), false if it was
+  // dropped (e.g. an iteration request with no duration when the application is
+  // not counting iterations, or another request is already pending).
+  bool scheduleTrace(const Config& config);
+  void step();
+
+  [[nodiscard]] bool isAsyncActive() const {
+    return currentRunloopState_ != RunloopState::WaitForRequest;
+  }
+
+  [[nodiscard]] bool isCollectingMemorySnapshot() const {
+    return currentRunloopState_ == RunloopState::CollectMemorySnapshot;
+  }
+
+  void cancel();
+
+  void configure(
+      const Config& config,
+      std::chrono::time_point<std::chrono::system_clock> now);
+
+  // Invoke at a regular interval to perform profiling activities.
+  // When not active, an interval of 1-5 seconds is probably fine,
+  // depending on required warm-up time and delayed start time.
+  // When active, it's a good idea to invoke more frequently to stay below
+  // memory usage limit (ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB) during warmup.
+  std::chrono::time_point<std::chrono::system_clock> performRunLoopStep(
+      const std::chrono::time_point<std::chrono::system_clock>& now,
+      const std::chrono::time_point<std::chrono::system_clock>& nextWakeupTime,
+      int64_t currentIter = -1);
+
+  void ensureCollectTraceDone();
+
+ private:
+  bool shouldActivateIterationConfig(int64_t currentIter);
+  bool shouldActivateTimestampConfig(
+      const std::chrono::time_point<std::chrono::system_clock>& now);
+  void profilerLoop();
+  void memoryProfilerLoop();
+  void completePendingTrace();
+  void activateConfig(std::chrono::time_point<std::chrono::system_clock> now);
+
+  std::unique_ptr<Config> asyncRequestConfig_;
+  std::mutex asyncConfigLock_;
+  std::array<std::unique_ptr<std::thread>, ThreadType::THREAD_MAX_COUNT>
+      profilerThreads_;
+  std::atomic_bool stopRunloop_{false};
+  std::atomic<std::int64_t> iterationCount_{-1};
+
+  GenericActivityProfiler& profiler_;
+  std::unique_ptr<ActivityLogger> logger_;
+
+  enum class RunloopState {
+    WaitForRequest,
+    Warmup,
+    CollectTrace,
+    ProcessTrace,
+    CollectMemorySnapshot,
+    Cancelling,
+  };
+
+  void performMemoryLoop(
+      const std::string& path,
+      uint32_t profile_time,
+      ActivityLogger* logger,
+      Config& config);
+
+  void collectTrace(
+      bool collection_done,
+      const std::chrono::time_point<std::chrono::system_clock>& now);
+
+  bool getCollectTraceState();
+
+  std::atomic<RunloopState> currentRunloopState_{RunloopState::WaitForRequest};
+  std::unique_ptr<std::thread> collectTraceThread_{nullptr};
+  std::recursive_mutex collectTraceStateMutex_;
+  bool isCollectingTrace_{false};
+};
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/Config.cpp
+++ b/third_party/kineto/libkineto/src/Config.cpp
@@ -1,0 +1,538 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "Config.h"
+
+#include <cstdlib>
+
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
+#include <chrono>
+#include <ctime>
+#include <functional>
+#include <mutex>
+#include <ostream>
+#include <string_view>
+#include <utility>
+
+#include "Logger.h"
+#include "ThreadUtil.h"
+
+using namespace std::chrono;
+
+using std::string;
+using std::vector;
+
+namespace KINETO_NAMESPACE {
+
+#if __cplusplus < 201703L
+constexpr std::chrono::milliseconds Config::kControllerIntervalMsecs;
+#endif
+
+constexpr milliseconds kDefaultActivitiesProfileDurationMSecs(500);
+constexpr int64_t kDefaultActivitiesMaxGpuBufferSize(128 * 1024 * 1024);
+constexpr seconds kDefaultActivitiesWarmupDurationSecs(5);
+constexpr seconds kMaxRequestAge(10);
+constexpr seconds kDefaultOnDemandConfigUpdateIntervalSecs(5);
+// 3200000 is the default value set by CUPTI
+constexpr size_t kDefaultCuptiDeviceBufferSize(3200000);
+// Default value set by CUPTI is 250
+constexpr size_t kDefaultCuptiDeviceBufferPoolLimit(20);
+
+// Activity Profiler
+constexpr char kActivitiesEnabledKey[] = "ACTIVITIES_ENABLED";
+constexpr char kCuptiPerThreadBufferEnabledKey[] =
+    "CUPTI_PER_THREAD_BUFFER_ENABLED";
+constexpr char kActivityTypesKey[] = "ACTIVITY_TYPES";
+constexpr char kActivitiesLogFileKey[] = "ACTIVITIES_LOG_FILE";
+constexpr char kActivitiesDurationKey[] = "ACTIVITIES_DURATION_SECS";
+constexpr char kActivitiesDurationMsecsKey[] = "ACTIVITIES_DURATION_MSECS";
+constexpr char kActivitiesWarmupDurationSecsKey[] =
+    "ACTIVITIES_WARMUP_PERIOD_SECS";
+constexpr char kActivitiesMaxGpuBufferSizeKey[] =
+    "ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB";
+constexpr char kActivitiesDisplayCudaSyncWaitEvents[] =
+    "ACTIVITIES_DISPLAY_CUDA_SYNC_WAIT_EVENTS";
+
+// Client Interface
+// TODO: keep supporting these older config options, deprecate in the future
+// using replacements.
+constexpr char kClientInterfaceEnableOpInputsCollection[] =
+    "CLIENT_INTERFACE_ENABLE_OP_INPUTS_COLLECTION";
+constexpr char kPythonStackTrace[] = "PYTHON_STACK_TRACE";
+// Profiler Config Options
+constexpr char kProfileReportInputShapes[] = "PROFILE_REPORT_INPUT_SHAPES";
+constexpr char kProfileProfileMemory[] = "PROFILE_PROFILE_MEMORY";
+constexpr char kProfileWithStack[] = "PROFILE_WITH_STACK";
+constexpr char kProfileWithFlops[] = "PROFILE_WITH_FLOPS";
+constexpr char kProfileWithModules[] = "PROFILE_WITH_MODULES";
+
+constexpr char kActivitiesWarmupIterationsKey[] =
+    "ACTIVITIES_WARMUP_ITERATIONS";
+constexpr char kActivitiesIterationsKey[] = "ACTIVITIES_ITERATIONS";
+
+// Memory Profiler
+constexpr char kProfileMemory[] = "PROFILE_MEMORY";
+constexpr char kProfileMemoryDuration[] = "PROFILE_MEMORY_DURATION_MSECS";
+
+// Roctracer
+constexpr char kRoctracerSetMaxEvents[] = "ROCTRACER_MAX_EVENTS";
+
+// Common
+
+// Client-side timestamp used for synchronized start across hosts for
+// distributed workloads.
+// Specified in milliseconds Unix time (milliseconds since epoch).
+// To use, compute a future timestamp as follows:
+//    * C++: <delay_ms> + duration_cast<milliseconds>(
+//               system_clock::now().time_since_epoch()).count()
+//    * Python: <delay_ms> + int(time.time() * 1000)
+//    * Bash: $((<delay_ms> + $(date +%s%3N)))
+//    * Bash: $(date -d "$time + <delay_secs>seconds" +%s%3N)
+// If used for a tracing request, timestamp must be far enough in the future
+// to accommodate ACTIVITIES_WARMUP_PERIOD_SECS as well as any delays in
+// propagating the request to the profiler.
+// If the request can not be honored, it is up to the profilers to report
+// an error somehow - no checks are done at config parse time.
+// Note PROFILE_START_ITERATION has higher precedence
+constexpr char kProfileStartTimeKey[] = "PROFILE_START_TIME";
+// Alternatively if the application supports reporting iterations
+// start the profile at specific iteration. If the iteration count
+// is >= this value the profile is started immediately.
+// A value >= 0 is valid for this config option to take effect.
+// Note PROFILE_START_ITERATION will take precedence over PROFILE_START_TIME.
+constexpr char kProfileStartIterationKey[] = "PROFILE_START_ITERATION";
+
+// Users can also start the profile on an integer multiple of the config
+// value PROFILE_START_ITERATION_ROUNDUP. This knob behaves similar to
+// PROFILE_START_ITERATION but instead of saying : "start collection trace on
+// iteration 500", one can configure it to "start collecting trace on the next
+// 100th iteration".
+//
+// For example,
+//   PROFILE_START_ITERATION_ROUNDUP = 1000, and the current iteration is 2010
+//   The profile will then be collected on the next multiple of 1000 ie. 3000
+// Note PROFILE_START_ITERATION_ROUNDUP will also take precedence over
+// PROFILE_START_TIME.
+constexpr char kProfileStartIterationRoundUpKey[] =
+    "PROFILE_START_ITERATION_ROUNDUP";
+
+constexpr char kRequestTraceID[] = "REQUEST_TRACE_ID";
+constexpr char kRequestGroupTraceID[] = "REQUEST_GROUP_TRACE_ID";
+
+// Enable communication through IPC Fabric
+// and disable thrift communication with dynolog daemon
+constexpr char kEnableIpcFabricKey[] = "ENABLE_IPC_FABRIC";
+// Period to pull on-demand config from dynolog daemon
+constexpr char kOnDemandConfigUpdateIntervalSecsKey[] =
+    "ON_DEMAND_CONFIG_UPDATE_INTERVAL_SECS";
+
+// Verbose log level
+// The actual glog is not used and --v and --vmodule has no effect.
+// Instead set the verbose level and modules in the config file.
+constexpr char kLogVerboseLevelKey[] = "VERBOSE_LOG_LEVEL";
+// By default, all modules will log verbose messages >= verboseLogLevel.
+// But to reduce noise we can specify one or more modules of interest.
+// A module is a C/C++ object file (source file name),
+// Example argument: ActivityProfiler.cpp,output_json.cpp
+constexpr char kLogVerboseModulesKey[] = "VERBOSE_LOG_MODULES";
+
+constexpr char kCustomConfigKey[] = "CUSTOM_CONFIG";
+
+namespace {
+
+struct FactoryMap {
+  void addFactory(
+      std::string name,
+      std::function<AbstractConfig*(Config&)> factory) {
+    std::scoped_lock lock(lock_);
+    factories_.emplace(std::move(name), std::move(factory));
+  }
+
+  void addFeatureConfigs(Config& cfg) {
+    std::scoped_lock lock(lock_);
+    for (const auto& p : factories_) {
+      cfg.addFeature(p.first, p.second(cfg));
+    }
+  }
+
+  // Config factories are shared between objects and since
+  // config objects can be created by multiple threads, we need a lock.
+  std::mutex lock_;
+  std::map<std::string, std::function<AbstractConfig*(Config&)>> factories_;
+};
+
+std::shared_ptr<FactoryMap> configFactories() {
+  // Ensure this is safe to call during shutdown, even as static
+  // destructors are invoked. getStaticObjectLifetimeHandle hangs onto
+  // FactoryMap delaying its destruction.
+  static auto factories = std::make_shared<FactoryMap>();
+  static std::weak_ptr<FactoryMap> weak_ptr = factories;
+  return weak_ptr.lock();
+}
+
+} // namespace
+
+void Config::addConfigFactory(
+    std::string name,
+    std::function<AbstractConfig*(Config&)> factory) {
+  auto factories = configFactories();
+  if (factories) {
+    factories->addFactory(std::move(name), std::move(factory));
+  }
+}
+
+static string defaultTraceFileName() {
+  return fmt::format("/tmp/libkineto_activities_{}.json", processId());
+}
+
+static string defaultMemoryTraceFileName() {
+  return fmt::format("/tmp/memory_snapshot_{}.pickle", processId());
+}
+
+namespace {
+
+// Dir that on-demand trace files are restricted to. Defaults to
+// /tmp; overridable locally via KINETO_ONDEMAND_TRACE_DIR.
+constexpr std::string_view kDefaultOnDemandTraceDir = "/tmp/";
+
+const string& allowedOnDemandTraceDir() {
+  static const string kDir = [] {
+    const char* env = std::getenv("KINETO_ONDEMAND_TRACE_DIR");
+    string d = (env != nullptr && *env != '\0')
+        ? string(env)
+        : string(kDefaultOnDemandTraceDir);
+    if (d.back() != '/') {
+      d.push_back('/');
+    }
+    return d;
+  }();
+  return kDir;
+}
+
+// Allowed only if under the allowed dir and free of ".." traversal.
+bool isAllowedOnDemandTraceFile(const string& path) {
+  const string& dir = allowedOnDemandTraceDir();
+  return path.starts_with(dir) && path.find("..") == string::npos;
+}
+
+} // namespace
+
+Config::Config()
+    : verboseLogLevel_(-1),
+      activityProfilerEnabled_(true),
+      perThreadBufferEnabled_(false),
+      activitiesLogFile_(defaultTraceFileName()),
+      activitiesLogUrl_(fmt::format("file://{}", activitiesLogFile_)),
+      activitiesMaxGpuBufferSize_(kDefaultActivitiesMaxGpuBufferSize),
+      activitiesWarmupDuration_(kDefaultActivitiesWarmupDurationSecs),
+      activitiesWarmupIterations_(0),
+      activitiesCudaSyncWaitEvents_(true),
+      activitiesDuration_(kDefaultActivitiesProfileDurationMSecs),
+      activitiesRunIterations_(0),
+      activitiesOnDemandTimestamp_(milliseconds(0)),
+      profileStartTime_(milliseconds(0)),
+      profileStartIteration_(-1),
+      profileStartIterationRoundUp_(-1),
+      enableIpcFabric_(false),
+      onDemandConfigUpdateIntervalSecs_(
+          kDefaultOnDemandConfigUpdateIntervalSecs),
+      cuptiDeviceBufferSize_(kDefaultCuptiDeviceBufferSize),
+      cuptiDeviceBufferPoolLimit_(kDefaultCuptiDeviceBufferPoolLimit) {
+  auto factories = configFactories();
+  if (factories) {
+    factories->addFeatureConfigs(*this);
+  }
+#if __linux__
+  enableIpcFabric_ = libkineto::isDaemonEnvVarSet();
+#endif
+}
+
+#if __linux__
+bool isDaemonEnvVarSet() {
+  static bool rc = [] {
+    void* ptr = getenv(kUseDaemonEnvVar);
+    return ptr != nullptr;
+  }();
+  return rc;
+}
+#else
+bool isDaemonEnvVarSet() {
+  return false;
+}
+#endif
+
+std::shared_ptr<void> Config::getStaticObjectsLifetimeHandle() {
+  return configFactories();
+}
+
+seconds Config::maxRequestAge() const {
+  return kMaxRequestAge;
+}
+
+static std::string getTimeStr(time_point<system_clock> t) {
+  std::time_t t_c = system_clock::to_time_t(t);
+  std::tm tm{};
+  get_local_time(&t_c, &tm);
+  return fmt::format("{:%H:%M:%S}", tm);
+}
+
+static time_point<system_clock> handleProfileStartTime(int64_t start_time_ms) {
+  // If 0, return 0, so that AbstractConfig::parse can fix the timestamp later.
+  if (start_time_ms == 0) {
+    return time_point<system_clock>(milliseconds(0));
+  }
+
+  auto t = time_point<system_clock>(milliseconds(start_time_ms));
+  // This should check that ProfileStartTime is in the future with
+  // enough time for warm-up.
+  // Unfortunately, warm-up duration is unknown at this point.
+  // But we can still check that the start time is not in the past.
+  auto now = system_clock::now();
+  if ((now - t) > kMaxRequestAge) {
+    throw std::invalid_argument(fmt::format(
+        "Invalid {}: {} - start time is more than {}s in the past",
+        kProfileStartTimeKey,
+        getTimeStr(t),
+        kMaxRequestAge.count()));
+  }
+  return t;
+}
+
+void Config::setActivityTypes(
+    const std::vector<std::string>& selected_activities) {
+  selectedActivityTypes_.clear();
+  if (!selected_activities.empty()) {
+    for (const auto& activity : selected_activities) {
+      if (activity.empty()) {
+        continue;
+      }
+      selectedActivityTypes_.insert(toActivityType(activity));
+    }
+  }
+}
+
+bool Config::handleOption(const std::string& name, std::string& val) {
+  // Activity Profiler
+  if (!name.compare(kActivitiesDurationKey)) {
+    activitiesDuration_ = duration_cast<milliseconds>(seconds(toInt32(val)));
+    activitiesOnDemandTimestamp_ = timestamp();
+  } else if (!name.compare(kActivityTypesKey)) {
+    vector<string> activity_types = splitAndTrim(toLower(val), ',');
+    setActivityTypes(activity_types);
+  } else if (!name.compare(kActivitiesDurationMsecsKey)) {
+    activitiesDuration_ = milliseconds(toInt32(val));
+    activitiesOnDemandTimestamp_ = timestamp();
+  } else if (!name.compare(kActivitiesIterationsKey)) {
+    activitiesRunIterations_ = toInt32(val);
+    activitiesOnDemandTimestamp_ = timestamp();
+  } else if (!name.compare(kLogVerboseLevelKey)) {
+    verboseLogLevel_ = toInt32(val);
+  } else if (!name.compare(kLogVerboseModulesKey)) {
+    verboseLogModules_ = splitAndTrim(val, ',');
+  } else if (!name.compare(kActivitiesEnabledKey)) {
+    activityProfilerEnabled_ = toBool(val);
+  } else if (!name.compare(kCuptiPerThreadBufferEnabledKey)) {
+    perThreadBufferEnabled_ = toBool(val);
+  } else if (!name.compare(kProfileMemory)) {
+    memoryProfilerEnabled_ = toBool(val);
+    if (memoryProfilerEnabled_) {
+      activitiesLogFile_ = defaultMemoryTraceFileName();
+    }
+  } else if (!name.compare(kProfileMemoryDuration)) {
+    profileMemoryDuration_ = toInt32(val);
+  } else if (!name.compare(kActivitiesLogFileKey)) {
+    if (onDemand_ && !isAllowedOnDemandTraceFile(val)) {
+      LOG(WARNING) << "Ignoring on-demand " << kActivitiesLogFileKey
+                   << " outside allowed directory " << allowedOnDemandTraceDir()
+                   << ": " << val << " (trace will use the default path)";
+    } else {
+      activitiesLogFile_ = val;
+      activitiesLogUrl_ = fmt::format("file://{}", val);
+      size_t jidx = activitiesLogUrl_.find(".pt.trace.json");
+      if (jidx != std::string::npos) {
+        activitiesLogUrl_.replace(
+            jidx, 14, fmt::format("_{}.pt.trace.json", processId()));
+      } else {
+        jidx = activitiesLogUrl_.find(".json");
+        if (jidx != std::string::npos) {
+          activitiesLogUrl_.replace(
+              jidx, 5, fmt::format("_{}.json", processId()));
+        }
+      }
+    }
+    activitiesOnDemandTimestamp_ = timestamp();
+  } else if (!name.compare(kActivitiesMaxGpuBufferSizeKey)) {
+    activitiesMaxGpuBufferSize_ =
+        static_cast<int64_t>(toInt32(val)) * 1024 * 1024;
+  } else if (!name.compare(kActivitiesWarmupDurationSecsKey)) {
+    activitiesWarmupDuration_ = seconds(toInt32(val));
+  } else if (!name.compare(kActivitiesWarmupIterationsKey)) {
+    activitiesWarmupIterations_ = toInt32(val);
+  } else if (!name.compare(kActivitiesDisplayCudaSyncWaitEvents)) {
+    activitiesCudaSyncWaitEvents_ = toBool(val);
+  } else if (!name.compare(kRequestTraceID)) {
+    requestTraceID_ = val;
+  } else if (!name.compare(kRequestGroupTraceID)) {
+    requestGroupTraceID_ = val;
+  } else if (!name.compare(kRoctracerSetMaxEvents)) {
+    maxEvents_ = toInt32(val);
+  }
+
+  // TODO: Deprecate Client Interface
+  else if (!name.compare(kClientInterfaceEnableOpInputsCollection)) {
+    enableReportInputShapes_ = toBool(val);
+  } else if (!name.compare(kPythonStackTrace)) {
+    enableWithStack_ = toBool(val);
+  }
+
+  // Profiler Config
+  else if (!name.compare(kProfileReportInputShapes)) {
+    enableReportInputShapes_ = toBool(val);
+  } else if (!name.compare(kProfileProfileMemory)) {
+    enableProfileMemory_ = toBool(val);
+  } else if (!name.compare(kProfileWithStack)) {
+    enableWithStack_ = toBool(val);
+  } else if (!name.compare(kProfileWithFlops)) {
+    enableWithFlops_ = toBool(val);
+  } else if (!name.compare(kProfileWithModules)) {
+    enableWithModules_ = toBool(val);
+  }
+
+  // Common
+  else if (!name.compare(kProfileStartTimeKey)) {
+    profileStartTime_ = handleProfileStartTime(toInt64(val));
+  } else if (!name.compare(kProfileStartIterationKey)) {
+    profileStartIteration_ = toInt32(val);
+  } else if (!name.compare(kProfileStartIterationRoundUpKey)) {
+    profileStartIterationRoundUp_ = toInt32(val);
+  } else if (!name.compare(kEnableIpcFabricKey)) {
+    enableIpcFabric_ = toBool(val);
+  } else if (!name.compare(kOnDemandConfigUpdateIntervalSecsKey)) {
+    onDemandConfigUpdateIntervalSecs_ = seconds(toInt32(val));
+  } else if (!name.compare(kCustomConfigKey)) {
+    customConfig_ = val;
+  } else {
+    return false;
+  }
+  return true;
+}
+
+void Config::updateActivityProfilerRequestReceivedTime() {
+  activitiesOnDemandTimestamp_ = system_clock::now();
+}
+
+void Config::setClientDefaults() {
+  AbstractConfig::setClientDefaults();
+  activitiesLogToMemory_ = true;
+}
+
+void Config::validate(
+    const time_point<system_clock>& fallbackProfileStartTime) {
+  if (!hasProfileStartTime()) {
+    VLOG(0)
+        << "No explicit timestamp has been set. "
+        << "Defaulting it to now + activitiesWarmupDuration with a buffer of double the period of the monitoring thread.";
+    profileStartTime_ = fallbackProfileStartTime + activitiesWarmupDuration() +
+        2 * Config::kControllerIntervalMsecs;
+  }
+
+  if (profileStartIterationRoundUp_ == 0) {
+    // setting to 0 will mess up modulo arithmetic, set it to -1 so it has no
+    // effect
+    LOG(WARNING) << "Profiler start iteration round up should be >= 1.";
+    profileStartIterationRoundUp_ = -1;
+  }
+
+  if (profileStartIterationRoundUp_ > 0 && !hasProfileStartIteration()) {
+    VLOG(0) << "Setting profiler start iteration to 0 so this config is "
+            << "triggered via iteration count.";
+    profileStartIteration_ = 0;
+  }
+
+  if (selectedActivityTypes_.empty()) {
+    selectDefaultActivityTypes();
+  }
+  setActivityDependentConfig();
+}
+
+void Config::printActivityProfilerConfig(std::ostream& s) const {
+  fmt::print(s, "  Log file: {}\n", activitiesLogFile());
+  if (hasProfileStartIteration()) {
+    fmt::print(
+        s,
+        "  Trace start Iteration: {}\n"
+        "  Trace warmup Iterations: {}\n"
+        "  Trace profile Iterations: {}\n",
+        profileStartIteration(),
+        activitiesWarmupIterations(),
+        activitiesRunIterations());
+    if (profileStartIterationRoundUp() > 0) {
+      fmt::print(
+          "  Trace start iteration roundup : {}\n",
+          profileStartIterationRoundUp());
+    }
+  } else if (hasProfileStartTime()) {
+    std::time_t t_c = system_clock::to_time_t(requestTimestamp());
+    std::tm tm{};
+    get_local_time(&t_c, &tm);
+    fmt::print(
+        s,
+        "  Trace start time: {:%Y-%m-%d %H:%M:%S}\n"
+        "  Trace duration: {}ms\n"
+        "  Warmup duration: {}s\n",
+        tm,
+        activitiesDuration().count(),
+        activitiesWarmupDuration().count());
+  }
+
+  fmt::print(
+      s,
+      "  Max GPU buffer size: {:.0f}MB\n",
+      static_cast<double>(activitiesMaxGpuBufferSize()) / 1024.0 / 1024.0);
+
+  std::vector<std::string> activities;
+  activities.reserve(selectedActivityTypes_.size());
+  for (const auto& activity : selectedActivityTypes_) {
+    activities.emplace_back(toString(activity));
+  }
+  fmt::print(s, "  Enabled activities: {}\n", fmt::join(activities, ","));
+
+  AbstractConfig::printActivityProfilerConfig(s);
+}
+
+void Config::setActivityDependentConfig() {
+  AbstractConfig::setActivityDependentConfig();
+}
+
+// Returns a reference to the protobuf trace enabled flag.
+// Default is false. Downstream consumers override at startup.
+bool& get_protobuf_trace_enabled() {
+  static bool _protobuf_trace_enabled = false;
+  return _protobuf_trace_enabled;
+}
+
+// Returns a reference to the perfetto trace enabled flag.
+// Default is false. Downstream consumers override at startup.
+bool& get_perfetto_trace_enabled() {
+  static bool perfetto_trace_enabled = false;
+  return perfetto_trace_enabled;
+}
+
+// Returns a reference to the perfetto packet compression enabled flag.
+// Default is true (compression is on). Downstream consumers override at
+// startup.
+bool& get_perfetto_packet_compression_enabled() {
+  static bool perfetto_packet_compression_enabled = true;
+  return perfetto_packet_compression_enabled;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/ConfigLoader.cpp
+++ b/third_party/kineto/libkineto/src/ConfigLoader.cpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ConfigLoader.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include "DaemonConfigLoader.h"
+
+#include "Logger.h"
+
+using namespace std::chrono;
+
+namespace KINETO_NAMESPACE {
+
+constexpr char kConfigFileEnvVar[] = "KINETO_CONFIG";
+#ifdef __linux__
+constexpr char kConfigFile[] = "/etc/libkineto.conf";
+#else
+constexpr char kConfigFile[] = "libkineto.conf";
+#endif
+
+constexpr std::chrono::seconds kConfigUpdateIntervalSecs(300);
+
+// return an empty string if reading gets any errors. Otherwise a config string.
+static std::string readConfigFromConfigFile(
+    const char* filename,
+    bool verbose = true) {
+  // Read whole file into a string.
+  std::ifstream file(filename);
+  std::string conf;
+  try {
+    conf.assign(
+        std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+  } catch (std::exception& e) {
+    if (verbose) {
+      VLOG(0) << "Error reading " << filename << ": " << e.what();
+    }
+
+    conf = "";
+  }
+  return conf;
+}
+
+static std::function<std::unique_ptr<IDaemonConfigLoader>()>&
+daemonConfigLoaderFactory() {
+  static std::function<std::unique_ptr<IDaemonConfigLoader>()> factory =
+      nullptr;
+  return factory;
+}
+
+void ConfigLoader::setDaemonConfigLoaderFactory(
+    std::function<std::unique_ptr<IDaemonConfigLoader>()> factory) {
+  daemonConfigLoaderFactory() = std::move(factory);
+}
+
+ConfigLoader& ConfigLoader::instance() {
+  static ConfigLoader config_loader;
+  return config_loader;
+}
+
+// return an empty string if polling gets any errors. Otherwise a config string.
+std::string ConfigLoader::readOnDemandConfigFromDaemon(
+    [[maybe_unused]] time_point<system_clock> now) {
+  if (!daemonConfigLoader_) {
+    return "";
+  }
+  bool activities = canHandlerAcceptConfig(ConfigKind::ActivityProfiler);
+  return daemonConfigLoader_->readOnDemandConfig(activities);
+}
+
+ConfigLoader::ConfigLoader()
+    : configUpdateIntervalSecs_(kConfigUpdateIntervalSecs),
+      // on-demand config will be overwritten by the value read from the regular
+      // config so the initial value is not important
+      onDemandConfigUpdateIntervalSecs_(kConfigUpdateIntervalSecs),
+      stopFlag_(false) {}
+
+void ConfigLoader::startThread() {
+  if (!updateThread_) {
+    // Reset the stop flag so a thread started after a prior stopThread() runs
+    // instead of exiting immediately on its first wakeup.
+    stopFlag_ = false;
+    // Create default base config here - at this point static initializers
+    // of extensions should have run and registered all config feature factories
+    std::scoped_lock lock(configLock_);
+    if (!config_) {
+      config_ = std::make_unique<Config>();
+    }
+    updateThread_ =
+        std::make_unique<std::thread>(&ConfigLoader::updateConfigThread, this);
+  }
+}
+
+void ConfigLoader::stopThread() {
+  if (updateThread_) {
+    stopFlag_ = true;
+    {
+      std::scoped_lock lock(updateThreadMutex_);
+      updateThreadCondVar_.notify_one();
+    }
+    if (updateThread_->joinable()) {
+      updateThread_->join();
+    }
+    updateThread_ = nullptr;
+  }
+}
+
+void ConfigLoader::stopUpdateThread() {
+  stopThread();
+}
+
+void ConfigLoader::resetDaemonConfigLoaderForTesting() {
+  daemonConfigLoader_.reset();
+}
+
+bool ConfigLoader::waitForUpdateThreadLoopCountForTesting(
+    uint64_t target,
+    std::chrono::milliseconds timeout) {
+  std::unique_lock<std::mutex> lock(loopCountMutex_);
+  return loopCountCondVar_.wait_for(lock, timeout, [this, target] {
+    return updateThreadLoopCount_.load(std::memory_order_acquire) >= target;
+  });
+}
+
+std::chrono::seconds ConfigLoader::onDemandConfigUpdateIntervalForTesting() {
+  std::scoped_lock lock(configLock_);
+  // config_ is the authoritative source; updateConfigThread caches its value
+  // into onDemandConfigUpdateIntervalSecs_ on each base-config refresh.
+  return config_ ? config_->onDemandConfigUpdateIntervalSecs()
+                 : onDemandConfigUpdateIntervalSecs_;
+}
+
+ConfigLoader::~ConfigLoader() {
+  stopThread();
+#if !USE_GOOGLE_LOG
+  Logger::clearLoggerObservers();
+#endif // !USE_GOOGLE_LOG
+}
+
+namespace {
+
+const char* configFileName() {
+  static const char* configFileName__ = []() {
+    const char* configFileName_ = getenv(kConfigFileEnvVar);
+    if (configFileName_ == nullptr) {
+      configFileName_ = kConfigFile;
+    }
+    return configFileName_;
+  }();
+  return configFileName__;
+}
+
+} // namespace
+
+IDaemonConfigLoader* ConfigLoader::daemonConfigLoader() {
+  if (!daemonConfigLoader_ && daemonConfigLoaderFactory()) {
+    daemonConfigLoader_ = daemonConfigLoaderFactory()();
+    daemonConfigLoader_->setCommunicationFabric(config_->ipcFabricEnabled());
+  }
+  return daemonConfigLoader_.get();
+}
+
+const char* ConfigLoader::customConfigFileName() {
+  return getenv(kConfigFileEnvVar);
+}
+
+std::string ConfigLoader::getConfString() {
+  return readConfigFromConfigFile(configFileName(), false);
+}
+
+void ConfigLoader::updateBaseConfig() {
+  // First try reading local config file
+  // If that fails, read from daemon
+  // TODO: Invert these once daemon path fully rolled out
+  std::string config_str = readConfigFromConfigFile(configFileName());
+  if (config_str.empty() && daemonConfigLoader()) {
+    // If local config file was not successfully loaded (e.g. not found)
+    // then try the daemon
+    config_str = daemonConfigLoader()->readBaseConfig();
+  }
+  if (config_str != config_->source()) {
+    std::scoped_lock lock(configLock_);
+    config_ = std::make_unique<Config>();
+    config_->parse(config_str);
+    if (daemonConfigLoader()) {
+      daemonConfigLoader()->setCommunicationFabric(config_->ipcFabricEnabled());
+    }
+    SET_LOG_VERBOSITY_LEVEL(
+        config_->verboseLogLevel(), config_->verboseLogModules());
+    VLOG(0) << "Detected base config change";
+  }
+}
+
+void ConfigLoader::configureFromDaemon(
+    time_point<system_clock> now,
+    Config& config) {
+  const std::string config_str = readOnDemandConfigFromDaemon(now);
+  if (config_str.empty()) {
+    return;
+  }
+
+  LOG(INFO) << "Received config from dyno:\n" << config_str;
+  // Untrusted daemon IPC config; restrict trace output path.
+  config.setOnDemand(true);
+  config.parse(config_str);
+  notifyHandlers(config);
+}
+
+void ConfigLoader::updateConfigThread() {
+  // It's important to hang to this reference until the thread stops.
+  // Otherwise, the Config's static members may be destroyed before this
+  // function finishes.
+  auto handle = Config::getStaticObjectsLifetimeHandle();
+
+  // We're trying to update two configs here:
+  // 1. Base config - this is the config that is read from the config file
+  // 2. On-demand config - this is the config that is read via IPC channel
+  //    from daemon. It's layered on top of the base config.
+  // They have different update intervals (on demand is more frequent).
+  // Besides, on-demand update frequency can be configured via base config.
+
+  // initialze with some time buffer in the past
+  auto prev_config_load_time =
+      system_clock::now() - configUpdateIntervalSecs_ * 2;
+  auto prev_on_demand_load_time = prev_config_load_time;
+  auto onDemandConfig = std::make_unique<Config>();
+
+  // This can potentially sleep for long periods of time, so allow
+  // the destructor to wake it to avoid a 5-minute long destruct period.
+  for (;;) {
+    auto interval =
+        std::min(
+            configUpdateIntervalSecs_ + prev_config_load_time,
+            onDemandConfigUpdateIntervalSecs_ + prev_on_demand_load_time) -
+        system_clock::now();
+    if (interval.count() > 0) {
+      std::unique_lock<std::mutex> lock(updateThreadMutex_);
+      updateThreadCondVar_.wait_for(lock, interval);
+    }
+    if (stopFlag_) {
+      break;
+    }
+    auto now = system_clock::now();
+    // This runs on a bare background thread: an escaped exception would
+    // terminate the process, so config-update failures are caught and skipped.
+    // Advance the load timestamps before the guarded work so a persistent
+    // failure backs off to the normal interval instead of hot-looping.
+    if (now > prev_config_load_time + configUpdateIntervalSecs_) {
+      prev_config_load_time = now;
+      try {
+        updateBaseConfig();
+        onDemandConfigUpdateIntervalSecs_ =
+            config_->onDemandConfigUpdateIntervalSecs();
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Skipping base config update after error: " << e.what();
+      } catch (...) {
+        LOG(ERROR) << "Skipping base config update after unknown error";
+      }
+    }
+    if (now > prev_on_demand_load_time + onDemandConfigUpdateIntervalSecs_) {
+      prev_on_demand_load_time = now;
+      onDemandConfig = std::make_unique<Config>();
+      try {
+        configureFromDaemon(now, *onDemandConfig);
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Skipping on-demand config update after error: "
+                   << e.what();
+      } catch (...) {
+        LOG(ERROR) << "Skipping on-demand config update after unknown error";
+      }
+    }
+    if (onDemandConfig->verboseLogLevel() >= 0) {
+      LOG(INFO) << "Setting verbose level to "
+                << onDemandConfig->verboseLogLevel()
+                << " from on-demand config";
+      SET_LOG_VERBOSITY_LEVEL(
+          onDemandConfig->verboseLogLevel(),
+          onDemandConfig->verboseLogModules());
+    }
+    // Mark one completed iteration and wake any test waiting for deterministic
+    // progression of the real poll thread.
+    {
+      std::scoped_lock lock(loopCountMutex_);
+      updateThreadLoopCount_.fetch_add(1, std::memory_order_release);
+    }
+    loopCountCondVar_.notify_all();
+  }
+}
+
+bool ConfigLoader::hasNewConfig(const Config& oldConfig) {
+  std::scoped_lock lock(configLock_);
+  return config_->timestamp() > oldConfig.timestamp();
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/ConfigLoader.h
+++ b/third_party/kineto/libkineto/src/ConfigLoader.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "Config.h"
+
+namespace libkineto {
+class LibkinetoApi;
+}
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+class IDaemonConfigLoader;
+
+class ConfigLoader {
+ public:
+  static ConfigLoader& instance();
+
+  enum ConfigKind { ActivityProfiler = 0, NumConfigKinds };
+
+  struct ConfigHandler {
+    virtual ~ConfigHandler() = default;
+    virtual bool canAcceptConfig() = 0;
+    // Returns true if the handler accepted the config for scheduling, false if
+    // it declined. Acceptance means the request was queued, NOT that profiling
+    // will run: a queued request can still be dropped later on the profiler
+    // thread (e.g. canStart() fails, or GPU buffers overflow during warmup).
+    virtual bool acceptConfig(const Config& cfg) = 0;
+  };
+
+  void addHandler(ConfigKind kind, ConfigHandler* handler) {
+    std::scoped_lock lock(updateThreadMutex_);
+    handlers_[kind].push_back(handler);
+    startThread();
+  }
+
+  void removeHandler(ConfigKind kind, ConfigHandler* handler) {
+    std::scoped_lock lock(updateThreadMutex_);
+    auto it =
+        std::find(handlers_[kind].begin(), handlers_[kind].end(), handler);
+    if (it != handlers_[kind].end()) {
+      handlers_[kind].erase(it);
+    }
+  }
+
+  void notifyHandlers(const Config& cfg) {
+    std::scoped_lock lock(updateThreadMutex_);
+    for (auto& key_val : handlers_) {
+      for (ConfigHandler* handler : key_val.second) {
+        handler->acceptConfig(cfg);
+      }
+    }
+  }
+
+  bool canHandlerAcceptConfig(ConfigKind kind) {
+    std::scoped_lock lock(updateThreadMutex_);
+    for (ConfigHandler* handler : handlers_[kind]) {
+      if (!handler->canAcceptConfig()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  std::unique_ptr<Config> getConfigCopy() {
+    std::scoped_lock lock(configLock_);
+    return config_->clone();
+  }
+
+  bool hasNewConfig(const Config& oldConfig);
+
+  static void setDaemonConfigLoaderFactory(
+      std::function<std::unique_ptr<IDaemonConfigLoader>()> factory);
+
+  std::string getConfString();
+
+  // Stops and joins the background config-update thread; a no-op if it was
+  // never started. Exposed so a test that drives the singleton can tear the
+  // thread down deterministically before the test process exits, rather than
+  // leaving the join to run during static destruction.
+  void stopUpdateThread();
+
+  // Test-only. Returns how many iterations the background poll thread has
+  // completed. A test that installs a fake daemon config loader can start the
+  // thread and wait for this count to advance, then deterministically observe
+  // the effects of a known number of real poll iterations. Loaded with acquire
+  // ordering so that observing an advanced count also makes that iteration's
+  // writes visible to the observer.
+  [[nodiscard]] uint64_t updateThreadLoopCountForTesting() const {
+    return updateThreadLoopCount_.load(std::memory_order_acquire);
+  }
+
+  // Test-only. Blocks until the poll thread's iteration count reaches target,
+  // or the timeout elapses; returns true if the count was reached.
+  bool waitForUpdateThreadLoopCountForTesting(
+      uint64_t target,
+      std::chrono::milliseconds timeout);
+
+  // Test-only. Drops the cached daemon config loader so the next poll rebuilds
+  // it from the currently registered factory. The loader is a member of this
+  // process-wide singleton, so a test that injected a fake via the factory must
+  // clear it (after stopping the thread) or a later test would reuse a loader
+  // pointing at destroyed test state.
+  void resetDaemonConfigLoaderForTesting();
+
+  // Test-only. Returns the on-demand poll interval the background thread is
+  // currently using, taken from the loaded base config. Lets a test size a
+  // timeout to the live cadence instead of assuming the default.
+  std::chrono::seconds onDemandConfigUpdateIntervalForTesting();
+
+ private:
+  ConfigLoader();
+  ~ConfigLoader();
+
+  IDaemonConfigLoader* daemonConfigLoader();
+
+  void startThread();
+  void stopThread();
+  void updateConfigThread();
+  void updateBaseConfig();
+
+  // Create configuration when receiving request from a daemon
+  void configureFromDaemon(
+      std::chrono::time_point<std::chrono::system_clock> now,
+      Config& config);
+
+  std::string readOnDemandConfigFromDaemon(
+      std::chrono::time_point<std::chrono::system_clock> now);
+
+  const char* customConfigFileName();
+
+  std::mutex configLock_;
+  std::unique_ptr<Config> config_;
+  std::unique_ptr<IDaemonConfigLoader> daemonConfigLoader_;
+  std::map<ConfigKind, std::vector<ConfigHandler*>> handlers_;
+
+  std::chrono::seconds configUpdateIntervalSecs_;
+  std::chrono::seconds onDemandConfigUpdateIntervalSecs_;
+  std::unique_ptr<std::thread> updateThread_;
+  std::condition_variable updateThreadCondVar_;
+  std::mutex updateThreadMutex_;
+  std::atomic_bool stopFlag_{false};
+
+  // Incremented at the end of each updateConfigThread() iteration. Test-only
+  // observation point; see updateThreadLoopCountForTesting(). loopCountCondVar_
+  // is notified on each increment so a test can block until a target count.
+  std::atomic<uint64_t> updateThreadLoopCount_{0};
+  std::mutex loopCountMutex_;
+  std::condition_variable loopCountCondVar_;
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/CuptiActivity.h
+++ b/third_party/kineto/libkineto/src/CuptiActivity.h
@@ -1,0 +1,856 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cupti.h>
+
+#include <fmt/format.h>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ApproximateClock.h"
+#include "CuptiCbidRegistry.h"
+#include "Demangle.h"
+#include "DeviceProperties.h"
+#include "GenericTraceActivity.h"
+#include "ITraceActivity.h"
+#include "Logger.h"
+#include "MetadataFieldCatalog.h"
+#include "ThreadUtil.h"
+#include "TypedMetadataJson.h"
+#include "cupti_strings.h"
+#include "output_base.h"
+
+namespace libkineto {
+class ActivityLogger;
+}
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+struct TraceSpan;
+
+// This function allows us to activate/deactivate TSC CUPTI callbacks
+// via a killswitch
+bool& use_cupti_tsc();
+
+// These classes wrap the various CUPTI activity types
+// into subclasses of ITraceActivity so that they can all be accessed
+// using the ITraceActivity interface and logged via ActivityLogger.
+
+// Abstract base class, templated on Cupti activity type
+template <class T>
+struct CuptiActivity : public ITraceActivity {
+  explicit CuptiActivity(const T* activity, const ITraceActivity* linked)
+      : activity_(*activity), linked_(linked) {}
+  // If we are running on Windows or are on a CUDA version < 11.6,
+  // we use the default system clock so no conversion needed same for all
+  // ifdefs below
+  int64_t timestamp() const override {
+#if defined(_WIN32) || CUDA_VERSION < 11060
+    return activity_.start;
+#else
+    if (use_cupti_tsc()) {
+      return get_time_converter()(activity_.start);
+    } else {
+      return activity_.start;
+    }
+#endif
+  }
+
+  int64_t duration() const override {
+#if defined(_WIN32) || CUDA_VERSION < 11060
+    return activity_.end - activity_.start;
+#else
+    if (use_cupti_tsc()) {
+      return get_time_converter()(activity_.end) -
+          get_time_converter()(activity_.start);
+    } else {
+      return activity_.end - activity_.start;
+    }
+#endif
+  }
+  // TODO(T107507796): Deprecate ITraceActivity
+  int64_t correlationId() const override {
+    return 0;
+  }
+  int32_t getThreadId() const override {
+    return 0;
+  }
+  const ITraceActivity* linkedActivity() const override {
+    return linked_;
+  }
+  int flowType() const override {
+    return kLinkAsyncCpuGpu;
+  }
+  int64_t flowId() const override {
+    return correlationId();
+  }
+  const T& raw() const {
+    return activity_;
+  }
+  const TraceSpan* traceSpan() const override {
+    return nullptr;
+  }
+
+ protected:
+  const T& activity_;
+  const ITraceActivity* linked_{nullptr};
+};
+
+// CUpti_ActivityAPI - CUDA runtime activities
+struct RuntimeActivity : public CuptiActivity<CUpti_ActivityAPI> {
+  explicit RuntimeActivity(
+      const CUpti_ActivityAPI* activity,
+      const ITraceActivity* linked,
+      int32_t threadId)
+      : CuptiActivity(activity, linked), threadId_(threadId) {}
+  int64_t correlationId() const override {
+    return activity_.correlationId;
+  }
+  int64_t deviceId() const override {
+    return processId();
+  }
+  int64_t resourceId() const override {
+    return threadId_;
+  }
+  ActivityType type() const override {
+    return ActivityType::CUDA_RUNTIME;
+  }
+  bool flowStart() const override;
+  const std::string name() const override {
+    return runtimeCbidName(activity_.cbid);
+  }
+  void log(ActivityLogger& logger) const override;
+  const std::string metadataJson() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
+
+ private:
+  const int32_t threadId_;
+};
+
+// CUpti_ActivityAPI - CUDA driver activities
+struct DriverActivity : public CuptiActivity<CUpti_ActivityAPI> {
+  explicit DriverActivity(
+      const CUpti_ActivityAPI* activity,
+      const ITraceActivity* linked,
+      int32_t threadId)
+      : CuptiActivity(activity, linked), threadId_(threadId) {}
+  int64_t correlationId() const override {
+    return activity_.correlationId;
+  }
+  int64_t deviceId() const override {
+    return processId();
+  }
+  int64_t resourceId() const override {
+    return threadId_;
+  }
+  ActivityType type() const override {
+    return ActivityType::CUDA_DRIVER;
+  }
+  bool flowStart() const override;
+  const std::string name() const override;
+  void log(ActivityLogger& logger) const override;
+  const std::string metadataJson() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
+
+ private:
+  const int32_t threadId_;
+};
+
+// CUpti_ActivityAPI - CUDA runtime activities
+struct OverheadActivity : public CuptiActivity<CUpti_ActivityOverhead> {
+  explicit OverheadActivity(
+      const CUpti_ActivityOverhead* activity,
+      const ITraceActivity* linked,
+      int32_t threadId = 0)
+      : CuptiActivity(activity, linked), threadId_(threadId) {}
+
+  int64_t timestamp() const override {
+#if defined(_WIN32) || CUDA_VERSION < 11060
+    return activity_.start;
+#else
+    if (use_cupti_tsc()) {
+      return get_time_converter()(activity_.start);
+    } else {
+      return activity_.start;
+    }
+#endif
+  }
+
+  int64_t duration() const override {
+#if defined(_WIN32) || CUDA_VERSION < 11060
+    return activity_.end - activity_.start;
+#else
+    if (use_cupti_tsc()) {
+      return get_time_converter()(activity_.end) -
+          get_time_converter()(activity_.start);
+    } else {
+      return activity_.end - activity_.start;
+    }
+#endif
+  }
+
+  // TODO: Update this with PID ordering
+  int64_t deviceId() const override {
+    return -1;
+  }
+  int64_t resourceId() const override {
+    return threadId_;
+  }
+  ActivityType type() const override {
+    return ActivityType::OVERHEAD;
+  }
+  bool flowStart() const override;
+  const std::string name() const override {
+    return overheadKindString(activity_.overheadKind);
+  }
+  void log(ActivityLogger& logger) const override;
+  const std::string metadataJson() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
+
+ private:
+  const int32_t threadId_;
+};
+
+// CUpti_ActivitySynchronization - CUDA synchronization events
+struct CudaSyncActivity : public CuptiActivity<CUpti_ActivitySynchronization> {
+  explicit CudaSyncActivity(
+      const CUpti_ActivitySynchronization* activity,
+      const ITraceActivity* linked,
+      int32_t srcStream,
+      int32_t srcCorrId)
+      : CuptiActivity(activity, linked),
+        srcStream_(srcStream),
+        srcCorrId_(srcCorrId) {}
+  int64_t correlationId() const override {
+    return raw().correlationId;
+  }
+  int64_t deviceId() const override;
+  int64_t resourceId() const override;
+  ActivityType type() const override {
+    return ActivityType::CUDA_SYNC;
+  }
+  bool flowStart() const override {
+    return false;
+  }
+  const std::string name() const override;
+  void log(ActivityLogger& logger) const override;
+  const std::string metadataJson() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
+  const CUpti_ActivitySynchronization& raw() const {
+    return CuptiActivity<CUpti_ActivitySynchronization>::raw();
+  }
+
+ private:
+  const int32_t srcStream_;
+  const int32_t srcCorrId_;
+};
+
+// Use CUpti_ActivityCudaEvent2 in CUDA 12.8+ for enhanced event tracking
+#if CUDA_VERSION >= 12080
+using CUpti_ActivityCudaEventType = CUpti_ActivityCudaEvent2;
+#else
+using CUpti_ActivityCudaEventType = CUpti_ActivityCudaEvent;
+#endif
+
+// Template specialization for timestamp() and duration() for CudaEvent types
+template <>
+inline int64_t CuptiActivity<CUpti_ActivityCudaEventType>::timestamp() const {
+#if CUDA_VERSION >= 12080
+#if defined(_WIN32)
+  return activity_.deviceTimestamp;
+#else
+  if (use_cupti_tsc()) {
+    return get_time_converter()(activity_.deviceTimestamp);
+  } else {
+    return activity_.deviceTimestamp;
+  }
+#endif
+#else
+  // For CUDA < 12.8, deviceTimestamp doesn't exist, set to 0
+  return 0;
+#endif
+}
+
+template <>
+inline int64_t CuptiActivity<CUpti_ActivityCudaEventType>::duration() const {
+  // Set duration to 1 to make events visible in trace
+  return 1;
+}
+
+// CUpti_ActivityCudaEvent - CUDA event activities
+struct CudaEventActivity : public CuptiActivity<CUpti_ActivityCudaEventType> {
+  explicit CudaEventActivity(
+      const CUpti_ActivityCudaEventType* activity,
+      const ITraceActivity* linked)
+      : CuptiActivity(activity, linked) {}
+
+  int64_t correlationId() const override {
+    return raw().correlationId;
+  }
+  int64_t deviceId() const override;
+  int64_t resourceId() const override;
+  ActivityType type() const override {
+    return ActivityType::CUDA_EVENT;
+  }
+  bool flowStart() const override {
+    return false;
+  }
+  const std::string name() const override;
+  void log(ActivityLogger& logger) const override;
+  const std::string metadataJson() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
+  const CUpti_ActivityCudaEventType& raw() const {
+    return CuptiActivity<CUpti_ActivityCudaEventType>::raw();
+  }
+};
+
+// Base class for GPU activities.
+// Can also be instantiated directly.
+template <class T>
+struct GpuActivity : public CuptiActivity<T> {
+  explicit GpuActivity(const T* activity, const ITraceActivity* linked)
+      : CuptiActivity<T>(activity, linked) {}
+  int64_t correlationId() const override {
+    return raw().correlationId;
+  }
+  int64_t deviceId() const override {
+    return raw().deviceId;
+  }
+  int64_t resourceId() const override {
+    return raw().streamId;
+  }
+  ActivityType type() const override;
+  bool flowStart() const override {
+    return false;
+  }
+  const std::string name() const override;
+  void log(ActivityLogger& logger) const override;
+  const std::string metadataJson() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
+  const T& raw() const {
+    return CuptiActivity<T>::raw();
+  }
+};
+
+// forward declaration
+uint32_t contextIdtoDeviceId(uint32_t contextId);
+
+template <>
+inline const std::string GpuActivity<CUpti_ActivityKernelType>::name() const {
+  return demangle(raw().name);
+}
+
+template <>
+inline ActivityType GpuActivity<CUpti_ActivityKernelType>::type() const {
+  return ActivityType::CONCURRENT_KERNEL;
+}
+
+inline bool isWaitEventSync(CUpti_ActivitySynchronizationType type) {
+  return (type == CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT);
+}
+
+inline bool isEventSync(CUpti_ActivitySynchronizationType type) {
+  return (
+      type == CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_EVENT_SYNCHRONIZE ||
+      type == CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT);
+}
+
+inline int32_t streamIdForTrace(uint32_t streamId) {
+  // CUPTI uses all bits set when no stream applies. Preserve the legacy trace
+  // representation where that sentinel appears as -1 instead of 4294967295.
+  if (streamId == static_cast<uint32_t>(CUPTI_SYNCHRONIZATION_INVALID_VALUE)) {
+    return -1;
+  }
+  return static_cast<int32_t>(streamId);
+}
+
+inline const std::string CudaSyncActivity::name() const {
+  return syncTypeString(raw().type);
+}
+
+inline int64_t CudaSyncActivity::deviceId() const {
+  return contextIdtoDeviceId(raw().contextId);
+}
+
+inline int64_t CudaSyncActivity::resourceId() const {
+  return streamIdForTrace(raw().streamId);
+}
+
+inline void CudaSyncActivity::log(ActivityLogger& logger) const {
+  logger.handleActivity(*this);
+}
+
+inline const std::string CudaSyncActivity::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+inline void CudaSyncActivity::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  const CUpti_ActivitySynchronization& sync = raw();
+  visitor.visit(
+      CudaMetadataFields::kCudaSyncKind,
+      std::string{syncTypeString(sync.type)});
+  if (isEventSync(sync.type)) {
+    visitor.visit(
+        CudaMetadataFields::kWaitOnStream, static_cast<int64_t>(srcStream_));
+    visitor.visit(
+        CudaMetadataFields::kWaitOnCudaEventRecordCorrId,
+        static_cast<int64_t>(srcCorrId_));
+    visitor.visit(
+        CudaMetadataFields::kWaitOnCudaEventId,
+        static_cast<uint64_t>(sync.cudaEventId));
+  }
+  visitor.visit(
+      CudaMetadataFields::kStream,
+      static_cast<int64_t>(streamIdForTrace(sync.streamId)));
+  visitor.visit(
+      CudaMetadataFields::kCorrelation,
+      static_cast<uint64_t>(sync.correlationId));
+  visitor.visit(CudaMetadataFields::kDevice, deviceId());
+  visitor.visit(
+      CudaMetadataFields::kContext, static_cast<uint64_t>(sync.contextId));
+}
+
+inline const std::string CudaEventActivity::name() const {
+  return "cudaEvent";
+}
+
+inline int64_t CudaEventActivity::deviceId() const {
+  return contextIdtoDeviceId(raw().contextId);
+}
+
+inline int64_t CudaEventActivity::resourceId() const {
+  return streamIdForTrace(raw().streamId);
+}
+
+inline void CudaEventActivity::log(ActivityLogger& logger) const {
+  logger.handleActivity(*this);
+}
+
+inline const std::string CudaEventActivity::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+inline void CudaEventActivity::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  const CUpti_ActivityCudaEventType& event = raw();
+  visitor.visit(
+      CudaMetadataFields::kEventId, static_cast<uint64_t>(event.eventId));
+  visitor.visit(
+      CudaMetadataFields::kStream,
+      static_cast<int64_t>(streamIdForTrace(event.streamId)));
+  visitor.visit(
+      CudaMetadataFields::kCorrelation,
+      static_cast<uint64_t>(event.correlationId));
+  visitor.visit(CudaMetadataFields::kDevice, deviceId());
+  visitor.visit(
+      CudaMetadataFields::kContext, static_cast<uint64_t>(event.contextId));
+}
+
+template <class T>
+inline void GpuActivity<T>::log(ActivityLogger& logger) const {
+  logger.handleActivity(*this);
+}
+
+constexpr int64_t us(int64_t timestamp) {
+  // It's important that this conversion is the same here and in the CPU trace.
+  // No rounding!
+  return timestamp / 1000;
+}
+
+template <class T>
+inline void addGraphNodeTypedMetadata(
+    [[maybe_unused]] ITypedMetadataVisitor& visitor,
+    [[maybe_unused]] const T& activity) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+  visitor.visit(
+      CudaMetadataFields::kGraphId, static_cast<uint64_t>(activity.graphId));
+  visitor.visit(
+      CudaMetadataFields::kGraphNodeId,
+      static_cast<uint64_t>(activity.graphNodeId));
+#endif
+}
+
+template <class T>
+inline void addPriorityTypedMetadata(
+    [[maybe_unused]] ITypedMetadataVisitor& visitor,
+    [[maybe_unused]] const T& kernel) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 13010
+  visitor.visit(
+      CudaMetadataFields::kPriority, static_cast<int64_t>(kernel.priority));
+#endif
+}
+
+template <class T>
+inline void addChannelTypedMetadata(
+    [[maybe_unused]] ITypedMetadataVisitor& visitor,
+    [[maybe_unused]] const T& activity) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+  visitor.visit(
+      CudaMetadataFields::kChannel, static_cast<uint64_t>(activity.channelID));
+  visitor.visit(
+      CudaMetadataFields::kChannelType,
+      static_cast<int64_t>(activity.channelType));
+#endif
+}
+
+inline void addBandwidthTypedMetadata(
+    [[maybe_unused]] ITypedMetadataVisitor& visitor,
+    uint64_t bytes,
+    int64_t duration) {
+  if (duration == 0) {
+    return;
+  }
+  visitor.visit(
+      CudaMetadataFields::kMemoryBandwidthGbps,
+      static_cast<double>(bytes) / static_cast<double>(duration));
+}
+
+// Convert limitingFactors bitmask to human-readable string
+// Based on cudaOccLimitingFactor enum from cuda_occupancy.h
+// This can be found in the CUDA toolkit typically
+// /usr/local/cuda/targets/x86_64-linux/include/cuda_occupancy.h
+inline std::string limitingFactorsToString(unsigned int factors) {
+  if (factors == 0) {
+    return "none";
+  }
+  constexpr std::pair<unsigned int, const char*> kFactors[] = {
+      {OCC_LIMIT_WARPS, "WARPS"},
+      {OCC_LIMIT_REGISTERS, "REGS"},
+      {OCC_LIMIT_SHARED_MEMORY, "SMEM"},
+      {OCC_LIMIT_BLOCKS, "BLOCKS"},
+      {OCC_LIMIT_BARRIERS, "BARRIERS"},
+  };
+  std::string result;
+  for (const auto& [mask, name] : kFactors) {
+    if (factors & mask) {
+      if (!result.empty()) {
+        result += "|";
+      }
+      result += name;
+    }
+  }
+  return result;
+}
+
+template <>
+inline void GpuActivity<CUpti_ActivityKernelType>::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  const CUpti_ActivityKernelType& kernel = raw();
+  const float blocksPerSmVal = blocksPerSm(kernel);
+  const float warpsPerSmVal = warpsPerSm(kernel);
+  const OccupancyMetrics occMetrics = computeOccupancyMetrics(kernel);
+
+  visitor.visit(
+      CudaMetadataFields::kQueued, static_cast<uint64_t>(kernel.queued));
+  visitor.visit(
+      CudaMetadataFields::kDevice, static_cast<int64_t>(kernel.deviceId));
+  visitor.visit(
+      CudaMetadataFields::kContext, static_cast<uint64_t>(kernel.contextId));
+  visitor.visit(
+      CudaMetadataFields::kStream, static_cast<int64_t>(kernel.streamId));
+  visitor.visit(
+      CudaMetadataFields::kCorrelation,
+      static_cast<uint64_t>(kernel.correlationId));
+  visitor.visit(
+      CudaMetadataFields::kRegistersPerThread,
+      static_cast<uint64_t>(kernel.registersPerThread));
+  visitor.visit(
+      CudaMetadataFields::kSharedMemory,
+      static_cast<int64_t>(
+          kernel.staticSharedMemory + kernel.dynamicSharedMemory));
+  visitor.visit(
+      CudaMetadataFields::kBlocksPerSm, static_cast<double>(blocksPerSmVal));
+  visitor.visit(
+      CudaMetadataFields::kWarpsPerSm, static_cast<double>(warpsPerSmVal));
+  visitor.visit(
+      CudaMetadataFields::kGrid,
+      std::vector<int64_t>{
+          static_cast<int64_t>(kernel.gridX),
+          static_cast<int64_t>(kernel.gridY),
+          static_cast<int64_t>(kernel.gridZ)});
+  visitor.visit(
+      CudaMetadataFields::kBlock,
+      std::vector<int64_t>{
+          static_cast<int64_t>(kernel.blockX),
+          static_cast<int64_t>(kernel.blockY),
+          static_cast<int64_t>(kernel.blockZ)});
+  visitor.visit(
+      CudaMetadataFields::kEstAchievedOccupancyPercent,
+      static_cast<int64_t>(std::lround(occMetrics.occupancy * 100.0)));
+  visitor.visit(CudaMetadataFields::kOccupancy, [&](auto& d) {
+    d.visit(
+        CudaMetadataFields::kActiveBlocksPerMultiprocessor,
+        static_cast<int64_t>(occMetrics.result.activeBlocksPerMultiprocessor));
+    d.visit(
+        CudaMetadataFields::kLimitingFactors,
+        limitingFactorsToString(occMetrics.result.limitingFactors));
+    d.visit(
+        CudaMetadataFields::kBlockLimitRegs,
+        static_cast<int64_t>(occMetrics.result.blockLimitRegs));
+    d.visit(
+        CudaMetadataFields::kBlockLimitSharedMem,
+        static_cast<int64_t>(occMetrics.result.blockLimitSharedMem));
+    d.visit(
+        CudaMetadataFields::kBlockLimitWarps,
+        static_cast<int64_t>(occMetrics.result.blockLimitWarps));
+    d.visit(
+        CudaMetadataFields::kBlockLimitBlocks,
+        static_cast<int64_t>(occMetrics.result.blockLimitBlocks));
+    d.visit(
+        CudaMetadataFields::kBlockLimitBarriers,
+        static_cast<int64_t>(occMetrics.result.blockLimitBarriers));
+    d.visit(
+        CudaMetadataFields::kAllocatedRegistersPerBlock,
+        static_cast<int64_t>(occMetrics.result.allocatedRegistersPerBlock));
+    d.visit(
+        CudaMetadataFields::kAllocatedSharedMemPerBlock,
+        static_cast<uint64_t>(occMetrics.result.allocatedSharedMemPerBlock));
+  });
+  addGraphNodeTypedMetadata(visitor, kernel);
+  addPriorityTypedMetadata(visitor, kernel);
+  addChannelTypedMetadata(visitor, kernel);
+}
+
+template <>
+inline const std::string GpuActivity<CUpti_ActivityKernelType>::metadataJson()
+    const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+inline std::string memcpyName(uint8_t kind, uint8_t src, uint8_t dst) {
+  return fmt::format(
+      "Memcpy {} ({} -> {})",
+      memcpyKindString((CUpti_ActivityMemcpyKind)kind),
+      memoryKindString((CUpti_ActivityMemoryKind)src),
+      memoryKindString((CUpti_ActivityMemoryKind)dst));
+}
+
+template <>
+inline ActivityType GpuActivity<CUpti_ActivityMemcpyType>::type() const {
+  return ActivityType::GPU_MEMCPY;
+}
+
+template <>
+inline const std::string GpuActivity<CUpti_ActivityMemcpyType>::name() const {
+  return memcpyName(raw().copyKind, raw().srcKind, raw().dstKind);
+}
+
+template <>
+inline void GpuActivity<CUpti_ActivityMemcpyType>::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  const CUpti_ActivityMemcpyType& memcpy = raw();
+  visitor.visit(
+      CudaMetadataFields::kDevice, static_cast<int64_t>(memcpy.deviceId));
+  visitor.visit(
+      CudaMetadataFields::kContext, static_cast<uint64_t>(memcpy.contextId));
+  visitor.visit(
+      CudaMetadataFields::kStream, static_cast<int64_t>(memcpy.streamId));
+  visitor.visit(
+      CudaMetadataFields::kCorrelation,
+      static_cast<uint64_t>(memcpy.correlationId));
+  visitor.visit(
+      CudaMetadataFields::kBytes, static_cast<uint64_t>(memcpy.bytes));
+  addBandwidthTypedMetadata(visitor, memcpy.bytes, duration());
+  addGraphNodeTypedMetadata(visitor, memcpy);
+  addChannelTypedMetadata(visitor, memcpy);
+}
+
+template <>
+inline const std::string GpuActivity<CUpti_ActivityMemcpyType>::metadataJson()
+    const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+template <>
+inline ActivityType GpuActivity<CUpti_ActivityMemcpyPtoPType>::type() const {
+  return ActivityType::GPU_MEMCPY;
+}
+
+template <>
+inline const std::string GpuActivity<CUpti_ActivityMemcpyPtoPType>::name()
+    const {
+  return memcpyName(raw().copyKind, raw().srcKind, raw().dstKind);
+}
+
+template <>
+inline void GpuActivity<CUpti_ActivityMemcpyPtoPType>::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  const CUpti_ActivityMemcpyPtoPType& memcpy = raw();
+  visitor.visit(
+      CudaMetadataFields::kFromDevice,
+      static_cast<uint64_t>(memcpy.srcDeviceId));
+  visitor.visit(
+      CudaMetadataFields::kInDevice, static_cast<uint64_t>(memcpy.deviceId));
+  visitor.visit(
+      CudaMetadataFields::kToDevice, static_cast<uint64_t>(memcpy.dstDeviceId));
+  visitor.visit(
+      CudaMetadataFields::kFromContext,
+      static_cast<uint64_t>(memcpy.srcContextId));
+  visitor.visit(
+      CudaMetadataFields::kInContext, static_cast<uint64_t>(memcpy.contextId));
+  visitor.visit(
+      CudaMetadataFields::kToContext,
+      static_cast<uint64_t>(memcpy.dstContextId));
+  visitor.visit(
+      CudaMetadataFields::kStream, static_cast<int64_t>(memcpy.streamId));
+  visitor.visit(
+      CudaMetadataFields::kCorrelation,
+      static_cast<uint64_t>(memcpy.correlationId));
+  visitor.visit(
+      CudaMetadataFields::kBytes, static_cast<uint64_t>(memcpy.bytes));
+  addBandwidthTypedMetadata(visitor, memcpy.bytes, duration());
+  addGraphNodeTypedMetadata(visitor, memcpy);
+  addChannelTypedMetadata(visitor, memcpy);
+}
+
+template <>
+inline const std::string GpuActivity<
+    CUpti_ActivityMemcpyPtoPType>::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+template <>
+inline const std::string GpuActivity<CUpti_ActivityMemsetType>::name() const {
+  const char* memory_kind =
+      memoryKindString((CUpti_ActivityMemoryKind)raw().memoryKind);
+  return fmt::format("Memset ({})", memory_kind);
+}
+
+template <>
+inline ActivityType GpuActivity<CUpti_ActivityMemsetType>::type() const {
+  return ActivityType::GPU_MEMSET;
+}
+
+template <>
+inline void GpuActivity<CUpti_ActivityMemsetType>::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  const CUpti_ActivityMemsetType& memset = raw();
+  visitor.visit(
+      CudaMetadataFields::kDevice, static_cast<int64_t>(memset.deviceId));
+  visitor.visit(
+      CudaMetadataFields::kContext, static_cast<uint64_t>(memset.contextId));
+  visitor.visit(
+      CudaMetadataFields::kStream, static_cast<int64_t>(memset.streamId));
+  visitor.visit(
+      CudaMetadataFields::kCorrelation,
+      static_cast<uint64_t>(memset.correlationId));
+  visitor.visit(
+      CudaMetadataFields::kBytes, static_cast<uint64_t>(memset.bytes));
+  addBandwidthTypedMetadata(visitor, memset.bytes, duration());
+  addGraphNodeTypedMetadata(visitor, memset);
+  addChannelTypedMetadata(visitor, memset);
+}
+
+template <>
+inline const std::string GpuActivity<CUpti_ActivityMemsetType>::metadataJson()
+    const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+inline void RuntimeActivity::log(ActivityLogger& logger) const {
+  logger.handleActivity(*this);
+}
+
+inline void DriverActivity::log(ActivityLogger& logger) const {
+  logger.handleActivity(*this);
+}
+
+inline void OverheadActivity::log(ActivityLogger& logger) const {
+  logger.handleActivity(*this);
+}
+
+inline bool OverheadActivity::flowStart() const {
+  return false;
+}
+
+inline const std::string OverheadActivity::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+inline void OverheadActivity::visitTypedMetadata(
+    [[maybe_unused]] ITypedMetadataVisitor& visitor) const {}
+
+inline bool RuntimeActivity::flowStart() const {
+  return CuptiCbidRegistry::instance().requiresFlowCorrelation(
+      CallbackDomain::RUNTIME, activity_.cbid);
+}
+
+inline const std::string RuntimeActivity::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+inline void RuntimeActivity::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  visitor.visit(
+      CudaMetadataFields::kCbid, static_cast<uint64_t>(activity_.cbid));
+  visitor.visit(
+      CudaMetadataFields::kCorrelation,
+      static_cast<uint64_t>(activity_.correlationId));
+}
+
+inline bool isTrackedDriverCbid(const CUpti_ActivityAPI& activity_) {
+  return CuptiCbidRegistry::instance().isRegistered(
+      CallbackDomain::DRIVER, activity_.cbid);
+}
+
+inline bool DriverActivity::flowStart() const {
+  return CuptiCbidRegistry::instance().requiresFlowCorrelation(
+      CallbackDomain::DRIVER, activity_.cbid);
+}
+
+inline const std::string DriverActivity::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+inline void DriverActivity::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  visitor.visit(
+      CudaMetadataFields::kCbid, static_cast<uint64_t>(activity_.cbid));
+  visitor.visit(
+      CudaMetadataFields::kCorrelation,
+      static_cast<uint64_t>(activity_.correlationId));
+}
+
+inline const std::string DriverActivity::name() const {
+  return driverCbidName(activity_.cbid);
+}
+
+template <class T>
+inline const std::string GpuActivity<T>::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+template <class T>
+inline void GpuActivity<T>::visitTypedMetadata(
+    [[maybe_unused]] ITypedMetadataVisitor& visitor) const {}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/CuptiActivityApi.cpp
+++ b/third_party/kineto/libkineto/src/CuptiActivityApi.cpp
@@ -1,0 +1,485 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CuptiActivityApi.h"
+
+#include <chrono>
+#include <mutex>
+#include <thread>
+
+#include "DeviceUtil.h"
+#include "Logger.h"
+
+using namespace std::chrono;
+
+namespace KINETO_NAMESPACE {
+
+// Set to 4MB to avoid constantly creating buffers (especially for networks
+// that have many small memcpy such as sparseNN). CUPTI recommends between
+// 1MB to 10MB.
+// Given the kDefaultActivitiesMaxGpuBufferSize is around 128MB, in the worst
+// case, there will be 32 buffers contending for the mutex.
+constexpr size_t kBufSize(4 * 1024 * 1024);
+
+inline bool cuptiTearDown_() {
+  auto teardown_env = getenv("TEARDOWN_CUPTI");
+  return teardown_env != nullptr && strcmp(teardown_env, "1") == 0;
+}
+
+inline bool cuptiLazyInit_() {
+  return cuptiTearDown_() && getenv("DISABLE_CUPTI_LAZY_REINIT") == nullptr;
+}
+
+inline void reenableCuptiCallbacks_(CuptiCallbackApi& cbapi) {
+  // Re-enable callbacks from the past if they exist.
+  LOG(INFO) << "Re-enable previous CUPTI callbacks - Starting";
+  VLOG(1) << "  CUPTI subscriber before reinit:" << cbapi.getCuptiSubscriber();
+  cbapi.initCallbackApi();
+  if (cbapi.initSuccess()) {
+    VLOG(1) << "  CUPTI subscriber after reinit:" << cbapi.getCuptiSubscriber();
+    bool status = cbapi.reenableCallbacks();
+    if (!status) {
+      LOG(WARNING)
+          << "Re-enable previous CUPTI callbacks - Failed to reenableCallbacks";
+    } else {
+      LOG(INFO) << "Re-enable previous CUPTI callbacks - Successful";
+    }
+  } else {
+    LOG(WARNING)
+        << "Re-enable previous CUPTI callbacks - Failed to initCallbackApi";
+  }
+}
+
+CuptiActivityApi& CuptiActivityApi::singleton() {
+  static auto* instance = new CuptiActivityApi();
+  return *instance;
+}
+
+void CuptiActivityApi::pushCorrelationID(int id, CorrelationFlowType type) {
+  if (!singleton().externalCorrelationEnabled_.load(
+          std::memory_order_relaxed)) {
+    return;
+  }
+  VLOG(2) << "pushCorrelationID(" << id << ")";
+  switch (type) {
+    case Default:
+      CUPTI_CALL(cuptiActivityPushExternalCorrelationId(
+          CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM0, id));
+      break;
+    case User:
+      CUPTI_CALL(cuptiActivityPushExternalCorrelationId(
+          CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM1, id));
+  }
+}
+
+void CuptiActivityApi::popCorrelationID(CorrelationFlowType type) {
+  if (!singleton().externalCorrelationEnabled_.load(
+          std::memory_order_relaxed)) {
+    return;
+  }
+  switch (type) {
+    case Default:
+      CUPTI_CALL(cuptiActivityPopExternalCorrelationId(
+          CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM0, nullptr));
+      break;
+    case User:
+      CUPTI_CALL(cuptiActivityPopExternalCorrelationId(
+          CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM1, nullptr));
+  }
+}
+
+static bool nextActivityRecord(
+    uint8_t* buffer,
+    size_t valid_size,
+    CUpti_Activity*& record) {
+  CUptiResult status = CUPTI_CALL_NOWARN(
+      cuptiActivityGetNextRecord(buffer, valid_size, &record));
+  if (status != CUPTI_SUCCESS) {
+    if (status != CUPTI_ERROR_MAX_LIMIT_REACHED) {
+      CUPTI_CALL(status);
+    }
+    record = nullptr;
+  }
+  return record != nullptr;
+}
+
+void CuptiActivityApi::setMaxBufferSize(int64_t size) {
+  maxGpuBufferCount_ = 1 + size / kBufSize;
+}
+
+void CuptiActivityApi::setDeviceBufferSize(size_t size) {
+  size_t valueSize = sizeof(size_t);
+  CUPTI_CALL(cuptiActivitySetAttribute(
+      CUPTI_ACTIVITY_ATTR_DEVICE_BUFFER_SIZE, &valueSize, &size));
+}
+
+void CuptiActivityApi::setDeviceBufferPoolLimit(size_t limit) {
+  size_t valueSize = sizeof(size_t);
+  CUPTI_CALL(cuptiActivitySetAttribute(
+      CUPTI_ACTIVITY_ATTR_DEVICE_BUFFER_POOL_LIMIT, &valueSize, &limit));
+}
+
+void CuptiActivityApi::forceLoadCupti() {
+  CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
+}
+
+void CuptiActivityApi::preConfigureCUPTI() {
+  if (!isGpuAvailable()) {
+    return;
+  }
+}
+
+void CUPTIAPI CuptiActivityApi::bufferRequestedTrampoline(
+    uint8_t** buffer,
+    size_t* size,
+    size_t* maxNumRecords) {
+  singleton().bufferRequested(buffer, size, maxNumRecords);
+}
+
+void CuptiActivityApi::bufferRequested(
+    uint8_t** buffer,
+    size_t* size,
+    size_t* maxNumRecords) {
+  std::lock_guard<std::mutex> guard(mutex_);
+  LOG(VERBOSE) << "CUPTI buffer requested";
+  if (static_cast<int64_t>(allocatedGpuTraceBuffers_.size()) >=
+      maxGpuBufferCount_) {
+    stopCollection = true;
+    LOG(WARNING) << "Exceeded max GPU buffer count ("
+                 << allocatedGpuTraceBuffers_.size()
+                 << " >= " << maxGpuBufferCount_ << ") - terminating tracing";
+    // Return null buffer to CUPTI. Per the CUPTI documentation for
+    // CUpti_BuffersCallbackRequestFunc: "If set to NULL then no buffer is
+    // returned." CUPTI will drop activity records, which are counted by
+    // cuptiActivityGetNumDroppedRecords.
+    *buffer = nullptr;
+    *size = 0;
+    *maxNumRecords = 0;
+    return;
+  }
+
+  auto buf = std::make_unique<CuptiActivityBuffer>(kBufSize);
+  *buffer = buf->data();
+  *size = kBufSize;
+
+  allocatedGpuTraceBuffers_[*buffer] = std::move(buf);
+
+  *maxNumRecords = 0;
+}
+
+std::unique_ptr<CuptiActivityBufferMap> CuptiActivityApi::activityBuffers() {
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (allocatedGpuTraceBuffers_.empty()) {
+      if (readyGpuTraceBuffers_) {
+        return std::move(readyGpuTraceBuffers_);
+      }
+      return nullptr;
+    }
+  }
+
+  VLOG(1) << "Flushing GPU activity buffers";
+  time_point<system_clock> t1;
+  if (VLOG_IS_ON(1)) {
+    t1 = system_clock::now();
+  }
+  // Can't hold mutex_ during this call, since bufferCompleted
+  // will be called by libcupti and mutex_ is acquired there.
+  CUPTI_CALL(cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED));
+  if (VLOG_IS_ON(1)) {
+    flushOverhead =
+        duration_cast<microseconds>(system_clock::now() - t1).count();
+  }
+
+#if (CUDART_VERSION >= 12030)
+  // Clear out per-thread buffer flag in case it was set
+  uint8_t value = 0;
+  size_t sizeof_value = sizeof(value);
+
+  CUPTI_CALL(cuptiActivitySetAttribute(
+      CUPTI_ACTIVITY_ATTR_PER_THREAD_ACTIVITY_BUFFER, &sizeof_value, &value));
+#endif // (CUDART_VERSION >= 12030)
+  std::lock_guard<std::mutex> guard(mutex_);
+  // Transfer ownership of buffers to caller. A new map is created on-demand.
+  return std::move(readyGpuTraceBuffers_);
+}
+
+int CuptiActivityApi::processActivitiesForBuffer(
+    uint8_t* buf,
+    size_t validSize,
+    const std::function<void(const CUpti_Activity*)>& handler) {
+  int count = 0;
+  if (buf && validSize) {
+    CUpti_Activity* record{nullptr};
+    while ((nextActivityRecord(buf, validSize, record))) {
+      handler(record);
+      ++count;
+    }
+  }
+  return count;
+}
+
+const std::pair<int, size_t> CuptiActivityApi::processActivities(
+    CuptiActivityBufferMap& buffers,
+    const std::function<void(const CUpti_Activity*)>& handler) {
+  std::pair<int, size_t> res{0, 0};
+  for (auto& pair : buffers) {
+    // No lock needed - only accessed from this thread
+    auto& buf = pair.second;
+    res.first += processActivitiesForBuffer(buf->data(), buf->size(), handler);
+    res.second += buf->size();
+  }
+  return res;
+}
+
+void CuptiActivityApi::flushActivities() {
+  CUPTI_CALL(cuptiActivityFlushAll(0));
+}
+
+void CuptiActivityApi::clearActivities() {
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (allocatedGpuTraceBuffers_.empty()) {
+      return;
+    }
+  }
+  // Can't hold mutex_ during this call, since bufferCompleted
+  // will be called by libcupti and mutex_ is acquired there.
+  CUPTI_CALL(cuptiActivityFlushAll(0));
+  // FIXME: We might want to make sure we reuse
+  // the same memory during warmup and tracing.
+  // Also, try to use the amount of memory required
+  // for active tracing during warmup.
+  std::lock_guard<std::mutex> guard(mutex_);
+  // Throw away ready buffers as a result of above flush
+  readyGpuTraceBuffers_ = nullptr;
+}
+
+void CUPTIAPI CuptiActivityApi::bufferCompletedTrampoline(
+    CUcontext ctx,
+    uint32_t streamId,
+    uint8_t* buffer,
+    size_t /* unused */,
+    size_t validSize) {
+  singleton().bufferCompleted(ctx, streamId, buffer, 0, validSize);
+}
+
+void CuptiActivityApi::bufferCompleted(
+    CUcontext ctx,
+    uint32_t streamId,
+    uint8_t* buffer,
+    size_t /* unused */,
+    size_t validSize) {
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto it = allocatedGpuTraceBuffers_.find(buffer);
+    if (it == allocatedGpuTraceBuffers_.end()) {
+      LOG(ERROR) << "bufferCompleted called with unknown buffer: "
+                 << static_cast<void*>(buffer);
+      return;
+    }
+
+    if (!readyGpuTraceBuffers_) {
+      readyGpuTraceBuffers_ = std::make_unique<CuptiActivityBufferMap>();
+    }
+    // Set valid size of buffer before moving to ready map
+    it->second->setSize(validSize);
+    (*readyGpuTraceBuffers_)[it->first] = std::move(it->second);
+    allocatedGpuTraceBuffers_.erase(it);
+  }
+
+  // report any records dropped from the queue; to avoid unnecessary cupti
+  // API calls, we make it report only in verbose mode (it doesn't happen
+  // often in our testing anyways)
+  // Can't hold mutex_ during this call, since cuptiActivityGetNumDroppedRecords
+  // re-enters CUPTI and can acquire CUPTI's internal lock, while CUPTI
+  // callbacks (e.g. bufferRequested) acquire mutex_ under that same lock -
+  // causing an ABBA deadlock in multi-threaded environments (e.g. free-threaded
+  // Python).
+  if (VLOG_IS_ON(1)) {
+    size_t dropped = 0;
+    CUPTI_CALL(cuptiActivityGetNumDroppedRecords(ctx, streamId, &dropped));
+    if (dropped != 0) {
+      LOG(WARNING) << "Dropped " << dropped << " activity records";
+    }
+  }
+}
+
+void CuptiActivityApi::enableCuptiActivities(
+    const std::set<ActivityType>& selected_activities,
+    bool enablePerThreadBuffers) {
+  // Lazily support re-init of CUPTI Callbacks, if they were finalized before.
+  auto& cbapi = CuptiCallbackApi::singleton();
+  if ((tracingEnabled_ == 0u) && !cbapi.initSuccess() && cuptiLazyInit_()) {
+    reenableCuptiCallbacks_(cbapi);
+  }
+
+  if (enablePerThreadBuffers) {
+#if (CUDART_VERSION >= 12030)
+    uint8_t value = 1;
+    size_t sizeof_value = sizeof(value);
+    LOG(INFO) << ("Enabling per-thread activity buffer");
+    CUPTI_CALL(cuptiActivitySetAttribute(
+        CUPTI_ACTIVITY_ATTR_PER_THREAD_ACTIVITY_BUFFER, &sizeof_value, &value));
+#else
+    LOG(WARNING) << "Per-thread activity buffer is not supported on CUDA";
+#endif // (CUDART_VERSION >= 12030)
+  } else {
+    LOG(VERBOSE) << ("Not enabling per-thread activity buffer");
+  }
+
+  CUPTI_CALL(cuptiActivityRegisterCallbacks(
+      bufferRequestedTrampoline, bufferCompletedTrampoline));
+
+  externalCorrelationEnabled_.store(false, std::memory_order_relaxed);
+  using enum ActivityType;
+  for (const auto& activity : selected_activities) {
+    if (activity == GPU_MEMCPY) {
+      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY));
+    }
+    if (activity == GPU_MEMSET) {
+      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMSET));
+    }
+    if (activity == CONCURRENT_KERNEL) {
+      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
+    }
+    if (activity == EXTERNAL_CORRELATION) {
+      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION));
+      externalCorrelationEnabled_.store(true, std::memory_order_relaxed);
+    }
+    if (activity == CUDA_SYNC) {
+#if CUDA_VERSION >= 13000
+      CUPTI_CALL(cuptiActivityEnableCudaEventDeviceTimestamps(true));
+#endif
+      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
+    }
+    if (activity == CUDA_RUNTIME) {
+      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_RUNTIME));
+#if (CUDART_VERSION >= 12050)
+      CUPTI_CALL(cuptiActivityEnableRuntimeApi(
+          CUPTI_RUNTIME_TRACE_CBID_cudaGetDevice_v3020, 0));
+#endif
+    }
+    if (activity == CUDA_DRIVER) {
+      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_DRIVER));
+#if (CUDART_VERSION >= 12050)
+      CUPTI_CALL(cuptiActivityEnableDriverApi(
+          CUPTI_DRIVER_TRACE_CBID_cuKernelGetAttribute, 0));
+      CUPTI_CALL(cuptiActivityEnableDriverApi(
+          CUPTI_DRIVER_TRACE_CBID_cuDevicePrimaryCtxGetState, 0));
+      CUPTI_CALL(cuptiActivityEnableDriverApi(
+          CUPTI_DRIVER_TRACE_CBID_cuCtxGetCurrent, 0));
+#endif
+    }
+    if (activity == OVERHEAD) {
+      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_OVERHEAD));
+    }
+  }
+
+  tracingEnabled_ = 1;
+
+  // Explicitly enabled, so reset this flag if set
+  stopCollection = false;
+}
+
+void CuptiActivityApi::disableCuptiActivities(
+    const std::set<ActivityType>& selected_activities) {
+  using enum ActivityType;
+  for (const auto& activity : selected_activities) {
+    if (activity == GPU_MEMCPY) {
+      CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_MEMCPY));
+    }
+    if (activity == GPU_MEMSET) {
+      CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_MEMSET));
+    }
+    if (activity == CONCURRENT_KERNEL) {
+      CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
+    }
+    if (activity == EXTERNAL_CORRELATION) {
+      CUPTI_CALL(
+          cuptiActivityDisable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION));
+    }
+    if (activity == CUDA_SYNC) {
+      CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
+    }
+    if (activity == CUDA_RUNTIME) {
+      CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_RUNTIME));
+    }
+    if (activity == CUDA_DRIVER) {
+      CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_DRIVER));
+    }
+    if (activity == OVERHEAD) {
+      CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_OVERHEAD));
+    }
+  }
+  externalCorrelationEnabled_.store(false, std::memory_order_relaxed);
+}
+
+void CuptiActivityApi::teardownContext() {
+  if (!tracingEnabled_) {
+    return;
+  }
+  if (tearingDown_) {
+    return;
+  }
+  if (cuptiTearDown_()) {
+    tearingDown_ = 1;
+    LOG(INFO) << "teardownCupti starting";
+
+    // PyTorch Profiler is synchronous, so teardown needs to be run async in
+    // this thread.
+    std::thread teardownThread([&] {
+      auto& cbapi = CuptiCallbackApi::singleton();
+      if (!cbapi.initSuccess()) {
+        cbapi.initCallbackApi();
+        if (!cbapi.initSuccess()) {
+          LOG(WARNING) << "CUPTI Callback failed to init, skipping teardown";
+          tearingDown_ = 0;
+          return;
+        }
+      }
+      // Subscribe callbacks to call cuptiFinalize in the exit callback of these
+      // APIs
+      bool status = cbapi.enableCallbackDomain(CUPTI_CB_DOMAIN_RUNTIME_API);
+      status = status && cbapi.enableCallbackDomain(CUPTI_CB_DOMAIN_DRIVER_API);
+      if (!status) {
+        LOG(WARNING)
+            << "CUPTI Callback failed to enable for domain, skipping teardown";
+        tearingDown_ = 0;
+        return;
+      }
+
+      // Force Flush before finalize
+      CUPTI_CALL(cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED));
+
+      LOG(INFO) << "  CUPTI subscriber before finalize:"
+                << cbapi.getCuptiSubscriber();
+      teardownCupti_ = 1;
+      std::unique_lock<std::mutex> lck(finalizeMutex_);
+      finalizeCond_.wait(lck, [&] { return teardownCupti_ == 0; });
+      lck.unlock();
+      LOG(INFO) << "teardownCupti complete";
+
+      teardownCupti_ = 0;
+      tracingEnabled_ = 0;
+
+      // Remove the callbacks used specifically for cuptiFinalize
+      cbapi.disableCallbackDomain(CUPTI_CB_DOMAIN_RUNTIME_API);
+      cbapi.disableCallbackDomain(CUPTI_CB_DOMAIN_DRIVER_API);
+
+      // Re-init CUPTI Callbacks if Lazy Re-init is not enabled.
+      if (!cuptiLazyInit_()) {
+        reenableCuptiCallbacks_(cbapi);
+      }
+      tearingDown_ = 0;
+    });
+    teardownThread.detach();
+  }
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/CuptiActivityApi.h
+++ b/third_party/kineto/libkineto/src/CuptiActivityApi.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <set>
+
+#include <cupti.h>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ActivityType.h"
+#include "CuptiActivityBuffer.h"
+#include "CuptiCallbackApi.h"
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+
+class CuptiActivityApi {
+ public:
+  enum CorrelationFlowType { Default, User };
+  // Control Variables shared with CuptiCallbackApi for teardown
+  std::atomic<uint32_t> teardownCupti_{0};
+  std::mutex finalizeMutex_;
+  std::condition_variable finalizeCond_;
+
+  CuptiActivityApi() = default;
+  CuptiActivityApi(const CuptiActivityApi&) = delete;
+  CuptiActivityApi& operator=(const CuptiActivityApi&) = delete;
+
+  virtual ~CuptiActivityApi() = default;
+
+  static CuptiActivityApi& singleton();
+
+  static void pushCorrelationID(int id, CorrelationFlowType type);
+  static void popCorrelationID(CorrelationFlowType type);
+
+  void enableCuptiActivities(
+      const std::set<ActivityType>& selected_activities,
+      bool enablePerThreadBuffers = false);
+  void disableCuptiActivities(
+      const std::set<ActivityType>& selected_activities);
+  void clearActivities();
+  void flushActivities();
+  void teardownContext();
+
+  virtual std::unique_ptr<CuptiActivityBufferMap> activityBuffers();
+
+  virtual const std::pair<int, size_t> processActivities(
+      CuptiActivityBufferMap&,
+      const std::function<void(const CUpti_Activity*)>& handler);
+
+  void setMaxBufferSize(int64_t size);
+  void setDeviceBufferSize(size_t size);
+  void setDeviceBufferPoolLimit(size_t limit);
+
+  std::atomic_bool stopCollection{false};
+  int64_t flushOverhead{0};
+
+  static void forceLoadCupti();
+
+  // CUPTI configuraiton that needs to be set before CUDA context creation
+  static void preConfigureCUPTI();
+
+ private:
+  int64_t maxGpuBufferCount_{0};
+  CuptiActivityBufferMap allocatedGpuTraceBuffers_;
+  std::unique_ptr<CuptiActivityBufferMap> readyGpuTraceBuffers_;
+  std::mutex mutex_;
+  std::atomic<uint32_t> tracingEnabled_{0};
+  std::atomic<uint32_t> tearingDown_{0};
+  std::atomic<bool> externalCorrelationEnabled_{false};
+
+  int processActivitiesForBuffer(
+      uint8_t* buf,
+      size_t validSize,
+      const std::function<void(const CUpti_Activity*)>& handler);
+  static void CUPTIAPI bufferRequestedTrampoline(
+      uint8_t** buffer,
+      size_t* size,
+      size_t* maxNumRecords);
+  static void CUPTIAPI bufferCompletedTrampoline(
+      CUcontext ctx,
+      uint32_t streamId,
+      uint8_t* buffer,
+      size_t /* unused */,
+      size_t validSize);
+
+ protected:
+  void bufferRequested(uint8_t** buffer, size_t* size, size_t* maxNumRecords);
+  void bufferCompleted(
+      CUcontext ctx,
+      uint32_t streamId,
+      uint8_t* buffer,
+      size_t /* unused */,
+      size_t validSize);
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/CuptiActivityBuffer.h
+++ b/third_party/kineto/libkineto/src/CuptiActivityBuffer.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <sys/types.h>
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "ITraceActivity.h"
+
+namespace KINETO_NAMESPACE {
+
+class CuptiActivityBuffer {
+ public:
+  explicit CuptiActivityBuffer(size_t size) : size_(size) {
+    buf_.reserve(size);
+  }
+  CuptiActivityBuffer() = delete;
+  CuptiActivityBuffer& operator=(const CuptiActivityBuffer&) = delete;
+  CuptiActivityBuffer(CuptiActivityBuffer&&) = default;
+  CuptiActivityBuffer& operator=(CuptiActivityBuffer&&) = default;
+
+  [[nodiscard]] size_t size() const {
+    return size_;
+  }
+
+  void setSize(size_t size) {
+    assert(size <= buf_.capacity());
+    size_ = size;
+  }
+
+  uint8_t* data() {
+    return buf_.data();
+  }
+
+ private:
+  std::vector<uint8_t> buf_;
+  size_t size_;
+
+  std::vector<std::unique_ptr<const ITraceActivity>> wrappers_;
+};
+
+using CuptiActivityBufferMap =
+    std::map<uint8_t*, std::unique_ptr<CuptiActivityBuffer>>;
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/CuptiActivityProfiler.cpp
+++ b/third_party/kineto/libkineto/src/CuptiActivityProfiler.cpp
@@ -1,0 +1,590 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CuptiActivityProfiler.h"
+#include <cupti.h>
+#include <fmt/format.h>
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "ActivityBuffers.h"
+#include "Config.h"
+#include "CuptiActivity.h"
+#include "CuptiActivityApi.h"
+#include "CuptiCbidRegistry.h"
+#include "Demangle.h"
+#include "DeviceUtil.h"
+#include "KernelRegistry.h"
+#include "Logger.h"
+
+using namespace std::chrono;
+using std::string;
+
+namespace {
+
+struct CtxEventPair {
+  uint32_t ctx = 0;
+  uint32_t eventId = 0;
+
+  bool operator==(const CtxEventPair& other) const {
+    return (this->ctx == other.ctx) && (this->eventId == other.eventId);
+  }
+};
+
+struct CtxEventPairHash {
+  std::size_t operator()(const CtxEventPair& c) const {
+    return KINETO_NAMESPACE::detail::hash_combine(
+        std::hash<uint32_t>()(c.ctx), std::hash<uint32_t>()(c.eventId));
+  }
+};
+
+struct WaitEventInfo {
+  // CUDA stream that the CUDA event was recorded on
+  uint32_t stream;
+  // Correlation ID of the cudaEventRecord event
+  uint32_t correlationId;
+};
+
+// Map (ctx, eventId) -> list of WaitEventInfo for all recorded events.
+std::unordered_map<CtxEventPair, std::vector<WaitEventInfo>, CtxEventPairHash>&
+waitEventMap() {
+  static std::
+      unordered_map<CtxEventPair, std::vector<WaitEventInfo>, CtxEventPairHash>
+          waitEventMap_;
+  return waitEventMap_;
+}
+
+// Map ctx -> deviceId
+std::unordered_map<uint32_t, uint32_t>& ctxToDeviceId() {
+  static std::unordered_map<uint32_t, uint32_t> ctxToDeviceId_;
+  return ctxToDeviceId_;
+}
+
+} // namespace
+
+namespace KINETO_NAMESPACE {
+
+bool& use_cupti_tsc() {
+  static bool use_cupti_tsc = true;
+  return use_cupti_tsc;
+}
+
+CuptiActivityProfiler::CuptiActivityProfiler(
+    CuptiActivityApi& cupti,
+    bool cpuOnly)
+    : GenericActivityProfiler(cpuOnly), cupti_(cupti) {
+  if (isGpuAvailable()) {
+    logGpuVersions();
+  }
+}
+
+void CuptiActivityProfiler::logGpuVersions() {
+  uint32_t cuptiVersion = 0;
+  int cudaRuntimeVersion = 0;
+  int cudaDriverVersion = 0;
+  CUPTI_CALL(cuptiGetVersion(&cuptiVersion));
+  CUDA_CALL(cudaRuntimeGetVersion(&cudaRuntimeVersion));
+  CUDA_CALL(cudaDriverGetVersion(&cudaDriverVersion));
+  LOG(INFO) << "CUDA versions. CUPTI: " << cuptiVersion
+            << "; Runtime: " << cudaRuntimeVersion
+            << "; Driver: " << cudaDriverVersion;
+
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
+      "cupti_version", std::to_string(cuptiVersion));
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
+      "cuda_runtime_version", std::to_string(cudaRuntimeVersion));
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
+      "cuda_driver_version", std::to_string(cudaDriverVersion));
+  addVersionMetadata("cupti_version", std::to_string(cuptiVersion));
+  addVersionMetadata(
+      "cuda_runtime_version", std::to_string(cudaRuntimeVersion));
+  addVersionMetadata("cuda_driver_version", std::to_string(cudaDriverVersion));
+}
+
+void CuptiActivityProfiler::setMaxGpuBufferSize(int64_t size) {
+  cupti_.setMaxBufferSize(size);
+}
+
+void CuptiActivityProfiler::enableGpuTracing() {
+#ifdef _WIN32
+  CUPTI_CALL(cuptiActivityRegisterTimestampCallback([]() -> uint64_t {
+    auto system = std::chrono::time_point_cast<std::chrono::nanoseconds>(
+        std::chrono::system_clock::now());
+    return system.time_since_epoch().count();
+  }));
+#else
+#if CUDA_VERSION >= 11060
+  use_cupti_tsc() = config().getTSCTimestampFlag();
+  if (use_cupti_tsc()) {
+    CUPTI_CALL(cuptiActivityRegisterTimestampCallback(
+        []() -> uint64_t { return getApproximateTime(); }));
+  }
+#endif // CUDA_VERSION >= 11060
+#endif // _WIN32
+  cupti_.enableCuptiActivities(
+      derivedConfig_->profileActivityTypes(),
+      derivedConfig_->isPerThreadBufferEnabled());
+}
+
+void CuptiActivityProfiler::disableGpuTracing() {
+  cupti_.disableCuptiActivities(derivedConfig_->profileActivityTypes());
+}
+
+void CuptiActivityProfiler::clearGpuActivities() {
+  cupti_.clearActivities();
+}
+
+bool CuptiActivityProfiler::isGpuCollectionStopped() const {
+  return cupti_.stopCollection;
+}
+
+void CuptiActivityProfiler::synchronizeGpuDevice() {
+  CUDA_CALL(cudaDeviceSynchronize());
+  cupti_.flushActivities();
+}
+
+void CuptiActivityProfiler::pushCorrelationIdImpl(
+    uint64_t id,
+    CorrelationFlowType type) {
+  CuptiActivityApi::CorrelationFlowType cuptiType =
+      (type == CorrelationFlowType::User)
+      ? CuptiActivityApi::CorrelationFlowType::User
+      : CuptiActivityApi::CorrelationFlowType::Default;
+  CuptiActivityApi::pushCorrelationID(id, cuptiType);
+}
+
+void CuptiActivityProfiler::popCorrelationIdImpl(CorrelationFlowType type) {
+  CuptiActivityApi::CorrelationFlowType cuptiType =
+      (type == CorrelationFlowType::User)
+      ? CuptiActivityApi::CorrelationFlowType::User
+      : CuptiActivityApi::CorrelationFlowType::Default;
+  CuptiActivityApi::popCorrelationID(cuptiType);
+}
+
+void CuptiActivityProfiler::onResetTraceData() {
+  cupti_.teardownContext();
+  KernelRegistry::singleton()->clear();
+  waitEventMap().clear();
+  ctxToDeviceId().clear();
+}
+
+void CuptiActivityProfiler::onFinalizeTrace(
+    [[maybe_unused]] const Config& config,
+    ActivityLogger& logger) {
+  // Overhead info
+  overheadInfo_.emplace_back("CUPTI Overhead");
+  for (const auto& info : overheadInfo_) {
+    logger.handleOverheadInfo(info, captureWindowStartTime_);
+  }
+}
+
+void CuptiActivityProfiler::processGpuActivities(ActivityLogger& logger) {
+  VLOG(0) << "Retrieving GPU activity buffers";
+  traceBuffers_->gpu = cupti_.activityBuffers();
+  if (VLOG_IS_ON(1)) {
+    addOverheadSample(flushOverhead_, cupti_.flushOverhead);
+  }
+  if (traceBuffers_->gpu) {
+    // Pass 1: Preprocess all raw records to populate correlation, event, and
+    // context lookup state.
+    buildProcessingState(*traceBuffers_->gpu);
+
+    // Pass 2: Materialize activities. buildProcessingState() has already
+    // populated correlation, event, and context lookup state;
+    // EXTERNAL_CORRELATION is a no-op in handleCuptiActivity.
+    const auto count_and_size = cupti_.processActivities(
+        *traceBuffers_->gpu, [this, &logger](const CUpti_Activity* record) {
+          handleCuptiActivity(record, &logger);
+        });
+    logDeferredEvents();
+    LOG(INFO) << "Processed " << count_and_size.first << " GPU records ("
+              << count_and_size.second << " bytes)";
+    LOGGER_OBSERVER_ADD_EVENT_COUNT(count_and_size.first);
+
+    // resourceOverheadCount_ is set while processing GPU activities
+    if (resourceOverheadCount_ > 0) {
+      LOG(INFO) << "Allocated " << resourceOverheadCount_
+                << " extra CUPTI buffers.";
+    }
+    LOGGER_OBSERVER_ADD_METADATA(
+        "ResourceOverhead", std::to_string(resourceOverheadCount_));
+  }
+}
+
+// Populate ctxToDeviceId from a record with (contextId, deviceId) fields.
+template <class T>
+static inline void updateCtxToDeviceId(const T* act) {
+  if (!ctxToDeviceId().contains(act->contextId)) {
+    ctxToDeviceId()[act->contextId] = act->deviceId;
+  }
+}
+
+// P2P memcpy carries separate source and destination (context, device) pairs.
+static inline void updateCtxToDeviceId(
+    const CUpti_ActivityMemcpyPtoPType* act) {
+  if (!ctxToDeviceId().contains(act->srcContextId)) {
+    ctxToDeviceId()[act->srcContextId] = act->srcDeviceId;
+  }
+  if (!ctxToDeviceId().contains(act->dstContextId)) {
+    ctxToDeviceId()[act->dstContextId] = act->dstDeviceId;
+  }
+}
+
+// Insert a CUDA event record into waitEventMap(), keeping the per-key vector
+// sorted by correlationId so getWaitEventInfo() can binary-search it.
+static inline void updateWaitEventMap(const CUpti_ActivityCudaEventType* act) {
+  auto key = CtxEventPair{act->contextId, act->eventId};
+  std::vector<WaitEventInfo>& vec = waitEventMap()[key];
+  auto pos = std::lower_bound(
+      vec.begin(),
+      vec.end(),
+      act->correlationId,
+      [](const WaitEventInfo& info, uint32_t val) {
+        return info.correlationId < val;
+      });
+  vec.insert(pos, WaitEventInfo{act->streamId, act->correlationId});
+}
+
+void CuptiActivityProfiler::buildProcessingState(
+    CuptiActivityBufferMap& buffers) {
+  cupti_.processActivities(buffers, [this](const CUpti_Activity* record) {
+    switch (record->kind) {
+      case CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION:
+        handleCorrelationActivity(
+            reinterpret_cast<const CUpti_ActivityExternalCorrelation*>(record));
+        break;
+      case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL:
+        updateCtxToDeviceId(
+            reinterpret_cast<const CUpti_ActivityKernelType*>(record));
+        break;
+      case CUPTI_ACTIVITY_KIND_MEMCPY:
+        updateCtxToDeviceId(
+            reinterpret_cast<const CUpti_ActivityMemcpyType*>(record));
+        break;
+      case CUPTI_ACTIVITY_KIND_MEMSET:
+        updateCtxToDeviceId(
+            reinterpret_cast<const CUpti_ActivityMemsetType*>(record));
+        break;
+      case CUPTI_ACTIVITY_KIND_MEMCPY2:
+        updateCtxToDeviceId(
+            reinterpret_cast<const CUpti_ActivityMemcpyPtoPType*>(record));
+        break;
+      case CUPTI_ACTIVITY_KIND_CUDA_EVENT:
+        updateWaitEventMap(
+            reinterpret_cast<const CUpti_ActivityCudaEventType*>(record));
+        break;
+      default:
+        break;
+    }
+  });
+}
+
+inline void CuptiActivityProfiler::handleCorrelationActivity(
+    const CUpti_ActivityExternalCorrelation* correlation) {
+  if (correlation->externalKind == CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM0) {
+    cpuCorrelationMap_[correlation->correlationId] = correlation->externalId;
+  } else if (
+      correlation->externalKind == CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM1) {
+    userCorrelationMap_[correlation->correlationId] = correlation->externalId;
+  } else {
+    LOG(WARNING) << "Invalid CUpti_ActivityExternalCorrelation sent to "
+                    "handleCuptiActivity";
+    ecs_.invalid_external_correlation_events++;
+  }
+}
+
+void CuptiActivityProfiler::handleRuntimeActivity(
+    const CUpti_ActivityAPI* activity,
+    ActivityLogger* logger) {
+  if (CuptiCbidRegistry::instance().isBlocklisted(
+          CallbackDomain::RUNTIME, activity->cbid)) {
+    ecs_.blocklisted_runtime_events++;
+    return;
+  }
+  VLOG(2) << activity->correlationId
+          << ": CUPTI_ACTIVITY_KIND_RUNTIME, cbid=" << activity->cbid
+          << " tid=" << activity->threadId;
+  int32_t tid = activity->threadId;
+  const auto& it = resourceInfo_.find({processId(), tid});
+  if (it != resourceInfo_.end()) {
+    tid = it->second.id;
+  }
+  const ITraceActivity* linked =
+      linkedActivity(activity->correlationId, cpuCorrelationMap_);
+  const auto& runtime_activity =
+      traceBuffers_->addActivityWrapper(RuntimeActivity(activity, linked, tid));
+  checkTimestampOrder(&runtime_activity);
+  if (outOfRange(runtime_activity)) {
+    return;
+  }
+  runtime_activity.log(*logger);
+  setGpuActivityPresent(true);
+}
+
+void CuptiActivityProfiler::handleDriverActivity(
+    const CUpti_ActivityAPI* activity,
+    ActivityLogger* logger) {
+  // we only want to collect cuLaunchKernel events, for triton kernel launches
+  if (!isTrackedDriverCbid(*activity)) {
+    // XXX should we count other driver events?
+    return;
+  }
+  VLOG(2) << activity->correlationId
+          << ": CUPTI_ACTIVITY_KIND_DRIVER, cbid=" << activity->cbid
+          << " tid=" << activity->threadId;
+  int32_t tid = activity->threadId;
+  const auto& it = resourceInfo_.find({processId(), tid});
+  if (it != resourceInfo_.end()) {
+    tid = it->second.id;
+  }
+  const ITraceActivity* linked =
+      linkedActivity(activity->correlationId, cpuCorrelationMap_);
+  const auto& runtime_activity =
+      traceBuffers_->addActivityWrapper(DriverActivity(activity, linked, tid));
+  checkTimestampOrder(&runtime_activity);
+  if (outOfRange(runtime_activity)) {
+    return;
+  }
+  runtime_activity.log(*logger);
+  setGpuActivityPresent(true);
+}
+
+void CuptiActivityProfiler::handleOverheadActivity(
+    const CUpti_ActivityOverhead* activity,
+    ActivityLogger* logger) {
+  VLOG(2) << ": CUPTI_ACTIVITY_KIND_OVERHEAD"
+          << " overheadKind=" << activity->overheadKind;
+  const auto& overhead_activity =
+      traceBuffers_->addActivityWrapper(OverheadActivity(activity, nullptr));
+  // Monitor memory overhead
+  if (activity->overheadKind == CUPTI_ACTIVITY_OVERHEAD_CUPTI_RESOURCE) {
+    resourceOverheadCount_++;
+  }
+
+  if (outOfRange(overhead_activity)) {
+    return;
+  }
+  overhead_activity.log(*logger);
+  setGpuActivityPresent(true);
+}
+
+static std::optional<WaitEventInfo> getWaitEventInfo(
+    uint32_t ctx,
+    uint32_t eventId,
+    uint32_t queryCorrelationId) {
+  auto key = CtxEventPair{ctx, eventId};
+  auto it = waitEventMap().find(key);
+  if (it != waitEventMap().end()) {
+    // Records are sorted by correlationId. Find the most recent record
+    // that precedes the query (i.e., the last record with
+    // correlationId < queryCorrelationId).
+    const std::vector<WaitEventInfo>& vec = it->second;
+    std::vector<WaitEventInfo>::const_iterator pos = std::upper_bound(
+        vec.begin(),
+        vec.end(),
+        queryCorrelationId,
+        [](uint32_t val, const WaitEventInfo& info) {
+          return val < info.correlationId;
+        });
+    if (pos != vec.begin()) {
+      return *std::prev(pos);
+    }
+  }
+  return std::nullopt;
+}
+
+void CuptiActivityProfiler::handleCudaEventActivity(
+    const CUpti_ActivityCudaEventType* activity,
+    ActivityLogger* logger) {
+  VLOG(2) << ": CUPTI_ACTIVITY_KIND_CUDA_EVENT"
+          << " corrId=" << activity->correlationId
+          << " eventId=" << activity->eventId
+          << " streamId=" << activity->streamId
+          << " contextId=" << activity->contextId;
+
+  // Create and log the CUDA event activity
+  const ITraceActivity* linked =
+      linkedActivity(activity->correlationId, cpuCorrelationMap_);
+  const auto& cuda_event_activity =
+      traceBuffers_->addActivityWrapper(CudaEventActivity(activity, linked));
+
+  if (outOfRange(cuda_event_activity)) {
+    return;
+  }
+
+  auto device_id = contextIdtoDeviceId(activity->contextId);
+  if (static_cast<int32_t>(activity->streamId) != -1) {
+    recordStream(device_id, activity->streamId, "");
+  } else {
+    recordDevice(device_id);
+  }
+
+  VLOG(2) << "Logging CUDA event activity device = " << device_id
+          << " stream = " << activity->streamId;
+  cuda_event_activity.log(*logger);
+  setGpuActivityPresent(true);
+}
+
+void CuptiActivityProfiler::handleCudaSyncActivity(
+    const CUpti_ActivitySynchronization* activity,
+    ActivityLogger* logger) {
+  VLOG(2) << ": CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"
+          << " type=" << syncTypeString(activity->type)
+          << " corrId=" << activity->correlationId
+          << " streamId=" << activity->streamId
+          << " eventId=" << activity->cudaEventId
+          << " contextId=" << activity->contextId;
+
+  if (!config().activitiesCudaSyncWaitEvents() &&
+      isWaitEventSync(activity->type)) {
+    return;
+  }
+
+  auto device_id = contextIdtoDeviceId(activity->contextId);
+  int32_t src_stream = -1;
+  int32_t src_corrid = -1;
+  if (isEventSync(activity->type)) {
+    auto maybe_wait_event_info = getWaitEventInfo(
+        activity->contextId, activity->cudaEventId, activity->correlationId);
+    if (maybe_wait_event_info) {
+      src_stream = maybe_wait_event_info->stream;
+      src_corrid = maybe_wait_event_info->correlationId;
+    }
+  }
+
+  // Marshal the logging to a functor so we can defer it if needed.
+  auto log_event =
+      [activity, src_stream, src_corrid, device_id, logger, this]() {
+        const ITraceActivity* linked =
+            linkedActivity(activity->correlationId, this->cpuCorrelationMap_);
+        const auto& cuda_sync_activity =
+            this->traceBuffers_->addActivityWrapper(
+                CudaSyncActivity(activity, linked, src_stream, src_corrid));
+
+        if (outOfRange(cuda_sync_activity)) {
+          return;
+        }
+
+        if (static_cast<int32_t>(activity->streamId) != -1) {
+          recordStream(device_id, activity->streamId, "");
+        } else {
+          recordDevice(device_id);
+        }
+        VLOG(2) << "Logging sync event device = " << device_id
+                << " stream = " << activity->streamId
+                << " sync type = " << syncTypeString(activity->type);
+        cuda_sync_activity.log(*logger);
+        setGpuActivityPresent(true);
+      };
+
+  if (isWaitEventSync(activity->type)) {
+    // Stream Wait Events still need deferral so we can suppress waits on
+    // streams that never show GPU work in the trace window.
+    DeferredLogEntry entry;
+    entry.device = device_id;
+    entry.stream = activity->streamId;
+    entry.logMe = log_event;
+
+    logQueue_.push_back(entry);
+  } else {
+    log_event();
+  }
+}
+
+void CuptiActivityProfiler::logDeferredEvents() {
+  // Stream Wait Events tend to be noisy, only pass these events if
+  // there was some GPU kernel/memcopy/memset observed on it in the trace
+  // window.
+  for (const auto& entry : logQueue_) {
+    if (!seenDeviceStreams_.contains({entry.device, entry.stream})) {
+      VLOG(2) << "Skipping Stream Wait Event on unseen stream = "
+              << entry.stream;
+    } else {
+      entry.logMe();
+    }
+  }
+}
+
+template <class T>
+inline void CuptiActivityProfiler::handleGpuActivity(
+    const T* act,
+    ActivityLogger* logger) {
+  const ITraceActivity* linked =
+      linkedActivity(act->correlationId, cpuCorrelationMap_);
+  const auto& gpu_activity =
+      traceBuffers_->addActivityWrapper(GpuActivity<T>(act, linked));
+  GenericActivityProfiler::handleGpuActivity(gpu_activity, logger);
+}
+
+uint32_t contextIdtoDeviceId(uint32_t contextId) {
+  auto it = ctxToDeviceId().find(contextId);
+  return it != ctxToDeviceId().end() ? it->second : 0;
+}
+
+void CuptiActivityProfiler::handleCuptiActivity(
+    const CUpti_Activity* record,
+    ActivityLogger* logger) {
+  switch (record->kind) {
+    case CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION:
+      // Populated in buildProcessingState().
+      break;
+    case CUPTI_ACTIVITY_KIND_RUNTIME:
+      handleRuntimeActivity(
+          reinterpret_cast<const CUpti_ActivityAPI*>(record), logger);
+      break;
+    case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL: {
+      const CUpti_ActivityKernelType* kernel =
+          reinterpret_cast<const CUpti_ActivityKernelType*>(record);
+      // Register all kernels launches so we could correlate them with other
+      // events.
+      KernelRegistry::singleton()->recordKernel(
+          kernel->deviceId, demangle(kernel->name), kernel->correlationId);
+      handleGpuActivity(kernel, logger);
+      break;
+    }
+    case CUPTI_ACTIVITY_KIND_SYNCHRONIZATION:
+      handleCudaSyncActivity(
+          reinterpret_cast<const CUpti_ActivitySynchronization*>(record),
+          logger);
+      break;
+    case CUPTI_ACTIVITY_KIND_CUDA_EVENT:
+      handleCudaEventActivity(
+          reinterpret_cast<const CUpti_ActivityCudaEventType*>(record), logger);
+      break;
+    case CUPTI_ACTIVITY_KIND_MEMCPY:
+      handleGpuActivity(
+          reinterpret_cast<const CUpti_ActivityMemcpyType*>(record), logger);
+      break;
+    case CUPTI_ACTIVITY_KIND_MEMCPY2:
+      handleGpuActivity(
+          reinterpret_cast<const CUpti_ActivityMemcpyPtoPType*>(record),
+          logger);
+      break;
+    case CUPTI_ACTIVITY_KIND_MEMSET:
+      handleGpuActivity(
+          reinterpret_cast<const CUpti_ActivityMemsetType*>(record), logger);
+      break;
+    case CUPTI_ACTIVITY_KIND_OVERHEAD:
+      handleOverheadActivity(
+          reinterpret_cast<const CUpti_ActivityOverhead*>(record), logger);
+      break;
+    case CUPTI_ACTIVITY_KIND_DRIVER:
+      handleDriverActivity(
+          reinterpret_cast<const CUpti_ActivityAPI*>(record), logger);
+      break;
+    default:
+      LOG(WARNING) << "Unexpected activity type: " << record->kind;
+      ecs_.unexepected_cuda_events++;
+      break;
+  }
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/CuptiActivityProfiler.h
+++ b/third_party/kineto/libkineto/src/CuptiActivityProfiler.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cupti.h>
+#include "CuptiActivity.h"
+#include "CuptiActivityApi.h"
+#include "GenericActivityProfiler.h"
+
+namespace KINETO_NAMESPACE {
+
+class CuptiActivityProfiler : public GenericActivityProfiler {
+ public:
+  CuptiActivityProfiler(CuptiActivityApi& cupti, bool cpuOnly);
+  CuptiActivityProfiler(const CuptiActivityProfiler&) = delete;
+  CuptiActivityProfiler& operator=(const CuptiActivityProfiler&) = delete;
+  ~CuptiActivityProfiler() override = default;
+
+ protected:
+  void logGpuVersions() override;
+  void setMaxGpuBufferSize(int64_t size) override;
+  void enableGpuTracing() override;
+  void disableGpuTracing() override;
+  void clearGpuActivities() override;
+  bool isGpuCollectionStopped() const override;
+  void processGpuActivities(ActivityLogger& logger) override;
+  void synchronizeGpuDevice() override;
+  void pushCorrelationIdImpl(uint64_t id, CorrelationFlowType type) override;
+  void popCorrelationIdImpl(CorrelationFlowType type) override;
+  void onResetTraceData() override;
+  void onFinalizeTrace(const Config& config, ActivityLogger& logger) override;
+
+ private:
+  void buildProcessingState(CuptiActivityBufferMap& buffers);
+  // Process generic CUPTI activity
+  void handleCuptiActivity(
+      const CUpti_Activity* record,
+      ActivityLogger* logger);
+  // Process specific GPU activity types
+  void handleCorrelationActivity(
+      const CUpti_ActivityExternalCorrelation* correlation);
+  void handleRuntimeActivity(
+      const CUpti_ActivityAPI* activity,
+      ActivityLogger* logger);
+  void handleDriverActivity(
+      const CUpti_ActivityAPI* activity,
+      ActivityLogger* logger);
+  void handleOverheadActivity(
+      const CUpti_ActivityOverhead* activity,
+      ActivityLogger* logger);
+  void handleCudaEventActivity(
+      const CUpti_ActivityCudaEventType* activity,
+      ActivityLogger* logger);
+  void handleCudaSyncActivity(
+      const CUpti_ActivitySynchronization* activity,
+      ActivityLogger* logger);
+  template <class T>
+  void handleGpuActivity(const T* act, ActivityLogger* logger);
+  void logDeferredEvents();
+
+  // Calls to CUPTI is encapsulated behind this interface
+  CuptiActivityApi& cupti_;
+};
+
+// Helper function to map context ID to device ID
+uint32_t contextIdtoDeviceId(uint32_t contextId);
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/CuptiCallbackApi.cpp
+++ b/third_party/kineto/libkineto/src/CuptiCallbackApi.cpp
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "CuptiCallbackApi.h"
+#include "CuptiActivityApi.h"
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <mutex>
+
+#include "DeviceUtil.h"
+#include "Logger.h"
+
+namespace KINETO_NAMESPACE {
+
+// limit on number of handles per callback type
+constexpr size_t MAX_CB_FNS_PER_CB = 8;
+
+// Use this value in enabledCallbacks_ set, when all cbids in a domain
+// is enabled, not a specific cbid.
+constexpr uint32_t MAX_CUPTI_CALLBACK_ID_ALL = 0xffffffff;
+
+/* Callback Table :
+ *  Overall goal of the design is to optimize the lookup of function
+ *  pointers. The table is structured at two levels and the leaf
+ *  elements in the table are std::list to enable fast access/inserts/deletes
+ *
+ *   <callback domain0> |
+ *                     -> cb id 0 -> std::list of callbacks
+ *                     ...
+ *                     -> cb id n -> std::list of callbacks
+ *   <callback domain1> |
+ *                    ...
+ *  CallbackTable is the finaly table type above
+ *  See type declrartions in header file.
+ */
+
+/* callback_switchboard : is the global callback handler we register
+ *  with CUPTI. The goal is to make it as efficient as possible
+ *  to re-direct to the registered callback(s).
+ *
+ *  Few things to care about :
+ *   a) use if/then switches rather than map/hash structures
+ *   b) avoid dynamic memory allocations
+ *   c) be aware of locking overheads
+ */
+static void CUPTIAPI callback_switchboard(
+    void* /* unused */,
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData* cbInfo) {
+  // __callback_switchboard acquires a reader lock
+  // on the callback list
+  CuptiCallbackApi::singleton().__callback_switchboard(domain, cbid, cbInfo);
+}
+
+void CuptiCallbackApi::__callback_switchboard(
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData* cbInfo) {
+  LOG(INFO) << "Callback: domain = " << domain << ", cbid = " << cbid;
+  CallbackList* cblist = nullptr;
+
+  switch (domain) {
+    // add the fastest path for kernel launch callbacks
+    // as these are the most frequent ones
+    case CUPTI_CB_DOMAIN_RUNTIME_API:
+      switch (cbid) {
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000:
+          cblist = &callbacks_.runtime[domainIndex(
+              CuptiCallBackID::CUDA_LAUNCH_KERNEL,
+              CuptiCallBackID::__RUNTIME_CB_DOMAIN_START)];
+          break;
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 11080)
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060:
+          cblist = &callbacks_.runtime[domainIndex(
+              CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC,
+              CuptiCallBackID::__RUNTIME_CB_DOMAIN_START)];
+          break;
+#endif
+        default:
+          break;
+      }
+      // This is required to teardown cupti after profiling to prevent QPS
+      // slowdown.
+      if (CuptiActivityApi::singleton().teardownCupti_) {
+        if (cbInfo->callbackSite == CUPTI_API_EXIT) {
+          LOG(INFO) << "  Calling cuptiFinalize in exit callsite";
+          // Teardown CUPTI calling cuptiFinalize()
+          CUPTI_CALL(cuptiUnsubscribe(subscriber_));
+          CUPTI_CALL(cuptiFinalize());
+          initSuccess_ = false;
+          subscriber_ = nullptr;
+          CuptiActivityApi::singleton().teardownCupti_ = 0;
+          CuptiActivityApi::singleton().finalizeCond_.notify_all();
+          return;
+        }
+      }
+      break;
+
+    case CUPTI_CB_DOMAIN_RESOURCE:
+      switch (cbid) {
+        case CUPTI_CBID_RESOURCE_CONTEXT_CREATED:
+          cblist = &callbacks_.resource[domainIndex(
+              CuptiCallBackID::RESOURCE_CONTEXT_CREATED,
+              CuptiCallBackID::__RESOURCE_CB_DOMAIN_START)];
+          break;
+        case CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING:
+          cblist = &callbacks_.resource[domainIndex(
+              CuptiCallBackID::RESOURCE_CONTEXT_DESTROYED,
+              CuptiCallBackID::__RESOURCE_CB_DOMAIN_START)];
+          break;
+        default:
+          break;
+      }
+      break;
+
+    default:
+      return;
+  }
+
+  // ignore callbacks that are not handled
+  if (cblist == nullptr) {
+    return;
+  }
+
+  // make a copy of the callback list so we avoid holding lock
+  // in common case this should be just one func pointer copy
+  std::array<CuptiCallbackFn, MAX_CB_FNS_PER_CB> callbacks;
+  size_t num_cbs = 0;
+  {
+    ReaderLockGuard rl(callbackLock_);
+    size_t i = 0;
+    for (auto it = cblist->begin();
+         it != cblist->end() && i < MAX_CB_FNS_PER_CB;
+         it++, i++) {
+      callbacks[i] = *it;
+    }
+    num_cbs = i;
+  }
+
+  for (size_t i = 0; i < num_cbs; i++) {
+    auto fn = callbacks[i];
+    fn(domain, cbid, cbInfo);
+  }
+}
+
+CuptiCallbackApi& CuptiCallbackApi::singleton() {
+  static auto* instance = new CuptiCallbackApi();
+  return *instance;
+}
+
+void CuptiCallbackApi::initCallbackApi() {
+  lastCuptiStatus_ = CUPTI_ERROR_UNKNOWN;
+  lastCuptiStatus_ = CUPTI_CALL_NOWARN(cuptiSubscribe(
+      &subscriber_,
+      reinterpret_cast<CUpti_CallbackFunc>(callback_switchboard),
+      nullptr));
+
+  // TODO: Remove temporarily to work around static initialization order issue
+  // betweent this and GLOG.
+  // if (lastCuptiStatus_ != CUPTI_SUCCESS) {
+  //   LOG(INFO) << "Failed cuptiSubscribe, status: " << lastCuptiStatus_;
+  // }
+
+  initSuccess_ = (lastCuptiStatus_ == CUPTI_SUCCESS);
+}
+
+CuptiCallbackApi::CallbackList* CuptiCallbackApi::CallbackTable::lookup(
+    CUpti_CallbackDomain domain,
+    CuptiCallBackID cbid) {
+  size_t idx;
+
+  switch (domain) {
+    case CUPTI_CB_DOMAIN_RESOURCE:
+      assert(cbid >= CuptiCallBackID::__RESOURCE_CB_DOMAIN_START);
+      assert(cbid < CuptiCallBackID::__RESOURCE_CB_DOMAIN_END);
+      idx = domainIndex(cbid, CuptiCallBackID::__RESOURCE_CB_DOMAIN_START);
+      return &resource.at(idx);
+
+    case CUPTI_CB_DOMAIN_RUNTIME_API:
+      assert(cbid >= CuptiCallBackID::__RUNTIME_CB_DOMAIN_START);
+      assert(cbid < CuptiCallBackID::__RUNTIME_CB_DOMAIN_END);
+      idx = domainIndex(cbid, CuptiCallBackID::__RUNTIME_CB_DOMAIN_START);
+      return &runtime.at(idx);
+
+    default:
+      LOG(WARNING) << " Unsupported callback domain : " << domain;
+      return nullptr;
+  }
+}
+
+bool CuptiCallbackApi::registerCallback(
+    CUpti_CallbackDomain domain,
+    CuptiCallBackID cbid,
+    CuptiCallbackFn cbfn) {
+  CallbackList* cblist = callbacks_.lookup(domain, cbid);
+
+  if (!cblist) {
+    LOG(WARNING) << "Could not register callback -- domain = " << domain
+                 << " callback id = " << static_cast<int>(cbid);
+    return false;
+  }
+
+  // avoid duplicates
+  auto it = std::ranges::find(*cblist, cbfn);
+  if (it != cblist->end()) {
+    LOG(WARNING) << "Adding duplicate callback -- domain = " << domain
+                 << " callback id = " << static_cast<int>(cbid);
+    return true;
+  }
+
+  if (cblist->size() == MAX_CB_FNS_PER_CB) {
+    LOG(WARNING) << "Already registered max callback -- domain = " << domain
+                 << " callback id = " << static_cast<int>(cbid);
+  }
+
+  WriteLockGuard wl(callbackLock_);
+  cblist->push_back(cbfn);
+  return true;
+}
+
+bool CuptiCallbackApi::deleteCallback(
+    CUpti_CallbackDomain domain,
+    CuptiCallBackID cbid,
+    CuptiCallbackFn cbfn) {
+  CallbackList* cblist = callbacks_.lookup(domain, cbid);
+  if (!cblist) {
+    LOG(WARNING) << "Attempting to remove unsupported callback -- domain = "
+                 << domain << " callback id = " << static_cast<int>(cbid);
+    return false;
+  }
+
+  // Locks are not required here as
+  //  https://en.cppreference.com/w/cpp/container/list/erase
+  //  "References and iterators to the erased elements are invalidated.
+  //   Other references and iterators are not affected."
+  auto it = std::ranges::find(*cblist, cbfn);
+  if (it == cblist->end()) {
+    LOG(WARNING) << "Could not find callback to remove -- domain = " << domain
+                 << " callback id = " << static_cast<int>(cbid);
+    return false;
+  }
+
+  WriteLockGuard wl(callbackLock_);
+  cblist->erase(it);
+  return true;
+}
+
+bool CuptiCallbackApi::enableCallback(
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid) {
+  if (initSuccess_) {
+    lastCuptiStatus_ =
+        CUPTI_CALL_NOWARN(cuptiEnableCallback(1, subscriber_, domain, cbid));
+    enabledCallbacks_.insert({domain, cbid});
+    return (lastCuptiStatus_ == CUPTI_SUCCESS);
+  }
+  return false;
+}
+
+bool CuptiCallbackApi::disableCallback(
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid) {
+  enabledCallbacks_.erase({domain, cbid});
+  if (initSuccess_) {
+    lastCuptiStatus_ =
+        CUPTI_CALL_NOWARN(cuptiEnableCallback(0, subscriber_, domain, cbid));
+    return (lastCuptiStatus_ == CUPTI_SUCCESS);
+  }
+  return false;
+}
+
+bool CuptiCallbackApi::enableCallbackDomain(CUpti_CallbackDomain domain) {
+  if (initSuccess_) {
+    lastCuptiStatus_ =
+        CUPTI_CALL_NOWARN(cuptiEnableDomain(1, subscriber_, domain));
+    enabledCallbacks_.insert({domain, MAX_CUPTI_CALLBACK_ID_ALL});
+    return (lastCuptiStatus_ == CUPTI_SUCCESS);
+  }
+  return false;
+}
+
+bool CuptiCallbackApi::disableCallbackDomain(CUpti_CallbackDomain domain) {
+  enabledCallbacks_.erase({domain, MAX_CUPTI_CALLBACK_ID_ALL});
+  if (initSuccess_) {
+    lastCuptiStatus_ =
+        CUPTI_CALL_NOWARN(cuptiEnableDomain(0, subscriber_, domain));
+    return (lastCuptiStatus_ == CUPTI_SUCCESS);
+  }
+  return false;
+}
+
+bool CuptiCallbackApi::reenableCallbacks() {
+  if (initSuccess_) {
+    for (auto& cbpair : enabledCallbacks_) {
+      if (static_cast<uint32_t>(cbpair.second) == MAX_CUPTI_CALLBACK_ID_ALL) {
+        lastCuptiStatus_ =
+            CUPTI_CALL_NOWARN(cuptiEnableDomain(1, subscriber_, cbpair.first));
+      } else {
+        lastCuptiStatus_ = CUPTI_CALL_NOWARN(
+            cuptiEnableCallback(1, subscriber_, cbpair.first, cbpair.second));
+      }
+    }
+    return (lastCuptiStatus_ == CUPTI_SUCCESS);
+  }
+  return false;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/CuptiCallbackApi.h
+++ b/third_party/kineto/libkineto/src/CuptiCallbackApi.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cupti.h>
+#include <array>
+#include <atomic>
+#include <list>
+#include <mutex>
+#include <set>
+#include <shared_mutex>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "CuptiCallbackApiMock.h"
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+
+/* CuptiCallbackApi : Provides an abstraction over CUPTI callback
+ *  interface. This enables various callback functions to be registered
+ *  with this class. The class registers a global callback handler that
+ *  redirects to the respective callbacks.
+ *
+ *  Note: one design choice we made is to only support simple function pointers
+ *  in order to speed up the implementation for fast path.
+ */
+
+using CuptiCallbackFn = void (*)(
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData* cbInfo);
+
+class CuptiCallbackApi {
+ public:
+  /* Global list of supported callback ids
+   *  use the class namespace to avoid confusing with CUPTI enums*/
+  enum class CuptiCallBackID : int {
+    CUDA_LAUNCH_KERNEL = 0,
+    // can possibly support more callback ids per domain
+    //
+    __RUNTIME_CB_DOMAIN_START = CUDA_LAUNCH_KERNEL,
+    CUDA_LAUNCH_KERNEL_EXC, // Used in H100
+
+    // Callbacks under Resource CB domain
+    RESOURCE_CONTEXT_CREATED,
+    RESOURCE_CONTEXT_DESTROYED,
+
+    __RUNTIME_CB_DOMAIN_END = RESOURCE_CONTEXT_CREATED,
+    __RESOURCE_CB_DOMAIN_START = RESOURCE_CONTEXT_CREATED,
+
+    __RESOURCE_CB_DOMAIN_END = RESOURCE_CONTEXT_DESTROYED + 1,
+  };
+
+  CuptiCallbackApi() = default;
+  CuptiCallbackApi(const CuptiCallbackApi&) = delete;
+  CuptiCallbackApi& operator=(const CuptiCallbackApi&) = delete;
+
+  static CuptiCallbackApi& singleton();
+
+  void initCallbackApi();
+
+  bool initSuccess() const {
+    return initSuccess_;
+  }
+
+  CUptiResult getCuptiStatus() const {
+    return lastCuptiStatus_;
+  }
+
+  CUpti_SubscriberHandle getCuptiSubscriber() const {
+    return subscriber_;
+  }
+
+  bool registerCallback(
+      CUpti_CallbackDomain domain,
+      CuptiCallBackID cbid,
+      CuptiCallbackFn cbfn);
+
+  // returns false if callback was not found
+  bool deleteCallback(
+      CUpti_CallbackDomain domain,
+      CuptiCallBackID cbid,
+      CuptiCallbackFn cbfn);
+
+  // Cupti Callback may be enable for domain and cbid pairs, or domains alone.
+  bool enableCallback(CUpti_CallbackDomain domain, CUpti_CallbackId cbid);
+  bool disableCallback(CUpti_CallbackDomain domain, CUpti_CallbackId cbid);
+  bool enableCallbackDomain(CUpti_CallbackDomain domain);
+  bool disableCallbackDomain(CUpti_CallbackDomain domain);
+  // Provide this API for when cuptiFinalize is executed, to allow the process
+  // to re-enabled all previously running callback subscriptions.
+  bool reenableCallbacks();
+
+  // Please do not use this method. This has to be exposed as public
+  // so it is accessible from the callback handler
+  void __callback_switchboard(
+      CUpti_CallbackDomain domain,
+      CUpti_CallbackId cbid,
+      const CUpti_CallbackData* cbInfo);
+
+ private:
+  // For callback table design overview see the .cpp file
+  using CallbackList = std::list<CuptiCallbackFn>;
+
+  // Computing the slot of the callback id within its domain's table.
+  static constexpr size_t domainIndex(
+      CuptiCallBackID cbid,
+      CuptiCallBackID domainStart) {
+    return static_cast<size_t>(cbid) - static_cast<size_t>(domainStart);
+  }
+
+  // level 2 tables sizes are known at compile time. Computed inline rather than
+  // via domainIndex(): an inline member function isn't yet usable in a
+  // constexpr member initializer within the same class definition.
+  constexpr static size_t RUNTIME_CB_DOMAIN_SIZE =
+      static_cast<size_t>(CuptiCallBackID::__RUNTIME_CB_DOMAIN_END) -
+      static_cast<size_t>(CuptiCallBackID::__RUNTIME_CB_DOMAIN_START);
+
+  constexpr static size_t RESOURCE_CB_DOMAIN_SIZE =
+      static_cast<size_t>(CuptiCallBackID::__RESOURCE_CB_DOMAIN_END) -
+      static_cast<size_t>(CuptiCallBackID::__RESOURCE_CB_DOMAIN_START);
+
+  // level 1 table is a struct
+  struct CallbackTable {
+    std::array<CallbackList, RUNTIME_CB_DOMAIN_SIZE> runtime;
+    std::array<CallbackList, RESOURCE_CB_DOMAIN_SIZE> resource;
+
+    CallbackList* lookup(CUpti_CallbackDomain domain, CuptiCallBackID cbid);
+  };
+
+  CallbackTable callbacks_;
+  bool initSuccess_ = false;
+  // Record a list of enabled callbacks, so that after teardown, we can
+  // re-enable the callbacks that were turned off to clean cupti context. As an
+  // implementation detail, cbid == 0xffffffff means enable the domain.
+  std::set<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>> enabledCallbacks_;
+
+  // Reader Writer lock types
+  using ReaderWriterLock = std::shared_timed_mutex;
+  using ReaderLockGuard = std::shared_lock<ReaderWriterLock>;
+  using WriteLockGuard = std::unique_lock<ReaderWriterLock>;
+  ReaderWriterLock callbackLock_;
+  CUptiResult lastCuptiStatus_;
+  CUpti_SubscriberHandle subscriber_{nullptr};
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/CuptiCallbackApiMock.h
+++ b/third_party/kineto/libkineto/src/CuptiCallbackApiMock.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Provides data structures to mock CUPTI Callback API
+#ifndef HAS_CUPTI
+
+enum CUpti_CallbackDomain {
+  CUPTI_CB_DOMAIN_RESOURCE,
+  CUPTI_CB_DOMAIN_RUNTIME_API,
+};
+enum CUpti_CallbackId {
+  CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 11080)
+  CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,
+#endif
+  CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
+  CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
+};
+
+using CUcontext = void*;
+
+struct CUpti_ResourceData {
+  CUcontext context;
+};
+
+constexpr int CUPTI_API_ENTER = 0;
+constexpr int CUPTI_API_EXIT = 0;
+
+struct CUpti_CallbackData {
+  CUcontext context;
+  const char* symbolName;
+  int callbackSite;
+};
+#endif // HAS_CUPTI

--- a/third_party/kineto/libkineto/src/CuptiCbidRegistry.cpp
+++ b/third_party/kineto/libkineto/src/CuptiCbidRegistry.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CuptiCbidRegistry.h"
+
+#include <stdexcept>
+
+namespace KINETO_NAMESPACE {
+
+CuptiCbidRegistry& CuptiCbidRegistry::instance() {
+  static CuptiCbidRegistry instance;
+  return instance;
+}
+
+std::unordered_map<uint32_t, CuptiCbidRegistry::CbidProperties>&
+CuptiCbidRegistry::getMapForDomain(CallbackDomain domain) {
+  switch (domain) {
+    case CallbackDomain::RUNTIME:
+      return runtimeCallbacks_;
+    case CallbackDomain::DRIVER:
+      return driverCallbacks_;
+    default:
+      throw std::invalid_argument("Unknown CallbackDomain");
+  }
+}
+
+void CuptiCbidRegistry::registerCbid(
+    CallbackDomain domain,
+    uint32_t cbid,
+    bool requiresFlowCorrelation,
+    bool isBlocklisted) {
+  getMapForDomain(domain)[cbid] =
+      CbidProperties{requiresFlowCorrelation, isBlocklisted};
+}
+
+void CuptiCbidRegistry::registerCbidRange(
+    CallbackDomain domain,
+    uint32_t startCbid,
+    uint32_t endCbid,
+    bool requiresFlowCorrelation,
+    bool isBlocklisted) {
+  cbidRanges_.emplace_back(
+      domain,
+      CbidRange{startCbid, endCbid, requiresFlowCorrelation, isBlocklisted});
+}
+
+CuptiCbidRegistry::CuptiCbidRegistry() {
+  // =========================================================================
+  // RUNTIME API - Kernel Launches
+  // =========================================================================
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_v9000,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernelMultiDevice_v9000,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+#if defined(CUPTI_API_VERSION) && CUPTI_API_VERSION >= 18
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+#endif
+
+  // =========================================================================
+  // RUNTIME API - CUDA Graph Operations
+  // =========================================================================
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  // =========================================================================
+  // RUNTIME API - Synchronization Operations
+  // =========================================================================
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaStreamSynchronize_v3020,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaDeviceSynchronize_v3020,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaStreamWaitEvent_v3020,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  // =========================================================================
+  // RUNTIME API - Memory Operations (range-based)
+  // =========================================================================
+  registerCbidRange(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*startCbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaMemcpy_v3020,
+      /*endCbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaMemset2DAsync_v3020,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  // =========================================================================
+  // RUNTIME API - Blocklisted (noisy) Callbacks
+  // =========================================================================
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaGetDevice_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaSetDevice_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaGetLastError_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaEventCreate_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaEventCreateWithFlags_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  registerCbid(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaEventDestroy_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  // =========================================================================
+  // DRIVER API - Kernel Launches
+  // =========================================================================
+  registerCbid(
+      /*domain=*/CallbackDomain::DRIVER,
+      /*cbid=*/CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11060
+  registerCbid(
+      /*domain=*/CallbackDomain::DRIVER,
+      /*cbid=*/CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+#endif
+  registerCbid(
+      /*domain=*/CallbackDomain::DRIVER,
+      /*cbid=*/CUPTI_DRIVER_TRACE_CBID_cuMemCreate,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/false);
+  registerCbid(
+      /*domain=*/CallbackDomain::DRIVER,
+      /*cbid=*/CUPTI_DRIVER_TRACE_CBID_cuMemMap,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/false);
+  registerCbid(
+      /*domain=*/CallbackDomain::DRIVER,
+      /*cbid=*/CUPTI_DRIVER_TRACE_CBID_cuMemUnmap,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/false);
+  registerCbid(
+      /*domain=*/CallbackDomain::DRIVER,
+      /*cbid=*/CUPTI_DRIVER_TRACE_CBID_cuMemRelease,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/false);
+  registerCbid(
+      /*domain=*/CallbackDomain::DRIVER,
+      /*cbid=*/CUPTI_DRIVER_TRACE_CBID_cuMemExportToShareableHandle,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/false);
+  registerCbid(
+      /*domain=*/CallbackDomain::DRIVER,
+      /*cbid=*/CUPTI_DRIVER_TRACE_CBID_cuMemImportFromShareableHandle,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/false);
+}
+
+bool CuptiCbidRegistry::requiresFlowCorrelation(
+    CallbackDomain domain,
+    uint32_t cbid) {
+  // Check explicit callback IDs first
+  const auto& map = getMapForDomain(domain);
+  if (auto it = map.find(cbid); it != map.end()) {
+    return it->second.requiresFlowCorrelation;
+  }
+  // Check ranges (for memory operations)
+  // TODO: reevaluate the loop once we iterate of many ranges
+  for (const auto& [rangeDomain, range] : cbidRanges_) {
+    if (rangeDomain == domain && cbid >= range.startCbid &&
+        cbid <= range.endCbid) {
+      return range.requiresFlowCorrelation;
+    }
+  }
+  return false;
+}
+
+bool CuptiCbidRegistry::isBlocklisted(CallbackDomain domain, uint32_t cbid) {
+  // Check explicit callbacks first
+  const auto& map = getMapForDomain(domain);
+  if (auto it = map.find(cbid); it != map.end()) {
+    return it->second.isBlocklisted;
+  }
+  // Check ranges
+  // TODO: reevaluate the loop once we iterate of many ranges
+  for (const auto& [rangeDomain, range] : cbidRanges_) {
+    if (rangeDomain == domain && cbid >= range.startCbid &&
+        cbid <= range.endCbid) {
+      return range.isBlocklisted;
+    }
+  }
+  return false;
+}
+
+bool CuptiCbidRegistry::isRegistered(CallbackDomain domain, uint32_t cbid) {
+  const auto& map = getMapForDomain(domain);
+  if (map.contains(cbid)) {
+    return true;
+  }
+  for (const auto& [rangeDomain, range] : cbidRanges_) {
+    if (rangeDomain == domain && cbid >= range.startCbid &&
+        cbid <= range.endCbid) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/CuptiCbidRegistry.h
+++ b/third_party/kineto/libkineto/src/CuptiCbidRegistry.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include <cupti.h>
+
+namespace KINETO_NAMESPACE {
+
+// Domain of the CUPTI callback
+enum class CallbackDomain : uint8_t {
+  RUNTIME, // CUDA Runtime API (cudaXxx functions)
+  DRIVER, // CUDA Driver API (cuXxx functions)
+};
+
+// CuptiCbidRegistry: Central registry for CUPTI callback ID metadata
+//
+// This class provides a single source of truth for all CUPTI callback ID
+// properties, replacing scattered hardcoded checks throughout the codebase.
+//
+// The registry is initialized lazily on first access via instance().
+// All callback IDs are registered in the constructor with their properties.
+//
+// Usage:
+//   auto& registry = CuptiCbidRegistry::instance();
+//   if (registry.requiresFlowCorrelation(CallbackDomain::RUNTIME, cbid)) {
+//     // Create flow correlation
+//   }
+//
+class CuptiCbidRegistry {
+ public:
+  // Get the singleton instance (lazy initialization on first call)
+  static CuptiCbidRegistry& instance();
+
+  // Disable copy/move
+  CuptiCbidRegistry(const CuptiCbidRegistry&) = delete;
+  CuptiCbidRegistry& operator=(const CuptiCbidRegistry&) = delete;
+  CuptiCbidRegistry(CuptiCbidRegistry&&) = delete;
+  CuptiCbidRegistry& operator=(CuptiCbidRegistry&&) = delete;
+
+  // Check if a callback ID requires flow correlation (CPU->GPU arrows in trace)
+  [[nodiscard]] bool requiresFlowCorrelation(
+      CallbackDomain domain,
+      uint32_t cbid);
+
+  // Check if a callback ID is blocklisted (should be filtered from traces)
+  [[nodiscard]] bool isBlocklisted(CallbackDomain domain, uint32_t cbid);
+
+  // Check if a callback ID is registered
+  [[nodiscard]] bool isRegistered(CallbackDomain domain, uint32_t cbid);
+
+ private:
+  CuptiCbidRegistry();
+  ~CuptiCbidRegistry() = default;
+
+  // Properties stored per callback ID
+  struct CbidProperties {
+    bool requiresFlowCorrelation;
+    bool isBlocklisted;
+  };
+
+  // Range of callback IDs (for memory operations)
+  struct CbidRange {
+    uint32_t startCbid;
+    uint32_t endCbid; // inclusive
+    bool requiresFlowCorrelation;
+    bool isBlocklisted;
+  };
+
+  // Register a callback ID
+  void registerCbid(
+      CallbackDomain domain,
+      uint32_t cbid,
+      bool requiresFlowCorrelation,
+      bool isBlocklisted);
+
+  // Register a range of callback IDs
+  void registerCbidRange(
+      CallbackDomain domain,
+      uint32_t startCbid,
+      uint32_t endCbid,
+      bool requiresFlowCorrelation,
+      bool isBlocklisted);
+
+  // Storage per domain
+  std::unordered_map<uint32_t, CbidProperties> runtimeCallbacks_;
+  std::unordered_map<uint32_t, CbidProperties> driverCallbacks_;
+
+  // Ranges for callback IDs that use range-based matching
+  std::vector<std::pair<CallbackDomain, CbidRange>> cbidRanges_;
+
+  // Helper to get the appropriate map for domain
+  [[nodiscard]] std::unordered_map<uint32_t, CbidProperties>& getMapForDomain(
+      CallbackDomain domain);
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/DaemonConfigLoader.cpp
+++ b/third_party/kineto/libkineto/src/DaemonConfigLoader.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef __linux__
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "DaemonConfigLoader.h"
+#include "ConfigLoader.h"
+#include "Logger.h"
+
+namespace KINETO_NAMESPACE {
+
+// TODO : implications of this singleton being thread safe on forks?
+IpcFabricConfigClient* DaemonConfigLoader::getConfigClient() {
+  if (!configClient) {
+    configClient = std::make_unique<IpcFabricConfigClient>();
+  }
+  return configClient.get();
+}
+
+std::string DaemonConfigLoader::readBaseConfig() {
+  LOG(INFO) << "Reading base config";
+  auto configClient_2 = getConfigClient();
+  if (!configClient_2) {
+    LOG_EVERY_N(WARNING, 10) << "Failed to read config: No dyno config client";
+    return "";
+  }
+  return configClient_2->getLibkinetoBaseConfig();
+}
+
+std::string DaemonConfigLoader::readOnDemandConfig(bool activities) {
+  auto configClient = getConfigClient();
+  if (!configClient) {
+    LOG_EVERY_N(WARNING, 10) << "Failed to read config: No dyno config client";
+    return "";
+  }
+  int config_type = static_cast<int>(LibkinetoConfigType::NONE);
+  if (activities) {
+    config_type |= static_cast<int>(LibkinetoConfigType::ACTIVITIES);
+  }
+  return configClient->getLibkinetoOndemandConfig(config_type);
+}
+
+void DaemonConfigLoader::setCommunicationFabric(bool enabled) {
+  LOG(INFO) << "Setting communication fabric enabled = " << enabled;
+  auto configClient = getConfigClient();
+
+  if (!configClient) {
+    LOG(WARNING) << "Failed to read config: No dyno config client";
+    // This is probably a temporary problem - return -1 to indicate error.
+    return;
+  }
+  configClient->setIpcFabricEnabled(enabled);
+}
+
+void DaemonConfigLoader::registerFactory() {
+  ConfigLoader::setDaemonConfigLoaderFactory([]() {
+    auto loader = std::make_unique<DaemonConfigLoader>();
+    loader->setCommunicationFabric(true);
+    return loader;
+  });
+}
+
+} // namespace KINETO_NAMESPACE
+#endif // __linux__

--- a/third_party/kineto/libkineto/src/DaemonConfigLoader.h
+++ b/third_party/kineto/libkineto/src/DaemonConfigLoader.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#if !USE_GOOGLE_LOG
+#include <memory>
+#endif // !USE_GOOGLE_LOG
+#ifdef __linux__
+#include "IpcFabricConfigClient.h"
+#endif // __linux__
+
+namespace KINETO_NAMESPACE {
+
+class IDaemonConfigLoader {
+ public:
+  virtual ~IDaemonConfigLoader() = default;
+
+  // Return the base config from the daemon
+  virtual std::string readBaseConfig() = 0;
+
+  // Return a configuration string from the daemon, if one has been posted.
+  virtual std::string readOnDemandConfig(bool activities) = 0;
+
+  virtual void setCommunicationFabric(bool enabled) = 0;
+};
+
+// Basic Daemon Config Loader that uses IPCFabric for communication
+// Only works on Linux based platforms
+#ifdef __linux__
+class DaemonConfigLoader : public IDaemonConfigLoader {
+ public:
+  DaemonConfigLoader() = default;
+
+  // Return the base config from the daemon
+  std::string readBaseConfig() override;
+
+  // Return a configuration string from the daemon, if one has been posted.
+  std::string readOnDemandConfig(bool activities) override;
+
+  void setCommunicationFabric(bool enabled) override;
+
+  IpcFabricConfigClient* getConfigClient();
+
+  static void registerFactory();
+
+ private:
+  std::unique_ptr<IpcFabricConfigClient> configClient;
+};
+#endif // __linux__
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/Demangle.cpp
+++ b/third_party/kineto/libkineto/src/Demangle.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "Demangle.h"
+
+#ifndef _MSC_VER
+
+#if defined(__clang__)
+_Pragma("GCC diagnostic push");
+_Pragma("GCC diagnostic ignored \"-Wdeprecated-dynamic-exception-spec\"");
+#endif
+#include <cxxabi.h>
+#if defined(__clang__)
+_Pragma("GCC diagnostic pop");
+#endif
+#endif // _MSC_VER
+
+#include <cstring>
+#include <string>
+
+namespace KINETO_NAMESPACE {
+
+static constexpr int kMaxSymbolSize = 8192;
+
+std::string demangle(const char* name) {
+#ifndef _MSC_VER
+  if (!name) {
+    return "";
+  }
+
+  if (strlen(name) > kMaxSymbolSize) {
+    return name;
+  }
+
+  int status = 0;
+  size_t len = 0;
+  char* demangled = abi::__cxa_demangle(name, nullptr, &len, &status);
+  if (status != 0) {
+    return name;
+  }
+  std::string res(demangled);
+  // The returned buffer must be freed!
+  free(demangled);
+  return res;
+#else
+  // TODO: demangling on Windows
+  if (!name) {
+    return "";
+  } else {
+    return name;
+  }
+#endif
+}
+
+std::string demangle(const std::string& name) {
+  return demangle(name.c_str());
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/Demangle.h
+++ b/third_party/kineto/libkineto/src/Demangle.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace KINETO_NAMESPACE {
+
+std::string demangle(const char* name);
+std::string demangle(const std::string& name);
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/DeviceProperties.cpp
+++ b/third_party/kineto/libkineto/src/DeviceProperties.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DeviceProperties.h"
+
+#include "MetadataFieldCatalog.h"
+#include "TypedMetadataJson.h"
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#ifdef HAS_CUPTI
+#include <cuda_occupancy.h>
+#include <cuda_runtime.h>
+#elif defined(HAS_ROCTRACER)
+#include <hip/hip_runtime.h>
+#elif defined(HAS_XPUPTI)
+#include "plugin/xpupti/XpuptiActivityProfiler.h"
+#endif
+
+#include "Logger.h"
+
+namespace KINETO_NAMESPACE {
+
+namespace DevicePropertyFields = libkineto::DevicePropertyMetadataFields;
+
+#ifdef HAS_CUPTI
+#define gpuDeviceProp cudaDeviceProp
+#define gpuError_t cudaError_t
+#define gpuSuccess cudaSuccess
+#define gpuGetDeviceCount cudaGetDeviceCount
+#define gpuGetDeviceProperties cudaGetDeviceProperties
+#elif defined(HAS_ROCTRACER)
+#define gpuDeviceProp hipDeviceProp_t
+#define gpuError_t hipError_t
+#define gpuSuccess hipSuccess
+#define gpuGetDeviceCount hipGetDeviceCount
+#define gpuGetDeviceProperties hipGetDeviceProperties
+#endif
+
+#if defined(HAS_CUPTI) || defined(HAS_ROCTRACER)
+static std::vector<gpuDeviceProp> createDeviceProps() {
+  std::vector<gpuDeviceProp> props;
+  int device_count;
+  gpuError_t error_id = gpuGetDeviceCount(&device_count);
+  // Return empty vector if error.
+  if (error_id != gpuSuccess) {
+    LOG(ERROR) << "gpuGetDeviceCount failed with code " << error_id;
+    return {};
+  }
+  VLOG(0) << "Device count is " << device_count;
+  for (int i = 0; i < device_count; ++i) {
+    gpuDeviceProp prop;
+    error_id = gpuGetDeviceProperties(&prop, i);
+    // Return empty vector if any device property fail to get.
+    if (error_id != gpuSuccess) {
+      LOG(ERROR) << "gpuGetDeviceProperties failed with " << error_id;
+      return {};
+    }
+    props.push_back(prop);
+    LOGGER_OBSERVER_ADD_DEVICE(i);
+  }
+  return props;
+}
+
+static const std::vector<gpuDeviceProp>& deviceProps() {
+  static const std::vector<gpuDeviceProp> props = createDeviceProps();
+  return props;
+}
+
+// Emit one device's compute properties as typed metadata
+static void visitDeviceMetadata(
+    size_t id,
+    const gpuDeviceProp& props,
+    libkineto::ITypedMetadataVisitor& visitor) {
+  visitor.visit(DevicePropertyFields::kId, static_cast<uint64_t>(id));
+  visitor.visit(DevicePropertyFields::kName, std::string{props.name});
+  visitor.visit(
+      DevicePropertyFields::kTotalGlobalMem,
+      static_cast<uint64_t>(props.totalGlobalMem));
+  visitor.visit(
+      DevicePropertyFields::kComputeMajor, static_cast<int64_t>(props.major));
+  visitor.visit(
+      DevicePropertyFields::kComputeMinor, static_cast<int64_t>(props.minor));
+  visitor.visit(
+      DevicePropertyFields::kMaxThreadsPerBlock,
+      static_cast<int64_t>(props.maxThreadsPerBlock));
+  visitor.visit(
+      DevicePropertyFields::kMaxThreadsPerMultiprocessor,
+      static_cast<int64_t>(props.maxThreadsPerMultiProcessor));
+  visitor.visit(
+      DevicePropertyFields::kRegsPerBlock,
+      static_cast<int64_t>(props.regsPerBlock));
+  visitor.visit(
+      DevicePropertyFields::kWarpSize, static_cast<int64_t>(props.warpSize));
+  visitor.visit(
+      DevicePropertyFields::kSharedMemPerBlock,
+      static_cast<uint64_t>(props.sharedMemPerBlock));
+  visitor.visit(
+      DevicePropertyFields::kNumSms,
+      static_cast<int64_t>(props.multiProcessorCount));
+#ifdef HAS_CUPTI
+  visitor.visit(
+      DevicePropertyFields::kRegsPerMultiprocessor,
+      static_cast<int64_t>(props.regsPerMultiprocessor));
+  visitor.visit(
+      DevicePropertyFields::kSharedMemPerBlockOptin,
+      static_cast<uint64_t>(props.sharedMemPerBlockOptin));
+  visitor.visit(
+      DevicePropertyFields::kSharedMemPerMultiprocessor,
+      static_cast<uint64_t>(props.sharedMemPerMultiprocessor));
+#elif defined(HAS_ROCTRACER)
+  visitor.visit(
+      DevicePropertyFields::kMaxSharedMemoryPerMultiProcessor,
+      static_cast<uint64_t>(props.maxSharedMemoryPerMultiProcessor));
+#endif
+}
+
+static std::string createDevicePropertiesJson() {
+  const auto& props = deviceProps();
+  std::vector<std::string> jsonProps;
+  jsonProps.reserve(props.size());
+  for (size_t i = 0; i < props.size(); i++) {
+    libkineto::internal::JsonTypedMetadataVisitor visitor;
+    visitDeviceMetadata(i, props[i], visitor);
+    jsonProps.push_back("{" + std::move(visitor).json() + "}");
+  }
+  return fmt::format("{}", fmt::join(jsonProps, ","));
+}
+#endif // HAS_CUPTI || HAS_ROCTRACER
+
+const std::string& devicePropertiesJson() {
+#if defined(HAS_CUPTI) || defined(HAS_ROCTRACER)
+  static std::string devicePropsJson = createDevicePropertiesJson();
+#elif defined(HAS_XPUPTI)
+  static std::string devicePropsJson = getXpuDeviceProperties();
+#else
+  static std::string devicePropsJson;
+#endif
+  return devicePropsJson;
+}
+
+int smCount([[maybe_unused]] uint32_t deviceId) {
+#if defined(HAS_CUPTI) || defined(HAS_ROCTRACER)
+  const std::vector<gpuDeviceProp>& props = deviceProps();
+  return deviceId >= props.size() ? 0 : props[deviceId].multiProcessorCount;
+#else
+  return 0;
+#endif
+}
+
+#ifdef HAS_CUPTI
+float blocksPerSm(const CUpti_ActivityKernelType& kernel) {
+  int sm_count = smCount(kernel.deviceId);
+  if (sm_count == 0) {
+    return std::numeric_limits<float>::infinity();
+  }
+  return (kernel.gridX * kernel.gridY * kernel.gridZ) /
+      static_cast<float>(sm_count);
+}
+
+float warpsPerSm(const CUpti_ActivityKernelType& kernel) {
+  constexpr int threads_per_warp = 32;
+  return blocksPerSm(kernel) * (kernel.blockX * kernel.blockY * kernel.blockZ) /
+      threads_per_warp;
+}
+
+OccupancyMetrics computeOccupancyMetrics(
+    const CUpti_ActivityKernelType& kernel) {
+  OccupancyMetrics metrics;
+  const std::vector<cudaDeviceProp>& props = deviceProps();
+  if (kernel.deviceId >= props.size()) {
+    LOG(ERROR) << "Invalid deviceId " << kernel.deviceId
+               << " exceeds available devices (" << props.size()
+               << "), skipping occupancy calculation";
+    return metrics;
+  }
+
+  float blocksPerSm = -1.0;
+  int sm_count = smCount(kernel.deviceId);
+  if (sm_count != 0) {
+    blocksPerSm = (kernel.gridX * kernel.gridY * kernel.gridZ) /
+        static_cast<float>(sm_count);
+  }
+
+  cudaOccFuncAttributes occFuncAttr;
+  occFuncAttr.maxThreadsPerBlock = INT_MAX;
+  occFuncAttr.numRegs = kernel.registersPerThread;
+  occFuncAttr.sharedSizeBytes = kernel.staticSharedMemory;
+  occFuncAttr.partitionedGCConfig = PARTITIONED_GC_OFF;
+  occFuncAttr.shmemLimitConfig = FUNC_SHMEM_LIMIT_DEFAULT;
+  occFuncAttr.maxDynamicSharedSizeBytes = 0;
+  const cudaOccDeviceState occDeviceState = {};
+  int blockSize = kernel.blockX * kernel.blockY * kernel.blockZ;
+  size_t dynamicSmemSize = kernel.dynamicSharedMemory;
+  cudaOccDeviceProp prop(props[kernel.deviceId]);
+  cudaOccError status = cudaOccMaxActiveBlocksPerMultiprocessor(
+      &metrics.result,
+      &prop,
+      &occFuncAttr,
+      &occDeviceState,
+      blockSize,
+      dynamicSmemSize);
+  if (status == CUDA_OCC_SUCCESS) {
+    float effectiveBlocksPerSm = std::min<float>(
+        metrics.result.activeBlocksPerMultiprocessor, blocksPerSm);
+    metrics.occupancy = effectiveBlocksPerSm * blockSize /
+        static_cast<float>(props[kernel.deviceId].maxThreadsPerMultiProcessor);
+  } else {
+    LOG_EVERY_N(ERROR, 1000)
+        << "Failed to calculate occupancy, status = " << status;
+  }
+  return metrics;
+}
+#endif // HAS_CUPTI
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/DeviceProperties.h
+++ b/third_party/kineto/libkineto/src/DeviceProperties.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#ifdef HAS_CUPTI
+#include <cuda_occupancy.h>
+#include <cupti.h>
+#endif
+
+namespace KINETO_NAMESPACE {
+
+// Return compute properties for each device as a json string
+const std::string& devicePropertiesJson();
+
+int smCount(uint32_t deviceId);
+
+// TODO: Implement the below for HAS_ROCTRACER
+#ifdef HAS_CUPTI
+
+// Use newer CUPTI activity structs for extended fields
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 13010
+using CUpti_ActivityKernelType = CUpti_ActivityKernel11;
+#elif defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+using CUpti_ActivityKernelType = CUpti_ActivityKernel9;
+#else
+using CUpti_ActivityKernelType = CUpti_ActivityKernel4;
+#endif
+
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+using CUpti_ActivityMemcpyType = CUpti_ActivityMemcpy5;
+using CUpti_ActivityMemcpyPtoPType = CUpti_ActivityMemcpyPtoP4;
+using CUpti_ActivityMemsetType = CUpti_ActivityMemset4;
+#else
+using CUpti_ActivityMemcpyType = CUpti_ActivityMemcpy;
+using CUpti_ActivityMemcpyPtoPType = CUpti_ActivityMemcpy2;
+using CUpti_ActivityMemsetType = CUpti_ActivityMemset;
+#endif
+
+float blocksPerSm(const CUpti_ActivityKernelType& kernel);
+float warpsPerSm(const CUpti_ActivityKernelType& kernel);
+
+// Occupancy results from CUDA occupancy calculator
+// Returns cudaOccResult from cuda_occupancy.h plus a computed occupancy metric
+struct OccupancyMetrics {
+  float occupancy = -1.0f; // Computed effective occupancy in number of threads
+  cudaOccResult result =
+      {}; // Raw results from cudaOccMaxActiveBlocksPerMultiprocessor
+};
+
+// Return detailed occupancy metrics including limiting factors
+OccupancyMetrics computeOccupancyMetrics(
+    const CUpti_ActivityKernelType& kernel);
+#endif
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/DeviceUtil.cpp
+++ b/third_party/kineto/libkineto/src/DeviceUtil.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DeviceUtil.h"
+
+#include <mutex>
+
+namespace KINETO_NAMESPACE {
+
+bool amdGpuAvailable = false;
+bool cudaGpuAvailable = false;
+
+bool isAMDGpuAvailable() {
+#ifdef HAS_ROCTRACER
+  static std::once_flag once;
+  std::call_once(once, [] {
+    // determine AMD GPU availability on the system
+    hipError_t error;
+    int deviceCount;
+    error = hipGetDeviceCount(&deviceCount);
+    amdGpuAvailable = (error == hipSuccess && deviceCount > 0);
+  });
+#endif
+  return amdGpuAvailable;
+}
+
+bool isCUDAGpuAvailable() {
+#ifdef HAS_CUPTI
+  static std::once_flag once;
+  std::call_once(once, [] {
+    // determine CUDA GPU availability on the system
+    cudaError_t error;
+    int deviceCount;
+    error = cudaGetDeviceCount(&deviceCount);
+    cudaGpuAvailable = (error == cudaSuccess && deviceCount > 0);
+  });
+#endif
+  return cudaGpuAvailable;
+}
+
+bool isGpuAvailable() {
+  bool amd = isAMDGpuAvailable();
+  bool cuda = isCUDAGpuAvailable();
+  return amd || cuda;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/DeviceUtil.h
+++ b/third_party/kineto/libkineto/src/DeviceUtil.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+
+#ifdef HAS_CUPTI
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cupti.h>
+
+// ok to use fmt::format as error will not occur often. Can't use fmt::print
+// easily since LOG(...) can return void, causes compiler error
+#define CUDA_CALL(call)                                    \
+  [&]() -> cudaError_t {                                   \
+    cudaError_t _status_ = call;                           \
+    if (_status_ != cudaSuccess) {                         \
+      const char* _errstr_ = cudaGetErrorString(_status_); \
+      LOG(WARNING) << fmt::format(                         \
+          "function {} failed with error {} ({})",         \
+          #call,                                           \
+          _errstr_,                                        \
+          (int)_status_);                                  \
+    }                                                      \
+    return _status_;                                       \
+  }()
+
+#define CUPTI_CALL(call)                           \
+  [&]() -> CUptiResult {                           \
+    CUptiResult _status_ = call;                   \
+    if (_status_ != CUPTI_SUCCESS) {               \
+      const char* _errstr_ = nullptr;              \
+      cuptiGetResultString(_status_, &_errstr_);   \
+      LOG(WARNING) << fmt::format(                 \
+          "function {} failed with error {} ({})", \
+          #call,                                   \
+          _errstr_,                                \
+          (int)_status_);                          \
+    }                                              \
+    return _status_;                               \
+  }()
+
+#elif defined(HAS_ROCTRACER)
+#include <hip/hip_runtime.h>
+#include <rocprofiler-sdk/version.h>
+
+#define CUDA_CALL(call)                                   \
+  {                                                       \
+    hipError_t _status_ = call;                           \
+    if (_status_ != hipSuccess) {                         \
+      const char* _errstr_ = hipGetErrorString(_status_); \
+      LOG(WARNING) << fmt::format(                        \
+          "function {} failed with error {} ({})",        \
+          #call,                                          \
+          _errstr_,                                       \
+          (int)_status_);                                 \
+    }                                                     \
+  }
+
+#define CUPTI_CALL(call) call
+
+#else
+#define CUPTI_CALL(call) call
+#endif // HAS_CUPTI
+
+#define CUPTI_CALL_NOWARN(call) call
+
+namespace KINETO_NAMESPACE {
+
+bool isAMDGpuAvailable();
+
+bool isCUDAGpuAvailable();
+
+bool isGpuAvailable();
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/GenericActivityProfiler.cpp
+++ b/third_party/kineto/libkineto/src/GenericActivityProfiler.cpp
@@ -1,0 +1,826 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "GenericActivityProfiler.h"
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+#include "ApproximateClock.h"
+
+#include "ActivityBuffers.h"
+#include "Config.h"
+#include "DeviceProperties.h"
+#include "DeviceUtil.h"
+#include "output_base.h"
+#include "time_since_epoch.h"
+
+#include "Logger.h"
+#include "ThreadUtil.h"
+
+using namespace std::chrono;
+using std::string;
+
+namespace KINETO_NAMESPACE {
+
+// TODO: Move config elsehwere. Sync with @sraikund16 on details.
+ConfigDerivedState::ConfigDerivedState(const Config& config) {
+  profileActivityTypes_ = config.selectedActivityTypes();
+  profileStartTime_ = config.requestTimestamp();
+  profileDuration_ = config.activitiesDuration();
+  profileWarmupDuration_ = config.activitiesWarmupDuration();
+  profilingByIter_ = config.hasProfileStartIteration();
+  perThreadBufferEnabled_ = config.perThreadBufferEnabled();
+  if (profilingByIter_) {
+    profileStartIter_ = config.profileStartIteration();
+    profileEndIter_ = profileStartIter_ + config.activitiesRunIterations();
+  } else {
+    profileEndIter_ = (std::numeric_limits<decltype(profileEndIter_)>::max)();
+    profileEndTime_ = profileStartTime_ + config.activitiesDuration();
+  }
+}
+
+bool ConfigDerivedState::canStart(
+    const std::chrono::time_point<std::chrono::system_clock>& now) const {
+  if (profilingByIter_) {
+    return true;
+  }
+  if (profileStartTime_ < now) {
+    LOG(WARNING)
+        << "Not starting tracing - start timestamp is in the past. Time difference (ms): "
+        << duration_cast<milliseconds>(now - profileStartTime_).count();
+    return false;
+  } else if ((profileStartTime_ - now) < profileWarmupDuration_) {
+    LOG(WARNING)
+        << "Not starting tracing - insufficient time for warmup. Time to warmup (ms): "
+        << duration_cast<milliseconds>(profileStartTime_ - now).count();
+    return false;
+  }
+  return true;
+}
+
+bool ConfigDerivedState::isCollectionDone(
+    const time_point<system_clock>& now,
+    int64_t currentIter) const {
+  bool isTimestampBased = !profilingByIter_ && currentIter < 0;
+  if (isTimestampBased) {
+    // qualify that this check is not being called from application step() API
+    return now >= profileEndTime_;
+  }
+  bool isIterationBased = profilingByIter_ && currentIter >= 0;
+  if (isIterationBased) {
+    return currentIter >= profileEndIter_;
+  }
+  return false;
+}
+
+std::ostream& operator<<(
+    std::ostream& oss,
+    const GenericActivityProfiler::ErrorCounts& ecs) {
+  oss << "Out-of-range = " << ecs.out_of_range_events
+      << ", Blocklisted runtime = " << ecs.blocklisted_runtime_events
+      << ", Invalid ext correlations = "
+      << ecs.invalid_external_correlation_events
+      << ", CPU GPU out-of-order = " << ecs.gpu_and_cpu_op_out_of_order
+      << ", Unexpected CUDA events = " << ecs.unexepected_cuda_events
+      << ", GPU stopped early? = " << ecs.gpu_stopped_early;
+  return oss;
+}
+
+GenericActivityProfiler::GenericActivityProfiler(bool cpuOnly)
+    : flushOverhead_{0, 0}, setupOverhead_{0, 0}, cpuOnly_{cpuOnly} {}
+GenericActivityProfiler::~GenericActivityProfiler() {}
+
+void GenericActivityProfiler::transferCpuTrace(
+    std::unique_ptr<libkineto::CpuTraceBuffer> cpuTrace) {
+  std::lock_guard<std::recursive_mutex> guard(mutex_);
+  const string& trace_name = cpuTrace->span.name;
+  // acceptCpuTraces_ stays true after the synchronous processTrace() path moves
+  // traceBuffers_ out via finalizeTrace() (only completeTrace()/resetInternal()
+  // clears it), so a late span can arrive with traceBuffers_ already null.
+  // Treat either condition as "not collecting" and discard instead of
+  // dereferencing.
+  if (!acceptCpuTraces_ || traceBuffers_ == nullptr) {
+    VLOG(0) << "Trace collection not in progress - discarding span "
+            << trace_name;
+    return;
+  }
+
+  cpuTrace->span.iteration = iterationCountMap_[trace_name]++;
+
+  VLOG(0) << "Received iteration " << cpuTrace->span.iteration << " of span "
+          << trace_name << " (" << cpuTrace->activities.size()
+          << " activities / " << cpuTrace->gpuOpCount << " gpu activities)";
+  traceBuffers_->cpu.push_back(std::move(cpuTrace));
+}
+
+namespace {
+
+const std::unordered_set<std::string>& getLoggerMedataAllowList() {
+  static const std::unordered_set<std::string> kLoggerMedataAllowList{
+      "with_stack", "with_modules", "record_shapes", "profile_memory"};
+  return kLoggerMedataAllowList;
+}
+
+} // namespace
+
+void GenericActivityProfiler::processTraceInternal(ActivityLogger& logger) {
+  UST_LOGGER_STAGE_SCOPE(kPostProcessingStage);
+  // A previous processTraceInternal() moved traceBuffers_ out via
+  // finalizeTrace(); a redundant process call can reach here with it already
+  // null. Bail out instead of dereferencing null.
+  if (traceBuffers_ == nullptr) {
+    LOG(WARNING) << "No trace buffers to process - skipping";
+    return;
+  }
+  LOG(INFO) << "Processing " << traceBuffers_->cpu.size() << " CPU buffers";
+  VLOG(0) << "Profile time range: " << captureWindowStartTime_ << " - "
+          << captureWindowEndTime_;
+
+  // Pass metadata within the trace to the logger observer.
+  for (const auto& pair : metadata_) {
+    if (getLoggerMedataAllowList().contains(pair.first)) {
+      LOGGER_OBSERVER_ADD_METADATA(pair.first, pair.second);
+    }
+  }
+  for (auto& pair : versionMetadata_) {
+    addMetadata(pair.first, pair.second);
+  }
+  std::vector<std::string> device_properties;
+  if (const auto& props = devicePropertiesJson(); !props.empty()) {
+    device_properties.push_back(props);
+  }
+  for (const auto& session : sessions_) {
+    if (auto props = session->getDeviceProperties(); !props.empty()) {
+      if (std::ranges::find(device_properties, props) ==
+          device_properties.end()) {
+        device_properties.push_back(props);
+      }
+    }
+    for (const auto& [key, value] : session->getMetadata()) {
+      addMetadata(key, value);
+    }
+  }
+  logger.handleTraceStart(
+      metadata_, fmt::format("{}", fmt::join(device_properties, ",")));
+  setCpuActivityPresent(false);
+  setGpuActivityPresent(false);
+  for (auto& cpu_trace : traceBuffers_->cpu) {
+    string trace_name = cpu_trace->span.name;
+    VLOG(0) << "Processing CPU buffer for " << trace_name << " ("
+            << cpu_trace->span.iteration << ") - "
+            << cpu_trace->activities.size() << " records";
+    VLOG(0) << "Span time range: " << cpu_trace->span.startTime << " - "
+            << cpu_trace->span.endTime;
+    processCpuTrace(*cpu_trace, logger);
+    LOGGER_OBSERVER_ADD_EVENT_COUNT(cpu_trace->activities.size());
+  }
+
+  // Process GPU activities via derived class
+  if (!cpuOnly_) {
+    processGpuActivities(logger);
+    if (!gpuActivityPresent()) {
+      LOG(WARNING) << "GPU trace is empty!";
+    }
+  }
+
+  if (!traceNonEmpty()) {
+    LOG(WARNING) << kEmptyTrace;
+  }
+
+  for (const auto& session : sessions_) {
+    LOG(INFO) << "Processing child profiler trace";
+    // cpuActivity() function here is used to get the linked cpuActivity for
+    // session's activities. Passing captureWindowStartTime_ and
+    // captureWindowEndTime_ in order to specify the range of activities that
+    // need to be processed.
+    session->processTrace(
+        logger,
+        [this](auto&& correlationId) {
+          return cpuActivity(
+              std::forward<decltype(correlationId)>(correlationId));
+        },
+        captureWindowStartTime_,
+        captureWindowEndTime_);
+  }
+
+  LOG(INFO) << "Record counts: " << ecs_;
+
+  finalizeTrace(*config_, logger);
+}
+
+GenericActivityProfiler::CpuGpuSpanPair& GenericActivityProfiler::
+    recordTraceSpan(TraceSpan& span, int gpuOpCount) {
+  TraceSpan gpu_span(gpuOpCount, span.iteration, span.name, "GPU: ");
+  auto& iterations = traceSpans_[span.name];
+  iterations.emplace_back(span, gpu_span);
+  return iterations.back();
+}
+
+void GenericActivityProfiler::processCpuTrace(
+    libkineto::CpuTraceBuffer& cpuTrace,
+    ActivityLogger& logger) {
+  if (cpuTrace.activities.empty()) {
+    LOG(WARNING) << "CPU trace is empty!";
+    return;
+  }
+  setCpuActivityPresent(true);
+  bool warn_once = false;
+  CpuGpuSpanPair& span_pair =
+      recordTraceSpan(cpuTrace.span, cpuTrace.gpuOpCount);
+  TraceSpan& cpu_span = span_pair.first;
+  for (auto const& act : cpuTrace.activities) {
+    VLOG(2) << act->correlationId() << ": OP " << act->activityName;
+    if (derivedConfig_->profileActivityTypes().contains(act->type())) {
+      static_assert(
+          std::is_same_v<
+              std::remove_reference_t<decltype(act)>,
+              const std::unique_ptr<GenericTraceActivity>>,
+          "handleActivity is unsafe and relies on the caller to maintain not "
+          "only lifetime but also address stability.");
+      if (act->duration() < 0) {
+        act->endTime = captureWindowEndTime_;
+        act->addMetadata("finished", "false");
+      }
+      logger.handleActivity(*act);
+    }
+    clientActivityTraceMap_[act->correlationId()] = &span_pair;
+    activityMap_[act->correlationId()] = act.get();
+    if (act->deviceId() == 0) {
+      if (!warn_once) {
+        LOG(WARNING)
+            << "CPU activity with pid 0 detected. This is likely due to the python stack"
+               " tracer not being able to determine the pid for an event. Overriding pid to main thread pid";
+      }
+      act->setDevice(processId());
+      warn_once = true;
+    }
+    recordThreadInfo(act->resourceId(), act->getThreadId(), act->deviceId());
+  }
+  logger.handleTraceSpan(cpu_span);
+}
+
+static GenericTraceActivity createUserGpuSpan(
+    const libkineto::ITraceActivity& cpuTraceActivity,
+    const libkineto::ITraceActivity& gpuTraceActivity) {
+  GenericTraceActivity res(
+      *cpuTraceActivity.traceSpan(),
+      ActivityType::GPU_USER_ANNOTATION,
+      cpuTraceActivity.name());
+  res.startTime = gpuTraceActivity.timestamp();
+  res.device = gpuTraceActivity.deviceId();
+  res.resource = gpuTraceActivity.resourceId();
+  res.endTime = gpuTraceActivity.timestamp() + gpuTraceActivity.duration();
+  res.id = cpuTraceActivity.correlationId();
+  return res;
+}
+
+void GenericActivityProfiler::GpuUserEventMap::insertOrExtendEvent(
+    const ITraceActivity& cpuTraceActivity,
+    const ITraceActivity& gpuTraceActivity) {
+  StreamKey key(gpuTraceActivity.deviceId(), gpuTraceActivity.resourceId());
+  CorrelationSpanMap& correlationSpanMap = streamSpanMap_[key];
+  auto it = correlationSpanMap.find(cpuTraceActivity.correlationId());
+  if (it == correlationSpanMap.end()) {
+    auto it_success = correlationSpanMap.insert(
+        {cpuTraceActivity.correlationId(),
+         createUserGpuSpan(cpuTraceActivity, gpuTraceActivity)});
+    it = it_success.first;
+  }
+  GenericTraceActivity& span = it->second;
+  if (gpuTraceActivity.timestamp() < span.startTime || span.startTime == 0) {
+    span.startTime = gpuTraceActivity.timestamp();
+  }
+  int64_t gpu_activity_end =
+      gpuTraceActivity.timestamp() + gpuTraceActivity.duration();
+  span.endTime = std::max(gpu_activity_end, span.endTime);
+}
+
+const GenericActivityProfiler::CpuGpuSpanPair& GenericActivityProfiler::
+    defaultTraceSpan() {
+  static TraceSpan span(0, 0, "Unknown", "");
+  static CpuGpuSpanPair span_pair(span, span);
+  return span_pair;
+}
+
+void GenericActivityProfiler::GpuUserEventMap::logEvents(
+    ActivityLogger* logger) {
+  for (auto const& streamMapPair : streamSpanMap_) {
+    for (auto const& correlationSpanPair : streamMapPair.second) {
+      correlationSpanPair.second.log(*logger);
+    }
+  }
+}
+
+bool GenericActivityProfiler::outOfRange(const ITraceActivity& act) {
+  bool out_of_range = act.timestamp() < captureWindowStartTime_ ||
+      (act.timestamp() + act.duration()) > captureWindowEndTime_;
+  if (out_of_range) {
+    VLOG(2) << "TraceActivity outside of profiling window: " << act.name()
+            << " (" << act.timestamp() << " < " << captureWindowStartTime_
+            << " or " << (act.timestamp() + act.duration()) << " > "
+            << captureWindowEndTime_;
+    ecs_.out_of_range_events++;
+  }
+  return out_of_range;
+}
+
+inline void GenericActivityProfiler::updateGpuNetSpan(
+    const ITraceActivity& gpuOp) {
+  if (!gpuOp.linkedActivity()) {
+    VLOG(0) << "Missing linked activity";
+    return;
+  }
+  const auto& it =
+      clientActivityTraceMap_.find(gpuOp.linkedActivity()->correlationId());
+  if (it == clientActivityTraceMap_.end()) {
+    // No correlation id mapping?
+    return;
+  }
+  TraceSpan& gpu_span = it->second->second;
+  if (gpuOp.timestamp() < gpu_span.startTime || gpu_span.startTime == 0) {
+    gpu_span.startTime = gpuOp.timestamp();
+  }
+  gpu_span.endTime =
+      std::max(gpuOp.timestamp() + gpuOp.duration(), gpu_span.endTime);
+}
+
+// I've observed occasional broken timestamps attached to GPU events...
+void GenericActivityProfiler::checkTimestampOrder(const ITraceActivity* act1) {
+  // Correlated GPU runtime activity cannot
+  // have timestamp greater than the GPU activity's
+  const auto& it = correlatedCudaActivities_.find(act1->correlationId());
+  if (it == correlatedCudaActivities_.end()) {
+    correlatedCudaActivities_.insert({act1->correlationId(), act1});
+    return;
+  }
+
+  // Activities may be appear in the buffers out of order.
+  // If we have a runtime activity in the map, it should mean that we
+  // have a GPU activity passed in, and vice versa.
+  const ITraceActivity* act2 = it->second;
+  if (act2->type() == ActivityType::CUDA_RUNTIME) {
+    // Buffer is out-of-order.
+    // Swap so that runtime activity is first for the comparison below.
+    std::swap(act1, act2);
+  }
+  // Range Profiling mode returns kernels with 0 ts and duration that we can
+  // pass through to output
+  if (act2->timestamp() == 0) {
+    return;
+  }
+  if (act1->timestamp() > act2->timestamp()) {
+    LOG_FIRST_N(WARNING, 10)
+        << "GPU op timestamp (" << act2->timestamp()
+        << ") < runtime timestamp (" << act1->timestamp() << ") by "
+        << act1->timestamp() - act2->timestamp() << "us"
+        << " Name: " << act2->name() << " Device: " << act2->deviceId()
+        << " Stream: " << act2->resourceId();
+    ecs_.gpu_and_cpu_op_out_of_order++;
+  }
+}
+
+const ITraceActivity* GenericActivityProfiler::linkedActivity(
+    int32_t correlationId,
+    const std::unordered_map<int64_t, int64_t>& correlationMap) {
+  const auto& it = correlationMap.find(correlationId);
+  if (it != correlationMap.end()) {
+    const auto& it2 = activityMap_.find(it->second);
+    if (it2 != activityMap_.end()) {
+      return it2->second;
+    }
+  }
+  return nullptr;
+}
+
+void GenericActivityProfiler::handleGpuActivity(
+    const ITraceActivity& act,
+    ActivityLogger* logger) {
+  if (outOfRange(act)) {
+    return;
+  }
+  checkTimestampOrder(&act);
+  VLOG(2) << act.correlationId() << ": " << act.name();
+  recordStream(act.deviceId(), act.resourceId(), "");
+  seenDeviceStreams_.insert({act.deviceId(), act.resourceId()});
+
+  act.log(*logger);
+  setGpuActivityPresent(true);
+  updateGpuNetSpan(act);
+  if (derivedConfig_->profileActivityTypes().contains(
+          ActivityType::GPU_USER_ANNOTATION)) {
+    const auto& it = userCorrelationMap_.find(act.correlationId());
+    if (it != userCorrelationMap_.end()) {
+      const auto& it2 = activityMap_.find(it->second);
+      if (it2 != activityMap_.end()) {
+        recordStream(act.deviceId(), act.resourceId(), "context");
+        gpuUserEventMap_.insertOrExtendEvent(*it2->second, act);
+      }
+    }
+  }
+}
+
+const ITraceActivity* GenericActivityProfiler::cpuActivity(
+    int32_t correlationId) {
+  const auto& it2 = activityMap_.find(correlationId);
+  return (it2 != activityMap_.end()) ? it2->second : nullptr;
+}
+
+void GenericActivityProfiler::configureChildProfilers() {
+  // If child profilers are enabled create profiler sessions
+  int64_t start_time_ms =
+      duration_cast<milliseconds>(
+          derivedConfig_->profileStartTime().time_since_epoch())
+          .count();
+  for (auto& profiler : profilers_) {
+    LOG(INFO) << "[Profiler = " << profiler->name() << "] "
+              << "Evaluating whether to run child profiler.";
+    auto session = profiler->configure(
+        start_time_ms,
+        derivedConfig_->profileDuration().count(),
+        derivedConfig_->profileActivityTypes(),
+        *config_);
+    if (session) {
+      LOG(INFO) << "[Profiler = " << profiler->name() << "] "
+                << "Running child profiler " << profiler->name() << " for "
+                << derivedConfig_->profileDuration().count() << " ms";
+      sessions_.push_back(std::move(session));
+    } else {
+      LOG(INFO) << "[Profiler = " << profiler->name() << "] "
+                << "Not running child profiler.";
+    }
+  }
+}
+
+void GenericActivityProfiler::configure(
+    const Config& config,
+    const time_point<system_clock>& now) {
+  std::lock_guard<std::recursive_mutex> guard(mutex_);
+  ApproximateClockToUnixTimeConverter clockConverter;
+  get_time_converter() = clockConverter.makeConverter();
+
+  config_ = config.clone();
+
+  // Ensure we're starting in a clean state
+  resetTraceData();
+
+  derivedConfig_.reset();
+  derivedConfig_ = std::make_unique<ConfigDerivedState>(*config_);
+
+  if (LOG_IS_ON(INFO)) {
+    config_->printActivityProfilerConfig(LIBKINETO_DBG_STREAM);
+  }
+  if (!cpuOnly_ && !libkineto::api().client()) {
+    gpuOnly_ = true;
+    if (derivedConfig_->isProfilingByIteration()) {
+      LOG(INFO) << "GPU-only tracing for " << config_->activitiesRunIterations()
+                << " iterations";
+    } else {
+      LOG(INFO) << "GPU-only tracing for "
+                << config_->activitiesDuration().count() << "ms";
+    }
+  }
+
+  // Set useful metadata into the logger.
+  LOGGER_OBSERVER_SET_TRACE_DURATION_MS(config_->activitiesDuration().count());
+  LOGGER_OBSERVER_SET_TRACE_ID(config_->requestTraceID());
+  LOGGER_OBSERVER_SET_GROUP_TRACE_ID(config_->requestGroupTraceID());
+  if (!config_->requestTraceID().empty()) {
+    addMetadata("trace_id", "\"" + config_->requestTraceID() + "\"");
+  }
+
+  if (!cpuOnly_) {
+    // Enabling CUPTI activity tracing incurs a larger perf hit at first,
+    // presumably because structures are allocated and initialized, callbacks
+    // are activated etc. After a while the overhead decreases and stabilizes.
+    // It's therefore useful to perform some warmup before starting recording.
+    LOG(INFO) << "Enabling GPU tracing with max buffer size "
+              << config_->activitiesMaxGpuBufferSize() / 1024 / 1024 << "MB)";
+    setMaxGpuBufferSize(config_->activitiesMaxGpuBufferSize());
+    time_point<system_clock> timestamp;
+    if (VLOG_IS_ON(1)) {
+      timestamp = system_clock::now();
+    }
+    toggleState_.store(true);
+    enableGpuTracing();
+    if (VLOG_IS_ON(1)) {
+      auto t2 = system_clock::now();
+      addOverheadSample(
+          setupOverhead_, duration_cast<microseconds>(t2 - timestamp).count());
+    }
+  }
+
+  if (!profilers_.empty()) {
+    configureChildProfilers();
+  }
+
+  if (libkineto::api().client()) {
+    libkineto::api().client()->prepare(
+        config_->isReportInputShapesEnabled(),
+        config_->isProfileMemoryEnabled(),
+        config_->isWithStackEnabled(),
+        config_->isWithFlopsEnabled(),
+        config_->isWithModulesEnabled());
+  }
+
+  if (derivedConfig_->isProfilingByIteration()) {
+    LOG(INFO) << "Tracing starting on iteration = "
+              << derivedConfig_->profileStartIteration();
+    LOG(INFO) << "Tracing will end on iteration = "
+              << derivedConfig_->profileEndIteration();
+  } else {
+    LOG(INFO) << "Tracing starting in "
+              << duration_cast<seconds>(
+                     derivedConfig_->profileStartTime() - now)
+                     .count()
+              << "s";
+    LOG(INFO) << "Tracing will end in "
+              << duration_cast<seconds>(derivedConfig_->profileEndTime() - now)
+                     .count()
+              << "s";
+  }
+
+  traceBuffers_ = std::make_unique<ActivityBuffers>();
+  captureWindowStartTime_ = captureWindowEndTime_ = 0;
+  acceptCpuTraces_ = false;
+}
+
+void GenericActivityProfiler::flushWarmupBuffers(
+    int64_t currentIter,
+    const time_point<system_clock>& nextWakeupTime) {
+  if (cpuOnly_) {
+    return;
+  }
+  // Flushing GPU activities can take a while so avoid doing it close to
+  // the start time. Clear during warmup in the following cases:
+  // 1. Iteration-based flow: called from application step() API
+  //    (currentIter >= 0) with iteration profiling enabled
+  // 2. Timestamp-based flow: called from periodic runloop
+  //    (currentIter < 0) when not close to profile start time
+  // 3. Iteration config with periodic runloop: always safe to clear
+  const bool isIterationBasedFlow =
+      derivedConfig_->isProfilingByIteration() && currentIter >= 0;
+  const bool isTimestampBasedFlowSafeToFlush =
+      !derivedConfig_->isProfilingByIteration() && currentIter < 0 &&
+      nextWakeupTime < derivedConfig_->profileStartTime();
+  const bool isIterationConfigWithPeriodicRunloop =
+      derivedConfig_->isProfilingByIteration() && currentIter < 0;
+
+  if (isIterationBasedFlow || isTimestampBasedFlowSafeToFlush ||
+      isIterationConfigWithPeriodicRunloop) {
+    clearGpuActivities();
+  }
+}
+
+void GenericActivityProfiler::toggleCollectionDynamic(const bool enable) {
+  if (toggleState_.load() == enable) {
+    return;
+  }
+  toggleState_.store(enable);
+
+  // The ordering of conditions and synchronization is deliberate. We
+  // intentionally synchronize:
+  //
+  //   - AFTER we disable
+  //   - BEFORE we enable
+  //
+  // Both to prevent the synchronization event from showing up in traces.
+  if (!enable) {
+    for (auto& session : sessions_) {
+      session->toggleCollectionDynamic(enable);
+    }
+    disableGpuTracing();
+  }
+  synchronizeGpuDevice();
+  if (enable) {
+    enableGpuTracing();
+    for (auto& session : sessions_) {
+      session->toggleCollectionDynamic(enable);
+    }
+  }
+}
+
+void GenericActivityProfiler::startTraceInternal(
+    const time_point<system_clock>& now) {
+  captureWindowStartTime_ = libkineto::timeSinceEpoch(now);
+  for (auto& session : sessions_) {
+    LOG(INFO) << "Starting child profiler session";
+    session->start();
+  }
+  acceptCpuTraces_ = true;
+}
+
+void GenericActivityProfiler::stopTraceInternal(
+    const time_point<system_clock>& now) {
+  captureWindowEndTime_ = libkineto::timeSinceEpoch(now);
+  if (!cpuOnly_) {
+    time_point<system_clock> timestamp;
+    if (VLOG_IS_ON(1)) {
+      timestamp = system_clock::now();
+    }
+    toggleState_.store(false);
+    disableGpuTracing();
+    if (VLOG_IS_ON(1)) {
+      auto t2 = system_clock::now();
+      addOverheadSample(
+          setupOverhead_, duration_cast<microseconds>(t2 - timestamp).count());
+    }
+  }
+
+  for (auto& session : sessions_) {
+    LOG(INFO) << "Stopping child profiler session";
+    session->stop();
+  }
+}
+
+void GenericActivityProfiler::resetInternal() {
+  acceptCpuTraces_ = false;
+  resetTraceData();
+}
+
+void GenericActivityProfiler::finalizeTrace(
+    const Config& config,
+    ActivityLogger& logger) {
+  LOG(INFO) << "CPU Traces Recorded:";
+  {
+    for (const auto& it : iterationCountMap_) {
+      LOG(INFO) << it.first << ": " << it.second << " span(s) recorded";
+    }
+    iterationCountMap_.clear();
+  }
+
+  // Thread & stream info
+  for (const auto& pair : resourceInfo_) {
+    const auto& resource = pair.second;
+    logger.handleResourceInfo(resource, captureWindowStartTime_);
+  }
+
+  bool use_default_device_info = true;
+  for (auto& session : sessions_) {
+    auto device_info = session->getDeviceInfo();
+    if (device_info != nullptr) {
+      use_default_device_info = false;
+      logger.handleDeviceInfo(*device_info, captureWindowStartTime_);
+    }
+
+    auto resource_infos = session->getResourceInfos();
+    for (const auto& resource_info : resource_infos) {
+      logger.handleResourceInfo(resource_info, captureWindowStartTime_);
+    }
+  }
+
+  // Process names
+  int32_t pid = processId();
+  string process_name = processName(pid);
+  if (!process_name.empty()) {
+    logger.handleDeviceInfo(
+        {.id = pid, .sortIndex = pid, .name = process_name, .label = "CPU"},
+        captureWindowStartTime_);
+    if (!cpuOnly_ && use_default_device_info) {
+      // Usually, GPU events use device id as pid (0-7).
+      // In some cases, CPU sockets are numbered starting from 0.
+      // In the worst case, 8 CPU sockets + 8 GPUs, so the max GPU ID is 15.
+      //
+      // TODO: We should either use a defined constant from Cupti or make an
+      //       API call to get this value.
+      constexpr int kMaxGpuID = 15;
+      // sortIndex is gpu + kExceedMaxPid to put GPU tracks at the bottom
+      // of the trace timelines.
+      for (int gpu = 0; gpu <= kMaxGpuID; gpu++) {
+        logger.handleDeviceInfo(
+            {.id = gpu,
+             .sortIndex = gpu + kExceedMaxPid,
+             .name = process_name,
+             .label = fmt::format("GPU {}", gpu)},
+            captureWindowStartTime_);
+      }
+    }
+  }
+
+  for (const auto& iterations : traceSpans_) {
+    for (const auto& span_pair : iterations.second) {
+      const TraceSpan& gpu_span = span_pair.second;
+      if (gpu_span.opCount > 0) {
+        logger.handleTraceSpan(gpu_span);
+      }
+    }
+  }
+
+  // Call derived class hook for device-specific finalization
+  onFinalizeTrace(config, logger);
+
+  gpuUserEventMap_.logEvents(&logger);
+
+  for (auto& session : sessions_) {
+    auto trace_buffer = session->getTraceBuffer();
+    if (trace_buffer) {
+      // Set child start time to profiling start time if not set
+      if (trace_buffer->span.startTime == 0) {
+        trace_buffer->span.startTime = captureWindowStartTime_;
+      }
+      traceBuffers_->cpu.push_back(std::move(trace_buffer));
+    }
+  }
+
+  logger.finalizeTrace(config, std::move(traceBuffers_), captureWindowEndTime_);
+}
+
+void GenericActivityProfiler::pushCorrelationId(uint64_t id) {
+  pushCorrelationIdImpl(id, CorrelationFlowType::Default);
+  for (auto& session : sessions_) {
+    session->pushCorrelationId(id);
+  }
+}
+
+void GenericActivityProfiler::popCorrelationId() {
+  popCorrelationIdImpl(CorrelationFlowType::Default);
+  for (auto& session : sessions_) {
+    session->popCorrelationId();
+  }
+}
+
+void GenericActivityProfiler::pushUserCorrelationId(uint64_t id) {
+  pushCorrelationIdImpl(id, CorrelationFlowType::User);
+  for (auto& session : sessions_) {
+    session->pushUserCorrelationId(id);
+  }
+}
+
+void GenericActivityProfiler::popUserCorrelationId() {
+  popCorrelationIdImpl(CorrelationFlowType::User);
+  for (auto& session : sessions_) {
+    session->popUserCorrelationId();
+  }
+}
+
+void GenericActivityProfiler::resetTraceData() {
+  if (!cpuOnly_) {
+    clearGpuActivities();
+    onResetTraceData();
+  }
+  activityMap_.clear();
+  cpuCorrelationMap_.clear();
+  correlatedCudaActivities_.clear();
+  gpuUserEventMap_.clear();
+  traceSpans_.clear();
+  clientActivityTraceMap_.clear();
+  seenDeviceStreams_.clear();
+  logQueue_.clear();
+  traceBuffers_ = nullptr;
+  metadata_.clear();
+  sessions_.clear();
+  resourceOverheadCount_ = 0;
+  ecs_ = ErrorCounts{};
+}
+
+void GenericActivityProfiler::collectTrace(
+    bool collection_done,
+    const std::chrono::time_point<std::chrono::system_clock>& now) {
+  if (libkineto::api().client()) {
+    libkineto::api().client()->stop();
+  }
+
+  if (isGpuCollectionStopped()) {
+    ecs_.gpu_stopped_early = true;
+    LOG(ERROR)
+        << "State: CollectTrace stopped by GPU profiler. (Buffer size configured is "
+        << config_->activitiesMaxGpuBufferSize() / 1024 / 1024 << "MB)";
+  }
+  std::lock_guard<std::recursive_mutex> guard(mutex_);
+  stopTraceInternal(now);
+  VLOG_IF(0, collection_done) << "Reached profile end time";
+  UST_LOGGER_MARK_COMPLETED(kCollectionStage);
+}
+
+bool ConfigDerivedState::isWarmupDone(
+    const time_point<system_clock>& now,
+    int64_t currentIter) const {
+  bool isTimestampBased = !profilingByIter_ && currentIter < 0;
+  if (isTimestampBased) {
+    // qualify that this check is not being called from application step() API
+    // this avoids races between the step() API and periodically invoked
+    // profiler run loop step() method
+    return now >= profileStartTime_;
+  }
+  bool isIterationBased = profilingByIter_ && currentIter >= 0;
+  if (isIterationBased) {
+    return currentIter >= profileStartIter_;
+  }
+  return false;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/GenericActivityProfiler.h
+++ b/third_party/kineto/libkineto/src/GenericActivityProfiler.h
@@ -1,0 +1,564 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <deque>
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+
+#include "GenericTraceActivity.h"
+#include "IActivityProfiler.h"
+#include "ThreadUtil.h"
+#include "TraceSpan.h"
+#include "libkineto.h"
+#include "output_base.h"
+
+namespace KINETO_NAMESPACE {
+
+// TODO: Move ConfigDerivedState and its implemenation into separate header and
+//       source files.
+class Config;
+
+// This struct is a derived snapshot of the Config. And should not
+// be mutable after construction.
+struct ConfigDerivedState final {
+  ConfigDerivedState() = delete;
+  ConfigDerivedState(const Config&);
+
+  // Calculate if starting is valid.
+  bool canStart(
+      const std::chrono::time_point<std::chrono::system_clock>& now) const;
+
+  // TODO: consider using union since only 1 arg is used.
+  bool isWarmupDone(
+      const std::chrono::time_point<std::chrono::system_clock>& now,
+      int64_t currentIter) const;
+
+  bool isCollectionDone(
+      const std::chrono::time_point<std::chrono::system_clock>& now,
+      int64_t currentIter) const;
+
+  // Set and Get Functions below.
+  const std::set<ActivityType>& profileActivityTypes() const {
+    return profileActivityTypes_;
+  }
+
+  const std::chrono::time_point<std::chrono::system_clock> profileStartTime()
+      const {
+    return profileStartTime_;
+  }
+
+  const std::chrono::time_point<std::chrono::system_clock> profileEndTime()
+      const {
+    return profileEndTime_;
+  }
+
+  const std::chrono::milliseconds profileDuration() const {
+    return profileDuration_;
+  }
+
+  int64_t profileStartIteration() const {
+    return profileStartIter_;
+  }
+  int64_t profileEndIteration() const {
+    return profileEndIter_;
+  }
+  bool isProfilingByIteration() const {
+    return profilingByIter_;
+  }
+
+  bool isPerThreadBufferEnabled() const {
+    return perThreadBufferEnabled_;
+  }
+
+ private:
+  std::set<ActivityType> profileActivityTypes_;
+  // Start and end time used for triggering and stopping profiling
+  std::chrono::time_point<std::chrono::system_clock> profileStartTime_;
+  std::chrono::time_point<std::chrono::system_clock> profileEndTime_;
+  std::chrono::milliseconds profileDuration_;
+  std::chrono::seconds profileWarmupDuration_;
+  int64_t profileStartIter_{-1};
+  int64_t profileEndIter_{-1};
+  bool profilingByIter_{false};
+  bool perThreadBufferEnabled_{false};
+};
+
+namespace detail {
+inline size_t hash_combine(size_t seed, size_t value) {
+  return seed ^ (value + 0x9e3779b9 + (seed << 6u) + (seed >> 2u));
+}
+} // namespace detail
+
+// Correlation flow type for push/pop correlation ID
+enum class CorrelationFlowType { Default, User };
+
+class GenericActivityProfiler {
+ public:
+  GenericActivityProfiler(bool cpuOnly);
+  GenericActivityProfiler(const GenericActivityProfiler&) = delete;
+  GenericActivityProfiler& operator=(const GenericActivityProfiler&) = delete;
+  virtual ~GenericActivityProfiler();
+
+  bool isStopped() const {
+    return isGpuCollectionStopped();
+  }
+
+  // Collect CPU and GPU traces
+  void collectTrace(
+      bool collection_done,
+      const std::chrono::time_point<std::chrono::system_clock>& now);
+
+  // Used for async requests
+  void setLogger(ActivityLogger* logger) {
+    logger_ = logger;
+  }
+
+  inline void setCpuActivityPresent(bool val) {
+    cpuActivityPresent_ = val;
+  }
+
+  inline void setGpuActivityPresent(bool val) {
+    gpuActivityPresent_ = val;
+  }
+
+  inline bool gpuActivityPresent() const {
+    return gpuActivityPresent_;
+  }
+
+  inline bool traceNonEmpty() const {
+    return cpuActivityPresent_ || gpuActivityPresent_;
+  }
+
+  void flushWarmupBuffers(
+      int64_t currentIter,
+      const std::chrono::time_point<std::chrono::system_clock>& nextWakeupTime);
+
+  bool isWarmupDone(
+      const std::chrono::time_point<std::chrono::system_clock>& now,
+      int64_t currentIter) const {
+    return derivedConfig_->isWarmupDone(now, currentIter);
+  }
+
+  bool isCollectionDone(
+      const std::chrono::time_point<std::chrono::system_clock>& now,
+      int64_t currentIter) const {
+    return derivedConfig_->isCollectionDone(now, currentIter);
+  }
+
+  virtual bool isGpuCollectionStopped() const {
+    return false;
+  }
+
+  bool isProfilingByIteration() const {
+    return derivedConfig_->isProfilingByIteration();
+  }
+
+  std::chrono::time_point<std::chrono::system_clock> profileStartTime() const {
+    return derivedConfig_->profileStartTime();
+  }
+
+  std::chrono::time_point<std::chrono::system_clock> profileEndTime() const {
+    return derivedConfig_->profileEndTime();
+  }
+
+  int activitiesMaxGpuBufferSizeMB() const {
+    return config_ ? config_->activitiesMaxGpuBufferSize() / 1024 / 1024 : 0;
+  }
+
+  void startTrace(
+      const std::chrono::time_point<std::chrono::system_clock>& now) {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    startTraceInternal(now);
+  }
+
+  void stopTrace(
+      const std::chrono::time_point<std::chrono::system_clock>& now) {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    stopTraceInternal(now);
+  }
+
+  void cancelTrace(
+      const std::chrono::time_point<std::chrono::system_clock>& now) {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    stopTraceInternal(now);
+    resetInternal();
+  }
+
+  void processTrace(ActivityLogger& logger) {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    processTraceInternal(logger);
+  }
+
+  void completeTrace(ActivityLogger& logger) {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    processTraceInternal(logger);
+    resetInternal();
+  }
+
+  void reset() {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    resetInternal();
+  }
+
+  bool canStart(
+      const Config& config,
+      const std::chrono::time_point<std::chrono::system_clock>& now) const {
+    ConfigDerivedState derived(config);
+    return derived.canStart(now);
+  }
+
+  void configure(
+      const Config& config,
+      const std::chrono::time_point<std::chrono::system_clock>& now);
+
+  // Toggle GPU tracing during a profile instance
+  void toggleCollectionDynamic(const bool enable);
+
+  // Registered with client API to pass CPU trace events over
+  void transferCpuTrace(std::unique_ptr<libkineto::CpuTraceBuffer> cpuTrace);
+
+  const Config& config() {
+    return *config_;
+  }
+
+  inline void recordThreadInfo() {
+    int32_t sysTid = systemThreadId();
+    // Note we're using the lower 32 bits of the (opaque) pthread id
+    // as key, because that's what CUPTI records.
+    int32_t tid = threadId();
+    int32_t pid = processId();
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    recordThreadInfo(sysTid, tid, pid);
+  }
+
+  // T107508020: We can deprecate the recordThreadInfo(void) once we optimized
+  // profiler_kineto
+  void recordThreadInfo(int32_t sysTid, int32_t tid, int32_t pid) {
+    if (!resourceInfo_.contains({pid, tid})) {
+      resourceInfo_.emplace(
+          std::make_pair(pid, tid),
+          ResourceInfo{
+              .id = sysTid,
+              .sortIndex = sysTid,
+              .deviceId = pid,
+              .name = fmt::format("thread {} ({})", sysTid, getThreadName())});
+    }
+  }
+
+  void addMetadata(const std::string& key, const std::string& value) {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    metadata_[key] = value;
+  }
+
+  void addVersionMetadata(const std::string& key, const std::string& value) {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    versionMetadata_[key] = value;
+  }
+
+  void addChildActivityProfiler(std::unique_ptr<IActivityProfiler> profiler) {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    profilers_.push_back(std::move(profiler));
+  }
+
+  void pushCorrelationId(uint64_t id);
+  void popCorrelationId();
+
+  void pushUserCorrelationId(uint64_t id);
+  void popUserCorrelationId();
+
+ protected:
+  // Derived classes should be for a particular device, and should override
+  // these virtual member functions. We provide empty defaults because
+  // GenericActivityProfiler can also be in cpuOnly mode.
+  virtual void logGpuVersions() {}
+  virtual void setMaxGpuBufferSize([[maybe_unused]] int64_t size) {}
+  virtual void enableGpuTracing() {}
+  virtual void disableGpuTracing() {}
+  virtual void clearGpuActivities() {}
+  virtual void processGpuActivities([[maybe_unused]] ActivityLogger& logger) {}
+  virtual void synchronizeGpuDevice() {}
+  virtual void pushCorrelationIdImpl(
+      [[maybe_unused]] uint64_t id,
+      [[maybe_unused]] CorrelationFlowType type) {}
+  virtual void popCorrelationIdImpl([[maybe_unused]] CorrelationFlowType type) {
+  }
+  virtual void onResetTraceData() {}
+  virtual void onFinalizeTrace(
+      [[maybe_unused]] const Config& config,
+      [[maybe_unused]] ActivityLogger& logger) {}
+
+  using CpuGpuSpanPair = std::pair<TraceSpan, TraceSpan>;
+  static const CpuGpuSpanPair& defaultTraceSpan();
+
+  // Deferred logging of CUDA-event synchronization
+  struct DeferredLogEntry {
+    uint32_t device;
+    uint32_t stream;
+    std::function<void()> logMe;
+  };
+
+  std::deque<DeferredLogEntry> logQueue_;
+
+  // Map of gpu activities to user defined events
+  class GpuUserEventMap {
+   public:
+    // Insert a user defined event which maps to the gpu trace activity.
+    // If the user defined event mapping already exists this will update the
+    // gpu side span to include the span of gpuTraceActivity.
+    void insertOrExtendEvent(
+        const ITraceActivity& cpuTraceActivity,
+        const ITraceActivity& gpuTraceActivity);
+    // Log out the events to the logger
+    void logEvents(ActivityLogger* logger);
+
+    void clear() {
+      streamSpanMap_.clear();
+    }
+
+   private:
+    // device id and stream name
+    using StreamKey = std::pair<int64_t, int64_t>;
+
+    // map of correlation id to TraceSpan
+    using CorrelationSpanMap =
+        std::unordered_map<int64_t, GenericTraceActivity>;
+    std::map<StreamKey, CorrelationSpanMap> streamSpanMap_;
+  };
+
+  GpuUserEventMap gpuUserEventMap_;
+  // id -> activity*
+  std::unordered_map<int64_t, const ITraceActivity*> activityMap_;
+  // cuda runtime id -> pytorch op id
+  // CUPTI provides a mechanism for correlating Cuda events to arbitrary
+  // external events, e.g.operator activities from PyTorch.
+  std::unordered_map<int64_t, int64_t> cpuCorrelationMap_;
+  // CUDA runtime <-> GPU Activity
+  std::unordered_map<int64_t, const ITraceActivity*> correlatedCudaActivities_;
+  std::unordered_map<int64_t, int64_t> userCorrelationMap_;
+
+  // data structure to collect cuptiActivityFlushAll() latency overhead
+  struct profilerOverhead {
+    int64_t overhead;
+    int cntr;
+  };
+
+  void startTraceInternal(
+      const std::chrono::time_point<std::chrono::system_clock>& now);
+
+  void stopTraceInternal(
+      const std::chrono::time_point<std::chrono::system_clock>& now);
+
+  void processTraceInternal(ActivityLogger& logger);
+
+  void resetInternal();
+
+  void finalizeTrace(const Config& config, ActivityLogger& logger);
+
+  void configureChildProfilers();
+
+  // Process a single CPU trace
+  void processCpuTrace(
+      libkineto::CpuTraceBuffer& cpuTrace,
+      ActivityLogger& logger);
+
+  inline bool hasDeviceResource(int64_t device, int64_t id) {
+    return resourceInfo_.contains({device, id});
+  }
+
+  // Create resource names for streams
+  inline void recordStream(int64_t device, int64_t id, const char* postfix) {
+    if (!hasDeviceResource(device, id)) {
+      resourceInfo_.emplace(
+          std::make_pair(device, id),
+          ResourceInfo{
+              .id = id,
+              .sortIndex = id,
+              .deviceId = device,
+              .name = fmt::format("stream {} {}", id, postfix)});
+    }
+  }
+
+  // Create resource names overall for device, id = -1
+  inline void recordDevice(int device) {
+    constexpr int id = -1;
+    if (!hasDeviceResource(device, id)) {
+      resourceInfo_.emplace(
+          std::make_pair(device, id),
+          ResourceInfo{
+              .id = id,
+              .sortIndex = id,
+              .deviceId = device,
+              .name = fmt::format("Device {}", device)});
+    }
+  }
+
+  // Record client trace span for subsequent lookups from activities
+  // Also creates a corresponding GPU-side span.
+  CpuGpuSpanPair& recordTraceSpan(TraceSpan& span, int gpuOpCount);
+
+  // Returns true if net name is to be tracked for a specified number of
+  // iterations.
+  bool iterationTargetMatch(libkineto::CpuTraceBuffer& trace);
+
+  // net name to id
+  int netId(const std::string& netName);
+
+  const ITraceActivity* linkedActivity(
+      int32_t correlationId,
+      const std::unordered_map<int64_t, int64_t>& correlationMap);
+
+  const ITraceActivity* cpuActivity(int32_t correlationId);
+  void updateGpuNetSpan(const ITraceActivity& gpuOp);
+  bool outOfRange(const ITraceActivity& act);
+  void handleGpuActivity(const ITraceActivity& act, ActivityLogger* logger);
+
+  void resetTraceData();
+
+  void addOverheadSample(profilerOverhead& counter, int64_t overhead) {
+    counter.overhead += overhead;
+    counter.cntr++;
+  }
+  int64_t getOverhead(const profilerOverhead& counter) {
+    if (counter.cntr == 0) {
+      return 0;
+    }
+    return counter.overhead / counter.cntr;
+  }
+
+  void checkTimestampOrder(const ITraceActivity* act1);
+
+  // On-demand Request Config (should not be modified)
+  // TODO: remove this config_, dependency needs to be removed from
+  // finalizeTrace.
+  std::unique_ptr<const Config> config_;
+
+  // Resolved details about the config and states are stored here.
+  std::unique_ptr<ConfigDerivedState> derivedConfig_;
+
+  // Logger used during trace processing
+  ActivityLogger* logger_;
+
+  // All recorded trace spans, both CPU and GPU
+  // Trace Id -> list of iterations.
+  // Using map of lists for the iterator semantics, since we are recording
+  // pointers to the elements in this structure.
+  std::map<std::string, std::list<CpuGpuSpanPair>> traceSpans_;
+
+  // Maintain a map of client trace activity to trace span.
+  // Maps correlation id -> TraceSpan* held by traceSpans_.
+  using ActivityTraceMap = std::unordered_map<int64_t, CpuGpuSpanPair*>;
+  ActivityTraceMap clientActivityTraceMap_;
+
+  // Cache thread names and system thread ids for pthread ids,
+  // and stream ids for GPU streams
+  std::map<std::pair<int64_t, int64_t>, ResourceInfo> resourceInfo_;
+
+  std::vector<ActivityLogger::OverheadInfo> overheadInfo_;
+
+  // the overhead to flush the activity buffer
+  profilerOverhead flushOverhead_;
+  // the overhead to enable/disable activity tracking
+  profilerOverhead setupOverhead_;
+
+  bool cpuOnly_{false};
+  bool gpuOnly_{false};
+  bool cpuActivityPresent_{false};
+  bool gpuActivityPresent_{false};
+
+  // Gate for CPU trace ingestion. True only between startTraceInternal()
+  // and resetInternal() — spans arriving outside this window are discarded.
+  bool acceptCpuTraces_{false};
+  std::atomic<bool> toggleState_{true};
+
+  // ***************************************************************************
+  // Below state is shared with external threads.
+  // These need to either be atomic, accessed under lock or only used
+  // by external threads in separate runloop phases from the profiler thread.
+  // ***************************************************************************
+
+  // Mutex to protect non-atomic access to below state
+  std::recursive_mutex mutex_;
+
+  // Keep track of the start time and end time for the trace collected.
+  // External threads using startTrace need to manually stopTrace. Part of the
+  // mock tests. All CUDA events before this time will be removed
+  int64_t captureWindowStartTime_{0};
+  // Similarly, all CUDA API events after the last net event will be removed
+  int64_t captureWindowEndTime_{0};
+
+  // span name -> iteration count
+  std::map<std::string, int> iterationCountMap_;
+
+  struct DevStream {
+    int64_t ctx = 0;
+    int64_t stream = 0;
+    bool operator==(const DevStream& other) const {
+      return (this->ctx == other.ctx) && (this->stream == other.stream);
+    }
+  };
+
+  struct DevStreamHash {
+    std::size_t operator()(const DevStream& c) const {
+      return detail::hash_combine(
+          std::hash<int64_t>()(c.ctx), std::hash<int64_t>()(c.stream));
+    }
+  };
+
+  struct ErrorCounts {
+    int32_t invalid_external_correlation_events = 0;
+    int32_t out_of_range_events = 0;
+    int32_t gpu_and_cpu_op_out_of_order = 0;
+    int32_t blocklisted_runtime_events = 0;
+    int32_t unexepected_cuda_events = 0;
+    bool gpu_stopped_early = false;
+  };
+
+  friend std::ostream& operator<<(std::ostream& oss, const ErrorCounts& ecs);
+
+  // This set tracks the (device, cuda streams) observed in the trace
+  // doing CUDA kernels/memcopies. This prevents emitting CUDA sync
+  // events on streams with no activity.
+  std::unordered_set<DevStream, DevStreamHash> seenDeviceStreams_;
+
+  // Buffers where trace data is stored
+  std::unique_ptr<ActivityBuffers> traceBuffers_;
+
+  // Trace metadata
+  std::unordered_map<std::string, std::string> metadata_;
+
+  // Version metadata
+  std::unordered_map<std::string, std::string> versionMetadata_;
+
+  // child activity profilers
+  std::vector<std::unique_ptr<IActivityProfiler>> profilers_;
+
+  // a vector of active profiler plugin sessions
+  std::vector<std::unique_ptr<IActivityProfilerSession>> sessions_;
+
+  // Number of memory overhead events encountered during the session
+  uint32_t resourceOverheadCount_;
+
+  ErrorCounts ecs_;
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/GenericTraceActivity.cpp
+++ b/third_party/kineto/libkineto/src/GenericTraceActivity.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "GenericTraceActivity.h"
+#include "TypedMetadataJson.h"
+#include "output_base.h"
+
+namespace libkineto {
+
+namespace {
+template <typename>
+inline constexpr bool kAlwaysFalse = false;
+
+// Render a stored metadata value back to its legacy string form.
+std::string metadataValueToString(const TypedValue& value) {
+  return std::visit(
+      [](const auto& v) -> std::string {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, std::string>) {
+          return v;
+        } else if constexpr (std::is_same_v<T, RawJson>) {
+          return v.value;
+        } else if constexpr (
+            std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t> ||
+            std::is_same_v<T, double> || std::is_same_v<T, bool>) {
+          return fmt::format("{}", v);
+        } else if constexpr (
+            std::is_same_v<T, std::vector<int64_t>> ||
+            std::is_same_v<T, std::vector<std::string>> ||
+            std::is_same_v<T, InputShapes>) {
+          // Serialize collections through the JSON visitor's array helper.
+          std::string out;
+          internal::JsonTypedMetadataVisitor::appendArray(out, v);
+          return out;
+        } else {
+          static_assert(
+              kAlwaysFalse<T>,
+              "unhandled TypedValue alternative in metadataValueToString");
+        }
+      },
+      value);
+}
+} // namespace
+
+void GenericTraceActivity::log(ActivityLogger& logger) const {
+  logger.handleGenericActivity(*this);
+}
+
+const std::string GenericTraceActivity::getMetadataValue(
+    const std::string& key) const {
+  const auto it = metadataMap_.find(key);
+  return it == metadataMap_.end() ? "" : metadataValueToString(it->second);
+}
+
+const std::string GenericTraceActivity::metadataJson() const {
+  internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/src/ILoggerObserver.cpp
+++ b/third_party/kineto/libkineto/src/ILoggerObserver.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ILoggerObserver.h"
+
+#if !USE_GOOGLE_LOG
+
+#include <fmt/format.h>
+#include <array>
+
+namespace libkineto {
+
+struct LoggerTypeName {
+  constexpr LoggerTypeName(const char* n, LoggerOutputType t)
+      : name(n), type(t) {}
+  const char* name;
+  LoggerOutputType type;
+};
+
+static constexpr std::array<LoggerTypeName, LoggerTypeCount + 1> LoggerMap{
+    {{"VERBOSE", LoggerOutputType::VERBOSE},
+     {"INFO", LoggerOutputType::INFO},
+     {"WARNING", LoggerOutputType::WARNING},
+     {"STAGE", LoggerOutputType::STAGE},
+     {"ERROR", LoggerOutputType::ERROR},
+     {"USDT", LoggerOutputType::USDT},
+     {"???", LoggerOutputType::ENUM_COUNT}}};
+
+static constexpr bool matchingOrder(int idx = 0) {
+  return LoggerMap[idx].type == LoggerOutputType::ENUM_COUNT ||
+      ((idx == (int)LoggerMap[idx].type) && matchingOrder(idx + 1));
+}
+static_assert(matchingOrder(), "LoggerTypeName map is out of order");
+
+const char* toString(LoggerOutputType t) {
+  if (t < VERBOSE || t >= ENUM_COUNT) {
+    return LoggerMap[ENUM_COUNT].name;
+  }
+  return LoggerMap[(int)t].name;
+}
+
+LoggerOutputType toLoggerOutputType(const std::string& str) {
+  for (int i = 0; i < LoggerTypeCount; i++) {
+    if (str == LoggerMap[i].name) {
+      return LoggerMap[i].type;
+    }
+  }
+  throw std::invalid_argument(fmt::format("Invalid activity type: {}", str));
+}
+
+} // namespace libkineto
+
+#endif // !USE_GOOGLE_LOG

--- a/third_party/kineto/libkineto/src/InvariantViolations.h
+++ b/third_party/kineto/libkineto/src/InvariantViolations.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace KINETO_NAMESPACE {
+
+class InvariantViolationsLogger {
+ public:
+  virtual ~InvariantViolationsLogger() = default;
+  virtual void logInvariantViolation(
+      const std::string& profile_id,
+      const std::string& assertion,
+      const std::string& error,
+      const std::string& group_profile_id) = 0;
+  static void registerFactory();
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/IpcFabricConfigClient.cpp
+++ b/third_party/kineto/libkineto/src/IpcFabricConfigClient.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef __linux__
+
+#include "IpcFabricConfigClient.h"
+
+#include <cstdlib>
+#include <random>
+#include <sstream>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ThreadUtil.h"
+
+namespace KINETO_NAMESPACE {
+
+namespace uuid {
+std::string generate_uuid_v4() {
+  static std::random_device rd;
+  static std::mt19937 gen(rd());
+  static std::uniform_int_distribution<> dis(0, 15);
+  static std::uniform_int_distribution<> dis2(8, 11);
+
+  std::stringstream ss;
+  int i = 0;
+  ss << std::hex;
+  for (i = 0; i < 8; i++) {
+    ss << dis(gen);
+  }
+  ss << "-";
+  for (i = 0; i < 4; i++) {
+    ss << dis(gen);
+  }
+  ss << "-4";
+  for (i = 0; i < 3; i++) {
+    ss << dis(gen);
+  }
+  ss << "-";
+  ss << dis2(gen);
+  for (i = 0; i < 3; i++) {
+    ss << dis(gen);
+  }
+  ss << "-";
+  for (i = 0; i < 12; i++) {
+    ss << dis(gen);
+  }
+  return ss.str();
+}
+} // namespace uuid
+
+static std::vector<int32_t> getPids() {
+  const auto& pids = pidCommandPairsOfAncestors();
+  std::vector<int32_t> res;
+  res.reserve(pids.size());
+  for (const auto& pid_pair : pids) {
+    res.push_back(pid_pair.first);
+  }
+  return res;
+}
+
+static int64_t getJobId() {
+  /* Look up a job id using env variables from job schedulers
+   */
+  // SLURM Job ID https://slurm.schedmd.com/sbatch.html#OPT_SLURM_JOB_ID
+  const char* id = getenv("SLURM_JOB_ID");
+
+  // Feel free to add other env variable look ups here
+  // for different schedulers
+  if (id == nullptr) {
+    return 0;
+  }
+  return strtoll(id, nullptr, 10);
+}
+
+IpcFabricConfigClient::IpcFabricConfigClient()
+    : jobId_(getJobId()), pids_(getPids()), ipcFabricEnabled_(true) {
+  // setup IPC Fabric
+  std::string ep_name = "dynoconfigclient" + uuid::generate_uuid_v4();
+
+  fabricManager_ = ::dynolog::ipcfabric::FabricManager::factory(ep_name);
+#ifdef ENABLE_IPC_FABRIC
+  LOG(INFO) << "Setting up IPC Fabric at endpoint: " << ep_name << " status = "
+            << (fabricManager_ ? "initialized" : "failed (null)");
+#endif
+}
+
+// The following only makes sense if IPC Fabric is being used
+#ifdef ENABLE_IPC_FABRIC
+
+// Connect to the Dynolog service through Fabric name `dynolog`
+constexpr const char* kDynoIpcName = "dynolog";
+constexpr int maxIpcRetries = 9;
+constexpr int kSleepUs = 10000;
+
+int32_t IpcFabricConfigClient::registerInstance(int32_t gpu) {
+  if (!ipcFabricEnabled_) {
+    return -1;
+  }
+
+  if (!fabricManager_) {
+    LOG(ERROR) << "FabricManager not initialized.";
+    return -1;
+  }
+
+  // Setup message
+  ::dynolog::ipcfabric::LibkinetoContext ctxt{gpu, getpid(), jobId_};
+
+  std::unique_ptr<::dynolog::ipcfabric::Message> msg =
+      ::dynolog::ipcfabric::Message::constructMessage<decltype(ctxt)>(
+          ctxt, "ctxt");
+
+  try {
+    if (!fabricManager_->sync_send(*msg, std::string(kDynoIpcName))) {
+      LOG(ERROR) << "Failed to register pid " << ctxt.pid
+                 << " with dyno: IPC sync_send fail";
+      return -1;
+    }
+    msg = fabricManager_->poll_recv(maxIpcRetries, kSleepUs);
+    if (!msg) {
+      LOG(ERROR) << "Failed to register pid " << ctxt.pid
+                 << " with dyno: IPC recv fail";
+      return -1;
+    }
+  } catch (const std::runtime_error& ex) {
+    LOG(ERROR) << "Failed to send/recv registering pic over fabric: "
+               << ex.what();
+    return -1;
+  }
+
+  LOG(INFO) << "Registered instance with daemon";
+  return *(int*)msg->buf.get();
+}
+
+std::string IpcFabricConfigClient::getLibkinetoBaseConfig() {
+  if (!ipcFabricEnabled_) {
+    return "";
+  }
+
+  LOG(WARNING)
+      << "Missing IPC Fabric implementation for getLibkinetoBaseConfig";
+  return "";
+}
+
+std::string IpcFabricConfigClient::getLibkinetoOndemandConfig(int32_t type) {
+  if (!ipcFabricEnabled_) {
+    return "";
+  }
+
+  if (!fabricManager_) {
+    LOG(ERROR) << "FabricManager not initialized.";
+    return "";
+  }
+
+  int size = pids_.size();
+  ::dynolog::ipcfabric::LibkinetoRequest* req =
+      (::dynolog::ipcfabric::LibkinetoRequest*)malloc(
+          sizeof(::dynolog::ipcfabric::LibkinetoRequest) +
+          sizeof(int32_t) * size);
+  req->type = type;
+  req->n = size;
+  req->jobid = jobId_;
+  for (int i = 0; i < size; i++) {
+    req->pids[i] = pids_[i];
+  }
+  std::unique_ptr<::dynolog::ipcfabric::Message> msg =
+      ::dynolog::ipcfabric::Message::
+          constructMessage<::dynolog::ipcfabric::LibkinetoRequest, int32_t>(
+              *req, "req", size);
+
+  try {
+    if (!fabricManager_->sync_send(*msg, std::string(kDynoIpcName))) {
+      LOG(ERROR) << "Failed to send config type=" << type
+                 << " to dyno: IPC sync_send fail";
+      free(req);
+      req = nullptr;
+      return "";
+    }
+    free(req);
+    msg = fabricManager_->poll_recv(maxIpcRetries, kSleepUs);
+    if (!msg) {
+      // LOG(ERROR) << "Failed to receive ondemand config type=" << type
+      //  << " from dyno: IPC recv fail";
+      return "";
+    }
+  } catch (const std::runtime_error& ex) {
+    LOG(ERROR) << "Failed to recv ondemand config over ipc fabric: "
+               << ex.what();
+    free(req);
+    return "";
+  }
+
+  return std::string((char*)msg->buf.get(), msg->metadata.size);
+}
+
+#else // ENABLE_IPC_FABRIC
+
+int32_t IpcFabricConfigClient::registerInstance([[maybe_unused]] int32_t gpu) {
+  return -1;
+}
+
+std::string IpcFabricConfigClient::getLibkinetoBaseConfig() {
+  return "";
+}
+std::string IpcFabricConfigClient::getLibkinetoOndemandConfig(
+    [[maybe_unused]] int32_t type) {
+  return "";
+}
+
+#endif // ENABLE_IPC_FABRIC
+} // namespace KINETO_NAMESPACE
+#endif // __linux__

--- a/third_party/kineto/libkineto/src/IpcFabricConfigClient.h
+++ b/third_party/kineto/libkineto/src/IpcFabricConfigClient.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifdef __linux__
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+// include logger before to enable ipc fabric to access LOG() macros
+#ifdef ENABLE_IPC_FABRIC
+
+#include "Logger.h"
+
+// The following is required for LOG() macros to work below
+// Include the IPC Fabric
+#include "FabricManager.h"
+
+#else
+
+// Adds an empty implementation so compilation works.
+namespace dynolog::ipcfabric {
+
+class FabricManager {
+ public:
+  FabricManager(const FabricManager&) = delete;
+  FabricManager& operator=(const FabricManager&) = delete;
+
+  static std::unique_ptr<FabricManager> factory(
+      std::string endpoint_name = "") {
+    return nullptr;
+  }
+};
+
+} // namespace dynolog::ipcfabric
+
+#endif // ENABLE_IPC_FABRIC
+
+namespace KINETO_NAMESPACE {
+
+enum LibkinetoConfigType {
+  NONE = 0,
+  EVENTS = 0x1,
+  ACTIVITIES = 0x2,
+};
+
+// IpcFabricConfigClient : connects to a daemon using the IPC Fabric
+//   this can be used as a base class for other Daemon Config clients as well.
+class IpcFabricConfigClient {
+ public:
+  IpcFabricConfigClient();
+  virtual ~IpcFabricConfigClient() {}
+
+  // Registers this application with the daemon
+  virtual int32_t registerInstance(int32_t gpu);
+
+  // Get the base config for libkineto
+  virtual std::string getLibkinetoBaseConfig();
+
+  // Get on demand configurations for tracing/counter collection
+  // type is a bit mask, please see LibkinetoConfigType encoding above.
+  virtual std::string getLibkinetoOndemandConfig(int32_t type);
+
+  void setIpcFabricEnabled(bool enabled) {
+    ipcFabricEnabled_ = enabled;
+  }
+
+ protected:
+  // Temporarily keep both int and string job id until IPC related code is
+  // updated to handle string job id.
+  int64_t jobId_;
+  std::string jobIdStr_;
+  std::vector<int32_t> pids_;
+  bool ipcFabricEnabled_;
+
+  std::unique_ptr<dynolog::ipcfabric::FabricManager> fabricManager_;
+};
+
+#endif // __linux__
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/KernelRegistry.cpp
+++ b/third_party/kineto/libkineto/src/KernelRegistry.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "KernelRegistry.h"
+
+namespace KINETO_NAMESPACE {
+
+// Static singleton instance:
+KernelRegistry* KernelRegistry::singleton() {
+  static KernelRegistry instance;
+  return &instance;
+}
+
+void KernelRegistry::recordKernel(
+    uint32_t deviceId,
+    const std::string& kernelName,
+    uint64_t correlationId) {
+  std::scoped_lock guard(mutex_);
+  deviceKernelMap_[deviceId].emplace_back(kernelName, correlationId);
+}
+
+/// Return kernel information for the n'th hernel of a specific device with
+/// 'deviceId'.
+std::optional<KernelRegistry::KernelInfoTy> KernelRegistry::getKernelInfo(
+    uint32_t deviceId,
+    size_t idx) const {
+  std::scoped_lock guard(mutex_);
+
+  auto it = deviceKernelMap_.find(deviceId);
+  if (it != deviceKernelMap_.end()) {
+    const std::vector<KernelRegistry::KernelInfoTy>& kernels = it->second;
+    if (idx < kernels.size()) {
+      return std::make_optional(kernels[idx]);
+    }
+  }
+  return std::nullopt;
+}
+
+/// Return the number of kernels recorded for a specific device with
+/// 'deviceId'.
+size_t KernelRegistry::getNumKernels(uint32_t deviceId) const {
+  std::scoped_lock guard(mutex_);
+
+  auto it = deviceKernelMap_.find(deviceId);
+  if (it != deviceKernelMap_.end()) {
+    return it->second.size();
+  } else {
+    return 0;
+  }
+}
+
+void KernelRegistry::clear() {
+  std::scoped_lock guard(mutex_);
+  deviceKernelMap_.clear();
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/KernelRegistry.h
+++ b/third_party/kineto/libkineto/src/KernelRegistry.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace KINETO_NAMESPACE {
+
+// Class to track kernel launches across different profiling mechanisms.
+class KernelRegistry {
+ public:
+  using KernelInfoTy = std::pair<std::string, uint64_t>;
+
+  // Get the singleton instance.
+  static KernelRegistry* singleton();
+
+  // Record a kernel launch for a specific device.
+  void recordKernel(
+      uint32_t deviceId,
+      const std::string& kernelName,
+      uint64_t correlationId);
+
+  /// Return kernel information for the n'th hernel of a specific device with
+  /// 'deviceId'.
+  std::optional<KernelRegistry::KernelInfoTy> getKernelInfo(
+      uint32_t deviceId,
+      size_t idx) const;
+
+  /// Return the number of kernels recorded for a specific device with
+  /// 'deviceId'.
+  size_t getNumKernels(uint32_t deviceId) const;
+
+  // Clear all recorded kernels.
+  void clear();
+
+ private:
+  // Private constructor to enforce singleton pattern.
+  KernelRegistry() = default;
+
+  mutable std::mutex mutex_;
+  std::unordered_map<uint32_t, std::vector<KernelInfoTy>> deviceKernelMap_;
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/Logger.cpp
+++ b/third_party/kineto/libkineto/src/Logger.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "Logger.h"
+#include "ILoggerObserver.h"
+
+#ifndef USE_GOOGLE_LOG
+
+#include <chrono>
+#include <cstring>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include "ThreadUtil.h"
+
+namespace KINETO_NAMESPACE {
+
+std::atomic_int Logger::severityLevel_{VERBOSE};
+std::atomic_int Logger::verboseLogLevel_{-1};
+std::atomic<uint64_t> Logger::verboseLogModules_{~0ull};
+
+void get_local_time(const time_t* time, struct tm* tm_result) {
+#ifdef _WIN32
+  // Windows-specific code
+  localtime_s(tm_result, time);
+#else
+  // Linux-specific code
+  localtime_r(time, tm_result);
+#endif
+}
+
+Logger::Logger(int severity, int line, const char* filePath, int errnum)
+    : out_(LIBKINETO_DBG_STREAM), errnum_(errnum), messageSeverity_(severity) {
+  buf_ << toString((LoggerOutputType)severity) << ":";
+
+  const auto tt =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  std::tm tm_result;
+  get_local_time(&tt, &tm_result);
+  const char* file = std::strrchr(filePath, '/');
+  fmt::print(
+      buf_,
+      "{:%Y-%m-%d %H:%M:%S} {}:{} {}:{}] ",
+      tm_result,
+      processId(false),
+      systemThreadId(false),
+      (file ? file + 1 : filePath),
+      line);
+}
+
+Logger::~Logger() {
+#ifdef __linux__
+  if (errnum_ != 0) {
+    thread_local char buf[1024];
+    buf_ << " : " << strerror_r(errnum_, buf, sizeof(buf));
+  }
+#endif
+
+  {
+    std::lock_guard<std::mutex> guard(loggerObserversMutex());
+    for (auto* observer : loggerObservers()) {
+      // Output to observers. Current Severity helps keep track of which bucket
+      // the output goes.
+      if (observer) {
+        observer->write(buf_.str(), (LoggerOutputType)messageSeverity_);
+      }
+    }
+  }
+
+  // Finally, print to terminal or console.
+  out_ << buf_.str() << std::endl;
+}
+
+void Logger::setVerboseLogModules(const std::vector<std::string>& modules) {
+  uint64_t mask = 0;
+  if (modules.empty()) {
+    mask = ~0ull;
+  } else {
+    for (const std::string& name : modules) {
+      mask |= hash(name.c_str());
+    }
+  }
+  verboseLogModules_ = mask;
+}
+
+void Logger::addLoggerObserver(ILoggerObserver* observer) {
+  if (observer == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  loggerObservers().insert(observer);
+}
+
+void Logger::removeLoggerObserver(ILoggerObserver* observer) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  loggerObservers().erase(observer);
+}
+
+void Logger::addLoggerObserverDevice(int64_t device) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->addDevice(device);
+  }
+}
+
+void Logger::addLoggerObserverEventCount(int64_t count) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->addEventCount(count);
+  }
+}
+
+void Logger::setLoggerObserverTraceDurationMS(int64_t duration) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->setTraceDurationMS(duration);
+  }
+}
+
+void Logger::setLoggerObserverTraceID(const std::string& tid) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->setTraceID(tid);
+  }
+}
+
+void Logger::setLoggerObserverGroupTraceID(const std::string& gtid) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->setGroupTraceID(gtid);
+  }
+}
+
+void Logger::addLoggerObserverDestination(const std::string& dest) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->addDestination(dest);
+  }
+}
+
+void Logger::setLoggerObserverOnDemand() {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->setTriggerOnDemand();
+  }
+}
+
+void Logger::resetLoggerObservers() {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->reset();
+  }
+}
+
+void Logger::addLoggerObserverAddMetadata(
+    const std::string& key,
+    const std::string& value) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->addMetadata(key, value);
+  }
+}
+
+void Logger::addLoggerObserverPersistentMetadata(
+    const std::string& key,
+    const std::string& value) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->addPersistentMetadata(key, value);
+  }
+}
+
+void Logger::writeStageCancellation(
+    const std::string& trace_id,
+    const std::string& group_trace_id,
+    const std::string& reason) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->writeStageCancellation(trace_id, group_trace_id, reason);
+  }
+}
+
+USTLoggerStageGuard::~USTLoggerStageGuard() {
+  try {
+    UST_LOGGER_MARK_COMPLETED(stage_);
+  } catch (...) {
+  }
+}
+
+} // namespace KINETO_NAMESPACE
+
+#endif // USE_GOOGLE_LOG

--- a/third_party/kineto/libkineto/src/Logger.h
+++ b/third_party/kineto/libkineto/src/Logger.h
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <iostream>
+
+#define LIBKINETO_DBG_STREAM std::cerr
+
+#if USE_GOOGLE_LOG
+
+#include <glog/logging.h>
+
+#define SET_LOG_SEVERITY_LEVEL(level)
+#define SET_LOG_VERBOSITY_LEVEL(level, modules)
+#define LOGGER_OBSERVER_ADD_DEVICE(device)
+#define LOGGER_OBSERVER_ADD_EVENT_COUNT(count)
+#define LOGGER_OBSERVER_SET_TRACE_DURATION_MS(duration)
+#define LOGGER_OBSERVER_SET_TRACE_ID(tid)
+#define LOGGER_OBSERVER_SET_GROUP_TRACE_ID(gtid)
+#define LOGGER_OBSERVER_ADD_DESTINATION(dest)
+#define LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND()
+#define LOGGER_OBSERVER_ADD_METADATA(key, value)
+#define LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(key, value)
+#define LOGGER_OBSERVER_RESET()
+#define LOGGER_OBSERVER_WRITE_STAGE_CANCELLATION( \
+    trace_id, group_trace_id, reason)
+#define UST_LOGGER_MARK_COMPLETED(stage)
+#define UST_LOGGER_STAGE_SCOPE(stage)
+#define USDT_LOGGER_EMIT_MESSAGE(usdt_type)
+#define USDT_EMIT_START_TRACE()
+#define USDT_EMIT_STOP_TRACE()
+
+#else // !USE_GOOGLE_LOG
+#include <stdio.h>
+#include <atomic>
+#include <map>
+#include <mutex>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ILoggerObserver.h"
+
+#ifdef _MSC_VER
+// unset a predefined ERROR (windows)
+#undef ERROR
+#endif // _MSC_VER
+
+namespace KINETO_NAMESPACE {
+void get_local_time(const time_t* time, struct tm* tm_result);
+
+class Logger {
+ public:
+  Logger(int severity, int line, const char* filePath, int errnum = 0);
+  ~Logger();
+
+  inline std::ostream& stream() {
+    return buf_;
+  }
+
+  static inline void setSeverityLevel(int level) {
+    severityLevel_ = level;
+  }
+
+  static inline int severityLevel() {
+    return severityLevel_;
+  }
+
+  static inline void setVerboseLogLevel(int level) {
+    verboseLogLevel_ = level;
+  }
+
+  static inline int verboseLogLevel() {
+    return verboseLogLevel_;
+  }
+
+  // This is constexpr so that the hash for a file name is computed at compile
+  // time when used in the VLOG macros.
+  // This way, there is no string comparison for matching VLOG modules,
+  // only a comparison of pre-computed hashes.
+  // No fancy hashing needed here. It's pretty inefficient (one character
+  // at a time) but the strings are not large and it's not in the critical path.
+  static constexpr uint64_t rol(uint64_t val, int amount) {
+    return val << amount | val >> (63 - amount);
+  }
+  static constexpr uint64_t hash(const char* s) {
+    uint64_t hash = hash_rec(s, 0);
+    return hash & rol(0x41a0240682483014ull, hash & 63);
+  }
+  static constexpr uint64_t hash_rec(const char* s, int off) {
+    // Random constants!
+    return (!s[off] ? 57ull : (hash_rec(s, off + 1) * 293) ^ s[off]);
+  }
+  static constexpr const char* basename(const char* s, int off = 0) {
+    return !s[off]      ? s
+        : s[off] == '/' ? basename(&s[off + 1])
+                        : basename(s, off + 1);
+  }
+
+  static void setVerboseLogModules(const std::vector<std::string>& modules);
+
+  static inline uint64_t verboseLogModules() {
+    return verboseLogModules_;
+  }
+
+  static void clearLoggerObservers() {
+    std::lock_guard<std::mutex> g(loggerObserversMutex());
+    loggerObservers().clear();
+  }
+
+  static void addLoggerObserver(ILoggerObserver* observer);
+
+  static void removeLoggerObserver(ILoggerObserver* observer);
+
+  static void addLoggerObserverDevice(int64_t device);
+
+  static void addLoggerObserverEventCount(int64_t count);
+
+  static void setLoggerObserverTraceDurationMS(int64_t duration);
+
+  static void setLoggerObserverTraceID(const std::string& tid);
+
+  static void setLoggerObserverGroupTraceID(const std::string& gtid);
+
+  static void addLoggerObserverDestination(const std::string& dest);
+
+  static void setLoggerObserverOnDemand();
+
+  static void resetLoggerObservers();
+
+  static void addLoggerObserverAddMetadata(
+      const std::string& key,
+      const std::string& value);
+
+  static void addLoggerObserverPersistentMetadata(
+      const std::string& key,
+      const std::string& value);
+
+  static void writeStageCancellation(
+      const std::string& trace_id,
+      const std::string& group_trace_id,
+      const std::string& reason);
+
+ private:
+  std::stringstream buf_;
+  std::ostream& out_;
+  int errnum_;
+  int messageSeverity_;
+  static std::atomic_int severityLevel_;
+  static std::atomic_int verboseLogLevel_;
+  static std::atomic<uint64_t> verboseLogModules_;
+  static std::set<ILoggerObserver*>& loggerObservers() {
+    static auto* inst = new std::set<ILoggerObserver*>();
+    return *inst;
+  }
+  static std::mutex& loggerObserversMutex() {
+    static auto* loggerObserversMutex = new std::mutex();
+    return *loggerObserversMutex;
+  }
+};
+
+class VoidLogger {
+ public:
+  VoidLogger() {}
+  void operator&(std::ostream&) {}
+};
+
+// RAII helper used to ensure a UST stage row is emitted on every exit from a
+// scope. Bucketed LOG(ERROR) / LOG(WARNING) calls within the scope are picked
+// up by the emitted row as usual.
+class USTLoggerStageGuard {
+ public:
+  explicit USTLoggerStageGuard(const std::string& stage) : stage_(stage) {}
+  ~USTLoggerStageGuard();
+
+  USTLoggerStageGuard(const USTLoggerStageGuard&) = delete;
+  USTLoggerStageGuard& operator=(const USTLoggerStageGuard&) = delete;
+  USTLoggerStageGuard(USTLoggerStageGuard&&) = delete;
+  USTLoggerStageGuard& operator=(USTLoggerStageGuard&&) = delete;
+
+ private:
+  std::string stage_;
+};
+
+} // namespace KINETO_NAMESPACE
+
+#ifdef LOG // Undefine in case these are already defined (quite likely)
+#undef LOG
+#undef LOG_IS_ON
+#undef LOG_IF
+#undef LOG_EVERY_N
+#undef LOG_IF_EVERY_N
+#undef DLOG
+#undef DLOG_IF
+#undef VLOG
+#undef VLOG_IF
+#undef VLOG_EVERY_N
+#undef VLOG_IS_ON
+#undef DVLOG
+#undef LOG_FIRST_N
+#undef CHECK
+#undef DCHECK
+#undef DCHECK_EQ
+#undef PLOG
+#undef PCHECK
+#undef LOG_OCCURRENCES
+#endif
+
+#define LOG_IS_ON(severity) (severity >= libkineto::Logger::severityLevel())
+
+#define LOG_IF(severity, condition)                                 \
+  !(LOG_IS_ON(severity) && (condition)) ? (void)0                   \
+                                        : libkineto::VoidLogger() & \
+          libkineto::Logger(severity, __LINE__, __FILE__).stream()
+
+#define LOG(severity) LOG_IF(severity, true)
+
+#define LOCAL_VARNAME_CONCAT(name, suffix) _##name##suffix##_
+
+#define LOCAL_VARNAME(name) LOCAL_VARNAME_CONCAT(name, __LINE__)
+
+#define LOG_OCCURRENCES LOCAL_VARNAME(log_count)
+
+#define LOG_EVERY_N(severity, rate)               \
+  static int LOG_OCCURRENCES = 0;                 \
+  LOG_IF(severity, LOG_OCCURRENCES++ % rate == 0) \
+      << "(x" << LOG_OCCURRENCES << ") "
+
+#define LOG_FIRST_N(severity, threshold)          \
+  static int LOG_OCCURRENCES = 0;                 \
+  LOG_IF(severity, LOG_OCCURRENCES++ < threshold) \
+      << "(x" << LOG_OCCURRENCES << ") "
+
+template <uint64_t n>
+struct __to_constant__ {
+  static const uint64_t val = n;
+};
+#define FILENAME_HASH                      \
+  __to_constant__<libkineto::Logger::hash( \
+      libkineto::Logger::basename(__FILE__))>::val
+#define VLOG_IS_ON(verbosity)                           \
+  (libkineto::Logger::verboseLogLevel() >= verbosity && \
+   (libkineto::Logger::verboseLogModules() & FILENAME_HASH) == FILENAME_HASH)
+
+#define VLOG_IF(verbosity, condition) \
+  LOG_IF(VERBOSE, VLOG_IS_ON(verbosity) && (condition))
+
+#define VLOG(verbosity) VLOG_IF(verbosity, true)
+
+#define VLOG_EVERY_N(verbosity, rate)               \
+  static int LOG_OCCURRENCES = 0;                   \
+  VLOG_IF(verbosity, LOG_OCCURRENCES++ % rate == 0) \
+      << "(x" << LOG_OCCURRENCES << ") "
+
+#define PLOG(severity) \
+  libkineto::Logger(severity, __LINE__, __FILE__, errno).stream()
+
+#define SET_LOG_SEVERITY_LEVEL(level) libkineto::Logger::setSeverityLevel(level)
+
+#define SET_LOG_VERBOSITY_LEVEL(level, modules) \
+  libkineto::Logger::setVerboseLogLevel(level); \
+  libkineto::Logger::setVerboseLogModules(modules)
+
+// Logging the set of devices the trace is collect on.
+#define LOGGER_OBSERVER_ADD_DEVICE(device_count) \
+  libkineto::Logger::addLoggerObserverDevice(device_count)
+
+// Incrementing the number of events collected by this trace.
+#define LOGGER_OBSERVER_ADD_EVENT_COUNT(count) \
+  libkineto::Logger::addLoggerObserverEventCount(count)
+
+// Record duration of trace in milliseconds.
+#define LOGGER_OBSERVER_SET_TRACE_DURATION_MS(duration) \
+  libkineto::Logger::setLoggerObserverTraceDurationMS(duration)
+
+// Record the trace id when given.
+#define LOGGER_OBSERVER_SET_TRACE_ID(tid) \
+  libkineto::Logger::setLoggerObserverTraceID(tid)
+
+// Record the group trace id when given.
+#define LOGGER_OBSERVER_SET_GROUP_TRACE_ID(gtid) \
+  libkineto::Logger::setLoggerObserverGroupTraceID(gtid)
+
+// Log the set of destinations the trace is sent to.
+#define LOGGER_OBSERVER_ADD_DESTINATION(dest) \
+  libkineto::Logger::addLoggerObserverDestination(dest)
+
+// Record this was triggered by On-Demand.
+#define LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND() \
+  libkineto::Logger::setLoggerObserverOnDemand()
+
+// Reset all logger observers to a clean per-trace state.
+#define LOGGER_OBSERVER_RESET() libkineto::Logger::resetLoggerObservers()
+
+// Record that an on-demand trace request was rejected.
+#define LOGGER_OBSERVER_WRITE_STAGE_CANCELLATION( \
+    trace_id, group_trace_id, reason)             \
+  libkineto::Logger::writeStageCancellation(trace_id, group_trace_id, reason)
+
+// Record this was triggered by On-Demand.
+#define LOGGER_OBSERVER_ADD_METADATA(key, value) \
+  libkineto::Logger::addLoggerObserverAddMetadata(key, value)
+
+// Metadata that is constant for the process lifetime and survives reset().
+#define LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(key, value) \
+  libkineto::Logger::addLoggerObserverPersistentMetadata(key, value)
+
+// UST Logger Semantics to describe when a stage is complete.
+// Use libkineto::Logger directly instead of the LOG/LOG_IS_ON macros, which
+// can be redefined by glog in translation units that include both Logger.h
+// and glog/logging.h. Inline the severity gate so messages are still
+// suppressed when libkineto's severity threshold is above the message
+// severity.
+#define UST_LOGGER_MARK_COMPLETED(stage)                                      \
+  !(libkineto::LoggerOutputType::STAGE >= libkineto::Logger::severityLevel()) \
+      ? (void)0                                                               \
+      : libkineto::VoidLogger() &                                             \
+          libkineto::Logger(                                                  \
+              libkineto::LoggerOutputType::STAGE, __LINE__, __FILE__)         \
+                  .stream()                                                   \
+              << "Completed Stage: " << stage
+
+// RAII helper that fires UST_LOGGER_MARK_COMPLETED(stage) on scope exit.
+#define UST_LOGGER_STAGE_SCOPE(stage) \
+  libkineto::USTLoggerStageGuard LOCAL_VARNAME(ust_stage_guard)(stage)
+
+#define USDT_LOGGER_EMIT_MESSAGE(usdt_type)                                  \
+  !(libkineto::LoggerOutputType::USDT >= libkineto::Logger::severityLevel()) \
+      ? (void)0                                                              \
+      : libkineto::VoidLogger() &                                            \
+          libkineto::Logger(                                                 \
+              libkineto::LoggerOutputType::USDT, __LINE__, __FILE__)         \
+                  .stream()                                                  \
+              << usdt_type
+#define USDT_EMIT_START_TRACE() USDT_LOGGER_EMIT_MESSAGE("profiler_start")
+#define USDT_EMIT_STOP_TRACE() USDT_LOGGER_EMIT_MESSAGE("profiler_stop")
+
+#endif // USE_GOOGLE_LOG

--- a/third_party/kineto/libkineto/src/LoggerCollector.h
+++ b/third_party/kineto/libkineto/src/LoggerCollector.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#if !USE_GOOGLE_LOG
+
+#include <atomic>
+#include <map>
+#include <set>
+#include <vector>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ILoggerObserver.h"
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+
+class LoggerCollector : public ILoggerObserver {
+ public:
+  LoggerCollector() : buckets_() {}
+
+  void write(const std::string& message, LoggerOutputType ot = ERROR) override {
+    // Skip STAGE output type which is only used by USTLoggerCollector.
+    // Skip VERBOSE output type which may bloat metadata section of traces.
+    if (ot == STAGE || ot == VERBOSE) {
+      return;
+    }
+    buckets_[ot].push_back(message);
+  }
+
+  const std::map<LoggerOutputType, std::vector<std::string>>
+  extractCollectorMetadata() override {
+    return buckets_;
+  }
+
+  void reset() override {
+    buckets_.clear();
+    trace_duration_ms = 0;
+    event_count = 0;
+    destinations.clear();
+  }
+
+  void addDevice(const int64_t device) override {
+    devices.insert(device);
+  }
+
+  void setTraceDurationMS(const int64_t duration) override {
+    trace_duration_ms = duration;
+  }
+
+  void addEventCount(const int64_t count) override {
+    event_count += count;
+  }
+
+  void addDestination(const std::string& dest) override {
+    if (!dest.empty()) {
+      destinations.insert(dest);
+    }
+  }
+
+  void addMetadata(
+      [[maybe_unused]] const std::string& key,
+      [[maybe_unused]] const std::string& value) override {}
+
+ protected:
+  std::map<LoggerOutputType, std::vector<std::string>> buckets_;
+
+  // These are useful metadata to collect from CUPTIActivityProfiler for
+  // internal tracking.
+  std::set<int64_t> devices;
+  int64_t trace_duration_ms{0};
+  std::atomic<uint64_t> event_count{0};
+  std::set<std::string> destinations;
+};
+
+} // namespace KINETO_NAMESPACE
+
+#endif // !USE_GOOGLE_LOG

--- a/third_party/kineto/libkineto/src/LoggingAPI.cpp
+++ b/third_party/kineto/libkineto/src/LoggingAPI.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "LoggingAPI.h"
+
+#include "Logger.h"
+
+namespace libkineto {
+int getLogSeverityLevel() {
+  return Logger::severityLevel();
+}
+
+void setLogSeverityLevel(int level) {
+  SET_LOG_SEVERITY_LEVEL(level);
+}
+} // namespace libkineto

--- a/third_party/kineto/libkineto/src/RocLogger.cpp
+++ b/third_party/kineto/libkineto/src/RocLogger.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RocLogger.h"
+
+ApiIdList::ApiIdList() : invert_(true) {}
+
+void ApiIdList::add(const std::string& apiName) {
+  uint32_t cid = mapName(apiName);
+  if (cid > 0)
+    filter_[cid] = 1;
+}
+
+void ApiIdList::remove(const std::string& apiName) {
+  uint32_t cid = mapName(apiName);
+  if (cid > 0)
+    filter_.erase(cid);
+}
+
+bool ApiIdList::loadUserPrefs() {
+  // FIXME: check an ENV variable that points to an exclude file
+  return false;
+}
+
+bool ApiIdList::contains(uint32_t apiId) {
+  return (filter_.find(apiId) != filter_.end()) ? !invert_ : invert_; // XOR
+}

--- a/third_party/kineto/libkineto/src/RocLogger.h
+++ b/third_party/kineto/libkineto/src/RocLogger.h
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <deque>
+#include <functional>
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <hip/hip_runtime_api.h>
+
+namespace libkineto {
+class RocprofActivityApi;
+}
+
+typedef uint64_t timestamp_t;
+
+[[maybe_unused]] static timestamp_t timespec_to_ns(const timespec& time) {
+  return (static_cast<timestamp_t>(time.tv_sec) * 1000000000) + time.tv_nsec;
+}
+
+namespace RocLogger {
+enum CorrelationDomain {
+  begin,
+  Default = begin,
+  Domain0 = begin,
+  Domain1,
+  end,
+  size = end
+};
+} // namespace RocLogger
+
+class ApiIdList {
+ public:
+  ApiIdList();
+  virtual ~ApiIdList() {}
+  bool invertMode() {
+    return invert_;
+  }
+  void setInvertMode(bool invert) {
+    invert_ = invert;
+  }
+  void add(const std::string& apiName);
+  void remove(const std::string& apiName);
+  bool loadUserPrefs();
+
+  // Map api string to cnid enum
+  virtual uint32_t mapName(const std::string& apiName) = 0;
+
+  bool contains(uint32_t apiId);
+  const std::unordered_map<uint32_t, uint32_t>& filterList() {
+    return filter_;
+  }
+
+ private:
+  std::unordered_map<uint32_t, uint32_t> filter_;
+  bool invert_;
+};
+
+typedef enum {
+  ROCTRACER_ACTIVITY_DEFAULT = 0,
+  ROCTRACER_ACTIVITY_KERNEL,
+  ROCTRACER_ACTIVITY_COPY,
+  ROCTRACER_ACTIVITY_MALLOC,
+  ROCTRACER_ACTIVITY_ASYNC,
+  ROCTRACER_ACTIVITY_NONE
+} rocprof_activity_types;
+
+struct rocprofBase {
+  rocprofBase(
+      uint64_t id,
+      uint32_t domain,
+      uint64_t begin,
+      uint64_t end,
+      rocprof_activity_types type = ROCTRACER_ACTIVITY_NONE)
+      : id(id), begin(begin), end(end), domain(domain), type(type) {}
+  uint64_t id; // correlation_id
+  uint64_t begin;
+  uint64_t end;
+  // Tracing domain/kind. Actual type depends on the code path:
+  // - rocprofiler-sdk callbacks: rocprofiler_callback_tracing_kind_t
+  // - rocprofiler-sdk buffer tracing (rocprofAsyncRow):
+  // rocprofiler_buffer_tracing_kind_t
+  // - roctracer fallback: activity_domain_t
+  uint32_t domain;
+  rocprof_activity_types type;
+};
+
+struct rocprofRow : public rocprofBase {
+  rocprofRow(
+      uint64_t id,
+      uint32_t domain,
+      uint32_t cid,
+      uint32_t pid,
+      uint32_t tid,
+      uint64_t begin,
+      uint64_t end,
+      rocprof_activity_types type = ROCTRACER_ACTIVITY_DEFAULT)
+      : rocprofBase(id, domain, begin, end, type),
+        cid(cid),
+        pid(pid),
+        tid(tid) {}
+  uint32_t cid;
+  uint32_t pid;
+  uint32_t tid;
+};
+
+struct rocprofKernelRow : public rocprofRow {
+  rocprofKernelRow(
+      uint64_t id,
+      uint32_t domain,
+      uint32_t cid,
+      uint32_t pid,
+      uint32_t tid,
+      uint64_t begin,
+      uint64_t end,
+      const void* faddr,
+      hipFunction_t function,
+      unsigned int gx,
+      unsigned int gy,
+      unsigned int gz,
+      unsigned int wx,
+      unsigned int wy,
+      unsigned int wz,
+      size_t gss,
+      hipStream_t stream,
+      rocprof_activity_types type = ROCTRACER_ACTIVITY_KERNEL)
+      : rocprofRow(id, domain, cid, pid, tid, begin, end, type),
+        functionAddr(faddr),
+        function(function),
+        gridX(gx),
+        gridY(gy),
+        gridZ(gz),
+        workgroupX(wx),
+        workgroupY(wy),
+        workgroupZ(wz),
+        groupSegmentSize(gss),
+        stream(stream) {}
+  const void* functionAddr;
+  hipFunction_t function;
+  unsigned int gridX;
+  unsigned int gridY;
+  unsigned int gridZ;
+  unsigned int workgroupX;
+  unsigned int workgroupY;
+  unsigned int workgroupZ;
+  size_t groupSegmentSize;
+  hipStream_t stream;
+};
+
+struct rocprofCopyRow : public rocprofRow {
+  rocprofCopyRow(
+      uint64_t id,
+      uint32_t domain,
+      uint32_t cid,
+      uint32_t pid,
+      uint32_t tid,
+      uint64_t begin,
+      uint64_t end,
+      const void* src,
+      const void* dst,
+      size_t size,
+      hipMemcpyKind kind,
+      hipStream_t stream,
+      rocprof_activity_types type = ROCTRACER_ACTIVITY_COPY)
+      : rocprofRow(id, domain, cid, pid, tid, begin, end, type),
+        src(src),
+        dst(dst),
+        size(size),
+        kind(kind),
+        stream(stream) {}
+  const void* src;
+  const void* dst;
+  size_t size;
+  hipMemcpyKind kind;
+  hipStream_t stream;
+};
+
+struct rocprofMallocRow : public rocprofRow {
+  rocprofMallocRow(
+      uint64_t id,
+      uint32_t domain,
+      uint32_t cid,
+      uint32_t pid,
+      uint32_t tid,
+      uint64_t begin,
+      uint64_t end,
+      const void* ptr,
+      size_t size,
+      rocprof_activity_types type = ROCTRACER_ACTIVITY_MALLOC)
+      : rocprofRow(id, domain, cid, pid, tid, begin, end, type),
+        ptr(ptr),
+        size(size) {}
+  const void* ptr;
+  size_t size;
+};
+
+struct rocprofAsyncRow : public rocprofBase {
+  rocprofAsyncRow(
+      uint64_t id,
+      uint32_t domain,
+      uint32_t kind,
+      uint32_t op,
+      int device,
+      uint64_t queue,
+      uint64_t begin,
+      uint64_t end,
+      const std::string& kernelName,
+      rocprof_activity_types type = ROCTRACER_ACTIVITY_ASYNC)
+      : rocprofBase(id, domain, begin, end, type),
+        kind(kind),
+        op(op),
+        device(device),
+        queue(queue),
+        kernelName(kernelName) {}
+  uint32_t kind;
+  uint32_t op;
+  int device;
+  uint64_t queue;
+  uint64_t stream{0};
+  std::string kernelName;
+};

--- a/third_party/kineto/libkineto/src/RocmActivityProfiler.cpp
+++ b/third_party/kineto/libkineto/src/RocmActivityProfiler.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef HAS_ROCTRACER
+
+#include "RocmActivityProfiler.h"
+#include <fmt/format.h>
+#include <string>
+#include "DeviceUtil.h"
+
+#include <rocprofiler-sdk/version.h>
+
+#include "ActivityBuffers.h"
+#include "Config.h"
+#include "Logger.h"
+// RocprofActivity.h must stay in this .cpp only — its corresponding _inl.h has
+// inline functions referencing thread_local maps.
+#include "RocprofActivity.h"
+#include "ThreadUtil.h"
+
+using namespace std::chrono;
+using std::string;
+
+namespace KINETO_NAMESPACE {
+
+RocmActivityProfiler::RocmActivityProfiler(
+    RocprofActivityApi& rocprof,
+    bool cpuOnly)
+    : GenericActivityProfiler(cpuOnly), roc_(rocprof) {
+  if (isGpuAvailable()) {
+    logGpuVersions();
+  }
+}
+
+void RocmActivityProfiler::logGpuVersions() {
+  uint32_t majorVersion = ROCPROFILER_VERSION_MAJOR;
+  uint32_t minorVersion = ROCPROFILER_VERSION_MINOR;
+  std::string rocprofVersion =
+      std::to_string(majorVersion) + "." + std::to_string(minorVersion);
+  int hipRuntimeVersion = 0, hipDriverVersion = 0;
+  CUDA_CALL(hipRuntimeGetVersion(&hipRuntimeVersion));
+  CUDA_CALL(hipDriverGetVersion(&hipDriverVersion));
+  LOG(INFO) << "HIP versions. Rocprofiler-sdk: " << rocprofVersion
+            << "; Runtime: " << hipRuntimeVersion
+            << "; Driver: " << hipDriverVersion;
+
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
+      "rocprofiler-sdk_version", rocprofVersion);
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
+      "hip_runtime_version", std::to_string(hipRuntimeVersion));
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
+      "hip_driver_version", std::to_string(hipDriverVersion));
+  addVersionMetadata("rocprofiler-sdk_version", rocprofVersion);
+  addVersionMetadata("hip_runtime_version", std::to_string(hipRuntimeVersion));
+  addVersionMetadata("hip_driver_version", std::to_string(hipDriverVersion));
+}
+
+void RocmActivityProfiler::setMaxGpuBufferSize(int64_t size) {
+  roc_.setMaxBufferSize(size);
+}
+
+void RocmActivityProfiler::enableGpuTracing() {
+  roc_.setMaxEvents(config().maxEvents());
+  roc_.enableActivities(derivedConfig_->profileActivityTypes());
+}
+
+void RocmActivityProfiler::disableGpuTracing() {
+  roc_.disableActivities(derivedConfig_->profileActivityTypes());
+}
+
+void RocmActivityProfiler::clearGpuActivities() {
+  roc_.clearActivities();
+}
+
+bool RocmActivityProfiler::isGpuCollectionStopped() const {
+  return roc_.stopCollection;
+}
+
+void RocmActivityProfiler::synchronizeGpuDevice() {
+  CUDA_CALL(hipDeviceSynchronize());
+  roc_.flushActivities();
+}
+
+void RocmActivityProfiler::pushCorrelationIdImpl(
+    uint64_t id,
+    CorrelationFlowType type) {
+  RocprofActivityApi::CorrelationFlowType rocprofType =
+      (type == CorrelationFlowType::User)
+      ? RocprofActivityApi::CorrelationFlowType::User
+      : RocprofActivityApi::CorrelationFlowType::Default;
+  RocprofActivityApi::pushCorrelationID(id, rocprofType);
+}
+
+void RocmActivityProfiler::popCorrelationIdImpl(CorrelationFlowType type) {
+  RocprofActivityApi::CorrelationFlowType rocprofType =
+      (type == CorrelationFlowType::User)
+      ? RocprofActivityApi::CorrelationFlowType::User
+      : RocprofActivityApi::CorrelationFlowType::Default;
+  RocprofActivityApi::popCorrelationID(rocprofType);
+}
+
+void RocmActivityProfiler::onResetTraceData() {
+  roc_.teardownContext();
+}
+
+void RocmActivityProfiler::onFinalizeTrace(
+    [[maybe_unused]] const Config& config,
+    [[maybe_unused]] ActivityLogger& logger) {
+  // No additional overhead info for ROCm currently
+}
+
+void RocmActivityProfiler::processGpuActivities(ActivityLogger& logger) {
+  VLOG(0) << "Retrieving GPU activity buffers";
+  const int count = roc_.processActivities(
+      std::bind(
+          &RocmActivityProfiler::handleRocprofActivity,
+          this,
+          std::placeholders::_1,
+          &logger),
+      std::bind(
+          &RocmActivityProfiler::handleCorrelationActivity,
+          this,
+          std::placeholders::_1,
+          std::placeholders::_2,
+          std::placeholders::_3));
+  LOG(INFO) << "Processed " << count << " GPU records";
+  LOGGER_OBSERVER_ADD_EVENT_COUNT(count);
+}
+
+inline void RocmActivityProfiler::handleCorrelationActivity(
+    uint64_t correlationId,
+    uint64_t externalId,
+    RocLogger::CorrelationDomain externalKind) {
+  if (externalKind == RocLogger::CorrelationDomain::Domain0) {
+    cpuCorrelationMap_[correlationId] = externalId;
+  } else if (externalKind == RocLogger::CorrelationDomain::Domain1) {
+    userCorrelationMap_[correlationId] = externalId;
+  } else {
+    LOG(WARNING)
+        << "Invalid RocLogger::CorrelationDomain sent to handleCorrelationActivity";
+    ecs_.invalid_external_correlation_events++;
+  }
+}
+
+template <class T>
+void RocmActivityProfiler::handleRuntimeActivity(
+    const T* activity,
+    ActivityLogger* logger) {
+  int32_t tid = activity->tid;
+  const auto& it = resourceInfo_.find({processId(), tid});
+  if (it != resourceInfo_.end()) {
+    tid = it->second.id;
+  }
+  const ITraceActivity* linked =
+      linkedActivity(activity->id, cpuCorrelationMap_);
+  const auto& runtime_activity =
+      traceBuffers_->addActivityWrapper(RuntimeActivity<T>(activity, linked));
+  checkTimestampOrder(&runtime_activity);
+  if (outOfRange(runtime_activity)) {
+    return;
+  }
+  runtime_activity.log(*logger);
+  setGpuActivityPresent(true);
+}
+
+inline void RocmActivityProfiler::handleGpuActivity(
+    const rocprofAsyncRow* act,
+    ActivityLogger* logger) {
+  const ITraceActivity* linked = linkedActivity(act->id, cpuCorrelationMap_);
+  const auto& gpu_activity =
+      traceBuffers_->addActivityWrapper(GpuActivity(act, linked));
+  GenericActivityProfiler::handleGpuActivity(gpu_activity, logger);
+}
+
+void RocmActivityProfiler::handleRocprofActivity(
+    const rocprofBase* record,
+    ActivityLogger* logger) {
+  switch (record->type) {
+    case ROCTRACER_ACTIVITY_DEFAULT:
+      handleRuntimeActivity(
+          reinterpret_cast<const rocprofRow*>(record), logger);
+      break;
+    case ROCTRACER_ACTIVITY_KERNEL:
+      handleRuntimeActivity(
+          reinterpret_cast<const rocprofKernelRow*>(record), logger);
+      break;
+    case ROCTRACER_ACTIVITY_COPY:
+      handleRuntimeActivity(
+          reinterpret_cast<const rocprofCopyRow*>(record), logger);
+      break;
+    case ROCTRACER_ACTIVITY_MALLOC:
+      handleRuntimeActivity(
+          reinterpret_cast<const rocprofMallocRow*>(record), logger);
+      break;
+    case ROCTRACER_ACTIVITY_ASYNC:
+      handleGpuActivity(
+          reinterpret_cast<const rocprofAsyncRow*>(record), logger);
+      break;
+    case ROCTRACER_ACTIVITY_NONE:
+    default:
+      LOG(WARNING) << "Unexpected activity type: " << record->type;
+      ecs_.unexepected_cuda_events++;
+      break;
+  }
+}
+
+} // namespace KINETO_NAMESPACE
+
+#endif // HAS_ROCTRACER

--- a/third_party/kineto/libkineto/src/RocmActivityProfiler.h
+++ b/third_party/kineto/libkineto/src/RocmActivityProfiler.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// TODO DEVICE_AGNOSTIC: The build system should be strict enough that we don't
+//                       need this guard in the header file.
+#ifdef HAS_ROCTRACER
+
+#include <cstdint>
+
+#include <rocprofiler-sdk/version.h>
+
+#include "GenericActivityProfiler.h"
+#include "RocLogger.h"
+#include "RocprofActivityApi.h"
+
+namespace KINETO_NAMESPACE {
+
+class RocmActivityProfiler : public GenericActivityProfiler {
+ public:
+  RocmActivityProfiler(RocprofActivityApi& rocprof, bool cpuOnly);
+  RocmActivityProfiler(const RocmActivityProfiler&) = delete;
+  RocmActivityProfiler& operator=(const RocmActivityProfiler&) = delete;
+  ~RocmActivityProfiler() override = default;
+
+ protected:
+  void logGpuVersions() override;
+  void setMaxGpuBufferSize(int64_t size) override;
+  void enableGpuTracing() override;
+  void disableGpuTracing() override;
+  void clearGpuActivities() override;
+  bool isGpuCollectionStopped() const override;
+  void processGpuActivities(ActivityLogger& logger) override;
+  void synchronizeGpuDevice() override;
+  void pushCorrelationIdImpl(uint64_t id, CorrelationFlowType type) override;
+  void popCorrelationIdImpl(CorrelationFlowType type) override;
+  void onResetTraceData() override;
+  void onFinalizeTrace(const Config& config, ActivityLogger& logger) override;
+
+ private:
+  // Process generic RocProf activity
+  void handleRocprofActivity(const rocprofBase* record, ActivityLogger* logger);
+  void handleCorrelationActivity(
+      uint64_t correlationId,
+      uint64_t externalId,
+      RocLogger::CorrelationDomain externalKind);
+  // Process specific GPU activity types
+  template <class T>
+  void handleRuntimeActivity(const T* activity, ActivityLogger* logger);
+  void handleGpuActivity(const rocprofAsyncRow* record, ActivityLogger* logger);
+
+  // Calls to rocprofiler-sdk is encapsulated behind this interface
+  RocprofActivityApi& roc_;
+};
+
+} // namespace KINETO_NAMESPACE
+
+#endif // HAS_ROCTRACER

--- a/third_party/kineto/libkineto/src/RocmStreamQueue.h
+++ b/third_party/kineto/libkineto/src/RocmStreamQueue.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef HAS_ROCTRACER
+
+#include <cstdint>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "RocLogger.h"
+
+namespace KINETO_NAMESPACE {
+namespace detail {
+
+inline uint64_t streamIdFromHipStream(hipStream_t stream) {
+  return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(stream));
+}
+
+inline uint64_t runtimeStreamId(const rocprofBase* item) {
+  if (item->type == ROCTRACER_ACTIVITY_KERNEL) {
+    return streamIdFromHipStream(
+        reinterpret_cast<const rocprofKernelRow*>(item)->stream);
+  }
+  if (item->type == ROCTRACER_ACTIVITY_COPY) {
+    return streamIdFromHipStream(
+        reinterpret_cast<const rocprofCopyRow*>(item)->stream);
+  }
+  return 0;
+}
+
+// Assign logical stream ID to async kernel and copy rows. Remap to small index
+// for proper display. Recover logical stream ID from the correlated runtime
+// row. isAsyncOp selects the async rows to process.
+template <class IsAsyncOp>
+void backfillAsyncStreams(
+    std::vector<rocprofBase*>& rows,
+    IsAsyncOp isAsyncOp) {
+  // Map correlation id -> HIP stream from the runtime kernel/copy rows.
+  std::unordered_map<uint64_t, uint64_t> streamByCorrelation;
+  for (const auto* item : rows) {
+    const uint64_t sid = runtimeStreamId(item);
+    if (sid != 0) {
+      streamByCorrelation[item->id] = sid;
+    }
+  }
+  if (streamByCorrelation.empty()) {
+    return;
+  }
+
+  // Set stream from the correlation-matched runtime row.
+  for (auto* item : rows) {
+    if (item->type != ROCTRACER_ACTIVITY_ASYNC) {
+      continue;
+    }
+    auto* async = reinterpret_cast<rocprofAsyncRow*>(item);
+    if (!isAsyncOp(*async) || async->stream != 0) {
+      continue;
+    }
+    const auto it = streamByCorrelation.find(async->id);
+    if (it != streamByCorrelation.end()) {
+      async->stream = it->second;
+    }
+  }
+
+  // Fallback: (e.g. ROCm-internal dispatches like __amd_rocclr_copyBuffer),
+  // infer the stream from the HSA queue, given the queue maps directly to a HIP
+  // stream
+  std::unordered_map<uint64_t, uint64_t> streamByQueue;
+  std::unordered_set<uint64_t> ambiguousQueues;
+  for (const auto* item : rows) {
+    if (item->type != ROCTRACER_ACTIVITY_ASYNC) {
+      continue;
+    }
+    const auto* async = reinterpret_cast<const rocprofAsyncRow*>(item);
+    if (!isAsyncOp(*async) || async->stream == 0 || async->queue == 0) {
+      continue;
+    }
+    if (ambiguousQueues.count(async->queue) > 0) {
+      continue;
+    }
+    const auto [it, inserted] =
+        streamByQueue.emplace(async->queue, async->stream);
+    if (!inserted && it->second != async->stream) {
+      streamByQueue.erase(it);
+      ambiguousQueues.insert(async->queue);
+    }
+  }
+  for (auto* item : rows) {
+    if (item->type != ROCTRACER_ACTIVITY_ASYNC) {
+      continue;
+    }
+    auto* async = reinterpret_cast<rocprofAsyncRow*>(item);
+    if (!isAsyncOp(*async) || async->stream != 0) {
+      continue;
+    }
+    const auto it = streamByQueue.find(async->queue);
+    if (it != streamByQueue.end()) {
+      async->stream = it->second;
+    }
+  }
+
+  // Remap raw HIP stream pointers to small per-device indices, avoiding
+  // misrenders of large 64-bit tid values. Fallback: if still no stream ID, use
+  // HSA queue ID tagged with high bit to avoid collisions with stream IDs
+  constexpr uint64_t kQueueKeyTag = uint64_t{1} << 63;
+  std::unordered_map<int, std::unordered_map<uint64_t, uint64_t>>
+      deviceStreamToIndex;
+  for (auto* item : rows) {
+    if (item->type != ROCTRACER_ACTIVITY_ASYNC) {
+      continue;
+    }
+    auto* async = reinterpret_cast<rocprofAsyncRow*>(item);
+    if (!isAsyncOp(*async)) {
+      continue;
+    }
+    uint64_t key;
+    if (async->stream != 0) {
+      key = async->stream;
+    } else if (async->queue != 0) {
+      key = async->queue | kQueueKeyTag;
+    } else {
+      continue;
+    }
+    auto& mapping = deviceStreamToIndex[async->device];
+    auto [it, inserted] = mapping.emplace(key, mapping.size() + 1);
+    async->stream = it->second;
+  }
+}
+
+} // namespace detail
+} // namespace KINETO_NAMESPACE
+
+#endif // HAS_ROCTRACER

--- a/third_party/kineto/libkineto/src/RocprofActivity.h
+++ b/third_party/kineto/libkineto/src/RocprofActivity.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "GenericTraceActivity.h"
+#include "ITraceActivity.h"
+#include "MetadataFieldCatalog.h"
+#include "RocprofLogger.h"
+#include "ThreadUtil.h"
+
+#include <rocprofiler-sdk/cxx/name_info.hpp>
+#include <rocprofiler-sdk/fwd.h>
+
+namespace libkineto {
+class ActivityLogger;
+}
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+struct TraceSpan;
+
+// These classes wrap the various Rocprof activity types
+// into subclasses of ITraceActivity so that they can all be accessed
+// using the ITraceActivity interface and logged via ActivityLogger.
+
+// Abstract base class, templated on Rocprof activity type
+template <class T>
+struct RocprofActivity : public ITraceActivity {
+  explicit RocprofActivity(const T* activity, const ITraceActivity* linked)
+      : activity_(*activity), linked_(linked) {}
+  // Our stored timestamps (from rocprof and generated) are in CLOCK_MONOTONIC
+  // domain (in ns). Convert the timestamps.
+  int64_t timestamp() const override {
+    return activity_.begin;
+  }
+  int64_t duration() const override {
+    return activity_.end - activity_.begin;
+  }
+  int64_t correlationId() const override {
+    return 0;
+  }
+  int32_t getThreadId() const override {
+    return 0;
+  }
+  const ITraceActivity* linkedActivity() const override {
+    return linked_;
+  }
+  int flowType() const override {
+    return kLinkAsyncCpuGpu;
+  }
+  int64_t flowId() const override {
+    return correlationId();
+  }
+  const T& raw() const {
+    return activity_;
+  }
+  const TraceSpan* traceSpan() const override {
+    return nullptr;
+  }
+  const std::string getMetadataValue(const std::string& key) const override {
+    auto it = metadata_.find(key);
+    if (it != metadata_.end()) {
+      return it->second;
+    }
+    return "";
+  }
+
+ protected:
+  const T& activity_;
+  const ITraceActivity* linked_{nullptr};
+  std::unordered_map<std::string, std::string> metadata_;
+};
+
+// rocprofAsyncRow - Rocprof GPU activities
+struct GpuActivity : public RocprofActivity<rocprofAsyncRow> {
+  explicit GpuActivity(
+      const rocprofAsyncRow* activity,
+      const ITraceActivity* linked)
+      : RocprofActivity(activity, linked) {
+    switch (activity_.domain) {
+      case ROCPROFILER_BUFFER_TRACING_MEMORY_COPY:
+        type_ = ActivityType::GPU_MEMCPY;
+        break;
+      case ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH:
+      default:
+        type_ = ActivityType::CONCURRENT_KERNEL;
+        break;
+    }
+  }
+  int64_t correlationId() const override {
+    return activity_.id;
+  }
+  int64_t deviceId() const override {
+    return activity_.device;
+  }
+  int64_t resourceId() const override {
+    return activity_.stream != 0 ? activity_.stream : activity_.queue;
+  }
+  ActivityType type() const override {
+    return type_;
+  };
+  bool flowStart() const override {
+    return false;
+  }
+  const std::string name() const override;
+  void log(ActivityLogger& logger) const override;
+  const std::string metadataJson() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
+
+  // Add small buffer to fix visual error created by
+  // https://github.com/ROCm/rocprof/issues/105 Once this is resolved we can
+  // use ifdef to handle having this buffer or not based on version
+  int64_t timestamp() const override {
+    return activity_.begin + 1;
+  }
+  int64_t duration() const override {
+    return activity_.end - (activity_.begin + 1);
+  }
+
+ private:
+  ActivityType type_;
+};
+
+// rocprofRow, rocprofKernelRow, rocprofCopyRow, rocprofMallocRow -
+// Rocprof runtime activities
+template <class T>
+struct RuntimeActivity : public RocprofActivity<T> {
+  explicit RuntimeActivity(const T* activity, const ITraceActivity* linked)
+      : RocprofActivity<T>(activity, linked) {}
+  int64_t correlationId() const override {
+    return raw().id;
+  }
+  int64_t deviceId() const override {
+    return raw().pid;
+  }
+  int64_t resourceId() const override {
+    return raw().tid;
+  }
+  ActivityType type() const override {
+    return ActivityType::CUDA_RUNTIME;
+  }
+  bool flowStart() const override;
+  const std::string name() const override {
+    return RocprofLogger::opString(
+        ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API, raw().cid);
+  }
+  void log(ActivityLogger& logger) const override;
+  const std::string metadataJson() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
+  const T& raw() const {
+    return RocprofActivity<T>::raw();
+  }
+};
+
+} // namespace KINETO_NAMESPACE
+
+// Include the implementation detail of this header file.
+// The *_inl.h helps separate header interface from implementation details.
+#include "RocprofActivity_inl.h"

--- a/third_party/kineto/libkineto/src/RocprofActivityApi.cpp
+++ b/third_party/kineto/libkineto/src/RocprofActivityApi.cpp
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RocprofActivityApi.h"
+
+#include <time.h>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <unordered_map>
+#include <vector>
+#include "ApproximateClock.h"
+#include "Demangle.h"
+#include "Logger.h"
+#include "RocmStreamQueue.h"
+#include "ThreadUtil.h"
+#include "output_base.h"
+
+using namespace std::chrono;
+
+namespace KINETO_NAMESPACE {
+
+namespace {
+bool isAsyncCopy(const rocprofAsyncRow& async) {
+  return async.domain == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY;
+}
+
+bool isAsyncKernel(const rocprofAsyncRow& async) {
+  return async.domain == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH;
+}
+} // namespace
+
+RocprofActivityApi& RocprofActivityApi::singleton() {
+  static RocprofActivityApi instance;
+  return instance;
+}
+
+RocprofActivityApi::RocprofActivityApi() : d(&RocprofLogger::singleton()) {}
+
+RocprofActivityApi::~RocprofActivityApi() {
+  disableActivities(std::set<ActivityType>());
+}
+
+void RocprofActivityApi::pushCorrelationID(int id, CorrelationFlowType type) {
+#ifdef HAS_ROCTRACER
+  if (!singleton().d->externalCorrelationEnabled_) {
+    return;
+  }
+  singleton().d->pushCorrelationID(
+      id, static_cast<RocLogger::CorrelationDomain>(type));
+#endif
+}
+
+void RocprofActivityApi::popCorrelationID(CorrelationFlowType type) {
+#ifdef HAS_ROCTRACER
+  if (!singleton().d->externalCorrelationEnabled_) {
+    return;
+  }
+  singleton().d->popCorrelationID(
+      static_cast<RocLogger::CorrelationDomain>(type));
+#endif
+}
+
+void RocprofActivityApi::setMaxEvents(uint32_t maxEvents) {
+  d->setMaxEvents(maxEvents);
+}
+
+void RocprofActivityApi::setMaxBufferSize([[maybe_unused]] int64_t size) {
+  // FIXME: implement?
+  // maxGpuBufferCount_ = 1 + size / kBufSize;
+}
+
+inline bool inRange(int64_t start, int64_t end, int64_t stamp) {
+  return ((stamp > start) && (stamp < end));
+}
+
+inline bool RocprofActivityApi::isLogged(libkineto::ActivityType atype) const {
+  return activityMaskSnapshot_ & (1 << static_cast<uint32_t>(atype));
+}
+
+timestamp_t getTimeOffset() {
+  int64_t t0, t00;
+  timespec t1;
+  t0 = libkineto::getApproximateTime();
+  clock_gettime(CLOCK_MONOTONIC, &t1);
+  t00 = libkineto::getApproximateTime();
+
+  // Confvert to ns (if necessary)
+  t0 = libkineto::get_time_converter()(t0);
+  t00 = libkineto::get_time_converter()(t00);
+
+  // Our stored timestamps (from roctracer and generated) are in CLOCK_MONOTONIC
+  // domain (in ns).
+  return (t0 >> 1) + (t00 >> 1) - timespec_to_ns(t1);
+}
+
+int RocprofActivityApi::processActivities(
+    std::function<void(const rocprofBase*)> handler,
+    std::function<void(uint64_t, uint64_t, RocLogger::CorrelationDomain)>
+        correlationHandler) {
+  // Find offset to map from monotonic clock to system clock.
+  // This will break time-ordering of events but is status quo.
+
+  int count = 0;
+
+  // Process all external correlations pairs
+  for (int it = RocLogger::CorrelationDomain::begin;
+       it < RocLogger::CorrelationDomain::end;
+       ++it) {
+    auto& externalCorrelations = d->externalCorrelations_[it];
+    for (auto& item : externalCorrelations) {
+      correlationHandler(
+          item.first,
+          item.second,
+          static_cast<RocLogger::CorrelationDomain>(it));
+    }
+    std::lock_guard<std::mutex> lock(d->externalCorrelationsMutex_);
+    externalCorrelations.clear();
+  }
+
+  // Async ops are in CLOCK_MONOTONIC rather than junk clock.
+  // Convert these timestamps, poorly.
+  // These accurate timestamps will skew when converted to approximate time
+  // The time_converter is not available at collection time.  Or we could do a
+  // much better job.
+  auto toffset = getTimeOffset();
+
+  const bool logCopies = isLogged(ActivityType::GPU_MEMCPY);
+  const bool logKernels = isLogged(ActivityType::CONCURRENT_KERNEL);
+  if (logCopies || logKernels) {
+    detail::backfillAsyncStreams(
+        d->rows_, [logCopies, logKernels](const rocprofAsyncRow& async) {
+          return (logCopies && isAsyncCopy(async)) ||
+              (logKernels && isAsyncKernel(async));
+        });
+  }
+
+  // All Runtime API Calls
+  for (auto& item : d->rows_) {
+    bool filtered = false;
+    if (item->type != ROCTRACER_ACTIVITY_ASYNC &&
+        !isLogged(ActivityType::CUDA_RUNTIME)) {
+      filtered = true;
+    } else {
+      switch (reinterpret_cast<rocprofAsyncRow*>(item)->domain) {
+        case ROCPROFILER_BUFFER_TRACING_MEMORY_COPY:
+          if (!isLogged(ActivityType::GPU_MEMCPY))
+            filtered = true;
+          break;
+        case ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH:
+        default:
+          if (!isLogged(ActivityType::CONCURRENT_KERNEL))
+            filtered = true;
+          break;
+      }
+    }
+    if (!filtered) {
+      // Convert the begin and end timestamps from monotonic clock to system
+      // clock.
+      if (item->type == ROCTRACER_ACTIVITY_ASYNC) {
+        // Async ops are in CLOCK_MONOTONIC, apply offset to converted
+        // approximate
+        item->begin += toffset;
+        item->end += toffset;
+      } else {
+        // Runtime ranges are in approximate clock, just apply conversion
+        item->begin = libkineto::get_time_converter()(item->begin);
+        item->end = libkineto::get_time_converter()(item->end);
+      }
+      handler(item);
+      ++count;
+    }
+  }
+  return count;
+}
+
+// TODO: implement the actual flush with roctracer_flush_activity
+void RocprofActivityApi::flushActivities() {}
+
+void RocprofActivityApi::clearActivities() {
+  d->clearLogs();
+}
+
+void RocprofActivityApi::enableActivities(
+    const std::set<ActivityType>& selected_activities) {
+#ifdef HAS_ROCTRACER
+  d->startLogging();
+
+  for (const auto& activity : selected_activities) {
+    activityMask_ |= (1 << static_cast<uint32_t>(activity));
+    if (activity == ActivityType::EXTERNAL_CORRELATION) {
+      d->externalCorrelationEnabled_ = true;
+    }
+  }
+#endif
+}
+
+void RocprofActivityApi::disableActivities(
+    const std::set<ActivityType>& selected_activities) {
+#ifdef HAS_ROCTRACER
+  d->stopLogging();
+
+  activityMaskSnapshot_ = activityMask_;
+
+  for (const auto& activity : selected_activities) {
+    activityMask_ &= ~(1 << static_cast<uint32_t>(activity));
+    if (activity == ActivityType::EXTERNAL_CORRELATION) {
+      d->externalCorrelationEnabled_ = false;
+    }
+  }
+#endif
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/RocprofActivityApi.h
+++ b/third_party/kineto/libkineto/src/RocprofActivityApi.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#ifdef HAS_ROCTRACER
+
+#include <atomic>
+#include <functional>
+#include <set>
+
+#include "RocprofLogger.h"
+
+#include "ActivityType.h"
+#include "GenericTraceActivity.h"
+
+class RocprofLogger;
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+
+class RocprofActivityApi {
+ public:
+  enum CorrelationFlowType { Default, User };
+
+  RocprofActivityApi();
+  RocprofActivityApi(const RocprofActivityApi&) = delete;
+  RocprofActivityApi& operator=(const RocprofActivityApi&) = delete;
+
+  virtual ~RocprofActivityApi();
+
+  static RocprofActivityApi& singleton();
+
+  static void pushCorrelationID(int id, CorrelationFlowType type);
+  static void popCorrelationID(CorrelationFlowType type);
+
+  void enableActivities(const std::set<ActivityType>& selected_activities);
+  void disableActivities(const std::set<ActivityType>& selected_activities);
+  void flushActivities();
+  void clearActivities();
+  void teardownContext() {}
+  void setTimeOffset(timestamp_t toffset);
+  void setMaxEvents(uint32_t maxEvents);
+
+  virtual int processActivities(
+      std::function<void(const rocprofBase*)> handler,
+      std::function<void(uint64_t, uint64_t, RocLogger::CorrelationDomain)>
+          correlationHandler);
+
+  void setMaxBufferSize(int64_t size);
+
+  std::atomic_bool stopCollection{false};
+
+ private:
+  bool registered_{false};
+  timestamp_t toffset_{0};
+
+  // Enabled Activity Filters
+  uint32_t activityMask_{0};
+  uint32_t activityMaskSnapshot_{0};
+  bool isLogged(libkineto::ActivityType atype) const;
+
+  RocprofLogger* d;
+};
+
+} // namespace KINETO_NAMESPACE
+#endif

--- a/third_party/kineto/libkineto/src/RocprofActivity_inl.h
+++ b/third_party/kineto/libkineto/src/RocprofActivity_inl.h
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "RocprofActivity.h"
+
+#include <fmt/format.h>
+#include <stddef.h>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "Demangle.h"
+#include "TypedMetadataJson.h"
+#include "output_base.h"
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+
+namespace {
+thread_local std::unordered_map<int, std::vector<int64_t>> correlationToGrid;
+thread_local std::unordered_map<int, std::vector<int64_t>> correlationToBlock;
+thread_local std::unordered_map<int, size_t> correlationToSize;
+
+inline std::vector<int64_t> rocprofKernelGrid(
+    const rocprofKernelRow& activity) {
+  return {
+      static_cast<int64_t>(activity.gridX),
+      static_cast<int64_t>(activity.gridY),
+      static_cast<int64_t>(activity.gridZ)};
+}
+
+inline std::vector<int64_t> rocprofKernelBlock(
+    const rocprofKernelRow& activity) {
+  return {
+      static_cast<int64_t>(activity.workgroupX),
+      static_cast<int64_t>(activity.workgroupY),
+      static_cast<int64_t>(activity.workgroupZ)};
+}
+
+} // namespace
+
+inline const char* getGpuActivityKindString(uint32_t domain, uint32_t op) {
+  if (domain == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH)
+    return "Dispatch Kernel";
+  else if (domain == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY) {
+    switch (op) {
+      case ROCPROFILER_MEMORY_COPY_HOST_TO_HOST:
+        return "HtoH";
+      case ROCPROFILER_MEMORY_COPY_HOST_TO_DEVICE:
+        return "HtoD";
+      case ROCPROFILER_MEMORY_COPY_DEVICE_TO_HOST:
+        return "DtoH";
+      case ROCPROFILER_MEMORY_COPY_DEVICE_TO_DEVICE:
+        return "DtoD";
+    }
+  }
+  return "<unknown>";
+}
+
+inline void getMemcpySrcDstString(
+    uint32_t kind,
+    std::string& src,
+    std::string& dst) {
+  switch (kind) {
+    case ROCPROFILER_MEMORY_COPY_HOST_TO_HOST:
+      src = "Host";
+      dst = "Host";
+      break;
+    case ROCPROFILER_MEMORY_COPY_DEVICE_TO_HOST:
+      src = "Device";
+      dst = "Host";
+      break;
+    case ROCPROFILER_MEMORY_COPY_HOST_TO_DEVICE:
+      src = "Host";
+      dst = "Device";
+      break;
+    case ROCPROFILER_MEMORY_COPY_DEVICE_TO_DEVICE:
+      src = "Device";
+      dst = "Device";
+      break;
+    default:
+      src = "?";
+      dst = "?";
+      break;
+  }
+}
+
+// GPU Activities
+
+inline const std::string GpuActivity::name() const {
+  if (type_ == ActivityType::CONCURRENT_KERNEL) {
+    auto op = raw().op;
+    auto domain = raw().domain;
+    std::string opString = RocprofLogger::opString(
+        static_cast<rocprofiler_buffer_tracing_kind_t>(domain), op);
+    const char* name = opString.c_str();
+    return demangle(
+        raw().kernelName.length() > 0 ? raw().kernelName : std::string(name));
+  } else if (type_ == ActivityType::GPU_MEMSET) {
+    return fmt::format(
+        "Memset ({})", getGpuActivityKindString(raw().domain, raw().op));
+  } else if (type_ == ActivityType::GPU_MEMCPY) {
+    std::string src = "";
+    std::string dst = "";
+    getMemcpySrcDstString(raw().op, src, dst);
+    return fmt::format(
+        "Memcpy {} ({} -> {})",
+        getGpuActivityKindString(raw().domain, raw().op),
+        src,
+        dst);
+  } else {
+    return "";
+  }
+  return "";
+}
+
+inline void GpuActivity::log(ActivityLogger& logger) const {
+  logger.handleActivity(*this);
+}
+
+static inline void addBandwidthTypedMetadata(
+    ITypedMetadataVisitor& visitor,
+    size_t bytes,
+    uint64_t duration) {
+  if (duration == 0) {
+    return;
+  }
+  visitor.visit(
+      RocmMetadataFields::kMemoryBandwidthGbps,
+      static_cast<double>(bytes) / static_cast<double>(duration));
+}
+
+inline const std::string GpuActivity::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+inline void GpuActivity::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  const auto& gpuActivity = raw();
+  visitor.visit(
+      RocmMetadataFields::kDevice, static_cast<int64_t>(gpuActivity.device));
+  visitor.visit(RocmMetadataFields::kStream, resourceId());
+  visitor.visit(
+      RocmMetadataFields::kHsaQueue, static_cast<uint64_t>(gpuActivity.queue));
+  visitor.visit(
+      RocmMetadataFields::kCorrelation, static_cast<uint64_t>(gpuActivity.id));
+  visitor.visit(
+      RocmMetadataFields::kKind,
+      std::string{
+          getGpuActivityKindString(gpuActivity.domain, gpuActivity.op)});
+
+  // if memcpy or memset, add size
+  auto sizeIt = correlationToSize.find(gpuActivity.id);
+  if (sizeIt != correlationToSize.end()) {
+    visitor.visit(
+        RocmMetadataFields::kBytes, static_cast<uint64_t>(sizeIt->second));
+    addBandwidthTypedMetadata(
+        visitor, sizeIt->second, gpuActivity.end - gpuActivity.begin);
+    return;
+  }
+
+  // if compute kernel, add grid and block
+  auto gridIt = correlationToGrid.find(gpuActivity.id);
+  auto blockIt = correlationToBlock.find(gpuActivity.id);
+  if (gridIt != correlationToGrid.end() &&
+      blockIt != correlationToBlock.end()) {
+    visitor.visit(RocmMetadataFields::kGrid, gridIt->second);
+    visitor.visit(RocmMetadataFields::kBlock, blockIt->second);
+  }
+}
+
+// Runtime Activities
+
+template <class T>
+inline bool RuntimeActivity<T>::flowStart() const {
+  bool should_correlate =
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipLaunchKernel ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipExtLaunchKernel ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipLaunchCooperativeKernel ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipHccModuleLaunchKernel ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipModuleLaunchKernel ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipExtModuleLaunchKernel ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMalloc ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipFree ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyAsync ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyWithStream ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipGraphLaunch;
+  return should_correlate;
+}
+
+template <class T>
+inline void RuntimeActivity<T>::log(ActivityLogger& logger) const {
+  logger.handleActivity(*this);
+}
+
+template <>
+inline void RuntimeActivity<rocprofKernelRow>::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  if ((raw().functionAddr != nullptr)) {
+    visitor.visit(
+        RocmMetadataFields::kKernel,
+        demangle(hipKernelNameRefByPtr(raw().functionAddr, raw().stream)));
+  } else if ((raw().function != nullptr)) {
+    visitor.visit(
+        RocmMetadataFields::kKernel,
+        demangle(hipKernelNameRef(raw().function)));
+  }
+
+  // cache grid and block so we can pass it into async activity (GPU track)
+  correlationToGrid[raw().id] = rocprofKernelGrid(raw());
+  correlationToBlock[raw().id] = rocprofKernelBlock(raw());
+
+  visitor.visit(RocmMetadataFields::kCid, static_cast<uint64_t>(raw().cid));
+  visitor.visit(
+      RocmMetadataFields::kCorrelation, static_cast<uint64_t>(raw().id));
+  visitor.visit(RocmMetadataFields::kGrid, correlationToGrid[raw().id]);
+  visitor.visit(RocmMetadataFields::kBlock, correlationToBlock[raw().id]);
+  visitor.visit(
+      RocmMetadataFields::kSharedMemory,
+      static_cast<uint64_t>(raw().groupSegmentSize));
+}
+
+template <>
+inline const std::string RuntimeActivity<rocprofKernelRow>::metadataJson()
+    const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+template <>
+inline void RuntimeActivity<rocprofCopyRow>::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  correlationToSize[raw().id] = raw().size;
+  visitor.visit(RocmMetadataFields::kCid, static_cast<uint64_t>(raw().cid));
+  visitor.visit(
+      RocmMetadataFields::kCorrelation, static_cast<uint64_t>(raw().id));
+  visitor.visit(RocmMetadataFields::kSrc, fmt::format("{}", raw().src));
+  visitor.visit(RocmMetadataFields::kDst, fmt::format("{}", raw().dst));
+  visitor.visit(RocmMetadataFields::kBytes, static_cast<uint64_t>(raw().size));
+  visitor.visit(
+      RocmMetadataFields::kKind,
+      fmt::format("{}", fmt::underlying(raw().kind)));
+}
+
+template <>
+inline const std::string RuntimeActivity<rocprofCopyRow>::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+template <>
+inline void RuntimeActivity<rocprofMallocRow>::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  correlationToSize[raw().id] = raw().size;
+  if (raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMalloc) {
+    visitor.visit(
+        RocmMetadataFields::kBytes, static_cast<uint64_t>(raw().size));
+  }
+  visitor.visit(RocmMetadataFields::kCid, static_cast<uint64_t>(raw().cid));
+  visitor.visit(
+      RocmMetadataFields::kCorrelation, static_cast<uint64_t>(raw().id));
+  visitor.visit(RocmMetadataFields::kPtr, fmt::format("{}", raw().ptr));
+}
+
+template <>
+inline const std::string RuntimeActivity<rocprofMallocRow>::metadataJson()
+    const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+template <class T>
+inline const std::string RuntimeActivity<T>::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+template <class T>
+inline void RuntimeActivity<T>::visitTypedMetadata(
+    ITypedMetadataVisitor& visitor) const {
+  visitor.visit(RocmMetadataFields::kCid, static_cast<uint64_t>(raw().cid));
+  visitor.visit(
+      RocmMetadataFields::kCorrelation, static_cast<uint64_t>(raw().id));
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/RocprofLogger.cpp
+++ b/third_party/kineto/libkineto/src/RocprofLogger.cpp
@@ -1,0 +1,851 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RocprofLogger.h"
+
+#include <rocprofiler-sdk/context.h>
+#include <rocprofiler-sdk/cxx/name_info.hpp>
+#include <rocprofiler-sdk/fwd.h>
+#include <rocprofiler-sdk/marker/api_id.h>
+#include <rocprofiler-sdk/registration.h>
+#include <rocprofiler-sdk/rocprofiler.h>
+
+#include <time.h>
+#include <unistd.h>
+#include <chrono>
+#include <cstring>
+#include <mutex>
+
+#include "ApproximateClock.h"
+#include "Demangle.h"
+#include "Logger.h"
+#include "ThreadUtil.h"
+
+using namespace libkineto;
+using namespace std::chrono;
+using namespace RocLogger;
+
+namespace {
+
+using kernel_symbol_data_t =
+    rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;
+using kernel_symbol_map_t =
+    std::unordered_map<rocprofiler_kernel_id_t, kernel_symbol_data_t>;
+using kernel_name_map_t =
+    std::unordered_map<rocprofiler_kernel_id_t, std::string>;
+using rocprofiler::sdk::buffer_name_info;
+using rocprofiler::sdk::callback_name_info;
+using agent_info_map_t = std::unordered_map<uint64_t, rocprofiler_agent_v0_t>;
+
+// extract copy args
+struct copy_args {
+  const char* dst{""};
+  const char* src{""};
+  size_t size{0};
+  const char* copyKindStr{""};
+  hipMemcpyKind copyKind{hipMemcpyDefault};
+  hipStream_t stream{nullptr};
+  rocprofiler_callback_tracing_kind_t kind;
+  rocprofiler_tracing_operation_t operation;
+};
+auto extract_copy_args =
+    []([[maybe_unused]] rocprofiler_callback_tracing_kind_t kind,
+       [[maybe_unused]] rocprofiler_tracing_operation_t operation,
+       [[maybe_unused]] uint32_t arg_num,
+       const void* const arg_value_addr,
+       [[maybe_unused]] int32_t indirection_count,
+       [[maybe_unused]] const char* arg_type,
+       const char* arg_name,
+       const char* arg_value_str,
+       [[maybe_unused]] int32_t dereference_count,
+       void* cb_data) -> int {
+  auto& args = *(static_cast<copy_args*>(cb_data));
+  if (strcmp("dst", arg_name) == 0) {
+    args.dst = arg_value_str;
+  } else if (strcmp("src", arg_name) == 0) {
+    args.src = arg_value_str;
+  } else if (strcmp("sizeBytes", arg_name) == 0) {
+    args.size = *(reinterpret_cast<const size_t*>(arg_value_addr));
+  } else if (strcmp("kind", arg_name) == 0) {
+    args.copyKindStr = arg_value_str;
+    args.copyKind = *(reinterpret_cast<const hipMemcpyKind*>(arg_value_addr));
+  } else if (strcmp("stream", arg_name) == 0) {
+    args.stream = *(reinterpret_cast<const hipStream_t*>(arg_value_addr));
+  }
+  return 0;
+};
+
+// extract kernel args
+struct kernel_args {
+  // const char *stream;
+  hipStream_t stream{nullptr};
+  uint32_t privateSize{0};
+  uint32_t groupSize{0};
+  rocprofiler_dim3_t workgroupSize{0, 0, 0};
+  rocprofiler_dim3_t gridSize{0, 0, 0};
+  rocprofiler_callback_tracing_kind_t kind;
+  rocprofiler_tracing_operation_t operation;
+};
+auto extract_kernel_args =
+    []([[maybe_unused]] rocprofiler_callback_tracing_kind_t kind,
+       [[maybe_unused]] rocprofiler_tracing_operation_t operation,
+       [[maybe_unused]] uint32_t arg_num,
+       const void* const arg_value_addr,
+       [[maybe_unused]] int32_t indirection_count,
+       [[maybe_unused]] const char* arg_type,
+       const char* arg_name,
+       [[maybe_unused]] const char* arg_value_str,
+       [[maybe_unused]] int32_t dereference_count,
+       void* cb_data) -> int {
+  auto& args = *(static_cast<kernel_args*>(cb_data));
+  if (strcmp("stream", arg_name) == 0)
+    args.stream = *(reinterpret_cast<const hipStream_t*>(arg_value_addr));
+  else if (strcmp("numBlocks", arg_name) == 0)
+    args.workgroupSize =
+        *(reinterpret_cast<const rocprofiler_dim3_t*>(arg_value_addr));
+  else if (strcmp("dimBlocks", arg_name) == 0)
+    args.gridSize =
+        *(reinterpret_cast<const rocprofiler_dim3_t*>(arg_value_addr));
+  else if (strcmp("sharedMemBytes", arg_name) == 0)
+    args.groupSize = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("gridDimX", arg_name) == 0)
+    args.workgroupSize.x = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("gridDimY", arg_name) == 0)
+    args.workgroupSize.y = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("gridDimZ", arg_name) == 0)
+    args.workgroupSize.z = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("blockDimX", arg_name) == 0)
+    args.gridSize.x = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("blockDimY", arg_name) == 0)
+    args.gridSize.y = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("blockDimZ", arg_name) == 0)
+    args.gridSize.z = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("globalWorkSizeX", arg_name) == 0)
+    args.workgroupSize.x = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("globalWorkSizeY", arg_name) == 0)
+    args.workgroupSize.y = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("globalWorkSizeZ", arg_name) == 0)
+    args.workgroupSize.z = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("localWorkSizeX", arg_name) == 0)
+    args.gridSize.x = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("localWorkSizeY", arg_name) == 0)
+    args.gridSize.y = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  else if (strcmp("localWorkSizeZ", arg_name) == 0)
+    args.gridSize.z = *(reinterpret_cast<const uint32_t*>(arg_value_addr));
+  return 0;
+};
+
+// extract malloc args
+struct malloc_args {
+  const char* ptr;
+  size_t size;
+};
+auto extract_malloc_args =
+    []([[maybe_unused]] rocprofiler_callback_tracing_kind_t kind,
+       [[maybe_unused]] rocprofiler_tracing_operation_t operation,
+       [[maybe_unused]] uint32_t arg_num,
+       const void* const arg_value_addr,
+       [[maybe_unused]] int32_t indirection_count,
+       [[maybe_unused]] const char* arg_type,
+       const char* arg_name,
+       const char* arg_value_str,
+       [[maybe_unused]] int32_t dereference_count,
+       void* cb_data) -> int {
+  auto& args = *(static_cast<malloc_args*>(cb_data));
+  if (strcmp("ptr", arg_name) == 0) {
+    args.ptr = arg_value_str;
+  }
+  if (strcmp("size", arg_name) == 0) {
+    args.size = *(reinterpret_cast<const size_t*>(arg_value_addr));
+  }
+  return 0;
+};
+
+// copy api calls
+bool isCopyApi(uint32_t id) {
+  switch (id) {
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2D:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2DAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2DFromArray:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2DFromArrayAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2DToArray:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2DToArrayAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy3D:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy3DAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyAtoH:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyDtoD:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyDtoDAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyDtoH:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyDtoHAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyFromArray:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyFromSymbol:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyFromSymbolAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyHtoA:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyHtoD:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyHtoDAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyParam2D:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyParam2DAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyPeer:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyPeerAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyToArray:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyToSymbol:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyToSymbolAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyWithStream:
+      return true;
+      break;
+    default:;
+  }
+  return false;
+}
+
+// kernel api calls
+bool isKernelApi(uint32_t id) {
+  switch (id) {
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipExtLaunchKernel:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipExtLaunchMultiKernelMultiDevice:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipLaunchCooperativeKernel:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipLaunchCooperativeKernelMultiDevice:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipLaunchKernel:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipModuleLaunchCooperativeKernel:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipModuleLaunchCooperativeKernelMultiDevice:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipModuleLaunchKernel:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipExtModuleLaunchKernel:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipHccModuleLaunchKernel:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipLaunchCooperativeKernel_spt:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipLaunchKernel_spt:
+      return true;
+      break;
+    default:;
+  }
+  return false;
+}
+
+// malloc api calls
+bool isMallocApi(uint32_t id) {
+  switch (id) {
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMalloc:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipFree:
+      return true;
+      break;
+    default:;
+  }
+  return false;
+}
+
+class RocprofApiIdList : public ApiIdList {
+ public:
+  RocprofApiIdList(callback_name_info& names);
+  uint32_t mapName(const std::string& apiName) override;
+  std::vector<rocprofiler_tracing_operation_t> allEnabled();
+
+ private:
+  std::unordered_map<std::string, size_t> nameMap_;
+};
+
+struct GlobalContext {
+  rocprofiler_client_id_t* clientId{nullptr};
+  rocprofiler_tool_configure_result_t cfg = rocprofiler_tool_configure_result_t{
+      sizeof(rocprofiler_tool_configure_result_t),
+      &RocprofLogger::toolInit,
+      &RocprofLogger::toolFinalize,
+      nullptr};
+
+  // Contexts
+  rocprofiler_context_id_t utilityContext = {0};
+  rocprofiler_context_id_t context = {0};
+
+  // Buffers
+  rocprofiler_buffer_id_t buffer = {};
+
+  // Manage kernel names - #betterThanRoctracer
+  kernel_symbol_map_t kernel_info = {};
+  kernel_name_map_t kernel_names = {};
+  std::mutex kernel_lock;
+
+  // Manage buffer name - #betterThanRoctracer
+  callback_name_info name_info = {};
+  buffer_name_info buff_name_info = {};
+
+  // Agent info
+  // <rocprofiler_profile_config_id_t.handle, rocprofiler_agent_v0_t>
+  agent_info_map_t agents = {};
+};
+
+GlobalContext& getGlobalContext() {
+  static GlobalContext instance;
+  return instance;
+}
+
+std::vector<rocprofiler_agent_v0_t> get_gpu_device_agents() {
+  std::vector<rocprofiler_agent_v0_t> agents;
+
+  // Callback used by rocprofiler_query_available_agents to return
+  // agents on the device. This can include CPU agents as well. We
+  // select GPU agents only (i.e. type == ROCPROFILER_AGENT_TYPE_GPU)
+  rocprofiler_query_available_agents_cb_t iterate_cb =
+      [](rocprofiler_agent_version_t agents_ver,
+         const void** agents_arr,
+         size_t num_agents,
+         void* udata) {
+        if (agents_ver != ROCPROFILER_AGENT_INFO_VERSION_0)
+          throw std::runtime_error{"unexpected rocprofiler agent version"};
+        auto* agents_v =
+            static_cast<std::vector<rocprofiler_agent_v0_t>*>(udata);
+        for (size_t i = 0; i < num_agents; ++i) {
+          const auto* agent =
+              static_cast<const rocprofiler_agent_v0_t*>(agents_arr[i]);
+          // if(agent->type == ROCPROFILER_AGENT_TYPE_GPU)
+          // agents_v->emplace_back(*agent);
+          agents_v->emplace_back(*agent);
+        }
+        return ROCPROFILER_STATUS_SUCCESS;
+      };
+
+  // Query the agents, only a single callback is made that contains a vector
+  // of all agents.
+  rocprofiler_query_available_agents(
+      ROCPROFILER_AGENT_INFO_VERSION_0,
+      iterate_cb,
+      sizeof(rocprofiler_agent_t),
+      const_cast<void*>(static_cast<const void*>(&agents)));
+  return agents;
+}
+} // namespace
+
+//
+// Static setup
+//
+extern "C" rocprofiler_tool_configure_result_t* rocprofiler_configure(
+    [[maybe_unused]] uint32_t version,
+    [[maybe_unused]] const char* runtime_version,
+    [[maybe_unused]] uint32_t priority,
+    rocprofiler_client_id_t* id) {
+  auto& globalContext = getGlobalContext();
+
+  id->name = "kineto";
+  globalContext.clientId = id;
+
+  // return pointer to configure data
+  return &globalContext.cfg;
+}
+
+int RocprofLogger::toolInit(
+    [[maybe_unused]] rocprofiler_client_finalize_t finialize_func,
+    [[maybe_unused]] void* tool_data) {
+  // Gather api names
+  auto& globalContext = getGlobalContext();
+  globalContext.name_info = rocprofiler::sdk::get_callback_tracing_names();
+  globalContext.buff_name_info = rocprofiler::sdk::get_buffer_tracing_names();
+
+  // Gather agent info
+  auto agent_info = get_gpu_device_agents();
+  for (auto agent : agent_info) {
+    globalContext.agents[agent.id.handle] = agent;
+  }
+
+  //
+  // Setup utility context to gather code object info
+  //
+  rocprofiler_create_context(&globalContext.utilityContext);
+  auto code_object_ops = std::vector<rocprofiler_tracing_operation_t>{
+      ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER};
+
+  rocprofiler_configure_callback_tracing_service(
+      globalContext.utilityContext,
+      ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT,
+      code_object_ops.data(),
+      code_object_ops.size(),
+      RocprofLogger::code_object_callback,
+      nullptr);
+  {
+    int isValid = 0;
+    rocprofiler_context_is_valid(globalContext.utilityContext, &isValid);
+    if (isValid == 0) {
+      globalContext.utilityContext.handle = 0; // Can't destroy it, so leak it
+      return -1;
+    }
+  }
+  rocprofiler_start_context(globalContext.utilityContext);
+
+  //
+  // select some api calls to omit, in the most inconvenient way possible
+  // #betterThanRoctracer
+  RocprofApiIdList apiList(globalContext.name_info);
+  apiList.setInvertMode(true); // Omit the specified api
+  apiList.add("hipGetDevice");
+  apiList.add("hipSetDevice");
+  apiList.add("hipGetLastError");
+  apiList.add("__hipPushCallConfiguration");
+  apiList.add("__hipPopCallConfiguration");
+  apiList.add("hipCtxSetCurrent");
+  apiList.add("hipGetDevicePropertiesR0600");
+  apiList.add("hipGetDeviceCount");
+  apiList.add("hipDeviceGetAttribute");
+  apiList.add("hipRuntimeGetVersion");
+  apiList.add("hipPeekAtLastError");
+  apiList.add("hipModuleGetFunction");
+
+  // Get a vector of the enabled api calls
+  auto apis = apiList.allEnabled();
+
+  //
+  // Setup main context to collect runtime and kernel info
+  //
+  rocprofiler_create_context(&globalContext.context);
+
+  // Collect api info via callback
+  rocprofiler_configure_callback_tracing_service(
+      globalContext.context,
+      ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API,
+      apis.data(),
+      apis.size(),
+      api_callback,
+      nullptr);
+
+  // Collect async ops via buffers
+  constexpr auto buffer_size_bytes = 0x40000;
+  constexpr auto buffer_watermark_bytes = buffer_size_bytes / 2;
+
+  rocprofiler_create_buffer(
+      globalContext.context,
+      buffer_size_bytes,
+      buffer_watermark_bytes,
+      ROCPROFILER_BUFFER_POLICY_LOSSLESS,
+      RocprofLogger::buffer_callback,
+      nullptr,
+      &globalContext.buffer);
+
+  rocprofiler_configure_buffer_tracing_service(
+      globalContext.context,
+      ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+      nullptr,
+      0,
+      globalContext.buffer);
+
+  rocprofiler_configure_buffer_tracing_service(
+      globalContext.context,
+      ROCPROFILER_BUFFER_TRACING_MEMORY_COPY,
+      nullptr,
+      0,
+      globalContext.buffer);
+  {
+    int isValid = 0;
+    rocprofiler_context_is_valid(globalContext.context, &isValid);
+    if (isValid == 0) {
+      globalContext.context.handle = 0; // Can't destroy it, so leak it
+      return -1;
+    }
+  }
+  rocprofiler_stop_context(globalContext.context);
+
+  return 0;
+}
+
+void RocprofLogger::toolFinalize([[maybe_unused]] void* tool_data) {
+  auto& globalContext = getGlobalContext();
+  rocprofiler_stop_context(globalContext.utilityContext);
+  globalContext.utilityContext.handle = 0;
+  rocprofiler_stop_context(globalContext.context);
+  globalContext.context.handle = 0;
+}
+
+class Flush {
+ public:
+  std::mutex mutex_;
+  std::atomic<uint64_t> maxCorrelationId_;
+  uint64_t maxCompletedCorrelationId_{0};
+  void reportCorrelation(const uint64_t& cid) {
+    uint64_t prev = maxCorrelationId_;
+    while (prev < cid && !maxCorrelationId_.compare_exchange_weak(prev, cid)) {
+    }
+  }
+};
+
+RocprofLogger& RocprofLogger::singleton() {
+  static RocprofLogger instance;
+  return instance;
+}
+
+RocprofLogger::RocprofLogger() {}
+
+RocprofLogger::~RocprofLogger() {
+  stopLogging();
+  endTracing();
+}
+
+namespace {
+thread_local std::deque<uint64_t>
+    t_externalIds[RocLogger::CorrelationDomain::size];
+}
+
+void RocprofLogger::pushCorrelationID(uint64_t id, CorrelationDomain type) {
+  if (!singleton().externalCorrelationEnabled_) {
+    return;
+  }
+  t_externalIds[type].push_back(id);
+}
+
+void RocprofLogger::popCorrelationID(CorrelationDomain type) {
+  if (!singleton().externalCorrelationEnabled_) {
+    return;
+  }
+  if (!t_externalIds[type].empty()) {
+    t_externalIds[type].pop_back();
+  } else {
+    LOG(ERROR)
+        << "Attempt to popCorrelationID from an empty external Ids stack";
+  }
+}
+
+void RocprofLogger::clearLogs() {
+  // CuptiActivityProfiler clears this before the output Loggers use the data
+  // for (auto &row : rows_)
+  //  delete row;
+  rows_.clear();
+  for (int i = 0; i < CorrelationDomain::size; ++i) {
+    externalCorrelations_[i].clear();
+  }
+}
+
+void RocprofLogger::insert_row_to_buffer(rocprofBase* row) {
+  RocprofLogger* dis = &singleton();
+  std::lock_guard<std::mutex> lock(dis->rowsMutex_);
+  if (dis->rows_.size() >= dis->maxBufferSize_) {
+    LOG_FIRST_N(WARNING, 10)
+        << "Exceeded max GPU buffer count (" << dis->rows_.size() << " > "
+        << dis->maxBufferSize_ << ") - terminating tracing";
+    return;
+  }
+  dis->rows_.push_back(row);
+}
+
+void RocprofLogger::code_object_callback(
+    rocprofiler_callback_tracing_record_t record,
+    [[maybe_unused]] rocprofiler_user_data_t* user_data,
+    [[maybe_unused]] void* callback_data) {
+  if (record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
+      record.operation == ROCPROFILER_CODE_OBJECT_LOAD) {
+    if (record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD) {
+      // flush the buffer to ensure that any lookups for the client kernel names
+      // for the code object are completed NOTE: not using buffer ATM
+    }
+  } else if (
+      record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
+      record.operation ==
+          ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER) {
+    auto* data = static_cast<kernel_symbol_data_t*>(record.payload);
+    if (record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD) {
+      auto& globalContext = getGlobalContext();
+      std::lock_guard<std::mutex> lock(globalContext.kernel_lock);
+      globalContext.kernel_info.emplace(data->kernel_id, *data);
+      globalContext.kernel_names.emplace(
+          data->kernel_id, demangle(data->kernel_name));
+    } else if (record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD) {
+      // FIXME: clear these?  At minimum need kernel names at shutdown, async
+      // completion
+      // globalContext.kernel_info.erase(data->kernel_id);
+      // globalContext.kernel_names.erase(data->kernel_id);
+    }
+  }
+}
+
+void RocprofLogger::api_callback(
+    rocprofiler_callback_tracing_record_t record,
+    [[maybe_unused]] rocprofiler_user_data_t* user_data,
+    [[maybe_unused]] void* callback_data) {
+  thread_local std::unordered_map<uint64_t, uint64_t> timestamps;
+
+  if (record.kind == ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API) {
+    if (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+      timestamps[record.correlation_id.internal] = getApproximateTime();
+    } // ROCPROFILER_CALLBACK_PHASE_ENTER
+    else { // ROCPROFILER_CALLBACK_PHASE_EXIT
+      uint64_t startTime = timestamps[record.correlation_id.internal];
+      timestamps.erase(record.correlation_id.internal);
+      uint64_t endTime = getApproximateTime();
+
+      // Kernel Launch Records
+      if (isKernelApi(record.operation)) {
+        kernel_args args;
+        rocprofiler_iterate_callback_tracing_kind_operation_args(
+            record,
+            extract_kernel_args,
+            1 /*max_deref*/
+            ,
+            &args);
+
+        rocprofKernelRow* row = new rocprofKernelRow(
+            record.correlation_id.internal,
+            record.kind,
+            record.operation,
+            processId(),
+            systemThreadId(),
+            startTime,
+            endTime,
+            nullptr,
+            nullptr,
+            args.workgroupSize.x,
+            args.workgroupSize.y,
+            args.workgroupSize.z,
+            args.gridSize.x,
+            args.gridSize.y,
+            args.gridSize.z,
+            args.groupSize,
+            args.stream);
+        insert_row_to_buffer(row);
+
+      }
+      // Copy Records
+      else if (isCopyApi(record.operation)) {
+        copy_args args;
+        rocprofiler_iterate_callback_tracing_kind_operation_args(
+            record,
+            extract_copy_args,
+            1 /*max_deref*/
+            ,
+            &args);
+
+        rocprofCopyRow* row = new rocprofCopyRow(
+            record.correlation_id.internal,
+            record.kind,
+            record.operation,
+            processId(),
+            systemThreadId(),
+            startTime,
+            endTime,
+            args.src,
+            args.dst,
+            args.size,
+            args.copyKind,
+            args.stream);
+        insert_row_to_buffer(row);
+      }
+      // Malloc Records
+      else if (isMallocApi(record.operation)) {
+        malloc_args args;
+        args.size = 0;
+        rocprofiler_iterate_callback_tracing_kind_operation_args(
+            record,
+            extract_malloc_args,
+            1 /*max_deref*/
+            ,
+            &args);
+        rocprofMallocRow* row = new rocprofMallocRow(
+            record.correlation_id.internal,
+            record.kind,
+            record.operation,
+            processId(),
+            systemThreadId(),
+            startTime,
+            endTime,
+            args.ptr,
+            args.size);
+        insert_row_to_buffer(row);
+      }
+      // Default Records
+      else {
+        rocprofRow* row = new rocprofRow(
+            record.correlation_id.internal,
+            record.kind,
+            record.operation,
+            processId(),
+            systemThreadId(),
+            startTime,
+            endTime);
+        insert_row_to_buffer(row);
+      }
+      // External correlation
+      static RocprofLogger* dis = &singleton();
+      for (int it = RocLogger::CorrelationDomain::begin;
+           it < RocLogger::CorrelationDomain::end;
+           ++it) {
+        if (t_externalIds[it].size() > 0) {
+          std::lock_guard<std::mutex> lock(dis->externalCorrelationsMutex_);
+          dis->externalCorrelations_[it].emplace_back(
+              record.correlation_id.internal, t_externalIds[it].back());
+        }
+      }
+    } // ROCPROFILER_CALLBACK_PHASE_EXIT
+  } // ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API
+}
+
+void RocprofLogger::buffer_callback(
+    [[maybe_unused]] rocprofiler_context_id_t context,
+    [[maybe_unused]] rocprofiler_buffer_id_t buffer_id,
+    rocprofiler_record_header_t** headers,
+    size_t num_headers,
+    [[maybe_unused]] void* user_data,
+    [[maybe_unused]] uint64_t drop_count) {
+  for (size_t i = 0; i < num_headers; ++i) {
+    auto* header = headers[i];
+
+    if (header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING) {
+      if (header->kind == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH) {
+        auto& record =
+            *(static_cast<rocprofiler_buffer_tracing_kernel_dispatch_record_t*>(
+                header->payload));
+        auto& dispatch = record.dispatch_info;
+
+        // Safe access to agents map with default value
+        auto& globalContext = getGlobalContext();
+        auto agent_it = globalContext.agents.find(dispatch.agent_id.handle);
+        int device_id = (agent_it != globalContext.agents.end())
+            ? agent_it->second.logical_node_type_id
+            : -1;
+
+        // Safe access to kernel_names map with default value
+        auto kernel_it = globalContext.kernel_names.find(dispatch.kernel_id);
+        std::string kernel_name =
+            (kernel_it != globalContext.kernel_names.end())
+            ? kernel_it->second
+            : "<unknown kernel>";
+
+        rocprofAsyncRow* row = new rocprofAsyncRow(
+            record.correlation_id.internal,
+            record.kind,
+            record.operation,
+            record.operation, // shared op - No longer a thing.  Placeholder
+            device_id,
+            dispatch.queue_id.handle,
+            record.start_timestamp,
+            record.end_timestamp,
+            kernel_name);
+        insert_row_to_buffer(row);
+      } else if (header->kind == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY) {
+        auto& record =
+            *(static_cast<rocprofiler_buffer_tracing_memory_copy_record_t*>(
+                header->payload));
+
+        // Safe access to agents map with default value
+        auto& globalContext = getGlobalContext();
+        auto agent_it = globalContext.agents.find(record.dst_agent_id.handle);
+        int device_id = (agent_it != globalContext.agents.end())
+            ? agent_it->second.logical_node_type_id
+            : -1;
+
+        rocprofAsyncRow* row = new rocprofAsyncRow(
+            record.correlation_id.internal,
+            record.kind,
+            record.operation,
+            record.operation, // shared op - No longer a thing.  Placeholder
+            device_id,
+            0,
+            record.start_timestamp,
+            record.end_timestamp,
+            "");
+        insert_row_to_buffer(row);
+      }
+    }
+  }
+}
+
+std::string RocprofLogger::opString(
+    rocprofiler_callback_tracing_kind_t kind,
+    rocprofiler_tracing_operation_t op) {
+  auto& globalContext = getGlobalContext();
+  auto& ops = globalContext.name_info[kind].operations;
+  if (op >= 0 && static_cast<size_t>(op) < ops.size()) {
+    return std::string(ops[op]);
+  }
+  return "<unknown operation:" + std::to_string(op) + ">";
+}
+
+std::string RocprofLogger::opString(
+    rocprofiler_buffer_tracing_kind_t kind,
+    rocprofiler_tracing_operation_t op) {
+  auto& globalContext = getGlobalContext();
+  auto& ops = globalContext.buff_name_info[kind].operations;
+  if (op >= 0 && static_cast<size_t>(op) < ops.size()) {
+    return std::string(ops[op]);
+  }
+  return "<unknown operation:" + std::to_string(op) + ">";
+}
+
+void RocprofLogger::setMaxEvents(uint32_t maxBufferSize) {
+  RocprofLogger* dis = &singleton();
+  std::lock_guard<std::mutex> lock(dis->rowsMutex_);
+  maxBufferSize_ = maxBufferSize;
+}
+
+void RocprofLogger::ensureRegistered() {
+  int status = 0;
+  rocprofiler_is_initialized(&status);
+  VLOG(0) << "rocprofiler_is_initialized returned " << status;
+  if (status == 0) {
+    VLOG(0) << "Forcing rocprofiler-sdk tool registration";
+    auto result = rocprofiler_force_configure(&rocprofiler_configure);
+    if (result == ROCPROFILER_STATUS_SUCCESS) {
+      VLOG(0) << "rocprofiler-sdk tool registration completed successfully";
+      singleton().registered_ = true;
+    } else {
+      LOG(WARNING) << "rocprofiler_force_configure failed with status "
+                   << result;
+    }
+  } else if (status == 1) {
+    singleton().registered_ = true;
+  }
+}
+
+void RocprofLogger::startLogging() {
+  if (!registered_) {
+    ensureRegistered();
+  }
+
+  externalCorrelationEnabled_ = true;
+  logging_ = true;
+  auto& globalContext = getGlobalContext();
+  rocprofiler_start_context(globalContext.context);
+}
+
+void RocprofLogger::stopLogging() {
+  if (logging_ == false)
+    return;
+  logging_ = false;
+
+  // Flush buffers
+  auto& globalContext = getGlobalContext();
+  rocprofiler_flush_buffer(globalContext.buffer);
+  rocprofiler_stop_context(globalContext.context);
+}
+
+void RocprofLogger::endTracing() {
+  // This should be handled in RocprofLogger::toolFinalize
+}
+
+//
+// ApiIdList
+//   Jump through some extra hoops
+//
+//
+RocprofApiIdList::RocprofApiIdList(callback_name_info& names) : nameMap_() {
+  auto& hipapis =
+      names[ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API].operations;
+
+  for (size_t i = 0; i < hipapis.size(); ++i) {
+    nameMap_.emplace(hipapis[i], i);
+  }
+}
+
+uint32_t RocprofApiIdList::mapName(const std::string& apiName) {
+  auto it = nameMap_.find(apiName);
+  if (it != nameMap_.end()) {
+    return it->second;
+  }
+  return 0;
+}
+
+std::vector<rocprofiler_tracing_operation_t> RocprofApiIdList::allEnabled() {
+  std::vector<rocprofiler_tracing_operation_t> oplist;
+  for (auto& it : nameMap_) {
+    if (contains(it.second))
+      oplist.push_back(it.second);
+  }
+  return oplist;
+}

--- a/third_party/kineto/libkineto/src/RocprofLogger.h
+++ b/third_party/kineto/libkineto/src/RocprofLogger.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <deque>
+#include <functional>
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <rocprofiler-sdk/registration.h>
+
+#include "RocLogger.h"
+
+class RocprofLogger {
+ public:
+  RocprofLogger();
+  RocprofLogger(const RocprofLogger&) = delete;
+  RocprofLogger& operator=(const RocprofLogger&) = delete;
+
+  virtual ~RocprofLogger();
+
+  static RocprofLogger& singleton();
+
+  static void pushCorrelationID(uint64_t id, RocLogger::CorrelationDomain type);
+  static void popCorrelationID(RocLogger::CorrelationDomain type);
+
+  static void ensureRegistered();
+  void startLogging();
+  void stopLogging();
+  void clearLogs();
+  void setMaxEvents(uint32_t maxBufferSize);
+
+  static int toolInit(
+      rocprofiler_client_finalize_t finalize_func,
+      void* tool_data);
+  static void toolFinalize(void* tool_data);
+
+  static std::string opString(
+      rocprofiler_callback_tracing_kind_t kind,
+      rocprofiler_tracing_operation_t op);
+
+  static std::string opString(
+      rocprofiler_buffer_tracing_kind_t kind,
+      rocprofiler_tracing_operation_t op);
+
+ private:
+  bool registered_{false};
+  void endTracing();
+
+  static void insert_row_to_buffer(rocprofBase* row);
+
+  //
+  static void api_callback(
+      rocprofiler_callback_tracing_record_t record,
+      rocprofiler_user_data_t* user_data,
+      void* callback_data);
+  static void buffer_callback(
+      rocprofiler_context_id_t context,
+      rocprofiler_buffer_id_t buffer_id,
+      rocprofiler_record_header_t** headers,
+      size_t num_headers,
+      void* user_data,
+      uint64_t drop_count);
+  static void code_object_callback(
+      rocprofiler_callback_tracing_record_t record,
+      rocprofiler_user_data_t* user_data,
+      void* callback_data);
+
+  // Api callback data
+  uint32_t maxBufferSize_{5000000}; // 5M GPU runtime/kernel events.
+  std::vector<rocprofBase*> rows_;
+  std::mutex rowsMutex_;
+
+  // This vector collects pairs of correlationId and their respective
+  // externalCorrelationId for each CorrelationDomain. This will be used
+  // to populate the Correlation maps during post processing.
+  std::vector<std::pair<uint64_t, uint64_t>>
+      externalCorrelations_[RocLogger::CorrelationDomain::size];
+  std::mutex externalCorrelationsMutex_;
+
+  bool externalCorrelationEnabled_{true};
+  bool logging_{false};
+
+  friend class libkineto::RocprofActivityApi;
+};

--- a/third_party/kineto/libkineto/src/ScopeExit.h
+++ b/third_party/kineto/libkineto/src/ScopeExit.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Implement a simple scope handler allowing a function to release
+// resources when an error or exception occurs
+
+template <typename T>
+class ScopeExit {
+ public:
+  explicit ScopeExit(T t) : t(t) {}
+  ~ScopeExit() {
+    t();
+  }
+  T t;
+};
+
+template <typename T>
+ScopeExit<T> makeScopeExit(T t) {
+  return ScopeExit<T>(t);
+}
+
+// Add a level of indirection so __LINE__ is expanded
+#define __kINETO_CONCAT(name, line) name##line
+#define ANON_VAR(name, line) __kINETO_CONCAT(name, line)
+
+#define SCOPE_EXIT(func) \
+  const auto ANON_VAR(SCOPE_BLOCK, __LINE__) = makeScopeExit([=]() { func(); })

--- a/third_party/kineto/libkineto/src/SyncActivityProfilerHandler.cpp
+++ b/third_party/kineto/libkineto/src/SyncActivityProfilerHandler.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "SyncActivityProfilerHandler.h"
+
+#include <chrono>
+
+#include "ActivityProfilerController.h"
+#include "ActivityTrace.h"
+#include "Config.h"
+#include "GenericActivityProfiler.h"
+#include "Logger.h"
+#include "libkineto.h"
+#include "output_membuf.h"
+
+using namespace std::chrono;
+
+namespace KINETO_NAMESPACE {
+
+SyncActivityProfilerHandler::SyncActivityProfilerHandler(
+    GenericActivityProfiler& profiler)
+    : profiler_(profiler) {}
+
+void SyncActivityProfilerHandler::prepareTrace(const Config& config) {
+  auto now = std::chrono::system_clock::now();
+  active_ = true;
+
+  LOGGER_OBSERVER_RESET();
+  profiler_.configure(config, now);
+}
+
+void SyncActivityProfilerHandler::startTrace() {
+  UST_LOGGER_MARK_COMPLETED(kWarmUpStage);
+  USDT_EMIT_START_TRACE();
+  profiler_.startTrace(std::chrono::system_clock::now());
+}
+
+std::unique_ptr<ActivityTraceInterface> SyncActivityProfilerHandler::
+    stopTrace() {
+  profiler_.stopTrace(std::chrono::system_clock::now());
+  USDT_EMIT_STOP_TRACE();
+  UST_LOGGER_MARK_COMPLETED(kCollectionStage);
+  auto logger = std::make_unique<MemoryTraceLogger>(profiler_.config());
+  profiler_.processTrace(*logger);
+  // Will follow up with another patch for logging URLs when ActivityTrace
+  // is moved.
+
+  profiler_.reset();
+  active_ = false;
+  return std::make_unique<ActivityTrace>(
+      std::move(logger), ActivityProfilerController::loggerFactory());
+}
+
+void SyncActivityProfilerHandler::cancel() {
+  if (!active_) {
+    return;
+  }
+
+  LOG(ERROR) << "Cancelling current trace request in order to start "
+             << "higher priority synchronous request";
+  UST_LOGGER_MARK_COMPLETED(kCancellationStage);
+
+  if (libkineto::api().client() != nullptr) {
+    libkineto::api().client()->stop();
+  }
+  profiler_.cancelTrace(std::chrono::system_clock::now());
+  active_ = false;
+}
+
+void SyncActivityProfilerHandler::toggleCollectionDynamic(const bool enable) {
+  profiler_.toggleCollectionDynamic(enable);
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/SyncActivityProfilerHandler.h
+++ b/third_party/kineto/libkineto/src/SyncActivityProfilerHandler.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+
+#include "ActivityTraceInterface.h"
+#include "GenericActivityProfiler.h"
+
+namespace KINETO_NAMESPACE {
+
+class Config;
+
+class SyncActivityProfilerHandler {
+ public:
+  explicit SyncActivityProfilerHandler(GenericActivityProfiler& profiler);
+  SyncActivityProfilerHandler(const SyncActivityProfilerHandler&) = delete;
+  SyncActivityProfilerHandler& operator=(const SyncActivityProfilerHandler&) =
+      delete;
+  SyncActivityProfilerHandler(SyncActivityProfilerHandler&&) = delete;
+  SyncActivityProfilerHandler& operator=(SyncActivityProfilerHandler&&) =
+      delete;
+  ~SyncActivityProfilerHandler() = default;
+
+  void prepareTrace(const Config& config);
+  void toggleCollectionDynamic(const bool enable);
+  void startTrace();
+  std::unique_ptr<ActivityTraceInterface> stopTrace();
+  void cancel();
+
+  [[nodiscard]] bool isSyncActive() const {
+    return active_;
+  }
+
+ private:
+  GenericActivityProfiler& profiler_;
+  std::atomic<bool> active_{false};
+};
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/ThreadUtil.cpp
+++ b/third_party/kineto/libkineto/src/ThreadUtil.cpp
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ThreadUtil.h"
+
+#ifndef _WIN32
+#include <pthread.h>
+#ifndef _AIX
+#include <sys/syscall.h>
+#endif // _AIX
+#include <unistd.h>
+#else // _WIN32
+#include <codecvt>
+#include <locale>
+#define WIN32_LEAN_AND_MEAN
+#define NOGDI
+#include <windows.h> // @manual
+// windows.h has to come first. Don't alphabetize, clang-format.
+
+#include <processthreadsapi.h> // @manual
+#undef ERROR
+#endif // _WIN32
+
+#ifdef __ANDROID__
+#include <sys/prctl.h>
+#endif
+
+#ifdef _AIX
+#include <pthread.h>
+#endif // _AIX
+
+#include <fcntl.h>
+#include <fmt/format.h>
+#include <iostream>
+#include <string>
+
+namespace libkineto {
+
+namespace {
+thread_local int32_t _pid = 0;
+thread_local int32_t _tid = 0;
+thread_local int32_t _sysTid = 0;
+} // namespace
+
+#ifdef __linux__
+int32_t pidNamespace(ino_t& ns) {
+  int fd = open("/proc/self/ns/pid", O_RDONLY);
+
+  if (fd == -1) {
+    return -1;
+  }
+
+  struct stat self_stat;
+  int rc = fstat(fd, &self_stat);
+  close(fd);
+  if (rc == -1) {
+    return -1;
+  }
+  ns = self_stat.st_ino;
+  return 0;
+}
+#endif
+
+int32_t processId(bool cache) {
+  int32_t pid = 0;
+  if (!_pid) {
+#ifndef _WIN32
+    pid = static_cast<int32_t>(getpid());
+#else
+    pid = static_cast<int32_t>(GetCurrentProcessId());
+#endif
+    if (cache) {
+      _pid = pid;
+    }
+    return pid;
+  }
+  return _pid;
+}
+
+int32_t systemThreadId(bool cache) {
+  int32_t sysTid = 0;
+  if (!_sysTid) {
+#ifdef __APPLE__
+    sysTid = static_cast<int32_t>(syscall(SYS_thread_selfid));
+#elif defined _WIN32
+    sysTid = static_cast<int32_t>(GetCurrentThreadId());
+#elif defined __FreeBSD__
+    syscall(SYS_thr_self, &sysTid);
+#elif defined _AIX
+    sysTid = pthread_self();
+#else
+    sysTid = static_cast<int32_t>(syscall(SYS_gettid));
+#endif
+    if (cache) {
+      _sysTid = sysTid;
+    }
+    return sysTid;
+  }
+  return _sysTid;
+}
+
+int32_t threadId() {
+  if (!_tid) {
+#ifdef __APPLE__
+    uint64_t tid;
+    pthread_threadid_np(nullptr, &tid);
+    _tid = tid;
+#elif defined _WIN32
+    _tid = static_cast<int32_t>(GetCurrentThreadId());
+#else
+    pthread_t pth = pthread_self();
+    auto* ptr = reinterpret_cast<int32_t*>(&pth);
+    _tid = *ptr;
+#endif
+  }
+  return _tid;
+}
+
+// Resets all cached Thread local state, this must be done on
+// forks to prevent stale values from being retained.
+void resetTLS() {
+  _pid = 0;
+  _tid = 0;
+  _sysTid = 0;
+}
+
+namespace {
+constexpr size_t kMaxThreadNameLength = 16;
+
+constexpr const char* basename(const char* s, int off = 0) {
+  return !s[off]      ? s
+      : s[off] == '/' ? basename(&s[off + 1])
+                      : basename(s, off + 1);
+}
+#if defined(_WIN32)
+void* getKernel32Func(const char* procName) {
+  return reinterpret_cast<void*>(
+      GetProcAddress(GetModuleHandleA("KERNEL32.DLL"), procName));
+}
+#endif
+} // namespace
+
+bool setThreadName(const std::string& name) {
+#ifdef __APPLE__
+  return 0 == pthread_setname_np(name.c_str());
+#elif defined _WIN32
+  // Per
+  // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription
+  // Use runtime linking to set thread description
+  static auto _SetThreadDescription =
+      reinterpret_cast<decltype(&SetThreadDescription)>(
+          getKernel32Func("SetThreadDescription"));
+  if (!_SetThreadDescription) {
+    return false;
+  }
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> conv;
+  std::wstring wname = conv.from_bytes(name);
+  HRESULT hr = _SetThreadDescription(GetCurrentThread(), wname.c_str());
+  return SUCCEEDED(hr);
+#elif defined _AIX
+  return 0;
+#else
+  return 0 == pthread_setname_np(pthread_self(), name.c_str());
+#endif
+}
+
+std::string getThreadName() {
+#ifdef _AIX
+  return "Unknown";
+#else
+#ifndef _WIN32
+  char buf[kMaxThreadNameLength];
+  if (
+#ifndef __ANDROID__
+      pthread_getname_np(pthread_self(), buf, kMaxThreadNameLength) != 0
+#else
+      prctl(PR_GET_NAME, buf, kMaxThreadNameLength) != 0
+#endif
+  ) {
+    return "Unknown";
+  }
+  return buf;
+#else // _WIN32
+  static auto _GetThreadDescription =
+      reinterpret_cast<decltype(&GetThreadDescription)>(
+          getKernel32Func("GetThreadDescription"));
+  if (!_GetThreadDescription) {
+    return "Unknown";
+  }
+  PWSTR data;
+  HRESULT hr = _GetThreadDescription(GetCurrentThread(), &data);
+  if (!SUCCEEDED(hr)) {
+    return "";
+  }
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> conv;
+  std::string name = conv.to_bytes(data);
+  LocalFree(data);
+  return name;
+#endif
+#endif
+}
+
+// Linux:
+// Extract process name from /proc/pid/cmdline. This does not have
+// the 16 character limit that /proc/pid/status and /prod/pid/comm has.
+std::string processName([[maybe_unused]] int32_t pid) {
+#ifdef __linux__
+  FILE* cmdfile = fopen(fmt::format("/proc/{}/cmdline", pid).c_str(), "r");
+  if (cmdfile != nullptr) {
+    char* command = nullptr;
+    // %m is a POSIX extension that makes fscanf allocate the buffer, avoiding
+    // fixed-size buffer risks. Suppress -Wformat since it's not ISO C++.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat"
+    int scanned = fscanf(cmdfile, "%ms", &command);
+#pragma GCC diagnostic pop
+    fclose(cmdfile);
+    if (scanned > 0 && command) {
+      std::string ret(basename(command));
+      free(command);
+      return ret;
+    }
+  }
+  std::cerr << "Failed to read process name for pid " << pid << std::endl;
+#endif
+  return "";
+}
+
+// Max number of parent pids to collect, just for extra safeguarding.
+constexpr int kMaxParentPids = 10;
+
+// Return a pair of <parent_pid, command_of_current_pid>
+static std::pair<int32_t, std::string> parentPidAndCommand(
+    [[maybe_unused]] int32_t pid) {
+#ifdef __linux__
+  FILE* statfile = fopen(fmt::format("/proc/{}/stat", pid).c_str(), "r");
+  if (statfile == nullptr) {
+    return std::make_pair(0, "");
+  }
+  int32_t parent_pid = 0;
+  char* command = nullptr;
+  // %m is a POSIX extension that makes fscanf allocate the buffer, avoiding
+  // fixed-size buffer risks. Suppress -Wformat since it's not ISO C++.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat"
+  int scanned = fscanf(statfile, "%*d (%m[^)]) %*c %d", &command, &parent_pid);
+#pragma GCC diagnostic pop
+  fclose(statfile);
+  std::pair<int32_t, std::string> ret;
+  if (scanned == 2) {
+    ret = std::make_pair(parent_pid, std::string(command));
+  } else {
+    std::cerr << "Failed to parse /proc/" << pid << "/stat" << std::endl;
+    ret = std::make_pair(0, "");
+  }
+
+  free(command);
+  return ret;
+#else
+  return std::make_pair(0, "");
+#endif
+}
+
+std::vector<std::pair<int32_t, std::string>> pidCommandPairsOfAncestors() {
+  std::vector<std::pair<int32_t, std::string>> pairs;
+  pairs.reserve(kMaxParentPids + 1);
+  int32_t curr_pid = processId();
+  // Usually we want to skip the root process (PID 1), but when running
+  // inside a container the process itself has PID 1, so we need to include it
+  for (int i = 0; i <= kMaxParentPids && (i == 0 || curr_pid > 1); i++) {
+    std::pair<int32_t, std::string> ppid_and_comm =
+        parentPidAndCommand(curr_pid);
+    pairs.emplace_back(curr_pid, ppid_and_comm.second);
+    curr_pid = ppid_and_comm.first;
+  }
+  return pairs;
+}
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/src/WeakSymbols.cpp
+++ b/third_party/kineto/libkineto/src/WeakSymbols.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdexcept>
+
+#ifndef _MSC_VER
+extern "C" {
+// This function is needed to avoid superfluous dependency on GNU OpenMP library
+// when cuPTI is linked statically For more details see
+// https://github.com/pytorch/pytorch/issues/51026
+__attribute__((weak)) int acc_get_device_type() {
+  throw std::runtime_error(
+      "Dummy implementation of acc_get_device_type is not supposed to be called!");
+}
+
+} // extern "C"
+#endif

--- a/third_party/kineto/libkineto/src/cupti_strings.cpp
+++ b/third_party/kineto/libkineto/src/cupti_strings.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "cupti_strings.h"
+
+#include <string>
+
+namespace libkineto {
+
+const char* memcpyKindString(CUpti_ActivityMemcpyKind kind) {
+  switch (kind) {
+    case CUPTI_ACTIVITY_MEMCPY_KIND_HTOD:
+      return "HtoD";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_DTOH:
+      return "DtoH";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_HTOA:
+      return "HtoA";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_ATOH:
+      return "AtoH";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_ATOA:
+      return "AtoA";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_ATOD:
+      return "AtoD";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_DTOA:
+      return "DtoA";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_DTOD:
+      return "DtoD";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_HTOH:
+      return "HtoH";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_PTOP:
+      return "PtoP";
+    default:
+      break;
+  }
+  return "<unknown>";
+}
+
+const char* memoryKindString(CUpti_ActivityMemoryKind kind) {
+  switch (kind) {
+    case CUPTI_ACTIVITY_MEMORY_KIND_UNKNOWN:
+      return "Unknown";
+    case CUPTI_ACTIVITY_MEMORY_KIND_PAGEABLE:
+      return "Pageable";
+    case CUPTI_ACTIVITY_MEMORY_KIND_PINNED:
+      return "Pinned";
+    case CUPTI_ACTIVITY_MEMORY_KIND_DEVICE:
+      return "Device";
+    case CUPTI_ACTIVITY_MEMORY_KIND_ARRAY:
+      return "Array";
+    case CUPTI_ACTIVITY_MEMORY_KIND_MANAGED:
+      return "Managed";
+    case CUPTI_ACTIVITY_MEMORY_KIND_DEVICE_STATIC:
+      return "Device Static";
+    case CUPTI_ACTIVITY_MEMORY_KIND_MANAGED_STATIC:
+      return "Managed Static";
+    case CUPTI_ACTIVITY_MEMORY_KIND_FORCE_INT:
+      return "Force Int";
+    default:
+      return "Unrecognized";
+  }
+}
+
+const char* overheadKindString(CUpti_ActivityOverheadKind kind) {
+  switch (kind) {
+    case CUPTI_ACTIVITY_OVERHEAD_UNKNOWN:
+      return "Unknown";
+    case CUPTI_ACTIVITY_OVERHEAD_DRIVER_COMPILER:
+      return "Driver Compiler";
+    case CUPTI_ACTIVITY_OVERHEAD_CUPTI_BUFFER_FLUSH:
+      return "Buffer Flush";
+    case CUPTI_ACTIVITY_OVERHEAD_CUPTI_INSTRUMENTATION:
+      return "Instrumentation";
+    case CUPTI_ACTIVITY_OVERHEAD_CUPTI_RESOURCE:
+      return "Resource";
+#if CUDART_VERSION >= 12040
+    case CUPTI_ACTIVITY_OVERHEAD_RUNTIME_TRIGGERED_MODULE_LOADING:
+      return "Runtime Triggered Module Loading";
+    case CUPTI_ACTIVITY_OVERHEAD_LAZY_FUNCTION_LOADING:
+      return "Lazy Function Loading";
+    case CUPTI_ACTIVITY_OVERHEAD_COMMAND_BUFFER_FULL:
+      return "Command Buffer Full";
+#endif
+#if CUDART_VERSION >= 12070
+    case CUPTI_ACTIVITY_OVERHEAD_ACTIVITY_BUFFER_REQUEST:
+      return "Activity Buffer Request";
+#endif
+    case CUPTI_ACTIVITY_OVERHEAD_FORCE_INT:
+      return "Force Int";
+    default:
+      return "Unrecognized";
+  }
+}
+
+namespace {
+
+// CUPTI returns identifiers like `cudaLaunchKernel_v7000` whose trailing
+// `_vNNNN` is the CUDA-version-introduced suffix. Strip it to match the
+// existing trace-label convention, while preserving single-digit
+// API-generation suffixes like `_v2` / `_v3` (lowest CUDA-version suffix is
+// `_v3020` for CUDA 3.2, so 4+ trailing digits is unambiguous).
+std::string lookupCbidName(CUpti_CallbackDomain domain, CUpti_CallbackId cbid) {
+  const char* raw = nullptr;
+  if (cuptiGetCallbackName(domain, cbid, &raw) != CUPTI_SUCCESS ||
+      raw == nullptr) {
+    return "INVALID";
+  }
+  std::string name = raw;
+  if (name.empty()) {
+    return "INVALID";
+  }
+  const auto vPos = name.find_last_not_of("0123456789");
+  if (vPos != std::string::npos && vPos >= 1 && name[vPos] == 'v' &&
+      name[vPos - 1] == '_' && name.size() - vPos - 1 >= 4) {
+    name.resize(vPos - 1);
+  }
+  return name;
+}
+
+} // namespace
+
+std::string runtimeCbidName(CUpti_CallbackId cbid) {
+  return lookupCbidName(CUPTI_CB_DOMAIN_RUNTIME_API, cbid);
+}
+
+std::string driverCbidName(CUpti_CallbackId cbid) {
+  return lookupCbidName(CUPTI_CB_DOMAIN_DRIVER_API, cbid);
+}
+
+// From
+// https://docs.nvidia.com/cupti/modules.html#group__CUPTI__ACTIVITY__API_1g80e1eb47615e31021f574df8ebbe5d9a
+//   enum CUpti_ActivitySynchronizationType
+const char* syncTypeString(CUpti_ActivitySynchronizationType kind) {
+  switch (kind) {
+    case CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_EVENT_SYNCHRONIZE:
+      return "Event Sync";
+    case CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT:
+      return "Stream Wait Event";
+    case CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_SYNCHRONIZE:
+      return "Stream Sync";
+    case CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_CONTEXT_SYNCHRONIZE:
+      return "Context Sync";
+    case CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_UNKNOWN:
+    default:
+      return "Unknown Sync";
+  }
+}
+} // namespace libkineto

--- a/third_party/kineto/libkineto/src/cupti_strings.h
+++ b/third_party/kineto/libkineto/src/cupti_strings.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <cupti.h>
+
+namespace libkineto {
+
+const char* memoryKindString(CUpti_ActivityMemoryKind kind);
+const char* memcpyKindString(CUpti_ActivityMemcpyKind kind);
+std::string runtimeCbidName(CUpti_CallbackId cbid);
+std::string driverCbidName(CUpti_CallbackId cbid);
+const char* overheadKindString(CUpti_ActivityOverheadKind kind);
+const char* syncTypeString(CUpti_ActivitySynchronizationType kind);
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/src/init.cpp
+++ b/third_party/kineto/libkineto/src/init.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <memory>
+#include <mutex>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ActivityProfilerProxy.h"
+#include "Config.h"
+#include "ConfigLoader.h"
+#include "DaemonConfigLoader.h"
+#include "DeviceUtil.h"
+#include "ThreadUtil.h"
+#ifdef HAS_CUPTI
+#include "CuptiActivityApi.h"
+#include "CuptiCallbackApi.h"
+#endif
+#ifdef HAS_ROCTRACER
+#include "RocprofLogger.h"
+#endif
+#ifdef HAS_XPUPTI
+#include "plugin/xpupti/XpuptiActivityApi.h"
+#include "plugin/xpupti/XpuptiActivityProfiler.h"
+#include "plugin/xpupti/XpuptiProfilerMacros.h"
+#include "plugin/xpupti/XpuptiScopeProfilerConfig.h"
+#endif
+#include "libkineto.h"
+
+#include "Logger.h"
+
+namespace KINETO_NAMESPACE {
+
+#if __linux__ || defined(HAS_CUPTI)
+static bool initialized = false;
+
+static void initProfilers() {
+  if (!initialized) {
+    // Caution: `initProfilerIfRegistered` spawns the `updateConfigThread`, so
+    // either:
+    // 1. Ensure nothing the main thread does not do anything which could race
+    // with the `updateConfigThread` (current invariant)
+    // 2. Guard the raceable data appropriately
+    libkineto::api().initProfilerIfRegistered();
+    initialized = true;
+    VLOG(0) << "libkineto profilers activated";
+  }
+}
+
+#endif // __linux__ || defined(HAS_CUPTI)
+
+#ifdef HAS_CUPTI
+static void initProfilersCallback(
+    [[maybe_unused]] CUpti_CallbackDomain domain,
+    [[maybe_unused]] CUpti_CallbackId cbid,
+    [[maybe_unused]] const CUpti_CallbackData* cbInfo) {
+  VLOG(0) << "CUDA Context created";
+  initProfilers();
+}
+
+// Some models suffer from excessive instrumentation code gen
+// on dynamic attach which can hang for more than 5+ seconds.
+// If the workload was meant to be traced, preload the CUPTI
+// to take the performance hit early on.
+// https://docs.nvidia.com/cupti/r_main.html#r_overhead
+static bool shouldPreloadCuptiInstrumentation() {
+#if defined(CUDA_VERSION) && CUDA_VERSION < 11020
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool setupCuptiInitCallback(bool logOnError) {
+  // libcupti will be lazily loaded on this call.
+  // If it is not available (e.g. CUDA is not installed),
+  // then this call will return an error and we just abort init.
+  auto& cbapi = CuptiCallbackApi::singleton();
+  cbapi.initCallbackApi();
+
+  bool status = false;
+
+  if (cbapi.initSuccess()) {
+    const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RESOURCE;
+    status = cbapi.registerCallback(
+        domain,
+        CuptiCallbackApi::CuptiCallBackID::RESOURCE_CONTEXT_CREATED,
+        initProfilersCallback);
+    if (status) {
+      status =
+          cbapi.enableCallback(domain, CUPTI_CBID_RESOURCE_CONTEXT_CREATED);
+    }
+  }
+
+  if (!cbapi.initSuccess() || !status) {
+    if (logOnError) {
+      CUPTI_CALL(cbapi.getCuptiStatus());
+      LOG(WARNING) << "CUPTI initialization failed - "
+                   << "CUDA profiler activities will be missing";
+      LOG(INFO)
+          << "If you see CUPTI_ERROR_INSUFFICIENT_PRIVILEGES, refer to "
+          << "https://developer.nvidia.com/nvidia-development-tools-solutions-err-nvgpuctrperm-cupti";
+    }
+  }
+
+  return status;
+}
+#endif // HAS_CUPTI
+
+} // namespace KINETO_NAMESPACE
+
+// Callback interface with CUPTI and library constructors
+using namespace KINETO_NAMESPACE;
+extern "C" {
+
+void libkineto_init(bool cpuOnly, [[maybe_unused]] bool logOnError) {
+  // Start with initializing the log level
+  const char* logLevelEnv = getenv("KINETO_LOG_LEVEL");
+  if (logLevelEnv) {
+    // atoi returns 0 on error, so that's what we want - default to VERBOSE
+    static_assert(static_cast<int>(VERBOSE) == 0);
+    SET_LOG_SEVERITY_LEVEL(atoi(logLevelEnv));
+  }
+
+  // Factory to connect to open source daemon if present
+#if __linux__
+  if (libkineto::isDaemonEnvVarSet()) {
+    LOG(INFO) << "Registering daemon config loader, cpuOnly =  " << cpuOnly;
+    DaemonConfigLoader::registerFactory();
+  }
+#endif
+
+#ifdef HAS_CUPTI
+  if (!cpuOnly && !libkineto::isDaemonEnvVarSet()) {
+    bool success = setupCuptiInitCallback(logOnError);
+    cpuOnly = !success;
+  }
+
+  if (!cpuOnly && shouldPreloadCuptiInstrumentation()) {
+    CuptiActivityApi::forceLoadCupti();
+  }
+#endif // HAS_CUPTI
+
+#ifdef HAS_ROCTRACER
+  if (!cpuOnly) {
+    RocprofLogger::ensureRegistered();
+  }
+#endif
+
+  ConfigLoader& config_loader = libkineto::api().configLoader();
+  libkineto::api().registerProfiler(
+      std::make_unique<ActivityProfilerProxy>(cpuOnly, config_loader));
+
+#ifdef HAS_XPUPTI
+  // register xpu pti profiler
+  libkineto::api().registerProfilerFactory(
+      []() -> std::unique_ptr<IActivityProfiler> {
+        XPUPTI_CALL(
+            ptiViewGPULocalAvailable(),
+            /*error_message=*/"Failed to enable Kineto Profiler on XPU.");
+        XpuptiScopeProfilerConfig::registerFactory();
+        return std::make_unique<XPUActivityProfiler>();
+      });
+#endif // HAS_XPUPTI
+
+#if __linux__
+  // For open source users that would like to connect to a profiling daemon
+  // we should always initialize the profiler at this point.
+  if (libkineto::isDaemonEnvVarSet()) {
+    initProfilers();
+  }
+#endif
+}
+
+// The cuda driver calls this function if the CUDA_INJECTION64_PATH environment
+// variable is set. Should be skipped if unset or CUDA_INJECTION64_PATH=none.
+int InitializeInjection(void) {
+  LOG(INFO) << "Injection mode: Initializing libkineto";
+  libkineto_init(false /*cpuOnly*/, true /*logOnError*/);
+  return 1;
+}
+
+bool hasTestEnvVar() {
+  return getenv("GTEST_OUTPUT") != nullptr || getenv("FB_TEST") != nullptr ||
+      getenv("PYTORCH_TEST") != nullptr || getenv("TEST_PILOT") != nullptr;
+}
+
+void suppressLibkinetoLogMessages() {
+  // Only suppress messages if explicit override wasn't provided
+  const char* logLevelEnv = getenv("KINETO_LOG_LEVEL");
+  // For unit tests, don't suppress log verbosity.
+  if (!hasTestEnvVar() && (!logLevelEnv || !*logLevelEnv)) {
+    SET_LOG_SEVERITY_LEVEL(ERROR);
+  }
+}
+
+} // extern C

--- a/third_party/kineto/libkineto/src/libkineto_api.cpp
+++ b/third_party/kineto/libkineto/src/libkineto_api.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "libkineto.h"
+
+#include "ConfigLoader.h"
+#include "ThreadUtil.h"
+
+namespace libkineto {
+
+LibkinetoApi& api() {
+  static LibkinetoApi instance(ConfigLoader::instance());
+  return instance;
+}
+
+void LibkinetoApi::initClientIfRegistered() {
+  if (client_) {
+    if (clientRegisterThread_ != threadId()) {
+      fprintf(
+          stderr,
+          "ERROR: External init callback must run in same thread as registerClient "
+          "(%d != %d)\n",
+          threadId(),
+          (int)clientRegisterThread_);
+    } else {
+      client_->init();
+    }
+  }
+}
+
+void LibkinetoApi::registerClient(ClientInterface* client) {
+  client_ = client;
+  if (client && activityProfiler_) {
+    // Can initialize straight away
+    client->init();
+  }
+  // Assume here that the external init callback is *not* threadsafe
+  // and only call it if it's the same thread that called registerClient
+  clientRegisterThread_ = threadId();
+}
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/src/output_json.cpp
+++ b/third_party/kineto/libkineto/src/output_json.cpp
@@ -1,0 +1,1068 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "output_json.h"
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <algorithm>
+#include <ctime>
+#include <fstream>
+#include <iterator>
+#include <string_view>
+#include "Config.h"
+#include "EnvMetadata.h"
+#include "TraceSpan.h"
+
+#include "Logger.h"
+
+namespace KINETO_NAMESPACE {
+namespace {
+
+constexpr int kSchemaVersion = 1;
+constexpr char kFlowStart = 's';
+constexpr char kFlowEnd = 'f';
+
+// CPU op name that is used to store collectives metadata
+// TODO: share the same string across c10d, profiler and libkineto
+constexpr std::string_view kParamCommsCallName = "record_param_comms";
+// Collective function metadata populated from CPU op to GPU kernel
+constexpr std::string_view kCollectiveName = "Collective name";
+constexpr std::string_view kDtype = "dtype";
+constexpr std::string_view kInMsgNelems = "In msg nelems";
+constexpr std::string_view kOutMsgNelems = "Out msg nelems";
+constexpr std::string_view kGroupSize = "Group size";
+constexpr std::string_view kInSplit = "In split size";
+constexpr std::string_view kOutSplit = "Out split size";
+constexpr std::string_view kProcessGroupName = "Process Group Name";
+constexpr std::string_view kProcessGroupDesc = "Process Group Description";
+constexpr std::string_view kGroupRanks = "Process Group Ranks";
+constexpr std::string_view kInTensorsStart = "Input Tensors start";
+constexpr std::string_view kOutTensorsStart = "Output Tensors start";
+constexpr std::string_view kRank = "Rank";
+constexpr std::string_view kP2pSrc = "Src Rank";
+constexpr std::string_view kP2pDst = "Dst Rank";
+constexpr std::string_view kSeqNum = "Seq";
+constexpr std::string_view kCommsId = "Comms Id";
+
+// Collective string metadata arrives quoted from the legacy RawJson path and
+// unquoted from the typed path; strip a single surrounding pair of double
+// quotes so downstream emission can re-quote uniformly (tolerates both).
+std::string stripQuotes(std::string s) {
+  if (s.size() >= 2 && s.front() == '"' && s.back() == '"') {
+    s.pop_back();
+    s.erase(0, 1);
+  }
+  return s;
+}
+
+#ifdef __linux__
+constexpr std::string_view kDefaultLogFileFmt =
+    "/tmp/libkineto_activities_{}.json";
+#else
+constexpr std::string_view kDefaultLogFileFmt = "libkineto_activities_{}.json";
+#endif
+
+void sanitizeStrForJSON(std::string& value) {
+  // Replace all backslashes with forward slash because Windows paths causing
+  // JSONDecodeError.
+  std::ranges::replace(value, '\\', '/');
+  // Remove all new line characters
+  std::erase(value, '\n');
+}
+
+// Escape bare double quotes so an event name can be safely embedded in a JSON
+// string value ("name": "<value>"). Names can contain `"` (e.g.
+// dynamo-generated co_filenames like {"device": "cpu"} surfaced with
+// with_stack=True); an unescaped `"` corrupts the whole trace. Run after
+// sanitizeStrForJSON() so the inserted backslashes aren't rewritten. See
+// pytorch/pytorch#146900.
+void escapeQuotesForJSON(std::string& value) {
+  for (size_t pos = value.find('"'); pos != std::string::npos;
+       pos = value.find('"', pos + 2)) {
+    value.insert(pos, 1, '\\');
+  }
+}
+
+std::string string2hex(const std::string& str) {
+  std::string out;
+  out.reserve(str.size() * 2);
+  for (uint8_t c : str) {
+    // “:02x” -> two‐digit, zero‐padded, lowercase hex
+    fmt::format_to(std::back_inserter(out), "{:02x}", c);
+  }
+  return out;
+}
+
+void sanitizeForNonReadableChars(std::string& value) {
+  for (auto& c : value) {
+    if (!std::isprint(c)) {
+      LOG(WARNING) << "Non JSON compliant character found in string: 0x"
+                   << string2hex(value) << " Replacing with 'unknown'";
+      value = "unknown";
+      break;
+    }
+  }
+}
+
+inline int64_t sanitizeTid(int64_t tid) {
+  // Convert all negative tids to its positive value. Create a specific case
+  // for INT64_MIN so it is obvious how it is being handled.
+  if (tid == INT64_MIN) {
+    return 0;
+  }
+  return std::abs(tid);
+}
+
+// Format nanosecond timestamp as "us.fractional" for Chrome Trace JSON.
+std::string fmtTs(int64_t time_ns) {
+  return fmt::format("{}.{:03}", time_ns / 1000, time_ns % 1000);
+}
+
+bool isWhitespace(std::string_view s) {
+  return std::ranges::all_of(
+      s, [](unsigned char c) { return std::isspace(c); });
+}
+
+} // namespace
+
+ChromeTraceBaseTime& ChromeTraceBaseTime::singleton() {
+  static ChromeTraceBaseTime instance;
+  return instance;
+}
+
+// The 'ts' field written into the json file has 19 significant digits,
+// while a double can only represent 15-16 digits. By using relative time,
+// other applications can accurately read the 'ts' field as a double.
+// Use the program loading time as the baseline time.
+int64_t transToRelativeTime(int64_t time) {
+  // Sometimes after converting to relative time, it can be a few nanoseconds
+  // negative. Since Chrome trace and json processing will throw a parser error,
+  // guard this.
+  int64_t res = time - ChromeTraceBaseTime::singleton().get();
+  if (res < 0) {
+    return 0;
+  }
+  return res;
+}
+
+// Internal helper for building the "args" JSON object content.
+// Handles comma separation automatically.
+class ArgsBuilder {
+ public:
+  // Add a key with a pre-formatted value (number, boolean, already-quoted
+  // string, JSON array/object).
+  void addRaw(std::string_view key, std::string_view value) {
+    appendComma();
+    fmt::format_to(std::back_inserter(buf_), R"("{}": {})", key, value);
+  }
+
+  // Add a key with a string value (will be JSON-quoted).
+  void addQuoted(std::string_view key, std::string_view value) {
+    appendComma();
+    fmt::format_to(std::back_inserter(buf_), R"("{}": "{}")", key, value);
+  }
+
+  // Append a pre-formatted JSON fragment (e.g., from metadataJson()).
+  void appendFragment(std::string_view json_fragment) {
+    // Skip empty or whitespace-only fragments: appending them after a comma
+    // from appendComma() would produce invalid JSON (e.g., "key": value, }).
+    if (json_fragment.empty() || isWhitespace(json_fragment)) {
+      return;
+    }
+    appendComma();
+    buf_.append(json_fragment);
+  }
+
+  [[nodiscard]] std::string_view str() const {
+    return buf_;
+  }
+
+  [[nodiscard]] bool empty() const {
+    return buf_.empty();
+  }
+
+  // Return the full "args" JSON field (e.g., ', "args": { ... }'), or an
+  // empty string if no args were added.
+  [[nodiscard]] std::string renderField() const {
+    if (buf_.empty()) {
+      return {};
+    }
+    return fmt::format(
+        R"JSON(,
+    "args": {{
+      {}
+    }})JSON",
+        buf_);
+  }
+
+ private:
+  void appendComma() {
+    if (!buf_.empty()) {
+      buf_.append(",");
+    }
+  }
+  std::string buf_;
+};
+
+void ChromeTraceLogger::writeMetadataEvent(
+    std::string_view name,
+    int64_t ts,
+    std::string_view pid,
+    std::string_view tid,
+    std::string_view arg_key,
+    std::string_view arg_value) {
+  // clang-format off
+  fmt::print(traceOf_, R"JSON(
+  {{
+    "ph": "M",
+    "name": "{}",
+    "ts": {},
+    "pid": {},
+    "tid": {},
+    "args": {{
+      "{}": {}
+    }}
+  }},)JSON",
+      name, fmtTs(ts), pid, tid, arg_key, arg_value);
+  // clang-format on
+}
+
+void ChromeTraceLogger::writeCompleteEvent(
+    std::string_view cat,
+    std::string_view name,
+    std::string_view pid,
+    std::string_view tid,
+    int64_t ts,
+    int64_t dur,
+    const ArgsBuilder& args) {
+  // clang-format off
+  fmt::print(traceOf_, R"JSON(
+  {{
+    "ph": "X",
+    "cat": "{}",
+    "name": "{}",
+    "pid": {},
+    "tid": {},
+    "ts": {},
+    "dur": {}
+    {}
+  }},)JSON",
+      cat, name, pid, tid, fmtTs(ts), fmtTs(dur), args.renderField());
+  // clang-format on
+}
+
+void ChromeTraceLogger::writeInstantEvent(
+    std::string_view cat,
+    std::string_view name,
+    std::string_view scope,
+    std::string_view pid,
+    std::string_view tid,
+    int64_t ts,
+    const ArgsBuilder& args,
+    bool finalEvent) {
+  std::string cat_str;
+  if (!cat.empty()) {
+    cat_str = fmt::format(
+        R"JSON(
+    "cat": "{}",)JSON",
+        cat);
+  }
+  const char* trailing = finalEvent ? "" : ",";
+  // clang-format off
+  fmt::print(traceOf_, R"JSON(
+  {{
+    "ph": "i",
+    {}
+    "s": "{}",
+    "name": "{}",
+    "pid": {},
+    "tid": {},
+    "ts": {}
+    {}
+  }}{})JSON",
+      cat_str, scope, name, pid, tid, fmtTs(ts), args.renderField(), trailing);
+  // clang-format on
+}
+
+void ChromeTraceLogger::writeCounterEvent(
+    std::string_view cat,
+    std::string_view name,
+    std::string_view pid,
+    std::string_view tid,
+    int64_t ts,
+    const ArgsBuilder& args) {
+  // clang-format off
+  fmt::print(traceOf_, R"JSON(
+  {{
+    "ph": "C",
+    "cat": "{}",
+    "name": "{}",
+    "pid": {},
+    "tid": {},
+    "ts": {},
+    "args": {{
+      {}
+    }}
+  }},)JSON",
+      cat, name, pid, tid, fmtTs(ts), args.str());
+  // clang-format on
+}
+
+void ChromeTraceLogger::writeFlowEvent(
+    char type,
+    int64_t id,
+    std::string_view pid,
+    std::string_view tid,
+    int64_t ts,
+    std::string_view cat,
+    std::string_view name) {
+  // Flow events must bind to specific slices in order to exist.
+  // Only Flow end needs to specify a binding point to enclosing slice.
+  // Flow start automatically sets binding point to enclosing slice.
+  const auto* const binding = (type == kFlowEnd) ? R"(, "bp": "e")" : "";
+
+  // clang-format off
+  fmt::print(traceOf_, R"JSON(
+  {{
+    "ph": "{}",
+    "id": {},
+    "pid": {},
+    "tid": {},
+    "ts": {},
+    "cat": "{}",
+    "name": "{}"
+    {}
+  }},)JSON",
+      type, id, pid, tid, fmtTs(ts), cat, name, binding);
+  // clang-format on
+}
+
+// Integer overloads — delegate to the string_view versions.
+void ChromeTraceLogger::writeMetadataEvent(
+    std::string_view name,
+    int64_t ts,
+    int64_t pid,
+    int64_t tid,
+    std::string_view arg_key,
+    std::string_view arg_value) {
+  writeMetadataEvent(
+      name, ts, std::to_string(pid), std::to_string(tid), arg_key, arg_value);
+}
+
+void ChromeTraceLogger::writeCompleteEvent(
+    std::string_view cat,
+    std::string_view name,
+    int64_t pid,
+    int64_t tid,
+    int64_t ts,
+    int64_t dur,
+    const ArgsBuilder& args) {
+  writeCompleteEvent(
+      cat, name, std::to_string(pid), std::to_string(tid), ts, dur, args);
+}
+
+void ChromeTraceLogger::writeInstantEvent(
+    std::string_view cat,
+    std::string_view name,
+    std::string_view scope,
+    int64_t pid,
+    int64_t tid,
+    int64_t ts,
+    const ArgsBuilder& args,
+    bool finalEvent) {
+  writeInstantEvent(
+      cat,
+      name,
+      scope,
+      std::to_string(pid),
+      std::to_string(tid),
+      ts,
+      args,
+      finalEvent);
+}
+
+void ChromeTraceLogger::writeCounterEvent(
+    std::string_view cat,
+    std::string_view name,
+    int64_t pid,
+    int64_t tid,
+    int64_t ts,
+    const ArgsBuilder& args) {
+  writeCounterEvent(
+      cat, name, std::to_string(pid), std::to_string(tid), ts, args);
+}
+
+void ChromeTraceLogger::writeFlowEvent(
+    char type,
+    int64_t id,
+    int64_t pid,
+    int64_t tid,
+    int64_t ts,
+    std::string_view cat,
+    std::string_view name) {
+  writeFlowEvent(
+      type, id, std::to_string(pid), std::to_string(tid), ts, cat, name);
+}
+
+void ChromeTraceLogger::metadataToJSON(
+    const std::unordered_map<std::string, std::string>& metadata) {
+  for (const auto& [k, v] : metadata) {
+    std::string sanitizedValue = v;
+    // There is a separate mechanism for recording distributedInfo in on-demand
+    // so add a guard to prevent "double counting" in auto-trace.
+    if (k == "distributedInfo") {
+      distInfo_.distInfo_present_ = true;
+    }
+    sanitizeStrForJSON(sanitizedValue);
+    fmt::print(
+        traceOf_,
+        R"JSON(
+      "{}": {},)JSON",
+        k,
+        sanitizedValue);
+  }
+}
+
+std::unordered_map<std::string, std::string> ChromeTraceLogger::
+    addEnvVarsToMetadata(
+        const std::unordered_map<std::string, std::string>& metadata) {
+  // Get environment metadata from the EnvMetadata module
+  auto combined = libkineto::getEnvMetadata();
+  // Original metadata takes precedence
+  for (const auto& [k, v] : metadata) {
+    combined[k] = v;
+  }
+  return combined;
+}
+
+void ChromeTraceLogger::handleTraceStart(
+    const std::unordered_map<std::string, std::string>& metadata,
+    const std::string& device_properties) {
+  if (!traceOf_) {
+    return;
+  }
+  std::string display_unit = "ms";
+#ifdef DISPLAY_TRACE_IN_NS
+  display_unit = "ns";
+#endif
+  // clang-format off
+  fmt::print(traceOf_, R"JSON( {{
+    "schemaVersion": {},
+    "deviceProperties": [{}],
+    )JSON",
+      kSchemaVersion, device_properties);
+  // clang-format on
+
+  // Note that metadataToJSON writes to the trace file.
+  auto combinedMetadata = addEnvVarsToMetadata(metadata);
+  metadataToJSON(combinedMetadata);
+
+  // Note that we open the `traceEvents` array, but we do not close it. Most
+  // of the rest of the writing are writing new trace events to the array. We
+  // close the array in `finalizeTrace`.
+  // clang-format off
+  fmt::print(traceOf_, R"JSON(
+    "displayTimeUnit": "{}",
+    "baseTimeNanoseconds": {},
+    "traceEvents": [
+    )JSON",
+      display_unit,
+      ChromeTraceBaseTime::singleton().get());
+  // clang-format on
+}
+
+static std::string defaultFileName() {
+  return fmt::format(kDefaultLogFileFmt, processId());
+}
+
+void ChromeTraceLogger::openTraceFile() {
+  tempFileName_ = fileName_ + ".tmp";
+  traceOf_.open(tempFileName_, std::ofstream::out | std::ofstream::trunc);
+  if (!traceOf_) {
+    PLOG(ERROR) << "Failed to open '" << fileName_ << "'";
+  } else {
+    LOG(INFO) << "Tracing to temporary file " << fileName_;
+  }
+}
+
+void ChromeTraceLogger::finalizeMemoryTrace(
+    [[maybe_unused]] const std::string& url,
+    [[maybe_unused]] const Config& config) {
+  LOG(INFO) << "finalizeMemoryTrace not implemented for ChromeTraceLogger";
+}
+
+ChromeTraceLogger::ChromeTraceLogger(const std::string& traceFileName) {
+  fileName_ = traceFileName.empty() ? defaultFileName() : traceFileName;
+  traceOf_.clear(std::ios_base::badbit);
+  openTraceFile();
+}
+
+void ChromeTraceLogger::handleDeviceInfo(const DeviceInfo& info, int64_t time) {
+  if (!traceOf_) {
+    return;
+  }
+
+  time = transToRelativeTime(time);
+  writeMetadataEvent(
+      /*name=*/"process_name",
+      /*ts=*/time,
+      /*pid=*/info.id,
+      /*tid=*/0,
+      /*arg_key=*/"name",
+      /*arg_value=*/fmt::format("\"{}\"", info.name));
+  writeMetadataEvent(
+      /*name=*/"process_labels",
+      /*ts=*/time,
+      /*pid=*/info.id,
+      /*tid=*/0,
+      /*arg_key=*/"labels",
+      /*arg_value=*/fmt::format("\"{}\"", info.label));
+  writeMetadataEvent(
+      /*name=*/"process_sort_index",
+      /*ts=*/time,
+      /*pid=*/info.id,
+      /*tid=*/0,
+      /*arg_key=*/"sort_index",
+      /*arg_value=*/fmt::format("{}", info.sortIndex));
+}
+
+void ChromeTraceLogger::handleResourceInfo(
+    const ResourceInfo& info,
+    int64_t time) {
+  if (!traceOf_) {
+    return;
+  }
+
+  time = transToRelativeTime(time);
+  int64_t tid = sanitizeTid(info.id);
+  writeMetadataEvent(
+      /*name=*/"thread_name",
+      /*ts=*/time,
+      /*pid=*/info.deviceId,
+      /*tid=*/tid,
+      /*arg_key=*/"name",
+      /*arg_value=*/fmt::format("\"{}\"", info.name));
+  writeMetadataEvent(
+      /*name=*/"thread_sort_index",
+      /*ts=*/time,
+      /*pid=*/info.deviceId,
+      /*tid=*/tid,
+      /*arg_key=*/"sort_index",
+      /*arg_value=*/fmt::format("{}", info.sortIndex));
+}
+
+void ChromeTraceLogger::handleOverheadInfo(
+    const OverheadInfo& info,
+    int64_t time) {
+  if (!traceOf_) {
+    return;
+  }
+
+  // TOOD: reserve pid = -1 for overhead but we need to rethink how to scale
+  // this for other metadata
+  time = transToRelativeTime(time);
+  writeMetadataEvent(
+      /*name=*/"process_name",
+      /*ts=*/time,
+      /*pid=*/-1,
+      /*tid=*/0,
+      /*arg_key=*/"name",
+      /*arg_value=*/fmt::format("\"{}\"", info.name));
+  writeMetadataEvent(
+      /*name=*/"process_sort_index",
+      /*ts=*/time,
+      /*pid=*/-1,
+      /*tid=*/0,
+      /*arg_key=*/"sort_index",
+      /*arg_value=*/fmt::format("{}", 0x100000All));
+}
+
+void ChromeTraceLogger::handleTraceSpan(const TraceSpan& span) {
+  if (!traceOf_) {
+    return;
+  }
+
+  int64_t start = transToRelativeTime(span.startTime);
+
+  // If endTime is 0 and start time is non-zero, dur can overflow. Add
+  // a guard to prevent this.
+  int64_t dur = (span.endTime == 0) ? 0 : span.endTime - span.startTime;
+
+  ArgsBuilder args;
+  args.addRaw("Op count", fmt::format("{}", span.opCount));
+  writeCompleteEvent(
+      /*cat=*/"Trace",
+      /*name=*/fmt::format("{}{} ({})", span.prefix, span.name, span.iteration),
+      /*pid=*/R"("Spans")",
+      /*tid=*/fmt::format("\"{}\"", span.name),
+      /*ts=*/start,
+      /*dur=*/dur,
+      /*args=*/args);
+  writeMetadataEvent(
+      /*name=*/"process_sort_index",
+      /*ts=*/start,
+      /*pid=*/R"("Spans")",
+      /*tid=*/"0",
+      /*arg_key=*/"sort_index",
+      // Large sort index to appear at the bottom
+      /*arg_value=*/fmt::format("{}", 0x20000000ll));
+
+  addIterationMarker(span);
+}
+
+void ChromeTraceLogger::addIterationMarker(const TraceSpan& span) {
+  if (!traceOf_) {
+    return;
+  }
+
+  int64_t start = transToRelativeTime(span.startTime);
+
+  ArgsBuilder args;
+  writeInstantEvent(
+      /*cat=*/"",
+      /*name=*/fmt::format("Iteration Start: {}", span.name),
+      /*scope=*/"g",
+      /*pid=*/R"("Traces")",
+      /*tid=*/fmt::format("\"Trace {}\"", span.name),
+      /*ts=*/start,
+      /*args=*/args);
+}
+
+void ChromeTraceLogger::handleGenericInstantEvent(
+    const libkineto::ITraceActivity& op) {
+  if (!traceOf_) {
+    return;
+  }
+
+  int64_t ts = transToRelativeTime(op.timestamp());
+  ArgsBuilder args;
+  args.appendFragment(op.metadataJson());
+  writeInstantEvent(
+      /*cat=*/toString(op.type()),
+      /*name=*/op.name(),
+      /*scope=*/"t",
+      /*pid=*/op.deviceId(),
+      /*tid=*/sanitizeTid(op.resourceId()),
+      /*ts=*/ts,
+      /*args=*/args);
+}
+
+void ChromeTraceLogger::handleCounterEvent(
+    const libkineto::ITraceActivity& op) {
+  if (!traceOf_) {
+    return;
+  }
+
+  ArgsBuilder args;
+  for (const auto& [name, value] : op.counterValues()) {
+    args.addRaw(name, fmt::format("{}", value));
+  }
+
+  int64_t ts = transToRelativeTime(op.timestamp());
+  writeCounterEvent(
+      /*cat=*/toString(op.type()),
+      /*name=*/op.name(),
+      /*pid=*/op.deviceId(),
+      /*tid=*/sanitizeTid(op.resourceId()),
+      /*ts=*/ts,
+      /*args=*/args);
+}
+
+void ChromeTraceLogger::appendCollectiveArgs(
+    ArgsBuilder& args,
+    const ITraceActivity& collectiveRecord) {
+  auto collectiveName = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kCollectiveName)));
+  const auto& inMsgSize =
+      collectiveRecord.getMetadataValue(std::string(kInMsgNelems));
+  const auto& outMsgSize =
+      collectiveRecord.getMetadataValue(std::string(kOutMsgNelems));
+  const auto& groupSize =
+      collectiveRecord.getMetadataValue(std::string(kGroupSize));
+  auto dtype =
+      stripQuotes(collectiveRecord.getMetadataValue(std::string(kDtype)));
+  if (!collectiveName.empty() && !inMsgSize.empty() && !outMsgSize.empty() &&
+      !groupSize.empty() && !dtype.empty()) {
+    args.addQuoted(kCollectiveName, collectiveName);
+    args.addRaw(kInMsgNelems, inMsgSize);
+    args.addRaw(kOutMsgNelems, outMsgSize);
+    args.addRaw(kGroupSize, groupSize);
+    args.addQuoted(kDtype, dtype);
+  }
+
+  auto inputTensorStarts = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kInTensorsStart)));
+  auto outputTensorStarts = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kOutTensorsStart)));
+  if (!inputTensorStarts.empty()) {
+    args.addQuoted(kInTensorsStart, inputTensorStarts);
+  }
+  if (!outputTensorStarts.empty()) {
+    args.addQuoted(kOutTensorsStart, outputTensorStarts);
+  }
+
+  // In/out split size are valid for all_to_all
+  auto inSplitSize =
+      stripQuotes(collectiveRecord.getMetadataValue(std::string(kInSplit)));
+  auto outSplitSize =
+      stripQuotes(collectiveRecord.getMetadataValue(std::string(kOutSplit)));
+  if (!inSplitSize.empty() && !outSplitSize.empty()) {
+    args.addQuoted(kInSplit, inSplitSize);
+    args.addQuoted(kOutSplit, outSplitSize);
+  }
+
+  auto processGroupName = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupName)));
+  if (!processGroupName.empty()) {
+    args.addQuoted(kProcessGroupName, processGroupName);
+  }
+
+  auto processGroupDesc = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupDesc)));
+  if (!processGroupDesc.empty()) {
+    args.addQuoted(kProcessGroupDesc, processGroupDesc);
+  }
+
+  auto groupRanks =
+      stripQuotes(collectiveRecord.getMetadataValue(std::string(kGroupRanks)));
+  if (!groupRanks.empty()) {
+    args.addQuoted(kGroupRanks, groupRanks);
+  }
+
+  const auto& dstRank = collectiveRecord.getMetadataValue(std::string(kP2pDst));
+  const auto& srcRank = collectiveRecord.getMetadataValue(std::string(kP2pSrc));
+  if (!dstRank.empty()) {
+    args.addRaw(kP2pDst, dstRank);
+  }
+  if (!srcRank.empty()) {
+    args.addRaw(kP2pSrc, srcRank);
+  }
+
+  const auto& seqNum = collectiveRecord.getMetadataValue(std::string(kSeqNum));
+  if (!seqNum.empty()) {
+    args.addRaw(kSeqNum, seqNum);
+  }
+
+  const auto& commsId =
+      collectiveRecord.getMetadataValue(std::string(kCommsId));
+  if (!commsId.empty()) {
+    args.addRaw(kCommsId, commsId);
+  }
+}
+
+void ChromeTraceLogger::appendCollectiveMetadata(
+    ArgsBuilder& args,
+    const ITraceActivity& collectiveRecord,
+    const std::string& backend,
+    const std::string& backendConfig) {
+  appendCollectiveArgs(args, collectiveRecord);
+
+  const auto& groupSize =
+      collectiveRecord.getMetadataValue(std::string(kGroupSize));
+  auto processGroupName = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupName)));
+  auto processGroupDesc = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupDesc)));
+  auto groupRanks =
+      stripQuotes(collectiveRecord.getMetadataValue(std::string(kGroupRanks)));
+
+  if (distInfo_.backend.empty() && processGroupDesc == "default_pg") {
+    distInfo_.backend = backend;
+    distInfo_.rank = collectiveRecord.getMetadataValue(std::string(kRank));
+    distInfo_.world_size = groupSize;
+    // DistributedInfo carries only an NCCL version and there is no version
+    // source for other backends, so populate it for NCCL and leave it empty
+    // otherwise rather than mislabel non-NCCL traffic.
+    if (backend == "nccl") {
+      distInfo_.nccl_version = "unknown";
+    }
+  }
+
+  auto pg_config = pgConfig();
+  pg_config.pg_name = processGroupName;
+  pg_config.pg_desc = std::move(processGroupDesc);
+  pg_config.backend_config = backendConfig;
+  pg_config.pg_size = groupSize;
+  pg_config.ranks = std::move(groupRanks);
+  pgMap_.insert({processGroupName, pg_config});
+}
+
+void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
+  if (!traceOf_) {
+    return;
+  }
+
+  if (op.type() == ActivityType::CPU_INSTANT_EVENT) {
+    handleGenericInstantEvent(op);
+    return;
+  }
+
+  switch (op.type()) {
+    case ActivityType::MTIA_COUNTERS:
+    case ActivityType::XPU_SCOPE_PROFILER:
+      handleCounterEvent(op);
+      return;
+    default:
+      break;
+  }
+
+  int64_t ts = op.timestamp();
+  int64_t duration = op.duration();
+
+  duration = std::max<int64_t>(duration, 0);
+
+  if (op.type() == ActivityType::GPU_USER_ANNOTATION) {
+    // The GPU user annotations start at the same time as the
+    // first associated GPU op. Since they appear later
+    // in the trace file, this causes a visualization issue in Chrome.
+    // Make it start one ns earlier and end 2 ns later.
+    ts -= 1;
+    duration += 2; // Still need it to end at the original point rounded up.
+  }
+
+  int external_id = 0;
+  if (op.linkedActivity()) {
+    external_id = op.linkedActivity()->correlationId();
+  } else {
+    // Some runtime events and kernels may not have a linked activity,
+    // should not set an "External id" for them. Otherwise, these events
+    // may be incorrectly linked to the other external events.
+    static const std::set<libkineto::ActivityType> excludedTypes = {
+        libkineto::ActivityType::GPU_MEMCPY,
+        libkineto::ActivityType::GPU_MEMSET,
+        libkineto::ActivityType::CONCURRENT_KERNEL,
+        libkineto::ActivityType::CUDA_RUNTIME,
+        libkineto::ActivityType::CUDA_DRIVER,
+        libkineto::ActivityType::XPU_RUNTIME,
+        libkineto::ActivityType::XPU_DRIVER,
+        libkineto::ActivityType::PRIVATEUSE1_RUNTIME,
+        libkineto::ActivityType::PRIVATEUSE1_DRIVER};
+    if (!excludedTypes.contains(op.type())) {
+      external_id = op.correlationId();
+    }
+  }
+  ArgsBuilder args;
+  if (external_id != 0) {
+    args.addRaw("External id", fmt::format("{}", external_id));
+  }
+  std::string op_metadata = op.metadataJson();
+  sanitizeStrForJSON(op_metadata);
+  args.appendFragment(op_metadata);
+
+  // Populate collective metadata from the linked record_param_comms CPU op.
+  const auto* linkedOp = op.linkedActivity();
+  if (linkedOp != nullptr && linkedOp->name() == kParamCommsCallName) {
+    if (op.type() == ActivityType::CONCURRENT_KERNEL) {
+      appendCollectiveMetadata(args, *linkedOp, "nccl", "cuda:nccl");
+    } else if (
+        op.type() == ActivityType::MTIA_CCP_EVENTS &&
+        op.name().starts_with("hccl::")) {
+      appendCollectiveMetadata(args, *linkedOp, "hccl", "mtia:hccl");
+    }
+  }
+
+  int64_t device = op.deviceId();
+  int64_t resource = op.resourceId();
+
+  // Move Stream Sync events to a dedicated row so they don't overlap with
+  // kernel events on the same stream in the trace viewer.
+  if (op.type() == ActivityType::CUDA_SYNC && op.name() == "Stream Sync") {
+    int64_t syncTid = resource + kSyncStreamTidOffset;
+    int64_t key = (device << 32) | syncTid;
+    if (syncStreamMetadataEmitted_.insert(key).second) {
+      int64_t metaTime = transToRelativeTime(ts);
+      // clang-format off
+      fmt::print(traceOf_, R"JSON(
+  {{
+    "name": "thread_name", "ph": "M", "ts": {}.{:03}, "pid": {}, "tid": {},
+    "args": {{
+      "name": "stream {} (sync)"
+    }}
+  }},
+  {{
+    "name": "thread_sort_index", "ph": "M", "ts": {}.{:03}, "pid": {}, "tid": {},
+    "args": {{
+      "sort_index": {}
+    }}
+  }},)JSON",
+          metaTime/1000, metaTime%1000, device, syncTid,
+          resource,
+          metaTime/1000, metaTime%1000, device, syncTid,
+          resource);
+      // clang-format on
+    }
+    resource = syncTid;
+  }
+
+  // TODO: Remove this once legacy tools are updated.
+  std::string op_name = op.name() == "kernel" ? "Kernel" : op.name();
+  sanitizeStrForJSON(op_name);
+  sanitizeForNonReadableChars(op_name);
+  escapeQuotesForJSON(op_name);
+
+  ts = transToRelativeTime(ts);
+  writeCompleteEvent(
+      /*cat=*/toString(op.type()),
+      /*name=*/op_name,
+      /*pid=*/device,
+      /*tid=*/sanitizeTid(resource),
+      /*ts=*/ts,
+      /*dur=*/duration,
+      /*args=*/args);
+  if (op.flowId() > 0) {
+    handleGenericLink(op);
+  }
+}
+
+void ChromeTraceLogger::handleGenericActivity(
+    const libkineto::GenericTraceActivity& op) {
+  if (!traceOf_) {
+    return;
+  }
+  handleActivity(op);
+}
+
+void ChromeTraceLogger::handleGenericLink(const ITraceActivity& act) {
+  if (!traceOf_) {
+    return;
+  }
+  static struct {
+    int type;
+    char name[16];
+  } flow_names[] = {{kLinkFwdBwd, "fwdbwd"}, {kLinkAsyncCpuGpu, "ac2g"}};
+  for (auto& flow : flow_names) {
+    if (act.flowType() == flow.type) {
+      // Link the activities via flow ID in source and destination.
+      // The source node must return true from flowStart()
+      // and the destination node false.
+      if (act.flowStart()) {
+        handleLink(kFlowStart, act, act.flowId(), flow.name);
+      } else {
+        handleLink(kFlowEnd, act, act.flowId(), flow.name);
+      }
+      return;
+    }
+  }
+  LOG(WARNING) << "Unknown flow type: " << act.flowType();
+}
+
+void ChromeTraceLogger::handleLink(
+    char type,
+    const ITraceActivity& e,
+    int64_t id,
+    const std::string& name) {
+  if (!traceOf_) {
+    return;
+  }
+
+  int64_t ts = transToRelativeTime(e.timestamp());
+  int64_t tid = e.resourceId();
+  // Use the virtual tid for Stream Sync events to match the row
+  // they were placed on in handleActivity().
+  if (e.type() == ActivityType::CUDA_SYNC && e.name() == "Stream Sync") {
+    tid = tid + kSyncStreamTidOffset;
+  }
+  writeFlowEvent(
+      /*type=*/type,
+      /*id=*/id,
+      /*pid=*/e.deviceId(),
+      /*tid=*/sanitizeTid(tid),
+      /*ts=*/ts,
+      /*cat=*/name,
+      /*name=*/name);
+}
+
+void ChromeTraceLogger::finalizeTrace(
+    [[maybe_unused]] const Config& config,
+    [[maybe_unused]] std::unique_ptr<ActivityBuffers> buffers,
+    int64_t endTime) {
+  finalizeTrace(endTime);
+}
+
+void ChromeTraceLogger::addOnDemandDistMetadata() {
+  if (distInfo_.backend.empty()) {
+    return;
+  }
+  fmt::print(
+      traceOf_,
+      R"JSON(
+  "distributedInfo": {{"backend": "{}", "rank": {}, "world_size": {}, "pg_count": {}, "pg_config": [)JSON",
+      distInfo_.backend,
+      distInfo_.rank,
+      distInfo_.world_size,
+      std::to_string(pgMap_.size()));
+
+  bool first = true;
+  for (const auto& element : pgMap_) {
+    if (!first) {
+      fmt::print(traceOf_, ",");
+    }
+    fmt::print(
+        traceOf_,
+        R"JSON({{"pg_name": "{}", "pg_desc": "{}", "backend_config": "{}", "pg_size": {}, "ranks": "{}"}})JSON",
+        element.second.pg_name,
+        element.second.pg_desc,
+        element.second.backend_config,
+        element.second.pg_size,
+        element.second.ranks);
+    first = false;
+  }
+
+  fmt::print(
+      traceOf_,
+      R"JSON(], "nccl_version": "{}"}},)JSON",
+      distInfo_.nccl_version);
+  distInfo_.distInfo_present_ = true;
+}
+
+void ChromeTraceLogger::finalizeTrace(int64_t endTime) {
+  if (!traceOf_) {
+    LOG(ERROR) << "Failed to write to log file!";
+    return;
+  }
+  sanitizeStrForJSON(fileName_);
+  LOG(INFO) << "Chrome Trace written to " << fileName_;
+
+  // Note that this call ends the `traceEvents` array opened up in
+  // `handleTraceStart.`
+  endTime = transToRelativeTime(endTime);
+  ArgsBuilder emptyArgs;
+  writeInstantEvent(
+      /*cat=*/"",
+      /*name=*/"Record Window End",
+      /*scope=*/"g",
+      /*pid=*/R"("")",
+      /*tid=*/R"("")",
+      /*ts=*/endTime,
+      /*args=*/emptyArgs,
+      /*finalEvent=*/true);
+
+  // Close the `traceEvents` array.
+  fmt::print(traceOf_, "\n  ],");
+
+  if (!distInfo_.distInfo_present_) {
+    addOnDemandDistMetadata();
+  }
+
+  // The last entry MUST NOT end with a comma.
+  fmt::print(traceOf_, R"JSON("traceName": "{}" }})JSON", fileName_);
+
+  traceOf_.close();
+
+  // On some systems, rename() fails if the destination file exists.
+  // So, remove the destination file first.
+  remove(fileName_.c_str());
+  if (rename(tempFileName_.c_str(), fileName_.c_str()) != 0) {
+    PLOG(ERROR) << "Failed to rename " << tempFileName_ << " to " << fileName_;
+  } else {
+    LOG(INFO) << "Renamed the trace file to " << fileName_;
+  }
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/output_json.h
+++ b/third_party/kineto/libkineto/src/output_json.h
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <fstream>
+#include <map>
+#include <ostream>
+#include <ratio>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ActivityBuffers.h"
+#include "GenericTraceActivity.h"
+#include "output_base.h"
+#include "time_since_epoch.h"
+
+namespace KINETO_NAMESPACE {
+// Previous declaration of TraceSpan is struct. Must match the same here.
+struct TraceSpan;
+} // namespace KINETO_NAMESPACE
+
+namespace KINETO_NAMESPACE {
+
+class ArgsBuilder;
+class Config;
+
+struct pgConfig {
+  pgConfig() = default;
+  std::string pg_name;
+  std::string pg_desc;
+  std::string backend_config;
+  std::string pg_size;
+  std::string ranks;
+};
+
+struct DistributedInfo {
+  DistributedInfo() = default;
+
+  std::string backend;
+  std::string rank;
+  std::string world_size;
+  std::string pg_count;
+  std::string nccl_version;
+  bool distInfo_present_{false};
+};
+
+class ChromeTraceLogger : public libkineto::ActivityLogger {
+ public:
+  explicit ChromeTraceLogger(const std::string& traceFileName);
+
+  // Note: the caller of these functions should handle concurrency
+  // i.e., we these functions are not thread-safe
+  void handleDeviceInfo(const DeviceInfo& info, int64_t time) override;
+
+  void handleOverheadInfo(const OverheadInfo& info, int64_t time) override;
+
+  void handleResourceInfo(const ResourceInfo& info, int64_t time) override;
+
+  void handleTraceSpan(const TraceSpan& span) override;
+
+  void handleActivity(const ITraceActivity& activity) override;
+  void handleGenericActivity(const GenericTraceActivity& activity) override;
+
+  void handleTraceStart(
+      const std::unordered_map<std::string, std::string>& metadata,
+      const std::string& device_properties) override;
+
+  void finalizeTrace(
+      const Config& config,
+      std::unique_ptr<ActivityBuffers> buffers,
+      int64_t endTime) override;
+
+  void finalizeMemoryTrace(const std::string&, const Config&) override;
+
+  std::string traceFileName() const {
+    return fileName_;
+  }
+
+ protected:
+  void finalizeTrace(int64_t endTime);
+
+ private:
+  // Create a flow event (arrow)
+  void handleLink(
+      char type,
+      const ITraceActivity& e,
+      int64_t id,
+      const std::string& name);
+
+  void addIterationMarker(const TraceSpan& span);
+
+  void openTraceFile();
+
+  void handleGenericInstantEvent(const ITraceActivity& op);
+
+  void handleCounterEvent(const ITraceActivity& op);
+
+  void handleGenericLink(const ITraceActivity& activity);
+
+  void metadataToJSON(
+      const std::unordered_map<std::string, std::string>& metadata);
+
+  std::unordered_map<std::string, std::string> addEnvVarsToMetadata(
+      const std::unordered_map<std::string, std::string>& metadata);
+
+  void addOnDemandDistMetadata();
+
+  // Chrome Trace event writer helpers.
+  // The string_view pid/tid variants are the canonical implementations.
+  // Integer overloads are provided for convenience at call sites with
+  // numeric process/thread IDs.
+  void writeMetadataEvent(
+      std::string_view name,
+      int64_t ts,
+      std::string_view pid,
+      std::string_view tid,
+      std::string_view arg_key,
+      std::string_view arg_value);
+
+  void writeMetadataEvent(
+      std::string_view name,
+      int64_t ts,
+      int64_t pid,
+      int64_t tid,
+      std::string_view arg_key,
+      std::string_view arg_value);
+
+  void writeCompleteEvent(
+      std::string_view cat,
+      std::string_view name,
+      std::string_view pid,
+      std::string_view tid,
+      int64_t ts,
+      int64_t dur,
+      const ArgsBuilder& args);
+
+  void writeCompleteEvent(
+      std::string_view cat,
+      std::string_view name,
+      int64_t pid,
+      int64_t tid,
+      int64_t ts,
+      int64_t dur,
+      const ArgsBuilder& args);
+
+  void writeInstantEvent(
+      std::string_view cat,
+      std::string_view name,
+      std::string_view scope,
+      std::string_view pid,
+      std::string_view tid,
+      int64_t ts,
+      const ArgsBuilder& args,
+      bool finalEvent = false);
+
+  void writeInstantEvent(
+      std::string_view cat,
+      std::string_view name,
+      std::string_view scope,
+      int64_t pid,
+      int64_t tid,
+      int64_t ts,
+      const ArgsBuilder& args,
+      bool finalEvent = false);
+
+  void writeCounterEvent(
+      std::string_view cat,
+      std::string_view name,
+      std::string_view pid,
+      std::string_view tid,
+      int64_t ts,
+      const ArgsBuilder& args);
+
+  void writeCounterEvent(
+      std::string_view cat,
+      std::string_view name,
+      int64_t pid,
+      int64_t tid,
+      int64_t ts,
+      const ArgsBuilder& args);
+
+  void writeFlowEvent(
+      char type,
+      int64_t id,
+      std::string_view pid,
+      std::string_view tid,
+      int64_t ts,
+      std::string_view cat,
+      std::string_view name);
+
+  void writeFlowEvent(
+      char type,
+      int64_t id,
+      int64_t pid,
+      int64_t tid,
+      int64_t ts,
+      std::string_view cat,
+      std::string_view name);
+
+  // Copy the collective args (name, message sizes, dtype, process group, ranks,
+  // seq, ...) recorded on a record_param_comms op into args. Backend-agnostic.
+  void appendCollectiveArgs(
+      ArgsBuilder& args,
+      const ITraceActivity& collectiveRecord);
+
+  // Enrich a device collective row from its linked record_param_comms op: copy
+  // the collective args and fold its process group into the trace's
+  // distributedInfo under the given backend labels.
+  void appendCollectiveMetadata(
+      ArgsBuilder& args,
+      const ITraceActivity& collectiveRecord,
+      const std::string& backend,
+      const std::string& backendConfig);
+
+  std::string fileName_;
+  std::string tempFileName_;
+  std::ofstream traceOf_;
+  DistributedInfo distInfo_ = DistributedInfo();
+  // Map of all observed process groups to their configs in trace. Key is
+  // pg_name, value is pgConfig that will be used to populate pg_config in
+  // distributedInfo of trace
+  std::unordered_map<std::string, pgConfig> pgMap_ = {};
+
+  // Offset added to stream ID for CUDA_SYNC events to place them on a
+  // separate row from kernel events in the Chrome Trace JSON output.
+  static constexpr int64_t kSyncStreamTidOffset = 1000000;
+
+  // Tracks which (device, virtualTid) pairs have had thread_name metadata
+  // emitted, to avoid duplicates.
+  std::unordered_set<int64_t> syncStreamMetadataEmitted_;
+};
+
+// std::chrono header start
+#ifdef _GLIBCXX_USE_C99_STDINT_TR1
+#define _KINETO_GLIBCXX_CHRONO_INT64_T int64_t
+#elif defined __INT64_TYPE__
+#define _KINETO_GLIBCXX_CHRONO_INT64_T __INT64_TYPE__
+#else
+#define _KINETO_GLIBCXX_CHRONO_INT64_T long long
+#endif
+// std::chrono header end
+
+// There are tools like Chrome Trace Viewer that uses double to represent
+// each element in the timeline. Double has a 53 bit mantissa to support
+// up to 2^53 significant digits (up to 9007199254740992). This holds at the
+// nanosecond level, about 3 months and 12 days. So, let's round base time to
+// 3 months intervals, so we can still collect traces across ranks relative
+// to each other.
+// A month is 2629746, so 3 months is 7889238.
+using _trimonths =
+    std::chrono::duration<_KINETO_GLIBCXX_CHRONO_INT64_T, std::ratio<7889238>>;
+#undef _GLIBCXX_CHRONO_INT64_T
+
+class ChromeTraceBaseTime {
+ public:
+  ChromeTraceBaseTime() = default;
+  static ChromeTraceBaseTime& singleton();
+  void init() {
+    get();
+  }
+  int64_t get() {
+    // Make all timestamps relative to 3 month intervals.
+    static int64_t base_time = libkineto::timeSinceEpoch(
+        std::chrono::time_point<std::chrono::system_clock>(
+            std::chrono::floor<_trimonths>(std::chrono::system_clock::now())));
+    return base_time;
+  }
+};
+
+int64_t transToRelativeTime(int64_t time);
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/output_membuf.h
+++ b/third_party/kineto/libkineto/src/output_membuf.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ActivityBuffers.h"
+#include "Config.h"
+#include "GenericTraceActivity.h"
+#include "Logger.h"
+#include "output_base.h"
+
+namespace KINETO_NAMESPACE {
+
+class Config;
+
+class MemoryTraceLogger : public ActivityLogger {
+ public:
+  MemoryTraceLogger(const Config& config) : config_(config.clone()) {
+    activities_.reserve(100000);
+  }
+
+  // Note: the caller of these functions should handle concurrency
+  // i.e., these functions are not thread-safe
+  void handleDeviceInfo(const DeviceInfo& info, int64_t time) override {
+    deviceInfoList_.emplace_back(info, time);
+  }
+
+  void handleResourceInfo(const ResourceInfo& info, int64_t time) override {
+    resourceInfoList_.emplace_back(info, time);
+  }
+
+  void handleOverheadInfo(
+      [[maybe_unused]] const OverheadInfo& info,
+      [[maybe_unused]] int64_t time) override {}
+
+  void handleTraceSpan([[maybe_unused]] const TraceSpan& span) override {
+    // Handled separately
+  }
+
+  template <class T>
+  void addActivityWrapper(const T& act) {
+    wrappers_.push_back(std::make_unique<T>(act));
+    activities_.push_back(wrappers_.back().get());
+  }
+
+  // Just add the pointer to the list - ownership of the underlying
+  // objects must be transferred in ActivityBuffers via finalizeTrace
+  void handleActivity(const ITraceActivity& activity) override {
+    activities_.push_back(&activity);
+  }
+  void handleGenericActivity(const GenericTraceActivity& activity) override {
+    addActivityWrapper(activity);
+  }
+
+  void handleTraceStart(
+      const std::unordered_map<std::string, std::string>& metadata,
+      const std::string& device_properties) override {
+    metadata_ = metadata;
+    device_properties_ = device_properties;
+  }
+
+  void finalizeTrace(
+      [[maybe_unused]] const Config& config,
+      std::unique_ptr<ActivityBuffers> buffers,
+      int64_t endTime) override {
+    buffers_ = std::move(buffers);
+    endTime_ = endTime;
+  }
+
+  void finalizeMemoryTrace(const std::string&, const Config&) override {
+    LOG(INFO) << "finalizeMemoryTrace not implemented for MemLogger";
+  }
+
+  const std::vector<const ITraceActivity*>* traceActivities() {
+    return &activities_;
+  }
+
+  void log(ActivityLogger& logger) {
+    logger.handleTraceStart(metadata_, device_properties_);
+    for (auto& p : deviceInfoList_) {
+      logger.handleDeviceInfo(p.first, p.second);
+    }
+    for (auto& p : resourceInfoList_) {
+      logger.handleResourceInfo(p.first, p.second);
+    }
+    for (auto& activity : activities_) {
+      activity->log(logger);
+    }
+    for (auto& cpu_trace_buffer : buffers_->cpu) {
+      logger.handleTraceSpan(cpu_trace_buffer->span);
+    }
+    // Hold on to the buffers
+    logger.finalizeTrace(*config_, nullptr, endTime_);
+  }
+
+  void setChromeLogger(std::shared_ptr<ActivityLogger> logger) {
+    chrome_logger_ = std::move(logger);
+  }
+
+  std::shared_ptr<ActivityLogger> getChromeLogger() {
+    return chrome_logger_;
+  }
+
+ private:
+  std::unique_ptr<Config> config_;
+  // Optimization: Remove unique_ptr by keeping separate vector per type
+  std::vector<const ITraceActivity*> activities_;
+  std::vector<std::unique_ptr<const ITraceActivity>> wrappers_;
+  std::vector<std::pair<DeviceInfo, int64_t>> deviceInfoList_;
+  std::vector<std::pair<ResourceInfo, int64_t>> resourceInfoList_;
+  std::unique_ptr<ActivityBuffers> buffers_;
+  std::unordered_map<std::string, std::string> metadata_;
+  std::string device_properties_;
+  int64_t endTime_{0};
+  std::shared_ptr<ActivityLogger> chrome_logger_;
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/CMakeLists.txt
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/CMakeLists.txt
@@ -1,0 +1,62 @@
+# xpupti: XPU implementation for kineto profiler
+# outputs:
+#  SYCL_INCLUDE_DIR   --  SYCL include dir
+#  SYCL_LIBRARY       --  SYCL library file
+#  XPU_xpupti_LIBRARY --  XPUPTI dependencies lib
+#  XPUPTI_BUILD_FLAG  --  XPUPTI build flags
+
+if((NOT SYCL_INCLUDE_DIR) OR (NOT SYCL_LIBRARY_DIR))
+    include(FindSYCLToolkit.cmake)
+    if(NOT SYCLTOOLKIT_FOUND)
+        message(FATAL_ERROR
+            "KINETO_BACKEND=xpu but SYCL toolkit was not found: "
+            "${SYCL_NOT_FOUND_MESSAGE}. "
+            "Install the SYCL toolkit or set KINETO_BACKEND=cpu.")
+    endif()
+endif()
+
+message(STATUS " SYCL_INCLUDE_DIR = ${SYCL_INCLUDE_DIR}")
+message(STATUS " SYCL_LIBRARY = ${SYCL_LIBRARY}")
+
+set(XPUPTI_INCLUDE_DIR ${SYCL_INCLUDE_DIR})
+
+# find xpupti sdk
+find_package(Pti REQUIRED)
+if(TARGET Pti::pti_view)
+    message(STATUS " Found XPUPTI")
+
+    set(pti_view_names)
+    # For Linux, due to it has soft link original file name is fine.
+    list(APPEND pti_view_names pti_view)
+    # For Windows, file name to be appended with version number.
+    foreach(ver_major RANGE 0 1)
+        foreach(ver_minor RANGE 0 19)
+        list(APPEND pti_view_names pti_view-${ver_major}-${ver_minor})
+        endforeach()
+    endforeach()
+
+    get_target_property(PTI_INCLUDE_DIR Pti::pti_view INTERFACE_INCLUDE_DIRECTORIES)
+    find_library(PTI_VIEW_LIBRARY NAMES ${pti_view_names} PATHS "${PTI_INCLUDE_DIR}/../lib")
+    set(PTI_LIBRARY ${PTI_VIEW_LIBRARY} CACHE STRING "Imported PTI library.")
+    set(PTI_INCLUDE_DIR ${PTI_INCLUDE_DIR} CACHE STRING "PTI include directory.")
+
+    # find dependent lib
+    set(XPU_xpupti_LIBRARY ${SYCL_LIBRARY})
+    list(APPEND XPU_xpupti_LIBRARY ${PTI_LIBRARY})
+    set(XPU_xpupti_LIBRARY ${XPU_xpupti_LIBRARY} PARENT_SCOPE)
+
+    # find dependent include
+    list(APPEND XPUPTI_INCLUDE_DIR ${PTI_INCLUDE_DIR})
+    set(XPUPTI_INCLUDE_DIR ${XPUPTI_INCLUDE_DIR} PARENT_SCOPE)
+
+    set(XPUPTI_BUILD_FLAG "-DHAS_XPUPTI")
+    set(XPUPTI_BUILD_FLAG ${XPUPTI_BUILD_FLAG} PARENT_SCOPE)
+
+    message(STATUS " XPU_xpupti_LIBRARY = ${XPU_xpupti_LIBRARY}")
+    message(STATUS " XPUPTI_INCLUDE_DIR = ${XPUPTI_INCLUDE_DIR}")
+    message(STATUS " XPUPTI_BUILD_FLAG = ${XPUPTI_BUILD_FLAG}")
+else()
+    message(FATAL_ERROR
+        "KINETO_BACKEND=xpu but XPUPTI (Pti::pti_view) was not found. "
+        "Install Intel PTI or set KINETO_BACKEND=cpu.")
+endif()

--- a/third_party/kineto/libkineto/src/plugin/xpupti/FindSYCLToolkit.cmake
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/FindSYCLToolkit.cmake
@@ -1,0 +1,109 @@
+#[=======================================================================[.rst:
+SYCLConfig
+-------
+
+Library to verify SYCL compatability of CMAKE_CXX_COMPILER
+and passes relevant compiler flags.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``SYCLTOOLKIT_FOUND``
+  True if the system has the SYCL library.
+``SYCL_COMPILER``
+  SYCL compiler executable.
+``SYCL_INCLUDE_DIR``
+  Include directories needed to use SYCL.
+``SYCL_LIBRARY_DIR``
+  Libaray directories needed to use SYCL.
+
+#]=======================================================================]
+
+set(SYCLTOOLKIT_FOUND False)
+include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
+
+set(SYCL_ROOT "")
+if(DEFINED ENV{SYCL_ROOT})
+  set(SYCL_ROOT $ENV{SYCL_ROOT})
+elseif(DEFINED ENV{CMPLR_ROOT})
+  set(SYCL_ROOT $ENV{CMPLR_ROOT})
+endif()
+
+if(WIN32)
+  set(SYCL_EXECUTABLE_NAME icx)
+else()
+  set(SYCL_EXECUTABLE_NAME icpx)
+endif()
+
+if(NOT SYCL_ROOT)
+  execute_process(
+    COMMAND which ${SYCL_EXECUTABLE_NAME}
+    OUTPUT_VARIABLE SYCL_CMPLR_FULL_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(NOT EXISTS "${SYCL_CMPLR_FULL_PATH}")
+    message(WARNING "Cannot find ENV{CMPLR_ROOT} or icpx, please setup SYCL compiler Tool kit enviroment before building!!")
+    return()
+  endif()
+
+  get_filename_component(SYCL_BIN_DIR "${SYCL_CMPLR_FULL_PATH}" DIRECTORY)
+  set(SYCL_ROOT ${SYCL_BIN_DIR}/..)
+endif()
+
+find_program(
+  SYCL_COMPILER
+  NAMES ${SYCL_EXECUTABLE_NAME}
+  PATHS "${SYCL_ROOT}"
+  PATH_SUFFIXES bin bin64
+  NO_DEFAULT_PATH
+  )
+
+string(COMPARE EQUAL "${SYCL_COMPILER}" "" nocmplr)
+if(nocmplr)
+  set(SYCLTOOLKIT_FOUND False)
+  set(SYCL_REASON_FAILURE "SYCL: CMAKE_CXX_COMPILER not set!!")
+  set(SYCL_NOT_FOUND_MESSAGE "${SYCL_REASON_FAILURE}")
+endif()
+
+find_file(
+  SYCL_INCLUDE_DIR
+  NAMES include
+  HINTS ${SYCL_ROOT}
+  NO_DEFAULT_PATH
+  )
+
+find_file(
+  SYCL_INCLUDE_SYCL_DIR
+  NAMES sycl
+  HINTS ${SYCL_ROOT}/include
+  NO_DEFAULT_PATH
+  )
+
+list(APPEND SYCL_INCLUDE_DIR ${SYCL_INCLUDE_SYCL_DIR})
+
+find_file(
+  SYCL_LIBRARY_DIR
+  NAMES lib lib64
+  HINTS ${SYCL_ROOT}
+  NO_DEFAULT_PATH
+  )
+
+find_library(
+  SYCL_LIBRARY
+  NAMES sycl
+  HINTS ${SYCL_LIBRARY_DIR}
+  NO_DEFAULT_PATH
+  )
+
+if((NOT SYCL_INCLUDE_DIR) OR (NOT SYCL_LIBRARY_DIR) OR (NOT SYCL_LIBRARY))
+  set(SYCLTOOLKIT_FOUND False)
+  set(SYCL_REASON_FAILURE "SYCL sdk is incomplete!!")
+  set(SYCL_NOT_FOUND_MESSAGE "${SYCL_REASON_FAILURE}")
+  return()
+endif()
+
+message(DEBUG "The SYCL compiler is ${SYCL_COMPILER}")
+
+set(SYCLTOOLKIT_FOUND True)

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityApi.cpp
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityApi.cpp
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "XpuptiActivityApi.h"
+
+#include <chrono>
+#include <filesystem>
+#include <stdexcept>
+
+#include "Logger.h"
+
+namespace KINETO_NAMESPACE {
+
+constexpr size_t kBufSize(4 * 1024 * 1024);
+
+XpuptiActivityApi& XpuptiActivityApi::singleton() {
+  static XpuptiActivityApi instance;
+  return instance;
+}
+
+void XpuptiActivityApi::pushCorrelationID(int id, CorrelationFlowType type) {
+  if (!singleton().externalCorrelationEnabled_) {
+    return;
+  }
+  switch (type) {
+    case Default:
+      XPUPTI_CALL(ptiViewPushExternalCorrelationId(
+          pti_view_external_kind::PTI_VIEW_EXTERNAL_KIND_CUSTOM_0, id));
+      break;
+    case User:
+      XPUPTI_CALL(ptiViewPushExternalCorrelationId(
+          pti_view_external_kind::PTI_VIEW_EXTERNAL_KIND_CUSTOM_1, id));
+  }
+}
+
+void XpuptiActivityApi::popCorrelationID(CorrelationFlowType type) {
+  if (!singleton().externalCorrelationEnabled_) {
+    return;
+  }
+  switch (type) {
+    case Default:
+      XPUPTI_CALL(ptiViewPopExternalCorrelationId(
+          pti_view_external_kind::PTI_VIEW_EXTERNAL_KIND_CUSTOM_0, nullptr));
+      break;
+    case User:
+      XPUPTI_CALL(ptiViewPopExternalCorrelationId(
+          pti_view_external_kind::PTI_VIEW_EXTERNAL_KIND_CUSTOM_1, nullptr));
+  }
+}
+
+static bool nextActivityRecord(
+    uint8_t* buffer,
+    size_t valid_size,
+    pti_view_record_base*& record) {
+  pti_result status = ptiViewGetNextRecord(buffer, valid_size, &record);
+  if (status != pti_result::PTI_SUCCESS) {
+    record = nullptr;
+  }
+  return record != nullptr;
+}
+
+void XpuptiActivityApi::bufferRequestedTrampoline(
+    uint8_t** buffer,
+    size_t* size) {
+  singleton().bufferRequested(buffer, size);
+}
+
+void XpuptiActivityApi::bufferRequested(uint8_t** buffer, size_t* size) {
+  std::lock_guard<std::mutex> guard(mutex_);
+
+  auto buf = std::make_unique<XpuptiActivityBuffer>(kBufSize);
+  *buffer = buf->data();
+  *size = kBufSize;
+
+  allocatedGpuTraceBuffers_[*buffer] = std::move(buf);
+}
+
+std::unique_ptr<XpuptiActivityBufferMap> XpuptiActivityApi::activityBuffers() {
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (allocatedGpuTraceBuffers_.empty()) {
+      return nullptr;
+    }
+  }
+
+  std::chrono::time_point<std::chrono::system_clock> t1;
+  XPUPTI_CALL(ptiFlushAllViews());
+
+  std::lock_guard<std::mutex> guard(mutex_);
+  return std::move(readyGpuTraceBuffers_);
+}
+
+int XpuptiActivityApi::processActivitiesForBuffer(
+    uint8_t* buf,
+    size_t validSize,
+    std::function<void(const pti_view_record_base*)> handler) {
+  int count = 0;
+  if (buf && validSize) {
+    pti_view_record_base* record{nullptr};
+    while (nextActivityRecord(buf, validSize, record)) {
+      handler(record);
+      ++count;
+    }
+  }
+  return count;
+}
+
+const std::pair<int, int> XpuptiActivityApi::processActivities(
+    XpuptiActivityBufferMap& buffers,
+    std::function<void(const pti_view_record_base*)> handler) {
+  std::pair<int, int> res{0, 0};
+  for (auto& pair : buffers) {
+    auto& buf = pair.second;
+    res.first += processActivitiesForBuffer(buf->data(), buf->size(), handler);
+    res.second += buf->size();
+  }
+  return res;
+}
+
+void XpuptiActivityApi::flushActivities() {
+  XPUPTI_CALL(ptiFlushAllViews());
+}
+
+void XpuptiActivityApi::clearActivities() {
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (allocatedGpuTraceBuffers_.empty()) {
+      return;
+    }
+  }
+  XPUPTI_CALL(ptiFlushAllViews());
+  std::lock_guard<std::mutex> guard(mutex_);
+  readyGpuTraceBuffers_ = nullptr;
+}
+
+void XpuptiActivityApi::bufferCompletedTrampoline(
+    uint8_t* buffer,
+    size_t size,
+    size_t validSize) {
+  singleton().bufferCompleted(buffer, size, validSize);
+}
+
+void XpuptiActivityApi::bufferCompleted(
+    uint8_t* buffer,
+    [[maybe_unused]] size_t size,
+    size_t validSize) {
+  std::lock_guard<std::mutex> guard(mutex_);
+  auto it = allocatedGpuTraceBuffers_.find(buffer);
+
+  if (!readyGpuTraceBuffers_) {
+    readyGpuTraceBuffers_ = std::make_unique<XpuptiActivityBufferMap>();
+  }
+  it->second->setSize(validSize);
+  (*readyGpuTraceBuffers_)[it->first] = std::move(it->second);
+  allocatedGpuTraceBuffers_.erase(it);
+}
+
+namespace {
+void warnIfIttNotifyLibInvalid() noexcept {
+  const auto itt_collector_path_env = std::getenv("INTEL_LIBITTNOTIFY64");
+  if (itt_collector_path_env == nullptr) {
+    LOG(WARNING) << "ENV variable `INTEL_LIBITTNOTIFY64` not set. "
+                 << "XCCL host calls will not be collected.";
+    return;
+  }
+
+  const std::filesystem::path itt_collector_path(itt_collector_path_env);
+
+  if (itt_collector_path.is_relative()) {
+    LOG(WARNING) << "`INTEL_LIBITTNOTIFY64` contains a relative path, "
+                 << "an absolute path is recommended.";
+  }
+
+  std::error_code ec;
+  if (not std::filesystem::exists(itt_collector_path, ec)) {
+    LOG(WARNING)
+        << "The library pointed to by `INTEL_LIBITTNOTIFY64` does not exist. "
+        << "XCCL host calls will not be collected.";
+  }
+}
+} // namespace
+
+void XpuptiActivityApi::enableXpuptiActivities(
+    const std::set<ActivityType>& selected_activities) {
+  XPUPTI_CALL(ptiViewSetCallbacks(
+      bufferRequestedTrampoline, bufferCompletedTrampoline));
+
+  externalCorrelationEnabled_ = false;
+  for (const auto& activity : selected_activities) {
+    switch (activity) {
+      case ActivityType::GPU_MEMCPY:
+        XPUPTI_CALL(ptiViewEnable(PTI_VIEW_DEVICE_GPU_MEM_COPY));
+        break;
+
+      case ActivityType::GPU_MEMSET:
+        XPUPTI_CALL(ptiViewEnable(PTI_VIEW_DEVICE_GPU_MEM_FILL));
+        break;
+
+      case ActivityType::CONCURRENT_KERNEL:
+        XPUPTI_CALL(ptiViewEnable(PTI_VIEW_DEVICE_GPU_KERNEL));
+        break;
+
+      case ActivityType::EXTERNAL_CORRELATION:
+        XPUPTI_CALL(ptiViewEnable(PTI_VIEW_EXTERNAL_CORRELATION));
+        externalCorrelationEnabled_ = true;
+        break;
+
+      case ActivityType::XPU_RUNTIME:
+        XPUPTI_CALL(ptiViewEnable(PTI_VIEW_RUNTIME_API));
+        XPUPTI_CALL(ptiViewEnableRuntimeApiClass(
+            1, PTI_API_CLASS_GPU_OPERATION_CORE, PTI_API_GROUP_ALL));
+        break;
+
+      case ActivityType::XPU_DRIVER:
+        XPUPTI_CALL(ptiViewEnable(PTI_VIEW_DRIVER_API));
+        break;
+
+      case ActivityType::XPU_SCOPE_PROFILER:
+        // This case is handled in constructor of
+        // XpuptiScopeProfilerSession
+        break;
+
+      case ActivityType::OVERHEAD:
+        XPUPTI_CALL(ptiViewEnable(PTI_VIEW_COLLECTION_OVERHEAD));
+        break;
+
+      case ActivityType::XPU_SYNC:
+        XPUPTI_CALL(ptiViewEnable(PTI_VIEW_DEVICE_SYNCHRONIZATION));
+        break;
+
+      case ActivityType::COLLECTIVE_COMM:
+        warnIfIttNotifyLibInvalid();
+        XPUPTI_CALL(ptiViewEnable(PTI_VIEW_COMMUNICATION));
+        break;
+
+      default:
+        break;
+    }
+  }
+}
+
+void XpuptiActivityApi::disablePtiActivities(
+    const std::set<ActivityType>& selected_activities) {
+  for (const auto& activity : selected_activities) {
+    switch (activity) {
+      case ActivityType::GPU_MEMCPY:
+        XPUPTI_CALL(ptiViewDisable(PTI_VIEW_DEVICE_GPU_MEM_COPY));
+        break;
+
+      case ActivityType::GPU_MEMSET:
+        XPUPTI_CALL(ptiViewDisable(PTI_VIEW_DEVICE_GPU_MEM_FILL));
+        break;
+
+      case ActivityType::CONCURRENT_KERNEL:
+        XPUPTI_CALL(ptiViewDisable(PTI_VIEW_DEVICE_GPU_KERNEL));
+        break;
+
+      case ActivityType::EXTERNAL_CORRELATION:
+        XPUPTI_CALL(ptiViewDisable(PTI_VIEW_EXTERNAL_CORRELATION));
+        break;
+
+      case ActivityType::XPU_RUNTIME:
+        XPUPTI_CALL(ptiViewDisable(PTI_VIEW_RUNTIME_API));
+        break;
+
+      case ActivityType::XPU_DRIVER:
+        XPUPTI_CALL(ptiViewDisable(PTI_VIEW_DRIVER_API));
+        break;
+
+      case ActivityType::OVERHEAD:
+        XPUPTI_CALL(ptiViewDisable(PTI_VIEW_COLLECTION_OVERHEAD));
+        break;
+
+      case ActivityType::XPU_SYNC:
+        XPUPTI_CALL(ptiViewDisable(PTI_VIEW_DEVICE_SYNCHRONIZATION));
+        break;
+
+      case ActivityType::COLLECTIVE_COMM:
+        XPUPTI_CALL(ptiViewDisable(PTI_VIEW_COMMUNICATION));
+        break;
+
+      default:
+        break;
+    }
+  }
+  externalCorrelationEnabled_ = false;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityApi.h
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityApi.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "XpuptiActivityBuffer.h"
+#include "XpuptiProfilerMacros.h"
+
+#include "ActivityType.h"
+
+#include <pti/pti_view.h>
+
+#include <functional>
+#include <mutex>
+
+namespace KINETO_NAMESPACE {
+
+class XpuptiActivityApi {
+ public:
+  enum CorrelationFlowType { Default, User };
+
+  XpuptiActivityApi() = default;
+  XpuptiActivityApi(const XpuptiActivityApi&) = delete;
+  XpuptiActivityApi& operator=(const XpuptiActivityApi&) = delete;
+
+  virtual ~XpuptiActivityApi() {}
+
+  static XpuptiActivityApi& singleton();
+
+  static void pushCorrelationID(int id, CorrelationFlowType type);
+  static void popCorrelationID(CorrelationFlowType type);
+
+  void enableXpuptiActivities(
+      const std::set<ActivityType>& selected_activities);
+  void disablePtiActivities(const std::set<ActivityType>& selected_activities);
+  void clearActivities();
+  void flushActivities();
+
+  virtual std::unique_ptr<XpuptiActivityBufferMap> activityBuffers();
+
+  virtual const std::pair<int, int> processActivities(
+      XpuptiActivityBufferMap&,
+      std::function<void(const pti_view_record_base*)> handler);
+
+ private:
+  XpuptiActivityBufferMap allocatedGpuTraceBuffers_;
+  std::unique_ptr<XpuptiActivityBufferMap> readyGpuTraceBuffers_;
+  std::mutex mutex_;
+  bool externalCorrelationEnabled_{false};
+
+  int processActivitiesForBuffer(
+      uint8_t* buf,
+      size_t validSize,
+      std::function<void(const pti_view_record_base*)> handler);
+  static void bufferRequestedTrampoline(uint8_t** buffer, size_t* size);
+  static void bufferCompletedTrampoline(
+      uint8_t* buffer,
+      size_t size,
+      size_t validSize);
+
+ protected:
+  void bufferRequested(uint8_t** buffer, size_t* size);
+  void bufferCompleted(uint8_t* buffer, size_t size, size_t validSize);
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityBuffer.h
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityBuffer.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace KINETO_NAMESPACE {
+
+class XpuptiActivityBuffer {
+ public:
+  explicit XpuptiActivityBuffer(size_t size) : size_(size) {
+    buf_.reserve(size);
+  }
+  XpuptiActivityBuffer() = delete;
+  XpuptiActivityBuffer& operator=(const XpuptiActivityBuffer&) = delete;
+  XpuptiActivityBuffer(XpuptiActivityBuffer&&) = default;
+  XpuptiActivityBuffer& operator=(XpuptiActivityBuffer&&) = default;
+
+  size_t size() const {
+    return size_;
+  }
+
+  void setSize(size_t size) {
+    assert(size <= buf_.capacity());
+    size_ = size;
+  }
+
+  uint8_t* data() {
+    return buf_.data();
+  }
+
+ private:
+  std::vector<uint8_t> buf_;
+  size_t size_;
+};
+
+using XpuptiActivityBufferMap =
+    std::map<uint8_t*, std::unique_ptr<XpuptiActivityBuffer>>;
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
@@ -1,0 +1,566 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "XpuptiActivityProfilerSession.h"
+#include "output_json.h"
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+namespace KINETO_NAMESPACE {
+
+// =========== Session Private Methods ============= //
+void XpuptiActivityProfilerSession::removeCorrelatedPtiActivities(
+    const ITraceActivity* act1) {
+  correlatedPtiActivities_.erase(act1->correlationId());
+}
+
+void XpuptiActivityProfilerSession::checkTimestampOrder(
+    const ITraceActivity* act1) {
+  auto [it, inserted] =
+      correlatedPtiActivities_.insert({act1->correlationId(), act1});
+  if (inserted) {
+    return;
+  }
+
+  const ITraceActivity* act2 = it->second;
+  if (act2->type() == ActivityType::XPU_RUNTIME) {
+    std::swap(act1, act2);
+  }
+  if (act1->timestamp() > act2->timestamp()) {
+    std::string err_msg;
+    err_msg += "GPU op timestamp (" + std::to_string(act2->timestamp());
+    err_msg += ") < runtime timestamp (" + std::to_string(act1->timestamp());
+    err_msg += ") by " + std::to_string(act1->timestamp() - act2->timestamp());
+    err_msg += "us Name: " + act2->name();
+    err_msg += " Device: " + std::to_string(act2->deviceId());
+    err_msg += " Queue: " + std::to_string(act2->resourceId());
+    errors_.push_back(err_msg);
+  }
+}
+
+inline bool XpuptiActivityProfilerSession::outOfRange(
+    const ITraceActivity* act) {
+  bool outOfRange = act->timestamp() < captureWindowStartTime_ ||
+      (act->timestamp() + act->duration()) > captureWindowEndTime_;
+  if (outOfRange) {
+    std::string err_msg;
+    err_msg += "TraceActivity outside of profiling window: " + act->name();
+    err_msg += " (" + std::to_string(act->timestamp());
+    err_msg += " < " + std::to_string(captureWindowStartTime_);
+    err_msg += " or " + std::to_string(act->timestamp() + act->duration());
+    err_msg += " > " + std::to_string(captureWindowEndTime_);
+    errors_.push_back(err_msg);
+  }
+  return outOfRange;
+}
+
+const ITraceActivity* XpuptiActivityProfilerSession::linkedActivity(
+    int32_t correlationId,
+    const std::unordered_map<int64_t, int64_t>& correlationMap) {
+  const auto& it = correlationMap.find(correlationId);
+  if (it != correlationMap.end()) {
+    return cpuActivity_(it->second);
+  }
+  return nullptr;
+}
+
+template <class ze_handle_type>
+inline std::string handleToHexString(ze_handle_type handle) {
+  return fmt::format("0x{:016x}", reinterpret_cast<uintptr_t>(handle));
+}
+
+inline void XpuptiActivityProfilerSession::handleCorrelationActivity(
+    const pti_view_record_external_correlation* correlation) {
+  switch (correlation->_external_kind) {
+    case PTI_VIEW_EXTERNAL_KIND_CUSTOM_0:
+      cpuCorrelationMap_[correlation->_correlation_id] =
+          correlation->_external_id;
+      break;
+    case PTI_VIEW_EXTERNAL_KIND_CUSTOM_1:
+      userCorrelationMap_[correlation->_correlation_id] =
+          correlation->_external_id;
+      break;
+    default:
+      errors_.push_back(
+          "Invalid PTI External Correlation activity sent to handlePtiActivity");
+  }
+}
+
+inline std::string memcpyName(
+    pti_view_memcpy_type kind,
+    pti_view_memory_type src,
+    pti_view_memory_type dst) {
+  return fmt::format(
+      "Memcpy {} ({} -> {})",
+      ptiViewMemcpyTypeToString(kind),
+      ptiViewMemoryTypeToString(src),
+      ptiViewMemoryTypeToString(dst));
+}
+
+inline std::string memsetName(pti_view_memory_type type, uint64_t val) {
+  return fmt::format("Memset ({} -> {})", val, ptiViewMemoryTypeToString(type));
+}
+
+template <class pti_view_memory_record_type>
+inline std::string bandwidth(pti_view_memory_record_type* activity) {
+  auto duration = activity->_end_timestamp - activity->_start_timestamp;
+  auto bytes = activity->_bytes;
+  return duration == 0 ? "\"N/A\"" : fmt::format("{}", bytes * 1.0 / duration);
+}
+
+void XpuptiActivityProfilerSession::addResouceInfo(
+    int32_t device_id,
+    int32_t sycl_queue_id) {
+  if (std::find_if(
+          resourceInfo_.begin(),
+          resourceInfo_.end(),
+          [device_id, sycl_queue_id](std::pair<int32_t, int32_t> pair) {
+            return (pair.first == device_id) && (pair.second == sycl_queue_id);
+          }) == resourceInfo_.end()) {
+    resourceInfo_.emplace_back(device_id, sycl_queue_id);
+  }
+}
+
+template <class T>
+inline std::string formatTimeLikeOutputJson(T time) {
+  return fmt::format("{}.{:03}", time / 1000, abs(time) % 1000);
+}
+
+inline int64_t signedFromUnsignedDiff(uint64_t time, uint64_t time_ref) {
+  if (time >= time_ref) {
+    return static_cast<int64_t>(time - time_ref);
+  } else {
+    return -static_cast<int64_t>(time_ref - time);
+  }
+}
+
+static void addTimestampMetadata(
+    GenericTraceActivity* trace_activity,
+    std::string&& label,
+    uint64_t time,
+    uint64_t time_ref) {
+  trace_activity->addMetadataQuoted(
+      label, formatTimeLikeOutputJson(transToRelativeTime(time)));
+  label += "_rel_to_start";
+  trace_activity->addMetadataQuoted(
+      label, formatTimeLikeOutputJson(signedFromUnsignedDiff(time, time_ref)));
+}
+
+template <class pti_view_memory_record_type>
+void XpuptiActivityProfilerSession::handleRuntimeKernelMemcpyMemsetActivities(
+    ActivityType activityType,
+    const pti_view_memory_record_type* activity,
+    ActivityLogger& logger) {
+  constexpr bool handleRuntimeActivities =
+      std::is_same_v<pti_view_memory_record_type, pti_view_record_api_t>;
+  constexpr bool handleKernelActivities =
+      std::is_same_v<pti_view_memory_record_type, pti_view_record_kernel>;
+  constexpr bool handleMemcpyActivities =
+      std::is_same_v<pti_view_memory_record_type, pti_view_record_memory_copy>;
+  constexpr bool handleMemsetActivities =
+      std::is_same_v<pti_view_memory_record_type, pti_view_record_memory_fill>;
+
+  traceBuffer_.span.opCount += 1;
+  traceBuffer_.gpuOpCount += 1;
+
+  if constexpr (handleRuntimeActivities) {
+    traceBuffer_.emplace_activity(
+        traceBuffer_.span, activityType, getApiName(activity));
+  } else if constexpr (handleKernelActivities) {
+    traceBuffer_.emplace_activity(
+        traceBuffer_.span, activityType, std::string(activity->_name));
+  } else if constexpr (handleMemcpyActivities) {
+    traceBuffer_.emplace_activity(
+        traceBuffer_.span,
+        activityType,
+        memcpyName(
+            activity->_memcpy_type, activity->_mem_src, activity->_mem_dst));
+  } else if constexpr (handleMemsetActivities) {
+    traceBuffer_.emplace_activity(
+        traceBuffer_.span,
+        activityType,
+        memsetName(activity->_mem_type, activity->_value_for_set));
+  }
+
+  auto& trace_activity = traceBuffer_.activities.back();
+
+  trace_activity->startTime = activity->_start_timestamp;
+  trace_activity->endTime = activity->_end_timestamp;
+  trace_activity->threadId = activity->_thread_id;
+  trace_activity->flow.id = activity->_correlation_id;
+  trace_activity->flow.type = libkineto::kLinkAsyncCpuGpu;
+
+  trace_activity->id = activity->_correlation_id;
+  trace_activity->linked =
+      linkedActivity(activity->_correlation_id, cpuCorrelationMap_);
+  trace_activity->addMetadata("correlation", activity->_correlation_id);
+
+  if constexpr (handleRuntimeActivities) {
+    trace_activity->device = activity->_process_id;
+    trace_activity->resource = activity->_thread_id;
+    trace_activity->flow.start = startsFlow(activityType);
+  } else {
+    trace_activity->device = getDeviceIdxFromUUID(activity->_device_uuid);
+    trace_activity->resource = activity->_sycl_queue_id;
+    trace_activity->flow.start = 0;
+
+    if constexpr (handleKernelActivities) {
+      kernelActivities_[activity->_kernel_id].emplace(
+          trace_activity->startTime,
+          trace_activity->endTime,
+          trace_activity->device,
+          trace_activity->resource);
+    }
+
+    addResouceInfo(trace_activity->device, trace_activity->resource);
+  }
+
+  if constexpr (handleMemcpyActivities || handleMemsetActivities) {
+    trace_activity->addMetadataQuoted("l0 call", std::string(activity->_name));
+  }
+
+  if constexpr (!handleRuntimeActivities) {
+    addTimestampMetadata(
+        trace_activity.get(),
+        "appended",
+        activity->_append_timestamp,
+        activity->_start_timestamp);
+    addTimestampMetadata(
+        trace_activity.get(),
+        "submitted",
+        activity->_submit_timestamp,
+        activity->_start_timestamp);
+    if constexpr (handleKernelActivities) {
+      addTimestampMetadata(
+          trace_activity.get(),
+          "sycl_task_begin",
+          activity->_sycl_task_begin_timestamp,
+          activity->_start_timestamp);
+      addTimestampMetadata(
+          trace_activity.get(),
+          "sycl_enqk_begin",
+          activity->_sycl_enqk_begin_timestamp,
+          activity->_start_timestamp);
+    }
+    trace_activity->addMetadata("device", trace_activity->deviceId());
+    trace_activity->addMetadataQuoted(
+        "context", handleToHexString(activity->_context_handle));
+    trace_activity->addMetadata("sycl queue", activity->_sycl_queue_id);
+    trace_activity->addMetadataQuoted(
+        "l0 queue", handleToHexString(activity->_queue_handle));
+  }
+
+  if constexpr (handleKernelActivities) {
+    if (activity->_source_file_name) {
+      trace_activity->addMetadataQuoted(
+          "source_file_name", activity->_source_file_name);
+      trace_activity->addMetadata(
+          "source_line_number", activity->_source_line_number);
+    }
+    trace_activity->addMetadata("kernel_id", activity->_kernel_id);
+    trace_activity->addMetadata("sycl_node_id", activity->_sycl_node_id);
+    trace_activity->addMetadata(
+        "sycl_invocation_id", activity->_sycl_invocation_id);
+  } else if constexpr (handleMemcpyActivities || handleMemsetActivities) {
+    trace_activity->addMetadata("memory opration id", activity->_mem_op_id);
+    trace_activity->addMetadata("bytes", activity->_bytes);
+    trace_activity->addMetadata("memory bandwidth (GB/s)", bandwidth(activity));
+  }
+
+  checkTimestampOrder(trace_activity.get());
+  if (outOfRange(trace_activity.get())) {
+    traceBuffer_.span.opCount -= 1;
+    traceBuffer_.gpuOpCount -= 1;
+    removeCorrelatedPtiActivities(trace_activity.get());
+    traceBuffer_.activities.pop_back();
+    return;
+  }
+  trace_activity->log(logger);
+
+  // GPU_USER_ANNOTATION activities are synthetic spans that bracket all
+  // GPU work (kernels/memcpies) on a given (device, stream) pair that was
+  // enqueued while a user correlation ID was active.  We only do this for
+  // actual GPU activities (handleRuntimeActivities == false); CPU-side
+  // runtime events are skipped because they carry no device/resource info.
+  // For each (device, stream, user_external_id) key we either expand the
+  // existing annotation to cover the new activity's time range, or create a
+  // fresh GenericTraceActivity linked back to the CPU op.  The annotations
+  // are flushed to the logger at the end of processTrace().
+  if constexpr (!handleRuntimeActivities) {
+    if (activity_types_.count(ActivityType::GPU_USER_ANNOTATION)) {
+      auto userIt = userCorrelationMap_.find(activity->_correlation_id);
+      if (userIt != userCorrelationMap_.end() && cpuActivity_) {
+        const int64_t user_external_id = userIt->second;
+        const int32_t dev = trace_activity->device;
+        const int32_t res = trace_activity->resource;
+        auto key = std::make_tuple(dev, res, user_external_id);
+        auto annIt = userAnnotationsByStream_.find(key);
+        if (annIt != userAnnotationsByStream_.end()) {
+          GenericTraceActivity* ua = annIt->second;
+          ua->startTime = std::min(ua->startTime, trace_activity->startTime);
+          ua->endTime = std::max(ua->endTime, trace_activity->endTime);
+        } else if (
+            const ITraceActivity* cpu_act = cpuActivity_(user_external_id)) {
+          traceBuffer_.emplace_activity(
+              traceBuffer_.span,
+              ActivityType::GPU_USER_ANNOTATION,
+              cpu_act->name());
+          auto& ua = traceBuffer_.activities.back();
+          ua->startTime = trace_activity->startTime;
+          ua->endTime = trace_activity->endTime;
+          ua->device = dev;
+          ua->resource = res;
+          ua->id = user_external_id;
+          ua->threadId = trace_activity->threadId;
+          ua->linked = cpu_act;
+          userAnnotationsByStream_.emplace(key, ua.get());
+        }
+      }
+    }
+  }
+}
+
+void XpuptiActivityProfilerSession::handleCommunicationActivity(
+    const pti_view_record_comms* activity,
+    ActivityLogger& logger) {
+  const auto& activity_record = *activity;
+  const std::string activity_name{activity_record._name};
+  const std::string xccl_prefix{"xccl::"};
+  const auto record_name = xccl_prefix + activity_name;
+
+  traceBuffer_.span.opCount += 1;
+  traceBuffer_.emplace_activity(
+      traceBuffer_.span, ActivityType::COLLECTIVE_COMM, record_name);
+  auto& comms_activity = *(traceBuffer_.activities.back());
+
+  comms_activity.startTime = activity_record._start_timestamp;
+  comms_activity.endTime = activity_record._end_timestamp;
+  comms_activity.device = activity_record._process_id;
+  comms_activity.resource = activity_record._thread_id;
+  comms_activity.threadId = activity_record._thread_id;
+
+  comms_activity.addMetadata(
+      "Communicator_id", activity_record._communicator_id);
+
+  if (outOfRange(&comms_activity)) {
+    traceBuffer_.span.opCount -= 1;
+    traceBuffer_.activities.pop_back();
+    return;
+  }
+
+  comms_activity.log(logger);
+}
+
+namespace {
+// Map a PTI overhead kind to a human-readable name aligned with CUPTI's
+// overheadKindString() (see cupti_strings.cpp), so XPU and CUDA traces use the
+// same vocabulary. PTI's own ptiViewOverheadKindToString() returns raw enum
+// spellings (e.g. "BUFFER_FLUSH", "BUFFER_TIME") which do not match CUDA.
+// PTI_VIEW_OVERHEAD_KIND_TIME aggregates the time PTI spends inside
+// the Level Zero calls it injects to instrument the workload,
+// which is the same notion as CUPTI's "Instrumentation" overhead.
+const char* overheadKindString(pti_view_overhead_kind kind) {
+  switch (kind) {
+    case PTI_VIEW_OVERHEAD_KIND_UNKNOWN:
+      return "Unknown";
+    case PTI_VIEW_OVERHEAD_KIND_RESOURCE:
+      return "Resource";
+    case PTI_VIEW_OVERHEAD_KIND_BUFFER_FLUSH:
+      return "Buffer Flush";
+    case PTI_VIEW_OVERHEAD_KIND_DRIVER:
+      return "Driver";
+    case PTI_VIEW_OVERHEAD_KIND_TIME:
+      return "Instrumentation";
+    default:
+      return "Unknown";
+  }
+}
+
+std::string getStringFromSynchronizationType(
+    const pti_view_synchronization_type& synchronization_type) {
+  using pv_st = pti_view_synchronization_type;
+  static const std::unordered_map<pv_st, std::string> name_map{
+      {pv_st::PTI_VIEW_SYNCHRONIZATION_TYPE_UNKNOWN, "UNKNOWN"},
+      {pv_st::PTI_VIEW_SYNCHRONIZATION_TYPE_GPU_BARRIER_EXECUTION,
+       "GPU_BARRIER_EXECUTION"},
+      {pv_st::PTI_VIEW_SYNCHRONIZATION_TYPE_GPU_BARRIER_MEMORY,
+       "GPU_BARRIER_MEMORY"},
+      {pv_st::PTI_VIEW_SYNCHRONIZATION_TYPE_HOST_FENCE, "HOST_FENCE"},
+      {pv_st::PTI_VIEW_SYNCHRONIZATION_TYPE_HOST_EVENT, "HOST_EVENT"},
+      {pv_st::PTI_VIEW_SYNCHRONIZATION_TYPE_HOST_COMMAND_LIST,
+       "HOST_COMMAND_LIST"},
+      {pv_st::PTI_VIEW_SYNCHRONIZATION_TYPE_HOST_COMMAND_QUEUE,
+       "HOST_COMMAND_QUEUE"},
+  };
+
+  const auto& name_string = name_map.find(synchronization_type);
+  if (name_string == name_map.end()) {
+    const std::string error_message =
+        "404: Not found string literal for this synchronization type: " +
+        std::to_string(synchronization_type);
+    return error_message;
+  }
+  return name_string->second;
+}
+} // namespace
+
+void XpuptiActivityProfilerSession::handleSynchronizationActivity(
+    const pti_view_record_synchronization* activity,
+    ActivityLogger& logger) {
+  const auto& activity_record = *activity;
+  const auto record_name = getApiName(activity);
+
+  const bool isGpuSync = activity_record._synch_type ==
+          PTI_VIEW_SYNCHRONIZATION_TYPE_GPU_BARRIER_EXECUTION ||
+      activity_record._synch_type ==
+          PTI_VIEW_SYNCHRONIZATION_TYPE_GPU_BARRIER_MEMORY;
+
+  traceBuffer_.span.opCount += 1;
+  if (isGpuSync) {
+    traceBuffer_.gpuOpCount += 1;
+  }
+  traceBuffer_.emplace_activity(
+      traceBuffer_.span, ActivityType::XPU_SYNC, record_name);
+  auto& synchronization_activity = *(traceBuffer_.activities.back());
+
+  synchronization_activity.startTime = activity_record._start_timestamp;
+  synchronization_activity.endTime = activity_record._end_timestamp;
+  synchronization_activity.device = -1;
+  synchronization_activity.resource = activity_record._thread_id;
+  synchronization_activity.threadId = activity_record._thread_id;
+
+  synchronization_activity.id = activity->_correlation_id;
+  synchronization_activity.linked =
+      linkedActivity(activity->_correlation_id, cpuCorrelationMap_);
+  synchronization_activity.addMetadata(
+      "correlation", activity_record._correlation_id);
+
+  synchronization_activity.addMetadataQuoted(
+      "Type", getStringFromSynchronizationType(activity_record._synch_type));
+  synchronization_activity.addMetadataQuoted(
+      "Context_handle", handleToHexString(activity_record._context_handle));
+  synchronization_activity.addMetadataQuoted(
+      "Queue_handle", handleToHexString(activity_record._queue_handle));
+  synchronization_activity.addMetadataQuoted(
+      "Event_handle", handleToHexString(activity_record._event_handle));
+  synchronization_activity.addMetadata(
+      "Number_wait_events", activity_record._number_wait_events);
+  synchronization_activity.addMetadata(
+      "Return_code", activity_record._return_code);
+
+  if (outOfRange(&synchronization_activity)) {
+    traceBuffer_.span.opCount -= 1;
+    if (isGpuSync) {
+      traceBuffer_.gpuOpCount -= 1;
+    }
+    removeCorrelatedPtiActivities(&synchronization_activity);
+    traceBuffer_.activities.pop_back();
+    return;
+  }
+
+  synchronization_activity.log(logger);
+}
+
+void XpuptiActivityProfilerSession::handleOverheadActivity(
+    const pti_view_record_overhead* activity,
+    ActivityLogger& logger) {
+  traceBuffer_.emplace_activity(
+      traceBuffer_.span,
+      ActivityType::OVERHEAD,
+      overheadKindString(activity->_overhead_kind));
+  auto& overhead_activity = traceBuffer_.activities.back();
+  overhead_activity->startTime = activity->_overhead_start_timestamp_ns;
+  overhead_activity->endTime = activity->_overhead_end_timestamp_ns;
+  overhead_activity->device = -1;
+  overhead_activity->resource = activity->_overhead_thread_id;
+  overhead_activity->threadId = activity->_overhead_thread_id;
+  overhead_activity->addMetadata(
+      "overhead cost", activity->_overhead_duration_ns);
+  // Occupancy is the share of the observation window [start, end] that was
+  // actually spent in overhead: _overhead_duration_ns is cumulative and may be
+  // smaller than the window. Guard on the divisor (duration()) directly so the
+  // check holds regardless of PTI's start/end/duration relationship -- PTI may
+  // emit point-like records (start == end), e.g. on platforms with a coarse
+  // clock.
+  const auto occupancy = overhead_activity->duration() > 0
+      ? activity->_overhead_duration_ns * 100 / overhead_activity->duration()
+      : 0;
+  overhead_activity->addMetadataQuoted(
+      "overhead occupancy", fmt::format("{}%", occupancy));
+  overhead_activity->addMetadata("overhead count", activity->_overhead_count);
+
+  if (!outOfRange(overhead_activity.get())) {
+    overhead_activity->log(logger);
+  }
+}
+
+void XpuptiActivityProfilerSession::handlePtiActivity(
+    const pti_view_record_base* record,
+    ActivityLogger& logger) {
+  switch (record->_view_kind) {
+    case PTI_VIEW_EXTERNAL_CORRELATION:
+      handleCorrelationActivity(
+          reinterpret_cast<const pti_view_record_external_correlation*>(
+              record));
+      break;
+    case PTI_VIEW_RUNTIME_API:
+      handleRuntimeKernelMemcpyMemsetActivities(
+          ActivityType::XPU_RUNTIME,
+          reinterpret_cast<const pti_view_record_api_t*>(record),
+          logger);
+      break;
+    case PTI_VIEW_DRIVER_API:
+      handleRuntimeKernelMemcpyMemsetActivities(
+          ActivityType::XPU_DRIVER,
+          reinterpret_cast<const pti_view_record_api_t*>(record),
+          logger);
+      break;
+    case PTI_VIEW_DEVICE_GPU_KERNEL:
+      handleRuntimeKernelMemcpyMemsetActivities(
+          ActivityType::CONCURRENT_KERNEL,
+          reinterpret_cast<const pti_view_record_kernel*>(record),
+          logger);
+      break;
+    case PTI_VIEW_DEVICE_GPU_MEM_COPY:
+      handleRuntimeKernelMemcpyMemsetActivities(
+          ActivityType::GPU_MEMCPY,
+          reinterpret_cast<const pti_view_record_memory_copy*>(record),
+          logger);
+      break;
+    case PTI_VIEW_DEVICE_GPU_MEM_FILL:
+      handleRuntimeKernelMemcpyMemsetActivities(
+          ActivityType::GPU_MEMSET,
+          reinterpret_cast<const pti_view_record_memory_fill*>(record),
+          logger);
+      break;
+    case PTI_VIEW_COLLECTION_OVERHEAD:
+      handleOverheadActivity(
+          reinterpret_cast<const pti_view_record_overhead*>(record), logger);
+      break;
+    case PTI_VIEW_DEVICE_SYNCHRONIZATION:
+      handleSynchronizationActivity(
+          reinterpret_cast<const pti_view_record_synchronization*>(record),
+          logger);
+      break;
+    case PTI_VIEW_COMMUNICATION:
+      handleCommunicationActivity(
+          reinterpret_cast<const pti_view_record_comms*>(record), logger);
+      break;
+    default:
+      errors_.push_back(
+          "Unexpected activity type: " + std::to_string(record->_view_kind));
+      break;
+  }
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.cpp
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "XpuptiActivityProfiler.h"
+#include "XpuptiScopeProfilerApi.h"
+#include "XpuptiScopeProfilerSession.h"
+
+#include <fmt/ranges.h>
+#include <sycl/sycl.hpp>
+
+namespace KINETO_NAMESPACE {
+
+std::string getXpuDeviceProperties() {
+  std::vector<std::string> jsonProps;
+  // Enumerated GPU devices from the specific platform
+  for (const auto& platform : sycl::platform::get_platforms()) {
+    if (platform.get_backend() != sycl::backend::ext_oneapi_level_zero) {
+      continue;
+    }
+    const auto& device_list = platform.get_devices();
+    for (size_t i = 0; i < device_list.size(); i++) {
+      const auto& device = device_list[i];
+      jsonProps.push_back(fmt::format(
+          R"JSON(
+    {{
+      "id": {},
+      "name": "{}",
+      "totalGlobalMem": {},
+      "maxComputeUnits": {},
+      "maxWorkGroupSize": {},
+      "maxClockFrequency": {},
+      "maxMemAllocSize": {},
+      "localMemSize": {},
+      "vendor": "{}",
+      "driverVersion": "{}"
+    }})JSON",
+          i,
+          device.get_info<sycl::info::device::name>(),
+          device.get_info<sycl::info::device::global_mem_size>(),
+          device.get_info<sycl::info::device::max_compute_units>(),
+          device.get_info<sycl::info::device::max_work_group_size>(),
+          device.get_info<sycl::info::device::max_clock_frequency>(),
+          device.get_info<sycl::info::device::max_mem_alloc_size>(),
+          device.get_info<sycl::info::device::local_mem_size>(),
+          device.get_info<sycl::info::device::vendor>(),
+          device.get_info<sycl::info::device::driver_version>()));
+    }
+  }
+
+  return fmt::format("{}", fmt::join(jsonProps, ","));
+}
+
+[[noreturn]] const std::set<ActivityType>& XPUActivityProfiler::
+    availableActivities() const {
+  throw std::runtime_error(
+      "The availableActivities is legacy method and should not be called by kineto");
+}
+
+std::unique_ptr<libkineto::IActivityProfilerSession> XPUActivityProfiler::
+    configure(
+        const std::set<ActivityType>& activity_types,
+        const libkineto::Config& config) {
+  return std::make_unique<XpuptiScopeProfilerSession>(
+      XpuptiActivityApi::singleton(), name(), config, activity_types);
+}
+
+std::unique_ptr<libkineto::IActivityProfilerSession> XPUActivityProfiler::
+    configure(
+        [[maybe_unused]] int64_t ts_ms,
+        [[maybe_unused]] int64_t duration_ms,
+        const std::set<ActivityType>& activity_types,
+        const libkineto::Config& config) {
+  return configure(activity_types, config);
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.h
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "IActivityProfiler.h"
+
+namespace KINETO_NAMESPACE {
+
+std::string getXpuDeviceProperties();
+
+class XPUActivityProfiler : public libkineto::IActivityProfiler {
+ public:
+  XPUActivityProfiler() = default;
+  XPUActivityProfiler(const XPUActivityProfiler&) = delete;
+  XPUActivityProfiler& operator=(const XPUActivityProfiler&) = delete;
+
+  const std::string& name() const override {
+    return name_;
+  }
+
+  [[noreturn]] const std::set<ActivityType>& availableActivities()
+      const override;
+
+  std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      const std::set<ActivityType>& activity_types,
+      const libkineto::Config& config) override;
+  std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      int64_t ts_ms,
+      int64_t duration_ms,
+      const std::set<ActivityType>& activity_types,
+      const libkineto::Config& config) override;
+
+ private:
+  std::string name_{"__xpu_profiler__"};
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "XpuptiActivityProfilerSession.h"
+#include "XpuptiActivityApi.h"
+
+#include "time_since_epoch.h"
+
+#include <sycl/sycl.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <iterator>
+
+namespace KINETO_NAMESPACE {
+
+uint32_t XpuptiActivityProfilerSession::iterationCount_ = 0;
+std::vector<DeviceUUIDsT> XpuptiActivityProfilerSession::deviceUUIDs_ = {};
+
+bool XpuptiActivityProfilerSession::startsFlow(ActivityType activityType) {
+  // Only host runtime records start the CPU->GPU flow. The runtime view is
+  // already filtered to work-submitting APIs via
+  // ptiViewEnableRuntimeApiClass(PTI_API_CLASS_GPU_OPERATION_CORE). Driver
+  // (XPU_DRIVER) records share the same correlation id as the runtime record
+  // and must not also start a flow, or the trace gets a duplicate flow start.
+  return activityType == ActivityType::XPU_RUNTIME;
+}
+
+// =========== Session Constructor ============= //
+XpuptiActivityProfilerSession::XpuptiActivityProfilerSession(
+    XpuptiActivityApi& xpti,
+    const std::string& name,
+    const libkineto::Config& config,
+    const std::set<ActivityType>& activity_types)
+    : xpti_(xpti),
+      config_(config.clone()),
+      activity_types_(activity_types),
+      name_(name) {
+  enumDeviceUUIDs();
+  xpti_.enableXpuptiActivities(activity_types_);
+}
+
+XpuptiActivityProfilerSession::~XpuptiActivityProfilerSession() {
+  xpti_.clearActivities();
+}
+
+// =========== Session Public Methods ============= //
+void XpuptiActivityProfilerSession::start() {
+  profilerStartTs_ =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+}
+
+void XpuptiActivityProfilerSession::stop() {
+  xpti_.disablePtiActivities(activity_types_);
+  profilerEndTs_ = libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+}
+
+void XpuptiActivityProfilerSession::toggleCollectionDynamic(const bool enable) {
+  if (enable) {
+    xpti_.enableXpuptiActivities(activity_types_);
+  } else {
+    xpti_.disablePtiActivities(activity_types_);
+  }
+}
+
+void XpuptiActivityProfilerSession::processTrace(ActivityLogger& logger) {
+  traceBuffer_.span =
+      libkineto::TraceSpan(profilerStartTs_, profilerEndTs_, name_);
+  traceBuffer_.span.iteration = iterationCount_++;
+  auto gpuBuffer = xpti_.activityBuffers();
+  if (gpuBuffer) {
+    xpti_.processActivities(
+        *gpuBuffer,
+        [this, &logger](const pti_view_record_base* record) -> void {
+          handlePtiActivity(record, logger);
+        });
+  }
+  for (auto& kv : userAnnotationsByStream_) {
+    kv.second->log(logger);
+  }
+  userAnnotationsByStream_.clear();
+}
+
+void XpuptiActivityProfilerSession::processTrace(
+    ActivityLogger& logger,
+    libkineto::getLinkedActivityCallback get_linked_activity,
+    int64_t captureWindowStartTime,
+    int64_t captureWindowEndTime) {
+  captureWindowStartTime_ = captureWindowStartTime;
+  captureWindowEndTime_ = captureWindowEndTime;
+  cpuActivity_ = get_linked_activity;
+  processTrace(logger);
+}
+
+std::unique_ptr<libkineto::CpuTraceBuffer> XpuptiActivityProfilerSession::
+    getTraceBuffer() {
+  return std::make_unique<libkineto::CpuTraceBuffer>(std::move(traceBuffer_));
+}
+
+std::vector<libkineto::ResourceInfo> XpuptiActivityProfilerSession::
+    getResourceInfos() {
+  std::vector<libkineto::ResourceInfo> result;
+  for (const auto& [device_id, sycl_queue_id] : resourceInfo_) {
+    result.push_back(
+        {.id = sycl_queue_id,
+         .sortIndex = sycl_queue_id,
+         .deviceId = device_id,
+         .name = fmt::format("Stream {}", sycl_queue_id)});
+  }
+  resourceInfo_.clear();
+  return result;
+}
+
+void XpuptiActivityProfilerSession::pushCorrelationId(uint64_t id) {
+  xpti_.pushCorrelationID(id, XpuptiActivityApi::CorrelationFlowType::Default);
+}
+
+void XpuptiActivityProfilerSession::popCorrelationId() {
+  xpti_.popCorrelationID(XpuptiActivityApi::CorrelationFlowType::Default);
+}
+
+void XpuptiActivityProfilerSession::pushUserCorrelationId(uint64_t id) {
+  xpti_.pushCorrelationID(id, XpuptiActivityApi::CorrelationFlowType::User);
+}
+
+void XpuptiActivityProfilerSession::popUserCorrelationId() {
+  xpti_.popCorrelationID(XpuptiActivityApi::CorrelationFlowType::User);
+}
+
+void XpuptiActivityProfilerSession::enumDeviceUUIDs() {
+  if (!deviceUUIDs_.empty()) {
+    return;
+  }
+  auto platform_list = sycl::platform::get_platforms();
+  // Enumerated GPU devices from the specific platform.
+  for (const auto& platform : platform_list) {
+    if (platform.get_backend() != sycl::backend::ext_oneapi_level_zero) {
+      continue;
+    }
+    auto device_list = platform.get_devices();
+    for (const auto& device : device_list) {
+      if (device.is_gpu()) {
+        if (device.has(sycl::aspect::ext_intel_device_info_uuid)) {
+          deviceUUIDs_.push_back(
+              device.get_info<sycl::ext::intel::info::device::uuid>());
+        } else {
+          std::cerr
+              << "Warnings: UUID is not supported for this XPU device. The device index of records will be 0."
+              << std::endl;
+          deviceUUIDs_.push_back(DeviceUUIDsT{});
+        }
+      }
+    }
+  }
+}
+
+DeviceIndex_t XpuptiActivityProfilerSession::getDeviceIdxFromUUID(
+    const uint8_t deviceUUID[16]) {
+  auto it = std::ranges::find_if(
+      deviceUUIDs_, [deviceUUID](const DeviceUUIDsT& deviceUUIDinVec) {
+        return std::equal(
+            deviceUUIDinVec.begin(),
+            deviceUUIDinVec.end(),
+            deviceUUID,
+            deviceUUID + 16);
+      });
+  if (it == deviceUUIDs_.end()) {
+    std::cerr
+        << "Warnings: Can't find the legal XPU device from the given UUID."
+        << std::endl;
+    return static_cast<DeviceIndex_t>(0);
+  }
+  return static_cast<DeviceIndex_t>(std::distance(deviceUUIDs_.begin(), it));
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "XpuptiProfilerMacros.h"
+
+#include "IActivityProfiler.h"
+#include "libkineto.h"
+
+#include <pti/pti_view.h>
+
+#include <map>
+#include <memory>
+#include <set>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+namespace KINETO_NAMESPACE {
+
+class XpuptiActivityApi;
+
+using DeviceUUIDsT = std::array<unsigned char, 16>;
+
+class XpuptiActivityProfilerSession
+    : public libkineto::IActivityProfilerSession {
+ public:
+  XpuptiActivityProfilerSession() = delete;
+  XpuptiActivityProfilerSession(
+      XpuptiActivityApi& xpti,
+      const std::string& name,
+      const libkineto::Config& config,
+      const std::set<ActivityType>& activity_types);
+  XpuptiActivityProfilerSession(const XpuptiActivityProfilerSession&) = delete;
+  XpuptiActivityProfilerSession& operator=(
+      const XpuptiActivityProfilerSession&) = delete;
+
+  ~XpuptiActivityProfilerSession();
+
+  void start() override;
+  void stop() override;
+  void toggleCollectionDynamic(const bool enable) override;
+  std::vector<std::string> errors() override {
+    return errors_;
+  };
+  void processTrace(ActivityLogger& logger) override;
+  void processTrace(
+      ActivityLogger& logger,
+      libkineto::getLinkedActivityCallback get_linked_activity,
+      int64_t captureWindowStartTime,
+      int64_t captureWindowEndTime) override;
+  std::unique_ptr<libkineto::DeviceInfo> getDeviceInfo() override {
+    return {};
+  }
+  std::vector<libkineto::ResourceInfo> getResourceInfos() override;
+  std::unique_ptr<libkineto::CpuTraceBuffer> getTraceBuffer() override;
+
+  void pushCorrelationId(uint64_t id) override;
+  void popCorrelationId() override;
+  void pushUserCorrelationId(uint64_t id) override;
+  void popUserCorrelationId() override;
+
+  // Whether a runtime/driver record starts a CPU->GPU flow arrow. Only host
+  // runtime (XPU_RUNTIME) records do; driver (XPU_DRIVER) records share the
+  // same correlation id and would otherwise create a duplicate flow start.
+  // Static so it can be unit-tested without real hardware.
+  static bool startsFlow(ActivityType activityType);
+
+ private:
+  void checkTimestampOrder(const ITraceActivity* act1);
+  void removeCorrelatedPtiActivities(const ITraceActivity* act1);
+  bool outOfRange(const ITraceActivity* act);
+  int64_t getMappedQueueId(uint64_t sycl_queue_id);
+  const ITraceActivity* linkedActivity(
+      int32_t correlationId,
+      const std::unordered_map<int64_t, int64_t>& correlationMap);
+  void handleCorrelationActivity(
+      const pti_view_record_external_correlation* correlation);
+
+  using pti_view_record_api_t = pti_view_record_api;
+
+  template <typename PTI_VIEW>
+  std::string getApiName(const PTI_VIEW* activity) {
+    const char* api_name = nullptr;
+    XPUPTI_CALL(ptiViewGetApiIdName(
+        activity->_api_group, activity->_api_id, &api_name));
+    return std::string(api_name);
+  }
+
+  template <class pti_view_memory_record_type>
+  void handleRuntimeKernelMemcpyMemsetActivities(
+      ActivityType activityType,
+      const pti_view_memory_record_type* activity,
+      ActivityLogger& logger);
+
+  void handleSynchronizationActivity(
+      const pti_view_record_synchronization* activity,
+      ActivityLogger& logger);
+  void handleCommunicationActivity(
+      const pti_view_record_comms* activity,
+      ActivityLogger& logger);
+  void handleOverheadActivity(
+      const pti_view_record_overhead* activity,
+      ActivityLogger& logger);
+  void handlePtiActivity(
+      const pti_view_record_base* record,
+      ActivityLogger& logger);
+
+  // enumerate XPU Device UUIDs from runtime for once
+  void enumDeviceUUIDs();
+
+  // get logical device index(int8) from the given UUID from runtime
+  // for profiling activity creation
+  DeviceIndex_t getDeviceIdxFromUUID(const uint8_t deviceUUID[16]);
+
+  void addResouceInfo(int32_t device_id, int32_t sycl_queue_id);
+
+ protected:
+  static uint32_t iterationCount_;
+  static std::vector<DeviceUUIDsT> deviceUUIDs_;
+
+  int64_t captureWindowStartTime_{0};
+  int64_t captureWindowEndTime_{0};
+  int64_t profilerStartTs_{0};
+  int64_t profilerEndTs_{0};
+  std::unordered_map<int64_t, int64_t> cpuCorrelationMap_;
+  std::unordered_map<int64_t, int64_t> userCorrelationMap_;
+  std::unordered_map<int64_t, const ITraceActivity*> correlatedPtiActivities_;
+  std::map<
+      std::tuple<int32_t, int32_t, int64_t>,
+      libkineto::GenericTraceActivity*>
+      userAnnotationsByStream_;
+  std::vector<std::string> errors_;
+
+  libkineto::getLinkedActivityCallback cpuActivity_;
+
+  XpuptiActivityApi& xpti_;
+  libkineto::CpuTraceBuffer traceBuffer_;
+  std::vector<std::pair<int32_t, int32_t>> resourceInfo_;
+  std::unique_ptr<const libkineto::Config> config_{nullptr};
+  const std::set<ActivityType>& activity_types_;
+  std::string name_;
+
+  struct KernelActivity {
+    void emplace(
+        int64_t startTime,
+        int64_t endTime,
+        int32_t device,
+        int32_t resource) {
+      startTime_ = startTime;
+      endTime_ = endTime;
+      device_ = device;
+      resource_ = resource;
+    }
+
+    int64_t startTime_{0};
+    int64_t endTime_{0};
+    int32_t device_{0};
+    int32_t resource_{0};
+  };
+
+  std::unordered_map<uint64_t, KernelActivity> kernelActivities_;
+  uint64_t lastKernelActivityEndTime_{0};
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.cpp
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "XpuptiProfilerMacros.h"
+
+#include <stdexcept>
+#include <string_view>
+
+#include <fmt/format.h>
+
+namespace KINETO_NAMESPACE {
+
+namespace {
+[[noreturn]] void throwXpuRuntimeError(
+    pti_result errCode,
+    std::string_view message,
+    std::source_location source_location) {
+  const std::string function_location = fmt::format(
+      "function {} located: {}:{}",
+      source_location.function_name(),
+      source_location.file_name(),
+      source_location.line());
+  const std::string error_code = fmt::format(
+      "Error code: {} ({})",
+      static_cast<int>(errCode),
+      ptiResultTypeToString(errCode));
+  const std::string error = fmt::format(
+      "Kineto Profiler on XPU got error from {}. {}.",
+      function_location,
+      error_code);
+
+  if (message.empty())
+    throw std::runtime_error(error);
+  else {
+    const std::string error_with_message =
+        fmt::format("{}. Message: {}", error, message);
+    throw std::runtime_error(error_with_message);
+  }
+}
+} // namespace
+
+void XPUPTI_CALL(
+    pti_result errCode,
+    std::string_view message,
+    std::source_location source_location) {
+  if (errCode != PTI_SUCCESS)
+    throwXpuRuntimeError(errCode, message, source_location);
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.h
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <source_location>
+#include <string_view>
+
+#include <pti/pti.h>
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+
+// Used to enable future features in PTI before release.
+#define PTI_VERSION_AT_LEAST(MAJOR, MINOR) \
+  (PTI_VERSION_MAJOR > MAJOR ||            \
+   (PTI_VERSION_MAJOR == MAJOR && PTI_VERSION_MINOR >= MINOR))
+
+void XPUPTI_CALL(
+    pti_result errCode,
+    std::string_view message = "",
+    std::source_location source_location = std::source_location::current());
+
+using DeviceIndex_t = int8_t;
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.cpp
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <algorithm>
+#include <iterator>
+#include <stdexcept>
+
+#include "XpuptiScopeProfilerApi.h"
+#include "XpuptiScopeProfilerConfig.h"
+
+namespace KINETO_NAMESPACE {
+
+XpuptiScopeProfilerApi::safe_pti_scope_collection_handle_t::
+    safe_pti_scope_collection_handle_t(std::exception_ptr& exceptFromDestructor)
+    : exceptFromDestructor_(exceptFromDestructor) {
+  XPUPTI_CALL(ptiMetricsScopeEnable(&handle_));
+}
+
+XpuptiScopeProfilerApi::safe_pti_scope_collection_handle_t::
+    ~safe_pti_scope_collection_handle_t() noexcept {
+  try {
+    XPUPTI_CALL(ptiMetricsScopeDisable(handle_));
+  } catch (...) {
+    exceptFromDestructor_ = std::current_exception();
+  }
+}
+
+void XpuptiScopeProfilerApi::enableScopeProfiler(const Config& cfg) {
+  uint32_t deviceCount = 0;
+  XPUPTI_CALL(ptiMetricsGetDevices(nullptr, &deviceCount));
+
+  if (deviceCount == 0) {
+    throw std::runtime_error("No XPU devices available");
+  }
+
+  auto devices = std::make_unique<pti_device_properties_t[]>(deviceCount);
+  XPUPTI_CALL(ptiMetricsGetDevices(devices.get(), &deviceCount));
+
+  auto devicesHandles = std::make_unique<pti_device_handle_t[]>(deviceCount);
+  for (uint32_t i = 0; i < deviceCount; ++i) {
+    devicesHandles[i] = devices[i]._handle;
+  }
+
+  const auto& spcfg = XpuptiScopeProfilerConfig::get(cfg);
+  const auto& activitiesXpuptiMetrics = spcfg.activitiesXpuptiMetrics();
+
+  std::vector<const char*> metricNames;
+  metricNames.reserve(activitiesXpuptiMetrics.size());
+  std::transform(
+      activitiesXpuptiMetrics.begin(),
+      activitiesXpuptiMetrics.end(),
+      std::back_inserter(metricNames),
+      [](const std::string& s) { return s.c_str(); });
+
+  pti_metrics_scope_mode_t collectionMode = spcfg.xpuptiProfilerPerKernel()
+      ? PTI_METRICS_SCOPE_AUTO_KERNEL
+      : PTI_METRICS_SCOPE_USER;
+
+  if (collectionMode == PTI_METRICS_SCOPE_USER) {
+    throw std::runtime_error(
+        "XPUPTI_PROFILER_ENABLE_PER_KERNEL has to be set to 1. Other variants are currently not supported.");
+  }
+
+  scopeHandleOpt_.emplace(exceptFromScopeHandleDestructor_);
+  XPUPTI_CALL(ptiMetricsScopeConfigure(
+      *scopeHandleOpt_,
+      collectionMode,
+      devicesHandles.get(),
+      ((void)deviceCount, 1), // Only 1 device is currently supported
+      metricNames.data(),
+      metricNames.size()));
+
+  uint64_t expectedKernels = spcfg.xpuptiProfilerMaxScopes();
+  size_t estimatedCollectionBufferSize = 0;
+  XPUPTI_CALL(ptiMetricsScopeQueryCollectionBufferSize(
+      *scopeHandleOpt_, expectedKernels, &estimatedCollectionBufferSize));
+
+  XPUPTI_CALL(ptiMetricsScopeSetCollectionBufferSize(
+      *scopeHandleOpt_, estimatedCollectionBufferSize));
+}
+
+void XpuptiScopeProfilerApi::disableScopeProfiler() {
+  scopeHandleOpt_.reset();
+  if (exceptFromScopeHandleDestructor_) {
+    std::rethrow_exception(exceptFromScopeHandleDestructor_);
+  }
+}
+
+void XpuptiScopeProfilerApi::startScopeActivity() {
+  if (scopeHandleOpt_) {
+    XPUPTI_CALL(ptiMetricsScopeStartCollection(*scopeHandleOpt_));
+  }
+}
+
+void XpuptiScopeProfilerApi::stopScopeActivity() {
+  if (scopeHandleOpt_) {
+    XPUPTI_CALL(ptiMetricsScopeStopCollection(*scopeHandleOpt_));
+  }
+}
+
+static size_t IntDivRoundUp(size_t a, size_t b) {
+  return (a + b - 1) / b;
+}
+
+void XpuptiScopeProfilerApi::processScopeTrace(
+    std::function<void(
+        const pti_metrics_scope_record_t*,
+        const pti_metrics_scope_record_metadata_t& metadata)> handler) {
+  if (scopeHandleOpt_) {
+    pti_metrics_scope_record_metadata_t metadata;
+    metadata._struct_size = sizeof(pti_metrics_scope_record_metadata_t);
+
+    XPUPTI_CALL(ptiMetricsScopeGetMetricsMetadata(*scopeHandleOpt_, &metadata));
+
+    uint64_t collectionBuffersCount = 0;
+    XPUPTI_CALL(ptiMetricsScopeGetCollectionBuffersCount(
+        *scopeHandleOpt_, &collectionBuffersCount));
+
+    for (uint64_t bufferId = 0; bufferId < collectionBuffersCount; ++bufferId) {
+      void* collectionBuffer = nullptr;
+      size_t actualCollectionBufferSize = 0;
+      XPUPTI_CALL(ptiMetricsScopeGetCollectionBuffer(
+          *scopeHandleOpt_,
+          bufferId,
+          &collectionBuffer,
+          &actualCollectionBufferSize));
+
+      pti_metrics_scope_collection_buffer_properties_t metricsBufferProps;
+      metricsBufferProps._struct_size =
+          sizeof(pti_metrics_scope_collection_buffer_properties_t);
+      XPUPTI_CALL(ptiMetricsScopeGetCollectionBufferProperties(
+          *scopeHandleOpt_, collectionBuffer, &metricsBufferProps));
+
+      size_t requiredMetricsBufferSize = 0;
+      size_t recordsCount = 0;
+      XPUPTI_CALL(ptiMetricsScopeQueryMetricsBufferSize(
+          *scopeHandleOpt_,
+          collectionBuffer,
+          &requiredMetricsBufferSize,
+          &recordsCount));
+
+      if (recordsCount > 0) {
+        auto metricsBuffer =
+            std::make_unique<pti_metrics_scope_record_t[]>(IntDivRoundUp(
+                requiredMetricsBufferSize, sizeof(pti_metrics_scope_record_t)));
+
+        size_t actualRecordsCount = 0;
+        XPUPTI_CALL(ptiMetricsScopeCalculateMetrics(
+            *scopeHandleOpt_,
+            collectionBuffer,
+            metricsBuffer.get(),
+            requiredMetricsBufferSize,
+            &actualRecordsCount));
+
+        for (size_t recordId = 0; recordId < actualRecordsCount; ++recordId) {
+          auto record = metricsBuffer.get() + recordId;
+          handler(record, metadata);
+        }
+      }
+    }
+  }
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.h
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <pti/pti_metrics_scope.h>
+
+#include "XpuptiActivityApi.h"
+
+namespace KINETO_NAMESPACE {
+
+class Config;
+
+class XpuptiScopeProfilerApi {
+ public:
+  XpuptiScopeProfilerApi() = default;
+  XpuptiScopeProfilerApi(const XpuptiScopeProfilerApi&) = delete;
+  XpuptiScopeProfilerApi& operator=(const XpuptiScopeProfilerApi&) = delete;
+
+  ~XpuptiScopeProfilerApi() = default;
+
+  void enableScopeProfiler(const Config&);
+  void disableScopeProfiler();
+  void startScopeActivity();
+  void stopScopeActivity();
+
+  void processScopeTrace(
+      std::function<void(
+          const pti_metrics_scope_record_t*,
+          const pti_metrics_scope_record_metadata_t& metadata)> handler);
+
+ private:
+  struct safe_pti_scope_collection_handle_t {
+    safe_pti_scope_collection_handle_t(
+        std::exception_ptr& exceptFromDestructor);
+    ~safe_pti_scope_collection_handle_t() noexcept;
+
+    operator pti_scope_collection_handle_t() {
+      return handle_;
+    }
+
+    pti_scope_collection_handle_t handle_{};
+    std::exception_ptr& exceptFromDestructor_;
+  };
+
+  std::optional<safe_pti_scope_collection_handle_t> scopeHandleOpt_;
+  std::exception_ptr exceptFromScopeHandleDestructor_;
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerConfig.cpp
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerConfig.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "XpuptiScopeProfilerConfig.h"
+
+#include <Logger.h>
+
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
+namespace KINETO_NAMESPACE {
+
+// number of scopes affect the size of counter data binary used by
+// the XPUPTI Profiler. these defaults can be tuned
+constexpr int KMaxAutoScopes = 1500; // supports 1500 kernels
+constexpr int KMaxUserScopes = 10; // enable upto 10 sub regions marked by user
+
+bool XpuptiScopeProfilerConfig::handleOption(
+    const std::string& name,
+    std::string& val) {
+  VLOG(0) << " handling : " << name << " = " << val;
+  // Xpupti Scope based Profiler configuration
+  using namespace std::literals::string_view_literals;
+  if (name == "XPUPTI_PROFILER_METRICS"sv) {
+    activitiesXpuptiMetrics_ = splitAndTrim(val, ',');
+  } else if (name == "XPUPTI_PROFILER_ENABLE_PER_KERNEL"sv) {
+    xpuptiProfilerPerKernel_ = toBool(val);
+  } else if (name == "XPUPTI_PROFILER_MAX_SCOPES"sv) {
+    xpuptiProfilerMaxScopes_ = toInt64(val);
+  } else {
+    return false;
+  }
+  return true;
+}
+
+void XpuptiScopeProfilerConfig::setDefaults() {
+  if (activitiesXpuptiMetrics_.size() > 0 && xpuptiProfilerMaxScopes_ == 0) {
+    xpuptiProfilerMaxScopes_ =
+        xpuptiProfilerPerKernel_ ? KMaxAutoScopes : KMaxUserScopes;
+  }
+}
+
+void XpuptiScopeProfilerConfig::printActivityProfilerConfig(
+    std::ostream& s) const {
+  if (activitiesXpuptiMetrics_.size() > 0) {
+    fmt::print(
+        s,
+        "Xpupti Profiler metrics : {}\n"
+        "Xpupti Profiler measure per kernel : {}\n"
+        "Xpupti Profiler max scopes : {}\n",
+        fmt::join(activitiesXpuptiMetrics_, ", "),
+        xpuptiProfilerPerKernel_,
+        xpuptiProfilerMaxScopes_);
+  }
+}
+
+void XpuptiScopeProfilerConfig::registerFactory() {
+  Config::addConfigFactory(kXpuptiProfilerConfigName, [](Config& cfg) {
+    return new XpuptiScopeProfilerConfig(cfg);
+  });
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerConfig.h
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerConfig.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "Config.h"
+
+#include <chrono>
+#include <vector>
+
+namespace KINETO_NAMESPACE {
+
+constexpr char kXpuptiProfilerConfigName[] = "xpupti_scope_profiler";
+
+class XpuptiScopeProfilerConfig : public AbstractConfig {
+ public:
+  bool handleOption(const std::string& name, std::string& val) override;
+
+  void validate(
+      [[maybe_unused]] const std::chrono::time_point<std::chrono::system_clock>&
+          fallbackProfileStartTime) override {}
+
+  static XpuptiScopeProfilerConfig& get(const Config& cfg) {
+    return dynamic_cast<XpuptiScopeProfilerConfig&>(
+        cfg.feature(kXpuptiProfilerConfigName));
+  }
+
+  Config& parent() const {
+    return *parent_;
+  }
+
+  std::vector<std::string> activitiesXpuptiMetrics() const {
+    return activitiesXpuptiMetrics_;
+  }
+
+  bool xpuptiProfilerPerKernel() const {
+    return xpuptiProfilerPerKernel_;
+  }
+
+  int64_t xpuptiProfilerMaxScopes() const {
+    return xpuptiProfilerMaxScopes_;
+  }
+
+  void setClientDefaults() override {
+    setDefaults();
+  }
+
+  void printActivityProfilerConfig(std::ostream& s) const override;
+  void setActivityDependentConfig() override {}
+  static void registerFactory();
+
+ protected:
+  AbstractConfig* cloneDerived(AbstractConfig& parent) const override {
+    XpuptiScopeProfilerConfig* clone = new XpuptiScopeProfilerConfig(*this);
+    clone->parent_ = dynamic_cast<Config*>(&parent);
+    return clone;
+  }
+
+ private:
+  XpuptiScopeProfilerConfig() = delete;
+  explicit XpuptiScopeProfilerConfig(Config& parent) : parent_(&parent) {}
+  explicit XpuptiScopeProfilerConfig(const XpuptiScopeProfilerConfig& other) =
+      default;
+
+  // some defaults will depend on other configuration
+  void setDefaults();
+
+  // Associated Config object
+  Config* parent_;
+
+  // Counter metrics exposed via XPUPTI Profiler API
+  std::vector<std::string> activitiesXpuptiMetrics_;
+
+  // Collect profiler metrics per kernel - autoscope made
+  bool xpuptiProfilerPerKernel_{false};
+
+  // max number of scopes to configure the profiler for.
+  // this has to be set before hand to reserve space for the output
+  int64_t xpuptiProfilerMaxScopes_ = 0;
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerHandlers.cpp
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerHandlers.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "XpuptiProfilerMacros.h"
+#include "XpuptiScopeProfilerSession.h"
+
+namespace KINETO_NAMESPACE {
+
+enum class MetadataOrCounterValue {
+  Metadata = 0,
+  CounterValue = 1,
+};
+
+static void AddPtiValueToMetadataOrCounterValue(
+    GenericTraceActivity* scopeActivity,
+    MetadataOrCounterValue metadataOrCounterValue,
+    const std::string& metricName,
+    pti_metric_value_type valueType,
+    const pti_value_t& value) {
+  switch (valueType) {
+#define CASE(T, FIELD)                                                \
+  case PTI_METRIC_VALUE_TYPE_##T:                                     \
+    if (metadataOrCounterValue == MetadataOrCounterValue::Metadata) { \
+      scopeActivity->addMetadata(metricName, value.FIELD);            \
+    } else {                                                          \
+      scopeActivity->addCounterValue(metricName, value.FIELD);        \
+    }                                                                 \
+    return;
+
+    CASE(UINT32, ui32);
+    CASE(UINT64, ui64);
+    CASE(FLOAT32, fp32);
+    CASE(FLOAT64, fp64);
+
+#undef CASE
+
+    case PTI_METRIC_VALUE_TYPE_BOOL8:
+      if (metadataOrCounterValue == MetadataOrCounterValue::Metadata) {
+        scopeActivity->addMetadata(metricName, value.b8 ? "true" : "false ");
+      } else {
+        scopeActivity->addCounterValue(metricName, value.b8);
+      }
+      return;
+
+    default:
+      break;
+  }
+}
+
+void XpuptiScopeProfilerSession::handleScopeRecord(
+    const pti_metrics_scope_record_t* record,
+    const pti_metrics_scope_record_metadata_t& metadata,
+    ActivityLogger& logger) {
+  std::array<GenericTraceActivity*, 3> scopeActivities{};
+
+  traceBuffer_.emplace_activity(
+      traceBuffer_.span,
+      ActivityType::CONCURRENT_KERNEL,
+      record->_kernel_name
+          ? fmt::format("metrics: {}", record->_kernel_name)
+          : fmt::format("metrics: kernel_{}", record->_kernel_id));
+
+  scopeActivities[0] = traceBuffer_.activities.back().get();
+
+  for (auto itSa = scopeActivities.begin() + 1; itSa != scopeActivities.end();
+       ++itSa) {
+    traceBuffer_.emplace_activity(
+        traceBuffer_.span, ActivityType::XPU_SCOPE_PROFILER, "xpu");
+
+    *itSa = traceBuffer_.activities.back().get();
+  }
+
+  std::function<void(GenericTraceActivity*)> FillActivityRecord{};
+  auto it = kernelActivities_.find(record->_kernel_id);
+  if (it != kernelActivities_.end()) {
+    FillActivityRecord = [it](GenericTraceActivity* act) {
+      act->startTime = it->second.startTime_ - 1;
+      act->endTime = it->second.endTime_ + 1;
+      act->device = it->second.device_;
+      act->resource = it->second.resource_;
+    };
+  } else {
+    FillActivityRecord = [this](GenericTraceActivity* act) {
+      act->startTime = lastKernelActivityEndTime_ + 1;
+      act->endTime = act->startTime + 1;
+      act->device = 0;
+      act->resource = 0;
+    };
+  }
+  for (auto sa : scopeActivities) {
+    FillActivityRecord(sa);
+  }
+  scopeActivities[2]->startTime = scopeActivities[2]->endTime;
+
+  if (it != kernelActivities_.end()) {
+    kernelActivities_.erase(it);
+  }
+  lastKernelActivityEndTime_ = scopeActivities[0]->endTime;
+
+  scopeActivities[0]->addMetadata("kernel_id", record->_kernel_id);
+  scopeActivities[0]->addMetadataQuoted(
+      "queue", fmt::format("{}", record->_queue));
+
+  for (uint32_t m = 0; m < metadata._metrics_count; ++m) {
+    const auto& unit = metadata._metric_units[m];
+    std::string unitSuffix = unit ? fmt::format("::{}", unit) : "";
+    std::string metricNameWithUnit =
+        fmt::format("{}{}", metadata._metric_names[m], unitSuffix);
+
+    AddPtiValueToMetadataOrCounterValue(
+        scopeActivities[0],
+        MetadataOrCounterValue::Metadata,
+        metricNameWithUnit,
+        metadata._value_types[m],
+        record->_metrics_values[m]);
+
+    AddPtiValueToMetadataOrCounterValue(
+        scopeActivities[1],
+        MetadataOrCounterValue::CounterValue,
+        metadata._metric_names[m],
+        metadata._value_types[m],
+        record->_metrics_values[m]);
+
+    scopeActivities[2]->addCounterValue(metadata._metric_names[m], 0);
+  }
+
+  for (auto sa : scopeActivities) {
+    sa->log(logger);
+  }
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerSession.cpp
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerSession.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "XpuptiScopeProfilerSession.h"
+
+namespace KINETO_NAMESPACE {
+
+XpuptiScopeProfilerSession::XpuptiScopeProfilerSession(
+    XpuptiActivityApi& xpti,
+    const std::string& name,
+    const libkineto::Config& config,
+    const std::set<ActivityType>& activity_types)
+    : XpuptiActivityProfilerSession(xpti, name, config, activity_types) {
+  scopeProfilerEnabled_ =
+      activity_types.count(ActivityType::XPU_SCOPE_PROFILER) > 0;
+  if (scopeProfilerEnabled_) {
+    xptiScopeProf_.enableScopeProfiler(*config_);
+  }
+}
+
+XpuptiScopeProfilerSession::~XpuptiScopeProfilerSession() {
+  if (scopeProfilerEnabled_) {
+    xptiScopeProf_.disableScopeProfiler();
+  }
+}
+
+void XpuptiScopeProfilerSession::start() {
+  XpuptiActivityProfilerSession::start();
+  if (scopeProfilerEnabled_) {
+    xptiScopeProf_.startScopeActivity();
+  }
+}
+
+void XpuptiScopeProfilerSession::stop() {
+  if (scopeProfilerEnabled_) {
+    xptiScopeProf_.stopScopeActivity();
+  }
+  XpuptiActivityProfilerSession::stop();
+}
+
+void XpuptiScopeProfilerSession::toggleCollectionDynamic(const bool enable) {
+  XpuptiActivityProfilerSession::toggleCollectionDynamic(enable);
+  if (scopeProfilerEnabled_) {
+    if (enable) {
+      xptiScopeProf_.startScopeActivity();
+    } else {
+      xptiScopeProf_.stopScopeActivity();
+    }
+  }
+}
+
+void XpuptiScopeProfilerSession::processTrace(ActivityLogger& logger) {
+  XpuptiActivityProfilerSession::processTrace(logger);
+  if (scopeProfilerEnabled_) {
+    xptiScopeProf_.processScopeTrace(
+        [this, &logger](
+            const pti_metrics_scope_record_t* record,
+            const pti_metrics_scope_record_metadata_t& metadata) -> void {
+          handleScopeRecord(record, metadata, logger);
+        });
+  }
+}
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerSession.h
+++ b/third_party/kineto/libkineto/src/plugin/xpupti/XpuptiScopeProfilerSession.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "XpuptiActivityProfilerSession.h"
+#include "XpuptiScopeProfilerApi.h"
+
+#include <pti/pti_metrics_scope.h>
+
+namespace KINETO_NAMESPACE {
+
+class XpuptiScopeProfilerApi;
+
+class XpuptiScopeProfilerSession : public XpuptiActivityProfilerSession {
+ public:
+  XpuptiScopeProfilerSession(
+      XpuptiActivityApi& xpti,
+      const std::string& name,
+      const libkineto::Config& config,
+      const std::set<ActivityType>& activity_types);
+
+  XpuptiScopeProfilerSession(const XpuptiScopeProfilerSession&) = delete;
+  XpuptiScopeProfilerSession& operator=(const XpuptiScopeProfilerSession&) =
+      delete;
+
+  ~XpuptiScopeProfilerSession();
+  void start();
+  void stop();
+  void toggleCollectionDynamic(const bool enable);
+
+  void processTrace(ActivityLogger& logger) override;
+
+  void handleScopeRecord(
+      const pti_metrics_scope_record_t* record,
+      const pti_metrics_scope_record_metadata_t& metadata,
+      ActivityLogger& logger);
+
+ private:
+  XpuptiScopeProfilerApi xptiScopeProf_;
+  bool scopeProfilerEnabled_{false};
+};
+
+} // namespace KINETO_NAMESPACE

--- a/third_party/kineto/libkineto/test/ActivityProfilerControllerTest.cpp
+++ b/third_party/kineto/libkineto/test/ActivityProfilerControllerTest.cpp
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <cstdlib>
+
+#include <chrono>
+#include <fstream>
+#include <string>
+
+#include "include/Config.h"
+#include "src/ActivityProfilerController.h"
+#include "test/TestUtils.h"
+
+using namespace std::chrono;
+using namespace KINETO_NAMESPACE;
+using namespace libkineto::test;
+
+namespace {
+
+bool traceFileHasContent(const std::string& filename) {
+  std::ifstream file(filename, std::ios::binary | std::ios::ate);
+  return file.is_open() && file.tellg() > 0;
+}
+
+} // namespace
+
+TEST(ActivityProfilerController, PrepareTraceClearsPendingAsyncRequest) {
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+  Config asyncCfg;
+  bool success = asyncCfg.parse(fmt::format(
+      R"CFG(
+    PROFILE_START_ITERATION = 5
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 2
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+      traceFile.path()));
+  ASSERT_TRUE(success);
+
+  // Start an async request via acceptConfig -- populate asyncRequestConfig_
+  ActivityProfilerController controller(ConfigLoader::instance(), true);
+  controller.asyncStep();
+  controller.acceptConfig(asyncCfg);
+  EXPECT_FALSE(controller.isActive());
+
+  // Start a sync trace before the async request starts
+  Config syncCfg;
+  syncCfg.setClientDefaults();
+  syncCfg.validate(system_clock::now());
+  controller.syncPrepareTrace(syncCfg);
+  EXPECT_TRUE(controller.isActive());
+
+  controller.syncStartTrace();
+
+  // When the sync trace stops, the async request should be completely inactive
+  auto trace = controller.syncStopTrace();
+  EXPECT_NE(trace, nullptr);
+  EXPECT_FALSE(controller.isActive());
+
+  // Use asyncStep() being no-op as a proxy to validate that async was cancelled
+  for (int i = 0; i < 10; ++i) {
+    controller.asyncStep();
+    EXPECT_FALSE(controller.isActive());
+  }
+
+  const std::string logFile = logUrlToPath(asyncCfg.activitiesLogUrl());
+  EXPECT_FALSE(traceFileHasContent(logFile)) << logFile;
+}
+
+TEST(ActivityProfilerController, IgnoreAsyncRequestsWhileSyncTraceIsActive) {
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+  Config asyncCfg;
+  bool success = asyncCfg.parse(fmt::format(
+      R"CFG(
+    PROFILE_START_ITERATION = 4
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 2
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+      traceFile.path()));
+  ASSERT_TRUE(success);
+
+  ActivityProfilerController controller(ConfigLoader::instance(), true);
+  controller.asyncStep();
+
+  Config syncCfg;
+  syncCfg.setClientDefaults();
+  syncCfg.validate(system_clock::now());
+
+  // Start a sync trace
+  controller.syncPrepareTrace(syncCfg);
+  EXPECT_TRUE(controller.isActive());
+  EXPECT_FALSE(controller.canAcceptConfig());
+
+  // Accept an async config while the sync trace is active
+  // This should be blocked at the controller level
+  controller.acceptConfig(asyncCfg);
+  EXPECT_TRUE(controller.isActive());
+
+  controller.syncStartTrace();
+  auto trace = controller.syncStopTrace();
+  EXPECT_NE(trace, nullptr);
+  EXPECT_FALSE(controller.isActive());
+
+  // After sync runs to completion, check that the async request was not
+  // accepted.
+  // Use asyncStep() being no-op as a proxy to validate that async was cancelled
+  for (int i = 0; i < 10; ++i) {
+    controller.asyncStep();
+    EXPECT_FALSE(controller.isActive());
+  }
+
+  const std::string logFile = logUrlToPath(asyncCfg.activitiesLogUrl());
+  EXPECT_FALSE(traceFileHasContent(logFile)) << logFile;
+}
+
+TEST(ActivityProfilerController, PrepareTracePreemptsActiveAsyncRequest) {
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+  Config asyncCfg;
+  bool success = asyncCfg.parse(fmt::format(
+      R"CFG(
+    PROFILE_START_ITERATION = 3
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 4
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+      traceFile.path()));
+  ASSERT_TRUE(success);
+
+  ActivityProfilerController controller(ConfigLoader::instance(), true);
+  controller.asyncStep();
+
+  // Start an async request, step until it's active
+  controller.acceptConfig(asyncCfg);
+  EXPECT_FALSE(controller.isActive());
+  controller.asyncStep();
+  EXPECT_FALSE(controller.isActive());
+  controller.asyncStep();
+  EXPECT_TRUE(controller.isActive());
+  controller.asyncStep();
+  EXPECT_TRUE(controller.isActive());
+
+  // Start a sync trace, which should preempt the async request
+  Config syncCfg;
+  syncCfg.setClientDefaults();
+  syncCfg.validate(system_clock::now());
+  controller.syncPrepareTrace(syncCfg);
+  EXPECT_TRUE(controller.isActive());
+  controller.syncStartTrace();
+  auto trace = controller.syncStopTrace();
+  EXPECT_NE(trace, nullptr);
+  EXPECT_FALSE(controller.isActive());
+
+  // Use asyncStep() being no-op as a proxy to validate that async was cancelled
+  for (int i = 0; i < 10; ++i) {
+    controller.asyncStep();
+    EXPECT_FALSE(controller.isActive());
+  }
+
+  const std::string logFile = logUrlToPath(asyncCfg.activitiesLogUrl());
+  EXPECT_FALSE(traceFileHasContent(logFile)) << logFile;
+}
+
+// While an async trace is already active, the controller drops a second
+// on-demand request instead of scheduling it. This complements the tests above,
+// which cover a sync trace blocking or preempting async.
+TEST(ActivityProfilerController, SecondAsyncRequestIgnoredWhileAsyncActive) {
+  auto firstFile = createTempTraceFile("libkineto_test_first", ".json");
+  auto secondFile = createTempTraceFile("libkineto_test_second", ".json");
+
+  Config firstCfg;
+  ASSERT_TRUE(firstCfg.parse(fmt::format(
+      R"CFG(
+    PROFILE_START_ITERATION = 3
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 4
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+      firstFile.path())));
+
+  Config secondCfg;
+  ASSERT_TRUE(secondCfg.parse(fmt::format(
+      R"CFG(
+    PROFILE_START_ITERATION = 3
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 4
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+      secondFile.path())));
+
+  ActivityProfilerController controller(ConfigLoader::instance(), true);
+  controller.asyncStep();
+
+  // Bring the first request to the active state; acceptConfig reports that it
+  // scheduled the request.
+  EXPECT_TRUE(controller.acceptConfig(firstCfg));
+  controller.asyncStep();
+  controller.asyncStep();
+  EXPECT_TRUE(controller.isActive());
+  EXPECT_FALSE(controller.canAcceptConfig());
+
+  // A second on-demand request arriving now is rejected by the controller.
+  EXPECT_FALSE(controller.acceptConfig(secondCfg));
+  EXPECT_TRUE(controller.isActive());
+
+  // The rejected request also never produced a trace.
+  const std::string secondLog = logUrlToPath(secondCfg.activitiesLogUrl());
+  EXPECT_FALSE(traceFileHasContent(secondLog)) << secondLog;
+}
+
+// canAcceptConfig() gates on the profiler being idle: it is true before a
+// request and false once one becomes active. Return-to-idle happens on the
+// background loop after collection finishes and is not asserted here.
+TEST(ActivityProfilerController, CanAcceptConfigReflectsActiveState) {
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  Config cfg;
+  ASSERT_TRUE(cfg.parse(fmt::format(
+      R"CFG(
+    PROFILE_START_ITERATION = 3
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 2
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+      traceFile.path())));
+
+  ActivityProfilerController controller(ConfigLoader::instance(), true);
+  EXPECT_TRUE(controller.canAcceptConfig());
+
+  controller.asyncStep();
+  EXPECT_TRUE(controller.acceptConfig(cfg));
+  controller.asyncStep();
+  controller.asyncStep();
+  EXPECT_TRUE(controller.isActive());
+  EXPECT_FALSE(controller.canAcceptConfig());
+}

--- a/third_party/kineto/libkineto/test/ApproximateClockTest.cpp
+++ b/third_party/kineto/libkineto/test/ApproximateClockTest.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "src/ApproximateClock.h"
+
+#include <chrono>
+
+#include <gtest/gtest.h>
+
+using namespace libkineto;
+
+TEST(ApproximateClockTest, ReturnsNonZero) {
+  approx_time_t t = getApproximateTime();
+  EXPECT_NE(t, 0);
+}
+
+TEST(ApproximateClockTest, IsMonotonic) {
+  constexpr int kIterations = 1000;
+  approx_time_t prev = getApproximateTime();
+  for (int i = 0; i < kIterations; ++i) {
+    approx_time_t curr = getApproximateTime();
+    ASSERT_GE(curr, prev) << "Clock went backwards at iteration " << i;
+    prev = curr;
+  }
+}
+
+TEST(ApproximateClockTest, AdvancesOverTime) {
+  approx_time_t t0 = getApproximateTime();
+
+  // We use this pattern several times in these tests. We keep checking
+  // approximate time until we find its value has increased, with a 10 ms
+  // timeout. If we hit the timeout, the test fails. On platforms such as
+  // x86, the first iteration should succeed as approximate time is tied
+  // to the clock cycle. On some other platforms, such as aarch64, it may take
+  // several clock cycles before approximate time actually increases.
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(10);
+  approx_time_t t1;
+  do {
+    t1 = getApproximateTime();
+  } while (t1 == t0 && std::chrono::steady_clock::now() < deadline);
+  EXPECT_GT(t1, t0);
+}
+
+TEST(ApproximateClockTest, MeasurePairCapturesBothClocks) {
+  auto pair = ApproximateClockToUnixTimeConverter::measurePair();
+  // Wall time should be a plausible epoch timestamp (after 2020, before 2100).
+  constexpr libkineto::time_t kYear2020 = 1577836800LL * 1'000'000'000;
+  constexpr libkineto::time_t kYear2100 = 4102444800LL * 1'000'000'000;
+  EXPECT_GT(pair.t_, kYear2020);
+  EXPECT_LT(pair.t_, kYear2100);
+  EXPECT_NE(pair.approx_t_, 0) << "Approximate time should be non-zero";
+}
+
+TEST(ApproximateClockTest, ConverterProducesPlausibleEpochTime) {
+  ApproximateClockToUnixTimeConverter converter;
+  auto convert = converter.makeConverter();
+
+  approx_time_t approx_now = getApproximateTime();
+  auto converted_ns = convert(approx_now);
+
+  constexpr libkineto::time_t kYear2020 = 1577836800LL * 1'000'000'000;
+  constexpr libkineto::time_t kYear2100 = 4102444800LL * 1'000'000'000;
+  EXPECT_GT(converted_ns, kYear2020);
+  EXPECT_LT(converted_ns, kYear2100);
+}
+
+TEST(ApproximateClockTest, ConverterPreservesOrdering) {
+  ApproximateClockToUnixTimeConverter converter;
+  auto convert = converter.makeConverter();
+
+  approx_time_t t0 = getApproximateTime();
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(10);
+  approx_time_t t1;
+  do {
+    t1 = getApproximateTime();
+  } while (t1 == t0 && std::chrono::steady_clock::now() < deadline);
+
+  auto wall0 = convert(t0);
+  auto wall1 = convert(t1);
+  EXPECT_GT(wall1, wall0) << "Converted times must preserve ordering";
+}
+
+TEST(ApproximateClockTest, GetTimeIsPositiveAndAdvances) {
+  libkineto::time_t t0 = getTime();
+  EXPECT_GT(t0, 0);
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(10);
+  libkineto::time_t t1;
+  do {
+    t1 = getTime();
+  } while (t1 == t0 && std::chrono::steady_clock::now() < deadline);
+  EXPECT_GT(t1, t0);
+}

--- a/third_party/kineto/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
+++ b/third_party/kineto/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
@@ -1,0 +1,850 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include <cstdlib>
+
+#include <atomic>
+#include <chrono>
+#include <fstream>
+#include <future>
+#include <mutex>
+
+#include "include/Config.h"
+#include "include/libkineto.h"
+#include "src/AsyncActivityProfilerHandler.h"
+#include "src/GenericActivityProfiler.h"
+
+#include "src/Logger.h"
+#include "test/TestUtils.h"
+
+using namespace std::chrono;
+using namespace KINETO_NAMESPACE;
+using namespace libkineto::test;
+
+// Several tests step to timestamps derived from the warmup and duration values
+// they pass in the config, using named constants shared between the two so they
+// cannot drift apart. startTime leads now by the warmup period plus a
+// one-second buffer: canStart() requires at least ACTIVITIES_WARMUP_PERIOD_SECS
+// of lead time, and the buffer absorbs the millisecond truncation in the
+// PROFILE_START_TIME round-trip (a bare now + warmup can round just under and
+// be rejected). Steps meant to fall after collection add a second past
+// startTime + ACTIVITIES_DURATION_SECS.
+
+// Subclass that lets us control isGpuCollectionStopped() for testing
+// the buffer-overflow-during-warmup path without needing real CUPTI.
+class MockGpuProfiler : public GenericActivityProfiler {
+ public:
+  MockGpuProfiler() : GenericActivityProfiler(/*cpuOnly=*/false) {}
+
+  void setGpuCollectionStopped(bool stopped) {
+    gpuStopped_ = stopped;
+  }
+
+ protected:
+  bool isGpuCollectionStopped() const override {
+    return gpuStopped_;
+  }
+
+ private:
+  bool gpuStopped_{false};
+};
+
+// Records ClientInterface callbacks so tests can assert the handler drives the
+// registered client. Counters are atomic because the memory-snapshot path
+// invokes them from a background thread.
+class MockClientInterface : public libkineto::ClientInterface {
+ public:
+  void init() override {}
+  void prepare(
+      bool /*unused*/,
+      bool /*unused*/,
+      bool /*unused*/,
+      bool /*unused*/,
+      bool /*unused*/) override {}
+  void start() override {
+    ++startCount;
+  }
+  void stop() override {
+    ++stopCount;
+  }
+  void start_memory_profile() override {
+    ++memoryStartCount;
+  }
+  void stop_memory_profile() override {
+    ++memoryStopCount;
+    // set_value() throws std::future_error if the promise is already satisfied,
+    // which on this background thread would terminate the test process. Signal
+    // exactly once so a repeated call surfaces via memoryStopCount instead of
+    // throwing.
+    if (!memoryStopSignaled_.exchange(true)) {
+      memoryStopPromise_.set_value();
+    }
+  }
+  void export_memory_profile(const std::string& path) override {
+    ++memoryExportCount;
+    std::scoped_lock guard(mutex_);
+    exportedPath_ = path;
+  }
+
+  std::string exportedPath() {
+    std::scoped_lock guard(mutex_);
+    return exportedPath_;
+  }
+
+  // Fulfilled when stop_memory_profile() runs, i.e. the memory loop finished.
+  std::future<void> memoryStopFuture() {
+    return memoryStopPromise_.get_future();
+  }
+
+  std::atomic<int> startCount{0};
+  std::atomic<int> stopCount{0};
+  std::atomic<int> memoryStartCount{0};
+  std::atomic<int> memoryStopCount{0};
+  std::atomic<int> memoryExportCount{0};
+
+ private:
+  std::mutex mutex_;
+  std::string exportedPath_;
+  std::promise<void> memoryStopPromise_;
+  std::atomic<bool> memoryStopSignaled_{false};
+};
+
+// Registers a mock client on the process-global libkineto::api() for a test,
+// saving and restoring whatever client was registered before so the fixture
+// never clobbers another test's client regardless of binary composition.
+class AsyncClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    priorClient_ = libkineto::api().client();
+    libkineto::api().registerClient(&client_);
+  }
+  void TearDown() override {
+    libkineto::api().registerClient(priorClient_);
+  }
+
+  MockClientInterface client_;
+  libkineto::ClientInterface* priorClient_ = nullptr;
+};
+
+TEST(AsyncActivityProfilerHandler, AsyncTrace) {
+  std::vector<std::string> log_modules(
+      {"CuptiActivityProfiler.cpp", "output_json.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(1, log_modules);
+
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  Config cfg;
+
+  constexpr int kWarmupSecs = 5;
+  constexpr int kDurationSecs = 1;
+  int iter = 0;
+  auto now = system_clock::now();
+  auto startTime = now + seconds(kWarmupSecs + 1);
+
+  bool success = cfg.parse(fmt::format(
+      R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = {}
+    ACTIVITIES_DURATION_SECS = {}
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+      kWarmupSecs,
+      kDurationSecs,
+      traceFile.path(),
+      duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
+
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(handler.isAsyncActive());
+
+  handler.configure(cfg, now);
+
+  EXPECT_TRUE(handler.isAsyncActive());
+
+  // fast forward in time and we have reached the startTime
+  now = startTime;
+
+  // Warmup
+  handler.performRunLoopStep(now, now);
+
+  // End of the collection window: startTime + duration.
+  auto next = startTime + seconds(kDurationSecs);
+
+  // Iteration-based steps should have no effect on timestamp-based config
+  while (++iter < 20) {
+    handler.performRunLoopStep(now, now, iter);
+  }
+
+  // Terminate collection
+  handler.performRunLoopStep(next, next);
+
+  EXPECT_TRUE(handler.isAsyncActive());
+
+  // Past the window, to drive the finalize (ProcessTrace) steps.
+  auto nextnext = next + seconds(kDurationSecs);
+
+  while (++iter < 40) {
+    handler.performRunLoopStep(next, next, iter);
+  }
+
+  EXPECT_TRUE(handler.isAsyncActive());
+
+  handler.performRunLoopStep(nextnext, nextnext);
+  handler.performRunLoopStep(nextnext, nextnext);
+
+  EXPECT_FALSE(handler.isAsyncActive());
+
+  auto logFile = logUrlToPath(cfg.activitiesLogUrl());
+  checkTracefile(logFile.c_str());
+}
+
+TEST(AsyncActivityProfilerHandler, AsyncTraceUsingIter) {
+  std::vector<std::string> log_modules(
+      {"CuptiActivityProfiler.cpp", "output_json.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(1, log_modules);
+
+  auto runIterTest = [&](int start_iter, int warmup_iters, int trace_iters) {
+    LOG(INFO) << "Async Trace Test: start_iteration = " << start_iter
+              << " warmup iterations = " << warmup_iters
+              << " trace iterations = " << trace_iters;
+
+    GenericActivityProfiler profiler(/*cpu only*/ true);
+    AsyncActivityProfilerHandler handler(profiler);
+
+    auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+    Config cfg;
+
+    int iter = 0;
+    auto now = system_clock::now();
+
+    bool success = cfg.parse(fmt::format(
+        R"CFG(
+      PROFILE_START_ITERATION = {}
+      ACTIVITIES_WARMUP_ITERATIONS={}
+      ACTIVITIES_ITERATIONS={}
+      ACTIVITIES_DURATION_SECS = 1
+      ACTIVITIES_LOG_FILE = {}
+    )CFG",
+        start_iter,
+        warmup_iters,
+        trace_iters,
+        traceFile.path()));
+
+    EXPECT_TRUE(success);
+    EXPECT_FALSE(handler.isAsyncActive());
+
+    while (iter < (start_iter - warmup_iters)) {
+      iter++;
+    }
+
+    handler.configure(cfg, now);
+    EXPECT_TRUE(handler.isAsyncActive());
+
+    now += seconds(10);
+    auto next = now + milliseconds(1000);
+
+    handler.performRunLoopStep(now, next);
+    EXPECT_TRUE(handler.isAsyncActive());
+
+    while (iter < start_iter) {
+      handler.performRunLoopStep(now, next, iter++);
+    }
+
+    while (iter < (start_iter + trace_iters)) {
+      handler.performRunLoopStep(now, next, iter++);
+    }
+
+    if (iter >= (start_iter + trace_iters)) {
+      handler.performRunLoopStep(now, next, iter++);
+    }
+    EXPECT_TRUE(handler.isAsyncActive());
+
+    auto nextnext = next + milliseconds(1000);
+    handler.performRunLoopStep(nextnext, nextnext);
+    handler.ensureCollectTraceDone();
+    handler.performRunLoopStep(nextnext, nextnext);
+
+    EXPECT_FALSE(handler.isAsyncActive());
+
+    auto logFile = logUrlToPath(cfg.activitiesLogUrl());
+    checkTracefile(logFile.c_str());
+  };
+
+  runIterTest(50, 5, 10);
+  runIterTest(0, 0, 2);
+  runIterTest(0, 5, 5);
+}
+
+TEST(AsyncActivityProfilerHandler, MetadataJsonFormatingTest) {
+  std::vector<std::string> log_modules(
+      {"CuptiActivityProfiler.cpp", "output_json.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(1, log_modules);
+
+  setenv("PT_PROFILER_JOB_NAME", "test_training_job", 1);
+  setenv("PT_PROFILER_JOB_VERSION", "2", 1);
+  setenv("PT_PROFILER_JOB_ATTEMPT_INDEX", "5", 1);
+
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  Config cfg;
+
+  constexpr int kWarmupSecs = 1;
+  constexpr int kDurationSecs = 1;
+  auto now = system_clock::now();
+  auto startTime = now + seconds(kWarmupSecs + 1);
+
+  bool success = cfg.parse(fmt::format(
+      R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = {}
+    ACTIVITIES_DURATION_SECS = {}
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+      kWarmupSecs,
+      kDurationSecs,
+      traceFile.path(),
+      duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
+
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(handler.isAsyncActive());
+
+  handler.configure(cfg, now);
+
+  EXPECT_TRUE(handler.isAsyncActive());
+
+  std::string keyPrefix = "TEST_METADATA_";
+  profiler.addMetadata(keyPrefix + "NORMAL", "\"metadata value\"");
+  profiler.addMetadata(keyPrefix + "NEWLINE", "\"metadata \nvalue\"");
+  profiler.addMetadata(keyPrefix + "BACKSLASH", R"("/test/metadata\path")");
+
+  // End of the collection window, then a step past it to finalize.
+  auto next = startTime + seconds(kDurationSecs);
+  auto after = next + seconds(kDurationSecs);
+
+  handler.performRunLoopStep(startTime, startTime);
+  EXPECT_TRUE(handler.isAsyncActive());
+
+  handler.performRunLoopStep(next, next);
+  EXPECT_TRUE(handler.isAsyncActive());
+
+  handler.performRunLoopStep(after, after);
+  EXPECT_FALSE(handler.isAsyncActive());
+
+#ifdef __linux__
+  auto logFile = logUrlToPath(cfg.activitiesLogUrl());
+  std::ifstream file(logFile);
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open the trace JSON file.");
+  }
+  std::string jsonStr(
+      (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  nlohmann::json jsonData = nlohmann::json::parse(jsonStr);
+
+  EXPECT_EQ(3, countSubstrings(jsonStr, keyPrefix));
+  EXPECT_EQ(2, countSubstrings(jsonStr, "metadata value"));
+  EXPECT_EQ(1, countSubstrings(jsonStr, "/test/metadata/path"));
+
+  EXPECT_EQ(
+      jsonData["PT_PROFILER_JOB_NAME"].get<std::string>(), "test_training_job");
+  EXPECT_EQ(jsonData["PT_PROFILER_JOB_VERSION"].get<std::string>(), "2");
+  EXPECT_EQ(jsonData["PT_PROFILER_JOB_ATTEMPT_INDEX"].get<std::string>(), "5");
+#endif
+
+  unsetenv("PT_PROFILER_JOB_NAME");
+  unsetenv("PT_PROFILER_JOB_VERSION");
+  unsetenv("PT_PROFILER_JOB_ATTEMPT_INDEX");
+}
+
+TEST(AsyncActivityProfilerHandler, Cancel) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  // Cancel when inactive is a no-op
+  EXPECT_FALSE(handler.isAsyncActive());
+  handler.cancel();
+  EXPECT_FALSE(handler.isAsyncActive());
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  Config cfg;
+  constexpr int kWarmupSecs = 5;
+  auto now = system_clock::now();
+  auto startTime = now + seconds(kWarmupSecs + 1);
+
+  bool success = cfg.parse(fmt::format(
+      R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = {}
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+      kWarmupSecs,
+      traceFile.path(),
+      duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
+  EXPECT_TRUE(success);
+
+  // Cancel during Warmup
+  handler.configure(cfg, now);
+  EXPECT_TRUE(handler.isAsyncActive());
+  handler.cancel();
+  EXPECT_FALSE(handler.isAsyncActive());
+
+  // Stays inactive on subsequent steps
+  handler.performRunLoopStep(startTime, startTime);
+  EXPECT_FALSE(handler.isAsyncActive());
+
+  // Cancel during CollectTrace
+  handler.configure(cfg, now);
+  EXPECT_TRUE(handler.isAsyncActive());
+  now = startTime;
+  handler.performRunLoopStep(now, now);
+  EXPECT_TRUE(handler.isAsyncActive());
+  handler.cancel();
+  EXPECT_FALSE(handler.isAsyncActive());
+}
+
+TEST(AsyncActivityProfilerHandler, FinalizesPendingTraceOnTeardown) {
+  // Destroying a scheduled handler with a collected-but-unprocessed trace must
+  // let the profiler loop finalize it, not drop it.
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  Config cfg;
+
+  bool success = cfg.parse(fmt::format(
+      R"CFG(
+    PROFILE_START_ITERATION = 1
+    ACTIVITIES_WARMUP_ITERATIONS = 0
+    ACTIVITIES_ITERATIONS = 1
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+      traceFile.path()));
+  EXPECT_TRUE(success);
+
+  {
+    AsyncActivityProfilerHandler handler(profiler);
+    handler.step();
+    EXPECT_FALSE(handler.isAsyncActive());
+
+    handler.scheduleTrace(cfg);
+
+    // Activate the scheduled config and enter CollectTrace.
+    handler.step();
+    EXPECT_TRUE(handler.isAsyncActive());
+
+    // CollectTrace -> ProcessTrace asynchronously. Application step()
+    // deliberately does not finalize ProcessTrace; the loop thread should do
+    // that while exiting.
+    handler.step();
+    handler.ensureCollectTraceDone();
+    EXPECT_TRUE(handler.isAsyncActive());
+
+    // handler goes out of scope here with a collected trace still pending.
+  }
+
+  // The pending trace must have been finalized during teardown.
+  auto logFile = logUrlToPath(cfg.activitiesLogUrl());
+  checkTracefile(logFile.c_str());
+}
+
+TEST(AsyncActivityProfilerHandler, BufferSizeLimitDuringWarmup) {
+  MockGpuProfiler profiler;
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  Config cfg;
+  constexpr int kWarmupSecs = 5;
+  auto now = system_clock::now();
+  auto startTime = now + seconds(kWarmupSecs + 1);
+
+  bool success = cfg.parse(fmt::format(
+      R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = {}
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+    ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB = 3
+  )CFG",
+      kWarmupSecs,
+      traceFile.path(),
+      duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
+  EXPECT_TRUE(success);
+
+  handler.configure(cfg, now);
+  EXPECT_TRUE(handler.isAsyncActive());
+
+  // Simulate GPU buffer overflow
+  profiler.setGpuCollectionStopped(true);
+
+  // During warmup, the handler should detect GPU collection stopped
+  // and transition back to WaitForRequest
+  now = startTime;
+  handler.performRunLoopStep(now, now);
+  EXPECT_FALSE(handler.isAsyncActive());
+}
+
+// An iteration-based request that arrives before the application has begun
+// counting iterations (iterationCount_ == -1) cannot be honored unless it also
+// carries a duration. With no duration it must be dropped, not scheduled.
+TEST(AsyncActivityProfilerHandler, IterationRequestWithoutStepIsRejected) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  Config cfg;
+  bool success = cfg.parse(fmt::format(
+      R"CFG(
+    PROFILE_START_ITERATION = 5
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 2
+    ACTIVITIES_DURATION_SECS = 0
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+      traceFile.path()));
+  ASSERT_TRUE(success);
+  ASSERT_TRUE(cfg.hasProfileStartIteration());
+
+  // No step() has advanced the iteration count, so the request is dropped
+  // synchronously.
+  EXPECT_FALSE(handler.scheduleTrace(cfg));
+  EXPECT_FALSE(handler.isAsyncActive());
+}
+
+// The same iteration-based request is accepted when it carries a duration: the
+// handler falls back to duration/timestamp scheduling instead of rejecting it.
+// This is the path daemon configs take when the application is not reporting
+// iterations.
+TEST(
+    AsyncActivityProfilerHandler,
+    IterationRequestWithDurationFallsBackToTimestamp) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  Config cfg;
+  bool success = cfg.parse(fmt::format(
+      R"CFG(
+    PROFILE_START_ITERATION = 5
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 2
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+      traceFile.path()));
+  ASSERT_TRUE(success);
+  ASSERT_TRUE(cfg.hasProfileStartIteration());
+
+  // Accepted via the duration fallback (contrast the no-duration case above,
+  // which is rejected). scheduleTrace() reports the decision synchronously.
+  EXPECT_TRUE(handler.scheduleTrace(cfg));
+}
+
+// Only one on-demand request may be pending at a time. A second request that
+// arrives while the first is still pending is dropped.
+TEST(AsyncActivityProfilerHandler, SecondRequestWhilePendingIsRejected) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto acceptedFile = createTempTraceFile("libkineto_test_accepted", ".json");
+  auto rejectedFile = createTempTraceFile("libkineto_test_rejected", ".json");
+
+  // Start far in the future so neither request activates during the test; the
+  // accept/reject decision is made synchronously inside scheduleTrace().
+  auto startMs = duration_cast<milliseconds>(
+                     (system_clock::now() + seconds(3600)).time_since_epoch())
+                     .count();
+
+  Config accepted;
+  ASSERT_TRUE(accepted.parse(fmt::format(
+      R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = 0
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+      acceptedFile.path(),
+      startMs)));
+
+  Config rejected;
+  ASSERT_TRUE(rejected.parse(fmt::format(
+      R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = 0
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+      rejectedFile.path(),
+      startMs)));
+
+  // The first request is accepted; a second arriving while it is still pending
+  // is rejected.
+  EXPECT_TRUE(handler.scheduleTrace(accepted));
+  EXPECT_FALSE(handler.scheduleTrace(rejected));
+}
+
+// configure() must refuse a request whose start time has already passed rather
+// than entering warmup for a trace that can never start on time. The start time
+// is kept within the max request age so the config still parses.
+TEST(AsyncActivityProfilerHandler, ConfigureRejectsStartTimeInThePast) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  auto now = system_clock::now();
+  auto startTime = now - seconds(5);
+
+  Config cfg;
+  bool success = cfg.parse(fmt::format(
+      R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = 5
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+      traceFile.path(),
+      duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
+  ASSERT_TRUE(success);
+
+  handler.configure(cfg, now);
+  EXPECT_FALSE(handler.isAsyncActive());
+}
+
+// cancel() must tear down cleanly when the trace has finished collecting and is
+// waiting to be processed (RunloopState::ProcessTrace), returning the handler
+// to the idle state.
+TEST(AsyncActivityProfilerHandler, CancelDuringProcessTrace) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  constexpr int kWarmupSecs = 5;
+  constexpr int kDurationSecs = 1;
+  auto now = system_clock::now();
+  auto startTime = now + seconds(kWarmupSecs + 1);
+
+  Config cfg;
+  bool success = cfg.parse(fmt::format(
+      R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = {}
+    ACTIVITIES_DURATION_SECS = {}
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+      kWarmupSecs,
+      kDurationSecs,
+      traceFile.path(),
+      duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
+  ASSERT_TRUE(success);
+
+  handler.configure(cfg, now);
+  EXPECT_TRUE(handler.isAsyncActive());
+
+  // Warmup -> CollectTrace at the start time.
+  now = startTime;
+  handler.performRunLoopStep(now, now);
+
+  // CollectTrace -> ProcessTrace once the collection window closes (a second
+  // past startTime + duration). Driving with the default currentIter (-1)
+  // collects inline, so the state settles on ProcessTrace.
+  auto afterEnd = startTime + seconds(kDurationSecs + 1);
+  handler.performRunLoopStep(afterEnd, afterEnd);
+  EXPECT_TRUE(handler.isAsyncActive());
+
+  handler.cancel();
+  EXPECT_FALSE(handler.isAsyncActive());
+}
+
+// acceptConfig() only schedules when the config actually enables the activity
+// profiler; a config with activities disabled is a no-op.
+TEST(
+    AsyncActivityProfilerHandler,
+    AcceptConfigIgnoresDisabledActivityProfiler) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  Config cfg;
+  ASSERT_TRUE(cfg.parse("ACTIVITIES_ENABLED = false"));
+  ASSERT_FALSE(cfg.activityProfilerEnabled());
+
+  // acceptConfig() reports that it declined the disabled config, rather than
+  // silently doing nothing.
+  EXPECT_FALSE(handler.acceptConfig(cfg));
+  EXPECT_FALSE(handler.isAsyncActive());
+}
+
+// acceptConfig() schedules and reports acceptance when the config enables the
+// activity profiler. Paired with the disabled case above, this pins that the
+// return value reflects the config rather than being constant.
+TEST(
+    AsyncActivityProfilerHandler,
+    AcceptConfigSchedulesEnabledActivityProfiler) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  // Far-future start so the request stays scheduled without activating during
+  // the test.
+  auto startMs = duration_cast<milliseconds>(
+                     (system_clock::now() + seconds(3600)).time_since_epoch())
+                     .count();
+
+  Config cfg;
+  ASSERT_TRUE(cfg.parse(fmt::format(
+      R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = 0
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+      traceFile.path(),
+      startMs)));
+  ASSERT_TRUE(cfg.activityProfilerEnabled());
+
+  EXPECT_TRUE(handler.acceptConfig(cfg));
+}
+
+// Collection start and end drive the registered client exactly once each:
+// start() when warmup completes and collection begins, and stop() when
+// collection finishes (the profiler stops the client while collecting the
+// final trace).
+TEST_F(AsyncClientTest, StartsAndStopsClientAroundCollection) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  constexpr int kWarmupSecs = 5;
+  constexpr int kDurationSecs = 1;
+
+  auto now = system_clock::now();
+  auto startTime = now + seconds(kWarmupSecs + 1);
+
+  Config cfg;
+  ASSERT_TRUE(cfg.parse(fmt::format(
+      R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = {}
+    ACTIVITIES_DURATION_SECS = {}
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+      kWarmupSecs,
+      kDurationSecs,
+      traceFile.path(),
+      duration_cast<milliseconds>(startTime.time_since_epoch()).count())));
+
+  handler.configure(cfg, now);
+  EXPECT_EQ(client_.startCount.load(), 0);
+
+  // Warmup -> CollectTrace starts the client.
+  now = startTime;
+  handler.performRunLoopStep(now, now);
+  EXPECT_EQ(client_.startCount.load(), 1);
+  EXPECT_EQ(client_.stopCount.load(), 0);
+
+  // A second past the end of the collection window (startTime + duration).
+  auto afterEnd = startTime + seconds(kDurationSecs + 1);
+
+  // The run loop advances one state per call. First tick: the collection window
+  // has closed, so it collects the trace (where the profiler stops the client)
+  // and moves CollectTrace -> ProcessTrace. Second tick: it finalizes the
+  // trace, moving ProcessTrace -> WaitForRequest (idle). Same timestamps --
+  // collection has already ended, so we only pump the state machine, not
+  // advance time.
+  handler.performRunLoopStep(afterEnd, afterEnd);
+  handler.performRunLoopStep(afterEnd, afterEnd);
+  EXPECT_FALSE(handler.isAsyncActive());
+  EXPECT_EQ(client_.startCount.load(), 1);
+  EXPECT_EQ(client_.stopCount.load(), 1);
+}
+
+// Cancelling an in-progress collection stops the registered client.
+TEST_F(AsyncClientTest, CancelStopsClient) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  constexpr int kWarmupSecs = 5;
+  auto now = system_clock::now();
+  auto startTime = now + seconds(kWarmupSecs + 1);
+
+  Config cfg;
+  ASSERT_TRUE(cfg.parse(fmt::format(
+      R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = {}
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+      kWarmupSecs,
+      traceFile.path(),
+      duration_cast<milliseconds>(startTime.time_since_epoch()).count())));
+
+  handler.configure(cfg, now);
+  now = startTime;
+  handler.performRunLoopStep(now, now); // Warmup -> CollectTrace
+  ASSERT_EQ(client_.startCount.load(), 1);
+
+  handler.cancel();
+  EXPECT_FALSE(handler.isAsyncActive());
+  EXPECT_EQ(client_.stopCount.load(), 1);
+}
+
+// A memory-profiling request drives the client's memory hooks in order and
+// exports to the configured path. This exercises the CollectMemorySnapshot
+// state and memoryProfilerLoop, which run on a background thread.
+TEST_F(AsyncClientTest, MemoryProfileRequestDrivesClientHooks) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+
+  auto traceFile = createTempTraceFile("libkineto_test_memory", ".json");
+
+  Config cfg;
+  // PROFILE_MEMORY resets the log file to a default, so ACTIVITIES_LOG_FILE
+  // must follow it to control the export path.
+  ASSERT_TRUE(cfg.parse(fmt::format(
+      R"CFG(
+    PROFILE_MEMORY = true
+    PROFILE_MEMORY_DURATION_MSECS = 50
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+      traceFile.path())));
+  ASSERT_TRUE(cfg.memoryProfilerEnabled());
+
+  auto memoryStopped = client_.memoryStopFuture();
+  {
+    // The memory loop runs on a background thread; block on its final client
+    // call (stop_memory_profile) via a future instead of polling. Destroying
+    // the handler at the end of this scope joins that thread before we read the
+    // client below, so the assertions and fixture teardown cannot race the
+    // still-running loop.
+    AsyncActivityProfilerHandler handler(profiler);
+    EXPECT_TRUE(handler.scheduleTrace(cfg));
+    ASSERT_EQ(memoryStopped.wait_for(seconds(15)), std::future_status::ready);
+  }
+
+  EXPECT_EQ(client_.memoryStartCount.load(), 1);
+  EXPECT_EQ(client_.memoryExportCount.load(), 1);
+  EXPECT_EQ(client_.exportedPath(), traceFile.path());
+}

--- a/third_party/kineto/libkineto/test/CMakeLists.txt
+++ b/third_party/kineto/libkineto/test/CMakeLists.txt
@@ -1,0 +1,218 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+include(GoogleTest)
+set(CMAKE_CXX_STANDARD 20)
+
+if(KINETO_BACKEND STREQUAL "xpu")
+    set(XPU_XPUPTI_LIBRARY ${PTI_LIBRARY} ${SYCL_LIBRARY})
+    add_subdirectory(xpupti)
+else()
+    set(XPU_XPUPTI_LIBRARY "")
+endif()
+
+include_directories(${LIBKINETO_DIR})
+link_libraries(fmt::fmt-header-only)
+# ApproximateClockTest
+add_executable(ApproximateClockTest ApproximateClockTest.cpp)
+target_link_libraries(ApproximateClockTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+gtest_discover_tests(ApproximateClockTest)
+
+# ConfigTest
+add_executable(ConfigTest ConfigTest.cpp)
+target_link_libraries(ConfigTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+gtest_discover_tests(ConfigTest)
+
+# ConfigLoaderTest
+add_executable(ConfigLoaderTest ConfigLoaderTest.cpp)
+target_link_libraries(ConfigLoaderTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+gtest_discover_tests(ConfigLoaderTest)
+
+# ActivityProfilerControllerTest
+# Not supported on Windows, uses unix "unistd.h"
+if(NOT WIN32)
+    add_executable(ActivityProfilerControllerTest
+        ActivityProfilerControllerTest.cpp
+        TestUtils.cpp)
+    target_link_libraries(ActivityProfilerControllerTest PRIVATE
+        gtest_main
+        kineto_base kineto_api
+        ${XPU_XPUPTI_LIBRARY})
+    gtest_discover_tests(ActivityProfilerControllerTest)
+
+    # AsyncActivityProfilerHandlerTest
+    add_executable(AsyncActivityProfilerHandlerTest
+        AsyncActivityProfilerHandlerTest.cpp
+        TestUtils.cpp)
+    target_link_libraries(AsyncActivityProfilerHandlerTest PRIVATE
+        gtest_main
+        kineto_base kineto_api
+        nlohmann_json::nlohmann_json
+        ${XPU_XPUPTI_LIBRARY})
+    gtest_discover_tests(AsyncActivityProfilerHandlerTest)
+
+    # SyncActivityProfilerHandlerTest
+    add_executable(SyncActivityProfilerHandlerTest
+        SyncActivityProfilerHandlerTest.cpp)
+    target_link_libraries(SyncActivityProfilerHandlerTest PRIVATE
+        gtest_main
+        kineto_base kineto_api
+        ${XPU_XPUPTI_LIBRARY})
+    gtest_discover_tests(SyncActivityProfilerHandlerTest)
+
+    # GenericActivityProfilerTeardownTest
+    add_executable(GenericActivityProfilerTeardownTest
+        GenericActivityProfilerTeardownTest.cpp)
+    target_link_libraries(GenericActivityProfilerTeardownTest PRIVATE
+        gtest_main
+        kineto_base kineto_api
+        ${XPU_XPUPTI_LIBRARY})
+    gtest_discover_tests(GenericActivityProfilerTeardownTest)
+endif()
+
+if(KINETO_BACKEND STREQUAL "cuda")
+# CuptiActivityProfilerTest
+add_executable(CuptiActivityProfilerTest
+    CuptiActivityProfilerTest.cpp
+    MockActivitySubProfiler.cpp
+    MockCpuActivityBuffer.cpp
+    TestUtils.cpp)
+target_link_libraries(CuptiActivityProfilerTest PRIVATE
+    gtest_main
+    gmock
+    kineto_base kineto_api
+    nlohmann_json::nlohmann_json)
+target_include_directories(CuptiActivityProfilerTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src"
+    "${CUDA_SOURCE_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
+gtest_discover_tests(CuptiActivityProfilerTest)
+# CuptiCallbackApiTest
+add_executable(CuptiCallbackApiTest CuptiCallbackApiTest.cpp)
+target_link_libraries(CuptiCallbackApiTest PRIVATE
+    gtest_main
+    kineto_base kineto_api)
+gtest_discover_tests(CuptiCallbackApiTest)
+
+# CuptiStringsTest
+add_executable(CuptiStringsTest CuptiStringsTest.cpp)
+target_link_libraries(CuptiStringsTest PRIVATE
+    gtest_main
+    kineto_base kineto_api)
+gtest_discover_tests(CuptiStringsTest)
+
+# DevicePropertiesTest
+add_executable(DevicePropertiesTest DevicePropertiesTest.cpp)
+target_link_libraries(DevicePropertiesTest PRIVATE
+    gtest_main
+    kineto_base kineto_api)
+gtest_discover_tests(DevicePropertiesTest)
+endif()
+
+if(KINETO_BACKEND STREQUAL "rocm")
+# RocmActivityProfilerTest
+add_executable(RocmActivityProfilerTest
+    RocmActivityProfilerTest.cpp
+    MockActivitySubProfiler.cpp
+    MockCpuActivityBuffer.cpp
+    TestUtils.cpp)
+target_compile_definitions(RocmActivityProfilerTest PRIVATE
+    "__HIP_PLATFORM_HCC__"
+    "__HIP_PLATFORM_AMD__")
+target_link_libraries(RocmActivityProfilerTest PRIVATE
+    gtest_main
+    gmock
+    kineto_base kineto_api
+    nlohmann_json::nlohmann_json)
+target_include_directories(RocmActivityProfilerTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src"
+    "${ROCM_INCLUDE_DIRS}")
+gtest_discover_tests(RocmActivityProfilerTest)
+endif()
+
+# LoggerObserverTest
+add_executable(LoggerObserverTest LoggerObserverTest.cpp)
+target_link_libraries(LoggerObserverTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+gtest_discover_tests(LoggerObserverTest)
+
+# RegisterLoggerFactoryTest
+add_executable(RegisterLoggerFactoryTest RegisterLoggerFactoryTest.cpp)
+target_link_libraries(RegisterLoggerFactoryTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+target_include_directories(RegisterLoggerFactoryTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src")
+gtest_discover_tests(RegisterLoggerFactoryTest)
+
+# PidInfoTest
+add_executable(PidInfoTest PidInfoTest.cpp)
+target_link_libraries(PidInfoTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+gtest_discover_tests(PidInfoTest)
+
+# TypedMetadataTest
+add_executable(TypedMetadataTest TypedMetadataTest.cpp)
+target_link_libraries(TypedMetadataTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+target_include_directories(TypedMetadataTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src")
+gtest_discover_tests(TypedMetadataTest)
+
+# GenericTraceActivityMetadataTest
+add_executable(GenericTraceActivityMetadataTest
+    GenericTraceActivityMetadataTest.cpp)
+target_link_libraries(GenericTraceActivityMetadataTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+target_include_directories(GenericTraceActivityMetadataTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src")
+gtest_discover_tests(GenericTraceActivityMetadataTest)
+
+# OutputJsonTest
+# Not supported on Windows, uses unix "unistd.h"
+if(NOT WIN32)
+    add_executable(OutputJsonTest
+        OutputJsonTest.cpp
+        TestUtils.cpp)
+    target_link_libraries(OutputJsonTest PRIVATE
+        gtest_main
+        kineto_base kineto_api
+        nlohmann_json::nlohmann_json
+        ${XPU_XPUPTI_LIBRARY})
+    target_include_directories(OutputJsonTest PRIVATE
+        "${LIBKINETO_DIR}"
+        "${LIBKINETO_DIR}/include"
+        "${LIBKINETO_DIR}/src")
+    gtest_discover_tests(OutputJsonTest)
+endif()

--- a/third_party/kineto/libkineto/test/ConfigLoaderTest.cpp
+++ b/third_party/kineto/libkineto/test/ConfigLoaderTest.cpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "include/Config.h"
+#include "src/ConfigLoader.h"
+#include "src/DaemonConfigLoader.h"
+
+using namespace KINETO_NAMESPACE;
+
+namespace {
+
+// Records how ConfigLoader dispatches to a handler and lets a test control
+// whether canAcceptConfig() accepts. When the real poll thread is running,
+// set canAcceptResult before starting it and do not mutate these fields while
+// it runs.
+struct RecordingConfigHandler : ConfigLoader::ConfigHandler {
+  bool canAcceptResult{true};
+  int acceptCalls{0};
+  const Config* lastAcceptedConfig{nullptr};
+
+  // Copied at accept time. The daemon-poll path dispatches a Config that lives
+  // only for the poll iteration, so lastAcceptedConfig dangles afterward; a
+  // value copy of a parsed field stays valid for assertions.
+  std::string lastRequestTraceID;
+
+  bool canAcceptConfig() override {
+    return canAcceptResult;
+  }
+
+  bool acceptConfig(const Config& cfg) override {
+    ++acceptCalls;
+    lastAcceptedConfig = &cfg;
+    lastRequestTraceID = cfg.requestTraceID();
+    return true;
+  }
+};
+
+// Canned daemon responses and recorded queries. Owned by the test; the fake
+// below holds a reference to it. The poll thread writes the recorded fields, so
+// a test reads them only after stopping (joining) the thread.
+struct DaemonPollProbe {
+  std::string onDemandConfig;
+  int readOnDemandCalls{0};
+  bool lastActivitiesRequested{false};
+};
+
+// Stands in for the dynolog IPC config source, so the real background poll
+// thread runs against canned configs with no daemon.
+class FakeDaemonConfigLoader : public IDaemonConfigLoader {
+ public:
+  explicit FakeDaemonConfigLoader(DaemonPollProbe& probe) : probe_(probe) {}
+
+  std::string readBaseConfig() override {
+    return "";
+  }
+
+  std::string readOnDemandConfig(bool activities) override {
+    ++probe_.readOnDemandCalls;
+    probe_.lastActivitiesRequested = activities;
+    return probe_.onDemandConfig;
+  }
+
+  void setCommunicationFabric(bool /*enabled*/) override {}
+
+ private:
+  DaemonPollProbe& probe_;
+};
+
+// Drives the ConfigLoader singleton. Two styles of test live here:
+//   * Handler fan-out tests call notifyHandlers()/canHandlerAcceptConfig()
+//     directly and install no daemon factory, so the background poll thread
+//     (started by addHandler) reads nothing and never calls the handlers.
+//   * Daemon-poll tests install a FakeDaemonConfigLoader factory, start the
+//     real poll thread, and wait on the thread's iteration counter to observe
+//     real poll iterations deterministically.
+// The singleton persists across tests, so TearDown stops the thread, drops the
+// injected loader, clears the factory, and unregisters handlers.
+class ConfigLoaderTest : public ::testing::Test {
+ protected:
+  static ConfigLoader& loader() {
+    return ConfigLoader::instance();
+  }
+
+  // Installs a fake daemon config source. Call before starting the poll thread
+  // (before registering a handler) so the thread's first iteration uses it.
+  static void installFakeDaemon(DaemonPollProbe& probe) {
+    ConfigLoader::setDaemonConfigLoaderFactory(
+        [&probe]() { return std::make_unique<FakeDaemonConfigLoader>(probe); });
+  }
+
+  // Blocks until the thread's iteration counter reaches target or the timeout
+  // elapses. Returns false on timeout.
+  [[nodiscard]] static bool waitForLoopCount(
+      uint64_t target,
+      std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+    return loader().waitForUpdateThreadLoopCountForTesting(target, timeout);
+  }
+
+  void registerHandler(
+      ConfigLoader::ConfigKind kind,
+      ConfigLoader::ConfigHandler* handler) {
+    loader().addHandler(kind, handler);
+    registered_.emplace_back(kind, handler);
+  }
+
+  // Registers handler as an ActivityProfiler handler (which starts the poll
+  // thread) and blocks until the thread has completed loops iterations.
+  // Returns false if that count is not reached before the timeout.
+  [[nodiscard]] bool startPollingAndWait(
+      RecordingConfigHandler& handler,
+      uint64_t loops) {
+    const uint64_t base = loader().updateThreadLoopCountForTesting();
+    registerHandler(ConfigLoader::ConfigKind::ActivityProfiler, &handler);
+    return waitForLoopCount(base + loops);
+  }
+
+  void TearDown() override {
+    // Join the poll thread first, so nothing touches the loader afterward.
+    loader().stopUpdateThread();
+
+    // Drop the injected loader and factory: both capture this test's probe,
+    // which does not outlive the test.
+    loader().resetDaemonConfigLoaderForTesting();
+    ConfigLoader::setDaemonConfigLoaderFactory(nullptr);
+
+    // removeHandler is a no-op for a handler already removed by the test, so
+    // double removal is safe.
+    for (const auto& [kind, handler] : registered_) {
+      loader().removeHandler(kind, handler);
+    }
+    registered_.clear();
+  }
+
+ private:
+  std::vector<std::pair<ConfigLoader::ConfigKind, ConfigLoader::ConfigHandler*>>
+      registered_;
+};
+
+// ---- Handler fan-out ----
+
+// notifyHandlers() forwards the config to every registered handler across all
+// config kinds, passing through the same config object.
+TEST_F(ConfigLoaderTest, NotifyHandlersForwardsConfigToAllRegisteredHandlers) {
+  RecordingConfigHandler activityA;
+  RecordingConfigHandler activityB;
+  registerHandler(ConfigLoader::ConfigKind::ActivityProfiler, &activityA);
+  registerHandler(ConfigLoader::ConfigKind::ActivityProfiler, &activityB);
+
+  Config cfg;
+  loader().notifyHandlers(cfg);
+
+  EXPECT_EQ(activityA.acceptCalls, 1);
+  EXPECT_EQ(activityB.acceptCalls, 1);
+  EXPECT_EQ(activityA.lastAcceptedConfig, &cfg);
+  EXPECT_EQ(activityB.lastAcceptedConfig, &cfg);
+}
+
+// A removed handler no longer receives configs.
+TEST_F(ConfigLoaderTest, RemoveHandlerStopsDispatch) {
+  RecordingConfigHandler handler;
+  registerHandler(ConfigLoader::ConfigKind::ActivityProfiler, &handler);
+
+  Config first;
+  loader().notifyHandlers(first);
+  EXPECT_EQ(handler.acceptCalls, 1);
+
+  loader().removeHandler(ConfigLoader::ConfigKind::ActivityProfiler, &handler);
+
+  Config second;
+  loader().notifyHandlers(second);
+  EXPECT_EQ(handler.acceptCalls, 1); // unchanged: no longer registered
+}
+
+// canHandlerAcceptConfig() is true only when every handler of that kind
+// accepts.
+TEST_F(ConfigLoaderTest, CanHandlerAcceptConfigRequiresAllHandlersOfKind) {
+  const auto kind = ConfigLoader::ConfigKind::ActivityProfiler;
+  RecordingConfigHandler first;
+  RecordingConfigHandler second;
+  registerHandler(kind, &first);
+  registerHandler(kind, &second);
+
+  EXPECT_TRUE(loader().canHandlerAcceptConfig(kind));
+
+  second.canAcceptResult = false;
+  EXPECT_FALSE(loader().canHandlerAcceptConfig(kind));
+}
+
+// canHandlerAcceptConfig() accepts vacuously for a config kind that has no
+// registered handlers.
+TEST_F(ConfigLoaderTest, CanHandlerAcceptConfigVacuouslyTrueWithNoHandlers) {
+  const auto kind = ConfigLoader::ConfigKind::ActivityProfiler;
+  EXPECT_TRUE(loader().canHandlerAcceptConfig(kind));
+}
+
+// ---- Real daemon poll thread ----
+//
+// These tests run the actual updateConfigThread() against a fake daemon and use
+// the iteration counter to synchronize. They tolerate a pre-existing local
+// config file (/etc/libkineto.conf or $KINETO_CONFIG) on the test system.
+
+// The poll thread reads the on-demand config from the daemon, parses it, and
+// dispatches it to registered handlers, requesting activities while the handler
+// can accept.
+TEST_F(ConfigLoaderTest, ThreadPollsDaemonAndDispatchesOnDemandConfig) {
+  DaemonPollProbe probe;
+  probe.onDemandConfig = "REQUEST_TRACE_ID=daemon-trace-42\n";
+  installFakeDaemon(probe);
+
+  RecordingConfigHandler handler;
+  ASSERT_TRUE(startPollingAndWait(handler, /*loops=*/1));
+  loader().stopUpdateThread();
+
+  EXPECT_GE(probe.readOnDemandCalls, 1);
+  EXPECT_TRUE(probe.lastActivitiesRequested);
+  EXPECT_GE(handler.acceptCalls, 1);
+  EXPECT_EQ(handler.lastRequestTraceID, "daemon-trace-42");
+}
+
+// The thread re-polls the on-demand config on its update cadence, so over a
+// couple of intervals it reads the daemon more than once.
+//
+// This runs at the real cadence, so it takes a few seconds. It cannot be sped
+// up by injecting a smaller ON_DEMAND_CONFIG_UPDATE_INTERVAL_SECS via the fake
+// daemon's base config: updateBaseConfig reads the local config file first and
+// uses the daemon base config only when the local read is empty, so a present
+// local config (as on the test hosts) shadows the fake. If that local-first
+// ordering is ever inverted (see the TODO in updateBaseConfig), injecting a
+// faster interval would let this test finish without the wait.
+TEST_F(ConfigLoaderTest, ThreadRepeatedlyPollsOnDemandConfig) {
+  DaemonPollProbe probe;
+  probe.onDemandConfig = "REQUEST_TRACE_ID=x\n";
+  installFakeDaemon(probe);
+
+  RecordingConfigHandler handler;
+  const uint64_t base = loader().updateThreadLoopCountForTesting();
+  registerHandler(ConfigLoader::ConfigKind::ActivityProfiler, &handler);
+
+  // The first poll is immediate; after it, the thread's on-demand interval
+  // reflects the loaded base config. Size the wait for the second poll to that
+  // live interval (with slack) so a host that configured a larger interval does
+  // not cause a spurious timeout.
+  ASSERT_TRUE(waitForLoopCount(base + 1));
+  const auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(
+      loader().onDemandConfigUpdateIntervalForTesting() * 3 +
+      std::chrono::seconds(5));
+  ASSERT_TRUE(waitForLoopCount(base + 2, timeout));
+  loader().stopUpdateThread();
+
+  EXPECT_GE(probe.readOnDemandCalls, 2);
+}
+
+// An empty on-demand response (no config posted) dispatches nothing.
+TEST_F(ConfigLoaderTest, ThreadDropsEmptyOnDemandConfig) {
+  DaemonPollProbe probe; // onDemandConfig defaults empty
+  installFakeDaemon(probe);
+
+  RecordingConfigHandler handler;
+  ASSERT_TRUE(startPollingAndWait(handler, /*loops=*/1));
+  loader().stopUpdateThread();
+
+  EXPECT_GE(probe.readOnDemandCalls, 1);
+  EXPECT_EQ(handler.acceptCalls, 0);
+}
+
+// The thread requests an activities config only while its handlers can accept
+// one; a busy handler suppresses the activities request.
+TEST_F(ConfigLoaderTest, ThreadSuppressesActivitiesRequestWhenHandlerBusy) {
+  DaemonPollProbe probe;
+  probe.onDemandConfig = "REQUEST_TRACE_ID=x\n";
+  installFakeDaemon(probe);
+
+  RecordingConfigHandler handler;
+  handler.canAcceptResult = false; // set before the thread starts
+  ASSERT_TRUE(startPollingAndWait(handler, /*loops=*/1));
+  loader().stopUpdateThread();
+
+  EXPECT_GE(probe.readOnDemandCalls, 1);
+  EXPECT_FALSE(probe.lastActivitiesRequested);
+}
+
+// With no daemon factory installed (the default on non-daemon hosts), the poll
+// thread reads no on-demand config and dispatches nothing.
+TEST_F(ConfigLoaderTest, ThreadWithoutDaemonFactoryDispatchesNothing) {
+  RecordingConfigHandler handler;
+  ASSERT_TRUE(startPollingAndWait(handler, /*loops=*/1));
+  loader().stopUpdateThread();
+
+  EXPECT_EQ(handler.acceptCalls, 0);
+}
+
+} // namespace

--- a/third_party/kineto/libkineto/test/ConfigTest.cpp
+++ b/third_party/kineto/libkineto/test/ConfigTest.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "include/Config.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <ctime>
+
+using namespace std::chrono;
+using namespace KINETO_NAMESPACE;
+
+TEST(ParseTest, Whitespace) {
+  Config cfg;
+  // Check that various types of whitespace is ignored
+  EXPECT_TRUE(cfg.parse(""));
+  EXPECT_TRUE(cfg.parse(" "));
+  EXPECT_TRUE(cfg.parse("\t"));
+  EXPECT_TRUE(cfg.parse("\n"));
+  EXPECT_TRUE(cfg.parse("    "));
+  EXPECT_TRUE(cfg.parse("\t \n  \t\t\n\n"));
+  // Only the above characters are supported
+  EXPECT_FALSE(cfg.parse("\r\n"));
+}
+
+TEST(ParseTest, Comment) {
+  Config cfg;
+  // Anything following a '#' should be ignored, up to a newline
+  EXPECT_TRUE(cfg.parse("# comment"));
+  EXPECT_TRUE(cfg.parse("   # ~!@#$"));
+  EXPECT_TRUE(cfg.parse("\t#abc"));
+  EXPECT_TRUE(cfg.parse("###\n##"));
+  EXPECT_TRUE(cfg.parse("ACTIVITIES_WARMUP_ITERATIONS=1 ##ok"));
+  EXPECT_TRUE(cfg.parse("ACTIVITIES_WARMUP_ITERATIONS=1 ## FOO=2"));
+  // Whatever appears before the comment must be valid format
+  EXPECT_FALSE(cfg.parse("util ## not ok"));
+  EXPECT_FALSE(cfg.parse("## ok \n blah # not OK"));
+  // Check that a comment does not affect config parsing
+  EXPECT_TRUE(cfg.parse(
+      "ACTIVITIES_WARMUP_ITERATIONS = 1 # Warm up for one iteration"));
+  EXPECT_EQ(cfg.activitiesWarmupIterations(), 1);
+}
+
+TEST(ParseTest, Format) {
+  Config cfg;
+  // The basic format is just "name = value"; unknown names are tolerated.
+  // A line with no '=' is invalid, an empty value is allowed, a leading '='
+  // is invalid, and only one setting is allowed per line.
+  EXPECT_FALSE(cfg.parse("foo"));
+  EXPECT_TRUE(cfg.parse("foo="));
+  EXPECT_FALSE(cfg.parse("=foo="));
+  EXPECT_TRUE(cfg.parse("foo=1,2,3"));
+  // Only one setting per line
+  EXPECT_FALSE(cfg.parse("foo = 1,2,3 ; bar = 4,5,6"));
+}
+
+TEST(ParseTest, DefaultActivityTypes) {
+  Config cfg;
+  cfg.validate(std::chrono::system_clock::now());
+  auto default_activities = defaultActivityTypes();
+  EXPECT_EQ(
+      cfg.selectedActivityTypes(),
+      std::set<ActivityType>(
+          default_activities.begin(), default_activities.end()));
+}
+
+TEST(ParseTest, ActivityTypes) {
+  Config cfg;
+  EXPECT_FALSE(cfg.parse("ACTIVITY_TYPES"));
+  EXPECT_TRUE(cfg.parse("ACTIVITY_TYPES="));
+  EXPECT_FALSE(cfg.parse("=ACTIVITY_TYPES="));
+
+  EXPECT_EQ(
+      cfg.selectedActivityTypes(),
+      std::set<ActivityType>(
+          {ActivityType::CPU_OP,
+           ActivityType::CPU_INSTANT_EVENT,
+           ActivityType::PYTHON_FUNCTION,
+           ActivityType::USER_ANNOTATION,
+           ActivityType::GPU_USER_ANNOTATION,
+           ActivityType::GPU_MEMCPY,
+           ActivityType::GPU_MEMSET,
+           ActivityType::CONCURRENT_KERNEL,
+           ActivityType::EXTERNAL_CORRELATION,
+           ActivityType::OVERHEAD,
+           ActivityType::CUDA_RUNTIME,
+           ActivityType::CUDA_DRIVER,
+           ActivityType::CUDA_SYNC,
+           ActivityType::CUDA_EVENT,
+           ActivityType::MTIA_RUNTIME,
+           ActivityType::MTIA_INSIGHT,
+           ActivityType::MTIA_CCP_EVENTS,
+           ActivityType::MTIA_COUNTERS}));
+
+  Config cfg2;
+  EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES=gpu_memcpy,gpu_MeMsEt,kernel"));
+  EXPECT_EQ(
+      cfg2.selectedActivityTypes(),
+      std::set<ActivityType>(
+          {ActivityType::GPU_MEMCPY,
+           ActivityType::GPU_MEMSET,
+           ActivityType::CONCURRENT_KERNEL}));
+
+  EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES = cuda_Runtime,"));
+  EXPECT_EQ(
+      cfg2.selectedActivityTypes(),
+      std::set<ActivityType>({ActivityType::CUDA_RUNTIME}));
+
+  // Should throw an exception because incorrect activity name
+  EXPECT_FALSE(cfg2.parse("ACTIVITY_TYPES = memcopy,cuda_runtime"));
+
+  EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES = cpu_op"));
+  EXPECT_EQ(
+      cfg2.selectedActivityTypes(),
+      std::set<ActivityType>({ActivityType::CPU_OP}));
+
+  EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES = xpu_Runtime"));
+  EXPECT_EQ(
+      cfg2.selectedActivityTypes(),
+      std::set<ActivityType>({ActivityType::XPU_RUNTIME}));
+
+  EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES = xpu_scope_profiler"));
+  EXPECT_EQ(
+      cfg2.selectedActivityTypes(),
+      std::set<ActivityType>({ActivityType::XPU_SCOPE_PROFILER}));
+
+  EXPECT_TRUE(
+      cfg2.parse("ACTIVITY_TYPES=privateuse1_Runtime,privateuse1_driver"));
+  EXPECT_EQ(
+      cfg2.selectedActivityTypes(),
+      std::set<ActivityType>(
+          {ActivityType::PRIVATEUSE1_RUNTIME,
+           ActivityType::PRIVATEUSE1_DRIVER}));
+}
+
+TEST(ParseTest, ProfileStartTime) {
+  Config cfg;
+  system_clock::time_point now = system_clock::now();
+  int64_t tgood_ms =
+      duration_cast<milliseconds>(now.time_since_epoch()).count();
+  EXPECT_TRUE(cfg.parse(fmt::format("PROFILE_START_TIME = {}", tgood_ms)));
+
+  // Pass given PROFILE_START_TIME = 0, a timestamp is assigned.
+  tgood_ms = 0;
+  EXPECT_TRUE(cfg.parse(fmt::format("PROFILE_START_TIME = {}", tgood_ms)));
+
+  // Fail given PROFILE_START_TIME older than kMaxRequestAge from now.
+  int64_t tbad_ms =
+      duration_cast<milliseconds>((now - seconds(15)).time_since_epoch())
+          .count();
+  EXPECT_FALSE(cfg.parse(fmt::format("PROFILE_START_TIME = {}", tbad_ms)));
+}
+
+TEST(ParseTest, RequestTraceIds) {
+  Config cfg;
+  EXPECT_TRUE(cfg.parse("REQUEST_TRACE_ID=XYZ"));
+  EXPECT_EQ(cfg.requestTraceID(), "XYZ");
+  EXPECT_TRUE(cfg.parse("REQUEST_GROUP_TRACE_ID=ABC"));
+  EXPECT_EQ(cfg.requestGroupTraceID(), "ABC");
+}
+
+// Trusted base config may set any trace path.
+TEST(ParseTest, BaseConfigLogFileUnrestricted) {
+  Config cfg;
+  EXPECT_TRUE(cfg.parse("ACTIVITIES_LOG_FILE=/home/user/custom/trace.json"));
+  EXPECT_EQ(cfg.activitiesLogFile(), "/home/user/custom/trace.json");
+}
+
+// On-demand path under the allowed dir is accepted.
+TEST(ParseTest, OnDemandLogFileAllowed) {
+  Config cfg;
+  cfg.setOnDemand(true);
+  EXPECT_TRUE(cfg.parse("ACTIVITIES_LOG_FILE=/tmp/my_trace.json"));
+  EXPECT_EQ(cfg.activitiesLogFile(), "/tmp/my_trace.json");
+}
+
+// On-demand path outside the allowed dir (or with traversal) falls back.
+TEST(ParseTest, OnDemandLogFileRejectedOutsideAllowedDir) {
+  Config cfg;
+  cfg.setOnDemand(true);
+  const std::string original = cfg.activitiesLogFile();
+
+  EXPECT_TRUE(cfg.parse("ACTIVITIES_LOG_FILE=/etc/cron.d/payload"));
+  EXPECT_EQ(cfg.activitiesLogFile(), original);
+  EXPECT_EQ(cfg.activitiesLogFile().rfind("/tmp/", 0), 0u);
+
+  EXPECT_TRUE(cfg.parse("ACTIVITIES_LOG_FILE=/tmp/../etc/cron.d/payload"));
+  EXPECT_EQ(cfg.activitiesLogFile(), original);
+}

--- a/third_party/kineto/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/third_party/kineto/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -1,0 +1,1180 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include <stdlib.h> // NOLINT(modernize-deprecated-headers) required for setenv unsetenv
+
+#include <strings.h>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <map>
+#include <optional>
+#include <variant>
+
+#include "include/Config.h"
+#include "include/MetadataFieldCatalog.h"
+#include "include/libkineto.h"
+#include "include/output_base.h"
+#include "include/time_since_epoch.h"
+#include "src/ActivityTrace.h"
+#include "src/ApproximateClock.h"
+#include "src/CuptiActivityApi.h"
+#include "src/CuptiActivityProfiler.h"
+#include "src/output_json.h"
+#include "src/output_membuf.h"
+
+#include "src/Logger.h"
+#include "test/MockActivitySubProfiler.h"
+#include "test/MockCpuActivityBuffer.h"
+#include "test/TestUtils.h"
+
+using namespace std::chrono;
+using namespace KINETO_NAMESPACE;
+using namespace libkineto::test;
+
+#define CUDA_LAUNCH_KERNEL CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000
+#define CUDA_MEMCPY CUPTI_RUNTIME_TRACE_CBID_cudaMemcpy_v3020
+#define CUDA_STREAM_SYNC CUPTI_RUNTIME_TRACE_CBID_cudaStreamSynchronize_v3020
+#define CUDA_EVENT_SYNC CUPTI_RUNTIME_TRACE_CBID_cudaEventSynchronize_v3020
+
+#define CU_LAUNCH_KERNEL CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel
+#define CU_LAUNCH_KERNEL_EX CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx
+#define CU_MEM_CREATE CUPTI_DRIVER_TRACE_CBID_cuMemCreate
+#define CU_MEM_MAP CUPTI_DRIVER_TRACE_CBID_cuMemMap
+#define CU_MEM_UNMAP CUPTI_DRIVER_TRACE_CBID_cuMemUnmap
+#define CU_MEM_RELEASE CUPTI_DRIVER_TRACE_CBID_cuMemRelease
+#define CU_MEM_EXPORT CUPTI_DRIVER_TRACE_CBID_cuMemExportToShareableHandle
+#define CU_MEM_IMPORT CUPTI_DRIVER_TRACE_CBID_cuMemImportFromShareableHandle
+
+namespace {
+using RecordedMetadataValue = std::variant<
+    int64_t,
+    uint64_t,
+    double,
+    bool,
+    std::string,
+    std::vector<int64_t>,
+    std::vector<std::string>>;
+
+class RecordingTypedMetadataVisitor final : public ITypedMetadataVisitor {
+ public:
+  template <typename T>
+  [[nodiscard]]
+  std::optional<typename MetadataField<T>::FieldType> get(
+      const MetadataField<T>& field) const {
+    auto it = values_.find(std::string{field.name});
+    if (it == values_.end()) {
+      return std::nullopt;
+    }
+    return std::get<typename MetadataField<T>::FieldType>(it->second);
+  }
+
+ private:
+  void visitValue(const MetadataField<int64_t>& field, int64_t value) override {
+    values_[std::string{field.name}] = value;
+  }
+
+  void visitValue(const MetadataField<double>& field, double value) override {
+    values_[std::string{field.name}] = value;
+  }
+
+  void visitValue(const MetadataField<bool>& field, bool value) override {
+    values_[std::string{field.name}] = value;
+  }
+
+  void visitValue(
+      const MetadataField<std::string>& field,
+      std::string_view value) override {
+    values_[std::string{field.name}] = std::string{value};
+  }
+
+  void visitValue(
+      const MetadataField<std::vector<int64_t>>& field,
+      const std::vector<int64_t>& value) override {
+    values_[std::string{field.name}] = value;
+  }
+
+  void visitValue(
+      const MetadataField<std::vector<std::string>>& field,
+      const std::vector<std::string>& value) override {
+    values_[std::string{field.name}] = value;
+  }
+
+  void visitValue(const MetadataField<RawJson>& field, const RawJson& value)
+      override {
+    values_[std::string{field.name}] = std::string{value.value};
+  }
+
+  void visitValue(const MetadataField<uint64_t>& field, uint64_t value)
+      override {
+    values_[std::string{field.name}] = value;
+  }
+
+  void visitValue(
+      [[maybe_unused]] const MetadataField<InputShapes>& field,
+      [[maybe_unused]] const InputShapes& value) override {}
+
+  void visitUnsupported(std::string_view /*name*/) override {}
+
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
+
+  std::map<std::string, RecordedMetadataValue> values_;
+};
+} // namespace
+
+// Provides ability to easily create a few test CUPTI ops
+struct MockCuptiActivityBuffer {
+  void addCorrelationActivity(
+      int64_t correlation,
+      CUpti_ExternalCorrelationKind externalKind,
+      int64_t externalId) {
+    auto& act = createActivity<CUpti_ActivityExternalCorrelation>(correlation);
+    act.kind = CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION;
+    act.externalId = externalId;
+    act.externalKind = externalKind;
+    activities.push_back(reinterpret_cast<CUpti_Activity*>(&act));
+  }
+
+  void addRuntimeActivity(
+      CUpti_runtime_api_trace_cbid_enum cbid,
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation) {
+    auto& act =
+        createActivity<CUpti_ActivityAPI>(start_ns, end_ns, correlation);
+    act.kind = CUPTI_ACTIVITY_KIND_RUNTIME;
+    act.cbid = cbid;
+    act.threadId = threadId();
+    activities.push_back(reinterpret_cast<CUpti_Activity*>(&act));
+  }
+
+  void addDriverActivity(
+      CUpti_driver_api_trace_cbid_enum cbid,
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation) {
+    auto& act =
+        createActivity<CUpti_ActivityAPI>(start_ns, end_ns, correlation);
+    act.kind = CUPTI_ACTIVITY_KIND_DRIVER;
+    act.cbid = cbid;
+    act.threadId = threadId();
+    activities.push_back(reinterpret_cast<CUpti_Activity*>(&act));
+  }
+
+  void addKernelActivity(
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation,
+      uint32_t deviceId = 0,
+      uint32_t contextId = 0,
+      uint32_t streamId = 1) {
+    auto& act =
+        createActivity<CUpti_ActivityKernelType>(start_ns, end_ns, correlation);
+    act.kind = CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL;
+    act.deviceId = deviceId;
+    act.contextId = contextId;
+    act.streamId = streamId;
+    act.name = "kernel";
+    act.gridX = act.gridY = act.gridZ = 1;
+    act.blockX = act.blockY = act.blockZ = 1;
+    activities.push_back(reinterpret_cast<CUpti_Activity*>(&act));
+  }
+
+  void addMemcpyActivity(
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation) {
+    auto& act =
+        createActivity<CUpti_ActivityMemcpyType>(start_ns, end_ns, correlation);
+    act.kind = CUPTI_ACTIVITY_KIND_MEMCPY;
+    act.deviceId = 0;
+    act.streamId = 2;
+    act.copyKind = CUPTI_ACTIVITY_MEMCPY_KIND_HTOD;
+    act.srcKind = CUPTI_ACTIVITY_MEMORY_KIND_PINNED;
+    act.dstKind = CUPTI_ACTIVITY_MEMORY_KIND_DEVICE;
+    activities.push_back(reinterpret_cast<CUpti_Activity*>(&act));
+  }
+
+  void addSyncActivity(
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation,
+      CUpti_ActivitySynchronizationType type,
+      int64_t stream = 1,
+      uint32_t cudaEventId = 0,
+      uint32_t contextId = 0) {
+    auto& act = createActivity<CUpti_ActivitySynchronization>(
+        start_ns, end_ns, correlation);
+    act.kind = CUPTI_ACTIVITY_KIND_SYNCHRONIZATION;
+    act.type = type;
+    act.contextId = contextId;
+    act.streamId = stream;
+    act.cudaEventId = cudaEventId;
+    activities.push_back(reinterpret_cast<CUpti_Activity*>(&act));
+  }
+
+  void addCudaEventActivity(
+      int64_t correlation,
+      uint32_t eventId,
+      uint32_t streamId = 1,
+      uint32_t contextId = 0) {
+    auto& act = createActivity<CUpti_ActivityCudaEventType>(correlation);
+    act.kind = CUPTI_ACTIVITY_KIND_CUDA_EVENT;
+    act.eventId = eventId;
+    act.streamId = streamId;
+    act.contextId = contextId;
+    activities.push_back(reinterpret_cast<CUpti_Activity*>(&act));
+  }
+
+  void addCollectiveActivity(
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation) {
+    auto& act =
+        createActivity<CUpti_ActivityKernelType>(start_ns, end_ns, correlation);
+    act.name = "collective_gpu";
+    act.kind = CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL;
+    act.queued = 0;
+    act.deviceId = 0;
+    act.contextId = 1;
+    act.streamId = 0;
+    act.registersPerThread = 32;
+    act.staticSharedMemory = 1024;
+    act.dynamicSharedMemory = 1024;
+    act.gridX = act.gridY = act.gridZ = 1;
+    act.blockX = act.blockY = act.blockZ = 1;
+    activities.push_back(reinterpret_cast<CUpti_Activity*>(&act));
+  }
+
+  template <class T>
+  T& createActivity(int64_t start_ns, int64_t end_ns, int64_t correlation) {
+    T& act = *static_cast<T*>(malloc(sizeof(T)));
+    bzero(&act, sizeof(act));
+    act.start = start_ns;
+    act.end = end_ns;
+    act.correlationId = correlation;
+    return act;
+  }
+
+  template <class T>
+  T& createActivity(int64_t correlation) {
+    T& act = *static_cast<T*>(malloc(sizeof(T)));
+    bzero(&act, sizeof(act));
+    act.correlationId = correlation;
+    return act;
+  }
+
+  ~MockCuptiActivityBuffer() {
+    for (CUpti_Activity* act : activities) {
+      free(act);
+    }
+  }
+
+  std::vector<CUpti_Activity*> activities;
+};
+
+// Mock parts of the CuptiActivityApi
+class MockCuptiActivities : public CuptiActivityApi {
+ public:
+  const std::pair<int, size_t> processActivities(
+      [[maybe_unused]] CuptiActivityBufferMap& bufferMap,
+      const std::function<void(const CUpti_Activity*)>& handler) override {
+    for (CUpti_Activity* act : activityBuffer->activities) {
+      handler(act);
+    }
+    return {activityBuffer->activities.size(), 100};
+  }
+
+  std::unique_ptr<CuptiActivityBufferMap> activityBuffers() override {
+    auto map = std::make_unique<CuptiActivityBufferMap>();
+    auto buf = std::make_unique<CuptiActivityBuffer>(100);
+    uint8_t* addr = buf->data();
+    (*map)[addr] = std::move(buf);
+    return map;
+  }
+
+  void bufferRequestedOverride(
+      uint8_t** buffer,
+      size_t* size,
+      size_t* maxNumRecords) {
+    this->bufferRequested(buffer, size, maxNumRecords);
+  }
+
+  std::unique_ptr<MockCuptiActivityBuffer> activityBuffer;
+};
+
+// Common setup / teardown and helper functions
+class CuptiActivityProfilerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    profiler_ = std::make_unique<CuptiActivityProfiler>(
+        cuptiActivities_, /*cpu only*/ false);
+    cfg_ = std::make_unique<Config>();
+    cfg_->validate(std::chrono::system_clock::now());
+    loggerFactory.addProtocol("file", [](const std::string& url) {
+      return std::unique_ptr<ActivityLogger>(new ChromeTraceLogger(url));
+    });
+  }
+
+  std::unique_ptr<Config> cfg_;
+  MockCuptiActivities cuptiActivities_;
+  std::unique_ptr<CuptiActivityProfiler> profiler_;
+  ActivityLoggerFactory loggerFactory;
+};
+
+TEST_F(CuptiActivityProfilerTest, SyncTrace) {
+  // Verbose logging is useful for debugging
+  std::vector<std::string> log_modules({"CuptiActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  // Start and stop profiling
+  CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  libkineto::get_time_converter() = [](approx_time_t t) { return t; };
+
+  profiler.recordThreadInfo();
+
+  // Log some cpu ops
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_ns, start_time_ns + duration_ns);
+  cpuOps->addOp("op1", start_time_ns + 20, start_time_ns + 50, 1);
+  cpuOps->addOp("op2", start_time_ns + 30, start_time_ns + 40, 2);
+  cpuOps->addOp("op3", start_time_ns + 100, start_time_ns + 150, 3);
+  cpuOps->addOp("op4", start_time_ns + 160, start_time_ns + 180, 4);
+  cpuOps->addOp("op5", start_time_ns + 190, start_time_ns + 210, 4);
+  profiler.transferCpuTrace(std::move(cpuOps));
+
+  // And some GPU ops
+  auto gpuOps = std::make_unique<MockCuptiActivityBuffer>();
+  gpuOps->addRuntimeActivity(
+      CUDA_LAUNCH_KERNEL, start_time_ns + 33, start_time_ns + 38, 1);
+  gpuOps->addRuntimeActivity(
+      CUDA_MEMCPY, start_time_ns + 110, start_time_ns + 120, 2);
+  gpuOps->addRuntimeActivity(
+      CUDA_LAUNCH_KERNEL, start_time_ns + 130, start_time_ns + 145, 3);
+  gpuOps->addDriverActivity(
+      CU_LAUNCH_KERNEL, start_time_ns + 165, start_time_ns + 175, 4);
+  gpuOps->addDriverActivity(
+      CU_LAUNCH_KERNEL_EX, start_time_ns + 195, start_time_ns + 205, 5);
+  gpuOps->addDriverActivity(
+      CU_MEM_CREATE, start_time_ns + 220, start_time_ns + 230, 6);
+  gpuOps->addDriverActivity(
+      CU_MEM_MAP, start_time_ns + 235, start_time_ns + 245, 7);
+  gpuOps->addDriverActivity(
+      CU_MEM_UNMAP, start_time_ns + 250, start_time_ns + 260, 8);
+  gpuOps->addDriverActivity(
+      CU_MEM_RELEASE, start_time_ns + 265, start_time_ns + 275, 9);
+  gpuOps->addDriverActivity(
+      CU_MEM_EXPORT, start_time_ns + 278, start_time_ns + 285, 10);
+  gpuOps->addDriverActivity(
+      CU_MEM_IMPORT, start_time_ns + 287, start_time_ns + 293, 11);
+  gpuOps->addRuntimeActivity(
+      CUDA_STREAM_SYNC, start_time_ns + 146, start_time_ns + 240, 12);
+  gpuOps->addRuntimeActivity(
+      CUDA_EVENT_SYNC, start_time_ns + 241, start_time_ns + 250, 13);
+  gpuOps->addKernelActivity(start_time_ns + 50, start_time_ns + 70, 1);
+  gpuOps->addMemcpyActivity(start_time_ns + 140, start_time_ns + 150, 2);
+  gpuOps->addKernelActivity(start_time_ns + 160, start_time_ns + 220, 3);
+  gpuOps->addKernelActivity(start_time_ns + 230, start_time_ns + 250, 4);
+  gpuOps->addKernelActivity(start_time_ns + 260, start_time_ns + 280, 5);
+  gpuOps->addSyncActivity(
+      start_time_ns + 221,
+      start_time_ns + 223,
+      12,
+      CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_SYNCHRONIZE);
+  // Add wait event on kernel stream 1
+  gpuOps->addSyncActivity(
+      start_time_ns + 224,
+      start_time_ns + 226,
+      13,
+      CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT,
+      1 /*stream*/);
+  // This event should be ignored because it is not on a stream that has no GPU
+  // kernels
+  gpuOps->addSyncActivity(
+      start_time_ns + 226,
+      start_time_ns + 230,
+      14,
+      CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT,
+      4 /*stream*/);
+  // Comes from CudaEventSynchronize call on CPU
+  gpuOps->addSyncActivity(
+      start_time_ns + 227,
+      start_time_ns + 226,
+      13,
+      CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_EVENT_SYNCHRONIZE,
+      -1 /*stream*/);
+  cuptiActivities_.activityBuffer = std::move(gpuOps);
+
+  // Have the profiler process them
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
+  // Wrapper that allows iterating over the activities
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  EXPECT_EQ(trace.activities()->size(), 26);
+  std::map<std::string, int> activityCounts;
+  std::map<int64_t, int> resourceIds;
+  for (auto& activity : *trace.activities()) {
+    activityCounts[activity->name()]++;
+    resourceIds[activity->resourceId()]++;
+    LOG(INFO) << "[test]" << activity->name() << "," << activity->resourceId();
+  }
+  for (const auto& p : activityCounts) {
+    LOG(INFO) << p.first << ": " << p.second;
+  }
+  EXPECT_EQ(activityCounts["op1"], 1);
+  EXPECT_EQ(activityCounts["op2"], 1);
+  EXPECT_EQ(activityCounts["op3"], 1);
+  EXPECT_EQ(activityCounts["op4"], 1);
+  EXPECT_EQ(activityCounts["cudaLaunchKernel"], 2);
+  EXPECT_EQ(activityCounts["cuLaunchKernelEx"], 1);
+  EXPECT_EQ(activityCounts["cuMemCreate"], 1);
+  EXPECT_EQ(activityCounts["cuMemMap"], 1);
+  EXPECT_EQ(activityCounts["cuMemUnmap"], 1);
+  EXPECT_EQ(activityCounts["cuMemRelease"], 1);
+  EXPECT_EQ(activityCounts["cuMemExportToShareableHandle"], 1);
+  EXPECT_EQ(activityCounts["cuMemImportFromShareableHandle"], 1);
+  EXPECT_EQ(activityCounts["cudaMemcpy"], 1);
+  EXPECT_EQ(activityCounts["cudaStreamSynchronize"], 1);
+  EXPECT_EQ(activityCounts["cudaEventSynchronize"], 1);
+  EXPECT_EQ(activityCounts["kernel"], 4);
+  EXPECT_EQ(activityCounts["Stream Sync"], 1);
+  EXPECT_EQ(activityCounts["Event Sync"], 1);
+  EXPECT_EQ(activityCounts["Memcpy HtoD (Pinned -> Device)"], 1);
+
+  auto sysTid = systemThreadId();
+  // Ops and runtime events are on thread sysTid along with the flow start
+  // events
+  EXPECT_EQ(resourceIds[sysTid], 18);
+  // Kernels and sync events are on stream 1, memcpy on stream 2
+  EXPECT_EQ(resourceIds[1], 6);
+  EXPECT_EQ(resourceIds[2], 1);
+
+#ifdef __linux__
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  trace.save(tmpTrace.path());
+  checkTracefile(tmpTrace.c_str());
+
+  // Verify Stream Sync events are on a separate row from kernel events
+  // in the JSON trace output (tid offset by kSyncStreamTidOffset).
+  {
+    std::ifstream traceFile(tmpTrace.path());
+    std::string traceStr(
+        (std::istreambuf_iterator<char>(traceFile)),
+        std::istreambuf_iterator<char>());
+    auto traceJson = nlohmann::json::parse(traceStr);
+    int64_t kernelTid = -1;
+    int64_t streamSyncTid = -1;
+    bool foundSyncRowMeta = false;
+    for (const auto& event : traceJson["traceEvents"]) {
+      if (event.value("name", "") == "Kernel") {
+        kernelTid = event.value("tid", (int64_t)-1);
+      }
+      if (event.value("name", "") == "Stream Sync") {
+        streamSyncTid = event.value("tid", (int64_t)-1);
+      }
+      if (event.value("name", "") == "thread_name") {
+        auto args = event.value("args", nlohmann::json::object());
+        std::string threadName = args.value("name", "");
+        if (threadName.find("sync") != std::string::npos) {
+          foundSyncRowMeta = true;
+        }
+      }
+    }
+    EXPECT_NE(kernelTid, -1) << "Expected kernel events in trace";
+    EXPECT_NE(streamSyncTid, -1) << "Expected Stream Sync event in trace";
+    EXPECT_NE(kernelTid, streamSyncTid)
+        << "Stream Sync should be on a different tid than kernels";
+    EXPECT_TRUE(foundSyncRowMeta)
+        << "Expected thread_name metadata for sync row";
+  }
+#endif
+}
+
+TEST_F(CuptiActivityProfilerTest, SyncEventCorrIdOutOfOrder) {
+  // Test that wait_on_cuda_event_record_corr_id is populated even when
+  // SYNCHRONIZATION records appear before both the CUDA_EVENT and the kernel
+  // that provides the context->device mapping.
+  std::vector<std::string> log_modules({"CuptiActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  libkineto::get_time_converter() = [](approx_time_t t) { return t; };
+
+  profiler.recordThreadInfo();
+
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_ns, start_time_ns + duration_ns);
+  cpuOps->addOp("op1", start_time_ns + 10, start_time_ns + 50, 1);
+  cpuOps->addOp("op_record", start_time_ns + 60, start_time_ns + 80, 100);
+  cpuOps->addOp("op_wait", start_time_ns + 90, start_time_ns + 110, 200);
+  cpuOps->addOp("op_evt_sync", start_time_ns + 120, start_time_ns + 140, 300);
+  profiler.transferCpuTrace(std::move(cpuOps));
+
+  constexpr uint32_t kEventId = 7777;
+  constexpr uint32_t kContextId = 7;
+  constexpr uint32_t kDeviceId = 3;
+  constexpr uint32_t kRecordCorrId = 100;
+  constexpr uint32_t kWaitCorrId = 200;
+  constexpr uint32_t kEvtSyncCorrId = 300;
+  constexpr uint32_t kEventStreamId = 11;
+  constexpr uint32_t kWaitStreamId = 13;
+
+  // Wait events and synchronization records are added
+  // before the CUDA_EVENT and kernel they reference, as CUPTI
+  // provides no ordering guarantee for activity buffer entries.
+  auto gpuOps = std::make_unique<MockCuptiActivityBuffer>();
+  gpuOps->addRuntimeActivity(
+      CUDA_LAUNCH_KERNEL, start_time_ns + 10, start_time_ns + 20, 1);
+  gpuOps->addSyncActivity(
+      start_time_ns + 100,
+      start_time_ns + 110,
+      kWaitCorrId,
+      CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT,
+      kWaitStreamId,
+      kEventId,
+      kContextId);
+  gpuOps->addSyncActivity(
+      start_time_ns + 120,
+      start_time_ns + 140,
+      kEvtSyncCorrId,
+      CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_EVENT_SYNCHRONIZE,
+      -1,
+      kEventId,
+      kContextId);
+  gpuOps->addCudaEventActivity(
+      kRecordCorrId, kEventId, kEventStreamId, kContextId);
+  gpuOps->addKernelActivity(
+      start_time_ns + 30,
+      start_time_ns + 50,
+      1,
+      kDeviceId,
+      kContextId,
+      kWaitStreamId);
+  cuptiActivities_.activityBuffer = std::move(gpuOps);
+
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+
+  // Find the sync activities and check their metadata
+  int streamWaitFound = 0;
+  int eventSyncFound = 0;
+  for (auto& activity : *trace.activities()) {
+    std::string metadata = activity->metadataJson();
+    if (metadata.find("Stream Wait Event") != std::string::npos) {
+      auto json = nlohmann::json::parse("{" + metadata + "}");
+      EXPECT_EQ(json["wait_on_cuda_event_id"], kEventId)
+          << "Stream Wait Event should reference the correct event ID";
+      EXPECT_EQ(json["wait_on_cuda_event_record_corr_id"], kRecordCorrId)
+          << "Stream Wait Event corr_id should be populated despite out-of-order records";
+      EXPECT_EQ(json["wait_on_stream"], kEventStreamId)
+          << "Stream Wait Event should reference stream the event was recorded on";
+      RecordingTypedMetadataVisitor typedMetadata;
+      activity->visitTypedMetadata(typedMetadata);
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventId),
+          static_cast<uint64_t>(kEventId));
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventRecordCorrId),
+          static_cast<int64_t>(kRecordCorrId));
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnStream),
+          static_cast<int64_t>(kEventStreamId));
+      streamWaitFound++;
+    }
+    if (metadata.find("Event Sync") != std::string::npos) {
+      auto json = nlohmann::json::parse("{" + metadata + "}");
+      EXPECT_EQ(json["wait_on_cuda_event_id"], kEventId)
+          << "Event Sync should reference the correct event ID";
+      EXPECT_EQ(json["wait_on_cuda_event_record_corr_id"], kRecordCorrId)
+          << "Event Sync corr_id should be populated despite out-of-order records";
+      EXPECT_EQ(json["wait_on_stream"], kEventStreamId)
+          << "Event Sync should reference stream the event was recorded on";
+      RecordingTypedMetadataVisitor typedMetadata;
+      activity->visitTypedMetadata(typedMetadata);
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventId),
+          static_cast<uint64_t>(kEventId));
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventRecordCorrId),
+          static_cast<int64_t>(kRecordCorrId));
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnStream),
+          static_cast<int64_t>(kEventStreamId));
+      eventSyncFound++;
+    }
+  }
+  EXPECT_EQ(streamWaitFound, 1) << "Expected exactly one Stream Wait Event";
+  EXPECT_EQ(eventSyncFound, 1) << "Expected exactly one Event Sync";
+
+#ifdef __linux__
+  auto tmpTrace = createTempTraceFile("libkineto_out_of_order_", ".json");
+  trace.save(tmpTrace.path());
+  LOG(INFO) << "Trace exported to: " << tmpTrace.path();
+#endif
+}
+
+TEST_F(CuptiActivityProfilerTest, GpuNCCLCollectiveTest) {
+  // Set logging level for debugging purpose
+  std::vector<std::string> log_modules(
+      {"CuptiActivityProfiler.cpp", "output_json.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  // Start and stop profiling
+  CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  libkineto::get_time_converter() = [](approx_time_t t) { return t; };
+
+  int64_t kernelLaunchTime = start_time_ns + 20;
+  profiler.recordThreadInfo();
+
+  // Prepare metadata map
+  std::unordered_map<std::string, std::string> metadataMap;
+  metadataMap.emplace(
+      kCollectiveName, fmt::format("\"{}\"", "_allgather_base"));
+  metadataMap.emplace(kDtype, fmt::format("\"{}\"", "Float"));
+  metadataMap.emplace(kInMsgNelems, "65664");
+  metadataMap.emplace(kOutMsgNelems, "131328");
+  metadataMap.emplace(kGroupSize, "2");
+  metadataMap.emplace(kProcessGroupName, fmt::format("\"{}\"", "12341234"));
+  metadataMap.emplace(kProcessGroupDesc, fmt::format("\"{}\"", "test_purpose"));
+  metadataMap.emplace(kSeqNum, "4242424242");
+  metadataMap.emplace(kCommsId, "12345678");
+
+  std::vector<int64_t> inSplitSizes(50, 0);
+  std::string inSplitSizesStr;
+  // Logic is copied from: https://fburl.com/code/811a3wq8
+  if (!inSplitSizes.empty() && inSplitSizes.size() <= kTruncatLength) {
+    inSplitSizesStr = fmt::format("\"[{}]\"", fmt::join(inSplitSizes, ", "));
+    metadataMap.emplace(kInSplit, inSplitSizesStr);
+  } else if (inSplitSizes.size() > kTruncatLength) {
+    inSplitSizesStr = fmt::format(
+        "\"[{}, ...]\"",
+        fmt::join(
+            inSplitSizes.begin(), inSplitSizes.begin() + kTruncatLength, ", "));
+    metadataMap.emplace(kInSplit, inSplitSizesStr);
+  }
+
+  std::vector<int64_t> outSplitSizes(20, 1);
+  std::string outSplitSizesStr;
+  // Logic is copied from: https://fburl.com/code/811a3wq8
+  if (!outSplitSizes.empty() && outSplitSizes.size() <= kTruncatLength) {
+    outSplitSizesStr = fmt::format("\"[{}]\"", fmt::join(outSplitSizes, ", "));
+    metadataMap.emplace(kOutSplit, outSplitSizesStr);
+  } else if (outSplitSizes.size() > kTruncatLength) {
+    outSplitSizesStr = fmt::format(
+        "\"[{}, ...]\"",
+        fmt::join(
+            outSplitSizes.begin(),
+            outSplitSizes.begin() + kTruncatLength,
+            ", "));
+    metadataMap.emplace(kOutSplit, outSplitSizesStr);
+  }
+
+  std::vector<int64_t> groupRanks(64, 0);
+  std::string groupRanksStr;
+  if (!groupRanks.empty() && groupRanks.size() <= kTruncatLength) {
+    metadataMap.emplace(
+        kGroupRanks, fmt::format("\"[{}]\"", fmt::join(groupRanks, ", ")));
+  } else if (groupRanks.size() > kTruncatLength) {
+    metadataMap.emplace(
+        kGroupRanks,
+        fmt::format(
+            "\"[{}, ..., {}]\"",
+            fmt::join(
+                groupRanks.begin(),
+                groupRanks.begin() + kTruncatLength - 1,
+                ", "),
+            groupRanks.back()));
+  }
+
+  // Set up CPU events
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_ns, start_time_ns + duration_ns);
+  cpuOps->addOp(
+      kParamCommsCallName,
+      kernelLaunchTime,
+      kernelLaunchTime + 10,
+      1,
+      metadataMap);
+  profiler.transferCpuTrace(std::move(cpuOps));
+
+  // Set up GPU events with two collectives: one after its correlation
+  // record (in-order) and one before (out-of-order), to verify metadata
+  // propagation works regardless of CUPTI buffer ordering.
+  auto gpuOps = std::make_unique<MockCuptiActivityBuffer>();
+  gpuOps->addCorrelationActivity(1, CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM0, 1);
+  gpuOps->addCollectiveActivity(kernelLaunchTime + 5, kernelLaunchTime + 10, 1);
+  gpuOps->addCollectiveActivity(
+      kernelLaunchTime + 15, kernelLaunchTime + 20, 2);
+  gpuOps->addCorrelationActivity(2, CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM0, 1);
+  cuptiActivities_.activityBuffer = std::move(gpuOps);
+
+  // Process trace
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.setLogger(logger.get());
+
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
+  // Check the content of GPU event and we should see extra
+  // collective fields get populated from CPU event.
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  EXPECT_EQ(3, trace.activities()->size());
+  auto& cpu_annotation = trace.activities()->at(0);
+  auto& gpu_annotation1 = trace.activities()->at(1);
+  auto& gpu_annotation2 = trace.activities()->at(2);
+  EXPECT_EQ(cpu_annotation->name(), kParamCommsCallName);
+  EXPECT_EQ(gpu_annotation1->name(), "collective_gpu");
+  EXPECT_EQ(gpu_annotation2->name(), "collective_gpu");
+
+  // Check vector with length > 30 get truncated successfully
+  std::vector<int64_t> expectedInSplit(kTruncatLength, 0);
+  auto expectedInSplitStr =
+      fmt::format("\"[{}, ...]\"", fmt::join(expectedInSplit, ", "));
+  EXPECT_EQ(cpu_annotation->getMetadataValue(kInSplit), expectedInSplitStr);
+  std::vector<int64_t> expectedGroupRanks(kTruncatLength - 1, 0);
+  auto expectedGroupRanksStr = fmt::format(
+      "\"[{}, ..., {}]\"", fmt::join(expectedGroupRanks, ", "), "0");
+  EXPECT_EQ(
+      cpu_annotation->getMetadataValue(kGroupRanks), expectedGroupRanksStr);
+
+#ifdef __linux__
+  // Test saved output can be loaded as JSON
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file: " << tmpTrace.path();
+  trace.save(tmpTrace.path());
+
+  // Check that the saved JSON file can be loaded and deserialized
+  std::ifstream file(tmpTrace.path());
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open the trace JSON file.");
+  }
+  std::string jsonStr(
+      (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  nlohmann::json jsonData = nlohmann::json::parse(jsonStr);
+
+  // Convert the JSON object to a string and check
+  // if the substring exists
+  std::string jsonString = jsonData.dump();
+  EXPECT_EQ(3, countSubstrings(jsonString, "65664"));
+  EXPECT_EQ(3, countSubstrings(jsonString, kInMsgNelems));
+  EXPECT_EQ(3, countSubstrings(jsonString, "65664"));
+  EXPECT_EQ(3, countSubstrings(jsonString, kOutMsgNelems));
+  EXPECT_EQ(3, countSubstrings(jsonString, "131328"));
+  EXPECT_EQ(3, countSubstrings(jsonString, kInSplit));
+  EXPECT_EQ(3, countSubstrings(jsonString, expectedInSplitStr));
+  EXPECT_EQ(3, countSubstrings(jsonString, kOutSplit));
+  EXPECT_EQ(3, countSubstrings(jsonString, outSplitSizesStr));
+  EXPECT_EQ(3, countSubstrings(jsonString, kCollectiveName));
+  EXPECT_EQ(3, countSubstrings(jsonString, "_allgather_base"));
+  EXPECT_EQ(3, countSubstrings(jsonString, kProcessGroupName));
+  EXPECT_EQ(3, countSubstrings(jsonString, "12341234"));
+  EXPECT_EQ(3, countSubstrings(jsonString, kProcessGroupDesc));
+  EXPECT_EQ(3, countSubstrings(jsonString, "test_purpose"));
+  EXPECT_EQ(3, countSubstrings(jsonString, kGroupRanks));
+  EXPECT_EQ(3, countSubstrings(jsonString, expectedGroupRanksStr));
+  EXPECT_EQ(3, countSubstrings(jsonString, kSeqNum));
+  EXPECT_EQ(3, countSubstrings(jsonString, "4242424242"));
+  EXPECT_EQ(3, countSubstrings(jsonString, kCommsId));
+  EXPECT_EQ(3, countSubstrings(jsonString, "12345678"));
+#endif
+}
+
+TEST_F(CuptiActivityProfilerTest, GpuUserAnnotationTest) {
+  // Verbose logging is useful for debugging
+  std::vector<std::string> log_modules({"CuptiActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  // Start and stop profiling
+  CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  libkineto::get_time_converter() = [](approx_time_t t) { return t; };
+
+  int64_t kernelLaunchTime = start_time_ns + 20;
+  profiler.recordThreadInfo();
+
+  // set up CPU event
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_ns, start_time_ns + duration_ns);
+  cpuOps->addOp("annotation", kernelLaunchTime, kernelLaunchTime + 10, 1);
+  profiler.transferCpuTrace(std::move(cpuOps));
+
+  // set up a couple of GPU events and correlate with above CPU event.
+  // CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM1 is used for user annotations.
+  auto gpuOps = std::make_unique<MockCuptiActivityBuffer>();
+  gpuOps->addCorrelationActivity(1, CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM1, 1);
+  gpuOps->addKernelActivity(kernelLaunchTime + 5, kernelLaunchTime + 10, 1);
+  gpuOps->addCorrelationActivity(1, CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM1, 1);
+  gpuOps->addKernelActivity(kernelLaunchTime + 15, kernelLaunchTime + 25, 1);
+  cuptiActivities_.activityBuffer = std::move(gpuOps);
+
+  // process trace
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  std::map<std::string, int> counts;
+  for (auto& activity : *trace.activities()) {
+    counts[activity->name()]++;
+  }
+
+  // We should now have an additional annotation activity created
+  // on the GPU timeline.
+  EXPECT_EQ(counts["annotation"], 2);
+  EXPECT_EQ(counts["kernel"], 2);
+
+  auto& annotation = trace.activities()->at(0);
+  auto& kernel1 = trace.activities()->at(1);
+  auto& kernel2 = trace.activities()->at(2);
+  auto& gpu_annotation = trace.activities()->at(3);
+  EXPECT_EQ(gpu_annotation->type(), ActivityType::GPU_USER_ANNOTATION);
+  EXPECT_EQ(gpu_annotation->timestamp(), kernel1->timestamp());
+  EXPECT_EQ(
+      gpu_annotation->duration(),
+      kernel2->timestamp() + kernel2->duration() - kernel1->timestamp());
+  EXPECT_EQ(gpu_annotation->deviceId(), kernel1->deviceId());
+  EXPECT_EQ(gpu_annotation->resourceId(), kernel1->resourceId());
+  EXPECT_EQ(gpu_annotation->correlationId(), annotation->correlationId());
+  EXPECT_EQ(gpu_annotation->name(), annotation->name());
+}
+
+TEST_F(CuptiActivityProfilerTest, SubActivityProfilers) {
+  // Verbose logging is useful for debugging
+  std::vector<std::string> log_modules({"CuptiActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  // Setup example events to test
+  GenericTraceActivity ev{defaultTraceSpan(), ActivityType::GLOW_RUNTIME, ""};
+  ev.device = 1;
+  ev.resource = 0;
+
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 1000;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+
+  std::deque<GenericTraceActivity> test_activities{3, ev};
+  test_activities[0].startTime = start_time_ns;
+  test_activities[0].endTime = start_time_ns + 5000;
+  test_activities[0].activityName = "SubGraph A execution";
+  test_activities[1].startTime = start_time_ns;
+  test_activities[1].endTime = start_time_ns + 2000;
+  test_activities[1].activityName = "Operator foo";
+  test_activities[2].startTime = start_time_ns + 2500;
+  test_activities[2].endTime = start_time_ns + 2900;
+  test_activities[2].activityName = "Operator bar";
+
+  auto mock_activity_profiler =
+      std::make_unique<MockActivityProfiler>(test_activities);
+
+  MockCuptiActivities activities;
+  CuptiActivityProfiler profiler(activities, /*cpu only*/ true);
+  profiler.addChildActivityProfiler(std::move(mock_activity_profiler));
+
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file " << tmpTrace.path();
+
+  // process trace
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.setLogger(logger.get());
+
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  trace.save(tmpTrace.path());
+  const auto& traced_activites = trace.activities();
+
+  // Test we have all the events
+  EXPECT_EQ(traced_activites->size(), test_activities.size());
+
+  checkTracefile(tmpTrace.c_str());
+}
+
+TEST_F(CuptiActivityProfilerTest, JsonGPUIDSortTest) {
+  // Set logging level for debugging purpose
+  std::vector<std::string> log_modules(
+      {"CuptiActivityProfiler.cpp", "output_json.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  // Start and stop profiling
+  CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 500;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  libkineto::get_time_converter() = [](approx_time_t t) { return t; };
+  profiler.recordThreadInfo();
+
+  // Set up CPU events and corresponding GPU events
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_ns, start_time_ns + duration_ns);
+  cpuOps->addOp("op1", start_time_ns + 10, start_time_ns + 30, 1);
+  profiler.transferCpuTrace(std::move(cpuOps));
+  auto gpuOps = std::make_unique<MockCuptiActivityBuffer>();
+  gpuOps->addRuntimeActivity(
+      CUDA_LAUNCH_KERNEL, start_time_ns + 23, start_time_ns + 28, 1);
+  gpuOps->addKernelActivity(start_time_ns + 50, start_time_ns + 70, 1);
+  cuptiActivities_.activityBuffer = std::move(gpuOps);
+
+  // Process trace
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.setLogger(logger.get());
+
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
+  // Check the content of GPU event and we should see extra
+  // collective fields get populated from CPU event.
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  EXPECT_EQ(3, trace.activities()->size());
+
+#ifdef __linux__
+  // Test saved output can be loaded as JSON
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file: " << tmpTrace.path();
+  trace.save(tmpTrace.path());
+
+  // Check that the saved JSON file can be loaded and deserialized
+  std::ifstream file(tmpTrace.path());
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open the trace JSON file.");
+  }
+  std::string jsonStr(
+      (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  nlohmann::json jsonData = nlohmann::json::parse(jsonStr);
+
+  std::unordered_map<int64_t, std::string> sortLabel;
+  std::unordered_map<int64_t, int64_t> sortIdx;
+  for (auto& event : jsonData["traceEvents"]) {
+    if (event["name"] == "process_labels" && event["tid"] == 0 &&
+        event["pid"].is_number_integer()) {
+      sortLabel[event["pid"].get<int64_t>()] =
+          event["args"]["labels"].get<std::string>();
+    }
+    if (event["name"] == "process_sort_index" && event["tid"] == 0 &&
+        event["pid"].is_number_integer()) {
+      sortIdx[event["pid"].get<int64_t>()] =
+          event["args"]["sort_index"].get<int64_t>();
+    }
+  }
+
+  // Expect there is 1 CUPTI Overhead, and 16 CPU + GPU sorts, total 17.
+  EXPECT_EQ(17, sortLabel.size());
+  for (int i = 0; i < 16; i++) {
+    // Check there are 16 GPU sorts (0-15) with expected sort_index.
+    EXPECT_EQ("GPU " + std::to_string(i), sortLabel[i]);
+    // sortIndex is gpu + kExceedMaxPid to put GPU tracks at the bottom
+    // of the trace timelines.
+    EXPECT_EQ(i + kExceedMaxPid, sortIdx[i]);
+  }
+#endif
+}
+
+TEST_F(CuptiActivityProfilerTest, StreamWaitEventFutureCorrelation) {
+  // When a CUDA event is re-recorded (same eventId, new correlationId), CUPTI
+  // may deliver the later record before the wait. Verify the wait links to the
+  // most recent record that precedes it, not the future re-record.
+  std::vector<std::string> log_modules({"CuptiActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 500;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  libkineto::get_time_converter() = [](approx_time_t t) { return t; };
+  profiler.recordThreadInfo();
+
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_ns, start_time_ns + duration_ns);
+  cpuOps->addOp("op1", start_time_ns + 10, start_time_ns + 30, 1);
+  profiler.transferCpuTrace(std::move(cpuOps));
+
+  // Chronological order: record(corrId=100), wait(corrId=101),
+  // re-record(corrId=200). Delivery order: record(100), re-record(200),
+  // wait(101).
+  auto gpuOps = std::make_unique<MockCuptiActivityBuffer>();
+  gpuOps->addRuntimeActivity(
+      CUDA_LAUNCH_KERNEL, start_time_ns + 13, start_time_ns + 18, 1);
+  gpuOps->addKernelActivity(start_time_ns + 50, start_time_ns + 70, 1);
+  gpuOps->addCudaEventActivity(100, 42, 1, 0);
+  gpuOps->addCudaEventActivity(200, 42, 1, 0);
+  gpuOps->addSyncActivity(
+      start_time_ns + 200,
+      start_time_ns + 202,
+      101,
+      CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT,
+      1,
+      42);
+  cuptiActivities_.activityBuffer = std::move(gpuOps);
+
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+
+  bool foundWaitEvent = false;
+  for (auto& activity : *trace.activities()) {
+    if (activity->name() == "Stream Wait Event") {
+      foundWaitEvent = true;
+      auto metadata = activity->metadataJson();
+      auto json = nlohmann::json::parse("{" + metadata + "}");
+      EXPECT_EQ(json["wait_on_cuda_event_record_corr_id"], 100)
+          << "Should reference corrId 100 (the record before the wait), got: "
+          << metadata;
+      EXPECT_EQ(json["wait_on_cuda_event_id"], 42)
+          << "Should reference eventId 42, got: " << metadata;
+    }
+  }
+  EXPECT_TRUE(foundWaitEvent) << "Stream Wait Event activity not found";
+}
+
+TEST_F(CuptiActivityProfilerTest, WaitEventMapClearedOnReset) {
+  // Verify waitEventMap is cleared between profiling sessions so that a wait
+  // event in session 2 does not pick up a stale record from session 1.
+  std::vector<std::string> log_modules({"CuptiActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 500;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+
+  // Session 1: record eventId=42 with corrId=100, then reset.
+  {
+    CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+    profiler.configure(*cfg_, start_time);
+    profiler.startTrace(start_time);
+    profiler.stopTrace(start_time + nanoseconds(duration_ns));
+    libkineto::get_time_converter() = [](approx_time_t t) { return t; };
+    profiler.recordThreadInfo();
+
+    auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+        start_time_ns, start_time_ns + duration_ns);
+    cpuOps->addOp("op1", start_time_ns + 10, start_time_ns + 30, 1);
+    profiler.transferCpuTrace(std::move(cpuOps));
+
+    auto gpuOps = std::make_unique<MockCuptiActivityBuffer>();
+    gpuOps->addRuntimeActivity(
+        CUDA_LAUNCH_KERNEL, start_time_ns + 13, start_time_ns + 18, 1);
+    gpuOps->addKernelActivity(start_time_ns + 50, start_time_ns + 70, 1);
+    gpuOps->addCudaEventActivity(100, 42, 1, 0);
+    cuptiActivities_.activityBuffer = std::move(gpuOps);
+
+    auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+    profiler.processTrace(*logger);
+    profiler.reset();
+  }
+
+  // Session 2: no cudaEventRecord for eventId=42, but a wait references it.
+  {
+    CuptiActivityProfiler profiler2(cuptiActivities_, /*cpu only*/ false);
+    int64_t start_time_ns2 = start_time_ns + 10000;
+    auto start_time2 = time_point<system_clock>(nanoseconds(start_time_ns2));
+
+    auto cfg2 = std::make_unique<Config>();
+    cfg2->validate(std::chrono::system_clock::now());
+
+    profiler2.configure(*cfg2, start_time2);
+    profiler2.startTrace(start_time2);
+    profiler2.stopTrace(start_time2 + nanoseconds(duration_ns));
+    libkineto::get_time_converter() = [](approx_time_t t) { return t; };
+    profiler2.recordThreadInfo();
+
+    auto cpuOps2 = std::make_unique<MockCpuActivityBuffer>(
+        start_time_ns2, start_time_ns2 + duration_ns);
+    cpuOps2->addOp("op1", start_time_ns2 + 10, start_time_ns2 + 30, 1);
+    profiler2.transferCpuTrace(std::move(cpuOps2));
+
+    auto gpuOps2 = std::make_unique<MockCuptiActivityBuffer>();
+    gpuOps2->addRuntimeActivity(
+        CUDA_LAUNCH_KERNEL, start_time_ns2 + 13, start_time_ns2 + 18, 1);
+    gpuOps2->addKernelActivity(start_time_ns2 + 50, start_time_ns2 + 70, 1);
+    gpuOps2->addSyncActivity(
+        start_time_ns2 + 200,
+        start_time_ns2 + 202,
+        501,
+        CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT,
+        1,
+        42);
+    cuptiActivities_.activityBuffer = std::move(gpuOps2);
+
+    auto logger2 = std::make_unique<MemoryTraceLogger>(*cfg2);
+    profiler2.processTrace(*logger2);
+    profiler2.reset();
+
+    ActivityTrace trace2(std::move(logger2), loggerFactory);
+
+    for (auto& activity : *trace2.activities()) {
+      if (activity->name() == "Stream Wait Event") {
+        auto metadata = activity->metadataJson();
+        auto json = nlohmann::json::parse("{" + metadata + "}");
+        EXPECT_EQ(json["wait_on_cuda_event_record_corr_id"], -1)
+            << "Expected default corrId -1 (no record in session 2), got: "
+            << metadata;
+      }
+    }
+  }
+}

--- a/third_party/kineto/libkineto/test/CuptiCallbackApiTest.cpp
+++ b/third_party/kineto/libkineto/test/CuptiCallbackApiTest.cpp
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "src/CuptiCallbackApi.h"
+#include "src/Logger.h"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono;
+using namespace libkineto;
+
+const size_t some_data = 42;
+
+std::atomic<int> simple_cb_calls = 0;
+
+void simple_cudaLaunchKernel_cb(
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData* cbInfo) {
+  // simple arg check
+  EXPECT_EQ(domain, CUPTI_CB_DOMAIN_RUNTIME_API);
+  EXPECT_EQ(cbid, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000);
+  EXPECT_EQ(*reinterpret_cast<const size_t*>(cbInfo), some_data);
+
+  LOG(INFO) << "CUDA Launch Kernel called";
+
+  simple_cb_calls++;
+}
+
+void simple_cudaLaunchKernelExC_cb(
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData* cbInfo) {
+  // simple arg check
+  EXPECT_EQ(domain, CUPTI_CB_DOMAIN_RUNTIME_API);
+  EXPECT_EQ(cbid, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060);
+  EXPECT_EQ(*reinterpret_cast<const size_t*>(cbInfo), some_data);
+
+  LOG(INFO) << "CUDA Launch Kernel ExC called";
+
+  simple_cb_calls++;
+}
+
+void atomic_cb(
+    [[maybe_unused]] CUpti_CallbackDomain domain,
+    [[maybe_unused]] CUpti_CallbackId cbid,
+    [[maybe_unused]] const CUpti_CallbackData* cbInfo) {
+  // do some atomics in a loop
+  for (int i = 0; i < 1000; i++) {
+    // would have used release consistency but this is fine
+    simple_cb_calls++;
+  }
+}
+
+void empty_cb(
+    [[maybe_unused]] CUpti_CallbackDomain domain,
+    [[maybe_unused]] CUpti_CallbackId cbid,
+    [[maybe_unused]] const CUpti_CallbackData* cbInfo) {}
+
+TEST(CuptiCallbackApiTest, SimpleTest) {
+  auto& api = CuptiCallbackApi::singleton();
+
+  auto addSimpleCallback = [&](CuptiCallbackApi::CuptiCallBackID cbApi,
+                               CuptiCallbackFn cb) -> bool {
+    bool ret = api.registerCallback(CUPTI_CB_DOMAIN_RUNTIME_API, cbApi, cb);
+    return ret;
+  };
+
+  EXPECT_TRUE(addSimpleCallback(
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL,
+      &simple_cudaLaunchKernel_cb))
+      << "Failed to add callback";
+  EXPECT_TRUE(addSimpleCallback(
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC,
+      &simple_cudaLaunchKernelExC_cb))
+      << "Failed to add callback";
+
+  // duplicate add should be okay
+  EXPECT_TRUE(addSimpleCallback(
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL,
+      &simple_cudaLaunchKernel_cb))
+      << "Failed to re-add callback";
+  EXPECT_TRUE(addSimpleCallback(
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC,
+      &simple_cudaLaunchKernelExC_cb))
+      << "Failed to re-add callback";
+
+  simple_cb_calls = 0;
+
+  // simulate callback
+  api.__callback_switchboard(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+      reinterpret_cast<const CUpti_CallbackData*>(&some_data));
+
+  EXPECT_EQ(simple_cb_calls, 1);
+
+  api.__callback_switchboard(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,
+      reinterpret_cast<const CUpti_CallbackData*>(&some_data));
+
+  EXPECT_EQ(simple_cb_calls, 2);
+
+  bool ret = api.deleteCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL,
+      &simple_cudaLaunchKernel_cb);
+
+  EXPECT_TRUE(ret) << "Failed to remove callback";
+
+  ret = api.deleteCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC,
+      &simple_cudaLaunchKernelExC_cb);
+
+  EXPECT_TRUE(ret) << "Failed to remove callback";
+
+  ret = api.deleteCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL,
+      &atomic_cb);
+
+  EXPECT_FALSE(ret) << "oops! deleted a callback that was never added";
+
+  ret = api.deleteCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC,
+      &atomic_cb);
+
+  EXPECT_FALSE(ret) << "oops! deleted a callback that was never added";
+}
+
+TEST(CuptiCallbackApiTest, AllCallbacks) {
+  auto& api = CuptiCallbackApi::singleton();
+
+  auto testCallback =
+      [&](CUpti_CallbackDomain domain,
+          CUpti_CallbackId cbid,
+          CuptiCallbackApi::CuptiCallBackID kineto_cbid) -> bool {
+    bool ret = api.registerCallback(domain, kineto_cbid, atomic_cb);
+    EXPECT_TRUE(ret) << "Failed to add callback";
+
+    if (!ret) {
+      return false;
+    }
+
+    simple_cb_calls = 0;
+    api.__callback_switchboard(domain, cbid, nullptr);
+    EXPECT_EQ(simple_cb_calls, 1000);
+    ret = simple_cb_calls == 1000;
+
+    EXPECT_TRUE(api.deleteCallback(domain, kineto_cbid, atomic_cb));
+
+    return ret;
+  };
+
+  EXPECT_TRUE(testCallback(
+      CUPTI_CB_DOMAIN_RESOURCE,
+      CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
+      CuptiCallbackApi::CuptiCallBackID::RESOURCE_CONTEXT_CREATED))
+      << "Failed to run callback for RESOURCE_CONTEXT_CREATED";
+
+  EXPECT_TRUE(testCallback(
+      CUPTI_CB_DOMAIN_RESOURCE,
+      CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
+      CuptiCallbackApi::CuptiCallBackID::RESOURCE_CONTEXT_DESTROYED))
+      << "Failed to run callback for RESOURCE_CONTEXT_DESTROYED";
+
+  EXPECT_TRUE(testCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL))
+      << "Failed to run callback for CUDA_LAUNCH_KERNEL";
+
+  EXPECT_TRUE(testCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC))
+      << "Failed to run callback for CUDA_LAUNCH_KERNEL_EXC";
+}
+
+TEST(CuptiCallbackApiTest, ContentionTest) {
+  auto& api = CuptiCallbackApi::singleton();
+  const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RUNTIME_API;
+  const CUpti_CallbackId cbid = CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000;
+  const CuptiCallbackApi::CuptiCallBackID kineto_cbid =
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL;
+
+  bool ret = api.registerCallback(domain, kineto_cbid, empty_cb);
+  EXPECT_TRUE(ret) << "Failed to add callback";
+
+  const int iters = 10000;
+  const int num_readers = 8;
+
+  simple_cb_calls = 0;
+
+  // simulate callbacks being executed on multiple threads in parallel
+  //  during this interval add a new atomic_callback.
+  //  this test ensured mutual exclusion is working fine
+  auto read_fn = [&](int tid) {
+    auto start_ts = high_resolution_clock::now();
+    for (int i = 0; i < iters; i++) {
+      api.__callback_switchboard(domain, cbid, nullptr);
+    }
+    auto runtime_ms =
+        duration_cast<milliseconds>(high_resolution_clock::now() - start_ts);
+    LOG(INFO) << "th " << tid << " done in " << runtime_ms.count() << " ms";
+  };
+
+  std::vector<std::thread> read_ths;
+  for (int i = 0; i < num_readers; i++) {
+    read_ths.emplace_back(read_fn, i);
+  }
+
+  ret = api.registerCallback(domain, kineto_cbid, atomic_cb);
+  EXPECT_TRUE(ret) << "Failed to add callback";
+
+  for (auto& t : read_ths) {
+    t.join();
+  }
+
+  // EXPECT_GT(simple_cb_calls, 0)
+  //  << "Atomic callback should have been called at least once.";
+
+  api.deleteCallback(domain, kineto_cbid, empty_cb);
+  api.deleteCallback(domain, kineto_cbid, atomic_cb);
+}
+
+TEST(CuptiCallbackApiTest, Bechmark) {
+  constexpr int iters = 1000;
+  // atomic bench a number of times to get a baseline
+
+  const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RUNTIME_API;
+  const CUpti_CallbackId cbid = CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000;
+  const CuptiCallbackApi::CuptiCallBackID kineto_cbid =
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL;
+
+  LOG(INFO) << "Iteration count = " << iters;
+
+  const bool use_empty = true;
+  auto cbfn = use_empty ? &empty_cb : &atomic_cb;
+
+  // warmup
+  for (int i = 0; i < 50; i++) {
+    (*cbfn)(domain, cbid, nullptr);
+  }
+
+  auto start_ts = high_resolution_clock::now();
+  for (int i = 0; i < iters; i++) {
+    (*cbfn)(domain, cbid, nullptr);
+  }
+  auto delta_baseline_ns =
+      duration_cast<nanoseconds>(high_resolution_clock::now() - start_ts);
+  LOG(INFO) << "Baseline runtime  = " << delta_baseline_ns.count() << " ns";
+
+  auto& api = CuptiCallbackApi::singleton();
+  bool ret = api.registerCallback(domain, kineto_cbid, cbfn);
+  EXPECT_TRUE(ret) << "Failed to add callback";
+
+  // warmup
+  for (int i = 0; i < 50; i++) {
+    api.__callback_switchboard(domain, cbid, nullptr);
+  }
+
+  start_ts = high_resolution_clock::now();
+  for (int i = 0; i < iters; i++) {
+    api.__callback_switchboard(domain, cbid, nullptr);
+  }
+
+  auto delta_callback_ns =
+      duration_cast<nanoseconds>(high_resolution_clock::now() - start_ts);
+  LOG(INFO) << "Callback runtime  = " << delta_callback_ns.count() << " ns";
+
+  LOG(INFO) << "Callback runtime per iteration = "
+            << (delta_callback_ns.count() - delta_baseline_ns.count()) /
+          (double)iters
+            << " ns";
+}

--- a/third_party/kineto/libkineto/test/CuptiStringsTest.cpp
+++ b/third_party/kineto/libkineto/test/CuptiStringsTest.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/cupti_strings.h"
+
+using namespace KINETO_NAMESPACE;
+
+TEST(CuptiStringsTest, RuntimeStripsFourDigitVersionSuffix) {
+  EXPECT_EQ(
+      runtimeCbidName(CUPTI_RUNTIME_TRACE_CBID_cudaDriverGetVersion_v3020),
+      "cudaDriverGetVersion");
+  EXPECT_EQ(
+      runtimeCbidName(CUPTI_RUNTIME_TRACE_CBID_cudaDeviceSynchronize_v3020),
+      "cudaDeviceSynchronize");
+  EXPECT_EQ(
+      runtimeCbidName(CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000),
+      "cudaLaunchKernel");
+}
+
+TEST(CuptiStringsTest, RuntimeStripsFiveDigitVersionSuffix) {
+#if defined(CUPTI_API_VERSION) && CUPTI_API_VERSION >= 18
+  EXPECT_EQ(
+      runtimeCbidName(CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060),
+      "cudaLaunchKernelExC");
+#endif
+  EXPECT_EQ(
+      runtimeCbidName(
+          CUPTI_RUNTIME_TRACE_CBID_cudaStreamSetAttribute_ptsz_v11000),
+      "cudaStreamSetAttribute_ptsz");
+}
+
+// Non-greedy strip: only the trailing CUDA-version suffix `_v12030` is removed.
+// The `_v3` API-generation suffix (single digit) must survive. This case also
+// exercises a cbid >= 446 — the range that returned "INVALID" before this
+// refactor (motivation for D104900166).
+#if defined(CUPTI_API_VERSION) && CUPTI_API_VERSION >= 21
+TEST(CuptiStringsTest, RuntimeStripsOnlyTrailingVersionSuffix) {
+  EXPECT_EQ(
+      runtimeCbidName(
+          CUPTI_RUNTIME_TRACE_CBID_cudaStreamGetCaptureInfo_v3_v12030),
+      "cudaStreamGetCaptureInfo_v3");
+}
+#endif
+
+TEST(CuptiStringsTest, RuntimePreservesNamesWithoutVersionSuffix) {
+  EXPECT_EQ(runtimeCbidName(CUPTI_RUNTIME_TRACE_CBID_INVALID), "INVALID");
+}
+
+TEST(CuptiStringsTest, RuntimeReturnsInvalidForUnknownCbids) {
+  EXPECT_EQ(runtimeCbidName(static_cast<CUpti_CallbackId>(-1)), "INVALID");
+  EXPECT_EQ(
+      runtimeCbidName(static_cast<CUpti_CallbackId>(0xFFFFFFFF)), "INVALID");
+  EXPECT_EQ(runtimeCbidName(100000), "INVALID");
+}
+
+TEST(CuptiStringsTest, DriverPreservesNamesWithoutVersionSuffix) {
+  EXPECT_EQ(driverCbidName(CUPTI_DRIVER_TRACE_CBID_INVALID), "INVALID");
+  EXPECT_EQ(
+      driverCbidName(CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel), "cuLaunchKernel");
+  EXPECT_EQ(driverCbidName(CUPTI_DRIVER_TRACE_CBID_cuMemCreate), "cuMemCreate");
+}
+
+TEST(CuptiStringsTest, DriverReturnsInvalidForUnknownCbids) {
+  EXPECT_EQ(driverCbidName(static_cast<CUpti_CallbackId>(-1)), "INVALID");
+  EXPECT_EQ(
+      driverCbidName(static_cast<CUpti_CallbackId>(0xFFFFFFFF)), "INVALID");
+}

--- a/third_party/kineto/libkineto/test/DevicePropertiesTest.cpp
+++ b/third_party/kineto/libkineto/test/DevicePropertiesTest.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/DeviceProperties.h"
+
+using namespace KINETO_NAMESPACE;
+
+class OccupancyMetricsTest : public ::testing::Test {};
+
+#ifdef HAS_CUPTI
+
+// Verify all cudaOccResult fields are mapped to OccupancyMetrics
+TEST_F(OccupancyMetricsTest, AllFieldsPopulated) {
+  if (smCount(0) == 0) {
+    GTEST_SKIP() << "No GPU available";
+  }
+
+  CUpti_ActivityKernelType kernel = {};
+  kernel.deviceId = 0;
+  kernel.registersPerThread = 32;
+  kernel.staticSharedMemory = 0;
+  kernel.dynamicSharedMemory = 0;
+  kernel.blockX = 256;
+  kernel.blockY = 1;
+  kernel.blockZ = 1;
+  kernel.gridX = 100;
+  kernel.gridY = 1;
+  kernel.gridZ = 1;
+
+  OccupancyMetrics metrics = computeOccupancyMetrics(kernel);
+
+  // All fields from cudaOccResult should be populated (non-default)
+  EXPECT_NE(metrics.occupancy, -1.0f);
+  EXPECT_NE(metrics.result.activeBlocksPerMultiprocessor, 0);
+  // limitingFactors can legitimately be 0 if nothing is limiting
+  EXPECT_NE(metrics.result.blockLimitRegs, 0);
+  EXPECT_NE(metrics.result.blockLimitSharedMem, 0);
+  EXPECT_NE(metrics.result.blockLimitWarps, 0);
+  EXPECT_NE(metrics.result.blockLimitBlocks, 0);
+  // blockLimitBarriers can be 0 if no barriers used
+  EXPECT_NE(metrics.result.allocatedRegistersPerBlock, 0);
+  // allocatedSharedMemPerBlock can be 0 if no shared mem used
+  EXPECT_EQ(metrics.result.partitionedGCConfig, PARTITIONED_GC_OFF);
+}
+
+#endif // HAS_CUPTI

--- a/third_party/kineto/libkineto/test/GenericActivityProfilerTeardownTest.cpp
+++ b/third_party/kineto/libkineto/test/GenericActivityProfilerTeardownTest.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <chrono>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "include/Config.h"
+#include "src/GenericActivityProfiler.h"
+#include "src/output_membuf.h"
+
+using namespace KINETO_NAMESPACE;
+using namespace std::chrono;
+
+namespace {
+
+// Run one full synchronous trace and leave the profiler in the post-teardown
+// state the guards protect: processTrace() -> finalizeTrace() std::move()s
+// traceBuffers_ out (now null). The bare processTrace() does not call
+// resetInternal(), so acceptCpuTraces_ stays true. Net: acceptCpuTraces_ ==
+// true and traceBuffers_ == nullptr -- the state a late transferCpuTrace() or a
+// redundant processTrace() can hit.
+void runSyncTraceLeavingStaleState(
+    GenericActivityProfiler& profiler,
+    const Config& cfg) {
+  const auto now = system_clock::now();
+  profiler.configure(cfg, now);
+  profiler.startTrace(now);
+  profiler.stopTrace(now);
+  MemoryTraceLogger logger(cfg);
+  profiler.processTrace(logger);
+}
+
+} // namespace
+
+class GenericActivityProfilerTeardownTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    cfg_ = std::make_unique<Config>();
+    cfg_->validate(system_clock::now());
+  }
+  std::unique_ptr<Config> cfg_;
+};
+
+// A span arriving after teardown must be discarded, not dereferenced.
+// acceptCpuTraces_ is still true here, so the acceptCpuTraces_ gate alone is
+// not enough -- transferCpuTrace() must also null-check traceBuffers_. Before
+// the fix it ran cpu.push_back() on the null traceBuffers_ and crashed.
+TEST_F(GenericActivityProfilerTeardownTest, LateTransferCpuTraceIsDiscarded) {
+  GenericActivityProfiler profiler(/*cpuOnly=*/true);
+  runSyncTraceLeavingStaleState(profiler, *cfg_);
+
+  auto lateSpan = std::make_unique<CpuTraceBuffer>();
+  lateSpan->span = TraceSpan(0, 0, "late span");
+  lateSpan->gpuOpCount = 0;
+  profiler.transferCpuTrace(std::move(lateSpan)); // must not crash
+}
+
+// A redundant processTrace() after teardown must be a no-op. Unlike
+// transferCpuTrace(), processTraceInternal() has no acceptCpuTraces_ gate, so
+// without the null guard it dereferences the moved-out traceBuffers_
+// (cpu.size()).
+TEST_F(GenericActivityProfilerTeardownTest, RedundantProcessTraceIsNoOp) {
+  GenericActivityProfiler profiler(/*cpuOnly=*/true);
+  runSyncTraceLeavingStaleState(profiler, *cfg_);
+
+  MemoryTraceLogger logger(*cfg_);
+  profiler.processTrace(logger); // must not crash
+}

--- a/third_party/kineto/libkineto/test/GenericTraceActivityMetadataTest.cpp
+++ b/third_party/kineto/libkineto/test/GenericTraceActivityMetadataTest.cpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "include/GenericTraceActivity.h"
+#include "include/TypedMetadata.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+using namespace libkineto;
+
+namespace {
+
+// Records each visited field tagged by the visitValue overload that fired, so
+// tests can tell the verbatim RawJson path (string-keyed addMetadata) apart
+// from the typed path (the MetadataField overload).
+class RecordingVisitor : public ITypedMetadataVisitor {
+ public:
+  std::map<std::string, std::string> recorded;
+
+  void visitValue(const MetadataField<int64_t>& field, int64_t value) override {
+    recorded[std::string{field.name}] = fmt::format("int64={}", value);
+  }
+  void visitValue(const MetadataField<double>& field, double value) override {
+    recorded[std::string{field.name}] = fmt::format("double={}", value);
+  }
+  void visitValue(const MetadataField<bool>& field, bool value) override {
+    recorded[std::string{field.name}] = fmt::format("bool={}", value);
+  }
+  void visitValue(
+      const MetadataField<std::string>& field,
+      std::string_view value) override {
+    recorded[std::string{field.name}] = fmt::format("string={}", value);
+  }
+  void visitValue(const MetadataField<RawJson>& field, const RawJson& value)
+      override {
+    recorded[std::string{field.name}] = fmt::format("rawjson={}", value.value);
+  }
+  void visitValue(
+      const MetadataField<std::vector<int64_t>>& field,
+      const std::vector<int64_t>& /*value*/) override {
+    recorded[std::string{field.name}] = "vector<int64>";
+  }
+  void visitValue(
+      const MetadataField<std::vector<std::string>>& field,
+      const std::vector<std::string>& /*value*/) override {
+    recorded[std::string{field.name}] = "vector<string>";
+  }
+  void visitValue(const MetadataField<uint64_t>& field, uint64_t value)
+      override {
+    recorded[std::string{field.name}] = fmt::format("uint64={}", value);
+  }
+  void visitValue(
+      const MetadataField<InputShapes>& field,
+      const InputShapes& /*value*/) override {
+    recorded[std::string{field.name}] = "inputshapes";
+  }
+  void visitUnsupported(std::string_view name) override {
+    recorded[std::string{name}] = "unsupported";
+  }
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
+};
+
+constexpr uint64_t kBigUnsigned = 18446744073709551615ULL;
+
+constexpr MetadataField<int64_t> kCount{"count"};
+constexpr MetadataField<double> kRatio{"ratio"};
+constexpr MetadataField<bool> kFlag{"flag"};
+constexpr MetadataField<std::string> kLabel{"label"};
+constexpr MetadataField<uint64_t> kAddress{"address"};
+constexpr MetadataField<InputShapes> kInputDims{"input_dims"};
+
+} // namespace
+
+TEST(GenericTraceActivityMetadataTest, StringKeyAddMetadataStoresRawJson) {
+  GenericTraceActivity activity;
+  activity.addMetadata("count", 5);
+  activity.addMetadata("ratio", 1.5);
+  activity.addMetadata("flag", true);
+  activity.addMetadataQuoted("label", "hello");
+  activity.addMetadata("dims", "[1, 2, 3]");
+  activity.addMetadata("addr", kBigUnsigned);
+
+  RecordingVisitor visitor;
+  activity.visitTypedMetadata(visitor);
+
+  // String-keyed addMetadata stores every non-string value as a verbatim JSON
+  // fragment
+  const std::map<std::string, std::string> expected{
+      {"count", "rawjson=5"},
+      {"ratio", "rawjson=1.5"},
+      {"flag", "rawjson=true"},
+      {"label", "string=hello"},
+      {"dims", "rawjson=[1, 2, 3]"},
+      {"addr", "rawjson=18446744073709551615"},
+  };
+  EXPECT_EQ(visitor.recorded, expected);
+}
+
+TEST(GenericTraceActivityMetadataTest, TypedFieldOverloadStoresDeclaredType) {
+  GenericTraceActivity activity;
+  activity.addMetadata(kCount, int64_t{5});
+  activity.addMetadata(kRatio, 1.5);
+  activity.addMetadata(kFlag, true);
+  activity.addMetadata(kLabel, std::string{"hello"});
+
+  RecordingVisitor visitor;
+  activity.visitTypedMetadata(visitor);
+
+  // The MetadataField overload stores each value as its declared type.
+  const std::map<std::string, std::string> expected{
+      {"count", "int64=5"},
+      {"ratio", "double=1.5"},
+      {"flag", "bool=true"},
+      {"label", "string=hello"},
+  };
+  EXPECT_EQ(visitor.recorded, expected);
+}
+
+TEST(GenericTraceActivityMetadataTest, AddTypedMetadataStoresTypedValue) {
+  GenericTraceActivity activity;
+  activity.addTypedMetadata("count", TypedValue{int64_t{5}});
+
+  RecordingVisitor visitor;
+  activity.visitTypedMetadata(visitor);
+
+  const std::map<std::string, std::string> expected{{"count", "int64=5"}};
+  EXPECT_EQ(visitor.recorded, expected);
+}
+
+TEST(GenericTraceActivityMetadataTest, MetadataJsonPreservesValueShapes) {
+  GenericTraceActivity activity;
+  activity.addMetadata("count", 5);
+  activity.addMetadata("ratio", 1.5);
+  activity.addMetadata("flag", true);
+  activity.addMetadataQuoted("label", "hello");
+  activity.addMetadata("dims", "[1, 2, 3]");
+  activity.addMetadata("addr", kBigUnsigned);
+
+  // Order is unspecified (unordered_map), so assert each field independently.
+  const std::string json = activity.metadataJson();
+  EXPECT_NE(json.find("\"count\": 5"), std::string::npos);
+  EXPECT_NE(json.find("\"ratio\": 1.5"), std::string::npos);
+  EXPECT_NE(json.find("\"flag\": true"), std::string::npos);
+  EXPECT_NE(json.find("\"label\": \"hello\""), std::string::npos);
+  // A raw JSON array stays an array, not a quoted string.
+  EXPECT_NE(json.find("\"dims\": [1, 2, 3]"), std::string::npos);
+  // 64-bit unsigned is emitted verbatim, not truncated.
+  EXPECT_NE(json.find("\"addr\": 18446744073709551615"), std::string::npos);
+}
+
+TEST(GenericTraceActivityMetadataTest, GetMetadataValueReturnsStringForm) {
+  GenericTraceActivity activity;
+  activity.addMetadata("count", 5);
+  activity.addMetadataQuoted("label", "hello");
+  activity.addMetadata("dims", "[1, 2, 3]");
+  activity.addMetadata("addr", kBigUnsigned);
+
+  // Each value comes back in the same string form addMetadata used to store
+  EXPECT_EQ(activity.getMetadataValue("count"), "5");
+  EXPECT_EQ(activity.getMetadataValue("label"), "hello");
+  EXPECT_EQ(activity.getMetadataValue("dims"), "[1, 2, 3]");
+  EXPECT_EQ(activity.getMetadataValue("addr"), "18446744073709551615");
+  EXPECT_EQ(activity.getMetadataValue("missing"), "");
+}
+
+TEST(GenericTraceActivityMetadataTest, TypedGetMetadataValueReturnsTypedValue) {
+  GenericTraceActivity activity;
+  activity.addMetadata(kCount, int64_t{5});
+  activity.addMetadata(kLabel, std::string{"hello"});
+  activity.addMetadata("rawInt", 7); // string path -> stored as RawJson
+
+  EXPECT_EQ(activity.getMetadataValue(kCount), std::optional<int64_t>{5});
+  EXPECT_EQ(
+      activity.getMetadataValue(kLabel), std::optional<std::string>{"hello"});
+  // Missing key.
+  EXPECT_EQ(activity.getMetadataValue(kRatio), std::nullopt);
+  // Stored as RawJson via the string path, so a typed int64 read doesn't match.
+  EXPECT_EQ(
+      activity.getMetadataValue(MetadataField<int64_t>{"rawInt"}),
+      std::nullopt);
+}
+
+TEST(GenericTraceActivityMetadataTest, TypedFieldOverloadStoresRichTypes) {
+  GenericTraceActivity activity;
+  activity.addMetadata(kAddress, kBigUnsigned);
+  InputShapes dims;
+  dims.emplace_back(std::vector<int64_t>{2, 2});
+  dims.emplace_back(TensorListShapes{{4, 1}, {4, 1}});
+  activity.addMetadata(kInputDims, dims);
+
+  // uint64 is stored typed and read back without truncation.
+  EXPECT_EQ(
+      activity.getMetadataValue(kAddress),
+      std::optional<uint64_t>{kBigUnsigned});
+
+  // Both rich types reach the visitor as their declared types.
+  RecordingVisitor visitor;
+  activity.visitTypedMetadata(visitor);
+  EXPECT_EQ(visitor.recorded.at("address"), "uint64=18446744073709551615");
+  EXPECT_EQ(visitor.recorded.at("input_dims"), "inputshapes");
+}
+
+TEST(
+    GenericTraceActivityMetadataTest,
+    GetMetadataValueSerializesTypedCollections) {
+  GenericTraceActivity activity;
+  activity.addMetadata(
+      MetadataField<std::vector<int64_t>>{"vec"},
+      std::vector<int64_t>{1, 2, 3});
+  InputShapes dims;
+  dims.emplace_back(std::vector<int64_t>{2, 2});
+  dims.emplace_back(TensorListShapes{{4, 1}, {4, 1}});
+  activity.addMetadata(kInputDims, dims);
+
+  // The string accessor renders a typed collection as the same JSON array
+  // string metadataJson() emits, not "".
+  EXPECT_EQ(activity.getMetadataValue("vec"), "[1, 2, 3]");
+  EXPECT_EQ(
+      activity.getMetadataValue("input_dims"), "[[2, 2], [[4, 1], [4, 1]]]");
+}

--- a/third_party/kineto/libkineto/test/LoggerObserverTest.cpp
+++ b/third_party/kineto/libkineto/test/LoggerObserverTest.cpp
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <thread>
+#include <vector>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "LoggerCollector.h"
+#include "include/libkineto.h"
+#include "src/ActivityProfilerController.h"
+#include "src/Logger.h"
+
+using namespace KINETO_NAMESPACE;
+
+#if !USE_GOOGLE_LOG
+
+constexpr char InfoTestStr[] = "Checking LOG(INFO)";
+constexpr char WarningTestStr[] = "Checking LOG(WARNING)";
+constexpr char ErrorTestStr[] = "Checking LOG(ERROR)";
+
+TEST(LoggerObserverTest, SingleCollectorObserver) {
+  // Add a LoggerObserverCollector to collect all logs during the trace.
+  std::unique_ptr<LoggerCollector> lCollector =
+      std::make_unique<LoggerCollector>();
+  Logger::addLoggerObserver(lCollector.get());
+
+  LOG(INFO) << InfoTestStr;
+  LOG(WARNING) << WarningTestStr;
+  LOG(ERROR) << ErrorTestStr;
+
+  auto LoggerMD = lCollector->extractCollectorMetadata();
+  EXPECT_TRUE(
+      LoggerMD[LoggerOutputType::INFO][0].find(InfoTestStr) !=
+      std::string::npos);
+  EXPECT_TRUE(
+      LoggerMD[LoggerOutputType::WARNING][0].find(WarningTestStr) !=
+      std::string::npos);
+  EXPECT_TRUE(
+      LoggerMD[LoggerOutputType::ERROR][0].find(ErrorTestStr) !=
+      std::string::npos);
+
+  Logger::removeLoggerObserver(lCollector.get());
+}
+
+#define NUM_OF_MESSAGES_FOR_EACH_TYPE 10
+#define NUM_OF_WRITE_THREADS 200
+
+// Writes NUM_OF_MESSAGES_FOR_EACH_TYPE messages for each INFO, WARNING, and
+// ERROR.
+void* writeSeveralMessages() {
+  for (int i = 0; i < NUM_OF_MESSAGES_FOR_EACH_TYPE; i++) {
+    LOG(INFO) << InfoTestStr;
+    LOG(WARNING) << WarningTestStr;
+    LOG(ERROR) << ErrorTestStr;
+  }
+  return nullptr;
+}
+
+TEST(LoggerObserverTest, FourCollectorObserver) {
+  // There shouldn't be too many CUPTIActivityProfilers active at the same time.
+  std::unique_ptr<LoggerCollector> lc1 = std::make_unique<LoggerCollector>();
+  std::unique_ptr<LoggerCollector> lc2 = std::make_unique<LoggerCollector>();
+  std::unique_ptr<LoggerCollector> lc3 = std::make_unique<LoggerCollector>();
+  std::unique_ptr<LoggerCollector> lc4 = std::make_unique<LoggerCollector>();
+  Logger::addLoggerObserver(lc1.get());
+  Logger::addLoggerObserver(lc2.get());
+  Logger::addLoggerObserver(lc3.get());
+  Logger::addLoggerObserver(lc4.get());
+
+  // Launch NUM_OF_WRITE_THREADS threads writing several messages.
+  std::vector<std::thread> ListOfThreads;
+  for (int i = 0; i < NUM_OF_WRITE_THREADS; i++) {
+    ListOfThreads.emplace_back(writeSeveralMessages);
+  }
+
+  // Wait for all threads to finish.
+  for (auto& thread : ListOfThreads) {
+    thread.join();
+  }
+
+  auto lc1MD = lc1->extractCollectorMetadata();
+  int InfoCount = 0, WarnCount = 0, ErrorCount = 0;
+  for (auto& md : lc1MD) {
+    InfoCount += md.first == LoggerOutputType::INFO ? md.second.size() : 0;
+    WarnCount += md.first == LoggerOutputType::WARNING ? md.second.size() : 0;
+    ErrorCount += md.first == LoggerOutputType::ERROR ? md.second.size() : 0;
+  }
+
+  EXPECT_EQ(InfoCount, NUM_OF_WRITE_THREADS * NUM_OF_MESSAGES_FOR_EACH_TYPE);
+  EXPECT_EQ(WarnCount, NUM_OF_WRITE_THREADS * NUM_OF_MESSAGES_FOR_EACH_TYPE);
+  EXPECT_EQ(ErrorCount, NUM_OF_WRITE_THREADS * NUM_OF_MESSAGES_FOR_EACH_TYPE);
+
+  Logger::removeLoggerObserver(lc1.get());
+  Logger::removeLoggerObserver(lc2.get());
+  Logger::removeLoggerObserver(lc3.get());
+  Logger::removeLoggerObserver(lc4.get());
+}
+
+TEST(LoggerObserverTest, AddAndGetLoggerCollector) {
+  auto baseline = ActivityProfilerController::getLoggerCollectors().size();
+
+  // Register a logger collector via the static API.
+  ActivityProfilerController::addLoggerCollectorFactory(
+      []() { return std::make_shared<LoggerCollector>(); });
+
+  auto collectors = ActivityProfilerController::getLoggerCollectors();
+  EXPECT_EQ(collectors.size(), baseline + 1);
+
+  // The returned collector should be a valid LoggerCollector that can
+  // receive log messages when manually registered as an observer.
+  auto& collector = collectors[baseline];
+  Logger::addLoggerObserver(collector.get());
+
+  LOG(INFO) << InfoTestStr;
+  LOG(WARNING) << WarningTestStr;
+  LOG(ERROR) << ErrorTestStr;
+
+  auto metadata = collector->extractCollectorMetadata();
+  EXPECT_TRUE(
+      metadata[LoggerOutputType::INFO][0].find(InfoTestStr) !=
+      std::string::npos);
+  EXPECT_TRUE(
+      metadata[LoggerOutputType::WARNING][0].find(WarningTestStr) !=
+      std::string::npos);
+  EXPECT_TRUE(
+      metadata[LoggerOutputType::ERROR][0].find(ErrorTestStr) !=
+      std::string::npos);
+
+  Logger::removeLoggerObserver(collector.get());
+}
+
+TEST(LoggerObserverTest, MultipleLoggerCollectors) {
+  auto baseline = ActivityProfilerController::getLoggerCollectors().size();
+
+  // Register two more collectors.
+  ActivityProfilerController::addLoggerCollectorFactory(
+      []() { return std::make_shared<LoggerCollector>(); });
+  ActivityProfilerController::addLoggerCollectorFactory(
+      []() { return std::make_shared<LoggerCollector>(); });
+
+  auto collectors = ActivityProfilerController::getLoggerCollectors();
+  EXPECT_EQ(collectors.size(), baseline + 2);
+
+  // Both collectors should independently receive log messages.
+  auto& c1 = collectors[baseline];
+  auto& c2 = collectors[baseline + 1];
+  Logger::addLoggerObserver(c1.get());
+  Logger::addLoggerObserver(c2.get());
+
+  LOG(INFO) << InfoTestStr;
+
+  auto md1 = c1->extractCollectorMetadata();
+  auto md2 = c2->extractCollectorMetadata();
+  EXPECT_EQ(md1[LoggerOutputType::INFO].size(), 1);
+  EXPECT_EQ(md2[LoggerOutputType::INFO].size(), 1);
+
+  Logger::removeLoggerObserver(c1.get());
+  Logger::removeLoggerObserver(c2.get());
+}
+
+// Minimal observer that, unlike LoggerCollector, retains STAGE messages so we
+// can verify UST_LOGGER_MARK_COMPLETED behavior.
+class CapturingObserver : public ILoggerObserver {
+ public:
+  void write(const std::string& message, LoggerOutputType ot) override {
+    messages[ot].push_back(message);
+  }
+  const std::map<LoggerOutputType, std::vector<std::string>>
+  extractCollectorMetadata() override {
+    return messages;
+  }
+  void reset() override {
+    messages.clear();
+  }
+  void addDevice([[maybe_unused]] const int64_t device) override {}
+  void setTraceDurationMS([[maybe_unused]] const int64_t duration) override {}
+  void addEventCount([[maybe_unused]] const int64_t count) override {}
+  void addDestination([[maybe_unused]] const std::string& dest) override {}
+  void addMetadata(
+      [[maybe_unused]] const std::string& key,
+      [[maybe_unused]] const std::string& value) override {}
+
+  std::map<LoggerOutputType, std::vector<std::string>> messages;
+};
+
+// Regression test for UST_LOGGER_MARK_COMPLETED and related UST logger
+// completion behavior. USDT_LOGGER_EMIT_MESSAGE previously expanded through the
+// unqualified `LOG`/`LOG_IS_ON` macros, which glog's <glog/logging.h> redefines
+// (LOG -> COMPACT_GOOGLE_LOG_##sev, LOG_IS_ON -> google::GLOG_##sev >= ...).
+// Including both headers in the same translation unit produced
+// COMPACT_GOOGLE_LOG_libkineto / google::GLOG_libkineto -- a compile error.
+//
+// Rather than taking on a build-time dep on glog (which the OSS CMake build
+// does not link), simulate glog's LOG and LOG_IS_ON macros locally. If a
+// future change reintroduces a bare `LOG(...)` or `LOG_IS_ON(...)` token at
+// any UST/USDT macro site, the preprocessor will expand it to
+// `COMPACT_GOOGLE_LOG_libkineto::...` / `google::GLOG_libkineto::...` here
+// and the test will fail to compile. The `#pragma push_macro/pop_macro` pairs
+// scope the redefinition so the surrounding tests still see libkineto's own
+// LOG/LOG_IS_ON.
+#pragma push_macro("LOG")
+#pragma push_macro("LOG_IS_ON")
+#undef LOG
+#undef LOG_IS_ON
+#define COMPACT_GOOGLE_LOG_INFO 0
+#define COMPACT_GOOGLE_LOG_WARNING 0
+#define COMPACT_GOOGLE_LOG_ERROR 0
+#define COMPACT_GOOGLE_LOG_FATAL 0
+#define LOG(severity) COMPACT_GOOGLE_LOG_##severity
+#define LOG_IS_ON(severity) (google::GLOG_##severity >= 0)
+
+TEST(LoggerObserverTest, MacrosImmuneToGlogLogCollision) {
+  auto observer = std::make_unique<CapturingObserver>();
+  Logger::addLoggerObserver(observer.get());
+
+  UST_LOGGER_MARK_COMPLETED("test_stage");
+  USDT_LOGGER_EMIT_MESSAGE("test_msg");
+  USDT_EMIT_START_TRACE();
+  USDT_EMIT_STOP_TRACE();
+
+  const auto md = observer->extractCollectorMetadata();
+  const auto stageIt = md.find(LoggerOutputType::STAGE);
+  ASSERT_NE(stageIt, md.end());
+  EXPECT_EQ(stageIt->second.size(), 1u);
+  EXPECT_NE(stageIt->second[0].find("test_stage"), std::string::npos);
+
+  const auto usdtIt = md.find(LoggerOutputType::USDT);
+  ASSERT_NE(usdtIt, md.end());
+  // One from USDT_LOGGER_EMIT_MESSAGE, plus one each from start/stop trace.
+  EXPECT_EQ(usdtIt->second.size(), 3u);
+
+  Logger::removeLoggerObserver(observer.get());
+}
+
+#pragma pop_macro("LOG_IS_ON")
+#pragma pop_macro("LOG")
+
+// Regression test for the second arm of the fix: the macros must
+// continue to honor Logger::severityLevel(). suppressLibkinetoLogMessages()
+// in init.cpp raises the threshold to ERROR, which historically suppressed
+// STAGE output (STAGE=3 < ERROR=4) via LOG_IF. Since the macros no longer
+// expand through LOG_IF, the gating must be re-implemented in the macro
+// expansion itself.
+//
+// USDT (=5) is the highest severity value in the enum, so it is never
+// suppressed by setSeverityLevel(ERROR); to verify USDT is also gated we set
+// the threshold one step above USDT.
+TEST(LoggerObserverTest, UstMacrosRespectSeverityThreshold) {
+  auto observer = std::make_unique<CapturingObserver>();
+  Logger::addLoggerObserver(observer.get());
+
+  const int originalLevel = Logger::severityLevel();
+
+  // STAGE (3) < ERROR (4): UST_LOGGER_MARK_COMPLETED must be suppressed.
+  Logger::setSeverityLevel(LoggerOutputType::ERROR);
+  UST_LOGGER_MARK_COMPLETED("suppressed_stage");
+  auto md = observer->extractCollectorMetadata();
+  EXPECT_EQ(md[LoggerOutputType::STAGE].size(), 0u);
+
+  // USDT (5) is the highest severity; to suppress it the threshold must be
+  // higher than USDT itself.
+  Logger::setSeverityLevel(LoggerOutputType::USDT + 1);
+  USDT_LOGGER_EMIT_MESSAGE("suppressed_usdt");
+  md = observer->extractCollectorMetadata();
+  EXPECT_EQ(md[LoggerOutputType::USDT].size(), 0u);
+
+  // Lower the threshold and confirm the macros now emit messages.
+  Logger::setSeverityLevel(LoggerOutputType::VERBOSE);
+  UST_LOGGER_MARK_COMPLETED("emitted_stage");
+  USDT_LOGGER_EMIT_MESSAGE("emitted_usdt");
+
+  md = observer->extractCollectorMetadata();
+  ASSERT_EQ(md[LoggerOutputType::STAGE].size(), 1u);
+  EXPECT_NE(
+      md[LoggerOutputType::STAGE][0].find("emitted_stage"), std::string::npos);
+  ASSERT_EQ(md[LoggerOutputType::USDT].size(), 1u);
+  EXPECT_NE(
+      md[LoggerOutputType::USDT][0].find("emitted_usdt"), std::string::npos);
+
+  Logger::setSeverityLevel(originalLevel);
+  Logger::removeLoggerObserver(observer.get());
+}
+
+#endif // !USE_GOOGLE_LOG
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/third_party/kineto/libkineto/test/MockActivitySubProfiler.cpp
+++ b/third_party/kineto/libkineto/test/MockActivitySubProfiler.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <memory>
+#include <set>
+#include <vector>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "libkineto.h"
+#include "output_base.h"
+#include "test/MockActivitySubProfiler.h"
+
+namespace libkineto {
+
+const std::set<ActivityType> supported_activities{ActivityType::CPU_OP};
+const std::string profile_name{"MockProfiler"};
+
+void MockProfilerSession::processTrace(ActivityLogger& logger) {
+  for (const auto& activity : test_activities_) {
+    activity.log(logger);
+  }
+}
+
+const std::string& MockActivityProfiler::name() const {
+  return profile_name;
+}
+
+const std::set<ActivityType>& MockActivityProfiler::availableActivities()
+    const {
+  return supported_activities;
+}
+
+MockActivityProfiler::MockActivityProfiler(
+    std::deque<GenericTraceActivity>& activities)
+    : test_activities_(activities) {}
+
+std::unique_ptr<IActivityProfilerSession> MockActivityProfiler::configure(
+    [[maybe_unused]] const std::set<ActivityType>& activity_types,
+    [[maybe_unused]] const Config& config) {
+  auto session = std::make_unique<MockProfilerSession>();
+  session->set_test_activities(std::move(test_activities_));
+  return session;
+}
+
+std::unique_ptr<IActivityProfilerSession> MockActivityProfiler::configure(
+    [[maybe_unused]] int64_t ts_ms,
+    [[maybe_unused]] int64_t duration_ms,
+    const std::set<ActivityType>& activity_types,
+    const Config& config) {
+  return configure(activity_types, config);
+}
+
+std::unique_ptr<CpuTraceBuffer> MockProfilerSession::getTraceBuffer() {
+  auto buf = std::make_unique<CpuTraceBuffer>();
+  for (auto& i : test_activities_) {
+    buf->emplace_activity(std::move(i));
+  }
+  test_activities_.clear();
+  return buf;
+}
+} // namespace libkineto

--- a/third_party/kineto/libkineto/test/MockActivitySubProfiler.h
+++ b/third_party/kineto/libkineto/test/MockActivitySubProfiler.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <set>
+
+#include "include/IActivityProfiler.h"
+#include "output_base.h"
+
+namespace libkineto {
+
+class MockProfilerSession : public IActivityProfilerSession {
+ public:
+  explicit MockProfilerSession() = default;
+
+  void start() override {
+    start_count++;
+    status_ = TraceStatus::RECORDING;
+  }
+
+  void stop() override {
+    stop_count++;
+    status_ = TraceStatus::PROCESSING;
+  }
+
+  std::vector<std::string> errors() override {
+    return {};
+  }
+
+  void processTrace(ActivityLogger& logger) override;
+
+  void set_test_activities(std::deque<GenericTraceActivity>&& acs) {
+    test_activities_ = std::move(acs);
+  }
+
+  std::unique_ptr<CpuTraceBuffer> getTraceBuffer() override;
+
+  std::unique_ptr<DeviceInfo> getDeviceInfo() override {
+    return {};
+  }
+
+  std::vector<ResourceInfo> getResourceInfos() override {
+    return {};
+  }
+
+  int start_count = 0;
+  int stop_count = 0;
+
+ private:
+  std::deque<GenericTraceActivity> test_activities_;
+};
+
+class MockActivityProfiler : public IActivityProfiler {
+ public:
+  explicit MockActivityProfiler(std::deque<GenericTraceActivity>& activities);
+
+  [[nodiscard]] const std::string& name() const override;
+
+  [[nodiscard]] const std::set<ActivityType>& availableActivities()
+      const override;
+
+  std::unique_ptr<IActivityProfilerSession> configure(
+      const std::set<ActivityType>& activity_types,
+      const Config& config) override;
+
+  std::unique_ptr<IActivityProfilerSession> configure(
+      int64_t ts_ms,
+      int64_t duration_ms,
+      const std::set<ActivityType>& activity_types,
+      const Config& config) override;
+
+ private:
+  std::deque<GenericTraceActivity> test_activities_;
+};
+
+} // namespace libkineto

--- a/third_party/kineto/libkineto/test/MockCpuActivityBuffer.cpp
+++ b/third_party/kineto/libkineto/test/MockCpuActivityBuffer.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "test/MockCpuActivityBuffer.h"
+
+#include "include/GenericTraceActivity.h"
+#include "include/ThreadUtil.h"
+
+namespace libkineto::test {
+
+const TraceSpan& defaultTraceSpan() {
+  static TraceSpan span(0, 0, "Unknown", "");
+  return span;
+}
+
+MockCpuActivityBuffer::MockCpuActivityBuffer(
+    int64_t startTime,
+    int64_t endTime) {
+  span = TraceSpan(startTime, endTime, "Test trace");
+  gpuOpCount = 0;
+}
+
+void MockCpuActivityBuffer::addOp(
+    const std::string& name,
+    int64_t startTime,
+    int64_t endTime,
+    int32_t correlation,
+    const std::unordered_map<std::string, std::string>& metadataMap) {
+  GenericTraceActivity op(span, ActivityType::CPU_OP, name);
+  op.startTime = startTime;
+  op.endTime = endTime;
+  op.device = systemThreadId();
+  op.resource = systemThreadId();
+  op.id = correlation;
+
+  for (const auto& [key, val] : metadataMap) {
+    op.addMetadata(key, val);
+  }
+
+  emplace_activity(std::move(op));
+  span.opCount++;
+}
+
+} // namespace libkineto::test

--- a/third_party/kineto/libkineto/test/MockCpuActivityBuffer.h
+++ b/third_party/kineto/libkineto/test/MockCpuActivityBuffer.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+#include "include/libkineto.h"
+
+// Shared fixtures for the CUDA and ROCm activity-profiler tests: a mock CPU-op
+// buffer, a default trace span, and the param-comms / collective metadata
+// field-name constants both tests assert on. These depend on the kineto
+// activity types, so they live here rather than in the generic TestUtils.h.
+
+namespace libkineto::test {
+
+inline const std::string kParamCommsCallName = "record_param_comms";
+inline constexpr auto kCollectiveName = "Collective name";
+inline constexpr auto kDtype = "dtype";
+inline constexpr auto kInMsgNelems = "In msg nelems";
+inline constexpr auto kOutMsgNelems = "Out msg nelems";
+inline constexpr auto kInSplit = "In split size";
+inline constexpr auto kOutSplit = "Out split size";
+inline constexpr auto kGroupSize = "Group size";
+inline constexpr const char* kProcessGroupName = "Process Group Name";
+inline constexpr const char* kProcessGroupDesc = "Process Group Description";
+inline constexpr const char* kGroupRanks = "Process Group Ranks";
+inline constexpr auto kSeqNum = "Seq";
+inline constexpr const char* kCommsId = "Comms Id";
+inline constexpr int32_t kTruncatLength = 30;
+
+// A shared default TraceSpan used to seed test activities.
+const TraceSpan& defaultTraceSpan();
+
+// A CpuTraceBuffer with a convenience addOp() for building CPU-side ops.
+struct MockCpuActivityBuffer : public CpuTraceBuffer {
+  MockCpuActivityBuffer(int64_t startTime, int64_t endTime);
+
+  void addOp(
+      const std::string& name,
+      int64_t startTime,
+      int64_t endTime,
+      int32_t correlation,
+      const std::unordered_map<std::string, std::string>& metadataMap = {});
+};
+
+} // namespace libkineto::test

--- a/third_party/kineto/libkineto/test/OutputJsonTest.cpp
+++ b/third_party/kineto/libkineto/test/OutputJsonTest.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+
+#include "include/GenericTraceActivity.h"
+#include "include/TraceSpan.h"
+#include "src/output_json.h"
+#include "test/TestUtils.h"
+
+using namespace KINETO_NAMESPACE;
+using namespace libkineto;
+
+namespace {
+
+// Exposes the protected finalizeTrace(endTime) overload so the test can flush a
+// trace without constructing a Config / ActivityBuffers.
+class TestableChromeTraceLogger : public ChromeTraceLogger {
+ public:
+  explicit TestableChromeTraceLogger(const std::string& file)
+      : ChromeTraceLogger(file) {}
+  using ChromeTraceLogger::finalizeTrace;
+};
+
+std::string readFile(const std::string& path) {
+  std::ifstream f(path);
+  return std::string(
+      (std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+}
+
+// Write a trace containing a single CPU-op event with the given name, parse it
+// back, and assert the trace is valid JSON and the name round-trips exactly.
+void expectEventNameRoundTrips(const std::string& eventName) {
+  const auto traceFile =
+      libkineto::test::createTempTraceFile("OutputJsonTest.", ".json");
+
+  TraceSpan span(0, 0, "test_span");
+  GenericTraceActivity act(span, ActivityType::CPU_OP, eventName);
+  act.startTime = 100;
+  act.endTime = 200;
+  act.device = 0;
+  act.resource = 0;
+
+  TestableChromeTraceLogger logger(traceFile.path());
+  logger.handleTraceStart({}, "");
+  logger.handleGenericActivity(act);
+  logger.finalizeTrace(/*endTime=*/300);
+
+  nlohmann::json data;
+  ASSERT_NO_THROW(data = nlohmann::json::parse(readFile(traceFile.path())));
+
+  bool found = false;
+  for (const auto& event : data["traceEvents"]) {
+    if (event.contains("ph") && event["ph"] == "X" && event.contains("name") &&
+        event["name"].get<std::string>() == eventName) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "event name did not round-trip: " << eventName;
+}
+
+// Write a trace with one CONCURRENT_KERNEL GPU event linked to a
+// record_param_comms CPU op carrying collective metadata, flush it, and parse
+// the result. `quoted` selects whether string fields use the legacy RawJson
+// path with surrounding double quotes or the typed path with bare values.
+// Kineto must emit identical valid JSON either way.
+nlohmann::json writeCollectiveTrace(bool quoted) {
+  const auto traceFile =
+      libkineto::test::createTempTraceFile("OutputJsonTest.", ".json");
+
+  TraceSpan span(0, 0, "test_span");
+  GenericTraceActivity recordOp(
+      span, ActivityType::CPU_OP, "record_param_comms");
+  auto addStringMetadata = [&](std::string_view key, const std::string& value) {
+    if (quoted) {
+      recordOp.addMetadata(std::string{key}, "\"" + value + "\"");
+    } else {
+      recordOp.addMetadata(MetadataField<std::string>{key}, value);
+    }
+  };
+  addStringMetadata("Collective name", "allreduce");
+  addStringMetadata("dtype", "Float");
+  addStringMetadata("Process Group Name", "0");
+  addStringMetadata("Process Group Description", "default_pg");
+  addStringMetadata("In split size", "[1, 2]");
+  addStringMetadata("Out split size", "[3, 4]");
+  addStringMetadata("Process Group Ranks", "[0, 1, 2, 3, 4, 5, 6, 7]");
+  addStringMetadata("Input Tensors start", "[[4096, 8192]]");
+  addStringMetadata("Output Tensors start", "[[12288]]");
+  recordOp.addMetadata(MetadataField<int64_t>{"In msg nelems"}, int64_t{1024});
+  recordOp.addMetadata(MetadataField<int64_t>{"Out msg nelems"}, int64_t{512});
+  recordOp.addMetadata(MetadataField<int64_t>{"Group size"}, int64_t{8});
+  recordOp.addMetadata(MetadataField<int64_t>{"Rank"}, int64_t{0});
+  recordOp.addMetadata(MetadataField<int64_t>{"Src Rank"}, int64_t{1});
+  recordOp.addMetadata(MetadataField<int64_t>{"Dst Rank"}, int64_t{2});
+  recordOp.addMetadata(MetadataField<int64_t>{"Seq"}, int64_t{3});
+  recordOp.addMetadata(MetadataField<uint64_t>{"Comms Id"}, uint64_t{4});
+
+  GenericTraceActivity kernel(
+      span, ActivityType::CONCURRENT_KERNEL, "nccl:all_reduce");
+  kernel.startTime = 100;
+  kernel.endTime = 200;
+  kernel.device = 0;
+  kernel.resource = 0;
+  kernel.linked = &recordOp;
+
+  TestableChromeTraceLogger logger(traceFile.path());
+  logger.handleTraceStart({}, "");
+  logger.handleActivity(kernel);
+  logger.finalizeTrace(/*endTime=*/300);
+
+  return nlohmann::json::parse(readFile(traceFile.path()));
+}
+
+// Return the "args" object of the single collective GPU-kernel event.
+nlohmann::json collectiveArgs(const nlohmann::json& trace) {
+  for (const auto& event : trace["traceEvents"]) {
+    if (event.contains("name") && event["name"] == "nccl:all_reduce" &&
+        event.contains("args")) {
+      return event["args"];
+    }
+  }
+  return nlohmann::json::object();
+}
+
+} // namespace
+
+// Reproduces pytorch/pytorch#146900: with with_stack=True an event name can
+// contain `"` (e.g. dynamo co_filenames like {"device": "cpu"}). The writer
+// must JSON-escape those quotes so the trace stays valid JSON.
+TEST(OutputJsonTest, EventNameWithQuotesProducesValidJson) {
+  expectEventNameRoundTrips(
+      R"({"device": "cpu", "dtype": "float32"}(12): run)");
+}
+
+TEST(OutputJsonTest, PlainEventNameIsUnchanged) {
+  expectEventNameRoundTrips("aten::addmm");
+}
+
+// Collective strings arrive quoted from the legacy RawJson path and unquoted
+// from the typed path. Kineto must strip and re-quote them so the GPU-kernel
+// args and distributedInfo have identical string shapes.
+TEST(OutputJsonTest, CollectiveMetadataToleratesQuotedAndUnquotedForms) {
+  const nlohmann::json quoted = writeCollectiveTrace(/*quoted=*/true);
+  const nlohmann::json unquoted = writeCollectiveTrace(/*quoted=*/false);
+
+  const nlohmann::json expectedArgs = {
+      {"Collective name", "allreduce"},
+      {"In msg nelems", 1024},
+      {"Out msg nelems", 512},
+      {"Group size", 8},
+      {"dtype", "Float"},
+      {"Input Tensors start", "[[4096, 8192]]"},
+      {"Output Tensors start", "[[12288]]"},
+      {"In split size", "[1, 2]"},
+      {"Out split size", "[3, 4]"},
+      {"Process Group Name", "0"},
+      {"Process Group Description", "default_pg"},
+      {"Process Group Ranks", "[0, 1, 2, 3, 4, 5, 6, 7]"},
+      {"Src Rank", 1},
+      {"Dst Rank", 2},
+      {"Seq", 3},
+      {"Comms Id", 4},
+  };
+  const nlohmann::json expectedDistInfo = {
+      {"backend", "nccl"},
+      {"rank", 0},
+      {"world_size", 8},
+      {"pg_count", 1},
+      {"pg_config",
+       {{{"pg_name", "0"},
+         {"pg_desc", "default_pg"},
+         {"backend_config", "cuda:nccl"},
+         {"pg_size", 8},
+         {"ranks", "[0, 1, 2, 3, 4, 5, 6, 7]"}}}},
+      {"nccl_version", "unknown"},
+  };
+  // Both input forms must normalize to the same collective args and
+  // distributedInfo; only environment-specific fields (e.g. traceName) differ.
+  EXPECT_EQ(collectiveArgs(quoted), expectedArgs);
+  EXPECT_EQ(collectiveArgs(unquoted), expectedArgs);
+  EXPECT_EQ(quoted["distributedInfo"], expectedDistInfo);
+  EXPECT_EQ(unquoted["distributedInfo"], expectedDistInfo);
+}

--- a/third_party/kineto/libkineto/test/PidInfoTest.cpp
+++ b/third_party/kineto/libkineto/test/PidInfoTest.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "include/ThreadUtil.h"
+
+#include <thread>
+
+#include <gtest/gtest.h>
+
+using namespace KINETO_NAMESPACE;
+
+TEST(ThreadNameTest, setAndGet) {
+  setThreadName("ThreadNameTest");
+  EXPECT_EQ(getThreadName(), "ThreadNameTest");
+
+  setThreadName("");
+  EXPECT_EQ(getThreadName(), "");
+
+  // Spaces etc are ok
+  setThreadName("Name w/ spaces");
+  EXPECT_EQ(getThreadName(), "Name w/ spaces");
+
+  // More than 16 chars is not OK on Linux (pthread_setname_np enforces limit).
+  // macOS and Windows do not enforce a 16-char limit.
+#ifdef __linux__
+  GTEST_EXPECT_FALSE(setThreadName("More than 16 characters"));
+  EXPECT_EQ(getThreadName(), "Name w/ spaces");
+#endif
+}

--- a/third_party/kineto/libkineto/test/RegisterLoggerFactoryTest.cpp
+++ b/third_party/kineto/libkineto/test/RegisterLoggerFactoryTest.cpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <atomic>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "include/libkineto.h"
+#include "include/output_base.h"
+#include "src/ActivityBuffers.h"
+#include "src/ActivityLoggerFactory.h"
+#include "src/ActivityProfilerController.h"
+#include "src/Logger.h"
+
+using namespace KINETO_NAMESPACE;
+
+class MockActivityLogger : public libkineto::ActivityLogger {
+ public:
+  explicit MockActivityLogger(const std::string& url) : url_(url) {}
+
+  void handleDeviceInfo(const libkineto::DeviceInfo&, int64_t) override {}
+  void handleResourceInfo(const libkineto::ResourceInfo&, int64_t) override {}
+  void handleOverheadInfo(
+      const libkineto::ActivityLogger::OverheadInfo&,
+      int64_t) override {}
+  void handleTraceSpan(const libkineto::TraceSpan&) override {}
+  void handleActivity(const libkineto::ITraceActivity&) override {}
+  void handleGenericActivity(const libkineto::GenericTraceActivity&) override {}
+  void handleTraceStart(
+      const std::unordered_map<std::string, std::string>&,
+      const std::string&) override {}
+  void finalizeTrace(
+      const libkineto::Config&,
+      std::unique_ptr<libkineto::ActivityBuffers>,
+      int64_t) override {}
+  void finalizeMemoryTrace(const std::string&, const libkineto::Config&)
+      override {}
+
+  const std::string& getUrl() const {
+    return url_;
+  }
+
+ private:
+  std::string url_;
+};
+
+class CountingLogger : public libkineto::ActivityLogger {
+ public:
+  explicit CountingLogger(std::shared_ptr<int> counter)
+      : counter_(std::move(counter)) {
+    (*counter_)++;
+  }
+
+  void handleDeviceInfo(const libkineto::DeviceInfo&, int64_t) override {}
+  void handleResourceInfo(const libkineto::ResourceInfo&, int64_t) override {}
+  void handleOverheadInfo(
+      const libkineto::ActivityLogger::OverheadInfo&,
+      int64_t) override {}
+  void handleTraceSpan(const libkineto::TraceSpan&) override {}
+  void handleActivity(const libkineto::ITraceActivity&) override {}
+  void handleGenericActivity(const libkineto::GenericTraceActivity&) override {}
+  void handleTraceStart(
+      const std::unordered_map<std::string, std::string>&,
+      const std::string&) override {}
+  void finalizeTrace(
+      const libkineto::Config&,
+      std::unique_ptr<libkineto::ActivityBuffers>,
+      int64_t) override {}
+  void finalizeMemoryTrace(const std::string&, const libkineto::Config&)
+      override {}
+
+ private:
+  std::shared_ptr<int> counter_;
+};
+
+class WarningObserver : public libkineto::ILoggerObserver {
+ public:
+  void write(const std::string& message, libkineto::LoggerOutputType ot)
+      override {
+    if (ot == libkineto::LoggerOutputType::WARNING) {
+      warnings_.push_back(message);
+    }
+  }
+  const std::map<libkineto::LoggerOutputType, std::vector<std::string>>
+  extractCollectorMetadata() override {
+    return {};
+  }
+  void reset() override {
+    warnings_.clear();
+  }
+  void addDevice(int64_t) override {}
+  void setTraceDurationMS(int64_t) override {}
+  void addEventCount(int64_t) override {}
+  void addDestination(const std::string&) override {}
+  void addMetadata(const std::string&, const std::string&) override {}
+
+  const std::vector<std::string>& warnings() const {
+    return warnings_;
+  }
+
+ private:
+  std::vector<std::string> warnings_;
+};
+
+// Basic public API functionality
+TEST(RegisterLoggerFactoryTest, BasicPublicAPI) {
+  libkineto::registerLoggerFactory(
+      "basic_api_proto", [](const std::string& path) {
+        return std::make_unique<MockActivityLogger>(path);
+      });
+
+  auto& factory = KINETO_NAMESPACE::ActivityProfilerController::loggerFactory();
+  auto logger = factory.makeLogger("basic_api_proto:///tmp/trace.log");
+
+  ASSERT_NE(logger, nullptr);
+  auto* mockLogger = dynamic_cast<MockActivityLogger*>(logger.get());
+  ASSERT_NE(mockLogger, nullptr);
+  EXPECT_EQ(mockLogger->getUrl(), "/tmp/trace.log");
+}
+
+// Protocol case insensitivity
+TEST(RegisterLoggerFactoryTest, ProtocolCaseInsensitive) {
+  libkineto::registerLoggerFactory("CaseProto", [](const std::string& path) {
+    return std::make_unique<MockActivityLogger>(path);
+  });
+
+  auto& factory = KINETO_NAMESPACE::ActivityProfilerController::loggerFactory();
+
+  auto logger1 = factory.makeLogger("caseproto:///path1");
+  ASSERT_NE(logger1, nullptr);
+  auto* mock1 = dynamic_cast<MockActivityLogger*>(logger1.get());
+  EXPECT_EQ(mock1->getUrl(), "/path1");
+
+  auto logger2 = factory.makeLogger("CASEPROTO:///path2");
+  ASSERT_NE(logger2, nullptr);
+  auto* mock2 = dynamic_cast<MockActivityLogger*>(logger2.get());
+  EXPECT_EQ(mock2->getUrl(), "/path2");
+
+  auto logger3 = factory.makeLogger("CaseProto:///path3");
+  ASSERT_NE(logger3, nullptr);
+  auto* mock3 = dynamic_cast<MockActivityLogger*>(logger3.get());
+  EXPECT_EQ(mock3->getUrl(), "/path3");
+}
+
+// Unregistered protocol throws
+TEST(RegisterLoggerFactoryTest, UnregisteredProtocolThrows) {
+  auto& factory = KINETO_NAMESPACE::ActivityProfilerController::loggerFactory();
+
+  EXPECT_THROW(
+      factory.makeLogger("nonexistent:///path"), std::invalid_argument);
+
+  try {
+    factory.makeLogger("unknown:///path");
+    FAIL() << "Expected std::invalid_argument";
+  } catch (const std::invalid_argument& e) {
+    std::string msg(e.what());
+    EXPECT_TRUE(
+        msg.find("unknown") != std::string::npos ||
+        msg.find("protocol") != std::string::npos);
+  }
+}
+
+// Protocol overwriting behavior and warning
+TEST(RegisterLoggerFactoryTest, OverwriteProtocolWarning) {
+  auto counter1 = std::make_shared<int>(0);
+  auto counter2 = std::make_shared<int>(0);
+
+  libkineto::registerLoggerFactory(
+      "overwrite_warning_proto", [counter1](const std::string&) {
+        return std::make_unique<CountingLogger>(counter1);
+      });
+
+  WarningObserver observer;
+  libkineto::Logger::addLoggerObserver(&observer);
+
+  libkineto::registerLoggerFactory(
+      "overwrite_warning_proto", [counter2](const std::string&) {
+        return std::make_unique<CountingLogger>(counter2);
+      });
+
+  libkineto::Logger::removeLoggerObserver(&observer);
+
+  // Assert the overwrite warning was emitted without pinning the exact count;
+  // the observer captures any WARNING logged during the second registration.
+  const auto& warnings = observer.warnings();
+  EXPECT_TRUE(std::any_of(
+      warnings.begin(), warnings.end(), [](const std::string& warning) {
+        return warning.find("Overwriting") != std::string::npos &&
+            warning.find("overwrite_warning_proto") != std::string::npos;
+      }));
+
+  auto& factory = KINETO_NAMESPACE::ActivityProfilerController::loggerFactory();
+  auto logger = factory.makeLogger("overwrite_warning_proto:///path");
+
+  EXPECT_EQ(*counter1, 0);
+  EXPECT_EQ(*counter2, 1);
+  ASSERT_NE(logger, nullptr);
+}
+
+// Built-in "file" protocol remains functional
+TEST(RegisterLoggerFactoryTest, BuiltInFileProtocolStillWorks) {
+  auto& factory = KINETO_NAMESPACE::ActivityProfilerController::loggerFactory();
+
+  const std::string tempDir = testing::TempDir();
+  auto logger1 = factory.makeLogger("file://" + tempDir + "trace1.json");
+  ASSERT_NE(logger1, nullptr);
+
+  libkineto::registerLoggerFactory(
+      "file_custom_proto", [](const std::string& path) {
+        return std::make_unique<MockActivityLogger>(
+            "file_custom_proto:" + path);
+      });
+
+  auto customLogger1 = factory.makeLogger("file_custom_proto:///path");
+
+  ASSERT_NE(customLogger1, nullptr);
+
+  auto logger2 = factory.makeLogger("file://" + tempDir + "trace2.json");
+  ASSERT_NE(logger2, nullptr);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/third_party/kineto/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/third_party/kineto/libkineto/test/RocmActivityProfilerTest.cpp
@@ -1,0 +1,976 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include <strings.h>
+#include <time.h>
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <iterator>
+#include <optional>
+
+#include <unistd.h>
+
+#ifdef __linux__
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
+
+#include "include/Config.h"
+#include "include/MetadataFieldCatalog.h"
+#include "include/libkineto.h"
+#include "include/output_base.h"
+#include "include/time_since_epoch.h"
+#include "src/ActivityTrace.h"
+#include "src/RocmActivityProfiler.h"
+#include "src/RocmStreamQueue.h"
+
+#include "src/RocprofActivity.h"
+#include "src/RocprofActivityApi.h"
+#include "src/RocprofLogger.h"
+
+#include "src/output_json.h"
+#include "src/output_membuf.h"
+
+#include "src/Logger.h"
+#include "test/MockActivitySubProfiler.h"
+#include "test/MockCpuActivityBuffer.h"
+#include "test/TestUtils.h"
+
+using namespace std::chrono;
+using namespace KINETO_NAMESPACE;
+using namespace libkineto::test;
+
+// API ID macros for rocprofiler-sdk
+#define HIP_LAUNCH_KERNEL ROCPROFILER_HIP_RUNTIME_API_ID_hipLaunchKernel
+#define HIP_MEMCPY ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy
+#define HIP_MALLOC ROCPROFILER_HIP_RUNTIME_API_ID_hipMalloc
+#define HIP_FREE ROCPROFILER_HIP_RUNTIME_API_ID_hipFree
+#define RUNTIME_DOMAIN ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API
+
+namespace {
+bool isAsyncCopy(const rocprofAsyncRow& async) {
+  return async.domain == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY;
+}
+
+bool isAsyncKernel(const rocprofAsyncRow& async) {
+  return async.domain == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH;
+}
+
+struct RocmStreamTypedMetadataVisitor final : public ITypedMetadataVisitor {
+  void visitValue(const MetadataField<int64_t>& field, int64_t value) override {
+    if (field.name == RocmMetadataFields::kStream.name) {
+      stream = value;
+    }
+  }
+
+  void visitValue(const MetadataField<uint64_t>& field, uint64_t value)
+      override {
+    if (field.name == RocmMetadataFields::kHsaQueue.name) {
+      hsaQueue = value;
+    }
+  }
+
+  void visitValue(
+      [[maybe_unused]] const MetadataField<double>& field,
+      [[maybe_unused]] double value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<bool>& field,
+      [[maybe_unused]] bool value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<std::string>& field,
+      [[maybe_unused]] std::string_view value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<std::vector<int64_t>>& field,
+      [[maybe_unused]] const std::vector<int64_t>& value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<std::vector<std::string>>& field,
+      [[maybe_unused]] const std::vector<std::string>& value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<RawJson>& field,
+      [[maybe_unused]] const RawJson& value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<InputShapes>& field,
+      [[maybe_unused]] const InputShapes& value) override {}
+
+  void visitUnsupported(std::string_view /*name*/) override {}
+
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
+
+  std::optional<int64_t> stream;
+  std::optional<uint64_t> hsaQueue;
+};
+} // namespace
+
+// Provides ability to easily create test ROCm ops using the shared types
+// from RocLogger.h (rocprofKernelRow, rocprofAsyncRow, etc.)
+struct MockRocLogger {
+  void addCorrelationActivity(
+      uint64_t correlation,
+      RocLogger::CorrelationDomain domain,
+      uint64_t externalId) {
+    externalCorrelations_[domain].emplace_back(correlation, externalId);
+  }
+
+  void addRuntimeKernelActivity(
+      uint32_t cid,
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation,
+      uint64_t stream = 0) {
+    rocprofKernelRow* row = new rocprofKernelRow(
+        correlation,
+        RUNTIME_DOMAIN,
+        cid,
+        processId(),
+        systemThreadId(),
+        start_ns,
+        end_ns,
+        nullptr,
+        nullptr,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        reinterpret_cast<hipStream_t>(stream));
+    activities_.push_back(row);
+  }
+
+  void addRuntimeMallocActivity(
+      uint32_t cid,
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation) {
+    rocprofMallocRow* row = new rocprofMallocRow(
+        correlation,
+        RUNTIME_DOMAIN,
+        cid,
+        processId(),
+        systemThreadId(),
+        start_ns,
+        end_ns,
+        nullptr,
+        1);
+    activities_.push_back(row);
+  }
+
+  void addRuntimeCopyActivity(
+      uint32_t cid,
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation,
+      hipMemcpyKind kind = hipMemcpyHostToHost,
+      uint64_t stream = 0) {
+    rocprofCopyRow* row = new rocprofCopyRow(
+        correlation,
+        RUNTIME_DOMAIN,
+        cid,
+        processId(),
+        systemThreadId(),
+        start_ns,
+        end_ns,
+        nullptr,
+        nullptr,
+        1,
+        kind,
+        reinterpret_cast<hipStream_t>(stream));
+    activities_.push_back(row);
+  }
+
+  void addKernelActivity(
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation,
+      uint64_t queue = 1) {
+    rocprofAsyncRow* row = new rocprofAsyncRow(
+        correlation,
+        ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+        0,
+        0,
+        0,
+        queue,
+        start_ns,
+        end_ns,
+        std::string("kernel"));
+    activities_.push_back(row);
+  }
+
+  void addMemcpyH2DActivity(
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation,
+      uint64_t queue = 2) {
+    rocprofAsyncRow* row = new rocprofAsyncRow(
+        correlation,
+        ROCPROFILER_BUFFER_TRACING_MEMORY_COPY,
+        0,
+        ROCPROFILER_MEMORY_COPY_HOST_TO_DEVICE,
+        0,
+        queue,
+        start_ns,
+        end_ns,
+        std::string());
+    activities_.push_back(row);
+  }
+
+  void addMemcpyD2HActivity(
+      int64_t start_ns,
+      int64_t end_ns,
+      int64_t correlation) {
+    rocprofAsyncRow* row = new rocprofAsyncRow(
+        correlation,
+        ROCPROFILER_BUFFER_TRACING_MEMORY_COPY,
+        0,
+        ROCPROFILER_MEMORY_COPY_DEVICE_TO_HOST,
+        0,
+        2,
+        start_ns,
+        end_ns,
+        std::string());
+    activities_.push_back(row);
+  }
+
+  ~MockRocLogger() {
+    while (!activities_.empty()) {
+      auto act = activities_.back();
+      activities_.pop_back();
+      free(act);
+    }
+  }
+
+  std::vector<rocprofBase*> activities_;
+  std::vector<std::pair<uint64_t, uint64_t>>
+      externalCorrelations_[RocLogger::CorrelationDomain::size];
+};
+
+// Mock parts of the ActivityApi
+class MockRocActivities : public RocprofActivityApi {
+ public:
+  virtual int processActivities(
+      std::function<void(const rocprofBase*)> handler,
+      std::function<void(uint64_t, uint64_t, RocLogger::CorrelationDomain)>
+          correlationHandler) override {
+    int count = 0;
+    for (int it = RocLogger::CorrelationDomain::begin;
+         it < RocLogger::CorrelationDomain::end;
+         ++it) {
+      auto& externalCorrelations = activityLogger->externalCorrelations_[it];
+      for (auto& item : externalCorrelations) {
+        correlationHandler(
+            item.first,
+            item.second,
+            static_cast<RocLogger::CorrelationDomain>(it));
+      }
+      externalCorrelations.clear();
+    }
+    detail::backfillAsyncStreams(
+        activityLogger->activities_, [](const rocprofAsyncRow& async) {
+          return isAsyncCopy(async) || isAsyncKernel(async);
+        });
+    for (auto& item : activityLogger->activities_) {
+      handler(item);
+      ++count;
+    }
+    return count;
+  }
+
+  std::unique_ptr<MockRocLogger> activityLogger;
+};
+
+// Common setup / teardown and helper functions
+class RocmActivityProfilerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    profiler_ = std::make_unique<RocmActivityProfiler>(
+        rocActivities_, /*cpu only*/ false);
+    cfg_ = std::make_unique<Config>();
+    cfg_->validate(std::chrono::system_clock::now());
+    loggerFactory.addProtocol("file", [](const std::string& url) {
+      return std::unique_ptr<ActivityLogger>(new ChromeTraceLogger(url));
+    });
+  }
+
+  std::unique_ptr<Config> cfg_;
+  MockRocActivities rocActivities_;
+  std::unique_ptr<RocmActivityProfiler> profiler_;
+  ActivityLoggerFactory loggerFactory;
+};
+
+TEST_F(RocmActivityProfilerTest, SyncTrace) {
+  // Verbose logging is useful for debugging
+  std::vector<std::string> log_modules({"RocmActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  // Start and stop profiling
+  RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+
+  profiler.recordThreadInfo();
+
+  // Log some cpu ops
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_ns, start_time_ns + duration_ns);
+  cpuOps->addOp("op1", start_time_ns + 20, start_time_ns + 50, 1);
+  cpuOps->addOp("op2", start_time_ns + 30, start_time_ns + 40, 2);
+  cpuOps->addOp("op3", start_time_ns + 100, start_time_ns + 150, 3);
+  cpuOps->addOp("op4", start_time_ns + 160, start_time_ns + 180, 4);
+  cpuOps->addOp("op5", start_time_ns + 190, start_time_ns + 210, 4);
+  profiler.transferCpuTrace(std::move(cpuOps));
+
+  // And some CPU runtime ops, and GPU ops
+  auto gpuOps = std::make_unique<MockRocLogger>();
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL, start_time_ns + 33, start_time_ns + 38, 1);
+  gpuOps->addRuntimeCopyActivity(
+      HIP_MEMCPY, start_time_ns + 110, start_time_ns + 120, 2);
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL, start_time_ns + 130, start_time_ns + 145, 3);
+  gpuOps->addRuntimeCopyActivity(
+      HIP_MEMCPY, start_time_ns + 165, start_time_ns + 175, 4);
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL, start_time_ns + 195, start_time_ns + 205, 5);
+  gpuOps->addKernelActivity(start_time_ns + 50, start_time_ns + 70, 1);
+  gpuOps->addMemcpyH2DActivity(start_time_ns + 140, start_time_ns + 150, 2);
+  gpuOps->addKernelActivity(start_time_ns + 160, start_time_ns + 220, 3);
+  gpuOps->addMemcpyD2HActivity(start_time_ns + 230, start_time_ns + 250, 4);
+  gpuOps->addKernelActivity(start_time_ns + 260, start_time_ns + 280, 5);
+  rocActivities_.activityLogger = std::move(gpuOps);
+
+  // Have the profiler process them
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
+  // Wrapper that allows iterating over the activities
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  EXPECT_EQ(trace.activities()->size(), 15);
+  std::map<std::string, int> activityCounts;
+  std::map<int64_t, int> resourceIds;
+  for (auto& activity : *trace.activities()) {
+    activityCounts[activity->name()]++;
+    resourceIds[activity->resourceId()]++;
+    LOG(INFO) << "[test]" << activity->name() << "," << activity->resourceId();
+  }
+  for (const auto& p : activityCounts) {
+    LOG(INFO) << p.first << ": " << p.second;
+  }
+  // Check all activities are present and names are correct.
+  EXPECT_EQ(activityCounts["op1"], 1);
+  EXPECT_EQ(activityCounts["op2"], 1);
+  EXPECT_EQ(activityCounts["op3"], 1);
+  EXPECT_EQ(activityCounts["op4"], 1);
+  EXPECT_EQ(activityCounts["op5"], 1);
+  EXPECT_EQ(activityCounts["hipLaunchKernel"], 3);
+  EXPECT_EQ(activityCounts["Memcpy HtoD (Host -> Device)"], 1);
+  EXPECT_EQ(activityCounts["Memcpy DtoH (Device -> Host)"], 1);
+  EXPECT_EQ(activityCounts["kernel"], 3);
+
+  auto sysTid = systemThreadId();
+  // Check ops and runtime events are on thread sysTid
+  EXPECT_EQ(resourceIds[sysTid], 10);
+  // Kernels are on stream 1, memcpy on stream 2
+  EXPECT_EQ(resourceIds[1], 3);
+  EXPECT_EQ(resourceIds[2], 2);
+
+#ifdef __linux__
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  trace.save(tmpTrace.path());
+  checkTracefile(tmpTrace.c_str());
+#endif
+}
+
+TEST_F(RocmActivityProfilerTest, GpuTypedMetadataMatchesLegacyStreamMetadata) {
+  RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+
+  auto gpuOps = std::make_unique<MockRocLogger>();
+  gpuOps->addMemcpyH2DActivity(start_time_ns + 10, start_time_ns + 20, 1, 42);
+  rocActivities_.activityLogger = std::move(gpuOps);
+
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  const ITraceActivity* memcpyActivity = nullptr;
+  for (const auto& activity : *trace.activities()) {
+    if (activity->name() == "Memcpy HtoD (Host -> Device)") {
+      memcpyActivity = activity;
+      break;
+    }
+  }
+
+  ASSERT_NE(memcpyActivity, nullptr);
+  EXPECT_EQ(memcpyActivity->resourceId(), 42);
+
+  RocmStreamTypedMetadataVisitor typedMetadata;
+  memcpyActivity->visitTypedMetadata(typedMetadata);
+  const auto jsonMetadata =
+      nlohmann::json::parse("{" + memcpyActivity->metadataJson() + "}");
+  EXPECT_EQ(typedMetadata.stream, jsonMetadata["stream"].get<int64_t>());
+  EXPECT_EQ(typedMetadata.hsaQueue, jsonMetadata["hsa_queue"].get<uint64_t>());
+}
+
+TEST_F(
+    RocmActivityProfilerTest,
+    HtoDMemcpyUsesRuntimeStreamWhenAsyncQueueIsZero) {
+  RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+
+  auto gpuOps = std::make_unique<MockRocLogger>();
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL, start_time_ns + 10, start_time_ns + 15, 2, 7);
+  gpuOps->addKernelActivity(start_time_ns + 16, start_time_ns + 19, 2, 23);
+  gpuOps->addRuntimeCopyActivity(
+      HIP_MEMCPY,
+      start_time_ns + 20,
+      start_time_ns + 30,
+      1,
+      hipMemcpyHostToDevice,
+      7);
+  gpuOps->addMemcpyH2DActivity(start_time_ns + 40, start_time_ns + 50, 1, 0);
+  rocActivities_.activityLogger = std::move(gpuOps);
+
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  const ITraceActivity* memcpyActivity = nullptr;
+  for (const auto& activity : *trace.activities()) {
+    if (activity->name() == "Memcpy HtoD (Host -> Device)") {
+      memcpyActivity = activity;
+      break;
+    }
+  }
+
+  ASSERT_NE(memcpyActivity, nullptr);
+  // The copy shares HIP stream 7 with the kernel (via runtime correlation), so
+  // both remap to the same dense per-device stream index (1).
+  EXPECT_EQ(memcpyActivity->resourceId(), 1);
+
+#ifdef __linux__
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  trace.save(tmpTrace.path());
+
+  std::ifstream file(tmpTrace.path());
+  ASSERT_TRUE(file.is_open());
+  std::string jsonStr(
+      (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  nlohmann::json jsonData = nlohmann::json::parse(jsonStr);
+
+  bool foundMemcpy = false;
+  for (const auto& event : jsonData["traceEvents"]) {
+    if (event.value("name", "") == "Memcpy HtoD (Host -> Device)") {
+      foundMemcpy = true;
+      EXPECT_EQ(event["args"]["stream"].get<int64_t>(), 1);
+    }
+  }
+  EXPECT_TRUE(foundMemcpy);
+#endif
+}
+
+TEST_F(RocmActivityProfilerTest, HtoDMemcpyPrefersRuntimeStreamOverAsyncQueue) {
+  RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+
+  auto gpuOps = std::make_unique<MockRocLogger>();
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL, start_time_ns + 10, start_time_ns + 15, 2, 7);
+  gpuOps->addKernelActivity(start_time_ns + 16, start_time_ns + 19, 2, 23);
+  gpuOps->addRuntimeCopyActivity(
+      HIP_MEMCPY,
+      start_time_ns + 20,
+      start_time_ns + 30,
+      1,
+      hipMemcpyHostToDevice,
+      7);
+  gpuOps->addMemcpyH2DActivity(start_time_ns + 40, start_time_ns + 50, 1, 42);
+  rocActivities_.activityLogger = std::move(gpuOps);
+
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  const ITraceActivity* memcpyActivity = nullptr;
+  for (const auto& activity : *trace.activities()) {
+    if (activity->name() == "Memcpy HtoD (Host -> Device)") {
+      memcpyActivity = activity;
+      break;
+    }
+  }
+
+  ASSERT_NE(memcpyActivity, nullptr);
+  // Even though the async copy carries a nonzero HW queue (42), it is grouped
+  // by its real HIP stream (7) -- shared with the kernel -> dense index 1.
+  EXPECT_EQ(memcpyActivity->resourceId(), 1);
+  // The raw HSA queue (42) is still logged in the event metadata for debugging,
+  // even though track placement uses the stream.
+  EXPECT_NE(
+      memcpyActivity->metadataJson().find("\"hsa_queue\": 42"),
+      std::string::npos);
+}
+
+TEST_F(
+    RocmActivityProfilerTest,
+    HtoDMemcpyJoinsRuntimeStreamDespiteQueueAmbiguity) {
+  RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+
+  auto gpuOps = std::make_unique<MockRocLogger>();
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL, start_time_ns + 10, start_time_ns + 15, 2, 7);
+  gpuOps->addKernelActivity(start_time_ns + 16, start_time_ns + 19, 2, 23);
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL, start_time_ns + 20, start_time_ns + 25, 3, 7);
+  gpuOps->addKernelActivity(start_time_ns + 26, start_time_ns + 29, 3, 24);
+  gpuOps->addRuntimeCopyActivity(
+      HIP_MEMCPY,
+      start_time_ns + 30,
+      start_time_ns + 40,
+      1,
+      hipMemcpyHostToDevice,
+      7);
+  gpuOps->addMemcpyH2DActivity(start_time_ns + 50, start_time_ns + 60, 1, 0);
+  rocActivities_.activityLogger = std::move(gpuOps);
+
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  const ITraceActivity* memcpyActivity = nullptr;
+  for (const auto& activity : *trace.activities()) {
+    if (activity->name() == "Memcpy HtoD (Host -> Device)") {
+      memcpyActivity = activity;
+      break;
+    }
+  }
+
+  ASSERT_NE(memcpyActivity, nullptr);
+  // The copy's stream is resolved directly from its runtime correlation (HIP
+  // stream 7), so HW-queue ambiguity no longer matters -- it joins the shared
+  // stream index 1 instead of being dropped to 0.
+  EXPECT_EQ(memcpyActivity->resourceId(), 1);
+}
+
+TEST_F(RocmActivityProfilerTest, GpuNCCLCollectiveTest) {
+  // Set logging level for debugging purpose
+  std::vector<std::string> log_modules(
+      {"RocmActivityProfiler.cpp", "output_json.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  // Start and stop profiling
+  RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+
+  int64_t kernelLaunchTime = start_time_ns + 20;
+  profiler.recordThreadInfo();
+
+  // Prepare metadata map
+  std::unordered_map<std::string, std::string> metadataMap;
+  metadataMap.emplace(
+      kCollectiveName, fmt::format("\"{}\"", "_allgather_base"));
+  metadataMap.emplace(kDtype, fmt::format("\"{}\"", "Float"));
+  metadataMap.emplace(kInMsgNelems, "65664");
+  metadataMap.emplace(kOutMsgNelems, "131328");
+  metadataMap.emplace(kGroupSize, "2");
+  metadataMap.emplace(kProcessGroupName, fmt::format("\"{}\"", "12341234"));
+  metadataMap.emplace(kProcessGroupDesc, fmt::format("\"{}\"", "test_purpose"));
+
+  std::vector<int64_t> inSplitSizes(50, 0);
+  std::string inSplitSizesStr = "";
+  // Logic is copied from: https://fburl.com/code/811a3wq8
+  if (!inSplitSizes.empty() && inSplitSizes.size() <= kTruncatLength) {
+    inSplitSizesStr = fmt::format("\"[{}]\"", fmt::join(inSplitSizes, ", "));
+    metadataMap.emplace(kInSplit, inSplitSizesStr);
+  } else if (inSplitSizes.size() > kTruncatLength) {
+    inSplitSizesStr = fmt::format(
+        "\"[{}, ...]\"",
+        fmt::join(
+            inSplitSizes.begin(), inSplitSizes.begin() + kTruncatLength, ", "));
+    metadataMap.emplace(kInSplit, inSplitSizesStr);
+  }
+
+  std::vector<int64_t> outSplitSizes(20, 1);
+  std::string outSplitSizesStr = "";
+  // Logic is copied from: https://fburl.com/code/811a3wq8
+  if (!outSplitSizes.empty() && outSplitSizes.size() <= kTruncatLength) {
+    outSplitSizesStr = fmt::format("\"[{}]\"", fmt::join(outSplitSizes, ", "));
+    metadataMap.emplace(kOutSplit, outSplitSizesStr);
+  } else if (outSplitSizes.size() > kTruncatLength) {
+    outSplitSizesStr = fmt::format(
+        "\"[{}, ...]\"",
+        fmt::join(
+            outSplitSizes.begin(),
+            outSplitSizes.begin() + kTruncatLength,
+            ", "));
+    metadataMap.emplace(kOutSplit, outSplitSizesStr);
+  }
+
+  std::vector<int64_t> groupRanks(64, 0);
+  std::string groupRanksStr = "";
+  if (!groupRanks.empty() && groupRanks.size() <= kTruncatLength) {
+    metadataMap.emplace(
+        kGroupRanks, fmt::format("\"[{}]\"", fmt::join(groupRanks, ", ")));
+  } else if (groupRanks.size() > kTruncatLength) {
+    metadataMap.emplace(
+        kGroupRanks,
+        fmt::format(
+            "\"[{}, ..., {}]\"",
+            fmt::join(
+                groupRanks.begin(),
+                groupRanks.begin() + kTruncatLength - 1,
+                ", "),
+            groupRanks.back()));
+  }
+
+  // Set up CPU events
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_ns, start_time_ns + duration_ns);
+  cpuOps->addOp(
+      kParamCommsCallName,
+      kernelLaunchTime,
+      kernelLaunchTime + 10,
+      1,
+      metadataMap);
+  profiler.transferCpuTrace(std::move(cpuOps));
+
+  // Set up corresponding GPU events and connect with CPU events
+  // via correlationId
+  auto gpuOps = std::make_unique<MockRocLogger>();
+  gpuOps->addCorrelationActivity(1, RocLogger::CorrelationDomain::Domain0, 1);
+  gpuOps->addKernelActivity(kernelLaunchTime + 5, kernelLaunchTime + 10, 1);
+  rocActivities_.activityLogger = std::move(gpuOps);
+
+  // Process trace
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.setLogger(logger.get());
+
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
+  // Check the content of GPU event and we should see extra
+  // collective fields get populated from CPU event.
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  EXPECT_EQ(2, trace.activities()->size());
+  auto& cpu_op = trace.activities()->at(0);
+  auto& gpu_kernel = trace.activities()->at(1);
+  EXPECT_EQ(cpu_op->name(), kParamCommsCallName);
+  EXPECT_EQ(gpu_kernel->name(), "kernel");
+
+  // Check vector with length > 30 get truncated successfully
+  std::vector<int64_t> expectedInSplit(kTruncatLength, 0);
+  auto expectedInSplitStr =
+      fmt::format("\"[{}, ...]\"", fmt::join(expectedInSplit, ", "));
+  EXPECT_EQ(cpu_op->getMetadataValue(kInSplit), expectedInSplitStr);
+  std::vector<int64_t> expectedGroupRanks(kTruncatLength - 1, 0);
+  auto expectedGroupRanksStr = fmt::format(
+      "\"[{}, ..., {}]\"", fmt::join(expectedGroupRanks, ", "), "0");
+  EXPECT_EQ(cpu_op->getMetadataValue(kGroupRanks), expectedGroupRanksStr);
+
+#ifdef __linux__
+  // Test saved output can be loaded as JSON
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file: " << tmpTrace.path();
+  trace.save(tmpTrace.path());
+
+  // Check that the saved JSON file can be loaded and deserialized
+  std::ifstream file(tmpTrace.path());
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open the trace JSON file.");
+  }
+  std::string jsonStr(
+      (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  nlohmann::json jsonData = nlohmann::json::parse(jsonStr);
+
+  // Convert the JSON object to a string and check
+  // if the substring exists
+  std::string jsonString = jsonData.dump();
+  // Check that the metadata fields are present in the JSON file
+  EXPECT_EQ(2, countSubstrings(jsonString, "65664"));
+  EXPECT_EQ(2, countSubstrings(jsonString, kInMsgNelems));
+  EXPECT_EQ(2, countSubstrings(jsonString, "65664"));
+  EXPECT_EQ(2, countSubstrings(jsonString, kOutMsgNelems));
+  EXPECT_EQ(2, countSubstrings(jsonString, "131328"));
+  EXPECT_EQ(2, countSubstrings(jsonString, kInSplit));
+  EXPECT_EQ(2, countSubstrings(jsonString, expectedInSplitStr));
+  EXPECT_EQ(2, countSubstrings(jsonString, kOutSplit));
+  EXPECT_EQ(2, countSubstrings(jsonString, outSplitSizesStr));
+  EXPECT_EQ(2, countSubstrings(jsonString, kCollectiveName));
+  EXPECT_EQ(2, countSubstrings(jsonString, "_allgather_base"));
+  EXPECT_EQ(2, countSubstrings(jsonString, kProcessGroupName));
+  EXPECT_EQ(2, countSubstrings(jsonString, "12341234"));
+  EXPECT_EQ(2, countSubstrings(jsonString, kProcessGroupDesc));
+  EXPECT_EQ(2, countSubstrings(jsonString, "test_purpose"));
+  EXPECT_EQ(2, countSubstrings(jsonString, kGroupRanks));
+  EXPECT_EQ(2, countSubstrings(jsonString, expectedGroupRanksStr));
+#endif
+}
+
+TEST_F(RocmActivityProfilerTest, GpuUserAnnotationTest) {
+  // Verbose logging is useful for debugging
+  std::vector<std::string> log_modules({"RocmActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  // Start and stop profiling
+  RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+
+  int64_t kernelLaunchTime = start_time_ns + 20;
+  profiler.recordThreadInfo();
+
+  // set up CPU event
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_ns, start_time_ns + duration_ns);
+  cpuOps->addOp("annotation", kernelLaunchTime, kernelLaunchTime + 10, 1);
+  profiler.transferCpuTrace(std::move(cpuOps));
+
+  // set up a couple of GPU events and correlate with above CPU event.
+  // RocLogger::CorrelationDomain::Domain1 is used for user annotations.
+  auto gpuOps = std::make_unique<MockRocLogger>();
+  gpuOps->addCorrelationActivity(1, RocLogger::CorrelationDomain::Domain1, 1);
+  gpuOps->addKernelActivity(kernelLaunchTime + 5, kernelLaunchTime + 10, 1);
+  gpuOps->addCorrelationActivity(1, RocLogger::CorrelationDomain::Domain1, 1);
+  gpuOps->addKernelActivity(kernelLaunchTime + 15, kernelLaunchTime + 25, 1);
+  rocActivities_.activityLogger = std::move(gpuOps);
+
+  // process trace
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  std::map<std::string, int> counts;
+  for (auto& activity : *trace.activities()) {
+    counts[activity->name()]++;
+  }
+
+  // We should now have an additional annotation activity created
+  // on the GPU timeline.
+  EXPECT_EQ(counts["annotation"], 2);
+  EXPECT_EQ(counts["kernel"], 2);
+
+  auto& annotation = trace.activities()->at(0);
+  auto& kernel1 = trace.activities()->at(1);
+  auto& kernel2 = trace.activities()->at(2);
+  auto& gpu_annotation = trace.activities()->at(3);
+  // Check that gpu_annotation covers both kernels
+  EXPECT_EQ(gpu_annotation->type(), ActivityType::GPU_USER_ANNOTATION);
+  EXPECT_EQ(gpu_annotation->timestamp(), kernel1->timestamp());
+  EXPECT_EQ(
+      gpu_annotation->duration(),
+      kernel2->timestamp() + kernel2->duration() - kernel1->timestamp());
+  EXPECT_EQ(gpu_annotation->deviceId(), kernel1->deviceId());
+  EXPECT_EQ(gpu_annotation->resourceId(), kernel1->resourceId());
+  EXPECT_EQ(gpu_annotation->correlationId(), annotation->correlationId());
+  EXPECT_EQ(gpu_annotation->name(), annotation->name());
+}
+
+TEST_F(RocmActivityProfilerTest, SubActivityProfilers) {
+  // Verbose logging is useful for debugging
+  std::vector<std::string> log_modules({"RocmActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  // Setup example events to test
+  GenericTraceActivity ev{defaultTraceSpan(), ActivityType::GLOW_RUNTIME, ""};
+  ev.device = 1;
+  ev.resource = 0;
+
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 1000;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+
+  std::deque<GenericTraceActivity> test_activities{3, ev};
+  test_activities[0].startTime = start_time_ns;
+  test_activities[0].endTime = start_time_ns + 5000;
+  test_activities[0].activityName = "SubGraph A execution";
+  test_activities[1].startTime = start_time_ns;
+  test_activities[1].endTime = start_time_ns + 2000;
+  test_activities[1].activityName = "Operator foo";
+  test_activities[2].startTime = start_time_ns + 2500;
+  test_activities[2].endTime = start_time_ns + 2900;
+  test_activities[2].activityName = "Operator bar";
+
+  auto mock_activity_profiler =
+      std::make_unique<MockActivityProfiler>(test_activities);
+
+  // Add a child profiler and check that it works
+  MockRocActivities activities;
+  RocmActivityProfiler profiler(activities, /*cpu only*/ true);
+  profiler.addChildActivityProfiler(std::move(mock_activity_profiler));
+
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file " << tmpTrace.path();
+
+  // process trace
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.setLogger(logger.get());
+
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  trace.save(tmpTrace.path());
+  const auto& traced_activites = trace.activities();
+
+  // Test we have all the events
+  EXPECT_EQ(traced_activites->size(), test_activities.size());
+
+  checkTracefile(tmpTrace.c_str());
+}
+
+TEST_F(RocmActivityProfilerTest, JsonGPUIDSortTest) {
+  // Set logging level for debugging purpose
+  std::vector<std::string> log_modules(
+      {"RocmActivityProfiler.cpp", "output_json.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  // Start and stop profiling
+  RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 500;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.recordThreadInfo();
+
+  // Set up CPU events
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_ns, start_time_ns + duration_ns);
+  cpuOps->addOp("op1", start_time_ns + 10, start_time_ns + 30, 1);
+  profiler.transferCpuTrace(std::move(cpuOps));
+
+  // Set up GPU events
+  auto gpuOps = std::make_unique<MockRocLogger>();
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL, start_time_ns + 23, start_time_ns + 28, 1);
+  gpuOps->addKernelActivity(start_time_ns + 50, start_time_ns + 70, 1);
+  rocActivities_.activityLogger = std::move(gpuOps);
+
+  // Process trace
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.setLogger(logger.get());
+
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
+  // Check the contents of trace matches
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  EXPECT_EQ(3, trace.activities()->size());
+
+#ifdef __linux__
+  // Test saved output can be loaded as JSON
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file: " << tmpTrace.path();
+  trace.save(tmpTrace.path());
+
+  // Check that the saved JSON file can be loaded and deserialized
+  std::ifstream file(tmpTrace.path());
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open the trace JSON file.");
+  }
+  std::string jsonStr(
+      (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  nlohmann::json jsonData = nlohmann::json::parse(jsonStr);
+
+  std::unordered_map<int64_t, std::string> sortLabel;
+  std::unordered_map<int64_t, int64_t> sortIdx;
+  for (auto& event : jsonData["traceEvents"]) {
+    if (event["name"] == "process_labels" && event["tid"] == 0 &&
+        event["pid"].is_number_integer()) {
+      sortLabel[event["pid"].get<int64_t>()] =
+          event["args"]["labels"].get<std::string>();
+      LOG(INFO) << sortLabel[event["pid"].get<int64_t>()];
+    }
+    if (event["name"] == "process_sort_index" && event["tid"] == 0 &&
+        event["pid"].is_number_integer()) {
+      sortIdx[event["pid"].get<int64_t>()] =
+          event["args"]["sort_index"].get<int64_t>();
+      LOG(INFO) << sortIdx[event["pid"].get<int64_t>()];
+    }
+  }
+
+  // Expect atleast 16 GPU nodes, and 1 or more CPU nodes.
+  EXPECT_LE(16, sortLabel.size());
+  for (int i = 0; i < 16; i++) {
+    // Check there are 16 GPU sorts (0-15) with expected sort_index.
+    EXPECT_EQ("GPU " + std::to_string(i), sortLabel[i]);
+    // sortIndex is gpu + kExceedMaxPid to put GPU tracks at the bottom
+    // of the trace timelines.
+    EXPECT_EQ(i + kExceedMaxPid, sortIdx[i]);
+  }
+#endif
+}

--- a/third_party/kineto/libkineto/test/SyncActivityProfilerHandlerTest.cpp
+++ b/third_party/kineto/libkineto/test/SyncActivityProfilerHandlerTest.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "include/Config.h"
+#include "src/GenericActivityProfiler.h"
+#include "src/SyncActivityProfilerHandler.h"
+
+using namespace std::chrono;
+using namespace KINETO_NAMESPACE;
+
+TEST(SyncActivityProfilerHandler, Cancel) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  SyncActivityProfilerHandler handler(profiler);
+
+  // Cancel when inactive is a no-op
+  EXPECT_FALSE(handler.isSyncActive());
+  handler.cancel();
+  EXPECT_FALSE(handler.isSyncActive());
+
+  // Cancel after prepareTrace
+  Config cfg;
+  cfg.validate(system_clock::now());
+  handler.prepareTrace(cfg);
+  EXPECT_TRUE(handler.isSyncActive());
+  handler.cancel();
+  EXPECT_FALSE(handler.isSyncActive());
+}

--- a/third_party/kineto/libkineto/test/TestUtils.cpp
+++ b/third_party/kineto/libkineto/test/TestUtils.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "test/TestUtils.h"
+
+#include <gtest/gtest.h>
+
+#include <unistd.h>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#ifdef __linux__
+#include <fcntl.h>
+#include <sys/stat.h>
+#endif
+
+namespace libkineto::test {
+
+TempTraceFile::TempTraceFile(std::string_view prefix, std::string_view suffix) {
+  std::string nameTemplate;
+  nameTemplate.reserve(5 + prefix.size() + 6 + suffix.size());
+  nameTemplate += "/tmp/";
+  nameTemplate += prefix;
+  nameTemplate += "XXXXXX";
+  nameTemplate += suffix;
+
+  const int fd = mkstemps(nameTemplate.data(), static_cast<int>(suffix.size()));
+  if (fd < 0) {
+    throw std::runtime_error("mkstemps failed for " + nameTemplate);
+  }
+  close(fd);
+  path_ = std::move(nameTemplate);
+}
+
+TempTraceFile::~TempTraceFile() {
+  if (!path_.empty()) {
+    unlink(path_.c_str());
+  }
+}
+
+TempTraceFile::TempTraceFile(TempTraceFile&& other) noexcept
+    : path_(std::move(other.path_)) {
+  other.path_.clear();
+}
+
+TempTraceFile& TempTraceFile::operator=(TempTraceFile&& other) noexcept {
+  if (this != &other) {
+    if (!path_.empty()) {
+      unlink(path_.c_str());
+    }
+    path_ = std::move(other.path_);
+    other.path_.clear();
+  }
+  return *this;
+}
+
+TempTraceFile createTempTraceFile(
+    std::string_view prefix,
+    std::string_view suffix) {
+  return TempTraceFile(prefix, suffix);
+}
+
+std::string logUrlToPath(const std::string& url) {
+  const std::string prefix = "file://";
+  if (url.starts_with(prefix)) {
+    return url.substr(prefix.size());
+  }
+  return url;
+}
+
+size_t countSubstrings(
+    const std::string& source,
+    const std::string& substring) {
+  if (source.empty() || substring.empty()) {
+    return 0;
+  }
+  size_t count = 0;
+  size_t pos = source.find(substring);
+  while (pos != std::string::npos) {
+    ++count;
+    pos = source.find(substring, pos + substring.length());
+  }
+  return count;
+}
+
+void checkTracefile(const char* path) {
+#ifdef __linux__
+  // @lint-ignore NULLSAFECLANG callers always pass a non-null path
+  int fd = open(path, O_RDONLY);
+  ASSERT_GE(fd, 0) << "failed to open " << path;
+  struct stat buf{};
+  fstat(fd, &buf);
+  EXPECT_GT(buf.st_size, 100);
+  close(fd);
+#endif
+}
+
+} // namespace libkineto::test

--- a/third_party/kineto/libkineto/test/TestUtils.h
+++ b/third_party/kineto/libkineto/test/TestUtils.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+namespace libkineto::test {
+
+// Owns a uniquely-named temporary file for a test to write a trace into. The
+// file is created and its descriptor immediately closed on construction, and
+// the file is removed when the owner goes out of scope, so tests never leak
+// files under /tmp.
+class TempTraceFile {
+ public:
+  // Creates a file named /tmp/<prefix>XXXXXX<suffix>, where mkstemps replaces
+  // the six X characters with a unique component. suffix is preserved after
+  // that component so callers can keep a .json extension; pass an empty suffix
+  // for a name that ends in the random component.
+  explicit TempTraceFile(std::string_view prefix, std::string_view suffix);
+  ~TempTraceFile();
+
+  TempTraceFile(const TempTraceFile&) = delete;
+  TempTraceFile& operator=(const TempTraceFile&) = delete;
+
+  TempTraceFile(TempTraceFile&& other) noexcept;
+  TempTraceFile& operator=(TempTraceFile&& other) noexcept;
+
+  [[nodiscard]] const std::string& path() const {
+    return path_;
+  }
+
+  [[nodiscard]] const char* c_str() const {
+    return path_.c_str();
+  }
+
+ private:
+  std::string path_;
+};
+
+// Creates a self-cleaning temporary trace file; see TempTraceFile for the
+// naming scheme. The returned object removes the file when it goes out of
+// scope.
+[[nodiscard]] TempTraceFile createTempTraceFile(
+    std::string_view prefix,
+    std::string_view suffix);
+
+// Strips a leading "file://" from url, returning the bare filesystem path.
+std::string logUrlToPath(const std::string& url);
+
+// Returns the number of non-overlapping occurrences of substring in source.
+size_t countSubstrings(const std::string& source, const std::string& substring);
+
+// Asserts (via gtest) that the file at path exists and holds more than 100
+// bytes. No-op on non-Linux platforms.
+void checkTracefile(const char* path);
+
+} // namespace libkineto::test

--- a/third_party/kineto/libkineto/test/TypedMetadataTest.cpp
+++ b/third_party/kineto/libkineto/test/TypedMetadataTest.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "include/TypedMetadata.h"
+#include "include/TypedMetadataJson.h"
+
+#include <gtest/gtest.h>
+#include <map>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace libkineto;
+
+namespace {
+
+constexpr MetadataField<int64_t> kCount{"count"};
+constexpr MetadataField<std::vector<int64_t>> kIds{"ids"};
+constexpr MetadataField<std::string> kLabel{"label"};
+constexpr MetadataField<double> kRatio{"ratio"};
+constexpr MetadataField<bool> kEnabled{"enabled"};
+constexpr MetadataField<std::vector<std::string>> kNames{"names"};
+constexpr MetadataField<std::pair<int64_t, int64_t>> kPair{"pair"};
+constexpr MetadataField<std::string> kSpecialChars{"special"};
+constexpr MetadataField<RawJson> kRaw{"raw"};
+constexpr MetadataField<uint64_t> kAddress{"address"};
+constexpr MetadataField<InputShapes> kInputDims{"input_dims"};
+constexpr MetadataDict kNested{"nested"};
+constexpr MetadataField<int64_t> kNestedCount{"nested_count"};
+constexpr MetadataField<int64_t> kNestedOther{"nested_other"};
+constexpr MetadataField<int64_t> kAfterNested{"after_nested"};
+constexpr MetadataDict kOuter{"outer"};
+constexpr MetadataDict kInner{"inner"};
+
+using RecordedValue = std::variant<
+    int64_t,
+    double,
+    bool,
+    std::string,
+    std::vector<int64_t>,
+    std::vector<std::string>>;
+
+class RecordingTypedMetadataVisitor : public ITypedMetadataVisitor {
+ public:
+  void visitValue(const MetadataField<int64_t>& field, int64_t value) override {
+    record(field, value);
+  }
+
+  void visitValue(const MetadataField<double>& field, double value) override {
+    record(field, value);
+  }
+
+  void visitValue(const MetadataField<bool>& field, bool value) override {
+    record(field, value);
+  }
+
+  void visitValue(
+      const MetadataField<std::string>& field,
+      std::string_view value) override {
+    record(field, std::string{value});
+  }
+
+  void visitValue(
+      const MetadataField<std::vector<int64_t>>& field,
+      const std::vector<int64_t>& value) override {
+    record(field, value);
+  }
+
+  void visitValue(
+      const MetadataField<std::vector<std::string>>& field,
+      const std::vector<std::string>& value) override {
+    record(field, value);
+  }
+
+  void visitValue(const MetadataField<RawJson>& field, const RawJson& value)
+      override {
+    record(field, std::string{value.value});
+  }
+
+  void visitValue(
+      [[maybe_unused]] const MetadataField<uint64_t>& field,
+      [[maybe_unused]] uint64_t value) override {}
+
+  void visitValue(
+      [[maybe_unused]] const MetadataField<InputShapes>& field,
+      [[maybe_unused]] const InputShapes& value) override {}
+
+  void visitUnsupported(std::string_view /*name*/) override {}
+
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
+
+  std::map<std::string, RecordedValue> values;
+
+ private:
+  template <typename T>
+  void record(const MetadataField<T>& field, RecordedValue value) {
+    values[std::string{field.name}] = std::move(value);
+  }
+};
+
+class UnsupportedRecordingTypedMetadataVisitor final
+    : public RecordingTypedMetadataVisitor {
+ public:
+  void visitUnsupported(std::string_view name) override {
+    unsupportedFields.emplace_back(name);
+  }
+
+  std::vector<std::string> unsupportedFields;
+};
+
+} // namespace
+
+TEST(TypedMetadataVisitorTest, VisitsTypedFields) {
+  RecordingTypedMetadataVisitor recorder;
+  ITypedMetadataVisitor& visitor = recorder;
+
+  visitor.visit(kCount, int64_t{5});
+  visitor.visit(kIds, std::vector<int64_t>{1, 2});
+  visitor.visit(kLabel, std::string{"label"});
+  visitor.visit(kRatio, 1.5);
+  visitor.visit(kEnabled, true);
+  visitor.visit(kNames, std::vector<std::string>{"a", "b"});
+
+  EXPECT_EQ(std::get<int64_t>(recorder.values.at("count")), int64_t{5});
+  EXPECT_EQ(
+      std::get<std::vector<int64_t>>(recorder.values.at("ids")),
+      std::vector<int64_t>({1, 2}));
+  EXPECT_EQ(
+      std::get<std::string>(recorder.values.at("label")), std::string{"label"});
+  EXPECT_EQ(std::get<double>(recorder.values.at("ratio")), 1.5);
+  EXPECT_EQ(std::get<bool>(recorder.values.at("enabled")), true);
+  EXPECT_EQ(
+      std::get<std::vector<std::string>>(recorder.values.at("names")),
+      std::vector<std::string>({"a", "b"}));
+}
+
+TEST(TypedMetadataVisitorTest, SerializesVisitedFieldsToJson) {
+  internal::JsonTypedMetadataVisitor jsonVisitor;
+  ITypedMetadataVisitor& visitor = jsonVisitor;
+
+  visitor.visit(kCount, int64_t{5});
+  visitor.visit(kIds, std::vector<int64_t>{1, 2});
+  visitor.visit(kLabel, std::string{"label"});
+  visitor.visit(kRatio, 1.5);
+  visitor.visit(kEnabled, true);
+  visitor.visit(kNames, std::vector<std::string>{"a", "b"});
+  visitor.visit(kSpecialChars, std::string{"quote \" slash \\ newline\n"});
+  visitor.visit(kNested, [&](auto& d) {
+    d.visit(kNestedCount, int64_t{7});
+    d.visit(kNestedOther, int64_t{8});
+  });
+  visitor.visit(kAfterNested, int64_t{9});
+
+  const auto json = std::move(jsonVisitor).json();
+
+  EXPECT_NE(json.find("\"count\": 5"), std::string::npos);
+  EXPECT_NE(json.find("\"ids\": [1, 2]"), std::string::npos);
+  EXPECT_NE(json.find("\"label\": \"label\""), std::string::npos);
+  EXPECT_NE(json.find("\"ratio\": 1.5"), std::string::npos);
+  EXPECT_NE(json.find("\"enabled\": true"), std::string::npos);
+  EXPECT_NE(json.find("\"names\": [\"a\", \"b\"]"), std::string::npos);
+  // String values pass through verbatim; output_json.cpp sanitizes the full
+  // metadata fragment before appending it to the Chrome trace.
+  EXPECT_NE(
+      json.find("\"special\": \"quote \" slash \\ newline\n\""),
+      std::string::npos);
+  EXPECT_NE(
+      json.find("\"nested\": {\"nested_count\": 7, \"nested_other\": 8}"),
+      std::string::npos);
+  EXPECT_NE(json.find("\"after_nested\": 9"), std::string::npos);
+}
+
+TEST(TypedMetadataVisitorTest, SerializesNestedDictsToJson) {
+  internal::JsonTypedMetadataVisitor jsonVisitor;
+  ITypedMetadataVisitor& visitor = jsonVisitor;
+
+  visitor.visit(kOuter, [&](auto& outer) {
+    outer.visit(kCount, int64_t{1});
+    outer.visit(kInner, [&](auto& inner) { inner.visit(kEnabled, true); });
+    outer.visit(kRatio, 2.5);
+  });
+  visitor.visit(kAfterNested, int64_t{9});
+
+  const auto json = std::move(jsonVisitor).json();
+
+  // A dict nested inside another dict, with sibling fields before and after the
+  // inner dict, then a field back at the top level.
+  EXPECT_NE(
+      json.find(
+          "\"outer\": {\"count\": 1, \"inner\": {\"enabled\": true}, \"ratio\": 2.5}"),
+      std::string::npos);
+  EXPECT_NE(json.find("\"after_nested\": 9"), std::string::npos);
+}
+
+TEST(TypedMetadataVisitorTest, FallsBackToVisitUnsupported) {
+  UnsupportedRecordingTypedMetadataVisitor recorder;
+  ITypedMetadataVisitor& visitor = recorder;
+
+  visitor.visit(kCount, int64_t{5});
+  visitor.visit(kPair, std::pair<int64_t, int64_t>{1, 2});
+
+  EXPECT_EQ(std::get<int64_t>(recorder.values.at("count")), int64_t{5});
+  EXPECT_EQ(recorder.unsupportedFields, std::vector<std::string>({"pair"}));
+}
+
+TEST(TypedMetadataVisitorTest, SerializesRawJsonVerbatim) {
+  internal::JsonTypedMetadataVisitor jsonVisitor;
+  ITypedMetadataVisitor& visitor = jsonVisitor;
+
+  visitor.visit(kCount, int64_t{5});
+  visitor.visit(kRaw, RawJson{"[1, 2, 3]"});
+
+  const auto json = std::move(jsonVisitor).json();
+
+  // RawJson is emitted as-is, unquoted, so an array stays an array.
+  EXPECT_NE(json.find("\"raw\": [1, 2, 3]"), std::string::npos);
+}
+
+TEST(TypedMetadataVisitorTest, SerializesUInt64AndInputShapesToJson) {
+  internal::JsonTypedMetadataVisitor jsonVisitor;
+  ITypedMetadataVisitor& visitor = jsonVisitor;
+
+  visitor.visit(kAddress, uint64_t{18446744073709551615ULL});
+  InputShapes dims;
+  dims.emplace_back(std::vector<int64_t>{2, 2});
+  dims.emplace_back(TensorListShapes{{4, 1}, {4, 1}});
+  visitor.visit(kInputDims, dims);
+
+  const auto json = std::move(jsonVisitor).json();
+
+  // uint64 is emitted as an unsigned number, not truncated.
+  EXPECT_NE(json.find("\"address\": 18446744073709551615"), std::string::npos);
+  // Each arg is a single tensor's shape or a nested list of tensor shapes.
+  EXPECT_NE(
+      json.find("\"input_dims\": [[2, 2], [[4, 1], [4, 1]]]"),
+      std::string::npos);
+}

--- a/third_party/kineto/libkineto/test/xpupti/CMakeLists.txt
+++ b/third_party/kineto/libkineto/test/xpupti/CMakeLists.txt
@@ -1,0 +1,99 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set(CMAKE_CXX_STANDARD 20)
+
+set(LINK_LIBRARIES
+  gtest_main
+  kineto_base
+  kineto_api
+  $<BUILD_INTERFACE:fmt::fmt-header-only>
+  ${SYCL_LIBRARY}
+  ${PTI_LIBRARY}
+)
+
+# Pure host-code tests (no SYCL device code): ordinary executables.
+add_executable(XpuptiScopeProfilerConfigTest XpuptiScopeProfilerConfigTest.cpp)
+target_link_libraries(XpuptiScopeProfilerConfigTest PRIVATE ${LINK_LIBRARIES})
+gtest_discover_tests(XpuptiScopeProfilerConfigTest)
+
+add_executable(XpuptiActivityHandlersTest XpuptiActivityHandlersTest.cpp)
+target_link_libraries(XpuptiActivityHandlersTest PRIVATE ${LINK_LIBRARIES})
+gtest_discover_tests(XpuptiActivityHandlersTest)
+
+# Hardware-free test for the CPU->GPU flow-link allowlist.
+add_executable(XpuptiFlowCorrelationTest XpuptiFlowCorrelationTest.cpp)
+target_link_libraries(XpuptiFlowCorrelationTest PRIVATE ${LINK_LIBRARIES})
+gtest_discover_tests(XpuptiFlowCorrelationTest)
+
+include(ExternalProject)
+
+# The compute translation unit contains SYCL device code and must be built by
+# the SYCL compiler (icpx -fsycl). CMake allows only one CXX compiler per build
+# tree, so it is built here as an isolated ExternalProject producing a kernel-only
+# shared library (libxpupti_compute.so / xpupti_compute.dll).
+set(XPUPTI_COMPUTE_LIB
+  ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}xpupti_compute${CMAKE_SHARED_LIBRARY_SUFFIX})
+
+if(WIN32)
+  set(XPUPTI_COMPUTE_IMPLIB
+      ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_IMPORT_LIBRARY_PREFIX}xpupti_compute${CMAKE_IMPORT_LIBRARY_SUFFIX})
+else()
+  set(XPUPTI_COMPUTE_IMPLIB "")
+endif()
+
+# On Windows SYCL/ICX requires the Ninja generator for the inner project.
+set(_xpupti_compute_generator ${CMAKE_GENERATOR})
+if(WIN32)
+  set(_xpupti_compute_generator Ninja)
+endif()
+
+set(_xpupti_compute_cmake_args
+    -DCMAKE_CXX_COMPILER=${SYCL_COMPILER}
+    -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR})
+
+if(WIN32)
+  get_filename_component(_sycl_compiler_dir "${SYCL_COMPILER}" DIRECTORY)
+  get_filename_component(_sycl_root "${_sycl_compiler_dir}" DIRECTORY)
+  list(APPEND _xpupti_compute_cmake_args
+    "-DCMAKE_EXE_LINKER_FLAGS=/Qoption,link,/LIBPATH:\"${_sycl_root}/lib\""
+    "-DCMAKE_SHARED_LINKER_FLAGS=/Qoption,link,/LIBPATH:\"${_sycl_root}/lib\"")
+endif()
+
+ExternalProject_Add(xpupti_compute_ep
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/compute
+  CONFIGURE_COMMAND ${CMAKE_COMMAND}
+    -G ${_xpupti_compute_generator}
+    -S <SOURCE_DIR>
+    -B <BINARY_DIR>
+    -DCMAKE_BUILD_TYPE=$<CONFIG>
+    ${_xpupti_compute_cmake_args}
+  BUILD_ALWAYS TRUE
+  BUILD_BYPRODUCTS ${XPUPTI_COMPUTE_LIB} ${XPUPTI_COMPUTE_IMPLIB})
+
+add_library(xpupti_compute SHARED IMPORTED)
+set_target_properties(xpupti_compute PROPERTIES
+  IMPORTED_LOCATION ${XPUPTI_COMPUTE_LIB})
+if(WIN32)
+  set_target_properties(xpupti_compute PROPERTIES
+    IMPORTED_IMPLIB ${XPUPTI_COMPUTE_IMPLIB})
+endif()
+add_dependencies(xpupti_compute xpupti_compute_ep)
+
+# Runtime tests: host code linking the kernel-only compute library.
+function(add_sycl_test test_file)
+  get_filename_component(test_name "${test_file}" NAME_WE)
+  add_executable(${test_name} ${test_file} XpuptiTestUtilities.cpp)
+  target_link_libraries(${test_name} PRIVATE
+    ${LINK_LIBRARIES}
+    xpupti_compute)
+  set_target_properties(${test_name} PROPERTIES
+    BUILD_RPATH ${CMAKE_CURRENT_BINARY_DIR})
+  gtest_discover_tests(${test_name})
+endfunction()
+
+add_sycl_test(XpuptiProfilerTest.cpp)
+add_sycl_test(XpuptiScopeProfilerTest.cpp)

--- a/third_party/kineto/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
+++ b/third_party/kineto/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "include/output_base.h"
+#include "src/ActivityBuffers.h"
+#include "src/plugin/xpupti/XpuptiActivityApi.h"
+#include "src/plugin/xpupti/XpuptiActivityProfilerSession.h"
+
+#include "src/plugin/xpupti/XpuptiProfilerMacros.h"
+
+#include <gtest/gtest.h>
+
+namespace KN = KINETO_NAMESPACE;
+using namespace libkineto;
+
+// Mock XpuptiActivityApi that delivers hand-crafted PTI records
+// through the virtual processActivities without needing PTI runtime.
+class MockXpuptiActivityApi : public KN::XpuptiActivityApi {
+ public:
+  std::vector<const pti_view_record_base*> records;
+
+  std::unique_ptr<KN::XpuptiActivityBufferMap> activityBuffers() override {
+    // Return a non-null map so processTrace enters the processing path.
+    return std::make_unique<KN::XpuptiActivityBufferMap>();
+  }
+
+  const std::pair<int, int> processActivities(
+      KN::XpuptiActivityBufferMap&,
+      std::function<void(const pti_view_record_base*)> handler) override {
+    for (auto* record : records) {
+      handler(record);
+    }
+    return {static_cast<int>(records.size()), 0};
+  }
+};
+
+// Minimal ActivityLogger that captures logged GenericTraceActivity objects.
+class MockActivityLogger : public ActivityLogger {
+ public:
+  std::vector<const GenericTraceActivity*> logged_activities;
+
+  void handleDeviceInfo(const DeviceInfo&, int64_t) override {}
+  void handleResourceInfo(const ResourceInfo&, int64_t) override {}
+  void handleOverheadInfo(const OverheadInfo&, int64_t) override {}
+  void handleTraceSpan(const TraceSpan&) override {}
+
+  void handleActivity(const ITraceActivity&) override {}
+
+  void handleGenericActivity(const GenericTraceActivity& activity) override {
+    logged_activities.push_back(&activity);
+  }
+
+  void handleTraceStart(
+      const std::unordered_map<std::string, std::string>&,
+      const std::string&) override {}
+
+  void finalizeMemoryTrace(const std::string&, const Config&) override {}
+
+  void finalizeTrace(
+      const Config&,
+      std::unique_ptr<KINETO_NAMESPACE::ActivityBuffers>,
+      int64_t) override {}
+};
+
+class XpuptiActivityHandlersTest : public ::testing::Test {
+ protected:
+  MockXpuptiActivityApi mockApi_;
+  MockActivityLogger logger_;
+
+  // Processes all records in mockApi_ through the handler pipeline
+  // and returns the resulting trace buffer.
+  std::unique_ptr<CpuTraceBuffer> processAndGetTrace(
+      int64_t windowStart = 0,
+      int64_t windowEnd = 1000) {
+    Config config;
+    std::set<ActivityType> activity_types = {
+        ActivityType::COLLECTIVE_COMM, ActivityType::XPU_SYNC};
+    auto session = std::make_unique<KN::XpuptiActivityProfilerSession>(
+        mockApi_, "__test_profiler__", config, activity_types);
+    session->processTrace(
+        logger_,
+        [](int64_t) -> const ITraceActivity* { return nullptr; },
+        windowStart,
+        windowEnd);
+    return session->getTraceBuffer();
+  }
+};
+
+// --- Communication Activity Tests ---
+
+TEST_F(XpuptiActivityHandlersTest, CommunicationActivityHasXcclPrefix) {
+  pti_view_record_comms comms_record{};
+  comms_record._view_kind._view_kind = PTI_VIEW_COMMUNICATION;
+  comms_record._name = "allreduce";
+  comms_record._start_timestamp = 100;
+  comms_record._end_timestamp = 200;
+  comms_record._process_id = 1;
+  comms_record._thread_id = 42;
+  comms_record._communicator_id = 7;
+
+  mockApi_.records.push_back(
+      reinterpret_cast<const pti_view_record_base*>(&comms_record));
+
+  auto traceBuffer = processAndGetTrace();
+  ASSERT_EQ(traceBuffer->activities.size(), 1);
+
+  auto& activity = *traceBuffer->activities[0];
+  EXPECT_EQ(activity.name(), "xccl::allreduce");
+  EXPECT_EQ(activity.type(), ActivityType::COLLECTIVE_COMM);
+}
+
+TEST_F(XpuptiActivityHandlersTest, CommunicationActivityFields) {
+  pti_view_record_comms comms_record{};
+  comms_record._view_kind._view_kind = PTI_VIEW_COMMUNICATION;
+  comms_record._name = "broadcast";
+  comms_record._start_timestamp = 300;
+  comms_record._end_timestamp = 500;
+  comms_record._process_id = 10;
+  comms_record._thread_id = 77;
+  comms_record._communicator_id = 99;
+
+  mockApi_.records.push_back(
+      reinterpret_cast<const pti_view_record_base*>(&comms_record));
+
+  auto traceBuffer = processAndGetTrace();
+  ASSERT_EQ(traceBuffer->activities.size(), 1);
+
+  auto& activity = *traceBuffer->activities[0];
+  EXPECT_EQ(activity.timestamp(), 300);
+  EXPECT_EQ(activity.duration(), 200);
+  EXPECT_EQ(activity.deviceId(), 10);
+  EXPECT_EQ(activity.resourceId(), 77);
+  EXPECT_EQ(activity.getThreadId(), 77);
+  EXPECT_EQ(activity.getMetadataValue("Communicator_id"), "99");
+}
+
+TEST_F(XpuptiActivityHandlersTest, CommunicationActivityOutOfRange) {
+  pti_view_record_comms comms_record{};
+  comms_record._view_kind._view_kind = PTI_VIEW_COMMUNICATION;
+  comms_record._name = "allgather";
+  comms_record._start_timestamp = 2000;
+  comms_record._end_timestamp = 3000;
+  comms_record._process_id = 1;
+  comms_record._thread_id = 1;
+  comms_record._communicator_id = 1;
+
+  mockApi_.records.push_back(
+      reinterpret_cast<const pti_view_record_base*>(&comms_record));
+
+  auto traceBuffer = processAndGetTrace(100, 500);
+  EXPECT_EQ(traceBuffer->activities.size(), 0);
+}
+
+// --- Synchronization Activity Tests ---
+
+TEST_F(XpuptiActivityHandlersTest, SynchronizationActivityDeviceIsNegativeOne) {
+  pti_view_record_synchronization sync_record{};
+  sync_record._view_kind._view_kind = PTI_VIEW_DEVICE_SYNCHRONIZATION;
+  sync_record._synch_type = PTI_VIEW_SYNCHRONIZATION_TYPE_HOST_EVENT;
+  sync_record._start_timestamp = 100;
+  sync_record._end_timestamp = 200;
+  sync_record._thread_id = 55;
+  sync_record._correlation_id = 1;
+  sync_record._api_id = 84; // zeEventHostSynchronize_id
+  sync_record._api_group =
+      static_cast<pti_api_group_id>(1); // PTI_API_GROUP_LEVELZERO
+
+  mockApi_.records.push_back(
+      reinterpret_cast<const pti_view_record_base*>(&sync_record));
+
+  auto traceBuffer = processAndGetTrace();
+  ASSERT_EQ(traceBuffer->activities.size(), 1);
+
+  auto& activity = *traceBuffer->activities[0];
+  EXPECT_EQ(activity.deviceId(), -1);
+  EXPECT_EQ(activity.type(), ActivityType::XPU_SYNC);
+}
+
+TEST_F(XpuptiActivityHandlersTest, SynchronizationActivityMetadata) {
+  pti_view_record_synchronization sync_record{};
+  sync_record._view_kind._view_kind = PTI_VIEW_DEVICE_SYNCHRONIZATION;
+  sync_record._synch_type = PTI_VIEW_SYNCHRONIZATION_TYPE_HOST_FENCE;
+  sync_record._context_handle = nullptr;
+  sync_record._queue_handle = nullptr;
+  sync_record._event_handle = nullptr;
+  sync_record._start_timestamp = 400;
+  sync_record._end_timestamp = 600;
+  sync_record._thread_id = 88;
+  sync_record._correlation_id = 5;
+  sync_record._number_wait_events = 3;
+  sync_record._return_code = 0;
+  sync_record._api_id = 84; // zeEventHostSynchronize_id
+  sync_record._api_group =
+      static_cast<pti_api_group_id>(1); // PTI_API_GROUP_LEVELZERO
+
+  mockApi_.records.push_back(
+      reinterpret_cast<const pti_view_record_base*>(&sync_record));
+
+  auto traceBuffer = processAndGetTrace();
+  ASSERT_EQ(traceBuffer->activities.size(), 1);
+
+  auto& activity = *traceBuffer->activities[0];
+  EXPECT_EQ(activity.timestamp(), 400);
+  EXPECT_EQ(activity.duration(), 200);
+  EXPECT_EQ(activity.resourceId(), 88);
+  EXPECT_EQ(activity.getMetadataValue("Type"), "HOST_FENCE");
+  EXPECT_EQ(activity.getMetadataValue("Number_wait_events"), "3");
+  EXPECT_EQ(activity.getMetadataValue("Return_code"), "0");
+  EXPECT_EQ(activity.getMetadataValue("correlation"), "5");
+}
+
+TEST_F(XpuptiActivityHandlersTest, SynchronizationAllTypes) {
+  struct SyncTypeTestCase {
+    pti_view_synchronization_type type;
+    std::string expected_name;
+  };
+  std::vector<SyncTypeTestCase> cases = {
+      {PTI_VIEW_SYNCHRONIZATION_TYPE_UNKNOWN, "UNKNOWN"},
+      {PTI_VIEW_SYNCHRONIZATION_TYPE_GPU_BARRIER_EXECUTION,
+       "GPU_BARRIER_EXECUTION"},
+      {PTI_VIEW_SYNCHRONIZATION_TYPE_GPU_BARRIER_MEMORY, "GPU_BARRIER_MEMORY"},
+      {PTI_VIEW_SYNCHRONIZATION_TYPE_HOST_FENCE, "HOST_FENCE"},
+      {PTI_VIEW_SYNCHRONIZATION_TYPE_HOST_EVENT, "HOST_EVENT"},
+      {PTI_VIEW_SYNCHRONIZATION_TYPE_HOST_COMMAND_LIST, "HOST_COMMAND_LIST"},
+      {PTI_VIEW_SYNCHRONIZATION_TYPE_HOST_COMMAND_QUEUE, "HOST_COMMAND_QUEUE"},
+  };
+
+  for (const auto& tc : cases) {
+    mockApi_.records.clear();
+
+    pti_view_record_synchronization sync_record{};
+    sync_record._view_kind._view_kind = PTI_VIEW_DEVICE_SYNCHRONIZATION;
+    sync_record._synch_type = tc.type;
+    sync_record._start_timestamp = 100;
+    sync_record._end_timestamp = 200;
+    sync_record._thread_id = 1;
+    sync_record._correlation_id = 1;
+    sync_record._api_id = 84; // zeEventHostSynchronize_id
+    sync_record._api_group =
+        static_cast<pti_api_group_id>(1); // PTI_API_GROUP_LEVELZERO
+
+    mockApi_.records.push_back(
+        reinterpret_cast<const pti_view_record_base*>(&sync_record));
+
+    auto traceBuffer = processAndGetTrace();
+    ASSERT_EQ(traceBuffer->activities.size(), 1)
+        << "Failed for type: " << tc.expected_name;
+
+    auto& activity = *traceBuffer->activities[0];
+    EXPECT_EQ(activity.getMetadataValue("Type"), tc.expected_name)
+        << "Wrong string for synchronization type " << tc.type;
+  }
+}
+
+TEST_F(XpuptiActivityHandlersTest, SynchronizationActivityOutOfRange) {
+  pti_view_record_synchronization sync_record{};
+  sync_record._view_kind._view_kind = PTI_VIEW_DEVICE_SYNCHRONIZATION;
+  sync_record._synch_type = PTI_VIEW_SYNCHRONIZATION_TYPE_HOST_FENCE;
+  sync_record._start_timestamp = 50;
+  sync_record._end_timestamp = 80;
+  sync_record._thread_id = 1;
+  sync_record._correlation_id = 1;
+  sync_record._api_id = 84; // zeEventHostSynchronize_id
+  sync_record._api_group =
+      static_cast<pti_api_group_id>(1); // PTI_API_GROUP_LEVELZERO
+
+  mockApi_.records.push_back(
+      reinterpret_cast<const pti_view_record_base*>(&sync_record));
+
+  auto traceBuffer = processAndGetTrace(100, 500);
+  EXPECT_EQ(traceBuffer->activities.size(), 0);
+}
+
+// --- Mixed dispatch test ---
+
+TEST_F(XpuptiActivityHandlersTest, MixedCommunicationAndSynchronization) {
+  pti_view_record_comms comms_record{};
+  comms_record._view_kind._view_kind = PTI_VIEW_COMMUNICATION;
+  comms_record._name = "reduce_scatter";
+  comms_record._start_timestamp = 100;
+  comms_record._end_timestamp = 200;
+  comms_record._process_id = 1;
+  comms_record._thread_id = 10;
+  comms_record._communicator_id = 5;
+
+  pti_view_record_synchronization sync_record{};
+  sync_record._view_kind._view_kind = PTI_VIEW_DEVICE_SYNCHRONIZATION;
+  sync_record._synch_type = PTI_VIEW_SYNCHRONIZATION_TYPE_GPU_BARRIER_EXECUTION;
+  sync_record._start_timestamp = 300;
+  sync_record._end_timestamp = 400;
+  sync_record._thread_id = 20;
+  sync_record._correlation_id = 2;
+  sync_record._api_id = 84; // zeEventHostSynchronize_id
+  sync_record._api_group =
+      static_cast<pti_api_group_id>(1); // PTI_API_GROUP_LEVELZERO
+
+  mockApi_.records.push_back(
+      reinterpret_cast<const pti_view_record_base*>(&comms_record));
+  mockApi_.records.push_back(
+      reinterpret_cast<const pti_view_record_base*>(&sync_record));
+
+  auto traceBuffer = processAndGetTrace();
+  ASSERT_EQ(traceBuffer->activities.size(), 2);
+
+  auto& comms_activity = *traceBuffer->activities[0];
+  EXPECT_EQ(comms_activity.name(), "xccl::reduce_scatter");
+  EXPECT_EQ(comms_activity.type(), ActivityType::COLLECTIVE_COMM);
+
+  auto& sync_activity = *traceBuffer->activities[1];
+  EXPECT_EQ(sync_activity.deviceId(), -1);
+  EXPECT_EQ(sync_activity.type(), ActivityType::XPU_SYNC);
+  EXPECT_EQ(sync_activity.getMetadataValue("Type"), "GPU_BARRIER_EXECUTION");
+}

--- a/third_party/kineto/libkineto/test/xpupti/XpuptiFlowCorrelationTest.cpp
+++ b/third_party/kineto/libkineto/test/xpupti/XpuptiFlowCorrelationTest.cpp
@@ -1,0 +1,41 @@
+//==============================================================
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+
+#include "src/plugin/xpupti/XpuptiActivityProfilerSession.h"
+
+#include <gtest/gtest.h>
+
+namespace KN = KINETO_NAMESPACE;
+
+// Exercises the predicate that decides which records start a CPU->GPU ("ac2g")
+// flow arrow. Runs without a GPU: only the static predicate is queried, no PTI
+// collection is performed.
+
+TEST(XpuptiFlowCorrelationTest, RuntimeRecordsStartFlow) {
+  // Host runtime records (kernel launches, memcpy/fill enqueues) are the source
+  // of the CPU->GPU arrow. The runtime view is filtered to work-submitting APIs
+  // by ptiViewEnableRuntimeApiClass(PTI_API_CLASS_GPU_OPERATION_CORE).
+  EXPECT_TRUE(KN::XpuptiActivityProfilerSession::startsFlow(
+      KN::ActivityType::XPU_RUNTIME));
+}
+
+TEST(XpuptiFlowCorrelationTest, DriverRecordsDoNotStartFlow) {
+  // Driver (ze*) records share the runtime record's correlation id; if they
+  // also started a flow the trace would have a duplicate flow start for that
+  // id (Perfetto flow_duplicate_id). They must only be flow ends.
+  EXPECT_FALSE(KN::XpuptiActivityProfilerSession::startsFlow(
+      KN::ActivityType::XPU_DRIVER));
+}
+
+TEST(XpuptiFlowCorrelationTest, DeviceRecordsDoNotStartFlow) {
+  // GPU-side activities are flow destinations, never sources.
+  EXPECT_FALSE(KN::XpuptiActivityProfilerSession::startsFlow(
+      KN::ActivityType::CONCURRENT_KERNEL));
+  EXPECT_FALSE(KN::XpuptiActivityProfilerSession::startsFlow(
+      KN::ActivityType::GPU_MEMCPY));
+  EXPECT_FALSE(KN::XpuptiActivityProfilerSession::startsFlow(
+      KN::ActivityType::GPU_MEMSET));
+}

--- a/third_party/kineto/libkineto/test/xpupti/XpuptiProfilerTest.cpp
+++ b/third_party/kineto/libkineto/test/xpupti/XpuptiProfilerTest.cpp
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "XpuptiTestUtilities.h"
+
+#include "include/GenericTraceActivity.h"
+#include "include/libkineto.h"
+
+#include <gtest/gtest.h>
+
+#include <set>
+#include <unordered_set>
+
+namespace KN = KINETO_NAMESPACE;
+
+namespace {
+
+constexpr int64_t kUserCorrId = 0xC0FFEE;
+
+enum class LinkedActivityMode {
+  AlwaysLinked,
+  MissFirstThenLinked,
+};
+
+std::vector<std::string_view> expectedGpuUserAnnotationActivities() {
+  return {
+      "urEnqueueMemBufferWrite",
+      "urEnqueueMemBufferWrite",
+      "urEnqueueMemBufferWrite",
+      "urEnqueueKernelLaunch",
+      "urEnqueueMemBufferRead",
+      "Memcpy M2D",
+      "Memcpy M2D",
+      "Memcpy M2D",
+      "Run(sycl::_V1::queue, ...)",
+      "Memcpy D2M",
+      "user_function",
+      "user_function"};
+}
+
+std::vector<std::string_view> expectedGpuUserAnnotationTypes() {
+  return {
+      "xpu_runtime",
+      "xpu_runtime",
+      "xpu_runtime",
+      "xpu_runtime",
+      "xpu_runtime",
+      "gpu_memcpy",
+      "gpu_memcpy",
+      "gpu_memcpy",
+      "kernel",
+      "gpu_memcpy",
+      "gpu_user_annotation",
+      "gpu_user_annotation"};
+}
+
+std::unique_ptr<KN::CpuTraceBuffer> runGpuUserAnnotationCase(
+    LinkedActivityMode mode) {
+  KN::Config cfg;
+  std::vector<std::string_view> metrics;
+
+  std::set<KN::ActivityType> activities{
+      KN::ActivityType::GPU_MEMCPY,
+      KN::ActivityType::CONCURRENT_KERNEL,
+      KN::ActivityType::XPU_RUNTIME,
+      KN::ActivityType::EXTERNAL_CORRELATION,
+      KN::ActivityType::GPU_USER_ANNOTATION,
+  };
+
+  auto expectedActivities = expectedGpuUserAnnotationActivities();
+  auto expectedTypes = expectedGpuUserAnnotationTypes();
+
+  static const KN::TraceSpan kCpuSpan(0, 0, "cpu_span", "");
+  static KN::GenericTraceActivity cpuAct(
+      kCpuSpan, KN::ActivityType::CPU_OP, "user_function");
+  cpuAct.id = kUserCorrId;
+
+  bool firstLookup = true;
+  auto linkedActivityCallback =
+      [&firstLookup, mode](int32_t corr) -> const KN::ITraceActivity* {
+    if (corr != kUserCorrId) {
+      return nullptr;
+    }
+    if (mode == LinkedActivityMode::MissFirstThenLinked && firstLookup) {
+      firstLookup = false;
+      return nullptr;
+    }
+    return &cpuAct;
+  };
+
+  constexpr unsigned repeatCount = 1;
+  [[maybe_unused]] auto [pSession, pBuffer] = RunProfilerTest(
+      metrics,
+      activities,
+      cfg,
+      repeatCount,
+      std::move(expectedActivities),
+      std::move(expectedTypes),
+      kUserCorrId,
+      &cpuAct,
+      linkedActivityCallback);
+
+  return std::move(pBuffer);
+}
+
+void expectTwoUserAnnotations(const KN::CpuTraceBuffer& buffer) {
+  std::set<std::pair<int64_t, int64_t>> streamKeys;
+  unsigned annotationCount = 0;
+  for (const auto& activity : buffer.activities) {
+    if (activity->type() != KN::ActivityType::GPU_USER_ANNOTATION) {
+      continue;
+    }
+    ++annotationCount;
+    EXPECT_EQ(activity->correlationId(), kUserCorrId);
+    ASSERT_NE(activity->linkedActivity(), nullptr);
+    EXPECT_EQ(activity->linkedActivity()->name(), "user_function");
+    streamKeys.insert({activity->deviceId(), activity->resourceId()});
+  }
+
+  EXPECT_EQ(annotationCount, 2);
+  EXPECT_EQ(streamKeys.size(), 2);
+}
+
+} // namespace
+
+TEST(XpuptiProfilerTest, XpuDriverEvents) {
+  KN::Config cfg;
+
+  std::vector<std::string_view> metrics;
+
+  std::set<KN::ActivityType> activities{
+      KN::ActivityType::XPU_RUNTIME,
+      KN::ActivityType::XPU_DRIVER,
+  };
+
+  std::vector<std::string_view> expectedActivities = {
+      "urEnqueueMemBufferWrite",
+      "urEnqueueMemBufferWrite",
+      "urEnqueueMemBufferWrite",
+      "urEnqueueKernelLaunch",
+      "urEnqueueMemBufferRead",
+  };
+
+  std::vector<std::string_view> expectedTypes = {
+      "xpu_runtime",
+      "xpu_runtime",
+      "xpu_runtime",
+      "xpu_runtime",
+      "xpu_runtime"};
+
+  constexpr unsigned repeatCount = 1;
+  RunProfilerTest(
+      metrics,
+      activities,
+      cfg,
+      repeatCount,
+      std::move(expectedActivities),
+      std::move(expectedTypes));
+}
+
+TEST(XpuptiProfilerTest, OverheadActivity) {
+  KN::Config cfg;
+
+  std::vector<std::string_view> metrics;
+
+  // Profile a normal kernel workload alongside the OVERHEAD activity so that
+  // PTI has collection work to attribute overhead to.
+  std::set<KN::ActivityType> activities{
+      KN::ActivityType::CONCURRENT_KERNEL,
+      KN::ActivityType::OVERHEAD,
+  };
+
+  std::vector<std::string_view> expectedActivities = {
+      "Run(sycl::_V1::queue, ...)"};
+  std::vector<std::string_view> expectedTypes = {"kernel"};
+
+  constexpr unsigned repeatCount = 1;
+  auto [pSession, pBuffer] = RunProfilerTest(
+      metrics,
+      activities,
+      cfg,
+      repeatCount,
+      std::move(expectedActivities),
+      std::move(expectedTypes));
+
+  // Verify the shape of every overhead record the run produced.
+  static const std::unordered_set<std::string> kExpectedNames{
+      "Unknown", "Resource", "Buffer Flush", "Driver", "Instrumentation"};
+  for (auto&& pActivity : pBuffer->activities) {
+    if (pActivity->type() != KN::ActivityType::OVERHEAD) {
+      continue;
+    }
+
+    // Overhead is host-side, not attributed to a device.
+    EXPECT_EQ(pActivity->deviceId(), -1);
+
+    const std::string name = pActivity->name();
+    EXPECT_TRUE(kExpectedNames.count(name) == 1)
+        << "unexpected overhead name: " << name;
+
+    const auto metadata = pActivity->metadataJson();
+    EXPECT_NE(metadata.find("overhead cost"), std::string::npos)
+        << "metadata = " << metadata;
+    EXPECT_NE(metadata.find("overhead count"), std::string::npos)
+        << "metadata = " << metadata;
+    EXPECT_NE(metadata.find("overhead occupancy"), std::string::npos)
+        << "metadata = " << metadata;
+  }
+}
+
+TEST(XpuptiProfilerTest, TestEvents) {
+  KN::Config cfg;
+
+  std::vector<std::string_view> metrics;
+
+  std::set<KN::ActivityType> activities{
+      KN::ActivityType::GPU_MEMCPY,
+      KN::ActivityType::GPU_MEMSET,
+      KN::ActivityType::CONCURRENT_KERNEL,
+      KN::ActivityType::EXTERNAL_CORRELATION};
+
+  std::vector<std::string_view> expectedActivities = {
+      "Memcpy M2D",
+      "Memcpy M2D",
+      "Memcpy M2D",
+      "Run(sycl::_V1::queue, ...)",
+      "Memcpy D2M"};
+
+  std::vector<std::string_view> expectedTypes = {
+      "gpu_memcpy", "gpu_memcpy", "gpu_memcpy", "kernel", "gpu_memcpy"};
+
+  constexpr unsigned repeatCount = 1;
+  auto [pSession, pBuffer] = RunProfilerTest(
+      metrics,
+      activities,
+      cfg,
+      repeatCount,
+      std::move(expectedActivities),
+      std::move(expectedTypes));
+
+  static bool isVerbose = IsEnvVerbose();
+
+  auto resourceInfos = pSession->getResourceInfos();
+  if (isVerbose) {
+    for (auto&& ri : resourceInfos) {
+#define PRINT(R) std::cout << #R " = " << ri.R << std::endl;
+      PRINT(id)
+      PRINT(sortIndex)
+      PRINT(deviceId)
+      PRINT(name)
+#undef PRINT
+    }
+  }
+
+  std::vector<unsigned> irUseCount(resourceInfos.size(), 0);
+  for (auto&& pActivity : pBuffer->activities) {
+    bool found = false;
+    auto resourceId = pActivity->resourceId();
+    auto deviceId = pActivity->deviceId();
+    for (unsigned i = 0; i < resourceInfos.size(); ++i) {
+      const auto& ri = resourceInfos[i];
+      if ((ri.id == resourceId) && (ri.deviceId == deviceId)) {
+        ++irUseCount[i];
+        found = true;
+        break;
+      }
+    }
+
+    EXPECT_TRUE(found) << "resourceInfo for deviceId = " << deviceId
+                       << ", resourceId=" << resourceId << " not found.";
+  }
+
+  for (unsigned i = 0; i < resourceInfos.size(); ++i) {
+    EXPECT_TRUE(irUseCount[i] > 0)
+        << "resourceInfo for deviceId = " << resourceInfos[i].deviceId
+        << ", resourceId=" << resourceInfos[i].id << " never used.";
+  }
+}
+
+TEST(XpuptiProfilerTest, GpuUserAnnotation) {
+  auto pBuffer = runGpuUserAnnotationCase(LinkedActivityMode::AlwaysLinked);
+  expectTwoUserAnnotations(*pBuffer);
+}
+
+TEST(XpuptiProfilerTest, GpuUserAnnotationLinkedActivityRetry) {
+  auto pBuffer =
+      runGpuUserAnnotationCase(LinkedActivityMode::MissFirstThenLinked);
+  expectTwoUserAnnotations(*pBuffer);
+}

--- a/third_party/kineto/libkineto/test/xpupti/XpuptiScopeProfilerConfigTest.cpp
+++ b/third_party/kineto/libkineto/test/xpupti/XpuptiScopeProfilerConfigTest.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "src/plugin/xpupti/XpuptiScopeProfilerConfig.h"
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+#include <gtest/gtest.h>
+
+namespace KN = KINETO_NAMESPACE;
+
+class XpuptiScopeProfilerConfigTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    KN::XpuptiScopeProfilerConfig::registerFactory();
+  }
+};
+
+TEST_F(XpuptiScopeProfilerConfigTest, ConfigureProfiler) {
+  KN::Config cfg;
+  std::vector<std::string> metrics = {
+      "metric1",
+      "metric2",
+      "metric3",
+  };
+  auto metricsConfigStr =
+      fmt::format("XPUPTI_PROFILER_METRICS = {}", fmt::join(metrics, ","));
+
+  EXPECT_TRUE(cfg.parse(metricsConfigStr));
+  EXPECT_TRUE(cfg.parse("XPUPTI_PROFILER_ENABLE_PER_KERNEL = true"));
+  EXPECT_TRUE(cfg.parse("XPUPTI_PROFILER_MAX_SCOPES = 314159"));
+
+  const KN::XpuptiScopeProfilerConfig& xpupti_cfg =
+      KN::XpuptiScopeProfilerConfig::get(cfg);
+
+  EXPECT_EQ(xpupti_cfg.activitiesXpuptiMetrics(), metrics);
+  EXPECT_EQ(xpupti_cfg.xpuptiProfilerPerKernel(), true);
+  EXPECT_EQ(xpupti_cfg.xpuptiProfilerMaxScopes(), 314159);
+}
+
+TEST_F(XpuptiScopeProfilerConfigTest, ScopesDefaults) {
+  KN::Config cfg, cfg_auto;
+
+  // do not set max scopes in config, check defaults are sane
+  EXPECT_TRUE(cfg.parse("XPUPTI_PROFILER_METRICS = metric1"));
+  EXPECT_TRUE(cfg.parse("XPUPTI_PROFILER_ENABLE_PER_KERNEL = false"));
+
+  cfg.setClientDefaults();
+
+  EXPECT_TRUE(cfg_auto.parse("XPUPTI_PROFILER_METRICS = metric2"));
+  EXPECT_TRUE(cfg_auto.parse("XPUPTI_PROFILER_ENABLE_PER_KERNEL = true"));
+
+  cfg_auto.setClientDefaults();
+
+  int user_scopes, auto_scopes;
+
+  user_scopes =
+      KN::XpuptiScopeProfilerConfig::get(cfg).xpuptiProfilerMaxScopes();
+  auto_scopes =
+      KN::XpuptiScopeProfilerConfig::get(cfg_auto).xpuptiProfilerMaxScopes();
+
+  EXPECT_EQ(user_scopes, 10);
+  EXPECT_EQ(auto_scopes, 1500);
+}

--- a/third_party/kineto/libkineto/test/xpupti/XpuptiScopeProfilerTest.cpp
+++ b/third_party/kineto/libkineto/test/xpupti/XpuptiScopeProfilerTest.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "XpuptiTestUtilities.h"
+
+#include "src/plugin/xpupti/XpuptiActivityProfiler.h"
+#include "src/plugin/xpupti/XpuptiProfilerMacros.h"
+#include "src/plugin/xpupti/XpuptiScopeProfilerConfig.h"
+
+#include <libkineto.h>
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+#include <gtest/gtest.h>
+
+namespace KN = KINETO_NAMESPACE;
+
+class XpuptiScopeProfilerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    KN::XpuptiScopeProfilerConfig::registerFactory();
+  }
+};
+
+void RunTest(std::string_view perKernel, unsigned maxScopes) {
+  KN::Config cfg;
+
+  std::vector<std::string_view> metrics = {
+      "GpuTime",
+      "GpuCoreClocks",
+      "AvgGpuCoreFrequencyMHz",
+      "XVE_INST_EXECUTED_ALU0_ALL_UTILIZATION",
+      "XVE_ACTIVE",
+      "XVE_STALL"};
+
+  EXPECT_TRUE(cfg.parse(
+      fmt::format("XPUPTI_PROFILER_METRICS = {}", fmt::join(metrics, ","))));
+  EXPECT_TRUE(cfg.parse(
+      fmt::format("XPUPTI_PROFILER_ENABLE_PER_KERNEL = {}", perKernel)));
+  EXPECT_TRUE(
+      cfg.parse(fmt::format("XPUPTI_PROFILER_MAX_SCOPES = {}", maxScopes)));
+
+  std::set<KN::ActivityType> activities{
+      KN::ActivityType::GPU_MEMCPY,
+      KN::ActivityType::GPU_MEMSET,
+      KN::ActivityType::CONCURRENT_KERNEL,
+      KN::ActivityType::EXTERNAL_CORRELATION,
+      KN::ActivityType::XPU_RUNTIME,
+      KN::ActivityType::XPU_SCOPE_PROFILER};
+
+  std::vector<std::string_view> expectedActivities = {
+      "urEnqueueMemBufferWrite",
+      "urEnqueueMemBufferWrite",
+      "urEnqueueMemBufferWrite",
+      "Memcpy M2D",
+      "Memcpy M2D",
+      "Memcpy M2D",
+      "urEnqueueKernelLaunch",
+      "Run(sycl::_V1::queue, ...)",
+      "urEnqueueMemBufferRead",
+      "Memcpy D2M",
+      "metrics: Run(sycl::_V1::queue, ...)",
+      "metrics",
+      "metrics"};
+
+  std::vector<std::string_view> expectedTypes = {
+      "xpu_runtime",
+      "xpu_runtime",
+      "xpu_runtime",
+      "gpu_memcpy",
+      "gpu_memcpy",
+      "gpu_memcpy",
+      "xpu_runtime",
+      "kernel",
+      "xpu_runtime",
+      "gpu_memcpy",
+      "kernel",
+      "xpu_scope_profiler",
+      "xpu_scope_profiler"};
+
+  std::exception_ptr eptr;
+
+  try {
+    constexpr unsigned repeatCount = 5;
+    RunProfilerTest(
+        metrics,
+        activities,
+        cfg,
+        repeatCount,
+        std::move(expectedActivities),
+        std::move(expectedTypes));
+  } catch (...) {
+    eptr = std::current_exception();
+  }
+
+  bool expectThrow = (perKernel == "false");
+
+  if (expectThrow) {
+    EXPECT_THROW(
+        try {
+          if (eptr) {
+            std::rethrow_exception(eptr);
+          }
+        } catch (const std::runtime_error& e) {
+          static bool isVerbose = IsEnvVerbose();
+          if (isVerbose) {
+            std::cout << "std::runtime_error = " << e.what() << std::endl;
+          }
+          throw;
+        },
+        std::runtime_error);
+  } else {
+    if (eptr) {
+      std::rethrow_exception(eptr);
+    }
+  }
+}
+
+/////////////////////////////////////////////////////////////////////
+
+TEST_F(XpuptiScopeProfilerTest, PerKernelScope) {
+  RunTest("true", 314);
+}
+
+TEST_F(XpuptiScopeProfilerTest, UserScope) {
+  RunTest("false", 159);
+}

--- a/third_party/kineto/libkineto/test/xpupti/XpuptiTestUtilities.cpp
+++ b/third_party/kineto/libkineto/test/xpupti/XpuptiTestUtilities.cpp
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "XpuptiTestUtilities.h"
+
+#include "src/ActivityBuffers.h"
+#include "src/plugin/xpupti/XpuptiActivityProfiler.h"
+#include "test/xpupti/compute/XpuptiScopeProfilerCompute.h"
+
+#include <libkineto.h>
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+#include <gtest/gtest.h>
+
+namespace KN = KINETO_NAMESPACE;
+
+bool IsEnvVerbose() {
+  auto verboseEnv = getenv("VERBOSE");
+  return verboseEnv && (strcmp(verboseEnv, "1") == 0);
+}
+
+std::ostream& operator<<(std::ostream& os, const KN::TraceSpan& span) {
+#define PRINT(V) os << std::endl << "      " #V " = " << span.V;
+  PRINT(startTime)
+  PRINT(endTime)
+  PRINT(opCount)
+  PRINT(iteration)
+  PRINT(name)
+  PRINT(prefix)
+#undef PRINT
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, KN::ActivityType actType) {
+  os << toString(actType);
+  return os;
+}
+
+static std::pair<unsigned, unsigned> CountMetricsInVector(
+    const std::vector<std::string_view>& metrics,
+    const decltype(std::declval<KN::GenericTraceActivity>()
+                       .counterValues())& vec) {
+  unsigned metricsCount = 0;
+  unsigned metricsMask = 0;
+  for (unsigned i = 0; i < metrics.size(); ++i) {
+    const auto metricSv = metrics[i];
+    if (std::find_if(vec.begin(), vec.end(), [metricSv](const auto& pair) {
+          return pair.first == metricSv;
+        }) != vec.end()) {
+      ++metricsCount;
+      metricsMask |= (1 << i);
+    }
+  }
+  return std::pair{metricsCount, metricsMask};
+}
+
+static std::pair<unsigned, unsigned> CountMetricsInString(
+    const std::vector<std::string_view>& metrics,
+    const std::string_view sv) {
+  unsigned metricsCount = 0;
+  unsigned metricsMask = 0;
+  for (unsigned i = 0; i < metrics.size(); ++i) {
+    const auto metricSv = metrics[i];
+    if (sv.find(metricSv) != std::string_view::npos) {
+      ++metricsCount;
+      metricsMask |= (1 << i);
+    }
+  }
+  return std::pair{metricsCount, metricsMask};
+}
+
+template <class MAP, class EXPMAP>
+void CheckCountsInMap(
+    const MAP& map,
+    unsigned expSize,
+    unsigned repeatCount,
+    const EXPMAP& expMap) {
+  EXPECT_EQ(map.size(), expSize);
+
+  std::map<unsigned, unsigned> countsMap;
+  for (const auto& [key, val] : map) {
+    countsMap[val]++;
+  }
+
+  EXPECT_EQ(countsMap.size(), expMap.size());
+
+  // Declared separately: countsMap is non-const (iterator) while expMap is
+  // const (const_iterator), so a single `auto` cannot deduce both.
+  auto itCountsMap = countsMap.begin();
+  auto itExpArray = expMap.begin();
+  for (; (itCountsMap != countsMap.end()) && (itExpArray != expMap.end());
+       ++itCountsMap, ++itExpArray) {
+    EXPECT_EQ(itCountsMap->first, itExpArray->first * repeatCount);
+    EXPECT_EQ(itCountsMap->second, itExpArray->second);
+  }
+}
+
+static std::pair<std::map<unsigned, unsigned>, size_t> CountsMap(
+    const std::vector<std::string_view>& names) {
+  std::map<std::string_view, unsigned> counts;
+  for (const auto& name : names) {
+    counts[name]++;
+  }
+
+  std::map<unsigned, unsigned> countsMap;
+  for (const auto& [name, count] : counts) {
+    countsMap[count]++;
+  }
+
+  return std::pair{countsMap, counts.size()};
+};
+
+constexpr const std::string_view driverActivity = "xpu_driver";
+
+static unsigned acceptDriverActivities(
+    const std::deque<std::unique_ptr<libkineto::GenericTraceActivity>>&
+        pBufferActivities,
+    std::vector<std::string_view>& expectedActivities,
+    std::vector<std::string_view>& expectedTypes,
+    std::set<std::string>& stringStorage) {
+  unsigned count = 0;
+  for (auto&& pActivity : pBufferActivities) {
+    if (pActivity->type() == KN::ActivityType::XPU_DRIVER) {
+      auto insertResult = stringStorage.insert(pActivity->name());
+      expectedActivities.push_back(*insertResult.first);
+      expectedTypes.push_back(driverActivity);
+      ++count;
+    }
+  }
+  return count;
+}
+
+constexpr const std::string_view overheadActivity = "overhead";
+
+static unsigned acceptOverheadActivities(
+    const std::deque<std::unique_ptr<libkineto::GenericTraceActivity>>&
+        pBufferActivities,
+    std::vector<std::string_view>& expectedActivities,
+    std::vector<std::string_view>& expectedTypes,
+    std::set<std::string>& stringStorage) {
+  unsigned count = 0;
+  for (auto&& pActivity : pBufferActivities) {
+    if (pActivity->type() == KN::ActivityType::OVERHEAD) {
+      auto insertResult = stringStorage.insert(pActivity->name());
+      expectedActivities.push_back(*insertResult.first);
+      expectedTypes.push_back(overheadActivity);
+      ++count;
+    }
+  }
+  return count;
+}
+
+class TestActivityLogger : public KN::ActivityLogger {
+  void handleDeviceInfo(
+      [[maybe_unused]] const KN::DeviceInfo& info,
+      [[maybe_unused]] int64_t time) override {}
+  void handleResourceInfo(
+      [[maybe_unused]] const KN::ResourceInfo& info,
+      [[maybe_unused]] int64_t time) override {}
+  void handleOverheadInfo(
+      [[maybe_unused]] const KN::ActivityLogger::OverheadInfo& info,
+      [[maybe_unused]] int64_t time) override {}
+  void handleTraceSpan([[maybe_unused]] const KN::TraceSpan& span) override {}
+  void handleActivity(
+      [[maybe_unused]] const KN::ITraceActivity& activity) override {}
+  void handleGenericActivity(
+      [[maybe_unused]] const KN::GenericTraceActivity& activity) override {}
+  void handleTraceStart(
+      [[maybe_unused]] const std::unordered_map<std::string, std::string>&
+          metadata,
+      [[maybe_unused]] const std::string& device_properties) override {}
+  void finalizeMemoryTrace(
+      [[maybe_unused]] const std::string&,
+      [[maybe_unused]] const KN::Config&) override {}
+  void finalizeTrace(
+      [[maybe_unused]] const KN::Config& config,
+      [[maybe_unused]] std::unique_ptr<KN::ActivityBuffers> buffers,
+      [[maybe_unused]] int64_t endTime) override {}
+};
+
+std::pair<
+    std::unique_ptr<KN::IActivityProfilerSession>,
+    std::unique_ptr<KN::CpuTraceBuffer>>
+RunProfilerTest(
+    const std::vector<std::string_view>& metrics,
+    const std::set<KN::ActivityType>& activities,
+    const KN::Config& cfg,
+    unsigned repeatCount,
+    std::vector<std::string_view>&& expectedActivities,
+    std::vector<std::string_view>&& expectedTypes,
+    int64_t userCorrelationId,
+    const KN::ITraceActivity* linkedCpuActivity,
+    std::function<const KN::ITraceActivity*(int32_t)> linkedActivityCallback) {
+  KN::XPUActivityProfiler profiler;
+  EXPECT_TRUE(profiler.name() == "__xpu_profiler__");
+
+  auto pSession = profiler.configure(activities, cfg);
+
+  int64_t startTime = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          std::chrono::system_clock::now().time_since_epoch())
+                          .count();
+  pSession->start();
+
+  if (userCorrelationId != 0) {
+    pSession->pushUserCorrelationId(static_cast<uint64_t>(userCorrelationId));
+  }
+
+  // A 16x16 GEMM is enough to exercise every activity type while keeping the
+  // simulator-based CI runtime small.
+  ComputeOnXpu(16, repeatCount);
+
+  if (userCorrelationId != 0) {
+    pSession->popUserCorrelationId();
+  }
+
+  pSession->stop();
+  int64_t endTime = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        std::chrono::system_clock::now().time_since_epoch())
+                        .count();
+
+  auto getLinkedActivity = std::move(linkedActivityCallback);
+  if (!getLinkedActivity) {
+    getLinkedActivity = [userCorrelationId, linkedCpuActivity](
+                            int32_t corr) -> const KN::ITraceActivity* {
+      if (userCorrelationId != 0 && corr == userCorrelationId) {
+        return linkedCpuActivity;
+      }
+      return nullptr;
+    };
+  }
+
+  TestActivityLogger logger;
+  pSession->processTrace(logger, getLinkedActivity, startTime, endTime);
+
+  EXPECT_TRUE(pSession->errors().empty())
+      << fmt::format("{}", fmt::join(pSession->errors(), ","));
+
+  auto pBuffer = pSession->getTraceBuffer();
+
+  std::set<std::string> stringStorage;
+  if (activities.find(KN::ActivityType::XPU_DRIVER) != activities.end()) {
+    EXPECT_EQ(repeatCount, 1);
+    auto count = acceptDriverActivities(
+        pBuffer->activities, expectedActivities, expectedTypes, stringStorage);
+    EXPECT_GT(count, 0);
+  }
+  if (activities.find(KN::ActivityType::OVERHEAD) != activities.end()) {
+    auto count = acceptOverheadActivities(
+        pBuffer->activities, expectedActivities, expectedTypes, stringStorage);
+    EXPECT_GT(count, 0);
+  }
+
+  static bool isVerbose = IsEnvVerbose();
+
+  if (isVerbose) {
+    std::cout << "span = " << pBuffer->span << std::endl;
+    std::cout << "gpuOpCount = " << pBuffer->gpuOpCount << std::endl;
+    std::cout << "activities.size = " << pBuffer->activities.size()
+              << std::endl;
+  }
+
+  auto [expectedActivitiesCountsMap, numUniqueActivities] =
+      CountsMap(expectedActivities);
+
+  const unsigned numMetrics = std::count_if(
+      expectedActivities.begin(),
+      expectedActivities.end(),
+      [](std::string_view name) { return name.find("metrics") == 0; });
+
+  auto [expectedTypesCountsMap, numUniqueTypes] = CountsMap(expectedTypes);
+
+  const unsigned numActivities = expectedActivities.size();
+  EXPECT_EQ(numActivities, expectedTypes.size());
+
+  EXPECT_EQ(pBuffer->activities.size(), numActivities * repeatCount);
+
+  std::map<std::string_view, unsigned> activitiesCount;
+  std::map<KN::ActivityType, unsigned> typesCount;
+  unsigned scopeProfilerActCount = 0;
+
+  for (auto&& pActivity : pBuffer->activities) {
+    auto insertResult = stringStorage.insert(pActivity->name());
+    activitiesCount[*insertResult.first]++;
+    typesCount[pActivity->type()]++;
+
+    bool isNameXpu = pActivity->name() == "xpu";
+    bool nameStartsWithMetrics = pActivity->name().find("metrics:") == 0;
+
+    unsigned metricsCount = 0;
+    unsigned metricsMask = 0;
+    if (isNameXpu) {
+      std::tie(metricsCount, metricsMask) =
+          CountMetricsInVector(metrics, pActivity->counterValues());
+    } else if (nameStartsWithMetrics) {
+      std::tie(metricsCount, metricsMask) =
+          CountMetricsInString(metrics, pActivity->metadataJson());
+    }
+
+    enum class TestScenario {
+      defaultScenario,
+      scopeProfiler,
+      nameStartsWithMetrics
+    };
+    TestScenario testScenario = TestScenario::defaultScenario;
+
+    switch (pActivity->type()) {
+      case KN::ActivityType::CONCURRENT_KERNEL:
+        if (nameStartsWithMetrics) {
+          testScenario = TestScenario::nameStartsWithMetrics;
+        } else {
+          testScenario = TestScenario::defaultScenario;
+        }
+        break;
+
+      case KN::ActivityType::XPU_SCOPE_PROFILER:
+        testScenario = TestScenario::scopeProfiler;
+        break;
+
+      default:
+        testScenario = TestScenario::defaultScenario;
+    }
+
+    switch (testScenario) {
+      case TestScenario::scopeProfiler:
+        EXPECT_TRUE(isNameXpu);
+        [[fallthrough]];
+      case TestScenario::nameStartsWithMetrics:
+        EXPECT_EQ(metricsCount, metrics.size());
+        EXPECT_EQ(metricsMask, (1u << metrics.size()) - 1);
+        ++scopeProfilerActCount;
+        break;
+
+      case TestScenario::defaultScenario:
+        EXPECT_FALSE(isNameXpu);
+        EXPECT_EQ(metricsCount, 0);
+        EXPECT_EQ(metricsMask, 0);
+    }
+
+    if (isVerbose) {
+#define PRINT(A) std::cout << #A " = " << pActivity->A() << std::endl;
+      PRINT(deviceId)
+      PRINT(resourceId)
+      PRINT(getThreadId)
+      PRINT(timestamp)
+      PRINT(duration)
+      PRINT(correlationId)
+      PRINT(linkedActivity)
+      PRINT(flowType)
+      PRINT(flowId)
+      PRINT(flowStart)
+      PRINT(name)
+      PRINT(type)
+      PRINT(metadataJson)
+#undef PRINT
+
+      if (auto pSpan = pActivity->traceSpan()) {
+        std::cout << "traceSpan = " << *pSpan << std::endl;
+      }
+
+      std::cout << "-----" << std::endl;
+    }
+  }
+
+  EXPECT_EQ(scopeProfilerActCount, numMetrics * repeatCount);
+
+  CheckCountsInMap(
+      activitiesCount,
+      numUniqueActivities,
+      repeatCount,
+      expectedActivitiesCountsMap);
+
+  CheckCountsInMap(
+      typesCount, numUniqueTypes, repeatCount, expectedTypesCountsMap);
+
+  return {std::move(pSession), std::move(pBuffer)};
+}

--- a/third_party/kineto/libkineto/test/xpupti/XpuptiTestUtilities.h
+++ b/third_party/kineto/libkineto/test/xpupti/XpuptiTestUtilities.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "include/output_base.h"
+
+#include <functional>
+
+namespace KN = KINETO_NAMESPACE;
+
+bool IsEnvVerbose();
+
+std::pair<
+    std::unique_ptr<KN::IActivityProfilerSession>,
+    std::unique_ptr<KN::CpuTraceBuffer>>
+RunProfilerTest(
+    const std::vector<std::string_view>& metrics,
+    const std::set<KN::ActivityType>& activities,
+    const KN::Config& cfg,
+    unsigned repeatCount,
+    std::vector<std::string_view>&& expectedActivities,
+    std::vector<std::string_view>&& expectedTypes,
+    int64_t userCorrelationId = 0,
+    const KN::ITraceActivity* linkedCpuActivity = nullptr,
+    std::function<const KN::ITraceActivity*(int32_t)> linkedActivityCallback =
+        nullptr);

--- a/third_party/kineto/libkineto/test/xpupti/compute/CMakeLists.txt
+++ b/third_party/kineto/libkineto/test/xpupti/compute/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+project(xpupti_compute LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-fsycl" has_sycl)
+if(NOT has_sycl)
+  message(FATAL_ERROR "xpupti_compute requires a SYCL-capable compiler (icpx -fsycl)")
+endif()
+
+# Kernel-only shared library. The SYCL compiler finalizes the device image
+# inside the library, so the host-compiled (GCC/MSVC) test executables can link
+# it without seeing any SYCL. ComputeOnXpu is exported via the API macro in the
+# header (dllexport on Windows / default visibility on ELF) - no need for
+# WINDOWS_EXPORT_ALL_SYMBOLS or an exe<->dll symbol cycle.
+add_library(xpupti_compute SHARED XpuptiScopeProfilerCompute.cpp)
+target_compile_options(xpupti_compute PRIVATE -fsycl)
+target_link_options(xpupti_compute PRIVATE -fsycl)
+
+# RPATH is a POSIX ELF concept; on Windows the loader finds the DLL via the
+# executable directory (where it is installed next to the tests), so guard it.
+if(NOT WIN32)
+  set_target_properties(xpupti_compute PROPERTIES INSTALL_RPATH "$ORIGIN")
+endif()
+
+# A SHARED library yields a runtime .dll (RUNTIME) + import .lib (ARCHIVE) on
+# Windows, and the .so (LIBRARY) on ELF. Install all three so the consumer can
+# link and load on either platform.
+install(TARGETS xpupti_compute
+  RUNTIME DESTINATION .
+  LIBRARY DESTINATION .
+  ARCHIVE DESTINATION .)

--- a/third_party/kineto/libkineto/test/xpupti/compute/XpuptiScopeProfilerCompute.cpp
+++ b/third_party/kineto/libkineto/test/xpupti/compute/XpuptiScopeProfilerCompute.cpp
@@ -1,0 +1,91 @@
+//==============================================================
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+
+// This file is copied from Intel repository:
+// https://github.com/intel/pti-gpu/blob/master/sdk/samples/metrics_scope/main_metrics_scope.cc
+// and edited:
+// - removed unnecessary code
+// - changed formatting
+
+// Mark that we are building the library so the header exports (not imports)
+// ComputeOnXpu on Windows.
+#define XPUPTI_COMPUTE_BUILDING
+#include "XpuptiScopeProfilerCompute.h"
+
+#include <sycl/sycl.hpp>
+#include <cmath>
+
+constexpr float A_VALUE = 0.128f;
+constexpr float B_VALUE = 0.256f;
+
+void GEMM(
+    const float* a,
+    const float* b,
+    float* c,
+    unsigned size,
+    sycl::id<2> id) {
+  int i = id.get(0);
+  int j = id.get(1);
+  float sum = 0.0f;
+  for (unsigned k = 0; k < size; ++k) {
+    sum += a[i * size + k] * b[k * size + j];
+  }
+  c[i * size + j] = sum;
+}
+
+static void Run(
+    sycl::queue queue,
+    const std::vector<float>& a,
+    const std::vector<float>& b,
+    std::vector<float>& c,
+    unsigned size) {
+  sycl::buffer<float, 1> a_buf(a.data(), a.size());
+  sycl::buffer<float, 1> b_buf(b.data(), b.size());
+  sycl::buffer<float, 1> c_buf(c.data(), c.size());
+
+  [[maybe_unused]] sycl::event event = queue.submit([&](sycl::handler& cgh) {
+    auto a_acc = a_buf.get_access<sycl::access::mode::read>(cgh);
+    auto b_acc = b_buf.get_access<sycl::access::mode::read>(cgh);
+    auto c_acc = c_buf.get_access<sycl::access::mode::write>(cgh);
+
+    cgh.parallel_for<class __GEMM>(
+        sycl::range<2>(size, size), [=](sycl::id<2> id) {
+          auto a_acc_ptr = a_acc.get_multi_ptr<sycl::access::decorated::no>();
+          auto b_acc_ptr = b_acc.get_multi_ptr<sycl::access::decorated::no>();
+          auto c_acc_ptr = c_acc.get_multi_ptr<sycl::access::decorated::no>();
+          GEMM(a_acc_ptr.get(), b_acc_ptr.get(), c_acc_ptr.get(), size, id);
+        });
+  });
+  queue.wait_and_throw();
+}
+
+XPUPTI_COMPUTE_API void ComputeOnXpu(unsigned size, unsigned repeatCount) {
+  unsigned sizeSq = size * size;
+  sycl::device dev = sycl::device(sycl::gpu_selector_v);
+  sycl::property_list propList{sycl::property::queue::in_order()};
+  sycl::queue queue(
+      dev, sycl::async_handler{}, propList); // Main runandcheck kernel
+
+  std::cout << "DPC++ Matrix Multiplication (matrix size: " << size << " x "
+            << size << ", repeats " << repeatCount << " times)" << std::endl;
+  std::cout << "Target device: "
+            << queue.get_info<sycl::info::queue::device>()
+                   .get_info<sycl::info::device::name>()
+            << std::endl;
+
+  std::vector<float> a(sizeSq, A_VALUE);
+  std::vector<float> b(sizeSq, B_VALUE);
+  std::vector<float> c(sizeSq, 0.0f);
+
+  auto start = std::chrono::steady_clock::now();
+
+  for (unsigned i = 0; i < repeatCount; ++i) {
+    Run(queue, a, b, c, size);
+  }
+  auto end = std::chrono::steady_clock::now();
+  std::chrono::duration<float> time = end - start;
+  std::cout << "Total execution time: " << time.count() << " sec" << std::endl;
+}

--- a/third_party/kineto/libkineto/test/xpupti/compute/XpuptiScopeProfilerCompute.h
+++ b/third_party/kineto/libkineto/test/xpupti/compute/XpuptiScopeProfilerCompute.h
@@ -1,0 +1,28 @@
+//==============================================================
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+
+#pragma once
+
+// Runs a small GEMM workload on the XPU. Implemented with SYCL device code in
+// XpuptiScopeProfilerCompute.cpp, which must be compiled by a SYCL compiler
+// (icpx -fsycl) and linked as the kernel-only shared library xpupti_compute.
+// The signature is a pure host ABI (POD args, no STL on the boundary) so the
+// GCC/MSVC-compiled test code can call it across the shared-library boundary.
+//
+// The symbol must be exported from the shared library: on Windows nothing is
+// exported by default (dllexport when building the library, dllimport when the
+// tests consume it); on ELF the default visibility already exports it.
+#if defined(_WIN32)
+#if defined(XPUPTI_COMPUTE_BUILDING)
+#define XPUPTI_COMPUTE_API __declspec(dllexport)
+#else
+#define XPUPTI_COMPUTE_API __declspec(dllimport)
+#endif
+#else
+#define XPUPTI_COMPUTE_API
+#endif
+
+XPUPTI_COMPUTE_API void ComputeOnXpu(unsigned size, unsigned repeatCount);

--- a/third_party/kineto/libkineto/third_party/dynolog_headers/LICENSE
+++ b/third_party/kineto/libkineto/third_party/dynolog_headers/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/kineto/libkineto/third_party/dynolog_headers/dynolog/src/ipcfabric/Endpoint.h
+++ b/third_party/kineto/libkineto/third_party/dynolog_headers/dynolog/src/ipcfabric/Endpoint.h
@@ -1,0 +1,272 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <asm/unistd.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <stdexcept>
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadCall-strerror
+
+/*
+ * Design: We are using the following components:
+ * 1) Use UNIX sockets and sendmsg/rcvmsg to pass ancillary control message and
+ * payloads. see https://sarata.com/manpages/CMSG_ALIGN.3.html 2) Use abstract
+ * sockets (https://man7.org/linux/man-pages/man7/unix.7.html) to avoid choosing
+ * a path. Note that abstract sockets are indicated by pathname[0]='\0' and the
+ * actual name in the remaining characters up to struct size + null terminator.
+ * 3) Use connectionless datagram sockets
+ *    (SOCK_DGRM https://man7.org/linux/man-pages/man2/socket.2.html) - in Linux
+ *    they are guaranteed to be always reliable and don't reorder - to avoid
+ * having to mantain multiple connections. 4) Use a stateless protocol
+ * connecting based on destination socket name passed in, using scatter/gather
+ * vectors for data communication, with user input vector sizes. 5) Non-blocking
+ * send/receive. 6) Keep serialization/deserialization simple by only supporting
+ * class that are trivially copyable (i.e. std::is_trivially_copyable), like
+ * Plain Old Data (POD) classes.
+ *    (https://en.cppreference.com/w/cpp/types/is_trivially_copyable)
+ *
+ *  You can list local domain sockets using-
+ *    netstat -a -p --unix on Linux
+ */
+
+namespace dynolog {
+namespace ipcfabric {
+
+[[noreturn]] inline void terminate_with_message(const std::string& message) {
+  std::fputs(message.c_str(), stderr);
+  std::terminate();
+}
+
+// Define a type for fds to improve readibility.
+using fd_t = int;
+
+struct Payload {
+  Payload(size_t size, void* data) : size(size), data(data) {}
+  size_t size;
+  void* data;
+};
+
+template <size_t kMaxNumFds = 0>
+struct EndPointCtxt {
+  explicit EndPointCtxt(size_t n) : iov{std::vector<struct iovec>(n)} {}
+  struct sockaddr_un msg_name;
+  size_t msg_namelen;
+  struct msghdr msghdr;
+  std::vector<struct iovec> iov;
+  fd_t* ctrl_fd_ptr;
+
+  // Ancillary data buffer sized to contain kMaxNumFds in data section.
+  char ancillary_buf[CMSG_SPACE(kMaxNumFds * sizeof(fd_t))];
+};
+
+template <size_t kMaxNumFds = 0>
+class EndPoint final {
+  using TCtxt = EndPointCtxt<kMaxNumFds>;
+
+ public:
+  // Maximum defined in man unix, but minus 2 because abstract sockets, first
+  // and last are '\0'.
+  constexpr static size_t kMaxNameLen = 108 - 2;
+
+  explicit EndPoint(const std::string& address) {
+    socket_fd_ = socket(AF_UNIX, SOCK_DGRAM, 0);
+    if (socket_fd_ == -1) {
+      throw std::runtime_error(std::strerror(errno));
+    }
+    struct sockaddr_un addr;
+    size_t addrlen = setAddress_(address, addr);
+    if (addr.sun_path[0] != '\0') {
+      // delete domain socket file just in case before binding
+      unlink(addr.sun_path);
+    }
+
+    int ret = bind(socket_fd_, (const struct sockaddr*)&addr, addrlen);
+    if (ret == -1) {
+      throw std::runtime_error(std::strerror(errno));
+    }
+    if (addr.sun_path[0] != '\0') {
+      // set correct permissions for the socket. We avoid using umask because
+      // of multithreaded nature. A short window exists between bind and chmod
+      // where the permissions are wrong but it's ok for our use case.
+      chmod(addr.sun_path, 0666);
+    }
+  }
+
+  ~EndPoint() {
+    close(socket_fd_);
+  }
+
+  [[nodiscard]] auto buildSendCtxt(
+      const std::string& dest_name,
+      const std::vector<Payload>& payload,
+      const std::vector<fd_t>& fds) {
+    if (fds.size() > kMaxNumFds) {
+      throw std::invalid_argument("Requested to fill more than kMaxNumFds");
+    }
+    if (dest_name.size() == 0) {
+      throw std::invalid_argument("Cannot send to empty socket name");
+    }
+
+    auto ctxt = buildCtxt_(payload, fds.size());
+    ctxt->msghdr.msg_namelen = setAddress_(dest_name, ctxt->msg_name);
+    if (fds.size()) {
+      memcpy(ctxt->ctrl_fd_ptr, fds.data(), fds.size() * sizeof(int));
+    }
+    return ctxt;
+  }
+
+  // non-blocking. The error ECONNREFUSED may be caused by socket not being yet
+  // initialized. See man unix.
+  [[nodiscard]] bool trySendMsg(
+      TCtxt const& ctxt,
+      bool retryOnConnRefused = true) {
+    ssize_t ret = sendmsg(socket_fd_, &ctxt.msghdr, MSG_DONTWAIT);
+    if (ret > 0) { // XXX: Enforce correct number of bytes sent.
+      return true;
+    }
+    if (ret == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+      return false;
+    }
+    if (ret == -1 && retryOnConnRefused && errno == ECONNREFUSED) {
+      return false;
+    }
+    throw std::runtime_error(std::strerror(errno));
+  }
+
+  [[nodiscard]] auto buildRcvCtxt(const std::vector<Payload>& payload) {
+    return buildCtxt_(payload, kMaxNumFds);
+  }
+
+  // If false, must retry. Only enabled for bound sockets.
+  [[nodiscard]] bool tryRcvMsg(TCtxt& ctxt) noexcept {
+    ssize_t ret = recvmsg(socket_fd_, &ctxt.msghdr, MSG_DONTWAIT);
+
+    if (ret > 0) { // XXX: Enforce correct number of bytes sent.
+      return true;
+    }
+    if (ret == 0) {
+      return false; // Receiver is down.
+    }
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return false;
+    }
+
+    terminate_with_message(
+        "tryRcvMsg() got " + std::string(std::strerror(errno)));
+  }
+
+  [[nodiscard]] bool tryPeekMsg(TCtxt& ctxt) noexcept {
+    ssize_t ret = recvmsg(socket_fd_, &ctxt.msghdr, MSG_DONTWAIT | MSG_PEEK);
+    if (ret > 0) { // XXX: Enforce correct number of bytes sent.
+      return true;
+    }
+    if (ret == 0) {
+      return false; // Receiver is down.
+    }
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return false;
+    }
+    terminate_with_message(
+        "tryPeekMsg() got " + std::string(std::strerror(errno)));
+  }
+
+  const char* getName(TCtxt const& ctxt) const noexcept {
+    const char* socket_dir = getenv("KINETO_IPC_SOCKET_DIR");
+    bool is_domain_socket = socket_dir && socket_dir[0];
+    if (is_domain_socket) {
+      int socket_dirname_len = strlen(socket_dir);
+      if (strncmp(socket_dir, ctxt.msg_name.sun_path, socket_dirname_len) !=
+              0 ||
+          ctxt.msg_name.sun_path[socket_dirname_len] != '/') {
+        terminate_with_message(
+            "Unexpected socket name: " + std::string(ctxt.msg_name.sun_path) +
+            ". Expected to start with " + std::string(socket_dir));
+      }
+      return ctxt.msg_name.sun_path + socket_dirname_len + 1;
+    } else {
+      if (ctxt.msg_name.sun_path[0] != '\0') {
+        terminate_with_message(
+            "Expected abstract socket, got " +
+            std::string(ctxt.msg_name.sun_path));
+      }
+      return ctxt.msg_name.sun_path + 1;
+    }
+  }
+
+  std::vector<fd_t> getFds(const TCtxt& ctxt) const {
+    struct cmsghdr* cmsg = CMSG_FIRSTHDR(&ctxt.msghdr);
+    unsigned num_fds = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(fd_t);
+    return {ctxt.ctrl_fd_ptr, ctxt.ctrl_fd_ptr + num_fds};
+  }
+
+ protected:
+  fd_t socket_fd_;
+
+  // Initialize <dest> with address provided in <src>.
+  size_t setAddress_(const std::string& src, struct sockaddr_un& dest) {
+    if (src.size() >
+        kMaxNameLen) { // First and last bytes are used for '/0' characters.
+      throw std::invalid_argument(
+          "Abstract UNIX Socket path cannot be larger than kMaxNameLen - 2");
+    }
+    dest.sun_family = AF_UNIX;
+    const char* socket_dir = getenv("KINETO_IPC_SOCKET_DIR");
+    bool is_domain_socket = socket_dir && socket_dir[0];
+    if (is_domain_socket) {
+      std::string full_path = std::string(socket_dir) + "/" + src;
+      full_path.copy(dest.sun_path, full_path.size());
+      dest.sun_path[full_path.size()] = '\0';
+      return sizeof(sa_family_t) + full_path.size() + 1;
+    } else {
+      dest.sun_path[0] = '\0';
+      if (src.size() == 0) {
+        return sizeof(sa_family_t); // autobind socket.
+      }
+      src.copy(dest.sun_path + 1, src.size());
+      dest.sun_path[src.size() + 1] = '\0';
+      return sizeof(sa_family_t) + src.size() + 2;
+    }
+  }
+
+  auto buildCtxt_(const std::vector<Payload>& payload, unsigned num_fds) {
+    auto ctxt = std::make_unique<TCtxt>(payload.size());
+    memset(&ctxt->msghdr, 0, sizeof(decltype(ctxt->msghdr)));
+    for (int i = 0; i < payload.size(); i++) {
+      ctxt->iov[i] = {payload[i].data, payload[i].size};
+    }
+    ctxt->msghdr.msg_name = &ctxt->msg_name;
+    ctxt->msghdr.msg_namelen = sizeof(decltype(ctxt->msg_name));
+    ctxt->msghdr.msg_iov = ctxt->iov.data();
+    ctxt->msghdr.msg_iovlen = payload.size();
+    ctxt->ctrl_fd_ptr = nullptr;
+
+    if (num_fds == 0) {
+      return ctxt;
+    }
+
+    const size_t fds_size = sizeof(fd_t) * num_fds;
+    ctxt->msghdr.msg_control = ctxt->ancillary_buf;
+    ctxt->msghdr.msg_controllen = CMSG_SPACE(fds_size);
+
+    struct cmsghdr* cmsg = CMSG_FIRSTHDR(&ctxt->msghdr);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    cmsg->cmsg_len = CMSG_LEN(fds_size);
+    ctxt->ctrl_fd_ptr = (fd_t*)CMSG_DATA(cmsg);
+    return ctxt;
+  }
+};
+
+} // namespace ipcfabric
+} // namespace dynolog

--- a/third_party/kineto/libkineto/third_party/dynolog_headers/dynolog/src/ipcfabric/FabricManager.h
+++ b/third_party/kineto/libkineto/third_party/dynolog_headers/dynolog/src/ipcfabric/FabricManager.h
@@ -1,0 +1,224 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <exception>
+#include <mutex>
+#include "dynolog/src/ipcfabric/Endpoint.h"
+#include "dynolog/src/ipcfabric/Utils.h"
+
+// If building inside Kineto, use its logger, otherwise use glog
+#if defined(KINETO_NAMESPACE) && defined(ENABLE_IPC_FABRIC)
+// We need to include the Logger header here for LOG() macros.
+// However this can alias with other files that include this and
+// also use glog. TODO(T131440833). Thus, the user should also set
+#include "Logger.h" // @manual
+// set error to use kineto version
+#define ERROR libkineto::ERROR
+
+#else // KINETO_NAMESPACE && ENABLE_IPC_FABRIC
+#include <glog/logging.h>
+#endif // KINETO_NAMESPACE && ENABLE_IPC_FABRIC
+
+namespace dynolog::ipcfabric {
+
+constexpr int TYPE_SIZE = 32;
+
+struct Metadata {
+  size_t size = 0;
+  char type[TYPE_SIZE] = "";
+};
+
+struct Message {
+  template <class T>
+  static std::unique_ptr<Message> constructMessage(
+      const T& data,
+      const std::string& type) {
+    std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
+    memcpy(msg->metadata.type, type.c_str(), type.size() + 1);
+    // TODO CXX 17 - https://github.com/pytorch/kineto/issues/650
+    // if constexpr (std::is_same_v<std::string, T>) {
+    // Without constexpr following is not possible
+#if __cplusplus >= 201703L
+    if constexpr (std::is_same<std::string, T>::value == true) {
+      msg->metadata.size = data.size();
+      msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
+      memcpy(msg->buf.get(), data.c_str(), msg->metadata.size);
+    } else {
+#endif
+      // ensure memcpy works on T
+      // TODO CXX 17 - https://github.com/pytorch/kineto/issues/650
+      // static_assert(std::is_trivially_copyable_v<T>);
+      static_assert(std::is_trivially_copyable<T>::value);
+      msg->metadata.size = sizeof(data);
+      msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
+      memcpy(msg->buf.get(), &data, msg->metadata.size);
+#if __cplusplus >= 201703L
+    }
+#endif
+    return msg;
+  }
+
+  // Construct message where T is a trivially copyable struct with
+  // a flexible array at the end. The items in the flexible array are
+  // of (trivially copyable) type U and there are n of them.
+  template <class T, class U>
+  static std::unique_ptr<Message>
+  constructMessage(const T& data, const std::string& type, int n) {
+    std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
+    memcpy(msg->metadata.type, type.c_str(), type.size() + 1);
+    // ensure memcpy works on T and U
+    // TODO CXX 17 - https://github.com/pytorch/kineto/issues/650
+    // static_assert(std::is_trivially_copyable_v<T>);
+    // static_assert(std::is_trivially_copyable_v<U>);
+    static_assert(std::is_trivially_copyable<T>::value);
+    static_assert(std::is_trivially_copyable<U>::value);
+    msg->metadata.size = sizeof(data) + sizeof(U) * n;
+    msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
+    memcpy(msg->buf.get(), &data, msg->metadata.size);
+    return msg;
+  }
+
+  Metadata metadata;
+  std::unique_ptr<unsigned char[]> buf;
+  // endpoint name of the sender
+  std::string src;
+};
+
+class FabricManager {
+ public:
+  FabricManager(const FabricManager&) = delete;
+  FabricManager& operator=(const FabricManager&) = delete;
+
+  static std::unique_ptr<FabricManager> factory(
+      std::string endpoint_name = "") {
+    try {
+      return std::unique_ptr<FabricManager>(new FabricManager(endpoint_name));
+    } catch (std::exception& e) {
+      LOG(ERROR) << "Error when initializing FabricManager: " << e.what();
+    }
+    return nullptr;
+  }
+
+  // warning: this will block for user passed in time with exponential increase
+  // if send keeps failing
+  bool sync_send(
+      const Message& msg,
+      const std::string& dest_name,
+      int num_retries = 10,
+      int sleep_time_us = 10000) {
+    if (dest_name.size() == 0) {
+      LOG(ERROR) << "Cannot send to empty socket name";
+      return false;
+    }
+
+    std::vector<Payload> payload{
+        Payload(sizeof(struct Metadata), (void*)&msg.metadata),
+        Payload(msg.metadata.size, msg.buf.get())};
+    int i = 0;
+    try {
+      auto ctxt = ep_.buildSendCtxt(dest_name, payload, std::vector<int>());
+      while (!ep_.trySendMsg(*ctxt) && i < num_retries) {
+        i++;
+        /* sleep override */
+        usleep(sleep_time_us);
+        sleep_time_us *= 2;
+      }
+    } catch (std::exception& e) {
+      LOG(ERROR) << "Error when sync_send(): " << e.what();
+      return false;
+    }
+    return i < num_retries;
+  }
+
+  bool recv() {
+    try {
+      Metadata receive_metadata;
+      std::vector<Payload> peek_payload{
+          Payload(sizeof(struct Metadata), &receive_metadata)};
+      auto peek_ctxt = ep_.buildRcvCtxt(peek_payload);
+      // unix socket only fills the data for the iov that have a non NULL
+      // buffer. Leverage that to read metadata to find buffer size by:
+      //   1) FabricManager assumes metadata in first iov, data in second
+      //   2) peek with only metadata buffer in iov
+      //   3) read metadata
+      //   4) use metadata to find the desired size for the buffer to allocate.
+      //   5) read metadata + data with allocated buffer
+      bool success;
+      try {
+        success = ep_.tryPeekMsg(*peek_ctxt);
+      } catch (std::exception& e) {
+        LOG(ERROR) << "Error when tryPeekMsg(): " << e.what();
+        return false;
+      }
+      if (success) {
+        std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
+        msg->metadata = receive_metadata;
+        // new unsigned char[N] guarantees the maximum alignment to hold any
+        // object thus we don't need to worry about memory alignment here see
+        // https://stackoverflow.com/questions/10587879/does-new-char-actually-guarantee-aligned-memory-for-a-class-type
+        // and
+        // https://stackoverflow.com/questions/39668561/allocate-n-bytes-by-new-and-fill-it-with-any-type
+        msg->buf = std::unique_ptr<unsigned char[]>(
+            new unsigned char[receive_metadata.size]);
+        msg->src = std::string(ep_.getName(*peek_ctxt));
+        std::vector<Payload> payload{
+            Payload(sizeof(struct Metadata), (void*)&msg->metadata),
+            Payload(receive_metadata.size, msg->buf.get())};
+        auto recv_ctxt = ep_.buildRcvCtxt(payload);
+
+        // the deque can potentially grow very large
+        try {
+          success = ep_.tryRcvMsg(*recv_ctxt);
+        } catch (std::exception& e) {
+          LOG(ERROR) << "Error when tryRcvMsg(): " << e.what();
+          return false;
+        }
+        if (success) {
+          std::lock_guard<std::mutex> wguard(dequeLock_);
+          message_deque_.push_back(std::move(msg));
+          return true;
+        }
+      }
+    } catch (std::exception& e) {
+      LOG(ERROR) << "Error in recv(): " << e.what();
+      return false;
+    }
+    return false;
+  }
+
+  std::unique_ptr<Message> retrieve_msg() {
+    std::lock_guard<std::mutex> wguard(dequeLock_);
+    if (message_deque_.empty()) {
+      return nullptr;
+    }
+    std::unique_ptr<Message> msg = std::move(message_deque_.front());
+    message_deque_.pop_front();
+    return msg;
+  }
+
+  std::unique_ptr<Message> poll_recv(int max_retries, int sleep_time_us) {
+    for (int i = 0; i < max_retries; i++) {
+      if (recv()) {
+        return retrieve_msg();
+      }
+      /* sleep override */
+      usleep(sleep_time_us);
+    }
+    return nullptr;
+  }
+
+ private:
+  explicit FabricManager(std::string endpoint_name = "") : ep_{endpoint_name} {}
+  // message LIFO deque with oldest message at front
+  std::deque<std::unique_ptr<Message>> message_deque_;
+  EndPoint<0> ep_;
+  std::mutex dequeLock_;
+};
+
+} // namespace dynolog::ipcfabric

--- a/third_party/kineto/libkineto/third_party/dynolog_headers/dynolog/src/ipcfabric/Utils.h
+++ b/third_party/kineto/libkineto/third_party/dynolog_headers/dynolog/src/ipcfabric/Utils.h
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <sys/types.h>
+#include <cstdint>
+
+namespace dynolog {
+namespace ipcfabric {
+
+// struct to register libkineto process
+struct LibkinetoContext {
+  // gpu id of the process running on
+  int32_t gpu;
+  // pid to register to dynolog
+  pid_t pid;
+  // job id of the process
+  int64_t jobid;
+};
+
+// struct to request libkineto ondemand config
+struct LibkinetoRequest {
+  // type of libkineto config
+  int type;
+  // size of pids
+  int n;
+  // job id of the libkineto process
+  int64_t jobid;
+  // pids of the process and its ancestors
+  int32_t pids[];
+};
+
+constexpr char dynolog_endpoint[] = "dynolog";
+constexpr char kLibkinetoRequest[] = "req";
+constexpr char kLibkinetoContext[] = "ctxt";
+} // namespace ipcfabric
+} // namespace dynolog

--- a/third_party/kineto/libkineto/third_party/dynolog_headers/vendor_dynolog.sh
+++ b/third_party/kineto/libkineto/third_party/dynolog_headers/vendor_dynolog.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Re-vendor the dynolog ipcfabric headers used by libkineto's open-source CMake
+# build. Kineto's CMake build consumes these three header-only files directly.
+#
+# Usage:
+#   vendor_dynolog.sh <commit> [--from <dynolog-checkout>]
+#
+#   <commit>            dynolog commit to vendor (required).
+#   --from <checkout>   Copy headers from an existing dynolog checkout rooted at
+#                       <checkout> instead of cloning from GitHub. Use this where
+#                       GitHub is unreachable. The caller must ensure the
+#                       checkout is at <commit>.
+
+set -euo pipefail
+
+# Destination is the same directory this script lives in.
+dest_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+version_file="${dest_dir}/version.txt"
+repo_url="https://github.com/facebookincubator/dynolog.git"
+rel_headers="dynolog/src/ipcfabric"
+headers=(FabricManager.h Endpoint.h Utils.h)
+
+commit=""
+from_dir=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --from)
+      from_dir="${2:?--from requires a path}"
+      shift 2
+      ;;
+    *)
+      commit="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${commit}" ]]; then
+  echo "error: a dynolog commit hash is required" >&2
+  echo "usage: vendor_dynolog.sh <commit> [--from <dynolog-checkout>]" >&2
+  exit 1
+fi
+
+tmp_dir=""
+cleanup() {
+  if [[ -n "${tmp_dir}" ]]; then
+    rm -rf "${tmp_dir}"
+  fi
+}
+trap cleanup EXIT
+
+if [[ -n "${from_dir}" ]]; then
+  src_dir="${from_dir}"
+else
+  tmp_dir="$(mktemp -d)"
+  git clone --filter=blob:none --no-checkout "${repo_url}" "${tmp_dir}"
+  git -C "${tmp_dir}" checkout "${commit}"
+  src_dir="${tmp_dir}"
+fi
+
+mkdir -p "${dest_dir}/${rel_headers}"
+for h in "${headers[@]}"; do
+  cp "${src_dir}/${rel_headers}/${h}" "${dest_dir}/${rel_headers}/${h}"
+done
+
+# The headers are MIT-licensed; carry dynolog's LICENSE alongside them so the
+# vendored copy satisfies the MIT notice requirement and the headers' reference
+# to the LICENSE in the root of this source tree resolves.
+cp "${src_dir}/LICENSE" "${dest_dir}/LICENSE"
+
+printf '%s\n%s\n' "${repo_url}" "${commit}" >"${version_file}"
+
+echo "Vendored ${headers[*]} + LICENSE from dynolog ${commit}"
+echo "  source: ${src_dir}/${rel_headers}"
+echo "  dest:   ${dest_dir}/${rel_headers}"
+echo "  wrote:  ${version_file}"

--- a/third_party/kineto/libkineto/third_party/dynolog_headers/version.txt
+++ b/third_party/kineto/libkineto/third_party/dynolog_headers/version.txt
@@ -1,0 +1,2 @@
+https://github.com/facebookincubator/dynolog.git
+d2ffe0a4e3acace628db49974246b66fc3e85fb1


### PR DESCRIPTION
This is a test for Step 4 in https://github.com/pytorch/kineto/issues/1478. The purpose is to see if there are any major blockers surfaced by CI. Not intended for merging.

Approach:
- Remove the third_party/kineto submodule (drop it from .gitmodules and de-register it) and commit Kineto's tree at the currently pinned commit 6f446fef254718c3803ffb71eae6762da6cf536e as regular files. The path is unchanged, so build references resolve without edits: add_subdirectory(third_party/kineto/libkineto) in cmake/Dependencies.cmake, the include paths in caffe2/CMakeLists.txt and torch/CMakeLists.txt, the Buck .bzl files, and tools/amd_build.
- Drop Kineto's three nested submodules (libkineto/third_party/{fmt,googletest,json}). The PyTorch build never uses them: it creates the fmt::fmt-header-only target from third_party/fmt before configuring Kineto, so Kineto's own fmt branch is skipped, and it sets KINETO_BUILD_TESTS=OFF, so the googletest/json branches never run. Vendoring them would duplicate deps PyTorch already ships (~27 MB). The vendored dynolog_headers (not a submodule) is kept.
- Exclude third_party/kineto from PyTorch's linters. lintrunner does not descend into submodules, so vendoring newly exposes Kineto's files to it; 13 linters use broad include globs without a third_party exclusion (for example RAWTHROW, which flags Kineto's raw throw statements). Add third_party/kineto/** to those linters' exclude_patterns, mirroring the existing third_party/concurrentqueue/** exclusion. The vendored files are left byte-identical to upstream rather than reformatted to PyTorch's rules.

This PR was authored with the assistance of an AI coding agent (Claude Code); all changes were reviewed by a human before submission.