### PR TITLE
[Logging] Add register_set_logs_callback() extension point to torch._logging

### DIFF
--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: unknown"]
 
+import contextlib
 import glob
 import gzip
 import logging
@@ -16,6 +17,19 @@ import torch
 import torch._logging._internal as log_internal
 from torch._logging._internal import _init_logs, trace_log, trace_structured
 from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+@contextlib.contextmanager
+def restored_log_state():
+    """Restore the global log state and the set_logs callback list on exit."""
+    old_callbacks = list(log_internal._set_logs_callbacks)
+    old_log_state = log_internal._get_log_state()
+    try:
+        yield
+    finally:
+        log_internal._set_logs_callbacks[:] = old_callbacks
+        log_internal._set_log_state(old_log_state)
+        _init_logs()
 
 
 class LoggingTest(TestCase):
@@ -90,6 +104,80 @@ class LoggingTest(TestCase):
             )
             self.assertIn("issue173759 component log", result.stderr)
             self.assertIn("issue173759 artifact log", result.stderr)
+
+    def test_set_logs_callback_is_invoked(self):
+        with restored_log_state():
+            calls = []
+            log_internal.register_set_logs_callback(lambda: calls.append(None))
+
+            torch._logging.set_logs(dynamo=logging.DEBUG)
+
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(logging.getLogger("torch._dynamo").level, logging.DEBUG)
+
+    def test_set_logs_callback_sees_the_new_log_state(self):
+        # Callbacks run after set_logs has applied its changes, so a backend can
+        # read the final state and mirror it into its own logging system.
+        with restored_log_state():
+            observed = []
+            log_internal.register_set_logs_callback(
+                lambda: observed.append(
+                    dict(log_internal._get_log_state().log_qname_to_level)
+                )
+            )
+
+            torch._logging.set_logs(dynamo=logging.DEBUG)
+
+            self.assertEqual(len(observed), 1)
+            self.assertEqual(observed[0].get("torch._dynamo"), logging.DEBUG)
+
+    def test_set_logs_callback_exception_is_contained(self):
+        with restored_log_state():
+
+            def failing_callback():
+                raise RuntimeError("callback failure")
+
+            calls = []
+            log_internal.register_set_logs_callback(failing_callback)
+            log_internal.register_set_logs_callback(lambda: calls.append(None))
+
+            with self.assertLogs(log_internal.log, level=logging.ERROR) as captured:
+                torch._logging.set_logs(dynamo=logging.DEBUG)
+
+            self.assertTrue(
+                any("callback failure" in message for message in captured.output)
+            )
+            # A failing callback must not stop the remaining ones, nor set_logs itself.
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(logging.getLogger("torch._dynamo").level, logging.DEBUG)
+
+    def test_set_logs_callbacks_skipped_when_env_var_takes_precedence(self):
+        # set_logs returns early when TORCH_LOGS is set, leaving the log state
+        # untouched, so there is nothing for a callback to synchronize.
+        with restored_log_state():
+            old_env = os.environ.get(log_internal.LOG_ENV_VAR)
+            try:
+                os.environ[log_internal.LOG_ENV_VAR] = "+dynamic"
+                calls = []
+                log_internal.register_set_logs_callback(lambda: calls.append(None))
+
+                torch._logging.set_logs(dynamo=logging.DEBUG)
+
+                self.assertEqual(calls, [])
+            finally:
+                if old_env is None:
+                    os.environ.pop(log_internal.LOG_ENV_VAR, None)
+                else:
+                    os.environ[log_internal.LOG_ENV_VAR] = old_env
+
+    def test_register_set_logs_callback_rejects_non_callable(self):
+        with restored_log_state():
+            registered = len(log_internal._set_logs_callbacks)
+
+            with self.assertRaises(TypeError):
+                log_internal.register_set_logs_callback("not a callable")
+
+            self.assertEqual(len(log_internal._set_logs_callbacks), registered)
 
     def testApiUsage(self):
         """

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -33,6 +33,27 @@ _P = ParamSpec("_P")
 
 log = logging.getLogger(__name__)
 
+# Callbacks invoked after every successful set_logs() call. Out-of-tree device
+# backends register a callback here to mirror the Python log
+# state into their own native logging systems, instead of monkey-patching
+# set_logs.
+_set_logs_callbacks: list[Callable[[], None]] = []
+
+
+def register_set_logs_callback(callback: Callable[[], None]) -> None:
+    """
+    Register a callback to be invoked after every successful call to set_logs().
+
+    Intended for out-of-tree backends that need to propagate the Python logging
+    state to their own logging systems. Callbacks take no arguments and their
+    return value is ignored; exceptions raised by a callback are logged and
+    swallowed so they cannot break set_logs() for other callers.
+    """
+    if not callable(callback):
+        raise TypeError(f"expected a callable, got {type(callback)}")
+    _set_logs_callbacks.append(callback)
+
+
 # This is a synthetic logger which doesn't correspond to an actual logger,
 # but handles all of our "tracing" logging, which is structured and doesn't go
 # to stderr but always goes to a dedicated log file.  We don't put these
@@ -602,6 +623,12 @@ def set_logs(
         compute_dependencies=compute_dependencies,
         caching=caching,
     )
+
+    for _callback in _set_logs_callbacks:
+        try:
+            _callback()
+        except Exception:
+            log.exception("set_logs callback %r failed", _callback)
 
 
 def get_loggers() -> list[logging.Logger]:


### PR DESCRIPTION
# Issue

Fixes #191902

## Summary

Out-of-tree device backends need to know when `set_logs()` changes the Python log
state, so they can mirror it into their own native logging systems. The only way to
observe that today is to replace `torch._logging.set_logs` with a wrapper. That is
what torch_npu does, and it has two problems:

- `torch/_logging/__init__.py` re-exports `set_logs`, so `torch._logging.set_logs`
  and `torch._logging._internal.set_logs` are two names for one function. Rebinding
  the first one leaves calls through the second unobserved, and the backend silently
  misses them.
- After the rebind, `inspect.getsource()` / `help()` on `set_logs` report the
  backend's wrapper rather than the real function.

This PR adds a minimal extension point: `register_set_logs_callback()` appends to a
module-level list, and `set_logs()` invokes every registered callback after it has
finished. Callbacks take no arguments, their return value is ignored, and exceptions
are logged and contained so a misbehaving backend cannot break `set_logs()` for other
callers.

Placement note: the loop is the last statement of `set_logs`' body, deliberately
after the early return taken when `LOG_ENV_VAR` is set. In that case `set_logs()`
changes nothing, so there is nothing for a backend to synchronize. The added tests
lock that behavior in.

## Checklist

- [x] Added/updated tests
- [ ] Updated documentation (if applicable) — not applicable, `torch._logging._internal`
      is private


## BC-breaking?

No. Purely additive: without a registered callback the loop iterates over an empty
list and `set_logs()` behaves exactly as before.