### PR TITLE
Restore dtensor_dispatch_custom_handler pr_time baseline to 38000

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -118,7 +118,7 @@ dtensor_dispatch_random,instruction_count,592800,0.1
 
 
 
-dtensor_dispatch_custom_handler,instruction_count,35970,0.1
+dtensor_dispatch_custom_handler,instruction_count,38000,0.1
 
 
 


### PR DESCRIPTION
## Summary

`dtensor_dispatch_custom_handler` fails ~50% of the time in
`linux-jammy-cuda13.2-py3.10-gcc11 / test (pr_time_benchmarks)`.

trunk.yml runs `pr_time_benchmarks` under both cuda13.0 (line 137) and
cuda13.2 (line 259), sharing one `expected_results.csv`. The cuda13.2 build
retires 5-9% more instructions in the small eager-dispatch benchmarks -- same
commit, run 30646475403: 36536 (13.0) vs 39803 (13.2). Baselines track
cuda13.0, so cuda13.2 starts ~8% into its +-10% budget.

| date | change | baseline | upper bound |
|---|---|---|---|
| Jul 23 | #190641 adds the cuda13.2 job, raises baseline 35830 -> 38000 to cover both | 38000 | 41800 |
| Jul 27 | #190678 refreshes from a cuda13.0 run (revert the baseline change for 13.2) | 36750 | 40425 |
| Jul 30 | #191247 refreshes again | 35970 | 39567 |

cuda13.2 lands at 38801 / 39706 / 39803 on consecutive commits, so the Jul 30
bound of 39567 cuts through the middle. Restoring 38000 leaves cuda13.0 6.4%
above the lower bound and cuda13.2 5.0% below the upper.

This is an unbreak -- the next refresh from a cuda13.0 run reintroduces it.
Real fix is to drop `pr_time_benchmarks` from the cuda13.2 matrix or key the
CSV by build config.

Authored with assistance from an AI coding assistant (Claude).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98