### PR TITLE
Fix embedding_bag CPU segfault on non-monotonic offsets

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -886,14 +886,22 @@ void check_arguments(
 
   AT_DISPATCH_INDEX_TYPES(offsets.scalar_type(), "_embedding_bag_cpu_impl", [&]() {
     if (offsets.size(0) > 0) {
-      index_t offset_0 = offsets.const_data_ptr<index_t>()[0];
-      index_t offset_n = offsets.const_data_ptr<index_t>()[offsets.size(0)-1];
+      const auto* offsets_data = offsets.const_data_ptr<index_t>();
+      index_t offset_0 = offsets_data[0];
+      index_t offset_n = offsets_data[offsets.size(0)-1];
       TORCH_CHECK(offset_0 == 0, "offsets[0] has to be 0, i.e., the first sequence "
                                 "in the mini-batch has to start from position 0. "
                                 "However, got ", offsets[0]);
       TORCH_CHECK(offset_n <= indices.size(0), "offsets[-1] can not "
                   "be greater than input's length ", indices.size(0), " but got offsets[-1] of ",
                   offset_n);
+      for (const auto i : c10::irange(1, offsets.size(0))) {
+        TORCH_CHECK(offsets_data[i - 1] <= offsets_data[i],
+                    "embedding_bag: offsets have to be monotonically "
+                    "non-decreasing, but got offsets[", i - 1, "] of ",
+                    offsets_data[i - 1], " and offsets[", i, "] of ",
+                    offsets_data[i]);
+      }
     }
   });
 

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1195,6 +1195,27 @@ class TestEmbeddingNNDeviceType(NNTestCase):
                     mode=mode,
                 )
 
+    @onlyOn("cpu")
+    @dtypes(torch.int, torch.long)
+    @parametrize_test("mode", ["sum", "mean", "max"])
+    def test_embedding_bag_invalid_offsets(self, device, dtype, mode):
+        # https://github.com/pytorch/pytorch/issues/175368
+        weight = torch.randn(5, 3, device=device)
+        msg = "monotonically non-decreasing"
+        for requires_grad in (False, True):
+            w = weight.detach().requires_grad_(requires_grad)
+            indices = torch.tensor([], device=device, dtype=dtype)
+            offsets = torch.tensor([0, 2, 0], device=device, dtype=dtype)
+            with self.assertRaisesRegex(RuntimeError, msg):
+                F.embedding_bag(indices, w, offsets, mode=mode)
+            indices = torch.tensor([1, 2, 3, 4], device=device, dtype=dtype)
+            offsets = torch.tensor([0, 3, 1, 4], device=device, dtype=dtype)
+            with self.assertRaisesRegex(RuntimeError, msg):
+                F.embedding_bag(indices, w, offsets, mode=mode)
+            offsets = torch.tensor([0, 2, 2, 4], device=device, dtype=dtype)
+            out = F.embedding_bag(indices, w, offsets, mode=mode)
+            self.assertEqual(out.shape, torch.Size([4, 3]))
+
     def test_embedding_bag_dimension_errors(self, device):
         funcs = (
             lambda x, y, z: torch.nn.functional.embedding_bag(y, x, z),


### PR DESCRIPTION

Fixes #175368

If you call `F.embedding_bag` with offsets that are not monotonic or that point past the end of `indices` (for example, `indices=[]` with `offsets=[0, 2, 0]`), it doesn't raise an error. Instead, it causes a segmentation fault. This is because only `offsets[0]` and `offsets[-1]` are validated, so invalid intermediate offsets flow into the bag size computation. This causes the kernels to read out of bounds.

I read through PR #175964, which was closed as stale, as well as the triage discussion on the issue. Building on those, this PR extends the existing `check_arguments` validation with a check for monotonicity over `offsets`. Combined with the current endpoint checks, this forces every offset to be within `[0, indices.size(0)]`. According to the review feedback on #175964 and the triage decision, validation on CUDA should be an in-kernel assert. As such, this PR is CPU-only, and CUDA is left as a follow-up.

The new regression test checks that both invalid cases raise a `RuntimeError`. It also checks that repeated offsets, which lead to empty bags, are still allowed. Both are covered across all three modes and both the forward-only and gradient-enabled dispatch paths.

cc @mikaylagawarecki