### PR TITLE
[package] Restore profiler after dependency tracing

### DIFF
--- a/test/package/test_analyze.py
+++ b/test/package/test_analyze.py
@@ -5,7 +5,7 @@ import unittest
 
 import torch
 from torch.package import analyze
-from torch.testing._internal.common_utils import IS_LINUX, run_tests
+from torch.testing._internal.common_utils import IS_LINUX, run_tests, skipIfTorchDynamo
 
 
 try:
@@ -18,6 +18,7 @@ except ImportError:
 class TestAnalyze(PackageTestCase):
     """Dependency analysis API tests."""
 
+    @skipIfTorchDynamo("trace_dependencies uses sys.setprofile")
     def test_trace_dependencies_restores_profile(self):
         def profile(frame, event, arg):
             pass
@@ -30,6 +31,7 @@ class TestAnalyze(PackageTestCase):
 
         self.assertIs(sys.getprofile(), profile)
 
+    @skipIfTorchDynamo("trace_dependencies uses sys.setprofile")
     def test_trace_dependencies_restores_profile_when_callable_raises(self):
         def profile(frame, event, arg):
             pass

--- a/test/package/test_analyze.py
+++ b/test/package/test_analyze.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: package/deploy"]
 
+import sys
 import unittest
 
 import torch
@@ -16,6 +17,34 @@ except ImportError:
 
 class TestAnalyze(PackageTestCase):
     """Dependency analysis API tests."""
+
+    def test_trace_dependencies_restores_profile(self):
+        def profile(frame, event, arg):
+            pass
+
+        previous_profile = sys.getprofile()
+        self.addCleanup(sys.setprofile, previous_profile)
+        sys.setprofile(profile)
+
+        analyze.trace_dependencies(lambda: None, [()])
+
+        self.assertIs(sys.getprofile(), profile)
+
+    def test_trace_dependencies_restores_profile_when_callable_raises(self):
+        def profile(frame, event, arg):
+            pass
+
+        def fail():
+            raise RuntimeError("boom")
+
+        previous_profile = sys.getprofile()
+        self.addCleanup(sys.setprofile, previous_profile)
+        sys.setprofile(profile)
+
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            analyze.trace_dependencies(fail, [()])
+
+        self.assertIs(sys.getprofile(), profile)
 
     @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/81213")
     def test_trace_dependencies(self):

--- a/torch/package/analyze/trace_dependencies.py
+++ b/torch/package/analyze/trace_dependencies.py
@@ -50,6 +50,7 @@ def trace_dependencies(
         if module:
             modules_used.add(module)
 
+    previous_profile = sys.getprofile()
     try:
         # Attach record_used_modules as the profiler function.
         sys.setprofile(record_used_modules)
@@ -59,7 +60,7 @@ def trace_dependencies(
             callable(*inp)
 
     finally:
-        # Detach the profiler function.
-        sys.setprofile(None)
+        # Restore the previous profiler function.
+        sys.setprofile(previous_profile)
 
     return list(modules_used)


### PR DESCRIPTION
Fixes #191839

Codex assisted with the implementation. The quoted summary below explains the resulting change and validation.

> `trace_dependencies()` always cleared `sys.setprofile()` on exit, discarding a profiling callback installed by its caller after both successful tracing and exceptions.
>
> This change captures the existing callback before dependency tracing and restores it from the existing `finally` block. Regression tests cover both paths.
>
> Test Plan:
>
> - `python -m py_compile torch/package/analyze/trace_dependencies.py test/package/test_analyze.py`
> - `spin lint torch/package/analyze/trace_dependencies.py test/package/test_analyze.py`
>
> The new success and exception regression cases were also exercised against a built PyTorch checkout.

BC-breaking: No.
