### PR TITLE
[c10d] Give each backend its own Options when splitting or merging a process group

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -30,6 +30,7 @@ import torch.distributed.distributed_c10d as c10d
 import torch.nn.functional as F
 import torch.testing._internal.common_utils as common
 from torch import nn
+from torch._C._distributed_c10d import Backend as C10DBackend
 from torch.nn.parallel import DistributedDataParallel
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
@@ -2580,6 +2581,80 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
 
 
 instantiate_parametrized_tests(CommonDistributedDataParallelTest)
+
+
+class SplitGroupOptionsTest(TestCase):
+    class _SplittingBackend(C10DBackend):
+        def __init__(self, rank, size, name):
+            super().__init__(rank, size)
+            self._name = name
+            self._options = C10DBackend.Options(name, timeout=timedelta(seconds=111))
+            self.split_opts = None
+
+        @property
+        def supports_splitting(self):
+            return True
+
+        @property
+        def options(self):
+            return self._options
+
+        def getBackendName(self):
+            return self._name
+
+        def split(self, store, ranks, opts):
+            self.split_opts = opts
+            return SplitGroupOptionsTest._SplittingBackend(
+                ranks.index(self.rank()), len(ranks), f"{self._name}-child"
+            )
+
+    def _make_group(self):
+        # Shaped like a "cpu:gloo,cuda:nccl" group: two distinct backends, the
+        # accelerator one being the group's default. The backend type tags are
+        # just map keys here, the backends themselves are Python ones.
+        cpu_backend = self._SplittingBackend(0, 1, "cpu-backend")
+        default_backend = self._SplittingBackend(0, 1, "default-backend")
+        pg = dist.ProcessGroup(dist.HashStore(), 0, 1)
+        pg._register_backend(
+            torch.device("cpu"), dist.ProcessGroup.BackendType.GLOO, cpu_backend
+        )
+        pg._register_backend(
+            torch.device("cuda"), dist.ProcessGroup.BackendType.NCCL, default_backend
+        )
+        pg._set_default_backend(dist.ProcessGroup.BackendType.NCCL)
+        pg._set_group_name("split-options-test")
+        return pg, cpu_backend, default_backend
+
+    def test_split_group_clones_parent_options(self):
+        # getBackendOptions() returns the backend's live options_, and split()
+        # implementations write into what they are given, so splitGroup used to
+        # rewrite the parent's group_name/timeout and hand the child an object
+        # aliasing the parent's.
+        pg, cpu_backend, default_backend = self._make_group()
+        pg.split_group([0], timeout=timedelta(seconds=222), group_name="child")
+
+        for backend in (cpu_backend, default_backend):
+            self.assertIsNot(backend.split_opts, backend.options)
+            self.assertEqual(backend.options.group_name, "")
+            self.assertEqual(backend.options._timeout, timedelta(seconds=111))
+            self.assertEqual(backend.split_opts.group_name, "child")
+            self.assertEqual(backend.split_opts._timeout, timedelta(seconds=222))
+
+    def test_split_group_opts_apply_to_default_backend_only(self):
+        # An explicit `opts` describes the group's default backend, the same way
+        # pg_options does for init_process_group. Handing it to every device's
+        # backend made the others reject it (and silently fall back to their
+        # defaults, losing the caller's timeout).
+        pg, cpu_backend, default_backend = self._make_group()
+        opts = C10DBackend.Options("caller-supplied", timeout=timedelta(seconds=5))
+        pg.split_group([0], opts=opts, timeout=timedelta(seconds=222))
+
+        self.assertEqual(default_backend.split_opts.backend, "caller-supplied")
+        self.assertEqual(cpu_backend.split_opts.backend, "cpu-backend")
+        # The caller's object is not mutated either.
+        self.assertIsNot(default_backend.split_opts, opts)
+        self.assertEqual(opts.group_name, "")
+        self.assertEqual(opts._timeout, timedelta(seconds=5))
 
 
 class ProcessGroupWithDispatchedCollectivesTests(MultiProcessTestCase):

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -3480,6 +3480,77 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
     def test_bool_tensors(self):
         self._test_bool_tensors(backend="gloo")
 
+    @requires_gloo()
+    def test_split_group_does_not_alias_parent_options(self):
+        # Regression test: ProcessGroup::splitGroup used to hand the parent
+        # backend's live Options object to the child, so a split rewrote the
+        # parent's group_name/timeout and ProcessGroupGloo::split overwrote the
+        # parent's global_ranks_in_group with the child's ranks. The parent's
+        # next split then indexed that subgroup-sized vector out of bounds.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        c10d.init_process_group(
+            backend="gloo",
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+            timeout=timedelta(seconds=111),
+        )
+        pg = c10d.distributed_c10d._get_default_group()
+        cpu = torch.device("cpu")
+        parent_options = pg._get_backend(cpu).options
+        parent_group_name = parent_options.group_name
+
+        half = self.world_size // 2
+        halves = (
+            list(range(half))
+            if self.rank < half
+            else list(range(half, self.world_size))
+        )
+        child = pg.split_group(
+            halves, timeout=timedelta(seconds=222), group_name=f"halves{halves}"
+        )
+        child_options = child._get_backend(cpu).options
+        self.assertIsNot(child_options, parent_options)
+        self.assertEqual(parent_options.group_name, parent_group_name)
+        self.assertEqual(parent_options._timeout, timedelta(seconds=111))
+        self.assertEqual(parent_options.global_ranks_in_group, [])
+        self.assertEqual(child_options._timeout, timedelta(seconds=222))
+        self.assertEqual(child_options.global_ranks_in_group, halves)
+
+        # A second split of the same parent must still see the world's ranks.
+        parity = [r for r in range(self.world_size) if r % 2 == self.rank % 2]
+        second = pg.split_group(
+            parity, timeout=timedelta(seconds=333), group_name=f"parity{parity}"
+        )
+        self.assertEqual(second._get_backend(cpu).options.global_ranks_in_group, parity)
+
+        c10d.destroy_process_group()
+
+    @skip_if_lt_x_gpu(1)
+    @requires_gloo()
+    def test_split_group_keeps_gloo_options(self):
+        # dist.split_group used to substitute a deep copy of the accelerator
+        # backend's options for every device. On a gloo world that raised
+        # "cannot pickle _Options" (ProcessGroupGloo._Options has no
+        # __deepcopy__), and on a "cpu:gloo,cuda:nccl" world the gloo leg
+        # rejected the nccl options and fell back to Options::create_default(),
+        # dropping the caller's timeout and group_name.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        c10d.init_process_group(
+            backend="gloo",
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+            device_id=torch.device("cuda", self.rank % torch.cuda.device_count()),
+        )
+        ranks = list(range(self.world_size))
+        child = c10d.split_group(split_ranks=[ranks], timeout=timedelta(seconds=222))
+        options = child._get_backend(torch.device("cpu")).options
+        self.assertEqual(options._timeout, timedelta(seconds=222))
+        self.assertEqual(options.group_name, child.group_name)
+        self.assertEqual(options.global_ranks_in_group, ranks)
+        c10d.destroy_process_group()
+
 
 class GlooProcessGroupWithDispatchedCollectivesTests(
     test_c10d_common.ProcessGroupWithDispatchedCollectivesTests

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -297,6 +297,43 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             fut.wait()
 
     @requires_gloo()
+    def test_split_world_pg_created_after_another_gloo_pg(self):
+        # Regression test: ProcessGroupGloo::groupRanks() used to derive the
+        # identity rank mapping only when local_id_ == 0. local_id_ is a
+        # process-global counter over every ProcessGroupGloo constructed in the
+        # process, so a world-sized pg built after any other gloo pg (e.g. a
+        # stateless pg, or one inherited across fork) fell through to its empty
+        # global_ranks_in_group, and split() then indexed that empty vector and
+        # segfaulted on a null data pointer.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        # (1) burn local_id_ == 0 on an unrelated gloo pg.
+        self._create_process_group_gloo(
+            c10d.PrefixStore("prior", store),
+            self.rank,
+            self.world_size,
+            self.opts(group_name="prior"),
+        )
+        # (2) a world-sized pg: default options -> global_ranks_in_group empty.
+        pg = self._create_process_group_gloo(
+            c10d.PrefixStore("world", store),
+            self.rank,
+            self.world_size,
+            self.opts(group_name="world"),
+        )
+
+        ranks = list(range(self.world_size))
+        split = pg.split(
+            c10d.PrefixStore("split", store), ranks, self.opts(group_name="split")
+        )
+        self.assertIsNotNone(split)
+        self.assertEqual(split.options.global_ranks_in_group, ranks)
+
+        tensor = torch.full((4,), float(self.rank + 1))
+        split.allreduce([tensor]).wait()
+        expected = float(sum(r + 1 for r in ranks))
+        self.assertEqual(tensor, torch.full_like(tensor, expected))
+
+    @requires_gloo()
     def test_empty_tensors(self):
         store = c10d.FileStore(self.file_name, self.world_size)
         pg = self._create_process_group_gloo(

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1226,6 +1226,50 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_comm_split_world_pg_created_after_another_nccl_pg(self):
+        # Regression test: ProcessGroupNCCL::groupRanks() used to derive the
+        # identity rank mapping only when local_id_ == 0. local_id_ is a
+        # process-global counter over every ProcessGroupNCCL constructed in the
+        # process, so a default pg built after any other nccl pg (e.g. a
+        # stateless pg, one inherited across fork, or an earlier
+        # init_process_group that was destroyed) fell through to its empty
+        # global_ranks_in_group, and split() then indexed that empty vector and
+        # segfaulted on a null data pointer.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        # (1) burn local_id_ == 0 on an unrelated nccl pg.
+        c10d.init_process_group(
+            "nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=c10d.PrefixStore("prior", store),
+        )
+        dist.destroy_process_group()
+        # (2) the real default pg -> global_ranks_in_group empty.
+        c10d.init_process_group(
+            "nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=c10d.PrefixStore("world", store),
+            pg_options=self.opts(),
+            device_id=device,
+        )
+        pg = c10d.distributed_c10d._get_default_group()
+
+        ranks = list(range(self.world_size))
+        ng = c10d.split_group(pg, [ranks])
+        self.assertIsNotNone(ng)
+        self.assertEqual(dist.get_process_group_ranks(ng), ranks)
+        self.assertEqual(ng._get_backend(device).options.global_ranks_in_group, ranks)
+
+        tensor = torch.full((1,), self.rank).cuda(device)
+        dist.broadcast(tensor, 0, group=ng)
+        self.assertEqual(tensor, torch.full((1,), 0))
+
+        dist.destroy_process_group()
+
+    @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_comm_split_group_mixed_backend(self):
         # Test `ncclCommSplit` for smaller subgroups of the world when
         # we've passed a specific device_id to init_process_group.

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -2,6 +2,8 @@
 #
 # Tests specific to the in-tree torchcomms NCCL backends.
 
+import ctypes
+import os
 import time
 
 import torch
@@ -173,6 +175,94 @@ class ProcessGroupNCCLLazyTest(ProcessGroupNCCL2Test):
 
         expected = 1 if nxt == prev else 2
         self.assertGreaterEqual(backend._num_active_channels(), expected)
+
+
+def _live_env(name: str) -> str | None:
+    # os.environ is a snapshot taken at interpreter startup and does NOT observe
+    # values set later by C++ via setenv (which is how the nccl2 backend forces
+    # NCCL_ALGO under deterministic mode), so read the live environ via libc.
+    libc = ctypes.CDLL(None)
+    libc.getenv.restype = ctypes.c_char_p
+    val = libc.getenv(name.encode())
+    return val.decode() if val is not None else None
+
+
+class _DeterministicNVLSTest(MultiProcContinuousTest):
+    """Base for the nccl2 deterministic-mode NVLS-disable hook.
+
+    Under torch deterministic mode, if the user has not set NCCL_ALGO the nccl2
+    backend forces NCCL_ALGO=^NVLS (NVLS can give non-deterministic reductions),
+    mirroring the stock ProcessGroupNCCL. The hook runs during PG init and the
+    env var persists once set, so each scenario is its own subclass: every class
+    gets a freshly spawned process pool (clean deterministic flag / NCCL_ALGO)
+    and configures the env in _init_pg before the PG (and thus the hook) runs.
+    """
+
+    deterministic: bool = False
+    preset_nccl_algo: str | None = None
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file) -> None:
+        if cls.preset_nccl_algo is not None:
+            os.environ["NCCL_ALGO"] = cls.preset_nccl_algo
+        else:
+            os.environ.pop("NCCL_ALGO", None)
+        if cls.deterministic:
+            torch.use_deterministic_algorithms(True)
+        super()._init_pg(rank, world_size, rdvz_file)
+
+    def _all_reduce_and_read_algo(self) -> str | None:
+        # Force the (possibly lazy) nccl2 comm to initialize so the hook runs,
+        # and confirm the reduction is numerically correct under the chosen algo.
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t)
+        torch.cuda.synchronize()
+        self.assertEqual(t, torch.full_like(t, self.world_size))
+        return _live_env("NCCL_ALGO")
+
+
+class ProcessGroupNCCL2DeterministicNVLSDisabledTest(_DeterministicNVLSTest):
+    deterministic = True
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_deterministic_disables_nvls(self) -> None:
+        self.assertEqual(self._all_reduce_and_read_algo(), "^NVLS")
+
+
+class ProcessGroupNCCL2DeterministicNVLSPresetTest(_DeterministicNVLSTest):
+    deterministic = True
+    preset_nccl_algo = "Ring"
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_deterministic_respects_user_nccl_algo(self) -> None:
+        self.assertEqual(self._all_reduce_and_read_algo(), "Ring")
+
+
+class ProcessGroupNCCL2NonDeterministicNVLSTest(_DeterministicNVLSTest):
+    deterministic = False
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_non_deterministic_does_not_force_nccl_algo(self) -> None:
+        self.assertIsNone(self._all_reduce_and_read_algo())
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -5,7 +5,10 @@
 import copy
 import ctypes
 import os
