### PR TITLE
[inductor] Simplify the sub-parent epilogue implementation

### DIFF
--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -107,12 +107,6 @@ class CUDACombinedScheduling(BaseScheduling):
             return self._nv_universal_gemm_scheduling.can_fuse_vertical(node1, node2)
         return self._triton_scheduling.can_fuse_vertical(node1, node2)
 
-    def can_fuse_nested_reduction_append(
-        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
-    ) -> bool:
-        # Fused nested reductions are Triton-only, so skip the template ladder.
-        return self._triton_scheduling.can_fuse_nested_reduction_append(node1, node2)
-
     def can_fuse_horizontal(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1520,6 +1520,23 @@ RemappedRangeValue = (
 )
 
 
+class _SubParentFusionDecision(NamedTuple):
+    """Everything one sub-parent plan build tells ``SIMDScheduling.can_fuse``."""
+
+    # The consumer's output would not be a leaf of the fused group: reject the
+    # pair outright, before any other branch.
+    leaf_violation: bool
+    # Every node of the consumer is an epilogue of a fully legal plan: accept
+    # the pair without consulting the numel/rnumel ladder.
+    consumer_is_planned_epilogue: bool
+
+
+# Default for ``SIMDScheduling._codegen_nodes``' plan argument, distinguishing
+# "the caller has not looked for a sub-parent epilogue plan" from "the caller
+# looked and there is none".
+_PLAN_NOT_SEARCHED: Any = object()
+
+
 def _select_lane(
     parts: tuple[CSEVariable, ...],
     lane: sympy.Expr,
@@ -1560,8 +1577,7 @@ def _resolve_remapped_value(
         if part is not None:
             return part
         raise AssertionError(
-            "sub-parent planner invariant violated: contiguous load "
-            f"for {name!r} has non-constant lane for index {index}"
+            f"contiguous load for {name!r} has non-constant lane for index {index}"
         )
     if not isinstance(value, tuple):
         return value
@@ -1569,10 +1585,7 @@ def _resolve_remapped_value(
     part = _select_lane(value, lane)
     if part is not None:
         return part
-    raise AssertionError(
-        "sub-parent planner invariant violated: "
-        f"load for {name!r} has non-constant lane {lane}"
-    )
+    raise AssertionError(f"load for {name!r} has non-constant lane {lane}")
 
 
 @dataclasses.dataclass
@@ -1645,6 +1658,23 @@ class _DerivedIterationFamily:
         self.ensure_headers(kernel)
         with kernel.use_range_trees(self.range_trees):
             yield
+
+
+@dataclasses.dataclass(frozen=True)
+class _SubParentStage:
+    """The sub-parent lane stage of a nested reduction, when there is one.
+
+    Present exactly when some fused pointwise node was classified onto the
+    PARENT_HALF domain. The three members are derived together from that one
+    fact and are meaningless apart -- the iteration family the stage runs in,
+    the source domain its bodies are remapped from, and the lane layout the
+    planner assigned to each full-resolution source it loads -- so they travel
+    as one optional instead of three that must be checked in lockstep.
+    """
+
+    family: _DerivedIterationFamily
+    source: _IterationSpace
+    source_layouts: dict[str, scheduler.NestedReduction.SubParentSourceLayout]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1795,6 +1825,12 @@ class _GroupedReductionLayout:
         )
 
     def parent_dim(self, value: CSEVariable) -> str | None:
+        """Extent of the grouped axis of ``value``, or None if it has no tile shape.
+
+        Compare the result against a block string (``parent_block``,
+        ``child_block(factor)``) to ask whether the grouped axis is that shape.
+        A 1-D tile counts when the passthrough axis is trivial.
+        """
         shape = getattr(value, "shape", None)
         if shape is None:
             return None
@@ -1805,26 +1841,6 @@ class _GroupedReductionLayout:
         ):
             return str(shape[0])
         return None
-
-    def _is_axis_tile_shaped(self, value: CSEVariable, block: str) -> bool:
-        # The grouped axis matches `block` (2-D tile), or a 1-D tile when the
-        # passthrough axis is trivial.
-        shape = getattr(value, "shape", None)
-        if shape is None:
-            return False
-        if len(shape) == 2:
-            return str(shape[self.parent_axis]) == block
-        return (
-            len(shape) == 1
-            and V.graph.sizevars.statically_known_equals(self.passthrough_tree.numel, 1)
-            and str(shape[0]) == block
-        )
-
-    def is_parent_tile_shaped(self, value: CSEVariable) -> bool:
-        return self._is_axis_tile_shaped(value, self.parent_block)
-
-    def is_child_tile_shaped(self, value: CSEVariable, factor: int) -> bool:
-        return self._is_axis_tile_shaped(value, self.child_block(factor))
 
     def construct_group_reduction_vars(
         self,
@@ -2046,7 +2062,7 @@ class _GroupedReductionLayout:
         if parent_dim is None or parent_dim == "1":
             family.remapped_values[name] = value
             return True
-        if self.is_child_tile_shaped(value, factor):
+        if parent_dim == self.child_block(factor):
             family.remapped_values[name] = value
             return True
         if parent_dim != self.parent_block:
@@ -2059,8 +2075,6 @@ class _GroupedReductionLayout:
                 elems_per_group=str(FloorDiv(self.local_reduction_size_sym, factor)),
             )
             return True
-        if not self.is_parent_tile_shaped(value):
-            return False
         if source_layout is None:
             return False
         source_layout_kind = scheduler.NestedReduction.SubParentSourceLayout
@@ -2077,17 +2091,17 @@ class _GroupedReductionLayout:
         )
         part_names = tuple(map(str, parts))
         if source_layout is source_layout_kind.CONTIGUOUS:
-            reshape_shape = (*prefix, factor_dim, child_block)
-            permute_dims = (0, 2, 1) if prefix else (1, 0)
-            kernel.emit_split_via_reshape_permute(
-                value, reshape_shape, permute_dims, part_names
+            kernel.emit_split_via_reshape(
+                value,
+                (*prefix, factor_dim, child_block),
+                part_names,
+                permute_dims=(0, 2, 1) if prefix else (1, 0),
             )
             family.remapped_values[name] = _ContiguousSubParentRemappedValue(
                 parts,
                 self.local_reduction_size,
             )
         else:
-            assert source_layout is source_layout_kind.INTERLEAVED  # noqa: S101
             kernel.emit_split_via_reshape(
                 value, (*prefix, child_block, factor_dim), part_names
             )
@@ -2308,11 +2322,11 @@ class _SubParentPointwiseRemapHandler(_PointwiseRemapHandler):
         layout: _GroupedReductionLayout,
         source_layouts: dict[str, scheduler.NestedReduction.SubParentSourceLayout],
         sub_parent_factor: int,
-        must_materialize_names: OrderedSet[str] | None = None,
+        must_materialize_names: OrderedSet[str],
     ):
         super().__init__(inner, kernel=kernel, family=family)
         self._layout = layout
-        self._must_materialize_names = must_materialize_names or OrderedSet()
+        self._must_materialize_names = must_materialize_names
         self._source_layouts = source_layouts
         self._sub_parent_factor = sub_parent_factor
 
@@ -2329,13 +2343,8 @@ class _SubParentPointwiseRemapHandler(_PointwiseRemapHandler):
         if not required:
             return
         value = self._kernel.cse.store_cache.get(name)
-        if value is None:
-            raise AssertionError(
-                f"sub-parent stage could not materialize required buffer {name!r}"
-            )
-
         triton_kernel = cast("TritonKernel", self._kernel)
-        materialized = self._layout.materialize_value_at_sub_parent_resolution(
+        if value is None or not self._layout.materialize_value_at_sub_parent_resolution(
             triton_kernel,
             self._family,
             self._sub_parent_factor,
@@ -2343,14 +2352,10 @@ class _SubParentPointwiseRemapHandler(_PointwiseRemapHandler):
             value,
             source_layout,
             allow_reduced_broadcast=name in self._must_materialize_names,
-        )
-        if materialized:
-            return
-
-        raise AssertionError(
-            "sub-parent planner did not provide a usable layout for required "
-            f"buffer {name!r}"
-        )
+        ):
+            raise AssertionError(
+                f"sub-parent stage could not materialize required buffer {name!r}"
+            )
 
     def load(self, name: str, index: sympy.Expr) -> CSEVariable:
         self._materialize_sub_parent_load(name)
@@ -2390,8 +2395,7 @@ class _SubParentSourceLoadMaterializer(WrapperHandler):  # type: ignore[type-arg
         )
         if not materialized:
             raise AssertionError(
-                "sub-parent planner invariant violated: could not materialize "
-                f"planned parent-tile load for {name!r}"
+                f"could not materialize planned parent-tile load for {name!r}"
             )
         return value
 
@@ -2423,9 +2427,20 @@ class SIMDScheduling(BaseScheduling):
         _, (numel2, rnumel2) = node2.group
         why = WhyNoFuse(node1, node2)
 
-        if self._sub_parent_epilogue_leaf_violation(node1, node2):
+        # One plan build answers both sub-parent questions this function asks:
+        # the leaf check here, and the "is this consumer a planned epilogue"
+        # test at the very bottom.
+        sub_parent = self._sub_parent_epilogue_decision(node1, node2)
+        if sub_parent.leaf_violation:
             why("sub-parent epilogue output must be a leaf")
             return False
+
+        if isinstance(node1, scheduler.FusedNestedReductions):
+            # Legality for appending into a nested-reduction group is decided by
+            # FusedNestedReductions.can_fuse_with; the numel/rnumel ladder below
+            # cannot model a group that owns two iteration spaces, and the
+            # template rungs above it are no-ops for a FusedSchedulerNode.
+            return True
 
         if node1.is_split_scan() and not node2.is_split_scan():
             if node2.is_reduction():
@@ -2591,36 +2606,17 @@ class SIMDScheduling(BaseScheduling):
             raise AssertionError(
                 "expected node1 to be a reduction and node2 not a reduction"
             )
-        if self._can_fuse_sub_parent_reduction_epilogue(node1, node2):
+        # node1 is the reduction and node2 the consumer here (asserted just
+        # above), which is exactly the role assignment
+        # _sub_parent_epilogue_decision made at the top of this function, so its
+        # plan covers this pair.
+        if sub_parent.consumer_is_planned_epilogue:
             return True
         # swap args to hit the case above
         return self.can_fuse_horizontal(node2, node1)
 
     can_fuse_vertical = can_fuse
     can_fuse_horizontal = can_fuse
-
-    def can_fuse_nested_reduction_append(
-        self,
-        node1: scheduler.BaseSchedulerNode,
-        node2: scheduler.BaseSchedulerNode,
-    ) -> bool:
-        why = WhyNoFuse(node1, node2)
-        if self._sub_parent_epilogue_leaf_violation(node1, node2):
-            why("sub-parent epilogue output must be a leaf")
-            return False
-        return True
-
-    def _can_fuse_sub_parent_reduction_epilogue(
-        self,
-        reduction_node: scheduler.BaseSchedulerNode,
-        consumer_node: scheduler.BaseSchedulerNode,
-    ) -> bool:
-        _, (numel, rnumel) = reduction_node.group
-        nodes = [*reduction_node.get_nodes(), *consumer_node.get_nodes()]
-        plan = self._sub_parent_epilogue_plan(nodes, numel, rnumel)
-        return plan is not None and all(
-            node in plan.epilogue_nodes for node in consumer_node.get_nodes()
-        )
 
     @staticmethod
     def _is_sub_parent_shaped(
@@ -2644,38 +2640,44 @@ class SIMDScheduling(BaseScheduling):
             or V.graph.sizevars.statically_known_equals(node_numel, numel * rnumel)
         )
 
-    def _sub_parent_epilogue_leaf_violation(
+    def _sub_parent_epilogue_decision(
         self,
         node1: scheduler.BaseSchedulerNode,
         node2: scheduler.BaseSchedulerNode,
-    ) -> bool:
-        """Reject non-leaf consumers of a sub-parent epilogue.
+    ) -> _SubParentFusionDecision:
+        """Both sub-parent answers ``can_fuse`` needs, from one plan build.
 
-        Sub-parent stores are emitted last in the kernel, so another stage that
-        reads such a buffer would load it before the store (read-before-write).
-        Full-resolution siblings are also not modeled by this standalone path;
-        keep them in a separate kernel.
-        A consumer can reach the group through the ordinary reduction-epilogue
-        path (the swapped ``can_fuse``), so this is gated here, before any branch,
-        and checks both arg orders via the combined node set.
+        ``consumer_is_planned_epilogue`` is the accept side: every node of the
+        consumer is an epilogue of a fully legal plan.
+
+        ``leaf_violation`` is the reject side. Sub-parent stores are emitted
+        last in the kernel, so another stage that reads such a buffer would load
+        it before the store (read-before-write). Full-resolution siblings are
+        also not modeled by this standalone path; keep them in a separate
+        kernel. A consumer can reach the group through the ordinary
+        reduction-epilogue path (the swapped ``can_fuse``), so this is evaluated
+        before any branch and checks both arg orders via the combined node set.
         """
         if (
             not self.supports_sub_parent_epilogue
             or not torch._inductor.config.triton.nested_reduction
         ):
-            return False
+            return _SubParentFusionDecision(False, False)
         if node1.is_reduction() == node2.is_reduction():
-            return False
+            return _SubParentFusionDecision(False, False)
         reduction_node = node1 if node1.is_reduction() else node2
         consumer_node = node2 if node1.is_reduction() else node1
         _, (numel, rnumel) = reduction_node.group
         nodes = [*node1.get_nodes(), *node2.get_nodes()]
-        complete_plan = self._sub_parent_epilogue_plan(nodes, numel, rnumel)
-        if complete_plan is not None and all(
-            node in complete_plan.epilogue_nodes for node in consumer_node.get_nodes()
+        # `leaves_ok` is the full-legality answer and the plan itself is the
+        # loose one the rest of this function needs, so build it once.
+        plan = self._sub_parent_epilogue_plan(nodes, numel, rnumel)
+        if (
+            plan is not None
+            and plan.leaves_ok
+            and all(node in plan.epilogue_nodes for node in consumer_node.get_nodes())
         ):
-            return False
-        plan = self._sub_parent_epilogue_plan(nodes, numel, rnumel, check_leaves=False)
+            return _SubParentFusionDecision(False, True)
         if plan is None:
             # No sub-parent plan covers the combined set, so a sub-parent-shaped
             # member would reach generic tiling and scheduling, neither of which
@@ -2685,9 +2687,10 @@ class SIMDScheduling(BaseScheduling):
             if isinstance(node1, scheduler.FusedNestedReductions) or isinstance(
                 node2, scheduler.FusedNestedReductions
             ):
-                return False
-            return any(
-                self._is_sub_parent_shaped(node, numel, rnumel) for node in nodes
+                return _SubParentFusionDecision(False, False)
+            return _SubParentFusionDecision(
+                any(self._is_sub_parent_shaped(node, numel, rnumel) for node in nodes),
+                False,
             )
         epilogue_nodes = plan.epilogue_nodes
         assert self.scheduler is not None  # noqa: S101
@@ -2711,24 +2714,27 @@ class SIMDScheduling(BaseScheduling):
         if not nested_reduction._sub_parent_epilogue_source_loads_are_unambiguous(
             nodes, epilogue_node_set, planned_source_deps, renames
         ):
-            return True
+            return _SubParentFusionDecision(True, False)
         if not nested_reduction._sub_parent_epilogue_outputs_unread(
             nodes, epilogue_node_set, renames
         ):
-            return True
+            return _SubParentFusionDecision(True, False)
         parent_source_names = OrderedSet(
             renames.get(dep.name, dep.name)
             for node in nodes
             if node.is_reduction()
             for dep in node.read_writes.reads
         )
-        return not nested_reduction._sub_parent_siblings_are_source_free(
-            nodes,
-            epilogue_node_set,
-            numel,
-            parent_source_names,
-            renames,
-            reject_group_mismatch=True,
+        return _SubParentFusionDecision(
+            not nested_reduction._sub_parent_siblings_are_source_free(
+                nodes,
+                epilogue_node_set,
+                numel,
+                parent_source_names,
+                renames,
+                reject_group_mismatch=True,
+            ),
+            False,
         )
 
     def _sub_parent_epilogue_plan(
@@ -2736,8 +2742,6 @@ class SIMDScheduling(BaseScheduling):
         nodes: Sequence[BaseSchedulerNode],
         numel: sympy.Expr,
         rnumel: sympy.Expr,
-        *,
-        check_leaves: bool = True,
     ) -> scheduler.NestedReduction.SubParentEpiloguePlan | None:
         if (
             not self.supports_sub_parent_epilogue
@@ -2746,9 +2750,17 @@ class SIMDScheduling(BaseScheduling):
             return None
         if not self._sub_parent_tiling_is_2d(nodes, numel, rnumel):
             return None
-        return scheduler.NestedReduction.sub_parent_epilogue_plan(
-            nodes, numel, rnumel, check_leaves=check_leaves
-        )
+        return scheduler.NestedReduction.sub_parent_epilogue_plan(nodes, numel, rnumel)
+
+    def _complete_sub_parent_epilogue_plan(
+        self,
+        nodes: Sequence[BaseSchedulerNode],
+        numel: sympy.Expr,
+        rnumel: sympy.Expr,
+    ) -> scheduler.NestedReduction.SubParentEpiloguePlan | None:
+        """``_sub_parent_epilogue_plan`` with the leaf constraints enforced."""
+        plan = self._sub_parent_epilogue_plan(nodes, numel, rnumel)
+        return plan if plan is not None and plan.leaves_ok else None
 
     def _sub_parent_tiling_is_2d(
         self,
@@ -2784,7 +2796,7 @@ class SIMDScheduling(BaseScheduling):
             if not node.is_reduction():
                 continue
             _, (numel, rnumel) = node.group
-            plan = self._sub_parent_epilogue_plan(nodes, numel, rnumel)
+            plan = self._complete_sub_parent_epilogue_plan(nodes, numel, rnumel)
             if plan is not None:
                 return plan, numel, rnumel
         return None
@@ -3305,20 +3317,19 @@ class SIMDScheduling(BaseScheduling):
             parent_full_source: _IterationSpace = layout.parent_full_iteration_values(
                 group_reduction_vars
             )
-            parent_half_family: _DerivedIterationFamily | None = None
-            parent_half_source: _IterationSpace | None = None
-            sub_parent_source_layouts: dict[
-                str, scheduler.NestedReduction.SubParentSourceLayout
-            ] = {}
+            sub_parent_stage: _SubParentStage | None = None
             if any(
                 domain is scheduler.NestedReduction.PointwiseDomain.PARENT_HALF
                 for domain in pointwise_domain_by_node.values()
             ):
                 parent_half_family = layout.make_sub_parent_family(parent_half_factor)
-                parent_half_source = layout.sub_parent_iteration_values(
-                    parent_half_family, parent_half_factor
+                sub_parent_stage = _SubParentStage(
+                    parent_half_family,
+                    layout.sub_parent_iteration_values(
+                        parent_half_family, parent_half_factor
+                    ),
+                    node.parent_half_source_layouts,
                 )
-                sub_parent_source_layouts = node.parent_half_source_layouts
             self._codegen_remapped_pointwise(
                 kernel,
                 outer_local_reduction_pointwise,
@@ -3337,20 +3348,17 @@ class SIMDScheduling(BaseScheduling):
                 pointwise_domain_by_node,
                 reduced_output_family,
                 parent_full_family,
-                parent_half_family,
-                sub_parent_source_layouts,
+                sub_parent_stage,
             )
             if grouped_parent_half_pointwise:
-                assert parent_half_family is not None  # noqa: S101
-                assert parent_half_source is not None  # noqa: S101
-                assert sub_parent_source_layouts is not None  # noqa: S101
+                assert sub_parent_stage is not None  # noqa: S101
                 self._codegen_sub_parent_pointwise(
                     kernel,
                     grouped_parent_half_pointwise,
                     layout,
-                    parent_half_family,
-                    parent_half_source,
-                    source_layouts=sub_parent_source_layouts,
+                    sub_parent_stage.family,
+                    sub_parent_stage.source,
+                    source_layouts=sub_parent_stage.source_layouts,
                     sub_parent_factor=parent_half_factor,
                     must_materialize_names=node.sub_parent_broadcast_source_names,
                 )
@@ -3411,11 +3419,7 @@ class SIMDScheduling(BaseScheduling):
         ],
         reduced_output_family,
         parent_full_family,
-        parent_half_family: _DerivedIterationFamily | None = None,
-        parent_half_source_layouts: dict[
-            str, scheduler.NestedReduction.SubParentSourceLayout
-        ]
-        | None = None,
+        sub_parent_stage: _SubParentStage | None = None,
     ) -> None:
         """Interpret the local reduction schedule with nested emitters.
 
@@ -3448,8 +3452,7 @@ class SIMDScheduling(BaseScheduling):
                     layout,
                     group_reduction_vars,
                     reduced_output_family,
-                    parent_half_family=parent_half_family,
-                    source_layouts=parent_half_source_layouts,
+                    sub_parent_stage=sub_parent_stage,
                 )
                 continue
             domain = pointwise_domain_by_node.get(sn)
@@ -3525,9 +3528,7 @@ class SIMDScheduling(BaseScheduling):
         layout: _GroupedReductionLayout,
         group_reduction_vars: _GroupedReductionVars,
         reduced_output_family,
-        parent_half_family: _DerivedIterationFamily | None = None,
-        source_layouts: dict[str, scheduler.NestedReduction.SubParentSourceLayout]
-        | None = None,
+        sub_parent_stage: _SubParentStage | None = None,
     ) -> None:
         grouped_reduction_body = grouped_reduction._body
         load_transform = _ParentFullLoadTransform(kernel, layout)
@@ -3538,14 +3539,13 @@ class SIMDScheduling(BaseScheduling):
             family=reduced_output_family,
             load_transform=load_transform,
         )
-        if parent_half_family is not None:
-            assert source_layouts is not None  # noqa: S101
+        if sub_parent_stage is not None:
             handler = _SubParentSourceLoadMaterializer(
                 handler,
                 kernel,
                 layout,
-                parent_half_family,
-                source_layouts=source_layouts,
+                sub_parent_stage.family,
+                source_layouts=sub_parent_stage.source_layouts,
                 sub_parent_factor=scheduler.NestedReduction.PARENT_HALF_FACTOR,
             )
         with V.set_ops_handler(handler), kernel.set_current_node(grouped_reduction):
@@ -3564,7 +3564,7 @@ class SIMDScheduling(BaseScheduling):
         sub_parent_source: _IterationSpace,
         source_layouts: dict[str, scheduler.NestedReduction.SubParentSourceLayout],
         sub_parent_factor: int,
-        must_materialize_names: OrderedSet[str] | None = None,
+        must_materialize_names: OrderedSet[str],
     ) -> None:
         with sub_parent_family.activate(kernel):
             handler = _SubParentPointwiseRemapHandler(
@@ -3659,6 +3659,10 @@ class SIMDScheduling(BaseScheduling):
         self,
         nodes: Sequence[scheduler.SchedulerNode],
         coalesce_analysis: CoalesceVarAnalysis | None = None,
+        sub_parent_epilogue: tuple[
+            scheduler.NestedReduction.SubParentEpiloguePlan, sympy.Expr, sympy.Expr
+        ]
+        | None = _PLAN_NOT_SEARCHED,
     ):
         if not self.scheduler:
             raise AssertionError("expected self.scheduler to be set")
@@ -3667,7 +3671,8 @@ class SIMDScheduling(BaseScheduling):
         ]
         if not nodes:
             return
