### PR TITLE
Use `TypeAliasType` for type alias reexports instead of `TypeAlias` annotation

### DIFF
--- a/torch/distributed/_pycute/int_tuple.py
+++ b/torch/distributed/_pycute/int_tuple.py
@@ -36,14 +36,14 @@ Functions for manipulating IntTuples
 
 from functools import reduce
 from itertools import chain
-from typing import TypeAlias
-from typing_extensions import TypeIs
+from typing_extensions import TypeAliasType, TypeIs
 
 from .typing import Integer
 
 
-# Type aliases for better readability
-IntTuple: TypeAlias = int | tuple["IntTuple", ...]
+# Use TypeAliasType so that __module__ is set correctly for public API reexports
+# See: https://github.com/pytorch/pytorch/issues/171905
+IntTuple = TypeAliasType("IntTuple", int | tuple["IntTuple", ...])
 
 
 def is_int(x: object) -> TypeIs[int]:

--- a/torch/distributed/_pycute/layout.py
+++ b/torch/distributed/_pycute/layout.py
@@ -50,6 +50,7 @@ from .int_tuple import (
     suffix_product,
 )
 
+
 # Use TypeAliasType so that __module__ is set correctly for public API reexports
 # See: https://github.com/pytorch/pytorch/issues/171905
 CoordinateType = TypeAliasType(

--- a/torch/distributed/_pycute/layout.py
+++ b/torch/distributed/_pycute/layout.py
@@ -36,8 +36,7 @@ of lexicographic instead of co-lexicographic as implemented in the original layo
 """
 
 from itertools import chain
-from typing import TypeAlias
-from typing_extensions import Self, TypeIs
+from typing_extensions import Self, TypeAliasType, TypeIs
 
 from .int_tuple import (
     crd2idx,
@@ -52,9 +51,11 @@ from .int_tuple import (
 )
 
 
-# Type aliases
-CoordinateType: TypeAlias = (
-    int | IntTuple | tuple[object, ...] | None
+# Use TypeAliasType so that __module__ is set correctly for public API reexports
+# See: https://github.com/pytorch/pytorch/issues/171905
+CoordinateType = TypeAliasType(
+    "CoordinateType",
+    int | IntTuple | tuple[object, ...] | None,
 )  # Input for slice_ and crd2idx functions
 
 
@@ -134,9 +135,9 @@ class Layout(LayoutBase):
 
 
 # Type aliases
-LayoutOrIntTuple: TypeAlias = Layout | IntTuple
-LayoutProfile: TypeAlias = tuple[object, ...] | Layout | None
-LayoutInput: TypeAlias = Layout | IntTuple | tuple[object, ...] | None
+LayoutOrIntTuple = TypeAliasType("LayoutOrIntTuple", Layout | IntTuple)
+LayoutProfile = TypeAliasType("LayoutProfile", tuple[object, ...] | Layout | None)
+LayoutInput = TypeAliasType("LayoutInput", Layout | IntTuple | tuple[object, ...] | None)
 
 
 # Make Layout from a list of layouts (each layout its own mode in the result)

--- a/torch/distributed/_pycute/layout.py
+++ b/torch/distributed/_pycute/layout.py
@@ -36,8 +36,7 @@ of lexicographic instead of co-lexicographic as implemented in the original layo
 """
 
 from itertools import chain
-from typing import TypeAlias
-from typing_extensions import Self, TypeIs
+from typing_extensions import Self, TypeAliasType, TypeIs
 
 from .int_tuple import (
     crd2idx,
@@ -51,10 +50,11 @@ from .int_tuple import (
     suffix_product,
 )
 
-
-# Type aliases
-CoordinateType: TypeAlias = (
-    int | IntTuple | tuple[object, ...] | None
+# Use TypeAliasType so that __module__ is set correctly for public API reexports
+# See: https://github.com/pytorch/pytorch/issues/171905
+CoordinateType = TypeAliasType(
+    "CoordinateType",
+    int | IntTuple | tuple[object, ...] | None,
 )  # Input for slice_ and crd2idx functions
 
 
@@ -134,9 +134,11 @@ class Layout(LayoutBase):
 
 
 # Type aliases
-LayoutOrIntTuple: TypeAlias = Layout | IntTuple
-LayoutProfile: TypeAlias = tuple[object, ...] | Layout | None
-LayoutInput: TypeAlias = Layout | IntTuple | tuple[object, ...] | None
+LayoutOrIntTuple = TypeAliasType("LayoutOrIntTuple", Layout | IntTuple)
+LayoutProfile = TypeAliasType("LayoutProfile", tuple[object, ...] | Layout | None)
+LayoutInput = TypeAliasType(
+    "LayoutInput", Layout | IntTuple | tuple[object, ...] | None
+)
 
 
 # Make Layout from a list of layouts (each layout its own mode in the result)

--- a/torch/distributed/checkpoint/_experimental/types.py
+++ b/torch/distributed/checkpoint/_experimental/types.py
@@ -7,11 +7,13 @@ saving and loading.
 """
 
 from dataclasses import dataclass
-from typing import Any, TypeAlias
+from typing import Any
+from typing_extensions import TypeAliasType
 
 
-# Type alias for state dictionaries used in checkpointing
-STATE_DICT: TypeAlias = dict[str, Any]
+# Use TypeAliasType so that __module__ is set correctly for public API reexports
+# See: https://github.com/pytorch/pytorch/issues/171905
+STATE_DICT = TypeAliasType("STATE_DICT", dict[str, Any])
 
 
 @dataclass


### PR DESCRIPTION
## Description

Closes #171905 
Replace old-style `X: TypeAlias = ...` annotations with `TypeAliasType("X", ...)` for public-facing type aliases in `torch/distributed`.

`TypeAliasType` (from `typing_extensions`, a backport of [PEP 695](https://peps.python.org/pep-0695/)) automatically sets `__module__` to the defining module, so type checkers and linters see the correct canonical location -- **without needing any manual `__module__` hack**.

### Before (problematic):
```python
from typing import TypeAlias
IntTuple: TypeAlias = int | tuple["IntTuple", ...]
# __module__ is not set - type checkers can't find the canonical location
```

### After (correct):
```python
from typing_extensions import TypeAliasType
# __module__ is automatically set to "torch.distributed._pycute.int_tuple"
IntTuple = TypeAliasType("IntTuple", int | tuple["IntTuple", ...])
```

### Files changed:
- `torch/distributed/_pycute/int_tuple.py`: `IntTuple`
- - `torch/distributed/_pycute/layout.py`: `CoordinateType`, `LayoutOrIntTuple`, `LayoutProfile`, `LayoutInput`
- - `torch/distributed/checkpoint/_experimental/types.py`: `STATE_DICT`
### Notes
- All aliases use Union types / generic types and are never used with `isinstance()`, so `TypeAliasType` is safe here (no runtime breakage).
- - `typing_extensions` is already a dependency of PyTorch.
- - Pattern follows the existing examples in `torch/ao/quantization/__init__.py` and `torch/ao/quantization/qconfig.py`.
cc @Skylion007