### PR TITLE
[CUDA] Add NHWC GroupNorm Implementation

### DIFF
--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -12,6 +12,7 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/cuda/MemoryAccess.cuh>
 #include <ATen/native/cuda/block_reduce.cuh>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -40,8 +41,8 @@ __inline__ __device__ T ReduceSum32(T val) {
   return val;
 }
 
-template <typename T, typename T_ACC>
-__global__ void RowwiseMomentsCUDAKernel(
+template <int VecSize, typename T, typename T_ACC>
+__global__ void RowwiseMomentsContiguousCUDAKernel(
     int64_t N,
     T eps,
     const T* __restrict__ X,
@@ -55,9 +56,16 @@ __global__ void RowwiseMomentsCUDAKernel(
   const int64_t i = blockIdx.x;
   WelfordOp welford_op = {/*correction=*/0, /*take_sqrt=*/false};
   WelfordType val(0, 0, 0, 0);
-  for (int64_t j = threadIdx.x; j < N; j += blockDim.x) {
-    const int64_t index = i * N + j;
-    val = welford_op.reduce(val, static_cast<T_ACC>(X[index]), index);
+  using LoadT = memory::aligned_vector<T, VecSize>;
+  const auto* X_vec = reinterpret_cast<const LoadT*>(X + i * N);
+  const int64_t N_vec = N / VecSize;
+  for (int64_t j = threadIdx.x; j < N_vec; j += blockDim.x) {
+    const LoadT values = X_vec[j];
+#pragma unroll
+    for (int k = 0; k < VecSize; ++k) {
+      val = welford_op.reduce(
+          val, static_cast<T_ACC>(values.val[k]), j * VecSize + k);
+    }
   }
   if (blockDim.x <= C10_WARP_SIZE) {
     val = cuda_utils::WarpReduce(val, welford_op);
@@ -84,6 +92,67 @@ __global__ void RowwiseMomentsCUDAKernel(
     if constexpr (!std::is_same_v<T, T_ACC>) {
       mean_acc[i] = m1;
       rstd_acc[i] = rstd_val;
+    }
+  }
+}
+
+template <int GroupsPerBlock, typename T, typename T_ACC>
+__global__ void RowwiseMomentsChannelsLastSmallDCUDAKernel(
+    int64_t C,
+    int64_t HxW,
+    int64_t D,
+    int64_t G,
+    T eps,
+    const T* __restrict__ X,
+    T* __restrict__ mean,
+    T* __restrict__ rstd,
+    T_ACC* __restrict__ mean_acc,
+    T_ACC* __restrict__ rstd_acc) {
+  using WelfordType = WelfordData<T_ACC, int64_t>;
+  using WelfordOp = WelfordOps<T_ACC, T_ACC, int64_t, std::pair<T_ACC, T_ACC>>;
+
+  const int64_t group_blocks = (G + GroupsPerBlock - 1) / GroupsPerBlock;
+  const int64_t n = blockIdx.x / group_blocks;
+  const int64_t first_group = (blockIdx.x % group_blocks) * GroupsPerBlock;
+  const int64_t channels_per_block = GroupsPerBlock * D;
+  const int64_t lane = threadIdx.x % channels_per_block;
+  const int64_t hw_lane = threadIdx.x / channels_per_block;
+  const int64_t hw_step = blockDim.x / channels_per_block;
+  const int64_t local_group = lane / D;
+  const int64_t g = first_group + local_group;
+  const int64_t c = g * D + lane % D;
+  WelfordOp welford_op = {/*correction=*/0, /*take_sqrt=*/false};
+  WelfordType val(0, 0, 0, 0);
+  if (g < G) {
+    for (int64_t hw = hw_lane; hw < HxW; hw += hw_step) {
+      const int64_t index = (n * HxW + hw) * C + c;
+      val = welford_op.reduce(val, static_cast<T_ACC>(X[index]), index);
+    }
+  }
+
+  alignas(WelfordType) __shared__ char
+      val_shared[sizeof(WelfordType) * kCUDANumThreads];
+  WelfordType* val_shared_ptr = reinterpret_cast<WelfordType*>(val_shared);
+  val_shared_ptr[threadIdx.x] = val;
+  __syncthreads();
+
+  if (threadIdx.x < GroupsPerBlock && first_group + threadIdx.x < G) {
+    val = WelfordType(0, 0, 0, 0);
+    for (int64_t i = 0; i < hw_step; ++i) {
+      const int64_t base = i * channels_per_block + threadIdx.x * D;
+      for (int64_t j = 0; j < D; ++j) {
+        val = welford_op.combine(val, val_shared_ptr[base + j]);
+      }
+    }
+    const int64_t ng = n * G + first_group + threadIdx.x;
+    auto [m2, m1] = welford_op.project(val);
+    const T_ACC rstd_val =
+        c10::cuda::compat::rsqrt(m2 + static_cast<T_ACC>(eps));
+    mean[ng] = m1;
+    rstd[ng] = rstd_val;
+    if constexpr (!std::is_same_v<T, T_ACC>) {
+      mean_acc[ng] = m1;
+      rstd_acc[ng] = rstd_val;
     }
   }
 }
@@ -148,6 +217,7 @@ __global__ void RowwiseMomentsChannelsLastCUDAKernel(
 
 template <typename T, typename T_ACC>
 __global__ void GroupNormBackwardChannelsLastCUDAKernel(
+    int64_t numel,
     int64_t C,
     int64_t HxW,
     int64_t D,
@@ -158,12 +228,14 @@ __global__ void GroupNormBackwardChannelsLastCUDAKernel(
     const T_ACC* __restrict__ c2,
     const T_ACC* __restrict__ c3,
     T* __restrict__ dX) {
-  const int64_t ng = blockIdx.x / HxW;
-  const int64_t hw = blockIdx.x % HxW;
-  const int64_t n = ng / (C / D);
-  const int64_t g = ng % (C / D);
-  for (int64_t c = g * D + threadIdx.x; c < (g + 1) * D; c += blockDim.x) {
-    const int64_t index = (n * HxW + hw) * C + c;
+  for (int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x +
+           threadIdx.x;
+       index < numel;
+       index += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+    const int64_t c = index % C;
+    const int64_t n = index / (HxW * C);
+    const int64_t g = c / D;
+    const int64_t ng = n * (C / D) + g;
     const T_ACC scale = static_cast<T_ACC>(rstd[ng]) *
         (gamma ? static_cast<T_ACC>(gamma[c]) : T_ACC(1));
     dX[index] = scale * static_cast<T_ACC>(dY[index]) +
@@ -374,8 +446,97 @@ __global__ void GammaBeta1dBackwardCUDAKernel2(
   }
 }
 
-template <bool ChannelsLast, typename T>
-__global__ void ComputeInternalGradientsCUDAKernel(
+template <int VecSize, typename T>
+__global__ void ComputeInternalGradientsContiguousCUDAKernel(
+    int64_t HxW,
+    const T* __restrict__ dY,
+    const T* __restrict__ X,
+    acc_type<T, true>* __restrict__ ds,
+    acc_type<T, true>* __restrict__ db) {
+  using T_ACC = acc_type<T, true>;
+  const int64_t nc = blockIdx.x;
+  using LoadT = memory::aligned_vector<T, VecSize>;
+  const auto* dY_vec =
+      reinterpret_cast<const LoadT*>(dY + nc * HxW);
+  const auto* X_vec = reinterpret_cast<const LoadT*>(X + nc * HxW);
+  const int64_t HxW_vec = HxW / VecSize;
+  T_ACC sum1 = 0;
+  T_ACC sum2 = 0;
+  for (int64_t hw = threadIdx.x; hw < HxW_vec; hw += blockDim.x) {
+    const LoadT dY_values = dY_vec[hw];
+    const LoadT X_values = X_vec[hw];
+#pragma unroll
+    for (int i = 0; i < VecSize; ++i) {
+      const T_ACC dy = static_cast<T_ACC>(dY_values.val[i]);
+      sum1 += dy * static_cast<T_ACC>(X_values.val[i]);
+      sum2 += dy;
+    }
+  }
+  if (blockDim.x <= C10_WARP_SIZE) {
+    sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
+    sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  } else {
+    __shared__ T_ACC ds_shared[C10_WARP_SIZE_UPPER_BOUND];
+    __shared__ T_ACC db_shared[C10_WARP_SIZE_UPPER_BOUND];
+    sum1 = cuda_utils::BlockReduceSum<T_ACC>(sum1, ds_shared);
+    sum2 = cuda_utils::BlockReduceSum<T_ACC>(sum2, db_shared);
+  }
+  if (threadIdx.x == 0) {
+    ds[nc] = sum1;
+    db[nc] = sum2;
+  }
+}
+
+template <int ChannelsPerBlock, typename T>
+__global__ void ComputeInternalGradientsChannelsLastCUDAKernel(
+    int64_t C,
+    int64_t HxW,
+    const T* __restrict__ dY,
+    const T* __restrict__ X,
+    acc_type<T, true>* __restrict__ ds,
+    acc_type<T, true>* __restrict__ db) {
+  using T_ACC = acc_type<T, true>;
+  const int64_t channel_blocks =
+      (C + ChannelsPerBlock - 1) / ChannelsPerBlock;
+  const int64_t n = blockIdx.x / channel_blocks;
+  const int64_t first_channel =
+      (blockIdx.x % channel_blocks) * ChannelsPerBlock;
+  const int64_t local_channel = threadIdx.x % ChannelsPerBlock;
+  const int64_t hw_lane = threadIdx.x / ChannelsPerBlock;
+  const int64_t hw_step = blockDim.x / ChannelsPerBlock;
+  const int64_t c = first_channel + local_channel;
+  T_ACC sum1 = 0;
+  T_ACC sum2 = 0;
+  if (c < C) {
+    for (int64_t hw = hw_lane; hw < HxW; hw += hw_step) {
+      const int64_t index = (n * HxW + hw) * C + c;
+      const T_ACC dy = static_cast<T_ACC>(dY[index]);
+      sum1 += dy * static_cast<T_ACC>(X[index]);
+      sum2 += dy;
+    }
+  }
+
+  __shared__ T_ACC ds_shared[kCUDANumThreads];
+  __shared__ T_ACC db_shared[kCUDANumThreads];
+  ds_shared[threadIdx.x] = sum1;
+  db_shared[threadIdx.x] = sum2;
+  __syncthreads();
+  if (threadIdx.x < ChannelsPerBlock && first_channel + threadIdx.x < C) {
+    sum1 = 0;
+    sum2 = 0;
+    for (int64_t i = 0; i < hw_step; ++i) {
+      const int64_t index = i * ChannelsPerBlock + threadIdx.x;
+      sum1 += ds_shared[index];
+      sum2 += db_shared[index];
+    }
+    const int64_t nc = n * C + first_channel + threadIdx.x;
+    ds[nc] = sum1;
+    db[nc] = sum2;
+  }
+}
+
+template <typename T>
+__global__ void ComputeInternalGradientsChannelsLastFallbackCUDAKernel(
     int64_t C,
     int64_t HxW,
     const T* __restrict__ dY,
@@ -384,21 +545,15 @@ __global__ void ComputeInternalGradientsCUDAKernel(
     acc_type<T, true>* __restrict__ db) {
   using T_ACC = acc_type<T, true>;
   const int64_t nc = blockIdx.x;
-  int64_t n = 0;
-  int64_t c = 0;
-  if constexpr (ChannelsLast) {
-    n = nc / C;
-    c = nc % C;
-  }
+  const int64_t n = nc / C;
+  const int64_t c = nc % C;
   T_ACC sum1 = 0;
   T_ACC sum2 = 0;
   for (int64_t hw = threadIdx.x; hw < HxW; hw += blockDim.x) {
-    int64_t index = nc * HxW + hw;
-    if constexpr (ChannelsLast) {
-      index = (n * HxW + hw) * C + c;
-    }
-    sum1 += static_cast<T_ACC>(dY[index]) * static_cast<T_ACC>(X[index]);
-    sum2 += static_cast<T_ACC>(dY[index]);
+    const int64_t index = (n * HxW + hw) * C + c;
+    const T_ACC dy = static_cast<T_ACC>(dY[index]);
+    sum1 += dy * static_cast<T_ACC>(X[index]);
+    sum2 += dy;
   }
   if (blockDim.x <= C10_WARP_SIZE) {
     sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
@@ -699,18 +854,37 @@ void GroupNormKernelImplInternal(
       ? at::cuda::warp_size()
       : cuda_utils::kCUDABlockReduceNumThreads;
   if (channels_last) {
-    RowwiseMomentsChannelsLastCUDAKernel<T, T_ACC>
-        <<<N * G, num_threads, 0, cuda_stream>>>(
-            N,
-            C,
-            HxW,
-            D,
-            eps,
-            X_data,
-            mean_data,
-            rstd_data,
-            mean_acc_data,
-            rstd_acc_data);
+    if ((D == 1 || D == 2) && G >= 4 &&
+        D * HxW >= cuda_utils::kCUDABlockReduceNumThreads) {
+      constexpr int kGroupsPerBlock = 4;
+      const int64_t group_blocks =
+          (G + kGroupsPerBlock - 1) / kGroupsPerBlock;
+      RowwiseMomentsChannelsLastSmallDCUDAKernel<kGroupsPerBlock, T, T_ACC>
+          <<<N * group_blocks, kCUDANumThreads, 0, cuda_stream>>>(
+              C,
+              HxW,
+              D,
+              G,
+              eps,
+              X_data,
+              mean_data,
+              rstd_data,
+              mean_acc_data,
+              rstd_acc_data);
+    } else {
+      RowwiseMomentsChannelsLastCUDAKernel<T, T_ACC>
+          <<<N * G, num_threads, 0, cuda_stream>>>(
+              N,
+              C,
+              HxW,
+              D,
+              eps,
+              X_data,
+              mean_data,
+              rstd_data,
+              mean_acc_data,
+              rstd_acc_data);
+    }
     C10_CUDA_KERNEL_LAUNCH_CHECK();
     Tensor a = at::empty({N, C}, kAccTypeOpts);
     Tensor b = at::empty({N, C}, kAccTypeOpts);
@@ -732,16 +906,38 @@ void GroupNormKernelImplInternal(
                     .resize_outputs(false)
                     .add_owned_output(Y.as_strided({N, HxW, C}, {HxW * C, C, 1}))
                     .add_owned_const_input(X.as_strided({N, HxW, C}, {HxW * C, C, 1}))
-                    .add_owned_input(a.view({N, 1, C}))
-                    .add_owned_input(b.view({N, 1, C}))
+                    .add_owned_const_input(a.view({N, 1, C}))
+                    .add_owned_const_input(b.view({N, 1, C}))
                     .build();
     gpu_kernel(iter, [] GPU_LAMBDA(T x, T_ACC a, T_ACC b) -> T {
       return a * static_cast<T_ACC>(x) + b;
     });
     return;
   }
-  RowwiseMomentsCUDAKernel<T, T_ACC><<<N * G, num_threads, 0, cuda_stream>>>(
-      D * HxW, eps, X_data, mean_data, rstd_data, mean_acc_data, rstd_acc_data);
+  constexpr int kVecSize = 16 / sizeof(T);
+  if (D * HxW % kVecSize == 0 &&
+      memory::can_vectorize_up_to<T>(
+          reinterpret_cast<const char*>(X_data)) >= kVecSize) {
+    RowwiseMomentsContiguousCUDAKernel<kVecSize, T, T_ACC>
+        <<<N * G, num_threads, 0, cuda_stream>>>(
+            D * HxW,
+            eps,
+            X_data,
+            mean_data,
+            rstd_data,
+            mean_acc_data,
+            rstd_acc_data);
+  } else {
+    RowwiseMomentsContiguousCUDAKernel<1, T, T_ACC>
+        <<<N * G, num_threads, 0, cuda_stream>>>(
+            D * HxW,
+            eps,
+            X_data,
+            mean_data,
+            rstd_data,
+            mean_acc_data,
+            rstd_acc_data);
+  }
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   if (HxW == 1) {
@@ -1011,13 +1207,34 @@ void GroupNormBackwardKernelImplInternal(
       ? warp_size
       : cuda_utils::kCUDABlockReduceNumThreads;
   if (channels_last) {
-    ComputeInternalGradientsCUDAKernel<true, T>
-        <<<N * C, num_threads, 0, cuda_stream>>>(
-            C, HxW, dY_data, X_data, ds_data, db_data);
+    constexpr int kChannelsPerBlock = 16;
+    if (C >= kChannelsPerBlock &&
+        HxW >= cuda_utils::kCUDABlockReduceNumThreads) {
+      const int64_t channel_blocks =
+          (C + kChannelsPerBlock - 1) / kChannelsPerBlock;
+      ComputeInternalGradientsChannelsLastCUDAKernel<kChannelsPerBlock, T>
+          <<<N * channel_blocks, kCUDANumThreads, 0, cuda_stream>>>(
+              C, HxW, dY_data, X_data, ds_data, db_data);
+    } else {
+      ComputeInternalGradientsChannelsLastFallbackCUDAKernel<T>
+          <<<N * C, num_threads, 0, cuda_stream>>>(
+              C, HxW, dY_data, X_data, ds_data, db_data);
+    }
   } else {
-    ComputeInternalGradientsCUDAKernel<false, T>
-        <<<N * C, num_threads, 0, cuda_stream>>>(
-            C, HxW, dY_data, X_data, ds_data, db_data);
+    constexpr int kVecSize = 16 / sizeof(T);
+    if (HxW % kVecSize == 0 &&
+        memory::can_vectorize_up_to<T>(
+            reinterpret_cast<const char*>(dY_data)) >= kVecSize &&
+        memory::can_vectorize_up_to<T>(
+            reinterpret_cast<const char*>(X_data)) >= kVecSize) {
+      ComputeInternalGradientsContiguousCUDAKernel<kVecSize, T>
+          <<<N * C, num_threads, 0, cuda_stream>>>(
+              HxW, dY_data, X_data, ds_data, db_data);
+    } else {
+      ComputeInternalGradientsContiguousCUDAKernel<1, T>
+          <<<N * C, num_threads, 0, cuda_stream>>>(
+              HxW, dY_data, X_data, ds_data, db_data);
+    }
   }
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
@@ -1058,9 +1275,12 @@ void GroupNormBackwardKernelImplInternal(
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     if (channels_last) {
-      const int64_t num_threads = D < kCUDANumThreads ? D : kCUDANumThreads;
+      const int64_t numel = N * C * HxW;
+      const int64_t blocks =
+          (numel + kCUDANumThreads - 1) / kCUDANumThreads;
       GroupNormBackwardChannelsLastCUDAKernel<T, T_ACC>
-          <<<N * G * HxW, num_threads, 0, cuda_stream>>>(
+          <<<blocks, kCUDANumThreads, 0, cuda_stream>>>(
+              numel,
               C,
               HxW,
               D,

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -44,11 +44,11 @@ template <typename T, typename T_ACC>
 __global__ void RowwiseMomentsCUDAKernel(
     int64_t N,
     T eps,
-    const T* X,
-    T* mean,
-    T* rstd,
-    T_ACC* mean_acc,
-    T_ACC* rstd_acc) {
+    const T* __restrict__ X,
+    T* __restrict__ mean,
+    T* __restrict__ rstd,
+    T_ACC* __restrict__ mean_acc,
+    T_ACC* __restrict__ rstd_acc) {
   using WelfordType = WelfordData<T_ACC, int64_t>;
   using WelfordOp = WelfordOps<T_ACC, T_ACC, int64_t, std::pair<T_ACC, T_ACC>>;
 
@@ -146,52 +146,18 @@ __global__ void RowwiseMomentsChannelsLastCUDAKernel(
   }
 }
 
-template <typename T>
-__global__ void ComputeInternalGradientsChannelsLastCUDAKernel(
-    int64_t C,
-    int64_t HxW,
-    const T* dY,
-    const T* X,
-    acc_type<T, true>* ds,
-    acc_type<T, true>* db) {
-  using T_ACC = acc_type<T, true>;
-  const int64_t nc = blockIdx.x;
-  const int64_t n = nc / C;
-  const int64_t c = nc % C;
-  T_ACC sum1 = 0;
-  T_ACC sum2 = 0;
-  for (int64_t hw = threadIdx.x; hw < HxW; hw += blockDim.x) {
-    const int64_t index = (n * HxW + hw) * C + c;
-    sum1 += static_cast<T_ACC>(dY[index]) * static_cast<T_ACC>(X[index]);
-    sum2 += static_cast<T_ACC>(dY[index]);
-  }
-  if (blockDim.x <= C10_WARP_SIZE) {
-    sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
-    sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
-  } else {
-    __shared__ T_ACC ds_shared[C10_WARP_SIZE_UPPER_BOUND];
-    __shared__ T_ACC db_shared[C10_WARP_SIZE_UPPER_BOUND];
-    sum1 = cuda_utils::BlockReduceSum<T_ACC>(sum1, ds_shared);
-    sum2 = cuda_utils::BlockReduceSum<T_ACC>(sum2, db_shared);
-  }
-  if (threadIdx.x == 0) {
-    ds[nc] = sum1;
-    db[nc] = sum2;
-  }
-}
-
 template <typename T, typename T_ACC>
 __global__ void GroupNormBackwardChannelsLastCUDAKernel(
     int64_t C,
     int64_t HxW,
     int64_t D,
-    const T* dY,
-    const T* X,
-    const T* rstd,
-    const T* gamma,
-    const T_ACC* c2,
-    const T_ACC* c3,
-    T* dX) {
+    const T* __restrict__ dY,
+    const T* __restrict__ X,
+    const T* __restrict__ rstd,
+    const T* __restrict__ gamma,
+    const T_ACC* __restrict__ c2,
+    const T_ACC* __restrict__ c3,
+    T* __restrict__ dX) {
   const int64_t ng = blockIdx.x / HxW;
   const int64_t hw = blockIdx.x % HxW;
   const int64_t n = ng / (C / D);
@@ -408,19 +374,29 @@ __global__ void GammaBeta1dBackwardCUDAKernel2(
   }
 }
 
-template <typename T>
+template <bool ChannelsLast, typename T>
 __global__ void ComputeInternalGradientsCUDAKernel(
+    int64_t C,
     int64_t HxW,
-    const T* dY,
-    const T* X,
-    acc_type<T, true>* ds,
-    acc_type<T, true>* db) {
+    const T* __restrict__ dY,
+    const T* __restrict__ X,
+    acc_type<T, true>* __restrict__ ds,
+    acc_type<T, true>* __restrict__ db) {
   using T_ACC = acc_type<T, true>;
   const int64_t nc = blockIdx.x;
+  int64_t n = 0;
+  int64_t c = 0;
+  if constexpr (ChannelsLast) {
+    n = nc / C;
+    c = nc % C;
+  }
   T_ACC sum1 = 0;
   T_ACC sum2 = 0;
   for (int64_t hw = threadIdx.x; hw < HxW; hw += blockDim.x) {
-    const int64_t index = nc * HxW + hw;
+    int64_t index = nc * HxW + hw;
+    if constexpr (ChannelsLast) {
+      index = (n * HxW + hw) * C + c;
+    }
     sum1 += static_cast<T_ACC>(dY[index]) * static_cast<T_ACC>(X[index]);
     sum2 += static_cast<T_ACC>(dY[index]);
   }
@@ -1035,12 +1011,13 @@ void GroupNormBackwardKernelImplInternal(
       ? warp_size
       : cuda_utils::kCUDABlockReduceNumThreads;
   if (channels_last) {
-    ComputeInternalGradientsChannelsLastCUDAKernel<T>
+    ComputeInternalGradientsCUDAKernel<true, T>
         <<<N * C, num_threads, 0, cuda_stream>>>(
             C, HxW, dY_data, X_data, ds_data, db_data);
   } else {
-    ComputeInternalGradientsCUDAKernel<T><<<N * C, num_threads, 0, cuda_stream>>>(
-        HxW, dY_data, X_data, ds_data, db_data);
+    ComputeInternalGradientsCUDAKernel<false, T>
+        <<<N * C, num_threads, 0, cuda_stream>>>(
+            C, HxW, dY_data, X_data, ds_data, db_data);
   }
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -7,6 +7,7 @@
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/Tensor.h>
+#include <ATen/cuda/detail/IntegerDivider.cuh>
 #include <ATen/native/SharedReduceOps.h>
 #include <ATen/native/TensorIterator.h>
 #include <c10/cuda/CUDAMathCompat.h>
@@ -215,12 +216,13 @@ __global__ void RowwiseMomentsChannelsLastCUDAKernel(
   }
 }
 
-template <typename T, typename T_ACC>
+template <typename index_t, typename T, typename T_ACC>
 __global__ void GroupNormBackwardChannelsLastCUDAKernel(
-    int64_t numel,
-    int64_t C,
-    int64_t HxW,
-    int64_t D,
+    index_t numel,
+    index_t G,
+    at::cuda::detail::IntDivider<index_t> C_divider,
+    at::cuda::detail::IntDivider<index_t> HxW_divider,
+    at::cuda::detail::IntDivider<index_t> D_divider,
     const T* __restrict__ dY,
     const T* __restrict__ X,
     const T* __restrict__ rstd,
@@ -228,14 +230,15 @@ __global__ void GroupNormBackwardChannelsLastCUDAKernel(
     const T_ACC* __restrict__ c2,
     const T_ACC* __restrict__ c3,
     T* __restrict__ dX) {
-  for (int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x +
+  for (index_t index = static_cast<index_t>(blockIdx.x) * blockDim.x +
            threadIdx.x;
        index < numel;
-       index += static_cast<int64_t>(blockDim.x) * gridDim.x) {
-    const int64_t c = index % C;
-    const int64_t n = index / (HxW * C);
-    const int64_t g = c / D;
-    const int64_t ng = n * (C / D) + g;
+       index += static_cast<index_t>(blockDim.x) * gridDim.x) {
+    const auto nhw_c = C_divider.divmod(index);
+    const index_t c = nhw_c.mod;
+    const index_t n = HxW_divider.div(nhw_c.div);
+    const index_t g = D_divider.div(c);
+    const index_t ng = n * G + g;
     const T_ACC scale = static_cast<T_ACC>(rstd[ng]) *
         (gamma ? static_cast<T_ACC>(gamma[c]) : T_ACC(1));
     dX[index] = scale * static_cast<T_ACC>(dY[index]) +
@@ -1278,19 +1281,39 @@ void GroupNormBackwardKernelImplInternal(
       const int64_t numel = N * C * HxW;
       const int64_t blocks =
           (numel + kCUDANumThreads - 1) / kCUDANumThreads;
-      GroupNormBackwardChannelsLastCUDAKernel<T, T_ACC>
-          <<<blocks, kCUDANumThreads, 0, cuda_stream>>>(
-              numel,
-              C,
-              HxW,
-              D,
-              dY_data,
-              X_data,
-              rstd_data,
-              gamma_data,
-              c2_data,
-              c3_data,
-              dX.mutable_data_ptr<T>());
+      if (at::cuda::detail::canUse32BitIndexMath(X)) {
+        using index_t = uint32_t;
+        GroupNormBackwardChannelsLastCUDAKernel<index_t, T, T_ACC>
+            <<<blocks, kCUDANumThreads, 0, cuda_stream>>>(
+                static_cast<index_t>(numel),
+                static_cast<index_t>(G),
+                at::cuda::detail::IntDivider<index_t>(C),
+                at::cuda::detail::IntDivider<index_t>(HxW),
+                at::cuda::detail::IntDivider<index_t>(D),
+                dY_data,
+                X_data,
+                rstd_data,
+                gamma_data,
+                c2_data,
+                c3_data,
+                dX.mutable_data_ptr<T>());
+      } else {
+        using index_t = int64_t;
+        GroupNormBackwardChannelsLastCUDAKernel<index_t, T, T_ACC>
+            <<<blocks, kCUDANumThreads, 0, cuda_stream>>>(
+                numel,
+                G,
+                at::cuda::detail::IntDivider<index_t>(C),
+                at::cuda::detail::IntDivider<index_t>(HxW),
+                at::cuda::detail::IntDivider<index_t>(D),
+                dY_data,
+                X_data,
+                rstd_data,
+                gamma_data,
+                c2_data,
+                c3_data,
+                dX.mutable_data_ptr<T>());
+      }
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else if (gamma.defined()) {
       auto iter = TensorIteratorConfig()

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -89,6 +89,123 @@ __global__ void RowwiseMomentsCUDAKernel(
 }
 
 template <typename T, typename T_ACC>
+__global__ void RowwiseMomentsChannelsLastCUDAKernel(
+    int64_t N,
+    int64_t C,
+    int64_t HxW,
+    int64_t D,
+    T eps,
+    const T* X,
+    T* mean,
+    T* rstd,
+    T_ACC* mean_acc,
+    T_ACC* rstd_acc) {
+  using WelfordType = WelfordData<T_ACC, int64_t>;
+  using WelfordOp = WelfordOps<T_ACC, T_ACC, int64_t, std::pair<T_ACC, T_ACC>>;
+  const int64_t ng = blockIdx.x;
+  const int64_t n = ng / (C / D);
+  const int64_t g = ng % (C / D);
+  const int64_t group_size = D * HxW;
+  WelfordOp welford_op = {/*correction=*/0, /*take_sqrt=*/false};
+  WelfordType val(0, 0, 0, 0);
+  int64_t hw = threadIdx.x / D;
+  int64_t c = g * D + threadIdx.x % D;
+  const int64_t hw_step = blockDim.x / D;
+  const int64_t c_step = blockDim.x % D;
+  for (int64_t j = threadIdx.x; j < group_size; j += blockDim.x) {
+    const int64_t index = (n * HxW + hw) * C + c;
+    val = welford_op.reduce(val, static_cast<T_ACC>(X[index]), ng * group_size + j);
+    hw += hw_step;
+    c += c_step;
+    if (c >= (g + 1) * D) {
+      c -= D;
+      ++hw;
+    }
+  }
+  if (blockDim.x <= C10_WARP_SIZE) {
+    val = cuda_utils::WarpReduce(val, welford_op);
+  } else {
+    alignas(WelfordType) __shared__ char
+        val_shared[sizeof(WelfordType) * C10_WARP_SIZE_UPPER_BOUND];
+    WelfordType* val_shared_ptr = reinterpret_cast<WelfordType*>(val_shared);
+    val = cuda_utils::BlockReduce(
+        val,
+        welford_op,
+        /*identity_element=*/WelfordType(0, 0, 0, 0),
+        val_shared_ptr);
+  }
+  if (threadIdx.x == 0) {
+    auto [m2, m1] = welford_op.project(val);
+    T_ACC rstd_val = c10::cuda::compat::rsqrt(m2 + static_cast<T_ACC>(eps));
+    mean[ng] = m1;
+    rstd[ng] = rstd_val;
+    if constexpr (!std::is_same_v<T, T_ACC>) {
+      mean_acc[ng] = m1;
+      rstd_acc[ng] = rstd_val;
+    }
+  }
+}
+
+template <typename T>
+__global__ void ComputeInternalGradientsChannelsLastCUDAKernel(
+    int64_t C,
+    int64_t HxW,
+    const T* dY,
+    const T* X,
+    acc_type<T, true>* ds,
+    acc_type<T, true>* db) {
+  using T_ACC = acc_type<T, true>;
+  const int64_t nc = blockIdx.x;
+  const int64_t n = nc / C;
+  const int64_t c = nc % C;
+  T_ACC sum1 = 0;
+  T_ACC sum2 = 0;
+  for (int64_t hw = threadIdx.x; hw < HxW; hw += blockDim.x) {
+    const int64_t index = (n * HxW + hw) * C + c;
+    sum1 += static_cast<T_ACC>(dY[index]) * static_cast<T_ACC>(X[index]);
+    sum2 += static_cast<T_ACC>(dY[index]);
+  }
+  if (blockDim.x <= C10_WARP_SIZE) {
+    sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
+    sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  } else {
+    __shared__ T_ACC ds_shared[C10_WARP_SIZE_UPPER_BOUND];
+    __shared__ T_ACC db_shared[C10_WARP_SIZE_UPPER_BOUND];
+    sum1 = cuda_utils::BlockReduceSum<T_ACC>(sum1, ds_shared);
+    sum2 = cuda_utils::BlockReduceSum<T_ACC>(sum2, db_shared);
+  }
+  if (threadIdx.x == 0) {
+    ds[nc] = sum1;
+    db[nc] = sum2;
+  }
+}
+
+template <typename T, typename T_ACC>
+__global__ void GroupNormBackwardChannelsLastCUDAKernel(
+    int64_t C,
+    int64_t HxW,
+    int64_t D,
+    const T* dY,
+    const T* X,
+    const T* rstd,
+    const T* gamma,
+    const T_ACC* c2,
+    const T_ACC* c3,
+    T* dX) {
+  const int64_t ng = blockIdx.x / HxW;
+  const int64_t hw = blockIdx.x % HxW;
+  const int64_t n = ng / (C / D);
+  const int64_t g = ng % (C / D);
+  for (int64_t c = g * D + threadIdx.x; c < (g + 1) * D; c += blockDim.x) {
+    const int64_t index = (n * HxW + hw) * C + c;
+    const T_ACC scale = static_cast<T_ACC>(rstd[ng]) *
+        (gamma ? static_cast<T_ACC>(gamma[c]) : T_ACC(1));
+    dX[index] = scale * static_cast<T_ACC>(dY[index]) +
+        c2[ng] * static_cast<T_ACC>(X[index]) + c3[ng];
+  }
+}
+
+template <typename T, typename T_ACC>
 __global__ void ComputeFusedParamsCUDAKernel(
     int64_t N,
     int64_t C,
@@ -599,9 +716,54 @@ void GroupNormKernelImplInternal(
   T_ACC* rstd_acc_data = rstd_acc.mutable_data_ptr<T_ACC>();
 
   cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
+  const bool channels_last =
+      X.is_contiguous(at::MemoryFormat::ChannelsLast) ||
+      X.is_contiguous(at::MemoryFormat::ChannelsLast3d);
   const int64_t num_threads = D * HxW < cuda_utils::kCUDABlockReduceNumThreads
       ? at::cuda::warp_size()
       : cuda_utils::kCUDABlockReduceNumThreads;
+  if (channels_last) {
+    RowwiseMomentsChannelsLastCUDAKernel<T, T_ACC>
+        <<<N * G, num_threads, 0, cuda_stream>>>(
+            N,
+            C,
+            HxW,
+            D,
+            eps,
+            X_data,
+            mean_data,
+            rstd_data,
+            mean_acc_data,
+            rstd_acc_data);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    Tensor a = at::empty({N, C}, kAccTypeOpts);
+    Tensor b = at::empty({N, C}, kAccTypeOpts);
+    const int64_t B = (N * C + kCUDANumThreads - 1) / kCUDANumThreads;
+    ComputeFusedParamsCUDAKernel<T, T_ACC>
+        <<<B, kCUDANumThreads, 0, cuda_stream>>>(
+            N,
+            C,
+            G,
+            mean_acc_data,
+            rstd_acc_data,
+            gamma.defined() ? gamma.const_data_ptr<T>() : nullptr,
+            beta.defined() ? beta.const_data_ptr<T>() : nullptr,
+            a.mutable_data_ptr<T_ACC>(),
+            b.mutable_data_ptr<T_ACC>());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    auto iter = TensorIteratorConfig()
+                    .check_all_same_dtype(std::is_same_v<T, T_ACC>)
+                    .resize_outputs(false)
+                    .add_owned_output(Y.as_strided({N, HxW, C}, {HxW * C, C, 1}))
+                    .add_owned_const_input(X.as_strided({N, HxW, C}, {HxW * C, C, 1}))
+                    .add_owned_input(a.view({N, 1, C}))
+                    .add_owned_input(b.view({N, 1, C}))
+                    .build();
+    gpu_kernel(iter, [] GPU_LAMBDA(T x, T_ACC a, T_ACC b) -> T {
+      return a * static_cast<T_ACC>(x) + b;
+    });
+    return;
+  }
   RowwiseMomentsCUDAKernel<T, T_ACC><<<N * G, num_threads, 0, cuda_stream>>>(
       D * HxW, eps, X_data, mean_data, rstd_data, mean_acc_data, rstd_acc_data);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -849,8 +1011,11 @@ void GroupNormBackwardKernelImplInternal(
   const T* mean_data = mean.const_data_ptr<T>();
   const T* rstd_data = rstd.const_data_ptr<T>();
   const T* gamma_data = gamma.defined() ? gamma.const_data_ptr<T>() : nullptr;
+  const bool channels_last =
+      X.is_contiguous(at::MemoryFormat::ChannelsLast) ||
+      X.is_contiguous(at::MemoryFormat::ChannelsLast3d);
 
-  if (HxW == 1) {
+  if (HxW == 1 && !channels_last) {
     GroupNorm1dBackward<T>(
         dY, X, mean, rstd, gamma, N, C, G, dX, dgamma, dbeta);
     return;
@@ -869,8 +1034,14 @@ void GroupNormBackwardKernelImplInternal(
   int64_t num_threads = HxW < cuda_utils::kCUDABlockReduceNumThreads
       ? warp_size
       : cuda_utils::kCUDABlockReduceNumThreads;
-  ComputeInternalGradientsCUDAKernel<T><<<N * C, num_threads, 0, cuda_stream>>>(
-      HxW, dY_data, X_data, ds_data, db_data);
+  if (channels_last) {
+    ComputeInternalGradientsChannelsLastCUDAKernel<T>
+        <<<N * C, num_threads, 0, cuda_stream>>>(
+            C, HxW, dY_data, X_data, ds_data, db_data);
+  } else {
+    ComputeInternalGradientsCUDAKernel<T><<<N * C, num_threads, 0, cuda_stream>>>(
+        HxW, dY_data, X_data, ds_data, db_data);
+  }
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   if (dX.defined()) {
@@ -880,7 +1051,7 @@ void GroupNormBackwardKernelImplInternal(
     T_ACC* c2_data = c2.mutable_data_ptr<T_ACC>();
     T_ACC* c3_data = c3.mutable_data_ptr<T_ACC>();
 
-    if (gamma.defined()) {
+    if (gamma.defined() && !channels_last) {
       auto iter = TensorIteratorConfig()
                       .check_all_same_dtype(std::is_same_v<T, T_ACC>)
                       .add_output(c1)
@@ -909,7 +1080,22 @@ void GroupNormBackwardKernelImplInternal(
             c3_data);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-    if (gamma.defined()) {
+    if (channels_last) {
+      const int64_t num_threads = D < kCUDANumThreads ? D : kCUDANumThreads;
+      GroupNormBackwardChannelsLastCUDAKernel<T, T_ACC>
+          <<<N * G * HxW, num_threads, 0, cuda_stream>>>(
+              C,
+              HxW,
+              D,
+              dY_data,
+              X_data,
+              rstd_data,
+              gamma_data,
+              c2_data,
+              c3_data,
+              dX.mutable_data_ptr<T>());
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+    } else if (gamma.defined()) {
       auto iter = TensorIteratorConfig()
                       .check_all_same_dtype(std::is_same_v<T, T_ACC>)
                       .resize_outputs(false)

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -7,11 +7,11 @@
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/Tensor.h>
-#include <ATen/cuda/detail/IntegerDivider.cuh>
 #include <ATen/native/SharedReduceOps.h>
 #include <ATen/native/TensorIterator.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
+#include <ATen/cuda/detail/IntegerDivider.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/MemoryAccess.cuh>
 #include <ATen/native/cuda/block_reduce.cuh>
@@ -131,8 +131,8 @@ __global__ void RowwiseMomentsChannelsLastSmallDCUDAKernel(
     }
   }
 
-  alignas(WelfordType) __shared__ char
-      val_shared[sizeof(WelfordType) * kCUDANumThreads];
+  alignas(WelfordType)
+      __shared__ char val_shared[sizeof(WelfordType) * kCUDANumThreads];
   WelfordType* val_shared_ptr = reinterpret_cast<WelfordType*>(val_shared);
   val_shared_ptr[threadIdx.x] = val;
   __syncthreads();
@@ -184,7 +184,8 @@ __global__ void RowwiseMomentsChannelsLastCUDAKernel(
   const int64_t c_step = blockDim.x % D;
   for (int64_t j = threadIdx.x; j < group_size; j += blockDim.x) {
     const int64_t index = (n * HxW + hw) * C + c;
-    val = welford_op.reduce(val, static_cast<T_ACC>(X[index]), ng * group_size + j);
+    val = welford_op.reduce(
+        val, static_cast<T_ACC>(X[index]), ng * group_size + j);
     hw += hw_step;
     c += c_step;
     if (c >= (g + 1) * D) {
@@ -230,8 +231,8 @@ __global__ void GroupNormBackwardChannelsLastCUDAKernel(
     const T_ACC* __restrict__ c2,
     const T_ACC* __restrict__ c3,
     T* __restrict__ dX) {
-  for (index_t index = static_cast<index_t>(blockIdx.x) * blockDim.x +
-           threadIdx.x;
+  for (index_t index =
+           static_cast<index_t>(blockIdx.x) * blockDim.x + threadIdx.x;
        index < numel;
        index += static_cast<index_t>(blockDim.x) * gridDim.x) {
     const auto nhw_c = C_divider.divmod(index);
@@ -459,8 +460,7 @@ __global__ void ComputeInternalGradientsContiguousCUDAKernel(
   using T_ACC = acc_type<T, true>;
   const int64_t nc = blockIdx.x;
   using LoadT = memory::aligned_vector<T, VecSize>;
-  const auto* dY_vec =
-      reinterpret_cast<const LoadT*>(dY + nc * HxW);
+  const auto* dY_vec = reinterpret_cast<const LoadT*>(dY + nc * HxW);
   const auto* X_vec = reinterpret_cast<const LoadT*>(X + nc * HxW);
   const int64_t HxW_vec = HxW / VecSize;
   T_ACC sum1 = 0;
@@ -499,8 +499,7 @@ __global__ void ComputeInternalGradientsChannelsLastCUDAKernel(
     acc_type<T, true>* __restrict__ ds,
     acc_type<T, true>* __restrict__ db) {
   using T_ACC = acc_type<T, true>;
-  const int64_t channel_blocks =
-      (C + ChannelsPerBlock - 1) / ChannelsPerBlock;
+  const int64_t channel_blocks = (C + ChannelsPerBlock - 1) / ChannelsPerBlock;
   const int64_t n = blockIdx.x / channel_blocks;
   const int64_t first_channel =
       (blockIdx.x % channel_blocks) * ChannelsPerBlock;
@@ -850,8 +849,7 @@ void GroupNormKernelImplInternal(
   T_ACC* rstd_acc_data = rstd_acc.mutable_data_ptr<T_ACC>();
 
   cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
-  const bool channels_last =
-      X.is_contiguous(at::MemoryFormat::ChannelsLast) ||
+  const bool channels_last = X.is_contiguous(at::MemoryFormat::ChannelsLast) ||
       X.is_contiguous(at::MemoryFormat::ChannelsLast3d);
   const int64_t num_threads = D * HxW < cuda_utils::kCUDABlockReduceNumThreads
       ? at::cuda::warp_size()
@@ -860,8 +858,7 @@ void GroupNormKernelImplInternal(
     if ((D == 1 || D == 2) && G >= 4 &&
         D * HxW >= cuda_utils::kCUDABlockReduceNumThreads) {
       constexpr int kGroupsPerBlock = 4;
-      const int64_t group_blocks =
-          (G + kGroupsPerBlock - 1) / kGroupsPerBlock;
+      const int64_t group_blocks = (G + kGroupsPerBlock - 1) / kGroupsPerBlock;
       RowwiseMomentsChannelsLastSmallDCUDAKernel<kGroupsPerBlock, T, T_ACC>
           <<<N * group_blocks, kCUDANumThreads, 0, cuda_stream>>>(
               C,
@@ -904,14 +901,15 @@ void GroupNormKernelImplInternal(
             a.mutable_data_ptr<T_ACC>(),
             b.mutable_data_ptr<T_ACC>());
     C10_CUDA_KERNEL_LAUNCH_CHECK();
-    auto iter = TensorIteratorConfig()
-                    .check_all_same_dtype(std::is_same_v<T, T_ACC>)
-                    .resize_outputs(false)
-                    .add_owned_output(Y.as_strided({N, HxW, C}, {HxW * C, C, 1}))
-                    .add_owned_const_input(X.as_strided({N, HxW, C}, {HxW * C, C, 1}))
-                    .add_owned_const_input(a.view({N, 1, C}))
-                    .add_owned_const_input(b.view({N, 1, C}))
-                    .build();
+    auto iter =
+        TensorIteratorConfig()
+            .check_all_same_dtype(std::is_same_v<T, T_ACC>)
+            .resize_outputs(false)
+            .add_owned_output(Y.as_strided({N, HxW, C}, {HxW * C, C, 1}))
+            .add_owned_const_input(X.as_strided({N, HxW, C}, {HxW * C, C, 1}))
+            .add_owned_const_input(a.view({N, 1, C}))
+            .add_owned_const_input(b.view({N, 1, C}))
+            .build();
     gpu_kernel(iter, [] GPU_LAMBDA(T x, T_ACC a, T_ACC b) -> T {
       return a * static_cast<T_ACC>(x) + b;
     });
@@ -919,8 +917,8 @@ void GroupNormKernelImplInternal(
   }
   constexpr int kVecSize = 16 / sizeof(T);
   if (D * HxW % kVecSize == 0 &&
-      memory::can_vectorize_up_to<T>(
-          reinterpret_cast<const char*>(X_data)) >= kVecSize) {
+      memory::can_vectorize_up_to<T>(reinterpret_cast<const char*>(X_data)) >=
+          kVecSize) {
     RowwiseMomentsContiguousCUDAKernel<kVecSize, T, T_ACC>
         <<<N * G, num_threads, 0, cuda_stream>>>(
             D * HxW,
@@ -1186,8 +1184,7 @@ void GroupNormBackwardKernelImplInternal(
   const T* mean_data = mean.const_data_ptr<T>();
   const T* rstd_data = rstd.const_data_ptr<T>();
   const T* gamma_data = gamma.defined() ? gamma.const_data_ptr<T>() : nullptr;
-  const bool channels_last =
-      X.is_contiguous(at::MemoryFormat::ChannelsLast) ||
+  const bool channels_last = X.is_contiguous(at::MemoryFormat::ChannelsLast) ||
       X.is_contiguous(at::MemoryFormat::ChannelsLast3d);
 
   if (HxW == 1 && !channels_last) {
@@ -1228,8 +1225,8 @@ void GroupNormBackwardKernelImplInternal(
     if (HxW % kVecSize == 0 &&
         memory::can_vectorize_up_to<T>(
             reinterpret_cast<const char*>(dY_data)) >= kVecSize &&
-        memory::can_vectorize_up_to<T>(
-            reinterpret_cast<const char*>(X_data)) >= kVecSize) {
+        memory::can_vectorize_up_to<T>(reinterpret_cast<const char*>(X_data)) >=
+            kVecSize) {
       ComputeInternalGradientsContiguousCUDAKernel<kVecSize, T>
           <<<N * C, num_threads, 0, cuda_stream>>>(
               HxW, dY_data, X_data, ds_data, db_data);
@@ -1279,8 +1276,7 @@ void GroupNormBackwardKernelImplInternal(
 
     if (channels_last) {
       const int64_t numel = N * C * HxW;
-      const int64_t blocks =
-          (numel + kCUDANumThreads - 1) / kCUDANumThreads;
+      const int64_t blocks = (numel + kCUDANumThreads - 1) / kCUDANumThreads;
       if (at::cuda::detail::canUse32BitIndexMath(X)) {
         using index_t = uint32_t;
         GroupNormBackwardChannelsLastCUDAKernel<index_t, T, T_ACC>

--- a/aten/src/ATen/native/group_norm.cpp
+++ b/aten/src/ATen/native/group_norm.cpp
@@ -27,6 +27,13 @@
 
 namespace at::native {
 
+static MemoryFormat group_norm_memory_format(const Tensor& input) {
+  return (input.device().is_cpu() || input.device().is_cuda() ||
+          input.device().is_privateuseone())
+      ? input.suggest_memory_format()
+      : MemoryFormat::Contiguous;
+}
+
 template <typename T>
 static void check_group_norm_inputs(
     const Tensor& input,
@@ -94,7 +101,7 @@ std::tuple<Tensor, Tensor, Tensor> native_group_norm(
     check_mixed_data_type(X, gamma, beta);
   }
 
-  auto memory_format{X.suggest_memory_format()};
+  auto memory_format{group_norm_memory_format(X)};
   auto stat_options{X.options()
                         .memory_format(at::MemoryFormat::Contiguous)
                         .dtype(param_scalar_type(X, mixed_type))};
@@ -149,7 +156,7 @@ std::tuple<Tensor, Tensor, Tensor> native_group_norm_backward(
     check_mixed_data_type(X, mean, rstd);
   }
 
-  auto memory_format = X.suggest_memory_format();
+  auto memory_format = group_norm_memory_format(X);
   auto dparam_options{(gamma.defined() ? gamma.options() : X.options())
                           .memory_format(MemoryFormat::Contiguous)};
 

--- a/aten/src/ATen/native/group_norm.cpp
+++ b/aten/src/ATen/native/group_norm.cpp
@@ -94,10 +94,7 @@ std::tuple<Tensor, Tensor, Tensor> native_group_norm(
     check_mixed_data_type(X, gamma, beta);
   }
 
-  auto memory_format{
-      (X.device().is_cpu() || X.device().is_privateuseone())
-          ? X.suggest_memory_format()
-          : at::MemoryFormat::Contiguous};
+  auto memory_format{X.suggest_memory_format()};
   auto stat_options{X.options()
                         .memory_format(at::MemoryFormat::Contiguous)
                         .dtype(param_scalar_type(X, mixed_type))};
@@ -152,9 +149,7 @@ std::tuple<Tensor, Tensor, Tensor> native_group_norm_backward(
     check_mixed_data_type(X, mean, rstd);
   }
 
-  auto memory_format = (X.device().is_cpu() || X.device().is_privateuseone())
-      ? X.suggest_memory_format()
-      : at::MemoryFormat::Contiguous;
+  auto memory_format = X.suggest_memory_format();
   auto dparam_options{(gamma.defined() ? gamma.options() : X.options())
                           .memory_format(MemoryFormat::Contiguous)};
 
@@ -247,10 +242,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> math_group_norm(
 
   check_group_norm_inputs(input, weight, bias, C, HxW, group);
 
-  auto memory_format{
-      (input.device().is_cpu() || input.device().is_privateuseone())
-          ? input.suggest_memory_format()
-          : at::MemoryFormat::Contiguous};
+  auto memory_format{input.suggest_memory_format()};
   auto stat_options{
       input.options().memory_format(at::MemoryFormat::Contiguous)};
 
@@ -263,7 +255,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> math_group_norm(
         at::empty({N, group}, stat_options));
   }
 
-  auto input_reshaped = input.view({N, group, C / group * HxW});
+  auto input_reshaped = input.reshape({N, group, C / group * HxW});
   auto [var, mean] = at::var_mean(input_reshaped, {2}, c10::Scalar(0), true);
   auto rsqrt = var.add(eps).rsqrt();
   auto out = input_reshaped.sub(mean).mul(rsqrt).reshape(input.sizes());
@@ -277,6 +269,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> math_group_norm(
     out = out.add(bias_opt->view(weight_bias_shape));
   }
 
+  out = out.contiguous(memory_format);
   mean = mean.squeeze(-1);
   rsqrt = rsqrt.squeeze(-1);
   return std::make_tuple(std::move(out), std::move(mean), std::move(rsqrt));

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1761,6 +1761,18 @@ class TestMeta(TestCase):
                 self._norm_backwards_test_helper(torch.ops.aten.native_group_norm_backward,
                                                  args, output_mask, expected_shapes)
 
+    def test_group_norm_channels_last(self):
+        input = torch.empty((2, 32, 8, 8), device="meta").contiguous(
+            memory_format=torch.channels_last
+        )
+        output, mean, rstd = torch.native_group_norm(input, None, None, 2, 32, 64, 4, 1e-5)
+        self.assertTrue(output.is_contiguous(memory_format=torch.channels_last))
+
+        grad_input, _, _ = torch.ops.aten.native_group_norm_backward(
+            torch.empty_like(output), input, mean, rstd, None, 2, 32, 64, 4, (True, False, False)
+        )
+        self.assertTrue(grad_input.is_contiguous(memory_format=torch.channels_last))
+
     @onlyCPU
     @parametrize("output_mask", list(itertools.product([True], [True, False], [True, False])))
     def test_batch_norm_backward(self, output_mask):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8536,10 +8536,9 @@ class TestNNDeviceType(NNTestCase):
             helper(self, (2, 9, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
             helper(self, (2, 60, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
 
-    @dtypesIfCUDA(torch.float, torch.half, torch.bfloat16)
-    @dtypesIfMPS(torch.float, torch.half)
+    @onlyCUDA
     @dtypes(torch.float, torch.half, torch.bfloat16)
-    def test_groupnorm_nhwc_memory_format(self, device, dtype):
+    def test_groupnorm_nhwc_cuda(self, device, dtype):
         for shape, groups, memory_format in [
             ((2, 32, 8, 8), 4, torch.channels_last),
             ((2, 32, 16, 16), 8, torch.channels_last),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8560,6 +8560,32 @@ class TestNNDeviceType(NNTestCase):
             helper(self, (2, 9, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
             helper(self, (2, 60, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
 
+    @onlyCUDA
+    @dtypes(torch.float, torch.half, torch.bfloat16)
+    def test_groupnorm_nhwc_cuda(self, device, dtype):
+        for shape, memory_format in [
+            ((2, 32, 8, 8), torch.channels_last),
+            ((2, 32, 4, 4, 4), torch.channels_last_3d),
+        ]:
+            input = torch.randn(shape, device=device, dtype=dtype)
+            input = input.contiguous(memory_format=memory_format).requires_grad_()
+            grad = torch.randn_like(input).contiguous(memory_format=memory_format)
+            ref_input = input.detach().clone().contiguous().requires_grad_()
+            ref_grad = grad.contiguous()
+            group_norm = nn.GroupNorm(4, shape[1]).to(device=device, dtype=dtype)
+            ref_group_norm = deepcopy(group_norm)
+
+            output = group_norm(input)
+            output.backward(grad)
+            ref_output = ref_group_norm(ref_input)
+            ref_output.backward(ref_grad)
+
+            self.assertTrue(output.is_contiguous(memory_format=memory_format))
+            self.assertEqual(output, ref_output, atol=5e-4, rtol=8e-3)
+            self.assertEqual(input.grad, ref_input.grad, atol=5e-4, rtol=8e-3)
+            self.assertEqual(group_norm.weight.grad, ref_group_norm.weight.grad, atol=5e-4, rtol=8e-3)
+            self.assertEqual(group_norm.bias.grad, ref_group_norm.bias.grad, atol=5e-4, rtol=8e-3)
+
     @onlyNativeDeviceTypes
     def test_GroupNorm_memory_format(self, device):
         # Tests for regression reported in https://github.com/pytorch/pytorch/issues/92166

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8560,10 +8560,9 @@ class TestNNDeviceType(NNTestCase):
             helper(self, (2, 9, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
             helper(self, (2, 60, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
 
-    @dtypesIfCUDA(torch.float, torch.half, torch.bfloat16)
-    @dtypesIfMPS(torch.float, torch.half)
+    @onlyCUDA
     @dtypes(torch.float, torch.half, torch.bfloat16)
-    def test_groupnorm_nhwc_memory_format(self, device, dtype):
+    def test_groupnorm_nhwc_cuda(self, device, dtype):
         for shape, groups, memory_format in [
             ((2, 32, 8, 8), 4, torch.channels_last),
             ((2, 32, 16, 16), 8, torch.channels_last),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8560,9 +8560,10 @@ class TestNNDeviceType(NNTestCase):
             helper(self, (2, 9, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
             helper(self, (2, 60, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
 
-    @onlyCUDA
+    @dtypesIfCUDA(torch.float, torch.half, torch.bfloat16)
+    @dtypesIfMPS(torch.float, torch.half)
     @dtypes(torch.float, torch.half, torch.bfloat16)
-    def test_groupnorm_nhwc_cuda(self, device, dtype):
+    def test_groupnorm_nhwc_memory_format(self, device, dtype):
         for shape, memory_format in [
             ((2, 32, 8, 8), torch.channels_last),
             ((2, 32, 4, 4, 4), torch.channels_last_3d),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8564,16 +8564,19 @@ class TestNNDeviceType(NNTestCase):
     @dtypesIfMPS(torch.float, torch.half)
     @dtypes(torch.float, torch.half, torch.bfloat16)
     def test_groupnorm_nhwc_memory_format(self, device, dtype):
-        for shape, memory_format in [
-            ((2, 32, 8, 8), torch.channels_last),
-            ((2, 32, 4, 4, 4), torch.channels_last_3d),
+        for shape, groups, memory_format in [
+            ((2, 32, 8, 8), 4, torch.channels_last),
+            ((2, 32, 16, 16), 8, torch.channels_last),
+            ((2, 32, 16, 16), 16, torch.channels_last),
+            ((2, 32, 16, 16), 32, torch.channels_last),
+            ((2, 32, 4, 4, 4), 4, torch.channels_last_3d),
         ]:
             input = torch.randn(shape, device=device, dtype=dtype)
             input = input.contiguous(memory_format=memory_format).requires_grad_()
             grad = torch.randn_like(input).contiguous(memory_format=memory_format)
             ref_input = input.detach().clone().contiguous().requires_grad_()
             ref_grad = grad.contiguous()
-            group_norm = nn.GroupNorm(4, shape[1]).to(device=device, dtype=dtype)
+            group_norm = nn.GroupNorm(groups, shape[1]).to(device=device, dtype=dtype)
             ref_group_norm = deepcopy(group_norm)
 
             output = group_norm(input)
@@ -8586,6 +8589,25 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(input.grad, ref_input.grad, atol=5e-4, rtol=8e-3)
             self.assertEqual(group_norm.weight.grad, ref_group_norm.weight.grad, atol=5e-4, rtol=8e-3)
             self.assertEqual(group_norm.bias.grad, ref_group_norm.bias.grad, atol=5e-4, rtol=8e-3)
+
+    @onlyCUDA
+    @dtypes(torch.float, torch.half, torch.bfloat16)
+    def test_groupnorm_unaligned_input(self, device, dtype):
+        shape = (2, 32, 16, 16)
+        input = torch.randn(math.prod(shape) + 1, device=device, dtype=dtype)[1:]
+        input = input.view(shape).requires_grad_()
+        grad = torch.randn_like(input)
+        ref_input = input.detach().clone().requires_grad_()
+        group_norm = nn.GroupNorm(8, shape[1]).to(device=device, dtype=dtype)
+        ref_group_norm = deepcopy(group_norm)
+
+        output = group_norm(input)
+        output.backward(grad)
+        ref_output = ref_group_norm(ref_input)
+        ref_output.backward(grad)
+
+        self.assertEqual(output, ref_output, atol=5e-4, rtol=8e-3)
+        self.assertEqual(input.grad, ref_input.grad, atol=5e-4, rtol=8e-3)
 
     @onlyNativeDeviceTypes
     def test_GroupNorm_memory_format(self, device):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8536,9 +8536,10 @@ class TestNNDeviceType(NNTestCase):
             helper(self, (2, 9, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
             helper(self, (2, 60, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
 
-    @onlyCUDA
+    @dtypesIfCUDA(torch.float, torch.half, torch.bfloat16)
+    @dtypesIfMPS(torch.float, torch.half)
     @dtypes(torch.float, torch.half, torch.bfloat16)
-    def test_groupnorm_nhwc_cuda(self, device, dtype):
+    def test_groupnorm_nhwc_memory_format(self, device, dtype):
         for shape, memory_format in [
             ((2, 32, 8, 8), torch.channels_last),
             ((2, 32, 4, 4, 4), torch.channels_last_3d),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8540,16 +8540,19 @@ class TestNNDeviceType(NNTestCase):
     @dtypesIfMPS(torch.float, torch.half)
     @dtypes(torch.float, torch.half, torch.bfloat16)
     def test_groupnorm_nhwc_memory_format(self, device, dtype):
-        for shape, memory_format in [
-            ((2, 32, 8, 8), torch.channels_last),
-            ((2, 32, 4, 4, 4), torch.channels_last_3d),
+        for shape, groups, memory_format in [
+            ((2, 32, 8, 8), 4, torch.channels_last),
+            ((2, 32, 16, 16), 8, torch.channels_last),
+            ((2, 32, 16, 16), 16, torch.channels_last),
+            ((2, 32, 16, 16), 32, torch.channels_last),
+            ((2, 32, 4, 4, 4), 4, torch.channels_last_3d),
         ]:
             input = torch.randn(shape, device=device, dtype=dtype)
             input = input.contiguous(memory_format=memory_format).requires_grad_()
             grad = torch.randn_like(input).contiguous(memory_format=memory_format)
             ref_input = input.detach().clone().contiguous().requires_grad_()
             ref_grad = grad.contiguous()
-            group_norm = nn.GroupNorm(4, shape[1]).to(device=device, dtype=dtype)
+            group_norm = nn.GroupNorm(groups, shape[1]).to(device=device, dtype=dtype)
             ref_group_norm = deepcopy(group_norm)
 
             output = group_norm(input)
@@ -8562,6 +8565,25 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(input.grad, ref_input.grad, atol=5e-4, rtol=8e-3)
             self.assertEqual(group_norm.weight.grad, ref_group_norm.weight.grad, atol=5e-4, rtol=8e-3)
             self.assertEqual(group_norm.bias.grad, ref_group_norm.bias.grad, atol=5e-4, rtol=8e-3)
+
+    @onlyCUDA
+    @dtypes(torch.float, torch.half, torch.bfloat16)
+    def test_groupnorm_unaligned_input(self, device, dtype):
+        shape = (2, 32, 16, 16)
+        input = torch.randn(math.prod(shape) + 1, device=device, dtype=dtype)[1:]
+        input = input.view(shape).requires_grad_()
+        grad = torch.randn_like(input)
+        ref_input = input.detach().clone().requires_grad_()
+        group_norm = nn.GroupNorm(8, shape[1]).to(device=device, dtype=dtype)
+        ref_group_norm = deepcopy(group_norm)
+
+        output = group_norm(input)
+        output.backward(grad)
+        ref_output = ref_group_norm(ref_input)
+        ref_output.backward(grad)
+
+        self.assertEqual(output, ref_output, atol=5e-4, rtol=8e-3)
+        self.assertEqual(input.grad, ref_input.grad, atol=5e-4, rtol=8e-3)
 
     @onlyNativeDeviceTypes
     def test_GroupNorm_memory_format(self, device):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8536,6 +8536,32 @@ class TestNNDeviceType(NNTestCase):
             helper(self, (2, 9, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
             helper(self, (2, 60, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
 
+    @onlyCUDA
+    @dtypes(torch.float, torch.half, torch.bfloat16)
+    def test_groupnorm_nhwc_cuda(self, device, dtype):
+        for shape, memory_format in [
+            ((2, 32, 8, 8), torch.channels_last),
+            ((2, 32, 4, 4, 4), torch.channels_last_3d),
+        ]:
+            input = torch.randn(shape, device=device, dtype=dtype)
+            input = input.contiguous(memory_format=memory_format).requires_grad_()
+            grad = torch.randn_like(input).contiguous(memory_format=memory_format)
+            ref_input = input.detach().clone().contiguous().requires_grad_()
+            ref_grad = grad.contiguous()
+            group_norm = nn.GroupNorm(4, shape[1]).to(device=device, dtype=dtype)
+            ref_group_norm = deepcopy(group_norm)
+
+            output = group_norm(input)
+            output.backward(grad)
+            ref_output = ref_group_norm(ref_input)
+            ref_output.backward(ref_grad)
+
+            self.assertTrue(output.is_contiguous(memory_format=memory_format))
+            self.assertEqual(output, ref_output, atol=5e-4, rtol=8e-3)
+            self.assertEqual(input.grad, ref_input.grad, atol=5e-4, rtol=8e-3)
+            self.assertEqual(group_norm.weight.grad, ref_group_norm.weight.grad, atol=5e-4, rtol=8e-3)
+            self.assertEqual(group_norm.bias.grad, ref_group_norm.bias.grad, atol=5e-4, rtol=8e-3)
+
     @onlyNativeDeviceTypes
     def test_GroupNorm_memory_format(self, device):
         # Tests for regression reported in https://github.com/pytorch/pytorch/issues/92166

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1788,8 +1788,10 @@ def native_group_norm_backward(
             if supports_memory_format
             else torch.contiguous_format
         )
-        d_input = d_input.reshape(input.shape).to(input.dtype).contiguous(
-            memory_format=memory_format
+        d_input = (
+            d_input.reshape(input.shape)
+            .to(input.dtype)
+            .contiguous(memory_format=memory_format)
         )
     if output_mask[1]:
         d_gamma = (

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1777,8 +1777,19 @@ def native_group_norm_backward(
             + torch.mul(input.reshape(N, group, cpg, HxW), c2)
             + c3
         )
+        supports_memory_format = input.device.type in (
+            "cpu",
+            "cuda",
+            "meta",
+            torch._C._get_privateuse1_backend_name(),
+        )
+        memory_format = (
+            utils.suggest_memory_format(input)
+            if supports_memory_format
+            else torch.contiguous_format
+        )
         d_input = d_input.reshape(input.shape).to(input.dtype).contiguous(
-            memory_format=utils.suggest_memory_format(input)
+            memory_format=memory_format
         )
     if output_mask[1]:
         d_gamma = (

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1777,7 +1777,9 @@ def native_group_norm_backward(
             + torch.mul(input.reshape(N, group, cpg, HxW), c2)
             + c3
         )
-        d_input = d_input.reshape(input.shape).to(input.dtype)
+        d_input = d_input.reshape(input.shape).to(input.dtype).contiguous(
+            memory_format=utils.suggest_memory_format(input)
+        )
     if output_mask[1]:
         d_gamma = (
             (

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3431,12 +3431,7 @@ def native_group_norm(
         lambda: f"Expected at least 2 dimensions for input tensor but received {input.ndim}",
     )
 
-    # Match contiguous behavior of eager implementation.  Only necessary for ref tests.
-    mem_fmt = (
-        torch.contiguous_format
-        if input.device.type not in ("cpu", torch._C._get_privateuse1_backend_name())
-        else utils.suggest_memory_format(input)
-    )
+    mem_fmt = utils.suggest_memory_format(input)
     input = input.contiguous(memory_format=mem_fmt)
     weight = weight.contiguous() if weight is not None else None
     bias = bias.contiguous() if bias is not None else None
@@ -3483,6 +3478,7 @@ def native_group_norm(
             out = out + unsqueeze_bias
 
     out = _maybe_convert_to_dtype(out, input.dtype)  # type: ignore[assignment]
+    out = out.contiguous(memory_format=mem_fmt)
     mean = _maybe_convert_to_dtype(mean, input.dtype)  # type: ignore[assignment]
     rstd = _maybe_convert_to_dtype(rstd, input.dtype)  # type: ignore[assignment]
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3431,7 +3431,17 @@ def native_group_norm(
         lambda: f"Expected at least 2 dimensions for input tensor but received {input.ndim}",
     )
 
-    mem_fmt = utils.suggest_memory_format(input)
+    supports_memory_format = input.device.type in (
+        "cpu",
+        "cuda",
+        "meta",
+        torch._C._get_privateuse1_backend_name(),
+    )
+    mem_fmt = (
+        utils.suggest_memory_format(input)
+        if supports_memory_format
+        else torch.contiguous_format
+    )
     input = input.contiguous(memory_format=mem_fmt)
     weight = weight.contiguous() if weight is not None else None
     bias = bias.contiguous() if bias is not None else None


### PR DESCRIPTION
Not SOL as it's reusing existing infra for GroupNorm but achieves comparable memory B/W on H100.
Still a perf. win as the current implementation forces outputs in channels-first/contiguous which is problematic for convnets.

authored with codex

cc @ptrblck @msaroufim @tinglvv @nWEIdia