### PR TITLE
[Testcase Refactoring] Add hw_classification and split device-dependent test in test_multi_threaded_pg

### DIFF
--- a/test/distributed/test_multi_threaded_pg.py
+++ b/test/distributed/test_multi_threaded_pg.py
@@ -17,20 +17,26 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     MultiThreadedTestCase,
     skip_if_lt_x_gpu,
     spawn_threads_and_init_comms,
 )
-from torch.testing._internal.common_utils import IS_SANDCASTLE, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_SANDCASTLE,
+    run_tests,
+    TestCase,
+)
 
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 DEFAULT_WORLD_SIZE = 4
 
 
 class TestCollectivesWithWrapper(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @spawn_threads_and_init_comms(world_size=4)
     def test_broadcast_object_list(self):
         val = 99 if dist.get_rank() == 0 else None
@@ -135,7 +141,7 @@ class TestCollectivesWithWrapper(TestCase):
         self.assertEqual(out.tolist(), list(zip(range(world_size), range(world_size))))
 
 
-class TestCollectivesWithBaseClass(MultiThreadedTestCase):
+class _TestCollectivesBase(MultiThreadedTestCase):
     @property
     def world_size(self):
         return 4
@@ -148,6 +154,10 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
     def tearDown(self):
         super().tearDown()
         os.environ["TORCH_DIST_INIT_BARRIER"] = "0"
+
+
+class TestCollectivesWithBaseClass(_TestCollectivesBase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_allgather(self):
         input_tensor = torch.ones(3, 3) * dist.get_rank()
@@ -301,8 +311,12 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
         self.assertEqual(t0, torch.ones(3, 3) * res_num)
         self.assertEqual(t1, torch.ones(3, 3) * (res_num * 2))
 
+
+class TestCollectivesWithBaseClassDevice(_TestCollectivesBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @skip_if_lt_x_gpu(1)
-    def test_bwd_sees_fwd_pg(self):
+    def test_bwd_sees_fwd_pg(self, device):
         fwd_tid = threading.current_thread().ident
 
         class MyFunc(torch.autograd.Function):
@@ -335,11 +349,14 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
                 return grad_output * result
 
         x = torch.tensor(
-            [dist.get_rank()], dtype=torch.float, device=device_type, requires_grad=True
+            [dist.get_rank()], dtype=torch.float, device=device, requires_grad=True
         )
         x = MyFunc.apply(x)
         x.sum().backward()
 
 
+instantiate_device_type_tests(
+    TestCollectivesWithBaseClassDevice, globals(), except_for=("cpu",), allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_multi_threaded_pg.py
+++ b/test/distributed/test_multi_threaded_pg.py
@@ -17,20 +17,25 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     MultiThreadedTestCase,
-    skip_if_lt_x_gpu,
     spawn_threads_and_init_comms,
 )
-from torch.testing._internal.common_utils import IS_SANDCASTLE, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_SANDCASTLE,
+    run_tests,
+    TestCase,
+)
 
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 DEFAULT_WORLD_SIZE = 4
 
 
 class TestCollectivesWithWrapper(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @spawn_threads_and_init_comms(world_size=4)
     def test_broadcast_object_list(self):
         val = 99 if dist.get_rank() == 0 else None
@@ -135,7 +140,7 @@ class TestCollectivesWithWrapper(TestCase):
         self.assertEqual(out.tolist(), list(zip(range(world_size), range(world_size))))
 
 
-class TestCollectivesWithBaseClass(MultiThreadedTestCase):
+class _TestCollectivesBase(MultiThreadedTestCase):
     @property
     def world_size(self):
         return 4
@@ -148,6 +153,10 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
     def tearDown(self):
         super().tearDown()
         os.environ["TORCH_DIST_INIT_BARRIER"] = "0"
+
+
+class TestCollectivesWithBaseClass(_TestCollectivesBase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_allgather(self):
         input_tensor = torch.ones(3, 3) * dist.get_rank()
@@ -301,8 +310,11 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
         self.assertEqual(t0, torch.ones(3, 3) * res_num)
         self.assertEqual(t1, torch.ones(3, 3) * (res_num * 2))
 
-    @skip_if_lt_x_gpu(1)
-    def test_bwd_sees_fwd_pg(self):
+
+class TestCollectivesWithBaseClassDevice(_TestCollectivesBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_bwd_sees_fwd_pg(self, device):
         fwd_tid = threading.current_thread().ident
 
         class MyFunc(torch.autograd.Function):
@@ -335,11 +347,14 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
                 return grad_output * result
 
         x = torch.tensor(
-            [dist.get_rank()], dtype=torch.float, device=device_type, requires_grad=True
+            [dist.get_rank()], dtype=torch.float, device=device, requires_grad=True
         )
         x = MyFunc.apply(x)
         x.sum().backward()
 
 
+instantiate_device_type_tests(
+    TestCollectivesWithBaseClassDevice, globals(), except_for=("cpu",), allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
Split the device-dependent test_bwd_sees_fwd_pg out of the mixed TestCollectivesWithBaseClass into a dedicated ACCELERATOR class instantiated via instantiate_device_type_tests, and label the CPU-only collective classes GENERIC, so the threaded-collective tests are correctly classified under --hw-classification filtering and run on-device via an injected device parameter instead of a module-level device string.

## Changes
- **`test/distributed/test_multi_threaded_pg.py`**:
  - Labeled `TestCollectivesWithWrapper` and `TestCollectivesWithBaseClass` with `hw_classification = HardwareClassification.GENERIC` (device-agnostic threaded-collective logic on CPU tensors).
  - Moved `test_bwd_sees_fwd_pg` (requires an accelerator; asserts that autograd backward runs in the same thread as forward and can still see the process group on a device tensor) out of `TestCollectivesWithBaseClass` into a new parallel `TestCollectivesWithBaseClassDevice` class labeled `hw_classification = HardwareClassification.ACCELERATOR`.
  - Extracted a shared `_TestCollectivesBase(MultiThreadedTestCase)` fixture base holding `world_size` / `setUp` / `tearDown` (the `TORCH_DIST_INIT_BARRIER` env setup plus `_spawn_threads`); both `TestCollectivesWithBaseClass` and `TestCollectivesWithBaseClassDevice` inherit it. The base has no `test_*` methods, so unittest does not collect it and `--hw-classification` filtering does not scan it; no `hw_classification` label is needed on it.
  - `test_bwd_sees_fwd_pg` now takes a `device` parameter, and `TestCollectivesWithBaseClassDevice` is instantiated via `instantiate_device_type_tests(..., except_for=("cpu",), allow_xpu=True)`. The `device` is injected per-variant rather than read from a module-level device string.
  - Removed the module-level `device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"` string and the pre-existing `@skip_if_lt_x_gpu(1)` decorator on `test_bwd_sees_fwd_pg` (plus its `skip_if_lt_x_gpu` import). On a CPU-only host the method is no longer collected because `except_for=("cpu",)` excludes the CPU variant at instantiation time; on an accelerator host only the accelerator variant is generated and runs with the injected `device`. This matches the original behavior (the test ran once on the available accelerator) while extending coverage to other accelerators beyond CUDA.


## Motivation
`TestCollectivesWithBaseClass` was a mixed class: 17 CPU threaded-collective methods plus one accelerator-dependent method (`test_bwd_sees_fwd_pg`). Under `--hw-classification` filtering such a mixed class cannot be classified unambiguously, and the accelerator method resolved its device from a module-level string (`device_type = acc.type if ...`) rather than the per-variant `device` parameter injected by `instantiate_device_type_tests` — so non-default device variants would use the wrong device. Splitting the class by hardware dependency and instantiating the ACCELERATOR class with an injected `device` parameter makes the classification unambiguous and aligns with the TEST_LINTER direction (PR #190173): instantiated, `device` param on every `test_*`, no `only_for`.

The `@skip_if_lt_x_gpu(1)` → `except_for=("cpu",)` change also fixes a behavior divergence surfaced in review: with `except_for` removed, a CPU variant would be generated on a GPU host and run with `device="cpu"` (since `@skip_if_lt_x_gpu(1)` only checks accelerator availability, not whether the current variant is an accelerator), diverging from the original single-on-accelerator run. `except_for=("cpu",)` keeps the original behavior by excluding the CPU variant at instantiation time.


## Test Plan
Verified on an 8-device accelerator backend with the threaded reference PG (the `HardwareClassification` infrastructure from #186918 are pre-applied on the verify host):

```bash
python test/distributed/test_multi_threaded_pg.py
# Ran 22 tests in 1.014s — OK

python test/distributed/test_multi_threaded_pg.py --hw-classification GENERIC ACCELERATOR
# total=22, passed=22, unclassified=0, mismatched=0

python test/distributed/test_multi_threaded_pg.py --hw-classification GENERIC
# total=22, passed=21, mismatched=1 (the ACCELERATOR class excluded, as expected)
```

## Notes
- This is part of the test case refactoring initiative tracked in #185590.