### PR TITLE
[autograd] Add opt-in NaN equality to gradcheck

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7008,6 +7008,50 @@ Done""",
         check(fast_mode=True)
         check(fast_mode=False)
 
+    def test_gradcheck_equal_nan(self):
+        class AlwaysNaN(Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x * torch.nan
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return torch.where(
+                    grad_output == 0,
+                    torch.zeros_like(grad_output),
+                    torch.full_like(grad_output, torch.nan),
+                )
+
+        x = torch.ones(1, dtype=torch.double, requires_grad=True)
+        for fast_mode in (False, True):
+            self.assertFalse(
+                gradcheck(
+                    AlwaysNaN.apply,
+                    (x,),
+                    raise_exception=False,
+                    check_batched_grad=False,
+                    fast_mode=fast_mode,
+                )
+            )
+            self.assertTrue(
+                gradcheck(
+                    AlwaysNaN.apply,
+                    (x,),
+                    equal_nan=True,
+                    check_batched_grad=False,
+                    fast_mode=fast_mode,
+                )
+            )
+
+        self.assertTrue(
+            gradgradcheck(
+                lambda y: y.sin(),
+                (x,),
+                equal_nan=True,
+                check_batched_grad=False,
+            )
+        )
+
     def test_gradcheck_dense_and_sparse_inputs(self):
         def check(fast_mode):
             def fn(x, y):

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1612,6 +1612,7 @@ def _slow_gradcheck(
     complex_indices=None,
     test_imag=False,
     masked=False,
+    equal_nan=False,
 ):
     func_out = _as_tuple(func_out)
     if not outputs:
@@ -1641,7 +1642,9 @@ def _slow_gradcheck(
         for i, n_per_out in enumerate(numerical):
             for j, n in enumerate(n_per_out):
                 a = analytical_forward[j][i]
-                if not _allclose_with_type_promotion(a, n.to(a.device), rtol, atol):
+                if not _allclose_with_type_promotion(
+                    a, n.to(a.device), rtol, atol, equal_nan=equal_nan
+                ):
                     raise GradcheckError(
                         _get_notallclose_msg(
                             a, n, i, j, complex_indices, test_imag, is_forward_ad=True
@@ -1654,7 +1657,9 @@ def _slow_gradcheck(
             )
 
             for j, (a, n) in enumerate(zip(analytical, numerical[i])):
-                if not _allclose_with_type_promotion(a, n.to(a.device), rtol, atol):
+                if not _allclose_with_type_promotion(
+                    a, n.to(a.device), rtol, atol, equal_nan=equal_nan
+                ):
                     raise GradcheckError(
                         _get_notallclose_msg(a, n, i, j, complex_indices, test_imag)
                     )
@@ -1670,11 +1675,11 @@ def _dot_with_type_promotion(u, v):
     return (u * v).sum()
 
 
-def _allclose_with_type_promotion(a, b, rtol, atol):
+def _allclose_with_type_promotion(a, b, rtol, atol, *, equal_nan=False):
     promoted_type = torch.promote_types(a.dtype, b.dtype)
     a = a.to(dtype=promoted_type)
     b = b.to(dtype=promoted_type)
-    return torch.allclose(a, b, rtol, atol)
+    return torch.allclose(a, b, rtol, atol, equal_nan=equal_nan)
 
 
 def _to_real_dtype(dtype):
@@ -1793,7 +1798,16 @@ If the test
 
 
 def _run_slow_mode_and_get_error(
-    func, tupled_inputs, outputs, input_idx, output_idx, rtol, atol, eps, is_forward_ad
+    func,
+    tupled_inputs,
+    outputs,
+    input_idx,
+    output_idx,
+    rtol,
+    atol,
+    eps,
+    is_forward_ad,
+    equal_nan,
 ):
     # Compute jacobians in slow mode for better error message
     slow_numerical = _get_numerical_jacobian(
@@ -1817,7 +1831,9 @@ def _run_slow_mode_and_get_error(
     # Assume jacobians are non-empty and have the same shape
     slow_max_diff = (slow_numerical - slow_analytical).abs().max()
 
-    slow_allclose = torch.allclose(slow_analytical, slow_numerical, rtol, atol)
+    slow_allclose = torch.allclose(
+        slow_analytical, slow_numerical, rtol, atol, equal_nan=equal_nan
+    )
     msg = (
         "\nThe above quantities relating the numerical and analytical jacobians are computed \n"
         "in fast mode. See: https://github.com/pytorch/pytorch/issues/53876 for more background \n"
@@ -1885,6 +1901,7 @@ def _check_analytical_numerical_equal(
     test_imag,
     *,
     is_forward_ad=False,
+    equal_nan=False,
 ):
     for i, all_numerical_for_input_i in enumerate(all_numerical):
         for j, n in enumerate(all_numerical_for_input_i):
@@ -1895,9 +1912,20 @@ def _check_analytical_numerical_equal(
                 a = all_analytical[j][i]
             n = n.to(device=a.device)
             updated_atol = _adjusted_atol(atol, all_u[i], all_v[j] if all_v else None)
-            if not _allclose_with_type_promotion(a, n.to(a.device), rtol, updated_atol):
+            if not _allclose_with_type_promotion(
+                a, n.to(a.device), rtol, updated_atol, equal_nan=equal_nan
+            ):
                 jacobians_str = _run_slow_mode_and_get_error(
-                    func, tupled_inputs, outputs, i, j, rtol, atol, eps, is_forward_ad
+                    func,
+                    tupled_inputs,
+                    outputs,
+                    i,
+                    j,
+                    rtol,
+                    atol,
+                    eps,
+                    is_forward_ad,
+                    equal_nan,
                 )
                 raise GradcheckError(
                     _get_notallclose_msg(
@@ -1922,6 +1950,7 @@ def _fast_gradcheck(
     complex_indices=None,
     test_imag=False,
     masked=False,
+    equal_nan=False,
 ):
     # See https://github.com/pytorch/pytorch/issues/53876 for details
     inp_tensors_idx, inp_tensors = _get_inp_tensors(inputs)
@@ -1985,6 +2014,7 @@ def _fast_gradcheck(
         eps,
         test_imag,
         is_forward_ad=use_forward_ad,
+        equal_nan=equal_nan,
     )
 
     return True
@@ -2003,6 +2033,7 @@ def gradcheck(
     eps: float = 1e-6,
     atol: float = 1e-5,
     rtol: float = 1e-3,
+    equal_nan: bool = False,
     raise_exception: bool = True,
     nondet_tol: float = 0.0,
     check_undefined_grad: bool = True,
@@ -2055,6 +2086,8 @@ def gradcheck(
         eps (float, optional): perturbation for finite differences
         atol (float, optional): absolute tolerance
         rtol (float, optional): relative tolerance
+        equal_nan (bool, optional): if ``True``, consider matching ``NaN`` values
+            in numerical and analytical gradients to be equal. Defaults to ``False``.
         raise_exception (bool, optional): indicating whether to raise an exception if
             the check fails. The exception gives more information about the
             exact nature of the failure. This is helpful when debugging gradchecks.
@@ -2110,6 +2143,7 @@ def _gradcheck_helper(
     eps,
     atol,
     rtol,
+    equal_nan,
     nondet_tol,
     check_undefined_grad,
     check_grad_dtypes,
@@ -2128,7 +2162,9 @@ def _gradcheck_helper(
     _check_outputs(outputs)
 
     gradcheck_fn = functools.partial(
-        _fast_gradcheck if fast_mode else _slow_gradcheck, masked=masked
+        _fast_gradcheck if fast_mode else _slow_gradcheck,
+        masked=masked,
+        equal_nan=equal_nan,
     )
     _gradcheck_real_imag(
         gradcheck_fn,
@@ -2172,6 +2208,7 @@ def gradgradcheck(
     eps: float = 1e-6,
     atol: float = 1e-5,
     rtol: float = 1e-3,
+    equal_nan: bool = False,
     gen_non_contig_grad_outputs: bool = False,
     raise_exception: bool = True,
     nondet_tol: float = 0.0,
@@ -2215,6 +2252,8 @@ def gradgradcheck(
         eps (float, optional): perturbation for finite differences
         atol (float, optional): absolute tolerance
         rtol (float, optional): relative tolerance
+        equal_nan (bool, optional): if ``True``, consider matching ``NaN`` values
+            in numerical and analytical gradients to be equal. Defaults to ``False``.
         gen_non_contig_grad_outputs (bool, optional): if :attr:`grad_outputs` is
             ``None`` and :attr:`gen_non_contig_grad_outputs` is ``True``, the
             randomly generated gradient outputs are made to be noncontiguous
@@ -2312,6 +2351,7 @@ def gradgradcheck(
         eps=eps,
         atol=atol,
         rtol=rtol,
+        equal_nan=equal_nan,
         raise_exception=raise_exception,
         nondet_tol=nondet_tol,
         check_undefined_grad=check_undefined_grad,


### PR DESCRIPTION
## Issue

Fixes #76780

## Summary

- Add an opt-in `equal_nan` argument to `gradcheck` and `gradgradcheck`.
- Apply it only to numerical-versus-analytical Jacobian comparisons in both slow and fast gradcheck.
- Keep the default `False`, so existing checks continue to reject NaNs.
- Keep fast-mode's slow-mode diagnostic consistent with the requested NaN semantics.

This deliberately avoids enabling NaN equality globally. Callers must opt in when matching NaNs represent the expected derivative behavior.

## Test plan

- Targeted regression on the official `2.14.0.dev20260801` CPU nightly runtime with this Python module loaded: 1 passed.
- Nearby gradcheck regression set on the same runtime: 20 passed.
- `ruff check torch/autograd/gradcheck.py test/test_autograd.py`
- `python -m py_compile torch/autograd/gradcheck.py test/test_autograd.py`
- `git diff --check`

A complete source build was not available locally. The author reviewed and verified the current diff and is submitting it for upstream CI and maintainer review.

## BC-breaking?

No. `equal_nan=False` preserves the existing behavior.

> AI assistance disclosure (required by `AI_POLICY.md`): Codex was used to identify the actionable issue, analyze prior attempts, prepare the regression test and implementation, run the checks above, and draft this description.
>
> Human review: The author confirmed reviewing and verifying the current diff and takes responsibility for submitting it for maintainer review.