### PR TITLE
Fix pixel_shuffle validation in compile paths

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3660,6 +3660,35 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         test_pixel_shuffle_unshuffle_4D()
         test_pixel_shuffle_unshuffle_5D()
 
+    def test_pixel_shuffle_decomp_validation(self):
+        from torch._refs.nn.functional import pixel_shuffle as pixel_shuffle_decomp
+
+        input = torch.randn(1, 4, 2, 2)
+        self.assertEqual(pixel_shuffle_decomp(input, 2).shape, (1, 1, 4, 4))
+
+        with self.assertRaisesRegex(RuntimeError, "positive upscale_factor"):
+            pixel_shuffle_decomp(input, 0)
+        with self.assertRaisesRegex(RuntimeError, "upscale factor is too large"):
+            pixel_shuffle_decomp(input, 3_037_000_500)
+        with self.assertRaisesRegex(RuntimeError, "channel.*divisible"):
+            pixel_shuffle_decomp(torch.randn(1, 5, 2, 2), 2)
+
+    def test_pixel_shuffle_meta_validation(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            input = torch.randn(1, 4, 2, 2)
+            self.assertEqual(
+                torch.ops.aten.pixel_shuffle(input, 2).shape, (1, 1, 4, 4)
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "positive upscale_factor"):
+                torch.ops.aten.pixel_shuffle(input, 0)
+            with self.assertRaisesRegex(RuntimeError, "upscale factor is too large"):
+                torch.ops.aten.pixel_shuffle(input, 3_037_000_500)
+            with self.assertRaisesRegex(RuntimeError, "Invalid input shape"):
+                torch.ops.aten.pixel_shuffle(torch.randn(1, 5, 2, 2), 2)
+
     @set_default_dtype(torch.double)
     def test_pixel_shuffle_nhwc_cpu(self):
         input = torch.randn(3, 18, 4, 4, device='cpu')

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7857,7 +7857,19 @@ def meta_pixel_shuffle(self, upscale_factor):
         lambda: f"Invalid input shape for pixel_shuffle: {self.shape}",
     )
     torch._check(
-        self.shape[-3] % (upscale_factor * upscale_factor) == 0,
+        upscale_factor > 0,
+        lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
+    )
+    torch._check(
+        upscale_factor <= torch.iinfo(torch.int64).max // upscale_factor,
+        lambda: (
+            "pixel_shuffle: upscale factor is too large, "
+            f"(upscale_factor)^2 overflowed: upscale_factor={upscale_factor}"
+        ),
+    )
+    upscale_factor_squared = upscale_factor * upscale_factor
+    torch._check(
+        self.shape[-3] % upscale_factor_squared == 0,
         lambda: f"Invalid input shape for pixel_shuffle: {self.shape} with upscale_factor = {upscale_factor}",
     )
 
@@ -7878,7 +7890,7 @@ def meta_pixel_shuffle(self, upscale_factor):
             return fmt
         return torch.contiguous_format
 
-    C = self.shape[-3] // (upscale_factor * upscale_factor)
+    C = self.shape[-3] // upscale_factor_squared
     Hr = self.shape[-2] * upscale_factor
     Wr = self.shape[-1] * upscale_factor
     out_shape = (*self.shape[:-3], C, Hr, Wr)

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -1291,8 +1291,29 @@ def pixel_shuffle(self: Tensor, upscale_factor: int):
         self.dim() >= 3,
         lambda: f"pixel_shuffle expects input to have at least 3 dimensions, but got input with {self.dim} dimension(s)",
     )
+    torch._check(
+        upscale_factor > 0,
+        lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
+    )
+    torch._check(
+        upscale_factor <= torch.iinfo(torch.int64).max // upscale_factor,
+        lambda: (
+            "pixel_shuffle: upscale factor is too large, "
+            f"(upscale_factor)^2 overflowed: upscale_factor={upscale_factor}"
+        ),
+    )
+    upscale_factor_squared = upscale_factor * upscale_factor
+    torch._check(
+        self.shape[-3] % upscale_factor_squared == 0,
+        lambda: (
+            "pixel_shuffle expects its input's 'channel' dimension to be divisible "
+            "by the square of upscale_factor, but "
+            f"input.size(-3)={self.shape[-3]} is not divisible by "
+            f"{upscale_factor_squared}"
+        ),
+    )
     batch = self.shape[:-3]
-    C_out = self.shape[-3] // upscale_factor**2
+    C_out = self.shape[-3] // upscale_factor_squared
     HW_out = (self.shape[-2] * upscale_factor, self.shape[-1] * upscale_factor)
     n = len(batch)
     B_dims = range(n)


### PR DESCRIPTION
> Fixes #171838
>
> The Python decomposition and meta implementation of `pixel_shuffle` calculated the squared upscale factor without matching eager validation. This could reach invalid shape arithmetic in compile and FakeTensor paths.
>
> Add positive-factor, int64-overflow, and channel-divisibility checks before shape calculations, matching eager behavior. The regression tests directly cover the decomposition and FakeTensor/meta paths.
>
> Test Plan:
>
> ```powershell
> $env:PYTHONPATH='.'
> .\.venv\Scripts\python.exe test\test_nn.py TestNN.test_pixel_shuffle_decomp_validation TestNN.test_pixel_shuffle_meta_validation
> .\.venv\Scripts\python.exe test\test_nn.py -k pixel_shuffle
> .\.venv\Scripts\python.exe -m py_compile torch\_refs\nn\functional\__init__.py torch\_meta_registrations.py test\test_nn.py
> git diff --check
> ```
>
> AI assistance disclosure: Codex assisted with implementation and validation. I have personally reviewed the code and test results, understand the change, and take responsibility for this contribution.