### PR TITLE
[CD] Use compatible-release (~=) triton pins for release builds

### DIFF
--- a/.ci/pytorch/binary_populate_env.sh
+++ b/.ci/pytorch/binary_populate_env.sh
@@ -104,7 +104,7 @@ if [[ "$PACKAGE_TYPE" =~ .*wheel.* && -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_B
     # CUDA/ROCm triton requirements above) so 3.15 xpu wheels don't pull an
     # unavailable triton-xpu. Applies to both Linux and Windows xpu.
     XPU_TRITON_CONSTRAINT="python_version < '3.15'"
-    TRITON_REQUIREMENT="triton-xpu==${TRITON_VERSION}; ${XPU_TRITON_CONSTRAINT}"
+    TRITON_REQUIREMENT="triton-xpu~=${TRITON_VERSION}; ${XPU_TRITON_CONSTRAINT}"
     if [[ -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_BUILD_VERSION" =~ .*dev.* ]]; then
         TRITON_SHORTHASH=$(cut -c1-8 $PYTORCH_ROOT/.ci/docker/ci_commit_pins/triton-xpu.txt)
         TRITON_REQUIREMENT="triton-xpu==${TRITON_VERSION}+git${TRITON_SHORTHASH}; ${XPU_TRITON_CONSTRAINT}"

--- a/scripts/install_triton_wheel.sh
+++ b/scripts/install_triton_wheel.sh
@@ -8,15 +8,20 @@ DOWNLOAD_PYTORCH_ORG="https://download.pytorch.org/whl"
 if [[ -z "${USE_XPU}" ]]; then
     # Default install from PyTorch source
 
-    TRITON_VERSION="triton==$(cat .ci/docker/triton_version.txt)"
+    TRITON_PACKAGE="triton"
+    TRITON_VERSION="$(cat .ci/docker/triton_version.txt)"
     TRITON_COMMIT_ID="$(head -c 8 .ci/docker/ci_commit_pins/triton.txt)"
 else
-    TRITON_VERSION="triton-xpu==$(cat .ci/docker/triton_xpu_version.txt)"
+    TRITON_PACKAGE="triton-xpu"
+    TRITON_VERSION="$(cat .ci/docker/triton_xpu_version.txt)"
     TRITON_COMMIT_ID="$(head -c 8 .ci/docker/ci_commit_pins/triton-xpu.txt)"
 fi
 
 if [[ "$BRANCH" =~ .*release.* ]]; then
-    ${PIP} install --index-url ${DOWNLOAD_PYTORCH_ORG}/test/ $TRITON_VERSION
+    # Release branches take any patch release of the pinned minor, matching the
+    # `~=` requirement baked into release wheels by binary_populate_env.sh
+    ${PIP} install --index-url ${DOWNLOAD_PYTORCH_ORG}/test/ "${TRITON_PACKAGE}~=${TRITON_VERSION}"
 else
-    ${PIP} install --index-url ${DOWNLOAD_PYTORCH_ORG}/nightly/ $TRITON_VERSION+git${TRITON_COMMIT_ID}
+    # Nightly stays on the exact commit-pinned build
+    ${PIP} install --index-url ${DOWNLOAD_PYTORCH_ORG}/nightly/ "${TRITON_PACKAGE}==${TRITON_VERSION}+git${TRITON_COMMIT_ID}"
 fi


### PR DESCRIPTION
Release wheels should take any **patch** release of the pinned triton minor
(`~=X.Y.Z`) instead of a single exact version, so a triton patch fix can ship
without respinning torch. Nightly is unchanged — it keeps the exact
`==<version>+git<shorthash>` pin against the nightly index.

Every release-path triton pin in the tree, before this PR:

| location | package | release spec | nightly spec |
|---|---|---|---|
| `binary_populate_env.sh:78` | `triton` | `~=` ✅ already | `==...+git` |
| `binary_populate_env.sh:88` | `triton-rocm` | `~=` ✅ already | `==...+git` |
| `binary_populate_env.sh:107` | `triton-xpu` | `==` ❌ | `==...+git` |
| `scripts/install_triton_wheel.sh:19` | `triton` / `triton-xpu` | `==` ❌ | `==...+git` |

`triton` and `triton-rocm` were already switched to `~=` in #188251; this PR
covers the two that were missed.

### `scripts/install_triton_wheel.sh`

The package name is now held separately from the version. The single
`TRITON_VERSION="triton==$(...)"` variable was shared by both paths, and `~=`
could not simply be substituted into it: PEP 440 disallows a local version
segment in a compatible-release clause, so the nightly path would have produced
the invalid `triton~=3.8.0+git10f6be36`.

Rendered specs after the change (verified by running the script with `pip`
stubbed out):

```
release/2.13, cuda : --index-url .../whl/test/    triton~=3.8.0
release/2.13, xpu  : --index-url .../whl/test/    triton-xpu~=3.7.2
main,         cuda : --index-url .../whl/nightly/ triton==3.8.0+git10f6be36
main,         xpu  : --index-url .../whl/nightly/ triton-xpu==3.7.2+git5fcc14d9
```

`shellcheck` is clean on both files.

Note `Dockerfile` declares `ARG TRITON_VERSION` (fed by `docker-release.yml`)
but never installs triton with it — triton arrives transitively via `torch` — so
no change is needed there.
