### PR TITLE
Document single-element tuple support for the remaining pooling ops

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -420,14 +420,14 @@ See :class:`~torch.nn.AvgPool3d` for details and output shape.
 
 Args:
     input: input tensor :math:`(\text{minibatch} , \text{in\_channels} , iT \times iH , iW)`
-    kernel_size: size of the pooling region. Can be a single number or a
+    kernel_size: size of the pooling region. Can be a single number, a single-element tuple or a
       tuple `(kT, kH, kW)`
-    stride: stride of the pooling operation. Can be a single number or a
+    stride: stride of the pooling operation. Can be a single number, a single-element tuple or a
       tuple `(sT, sH, sW)`. Default: :attr:`kernel_size`
     padding: implicit zero paddings on both sides of the input. Can be a
-      single number or a tuple `(padT, padH, padW)`. Should be at most half
-      of effective kernel size, that is :math:`((kernelSize - 1) * dilation + 1) / 2`.
-      Default: 0
+      single number, a single-element tuple or a tuple `(padT, padH, padW)`.
+      Should be at most half of effective kernel size, that
+      is :math:`((kernelSize - 1) * dilation + 1) / 2`. Default: 0
     ceil_mode: when True, will use `ceil` instead of `floor` in the formula
         to compute the output shape
     count_include_pad: when True, will include the zero-padding in the
