### PR TITLE
[Test][XPU] Enable nn and profiler tests for XPU

### DIFF
--- a/test/nn/test_load_state_dict.py
+++ b/test/nn/test_load_state_dict.py
@@ -440,7 +440,14 @@ class TestLoadStateDict(NNTestCase):
         with torch.device("meta"):
             m = torch.nn.Linear(3, 5)
         state_dict = m.state_dict()
-        state_dict["weight"] = torch.empty_like(state_dict["weight"], device="cpu")
+        runtime_device = (
+            torch.device("xpu")
+            if hasattr(torch, "xpu") and torch.xpu.is_available()
+            else torch.device("cpu")
+        )
+        state_dict["weight"] = torch.empty_like(
+            state_dict["weight"], device=runtime_device
+        )
         with self.assertWarnsRegex(
             UserWarning,
             "for weight: copying from a non-meta parameter in the checkpoint to a meta",

--- a/test/nn/test_module_hooks.py
+++ b/test/nn/test_module_hooks.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import torch
 import torch.nn as nn
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_nn import _create_basic_net, NNTestCase
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -1257,25 +1258,28 @@ class TestModuleHookNN(NNTestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
-    def _test_hooks(self, backward_register_fn):
-        module = nn.Sigmoid()
-        input = torch.ones(5, 5, requires_grad=True)
+    def _test_hooks(self, backward_register_fn, device):
+        module = nn.Sigmoid().to(device)
+        input = torch.ones(5, 5, requires_grad=True, device=device)
 
         counter = {"forwards": 0, "backwards": 0}
 
-        def fw_hook(inc, h_module, input, output):
-            self.assertIsInstance(input, tuple)
+        def fw_hook(inc, h_module, hook_input, output):
+            self.assertIsInstance(hook_input, tuple)
             self.assertTrue(isinstance(output, torch.Tensor))
             self.assertTrue(h_module is module)
-            self.assertEqual(input[0], torch.ones(5, 5))
-            self.assertEqual(output, torch.empty(5, 5).fill_(1 / (1 + 1 / math.e)))
+            self.assertEqual(hook_input[0], torch.ones(5, 5, device=device))
+            self.assertEqual(
+                output,
+                torch.empty(5, 5, device=device).fill_(1 / (1 + 1 / math.e)),
+            )
             counter["forwards"] += inc
 
         def bw_hook(inc, h_module, grad_input, grad_output):
             self.assertIsInstance(grad_input, tuple)
             self.assertIsInstance(grad_output, tuple)
             self.assertTrue(h_module is module)
-            self.assertEqual(grad_output[0], torch.ones(5, 5) * 2)
+            self.assertEqual(grad_output[0], torch.ones(5, 5, device=device) * 2)
             counter["backwards"] += inc
 
         # backward_pre_hook expects callback with only `module` and `grad_output`
@@ -1283,7 +1287,7 @@ class TestModuleHookNN(NNTestCase):
         def bw_pre_hook(inc, h_module, grad_output):
             self.assertIsInstance(grad_output, tuple)
             self.assertTrue(h_module is module)
-            self.assertEqual(grad_output[0], torch.ones(5, 5) * 2)
+            self.assertEqual(grad_output[0], torch.ones(5, 5, device=device) * 2)
             counter["backwards"] += inc
 
         test_fwd = module.register_forward_hook(lambda *args: fw_hook(1, *args))
@@ -1306,11 +1310,11 @@ class TestModuleHookNN(NNTestCase):
         self.assertEqual(counter["forwards"], 3)
         self.assertEqual(counter["backwards"], 0)
 
-        output.backward(torch.ones(5, 5) * 2, retain_graph=True)
+        output.backward(torch.ones(5, 5, device=device) * 2, retain_graph=True)
         self.assertEqual(counter["forwards"], 3)
         self.assertEqual(counter["backwards"], 1)
 
-        output.backward(torch.ones(5, 5) * 2, retain_graph=True)
+        output.backward(torch.ones(5, 5, device=device) * 2, retain_graph=True)
         self.assertEqual(counter["forwards"], 3)
         self.assertEqual(counter["backwards"], 2)
 
@@ -1324,32 +1328,32 @@ class TestModuleHookNN(NNTestCase):
             lambda *args: bw_hook_fn(2, *args)
         )
 
-        module(input).backward(torch.ones(5, 5) * 2)
+        module(input).backward(torch.ones(5, 5, device=device) * 2)
         self.assertEqual(counter["forwards"], 9)
         self.assertEqual(counter["backwards"], 5)
 
         test2_bwd.remove()
 
-        module(input).backward(torch.ones(5, 5) * 2)
+        module(input).backward(torch.ones(5, 5, device=device) * 2)
         self.assertEqual(counter["forwards"], 12)
         self.assertEqual(counter["backwards"], 6)
 
         test2_fwd.remove()
 
-        module(input).backward(torch.ones(5, 5) * 2)
+        module(input).backward(torch.ones(5, 5, device=device) * 2)
         self.assertEqual(counter["forwards"], 13)
         self.assertEqual(counter["backwards"], 7)
 
         test_fwd.remove()
         test_bwd.remove()
 
-    def test_hooks(self):
-        self._test_hooks("register_backward_hook")
-        self._test_hooks("register_full_backward_hook")
-        self._test_hooks("register_full_backward_pre_hook")
+    def test_hooks(self, device):
+        self._test_hooks("register_backward_hook", device)
+        self._test_hooks("register_full_backward_hook", device)
+        self._test_hooks("register_full_backward_pre_hook", device)
 
-    def test_hook_cpp(self):
-        bn = nn.BatchNorm1d(5)
+    def test_hook_cpp(self, device):
+        bn = nn.BatchNorm1d(5).to(device)
 
         def hook(module, grad_inputs, grad_outputs):
             self.assertEqual(len(grad_inputs), 1)
@@ -1357,7 +1361,7 @@ class TestModuleHookNN(NNTestCase):
             self.assertEqual(module, bn)
 
         bn.register_full_backward_hook(hook)
-        output = bn(torch.randn(5, 5, requires_grad=True))
+        output = bn(torch.randn(5, 5, requires_grad=True, device=device))
         output.sum().backward()
 
     def test_backward_hooks_interaction(self):
@@ -1681,9 +1685,9 @@ class TestModuleHookNN(NNTestCase):
         expected_grad = sig_x * (1 - sig_x) * 2
         self.assertEqual(input.grad, expected_grad)
 
-    def test_hook_forward_preforward_writable(self):
-        module = nn.Sigmoid()
-        input = torch.randn(5, 5, requires_grad=True)
+    def test_hook_forward_preforward_writable(self, device):
+        module = nn.Sigmoid().to(device)
+        input = torch.randn(5, 5, requires_grad=True, device=device)
         sig_x = torch.nn.functional.sigmoid(input)
 
         def forward_pre_hook(m, input):
@@ -1697,7 +1701,7 @@ class TestModuleHookNN(NNTestCase):
         output = module(input)
         expected_res = -torch.nn.functional.sigmoid(torch.nn.functional.relu(input))
         self.assertEqual(output, expected_res)
-        output.backward(torch.ones(5, 5) * 2, retain_graph=True)
+        output.backward(torch.ones(5, 5, device=device) * 2, retain_graph=True)
         mask = input > 0
         expected_grad = -sig_x * (1 - sig_x) * 2 * mask
         self.assertEqual(input.grad, expected_grad)
@@ -1759,9 +1763,9 @@ class TestModuleHookNN(NNTestCase):
             finally:
                 handle.remove()
 
-
 instantiate_parametrized_tests(TestModuleHooks)
 instantiate_parametrized_tests(TestStateDictHooks)
+instantiate_device_type_tests(TestModuleHookNN, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/nn/test_pruning.py
+++ b/test/nn/test_pruning.py
@@ -6,6 +6,7 @@ import unittest.mock as mock
 import torch
 import torch.nn as nn
 import torch.nn.utils.prune as prune
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -157,10 +158,10 @@ class TestPruningNN(NNTestCase):
                         * getattr(m, name + "_mask").to(dtype=original_tensor.dtype),
                     )
 
-    def test_identity_pruning(self):
+    def test_identity_pruning(self, device):
         r"""Test that a mask of 1s does not change forward or backward."""
-        input_ = torch.ones(1, 5)
-        m = nn.Linear(5, 2)
+        input_ = torch.ones(1, 5, device=device)
+        m = nn.Linear(5, 2).to(device)
         y_prepruning = m(input_)  # output prior to pruning
 
         # compute grad pre-pruning and check it's equal to all ones
@@ -229,9 +230,9 @@ class TestPruningNN(NNTestCase):
         y2 = m(input_)
         self.assertEqual(y1, y2)
 
-    def test_random_pruning(self):
-        input_ = torch.ones(1, 5)
-        m = nn.Linear(5, 2)
+    def test_random_pruning(self, device):
+        input_ = torch.ones(1, 5, device=device)
+        m = nn.Linear(5, 2).to(device)
 
         # define custom mask to assign with mock
         mask = torch.ones_like(m.weight)
@@ -281,12 +282,12 @@ class TestPruningNN(NNTestCase):
         self.assertEqual(yhat[0, 0], m.weight_orig[0, 3] + m.bias[0])
         self.assertEqual(yhat[0, 1], m.weight_orig[1, 0] + m.bias[1])
 
-    def test_remove_pruning_forward(self):
+    def test_remove_pruning_forward(self, device):
         r"""Remove pruning and check forward is unchanged from previous
         pruned state.
         """
-        input_ = torch.ones(1, 5)
-        m = nn.Linear(5, 2)
+        input_ = torch.ones(1, 5, device=device)
+        m = nn.Linear(5, 2).to(device)
 
         # define custom mask to assign with mock
         mask = torch.ones_like(m.weight)
@@ -930,8 +931,8 @@ class TestPruningNN(NNTestCase):
                 "'weight_ih_l0_orig' should not be in l.named_parameters()"
             )
 
