### PR TITLE
Add overload of isFwGradDefined to avoid optional ctor

### DIFF
--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -91,8 +91,12 @@ inline void set_history(
   }
 }
 
+inline bool isFwGradDefined(const at::Tensor& t) {
+  return t.defined() && t._fw_grad(/*level */ 0).defined();
+}
+
 inline bool isFwGradDefined(const std::optional<at::Tensor>& t) {
-  return t.has_value() && t->defined() && t->_fw_grad(/*level */ 0).defined();
+  return t.has_value() && isFwGradDefined(t.value());
 }
 
 inline bool isFwGradDefinedTensorList(const at::ITensorListRef& variables) {


### PR DESCRIPTION
isFwGradDefined is called a lot in
torch/csrc/autograd/generated/VariableType*.cpp. Many of these calls pass a Tensor into the function. The original implementation of this function only accepted an optional<Tensor>. This forced a call to the optional constructor every time that function is called and an unnecessary call to optional<Tensor>::has_value() later.

This commit adds an overload that accepts Tensor. I got Codex to write a microbenchmark that calls torch.sin, torch.add, and torch.addcmul with 1, 2, and 3 empty tensors respectively and it consistently shows a small improvement in the run time. Here are the results for visibility but the big caveat is that **this is a microbenchmark specifically targeting this code path and not representative of real world performance**.

| Benchmark   | Baseline (ns) | Candidate (ns) | Improvement |
| ----------- | ------------: | -------------: | ----------: |
| sin         |         914.0 |          803.2 |      12.12% |
| add         |        1105.5 |          940.2 |      14.95% |
| addcmul     |        1262.7 |         1111.5 |      11.97% |
| add_inplace |         975.4 |          711.3 |      27.07% |