-        sub_parent_epilogue = self._find_sub_parent_epilogue_plan(nodes)
+        if sub_parent_epilogue is _PLAN_NOT_SEARCHED:
+            sub_parent_epilogue = self._find_sub_parent_epilogue_plan(nodes)
         if sub_parent_epilogue is not None:
             sub_parent_epilogue_plan, numel, rnumel = sub_parent_epilogue
             return self._codegen_reduction_with_sub_parent_epilogue(
@@ -3681,6 +3686,50 @@ class SIMDScheduling(BaseScheduling):
         return self.codegen_node_schedule(
             SIMDKernelFeatures(node_schedule, numel, rnumel, coalesce_analysis)
         )
+
+    @staticmethod
+    def _defer_sub_parent_source_chain(
+        parent_nodes: list[BaseSchedulerNode],
+        internal_source_names: OrderedSet[str],
+        numel: sympy.Expr,
+        rnumel: sympy.Expr,
+    ) -> list[BaseSchedulerNode]:
+        """Keep the source chain last so a looped kernel emits it and the
+        derived epilogue together in the final reduction loop.
+
+        Only nodes that feed one of the internally produced sources, are not
+        themselves needed by the reduction, and fit the parent tile can move.
+        The move is refused outright if anything left ahead of them still
+        depends on them, so the returned order is always a valid schedule.
+        """
+        source_ancestors = OrderedSet(
+            name
+            for node in parent_nodes
+            if internal_source_names & node.get_buffer_names()
+            for name in (*node.ancestors, *node.get_operation_names())
+        )
+        reduction_ancestors = OrderedSet(
+            name
+            for node in parent_nodes
+            if node.is_reduction()
+            for name in node.ancestors
+        )
+        deferred_nodes = [
+            node
+            for node in parent_nodes
+            if not node.is_reduction()
+            and node.get_operation_names() & source_ancestors
+            and not node.get_operation_names() & reduction_ancestors
+            and SIMDKernel.is_compatible((numel, rnumel), node.get_ranges())
+        ]
+        deferred_names = OrderedSet(
+            name for node in deferred_nodes for name in node.get_operation_names()
+        )
+        deferred_node_set = OrderedSet(deferred_nodes)
+        leading_nodes = [node for node in parent_nodes if node not in deferred_node_set]
+        if any(node.ancestors & deferred_names for node in leading_nodes):
+            return parent_nodes
+        return [*leading_nodes, *deferred_nodes]
 
     def _codegen_reduction_with_sub_parent_epilogue(
         self,
@@ -3696,41 +3745,9 @@ class SIMDScheduling(BaseScheduling):
             name for node in parent_nodes for name in node.get_buffer_names()
         )
         if internal_source_names:
-            # Keep the source chain last so a looped kernel emits it and the
-            # derived epilogue together in the final reduction loop.
-            source_nodes = [
-                node
-                for node in parent_nodes
-                if internal_source_names & node.get_buffer_names()
-            ]
-            source_ancestors = OrderedSet(
-                name
-                for node in source_nodes
-                for name in (*node.ancestors, *node.get_operation_names())
+            parent_nodes = self._defer_sub_parent_source_chain(
+                parent_nodes, internal_source_names, numel, rnumel
             )
-            reduction_ancestors = OrderedSet(
-                name
-                for node in parent_nodes
-                if node.is_reduction()
-                for name in node.ancestors
-            )
-            deferred_nodes = [
-                node
-                for node in parent_nodes
-                if not node.is_reduction()
-                and node.get_operation_names() & source_ancestors
-                and not node.get_operation_names() & reduction_ancestors
-                and SIMDKernel.is_compatible((numel, rnumel), node.get_ranges())
-            ]
-            deferred_names = OrderedSet(
-                name for node in deferred_nodes for name in node.get_operation_names()
-            )
-            deferred_node_set = OrderedSet(deferred_nodes)
-            leading_nodes = [
-                node for node in parent_nodes if node not in deferred_node_set
-            ]
-            if not any(node.ancestors & deferred_names for node in leading_nodes):
-                parent_nodes = [*leading_nodes, *deferred_nodes]
         parent_schedule = self.generate_node_schedule(
             parent_nodes,
             numel,
@@ -3816,15 +3833,7 @@ class SIMDScheduling(BaseScheduling):
             if not kernel.persistent_reduction and not internal_source_names:
                 kernel.codegen_body()
         with kernel:
-            nodes_and_lanes = zip(
-                sub_parent_epilogue_nodes,
-                sub_parent_epilogue_plan.epilogue_node_output_lanes,
-                strict=True,
-            )
-            for output_lanes, stage in itertools.groupby(
-                nodes_and_lanes, key=operator.itemgetter(1)
-            ):
-                stage_nodes = tuple(node for node, _lanes in stage)
+            for output_lanes, stage_nodes in sub_parent_epilogue_plan.epilogue_stages:
                 for output_lane in range(output_lanes):
                     sub_parent_source = layout.sub_parent_iteration_values(
                         sub_parent_family,
@@ -3865,7 +3874,8 @@ class SIMDScheduling(BaseScheduling):
         if len(nodes) == 0:
             return
 
-        has_sub_parent_epilogue = self._find_sub_parent_epilogue_plan(nodes) is not None
+        sub_parent_epilogue = self._find_sub_parent_epilogue_plan(nodes)
+        has_sub_parent_epilogue = sub_parent_epilogue is not None
         if torch._inductor.config.triton.coalesce_tiling_analysis:
             if len(nodes) != len(node.get_nodes()):
                 if not self.scheduler:
@@ -3892,7 +3902,9 @@ class SIMDScheduling(BaseScheduling):
         else:
             coalesce_analysis = None
 
-        return self._codegen_nodes(nodes, coalesce_analysis)  # type: ignore[arg-type]
+        return self._codegen_nodes(  # type: ignore[arg-type]
+            nodes, coalesce_analysis, sub_parent_epilogue
+        )
 
     @staticmethod
     def can_use_32bit_indexing(
@@ -4078,11 +4090,7 @@ class SIMDScheduling(BaseScheduling):
             )
         ]
 
-    def codegen_node_schedule_with_kernel(
-        self,
-        node_schedule,
-        kernel,
-    ):
+    def codegen_node_schedule_with_kernel(self, node_schedule, kernel):
         with kernel:
             self._codegen_node_schedule_body(node_schedule, kernel)
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6208,30 +6208,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         value: CSEVariable,
         reshape_shape: Sequence[sympy.Expr | int | str],
         part_names: Sequence[str],
+        permute_dims: Sequence[int] | None = None,
     ) -> None:
-        dtype = value.dtype
-        assert dtype is not None  # noqa: S101
-        reshaped = self._bitcast_reshape_expr(value, reshape_shape, dtype)
-        self._emit_recursive_split(reshaped, part_names, reshape_shape, dtype)
-
-    def emit_split_via_reshape_permute(
-        self,
-        value: CSEVariable,
-        reshape_shape: Sequence[sympy.Expr | int | str],
-        permute_dims: Sequence[int],
-        part_names: Sequence[str],
-    ) -> None:
-        """Split ``value`` into lanes that are *strided blocks*, not neighbours.
+        """Split ``value`` into the lanes named by ``part_names``.
 
         ``tl.split`` only ever splits the **trailing** axis, and only into two.
         Both sub-parent layouts therefore reduce to "get my lane axis last":
 
         - interleaved lanes are already adjacent, so a plain reshape to
-          ``[..., extent // factor, factor]`` suffices -- see
-          ``emit_split_via_reshape``.
+          ``[..., extent // factor, factor]`` suffices and ``permute_dims`` is
+          left as ``None``.
         - contiguous lanes are ``factor`` consecutive *blocks*, so the lane axis
-          reshapes out in front (``[..., factor, extent // factor]``) and has to
-          be permuted to the end before it can be split.
+          reshapes out in front (``[..., factor, extent // factor]``) and
+          ``permute_dims`` moves it to the end before it can be split.
 
         That permute is the only codegen difference between the two layouts.
         ``_emit_recursive_split`` then peels one axis at a time, so a factor of
@@ -6239,10 +6228,12 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         """
         dtype = value.dtype
         assert dtype is not None  # noqa: S101
-        reshaped = self._bitcast_reshape_expr(value, reshape_shape, dtype)
-        permuted = f"tl.permute({reshaped}, ({', '.join(map(str, permute_dims))}))"
-        permuted_shape = tuple(reshape_shape[i] for i in permute_dims)
-        self._emit_recursive_split(permuted, part_names, permuted_shape, dtype)
+        expr = self._bitcast_reshape_expr(value, reshape_shape, dtype)
+        split_shape: Sequence[sympy.Expr | int | str] = reshape_shape
+        if permute_dims is not None:
+            expr = f"tl.permute({expr}, ({', '.join(map(str, permute_dims))}))"
+            split_shape = tuple(reshape_shape[i] for i in permute_dims)
+        self._emit_recursive_split(expr, part_names, split_shape, dtype)
 
     def emit_broadcast_via_reshape(
         self,

--- a/torch/_inductor/codegen/xpu/xpu_combined_scheduling.py
+++ b/torch/_inductor/codegen/xpu/xpu_combined_scheduling.py
@@ -63,11 +63,6 @@ class XPUCombinedScheduling(BaseScheduling):
             return False
         return self._triton_scheduling.can_fuse_vertical(node1, node2)
 
-    def can_fuse_nested_reduction_append(
-        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
-    ) -> bool:
-        return self._triton_scheduling.can_fuse_nested_reduction_append(node1, node2)
-
     def can_fuse_horizontal(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -585,6 +585,13 @@ class NestedReduction:
     # The fused nested-reduction append path supports only factor-2 interleaving.
     PARENT_HALF_FACTOR = 2
     MAX_SUB_PARENT_FACTOR = 16
+    # Widest INTERLEAVED source the planner accepts. The interleaved matcher is
+    # itself factor-generic; this is a scope bound, in keeping with the rest of
+    # the planner accepting only the shapes the stack exercises. Real
+    # interleaved consumers are pair packing (2) and 4->3 packing (4). Wider
+    # factors still reach codegen through CONTIGUOUS, where chunked consumers
+    # are exercised up to MAX_SUB_PARENT_FACTOR.
+    MAX_INTERLEAVED_SUB_PARENT_FACTOR = 4
 
     class GroupedAxis(enum.Enum):
         R = enum.auto()
@@ -607,6 +614,40 @@ class NestedReduction:
         parent_full_domain: tuple[sympy.Expr, ...]
         parent_half_domain: tuple[sympy.Expr, ...] | None = None
 
+        @classmethod
+        def create(
+            cls,
+            grouped_reduction: SchedulerNode,
+            grouped_numel: sympy.Expr,
+            grouped_rnumel: sympy.Expr,
+            grouped_axis: NestedReduction.GroupedAxis,
+            group_size: int,
+            outer_numel: sympy.Expr,
+            outer_rnumel: sympy.Expr,
+        ) -> NestedReduction.PointwiseDomainContext:
+            """Derive all four pointwise domains from the nested pair's shapes.
+
+            Legality (``NestedReduction.can_fuse``) and codegen
+            (``FusedNestedReductions``) both need this context, and a fusion
+            accepted against one derivation and emitted against another is
+            exactly the bug ``_parent_half_domain`` was factored out to fix.
+            The whole derivation lives here so the two callers cannot drift.
+            """
+            iter_ranges, reduce_ranges = grouped_reduction.get_ranges()
+            return cls(
+                grouped_reduction=grouped_reduction,
+                grouped_numel=grouped_numel,
+                grouped_rnumel=grouped_rnumel,
+                local_reduction_domain=(*iter_ranges, *reduce_ranges),
+                parent_full_domain=(outer_numel, outer_rnumel),
+                parent_half_domain=NestedReduction._parent_half_domain(
+                    grouped_axis,
+                    group_size,
+                    outer_numel,
+                    outer_rnumel,
+                ),
+            )
+
     @classmethod
     def _parent_half_domain(
         cls,
@@ -624,12 +665,39 @@ class NestedReduction:
 
     @dataclasses.dataclass(frozen=True)
     class SubParentEpiloguePlan:
-        epilogue_nodes: tuple[SchedulerNode, ...]
-        epilogue_node_output_lanes: tuple[int, ...]
+        # One entry per output-lane stage, in emission order: how many outputs
+        # the stage writes per lane group, and the nodes forming it. Codegen
+        # replays a stage's bodies once per output lane, so the grouping is the
+        # unit it iterates -- see _sub_parent_epilogue_candidate_nodes, which
+        # builds it and owns the precondition that makes it a partition.
+        epilogue_stages: tuple[tuple[int, tuple[SchedulerNode, ...]], ...]
         parent_nodes: tuple[BaseSchedulerNode, ...]
         sub_parent_factor: int
         parent_rnumel: int
         source_layouts: tuple[tuple[str, NestedReduction.SubParentSourceLayout], ...]
+        # Whether the source-load and leaf constraints hold. They only ever
+        # reject *additional* fusions and never change the rest of the plan, so
+        # the plan carries the answer instead of the planner being run twice,
+        # once with them and once without.
+        leaves_ok: bool
+
+        @property
+        def epilogue_nodes(self) -> tuple[SchedulerNode, ...]:
+            """Every planned epilogue node, in emission order."""
+            return tuple(
+                node for _lanes, nodes in self.epilogue_stages for node in nodes
+            )
+
+    @classmethod
+    def complete_sub_parent_epilogue_plan(
+        cls,
+        nodes: Sequence[BaseSchedulerNode],
+        numel: sympy.Expr,
+        rnumel: sympy.Expr,
+    ) -> SubParentEpiloguePlan | None:
+        """``sub_parent_epilogue_plan`` with the leaf constraints enforced."""
+        plan = cls.sub_parent_epilogue_plan(nodes, numel, rnumel)
+        return plan if plan is not None and plan.leaves_ok else None
 
     @classmethod
     def sub_parent_epilogue_plan(
@@ -637,13 +705,12 @@ class NestedReduction:
         nodes: Sequence[BaseSchedulerNode],
         numel: sympy.Expr,
         rnumel: sympy.Expr,
-        *,
-        check_leaves: bool = True,
     ) -> SubParentEpiloguePlan | None:
         r"""Return a fusion plan for compatible sub-parent reduction epilogues.
 
-        When ``check_leaves`` is false, skip source-load and leaf constraints
-        used only to reject additional fusions.
+        The source-load and leaf constraints are reported through
+        ``SubParentEpiloguePlan.leaves_ok`` rather than applied here; callers
+        that want them enforced use ``complete_sub_parent_epilogue_plan``.
         """
         parent_rnumel = cls._sub_parent_epilogue_parent_rnumel(rnumel)
         if parent_rnumel is None:
@@ -682,7 +749,10 @@ class NestedReduction:
         )
         if candidate is None:
             return None
-        epilogue_nodes, sub_parent_factor, epilogue_node_output_lanes = candidate
+        epilogue_stages, sub_parent_factor = candidate
+        epilogue_nodes = tuple(
+            node for _lanes, stage_nodes in epilogue_stages for node in stage_nodes
+        )
         if not cls._sub_parent_epilogue_internal_reads_match(
             epilogue_nodes,
             source_writes,
@@ -695,9 +765,23 @@ class NestedReduction:
             reduction_reads,
             source_writes,
             sub_parent_factor,
+            allow_contiguous=True,
             parent_rnumel=parent_rnumel,
         )
         if not source_deps:
+            return None
+        # The one (layout, lane-count) pairing the stack has never emitted.
+        # Splitting a source into lanes and replicating a consumer body across
+        # several outputs per lane group are independent mechanisms, so the
+        # rate derivation admits their product without either one vouching for
+        # it; only the interleaved half of that product is exercised (MXFP6
+        # packs four lanes into three bytes). Rather than emit an untested
+        # combination, decline it -- the same "planner narrower than the
+        # codegen it drives" stance as MAX_INTERLEAVED_SUB_PARENT_FACTOR.
+        if any(lanes != 1 for lanes, _stage_nodes in epilogue_stages) and any(
+            layout is cls.SubParentSourceLayout.CONTIGUOUS
+            for _dep, layout in source_deps
+        ):
             return None
         planned_source_deps = tuple(dep for dep, _layout in source_deps)
         # Plans must support looped codegen, which cannot retain an internally
@@ -708,30 +792,27 @@ class NestedReduction:
         ):
             return None
         epilogue_node_set = OrderedSet(epilogue_nodes)
-        if check_leaves and not cls._sub_parent_epilogue_source_loads_are_unambiguous(
-            nodes,
-            epilogue_node_set,
-            planned_source_deps,
-        ):
-            return None
-        if check_leaves and not cls._sub_parent_epilogue_outputs_unread(
-            nodes, epilogue_node_set
-        ):
-            return None
-        if check_leaves and not cls._sub_parent_siblings_are_source_free(
-            nodes,
-            epilogue_node_set,
-            numel,
-            OrderedSet(dep.name for dep in planned_source_deps),
-        ):
-            return None
+        leaves_ok = (
+            cls._sub_parent_epilogue_source_loads_are_unambiguous(
+                nodes,
+                epilogue_node_set,
+                planned_source_deps,
+            )
+            and cls._sub_parent_epilogue_outputs_unread(nodes, epilogue_node_set)
+            and cls._sub_parent_siblings_are_source_free(
+                nodes,
+                epilogue_node_set,
+                numel,
+                OrderedSet(dep.name for dep in planned_source_deps),
+            )
+        )
         return cls.SubParentEpiloguePlan(
-            tuple(epilogue_nodes),
-            epilogue_node_output_lanes,
+            epilogue_stages,
             tuple(node for node in nodes if node not in epilogue_node_set),
             sub_parent_factor,
             parent_rnumel,
             tuple((dep.name, layout) for dep, layout in source_deps),
+            leaves_ok,
         )
 
     @classmethod
@@ -745,7 +826,7 @@ class NestedReduction:
         parent_rnumel: int,
         reduction_names: OrderedSet[str],
         reduction_buffer_names: OrderedSet[str],
-    ) -> tuple[tuple[SchedulerNode, ...], int, tuple[int, ...]] | None:
+    ) -> tuple[tuple[tuple[int, tuple[SchedulerNode, ...]], ...], int] | None:
         from .codegen.simd import SIMDKernel
 
         candidates: list[tuple[SchedulerNode, int, int]] = []
@@ -783,25 +864,27 @@ class NestedReduction:
             for node, factor, lanes in candidates
             if factor == sub_parent_factor
         ]
-        omitted_nodes = [
-            node.get_name()
-            for node, factor, _lanes in candidates
-            if factor != sub_parent_factor
-        ]
-        if omitted_nodes:
-            fusion_log.debug(
-                "sub-parent factor %s omits candidates %s from this plan",
-                sub_parent_factor,
-                omitted_nodes,
-            )
+        fusion_log.debug(
+            "sub-parent factor %s keeps %s of %s candidates in this plan",
+            sub_parent_factor,
+            len(epilogue_nodes_and_lanes),
+            len(candidates),
+        )
+        # Codegen emits one stage per output-lane count and replays the stage's
+        # bodies once per output lane, so nodes sharing a lane count have to be
+        # contiguous for that grouping to be a partition of the epilogue.
+        # Reordering here would move stores past each other, so require the
+        # lane sequence to already be sorted and decline otherwise.
         output_lanes = tuple(lanes for _node, lanes in epilogue_nodes_and_lanes)
         if output_lanes != tuple(sorted(output_lanes)):
             return None
-        return (
-            tuple(node for node, _lanes in epilogue_nodes_and_lanes),
-            sub_parent_factor,
-            output_lanes,
+        epilogue_stages = tuple(
+            (lanes, tuple(node for node, _lanes in stage))
+            for lanes, stage in itertools.groupby(
+                epilogue_nodes_and_lanes, key=operator.itemgetter(1)
+            )
         )
+        return epilogue_stages, sub_parent_factor
 
     @staticmethod
     def _sub_parent_epilogue_parent_rnumel(rnumel: sympy.Expr) -> int | None:
@@ -879,10 +962,23 @@ class NestedReduction:
         source_writes: dict[str, list[MemoryDep]],
         sub_parent_factor: int,
         *,
+        allow_contiguous: bool,
         parent_rnumel: int | None = None,
         renames: dict[str, str] | None = None,
     ) -> tuple[tuple[MemoryDep, NestedReduction.SubParentSourceLayout], ...] | None:
-        # parent_rnumel=None disables contiguous-layout matching.
+        """Assign a lane layout to every full-resolution read of ``nodes``.
+
+        ``allow_contiguous`` says whether CONTIGUOUS is a candidate layout at
+        all. The nested append path (``FusedNestedReductions``) leaves it false,
+        which is what keeps that path factor-2 interleaved. CONTIGUOUS recovers
+        a lane from a read's constant term modulo the extent of the tile being
+        split, and both the matcher here and ``_resolve_remapped_value`` in
+        codegen must use the same extent or they silently disagree. For the
+        append path that extent is the grouped reduction's group size, not
+        ``parent_rnumel``, so the flag has to sit beside the extent rather than
+        be inferred from it: ``parent_rnumel`` is only meaningful, and only
+        required, when ``allow_contiguous`` is true.
+        """
         renames = renames or {}
         source_deps: list[tuple[MemoryDep, NestedReduction.SubParentSourceLayout]] = []
         source_layouts: dict[str, NestedReduction.SubParentSourceLayout] = {}
@@ -915,31 +1011,37 @@ class NestedReduction:
                     ):
                         return None
                     continue
-                source_deps_for_name = reduction_reads.get(
-                    dep.name, source_writes.get(dep.name, [])
-                )
                 full_resolution_source_deps = [
-                    source_dep
-                    for source_dep in source_deps_for_name
+                    candidate
+                    for candidate in reduction_reads.get(
+                        dep.name, source_writes.get(dep.name, [])
+                    )
                     if V.graph.sizevars.statically_known_equals(
-                        sympy_product(source_dep.ranges.values()), full_numel
+                        sympy_product(candidate.ranges.values()), full_numel
                     )
                 ]
-                if dep.name in fused_buffer_names and not full_resolution_source_deps:
-                    continue
-                reduction_deps = full_resolution_source_deps
-                if not reduction_deps:
-                    if dep.name in V.graph.removed_buffers:
+                if not full_resolution_source_deps:
+                    # Nothing at full resolution to split into lanes. For a
+                    # buffer the fused group produces itself, or an external one
+                    # that survives, this read simply is not a lane source. A
+                    # removed buffer has no producer left at all, so no plan can
+                    # stand on it.
+                    if (
+                        dep.name not in fused_buffer_names
+                        and dep.name in V.graph.removed_buffers
+                    ):
                         return None
                     continue
-                if len(reduction_deps) != 1:
+                if len(full_resolution_source_deps) != 1:
                     return None
-                source_dep = reduction_deps[0]
+                source_dep = full_resolution_source_deps[0]
                 lane = V.graph.sizevars.simplify(
                     sympy.Mod(dep.index, sub_parent_factor)
                 )
                 if (
-                    sub_parent_factor in (cls.PARENT_HALF_FACTOR, 4)
+                    # sub_parent_factor is always a power of two >= 2, so this
+                    # bound admits exactly the factors 2 and 4.
+                    sub_parent_factor <= cls.MAX_INTERLEAVED_SUB_PARENT_FACTOR
                     and any(
                         V.graph.sizevars.statically_known_equals(lane, value)
                         for value in range(sub_parent_factor)
@@ -954,21 +1056,20 @@ class NestedReduction:
                     ):
                         return None
                     continue
-                if (
-                    parent_rnumel is not None
-                    and cls._contiguous_sub_parent_epilogue_read_matches_reduction_read(
+                if allow_contiguous:
+                    assert parent_rnumel is not None  # noqa: S101
+                    if cls._contiguous_sub_parent_epilogue_read_matches_reduction_read(
                         dep,
                         source_dep,
                         sub_parent_factor,
                         parent_rnumel,
-                    )
-                ):
-                    if not add_source(
-                        source_dep,
-                        cls.SubParentSourceLayout.CONTIGUOUS,
                     ):
-                        return None
-                    continue
+                        if not add_source(
+                            source_dep,
+                            cls.SubParentSourceLayout.CONTIGUOUS,
+                        ):
+                            return None
+                        continue
                 return None
         return tuple(source_deps)
 
@@ -1078,45 +1179,67 @@ class NestedReduction:
         dep: MemoryDep,
         reduction_dep: MemoryDep,
         lane_dim: int,
-        lane_exprs: Sequence[sympy.Expr],
-    ) -> list[dict[sympy.Symbol, sympy.Expr]] | None:
-        """Map reduction-read vars to epilogue-read vars, one dict per lane
-        candidate; the lane dim maps to the corresponding lane expression."""
-        substitutions_by_lane: list[dict[sympy.Symbol, sympy.Expr]] = [
-            {} for _ in lane_exprs
-        ]
+        lane_expr: sympy.Expr,
+    ) -> dict[sympy.Symbol, sympy.Expr] | None:
+        """Map reduction-read vars to epilogue-read vars; the lane dim maps to
+        ``lane_expr``."""
+        substitutions: dict[sympy.Symbol, sympy.Expr] = {}
         for i, reduction_var in enumerate(reduction_dep.var_names):
             dep_var = dep.var_names[i]
             if i == lane_dim:
-                for substitutions, lane_expr in zip(substitutions_by_lane, lane_exprs):
-                    substitutions[reduction_var] = lane_expr
+                substitutions[reduction_var] = lane_expr
             elif V.graph.sizevars.statically_known_equals(
                 reduction_dep.size[i], dep.size[i]
             ):
-                for substitutions in substitutions_by_lane:
-                    substitutions[reduction_var] = dep_var
+                substitutions[reduction_var] = dep_var
             else:
                 return None
-        return substitutions_by_lane
+        return substitutions
 
     @staticmethod
-    def _matches_unique_sub_parent_lane(
+    def _sub_parent_read_matches_lane(
         dep: MemoryDep,
-        expected_by_lane: Sequence[sympy.Expr],
+        reduction_dep: MemoryDep,
+        lane_dim: int,
+        lane_expr: sympy.Expr,
+    ) -> bool:
+        """Shared body of the same-rank read matchers.
+
+        Both layouts derive ``lane_expr`` -- the value the reduction read's
+        lane variable takes for the lane this read addresses -- in their own
+        way, and interleaved deliberately keeps a form sympy can cancel. From
+        here the check is identical for both: rewrite the reduction read in the
+        epilogue read's variables and compare indices.
+        """
+        substitutions = NestedReduction._sub_parent_lane_substitutions(
+            dep, reduction_dep, lane_dim, lane_expr
+        )
+        if substitutions is None:
+            return False
+        expected = reduction_dep.index.subs(substitutions)
+        return V.graph.sizevars.statically_known_equals(dep.index, expected)
+
+    @staticmethod
+    def _contiguous_sub_parent_lane_index(
+        dep: MemoryDep,
         sub_parent_factor: int,
         parent_rnumel: int,
-    ) -> bool:
-        matching_lanes = [
-            lane
-            for lane, expected in enumerate(expected_by_lane)
-            if V.graph.sizevars.statically_known_equals(dep.index, expected)
-        ]
-        return len(matching_lanes) == 1 and V.graph.sizevars.statically_known_equals(
-            NestedReduction._contiguous_sub_parent_epilogue_emitted_lane(
-                dep, sub_parent_factor, parent_rnumel
-            ),
-            matching_lanes[0],
+    ) -> int | None:
+        """The lane codegen will emit for ``dep``, as a Python int.
+
+        ``_resolve_remapped_value`` selects ``parts[lane]`` for exactly this
+        lane and no other, so a read is satisfied iff *this* lane reproduces
+        the reduction read -- whether or not some other lane happens to alias
+        the same address. Resolved with ``statically_known_equals`` rather than
+        ``int()`` so a symbolic-but-known offset still resolves.
+        """
+        emitted_lane = NestedReduction._contiguous_sub_parent_epilogue_emitted_lane(
+            dep, sub_parent_factor, parent_rnumel
         )
+        for lane in range(sub_parent_factor):
+            if V.graph.sizevars.statically_known_equals(emitted_lane, lane):
+                return lane
+        return None
 
     @staticmethod
     def _interleaved_sub_parent_epilogue_read_matches_reduction_read(
@@ -1136,14 +1259,13 @@ class NestedReduction:
             return NestedReduction._interleaved_sub_parent_epilogue_read_matches_flat_reduction_read(
                 dep, reduction_dep, lane, sub_parent_factor
             )
+        # Derived from the full index: every other term is a multiple of the
+        # factor, so sympy cancels them. Do not switch this to the contiguous
+        # constant-offset form -- it is strictly less conservative here.
         lane_expr = sub_parent_factor * dep.var_names[lane_dim] + lane
-        substitutions_by_lane = NestedReduction._sub_parent_lane_substitutions(
-            dep, reduction_dep, lane_dim, [lane_expr]
+        return NestedReduction._sub_parent_read_matches_lane(
+            dep, reduction_dep, lane_dim, lane_expr
         )
-        if substitutions_by_lane is None:
-            return False
-        expected = reduction_dep.index.subs(substitutions_by_lane[0])
-        return V.graph.sizevars.statically_known_equals(dep.index, expected)
 
     @staticmethod
     def _interleaved_sub_parent_epilogue_read_matches_flat_reduction_read(
@@ -1212,21 +1334,17 @@ class NestedReduction:
         )
         if lane_dim is None:
             return False
-        lane_exprs = [
-            dep.var_names[lane_dim] + lane * dep.size[lane_dim]
-            for lane in range(sub_parent_factor)
-        ]
-        substitutions_by_lane = NestedReduction._sub_parent_lane_substitutions(
-            dep, reduction_dep, lane_dim, lane_exprs
+        # The child variable has stride 1 and would pollute a modulus over the
+        # whole index, so the lane comes from the constant term alone -- the
+        # same derivation codegen uses to pick a lane.
+        lane = NestedReduction._contiguous_sub_parent_lane_index(
+            dep, sub_parent_factor, parent_rnumel
         )
-        if substitutions_by_lane is None:
+        if lane is None:
             return False
-        expected_by_lane = [
-            reduction_dep.index.subs(substitutions)
-            for substitutions in substitutions_by_lane
-        ]
-        return NestedReduction._matches_unique_sub_parent_lane(
-            dep, expected_by_lane, sub_parent_factor, parent_rnumel
+        lane_expr = dep.var_names[lane_dim] + lane * dep.size[lane_dim]
+        return NestedReduction._sub_parent_read_matches_lane(
+            dep, reduction_dep, lane_dim, lane_expr
         )
 
     @staticmethod
@@ -1251,15 +1369,15 @@ class NestedReduction:
             stride,
         ):
             return False
-        expected_by_lane = [
-            reduction_dep.index.subs(
-                {reduction_var: parent_index + lane * dep.size[lane_dim]}
-            )
-            for lane in range(sub_parent_factor)
-        ]
-        return NestedReduction._matches_unique_sub_parent_lane(
-            dep, expected_by_lane, sub_parent_factor, parent_rnumel
+        lane = NestedReduction._contiguous_sub_parent_lane_index(
+            dep, sub_parent_factor, parent_rnumel
         )
+        if lane is None:
+            return False
+        expected = reduction_dep.index.subs(
+            {reduction_var: parent_index + lane * dep.size[lane_dim]}
+        )
+        return V.graph.sizevars.statically_known_equals(dep.index, expected)
 
     @staticmethod
     def sub_parent_contiguous_lane(
@@ -1481,7 +1599,7 @@ class NestedReduction:
 
         iter_ranges, _ = domain_context.grouped_reduction.get_ranges()
         _, (sn_numel, _) = sn.group
-        expected_numel: sympy.Expr | None
+        expected_numel: sympy.Expr
         if domain is cls.PointwiseDomain.REDUCED:
             expected_numel = domain_context.grouped_numel
             expected_groups: Sequence[sympy.Expr] = tuple(iter_ranges)
@@ -1496,8 +1614,8 @@ class NestedReduction:
             )
             expected_groups = domain_context.parent_full_domain
         elif domain is cls.PointwiseDomain.PARENT_HALF:
-            if domain_context.parent_half_domain is None:
-                return False
+            # The classifier only emits PARENT_HALF when the half domain exists.
+            assert domain_context.parent_half_domain is not None  # noqa: S101
             expected_groups = domain_context.parent_half_domain
             expected_numel = sympy_product(expected_groups)
         else:
@@ -1653,20 +1771,14 @@ class NestedReduction:
             group_size=group_size_int,
         ):
             return False
-        iter_ranges, reduce_ranges = grouped_reduction.get_ranges()
-        parent_half_domain = cls._parent_half_domain(
+        domain_context = cls.PointwiseDomainContext.create(
+            grouped_reduction,
+            grouped_numel,
+            grouped_rnumel,
             grouped_axis,
             group_size_int,
             outer_numel,
             outer_rnumel,
-        )
-        domain_context = cls.PointwiseDomainContext(
-            grouped_reduction=grouped_reduction,
-            grouped_numel=grouped_numel,
-            grouped_rnumel=grouped_rnumel,
-            local_reduction_domain=(*iter_ranges, *reduce_ranges),
-            parent_full_domain=(outer_numel, outer_rnumel),
-            parent_half_domain=parent_half_domain,
         )
         if not cls._pointwise_nodes_match_nested_domains(
             outer_node,
@@ -3819,21 +3931,15 @@ class FusedNestedReductions(FusedSchedulerNode):
             raise AssertionError("expected grouped_axis to be non-None")
         self.grouped_axis: NestedReduction.GroupedAxis = grouped_axis
         self.group_size_in_r: bool = self.grouped_axis is NestedReduction.GroupedAxis.R
-        iter_ranges, reduce_ranges = grouped_reduction.get_ranges()
-        parent_half_domain = NestedReduction._parent_half_domain(
-            grouped_axis,
-            int(exact_group_size),
-            outer_numel,
-            outer_rnumel,
-        )
         self.domain_context: NestedReduction.PointwiseDomainContext = (
-            NestedReduction.PointwiseDomainContext(
-                grouped_reduction=grouped_reduction,
-                grouped_numel=grouped_numel,
-                grouped_rnumel=grouped_rnumel,
-                local_reduction_domain=(*iter_ranges, *reduce_ranges),
-                parent_full_domain=(outer_numel, outer_rnumel),
-                parent_half_domain=parent_half_domain,
+            NestedReduction.PointwiseDomainContext.create(
+                grouped_reduction,
+                grouped_numel,
+                grouped_rnumel,
+                grouped_axis,
+                int(exact_group_size),
+                outer_numel,
+                outer_rnumel,
             )
         )
         grouped_pointwise_domains = NestedReduction._classify_grouped_pointwise_nodes(
@@ -3842,12 +3948,9 @@ class FusedNestedReductions(FusedSchedulerNode):
         )
         if grouped_pointwise_domains is None:
             raise AssertionError("expected grouped pointwise domains to be classified")
-        self.grouped_pointwise_domains: tuple[
-            tuple[SchedulerNode, NestedReduction.PointwiseDomain], ...
-        ] = tuple(grouped_pointwise_domains)
         self.sub_parent_broadcast_source_names: OrderedSet[str] = OrderedSet(
             name
-            for sn, domain in self.grouped_pointwise_domains
+            for sn, domain in grouped_pointwise_domains
             if domain is NestedReduction.PointwiseDomain.REDUCED
             for name in sn.get_buffer_names()
         )
@@ -3857,17 +3960,17 @@ class FusedNestedReductions(FusedSchedulerNode):
         for sn in self.node1.get_nodes():
             if sn.is_reduction():
                 self.sub_parent_broadcast_source_names.update(sn.get_buffer_names())
-        parent_half_nodes = [
+        self.parent_half_nodes: tuple[SchedulerNode, ...] = tuple(
             sn
-            for sn, domain in self.grouped_pointwise_domains
+            for sn, domain in grouped_pointwise_domains
             if domain is NestedReduction.PointwiseDomain.PARENT_HALF
-        ]
+        )
         self.parent_half_source_layouts: dict[
             str, NestedReduction.SubParentSourceLayout
         ] = {}
-        if parent_half_nodes:
-            source_layouts = self._parent_half_source_layouts(
-                parent_half_nodes, self.node2.get_nodes()
+        if self.parent_half_nodes:
+            source_layouts = self._plan_parent_half_source_layouts(
+                self.parent_half_nodes, self.node2.get_nodes()
             )
             if source_layouts is None:
                 raise AssertionError("expected parent-half sources to be planned")
@@ -3918,11 +4021,9 @@ class FusedNestedReductions(FusedSchedulerNode):
         # that read a half-resolution output buffer are rejected. Checking the
         # whole combined set makes this independent of fusion order.
         combined_nodes = [*self.node2.get_nodes(), *other.get_nodes()]
-        candidate_domains = [*self.grouped_pointwise_domains, *pointwise_domains]
         candidate_half_resolution_nodes = [
-            sn
-            for sn, domain in candidate_domains
-            if domain is NestedReduction.PointwiseDomain.PARENT_HALF
+            *self.parent_half_nodes,
+            *half_resolution_nodes,
         ]
         if not NestedReduction._sub_parent_epilogue_outputs_unread(
             combined_nodes,
@@ -3931,7 +4032,7 @@ class FusedNestedReductions(FusedSchedulerNode):
         ):
             return False
         if candidate_half_resolution_nodes and (
-            self._parent_half_source_layouts(
+            self._plan_parent_half_source_layouts(
                 candidate_half_resolution_nodes,
                 combined_nodes,
             )
@@ -3947,7 +4048,7 @@ class FusedNestedReductions(FusedSchedulerNode):
             producer_node=self if half_resolution_nodes else None,
         )
 
-    def _parent_half_source_layouts(
+    def _plan_parent_half_source_layouts(
         self,
         half_nodes: Sequence[SchedulerNode],
         all_grouped_nodes: Sequence[BaseSchedulerNode],
@@ -3981,6 +4082,7 @@ class FusedNestedReductions(FusedSchedulerNode):
             reduction_reads,
             source_writes,
             NestedReduction.PARENT_HALF_FACTOR,
+            allow_contiguous=False,
             renames=renames,
         )
         if not source_deps:
@@ -8721,6 +8823,9 @@ class Scheduler:
             # compile-time profiles, without letting score-only names relax legality.
             if NestedReduction.can_fuse(node1, node2):
                 return self._producer_output_names_read_by_consumer(node1, node2)
+            # is_candidate() requires node2 to be a reduction, which the
+            # sub-parent relation below rejects: the two are mutually exclusive.
+            return None
 
         # _is_enabled_for, not the config flag alone: only a GPU Triton backend
         # without cpp_wrapper can emit a sub-parent epilogue, and planning one
@@ -8733,11 +8838,11 @@ class Scheduler:
         ):
             return None
         _, (numel, rnumel) = node1.group
-        plan = NestedReduction.sub_parent_epilogue_plan(
+        plan = NestedReduction.complete_sub_parent_epilogue_plan(
             [*node1.get_nodes(), *node2.get_nodes()], numel, rnumel
         )
         if plan is None and isinstance(node2, SchedulerNode):
-            existing_plan = NestedReduction.sub_parent_epilogue_plan(
+            existing_plan = NestedReduction.complete_sub_parent_epilogue_plan(
                 node1.get_nodes(), numel, rnumel
             )
             if existing_plan is not None:
@@ -8745,7 +8850,7 @@ class Scheduler:
                 keep_reindex = False
                 try:
                     if self._reindex_sub_parent_consumer(existing_plan, node2):
-                        plan = NestedReduction.sub_parent_epilogue_plan(
+                        plan = NestedReduction.complete_sub_parent_epilogue_plan(
                             [*node1.get_nodes(), *node2.get_nodes()], numel, rnumel
                         )
                         keep_reindex = plan is not None and all(
@@ -8769,19 +8874,18 @@ class Scheduler:
             return False
 
         candidates: list[tuple[SchedulerNode, MemoryDep, MemoryDep]] = []
-        for producer, output_lanes in zip(
-            plan.epilogue_nodes, plan.epilogue_node_output_lanes, strict=True
-        ):
+        for output_lanes, stage_nodes in plan.epilogue_stages:
             if output_lanes == 1:
                 continue
-            for write in producer.read_writes.writes:
-                if not isinstance(write, MemoryDep):
-                    continue
-                candidates.extend(
-                    (producer, read, write)
-                    for read in consumer.read_writes.reads
-                    if isinstance(read, MemoryDep) and read.name == write.name
-                )
+            for producer in stage_nodes:
+                for write in producer.read_writes.writes:
+                    if not isinstance(write, MemoryDep):
+                        continue
+                    candidates.extend(
+                        (producer, read, write)
+                        for read in consumer.read_writes.reads
+                        if isinstance(read, MemoryDep) and read.name == write.name
+                    )
         if len(candidates) != 1:
             return False
         producer, read, write = candidates[0]
@@ -8834,6 +8938,10 @@ class Scheduler:
 
         # Partition read dimensions by the physical interval covered by each
         # write dimension, ordering each partition from outermost to innermost.
+        # The write is contiguous, so its dims already have strictly descending
+        # strides: the result is just a descending-stride sort of the read dims,
+        # and the rest of the loop is validation that no read dim straddles a
+        # write dim.
         order: list[int] = []
         for write_stride, write_size in zip(write_strides, write.size):
             upper_bound = write_stride * int(write_size)
@@ -8892,7 +9000,6 @@ class Scheduler:
             other,
             can_reorder=can_reorder,
             index_equivalent_dep_names=index_equivalent_dep_names,
-            _skip_fused_nested_dispatch=True,
         )
 
     def can_fuse(
@@ -8920,6 +9027,25 @@ class Scheduler:
         finally:
             tracker.finish(rollback=not can_fuse)
 
+    def _fusion_blocked_by_placement(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> bool:
+        """Reject pairs that cannot share a kernel regardless of their bodies."""
+        if node1 is node2:
+            return True
+        # Prevent fusion across stream boundaries
+        if self._has_multi_stream_nodes():
+            stream1 = self.get_node_stream(node1)
+            stream2 = self.get_node_stream(node2)
+            if stream1 != stream2:
+                return True
+        if self._has_mempool_nodes():
+            mempool1 = self.node_to_mempool.get(node1)
+            mempool2 = self.node_to_mempool.get(node2)
+            if mempool1 != mempool2:
+                return True
+        return False
+
     def _can_fuse_impl(
         self,
         node1: BaseSchedulerNode,
@@ -8931,6 +9057,25 @@ class Scheduler:
         Determine if it is possible to combine node1 and node2 into a
         single fused node.
         """
+        if self._fusion_blocked_by_placement(node1, node2):
+            return False
+
+        # Composite reduction nodes answer for themselves. These sit here
+        # rather than in _can_fuse so that FusedNestedReductions.can_fuse_with
+        # can re-enter _can_fuse for the pair it has already dispatched on,
+        # without a flag to suppress the dispatch.
+        if isinstance(node1, FusedNestedReductions):
+            return node1.can_fuse_with(node2, can_reorder=can_reorder)
+        if isinstance(node2, FusedNestedReductions):
+            return False
+
+        if isinstance(node1, FusedMixOrderReductions):
+            return node1.can_fuse_with(node2)
+        if isinstance(node2, FusedMixOrderReductions):
+            # We don't fuse something before a FusedMixOrderReductions
+            # right now
+            return False
+
         return self._can_fuse(
             node1,
             node2,
@@ -8945,39 +9090,14 @@ class Scheduler:
         can_reorder: bool = False,
         allow_mix_order_reduction: bool = True,
         index_equivalent_dep_names: OrderedSet[str] | None = None,
-        _skip_fused_nested_dispatch: bool = False,
     ) -> bool:
-        if node1 is node2:
+        if self._fusion_blocked_by_placement(node1, node2):
             return False
         if index_equivalent_dep_names is not None:
             index_equivalent_dep_names = OrderedSet(
                 self.mutation_renames.get(name, name)
                 for name in index_equivalent_dep_names
             )
-
-        # Prevent fusion across stream boundaries
-        if self._has_multi_stream_nodes():
-            stream1 = self.get_node_stream(node1)
-            stream2 = self.get_node_stream(node2)
-            if stream1 != stream2:
-                return False
-        if self._has_mempool_nodes():
-            mempool1 = self.node_to_mempool.get(node1)
-            mempool2 = self.node_to_mempool.get(node2)
-            if mempool1 != mempool2:
-                return False
-
-        if isinstance(node1, FusedNestedReductions) and not _skip_fused_nested_dispatch:
-            return node1.can_fuse_with(node2, can_reorder=can_reorder)
-        if isinstance(node2, FusedNestedReductions):
-            return False
-
-        if isinstance(node1, FusedMixOrderReductions):
-            return node1.can_fuse_with(node2)
-        if isinstance(node2, FusedMixOrderReductions):
-            # We don't fuse something before a FusedMixOrderReductions
-            # right now
-            return False
 
         why = WhyNoFuse(node1, node2)
 
@@ -9244,11 +9364,6 @@ class Scheduler:
         if node1.get_operation_names() & node2.ancestors:
             # node2 depends on node1 outputs
             backend = self.get_backend(device)
-            backend_can_fuse = (
-                backend.can_fuse_nested_reduction_append
-                if isinstance(node1, FusedNestedReductions)
-                else backend.can_fuse_vertical
-            )
             if (
                 self.can_fuse_vertical(
                     node1,
@@ -9256,7 +9371,7 @@ class Scheduler:
                     index_equivalent_dep_names=index_equivalent_dep_names,
                 )
                 and V.choices.can_fuse_vertical(self, node1, node2, shared_data_score)
-                and backend_can_fuse(node1, node2)
+                and backend.can_fuse_vertical(node1, node2)
             ):
                 return True
 
@@ -9277,7 +9392,7 @@ class Scheduler:
                     and V.choices.can_fuse_vertical(
                         self, node1, node2, shared_data_score
                     )
-                    and backend_can_fuse(node1, node2)
+                    and backend.can_fuse_vertical(node1, node2)
                 )
 
             return False
@@ -9528,9 +9643,14 @@ class Scheduler:
     ) -> int:
         """Score vertical producer-output deps missed by exact dep scoring.
 
-        Exact scoring is set-intersection based, but vertical legality can also
-        accept normalized equivalent read/write deps. Give those pairs a memory
-        score so heuristics do not discard them before legality runs.
+        Exact scoring is set-intersection based, so it misses pairs vertical
+        legality would still accept. Two kinds: a read/write pair that
+        ``fusable_read_and_write`` matches, and -- for the buffers named in
+        ``index_equivalent_dep_names`` -- any read of one of them, matched on
+        buffer name alone with no index comparison, because the nested-reduction
+        planner has already validated the whole plan those names came from.
+        Give those pairs a memory score so heuristics do not discard them
+        before legality runs.
         """
         if not (producer.get_operation_names() & consumer.ancestors):
             return 0
@@ -11313,11 +11433,6 @@ class BaseScheduling:  # noqa: docstring_linter
         Check whether node1 and node2 can be vertically fused or not.
         """
         raise NotImplementedError
-
-    def can_fuse_nested_reduction_append(
-        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
-    ) -> bool:
-        return self.can_fuse_vertical(node1, node2)
 
     def can_fuse_horizontal(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #191696
* __->__ #191975
* #191974
* #191775
* #190596
* #190595
* #190594

Source-only cleanup of the four commits below. Net negative on code: roughly
-130 lines of code with ~+240 lines of comments and docstrings explaining the
parts that were previously implicit.

Deletions and merges:
- delete _is_axis_tile_shaped and its two wrappers; the predicate is textually
  equal to parent_dim(value) == block on every input, and the
  is_parent_tile_shaped call sat behind a guard where every path already
  returns, so that branch was dead
- merge emit_split_via_reshape_permute into emit_split_via_reshape via
  permute_dims=None -- they differed by three lines with one caller each, and
  the callers are the two arms of one if
- delete verified-dead code: an assert on a two-member enum's other arm, a
  parent_half_domain None check inside the arm that guarantees it, two
  always-passed optionals, an unreachable fall-through
- delete the can_fuse_nested_reduction_append backend hook: a BaseScheduling
  virtual plus two pure-delegation overrides, where the template ladder it
  existed to skip is already a no-op for a FusedSchedulerNode
- collapse _skip_fused_nested_dispatch, with the placement guards extracted so
  nothing is reordered past them

Representation:
- bundle the three parent_half_* optionals into one object; they are always
  all-set or all-None and were paid for with four asserts, one provably dead
- replace the plan's parallel epilogue_nodes / epilogue_node_output_lanes
  tuples with epilogue_stages plus a flat property. This deletes the
  zip + groupby + itemgetter in codegen and puts the sortedness precondition
  next to the grouping it exists for; they were ~1100 lines and a module apart
- one PointwiseDomainContext factory instead of two verbatim constructions --
  keeping those in sync by hand is what #190595 already had to fix once
- untangle _sub_parent_epilogue_source_deps, where one list acquired four names
  in twenty lines including an alias that had become inaccurate
- extract the 36-line deferred-source reorder into a named method

Legality path:
- build the plan once per can_fuse. leaves_ok rides on the plan and
  check_leaves is gone from both sides: the leaf constraints only reject
  additional fusions, they never change the plan. can_fuse drops from 3 plan
  builds to 1, codegen_node from 2 to 1.
- unify the four read matchers. The lane *derivation* stays per-layout
  deliberately: interleaved derives from the full index and lets sympy cancel,
  contiguous zeroes the free symbols first, and unifying on the constant-offset
  form would be strictly less conservative for interleaved.
- index the contiguous lane directly rather than building an expected index per
  lane and requiring a unique match. This WIDENS the accepted set: a read two
  or more lanes reproduce is now accepted when the emitted lane is one of them.
  Sound, because _resolve_remapped_value selects parts[emitted_lane] and
  nothing else, so uniqueness was never load-bearing. Not covered by a positive
  test -- the newly-accepted shapes are lane-invariant sources and I could not
  construct one that reaches the path.

Naming:
- MAX_INTERLEAVED_SUB_PARENT_FACTOR instead of borrowing PARENT_HALF_FACTOR,
  which documents the append path's factor-2 restriction, as a stand-in for 2
- reject a 3-lane CONTIGUOUS plan explicitly. It was reachable and untested:
  dep.ranges is not the node's iteration space, since drop_unused_symbols pops
  trailing vars the index does not mention
- replace the parent_rnumel=None sentinel with an explicit allow_contiguous
  flag; parent_rnumel stays, since the contiguous matcher still needs the value

Not done: dropping allow_reduced_broadcast. Its premise is false -- the flag
guards a branch above the 'source_layout is None' early return, so removing it
would turn a loud 'could not materialize planned parent-tile load' into a
silent broadcast of a reduced value into every lane.

Test Plan: TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 python test/inductor/test_nested_reduction.py