### PR TITLE
Warn on conditional graph in mark_kernels and get_graph_data

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -32,6 +32,62 @@ from torch.testing._internal.common_utils import (
 )
 
 
+# Nested graphs (child-graph and conditional nodes) have no torch API, so the tests
+# below build them through cuda.bindings the way a library embedding one would.
+# cuda.bindings is imported lazily so this module still imports without it.
+def _memset_params(dst: torch.Tensor):
+    from cuda.bindings import runtime as cuda_runtime
+
+    params = cuda_runtime.cudaMemsetParams()
+    params.dst = dst.data_ptr()
+    params.elementSize = 4
+    params.width = dst.numel()
+    params.height = 1
+    params.pitch = 0
+    params.value = 0
+    return params
+
+
+def _add_child_graph_node(graph, deps, dst):
+    from cuda.bindings import runtime as cuda_runtime
+
+    body = _check_cuda_bindings(cuda_runtime.cudaGraphCreate(0))
+    _check_cuda_bindings(
+        cuda_runtime.cudaGraphAddMemsetNode(body, [], 0, _memset_params(dst))
+    )
+    return _check_cuda_bindings(
+        cuda_runtime.cudaGraphAddChildGraphNode(graph, deps, len(deps), body)
+    )
+
+
+def _add_conditional_node(graph, deps, dst):
+    from cuda.bindings import driver, runtime as cuda_runtime
+
+    handle = _check_cuda_bindings(
+        cuda_runtime.cudaGraphConditionalHandleCreate(graph, 1, 1)
+    )
+    params = cuda_runtime.cudaGraphNodeParams()
+    params.type = cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeConditional
+    params.conditional.handle = handle
+    params.conditional.type = driver.CUgraphConditionalNodeType.CU_GRAPH_COND_TYPE_IF
+    params.conditional.size = 1
+    node = _check_cuda_bindings(
+        cuda_runtime.cudaGraphAddNode(graph, deps, None, len(deps), params)
+    )
+    _check_cuda_bindings(
+        cuda_runtime.cudaGraphAddMemsetNode(
+            params.conditional.phGraph_out[0], [], 0, _memset_params(dst)
+        )
+    )
+    return node
+
+
+_NESTED_NODE_ADDERS = {
+    "child_graph": _add_child_graph_node,
+    "conditional": _add_conditional_node,
+}
+
+
 # cuda.bindings is NVIDIA-only; graph annotation APIs have no ROCm equivalent.
 @instantiate_parametrized_tests
 @skipIfRocm
@@ -642,8 +698,77 @@ class TestMarkKernels(TestCase):
         for anns in annotations.values():
             self.assertEqual(anns, [{"name": "tagged"}])
 
+    def test_scope_inside_conditional_body_records_nothing(self):
+        """A scope inside a torch.cond body warns and records no annotations.
+
+        begin_capture_to_if_node captures into a separate cudaGraph_t, so node ids
+        there are in the body graph's id space; remap_to_exec_graph only rekeys the
+        top-level capture id, so anything recorded would be a key matching nothing.
+        """
+        from torch._higher_order_ops.cudagraph_conditional_nodes import _if_body
+
+        x = torch.ones([2000], device="cuda")
+        pred = torch.tensor(True, device="cuda")
+        g = torch.cuda.CUDAGraph(keep_graph=True)
+
+        with torch.cuda.graph(g, enable_annotations=True):
+            with mark_kernels("outer_region"):
+                z = x + 1
+            with self.assertWarnsRegex(UserWarning, "conditional-node body"):
+                with _if_body(pred):
+                    with mark_kernels("inside_body"):
+                        _ = z * 2
+        g.instantiate()
+
+        # Only the top-level scope is recorded, and its key matches the exec graph.
+        annotations = get_kernel_annotations()
+        self.assertEqual(
+            [a for anns in annotations.values() for a in anns],
+            [{"name": "outer_region"}],
+        )
+        with self.assertWarns(UserWarning):  # the graph has a conditional node
+            exec_graph_id = g.get_graph_data()["exec_graph_id"]
+        for tools_id in annotations:
+            self.assertEqual(tools_id >> 32, exec_graph_id)
+
+    @parametrize("kind", ["child_graph", "conditional"])
+    def test_nested_graph_node_in_scope_warns(self, kind):
+        """A scope containing a nested graph node warns; the rest is annotated.
+
+        The dependent-edge walk stops at such a node, so the work in its body is
+        left unannotated (and its ids, being in the body graph's id space, would
+        never be rekeyed by remap_to_exec_graph). What is recorded stays correct.
+        """
+        from cuda.bindings import runtime as cuda_runtime
+
+        dst = torch.zeros(64, device="cuda")
+        x = torch.zeros([2000], device="cuda")
+        g = torch.cuda.CUDAGraph(keep_graph=True)
+
+        with self.assertWarnsRegex(UserWarning, "left unannotated"):
+            with torch.cuda.graph(
+                g, enable_annotations=True, capture_error_mode="relaxed"
+            ):
+                with mark_kernels("region"):
+                    y = x + 1
+                    stream = cuda_runtime.cudaStream_t(
+                        init_value=torch.cuda.current_stream().cuda_stream
+                    )
+                    _s, _i, cap_graph, deps, _e, num = _check_cuda_bindings(
+                        cuda_runtime.cudaStreamGetCaptureInfo(stream)
+                    )
+                    _NESTED_NODE_ADDERS[kind](cap_graph, list(deps[:num]), dst)
+                    _ = y * 2
+
+        # The two elementwise kernels in the scope are still annotated correctly.
+        annotations = get_kernel_annotations()
+        self.assertEqual(len(annotations), 2)
+        for anns in annotations.values():
+            self.assertEqual(anns, [{"name": "region"}])
+
 
 # cuda.bindings is NVIDIA-only; get_graph_data has no ROCm equivalent.
+@instantiate_parametrized_tests
 @skipIfRocm
 @requires_cuda
 @requires_cuda_python_bindings
@@ -765,6 +890,35 @@ class TestGetGraphData(TestCase):
         after = g.get_graph_data()
         self.assertIsNot(after, seen[0])
         self.assertEqual(after, seen[0])
+
+    @parametrize("kind", ["child_graph", "conditional"])
+    def test_nested_graph_node_warns_but_reports_top_level(self, kind):
+        """A nested cudaGraph_t warns; the top-level nodes are still reported.
+
+        cudaGraphGetNodes does not descend into a child graph or a conditional
+        body, so that work is missing from the result -- but the ids that are
+        reported stay valid, since the exec graph preserves top-level node ids.
+        """
+        dst = torch.zeros(64, device="cuda")
+        x = torch.zeros([2000], device="cuda")
+        g = torch.cuda.CUDAGraph(keep_graph=True)
+        with torch.cuda.graph(g, capture_error_mode="relaxed"):
+            _ = x + 1
+        _NESTED_NODE_ADDERS[kind](g.raw_cuda_graph(), [], dst)
+        g.instantiate()
+
+        with self.assertWarnsRegex(UserWarning, kind):
+            data = g.get_graph_data()
+
+        # The nested node itself is reported, its body is not: exactly one memset
+        # lives in the body, and it must not appear among the returned nodes.
+        self.assertEqual(len([n for n in data["nodes"] if n["node_type"] == kind]), 1)
+        self.assertEqual(
+            len([n for n in data["nodes"] if n["node_type"] == "memset"]), 0
+        )
+        exec_graph_id = data["exec_graph_id"]
+        for node in data["nodes"]:
+            self.assertEqual(node["tools_id"], (exec_graph_id << 32) | node["node_id"])
 
     def test_keep_graph_false_raises(self):
         g = torch.cuda.CUDAGraph(keep_graph=False)

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -91,20 +91,31 @@ _tools_id_available: bool | None = None
 _annotations_enabled: bool = False
 
 
-# The top-level capture graph of the active capture. A conditional node's body is
+# Id of the top-level capture graph of the active capture. A conditional node's body is
 # captured into a separate cudaGraph_t (see CUDAGraph::begin_capture_to_conditional_node),
 # and its node ids live in that graph's id space, which remap_to_exec_graph never rekeys --
 # so mark_kernels compares against this to detect a scope inside a body.
-_capture_root_graph: int | None = None
+_capture_root_graph_id: int | None = None
 
 
 def _set_annotations_enabled(enabled: bool) -> None:
     """Set whether annotation recording is active. Used by ``torch.cuda.graph``
     to scope annotations to a capture; not a public API."""
-    global _annotations_enabled, _capture_root_graph
+    global _annotations_enabled, _capture_root_graph_id
     _annotations_enabled = enabled
     if not enabled:
-        _capture_root_graph = None
+        _capture_root_graph_id = None
+
+
+def _graph_id(graph: Any) -> int:
+    """The driver's unique id for a ``cudaGraph_t``.
+
+    Identifies a graph across its whole lifetime, unlike the handle itself: that is a
+    pointer, so a graph created after another is destroyed can reuse the value and
+    compare equal to it."""
+    return _check_cuda_bindings(
+        _cuda_runtime.cudaGraphGetId(graph)  # pyrefly: ignore[missing-attribute]
+    )
 
 
 def maybe_stamp_capture_root(stream: Any) -> None:
@@ -112,8 +123,8 @@ def maybe_stamp_capture_root(stream: Any) -> None:
 
     Called by ``torch.cuda.graph`` right after ``capture_begin``, while ``stream`` is
     still capturing into the top-level graph. Not a public API."""
-    global _capture_root_graph
-    _capture_root_graph = None
+    global _capture_root_graph_id
+    _capture_root_graph_id = None
     if not _annotations_enabled or _is_tools_id_unavailable():
         return
     stream_handle = _cuda_runtime.cudaStream_t(  # pyrefly: ignore[missing-attribute]
@@ -121,7 +132,7 @@ def maybe_stamp_capture_root(stream: Any) -> None:
     )
     state = _get_capture_state(stream_handle)
     if state is not None:
-        _capture_root_graph = int(state[0])
+        _capture_root_graph_id = _graph_id(state[0])
 
 
 def _probe_tools_id() -> bool:
@@ -307,9 +318,11 @@ def _get_annotatable_types() -> set[Any]:
 
 
 # Node types whose work lives in a separate cudaGraph_t (child graphs, conditional
-# bodies). The dependent-edge walk stops at such a node, and the nodes inside are
-# numbered in the body graph's id space, which remap_to_exec_graph never rekeys --
-# so annotations there would be silently lost. See mark_kernels.
+# bodies). The dependent-edge walk does not descend into such a node, and the nodes
+# inside are numbered in the body graph's id space, which remap_to_exec_graph never
+# rekeys -- so annotations there would be silently lost. See mark_kernels. Initialized
+# lazily, like _ANNOTATABLE_TYPES above: _cuda_driver is None when cuda.bindings is
+# absent, so reading the enum at import time would break `import torch`.
 _NESTED_GRAPH_TYPES: set[Any] | None = None
 
 
@@ -394,8 +407,8 @@ def _end_kernel_scope(scope: _KernelScope) -> list[int]:
         # top-level node ids -- they just do not cover the nested body.
         warnings.warn(
             f"mark_kernels: this scope contains {sorted(nested_seen)} nodes; the work "
-            "inside them is in a separate cudaGraph_t that the dependent-edge walk "
-            "cannot enter, so it is left unannotated",
+            "inside them is in a separate cudaGraph_t that this walk does not descend "
+            "into, so it is left unannotated",
             stacklevel=4,
         )
     return tools_ids
@@ -436,11 +449,15 @@ def mark_kernels(annotation: str | dict[str, Any]):
 
     .. note::
         Child-graph and conditional nodes have bodies in a separate
-        ``cudaGraph_t`` that the walk cannot enter, so their work is left
-        unannotated and a warning is issued. A scope *inside* a conditional
-        body (``torch.cond`` / ``torch.while_loop``) records nothing at all:
-        node ids there are in the body graph's id space, which is never
-        remapped to the exec graph.
+        ``cudaGraph_t`` that this walk does not descend into, so their work is
+        left unannotated and a warning is issued. Descending is possible
+        (``cudaGraphNodeGetParams`` exposes the body graphs), but would not be
+        enough on its own: a body's nodes are numbered in that graph's id space
+        and are renumbered again when the exec graph inlines them, and nothing
+        exposes that renumbering, so :func:`remap_to_exec_graph` could not key
+        the annotations to what a profiler reports. For the same reason a scope
+        *inside* a conditional body (``torch.cond`` / ``torch.while_loop``)
+        records nothing at all.
 
     .. warning::
         This API is in prototype and may change in future releases.
@@ -466,7 +483,10 @@ def mark_kernels(annotation: str | dict[str, Any]):
         yield
         return
 
-    if _capture_root_graph is not None and int(scope.graph) != _capture_root_graph:
+    if (
+        _capture_root_graph_id is not None
+        and _graph_id(scope.graph) != _capture_root_graph_id
+    ):
         # Inside a conditional node's body: torch.cond / torch.while_loop capture into a
         # separate cudaGraph_t. Its node ids are in that graph's id space and are
         # renumbered again in the exec graph, so anything recorded here would be a key

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -44,6 +44,7 @@ control (e.g. resolving once before remapping several graphs).
 from __future__ import annotations
 
 import importlib.metadata
+import warnings
 from collections import defaultdict
 from contextlib import contextmanager
 from logging import getLogger
@@ -90,11 +91,37 @@ _tools_id_available: bool | None = None
 _annotations_enabled: bool = False
 
 
+# The top-level capture graph of the active capture. A conditional node's body is
+# captured into a separate cudaGraph_t (see CUDAGraph::begin_capture_to_conditional_node),
+# and its node ids live in that graph's id space, which remap_to_exec_graph never rekeys --
+# so mark_kernels compares against this to detect a scope inside a body.
+_capture_root_graph: int | None = None
+
+
 def _set_annotations_enabled(enabled: bool) -> None:
     """Set whether annotation recording is active. Used by ``torch.cuda.graph``
     to scope annotations to a capture; not a public API."""
-    global _annotations_enabled
+    global _annotations_enabled, _capture_root_graph
     _annotations_enabled = enabled
+    if not enabled:
+        _capture_root_graph = None
+
+
+def maybe_stamp_capture_root(stream: Any) -> None:
+    """Record the top-level capture graph of the capture just begun on ``stream``.
+
+    Called by ``torch.cuda.graph`` right after ``capture_begin``, while ``stream`` is
+    still capturing into the top-level graph. Not a public API."""
+    global _capture_root_graph
+    _capture_root_graph = None
+    if not _annotations_enabled or _is_tools_id_unavailable():
+        return
+    stream_handle = _cuda_runtime.cudaStream_t(  # pyrefly: ignore[missing-attribute]
+        init_value=stream.cuda_stream
+    )
+    state = _get_capture_state(stream_handle)
+    if state is not None:
+        _capture_root_graph = int(state[0])
 
 
 def _probe_tools_id() -> bool:
@@ -279,6 +306,24 @@ def _get_annotatable_types() -> set[Any]:
     return _ANNOTATABLE_TYPES
 
 
+# Node types whose work lives in a separate cudaGraph_t (child graphs, conditional
+# bodies). The dependent-edge walk stops at such a node, and the nodes inside are
+# numbered in the body graph's id space, which remap_to_exec_graph never rekeys --
+# so annotations there would be silently lost. See mark_kernels.
+_NESTED_GRAPH_TYPES: set[Any] | None = None
+
+
+def _get_nested_graph_types() -> set[Any]:
+    global _NESTED_GRAPH_TYPES
+    if _NESTED_GRAPH_TYPES is None:
+        node_types = _cuda_driver.CUgraphNodeType  # pyrefly: ignore[missing-attribute]
+        _NESTED_GRAPH_TYPES = {
+            node_types.CU_GRAPH_NODE_TYPE_GRAPH,
+            node_types.CU_GRAPH_NODE_TYPE_CONDITIONAL,
+        }
+    return _NESTED_GRAPH_TYPES
+
+
 # Pending scopes: (annotation, toolsIds discovered for the scope).
 _pending_scopes: list[tuple[Any, list[int]]] = []
 
@@ -327,9 +372,13 @@ def _end_kernel_scope(scope: _KernelScope) -> list[int]:
         scope_nodes = _collect_descendants(new_roots, include_start_nodes=True)
 
     annotatable = _get_annotatable_types()
+    nested = _get_nested_graph_types()
+    nested_seen: set[str] = set()
     tools_ids: list[int] = []
     for node in scope_nodes.values():
         node_type = _get_node_type(node)
+        if node_type in nested:
+            nested_seen.add(node_type.name)
         if node_type not in annotatable:
             continue
         tools_ids.append(
@@ -338,6 +387,16 @@ def _end_kernel_scope(scope: _KernelScope) -> list[int]:
                     node
                 )
             )
+        )
+
+    if nested_seen:
+        # The annotations recorded above are still correct -- the exec graph preserves
+        # top-level node ids -- they just do not cover the nested body.
+        warnings.warn(
+            f"mark_kernels: this scope contains {sorted(nested_seen)} nodes; the work "
+            "inside them is in a separate cudaGraph_t that the dependent-edge walk "
+            "cannot enter, so it is left unannotated",
+            stacklevel=4,
         )
     return tools_ids
 
@@ -375,6 +434,14 @@ def mark_kernels(annotation: str | dict[str, Any]):
         already-capturing stream must be synchronized with the current
         stream first.
 
+    .. note::
+        Child-graph and conditional nodes have bodies in a separate
+        ``cudaGraph_t`` that the walk cannot enter, so their work is left
+        unannotated and a warning is issued. A scope *inside* a conditional
+        body (``torch.cond`` / ``torch.while_loop``) records nothing at all:
+        node ids there are in the body graph's id space, which is never
+        remapped to the exec graph.
+
     .. warning::
         This API is in prototype and may change in future releases.
 
@@ -396,6 +463,21 @@ def mark_kernels(annotation: str | dict[str, Any]):
 
     scope = _begin_kernel_scope()
     if scope is None:
+        yield
+        return
+
+    if _capture_root_graph is not None and int(scope.graph) != _capture_root_graph:
+        # Inside a conditional node's body: torch.cond / torch.while_loop capture into a
+        # separate cudaGraph_t. Its node ids are in that graph's id space and are
+        # renumbered again in the exec graph, so anything recorded here would be a key
+        # that matches nothing in a trace. Record nothing rather than dead keys.
+        warnings.warn(
+            "mark_kernels: this scope is inside a CUDA graph conditional-node body "
+            "(torch.cond / torch.while_loop), which is captured into a separate "
+            "cudaGraph_t whose node ids are never remapped to the exec graph; "
+            "nothing is annotated for it",
+            stacklevel=3,
+        )
         yield
         return
 

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import gc
 import typing
+import warnings
 import weakref
 from collections import OrderedDict
 from collections.abc import Callable
@@ -726,6 +727,12 @@ class CUDAGraph(_CUDAGraph):
         is a true dependency (encoded in the graph) or a fake dependency
         caused by mapping of independent streams to the same hardware
         channel.
+
+        Child-graph and conditional nodes are reported as nodes in their own
+        right, but this walk does not descend into their bodies (those are
+        separate ``cudaGraph_t`` objects), so the work inside them is absent
+        from ``nodes`` and a warning is issued. The ids that *are* reported
+        stay valid: the exec graph preserves top-level node ids.
         """
         # Serve the shared cache when instantiate() has it live (see _caching_graph_data).
         if self._instantiate_graph_data is not None:
@@ -754,7 +761,14 @@ class CUDAGraph(_CUDAGraph):
             _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeEventRecord: "event_record",
             _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeMemAlloc: "mem_alloc",
             _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeMemFree: "mem_free",
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeConditional: "conditional",
         }
+        # Node types whose work lives in a separate cudaGraph_t (see the warning below).
+        nested_graph_types = {
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeGraph,
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeConditional,
+        }
+        nested_node_types: set[str] = set()
 
         raw = self.raw_cuda_graph()
 
@@ -771,6 +785,8 @@ class CUDAGraph(_CUDAGraph):
             handle_to_idx[int(node)] = i
 
             ntype = _check_cuda_bindings(_cuda_runtime.cudaGraphNodeGetType(node))
+            if ntype in nested_graph_types:
+                nested_node_types.add(node_type_names.get(ntype, ntype))
             tools_id = _check_cuda_bindings(_cuda_runtime.cudaGraphNodeGetToolsId(node))
             graph_id = tools_id >> 32
             node_id = tools_id & 0xFFFFFFFF
@@ -821,6 +837,18 @@ class CUDAGraph(_CUDAGraph):
         for info in node_infos:
             info["tools_id"] = (exec_graph_id << 32) | info["node_id"]
             info["graph_id"] = exec_graph_id
