### PR TITLE
Convert attn_bias to match query dtype before cuDNN attention execution

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1066,6 +1066,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt, Tensor, Ten
     const int64_t head_dim_v = value.size(3);
     auto attn_bias_ = attn_bias;
     if (attn_bias_.has_value()) {
+      if (attn_bias_.value().dtype() != query.dtype()) {
+        attn_bias_ = attn_bias_.value().to(query.dtype());
+      }
       const auto bias_dim = attn_bias_.value().dim();
       if (bias_dim == 2) {
         attn_bias_ = attn_bias_.value().expand({batch_size, 1, max_seqlen_batch_q, max_seqlen_batch_kv});
@@ -1192,6 +1195,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt, Tensor, Ten
     }
     auto attn_bias_ = attn_bias;
     if (attn_bias_.has_value()) {
+      if (attn_bias_.value().dtype() != query.dtype()) {
+        attn_bias_ = attn_bias_.value().to(query.dtype());
+      }
       const auto bias_dim = attn_bias_.value().dim();
       if (bias_dim == 2) {
         attn_bias_ = attn_bias_.value().expand({batch_size, 1, max_seqlen_batch_q, max_seqlen_batch_kv});

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -262,7 +262,9 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_attention_backward(
       // std::optional to undefined tensor
       std::optional<Tensor> attn_bias_;
       if (attn_bias.defined()) {
-        attn_bias_ = attn_bias;
+        attn_bias_ = attn_bias.dtype() != query.dtype()
+            ? attn_bias.to(query.dtype())
+            : attn_bias;
       }
       if (attn_bias_.has_value()) {
         const auto bias_dim = attn_bias_.value().dim();
@@ -312,7 +314,9 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_attention_backward(
       const int64_t head_dim_v = value.size(-1);
       std::optional<Tensor> attn_bias_;
       if (attn_bias.defined()) {
-        attn_bias_ = attn_bias;
+        attn_bias_ = attn_bias.dtype() != query.dtype()
+            ? attn_bias.to(query.dtype())
+            : attn_bias;
       }
       if (attn_bias_.has_value()) {
         const auto bias_dim = attn_bias_.value().dim();


### PR DESCRIPTION
Fixes `AssertionError: tensor(False, device='cuda:0') is not true : non-finite output for a torch.float32 mask` in `TestSDPACudaOnlyCUDA.test_cudnn_attention_attn_mask_dtype`.

```python
"/third_party/py/torch/test/test_transformers.py", line 3951, in test_cudnn_attention_attn_mask_dtype
    self.assertTrue(out.isfinite().all(), f"non-finite output for a {m.dtype} mask")
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/<embedded stdlib>/unittest/case.py", line 762, in assertTrue
    raise self.failureException(msg)
AssertionError: tensor(False, device='cuda:0') is not true : non-finite output for a torch.float32 mask
```
  
  While PyTorch's `scaled_dot_product_attention` accepts an attention mask/bias of dtype `torch.float32` alongside low-precision (`torch.float16` / `torch.bfloat16`) query/key/value tensors, cuDNN's GPU Flash Attention kernels require that the `attn_bias` buffer in global memory match the graph I/O data type (`float16` or `bfloat16`). Previously, when a `torch.float32` mask was passed to `_scaled_dot_product_cudnn_attention` without conversion, the GPU kernel reinterpreted the 32-bit float buffer in memory as 16-bit half/bfloat16 elements, producing non-finite outputs (`NaN` / `Inf`) and silently incorrect gradients.
