### PR TITLE
Fix aliased output identity for no-grad no-op views in AOTAutograd

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -9784,6 +9784,40 @@ def forward(self, primals_1, tangents_1):
             [0, 1, 2],
         )
 
+    def test_collect_metadata_no_grad_no_op_view_of_user_output(self):
+        # https://github.com/pytorch/pytorch/issues/191449
+        # Without gradients, a no-op view of another user output must still be
+        # classified as an alias so the runtime wrapper regenerates a distinct
+        # tensor object; otherwise the backend may return one object for both
+        # outputs, while eager returns distinct objects.
+        from torch._functorch._aot_autograd.collect_metadata_analysis import (
+            run_functionalized_fw_and_collect_metadata,
+        )
+        from torch._functorch._aot_autograd.descriptors import PlainAOTInput
+        from torch._functorch._aot_autograd.schemas import OutputType
+
+        def f(x):
+            base = x + 1
+            return [base.view(-1), base]
+
+        fake_mode = FakeTensorMode()
+        arg = fake_mode.from_tensor(torch.ones(1))
+
+        metadata = run_functionalized_fw_and_collect_metadata(
+            f,
+            flat_args_descs=[PlainAOTInput(0)],
+            keep_input_mutations=True,
+            static_input_indices=[],
+        )(arg)
+
+        self.assertEqual(
+            metadata.output_info[0].output_type,
+            OutputType.alias_of_intermediate_base_is_user_output,
+        )
+        self.assertEqual(metadata.output_info[0].base_idx, 1)
+        self.assertEqual(metadata.output_info[1].output_type, OutputType.non_alias)
+        self.assertEqual(metadata.num_intermediate_bases, 0)
+
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
     def test_register_hook_in_checkpoint_accumulated_grad(self):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -9878,6 +9878,40 @@ def forward(self, primals_1, tangents_1):
             [0, 1, 2],
         )
 
+    def test_collect_metadata_no_grad_no_op_view_of_user_output(self):
+        # https://github.com/pytorch/pytorch/issues/191449
+        # Without gradients, a no-op view of another user output must still be
+        # classified as an alias so the runtime wrapper regenerates a distinct
+        # tensor object; otherwise the backend may return one object for both
+        # outputs, while eager returns distinct objects.
+        from torch._functorch._aot_autograd.collect_metadata_analysis import (
+            run_functionalized_fw_and_collect_metadata,
+        )
+        from torch._functorch._aot_autograd.descriptors import PlainAOTInput
+        from torch._functorch._aot_autograd.schemas import OutputType
+
+        def f(x):
+            base = x + 1
+            return [base.view(-1), base]
+
+        fake_mode = FakeTensorMode()
+        arg = fake_mode.from_tensor(torch.ones(1))
+
+        metadata = run_functionalized_fw_and_collect_metadata(
+            f,
+            flat_args_descs=[PlainAOTInput(0)],
+            keep_input_mutations=True,
+            static_input_indices=[],
+        )(arg)
+
+        self.assertEqual(
+            metadata.output_info[0].output_type,
+            OutputType.alias_of_intermediate_base_is_user_output,
+        )
+        self.assertEqual(metadata.output_info[0].base_idx, 1)
+        self.assertEqual(metadata.output_info[1].output_type, OutputType.non_alias)
+        self.assertEqual(metadata.num_intermediate_bases, 0)
+
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
     def test_register_hook_in_checkpoint_accumulated_grad(self):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -4100,6 +4100,57 @@ def forward(self, tangents_1):
         self.assertEqual(out_ref, out_test)
         self.assertEqual(a, a2)
 
+    # See https://github.com/pytorch/pytorch/issues/191449
+    def test_dupe_arg_with_no_grad_alias_of_output(self):
+        # Duplicating and mutating an input routes metadata through
+        # AOTDedupeWrapper, which remaps base_idx through add_dupe_map. Only
+        # alias_of_input / is_input hold an input index there; a no-grad alias
+        # of a user output holds a user-output index and must be left alone.
+        # The leading outputs push that index past the input count, so remapping
+        # it used to raise IndexError.
+        def f(x, y):
+            y.mul_(2)
+            a, b, c = x + 1, x + 2, x + 3
+            d = x + 4 + y
+            return a, b, c, d, d.view(-1)
+
+        f_compiled = aot_function(f, nop)
+        x = torch.ones(4)
+        out_ref = f(x, x)
+
+        x2 = torch.ones(4)
+        out_test = f_compiled(x2, x2)
+
+        self.assertEqual(out_ref, out_test)
+        self.assertEqual(x, x2)
+        # Eager returns two distinct objects sharing storage, so the compiled
+        # function must too, or an eager resize_() on the alias corrupts d.
+        self.assertIsNot(out_test[3], out_test[4])
+        self.assertEqual(out_test[3].data_ptr(), out_test[4].data_ptr())
+
+    # See https://github.com/pytorch/pytorch/issues/191449
+    def test_synthetic_base_with_no_grad_alias_of_output(self):
+        # Overlapping aliased inputs plus a mutation build synthetic bases,
+        # which remap base_idx through synthetic_base_info. As with dedup, only
+        # alias_of_input / is_input hold an input index there.
+        def f(x, y):
+            y.mul_(2)
+            a, b, c = x + 1, x + 2, x + 3
+            d = x + 4 + y
+            return a, b, c, d, d.view(-1)
+
+        f_compiled = aot_function(f, nop)
+        base = torch.ones(8)
+        out_ref = f(base[0:6], base[2:8])
+
+        base2 = torch.ones(8)
+        out_test = f_compiled(base2[0:6], base2[2:8])
+
+        self.assertEqual(out_ref, out_test)
+        self.assertEqual(base, base2)
+        self.assertIsNot(out_test[3], out_test[4])
+        self.assertEqual(out_test[3].data_ptr(), out_test[4].data_ptr())
+
     @patch("torch._functorch.aot_autograd.AOT_COUNTER", new_callable=itertools.count)
     @patch("torch._functorch.config.debug_assert", True)
     def test_invalid_dupe_left_bias(self, counter):

--- a/test/inductor/test_inductor_freezing.py
+++ b/test/inductor/test_inductor_freezing.py
@@ -244,6 +244,43 @@ class OptimizeForInferenceTemplate(TestCase):
             mod_eager = mod()
             self.assertEqual(foo(mod), mod_eager)
 
