### PR TITLE
[BE] Fix B018 warnings in symmetric-memory Triton hooks

### DIFF
--- a/torch/distributed/_symmetric_memory/_nvshmem_triton.py
+++ b/torch/distributed/_symmetric_memory/_nvshmem_triton.py
@@ -167,7 +167,7 @@ def _nvshmem_init_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         kernel_cache = jit_function.device_caches[device][0]
         kernel = kernel_cache.get(key, None)
         if kernel is not None:
-            kernel.run
+            _ = kernel.run
             # Initialize NVSHMEM for the CU module
             _nvshmemx_cumodule_init(kernel.module)
         else:

--- a/torch/distributed/_symmetric_memory/_shmem_triton_utils.py
+++ b/torch/distributed/_symmetric_memory/_shmem_triton_utils.py
@@ -48,7 +48,7 @@ def run_shmem_init_hook(
     kernel_cache = jit_function.device_caches[device][0]
     kernel = kernel_cache.get(key, None)
     if kernel is not None:
-        kernel.run
+        _ = kernel.run
         module_init(kernel.module)
     else:
         logger.warning(


### PR DESCRIPTION
## Issue

Part of #106571.

## Summary

Assign the intentional `kernel.run` accesses to `_` in the symmetric-memory post-compile hooks. This preserves the lazy attribute lookup before module initialization while resolving the corresponding B018 warnings.

## Checklist

- [x] Passes targeted lint: `spin lint -- --take RUFF torch/distributed/_symmetric_memory/_nvshmem_triton.py torch/distributed/_symmetric_memory/_shmem_triton_utils.py`
- [ ] Added/updated tests (not applicable; no behavior change)
- [ ] Updated documentation (not applicable)
- [ ] Included benchmark results (not applicable)

## BC-breaking?

No.

> This PR was prepared with ai assistance.

I reviewed commit `1d361b7` and confirmed the two `_ = kernel.run` assignments preserve the intended attribute lookups.
