### PR TITLE
Fix nn.LPPool1d and F.lp_pool1d rejecting tuple/list kernel_size (#191865)

### DIFF
--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -962,6 +962,18 @@ torch.cuda.synchronize()
         with self.assertRaisesRegex(ValueError, err):
             torch.nn.LPPool3d(norm_type=0, kernel_size=3)
 
+    def test_LPPool1d_tuple_kernel_size(self, device):
+        x = torch.rand(20, 16, 50, device=device)
+        ref = F.lp_pool1d(x, 2, 2)
+        res_tuple = F.lp_pool1d(x, 2, (2,))
+        res_list = F.lp_pool1d(x, 2, [2])
+        res_mod_tuple = torch.nn.LPPool1d(2, (2,)).to(device)(x)
+        res_mod_list = torch.nn.LPPool1d(2, [2]).to(device)(x)
+        self.assertEqual(ref, res_tuple)
+        self.assertEqual(ref, res_list)
+        self.assertEqual(ref, res_mod_tuple)
+        self.assertEqual(ref, res_mod_list)
+
     def test_AvgPool2d_empty(self, device):
         avgpool = torch.nn.AvgPool2d(3, stride=2).to(device)
         inp = torch.randn(0, 16, 20, 32, device=device)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1207,7 +1207,7 @@ def lp_pool2d(
 def lp_pool1d(
     input: Tensor,
     norm_type: int | float,
-    kernel_size: int,
+    kernel_size: BroadcastingList1[int],
     stride: Optional[BroadcastingList1[int]] = None,  # noqa: UP045
     ceil_mode: bool = False,
 ) -> Tensor:
@@ -1231,6 +1231,7 @@ def lp_pool1d(
             stride=stride,
             ceil_mode=ceil_mode,
         )
+    (kw,) = _single(kernel_size)
     if isinstance(norm_type, (int, float)):
         if norm_type == 0:
             raise ValueError(f"norm_type must be a non-zero value, but got {norm_type}")
@@ -1247,7 +1248,7 @@ def lp_pool1d(
         )
 
     return (
-        (torch.sign(out) * relu(torch.abs(out))).mul(kernel_size).pow(1.0 / norm_type)
+        (torch.sign(out) * relu(torch.abs(out))).mul(kw).pow(1.0 / norm_type)
     )
 
 


### PR DESCRIPTION
Fixes #191865. `torch.nn.LPPool1d` and `F.lp_pool1d` type annotations allow sequence form of `kernel_size` (`BroadcastingList1[int]`), but passing a tuple like `(2,)` or list `[2]` previously failed with `TypeError: mul(): argument 'other' (position 1) must be Tensor, not tuple`.

### Root Cause
`F.lp_pool1d` passed `kernel_size` directly into `.mul(kernel_size)` without normalizing it first.

### Fix
Normalized `kernel_size` in `F.lp_pool1d` using `(kw,) = _single(kernel_size)` (consistent with `lp_pool2d` and `lp_pool3d` which use `_pair` and `_triple`) and updated to `.mul(kw)`. Also updated the type hint of `kernel_size` in `F.lp_pool1d` to `BroadcastingList1[int]`.

### Test Plan
Added unit test `test_LPPool1d_tuple_kernel_size` in `test/nn/test_pooling.py`.