### PR TITLE
[BE][MPS] Remove unused kernel parameters

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -1215,7 +1215,6 @@ kernel void scatter_nonzero_indices(
     constant uint& block_base [[buffer(7)]],
     uint tid [[thread_position_in_grid]],
     uint tgid [[threadgroup_position_in_grid]],
-    uint lid [[thread_position_in_threadgroup]],
     uint tgsize [[threads_per_threadgroup]],
     uint simd_lane_id [[thread_index_in_simdgroup]],
     uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
@@ -1315,7 +1314,6 @@ kernel void scatter_nonzero_indices(
       constant uint& block_base [[buffer(7)]],                \
       uint tid [[thread_position_in_grid]],                   \
       uint tgid [[threadgroup_position_in_grid]],             \
-      uint lid [[thread_position_in_threadgroup]],            \
       uint tgsize [[threads_per_threadgroup]],                \
       uint simd_lane_id [[thread_index_in_simdgroup]],        \
       uint simd_group_id [[simdgroup_index_in_threadgroup]])


### PR DESCRIPTION
Fixes
```
Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/Indexing.metal:1218:10: warning: unused parameter 'lid' [-Wunused-parameter]
    uint lid [[thread_position_in_threadgroup]],
         ^
1 warning generated.
```