### PR TITLE
[macOS] Detect conflicting OpenMP runtimes

### DIFF
--- a/test/test_openmp.py
+++ b/test/test_openmp.py
@@ -1,7 +1,9 @@
 # Owner(s): ["module: unknown"]
 
 import collections
+import sys
 import unittest
+from unittest import mock
 
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -17,6 +19,35 @@ except ModuleNotFoundError:
 
 
 device = torch.device("cpu")
+
+
+class TestOpenMP(TestCase):
+    def test_find_openmp_lib(self):
+        with mock.patch.object(
+            torch, "_get_loaded_openmp_libraries", return_value=("/tmp/libomp.dylib",)
+        ):
+            self.assertEqual(
+                torch.backends.openmp.find_openmp_lib(), "/tmp/libomp.dylib"
+            )
+
+    def test_find_openmp_lib_rejects_multiple_runtimes(self):
+        libraries = ("/tmp/first/libomp.dylib", "/tmp/second/libomp.dylib")
+        with mock.patch.object(
+            torch, "_get_loaded_openmp_libraries", return_value=libraries
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Multiple OpenMP runtimes"):
+                torch.backends.openmp.find_openmp_lib()
+
+    @unittest.skipUnless(sys.platform == "darwin", "macOS-only OpenMP resolution")
+    def test_inductor_links_loaded_openmp_runtime(self):
+        from torch._inductor import cpp_builder
+
+        path = "/tmp/loaded/libomp.dylib"
+        with mock.patch.object(
+            torch.backends.openmp, "find_openmp_lib", return_value=path
+        ):
+            openmp_args = cpp_builder._get_openmp_args("/usr/bin/clang++")
+        self.assertEqual(openmp_args[4], [path])
 
 
 class Network(torch.nn.Module):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -162,6 +162,39 @@ if __all__ != sorted(__all__):
 # Load the extension module
 ################################################################################
 
+
+def _get_loaded_openmp_libraries() -> tuple[str, ...]:
+    if sys.platform != "darwin":
+        return ()
+
+    libdyld = ctypes.CDLL("/usr/lib/libSystem.B.dylib")
+    libdyld._dyld_image_count.restype = ctypes.c_uint32
+    libdyld._dyld_get_image_name.argtypes = [ctypes.c_uint32]
+    libdyld._dyld_get_image_name.restype = ctypes.c_char_p
+
+    libraries: list[str] = []
+    for i in builtins.range(libdyld._dyld_image_count()):
+        image_name = libdyld._dyld_get_image_name(i)
+        if image_name is None:
+            continue
+        path = os.fsdecode(image_name)
+        name = os.path.basename(path)
+        if name.endswith(".dylib") and name.startswith(("libomp", "libiomp")):
+            libraries.append(os.path.realpath(path))
+    return tuple(dict.fromkeys(libraries))
+
+
+def _find_openmp_lib() -> str | None:
+    libraries = _get_loaded_openmp_libraries()
+    if len(libraries) > 1:
+        paths = "\n  ".join(libraries)
+        raise RuntimeError(
+            "Multiple OpenMP runtimes were loaded into the process. This can cause "
+            f"crashes or incorrect results:\n  {paths}"
+        )
+    return libraries[0] if libraries else None
+
+
 # If PyTorch was built against the ROCm runtime wheels, then there will be
 # a _rocm_init module and it will define an initialize() function which can
 # prepare ROCm for use. See general documentation on ROCm runtime wheels:
@@ -543,6 +576,10 @@ def _load_global_deps() -> None:
         ctypes.CDLL(global_deps_lib_path, mode=ctypes.RTLD_GLOBAL)
 
 
+# Check before and after loading the native libraries so an existing collision is
+# reported before PyTorch uses OpenMP and a collision introduced by dyld is caught.
+_find_openmp_lib()
+
 if (USE_RTLD_GLOBAL_WITH_LIBTORCH or os.getenv("TORCH_USE_RTLD_GLOBAL")) and (
     platform.system() != "Windows"
 ):
@@ -583,6 +620,9 @@ else:
     if USE_GLOBAL_DEPS:
         _load_global_deps()
     from torch._C import *  # noqa: F403
+
+
+_find_openmp_lib()
 
 
 _PrimType = _TypeVar("_PrimType")

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1548,8 +1548,12 @@ def _get_openmp_args(
         cflags.append("Xclang")
         cflags.append("fopenmp")
 
+        loaded_openmp = torch.backends.openmp.find_openmp_lib()
+        if loaded_openmp is not None:
+            libs.append(loaded_openmp)
+
         # only Apple builtin compilers (Apple Clang++) require openmp
-        omp_available = not _is_apple_clang(cpp_compiler)
+        omp_available = loaded_openmp is not None or not _is_apple_clang(cpp_compiler)
 
         # check the `OMP_PREFIX` environment first
         omp_prefix = os.getenv("OMP_PREFIX")
@@ -2503,6 +2507,8 @@ class CppBuilder:
         for lib in BuildOption.get_libraries():
             if _IS_WINDOWS:
                 self._libraries_args += f'"{lib}.lib" '
+            elif os.path.isabs(lib):
+                self._libraries_args += f"{shlex.quote(lib)} "
             else:
                 self._libraries_args += f"-l{lib} "
 

--- a/torch/backends/openmp/__init__.py
+++ b/torch/backends/openmp/__init__.py
@@ -5,3 +5,12 @@ import torch
 def is_available():
     r"""Return whether PyTorch is built with OpenMP support."""
     return torch._C.has_openmp
+
+
+def find_openmp_lib() -> str | None:
+    r"""Return the loaded OpenMP runtime path, or ``None`` if none is loaded.
+
+    Raises:
+        RuntimeError: If multiple OpenMP runtimes are loaded in the process.
+    """
+    return torch._find_openmp_lib()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

PyTorch and another native Python package can resolve libomp through different paths, causing dyld to load multiple OpenMP runtimes into one process. The runtimes then corrupt each other's worker-thread state and eventually crash in libomp.

Enumerate dyld images before and after loading torch._C and fail with the conflicting paths when more than one LLVM or Intel OpenMP runtime is present. Expose the selected runtime through torch.backends.openmp and make Inductor link that exact library rather than independently selecting a Conda or Homebrew installation. Keep the existing @rpath packaging behavior so dyld can continue to reuse an already loaded compatible runtime.

Authored with assistance from an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo