### PR TITLE
Add merge rule for the Greenlight review bot

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -640,6 +640,16 @@
   - Lint
   - pull
 
+- name: Greenlight Review Bot
+  patterns:
+  - '*'
+  approved_by:
+  - pytorchgreenlight[bot]
+  mandatory_checks_name:
+  - EasyCLA
+  - Lint
+  - pull
+
 - name: Core Reviewers
   patterns:
   - '*'


### PR DESCRIPTION
**Impact:** PR merge automation / CI only
**Risk:** low

## What
Adds a new `Greenlight Review Bot` entry to `.github/merge_rules.yaml` that lets `pytorchgreenlight[bot]` approve any PR (`*`), gated on the standard mandatory checks (EasyCLA, Lint, pull).

## Why
Enables the Greenlight bot's approvals to satisfy the merge-rule requirements, so PRs it signs off on can be landed through the usual merge flow like those approved by human reviewer groups.