### PR TITLE
Restore the caller's profiler in torch.package trace_dependencies

### DIFF
--- a/test/package/test_analyze.py
+++ b/test/package/test_analyze.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: package/deploy"]
 
+import sys
 import unittest
 
 import torch
@@ -27,6 +28,37 @@ class TestAnalyze(PackageTestCase):
 
         self.assertNotIn("yaml", used_modules)
         self.assertIn("test_trace_dep", used_modules)
+
+    def test_trace_dependencies_restores_prior_profiler(self):
+        def prior_profile(frame, event, arg):
+            pass
+
+        sys.setprofile(prior_profile)
+        try:
+            analyze.trace_dependencies(lambda x: x, [(1,)])
+            self.assertIs(sys.getprofile(), prior_profile)
+        finally:
+            sys.setprofile(None)
+
+    def test_trace_dependencies_restores_prior_profiler_on_exception(self):
+        def prior_profile(frame, event, arg):
+            pass
+
+        def raises(x):
+            raise ValueError("boom")
+
+        sys.setprofile(prior_profile)
+        try:
+            with self.assertRaises(ValueError):
+                analyze.trace_dependencies(raises, [(1,)])
+            self.assertIs(sys.getprofile(), prior_profile)
+        finally:
+            sys.setprofile(None)
+
+    def test_trace_dependencies_clears_profiler_when_none_installed(self):
+        self.assertIsNone(sys.getprofile())
+        analyze.trace_dependencies(lambda x: x, [(1,)])
+        self.assertIsNone(sys.getprofile())
 
 
 if __name__ == "__main__":

--- a/torch/package/analyze/trace_dependencies.py
+++ b/torch/package/analyze/trace_dependencies.py
@@ -50,6 +50,9 @@ def trace_dependencies(
         if module:
             modules_used.add(module)
 
+    # Save the caller's profiler, if any, so that tracing does not clobber it.
+    prior_profile = sys.getprofile()
+
     try:
         # Attach record_used_modules as the profiler function.
         sys.setprofile(record_used_modules)
@@ -59,7 +62,7 @@ def trace_dependencies(
             callable(*inp)
 
     finally:
-        # Detach the profiler function.
-        sys.setprofile(None)
+        # Restore the profiler that was installed before tracing started.
+        sys.setprofile(prior_profile)
 
     return list(modules_used)


### PR DESCRIPTION
Fixes #191839

`trace_dependencies()` installs its own profiler with `sys.setprofile()` and then unconditionally calls `sys.setprofile(None)` in its `finally` block, so any profiler the caller had installed is destroyed rather than restored.

The blast radius is wider than a lost user callback: `cProfile` and `coverage.py` both work by installing a profile function, so a single `trace_dependencies()` call under `coverage run` or inside a profiling session silently stops collection for the rest of the process, with no error to point at the cause. `find_first_use_of_broken_modules()` calls `trace_dependencies()`, so it inherits the same behavior.

This saves `sys.getprofile()` before tracing starts and restores that value from the existing `finally` block. It matches what every other hook-swap site in the tree already does -- `torch/utils/viz/_cycles.py`, `torch/_dynamo/bytecode_debugger.py`, `torch/_numpy/testing/utils.py` -- and preserves the previous behavior when no profiler was installed, since `sys.getprofile()` returns `None` in that case.

## Test plan

Three tests added to `test/package/test_analyze.py`:

- `test_trace_dependencies_restores_prior_profiler` -- a profiler installed before the call is still installed after it
- `test_trace_dependencies_restores_prior_profiler_on_exception` -- same, when the traced callable raises
- `test_trace_dependencies_clears_profiler_when_none_installed` -- guards the pre-existing behavior

The first two fail on main and pass with this change; the third passes both ways.

```
python test/package/test_analyze.py
```

`lintrunner --take PYFMT,RUFF,FLAKE8` clean on both files.