### PR TITLE
[symm_mem] Validate peer rank in put_signal/wait_signal, complete channel OOB tests

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -366,6 +366,47 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
+    @skip_if_lt_x_gpu(2)
+    def test_nccl_symmem_barrier_channel_out_of_bounds(self):
+        symm_mem.set_backend("NCCL")
+        torch.cuda.set_device(self.rank)
+        c10d.all_reduce(torch.ones(1, device=self.device))
+        group_name = c10d.group.WORLD.group_name
+
+        t = symm_mem.empty(64, dtype=torch.float32, device=self.device)
+        handle = symm_mem.rendezvous(t, group=group_name)
+
+        num_slots = handle.signal_pad_size // 4
+        max_channel = num_slots // self.world_size
+
+        # check_channel() is shared with the CUDA backend; an over-capacity
+        # channel must be rejected host-side before the kernel launch (#191618).
+        with self.assertRaisesRegex(RuntimeError, "maximum supported channel"):
+            handle.barrier(channel=max_channel)
+        handle.barrier(channel=max_channel - 1)
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
+    @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
+    @skip_if_lt_x_gpu(2)
+    def test_nccl_symmem_signal_rank_out_of_bounds(self):
+        symm_mem.set_backend("NCCL")
+        torch.cuda.set_device(self.rank)
+        c10d.all_reduce(torch.ones(1, device=self.device))
+        group_name = c10d.group.WORLD.group_name
+
+        t = symm_mem.empty(64, dtype=torch.float32, device=self.device)
+        handle = symm_mem.rendezvous(t, group=group_name)
+
+        for bad_rank in (-1, self.world_size):
+            with self.assertRaisesRegex(RuntimeError, r"must be in \[0"):
+                handle.put_signal(dst_rank=bad_rank)
+            with self.assertRaisesRegex(RuntimeError, r"must be in \[0"):
+                handle.wait_signal(src_rank=bad_rank)
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
+    @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_if_lt_x_gpu(2)
     def test_nccl_symmem_rendezvous_subgroup(self):
         symm_mem.set_backend("NCCL")

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -366,7 +366,9 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
-    @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
+    @requires_nccl_version(
+        (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
+    )
     @skip_if_lt_x_gpu(2)
     def test_nccl_symmem_barrier_channel_out_of_bounds(self):
         symm_mem.set_backend("NCCL")
@@ -388,7 +390,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
-    @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
+    @requires_nccl_version((2, 29), "NCCL one-sided host API support from nccl 2.29")
     @skip_if_lt_x_gpu(2)
     def test_nccl_symmem_signal_rank_out_of_bounds(self):
         symm_mem.set_backend("NCCL")

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1372,11 +1372,14 @@ class SymmMemNegativeTest(MultiProcessTestCase):
 
         # An out-of-range rank indexes a wild signal pad pointer (put_signal)
         # or a slot past the signal pad, in the tensor data (wait_signal).
+        # get_signal_pad wraps the wild pointer in a tensor handed to the user.
         for bad_rank in (-1, self.world_size):
             with self.assertRaisesRegex(RuntimeError, r"must be in \[0"):
                 symm_mem_hdl.put_signal(dst_rank=bad_rank)
             with self.assertRaisesRegex(RuntimeError, r"must be in \[0"):
                 symm_mem_hdl.wait_signal(src_rank=bad_rank)
+            with self.assertRaisesRegex(RuntimeError, r"must be in \[0"):
+                symm_mem_hdl.get_signal_pad(bad_rank)
 
 
 @instantiate_parametrized_tests

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1337,6 +1337,47 @@ class SymmMemNegativeTest(MultiProcessTestCase):
             symm_mem_hdl.barrier(channel=max_channel - 1)
         torch.cuda.synchronize()
 
+    @skip_if_rocm_multiprocess
+    @skip_if_lt_x_gpu(2)
+    def test_put_wait_signal_channel_out_of_bounds(self) -> None:
+        self._init_process()
+
+        t = symm_mem.empty(64, device="cuda")
+        symm_mem_hdl = symm_mem.rendezvous(t, group=dist.group.WORLD)
+
+        num_slots = symm_mem_hdl.signal_pad_size // 4
+        max_channel = num_slots // self.world_size
+        peer = (self.rank + 1) % self.world_size
+
+        # An over-capacity channel would write past the signal pad, into the
+        # peer's tensor data (see #191618). Both ops must reject it host-side.
+        with self.assertRaisesRegex(RuntimeError, "maximum supported channel"):
+            symm_mem_hdl.put_signal(dst_rank=peer, channel=max_channel)
+        with self.assertRaisesRegex(RuntimeError, "maximum supported channel"):
+            symm_mem_hdl.wait_signal(src_rank=peer, channel=max_channel)
+
+        # The boundary channel is accepted: ring-exchange a signal on it.
+        src = (self.rank - 1) % self.world_size
+        symm_mem_hdl.put_signal(dst_rank=peer, channel=max_channel - 1)
+        symm_mem_hdl.wait_signal(src_rank=src, channel=max_channel - 1)
+        torch.cuda.synchronize()
+
+    @skip_if_rocm_multiprocess
+    @skip_if_lt_x_gpu(2)
+    def test_put_wait_signal_rank_out_of_bounds(self) -> None:
+        self._init_process()
+
+        t = symm_mem.empty(64, device="cuda")
+        symm_mem_hdl = symm_mem.rendezvous(t, group=dist.group.WORLD)
+
+        # An out-of-range rank indexes a wild signal pad pointer (put_signal)
+        # or a slot past the signal pad, in the tensor data (wait_signal).
+        for bad_rank in (-1, self.world_size):
+            with self.assertRaisesRegex(RuntimeError, r"must be in \[0"):
+                symm_mem_hdl.put_signal(dst_rank=bad_rank)
+            with self.assertRaisesRegex(RuntimeError, r"must be in \[0"):
+                symm_mem_hdl.wait_signal(src_rank=bad_rank)
+
 
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh
@@ -116,7 +116,7 @@ inline void check_channel(int channel, int world_size, size_t signal_pad_size) {
   TORCH_CHECK(
       channel >= 0,
       "channel for barrier(), put_signal() and wait_signal() ",
-      "must be greater than 0 (got ",
+      "must be non-negative (got ",
       channel,
       ")");
   const size_t num_channels =
@@ -127,6 +127,20 @@ inline void check_channel(int channel, int world_size, size_t signal_pad_size) {
       num_channels - 1,
       " (got ",
       channel,
+      ")");
+}
+
+// Validates the peer rank argument for put_signal() and wait_signal(). The
+// rank indexes the device array of signal pad pointers and the per-channel
+// slot row, so an out-of-range value reads a wild pointer or lands past the
+// signal pad, in the peer's tensor data.
+inline void check_rank(int rank, int world_size) {
+  TORCH_CHECK(
+      rank >= 0 && rank < world_size,
+      "rank for put_signal() and wait_signal() must be in [0, ",
+      world_size,
+      ") (got ",
+      rank,
       ")");
 }
 

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh
@@ -130,20 +130,6 @@ inline void check_channel(int channel, int world_size, size_t signal_pad_size) {
       ")");
 }
 
