### PR TITLE
[MPS] Reject complex bucketize/searchsorted inputs

### DIFF
--- a/aten/src/ATen/native/mps/operations/Bucketization.mm
+++ b/aten/src/ATen/native/mps/operations/Bucketization.mm
@@ -84,11 +84,7 @@ Tensor& searchsorted_out_mps(const Tensor& sorted_sequence,
   searchsorted_pre_check(sorted_sequence, self, result, out_int32, right, side_opt, sorter);
 
   TORCH_CHECK_NOT_IMPLEMENTED(
-      !c10::isComplexType(self.scalar_type()),
-      "searchsorted is not supported for complex on MPS");
-
-  TORCH_CHECK_NOT_IMPLEMENTED(
-      !c10::isComplexType(sorted_sequence.scalar_type()),
+      !c10::isComplexType(self.scalar_type()) && !c10::isComplexType(sorted_sequence.scalar_type()),
       "searchsorted is not supported for complex on MPS");
 
   resize_output(result, self.sizes());

--- a/aten/src/ATen/native/mps/operations/Bucketization.mm
+++ b/aten/src/ATen/native/mps/operations/Bucketization.mm
@@ -82,6 +82,15 @@ Tensor& searchsorted_out_mps(const Tensor& sorted_sequence,
   auto sorter_maybe_owned = at::borrow_from_optional_tensor(sorter_opt);
   const Tensor& sorter = *sorter_maybe_owned;
   searchsorted_pre_check(sorted_sequence, self, result, out_int32, right, side_opt, sorter);
+
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      !c10::isComplexType(self.scalar_type()),
+      "searchsorted is not supported for complex on MPS");
+
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      !c10::isComplexType(sorted_sequence.scalar_type()),
+      "searchsorted is not supported for complex on MPS");
+
   resize_output(result, self.sizes());
 
   // we have two inputs to set right, pre_check checks that they aren't set to opposites

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -836,31 +836,6 @@ class TestAvgPool(TestCaseMPS):
         with self.assertRaisesRegex(NotImplementedError, "complex"):
             F.local_response_norm(x, size=4)
 
-    def test_bucketize_complex_input_raises(self):
-        # Regression test for gh-191692:
-        # complex input should raise NotImplementedError instead of
-        # an opaque Metal RuntimeError on MPS.
-
-        # Complex values should be rejected.
-        values = torch.randn(2, 2, dtype=torch.complex64, device="mps")
-        boundaries = torch.randn(2, dtype=torch.float32, device="mps")
-
-        with self.assertRaisesRegex(
-            NotImplementedError,
-            "searchsorted is not supported for complex on MPS",
-        ):
-            torch.bucketize(values, boundaries)
-
-        # Complex boundaries should also be rejected.
-        values = torch.randn(2, 2, dtype=torch.float32, device="mps")
-        boundaries = torch.randn(2, dtype=torch.complex64, device="mps")
-
-        with self.assertRaisesRegex(
-            NotImplementedError,
-            "searchsorted is not supported for complex on MPS",
-        ):
-            torch.bucketize(values, boundaries)
-
     def test_channels_last_storage_offset(self):
         # Regression test: channels_last tensors with non-zero storage_offset produced wrong
         # results on MPS because the Placeholder path for NHWC ops ignored storage_offset.

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -836,6 +836,31 @@ class TestAvgPool(TestCaseMPS):
         with self.assertRaisesRegex(NotImplementedError, "complex"):
             F.local_response_norm(x, size=4)
 
+    def test_bucketize_complex_input_raises(self):
+        # Regression test for gh-191692:
+        # complex input should raise NotImplementedError instead of
+        # an opaque Metal RuntimeError on MPS.
+
+        # Complex values should be rejected.
+        values = torch.randn(2, 2, dtype=torch.complex64, device="mps")
+        boundaries = torch.randn(2, dtype=torch.float32, device="mps")
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "searchsorted is not supported for complex on MPS",
+        ):
+            torch.bucketize(values, boundaries)
+
+        # Complex boundaries should also be rejected.
+        values = torch.randn(2, 2, dtype=torch.float32, device="mps")
+        boundaries = torch.randn(2, dtype=torch.complex64, device="mps")
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "searchsorted is not supported for complex on MPS",
+        ):
+            torch.bucketize(values, boundaries)
+
     def test_channels_last_storage_offset(self):
         # Regression test: channels_last tensors with non-zero storage_offset produced wrong
         # results on MPS because the Placeholder path for NHWC ops ignored storage_offset.


### PR DESCRIPTION
Fixes #191692

## Summary

Reject complex inputs in the MPS implementation of searchsorted (and therefore bucketize).
before dispatching to the Metal kernel.

Previously these inputs reached kernel selection and failed with an opaque Metal
RuntimeError. This change raises a clear `NotImplementedError` instead and adds
a regression test.

## Testing

- `git diff --check`
- `python -m py_compile test/test_mps.py`

I could not run MPS-specific tests locally because development was performed on Windows without access to Apple Silicon hardware. The added regression test will be exercised by macOS MPS CI.