### PR TITLE
[XPU] Route GPU_USER_ANNOTATION kineto events to DeviceType::XPU

### DIFF
--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -52,6 +52,7 @@ const ActivityTypeMap kCudaTypes{
 const ActivityTypeMap kXpuTypes{
     {libkineto::ActivityType::GPU_MEMCPY,            "GPU_MEMCPY"},
     {libkineto::ActivityType::GPU_MEMSET,            "GPU_MEMSET"},
+    {libkineto::ActivityType::GPU_USER_ANNOTATION,   "GPU_USER_ANNOTATION"},
     {libkineto::ActivityType::CONCURRENT_KERNEL,     "CONCURRENT_KERNEL"},
     // XPU_RUNTIME and XPU_DRIVER appear in both kCpuTypes and kXpuTypes.
     {libkineto::ActivityType::XPU_RUNTIME,           "XPU_RUNTIME"},
@@ -509,12 +510,12 @@ c10::DeviceType deviceTypeFromActivity(libkineto::ActivityType activity_type) {
     case libkineto::ActivityType::GPU_MEMCPY:
     case libkineto::ActivityType::GPU_MEMSET:
     case libkineto::ActivityType::CONCURRENT_KERNEL:
+    case libkineto::ActivityType::GPU_USER_ANNOTATION:
 #if defined(USE_XPU)
       return device_type_privateuse1_or(c10::DeviceType::XPU);
 #endif
       [[fallthrough]];
     case libkineto::ActivityType::CUDA_SYNC:
-    case libkineto::ActivityType::GPU_USER_ANNOTATION:
     case libkineto::ActivityType::CUDA_PROFILER_RANGE:
       return device_type_privateuse1_or(c10::DeviceType::CUDA);
     // TODO: T151322015


### PR DESCRIPTION
When a user wraps code with torch.autograd.profiler.record_function while running on an XPU device, kineto's XPUPTI plugin emits synthetic GPU_USER_ANNOTATION activities that bracket the corresponding CPU op. kineto_shim.cpp previously (a) did not list GPU_USER_ANNOTATION in the XPU activity map (kXpuTypes) and (b) hard-coded the activity's device type to DeviceType::CUDA in deviceTypeFromActivity(). As a result, the resulting Kineto events were attributed to CUDA even on Intel GPUs, and consumers filtering by "DeviceType.XPU" (e.g. the torch-xpu-ops CppThreadTestXPU tests) saw zero user_function events.

Add GPU_USER_ANNOTATION to kXpuTypes and, under #if defined(USE_XPU), route it to DeviceType::XPU in deviceTypeFromActivity so user annotations produced on XPU are tagged correctly.