### PR TITLE
[c10d][nccl2] Don't allocate from the CUDA caching allocator during eager init

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -297,6 +297,43 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             fut.wait()
 
     @requires_gloo()
+    def test_split_world_pg_created_after_another_gloo_pg(self):
+        # Regression test: ProcessGroupGloo::groupRanks() used to derive the
+        # identity rank mapping only when local_id_ == 0. local_id_ is a
+        # process-global counter over every ProcessGroupGloo constructed in the
+        # process, so a world-sized pg built after any other gloo pg (e.g. a
+        # stateless pg, or one inherited across fork) fell through to its empty
+        # global_ranks_in_group, and split() then indexed that empty vector and
+        # segfaulted on a null data pointer.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        # (1) burn local_id_ == 0 on an unrelated gloo pg.
+        self._create_process_group_gloo(
+            c10d.PrefixStore("prior", store),
+            self.rank,
+            self.world_size,
+            self.opts(group_name="prior"),
+        )
+        # (2) a world-sized pg: default options -> global_ranks_in_group empty.
+        pg = self._create_process_group_gloo(
+            c10d.PrefixStore("world", store),
+            self.rank,
+            self.world_size,
+            self.opts(group_name="world"),
+        )
+
+        ranks = list(range(self.world_size))
+        split = pg.split(
+            c10d.PrefixStore("split", store), ranks, self.opts(group_name="split")
+        )
+        self.assertIsNotNone(split)
+        self.assertEqual(split.options.global_ranks_in_group, ranks)
+
+        tensor = torch.full((4,), float(self.rank + 1))
+        split.allreduce([tensor]).wait()
+        expected = float(sum(r + 1 for r in ranks))
+        self.assertEqual(tensor, torch.full_like(tensor, expected))
+
+    @requires_gloo()
     def test_empty_tensors(self):
         store = c10d.FileStore(self.file_name, self.world_size)
         pg = self._create_process_group_gloo(

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -5,10 +5,12 @@
 import ctypes
 import os
 import time
+from datetime import timedelta
+from unittest import mock
 
 import torch
 import torch.distributed as dist
-from torch._C._distributed_c10d import ReconfigureOptions
+from torch._C._distributed_c10d import ErrorType, ReconfigureOptions
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_nccl,
@@ -142,6 +144,110 @@ class ProcessGroupNCCLLegacyNonblockingTest(ProcessGroupNCCL2NonblockingTest):
     @classmethod
     def backend_str(cls) -> str:
         return "nccl-legacy"
+
+
+class _ProcessGroupNCCL2SubgroupTest(MultiProcContinuousTest):
+    """Base for tests that tear a group down.
+
+    They run on a throwaway subgroup so the class-wide default group survives;
+    a collective on that default group afterwards is what proves the process is
+    still alive and healthy.
+    """
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    def _new_subgroup(self, timeout=timedelta(seconds=60)):
+        return dist.new_group(
+            backend="nccl2",
+            use_local_synchronization=True,
+            timeout=timeout,
+        )
+
+    def _check_all_reduce(self, group=None) -> None:
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t, group=group)
+        self.assertEqual(t, torch.full_like(t, self.world_size))
+
+
+class ProcessGroupNCCL2AbortTest(_ProcessGroupNCCL2SubgroupTest):
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_backend_abort_on_healthy_group(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        backend = pg._get_backend(self.device)
+        # Must return instead of ::abort()ing the process, like stock NCCL.
+        backend.abort()
+        self.assertEqual(backend.get_error(), ErrorType.COMM_ERROR)
+
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_abort_process_group_on_healthy_group(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        dist.distributed_c10d._abort_process_group(pg)
+        self._check_all_reduce()
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_destroy_process_group_returns(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
+
+
+class ProcessGroupNCCL2WatchdogNoTearDownTest(_ProcessGroupNCCL2SubgroupTest):
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_timeout_without_process_abort(self) -> None:
+        # NoHandling is how a stock NCCL user opts out of the process being
+        # taken down by the watchdog; nccl2 reads the same variable, when the
+        # backend is constructed.
+        env = {"TORCH_NCCL_ASYNC_ERROR_HANDLING": "0"}
+        with mock.patch.dict(os.environ, env):
+            pg = self._new_subgroup(timeout=timedelta(seconds=5))
+        backend = pg._get_backend(self.device)
+        self._check_all_reduce(pg)
+
+        if self.rank == 0:
+            # Nobody else joins, so this can never complete and the watchdog
+            # trips. Without the tear-down the process must survive and the
+            # timeout must become readable through get_error().
+            dist.all_reduce(torch.ones(1024, device=self.device), group=pg)
+            deadline = time.time() + 60
+            while time.time() < deadline and backend.get_error() == ErrorType.SUCCESS:
+                time.sleep(0.5)
+            self.assertEqual(backend.get_error(), ErrorType.TIMEOUT)
+            # The next collective on the timed-out group raises rather than
+            # silently proceeding on a dead communicator.
+            with self.assertRaises(RuntimeError):
+                dist.all_reduce(torch.ones(4, device=self.device), group=pg)
+        else:
+            time.sleep(30)
+
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
 
 
 class ProcessGroupNCCL2ExpandableSegmentsTest(MultiProcContinuousTest):

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -2,6 +2,8 @@
 #
 # Tests specific to the in-tree torchcomms NCCL backends.
 
+import ctypes
+import os
 import time
 
 import torch
@@ -240,6 +242,94 @@ class ProcessGroupNCCLLazyNonblockingTest(ProcessGroupNCCL2NonblockingTest):
     @classmethod
     def backend_str(cls) -> str:
         return "nccl-lazy"
+
+
+def _live_env(name: str) -> str | None:
+    # os.environ is a snapshot taken at interpreter startup and does NOT observe
+    # values set later by C++ via setenv (which is how the nccl2 backend forces
+    # NCCL_ALGO under deterministic mode), so read the live environ via libc.
+    libc = ctypes.CDLL(None)
+    libc.getenv.restype = ctypes.c_char_p
+    val = libc.getenv(name.encode())
+    return val.decode() if val is not None else None
+
+
+class _DeterministicNVLSTest(MultiProcContinuousTest):
+    """Base for the nccl2 deterministic-mode NVLS-disable hook.
+
+    Under torch deterministic mode, if the user has not set NCCL_ALGO the nccl2
+    backend forces NCCL_ALGO=^NVLS (NVLS can give non-deterministic reductions),
+    mirroring the stock ProcessGroupNCCL. The hook runs during PG init and the
+    env var persists once set, so each scenario is its own subclass: every class
+    gets a freshly spawned process pool (clean deterministic flag / NCCL_ALGO)
+    and configures the env in _init_pg before the PG (and thus the hook) runs.
+    """
+
+    deterministic: bool = False
+    preset_nccl_algo: str | None = None
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file) -> None:
+        if cls.preset_nccl_algo is not None:
+            os.environ["NCCL_ALGO"] = cls.preset_nccl_algo
+        else:
+            os.environ.pop("NCCL_ALGO", None)
+        if cls.deterministic:
+            torch.use_deterministic_algorithms(True)
+        super()._init_pg(rank, world_size, rdvz_file)
+
+    def _all_reduce_and_read_algo(self) -> str | None:
+        # Force the (possibly lazy) nccl2 comm to initialize so the hook runs,
+        # and confirm the reduction is numerically correct under the chosen algo.
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t)
+        torch.cuda.synchronize()
+        self.assertEqual(t, torch.full_like(t, self.world_size))
+        return _live_env("NCCL_ALGO")
+
+
+class ProcessGroupNCCL2DeterministicNVLSDisabledTest(_DeterministicNVLSTest):
+    deterministic = True
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_deterministic_disables_nvls(self) -> None:
+        self.assertEqual(self._all_reduce_and_read_algo(), "^NVLS")
+
+
+class ProcessGroupNCCL2DeterministicNVLSPresetTest(_DeterministicNVLSTest):
+    deterministic = True
+    preset_nccl_algo = "Ring"
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_deterministic_respects_user_nccl_algo(self) -> None:
+        self.assertEqual(self._all_reduce_and_read_algo(), "Ring")
+
+
+class ProcessGroupNCCL2NonDeterministicNVLSTest(_DeterministicNVLSTest):
+    deterministic = False
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_non_deterministic_does_not_force_nccl_algo(self) -> None:
+        self.assertIsNone(self._all_reduce_and_read_algo())
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -4,7 +4,10 @@
 
 import ctypes
 import os
+import subprocess
+import sys
 import time
+import unittest
 from datetime import timedelta
 from unittest import mock
 
@@ -16,7 +19,13 @@ from torch.testing._internal.common_distributed import (
     requires_nccl,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_CUDA
+from torch.testing._internal.common_utils import (
+    IS_FBCODE,
+    IS_SANDCASTLE,
+    run_tests,
+    TEST_CUDA,
+    TestCase,
+)
 
 
 class ProcessGroupNCCL2Test(MultiProcContinuousTest):
@@ -436,6 +445,66 @@ class ProcessGroupNCCL2NonDeterministicNVLSTest(_DeterministicNVLSTest):
     @skip_if_lt_x_gpu(2)
     def test_non_deterministic_does_not_force_nccl_algo(self) -> None:
         self.assertIsNone(self._all_reduce_and_read_algo())
+
+
+_UNINITIALIZED_CUDA_SCRIPT = """\
+import torch
+import torch.distributed as dist
+
+# Nothing above this point may touch torch.cuda: the caching allocator is
+# brought up lazily by the Python torch.cuda layer, and neither CUDAGuard nor
+# stream/event creation does it.
+dist.init_process_group(
+    "cpu:gloo,cuda:nccl2",
+    rank=0,
+    world_size=1,
+    store=dist.HashStore(),
+    device_id=torch.device("cuda:0"),
+)
+assert not torch.cuda.is_initialized(), "creating a process group initialized CUDA"
+{extra}
+dist.destroy_process_group()
+"""
+
+
+class ProcessGroupNCCL2UninitializedCudaTest(TestCase):
+    """Constructing a process group must not need the CUDA caching allocator up.
+
+    Eager init (`init_process_group(device_id=...)`) allocated the barrier
+    buffer from the caching allocator, so a process that had made no torch.cuda
+    call died inside init_process_group with "Allocator not initialized for
+    device 0". Any external launcher or library that builds the PG before
+    touching CUDA hits this. Runs in a subprocess because the harness (and
+    every other test here) calls torch.cuda.set_device in setUp, which hides it.
+    """
+
+    def _run_child(self, extra: str = "") -> None:
+        try:
+            subprocess.check_output(
+                [sys.executable, "-c", _UNINITIALIZED_CUDA_SCRIPT.format(extra=extra)],
+                stderr=subprocess.STDOUT,
+                cwd=os.path.dirname(os.path.realpath(__file__)),
+                timeout=300,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("child process timed out")
+        except subprocess.CalledProcessError as e:
+            self.fail(f"child process failed with:\n{e.output.decode()}")
+
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "subprocess test fails in fbcode")
+    @requires_nccl()
+    @skip_if_lt_x_gpu(1)
+    def test_eager_init(self) -> None:
+        self._run_child()
+
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "subprocess test fails in fbcode")
+    @requires_nccl()
+    @skip_if_lt_x_gpu(1)
+    def test_barrier_after_init(self) -> None:
+        # The allocation is merely deferred, so barrier() is the second entrance
+        # into the same allocator: without lazyInitDevice() it hits the identical
+        # assert one call later.
+        self._run_child("dist.barrier()")
 
 
 if __name__ == "__main__":

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -753,7 +753,20 @@ void ProcessGroupGloo::runLoop(int workerIndex) {
 }
 
 const std::vector<uint64_t>& ProcessGroupGloo::groupRanks() const {
-  if (options_->global_ranks_in_group.empty() && local_id_ == 0) {
+  // An empty global_ranks_in_group means "this group spans the whole world, in
+  // rank order": _new_process_group_helper() only fills the vector in for
+  // subgroups, and a directly-constructed (stateless) ProcessGroupGloo leaves
+  // it at its default. Deriving the identity mapping is therefore the right
+  // answer whenever it is empty.
+  //
+  // This must NOT be gated on local_id_ == 0. local_id_ is a process-global
+  // counter over every ProcessGroupGloo ever constructed in this process, so
+  // the default group only gets 0 when it happens to be the first gloo backend
+  // built. If any gloo pg was created earlier -- a stateless pg, or one
+  // inherited across fork() -- the default group fell through to the empty
+  // global_ranks_in_group below and split() then indexed an empty vector,
+  // segfaulting on a null data pointer.
+  if (options_->global_ranks_in_group.empty()) {
     if (defaultRanks_.size() != static_cast<size_t>(size_)) {
       defaultRanks_.resize(size_);
       std::iota(defaultRanks_.begin(), defaultRanks_.end(), 0);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -13,9 +13,11 @@
 #include <thread>
 #include <unordered_set>
 
+#include <ATen/Context.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/util/env.h>
 #include <fmt/core.h>
 #include <nccl.h>
 #include <torch/csrc/cuda/CUDAPluggableAllocator.h>
@@ -165,6 +167,21 @@ void ProcessGroupNCCL::init(at::Device device) {
 
   if (!nccl_api_) {
     nccl_api_ = std::make_unique<DefaultNcclApi>();
+  }
+
+  // If deterministic mode is enabled, disable the NVLS algorithm in NCCL
+  // (which can lead to non-deterministic reductions). Mirrors the stock
+  // ProcessGroupNCCL. NCCL reads NCCL_ALGO when the communicator is created,
+  // so this must run before createNcclComm below. If the user already set
+  // NCCL_ALGO, leave it untouched.
+  // TODO: remove this once NVLS supports deterministic mode.
+  if (at::globalContext().deterministicAlgorithms()) {
+    if (!c10::utils::get_env("NCCL_ALGO").has_value()) {
+      LOG(INFO)
+          << "torch deterministic mode is enabled, "
+          << "disabling NVLS algorithm in NCCL which can lead to non-deterministic reduction.";
+      c10::utils::set_env("NCCL_ALGO", "^NVLS");
+    }
   }
 
   if (device_.index() == -1 || nccl_comm_ == nullptr) {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -205,11 +205,6 @@ void ProcessGroupNCCL::initNcclResources() {
     dependency_event_.emplace(cudaEventDisableTiming);
   }
 
-  if (!barrier_buffer_) {
-    barrier_buffer_ =
-        c10::cuda::CUDACachingAllocator::get()->allocate(sizeof(float));
-  }
-
   max_event_pool_size_ = kDefaultMaxEventPoolSize;
 
   NCCL_CHECK(
@@ -1501,6 +1496,20 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::barrierImpl(
     std::chrono::milliseconds timeout) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
+
+  // Allocated here rather than in initNcclResources() so that merely creating a
+  // process group never touches the CUDA caching allocator. Eager init runs
+  // before anything has initialized CUDA (init_process_group(device_id=...) on
+  // a process that has made no torch.cuda call), and the allocator is brought
+  // up lazily, so allocating there tripped "Allocator not initialized for
+  // device N". lazyInitDevice() is what ATen's own allocating paths call, and
+  // is a no-op once CUDA is up.
+  if (!barrier_buffer_) {
+    at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
+    c10::cuda::CUDAGuard gpuGuard(device_);
+    barrier_buffer_ =
+        c10::cuda::CUDACachingAllocator::get()->allocate(sizeof(float));
+  }
 
   TracingGuard tracingGuard(name_, comm_size_, "barrier", rank_);
   c10::cuda::CUDAGuard device_guard(device_);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -103,31 +103,14 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
         << " was not finalized before destruction. "
         << "This may indicate a resource leak. Please call finalize() explicitly.";
 
-    // Signal shutdown to timeout watchdog thread to prevent it from accessing
-    // this object after destruction
-    shutdown_ = true;
+    // Stop the watchdog so it cannot access this object after destruction. It
+    // may be the caller (garbageCollect can pop a work item whose destruction
+    // releases the last reference to this comm), which stopWatchdog handles.
+    stopWatchdog();
 
-    // Wake up the timeout watchdog thread
-    {
-      std::lock_guard<std::mutex> lock(timeout_mutex_);
-      timeout_cv_.notify_all();
-    }
-
-    // Wait for timeout thread to finish. If we're being called from within
-    // the timeout thread itself (e.g., garbageCollect popped a work item whose
-    // destruction released the last shared_ptr to this comm), we must detach
-    // instead of join to avoid a deadlock.
-    if (timeout_thread_.joinable()) {
-      if (std::this_thread::get_id() != timeout_thread_.get_id()) {
-        timeout_thread_.join();
-      } else {
-        timeout_thread_.detach(); // NOLINT(facebook-hte-BadCall-detach)
-      }
-    }
-
-    // Abort the NCCL communicator since we can't do a clean finalization
-    // Note: We don't call the full abortNcclComm() to avoid potential abort()
-    // calls from abort_process_on_timeout_or_error_
+    // Abort the NCCL communicator since we can't do a clean finalization.
+    // Open-coded rather than abortNcclComm() so a failure cannot throw out of
+    // the destructor (abortNcclComm() throws on a failed or timed-out abort).
     if (nccl_comm_) {
       // Drop our symmetric-memory registration while nccl_comm_ is still valid
       // (it is nulled below, before detachMemoryHook runs).
@@ -349,10 +332,24 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::split(
 }
 
 void ProcessGroupNCCL::abort() {
-  comm_state_ = CommState::ERROR;
+  // User-initiated (backend.abort() / _abort_process_group()): tear the
+  // communicator down and return. Never terminates the process, whatever
+  // TORCH_NCCL_ASYNC_ERROR_HANDLING says -- that gate only covers failures the
+  // watchdog detects on its own.
+  TC_LOG(INFO, this) << "abort() requested on rank " << rank_
+                     << "; aborting the NCCL communicator";
   if (options_c10d_->enable_reconfigure) {
+    comm_state_ = CommState::ERROR;
     revokeNcclComm();
   } else {
+    // Stop the watchdog before publishing the error: this failure is one the
+    // caller asked for, so it must not trigger a process abort, and there is no
+    // communicator left to watch either. Not done in reconfigurable mode, where
+    // the comm is revoked rather than destroyed and the watchdog is needed again
+    // after reconfigure(). The error is still published before the teardown, so
+    // work in flight reports it instead of completing.
+    stopWatchdog();
+    comm_state_ = CommState::ERROR;
     abortNcclComm();
   }
 }
@@ -416,19 +413,10 @@ void ProcessGroupNCCL::finalize() {
   }
   init_state_ = InitializationState::FINALIZED;
 
-  // Signal shutdown to timeout watchdog
-  shutdown_ = true;
-
-  // Wake up the timeout watchdog thread
-  {
-    std::lock_guard<std::mutex> lock(timeout_mutex_);
-    timeout_cv_.notify_all();
-  }
-
-  // Wait for timeout thread to finish
-  if (timeout_thread_.joinable()) {
-    timeout_thread_.join();
-  }
+  // Stop the watchdog first: draining the work queue below may surface a
+  // timeout, which is a teardown result to report to the caller, not a reason
+  // to terminate the process.
+  stopWatchdog();
 
   // Wait for all pending work objects to complete and get final status
   auto work_status = workq_.finalize();
@@ -446,6 +434,10 @@ void ProcessGroupNCCL::finalize() {
     throw std::runtime_error("Work timed out during finalize");
   } else if (work_status == WorkNCCL::WorkStatus::ERROR) {
     comm_state_ = CommState::ERROR;
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCL communicator was aborted after a previous error");
+    }
     ncclResult_t asyncErr{};
     NCCL_CHECK(
         nccl_api_,
@@ -500,14 +492,36 @@ void ProcessGroupNCCL::abortNcclComm() {
         "NCCL Abort failed");
     nccl_comm_ = nullptr;
   }
-  // Never abort the process in reconfigurable mode: callers fall back to
-  // revoke + throw so the failure can be handled by reconfiguring.
-  if (abort_process_on_timeout_or_error_ &&
-      !options_c10d_->enable_reconfigure) {
-    TC_LOG(ERROR, this) << "Aborting process due to timeout";
-    runAbortHooks();
-    ::abort();
+}
+
+void ProcessGroupNCCL::stopWatchdog() {
+  shutdown_ = true;
+  {
+    std::lock_guard<std::mutex> lock(timeout_mutex_);
+    timeout_cv_.notify_all();
   }
+  if (timeout_thread_.joinable()) {
+    // Joining from within the watchdog thread (the async-error path calls
+    // abort()) would deadlock.
+    if (std::this_thread::get_id() != timeout_thread_.get_id()) {
+      timeout_thread_.join();
+    } else {
+      timeout_thread_.detach(); // NOLINT(facebook-hte-BadCall-detach)
+    }
+  }
+}
+
+void ProcessGroupNCCL::abortProcess(const std::string& reason) {
+  // Never terminate the process in reconfigurable mode: callers fall back to
+  // revoke + throw so the failure can be handled by reconfiguring.
+  if (!abort_process_on_timeout_or_error_ ||
+      options_c10d_->enable_reconfigure) {
+    return;
+  }
+  TC_LOG(ERROR, this) << "Aborting process on rank " << rank_ << " due to "
+                      << reason;
+  runAbortHooks();
+  ::abort();
 }
 
 void ProcessGroupNCCL::revokeNcclComm() {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -328,7 +328,19 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
       ncclResult_t status,
       std::chrono::milliseconds timeout,
       std::string_view operation);
+  // Tears the NCCL communicator down. This NEVER terminates the process --
+  // a user-initiated abort()/shutdown() must be survivable, matching
+  // ::c10d::ProcessGroupNCCL::abort(). Callers that are handling a
+  // watchdog-detected timeout or async error follow it with abortProcess().
   void abortNcclComm();
+  // Terminates the process (after running the abort hooks) if
+  // TORCH_NCCL_ASYNC_ERROR_HANDLING asks for a tear-down and we are not in
+  // reconfigurable mode. `reason` is logged after "Aborting process on rank N
+  // due to ", so it must describe the actual trigger.
+  void abortProcess(const std::string& reason);
+  // Signals the watchdog thread to exit and reaps it. Detaches instead of
+  // joining when called from the watchdog thread itself.
+  void stopWatchdog();
   void revokeNcclComm();
 
   enum class CommState {
@@ -567,8 +579,13 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   std::mutex timeout_mutex_;
 
   bool is_high_priority_stream_{false};
-  bool abort_process_on_timeout_or_error_{true};
   std::string name_;
+
+  // Whether a watchdog-detected timeout or async error takes the process down,
+  // read from TORCH_NCCL_ASYNC_ERROR_HANDLING so both NCCL backends fail the
+  // same way. Only the tear-down half of the mode applies here: our watchdog
+  // deliberately leaves the communicator for the next collective to abort.
+  const bool abort_process_on_timeout_or_error_;
 
   c10::intrusive_ptr<Options> options_c10d_;
 

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -88,6 +88,10 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     : Backend(rank, size),
       device_(at::kCUDA),
       store_(std::move(store)),
+      abort_process_on_timeout_or_error_(
+          SHOULD_TEAR_DOWN(static_cast<::c10d::ErrorHandlingMode>(getCvarInt(
+              ::c10d::TORCH_NCCL_ASYNC_ERROR_HANDLING,
+              ::c10d::SkipCleanUp)))),
       options_c10d_(options ? std::move(options) : Options::create()) {
   name_ = options_c10d_->group_name.empty() ? std::string(kBackendName)
                                             : options_c10d_->group_name;

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -265,22 +265,15 @@ void ProcessGroupNCCL::timeoutWatchdog() noexcept {
       if (shutdown_) {
         break;
       }
-      if (comm_state_ != CommState::NORMAL &&
-          abort_process_on_timeout_or_error_ &&
-          !options_c10d_->enable_reconfigure) {
-        if (comm_state_ == CommState::TIMEOUT) {
-          TC_LOG(ERROR, this)
-              << "Aborting process due to timeout on rank " << rank_
-              << " - timeout watchdog detected operation timeout";
-        } else if (comm_state_ == CommState::ERROR) {
-          TC_LOG(ERROR, this)
-              << "Aborting process due to error on rank " << rank_
-              << " - timeout watchdog detected operation error. ";
-        }
-
-        runAbortHooks();
-
-        ::abort();
+      // With abort_process_on_timeout_or_error disabled this is a no-op and
+      // the loop keeps running: comm_state_ stays TIMEOUT/ERROR so getError()
+      // reports it, and the next collective throws from
+      // checkAndAbortIfTimedOutOrError().
+      if (comm_state_ != CommState::NORMAL) {
+        abortProcess(
+            comm_state_ == CommState::TIMEOUT
+                ? "timeout - timeout watchdog detected operation timeout"
+                : "error - timeout watchdog detected operation error");
       }
 
       // Detect a communicator-level async error while the comm is still
@@ -295,13 +288,14 @@ void ProcessGroupNCCL::timeoutWatchdog() noexcept {
         if (asyncErr != ncclSuccess && asyncErr != ncclInProgress) {
           comm_state_ = CommState::ERROR;
           if (!options_c10d_->enable_reconfigure) {
-            TC_LOG(ERROR, this)
-                << "Aborting process due to error on rank " << rank_
-                << " - nccl hit async error: " << ncclGetErrorString(asyncErr);
-
-            runAbortHooks();
-
+            TC_LOG(ERROR, this) << "nccl hit async error on rank " << rank_
+                                << ": " << ncclGetErrorString(asyncErr);
+            // abort() only tears the communicator down; abortProcess() runs
+            // the abort hooks and terminates if the mode allows it.
             abort();
+            abortProcess(
+                std::string("error - nccl hit async error: ") +
+                ncclGetErrorString(asyncErr));
           } else {
             // Revoked below by the reconfigurable-mode handler.
             TC_LOG(ERROR, this)
@@ -360,15 +354,17 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
       throw std::runtime_error("NCCL operation timed out");
     } else {
       abortNcclComm();
-      if (abort_process_on_timeout_or_error_) {
-        TC_LOG(ERROR, this) << "Aborting process due to timeout";
-        runAbortHooks();
-        ::abort();
-      } else {
-        throw std::runtime_error("NCCL operation timed out");
-      }
+      abortProcess("timeout - collective operation timed out");
+      throw std::runtime_error("NCCL operation timed out");
     }
   } else if (comm_state_ == CommState::ERROR) {
+    // With abort_process_on_timeout_or_error disabled the watchdog aborts the
+    // communicator on an async error and lets the process live, so a later
+    // collective can reach here with no communicator left to query.
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCL communicator was aborted after a previous error");
+    }
     ncclResult_t asyncErr{};
     NCCL_CHECK(
         nccl_api_,
@@ -384,14 +380,8 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
       throw std::move(ncclException);
     }
     abortNcclComm();
-    if (abort_process_on_timeout_or_error_) {
-      TC_LOG(ERROR, this) << "Aborting process due to error: "
-                          << ncclException.what();
-      runAbortHooks();
-      ::abort();
-    } else {
-      throw std::move(ncclException);
-    }
+    abortProcess(std::string("error - ") + ncclException.what());
+    throw std::move(ncclException);
   }
 }
 


### PR DESCRIPTION

Summary:
init_process_group("cpu:gloo,cuda:nccl2", device_id=cuda:0) failed when nothing
had touched torch.cuda first:

    INTERNAL ASSERT FAILED at CUDACachingAllocator.cpp:4598,
    "Allocator not initialized for device 0: did you call init?"

The job dies during init_process_group, before any collective, with an internal
assert that names the caching allocator rather than the backend -- so it reads
as a torch bug rather than a startup-order requirement of the PG being created.

initNcclResources() allocated barrier_buffer_ from the caching allocator, and is
reached from eagerConnectSingleDevice() during a device_id-bound
init_process_group. The caching allocator is brought up lazily by the Python
torch.cuda layer; neither CUDAGuard nor stream/event creation does it. Stock
ProcessGroupNCCL is unaffected because its barrier allocates with at::empty,
which calls lazyInitDevice() itself.

nccl2-only, therefore, and a genuine port defect rather than an inherited one:
the same call from the same bare process succeeds on stock nccl. It was found
during the migration's own sweep of nccl2 against stock, by driving
init_process_group from a process that had made no torch.cuda call at all, not
from any downstream report -- every shipping launcher sets the device
(torch.cuda.set_device in the worker) before building the PG, so this is purely
startup-order dependent, which is why a sweep found it and the bit-exact matrix
did not. It bites any external-launcher, torchrun or library caller that
creates the PG before touching CUDA. One concrete entrance is already on record:
vLLM's stateless_init_device_torch_dist_pg hardcoded stock ProcessGroupNCCL and
ignored the backend its callers asked for, so those device-side stateless groups
never reached nccl2 at all; once it honors the requested backend they land on
this path.

The workaround available downstream -- "call torch.cuda.init(), or allocate one
throwaway tensor, before init_process_group" -- is action at a distance that the
backend must not require: it is invisible in the traceback, it has to be
replicated by every framework and every test, and a library that builds a PG on
behalf of its caller (a vLLM external launcher, a torchrun wrapper) has no way to
know the caller has not initialized CUDA. Constructing a process group must not
require the CUDA caching allocator to be up, which is the contract stock keeps.

Move the allocation to barrierImpl(), its only consumer, and precede it with
at::globalContext().lazyInitDevice(kCUDA) plus a CUDAGuard. Moving it is the
load-bearing half: it is what keeps merely creating a process group from
touching the allocator at all -- the property worth establishing, and the
reason the buffer now lives with the one operation that uses it. The other two
halves are defensive, and an earlier claim here that laziness alone was
insufficient does not survive measurement. A build carrying only the move --
allocation in barrierImpl(), no lazyInitDevice, no CUDAGuard -- passes both of
the regression tests in the test plan below, init_process_group() followed by
barrier() included. The reason is that initNcclResources() calls
attachMemoryHook() about eighteen lines past where the allocation used to sit,
and the NCCLCachingAllocatorHook singleton's constructor already calls
at::globalContext().lazyInitDevice(kCUDA) itself, so by the time any barrier can
run, some nccl2 PG has been initialized and CUDA is up process-wide. The
CUDAGuard half was probed the same way -- PG bound to cuda:1 with the calling
thread's current device left at 0 -- and it also passes without the guard, since
a device-0 buffer on a single-rank device-1 communicator does not fault. Both
are kept regardless, as guards rather than as fixes: if attachMemoryHook() ever
moves, becomes conditional or stops initializing CUDA, the deferred allocation
silently reintroduces the identical assert, and a barrier issued from a thread
whose current device differs from the PG's would place the buffer on the wrong
device. lazyInitDevice() is the right call for that job because it is what
ATen's own allocating paths use -- it is call_once-guarded, GIL-free, and does
the full CUDAHooks::init rather than a partial one -- which is precisely why
stock's at::empty-based barrier never had this bug; calling the allocator's own
init directly would do less and depend on which parts of CUDA happen to be up.
Neither guard costs anything after the first call.

Side benefit: nccl2 creates a PG per subgroup and most never barrier, so this
stops paying an allocator segment plus CUDA init per PG.

Known and left as-is: two threads calling barrier() on the same PG could both
take the !barrier_buffer_ branch and allocate. That is not a new hazard class
here -- sequence_number_ is already unsynchronized and NCCL operations on a
shared communicator are single-threaded by contract -- and closing it would need
a mutex in the header, so it is documented rather than fixed.

Test Plan:
The regression test is ProcessGroupNCCL2UninitializedCudaTest in
test/distributed/test_c10d_nccl2.py, one entrance per case: test_eager_init
does the device_id-bound init_process_group, and test_barrier_after_init
follows it with dist.barrier(), which is the next caller into the allocator now
that the allocation is deferred. Both drive the same script through a clean
child process via subprocess, and that is not incidental -- every existing
class in that file, and every probe script in the nccl2 tracking directory,
calls torch.cuda.set_device() before anything else, which is precisely why this
was never caught. The child additionally asserts that torch.cuda is still
uninitialized once init_process_group has returned, so the test pins the
property rather than merely the absence of a crash. World size is 1 over a
HashStore, so it needs one GPU and no rendezvous setup.

    python test/distributed/test_c10d_nccl2.py \
      ProcessGroupNCCL2UninitializedCudaTest -v
    test_barrier_after_init ... ok
    test_eager_init ... ok

Built against this commit's parent, both fail with the exact "Allocator not
initialized for device" assert quoted above, raised out of
eager_connect_single_device:

    Ran 2 tests in 5.160s
    FAILED (failures=2)

Before the test existed the fix was pinned across eight cells, {conda env,
vLLM venv} x {nccl2, nccl} x {plain init, init + barrier}, with all four stock
cells passing, which is what makes it count under our rule that a finding only
stands if stock passes and nccl2 fails.

Full file: Ran 22 tests in 110.6s ... OK (20 pre-existing + 2 new).
test_c10d_nccl.py on the same build: Ran 285 tests in 1691.3s, OK (skipped=15).

Authored with the assistance of an AI coding agent.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/191950).
* #192101
* #191988
* #191996
* #191990
* #191989
* #191987
* #191986
* #191985
* #191952
* #191951
* __->__ #191950
* #191949
* #191948
* #191782