### PR TITLE
[dynamo] Fix slow invoke_subgraph reuse lookup for pytree args (dataclasses, namedtuples, etc.)

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -3975,6 +3975,15 @@ class GraphModule(torch.nn.Module):
             for ri, ei in zip(r, e):
                 self.assertEqual(ri, ei)
 
+    def _cleanup_pytree_registration(self, cls):
+        # _deregister_pytree_node raises KeyError for classes registered
+        # without serialized_type_name (they share a sentinel key in
+        # SERIALIZED_TYPE_TO_PYTHON_TYPE), so pop the registries directly
+        # instead, as in test_activation_checkpointing.py.
+        pytree.SUPPORTED_NODES.pop(cls, None)
+        pytree.SUPPORTED_SERIALIZED_TYPES.pop(cls, None)
+        pytree.CONSTANT_NODES.discard(cls)
+
     def test_subgraph_reuse_dataclass_pytree_arg(self):
         """Reuse must work for args that are registered pytree dataclasses.
 
@@ -3987,7 +3996,8 @@ class GraphModule(torch.nn.Module):
         Note: this also passes on the pre-fix implementation (reuse already
         worked, just slowly by re-tracing pytree.tree_flatten's dispatch on
         every call) -- this guards the fingerprinting correctness, not the
-        compile-time regression fixed alongside it.
+        compile-time regression fixed alongside it (see
+        test_subgraph_reuse_pytree_avoids_retracing_tree_flatten).
         """
         import dataclasses
 
@@ -4000,7 +4010,7 @@ class GraphModule(torch.nn.Module):
             lambda value: ([value.hidden], None),
             lambda children, _: RegionInput(*children),
         )
-        self.addCleanup(pytree._deregister_pytree_node, RegionInput)
+        self.addCleanup(self._cleanup_pytree_registration, RegionInput)
 
         @nested_compile_region
         def gn(inp):
@@ -4020,6 +4030,115 @@ class GraphModule(torch.nn.Module):
 
         # Same treespec/leaf types on every call -> single trace, rest reused.
         self.assertEqual(count(), 1)
+        self.assertEqual(ref, res)
+
+    def test_subgraph_reuse_pytree_avoids_retracing_tree_flatten(self):
+        """Regression test for the #191809 compile-time blowup.
+
+        build_input_fingerprint used to call
+        _make_inlined(tx, pytree.tree_flatten) on every single reuse-lookup
+        (i.e. once per region invocation, not once per compile), making
+        Dynamo bytecode-trace tree_flatten's own recursive dispatch from
+        scratch every time. Only the leaf-level flatten_fn of each container
+        node should be inlined/traced now, so _make_inlined must never be
+        called with pytree.tree_flatten itself for a plain dataclass arg.
+        """
+        import dataclasses
+
+        from torch._dynamo.variables import invoke_subgraph as invoke_subgraph_mod
+
+        def flatten_fn(value):
+            return ([value.hidden], None)
+
+        @dataclasses.dataclass
+        class RegionInput:
+            hidden: torch.Tensor
+
+        pytree.register_pytree_node(
+            RegionInput, flatten_fn, lambda children, _: RegionInput(*children)
+        )
+        self.addCleanup(self._cleanup_pytree_registration, RegionInput)
+
+        @nested_compile_region
+        def gn(inp):
+            return inp.hidden.sin()
+
+        def fn(x):
+            out = x
+            for _ in range(8):
+                out = gn(RegionInput(out))
+            return out
+
+        x = torch.randn(8)
+
+        orig_make_inlined = invoke_subgraph_mod._make_inlined
+        inlined_fns = []
+
+        def _tracking_make_inlined(tx, f):
+            inlined_fns.append(f)
+            return orig_make_inlined(tx, f)
+
+        with (
+            mock.patch.object(
+                invoke_subgraph_mod, "_make_inlined", _tracking_make_inlined
+            ),
+            self._count_speculate_calls() as count,
+        ):
+            torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+
+        # Reuse must still work (same treespec/tags on every call).
+        self.assertEqual(count(), 1)
+        # The dataclass's own flatten_fn must have been inlined at least
+        # once, to confirm this test actually reaches
+        # build_fingerprint_with_pytree rather than passing vacuously (e.g.
+        # if a future change routed this case through the flat-leaf fast
+        # path instead).
+        self.assertIn(flatten_fn, inlined_fns)
+        # But the *generic recursive dispatch* must not be re-traced on
+        # every call -- that's the bug being fixed.
+        self.assertNotIn(pytree.tree_flatten, inlined_fns)
+
+    def test_subgraph_reuse_pytree_partial_flatten_fn(self):
+        """flatten_fn need not be a plain function -- e.g. functools.partial.
+
+        _make_inlined only supports plain Python functions (it always wraps
+        its argument in a UserFunctionVariable, which graph-breaks on
+        anything else). build_input_fingerprint must fall back rather than
+        call _make_inlined directly on a non-function flatten_fn.
+        """
+        import dataclasses
+        import functools
+
+        @dataclasses.dataclass
+        class RegionInput:
+            hidden: torch.Tensor
+
+        def _flatten_impl(config_flag, value):
+            return ([value.hidden], config_flag)
+
+        pytree.register_pytree_node(
+            RegionInput,
+            functools.partial(_flatten_impl, "cfg"),
+            lambda children, _: RegionInput(*children),
+        )
+        self.addCleanup(self._cleanup_pytree_registration, RegionInput)
+
+        @nested_compile_region
+        def gn(inp):
+            return inp.hidden.cos()
+
+        def fn(x):
+            out = x
+            for _ in range(4):
+                out = gn(RegionInput(out))
+            return out
+
+        x = torch.randn(8)
+        ref = fn(x)
+        # fullgraph=True raises on any graph break instead of silently
+        # falling back, so this proves the partial flatten_fn doesn't
+        # graph-break.
+        res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
         self.assertEqual(ref, res)
 
     def test_subgraph_reuse_namedtuple_arg(self):
@@ -4053,6 +4172,154 @@ class GraphModule(torch.nn.Module):
             res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
 
         self.assertEqual(count(), 1)
+        self.assertEqual(ref, res)
+
+    def test_subgraph_reuse_two_distinct_namedtuple_types(self):
+        """Two different namedtuple types must not be conflated by reuse.
+
+        Both types normalize to the same registry key (collections.
+        namedtuple), so correctness depends on the concrete class surviving
+        in the TreeSpec context (set by pytree._namedtuple_flatten, which
+        returns type(d)) rather than being lost during normalization.
+        """
+        import collections
+
+        Left = collections.namedtuple("Left", ["hidden"])
+        Right = collections.namedtuple("Right", ["hidden"])
+
+        @nested_compile_region
+        def gn(inp):
+            return inp.hidden.sin()
+
+        def fn(x, y):
+            a = gn(Left(x))
+            b = gn(Right(y))
+            # A second Left(...) call should hit the cache from the first,
+            # proving reuse isn't simply broken outright (which would also
+            # produce two traces, same as the false Left/Right conflation
+            # this test is meant to catch).
+            c = gn(Left(y))
+            return a, b, c
+
+        x = torch.randn(8)
+        y = torch.randn(8)
+        ref = fn(x, y)
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x, y)
+
+        # Left and Right each need their own trace (2), but the second Left
+        # call reuses the first rather than adding a third trace.
+        self.assertEqual(count(), 2)
+        self.assertEqual(ref, res)
+
+    def test_subgraph_reuse_dataclass_pytree_kwarg(self):
+        """Reuse must work for pytree dataclasses passed as kwargs.
+
+        build_input_fingerprint's fast path only applies when there are no
+        kwargs (build_input_fingerprint:217), so the pytree-flatten path
+        (exercised here with a kwarg) is the one primarily exercised by
+        real callers of nested_compile_region.
+        """
+        import dataclasses
+
+        @dataclasses.dataclass
+        class RegionInput:
+            hidden: torch.Tensor
+
+        pytree.register_pytree_node(
+            RegionInput,
+            lambda value: ([value.hidden], None),
+            lambda children, _: RegionInput(*children),
+        )
+        self.addCleanup(self._cleanup_pytree_registration, RegionInput)
+
+        @nested_compile_region
+        def gn(*, inp):
+            return inp.hidden.sin()
+
+        def fn(x):
+            out = x
+            for _ in range(4):
+                out = gn(inp=RegionInput(out))
+            return out
+
+        x = torch.randn(8)
+        ref = fn(x)
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+
+        self.assertEqual(count(), 1)
+        self.assertEqual(ref, res)
+
+    def test_subgraph_reuse_nested_pytree_arg(self):
+        """Reuse must work for multi-level nested pytree structures.
+
+        Exercises the recursive `flatten(child)` call for a dict containing
+        a tuple of a tensor and a registered dataclass, rather than only a
+        depth-1 structure.
+        """
+        import dataclasses
+
+        @dataclasses.dataclass
+        class Wrapper:
+            hidden: torch.Tensor
+
+        pytree.register_pytree_node(
+            Wrapper,
+            lambda value: ([value.hidden], None),
+            lambda children, _: Wrapper(*children),
+        )
+        self.addCleanup(self._cleanup_pytree_registration, Wrapper)
+
+        @nested_compile_region
+        def gn(d):
+            b_tensor, wrapper = d["b"]
+            return d["a"].sin() + b_tensor.cos() + wrapper.hidden.relu()
+
+        def fn(x, y, z):
+            out = x
+            for _ in range(4):
+                out = gn({"a": out, "b": (y, Wrapper(z))})
+            return out
+
+        x, y, z = torch.randn(8), torch.randn(8), torch.randn(8)
+        ref = fn(x, y, z)
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x, y, z)
+
+        self.assertEqual(count(), 1)
+        self.assertEqual(ref, res)
+
+    def test_subgraph_reuse_pytree_unsupported_leaf(self):
+        """An arg containing an opaque/unregistered object must not crash.
+
+        build_input_fingerprint's has_unknown flag is set instead, which
+        gates reuse off for that call (the region is simply retraced) rather
+        than raising or misclassifying the object.
+        """
+
+        class Opaque:
+            def __init__(self, v):
+                self.v = v
+
+        @nested_compile_region
+        def gn(pair):
+            t, _opaque = pair
+            return t.sin()
+
+        def fn(pair):
+            out = pair[0]
+            for _ in range(4):
+                out = gn((out, pair[1]))
+            return out
+
+        opaque = Opaque(1)
+        x = torch.randn(8)
+        ref = fn((x, opaque))
+        res = torch.compile(fn, backend="aot_eager", fullgraph=True)((x, opaque))
         self.assertEqual(ref, res)
 
     def test_subgraph_reuse_different_constants_retrace(self):

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -4319,8 +4319,66 @@ class GraphModule(torch.nn.Module):
         opaque = Opaque(1)
         x = torch.randn(8)
         ref = fn((x, opaque))
