### PR TITLE
[tunable_ops] Add serving dispatch hit-rate logging

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -816,9 +816,18 @@ void bgemm_internal<at::BFloat16, float>(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(at:
   }
 }
 
+// Returns true iff dispatched via TunableOp (concrete hit, wildcard hit, or
+// tuning ran via FindFastest). Returns false on a tuned-entry miss with
+// tuning disabled, leaving the caller to fall back to bgemm_internal --
+// the same path bgemm() takes when TunableOp is disabled. We never let the
+// dispatch fall through to ResultEntry::Default(), since the Default
+// kernel can fault on MI300X for some shapes.
 template <typename Dtype, typename C_Dtype = Dtype>
-inline void bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
+inline bool bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
   tunable::GemmStridedBatchedParams<Dtype> params;
+  // Stamp per-call dynamic-dims mask before invoking the TunableOp; see
+  // launchTunableGemmAndBias in Blas.cpp for the rationale.
+  params.dynamic_dims_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
   params.transa = transa;
   params.transb = transb;
   params.m = m;
@@ -840,21 +849,45 @@ inline void bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
   bool transa_ = ((transa != 'n') && (transa != 'N'));
   bool transb_ = ((transb != 'n') && (transb != 'N'));
 
+  auto try_dispatch = [&](auto& bgemm_op) -> bool {
+    auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+    auto& mgr = tuning_ctx->GetTuningResultsManager();
+    auto op_sig = bgemm_op.Signature();
+    auto concrete_sig = params.Signature();
+    auto result = mgr.Lookup(op_sig, concrete_sig);
+    if (result == at::cuda::tunable::ResultEntry::Null()
+        && !tuning_ctx->IsTuningEnabled()) {
+      // Concrete miss + tuning disabled. Scan persisted wildcard entries via
+      // token-pattern matching against the concrete signature, matching the
+      // addmm path (launchTunableGemmAndBias). Do not rely on a caller-set
+      // dynamic mask: the AOTI cpp_wrapper does not emit a
+      // TunableDynamicDimsGuard, so GetCurrentDynamicDimsMask() (and thus
+      // DynamicSignature()) is empty here even when wildcard entries were
+      // persisted at compile-time tuning.
+      result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()) {
+        return false;
+      }
+    }
+    bgemm_op(&params);
+    return true;
+  };
+
   if (transa_ && transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::T, tunable::BlasOp::T> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else if (transa_ && !transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::T, tunable::BlasOp::N> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else if (!transa_ && transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::N, tunable::BlasOp::T> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else if (!transa_ && !transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::N, tunable::BlasOp::N> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else {
     TORCH_CHECK(false, "unreachable");
@@ -864,67 +897,61 @@ inline void bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
 template <>
 void bgemm<double>(CUDABLAS_BGEMM_ARGTYPES(double)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<double>(CUDABLAS_BGEMM_ARGS(double));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<double>(CUDABLAS_BGEMM_ARGS(double))) {
+    return;
   }
-  else {
-    bgemm_internal<double>(CUDABLAS_BGEMM_ARGS(double));
-  }
+  bgemm_internal<double>(CUDABLAS_BGEMM_ARGS(double));
 }
 
 template <>
 void bgemm<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<float>(CUDABLAS_BGEMM_ARGS(float));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<float>(CUDABLAS_BGEMM_ARGS(float))) {
+    return;
   }
-  else {
-    bgemm_internal<float>(CUDABLAS_BGEMM_ARGS(float));
-  }
+  bgemm_internal<float>(CUDABLAS_BGEMM_ARGS(float));
 }
 
 template <>
 void bgemm<c10::complex<double>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<double>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>))) {
+    return;
   }
-  else {
-    bgemm_internal<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>));
-  }
+  bgemm_internal<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>));
 }
 
 template <>
 void bgemm<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<float>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>))) {
+    return;
   }
-  else {
-    bgemm_internal<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>));
-  }
+  bgemm_internal<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>));
 }
 
 template <>
 void bgemm<at::Half>(CUDABLAS_BGEMM_ARGTYPES(at::Half)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half))) {
+    return;
   }
-  else {
-    bgemm_internal<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half));
-  }
+  bgemm_internal<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half));
 }
 
 template <>
 void bgemm<at::BFloat16>(CUDABLAS_BGEMM_ARGTYPES(at::BFloat16)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16))) {
+    return;
   }
-  else {
-    bgemm_internal<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16));
-  }
+  bgemm_internal<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16));
 }
 
 template <>
@@ -1365,9 +1392,17 @@ void gemm_internal<at::BFloat16, float>(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(at::B
   }
 }
 
+// Returns true iff dispatched via TunableOp. Returns false on a
+// tuned-entry miss with tuning disabled, leaving the caller to fall back
+// to gemm_internal -- the same path gemm() takes when TunableOp is
+// disabled. We never let the dispatch fall through to ResultEntry::Default()
+// since the Default kernel can fault on MI300X for some shapes.
 template <typename DType, typename C_Dtype>
-inline void gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
+inline bool gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
   tunable::GemmParams<DType> params;
+  // Stamp per-call dynamic-dims mask before invoking the TunableOp; see
+  // launchTunableGemmAndBias in Blas.cpp for the rationale.
+  params.dynamic_dims_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
   params.transa = transa;
   params.transb = transb;
   params.m = m;
@@ -1385,21 +1420,45 @@ inline void gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
   bool transa_ = ((transa != 'n') && (transa != 'N'));
   bool transb_ = ((transb != 'n') && (transb != 'N'));
 
+  auto try_dispatch = [&](auto& gemm_op) -> bool {
+    auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+    auto& mgr = tuning_ctx->GetTuningResultsManager();
+    auto op_sig = gemm_op.Signature();
+    auto concrete_sig = params.Signature();
+    auto result = mgr.Lookup(op_sig, concrete_sig);
+    if (result == at::cuda::tunable::ResultEntry::Null()
+        && !tuning_ctx->IsTuningEnabled()) {
+      // Concrete miss + tuning disabled. Scan persisted wildcard entries via
+      // token-pattern matching against the concrete signature, matching the
+      // addmm path (launchTunableGemmAndBias). Do not rely on a caller-set
+      // dynamic mask: the AOTI cpp_wrapper does not emit a
+      // TunableDynamicDimsGuard, so GetCurrentDynamicDimsMask() (and thus
+      // DynamicSignature()) is empty here even when wildcard entries were
+      // persisted at compile-time tuning.
+      result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()) {
+        return false;
+      }
+    }
+    gemm_op(&params);
+    return true;
+  };
+
   if (transa_ && transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::T, tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (transa_ && !transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::T, tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::N, tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && !transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::N, tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else {
     TORCH_CHECK(false, "unreachable");
@@ -1409,67 +1468,61 @@ inline void gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
 template <>
 void gemm<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<double>(CUDABLAS_GEMM_ARGS(double));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<double>(CUDABLAS_GEMM_ARGS(double))) {
+    return;
   }
-  else {
-    gemm_internal<double>(CUDABLAS_GEMM_ARGS(double));
-  }
+  gemm_internal<double>(CUDABLAS_GEMM_ARGS(double));
 }
 
 template <>
 void gemm<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<float>(CUDABLAS_GEMM_ARGS(float));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<float>(CUDABLAS_GEMM_ARGS(float))) {
+    return;
   }
-  else {
-    gemm_internal<float>(CUDABLAS_GEMM_ARGS(float));
-  }
+  gemm_internal<float>(CUDABLAS_GEMM_ARGS(float));
 }
 
 template <>
 void gemm<c10::complex<double>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<double>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>))) {
+    return;
   }
-  else {
-    gemm_internal<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>));
-  }
+  gemm_internal<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>));
 }
 
 template <>
 void gemm<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<float>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>))) {
+    return;
   }
-  else {
-    gemm_internal<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>));
-  }
+  gemm_internal<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>));
 }
 
 template <>
 void gemm<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<at::Half>(CUDABLAS_GEMM_ARGS(at::Half))) {
+    return;
   }
-  else {
-    gemm_internal<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
-  }
+  gemm_internal<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
 }
 
 template <>
 void gemm<at::BFloat16>(CUDABLAS_GEMM_ARGTYPES(at::BFloat16)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16))) {
+    return;
   }
-  else {
-    gemm_internal<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16));
-  }
+  gemm_internal<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16));
 }
 
 template <>

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -869,6 +869,11 @@ inline bool bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
         return false;
       }
     }
+    if (!tuning_ctx->IsTuningEnabled() &&
+        (result == at::cuda::tunable::ResultEntry::Default() ||
+         !bgemm_op.CanDispatchResult(result, &params))) {
+      return false;
+    }
     bgemm_op(&params);
     return true;
   };
@@ -1439,6 +1444,11 @@ inline bool gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
       if (result == at::cuda::tunable::ResultEntry::Null()) {
         return false;
       }
+    }
+    if (!tuning_ctx->IsTuningEnabled() &&
+        (result == at::cuda::tunable::ResultEntry::Default() ||
+         !gemm_op.CanDispatchResult(result, &params))) {
+      return false;
     }
     gemm_op(&params);
     return true;

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -855,6 +855,7 @@ inline bool bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
     auto op_sig = bgemm_op.Signature();
     auto concrete_sig = params.Signature();
     auto result = mgr.Lookup(op_sig, concrete_sig);
+    bool via_wildcard = false;
     if (result == at::cuda::tunable::ResultEntry::Null()
         && !tuning_ctx->IsTuningEnabled()) {
       // Concrete miss + tuning disabled. Scan persisted wildcard entries via
@@ -865,14 +866,19 @@ inline bool bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
       // DynamicSignature()) is empty here even when wildcard entries were
       // persisted at compile-time tuning.
       result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      via_wildcard = result != at::cuda::tunable::ResultEntry::Null();
       if (result == at::cuda::tunable::ResultEntry::Null()) {
+        at::cuda::tunable::RecordServingDispatch(false, false, op_sig, concrete_sig);
         return false;
       }
     }
-    if (!tuning_ctx->IsTuningEnabled() &&
-        (result == at::cuda::tunable::ResultEntry::Default() ||
-         !bgemm_op.CanDispatchResult(result, &params))) {
-      return false;
+    if (!tuning_ctx->IsTuningEnabled()) {
+      if (result == at::cuda::tunable::ResultEntry::Default() ||
+          !bgemm_op.CanDispatchResult(result, &params)) {
+        at::cuda::tunable::RecordServingDispatch(false, false, op_sig, concrete_sig);
+        return false;
+      }
+      at::cuda::tunable::RecordServingDispatch(true, via_wildcard);
     }
     bgemm_op(&params);
     return true;
@@ -1431,6 +1437,7 @@ inline bool gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
     auto op_sig = gemm_op.Signature();
     auto concrete_sig = params.Signature();
     auto result = mgr.Lookup(op_sig, concrete_sig);
+    bool via_wildcard = false;
     if (result == at::cuda::tunable::ResultEntry::Null()
         && !tuning_ctx->IsTuningEnabled()) {
       // Concrete miss + tuning disabled. Scan persisted wildcard entries via
@@ -1441,14 +1448,19 @@ inline bool gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
       // DynamicSignature()) is empty here even when wildcard entries were
       // persisted at compile-time tuning.
       result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      via_wildcard = result != at::cuda::tunable::ResultEntry::Null();
       if (result == at::cuda::tunable::ResultEntry::Null()) {
+        at::cuda::tunable::RecordServingDispatch(false, false, op_sig, concrete_sig);
         return false;
       }
     }
-    if (!tuning_ctx->IsTuningEnabled() &&
-        (result == at::cuda::tunable::ResultEntry::Default() ||
-         !gemm_op.CanDispatchResult(result, &params))) {
-      return false;
+    if (!tuning_ctx->IsTuningEnabled()) {
+      if (result == at::cuda::tunable::ResultEntry::Default() ||
+          !gemm_op.CanDispatchResult(result, &params)) {
+        at::cuda::tunable::RecordServingDispatch(false, false, op_sig, concrete_sig);
+        return false;
+      }
+      at::cuda::tunable::RecordServingDispatch(true, via_wildcard);
     }
     gemm_op(&params);
     return true;

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -26,6 +26,7 @@
 #include <ATen/ops/from_blob.h>
 #endif
 #include <ATen/OpMathType.h>
+#include <fmt/core.h>
 #include <fmt/printf.h>
 
 namespace at::cuda::tunable {
@@ -102,6 +103,33 @@ inline const char* BLASTypeName(c10::complex<double> v) {
 template <>
 inline const char* BLASTypeName(c10::complex<float> v) {
   return "f32_r";
+}
+
+inline std::string MaybeWildcardInt(int64_t value, bool wildcard) {
+  return wildcard ? "*" : c10::str(value);
+}
+
+inline bool UsesMForLda(char transa) {
+  // lda is the leading dim of A. For non-transposed A (transa == 'N'), A is
+  // laid out with lda >= m, so lda tracks M; for transposed A (transa == 'T'),
+  // lda >= k, so lda tracks K. This mirrors GetSizeA's stride computation.
+  return transa == 'N' || transa == 'n';
+}
+
+inline bool UsesKForLdb(char transb) {
+  return transb == 'N' || transb == 'n';
+}
+
+inline bool ShouldWildcardLda(char transa, bool dynamic_m, bool dynamic_k) {
+  return UsesMForLda(transa) ? dynamic_m : dynamic_k;
+}
+
+inline bool ShouldWildcardLdb(char transb, bool dynamic_n, bool dynamic_k) {
+  return UsesKForLdb(transb) ? dynamic_k : dynamic_n;
+}
+
+inline bool ShouldWildcardLdc(bool dynamic_m) {
+  return dynamic_m;
 }
 
 inline std::string ScalarTypeToBLASType(c10::ScalarType scalar_type) {
@@ -291,7 +319,36 @@ struct GemmParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld", transa, transb, m, n, k, lda, ldb, ldc);
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        lda,
+        ldb,
+        ldc);
+    TUNABLE_LOG3("GemmParams concrete_signature=", signature);
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        MaybeWildcardInt(m, dynamic_m),
+        MaybeWildcardInt(n, dynamic_n),
+        MaybeWildcardInt(k, dynamic_k),
+        MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k)),
+        MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k)),
+        MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m)));
+    TUNABLE_LOG3("GemmParams dynamic_signature=", signature, " dyn=", this->dynamic_dims_mask.ToString());
+    return signature;
   }
 
   size_t GetSizeA() const {
@@ -393,7 +450,36 @@ struct GemmAndBiasParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld", transa, transb, m, n, k, lda, ldb, ldc);
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        lda,
+        ldb,
+        ldc);
+    TUNABLE_LOG3("GemmAndBiasParams concrete_signature=", signature);
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        MaybeWildcardInt(m, dynamic_m),
+        MaybeWildcardInt(n, dynamic_n),
+        MaybeWildcardInt(k, dynamic_k),
+        MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k)),
+        MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k)),
+        MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m)));
+    TUNABLE_LOG3("GemmAndBiasParams dynamic_signature=", signature, " dyn=", this->dynamic_dims_mask.ToString());
+    return signature;
   }
 
   size_t GetSizeA() const {
@@ -496,7 +582,39 @@ struct GemmStridedBatchedParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_B_%ld_ld_%ld_%ld_%ld", transa, transb, m, n, k, batch, lda, ldb, ldc);
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_B_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        batch,
+        lda,
+        ldb,
+        ldc);
+    TUNABLE_LOG3("GemmStridedBatchedParams concrete_signature=", signature);
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    const bool dynamic_batch = this->IsDynamicBatch();
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_B_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        MaybeWildcardInt(m, dynamic_m),
+        MaybeWildcardInt(n, dynamic_n),
+        MaybeWildcardInt(k, dynamic_k),
+        MaybeWildcardInt(batch, dynamic_batch),
+        MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k)),
+        MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k)),
+        MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m)));
+    TUNABLE_LOG3("GemmStridedBatchedParams dynamic_signature=", signature, " dyn=", this->dynamic_dims_mask.ToString());
+    return signature;
   }
 
   size_t GetSizeA() const {
@@ -618,10 +736,40 @@ struct ScaledGemmParams : OpParams {
     // params.bias_dtype = bias ? bias->scalar_type() : isFloat8Type(out_dtype_) ? at::ScalarType::Half : out_dtype_;
     //
     // In TunableOp, we must distinguish in param signature these two cases: with and without a bias vector.
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld_rw_%d_bias_%s",
-      transa, transb, m, n, k, lda, ldb, ldc,
+    auto signature = fmt::format(
+      "{}{}_{}_{}_{}_ld_{}_{}_{}_rw_{}_bias_{}",
+      transa,
+      transb,
+      m,
+      n,
+      k,
+      lda,
+      ldb,
+      ldc,
       a_scaling_type == ScalingType::RowWise && b_scaling_type == ScalingType::RowWise,
       bias_ptr == nullptr ? "None" : at::toString(bias_dtype));
+    TUNABLE_LOG3("ScaledGemmParams concrete_signature=", signature);
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    auto signature = fmt::format(
+      "{}{}_{}_{}_{}_ld_{}_{}_{}_rw_{}_bias_{}",
+      transa,
+      transb,
+      MaybeWildcardInt(m, dynamic_m),
+      MaybeWildcardInt(n, dynamic_n),
+      MaybeWildcardInt(k, dynamic_k),
+      MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k)),
+      MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k)),
+      MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m)),
+      a_scaling_type == ScalingType::RowWise && b_scaling_type == ScalingType::RowWise,
+      bias_ptr == nullptr ? "None" : at::toString(bias_dtype));
+    TUNABLE_LOG3("ScaledGemmParams dynamic_signature=", signature, " dyn=", this->dynamic_dims_mask.ToString());
+    return signature;
   }
 
   size_t GetSizeA() const {

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -46,6 +47,44 @@
 #endif
 
 namespace at::cuda::tunable {
+
+namespace {
+
+// Matches a tunableop params signature against a wildcard pattern. Both
+// strings are split on '_' and compared token-by-token; '*' in the pattern
+// matches any single token. Returns true iff every pattern token equals
+// the corresponding concrete token (or is '*').
+bool matches_wildcard_pattern(
+    const std::string& pattern,
+    const std::string& concrete) {
+  if (pattern.find('*') == std::string::npos) {
+    // Pattern has no wildcard token -> only exact match counts.
+    return pattern == concrete;
+  }
+  size_t p_i = 0, c_i = 0;
+  while (p_i < pattern.size() && c_i < concrete.size()) {
+    // Find next token boundary in each string.
+    size_t p_end = pattern.find('_', p_i);
+    if (p_end == std::string::npos) {
+      p_end = pattern.size();
+    }
+    size_t c_end = concrete.find('_', c_i);
+    if (c_end == std::string::npos) {
+      c_end = concrete.size();
+    }
+    const auto p_tok = std::string_view(pattern).substr(p_i, p_end - p_i);
+    const auto c_tok = std::string_view(concrete).substr(c_i, c_end - c_i);
+    if (p_tok != "*" && p_tok != c_tok) {
+      return false;
+    }
+    p_i = (p_end == pattern.size()) ? pattern.size() : p_end + 1;
+    c_i = (c_end == concrete.size()) ? concrete.size() : c_end + 1;
+  }
+  // Both must be fully consumed (same token count).
+  return p_i >= pattern.size() && c_i >= concrete.size();
+}
+
+} // namespace
 
 TuningContext* getTuningContext() {
   static TuningContext tuning_context;
@@ -83,12 +122,55 @@ ResultEntry TuningResultsManager::Lookup(const std::string& op_signature, const 
 
   const auto& km = kernel_map_it->second;
   auto it = km.find(params_signature);
-  if (it == km.cend()) {
-    TUNABLE_LOG3("missing params_signature, returning null ResultEntry for ", op_signature, ",", params_signature);
+  if (it != km.cend()) {
+    TUNABLE_LOG3(
+        "ResultEntry found for ",
+        op_signature,
+        ",",
+        params_signature);
+    return it->second;
+  }
+  // Exact-match-only Lookup. Callers that want to look up a wildcard key
+  // (e.g. operator() in TunableOp.h, or try_dispatch in Blas.cpp) must pass
+  // the already-formed wildcard signature; this Lookup will neither expand
+  // wildcards in the request nor match a wildcard request against concrete
+  // candidates. The previous "fuzzy fallback" scan was removed because it
+  // conflicted with the case-4 "is the wildcard KEY persisted?" check
+  // performed by operator() (the scan would spuriously return a concrete
+  // result for a wildcard request).
+  TUNABLE_LOG3(
+      "missing params_signature, returning null ResultEntry for ",
+      op_signature,
+      ",",
+      params_signature);
+  return ResultEntry::Null();
+}
+
+ResultEntry TuningResultsManager::LookupWildcardFallback(
+    const std::string& op_signature,
+    const std::string& concrete_params_signature) {
+  std::scoped_lock l{lock_};
+  auto kernel_map_it = results_.find(op_signature);
+  if (kernel_map_it == results_.cend()) {
     return ResultEntry::Null();
   }
-  TUNABLE_LOG3("ResultEntry found for ", op_signature, ",", params_signature);
-  return it->second;
+  const auto& km = kernel_map_it->second;
+  for (const auto& [key, entry] : km) {
+    if (key.find('*') == std::string::npos) {
+      continue; // skip concrete entries
+    }
+    if (matches_wildcard_pattern(key, concrete_params_signature)) {
+      TUNABLE_LOG3(
+          "wildcard fallback hit for ",
+          op_signature,
+          ",",
+          concrete_params_signature,
+          " via wildcard ",
+          key);
+      return entry;
+    }
+  }
+  return ResultEntry::Null();
 }
 
 void TuningResultsManager::AddImpl(const std::string& op_signature,
@@ -516,8 +598,7 @@ TuningContext::TuningContext() :
     rotating_buffer_size_{-1},
     results_count_from_input_file_{0},
     is_shutting_down_{false}
-{
-}
+{}
 
 TuningContext::~TuningContext() {
   is_shutting_down_ = true;
@@ -934,6 +1015,43 @@ bool TuningContext::GetLogOkay() const {
 std::ostream& TuningContext::GetLog() const {
   static auto streamptr = get_stream(GetLogFilename());
   return *streamptr;
+}
+
+namespace {
+
+// Per-thread stack of dynamic-dims masks. Producers in Blas.cpp /
+// CUDABlas.cpp / ScaledBlas.cpp read the top via GetCurrentDynamicDimsMask()
+// and stamp it onto the constructed Gemm*Params before calling the
+// TunableOp. The stack semantics let nested wrappers compose naturally:
+// e.g. an outer torch.cuda.tunable.dynamic_dims_mask(...) ctx-mgr around a
+// benchmark loop, with inner per-choice or per-call wrappers; each
+// TunableDynamicDimsGuard pushes on construction and pops on destruction.
+std::vector<DynamicDimsMask>& dynamic_dims_stack() {
+  // Function-local TLS: avoids a static-init dependency on std::vector's
+  // ctor running before any TunableDynamicDimsGuard is constructed.
+  thread_local std::vector<DynamicDimsMask> stack;
+  return stack;
+}
+
+} // namespace
+
+DynamicDimsMask GetCurrentDynamicDimsMask() {
+  const auto& stack = dynamic_dims_stack();
+  if (stack.empty()) {
+    return DynamicDimsMask{};
+  }
+  return stack.back();
+}
+
+TunableDynamicDimsGuard::TunableDynamicDimsGuard(DynamicDimsMask mask) {
+  dynamic_dims_stack().push_back(mask);
+}
+
+TunableDynamicDimsGuard::~TunableDynamicDimsGuard() {
+  auto& stack = dynamic_dims_stack();
+  if (!stack.empty()) {
+    stack.pop_back();
+  }
 }
 
 } // namespace at::cuda::tunable

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -24,6 +24,9 @@
 #endif
 
 #include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <mutex>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -84,11 +87,91 @@ bool matches_wildcard_pattern(
   return p_i >= pattern.size() && c_i >= concrete.size();
 }
 
+constexpr int64_t kServingDispatchLogEvery = 100000;
+constexpr size_t kServingDispatchMaxMissSigs = 2000;
+
+std::atomic<int64_t> serving_dispatch_total{0};
+std::atomic<int64_t> serving_dispatch_concrete_hits{0};
+std::atomic<int64_t> serving_dispatch_wildcard_hits{0};
+std::atomic<int64_t> serving_dispatch_misses{0};
+std::atomic<int64_t> serving_dispatch_last_logged_total{0};
+
 } // namespace
 
 TuningContext* getTuningContext() {
   static TuningContext tuning_context;
   return &tuning_context;
+}
+
+void LogServingDispatchSummary(bool force) {
+  if (!getTuningContext()->IsServingDispatchCounterEnabled()) {
+    return;
+  }
+  const auto total = serving_dispatch_total.load(std::memory_order_relaxed);
+  if (total == 0) {
+    return;
+  }
+
+  auto last_logged =
+      serving_dispatch_last_logged_total.load(std::memory_order_relaxed);
+  if (!force && total - last_logged < kServingDispatchLogEvery) {
+    return;
+  }
+  if (!serving_dispatch_last_logged_total.compare_exchange_strong(
+          last_logged,
+          total,
+          std::memory_order_relaxed,
+          std::memory_order_relaxed)) {
+    return;
+  }
+
+  const auto concrete_hits =
+      serving_dispatch_concrete_hits.load(std::memory_order_relaxed);
+  const auto wildcard_hits =
+      serving_dispatch_wildcard_hits.load(std::memory_order_relaxed);
+  const auto misses = serving_dispatch_misses.load(std::memory_order_relaxed);
+  const auto hits = concrete_hits + wildcard_hits;
+  const auto hit_rate = static_cast<double>(hits) * 100.0 /
+      static_cast<double>(total);
+  TORCH_WARN(
+      "[TunableOp][DispatchCounter] total=",
+      total,
+      " hits=",
+      hits,
+      " concrete=",
+      concrete_hits,
+      " wildcard=",
+      wildcard_hits,
+      " misses=",
+      misses,
+      " hit_rate_pct=",
+      hit_rate);
+}
+
+void RecordServingDispatch(bool tuned_hit, bool via_wildcard, const std::string& op_signature, const std::string& params_signature) {
+  if (!getTuningContext()->IsServingDispatchCounterEnabled()) {
+    return;
+  }
+  if (!tuned_hit) {
+    serving_dispatch_misses.fetch_add(1, std::memory_order_relaxed);
+    // Dump each distinct missing GEMM signature once (capped) so we can see
+    // exactly which shapes/ops fall through to the default (untuned) kernel.
+    if (!op_signature.empty()) {
+      static std::mutex miss_sig_mutex;
+      static std::unordered_set<std::string> logged_miss_sigs;
+      std::lock_guard<std::mutex> lk(miss_sig_mutex);
+      if (logged_miss_sigs.size() < kServingDispatchMaxMissSigs &&
+          logged_miss_sigs.emplace(op_signature + "," + params_signature).second) {
+        TORCH_WARN("[TunableOp][Miss] ", op_signature, ",", params_signature);
+      }
+    }
+  } else if (via_wildcard) {
+    serving_dispatch_wildcard_hits.fetch_add(1, std::memory_order_relaxed);
+  } else {
+    serving_dispatch_concrete_hits.fetch_add(1, std::memory_order_relaxed);
+  }
+  serving_dispatch_total.fetch_add(1, std::memory_order_relaxed);
+  LogServingDispatchSummary(false);
 }
 
 std::ostream& operator<<(std::ostream& stream, const ResultEntry& entry) {
@@ -585,6 +668,7 @@ TuningStatus TuningResultsValidator::ValidatePyTorchVersion(const std::string& v
 
 TuningContext::TuningContext() :
     enable_{false},
+    serving_dispatch_counter_enable_{false},
     tuning_enable_{true},
     record_untuned_enable_{false},
     manager_initialized_{false},
@@ -609,6 +693,7 @@ TuningContext::~TuningContext() {
     return;
   }
   TUNABLE_LOG1("Closing File");
+  LogServingDispatchSummary(true);
   GetTuningResultsManager().CloseRealtimeAppend(); // Since, we do instant logging by default now.
 
   if (untuned_file_.good()) {
@@ -632,6 +717,14 @@ bool TuningContext::IsTunableOpEnabled() const {
     return true;
   }
   return enable_;
+}
+
+void TuningContext::EnableServingDispatchCounter(bool value) {
+  serving_dispatch_counter_enable_ = value;
+}
+
+bool TuningContext::IsServingDispatchCounterEnabled() const {
+  return serving_dispatch_counter_enable_;
 }
 
 void TuningContext::EnableTuning(bool value) {

--- a/aten/src/ATen/cuda/tunable/Tunable.h
+++ b/aten/src/ATen/cuda/tunable/Tunable.h
@@ -77,6 +77,16 @@ class TORCH_CUDA_CPP_API TuningResultsManager {
 
     ResultEntry Lookup(const std::string& op_signature, const std::string& params_signature);
 
+    // Scans persisted wildcard entries (keys containing '*') under
+    // `op_signature` and returns the first whose token-by-token pattern
+    // matches `concrete_params_signature`. Used as a runtime fallback
+    // when a concrete miss happens without an active TunableDynamicDimsGuard
+    // (e.g., AOTI cpp_wrapper that wasn't compiled with guard emission).
+    // Returns ResultEntry::Null() if no wildcard matches.
+    ResultEntry LookupWildcardFallback(
+        const std::string& op_signature,
+        const std::string& concrete_params_signature);
+
     void AddImpl(const std::string& op_signature,
         const std::string& params_signature,
         ResultEntry best,
@@ -158,6 +168,64 @@ struct NumericalCheckConfig {
   NumericalCheckConfig(bool e, double a, double r) : enabled(e), atol(a), rtol(r) {}
 };
 
+enum class TORCH_CUDA_CPP_API DynamicGemmDim {
+  M = 0,
+  N = 1,
+  K = 2,
+  BATCH = 3,
+};
+
+// Per-call dynamic-dims mask. POD, trivially copyable so it composes with
+// the existing OpParams DeepCopy(*this) paths without any custom copy logic.
+// The four bits select which logical GEMM dim (M/N/K/BATCH) is wildcarded
+// when computing DynamicSignature() for that specific op invocation.
+struct TORCH_CUDA_CPP_API DynamicDimsMask {
+  static constexpr uint8_t M_BIT = 1u << 0;
+  static constexpr uint8_t N_BIT = 1u << 1;
+  static constexpr uint8_t K_BIT = 1u << 2;
+  static constexpr uint8_t BATCH_BIT = 1u << 3;
+
+  uint8_t bits{0};
+
+  constexpr DynamicDimsMask() = default;
+  constexpr DynamicDimsMask(bool m, bool n, bool k, bool batch)
+      : bits(
+            static_cast<uint8_t>(
+                (m ? M_BIT : 0) | (n ? N_BIT : 0) | (k ? K_BIT : 0) |
+                (batch ? BATCH_BIT : 0))) {}
+  explicit constexpr DynamicDimsMask(uint8_t b) : bits(b) {}
+
+  constexpr bool m() const { return (bits & M_BIT) != 0; }
+  constexpr bool n() const { return (bits & N_BIT) != 0; }
+  constexpr bool k() const { return (bits & K_BIT) != 0; }
+  constexpr bool batch() const { return (bits & BATCH_BIT) != 0; }
+  constexpr bool any() const { return bits != 0; }
+  constexpr bool empty() const { return bits == 0; }
+
+  // Human-readable form, e.g. "M|N" or "" when empty.
+  std::string ToString() const {
+    std::string s;
+    auto add = [&s](const char* tok) {
+      if (!s.empty()) {
+        s.push_back('|');
+      }
+      s.append(tok);
+    };
+    if (m()) {
+      add("M");
+    }
+    if (n()) {
+      add("N");
+    }
+    if (k()) {
+      add("K");
+    }
+    if (batch()) {
+      add("B");
+    }
+    return s;
+  }
+};
 
 class TORCH_CUDA_CPP_API TuningContext {
   public:
@@ -254,6 +322,34 @@ class TORCH_CUDA_CPP_API TuningContext {
 };
 
 TORCH_CUDA_CPP_API TuningContext* getTuningContext();
+
+// Returns the current top-of-stack DynamicDimsMask for this thread, or an
+// all-zero mask when no TunableDynamicDimsGuard is active. Producers in
+// Blas.cpp / CUDABlas.cpp / ScaledBlas.cpp call this once per Gemm*Params
+// construction and stamp the result onto the params before invoking the
+// TunableOp, so DynamicSignature() can read the mask off *this rather than
+// from a global TuningContext setting.
+TORCH_CUDA_CPP_API DynamicDimsMask GetCurrentDynamicDimsMask();
+
+// RAII guard that pushes a DynamicDimsMask onto the thread-local stack on
+// construction and pops on destruction. Use to wrap a single GEMM call (or a
+// scope containing GEMM calls) with the mask that applies to that op.
+//
+// Lives in at::cuda::tunable so it is reachable from both ATen Blas.cpp
+// callers (eager mode) and the AOTI cpp_wrapper-emitted code in compiled .so
+// shared libraries (which include this header).
+class TORCH_CUDA_CPP_API TunableDynamicDimsGuard {
+ public:
+  explicit TunableDynamicDimsGuard(DynamicDimsMask mask);
+  TunableDynamicDimsGuard(bool dyn_m, bool dyn_n, bool dyn_k, bool dyn_batch)
+      : TunableDynamicDimsGuard(DynamicDimsMask(dyn_m, dyn_n, dyn_k, dyn_batch)) {}
+  ~TunableDynamicDimsGuard();
+
+  TunableDynamicDimsGuard(const TunableDynamicDimsGuard&) = delete;
+  TunableDynamicDimsGuard& operator=(const TunableDynamicDimsGuard&) = delete;
+  TunableDynamicDimsGuard(TunableDynamicDimsGuard&&) = delete;
+  TunableDynamicDimsGuard& operator=(TunableDynamicDimsGuard&&) = delete;
+};
 
 class ITimer {
   public:

--- a/aten/src/ATen/cuda/tunable/Tunable.h
+++ b/aten/src/ATen/cuda/tunable/Tunable.h
@@ -239,6 +239,9 @@ class TORCH_CUDA_CPP_API TuningContext {
     void EnableTunableOp(bool value);
     bool IsTunableOpEnabled() const;
 
+    void EnableServingDispatchCounter(bool value);
+    bool IsServingDispatchCounterEnabled() const;
+
     void EnableTuning(bool value);
     bool IsTuningEnabled() const;
 
@@ -299,6 +302,7 @@ class TORCH_CUDA_CPP_API TuningContext {
     std::ostream& GetLog() const;
 
     bool enable_;
+    bool serving_dispatch_counter_enable_;
     bool tuning_enable_;
     bool record_untuned_enable_;
     bool manager_initialized_;
@@ -323,6 +327,11 @@ class TORCH_CUDA_CPP_API TuningContext {
 
 TORCH_CUDA_CPP_API TuningContext* getTuningContext();
 
+// Records low-volume serving-time cache hit accounting. This is intentionally
+// separate from TUNABLE_LOG* because per-dispatch verbose logs are too noisy for
+// ICE; summaries are emitted periodically and at shutdown.
+TORCH_CUDA_CPP_API void RecordServingDispatch(bool tuned_hit, bool via_wildcard, const std::string& op_signature = "", const std::string& params_signature = "");
+TORCH_CUDA_CPP_API void LogServingDispatchSummary(bool force = false);
 // Returns the current top-of-stack DynamicDimsMask for this thread, or an
 // all-zero mask when no TunableDynamicDimsGuard is active. Producers in
 // Blas.cpp / CUDABlas.cpp / ScaledBlas.cpp call this once per Gemm*Params

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -117,6 +117,19 @@ class TunableOp {
   public:
     virtual ~TunableOp() = default;
 
+    bool CanDispatchResult(
+        const ResultEntry& result,
+        const ParamsT* params) {
+      if (HasOp(result.GetKey())) {
+        return true;
+      }
+#ifndef USE_ROCM
+      return RegisterOpForResult(result, params) && HasOp(result.GetKey());
+#else
+      return false;
+#endif
+    }
+
     TuningStatus operator()(const ParamsT* params) {
       // Dynamic TunableOp dispatch matrix:
       //
@@ -230,11 +243,9 @@ class TunableOp {
         result = ResultEntry::Default();
       }
       auto* op = GetOp(result.GetKey());
-#ifndef USE_ROCM
-      if (op == nullptr && RegisterOpForResult(result, params)) {
+      if (op == nullptr && CanDispatchResult(result, params)) {
         op = GetOp(result.GetKey());
       }
-#endif
       if (op == nullptr) {
         TUNABLE_LOG2("missing candidate ", result, ", using default");
         result = ResultEntry::Default();

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -118,38 +118,108 @@ class TunableOp {
     virtual ~TunableOp() = default;
 
     TuningStatus operator()(const ParamsT* params) {
+      // Dynamic TunableOp dispatch matrix:
+      //
+      // Tuning enabled (compile-time autotune)
+      //   1. no dynamic dim + concrete miss -> tune; persist concrete
+      //   2. has dynamic dim + concrete miss -> tune; persist concrete + wildcard
+      //   3. no dynamic dim + concrete hit  -> nothing
+      //   4. has dynamic dim + concrete hit -> if wildcard not persisted, persist wildcard
+      //
+      // Tuning disabled (runtime)
+      //   At runtime we cannot know which dim is dynamic (the AOTI
+      //   cpp_wrapper does not propagate that information into the .so),
+      //   so:
+      //   1. concrete hit                       -> dispatch via concrete
+      //   2. concrete miss + wildcard match     -> dispatch via wildcard
+      //                                            (LookupWildcardFallback
+      //                                            scans persisted wildcards
+      //                                            and returns the first
+      //                                            whose pattern matches the
+      //                                            concrete signature)
+      //   3. concrete miss + no wildcard match  -> result stays Null;
+      //                                            generic TunableOp falls
+      //                                            through to Default, while
+      //                                            BLAS callers pre-check and
+      //                                            skip to the disabled aten
+      //                                            path instead
       ResultEntry result = ResultEntry::Null();
       TuningContext* ctx = getTuningContext();
       if (ctx->IsTunableOpEnabled()) {
         auto& mgr = ctx->GetTuningResultsManager();
         auto op_sig = Signature();
-        auto params_sig = params->Signature();
-        auto blas_sig = params->BLASSignature();
-        result = mgr.Lookup(op_sig, params_sig);
-        // If there is not previous tuning result been found, we do the tuning iff tuning is enabled
-        if (result == ResultEntry::Null()) {
-          bool should_record_untuned = !ctx->IsTuningEnabled();
-          if (ctx->IsTuningEnabled()) {
+        auto concrete_params_sig = params->Signature();
+        // Only this `any()` bit-check is on the cache-hit fast path. The
+        // full DynamicSignature() (which performs a fmt::format with
+        // several string allocations) is computed lazily, only inside the
+        // miss / case-4 branches that actually need it. At runtime
+        // dynamic_dims_mask is always empty (no TunableDynamicDimsGuard
+        // emitted by AOTI cpp_wrapper) so this stays false on the
+        // hot path; only compile-time tuning (when Python pushes a mask
+        // via torch.cuda.tunable.dynamic_dims_mask) sets it.
+        const bool has_dynamic_dim = params->dynamic_dims_mask.any();
+
+        result = mgr.Lookup(op_sig, concrete_params_sig);
+        const bool concrete_hit = (result != ResultEntry::Null());
+
+        if (ctx->IsTuningEnabled()) {
+          if (!concrete_hit) {
+            // Cases 1 & 2: concrete miss with tuning -> tune + persist.
+            bool can_tune = true;
 #ifndef USE_ROCM
-            bool is_capturing =
-                c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
+            can_tune =
+                c10::cuda::currentStreamCaptureStatusMayInitCtx() ==
                 c10::cuda::CaptureStatus::None;
-            if (!is_capturing) {
+            if (can_tune) {
               RegisterOpCandidates(params);
-              result = FindFastest(params);
-              mgr.Add(op_sig, params_sig, result);
-            } else {
-              should_record_untuned = true;
             }
-#else
-            result = FindFastest(params);
-            mgr.Add(op_sig, params_sig, result);
 #endif
+            if (can_tune) {
+              result = FindFastest(params);
+              mgr.Add(op_sig, concrete_params_sig, result);
+              if (has_dynamic_dim) {
+                // Case 2: also seed wildcard key with the same tuned kernel.
+                // mgr.Add is a no-op when the key already exists, so the
+                // first-tuned-wins semantics required by the dynamic-dims
+                // contract are preserved.
+                mgr.Add(op_sig, params->DynamicSignature(), result);
+              }
+            } else if (ctx->IsRecordUntunedEnabled()) {
+              mgr.RecordUntuned(
+                  ctx->GetUntunedFile(),
+                  op_sig,
+                  concrete_params_sig,
+                  params->BLASSignature());
+            }
           }
-          if (should_record_untuned && ctx->IsRecordUntunedEnabled()) {
-            // or record the gemm into file
-            mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, params_sig, blas_sig);
+          else if (has_dynamic_dim) {
+            // Case 4: concrete hit + dynamic -> ensure wildcard is persisted
+            // so subsequent shapes that differ only in the dynamic dims can
+            // reuse this kernel without re-tuning.
+            auto dynamic_params_sig = params->DynamicSignature();
+            if (mgr.Lookup(op_sig, dynamic_params_sig) == ResultEntry::Null()) {
+              mgr.Add(op_sig, dynamic_params_sig, result);
+            }
           }
+          // Case 3: concrete hit + no dynamic -> nothing to do.
+        }
+        else {
+          // Tuning disabled (runtime). We cannot rely on any caller-set
+          // dynamic mask here -- AOTI cpp_wrapper does not emit a
+          // TunableDynamicDimsGuard so GetCurrentDynamicDimsMask() is
+          // empty. On concrete miss, scan all persisted wildcard
+          // entries and return any whose token-pattern matches the
+          // concrete signature. If none match, result stays Null and
+          // the caller (e.g. launchTunableGemmAndBias) falls back to
+          // the non-tunable aten path.
+          if (!concrete_hit) {
+            result = mgr.LookupWildcardFallback(op_sig, concrete_params_sig);
+            if (result == ResultEntry::Null() && ctx->IsRecordUntunedEnabled()) {
+              auto blas_sig = params->BLASSignature();
+              mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, concrete_params_sig, blas_sig);
+            }
+          }
+          // Case 1: concrete hit -> use it.
         }
       }
       else {
@@ -433,9 +503,6 @@ class TunableOp {
         WarmUp(candidate, reusable_params, warmup_iter, offset);
         s = ProfileStats(candidate, reusable_params, tuning_iter, offset);
         auto s_stddev = s.stddev();
-        // Assume normal distribution.
-        // Solution with smallest mean + 2*sigma will be a better solution?
-        // if ((s._mean + 2*s_stddev) < (min_duration_ms + 2*min_stddev_ms)) {
         if (s._mean < min_duration_ms) {
           TUNABLE_LOG3("├──found better instance id=", i, ". " , s._mean, "ms. ", candidate_names[i],
                 " min ", s._min,
@@ -501,7 +568,27 @@ struct OpParams {
   OpParams(const OpParams&) = default;
   virtual ~OpParams() = default;
   virtual std::string Signature() const = 0;
+  virtual std::string DynamicSignature() const {
+    return Signature();
+  }
   virtual std::string BLASSignature() const = 0;
+
+  // Per-instance mask describing which logical GEMM dims are dynamic for
+  // this particular op invocation. The producer (Blas.cpp / CUDABlas.cpp /
+  // ScaledBlas.cpp) reads at::cuda::tunable::GetCurrentDynamicDimsMask()
+  // once and stamps the result here before calling the TunableOp; the
+  // Gemm*Params subclasses' DynamicSignature() implementations then read
+  // this field instead of the previously-global TuningContext setting.
+  //
+  // Default-constructed (all-zero) means "no dim is dynamic", which yields
+  // a DynamicSignature() byte-identical to Signature() and preserves the
+  // legacy concrete-only behavior for callers that don't push a guard.
+  DynamicDimsMask dynamic_dims_mask{};
+
+  bool IsDynamicM() const { return dynamic_dims_mask.m(); }
+  bool IsDynamicN() const { return dynamic_dims_mask.n(); }
+  bool IsDynamicK() const { return dynamic_dims_mask.k(); }
+  bool IsDynamicBatch() const { return dynamic_dims_mask.batch(); }
 };
 
 } // namespace at::cuda::tunable

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -229,11 +229,69 @@ static bool isInputCompliesAddmmCudaLt(
   );
 }
 
+// Direct call into at::cuda::blas::gemm_and_bias -- the same code path
+// taken when TunableOp is disabled. Extracted into a free function so both
+// the "TunableOp disabled" branch and the "TunableOp enabled but tunable
+// lookup missed" branch in launchGemmAndBiasCublasLt can call it without
+// having to flip the global TunableOp enable flag (which would be a data
+// race in multithreaded benchmark configs).
+template <typename scalar_t, typename res_scalar_t = scalar_t>
+bool launchGemmAndBiasNonTunable(
+    cublasCommonArgs& args,
+    const scalar_t* self_ptr,
+    const Scalar& alpha,
+    Activation activation) {
+  return at::cuda::blas::gemm_and_bias<scalar_t, res_scalar_t>(
+    args.transa == 't',
+    args.transb == 't',
+    args.m,
+    args.n,
+    args.k,
+    alpha.to<at::opmath_type<scalar_t>>(),
+    args.mata->const_data_ptr<scalar_t>(),
+    args.lda,
+    args.matb->const_data_ptr<scalar_t>(),
+    args.ldb,
+    self_ptr,
+    args.result->data_ptr<res_scalar_t>(),
+    args.result_ld,
+    activation_to_gemm_and_blas_arg(activation));
+}
+
+// Returns true iff the call was dispatched via TunableOp (either an
+// already-tuned entry was found, or tuning ran via FindFastest and produced
+// a result). Returns false when TunableOp is enabled but has no tuned entry
+// for this shape AND tuning is disabled -- in that case the caller must
+// fall back to the regular at::cuda::blas::gemm_and_bias path. We
+// intentionally do NOT let the dispatch fall through to ResultEntry::Default
+// here, because the GemmAndBias Default kernel can hit a GPU memory-access
+// fault on MI300X for large-K shapes, and the safest behavior on miss is
+// the same as the pre-TunableOp behavior (i.e. raw cuBLAS-Lt).
 template <typename scalar_t>
-void launchTunableGemmAndBias(cublasCommonArgs &args, const Scalar& alpha, const scalar_t* bias, cuda::blas::GEMMAndBiasActivationEpilogue activation) {
+bool launchTunableGemmAndBias(cublasCommonArgs &args, const Scalar& alpha, const scalar_t* bias, cuda::blas::GEMMAndBiasActivationEpilogue activation) {
   bool transa_ = ((args.transa != 'n') && (args.transa != 'N'));
   bool transb_ = ((args.transb != 'n') && (args.transb != 'N'));
   at::cuda::tunable::GemmAndBiasParams<scalar_t> params;
+  // Stamp the per-call dynamic-dims mask onto the params before invoking the
+  // TunableOp. The mask was pushed by inductor's autotune in INDUCTOR frame
+  // (M = mat1.size(0), N = mat2.size(1), K = mat1.size(1)). PyTorch's BLAS
+  // dispatch may swap inductor's (M, N) -> BLAS's (n, m) so cuBLAS can stay
+  // column-major (`cublasCommonArgs::swapped_mn`). When the swap happens,
+  // remap the mask so the dynamic bit lands on the BLAS dim that actually
+  // varies between calls; otherwise `DynamicSignature()` would put `*` in
+  // the wrong slot and runtime `LookupWildcardFallback` would never match.
+  {
+    auto raw_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+    if (args.swapped_mn) {
+      params.dynamic_dims_mask = at::cuda::tunable::DynamicDimsMask(
+          /*M=*/raw_mask.n(),
+          /*N=*/raw_mask.m(),
+          /*K=*/raw_mask.k(),
+          /*BATCH=*/raw_mask.batch());
+    } else {
+      params.dynamic_dims_mask = raw_mask;
+    }
+  }
   params.transa = args.transa;
   params.transb = args.transb;
   params.m = args.m;
@@ -248,21 +306,57 @@ void launchTunableGemmAndBias(cublasCommonArgs &args, const Scalar& alpha, const
   params.ldc = args.result_ld;
   params.bias = bias;
   params.activation = activation;
+
+  // Helper: returns true if `gemm` has a usable tuned entry (concrete or
+  // wildcard) for `params` and dispatched it; returns false on a pure miss
+  // when tuning is disabled, leaving the caller to fall back.
+  auto try_dispatch = [&](auto& gemm) -> bool {
+    auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+    auto& mgr = tuning_ctx->GetTuningResultsManager();
+    auto op_sig = gemm.Signature();
+    auto concrete_sig = params.Signature();
+    auto result = mgr.Lookup(op_sig, concrete_sig);
+    if (result == at::cuda::tunable::ResultEntry::Null()
+        && !tuning_ctx->IsTuningEnabled()) {
+      // Concrete miss + tuning disabled. Scan persisted wildcard
+      // entries via token-pattern matching against the concrete
+      // signature. This avoids relying on any caller-set dynamic
+      // mask -- the AOTI cpp_wrapper does not emit a
+      // TunableDynamicDimsGuard so `params.dynamic_dims_mask` may be
+      // empty here even when wildcard entries were persisted at
+      // compile-time tuning.
+      result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()) {
+        // Both concrete and wildcard missed -- skip the TunableOp dispatch
+        // entirely so we do not invoke the (potentially crashing) Default
+        // kernel. Caller (launchGemmAndBiasCublasLt) re-dispatches via
+        // launchGemmAndBiasNonTunable.
+        return false;
+      }
+    }
+    // Either we have a tuned entry (concrete or wildcard), or tuning is
+    // enabled and the standard operator() will run FindFastest and store a
+    // result. In all cases operator() dispatches to a real (tuned) kernel,
+    // never Default.
+    gemm(&params);
+    return true;
+  };
+
   if (transa_ && transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::T, at::cuda::tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (transa_ && !transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::T, at::cuda::tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::N, at::cuda::tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && !transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::N, at::cuda::tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else {
     TORCH_CHECK(false, "unreachable");
@@ -286,29 +380,24 @@ bool launchGemmAndBiasCublasLt(
 
   const auto tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
-    // TODO: maybe also return some success state?
-    launchTunableGemmAndBias<scalar_t>(
-      args, alpha, self_ptr, activation_to_gemm_and_blas_arg(activation)
-    );
-    return true;
+    if (launchTunableGemmAndBias<scalar_t>(
+            args, alpha, self_ptr, activation_to_gemm_and_blas_arg(activation))) {
+      return true;
+    }
+    // launchTunableGemmAndBias returned false: TunableOp is enabled but
+    // there is no tuned entry for this shape and tuning is disabled.
+    // Re-dispatch through launchGemmAndBiasNonTunable -- the exact same
+    // code path taken when TunableOp is disabled at the call site. We do
+    // NOT toggle the global TunableOp enable flag for this fallback,
+    // because that flag is non-atomic global state and would race with
+    // concurrent dispatches on other CPU threads (mts_gpu_benchmark uses
+    // num_threads > 1 in some configs).
+    return launchGemmAndBiasNonTunable<scalar_t, res_scalar_t>(
+        args, self_ptr, alpha, activation);
   }
 
-  return at::cuda::blas::gemm_and_bias<scalar_t, res_scalar_t>(
-    args.transa == 't',
-    args.transb == 't',
-    args.m,
-    args.n,
-    args.k,
-    alpha.to<at::opmath_type<scalar_t>>(),
-    args.mata->const_data_ptr<scalar_t>(),
-    args.lda,
-    args.matb->const_data_ptr<scalar_t>(),
-    args.ldb,
-    self_ptr,
-    args.result->data_ptr<res_scalar_t>(),
-    args.result_ld,
-    activation_to_gemm_and_blas_arg(activation)
-  );
+  return launchGemmAndBiasNonTunable<scalar_t, res_scalar_t>(
+      args, self_ptr, alpha, activation);
 }
 
 template <typename scalar_t, typename res_scalar_t = scalar_t>
@@ -318,6 +407,22 @@ bool launchGemmCublas(
     const Scalar& alpha,
     const Scalar& beta
 ) {
+  // Remap the inductor-frame dynamic-dims mask into BLAS frame when the
+  // dispatch swapped (M, N) -> (n, m), and push it for the duration of the
+  // gemm call so gemm_tunable (CUDABlas.cpp) stamps the correctly-framed mask
+  // onto its params. Mirrors the remap in launchTunableGemmAndBias; needed
+  // because at::cuda::blas::gemm's ABI does not carry swapped_mn. Only pushed
+  // when a dynamic mask is active AND the dispatch swapped, so the common
+  // (eager, non-dynamic) path is unaffected.
+  const auto raw_dyn_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+  std::optional<at::cuda::tunable::TunableDynamicDimsGuard> dyn_guard;
+  if (raw_dyn_mask.any() && args.swapped_mn) {
+    dyn_guard.emplace(at::cuda::tunable::DynamicDimsMask(
+        /*M=*/raw_dyn_mask.n(),
+        /*N=*/raw_dyn_mask.m(),
+        /*K=*/raw_dyn_mask.k(),
+        /*BATCH=*/raw_dyn_mask.batch()));
+  }
   at::cuda::blas::gemm<scalar_t, res_scalar_t>(
     args.transa,
     args.transb,
@@ -554,6 +659,22 @@ const Tensor& baddbmm_out_cuda_impl(const Tensor& result, const Tensor& self, co
 
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!result_->is_conj());
   bool is_float_output_with_half_input = (batch1.scalar_type() == at::ScalarType::Half || batch1.scalar_type() == at::ScalarType::BFloat16) && result.scalar_type() == at::ScalarType::Float;
+
+  // Remap the inductor-frame dynamic-dims mask into BLAS frame when the
+  // batched dispatch transposes the result (swapping M<->N), then push it for
+  // the duration of the (b)gemm call so (b)gemm_tunable stamps the correctly-
+  // framed mask. Mirrors launchTunableGemmAndBias; the batched dispatch
+  // carries no swapped_mn flag. Only pushed when a dynamic mask is active AND
+  // the result is transposed, leaving the common path untouched.
+  const auto raw_dyn_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+  std::optional<at::cuda::tunable::TunableDynamicDimsGuard> baddbmm_dyn_guard;
+  if (raw_dyn_mask.any() && transpose_result) {
+    baddbmm_dyn_guard.emplace(at::cuda::tunable::DynamicDimsMask(
+        /*M=*/raw_dyn_mask.n(),
+        /*N=*/raw_dyn_mask.m(),
+        /*K=*/raw_dyn_mask.k(),
+        /*BATCH=*/raw_dyn_mask.batch()));
+  }
 
   if (is_float_output_with_half_input) {
     AT_DISPATCH_REDUCED_FLOATING_TYPES(batch1.scalar_type(), "baddbmm_cuda", [&] {

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -316,6 +316,7 @@ bool launchTunableGemmAndBias(cublasCommonArgs &args, const Scalar& alpha, const
     auto op_sig = gemm.Signature();
     auto concrete_sig = params.Signature();
     auto result = mgr.Lookup(op_sig, concrete_sig);
+    bool via_wildcard = false;
     if (result == at::cuda::tunable::ResultEntry::Null()
         && !tuning_ctx->IsTuningEnabled()) {
       // Concrete miss + tuning disabled. Scan persisted wildcard
@@ -326,13 +327,18 @@ bool launchTunableGemmAndBias(cublasCommonArgs &args, const Scalar& alpha, const
       // empty here even when wildcard entries were persisted at
       // compile-time tuning.
       result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      via_wildcard = result != at::cuda::tunable::ResultEntry::Null();
       if (result == at::cuda::tunable::ResultEntry::Null()) {
         // Both concrete and wildcard missed -- skip the TunableOp dispatch
         // entirely so we do not invoke the (potentially crashing) Default
         // kernel. Caller (launchGemmAndBiasCublasLt) re-dispatches via
         // launchGemmAndBiasNonTunable.
+        at::cuda::tunable::RecordServingDispatch(false, false, op_sig, concrete_sig);
         return false;
       }
+    }
+    if (!tuning_ctx->IsTuningEnabled()) {
+      at::cuda::tunable::RecordServingDispatch(true, via_wildcard);
     }
     // Either we have a tuned entry (concrete or wildcard), or tuning is
     // enabled and the standard operator() will run FindFastest and store a

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -254,7 +254,7 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
   );
 }
 
-Tensor&
+bool
 _tunable_scaled_gemm_rocm(
           cublasCommonArgs& args,
           const Tensor& mat1, const Tensor& mat2,
@@ -265,19 +265,20 @@ _tunable_scaled_gemm_rocm(
           const at::ScalarType out_dtype,
           Tensor& out) {
 #ifdef USE_ROCM
+  bool dispatched = false;
 #define TUNABLE_DISPATCH(BLASOP_A, BLASOP_B)                            \
       if (mat1.scalar_type() == ScalarType::Float8_e4m3fnuz) {        \
         if (mat2.scalar_type() == ScalarType::Float8_e4m3fnuz) {      \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fnuz, at::Float8_e4m3fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2fnuz) { \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fnuz, at::Float8_e5m2fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }                                                               \
       else if (mat1.scalar_type() == ScalarType::Float8_e5m2fnuz) {   \
@@ -285,13 +286,13 @@ _tunable_scaled_gemm_rocm(
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2fnuz, at::Float8_e4m3fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2fnuz) { \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2fnuz, at::Float8_e5m2fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }                                                               \
       else if (mat1.scalar_type() == ScalarType::Float8_e4m3fn) {     \
@@ -299,13 +300,13 @@ _tunable_scaled_gemm_rocm(
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fn, at::Float8_e4m3fn, scalar_t,         \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2) {     \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fn, at::Float8_e5m2, scalar_t,           \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }                                                               \
       else if (mat1.scalar_type() == ScalarType::Float8_e5m2) {       \
@@ -313,19 +314,41 @@ _tunable_scaled_gemm_rocm(
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2, at::Float8_e4m3fn, scalar_t,           \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2) {     \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2, at::Float8_e5m2, scalar_t,             \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }
   AT_DISPATCH_V2(out_dtype, "_tunable_scaled_gemm", AT_WRAP([&] {
     bool transa_ = ((args.transa != 'n') && (args.transa != 'N'));
     bool transb_ = ((args.transb != 'n') && (args.transb != 'N'));
     at::cuda::tunable::ScaledGemmParams<scalar_t> params;
+    // Stamp per-call dynamic-dims mask before invoking the TunableOp.
+    // The mask was pushed by inductor's autotune in INDUCTOR frame
+    // (M = mat1.size(0), N = mat2.size(1), K = mat1.size(1)). PyTorch's
+    // BLAS dispatch may swap inductor's (M, N) -> BLAS's (n, m) so cuBLAS
+    // can stay column-major. When the swap happens (`cublasCommonArgs::
+    // swapped_mn`), remap the bits so the dynamic flag lands on the
+    // BLAS dim that actually varies between calls; otherwise
+    // `DynamicSignature()` would put `*` in the wrong slot and runtime
+    // `LookupWildcardFallback` would never match. Same logic as
+    // `launchTunableGemmAndBias` in Blas.cpp.
+    {
+      auto raw_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+      if (args.swapped_mn) {
+        params.dynamic_dims_mask = at::cuda::tunable::DynamicDimsMask(
+            /*M=*/raw_mask.n(),
+            /*N=*/raw_mask.m(),
+            /*K=*/raw_mask.k(),
+            /*BATCH=*/raw_mask.batch());
+      } else {
+        params.dynamic_dims_mask = raw_mask;
+      }
+    }
     params.transa = args.transa;
     params.transb = args.transb;
     params.m = args.m;
@@ -352,6 +375,27 @@ _tunable_scaled_gemm_rocm(
     params.ldc = args.result_ld;
     params.c_dtype = out_dtype;
     params.use_fast_accum = use_fast_accum;
+    // Gate dispatch to match the addmm path (launchTunableGemmAndBias): on a
+    // concrete miss with tuning disabled, scan persisted wildcard entries;
+    // on a total miss return false so the caller (_scaled_gemm) re-dispatches
+    // the non-tunable at::cuda::blas::scaled_gemm instead of the (potentially
+    // crashing) Default kernel.
+    auto try_scaled_dispatch = [&](auto& scaledgemm) -> bool {
+      auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+      auto& mgr = tuning_ctx->GetTuningResultsManager();
+      auto op_sig = scaledgemm.Signature();
+      auto concrete_sig = params.Signature();
+      auto result = mgr.Lookup(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()
+          && !tuning_ctx->IsTuningEnabled()) {
+        result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+        if (result == at::cuda::tunable::ResultEntry::Null()) {
+          return false;
+        }
+      }
+      scaledgemm(&params);
+      return true;
+    };
     if (transa_ && transb_) {
       TUNABLE_DISPATCH(at::cuda::tunable::BlasOp::T, at::cuda::tunable::BlasOp::T)
     }
@@ -370,7 +414,7 @@ _tunable_scaled_gemm_rocm(
   }),
   kHalf, kBFloat16, AT_EXPAND(AT_FLOAT8_TYPES), AT_EXPAND(AT_FLOATING_TYPES));
 #undef TUNABLE_DISPATCH
-  return out;
+  return dispatched;
 #else
   TORCH_CHECK_NOT_IMPLEMENTED(false, "_scaled_gemm_rocm only callable on ROCM devices");
 #endif
@@ -409,18 +453,23 @@ _scaled_gemm(
   bool tunable_op_enabled = false;
 #endif
   if (tunable_op_enabled) {
-      // Only available on ROCM
-      return _tunable_scaled_gemm_rocm(
-          args,
-          mat1, mat2,
-          scale_a, scale_b,
-          scaling_choice_a, scaling_choice_b,
-          bias,
-          use_fast_accum,
-          out_dtype_,
-          out);
+      // Only available on ROCM. Returns false when TunableOp is enabled but
+      // there is no tuned entry (concrete or wildcard) and tuning is disabled;
+      // in that case fall through to the non-tunable scaled_gemm below rather
+      // than invoking the Default kernel. Matches the addmm fallback in
+      // launchGemmAndBiasCublasLt.
+      if (_tunable_scaled_gemm_rocm(
+              args,
+              mat1, mat2,
+              scale_a, scale_b,
+              scaling_choice_a, scaling_choice_b,
+              bias,
+              use_fast_accum,
+              out_dtype_,
+              out)) {
+        return out;
+      }
   }
-  else
   {
       at::cuda::blas::scaled_gemm(
           args.transa,

--- a/aten/src/ATen/native/cuda/cuBlasCommonArgs.h
+++ b/aten/src/ATen/native/cuda/cuBlasCommonArgs.h
@@ -142,6 +142,13 @@ struct cublasCommonArgs {
     transa = transpose_a ? mata->is_conj() ? 'c' : 't' : 'n';
     transb = transpose_b ? matb->is_conj() ? 'c' : 't' : 'n';
 
+    // Record whether PyTorch's BLAS dispatch swapped inductor's
+    // (M, N) -> (n, m) when computing C^T = B^T @ A^T in column-major
+    // cuBLAS. Consumers that need to translate an inductor-frame
+    // dynamic-dims mask (e.g. TunableOp wildcard signatures) into the
+    // BLAS frame read this flag and swap the M and N bits when set.
+    swapped_mn = transpose_result;
+
     // cuBLAS expects unpacked values of `k`, `lda` and `ldb`, adjust for 4x2 packing
     // if the gemm operands are in packed float4
     if (mat1.dtype() == at::kFloat4_e2m1fn_x2 && mat2.dtype() == at::kFloat4_e2m1fn_x2) {
@@ -156,6 +163,11 @@ struct cublasCommonArgs {
   int64_t m, n, k;
   int64_t lda, ldb, result_ld;
   c10::MaybeOwned<Tensor> mata, matb, result;
+  // True iff PyTorch's BLAS dispatch swapped inductor's (M, N) into
+  // BLAS's (n, m). Used by TunableOp consumers to translate a dynamic
+  // -dims mask captured in inductor frame into the BLAS frame stamped
+  // onto `params.dynamic_dims_mask`.
+  bool swapped_mn = false;
 
   // Scale members
   void* scale_mata_ptr = nullptr;

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -126,6 +126,80 @@ class TestAlgorithmSelectorChoiceTypes(TestCase):
         self.assertEqual(out.expr, sympy.Integer(2048))
 
 
+class TestPerChoiceInputs(TestCase):
+    class FakeNode:
+        def __init__(self, name, size, stride):
+            self.name = name
+            self.size = size
+            self.stride = stride
+
+        def get_name(self):
+            return self.name
+
+        def get_size(self):
+            return self.size
+
+        def get_stride(self):
+            return self.stride
+
+        def get_dtype(self):
+            return torch.bfloat16
+
+        def get_device(self):
+            return "cuda"
+
+    class FakeChoice:
+        def __init__(self, name, input_nodes):
+            self.name = name
+            self.input_nodes = input_nodes
+
+    def test_divergent_extern_materializes_only_its_own_choice(self):
+        global_nodes = [self.FakeNode("bias_2d", (32, 64), (0, 1))]
+        first = self.FakeChoice(
+            "addmm", [self.FakeNode("bias_1d", (64,), (1,))]
+        )
+        second = self.FakeChoice(
+            "other_extern", [self.FakeNode("other_bias", (32,), (1,))]
+        )
+        template = self.FakeChoice("triton", global_nodes)
+        calls = []
+
+        def materialize(
+            _cls,
+            choices,
+            input_nodes,
+            _layout,
+            _input_gen_fns,
+            _hint_override=None,
+        ):
+            calls.append((list(input_nodes), list(choices)))
+            inputs = [torch.empty(0) for _ in input_nodes]
+            return inputs, inputs, torch.empty(0), torch.empty(0)
+
+        with patch.object(
+            select_algorithm.AlgorithmSelectorCache,
+            "_materialize_inputs",
+            classmethod(materialize),
+        ), patch.object(
+            select_algorithm.AlgorithmSelectorCache,
+            "_is_extern",
+            staticmethod(lambda choice: choice in (first, second)),
+        ), patch.object(select_algorithm, "VERIFY", {}):
+            result = select_algorithm.AlgorithmSelectorCache.get_inputs(
+                choices=[first, second, template],
+                input_nodes=global_nodes,
+                layout=None,
+                input_gen_fns=None,
+            )
+
+        self.assertEqual(calls[0][1], [first, second, template])
+        self.assertEqual(calls[1][1], [first])
+        self.assertEqual(calls[2][1], [second])
+        self.assertIn(id(first), result.per_choice)
+        self.assertIn(id(second), result.per_choice)
+        self.assertNotIn(id(template), result.per_choice)
+
+
 class TestSelectAlgorithm(TestCase):
     def setUp(self):
         super().setUp()

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -10140,7 +10140,6 @@ class TestLinalgCudaOnly(TestCase):
             fastest_time = min(info["timings"].values())
             self.assertEqual(winner_time, fastest_time, (key, info))
 
-    @skipIfRocm
     @dtypes(torch.half)
     def test_invalid_cublaslt_candidate_fallback_tunableop(self, device, dtype):
         with self._tunableop_ctx():
@@ -10159,8 +10158,11 @@ class TestLinalgCudaOnly(TestCase):
 
             A = torch.randn(128, 256, device=device, dtype=dtype)
             B = torch.randn(256, 96, device=device, dtype=dtype)
-            C = torch.matmul(A, B)
-            self.assertEqual(C.shape, (128, 96))
+            torch.cuda.tunable.enable(False)
+            expected = torch.matmul(A, B)
+            torch.cuda.tunable.enable(True)
+            actual = torch.matmul(A, B)
+            torch.testing.assert_close(actual, expected)
 
     @skipIfRocm
     @dtypes(torch.half)

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -392,7 +392,17 @@ class InductorChoices:
                 if hasattr(ktc, "_choice"):
                     del ktc._choice
         # Third pass: Convert to ChoiceCaller objects
-        return [ktc.choice for ktc in adjusted_choices if ktc.choice is not None]
+        callers = [ktc.choice for ktc in adjusted_choices if ktc.choice is not None]
+
+        # All-False is a no-op, but keep it explicit on the caller.
+        try:
+            mask = kernel_inputs.dynamic_dim_mask(op_name)
+        except Exception:  # noqa: BLE001
+            mask = (False, False, False, False)
+        for caller in callers:
+            caller.tunable_dyn_dims_mask = mask
+
+        return callers
 
     def triton_kernel_kwargs(
         self,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2035,6 +2035,25 @@ class triton:
     # max autotune gemm with cublasLt
     autotune_cublasLt = True
 
+
+    # When True, the inductor autotune harness pushes a per-op
+    # `torch.cuda.tunable.dynamic_dims_mask` whenever a GEMM input dim
+    # is symbolic (sympy free-symbol). The mask is read by the C++
+    # producer (`launchTunableGemmAndBias`, `launchTunableScaledGemm`,
+    # `bgemm_tunable`), translated to BLAS frame via
+    # `cublasCommonArgs::swapped_mn`, and stamped onto
+    # `params.dynamic_dims_mask`. With a non-empty mask,
+    # `TunableOp::operator()` persists BOTH the concrete and the
+    # wildcard kernel-map entries (cases 2/4 of the dispatch matrix);
+    # at runtime, `LookupWildcardFallback` lets concrete-miss queries
+    # dispatch via the wildcard entry.
+    #
+    # Set to False to stop producing new wildcard entries. Existing wildcard
+    # rows in a loaded persistence file can still satisfy runtime lookups.
+    #
+    # The runtime scan is a no-op when no wildcards exist in the file.
+    autotune_tunableop_dynamic_dims_wildcard: bool = False
+
     # Tune the generated Triton kernels at compile time instead of first time they run
     # Setting to None means uninitialized
     autotune_at_compile_time: bool | None = autotune_at_compile_time_default()

--- a/torch/_inductor/kernel_inputs.py
+++ b/torch/_inductor/kernel_inputs.py
@@ -5,7 +5,9 @@ from typing import Any, TYPE_CHECKING
 
 import torch
 import torch._inductor.config
+from torch._inductor import config as inductor_config
 from torch._inductor import ir
+from torch._inductor.utils import has_free_symbols
 from torch._inductor.virtualized import V
 
 from .ir import FixedLayout, FlexibleLayout, Layout
@@ -115,6 +117,96 @@ class KernelInputs(ABC):
             A tuple of shape tuples for each input node
         """
         return tuple(node.get_size() for node in self._input_nodes)
+
+    def _mnk_operand_shapes(
+        self,
+    ) -> tuple[tuple[Any, ...], tuple[Any, ...]] | None:
+        """
+        Return the (mat1_shape, mat2_shape) used for GEMM dim-dynamism
+        analysis in `dynamic_dim_mask`.
+
+        The base implementation assumes the GEMM operands are the trailing
+        two inputs. Subclasses that track explicit operand positions (see
+        MMKernelInputs.mat1_idx / mat2_idx) override this so the mask is
+        derived from the real operands -- which matters for scaled GEMM,
+        where the trailing inputs are scale/bias tensors.
+
+        Returns None when there are fewer than two inputs.
+        """
+        shapes = self.shapes_symbolic()
+        if len(shapes) < 2:
+            return None
+        return shapes[-2], shapes[-1]
+
+    def dynamic_dim_mask(self, op_name: str) -> tuple[bool, bool, bool, bool]:
+        """
+        Derive a per-call (dyn_m, dyn_n, dyn_k, dyn_batch) mask describing
+        which logical GEMM dims are dynamic (SymInt) for this op invocation.
+
+        The autotune path pushes this mask so TunableOp persists wildcard keys
+        that runtime lookup can reuse.
+
+        Operands are selected via `_mnk_operand_shapes()` so subclasses that
+        track explicit operand positions (see MMKernelInputs) read the true
+        mat1/mat2 shapes rather than the trailing two inputs.
+
+        Mask derivation rules:
+        - mm / addmm / scaled_mm:
+            (M, K) = mat1.shape, (K, N) = mat2.shape
+            dyn_m = is_symbolic(M); dyn_k = is_symbolic(K); dyn_n = is_symbolic(N);
+            dyn_batch = False
+        - bmm / baddbmm:
+            (B, M, K) = mat1.shape, (B, K, N) = mat2.shape
+            dyn_batch = is_symbolic(B); others as above
+
+        For unrecognized op_names we return all-zero (no wildcarding) so the
+        caller falls back to the legacy concrete-only behavior.
+        """
+        # Feature disabled: persist concrete signatures for new tuning entries.
+        if not getattr(
+            inductor_config.triton,
+            "autotune_tunableop_dynamic_dims_wildcard",
+            True,
+        ):
+            return (False, False, False, False)
+
+        # IR dimensions may be symbolic sympy expressions.
+        def _dyn(d: Any) -> bool:
+            return has_free_symbols((d,))
+
+        # Operands come from the subclass-aware selector so that kernels
+        # whose GEMM operands are not the trailing two inputs (e.g. scaled
+        # GEMM, where the trailing inputs are scale/bias tensors) still read
+        # the true mat1/mat2 shapes.
+        operand_shapes = self._mnk_operand_shapes()
+        if operand_shapes is None:
+            return (False, False, False, False)
+        mat1_shape, mat2_shape = operand_shapes
+
+        # bmm / baddbmm: both operands carry a leading batch dim.
+        if op_name in ("bmm", "baddbmm") and len(mat1_shape) >= 3 and len(mat2_shape) >= 3:
+            b1, m, k1 = mat1_shape[-3], mat1_shape[-2], mat1_shape[-1]
+            b2, k2, n = mat2_shape[-3], mat2_shape[-2], mat2_shape[-1]
+            dyn_batch = _dyn(b1) or _dyn(b2)
+            dyn_m = _dyn(m)
+            dyn_k = _dyn(k1) or _dyn(k2)
+            dyn_n = _dyn(n)
+            return (dyn_m, dyn_n, dyn_k, dyn_batch)
+
+        # mm / addmm / scaled_mm: 2D matmul, no batch axis.
+        if (
+            op_name in ("mm", "addmm", "scaled_mm", "_scaled_mm")
+            and len(mat1_shape) >= 2
+            and len(mat2_shape) >= 2
+        ):
+            m, k1 = mat1_shape[-2], mat1_shape[-1]
+            k2, n = mat2_shape[-2], mat2_shape[-1]
+            dyn_m = _dyn(m)
+            dyn_k = _dyn(k1) or _dyn(k2)
+            dyn_n = _dyn(n)
+            return (dyn_m, dyn_n, dyn_k, False)
+
+        return (False, False, False, False)
 
     def shapes_hinted(self) -> tuple[tuple[int, ...], ...]:
         """
@@ -312,6 +404,22 @@ class MMKernelInputs(KernelInputs):
         """
         nodes = self.nodes()
         return nodes[self._mat1_idx], nodes[self._mat2_idx]
+
+    def _mnk_operand_shapes(
+        self,
+    ) -> tuple[tuple[Any, ...], tuple[Any, ...]] | None:
+        """
+        Select the GEMM operand shapes using the explicit mat1_idx / mat2_idx
+        positions instead of the trailing two inputs.
+
+        This is required for callsites where the operands are not the last two
+        inputs -- e.g. scaled GEMM, whose inputs are
+        [mat_a, mat_b, scale_a, scale_b, (bias)] with mat1_idx=0, mat2_idx=1.
+        Reading the trailing inputs there would derive the mask from the
+        scale/bias tensors rather than the true M/N/K operands.
+        """
+        shapes = self.shapes_symbolic()
+        return shapes[self._mat1_idx], shapes[self._mat2_idx]
 
     def mnk_hinted(self) -> tuple[int, int, int]:
         """

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -141,20 +141,43 @@ class BenchmarkTensors:
 
 @dataclasses.dataclass
 class AutotuneArgs:
-    """During autotuning, we need to pass the same inputs to all choices.
+    """Inputs used during autotuning.
+
     Note:
         Since we typically have a mix of external choices and triton choices, we create
         two lists of inputs for the same underlying buffers:
         - External inputs (for aten kernels): Include offset for sliced tensors
         - Triton inputs: Use base pointer for sliced tensors, without offset
+
+    Per-choice override:
+        Extern choices may need tensors materialized from their own bound
+        input nodes, not the shared autotune inputs. Those overrides are keyed
+        by ``id(choice)``.
     """
 
     triton: BenchmarkTensors
     extern: BenchmarkTensors
     expected: torch.Tensor | None = None
+    # Per-choice override keyed by id(choice).
+    per_choice: dict[int, BenchmarkTensors] = dataclasses.field(default_factory=dict)
 
-    def get_benchmark_tensors(self, extern=False) -> BenchmarkTensors:
-        """Returns the inputs and output tensors for a given choice."""
+    def get_benchmark_tensors(
+        self,
+        extern: bool = False,
+        choice: ChoiceCaller | None = None,
+    ) -> BenchmarkTensors:
+        """Returns the inputs and output tensors for a given choice.
+
+        If ``choice`` is provided and has a per-choice override registered,
+        return that override instead of the shared ``triton``/``extern``
+        bundle. This allows different choices in the same autotune call to
+        be benchmarked with input tensors derived from their own bound
+        ``input_nodes``.
+        """
+        if choice is not None:
+            override = self.per_choice.get(id(choice))
+            if override is not None:
+                return override
         bench_tensors = self.extern if extern else self.triton
         return bench_tensors
 
@@ -166,12 +189,14 @@ class AutotuneArgs:
         out: torch.Tensor,
         out_extern: torch.Tensor,
         expected: torch.Tensor | None = None,
+        per_choice: dict[int, BenchmarkTensors] | None = None,
     ) -> Self:
         """Factory method to create AutotuneInputs from separate inputs/outputs"""
         return cls(
             triton=BenchmarkTensors(example_inputs, out),
             extern=BenchmarkTensors(example_inputs_extern, out_extern),
             expected=expected,
+            per_choice=per_choice or {},
         )
 
     def verify(self, **kwargs):
@@ -3528,6 +3553,12 @@ class ExternKernelCaller(ChoiceCaller):
             raise AssertionError("self.bmreq must not be None")
         # pyrefly: ignore[missing-attribute]
         self.bmreq.benchmark_with_cudagraphs = self._benchmark_with_cudagraphs
+        mask = getattr(self, "tunable_dyn_dims_mask", None)
+        if mask is not None and any(mask):
+            with torch.cuda.tunable.dynamic_dims_mask(
+                M=mask[0], N=mask[1], K=mask[2], BATCH=mask[3]
+            ):
+                return self.bmreq.benchmark(*args, out=out)
         return self.bmreq.benchmark(*args, out=out)
 
     def benchmark_collective(self, *args, out):
@@ -4933,10 +4964,138 @@ class AlgorithmSelectorCache(PersistentCache):
     ) -> AutotuneArgs:
         """
         Factory method to create AutotuneArgs from a list of ChoiceCallers.
+
+        Materializes a global ``triton``/``extern`` bundle from the provided
+        ``input_nodes`` (back-compat path), then for any choice whose bound
+        ``input_nodes`` diverge from the global ``input_nodes`` (different
+        size / stride / dtype / device of any positional input) materializes
+        a per-choice ``BenchmarkTensors`` and registers it in
+        ``AutotuneArgs.per_choice``. Identical per-choice layouts are
+        deduplicated via a layout key cache so we only allocate once per
+        unique layout.
+
+        This unblocks lowerings that pass differently-shaped IR nodes for
+        different choices (e.g., addmm passing a 1D bias to ``aten_addmm``
+        but a 2D-expanded bias to Triton/CUTLASS templates) without the
+        autotune harness force-materializing the global layout for every
+        choice.
         """
         if input_gen_fns is None:
             input_gen_fns = {}
 
+        example_inputs, example_inputs_extern, out, out_extern = (
+            cls._materialize_inputs(
+                choices, input_nodes, layout, input_gen_fns, hint_override
+            )
+        )
+
+        # Per-choice materialization. Only consider extern-style choices --
+        # template (Triton/CUTLASS/CK/CppGemm) choices share a single
+        # generated kernel signature with the global input_nodes layout, so
+        # giving them per-choice tensors would mismatch the kernel's
+        # compile-time shape constants.
+        global_key = cls._node_layout_key(input_nodes)
+        per_choice: dict[int, BenchmarkTensors] = {}
+        # Cache: layout_key -> BenchmarkTensors. Includes the global key so
+        # choices whose layout matches global don't get a redundant entry.
+        layout_cache: dict[str, BenchmarkTensors] = {
+            global_key: BenchmarkTensors(example_inputs_extern, out_extern),
+        }
+        for choice in choices:
+            if not cls._is_extern(choice):
+                continue
+            choice_nodes = getattr(choice, "input_nodes", None)
+            if not choice_nodes:
+                continue
+            try:
+                ckey = cls._node_layout_key(choice_nodes)
+            except Exception:
+                # Defensive: if we can't compute the layout key (e.g. a
+                # choice's input_nodes contain something with no get_size),
+                # fall back to the global bundle for this choice.
+                continue
+            if ckey == global_key:
+                continue
+            if ckey not in layout_cache:
+                _, ch_extern, _, ch_out = cls._materialize_inputs(
+                    (choice,), choice_nodes, layout, input_gen_fns, hint_override
+                )
+                layout_cache[ckey] = BenchmarkTensors(ch_extern, ch_out)
+                log.info(
+                    "[per_choice_inputs] registered override for choice=%s "
+                    "(extern=%s); global_key=%s choice_key=%s; "
+                    "bundle bias.size=%s bias.stride=%s",
+                    getattr(choice, "name", type(choice).__name__),
+                    type(choice).__name__,
+                    global_key,
+                    ckey,
+                    tuple(ch_extern[0].size()) if ch_extern else None,
+                    tuple(ch_extern[0].stride()) if ch_extern else None,
+                )
+            per_choice[id(choice)] = layout_cache[ckey]
+
+        expected = None
+        if VERIFY:
+            # Run the verification call on the per-choice bundle for
+            # choices[0] if it has one, else on the global extern bundle.
+            verify_inputs = example_inputs_extern
+            verify_out = out_extern
+            override = per_choice.get(id(choices[0])) if choices else None
+            if override is not None:
+                verify_inputs = override.input_tensors
+                verify_out = override.output_tensor  # type: ignore[assignment]
+            choices[0].benchmark(*verify_inputs, out=verify_out)
+            expected = verify_out.clone()  # type: ignore[union-attr]
+
+        return AutotuneArgs.from_choice_args(
+            example_inputs,
+            example_inputs_extern,
+            out,
+            out_extern,
+            expected,
+            per_choice=per_choice,
+        )
+
+    @classmethod
+    def _node_layout_key(cls, nodes: Sequence[ir.IRNode]) -> str:
+        """Stable, hashable key describing the layout (size+stride+dtype+
+        device) of every node in ``nodes``. Used to dedup per-choice
+        materializations across choices that bind structurally identical
+        input lists.
+        """
+        parts: list[Any] = []
+        for n in nodes:
+            try:
+                size = tuple(n.get_size())
+                stride = tuple(n.get_stride())
+                dtype = str(n.get_dtype())
+                device = str(n.get_device())
+            except Exception:
+                # If a node doesn't expose layout info (rare), fall back to
+                # its name -- this still gives stable per-choice grouping.
+                size = stride = ()
+                dtype = device = ""
+            parts.append((size, stride, dtype, device, n.get_name()))
+        return repr(parts)
+
+    @classmethod
+    def _materialize_inputs(
+        cls,
+        choices: Sequence[ChoiceCaller],
+        input_nodes: list[ir.IRNode],
+        layout: ir.Layout,
+        input_gen_fns: dict[int, Callable[[ir.Buffer], torch.Tensor]],
+        hint_override: int | None = None,
+    ) -> tuple[
+        list[torch.Tensor], list[torch.Tensor], torch.Tensor, torch.Tensor
+    ]:
+        """Materialize example tensors for a given list of input nodes.
+
+        Returns (triton_inputs, extern_inputs, triton_out, extern_out). This
+        is the body of the previous monolithic ``get_inputs``, factored out
+        so it can be called multiple times -- once for the global
+        ``input_nodes`` and again per divergent choice.
+        """
         # de-duplicate args
         unique_example_inputs = {
             x.get_name(): input_gen_fns.get(
@@ -5080,18 +5239,7 @@ class AlgorithmSelectorCache(PersistentCache):
             )
 
         out_extern = torch.as_strided(out_base, out.size(), out.stride(), out_offset)
-        expected = None
-        if VERIFY:
-            choices[0].benchmark(*example_inputs_extern, out=out_extern)
-            expected = out_extern.clone()
-
-        return AutotuneArgs.from_choice_args(
-            example_inputs,
-            example_inputs_extern,
-            out,
-            out_extern,
-            expected,
-        )
+        return example_inputs, example_inputs_extern, out, out_extern
 
     @staticmethod
     def _is_extern(choice: ChoiceCaller) -> bool:
@@ -5101,7 +5249,31 @@ class AlgorithmSelectorCache(PersistentCache):
     def benchmark_choice(
         cls, choice: ChoiceCaller, autotune_args: AutotuneArgs
     ) -> float:
-        benchmark_tensors = autotune_args.get_benchmark_tensors(cls._is_extern(choice))
+        # Pass `choice` so AutotuneArgs can return a per-choice override
+        # bundle when one was registered (Option 2 / per-choice benchmark
+        # inputs). Choices without an override fall through to the shared
+        # extern/triton bundles.
+        benchmark_tensors = autotune_args.get_benchmark_tensors(
+            extern=cls._is_extern(choice), choice=choice
+        )
+        # Diagnostic: announce which bundle this choice is benchmarking
+        # against. Useful to confirm at a JIT-inductor `torch.compile` log
+        # level whether `aten_addmm` is consuming a per-choice (1D bias)
+        # override or the shared `extern` (2D-expanded bias) bundle.
+        used_per_choice = id(choice) in autotune_args.per_choice
+        log.info(
+            "[per_choice_inputs] benchmark_choice name=%s extern=%s "
+            "used_per_choice_override=%s bias.size=%s bias.stride=%s",
+            getattr(choice, "name", type(choice).__name__),
+            cls._is_extern(choice),
+            used_per_choice,
+            tuple(benchmark_tensors.input_tensors[0].size())
+            if benchmark_tensors.input_tensors
+            else None,
+            tuple(benchmark_tensors.input_tensors[0].stride())
+            if benchmark_tensors.input_tensors
+            else None,
+        )
         inputs, output = benchmark_tensors.unpack()
         output.zero_()
         try:

--- a/torch/_inductor/tests/test_dynamic_tunable_ops.py
+++ b/torch/_inductor/tests/test_dynamic_tunable_ops.py
@@ -1,0 +1,1704 @@
+"""Test suite for the dynamic TunableOp dispatch matrix.
+
+Exercises every branch of the design:
+
+Tuning enabled (compile-time autotune)
+  1. no dynamic dim + concrete key miss  -> tune; persist concrete key only
+  2. has dynamic dim + concrete key miss -> tune; persist concrete + wildcard
+  3. no dynamic dim + concrete key hit   -> nothing new persisted
+  4. has dynamic dim + concrete key hit  -> persist wildcard if missing
+
+Tuning disabled (runtime)
+  Runtime callers (notably the AOTI cpp_wrapper) cannot know which
+  dim is dynamic: no `TunableDynamicDimsGuard` is emitted, so
+  `GetCurrentDynamicDimsMask()` is always empty.
+
+  1. concrete key hit                       -> dispatch via concrete
+  2. concrete miss + wildcard match         -> dispatch via wildcard
+                                               (TuningResultsManager::
+                                               LookupWildcardFallback scans
+                                               persisted wildcard entries
+                                               token-by-token against the
+                                               concrete signature)
+  3. concrete miss + no wildcard match      -> result stays Null;
+                                               caller (e.g.
+                                               launchTunableGemmAndBias)
+                                               falls back to the
+                                               non-tunable aten path
+                                               (no Default kernel invoked,
+                                               no entries added)
+
+Covered (every variant is verified for all three runtime dispatch outcomes --
+concrete hit, concrete miss + wildcard fallback, and concrete miss + no
+wildcard -> safe non-tunable aten fallback -- matching the addmm reference
+launchTunableGemmAndBias):
+  - GemmAndBiasTunableOp via torch.addmm
+  - GemmTunableOp via torch.mm
+  - GemmStridedBatchedTunableOp via torch.bmm and torch.baddbmm
+  - ScaledGemmTunableOp via torch._scaled_mm (incl. the safe-aten fallback on
+    a total miss -- the ResultEntry::Default() kernel is never invoked)
+  - several mm layout combinations: NN/NT/TN/TT (exercising the swapped_mn
+    M<->N mask remap)
+
+All non-scaled entry points (mm/bmm/baddbmm) route through gemm_tunable /
+bgemm_tunable in CUDABlas.cpp, which now (a) resolve a concrete miss via
+TuningResultsManager::LookupWildcardFallback and (b) receive the inductor-frame
+mask already remapped into BLAS frame (by launchGemmCublas /
+baddbmm_out_cuda_impl in Blas.cpp) when the dispatch swaps M<->N -- exactly as
+launchTunableGemmAndBias does for addmm. The scaled path (_tunable_scaled_gemm_
+rocm in ScaledBlas.cpp) applies the same remap and now gates dispatch so a
+total miss falls back to at::cuda::blas::scaled_gemm.
+
+Not fully covered:
+  - addbmm or other higher-level batched add variants, if routed differently
+  - scaled GEMM variants beyond the FP8 tensorwise _scaled_mm shape
+"""
+
+# pyre-strict
+
+import logging
+import os
+import tempfile
+import unittest
+
+import sympy
+
+import torch
+import torch.cuda.tunable
+from torch._inductor import config as inductor_config
+from torch._inductor.kernel_inputs import MMKernelInputs
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+DEVICE: str = "cuda"
+DTYPE: torch.dtype = torch.bfloat16
+
+
+def _addmm(
+    m: int, n: int, k: int, seed: int = 0
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build (bias, mat1, mat2) for an addmm of shape (m, n, k)."""
+    torch.manual_seed(seed)
+    bias = torch.randn(n, dtype=DTYPE, device=DEVICE)
+    mat1 = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+    mat2 = torch.randn(k, n, dtype=DTYPE, device=DEVICE)
+    return bias, mat1, mat2
+
+
+def _mm(m: int, n: int, k: int, seed: int = 0) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build (mat1, mat2) for a plain mm of shape (m, n, k)."""
+    torch.manual_seed(seed)
+    mat1 = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+    mat2 = torch.randn(k, n, dtype=DTYPE, device=DEVICE)
+    return mat1, mat2
+
+
+def _bmm(
+    b: int, m: int, n: int, k: int, seed: int = 0
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build (batch1, batch2) for a bmm of shape (b, m, n, k)."""
+    torch.manual_seed(seed)
+    batch1 = torch.randn(b, m, k, dtype=DTYPE, device=DEVICE)
+    batch2 = torch.randn(b, k, n, dtype=DTYPE, device=DEVICE)
+    return batch1, batch2
+
+
+def _baddbmm(
+    b: int, m: int, n: int, k: int, seed: int = 0
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build (bias, batch1, batch2) for a baddbmm of shape (b, m, n, k)."""
+    torch.manual_seed(seed)
+    bias = torch.randn(b, m, n, dtype=DTYPE, device=DEVICE)
+    batch1 = torch.randn(b, m, k, dtype=DTYPE, device=DEVICE)
+    batch2 = torch.randn(b, k, n, dtype=DTYPE, device=DEVICE)
+    return bias, batch1, batch2
+
+
+def _entries_for(op_substr: str, *required_dim_tokens: str) -> list:
+    """Filter `torch.cuda.tunable.get_results()` to entries whose
+    op-signature contains `op_substr` AND whose params-signature contains
+    every requested `_<token>_` substring.
+
+    The dim tokens are matched as `_<token>_` against `_<params_sig>_`, so
+    callers do not have to know the cuBLAS-vs-PyTorch column-major /
+    row-major dim ordering -- they just supply the integer dims that must
+    appear somewhere in the params signature."""
+    out = []
+    for entry in torch.cuda.tunable.get_results():
+        # Each entry is a 4-tuple: (op_signature, params_signature, key, time).
+        op_sig, params_sig, _, _ = entry
+        if op_substr not in op_sig:
+            continue
+        padded = "_" + params_sig + "_"
+        if all(f"_{tok}_" in padded for tok in required_dim_tokens):
+            out.append(entry)
+    return out
+
+
+def _has_concrete_entry(op_substr: str, m: int, n: int, k: int) -> bool:
+    """True if get_results() has an entry whose params_sig contains every
+    one of (m, n, k) as `_N_` substrings AND no `*` wildcard token."""
+    for entry in _entries_for(op_substr, str(m), str(n), str(k)):
+        if "*" not in entry[1]:
+            return True
+    return False
+
+
+def _has_wildcard_entry(op_substr: str) -> bool:
+    """True if get_results() has any wildcard (asterisk-bearing) entry for
+    the given op."""
+    for entry in torch.cuda.tunable.get_results():
+        op_sig, params_sig, _, _ = entry
+        if op_substr in op_sig and "*" in params_sig:
+            return True
+    return False
+
+
+def _has_wildcard_with_dims(op_substr: str, *dims: int) -> bool:
+    """True if get_results() has a wildcard entry whose params_sig contains
+    every one of `dims` as `_N_` substrings."""
+    for entry in torch.cuda.tunable.get_results():
+        op_sig, params_sig, _, _ = entry
+        if op_substr not in op_sig or "*" not in params_sig:
+            continue
+        padded = "_" + params_sig + "_"
+        if all(f"_{d}_" in padded for d in dims):
+            return True
+    return False
+
+
+# Positions of (lda, ldb, ldc) tokens right after the "_ld_" marker.
+_LD_MARKER = "_ld_"
+
+
+def _parse_gemm_params_sig(
+    params_sig: str,
+) -> tuple[str, str, str, str, str, str, str, str]:
+    """Split a Gemm*Params signature into its component tokens.
+
+    Handles all variants -- GemmParams / GemmAndBiasParams
+    (``{ta}{tb}_{m}_{n}_{k}_ld_{lda}_{ldb}_{ldc}``), GemmStridedBatched
+    (extra ``_B_{batch}`` before ``_ld_``) and ScaledGemm (extra
+    ``_rw_..._bias_...`` after the ld triple) -- because m/n/k are always the
+    first three tokens after the leading ``{ta}{tb}`` token and lda/ldb/ldc
+    are always the first three tokens after ``_ld_``.
+
+    Returns ``(transa, transb, m, n, k, lda, ldb, ldc)`` as raw string tokens
+    (each is either a decimal integer or ``"*"``)."""
+    transa, transb = params_sig[0], params_sig[1]
+    ld_idx = params_sig.find(_LD_MARKER)
+    assert ld_idx != -1, f"no '{_LD_MARKER}' marker in signature: {params_sig}"
+    prefix_toks = params_sig[:ld_idx].split("_")
+    m_tok, n_tok, k_tok = prefix_toks[1], prefix_toks[2], prefix_toks[3]
+    ld_toks = params_sig[ld_idx + len(_LD_MARKER) :].split("_")
+    lda_tok, ldb_tok, ldc_tok = ld_toks[0], ld_toks[1], ld_toks[2]
+    return transa, transb, m_tok, n_tok, k_tok, lda_tok, ldb_tok, ldc_tok
+
+
+def _assert_ld_wildcarding_consistent(test: TestCase, op_substr: str) -> None:
+    """White-box check that the leading-dim wildcarding of every persisted
+    wildcard entry matches the actual lda/ldb/ldc dependency encoded by the
+    transpose flags in that same signature.
+
+    This is the invariant that ``ShouldWildcardLda/Ldb/Ldc`` in GemmCommon.h
+    must satisfy, derived from ``GetSizeA/B/C`` in that file:
+
+      * lda >= m for non-transposed A (transa == 'N'), lda >= k for
+        transposed A (transa == 'T'), so lda tracks M or K accordingly.
+      * ldb >= k for non-transposed B (transb == 'N'), ldb >= n for
+        transposed B (transb == 'T'), so ldb tracks K or N accordingly.
+      * ldc >= m always, so ldc tracks M.
+
+    Reading transa/transb and which of m/n/k are ``*`` from the persisted
+    signature makes the check independent of the row-major addmm/mm M<->N
+    remap: whatever frame the signature ends up in, its ld wildcarding must
+    be self-consistent. The pre-fix inverted ``UsesMForLda`` wildcards lda on
+    the wrong dim whenever exactly one of {m, k} is dynamic, which this check
+    flags."""
+    checked = 0
+    for op_sig, params_sig, _, _ in torch.cuda.tunable.get_results():
+        if op_substr not in op_sig or "*" not in params_sig:
+            continue
+        transa, transb, m_tok, n_tok, k_tok, lda_tok, ldb_tok, ldc_tok = (
+            _parse_gemm_params_sig(params_sig)
+        )
+        dyn_m, dyn_n, dyn_k = m_tok == "*", n_tok == "*", k_tok == "*"
+        exp_lda = dyn_m if transa in "Nn" else dyn_k
+        exp_ldb = dyn_k if transb in "Nn" else dyn_n
+        exp_ldc = dyn_m
+        test.assertEqual(
+            lda_tok == "*",
+            exp_lda,
+            f"lda wildcarding wrong for {params_sig!r}: transa={transa}, "
+            f"dyn_m={dyn_m}, dyn_k={dyn_k}; lda tracks "
+            f"{'M' if transa in 'Nn' else 'K'}",
+        )
+        test.assertEqual(
+            ldb_tok == "*",
+            exp_ldb,
+            f"ldb wildcarding wrong for {params_sig!r}: transb={transb}, "
+            f"dyn_n={dyn_n}, dyn_k={dyn_k}; ldb tracks "
+            f"{'K' if transb in 'Nn' else 'N'}",
+        )
+        test.assertEqual(
+            ldc_tok == "*",
+            exp_ldc,
+            f"ldc wildcarding wrong for {params_sig!r}: dyn_m={dyn_m}; "
+            f"ldc always tracks M",
+        )
+        checked += 1
+    test.assertGreaterEqual(
+        checked,
+        1,
+        f"expected at least one {op_substr} wildcard entry to validate",
+    )
+
+
+class DynamicTunableOpsTest(TestCase):
+    """Verification of the full tuning enable/disable x dynamic-dim matrix.
+
+    Note: each test case picks distinct (m, n, k) shapes so the in-memory
+    TuningResultsManager state from one test does not leak useful entries
+    into another.  The state is always restored to (enabled=False,
+    tuning=False) in tearDown.
+    """
+
+    _tmpdir: str = ""
+    _tmp_results_path: str = ""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("cuda not available")
+        # Redirect TunableOp persistence to a fresh per-process tempfile.
+        # The default filename "tunableop_results.csv" is shared across
+        # invocations; once a prior test run has tuned anything, its
+        # realtime-append writes pollute the in-memory results table for
+        # every subsequent run (the default file is auto-loaded lazily on
+        # the first GetTuningResultsManager() call). Setting our own
+        # filename BEFORE any tunable operation forces the lazy load to
+        # read our (empty) tempfile instead.
+        cls._tmpdir = tempfile.mkdtemp(prefix="dynamic_tunable_ops_test_")
+        cls._tmp_results_path = os.path.join(cls._tmpdir, "tunable_results.csv")
+        torch.cuda.tunable.set_filename(cls._tmp_results_path, False)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls._tmpdir:
+            import shutil
+
+            shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def setUp(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def tearDown(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    # -- Tuning enabled --------------------------------------------------
+
+    def test_tuning_enabled_no_dynamic_concrete_miss_persists_concrete_only(
+        self,
+    ) -> None:
+        """Tuning enabled + no dynamic dim + concrete miss
+        -> tune; persist concrete; do NOT persist wildcard."""
+        # Choose a fresh shape that is unlikely to clash with anything else
+        # (small to keep tuning latency low).
+        # Unusual primes -> guaranteed not in any prod-style CSV.
+        m, n, k = 17, 2053, 257
+        bias, mat1, mat2 = _addmm(m, n, k, seed=1)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        out = torch.addmm(bias, mat1, mat2)
+        self.assertEqual(out.shape, (m, n))
+
+        matched = _entries_for("GemmAndBiasTunableOp", str(m), str(n), str(k))
+        # Should have exactly one concrete entry, no wildcard entry.
+        self.assertGreaterEqual(
+            len(matched), 1, f"expected >=1 entry for ({m},{n},{k}), got {matched}"
+        )
+        for entry in matched:
+            self.assertNotIn(
+                "*",
+                entry[1],
+                f"unexpected wildcard entry for non-dynamic call: {entry}",
+            )
+
+    def test_tuning_enabled_dynamic_concrete_miss_persists_concrete_and_wildcard(
+        self,
+    ) -> None:
+        """Tuning enabled + has dynamic dim (M dynamic) + concrete miss
+        -> tune; persist concrete AND wildcard."""
+        m, n, k = 23, 2053, 269
+        bias, mat1, mat2 = _addmm(m, n, k, seed=2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            out = torch.addmm(bias, mat1, mat2)
+        self.assertEqual(out.shape, (m, n))
+
+        concrete_matched = [
+            e
+            for e in _entries_for("GemmAndBiasTunableOp", str(m), str(n), str(k))
+            if "*" not in e[1]
+        ]
+        wildcard_matched = [
+            e for e in _entries_for("GemmAndBiasTunableOp") if "*" in e[1]
+        ]
+        self.assertGreaterEqual(
+            len(concrete_matched),
+            1,
+            f"expected concrete entry for ({m},{n},{k}); got {concrete_matched}",
+        )
+        self.assertGreaterEqual(
+            len(wildcard_matched),
+            1,
+            f"expected at least one wildcard entry; got {wildcard_matched}",
+        )
+
+    def test_tuning_enabled_no_dynamic_concrete_hit_no_new_entries(self) -> None:
+        """Tuning enabled + no dynamic dim + concrete hit
+        -> no new entries are added on the second call."""
+        m, n, k = 29, 2053, 271
+        bias, mat1, mat2 = _addmm(m, n, k, seed=3)
+
+        # Prime: tune once.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.addmm(bias, mat1, mat2)
+        before = len(torch.cuda.tunable.get_results())
+
+        # Run again with same shape, no dynamic mask.
+        torch.addmm(bias, mat1, mat2)
+        after = len(torch.cuda.tunable.get_results())
+        self.assertEqual(
+            before,
+            after,
+            "concrete-hit + no-dynamic case should not add entries",
+        )
+
+    def test_tuning_enabled_dynamic_concrete_hit_persists_wildcard_if_missing(
+        self,
+    ) -> None:
+        """Tuning enabled + has dynamic dim + concrete hit (wildcard not
+        yet persisted) -> persist wildcard now.
+
+        Note on the BLAS-frame remap: PyTorch's row-major addmm dispatch
+        swaps inductor's (M, N) into BLAS's (n, m) so cuBLAS can stay
+        column-major. `cublasCommonArgs::swapped_mn` flags this and
+        `launchTunableGemmAndBias` remaps the inductor-frame mask sent
+        by the test (`dynamic_dims_mask(M=True)`) into a BLAS-frame
+        (N=True) before stamping `params.dynamic_dims_mask`. The
+        persisted wildcard signature therefore has `*` in the BLAS-n
+        slot (which is the original inductor-M, the actually dynamic
+        dim). The wildcard's BLAS-m slot is concrete and equals
+        inductor-N, and BLAS-k stays inductor-K."""
+        # Use a (m, k) pair that no other test in this class touches so the
+        # wildcard signature is unique and we can check for its specific
+        # presence rather than relying on a fragile count delta.
+        m, n, k = 41, 2053, 1009
+        bias, mat1, mat2 = _addmm(m, n, k, seed=4)
+
+        # Phase A: tune the concrete shape WITHOUT any dynamic mask, so only
+        # the concrete key gets persisted.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.addmm(bias, mat1, mat2)
+
+        # Sanity: concrete entry should exist, but no wildcard for it yet.
+        self.assertTrue(
+            _has_concrete_entry("GemmAndBiasTunableOp", m, n, k),
+            f"expected concrete entry for ({m},{n},{k}) after phase A",
+        )
+        # The "concrete-as-checked" tokens here are inductor-frame; the
+        # actual BLAS-frame signature swaps M↔N. `_has_wildcard_with_dims`
+        # below checks BLAS-frame tokens to match what's persisted.
+        self.assertFalse(
+            _has_wildcard_with_dims("GemmAndBiasTunableOp", n, k),
+            f"unexpected wildcard for BLAS-frame ({n},*,{k}) before phase B",
+        )
+
+        # Phase B: same concrete shape, but now declare M dynamic. operator()
+        # should hit the concrete entry and persist the wildcard.
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.addmm(bias, mat1, mat2)
+
+        # The persisted wildcard is in BLAS frame: tokens `_<n>_` (BLAS m
+        # = inductor N) and `_<k>_` (BLAS k = inductor K) are concrete;
+        # the BLAS-n slot holds `*` (the swapped inductor-M).
+        self.assertTrue(
+            _has_wildcard_with_dims("GemmAndBiasTunableOp", n, k),
+            f"expected BLAS-frame wildcard containing ({n},*,{k}) after "
+            "phase B (case 4: concrete hit + dynamic must persist wildcard "
+            "if missing). With cublasCommonArgs::swapped_mn the inductor-M "
+            "dynamic bit lands in BLAS-n.",
+        )
+
+    # -- Tuning disabled -------------------------------------------------
+
+    def test_tuning_disabled_concrete_hit_dispatches_via_concrete(self) -> None:
+        """Tuning disabled + concrete hit -> dispatch via concrete entry,
+        result matches tunable-disabled reference."""
+        m, n, k = 43, 2053, 1013
+        bias, mat1, mat2 = _addmm(m, n, k, seed=5)
+
+        # Prime concrete entry.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.addmm(bias, mat1, mat2)
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias, mat1, mat2)
+
+        # Test: tunable enabled, tuning disabled. Concrete hit.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        before = len(torch.cuda.tunable.get_results())
+        out = torch.addmm(bias, mat1, mat2)
+        after = len(torch.cuda.tunable.get_results())
+
+        self.assertEqual(before, after, "tuning disabled should not add entries")
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "tunable-enabled output should match tunable-disabled reference",
+        )
+
+    def test_tuning_disabled_concrete_miss_wildcard_hit_dispatches_via_wildcard(
+        self,
+    ) -> None:
+        """Tuning disabled + concrete miss + wildcard match
+        -> dispatch via wildcard entry, result matches tunable-disabled
+        reference. The runtime cannot push a dynamic-dims mask (AOTI
+        cpp_wrapper does not emit a TunableDynamicDimsGuard), so this
+        test deliberately runs Phase B WITHOUT a `dynamic_dims_mask`
+        context to mirror real runtime behavior. The wildcard match
+        comes from `LookupWildcardFallback`'s token-by-token scan over
+        persisted wildcard entries."""
+        m_tuned, n, k = 47, 2053, 1019
+        m_test = 53  # different M, same wildcard pattern
+        bias_t, mat1_t, mat2_t = _addmm(m_tuned, n, k, seed=6)
+        bias_x, mat1_x, mat2_x = _addmm(m_test, n, k, seed=7)
+
+        # Phase A (compile-time analog): tune at m_tuned with M dynamic
+        # so the wildcard `tn_*_n_k_…` is seeded into the manager.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.addmm(bias_t, mat1_t, mat2_t)
+
+        wildcard_present = _has_wildcard_entry("GemmAndBiasTunableOp")
+        self.assertTrue(
+            wildcard_present, "expected wildcard entry after phase A tuning"
+        )
+        # m_test has no concrete entry yet.
+        self.assertFalse(
+            _has_concrete_entry("GemmAndBiasTunableOp", m_test, n, k),
+            "should have no concrete entry for the new M before phase B",
+        )
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias_x, mat1_x, mat2_x)
+
+        # Phase B (runtime analog): tunable enabled, tuning disabled,
+        # NO `dynamic_dims_mask` context -- the AOTI runtime cannot push
+        # one. Concrete miss for m_test -> LookupWildcardFallback finds
+        # the wildcard seeded in Phase A and dispatches via it.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.addmm(bias_x, mat1_x, mat2_x)
+
+        self.assertFalse(
+            _has_concrete_entry("GemmAndBiasTunableOp", m_test, n, k),
+            "tuning-disabled wildcard-fallback dispatch must not add a concrete entry",
+        )
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "wildcard-fallback dispatched output should match "
+            "tunable-disabled reference",
+        )
+
+    def test_tuning_disabled_concrete_miss_wildcard_hit_without_runtime_mask(
+        self,
+    ) -> None:
+        """Variant of the test above using a different shape to ensure the
+        LookupWildcardFallback path is exercised across multiple
+        compile/runtime tuples in the suite (regression gate against the
+        runtime path silently regressing)."""
+        m_tuned, n, k = 41, 2053, 1019
+        m_test = 67  # different M, same wildcard pattern as Phase A
+        bias_t, mat1_t, mat2_t = _addmm(m_tuned, n, k, seed=18)
+        bias_x, mat1_x, mat2_x = _addmm(m_test, n, k, seed=19)
+
+        # Phase A (compile-time analog): tune with M dynamic so the
+        # wildcard `tn_*_n_k_...` is seeded into the tuning manager.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.addmm(bias_t, mat1_t, mat2_t)
+        self.assertTrue(
+            _has_wildcard_entry("GemmAndBiasTunableOp"),
+            "expected wildcard entry after compile-time tuning phase",
+        )
+        self.assertFalse(
+            _has_concrete_entry("GemmAndBiasTunableOp", m_test, n, k),
+            "should have no concrete entry for the test M before runtime dispatch",
+        )
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias_x, mat1_x, mat2_x)
+
+        # Phase B (runtime analog): tunable enabled, tuning disabled, NO
+        # dynamic_dims_mask context active -- the AOTI cpp_wrapper does
+        # not emit TunableDynamicDimsGuard, so GetCurrentDynamicDimsMask()
+        # is empty here. LookupWildcardFallback should still scan
+        # persisted wildcard entries and dispatch via the matching one.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.addmm(bias_x, mat1_x, mat2_x)
+
+        self.assertFalse(
+            _has_concrete_entry("GemmAndBiasTunableOp", m_test, n, k),
+            "wildcard-fallback dispatch must not add a concrete entry "
+            "when tuning is disabled",
+        )
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "wildcard-fallback dispatch (no runtime mask) should match "
+            "tunable-disabled reference",
+        )
+
+    def test_tuning_disabled_both_miss_falls_back_to_non_tunable_aten(self) -> None:
+        """Tuning disabled + concrete miss + no wildcard match
+        -> dispatch falls back to the non-tunable aten path; no Default
+        kernel invoked, no entries added, output matches tunable-disabled
+        reference. Uses a large-K shape that historically crashed via the
+        Default kernel on MI300X to confirm the safe path is taken."""
+        # One of the prod shapes that crashed in tunable_mi300x_fresh_v2.txt
+        # when TunableOp was enabled with no tuned entries.
+        m, n, k = 2048, 2048, 11088
+        bias, mat1, mat2 = _addmm(m, n, k, seed=8)
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias, mat1, mat2)
+
+        # Test: tunable enabled, tuning disabled, no entries primed (no
+        # concrete or wildcard for this shape exists in the manager).
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        before_results = len(torch.cuda.tunable.get_results())
+        out = torch.addmm(bias, mat1, mat2)  # must NOT crash
+        after_results = len(torch.cuda.tunable.get_results())
+
+        self.assertEqual(
+            before_results,
+            after_results,
+            "both-miss + tuning disabled must not add any entries",
+        )
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "fallback dispatch result should match tunable-disabled reference",
+        )
+
+    def test_tuning_disabled_no_wildcard_match_falls_back_safely(self) -> None:
+        """Variant of `..._both_miss_falls_back_to_non_tunable_aten` using a
+        fresh shape that has no concrete entry AND no wildcard pattern that
+        could match. Verifies the runtime fall-through path stays safe even
+        when the manager has unrelated wildcard entries from other tests
+        (LookupWildcardFallback must reject non-matching wildcards rather
+        than dispatch a wrong kernel).
+        """
+        m, n, k = 59, 2053, 1031
+        bias, mat1, mat2 = _addmm(m, n, k, seed=9)
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias, mat1, mat2)
+
+        # Test: tunable enabled, tuning disabled, no concrete entry exists
+        # for this shape and no wildcard pattern matches it. (Runtime
+        # cannot push a dynamic mask -- AOTI cpp_wrapper does not emit
+        # TunableDynamicDimsGuard.)
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.addmm(bias, mat1, mat2)  # must NOT crash
+
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "fallback dispatch result should match tunable-disabled reference",
+        )
+
+    # -- Tuning disabled: mm / bmm runtime wildcard fallback -------------
+    # Regression coverage for making GemmTunableOp (torch.mm) and
+    # GemmStridedBatchedTunableOp (torch.bmm) consume persisted wildcard
+    # entries at runtime via LookupWildcardFallback, matching the addmm
+    # path (launchTunableGemmAndBias). Before the fix, gemm_tunable /
+    # bgemm_tunable in CUDABlas.cpp did an exact-match Lookup on
+    # DynamicSignature(); at runtime the mask is empty (no
+    # TunableDynamicDimsGuard), so dynamic_sig == concrete_sig and the
+    # lookup never fired -- every concrete miss silently fell back to the
+    # non-tunable aten path instead of the persisted wildcard-tuned kernel.
+
+    def test_tuning_disabled_mm_concrete_miss_wildcard_hit(self) -> None:
+        """torch.mm: tuning disabled + concrete miss + wildcard match.
+        Phase A tunes at m_tuned with M dynamic (seeds a GemmTunableOp
+        wildcard); Phase B queries a different M at runtime with no mask.
+        The concrete miss must resolve via LookupWildcardFallback (no
+        concrete entry added) and match the tunable-disabled reference."""
+        m_tuned, n, k = 61, 2063, 1021
+        m_test = 79
+        mat1_t, mat2_t = _mm(m_tuned, n, k, seed=50)
+        mat1_x, mat2_x = _mm(m_test, n, k, seed=51)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.mm(mat1_t, mat2_t)
+        self.assertTrue(
+            _has_wildcard_entry("GemmTunableOp"),
+            "expected GemmTunableOp wildcard entry after phase A tuning",
+        )
+        self.assertFalse(
+            _has_concrete_entry("GemmTunableOp", m_test, n, k),
+            "should have no concrete entry for the new M before phase B",
+        )
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.mm(mat1_x, mat2_x)
+
+        # Runtime: tunable enabled, tuning disabled, no mask.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.mm(mat1_x, mat2_x)
+
+        self.assertFalse(
+            _has_concrete_entry("GemmTunableOp", m_test, n, k),
+            "mm wildcard-fallback dispatch must not add a concrete entry",
+        )
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "mm wildcard-fallback output should match tunable-disabled reference",
+        )
+
+    def test_tuning_disabled_bmm_concrete_miss_wildcard_hit(self) -> None:
+        """torch.bmm: tuning disabled + concrete miss + wildcard match.
+        bmm is not subject to the cuBLAS M<->N swap, so the inductor-frame
+        M-dynamic mask lands directly on the BLAS m slot; the persisted
+        wildcard therefore matches a different-M concrete signature via
+        LookupWildcardFallback's token scan. No concrete entry is added and
+        the output matches the tunable-disabled reference."""
+        b = 8
+        m_tuned, n, k = 37, 263, 277
+        m_test = 43
+        b1_t, b2_t = _bmm(b, m_tuned, n, k, seed=52)
+        b1_x, b2_x = _bmm(b, m_test, n, k, seed=53)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.bmm(b1_t, b2_t)
+        self.assertTrue(
+            _has_wildcard_entry("GemmStridedBatchedTunableOp"),
+            "expected GemmStridedBatchedTunableOp wildcard entry after phase A",
+        )
+        self.assertFalse(
+            _has_concrete_entry("GemmStridedBatchedTunableOp", m_test, n, k),
+            "should have no concrete entry for the new M before phase B",
+        )
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.bmm(b1_x, b2_x)
+
+        # Runtime: tunable enabled, tuning disabled, no mask.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.bmm(b1_x, b2_x)
+
+        self.assertFalse(
+            _has_concrete_entry("GemmStridedBatchedTunableOp", m_test, n, k),
+            "bmm wildcard-fallback dispatch must not add a concrete entry",
+        )
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "bmm wildcard-fallback output should match tunable-disabled reference",
+        )
+
+    # -- Cache-behavior parity: concrete hit + safe aten fallback --------
+    # Mirror the three addmm runtime scenarios (concrete hit, wildcard
+    # fallback, both-miss safe fallback) for mm/bmm/baddbmm so every
+    # non-scaled variant is verified to behave identically to
+    # launchTunableGemmAndBias.
+
+    def test_tuning_disabled_mm_concrete_hit(self) -> None:
+        """torch.mm concrete hit: after tuning a concrete entry, a runtime
+        query for the same shape dispatches via it -- no new entry, output
+        matches the tunable-disabled reference."""
+        m, n, k = 83, 2039, 1033
+        mat1, mat2 = _mm(m, n, k, seed=54)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.mm(mat1, mat2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.mm(mat1, mat2)
+        before = len(torch.cuda.tunable.get_results())
+
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.mm(mat1, mat2)
+        after = len(torch.cuda.tunable.get_results())
+
+        self.assertEqual(before, after, "mm concrete-hit must not add an entry")
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "mm concrete-hit output should match reference",
+        )
+
+    def test_tuning_disabled_mm_both_miss_falls_back_safely(self) -> None:
+        """torch.mm both-miss: tunable enabled, tuning disabled, no concrete
+        entry and no matching wildcard -> safe non-tunable aten fallback (no
+        crash, no entry added, output matches reference)."""
+        m, n, k = 97, 1493, 1499
+        mat1, mat2 = _mm(m, n, k, seed=55)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.mm(mat1, mat2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        before = len(torch.cuda.tunable.get_results())
+        out = torch.mm(mat1, mat2)  # must NOT crash
+        after = len(torch.cuda.tunable.get_results())
+
+        self.assertEqual(before, after, "mm both-miss must not add an entry")
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "mm both-miss fallback output should match reference",
+        )
+
+    def test_tuning_disabled_bmm_concrete_hit(self) -> None:
+        """torch.bmm concrete hit -> dispatch via concrete entry, no new
+        entry added, output matches reference."""
+        b, m, n, k = 8, 31, 269, 281
+        b1, b2 = _bmm(b, m, n, k, seed=56)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.bmm(b1, b2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.bmm(b1, b2)
+        before = len(torch.cuda.tunable.get_results())
+
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.bmm(b1, b2)
+        after = len(torch.cuda.tunable.get_results())
+
+        self.assertEqual(before, after, "bmm concrete-hit must not add an entry")
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "bmm concrete-hit output should match reference",
+        )
+
+    def test_tuning_disabled_bmm_both_miss_falls_back_safely(self) -> None:
+        """torch.bmm both-miss -> safe non-tunable aten fallback (no crash,
+        no entry added, output matches reference)."""
+        b, m, n, k = 8, 101, 1451, 1453
+        b1, b2 = _bmm(b, m, n, k, seed=57)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.bmm(b1, b2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        before = len(torch.cuda.tunable.get_results())
+        out = torch.bmm(b1, b2)  # must NOT crash
+        after = len(torch.cuda.tunable.get_results())
+
+        self.assertEqual(before, after, "bmm both-miss must not add an entry")
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "bmm both-miss fallback output should match reference",
+        )
+
+    def test_tuning_disabled_baddbmm_concrete_miss_wildcard_hit(self) -> None:
+        """torch.baddbmm: tune at m_tuned with M dynamic -> wildcard; runtime
+        query at a different M with no mask -> wildcard fallback, output
+        matches reference. baddbmm shares bgemm_tunable with bmm; the bias is
+        applied around the same GemmStridedBatchedTunableOp dispatch."""
+        b = 8
+        m_tuned, n, k = 29, 277, 287
+        m_test = 41
+        bias_t, b1_t, b2_t = _baddbmm(b, m_tuned, n, k, seed=58)
+        bias_x, b1_x, b2_x = _baddbmm(b, m_test, n, k, seed=59)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.baddbmm(bias_t, b1_t, b2_t)
+        self.assertTrue(
+            _has_wildcard_entry("GemmStridedBatchedTunableOp"),
+            "expected GemmStridedBatchedTunableOp wildcard entry after baddbmm phase A",
+        )
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.baddbmm(bias_x, b1_x, b2_x)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.baddbmm(bias_x, b1_x, b2_x)
+
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "baddbmm wildcard-fallback output should match reference",
+        )
+
+    def test_tuning_disabled_baddbmm_both_miss_falls_back_safely(self) -> None:
+        """torch.baddbmm both-miss -> safe non-tunable aten fallback (no
+        crash, output matches reference)."""
+        b = 8
+        m, n, k = 103, 1481, 1483
+        bias, b1, b2 = _baddbmm(b, m, n, k, seed=60)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.baddbmm(bias, b1, b2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.baddbmm(bias, b1, b2)  # must NOT crash
+
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "baddbmm both-miss fallback output should match reference",
+        )
+
+# ─── Coverage across all four TunableOp variants ──────────────────────
+# These tests exercise the full compile-time-tune -> runtime-fallback
+# loop on each TunableOp class:
+#   - GemmAndBiasTunableOp     (torch.addmm with 1D bias, LT-fused-bias)
+#   - GemmTunableOp            (torch.mm, plain GEMM)
+#   - GemmStridedBatchedTunableOp (torch.bmm)
+# For each class the test:
+#   Phase A: tune at one shape with M dynamic -> wildcard persisted.
+#   Phase B: compute reference with TunableOp disabled.
+#   Phase C: query at a different M with TunableOp enabled, tuning OFF,
+#            no runtime mask -> LookupWildcardFallback must hit the
+#            wildcard, no concrete entry added, output matches reference.
+
+
+class AllTunableOpsWildcardFallbackTest(TestCase):
+    """Verify the dynamic-mask + wildcard-fallback contract on each
+    TunableOp variant."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("cuda not available")
+        cls._tmpdir = tempfile.mkdtemp(prefix="all_tunable_ops_test_")
+        cls._tmp_results_path = os.path.join(cls._tmpdir, "tunable_results.csv")
+        torch.cuda.tunable.set_filename(cls._tmp_results_path, False)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls._tmpdir:
+            import shutil
+
+            shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def setUp(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def tearDown(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def _ref(self, fn) -> torch.Tensor:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        return fn()
+
+    def test_gemm_and_bias_tunable_op_addmm_wildcard_round_trip(self) -> None:
+        """GemmAndBiasTunableOp via torch.addmm with M-dynamic mask.
+        Verifies the addmm path (the original repro)."""
+        m_tuned, n, k = 53, 2069, 1013
+        m_test = 71
+        bias_t, mat1_t, mat2_t = _addmm(m_tuned, n, k, seed=20)
+        bias_x, mat1_x, mat2_x = _addmm(m_test, n, k, seed=21)
+
+        # Phase A: tune at m_tuned with M dynamic -> wildcard persisted.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.addmm(bias_t, mat1_t, mat2_t)
+        self.assertTrue(
+            _has_wildcard_entry("GemmAndBiasTunableOp"),
+            "expected GemmAndBiasTunableOp wildcard entry after tuning",
+        )
+
+        # Reference.
+        ref = self._ref(lambda: torch.addmm(bias_x, mat1_x, mat2_x))
+
+        # Phase C: runtime, no mask, different M -> wildcard fallback hits.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.addmm(bias_x, mat1_x, mat2_x)
+
+        self.assertFalse(
+            _has_concrete_entry("GemmAndBiasTunableOp", m_test, n, k),
+            "wildcard-fallback dispatch should not add a concrete entry",
+        )
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "GemmAndBiasTunableOp wildcard-fallback output should match "
+            "tunable-disabled reference",
+        )
+
+    def test_gemm_tunable_op_mm_wildcard_round_trip(self) -> None:
+        """GemmTunableOp via torch.mm with M-dynamic mask.
+        Verifies the plain-GEMM (no bias) path also remaps the mask
+        through `cublasCommonArgs::swapped_mn` and dispatches via the
+        wildcard fallback at runtime."""
+        m_tuned, n, k = 59, 2089, 1019
+        m_test = 73
+        mat1_t, mat2_t = _mm(m_tuned, n, k, seed=22)
+        mat1_x, mat2_x = _mm(m_test, n, k, seed=23)
+
+        # Phase A.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.mm(mat1_t, mat2_t)
+        self.assertTrue(
+            _has_wildcard_entry("GemmTunableOp"),
+            "expected GemmTunableOp wildcard entry after tuning",
+        )
+
+        # Reference.
+        ref = self._ref(lambda: torch.mm(mat1_x, mat2_x))
+
+        # Phase C.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.mm(mat1_x, mat2_x)
+
+        self.assertFalse(
+            _has_concrete_entry("GemmTunableOp", m_test, n, k),
+            "GemmTunableOp wildcard-fallback dispatch should not add a concrete entry",
+        )
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "GemmTunableOp wildcard-fallback output should match "
+            "tunable-disabled reference",
+        )
+
+    def test_gemm_strided_batched_tunable_op_bmm_wildcard_round_trip(
+        self,
+    ) -> None:
+        """GemmStridedBatchedTunableOp via torch.bmm with M-dynamic
+        mask. bmm is not subject to the cuBLAS M<->N swap, so the
+        M-dynamic wildcard is persisted with `*` in the BLAS m slot and
+        `bgemm_tunable` (CUDABlas.cpp) now resolves the runtime concrete
+        miss through `LookupWildcardFallback`, matching the addmm path."""
+        b = 16
+        m_tuned, n, k = 47, 257, 251
+        m_test = 53
+        b1_t, b2_t = _bmm(b, m_tuned, n, k, seed=24)
+        b1_x, b2_x = _bmm(b, m_test, n, k, seed=25)
+
+        # Phase A: tune with both M dynamic and BATCH dynamic so the
+        # wildcard signature has wildcards in the dims that vary at
+        # runtime. (M is what changes between Phases B and C; BATCH is
+        # constant in this test but pushed for symmetry with the
+        # inductor-side mask that would normally include both.)
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.bmm(b1_t, b2_t)
+        self.assertTrue(
+            _has_wildcard_entry("GemmStridedBatchedTunableOp"),
+            "expected GemmStridedBatchedTunableOp wildcard entry after tuning",
+        )
+
+        # Reference.
+        ref = self._ref(lambda: torch.bmm(b1_x, b2_x))
+
+        # Phase C.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.bmm(b1_x, b2_x)
+
+        # Output correctness: whether dispatch resolves via the wildcard
+        # fallback or (on a wildcard miss) via the non-tunable aten path,
+        # both produce the same numerical result, so this assertion is a
+        # correctness sanity check rather than a hard gate on the wildcard
+        # fallback firing (no Python-visible hit counter exists yet).
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "GemmStridedBatchedTunableOp dispatch output should match "
+            "tunable-disabled reference (either via wildcard fallback "
+            "or via non-tunable aten fallback)",
+        )
+
+
+# ─── Layout coverage: verify swap remap across NN/NT/TN/TT ────────────
+# PyTorch's BLAS dispatch picks `transa, transb` and the
+# `transpose_result` decision based on operand layouts. The
+# `cublasCommonArgs::swapped_mn` flag tracks `transpose_result` so the
+# `launchTunableGemmAndBias` mask remap fires whenever the dispatch
+# swaps inductor (M, N) -> BLAS (n, m). These tests force each
+# (transa, transb) combination by transposing input tensors and
+# verify the wildcard-tune -> wildcard-fallback round trip works
+# correctly for every layout.
+
+
+class LayoutCoverageWildcardTest(TestCase):
+    """Exercise the dynamic-mask + wildcard-fallback contract for each
+    of the four (transa, transb) layout combinations, with each of the
+    M/N/K dims taken dynamic in turn. Each test tunes at one shape, then
+    queries at a shape that differs only in the dynamic dim with no
+    runtime mask, and asserts: a wildcard entry was persisted, its
+    leading-dim wildcarding is self-consistent with the transpose flags
+    (white-box), no concrete entry is added at runtime, and output
+    matches a tunable-disabled reference.
+
+    The K-dynamic cases are what give lda coverage: for torch.mm the
+    row-major dispatch swaps inductor (M, N) into BLAS (n, m), so an
+    M-dynamic call lands the dynamic bit on BLAS-n (never lda). K is not
+    swapped, so a K-dynamic call keeps k dynamic in the BLAS frame and
+    forces lda to be wildcarded exactly when transa == 'T'."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("cuda not available")
+        cls._tmpdir = tempfile.mkdtemp(prefix="layout_coverage_test_")
+        cls._tmp_results_path = os.path.join(cls._tmpdir, "tunable_results.csv")
+        torch.cuda.tunable.set_filename(cls._tmp_results_path, False)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls._tmpdir:
+            import shutil
+
+            shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def setUp(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def tearDown(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    @staticmethod
+    def _make_layout(
+        m: int, k: int, n: int, transa: bool, transb: bool, seed: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build (mat1, mat2) for `mm(mat1, mat2)` so the BLAS dispatch
+        picks the requested (transa, transb) layout. We synthesize the
+        layout by allocating the underlying storage in the transposed
+        shape and then transposing the view; this is the canonical way
+        to make a tensor "non-contiguous" along a particular axis without
+        triggering a contiguous() copy."""
+        torch.manual_seed(seed)
+        if not transa:
+            mat1 = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+        else:
+            mat1 = torch.randn(k, m, dtype=DTYPE, device=DEVICE).t()
+        if not transb:
+            mat2 = torch.randn(k, n, dtype=DTYPE, device=DEVICE)
+        else:
+            mat2 = torch.randn(n, k, dtype=DTYPE, device=DEVICE).t()
+        return mat1, mat2
+
+    def _round_trip_for_layout(
+        self, transa: bool, transb: bool, seed_offset: int, dynamic: str = "M"
+    ) -> None:
+        """Run the tune-then-fallback round trip for one layout, taking the
+        `dynamic` dim (one of "M"/"N"/"K") as symbolic. Tuning and runtime
+        shapes differ only in that dim."""
+        base_m, n, k = 41 + seed_offset, 257, 251
+        delta = 12
+        tuned = {"m": base_m, "n": n, "k": k}
+        test = {"m": base_m, "n": n, "k": k}
+        test[dynamic.lower()] += delta
+
+        mat1_t, mat2_t = self._make_layout(
+            tuned["m"], tuned["k"], tuned["n"], transa, transb, seed=100 + seed_offset
+        )
+        mat1_x, mat2_x = self._make_layout(
+            test["m"], test["k"], test["n"], transa, transb, seed=200 + seed_offset
+        )
+
+        # Reference (tunable disabled).
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.mm(mat1_x, mat2_x)
+
+        # Phase A: tune at the tuned shape with the chosen dim dynamic ->
+        # wildcard persisted.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(**{dynamic: True}):
+            torch.mm(mat1_t, mat2_t)
+        self.assertTrue(
+            _has_wildcard_entry("GemmTunableOp"),
+            f"expected GemmTunableOp wildcard entry after tuning "
+            f"layout (transa={transa}, transb={transb}, dynamic={dynamic})",
+        )
+        # White-box: the persisted wildcard must wildcard the correct
+        # leading dims for its transpose flags. This is what catches an
+        # inverted lda/ldb/ldc -> dim mapping (e.g. a broken UsesMForLda),
+        # which _has_wildcard_entry alone silently tolerates because a
+        # mis-wildcarded key still contains a '*'.
+        _assert_ld_wildcarding_consistent(self, "GemmTunableOp")
+
+        # Phase C: runtime, no mask, shape differs only in the dynamic dim
+        # -> must dispatch via wildcard fallback (no new concrete entry) and
+        # match the tunable-disabled reference.
+        before = len(torch.cuda.tunable.get_results())
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.mm(mat1_x, mat2_x)
+        after = len(torch.cuda.tunable.get_results())
+        self.assertEqual(
+            before,
+            after,
+            f"layout (transa={transa}, transb={transb}, dynamic={dynamic}): "
+            f"runtime dispatch with tuning disabled must not add a new entry",
+        )
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            f"layout (transa={transa}, transb={transb}, dynamic={dynamic}): "
+            f"wildcard-fallback dispatch output must match tunable-disabled "
+            f"reference",
+        )
+
+    def test_layout_NN(self) -> None:
+        """No transpose on either operand."""
+        self._round_trip_for_layout(transa=False, transb=False, seed_offset=0)
+
+    def test_layout_NT(self) -> None:
+        """mat1 contiguous, mat2 transposed."""
+        self._round_trip_for_layout(transa=False, transb=True, seed_offset=4)
+
+    def test_layout_TN(self) -> None:
+        """mat1 transposed, mat2 contiguous."""
+        self._round_trip_for_layout(transa=True, transb=False, seed_offset=8)
+
+    def test_layout_TT(self) -> None:
+        """Both operands transposed."""
+        self._round_trip_for_layout(transa=True, transb=True, seed_offset=12)
+
+    def test_layout_NN_dynamic_k(self) -> None:
+        """K dynamic (not swapped by the mm remap) exercises lda/ldb."""
+        self._round_trip_for_layout(
+            transa=False, transb=False, seed_offset=16, dynamic="K"
+        )
+
+    def test_layout_NT_dynamic_k(self) -> None:
+        self._round_trip_for_layout(
+            transa=False, transb=True, seed_offset=20, dynamic="K"
+        )
+
+    def test_layout_TN_dynamic_k(self) -> None:
+        """transa == 'T' + K dynamic forces lda to be wildcarded; the
+        inverted UsesMForLda leaves it concrete and this test fails."""
+        self._round_trip_for_layout(
+            transa=True, transb=False, seed_offset=24, dynamic="K"
+        )
+
+    def test_layout_TT_dynamic_k(self) -> None:
+        self._round_trip_for_layout(
+            transa=True, transb=True, seed_offset=28, dynamic="K"
+        )
+
+
+# ─── ScaledGemmTunableOp coverage (FP8 _scaled_mm) ────────────────────
+# Mirrors the inductor_lowering_context node_replacement_dict
+# `{'torch.nn.Linear':{'(10000+,1000+)': 'fp8_float_model_dynamic_quantization_tensorwise'}}`
+# which rewrites large Linear layers into FP8 + per-tensor (tensorwise)
+# scaling. The lowered op is `torch._scaled_mm(a_fp8, b_fp8, scale_a,
+# scale_b, ...)` which ultimately dispatches to
+# `launchTunableScaledGemm` -> `ScaledGemmTunableOp::operator()`.
+#
+# This test verifies the same wildcard round-trip for that op:
+#   Phase A: tune at m_tuned with M dynamic -> wildcard persisted.
+#   Phase C: runtime concrete miss at m_test, no runtime mask
+#            -> LookupWildcardFallback hits the wildcard.
+
+
+class ScaledGemmTunableOpFP8Test(TestCase):
+    """Verify the dynamic-mask + wildcard-fallback contract for
+    `torch._scaled_mm` with tensorwise FP8 scaling, matching the
+    `node_replacement_dict` setup that triggers
+    `ScaledGemmTunableOp` for large Linear layers."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("cuda not available")
+        # FP8 e4m3fn requires a recent enough device; skip on older
+        # hardware that doesn't expose the dtype.
+        if not hasattr(torch, "float8_e4m3fn"):
+            raise unittest.SkipTest("torch.float8_e4m3fn not available")
+        cls._tmpdir = tempfile.mkdtemp(prefix="scaled_gemm_test_")
+        cls._tmp_results_path = os.path.join(cls._tmpdir, "tunable_results.csv")
+        torch.cuda.tunable.set_filename(cls._tmp_results_path, False)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls._tmpdir:
+            import shutil
+
+            shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def setUp(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def tearDown(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    @staticmethod
+    def _scaled_mm_inputs(
+        m: int, n: int, k: int, seed: int = 0
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Build (a_fp8, b_fp8, scale_a, scale_b) for a tensorwise-
+        scaled `_scaled_mm(a, b, scale_a, scale_b)` of shape (m, n, k).
+
+        a is M×K row-major, b is K×N -> b must be col-major for the
+        cuBLAS scaled-mm path (the typical inductor pattern after the
+        `fp8_float_model_dynamic_quantization_tensorwise` rewrite).
+        """
+        torch.manual_seed(seed)
+        # Random BF16 then quantize to FP8 e4m3fn with a tensorwise scale.
+        a_bf16 = torch.randn(m, k, dtype=torch.bfloat16, device=DEVICE)
+        b_bf16 = torch.randn(n, k, dtype=torch.bfloat16, device=DEVICE)
+        # Per-tensor (tensorwise) absmax scale -> single-element fp32
+        # tensor.
+        a_amax = a_bf16.abs().max().to(torch.float32)
+        b_amax = b_bf16.abs().max().to(torch.float32)
+        # FP8 e4m3fn dynamic range max value.
+        fp8_max = torch.finfo(torch.float8_e4m3fn).max
+        scale_a = (a_amax / fp8_max).reciprocal().clamp(min=1e-12)
+        scale_b = (b_amax / fp8_max).reciprocal().clamp(min=1e-12)
+        a_fp8 = (
+            (a_bf16.to(torch.float32) * scale_a)
+            .clamp(min=-fp8_max, max=fp8_max)
+            .to(torch.float8_e4m3fn)
+        )
+        b_fp8 = (
+            (b_bf16.to(torch.float32) * scale_b)
+            .clamp(min=-fp8_max, max=fp8_max)
+            .to(torch.float8_e4m3fn)
+        )
+        # `_scaled_mm` requires `b` to be column-major (matches the
+        # inductor lowering for the fp8 quantization rewrite).
+        b_fp8_colmajor = b_fp8.t().contiguous().t()
+        # Scale tensors are reciprocals of the quantization scales.
+        scale_a_inv = scale_a.reciprocal()
+        scale_b_inv = scale_b.reciprocal()
+        return a_fp8, b_fp8_colmajor, scale_a_inv, scale_b_inv
+
+    def _run_scaled_mm(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+    ) -> torch.Tensor:
+        # `_scaled_mm` with a column-major `b` produces an M×N bf16 out.
+        return torch._scaled_mm(a, b, scale_a, scale_b, out_dtype=torch.bfloat16)
+
+    def test_scaled_gemm_tunable_op_wildcard_round_trip(self) -> None:
+        """Tune `_scaled_mm` at m_tuned with M dynamic; query at
+        m_test with no runtime mask. Wildcard fallback must hit (or
+        the dispatch must safely fall through to a non-tunable path
+        with correct output)."""
+        # Use shapes that match the
+        # `node_replacement_dict`-style trigger: a "large Linear" with
+        # K and N >= 1000 (the prod rule says 10000+, 1000+; we use a
+        # smaller-but-representative shape so the test runs quickly).
+        m_tuned, n, k = 1024, 1024, 1024
+        m_test = 2048
+
+        # Reference: tunable disabled.
+        a_t, b_t, sa_t, sb_t = self._scaled_mm_inputs(m_tuned, n, k, seed=30)
+        a_x, b_x, sa_x, sb_x = self._scaled_mm_inputs(m_test, n, k, seed=31)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        try:
+            ref = self._run_scaled_mm(a_x, b_x, sa_x, sb_x)
+        except RuntimeError as e:
+            # _scaled_mm may not be supported on this device/dtype combo
+            # (e.g. unsupported gfx arch). Skip rather than fail.
+            raise unittest.SkipTest(
+                f"_scaled_mm not supported in this configuration: {e}"
+            ) from e
+
+        # Phase A: tune at m_tuned with M dynamic.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            self._run_scaled_mm(a_t, b_t, sa_t, sb_t)
+
+        # We don't strictly require a wildcard entry to exist -- some
+        # FP8 paths may take a non-tunable shortcut. But if any
+        # ScaledGemmTunableOp entry is present it should be the one we
+        # tuned. Check for "any" Scaled entry as a sanity gate.
+        scaled_entries = [
+            e for e in torch.cuda.tunable.get_results() if "ScaledGemmTunableOp" in e[0]
+        ]
+        if not scaled_entries:
+            raise unittest.SkipTest(
+                "no ScaledGemmTunableOp entries persisted; "
+                "_scaled_mm may have skipped the tunable path on this "
+                "configuration"
+            )
+        wildcard_present = any("*" in e[1] for e in scaled_entries)
+        self.assertTrue(
+            wildcard_present,
+            f"expected ScaledGemmTunableOp wildcard entry after tuning "
+            f"with M dynamic; got entries: {scaled_entries}",
+        )
+
+        # Phase C: runtime, no mask, different M -> wildcard fallback
+        # (or aten fallback) must produce correct output.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = self._run_scaled_mm(a_x, b_x, sa_x, sb_x)
+
+        self.assertTrue(
+            torch.allclose(out, ref, atol=5e-2, rtol=5e-2),
+            "ScaledGemmTunableOp dispatch output should match "
+            "tunable-disabled reference (either via wildcard fallback "
+            "or via non-tunable aten fallback)",
+        )
+
+    def test_scaled_gemm_both_miss_falls_back_safely(self) -> None:
+        """_scaled_mm both-miss: tunable enabled, tuning disabled, with no
+        concrete and no wildcard entry primed -> must fall back to the
+        non-tunable at::cuda::blas::scaled_gemm (NOT ResultEntry::Default())
+        and produce correct output without crashing. Regression gate for the
+        scaled path's safe-aten fallback: before the try_scaled_dispatch gate
+        in _tunable_scaled_gemm_rocm, a total miss reached the Default kernel
+        instead of falling back like the addmm path does."""
+        m, n, k = 4096, 1024, 1024
+        a, b, sa, sb = self._scaled_mm_inputs(m, n, k, seed=32)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        try:
+            ref = self._run_scaled_mm(a, b, sa, sb)
+        except RuntimeError as e:
+            raise unittest.SkipTest(
+                f"_scaled_mm not supported in this configuration: {e}"
+            ) from e
+
+        # No entries primed for this shape. Tunable enabled, tuning disabled:
+        # concrete miss + wildcard miss must fall back safely.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = self._run_scaled_mm(a, b, sa, sb)  # must NOT crash / Default
+
+        self.assertTrue(
+            torch.allclose(out, ref, atol=5e-2, rtol=5e-2),
+            "scaled both-miss fallback output should match "
+            "tunable-disabled reference",
+        )
+
+
+# ─── Legacy "non-dynamic" behavior (BEFORE the wildcard feature) ─────
+# These tests assert what TunableOp does when no `dynamic_dims_mask`
+# is ever pushed (the pre-feature world): only concrete-key entries
+# get persisted at compile-time tuning, and runtime concrete-miss
+# queries fall through to the non-tunable aten path. These are the
+# canonical "before" behavior gates -- they document and lock in what
+# the system reverts to when `triton.autotune_tunableop_dynamic_dims_
+# wildcard=False` (the kill-switch for the dynamic-tunable-ops
+# feature).
+
+
+class LegacyConcreteOnlyTunableOpsTest(TestCase):
+    """Verify that without a dynamic-dims mask (the pre-feature
+    behavior), TunableOp only persists concrete entries and runtime
+    concrete-misses safely fall through. These tests do NOT push any
+    `dynamic_dims_mask` -- they emulate the world where the feature
+    flag `triton.autotune_tunableop_dynamic_dims_wildcard=False`."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("cuda not available")
+        cls._tmpdir = tempfile.mkdtemp(prefix="legacy_concrete_only_test_")
+        cls._tmp_results_path = os.path.join(cls._tmpdir, "tunable_results.csv")
+        torch.cuda.tunable.set_filename(cls._tmp_results_path, False)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls._tmpdir:
+            import shutil
+
+            shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def setUp(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def tearDown(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def _entries_for_op(self, op_substr: str) -> list:
+        return [e for e in torch.cuda.tunable.get_results() if op_substr in e[0]]
+
+    def test_addmm_tuning_no_mask_persists_concrete_only(self) -> None:
+        """Tuning enabled, NO `dynamic_dims_mask` context.
+        addmm produces a single concrete entry; no wildcard."""
+        m, n, k = 89, 1031, 257
+        bias, mat1, mat2 = _addmm(m, n, k, seed=40)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.addmm(bias, mat1, mat2)  # NO mask context
+
+        entries = self._entries_for_op("GemmAndBiasTunableOp")
+        # The persisted entries must NOT contain a wildcard.
+        for op_sig, params_sig, _, _ in entries:
+            self.assertNotIn(
+                "*",
+                params_sig,
+                f"legacy mode (no mask) must not persist wildcards; "
+                f"got {op_sig},{params_sig}",
+            )
+        # At least one concrete entry must exist for our shape.
+        concrete_match = [
+            e for e in entries if all(f"_{d}_" in ("_" + e[1] + "_") for d in (m, n, k))
+        ]
+        self.assertGreaterEqual(
+            len(concrete_match),
+            1,
+            f"expected concrete entry covering ({m},{n},{k}) after tuning",
+        )
+
+    def test_mm_tuning_no_mask_persists_concrete_only(self) -> None:
+        """torch.mm tuning without mask: only GemmTunableOp concrete."""
+        m, n, k = 91, 1033, 263
+        mat1, mat2 = _mm(m, n, k, seed=41)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.mm(mat1, mat2)  # NO mask
+
+        for op_sig, params_sig, _, _ in self._entries_for_op("GemmTunableOp"):
+            self.assertNotIn(
+                "*",
+                params_sig,
+                f"legacy mode (no mask) must not persist wildcards; "
+                f"got {op_sig},{params_sig}",
+            )
+
+    def test_bmm_tuning_no_mask_persists_concrete_only(self) -> None:
+        """torch.bmm tuning without mask: only StridedBatched concrete."""
+        b, m, n, k = 16, 47, 257, 251
+        b1, b2 = _bmm(b, m, n, k, seed=42)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.bmm(b1, b2)  # NO mask
+
+        for op_sig, params_sig, _, _ in self._entries_for_op(
+            "GemmStridedBatchedTunableOp"
+        ):
+            self.assertNotIn(
+                "*",
+                params_sig,
+                f"legacy mode (no mask) must not persist wildcards; "
+                f"got {op_sig},{params_sig}",
+            )
+
+    def test_runtime_concrete_miss_no_mask_falls_back_to_aten(self) -> None:
+        """Runtime: tunable enabled, tuning OFF, NO mask, no
+        wildcards exist -> concrete miss must fall back to non-
+        tunable aten (output correct, no entries added, no Default
+        crash)."""
+        # Use a fresh shape that no other test seeded.
+        m, n, k = 73, 1039, 269
+        bias, mat1, mat2 = _addmm(m, n, k, seed=43)
+
+        # Reference.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias, mat1, mat2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        before = len(torch.cuda.tunable.get_results())
+        out = torch.addmm(bias, mat1, mat2)  # NO mask, NO concrete entry
+        after = len(torch.cuda.tunable.get_results())
+
+        self.assertEqual(
+            before,
+            after,
+            "concrete-miss + tuning-disabled must not add any entries",
+        )
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "fallback dispatch result should match tunable-disabled reference",
+        )
+
+    def test_runtime_concrete_hit_no_mask_dispatches_via_concrete(
+        self,
+    ) -> None:
+        """After tuning a concrete entry (no mask), runtime queries
+        for the same shape must hit that concrete entry. No wildcard
+        scan needed."""
+        m, n, k = 79, 1049, 271
+        bias, mat1, mat2 = _addmm(m, n, k, seed=44)
+
+        # Reference.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias, mat1, mat2)
+
+        # Tune the concrete shape (no mask).
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.addmm(bias, mat1, mat2)
+        before = len(torch.cuda.tunable.get_results())
+
+        # Runtime: same shape -> concrete hit, no new entry, output
+        # matches.
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.addmm(bias, mat1, mat2)
+        after = len(torch.cuda.tunable.get_results())
+
+        self.assertEqual(
+            before,
+            after,
+            "concrete-hit dispatch must not add any new entry",
+        )
+        self.assertTrue(
+            torch.allclose(out, ref, atol=1e-2, rtol=1e-2),
+            "concrete-hit dispatch result should match reference",
+        )
+
+
+class _SizeOnlyNode:
+    """Minimal input-node stub exposing only get_size(), which is all that
+    shapes_symbolic / dynamic_dim_mask consult. Lets us drive
+    dynamic_dim_mask with symbolic (sympy) dims on CPU, no GPU needed."""
+
+    def __init__(self, size: tuple[object, ...]) -> None:
+        self._size = size
+
+    def get_size(self) -> tuple[object, ...]:
+        return self._size
+
+
+@inductor_config.patch({"triton.autotune_tunableop_dynamic_dims_wildcard": True})
+class DynamicDimMaskOperandSelectionTest(TestCase):
+    """CPU unit tests pinning down two properties of
+    ``MMKernelInputs.dynamic_dim_mask`` that matter for scaled GEMM:
+
+      1. Operands are read from the explicit mat1_idx / mat2_idx, not the
+         trailing two inputs. Scaled GEMM lays out inputs as
+         ``[mat_a, mat_b, scale_a, scale_b, (bias)]`` with mat1_idx=0,
+         mat2_idx=1, so reading the trailing inputs would derive the mask
+         from the scale/bias tensors instead of the real M/N/K operands.
+      2. The ``"scaled_mm"`` op name (used by the inductor scaled-mm
+         lowering) is recognized as a 2D matmul.
+    """
+
+    def _scaled_mm_inputs(self, with_bias: bool) -> MMKernelInputs:
+        """Scaled-mm-style inputs where the real operands (indices 0, 1)
+        have a dynamic M only, while the trailing scale/bias tensors carry a
+        *different* dynamic dim -- so a (buggy) trailing-input mask would be
+        distinguishable from the correct operand-based mask."""
+        s_m = sympy.Symbol("s_m", positive=True, integer=True)
+        s_bad = sympy.Symbol("s_bad", positive=True, integer=True)
+        mat_a = _SizeOnlyNode((s_m, 512))  # (M_dyn, K)
+        mat_b = _SizeOnlyNode((512, 256))  # (K, N)  static
+        scale_a = _SizeOnlyNode((1, 1))
+        scale_b = _SizeOnlyNode((s_bad, 999))  # dynamic dim in trailing input
+        nodes: list[object] = [mat_a, mat_b, scale_a, scale_b]
+        if with_bias:
+            nodes.append(_SizeOnlyNode((256,)))
+        return MMKernelInputs(nodes, mat1_idx=0, mat2_idx=1)
+
+    def test_scaled_mm_reads_operands_not_trailing_scales(self) -> None:
+        ki = self._scaled_mm_inputs(with_bias=False)
+        # Correct mask is derived from mat_a/mat_b -> only M dynamic. If the
+        # trailing scale tensors were read, s_bad would surface as dyn_k.
+        self.assertEqual(
+            ki.dynamic_dim_mask("scaled_mm"), (True, False, False, False)
+        )
+
+    def test_scaled_mm_with_bias_reads_operands(self) -> None:
+        ki = self._scaled_mm_inputs(with_bias=True)
+        self.assertEqual(
+            ki.dynamic_dim_mask("scaled_mm"), (True, False, False, False)
+        )
+
+    def test_scaled_mm_op_name_recognized(self) -> None:
+        # A dynamic operand dim must yield a non-all-False mask, proving the
+        # "scaled_mm" name is recognized as a 2D matmul.
+        ki = self._scaled_mm_inputs(with_bias=False)
+        self.assertNotEqual(
+            ki.dynamic_dim_mask("scaled_mm"), (False, False, False, False)
+        )
+
+    def test_unrecognized_op_name_returns_all_false(self) -> None:
+        ki = self._scaled_mm_inputs(with_bias=False)
+        self.assertEqual(
+            ki.dynamic_dim_mask("not_a_gemm"), (False, False, False, False)
+        )
+
+    def test_default_indices_mm_reads_trailing_operands(self) -> None:
+        # Plain mm: [mat1, mat2], default indices, dynamic N only.
+        s_n = sympy.Symbol("s_n", positive=True, integer=True)
+        mat1 = _SizeOnlyNode((128, 512))  # (M, K)
+        mat2 = _SizeOnlyNode((512, s_n))  # (K, N_dyn)
+        ki = MMKernelInputs([mat1, mat2])
+        self.assertEqual(ki.dynamic_dim_mask("mm"), (False, True, False, False))
+
+    def test_feature_flag_off_returns_all_false(self) -> None:
+        with inductor_config.patch(
+            {"triton.autotune_tunableop_dynamic_dims_wildcard": False}
+        ):
+            ki = self._scaled_mm_inputs(with_bias=False)
+            self.assertEqual(
+                ki.dynamic_dim_mask("scaled_mm"), (False, False, False, False)
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/tests/test_dynamic_tunable_ops.py
+++ b/torch/_inductor/tests/test_dynamic_tunable_ops.py
@@ -1016,6 +1016,30 @@ class AllTunableOpsWildcardFallbackTest(TestCase):
             "tunable-disabled reference",
         )
 
+    def test_swapped_mask_guard_restores_outer_mask(self) -> None:
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.cuda.tunable.set_max_tuning_duration(1)
+        torch.cuda.tunable.set_max_tuning_iterations(1)
+
+        dynamic_shapes = [(31, 263, 251), (37, 269, 257)]
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            for seed, (m, n, k) in enumerate(dynamic_shapes, start=30):
+                mat1, mat2 = _mm(m, n, k, seed=seed)
+                torch.mm(mat1, mat2)
+                self.assertTrue(
+                    _has_wildcard_with_dims("GemmTunableOp", n, k),
+                    f"expected wildcard entry for ({m}, {n}, {k})",
+                )
+
+        m, n, k = 41, 271, 277
+        mat1, mat2 = _mm(m, n, k, seed=32)
+        torch.mm(mat1, mat2)
+        self.assertFalse(
+            _has_wildcard_with_dims("GemmTunableOp", n, k),
+            "swapped inner guard leaked outside the dynamic mask scope",
+        )
+
     def test_gemm_strided_batched_tunable_op_bmm_wildcard_round_trip(
         self,
     ) -> None:

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1936,6 +1936,53 @@ PyObject* THCPModule_cuda_tunableop_get_cublaslt_requested_algo_count(
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* THCPModule_cuda_tunableop_push_dynamic_dims_mask(
+    PyObject* _unused,
+    PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      THPUtils_checkLong(arg),
+      "cuda_tunableop_push_dynamic_dims_mask expects an int, but got ",
+      THPUtils_typename(arg));
+  // Pack the four dim flags (M/N/K/BATCH) into the low 4 bits on the Python
+  // side, push as a single mask value here. See torch.cuda.tunable
+  // .dynamic_dims_mask context manager for the high-level wrapper.
+  auto bits = static_cast<uint8_t>(THPUtils_unpackLong(arg));
+  at::cuda::tunable::TunableDynamicDimsGuard* guard =
+      new at::cuda::tunable::TunableDynamicDimsGuard(
+          at::cuda::tunable::DynamicDimsMask{bits});
+  // Returning the heap-owned guard pointer as a PyCapsule so the Python side
+  // owns its lifetime; pop_dynamic_dims_mask takes the same capsule and
+  // deletes it, which runs the dtor and pops the TLS stack.
+  return PyCapsule_New(
+      static_cast<void*>(guard),
+      "at::cuda::tunable::TunableDynamicDimsGuard",
+      nullptr);
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THCPModule_cuda_tunableop_pop_dynamic_dims_mask(
+    PyObject* _unused,
+    PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      PyCapsule_CheckExact(arg),
+      "cuda_tunableop_pop_dynamic_dims_mask expects a PyCapsule, but got ",
+      THPUtils_typename(arg));
+  void* p = PyCapsule_GetPointer(
+      arg, "at::cuda::tunable::TunableDynamicDimsGuard");
+  TORCH_CHECK(p != nullptr, "invalid capsule for TunableDynamicDimsGuard");
+  delete static_cast<at::cuda::tunable::TunableDynamicDimsGuard*>(p);
+  // Mark the capsule as consumed by renaming it. PyCapsule_SetPointer
+  // rejects nullptr (it raises a ValueError), so we instead change the
+  // capsule's name to a sentinel that subsequent PyCapsule_GetPointer
+  // calls will not match -- giving us double-pop detection without
+  // tripping the CPython null-pointer guard.
+  PyCapsule_SetName(arg, "at::cuda::tunable::TunableDynamicDimsGuard[popped]");
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject* THCPModule_cuda_tunableop_set_filename(
     PyObject* _unused,
     PyObject* args) {
@@ -2447,6 +2494,14 @@ static struct PyMethodDef _THCPModule_methods[] = {
     {"_cuda_tunableop_set_filename",
      THCPModule_cuda_tunableop_set_filename,
      METH_VARARGS,
+     nullptr},
+    {"_cuda_tunableop_push_dynamic_dims_mask",
+     THCPModule_cuda_tunableop_push_dynamic_dims_mask,
+     METH_O,
+     nullptr},
+    {"_cuda_tunableop_pop_dynamic_dims_mask",
+     THCPModule_cuda_tunableop_pop_dynamic_dims_mask,
+     METH_O,
      nullptr},
     {"_cuda_tunableop_get_filename",
      THCPModule_cuda_tunableop_get_filename,

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -189,13 +189,21 @@ Use the C++ or Python APIs instead.
 
 """
 
+import concurrent.futures
+import contextlib
 import glob
 import multiprocessing as mp
 import os
 import shutil
 import warnings
+from collections.abc import Iterator
 
 import torch
+
+_DYN_M_BIT = 1 << 0
+_DYN_N_BIT = 1 << 1
+_DYN_K_BIT = 1 << 2
+_DYN_BATCH_BIT = 1 << 3
 
 
 __all__ = [
@@ -211,6 +219,9 @@ __all__ = [
     "get_max_tuning_iterations",
     "set_cublaslt_requested_algo_count",
     "get_cublaslt_requested_algo_count",
+    "push_dynamic_dims_mask",
+    "pop_dynamic_dims_mask",
+    "dynamic_dims_mask",
     "set_filename",
     "get_filename",
     "get_results",
@@ -303,6 +314,71 @@ def get_cublaslt_requested_algo_count() -> int:
         torch._C._cuda_tunableop_get_cublaslt_requested_algo_count  # type: ignore[attr-defined]
     )
     return get_count()
+
+
+def _pack_dynamic_dims_mask(
+    M: bool = False,
+    N: bool = False,
+    K: bool = False,
+    BATCH: bool = False,
+) -> int:
+    r"""Pack four per-dim flags into the single byte mask used by C++."""
+    bits = 0
+    if M:
+        bits |= _DYN_M_BIT
+    if N:
+        bits |= _DYN_N_BIT
+    if K:
+        bits |= _DYN_K_BIT
+    if BATCH:
+        bits |= _DYN_BATCH_BIT
+    return bits
+
+
+def push_dynamic_dims_mask(
+    M: bool = False,
+    N: bool = False,
+    K: bool = False,
+    BATCH: bool = False,
+) -> object:
+    r"""Push a per-call dynamic-dims mask onto the thread-local TunableOp stack.
+
+    Returns an opaque handle (PyCapsule) that must be passed to
+    :func:`pop_dynamic_dims_mask`. Prefer the :func:`dynamic_dims_mask`
+    context manager unless you need raw push/pop semantics.
+
+    The mask wildcards the named GEMM dims when computing the TunableOp
+    DynamicSignature; tuned entries seeded under the wildcard key will be
+    reused by subsequent shapes that differ only in the dynamic dim(s).
+    """
+    bits = _pack_dynamic_dims_mask(M=M, N=N, K=K, BATCH=BATCH)
+    return torch._C._cuda_tunableop_push_dynamic_dims_mask(bits)  # type: ignore[attr-defined]
+
+
+def pop_dynamic_dims_mask(handle: object) -> None:
+    r"""Pop a previously-pushed dynamic-dims mask. Pass the handle returned
+    by :func:`push_dynamic_dims_mask`."""
+    torch._C._cuda_tunableop_pop_dynamic_dims_mask(handle)  # type: ignore[attr-defined]
+
+
+@contextlib.contextmanager
+def dynamic_dims_mask(
+    M: bool = False,
+    N: bool = False,
+    K: bool = False,
+    BATCH: bool = False,
+) -> Iterator[None]:
+    r"""Context manager that wraps a scope with a per-call dynamic-dims mask.
+
+    Each TunableOp GEMM call inside the scope uses the given mask when
+    computing its wildcard signature; outside the scope the legacy
+    concrete-only behavior applies.
+    """
+    handle = push_dynamic_dims_mask(M=M, N=N, K=K, BATCH=BATCH)
+    try:
+        yield
+    finally:
+        pop_dynamic_dims_mask(handle)
 
 
 def set_filename(filename: str, insert_device_ordinal: bool = False) -> None:


### PR DESCRIPTION
Summary:
**Context:** TunableOp ICE runs can show that the CSV config loads, but the logs do not currently provide a low-volume way to verify serving-time cache hit rate.

**Motivation:** Add an opt-in predictor flag that emits periodic TunableOp dispatch summaries without logging per request or per GEMM.

**This diff:**
- Adds serving dispatch counters for concrete hits, wildcard hits, and misses.
- Records dispatch outcomes in GEMM, batched GEMM, and fused GemmAndBias serving paths when tuning is disabled.
- Wires the counter to predictor gflag , default off, and includes the enabled state in the CSV load log.

Test Plan: arc f

Reviewed By: ZhitongGuo

Differential Revision: D112447779


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo