### PR TITLE
Make linux.dgx.b200 a passthrough instead of an OSDC runner

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -94,15 +94,10 @@ runner_mapping:
   linux.aws.h100.4: l-x86iamx-88-900-h100-4                         # 4 GPUs
   linux.aws.h100.8: l-bx86iamx-176-1800-h100-8                      # 8 GPUs (bare metal)
 
-  # ---- x86 GPU — B200 (p6 family) ----
-
-  linux.dgx.b200: l-x86iamx-22-225-b200                             # p6-b200.48xlarge (1 GPU)
-
   # ---- Partner hardwares ----
 
-  # 8-GPU B200 has OSDC runners, but not enough capacity there yet, so keep it as
-  # a passthrough for now: OSDC builds can run while tests stay on the existing
-  # linux.dgx.b200.8 runner until OSDC capacity is available.
+  # No B200 capacity on OSDC.
+  linux.dgx.b200: linux.dgx.b200
   linux.dgx.b200.8: linux.dgx.b200.8
   linux.idc.xpu: linux.idc.xpu
   linux.client.xpu: linux.client.xpu
@@ -132,4 +127,3 @@ meta_only_runners:
   - linux.aws.h100
   - linux.aws.h100.4
   - linux.aws.h100.8
-  - linux.dgx.b200

--- a/.github/scripts/test_map_ec2_to_arc.py
+++ b/.github/scripts/test_map_ec2_to_arc.py
@@ -221,14 +221,20 @@ def test_h100_with_mt_prefix_idempotent():
     check(output["include"][0]["runner"] == "mt-l-x86iamx-22-225-h100")
 
 
-def test_b200_forces_mt_prefix_overriding_lf():
+def test_b200_passthrough_regardless_of_prefix():
+    """B200 stays on the EC2 runners until OSDC has capacity."""
     matrix = """{ include: [
       { config: "default", shard: 1, num_shards: 1, runner: "lf-linux.dgx.b200" },
+      { config: "default", shard: 1, num_shards: 1, runner: "lf-linux.dgx.b200.8" },
     ]}"""
     result = run(matrix, prefix="lf-")
     check(result.returncode == 0, result.stderr)
     output = parse_output(result.stdout)
-    check(output["include"][0]["runner"] == "mt-l-x86iamx-22-225-b200")
+    runners = [e["runner"] for e in output["include"]]
+    check(
+        runners == ["linux.dgx.b200", "linux.dgx.b200.8"],
+        f"b200 should pass through unprefixed, got {runners}",
+    )
 
 
 def test_non_h100_keeps_lf_prefix():


### PR DESCRIPTION
## Summary

We no longer have B200 capacity on OSDC, so route these tests back to the EC2
runners.

`linux.dgx.b200` mapped to `l-x86iamx-22-225-b200` and was listed in
`meta_only_runners`, which makes `map_ec2_to_arc.py` force the `mt-` prefix
regardless of the build job's fleet. Mapping it to itself and dropping it from
that list makes it a passthrough, matching `linux.dgx.b200.8`.

Affects the B200 jobs in `attention_op_microbenchmark.yml`,
`inductor-perf-test-b200.yml`, `operator_microbenchmark.yml`,
`operator_microbenchmark_compare.yml` and `test-b200.yml`.

Authored with assistance from an AI coding assistant (Claude).
