### PR TITLE
Close file descriptor returned by mkstemp in _create_file_store

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -274,6 +274,21 @@ class CreateBackendTest(TestCase):
         ):
             create_backend(self._params_filestore)
 
+    def test_create_backend_closes_tempfile_descriptor(self) -> None:
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.addCleanup(os.remove, path)
+        # Set the endpoint to empty so it defaults to creating a temp file
+        self._params_filestore.endpoint = ""
+
+        with (
+            mock.patch("tempfile.mkstemp", return_value=(42, path)),
+            mock.patch("os.close") as close_mock,
+        ):
+            create_backend(self._params_filestore)
+
+        close_mock.assert_called_once_with(42)
+
     @mock.patch(
         "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"
     )

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,7 +192,10 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            # The FileStore opens the file by path; close the descriptor
+            # returned by mkstemp so it is not leaked.
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."


### PR DESCRIPTION
Fixes #191394

`_create_file_store()` in `torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py` calls `tempfile.mkstemp()` when no endpoint is supplied but discards the returned file descriptor. `FileStore` opens the path independently, so the descriptor stays open for the life of the process — one leaked fd per rendezvous.

This PR closes the descriptor immediately after `mkstemp()` returns.

## Test plan

Added `test_create_backend_closes_tempfile_descriptor` to `test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py` — mocks `tempfile.mkstemp` to return a known fd and asserts `os.close` is called with it. Fails ("`close` called 0 times") before this change, passes after. Adjacent `CreateBackendTest` file-store tests still pass.