-
 instantiate_parametrized_tests(TestPruningNN)
+instantiate_device_type_tests(TestPruningNN, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/profiler/test_torch_tidy.py
+++ b/test/profiler/test_torch_tidy.py
@@ -578,6 +578,7 @@ class TestTorchTidyProfiler(TestCase):
     def test_tensor_properties(self):
         x = torch.ones(10, 10).as_strided([4, 4], [12, 3])
         y = torch.ones(4, 1, requires_grad=True)
+        expected_device = x.device
 
         with profile(with_stack=True, profile_memory=True, record_shapes=True) as p:
             _ = x + y
@@ -601,7 +602,7 @@ class TestTorchTidyProfiler(TestCase):
         )
         self.assertEqual(
             getattr_inputs("device", None),
-            [torch.device("cpu"), torch.device("cpu"), None],
+            [expected_device, expected_device, None],
         )
         self.assertEqual(
             getattr_inputs("dtype", None), [torch.float32, torch.float32, None]
@@ -618,6 +619,7 @@ class TestTorchTidyProfiler(TestCase):
         i = [[0, 1, 1], [2, 0, 2]]
         v = [3, 4, 5]
         s = torch.sparse_coo_tensor(i, v, (2, 3))
+        expected_device = s.device
 
         with profile(with_stack=True, profile_memory=True, record_shapes=True) as p:
             _ = s + s
@@ -640,7 +642,7 @@ class TestTorchTidyProfiler(TestCase):
         )
         self.assertEqual(
             getattr_inputs("device", None),
-            [torch.device("cpu"), torch.device("cpu"), None],
+            [expected_device, expected_device, None],
         )
 
     @unittest.skipIf(
@@ -648,6 +650,8 @@ class TestTorchTidyProfiler(TestCase):
     )
     def test_mkldnn_tensors(self):
         x = torch.ones(4, 3).to_mkldnn()
+        # MKLDNN tensors are CPU-only; keep this test tied to CPU behavior.
+        self.assertEqual(x.device, torch.device("cpu"))
 
         with profile(with_stack=True, profile_memory=True, record_shapes=True) as p:
             _ = x + x
@@ -670,7 +674,7 @@ class TestTorchTidyProfiler(TestCase):
         )
         self.assertEqual(
             getattr_inputs("device", None),
-            [torch.device("cpu"), torch.device("cpu"), None],
+            [x.device, x.device, None],
         )
 
     def test_scalar_ins(self):
@@ -859,6 +863,7 @@ class TestTorchTidyProfiler(TestCase):
         gc.collect()
         with profile(profile_memory=True) as p:
             x = torch.empty((3, 4))
+        expected_device = x.device
 
         nodes = p.profiler.kineto_results.experimental_event_tree()
         node = find_node_with_name(nodes, "[memory]")
@@ -868,7 +873,7 @@ class TestTorchTidyProfiler(TestCase):
         ptr = node.extra_fields.ptr
         self.assertGreater(ptr, 0)
         self.assertEqual(node.extra_fields.alloc_size, alloc_size)
-        self.assertEqual(node.extra_fields.device, torch.device("cpu"))
+        self.assertEqual(node.extra_fields.device, expected_device)
         total_allocated = node.extra_fields.total_allocated
 
         # total_reserved is only for CUDACachingAllocator
@@ -884,7 +889,7 @@ class TestTorchTidyProfiler(TestCase):
 
         self.assertEqual(node.extra_fields.ptr, ptr)
         self.assertEqual(node.extra_fields.alloc_size, -alloc_size)
-        self.assertEqual(node.extra_fields.device, torch.device("cpu"))
+        self.assertEqual(node.extra_fields.device, expected_device)
         self.assertEqual(
             node.extra_fields.total_allocated, total_allocated - alloc_size
         )


### PR DESCRIPTION
This PR enables nn and profiler tests to be able run on XPU without any adjustments by removing hardcoded references to specific devices as well as ensuring test tensors are created on a device they were intended to be.