### PR TITLE
[CI] Harden test_libtorch_agnostic_targetting BC/FC matrix

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1871,7 +1871,7 @@ _cleanup_libtorch_agnostic_runtime() {
     MATRIX_INSTALLED_IN_AMBIENT=0
 }
 
-# BC/FC matrix over build (B) / target (T) / runtime (R); expect success only when T <= min(B, R).
+# BC/FC matrix over build (B) / target (T) / runtime (R); expect success when T <= min(B, R).
 test_libtorch_agnostic_targetting() {
     echo "Testing libtorch_agnostic BC/FC across the build/target/runtime version matrix"
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1719,93 +1719,308 @@ test_custom_script_ops() {
   assert_git_not_dirty
 }
 
-test_libtorch_agnostic_targetting() {
-    echo "Testing libtorch_agnostic runs correctly on TORCH_TARGET_VERSION"
+# --- libtorch_agnostic targeting matrix helpers ----------------------------
 
-    REPO_DIR=$(pwd)
-    WHEEL_DIR="${REPO_DIR}/test/cpp_extensions/.wheels"
-
-    # Build wheel with current PyTorch (this has TORCH_TARGET_VERSION 2_9_0)
-    echo "Building 2.9 extension wheel with current PyTorch..."
-    pushd test/cpp_extensions/libtorch_agn_2_9_extension
-    time python setup.py bdist_wheel
-
-    # Save the wheel
-    mkdir -p "$WHEEL_DIR"
-    cp dist/*.whl "$WHEEL_DIR/"
-    WHEEL_FILE=$(find "$WHEEL_DIR" -maxdepth 1 -name "*.whl" -type f | head -1)
-    echo "Built wheel: $(basename "$WHEEL_FILE")"
+# Builds the wheel for test/cpp_extensions/<ext_dir> with the currently active
+# python/torch, copies it into $WHEEL_DIR, and cleans build/dist.
+_build_libtorch_agnostic_wheel() {
+    local ext_dir="$1"
+    local build_ok=0
+    pushd "${REPO_DIR}/test/cpp_extensions/${ext_dir}"
+    rm -rf build dist
+    time python setup.py bdist_wheel || build_ok=1
+    if [[ "${build_ok}" -eq 0 ]]; then
+        mkdir -p "$WHEEL_DIR"
+        cp dist/*.whl "$WHEEL_DIR/"
+    fi
+    rm -rf build dist
     popd
+    return "${build_ok}"
+}
 
-    # Create venv and install PyTorch 2.9
-    python -m venv venv_pytorch_2_9
-    # shellcheck disable=SC1091
-    . venv_pytorch_2_9/bin/activate
+# Creates and activates a release-torch venv named $1 with torch==$2.
+# Uses $AMBIENT_PYTHON. Callers must pair with _deactivate_release_torch_venv.
+_activate_release_torch_venv() {
+    local venv_name="$1"
+    local torch_version="$2"
 
-    # Clear PYTHONPATH to avoid using the development PyTorch
-    echo "Clearing PYTHONPATH to use only venv packages..."
-    unset PYTHONPATH
-
-    # Upgrade pip to latest version
-    echo "Upgrading pip to latest version..."
-    pip install --upgrade pip
-    pip --version
-
-    echo "Installing PyTorch 2.9..."
-
-    # Install from release channel only
-    PYTORCH_VERSION="2.9.0"
-
-    # Extract CUDA version from BUILD_ENVIRONMENT (e.g., "cuda12.1" -> "cu121")
+    local release_channel
     if [[ "$BUILD_ENVIRONMENT" =~ cuda([0-9]+)\.([0-9]+) ]]; then
-        CUDA_MAJOR="${BASH_REMATCH[1]}"
-        CUDA_MINOR="${BASH_REMATCH[2]}"
-        CUDA_VERSION="cu${CUDA_MAJOR}${CUDA_MINOR}"
-        echo "  Detected CUDA ${CUDA_MAJOR}.${CUDA_MINOR} from BUILD_ENVIRONMENT, using ${CUDA_VERSION}"
+        release_channel="cu${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+        echo "  Detected CUDA ${BASH_REMATCH[1]}.${BASH_REMATCH[2]} from BUILD_ENVIRONMENT, using ${release_channel}"
     else
-        # Default to CPU build
-        CUDA_VERSION="cpu"
+        release_channel="cpu"
         echo "  No CUDA detected in BUILD_ENVIRONMENT, using CPU build"
     fi
 
-    if pip install torch=="${PYTORCH_VERSION}" --index-url https://download.pytorch.org/whl/${CUDA_VERSION}/; then
-        echo "Installed PyTorch ${PYTORCH_VERSION} from release channel (${CUDA_VERSION})"
+    "${AMBIENT_PYTHON}" -m venv "${venv_name}"
+    # shellcheck disable=SC1091
+    . "${venv_name}/bin/activate"
+    unset PYTHONPATH
+    pip install --upgrade pip
+
+    if pip install torch=="${torch_version}" --index-url "https://download.pytorch.org/whl/${release_channel}/"; then
+        echo "  Installed PyTorch ${torch_version} from release channel (${release_channel})"
     else
-        echo "  FAILED to install PyTorch 2.9.0 from release channel"
-        echo "  URL: https://download.pytorch.org/whl/${CUDA_VERSION}/"
-        deactivate
-        rm -rf venv_pytorch_2_9
+        echo "  FAILED to install PyTorch ${torch_version} from release channel (${release_channel})"
+        _deactivate_release_torch_venv
+        rm -rf "${venv_name}"
         return 1
     fi
 
-    INSTALLED_VERSION=$(python -c "import torch; print(torch.__version__)" 2>/dev/null || echo "unknown")
-    echo "  Installed version: $INSTALLED_VERSION"
-
-    # Install test dependencies
-    echo "Installing test dependencies..."
     pip install expecttest numpy unittest-xml-reporting
+}
 
-    # Install the pre-built wheel
-    echo ""
-    echo "Installing pre-built 2.9 extension wheel (built with PyTorch 2.10)..."
-    pip install "$WHEEL_FILE"
-    echo "Installed $(basename "$WHEEL_FILE") into PyTorch 2.9 environment"
-
-    # Run tests with PyTorch 2.9 runtime (2.10 tests will be skipped automatically)
-    echo ""
-    echo "Running tests with PyTorch 2.9 runtime (using wheel built on PyTorch 2.10)..."
-    if time python test/cpp_extensions/test_libtorch_agnostic.py -v; then
-        echo ""
-        echo "  Wheel built with current torch and TORCH_TARGET_VERSION 2_9_0 works with PyTorch 2.9 runtime!"
-    else
-        echo "targeting test failed"
+_deactivate_release_torch_venv() {
+    # Only deactivate if a venv is actually active (branch runtime has none).
+    if [[ -n "${VIRTUAL_ENV-}" ]]; then
         deactivate
-        rm -rf venv_pytorch_2_9 "$WHEEL_DIR"
+    fi
+    if [[ -n "${AMBIENT_PYTHONPATH}" ]]; then
+        export PYTHONPATH="${AMBIENT_PYTHONPATH}"
+    else
+        unset PYTHONPATH
+    fi
+}
+
+# Run python -c from /tmp so repo-root ./torch does not shadow site-packages.
+_run_python_c() {
+    (cd /tmp && python -c "$1")
+}
+
+# Set up one matrix cell: build version, target version, runtime version.
+#
+# Args:
+#   $1 build:   "branch" | "<release>" e.g. "2.9.0"
+#               Which torch headers/libs to compile the extension against.
+#   $2 target:  "2_9" | "2_10" | ... | "2_14" | "frozen"
+#               Selects libtorch_agn_<target>_extension.
+#               "frozen" is a version-adaptive BC fixture (2.9 ABI on torch 2.9;
+#               2.13 ABI on torch >= 2.13).
+#   $3 runtime: "branch" | "<release>" e.g. "2.9.0"
+#               Which torch to install the wheel into for the subsequent python test.
+#
+# On success (return 0):
+#   - Wheel is built and pip-installed into the runtime env
+#   - Runtime env is active (release venv, or ambient branch env)
+#   - MATRIX_PACKAGE / MATRIX_WHEEL / MATRIX_RELEASE_VENV are set for cleanup
+# On build failure (return 1): build env is cleaned up; MATRIX_BUILD_FAILED=1
+# On other setup failure (return 2): cleaned up as far as possible
+#
+# Always call _cleanup_libtorch_agnostic_case afterwards.
+_setup_libtorch_agnostic_case() {
+    local build_ver="$1"
+    local target_ver="$2"
+    local runtime_ver="$3"
+    local ext_dir="libtorch_agn_${target_ver}_extension"
+    local package="libtorch_agn_${target_ver}"
+    local build_venv=""
+    local runtime_venv=""
+
+    MATRIX_PACKAGE="${package}"
+    MATRIX_WHEEL=""
+    MATRIX_RELEASE_VENV=""
+    MATRIX_BUILD_FAILED=0
+    MATRIX_INSTALLED_IN_AMBIENT=0
+
+    echo "  setup: build=${build_ver} target=${target_ver} runtime=${runtime_ver}"
+    rm -rf "$WHEEL_DIR"
+
+    # --- build env ---
+    if [[ "${build_ver}" == "branch" ]]; then
+        # Ambient interpreter already has the branch torch.
+        :
+    else
+        build_venv="venv_matrix_build_${build_ver//./_}"
+        if ! _activate_release_torch_venv "${build_venv}" "${build_ver}"; then
+            return 2
+        fi
+        MATRIX_RELEASE_VENV="${build_venv}"
+    fi
+
+    if ! _build_libtorch_agnostic_wheel "${ext_dir}"; then
+        MATRIX_BUILD_FAILED=1
+        echo "  setup: build FAILED (extension=${ext_dir}, build=${build_ver})"
+        # Leave release build venv if any; cleanup will tear it down.
         return 1
     fi
 
-    deactivate
-    rm -rf venv_pytorch_2_9 "$WHEEL_DIR"
+    MATRIX_WHEEL=$(find "$WHEEL_DIR" -maxdepth 1 -name "${package}*.whl" -type f | head -1)
+    echo "  setup: built $(basename "$MATRIX_WHEEL")"
+
+    # Done with build-only release venv; return to ambient before runtime switch.
+    if [[ -n "${build_venv}" ]]; then
+        _deactivate_release_torch_venv
+        rm -rf "${build_venv}"
+        MATRIX_RELEASE_VENV=""
+    fi
+
+    # --- runtime env ---
+    if [[ "${runtime_ver}" == "branch" ]]; then
+        # Stay on ambient branch torch.
+        :
+    else
+        # If build used the same release already and we tore it down, make a fresh
+        # runtime venv. (Build and runtime are separate phases.)
+        runtime_venv="venv_matrix_runtime_${runtime_ver//./_}"
+        if ! _activate_release_torch_venv "${runtime_venv}" "${runtime_ver}"; then
+            return 2
+        fi
+        MATRIX_RELEASE_VENV="${runtime_venv}"
+    fi
+
+    if ! pip install "$MATRIX_WHEEL"; then
+        echo "  setup: pip install of $(basename "$MATRIX_WHEEL") FAILED"
+        return 2
+    fi
+    if [[ "${runtime_ver}" == "branch" ]]; then
+        MATRIX_INSTALLED_IN_AMBIENT=1
+    fi
+
+    echo "  setup: ready (package=${MATRIX_PACKAGE}, runtime=${runtime_ver})"
+    return 0
+}
+
+_cleanup_libtorch_agnostic_case() {
+    if [[ "${MATRIX_INSTALLED_IN_AMBIENT:-0}" -eq 1 && -n "${MATRIX_PACKAGE:-}" ]]; then
+        pip uninstall -y "${MATRIX_PACKAGE}" > /dev/null 2>&1 || true
+    fi
+    if [[ -n "${MATRIX_RELEASE_VENV:-}" ]]; then
+        _deactivate_release_torch_venv
+        rm -rf "${MATRIX_RELEASE_VENV}"
+    fi
+    rm -rf "${WHEEL_DIR:-}"
+    MATRIX_PACKAGE=""
+    MATRIX_WHEEL=""
+    MATRIX_RELEASE_VENV=""
+    MATRIX_BUILD_FAILED=0
+    MATRIX_INSTALLED_IN_AMBIENT=0
+}
+
+# Tests the BC/FC contract of the stable ABI across build (B) / target (T) /
+# runtime (R). The extension is only expected to work when T <= min(B, R).
+#
+# Case 2 uses libtorch_agn_frozen_extension: on torch 2.9 it stays on the 2.9
+# header/ops surface so it can be compiled with B=2.9.0 and loaded on branch
+# runtime (literal BC).
+test_libtorch_agnostic_targetting() {
+    echo "Testing libtorch_agnostic BC/FC across the build/target/runtime version matrix"
+
+    REPO_DIR=$(pwd)
+    WHEEL_DIR="${REPO_DIR}/test/cpp_extensions/.wheels"
+    OVERALL_FAILED=0
+
+    AMBIENT_PYTHON="$(python -c 'import sys; print(sys.executable)')"
+    AMBIENT_PYTHONPATH="${PYTHONPATH-}"
+    echo "Ambient python: ${AMBIENT_PYTHON}"
+    if ! python -c "import torch, setuptools; print('Ambient torch', torch.__version__, 'from', torch.__file__)"; then
+        echo "Ambient python must provide importable torch and setuptools."
+        echo "Activate the venv you used to build/install this branch's PyTorch first"
+        echo "(e.g. source /home/dev/.venv/bin/activate), then re-run."
+        return 1
+    fi
+
+    # ----- Case 1 (FC): B=branch, T=2.9, R=2.9 -> expect PASS -----
+    # Same signal as the original targeting test: full unittest suite under the
+    # 2.9 release runtime. Newer-version tests skip via skipIfTorchVersionLessThan.
+    # Running the .py file (not python -c) puts test/cpp_extensions/ first on
+    # sys.path, so repo-root ./torch does not shadow the venv install.
+    echo ""
+    echo "=== Case 1 (FC): build=branch, target=2_9, runtime=2.9.0 ==="
+    echo "=== target <= min(build, runtime) -> expect PASS ==="
+    if _setup_libtorch_agnostic_case "branch" "2_9" "2.9.0"; then
+        echo "Running test_libtorch_agnostic.py with PyTorch 2.9 runtime..."
+        if time python test/cpp_extensions/test_libtorch_agnostic.py -v; then
+            echo "CASE 1 PASSED as expected"
+        else
+            echo "CASE 1 FAILED: expected PASS but test_libtorch_agnostic.py failed"
+            OVERALL_FAILED=1
+        fi
+    else
+        echo "CASE 1 FAILED: setup failed"
+        OVERALL_FAILED=1
+    fi
+    _cleanup_libtorch_agnostic_case
+
+    # ----- Case 2 (BC): B=2.9, T=frozen@2.9, R=branch -> expect PASS -----
+    # Literal BC: compile the frozen extension with TORCH_TARGET_VERSION=2.9
+    # against released torch==2.9.0, then load it on the branch runtime.
+    echo ""
+    echo "=== Case 2 (BC): build=2.9.0, target=frozen (TORCH_TARGET_VERSION=2.9), runtime=branch ==="
+    echo "=== frozen extension (2.9 ABI) on new runtime -> expect PASS ==="
+    if TORCH_TARGET_VERSION=0x0209000000000000 \
+        _setup_libtorch_agnostic_case "2.9.0" "frozen" "branch"; then
+        if _run_python_c "
+import torch
+import libtorch_agn_frozen
+t = torch.tensor([-1.0, 2.0])
+assert torch.equal(libtorch_agn_frozen.ops.identity(t), t)
+assert torch.equal(libtorch_agn_frozen.ops.my_abs(t), t.abs())
+"; then
+            echo "CASE 2 PASSED as expected"
+        else
+            echo "CASE 2 FAILED: expected PASS but the python call failed"
+            OVERALL_FAILED=1
+        fi
+    else
+        echo "CASE 2 FAILED: setup failed"
+        OVERALL_FAILED=1
+    fi
+    _cleanup_libtorch_agnostic_case
+
+    # ----- Case 3: B=branch, T=2.14, R=2.9 -> expect RUNTIME FAIL -----
+    echo ""
+    echo "=== Case 3: build=branch, target=2_14, runtime=2.9.0 ==="
+    echo "=== target > runtime -> expect RUNTIME FAILURE ==="
+    if _setup_libtorch_agnostic_case "branch" "2_14" "2.9.0"; then
+        if ! _run_python_c "import torch; assert torch.__version__.startswith('2.9.'), torch.__version__"; then
+            echo "CASE 3 FAILED: runtime venv is not using torch 2.9"
+            OVERALL_FAILED=1
+        elif _run_python_c "
+import libtorch_agn_2_14
+" 2>/tmp/case3_stderr.log; then
+            echo "CASE 3 FAILED: expected a runtime failure but the import succeeded"
+            OVERALL_FAILED=1
+        elif ! grep -q "undefined symbol" /tmp/case3_stderr.log; then
+            echo "CASE 3 FAILED: import failed, but not with the expected undefined symbol error"
+            echo "  captured error:"
+            cat /tmp/case3_stderr.log
+            OVERALL_FAILED=1
+        else
+            echo "CASE 3 PASSED as expected (runtime failure)"
+            echo "  captured error:"
+            cat /tmp/case3_stderr.log
+        fi
+        rm -f /tmp/case3_stderr.log
+    else
+        echo "CASE 3 FAILED: setup failed (build/install should have succeeded)"
+        OVERALL_FAILED=1
+    fi
+    _cleanup_libtorch_agnostic_case
+
+    # ----- Case 4: B=2.9, T=frozen@2.14, R=branch -> expect BUILD FAIL -----
+    # Target 2.14 (>= 2.13) pulls tip-only APIs/sources into the frozen
+    # extension; those cannot compile against released 2.9 headers.
+    echo ""
+    echo "=== Case 4: build=2.9.0, target=frozen (TORCH_TARGET_VERSION=2.14), runtime=branch (unused if build fails) ==="
+    echo "=== target > build -> expect BUILD FAILURE ==="
+    if TORCH_TARGET_VERSION=0x020e000000000000 \
+        _setup_libtorch_agnostic_case "2.9.0" "frozen" "branch"; then
+        echo "CASE 4 FAILED: expected build to fail, but setup succeeded"
+        OVERALL_FAILED=1
+    elif [[ "${MATRIX_BUILD_FAILED}" -eq 1 ]]; then
+        echo "CASE 4 PASSED as expected (build failure)"
+    else
+        echo "CASE 4 FAILED: setup failed for a reason other than the expected build failure"
+        OVERALL_FAILED=1
+    fi
+    _cleanup_libtorch_agnostic_case
+
+    if [[ "${OVERALL_FAILED}" -ne 0 ]]; then
+        echo ""
+        echo "libtorch_agnostic targeting matrix: at least one case did not behave as expected"
+        return 1
+    fi
 
     assert_git_not_dirty
 }

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1721,30 +1721,11 @@ test_custom_script_ops() {
 
 # --- libtorch_agnostic targeting matrix helpers ----------------------------
 
-# Builds the wheel for test/cpp_extensions/<ext_dir> with the currently active
-# python/torch, copies it into $WHEEL_DIR, and cleans build/dist.
-_build_libtorch_agnostic_wheel() {
-    local ext_dir="$1"
-    local build_ok=0
-    pushd "${REPO_DIR}/test/cpp_extensions/${ext_dir}"
-    rm -rf build dist
-    time python setup.py bdist_wheel || build_ok=1
-    if [[ "${build_ok}" -eq 0 ]]; then
-        mkdir -p "$WHEEL_DIR"
-        cp dist/*.whl "$WHEEL_DIR/"
-    fi
-    rm -rf build dist
-    popd
-    return "${build_ok}"
-}
-
-# Creates and activates a release-torch venv named $1 with torch==$2.
-# Uses $AMBIENT_PYTHON. Callers must pair with _deactivate_release_torch_venv.
-_activate_release_torch_venv() {
+_libtorch_agnostic_activate_release() {
     local venv_name="$1"
     local torch_version="$2"
-
     local release_channel
+
     if [[ "$BUILD_ENVIRONMENT" =~ cuda([0-9]+)\.([0-9]+) ]]; then
         release_channel="cu${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
         echo "  Detected CUDA ${BASH_REMATCH[1]}.${BASH_REMATCH[2]} from BUILD_ENVIRONMENT, using ${release_channel}"
@@ -1759,20 +1740,22 @@ _activate_release_torch_venv() {
     unset PYTHONPATH
     pip install --upgrade pip
 
-    if pip install torch=="${torch_version}" --index-url "https://download.pytorch.org/whl/${release_channel}/"; then
-        echo "  Installed PyTorch ${torch_version} from release channel (${release_channel})"
-    else
+    if ! pip install torch=="${torch_version}" --index-url "https://download.pytorch.org/whl/${release_channel}/"; then
         echo "  FAILED to install PyTorch ${torch_version} from release channel (${release_channel})"
-        _deactivate_release_torch_venv
+        deactivate
+        if [[ -n "${AMBIENT_PYTHONPATH}" ]]; then
+            export PYTHONPATH="${AMBIENT_PYTHONPATH}"
+        else
+            unset PYTHONPATH
+        fi
         rm -rf "${venv_name}"
         return 1
     fi
-
+    echo "  Installed PyTorch ${torch_version} from release channel (${release_channel})"
     pip install expecttest numpy unittest-xml-reporting
 }
 
-_deactivate_release_torch_venv() {
-    # Only deactivate if a venv is actually active (branch runtime has none).
+_libtorch_agnostic_deactivate_release() {
     if [[ -n "${VIRTUAL_ENV-}" ]]; then
         deactivate
     fi
@@ -1783,126 +1766,112 @@ _deactivate_release_torch_venv() {
     fi
 }
 
-# Run python -c from /tmp so repo-root ./torch does not shadow site-packages.
-_run_python_c() {
-    (cd /tmp && python -c "$1")
-}
-
-# Set up one matrix cell: build version, target version, runtime version.
-#
-# Args:
-#   $1 build:   "branch" | "<release>" e.g. "2.9.0"
-#               Which torch headers/libs to compile the extension against.
-#   $2 target:  "2_9" | "2_10" | ... | "2_14" | "frozen"
-#               Selects libtorch_agn_<target>_extension.
-#               "frozen" is a version-adaptive BC fixture (2.9 ABI on torch 2.9;
-#               2.13 ABI on torch >= 2.13).
-#   $3 runtime: "branch" | "<release>" e.g. "2.9.0"
-#               Which torch to install the wheel into for the subsequent python test.
-#
-# On success (return 0):
-#   - Wheel is built and pip-installed into the runtime env
-#   - Runtime env is active (release venv, or ambient branch env)
-#   - MATRIX_PACKAGE / MATRIX_WHEEL / MATRIX_RELEASE_VENV are set for cleanup
-# On build failure (return 1): build env is cleaned up; MATRIX_BUILD_FAILED=1
-# On other setup failure (return 2): cleaned up as far as possible
-#
-# Always call _cleanup_libtorch_agnostic_case afterwards.
-_setup_libtorch_agnostic_case() {
+# Build libtorch_agn_* against torch B; T is M_N (named ext) or a version for frozen.
+_build_libtorch_agnostic_extension() {
     local build_ver="$1"
     local target_ver="$2"
-    local runtime_ver="$3"
-    local ext_dir="libtorch_agn_${target_ver}_extension"
-    local package="libtorch_agn_${target_ver}"
-    local build_venv=""
-    local runtime_venv=""
+    local ext_key package ext_dir build_venv="" build_ok=0
+    local saved_torch_target_version="${TORCH_TARGET_VERSION-}"
+
+    if [[ "${target_ver}" =~ ^[0-9]+_[0-9]+$ ]]; then
+        ext_key="${target_ver}"
+    else
+        ext_key="frozen"
+        export TORCH_TARGET_VERSION="${target_ver}"
+    fi
+    package="libtorch_agn_${ext_key}"
+    ext_dir="${package}_extension"
 
     MATRIX_PACKAGE="${package}"
     MATRIX_WHEEL=""
-    MATRIX_RELEASE_VENV=""
-    MATRIX_BUILD_FAILED=0
-    MATRIX_INSTALLED_IN_AMBIENT=0
 
-    echo "  setup: build=${build_ver} target=${target_ver} runtime=${runtime_ver}"
+    echo "  build: B=${build_ver} T=${target_ver} (extension=${ext_key})"
     rm -rf "$WHEEL_DIR"
 
-    # --- build env ---
-    if [[ "${build_ver}" == "branch" ]]; then
-        # Ambient interpreter already has the branch torch.
-        :
-    else
+    if [[ "${build_ver}" != "branch" ]]; then
         build_venv="venv_matrix_build_${build_ver//./_}"
-        if ! _activate_release_torch_venv "${build_venv}" "${build_ver}"; then
-            return 2
+        if ! _libtorch_agnostic_activate_release "${build_venv}" "${build_ver}"; then
+            if [[ -n "${saved_torch_target_version}" ]]; then
+                export TORCH_TARGET_VERSION="${saved_torch_target_version}"
+            else
+                unset TORCH_TARGET_VERSION
+            fi
+            return 1
         fi
-        MATRIX_RELEASE_VENV="${build_venv}"
     fi
 
-    if ! _build_libtorch_agnostic_wheel "${ext_dir}"; then
-        MATRIX_BUILD_FAILED=1
-        echo "  setup: build FAILED (extension=${ext_dir}, build=${build_ver})"
-        # Leave release build venv if any; cleanup will tear it down.
-        return 1
-    fi
-
-    MATRIX_WHEEL=$(find "$WHEEL_DIR" -maxdepth 1 -name "${package}*.whl" -type f | head -1)
-    echo "  setup: built $(basename "$MATRIX_WHEEL")"
-
-    # Done with build-only release venv; return to ambient before runtime switch.
-    if [[ -n "${build_venv}" ]]; then
-        _deactivate_release_torch_venv
-        rm -rf "${build_venv}"
-        MATRIX_RELEASE_VENV=""
-    fi
-
-    # --- runtime env ---
-    if [[ "${runtime_ver}" == "branch" ]]; then
-        # Stay on ambient branch torch.
-        :
+    pushd "${REPO_DIR}/test/cpp_extensions/${ext_dir}"
+    rm -rf build dist
+    time python setup.py bdist_wheel || build_ok=1
+    if [[ "${build_ok}" -eq 0 ]]; then
+        mkdir -p "$WHEEL_DIR"
+        cp dist/*.whl "$WHEEL_DIR/"
+        MATRIX_WHEEL=$(find "$WHEEL_DIR" -maxdepth 1 -name "${package}*.whl" -type f | head -1)
+        echo "  build: built $(basename "$MATRIX_WHEEL")"
     else
-        # If build used the same release already and we tore it down, make a fresh
-        # runtime venv. (Build and runtime are separate phases.)
-        runtime_venv="venv_matrix_runtime_${runtime_ver//./_}"
-        if ! _activate_release_torch_venv "${runtime_venv}" "${runtime_ver}"; then
-            return 2
-        fi
-        MATRIX_RELEASE_VENV="${runtime_venv}"
+        echo "  build: FAILED (extension=${ext_dir}, B=${build_ver})"
+    fi
+    rm -rf build dist
+    popd
+
+    if [[ -n "${build_venv}" ]]; then
+        _libtorch_agnostic_deactivate_release
+        rm -rf "${build_venv}"
     fi
 
-    if ! pip install "$MATRIX_WHEEL"; then
-        echo "  setup: pip install of $(basename "$MATRIX_WHEEL") FAILED"
-        return 2
+    if [[ -n "${saved_torch_target_version}" ]]; then
+        export TORCH_TARGET_VERSION="${saved_torch_target_version}"
+    else
+        unset TORCH_TARGET_VERSION
     fi
-    if [[ "${runtime_ver}" == "branch" ]]; then
+
+    return "${build_ok}"
+}
+
+# Install MATRIX_WHEEL into torch R ("branch" | release version).
+_setup_libtorch_agnostic_runtime() {
+    local runtime_ver="$1"
+
+    MATRIX_RELEASE_VENV=""
+    MATRIX_INSTALLED_IN_AMBIENT=0
+
+    echo "  runtime: R=${runtime_ver}"
+
+    if [[ "${runtime_ver}" != "branch" ]]; then
+        MATRIX_RELEASE_VENV="venv_matrix_runtime_${runtime_ver//./_}"
+        if ! _libtorch_agnostic_activate_release "${MATRIX_RELEASE_VENV}" "${runtime_ver}"; then
+            MATRIX_RELEASE_VENV=""
+            return 1
+        fi
+    else
         MATRIX_INSTALLED_IN_AMBIENT=1
     fi
 
-    echo "  setup: ready (package=${MATRIX_PACKAGE}, runtime=${runtime_ver})"
+    if ! pip install "$MATRIX_WHEEL"; then
+        echo "  runtime: pip install of $(basename "$MATRIX_WHEEL") FAILED"
+        return 1
+    fi
+
+    echo "  runtime: ready (package=${MATRIX_PACKAGE}, R=${runtime_ver})"
     return 0
 }
 
-_cleanup_libtorch_agnostic_case() {
+_cleanup_libtorch_agnostic_runtime() {
     if [[ "${MATRIX_INSTALLED_IN_AMBIENT:-0}" -eq 1 && -n "${MATRIX_PACKAGE:-}" ]]; then
         pip uninstall -y "${MATRIX_PACKAGE}" > /dev/null 2>&1 || true
     fi
     if [[ -n "${MATRIX_RELEASE_VENV:-}" ]]; then
-        _deactivate_release_torch_venv
+        _libtorch_agnostic_deactivate_release
         rm -rf "${MATRIX_RELEASE_VENV}"
     fi
     rm -rf "${WHEEL_DIR:-}"
     MATRIX_PACKAGE=""
     MATRIX_WHEEL=""
     MATRIX_RELEASE_VENV=""
-    MATRIX_BUILD_FAILED=0
     MATRIX_INSTALLED_IN_AMBIENT=0
 }
 
-# Tests the BC/FC contract of the stable ABI across build (B) / target (T) /
-# runtime (R). The extension is only expected to work when T <= min(B, R).
-#
-# Case 2 uses libtorch_agn_frozen_extension: on torch 2.9 it stays on the 2.9
-# header/ops surface so it can be compiled with B=2.9.0 and loaded on branch
-# runtime (literal BC).
+# BC/FC matrix over build (B) / target (T) / runtime (R); expect success only when T <= min(B, R).
 test_libtorch_agnostic_targetting() {
     echo "Testing libtorch_agnostic BC/FC across the build/target/runtime version matrix"
 
@@ -1920,15 +1889,12 @@ test_libtorch_agnostic_targetting() {
         return 1
     fi
 
-    # ----- Case 1 (FC): B=branch, T=2.9, R=2.9 -> expect PASS -----
-    # Same signal as the original targeting test: full unittest suite under the
-    # 2.9 release runtime. Newer-version tests skip via skipIfTorchVersionLessThan.
-    # Running the .py file (not python -c) puts test/cpp_extensions/ first on
-    # sys.path, so repo-root ./torch does not shadow the venv install.
+    # Case 1 (FC): B=branch, T=2_9, R=2.9 -> expect PASS
     echo ""
     echo "=== Case 1 (FC): build=branch, target=2_9, runtime=2.9.0 ==="
     echo "=== target <= min(build, runtime) -> expect PASS ==="
-    if _setup_libtorch_agnostic_case "branch" "2_9" "2.9.0"; then
+    if _build_libtorch_agnostic_extension "branch" "2_9" \
+        && _setup_libtorch_agnostic_runtime "2.9.0"; then
         echo "Running test_libtorch_agnostic.py with PyTorch 2.9 runtime..."
         if time python test/cpp_extensions/test_libtorch_agnostic.py -v; then
             echo "CASE 1 PASSED as expected"
@@ -1937,48 +1903,48 @@ test_libtorch_agnostic_targetting() {
             OVERALL_FAILED=1
         fi
     else
-        echo "CASE 1 FAILED: setup failed"
+        echo "CASE 1 FAILED: build or runtime setup failed"
         OVERALL_FAILED=1
     fi
-    _cleanup_libtorch_agnostic_case
+    _cleanup_libtorch_agnostic_runtime
 
-    # ----- Case 2 (BC): B=2.9, T=frozen@2.9, R=branch -> expect PASS -----
-    # Literal BC: compile the frozen extension with TORCH_TARGET_VERSION=2.9
-    # against released torch==2.9.0, then load it on the branch runtime.
+    # Case 2 (BC): B=2.9, T=2.9 (frozen), R=branch -> expect PASS
     echo ""
-    echo "=== Case 2 (BC): build=2.9.0, target=frozen (TORCH_TARGET_VERSION=2.9), runtime=branch ==="
+    echo "=== Case 2 (BC): build=2.9.0, TORCH_TARGET_VERSION=2.9 (frozen), runtime=branch ==="
     echo "=== frozen extension (2.9 ABI) on new runtime -> expect PASS ==="
-    if TORCH_TARGET_VERSION=0x0209000000000000 \
-        _setup_libtorch_agnostic_case "2.9.0" "frozen" "branch"; then
-        if _run_python_c "
+    if _build_libtorch_agnostic_extension "2.9.0" "2.9" \
+        && _setup_libtorch_agnostic_runtime "branch"; then
+        # /tmp avoids repo-root ./torch shadowing site-packages
+        if (cd /tmp && python -c "
 import torch
 import libtorch_agn_frozen
 t = torch.tensor([-1.0, 2.0])
 assert torch.equal(libtorch_agn_frozen.ops.identity(t), t)
 assert torch.equal(libtorch_agn_frozen.ops.my_abs(t), t.abs())
-"; then
+"); then
             echo "CASE 2 PASSED as expected"
         else
             echo "CASE 2 FAILED: expected PASS but the python call failed"
             OVERALL_FAILED=1
         fi
     else
-        echo "CASE 2 FAILED: setup failed"
+        echo "CASE 2 FAILED: build or runtime setup failed"
         OVERALL_FAILED=1
     fi
-    _cleanup_libtorch_agnostic_case
+    _cleanup_libtorch_agnostic_runtime
 
-    # ----- Case 3: B=branch, T=2.14, R=2.9 -> expect RUNTIME FAIL -----
+    # Case 3: B=branch, T=2_14, R=2.9 -> expect RUNTIME FAIL
     echo ""
     echo "=== Case 3: build=branch, target=2_14, runtime=2.9.0 ==="
     echo "=== target > runtime -> expect RUNTIME FAILURE ==="
-    if _setup_libtorch_agnostic_case "branch" "2_14" "2.9.0"; then
-        if ! _run_python_c "import torch; assert torch.__version__.startswith('2.9.'), torch.__version__"; then
+    if _build_libtorch_agnostic_extension "branch" "2_14" \
+        && _setup_libtorch_agnostic_runtime "2.9.0"; then
+        if ! (cd /tmp && python -c "import torch; assert torch.__version__.startswith('2.9.'), torch.__version__"); then
             echo "CASE 3 FAILED: runtime venv is not using torch 2.9"
             OVERALL_FAILED=1
-        elif _run_python_c "
+        elif (cd /tmp && python -c "
 import libtorch_agn_2_14
-" 2>/tmp/case3_stderr.log; then
+") 2>/tmp/case3_stderr.log; then
             echo "CASE 3 FAILED: expected a runtime failure but the import succeeded"
             OVERALL_FAILED=1
         elif ! grep -q "undefined symbol" /tmp/case3_stderr.log; then
@@ -1993,28 +1959,22 @@ import libtorch_agn_2_14
         fi
         rm -f /tmp/case3_stderr.log
     else
-        echo "CASE 3 FAILED: setup failed (build/install should have succeeded)"
+        echo "CASE 3 FAILED: build/runtime setup failed (both should have succeeded)"
         OVERALL_FAILED=1
     fi
-    _cleanup_libtorch_agnostic_case
+    _cleanup_libtorch_agnostic_runtime
 
-    # ----- Case 4: B=2.9, T=frozen@2.14, R=branch -> expect BUILD FAIL -----
-    # Target 2.14 (>= 2.13) pulls tip-only APIs/sources into the frozen
-    # extension; those cannot compile against released 2.9 headers.
+    # Case 4: B=2.9, T=2.14 (frozen) -> expect BUILD FAIL
     echo ""
-    echo "=== Case 4: build=2.9.0, target=frozen (TORCH_TARGET_VERSION=2.14), runtime=branch (unused if build fails) ==="
+    echo "=== Case 4: build=2.9.0, TORCH_TARGET_VERSION=2.14 (frozen) ==="
     echo "=== target > build -> expect BUILD FAILURE ==="
-    if TORCH_TARGET_VERSION=0x020e000000000000 \
-        _setup_libtorch_agnostic_case "2.9.0" "frozen" "branch"; then
-        echo "CASE 4 FAILED: expected build to fail, but setup succeeded"
+    if _build_libtorch_agnostic_extension "2.9.0" "2.14"; then
+        echo "CASE 4 FAILED: expected build to fail, but it succeeded"
         OVERALL_FAILED=1
-    elif [[ "${MATRIX_BUILD_FAILED}" -eq 1 ]]; then
-        echo "CASE 4 PASSED as expected (build failure)"
     else
-        echo "CASE 4 FAILED: setup failed for a reason other than the expected build failure"
-        OVERALL_FAILED=1
+        echo "CASE 4 PASSED as expected (build failure)"
     fi
-    _cleanup_libtorch_agnostic_case
+    _cleanup_libtorch_agnostic_runtime
 
     if [[ "${OVERALL_FAILED}" -ne 0 ]]; then
         echo ""

--- a/test/cpp_extensions/libtorch_agn_frozen_extension/csrc/kernel.cpp
+++ b/test/cpp_extensions/libtorch_agn_frozen_extension/csrc/kernel.cpp
@@ -1,0 +1,94 @@
+// Shared identity / abs / is_cpu kernels for the frozen BC fixture.
+//
+// TORCH_TARGET_VERSION is set by setup.py (overridable via the env var of the
+// same name). Values match the other libtorch_agn_* extensions:
+//   0x0209000000000000 (2.9)  -> manual boxed kernels (to<>/from<>)
+//   0x020d000000000000 (2.13) -> TORCH_BOX (+ csrc/v213 sources)
+
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/tensor.h>
+
+#ifndef TORCH_TARGET_VERSION
+#error "TORCH_TARGET_VERSION must be defined (see libtorch_agn_frozen setup.py)"
+#endif
+
+using torch::stable::Tensor;
+
+Tensor identity(Tensor t) {
+  return t;
+}
+
+Tensor my_abs(Tensor t) {
+  const auto num_args = 1;
+  StableIValue stack[num_args];
+  stack[0] = from(t);
+  aoti_torch_call_dispatcher("aten::abs", "", stack);
+  return to<Tensor>(stack[0]);
+}
+
+bool my_is_cpu(Tensor t) {
+  return t.is_cpu();
+}
+
+#if TORCH_TARGET_VERSION >= 0x020d000000000000
+
+STABLE_TORCH_LIBRARY(STABLE_LIB_NAME, m) {
+  m.def("identity(Tensor t) -> Tensor");
+  m.def("my_abs(Tensor t) -> Tensor");
+  m.def("my_is_cpu(Tensor t) -> bool");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(STABLE_LIB_NAME, CPU, m) {
+  m.impl("identity", TORCH_BOX(&identity));
+}
+
+STABLE_TORCH_LIBRARY_IMPL(STABLE_LIB_NAME, CUDA, m) {
+  m.impl("identity", TORCH_BOX(&identity));
+}
+
+STABLE_TORCH_LIBRARY_IMPL(STABLE_LIB_NAME, CompositeExplicitAutograd, m) {
+  m.impl("my_abs", TORCH_BOX(&my_abs));
+  m.impl("my_is_cpu", TORCH_BOX(&my_is_cpu));
+}
+
+#else // TORCH_TARGET_VERSION < 2.13
+
+void boxed_identity(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
+  Tensor res = identity(to<Tensor>(stack[0]));
+  stack[0] = from(res);
+}
+
+void boxed_my_abs(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
+  Tensor tensor_res = my_abs(to<Tensor>(stack[0]));
+  stack[0] = from(tensor_res);
+}
+
+void boxed_my_is_cpu(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
+  auto res = my_is_cpu(to<Tensor>(stack[0]));
+  stack[0] = from(res);
+}
+
+// Hardcoded library name: STABLE_LIB_NAME / TORCH_BOX are tip conveniences;
+// the 2.9 header surface registers with a literal identifier.
+STABLE_TORCH_LIBRARY(libtorch_agn_frozen, m) {
+  m.def("identity(Tensor t) -> Tensor");
+  m.def("my_abs(Tensor t) -> Tensor");
+  m.def("my_is_cpu(Tensor t) -> bool");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(libtorch_agn_frozen, CPU, m) {
+  m.impl("identity", &boxed_identity);
+}
+
+// Same boxed identity works on CUDA tensors (matches the 2.9-era extension).
+STABLE_TORCH_LIBRARY_IMPL(libtorch_agn_frozen, CUDA, m) {
+  m.impl("identity", &boxed_identity);
+}
+
+STABLE_TORCH_LIBRARY_IMPL(libtorch_agn_frozen, CompositeExplicitAutograd, m) {
+  m.impl("my_abs", &boxed_my_abs);
+  m.impl("my_is_cpu", &boxed_my_is_cpu);
+}
+
+#endif // TORCH_TARGET_VERSION >= 2.13

--- a/test/cpp_extensions/libtorch_agn_frozen_extension/csrc/v213/my_exception_what.cpp
+++ b/test/cpp_extensions/libtorch_agn_frozen_extension/csrc/v213/my_exception_what.cpp
@@ -1,0 +1,26 @@
+// 2.13-only ops: compiled only when TORCH_TARGET_VERSION >= 2.13.
+
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/macros.h>
+
+#include <string>
+
+std::string my_exception_what() {
+  return std::string(torch_exception_get_what());
+}
+
+std::string my_exception_get_what_without_backtrace() {
+  return std::string(torch_exception_get_what_without_backtrace());
+}
+
+STABLE_TORCH_LIBRARY_FRAGMENT(STABLE_LIB_NAME, m) {
+  m.def("my_exception_what() -> str");
+  m.def("my_exception_get_what_without_backtrace() -> str");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(STABLE_LIB_NAME, CompositeExplicitAutograd, m) {
+  m.impl("my_exception_what", TORCH_BOX(&my_exception_what));
+  m.impl(
+      "my_exception_get_what_without_backtrace",
+      TORCH_BOX(&my_exception_get_what_without_backtrace));
+}

--- a/test/cpp_extensions/libtorch_agn_frozen_extension/libtorch_agn_frozen/__init__.py
+++ b/test/cpp_extensions/libtorch_agn_frozen_extension/libtorch_agn_frozen/__init__.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import torch
+
+
+so_files = list(
+    Path(__file__).parent.glob("_C*" + (".pyd" if sys.platform == "win32" else ".so"))
+)
+if len(so_files) != 1:
+    raise AssertionError(f"Expected one _C*.{{so,pyd}} file, found {len(so_files)}")
+
+torch.ops.load_library(str(so_files[0]))
+
+from . import ops
+
+
+__all__ = [
+    "ops",
+]

--- a/test/cpp_extensions/libtorch_agn_frozen_extension/libtorch_agn_frozen/ops.py
+++ b/test/cpp_extensions/libtorch_agn_frozen_extension/libtorch_agn_frozen/ops.py
@@ -1,0 +1,37 @@
+import torch
+from torch import Tensor
+
+
+_NAMESPACE = "libtorch_agn_frozen"
+
+
+def identity(t) -> Tensor:
+    """Returns the input tensor."""
+    return torch.ops.libtorch_agn_frozen.identity.default(t)
+
+
+def my_abs(t) -> Tensor:
+    """Returns abs on the input tensor."""
+    return torch.ops.libtorch_agn_frozen.my_abs.default(t)
+
+
+def my_is_cpu(t) -> bool:
+    """Returns whether the input tensor is on CPU."""
+    return torch.ops.libtorch_agn_frozen.my_is_cpu.default(t)
+
+
+# 2.13-only ops are registered only when the extension was *built* against
+# torch >= 2.13. Probe the loaded library (not runtime torch.__version__),
+# since Case 2 builds on 2.9 and runs on a newer runtime.
+_ops_ns = getattr(torch.ops, _NAMESPACE, None)
+if _ops_ns is not None and hasattr(_ops_ns, "my_exception_what"):
+
+    def my_exception_what() -> str:
+        """Stable exception what() shim (present when built with ABI >= 2.13)."""
+        return torch.ops.libtorch_agn_frozen.my_exception_what.default()
+
+    def my_exception_get_what_without_backtrace() -> str:
+        """Stable exception what-without-backtrace shim (ABI >= 2.13 builds)."""
+        return (
+            torch.ops.libtorch_agn_frozen.my_exception_get_what_without_backtrace.default()
+        )

--- a/test/cpp_extensions/libtorch_agn_frozen_extension/libtorch_agn_frozen/ops.py
+++ b/test/cpp_extensions/libtorch_agn_frozen_extension/libtorch_agn_frozen/ops.py
@@ -32,6 +32,4 @@ if _ops_ns is not None and hasattr(_ops_ns, "my_exception_what"):
 
     def my_exception_get_what_without_backtrace() -> str:
         """Stable exception what-without-backtrace shim (ABI >= 2.13 builds)."""
-        return (
-            torch.ops.libtorch_agn_frozen.my_exception_get_what_without_backtrace.default()
-        )
+        return torch.ops.libtorch_agn_frozen.my_exception_get_what_without_backtrace.default()

--- a/test/cpp_extensions/libtorch_agn_frozen_extension/setup.py
+++ b/test/cpp_extensions/libtorch_agn_frozen_extension/setup.py
@@ -22,9 +22,9 @@ from setuptools import find_packages, setup
 
 import torch
 from torch.utils.cpp_extension import (
-    CUDA_HOME,
     BuildExtension,
     CppExtension,
+    CUDA_HOME,
     CUDAExtension,
     IS_WINDOWS,
 )
@@ -33,6 +33,7 @@ from torch.utils.cpp_extension import (
 ROOT_DIR = Path(__file__).parent
 CSRC_DIR = ROOT_DIR / "csrc"
 PACKAGE = "libtorch_agn_frozen"
+
 
 # Same encoding as the other libtorch_agn_*_extension setup.py files:
 #   (major, minor) -> 0xMMNN000000000000

--- a/test/cpp_extensions/libtorch_agn_frozen_extension/setup.py
+++ b/test/cpp_extensions/libtorch_agn_frozen_extension/setup.py
@@ -1,0 +1,162 @@
+"""
+Version-adaptive frozen libtorch-agnostic extension for BC testing.
+
+ABI surface is selected by TORCH_TARGET_VERSION (compile define), which can be
+set from the environment before invoking setup.py / bdist_wheel, e.g.:
+
+  export TORCH_TARGET_VERSION=0x0209000000000000   # or 2.9 / 2_9
+
+When unset, defaults from the build torch: 2.9.x -> 2.9 target, else if
+torch >= 2.13 -> 2.13 target.
+
+  - target < 2.13:  2.9-era API style (manual boxed kernels)
+  - target >= 2.13: TORCH_BOX registration + csrc/v213 ops
+"""
+
+import distutils.command.clean
+import os
+import shutil
+from pathlib import Path
+
+from setuptools import find_packages, setup
+
+import torch
+from torch.utils.cpp_extension import (
+    CUDA_HOME,
+    BuildExtension,
+    CppExtension,
+    CUDAExtension,
+    IS_WINDOWS,
+)
+
+
+ROOT_DIR = Path(__file__).parent
+CSRC_DIR = ROOT_DIR / "csrc"
+PACKAGE = "libtorch_agn_frozen"
+
+# Same encoding as the other libtorch_agn_*_extension setup.py files:
+#   (major, minor) -> 0xMMNN000000000000
+def _version_to_hex(major: int, minor: int) -> str:
+    return f"0x{major:02x}{minor:02x}000000000000"
+
+
+_TARGET_2_9 = _version_to_hex(2, 9)
+_TARGET_2_13 = _version_to_hex(2, 13)
+_TARGET_2_13_INT = int(_TARGET_2_13, 16)
+
+
+def _torch_version_tuple():
+    # "2.9.0+cpu" / "2.14.0a0+git..." -> (2, 9) / (2, 14)
+    base = torch.__version__.split("+")[0].split("a")[0].split("b")[0].split("rc")[0]
+    parts = base.split(".")
+    return int(parts[0]), int(parts[1])
+
+
+def _parse_target_version(raw: str) -> str:
+    """Return a 0x... hex string suitable for -DTORCH_TARGET_VERSION=."""
+    s = raw.strip()
+    if s.lower().startswith("0x"):
+        int(s, 16)  # validate
+        return s.lower()
+    # Accept 2.9 / 2_9 / 2.14 / 2_14 / ...
+    norm = s.replace("_", ".")
+    parts = norm.split(".")
+    if len(parts) < 2:
+        raise ValueError(
+            f"Invalid TORCH_TARGET_VERSION={raw!r}; expected 0x... or M.N / M_N"
+        )
+    return _version_to_hex(int(parts[0]), int(parts[1]))
+
+
+def _resolve_target_version_hex() -> str:
+    env = os.environ.get("TORCH_TARGET_VERSION")
+    if env:
+        return _parse_target_version(env)
+    major, minor = _torch_version_tuple()
+    if (major, minor) >= (2, 13):
+        return _TARGET_2_13
+    return _TARGET_2_9
+
+
+class clean(distutils.command.clean.clean):
+    def run(self):
+        distutils.command.clean.clean.run(self)
+        for path in (ROOT_DIR / PACKAGE).glob("**/*.so"):
+            path.unlink()
+        for path in (
+            ROOT_DIR / "build",
+            ROOT_DIR / "dist",
+            ROOT_DIR / f"{PACKAGE}.egg-info",
+        ):
+            if path.exists():
+                shutil.rmtree(str(path), ignore_errors=True)
+
+
+def get_extension():
+    target_hex = _resolve_target_version_hex()
+    target_int = int(target_hex, 16)
+    use_v213 = target_int >= _TARGET_2_13_INT
+    print(
+        f"{PACKAGE}: build torch={torch.__version__} "
+        f"TORCH_TARGET_VERSION={target_hex} "
+        f"(from {'env' if os.environ.get('TORCH_TARGET_VERSION') else 'default'})"
+    )
+
+    cxx_flags = [
+        "-DTORCH_STABLE_ONLY",
+        f"-DTORCH_TARGET_VERSION={target_hex}",
+        f"-DSTABLE_LIB_NAME={PACKAGE}",
+    ]
+    if not IS_WINDOWS:
+        cxx_flags.append("-fdiagnostics-color=always")
+
+    extra_compile_args = {"cxx": cxx_flags}
+
+    sources = [CSRC_DIR / "kernel.cpp"]
+    if use_v213:
+        sources.extend(sorted((CSRC_DIR / "v213").glob("**/*.cpp")))
+
+    extension = CppExtension
+    if torch.cuda._is_compiled() and CUDA_HOME is not None:
+        extra_compile_args["cxx"].append("-DLAE_USE_CUDA")
+        extra_compile_args["nvcc"] = [
+            "-O2",
+            "-DUSE_CUDA",
+            f"-DTORCH_TARGET_VERSION={target_hex}",
+            f"-DSTABLE_LIB_NAME={PACKAGE}",
+        ]
+        extension = CUDAExtension
+        sources.extend(sorted(CSRC_DIR.glob("*.cu")))
+        if use_v213:
+            sources.extend(sorted((CSRC_DIR / "v213").glob("**/*.cu")))
+
+    return [
+        extension(
+            f"{PACKAGE}._C",
+            sources=sorted(str(s) for s in sources),
+            py_limited_api=True,
+            extra_compile_args=extra_compile_args,
+            extra_link_args=[],
+        )
+    ]
+
+
+setup(
+    name=PACKAGE,
+    version="0.0",
+    author="PyTorch Core Team",
+    description=(
+        "Frozen libtorch-agnostic toy extension; ABI surface selected by "
+        "TORCH_TARGET_VERSION"
+    ),
+    packages=find_packages(exclude=("test",)),
+    package_data={PACKAGE: ["*.dll", "*.dylib", "*.so"]},
+    # Intentionally no install_requires=["torch"]: pip installing this wheel
+    # into an env must not pull a PyPI torch over an editable branch install.
+    ext_modules=get_extension(),
+    cmdclass={
+        "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),
+        "clean": clean,
+    },
+    options={"bdist_wheel": {"py_limited_api": "cp39"}},
+)


### PR DESCRIPTION
## Summary
- Refactor `test_libtorch_agnostic_targetting` into clear build / runtime / cleanup helpers (`_build_libtorch_agnostic_extension`, `_setup_libtorch_agnostic_runtime`, `_cleanup_libtorch_agnostic_runtime`).
- Add a frozen `libtorch_agn_frozen` extension whose ABI surface is selected by `TORCH_TARGET_VERSION`, so BC can be tested against release build torch (e.g. 2.9) without relying on tip-only registration helpers.
- Cover four B / T / R cases:
  1. **FC pass:** build=branch, target=2.9, runtime=2.9
  2. **BC pass:** build=2.9, target=2.9 (frozen), runtime=branch
  3. **Runtime fail:** build=branch, target=2.14, runtime=2.9 (`undefined symbol`)
  4. **Build fail:** build=2.9, target=2.14 (frozen)

Safe expectation remains success when `T <= min(B, R)` for the APIs in use; headers/libs always come from the build torch.

(Will update this to use existing extensions)

## Test plan
- [ ] `TEST_CONFIG=libtorch_agnostic_targetting` CI job on this PR is green
- [x] Locally (with branch torch installed): run the targeting job and confirm all four cases report the expected pass/fail outcome
- [x] Confirm Case 3 fails specifically with `undefined symbol`, and Case 4 fails at extension build time