### PR TITLE
skip miopen rnn on gfx1201 and big batches (rocm)

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -90,17 +90,20 @@ bool use_miopen(
   }
 
 #ifdef USE_ROCM
-  // MIOpen RNN produces incorrect outputs on gfx1201 for batch sizes >100.
+  // MIOpen RNN produces incorrect outputs on gfx1201 (RDNA4) for batch >100.
+  // Confirmed on PyTorch 2.12+ROCm 7.14; may be fixed in ROCm 10.0 dev builds
+  // (see issue #177834 comment by k-artem) but not in current release wheels.
   // See https://github.com/pytorch/pytorch/issues/177834
   if (detail::getCUDAHooks().isGPUArch({"gfx1201"})) {
     return false;
   }
 
-  // MIOpen RNN fails with miopenStatusBadParm ("Lengths must be > 0") for
-  // large batch sizes on multiple ROCm GPU architectures including gfx950.
-  // Fall back to the native implementation which produces correct results.
+  // MIOpen RNN fails with miopenStatusBadParm ("Lengths must be > 0") at
+  // batch 583+ on gfx950 (MI355X, MIOpen 3.5.1.70201). rocm-libraries #7300
+  // was expected to fix large-batch RNN but crash persists on ROCm 7.2.
+  // Threshold 582 preserves MIOpen for all working batch sizes on gfx950.
   // See https://github.com/pytorch/pytorch/issues/177834
-  constexpr int64_t miopen_rnn_max_batch = 512;
+  constexpr int64_t miopen_rnn_max_batch = 582;
   if (batch_size.has_value() && batch_size.value() > miopen_rnn_max_batch) {
     return false;
   }

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -68,18 +68,45 @@ namespace at::native {
 namespace {
 
 // Check if pytorch is compiled with MIOpen.
-bool use_miopen(const at::Tensor& input, const double dropout_state) {
-    bool is_miopen_acceptable = ((input.scalar_type() == at::kFloat)|| (input.scalar_type() == at::kHalf)) &&
-                                (detail::getCUDAHooks().compiledWithMIOpen()) &&
-                                (input.is_cuda()) &&
-                                (at::globalContext().userEnabledCuDNN());
-    // MIOpen functions returns miopenStatusBadParm on empty
-    // tensors. Maybe some functions actually support empty tensors, but
-    // native kernels shouldn't be much slower because the output is also
-    // likely empty.
-    if (input.sym_numel() == 0) return false;
+bool use_miopen(
+    const at::Tensor& input,
+    const double dropout_state,
+    std::optional<int64_t> batch_size = std::nullopt) {
+  bool is_miopen_acceptable =
+      ((input.scalar_type() == at::kFloat) ||
+       (input.scalar_type() == at::kHalf)) &&
+      (detail::getCUDAHooks().compiledWithMIOpen()) && (input.is_cuda()) &&
+      (at::globalContext().userEnabledCuDNN());
+  // MIOpen functions returns miopenStatusBadParm on empty
+  // tensors. Maybe some functions actually support empty tensors, but
+  // native kernels shouldn't be much slower because the output is also
+  // likely empty.
+  if (input.sym_numel() == 0) {
+    return false;
+  }
 
-    return is_miopen_acceptable;
+  if (!is_miopen_acceptable) {
+    return false;
+  }
+
+#ifdef USE_ROCM
+  // MIOpen RNN produces incorrect outputs on gfx1201 for batch sizes >100.
+  // See https://github.com/pytorch/pytorch/issues/177834
+  if (detail::getCUDAHooks().isGPUArch({"gfx1201"})) {
+    return false;
+  }
+
+  // MIOpen RNN fails with miopenStatusBadParm ("Lengths must be > 0") for
+  // large batch sizes on multiple ROCm GPU architectures including gfx950.
+  // Fall back to the native implementation which produces correct results.
+  // See https://github.com/pytorch/pytorch/issues/177834
+  constexpr int64_t miopen_rnn_max_batch = 512;
+  if (batch_size.has_value() && batch_size.value() > miopen_rnn_max_batch) {
+    return false;
+  }
+#endif
+
+  return true;
 }
 
 bool use_mkldnn(const Tensor& input, TensorList params, TensorList hx) {
@@ -1253,7 +1280,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
           batch_first);                                                     \
       return std::make_tuple(std::move(output), std::move(hy));             \
     }                                                                       \
-    if (use_miopen(_input, dropout_p)) {                                    \
+    if (use_miopen(_input, dropout_p, batch_first ? _input.sym_size(0) : _input.sym_size(1))) {                                    \
       Tensor output, hy;                                                    \
       NAME##_miopen_stub(                                                   \
           _input.device().type(),                                           \
@@ -1315,7 +1342,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
           bidirectional);                                                   \
       return std::make_tuple(std::move(output), std::move(hy));             \
     }                                                                       \
-    if (use_miopen(data, dropout_p)) {                                      \
+    if (use_miopen(data, dropout_p, batch_sizes.numel() > 0 ? batch_sizes[0].item<int64_t>() : std::nullopt)) {                                      \
       Tensor output, hy;                                                    \
       NAME##_packed_miopen_stub(                                            \
           data.device().type(),                                             \
@@ -1485,7 +1512,7 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
 #endif
   // if cells are of different size, that means projections are used
   bool has_projections = (hx[0].sym_size(2) != hx[1].sym_size(2));
-  if (use_miopen(_input, dropout_p)) {
+  if (use_miopen(_input, dropout_p, batch_first ? _input.sym_size(0) : _input.sym_size(1))) {
     if (!has_projections) {
       Tensor output, hy, cy;
       lstm_miopen_stub(_input.device().type(), output, hy, cy, _input, hx, _params, has_biases,
@@ -1538,7 +1565,7 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
   }
   // if cells are of different size, that means projections are used
   bool has_projections = (hx[0].size(2) != hx[1].size(2));
-  if (use_miopen(data, dropout_p)) {
+  if (use_miopen(data, dropout_p, batch_sizes.numel() > 0 ? batch_sizes[0].item<int64_t>() : std::nullopt)) {
     if (!has_projections) {
       Tensor output, hy, cy;
       lstm_packed_miopen_stub(data.device().type(), output, hy, cy, data, batch_sizes, hx,


### PR DESCRIPTION
Fixes #177834

## Background

Issue #177834 contains two distinct defects. They have different root causes and different upstream status, so this description separates them.

### 1. Large-batch RNN crash (fixed upstream)

The `miopenStatusBadParm` failure on large-batch LSTM is a 32-bit integer overflow in MIOpen. The element count is `6 * num_layers * seq_len * hidden * num_directions * batch`, which crosses `INT_MAX` at batch 583 for the reporter's configuration (4 layers, sequence length 600, hidden size 128, bidirectional). The threshold is therefore shape dependent rather than a fixed batch size. The same formula predicts a threshold of 292 at hidden size 256, and the reporter's own hidden size 256 sweep in #177834 passes at batch 250 and crashes at batch 300, bracketing that prediction.

This overflow is fixed upstream by ROCm/rocm-libraries#7300, a mechanical `int` to `size_t` widening with 291 added `static_cast<size_t>`. That change contains no `gfx` strings and no architecture gating of any kind, so both the defect and its fix are architecture agnostic.

ROCm/rocm-libraries#7300 shipped in MIOpen 3.5.2 / ROCm 7.14.0. MIOpen 3.5.1 spans ROCm 7.1 through 7.13, so the fix is not present in any ROCm 7.2.x stack. The crash reproduced here on ROCm 7.2.1 with MIOpen 3.5.1 is the pre-fix overflow behavior and is not evidence of a gfx950-specific gap. The original reporter confirmed on 2026-07-23 that the crash is resolved on the post-fix stack.

### 2. gfx1201 numerical corruption (still open)

Silently incorrect RNN results on gfx1201 are a separate defect. It survived ROCm/rocm-libraries#7300 and was still present on ROCm 7.14.0 as of July. @hongxiayang reported reproducing the numerical issue on gfx1201 and noted that it appeared correct on gfx950.

## Current contents of this patch

- Skip MIOpen for RNN on gfx1201.
- Skip MIOpen when batch size is greater than 582.
- Pass batch size into `use_miopen()` from the LSTM, GRU and RNN call sites.

## Status

Because the overflow is fixed upstream in MIOpen 3.5.2, the large-batch portion of this patch is being reassessed and may be reduced or dropped. A fixed batch threshold is also the wrong shape of guard, since the real limit depends on the full element count rather than on batch size alone. The gfx1201 portion targets the numerical defect, which remains open.

The code is unchanged for now while that reassessment is in progress, so this patch should not be treated as justified as written in its current form.

## Environment

Reproduced on MI355X with torch 2.13 dev and ROCm 7.2.1. Workaround on pre-fix stacks: `torch.backends.cudnn.enabled = False`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
