### PR TITLE
support DTensor S(1) -> Partial("sum")

### DIFF
--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -1871,8 +1871,8 @@ class TestMixedPartialTypes(TestCase):
             api()
 
         # Test redistribute_local_tensor separately (different call pattern)
-        # Note: public DTensor.redistribute() doesn't allow Partial targets at all,
-        # so we test the internal redistribute_local_tensor directly
+        # Public DTensor.redistribute() only allows Shard -> Partial(sum), so
+        # test mixed Partial targets through redistribute_local_tensor directly.
         current_spec = DTensorSpec(
             mesh,
             (Replicate(), Replicate()),

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -116,6 +116,67 @@ class RedistributeTest(DTensorContinuousTestBase):
             )
             self.assertEqual(comm_mode.get_total_counts(), 0)
 
+    @parametrize("dtype", [torch.float32, torch.cfloat])
+    def test_shard_to_partial_sum_forward_backward(self, dtype):
+        device_mesh = self.build_device_mesh()
+        partial_spec = [Partial("sum")]
+        input_sizes = [
+            (3, self.world_size - 1),
+            (3, self.world_size * 3),
+            (3, self.world_size * 3 + 1),
+            (3, self.world_size * 3 + 2),
+        ]
+
+        for input_size in input_sizes:
+            input_tensor = torch.randn(
+                input_size, device=self.device_type, requires_grad=True, dtype=dtype
+            )
+            shard_spec = [Shard(1)]
+            shard_dtensor = distribute_tensor(input_tensor, device_mesh, shard_spec)
+
+            comm_mode = CommDebugMode()
+            with comm_mode:
+                partial_dtensor = shard_dtensor.redistribute(device_mesh, partial_spec)
+            self.assertEqual(partial_dtensor.placements, partial_spec)
+            self.assertEqual(partial_dtensor.to_local().shape, input_tensor.shape)
+            self.assertEqual(comm_mode.get_total_counts(), 0)
+            self.assertEqual(partial_dtensor.full_tensor(), input_tensor)
+
+            grad_output = DTensor.from_local(
+                torch.ones_like(input_tensor),
+                device_mesh,
+                [Replicate()],
+                run_check=False,
+            )
+            with comm_mode:
+                partial_dtensor.backward(grad_output)
+            self.assertEqual(shard_dtensor.grad.placements, shard_spec)
+            self.assertEqual(
+                shard_dtensor.grad.to_local(),
+                torch.ones_like(shard_dtensor.to_local()),
+            )
+            self.assertEqual(comm_mode.get_total_counts(), 0)
+
+    def test_shard_to_partial_sum_graph_based(self):
+        device_mesh = self.build_device_mesh()
+        input_tensor = torch.randn(3, self.world_size * 3 + 1, device=self.device_type)
+        shard_dtensor = distribute_tensor(input_tensor, device_mesh, [Shard(1)])
+
+        with use_min_cost_redistribution_plan():
+            partial_dtensor = shard_dtensor.redistribute(device_mesh, [Partial("sum")])
+
+        self.assertEqual(partial_dtensor.full_tensor(), input_tensor)
+
+    def test_shard_to_non_sum_partial_raises(self):
+        device_mesh = self.build_device_mesh()
+        input_tensor = torch.randn(3, 12, device=self.device_type)
+        shard_dtensor = distribute_tensor(input_tensor, device_mesh, [Shard(1)])
+
+        with self.assertRaisesRegex(
+            RuntimeError, "only Shard to Partial\\(sum\\) redistribution"
+        ):
+            shard_dtensor.redistribute(device_mesh, [Partial("avg")])
+
     def test_replicate_to_replicate_forward_backward(self):
         device_mesh = self.build_device_mesh()
         replica_spec = [Replicate()]
@@ -851,7 +912,7 @@ class RedistributeTest(DTensorContinuousTestBase):
             # Non-Partial to Partial is NOT allowed
             ([Shard(0), Replicate()], [Shard(0), Partial()], False),
             ([Shard(0), Replicate()], [Replicate(), Partial()], False),
-            ([Shard(0), Shard(1)], [Replicate(), Partial()], False),
+            ([Shard(0), Shard(1)], [Replicate(), Partial()], True),
             # Partial to partial is allowed, if only the reduction ops is the same
             ([Shard(0), Partial("prod")], [Replicate(), Partial("sum")], False),
         ]
@@ -2024,6 +2085,19 @@ class DistributeWithStridedShardTest(DTensorContinuousTestBase):
         )
         with self.assertRaises(RuntimeError):
             src_dt.redistribute(mesh_2d, [Partial("sum"), Replicate()])
+
+        # Retaining _StridedShard after replacing its inner shard makes the
+        # greedy planner's logical shape inconsistent with the local shard.
+        src_dt = distribute_tensor(
+            input_2d,
+            mesh_2d,
+            [_StridedShard(0, split_factor=2), Shard(0)],
+        )
+        with self.assertRaises(RuntimeError):
+            src_dt.redistribute(
+                mesh_2d,
+                [_StridedShard(0, split_factor=2), Partial("sum")],
+            )
 
 
 class TransformInfoTest(TestCase):

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -730,7 +730,14 @@ class DTensor(torch.Tensor):
         3. ``Replicate()`` -> ``Shard(dim)``: local chunking (i.e. ``torch.chunk``)
         4. ``Partial()`` -> ``Replicate()``: ``all_reduce``
         5. ``Partial()`` -> ``Shard(dim)``: ``reduce_scatter``
+        6. ``Shard(dim)`` -> ``Partial("sum")``: local zero-filling. This
+           explicit-only conversion materializes a global-shape local tensor
+           on every rank and does not communicate.
 
+        Of conversions to ``Partial``, this public API supports only
+        ``Shard(dim)`` -> ``Partial("sum")``. Each rank places its local shard
+        at the corresponding offset in a zero-filled logical-shape tensor, so
+        summing across ranks reconstructs the original logical tensor.
 
         ``redistribute`` would correctly figure out the necessary redistribute steps for DTensors
         that are created either on 1-D or N-D DeviceMesh.
@@ -781,10 +788,16 @@ class DTensor(torch.Tensor):
         placements = list(placements)
         for i, placement in enumerate(placements):
             if placement.is_partial() and self.placements[i] != placement:
-                raise RuntimeError(
-                    f"Can not redistribute from {self.placements[i]} to {placement}, "
-                    "redistributing to Partial is for internal use only!"
-                )
+                source = self.placements[i]
+                if not (
+                    isinstance(source, Shard)
+                    and type(placement) is Partial
+                    and placement.reduce_op == "sum"
+                ):
+                    raise RuntimeError(
+                        f"Can not redistribute from {source} to {placement}, "
+                        "only Shard to Partial(sum) redistribution is supported!"
+                    )
             elif isinstance(placement, Shard) and placement.dim < 0:
                 # normalize shard dim to be positive
                 placements[i] = Shard(placement.dim + self.ndim)

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -730,6 +730,7 @@ class DTensor(torch.Tensor):
         3. ``Replicate()`` -> ``Shard(dim)``: local chunking (i.e. ``torch.chunk``)
         4. ``Partial()`` -> ``Replicate()``: ``all_reduce``
         5. ``Partial()`` -> ``Shard(dim)``: ``reduce_scatter``
+        6. ``Shard(dim)`` -> ``Partial("sum")``: local zero-filling
 
 
         ``redistribute`` would correctly figure out the necessary redistribute steps for DTensors
@@ -781,10 +782,16 @@ class DTensor(torch.Tensor):
         placements = list(placements)
         for i, placement in enumerate(placements):
             if placement.is_partial() and self.placements[i] != placement:
-                raise RuntimeError(
-                    f"Can not redistribute from {self.placements[i]} to {placement}, "
-                    "redistributing to Partial is for internal use only!"
-                )
+                source = self.placements[i]
+                if not (
+                    isinstance(source, Shard)
+                    and type(placement) is Partial
+                    and placement.reduce_op == "sum"
+                ):
+                    raise RuntimeError(
+                        f"Can not redistribute from {source} to {placement}, "
+                        "only Shard to Partial(sum) redistribution is supported!"
+                    )
             elif isinstance(placement, Shard) and placement.dim < 0:
                 # normalize shard dim to be positive
                 placements[i] = Shard(placement.dim + self.ndim)

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -459,8 +459,8 @@ def _compute_placement_transition_cost(
         comm_bytes_gb /= num_devices_on_mesh_dim
         return cost, comm_bytes_gb
     elif current_placement.is_shard() and target_placement.is_partial():
-        # ban shard -> partial as it does not make sense to perform
-        # this redistribute
+        # Do not introduce Shard -> Partial as an automatic op-strategy option.
+        # Explicit redistribution handles the supported Partial("sum") case.
         return float("inf"), comm_bytes_gb
     elif current_placement.is_partial() and target_placement.is_partial():
         # we already handled the == case at the top, and we ban converting between partial types.

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -432,7 +432,9 @@ def _compute_placement_transition_cost(
 
     Returns:
         A tuple of (cost, updated_comm_bytes_gb):
-            - cost: The communication cost for this transition (float("inf") if invalid).
+            - cost: The communication cost for this transition. ``float("inf")``
+              means that the strategy planner must not select the transition
+              implicitly; the explicit redistribution API may still support it.
             - updated_comm_bytes_gb: The updated communication bytes after this step.
     """
     if current_placement == target_placement:
@@ -459,8 +461,11 @@ def _compute_placement_transition_cost(
         comm_bytes_gb /= num_devices_on_mesh_dim
         return cost, comm_bytes_gb
     elif current_placement.is_shard() and target_placement.is_partial():
-        # ban shard -> partial as it does not make sense to perform
-        # this redistribute
+        # Shard -> Partial("sum") is a valid explicit redistribution, but it
+        # materializes a logical-shape tensor and copies the local shard into it.
+        # The cost model accounts only for communication, so assigning zero cost
+        # would make the strategy planner over-prefer this memory- and copy-heavy
+        # transition. Exclude it from implicit strategy selection instead.
         return float("inf"), comm_bytes_gb
     elif current_placement.is_partial() and target_placement.is_partial():
         # we already handled the == case at the top, and we ban converting between partial types.

--- a/torch/distributed/tensor/_ops/single_dim_strategy.py
+++ b/torch/distributed/tensor/_ops/single_dim_strategy.py
@@ -943,6 +943,12 @@ def _get_neighbor_placements(
     - Shard(d1) -> Shard(d2): all-to-all, valid if neither d1 nor d2 sharded right
     - Partial -> Replicate: allreduce, always valid
     - Partial -> Shard(d): reduce-scatter, valid if d not sharded to the right
+
+    Shard -> Partial("sum") is intentionally absent. Although explicit
+    redistribution supports it, the conversion materializes a global-shape
+    local tensor. Because the strategy cost model accounts only for communication,
+    we exclude this transition to avoid selecting it without accounting for its
+    memory and copy costs.
     """
     # Note: circular import
     from torch.distributed.tensor.placement_types import Partial

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -928,19 +928,23 @@ class DTensorRedistributePlanner:
         # Case 6. Replicate() -> Partial(), local math op, applies to:
         #   R* -> P[..., x]
         #
-        # (TODO) Case 7. _StridedShard(a) -> Shard(b), use all-to-all (a2a), applies to:
+        # Case 7. Shard() -> Partial("sum"), local zero-fill, generated as a
+        # destination-directed transition in find_min_cost_path(), applies to:
+        #   S(a)[..., x] -> P[..., x]
+        #
+        # (TODO) Case 8. _StridedShard(a) -> Shard(b), use all-to-all (a2a), applies to:
         #   SS(a)[..., x] -> S(b)[..., x]
         #
-        # Case 8. _StridedShard() -> Replicate(), use all-gather, applies to:
+        # Case 9. _StridedShard() -> Replicate(), use all-gather, applies to:
         #   SS(a)[..., x, y, z] -> SS(a)[..., x, y]
         #
-        # (TODO) Case 9. Shard(a) -> _StridedShard(b), use all-to-all (a2a), applies to:
+        # (TODO) Case 10. Shard(a) -> _StridedShard(b), use all-to-all (a2a), applies to:
         #   S(a)[..., x] -> SS(b)[..., x]
         #
-        # (TODO) Case 10. Partial() -> _StridedShard(), use reduce-scatter, applies to:
+        # (TODO) Case 11. Partial() -> _StridedShard(), use reduce-scatter, applies to:
         #   P[..., x, y] -> P[..., x]SS(a)[..., y] or P[..., x, y] -> P[..., y]SS(a)[..., x]
         #
-        # Case 11. Replicate() -> _StridedShard(), use chunk, applies to:
+        # Case 12. Replicate() -> _StridedShard(), use chunk, applies to:
         #   R* -> SS(a)[..., x]
         #
         # NB: Regarding `_StridedShard``, we only allow changing `Replicate` into
@@ -1106,10 +1110,10 @@ class DTensorRedistributePlanner:
         # Additional cases handling for _StridedShard
 
         ######################################################################
-        # TODO(zpcore): handle case 7: _StridedShard() -> Shard() on the same dim
+        # TODO(zpcore): handle case 8: _StridedShard() -> Shard() on the same dim
 
         ######################################################################
-        # handle case 8: _StridedShard() -> Replicate()
+        # handle case 9: _StridedShard() -> Replicate()
         for entry in tensor_mesh_dim_tuple:
             src_tensor_dim = entry.tensor_dim
             src_mesh_dim = tensor_mesh_dim_dict[src_tensor_dim][-1]
@@ -1133,13 +1137,13 @@ class DTensorRedistributePlanner:
             return all_next_state
 
         ######################################################################
-        # TODO(zpcore): handle case 9: Shard() -> _StridedShard()
+        # TODO(zpcore): handle case 10: Shard() -> _StridedShard()
 
         ######################################################################
-        # TODO(zpcore): handle case 10: Partial() -> _StridedShard()
+        # TODO(zpcore): handle case 11: Partial() -> _StridedShard()
 
         ######################################################################
-        # handle case 11: Replicate() -> _StridedShard()
+        # handle case 12: Replicate() -> _StridedShard()
         for mesh_dim, placement in enumerate(placements):
             if not isinstance(placement, Replicate):
                 continue
@@ -1162,6 +1166,36 @@ class DTensorRedistributePlanner:
                 tensor_mesh_dim_dict[dst_tensor_dim].pop()
 
         return all_next_state
+
+    def _get_shard_to_partial_target_states(
+        self, current_state: DistState, dst_state: DistState
+    ) -> dict[DistState, float]:
+        """Generate local Shard -> Partial("sum") steps required by dst_state."""
+        next_states: dict[DTensorRedistributePlanner.DistState, float] = {}
+        shard_order = self._ShardOrder_to_dict(
+            current_state.tensor_dim_to_mesh_dim
+        )
+        for entry in current_state.tensor_dim_to_mesh_dim:
+            tensor_dim = entry.tensor_dim
+            mesh_dim = shard_order[tensor_dim][-1]
+            current = current_state.placements[mesh_dim]
+            target = dst_state.placements[mesh_dim]
+            if not (
+                isinstance(current, Shard)
+                and type(target) is Partial
+                and target.reduce_op == "sum"
+            ):
+                continue
+
+            shard_order[tensor_dim].pop()
+            placements = list(current_state.placements)
+            placements[mesh_dim] = target
+            next_state = self.DistState(
+                tuple(placements), self._dict_to_ShardOrder(shard_order)
+            )
+            shard_order[tensor_dim].append(mesh_dim)
+            next_states[next_state] = 0.0
+        return next_states
 
     # TODO(zpcore): if the dst_state contains special placement like
     # `_MaskPartial`, we will never reach that state. Need to support this case.
@@ -1206,7 +1240,11 @@ class DTensorRedistributePlanner:
             visited.add(current_state)
             # get all possible next states and their costs
             next_states = self.get_next_state(
-                current_state.placements, current_state.tensor_dim_to_mesh_dim
+                current_state.placements,
+                current_state.tensor_dim_to_mesh_dim,
+            )
+            next_states.update(
+                self._get_shard_to_partial_target_states(current_state, dst_state)
             )
             for next_state, transition_cost in next_states.items():
                 if next_state not in visited:
@@ -1510,7 +1548,9 @@ def _gen_transform_infos_non_cached(
         # overloaded for two purposes.
         try:
             transform_infos = drp.generate_graph_based_transform_infos(
-                src_spec, dst_spec, src_spec.shape
+                src_spec,
+                dst_spec,
+                src_spec.shape,
             )
         except _StridedShardNotDecodableError:
             transform_infos = drp.generate_greedy_transform_infos(src_spec, dst_spec)
@@ -1526,7 +1566,9 @@ def _gen_transform_infos(
     use_graph_based_transform: bool | None = None,
 ) -> list[_TransformInfo]:
     return _gen_transform_infos_non_cached(
-        src_spec, dst_spec, use_graph_based_transform
+        src_spec,
+        dst_spec,
+        use_graph_based_transform,
     )
 
 
@@ -1571,11 +1613,15 @@ def redistribute_local_tensor(
 
     if _are_we_tracing():
         transform_infos = _gen_transform_infos_non_cached(
-            current_spec, target_spec, use_graph_based_transform
+            current_spec,
+            target_spec,
+            use_graph_based_transform,
         )
     else:
         transform_infos = _gen_transform_infos(
-            current_spec, target_spec, use_graph_based_transform
+            current_spec,
+            target_spec,
+            use_graph_based_transform,
         )
 
     # Optimize by grouping same-type collectives into flattened operations
@@ -1715,8 +1761,19 @@ def redistribute_local_tensor(
                         local_tensor, mesh_to_use, i
                     )
                 elif _is_shard_like(current):
-                    raise RuntimeError(
-                        f"redistribute from {current} to {target} not supported yet"
+                    if (
+                        not isinstance(current, Shard)
+                        or type(target) is not Partial
+                        or target.reduce_op != "sum"
+                    ):
+                        raise RuntimeError(
+                            f"redistribute from {current} to {target} not supported yet"
+                        )
+                    new_local_tensor = current._to_partial_tensor(
+                        local_tensor,
+                        mesh_to_use,
+                        i,
+                        transform_info.logical_shape,
                     )
                 else:
                     if current != target:

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -928,19 +928,33 @@ class DTensorRedistributePlanner:
         # Case 6. Replicate() -> Partial(), local math op, applies to:
         #   R* -> P[..., x]
         #
-        # (TODO) Case 7. _StridedShard(a) -> Shard(b), use all-to-all (a2a), applies to:
+        # Case 7. Shard() -> Partial("sum"), local zero-fill, generated only as
+        # a destination-directed transition in find_min_cost_path(), applies to:
+        #   S(a)[..., x] -> P[..., x]
+        # This transition is available only for explicit redistribution.
+        #
+        # Strategy planning assigns it infinite cost. A zero communication cost
+        # would ignore the logical-shape allocation, zero-fill, and shard copy,
+        # causing the planner to over-prefer it.
+        #
+        # Transform planning assigns an explicit request zero search cost because
+        # it requires no communication. This difference is intentional: the
+        # transform planner supports strategy-selected transitions plus additional
+        # explicit-only transitions.
+
+        # (TODO) Case 8. _StridedShard(a) -> Shard(b), use all-to-all (a2a), applies to:
         #   SS(a)[..., x] -> S(b)[..., x]
         #
-        # Case 8. _StridedShard() -> Replicate(), use all-gather, applies to:
+        # Case 9. _StridedShard() -> Replicate(), use all-gather, applies to:
         #   SS(a)[..., x, y, z] -> SS(a)[..., x, y]
         #
-        # (TODO) Case 9. Shard(a) -> _StridedShard(b), use all-to-all (a2a), applies to:
+        # (TODO) Case 10. Shard(a) -> _StridedShard(b), use all-to-all (a2a), applies to:
         #   S(a)[..., x] -> SS(b)[..., x]
         #
-        # (TODO) Case 10. Partial() -> _StridedShard(), use reduce-scatter, applies to:
+        # (TODO) Case 11. Partial() -> _StridedShard(), use reduce-scatter, applies to:
         #   P[..., x, y] -> P[..., x]SS(a)[..., y] or P[..., x, y] -> P[..., y]SS(a)[..., x]
         #
-        # Case 11. Replicate() -> _StridedShard(), use chunk, applies to:
+        # Case 12. Replicate() -> _StridedShard(), use chunk, applies to:
         #   R* -> SS(a)[..., x]
         #
         # NB: Regarding `_StridedShard``, we only allow changing `Replicate` into
@@ -1106,10 +1120,10 @@ class DTensorRedistributePlanner:
         # Additional cases handling for _StridedShard
 
         ######################################################################
-        # TODO(zpcore): handle case 7: _StridedShard() -> Shard() on the same dim
+        # TODO(zpcore): handle case 8: _StridedShard() -> Shard() on the same dim
 
         ######################################################################
-        # handle case 8: _StridedShard() -> Replicate()
+        # handle case 9: _StridedShard() -> Replicate()
         for entry in tensor_mesh_dim_tuple:
             src_tensor_dim = entry.tensor_dim
             src_mesh_dim = tensor_mesh_dim_dict[src_tensor_dim][-1]
@@ -1133,13 +1147,13 @@ class DTensorRedistributePlanner:
             return all_next_state
 
         ######################################################################
-        # TODO(zpcore): handle case 9: Shard() -> _StridedShard()
+        # TODO(zpcore): handle case 10: Shard() -> _StridedShard()
 
         ######################################################################
-        # TODO(zpcore): handle case 10: Partial() -> _StridedShard()
+        # TODO(zpcore): handle case 11: Partial() -> _StridedShard()
 
         ######################################################################
-        # handle case 11: Replicate() -> _StridedShard()
+        # handle case 12: Replicate() -> _StridedShard()
         for mesh_dim, placement in enumerate(placements):
             if not isinstance(placement, Replicate):
                 continue
@@ -1162,6 +1176,39 @@ class DTensorRedistributePlanner:
                 tensor_mesh_dim_dict[dst_tensor_dim].pop()
 
         return all_next_state
+
+    def _get_shard_to_partial_target_states(
+        self, current_state: DistState, dst_state: DistState
+    ) -> dict[DistState, float]:
+        """Generate explicit-only Shard -> Partial("sum") target steps.
+
+        Zero weight means no communication; allocation and copy costs are omitted.
+        This edge is generated only when Partial("sum") is the requested target,
+        so path search cannot use it as an intermediate step to another layout.
+        """
+        next_states: dict[DTensorRedistributePlanner.DistState, float] = {}
+        shard_order = self._ShardOrder_to_dict(current_state.tensor_dim_to_mesh_dim)
+        for entry in current_state.tensor_dim_to_mesh_dim:
+            tensor_dim = entry.tensor_dim
+            mesh_dim = shard_order[tensor_dim][-1]
+            current = current_state.placements[mesh_dim]
+            target = dst_state.placements[mesh_dim]
+            if not (
+                isinstance(current, Shard)
+                and type(target) is Partial
+                and target.reduce_op == "sum"
+            ):
+                continue
+
+            shard_order[tensor_dim].pop()
+            placements = list(current_state.placements)
+            placements[mesh_dim] = target
+            next_state = self.DistState(
+                tuple(placements), self._dict_to_ShardOrder(shard_order)
+            )
+            shard_order[tensor_dim].append(mesh_dim)
+            next_states[next_state] = 0.0
+        return next_states
 
     # TODO(zpcore): if the dst_state contains special placement like
     # `_MaskPartial`, we will never reach that state. Need to support this case.
@@ -1206,7 +1253,11 @@ class DTensorRedistributePlanner:
             visited.add(current_state)
             # get all possible next states and their costs
             next_states = self.get_next_state(
-                current_state.placements, current_state.tensor_dim_to_mesh_dim
+                current_state.placements,
+                current_state.tensor_dim_to_mesh_dim,
+            )
+            next_states.update(
+                self._get_shard_to_partial_target_states(current_state, dst_state)
             )
             for next_state, transition_cost in next_states.items():
                 if next_state not in visited:
@@ -1510,7 +1561,9 @@ def _gen_transform_infos_non_cached(
         # overloaded for two purposes.
         try:
             transform_infos = drp.generate_graph_based_transform_infos(
-                src_spec, dst_spec, src_spec.shape
+                src_spec,
+                dst_spec,
+                src_spec.shape,
             )
         except _StridedShardNotDecodableError:
             transform_infos = drp.generate_greedy_transform_infos(src_spec, dst_spec)
@@ -1526,7 +1579,9 @@ def _gen_transform_infos(
     use_graph_based_transform: bool | None = None,
 ) -> list[_TransformInfo]:
     return _gen_transform_infos_non_cached(
-        src_spec, dst_spec, use_graph_based_transform
+        src_spec,
+        dst_spec,
+        use_graph_based_transform,
     )
 
 
@@ -1571,11 +1626,15 @@ def redistribute_local_tensor(
 
     if _are_we_tracing():
         transform_infos = _gen_transform_infos_non_cached(
-            current_spec, target_spec, use_graph_based_transform
+            current_spec,
+            target_spec,
+            use_graph_based_transform,
         )
     else:
         transform_infos = _gen_transform_infos(
-            current_spec, target_spec, use_graph_based_transform
+            current_spec,
+            target_spec,
+            use_graph_based_transform,
         )
 
     # Optimize by grouping same-type collectives into flattened operations
@@ -1715,8 +1774,19 @@ def redistribute_local_tensor(
                         local_tensor, mesh_to_use, i
                     )
                 elif _is_shard_like(current):
-                    raise RuntimeError(
-                        f"redistribute from {current} to {target} not supported yet"
+                    if (
+                        not isinstance(current, Shard)
+                        or type(target) is not Partial
+                        or target.reduce_op != "sum"
+                    ):
+                        raise RuntimeError(
+                            f"redistribute from {current} to {target} not supported yet"
+                        )
+                    new_local_tensor = current._to_partial_tensor(
+                        local_tensor,
+                        mesh_to_use,
+                        i,
+                        transform_info.logical_shape,
                     )
                 else:
                     if current != target:

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -636,6 +636,33 @@ class Shard(torch._C._distributed.Shard):
             clone=True,
         )
 
+    def _to_partial_tensor(
+        self,
+        local_tensor: torch.Tensor,
+        mesh: DeviceMesh,
+        mesh_dim: int,
+        current_logical_shape: Sequence[IntLikeType],
+    ) -> torch.Tensor:
+        """Embed a local shard in a zero-filled tensor pending sum reduction."""
+        num_chunks = mesh.size(mesh_dim=mesh_dim)
+        logical_dim_size = current_logical_shape[self.dim]
+        local_shard_size, local_offset = self.local_shard_size_and_offset(
+            logical_dim_size,
+            num_chunks,
+            mesh._sym_get_coordinate(mesh_dim),
+        )
+        torch._check(local_tensor.size(self.dim) == local_shard_size)
+        output_shape: list[IntLikeType] = list(local_tensor.shape)
+        output_shape[self.dim] = logical_dim_size
+        output = local_tensor.new_zeros(output_shape)
+        offset = torch.scalar_tensor(
+            local_offset, dtype=torch.int64, device=local_tensor.device
+        )
+        indices = torch.arange(
+            local_shard_size, dtype=torch.int64, device=local_tensor.device
+        )
+        return output.index_add(self.dim, indices + offset, local_tensor)
+
     @staticmethod
     @maybe_run_for_local_tensor
     def _get_shard_pad_size(
@@ -1766,8 +1793,9 @@ class Partial(torch._C._distributed.Partial):
             * ``"bor"``: Bitwise OR across all ranks (integer tensors only).
             * ``"bxor"``: Bitwise XOR across all ranks (integer tensors only).
 
-    .. note:: The ``Partial`` placement can be generated as a result of the DTensor operators,
-        and can only be used by the ``DTensor.from_local`` API.
+    .. note:: The ``Partial`` placement can be generated as a result of DTensor
+        operators, by ``DTensor.from_local``, or by redistributing a ``Shard``
+        placement to ``Partial("sum")``.
     """
 
     def _reduce_value(


### PR DESCRIPTION
## Summary

  Add DTensor support for Shard(dim) -> Partial("sum") redistribution
  using local zero-fill. This enables the S(1) -> P transition required
  by TorchTitan's new MoE sharding
  (https://github.com/pytorch/torchtitan/pull/3996).

  ## Testing

  Added forward, backward, uneven-sharding, and graph-planner coverage.
```
python test/distributed/tensor/test_redistribute.py -k shard_to_partial
```
