### PR TITLE
Fix example code in symmetric memory docs

### DIFF
--- a/docs/source/symmetric_memory.md
+++ b/docs/source/symmetric_memory.md
@@ -264,7 +264,7 @@ In the example below, tensor `x` will be created from symmetric memory:
     mempool = symm_mem.get_mem_pool(device)
 
     with torch.cuda.use_mem_pool(mempool):
-        x = torch.arange(128, device=device)
+        x = torch.arange(128, device=device, dtype=torch.float32)
 
     torch.ops.symm_mem.one_shot_all_reduce(x, "sum", group_name)
 ```


### PR DESCRIPTION
The current code yields this error:

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/devuser/pytorch/test_symmem.py", line 98, in <module>
[rank0]:     do_mem_pool()
[rank0]:   File "/home/devuser/pytorch/test_symmem.py", line 81, in do_mem_pool
[rank0]:     reduced = torch.ops.symm_mem.one_shot_all_reduce(x, "sum", dist.group.WORLD.group_name)
[rank0]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/devuser/pytorch/torch/_ops.py", line 1350, in __call__
[rank0]:     return self._op(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: NotImplementedError: "one_shot_all_reduce" not implemented for 'Long'
```

As a side question, is a rendezvous call needed here? After the dtype update the code ran successfully.