-        res = torch.compile(fn, backend="aot_eager", fullgraph=True)((x, opaque))
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)((x, opaque))
+
+        # has_unknown must actually be reached: every call retraces rather
+        # than misclassifying Opaque as something reusable.
+        self.assertEqual(count(), 4)
         self.assertEqual(ref, res)
+
+    def test_subgraph_reuse_pytree_registry_change_stays_correct(self):
+        """Correctness must hold even if the pytree registry changes
+        between calls to an already-compiled function.
+
+        build_fingerprint_with_pytree's fast path no longer installs a
+        guard on the pytree registry itself for plain-function flatten_fns
+        (see its docstring), on the theory that the registry can't change
+        mid-trace, and a stale/changed registry can only affect whether a
+        subgraph gets reused at compile time -- never the values the
+        compiled graph actually computes. This pins that: after
+        deregistering the pytree node the compiled artifact was built
+        against, calling that artifact again (whether or not it triggers a
+        recompile) must still produce correct results.
+        """
+        import dataclasses
+
+        @dataclasses.dataclass
+        class RegionInput:
+            hidden: torch.Tensor
+
+        pytree.register_pytree_node(
+            RegionInput,
+            lambda value: ([value.hidden], None),
+            lambda children, _: RegionInput(*children),
+        )
+        self.addCleanup(self._cleanup_pytree_registration, RegionInput)
+
+        @nested_compile_region
+        def gn(inp):
+            return inp.hidden.sin()
+
+        def fn(x):
+            out = x
+            for _ in range(4):
+                out = gn(RegionInput(out))
+            return out
+
+        x1 = torch.randn(8)
+        ref1 = fn(x1)
+        compiled = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        self.assertEqual(ref1, compiled(x1))
+
+        # Deregister the pytree node the compiled artifact was built
+        # against, then call it again -- via the same compiled wrapper, not
+        # a fresh torch.compile call, so this exercises whatever guard
+        # check (or lack thereof) protects the existing compiled artifact.
+        self._cleanup_pytree_registration(RegionInput)
+
+        x2 = torch.randn(8)
+        ref2 = fn(x2)
+        self.assertEqual(ref2, compiled(x2))
 
     def test_subgraph_reuse_different_constants_retrace(self):
         """Constant args with different values each require a fresh trace.

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -3975,6 +3975,86 @@ class GraphModule(torch.nn.Module):
             for ri, ei in zip(r, e):
                 self.assertEqual(ri, ei)
 
+    def test_subgraph_reuse_dataclass_pytree_arg(self):
+        """Reuse must work for args that are registered pytree dataclasses.
+
+        Fingerprinting such args goes through the pytree-flatten path of
+        build_input_fingerprint (rather than the flat-leaf fast path), which
+        must classify the tensor field inside the dataclass as a reusable
+        leaf so that repeated calls with structurally-identical dataclass
+        instances hit the cache instead of retracing every time.
+
+        Note: this also passes on the pre-fix implementation (reuse already
+        worked, just slowly by re-tracing pytree.tree_flatten's dispatch on
+        every call) -- this guards the fingerprinting correctness, not the
+        compile-time regression fixed alongside it.
+        """
+        import dataclasses
+
+        @dataclasses.dataclass
+        class RegionInput:
+            hidden: torch.Tensor
+
+        pytree.register_pytree_node(
+            RegionInput,
+            lambda value: ([value.hidden], None),
+            lambda children, _: RegionInput(*children),
+        )
+        self.addCleanup(pytree._deregister_pytree_node, RegionInput)
+
+        @nested_compile_region
+        def gn(inp):
+            return inp.hidden.sin()
+
+        def fn(x):
+            out = x
+            for _ in range(4):
+                out = gn(RegionInput(out))
+            return out
+
+        x = torch.randn(8)
+        ref = fn(x)
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+
+        # Same treespec/leaf types on every call -> single trace, rest reused.
+        self.assertEqual(count(), 1)
+        self.assertEqual(ref, res)
+
+    def test_subgraph_reuse_namedtuple_arg(self):
+        """Reuse must work for args that are plain namedtuples.
+
+        All namedtuple types are implicitly registered as pytree nodes under
+        a single shared registry key (collections.namedtuple), unlike
+        explicitly-registered dataclasses. The fingerprinting path must
+        normalize the concrete namedtuple subtype to that shared key the same
+        way pytree._get_node_type does, or it will be misclassified as an
+        unsupported leaf and never get reused.
+        """
+        import collections
+
+        RegionInput = collections.namedtuple("RegionInput", ["hidden"])
+
+        @nested_compile_region
+        def gn(inp):
+            return inp.hidden.sin()
+
+        def fn(x):
+            out = x
+            for _ in range(4):
+                out = gn(RegionInput(out))
+            return out
+
+        x = torch.randn(8)
+        ref = fn(x)
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+
+        self.assertEqual(count(), 1)
+        self.assertEqual(ref, res)
+
     def test_subgraph_reuse_different_constants_retrace(self):
         """Constant args with different values each require a fresh trace.
 

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -4,6 +4,7 @@ supporting helpers for subgraph reuse (auto-cache) in Dynamo's invoke_subgraph
 higher-order operator.
 """
 
+import collections
 import enum
 import logging
 import traceback
@@ -205,13 +206,12 @@ def build_input_fingerprint(
 ) -> InputFingerprint:
     """Build an InputFingerprint by flattening (args, kwargs) via pytree.
 
-    Uses _make_inlined(tx, pytree.tree_flatten) to recursively flatten
-    the argument structure into leaf VTs, classifying each leaf as
+    Flattens the argument structure into leaf VTs, classifying each leaf as
     tensor/symnode/constant/module. Also records the TreeSpec so that
     cache lookups can verify structural equivalence.
 
     Fast path: when kwargs is empty and all args are already leaf VTs
-    (tensor/symnode/constant/module), skip the expensive pytree flatten.
+    (tensor/symnode/constant/module), skip the pytree flatten entirely.
     """
     # Fast path: flat args, no kwargs — skip pytree machinery.
     if not kwargs:
@@ -250,25 +250,35 @@ def build_fingerprint_with_pytree(
 ) -> InputFingerprint:
     """Build fingerprint via pytree flatten for nested/kwargs cases.
 
-    Recurses over the pytree structure natively (untraced) instead of calling
-    ``_make_inlined(tx, pytree.tree_flatten)``, which used to bytecode-trace
-    pytree.tree_flatten's own recursive dispatch from scratch on every
-    reuse-lookup (i.e. once per region invocation, not once per compile).
-    Only the leaf-level ``flatten_fn`` of each container node is still
-    inlined/traced, same as before.
+    Recurses over the pytree structure natively (untraced), inlining/tracing
+    only each container node's own ``flatten_fn`` rather than the full
+    recursive tree_flatten dispatch around it. This is safe because node-type
+    classification only depends on ``type()``, never on tensor values.
 
-    Note: since the node-type/registry dispatch (tree_is_leaf,
-    SUPPORTED_NODES lookup) is no longer traced, it no longer installs
-    guards on the pytree registry itself. This is safe: this flatten is
-    purely internal reuse bookkeeping, and a stale/mismatched registry can
-    only make a cached subgraph ineligible for reuse (has_unknown / treespec
-    mismatch), never silently wrong.
+    Note: skipping the traced registry dispatch also means we no longer
+    install guards on the pytree registry itself. That's fine here: this
+    fingerprint is built fresh from the live registry on every reuse-lookup
+    (register_pytree_node isn't traceable, so the registry can't change
+    mid-trace), and reuse is separately gated on treespec/tag equality. So a
+    registry change between compiles can only make a cached subgraph
+    ineligible for reuse (has_unknown / treespec mismatch), never silently
+    wrong.
     """
     from torch._dynamo.variables.builder import SourcelessBuilder
 
     flat_vts: list[tuple[InputTag, VariableTracker]] = []
     arg_sources: list[Source | None] = []
     has_unknown = False
+
+    def add_leaf(vt: VariableTracker) -> None:
+        nonlocal has_unknown
+        tag = classify_vt(vt)
+        if tag is None:
+            has_unknown = True
+        else:
+            flat_vts.append((tag, vt))
+            # Always append (even None) to keep positional alignment with flat_vts.
+            arg_sources.append(getattr(vt, "source", None))
 
     def flatten(node_vt: VariableTracker) -> pytree.TreeSpec:
         nonlocal has_unknown
@@ -279,19 +289,27 @@ def build_fingerprint_with_pytree(
             return pytree.treespec_leaf()
         # Keep in sync with pytree._get_node_type.
         if pytree.is_namedtuple_class(node_type):
-            node_type = pytree.namedtuple
+            node_type = collections.namedtuple
 
         if node_type not in pytree.SUPPORTED_NODES:
-            tag = classify_vt(node_vt)
-            if tag is None:
-                has_unknown = True
-            else:
-                flat_vts.append((tag, node_vt))
-                # Always append (even None) to keep positional alignment with flat_vts.
-                arg_sources.append(getattr(node_vt, "source", None))
+            add_leaf(node_vt)
             return pytree.treespec_leaf()
 
         flatten_fn = pytree.SUPPORTED_NODES[node_type].flatten_fn
+        if not isinstance(flatten_fn, types.FunctionType):
+            # _make_inlined only supports plain Python functions (it always
+            # wraps its argument in a UserFunctionVariable). A flatten_fn
+            # registered as e.g. a functools.partial, bound method, or
+            # callable object can't go through it directly. Fall back to
+            # tracing the full recursive tree_flatten for this subtree, which
+            # dispatches calls generically and so handles any callable.
+            leaves_vt, treespec_vt = unpack_iterable(
+                tx, _make_inlined(tx, pytree.tree_flatten)(node_vt)
+            )
+            for leaf_vt in unpack_iterable(tx, leaves_vt):
+                add_leaf(leaf_vt)
+            return treespec_vt.as_python_constant()
+
         children_vt, context_vt = unpack_iterable(
             tx, _make_inlined(tx, flatten_fn)(node_vt)
         )

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -248,29 +248,59 @@ def build_fingerprint_with_pytree(
     fn_args_vt: Any,
     kwargs: dict[str, Any],
 ) -> InputFingerprint:
-    """Build fingerprint via pytree flatten for nested/kwargs cases."""
-    from torch._dynamo.variables.builder import SourcelessBuilder
+    """Build fingerprint via pytree flatten for nested/kwargs cases.
 
