### PR TITLE
Add missing compiler flag for XNNPACK

### DIFF
--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -748,6 +748,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-mavxvnni",
             "-mf16c",
             "-mfma",
+            "-mgfni",
         ] + select({
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": [
@@ -755,12 +756,14 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 "-mavxvnni",
                 "-mf16c",
                 "-mfma",
+                "-mgfni",
             ],
             "ovr_config//cpu:x86_64": [
                 "-mavx2",
                 "-mavxvnni",
                 "-mf16c",
                 "-mfma",
+                "-mgfni",
             ],
         }),
         labels = labels,


### PR DESCRIPTION
Summary: The new pin's AVXVNNI microkernels emit _mm256_gf2p8affine_epi64_epi8, which Clang rejects without -mgfni. Added -mgfni to AVXVNNI_COMPILER_FLAGS in xplat/third-party/XNNPACK/BUCK, and to the ukernels_avxvnni base compiler_flags plus both x86_32/x86_64 select branches in fbcode/caffe2/third_party/xnnpack.buck.bzl. Matches the earlier sibling fixes D111294545/D111188711.

Test Plan:
```
buck2 build fbsource//xplat/third-party/XNNPACK:ukernels_avxvnni
```

Differential Revision: D114676466


