### PR TITLE
Fix silent data corruption in triu_/tril_ with internal memory overlap

### DIFF
--- a/aten/src/ATen/native/TriangularOps.cpp
+++ b/aten/src/ATen/native/TriangularOps.cpp
@@ -142,6 +142,8 @@ void compute_triu_tril(const Tensor& self, int64_t k, const Tensor &result) {
     return;
   }
 
+  checkTrilTriuMatrixOverlap(result);
+
   bool inplace_op = self.is_same(result);
 
   bool inplace_update = false;

--- a/aten/src/ATen/native/TriangularOpsUtils.h
+++ b/aten/src/ATen/native/TriangularOpsUtils.h
@@ -1,7 +1,19 @@
+#pragma once
 #include <ATen/core/Tensor.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/native/LinearAlgebraUtils.h>
 
 namespace at::native {
+
+static inline void checkTrilTriuMatrixOverlap(const Tensor& result) {
+  if (result.numel() == 0 || result.is_contiguous()) {
+    return;
+  }
+  auto matrix = result.as_strided(
+      {result.size(-2), result.size(-1)},
+      {result.stride(-2), result.stride(-1)});
+  at::assert_no_internal_overlap(matrix);
+}
 
 /*
  * Given batches of matrices with arbitrary batch dim,

--- a/aten/src/ATen/native/cuda/TriangularOps.cu
+++ b/aten/src/ATen/native/cuda/TriangularOps.cu
@@ -5,6 +5,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/MemoryOverlap.h>
 #include <ATen/native/Resize.h>
+#include <ATen/native/TriangularOpsUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -181,6 +182,7 @@ void launch_triu_tril_kernel(const Tensor& result, const Tensor& self, int64_t k
 
 template <bool upper>
 void triu_tril_cuda_template(const Tensor& result, const Tensor& self, int64_t k, const char* name) {
+  checkTrilTriuMatrixOverlap(result);
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
       at::ScalarType::ComplexHalf,
       at::ScalarType::Half,

--- a/aten/src/ATen/native/mps/operations/TriangularOps.mm
+++ b/aten/src/ATen/native/mps/operations/TriangularOps.mm
@@ -4,6 +4,7 @@
 #include <ATen/mps/EmptyTensor.h>
 #include <ATen/native/LinearAlgebraUtils.h>
 #include <ATen/native/TensorFactories.h>
+#include <ATen/native/TriangularOpsUtils.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <fmt/format.h>
 
@@ -41,6 +42,7 @@ static void triu_tril_impl(const Tensor& self, int64_t k, const Tensor& out, con
   if (self.numel() == 0) {
     return;
   }
+  checkTrilTriuMatrixOverlap(out);
   auto sizes = reverse_array<uint32_t>(self.sizes());
   auto inp_strides = reverse_array<int32_t>(self.strides());
   auto out_strides = reverse_array<int32_t>(out.strides());

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9152,6 +9152,57 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         self.assertEqual(result_triu_min, expected_triu_min)
         self.assertEqual(result_tril_min, expected_tril_min)
 
+    @dtypes(torch.float)
+    def test_triu_tril_matrix_overlap(self, device, dtype):
+        msg = "unsupported operation: more than one element of the written-to tensor"
+
+        for shape, expanded in (((), (3, 3)), ((1, 3), (3, 3)), ((3, 1), (3, 3)),
+                                ((5, 3, 1), (5, 3, 3)), ((5, 1, 3), (5, 3, 3))):
+            overlapping = make_tensor(shape, dtype=dtype, device=device).expand(expanded)
+            with self.assertRaisesRegex(RuntimeError, msg):
+                overlapping.triu_(1)
+            with self.assertRaisesRegex(RuntimeError, msg):
+                overlapping.tril_(-1)
+        src = make_tensor((3, 3), dtype=dtype, device=device)
+        overlapping_out = make_tensor((), dtype=dtype, device=device).expand(3, 3)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.triu(src, out=overlapping_out)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.tril(src, out=overlapping_out)
+
+        for shape in ((3, 1), (1, 3), (0, 0), (0, 3), (3, 0), (5, 3, 1)):
+            t = make_tensor(shape, dtype=dtype, device=device)
+            t.triu_(1)
+            t.tril_(-1)
+
+        empty_expanded = make_tensor((0, 1), dtype=dtype, device=device).expand(0, 3)
+        empty_expanded.triu_(1)
+        empty_expanded.tril_(-1)
+
+        for t in (
+            make_tensor((3, 3), dtype=dtype, device=device).mT,
+            make_tensor((3, 6), dtype=dtype, device=device)[:, ::2],
+            make_tensor((5, 3, 3), dtype=dtype, device=device).mT,
+        ):
+            t.triu_(1)
+            t.tril_(-1)
+
+        strided_out = make_tensor((3, 3), dtype=dtype, device=device).mT
+        torch.triu(src, 1, out=strided_out)
+        self.assertEqual(strided_out, torch.triu(src, 1))
+
+        batched = make_tensor((5, 3, 3), dtype=dtype, device=device)
+        expected = torch.stack([torch.triu(batched[i], 1) for i in range(5)])
+        batched.triu_(1)
+        self.assertEqual(batched, expected)
+
+        base = make_tensor((3, 3), dtype=dtype, device=device)
+        expected_slice = torch.triu(base.clone(), 1)
+        broadcast = base.expand(5, 3, 3)
+        broadcast.triu_(1)
+        for i in range(5):
+            self.assertEqual(broadcast[i], expected_slice)
+
     @dtypes(torch.float, torch.double)
     @precisionOverride({torch.float32: 1e-4})
     def test_1_sized_with_0_strided(self, device, dtype):


### PR DESCRIPTION
Fixes #165987

If you call `triu_`/`tril_` on a tensor with internal memory overlap (for example, `torch.tensor(5.).expand(3, 3).triu_(1)`), it doesn't raise an error. Instead, it silently corrupts data.

I read through PRs #165993 and #176782, which were closed as stale. Building on those, this PR adds a shared helper, called from the CPU/CUDA/MPS kernels, that checks the last two dimensions of the output for overlap and raises a `RuntimeError` asking the user to `clone()` first. Since overlap only in batch dims is safe to write, it is allowed.

Based on the review feedback on those two PRs, the new regression test checks three things. First, it checks that the overlapping cases raise an error. Second, it checks that the safe non-contiguous cases don't. Third, it checks that the results are still correct. The test passes on CPU and MPS, under eager as well as the dynamo and crossref wrappers. I don't have a CUDA machine, so for CUDA I am relying on CI.

This is my first PyTorch contribution, so I'm happy to make changes if I missed a guideline!

cc @nikitaved