### PR TITLE
fix(grid_sampler): Validate grad_output shape in 2D/3D backward

### DIFF
--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -982,6 +982,7 @@ grid_sampler_2d_backward_cpu(const Tensor& grad_output, const Tensor& input, con
   // Add checks here in case this is called instead of grid_sampler.
   check_grid_sampler_common(input, grid);
   check_grid_sampler_2d(input, grid);
+  check_grid_sampler_2d_backward(input, grid, grad_output);
 
   // AVX gather instructions use signed 32-bit offsets to gather float values.
   // Check for possible overflow and fallback to scalar implementation
@@ -1029,6 +1030,7 @@ grid_sampler_3d_backward_cpu(const Tensor& grad_output, const Tensor& input, con
   // Add checks here in case this is called instead of grid_sampler.
   check_grid_sampler_common(input, grid);
   check_grid_sampler_3d(input, grid, interpolation_mode);
+  check_grid_sampler_3d_backward(input, grid, grad_output);
 
   return AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(), "grid_sampler_3d_backward_cpu", [&] {
     return grid_sampler_3d_backward_cpu_impl<scalar_t>(

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -718,8 +718,7 @@ _grid_sampler_2d_cpu_fallback_backward(const Tensor& grad_output,
                                        bool align_corners) {
   // See NOTE [ grid_sampler Native Functions ].
   // Add checks here in case this is called instead of grid_sampler.
-  check_grid_sampler_common(input, grid);
-  check_grid_sampler_2d(input, grid);
+  check_grid_sampler_2d_backward(input, grid, grad_output);
 
   const auto interpolation_mode = static_cast<GridSamplerInterpolation>(interpolation_mode_);
   const auto padding_mode = static_cast<GridSamplerPadding>(padding_mode_);
@@ -980,8 +979,6 @@ grid_sampler_2d_backward_cpu(const Tensor& grad_output, const Tensor& input, con
                              std::array<bool,2> output_mask) {
   // See NOTE [ grid_sampler Native Functions ].
   // Add checks here in case this is called instead of grid_sampler.
-  check_grid_sampler_common(input, grid);
-  check_grid_sampler_2d(input, grid);
   check_grid_sampler_2d_backward(input, grid, grad_output);
 
   // AVX gather instructions use signed 32-bit offsets to gather float values.
@@ -1028,9 +1025,7 @@ grid_sampler_3d_backward_cpu(const Tensor& grad_output, const Tensor& input, con
                              std::array<bool,2> output_mask) {
   // See NOTE [ grid_sampler Native Functions ].
   // Add checks here in case this is called instead of grid_sampler.
-  check_grid_sampler_common(input, grid);
-  check_grid_sampler_3d(input, grid, interpolation_mode);
-  check_grid_sampler_3d_backward(input, grid, grad_output);
+  check_grid_sampler_3d_backward(input, grid, grad_output, interpolation_mode);
 
   return AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(), "grid_sampler_3d_backward_cpu", [&] {
     return grid_sampler_3d_backward_cpu_impl<scalar_t>(

--- a/aten/src/ATen/native/GridSamplerUtils.h
+++ b/aten/src/ATen/native/GridSamplerUtils.h
@@ -5,6 +5,7 @@
 #include <ATen/core/TensorBase.h>
 #include <ATen/native/TensorProperties.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
+#include <c10/util/DimVector.h>
 
 namespace at::native {
 
@@ -88,42 +89,45 @@ inline void check_grid_sampler_3d(
 }
 
 // See NOTE [ grid_sampler Native Functions ].
+inline void check_grid_sampler_backward(
+  const TensorBase& input,
+  const TensorBase& grid,
+  const TensorBase& grad_output
+) {
+  c10::DimVector expected_grad_output_shape = {input.size(0), input.size(1)};
+  for (const auto i : c10::irange(1, grid.dim() - 1)) {
+    expected_grad_output_shape.push_back(grid.size(i));
+  }
+
+  // a mismatched grad_output tensor leads to out-of-bounds reads in the kernel
+  TORCH_CHECK_VALUE(
+    grad_output.sizes() == expected_grad_output_shape,
+    "grid_sampler(): expected grad_output to have sizes ",
+    expected_grad_output_shape,
+    " but got grad_output with sizes ", grad_output.sizes());
+}
+
+// See NOTE [ grid_sampler Native Functions ].
 inline void check_grid_sampler_2d_backward(
   const TensorBase& input,
   const TensorBase& grid,
   const TensorBase& grad_output
 ) {
-  auto N = input.size(0);
-  auto C = input.size(1);
-  auto H = grid.size(1);
-  auto W = grid.size(2);
-
-  // a mismatched grad_output tensor leads to out-of-bounds reads in the kernel
-  TORCH_CHECK_VALUE(
-    grad_output.sizes() == IntArrayRef({N, C, H, W}),
-    "grid_sampler(): expected grad_output to have sizes ",
-    IntArrayRef({N, C, H, W}),
-    " but got grad_output with sizes ", grad_output.sizes());
+  check_grid_sampler_common(input, grid);
+  check_grid_sampler_2d(input, grid);
+  check_grid_sampler_backward(input, grid, grad_output);
 }
 
 // See NOTE [ grid_sampler Native Functions ].
 inline void check_grid_sampler_3d_backward(
   const TensorBase& input,
   const TensorBase& grid,
-  const TensorBase& grad_output
+  const TensorBase& grad_output,
+  int64_t interpolation_mode
 ) {
-  auto N = input.size(0);
-  auto C = input.size(1);
-  auto D = grid.size(1);
-  auto H = grid.size(2);
-  auto W = grid.size(3);
-
-  // a mismatched grad_output tensor leads to out-of-bounds reads in the kernel
-  TORCH_CHECK_VALUE(
-    grad_output.sizes() == IntArrayRef({N, C, D, H, W}),
-    "grid_sampler(): expected grad_output to have sizes ",
-    IntArrayRef({N, C, D, H, W}),
-    " but got grad_output with sizes ", grad_output.sizes());
+  check_grid_sampler_common(input, grid);
+  check_grid_sampler_3d(input, grid, interpolation_mode);
+  check_grid_sampler_backward(input, grid, grad_output);
 }
 
 // See NOTE [ grid_sampler Native Functions ].

--- a/aten/src/ATen/native/GridSamplerUtils.h
+++ b/aten/src/ATen/native/GridSamplerUtils.h
@@ -88,6 +88,45 @@ inline void check_grid_sampler_3d(
 }
 
 // See NOTE [ grid_sampler Native Functions ].
+inline void check_grid_sampler_2d_backward(
+  const TensorBase& input,
+  const TensorBase& grid,
+  const TensorBase& grad_output
+) {
+  auto N = input.size(0);
+  auto C = input.size(1);
+  auto H = grid.size(1);
+  auto W = grid.size(2);
+
+  // a mismatched grad_output tensor leads to out-of-bounds reads in the kernel
+  TORCH_CHECK_VALUE(
+    grad_output.sizes() == IntArrayRef({N, C, H, W}),
+    "grid_sampler(): expected grad_output to have sizes ",
+    IntArrayRef({N, C, H, W}),
+    " but got grad_output with sizes ", grad_output.sizes());
+}
+
+// See NOTE [ grid_sampler Native Functions ].
+inline void check_grid_sampler_3d_backward(
+  const TensorBase& input,
+  const TensorBase& grid,
+  const TensorBase& grad_output
+) {
+  auto N = input.size(0);
+  auto C = input.size(1);
+  auto D = grid.size(1);
+  auto H = grid.size(2);
+  auto W = grid.size(3);
+
+  // a mismatched grad_output tensor leads to out-of-bounds reads in the kernel
+  TORCH_CHECK_VALUE(
+    grad_output.sizes() == IntArrayRef({N, C, D, H, W}),
+    "grid_sampler(): expected grad_output to have sizes ",
+    IntArrayRef({N, C, D, H, W}),
+    " but got grad_output with sizes ", grad_output.sizes());
+}
+
+// See NOTE [ grid_sampler Native Functions ].
 // cudnn does not support inputs larger than 1024.
 inline bool cond_cudnn_grid_sampler(
   const TensorBase& input,

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -843,8 +843,6 @@ void launch_grid_sampler_2d_backward_kernel(
     bool align_corners, std::array<bool,2> output_mask) {
   // See NOTE [ grid_sampler Native Functions ].
   // Add checks here in case this is called instead of grid_sampler.
-  check_grid_sampler_common(input, grid);
-  check_grid_sampler_2d(input, grid);
   check_grid_sampler_2d_backward(input, grid, grad_output);
 
   // See Note [Writing Nondeterministic Operations]
@@ -907,9 +905,7 @@ void launch_grid_sampler_3d_backward_kernel(
     bool align_corners, std::array<bool,2> output_mask) {
   // See NOTE [ grid_sampler Native Functions ].
   // Add checks here in case this is called instead of grid_sampler.
-  check_grid_sampler_common(input, grid);
-  check_grid_sampler_3d(input, grid, interpolation_mode);
-  check_grid_sampler_3d_backward(input, grid, grad_output);
+  check_grid_sampler_3d_backward(input, grid, grad_output, interpolation_mode);
 
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -845,6 +845,7 @@ void launch_grid_sampler_2d_backward_kernel(
   // Add checks here in case this is called instead of grid_sampler.
   check_grid_sampler_common(input, grid);
   check_grid_sampler_2d(input, grid);
+  check_grid_sampler_2d_backward(input, grid, grad_output);
 
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage
@@ -908,6 +909,7 @@ void launch_grid_sampler_3d_backward_kernel(
   // Add checks here in case this is called instead of grid_sampler.
   check_grid_sampler_common(input, grid);
   check_grid_sampler_3d(input, grid, interpolation_mode);
+  check_grid_sampler_3d_backward(input, grid, grad_output);
 
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage

--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -233,8 +233,6 @@ std::tuple<Tensor, Tensor> grid_sampler_2d_backward_mps(const Tensor& grad_outpu
                                                         int64_t _padding_mode,
                                                         bool align_corners,
                                                         std::array<bool, 2> output_mask) {
-  check_grid_sampler_common(input, grid);
-  check_grid_sampler_2d(input, grid);
   check_grid_sampler_2d_backward(input, grid, grad_output);
 
   TORCH_CHECK(input.scalar_type() == grid.scalar_type(),
@@ -331,9 +329,7 @@ std::tuple<Tensor, Tensor> grid_sampler_3d_backward_mps(const Tensor& grad_outpu
                                                         bool align_corners,
                                                         std::array<bool, 2> output_mask) {
   using namespace mps;
-  check_grid_sampler_common(input, grid);
-  check_grid_sampler_3d(input, grid, interpolation_mode);
-  check_grid_sampler_3d_backward(input, grid, grad_output);
+  check_grid_sampler_3d_backward(input, grid, grad_output, interpolation_mode);
 
   TORCH_CHECK_NOT_IMPLEMENTED(interpolation_mode == 0 || interpolation_mode == 1,
                               "grid_sampler_3d backward on MPS only supports bilinear and nearest interpolation");

--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -235,6 +235,7 @@ std::tuple<Tensor, Tensor> grid_sampler_2d_backward_mps(const Tensor& grad_outpu
                                                         std::array<bool, 2> output_mask) {
   check_grid_sampler_common(input, grid);
   check_grid_sampler_2d(input, grid);
+  check_grid_sampler_2d_backward(input, grid, grad_output);
 
   TORCH_CHECK(input.scalar_type() == grid.scalar_type(),
               "expected input and grid to have the same type, but got ",
@@ -332,6 +333,7 @@ std::tuple<Tensor, Tensor> grid_sampler_3d_backward_mps(const Tensor& grad_outpu
   using namespace mps;
   check_grid_sampler_common(input, grid);
   check_grid_sampler_3d(input, grid, interpolation_mode);
+  check_grid_sampler_3d_backward(input, grid, grad_output);
 
   TORCH_CHECK_NOT_IMPLEMENTED(interpolation_mode == 0 || interpolation_mode == 1,
                               "grid_sampler_3d backward on MPS only supports bilinear and nearest interpolation");

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4632,27 +4632,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             with self.assertRaisesRegex(RuntimeError, "Expected all tensors to be on the same device"):
                 F.grid_sample(input.cuda(), grid, align_corners=False)
 
-    def test_grid_sample_backward_error_checking(self):
-        input = torch.empty(1, 1, 2, 2)
-        grid = torch.empty(1, 1, 1, 2)
-        grad_output = torch.empty(1, 1, 1, 1)
-
-        # assert no error
-        torch.ops.aten.grid_sampler_2d_backward(grad_output, input, grid, 0, 0, False, (True, True))
-
-        with self.assertRaisesRegex(ValueError, "expected grad_output to have sizes"):
-            torch.ops.aten.grid_sampler_2d_backward(torch.empty(2, 1, 1, 1), input, grid, 0, 0, False, (True, True))
-
-        input = torch.empty(1, 1, 2, 2, 2)
-        grid = torch.empty(1, 1, 1, 1, 3)
-        grad_output = torch.empty(1, 1, 1, 1, 1)
-
-        # assert no error
-        torch.ops.aten.grid_sampler_3d_backward(grad_output, input, grid, 0, 0, False, (True, True))
-
-        with self.assertRaisesRegex(ValueError, "expected grad_output to have sizes"):
-            torch.ops.aten.grid_sampler_3d_backward(torch.empty(2, 1, 1, 1, 1), input, grid, 0, 0, False, (True, True))
-
     def test_affine_grid_error_checking(self):
         # 2D affine
         theta = torch.empty(1, 2, 3, dtype=torch.double)
@@ -7389,6 +7368,30 @@ def _buildEquivalentAffineTransforms3d(device, input_size, output_size, angle_ra
 
 
 class TestNNDeviceType(NNTestCase):
+
+    def test_grid_sample_backward_error_checking(self, device):
+        input = torch.empty(1, 1, 2, 2, device=device)
+        grid = torch.empty(1, 1, 1, 2, device=device)
+        grad_output = torch.empty(1, 1, 1, 1, device=device)
+
+        # assert no error
+        torch.ops.aten.grid_sampler_2d_backward(grad_output, input, grid, 0, 0, False, (True, True))
+
+        with self.assertRaisesRegex(ValueError, "expected grad_output to have sizes"):
+            invalid_grad_output = torch.empty(2, 1, 1, 1, device=device)
+            torch.ops.aten.grid_sampler_2d_backward(invalid_grad_output, input, grid, 0, 0, False, (True, True))
+
+        input = torch.empty(1, 1, 2, 2, 2, device=device)
+        grid = torch.empty(1, 1, 1, 1, 3, device=device)
+        grad_output = torch.empty(1, 1, 1, 1, 1, device=device)
+
+        # assert no error
+        torch.ops.aten.grid_sampler_3d_backward(grad_output, input, grid, 0, 0, False, (True, True))
+
+        with self.assertRaisesRegex(ValueError, "expected grad_output to have sizes"):
+            invalid_grad_output = torch.empty(2, 1, 1, 1, 1, device=device)
+            torch.ops.aten.grid_sampler_3d_backward(invalid_grad_output, input, grid, 0, 0, False, (True, True))
+
     def _get_mixed_dtypes(self, device):
         """Get appropriate mixed dtype pair (param_dtype, input_dtype) for the device.
         Returns lower precision for params and higher precision for input to test

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4632,6 +4632,27 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             with self.assertRaisesRegex(RuntimeError, "Expected all tensors to be on the same device"):
                 F.grid_sample(input.cuda(), grid, align_corners=False)
 
+    def test_grid_sample_backward_error_checking(self):
+        input = torch.empty(1, 1, 2, 2)
+        grid = torch.empty(1, 1, 1, 2)
+        grad_output = torch.empty(1, 1, 1, 1)
+
+        # assert no error
+        torch.ops.aten.grid_sampler_2d_backward(grad_output, input, grid, 0, 0, False, (True, True))
+
+        with self.assertRaisesRegex(ValueError, "expected grad_output to have sizes"):
+            torch.ops.aten.grid_sampler_2d_backward(torch.empty(2, 1, 1, 1), input, grid, 0, 0, False, (True, True))
+
+        input = torch.empty(1, 1, 2, 2, 2)
+        grid = torch.empty(1, 1, 1, 1, 3)
+        grad_output = torch.empty(1, 1, 1, 1, 1)
+
+        # assert no error
+        torch.ops.aten.grid_sampler_3d_backward(grad_output, input, grid, 0, 0, False, (True, True))
+
+        with self.assertRaisesRegex(ValueError, "expected grad_output to have sizes"):
+            torch.ops.aten.grid_sampler_3d_backward(torch.empty(2, 1, 1, 1, 1), input, grid, 0, 0, False, (True, True))
+
     def test_affine_grid_error_checking(self):
         # 2D affine
         theta = torch.empty(1, 2, 3, dtype=torch.double)


### PR DESCRIPTION
### What does this PR do?

→ The 2D/3D backward validates `input` and `grid` via [check_grid_sampler_common and check_grid_sampler_{2d_3d}](https://github.com/pytorch/pytorch/blob/ece45c392cb3ed8a958fbaea8eaf0fe5d812da6d/aten/src/ATen/native/cuda/GridSampler.cu#L846-L847) but never `grad_output`, so a `grad_output` whose shape does not match the forward's makes the [kernel read it as out of bounds](https://github.com/pytorch/pytorch/blob/ece45c392cb3ed8a958fbaea8eaf0fe5d812da6d/aten/src/ATen/native/cuda/GridSampler.cu#L388-L392) 
→ Adding `check_grid_sampler_{2d_3d}_backward` that validate `grad_output` against the forward output shape ahead of the kernel across the CPU and CUDA 2D/3D backward paths fixes this :)
→ Requesting triage, thank you.

Fixes #191849

Edits by @malfet:
 - Move tests from CPU only to device-agnostic
 - Added similar checks for MPS backwards
 - Refactored the backward validation helpers and call sites to remove duplicated checks

### Verification and Testing

→ <ins>On an L4</ins>: Reproduced exactly on the unfixed build, then confirmed the fix turns both the 2D and 3D backward into a clean `ValueError` with the operand tensors intact. The new regression test fails without the fix and passes with it; `test_grid_sample_error_checking` and `test_grid_sample_backward_error_checking` stay green.

```
python test/test_nn.py TestNN.test_grid_sample_backward_error_checking
```

**Before**

<img src="https://github.com/user-attachments/assets/9438b3a9-13a1-4c63-91a8-c6fa0d544ec1" /><br>

**After**

<img src="https://github.com/user-attachments/assets/da9e8b91-d623-42a3-8862-cb19957c8779" /><br>

### Environment

* `torch` version: `2.14.0a0+gitece45c3` (source build, `USE_CUDA=1 USE_CUDNN=1`, `TORCH_CUDA_ARCH_LIST=8.9`)
* Platform: `Linux-6.8.0-1064-gcp-x86_64-with-glibc2.35`
* GPU: NVIDIA L4 (sm_89), driver `595.58.03`, cuDNN `9.24.0`, CUDA runtime `13.0`
* Python version: `3.10.12`