### PR TITLE
[Testcase Refactoring] Add hw-classification in test_pipe

### DIFF
--- a/test/distributed/pipelining/test_pipe.py
+++ b/test/distributed/pipelining/test_pipe.py
@@ -5,6 +5,7 @@ from model_registry import MLPModule, ModelWithParamAlias
 import torch
 from torch.distributed.pipelining import pipe_split, pipeline
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -78,6 +79,8 @@ CHECK_FQN_SET_EQUALITY = False
 
 
 class PipeTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize("ModelClass", [ExampleCode, MultiMLP, ModelWithParamAlias])
     def test_model_split(self, ModelClass):
         mod = ModelClass()


### PR DESCRIPTION
## Summary
Classify `PipeTests` in `test_pipe.py` as `HardwareClassification.GENERIC`.

## Changes
- `test/distributed/pipelining/test_pipe.py`:
  - Added `from torch.testing._internal.common_utils import HardwareClassification` and `hw_classification = HardwareClassification.GENERIC` on `PipeTests`. `PipeTests` is a plain `TestCase` (no `instantiate_device_type_tests`, no `device` parameter) exercising the `torch.distributed.pipelining.pipe` FX-splitting API on CPU — device-agnostic logic that is not parametrized over device types, so it belongs to the GENERIC category. The classification is metadata: it only filters tests when `--hw-classification` is passed; normal discovery/execution is unchanged.

## Motivation
`PipeTests` had no `hw_classification` label, so it could not participate in `--hw-classification` filtering. As a device-agnostic (non-device-parametrized) test class, it belongs to the GENERIC category, which lets the suite filter it appropriately by hardware category.

## Notes
This is part of the test case refactoring initiative tracked in #185590.