### PR TITLE
[pytorch][aten] make isinf/isfinite work for fp8 dtypes that cannot encode infinity (#192008)

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -458,6 +458,12 @@ Tensor isinf(const Tensor& self) {
     return at::zeros_like(self, at::kBool, at::MemoryFormat::Preserve);
   }
 
+  // FP8 types other than e5m2 cannot encode infinity
+  if (c10::isFloat8Type(self.scalar_type()) &&
+      self.scalar_type() != kFloat8_e5m2) {
+    return at::zeros_like(self, at::kBool, at::MemoryFormat::Preserve);
+  }
+
   // Note: a complex value is infinite when either part is infinite
   if (self.is_complex()) {
     return at::isinf(at::real(self)).__ior__(at::isinf(at::imag(self)));
@@ -473,6 +479,13 @@ Tensor isfinite(const Tensor& self) {
   if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true) ||
       self.scalar_type() == kFloat8_e8m0fnu) {
     return at::ones_like(self, at::kBool, at::MemoryFormat::Preserve);
+  }
+
+  // FP8 types other than e5m2 cannot encode infinity, so finiteness reduces to
+  // !isnan().
+  if (c10::isFloat8Type(self.scalar_type()) &&
+      self.scalar_type() != kFloat8_e5m2) {
+    return self == self;
   }
 
   // Note: a complex value is finite iff both parts are finite


### PR DESCRIPTION
Summary:

To fix `TORCHINDUCTOR_NAN_ASSERTS` to work with FP8 types, this is inspired by https://github.com/pytorch/pytorch/pull/178376/changes as that PR was closed unmerged. 

torch.isinf() raises `NotImplementedError`for Float8_e4m3fn (and e4m3fnuz/e5m2fnuz): isinf dispatches through _AT_DISPATCH_INF_TYPES, which only covers Double/Float/Half/BFloat16/Float8_e5m2, so the other fp8 types fall through to the dispatcher's default and throw. Simply adding them to the macro does not compile, because std::numeric_limits<Float8_e4m3fn> has no infinity() member at all.

Float8_e5m2 is the only fp8 type with an infinity encoding, so for the rest isinf is trivially false. Return zeros_like before the dispatch, mirroring the existing integral-type guard. isfinite shares the same macro and throws identically; with no infinity representation it reduces to "not NaN", i.e. `self == self`, which routes through the fp8-capable eq kernels.

Authored and iterated on with Opus 4.8.

Test Plan:
**The bug.** Before this change, `torch.isinf()` on an fp8 tensor of any type other than `Float8_e5m2` raised:

```lang=text, counterexample
NotImplementedError: "isinf" not implemented for 'Float8_e4m3fn'
```

`torch.isfinite()` failed identically (`"isfinite" not implemented for 'Float8_e4m3fn'`) because both dispatch through the same `_AT_DISPATCH_INF_TYPES` macro. `torch.isnan()` was unaffected: it is `self != self`, and the `ne` kernels already cover fp8.

With this fix, we were able to run a previously failing  (`NotImplementedError`) MAST job with `TORCHINDUCTOR_NAN_ASSERTS` turned on for much longer, and have it eventual vfail on an actual NaN assert, rather than the NotImplementedError.

Differential Revision: D114427404


