### PR TITLE
[Testcase Refactoring] Tag device-agnostic DCP test classes with hw_classification

### DIFF
--- a/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
@@ -20,7 +20,11 @@ from torch.distributed.checkpoint._experimental.checkpoint_writer import (
     CheckpointWriterConfig,
 )
 from torch.distributed.checkpoint._experimental.types import RankInfo
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def subprocess_init_fn(name: str, parent_pid: int) -> None:
@@ -117,6 +121,8 @@ def shared_tensor_verifier_init_fn(**kwargs: Any) -> CheckpointWriter:
 class TestRequestTypes(TestCase):
     """Test the request/response data structures."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_request_type_enum(self) -> None:
         """Test RequestType enum values."""
         self.assertEqual(RequestType.PING.value, "ping")
@@ -146,6 +152,8 @@ class TestRequestTypes(TestCase):
 class TestCheckpointProcessConfig(TestCase):
     """Test CheckpointProcessConfig configuration."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_default_options(self) -> None:
         """Test default CheckpointProcessConfig."""
         options = CheckpointProcessConfig()
@@ -163,6 +171,8 @@ class TestCheckpointProcessConfig(TestCase):
 
 
 class TestCheckpointProcess(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         """Set up common test fixtures."""

--- a/test/distributed/checkpoint/test_planner.py
+++ b/test/distributed/checkpoint/test_planner.py
@@ -49,6 +49,7 @@ from torch.distributed.checkpoint.planner_helpers import (
     create_read_items_for_chunk_list,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
     TestCase,
@@ -166,6 +167,8 @@ class TestCheckpointableTensorDistributed(DTensorTestBase):
 
 
 class TestSavePlan(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @with_fake_comms(rank=1, world_size=4)
     def test_local_plan(self):
         tensor = torch.rand(10)
@@ -620,6 +623,8 @@ class TestSavePlan(TestCase):
 
 
 class TestPlannerHelpers(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_create_read_item_from_chunks(self):
         tensor_md = TensorStorageMetadata(
             properties=TensorProperties.create_from_tensor(torch.empty([16])),
@@ -713,6 +718,8 @@ class TestPlannerHelpers(TestCase):
 
 
 class TestValidateGlobalPlan(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _make_metadata(self, chunks, size):
         storage = TensorStorageMetadata(
             properties=TensorProperties(dtype=torch.float32),
@@ -739,6 +746,8 @@ class TestValidateGlobalPlan(TestCase):
 
 
 class TestLoadPlanner(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @with_temp_dir
     def test_strict(self):
         original_module = nn.Linear(2, 2)

--- a/test/distributed/checkpoint/test_planner.py
+++ b/test/distributed/checkpoint/test_planner.py
@@ -48,6 +48,7 @@ from torch.distributed.checkpoint.planner_helpers import (
     _merge_delta_local_plans,
     create_read_items_for_chunk_list,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -104,6 +105,11 @@ def create_sharded_tensor(rank, world_size, shards_per_rank, shard_size=8):
 
 
 class TestCheckpointableTensorDistributed(DTensorTestBase):
+    # `device_type` is hard-coded to "cpu" below rather than derived from
+    # whatever accelerator is present, so this is tied to CPU by
+    # construction -- CPU, not GENERIC.
+    hw_classification = HardwareClassification.CPU
+
     @property
     def world_size(self) -> int:
         return 4
@@ -114,7 +120,7 @@ class TestCheckpointableTensorDistributed(DTensorTestBase):
 
     @with_comms
     @with_temp_dir
-    def test_checkpointable_tensor_shard_save_load(self):
+    def test_checkpointable_tensor_shard_save_load(self, device):
         shard_size = 4
         rank = dist.get_rank()
         start = rank * shard_size
@@ -798,5 +804,8 @@ class TestLoadPlanner(TestCase):
         self.assertEqual(planner.metadata.version, CURRENT_DCP_VERSION)
 
 
+instantiate_device_type_tests(
+    TestCheckpointableTensorDistributed, globals(), only_for="cpu"
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_planner.py
+++ b/test/distributed/checkpoint/test_planner.py
@@ -105,18 +105,25 @@ def create_sharded_tensor(rank, world_size, shards_per_rank, shard_size=8):
 
 
 class TestCheckpointableTensorDistributed(DTensorTestBase):
-    # `device_type` is hard-coded to "cpu" below rather than derived from
-    # whatever accelerator is present, so this is tied to CPU by
-    # construction -- CPU, not GENERIC.
+    # Deliberately CPU, not GENERIC or ACCELERATOR: the test always wants
+    # "cpu" regardless of what accelerator is present, not whatever
+    # `DTensorTestMixin.device_type` would dynamically pick.
+    #
+    # Do NOT add a `device_type` property/classmethod here to pin it: this
+    # class's own dict is scanned by `instantiate_device_type_tests` and any
+    # `device_type` found there is copied verbatim onto the generated
+    # `...CPU` class, shadowing `CPUTestBase.device_type = "cpu"` with the
+    # raw (non-string) descriptor and crashing "_" + cls.device_type with
+    # "can only concatenate str (not 'property') to str". `only_for="cpu"`
+    # below already pins device_type to "cpu" the correct way, through
+    # CPUTestBase, which precedes DTensorTestMixin in the generated class's
+    # MRO -- so `self.device_type` still resolves to "cpu" without an
+    # explicit override.
     hw_classification = HardwareClassification.CPU
 
     @property
     def world_size(self) -> int:
         return 4
-
-    @property
-    def device_type(self) -> str:
-        return "cpu"
 
     @with_comms
     @with_temp_dir

--- a/test/distributed/checkpoint/test_traverse.py
+++ b/test/distributed/checkpoint/test_traverse.py
@@ -5,7 +5,11 @@ from typing import TYPE_CHECKING
 
 import torch
 import torch.distributed.checkpoint._traverse as _traverse
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 if TYPE_CHECKING:
@@ -16,6 +20,8 @@ class TestTraverse(TestCase):
     """
     Test class for util methods of _traverse
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_traverse_shallow(self) -> None:
         state_dict = {


### PR DESCRIPTION
<!-- PR title: [Test] Tag device-agnostic DCP test classes with hw_classification -->

## Summary

Add `hw_classification = HardwareClassification.GENERIC` to the 8
`TestCase` subclasses in `test/distributed/checkpoint/test_planner.py`,
`test/distributed/checkpoint/test_traverse.py`, and
`test/distributed/checkpoint/_experimental/test_checkpoint_process.py`
that have no device dependency.

## Motivation

Enables `--hw-classification` filtering (introduced in #186918) to
correctly identify these classes as accelerator-independent. All three
files were audited class-by-class: none of the touched classes construct
tensors on a specific device, call any accelerator API, or use
`instantiate_device_type_tests`/`DistributedTestBase`/
`MultiProcessTestCase`. `test_planner.py`'s
`TestCheckpointableTensorDistributed` (a `DTensorTestBase` subclass) is
intentionally left untouched in this PR — out of scope for this change.

## Changes

- `test_planner.py`: `TestSavePlan`, `TestPlannerHelpers`,
  `TestValidateGlobalPlan`, `TestLoadPlanner` -> `GENERIC`.
- `test_traverse.py`: `TestTraverse` -> `GENERIC`.
- `_experimental/test_checkpoint_process.py`: `TestRequestTypes`,
  `TestCheckpointProcessConfig`, `TestCheckpointProcess` -> `GENERIC`.

No behavior change (metadata-only attribute addition).

## Test Plan

NPU/HCCL:

- `test/distributed/checkpoint/test_planner.py`: 18 tests passed
- `test/distributed/checkpoint/test_traverse.py`: 7 tests passed
- `test/distributed/checkpoint/_experimental/test_checkpoint_process.py`: 15 tests passed

CPU: not independently re-run for this PR; the change adds a class
attribute only and does not affect test discovery or execution when
`--hw-classification` is not passed.

## Related

Related to #185590.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian
