### PR TITLE
[BE] add test for metal nchw_to_nhwc_kernel

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -46,6 +46,7 @@ from torch.testing._internal.common_methods_invocations import (
 from torch.testing._internal.common_device_type import ops, dtypes, instantiate_device_type_tests, OpDTypes, largeTensorTest
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel
+from torch.utils._cpp_embed_headers import embed_headers
 import numpy as np
 import torch
 import torch.utils._pytree as pytree
@@ -17186,6 +17187,15 @@ class TestMetalLibrary(TestCaseMPS):
         x = torch.tensor([1.0, 2.0, 3.0, 4.0], device="mps")
         lib.square(x)
         self.assertEqual(x, torch.tensor([1.0, 4.0, 9.0, 16.0], device="mps"))
+
+    def test_nchw_to_nhwc_kernel(self):
+        path = os.path.join(_CONFORMANCE_REPO_ROOT, "aten/src/ATen/native/mps/kernels/Convolution.metal")
+        lib = torch.mps.compile_shader(embed_headers(path))
+        src = torch.arange(2 * 11 * 35, dtype=torch.float32, device="mps").reshape(2, 11, 35)
+        dst = torch.empty(2, 35, 11, device="mps")
+        kernel = lib.nchw_to_nhwc_float_16_64_false_false
+        kernel(src, dst, [11, 35], threads=(256, 1, 2), group_size=(256, 1, 1), arg_casts="int32")
+        self.assertEqual(dst, src.permute(0, 2, 1))
 
 
 # TODO: Actually instantiate that test for the "mps" device to better reflect what it is doing.


### PR DESCRIPTION
Adds test for recently added `nchw_to_nhwc` kernel in `aten/src/ATen/native/mps/kernels/Convolution.metal`.