### PR TITLE
Use ring addmm schedule for matmul reduce-scatter

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1005,6 +1005,34 @@ class AsyncTPTest(MultiProcContinuousTest):
                 f"Expected strides to match: {output_0.stride()} vs {output_1.stride()}"
             )
 
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    @parametrize("reduce_op", ["sum", "avg"])
+    def test_fused_matmul_reduce_scatter_2d_dim0(self, reduce_op: str) -> None:
+        self._init_process()
+
+        M = 64
+        N = 16
+        K = 128
+        group = dist.group.WORLD
+        rank = self.rank
+
+        torch.manual_seed(42 + rank)
+        A = torch.rand(M, K, device="cuda")
+        B = torch.rand(K, N, device="cuda")
+
+        output_0 = _fused_matmul_reduce_scatter_fallback(
+            A, B, reduce_op, scatter_dim=0, group_name=group.group_name
+        )
+        output_1 = torch.ops.symm_mem.fused_matmul_reduce_scatter(
+            A, B, reduce_op, scatter_dim=0, group_name=group.group_name
+        )
+
+        self.assertTrue(torch.allclose(output_0, output_1))
+        self.assertEqual(output_0.stride(), output_1.stride())
+
     @skip_if_rocm_multiprocess  # AsyncTP support changed _fused_scaled_matmul_reduce_scatter_fallback API, need more changes
     @skip_if_lt_x_gpu(2)
     @skipUnless(SM89OrLater, "Requires compute capability >= 8.9")

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -444,6 +444,63 @@ def _pipelined_produce_and_all2all(
     symm_mem.barrier(channel=0)
 
 
+def _ring_addmm_reduce_scatter(
+    mm_out_op: torch._ops.OpOverload,
+    A_shards: tuple[torch.Tensor, ...],
+    B: torch.Tensor,
+    output: torch.Tensor,
+    reduce_op: str,
+    group_name: c10d.GroupName,
+) -> torch.Tensor:
+    """
+    Reduce-scatter GEMM schedule that rotates partial sums around the ring and
+    uses GEMM's C operand for accumulation.
+    """
+    M_shard, N = output.shape
+    dtype = output.dtype
+    num_d_buffers = max(2, len(A_shards) - 1)
+    p2p_workspace_size_req = num_d_buffers * output.numel() * output.element_size()
+    symm_mem = get_symm_mem_workspace(group_name, min_size=p2p_workspace_size_req)
+    group_size = symm_mem.world_size
+    rank = symm_mem.rank
+    left_peer = (rank - 1 + group_size) % group_size
+    right_peer = (rank + 1) % group_size
+    signal_channel = 1
+
+    local_d_full = symm_mem.get_buffer(rank, (num_d_buffers * M_shard, N), dtype)
+    left_d_full = symm_mem.get_buffer(left_peer, (num_d_buffers * M_shard, N), dtype)
+
+    symm_mem.barrier(channel=0)
+
+    for i in range(group_size):
+        tile_idx = (rank - 1 - i + group_size) % group_size
+        a_tile = A_shards[tile_idx]
+        if i < group_size - 1:
+            buf_idx = i % num_d_buffers
+            d_target = local_d_full[buf_idx * M_shard : (buf_idx + 1) * M_shard, :]
+        else:
+            d_target = output
+
+        if i == 0:
+            mm_out_op(a_tile, B, out=d_target)
+        else:
+            symm_mem.wait_signal(src_rank=left_peer, channel=signal_channel)
+            prev_buf_idx = (i - 1) % num_d_buffers
+            c_source = left_d_full[
+                prev_buf_idx * M_shard : (prev_buf_idx + 1) * M_shard, :
+            ]
+            torch.addmm(c_source, a_tile, B, beta=1, out=d_target)
+
+        if i < group_size - 1:
+            symm_mem.put_signal(dst_rank=right_peer, channel=signal_channel)
+
+    if reduce_op == "avg":
+        output.div_(group_size)
+
+    symm_mem.barrier(channel=0)
+    return output
+
+
 lib = torch.library.Library("symm_mem", "DEF")
 lib.define(
     "fused_all_gather_matmul("
@@ -1332,6 +1389,19 @@ def _fused_matmul_reduce_scatter_impl(
     leading_dims[1] //= group.size()
     x = x.flatten(0, -2)
     A_shards = x.chunk(group.size())
+
+    if A.dim() == 2 and scatter_dim == 0 and not kwargs and reduce_op in ("sum", "avg"):
+        output = x.new_empty(
+            A_shards[0].shape[0], B.shape[1], dtype=out_dtype or A.dtype
+        )
+        return _ring_addmm_reduce_scatter(
+            mm_out_op,
+            A_shards,
+            B,
+            output,
+            reduce_op,
+            group_name,
+        )
 
     # Computing block-wise matmul along the first dim of A
     def chunk_producer(rank: int, out: torch.Tensor) -> None:


### PR DESCRIPTION
Stacked on #191706.

Update the 2D `scatter_dim=0` `fused_matmul_reduce_scatter` path to use a ring schedule that accumulates partial sums through `torch.addmm` instead of materializing all partial outputs and reducing them at the end.

The existing implementation computes per-destination GEMM partials, exchanges them with the all-to-all pipeline, then performs the reduction with a final `torch.sum`/`torch.mean` over `stacked_partials`. That final reduction is a separate memory-bandwidth-bound kernel after the communication and GEMM work has already completed, so its memory traffic is exposed on the critical path. We also tried splitting the final reduction into smaller add operations and overlapping them with the existing pipeline, but that still left exposed memory bandwidth from separate reduction reads/writes.

This change rotates each partial output shard around the ring. For the first iteration a rank writes its local partial with `mm.out`; for later iterations it waits for the left peer's partial and passes that remote partial as the C operand to `torch.addmm`, writing the next partial (or the final output). This folds the reduction into GEMM's C operand instead of launching a final `torch.sum` reduction over `stacked_partials`.

The performance-critical form depends on #191706 so `addmm` can pass distinct C and D pointers to cuBLASLt without first copying C into D. Without that addmm change, a remote symmetric-memory C operand can trigger an extra D2D copy before GEMM, which defeats much of the ring schedule benefit.

Scope is intentionally narrow for now: unscaled 2D inputs with `scatter_dim=0` and `reduce_op in {"sum", "avg"}`. Other shapes and scaled matmul continue through the existing implementation.

Test plan:
- `git diff --check`
- `python -m py_compile torch/distributed/_symmetric_memory/__init__.py test/distributed/test_symmetric_memory.py`
- Standalone 2-rank NCCL check comparing `fused_matmul_reduce_scatter` against `_fused_matmul_reduce_scatter_fallback` for 2D `scatter_dim=0`, `sum` and `avg`

Coauthored by Codex