### PR TITLE
Respect Tensor.grad_dtype when priming optimizer state for checkpointing

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -1109,6 +1109,25 @@ class TestNoComm(MultiProcessTestCase):
         set_optimizer_state_dict(model, optim, osd)
         set_optimizer_state_dict(model, optim, optim.state_dict())
 
+    def test_optim_state_dict_with_grad_dtype(self) -> None:
+        # A parameter may declare a gradient dtype that differs from its own
+        # dtype, e.g. an fp32 master weight accumulating bf16 gradients.
+        # _init_optim_state() has to prime the optimizer without tripping over
+        # that mismatch. See https://github.com/pytorch/pytorch/issues/191918.
+        self.assertFalse(dist.is_initialized())
+        for optim_class in (torch.optim.Adam, torch.optim.SGD):
+            model = nn.Linear(4, 4, dtype=torch.float32)
+            for param in model.parameters():
+                param.grad_dtype = torch.bfloat16
+            optim = optim_class(model.parameters(), lr=1e-2)
+
+            get_optimizer_state_dict(model, optim)
+
+            # Priming must leave the parameters exactly as it found them.
+            for param in model.parameters():
+                self.assertEqual(param.grad_dtype, torch.bfloat16)
+                self.assertIsNone(param.grad)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -643,9 +643,19 @@ def _init_optim_state(optim: torch.optim.Optimizer) -> None:
             if param.grad is not None:
                 return
 
+    # A parameter can declare a gradient dtype that differs from its own dtype
+    # (e.g. an fp32 master weight accumulating bf16 gradients). Autograd rejects
+    # a gradient that does not match `grad_dtype`, while the optimizers require
+    # the gradient to match the parameter dtype. The priming gradient is all
+    # zeros and `lr` is forced to zero below, so the dtype used here cannot
+    # affect the resulting optimizer state; relax `grad_dtype` for the duration
+    # of the priming step and restore it afterwards.
+    grad_dtypes = []
     for param_group in optim.param_groups:
         for param in param_group[_PARAMS]:
             if param.requires_grad:
+                grad_dtypes.append((param, param.grad_dtype))
+                param.grad_dtype = None
                 param.grad = torch.zeros_like(param)
 
     # Some optimizers will update parameters regardless of grads due to lr, so
@@ -659,13 +669,19 @@ def _init_optim_state(optim: torch.optim.Optimizer) -> None:
                 if isinstance(param_group["lr"], torch.Tensor)
                 else 0.0
             )
-    optim.step(closure=None)
-    # Whether to recover the "lr" should not matter too much as we will
-    # restore checkpointing later.
-    for param_group in optim.param_groups:
-        if "lr" in param_group:
-            param_group["lr"] = lrs.pop(0)
-    optim.zero_grad(set_to_none=True)
+    try:
+        optim.step(closure=None)
+    finally:
+        # Whether to recover the "lr" should not matter too much as we will
+        # restore checkpointing later.
+        for param_group in optim.param_groups:
+            if "lr" in param_group:
+                param_group["lr"] = lrs.pop(0)
+        # The gradients have to be cleared before `grad_dtype` is restored:
+        # assigning `grad_dtype` while a gradient is still attached is an error.
+        optim.zero_grad(set_to_none=True)
+        for param, grad_dtype in grad_dtypes:
+            param.grad_dtype = grad_dtype
 
 
 def _flatten_optim_state_dict(state_dict: OptimizerStateType) -> dict[str, ValueType]:


### PR DESCRIPTION
Fixes #191918

`_init_optim_state()` primes the optimizer by assigning a zero gradient at the parameter's dtype and calling `step()`. A parameter may declare a gradient dtype that differs from its own via `Tensor.grad_dtype` -- the mixed-precision setup of an fp32 master weight accumulating bf16 gradients -- and autograd rejects a gradient that does not match it. Any optimizer holding such parameters therefore cannot go through `get_optimizer_state_dict()` / `get_state_dict()` at all.

Priming at `grad_dtype` instead (the fix suggested on the issue) is not sufficient. It clears the autograd check, but then fails inside the `step()` two lines later, because the optimizers require the gradient to match the parameter dtype:

```
Adam   -> RuntimeError: expected dtype float for `end` but got dtype c10::BFloat16
AdamW  -> RuntimeError: expected dtype float for `end` but got dtype c10::BFloat16
```

That variant only appears to work on stateless optimizers like SGD, and on optimizers such as Adagrad that populate `state` in `__init__` and so return at the `if optim.state` guard before ever reaching the priming code.

This PR relaxes `grad_dtype` for the duration of the priming step instead. The priming gradient is all zeros and `lr` is forced to zero, so the dtype used here cannot affect the resulting optimizer state. Two details worth calling out:

- The restore runs from a `finally` block, so a failing `step()` cannot leave `grad_dtype` clobbered on the caller's parameters.
- It clears the gradients *before* restoring `grad_dtype`, since assigning `grad_dtype` while a gradient is still attached raises `Cannot set grad_dtype to 'BFloat16' because there is already a gradient`.

Note `grad_dtype` has three states: unset returns the parameter dtype, an explicit dtype returns that dtype, and explicitly-set-`None` returns `None`, meaning "any dtype allowed". Save-and-restore handles all three; a fix keyed on `if param.grad_dtype is not None` would not.

## Test plan

`test_optim_state_dict_with_grad_dtype` added to `TestNoComm` in `test/distributed/checkpoint/test_state_dict.py`. It sets `grad_dtype=torch.bfloat16` on fp32 parameters, calls `get_optimizer_state_dict()` over Adam and SGD, and asserts the parameters are left exactly as found (`grad_dtype` unchanged, `grad` cleared). It needs no GPU and no comms.

The test fails on main with the `RuntimeError` above and passes with this change.

```
python test/distributed/checkpoint/test_state_dict.py -k test_optim_state_dict_with_grad_dtype
```

Separately verified that the `finally` restore holds when `step()` raises: `grad_dtype` restored, gradients cleared, `lr` restored.

`lintrunner --take PYFMT,RUFF,FLAKE8,CODESPELL,TESTOWNERS` clean on both files.