### PR TITLE
[Testcase Refactoring] Add proper hw_classification attribute to test classes

### DIFF
--- a/test/inductor/test_pad_mm_utils.py
+++ b/test/inductor/test_pad_mm_utils.py
@@ -4,9 +4,13 @@ import operator
 import torch
 from torch._inductor.fx_passes.pad_mm import get_non_view_def
 from torch._inductor.test_case import run_tests, TestCase
-
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+)
 
 class PadMMUtilsTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_get_non_view_def_traverses_getitem(self):
         graph = torch.fx.Graph()
         arg = graph.placeholder("arg")

--- a/test/inductor/test_remote_cache.py
+++ b/test/inductor/test_remote_cache.py
@@ -14,7 +14,10 @@ from torch._inductor.remote_cache import (
     RemoteCacheBackend,
     RemoteCachePassthroughSerde,
 )
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    TestCase,
+)
 from torch.testing._internal.logging_utils import log_settings
 
 
@@ -51,6 +54,8 @@ class FakeCache(RemoteCache):
 
 
 class TestRemoteCache(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_normal_logging(
         self,
     ) -> None:

--- a/test/inductor/test_segmented_tree.py
+++ b/test/inductor/test_segmented_tree.py
@@ -4,6 +4,9 @@ from hypothesis import given, strategies as st
 
 from torch._inductor.codegen.segmented_tree import SegmentedTree
 from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+)
 
 
 # Helper functions for operations
@@ -42,6 +45,8 @@ update_values = st.integers(min_value=1, max_value=50)
 
 
 class TestSegmentedTree(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # Basic construction and initialization tests
     def test_basic_construction(self):
         values = [1, 3, 5, 7, 9]

--- a/test/inductor/test_simd_range_trees.py
+++ b/test/inductor/test_simd_range_trees.py
@@ -10,7 +10,11 @@ from torch._inductor.codegen.simd import DerivedIterationRangesRoot, IterationRa
 from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.codegen.triton import IndexingOptions, TritonKernel, TritonSymbols
 from torch._inductor.virtualized import V
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.inductor_utils import MockGraphHandler
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import FloorDiv
@@ -25,6 +29,8 @@ except ImportError:
 
 
 class TestSIMDRangeTrees(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _make_graph(self):
         return MockGraphHandler()
 


### PR DESCRIPTION
## Summary

Adds hw_classification annotations to test classes and aligning test methods with their hardware classification.

## Changes

- Add `HardwareClassification `to imports from `common_utils`

- Added `hw_classification = HardwareClassification.GENERIC` to each class  to mark it as device-GENERIC.


## Test plan

`python test/inductor/test_pad_mm_utils.py -v --hw-classification GENERIC` 
`python test/inductor/test_remote_cache.py -v --hw-classification GENERIC` 
`python test/inductor/test_segmented_tree.py -v --hw-classification GENERIC` 
`python test/inductor/test_simd_range_trees.py -v --hw-classification GENERIC` 

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo