### PR TITLE
[AOTI] Fix CPU ISA capability check in _load_aoti to recognize safe supersets (#191713)

### DIFF
--- a/test/export/test_package.py
+++ b/test/export/test_package.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest import mock
 
 import torch
+
 from torch._dynamo.eval_frame import is_dynamo_supported
 from torch._inductor.package import load_package
 from torch.export import Dim
@@ -217,20 +218,19 @@ class TestAOTIPackageDeviceValidation(TestCase):
 
         with (
             mock.patch.object(
-                torch._C._aoti, "AOTIModelPackageLoader", FakeAOTIModelPackageLoaderAvx512
+                torch._C._aoti,
+                "AOTIModelPackageLoader",
+                FakeAOTIModelPackageLoaderAvx512,
             ),
             mock.patch(
                 "torch._inductor.codecache.get_device_information",
                 return_value={"AOTI_CPU_ISA": "AVX2"},
             ),
-            mock.patch(
-                "torch.export.pt2_archive._package.logger.warning"
-            ) as mock_warn,
+            mock.patch("torch.export.pt2_archive._package.logger.warning") as mock_warn,
         ):
             _load_aoti("model.pt2", "model", False, 1, -1)
             mock_warn.assert_called_once()
             self.assertIn("Device information mismatch", mock_warn.call_args[0][0])
-
 
 
 if __name__ == "__main__":

--- a/test/export/test_package.py
+++ b/test/export/test_package.py
@@ -166,6 +166,65 @@ class TestAOTIPackageDeviceValidation(TestCase):
             ):
                 torch._C._aoti.AOTIModelPackageLoader(str(tmp), "model", False, 1, -1)
 
+    def test_is_cpu_isa_compatible(self):
+        from torch._inductor.cpu_vec_isa import is_cpu_isa_compatible
+
+        self.assertTrue(is_cpu_isa_compatible("AVX512 AVX512_VNNI", "AVX2"))
+        self.assertTrue(is_cpu_isa_compatible("AVX512", "AVX2"))
+        self.assertTrue(is_cpu_isa_compatible("AVX2", "AVX2"))
+        self.assertTrue(is_cpu_isa_compatible("ASIMD", "NEON"))
+        self.assertTrue(is_cpu_isa_compatible("SVE", "ASIMD"))
+
+        self.assertFalse(is_cpu_isa_compatible("AVX2", "AVX512"))
+        self.assertFalse(is_cpu_isa_compatible("AVX2", "SVE"))
+
+    def test_aoti_load_cpu_isa_compatibility_warning(self):
+        class FakeAOTIModelPackageLoader:
+            @staticmethod
+            def load_metadata_from_package(file, model_name):
+                return {"AOTI_DEVICE_KEY": "cpu", "AOTI_CPU_ISA": "AVX2"}
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+        with (
+            mock.patch.object(
+                torch._C._aoti, "AOTIModelPackageLoader", FakeAOTIModelPackageLoader
+            ),
+            mock.patch(
+                "torch._inductor.codecache.get_device_information",
+                return_value={"AOTI_CPU_ISA": "AVX512 AVX512_VNNI"},
+            ),
+            mock.patch("torch.export.pt2_archive._package.logger.warning") as mock_warn,
+        ):
+            _load_aoti("model.pt2", "model", False, 1, -1)
+            mock_warn.assert_not_called()
+
+        class FakeAOTIModelPackageLoaderAvx512:
+            @staticmethod
+            def load_metadata_from_package(file, model_name):
+                return {"AOTI_DEVICE_KEY": "cpu", "AOTI_CPU_ISA": "AVX512"}
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+        with (
+            mock.patch.object(
+                torch._C._aoti, "AOTIModelPackageLoader", FakeAOTIModelPackageLoaderAvx512
+            ),
+            mock.patch(
+                "torch._inductor.codecache.get_device_information",
+                return_value={"AOTI_CPU_ISA": "AVX2"},
+            ),
+            mock.patch(
+                "torch.export.pt2_archive._package.logger.warning"
+            ) as mock_warn,
+        ):
+            _load_aoti("model.pt2", "model", False, 1, -1)
+            mock_warn.assert_called_once()
+            self.assertIn("Device information mismatch", mock_warn.call_args[0][0])
+
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/export/test_package.py
+++ b/test/export/test_package.py
@@ -169,14 +169,21 @@ class TestAOTIPackageDeviceValidation(TestCase):
     def test_is_cpu_isa_compatible(self):
         from torch._inductor.cpu_vec_isa import is_cpu_isa_compatible
 
+        # Normal superset cases
         self.assertTrue(is_cpu_isa_compatible("AVX512 AVX512_VNNI", "AVX2"))
         self.assertTrue(is_cpu_isa_compatible("AVX512", "AVX2"))
         self.assertTrue(is_cpu_isa_compatible("AVX2", "AVX2"))
         self.assertTrue(is_cpu_isa_compatible("ASIMD", "NEON"))
-        self.assertTrue(is_cpu_isa_compatible("SVE", "ASIMD"))
 
+        # INVALID_VEC_ISA sentinel: scalar artifact runs anywhere
+        self.assertTrue(is_cpu_isa_compatible("AVX512", "INVALID_VEC_ISA"))
+        # INVALID_VEC_ISA sentinel: unknown host (e.g. no compiler at load time)
+        self.assertTrue(is_cpu_isa_compatible("INVALID_VEC_ISA", "AVX2"))
+        # Both INVALID_VEC_ISA
+        self.assertTrue(is_cpu_isa_compatible("INVALID_VEC_ISA", "INVALID_VEC_ISA"))
+
+        # Incompatible cases
         self.assertFalse(is_cpu_isa_compatible("AVX2", "AVX512"))
-        self.assertFalse(is_cpu_isa_compatible("AVX2", "SVE"))
 
     def test_aoti_load_cpu_isa_compatibility_warning(self):
         class FakeAOTIModelPackageLoader:

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -13,6 +13,7 @@ from typing import Any
 import torch
 from torch._inductor import config
 from torch._inductor.utils import python_subprocess_env
+from torch.utils._ordered_set import OrderedSet
 
 
 _IS_WINDOWS = sys.platform == "win32"
@@ -626,24 +627,28 @@ def is_cpu_isa_compatible(host_isa: str, artifact_isa: str) -> bool:
     if artifact_isa.lower() == _INVALID or host_isa.lower() == _INVALID:
         return True
 
-    host_tokens = set(host_isa.lower().split())
-    artifact_tokens = set(artifact_isa.lower().split())
+    host_tokens = OrderedSet(host_isa.lower().split())
+    artifact_tokens = OrderedSet(artifact_isa.lower().split())
 
     if artifact_tokens.issubset(host_tokens):
         return True
 
-    expanded_host_tokens = set(host_tokens)
+    expanded_host_tokens = OrderedSet(host_tokens)
 
     # neon/asimd are two names for the same ARMv8 SIMD extension.
     if "neon" in host_tokens or "asimd" in host_tokens:
-        expanded_host_tokens.update({"neon", "asimd"})
+        expanded_host_tokens.update(OrderedSet(["neon", "asimd"]))
 
     # x86 SIMD hierarchy: VecISA.__str__ already chains tokens cumulatively
     # (VecAMX.__str__ == "avx512 avx512_vnni amx_tile"), so a host string from
     # pick_vec_isa() already contains all implied tokens.  The expansion below
     # is still needed for strings sourced from AOTI_CPU_ISA metadata (which
     # stores only the highest-capability token).
-    if "avx512" in host_tokens or "avx512_vnni" in host_tokens or "amx_tile" in host_tokens:
+    if (
+        "avx512" in host_tokens
+        or "avx512_vnni" in host_tokens
+        or "amx_tile" in host_tokens
+    ):
         expanded_host_tokens.add("avx2")
     if "avx512_vnni" in host_tokens or "amx_tile" in host_tokens:
         expanded_host_tokens.add("avx512")

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -608,8 +608,22 @@ def is_cpu_isa_compatible(host_isa: str, artifact_isa: str) -> bool:
     For example, a host with AVX512 (or AVX512_VNNI, AMX_TILE) capability can run
     artifacts compiled for AVX2. However, a host with AVX2 cannot run artifacts
     compiled for AVX512.
