### PR TITLE
[Testcase Refactoring] Add hw_classification to cpython test files

### DIFF
--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -24,6 +24,7 @@ import torch.testing
 from torch._dynamo import polyfills
 from torch._logging._internal import trace_log
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
+    HardwareClassification,
     IS_WINDOWS,
     TEST_WITH_CROSSREF,
     TEST_WITH_TORCHDYNAMO,
@@ -141,6 +142,7 @@ class CPythonTestCase(TestCase):
     tracing through unittest methods.
     """
 
+    hw_classification = HardwareClassification.GENERIC
     _stack: contextlib.ExitStack
     dynamo_strict_nopython = True
 

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -24,6 +24,7 @@ import torch.testing
 from torch._dynamo import polyfills
 from torch._logging._internal import trace_log
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
+    HardwareClassification,
     IS_WINDOWS,
     TEST_WITH_CROSSREF,
     TEST_WITH_TORCHDYNAMO,
@@ -142,6 +143,7 @@ class CPythonTestCase(TestCase):
     """
 
     _stack: contextlib.ExitStack
+    hw_classification = HardwareClassification.GENERIC
     dynamo_strict_nopython = True
 
     # Restore original unittest methods to simplify tracing CPython test cases.


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to `CPythonTestCase` base class in `torch/_dynamo/test_case.py`. All 316+ CPython test subclasses across 59 files inherit this attribute automatically, as part of #185590.

## Changes

- Add `hw_classification = HardwareClassification.GENERIC` to `CPythonTestCase` (line 145, after docstring)
- Import `HardwareClassification` from `torch.testing._internal.common_utils`

This is a 2-line metadata-only change; no test logic is modified. The `test/cpython` directory is explicitly skipped by the HW_CLASSIFICATION linter (#190173) since these files are vendored from CPython.

## Motivation

Setting `hw_classification` on the base class `CPythonTestCase` (rather than annotating each of the 316 subclasses individually) is the equivalent but simpler approach, as agreed with @can-gaa-hou and @fffrog in the review discussion.

## Test Plan

Verified on CPU (Python 3.13):

```bash
python -m pytest test/cpython/v3_13/ -v --tb=short
# Result: 5059 passed, 2 failed, 44 skipped, 4 xfailed in 193s
```

The 2 failures are known community expected failures (`test_input_no_stdout_fileno`, `test_pydoc`), not related to this change.

## Verification Report

### Verification Results

| Hardware | Cases | Passed | Failed | Skipped | Result |
|----------|-------|--------|--------|---------|--------|
| CPU (Python 3.13) | 5109 | 5059 | 2 | 44 | 2 known community failures (not related to this change) |

### Environment

| Item | Version |
|------|---------|
| PyTorch | 2.14.0.dev20260811+cpu |
| Python | 3.13.14 |
| Platform | aarch64 Linux |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98