### PR TITLE
Make torch.is_autocast_enabled&torch.set_autocast_enabled support on current accelerator

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -369,11 +369,18 @@ class TestAutocastMPS(TestCase):
         self.assertEqual(found_inf.item(), 1.0)
 
     def test_autocast_is_enabled(self):
-            self.assertEqual(torch.is_autocast_enabled(device="mps"), torch.is_autocast_enabled())
-            with torch.amp.autocast("mps"):
-                self.assertEqual(torch.is_autocast_enabled(device="mps"), torch.is_autocast_enabled())
-            with torch.amp.autocast("mps", enabled=False):
-                self.assertEqual(torch.is_autocast_enabled(device="mps"), torch.is_autocast_enabled())
+        is_enabled = torch.is_autocast_enabled("mps")
+        self.assertEqual(is_enabled, torch.is_autocast_enabled())
+        torch.set_autocast_enabled(not is_enabled)
+        self.assertEqual(
+            torch.is_autocast_enabled(device="mps"), torch.is_autocast_enabled()
+        )
+        self.assertEqual(not is_enabled, torch.is_autocast_enabled())
+        torch.set_autocast_enabled(is_enabled)
+        self.assertEqual(
+            torch.is_autocast_enabled(device="mps"), torch.is_autocast_enabled()
+        )
+        self.assertEqual(is_enabled, torch.is_autocast_enabled())
 
 # Expand TestCase class with Memory Leak Detection on MPS device
 class TestCaseMPS(TestCase):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -368,6 +368,13 @@ class TestAutocastMPS(TestCase):
         self.assertEqual(grads[1][:2], make_tensor([4.0, 8.0]))
         self.assertEqual(found_inf.item(), 1.0)
 
+    def test_autocast_is_enabled(self):
+            self.assertEqual(torch.is_autocast_enabled(device="mps"), torch.is_autocast_enabled())
+            with torch.amp.autocast("mps"):
+                self.assertEqual(torch.is_autocast_enabled(device="mps"), torch.is_autocast_enabled())
+            with torch.amp.autocast("mps", enabled=False):
+                self.assertEqual(torch.is_autocast_enabled(device="mps"), torch.is_autocast_enabled())
+
 # Expand TestCase class with Memory Leak Detection on MPS device
 class TestCaseMPS(TestCase):
     _do_mps_memory_leak_check = True

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -372,14 +372,10 @@ class TestAutocastMPS(TestCase):
         is_enabled = torch.is_autocast_enabled("mps")
         self.assertEqual(is_enabled, torch.is_autocast_enabled())
         torch.set_autocast_enabled(not is_enabled)
-        self.assertEqual(
-            torch.is_autocast_enabled(device="mps"), torch.is_autocast_enabled()
-        )
+        self.assertEqual(torch.is_autocast_enabled("mps"), torch.is_autocast_enabled())
         self.assertEqual(not is_enabled, torch.is_autocast_enabled())
         torch.set_autocast_enabled(is_enabled)
-        self.assertEqual(
-            torch.is_autocast_enabled(device="mps"), torch.is_autocast_enabled()
-        )
+        self.assertEqual(torch.is_autocast_enabled("mps"), torch.is_autocast_enabled())
         self.assertEqual(is_enabled, torch.is_autocast_enabled())
 
 # Expand TestCase class with Memory Leak Detection on MPS device

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -3534,14 +3534,10 @@ class TestXpuAutocast(TestAutocast):
         is_enabled = torch.is_autocast_enabled("xpu")
         self.assertEqual(is_enabled, torch.is_autocast_enabled())
         torch.set_autocast_enabled(not is_enabled)
-        self.assertEqual(
-            torch.is_autocast_enabled(device="xpu"), torch.is_autocast_enabled()
-        )
+        self.assertEqual(torch.is_autocast_enabled("xpu"), torch.is_autocast_enabled())
         self.assertEqual(not is_enabled, torch.is_autocast_enabled())
         torch.set_autocast_enabled(is_enabled)
