### PR TITLE
[XPU] Add _addmm_activation to lower precision cast policy

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -558,6 +558,9 @@ TORCH_LIBRARY_IMPL(aten, AutocastXPU, m) {
 
   AT_FORALL_LOWER_PRECISION_FP(_KERNEL_XPU_LOW_PRECISION_FP)
 
+  // Fix #191796: Avoid type mismatch in nn.TransformerEncoder.
+  KERNEL_XPU(_addmm_activation, lower_precision_fp)
+
   // fp32
 #define _KERNEL_XPU_FP32(...) KERNEL_XPU(__VA_ARGS__, fp32)
 

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -3507,6 +3507,20 @@ class TestXpuAutocast(TestAutocast):
                 amp_dtype=torch.float16,
             )
 
+    def test_autocast_torch_addmm_activation(self):
+        args = tuple(
+            torch.randn((8, 8), device="xpu", dtype=torch.float32) for _ in range(3)
+        )
+        for amp_dtype in (torch.float16, torch.bfloat16):
+            self._run_autocast_outofplace(
+                "_addmm_activation",
+                args,
+                amp_dtype,
+                device="xpu",
+                add_kwargs={"use_gelu": True},
+                amp_dtype=amp_dtype,
+            )
+
     def test_autocast_checkpointing(self):
         model = torch.nn.Sequential(
             torch.nn.Linear(8, 8), torch.nn.Linear(8, 8), torch.nn.Linear(8, 8)


### PR DESCRIPTION
Fixes #191796.

This fix adds `_addmm_activation` to the `AutocastXPU` lower precision cast policy.

Without this addition, `nn.TransformerEncoder` raises a RuntimeError when the model weights are already in reduced precision because the encoder fast path for `_addmm_activation` uses a fp32 `mat1` and reduced precision `mat2`.

This fix is similar to #135936, which adds `_addmm_activation` to `AutocastCPU` (#132613).

It is kept out of `AT_FORALL_LOWER_PRECISION_FP` because that list is shared with other device types.

Test Plan:
```bash
python test/test_xpu.py TestXpuAutocast.test_autocast_torch_addmm_activation
```

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5