### PR TITLE
[TEST] Add `hw_classification` to `test_symmetric_memory.py`

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -55,6 +55,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_rocm_ver_lessthan_multiprocess,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     requires_cuda,
@@ -97,6 +98,8 @@ device_module = torch.get_device_module(device_type)
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmetricMemoryTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -799,6 +802,8 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class AsyncTPTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -1162,6 +1167,8 @@ class AsyncTPTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
@@ -1285,6 +1292,8 @@ class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
 # MultiProcessTestCase instead of MultiProcContinuousTest.
 @requires_cuda_p2p_access()
 class SymmMemNegativeTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
@@ -1414,6 +1423,8 @@ class SymmMemNegativeTest(MultiProcessTestCase):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmMemCollectiveTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -1703,6 +1714,8 @@ class SymmMemCollectiveTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmetricMemoryTestCudaGraph(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -1772,6 +1785,8 @@ class SymmetricMemoryTestCudaGraph(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class LoweringTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_process(self) -> None:
         torch.cuda.set_device(self.device)
         torch.manual_seed(42 + self.rank)
@@ -2259,6 +2274,8 @@ class LoweringTest(MultiProcContinuousTest):
 
 
 class SymmMemSingleProcTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @requires_cuda
     @skipIf(
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
@@ -2338,6 +2355,8 @@ class SymmMemSingleProcTest(TestCase):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmMemPoolTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -2514,6 +2533,7 @@ class SymmMemPoolTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class TorchCommsCudaSymmMemTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
     """CUDA symm_mem rendezvous against a torchcomms-backed PG.
 
     Builds a torchcomms comm, wraps it in _BackendWrapper, registers it as
@@ -2568,6 +2588,7 @@ class TorchCommsCudaSymmMemTest(MultiProcContinuousTest):
 @skipIf(TEST_WITH_ROCM, "NCCL symmetric memory is not supported on ROCm")
 @skipIf(not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch")
 class ExternalNcclCommRegistrationTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
     """Tests for the external NCCL comm registration API
     (``register_external_nccl_comm`` and the ``NcclCommRegistration`` handle
     from ``torch.distributed._symmetric_memory._nccl``), exercised against a

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -2533,13 +2533,14 @@ class SymmMemPoolTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class TorchCommsCudaSymmMemTest(MultiProcContinuousTest):
-    hw_classification = HardwareClassification.CUDA
     """CUDA symm_mem rendezvous against a torchcomms-backed PG.
 
     Builds a torchcomms comm, wraps it in _BackendWrapper, registers it as
     the NCCL backend on a bare ProcessGroup, and exercises symm_mem on the
     CUDA backend (cuMemMap/IPC).
     """
+
+    hw_classification = HardwareClassification.CUDA
 
     @property
     def device(self) -> torch.device:
@@ -2588,7 +2589,6 @@ class TorchCommsCudaSymmMemTest(MultiProcContinuousTest):
 @skipIf(TEST_WITH_ROCM, "NCCL symmetric memory is not supported on ROCm")
 @skipIf(not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch")
 class ExternalNcclCommRegistrationTest(TestCase):
-    hw_classification = HardwareClassification.CUDA
     """Tests for the external NCCL comm registration API
     (``register_external_nccl_comm`` and the ``NcclCommRegistration`` handle
     from ``torch.distributed._symmetric_memory._nccl``), exercised against a
@@ -2599,6 +2599,8 @@ class ExternalNcclCommRegistrationTest(TestCase):
     These run the real C++ registry path: register the real pointer into the
     per-device ``NCCLDevCommManager`` and unregister via the handle.
     """
+
+    hw_classification = HardwareClassification.CUDA
 
     def _make_real_comm(self, device_index: int = 0) -> int:
         """Create a real 1-rank ncclComm on ``device_index`` and return its


### PR DESCRIPTION
## Summary

Apply hardware classification following #186918 

Changes:
- Add `hw_classification = HardwareClassification.CUDA` to all 11 test classes.

All classes require CUDA P2P access (`@requires_cuda_p2p_access`) or CUDA (`@requires_cuda`) — tests symmetric memory APIs inherently locked to CUDA hardware.

No split needed — no class has mixed CUDA+CPU tests.

## Test Plan
```
python test/distributed/test_symmetric_memory.py -v Ran 133 tests in 66.943s — OK (skipped=66)
```


(Verified on 2xH200 with CUDA P2P access — 66 pass, 66 skip, 1 pre-existing interaction error that passes individually)

Co-authored with Opus 4.6

cc: @vishalgoyal316 @mansiag05 @RiyaP2508