@@ -781,9 +781,9 @@ def max_pool2d_with_indices(
 
     Args:
         input: input tensor :math:`(\text{minibatch} , \text{in\_channels} , iH , iW)`, minibatch dim optional.
-        kernel_size: size of the pooling region. Can be a single number or a
+        kernel_size: size of the pooling region. Can be a single number, a single-element tuple or a
             tuple `(kH, kW)`
-        stride: stride of the pooling operation. Can be a single number or a
+        stride: stride of the pooling operation. Can be a single number, a single-element tuple or a
             tuple `(sH, sW)`. Default: :attr:`kernel_size`
         padding: Implicit negative infinity padding to be added on both sides, must be >= 0 and <= kernel_size / 2.
         dilation: The stride between elements within a sliding window, must be > 0.
@@ -871,10 +871,10 @@ def max_pool3d_with_indices(
 
     Args:
         input: input tensor :math:`(\text{minibatch} , \text{in\_channels} , iD, iH , iW)`, minibatch dim optional.
-        kernel_size: size of the pooling region. Can be a single number or a
-                     tuple `(kT, kH, kW)`
-        stride: stride of the pooling operation. Can be a single number or a
-                tuple `(sT, sH, sW)`. Default: :attr:`kernel_size`
+        kernel_size: size of the pooling region. Can be a single number, a single-element tuple
+                     or a tuple `(kT, kH, kW)`
+        stride: stride of the pooling operation. Can be a single number, a single-element tuple
+                or a tuple `(sT, sH, sW)`. Default: :attr:`kernel_size`
         padding: Implicit negative infinity padding to be added on both sides, must be >= 0 and <= kernel_size / 2.
         dilation: The stride between elements within a sliding window, must be > 0.
         ceil_mode: If ``True``, will use `ceil` instead of `floor` to compute the output shape. This

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -176,7 +176,7 @@ class MaxPool2d(_MaxPoolNd):
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`dilation` can either be:
 
-        - a single ``int`` -- in which case the same value is used for the height and width dimension
+        - a single ``int`` or a single-element tuple -- in which case the same value is used for the height and width dimension
         - a ``tuple`` of two ints -- in which case, the first `int` is used for the height dimension,
           and the second `int` for the width dimension
 
@@ -256,7 +256,7 @@ class MaxPool3d(_MaxPoolNd):
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`dilation` can either be:
 
-        - a single ``int`` -- in which case the same value is used for the depth, height and width dimension
+        - a single ``int`` or a single-element tuple -- in which case the same value is used for the depth, height and width dimension
         - a ``tuple`` of three ints -- in which case, the first `int` is used for the depth dimension,
           the second `int` for the height dimension and the third `int` for the width dimension
 
@@ -814,7 +814,7 @@ class AvgPool3d(_AvgPoolNd):
 
     The parameters :attr:`kernel_size`, :attr:`stride` can either be:
 
-        - a single ``int`` -- in which case the same value is used for the depth, height and width dimension
+        - a single ``int`` or a single-element tuple -- in which case the same value is used for the depth, height and width dimension
         - a ``tuple`` of three ints -- in which case, the first `int` is used for the depth dimension,
           the second `int` for the height dimension and the third `int` for the width dimension
 


### PR DESCRIPTION
Fixes the remaining part of #153149.

#154353 updated `F.avg_pool2d` to document that `kernel_size`, `stride` and `padding` accept a single-element tuple, but the sibling pooling ops kept the older wording that mentions only a single number or a full-length tuple. ATen has always accepted the size-1 form — each op checks `kernel_size.size() == 1 || kernel_size.size() == N` and reuses element 0 for the remaining spatial dimensions (e.g. `aten/src/ATen/native/AveragePool3d.cpp:30-34`) — so only the documentation was wrong, which @albanD confirmed on the issue.

Reworded to match the existing `avg_pool2d` text: `F.avg_pool3d`, `F.max_pool2d`, `F.max_pool3d`, and the `nn.AvgPool3d`, `nn.MaxPool2d`, `nn.MaxPool3d` class docstrings. The 1D ops need no change — for them `(kW,)` is already the documented tuple form.

## Test Plan

Docs-only change, so the check is that the newly documented behavior is real. Every parameter the reworded text covers accepts a single-element tuple and returns a bit-identical result to the scalar form:

```python
import torch, torch.nn.functional as F
x2 = torch.rand(1, 3, 8, 8); x3 = torch.rand(1, 3, 8, 8, 8)
rows = [
 ("F.avg_pool3d", lambda: F.avg_pool3d(x3, (3,), stride=(2,), padding=(1,)),
                  lambda: F.avg_pool3d(x3,  3,  stride= 2,  padding= 1)),
 ("F.max_pool2d", lambda: F.max_pool2d(x2, (3,), stride=(2,), padding=(1,), dilation=(1,)),
                  lambda: F.max_pool2d(x2,  3,  stride= 2,  padding= 1,  dilation= 1)),
 ("F.max_pool3d", lambda: F.max_pool3d(x3, (3,), stride=(2,), padding=(1,), dilation=(1,)),
                  lambda: F.max_pool3d(x3,  3,  stride= 2,  padding= 1,  dilation= 1)),
 ("nn.AvgPool3d", lambda: torch.nn.AvgPool3d((3,), stride=(2,), padding=(1,))(x3),
                  lambda: torch.nn.AvgPool3d( 3,  stride= 2,  padding= 1)(x3)),
 ("nn.MaxPool2d", lambda: torch.nn.MaxPool2d((3,), stride=(2,), padding=(1,), dilation=(1,))(x2),
                  lambda: torch.nn.MaxPool2d( 3,  stride= 2,  padding= 1,  dilation= 1)(x2)),
 ("nn.MaxPool3d", lambda: torch.nn.MaxPool3d((3,), stride=(2,), padding=(1,), dilation=(1,))(x3),
                  lambda: torch.nn.MaxPool3d( 3,  stride= 2,  padding= 1,  dilation= 1)(x3)),
]
for name, tup, sca in rows:
    a, b = tup(), sca()
    print(f"{name:14} {str(tuple(a.shape)):22} {str(tuple(b.shape)):22} {torch.equal(a, b)}")
```

```
F.avg_pool3d   (1, 3, 4, 4, 4)        (1, 3, 4, 4, 4)        True
F.max_pool2d   (1, 3, 4, 4)           (1, 3, 4, 4)           True
F.max_pool3d   (1, 3, 4, 4, 4)        (1, 3, 4, 4, 4)        True
nn.AvgPool3d   (1, 3, 4, 4, 4)        (1, 3, 4, 4, 4)        True
nn.MaxPool2d   (1, 3, 4, 4)           (1, 3, 4, 4)           True
nn.MaxPool3d   (1, 3, 4, 4, 4)        (1, 3, 4, 4, 4)        True
```

Lint:

```
lintrunner --take RUFF,PYFMT torch/nn/functional.py torch/nn/modules/pooling.py
```

```
ok No lint issues.
```

Two related things I left out of this PR to keep it to one idea: `AvgPool3d`'s parameter block lists only `kernel_size` and `stride` even though `padding` also accepts both forms, and `F.lp_pool2d` rejects a single-element tuple unlike every other pooling op. Happy to follow up on either.

This PR was prepared with the assistance of an AI coding assistant; I have reviewed the change and the verification above.
