### PR TITLE
[Testcase Refactoring] Add hw_classification to generic dynamo test files

### DIFF
--- a/test/dynamo/test_complex.py
+++ b/test/dynamo/test_complex.py
@@ -7,6 +7,7 @@ from torch.testing._internal.common_utils import instantiate_parametrized_tests
 
 
 class ComplexDynamoTestCase(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/test/dynamo/test_exception_contract.py
+++ b/test/dynamo/test_exception_contract.py
@@ -21,6 +21,7 @@ OPS = [
 
 
 class TestIndexErrorContract(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     def _make_tensor(self):
         return torch.randn(4)
 

--- a/test/dynamo/test_nb_and.py
+++ b/test/dynamo/test_nb_and.py
@@ -5,6 +5,7 @@
 import torch
 import torch._dynamo.test_case
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     make_dynamo_test,
 )
@@ -12,6 +13,7 @@ from torch.utils._ordered_set import OrderedSet
 
 
 class TestNbAnd(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
     def setUp(self):
         super().setUp()
         self._u_prev = torch._dynamo.config.enable_trace_unittest

--- a/test/dynamo/test_nb_divmod.py
+++ b/test/dynamo/test_nb_divmod.py
@@ -2,12 +2,13 @@
 
 import torch
 import torch._dynamo.test_case
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import HardwareClassification, make_dynamo_test
 
 
 @torch._dynamo.config.patch(enable_trace_unittest=True)
 @torch._dynamo.config.patch(enable_trace_load_build_class=True)
 class TestNbDivmod(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
     # --- Integer divmod ---
     @make_dynamo_test
     def test_divmod_integers(self):

--- a/test/dynamo/test_nb_floordiv.py
+++ b/test/dynamo/test_nb_floordiv.py
@@ -2,12 +2,13 @@
 
 import torch
 import torch._dynamo.test_case
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import HardwareClassification, make_dynamo_test
 
 
 @torch._dynamo.config.patch(enable_trace_unittest=True)
 @torch._dynamo.config.patch(enable_trace_load_build_class=True)
 class TestNbFloorDivide(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
     # --- Integer floordiv ---
     @make_dynamo_test
     def test_floordiv_integers(self):

--- a/test/dynamo/test_nb_remainder.py
+++ b/test/dynamo/test_nb_remainder.py
@@ -2,12 +2,13 @@
 
 import torch
 import torch._dynamo.test_case
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import HardwareClassification, make_dynamo_test
 
 
 @torch._dynamo.config.patch(enable_trace_unittest=True)
 @torch._dynamo.config.patch(enable_trace_load_build_class=True)
 class TestNbRemainder(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
     # --- Integer remainder ---
     @make_dynamo_test
     def test_mod_integers(self):

--- a/test/dynamo/test_nb_truediv.py
+++ b/test/dynamo/test_nb_truediv.py
@@ -2,12 +2,13 @@
 
 import torch
 import torch._dynamo.test_case
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import HardwareClassification, make_dynamo_test
 
 
 @torch._dynamo.config.patch(enable_trace_unittest=True)
 @torch._dynamo.config.patch(enable_trace_load_build_class=True)
 class TestNbTrueDivide(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
     # --- Integer truediv (always promotes to float) ---
     @make_dynamo_test
     def test_truediv_integers(self):

--- a/test/dynamo/test_nb_xor.py
+++ b/test/dynamo/test_nb_xor.py
@@ -5,6 +5,7 @@
 import torch
 import torch._dynamo.test_case
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     make_dynamo_test,
 )
@@ -12,6 +13,7 @@ from torch.utils._ordered_set import OrderedSet
 
 
 class TestNbXor(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
     def setUp(self):
         super().setUp()
         self._u_prev = torch._dynamo.config.enable_trace_unittest

--- a/test/dynamo/test_repr_protocol.py
+++ b/test/dynamo/test_repr_protocol.py
@@ -8,7 +8,7 @@ import unittest
 
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import HardwareClassification, make_dynamo_test
 
 
 class _Color(enum.Enum):
@@ -21,6 +21,7 @@ class _OpaqueReprDescriptorObject:
 
 
 class TpReprTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     @make_dynamo_test
     def test_int_repr(self):
         assert repr(3) == "3"  # noqa: S101

--- a/test/dynamo/test_str_protocol.py
+++ b/test/dynamo/test_str_protocol.py
@@ -7,7 +7,7 @@ import unittest
 
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import HardwareClassification, make_dynamo_test
 
 
 class _OpaqueStrDescriptorObject:
@@ -15,6 +15,7 @@ class _OpaqueStrDescriptorObject:
 
 
 class TpStrTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     @make_dynamo_test
     def test_str_int(self):
         assert str(42) == "42"  # noqa: S101

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -16,6 +16,7 @@ from torch._dynamo import utils
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_LINUX,
     IS_MACOS,
     TEST_WITH_ASAN,
@@ -28,6 +29,7 @@ _IS_WINDOWS = sys.platform == "win32"
 
 
 class TestUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     def test_cleanup_hook_tolerates_missing_name(self):
         # During interpreter shutdown the scope's module __dict__ may already be
         # cleared before the weakref callback fires the hook. The hook must not
@@ -352,6 +354,7 @@ class TestModel(torch.nn.Module):
 
 
 class TestDynamoTimed(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     """
     Test utilities surrounding dynamo_timed.
     """
@@ -1299,6 +1302,7 @@ class TestDynamoTimed(TestCase):
 
 
 class TestTimedSync(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
     def test_timed_syncs_on_accelerator(self, device):
         if torch.device(device).type == "cpu":
             self.skipTest("sync only triggered for non-CPU devices")
@@ -1322,6 +1326,7 @@ instantiate_device_type_tests(TestTimedSync, globals(), allow_xpu=True)
 
 
 class TestInductorConfigParsingForLogging(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     """
     Test for parsing inductor config for logging in CompilationMetrics.
     """
@@ -1392,6 +1397,7 @@ class TestInductorConfigParsingForLogging(TestCase):
 
 
 class TestFunctorchConfigParsingForLogging(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     def test_functorch_config_jsonify(self):
         functorch_config_json = utils._functorch_config_for_logging()
         self.assertIsInstance(functorch_config_json, str)


### PR DESCRIPTION
## Summary

Add hw_classification = HardwareClassification.GENERIC to 14 TestCase subclasses across 11 test/dynamo files. Also add ACCELERATOR to TestTimedSync (already uses instantiate_device_type_tests).

## Motivation

Enables --hw-classification filtering (introduced in #186918) to correctly classify these tests.

## Test Plan

No behavior change (only adds metadata attribute). CI runs on main where HardwareClassification is available.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98