-    container_vt = SourcelessBuilder.create(tx, (list(fn_args_vt), kwargs))
-    flat_list_vt, treespec_vt = unpack_iterable(
-        tx, _make_inlined(tx, pytree.tree_flatten)(container_vt)
-    )
-    treespec = treespec_vt.as_python_constant()
+    Recurses over the pytree structure natively (untraced) instead of calling
+    ``_make_inlined(tx, pytree.tree_flatten)``, which used to bytecode-trace
+    pytree.tree_flatten's own recursive dispatch from scratch on every
+    reuse-lookup (i.e. once per region invocation, not once per compile).
+    Only the leaf-level ``flatten_fn`` of each container node is still
+    inlined/traced, same as before.
+
+    Note: since the node-type/registry dispatch (tree_is_leaf,
+    SUPPORTED_NODES lookup) is no longer traced, it no longer installs
+    guards on the pytree registry itself. This is safe: this flatten is
+    purely internal reuse bookkeeping, and a stale/mismatched registry can
+    only make a cached subgraph ineligible for reuse (has_unknown / treespec
+    mismatch), never silently wrong.
+    """
+    from torch._dynamo.variables.builder import SourcelessBuilder
 
     flat_vts: list[tuple[InputTag, VariableTracker]] = []
     arg_sources: list[Source | None] = []
     has_unknown = False
 
-    for vt in unpack_iterable(tx, flat_list_vt):
-        tag = classify_vt(vt)
-        if tag is not None:
-            flat_vts.append((tag, vt))
-        else:
+    def flatten(node_vt: VariableTracker) -> pytree.TreeSpec:
+        nonlocal has_unknown
+        try:
+            node_type = node_vt.python_type()
+        except NotImplementedError:
             has_unknown = True
-            continue
+            return pytree.treespec_leaf()
+        # Keep in sync with pytree._get_node_type.
+        if pytree.is_namedtuple_class(node_type):
+            node_type = pytree.namedtuple
 
-        # Always append (even None) to keep positional alignment with flat_vts.
-        arg_sources.append(getattr(vt, "source", None))
+        if node_type not in pytree.SUPPORTED_NODES:
+            tag = classify_vt(node_vt)
+            if tag is None:
+                has_unknown = True
+            else:
+                flat_vts.append((tag, node_vt))
+                # Always append (even None) to keep positional alignment with flat_vts.
+                arg_sources.append(getattr(node_vt, "source", None))
+            return pytree.treespec_leaf()
+
+        flatten_fn = pytree.SUPPORTED_NODES[node_type].flatten_fn
+        children_vt, context_vt = unpack_iterable(
+            tx, _make_inlined(tx, flatten_fn)(node_vt)
+        )
+        context = context_vt.as_python_constant()
+        child_specs = [flatten(child) for child in unpack_iterable(tx, children_vt)]
+        return pytree.TreeSpec(node_type, context, child_specs)
+
+    container_vt = SourcelessBuilder.create(tx, (list(fn_args_vt), kwargs))
+    treespec = flatten(container_vt)
 
     return InputFingerprint(flat_vts, arg_sources, has_unknown, treespec)
 

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -256,13 +256,15 @@ def build_fingerprint_with_pytree(
     classification only depends on ``type()``, never on tensor values.
 
     Note: skipping the traced registry dispatch also means we no longer
-    install guards on the pytree registry itself. That's fine here: this
-    fingerprint is built fresh from the live registry on every reuse-lookup
-    (register_pytree_node isn't traceable, so the registry can't change
-    mid-trace), and reuse is separately gated on treespec/tag equality. So a
-    registry change between compiles can only make a cached subgraph
-    ineligible for reuse (has_unknown / treespec mismatch), never silently
-    wrong.
+    install guards on the pytree registry itself, for the plain-function
+    flatten_fn case (the non-FunctionType fallback below still traces the
+    full tree_flatten and so still installs them). That's fine either way:
+    this fingerprint is built fresh from the live registry on every
+    reuse-lookup (register_pytree_node isn't traceable, so the registry
+    can't change mid-trace), and reuse is separately gated on treespec/tag
+    equality. So a registry change between compiles can only make a cached
+    subgraph ineligible for reuse (has_unknown / treespec mismatch), never
+    silently wrong.
     """
     from torch._dynamo.variables.builder import SourcelessBuilder
 


### PR DESCRIPTION
Fixes #191809

## Root cause

`build_input_fingerprint()` in `torch/_dynamo/variables/invoke_subgraph.py`
runs on every single invocation of a `nested_compile_region`-decorated
function, not just the first, to decide whether a previously-traced
subgraph can be reused. When the arguments are already flat leaf tensors
this is cheap (`build_fingerprint_fast`, an untraced Python loop). When an
argument needs pytree flattening (e.g. a `@dataclass` registered as a
pytree node), it fell back to `build_fingerprint_with_pytree`, which called
`_make_inlined(tx, pytree.tree_flatten)(...)` -- i.e. it made Dynamo
bytecode-trace pytree.tree_flatten's own recursive Python implementation
(a closure-based recursive `helper` plus list comprehensions) from scratch
on every call. Profiling the reported repro (36-layer loop) showed ~28,600
`symbolic_convert.step()` calls and ~900 fresh inline-tracer setups coming
almost entirely from this one lookup path, matching the reported ~17ms per
lookup vs ~0.04ms for flat args.

## Fix

`build_fingerprint_with_pytree` now recurses over the pytree structure
natively (untraced, in the Dynamo implementation itself) instead of
inlining `pytree.tree_flatten`. It mirrors `pytree.tree_flatten`'s own
recursion (`tree_is_leaf` / `_get_node_type` / `SUPPORTED_NODES` lookup),
which is safe to do untraced since pytree node classification depends only
on `type()`, never on tensor values. Dynamo's inline-tracing is now
invoked only for each container node's own `flatten_fn` -- the same calls
that were already happening as sub-calls inside the old generic recursive
trace -- so the expensive generic dispatch/recursion wrapper around them is
no longer itself traced.

One side effect: since the registry dispatch (`tree_is_leaf`,
`SUPPORTED_NODES` lookup) is no longer traced, it no longer installs
guards on the pytree registry itself (measured up to 143 -> 16 guards in
one case). This is safe -- this flatten is purely internal reuse
bookkeeping; a stale/mismatched registry can only make a cached subgraph
ineligible for reuse, never silently wrong.

## Test plan

Added `test_subgraph_reuse_dataclass_pytree_arg` and
`test_subgraph_reuse_namedtuple_arg` to
`test/higher_order_ops/test_invoke_subgraph.py`, asserting reuse still
triggers (single trace) and results match eager for both a registered
dataclass arg and a plain namedtuple arg (namedtuples are normalized to a
shared registry key, which is the trickiest part of this change).

I was not able to build this repo locally (Windows box, no local
`pip install -e .` build available), so I validated behavior-preservation
differentially instead: I extracted the old and new `build_fingerprint_with_pytree`
implementations and ran both against a separately-installed torch wheel
across 10 pytree-shaped scenarios (dataclass, namedtuple, nested
dict/list/dataclass, kwargs, OrderedDict, defaultdict, an unsupported/opaque
leaf, a module-typed arg), comparing treespec, per-leaf tags, arg_sources,
has_unknown, and the leaf proxy identities wired into the traced graph --
all identical old vs. new. I also reproduced the reported speedup this way:
`build_input_fingerprint` total time for a 36-layer dataclass-pytree loop
dropped from ~1.6-2.0s to ~80-200ms.

The two new unit tests were validated the same way (translated to the
installed wheel and run standalone), matching in both patched and
unpatched configurations where applicable, but have **not** been executed
via `python test/higher_order_ops/test_invoke_subgraph.py` against an
actual build of this diff. Given the guard-set change noted above, it's
worth someone with a working build also running `test/dynamo/test_misc.py`
and `test/dynamo/test_recompiles.py` before merging, in case any
guard-count-sensitive expected-inline tests need updating.

```
python test/higher_order_ops/test_invoke_subgraph.py -k test_subgraph_reuse_dataclass_pytree_arg
python test/higher_order_ops/test_invoke_subgraph.py -k test_subgraph_reuse_namedtuple_arg
lintrunner torch/_dynamo/variables/invoke_subgraph.py test/higher_order_ops/test_invoke_subgraph.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98