### PR TITLE
[DSD] Honor grad_dtype when priming gradients in _init_optim_state

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -47,7 +47,11 @@ from torch.testing._internal.common_dist_composable import (
     UnitModule,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     MultiProcessTestCase,
@@ -1108,6 +1112,25 @@ class TestNoComm(MultiProcessTestCase):
         )
         set_optimizer_state_dict(model, optim, osd)
         set_optimizer_state_dict(model, optim, optim.state_dict())
+
+
+class TestInitOptimState(TestCase):
+    def test_grad_dtype(self) -> None:
+        # An fp32 master weight accumulating bf16 grads rejects a param-dtype gradient, so
+        # _init_optim_state() has to prime the gradient at grad_dtype to materialize state.
+        class StateOnlyOptimizer(Optimizer):
+            def step(self, closure=None) -> None:
+                for group in self.param_groups:
+                    for param in group["params"]:
+                        self.state[param]["exp_avg"] = torch.zeros_like(param)
+
+        model = nn.Linear(4, 4, dtype=torch.float32)
+        for param in model.parameters():
+            param.grad_dtype = torch.bfloat16
+        optim = StateOnlyOptimizer(model.parameters(), {"lr": 0.0})
+
+        osd = get_optimizer_state_dict(model, optim)
+        self.assertEqual(sorted(osd["state"].keys()), ["bias", "weight"])
 
 
 if __name__ == "__main__":

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -646,7 +646,8 @@ def _init_optim_state(optim: torch.optim.Optimizer) -> None:
     for param_group in optim.param_groups:
         for param in param_group[_PARAMS]:
             if param.requires_grad:
-                param.grad = torch.zeros_like(param)
+                # A param whose grad_dtype differs from its dtype rejects a mismatched grad.
+                param.grad = torch.zeros_like(param, dtype=param.grad_dtype)
 
     # Some optimizers will update parameters regardless of grads due to lr, so
     # make lr to zero when calling `step()`.


### PR DESCRIPTION
Fixes #191918

## Summary

`_init_optim_state()` primes the optimizer state with `param.grad = torch.zeros_like(param)`, which
ignores `Tensor.grad_dtype`. A parameter that declares a gradient dtype different from its own (an
fp32 master weight accumulating bf16 gradients) rejects that assignment, so
`get_optimizer_state_dict()` / `get_state_dict()` raise for any such optimizer. Priming at
`param.grad_dtype` matches what a real backward pass would produce, `grad_dtype` defaults to the
parameter's dtype and `None` means "any dtype", so `torch.zeros_like(param, dtype=param.grad_dtype)`
is a no-op for every existing case. Note this only unblocks optimizers that support a mixed
gradient dtype: the built-in optimizers cannot step on a gradient whose dtype differs from the
parameter's, in `_init_optim_state()` or in a normal training loop, so their behavior is unchanged.

Test plan:

```
python test/distributed/checkpoint/test_state_dict.py TestNoComm.test_grad_dtype
python test/distributed/checkpoint/test_state_dict.py
```

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.
