### PR TITLE
[DCP] Propagate FileSystemWriter background thread exceptions (#191391)

### DIFF
--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -1,7 +1,11 @@
 # Owner(s): ["oncall: distributed"]
 
+import io
+import os
 import sys
 import tempfile
+from collections.abc import Generator
+from contextlib import contextmanager
 from typing import Any, IO
 
 import torch
@@ -23,6 +27,8 @@ from torch.distributed.checkpoint import (
     save_state_dict,
 )
 from torch.distributed.checkpoint._extension import ZStandard
+from torch.distributed.checkpoint.api import CheckpointException
+from torch.distributed.checkpoint.filesystem import FileSystem
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -556,6 +562,40 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     )
 
 
+class _FailingFileSystem(FileSystem):
+    """A FileSystem that raises OSError on write streams."""
+
+    @contextmanager
+    def create_stream(
+        self, path: str | os.PathLike, mode: str
+    ) -> Generator[io.IOBase, None, None]:
+        if "w" in mode:
+            raise OSError("Injected write failure")
+        with super().create_stream(path, mode) as stream:
+            yield stream
+
+
+class TestFileSystemWriterErrorPropagation(TestCase):
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_write_data_propagates_thread_errors(self, thread_count) -> None:
+        """Regression test for gh-191391: background writer thread exceptions must
+        propagate through the returned future, not be silently swallowed."""
+        with tempfile.TemporaryDirectory() as path:
+            state_dict = {"weight": torch.randn(10, 10)}
+            fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+            fs_writer.fs = _FailingFileSystem()
+            with self.assertRaises(CheckpointException) as cm:
+                save_state_dict(
+                    state_dict=state_dict,
+                    storage_writer=fs_writer,
+                    no_dist=True,
+                )
+            rank_0_exc = cm.exception.failures[0][0]
+            self.assertIsInstance(rank_0_exc, OSError)
+            self.assertIn("Injected write failure", str(rank_0_exc))
+
+
+instantiate_parametrized_tests(TestFileSystemWriterErrorPropagation)
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoad)
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoadRot13)
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)

--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -578,8 +578,10 @@ class _FailingFileSystem(FileSystem):
 class TestFileSystemWriterErrorPropagation(TestCase):
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_write_data_propagates_thread_errors(self, thread_count) -> None:
-        """Regression test for gh-191391: background writer thread exceptions must
-        propagate through the returned future, not be silently swallowed."""
+        """Regression test for gh-191391: writer thread exceptions must propagate
+        through the returned future, not be silently swallowed. thread_count=1
+        exercises the calling-thread path; thread_count=2 also exercises a spawned
+        writer thread."""
         with tempfile.TemporaryDirectory() as path:
             state_dict = {"weight": torch.randn(10, 10)}
             fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
@@ -593,6 +595,9 @@ class TestFileSystemWriterErrorPropagation(TestCase):
             rank_0_exc = cm.exception.failures[0][0]
             self.assertIsInstance(rank_0_exc, OSError)
             self.assertIn("Injected write failure", str(rank_0_exc))
+            # finish() must not run on a failed write, so no metadata is published
+            # for the partial checkpoint.
+            self.assertFalse(os.path.exists(os.path.join(path, ".metadata")))
 
 
 instantiate_parametrized_tests(TestFileSystemWriterErrorPropagation)

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -715,49 +715,48 @@ class _FileSystemWriter(StorageWriter):
         file_queue: queue.Queue,
     ) -> Future[list[WriteResult]]:
         result_queue: queue.Queue = queue.Queue()
+        error_queue: queue.Queue = queue.Queue()
+
+        def _target():
+            try:
+                _write_files_from_queue(
+                    create_stream=self.fs.create_stream,
+                    file_queue=file_queue,
+                    result_queue=result_queue,
+                    planner=planner,
+                    transforms=self.transforms,
+                    inflight_threshhold=self.per_thread_copy_ahead,
+                    use_fsync=self.sync_files,
+                    thread_count=self.thread_count,
+                    serialization_format=self.serialization_format,
+                )
+            except Exception as e:
+                error_queue.put(e)
 
         threads = []
         for _ in range(1, self.thread_count):
-            t = threading.Thread(
-                target=_write_files_from_queue,
-                args=(
-                    self.fs.create_stream,
-                    file_queue,
-                    result_queue,
-                    planner,
-                    self.transforms,
-                    self.per_thread_copy_ahead,
-                    self.sync_files,
-                    self.thread_count,
-                    self.serialization_format,
-                ),
-            )
+            t = threading.Thread(target=_target)
             t.start()
             threads.append(t)
 
-        _write_files_from_queue(
-            create_stream=self.fs.create_stream,
-            file_queue=file_queue,
-            result_queue=result_queue,
-            planner=planner,
-            transforms=self.transforms,
-            inflight_threshhold=self.per_thread_copy_ahead,
-            use_fsync=self.sync_files,
-            thread_count=self.thread_count,
-            serialization_format=self.serialization_format,
-        )
+        _target()
 
         for t in threads:
             t.join()
 
-        res = []
+        fut: Future[list[WriteResult]] = Future()
         try:
-            while True:
-                res += result_queue.get_nowait()
+            error = error_queue.get_nowait()
+            fut.set_exception(error)
         except queue.Empty:
-            fut: Future[list[WriteResult]] = Future()
+            res = []
+            try:
+                while True:
+                    res += result_queue.get_nowait()
+            except queue.Empty:
+                pass
             fut.set_result(res)
-            return fut
+        return fut
 
     def finish(self, metadata: Metadata, results: list[list[WriteResult]]) -> None:
         metadata.version = CURRENT_DCP_VERSION


### PR DESCRIPTION
`FileSystemWriter._write_data()` runs `_write_files_from_queue()` on `thread_count - 1` spawned threads plus the calling thread. That function only catches `queue.Empty` (its normal loop-termination signal), so a real error propagates out of it.  On the calling thread that error reached the caller, but on a spawned thread it only reached `threading.excepthook`: `Thread.join()` returns normally whether or not the thread died. `_write_data()` then unconditionally drained `result_queue` and returned a successfully completed future holding however many `WriteResult`s happened to make it in. The caller treats that as a complete write and calls `finish()`, which publishes `.metadata` describing every planned item. An I/O failure is therefore reported as a successful save, and the damage only surfaces later at load time (e.g. a `KeyError` for the missing item).

Fixes: #191391 