### PR TITLE
Stop running test_vec_compare_op_cpu_only on GPU CI runners

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3593,6 +3593,7 @@ class CPUReproTests(TestCase):
         eps = torch.tensor(0.9, dtype=torch.float64)
         self.common(fn, (input, eps))
 
+    @slowTest
     @requires_vectorization
     @patch("torch.cuda.is_available", lambda: False)
     def test_vec_compare_op_cpu_only(self):

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -31,6 +31,7 @@ from torch.testing._internal.common_utils import (
     get_gcc_major_version,
     instantiate_parametrized_tests,
     IS_ARM64,
+    IS_CI,
     IS_CPU_EXT_SVE_SUPPORTED,
     IS_FBCODE,
     IS_MACOS,
@@ -41,6 +42,7 @@ from torch.testing._internal.common_utils import (
     skipIfRocm,
     skipIfRocmArch,
     slowTest,
+    TEST_CUDA,
     TEST_WITH_ROCM,
     xfailIf,
     xfailIfS390X,
@@ -3594,8 +3596,10 @@ class CPUReproTests(TestCase):
         self.common(fn, (input, eps))
 
     @slowTest
+    # Pure CPU vec codegen; running it on a GPU CI runner leaves the GPU idle
+    # for the ~1h this test takes.
+    @unittest.skipIf(IS_CI and TEST_CUDA, "CPU-only test, skip on GPU runners")
     @requires_vectorization
-    @patch("torch.cuda.is_available", lambda: False)
     def test_vec_compare_op_cpu_only(self):
         def fn(x):
             y1 = torch.eq(x, 1.0)


### PR DESCRIPTION
## Summary

`test_vec_compare_op_cpu_only` is pure CPU vec codegen -- it compiles
comparison ops over a 2x9 CPU tensor. No CUDA kernel is launched. It still
runs on the cuda sm86 slow shards, taking ~57 min (measured 3429s, 3489s)
with the a10g idle throughout.

That straddles the 60 min per-test timeout (`run_test.py:667`), and
`run_test_retries` re-runs it 3x with a fresh budget each (`:872`) -- 180 min
against a 240 min job cap. 12 of the last 14 slow runs lost at least one sm86
shard to this.

CI test selection is per build config, not per device, and there is no CUDA
blocklist -- ROCm and s390x both already blocklist this file.

## Change

- `@slowTest` explicitly. Currently slow-gated only via `slow_tests.json`,
  stale since 2026-04-06 and recording this test at 62.9s.
- `@unittest.skipIf(IS_CI and TEST_CUDA, ...)`. Keeps it on the CPU-only
  clang21 slow jobs and on dev machines; drops it where a GPU sits idle.
- Removes the now-unreachable
  `@patch("torch.cuda.is_available", lambda: False)`.

Drops the only AVX2 coverage of this test (sm86 is the sole AVX2 runner,
clang21 is AVX512), and does not make it cheaper -- ~40 min remains on the
CPU job. True, but that's the problem of CPU coverage, not to bundle with GPU runner

Authored with assistance from an AI coding assistant (Claude).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo