### PR TITLE
[c10d] Fix cudaErrorStreamCaptureMerge with NCCL in nested CUDA graph captures

### DIFF
--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_utils import (
     IS_LINUX,
     run_tests,
     skip_but_pass_in_sandcastle_if,
+    TEST_CUDA_GRAPH_CONDITIONAL_NODES,
     TEST_WITH_DEV_DBG_ASAN,
     TEST_WITH_ROCM,
 )
@@ -378,6 +379,104 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
         self.assertEqual(static_output.sum().item(), expected_sum)
         torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH_CONDITIONAL_NODES,
+        "CUDA 12.4 or greater is required for CUDA Graphs with conditional nodes",
+    )
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_nccl_cudagraph_nested_capture(self):
+        """NCCL in a parent capture followed by NCCL in a nested child capture
+        must not hit cudaErrorStreamCaptureMerge."""
+        from torch._higher_order_ops.cudagraph_conditional_nodes import (
+            CUDAGraphCaptureControlFlowOpDispatchMode,
+        )
+
+        rank = self.rank_to_GPU[self.rank][0]
+        torch.cuda.set_device(rank)
+        group_name = self.pg.group_name
+
+        def all_reduce(tensor):
+            result = torch.ops._c10d_functional.all_reduce(tensor, "sum", group_name)
+            return torch.ops._c10d_functional.wait_tensor(result)
+
+        def true_branch(tensor):
+            return all_reduce(tensor + 1)
+
+        def false_branch(tensor):
+            return tensor - 1
+
+        tensor = torch.full((4,), self.rank + 1, dtype=torch.float32, device=rank)
+        predicate = torch.tensor(True, device=rank)
+        capture_stream = torch.cuda.Stream(device=rank)
+
+        with torch.cuda.stream(capture_stream):
+            all_reduce(tensor)
+            true_branch(tensor)
+            false_branch(tensor)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        with (
+            torch.cuda.graph(graph, stream=capture_stream),
+            CUDAGraphCaptureControlFlowOpDispatchMode(),
+        ):
+            t = all_reduce(tensor)
+            torch.cond(predicate, true_branch, false_branch, (t,))
+
+        # The graph is intentionally not instantiated: conditional-node bodies
+        # do not support the event nodes NCCL stream syncing records, which is
+        # a separate limitation from the capture-time merge error tested here.
+        graph.reset()
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH_CONDITIONAL_NODES,
+        "CUDA 12.4 or greater is required for CUDA Graphs with conditional nodes",
+    )
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_nccl_cudagraph_many_nested_captures(self):
+        """NCCL inside >32 conditional nodes must not exhaust the stream pool."""
+        from torch._higher_order_ops.cudagraph_conditional_nodes import (
+            CUDAGraphCaptureControlFlowOpDispatchMode,
+        )
+
+        rank = self.rank_to_GPU[self.rank][0]
+        torch.cuda.set_device(rank)
+        group_name = self.pg.group_name
+
+        def all_reduce(tensor):
+            result = torch.ops._c10d_functional.all_reduce(tensor, "sum", group_name)
+            return torch.ops._c10d_functional.wait_tensor(result)
+
+        def true_branch(tensor):
+            return all_reduce(tensor + 1)
+
+        def false_branch(tensor):
+            return tensor - 1
+
+        tensor = torch.full((4,), self.rank + 1, dtype=torch.float32, device=rank)
+        predicate = torch.tensor(True, device=rank)
+        capture_stream = torch.cuda.Stream(device=rank)
+
+        with torch.cuda.stream(capture_stream):
+            all_reduce(tensor)
+            true_branch(tensor)
+            false_branch(tensor)
+        torch.cuda.synchronize()
+
+        num_cond_nodes = 40
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        with (
+            torch.cuda.graph(graph, stream=capture_stream),
+            CUDAGraphCaptureControlFlowOpDispatchMode(),
+        ):
+            t = all_reduce(tensor)
+            for _ in range(num_cond_nodes):
+                t = torch.cond(predicate, true_branch, false_branch, (t,))
+
+        graph.reset()
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -379,6 +379,53 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         self.assertEqual(static_output.sum().item(), expected_sum)
         torch.cuda.memory._set_allocator_settings("expandable_segments:False")
 
+    @unittest.skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/157896")
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_nccl_cudagraph_nested_capture(self):
+        """NCCL in a parent capture followed by NCCL in a nested child capture
+        must not hit cudaErrorStreamCaptureMerge."""
+        from torch._higher_order_ops.cudagraph_conditional_nodes import (
+            CUDAGraphCaptureControlFlowOpDispatchMode,
+        )
+
+        rank = self.rank_to_GPU[self.rank][0]
+        torch.cuda.set_device(rank)
+        group_name = self.pg.group_name
+
+        def all_reduce(tensor):
+            result = torch.ops._c10d_functional.all_reduce(tensor, "sum", group_name)
+            return torch.ops._c10d_functional.wait_tensor(result)
+
+        def true_branch(tensor):
+            return all_reduce(tensor + 1)
+
+        def false_branch(tensor):
+            return tensor - 1
+
+        tensor = torch.full((4,), self.rank + 1, dtype=torch.float32, device=rank)
+        predicate = torch.tensor(True, device=rank)
+        capture_stream = torch.cuda.Stream(device=rank)
+
+        with torch.cuda.stream(capture_stream):
+            all_reduce(tensor)
+            true_branch(tensor)
+            false_branch(tensor)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        with (
+            torch.cuda.graph(graph, stream=capture_stream),
+            CUDAGraphCaptureControlFlowOpDispatchMode(),
+        ):
+            t = all_reduce(tensor)
+            torch.cond(predicate, true_branch, false_branch, (t,))
+
+        # The graph is intentionally not instantiated: conditional-node bodies
+        # do not support the event nodes NCCL stream syncing records, which is
+        # a separate limitation from the capture-time merge error tested here.
+        graph.reset()
+
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_reduce_ops(self):

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3620,7 +3620,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing(OpType optype) {
 
   // `getKeyFromDevice` is how we get keys for both collectives and batch P2P
   const auto key = getKeyFromDevice(device);
-  auto ncclStream = ncclStreams_.at(key);
+  auto ncclStream = getNCCLStream(key, device);
   auto opProfilerTitle = optype != OpType::COALESCED
       ? "nccl:" + opTypeToString(optype) + "_coalesced"
       : "nccl:coalesced";
@@ -3779,7 +3779,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
 
   // in asyncOp=false [default] mode, we use currentStream as ncclStream
   // otherwise, we use separate ncclStream and let it sync on currentStream
-  auto ncclStream = asyncOp ? ncclStreams_.at(key)
+  auto ncclStream = asyncOp ? getNCCLStream(key, device)
                             : at::cuda::getCurrentCUDAStream(device.index());
   if (asyncOp) {
     // First let NCCL streams wait for input tensors allocation streams
@@ -3977,7 +3977,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
 
   // in asyncOp=false [default] mode, we use currentStream as ncclStream
   // otherwise, we use separate ncclStream and let it sync on currentStream
-  auto ncclStream = asyncOp ? ncclStreams_.at(key)
+  auto ncclStream = asyncOp ? getNCCLStream(key, device)
                             : at::cuda::getCurrentCUDAStream(device.index());
   if (asyncOp) {
     // First let NCCL streams wait for input tensors allocation streams
@@ -4236,7 +4236,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
   }
 
   // Used many times below, so we stash the unordered_map lookup
-  auto ncclStream = ncclStreams_.at(key);
+  auto ncclStream = getNCCLStream(key, device);
   // First let NCCL streams wait for input tensors allocation streams
   syncStream(device, ncclEvents_[key], ncclStream);
 
@@ -6157,6 +6157,61 @@ c10::intrusive_ptr<Backend> ProcessGroupNCCL::shrink(
 }
 
 #endif // NCCL_HAS_COMM_SHRINK
+
+at::cuda::CUDAStream ProcessGroupNCCL::getNCCLStream(
+    const std::string& key,
+    const at::Device& device) {
+  auto& defaultStream = ncclStreams_.at(key);
+  auto currentStream = at::cuda::getCurrentCUDAStream(device.index());
+  auto curInfo = c10::cuda::captureInfoMayInitCtx(currentStream.stream());
+  if (curInfo.status != c10::cuda::CaptureStatus::Active) {
+    return defaultStream;
+  }
+  auto ncclInfo = c10::cuda::captureInfoMayInitCtx(defaultStream.stream());
+  if (ncclInfo.status != c10::cuda::CaptureStatus::Active ||
+      ncclInfo.id == curInfo.id) {
+    return defaultStream;
+  }
+  std::lock_guard<std::mutex> lock(ncclCaptureStreamsMutex_);
+  auto& pool = ncclCaptureStreams_[key];
+  auto it = pool.active.find(curInfo.id);
+  if (it != pool.active.end()) {
+    return it->second;
+  }
+  for (auto mapIt = pool.active.begin(); mapIt != pool.active.end();) {
+    auto info = c10::cuda::captureInfoMayInitCtx(mapIt->second.stream());
+    if (info.status != c10::cuda::CaptureStatus::Active) {
+      pool.retired.push_back(mapIt->second);
+      mapIt = pool.active.erase(mapIt);
+    } else {
+      ++mapIt;
+    }
+  }
+  if (!pool.retired.empty()) {
+    auto stream = pool.retired.back();
+    pool.retired.pop_back();
+    pool.active.emplace(curInfo.id, stream);
+    return stream;
+  }
+  at::cuda::CUDAGuard gpuGuard(device.index());
+  cudaStream_t raw_stream = nullptr;
+  bool force_high = getCvarBool(TORCH_NCCL_HIGH_PRIORITY, false);
+  if (options_->is_high_priority_stream || force_high) {
+    int least_priority = -1, greatest_priority = -1;
+    C10_CUDA_CHECK(
+        cudaDeviceGetStreamPriorityRange(&least_priority, &greatest_priority));
+    C10_CUDA_CHECK(cudaStreamCreateWithPriority(
+        &raw_stream, cudaStreamNonBlocking, greatest_priority));
+  } else {
+    C10_CUDA_CHECK(
+        cudaStreamCreateWithFlags(&raw_stream, cudaStreamNonBlocking));
+  }
+  OwnedCUDAStream owned_stream(raw_stream);
+  auto stream = at::cuda::getStreamFromExternal(raw_stream, device.index());
+  pool.owned.push_back(std::move(owned_stream));
+  pool.active.emplace(curInfo.id, stream);
+  return stream;
+}
 
 void ProcessGroupNCCL::initializeDeviceStateForComm(
     const at::Device& device,

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3620,7 +3620,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing(OpType optype) {
 
   // `getKeyFromDevice` is how we get keys for both collectives and batch P2P
   const auto key = getKeyFromDevice(device);
-  auto ncclStream = ncclStreams_.at(key);
+  auto ncclStream = getNCCLStream(key, device);
   auto opProfilerTitle = optype != OpType::COALESCED
       ? "nccl:" + opTypeToString(optype) + "_coalesced"
       : "nccl:coalesced";
@@ -3779,7 +3779,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
 
   // in asyncOp=false [default] mode, we use currentStream as ncclStream
   // otherwise, we use separate ncclStream and let it sync on currentStream
-  auto ncclStream = asyncOp ? ncclStreams_.at(key)
+  auto ncclStream = asyncOp ? getNCCLStream(key, device)
                             : at::cuda::getCurrentCUDAStream(device.index());
   if (asyncOp) {
     // First let NCCL streams wait for input tensors allocation streams
@@ -3977,7 +3977,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
 
   // in asyncOp=false [default] mode, we use currentStream as ncclStream
   // otherwise, we use separate ncclStream and let it sync on currentStream
-  auto ncclStream = asyncOp ? ncclStreams_.at(key)
+  auto ncclStream = asyncOp ? getNCCLStream(key, device)
                             : at::cuda::getCurrentCUDAStream(device.index());
   if (asyncOp) {
     // First let NCCL streams wait for input tensors allocation streams
@@ -4236,7 +4236,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
   }
 
   // Used many times below, so we stash the unordered_map lookup
-  auto ncclStream = ncclStreams_.at(key);
+  auto ncclStream = getNCCLStream(key, device);
   // First let NCCL streams wait for input tensors allocation streams
   syncStream(device, ncclEvents_[key], ncclStream);
 
@@ -6157,6 +6157,44 @@ c10::intrusive_ptr<Backend> ProcessGroupNCCL::shrink(
 }
 
 #endif // NCCL_HAS_COMM_SHRINK
+
+at::cuda::CUDAStream ProcessGroupNCCL::getNCCLStream(
+    const std::string& key,
+    const at::Device& device) {
+  auto& defaultStream = ncclStreams_.at(key);
+  auto currentStream = at::cuda::getCurrentCUDAStream(device.index());
+  auto curInfo = c10::cuda::captureInfoMayInitCtx(currentStream.stream());
+  if (curInfo.status != c10::cuda::CaptureStatus::Active) {
+    return defaultStream;
+  }
+  auto ncclInfo = c10::cuda::captureInfoMayInitCtx(defaultStream.stream());
+  if (ncclInfo.status != c10::cuda::CaptureStatus::Active ||
+      ncclInfo.id == curInfo.id) {
+    return defaultStream;
+  }
+  auto captureKey = key + "_" + std::to_string(curInfo.id);
+  auto it = ncclCaptureStreams_.find(captureKey);
+  if (it != ncclCaptureStreams_.end()) {
+    return it->second;
+  }
+  // Capture ids are unique per capture, so entries can never be looked up
+  // again once their capture ends. Prune them here (only on the miss path)
+  // to keep the map bounded by the number of concurrently active captures.
+  for (auto mapIt = ncclCaptureStreams_.begin();
+       mapIt != ncclCaptureStreams_.end();) {
+    auto info = c10::cuda::captureInfoMayInitCtx(mapIt->second.stream());
+    if (info.status != c10::cuda::CaptureStatus::Active) {
+      mapIt = ncclCaptureStreams_.erase(mapIt);
+    } else {
+      ++mapIt;
+    }
+  }
+  bool force_high = getCvarBool(TORCH_NCCL_HIGH_PRIORITY, false);
+  auto stream = at::cuda::getStreamFromPool(
+      options_->is_high_priority_stream || force_high, device.index());
+  ncclCaptureStreams_.emplace(captureKey, stream);
+  return stream;
+}
 
 void ProcessGroupNCCL::initializeDeviceStateForComm(
     const at::Device& device,

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -35,6 +35,7 @@
 #include <c10/core/Stream.h>
 #include <c10/core/StreamGuard.h>
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
 
@@ -1400,6 +1401,48 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   // The CUDA streams used by NCCL kernels
   std::unordered_map<std::string, at::cuda::CUDAStream> ncclStreams_;
+
+  // Streams for nested CUDA graph captures. When NCCL is used inside both a
+  // parent capture and a nested capture (e.g. a conditional-node body), the
+  // default ncclStream is already bound to the parent capture graph. Reusing
+  // it in the child capture would cause cudaErrorStreamCaptureMerge. Each
+  // per-device-key pool hands out one stream per active capture id. Streams
+  // are created raw rather than via getStreamFromPool, whose round-robin
+  // could hand back a stream already bound to the parent capture (the
+  // default ncclStream itself comes from that pool). Once a capture ends,
+  // its stream is retired for reuse by later captures. The raw streams are
+  // owned by the pool and destroyed with the process group; mirrors
+  // at::cuda::CUDAGraph::OwnedCUDAStream (private to that class).
+  // Guarded by ncclCaptureStreamsMutex_.
+  struct OwnedCUDAStream {
+    cudaStream_t stream = nullptr;
+    explicit OwnedCUDAStream(cudaStream_t s) : stream(s) {}
+    ~OwnedCUDAStream() {
+      if (stream) {
+        C10_CUDA_CHECK_WARN(cudaStreamDestroy(stream));
+      }
+    }
+    OwnedCUDAStream(const OwnedCUDAStream&) = delete;
+    OwnedCUDAStream& operator=(const OwnedCUDAStream&) = delete;
+    OwnedCUDAStream(OwnedCUDAStream&& o) noexcept : stream(o.stream) {
+      o.stream = nullptr;
+    }
+    OwnedCUDAStream& operator=(OwnedCUDAStream&&) = delete;
+  };
+  struct CaptureStreamPool {
+    std::unordered_map<c10::CaptureId_t, at::cuda::CUDAStream> active;
+    std::vector<at::cuda::CUDAStream> retired;
+    std::vector<OwnedCUDAStream> owned;
+  };
+  std::unordered_map<std::string, CaptureStreamPool> ncclCaptureStreams_;
+  std::mutex ncclCaptureStreamsMutex_;
+
+  // Returns the NCCL stream for the given device key, creating a
+  // capture-specific stream when the current stream and the default NCCL
+  // stream belong to different CUDA graph captures.
+  at::cuda::CUDAStream getNCCLStream(
+      const std::string& key,
+      const at::Device& device);
 
   // The CUDA events used to sync NCCL streams
   std::unordered_map<std::string, at::cuda::CUDAEvent> ncclEvents_;

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1401,6 +1401,22 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // The CUDA streams used by NCCL kernels
   std::unordered_map<std::string, at::cuda::CUDAStream> ncclStreams_;
 
+  // Streams for nested CUDA graph captures. When NCCL is used inside both a
+  // parent capture and a nested capture (e.g. a conditional-node body), the
+  // default ncclStream is already bound to the parent capture graph. Reusing
+  // it in the child capture would cause cudaErrorStreamCaptureMerge.  This
+  // map holds per-(device-key, capture-id) streams that are safe to use
+  // inside the nested capture. Entries are pruned lazily in getNCCLStream
+  // once their capture is no longer active.
+  std::unordered_map<std::string, at::cuda::CUDAStream> ncclCaptureStreams_;
+
+  // Returns the NCCL stream for the given device key, creating a
+  // capture-specific stream when the current stream and the default NCCL
+  // stream belong to different CUDA graph captures.
+  at::cuda::CUDAStream getNCCLStream(
+      const std::string& key,
+      const at::Device& device);
+
   // The CUDA events used to sync NCCL streams
   std::unordered_map<std::string, at::cuda::CUDAEvent> ncclEvents_;
 


### PR DESCRIPTION
Using NCCL inside a parent CUDA graph capture and then again inside a nested child capture (e.g. a `torch.cond()` branch body) fails with `cudaErrorStreamCaptureMerge`. The communicator's dedicated `ncclStream` is already capturing into the parent graph, so when the child capture tries to join it through an event wait, CUDA rejects the cross-capture dependency.

`getNCCLStream()` now compares the current stream's capture id against the one the default nccl stream is bound to. In the common cases (no capture, or same capture) it returns the default stream as before. If the ids differ, it hands out a dedicated stream for that capture from a small per-device pool, and once a capture ends its stream is retired and reused by the next nested capture.

`getStreamFromPool()` doesn't work here: the default nccl stream comes from that same 32-stream round-robin pool, so it could hand back a stream that is already capturing into the parent graph (cudagraph conditional nodes hit the same problem, see #185836). The pool streams are therefore created raw, honoring `TORCH_NCCL_HIGH_PRIORITY` and `is_high_priority_stream`, and owned by an RAII wrapper (modeled on `at::cuda::CUDAGraph::OwnedCUDAStream`) that destroys them with the process group. Destroying retired streams eagerly instead would be unsafe: `pointToPoint()` records tensors on the nccl stream via `CUDACachingAllocator::recordStream`, and a block that outlives the capture would later record an event on the destroyed stream. Pool access is guarded by its own mutex, taken only on the nested-capture path.

Note this only unblocks capture. Instantiating a graph with NCCL inside a conditional body still trips over the event nodes NCCL records for stream syncing, which is a separate limitation.

Fixes #191681

**Test Plan**

Two new regression tests: `test_nccl_cudagraph_nested_capture` (NCCL in a parent capture followed by NCCL inside a `torch.cond()` body) and `test_nccl_cudagraph_many_nested_captures` (40 conditional nodes, going past the 32-stream pool limit and exercising stream retire/reuse). Ran those plus the full op suite on 2x H200:

```
python test/distributed/test_c10d_ops_nccl.py -k cudagraph
python test/distributed/test_c10d_ops_nccl.py
```

All 34 tests pass (2 version-gated skips unrelated to this change).

Written with the help of an AI coding assistant.