+
+        if nested_node_types:
+            # What is returned stays correct: the exec graph preserves top-level node
+            # ids and numbers the nested ones after them. Those nested nodes do execute
+            # and do show up in a profiler trace (under this exec graph id, with the
+            # appended node ids), they are just missing from the topology below.
+            warnings.warn(
+                f"get_graph_data: this graph contains {sorted(nested_node_types)} "
+                "nodes; the work inside them is in a separate cudaGraph_t that this "
+                "walk does not descend into, so it is absent from the returned nodes",
+                stacklevel=2,
+            )
 
         data = {
             "exec_graph_id": exec_graph_id,
@@ -984,6 +1012,11 @@ class graph:
             # pyrefly: ignore [bad-keyword-argument]
             check_input_liveness=self.check_input_liveness,
         )
+        # The capture stream is now capturing into the top-level graph; remember it so
+        # mark_kernels can tell a conditional-node body apart from this graph.
+        from torch.cuda._graph_annotations import maybe_stamp_capture_root
+
+        maybe_stamp_capture_root(torch.cuda.current_stream())
 
     def __exit__(self, *args: object) -> None:
         from torch.cuda._graph_annotations import (


### PR DESCRIPTION
 Warn in mark_kernels and get_graph_data when a CUDA graph contains a child-graph or
 conditional node: their bodies are separate cudaGraph_t objects, so
`get_graph_data` does not descend into them and `mark_kernels` does not annotate them,
 and a mark_kernels scope inside a torch.cond body now records nothing rather
 than annotations keyed to a graph id that is never remapped to the exec graph.
 
 Authored with claude