### PR TITLE
[TEST] Add `hw_classification` to `test_convolution_ops.py`

### DIFF
--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -17,7 +17,7 @@ from torch.distributed.tensor.debug import CommDebugMode
 from torch.nn import functional as F
 from torch.testing._internal.common_cuda import with_tf32_off
 from torch.testing._internal.common_distributed import run_subtests
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -45,6 +45,8 @@ def _conv_fn(
 
 
 class DistConvolutionOpsTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         # hard code world size to 2

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -16,6 +16,7 @@ from torch.distributed.tensor import (
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.nn import functional as F
 from torch.testing._internal.common_cuda import with_tf32_off
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import run_subtests
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -488,6 +489,9 @@ DistConvolutionOpsTestWithLocalTensor = create_local_tensor_test_class(
         "test_conv3d_batch_shard",
     ],
 )
+
+instantiate_device_type_tests(DistConvolutionOpsTest, globals())
+instantiate_device_type_tests(DistConvolutionOpsTestWithLocalTensor, globals())
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Apply hardware classification following #186918

Changes:
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `DistConvolutionOpsTest` — 11 test methods, all use `self.device_type` via `DTensorTestBase` (no hardcoded CUDA references)

Tests distributed convolution operations (1D/2D/3D, depthwise, strided, backward) that work identically across accelerator backends. Tests with `@skip_if_lt_x_gpu(2)` differ only in device count, not device type — no split needed.

Depends on: #186918

## Test Plan

```
python test/distributed/tensor/test_convolution_ops.py -v Ran 22 tests in 76.898s — OK 
```

cc: @vishalgoyal316 @mansiag05 @RiyaP2508