+
+    The sentinel string ``"INVALID_VEC_ISA"`` (emitted by ``InvalidVecISA.__str__``)
+    is handled specially:
+    - An artifact built with no vectorisation (INVALID_VEC_ISA) runs correctly on
+      any host, so the function always returns True.
+    - A host that reports INVALID_VEC_ISA (e.g. no C++ compiler available at load
+      time, so ``valid_vec_isa_list`` dry-compiles nothing) is *unknown*, not known-
+      incapable; returning True avoids spurious warnings on capable hardware that
+      simply lacks a toolchain at inference time.
     """
+    _INVALID = "invalid_vec_isa"
+
     if not artifact_isa or not host_isa:
+        return True
+
+    if artifact_isa.lower() == _INVALID or host_isa.lower() == _INVALID:
         return True
 
     host_tokens = set(host_isa.lower().split())
@@ -620,26 +634,23 @@ def is_cpu_isa_compatible(host_isa: str, artifact_isa: str) -> bool:
 
     expanded_host_tokens = set(host_tokens)
 
-    # Alias mappings
+    # neon/asimd are two names for the same ARMv8 SIMD extension.
     if "neon" in host_tokens or "asimd" in host_tokens:
         expanded_host_tokens.update({"neon", "asimd"})
 
-    # x86 SIMD hierarchy
-    if any(t in host_tokens for t in ("amx_tile", "avx512_vnni", "avx512")):
+    # x86 SIMD hierarchy: VecISA.__str__ already chains tokens cumulatively
+    # (VecAMX.__str__ == "avx512 avx512_vnni amx_tile"), so a host string from
+    # pick_vec_isa() already contains all implied tokens.  The expansion below
+    # is still needed for strings sourced from AOTI_CPU_ISA metadata (which
+    # stores only the highest-capability token).
+    if "avx512" in host_tokens or "avx512_vnni" in host_tokens or "amx_tile" in host_tokens:
         expanded_host_tokens.add("avx2")
-
-    if any(t in host_tokens for t in ("amx_tile", "avx512_vnni")):
+    if "avx512_vnni" in host_tokens or "amx_tile" in host_tokens:
         expanded_host_tokens.add("avx512")
-
     if "amx_tile" in host_tokens:
         expanded_host_tokens.add("avx512_vnni")
 
-    # ARM hierarchy
-    if any(t.startswith("sve") for t in host_tokens):
-        expanded_host_tokens.update({"neon", "asimd"})
-
     return artifact_tokens.issubset(expanded_host_tokens)
-
 
 
 # Cache the cpuinfo to avoid I/O overhead. Meanwhile, the cpuinfo content

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -601,6 +601,47 @@ def get_isa_from_cpu_capability(
     return vec_isa_list[0]
 
 
+def is_cpu_isa_compatible(host_isa: str, artifact_isa: str) -> bool:
+    """Checks if host_isa capability is compatible with (equal to or a superset of)
+    artifact_isa capability.
+
+    For example, a host with AVX512 (or AVX512_VNNI, AMX_TILE) capability can run
+    artifacts compiled for AVX2. However, a host with AVX2 cannot run artifacts
+    compiled for AVX512.
+    """
+    if not artifact_isa or not host_isa:
+        return True
+
+    host_tokens = set(host_isa.lower().split())
+    artifact_tokens = set(artifact_isa.lower().split())
+
+    if artifact_tokens.issubset(host_tokens):
+        return True
+
+    expanded_host_tokens = set(host_tokens)
+
+    # Alias mappings
+    if "neon" in host_tokens or "asimd" in host_tokens:
+        expanded_host_tokens.update({"neon", "asimd"})
+
+    # x86 SIMD hierarchy
+    if any(t in host_tokens for t in ("amx_tile", "avx512_vnni", "avx512")):
+        expanded_host_tokens.add("avx2")
+
+    if any(t in host_tokens for t in ("amx_tile", "avx512_vnni")):
+        expanded_host_tokens.add("avx512")
+
+    if "amx_tile" in host_tokens:
+        expanded_host_tokens.add("avx512_vnni")
+
+    # ARM hierarchy
+    if any(t.startswith("sve") for t in host_tokens):
+        expanded_host_tokens.update({"neon", "asimd"})
+
+    return artifact_tokens.issubset(expanded_host_tokens)
+
+
+
 # Cache the cpuinfo to avoid I/O overhead. Meanwhile, the cpuinfo content
 # might have too much redundant content that is useless for ISA check. Hence,
 # we only cache some key isa information.

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -1068,6 +1068,13 @@ def _load_aoti(
     for k, v in current_device_info.items():
         if k in loaded_metadata:
             if v != loaded_metadata[k]:
+                if k == "AOTI_CPU_ISA":
+                    from torch._inductor.cpu_vec_isa import is_cpu_isa_compatible
+
+                    if is_cpu_isa_compatible(
+                        host_isa=v, artifact_isa=loaded_metadata[k]
+                    ):
+                        continue
                 logger.warning(
                     "Device information mismatch for %s: %s vs %s. "
                     "This could cause some issues when loading the AOTInductor compiled artifacts.",


### PR DESCRIPTION
### Summary
When loading an AOTInductor compiled package, `_load_aoti` compares host device info (`current_device_info`) with package metadata (`loaded_metadata`). Currently, `_load_aoti` performs a strict string equality check (`v != loaded_metadata[k]`) for `AOTI_CPU_ISA`.

When an artifact is compiled with a minimum ISA target (e.g., `AVX2` or `cpp.simdlen=256`) for fleet compatibility and loaded on a host with higher CPU capabilities (e.g. `AVX512`), the strict check triggers an advisory "Device information mismatch" warning on every load.

However, loading an `AVX2` artifact on an `AVX512` host is completely safe (the host CPU capability is a strict superset of the artifact capability). The warning should only trigger when the host CPU lacks the required ISA (e.g. loading an `AVX512` artifact on an `AVX2` host), which would result in SIGILL.

This PR adds `is_cpu_isa_compatible()` in `torch._inductor.cpu_vec_isa` to compare CPU ISA capabilities hierarchically and suppresses false-positive warnings when the host ISA is compatible with the artifact ISA.

Fixes #191713

### Test Plan
Added unit tests in `TestAOTIPackageDeviceValidation` in `test/export/test_package.py`:
- `test_is_cpu_isa_compatible`: Tests `is_cpu_isa_compatible` for x86 (AVX512 vs AVX2), ARM (SVE vs ASIMD vs NEON), exact matches, and incompatible combinations.
- `test_aoti_load_cpu_isa_compatibility_warning`: Verifies that `_load_aoti` suppresses warnings when host ISA is a compatible superset (e.g., host AVX512 vs artifact AVX2) and still emits warnings when host ISA is incompatible (e.g., host AVX2 vs artifact AVX512).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo