### PR TITLE
[Testcase Refactoring] Add hw-classification and split device-exercising tests in test_schedule

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -54,9 +54,10 @@ from torch.distributed.pipelining.stage import (
     _RecvInfo,
     PipelineStage,
 )
-from torch.testing._internal.common_distributed import requires_accelerator_dist_backend
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     check_leaked_tensors,
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -67,11 +68,6 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 
 ARTIFACTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "artifacts")
 
-device = (
-    acc.type
-    if (acc := torch.accelerator.current_accelerator(check_available=True))
-    else "cpu"
-)
 logger = logging.getLogger(__name__)
 torch.manual_seed(0)
 
@@ -147,6 +143,8 @@ def _run_adjacency_validation(stage, num_stages):
 
 
 class ScheduleTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_get_schedule_class(self):
         # List of all expected schedule names
         schedule_names = [
@@ -599,6 +597,8 @@ instantiate_parametrized_tests(ScheduleTest)
 
 
 class TestSchedulePlan(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # Define a list of test cases with varying num_local_stages, num_microbatches, and group_size
@@ -765,6 +765,8 @@ instantiate_parametrized_tests(TestSchedulePlan)
 
 
 class TestScheduleCsv(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize(
         "ScheduleClass,csv_name",
         [
@@ -808,11 +810,14 @@ class TestScheduleCsv(TestCase):
 instantiate_parametrized_tests(TestScheduleCsv)
 
 
+def _parse_actions(actions: list[str]) -> list[_Action]:
+    return [_Action.from_str(s) for s in actions]
+
+
 class TestScheduleLowering(TestCase):
     """Tests lowering passes that convert simple compute-only (FBW) schedules into compute+comms schedules"""
 
-    def _parse_actions(self, actions: list[str]) -> list[_Action]:
-        return [_Action.from_str(s) for s in actions]
+    hw_classification = HardwareClassification.GENERIC
 
     @parametrize(
         "action_str_and_ref",
@@ -865,8 +870,8 @@ class TestScheduleLowering(TestCase):
         FSDP unshard/reshard operations to the schedule.  This is just part of the process of adding communication
         ops and producing a complete schedule.
         """
-        compute_sch = self._parse_actions(test_info["compute"])
-        expected_comms_sch = self._parse_actions(test_info["comms"])
+        compute_sch = _parse_actions(test_info["compute"])
+        expected_comms_sch = _parse_actions(test_info["comms"])
 
         comms_sch = _add_unshard_reshard(compute_sch)
         for expected, actual in zip(expected_comms_sch, comms_sch):
@@ -904,8 +909,8 @@ class TestScheduleLowering(TestCase):
         ],
     )
     def test_reduce_grad(self, test_info):
-        compute_sch = self._parse_actions(test_info["compute"])
-        expected_comms_sch = self._parse_actions(test_info["comms"])
+        compute_sch = _parse_actions(test_info["compute"])
+        expected_comms_sch = _parse_actions(test_info["comms"])
 
         comms_sch = _add_reduce_grad(compute_sch, 2)
         for expected, actual in zip(expected_comms_sch, comms_sch, strict=True):
@@ -939,8 +944,8 @@ class TestScheduleLowering(TestCase):
     )
     def test_merge_bw(self, test_info):
         """Test the pass that merges adjacent I and W operations into a B operation."""
-        compute_sch = self._parse_actions(test_info["compute"])
-        expected_merged_sch = self._parse_actions(test_info["comms"])
+        compute_sch = _parse_actions(test_info["compute"])
+        expected_merged_sch = _parse_actions(test_info["comms"])
 
         merged_sch = _merge_bw(compute_sch)
         for expected, actual in zip(expected_merged_sch, merged_sch):
@@ -1080,11 +1085,11 @@ class TestScheduleLowering(TestCase):
     def test_send_recv(self, test_info):
         """Tests the lowering pass that adds send/recv ops to a compute-only schedule."""
         compute_sch = {
-            rank: self._parse_actions(test_info["compute"][rank])
+            rank: _parse_actions(test_info["compute"][rank])
             for rank in test_info["compute"]
         }
         expected_comms_sch = {
-            rank: self._parse_actions(test_info["comms"][rank])
+            rank: _parse_actions(test_info["comms"][rank])
             for rank in test_info["comms"]
         }
 
@@ -1436,11 +1441,11 @@ class TestScheduleLowering(TestCase):
     def test_defer_recv_ops(self, test_info):
         """Tests that _defer_recv_ops defers RECVs with rank-parity ordering."""
         input_sch = {
-            rank: self._parse_actions(test_info["input"][rank])
+            rank: _parse_actions(test_info["input"][rank])
             for rank in test_info["input"]
         }
         expected_sch = {
-            rank: self._parse_actions(test_info["expected"][rank])
+            rank: _parse_actions(test_info["expected"][rank])
             for rank in test_info["expected"]
         }
 
@@ -1635,8 +1640,11 @@ class TestScheduleLowering(TestCase):
         # print(_format_pipeline_order(simulated_schedule))
         self.assertEqual(num_steps, 113)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_grad_with_v_schedule(self):
+
+class TestScheduleLoweringDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_grad_with_v_schedule(self, device):
         """
         We have a special case for V schedules where 2 adjacent stages are on the same rank.
         E.g.
@@ -1700,7 +1708,7 @@ class TestScheduleLowering(TestCase):
         )
         schedule._prepare_schedule_with_comms(
             {
-                0: self._parse_actions(
+                0: _parse_actions(
                     [
                         "0F0",
                         "0F1",
@@ -1753,8 +1761,7 @@ class TestScheduleLowering(TestCase):
 
         torch.distributed.destroy_process_group()
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_grad_with_split_b_w(self):
+    def test_grad_with_split_b_w(self, device):
         """
         Ensure that separate dInput and dWeight computations are correctly executed.
         This test runs on a single rank and just tests a single stage with 2 microbatches with separate B, W operations.
@@ -1811,7 +1818,7 @@ class TestScheduleLowering(TestCase):
         )
         schedule._prepare_schedule_with_comms(
             {
-                0: self._parse_actions(
+                0: _parse_actions(
                     [
                         "0F0",
                         "0F1",
@@ -1863,7 +1870,17 @@ class TestScheduleLowering(TestCase):
         torch.distributed.destroy_process_group()
 
 
+instantiate_device_type_tests(
+    TestScheduleLoweringDevice,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+
+
 class TestValidateSchedule(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_valid_schedule(self):
         schedule_actions = [
             {
@@ -1904,6 +1921,8 @@ class TestValidateSchedule(TestCase):
 
 
 class ScheduleUtilTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_generate_stage_to_rank_mapping(self):
         stage_to_rank = generate_stage_to_rank_mapping(2, 2)
         self.assertEqual(
@@ -1977,6 +1996,8 @@ instantiate_parametrized_tests(TestScheduleLowering)
 class TestBatchP2P(TestCase):
     """Tests that _batch_p2p dispatches homogeneous ops individually to avoid
     head-of-line blocking, while still batching mixed ops for deadlock avoidance."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def _make_p2p_op(self, op, group_peer=0, group=None):
         p = MagicMock()

--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -54,9 +54,10 @@ from torch.distributed.pipelining.stage import (
     _RecvInfo,
     PipelineStage,
 )
-from torch.testing._internal.common_distributed import requires_accelerator_dist_backend
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     check_leaked_tensors,
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -67,11 +68,6 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 
 ARTIFACTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "artifacts")
 
-device = (
-    acc.type
-    if (acc := torch.accelerator.current_accelerator(check_available=True))
-    else "cpu"
-)
 logger = logging.getLogger(__name__)
 torch.manual_seed(0)
 
@@ -147,6 +143,8 @@ def _run_adjacency_validation(stage, num_stages):
 
 
 class ScheduleTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_get_schedule_class(self):
         # List of all expected schedule names
         schedule_names = [
@@ -599,6 +597,8 @@ instantiate_parametrized_tests(ScheduleTest)
 
 
 class TestSchedulePlan(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # Define a list of test cases with varying num_local_stages, num_microbatches, and group_size
@@ -765,6 +765,8 @@ instantiate_parametrized_tests(TestSchedulePlan)
 
 
 class TestScheduleCsv(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize(
         "ScheduleClass,csv_name",
         [
@@ -808,11 +810,15 @@ class TestScheduleCsv(TestCase):
 instantiate_parametrized_tests(TestScheduleCsv)
 
 
-class TestScheduleLowering(TestCase):
-    """Tests lowering passes that convert simple compute-only (FBW) schedules into compute+comms schedules"""
-
+class ScheduleLoweringTestBase(TestCase):
     def _parse_actions(self, actions: list[str]) -> list[_Action]:
         return [_Action.from_str(s) for s in actions]
+
+
+class TestScheduleLowering(ScheduleLoweringTestBase):
+    """Tests lowering passes that convert simple compute-only (FBW) schedules into compute+comms schedules"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     @parametrize(
         "action_str_and_ref",
@@ -1635,8 +1641,11 @@ class TestScheduleLowering(TestCase):
         # print(_format_pipeline_order(simulated_schedule))
         self.assertEqual(num_steps, 113)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_grad_with_v_schedule(self):
+
+class TestScheduleLoweringDevice(ScheduleLoweringTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_grad_with_v_schedule(self, device):
         """
         We have a special case for V schedules where 2 adjacent stages are on the same rank.
         E.g.
@@ -1753,8 +1762,7 @@ class TestScheduleLowering(TestCase):
 
         torch.distributed.destroy_process_group()
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_grad_with_split_b_w(self):
+    def test_grad_with_split_b_w(self, device):
         """
         Ensure that separate dInput and dWeight computations are correctly executed.
         This test runs on a single rank and just tests a single stage with 2 microbatches with separate B, W operations.
@@ -1863,7 +1871,17 @@ class TestScheduleLowering(TestCase):
         torch.distributed.destroy_process_group()
 
 
+instantiate_device_type_tests(
+    TestScheduleLoweringDevice,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+
+
 class TestValidateSchedule(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_valid_schedule(self):
         schedule_actions = [
             {
@@ -1904,6 +1922,8 @@ class TestValidateSchedule(TestCase):
 
 
 class ScheduleUtilTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_generate_stage_to_rank_mapping(self):
         stage_to_rank = generate_stage_to_rank_mapping(2, 2)
         self.assertEqual(
@@ -1977,6 +1997,8 @@ instantiate_parametrized_tests(TestScheduleLowering)
 class TestBatchP2P(TestCase):
     """Tests that _batch_p2p dispatches homogeneous ops individually to avoid
     head-of-line blocking, while still batching mixed ops for deadlock avoidance."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def _make_p2p_op(self, op, group_peer=0, group=None):
         p = MagicMock()

--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -223,80 +223,82 @@ class ScheduleTest(TestCase):
         torch.distributed.init_process_group(
             backend="fake", rank=0, world_size=1, store=store
         )
-        d_hid, batch_size = 512, 256
-        n_stages = 1
-        device = "cpu"
-        full_mod = MultiMLP(d_hid, n_layers=n_stages)
-        full_mod.to(device)
+        try:
+            d_hid, batch_size = 512, 256
+            n_stages = 1
+            device = "cpu"
+            full_mod = MultiMLP(d_hid, n_layers=n_stages)
+            full_mod.to(device)
 
-        x = torch.randn(batch_size, d_hid, device=device)
-        ref_mod = copy.deepcopy(full_mod)
-        with torch.no_grad():
-            y = ref_mod(x)
-            # Add a small perturbation
-            target = y + torch.randn(batch_size, d_hid, device=device)
+            x = torch.randn(batch_size, d_hid, device=device)
+            ref_mod = copy.deepcopy(full_mod)
+            with torch.no_grad():
+                y = ref_mod(x)
+                # Add a small perturbation
+                target = y + torch.randn(batch_size, d_hid, device=device)
 
-        def loss_fn(y, target):
-            return torch.nn.functional.cross_entropy(y, target)
+            def loss_fn(y, target):
+                return torch.nn.functional.cross_entropy(y, target)
 
-        # Run reference
-        for _ in range(2):
-            ref_mod.zero_grad()
-            ref_out = ref_mod(x)
-            ref_loss = loss_fn(ref_out, target)
-            ref_loss.backward()
+            # Run reference
+            for _ in range(2):
+                ref_mod.zero_grad()
+                ref_out = ref_mod(x)
+                ref_loss = loss_fn(ref_out, target)
+                ref_loss.backward()
 
-        submod_name = "layers.0"
-        stage_module = full_mod.get_submodule(submod_name)
+            submod_name = "layers.0"
+            stage_module = full_mod.get_submodule(submod_name)
 
-        # Create a pipeline stage to wrap that submodule
-        num_microbatches = 2
-        stages = [
-            PipelineStage(
-                stage_module,
-                0,
-                n_stages,
-                device,
+            # Create a pipeline stage to wrap that submodule
+            num_microbatches = 2
+            stages = [
+                PipelineStage(
+                    stage_module,
+                    0,
+                    n_stages,
+                    device,
+                )
+            ]
+
+            if issubclass(ScheduleClass, PipelineScheduleSingle):
+                stages = stages[0]
+
+            # Attach to a schedule
+            schedule = ScheduleClass(
+                stages,
+                num_microbatches,
+                loss_fn=loss_fn,
             )
-        ]
+            # Run
+            for _ in range(2):
+                # Zero gradients
+                stage_module.zero_grad()
+                losses = []
+                out = schedule.step(x, target=target, losses=losses)
 
-        if issubclass(ScheduleClass, PipelineScheduleSingle):
-            stages = stages[0]
+            # Check output
+            torch.testing.assert_close(out, ref_out)
+            # Check loss
+            # Since the reduction used in the loss function above is "mean", we use
+            # "mean" here to reduce microbatch losses into a single value too.
+            pipe_loss = torch.stack(losses).mean()
+            torch.testing.assert_close(pipe_loss, ref_loss)
 
-        # Attach to a schedule
-        schedule = ScheduleClass(
-            stages,
-            num_microbatches,
-            loss_fn=loss_fn,
-        )
-        # Run
-        for _ in range(2):
-            # Zero gradients
-            stage_module.zero_grad()
-            losses = []
-            out = schedule.step(x, target=target, losses=losses)
+            # Check gradients
+            # Get corresponding submodule from reference model
+            ref_submod = ref_mod.get_submodule(submod_name)
+            # Check gradients per parameter
+            for name, p in stage_module.named_parameters():
+                ref_p = ref_submod.get_parameter(name)
+                try:
+                    torch.testing.assert_close(p.grad, ref_p.grad, rtol=1e-5, atol=4e-5)
+                except AssertionError:
+                    print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
+                    raise
 
-        # Check output
-        torch.testing.assert_close(out, ref_out)
-        # Check loss
-        # Since the reduction used in the loss function above is "mean", we use
-        # "mean" here to reduce microbatch losses into a single value too.
-        pipe_loss = torch.stack(losses).mean()
-        torch.testing.assert_close(pipe_loss, ref_loss)
-
-        # Check gradients
-        # Get corresponding submodule from reference model
-        ref_submod = ref_mod.get_submodule(submod_name)
-        # Check gradients per parameter
-        for name, p in stage_module.named_parameters():
-            ref_p = ref_submod.get_parameter(name)
-            try:
-                torch.testing.assert_close(p.grad, ref_p.grad, rtol=1e-5, atol=4e-5)
-            except AssertionError:
-                print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
-                raise
-
-        torch.distributed.destroy_process_group()
+        finally:
+            torch.distributed.destroy_process_group()
 
     @parametrize(
         "ScheduleClass",
@@ -1661,106 +1663,112 @@ class TestScheduleLoweringDevice(ScheduleLoweringTestBase):
         torch.distributed.init_process_group(
             backend="fake", rank=0, world_size=1, store=store
         )
-        d_hid = 512
-        batch_size = 256
-        n_stages = 2
-        full_mod = MultiMLP(d_hid, n_layers=n_stages)
-        full_mod.to(device)
+        try:
+            d_hid = 512
+            batch_size = 256
+            n_stages = 2
+            full_mod = MultiMLP(d_hid, n_layers=n_stages)
+            full_mod.to(device)
 
-        ref_mod = copy.deepcopy(full_mod)
-        x = torch.randn(batch_size, d_hid, device=device)
-        with torch.no_grad():
-            y = ref_mod(x)
-            # Add a small perturbation
-            target = y + torch.randn(batch_size, d_hid, device=device)
+            ref_mod = copy.deepcopy(full_mod)
+            x = torch.randn(batch_size, d_hid, device=device)
+            with torch.no_grad():
+                y = ref_mod(x)
+                # Add a small perturbation
+                target = y + torch.randn(batch_size, d_hid, device=device)
 
-        loss_fn = torch.nn.MSELoss(reduction="sum")
+            loss_fn = torch.nn.MSELoss(reduction="sum")
 
-        # Run reference
-        for _ in range(2):
-            ref_mod.zero_grad()
-            ref_out = ref_mod(x)
-            ref_loss = loss_fn(ref_out, target)
-            ref_loss.backward()
-
-        stage_indices = [0, 1]
-        submod_names = [f"layers.{i}" for i in stage_indices]
-        stage_modules = [
-            full_mod.get_submodule(submod_name) for submod_name in submod_names
-        ]
-        # Create a pipeline stage to wrap that submodule
-        num_microbatches = 2
-        stages = [
-            PipelineStage(
-                stage_module,
-                stage_idx,
-                n_stages,
-                device,
-            )
-            for stage_module, stage_idx in zip(stage_modules, stage_indices)
-        ]
-
-        # Attach to a schedule
-        schedule = _PipelineScheduleRuntime(
-            stages,
-            num_microbatches,
-            loss_fn=loss_fn,
-            scale_grads=False,
-        )
-        schedule._prepare_schedule_with_comms(
-            {
-                0: self._parse_actions(
-                    [
-                        "0F0",
-                        "0F1",
-                        "1F0",
-                        "1F1",
-                        "1B0",
-                        "1B1",
-                        "0B0",
-                        "0B1",
-                    ]
-                ),
-            },
-            format="compute_comms",
-        )
-
-        # Run
-        with check_leaked_tensors() as garbage_tensors:
+            # Run reference
             for _ in range(2):
-                # Zero gradients
-                for stage_module in stage_modules:
-                    stage_module.zero_grad()
-                losses = []
-                out = schedule.step(x, target=target, losses=losses)
-        self.assertEqual(
-            len(garbage_tensors),
-            0,
-            "Found leaked tensors, check logs above for debug info",
-        )
+                ref_mod.zero_grad()
+                ref_out = ref_mod(x)
+                ref_loss = loss_fn(ref_out, target)
+                ref_loss.backward()
 
-        # Check output
-        torch.testing.assert_close(out, ref_out)
-        # Check loss
-        # Since the reduction used in the loss function above is "sum", we use
-        # "sum" here to reduce microbatch losses into a single value too.
-        pipe_loss = sum(losses)
-        torch.testing.assert_close(pipe_loss, ref_loss)
+            stage_indices = [0, 1]
+            submod_names = [f"layers.{i}" for i in stage_indices]
+            stage_modules = [
+                full_mod.get_submodule(submod_name) for submod_name in submod_names
+            ]
+            # Create a pipeline stage to wrap that submodule
+            num_microbatches = 2
+            stages = [
+                PipelineStage(
+                    stage_module,
+                    stage_idx,
+                    n_stages,
+                    device,
+                )
+                for stage_module, stage_idx in zip(stage_modules, stage_indices)
+            ]
 
-        # Check gradients
-        for stage_module, submod_name in zip(stage_modules, submod_names):
-            # Get corresponding submodule from reference model
-            ref_submod = ref_mod.get_submodule(submod_name)
-            # Check gradients per parameter
-            for name, p in stage_module.named_parameters():
-                ref_p = ref_submod.get_parameter(name)
-                try:
-                    torch.testing.assert_close(p.grad, ref_p.grad, rtol=1e-5, atol=4e-5)
-                except AssertionError:
-                    print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
-                    raise
+            # Attach to a schedule
+            schedule = _PipelineScheduleRuntime(
+                stages,
+                num_microbatches,
+                loss_fn=loss_fn,
+                scale_grads=False,
+            )
+            schedule._prepare_schedule_with_comms(
+                {
+                    0: self._parse_actions(
+                        [
+                            "0F0",
+                            "0F1",
+                            "1F0",
+                            "1F1",
+                            "1B0",
+                            "1B1",
+                            "0B0",
+                            "0B1",
+                        ]
+                    ),
+                },
+                format="compute_comms",
+            )
 
-        torch.distributed.destroy_process_group()
+            # Run
+            with check_leaked_tensors() as garbage_tensors:
+                for _ in range(2):
+                    # Zero gradients
+                    for stage_module in stage_modules:
+                        stage_module.zero_grad()
+                    losses = []
+                    out = schedule.step(x, target=target, losses=losses)
+            self.assertEqual(
+                len(garbage_tensors),
+                0,
+                "Found leaked tensors, check logs above for debug info",
+            )
+
+            # Check output
+            torch.testing.assert_close(out, ref_out)
+            # Check loss
+            # Since the reduction used in the loss function above is "sum", we use
+            # "sum" here to reduce microbatch losses into a single value too.
+            pipe_loss = sum(losses)
+            torch.testing.assert_close(pipe_loss, ref_loss)
+
+            # Check gradients
+            for stage_module, submod_name in zip(stage_modules, submod_names):
+                # Get corresponding submodule from reference model
+                ref_submod = ref_mod.get_submodule(submod_name)
+                # Check gradients per parameter
+                for name, p in stage_module.named_parameters():
+                    ref_p = ref_submod.get_parameter(name)
+                    try:
+                        torch.testing.assert_close(
+                            p.grad, ref_p.grad, rtol=1e-5, atol=4e-5
+                        )
+                    except AssertionError:
+                        print(
+                            f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}"
+                        )
+                        raise
+
+        finally:
+            torch.distributed.destroy_process_group()
 
     def test_grad_with_split_b_w(self, device):
         """
@@ -1771,104 +1779,110 @@ class TestScheduleLoweringDevice(ScheduleLoweringTestBase):
         torch.distributed.init_process_group(
             backend="fake", rank=0, world_size=1, store=store
         )
-        d_hid = 512
-        batch_size = 256
-        n_stages = 1
-        full_mod = MultiMLP(d_hid, n_layers=n_stages)
-        full_mod.to(device)
+        try:
+            d_hid = 512
+            batch_size = 256
+            n_stages = 1
+            full_mod = MultiMLP(d_hid, n_layers=n_stages)
+            full_mod.to(device)
 
-        ref_mod = copy.deepcopy(full_mod)
-        x = torch.randn(batch_size, d_hid, device=device)
-        with torch.no_grad():
-            y = ref_mod(x)
-            # Add a small perturbation
-            target = y + torch.randn(batch_size, d_hid, device=device)
+            ref_mod = copy.deepcopy(full_mod)
+            x = torch.randn(batch_size, d_hid, device=device)
+            with torch.no_grad():
+                y = ref_mod(x)
+                # Add a small perturbation
+                target = y + torch.randn(batch_size, d_hid, device=device)
 
-        loss_fn = torch.nn.MSELoss(reduction="sum")
+            loss_fn = torch.nn.MSELoss(reduction="sum")
 
-        # Run reference
-        for _ in range(2):
-            ref_mod.zero_grad()
-            ref_out = ref_mod(x)
-            ref_loss = loss_fn(ref_out, target)
-            ref_loss.backward()
-
-        stage_indices = [0]
-        submod_names = [f"layers.{i}" for i in stage_indices]
-        stage_modules = [
-            full_mod.get_submodule(submod_name) for submod_name in submod_names
-        ]
-        # Create a pipeline stage to wrap that submodule
-        num_microbatches = 2
-        stages = [
-            PipelineStage(
-                stage_module,
-                stage_idx,
-                n_stages,
-                device,
-            )
-            for stage_module, stage_idx in zip(stage_modules, stage_indices)
-        ]
-
-        # Attach to a schedule
-        schedule = _PipelineScheduleRuntime(
-            stages,
-            num_microbatches,
-            loss_fn=loss_fn,
-            scale_grads=False,
-        )
-        schedule._prepare_schedule_with_comms(
-            {
-                0: self._parse_actions(
-                    [
-                        "0F0",
-                        "0F1",
-                        "0I0",
-                        "0I1",
-                        "0W0",
-                        "0W1",
-                    ]
-                ),
-            },
-            format="compute_comms",
-        )
-
-        # Run
-        with check_leaked_tensors() as garbage_tensors:
+            # Run reference
             for _ in range(2):
-                # Zero gradients
-                for stage_module in stage_modules:
-                    stage_module.zero_grad()
-                losses = []
-                out = schedule.step(x, target=target, losses=losses)
-        self.assertEqual(
-            len(garbage_tensors),
-            0,
-            "Found leaked tensors, check logs above for debug info",
-        )
+                ref_mod.zero_grad()
+                ref_out = ref_mod(x)
+                ref_loss = loss_fn(ref_out, target)
+                ref_loss.backward()
 
-        # Check output
-        torch.testing.assert_close(out, ref_out)
-        # Check loss
-        # Since the reduction used in the loss function above is "sum", we use
-        # "sum" here to reduce microbatch losses into a single value too.
-        pipe_loss = sum(losses)
-        torch.testing.assert_close(pipe_loss, ref_loss)
+            stage_indices = [0]
+            submod_names = [f"layers.{i}" for i in stage_indices]
+            stage_modules = [
+                full_mod.get_submodule(submod_name) for submod_name in submod_names
+            ]
+            # Create a pipeline stage to wrap that submodule
+            num_microbatches = 2
+            stages = [
+                PipelineStage(
+                    stage_module,
+                    stage_idx,
+                    n_stages,
+                    device,
+                )
+                for stage_module, stage_idx in zip(stage_modules, stage_indices)
+            ]
 
-        # Check gradients
-        for stage_module, submod_name in zip(stage_modules, submod_names):
-            # Get corresponding submodule from reference model
-            ref_submod = ref_mod.get_submodule(submod_name)
-            # Check gradients per parameter
-            for name, p in stage_module.named_parameters():
-                ref_p = ref_submod.get_parameter(name)
-                try:
-                    torch.testing.assert_close(p.grad, ref_p.grad, rtol=1e-5, atol=4e-5)
-                except AssertionError:
-                    print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
-                    raise
+            # Attach to a schedule
+            schedule = _PipelineScheduleRuntime(
+                stages,
+                num_microbatches,
+                loss_fn=loss_fn,
+                scale_grads=False,
+            )
+            schedule._prepare_schedule_with_comms(
+                {
+                    0: self._parse_actions(
+                        [
+                            "0F0",
+                            "0F1",
+                            "0I0",
+                            "0I1",
+                            "0W0",
+                            "0W1",
+                        ]
+                    ),
+                },
+                format="compute_comms",
+            )
 
-        torch.distributed.destroy_process_group()
+            # Run
+            with check_leaked_tensors() as garbage_tensors:
+                for _ in range(2):
+                    # Zero gradients
+                    for stage_module in stage_modules:
+                        stage_module.zero_grad()
+                    losses = []
+                    out = schedule.step(x, target=target, losses=losses)
+            self.assertEqual(
+                len(garbage_tensors),
+                0,
+                "Found leaked tensors, check logs above for debug info",
+            )
+
+            # Check output
+            torch.testing.assert_close(out, ref_out)
+            # Check loss
+            # Since the reduction used in the loss function above is "sum", we use
+            # "sum" here to reduce microbatch losses into a single value too.
+            pipe_loss = sum(losses)
+            torch.testing.assert_close(pipe_loss, ref_loss)
+
+            # Check gradients
+            for stage_module, submod_name in zip(stage_modules, submod_names):
+                # Get corresponding submodule from reference model
+                ref_submod = ref_mod.get_submodule(submod_name)
+                # Check gradients per parameter
+                for name, p in stage_module.named_parameters():
+                    ref_p = ref_submod.get_parameter(name)
+                    try:
+                        torch.testing.assert_close(
+                            p.grad, ref_p.grad, rtol=1e-5, atol=4e-5
+                        )
+                    except AssertionError:
+                        print(
+                            f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}"
+                        )
+                        raise
+
+        finally:
+            torch.distributed.destroy_process_group()
 
 
 instantiate_device_type_tests(


### PR DESCRIPTION
## Summary
Add `hw_classification` to `test_schedule.py` and split the two device-exercising grad-correctness methods out of `TestScheduleLowering` into an instantiated `TestScheduleLoweringDevice` (ACCELERATOR) class.

## Changes
- `test/distributed/pipelining/test_schedule.py`:
  - Removed `@requires_accelerator_dist_backend(["nccl", "xccl"])` from `test_grad_with_v_schedule` and `test_grad_with_split_b_w`. Both are single-rank tests against a fake process group (`FakeStore`, `world_size=1`); the decorator was a has-accelerator proxy that skipped them on PrivateUse1 even though the tests need no nccl/xccl backend specifically — only an accelerator device for the fake-PG grad-correctness check.
  - Classified the seven device-agnostic logic classes (`ScheduleTest`, `TestSchedulePlan`, `TestScheduleCsv`, `TestScheduleLowering`, `TestValidateSchedule`, `ScheduleUtilTests`, `TestBatchP2P`) as `HardwareClassification.GENERIC` — they exercise device-agnostic pipeline-schedule logic (plan/csv generation, lowering, validation, batched-p2p dispatch), not device-type behavior.
  - Moved the two grad-correctness methods (which run on the current accelerator and assert pipeline output/loss/grad numerics against a reference) out of `TestScheduleLowering` into a new `TestScheduleLoweringDevice` class classified `HardwareClassification.ACCELERATOR` and instantiated via `instantiate_device_type_tests(except_for=["cpu"], allow_xpu=True)` — the methods take a `device` parameter and run as proper device-type tests on every accelerator variant (cuda/hpu/xpu/privateuse1), skipping cpu (the tests need an accelerator comm backend, which cpu lacks — the legitimate restriction preserved from the original `requires_accelerator_dist_backend`) and keeping xpu (`allow_xpu=True`, which needs opt-in). The now-unused module-level `device` variable is removed (the parameter supplies it), and the pure `_parse_actions` helper shared by both classes is lifted to module level.
  - The classification is metadata: it only filters tests when `--hw-classification` is passed; normal discovery/execution is unchanged. The split preserves every original `def test_*` name (verified identical before/after — no case dropped).

## Motivation
Part of the test-case refactoring initiative (#185590) to decouple tests from hardcoded CUDA/NCCL assumptions so out-of-tree PrivateUse1 accelerators can run the suite. The two grad methods now run on PrivateUse1 instead of being skipped; the classification lets the suite filter by hardware category.

## Notes
This is part of the test case refactoring initiative tracked in #185590.
