### PR TITLE
[CI] Enable Claude execution logs

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -36,6 +36,9 @@ jobs:
         }}
       # Surface stalled Bedrock requests before the one-hour job timeout.
       settings: '{"alwaysThinkingEnabled":true,"env":{"API_TIMEOUT_MS":"180000","CLAUDE_CODE_MAX_RETRIES":"2","CLAUDE_ENABLE_STREAM_WATCHDOG":"1"}}'
+      # These logs are public and may include assistant messages and tool output.
+      show_full_output: true
+      upload_execution_log: true
       append_system_prompt: |
         When asked to review a PR, always use the /pr-review skill first.
         It contains PyTorch-specific review guidelines, output format, and critical checks.


### PR DESCRIPTION
Human Note

Wire up the logs

Agent note

> This PR was prepared with an AI assistant.
>
> The reusable test-infra workflow now supports streaming complete Claude events and archiving the completed execution trace. Enable both options for PyTorch so long-running reviews expose live progress and completed runs populate the public trace archive. The caller includes an explicit warning because assistant messages and tool output may be public.
>
> A hard job timeout can still prevent the final JSON upload, but events already streamed to the Actions log remain available.

Test Plan:

```bash
PATH="$HOME/.venvs/dev/bin:$PATH" lintrunner -a
git diff --check
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-code.yml"); puts "YAML OK"'
```
