### PR TITLE
[Pytorch] Keep saved-activation strides symbolic under dynamic shapes (#191885)

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -370,6 +370,40 @@ class TestInductorDynamic(DynamicShapesTestCase):
         )
         self.assertEqual(fn(arg0_test, arg1_test), compiled_fn(arg0_test, arg1_test))
 
+    # pad_dynamic_shapes is off by default and is what lets inductor pad a
+    # symbolically-shaped buffer at all; comprehensive_padding is on by default
+    # but is env-controlled, so pin it too.
+    @torch._inductor.config.patch(comprehensive_padding=True, pad_dynamic_shapes=True)
+    def test_saved_activation_symbolic_stride_backward(self, device):
+        # A saved activation's stride must stay symbolic under dynamic shapes.
+        # Without the fix it freezes at the first input's hint (128*112 =
+        # 14336) and the n=96 pass dies in the backward's assert_size_stride
+        # with `stride 24576==14336 at dim=0`.
+        #
+        # The setup is load-bearing. The saved activation must be a computed
+        # intermediate so inductor owns its layout -- a graph input's layout is
+        # fixed by the caller and can never diverge. The innermost dim must be
+        # misaligned (98 pads to 128) so inductor's layout moves off the
+        # contiguous stride the backward placeholder assumes, which is what
+        # makes the restride fire. And the outer stride must depend on a
+        # dynamic dim, so the freeze is observable at a second size.
+        def fn(x, w):
+            h = torch.tanh(x).permute(0, 2, 1)
+            return (h @ w).sum()
+
+        cfn = self.compile_fn(fn)
+        for n in (56, 96):
+            x = torch.randn(2, 2 * n, 98, device=device, requires_grad=True)
+            w = torch.randn(2, 2 * n, 128, device=device, requires_grad=True)
+            x_ref = x.detach().clone().requires_grad_()
+            w_ref = w.detach().clone().requires_grad_()
+
+            cfn(x, w).backward()
+            fn(x_ref, w_ref).backward()
+
+            self.assertEqual(x.grad, x_ref.grad)
+            self.assertEqual(w.grad, w_ref.grad)
+
     def test_arange_dynamic(self, device):
         def fn(a):
             batch_size = a.numel()

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -370,6 +370,42 @@ class TestInductorDynamic(DynamicShapesTestCase):
         )
         self.assertEqual(fn(arg0_test, arg1_test), compiled_fn(arg0_test, arg1_test))
 
+    # pad_dynamic_shapes is off by default and is what lets inductor pad a
+    # symbolically-shaped buffer at all; comprehensive_padding is on by default
+    # but is env-controlled, so pin it too.
+    @torch._inductor.config.patch(
+        comprehensive_padding=True, pad_dynamic_shapes=True
+    )
+    def test_saved_activation_symbolic_stride_backward(self, device):
+        # A saved activation's stride must stay symbolic under dynamic shapes.
+        # Without the fix it freezes at the first input's hint (128*112 =
+        # 14336) and the n=96 pass dies in the backward's assert_size_stride
+        # with `stride 24576==14336 at dim=0`.
+        #
+        # The setup is load-bearing. The saved activation must be a computed
+        # intermediate so inductor owns its layout -- a graph input's layout is
+        # fixed by the caller and can never diverge. The innermost dim must be
+        # misaligned (98 pads to 128) so inductor's layout moves off the
+        # contiguous stride the backward placeholder assumes, which is what
+        # makes the restride fire. And the outer stride must depend on a
+        # dynamic dim, so the freeze is observable at a second size.
+        def fn(x, w):
+            h = torch.tanh(x).permute(0, 2, 1)
+            return (h @ w).sum()
+
+        cfn = self.compile_fn(fn)
+        for n in (56, 96):
+            x = torch.randn(2, 2 * n, 98, device=device, requires_grad=True)
+            w = torch.randn(2, 2 * n, 128, device=device, requires_grad=True)
+            x_ref = x.detach().clone().requires_grad_()
+            w_ref = w.detach().clone().requires_grad_()
+
+            cfn(x, w).backward()
+            fn(x_ref, w_ref).backward()
+
+            self.assertEqual(x.grad, x_ref.grad)
+            self.assertEqual(w.grad, w_ref.grad)
+
     def test_arange_dynamic(self, device):
         def fn(a):
             batch_size = a.numel()

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -2365,12 +2365,12 @@ def _aot_stage2b_bw_compile(
 
                 # Inductor can choose different strides for activations than
                 # what backward graph has. if we can't statically tell that
-                # strides are the same, we assume they are not.
+                # strides are the same, we assume they are not. real_stride may
+                # be symbolic (see set_tracing_context_output_strides), so compare
+                # it directly rather than materializing it to an int hint.
                 with suppress_ctx:
                     for k in range(len(ph_arg.stride())):
-                        # real_stride can't be symbolic.
-
-                        if guard_or_true(ph_arg.stride()[k] != int(real_stride[k])):
+                        if guard_or_true(ph_arg.stride()[k] != real_stride[k]):
                             stride_different = True
                             break
 

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -2368,8 +2368,6 @@ def _aot_stage2b_bw_compile(
                 # strides are the same, we assume they are not.
                 with suppress_ctx:
                     for k in range(len(ph_arg.stride())):
-                        # real_stride can't be symbolic.
-
                         if guard_or_true(ph_arg.stride()[k] != int(real_stride[k])):
                             stride_different = True
                             break

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3850,16 +3850,29 @@ def set_tracing_context_output_strides(
             if exprs is None:
                 context.output_strides.append(None)
             else:
-                fakify_first_call = False
-                if ctx := torch._guards.TracingContext.try_get():
-                    fakify_first_call = ctx.fakify_first_call
-
                 def map_expr(e: Any) -> float | int | SymInt | SymFloat | SymBool:
                     if shape_env is None:
                         return int(e)
-                    if fakify_first_call:
+                    # Keep symbolic strides symbolic. deserialize_symexpr returns a
+                    # concrete value for constant exprs and a SymInt otherwise, so a
+                    # stride like 208*s stays symbolic instead of being collapsed to
+                    # the hint from the first example input. Collapsing it here is
+                    # what lets a stale constant get frozen into the backward graph's
+                    # saved-activation placeholder, which is then wrong for every
+                    # later input with a different dynamic size.
+                    #
+                    # deserialize_symexpr eagerly binds every symbol in
+                    # backed_var_to_val through int(val), which raises for entries
+                    # whose value is itself symbolic (nested tensors hit this). Such
+                    # a symbol has no integer hint to bind, and the failure is
+                    # unrelated to the expression being mapped, so fall back to the
+                    # previous evaluate_symexpr behaviour instead of failing the
+                    # compile. Strides in that graph stay concrete, exactly as
+                    # before this change.
+                    try:
                         return shape_env.deserialize_symexpr(e)
-                    return shape_env.evaluate_symexpr(e)
+                    except TypeError:
+                        return shape_env.evaluate_symexpr(e)
 
                 context.output_strides.append(
                     tuple(map_expr(e) for e in exprs)  # type: ignore[misc]

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3850,16 +3850,21 @@ def set_tracing_context_output_strides(
             if exprs is None:
                 context.output_strides.append(None)
             else:
-                fakify_first_call = False
-                if ctx := torch._guards.TracingContext.try_get():
-                    fakify_first_call = ctx.fakify_first_call
 
                 def map_expr(e: Any) -> float | int | SymInt | SymFloat | SymBool:
                     if shape_env is None:
                         return int(e)
-                    if fakify_first_call:
+                    # Keep the stride symbolic; evaluate_symexpr collapses it to
+                    # the first input's hint, which then gets frozen into the
+                    # backward graph's saved-activation placeholder.
+                    #
+                    # deserialize_symexpr binds every symbol in backed_var_to_val
+                    # via int(val) and raises when a value is itself symbolic
+                    # (nested tensors). Those graphs keep the old behaviour.
+                    try:
                         return shape_env.deserialize_symexpr(e)
-                    return shape_env.evaluate_symexpr(e)
+                    except TypeError:
+                        return shape_env.evaluate_symexpr(e)
 
                 context.output_strides.append(
                     tuple(map_expr(e) for e in exprs)  # type: ignore[misc]


### PR DESCRIPTION
Summary:

Under dynamic shapes a saved-for-backward activation could get a constant stride baked into the backward graph, breaking every input whose dynamic size differed from the first. Production FSDP2 job `fire-ycui1984-train-20260731-2336-fsdp2contig-3838c704` died in `.backward()` with:

```
AssertionError: expected size 650==650, stride 11648==19968 at dim=0
```

`11648 = 208*56` and `19968 = 208*96` - one stride expression resolved against two different hints.

`map_expr` in `set_tracing_context_output_strides` resolved the forward's output strides with `evaluate_symexpr`, which substitutes hints and returns a concrete int, so `208*s32` collapsed to the first input's value. `_aot_stage2b_bw_compile` then passes that to `as_strided`, freezing the constant into the backward graph's saved-activation placeholder.

Fix: `map_expr` uses `deserialize_symexpr`, which is concrete for constant exprs and a `SymInt` otherwise. Statically-known cases are unaffected.

`map_expr` falls back to `evaluate_symexpr` on `TypeError`. `deserialize_symexpr` binds every symbol in `backed_var_to_val` through `int(val)`, which raises for nested-tensor graphs where a value is itself symbolic. Those graphs keep the previous behaviour, tracked by a TODO.

In `graph_compile.py`, the restride comparison drops its `int(real_stride[k])` cast. Now that `real_stride` can be symbolic, the cast collapses one side to a constant: when the placeholder's stride and `real_stride[k]` are the same symbol, `guard_or_true` would report them as different and trigger a needless restride. Comparing symbolically gives the right answer. The stale comment claiming `real_stride` can't be symbolic is removed.

`symbolic_shapes.py`: `deserialize_symexpr` built its `SymNode`s with `fx_node=None`. Comparing one of those against a placeholder's `SymInt` tripped the "Cannot mix SymNodes with fx_node and without fx_node" assertion under translation validation. It now builds them with `_create_fx_placeholder_and_z3var(e, int)`, matching every other `SymNode` construction in the file. That helper returns `None` when translation validation is off, so the default path is unchanged.

Test Plan:
```
buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:torchinductor_dynamic_shapes -- test_saved_activation_symbolic_stride_backward
Buck UI: https://www.internalfb.com/buck2/0971157b-2700-4c91-ab6e-33f3eb3a917b
Network: up     0B           
File changed (since mergebase): fbcode//caffe2/test/inductor/test_torchinductor_dynamic_shapes.py
File changed (since mergebase): fbcode//caffe2/torch/_functorch/_aot_autograd/graph_compile.py
File changed (since mergebase): fbcode//caffe2/torch/_inductor/utils.py
3 additional file change events (since mergebase)
File Watcher fresh instance: new mergebase, cleared graph state, cleared dep files
Buck UI:    https://www.internalfb.com/buck2/0971157b-2700-4c91-ab6e-33f3eb3a917b
Test UI:    https://www.internalfb.com/intern/testinfra/testrun/24206848033656444
RE session: reSessionID-1b4d1624-e869-40d2-96d5-43fc52447291
Network:    up 0B  down 597MiB
Phase                   Remaining                               Details
Loading targets          0/  8253                               125837 dirs read, 915374 targets declared
Analyzing targets        0/124219                               2735992 actions, 3730407 artifacts declared
Executing actions        0/756105                               232:27:02.2s exec time total
Command test                                                    Finished 254930 cache (100% hit)  232:27:02.2s exec time cached (100%)
elapsed 1:36.5s
Buck UI: https://www.internalfb.com/buck2/0971157b-2700-4c91-ab6e-33f3eb3a917b
Tests finished: Pass 2. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
```

Differential Revision: D114505755


