### PR TITLE
casts between `torch.float4_e2m1fn_x2` and fp32|bf16|fp16

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -240,8 +240,7 @@ static inline std::optional<Device> ensure_has_index(
 static SymDimVector float4_e2m1fn_x2_packed_sizes(const Tensor& self) {
   TORCH_CHECK(
       self.dim() >= 1,
-      "conversion to Float4_e2m1fn_x2 requires the last dimension to be even, got shape ",
-      self.sym_sizes());
+      "conversion to Float4_e2m1fn_x2 requires at least 1 dimension, got a 0-dim tensor");
   auto last = self.sym_size(-1);
   TORCH_SYM_CHECK(
       (last % 2).sym_eq(0),
@@ -253,12 +252,24 @@ static SymDimVector float4_e2m1fn_x2_packed_sizes(const Tensor& self) {
 }
 
 static void check_convert_to_float4_input(const Tensor& self) {
+  // float64 is rejected: the kernels narrow the input through an intermediate
+  // float32 (self.to(kFloat)), and a double within half a float32 ULP of an
+  // exact fp4 midpoint would double-round to the wrong bucket.
+  // TODO(future PR): implement cast from float64 if there is a need, for now
+  // not worth the extra complexity
   TORCH_CHECK(
       isFloatingType(self.scalar_type()) &&
-          self.scalar_type() != kFloat4_e2m1fn_x2,
+          self.scalar_type() != kFloat4_e2m1fn_x2 &&
+          self.scalar_type() != kDouble,
       "conversion to Float4_e2m1fn_x2 is only supported from a floating point "
-      "dtype, got ",
+      "dtype other than float64, got ",
       self.scalar_type());
+  // Require a contiguous input: the pack kernel assumes row-major layout (two
+  // fp4 values share a byte along the last dim). Supporting arbitrary strides
+  // would need stride-aware kernels, which is not worth it right now.
+  TORCH_CHECK(
+      self.is_contiguous(),
+      "conversion to Float4_e2m1fn_x2 requires a contiguous input");
 }
 
 // Output sizes for unpacking a Float4_e2m1fn_x2 tensor: the last dimension is
@@ -280,11 +291,17 @@ static void check_convert_from_float4_input(const Tensor& self) {
       "conversion from Float4_e2m1fn_x2 is only supported from a "
       "Float4_e2m1fn_x2 dtype, got ",
       self.scalar_type());
+  // Require a contiguous input: the unpack kernel assumes row-major layout (two
+  // fp4 values share a byte along the last dim). Supporting arbitrary strides
+  // would need stride-aware kernels, which is not worth it right now.
+  TORCH_CHECK(
+      self.is_contiguous(),
+      "conversion from Float4_e2m1fn_x2 requires a contiguous input");
 }
 
 Tensor _convert_to_float4_e2m1fn_x2_cpu(const Tensor& self) {
   check_convert_to_float4_input(self);
-  auto input = self.to(kFloat).contiguous();
+  auto input = self.to(kFloat);
   auto out = at::empty_symint(
       float4_e2m1fn_x2_packed_sizes(input),
       input.options().dtype(kFloat4_e2m1fn_x2));
@@ -311,7 +328,7 @@ Tensor _convert_to_float4_e2m1fn_x2_meta(const Tensor& self) {
 
 Tensor _convert_from_float4_e2m1fn_x2_cpu(const Tensor& self) {
   check_convert_from_float4_input(self);
-  auto input = self.contiguous();
+  const Tensor& input = self;
   auto out = at::empty_symint(
       float4_e2m1fn_x2_unpacked_sizes(input), input.options().dtype(kFloat));
   const auto* in_ptr = reinterpret_cast<const uint8_t*>(input.const_data_ptr());
@@ -542,26 +559,48 @@ static inline Tensor to_impl(
     return self;
   }
   // Casting to fp4 is shape-changing, so we cannot reuse the _to_copy machinery
-  // like we do for whole-byte casts and have to use a custom kernel.
+  // like we do for whole-byte casts and have to use a custom kernel. The kernel
+  // produces a contiguous, unpinned fp4 tensor on self's device; defer any
+  // requested device or memory-format change to _to_copy (dtype is already fp4,
+  // so it is unchanged), gated by to_will_alias to avoid a redundant copy on
+  // the common no-op tail. The conversion output is always a fresh tensor, so
+  // copy=true is already satisfied.
   if (dtype == kFloat4_e2m1fn_x2 && self.scalar_type() != kFloat4_e2m1fn_x2) {
     TORCH_CHECK(
         !layout.has_value() || self.layout() == layout.value(),
         "conversion to Float4_e2m1fn_x2 does not support changing layout");
     auto result = at::_convert_to_float4_e2m1fn_x2(self);
-    if (device.has_value() && device.value() != self.device()) {
-      result = result.to(device.value(), non_blocking);
+    if (!pin_memory.value_or(false) &&
+        to_will_alias(
+            result, std::nullopt, layout, device, false, optional_memory_format)) {
+      return result;
     }
-    return result;
+    return at::_to_copy(
+        result,
+        std::nullopt,
+        layout,
+        device,
+        pin_memory,
+        non_blocking,
+        optional_memory_format);
   }
   // Casting from fp4 is shape-changing too (each byte unpacks to two values),
-  // so it likewise cannot use the _to_copy machinery. Unpack to fp32 here, then
-  // let the normal cast handle any remaining dtype/device change.
+  // so it likewise cannot use the _to_copy machinery. Unpack to fp32 here; the
+  // unpack always yields a fresh contiguous fp32 tensor on self's device, so if
+  // the caller only wants fp32 with no device/memory-format change (the common
+  // x.to(float32) case) return it directly, gated by to_will_alias. Otherwise
+  // defer the remaining dtype/device change to _to_copy.
   if (self.scalar_type() == kFloat4_e2m1fn_x2 && dtype.has_value() &&
       dtype.value() != kFloat4_e2m1fn_x2) {
     TORCH_CHECK(
         !layout.has_value() || self.layout() == layout.value(),
         "conversion from Float4_e2m1fn_x2 does not support changing layout");
     auto result = at::_convert_from_float4_e2m1fn_x2(self);
+    if (!pin_memory.value_or(false) &&
+        to_will_alias(
+            result, dtype, layout, device, false, optional_memory_format)) {
+      return result;
+    }
     return at::_to_copy(
         result,
         dtype,

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -2,10 +2,10 @@
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
-#include <c10/util/Float4_e2m1fn_x2.h>
 #include <ATen/TensorOperators.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/quantized/Quantizer.h>
+#include <c10/util/Float4_e2m1fn_x2.h>
 #include <optional>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -14,6 +14,8 @@
 #else
 #include <ATen/ops/_autocast_to_full_precision_native.h>
 #include <ATen/ops/_autocast_to_reduced_precision_native.h>
+#include <ATen/ops/_convert_from_float4_e2m1fn_x2.h>
+#include <ATen/ops/_convert_from_float4_e2m1fn_x2_native.h>
 #include <ATen/ops/_convert_indices_from_coo_to_csr.h>
 #include <ATen/ops/_convert_indices_from_coo_to_csr_native.h>
 #include <ATen/ops/_convert_indices_from_csr_to_coo.h>
@@ -259,6 +261,27 @@ static void check_convert_to_float4_input(const Tensor& self) {
       self.scalar_type());
 }
 
+// Output sizes for unpacking a Float4_e2m1fn_x2 tensor: the last dimension is
+// doubled because each byte holds two fp4 values. Symbolic-aware so the meta
+// path preserves dynamic shapes instead of specializing to constants.
+static SymDimVector float4_e2m1fn_x2_unpacked_sizes(const Tensor& self) {
+  TORCH_CHECK(
+      self.dim() >= 1,
+      "conversion from Float4_e2m1fn_x2 requires at least 1 dimension, got shape ",
+      self.sym_sizes());
+  SymDimVector sizes(self.sym_sizes().begin(), self.sym_sizes().end());
+  sizes.back() = self.sym_size(-1) * 2;
+  return sizes;
+}
+
+static void check_convert_from_float4_input(const Tensor& self) {
+  TORCH_CHECK(
+      self.scalar_type() == kFloat4_e2m1fn_x2,
+      "conversion from Float4_e2m1fn_x2 is only supported from a "
+      "Float4_e2m1fn_x2 dtype, got ",
+      self.scalar_type());
+}
+
 Tensor _convert_to_float4_e2m1fn_x2_cpu(const Tensor& self) {
   check_convert_to_float4_input(self);
   auto input = self.to(kFloat).contiguous();
@@ -268,13 +291,14 @@ Tensor _convert_to_float4_e2m1fn_x2_cpu(const Tensor& self) {
   const float* in_ptr = input.const_data_ptr<float>();
   auto* out_ptr = reinterpret_cast<uint8_t*>(out.data_ptr());
   const int64_t n = out.numel();
-  at::parallel_for(0, n, at::internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
-    for (const auto i : c10::irange(begin, end)) {
-      uint8_t lo = c10::detail::fp4e2m1_from_fp32_value(in_ptr[2 * i]);
-      uint8_t hi = c10::detail::fp4e2m1_from_fp32_value(in_ptr[2 * i + 1]);
-      out_ptr[i] = static_cast<uint8_t>((hi << 4) | lo);
-    }
-  });
+  at::parallel_for(
+      0, n, at::internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+        for (const auto i : c10::irange(begin, end)) {
+          uint8_t lo = c10::detail::fp4e2m1_from_fp32_value(in_ptr[2 * i]);
+          uint8_t hi = c10::detail::fp4e2m1_from_fp32_value(in_ptr[2 * i + 1]);
+          out_ptr[i] = static_cast<uint8_t>((hi << 4) | lo);
+        }
+      });
   return out;
 }
 
@@ -283,6 +307,31 @@ Tensor _convert_to_float4_e2m1fn_x2_meta(const Tensor& self) {
   return at::empty_symint(
       float4_e2m1fn_x2_packed_sizes(self),
       self.options().dtype(kFloat4_e2m1fn_x2));
+}
+
+Tensor _convert_from_float4_e2m1fn_x2_cpu(const Tensor& self) {
+  check_convert_from_float4_input(self);
+  auto input = self.contiguous();
+  auto out = at::empty_symint(
+      float4_e2m1fn_x2_unpacked_sizes(input), input.options().dtype(kFloat));
+  const auto* in_ptr = reinterpret_cast<const uint8_t*>(input.const_data_ptr());
+  float* out_ptr = out.data_ptr<float>();
+  const int64_t n = input.numel();
+  at::parallel_for(
+      0, n, at::internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+        for (const auto i : c10::irange(begin, end)) {
+          const uint8_t byte = in_ptr[i];
+          out_ptr[2 * i] = c10::detail::fp4e2m1_to_fp32_value(byte & 0xF);
+          out_ptr[2 * i + 1] = c10::detail::fp4e2m1_to_fp32_value(byte >> 4);
+        }
+      });
+  return out;
+}
+
+Tensor _convert_from_float4_e2m1fn_x2_meta(const Tensor& self) {
+  check_convert_from_float4_input(self);
+  return at::empty_symint(
+      float4_e2m1fn_x2_unpacked_sizes(self), self.options().dtype(kFloat));
 }
 
 Tensor _to_copy(
@@ -494,8 +543,7 @@ static inline Tensor to_impl(
   }
   // Casting to fp4 is shape-changing, so we cannot reuse the _to_copy machinery
   // like we do for whole-byte casts and have to use a custom kernel.
-  if (dtype == kFloat4_e2m1fn_x2 &&
-      self.scalar_type() != kFloat4_e2m1fn_x2) {
+  if (dtype == kFloat4_e2m1fn_x2 && self.scalar_type() != kFloat4_e2m1fn_x2) {
     TORCH_CHECK(
         !layout.has_value() || self.layout() == layout.value(),
         "conversion to Float4_e2m1fn_x2 does not support changing layout");
@@ -504,6 +552,24 @@ static inline Tensor to_impl(
       result = result.to(device.value(), non_blocking);
     }
     return result;
+  }
+  // Casting from fp4 is shape-changing too (each byte unpacks to two values),
+  // so it likewise cannot use the _to_copy machinery. Unpack to fp32 here, then
+  // let the normal cast handle any remaining dtype/device change.
+  if (self.scalar_type() == kFloat4_e2m1fn_x2 && dtype.has_value() &&
+      dtype.value() != kFloat4_e2m1fn_x2) {
+    TORCH_CHECK(
+        !layout.has_value() || self.layout() == layout.value(),
+        "conversion from Float4_e2m1fn_x2 does not support changing layout");
+    auto result = at::_convert_from_float4_e2m1fn_x2(self);
+    return at::_to_copy(
+        result,
+        dtype,
+        layout,
+        device,
+        pin_memory,
+        non_blocking,
+        optional_memory_format);
   }
   return at::_to_copy(
       self,

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -2,6 +2,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
+#include <c10/util/Float4_e2m1fn_x2.h>
 #include <ATen/TensorOperators.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/quantized/Quantizer.h>
@@ -17,6 +18,8 @@
 #include <ATen/ops/_convert_indices_from_coo_to_csr_native.h>
 #include <ATen/ops/_convert_indices_from_csr_to_coo.h>
 #include <ATen/ops/_convert_indices_from_csr_to_coo_native.h>
+#include <ATen/ops/_convert_to_float4_e2m1fn_x2.h>
+#include <ATen/ops/_convert_to_float4_e2m1fn_x2_native.h>
 #include <ATen/ops/_sparse_bsc_tensor_unsafe_native.h>
 #include <ATen/ops/_sparse_bsr_tensor_unsafe_native.h>
 #include <ATen/ops/_sparse_compressed_tensor_unsafe_native.h>
@@ -229,6 +232,59 @@ static inline std::optional<Device> ensure_has_index(
   return ensure_has_index(device.value());
 }
 
+// Output sizes for packing a floating tensor into Float4_e2m1fn_x2: the last
+// dimension is halved because two fp4 values share one byte. Symbolic-aware so
+// the meta path preserves dynamic shapes instead of specializing to constants.
+static SymDimVector float4_e2m1fn_x2_packed_sizes(const Tensor& self) {
+  TORCH_CHECK(
+      self.dim() >= 1,
+      "conversion to Float4_e2m1fn_x2 requires the last dimension to be even, got shape ",
+      self.sym_sizes());
+  auto last = self.sym_size(-1);
+  TORCH_SYM_CHECK(
+      (last % 2).sym_eq(0),
+      "conversion to Float4_e2m1fn_x2 requires the last dimension to be even, got shape ",
+      self.sym_sizes());
+  SymDimVector sizes(self.sym_sizes().begin(), self.sym_sizes().end());
+  sizes.back() = last / 2;
+  return sizes;
+}
+
+static void check_convert_to_float4_input(const Tensor& self) {
+  TORCH_CHECK(
+      isFloatingType(self.scalar_type()) &&
+          self.scalar_type() != kFloat4_e2m1fn_x2,
+      "conversion to Float4_e2m1fn_x2 is only supported from a floating point "
+      "dtype, got ",
+      self.scalar_type());
+}
+
+Tensor _convert_to_float4_e2m1fn_x2_cpu(const Tensor& self) {
+  check_convert_to_float4_input(self);
+  auto input = self.to(kFloat).contiguous();
+  auto out = at::empty_symint(
+      float4_e2m1fn_x2_packed_sizes(input),
+      input.options().dtype(kFloat4_e2m1fn_x2));
+  const float* in_ptr = input.const_data_ptr<float>();
+  auto* out_ptr = reinterpret_cast<uint8_t*>(out.data_ptr());
+  const int64_t n = out.numel();
+  at::parallel_for(0, n, at::internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    for (const auto i : c10::irange(begin, end)) {
+      uint8_t lo = c10::detail::fp4e2m1_from_fp32_value(in_ptr[2 * i]);
+      uint8_t hi = c10::detail::fp4e2m1_from_fp32_value(in_ptr[2 * i + 1]);
+      out_ptr[i] = static_cast<uint8_t>((hi << 4) | lo);
+    }
+  });
+  return out;
+}
+
+Tensor _convert_to_float4_e2m1fn_x2_meta(const Tensor& self) {
+  check_convert_to_float4_input(self);
+  return at::empty_symint(
+      float4_e2m1fn_x2_packed_sizes(self),
+      self.options().dtype(kFloat4_e2m1fn_x2));
+}
+
 Tensor _to_copy(
     const Tensor& self,
     std::optional<ScalarType> dtype,
@@ -435,6 +491,21 @@ static inline Tensor to_impl(
   if (to_will_alias(
           self, dtype, layout, device, copy, optional_memory_format)) {
     return self;
+  }
+  // Casting a floating tensor to the packed fp4 dtype changes the element count
+  // (two fp4 values per byte), so it cannot go through the shape-preserving
+  // copy_ path. Route it to a dedicated, non-differentiable conversion here,
+  // above _to_copy, so no (shape-mismatched) ToCopyBackward is recorded.
+  if (dtype == kFloat4_e2m1fn_x2 &&
+      self.scalar_type() != kFloat4_e2m1fn_x2) {
+    TORCH_CHECK(
+        !layout.has_value() || self.layout() == layout.value(),
+        "conversion to Float4_e2m1fn_x2 does not support changing layout");
+    auto result = at::_convert_to_float4_e2m1fn_x2(self);
+    if (device.has_value() && device.value() != self.device()) {
+      result = result.to(device.value(), non_blocking);
+    }
+    return result;
   }
   return at::_to_copy(
       self,

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -492,10 +492,8 @@ static inline Tensor to_impl(
           self, dtype, layout, device, copy, optional_memory_format)) {
     return self;
   }
-  // Casting a floating tensor to the packed fp4 dtype changes the element count
-  // (two fp4 values per byte), so it cannot go through the shape-preserving
-  // copy_ path. Route it to a dedicated, non-differentiable conversion here,
-  // above _to_copy, so no (shape-mismatched) ToCopyBackward is recorded.
+  // Casting to fp4 is shape-changing, so we cannot reuse the _to_copy machinery
+  // like we do for whole-byte casts and have to use a custom kernel.
   if (dtype == kFloat4_e2m1fn_x2 &&
       self.scalar_type() != kFloat4_e2m1fn_x2) {
     TORCH_CHECK(

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -301,20 +301,31 @@ static void check_convert_from_float4_input(const Tensor& self) {
 
 Tensor _convert_to_float4_e2m1fn_x2_cpu(const Tensor& self) {
   check_convert_to_float4_input(self);
-  auto input = self.to(kFloat);
   auto out = at::empty_symint(
-      float4_e2m1fn_x2_packed_sizes(input),
-      input.options().dtype(kFloat4_e2m1fn_x2));
-  const float* in_ptr = input.const_data_ptr<float>();
+      float4_e2m1fn_x2_packed_sizes(self),
+      self.options().dtype(kFloat4_e2m1fn_x2));
   auto* out_ptr = reinterpret_cast<uint8_t*>(out.data_ptr());
   const int64_t n = out.numel();
-  at::parallel_for(
-      0, n, at::internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
-        for (const auto i : c10::irange(begin, end)) {
-          uint8_t lo = c10::detail::fp4e2m1_from_fp32_value(in_ptr[2 * i]);
-          uint8_t hi = c10::detail::fp4e2m1_from_fp32_value(in_ptr[2 * i + 1]);
-          out_ptr[i] = static_cast<uint8_t>((hi << 4) | lo);
-        }
+  // Read the low-precision input directly and narrow per element, rather than
+  // materializing a full float32 temp via self.to(kFloat); double is excluded
+  // by check_convert_to_float4_input above.
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      kHalf,
+      kBFloat16,
+      self.scalar_type(),
+      "_convert_to_float4_e2m1fn_x2_cpu",
+      [&] {
+        const scalar_t* in_ptr = self.const_data_ptr<scalar_t>();
+        at::parallel_for(
+            0, n, at::internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+              for (const auto i : c10::irange(begin, end)) {
+                uint8_t lo = c10::detail::fp4e2m1_from_fp32_value(
+                    static_cast<float>(in_ptr[2 * i]));
+                uint8_t hi = c10::detail::fp4e2m1_from_fp32_value(
+                    static_cast<float>(in_ptr[2 * i + 1]));
+                out_ptr[i] = static_cast<uint8_t>((hi << 4) | lo);
+              }
+            });
       });
   return out;
 }
@@ -572,7 +583,12 @@ static inline Tensor to_impl(
     auto result = at::_convert_to_float4_e2m1fn_x2(self);
     if (!pin_memory.value_or(false) &&
         to_will_alias(
-            result, std::nullopt, layout, device, false, optional_memory_format)) {
+            result,
+            std::nullopt,
+            layout,
+            device,
+            false,
+            optional_memory_format)) {
       return result;
     }
     return at::_to_copy(

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -264,12 +264,17 @@ static void check_convert_to_float4_input(const Tensor& self) {
       "conversion to Float4_e2m1fn_x2 is only supported from a floating point "
       "dtype other than float64, got ",
       self.scalar_type());
-  // Require a contiguous input: the pack kernel assumes row-major layout (two
-  // fp4 values share a byte along the last dim). Supporting arbitrary strides
-  // would need stride-aware kernels, which is not worth it right now.
-  TORCH_CHECK(
-      self.is_contiguous(),
-      "conversion to Float4_e2m1fn_x2 requires a contiguous input");
+  // Require the last dimension to be contiguous: the pack fuses two adjacent
+  // last-dim values into one byte, so they must be adjacent in memory. Outer
+  // dimensions may be strided; the kernels handle that (CUDA via
+  // TensorIterator, CPU via a contiguous copy). Use the symbolic stride so the
+  // dynamic-shape meta path stays unspecialized (a contiguous tensor has a
+  // literal stride of 1 here, so this adds no guard).
+  if (self.dim() >= 1) {
+    TORCH_SYM_CHECK(
+        self.sym_stride(-1).sym_eq(1),
+        "conversion to Float4_e2m1fn_x2 requires the last dimension to be contiguous");
+  }
 }
 
 // Output sizes for unpacking a Float4_e2m1fn_x2 tensor: the last dimension is
@@ -291,12 +296,9 @@ static void check_convert_from_float4_input(const Tensor& self) {
       "conversion from Float4_e2m1fn_x2 is only supported from a "
       "Float4_e2m1fn_x2 dtype, got ",
       self.scalar_type());
-  // Require a contiguous input: the unpack kernel assumes row-major layout (two
-  // fp4 values share a byte along the last dim). Supporting arbitrary strides
-  // would need stride-aware kernels, which is not worth it right now.
-  TORCH_CHECK(
-      self.is_contiguous(),
-      "conversion from Float4_e2m1fn_x2 requires a contiguous input");
+  // No layout requirement: each byte unpacks independently into two outputs, so
+  // any strided input is fine (CUDA reads it through TensorIterator, CPU
+  // through a contiguous copy).
 }
 
 Tensor _convert_to_float4_e2m1fn_x2_cpu(const Tensor& self) {
@@ -304,6 +306,10 @@ Tensor _convert_to_float4_e2m1fn_x2_cpu(const Tensor& self) {
   auto out = at::empty_symint(
       float4_e2m1fn_x2_packed_sizes(self),
       self.options().dtype(kFloat4_e2m1fn_x2));
+  // The loop below reads the input as a flat contiguous buffer; materialize a
+  // contiguous copy when the input is only last-dim contiguous (no-op if it is
+  // already contiguous).
+  const Tensor input = self.contiguous();
   auto* out_ptr = reinterpret_cast<uint8_t*>(out.data_ptr());
   const int64_t n = out.numel();
   // Read the low-precision input directly and narrow per element, rather than
@@ -315,7 +321,7 @@ Tensor _convert_to_float4_e2m1fn_x2_cpu(const Tensor& self) {
       self.scalar_type(),
       "_convert_to_float4_e2m1fn_x2_cpu",
       [&] {
-        const scalar_t* in_ptr = self.const_data_ptr<scalar_t>();
+        const scalar_t* in_ptr = input.const_data_ptr<scalar_t>();
         at::parallel_for(
             0, n, at::internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
               for (const auto i : c10::irange(begin, end)) {
@@ -339,7 +345,9 @@ Tensor _convert_to_float4_e2m1fn_x2_meta(const Tensor& self) {
 
 Tensor _convert_from_float4_e2m1fn_x2_cpu(const Tensor& self) {
   check_convert_from_float4_input(self);
-  const Tensor& input = self;
+  // The loop below reads the input as a flat contiguous buffer; materialize a
+  // contiguous copy when the input is strided (no-op if already contiguous).
+  const Tensor input = self.contiguous();
   auto out = at::empty_symint(
       float4_e2m1fn_x2_unpacked_sizes(input), input.options().dtype(kFloat));
   const auto* in_ptr = reinterpret_cast<const uint8_t*>(input.const_data_ptr());

--- a/aten/src/ATen/native/cuda/Float4Conversion.cu
+++ b/aten/src/ATen/native/cuda/Float4Conversion.cu
@@ -1,0 +1,70 @@
+#include <ATen/core/Tensor.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/util/Float4_e2m1fn_x2.h>
+
+#include <algorithm>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/empty.h>
+#include <ATen/ops/_convert_to_float4_e2m1fn_x2_native.h>
+#endif
+
+namespace at::native {
+
+namespace {
+
+__global__ void convert_to_float4_e2m1fn_x2_kernel(
+    const float* in,
+    uint8_t* out,
+    int64_t n_out) {
+  const int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < n_out;
+       i += stride) {
+    uint8_t lo = c10::detail::fp4e2m1_from_fp32_value(in[2 * i]);
+    uint8_t hi = c10::detail::fp4e2m1_from_fp32_value(in[2 * i + 1]);
+    out[i] = static_cast<uint8_t>((hi << 4) | lo);
+  }
+}
+
+} // namespace
+
+Tensor _convert_to_float4_e2m1fn_x2_cuda(const Tensor& self) {
+  TORCH_CHECK(
+      isFloatingType(self.scalar_type()) &&
+          self.scalar_type() != kFloat4_e2m1fn_x2,
+      "conversion to Float4_e2m1fn_x2 is only supported from a floating point "
+      "dtype, got ",
+      self.scalar_type());
+  TORCH_CHECK(
+      self.dim() >= 1 && self.size(-1) % 2 == 0,
+      "conversion to Float4_e2m1fn_x2 requires the last dimension to be even, got shape ",
+      self.sizes());
+
+  auto input = self.to(kFloat).contiguous();
+  auto sizes = input.sizes().vec();
+  sizes.back() /= 2;
+  auto out = at::empty(sizes, input.options().dtype(kFloat4_e2m1fn_x2));
+
+  const int64_t n_out = out.numel();
+  if (n_out == 0) {
+    return out;
+  }
+
+  constexpr int threads = 256;
+  const int64_t blocks = std::min<int64_t>(
+      (n_out + threads - 1) / threads, static_cast<int64_t>(65535));
+  auto stream = at::cuda::getCurrentCUDAStream();
+  convert_to_float4_e2m1fn_x2_kernel<<<blocks, threads, 0, stream>>>(
+      input.const_data_ptr<float>(),
+      reinterpret_cast<uint8_t*>(out.data_ptr()),
+      n_out);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out;
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Float4Conversion.cu
+++ b/aten/src/ATen/native/cuda/Float4Conversion.cu
@@ -49,18 +49,33 @@ __global__ void convert_from_float4_e2m1fn_x2_kernel(
 } // namespace
 
 Tensor _convert_to_float4_e2m1fn_x2_cuda(const Tensor& self) {
+  // float64 is rejected: the kernel narrows the input through an intermediate
+  // float32 (self.to(kFloat)), and a double within half a float32 ULP of an
+  // exact fp4 midpoint would double-round to the wrong bucket.
+  // TODO(future PR): implement cast from float64 if there is a need, for now
+  // not worth the extra complexity
   TORCH_CHECK(
       isFloatingType(self.scalar_type()) &&
-          self.scalar_type() != kFloat4_e2m1fn_x2,
+          self.scalar_type() != kFloat4_e2m1fn_x2 &&
+          self.scalar_type() != kDouble,
       "conversion to Float4_e2m1fn_x2 is only supported from a floating point "
-      "dtype, got ",
+      "dtype other than float64, got ",
       self.scalar_type());
+  // Require a contiguous input: the pack kernel assumes row-major layout (two
+  // fp4 values share a byte along the last dim). Supporting arbitrary strides
+  // would need stride-aware kernels, which is not worth it right now.
   TORCH_CHECK(
-      self.dim() >= 1 && self.size(-1) % 2 == 0,
+      self.is_contiguous(),
+      "conversion to Float4_e2m1fn_x2 requires a contiguous input");
+  TORCH_CHECK(
+      self.dim() >= 1,
+      "conversion to Float4_e2m1fn_x2 requires at least 1 dimension, got a 0-dim tensor");
+  TORCH_CHECK(
+      self.size(-1) % 2 == 0,
       "conversion to Float4_e2m1fn_x2 requires the last dimension to be even, got shape ",
       self.sizes());
 
-  auto input = self.to(kFloat).contiguous();
+  auto input = self.to(kFloat);
   auto sizes = input.sizes().vec();
   sizes.back() /= 2;
   auto out = at::empty(sizes, input.options().dtype(kFloat4_e2m1fn_x2));
@@ -90,7 +105,13 @@ Tensor _convert_from_float4_e2m1fn_x2_cuda(const Tensor& self) {
       "conversion from Float4_e2m1fn_x2 is only supported from a "
       "Float4_e2m1fn_x2 dtype, got ",
       self.scalar_type());
-  auto input = self.contiguous();
+  // Require a contiguous input: the unpack kernel assumes row-major layout (two
+  // fp4 values share a byte along the last dim). Supporting arbitrary strides
+  // would need stride-aware kernels, which is not worth it right now.
+  TORCH_CHECK(
+      self.is_contiguous(),
+      "conversion from Float4_e2m1fn_x2 requires a contiguous input");
+  const Tensor& input = self;
   auto sizes = input.sizes().vec();
   TORCH_CHECK(
       !sizes.empty(),

--- a/aten/src/ATen/native/cuda/Float4Conversion.cu
+++ b/aten/src/ATen/native/cuda/Float4Conversion.cu
@@ -59,6 +59,8 @@ Tensor _convert_to_float4_e2m1fn_x2_cuda(const Tensor& self) {
   const int64_t blocks = std::min<int64_t>(
       (n_out + threads - 1) / threads, static_cast<int64_t>(65535));
   auto stream = at::cuda::getCurrentCUDAStream();
+  // TODO(future PR): use hardware intrinsics instead of bitshifting on 
+  // CUDA 10.0+
   convert_to_float4_e2m1fn_x2_kernel<<<blocks, threads, 0, stream>>>(
       input.const_data_ptr<float>(),
       reinterpret_cast<uint8_t*>(out.data_ptr()),

--- a/aten/src/ATen/native/cuda/Float4Conversion.cu
+++ b/aten/src/ATen/native/cuda/Float4Conversion.cu
@@ -11,6 +11,7 @@
 #else
 #include <ATen/ops/empty.h>
 #include <ATen/ops/_convert_to_float4_e2m1fn_x2_native.h>
+#include <ATen/ops/_convert_from_float4_e2m1fn_x2_native.h>
 #endif
 
 namespace at::native {
@@ -28,6 +29,20 @@ __global__ void convert_to_float4_e2m1fn_x2_kernel(
     uint8_t lo = c10::detail::fp4e2m1_from_fp32_value(in[2 * i]);
     uint8_t hi = c10::detail::fp4e2m1_from_fp32_value(in[2 * i + 1]);
     out[i] = static_cast<uint8_t>((hi << 4) | lo);
+  }
+}
+
+__global__ void convert_from_float4_e2m1fn_x2_kernel(
+    const uint8_t* in,
+    float* out,
+    int64_t n_in) {
+  const int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < n_in;
+       i += stride) {
+    const uint8_t byte = in[i];
+    out[2 * i] = c10::detail::fp4e2m1_to_fp32_value(byte & 0xF);
+    out[2 * i + 1] = c10::detail::fp4e2m1_to_fp32_value(byte >> 4);
   }
 }
 
@@ -59,12 +74,44 @@ Tensor _convert_to_float4_e2m1fn_x2_cuda(const Tensor& self) {
   const int64_t blocks = std::min<int64_t>(
       (n_out + threads - 1) / threads, static_cast<int64_t>(65535));
   auto stream = at::cuda::getCurrentCUDAStream();
-  // TODO(future PR): use hardware intrinsics instead of bitshifting on 
+  // TODO(future PR): use hardware intrinsics instead of bitshifting on
   // CUDA 10.0+
   convert_to_float4_e2m1fn_x2_kernel<<<blocks, threads, 0, stream>>>(
       input.const_data_ptr<float>(),
       reinterpret_cast<uint8_t*>(out.data_ptr()),
       n_out);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out;
+}
+
+Tensor _convert_from_float4_e2m1fn_x2_cuda(const Tensor& self) {
+  TORCH_CHECK(
+      self.scalar_type() == kFloat4_e2m1fn_x2,
+      "conversion from Float4_e2m1fn_x2 is only supported from a "
+      "Float4_e2m1fn_x2 dtype, got ",
+      self.scalar_type());
+  auto input = self.contiguous();
+  auto sizes = input.sizes().vec();
+  TORCH_CHECK(
+      !sizes.empty(),
+      "conversion from Float4_e2m1fn_x2 requires at least 1 dimension, got shape ",
+      input.sizes());
+  sizes.back() *= 2;
+  auto out = at::empty(sizes, input.options().dtype(kFloat));
+
+  const int64_t n_in = input.numel();
+  if (n_in == 0) {
+    return out;
+  }
+
+  constexpr int threads = 256;
+  const int64_t blocks = std::min<int64_t>(
+      (n_in + threads - 1) / threads, static_cast<int64_t>(65535));
+  auto stream = at::cuda::getCurrentCUDAStream();
+  convert_from_float4_e2m1fn_x2_kernel<<<blocks, threads, 0, stream>>>(
+      reinterpret_cast<const uint8_t*>(input.const_data_ptr()),
+      out.data_ptr<float>(),
+      n_in);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return out;
 }

--- a/aten/src/ATen/native/cuda/Float4Conversion.cu
+++ b/aten/src/ATen/native/cuda/Float4Conversion.cu
@@ -4,6 +4,7 @@
 #include <ATen/native/cuda/Loops.cuh>
 #include <c10/util/Float4_e2m1fn_x2.h>
 #include <c10/util/bit_cast.h>
+#include <c10/util/irange.h>
 
 #include <cuda.h>
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
@@ -56,16 +57,15 @@ Tensor _convert_to_float4_e2m1fn_x2_cuda(const Tensor& self) {
       "conversion to Float4_e2m1fn_x2 is only supported from a floating point "
       "dtype other than float64, got ",
       self.scalar_type());
-  // Require a contiguous input: the pack reinterprets each pair of last-dim
-  // values as one wider element, which assumes row-major layout. Supporting
-  // arbitrary strides would need stride-aware kernels, which is not worth it
-  // right now.
-  TORCH_CHECK(
-      self.is_contiguous(),
-      "conversion to Float4_e2m1fn_x2 requires a contiguous input");
   TORCH_CHECK(
       self.dim() >= 1,
       "conversion to Float4_e2m1fn_x2 requires at least 1 dimension, got a 0-dim tensor");
+  // Require the last dimension to be contiguous: the pack fuses two adjacent
+  // last-dim values into one byte, so they must be adjacent in memory. Outer
+  // dimensions may be strided; TensorIterator handles the outer strides.
+  TORCH_CHECK(
+      self.stride(-1) == 1,
+      "conversion to Float4_e2m1fn_x2 requires the last dimension to be contiguous");
   TORCH_CHECK(
       self.size(-1) % 2 == 0,
       "conversion to Float4_e2m1fn_x2 requires the last dimension to be even, got shape ",
@@ -81,7 +81,14 @@ Tensor _convert_to_float4_e2m1fn_x2_cuda(const Tensor& self) {
   // Pack two consecutive inputs into each output byte. We reinterpret each input
   // pair as a single element twice as wide (fp32->fp64, bf16/fp16->fp32) so the
   // cast becomes a 1:1 elementwise map; TensorIterator then handles vectorized
-  // loads/stores instead of a hand-written kernel.
+  // loads/stores instead of a hand-written kernel. The wide view additionally
+  // needs even outer strides and storage offset, which last-dim contiguity does
+  // not guarantee, so fall back to a contiguous copy when it does not hold.
+  bool can_view_wide = self.storage_offset() % 2 == 0;
+  for (const auto d : c10::irange(self.dim() - 1)) {
+    can_view_wide = can_view_wide && self.stride(d) % 2 == 0;
+  }
+  const Tensor src = can_view_wide ? self : self.contiguous();
   auto out_bytes = out.view(kByte);
   AT_DISPATCH_V2(
       self.scalar_type(),
@@ -89,7 +96,7 @@ Tensor _convert_to_float4_e2m1fn_x2_cuda(const Tensor& self) {
       AT_WRAP([&] {
         constexpr bool is_4byte = std::is_same_v<scalar_t, float>;
         using wide_t = std::conditional_t<is_4byte, double, float>;
-        auto input = self.view(is_4byte ? kDouble : kFloat);
+        auto input = src.view(is_4byte ? kDouble : kFloat);
         auto iter = TensorIteratorConfig()
                         .check_all_same_dtype(false)
                         .add_output(out_bytes)
@@ -113,13 +120,9 @@ Tensor _convert_from_float4_e2m1fn_x2_cuda(const Tensor& self) {
       "conversion from Float4_e2m1fn_x2 is only supported from a "
       "Float4_e2m1fn_x2 dtype, got ",
       self.scalar_type());
-  // Require a contiguous input: the unpack reinterprets each pair of output
-  // values as one wider element, which assumes row-major layout. Supporting
-  // arbitrary strides would need stride-aware kernels, which is not worth it
-  // right now.
-  TORCH_CHECK(
-      self.is_contiguous(),
-      "conversion from Float4_e2m1fn_x2 requires a contiguous input");
+  // No layout requirement: each byte unpacks independently into two outputs, so
+  // any strided input is fine. The input is viewed as kByte (same itemsize, any
+  // strides) and TensorIterator reads it; only the output is reinterpreted wide.
   TORCH_CHECK(
       self.dim() >= 1,
       "conversion from Float4_e2m1fn_x2 requires at least 1 dimension, got shape ",

--- a/aten/src/ATen/native/cuda/Float4Conversion.cu
+++ b/aten/src/ATen/native/cuda/Float4Conversion.cu
@@ -1,9 +1,18 @@
 #include <ATen/core/Tensor.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAException.h>
+#include <ATen/Dispatch_v2.h>
+#include <ATen/TensorIterator.h>
+#include <ATen/native/cuda/Loops.cuh>
 #include <c10/util/Float4_e2m1fn_x2.h>
+#include <c10/util/bit_cast.h>
 
-#include <algorithm>
+#include <cuda.h>
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+#include <cuda_fp4.h>
+#define AT_FP4_HAS_CVT_INTRINSIC 1
+#endif
+
+#include <array>
+#include <type_traits>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -18,40 +27,26 @@ namespace at::native {
 
 namespace {
 
-__global__ void convert_to_float4_e2m1fn_x2_kernel(
-    const float* in,
-    uint8_t* out,
-    int64_t n_out) {
-  const int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
-  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-       i < n_out;
-       i += stride) {
-    uint8_t lo = c10::detail::fp4e2m1_from_fp32_value(in[2 * i]);
-    uint8_t hi = c10::detail::fp4e2m1_from_fp32_value(in[2 * i + 1]);
-    out[i] = static_cast<uint8_t>((hi << 4) | lo);
-  }
-}
-
-__global__ void convert_from_float4_e2m1fn_x2_kernel(
-    const uint8_t* in,
-    float* out,
-    int64_t n_in) {
-  const int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
-  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-       i < n_in;
-       i += stride) {
-    const uint8_t byte = in[i];
-    out[2 * i] = c10::detail::fp4e2m1_to_fp32_value(byte & 0xF);
-    out[2 * i + 1] = c10::detail::fp4e2m1_to_fp32_value(byte >> 4);
-  }
+// Pack two fp32 values into one fp4x2 byte (val_a -> low nibble, val_b -> high).
+// On sm_100+ this uses the hardware fp4 convert intrinsic; the software encoder
+// below matches its numerics exactly (including NaN -> positive max magnitude),
+// so the two paths produce identical bytes on every architecture.
+C10_HOST_DEVICE inline uint8_t pack_two_fp4(float a, float b) {
+#if defined(AT_FP4_HAS_CVT_INTRINSIC) && defined(__CUDA_ARCH__) && \
+    __CUDA_ARCH__ >= 1000
+  return __nv_cvt_float2_to_fp4x2(make_float2(a, b), __NV_E2M1, cudaRoundNearest);
+#else
+  uint8_t lo = c10::detail::fp4e2m1_from_fp32_value(a);
+  uint8_t hi = c10::detail::fp4e2m1_from_fp32_value(b);
+  return static_cast<uint8_t>((hi << 4) | lo);
+#endif
 }
 
 } // namespace
 
 Tensor _convert_to_float4_e2m1fn_x2_cuda(const Tensor& self) {
-  // float64 is rejected: the kernel narrows the input through an intermediate
-  // float32 (self.to(kFloat)), and a double within half a float32 ULP of an
-  // exact fp4 midpoint would double-round to the wrong bucket.
+  // float64 is rejected: the encode narrows through an intermediate float32, and
+  // a double within half a float32 ULP of an exact fp4 midpoint would double-round.
   // TODO(future PR): implement cast from float64 if there is a need, for now
   // not worth the extra complexity
   TORCH_CHECK(
@@ -61,9 +56,10 @@ Tensor _convert_to_float4_e2m1fn_x2_cuda(const Tensor& self) {
       "conversion to Float4_e2m1fn_x2 is only supported from a floating point "
       "dtype other than float64, got ",
       self.scalar_type());
-  // Require a contiguous input: the pack kernel assumes row-major layout (two
-  // fp4 values share a byte along the last dim). Supporting arbitrary strides
-  // would need stride-aware kernels, which is not worth it right now.
+  // Require a contiguous input: the pack reinterprets each pair of last-dim
+  // values as one wider element, which assumes row-major layout. Supporting
+  // arbitrary strides would need stride-aware kernels, which is not worth it
+  // right now.
   TORCH_CHECK(
       self.is_contiguous(),
       "conversion to Float4_e2m1fn_x2 requires a contiguous input");
@@ -75,27 +71,39 @@ Tensor _convert_to_float4_e2m1fn_x2_cuda(const Tensor& self) {
       "conversion to Float4_e2m1fn_x2 requires the last dimension to be even, got shape ",
       self.sizes());
 
-  auto input = self.to(kFloat);
-  auto sizes = input.sizes().vec();
+  auto sizes = self.sizes().vec();
   sizes.back() /= 2;
-  auto out = at::empty(sizes, input.options().dtype(kFloat4_e2m1fn_x2));
-
-  const int64_t n_out = out.numel();
-  if (n_out == 0) {
+  auto out = at::empty(sizes, self.options().dtype(kFloat4_e2m1fn_x2));
+  if (out.numel() == 0) {
     return out;
   }
 
-  constexpr int threads = 256;
-  const int64_t blocks = std::min<int64_t>(
-      (n_out + threads - 1) / threads, static_cast<int64_t>(65535));
-  auto stream = at::cuda::getCurrentCUDAStream();
-  // TODO(future PR): use hardware intrinsics instead of bitshifting on
-  // CUDA 10.0+
-  convert_to_float4_e2m1fn_x2_kernel<<<blocks, threads, 0, stream>>>(
-      input.const_data_ptr<float>(),
-      reinterpret_cast<uint8_t*>(out.data_ptr()),
-      n_out);
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  // Pack two consecutive inputs into each output byte. We reinterpret each input
+  // pair as a single element twice as wide (fp32->fp64, bf16/fp16->fp32) so the
+  // cast becomes a 1:1 elementwise map; TensorIterator then handles vectorized
+  // loads/stores instead of a hand-written kernel.
+  auto out_bytes = out.view(kByte);
+  AT_DISPATCH_V2(
+      self.scalar_type(),
+      "_convert_to_float4_e2m1fn_x2_cuda",
+      AT_WRAP([&] {
+        constexpr bool is_4byte = std::is_same_v<scalar_t, float>;
+        using wide_t = std::conditional_t<is_4byte, double, float>;
+        auto input = self.view(is_4byte ? kDouble : kFloat);
+        auto iter = TensorIteratorConfig()
+                        .check_all_same_dtype(false)
+                        .add_output(out_bytes)
+                        .add_input(input)
+                        .build();
+        gpu_kernel(iter, [] GPU_LAMBDA(wide_t packed) -> uint8_t {
+          auto pair = c10::bit_cast<std::array<scalar_t, 2>>(packed);
+          return pack_two_fp4(
+              static_cast<float>(pair[0]), static_cast<float>(pair[1]));
+        });
+      }),
+      kFloat,
+      kHalf,
+      kBFloat16);
   return out;
 }
 
@@ -105,35 +113,41 @@ Tensor _convert_from_float4_e2m1fn_x2_cuda(const Tensor& self) {
       "conversion from Float4_e2m1fn_x2 is only supported from a "
       "Float4_e2m1fn_x2 dtype, got ",
       self.scalar_type());
-  // Require a contiguous input: the unpack kernel assumes row-major layout (two
-  // fp4 values share a byte along the last dim). Supporting arbitrary strides
-  // would need stride-aware kernels, which is not worth it right now.
+  // Require a contiguous input: the unpack reinterprets each pair of output
+  // values as one wider element, which assumes row-major layout. Supporting
+  // arbitrary strides would need stride-aware kernels, which is not worth it
+  // right now.
   TORCH_CHECK(
       self.is_contiguous(),
       "conversion from Float4_e2m1fn_x2 requires a contiguous input");
-  const Tensor& input = self;
-  auto sizes = input.sizes().vec();
   TORCH_CHECK(
-      !sizes.empty(),
+      self.dim() >= 1,
       "conversion from Float4_e2m1fn_x2 requires at least 1 dimension, got shape ",
-      input.sizes());
-  sizes.back() *= 2;
-  auto out = at::empty(sizes, input.options().dtype(kFloat));
+      self.sizes());
 
-  const int64_t n_in = input.numel();
-  if (n_in == 0) {
+  auto sizes = self.sizes().vec();
+  sizes.back() *= 2;
+  auto out = at::empty(sizes, self.options().dtype(kFloat));
+  if (self.numel() == 0) {
     return out;
   }
 
-  constexpr int threads = 256;
-  const int64_t blocks = std::min<int64_t>(
-      (n_in + threads - 1) / threads, static_cast<int64_t>(65535));
-  auto stream = at::cuda::getCurrentCUDAStream();
-  convert_from_float4_e2m1fn_x2_kernel<<<blocks, threads, 0, stream>>>(
-      reinterpret_cast<const uint8_t*>(input.const_data_ptr()),
-      out.data_ptr<float>(),
-      n_in);
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  // Unpack each byte into two floats. We reinterpret each output pair as one
+  // wider float64 element so the map is 1:1 (uint8 -> float64), reusing
+  // TensorIterator's vectorized path.
+  auto in_bytes = self.view(kByte);
+  auto out_wide = out.view(kDouble);
+  auto iter = TensorIteratorConfig()
+                  .check_all_same_dtype(false)
+                  .add_output(out_wide)
+                  .add_input(in_bytes)
+                  .build();
+  gpu_kernel(iter, [] GPU_LAMBDA(uint8_t byte) -> double {
+    std::array<float, 2> pair{
+        c10::detail::fp4e2m1_to_fp32_value(byte & 0xF),
+        c10::detail::fp4e2m1_to_fp32_value(byte >> 4)};
+    return c10::bit_cast<double>(pair);
+  });
   return out;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7648,6 +7648,13 @@
     CPU, CUDA, XPU: quantize_per_tensor_dynamic
   autogen: quantize_per_tensor_dynamic.out
 
+- func: _convert_to_float4_e2m1fn_x2(Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _convert_to_float4_e2m1fn_x2_cpu
+    CUDA: _convert_to_float4_e2m1fn_x2_cuda
+    Meta: _convert_to_float4_e2m1fn_x2_meta
+
 - func: quantize_per_tensor(Tensor self, float scale, int zero_point, ScalarType dtype) -> Tensor
   variants: function
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7655,6 +7655,13 @@
     CUDA: _convert_to_float4_e2m1fn_x2_cuda
     Meta: _convert_to_float4_e2m1fn_x2_meta
 
+- func: _convert_from_float4_e2m1fn_x2(Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _convert_from_float4_e2m1fn_x2_cpu
+    CUDA: _convert_from_float4_e2m1fn_x2_cuda
+    Meta: _convert_from_float4_e2m1fn_x2_meta
+
 - func: quantize_per_tensor(Tensor self, float scale, int zero_point, ScalarType dtype) -> Tensor
   variants: function
   dispatch:

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -53,10 +53,12 @@ aten::_conj_physical
 aten::_conj_physical.out
 aten::_conv_depthwise2d
 aten::_conv_depthwise2d.out
+aten::_convert_from_float4_e2m1fn_x2
 aten::_convert_indices_from_coo_to_csr
 aten::_convert_indices_from_coo_to_csr.out
 aten::_convert_indices_from_csr_to_coo
 aten::_convert_indices_from_csr_to_coo.out
+aten::_convert_to_float4_e2m1fn_x2
 aten::_convert_weight_to_int4pack
 aten::_convert_weight_to_int4pack_for_cpu
 aten::_convolution

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -457,6 +457,31 @@ class TestFloat4Dtype(TestCase):
         ref = pack_uint4(_f32_to_floatx_unpacked(x.float(), FP4_EBITS, FP4_MBITS))
         self.assertEqual(out.view(torch.uint8), ref, atol=0, rtol=0)
 
+    def test_float4_e2m1fn_x2_cast_inf_nan(self, device):
+        # fp4 has no inf/NaN encoding; per the OCP MX spec inf/overflow saturate
+        # to the max magnitude (sign preserved) and NaN (implementation-defined)
+        # is clamped the same way, so every NaN payload maps deterministically.
+        inf = float("inf")
+        nan = float("nan")
+        x = torch.tensor(
+            [[inf, -inf, nan, -nan, 1e30, -1e30, 6.0, -6.0]],
+            device=device,
+        )
+        out = x.to(torch.float4_e2m1fn_x2).to(torch.float32)
+        expected = torch.tensor(
+            [[6.0, -6.0, 6.0, -6.0, 6.0, -6.0, 6.0, -6.0]],
+            device=device,
+        )
+        self.assertEqual(out, expected, atol=0, rtol=0)
+
+        # NaN with an arbitrary payload must also saturate, not slip through
+        payloaded = torch.tensor([0x7FABCDEF], dtype=torch.int32, device=device).view(
+            torch.float32
+        )
+        x2 = torch.cat([payloaded, payloaded]).reshape(1, 2)
+        out2 = x2.to(torch.float4_e2m1fn_x2).to(torch.float32)
+        self.assertEqual(out2, torch.full((1, 2), 6.0, device=device), atol=0, rtol=0)
+
     def test_float4_e2m1fn_x2_cast_non_differentiable(self, device):
         x = torch.randn(2, 4, device=device, requires_grad=True)
         out = x.to(torch.float4_e2m1fn_x2)

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -537,15 +537,35 @@ class TestFloat4Dtype(TestCase):
         with self.assertRaisesRegex(RuntimeError, "other than float64"):
             x.to(torch.float4_e2m1fn_x2)
 
-    def test_float4_e2m1fn_x2_cast_non_contiguous(self, device):
-        # the pack/unpack kernels assume row-major layout, so non-contiguous
-        # inputs are rejected rather than silently made contiguous
+    def test_float4_e2m1fn_x2_cast_last_dim_not_contiguous(self, device):
+        # the pack fuses two adjacent last-dim values into one byte, so the last
+        # dim must be contiguous; a transpose makes it strided and is rejected
         x = torch.randn(4, 8, device=device).t()
-        with self.assertRaisesRegex(RuntimeError, "requires a contiguous input"):
+        with self.assertRaisesRegex(RuntimeError, "last dimension to be contiguous"):
             x.to(torch.float4_e2m1fn_x2)
-        f4 = torch.randn(4, 8, device=device).to(torch.float4_e2m1fn_x2)
-        with self.assertRaisesRegex(RuntimeError, "requires a contiguous input"):
-            f4[:, ::2].to(torch.float32)
+
+    def test_float4_e2m1fn_x2_cast_outer_strided(self, device):
+        # outer dims may be strided as long as the last dim is contiguous; the
+        # result must match casting a contiguous copy. Cover both an even outer
+        # stride (zero-copy wide view) and an odd one (contiguous fallback).
+        even_outer = torch.randn(8, 8, device=device)[::2]  # stride (16, 1)
+        odd_outer = torch.randn(8, 3, device=device)[:, 0:2]  # stride (3, 1)
+        for strided in (even_outer, odd_outer):
+            self.assertFalse(strided.is_contiguous())
+            self.assertEqual(strided.stride(-1), 1)
+            out = strided.to(torch.float4_e2m1fn_x2)
+            ref = strided.contiguous().to(torch.float4_e2m1fn_x2)
+            self.assertEqual(out.view(torch.uint8), ref.view(torch.uint8))
+
+    def test_float4_e2m1fn_x2_cast_from_strided(self, device):
+        # the unpack reads each byte independently, so any strided fp4 input is
+        # supported; the result must match unpacking a contiguous copy
+        f4 = torch.randn(8, 8, device=device).to(torch.float4_e2m1fn_x2)
+        for strided in (f4[:, ::2], f4.t(), f4[::2]):
+            self.assertFalse(strided.is_contiguous())
+            out = strided.to(torch.float32)
+            ref = strided.contiguous().to(torch.float32)
+            self.assertEqual(out, ref)
 
     def test_float4_e2m1fn_x2_cast_cross_device(self, device):
         # dtype + device together: the conversion kernel runs on the source

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -436,51 +436,83 @@ class TestFloat4Dtype(TestCase):
         x1[:, 0:2048].contiguous()
 
     @parametrize("input_dtype", [torch.float, torch.float16, torch.bfloat16])
-    def test_float4_e2m1fn_x2_cast(self, device, input_dtype):
-        # exact representable values, sign, saturation and rounding cases
-        x = torch.tensor(
-            [
-                [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
-                [-0.5, -6.0, 0.3, 100.0, -100.0, 5.0, 2.7, 1.1],
-            ],
+    def test_float4_e2m1fn_x2_cast_finite(self, device, input_dtype):
+        # The fp4 grid, plus the midpoint between each adjacent pair and the
+        # values just below / just above it. RTNE sends an exact midpoint to the
+        # neighbor with an even mantissa bit, which are the grid values at even
+        # indices (0.0, 1.0, 2.0, 4.0); just-below rounds down, just-above up.
+        grid = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
+        grid_t = torch.tensor(grid, device=device, dtype=input_dtype)
+        mid = (grid_t[:-1] + grid_t[1:]) / 2
+        below = torch.nextafter(mid, torch.zeros_like(mid))
+        above = torch.nextafter(mid, torch.full_like(mid, float("inf")))
+        even_neighbor = torch.tensor(
+            [grid[i] if i % 2 == 0 else grid[i + 1] for i in range(len(grid) - 1)],
             device=device,
             dtype=input_dtype,
         )
+
+        x_pos = torch.cat([grid_t, below, mid, above])
+        exp_pos = torch.cat([grid_t, grid_t[:-1], even_neighbor, grid_t[1:]])
+        # include negatives (sign must be preserved) and give a 2D shape with an
+        # even last dim so the pack path is exercised over more than one row
+        x = torch.cat([x_pos, -x_pos]).reshape(-1, 2)
+        expected = torch.cat([exp_pos, -exp_pos]).reshape(-1, 2)
 
         out = x.to(torch.float4_e2m1fn_x2)
 
         # the cast packs two fp4 values per byte, halving the last dim
         self.assertEqual(out.dtype, torch.float4_e2m1fn_x2)
-        self.assertEqual(out.shape, (2, 4))
+        self.assertEqual(out.shape, (x.shape[0], x.shape[1] // 2))
 
         # byte-exact match against the reference encode + pack
         ref = pack_uint4(_f32_to_floatx_unpacked(x.float(), FP4_EBITS, FP4_MBITS))
         self.assertEqual(out.view(torch.uint8), ref, atol=0, rtol=0)
 
-    def test_float4_e2m1fn_x2_cast_inf_nan(self, device):
+        # decoding reproduces the RTNE-rounded grid values (independent of the
+        # reference), pinning the tie-to-even behavior at each midpoint
+        self.assertEqual(out.to(torch.float32), expected.float(), atol=0, rtol=0)
+
+    @parametrize("input_dtype", [torch.float, torch.float16, torch.bfloat16])
+    def test_float4_e2m1fn_x2_cast_inf_nan(self, device, input_dtype):
         # fp4 has no inf/NaN encoding; per the OCP MX spec inf/overflow saturate
         # to the max magnitude (sign preserved) and NaN (implementation-defined)
         # is clamped the same way, so every NaN payload maps deterministically.
+        # All input dtypes reach the same scalar encode after the internal
+        # narrow to float32, so parametrize to pin each one.
+        # inf and finite overflow: the sign is meaningful and preserved.
         inf = float("inf")
-        nan = float("nan")
         x = torch.tensor(
-            [[inf, -inf, nan, -nan, 1e30, -1e30, 6.0, -6.0]],
+            [[inf, -inf, 1e30, -1e30, 6.0, -6.0]],
             device=device,
+            dtype=input_dtype,
         )
         out = x.to(torch.float4_e2m1fn_x2).to(torch.float32)
         expected = torch.tensor(
-            [[6.0, -6.0, 6.0, -6.0, 6.0, -6.0, 6.0, -6.0]],
+            [[6.0, -6.0, 6.0, -6.0, 6.0, -6.0]],
             device=device,
         )
         self.assertEqual(out, expected, atol=0, rtol=0)
 
-        # NaN with an arbitrary payload must also saturate, not slip through
-        payloaded = torch.tensor([0x7FABCDEF], dtype=torch.int32, device=device).view(
-            torch.float32
+        # NaN saturates to the max magnitude too. Its sign is not meaningful and
+        # is not preserved by narrowing casts to float16/bfloat16, so only pin
+        # the magnitude. Build a payloaded NaN (exponent all ones, non-zero
+        # mantissa) from a bit pattern of the input dtype so every dtype
+        # exercises an arbitrary payload rather than a canonical NaN.
+        nan_bits = {
+            torch.float: (torch.int32, 0x7FABCDEF),
+            torch.float16: (torch.int16, 0x7D55),
+            torch.bfloat16: (torch.int16, 0x7FD5),
+        }
+        int_dtype, bits = nan_bits[input_dtype]
+        payloaded = torch.tensor([bits], dtype=int_dtype, device=device).view(
+            input_dtype
         )
         x2 = torch.cat([payloaded, payloaded]).reshape(1, 2)
         out2 = x2.to(torch.float4_e2m1fn_x2).to(torch.float32)
-        self.assertEqual(out2, torch.full((1, 2), 6.0, device=device), atol=0, rtol=0)
+        self.assertEqual(
+            out2.abs(), torch.full((1, 2), 6.0, device=device), atol=0, rtol=0
+        )
 
     def test_float4_e2m1fn_x2_cast_non_differentiable(self, device):
         x = torch.randn(2, 4, device=device, requires_grad=True)
@@ -492,6 +524,44 @@ class TestFloat4Dtype(TestCase):
         x = torch.randn(2, 3, device=device)
         with self.assertRaisesRegex(RuntimeError, "last dimension to be even"):
             x.to(torch.float4_e2m1fn_x2)
+
+    def test_float4_e2m1fn_x2_cast_zero_dim(self, device):
+        x = torch.tensor(1.0, device=device)
+        with self.assertRaisesRegex(RuntimeError, "at least 1 dimension"):
+            x.to(torch.float4_e2m1fn_x2)
+
+    def test_float4_e2m1fn_x2_cast_float64_rejected(self, device):
+        # float64 would narrow through an intermediate float32 and could
+        # double-round near an fp4 midpoint, so it is rejected outright
+        x = torch.randn(2, 4, device=device, dtype=torch.float64)
+        with self.assertRaisesRegex(RuntimeError, "other than float64"):
+            x.to(torch.float4_e2m1fn_x2)
+
+    def test_float4_e2m1fn_x2_cast_non_contiguous(self, device):
+        # the pack/unpack kernels assume row-major layout, so non-contiguous
+        # inputs are rejected rather than silently made contiguous
+        x = torch.randn(4, 8, device=device).t()
+        with self.assertRaisesRegex(RuntimeError, "requires a contiguous input"):
+            x.to(torch.float4_e2m1fn_x2)
+        f4 = torch.randn(4, 8, device=device).to(torch.float4_e2m1fn_x2)
+        with self.assertRaisesRegex(RuntimeError, "requires a contiguous input"):
+            f4[:, ::2].to(torch.float32)
+
+    def test_float4_e2m1fn_x2_cast_cross_device(self, device):
+        # dtype + device together: the conversion kernel runs on the source
+        # device (CPU) and the requested device move is deferred to _to_copy,
+        # so this pins the device-move tail of the forward branch.
+        if torch.device(device).type == "cpu":
+            self.skipTest("cross-device cast needs a non-CPU device")
+        x = torch.randn(2, 8)
+        out = x.to(dtype=torch.float4_e2m1fn_x2, device=device)
+        self.assertEqual(out.dtype, torch.float4_e2m1fn_x2)
+        self.assertEqual(out.device.type, torch.device(device).type)
+        # bytes must match the same cast performed entirely on CPU
+        ref = x.to(torch.float4_e2m1fn_x2)
+        self.assertEqual(
+            out.cpu().view(torch.uint8), ref.view(torch.uint8), atol=0, rtol=0
+        )
 
     @unittest.skipIf(IS_WINDOWS, "torch.compile not supported on Windows yet")
     def test_float4_e2m1fn_x2_cast_compile(self, device):
@@ -562,6 +632,18 @@ class TestFloat4Dtype(TestCase):
         out = f4.to(target_dtype)
         self.assertEqual(out.dtype, target_dtype)
         self.assertEqual(out, f4.to(torch.float32).to(target_dtype), atol=0, rtol=0)
+
+    def test_float4_e2m1fn_x2_cast_from_cross_device(self, device):
+        # fp4 -> float32 with a device move: the unpack runs on the source
+        # device (CPU) and the device change falls through to _to_copy, so this
+        # pins the non-aliasing tail of the reverse branch.
+        if torch.device(device).type == "cpu":
+            self.skipTest("cross-device cast needs a non-CPU device")
+        f4 = torch.randn(2, 8).to(torch.float4_e2m1fn_x2)
+        out = f4.to(dtype=torch.float32, device=device)
+        self.assertEqual(out.dtype, torch.float32)
+        self.assertEqual(out.device.type, torch.device(device).type)
+        self.assertEqual(out.cpu(), f4.to(torch.float32), atol=0, rtol=0)
 
     def test_float4_e2m1fn_x2_cast_from_non_differentiable(self, device):
         f4 = torch.randn(2, 4, device=device).to(torch.float4_e2m1fn_x2)

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -10,6 +10,12 @@ from torch.testing._internal.common_device_type import (
     dtypesIfCUDA,
     instantiate_device_type_tests,
 )
+from torch.testing._internal.common_quantized import (
+    _f32_to_floatx_unpacked,
+    FP4_EBITS,
+    FP4_MBITS,
+    pack_uint4,
+)
 from torch.testing._internal.common_utils import (
     DeterministicGuard,
     IS_WINDOWS,
@@ -427,6 +433,70 @@ class TestFloat4Dtype(TestCase):
 
         # can call contiguous on a dim1 slice (calls `copy_` under the hood)
         x1[:, 0:2048].contiguous()
+
+    @parametrize("input_dtype", [torch.float, torch.float16, torch.bfloat16])
+    def test_float4_e2m1fn_x2_cast(self, device, input_dtype):
+        # exact representable values, sign, saturation and rounding cases
+        x = torch.tensor(
+            [
+                [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+                [-0.5, -6.0, 0.3, 100.0, -100.0, 5.0, 2.7, 1.1],
+            ],
+            device=device,
+            dtype=input_dtype,
+        )
+
+        out = x.to(torch.float4_e2m1fn_x2)
+
+        # the cast packs two fp4 values per byte, halving the last dim
+        self.assertEqual(out.dtype, torch.float4_e2m1fn_x2)
+        self.assertEqual(out.shape, (2, 4))
+
+        # byte-exact match against the reference encode + pack
+        ref = pack_uint4(_f32_to_floatx_unpacked(x.float(), FP4_EBITS, FP4_MBITS))
+        self.assertEqual(out.view(torch.uint8), ref, atol=0, rtol=0)
+
+    def test_float4_e2m1fn_x2_cast_non_differentiable(self, device):
+        x = torch.randn(2, 4, device=device, requires_grad=True)
+        out = x.to(torch.float4_e2m1fn_x2)
+        # the cast is a lossy, element-count changing quantization: non-diff
+        self.assertFalse(out.requires_grad)
+
+    def test_float4_e2m1fn_x2_cast_odd_last_dim(self, device):
+        x = torch.randn(2, 3, device=device)
+        with self.assertRaisesRegex(RuntimeError, "last dimension to be even"):
+            x.to(torch.float4_e2m1fn_x2)
+
+    @unittest.skipIf(IS_WINDOWS, "torch.compile not supported on Windows yet")
+    def test_float4_e2m1fn_x2_cast_compile(self, device):
+        def fn(x):
+            return x.to(torch.float4_e2m1fn_x2)
+
+        x = torch.randn(2, 8, device=device)
+        ref = fn(x)
+        out = torch.compile(fn, backend="inductor", fullgraph=True)(x)
+        self.assertEqual(out.dtype, torch.float4_e2m1fn_x2)
+        self.assertEqual(out.view(torch.uint8), ref.view(torch.uint8), atol=0, rtol=0)
+
+    @unittest.skipIf(IS_WINDOWS, "torch.compile not supported on Windows yet")
+    def test_float4_e2m1fn_x2_cast_dynamic_shape(self, device):
+        # The packed cast halves the last dim, so the meta kernel must stay
+        # symbolic: a dynamic last dim must not be specialized to a constant.
+        from torch._dynamo.utils import counters
+
+        def fn(x):
+            return x.to(torch.float4_e2m1fn_x2)
+
+        torch._dynamo.reset()
+        counters.clear()
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=True)
+        for n in (8, 16, 32):
+            x = torch.randn(2, n, device=device)
+            torch._dynamo.mark_dynamic(x, 1)
+            out = compiled(x)
+            self.assertEqual(out.view(torch.uint8), fn(x).view(torch.uint8), atol=0, rtol=0)
+        # a single graph should cover every size if the last dim stays symbolic
+        self.assertEqual(counters["stats"]["unique_graphs"], 1)
 
     def test_f4_save_load(self, device):
         x1 = torch.randint(0, 10, (4, 4), device=device, dtype=torch.uint8).view(

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -12,6 +12,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_quantized import (
     _f32_to_floatx_unpacked,
+    _floatx_unpacked_to_f32,
     FP4_EBITS,
     FP4_MBITS,
     pack_uint4,
@@ -494,7 +495,82 @@ class TestFloat4Dtype(TestCase):
             x = torch.randn(2, n, device=device)
             torch._dynamo.mark_dynamic(x, 1)
             out = compiled(x)
-            self.assertEqual(out.view(torch.uint8), fn(x).view(torch.uint8), atol=0, rtol=0)
+            self.assertEqual(
+                out.view(torch.uint8), fn(x).view(torch.uint8), atol=0, rtol=0
+            )
+        # a single graph should cover every size if the last dim stays symbolic
+        self.assertEqual(counters["stats"]["unique_graphs"], 1)
+
+    def test_float4_e2m1fn_x2_cast_from(self, device):
+        # decode all 16 codes (8 magnitudes x sign), two per byte, and match the
+        # reference dequant applied to the same unpacked nibbles
+        codes = torch.arange(16, dtype=torch.uint8, device=device).reshape(1, 16)
+        packed = pack_uint4(codes).view(torch.float4_e2m1fn_x2)
+        out = packed.to(torch.float32)
+
+        # unpacking doubles the last dim (two fp4 values per byte)
+        self.assertEqual(out.shape, (1, 16))
+        ref = _floatx_unpacked_to_f32(codes, FP4_EBITS, FP4_MBITS)
+        self.assertEqual(out, ref, atol=0, rtol=0)
+
+    def test_float4_e2m1fn_x2_roundtrip_exact(self, device):
+        # values already on the fp4 grid round-trip bit-exactly
+        grid = torch.tensor(
+            [
+                [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+                [-0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0, -0.0],
+            ],
+            device=device,
+        )
+        back = grid.to(torch.float4_e2m1fn_x2).to(torch.float32)
+        self.assertEqual(back, grid, atol=0, rtol=0)
+
+    @parametrize(
+        "target_dtype",
+        [torch.float16, torch.bfloat16, torch.float8_e4m3fn, torch.float8_e5m2],
+    )
+    def test_float4_e2m1fn_x2_cast_from_targets(self, device, target_dtype):
+        # unpack composes with the normal cast for non-fp32 targets
+        f4 = torch.tensor([[0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]], device=device).to(
+            torch.float4_e2m1fn_x2
+        )
+        out = f4.to(target_dtype)
+        self.assertEqual(out.dtype, target_dtype)
+        self.assertEqual(out, f4.to(torch.float32).to(target_dtype), atol=0, rtol=0)
+
+    def test_float4_e2m1fn_x2_cast_from_non_differentiable(self, device):
+        f4 = torch.randn(2, 4, device=device).to(torch.float4_e2m1fn_x2)
+        with torch.enable_grad():
+            out = f4.to(torch.float32)
+        self.assertFalse(out.requires_grad)
+
+    @unittest.skipIf(IS_WINDOWS, "torch.compile not supported on Windows yet")
+    def test_float4_e2m1fn_x2_cast_from_compile(self, device):
+        def fn(x):
+            return x.to(torch.float32)
+
+        x = torch.randn(2, 8, device=device).to(torch.float4_e2m1fn_x2)
+        ref = fn(x)
+        out = torch.compile(fn, backend="inductor", fullgraph=True)(x)
+        self.assertEqual(out, ref, atol=0, rtol=0)
+
+    @unittest.skipIf(IS_WINDOWS, "torch.compile not supported on Windows yet")
+    def test_float4_e2m1fn_x2_cast_from_dynamic_shape(self, device):
+        # the unpack doubles the last dim, so the meta kernel must stay symbolic:
+        # a dynamic last dim must not be specialized to a constant.
+        from torch._dynamo.utils import counters
+
+        def fn(x):
+            return x.to(torch.float32)
+
+        torch._dynamo.reset()
+        counters.clear()
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=True)
+        for n in (4, 8, 16):
+            x = torch.randn(2, 2 * n, device=device).to(torch.float4_e2m1fn_x2)
+            torch._dynamo.mark_dynamic(x, 1)
+            out = compiled(x)
+            self.assertEqual(out, fn(x), atol=0, rtol=0)
         # a single graph should cover every size if the last dim stays symbolic
         self.assertEqual(counters["stats"]["unique_graphs"], 1)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -288,6 +288,11 @@
   self: angle_backward(grad, self)
   result: handle_r_to_c(result.scalar_type(), angle_backward(self_t.conj(), self_p).conj())
 
+# Casting a float tensor to the packed fp4 dtype is a lossy, element-count
+# changing quantization; there is no meaningful gradient.
+- name: _convert_to_float4_e2m1fn_x2(Tensor self) -> Tensor
+  output_differentiability: [False]
+
 # The four items below are necessary because TensorIterator doesn't work on
 # Variables (codegen does not unwrap the input Tensor for all() and any() ).
 - name: any(Tensor self) -> Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -288,8 +288,13 @@
   self: angle_backward(grad, self)
   result: handle_r_to_c(result.scalar_type(), angle_backward(self_t.conj(), self_p).conj())
 
-# Casting a float tensor to the packed fp4 dtype is a lossy, element-count
-# changing quantization; there is no meaningful gradient.
+# We explicitly do not support differentiability of casting to fp4, because:
+# 1. numerically, all known prod-quality quantization recipes define
+#    a custom backward for the scaling + cast operation together, using
+#    autograd here will be a footgun
+# 2. even if someone wanted (1), to properly support autograd we need to define 
+#    `add` to make grad accumulation work, and adding fp4 numbers with the 
+#    output in fp4 is not numerically useful due to the format's small range
 - name: _convert_to_float4_e2m1fn_x2(Tensor self) -> Tensor
   output_differentiability: [False]
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -292,10 +292,16 @@
 # 1. numerically, all known prod-quality quantization recipes define
 #    a custom backward for the scaling + cast operation together, using
 #    autograd here will be a footgun
-# 2. even if someone wanted (1), to properly support autograd we need to define 
-#    `add` to make grad accumulation work, and adding fp4 numbers with the 
+# 2. even if someone wanted (1), to properly support autograd we need to define
+#    `add` to make grad accumulation work, and adding fp4 numbers with the
 #    output in fp4 is not numerically useful due to the format's small range
 - name: _convert_to_float4_e2m1fn_x2(Tensor self) -> Tensor
+  output_differentiability: [False]
+
+# Casting from fp4 back to a float dtype is non-differentiable for the same
+# reason: a backward would need to accumulate gradients into the fp4 tensor,
+# which requires fp4 `add` (see above).
+- name: _convert_from_float4_e2m1fn_x2(Tensor self) -> Tensor
   output_differentiability: [False]
 
 # The four items below are necessary because TensorIterator doesn't work on

--- a/torch/headeronly/util/Float4_e2m1fn_x2.h
+++ b/torch/headeronly/util/Float4_e2m1fn_x2.h
@@ -25,9 +25,9 @@ namespace detail {
 
 /// Convert a single fp32 value to its 4-bit e2m1 code (sign, 2 exponent, 1
 /// mantissa), returned in the low nibble of a uint8_t. Values are rounded to
-/// nearest even and clamped to the max representable magnitude (6.0); there is
-/// no NaN/inf support. This is a scalar specialization (ebits=2, mbits=1) of
-/// the branchless algorithm in
+/// nearest even. fp4 has no inf/NaN encoding, so both saturate to the max
+/// representable magnitude (6.0), preserving sign. This is a scalar
+/// specialization (ebits=2, mbits=1) of the branchless algorithm in
 /// torch/testing/_internal/common_quantized.py::_f32_to_floatx_unpacked.
 inline C10_HOST_DEVICE uint8_t fp4e2m1_from_fp32_value(float f) {
   constexpr uint32_t denorm_mask_int = 149u << 23;
@@ -41,19 +41,26 @@ inline C10_HOST_DEVICE uint8_t fp4e2m1_from_fp32_value(float f) {
   const float x = c10::bit_cast<float>(bits ^ sign);
 
   uint8_t mag = 0;
-  if (x >= 6.0f) {
-    // saturate to max magnitude code
+  if (!(x < 6.0f)) {
+    // saturation branch, for values >=6, inf and NaN
+    // Note: `!(x < 6.0f)` instead of `(x >= 6.0f)` makes the comparison
+    // also work for NaNs.
     mag = 7;
   } else if (x < 1.0f) {
-    // denormal
+    // denormal branch
+    // x + 2^22
     const uint32_t d = c10::bit_cast<uint32_t>(x + denorm_mask_float);
+    // strip the 2^22 bits out, leaving us with the target code bits
     mag = static_cast<uint8_t>(d - denorm_mask_int);
   } else {
-    // normal: adjust exponent and round to nearest even
+    // normal branch
     int32_t nx = static_cast<int32_t>(bits ^ sign);
     const int32_t mant_odd = (nx >> 22) & 1;
+    // rebias the exponent + round-to-nearest
     nx += val_to_add;
+    // go from round-to-nearest to round-to-nearest-even
     nx += mant_odd;
+    // shift right to the target code bits
     mag = static_cast<uint8_t>(nx >> 22);
   }
   const uint8_t sign_lp = static_cast<uint8_t>(sign >> 28) & 0x8;
@@ -61,9 +68,7 @@ inline C10_HOST_DEVICE uint8_t fp4e2m1_from_fp32_value(float f) {
 }
 
 /// Convert a single 4-bit e2m1 code (in the low nibble of a uint8_t) back to
-/// fp32. e2m1 has only 8 magnitudes, so the magnitude is a direct table lookup
-/// (indexed by the 3 sign-less bits); the sign bit (bit 3) is applied
-/// separately. This is the inverse of fp4e2m1_from_fp32_value.
+/// fp32.
 inline C10_HOST_DEVICE float fp4e2m1_to_fp32_value(uint8_t code) {
   constexpr std::array<float, 8> mag_lut = {
       0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};

--- a/torch/headeronly/util/Float4_e2m1fn_x2.h
+++ b/torch/headeronly/util/Float4_e2m1fn_x2.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <array>
 #include <cstdint>
 
 #include <torch/headeronly/macros/Macros.h>
@@ -25,9 +24,10 @@ namespace detail {
 
 /// Convert a single fp32 value to its 4-bit e2m1 code (sign, 2 exponent, 1
 /// mantissa), returned in the low nibble of a uint8_t. Values are rounded to
-/// nearest even. fp4 has no inf/NaN encoding, so both saturate to the max
-/// representable magnitude (6.0), preserving sign. This is a scalar
-/// specialization (ebits=2, mbits=1) of the branchless algorithm in
+/// nearest even. fp4 has no inf/NaN encoding: inf and finite overflow saturate
+/// to the max representable magnitude (6.0) preserving sign, while NaN clamps
+/// to positive 6.0 to match the hardware fp4 convert intrinsic. This is a
+/// scalar specialization (ebits=2, mbits=1) of the branchless algorithm in
 /// torch/testing/_internal/common_quantized.py::_f32_to_floatx_unpacked.
 inline C10_HOST_DEVICE uint8_t fp4e2m1_from_fp32_value(float f) {
   constexpr uint32_t denorm_mask_int = 149u << 23;
@@ -63,16 +63,30 @@ inline C10_HOST_DEVICE uint8_t fp4e2m1_from_fp32_value(float f) {
     // shift right to the target code bits
     mag = static_cast<uint8_t>(nx >> 22);
   }
-  const uint8_t sign_lp = static_cast<uint8_t>(sign >> 28) & 0x8;
+  // NaN clamps to positive max magnitude (matching the hardware fp4 convert
+  // intrinsic); inf and finite overflow keep their sign. `f != f` is true only
+  // for NaN.
+  const uint8_t sign_lp =
+      (f != f) ? 0 : (static_cast<uint8_t>(sign >> 28) & 0x8);
   return (mag | sign_lp) & 0xF;
 }
 
 /// Convert a single 4-bit e2m1 code (in the low nibble of a uint8_t) back to
 /// fp32.
 inline C10_HOST_DEVICE float fp4e2m1_to_fp32_value(uint8_t code) {
-  constexpr std::array<float, 8> mag_lut = {
-      0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
-  const float mag = mag_lut[code & 0x7];
+  // Decode the magnitude from the 3 low bits (the e2m1 code without its sign)
+  // with a branch-free select tree. The tree walks the bits high-to-low, so the
+  // leaves are in code order; magnitude by code is 0->0, 1->0.5, 2->1, 3->1.5,
+  // 4->2, 5->3, 6->4, 7->6. This is deliberately not a runtime-indexed lookup
+  // table (spills to slow local memory on CUDA) nor a switch/field arithmetic:
+  // both measured ~3-54% slower on the reverse cast because they add register
+  // pressure or serialized control flow, while these predicated selects on
+  // immediate constants stay on the fast path.
+  const uint8_t idx = code & 0x7;
+  const float mag = (idx & 0x4) ? ((idx & 0x2) ? ((idx & 0x1) ? 6.0f : 4.0f)
+                                               : ((idx & 0x1) ? 3.0f : 2.0f))
+                                : ((idx & 0x2) ? ((idx & 0x1) ? 1.5f : 1.0f)
+                                               : ((idx & 0x1) ? 0.5f : 0.0f));
   return (code & 0x8) ? -mag : mag;
 }
 

--- a/torch/headeronly/util/Float4_e2m1fn_x2.h
+++ b/torch/headeronly/util/Float4_e2m1fn_x2.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 
 #include <torch/headeronly/macros/Macros.h>
+#include <torch/headeronly/util/bit_cast.h>
 
 /// Defines the Float4_e2m1fn_x2 type (4-bit floating-point, two elements packed
 /// into one byte). This is the FP4 dtype from the OCP MX format spec
@@ -18,6 +19,46 @@
 ///
 
 namespace c10 {
+
+namespace detail {
+
+/// Convert a single fp32 value to its 4-bit e2m1 code (sign, 2 exponent, 1
+/// mantissa), returned in the low nibble of a uint8_t. Values are rounded to
+/// nearest even and clamped to the max representable magnitude (6.0); there is
+/// no NaN/inf support. This is a scalar specialization (ebits=2, mbits=1) of
+/// the branchless algorithm in
+/// torch/testing/_internal/common_quantized.py::_f32_to_floatx_unpacked.
+inline C10_HOST_DEVICE uint8_t fp4e2m1_from_fp32_value(float f) {
+  constexpr uint32_t denorm_mask_int = 149u << 23;
+  const float denorm_mask_float = c10::bit_cast<float>(denorm_mask_int);
+  // (exp_bias - F32_EXP_BIAS) << MBITS_F32 + magic_adder == (-126 << 23) + 2^21-1
+  constexpr int32_t val_to_add = -1054867457;
+
+  const uint32_t bits = c10::bit_cast<uint32_t>(f);
+  const uint32_t sign = bits & 0x80000000u;
+  const float x = c10::bit_cast<float>(bits ^ sign);
+
+  uint8_t mag;
+  if (x >= 6.0f) {
+    // saturate to max magnitude code
+    mag = 7;
+  } else if (x < 1.0f) {
+    // denormal
+    const uint32_t d = c10::bit_cast<uint32_t>(x + denorm_mask_float);
+    mag = static_cast<uint8_t>(d - denorm_mask_int);
+  } else {
+    // normal: adjust exponent and round to nearest even
+    int32_t nx = static_cast<int32_t>(bits ^ sign);
+    const int32_t mant_odd = (nx >> 22) & 1;
+    nx += val_to_add;
+    nx += mant_odd;
+    mag = static_cast<uint8_t>(nx >> 22);
+  }
+  const uint8_t sign_lp = static_cast<uint8_t>(sign >> 28) & 0x8;
+  return (mag | sign_lp) & 0xF;
+}
+
+} // namespace detail
 
 struct alignas(1) Float4_e2m1fn_x2 {
   uint8_t val_;

--- a/torch/headeronly/util/Float4_e2m1fn_x2.h
+++ b/torch/headeronly/util/Float4_e2m1fn_x2.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <cstdint>
 
 #include <torch/headeronly/macros/Macros.h>
@@ -31,14 +32,15 @@ namespace detail {
 inline C10_HOST_DEVICE uint8_t fp4e2m1_from_fp32_value(float f) {
   constexpr uint32_t denorm_mask_int = 149u << 23;
   const float denorm_mask_float = c10::bit_cast<float>(denorm_mask_int);
-  // (exp_bias - F32_EXP_BIAS) << MBITS_F32 + magic_adder == (-126 << 23) + 2^21-1
+  // (exp_bias - F32_EXP_BIAS) << MBITS_F32 + magic_adder == (-126 << 23) +
+  // 2^21-1
   constexpr int32_t val_to_add = -1054867457;
 
   const uint32_t bits = c10::bit_cast<uint32_t>(f);
   const uint32_t sign = bits & 0x80000000u;
   const float x = c10::bit_cast<float>(bits ^ sign);
 
-  uint8_t mag;
+  uint8_t mag = 0;
   if (x >= 6.0f) {
     // saturate to max magnitude code
     mag = 7;
@@ -56,6 +58,17 @@ inline C10_HOST_DEVICE uint8_t fp4e2m1_from_fp32_value(float f) {
   }
   const uint8_t sign_lp = static_cast<uint8_t>(sign >> 28) & 0x8;
   return (mag | sign_lp) & 0xF;
+}
+
+/// Convert a single 4-bit e2m1 code (in the low nibble of a uint8_t) back to
+/// fp32. e2m1 has only 8 magnitudes, so the magnitude is a direct table lookup
+/// (indexed by the 3 sign-less bits); the sign bit (bit 3) is applied
+/// separately. This is the inverse of fp4e2m1_from_fp32_value.
+inline C10_HOST_DEVICE float fp4e2m1_to_fp32_value(uint8_t code) {
+  constexpr std::array<float, 8> mag_lut = {
+      0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+  const float mag = mag_lut[code & 0x7];
+  return (code & 0x8) ? -mag : mag;
 }
 
 } // namespace detail

--- a/torch/testing/_internal/common_quantized.py
+++ b/torch/testing/_internal/common_quantized.py
@@ -254,9 +254,9 @@ def _f32_to_floatx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
       fp4: bits 0-3 empty and bits 4-7 in fp4_e2m1 encoding
       fp6: bits 0-1 empty and bits 2-7 in fp6_e2m3 or fp6_e3m2 encoding
 
-    Note: there are no special values (NaN, inf) support in this code. Values
-    outside the representable range of Floatx after rounding are clamped to the
-    maximum Floatx magnitude (sign is preserved).
+    Note: Floatx has no inf/NaN encoding. Values outside the representable range
+    after rounding, as well as inf and NaN, are clamped to the maximum Floatx
+    magnitude (sign is preserved).
 
     Code below is an adaptation of https://fburl.com/code/ciwofcg4
 
@@ -311,8 +311,12 @@ def _f32_to_floatx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
     x = x.view(torch.float)
 
     # rewrite saturate/denorm/norm branches without explicit data dependent
-    # control flow, to be more compiler friendly
-    saturate_mask = x >= max_normal
+    # control flow, to be more compiler friendly.
+    # The negated comparison is what catches NaN (all NaN comparisons are
+    # false): Floatx has no inf/NaN encoding, so inf/overflow and NaN alike
+    # saturate to the max magnitude (sign preserved), matching the OCP MX spec
+    # overflow rule and leaving NaN (implementation-defined) consistent with it.
+    saturate_mask = torch.logical_not(x < max_normal)
     denormal_mask = torch.logical_and(torch.logical_not(saturate_mask), x < min_normal)
     normal_mask = torch.logical_not(torch.logical_or(saturate_mask, denormal_mask))
 

--- a/torch/testing/_internal/common_quantized.py
+++ b/torch/testing/_internal/common_quantized.py
@@ -255,8 +255,9 @@ def _f32_to_floatx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
       fp6: bits 0-1 empty and bits 2-7 in fp6_e2m3 or fp6_e3m2 encoding
 
     Note: Floatx has no inf/NaN encoding. Values outside the representable range
-    after rounding, as well as inf and NaN, are clamped to the maximum Floatx
-    magnitude (sign is preserved).
+    after rounding, as well as inf, are clamped to the maximum Floatx magnitude
+    (sign is preserved). NaN clamps to the positive maximum magnitude, matching
+    the hardware fp4 convert intrinsic.
 
     Code below is an adaptation of https://fburl.com/code/ciwofcg4
 
@@ -314,9 +315,11 @@ def _f32_to_floatx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
     # control flow, to be more compiler friendly.
     # The negated comparison is what catches NaN (all NaN comparisons are
     # false): Floatx has no inf/NaN encoding, so inf/overflow and NaN alike
-    # saturate to the max magnitude (sign preserved), matching the OCP MX spec
-    # overflow rule and leaving NaN (implementation-defined) consistent with it.
+    # saturate to the max magnitude, matching the OCP MX spec overflow rule.
+    # inf/overflow keep their sign; NaN clamps to the positive max magnitude
+    # (implementation-defined) to match the hardware fp4 convert intrinsic.
     saturate_mask = torch.logical_not(x < max_normal)
+    nan_mask = torch.isnan(x)
     denormal_mask = torch.logical_and(torch.logical_not(saturate_mask), x < min_normal)
     normal_mask = torch.logical_not(torch.logical_or(saturate_mask, denormal_mask))
 
@@ -363,6 +366,8 @@ def _f32_to_floatx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
     # doesn't have an uint32 dtype, we mask out these bits to get just the
     # f4 sign bit
     sign_lp = sign_lp & sign_mask
+    # NaN clamps to the positive max magnitude, so drop its sign.
+    sign_lp = torch.where(nan_mask, torch.zeros_like(sign_lp), sign_lp)
     x = x | sign_lp
 
     return x.to(torch.uint8)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191928

Summary:

## Motivation

Make it easier to express fp4 casting in eager mode. Today, people work around not being able to cast to fp4 in PyTorch with implementing their own casts with bitshifting or LUTs or inline_asm. This PR makes the default RTNE cast easy in eager PyTorch.

## Functionality enabled in this PR

```python
import torch
M, K = 4, 4
x = torch.randn(M, K, device="cuda")
# NEW - can cast fp32 (or bf16, etc) to fp4
x_fp4 = x.to(torch.float4_e2m1fn_x2)  # shape (M, K // 2)
# NEW - can cast fp4 to fp32 (or bf16, etc)
x_fp4_fp32 = x_fp4.to(torch.float32)  # shape (M, K)
```

In modeling code, that means we can simplify the reference:

```python
# before - _f32_to_packed_fp4 is usually bitshifting/LUTs
qdata = _f32_to_packed_fp4(data_scaled).view(torch.float4_e2m1fn_x2)

# after - just cast it
qdata = data_scaled.to(torch.float4_e2m1fn_x2)
```

## Performance

results on an 8192x8192 tensor roundtrip (fp32|bf16) <-> fp4x2, NVIDIA B200:

```code
┌─────────────┬───────┬─────────────────────┬─────────────────────┬────────────┐ 
│   Device    │ dtype │       Forward       │       Reverse       │ Round-trip │ 
├─────────────┼───────┼─────────────────────┼─────────────────────┼────────────┤ 
│ CUDA (B200) │ fp32  │ 44.3 µs (6817 GB/s) │ 52.7 µs (5726 GB/s) │ 104.3 µs   │ 
├─────────────┼───────┼─────────────────────┼─────────────────────┼────────────┤ 
│ CUDA (B200) │ bf16  │ 25.5 µs (6576 GB/s) │ 52.9 µs (5713 GB/s) │ 80.5 µs    │ 
├─────────────┼───────┼─────────────────────┼─────────────────────┼────────────┤ 
│ CPU         │ fp32  │ 11.1 ms (27 GB/s)   │ 34.1 ms (8.9 GB/s)  │ 45.0 ms    │ 
├─────────────┼───────┼─────────────────────┼─────────────────────┼────────────┤ 
│ CPU         │ bf16  │ 12.1 ms (13.8 GB/s) │ 31.4 ms (9.6 GB/s)  │ 43.8 ms    │ 
└─────────────┴───────┴─────────────────────┴─────────────────────┴────────────┘ 
```

bench code (100% clauded): https://gist.github.com/vkuzo/661485efcc5114dee508a8b15768cfde

On GPU, the native cast in this PR is 40x+ faster than eager mode bit shifting cast with individual ops, and ~2x+ faster than compiling the reference cast.

## High level decisions in this PR

I'd welcome discussion and feedback on any and all of these!

1. `NaN` gets mapped to +6.0.  The fp4 encoding as defined in the MX OCP spec and commonly used in industry does not specify a `NaN` encoding.  We have to do something for `NaN` inputs.  There are two choices I see - (a) we choose an encoding to map NaN to, or (b) we let NaN stay undefined and just let it follow the bit shifting branches.  I don't like (b), and I think 6.0 is a reasonable encoding for (a).  This also matches NVIDIA's choice on the sm100 intrinsics.
2. fp32 -> fp4 and fp4 -> fp32 are **not** differentiable.  The way people cast to fp4 in training is to have custom autograd functions around the scaled cast, so the derivative of the unscaled cast is not that important at 4 bits.
3. testing is kept in `test_floatx.py` as opposed to being integrated more broadly with how fp32/bf16/etc are tested as `float4_e2m1fn_x2` is still very much a shell dtype and not a full fledged dtype, even after casts work.

## Left for future PRs, natural extension of this PR
* do the cast with intrinsics on supported hardware (sm100+) in torchinductor, with fusion to preceding op
* hook up other rounding modes, including stochastic rounding (https://github.com/pytorch/pytorch/issues/175409), this is orthogonal

## Left for future + needs design
* fp3, fp5, fp6, fp7

Assisted by Opus 4.8

Test Plan:

```bash
pytest test/quantization/core/experimental/test_floatx.py -s -k float4
```