+import subprocess
+import sys
 import time
+import unittest
 from datetime import timedelta
 
 import torch
@@ -16,7 +19,13 @@ from torch.testing._internal.common_distributed import (
     requires_nccl,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_CUDA
+from torch.testing._internal.common_utils import (
+    IS_FBCODE,
+    IS_SANDCASTLE,
+    run_tests,
+    TEST_CUDA,
+    TestCase,
+)
 
 
 class ProcessGroupNCCL2Test(MultiProcContinuousTest):
@@ -398,6 +407,66 @@ class ProcessGroupNCCL2NonDeterministicNVLSTest(_DeterministicNVLSTest):
     @skip_if_lt_x_gpu(2)
     def test_non_deterministic_does_not_force_nccl_algo(self) -> None:
         self.assertIsNone(self._all_reduce_and_read_algo())
+
+
+_UNINITIALIZED_CUDA_SCRIPT = """\
+import torch
+import torch.distributed as dist
+
+# Nothing above this point may touch torch.cuda: the caching allocator is
+# brought up lazily by the Python torch.cuda layer, and neither CUDAGuard nor
+# stream/event creation does it.
+dist.init_process_group(
+    "cpu:gloo,cuda:nccl2",
+    rank=0,
+    world_size=1,
+    store=dist.HashStore(),
+    device_id=torch.device("cuda:0"),
+)
+assert not torch.cuda.is_initialized(), "creating a process group initialized CUDA"
+{extra}
+dist.destroy_process_group()
+"""
+
+
+class ProcessGroupNCCL2UninitializedCudaTest(TestCase):
+    """Constructing a process group must not need the CUDA caching allocator up.
+
+    Eager init (`init_process_group(device_id=...)`) allocated the barrier
+    buffer from the caching allocator, so a process that had made no torch.cuda
+    call died inside init_process_group with "Allocator not initialized for
+    device 0". Any external launcher or library that builds the PG before
+    touching CUDA hits this. Runs in a subprocess because the harness (and
+    every other test here) calls torch.cuda.set_device in setUp, which hides it.
+    """
+
+    def _run_child(self, extra: str = "") -> None:
+        try:
+            subprocess.check_output(
+                [sys.executable, "-c", _UNINITIALIZED_CUDA_SCRIPT.format(extra=extra)],
+                stderr=subprocess.STDOUT,
+                cwd=os.path.dirname(os.path.realpath(__file__)),
+                timeout=300,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("child process timed out")
+        except subprocess.CalledProcessError as e:
+            self.fail(f"child process failed with:\n{e.output.decode()}")
+
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "subprocess test fails in fbcode")
+    @requires_nccl()
+    @skip_if_lt_x_gpu(1)
+    def test_eager_init(self) -> None:
+        self._run_child()
+
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "subprocess test fails in fbcode")
+    @requires_nccl()
+    @skip_if_lt_x_gpu(1)
+    def test_barrier_after_init(self) -> None:
+        # The allocation is merely deferred, so barrier() is the second entrance
+        # into the same allocator: without lazyInitDevice() it hits the identical
+        # assert one call later.
+        self._run_child("dist.barrier()")
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -2,12 +2,15 @@
 #
 # Tests specific to the in-tree torchcomms NCCL backends.
 
+import copy
 import ctypes
 import os
 import time
+from datetime import timedelta
 
 import torch
 import torch.distributed as dist
