### PR TITLE
Fix error masking in find_free_port when socket creation fails

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -6,17 +6,39 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+import socket
 import sys
 import unittest
+from unittest import mock
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
 if os.getenv("CIRCLECI"):
     print("T85992919 temporarily disabling in circle ci", file=sys.stderr)
     sys.exit(0)
+
+
+class FindFreePortTest(unittest.TestCase):
+    def test_returns_bound_socket(self):
+        sock = find_free_port()
+        try:
+            self.assertGreater(sock.getsockname()[1], 0)
+        finally:
+            sock.close()
+
+    def test_raises_runtime_error_when_socket_creation_fails(self):
+        # If socket.socket() itself raises, the cleanup path must not fail
+        # with UnboundLocalError and mask the original error.
+        addr = (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))
+        with (
+            mock.patch("socket.getaddrinfo", return_value=[addr]),
+            mock.patch("socket.socket", side_effect=OSError("socket failed")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Failed to create a socket"):
+                find_free_port()
 
 
 class EtcdServerTest(unittest.TestCase):

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,15 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
Fixes #191395

`torch.distributed.elastic.rendezvous.etcd_server.find_free_port()` assigns `s` inside the `try` block but unconditionally calls `s.close()` in the `except OSError` handler. If `socket.socket()` itself raises, `s` was never assigned and the cleanup raises `UnboundLocalError`, masking the actual socket error (the existing `# type: ignore[possibly-undefined]` was suppressing exactly this warning).

This PR initializes `s = None` before the `try` and only closes it if it was created, so the all-addresses-failed case now reaches the intended `RuntimeError("Failed to create a socket")`.

## Test plan

Added `FindFreePortTest` to `test/distributed/elastic/rendezvous/etcd_server_test.py`:
- `test_returns_bound_socket` — happy path, returns a socket bound to a free port
- `test_raises_runtime_error_when_socket_creation_fails` — mocks `socket.socket` to raise `OSError`; fails with `UnboundLocalError` before this change, passes after