+    def test_aliased_intermediate_output_folds_params(self):
+        # https://github.com/pytorch/pytorch/issues/191449
+        # base_idx on an alias_of_intermediate* output indexes user outputs,
+        # not graph inputs. Treating it as an input index preserved whichever
+        # parameter happened to share that number, silently disabling folding.
+        from unittest.mock import patch as mock_patch
+
+        from torch._inductor import freezing
+
+        class Mod(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.lin = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                base = self.lin(x)
+                return base, base.view_as(base)
+
+        mod = Mod().to(self.device).eval()
+        inp = torch.randn(2, 4, device=self.device)
+        preserved = []
+        orig = freezing.replace_params_with_constants
+
+        def spy(gm, flat_params, fw_metadata):
+            out = orig(gm, flat_params, fw_metadata)
+            preserved.append(list(out))
+            return out
+
+        with torch.no_grad():
+            mod_eager = mod(inp)
+            with mock_patch.object(freezing, "replace_params_with_constants", spy):
+                self.assertEqual(torch.compile(mod)(inp), mod_eager)
+
+        # Only the graph input survives; the Linear weight and bias are folded.
+        self.assertTrue(preserved)
+        self.assertEqual(preserved[0], [2])
+
     def test_autocast(self):
         if self.device == "cpu":
             raise unittest.SkipTest("MLKDNN Bug")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19354,6 +19354,61 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         for _ in range(4):
             self.assertEqual(compiled(x, a, b), fn(x, a, b))
 
+    def test_resize_on_view_after_graph_break(self):
+        # https://github.com/pytorch/pytorch/issues/191449
+        # resize_() graph-breaks, so base and alias escape the compiled
+        # graph into eager code; they must be distinct tensor objects as
+        # in eager mode, or the resize_ corrupts base as well.
+        def fn(x):
+            base = x + 1
+            alias = base.view(-1)
+            alias.resize_(12)
+            return base + 1
+
+        expected = fn(torch.zeros(1, device=self.device))
+        actual = torch.compile(fn)(torch.zeros(1, device=self.device))
+        self.assertEqual(expected, actual)
+
+    def test_no_op_view_output_identity(self):
+        # https://github.com/pytorch/pytorch/issues/191449
+        # A no-op view returned alongside its base must stay a distinct
+        # tensor object sharing storage, as in eager. A tensor returned
+        # twice must stay the same object in both slots, as in eager.
+        def fn_view(x):
+            base = x + 1
+            return base, base.view(-1)
+
+        base, alias = torch.compile(fn_view)(torch.zeros(1, device=self.device))
+        self.assertIsNot(base, alias)
+        self.assertEqual(base.data_ptr(), alias.data_ptr())
+
+        def fn_dup(x):
+            t = x + 1
+            return t, t
+
+        a, b = torch.compile(fn_dup)(torch.zeros(1, device=self.device))
+        self.assertIs(a, b)
+
+    def test_no_op_view_output_identity_joint(self):
+        # https://github.com/pytorch/pytorch/issues/191449
+        # Same as test_no_op_view_output_identity, but with a differentiable
+        # output alongside, so the aliased no-grad pair flows through the
+        # autograd (joint) runtime path.
+        def fn(x):
+            y = x * 2
+            with torch.no_grad():
+                base = x + 1
+                alias = base.view(-1)
+            return y, base, alias
+
+        x = torch.zeros(1, device=self.device, requires_grad=True)
+        ey, ebase, ealias = fn(x)
+        y, base, alias = torch.compile(fn)(x)
+        self.assertIsNot(base, alias)
+        self.assertEqual(base.data_ptr(), alias.data_ptr())
+        self.assertEqual(y, ey)
+        self.assertEqual(base, ebase)
+
     # end of class CommonTemplate - add new tests here
 
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19636,6 +19636,61 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
         self.common(fn, (torch.zeros(10, 256, device=self.device),))
 
+    def test_resize_on_view_after_graph_break(self):
+        # https://github.com/pytorch/pytorch/issues/191449
+        # resize_() graph-breaks, so base and alias escape the compiled
+        # graph into eager code; they must be distinct tensor objects as
+        # in eager mode, or the resize_ corrupts base as well.
+        def fn(x):
+            base = x + 1
+            alias = base.view(-1)
+            alias.resize_(12)
+            return base + 1
+
+        expected = fn(torch.zeros(1, device=self.device))
+        actual = torch.compile(fn)(torch.zeros(1, device=self.device))
+        self.assertEqual(expected, actual)
+
+    def test_no_op_view_output_identity(self):
+        # https://github.com/pytorch/pytorch/issues/191449
+        # A no-op view returned alongside its base must stay a distinct
+        # tensor object sharing storage, as in eager. A tensor returned
+        # twice must stay the same object in both slots, as in eager.
+        def fn_view(x):
+            base = x + 1
+            return base, base.view(-1)
+
+        base, alias = torch.compile(fn_view)(torch.zeros(1, device=self.device))
+        self.assertIsNot(base, alias)
+        self.assertEqual(base.data_ptr(), alias.data_ptr())
+
+        def fn_dup(x):
+            t = x + 1
+            return t, t
+
+        a, b = torch.compile(fn_dup)(torch.zeros(1, device=self.device))
+        self.assertIs(a, b)
+
+    def test_no_op_view_output_identity_joint(self):
+        # https://github.com/pytorch/pytorch/issues/191449
+        # Same as test_no_op_view_output_identity, but with a differentiable
+        # output alongside, so the aliased no-grad pair flows through the
+        # autograd (joint) runtime path.
+        def fn(x):
+            y = x * 2
+            with torch.no_grad():
+                base = x + 1
+                alias = base.view(-1)
+            return y, base, alias
+
+        x = torch.zeros(1, device=self.device, requires_grad=True)
+        ey, ebase, ealias = fn(x)
+        y, base, alias = torch.compile(fn)(x)
+        self.assertIsNot(base, alias)
+        self.assertEqual(base.data_ptr(), alias.data_ptr())
+        self.assertEqual(y, ey)
+        self.assertEqual(base, ebase)
+
     # end of class CommonTemplate - add new tests here
 
 

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -45,6 +45,7 @@ from .functional_utils import (
     from_fun,
     has_data_mutation,
     has_metadata_mutation,
+    has_same_metadata,
     MetadataKey,
     to_fun,
     ViewMetaSequence,
@@ -633,6 +634,35 @@ from a multi-output view call"
                 existing_out_idx = out_tensor_ids[id(out_alias)]
                 output_type = OutputType.alias_of_intermediate_base_is_user_output
                 base_idx = existing_out_idx
+            elif (
+                o._base is not None
+                and not is_traceable_wrapper_subclass(o)
+                and has_same_metadata(o, o._base)
+                and (
+                    id(o._base) in out_tensor_ids
+                    or id(o._base) in intermediate_base_tensor_id_to_output_idx
+                )
+            ):
+                # None of the differentiable-alias branches above fired, but o
+                # is a no-op view of another graph output. If we classify it as
+                # non_alias, the backend is free to collapse the view into its
+                # base and return the same tensor object for both outputs,
+                # while eager returns distinct objects. That identity
+                # difference is observable across graph breaks (e.g. an eager
+                # resize_() between two compiled regions corrupts the base).
+                # Regenerate the view at runtime like the differentiable
+                # aliasing cases above. Wrapper subclasses are excluded: their
+                # view_meta_sequence is not captured, and the as_strided
+                # fallback in gen_alias_from_base is not supported by e.g.
+                # DTensor, so they keep the old passthrough behavior.
+                # See https://github.com/pytorch/pytorch/issues/191449
+                maybe_existing_out_idx = out_tensor_ids.get(id(o._base))
+                if maybe_existing_out_idx is not None:
+                    output_type = OutputType.alias_of_intermediate_base_is_user_output
+                    base_idx = maybe_existing_out_idx
+                else:
+                    output_type = OutputType.alias_of_intermediate
+                    base_idx = intermediate_base_tensor_id_to_output_idx[id(o._base)]
             else:
                 output_type = OutputType.non_alias
                 base_idx = None

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -638,31 +638,30 @@ from a multi-output view call"
                 o._base is not None
                 and not is_traceable_wrapper_subclass(o)
                 and has_same_metadata(o, o._base)
-                and (
-                    id(o._base) in out_tensor_ids
-                    or id(o._base) in intermediate_base_tensor_id_to_output_idx
-                )
+                and id(o._base) in out_tensor_ids
             ):
-                # None of the differentiable-alias branches above fired, but o
-                # is a no-op view of another graph output. If we classify it as
-                # non_alias, the backend is free to collapse the view into its
-                # base and return the same tensor object for both outputs,
-                # while eager returns distinct objects. That identity
-                # difference is observable across graph breaks (e.g. an eager
-                # resize_() between two compiled regions corrupts the base).
-                # Regenerate the view at runtime like the differentiable
-                # aliasing cases above. Wrapper subclasses are excluded: their
-                # view_meta_sequence is not captured, and the as_strided
-                # fallback in gen_alias_from_base is not supported by e.g.
-                # DTensor, so they keep the old passthrough behavior.
+                # o is a no-op view of another user output, but not
+                # differentiable, so none of the branches above fired. Left as
+                # non_alias, the backend is free to collapse the view and return
+                # one object for both outputs while eager returns two; an eager
+                # resize_() on the alias across a graph break then corrupts the
+                # base. Regenerate the view at runtime instead.
                 # See https://github.com/pytorch/pytorch/issues/191449
-                maybe_existing_out_idx = out_tensor_ids.get(id(o._base))
-                if maybe_existing_out_idx is not None:
-                    output_type = OutputType.alias_of_intermediate_base_is_user_output
-                    base_idx = maybe_existing_out_idx
-                else:
-                    output_type = OutputType.alias_of_intermediate
-                    base_idx = intermediate_base_tensor_id_to_output_idx[id(o._base)]
+                #
+                # Two shapes of this bug are knowingly still broken here and are
+                # tracked in #191449, which stays open for them: t.detach() leaves ._base as None so
+                # it never reaches this arm, and traceable wrapper subclasses
+                # are excluded because their view_meta_sequence is not captured
+                # and the as_strided fallback in gen_alias_from_base is not
+                # supported by e.g. DTensor. For both, the issue's own repro
+                # still returns a base of shape (12,) where eager gives (1,).
+                #
+                # o._base.requires_grad would imply o.requires_grad
+                # (DifferentiableViewMeta), which the branch above already
+                # handles, so o._base is never a saved intermediate base and
+                # this index is always in user-output space.
+                output_type = OutputType.alias_of_intermediate_base_is_user_output
+                base_idx = out_tensor_ids[id(o._base)]
             else:
                 output_type = OutputType.non_alias
                 base_idx = None

--- a/torch/_functorch/_aot_autograd/input_output_analysis.py
+++ b/torch/_functorch/_aot_autograd/input_output_analysis.py
@@ -40,6 +40,12 @@ from .utils import strict_zip
 zip = strict_zip
 
 
+# The only output types whose base_idx is an index into the graph inputs. The
+# alias_of_intermediate* types index into graph intermediates or user outputs
+# instead, so input renumbering must skip them. See OutputAliasInfo.base_idx.
+INPUT_ALIAS_TYPES = (OutputType.alias_of_input, OutputType.is_input)
+
+
 def remove_dupe_metadata(
     m: ViewAndMutationMeta,
     keep_arg_mask: list[bool],
@@ -89,12 +95,17 @@ def remove_dupe_metadata(
         input_info=[x for i, x in enumerate(m.input_info) if keep_arg_mask[i]],
         # For outputs that are views of inputs, we store the index of the input that the output
         # was generated from. Need to update that index to account for removed dupes.
+        # Dedup renumbers inputs only, so this skips the non-input index spaces.
         output_info=[
             OutputAliasInfo(
                 output_type=o.output_type,
                 raw_type=o.raw_type,
                 dynamic_dims=o.dynamic_dims,
-                base_idx=None if o.base_idx is None else add_dupe_map[o.base_idx],
+                base_idx=(
+                    add_dupe_map[o.base_idx]
+                    if o.base_idx is not None and o.output_type in INPUT_ALIAS_TYPES
+                    else o.base_idx
+                ),
                 requires_grad=o.requires_grad,
                 requires_grad_for_backward=o.requires_grad_for_backward,
                 view_meta_sequence=o.view_meta_sequence,
@@ -236,28 +247,26 @@ def create_synthetic_base_metadata(
     ]
     existing_output_infos = []
     for o in m.output_info:
-        synthetic_base_info_for_output = (
-            None if o.base_idx is None else synthetic_base_info[o.base_idx]
-        )
-        new_base_idx = (
-            None
-            if o.base_idx is None
-            else (
-                synthetic_base_info_for_output
-                if isinstance(synthetic_base_info_for_output, int)
-                else synthetic_base_info_for_output[0]  # type: ignore[index]
+        if o.base_idx is None or o.output_type not in INPUT_ALIAS_TYPES:
+            # base_idx is not an input index for these, so synthetic bases
+            # leave it alone. See OutputAliasInfo.base_idx.
+            new_base_idx = o.base_idx
+            new_output_type = o.output_type
+        else:
+            synthetic_base_info_for_output = synthetic_base_info[o.base_idx]
+            # If the original input was merged into a synthetic base, then an
+            # output that was literally that input is now a view of the base.
+            input_merged = isinstance(synthetic_base_info_for_output, tuple)
+            new_base_idx = (
+                synthetic_base_info_for_output[0]  # type: ignore[index]
+                if input_merged
+                else synthetic_base_info_for_output  # type: ignore[assignment]
             )
-        )
-        # If the original input was merged into a synthetic base, then an
-        # output that was literally that input is now a view of the base.
-        input_merged = o.base_idx is not None and isinstance(
-            synthetic_base_info[o.base_idx], tuple
-        )
-        new_output_type = (
-            OutputType.alias_of_input
-            if o.output_type == OutputType.is_input and input_merged
-            else o.output_type
-        )
+            new_output_type = (
+                OutputType.alias_of_input
+                if o.output_type == OutputType.is_input and input_merged
+                else o.output_type
+            )
         existing_output_infos.append(
             OutputAliasInfo(
                 output_type=new_output_type,

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -9,6 +9,7 @@ from typing import Any
 import torch
 import torch.utils._pytree as pytree
 from torch._dynamo.utils import dynamo_timed, lazy_format_graph_code
+from torch._functorch._aot_autograd.input_output_analysis import INPUT_ALIAS_TYPES
 from torch._functorch.aot_autograd import MutationType
 from torch._functorch.compile_utils import fx_graph_cse
 from torch._inductor.constant_folding import constant_fold, replace_node_with_constant
@@ -37,10 +38,12 @@ def replace_params_with_constants(
     params = gm.graph.find_nodes(op="placeholder")
     fake_inp_nodes = params[: len(params)]
     preserved_arg_indices = []
+    # Skipping the non-input index spaces matters here: an output-space base_idx
+    # would preserve whichever parameter happened to share that number.
     aliased_input_args = [
         out_info.base_idx
         for out_info in fw_metadata.output_info
-        if out_info.base_idx is not None
+        if out_info.base_idx is not None and out_info.output_type in INPUT_ALIAS_TYPES
     ]
 
     # TODO (tmanlaibaatar) figure out why this is different


### PR DESCRIPTION
Addresses #191449 (the no-op view case; the detach() and traceable-wrapper-subclass shapes remain and are tracked there).

## Summary

`torch.compile` silently returns wrong results when `resize_()` is called on a
view of an intermediate tensor. Eager returns a 1-element tensor, while the
compiled function returns 12 elements of mostly uninitialized memory. The full
investigation is in the issue thread. Per review feedback, the fix now lives
in AOTAutograd instead of Inductor.

## Root cause

1. Dynamo graph-breaks on `resize_()` as documented (gb0126), so the `resize_`
   runs in eager mode between two compiled graphs. The first graph returns an
   intermediate plus a no-op view of it. In eager these are two distinct
   tensor objects sharing one storage.
2. `collect_metadata_analysis.py` only classifies an output as an alias of an
   intermediate when both the output and its base require grad. In no-grad
   code the no-op view fell into `non_alias`, so the runtime wrapper never
   regenerated it and object identity was left to the backend.
3. Backends are free to collapse no-op views (Inductor's `remove_noop_ops`
   and `pointless_view` do exactly that), so the compiled function returned
   one object twice, e.g. `return (buf0, buf0, )`. The eager `resize_()` on
   one output therefore resized the base as well, and the second graph was
   traced against the already corrupted tensor.

## Fix

`run_functionalized_fw_and_collect_metadata` gets one new classification arm:
a view with the same metadata as its `._base`, where the base is another user
output (or an already registered intermediate base), is classified
`alias_of_intermediate_base_is_user_output`. The existing runtime epilogue
then regenerates a distinct view object through `gen_alias_from_base`.

- `return t, t` still returns one object twice, matching eager. Dynamo dedups
  same-object outputs, and the new arm requires `._base`.
- Wrapper subclasses keep the old passthrough: their regeneration would fall
  back to `as_strided`, which DTensor rejects (the failure that reverted
  #184367).
- Unlike the previous wrapper-level fix, this also covers cpp_wrapper.
- Known behavior change: `aot_export_joint_simple` now rejects such programs,
  since it rejects all alias outputs by design.

## Test plan

- `test_collect_metadata_no_grad_no_op_view_of_user_output` in
  `test/functorch/test_aotdispatch.py`: metadata-level regression test, fails
  without the fix (outputs were `non_alias`).
- `test_resize_on_view_after_graph_break`, `test_no_op_view_output_identity`,
  and `test_no_op_view_output_identity_joint` in
  `test/inductor/test_torchinductor.py`: the issue's repro plus object
  identity in both directions (view stays distinct, `return t, t` stays the
  same object), including the joint/autograd runtime path.
- Repro matches eager with the fix on a from-source CPU build and on the CUDA
  nightly wheel (GTX 1660 Ti); without the fix both fail with shape (1,) vs
  (12,).
- Full `test/functorch/test_aotdispatch.py` passes; lintrunner reports no
  issues on the changed files.

Fable-Assisted.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jansel @zou3519

## Performance note
On a microbenchmark that is almost entirely epilogue (`def f(x): y = x + 1; return y, y.view(-1)` on an 8-element input) the reviewer measured +10.5 us/call (+28%); on an ARM Neoverse-N1 (4 OCPU, CPU-only) I measure +27.6 us/call (+131%) at the median of 6 interleaved runs. So the unconditional per-call cost on affected graphs is roughly +10 to +28 us depending on hardware, against a call that does almost no real work -- the relative number is large because the denominator is tiny, and it will shrink as a fraction of any realistic graph. A graph with no aliased output pair is unchanged (21.3 -> 21.2 us/call), so nothing is paid by graphs the fix does not reclassify. The trade is correctness: without the reclassification these graphs can return one tensor object where eager returns two, which silently corrupts the base across a graph break (#191449).
