### PR TITLE
Strict pyrefly checking: stop emitting `# mypy: ignore-errors` for serialized inductor patterns

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -382,3 +382,13 @@ bad-param-name-override = false
 unannotated-return = true
 unannotated-parameter = true
 unannotated-attribute = true
+
+[[sub-config]]
+matches = "torch/_inductor/fx_passes/serialized_patterns/**"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_1.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_1.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_10.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_10.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_11.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_11.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_12.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_12.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_13.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_13.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_14.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_14.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_15.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_15.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_16.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_16.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_17.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_17.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_18.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_18.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_19.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_19.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_2.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_2.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_20.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_20.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_21.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_21.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_22.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_22.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_23.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_23.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_24.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_24.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_25.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_25.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_26.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_26.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_27.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_27.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_28.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_28.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_29.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_29.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_3.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_3.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_30.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_30.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_4.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_4.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_5.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_5.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_6.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_6.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_7.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_7.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_8.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_8.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_9.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_9.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/addmm_pattern.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/addmm_pattern.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/bmm_pattern.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/bmm_pattern.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/fx_passes/serialized_patterns/mm_pattern.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/mm_pattern.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 # noqa: F401, E501
 # This is an auto-generated file. Please do not modify it by hand.
 # To re-generate, run:

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -2113,8 +2113,6 @@ def _serialize_pattern(
 
         file_template = textwrap.dedent(
             """\
-            # mypy: ignore-errors
-
             # noqa: F401, E501
             {msg}
             import torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #191962

The serialized-pattern generator in torch/_inductor/pattern_matcher.py wrote a
blanket "# mypy: ignore-errors" header into every file it emits under
torch/_inductor/fx_passes/serialized_patterns/. This drops that header from the
generator's file template, updates the 33 already-generated files to match, and
adds a per-directory pyrefly [[sub-config]] glob that turns on whole-file strict
checking for them.

These are auto-generated pattern-definition files -- typed pattern-expression
data with no function definitions -- so they pass strict checking as-is once the
blanket suppression is removed (the "# noqa: F401, E501" line for the unused
imports and long lines is kept).

Test Plan:

```
lintrunner -a torch/_inductor/pattern_matcher.py pyrefly.toml torch/_inductor/fx_passes/serialized_patterns/*.py
pyrefly check   # whole project: 156 errors == baseline, no net-new
```

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo