### PR TITLE
Update local linting guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -426,13 +426,15 @@ command runs tests such as `TestNN.test_BCELoss` and
 
 ### Local linting
 
-You can run the same linting steps that are used in CI locally via `make`:
+Use `spin quicklint` to lint the files changed in your latest commit and
+working tree:
 
 ```bash
-make lint
+spin quicklint
 ```
 
-Learn more about the linter on the [lintrunner wiki page](https://github.com/pytorch/pytorch/wiki/lintrunner)
+See [Linting before committing](#linting-before-committing) for the full lint
+and autofix commands.
 
 #### Running `pyrefly`
 


### PR DESCRIPTION
## Summary

- Replace the obsolete `make lint` command with `spin quicklint`.
- Link the local linting section to the canonical `lintrunner` guidance.

Fixes #158895.

## Testing

- `git diff --check`
- `uv tool run --python 3.10 lintrunner@0.12.7 --skip EXEC -a CONTRIBUTING.md`

`spin quicklint` was not completed because the shallow checkout expanded it to repository-wide linting. The targeted lint passed; `EXEC` was skipped because WSL marks Windows-mounted files executable.

## AI disclosure

This PR was prepared with assistance from Codex. I reviewed the change and take responsibility for this submission.