### PR TITLE
[CUDA] Remove cuBLAS grouped_gemm row/col swap workaround

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -2246,10 +2246,8 @@ void grouped_gemm(
   auto ltworkspace = CublasLtWorkspace();
   auto stream = at::cuda::getCurrentCUDAStream();
   preference.setAttribute(CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, ltworkspace.size);
-  // As of CUDA 13.3u1, cuBLASLt grouped GEMM heuristics return suboptimal algos when inputs are row major
-  // Swap average rows and cols to recover optimal kernels, and update this once fixed in cuBLASLt
-  preference.setAttribute(CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_ROWS, avgN);
-  preference.setAttribute(CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_COLS, avgM);
+  preference.setAttribute(CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_ROWS, avgM);
+  preference.setAttribute(CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_COLS, avgN);
   preference.setAttribute(CUBLASLT_MATMUL_PREF_GROUPED_AVERAGE_REDUCTION_DIM, avgK);
 
   cublasLtMatmulHeuristicResult_t heuristicResult = {};


### PR DESCRIPTION
cuBLAS released a [patch](https://docs.nvidia.com/cuda/cublas-patch-release-notes/#cublas-patch-release-13-6-1) that fixes the grouped GEMM heuristic with row major inputs, so the row/col switch workaround is no longer needed.

cc @eqy