### PR TITLE
Use MIOPEN_FIND_MODE=FAST for all ROCm CI

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -96,6 +96,11 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     # thread, which runs compilation inline with no pool) but bounds the number of
     # concurrent GPU-attached workers below the oversubscription threshold.
     export TORCHINDUCTOR_COMPILE_THREADS=16
+    
+    # On ROCm, MIOpen exhaustive kernel search can take hours per shape on cold cache.
+    # Use FAST mode (heuristics only) to keep benchmark CI from timing out and
+    # unit tests from running excessively long.
+    export MIOPEN_FIND_MODE=FAST
 fi
 
 export VALGRIND=ON
@@ -2219,12 +2224,6 @@ test_operator_benchmark() {
   cd benchmarks/operator_benchmark/pt_extension
   python -m pip install . -v --no-build-isolation
 
-  # On ROCm, MIOpen exhaustive kernel search can take hours per shape on cold cache.
-  # Use FAST mode (heuristics only) to keep benchmark CI from timing out.
-  if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
-    export MIOPEN_FIND_MODE=FAST
-  fi
-
   cd "${TEST_DIR}"/benchmarks/operator_benchmark
   $TASKSET python -m benchmark_all_test --device "$1" --tag-filter "$2" \
       --output-csv "${TEST_REPORTS_DIR}/operator_benchmark_eager_float32_cpu.csv" \
@@ -2253,12 +2252,6 @@ test_operator_microbenchmark() {
   python -m pip install . -v --no-build-isolation
 
   cd "${TEST_DIR}"/benchmarks/operator_benchmark
-
-  # On ROCm, MIOpen exhaustive kernel search can take hours per shape on cold cache.
-  # Use FAST mode (heuristics only) to keep benchmark CI from timing out.
-  if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
-    export MIOPEN_FIND_MODE=FAST
-  fi
 
   # NOTE: When adding a new test here, please update README: ../../benchmarks/operator_benchmark/README.md
   # OP_BENCHMARK_TESTS env var can override the default operator list (set via _linux-test.yml matrix)

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -96,6 +96,11 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     # thread, which runs compilation inline with no pool) but bounds the number of
     # concurrent GPU-attached workers below the oversubscription threshold.
     export TORCHINDUCTOR_COMPILE_THREADS=16
+    
+    # On ROCm, MIOpen exhaustive kernel search can take hours per shape on cold cache.
+    # Use FAST mode (heuristics only) to keep benchmark CI from timing out and
+    # unit tests from running excessively long.
+    export MIOPEN_FIND_MODE=FAST
 fi
 
 export VALGRIND=ON
@@ -2124,12 +2129,6 @@ test_operator_benchmark() {
   cd benchmarks/operator_benchmark/pt_extension
   python -m pip install . -v --no-build-isolation
 
-  # On ROCm, MIOpen exhaustive kernel search can take hours per shape on cold cache.
-  # Use FAST mode (heuristics only) to keep benchmark CI from timing out.
-  if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
-    export MIOPEN_FIND_MODE=FAST
-  fi
-
   cd "${TEST_DIR}"/benchmarks/operator_benchmark
   $TASKSET python -m benchmark_all_test --device "$1" --tag-filter "$2" \
       --output-csv "${TEST_REPORTS_DIR}/operator_benchmark_eager_float32_cpu.csv" \
@@ -2158,12 +2157,6 @@ test_operator_microbenchmark() {
   python -m pip install . -v --no-build-isolation
 
   cd "${TEST_DIR}"/benchmarks/operator_benchmark
-
-  # On ROCm, MIOpen exhaustive kernel search can take hours per shape on cold cache.
-  # Use FAST mode (heuristics only) to keep benchmark CI from timing out.
-  if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
-    export MIOPEN_FIND_MODE=FAST
-  fi
 
   # NOTE: When adding a new test here, please update README: ../../benchmarks/operator_benchmark/README.md
   # OP_BENCHMARK_TESTS env var can override the default operator list (set via _linux-test.yml matrix)


### PR DESCRIPTION
Here are the top 20 unit tests that run much longer than CUDA in CI as of 2026-07-27 trunk run. Many of them are conv tests that involve MIOpen. We set the `MIOPEN_FIND_MODE=FAST` env var in ROCm CI to reduce the test run time:

test_file | test_class | test_name | test_config | running_time_rocm | running_time_cuda | abs_time_diff
-- | -- | -- | -- | -- | -- | --
inductor.test_torchinductor_dynamic_shapes | DynamicShapesGPUTests | test_graph_partition_refcount_dynamic_shapes_cuda | default | 1121.9 | 24.759 | 1097.141
inductor.test_torchinductor_codegen_dynamic_shapes | DynamicShapesCodegenGPUTests | test_graph_partition_refcount_dynamic_shapes_cuda | default | 984.661 | 21.588 | 963.073
test_modules | TestModuleCUDA | test_cpu_gpu_parity_nn_LinearCrossEntropyLoss_cuda_float32 | default | 771.686 | 6.123 | 765.563
test_modules | TestModuleCUDA | test_cpu_gpu_parity_nn_LinearCrossEntropyLoss_cuda_float64 | default | 742.925 | 6.212 | 736.713
inductor.test_compile_subprocess | GPUTests | test_graph_partition_refcount_cuda | default | 589.508 | 10.964 | 578.544
test_optim | TestOptimRenewedCUDA | test_rosenbrock_sparse_with_lrsched_False_SGD_cuda_float64 | default | 504.883 | 8.165 | 496.718
test_modules | TestModuleCUDA | test_cpu_gpu_parity_nn_LinearCrossEntropyLoss_cuda_float32 | inductor | 465.613 | 9.754 | 455.859
nn.test_convolution | TestConvolutionNN | test_ConvTranspose2d_output_size_downsample_upsample | default | 358.8 | 8.43 | 350.37
test_mkldnn_fusion | TestMkldnnFusion | test_conv_unary_fusion_ops | default | 330.982 | 16.223 | 314.759
test_mkldnn_fusion | TestMkldnnFusion | test_conv_binary_fusion_ops | default | 304.622 | 5.812 | 298.81
nn.test_convolution | TestConvolutionNN | test_thnn_conv_strided_padded_dilated | default | 269.522 | 2.58 | 266.942
test_modules | TestModuleCUDA | test_cpu_gpu_parity_nn_LinearCrossEntropyLoss_cuda_float16 | inductor | 272.941 | 12.169 | 260.772
test_fx_experimental | TestFXExperimental | test_optimize_for_inference_cpu_torchvision | default | 252.553 | 5.914 | 246.639
test_modules | TestModuleCUDA | test_cpu_gpu_parity_nn_LinearCrossEntropyLoss_cuda_float64 | inductor | 255.459 | 10.386 | 245.073
nn.test_convolution | TestConvolutionNNDeviceTypeCUDA | test_conv_transpose_with_output_size_and_no_batch_dim_ConvTranspose3d_cuda | default | 242.269 | 0.002 | 242.267
export.test_retraceability | RetraceExportTestExport | test_dynamic_lstm_retraceability_strict | default | 241.071 | 13.1 | 227.971
export.test_retraceability | RetraceExportNonStrictTestExport | test_dynamic_lstm_retraceability_nonstrict | default | 231.71 | 4.298 | 227.412
nn.test_convolution | TestConvolutionNNDeviceTypeCUDA | test_conv_large_batch_1_cuda | default | 215.964 | 0.218 | 215.746
export.test_export | TestExport | test_dynamic_lstm | default | 208.49 | 3.779 | 204.711
test_legacy_vmap | TestVmapAPILegacy | test_fallback_masked_fill | default | 189.804 | 0.083 | 189.721


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang