### PR TITLE
[c10d] Only honor TORCHELASTIC_USE_AGENT_STORE at the agent's own address

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -30,6 +30,7 @@ import torch.distributed.distributed_c10d as c10d
 import torch.nn.functional as F
 import torch.testing._internal.common_utils as common
 from torch import nn
+from torch._C._distributed_c10d import Backend as C10DBackend
 from torch.nn.parallel import DistributedDataParallel
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
@@ -2580,6 +2581,80 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
 
 
 instantiate_parametrized_tests(CommonDistributedDataParallelTest)
+
+
+class SplitGroupOptionsTest(TestCase):
+    class _SplittingBackend(C10DBackend):
+        def __init__(self, rank, size, name):
+            super().__init__(rank, size)
+            self._name = name
+            self._options = C10DBackend.Options(name, timeout=timedelta(seconds=111))
+            self.split_opts = None
+
+        @property
+        def supports_splitting(self):
+            return True
+
+        @property
+        def options(self):
+            return self._options
+
+        def getBackendName(self):
+            return self._name
+
+        def split(self, store, ranks, opts):
+            self.split_opts = opts
+            return SplitGroupOptionsTest._SplittingBackend(
+                ranks.index(self.rank()), len(ranks), f"{self._name}-child"
+            )
+
+    def _make_group(self):
+        # Shaped like a "cpu:gloo,cuda:nccl" group: two distinct backends, the
+        # accelerator one being the group's default. The backend type tags are
+        # just map keys here, the backends themselves are Python ones.
+        cpu_backend = self._SplittingBackend(0, 1, "cpu-backend")
+        default_backend = self._SplittingBackend(0, 1, "default-backend")
+        pg = dist.ProcessGroup(dist.HashStore(), 0, 1)
+        pg._register_backend(
+            torch.device("cpu"), dist.ProcessGroup.BackendType.GLOO, cpu_backend
+        )
+        pg._register_backend(
+            torch.device("cuda"), dist.ProcessGroup.BackendType.NCCL, default_backend
+        )
+        pg._set_default_backend(dist.ProcessGroup.BackendType.NCCL)
+        pg._set_group_name("split-options-test")
+        return pg, cpu_backend, default_backend
+
+    def test_split_group_clones_parent_options(self):
+        # getBackendOptions() returns the backend's live options_, and split()
+        # implementations write into what they are given, so splitGroup used to
+        # rewrite the parent's group_name/timeout and hand the child an object
+        # aliasing the parent's.
+        pg, cpu_backend, default_backend = self._make_group()
+        pg.split_group([0], timeout=timedelta(seconds=222), group_name="child")
+
+        for backend in (cpu_backend, default_backend):
+            self.assertIsNot(backend.split_opts, backend.options)
+            self.assertEqual(backend.options.group_name, "")
+            self.assertEqual(backend.options._timeout, timedelta(seconds=111))
+            self.assertEqual(backend.split_opts.group_name, "child")
+            self.assertEqual(backend.split_opts._timeout, timedelta(seconds=222))
+
+    def test_split_group_opts_apply_to_default_backend_only(self):
+        # An explicit `opts` describes the group's default backend, the same way
+        # pg_options does for init_process_group. Handing it to every device's
+        # backend made the others reject it (and silently fall back to their
+        # defaults, losing the caller's timeout).
+        pg, cpu_backend, default_backend = self._make_group()
+        opts = C10DBackend.Options("caller-supplied", timeout=timedelta(seconds=5))
+        pg.split_group([0], opts=opts, timeout=timedelta(seconds=222))
+
+        self.assertEqual(default_backend.split_opts.backend, "caller-supplied")
+        self.assertEqual(cpu_backend.split_opts.backend, "cpu-backend")
+        # The caller's object is not mutated either.
+        self.assertIsNot(default_backend.split_opts, opts)
+        self.assertEqual(opts.group_name, "")
+        self.assertEqual(opts._timeout, timedelta(seconds=5))
 
 
 class ProcessGroupWithDispatchedCollectivesTests(MultiProcessTestCase):

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -3480,6 +3480,77 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
     def test_bool_tensors(self):
         self._test_bool_tensors(backend="gloo")
 
+    @requires_gloo()
+    def test_split_group_does_not_alias_parent_options(self):
+        # Regression test: ProcessGroup::splitGroup used to hand the parent
+        # backend's live Options object to the child, so a split rewrote the
+        # parent's group_name/timeout and ProcessGroupGloo::split overwrote the
+        # parent's global_ranks_in_group with the child's ranks. The parent's
+        # next split then indexed that subgroup-sized vector out of bounds.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        c10d.init_process_group(
+            backend="gloo",
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+            timeout=timedelta(seconds=111),
+        )
+        pg = c10d.distributed_c10d._get_default_group()
+        cpu = torch.device("cpu")
+        parent_options = pg._get_backend(cpu).options
+        parent_group_name = parent_options.group_name
+
+        half = self.world_size // 2
+        halves = (
+            list(range(half))
+            if self.rank < half
+            else list(range(half, self.world_size))
+        )
+        child = pg.split_group(
+            halves, timeout=timedelta(seconds=222), group_name=f"halves{halves}"
+        )
+        child_options = child._get_backend(cpu).options
+        self.assertIsNot(child_options, parent_options)
+        self.assertEqual(parent_options.group_name, parent_group_name)
+        self.assertEqual(parent_options._timeout, timedelta(seconds=111))
+        self.assertEqual(parent_options.global_ranks_in_group, [])
+        self.assertEqual(child_options._timeout, timedelta(seconds=222))
+        self.assertEqual(child_options.global_ranks_in_group, halves)
+
+        # A second split of the same parent must still see the world's ranks.
+        parity = [r for r in range(self.world_size) if r % 2 == self.rank % 2]
+        second = pg.split_group(
+            parity, timeout=timedelta(seconds=333), group_name=f"parity{parity}"
+        )
+        self.assertEqual(second._get_backend(cpu).options.global_ranks_in_group, parity)
+
+        c10d.destroy_process_group()
+
+    @skip_if_lt_x_gpu(1)
+    @requires_gloo()
+    def test_split_group_keeps_gloo_options(self):
+        # dist.split_group used to substitute a deep copy of the accelerator
+        # backend's options for every device. On a gloo world that raised
+        # "cannot pickle _Options" (ProcessGroupGloo._Options has no
+        # __deepcopy__), and on a "cpu:gloo,cuda:nccl" world the gloo leg
+        # rejected the nccl options and fell back to Options::create_default(),
+        # dropping the caller's timeout and group_name.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        c10d.init_process_group(
+            backend="gloo",
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+            device_id=torch.device("cuda", self.rank % torch.cuda.device_count()),
+        )
+        ranks = list(range(self.world_size))
+        child = c10d.split_group(split_ranks=[ranks], timeout=timedelta(seconds=222))
+        options = child._get_backend(torch.device("cpu")).options
+        self.assertEqual(options._timeout, timedelta(seconds=222))
+        self.assertEqual(options.group_name, child.group_name)
+        self.assertEqual(options.global_ranks_in_group, ranks)
+        c10d.destroy_process_group()
+
 
 class GlooProcessGroupWithDispatchedCollectivesTests(
     test_c10d_common.ProcessGroupWithDispatchedCollectivesTests

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -297,6 +297,43 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             fut.wait()
 
     @requires_gloo()
+    def test_split_world_pg_created_after_another_gloo_pg(self):
+        # Regression test: ProcessGroupGloo::groupRanks() used to derive the
+        # identity rank mapping only when local_id_ == 0. local_id_ is a
+        # process-global counter over every ProcessGroupGloo constructed in the
+        # process, so a world-sized pg built after any other gloo pg (e.g. a
+        # stateless pg, or one inherited across fork) fell through to its empty
+        # global_ranks_in_group, and split() then indexed that empty vector and
+        # segfaulted on a null data pointer.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        # (1) burn local_id_ == 0 on an unrelated gloo pg.
+        self._create_process_group_gloo(
+            c10d.PrefixStore("prior", store),
+            self.rank,
+            self.world_size,
+            self.opts(group_name="prior"),
+        )
+        # (2) a world-sized pg: default options -> global_ranks_in_group empty.
+        pg = self._create_process_group_gloo(
+            c10d.PrefixStore("world", store),
+            self.rank,
+            self.world_size,
+            self.opts(group_name="world"),
+        )
+
+        ranks = list(range(self.world_size))
+        split = pg.split(
+            c10d.PrefixStore("split", store), ranks, self.opts(group_name="split")
+        )
+        self.assertIsNotNone(split)
+        self.assertEqual(split.options.global_ranks_in_group, ranks)
+
+        tensor = torch.full((4,), float(self.rank + 1))
+        split.allreduce([tensor]).wait()
+        expected = float(sum(r + 1 for r in ranks))
+        self.assertEqual(tensor, torch.full_like(tensor, expected))
+
+    @requires_gloo()
     def test_empty_tensors(self):
         store = c10d.FileStore(self.file_name, self.world_size)
         pg = self._create_process_group_gloo(

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
 import copy
+import glob
 import json
 import logging
 import os
@@ -374,10 +375,13 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
     def tearDown(self):
         super().tearDown()
-        try:
-            os.remove(self.file_name)
-        except OSError:
-            pass
+        # self.file_name plus anything a test derived from it, e.g. the flight
+        # recorder dumps of test_global_rank_of_pg_created_after_another_nccl_pg
+        for path in glob.glob(f"{self.file_name}*"):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
 
     @property
     def world_size(self):
@@ -1267,6 +1271,43 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         self.assertEqual(tensor, torch.full((1,), 0))
 
         dist.destroy_process_group()
+
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_global_rank_of_pg_created_after_another_nccl_pg(self):
+        # Regression test: ProcessGroupNCCL::globalRank() used to be a
+        # function-local static, so it was seeded by whichever pg was
+        # constructed first in the process (the constructor calls it while
+        # logging) and never updated. A stateless subgroup built before the
+        # default pg therefore froze its own group-local rank as "the global
+        # rank" for every pg in the process. Checked here through the flight
+        # recorder dump, which is named after globalRank(); the same value also
+        # names broadcastSignal(kStoreDumpKey) and picks the device in
+        # guessDeviceId(), which split() relies on.
+        trace_prefix = f"{self.file_name}_trace_"
+        os.environ["TORCH_NCCL_ENABLE_MONITORING"] = "0"
+        os.environ["TORCH_NCCL_EXTRA_DUMP_ON_EXEC"] = "1"
+        os.environ["TORCH_FR_DUMP_TEMP_FILE"] = trace_prefix
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        # (1) a single-rank stateless pg, constructed before the default pg.
+        prior = c10d.ProcessGroupNCCL(c10d.PrefixStore("prior", store), 0, 1)
+        # (2) the real default pg, whose rank is the global one.
+        c10d.init_process_group(
+            "nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=c10d.PrefixStore("world", store),
+            pg_options=self.opts(),
+            device_id=device,
+        )
+        pg = c10d.distributed_c10d._get_default_group()
+        dist.all_reduce(torch.ones(1, device=device))
+
+        # abort() dumps the flight recorder to <prefix><globalRank()>.
+        pg._get_backend(device).abort()
+        self.assertTrue(os.path.exists(f"{trace_prefix}{self.rank}"))
+        del prior
 
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1226,6 +1226,50 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_comm_split_world_pg_created_after_another_nccl_pg(self):
+        # Regression test: ProcessGroupNCCL::groupRanks() used to derive the
+        # identity rank mapping only when local_id_ == 0. local_id_ is a
+        # process-global counter over every ProcessGroupNCCL constructed in the
+        # process, so a default pg built after any other nccl pg (e.g. a
+        # stateless pg, one inherited across fork, or an earlier
+        # init_process_group that was destroyed) fell through to its empty
+        # global_ranks_in_group, and split() then indexed that empty vector and
+        # segfaulted on a null data pointer.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        # (1) burn local_id_ == 0 on an unrelated nccl pg.
+        c10d.init_process_group(
+            "nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=c10d.PrefixStore("prior", store),
+        )
+        dist.destroy_process_group()
+        # (2) the real default pg -> global_ranks_in_group empty.
+        c10d.init_process_group(
+            "nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=c10d.PrefixStore("world", store),
+            pg_options=self.opts(),
+            device_id=device,
+        )
+        pg = c10d.distributed_c10d._get_default_group()
+
+        ranks = list(range(self.world_size))
+        ng = c10d.split_group(pg, [ranks])
+        self.assertIsNotNone(ng)
+        self.assertEqual(dist.get_process_group_ranks(ng), ranks)
+        self.assertEqual(ng._get_backend(device).options.global_ranks_in_group, ranks)
+
+        tensor = torch.full((1,), self.rank).cuda(device)
+        dist.broadcast(tensor, 0, group=ng)
+        self.assertEqual(tensor, torch.full((1,), 0))
+
+        dist.destroy_process_group()
+
+    @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_comm_split_group_mixed_backend(self):
         # Test `ncclCommSplit` for smaller subgroups of the world when
         # we've passed a specific device_id to init_process_group.

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -2,6 +2,8 @@
 #
 # Tests specific to the in-tree torchcomms NCCL backends.
 
+import ctypes
+import os
 import time
 
 import torch
@@ -173,6 +175,94 @@ class ProcessGroupNCCLLazyTest(ProcessGroupNCCL2Test):
 
         expected = 1 if nxt == prev else 2
         self.assertGreaterEqual(backend._num_active_channels(), expected)
+
+
+def _live_env(name: str) -> str | None:
+    # os.environ is a snapshot taken at interpreter startup and does NOT observe
+    # values set later by C++ via setenv (which is how the nccl2 backend forces
+    # NCCL_ALGO under deterministic mode), so read the live environ via libc.
+    libc = ctypes.CDLL(None)
+    libc.getenv.restype = ctypes.c_char_p
+    val = libc.getenv(name.encode())
+    return val.decode() if val is not None else None
+
+
+class _DeterministicNVLSTest(MultiProcContinuousTest):
+    """Base for the nccl2 deterministic-mode NVLS-disable hook.
+
+    Under torch deterministic mode, if the user has not set NCCL_ALGO the nccl2
+    backend forces NCCL_ALGO=^NVLS (NVLS can give non-deterministic reductions),
+    mirroring the stock ProcessGroupNCCL. The hook runs during PG init and the
+    env var persists once set, so each scenario is its own subclass: every class
+    gets a freshly spawned process pool (clean deterministic flag / NCCL_ALGO)
+    and configures the env in _init_pg before the PG (and thus the hook) runs.
+    """
+
+    deterministic: bool = False
+    preset_nccl_algo: str | None = None
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file) -> None:
+        if cls.preset_nccl_algo is not None:
+            os.environ["NCCL_ALGO"] = cls.preset_nccl_algo
+        else:
+            os.environ.pop("NCCL_ALGO", None)
+        if cls.deterministic:
+            torch.use_deterministic_algorithms(True)
+        super()._init_pg(rank, world_size, rdvz_file)
+
+    def _all_reduce_and_read_algo(self) -> str | None:
+        # Force the (possibly lazy) nccl2 comm to initialize so the hook runs,
+        # and confirm the reduction is numerically correct under the chosen algo.
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t)
+        torch.cuda.synchronize()
+        self.assertEqual(t, torch.full_like(t, self.world_size))
+        return _live_env("NCCL_ALGO")
+
+
+class ProcessGroupNCCL2DeterministicNVLSDisabledTest(_DeterministicNVLSTest):
+    deterministic = True
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_deterministic_disables_nvls(self) -> None:
+        self.assertEqual(self._all_reduce_and_read_algo(), "^NVLS")
+
+
+class ProcessGroupNCCL2DeterministicNVLSPresetTest(_DeterministicNVLSTest):
+    deterministic = True
+    preset_nccl_algo = "Ring"
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_deterministic_respects_user_nccl_algo(self) -> None:
+        self.assertEqual(self._all_reduce_and_read_algo(), "Ring")
+
+
+class ProcessGroupNCCL2NonDeterministicNVLSTest(_DeterministicNVLSTest):
+    deterministic = False
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_non_deterministic_does_not_force_nccl_algo(self) -> None:
+        self.assertIsNone(self._all_reduce_and_read_algo())
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -5,7 +5,10 @@
 import copy
 import ctypes
 import os
+import subprocess
+import sys
 import time
+import unittest
 from datetime import timedelta
 
 import torch
@@ -16,7 +19,13 @@ from torch.testing._internal.common_distributed import (
     requires_nccl,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_CUDA
+from torch.testing._internal.common_utils import (
+    IS_FBCODE,
+    IS_SANDCASTLE,
+    run_tests,
+    TEST_CUDA,
+    TestCase,
+)
 
 
 class ProcessGroupNCCL2Test(MultiProcContinuousTest):
@@ -398,6 +407,66 @@ class ProcessGroupNCCL2NonDeterministicNVLSTest(_DeterministicNVLSTest):
     @skip_if_lt_x_gpu(2)
     def test_non_deterministic_does_not_force_nccl_algo(self) -> None:
         self.assertIsNone(self._all_reduce_and_read_algo())
+
+
+_UNINITIALIZED_CUDA_SCRIPT = """\
+import torch
+import torch.distributed as dist
+
+# Nothing above this point may touch torch.cuda: the caching allocator is
+# brought up lazily by the Python torch.cuda layer, and neither CUDAGuard nor
+# stream/event creation does it.
+dist.init_process_group(
+    "cpu:gloo,cuda:nccl2",
+    rank=0,
+    world_size=1,
+    store=dist.HashStore(),
+    device_id=torch.device("cuda:0"),
+)
+assert not torch.cuda.is_initialized(), "creating a process group initialized CUDA"
+{extra}
+dist.destroy_process_group()
+"""
+
+
+class ProcessGroupNCCL2UninitializedCudaTest(TestCase):
+    """Constructing a process group must not need the CUDA caching allocator up.
+
+    Eager init (`init_process_group(device_id=...)`) allocated the barrier
+    buffer from the caching allocator, so a process that had made no torch.cuda
+    call died inside init_process_group with "Allocator not initialized for
+    device 0". Any external launcher or library that builds the PG before
+    touching CUDA hits this. Runs in a subprocess because the harness (and
+    every other test here) calls torch.cuda.set_device in setUp, which hides it.
+    """
+
+    def _run_child(self, extra: str = "") -> None:
+        try:
+            subprocess.check_output(
+                [sys.executable, "-c", _UNINITIALIZED_CUDA_SCRIPT.format(extra=extra)],
+                stderr=subprocess.STDOUT,
+                cwd=os.path.dirname(os.path.realpath(__file__)),
+                timeout=300,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("child process timed out")
+        except subprocess.CalledProcessError as e:
+            self.fail(f"child process failed with:\n{e.output.decode()}")
+
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "subprocess test fails in fbcode")
+    @requires_nccl()
+    @skip_if_lt_x_gpu(1)
+    def test_eager_init(self) -> None:
+        self._run_child()
+
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "subprocess test fails in fbcode")
+    @requires_nccl()
+    @skip_if_lt_x_gpu(1)
+    def test_barrier_after_init(self) -> None:
+        # The allocation is merely deferred, so barrier() is the second entrance
+        # into the same allocator: without lazyInitDevice() it hits the identical
+        # assert one call later.
+        self._run_child("dist.barrier()")
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -2,12 +2,15 @@
 #
 # Tests specific to the in-tree torchcomms NCCL backends.
 
+import copy
 import ctypes
 import os
 import time
+from datetime import timedelta
 
 import torch
 import torch.distributed as dist
+from torch._C._distributed_c10d import ErrorType
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_nccl,
@@ -51,13 +54,42 @@ class ProcessGroupNCCL2Test(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
-    def test_shared_options_type(self) -> None:
-        self.assertIs(dist.ProcessGroupNCCL2.Options, dist.ProcessGroupNCCL.Options)
+    def test_options_type(self) -> None:
+        # nccl2 has its own Options, but it derives from the stock one so the
+        # whole pre-existing attribute surface keeps working.
+        self.assertTrue(
+            issubclass(dist.ProcessGroupNCCL2.Options, dist.ProcessGroupNCCL.Options)
+        )
         opts = dist.ProcessGroupNCCL2.Options()
         opts.config.cga_cluster_size = 2
         opts.config.max_ctas = 4
         self.assertEqual(opts.config.cga_cluster_size, 2)
         self.assertEqual(opts.config.max_ctas, 4)
+        self.assertTrue(opts.abort_process_on_timeout_or_error)
+        opts.abort_process_on_timeout_or_error = False
+        self.assertFalse(copy.deepcopy(opts).abort_process_on_timeout_or_error)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_stock_options_accepted(self) -> None:
+        # Callers written against the stock backend hand us a
+        # ProcessGroupNCCL.Options; it must still be usable and get the nccl2
+        # defaults for the nccl2-only fields.
+        opts = dist.ProcessGroupNCCL.Options()
+        pg = dist.new_group(
+            backend=self.backend_str(),
+            pg_options=opts,
+            use_local_synchronization=True,
+            timeout=timedelta(seconds=60),
+        )
+        try:
+            backend = pg._get_backend(self.device)
+            self.assertTrue(backend.options.abort_process_on_timeout_or_error)
+            t = torch.ones(4, device=self.device)
+            dist.all_reduce(t, group=pg)
+            self.assertEqual(t, torch.full_like(t, self.world_size))
+        finally:
+            dist.destroy_process_group(pg)
 
 
 class _ProcessGroupNCCL2OptionsTest(MultiProcContinuousTest):
@@ -101,6 +133,109 @@ class ProcessGroupNCCL2ConfigTest(_ProcessGroupNCCL2OptionsTest):
         self.assertEqual(backend.options.config.cga_cluster_size, 2)
         self.assertEqual(backend.options.config.max_ctas, 4)
         self.assertTrue(backend.options.is_high_priority_stream)
+        self._check_all_reduce()
+
+
+class _ProcessGroupNCCL2SubgroupTest(MultiProcContinuousTest):
+    """Base for tests that tear a group down.
+
+    They run on a throwaway subgroup so the class-wide default group survives;
+    a collective on that default group afterwards is what proves the process is
+    still alive and healthy.
+    """
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    def _new_subgroup(self, backend_options=None, timeout=timedelta(seconds=60)):
+        return dist.new_group(
+            backend="nccl2",
+            pg_options=backend_options,
+            use_local_synchronization=True,
+            timeout=timeout,
+        )
+
+    def _check_all_reduce(self, group=None) -> None:
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t, group=group)
+        self.assertEqual(t, torch.full_like(t, self.world_size))
+
+
+class ProcessGroupNCCL2AbortTest(_ProcessGroupNCCL2SubgroupTest):
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_backend_abort_on_healthy_group(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        backend = pg._get_backend(self.device)
+        # Must return instead of ::abort()ing the process, like stock NCCL.
+        backend.abort()
+        self.assertEqual(backend.get_error(), ErrorType.COMM_ERROR)
+
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_abort_process_group_on_healthy_group(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        dist.distributed_c10d._abort_process_group(pg)
+        self._check_all_reduce()
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_destroy_process_group_returns(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
+
+
+class ProcessGroupNCCL2WatchdogAbortOptionTest(_ProcessGroupNCCL2SubgroupTest):
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_timeout_without_process_abort(self) -> None:
+        opts = dist.ProcessGroupNCCL2.Options()
+        opts.abort_process_on_timeout_or_error = False
+        pg = self._new_subgroup(opts, timeout=timedelta(seconds=5))
+        backend = pg._get_backend(self.device)
+        self.assertFalse(backend.options.abort_process_on_timeout_or_error)
+        self._check_all_reduce(pg)
+
+        if self.rank == 0:
+            # Nobody else joins, so this can never complete and the watchdog
+            # trips. With the option off the process must survive and the
+            # timeout must become readable through get_error().
+            dist.all_reduce(torch.ones(1024, device=self.device), group=pg)
+            deadline = time.time() + 60
+            while time.time() < deadline and backend.get_error() == ErrorType.SUCCESS:
+                time.sleep(0.5)
+            self.assertEqual(backend.get_error(), ErrorType.TIMEOUT)
+            # The next collective on the timed-out group raises rather than
+            # silently proceeding on a dead communicator.
+            with self.assertRaises(RuntimeError):
+                dist.all_reduce(torch.ones(4, device=self.device), group=pg)
+        else:
+            time.sleep(30)
+
+        dist.destroy_process_group(pg)
         self._check_all_reduce()
 
 

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -289,6 +289,96 @@ class ProcessGroupNCCL2ExpandableSegmentsTest(MultiProcContinuousTest):
             self.assertEqual(chunk, torch.full_like(chunk, rank))
 
 
+class ProcessGroupNCCL2MemPoolTest(MultiProcContinuousTest):
+    """register_mem_pool / deregister_mem_pool: the NCCL user-buffer path that
+    Megatron's nccl_allocator drives (megatron/core/nccl_allocator.py)."""
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    def _backend(self):
+        # nccl2 bootstraps its communicator on the first collective, and
+        # register_mem_pool needs it up (as it does on the stock backend, whose
+        # test eagerly inits via init_process_group(device_id=...) instead).
+        dist.all_reduce(torch.zeros(1, device=self.device))
+        torch.cuda.synchronize()
+        return dist.get_backend_impl(device=self.device)
+
+    @property
+    def _all_reduced(self) -> float:
+        return float(sum(range(self.world_size)))
+
+    def _pool_tensor(self, pool, numel: int = 1024 * 1024) -> torch.Tensor:
+        with torch.cuda.use_mem_pool(pool):
+            return torch.full((numel,), float(self.rank), device=self.device)
+
+    def _check_all_reduce_over_pool(self, symm: bool) -> None:
+        backend = self._backend()
+        pool = torch.cuda.MemPool(backend.mem_allocator)
+        tensor = self._pool_tensor(pool)
+        backend.register_mem_pool(pool, symm=symm)
+        try:
+            dist.all_reduce(tensor)
+            torch.cuda.synchronize()
+            self.assertEqual(tensor, torch.full_like(tensor, self._all_reduced))
+        finally:
+            backend.deregister_mem_pool(pool)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_register_mem_pool(self) -> None:
+        self._check_all_reduce_over_pool(symm=False)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_register_mem_pool_symmetric(self) -> None:
+        self._check_all_reduce_over_pool(symm=True)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_register_mem_pool_round_trip(self) -> None:
+        # Megatron re-enters its allocator context once per bucket: deregister,
+        # grow the pool, register again. Neither leg may trip over a segment
+        # the caching-allocator hook already registered, and the second
+        # register has to pick up segments the hook never saw (reused ones).
+        backend = self._backend()
+        pool = torch.cuda.MemPool(backend.mem_allocator)
+        first = self._pool_tensor(pool)
+        backend.register_mem_pool(pool, symm=True)
+        backend.deregister_mem_pool(pool)
+        second = self._pool_tensor(pool)
+        backend.register_mem_pool(pool, symm=True)
+        try:
+            for tensor in (first, second):
+                dist.all_reduce(tensor)
+            torch.cuda.synchronize()
+            for tensor in (first, second):
+                self.assertEqual(tensor, torch.full_like(tensor, self._all_reduced))
+        finally:
+            backend.deregister_mem_pool(pool)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_deregister_unregistered_mem_pool_raises(self) -> None:
+        backend = self._backend()
+        pool = torch.cuda.MemPool(backend.mem_allocator)
+        with self.assertRaisesRegex(RuntimeError, "not previously registered"):
+            backend.deregister_mem_pool(pool)
+
+
 class ProcessGroupNCCLLazyTest(ProcessGroupNCCL2Test):
     @classmethod
     def backend_str(cls) -> str:

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -777,6 +777,50 @@ class TestFakePG(TestCase):
 
     @skipIfHpu
     @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
+    def test_split_group_backend_filter(self):
+        # A fake world's backend string is the bare name "fake", which
+        # BackendConfig expands to every device fake supports. split_group's
+        # filter validation used to re-expand it through
+        # Backend.default_device_backend_map -- where fake is only the default
+        # for hpu -- so every device-qualified filter was rejected as "not
+        # present in the parent" and the bare "fake" filter selected hpu alone.
+        store = FakeStore()
+        dist.init_process_group(
+            backend="fake",
+            rank=0,
+            world_size=2,
+            store=store,
+            device_id=torch.device(device_type, 0),
+        )
+        parent_pg = dist.distributed_c10d._get_default_group()
+        parent_devices = {d.type for d in parent_pg._device_types}
+        self.assertIn(device_type, parent_devices)
+
+        # A bare filter naming the parent's backend keeps every parent device.
+        full = dist.split_group(split_ranks=[[0, 1]], backend="fake")
+        self.assertEqual({d.type for d in full._device_types}, parent_devices)
+
+        # A device-qualified filter keeps exactly the named devices. The C++
+        # split additionally requires the filter to keep the parent's default
+        # backend device, which for an all-fake parent is cpu.
+        cpu_only = dist.split_group(split_ranks=[[0, 1]], backend="cpu:fake")
+        self.assertEqual({d.type for d in cpu_only._device_types}, {"cpu"})
+
+        pair = dist.split_group(
+            split_ranks=[[0, 1]], backend=f"cpu:fake,{device_type}:fake"
+        )
+        self.assertEqual({d.type for d in pair._device_types}, {"cpu", device_type})
+
+        # Filters that genuinely do not match the parent are still rejected.
+        with self.assertRaisesRegex(ValueError, "is not present in the parent"):
+            dist.split_group(split_ranks=[[0, 1]], backend="mps:fake")
+        with self.assertRaisesRegex(ValueError, "Backend mismatch"):
+            dist.split_group(split_ranks=[[0, 1]], backend="cpu:gloo")
+        with self.assertRaisesRegex(ValueError, "is not present in the parent"):
+            dist.split_group(split_ranks=[[0, 1]], backend="gloo")
+
+    @skipIfHpu
+    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
     def test_split_group_non_member(self):
         store = FakeStore()
         dist.init_process_group(

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -11,6 +11,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from sys import platform
+from unittest import mock
 
 import torch
 import torch.distributed as dist
@@ -934,6 +935,40 @@ class RendezvousTCPTest(TestCase):
         gen0 = dist.rendezvous(url + "&rank=0&use_libuv=1")
         store0, _, _ = next(gen0)
         self.assertTrue(store0.libuvBackend)
+
+    def test_agent_store_ignored_for_other_address(self):
+        # torchrun's elastic agent exports TORCHELASTIC_USE_AGENT_STORE into
+        # every worker, meaning "the agent serves a store at
+        # MASTER_ADDR:MASTER_PORT". _create_c10d_store used to honor it for any
+        # address it was handed, so a private store on a caller-chosen port
+        # became client-only on every rank, nobody ever started a server and
+        # every rank blocked in connect-retry until the store timeout.
+        url = self.create_tcp_url()
+        env = {
+            "TORCHELASTIC_USE_AGENT_STORE": "True",
+            "MASTER_ADDR": DEFAULT_HOSTNAME,
+            "MASTER_PORT": str(common.find_free_port()),
+        }
+        with mock.patch.dict(os.environ, env):
+            gen0 = dist.rendezvous(url + "&rank=0", timeout=timedelta(seconds=10))
+            store0, _, _ = next(gen0)
+        store0.set("key0", "value0")
+        self.assertEqual(b"value0", store0.get("key0"))
+
+    def test_agent_store_honored_for_master_address(self):
+        # The flip side: at MASTER_ADDR:MASTER_PORT the agent is the server, so
+        # every rank must stay a client. Point at a port nothing listens on and
+        # check we fail to connect rather than silently starting a server.
+        port = common.find_free_port()
+        url = f"tcp://{DEFAULT_HOSTNAME}:{port:d}?world_size=1&rank=0"
+        env = {
+            "TORCHELASTIC_USE_AGENT_STORE": "True",
+            "MASTER_ADDR": DEFAULT_HOSTNAME,
+            "MASTER_PORT": str(port),
+        }
+        with mock.patch.dict(os.environ, env):
+            with self.assertRaises(DistNetworkError):
+                next(dist.rendezvous(url, timeout=timedelta(seconds=1)))
 
 
 class DummyStore(dist.Store):

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -1127,7 +1127,10 @@ class ProcessGroupXCCL(Backend):
     def _reset_fr_recording_xccl(self) -> None: ...
 
 class ProcessGroupNCCL2(Backend):
-    Options = ProcessGroupNCCL.Options
+    class Options(ProcessGroupNCCL.Options):
+        abort_process_on_timeout_or_error: bool
+
+        def __init__(self, is_high_priority_stream: bool = False) -> None: ...
 
     def __init__(
         self,

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -94,6 +94,18 @@ class TORCH_API Backend : public torch::CustomClassHolder {
     ~Options() override = default;
     Options(const Options&) = default;
 
+    // Returns an independent copy, preserving the concrete type.
+    // ProcessGroup::splitGroup()/mergeRemoteGroup() clone the options they
+    // hand to a child backend: getBackendOptions() returns the parent's live
+    // options_, and split()/merge() implementations mutate what they are given
+    // (group_name, timeout, global_ranks_in_group, split_color, ...), so
+    // sharing one object corrupts the parent. A subclass that adds fields must
+    // override this or it would be sliced; ProcessGroup detects a sliced clone
+    // and falls back to sharing rather than handing a backend the wrong type.
+    virtual c10::intrusive_ptr<Options> clone() const {
+      return c10::make_intrusive<Options>(*this);
+    }
+
     std::chrono::milliseconds timeout;
 
     // backend name

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -29,6 +29,10 @@ class FakeProcessGroup : public Backend {
   struct Options : Backend::Options {
     explicit Options() : Backend::Options("fake") {}
 
+    c10::intrusive_ptr<Backend::Options> clone() const override {
+      return c10::make_intrusive<Options>(*this);
+    }
+
     int fake_option = 0;
     bool error_on_collective = false;
   };

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -519,7 +519,7 @@ ncclResult_t NCCLComm::registerSegment(
   return ncclSuccess;
 }
 
-ncclResult_t NCCLComm::deregisterSegment(void* ptr, bool window /*false*/) {
+ncclResult_t NCCLComm::deregisterSegment(void* ptr) {
   LockType lock(mutex_);
   TORCH_CHECK(
       registeredSegmentHandles_.count(ptr) == 1,
@@ -532,7 +532,10 @@ ncclResult_t NCCLComm::deregisterSegment(void* ptr, bool window /*false*/) {
   // Use getNcclComm to make sure comm is ready before calling nccl APIs
   auto comm = getNcclComm();
 #ifdef NCCL_HAS_COMM_WINDOW_REGISTER
-  if (window) {
+  // Pick the API from how the segment was actually registered: a caller's view
+  // of a pool ("symmetric") can disagree with an individual segment, and
+  // passing a ncclReg* to the window API (or vice versa) is a type confusion.
+  if (registeredSegmentHandles_[ptr].second) {
     C10D_NCCL_CHECK(
         ncclCommWindowDeregister(comm, (ncclWindow_t)handle),
         c10::str(

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -334,7 +334,8 @@ class NCCLComm {
       bool errorOnRereg = true,
       bool window = false);
 
-  ncclResult_t deregisterSegment(void* ptr, bool window = false);
+  // Uses the window vs local API recorded when the segment was registered.
+  ncclResult_t deregisterSegment(void* ptr);
 
   std::string repr() const;
 

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -6,11 +6,35 @@
 #include <fmt/ranges.h>
 
 #include <algorithm>
+#include <typeinfo>
 #include <unordered_set>
 
 #include <torch/csrc/distributed/c10d/PrefixStore.hpp>
 
 namespace c10d {
+
+namespace {
+
+// Options handed to a child backend must never alias the parent's (or the
+// caller's) object: Backend::getBackendOptions() returns the backend's live
+// options_, and split()/merge() implementations write into what they are given
+// (ProcessGroupGloo::split overwrites global_ranks_in_group,
+// ProcessGroupNCCL::split also sets split_from/split_color). Sharing one object
+// leaves the parent describing its child's ranks, which the parent's next split
+// then indexes out of bounds.
+c10::intrusive_ptr<Backend::Options> cloneOptions(
+    const c10::intrusive_ptr<Backend::Options>& opts) {
+  auto copy = opts->clone();
+  if (copy == nullptr || typeid(*copy) != typeid(*opts)) {
+    // An out-of-tree Options subclass that does not override clone() would be
+    // sliced. Keep the legacy aliasing behavior for it rather than handing its
+    // backend an object of the wrong type.
+    return opts;
+  }
+  return copy;
+}
+
+} // namespace
 
 std::string opTypeToString(OpType opType) {
   switch (opType) {
@@ -202,6 +226,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
   std::string groupDesc = desc.has_value()
       ? desc.value()
       : c10::str(getGroupDesc(), ":split:", incrementSplitCount());
+  std::unordered_map<BackendType, c10::intrusive_ptr<Backend>> splitBackends;
   for (const auto& pair : deviceTypeToBackendType_) {
     c10::DeviceType deviceType = pair.first;
     BackendType backendType = pair.second;
@@ -210,9 +235,27 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
       continue;
     }
 
+    // One backend instance can serve several device types -- a gloo world maps
+    // both cpu and cuda to the same ProcessGroupGloo, and setBackend() reuses
+    // whatever is already registered for a backend type. Split it once: the
+    // second child would be thrown away by setBackend() below, but only after
+    // rendezvousing on the same store prefix as the real child, which races
+    // with it and hangs.
+    auto splitIt = splitBackends.find(backendType);
+    if (splitIt != splitBackends.end()) {
+      newGroup->setBackend(deviceType, backendType, splitIt->second);
+      continue;
+    }
+
     auto parentBackend = getBackend(deviceType);
-    auto backendOpts =
-        opts.has_value() ? opts.value() : parentBackend->getBackendOptions();
+    // `opts` describes the group's default backend, mirroring what
+    // `pg_options` means for init_process_group; a backend of another type
+    // would reject it (or worse, silently fall back to defaults and drop the
+    // caller's timeout), so those inherit the parent's own options instead.
+    auto backendOpts = cloneOptions(
+        opts.has_value() && backendType == backendType_
+            ? opts.value()
+            : parentBackend->getBackendOptions());
     backendOpts->group_name = groupName;
     backendOpts->timeout =
         timeout.has_value() ? timeout.value() : backendOpts->timeout;
@@ -228,6 +271,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
       newGroup->setDefaultBackend(backendType_);
     }
     newGroup->setBackend(deviceType, backendType, splitBackend);
+    splitBackends.emplace(backendType, splitBackend);
   }
 
   if (!newGroup) {
@@ -252,11 +296,18 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::mergeRemoteGroup(
   std::string groupDesc = opts.group_desc.has_value()
       ? opts.group_desc.value()
       : c10::str(getGroupDesc(), ":merge");
+  std::unordered_map<BackendType, c10::intrusive_ptr<Backend>> mergedBackends;
   for (const auto& pair : deviceTypeToBackendType_) {
     c10::DeviceType deviceType = pair.first;
     BackendType backendType = pair.second;
+    // Merge each backend instance once; see the same guard in splitGroup().
+    auto mergedIt = mergedBackends.find(backendType);
+    if (mergedIt != mergedBackends.end()) {
+      newGroup->setBackend(deviceType, backendType, mergedIt->second);
+      continue;
+    }
     auto parentBackend = getBackend(deviceType);
-    auto backendOpts = parentBackend->getBackendOptions();
+    auto backendOpts = cloneOptions(parentBackend->getBackendOptions());
     backendOpts->group_name = groupName;
     backendOpts->timeout = opts.timeout;
     auto mergedBackend = parentBackend->merge(store, backendOpts, rank, size);
@@ -270,6 +321,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::mergeRemoteGroup(
       newGroup->setDefaultBackend(backendType_);
     }
     newGroup->setBackend(deviceType, backendType, mergedBackend);
+    mergedBackends.emplace(backendType, mergedBackend);
   }
 
   if (!newGroup) {

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -753,7 +753,20 @@ void ProcessGroupGloo::runLoop(int workerIndex) {
 }
 
 const std::vector<uint64_t>& ProcessGroupGloo::groupRanks() const {
-  if (options_->global_ranks_in_group.empty() && local_id_ == 0) {
+  // An empty global_ranks_in_group means "this group spans the whole world, in
+  // rank order": _new_process_group_helper() only fills the vector in for
+  // subgroups, and a directly-constructed (stateless) ProcessGroupGloo leaves
+  // it at its default. Deriving the identity mapping is therefore the right
+  // answer whenever it is empty.
+  //
+  // This must NOT be gated on local_id_ == 0. local_id_ is a process-global
+  // counter over every ProcessGroupGloo ever constructed in this process, so
+  // the default group only gets 0 when it happens to be the first gloo backend
+  // built. If any gloo pg was created earlier -- a stateless pg, or one
+  // inherited across fork() -- the default group fell through to the empty
+  // global_ranks_in_group below and split() then indexed an empty vector,
+  // segfaulting on a null data pointer.
+  if (options_->global_ranks_in_group.empty()) {
     if (defaultRanks_.size() != static_cast<size_t>(size_)) {
       defaultRanks_.resize(size_);
       std::iota(defaultRanks_.begin(), defaultRanks_.end(), 0);

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -259,6 +259,10 @@ class TORCH_API ProcessGroupGloo : public Backend {
     static c10::intrusive_ptr<Options> create_default(
         std::chrono::milliseconds timeout = kBackendDefaultTimeout);
 
+    c10::intrusive_ptr<Backend::Options> clone() const override {
+      return c10::make_intrusive<Options>(*this);
+    }
+
     std::vector<std::shared_ptr<::gloo::transport::Device>> devices;
     int threads{2};
   };

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -320,6 +320,52 @@ static std::mutex ncclCommMemPoolMapMutex;
 
 std::atomic<bool> ProcessGroupNCCL::shouldDump_(false);
 
+// NOTE [NCCL calls from the caching allocator trace hooks]
+// The hooks below run on whichever thread allocated or freed the segment, with
+// the caching allocator's mutex held, so only NCCL calls that are local to this
+// rank are safe here. ncclCommWindowRegister is not one of them: it runs a
+// bootstrap allgather and barrier across the whole communicator (and
+// ncclCommWindowDeregister is collective too on NCCL builds that barrier before
+// tearing a window down). Issuing one from a hook deadlocks the job inside an
+// innocent-looking `torch.empty()` as soon as one rank allocates or frees a
+// segment that the others do not -- and the allocator mutex it holds stalls
+// every other thread of this process meanwhile. Symmetric windows are therefore
+// only created by registerMemPool(), which the user calls collectively.
+//
+// Returns the communicators interested in this segment, paired with whether
+// their pool was registered as symmetric. Caller must hold
+// ncclCommMemPoolMapMutex, and must keep holding it while acting on the result:
+// that is what keeps abortComms() from retiring a communicator underneath us.
+static std::vector<std::pair<std::shared_ptr<NCCLComm>, bool>>
+commsInterestedInSegment(const c10::CachingDeviceAllocator::TraceEntry& te) {
+  std::vector<std::pair<std::shared_ptr<NCCLComm>, bool>> comms;
+  for (auto& [ncclComm, memPools] : ncclCommMemPoolMap) {
+    if (te.device_ != ncclComm->getDeviceIndex()) {
+      continue;
+    }
+    bool symm = false;
+    bool should_register = shouldAllCommunicatorsRegisterAllTensors();
+    auto it =
+        std::find_if(memPools.begin(), memPools.end(), [&](const auto& tup) {
+          return std::get<0>(tup) == te.mempool_;
+        });
+    if (it != memPools.end()) {
+      should_register = true;
+      symm = std::get<1>(*it);
+    }
+    if (should_register) {
+      comms.emplace_back(ncclComm, symm);
+    }
+  }
+  // ncclCommMemPoolMap is keyed by pointer, so its iteration order differs
+  // between ranks; sort by a key every rank agrees on so that any NCCL call
+  // that does wait on peers is at least issued in the same order everywhere.
+  std::sort(comms.begin(), comms.end(), [](const auto& a, const auto& b) {
+    return a.first->getUniqueHash() < b.first->getUniqueHash();
+  });
+  return comms;
+}
+
 static void cacheAllocatorRegisterHook(
     const c10::CachingDeviceAllocator::TraceEntry& te) {
   // Register after SEGMENT_ALLOC
@@ -329,27 +375,22 @@ static void cacheAllocatorRegisterHook(
   }
 
   std::lock_guard<std::mutex> lock(ncclCommMemPoolMapMutex);
-  for (auto& [ncclComm, memPools] : ncclCommMemPoolMap) {
-    if (te.device_ == ncclComm->getDeviceIndex()) {
-      bool symm = false;
-      bool should_register = shouldAllCommunicatorsRegisterAllTensors();
-      auto it =
-          std::find_if(memPools.begin(), memPools.end(), [&](const auto& tup) {
-            return std::get<0>(tup) == te.mempool_;
-          });
-      if (it != memPools.end()) {
-        should_register = true;
-        symm = std::get<1>(*it);
-      }
-      if (should_register) {
-        // NOLINTNEXTLINE(performance-no-int-to-ptr)
-        ncclComm->registerSegment(
-            reinterpret_cast<void*>(te.addr_),
-            te.size_,
-            /*errorOnRereg*/ false,
-            /*window*/ symm);
-      }
+  for (const auto& [ncclComm, symm] : commsInterestedInSegment(te)) {
+    if (symm) {
+      TORCH_WARN_ONCE(
+          "A segment was allocated in a MemPool that is registered with "
+          "symm=True. It is registered with NCCL, but not as a symmetric "
+          "window, because window registration is collective and cannot be "
+          "issued from the allocator hook. Call deregister_mem_pool() and "
+          "register_mem_pool() again, from every rank, to window-register the "
+          "new segments.");
     }
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    ncclComm->registerSegment(
+        reinterpret_cast<void*>(te.addr_),
+        te.size_,
+        /*errorOnRereg*/ false,
+        /*window*/ false);
   }
 }
 
@@ -362,23 +403,24 @@ static void cacheAllocatorDeregisterHook(
   }
 
   std::lock_guard<std::mutex> lock(ncclCommMemPoolMapMutex);
-  for (auto& [ncclComm, memPools] : ncclCommMemPoolMap) {
-    if (te.device_ == ncclComm->getDeviceIndex()) {
-      bool symm = false;
-      bool should_register = shouldAllCommunicatorsRegisterAllTensors();
-      auto it =
-          std::find_if(memPools.begin(), memPools.end(), [&](const auto& tup) {
-            return std::get<0>(tup) == te.mempool_;
-          });
-      if (it != memPools.end()) {
-        should_register = true;
-        symm = std::get<1>(*it);
-      }
-      if (should_register) {
-        // NOLINTNEXTLINE(performance-no-int-to-ptr)
-        ncclComm->deregisterSegment(reinterpret_cast<void*>(te.addr_), symm);
-      }
+  for (const auto& [ncclComm, symm] : commsInterestedInSegment(te)) {
+    // Leaving the window behind would be worse than tearing it down here: the
+    // allocator is about to hand this address range back, and a later
+    // allocation reusing it would silently resolve to the stale window.
+    if (symm) {
+      TORCH_WARN_ONCE(
+          "Freeing a segment of a MemPool that is registered with symm=True "
+          "without calling deregister_mem_pool() first. The NCCL window has to "
+          "be torn down from the allocator hook, which hangs on NCCL builds "
+          "where that is a collective unless every rank frees the same segment "
+          "in the same order. Call deregister_mem_pool() from every rank before "
+          "freeing.");
     }
+    // deregisterSegment picks the window vs local API from what was recorded at
+    // registration time, not from `symm`: a symm=True pool can also hold
+    // segments that were registered locally by the hook above.
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    ncclComm->deregisterSegment(reinterpret_cast<void*>(te.addr_));
   }
 }
 
@@ -1215,7 +1257,6 @@ void ProcessGroupNCCL::deregisterMemPool(at::cuda::MemPool* pool) {
         DistBackendError,
         "NCCL communicator has not been initialized before mem pool creation. You can pass `device_id` to init_process_group -- one way of eager initialization -- to work around this issue");
   }
-  bool symm;
   {
     std::lock_guard<std::mutex> lock(ncclCommMemPoolMapMutex);
     auto iter = ncclCommMemPoolMap.find(ncclComm);
@@ -1226,7 +1267,6 @@ void ProcessGroupNCCL::deregisterMemPool(at::cuda::MemPool* pool) {
     TORCH_CHECK(
         mempool_it != iter->second.end(),
         "Trying to unregister not previously registered pool");
-    symm = std::get<1>(*mempool_it);
     iter->second.erase(mempool_it);
   }
   auto snapshot = c10::cuda::CUDACachingAllocator::snapshot(pool->id());
@@ -1235,8 +1275,7 @@ void ProcessGroupNCCL::deregisterMemPool(at::cuda::MemPool* pool) {
         segmentInfo.device == pool->device(),
         "Mismatch between CUDA memory segment device and pool's device");
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    ncclComm->deregisterSegment(
-        reinterpret_cast<void*>(segmentInfo.address), symm);
+    ncclComm->deregisterSegment(reinterpret_cast<void*>(segmentInfo.address));
   }
 }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -999,6 +999,17 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     std::iota(defaultRanks_.begin(), defaultRanks_.end(), 0);
   }
 
+  // groupRanks() maps this group's ranks onto world ranks, so
+  // groupRanks()[rank_] is this process's global rank. Compute it here, before
+  // the watchdog and heartbeat monitor threads that read it are started, so
+  // globalRank() is a pure read of state published by thread creation. A merged
+  // group inherits its parent's (shorter) global_ranks_in_group, so fall back
+  // to rank_ instead of reading out of bounds.
+  const auto& ranks = groupRanks();
+  globalRank_ = rank_ < static_cast<int>(ranks.size())
+      ? static_cast<int>(ranks[rank_])
+      : rank_;
+
   // getNcclVersion needs to get called before launching threads which can
   // potentially call getenv. getNcclVersion internally calls setenv to set some
   // environment variables from config file, which can race with getenv from
@@ -2706,8 +2717,14 @@ const std::string& ProcessGroupNCCL::logPrefix() const {
 }
 
 const int& ProcessGroupNCCL::globalRank() const {
-  static int globalRank = rank_;
-  return globalRank;
+  // This must NOT be a function-local static. A static is seeded by whichever
+  // ProcessGroupNCCL is constructed first in the process -- the constructor
+  // calls globalRank() while logging -- and never updated, so if that first
+  // group is a subgroup whose group-local rank differs from the world rank,
+  // every later group reports the wrong global rank: flight recorder dumps
+  // land in another rank's file, broadcastSignal(kStoreDumpKey) names the wrong
+  // rank, and guessDeviceId() (used by split()) picks the wrong CUDA device.
+  return globalRank_;
 }
 
 const c10::intrusive_ptr<Store>& ProcessGroupNCCL::globalStore() const {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -949,6 +949,14 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       "ProcessGroupNCCL does not support enable_reconfigure "
       "(reconfigure-based fault tolerance).");
 
+  // An empty global_ranks_in_group means "this group spans the whole world, in
+  // rank order"; see groupRanks(). Materialize that mapping here rather than
+  // lazily, so groupRanks() is a pure read and needs no synchronization.
+  if (options_->global_ranks_in_group.empty()) {
+    defaultRanks_.resize(size_);
+    std::iota(defaultRanks_.begin(), defaultRanks_.end(), 0);
+  }
+
   // getNcclVersion needs to get called before launching threads which can
   // potentially call getenv. getNcclVersion internally calls setenv to set some
   // environment variables from config file, which can race with getenv from
@@ -2668,10 +2676,22 @@ const c10::intrusive_ptr<Store>& ProcessGroupNCCL::globalStore() const {
 }
 
 const std::vector<uint64_t>& ProcessGroupNCCL::groupRanks() const {
-  if (options_->global_ranks_in_group.empty() && local_id_ == 0) {
-    static std::vector<uint64_t> globalRanks(size_);
-    std::iota(globalRanks.begin(), globalRanks.end(), 0);
-    return globalRanks;
+  // An empty global_ranks_in_group means "this group spans the whole world, in
+  // rank order": _new_process_group_helper() only fills the vector in for
+  // subgroups, and a directly-constructed (stateless) ProcessGroupNCCL leaves
+  // it at its default. defaultRanks_ (built in the constructor) is therefore
+  // the right answer whenever it is empty.
+  //
+  // This must NOT be gated on local_id_ == 0. local_id_ is a process-global
+  // counter over every ProcessGroupNCCL ever constructed in this process, so
+  // the default group only gets 0 when it happens to be the first NCCL backend
+  // built. If any NCCL pg was created earlier -- a stateless pg, one inherited
+  // across fork(), or simply a previous init_process_group() that has since
+  // been destroyed -- the default group fell through to the empty
+  // global_ranks_in_group below and split() then indexed an empty vector,
+  // segfaulting on a null data pointer.
+  if (options_->global_ranks_in_group.empty()) {
+    return defaultRanks_;
   }
   return options_->global_ranks_in_group;
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -525,6 +525,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       return c10::make_intrusive<Options>(is_high_priority_stream);
     }
 
+    c10::intrusive_ptr<Backend::Options> clone() const override {
+      return c10::make_intrusive<Options>(*this);
+    }
+
     // Schedule NCCL operations on high priority CUDA streams
     bool is_high_priority_stream;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1236,10 +1236,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Returns the unique prefix created in createLogPrefix
   const std::string& logPrefix() const;
 
-  // Returns the global rank of the device. This function assumes that users
-  // always create a default global process group(PG) which includes all
-  // devices. It is called in the constructor of ProcessGroupNCCL, so it always
-  // return the rank_ of the very first PG created, aka, default global PG.
+  // Returns this process's rank in the world, i.e. this group's rank_ mapped
+  // through groupRanks(). Computed per instance in the constructor.
   const int& globalRank() const;
 
   const c10::intrusive_ptr<Store>& globalStore() const;
@@ -1490,6 +1488,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Identity rank mapping [0, size_), used by groupRanks() when
   // options_->global_ranks_in_group is empty. Filled in the constructor.
   std::vector<uint64_t> defaultRanks_;
+
+  // This process's rank in the world, i.e. groupRanks()[rank_]. Filled in the
+  // constructor; see globalRank().
+  int globalRank_{};
 
   std::string logPrefix_;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1483,6 +1483,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // The number of ProcessGroupNCCL created on the current rank.
   size_t local_id_;
 
+  // Identity rank mapping [0, size_), used by groupRanks() when
+  // options_->global_ranks_in_group is empty. Filled in the constructor.
+  std::vector<uint64_t> defaultRanks_;
+
   std::string logPrefix_;
 
   c10::intrusive_ptr<intra_node_comm::IntraNodeComm> intraNodeComm_;

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -4171,6 +4171,14 @@ Returns:
               "get_error",
               &::c10d::nccl2::ProcessGroupNCCL::getError,
               py::call_guard<py::gil_scoped_release>())
+          .def(
+              "register_mem_pool",
+              &::c10d::nccl2::ProcessGroupNCCL::registerMemPool,
+              py::arg("pool"),
+              py::arg("symm") = false)
+          .def(
+              "deregister_mem_pool",
+              &::c10d::nccl2::ProcessGroupNCCL::deregisterMemPool)
           .def_property_readonly(
               "options",
               &::c10d::nccl2::ProcessGroupNCCL::getBackendOptions,

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -4136,18 +4136,18 @@ Returns:
       intrusive_ptr_no_gil_destructor_class_<::c10d::nccl2::ProcessGroupNCCL>(
           module, "ProcessGroupNCCL2", backend)
           .def(
-              py::init(
-                  [](const c10::intrusive_ptr<::c10d::Store>& store,
-                     int rank,
-                     int size,
-                     c10::intrusive_ptr<
-                         ::c10d::nccl2::ProcessGroupNCCL::Options> options) {
-                    // gil_scoped_release is not safe as a call_guard in init.
-                    // https://github.com/pybind/pybind11/issues/5473
-                    py::gil_scoped_release nogil{};
-                    return c10::make_intrusive<::c10d::nccl2::ProcessGroupNCCL>(
-                        store, rank, size, std::move(options));
-                  }),
+              py::init([](const c10::intrusive_ptr<::c10d::Store>& store,
+                          int rank,
+                          int size,
+                          const c10::intrusive_ptr<
+                              ::c10d::nccl2::ProcessGroupNCCL::BaseOptions>&
+                              options) {
+                // gil_scoped_release is not safe as a call_guard in init.
+                // https://github.com/pybind/pybind11/issues/5473
+                py::gil_scoped_release nogil{};
+                return c10::make_intrusive<::c10d::nccl2::ProcessGroupNCCL>(
+                    store, rank, size, options);
+              }),
               py::arg("store"),
               py::arg("rank"),
               py::arg("size"),
@@ -4176,20 +4176,57 @@ Returns:
               &::c10d::nccl2::ProcessGroupNCCL::getBackendOptions,
               R"(Return the options used to create this ProcessGroupNCCL2 instance.)");
 
-  processGroupNCCL2.attr("Options") = processGroupNCCL.attr("Options");
+  intrusive_ptr_class_<::c10d::nccl2::ProcessGroupNCCL::Options>(
+      processGroupNCCL2,
+      "Options",
+      processGroupNCCL.attr("Options"),
+      R"(
+ProcessGroup options for the nccl2 backend.
+
+Everything :class:`~torch.distributed.ProcessGroupNCCL.Options` accepts is
+accepted here too; the attribute below is specific to nccl2.
+
+Attributes:
+    abort_process_on_timeout_or_error (bool): if True (the default), a
+            collective timeout or NCCL async error detected by the nccl2
+            watchdog terminates the process with ``abort()`` after running the
+            registered abort hooks. If False the communicator is still aborted
+            but the process survives: ``backend.get_error()`` reports
+            ``TIMEOUT``/``COMM_ERROR`` and the next collective raises. It does
+            not affect ``backend.abort()`` or ``destroy_process_group()``,
+            which never terminate the process.
+      )")
+      .def(py::init<bool>(), py::arg("is_high_priority_stream") = false)
+      .def_readwrite(
+          "abort_process_on_timeout_or_error",
+          &::c10d::nccl2::ProcessGroupNCCL::Options::
+              abort_process_on_timeout_or_error)
+      .def(
+          "__copy__",
+          [](const ::c10d::nccl2::ProcessGroupNCCL::Options& self) {
+            return ::c10d::nccl2::ProcessGroupNCCL::Options(self);
+          })
+      .def(
+          "__deepcopy__",
+          [](const ::c10d::nccl2::ProcessGroupNCCL::Options& self,
+             const py::dict& memo) {
+            return ::c10d::nccl2::ProcessGroupNCCL::Options(self);
+          },
+          py::arg("memo"));
 
   intrusive_ptr_no_gil_destructor_class_<::c10d::nccl2::ProcessGroupNCCLLazy>(
       module, "ProcessGroupNCCLLazy", backend)
       .def(
-          py::init([](const c10::intrusive_ptr<::c10d::Store>& store,
-                      int rank,
-                      int size,
-                      const c10::intrusive_ptr<
-                          ::c10d::nccl2::ProcessGroupNCCL::Options>& options) {
-            py::gil_scoped_release nogil{};
-            return c10::make_intrusive<::c10d::nccl2::ProcessGroupNCCLLazy>(
-                store, rank, size, options);
-          }),
+          py::init(
+              [](const c10::intrusive_ptr<::c10d::Store>& store,
+                 int rank,
+                 int size,
+                 const c10::intrusive_ptr<
+                     ::c10d::nccl2::ProcessGroupNCCL::BaseOptions>& options) {
+                py::gil_scoped_release nogil{};
+                return c10::make_intrusive<::c10d::nccl2::ProcessGroupNCCLLazy>(
+                    store, rank, size, options);
+              }),
           py::arg("store"),
           py::arg("rank"),
           py::arg("size"),

--- a/torch/csrc/distributed/c10d/nccl2/NCCLCachingAllocatorHook.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/NCCLCachingAllocatorHook.cpp
@@ -4,6 +4,9 @@
 
 #include <torch/csrc/distributed/c10d/nccl2/NCCLCachingAllocatorHook.hpp>
 
+#include <algorithm>
+#include <vector>
+
 #include <ATen/Context.h>
 #include <c10/core/AllocatorConfig.h>
 #include <torch/csrc/distributed/c10d/nccl2/Logging.hpp>
@@ -15,6 +18,25 @@ namespace {
 void ncclCachingAllocatorHookFn(
     const c10::cuda::CUDACachingAllocator::TraceEntry& te) {
   NCCLCachingAllocatorHook::getInstance().regDeregMem(te);
+}
+
+// registeredComms_ is ordered by pointer, which differs between ranks. Any NCCL
+// call these hooks make that waits on peers (deregister_address tearing down a
+// symmetric window does so on NCCL builds that barrier there) must be issued in
+// the same order everywhere, so order by the group name instead.
+std::vector<ProcessGroupNCCL*> commsForDevice(
+    const std::set<ProcessGroupNCCL*>& comms,
+    c10::DeviceIndex device) {
+  std::vector<ProcessGroupNCCL*> out;
+  for (auto* comm : comms) {
+    if (device == comm->getDevice().index()) {
+      out.push_back(comm);
+    }
+  }
+  std::stable_sort(out.begin(), out.end(), [](auto* a, auto* b) {
+    return a->getCommName() < b->getCommName();
+  });
+  return out;
 }
 } // namespace
 
@@ -73,10 +95,8 @@ void NCCLCachingAllocatorHook::regDeregMem(
     TORCH_CHECK(
         !registeredMemMap_.count(addr), "Memory already registered with NCCL");
     registeredMemMap_.emplace(addr, MemInfo{len, te.device_});
-    for (auto* comm : registeredComms_) {
-      if (te.device_ == comm->getDevice().index()) {
-        comm->register_address(addr, len);
-      }
+    for (auto* comm : commsForDevice(registeredComms_, te.device_)) {
+      comm->register_address(addr, len);
     }
   } else if (
       te.action_ ==
@@ -86,10 +106,8 @@ void NCCLCachingAllocatorHook::regDeregMem(
     TORCH_CHECK(
         registeredMemMap_.count(addr), "Memory not registered with NCCL");
     registeredMemMap_.erase(addr);
-    for (auto* comm : registeredComms_) {
-      if (te.device_ == comm->getDevice().index()) {
-        comm->deregister_address(addr);
-      }
+    for (auto* comm : commsForDevice(registeredComms_, te.device_)) {
+      comm->deregister_address(addr, /*from_allocator_hook=*/true);
     }
   }
 }

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -12,9 +12,11 @@
 #include <string>
 #include <unordered_set>
 
+#include <ATen/Context.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/util/env.h>
 #include <fmt/core.h>
 #include <nccl.h>
 #include <torch/csrc/cuda/CUDAPluggableAllocator.h>
@@ -118,6 +120,21 @@ void ProcessGroupNCCL::init(at::Device device) {
 
   if (!nccl_api_) {
     nccl_api_ = std::make_unique<DefaultNcclApi>();
+  }
+
+  // If deterministic mode is enabled, disable the NVLS algorithm in NCCL
+  // (which can lead to non-deterministic reductions). Mirrors the stock
+  // ProcessGroupNCCL. NCCL reads NCCL_ALGO when the communicator is created,
+  // so this must run before createNcclComm below. If the user already set
+  // NCCL_ALGO, leave it untouched.
+  // TODO: remove this once NVLS supports deterministic mode.
+  if (at::globalContext().deterministicAlgorithms()) {
+    if (!c10::utils::get_env("NCCL_ALGO").has_value()) {
+      LOG(INFO)
+          << "torch deterministic mode is enabled, "
+          << "disabling NVLS algorithm in NCCL which can lead to non-deterministic reduction.";
+      c10::utils::set_env("NCCL_ALGO", "^NVLS");
+    }
   }
 
   if (device_.index() == -1 || nccl_comm_ == nullptr) {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -158,11 +158,6 @@ void ProcessGroupNCCL::initNcclResources() {
     dependency_event_.emplace(cudaEventDisableTiming);
   }
 
-  if (!barrier_buffer_) {
-    barrier_buffer_ =
-        c10::cuda::CUDACachingAllocator::get()->allocate(sizeof(float));
-  }
-
   max_event_pool_size_ = kDefaultMaxEventPoolSize;
 
   NCCL_CHECK(
@@ -1415,6 +1410,20 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::barrierImpl(
     std::chrono::milliseconds timeout) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
+
+  // Allocated here rather than in initNcclResources() so that merely creating a
+  // process group never touches the CUDA caching allocator. Eager init runs
+  // before anything has initialized CUDA (init_process_group(device_id=...) on
+  // a process that has made no torch.cuda call), and the allocator is brought
+  // up lazily, so allocating there tripped "Allocator not initialized for
+  // device N". lazyInitDevice() is what ATen's own allocating paths call, and
+  // is a no-op once CUDA is up.
+  if (!barrier_buffer_) {
+    at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
+    c10::cuda::CUDAGuard gpuGuard(device_);
+    barrier_buffer_ =
+        c10::cuda::CUDACachingAllocator::get()->allocate(sizeof(float));
+  }
 
   TracingGuard tracingGuard(name_, comm_size_, "barrier", rank_);
   cudaStream_t stream = getOperationStream(async_op);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -65,31 +65,14 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
         << " was not finalized before destruction. "
         << "This may indicate a resource leak. Please call finalize() explicitly.";
 
-    // Signal shutdown to timeout watchdog thread to prevent it from accessing
-    // this object after destruction
-    shutdown_ = true;
+    // Stop the watchdog so it cannot access this object after destruction. It
+    // may be the caller (garbageCollect can pop a work item whose destruction
+    // releases the last reference to this comm), which stopWatchdog handles.
+    stopWatchdog();
 
-    // Wake up the timeout watchdog thread
-    {
-      std::lock_guard<std::mutex> lock(timeout_mutex_);
-      timeout_cv_.notify_all();
-    }
-
-    // Wait for timeout thread to finish. If we're being called from within
-    // the timeout thread itself (e.g., garbageCollect popped a work item whose
-    // destruction released the last shared_ptr to this comm), we must detach
-    // instead of join to avoid a deadlock.
-    if (timeout_thread_.joinable()) {
-      if (std::this_thread::get_id() != timeout_thread_.get_id()) {
-        timeout_thread_.join();
-      } else {
-        timeout_thread_.detach(); // NOLINT(facebook-hte-BadCall-detach)
-      }
-    }
-
-    // Abort the NCCL communicator since we can't do a clean finalization
-    // Note: We don't call the full abortNcclComm() to avoid potential abort()
-    // calls from abort_process_on_timeout_or_error_
+    // Abort the NCCL communicator since we can't do a clean finalization.
+    // Open-coded rather than abortNcclComm() so a failure cannot throw out of
+    // the destructor (abortNcclComm() uses NCCL_CHECK).
     if (nccl_comm_) {
       // Drop our symmetric-memory registration while nccl_comm_ is still valid
       // (it is nulled below, before detachMemoryHook runs).
@@ -237,10 +220,11 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::split(
         " appears multiple times in ranks");
   }
 
-  auto ncclOpts = c10::dynamic_intrusive_pointer_cast<Options>(opts);
+  auto baseOpts = c10::dynamic_intrusive_pointer_cast<BaseOptions>(opts);
   TORCH_CHECK(
-      ncclOpts != nullptr,
+      baseOpts != nullptr,
       "ProcessGroupNCCL::split: opts is not a nccl2 ProcessGroupNCCL::Options");
+  auto ncclOpts = toNccl2Options(baseOpts);
 
   // ncclCommSplit is collective over the parent communicator, so the parent
   // must be initialized before we split. All parent ranks call split(), so a
@@ -294,6 +278,8 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::split(
   childOpts->config = config;
   childOpts->group_name = ncclOpts->group_name;
   childOpts->group_desc = ncclOpts->group_desc;
+  childOpts->abort_process_on_timeout_or_error =
+      ncclOpts->abort_process_on_timeout_or_error;
 
   auto child = c10::make_intrusive<ProcessGroupNCCL>(
       store, newRank, static_cast<int>(ranks.size()), childOpts);
@@ -302,9 +288,21 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::split(
 }
 
 void ProcessGroupNCCL::abort() {
+  // User-initiated (backend.abort() / _abort_process_group()): tear the
+  // communicator down and return. Never terminates the process, even when
+  // Options::abort_process_on_timeout_or_error is set -- that gate only covers
+  // failures the watchdog detects on its own.
+  TC_LOG(INFO, this) << "abort() requested on rank " << rank_
+                     << "; aborting the NCCL communicator";
   if (options_c10d_->enable_reconfigure) {
     revokeNcclComm();
   } else {
+    // Stop the watchdog before it can observe the comm_state_ set below: this
+    // failure is one the caller asked for, so it must not trigger a process
+    // abort, and there is no communicator left to watch either. Not done in
+    // reconfigurable mode, where the comm is revoked rather than destroyed and
+    // the watchdog is needed again after reconfigure().
+    stopWatchdog();
     abortNcclComm();
   }
   comm_state_ = CommState::ERROR;
@@ -369,19 +367,10 @@ void ProcessGroupNCCL::finalize() {
   }
   init_state_ = InitializationState::FINALIZED;
 
-  // Signal shutdown to timeout watchdog
-  shutdown_ = true;
-
-  // Wake up the timeout watchdog thread
-  {
-    std::lock_guard<std::mutex> lock(timeout_mutex_);
-    timeout_cv_.notify_all();
-  }
-
-  // Wait for timeout thread to finish
-  if (timeout_thread_.joinable()) {
-    timeout_thread_.join();
-  }
+  // Stop the watchdog first: draining the work queue below may surface a
+  // timeout, which is a teardown result to report to the caller, not a reason
+  // to terminate the process.
+  stopWatchdog();
 
   // Wait for all pending work objects to complete and get final status
   auto work_status = workq_.finalize();
@@ -399,6 +388,10 @@ void ProcessGroupNCCL::finalize() {
     throw std::runtime_error("Work timed out during finalize");
   } else if (work_status == WorkNCCL::WorkStatus::ERROR) {
     comm_state_ = CommState::ERROR;
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCL communicator was aborted after a previous error");
+    }
     ncclResult_t asyncErr{};
     NCCL_CHECK(
         nccl_api_,
@@ -451,14 +444,36 @@ void ProcessGroupNCCL::abortNcclComm() {
         "NCCL Abort failed");
     nccl_comm_ = nullptr;
   }
-  // Never abort the process in reconfigurable mode: callers fall back to
-  // revoke + throw so the failure can be handled by reconfiguring.
-  if (abort_process_on_timeout_or_error_ &&
-      !options_c10d_->enable_reconfigure) {
-    TC_LOG(ERROR, this) << "Aborting process due to timeout";
-    runAbortHooks();
-    ::abort();
+}
+
+void ProcessGroupNCCL::stopWatchdog() {
+  shutdown_ = true;
+  {
+    std::lock_guard<std::mutex> lock(timeout_mutex_);
+    timeout_cv_.notify_all();
   }
+  if (timeout_thread_.joinable()) {
+    // Joining from within the watchdog thread (the async-error path calls
+    // abort()) would deadlock.
+    if (std::this_thread::get_id() != timeout_thread_.get_id()) {
+      timeout_thread_.join();
+    } else {
+      timeout_thread_.detach(); // NOLINT(facebook-hte-BadCall-detach)
+    }
+  }
+}
+
+void ProcessGroupNCCL::abortProcess(const std::string& reason) {
+  // Never terminate the process in reconfigurable mode: callers fall back to
+  // revoke + throw so the failure can be handled by reconfiguring.
+  if (!options_c10d_->abort_process_on_timeout_or_error ||
+      options_c10d_->enable_reconfigure) {
+    return;
+  }
+  TC_LOG(ERROR, this) << "Aborting process on rank " << rank_ << " due to "
+                      << reason;
+  runAbortHooks();
+  ::abort();
 }
 
 void ProcessGroupNCCL::revokeNcclComm() {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -95,17 +95,53 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
  public:
   static constexpr std::string_view kBackendName = "nccl2";
 
-  using Options = ::c10d::ProcessGroupNCCL::Options;
+  // nccl2 shares the whole option surface of the stock NCCL backend (config,
+  // split_from/split_color, is_high_priority_stream, ...) and adds the knobs
+  // that only exist in this engine. Anything accepting a
+  // ::c10d::ProcessGroupNCCL::Options keeps working with these.
+  using BaseOptions = ::c10d::ProcessGroupNCCL::Options;
+
+  struct TORCH_API Options : BaseOptions {
+    explicit Options(bool is_high_priority_stream = false)
+        : BaseOptions(is_high_priority_stream) {}
+    // Adopt a plain base Options; the nccl2-only fields take their defaults.
+    explicit Options(const BaseOptions& base) : BaseOptions(base) {}
+    Options(const Options&) = default;
+    ~Options() override = default;
+
+    static c10::intrusive_ptr<Options> create(
+        bool is_high_priority_stream = false) {
+      return c10::make_intrusive<Options>(is_high_priority_stream);
+    }
+
+    // Whether a watchdog-detected collective timeout or NCCL async error
+    // terminates the process with ::abort() (after running the abort hooks).
+    // When false the communicator is still aborted, but the process survives:
+    // getError() reports TIMEOUT/COMM_ERROR and the next collective throws.
+    // Has no effect on a user-initiated abort()/shutdown(), which never
+    // terminate the process.
+    bool abort_process_on_timeout_or_error{true};
+  };
+
+  // Returns `options` unchanged if it already is an nccl2 Options, otherwise a
+  // copy of it as one (nccl2-only fields at their defaults). A null `options`
+  // yields a default-constructed Options.
+  static c10::intrusive_ptr<Options> toNccl2Options(
+      const c10::intrusive_ptr<BaseOptions>& options);
 
   // c10d-style constructor: the NCCL communicator is bootstrapped lazily, on
   // the first collective (or via eagerConnectSingleDevice / bound_device_id),
   // matching c10d's device-binding model -- unlike torchcomms which took an
   // eager init(device).
+  //
+  // `options` may be a plain ::c10d::ProcessGroupNCCL::Options (what callers
+  // passed before nccl2 had its own Options subclass); it is then copied into
+  // an nccl2 Options carrying the defaults for the nccl2-only fields.
   ProcessGroupNCCL(
       c10::intrusive_ptr<::c10d::Store> store,
       int rank,
       int size,
-      c10::intrusive_ptr<Options> options = Options::create());
+      const c10::intrusive_ptr<BaseOptions>& options = Options::create());
   ~ProcessGroupNCCL() override;
 
   ProcessGroupNCCL(const ProcessGroupNCCL&) = delete;
@@ -309,7 +345,19 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   void returnEvent(
       std::unique_ptr<at::cuda::CUDAEvent> event,
       bool timing_enabled);
+  // Tears the NCCL communicator down. This NEVER terminates the process --
+  // a user-initiated abort()/shutdown() must be survivable, matching
+  // ::c10d::ProcessGroupNCCL::abort(). Callers that are handling a
+  // watchdog-detected timeout or async error follow it with abortProcess().
   void abortNcclComm();
+  // Terminates the process (after running the abort hooks) if
+  // Options::abort_process_on_timeout_or_error is set and we are not in
+  // reconfigurable mode. `reason` is logged after "Aborting process on rank N
+  // due to ", so it must describe the actual trigger.
+  void abortProcess(const std::string& reason);
+  // Signals the watchdog thread to exit and reaps it. Detaches instead of
+  // joining when called from the watchdog thread itself.
+  void stopWatchdog();
   void revokeNcclComm();
 
   enum class CommState {
@@ -548,9 +596,10 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   std::mutex timeout_mutex_;
 
   bool is_high_priority_stream_{false};
-  bool abort_process_on_timeout_or_error_{true};
   std::string name_;
 
+  // Always an nccl2 Options: the constructor copies a plain
+  // ::c10d::ProcessGroupNCCL::Options into one.
   c10::intrusive_ptr<Options> options_c10d_;
 
   // Identifies the current communicator generation in the reconfigure regime;

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -320,7 +320,9 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // Caching-allocator segment registration (called by
   // NCCLCachingAllocatorHook, potentially from allocator threads).
   void register_address(void* addr, size_t len);
-  void deregister_address(void* addr);
+  // from_allocator_hook only controls diagnostics: tearing a symmetric window
+  // down from the hook is the uncollective path worth warning about.
+  void deregister_address(void* addr, bool from_allocator_hook = false);
   // Returns {window handle, byte offset of ptr within the segment}, or
   // {nullptr, 0} if ptr is not inside a window-registered segment.
   std::pair<ncclWindow_t, size_t> lookupSegmentWindow(const void* ptr);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -115,6 +115,12 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
       return c10::make_intrusive<Options>(is_high_priority_stream);
     }
 
+    c10::intrusive_ptr<::c10d::Backend::Options> clone() const override {
+      auto copy = c10::make_intrusive<Options>(*this);
+      copy->config = cloneNcclConfig(config);
+      return copy;
+    }
+
     // Whether a watchdog-detected collective timeout or NCCL async error
     // terminates the process with ::abort() (after running the abort hooks).
     // When false the communicator is still aborted, but the process survives:

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <optional>
 #include <queue>
+#include <set>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -299,6 +300,16 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   }
   c10::intrusive_ptr<::c10d::Window> new_window(
       const std::optional<at::Tensor>& tensor = std::nullopt) override;
+
+  // MemPool registration (::c10d::ProcessGroupNCCL::registerMemPool parity).
+  // Unlike the stock backend, plain ncclCommRegister of every private-pool
+  // segment already happens unconditionally through NCCLCachingAllocatorHook,
+  // so this only has to cover the segments the hook could not reach and -- for
+  // symm -- perform the collective NCCL_WIN_COLL_SYMMETRIC upgrade that the
+  // hook must not do from an allocator thread. Collective when symm is set:
+  // every rank must call it with the same pool contents, in the same order.
+  void registerMemPool(at::cuda::MemPool* pool, bool symm = false);
+  void deregisterMemPool(at::cuda::MemPool* pool);
 
   // Caching-allocator segment registration (called by
   // NCCLCachingAllocatorHook, potentially from allocator threads).
@@ -616,9 +627,18 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
     size_t len{0};
   };
   std::map<void*, RegistrationHandle, std::less<>> memoryRegistrationHandles_;
-  // Guards memoryRegistrationHandles_: register/deregister_address run on
-  // allocator threads while window ops look segments up on the main thread.
+  // Guards memoryRegistrationHandles_ and registeredMemPools_:
+  // register/deregister_address run on allocator threads while window ops look
+  // segments up on the main thread.
   std::mutex memory_registration_mutex_;
+  // MemPools passed to registerMemPool, so deregisterMemPool can reject a pool
+  // that was never registered (stock does the same via its global
+  // ncclCommMemPoolMap). The symm mode is not tracked: a segment carries its
+  // own window handle, so teardown does not need to be told which mode to use.
+  std::set<c10::cuda::MempoolId_t> registeredMemPools_;
+  // Caller must hold memory_registration_mutex_ and have checked that `addr`
+  // is not already registered.
+  void registerAddressLocked(void* addr, size_t len);
 
   // Abort hooks (c10d::Backend API; storage was in torchcomms' TorchCommBackend
   // base, folded in here).

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -69,15 +69,26 @@ c10::intrusive_ptr<WorkNCCL> coalesceWorks(
 
 } // namespace
 
+c10::intrusive_ptr<ProcessGroupNCCL::Options> ProcessGroupNCCL::toNccl2Options(
+    const c10::intrusive_ptr<BaseOptions>& options) {
+  if (!options) {
+    return Options::create();
+  }
+  if (auto derived = c10::dynamic_intrusive_pointer_cast<Options>(options)) {
+    return derived;
+  }
+  return c10::make_intrusive<Options>(*options);
+}
+
 ProcessGroupNCCL::ProcessGroupNCCL(
     c10::intrusive_ptr<::c10d::Store> store,
     int rank,
     int size,
-    c10::intrusive_ptr<Options> options)
+    const c10::intrusive_ptr<BaseOptions>& options)
     : Backend(rank, size),
       device_(at::kCUDA),
       store_(std::move(store)),
-      options_c10d_(options ? std::move(options) : Options::create()) {
+      options_c10d_(toNccl2Options(options)) {
   name_ = options_c10d_->group_name.empty() ? std::string(kBackendName)
                                             : options_c10d_->group_name;
 }

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLLazy.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLLazy.cpp
@@ -30,6 +30,11 @@ ProcessGroupNCCLLazy::PairFactory makePairFactory(
     pair_options->is_high_priority_stream = options->is_high_priority_stream;
     pair_options->config = cloneNcclConfig(options->config);
     pair_options->group_name = pair_name;
+    // Each pair comm runs its own watchdog, so it needs the same abort policy
+    // as the primary -- otherwise one stalled pair kills a process that asked
+    // not to be killed.
+    pair_options->abort_process_on_timeout_or_error =
+        options->abort_process_on_timeout_or_error;
     return c10::make_intrusive<ProcessGroupNCCL>(
         pair_store, pair_rank, /*size=*/2, pair_options);
   };
@@ -41,7 +46,7 @@ ProcessGroupNCCLLazy::ProcessGroupNCCLLazy(
     const c10::intrusive_ptr<::c10d::Store>& store,
     int rank,
     int size,
-    const c10::intrusive_ptr<ProcessGroupNCCL::Options>& options)
+    const c10::intrusive_ptr<ProcessGroupNCCL::BaseOptions>& options)
     : LazyBackend(
           rank,
           size,
@@ -49,10 +54,8 @@ ProcessGroupNCCLLazy::ProcessGroupNCCLLazy(
               store,
               rank,
               size,
-              options ? options : ProcessGroupNCCL::Options::create()),
-          makePairFactory(
-              store,
-              options ? options : ProcessGroupNCCL::Options::create())) {}
+              ProcessGroupNCCL::toNccl2Options(options)),
+          makePairFactory(store, ProcessGroupNCCL::toNccl2Options(options))) {}
 
 } // namespace c10d::nccl2
 

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLLazy.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLLazy.hpp
@@ -29,7 +29,7 @@ class TORCH_API ProcessGroupNCCLLazy
       const c10::intrusive_ptr<::c10d::Store>& store,
       int rank,
       int size,
-      const c10::intrusive_ptr<ProcessGroupNCCL::Options>& options =
+      const c10::intrusive_ptr<ProcessGroupNCCL::BaseOptions>& options =
           ProcessGroupNCCL::Options::create());
 
   const std::string getBackendName() const override {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -574,7 +574,7 @@ void ProcessGroupNCCL::register_address(void* addr, size_t len) {
   registerAddressLocked(addr, len);
 }
 
-void ProcessGroupNCCL::deregister_address(void* addr) {
+void ProcessGroupNCCL::deregister_address(void* addr, bool from_allocator_hook) {
   if (nccl_comm_ == nullptr) {
     return;
   }
@@ -584,6 +584,19 @@ void ProcessGroupNCCL::deregister_address(void* addr) {
     return;
   }
   if (it->second.winHandle != nullptr) {
+    // Tearing the window down is still the least bad option -- the allocator is
+    // about to hand this address range back, and a later allocation reusing it
+    // would silently resolve to the stale window -- but say so loudly: on NCCL
+    // builds where ncclCommWindowDeregister barriers, a rank-divergent free
+    // hangs here, on an allocator thread, holding the allocator's mutex.
+    if (from_allocator_hook) {
+      TORCH_WARN_ONCE(
+          "A symmetric-window segment was freed without deregister_mem_pool() "
+          "being called first, so its NCCL window is being torn down from the "
+          "CUDA allocator hook. That is only safe if every rank frees the same "
+          "segment in the same order; call deregister_mem_pool() from every "
+          "rank before freeing.");
+    }
     NCCL_CHECK_IGNORE(
         nccl_api_,
         nccl_api_->commWindowDeregister(nccl_comm_, it->second.winHandle),

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -8,9 +8,11 @@
 #include <nccl.h>
 #include <torch/csrc/distributed/c10d/nccl2/Logging.hpp>
 #include <torch/csrc/distributed/c10d/nccl2/NCCLCachingAllocatorHook.hpp>
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <variant>
+#include <vector>
 
 namespace c10d::nccl2 {
 
@@ -547,14 +549,7 @@ void ProcessGroupNCCL::detachMemoryHook() {
   NCCLCachingAllocatorHook::getInstance().deregisterComm(this);
 }
 
-void ProcessGroupNCCL::register_address(void* addr, size_t len) {
-  if (nccl_comm_ == nullptr) {
-    return;
-  }
-  std::lock_guard<std::mutex> lock(memory_registration_mutex_);
-  TORCH_CHECK(
-      !memoryRegistrationHandles_.count(addr),
-      "Memory already registered with NCCL");
+void ProcessGroupNCCL::registerAddressLocked(void* addr, size_t len) {
   void* handle = nullptr;
   NCCL_CHECK(
       nccl_api_,
@@ -566,6 +561,17 @@ void ProcessGroupNCCL::register_address(void* addr, size_t len) {
   // happens lazily in ensureSegmentWindow(), keyed by the base recorded here.
   memoryRegistrationHandles_.emplace(
       addr, RegistrationHandle{handle, nullptr, len});
+}
+
+void ProcessGroupNCCL::register_address(void* addr, size_t len) {
+  if (nccl_comm_ == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+  TORCH_CHECK(
+      !memoryRegistrationHandles_.count(addr),
+      "Memory already registered with NCCL");
+  registerAddressLocked(addr, len);
 }
 
 void ProcessGroupNCCL::deregister_address(void* addr) {
@@ -642,6 +648,108 @@ ncclResult_t ProcessGroupNCCL::ensureSegmentWindow(const void* ptr) {
   }
   it->second.winHandle = win;
   return ncclSuccess;
+}
+
+namespace {
+
+// Segments currently backing `id`, in allocation order. Symmetric window
+// registration is collective, so every rank has to walk them in the same
+// order; registration_counter is the only cross-rank-stable ordering the
+// snapshot offers (this is what the stock backend sorts on too).
+std::vector<c10::cuda::CUDACachingAllocator::SegmentInfo> poolSegments(
+    const c10::cuda::MempoolId_t& id) {
+  auto snapshot = c10::cuda::CUDACachingAllocator::snapshot(id);
+  std::sort(
+      snapshot.segments.begin(),
+      snapshot.segments.end(),
+      [](const auto& a, const auto& b) {
+        return a.registration_counter < b.registration_counter;
+      });
+  return std::move(snapshot.segments);
+}
+
+constexpr const char* kUninitializedCommError =
+    "NCCL communicator has not been initialized before mem pool creation. You can pass `device_id` to init_process_group -- one way of eager initialization -- to work around this issue";
+
+} // namespace
+
+void ProcessGroupNCCL::registerMemPool(at::cuda::MemPool* pool, bool symm) {
+  if (nccl_comm_ == nullptr) {
+    C10_THROW_ERROR(DistBackendError, kUninitializedCommError);
+  }
+  TORCH_CHECK(
+      pool->device() == device_.index(),
+      "MemPool is on device ",
+      static_cast<int>(pool->device()),
+      " but this process group is bound to ",
+      device_);
+  TC_LOG(INFO, this) << "Registering MemPool " << pool->id().first << ":"
+                     << pool->id().second << " (symm=" << symm << ") on "
+                     << device_;
+  {
+    std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+    registeredMemPools_.insert(pool->id());
+  }
+  bool symmUnsupported = false;
+  for (const auto& segment : poolSegments(pool->id())) {
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    void* addr = reinterpret_cast<void*>(segment.address);
+    {
+      std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+      // The allocator hook normally registered this segment already; only the
+      // ones it could not reach (allocated while the comm was down, or
+      // deregistered by an earlier deregisterMemPool) are left to do here.
+      if (!memoryRegistrationHandles_.count(addr)) {
+        registerAddressLocked(addr, segment.total_size);
+      }
+    }
+    if (!symm) {
+      continue;
+    }
+    // Only segments that exist now can be upgraded: the window call is
+    // collective, so a segment another thread allocates concurrently must be
+    // left to the next registerMemPool.
+    auto rc = ensureSegmentWindow(addr);
+    if (rc == ncclInvalidUsage) {
+      // No symmetric-memory-capable transport (or NCCL predates
+      // ncclCommWindowRegister). The stock backend keeps the plain
+      // registration and reports success here; do the same, but say so.
+      symmUnsupported = true;
+      continue;
+    }
+    TORCH_CHECK(
+        rc == ncclSuccess,
+        "Failed to register segment ",
+        addr,
+        " as an NCCL symmetric window: ",
+        nccl_api_->getErrorString(rc));
+  }
+  if (symmUnsupported) {
+    TC_LOG(WARNING, this)
+        << "Symmetric (NVLS) registration unavailable for MemPool "
+        << pool->id().first << ":" << pool->id().second
+        << "; its buffers stay registered as plain NCCL user buffers.";
+  }
+}
+
+void ProcessGroupNCCL::deregisterMemPool(at::cuda::MemPool* pool) {
+  if (nccl_comm_ == nullptr) {
+    C10_THROW_ERROR(DistBackendError, kUninitializedCommError);
+  }
+  {
+    std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+    TORCH_CHECK(
+        registeredMemPools_.erase(pool->id()) == 1,
+        "Trying to unregister not previously registered pool");
+  }
+  TC_LOG(INFO, this) << "Deregistering MemPool " << pool->id().first << ":"
+                     << pool->id().second << " on " << device_;
+  for (const auto& segment : poolSegments(pool->id())) {
+    // deregister_address tears the symmetric window down before the plain
+    // registration and tolerates a segment that is not registered.
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    deregister_address(reinterpret_cast<void*>(segment.address));
+  }
 }
 
 } // namespace c10d::nccl2

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -265,22 +265,15 @@ void ProcessGroupNCCL::timeoutWatchdog() noexcept {
       if (shutdown_) {
         break;
       }
-      if (comm_state_ != CommState::NORMAL &&
-          abort_process_on_timeout_or_error_ &&
-          !options_c10d_->enable_reconfigure) {
-        if (comm_state_ == CommState::TIMEOUT) {
-          TC_LOG(ERROR, this)
-              << "Aborting process due to timeout on rank " << rank_
-              << " - timeout watchdog detected operation timeout";
-        } else if (comm_state_ == CommState::ERROR) {
-          TC_LOG(ERROR, this)
-              << "Aborting process due to error on rank " << rank_
-              << " - timeout watchdog detected operation error. ";
-        }
-
-        runAbortHooks();
-
-        ::abort();
+      // With abort_process_on_timeout_or_error disabled this is a no-op and
+      // the loop keeps running: comm_state_ stays TIMEOUT/ERROR so getError()
+      // reports it, and the next collective throws from
+      // checkAndAbortIfTimedOutOrError().
+      if (comm_state_ != CommState::NORMAL) {
+        abortProcess(
+            comm_state_ == CommState::TIMEOUT
+                ? "timeout - timeout watchdog detected operation timeout"
+                : "error - timeout watchdog detected operation error");
       }
 
       // Detect a communicator-level async error while the comm is still
@@ -295,13 +288,14 @@ void ProcessGroupNCCL::timeoutWatchdog() noexcept {
         if (asyncErr != ncclSuccess) {
           comm_state_ = CommState::ERROR;
           if (!options_c10d_->enable_reconfigure) {
-            TC_LOG(ERROR, this)
-                << "Aborting process due to error on rank " << rank_
-                << " - nccl hit async error: " << ncclGetErrorString(asyncErr);
-
-            runAbortHooks();
-
+            TC_LOG(ERROR, this) << "nccl hit async error on rank " << rank_
+                                << ": " << ncclGetErrorString(asyncErr);
+            // abort() only tears the communicator down; abortProcess() runs
+            // the abort hooks and terminates if the option allows it.
             abort();
+            abortProcess(
+                std::string("error - nccl hit async error: ") +
+                ncclGetErrorString(asyncErr));
           } else {
             // Revoked below by the reconfigurable-mode handler.
             TC_LOG(ERROR, this)
@@ -360,15 +354,17 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
       throw std::runtime_error("NCCL operation timed out");
     } else {
       abortNcclComm();
-      if (abort_process_on_timeout_or_error_) {
-        TC_LOG(ERROR, this) << "Aborting process due to timeout";
-        runAbortHooks();
-        ::abort();
-      } else {
-        throw std::runtime_error("NCCL operation timed out");
-      }
+      abortProcess("timeout - collective operation timed out");
+      throw std::runtime_error("NCCL operation timed out");
     }
   } else if (comm_state_ == CommState::ERROR) {
+    // With abort_process_on_timeout_or_error disabled the watchdog aborts the
+    // communicator on an async error and lets the process live, so a later
+    // collective can reach here with no communicator left to query.
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCL communicator was aborted after a previous error");
+    }
     ncclResult_t asyncErr{};
     NCCL_CHECK(
         nccl_api_,
@@ -384,14 +380,8 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
       throw std::move(ncclException);
     }
     abortNcclComm();
-    if (abort_process_on_timeout_or_error_) {
-      TC_LOG(ERROR, this) << "Aborting process due to error: "
-                          << ncclException.what();
-      runAbortHooks();
-      ::abort();
-    } else {
-      throw std::move(ncclException);
-    }
+    abortProcess(std::string("error - ") + ncclException.what());
+    throw std::move(ncclException);
   }
 }
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -6659,13 +6659,38 @@ def split_group(
     # loop honors this filter so unwanted backends are never split.
     device_types_filter: list[torch.device] | None = None
     if backend is not None:
+        # The parent's per-device backends are what BackendConfig expanded its
+        # backend string to when the group was built (see
+        # _new_process_group_helper), restricted to what actually got
+        # registered. Re-deriving them from Backend.default_device_backend_map
+        # answers a different question -- "which devices default to this
+        # backend" -- and gets a bare parent string wrong: a "gloo" parent runs
+        # gloo on cuda too, and "fake" is no device's default at all.
         parent_devices = {d.type for d in parent_pg._device_types}
-        parent_device_backends = _parse_backend_string(
-            parent_backend_str, available_devices=parent_devices
-        )
-        requested_device_backends = _parse_backend_string(
-            str(backend), available_devices=parent_devices
-        )
+        parent_device_backends = {
+            device_type: str(be)
+            for device_type, be in backend_config.get_device_backend_map().items()
+            if device_type in parent_devices
+        }
+        requested_backend_str = str(backend).lower()
+        if ":" in requested_backend_str:
+            requested_device_backends = _parse_backend_string(
+                requested_backend_str, available_devices=parent_devices
+            )
+        else:
+            # A bare backend name selects every parent device running it.
+            Backend._ensure_backend_registered(requested_backend_str)
+            requested_device_backends = {
+                device_type: be
+                for device_type, be in parent_device_backends.items()
+                if be == requested_backend_str
+            }
+            if not requested_device_backends:
+                raise ValueError(
+                    f"Requested backend '{requested_backend_str}' is not present "
+                    f"in the parent process group (parent backends: "
+                    f"{parent_device_backends})"
+                )
         for device_type, requested_be in requested_device_backends.items():
             if device_type not in parent_device_backends:
                 raise ValueError(
@@ -6736,17 +6761,19 @@ def split_group(
     global_ranks_in_my_group = [parent_group_to_global_ranks[rank] for rank in my_group]
     split_pg.bound_device_id = device_id  # type: ignore[union-attr]
 
-    if torch.accelerator.is_available():
-        split_backend_class = split_pg._get_backend(
-            torch.accelerator.current_accelerator()  # pyrefly: ignore[bad-argument-type]
-        )
-    elif _use_torchcomms_enabled():
-        # torchcomms supports CPU/gloo splitting; no accelerator is required.
-        split_backend_class = split_pg._get_backend(torch.device("cpu"))
+    # `backend` may have filtered the accelerator's leg out of the child, so
+    # look the child's backend up on a device the child actually has.
+    accelerator = torch.accelerator.current_accelerator()
+    split_devices = {d.type for d in split_pg._device_types}
+    if accelerator is not None and accelerator.type in split_devices:
+        split_backend_device = accelerator
+    elif "cpu" in split_devices:
+        split_backend_device = torch.device("cpu")
     else:
         raise RuntimeError(
             "No backend for the parent process group or its backend does not support splitting"
         )
+    split_backend_class = split_pg._get_backend(split_backend_device)
 
     if split_pg.group_name != group_name:
         raise AssertionError(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -4,7 +4,6 @@
 import builtins
 import collections.abc
 import contextlib
-import copy
 import ctypes
 import hashlib
 import io
@@ -6687,11 +6686,12 @@ def split_group(
         pg_backend = Backend(str(backend))
         backend_config = BackendConfig(pg_backend)
 
-    if pg_options is None and not _use_torchcomms_enabled():
-        # default pg_options same as the parent process group
-        # A deep copy is needed because if the option will be modified inside split
-        # and if we split parent pg multiple times, we will run into device out of bound error.
-        pg_options = copy.deepcopy(parent_backend.options)
+    # pg_options is left as-is when the caller did not pass any: ProcessGroup::
+    # splitGroup gives each device's backend a copy of *that backend's* options,
+    # which is what the child needs. Substituting the default (accelerator)
+    # backend's options here would hand e.g. ProcessGroupNCCL::Options to the
+    # gloo leg of a "cpu:gloo,cuda:nccl" group, which rejects them and silently
+    # falls back to defaults, dropping the caller's timeout and group_name.
 
     # this timeout defaulting/validation is used for all the new_groups/new_subgroups variants,
     # which may just pass their timeout value (or None)

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -721,8 +721,11 @@ def _create_nccl_process_group(
 def _nccl2_options(
     backend_options: object | None,
 ) -> "ProcessGroupNCCL.Options":
+    # ProcessGroupNCCL2.Options subclasses ProcessGroupNCCL.Options and adds the
+    # nccl2-only knobs; a plain ProcessGroupNCCL.Options is still accepted (the
+    # backend copies it) so callers written against the stock backend work.
     if backend_options is None:
-        return ProcessGroupNCCL.Options()
+        return ProcessGroupNCCL2.Options()
     if not isinstance(backend_options, ProcessGroupNCCL.Options):
         raise AssertionError(
             "Expected backend_options argument to be of type ProcessGroupNCCL.Options"

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -159,6 +159,22 @@ def _torchelastic_use_agent_store() -> bool:
     return os.environ.get("TORCHELASTIC_USE_AGENT_STORE", None) == str(True)
 
 
+def _agent_store_serves(hostname, port) -> bool:
+    """Whether the elastic agent is the one serving a store at ``hostname:port``.
+
+    ``TORCHELASTIC_USE_AGENT_STORE`` only promises a server at the agent's own
+    ``MASTER_ADDR:MASTER_PORT``, which the agent exports alongside it. Honoring
+    the flag for any other endpoint makes every rank a client of a store nobody
+    hosts. ``TCPStore``'s C++ constructor applies the same address check before
+    it forgives a failed server bind.
+    """
+    return (
+        _torchelastic_use_agent_store()
+        and os.environ.get("MASTER_ADDR") == hostname
+        and os.environ.get("MASTER_PORT") == str(port)
+    )
+
+
 def _create_c10d_store(
     hostname, port, rank, world_size, timeout, use_libuv=True
 ) -> Store:
@@ -171,21 +187,21 @@ def _create_c10d_store(
     By default, the TCPStore server uses the asynchronous implementation
     ``LibUVStoreDaemon`` which utilizes libuv.
 
-    If ``torchelastic_use_agent_store()`` is ``True``, then it is assumed that
-    the agent leader (node rank 0) hosts the TCPStore server (for which the
-    endpoint is specified by the given ``hostname:port``). Hence
+    If ``torchelastic_use_agent_store()`` is ``True`` *and* ``hostname:port`` is
+    the agent's own ``MASTER_ADDR:MASTER_PORT``, then it is assumed that the
+    agent leader (node rank 0) hosts the TCPStore server there. Hence
     ALL ranks will create and return a TCPStore client (e.g. ``start_daemon=False``).
 
-    If ``torchelastic_use_agent_store()`` is ``False``, then rank 0 will host
-    the TCPStore (with multi-tenancy) and it is assumed that rank 0's hostname
-    and port are correctly passed via ``hostname`` and ``port``. All
-    non-zero ranks will create and return a TCPStore client.
+    Otherwise rank 0 will host the TCPStore (with multi-tenancy) and it is
+    assumed that rank 0's hostname and port are correctly passed via
+    ``hostname`` and ``port``. All non-zero ranks will create and return a
+    TCPStore client.
     """
     # check if port is uint16_t
     if not 0 <= port < 2**16:
         raise ValueError(f"port must have value from 0 to 65535 but was {port}.")
 
-    if _torchelastic_use_agent_store():
+    if _agent_store_serves(hostname, port):
         # We create a new TCPStore for every retry so no need to add prefix for each attempt.
         return TCPStore(
             host_name=hostname,


### PR DESCRIPTION

Summary:
_create_c10d_store() began with

    if _torchelastic_use_agent_store():
        return TCPStore(hostname, port, world_size, is_master=False, timeout)

so under torchrun every rank got a client-only TCPStore for whatever host and
port it had been handed. torchrun's elastic agent exports
TORCHELASTIC_USE_AGENT_STORE=True into every worker it spawns, alongside
MASTER_ADDR and MASTER_PORT, and the flag promises exactly one thing: the agent
hosts a store at that endpoint. _create_c10d_store applied it to every
endpoint. So any caller building a private store on a port of its own choosing
-- a library making a stateless group, or a script calling
init_process_group(init_method="tcp://host:port") -- ended up with a client on
every rank, no rank ever started a server, and every rank sat in connect-retry
against nothing until the store timeout expired: thirty minutes on gloo, ten on
nccl. From the outside that is an unexplained hang at startup with no error and
nothing in the logs, on a code path that works perfectly the moment the same
program is run without torchrun.

Torch already knew the address had to match. TCPStore's C++ constructor only
forgives a failed server bind when useAgentStore && masterPort == opts.port --
the same guard, one layer down. The Python layer was contradicting the C++
layer: rendezvous.py behaved as though the agent serves every address, while
TCPStore.cpp assumes it serves only its own.

Found by root-causing a hang rather than by reading. vLLM's
stateless_init_torch_distributed_process_group hangs when called from inside a
torchrun-managed process, on both the gloo and the nccl arms and identically on
stock nccl and on nccl2. Isolating it ruled out everything torchrun-shaped in
turn -- RANK and WORLD_SIZE, MASTER_PORT collisions, store key collisions --
and left one variable: popping TORCHELASTIC_USE_AGENT_STORE out of the
environment makes the identical run succeed. That pointed at
torch.distributed.rendezvous, which is where vLLM was getting its store, and
from there at this branch.

This is a stock defect. rendezvous.py is stock torch, the elastic agent that
sets the variable is stock torch, and the hang reproduces on a stock
init_process_group(init_method="tcp://...") under stock torchrun with nothing
from the migration loaded at all. No part of it requires nccl2.

It is also only fixable here, which is the whole reason it belongs in c10d
rather than downstream. vLLM has already fixed itself, independently, by
building the TCPStore directly instead of going through rendezvous -- and that
bypass is byte-for-byte the branch _create_c10d_store now takes for a private
address, so on a torch carrying this commit the two are equivalent and the
workaround is functionally redundant. It was nonetheless deliberately left in
place, because vLLM supports torch releases that will not carry this fix for a
long time and on a fixed torch it is a no-op that costs nothing. What a
downstream patch cannot close is the broader exposure: an API server started
under torchrun whose workers call
init_distributed_environment(distributed_init_method="tcp://...") reaches this
code through init_process_group, which builds its store via
_create_c10d_store, and no amount of patching a stateless-group helper reaches
that path. Every framework offering a "connect to this address" knob has the
same shape, so the guard has to live in torch.

The fix is a predicate, _agent_store_serves(hostname, port), that honors
TORCHELASTIC_USE_AGENT_STORE only when the hostname and port it is asked about
are the agent's own MASTER_ADDR and MASTER_PORT. _create_c10d_store gates on
that instead of on the raw env read, and the docstring is corrected to describe
what the code now does. _torchelastic_use_agent_store() itself stays, since it
is the raw env read and is referenced elsewhere in the ecosystem. This is
TCPStore.cpp's existing guard extended to the hostname, which the Python layer
has in hand and the C++ layer does not.

Comparing the hostname as a string is safe in both directions. Everything that
legitimately wants the agent's store arrives through env://, and
_env_rendezvous_handler reads MASTER_ADDR verbatim out of the same environment
the agent wrote it into, so for that path the comparison is exact by
construction. A caller who instead hand-writes tcp://<resolved-ip>:<MASTER_PORT>
and so trips the string mismatch does not get the old broken behaviour but the
correct one: rank 0 takes the is_master=True branch, its bind fails because the
agent already holds that port, and TCPStore.cpp's port-only guard forgives the
failure and turns it into a client -- which is precisely what the old code did
directly. The degradation is into a slower path, not into a broken one.

Test Plan:
Two regression tests in test_store.py::RendezvousTCPTest, next to the other
dist.rendezvous("tcp://...") tests and in the same create_tcp_url() /
common.find_free_port() idiom. They are a matched pair on purpose, so that the
fix cannot quietly degrade into deleting the feature:
test_agent_store_ignored_for_other_address sets the agent environment but
points it at a different port and requires the private store to come up and
round-trip a key, while test_agent_store_honored_for_master_address sets it
matching, with nothing listening, and requires a DistNetworkError rather than
some rank silently starting a server.

    python test/distributed/test_store.py -v -k agent_store
    test_agent_store (LibUvTCPStoreTest.test_agent_store) ... ok
    test_agent_store_honored_for_master_address (RendezvousTCPTest...) ... ok
    test_agent_store_ignored_for_other_address (RendezvousTCPTest...) ... ok
    test_agent_store (TCPStoreTest.test_agent_store) ... ok
    Ran 4 tests in 4.175s
    OK

Pre-fix the same selection is 199.719 s and FAILED (errors=1), with
test_agent_store_ignored_for_other_address raising DistNetworkError: The client
socket has timed out after 10000ms while trying to connect to (localhost,
37515). Neither new test is decorated with @retry_on_connect_failures, and that
is deliberate: that helper's default connect_errors=(ADDRESS_IN_USE) is missing
its trailing comma, so it is a plain string rather than a tuple, the membership
test iterates it character by character, and consequently almost any
RuntimeError matches and is retried ten times, each attempt paying its full
timeout. That is what turned the genuine pre-fix failure here into a roughly
190-second hang with the real error buried behind "Failing after 10 retries".
It is a pre-existing wart in common_utils.py whose blast radius covers every
test currently using the decorator, so it is left untouched here and filed
separately.

End-to-end under real torchrun, driven by triage/bug14_private_store_torchrun.py
(stock torch, no vLLM), which can monkeypatch the predicate back to its legacy
form with --legacy so both behaviours are observable on one binary. Two modes:
rendezvous (what vLLM's stateless helper did) and init_pg
(init_process_group(init_method="tcp://..."), the path vLLM cannot bypass):

    torchrun --nproc_per_node=2 --master_port=29502 \
      triage/bug14_private_store_torchrun.py <mode> --port 29783 \
      --store-timeout 15 [--legacy]
    rendezvous --legacy : [rank1] RAISED after 26.1s: DistNetworkError
    rendezvous (fixed)  : [rank0] OK in 0.19s / [rank1] OK in 0.01s,
                          allreduce -> 2.0
    init_pg    --legacy : [rank1] RAISED after 20.8s: DistNetworkError
    init_pg    (fixed)  : [rank0] OK in 0.05s / [rank1] OK in 0.04s,
                          allreduce -> 2.0

With stock timeouts rather than the repro's fifteen seconds the legacy arms
never finish at all. A four-rank env:// run confirms the genuine agent-store
path is untouched: _agent_store_serves reports True on every rank and the
allreduce returns 4.0.

Verified on 4x H100, CUDA 13.0, NCCL 2.29.7, against a freshly rebuilt HEAD:
the pre-existing install predated the commits already landed in this stack, so
unmodified HEAD was rebuilt first to make the before-numbers honest
measurements rather than comparisons against a stale binary. 879 tests across
six suites with zero failures, with only the skips those suites already had:

    test_c10d_nccl.py    Ran 285 tests in 1659.524s  OK (skipped=15)
    test_c10d_gloo.py    Ran 289 tests in 1089.249s  OK (skipped=4)
    test_c10d_nccl2.py   Ran 20 tests in 102.125s    OK
    test_c10d_common.py  Ran 72 tests in 117.529s    OK
    test_store.py        Ran 140 tests in 23.000s    OK (skipped=12)
    test_fake_pg.py      Ran 73 tests in 1.543s      OK

Authored with the assistance of an AI coding agent.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/191957).
* __->__ #191957
* #191956
* #191955
* #191954
* #191953
* #191952
* #191951
* #191950
* #191949
* #191948
* #191782