### PR TITLE
[ROCm] Skip tests for mi200 due to fp16 numerical precision issues

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2926,6 +2926,8 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             fa._WARNINGS_SHOWN.clear()
             fa._WARNINGS_SHOWN.update(original_shown)
 
+    # https://github.com/pytorch/pytorch/issues/191552: fails on MI200 (gfx90a)
+    @skipIfRocmArch(MI200_ARCH)
     @supported_platform
     @dtypes(*device_configs["cpu"].dtypes)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes)
@@ -10167,6 +10169,8 @@ class TestLearnableBiases(InductorTestCase):
             device,
         )
 
+    # https://github.com/pytorch/pytorch/issues/191552: fails on MI200 (gfx90a)
+    @skipIfRocmArch(MI200_ARCH)
     @supported_platform
     @skip_on_cpu
     def test_comparison_vs_sdpa_with_learnable_bias(self, device):

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -17,7 +17,13 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FUSED_ATTENTION,
     SM80OrLater,
 )
-from torch.testing._internal.common_utils import IS_LINUX, MI200_ARCH, skipIfRocmArch, skipIfXpu, TEST_WITH_ROCM
+from torch.testing._internal.common_utils import (
+    IS_LINUX,
+    MI200_ARCH,
+    skipIfRocmArch,
+    skipIfXpu,
+    TEST_WITH_ROCM,
+)
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CPU,

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -17,7 +17,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FUSED_ATTENTION,
     SM80OrLater,
 )
-from torch.testing._internal.common_utils import IS_LINUX, skipIfXpu, TEST_WITH_ROCM
+from torch.testing._internal.common_utils import IS_LINUX, MI200_ARCH, skipIfRocmArch, skipIfXpu, TEST_WITH_ROCM
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CPU,
@@ -1787,7 +1787,10 @@ if HAS_XPU_AND_TRITON or (HAS_CUDA_AND_TRITON and PLATFORM_SUPPORTS_FUSED_ATTENT
 
     class SDPAPatternRewriterGpuTests(TestSDPAPatternRewriterTemplate):
         device = GPU_TYPE
-        test_sdpa_rewriter_1_gpu = TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_1
+        # https://github.com/pytorch/pytorch/issues/191552: fails on MI200 (gfx90a)
+        test_sdpa_rewriter_1_gpu = skipIfRocmArch(MI200_ARCH)(
+            TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_1
+        )
         test_sdpa_rewriter_1_freezing = (
             TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_1_freezing
         )
@@ -1802,8 +1805,13 @@ if HAS_XPU_AND_TRITON or (HAS_CUDA_AND_TRITON and PLATFORM_SUPPORTS_FUSED_ATTENT
         test_sdpa_rewriter_4_gpu = TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_4
         test_sdpa_rewriter_5_gpu = TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_5
         test_sdpa_rewriter_6_gpu = TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_6
-        test_sdpa_rewriter_7_gpu = TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_7
-        test_sdpa_rewriter_8_gpu = TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_8
+        # https://github.com/pytorch/pytorch/issues/191552: fail on MI200 (gfx90a)
+        test_sdpa_rewriter_7_gpu = skipIfRocmArch(MI200_ARCH)(
+            TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_7
+        )
+        test_sdpa_rewriter_8_gpu = skipIfRocmArch(MI200_ARCH)(
+            TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_8
+        )
         test_sdpa_rewriter_9_gpu = TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_9
         test_sdpa_rewriter_10_gpu = (
             TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_10

--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -43,6 +43,7 @@ import pytest
 import torch
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_inductor_cache
+from torch.testing._internal.common_cuda import CDNA3OrLater
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
@@ -474,7 +475,9 @@ ROCM_BATCH_INVARIANCE_XFAILS = {
     },
     "inductor_default": {
         "nn.functional.linear": {ALL},
-        "log1p": {fp32},
+        # https://github.com/pytorch/pytorch/issues/191552: log1p is batch-variant on
+        # CDNA3+ (gfx942/gfx950) but passes on MI200 (gfx90a), where this entry would XPASS.
+        **({"log1p": {fp32}} if CDNA3OrLater() else {}),
     },
     "inductor_numerics": {
         "nn.functional.linear": {ALL},

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, r
     download_file, get_function_arglist, load_tests, skipIfMPS, MACOS_VERSION, \
     IS_PPC, IS_ARM64, IS_MACOS, IS_WINDOWS, IS_CPU_CAPABILITY_SVE, IS_CPU_EXT_SVE_SUPPORTED, xfailIf, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
-    skipIfTorchDynamo, gcIfJetson, set_default_dtype, skipIfNoCuteDSL
+    skipIfTorchDynamo, gcIfJetson, set_default_dtype, skipIfNoCuteDSL, skipIfRocmArch, MI200_ARCH
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
     SM80OrLater, SM90OrLater, _get_torch_rocm_version
 from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
@@ -14571,6 +14571,8 @@ if __name__ == '__main__':
             acc_dtype={torch.float16: torch.float32, torch.bfloat16: torch.float32}[dtype],
             bias=bias)
 
+    # https://github.com/pytorch/pytorch/issues/191552: fp16 acc_dtype path fails on MI200 (gfx90a)
+    @skipIfRocmArch(MI200_ARCH)
     @parametrize_test("bias", [False, True])
     @parametrize_test("dtype", [torch.float16, torch.bfloat16])
     @parametrize_test("acc_policy", ["accurate", "compact", "auto"])

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -25,7 +25,7 @@ from torch.testing._internal.common_nn import (
     nllloss_reference, nlllossNd_reference, smoothl1loss_reference, softmarginloss_reference, get_reduction)
 from torch.testing._internal.common_utils import (
     freeze_rng_state, skipIfMPS, GRADCHECK_NONDET_TOL, TEST_WITH_ROCM, IS_WINDOWS,
-    skipIfTorchDynamo, skipIfXpu)
+    skipIfTorchDynamo, skipIfXpu, skipIfRocmArch, MI200_ARCH)
 from types import ModuleType
 import operator
 
@@ -4703,6 +4703,9 @@ module_db: list[ModuleInfo] = [
                                 "test_non_contiguous_tensors", dtypes=[torch.bfloat16]),
                    DecorateInfo(toleranceOverride({torch.float16: tol(atol=4e-2, rtol=3e-1)}), "TestModule",
                                 "test_cpu_gpu_parity", dtypes=[torch.float16]),
+                   # https://github.com/pytorch/pytorch/issues/191552: fp16 parity fails on MI200 (gfx90a)
+                   DecorateInfo(skipIfRocmArch(MI200_ARCH), "TestModule", "test_cpu_gpu_parity",
+                                dtypes=[torch.float16], device_type="cuda"),
                    # Insufficient accuracy, likely related to an issue with cross_entropy
                    DecorateInfo(unittest.expectedFailure, "TestModule", "test_cpu_gpu_parity",
                                 dtypes=[torch.bfloat16], device_type='cuda'),


### PR DESCRIPTION
Related to https://github.com/pytorch/pytorch/issues/191552#issuecomment-5137115835

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben