### PR TITLE
[BE] Fix B018 useless-expression violations in inductor and fx unification

### DIFF
--- a/torch/_inductor/comm_lowering.py
+++ b/torch/_inductor/comm_lowering.py
@@ -199,7 +199,7 @@ def register_comm_lowerings():
     Register lowerings for the comm subsystem.
     """
     try:
-        torch.ops._c10d_functional.all_reduce
+        _ = torch.ops._c10d_functional.all_reduce
     except AttributeError:
         log.info(
             "Inductor support for distributed collectives depends on building "
@@ -483,7 +483,7 @@ def register_symm_mem_lowerings():
         # torch.ops.symm_mem is a lazy namespace that always exists,
         # but the operations may not exist on non-CUDA platforms or
         # when USE_DISTRIBUTED is disabled.
-        symm_mem.one_shot_all_reduce
+        _ = symm_mem.one_shot_all_reduce
     except AttributeError:
         log.info("symm_mem ops not available, skipping symm_mem lowerings")
         return

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3331,7 +3331,9 @@ def _find_names(obj):
 
     frame = inspect.currentframe()
     while frame is not None:
-        frame.f_locals
+        # accessing f_locals materializes the frame's locals dict so
+        # gc.get_referrers below can find obj inside it
+        _ = frame.f_locals
         frame = frame.f_back
     obj_names = []
     for referrer in gc.get_referrers(obj):

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3331,8 +3331,10 @@ def _find_names(obj):
 
     frame = inspect.currentframe()
     while frame is not None:
-        # accessing f_locals materializes the frame's locals dict so
-        # gc.get_referrers below can find obj inside it
+        # On CPython <= 3.12 this access materializes the frame's locals
+        # dict so gc.get_referrers below can find obj inside it. On 3.13+
+        # f_locals is a fresh write-through proxy (PEP 667) and this loop
+        # is a no-op, so function-local names are not discoverable there.
         _ = frame.f_locals
         frame = frame.f_back
     obj_names = []

--- a/torch/fx/experimental/unification/core.py
+++ b/torch/fx/experimental/unification/core.py
@@ -30,15 +30,9 @@ def _reify(t: Iterator[object], s: dict[Var, object]) -> Iterator[object]:
     # return (reify(arg, s) for arg in t)
 
 
-_reify
-
-
 @dispatch(tuple, dict)  # type: ignore[no-redef]
 def _reify(t: tuple[Unpack[_Ts]], s: dict[Var, object]) -> tuple[Unpack[_Ts]]:
     return tuple(reify(iter(t), s))  # pyrefly: ignore[bad-argument-type, bad-return]
-
-
-_reify
 
 
 @dispatch(list, dict)  # type: ignore[no-redef]
@@ -46,15 +40,9 @@ def _reify(t: list[object], s: dict[Var, object]) -> list[object]:
     return list(reify(iter(t), s))  # pyrefly: ignore[bad-argument-type]
 
 
-_reify
-
-
 @dispatch(dict, dict)  # type: ignore[no-redef]
 def _reify(d: dict[object, object], s: dict[Var, object]) -> dict[object, object]:
     return {k: reify(v, s) for k, v in d.items()}
-
-
-_reify
 
 
 @dispatch(object, dict)  # type: ignore[no-redef]
@@ -146,9 +134,6 @@ def unify(
     return _unify(u, v, s)
 
 
-unify
-
-
 @dispatch(object, object)  # type: ignore[no-redef]
-def unify(u: object, v: object) -> dict[Var, object] | bool:
+def unify(u: object, v: object) -> dict[Var, object] | bool:  # noqa: F811
     return unify(u, v, {})

--- a/torch/fx/experimental/unification/core.py
+++ b/torch/fx/experimental/unification/core.py
@@ -135,5 +135,7 @@ def unify(
 
 
 @dispatch(object, object)  # type: ignore[no-redef]
+# The noqa suppresses F811 for this multipledispatch overload redefinition
+# (it replaces the bare-name-statement hack that previously silenced it).
 def unify(u: object, v: object) -> dict[Var, object] | bool:  # noqa: F811
     return unify(u, v, {})

--- a/torch/fx/experimental/unification/variable.py
+++ b/torch/fx/experimental/unification/variable.py
@@ -58,6 +58,8 @@ def isvar(v: Var) -> Literal[True]:
 
 
 @dispatch(object)  # type: ignore[no-redef]
+# The noqa suppresses F811 for this multipledispatch overload redefinition
+# (it replaces the bare-name-statement hack that previously silenced it).
 def isvar(o: object) -> bool:  # noqa: F811
     return bool(_glv and hashable(o) and o in _glv)
 

--- a/torch/fx/experimental/unification/variable.py
+++ b/torch/fx/experimental/unification/variable.py
@@ -57,11 +57,8 @@ def isvar(v: Var) -> Literal[True]:
     return True
 
 
-isvar
-
-
 @dispatch(object)  # type: ignore[no-redef]
-def isvar(o: object) -> bool:
+def isvar(o: object) -> bool:  # noqa: F811
     return bool(_glv and hashable(o) and o in _glv)
 
 


### PR DESCRIPTION

---

### Addendum (post-review): F811 evidence and runtime verification

**Literal F811 output** with the two noqas stripped from the PR's files (CI-pinned ruff 0.14.4):

```
core.py:140:5: F811 Redefinition of unused `unify` from line 118: `unify` redefined here
variable.py:63:5: F811 Redefinition of unused `isvar` from line 56: `isvar` redefined here
Found 2 errors.
```

With the noqas present, the full-config check reports `All checks passed!` — so under RUF100 both the presence and the placement are exactly what ruff requires.

**Why only these two sites**: ruff's F811 exempts underscore-prefixed names (dummy-variable convention). Minimal repro — two identical `@dispatch` overload chains, one named `_priv`, one named `pub`:

```
f811_repro.py:9:5: F811 Redefinition of unused `pub` from line 7: `pub` redefined here
Found 1 error.
```

Only `pub` is flagged. That is why the five `_reify` redefinitions (and `_eval_is_ge` in `torch/utils/_sympy/singleton_int.py`) need no suppression while the public `unify`/`isvar` do.

**Runtime verification**: imported the changed `unification` package and the unmodified main version side by side as standalone packages (the subtree is stdlib-only + vendored multipledispatch) and compared 18 aspects: `unify`/`reify`/`isvar` behavior on tuples/lists/dicts/vars including exact exception types and messages for the unsupported-signature cases, plus the complete dispatch registries of `unify`, `isvar`, `_unify`, and `_reify`. All 18 identical (package-name normalized). This exercises the import-time `@dispatch` registration side effects directly.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo