### PR TITLE
Use index_select for CPU unique_dim row gathering (#191961)

### DIFF
--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -16,6 +16,8 @@
 #include <ATen/ops/_unique_native.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/equal.h>
+#include <ATen/ops/from_blob.h>
+#include <ATen/ops/index_select.h>
 #include <ATen/ops/narrow.h>
 #include <ATen/ops/stack.h>
 #include <ATen/ops/unbind.h>
@@ -416,10 +418,11 @@ std::tuple<Tensor, Tensor, Tensor> _unique_dim_cpu_template(
 
   Tensor input_sorted;
   if (!consecutive) {
-    input_sorted = at::empty(input_flat.sizes(), input_flat.options());
-    for (const auto i : c10::irange(indices.size())) {
-      input_sorted[i] = input_flat[indices[i]];
-    }
+    const auto indices_tensor = at::from_blob(
+        indices.data(),
+        {static_cast<int64_t>(indices.size())},
+        at::kLong);
+    input_sorted = at::index_select(input_flat, 0, indices_tensor);
   } else {
     input_sorted = std::move(input_flat);
   }


### PR DESCRIPTION
Summary:

**Summary**

Unique.cpp implements PyTorch’s CPU operations for removing duplicate tensor values.

The changed function, _unique_dim_cpu_template, handles uniqueness by row or another dimension:

  torch.unique(input, dim=0)

At a high level, it:

  1. Treats every row as one item.
  2. Sorts the rows.
  3. Places them in sorted order.
  4. Removes adjacent duplicate rows.
  5. Optionally calculates counts and inverse positions.

***Change***
Step 3 

Before - copies one row at a time, where each copy repeated PyTorch’s validation, view creation, dispatch, and kernel setup. 

After - use index_select to provide the complete list of positions once, and copies all rows internally

**Details**

`unique_dim` gathers sorted CPU rows with one dispatched `select` and `copy_` per row, paying dispatcher, view construction, and TensorIterator setup for every row.

Wrap the sorted `std::vector<int64_t>` as a borrowed CPU Long tensor and gather the rows with one `index_select`. The CPU call is synchronous, so the vector outlives every read without an index clone. Register the new operator edge for selective builds.

Test Plan:
Passed:

```
arc lint -a caffe2/aten/src/ATen/native/Unique.cpp caffe2/fb/pytorch_op_deps.yaml
arc lint caffe2/aten/src/ATen/native/Unique.cpp caffe2/fb/pytorch_op_deps.yaml
buck2 build //caffe2:ATen-cpu
buck2 test //caffe2/test:torch -- unique_dim --return-nonzero-on-failures --print-passing-details
buck2 test //caffe2/test:test_ops -- --regex '_unique_cpu(_|$)' --return-nonzero-on-failures --return-zero-on-skips
```

The dedicated `unique_dim` test passed. The OpInfo selection completed with 14 passes and 3 expected skips.

Optimized single-thread before/after benchmark, median runtime:

| Rows x width | Parent | Diff | Speedup |
|---|---|---|---|
| 32 x 1 | 34.50 us | 17.45 us | 1.98x |
| 256 x 4 | 249.79 us | 104.56 us | 2.39x |
| 1024 x 4 | 1019.21 us | 405.75 us | 2.51x |
| 4096 x 4 | 4375.11 us | 1880.38 us | 2.33x |
| 256 x 64 | 253.76 us | 107.90 us | 2.35x |
| 256 x 256 | 279.45 us | 135.09 us | 2.07x |

Below 32 - P2448660590

P2445985861


AI-assisted

Reviewed By: ezyang

Differential Revision: D114427208


