### PR TITLE
Fix typo in DeviceCapability doc comment

### DIFF
--- a/c10/core/DeviceCapability.h
+++ b/c10/core/DeviceCapability.h
@@ -19,7 +19,7 @@ enum ScalarTypeIndex {
 };
 
 /**
- * @brief DeviceCapability represents the the common capabilities that all
+ * @brief DeviceCapability represents the common capabilities that all
  * devices should support.
  *
  * This struct provides a compact way to represent the common capabilities that


### PR DESCRIPTION
**Impact:** Documentation only — no code behavior changes **Risk:** low

## What
Removes a duplicated "the" in the Doxygen comment describing `DeviceCapability` in `c10/core/DeviceCapability.h`.

## Why
Minor typo cleanup in a comment ("the the" -> "the").