### PR TITLE
[MPS] Fix silent wrong results for complex bmm with conj/mH views

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1396,6 +1396,17 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
     return result;
   }
 
+  // Materialize the conjugate bit before any MPS path.
+  //
+  // Placeholder feeds the raw storage of conj views; graph-level
+  // conjugateWithTensor (added in #178010) is insufficient for complex batch
+  // matmul and silently returns wrong results for inputs such as b.conj() or
+  // U.mH. Metal and tiled paths already call resolve_conj; do the same here so
+  // all bmm paths see physically conjugated tensors.
+  if (batch1.is_conj() || batch2.is_conj()) {
+    return bmm_out_mps_impl(batch1.resolve_conj(), batch2.resolve_conj(), result);
+  }
+
   if (c10::isIntegralType(batch1.scalar_type(), true)) {
     return do_metal_bmm(batch1, batch2, result);
   }
@@ -1434,8 +1445,7 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
   // Call tiled implementation if the number of elements exceeds 2^32
   uint64_t resultSize = batch1.size(0) * batch1.size(1) * batch2.size(2);
   if (resultSize > pow(2, 32)) {
-    // Tiled path uses MPSNDArray directly, so resolve conjugate views upfront
-    result = tiled_bmm_out_mps_impl(batch1.resolve_conj(), batch2.resolve_conj(), result);
+    result = tiled_bmm_out_mps_impl(batch1, batch2, result);
     return result;
   }
 
@@ -1455,15 +1465,13 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       auto batch1Tensor = mps::mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(batch1.scalar_type()));
       auto batch2Tensor = mps::mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(batch2.scalar_type()));
-
-      auto batch1TensorOp = batch1.is_conj() ? [mpsGraph conjugateWithTensor:batch1Tensor name:nil] : batch1Tensor;
-      auto batch2TensorOp = batch2.is_conj() ? [mpsGraph conjugateWithTensor:batch2Tensor name:nil] : batch2Tensor;
+      auto batch2TensorOp = batch2Tensor;
 
       if (doTranspose) {
-        batch2TensorOp = [mpsGraph transposeTensor:batch2TensorOp dimension:-1 withDimension:-2 name:nil];
+        batch2TensorOp = [mpsGraph transposeTensor:batch2Tensor dimension:-1 withDimension:-2 name:nil];
       }
 
-      MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:batch1TensorOp
+      MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:batch1Tensor
                                                                       secondaryTensor:batch2TensorOp
                                                                                  name:@"MM/(batch1@batch2)"];
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1367,6 +1367,8 @@ class TestMPS(TestCaseMPS):
     def test_bmm_conj(self):
         # bmm must respect the conjugate bit on input tensors.
         # See https://github.com/pytorch/pytorch/issues/177474
+        # Graph-level conjugateWithTensor alone was insufficient; resolve_conj
+        # is required so complex batch matmul does not silently ignore conj/mH.
         a = torch.randn(4, 3, 5, dtype=torch.complex64, device="mps")
         b = torch.randn(4, 5, 2, dtype=torch.complex64, device="mps")
         result_mps = torch.bmm(a, b.conj())
@@ -1374,6 +1376,17 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(result_cpu, result_mps)
         result_mps = torch.bmm(a.conj(), b)
         result_cpu = torch.bmm(a.cpu().conj(), b.cpu())
+        self.assertEqual(result_cpu, result_mps)
+        result_mps = torch.bmm(a.conj(), b.conj())
+        result_cpu = torch.bmm(a.cpu().conj(), b.cpu().conj())
+        self.assertEqual(result_cpu, result_mps)
+
+        # Hermitian adjoint view (conj + transpose) used by unitary matmuls.
+        u = torch.randn(8, 4, 4, dtype=torch.complex64, device="mps")
+        d = torch.diag_embed(torch.randn(8, 4, dtype=torch.complex64, device="mps"))
+        left = u @ d
+        result_mps = left @ u.mH
+        result_cpu = left.cpu() @ u.cpu().mH.contiguous()
         self.assertEqual(result_cpu, result_mps)
 
     def test_addmm_conj(self):


### PR DESCRIPTION
## Summary

`torch.bmm` on MPS silently returns wrong results for **complex** inputs that carry the conjugate bit (`tensor.conj()`, `tensor.mH`). Errors are large (order 1e1 vs 1e-6), not rounding noise.

This was partially addressed in #178010 by adding graph-level `conjugateWithTensor`. That is **insufficient**: `Placeholder` feeds the raw storage of conj views, and the MPSGraph path still ignores conjugation for complex batch matmul.

### Repro (torch 2.9.1 / current main logic, macOS 26.1, Apple Silicon)

```python
import torch
torch.manual_seed(0)
a = torch.randn(4, 3, 5, dtype=torch.complex64, device="mps")
b = torch.randn(4, 5, 2, dtype=torch.complex64, device="mps")
# max |diff| ~ 1e1 (wrong)
print((torch.bmm(a, b.conj()).cpu() - torch.bmm(a.cpu(), b.cpu().conj())).abs().max())
# works after materializing conjugation
print((torch.bmm(a, b.conj().resolve_conj()).cpu() - torch.bmm(a.cpu(), b.cpu().conj())).abs().max())
```

Same bug hits `A @ U.mH` (Hermitian adjoint), which is common in unitary / quantum-inspired code.

2D `torch.mm` with conj bit is fine; only the batched path is broken.

## Fix

Call `resolve_conj()` on both operands at the start of `bmm_out_mps_impl` when either input is conjugated, then re-enter. This matches the metal and tiled paths (which already materialize conjugation) and makes the MPSGraph path see physically conjugated tensors.

## Test plan

- [x] Local repro confirms bug on torch 2.9.1 MPS before fix
- [x] Local check: `resolve_conj` before `bmm` restores CPU agreement (~1e-6)
- [x] Extended `test_bmm_conj` for both-conj and `U.mH` adjoint matmul
- [ ] CI: `test_mps.py::TestMPS::test_bmm_conj` on MPS runners

Fixes related silent-correctness gap left after #178010 / #177474.