### PR TITLE
[elastic] fix: guard s.close() in find_free_port against UnboundLocalError

### DIFF
--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,18 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None  # initialise before try so that except can safely reference it
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            # Only close the socket if it was successfully created (resolves
+            # #191395 -- previously s.close() raised UnboundLocalError when
+            # socket.socket() itself failed, masking the real error).
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 
@@ -230,7 +235,6 @@ class EtcdServer:
 
         while time.time() < max_time:
             if self._get_etcd_server_process().poll() is not None:
-                # etcd server process finished
                 exitcode = self._get_etcd_server_process().returncode
                 raise RuntimeError(
                     f"Etcd server process exited with the code: {exitcode}"


### PR DESCRIPTION
## Summary

Fixes #191395 — if `socket.socket()` raised on the **first** address family, the variable `s` was never assigned, yet the `except OSError` block unconditionally called `s.close()`, raising `UnboundLocalError` and masking the actual socket creation error. The function then stopped trying remaining address families.

**Change in `torch/distributed/elastic/rendezvous/etcd_server.py`:**
- Initialise `s = None` before the `try` block
- Guard cleanup as `if s is not None: s.close()`

## Test plan
```python
from unittest.mock import patch
from torch.distributed.elastic.rendezvous.etcd_server import find_free_port

with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("127.0.0.1", 0))]), \
     patch("socket.socket", side_effect=OSError("socket failed")):
    try:
        find_free_port()
    except RuntimeError:
        pass  # expected — should NOT be UnboundLocalError
```