### PR TITLE
Add missing output_padding validation to the conv meta registration

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -777,6 +777,47 @@ class TestConvolutionNN(NNTestCase):
             torch.Size([2, 6, 1, 1]),
         )
 
+    @parametrize_test("dim", [1, 2, 3])
+    def test_conv_transpose_shapecheck_meta_output_padding(self, dim):
+        """Meta tensors should reject invalid output_padding like eager does.
+
+        Regression test for https://github.com/pytorch/pytorch/issues/178127
+        """
+        conv = [F.conv_transpose1d, F.conv_transpose2d, F.conv_transpose3d][dim - 1]
+        input_tensor = torch.randn(1, 4, *([5] * dim))
+        weight_tensor = torch.randn(4, 8, *([3] * dim))
+        input_meta = input_tensor.to("meta")
+        weight_meta = weight_tensor.to("meta")
+        invalid = dict(stride=2, output_padding=2, dilation=2)
+
+        msg = "output padding must be smaller than either stride or dilation"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            conv(input_tensor, weight_tensor, **invalid)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            conv(input_meta, weight_meta, **invalid)
+
+        torch._dynamo.reset()
+        compiled_invalid = torch.compile(
+            lambda inp, w: conv(inp, w, **invalid), backend="aot_eager"
+        )
+        with self.assertRaisesRegex(RuntimeError, msg):
+            compiled_invalid(input_tensor, weight_tensor)
+
+        neg_msg = "negative output_padding is not supported"
+        with self.assertRaisesRegex(RuntimeError, neg_msg):
+            conv(input_tensor, weight_tensor, stride=2, output_padding=-1)
+        with self.assertRaisesRegex(RuntimeError, neg_msg):
+            conv(input_meta, weight_meta, stride=2, output_padding=-1)
+
+        # Boundary: output_padding only needs to be smaller than one of
+        # stride and dilation, so these are valid and shapes must match eager.
+        for valid in (
+            dict(stride=2, output_padding=2, dilation=3),
+            dict(stride=3, output_padding=2, dilation=1),
+        ):
+            expected = conv(input_tensor, weight_tensor, **valid).shape
+            self.assertEqual(conv(input_meta, weight_meta, **valid).shape, expected)
+
     def test_ConvTranspose2d_output_size(self):
         m = nn.ConvTranspose2d(3, 4, 3, 3, 0, 2)
         i = torch.randn(2, 3, 6, 6)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2736,6 +2736,31 @@ def calc_conv_nd_return_shape(
             ),
         )
 
+    elif output_padding_list:
+        # Mirrors C++ check_shape_forward (Convolution.cpp) and
+        # slow_conv_transpose2d_shape_check (NaiveConvolutionTranspose2d.cpp).
+        from torch.fx.experimental.symbolic_shapes import sym_and, sym_or
+
+        torch._check(
+            sym_and(*[op >= 0 for op in output_padding_list]),
+            lambda: "negative output_padding is not supported",
+        )
+        torch._check(
+            sym_and(
+                *[
+                    sym_or(op < s, op < d)
+                    for op, s, d in zip(
+                        output_padding_list, stride, dilation, strict=True
+                    )
+                ]
+            ),
+            lambda: (
+                f"output padding must be smaller than either stride or dilation, "
+                f"but got output_padding: {output_padding_list}, "
+                f"stride: {stride}, dilation: {dilation}"
+            ),
+        )
+
     for i in range(len(dims)):
         # If output_padding is present, we are dealing with a transposed convolution
         if output_padding_list:


### PR DESCRIPTION
Fixes #178127

conv_transpose1d/2d/3d on the meta device accepted output_padding values that eager rejects, so meta tensors and FakeTensor tracing got a made up shape for configs where cpu/cuda raise. The meta registration for aten.convolution (calc_conv_nd_return_shape in torch/_meta_registrations.py) only computed the output shape and never mirrored the eager checks.

This adds the two missing checks there, next to the analogous non-transposed kernel size check from #180448: output_padding must be smaller than stride or dilation per dim, and negative output_padding is rejected. Implemented with torch._check plus sym_and/sym_or so symbolic values don't force guards. Valid combinations are unchanged, and torch.compile now fails at trace time with the real cause instead of at kernel run time.

One note: for zero numel inputs eager skips these checks through the empty input shortcut in _convolution, so meta is now slightly stricter there. Gating on numel would force guards on dynamic batch sizes, and any nonzero batch with such a config fails in eager anyway.

The new test in test/nn/test_convolution.py is parametrized over 1d/2d/3d and fails without the fix.

cc @malfet @ezyang @eellison @bdhirsh @bobrenjc93 @aorenste @liangel-02