### PR TITLE
[Pytorch] Fix ValueRanges.eq/ne raising TypeError on boolean ranges (#191886)

### DIFF
--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -411,6 +411,32 @@ class TestValueRanges(TestCase):
                     ):
                         getattr(ValueRangeAnalysis, fn)(a, b)
 
+    def test_eq_ne_bool_ranges(self):
+        # eq/ne must accept boolean ranges. sympy booleans do not support
+        # ordered comparison (bool >/< raises), which the disjoint-range test in
+        # eq would otherwise hit. Regression test for eq/ne raising TypeError on
+        # a boolean range, which test_binary_bool_ref_range does not cover (it
+        # omits COMPARE_OPS).
+        full = ValueRanges(sympy.false, sympy.true)
+        T = ValueRanges.wrap(sympy.true)
+        F = ValueRanges.wrap(sympy.false)
+        for a, b in [(full, full), (full, T), (F, full), (T, F), (T, T), (F, F)]:
+            with self.subTest(a=a, b=b):
+                for fn in ("eq", "ne"):
+                    r = getattr(ValueRangeAnalysis, fn)(a, b)
+                    self.assertTrue(r.is_bool)
+                    self.assertIn(r.lower, (sympy.true, sympy.false))
+                    self.assertIn(r.upper, (sympy.true, sympy.false))
+        # singletons resolve precisely: equal -> definitely eq, disjoint -> not
+        self.assertEqual(ValueRangeAnalysis.eq(T, T), T)
+        self.assertEqual(ValueRangeAnalysis.ne(T, T), F)
+        self.assertEqual(ValueRangeAnalysis.eq(F, F), T)
+        self.assertEqual(ValueRangeAnalysis.ne(F, F), F)
+        self.assertEqual(ValueRangeAnalysis.eq(T, F), F)
+        self.assertEqual(ValueRangeAnalysis.ne(T, F), T)
+        self.assertEqual(ValueRangeAnalysis.eq(F, T), F)
+        self.assertEqual(ValueRangeAnalysis.ne(F, T), T)
+
     @parametrize("fn", UNARY_OPS)
     def test_unary_ref_range(self, fn):
         # TODO: bring back sympy.oo testing for float unary fns

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -603,13 +603,19 @@ class SymPyValueRangeAnalysis:
             return ValueRanges(value_range, value_range)
         return ValueRanges(-int_oo, int_oo)
 
-    @staticmethod
-    def eq(a, b):
+    @classmethod
+    def eq(cls, a, b):
         a = ValueRanges.wrap(a)
         b = ValueRanges.wrap(b)
         if a.is_singleton() and b.is_singleton() and a.lower == b.lower:
             return ValueRanges.wrap(sympy.true)
-        elif a.lower > b.upper or b.lower > a.upper:  # ranges disjoint
+        # sympy booleans do not support ordered comparison (bool >/< raises), so
+        # map them to {0, 1} before the disjoint-range test below.
+        if a.is_bool:
+            a = cls._bool_to_int(a)
+        if b.is_bool:
+            b = cls._bool_to_int(b)
+        if a.lower > b.upper or b.lower > a.upper:  # ranges disjoint
             return ValueRanges.wrap(sympy.false)
         return ValueRanges(sympy.false, sympy.true)
 


### PR DESCRIPTION
Summary:

# Context
`ValueRangeAnalysis.eq` short-circuits to `false` when the operand ranges are provably disjoint, using `a.lower > b.upper or b.lower > a.upper`. That ordered comparison is invalid for boolean ranges -- sympy raises `TypeError` on `BooleanAtom` `<`/`>` -- and `ne` inherits it via `not_(eq(...))`.

Sibling ops already handle this: `bitwise_and`/`bitwise_xor` map bools to `{0, 1}` via `_bool_to_int`, and `lt`/`gt`/`le`/`ge` special-case bool. The fix reuses that idiom, mapping boolean operands to `{0, 1}` before the disjoint test, which keeps `eq`/`ne` precise: equal singletons resolve to `true`, disjoint ones to `false`, overlapping ranges to `[false, true]`.

This crashes Inductor bounds analysis with an `InductorError` when a symbolic-dependent boolean expression produces a non-singleton boolean range, so it only reproduces under dynamic shapes.

Test Plan:
```
buck2 test mode/opt fbcode//caffe2/test:sympy_utils -- test_eq_ne_bool_ranges
File changed: fbcode//caffe2/torch/utils/_sympy/value_ranges.py
Buck UI:    https://www.internalfb.com/buck2/cd8b1633-d0c5-4e90-9e74-6210c735af4e
Test UI:    https://www.internalfb.com/intern/testinfra/testrun/8444249667250822
RE session: reSessionID-c07a86b7-dada-4b6e-8903-1c0d973db04a
Network:    up 0B  down 1.2MiB
Phase                 Remaining                    Details
Analyzing targets       0/  197
Executing actions       0/16238                    21.0s exec time total
Command test                                       Finished 4 cache (100% hit)  21.0s exec time cached (100%)
elapsed 21.8s
Buck UI: https://www.internalfb.com/buck2/cd8b1633-d0c5-4e90-9e74-6210c735af4e
Tests finished: Pass 1. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0```

Reviewed By: ezyang

Differential Revision: D114504654




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01