-// Validates the peer rank argument for put_signal() and wait_signal(). The
-// rank indexes the device array of signal pad pointers and the per-channel
-// slot row, so an out-of-range value reads a wild pointer or lands past the
-// signal pad, in the peer's tensor data.
-inline void check_rank(int rank, int world_size) {
-  TORCH_CHECK(
-      rank >= 0 && rank < world_size,
-      "rank for put_signal() and wait_signal() must be in [0, ",
-      world_size,
-      ") (got ",
-      rank,
-      ")");
-}
-
 // All-to-all signal barrier over the symmetric-memory signal pads, shared by
 // the CUDA and NCCL backends. Each rank sets a flag in every peer's signal pad
 // (at its own slot) and waits for every peer to set the matching flag in its

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -214,6 +214,7 @@ void CUDASymmetricMemory::put_signal(
     int channel,
     size_t timeout_ms) {
   check_channel(channel, world_size_, get_signal_pad_size());
+  check_rank(dst_rank, world_size_);
   auto pg = c10d::resolve_process_group(pai_->group_name_);
   RECORD_PARAM_COMMS(
       static_cast<int64_t>(0),
@@ -276,6 +277,7 @@ void CUDASymmetricMemory::wait_signal(
     int channel,
     size_t timeout_ms) {
   check_channel(channel, world_size_, get_signal_pad_size());
+  check_rank(src_rank, world_size_);
   auto pg = c10d::resolve_process_group(pai_->group_name_);
   RECORD_PARAM_COMMS(
       static_cast<int64_t>(0),

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -396,6 +396,7 @@ void NCCLSymmetricMemory::barrier(int channel, size_t timeout_ms) {
 }
 
 void NCCLSymmetricMemory::put_signal(int dst_rank, int channel, size_t timeout_ms) {
+  check_rank(dst_rank, world_size_);
 #ifdef NCCL_HAS_ONE_SIDED_API
   TORCH_CHECK(channel == 0, "channel must be 0 (sigIdx is reserved for future use)");
 
@@ -421,6 +422,7 @@ void NCCLSymmetricMemory::put_signal(int dst_rank, int channel, size_t timeout_m
 }
 
 void NCCLSymmetricMemory::wait_signal(int src_rank, int channel, size_t timeout_ms) {
+  check_rank(src_rank, world_size_);
 #ifdef NCCL_HAS_ONE_SIDED_API
   TORCH_CHECK(channel == 0, "channel must be 0 (sigIdx is reserved for future use)");
 

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -396,8 +396,8 @@ void NCCLSymmetricMemory::barrier(int channel, size_t timeout_ms) {
 }
 
 void NCCLSymmetricMemory::put_signal(int dst_rank, int channel, size_t timeout_ms) {
-  check_rank(dst_rank, world_size_);
 #ifdef NCCL_HAS_ONE_SIDED_API
+  check_rank(dst_rank, world_size_);
   TORCH_CHECK(channel == 0, "channel must be 0 (sigIdx is reserved for future use)");
 
   c10::cuda::CUDAGuard guard(device_idx_);
@@ -422,8 +422,8 @@ void NCCLSymmetricMemory::put_signal(int dst_rank, int channel, size_t timeout_m
 }
 
 void NCCLSymmetricMemory::wait_signal(int src_rank, int channel, size_t timeout_ms) {
-  check_rank(src_rank, world_size_);
 #ifdef NCCL_HAS_ONE_SIDED_API
+  check_rank(src_rank, world_size_);
   TORCH_CHECK(channel == 0, "channel must be 0 (sigIdx is reserved for future use)");
 
   c10::cuda::CUDAGuard guard(device_idx_);

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -384,10 +384,7 @@ static at::Tensor get_buffer_at_byte_offset(
     c10::IntArrayRef sizes,
     c10::ScalarType dtype,
     size_t offset_bytes) {
-  TORCH_CHECK(
-      peer >= 0 && peer < handle->get_world_size(),
-      "Invalid peer rank: ",
-      peer);
+  check_rank(peer, handle->get_world_size());
   auto peer_ptr = handle->get_buffer_ptrs()[peer];
   TORCH_CHECK(
       peer_ptr != nullptr,
@@ -442,6 +439,8 @@ at::Tensor SymmetricMemory::get_signal_pad(
     c10::IntArrayRef sizes,
     std::optional<c10::ScalarType> dtype,
     int64_t storage_offset) {
+  check_rank(rank, get_world_size());
+
   // If the dtype is unspecified, default it to UInt32, as it
   // is the most common type for signaling purposes.
   if (!dtype.has_value()) {

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -6,6 +6,19 @@
 
 namespace c10d::symmetric_memory {
 
+// Validates a peer rank used to index the per-peer arrays of buffer/signal
+// pad pointers. An out-of-range rank reads or writes through a wild pointer,
+// or lands past the signal pad in the peer's tensor data.
+inline void check_rank(int rank, int world_size) {
+  TORCH_CHECK(
+      rank >= 0 && rank < world_size,
+      "rank must be in [0, ",
+      world_size,
+      ") (got ",
+      rank,
+      ")");
+}
+
 // SymmetricMemory represents symmetric allocations across a group of devices.
 // The allocations represented by a SymmetricMemory object are accessible by
 // all devices in the group. The class can be used for op-level custom


### PR DESCRIPTION
`put_signal()/wait_signal()` validate the channel argument (since #191596) but pass `dst_rank/src_rank` from Python to the device kernels unchecked. The rank indexes the device array of signal pad pointers (`put_signal`) and the per-channel slot row (`wait_signal`), so an out-of-range value dereferences a wild pointer or lands one row past the signal pad but in the tensor data with the pad-first layout. I verified on 2x H200: `wait_signal(src_rank=world_size, channel=max)` was accepted and silently consumed the caller's own tensor element via the CAS(1 -> 0) protocol. The mistake is easy to hit in practice by passing a global rank where a subgroup-local rank is expected.

The fix adds `check_rank()` next to `check_channel()` and calls it host-side from both the CUDA and NCCL backends, so a bad rank raises before any kernel launch. An alternative was a single check at the pybind layer covering all backends at once; the per-backend helper mirrors how `check_channel()` is already wired, so it stays consistent with the existing structure. Also corrects the `check_channel()` negative-channel error message, which said "greater than 0" for a >= 0 check.

Tests also close the coverage gap from #191618: #191596 only tested `barrier()` on the CUDA backend, so this adds channel OOB tests for `put_signal()/ wait_signal()` (the demonstrated corruption vector), rank OOB tests for both backends, and a channel OOB test for the NCCL backend's `barrier()`.

Closes #191618

Test Plan:

```
python test/distributed/test_symmetric_memory.py -k "out_of_bounds"
python test/distributed/test_nccl.py -k "symmem"
```