### PR TITLE
[Testcase Refactoring] Add proper hw_classification attribute to test classes

### DIFF
--- a/test/inductor/test_op_completeness.py
+++ b/test/inductor/test_op_completeness.py
@@ -7,9 +7,12 @@ from torch._inductor.codegen.mps import MetalOverrides
 from torch._inductor.codegen.triton import TritonKernelOverrides
 from torch._inductor.ops_handler import list_ops, OP_NAMES, OpsHandler
 from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestOpCompleteness(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def verify_ops_handler_completeness(self, handler):
         for op in OP_NAMES:
             self.assertIsNot(


### PR DESCRIPTION
## Summary

Adds hw_classification annotations to test classes and aligning test methods with their hardware classification.

## Changes

- Add `HardwareClassification `to imports from `common_utils`

- Added `hw_classification = HardwareClassification.GENERIC` to `TestOpCompleteness`  to mark the class as device-GENERIC.


## Test plan

`python test/inductor/test_op_completeness.py ` 
`python test/inductor/test_op_completeness.py -v --hw-classification GENERIC` 


## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo