### PR TITLE
[inductor][FlexGEMM] Fix reduction plan test and runtime routing

### DIFF
--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -1554,7 +1554,7 @@ class TestFlexGemmRuntime(FlexGemmTestCase):
         output = graph.placeholder("output")
         reduced = graph.placeholder("reduced")
         match = FlexGemmLocalReduceMatch(
-            reduced, FlexGemmLocalReduceGeometry(8, 0), "max"
+            reduced, FlexGemmLocalReduceGeometry(8, 0), reduction_type="max"
         )
         outputs = FlexGemmOutputPlan(
             output,

--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -505,8 +505,14 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
         ),
         lowering_name=subgraph.name,
     )
-    template_local_reduce = FlexGemmEpilogueLocalReduceConfig.from_reduction_plan(
-        epilogue_analysis.reduction_plan, local_reduce_out_index
+    template_local_reduce = (
+        None
+        if outputs.local_reduce is None
+        else FlexGemmEpilogueLocalReduceConfig(
+            outputs.local_reduce.match.geometry,
+            local_reduce_out_index,
+            outputs.local_reduce.feeds_main,
+        )
     )
     epilogue_name, epilogue_source = materialize_flex_gemm_epilogue(
         subgraph.graph_module,

--- a/torch/_inductor/kernel/flex_gemm/template.py
+++ b/torch/_inductor/kernel/flex_gemm/template.py
@@ -19,7 +19,6 @@ from torch._inductor.kernel.flex_gemm.constraints import (
     LOCAL_REDUCE_FINALIZE_FN_SUFFIX,
 )
 from torch._inductor.kernel.flex_gemm.runtime import inductor_quack_cache_dir
-from torch._inductor.kernel.gemm_epilogue import GemmReductionPlan
 from torch._inductor.select_algorithm import PartialRender
 from torch.utils._ordered_set import OrderedSet
 
@@ -34,19 +33,6 @@ class FlexGemmEpilogueLocalReduceConfig:
     geometry: FlexGemmLocalReduceGeometry
     out_index: int | None = None
     feeds_main: bool = False
-
-    @classmethod
-    def from_reduction_plan(
-        cls, reduction_plan: GemmReductionPlan | None, out_index: int | None
-    ) -> "FlexGemmEpilogueLocalReduceConfig | None":
-        """Bind the shared reduction plan to FlexGEMM's output index."""
-        if reduction_plan is None:
-            return None
-        return FlexGemmEpilogueLocalReduceConfig(
-            FlexGemmLocalReduceGeometry(reduction_plan.group, reduction_plan.axis),
-            out_index,
-            reduction_plan.feeds_main,
-        )
 
     @property
     def group(self) -> int:


### PR DESCRIPTION
## Summary
We observed two `test_flex_gemm` failures while updating the Triton pin in https://github.com/pytorch/pytorch/pull/191697.

The first failure was caused by the test passing `"max"` as `reduction_node` instead of `reduction_type`. Use the explicit `reduction_type="max"` keyword. The B200 test job stops after the first consistent failure, so this prevented the remaining tests in the file from running.

Once fixed, the B200 suite reached an existing stable logsumexp test and failed with `AttributeError: 'tuple' object has no attribute 'shape'`. Stable logsumexp returns `(main, reduced_aux)`, but its `reduction_plan` is `None` because it is not a single reduction. Lowering therefore failed to tell QuACK about `reduced_aux`, and QuACK treated the tuple as a tensor.

Use `outputs.local_reduce` to route the reduced output instead.

## Test Plan

- `lintrunner --take PYFMT test/inductor/test_flex_gemm.py torch/_inductor/kernel/flex_gemm/lowering.py`
- `python -m py_compile test/inductor/test_flex_gemm.py torch/_inductor/kernel/flex_gemm/lowering.py`
- B200: all four chained grouped-expression tests
- B200: full `test/inductor/test_flex_gemm.py` (321 tests passed)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo