### PR TITLE
Fix int32 overflow in cunn_SoftMaxForward for rows near INT32_MAX

### DIFF
--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -532,21 +532,25 @@ int32_t potential_register_count(int32_t dim_size, int32_t thread_count){
   return reg_cnt;
 }
 
+C10_DEVICE bool inline is_32bit_representable(const int64_t value) {
+  return value < static_cast<int64_t>(std::numeric_limits<int32_t>::max());
+}
+
 /**
  * This will apply the Epilogue with vectorized reads & writes when input & output have the same shift
  */
-template <int ILP, typename scalar_t, typename accum_t, typename outscalar_t, template<typename, typename, typename> class Epilogue>
+template <int ILP, typename scalar_t, typename accum_t, typename outscalar_t, template<typename, typename, typename> class Epilogue, typename index_t = int32_t>
 __device__ __forceinline__ void
 WriteFpropResultsVectorized(
-             int size,
-             const int shift,
+             index_t size,
+             const index_t shift,
              const scalar_t *input,
              outscalar_t *output,
              Epilogue<scalar_t, accum_t, outscalar_t> epilogue) {
   using LoadT = at::native::memory::aligned_vector<scalar_t, ILP>;
   using StoreT = at::native::memory::aligned_vector<outscalar_t, ILP>;
 
-  int offset = threadIdx.x;
+  index_t offset = threadIdx.x;
 
   // if unaligned, do one value / thread and move on, guaranteeing aligned reads/writes later
   if (shift > 0) {
@@ -562,7 +566,7 @@ WriteFpropResultsVectorized(
     output += blockDim.x;
   }
 
-  const int last = size % (ILP * blockDim.x);
+  const index_t last = size % (ILP * blockDim.x);
 
   scalar_t in_v[ILP];
   LoadT* in_value = reinterpret_cast<LoadT*>(&in_v);
@@ -650,14 +654,14 @@ WriteBpropResultsVectorized(
 /**
  * This will apply the Epilogue with non-vectorized reads & writes for the general case
  */
-template <int ILP, typename scalar_t, typename accum_t, typename outscalar_t, template<typename, typename, typename> class Epilogue>
+template <int ILP, typename scalar_t, typename accum_t, typename outscalar_t, template<typename, typename, typename> class Epilogue, typename index_t = int32_t>
 __device__ __forceinline__ void
 WriteFpropResults(
-             int classes,
+             index_t classes,
              const scalar_t *input,
              outscalar_t *output,
              Epilogue<scalar_t, accum_t, outscalar_t> epilogue) {
-  for (int offset = threadIdx.x; offset < classes; offset += blockDim.x) {
+  for (index_t offset = threadIdx.x; offset < classes; offset += blockDim.x) {
     output[offset] = epilogue(input[offset]);
   }
 }
@@ -731,7 +735,7 @@ cunn_SoftMaxForwardFast(outscalar_t *output, const scalar_t *input, int classes)
 
 template <int ILP, typename scalar_t, typename accscalar_t, typename outscalar_t, template <typename, typename, typename> class Epilogue>
 __global__ void
-cunn_SoftMaxForward(outscalar_t *output, const scalar_t *input, int classes)
+cunn_SoftMaxForward(outscalar_t *output, const scalar_t *input, int64_t classes)
 {
   extern __shared__ unsigned char smem[];
   auto sdata = reinterpret_cast<accscalar_t*>(smem);
@@ -741,27 +745,61 @@ cunn_SoftMaxForward(outscalar_t *output, const scalar_t *input, int classes)
   input += static_cast<int64_t>(blockIdx.x) * classes;
   output += static_cast<int64_t>(blockIdx.x) * classes;
 
-  const int shift = ((uint64_t)input) % ALIGN_BYTES / sizeof(scalar_t);
-  const int output_shift = ((uint64_t)output) % ALIGN_BYTES / sizeof(outscalar_t);
+  const int64_t shift = ((uint64_t)input) % ALIGN_BYTES / sizeof(scalar_t);
+  const int64_t output_shift = ((uint64_t)output) % ALIGN_BYTES / sizeof(outscalar_t);
+
+  // Row length can reach INT32_MAX (gh-191565); 32-bit index math would then
+  // wrap negative and read out of bounds. Mirror cunn_SoftMaxBackward: keep the
+  // cheaper 32-bit path and widen only when the sizes demand it.
+  const bool can_use_32bit_indexing = is_32bit_representable(shift) &&
+      is_32bit_representable(output_shift) && is_32bit_representable(classes);
 
   // find the max
-  accscalar_t threadMax = ilpReduce<MaxFloat, ILP, scalar_t, accscalar_t>(
-    shift, input, classes, MaxFloat<scalar_t, accscalar_t>(), std::numeric_limits<accscalar_t>::lowest());
+  accscalar_t threadMax;
+  if (can_use_32bit_indexing) {
+    threadMax = ilpReduce<MaxFloat, ILP, scalar_t, accscalar_t, int32_t>(
+      static_cast<int32_t>(shift), input, static_cast<int32_t>(classes),
+      MaxFloat<scalar_t, accscalar_t>(), std::numeric_limits<accscalar_t>::lowest());
+  } else {
+    threadMax = ilpReduce<MaxFloat, ILP, scalar_t, accscalar_t, int64_t>(
+      shift, input, classes,
+      MaxFloat<scalar_t, accscalar_t>(), std::numeric_limits<accscalar_t>::lowest());
+  }
   accscalar_t max_k = blockReduceWarp<Max, accscalar_t>(sdata, threadMax,
     Max<accscalar_t>(), std::numeric_limits<accscalar_t>::lowest());
 
   // reduce all values
-  accscalar_t threadExp = ilpReduce<SumExpFloat, ILP, scalar_t, accscalar_t>(
-    shift, input, classes, SumExpFloat<scalar_t, accscalar_t>(max_k), static_cast<accscalar_t>(0));
+  accscalar_t threadExp;
+  if (can_use_32bit_indexing) {
+    threadExp = ilpReduce<SumExpFloat, ILP, scalar_t, accscalar_t, int32_t>(
+      static_cast<int32_t>(shift), input, static_cast<int32_t>(classes),
+      SumExpFloat<scalar_t, accscalar_t>(max_k), static_cast<accscalar_t>(0));
+  } else {
+    threadExp = ilpReduce<SumExpFloat, ILP, scalar_t, accscalar_t, int64_t>(
+      shift, input, classes,
+      SumExpFloat<scalar_t, accscalar_t>(max_k), static_cast<accscalar_t>(0));
+  }
   accscalar_t sumAll = blockReduceWarp<Add, accscalar_t>(sdata, threadExp,
     Add<accscalar_t>(), static_cast<accscalar_t>(0));
 
   Epilogue<scalar_t, accscalar_t, outscalar_t> epilogue(max_k, sumAll);
 
   if (shift == output_shift) {
-    WriteFpropResultsVectorized<ILP, scalar_t, accscalar_t, outscalar_t, Epilogue>(classes, shift, input, output, epilogue);
+    if (can_use_32bit_indexing) {
+      WriteFpropResultsVectorized<ILP, scalar_t, accscalar_t, outscalar_t, Epilogue, int32_t>(
+          static_cast<int32_t>(classes), static_cast<int32_t>(shift), input, output, epilogue);
+    } else {
+      WriteFpropResultsVectorized<ILP, scalar_t, accscalar_t, outscalar_t, Epilogue, int64_t>(
+          classes, shift, input, output, epilogue);
+    }
   } else {
-    WriteFpropResults<ILP, scalar_t, accscalar_t, outscalar_t, Epilogue>(classes, input, output, epilogue);
+    if (can_use_32bit_indexing) {
+      WriteFpropResults<ILP, scalar_t, accscalar_t, outscalar_t, Epilogue, int32_t>(
+          static_cast<int32_t>(classes), input, output, epilogue);
+    } else {
+      WriteFpropResults<ILP, scalar_t, accscalar_t, outscalar_t, Epilogue, int64_t>(
+          classes, input, output, epilogue);
+    }
   }
 }
 
@@ -954,9 +992,6 @@ cunn_SoftMaxForwardSmem(outscalar_t *output, const scalar_t *input, index_t clas
   }
 }
 
-C10_DEVICE bool inline is_32bit_representable(const int64_t value) {
-  return value < static_cast<int64_t>(std::numeric_limits<int32_t>::max());
-}
 
 template <int ILP, typename scalar_t, typename accscalar_t, typename outscalar_t, template<typename, typename, typename> class Epilogue>
 __global__ void

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14190,6 +14190,21 @@ if __name__ == '__main__':
         rtol, atol = torch.testing._comparison.get_tolerances(torch.float16, rtol=None, atol=None)
         self.assertEqual(nll, torch.ones_like(nll) * torch.log(torch.tensor(vocab_size)), rtol=rtol, atol=atol)
 
+    # reference issue: https://github.com/pytorch/pytorch/issues/191565
+    @onlyCUDA
+    @largeTensorTest("14GB", "cuda")
+    def test_softmax_forward_64bit_indexing_large_dim(self, device):
+        # The existing 64-bit indexing coverage uses many short rows, which only
+        # exercises the int64 batch offset. A single row whose length reaches
+        # INT32_MAX overflows the index math inside cunn_SoftMaxForward instead.
+        numel = 2**31 - 1
+        x = torch.ones(1, dtype=torch.float16, device=device).expand(numel)
+        out = F.log_softmax(x, dim=-1, dtype=torch.float32)
+        # every input is equal, so softmax is uniform and log_softmax is -log(numel)
+        expected = -math.log(numel)
+        self.assertEqual(out[0].item(), expected, atol=1e-3, rtol=0)
+        self.assertEqual(out[-1].item(), expected, atol=1e-3, rtol=0)
+
     @onlyCUDA
     @largeTensorTest("20GB", "cuda")
     def test_softmax_backward_64bit_indexing(self, device):


### PR DESCRIPTION
## Issue

Fixes #191565

## Summary

`cunn_SoftMaxForward` takes the row length as a 32-bit `int`, so at `dim_size = 2**31 - 1` the index math in `ilpReduce` and `WriteFpropResults{,Vectorized}` wraps negative and reads before the buffer: an illegal memory read. 

This fix ports the `int64_t` length plus `can_use_32bit_indexing` dual dispatch that `cunn_SoftMaxBackward` already uses further down the same file, so the 32-bit path is still taken whenever the length fits. Full root cause and the reason existing 64-bit tests miss this are in #191565.

Verified on an A10 (CUDA 13.0): the reproducer is clean under `compute-sanitizer` after the change, the added test fails on an unpatched build of the same commit, and `test_nn.py` is otherwise unchanged. Timings across 8 shapes (median-of-7, 3 runs per build) moved in both directions and never by more than 0.41%.

This leaves the dual-dispatch shape duplicated between the forward and backward kernels. Factoring it into a shared helper would mean touching the working backward path and widening the diff, so I left it out, but happy to do that here or as a follow-up.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [x] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.