### PR TITLE
[inductor][fxir] Fix FX-backend crash on a compound symint graph input (#191811)

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -30,6 +30,7 @@ from torch._inductor.codegen.wrapper_fxir import (
     replace_floor_div,
     WrapperFxCodegen,
 )
+from torch._inductor.exc import InductorError
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import fresh_cache
 from torch.export import Dim
@@ -1372,6 +1373,102 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         offsets = torch.tensor([0, 3, 7, length], dtype=torch.int64, device=self.device)
 
         self.check(TestModule(), (data, offsets))
+
+    def test_compound_symint_graph_input(self):
+        """A compound symbolic graph input binds to a single placeholder.
+
+        The branches close over 2 * y.shape[0] + 1, so the lifted argument
+        reaches the converter as a sympy.Add rather than a single Symbol.
+        """
+
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                a = 2 * y.shape[0] + 1
+
+                def true_fn(t):
+                    return t + a
+
+                # Identical branches would share one Triton kernel between
+                # two separately converted subgraphs, which FX conversion
+                # cannot resolve.
+                def false_fn(t):
+                    return t + a + 1
+
+                return torch.cond(x.shape[0] > 5, true_fn, false_fn, (x,))
+
+        inp = tuple(torch.randn(numel, device=self.device) for numel in (8, 4))
+        gm = self.check(M(), inp, dynamic_shapes=({0: Dim.DYNAMIC}, {0: Dim.DYNAMIC}))
+
+        # The lifted argument is a placeholder of the branch subgraphs, not of
+        # the parent graph. Check each branch on its own: one symbolic
+        # placeholder holding the whole expression, so neither branch fell back
+        # to taking the constituent symbol instead.
+        branches = [
+            submod
+            for name, submod in gm.named_modules()
+            if name and isinstance(submod, torch.fx.GraphModule)
+        ]
+        self.assertEqual(len(branches), 2, "expected the two cond subgraphs")
+        for branch in branches:
+            symbolic = [
+                node.meta["val"]
+                for node in branch.graph.find_nodes(op="placeholder")
+                if isinstance(node.meta.get("val"), torch.SymInt)
+            ]
+            self.assertEqual(len(symbolic), 1)
+            expr = symbolic[0].node.expr
+            (sym,) = expr.free_symbols
+            self.assertEqual(expr, 2 * sym + 1)
+
+    def test_nonlinear_compound_input_rejected(self):
+        """A compound input the solver cannot invert fails with a clear error.
+
+        y.shape[0] * y.shape[0] lifts as s**2, which the solver does not invert
+        to recover s.
+        """
+
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                a = y.shape[0] * y.shape[0]
+
+                def true_fn(t):
+                    return t + a
+
+                def false_fn(t):
+                    return t + a + 1
+
+                return torch.cond(x.shape[0] > 5, true_fn, false_fn, (x,))
+
+        inp = tuple(torch.randn(numel, device=self.device) for numel in (8, 4))
+        with self.assertRaisesRegex(InductorError, "Cannot solve input expression"):
+            self.check(M(), inp, dynamic_shapes=({0: Dim.DYNAMIC}, {0: Dim.DYNAMIC}))
+
+    def test_underdetermined_compound_input_rejected(self):
+        """A compound input holding two unknowns fails with a clear error.
+
+        The branches close over y.shape[0] + z.shape[0] but take neither
+        tensor, so one bound value would have to determine both symbols.
+        """
+
+        class M(torch.nn.Module):
+            def forward(self, x, y, z):
+                a = y.shape[0] + z.shape[0]
+
+                def true_fn(t):
+                    return t + a
+
+                def false_fn(t):
+                    return t + a + 1
+
+                return torch.cond(x.shape[0] > 5, true_fn, false_fn, (x,))
+
+        inp = tuple(torch.randn(numel, device=self.device) for numel in (8, 4, 6))
+        with self.assertRaisesRegex(InductorError, "leaves these symbols undefined"):
+            self.check(
+                M(),
+                inp,
+                dynamic_shapes=({0: Dim.DYNAMIC}, {0: Dim.DYNAMIC}, {0: Dim.DYNAMIC}),
+            )
 
 
 class TestReplaceFloorDiv(InductorTestCase):

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -30,6 +30,7 @@ from torch._inductor.codegen.wrapper_fxir import (
     replace_floor_div,
     WrapperFxCodegen,
 )
+from torch._inductor.exc import InductorError
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import fresh_cache
 from torch.export import Dim
@@ -1372,6 +1373,102 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         offsets = torch.tensor([0, 3, 7, length], dtype=torch.int64, device=self.device)
 
         self.check(TestModule(), (data, offsets))
+
+    def test_compound_symint_graph_input(self):
+        """A compound symbolic graph input binds to a single placeholder.
+
+        The branches close over 2 * y.shape[0] + 1, so the lifted argument
+        reaches the converter as a sympy.Add rather than a single Symbol.
+        """
+
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                a = 2 * y.shape[0] + 1
+
+                def true_fn(t):
+                    return t + a
+
+                # Identical branches would share one Triton kernel between
+                # two separately converted subgraphs, which FX conversion
+                # cannot resolve.
+                def false_fn(t):
+                    return t + a + 1
+
+                return torch.cond(x.shape[0] > 5, true_fn, false_fn, (x,))
+
+        inp = tuple(torch.randn(numel, device=self.device) for numel in (8, 4))
+        gm = self.check(M(), inp, dynamic_shapes=({0: Dim.DYNAMIC}, {0: Dim.DYNAMIC}))
+
+        # The lifted argument is a placeholder of the branch subgraphs, not of
+        # the parent graph. Check each branch on its own: one symbolic
+        # placeholder holding the whole expression, so neither branch fell back
+        # to taking the constituent symbol instead.
+        branches = [
+            submod
+            for name, submod in gm.named_modules()
+            if name and isinstance(submod, torch.fx.GraphModule)
+        ]
+        self.assertEqual(len(branches), 2, "expected the two cond subgraphs")
+        for branch in branches:
+            symbolic = [
+                node.meta["val"]
+                for node in branch.graph.find_nodes(op="placeholder")
+                if isinstance(node.meta.get("val"), torch.SymInt)
+            ]
+            self.assertEqual(len(symbolic), 1)
+            expr = symbolic[0].node.expr
+            (sym,) = expr.free_symbols
+            self.assertEqual(expr, 2 * sym + 1)
+
+    def test_nonlinear_compound_input_rejected(self):
+        """A compound input the solver cannot invert fails with a clear error.
+
+        y.shape[0] * y.shape[0] lifts as s**2. try_solve only isolates a symbol
+        appearing linearly, so there is no unique inverse to recover s from.
+        """
+
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                a = y.shape[0] * y.shape[0]
+
+                def true_fn(t):
+                    return t + a
+
+                def false_fn(t):
+                    return t + a + 1
+
+                return torch.cond(x.shape[0] > 5, true_fn, false_fn, (x,))
+
+        inp = tuple(torch.randn(numel, device=self.device) for numel in (8, 4))
+        with self.assertRaisesRegex(InductorError, "Cannot solve input expression"):
+            self.check(M(), inp, dynamic_shapes=({0: Dim.DYNAMIC}, {0: Dim.DYNAMIC}))
+
+    def test_underdetermined_compound_input_rejected(self):
+        """A compound input holding two unknowns fails with a clear error.
+
+        The branches close over y.shape[0] + z.shape[0] but take neither
+        tensor, so one bound value would have to determine both symbols.
+        """
+
+        class M(torch.nn.Module):
+            def forward(self, x, y, z):
+                a = y.shape[0] + z.shape[0]
+
+                def true_fn(t):
+                    return t + a
+
+                def false_fn(t):
+                    return t + a + 1
+
+                return torch.cond(x.shape[0] > 5, true_fn, false_fn, (x,))
+
+        inp = tuple(torch.randn(numel, device=self.device) for numel in (8, 4, 6))
+        with self.assertRaisesRegex(InductorError, "leaves these symbols undefined"):
+            self.check(
+                M(),
+                inp,
+                dynamic_shapes=({0: Dim.DYNAMIC}, {0: Dim.DYNAMIC}, {0: Dim.DYNAMIC}),
+            )
 
 
 class TestReplaceFloorDiv(InductorTestCase):

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -86,16 +86,22 @@ log = logging.getLogger(__name__)
 @dataclasses.dataclass
 class SymbolBuffer(CodegenSymbol):
     """
-    Represents a sympy.Symbol graph input.
+    Represents a symbolic graph input. Expressions more complex than a single
+    sympy.Symbol require a name.
     """
 
-    symbol: sympy.Symbol
+    expr: sympy.Expr
+    name: str | None = None
 
     def get_name(self) -> str:
-        return str(self.symbol)
+        if self.name is not None:
+            return self.name
+        if not isinstance(self.expr, sympy.Symbol):
+            raise AssertionError(f"expression requires a name: {self.expr}")
+        return str(self.expr)
 
     def get_example(self) -> torch.Tensor | torch.SymInt:
-        sym_int = convert_to_symint(self.symbol)
+        sym_int = convert_to_symint(self.expr)
         if not isinstance(sym_int, torch.SymInt):
             raise AssertionError(f"expected torch.SymInt, got {type(sym_int)}")
         return sym_int
@@ -412,11 +418,22 @@ class FxConverter:
 
             # Introduce a new symbol for constant inputs.
             is_constant = isinstance(ir_node, (int, float, sympy.Integer, sympy.Float))
-            buffer = (
-                SymbolBuffer(sympy.Symbol(name, is_integer=True))
-                if is_constant
-                else self._get_buffer(ir_node)
+
+            # Special handling for dynamic shapes which are not simple symbols.
+            is_expr = isinstance(ir_node, sympy.Expr) and not isinstance(
+                ir_node, (sympy.Symbol, sympy.Integer, sympy.Float)
             )
+            if is_expr and ir_node.is_integer is not True:
+                raise NotImplementedError(
+                    f"Unsupported non-integer symbolic graph input: {ir_node}"
+                )
+
+            if is_constant:
+                buffer = SymbolBuffer(sympy.Symbol(name, is_integer=True))
+            elif is_expr:
+                buffer = SymbolBuffer(ir_node, name=name)
+            else:
+                buffer = self._get_buffer(ir_node)
             placeholder_node = self.gm.graph.placeholder(buffer.get_name())
             placeholder_node.meta["val"] = (
                 ir_node if is_constant else buffer.get_example()
@@ -424,7 +441,7 @@ class FxConverter:
             self._record_allocation(buffer, placeholder_node)
 
             # Record symbol definitions for dynamic shapes.
-            if isinstance(ir_node, sympy.Symbol):
+            if isinstance(ir_node, sympy.Expr) and not is_constant:
                 self._generate_size_proxy(placeholder_node, ir_node)
 
     def _generate_graph_input_shapes(self) -> None:
@@ -463,7 +480,9 @@ class FxConverter:
                     self._sympy_interp(sym_or_exp)
                     return
                 elif len(undefined_symbols) > 1:
-                    raise ValueError(f"Underdetermined input expression: {sym_or_exp}")
+                    raise NotImplementedError(
+                        f"Underdetermined input expression: {sym_or_exp}"
+                    )
 
                 # Define a new symbol for the input size.
                 size_proxy = codegen_proxy()
@@ -472,27 +491,9 @@ class FxConverter:
                 )
                 self.expr_to_proxy[size_symbol] = size_proxy
 
-                # Solve for the undefined symbol.
-                undefined_symbol = undefined_symbols[0]
-                solution = try_solve(
-                    sympy.Eq(sym_or_exp, size_symbol), undefined_symbol
+                self._define_symbol_by_solving(
+                    sym_or_exp, size_symbol, undefined_symbols[0]
                 )
-                if solution is None:
-                    raise ValueError(f"Cannot solve input expression: {sym_or_exp}")
-
-                # Since the symbol is a size, it must be an integer.
-                # Therefore, we can convert division to FloorDiv.
-                undefined_symbol_expr = solution[1]
-                if undefined_symbol.is_integer:
-                    undefined_symbol_expr = replace_floor_div(
-                        sympy.floor(undefined_symbol_expr)
-                    )
-
-                # Generate FX for the symbol.
-                self._sympy_interp(undefined_symbol_expr)
-                self.expr_to_proxy[undefined_symbol] = self.expr_to_proxy[
-                    undefined_symbol_expr
-                ]
 
         for ir_node in self.graph_inputs.values():
             if isinstance(ir_node, ir.TensorBox):
@@ -507,6 +508,36 @@ class FxConverter:
                     _codegen_symbol(
                         stride, placeholder_node, torch.ops.aten.sym_stride.int, dim
                     )
+
+        # A compound input binds its whole expression to one placeholder, so a
+        # symbol appearing only inside it has no node of its own. Recover it
+        # from that placeholder, after the loop above has defined every symbol
+        # the tensor shapes determine.
+        for ir_node in self.graph_inputs.values():
+            if not isinstance(ir_node, sympy.Expr) or isinstance(ir_node, sympy.Symbol):
+                continue
+            proxy = self.expr_to_proxy.get(ir_node)
+            if proxy is None:
+                continue
+            undefined = [
+                sym for sym in ir_node.free_symbols if sym not in self.expr_to_proxy
+            ]
+            if len(undefined) == 0:
+                continue
+            elif len(undefined) > 1:
+                # One bound value cannot determine several symbols. This is a
+                # branch closing over an expression whose symbols come from
+                # tensors it does not take, such as y.shape[0] + z.shape[0].
+                raise NotImplementedError(
+                    f"Compound input {ir_node} leaves these symbols undefined: "
+                    f"{sorted(undefined, key=str)}"
+                )
+
+            # A tensor-derived FX node does not reserve its symbol's name, so a
+            # Dummy is what keeps the anchor from colliding with one.
+            anchor = sympy.Dummy(proxy.node.name, integer=True)
+            self.expr_to_proxy[anchor] = proxy
+            self._define_symbol_by_solving(ir_node, anchor, undefined[0])
 
     def _generate_graph_constants(self) -> None:
         for name, value in V.graph.constants.items():
@@ -671,6 +702,28 @@ class FxConverter:
             expr,
         )
         return self.expr_to_proxy[expr]
+
+    def _define_symbol_by_solving(
+        self, expr: sympy.Expr, anchor: sympy.Symbol, symbol: sympy.Symbol
+    ) -> None:
+        """
+        Define symbol by solving expr == anchor, which already maps to a proxy.
+        """
+        # A returned solution directly defines the symbol in terms of the anchor.
+        solution = try_solve(sympy.Eq(expr, anchor), symbol)
+        if solution is None:
+            raise NotImplementedError(
+                f"Cannot solve input expression {expr} for {symbol}"
+            )
+
+        symbol_expr = solution[1]
+        # If the symbol is an integer, division becomes FloorDiv.
+        if symbol.is_integer:
+            symbol_expr = replace_floor_div(sympy.floor(symbol_expr))
+
+        # Generate FX for the symbol.
+        self._sympy_interp(symbol_expr)
+        self.expr_to_proxy[symbol] = self.expr_to_proxy[symbol_expr]
 
     def _generate_sym_node(self, s: int | sympy.Expr) -> int | torch.fx.Node:
         if isinstance(s, (int, sympy.Integer)):

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -86,16 +86,22 @@ log = logging.getLogger(__name__)
 @dataclasses.dataclass
 class SymbolBuffer(CodegenSymbol):
     """
-    Represents a sympy.Symbol graph input.
+    Represents a symbolic graph input. Expressions more complex than a single
+    sympy.Symbol require a name.
     """
 
-    symbol: sympy.Symbol
+    expr: sympy.Expr
+    name: str | None = None
 
     def get_name(self) -> str:
-        return str(self.symbol)
+        if self.name is not None:
+            return self.name
+        if not isinstance(self.expr, sympy.Symbol):
+            raise AssertionError(f"expression requires a name: {self.expr}")
+        return str(self.expr)
 
     def get_example(self) -> torch.Tensor | torch.SymInt:
-        sym_int = convert_to_symint(self.symbol)
+        sym_int = convert_to_symint(self.expr)
         if not isinstance(sym_int, torch.SymInt):
             raise AssertionError(f"expected torch.SymInt, got {type(sym_int)}")
         return sym_int
@@ -412,11 +418,22 @@ class FxConverter:
 
             # Introduce a new symbol for constant inputs.
             is_constant = isinstance(ir_node, (int, float, sympy.Integer, sympy.Float))
-            buffer = (
-                SymbolBuffer(sympy.Symbol(name, is_integer=True))
-                if is_constant
-                else self._get_buffer(ir_node)
+
+            # Special handling for dynamic shapes which are not simple symbols.
+            is_expr = isinstance(ir_node, sympy.Expr) and not isinstance(
+                ir_node, (sympy.Symbol, sympy.Integer, sympy.Float)
             )
+            if is_expr and ir_node.is_integer is not True:
+                raise NotImplementedError(
+                    f"Unsupported non-integer symbolic graph input: {ir_node}"
+                )
+
+            if is_constant:
+                buffer = SymbolBuffer(sympy.Symbol(name, is_integer=True))
+            elif is_expr:
+                buffer = SymbolBuffer(ir_node, name=name)
+            else:
+                buffer = self._get_buffer(ir_node)
             placeholder_node = self.gm.graph.placeholder(buffer.get_name())
             placeholder_node.meta["val"] = (
                 ir_node if is_constant else buffer.get_example()
@@ -424,7 +441,7 @@ class FxConverter:
             self._record_allocation(buffer, placeholder_node)
 
             # Record symbol definitions for dynamic shapes.
-            if isinstance(ir_node, sympy.Symbol):
+            if isinstance(ir_node, sympy.Symbol) or is_expr:
                 self._generate_size_proxy(placeholder_node, ir_node)
 
     def _generate_graph_input_shapes(self) -> None:
@@ -463,7 +480,9 @@ class FxConverter:
                     self._sympy_interp(sym_or_exp)
                     return
                 elif len(undefined_symbols) > 1:
-                    raise ValueError(f"Underdetermined input expression: {sym_or_exp}")
+                    raise NotImplementedError(
+                        f"Underdetermined input expression: {sym_or_exp}"
+                    )
 
                 # Define a new symbol for the input size.
                 size_proxy = codegen_proxy()
@@ -472,27 +491,9 @@ class FxConverter:
                 )
                 self.expr_to_proxy[size_symbol] = size_proxy
 
-                # Solve for the undefined symbol.
-                undefined_symbol = undefined_symbols[0]
-                solution = try_solve(
-                    sympy.Eq(sym_or_exp, size_symbol), undefined_symbol
+                self._define_symbol_by_solving(
+                    sym_or_exp, size_symbol, undefined_symbols[0]
                 )
-                if solution is None:
-                    raise ValueError(f"Cannot solve input expression: {sym_or_exp}")
-
-                # Since the symbol is a size, it must be an integer.
-                # Therefore, we can convert division to FloorDiv.
-                undefined_symbol_expr = solution[1]
-                if undefined_symbol.is_integer:
-                    undefined_symbol_expr = replace_floor_div(
-                        sympy.floor(undefined_symbol_expr)
-                    )
-
-                # Generate FX for the symbol.
-                self._sympy_interp(undefined_symbol_expr)
-                self.expr_to_proxy[undefined_symbol] = self.expr_to_proxy[
-                    undefined_symbol_expr
-                ]
 
         for ir_node in self.graph_inputs.values():
             if isinstance(ir_node, ir.TensorBox):
@@ -507,6 +508,36 @@ class FxConverter:
                     _codegen_symbol(
                         stride, placeholder_node, torch.ops.aten.sym_stride.int, dim
                     )
+
+        # A compound input binds its whole expression to one placeholder, so a
+        # symbol appearing only inside it has no node of its own. Recover it
+        # from that placeholder, after the loop above has defined every symbol
+        # the tensor shapes determine.
+        for ir_node in self.graph_inputs.values():
+            if not isinstance(ir_node, sympy.Expr) or isinstance(ir_node, sympy.Symbol):
+                continue
+            proxy = self.expr_to_proxy.get(ir_node)
+            if proxy is None:
+                continue
+            undefined = [
+                sym for sym in ir_node.free_symbols if sym not in self.expr_to_proxy
+            ]
+            if len(undefined) == 0:
+                continue
+            elif len(undefined) > 1:
+                # One bound value cannot determine several symbols. This is a
+                # branch closing over an expression whose symbols come from
+                # tensors it does not take, such as y.shape[0] + z.shape[0].
+                raise NotImplementedError(
+                    f"Compound input {ir_node} leaves these symbols undefined: "
+                    f"{sorted(undefined, key=str)}"
+                )
+
+            # A tensor-derived FX node does not reserve its symbol's name, so a
+            # Dummy is what keeps the anchor from colliding with one.
+            anchor = sympy.Dummy(proxy.node.name, integer=True)
+            self.expr_to_proxy[anchor] = proxy
+            self._define_symbol_by_solving(ir_node, anchor, undefined[0])
 
     def _generate_graph_constants(self) -> None:
         for name, value in V.graph.constants.items():
@@ -671,6 +702,28 @@ class FxConverter:
             expr,
         )
         return self.expr_to_proxy[expr]
+
+    def _define_symbol_by_solving(
+        self, expr: sympy.Expr, anchor: sympy.Symbol, symbol: sympy.Symbol
+    ) -> None:
+        """
+        Define symbol by solving expr == anchor, which already maps to a proxy.
+        """
+        # try_solve only isolates a symbol appearing linearly, so the inverse
+        # it returns is the only one.
+        solution = try_solve(sympy.Eq(expr, anchor), symbol)
+        if solution is None:
+            raise NotImplementedError(
+                f"Cannot solve input expression {expr} for {symbol}"
+            )
+
+        symbol_expr = solution[1]
+        # The symbol is an integer, so division becomes FloorDiv.
+        if symbol.is_integer:
+            symbol_expr = replace_floor_div(sympy.floor(symbol_expr))
+
+        self._sympy_interp(symbol_expr)
+        self.expr_to_proxy[symbol] = self.expr_to_proxy[symbol_expr]
 
     def _generate_sym_node(self, s: int | sympy.Expr) -> int | torch.fx.Node:
         if isinstance(s, (int, sympy.Integer)):


### PR DESCRIPTION
Summary:

## Context
Inductor's FX backend (`fx_wrapper`) turns a lowered graph into an FX `GraphModule`. `_generate_graph_inputs` binds each runtime argument to a node, and it recognized only two kinds of symbolic input: a constant, or a single `sympy.Symbol`.

## TLDR
Accept a compound symbolic graph input such as `2*s0 + 1`: bind the whole expression to one placeholder instead of aborting with "Unable to extract buffer from node", and recover its constituent symbol by solving that expression.

## Problem
- **Compound symbolic inputs fell through.** `_generate_graph_inputs` passed them to `_get_buffer`, which failed to extract a buffer.
- **It reaches real graphs.** A `torch.cond` branch closing over a compound `SymInt` receives it as a subgraph input, so the expression arrives as a `sympy.Add`.
- **Binding the expression is not enough on its own.** Kernel indexing takes an expression's free symbols as its size arguments, so a Triton call inside the branch asks for `s0` itself, which has no node: `Could not find a node corresponding to the symbol s0`.

## Solution
- **One placeholder carries the whole expression.** `SymbolBuffer` now holds any `sympy.Expr` plus an optional name, so a compound input takes the same buffer, placeholder and `expr_to_proxy` path as a single symbol instead of a parallel one.
- **Resolve constituent symbols after tensor shapes.** `_generate_graph_input_shapes` makes a second pass over compound inputs, when at most one symbol remains unknown, and solves for it.
- **Share one solving path.** `_define_symbol_by_solving` centralizes solving, `FloorDiv` conversion, FX interpretation, and symbol registration, which the tensor-shape path previously duplicated inline. Each caller creates its anchor: a nonnegative integer `Symbol` for a size, or a `Dummy` for a compound input whose name is not reserved by a tensor-derived FX node.
- **Two compound-input cases are rejected outright.** An expression the solver cannot invert and an expression containing more than one unknown both raise `NotImplementedError` naming the expression. One bound value cannot determine several symbols.
- **Compound expressions must be known to be integer-valued**, otherwise `_generate_graph_inputs` raises `NotImplementedError` before calling `convert_to_symint`, which would build a `SymInt` that is not an integer. An expression whose integer-ness is merely unknown is rejected too.

## Note on scope
Neither path validates that a solution's denominator is nonzero, so an input such as `u0 * s0` inverts to a division that is meaningless when `u0` is zero. This is pre-existing on the tensor-shape path and unchanged here; `2*s0 + 1` is unaffected. A proper fix should consult ShapeEnv nonzero facts and cover both paths, and is left to a follow-up.

Test Plan:
## Automated verification
- `test_compound_symint_graph_input` — compiles a GPU `torch.cond` whose branches close over `2*y.shape[0] + 1`, compares it with eager through `check`, and verifies each branch has one symbolic placeholder holding the whole expression.
- `test_nonlinear_compound_input_rejected` and `test_underdetermined_compound_input_rejected` — the two rejected cases above, reached through export rather than injection: `y.shape[0] * y.shape[0]` lifts as `s**2`, and `y.shape[0] + z.shape[0]` leaves two symbols undefined.
- Full `fxir_backend` suite under `fbcode//mode/opt`: Pass 86, Fail 0, Skip 0.

## Manual verification steps
Compiling the model in the test, before and after this change:

- **Before** (parent commit): `InductorError: Unable to extract buffer from node: 2*s17 + 1`
- **After**: compiles and matches eager.

Each half of the fix was then removed on its own and the test re-run, to confirm it is actually covered:

- **Whole-expression binding removed:** `Unable to extract buffer from node`.
- **Constituent-symbol recovery removed:** `AssertionError: Could not find a node corresponding to the symbol s17`.

Differential Revision: D114096755


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo