### PR TITLE
[MOCK][DO NOT MERGE] Run aarch64 inductor perf on staging m8g.metal-24xl

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -150,7 +150,12 @@ jobs:
       actions: read
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
-    runs-on: ${{ inputs.runner_prefix }}${{ startsWith(inputs.runner, 'l-') && inputs.runner || contains(inputs.runner, 'arm64') && 'l-arm64g4-16-62' || 'l-x86iavx512-8-64' }}
+    # MOCK / DO NOT MERGE: staging runners (runner_prefix "c-mt-") live in the
+    # "meta-staging-aws-ue1" runner group and must be targeted by group +
+    # label. Every other prefix keeps the original plain string form, so the
+    # rest of this PR's build jobs are unaffected. Revert to the single-line
+    # `runs-on: ${{ inputs.runner_prefix }}${{ ... }}` before merging.
+    runs-on: ${{ inputs.runner_prefix == 'c-mt-' && fromJSON(format('{{"group":"meta-staging-aws-ue1","labels":["{0}{1}"]}}', inputs.runner_prefix, startsWith(inputs.runner, 'l-') && inputs.runner || contains(inputs.runner, 'arm64') && 'l-arm64g4-16-62' || 'l-x86iavx512-8-64')) || format('{0}{1}', inputs.runner_prefix, startsWith(inputs.runner, 'l-') && inputs.runner || contains(inputs.runner, 'arm64') && 'l-arm64g4-16-62' || 'l-x86iavx512-8-64') }}
     container:
       image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${{ inputs.docker-image-name }}${{ inputs.ci-docker-hash && format('-{0}', inputs.ci-docker-hash) || '' }}
     timeout-minutes: 480

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -130,7 +130,12 @@ jobs:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
     environment: ${{ github.ref == 'refs/heads/main' && 'scribe-protected' || startsWith(github.ref, 'refs/heads/release/') && 'scribe-protected' || contains(github.event.pull_request.labels.*.name, 'ci-scribe') && 'scribe-pr' || '' }}
-    runs-on: ${{ matrix.runner }}
+    # MOCK / DO NOT MERGE: staging runners (c-mt-) live in the
+    # "meta-staging-aws-ue1" runner group, so they must be targeted by group +
+    # label rather than label alone. Non-staging runners keep the plain string
+    # form, so every other job in this PR is unaffected. Revert to
+    # `runs-on: ${{ matrix.runner }}` before merging.
+    runs-on: ${{ startsWith(matrix.runner, 'c-mt-') && fromJSON(format('{{"group":"meta-staging-aws-ue1","labels":["{0}"]}}', matrix.runner)) || matrix.runner }}
     container:
       image: ${{ inputs.docker-image }}
       options: "--gpus all"

--- a/.github/workflows/inductor-perf-test-nightly-aarch64.yml
+++ b/.github/workflows/inductor-perf-test-nightly-aarch64.yml
@@ -5,6 +5,12 @@ on:
   schedule:
     # Does not perform max_autotune on CPU, so skip the weekly run setup
     - cron: 0 7 * * *
+  # MOCK / DO NOT MERGE: run this workflow on the PR that edits it, so the
+  # aarch64 perf matrix can be exercised against the staging m8g.metal-24xl
+  # runner before the bare-metal switch lands. Remove before merging.
+  pull_request:
+    paths:
+      - .github/workflows/inductor-perf-test-nightly-aarch64.yml
   # NB: GitHub has an upper limit of 10 inputs here
   workflow_dispatch:
     inputs:
@@ -80,7 +86,11 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner_prefix: "mt-"
+      # MOCK / DO NOT MERGE: "c-mt-" routes both this build and the whole
+      # translated test-matrix to the meta-staging-aws-ue1 cluster, so the perf
+      # shards land on c-mt-l-barm64g4-94-344 (m8g.metal-24xl bare metal).
+      # Revert to "mt-" before merging.
+      runner_prefix: "c-mt-"
       runner: linux.arm64.${{ needs.get-label-type.outputs.runner-config }}.4xlarge
       build-environment: linux-jammy-aarch64-py3.10
       docker-image-name: ci-image:pytorch-linux-jammy-aarch64-py3.10-gcc13-inductor-benchmarks
@@ -136,7 +146,10 @@ jobs:
     name: linux-jammy-aarch64-py3.10-inductor
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-aarch64-py3_10-inductor-build
-    if: github.event.schedule == '0 7 * * *'
+    # MOCK / DO NOT MERGE: the `|| pull_request` clause is what makes the full
+    # 39-shard matrix actually run on this PR. Revert to the schedule-only
+    # condition before merging.
+    if: github.event.schedule == '0 7 * * *' || github.event_name == 'pull_request'
     with:
       build-environment: ${{ needs.linux-jammy-aarch64-py3_10-inductor-build.outputs.build-environment }}
       dashboard-tag: training-false-inference-true-default-true-dynamic-true-cppwrapper-true-aotinductor-true


### PR DESCRIPTION
**Do not merge.** Validation-only PR for pytorch/ci-infra#969.

## Why

#188336 reports an aarch64 inductor regression on *Abs Execution Time* after the ARC migration, with relative speedup flat — eager slowed by the same factor, which points at the host rather than the compiler.

Cause: `l-barm64g4-94-344` was added on a **virtualized `m8g.24xlarge`** as a stand-in for `m8g.metal-24xl`, so the benchmarks run under the Nitro hypervisor and pick up steal time and scheduling jitter. pytorch/ci-infra#969 moves it to real bare metal. This PR exercises that runner before the switch reaches prod.

## What this does

Routes the aarch64 nightly at the `meta-staging-aws-ue1` cluster, where the bare-metal change is already deployed:

- `inductor-perf-test-nightly-aarch64.yml`: `runner_prefix: "mt-"` → `"c-mt-"`, a `pull_request` trigger path-filtered to this file, and the nightly test job's `if:` also accepts `pull_request`.
- `_linux-build.yml` / `_linux-test.yml`: staging runners live in the **`meta-staging-aws-ue1` runner group**, so `runs-on` has to name the group, not just the label. Applied **conditionally** — only `c-mt-` prefixed runners get the `{group, labels}` object form; every other prefix falls through to the original plain string. So no other job in this PR changes behaviour and nothing else needs disabling.

All five edits are marked `MOCK / DO NOT MERGE` inline.

Full 39-shard matrix is unchanged (9 huggingface + 15 timm + 15 torchbench), so numbers stay comparable to the nightly.

## Verified before opening

- `map_ec2_to_arc.py --prefix "c-mt-"` on `linux.arm64.m8g.metal-24xl` → `c-mt-l-barm64g4-94-344`. The `arc.yaml:84` mapping already exists; no change needed there.
- `actionlint` clean on all three workflows.
- The `runs-on` expressions resolve to exactly `{"group":"meta-staging-aws-ue1","labels":["c-mt-l-barm64g4-94-344"]}` (test) and `...["c-mt-l-arm64g4-16-62"]` (build).
- Both scale sets exist on staging-ue1 with unlimited `maxRunners`, and their `runnerGroup` is `meta-staging-aws-ue1`.
- On that cluster the NodePool `m8g-metal-metal-24xl` is `Ready`, pinned to `m8g.metal-24xl`, `arch=arm64`, tainted `node-fleet=m8g-metal`; the job-pod spec tolerates only that fleet and requests 94 CPU / 344Gi.
- `m8g.metal-24xl` is offered in us-east-1 a/b/c, which is what this cluster uses.

## Known risks

1. **Runner group must grant this repo.** Naming the group in `runs-on` only selects it — the group still has to list `pytorch/pytorch` in its repository access, which is org-level config (needs `admin:org`, so I could not check it). If access is not granted the shards queue regardless; the fallback is to run this on `pytorch/pytorch-canary`, where `c-mt-` is the native prefix.
2. **No `m8g.metal-24xl` has booted yet.** Zero NodeClaims so far, so Karpenter has never launched this type here. Bare-metal capacity errors or AMI boot problems would surface for the first time on this run — which is the point.
3. Bare metal boots slower than virtualized, so expect a long lead time before the first shard starts. 39 shards means 39 bare-metal nodes on a staging cluster.

## What to look for

Abs Execution Time back at pre-migration levels. Relative speedup should be unchanged, since it was never the thing that regressed.

Related: pytorch/ci-infra#969
Issue: #188336