-        self.assertEqual(
-            torch.is_autocast_enabled(device="xpu"), torch.is_autocast_enabled()
-        )
+        self.assertEqual(torch.is_autocast_enabled("xpu"), torch.is_autocast_enabled())
         self.assertEqual(is_enabled, torch.is_autocast_enabled())
 
 

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -3531,17 +3531,18 @@ class TestXpuAutocast(TestAutocast):
             self.assertEqual(result.dtype, torch.float16)
 
     def test_autocast_is_enabled(self):
+        is_enabled = torch.is_autocast_enabled("xpu")
+        self.assertEqual(is_enabled, torch.is_autocast_enabled())
+        torch.set_autocast_enabled(not is_enabled)
         self.assertEqual(
             torch.is_autocast_enabled(device="xpu"), torch.is_autocast_enabled()
         )
-        with torch.amp.autocast("xpu"):
-            self.assertEqual(
-                torch.is_autocast_enabled(device="xpu"), torch.is_autocast_enabled()
-            )
-        with torch.amp.autocast("xpu", enabled=False):
-            self.assertEqual(
-                torch.is_autocast_enabled(device="xpu"), torch.is_autocast_enabled()
-            )
+        self.assertEqual(not is_enabled, torch.is_autocast_enabled())
+        torch.set_autocast_enabled(is_enabled)
+        self.assertEqual(
+            torch.is_autocast_enabled(device="xpu"), torch.is_autocast_enabled()
+        )
+        self.assertEqual(is_enabled, torch.is_autocast_enabled())
 
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -3530,6 +3530,19 @@ class TestXpuAutocast(TestAutocast):
             result = torch.mm(mat0_fp32, mat1_fp32)
             self.assertEqual(result.dtype, torch.float16)
 
+    def test_autocast_is_enabled(self):
+        self.assertEqual(
+            torch.is_autocast_enabled(device="xpu"), torch.is_autocast_enabled()
+        )
+        with torch.amp.autocast("xpu"):
+            self.assertEqual(
+                torch.is_autocast_enabled(device="xpu"), torch.is_autocast_enabled()
+            )
+        with torch.amp.autocast("xpu", enabled=False):
+            self.assertEqual(
+                torch.is_autocast_enabled(device="xpu"), torch.is_autocast_enabled()
+            )
+
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpuTrace(TestCase):

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -775,7 +775,7 @@ static PyObject* set_autocast_enabled(
   ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   // Set at::kCUDA as default value to prevent BC-breaking changes.
-  at::DeviceType device_type = at::kCUDA;
+  auto device_type = at::accelerator::getAccelerator(false).value_or(at::kCUDA);
   int enabled_id = 0;
   if (r.idx == 0) {
     device_type = at::Device(r.string(0)).type();
@@ -798,7 +798,7 @@ static PyObject* is_autocast_enabled(
   ParsedArgs<1> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   // Set at::kCUDA as default value to prevent BC-breaking changes.
-  at::DeviceType device_type = at::kCUDA;
+  auto device_type = at::accelerator::getAccelerator(false).value_or(at::kCUDA);
   if (r.idx == 0) {
     device_type = at::Device(r.string(0)).type();
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #191916

# Motivation
Fix https://github.com/pytorch/pytorch/issues/191796

The reason is in `nn.TransformerEncoder` and `nn.TransformerEncoderLayer`, they still use `torch.is_autocast_enabled`, which is hard-coded to CUDA.
https://github.com/pytorch/pytorch/blob/ece45c392cb3ed8a958fbaea8eaf0fe5d812da6d/torch/nn/modules/transformer.py#L494
https://github.com/pytorch/pytorch/blob/ece45c392cb3ed8a958fbaea8eaf0fe5d812da6d/torch/nn/modules/transformer.py#L869