+from torch._C._distributed_c10d import ErrorType
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_nccl,
@@ -51,13 +54,42 @@ class ProcessGroupNCCL2Test(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
-    def test_shared_options_type(self) -> None:
-        self.assertIs(dist.ProcessGroupNCCL2.Options, dist.ProcessGroupNCCL.Options)
+    def test_options_type(self) -> None:
+        # nccl2 has its own Options, but it derives from the stock one so the
+        # whole pre-existing attribute surface keeps working.
+        self.assertTrue(
+            issubclass(dist.ProcessGroupNCCL2.Options, dist.ProcessGroupNCCL.Options)
+        )
         opts = dist.ProcessGroupNCCL2.Options()
         opts.config.cga_cluster_size = 2
         opts.config.max_ctas = 4
         self.assertEqual(opts.config.cga_cluster_size, 2)
         self.assertEqual(opts.config.max_ctas, 4)
+        self.assertTrue(opts.abort_process_on_timeout_or_error)
+        opts.abort_process_on_timeout_or_error = False
+        self.assertFalse(copy.deepcopy(opts).abort_process_on_timeout_or_error)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_stock_options_accepted(self) -> None:
+        # Callers written against the stock backend hand us a
+        # ProcessGroupNCCL.Options; it must still be usable and get the nccl2
+        # defaults for the nccl2-only fields.
+        opts = dist.ProcessGroupNCCL.Options()
+        pg = dist.new_group(
+            backend=self.backend_str(),
+            pg_options=opts,
+            use_local_synchronization=True,
+            timeout=timedelta(seconds=60),
+        )
+        try:
+            backend = pg._get_backend(self.device)
+            self.assertTrue(backend.options.abort_process_on_timeout_or_error)
+            t = torch.ones(4, device=self.device)
+            dist.all_reduce(t, group=pg)
+            self.assertEqual(t, torch.full_like(t, self.world_size))
+        finally:
+            dist.destroy_process_group(pg)
 
 
 class _ProcessGroupNCCL2OptionsTest(MultiProcContinuousTest):
@@ -101,6 +133,109 @@ class ProcessGroupNCCL2ConfigTest(_ProcessGroupNCCL2OptionsTest):
         self.assertEqual(backend.options.config.cga_cluster_size, 2)
         self.assertEqual(backend.options.config.max_ctas, 4)
         self.assertTrue(backend.options.is_high_priority_stream)
+        self._check_all_reduce()
+
+
+class _ProcessGroupNCCL2SubgroupTest(MultiProcContinuousTest):
+    """Base for tests that tear a group down.
+
+    They run on a throwaway subgroup so the class-wide default group survives;
+    a collective on that default group afterwards is what proves the process is
+    still alive and healthy.
+    """
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    def _new_subgroup(self, backend_options=None, timeout=timedelta(seconds=60)):
+        return dist.new_group(
+            backend="nccl2",
+            pg_options=backend_options,
+            use_local_synchronization=True,
+            timeout=timeout,
+        )
+
+    def _check_all_reduce(self, group=None) -> None:
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t, group=group)
+        self.assertEqual(t, torch.full_like(t, self.world_size))
+
+
+class ProcessGroupNCCL2AbortTest(_ProcessGroupNCCL2SubgroupTest):
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_backend_abort_on_healthy_group(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        backend = pg._get_backend(self.device)
+        # Must return instead of ::abort()ing the process, like stock NCCL.
+        backend.abort()
+        self.assertEqual(backend.get_error(), ErrorType.COMM_ERROR)
+
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_abort_process_group_on_healthy_group(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        dist.distributed_c10d._abort_process_group(pg)
+        self._check_all_reduce()
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_destroy_process_group_returns(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
+
+
+class ProcessGroupNCCL2WatchdogAbortOptionTest(_ProcessGroupNCCL2SubgroupTest):
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_timeout_without_process_abort(self) -> None:
+        opts = dist.ProcessGroupNCCL2.Options()
+        opts.abort_process_on_timeout_or_error = False
+        pg = self._new_subgroup(opts, timeout=timedelta(seconds=5))
+        backend = pg._get_backend(self.device)
+        self.assertFalse(backend.options.abort_process_on_timeout_or_error)
+        self._check_all_reduce(pg)
+
+        if self.rank == 0:
+            # Nobody else joins, so this can never complete and the watchdog
+            # trips. With the option off the process must survive and the
+            # timeout must become readable through get_error().
+            dist.all_reduce(torch.ones(1024, device=self.device), group=pg)
+            deadline = time.time() + 60
+            while time.time() < deadline and backend.get_error() == ErrorType.SUCCESS:
+                time.sleep(0.5)
+            self.assertEqual(backend.get_error(), ErrorType.TIMEOUT)
+            # The next collective on the timed-out group raises rather than
+            # silently proceeding on a dead communicator.
+            with self.assertRaises(RuntimeError):
+                dist.all_reduce(torch.ones(4, device=self.device), group=pg)
+        else:
+            time.sleep(30)
+
+        dist.destroy_process_group(pg)
         self._check_all_reduce()
 
 

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -289,6 +289,96 @@ class ProcessGroupNCCL2ExpandableSegmentsTest(MultiProcContinuousTest):
             self.assertEqual(chunk, torch.full_like(chunk, rank))
 
 
+class ProcessGroupNCCL2MemPoolTest(MultiProcContinuousTest):
+    """register_mem_pool / deregister_mem_pool: the NCCL user-buffer path that
+    Megatron's nccl_allocator drives (megatron/core/nccl_allocator.py)."""
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    def _backend(self):
+        # nccl2 bootstraps its communicator on the first collective, and
+        # register_mem_pool needs it up (as it does on the stock backend, whose
+        # test eagerly inits via init_process_group(device_id=...) instead).
+        dist.all_reduce(torch.zeros(1, device=self.device))
+        torch.cuda.synchronize()
+        return dist.get_backend_impl(device=self.device)
+
+    @property
+    def _all_reduced(self) -> float:
+        return float(sum(range(self.world_size)))
+
+    def _pool_tensor(self, pool, numel: int = 1024 * 1024) -> torch.Tensor:
+        with torch.cuda.use_mem_pool(pool):
+            return torch.full((numel,), float(self.rank), device=self.device)
+
+    def _check_all_reduce_over_pool(self, symm: bool) -> None:
+        backend = self._backend()
+        pool = torch.cuda.MemPool(backend.mem_allocator)
+        tensor = self._pool_tensor(pool)
+        backend.register_mem_pool(pool, symm=symm)
+        try:
+            dist.all_reduce(tensor)
+            torch.cuda.synchronize()
+            self.assertEqual(tensor, torch.full_like(tensor, self._all_reduced))
+        finally:
+            backend.deregister_mem_pool(pool)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_register_mem_pool(self) -> None:
+        self._check_all_reduce_over_pool(symm=False)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_register_mem_pool_symmetric(self) -> None:
+        self._check_all_reduce_over_pool(symm=True)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_register_mem_pool_round_trip(self) -> None:
+        # Megatron re-enters its allocator context once per bucket: deregister,
+        # grow the pool, register again. Neither leg may trip over a segment
+        # the caching-allocator hook already registered, and the second
+        # register has to pick up segments the hook never saw (reused ones).
+        backend = self._backend()
+        pool = torch.cuda.MemPool(backend.mem_allocator)
+        first = self._pool_tensor(pool)
+        backend.register_mem_pool(pool, symm=True)
+        backend.deregister_mem_pool(pool)
+        second = self._pool_tensor(pool)
+        backend.register_mem_pool(pool, symm=True)
+        try:
+            for tensor in (first, second):
+                dist.all_reduce(tensor)
+            torch.cuda.synchronize()
+            for tensor in (first, second):
+                self.assertEqual(tensor, torch.full_like(tensor, self._all_reduced))
+        finally:
+            backend.deregister_mem_pool(pool)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_deregister_unregistered_mem_pool_raises(self) -> None:
+        backend = self._backend()
+        pool = torch.cuda.MemPool(backend.mem_allocator)
+        with self.assertRaisesRegex(RuntimeError, "not previously registered"):
+            backend.deregister_mem_pool(pool)
+
+
 class ProcessGroupNCCLLazyTest(ProcessGroupNCCL2Test):
     @classmethod
     def backend_str(cls) -> str:

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -1127,7 +1127,10 @@ class ProcessGroupXCCL(Backend):
     def _reset_fr_recording_xccl(self) -> None: ...
 
 class ProcessGroupNCCL2(Backend):
-    Options = ProcessGroupNCCL.Options
+    class Options(ProcessGroupNCCL.Options):
+        abort_process_on_timeout_or_error: bool
+
+        def __init__(self, is_high_priority_stream: bool = False) -> None: ...
 
     def __init__(
         self,

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -94,6 +94,18 @@ class TORCH_API Backend : public torch::CustomClassHolder {
     ~Options() override = default;
     Options(const Options&) = default;
 
+    // Returns an independent copy, preserving the concrete type.
+    // ProcessGroup::splitGroup()/mergeRemoteGroup() clone the options they
+    // hand to a child backend: getBackendOptions() returns the parent's live
+    // options_, and split()/merge() implementations mutate what they are given
+    // (group_name, timeout, global_ranks_in_group, split_color, ...), so
+    // sharing one object corrupts the parent. A subclass that adds fields must
+    // override this or it would be sliced; ProcessGroup detects a sliced clone
+    // and falls back to sharing rather than handing a backend the wrong type.
+    virtual c10::intrusive_ptr<Options> clone() const {
+      return c10::make_intrusive<Options>(*this);
+    }
+
     std::chrono::milliseconds timeout;
 
     // backend name

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -29,6 +29,10 @@ class FakeProcessGroup : public Backend {
   struct Options : Backend::Options {
     explicit Options() : Backend::Options("fake") {}
 
+    c10::intrusive_ptr<Backend::Options> clone() const override {
+      return c10::make_intrusive<Options>(*this);
+    }
+
     int fake_option = 0;
     bool error_on_collective = false;
   };

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -6,11 +6,35 @@
 #include <fmt/ranges.h>
 
 #include <algorithm>
+#include <typeinfo>
 #include <unordered_set>
 
 #include <torch/csrc/distributed/c10d/PrefixStore.hpp>
 
 namespace c10d {
+
+namespace {
+
+// Options handed to a child backend must never alias the parent's (or the
+// caller's) object: Backend::getBackendOptions() returns the backend's live
+// options_, and split()/merge() implementations write into what they are given
+// (ProcessGroupGloo::split overwrites global_ranks_in_group,
+// ProcessGroupNCCL::split also sets split_from/split_color). Sharing one object
+// leaves the parent describing its child's ranks, which the parent's next split
+// then indexes out of bounds.
+c10::intrusive_ptr<Backend::Options> cloneOptions(
+    const c10::intrusive_ptr<Backend::Options>& opts) {
+  auto copy = opts->clone();
+  if (copy == nullptr || typeid(*copy) != typeid(*opts)) {
+    // An out-of-tree Options subclass that does not override clone() would be
+    // sliced. Keep the legacy aliasing behavior for it rather than handing its
+    // backend an object of the wrong type.
+    return opts;
+  }
+  return copy;
+}
+
+} // namespace
 
 std::string opTypeToString(OpType opType) {
   switch (opType) {
@@ -202,6 +226,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
   std::string groupDesc = desc.has_value()
       ? desc.value()
       : c10::str(getGroupDesc(), ":split:", incrementSplitCount());
+  std::unordered_map<BackendType, c10::intrusive_ptr<Backend>> splitBackends;
   for (const auto& pair : deviceTypeToBackendType_) {
     c10::DeviceType deviceType = pair.first;
     BackendType backendType = pair.second;
@@ -210,9 +235,27 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
       continue;
     }
 
+    // One backend instance can serve several device types -- a gloo world maps
+    // both cpu and cuda to the same ProcessGroupGloo, and setBackend() reuses
+    // whatever is already registered for a backend type. Split it once: the
+    // second child would be thrown away by setBackend() below, but only after
+    // rendezvousing on the same store prefix as the real child, which races
+    // with it and hangs.
+    auto splitIt = splitBackends.find(backendType);
+    if (splitIt != splitBackends.end()) {
+      newGroup->setBackend(deviceType, backendType, splitIt->second);
+      continue;
+    }
+
     auto parentBackend = getBackend(deviceType);
-    auto backendOpts =
-        opts.has_value() ? opts.value() : parentBackend->getBackendOptions();
+    // `opts` describes the group's default backend, mirroring what
+    // `pg_options` means for init_process_group; a backend of another type
+    // would reject it (or worse, silently fall back to defaults and drop the
+    // caller's timeout), so those inherit the parent's own options instead.
+    auto backendOpts = cloneOptions(
+        opts.has_value() && backendType == backendType_
+            ? opts.value()
+            : parentBackend->getBackendOptions());
     backendOpts->group_name = groupName;
     backendOpts->timeout =
         timeout.has_value() ? timeout.value() : backendOpts->timeout;
@@ -228,6 +271,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
       newGroup->setDefaultBackend(backendType_);
     }
     newGroup->setBackend(deviceType, backendType, splitBackend);
+    splitBackends.emplace(backendType, splitBackend);
   }
 
   if (!newGroup) {
@@ -252,11 +296,18 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::mergeRemoteGroup(
   std::string groupDesc = opts.group_desc.has_value()
       ? opts.group_desc.value()
       : c10::str(getGroupDesc(), ":merge");
+  std::unordered_map<BackendType, c10::intrusive_ptr<Backend>> mergedBackends;
   for (const auto& pair : deviceTypeToBackendType_) {
     c10::DeviceType deviceType = pair.first;
     BackendType backendType = pair.second;
+    // Merge each backend instance once; see the same guard in splitGroup().
+    auto mergedIt = mergedBackends.find(backendType);
+    if (mergedIt != mergedBackends.end()) {
+      newGroup->setBackend(deviceType, backendType, mergedIt->second);
+      continue;
+    }
     auto parentBackend = getBackend(deviceType);
-    auto backendOpts = parentBackend->getBackendOptions();
+    auto backendOpts = cloneOptions(parentBackend->getBackendOptions());
     backendOpts->group_name = groupName;
     backendOpts->timeout = opts.timeout;
     auto mergedBackend = parentBackend->merge(store, backendOpts, rank, size);
@@ -270,6 +321,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::mergeRemoteGroup(
       newGroup->setDefaultBackend(backendType_);
     }
     newGroup->setBackend(deviceType, backendType, mergedBackend);
+    mergedBackends.emplace(backendType, mergedBackend);
   }
 
   if (!newGroup) {

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -753,7 +753,20 @@ void ProcessGroupGloo::runLoop(int workerIndex) {
 }
 
 const std::vector<uint64_t>& ProcessGroupGloo::groupRanks() const {
-  if (options_->global_ranks_in_group.empty() && local_id_ == 0) {
+  // An empty global_ranks_in_group means "this group spans the whole world, in
+  // rank order": _new_process_group_helper() only fills the vector in for
+  // subgroups, and a directly-constructed (stateless) ProcessGroupGloo leaves
+  // it at its default. Deriving the identity mapping is therefore the right
+  // answer whenever it is empty.
+  //
+  // This must NOT be gated on local_id_ == 0. local_id_ is a process-global
+  // counter over every ProcessGroupGloo ever constructed in this process, so
+  // the default group only gets 0 when it happens to be the first gloo backend
+  // built. If any gloo pg was created earlier -- a stateless pg, or one
+  // inherited across fork() -- the default group fell through to the empty
+  // global_ranks_in_group below and split() then indexed an empty vector,
+  // segfaulting on a null data pointer.
+  if (options_->global_ranks_in_group.empty()) {
     if (defaultRanks_.size() != static_cast<size_t>(size_)) {
       defaultRanks_.resize(size_);
       std::iota(defaultRanks_.begin(), defaultRanks_.end(), 0);

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -259,6 +259,10 @@ class TORCH_API ProcessGroupGloo : public Backend {
     static c10::intrusive_ptr<Options> create_default(
         std::chrono::milliseconds timeout = kBackendDefaultTimeout);
 
+    c10::intrusive_ptr<Backend::Options> clone() const override {
+      return c10::make_intrusive<Options>(*this);
+    }
+
     std::vector<std::shared_ptr<::gloo::transport::Device>> devices;
     int threads{2};
   };

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -949,6 +949,14 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       "ProcessGroupNCCL does not support enable_reconfigure "
       "(reconfigure-based fault tolerance).");
 
+  // An empty global_ranks_in_group means "this group spans the whole world, in
+  // rank order"; see groupRanks(). Materialize that mapping here rather than
+  // lazily, so groupRanks() is a pure read and needs no synchronization.
+  if (options_->global_ranks_in_group.empty()) {
+    defaultRanks_.resize(size_);
+    std::iota(defaultRanks_.begin(), defaultRanks_.end(), 0);
+  }
+
   // getNcclVersion needs to get called before launching threads which can
   // potentially call getenv. getNcclVersion internally calls setenv to set some
   // environment variables from config file, which can race with getenv from
@@ -2668,10 +2676,22 @@ const c10::intrusive_ptr<Store>& ProcessGroupNCCL::globalStore() const {
 }
 
 const std::vector<uint64_t>& ProcessGroupNCCL::groupRanks() const {
-  if (options_->global_ranks_in_group.empty() && local_id_ == 0) {
-    static std::vector<uint64_t> globalRanks(size_);
-    std::iota(globalRanks.begin(), globalRanks.end(), 0);
-    return globalRanks;
+  // An empty global_ranks_in_group means "this group spans the whole world, in
+  // rank order": _new_process_group_helper() only fills the vector in for
+  // subgroups, and a directly-constructed (stateless) ProcessGroupNCCL leaves
+  // it at its default. defaultRanks_ (built in the constructor) is therefore
+  // the right answer whenever it is empty.
+  //
+  // This must NOT be gated on local_id_ == 0. local_id_ is a process-global
+  // counter over every ProcessGroupNCCL ever constructed in this process, so
+  // the default group only gets 0 when it happens to be the first NCCL backend
+  // built. If any NCCL pg was created earlier -- a stateless pg, one inherited
+  // across fork(), or simply a previous init_process_group() that has since
+  // been destroyed -- the default group fell through to the empty
+  // global_ranks_in_group below and split() then indexed an empty vector,
+  // segfaulting on a null data pointer.
+  if (options_->global_ranks_in_group.empty()) {
+    return defaultRanks_;
   }
   return options_->global_ranks_in_group;
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -525,6 +525,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       return c10::make_intrusive<Options>(is_high_priority_stream);
     }
 
+    c10::intrusive_ptr<Backend::Options> clone() const override {
+      return c10::make_intrusive<Options>(*this);
+    }
+
     // Schedule NCCL operations on high priority CUDA streams
     bool is_high_priority_stream;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1483,6 +1483,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // The number of ProcessGroupNCCL created on the current rank.
   size_t local_id_;
 
+  // Identity rank mapping [0, size_), used by groupRanks() when
+  // options_->global_ranks_in_group is empty. Filled in the constructor.
+  std::vector<uint64_t> defaultRanks_;
+
   std::string logPrefix_;
 
   c10::intrusive_ptr<intra_node_comm::IntraNodeComm> intraNodeComm_;

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -4171,6 +4171,14 @@ Returns:
               "get_error",
               &::c10d::nccl2::ProcessGroupNCCL::getError,
               py::call_guard<py::gil_scoped_release>())
+          .def(
+              "register_mem_pool",
+              &::c10d::nccl2::ProcessGroupNCCL::registerMemPool,
+              py::arg("pool"),
+              py::arg("symm") = false)
+          .def(
+              "deregister_mem_pool",
+              &::c10d::nccl2::ProcessGroupNCCL::deregisterMemPool)
           .def_property_readonly(
               "options",
               &::c10d::nccl2::ProcessGroupNCCL::getBackendOptions,

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -4136,18 +4136,18 @@ Returns:
       intrusive_ptr_no_gil_destructor_class_<::c10d::nccl2::ProcessGroupNCCL>(
           module, "ProcessGroupNCCL2", backend)
           .def(
-              py::init(
-                  [](const c10::intrusive_ptr<::c10d::Store>& store,
-                     int rank,
-                     int size,
-                     c10::intrusive_ptr<
-                         ::c10d::nccl2::ProcessGroupNCCL::Options> options) {
-                    // gil_scoped_release is not safe as a call_guard in init.
-                    // https://github.com/pybind/pybind11/issues/5473
-                    py::gil_scoped_release nogil{};
-                    return c10::make_intrusive<::c10d::nccl2::ProcessGroupNCCL>(
-                        store, rank, size, std::move(options));
-                  }),
+              py::init([](const c10::intrusive_ptr<::c10d::Store>& store,
+                          int rank,
+                          int size,
+                          const c10::intrusive_ptr<
+                              ::c10d::nccl2::ProcessGroupNCCL::BaseOptions>&
+                              options) {
+                // gil_scoped_release is not safe as a call_guard in init.
+                // https://github.com/pybind/pybind11/issues/5473
+                py::gil_scoped_release nogil{};
+                return c10::make_intrusive<::c10d::nccl2::ProcessGroupNCCL>(
+                    store, rank, size, options);
+              }),
               py::arg("store"),
               py::arg("rank"),
               py::arg("size"),
@@ -4176,20 +4176,57 @@ Returns:
               &::c10d::nccl2::ProcessGroupNCCL::getBackendOptions,
               R"(Return the options used to create this ProcessGroupNCCL2 instance.)");
 
-  processGroupNCCL2.attr("Options") = processGroupNCCL.attr("Options");
+  intrusive_ptr_class_<::c10d::nccl2::ProcessGroupNCCL::Options>(
+      processGroupNCCL2,
+      "Options",
+      processGroupNCCL.attr("Options"),
+      R"(
+ProcessGroup options for the nccl2 backend.
+
+Everything :class:`~torch.distributed.ProcessGroupNCCL.Options` accepts is
+accepted here too; the attribute below is specific to nccl2.
+
+Attributes:
+    abort_process_on_timeout_or_error (bool): if True (the default), a
+            collective timeout or NCCL async error detected by the nccl2
+            watchdog terminates the process with ``abort()`` after running the
+            registered abort hooks. If False the communicator is still aborted
+            but the process survives: ``backend.get_error()`` reports
+            ``TIMEOUT``/``COMM_ERROR`` and the next collective raises. It does
+            not affect ``backend.abort()`` or ``destroy_process_group()``,
+            which never terminate the process.
+      )")
+      .def(py::init<bool>(), py::arg("is_high_priority_stream") = false)
+      .def_readwrite(
+          "abort_process_on_timeout_or_error",
+          &::c10d::nccl2::ProcessGroupNCCL::Options::
+              abort_process_on_timeout_or_error)
+      .def(
+          "__copy__",
+          [](const ::c10d::nccl2::ProcessGroupNCCL::Options& self) {
+            return ::c10d::nccl2::ProcessGroupNCCL::Options(self);
+          })
+      .def(
+          "__deepcopy__",
+          [](const ::c10d::nccl2::ProcessGroupNCCL::Options& self,
+             const py::dict& memo) {
+            return ::c10d::nccl2::ProcessGroupNCCL::Options(self);
+          },
+          py::arg("memo"));
 
   intrusive_ptr_no_gil_destructor_class_<::c10d::nccl2::ProcessGroupNCCLLazy>(
       module, "ProcessGroupNCCLLazy", backend)
       .def(
-          py::init([](const c10::intrusive_ptr<::c10d::Store>& store,
-                      int rank,
-                      int size,
-                      const c10::intrusive_ptr<
-                          ::c10d::nccl2::ProcessGroupNCCL::Options>& options) {
-            py::gil_scoped_release nogil{};
-            return c10::make_intrusive<::c10d::nccl2::ProcessGroupNCCLLazy>(
-                store, rank, size, options);
-          }),
+          py::init(
+              [](const c10::intrusive_ptr<::c10d::Store>& store,
+                 int rank,
+                 int size,
+                 const c10::intrusive_ptr<
+                     ::c10d::nccl2::ProcessGroupNCCL::BaseOptions>& options) {
+                py::gil_scoped_release nogil{};
+                return c10::make_intrusive<::c10d::nccl2::ProcessGroupNCCLLazy>(
+                    store, rank, size, options);
+              }),
           py::arg("store"),
           py::arg("rank"),
           py::arg("size"),

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -12,9 +12,11 @@
 #include <string>
 #include <unordered_set>
 
+#include <ATen/Context.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/util/env.h>
 #include <fmt/core.h>
 #include <nccl.h>
 #include <torch/csrc/cuda/CUDAPluggableAllocator.h>
@@ -118,6 +120,21 @@ void ProcessGroupNCCL::init(at::Device device) {
 
   if (!nccl_api_) {
     nccl_api_ = std::make_unique<DefaultNcclApi>();
+  }
+
+  // If deterministic mode is enabled, disable the NVLS algorithm in NCCL
+  // (which can lead to non-deterministic reductions). Mirrors the stock
+  // ProcessGroupNCCL. NCCL reads NCCL_ALGO when the communicator is created,
+  // so this must run before createNcclComm below. If the user already set
+  // NCCL_ALGO, leave it untouched.
+  // TODO: remove this once NVLS supports deterministic mode.
+  if (at::globalContext().deterministicAlgorithms()) {
+    if (!c10::utils::get_env("NCCL_ALGO").has_value()) {
+      LOG(INFO)
+          << "torch deterministic mode is enabled, "
+          << "disabling NVLS algorithm in NCCL which can lead to non-deterministic reduction.";
+      c10::utils::set_env("NCCL_ALGO", "^NVLS");
+    }
   }
 
   if (device_.index() == -1 || nccl_comm_ == nullptr) {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -158,11 +158,6 @@ void ProcessGroupNCCL::initNcclResources() {
     dependency_event_.emplace(cudaEventDisableTiming);
   }
 
-  if (!barrier_buffer_) {
-    barrier_buffer_ =
-        c10::cuda::CUDACachingAllocator::get()->allocate(sizeof(float));
-  }
-
   max_event_pool_size_ = kDefaultMaxEventPoolSize;
 
   NCCL_CHECK(
@@ -1415,6 +1410,20 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::barrierImpl(
     std::chrono::milliseconds timeout) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
+
+  // Allocated here rather than in initNcclResources() so that merely creating a
+  // process group never touches the CUDA caching allocator. Eager init runs
+  // before anything has initialized CUDA (init_process_group(device_id=...) on
+  // a process that has made no torch.cuda call), and the allocator is brought
+  // up lazily, so allocating there tripped "Allocator not initialized for
+  // device N". lazyInitDevice() is what ATen's own allocating paths call, and
+  // is a no-op once CUDA is up.
+  if (!barrier_buffer_) {
+    at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
+    c10::cuda::CUDAGuard gpuGuard(device_);
+    barrier_buffer_ =
+        c10::cuda::CUDACachingAllocator::get()->allocate(sizeof(float));
+  }
 
   TracingGuard tracingGuard(name_, comm_size_, "barrier", rank_);
   cudaStream_t stream = getOperationStream(async_op);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -65,31 +65,14 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
         << " was not finalized before destruction. "
         << "This may indicate a resource leak. Please call finalize() explicitly.";
 
-    // Signal shutdown to timeout watchdog thread to prevent it from accessing
-    // this object after destruction
-    shutdown_ = true;
+    // Stop the watchdog so it cannot access this object after destruction. It
+    // may be the caller (garbageCollect can pop a work item whose destruction
+    // releases the last reference to this comm), which stopWatchdog handles.
+    stopWatchdog();
 
-    // Wake up the timeout watchdog thread
-    {
-      std::lock_guard<std::mutex> lock(timeout_mutex_);
-      timeout_cv_.notify_all();
-    }
-
-    // Wait for timeout thread to finish. If we're being called from within
-    // the timeout thread itself (e.g., garbageCollect popped a work item whose
-    // destruction released the last shared_ptr to this comm), we must detach
-    // instead of join to avoid a deadlock.
-    if (timeout_thread_.joinable()) {
-      if (std::this_thread::get_id() != timeout_thread_.get_id()) {
-        timeout_thread_.join();
-      } else {
-        timeout_thread_.detach(); // NOLINT(facebook-hte-BadCall-detach)
-      }
-    }
-
-    // Abort the NCCL communicator since we can't do a clean finalization
-    // Note: We don't call the full abortNcclComm() to avoid potential abort()
-    // calls from abort_process_on_timeout_or_error_
+    // Abort the NCCL communicator since we can't do a clean finalization.
+    // Open-coded rather than abortNcclComm() so a failure cannot throw out of
+    // the destructor (abortNcclComm() uses NCCL_CHECK).
     if (nccl_comm_) {
       // Drop our symmetric-memory registration while nccl_comm_ is still valid
       // (it is nulled below, before detachMemoryHook runs).
@@ -237,10 +220,11 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::split(
         " appears multiple times in ranks");
   }
 
-  auto ncclOpts = c10::dynamic_intrusive_pointer_cast<Options>(opts);
+  auto baseOpts = c10::dynamic_intrusive_pointer_cast<BaseOptions>(opts);
   TORCH_CHECK(
-      ncclOpts != nullptr,
+      baseOpts != nullptr,
       "ProcessGroupNCCL::split: opts is not a nccl2 ProcessGroupNCCL::Options");
+  auto ncclOpts = toNccl2Options(baseOpts);
 
   // ncclCommSplit is collective over the parent communicator, so the parent
   // must be initialized before we split. All parent ranks call split(), so a
@@ -294,6 +278,8 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::split(
   childOpts->config = config;
   childOpts->group_name = ncclOpts->group_name;
   childOpts->group_desc = ncclOpts->group_desc;
+  childOpts->abort_process_on_timeout_or_error =
+      ncclOpts->abort_process_on_timeout_or_error;
 
   auto child = c10::make_intrusive<ProcessGroupNCCL>(
       store, newRank, static_cast<int>(ranks.size()), childOpts);
@@ -302,9 +288,21 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::split(
 }
 
 void ProcessGroupNCCL::abort() {
+  // User-initiated (backend.abort() / _abort_process_group()): tear the
+  // communicator down and return. Never terminates the process, even when
+  // Options::abort_process_on_timeout_or_error is set -- that gate only covers
+  // failures the watchdog detects on its own.
+  TC_LOG(INFO, this) << "abort() requested on rank " << rank_
+                     << "; aborting the NCCL communicator";
   if (options_c10d_->enable_reconfigure) {
     revokeNcclComm();
   } else {
+    // Stop the watchdog before it can observe the comm_state_ set below: this
+    // failure is one the caller asked for, so it must not trigger a process
+    // abort, and there is no communicator left to watch either. Not done in
+    // reconfigurable mode, where the comm is revoked rather than destroyed and
+    // the watchdog is needed again after reconfigure().
+    stopWatchdog();
     abortNcclComm();
   }
   comm_state_ = CommState::ERROR;
@@ -369,19 +367,10 @@ void ProcessGroupNCCL::finalize() {
   }
   init_state_ = InitializationState::FINALIZED;
 
-  // Signal shutdown to timeout watchdog
-  shutdown_ = true;
-
-  // Wake up the timeout watchdog thread
-  {
-    std::lock_guard<std::mutex> lock(timeout_mutex_);
-    timeout_cv_.notify_all();
-  }
-
-  // Wait for timeout thread to finish
-  if (timeout_thread_.joinable()) {
-    timeout_thread_.join();
-  }
+  // Stop the watchdog first: draining the work queue below may surface a
+  // timeout, which is a teardown result to report to the caller, not a reason
+  // to terminate the process.
+  stopWatchdog();
 
   // Wait for all pending work objects to complete and get final status
   auto work_status = workq_.finalize();
@@ -399,6 +388,10 @@ void ProcessGroupNCCL::finalize() {
     throw std::runtime_error("Work timed out during finalize");
   } else if (work_status == WorkNCCL::WorkStatus::ERROR) {
     comm_state_ = CommState::ERROR;
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCL communicator was aborted after a previous error");
+    }
     ncclResult_t asyncErr{};
     NCCL_CHECK(
         nccl_api_,
@@ -451,14 +444,36 @@ void ProcessGroupNCCL::abortNcclComm() {
         "NCCL Abort failed");
     nccl_comm_ = nullptr;
   }
-  // Never abort the process in reconfigurable mode: callers fall back to
-  // revoke + throw so the failure can be handled by reconfiguring.
-  if (abort_process_on_timeout_or_error_ &&
-      !options_c10d_->enable_reconfigure) {
-    TC_LOG(ERROR, this) << "Aborting process due to timeout";
-    runAbortHooks();
-    ::abort();
+}
+
+void ProcessGroupNCCL::stopWatchdog() {
+  shutdown_ = true;
+  {
+    std::lock_guard<std::mutex> lock(timeout_mutex_);
+    timeout_cv_.notify_all();
   }
+  if (timeout_thread_.joinable()) {
+    // Joining from within the watchdog thread (the async-error path calls
+    // abort()) would deadlock.
+    if (std::this_thread::get_id() != timeout_thread_.get_id()) {
+      timeout_thread_.join();
+    } else {
+      timeout_thread_.detach(); // NOLINT(facebook-hte-BadCall-detach)
+    }
+  }
+}
+
+void ProcessGroupNCCL::abortProcess(const std::string& reason) {
+  // Never terminate the process in reconfigurable mode: callers fall back to
+  // revoke + throw so the failure can be handled by reconfiguring.
+  if (!options_c10d_->abort_process_on_timeout_or_error ||
+      options_c10d_->enable_reconfigure) {
+    return;
+  }
+  TC_LOG(ERROR, this) << "Aborting process on rank " << rank_ << " due to "
+                      << reason;
+  runAbortHooks();
+  ::abort();
 }
 
 void ProcessGroupNCCL::revokeNcclComm() {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -95,17 +95,53 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
  public:
   static constexpr std::string_view kBackendName = "nccl2";
 
-  using Options = ::c10d::ProcessGroupNCCL::Options;
+  // nccl2 shares the whole option surface of the stock NCCL backend (config,
+  // split_from/split_color, is_high_priority_stream, ...) and adds the knobs
+  // that only exist in this engine. Anything accepting a
+  // ::c10d::ProcessGroupNCCL::Options keeps working with these.
+  using BaseOptions = ::c10d::ProcessGroupNCCL::Options;
+
+  struct TORCH_API Options : BaseOptions {
+    explicit Options(bool is_high_priority_stream = false)
+        : BaseOptions(is_high_priority_stream) {}
+    // Adopt a plain base Options; the nccl2-only fields take their defaults.
+    explicit Options(const BaseOptions& base) : BaseOptions(base) {}
+    Options(const Options&) = default;
+    ~Options() override = default;
+
+    static c10::intrusive_ptr<Options> create(
+        bool is_high_priority_stream = false) {
+      return c10::make_intrusive<Options>(is_high_priority_stream);
+    }
+
+    // Whether a watchdog-detected collective timeout or NCCL async error
+    // terminates the process with ::abort() (after running the abort hooks).
+    // When false the communicator is still aborted, but the process survives:
+    // getError() reports TIMEOUT/COMM_ERROR and the next collective throws.
+    // Has no effect on a user-initiated abort()/shutdown(), which never
+    // terminate the process.
+    bool abort_process_on_timeout_or_error{true};
+  };
+
+  // Returns `options` unchanged if it already is an nccl2 Options, otherwise a
+  // copy of it as one (nccl2-only fields at their defaults). A null `options`
+  // yields a default-constructed Options.
+  static c10::intrusive_ptr<Options> toNccl2Options(
+      const c10::intrusive_ptr<BaseOptions>& options);
 
   // c10d-style constructor: the NCCL communicator is bootstrapped lazily, on
   // the first collective (or via eagerConnectSingleDevice / bound_device_id),
   // matching c10d's device-binding model -- unlike torchcomms which took an
   // eager init(device).
+  //
+  // `options` may be a plain ::c10d::ProcessGroupNCCL::Options (what callers
+  // passed before nccl2 had its own Options subclass); it is then copied into
+  // an nccl2 Options carrying the defaults for the nccl2-only fields.
   ProcessGroupNCCL(
       c10::intrusive_ptr<::c10d::Store> store,
       int rank,
       int size,
-      c10::intrusive_ptr<Options> options = Options::create());
+      const c10::intrusive_ptr<BaseOptions>& options = Options::create());
   ~ProcessGroupNCCL() override;
 
   ProcessGroupNCCL(const ProcessGroupNCCL&) = delete;
@@ -309,7 +345,19 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   void returnEvent(
       std::unique_ptr<at::cuda::CUDAEvent> event,
       bool timing_enabled);
+  // Tears the NCCL communicator down. This NEVER terminates the process --
+  // a user-initiated abort()/shutdown() must be survivable, matching
+  // ::c10d::ProcessGroupNCCL::abort(). Callers that are handling a
+  // watchdog-detected timeout or async error follow it with abortProcess().
   void abortNcclComm();
+  // Terminates the process (after running the abort hooks) if
+  // Options::abort_process_on_timeout_or_error is set and we are not in
+  // reconfigurable mode. `reason` is logged after "Aborting process on rank N
+  // due to ", so it must describe the actual trigger.
+  void abortProcess(const std::string& reason);
+  // Signals the watchdog thread to exit and reaps it. Detaches instead of
+  // joining when called from the watchdog thread itself.
+  void stopWatchdog();
   void revokeNcclComm();
 
   enum class CommState {
@@ -548,9 +596,10 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   std::mutex timeout_mutex_;
 
   bool is_high_priority_stream_{false};
-  bool abort_process_on_timeout_or_error_{true};
   std::string name_;
 
+  // Always an nccl2 Options: the constructor copies a plain
+  // ::c10d::ProcessGroupNCCL::Options into one.
   c10::intrusive_ptr<Options> options_c10d_;
 
   // Identifies the current communicator generation in the reconfigure regime;

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -115,6 +115,12 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
       return c10::make_intrusive<Options>(is_high_priority_stream);
     }
 
+    c10::intrusive_ptr<::c10d::Backend::Options> clone() const override {
+      auto copy = c10::make_intrusive<Options>(*this);
+      copy->config = cloneNcclConfig(config);
+      return copy;
+    }
+
     // Whether a watchdog-detected collective timeout or NCCL async error
     // terminates the process with ::abort() (after running the abort hooks).
     // When false the communicator is still aborted, but the process survives:

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <optional>
 #include <queue>
+#include <set>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -299,6 +300,16 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   }
   c10::intrusive_ptr<::c10d::Window> new_window(
       const std::optional<at::Tensor>& tensor = std::nullopt) override;
+
+  // MemPool registration (::c10d::ProcessGroupNCCL::registerMemPool parity).
+  // Unlike the stock backend, plain ncclCommRegister of every private-pool
+  // segment already happens unconditionally through NCCLCachingAllocatorHook,
+  // so this only has to cover the segments the hook could not reach and -- for
+  // symm -- perform the collective NCCL_WIN_COLL_SYMMETRIC upgrade that the
+  // hook must not do from an allocator thread. Collective when symm is set:
+  // every rank must call it with the same pool contents, in the same order.
+  void registerMemPool(at::cuda::MemPool* pool, bool symm = false);
+  void deregisterMemPool(at::cuda::MemPool* pool);
 
   // Caching-allocator segment registration (called by
   // NCCLCachingAllocatorHook, potentially from allocator threads).
@@ -616,9 +627,18 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
     size_t len{0};
   };
   std::map<void*, RegistrationHandle, std::less<>> memoryRegistrationHandles_;
-  // Guards memoryRegistrationHandles_: register/deregister_address run on
-  // allocator threads while window ops look segments up on the main thread.
+  // Guards memoryRegistrationHandles_ and registeredMemPools_:
+  // register/deregister_address run on allocator threads while window ops look
+  // segments up on the main thread.
   std::mutex memory_registration_mutex_;
+  // MemPools passed to registerMemPool, so deregisterMemPool can reject a pool
+  // that was never registered (stock does the same via its global
+  // ncclCommMemPoolMap). The symm mode is not tracked: a segment carries its
+  // own window handle, so teardown does not need to be told which mode to use.
+  std::set<c10::cuda::MempoolId_t> registeredMemPools_;
+  // Caller must hold memory_registration_mutex_ and have checked that `addr`
+  // is not already registered.
+  void registerAddressLocked(void* addr, size_t len);
 
   // Abort hooks (c10d::Backend API; storage was in torchcomms' TorchCommBackend
   // base, folded in here).

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -69,15 +69,26 @@ c10::intrusive_ptr<WorkNCCL> coalesceWorks(
 
 } // namespace
 
+c10::intrusive_ptr<ProcessGroupNCCL::Options> ProcessGroupNCCL::toNccl2Options(
+    const c10::intrusive_ptr<BaseOptions>& options) {
+  if (!options) {
+    return Options::create();
+  }
+  if (auto derived = c10::dynamic_intrusive_pointer_cast<Options>(options)) {
+    return derived;
+  }
+  return c10::make_intrusive<Options>(*options);
+}
+
 ProcessGroupNCCL::ProcessGroupNCCL(
     c10::intrusive_ptr<::c10d::Store> store,
     int rank,
     int size,
-    c10::intrusive_ptr<Options> options)
+    const c10::intrusive_ptr<BaseOptions>& options)
     : Backend(rank, size),
       device_(at::kCUDA),
       store_(std::move(store)),
-      options_c10d_(options ? std::move(options) : Options::create()) {
+      options_c10d_(toNccl2Options(options)) {
   name_ = options_c10d_->group_name.empty() ? std::string(kBackendName)
                                             : options_c10d_->group_name;
 }

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLLazy.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLLazy.cpp
@@ -30,6 +30,11 @@ ProcessGroupNCCLLazy::PairFactory makePairFactory(
     pair_options->is_high_priority_stream = options->is_high_priority_stream;
     pair_options->config = cloneNcclConfig(options->config);
     pair_options->group_name = pair_name;
+    // Each pair comm runs its own watchdog, so it needs the same abort policy
+    // as the primary -- otherwise one stalled pair kills a process that asked
+    // not to be killed.
+    pair_options->abort_process_on_timeout_or_error =
+        options->abort_process_on_timeout_or_error;
     return c10::make_intrusive<ProcessGroupNCCL>(
         pair_store, pair_rank, /*size=*/2, pair_options);
   };
@@ -41,7 +46,7 @@ ProcessGroupNCCLLazy::ProcessGroupNCCLLazy(
     const c10::intrusive_ptr<::c10d::Store>& store,
     int rank,
     int size,
-    const c10::intrusive_ptr<ProcessGroupNCCL::Options>& options)
+    const c10::intrusive_ptr<ProcessGroupNCCL::BaseOptions>& options)
     : LazyBackend(
           rank,
           size,
@@ -49,10 +54,8 @@ ProcessGroupNCCLLazy::ProcessGroupNCCLLazy(
               store,
               rank,
               size,
-              options ? options : ProcessGroupNCCL::Options::create()),
-          makePairFactory(
-              store,
-              options ? options : ProcessGroupNCCL::Options::create())) {}
+              ProcessGroupNCCL::toNccl2Options(options)),
+          makePairFactory(store, ProcessGroupNCCL::toNccl2Options(options))) {}
 
 } // namespace c10d::nccl2
 

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLLazy.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLLazy.hpp
@@ -29,7 +29,7 @@ class TORCH_API ProcessGroupNCCLLazy
       const c10::intrusive_ptr<::c10d::Store>& store,
       int rank,
       int size,
-      const c10::intrusive_ptr<ProcessGroupNCCL::Options>& options =
+      const c10::intrusive_ptr<ProcessGroupNCCL::BaseOptions>& options =
           ProcessGroupNCCL::Options::create());
 
   const std::string getBackendName() const override {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -8,9 +8,11 @@
 #include <nccl.h>
 #include <torch/csrc/distributed/c10d/nccl2/Logging.hpp>
 #include <torch/csrc/distributed/c10d/nccl2/NCCLCachingAllocatorHook.hpp>
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <variant>
+#include <vector>
 
 namespace c10d::nccl2 {
 
@@ -547,14 +549,7 @@ void ProcessGroupNCCL::detachMemoryHook() {
   NCCLCachingAllocatorHook::getInstance().deregisterComm(this);
 }
 
-void ProcessGroupNCCL::register_address(void* addr, size_t len) {
-  if (nccl_comm_ == nullptr) {
-    return;
-  }
-  std::lock_guard<std::mutex> lock(memory_registration_mutex_);
-  TORCH_CHECK(
-      !memoryRegistrationHandles_.count(addr),
-      "Memory already registered with NCCL");
+void ProcessGroupNCCL::registerAddressLocked(void* addr, size_t len) {
   void* handle = nullptr;
   NCCL_CHECK(
       nccl_api_,
@@ -566,6 +561,17 @@ void ProcessGroupNCCL::register_address(void* addr, size_t len) {
   // happens lazily in ensureSegmentWindow(), keyed by the base recorded here.
   memoryRegistrationHandles_.emplace(
       addr, RegistrationHandle{handle, nullptr, len});
+}
+
+void ProcessGroupNCCL::register_address(void* addr, size_t len) {
+  if (nccl_comm_ == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+  TORCH_CHECK(
+      !memoryRegistrationHandles_.count(addr),
+      "Memory already registered with NCCL");
+  registerAddressLocked(addr, len);
 }
 
 void ProcessGroupNCCL::deregister_address(void* addr) {
@@ -642,6 +648,108 @@ ncclResult_t ProcessGroupNCCL::ensureSegmentWindow(const void* ptr) {
   }
   it->second.winHandle = win;
   return ncclSuccess;
+}
+
+namespace {
+
+// Segments currently backing `id`, in allocation order. Symmetric window
+// registration is collective, so every rank has to walk them in the same
+// order; registration_counter is the only cross-rank-stable ordering the
+// snapshot offers (this is what the stock backend sorts on too).
+std::vector<c10::cuda::CUDACachingAllocator::SegmentInfo> poolSegments(
+    const c10::cuda::MempoolId_t& id) {
+  auto snapshot = c10::cuda::CUDACachingAllocator::snapshot(id);
+  std::sort(
+      snapshot.segments.begin(),
+      snapshot.segments.end(),
+      [](const auto& a, const auto& b) {
+        return a.registration_counter < b.registration_counter;
+      });
+  return std::move(snapshot.segments);
+}
+
+constexpr const char* kUninitializedCommError =
+    "NCCL communicator has not been initialized before mem pool creation. You can pass `device_id` to init_process_group -- one way of eager initialization -- to work around this issue";
+
+} // namespace
+
+void ProcessGroupNCCL::registerMemPool(at::cuda::MemPool* pool, bool symm) {
+  if (nccl_comm_ == nullptr) {
+    C10_THROW_ERROR(DistBackendError, kUninitializedCommError);
+  }
+  TORCH_CHECK(
+      pool->device() == device_.index(),
+      "MemPool is on device ",
+      static_cast<int>(pool->device()),
+      " but this process group is bound to ",
+      device_);
+  TC_LOG(INFO, this) << "Registering MemPool " << pool->id().first << ":"
+                     << pool->id().second << " (symm=" << symm << ") on "
+                     << device_;
+  {
+    std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+    registeredMemPools_.insert(pool->id());
+  }
+  bool symmUnsupported = false;
+  for (const auto& segment : poolSegments(pool->id())) {
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    void* addr = reinterpret_cast<void*>(segment.address);
+    {
+      std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+      // The allocator hook normally registered this segment already; only the
+      // ones it could not reach (allocated while the comm was down, or
+      // deregistered by an earlier deregisterMemPool) are left to do here.
+      if (!memoryRegistrationHandles_.count(addr)) {
+        registerAddressLocked(addr, segment.total_size);
+      }
+    }
+    if (!symm) {
+      continue;
+    }
+    // Only segments that exist now can be upgraded: the window call is
+    // collective, so a segment another thread allocates concurrently must be
+    // left to the next registerMemPool.
+    auto rc = ensureSegmentWindow(addr);
+    if (rc == ncclInvalidUsage) {
+      // No symmetric-memory-capable transport (or NCCL predates
+      // ncclCommWindowRegister). The stock backend keeps the plain
+      // registration and reports success here; do the same, but say so.
+      symmUnsupported = true;
+      continue;
+    }
+    TORCH_CHECK(
+        rc == ncclSuccess,
+        "Failed to register segment ",
+        addr,
+        " as an NCCL symmetric window: ",
+        nccl_api_->getErrorString(rc));
+  }
+  if (symmUnsupported) {
+    TC_LOG(WARNING, this)
+        << "Symmetric (NVLS) registration unavailable for MemPool "
+        << pool->id().first << ":" << pool->id().second
+        << "; its buffers stay registered as plain NCCL user buffers.";
+  }
+}
+
+void ProcessGroupNCCL::deregisterMemPool(at::cuda::MemPool* pool) {
+  if (nccl_comm_ == nullptr) {
+    C10_THROW_ERROR(DistBackendError, kUninitializedCommError);
+  }
+  {
+    std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+    TORCH_CHECK(
+        registeredMemPools_.erase(pool->id()) == 1,
+        "Trying to unregister not previously registered pool");
+  }
+  TC_LOG(INFO, this) << "Deregistering MemPool " << pool->id().first << ":"
+                     << pool->id().second << " on " << device_;
+  for (const auto& segment : poolSegments(pool->id())) {
+    // deregister_address tears the symmetric window down before the plain
+    // registration and tolerates a segment that is not registered.
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    deregister_address(reinterpret_cast<void*>(segment.address));
+  }
 }
 
 } // namespace c10d::nccl2

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -265,22 +265,15 @@ void ProcessGroupNCCL::timeoutWatchdog() noexcept {
       if (shutdown_) {
         break;
       }
-      if (comm_state_ != CommState::NORMAL &&
-          abort_process_on_timeout_or_error_ &&
-          !options_c10d_->enable_reconfigure) {
-        if (comm_state_ == CommState::TIMEOUT) {
-          TC_LOG(ERROR, this)
-              << "Aborting process due to timeout on rank " << rank_
-              << " - timeout watchdog detected operation timeout";
-        } else if (comm_state_ == CommState::ERROR) {
-          TC_LOG(ERROR, this)
-              << "Aborting process due to error on rank " << rank_
-              << " - timeout watchdog detected operation error. ";
-        }
-
-        runAbortHooks();
-
-        ::abort();
+      // With abort_process_on_timeout_or_error disabled this is a no-op and
+      // the loop keeps running: comm_state_ stays TIMEOUT/ERROR so getError()
+      // reports it, and the next collective throws from
+      // checkAndAbortIfTimedOutOrError().
+      if (comm_state_ != CommState::NORMAL) {
+        abortProcess(
+            comm_state_ == CommState::TIMEOUT
+                ? "timeout - timeout watchdog detected operation timeout"
+                : "error - timeout watchdog detected operation error");
       }
 
       // Detect a communicator-level async error while the comm is still
@@ -295,13 +288,14 @@ void ProcessGroupNCCL::timeoutWatchdog() noexcept {
         if (asyncErr != ncclSuccess) {
           comm_state_ = CommState::ERROR;
           if (!options_c10d_->enable_reconfigure) {
-            TC_LOG(ERROR, this)
-                << "Aborting process due to error on rank " << rank_
-                << " - nccl hit async error: " << ncclGetErrorString(asyncErr);
-
-            runAbortHooks();
-
+            TC_LOG(ERROR, this) << "nccl hit async error on rank " << rank_
+                                << ": " << ncclGetErrorString(asyncErr);
+            // abort() only tears the communicator down; abortProcess() runs
+            // the abort hooks and terminates if the option allows it.
             abort();
+            abortProcess(
+                std::string("error - nccl hit async error: ") +
+                ncclGetErrorString(asyncErr));
           } else {
             // Revoked below by the reconfigurable-mode handler.
             TC_LOG(ERROR, this)
@@ -360,15 +354,17 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
       throw std::runtime_error("NCCL operation timed out");
     } else {
       abortNcclComm();
-      if (abort_process_on_timeout_or_error_) {
-        TC_LOG(ERROR, this) << "Aborting process due to timeout";
-        runAbortHooks();
-        ::abort();
-      } else {
-        throw std::runtime_error("NCCL operation timed out");
-      }
+      abortProcess("timeout - collective operation timed out");
+      throw std::runtime_error("NCCL operation timed out");
     }
   } else if (comm_state_ == CommState::ERROR) {
+    // With abort_process_on_timeout_or_error disabled the watchdog aborts the
+    // communicator on an async error and lets the process live, so a later
+    // collective can reach here with no communicator left to query.
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCL communicator was aborted after a previous error");
+    }
     ncclResult_t asyncErr{};
     NCCL_CHECK(
         nccl_api_,
@@ -384,14 +380,8 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
       throw std::move(ncclException);
     }
     abortNcclComm();
-    if (abort_process_on_timeout_or_error_) {
-      TC_LOG(ERROR, this) << "Aborting process due to error: "
-                          << ncclException.what();
-      runAbortHooks();
-      ::abort();
-    } else {
-      throw std::move(ncclException);
-    }
+    abortProcess(std::string("error - ") + ncclException.what());
+    throw std::move(ncclException);
   }
 }
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -4,7 +4,6 @@
 import builtins
 import collections.abc
 import contextlib
-import copy
 import ctypes
 import hashlib
 import io
@@ -6687,11 +6686,12 @@ def split_group(
         pg_backend = Backend(str(backend))
         backend_config = BackendConfig(pg_backend)
 
-    if pg_options is None and not _use_torchcomms_enabled():
-        # default pg_options same as the parent process group
-        # A deep copy is needed because if the option will be modified inside split
-        # and if we split parent pg multiple times, we will run into device out of bound error.
-        pg_options = copy.deepcopy(parent_backend.options)
+    # pg_options is left as-is when the caller did not pass any: ProcessGroup::
+    # splitGroup gives each device's backend a copy of *that backend's* options,
+    # which is what the child needs. Substituting the default (accelerator)
+    # backend's options here would hand e.g. ProcessGroupNCCL::Options to the
+    # gloo leg of a "cpu:gloo,cuda:nccl" group, which rejects them and silently
+    # falls back to defaults, dropping the caller's timeout and group_name.
 
     # this timeout defaulting/validation is used for all the new_groups/new_subgroups variants,
     # which may just pass their timeout value (or None)

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -721,8 +721,11 @@ def _create_nccl_process_group(
 def _nccl2_options(
     backend_options: object | None,
 ) -> "ProcessGroupNCCL.Options":
+    # ProcessGroupNCCL2.Options subclasses ProcessGroupNCCL.Options and adds the
+    # nccl2-only knobs; a plain ProcessGroupNCCL.Options is still accepted (the
+    # backend copies it) so callers written against the stock backend work.
     if backend_options is None:
-        return ProcessGroupNCCL.Options()
+        return ProcessGroupNCCL2.Options()
     if not isinstance(backend_options, ProcessGroupNCCL.Options):
         raise AssertionError(
             "Expected backend_options argument to be of type ProcessGroupNCCL.Options"


### PR DESCRIPTION

Summary:
ProcessGroup::splitGroup did

    auto backendOpts = opts.has_value() ? *opts
                                        : parentBackend->getBackendOptions();
    backendOpts->group_name = groupName;
    backendOpts->timeout    = ...;
    backendOpts->group_desc = groupDesc;
    auto splitBackend = parentBackend->split(store, ranks, backendOpts);

and every getBackendOptions() in tree returns the backend's live options_, not a
copy -- ProcessGroupGloo, ProcessGroupNCCL, nccl2 and FakeProcessGroup all just
cast options_, and ProcessGroupWrapper/LazyBackend delegate. So a split rewrites
the *parent's* group_name, timeout and group_desc, and the child ends up holding
the very same Options object. ProcessGroupGloo::split then writes
`glooOpts->global_ranks_in_group = std::move(globalRanksInGroup)` onto it, i.e.
the parent's rank map is replaced by the child's, and the parent's next split
indexes a vector sized for the child:

    parent BEFORE any split: group_name='0' timeout=0:01:51 ranks=[]
    parent AFTER split #1:   group_name='0:split:[0, 1]' timeout=0:03:42 ranks=[0, 1]
    child1.options IS parent.options: True
    [rank2] split #2 child ranks = [139894703605936, 1900999358] (expected [0, 2])
    [rank0] split #2 child ranks = [0, 1954417006]               (expected [0, 2])

That is a heap read past the end, on a stock 4-rank CPU-only gloo world driven
entirely through the public ProcessGroup.split_group(ranks) pybind, whose opts
argument defaults to nullopt (test/distributed/test_device_mesh.py already calls
it that way). The child it produces has garbage global ranks, so its
FlightRecorder identity and any rank translation done through it are wrong; on a
different heap layout the same read is a SIGSEGV. mergeRemoteGroup has the same
aliasing and no escape hatch at all: it takes no opts parameter, so it always
rewrites the parent's options and hands the live object to merge(), leaving
parent and merged child permanently sharing one Options for the rest of the
process.

All four defects fixed here are stock. None needs nccl2, or any custom backend:
the aliasing is a 4-rank CPU-only gloo world, the Python options substitution is
any "cpu:gloo,cuda:nccl" world, the split-once-per-backend hang is a bare "gloo"
world on an accelerator host, and the deepcopy TypeError is any gloo-backed
group. What the nccl2 migration changed is only reachability: it routes CPU
coordination groups through split_group (see MIGRATION_RULES.md), which is what
made every rank start printing the ProcessGroupGloo::split options warning on
every compound split. That warning is the thread this change was pulled from.

The order of discovery matters for reading the rest of this message. The warning
looked cosmetic, so the obvious Python one-liner -- stop substituting
pg_options, let the C++ per-backend fallback do its job -- was implemented and
probed. It removed the warning and gave the gloo child the right group_name,
timeout and ranks, and it turned the cosmetic problem into a memory-safety one,
because the fallback path is exactly the aliasing above. That is how the C++
defect was found. The split-once-per-device-type hang was then found while
verifying the Python change, because deleting the deepcopy is what first makes
dist.split_group reachable at all on a gloo world; and the gloo _Options
TypeError surfaced in the same runs.

Fix it in C++, at the point where the options are handed to a backend: add a
virtual Backend::Options::clone() and copy per backend in splitGroup and
mergeRemoteGroup. Threading a per-device opts map through splitGroup instead was
considered and is strictly worse -- it does not fix the no-entry fallback (a
device with no map entry still lands on the parent's live options), does not fix
mergeRemoteGroup at all, changes the signature and every caller, and the right
per-device options are simply the parent's own, which clone() gives for free.
Making each backend's split()/merge() defensively copy what it is handed was
also rejected: the parent's group_name, timeout and group_desc are already
overwritten before split() is ever called, so the copy has to happen at the call
site or the parent is corrupted regardless. And copying in Python -- which is
what the deleted deepcopy was -- requires every Options subclass to carry a
pickling pybind, which is precisely the requirement gloo failed.

clone() is deliberately not pure. ProcessGroupXCCL::Options derives from
Backend::Options but lives out of tree in third_party/torch-xpu-ops, fetched by
caffe2/CMakeLists.txt and pinned by third_party/xpu.txt, so a pure virtual would
make it abstract and break the XPU build. For the same reason the call site
guards against slicing:

    auto copy = opts->clone();
    if (copy == nullptr || typeid(*copy) != typeid(*opts)) {
      return opts;   // subclass has not adopted clone(): keep legacy sharing
    }

so a backend that has not adopted clone() keeps exactly today's behaviour rather
than being handed a sliced base Options -- aliasing is a bug, but handing a
backend an object of the wrong dynamic type is worse, and the backend cannot
detect it. RTTI is already required by c10d (the dynamic_intrusive_pointer_casts
in ProcessGroupGloo.cpp and FakeProcessGroup.hpp), so the typeid test costs
nothing new.

An explicit caller-supplied opts is now applied only to the group's *default*
backend type; the other device legs inherit a clone of their own backend's
options. That mirrors what pg_options already means for init_process_group,
where _new_process_group_helper hands it to the backend creator that understands
it, and it is what stops a ProcessGroupNCCL::Options from reaching the gloo leg
of a "cpu:gloo,cuda:nccl" group. The caller's object is cloned too, so
split_group no longer mutates it.

While here, split (and merge) each backend *instance* once rather than once per
device type. splitGroup iterates deviceTypeToBackendType_, but several device
types can map to the same backend object: init_process_group("gloo") registers
one ProcessGroupGloo for both cpu and cuda, and ProcessGroup::setBackend
explicitly reuses the backend already registered for a backend type. The loop
therefore built a second child that was immediately discarded -- after it had
already rendezvoused on the *same* PrefixStore("<groupName>/") keys as the real
child. The two gloo contexts race for "<group>/0/rank_N" and peers pair with the
discarded group:

    $ python bug3b_double_split_same_backend.py gloo 5      # cpu+cuda -> one PG
    [rank1] split 0 done
    <hang; rank0 never returns from split 0>
    $ python bug3b_double_split_same_backend.py cpu:gloo 5  # one device type
    [rank0] split 0..4 done / [rank1] split 0..4 done

This is pre-existing and independent, but it blocks the change below: removing
the Python deepcopy is what makes dist.split_group reachable at all on a gloo
world, and the first thing it then hits is this hang.

On the Python side, split_group substituted
`pg_options = copy.deepcopy(parent_backend.options)` where parent_backend is the
*accelerator* backend, and passed that one object to every device's split(). On
a "cpu:gloo,cuda:nccl" world the gloo leg got a ProcessGroupNCCL::Options,
warned "Tried to pass options to ProcessGroupGloo::split that are not
ProcessGroupGloo::Options. Falling back to default options.", and silently lost
the caller's timeout and group_name (123 s and a real name became 0:30:00 and
''; the empty name is what the ctor feeds to setGroupUid, so the child's pg uid
was empty too). Not cosmetic even for backends that only warn -- a 30-minute
timeout where the caller asked for 123 s changes when a hang is detected -- and
a backend that is strict about its Options type hard-errors on the same mismatch
instead of warning. Worse, on a *gloo* world the accelerator backend is the gloo
backend, and ProcessGroupGloo::_Options has no __copy__/__deepcopy__ pybind
(unlike the NCCL, nccl2 and fake Options), so dist.split_group did not merely
warn, it threw:

    TypeError: cannot pickle 'torch._C._distributed_c10d._Options' object

i.e. dist.split_group was unusable for every gloo-backed group on an accelerator
host, in stock, with no migration involved -- nothing in stock CI splits a bare
gloo world on such a host. Delete the deepcopy and leave pg_options as the
caller passed it; the C++ side now gives each device backend a copy of its own
options, and the pickling requirement disappears with the deepcopy that imposed
it.

The two halves must land together. Leaving pg_options=None *without* the C++
clone was tried and is a memory-safety regression, not a fix: it routes the gloo
leg straight to parentBackend->getBackendOptions(), i.e. exactly the aliasing
above, so the parent's global_ranks_in_group is overwritten with the child's and
the parent's next split reads out of bounds. The Python-only "one-line fix" is
not viable on its own.

There is no downstream fix for any of this. A caller can pass explicit
pg_options, but there is no per-device options API to pass, so on a multi-device
world one of the legs is still wrong; merge_remote_group takes no opts at all;
and nothing outside c10d can stop splitGroup writing group_name, timeout and
global_ranks_in_group onto the parent's live object. The only downstream
"mitigation" is to never split the same parent twice -- which DeviceMesh, vLLM
and our own migration all do routinely.

Test Plan:
The four repro scripts, re-run against the rebuilt tree.
bug3_gloo_split_alias.py (4 ranks, CPU only) now keeps the parent untouched,
reports that the child's options are a distinct object, and gives all four
ranks the correct second-split ranks:

    python triage/bug3_gloo_split_alias.py 29541
    parent BEFORE any split: group_name='0' timeout=0:01:51 ranks=[]
    parent AFTER split #1:   group_name='0' timeout=0:01:51 ranks=[]
    child #1:      group_name='0:split:[0, 1]' timeout=0:03:42 ranks=[0, 1]
    child1.options IS parent.options: False
    [rank0] split #2 child global_ranks_in_group = [0, 2] (expected [0, 2]) OK
    [rank1] split #2 child global_ranks_in_group = [1, 3] (expected [1, 3]) OK
    [rank2] split #2 child global_ranks_in_group = [0, 2] (expected [0, 2]) OK
    [rank3] split #2 child global_ranks_in_group = [1, 3] (expected [1, 3]) OK

Pre-fix the parent was rewritten to group_name='0:split:[0, 1]'
timeout=0:03:42 ranks=[0, 1], "child1.options IS parent.options: True", and all
four ranks printed CORRUPT with garbage rank lists.

bug4_python_options.py (2 ranks, "cpu:gloo,cuda:nccl") emits no warning and the
gloo child keeps the caller's 123 s timeout and group name:

    CUDA_VISIBLE_DEVICES=2,3 torchrun --nproc-per-node 2 \
      triage/bug4_python_options.py
    child gloo opts type=_Options timeout=0:02:03 name='4a2ad14e...'
    child nccl opts type=Options  timeout=0:02:03 name='4a2ad14e...'
    both with ranks=[0, 1]
    child gloo options IS parent gloo options: False
    parent gloo timeout after split: 0:01:51 ranks=[]

Pre-fix this printed the "Tried to pass options to ProcessGroupGloo::split"
warning and gave the gloo child 0:30:00 and ''.

bug4_gloo_world_deepcopy.py splits instead of raising TypeError:

    CUDA_VISIBLE_DEVICES=2,3 torchrun --nproc-per-node 2 \
      triage/bug4_gloo_world_deepcopy.py
    OK: child gloo timeout=0:30:00 name='4a2ad14e...' ranks=[0, 1]

The 0:30:00 there is not a regression: that script passes no timeout= to
split_group, and stock split_group resolves timeout=None to
_get_default_timeout(pg_backend) = 30 min before the C++ ever sees it.

bug3b_double_split_same_backend.py completes 5/5 with a bare "gloo" world,
where it previously hung with rank 0 never returning from split 0:

    CUDA_VISIBLE_DEVICES=2,3 timeout 180 python \
      triage/bug3b_double_split_same_backend.py gloo 5
    [rank0] split 0 done ... [rank0] split 4 done
    [rank1] split 0 done ... [rank1] split 4 done
    EXIT=0

New tests, all of which fail pre-fix:

    CUDA_VISIBLE_DEVICES=2,3 python test/distributed/test_c10d_gloo.py \
      CommTest.test_split_group_does_not_alias_parent_options \
      CommTest.test_split_group_keeps_gloo_options -v
    Ran 2 tests in 7.291s
    OK
    python test/distributed/test_c10d_common.py SplitGroupOptionsTest -v
    test_split_group_clones_parent_options ... ok
    test_split_group_opts_apply_to_default_backend_only ... ok
    Ran 2 tests in 0.900s
    OK

Against the pre-fix binary the same three fail as "unexpectedly identical:
ProcessGroupGloo._Options object", "unexpectedly identical: Backend.Options
object" and "'caller-supplied' != 'cpu-backend'".

Full suites, serially on otherwise-idle GPUs, all green:

    test_c10d_common.py      Ran 72 tests in 113.349s   OK
    test_c10d_gloo.py        Ran 289 tests in 1098.597s OK (skipped=4)
    test_c10d_nccl.py        Ran 284 tests in 1645.782s OK (skipped=15)
    test_c10d_nccl2.py       Ran 20 tests in 103.397s   OK
    test_c10d_pybackend.py   Ran 5 tests in 4.845s      OK
    test_device_mesh.py      Ran 76 tests in 297.845s   OK (skipped=5)

Three known gaps. mergeRemoteGroup's clone and merge-once path has no
multi-device test in tree -- test_c10d_pybackend.py covers the single-device
merge only -- so the dedupe branch there is argued from symmetry with split, not
measured. The typeid slicing guard is dead code in an in-tree build, since every
in-tree Options subclass now overrides clone(); its real consumer is the
out-of-tree XPU Options, which cannot be built here, so someone with an XPU
build should confirm it compiles and does not silently fall back to aliasing.
And stock ProcessGroupNCCL::Options::clone() copies ncclConfig_t shallowly, so a
caller-set config.net_name/comm_name (strdup'd in init.cpp) stays shared between
parent and child -- unchanged from the __deepcopy__ pybind it replaces, so not a
regression; nccl2's clone deep-copies via cloneNcclConfig(), and fixing the
stock one belongs to whoever owns ProcessGroupNCCL.cpp.

Authored with the assistance of an AI coding agent.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/191953).
* #191957
* #191956
* #191955
* #191954
* __->__ #191953
* #191952
* #191951
* #191950
* #191949
* #191948
* #191782