### PR TITLE
Fix typo: remove duplicated the in DeviceCapability doc comment

### DIFF
--- a/c10/core/DeviceCapability.h
+++ b/c10/core/DeviceCapability.h
@@ -19,7 +19,7 @@ enum ScalarTypeIndex {
 };
 
 /**
- * @brief DeviceCapability represents the the common capabilities that all
+ * @brief DeviceCapability represents the common capabilities that all
  * devices should support.
  *
  * This struct provides a compact way to represent the common capabilities that


### PR DESCRIPTION
Fixes #191819

Removes duplicated "the" in Doxygen comment for DeviceCapability.