### PR TITLE
[Testcase Refactoring] Tag instantiate_device_type_tests-based FSDP test classes with hw_classification

### DIFF
--- a/test/distributed/fsdp/test_fsdp_traversal.py
+++ b/test/distributed/fsdp/test_fsdp_traversal.py
@@ -12,7 +12,11 @@ from torch.testing._internal.common_fsdp import (
     FSDPTestContinuous,
     NestedWrappedModule,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 
 
 if not dist.is_available():
@@ -27,6 +31,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestTraversal(FSDPTestContinuous):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         if torch.torch.accelerator.is_available():
@@ -61,9 +67,8 @@ class TestTraversal(FSDPTestContinuous):
         )
 
 
-devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(
-    TestTraversal, globals(), only_for=devices, allow_xpu=True
+    TestTraversal, globals(), except_for="cpu", allow_xpu=True
 )
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_uneven.py
+++ b/test/distributed/fsdp/test_fsdp_uneven.py
@@ -10,7 +10,11 @@ from torch.optim import SGD
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTestContinuous, get_devtype
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 
 
 if not dist.is_available():
@@ -28,6 +32,8 @@ device_type = torch.device(get_devtype())
 
 
 class TestUnevenParamShard(FSDPTestContinuous):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _get_ref_results(self, device, model, input, my_lr):
         with torch.no_grad():
             # Compute one iteration local output.
@@ -68,9 +74,8 @@ class TestUnevenParamShard(FSDPTestContinuous):
             self.assertEqual(ref_weight_out, weight_out)
 
 
-devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(
-    TestUnevenParamShard, globals(), only_for=devices, allow_xpu=True
+    TestUnevenParamShard, globals(), except_for="cpu", allow_xpu=True
 )
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
@@ -18,7 +18,11 @@ from torch.distributed.fsdp.api import (
 from torch.distributed.tensor import DTensor, Replicate, Shard
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_fsdp import get_devtype
-from torch.testing._internal.common_utils import parametrize, run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    parametrize,
+    run_tests,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorContinuousTestBase,
     skip_if_lt_x_gpu,
@@ -49,6 +53,8 @@ class DenseModel(torch.nn.Module):
 
 # TODO: Consolidate DeviceMesh based FSDP and HSDP test cases.
 class TestHSDPWithDeviceMeshAndDTensor(DTensorContinuousTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _create_model(self, device, device_mesh=None):
         device_id = device_type
         if device_mesh:
@@ -324,9 +330,8 @@ class TestHSDPWithDeviceMeshAndDTensor(DTensorContinuousTestBase):
                 self.assertIsInstance(state["exp_avg_sq"], torch.Tensor)
 
 
-devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(
-    TestHSDPWithDeviceMeshAndDTensor, globals(), only_for=devices, allow_xpu=True
+    TestHSDPWithDeviceMeshAndDTensor, globals(), except_for="cpu", allow_xpu=True
 )
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -15,6 +15,7 @@ from torch.distributed.utils import _apply_to_tensors, _replace_by_prefix
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     parametrize,
     run_tests,
     subtest,
@@ -45,6 +46,8 @@ else:
 
 
 class TestUtils(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @parametrize(
         "device_list",
         [
@@ -203,7 +206,6 @@ class TestUtils(TestCase):
         )
 
 
-devices = ("cuda", "hpu", "xpu")
-instantiate_device_type_tests(TestUtils, globals(), only_for=devices, allow_xpu=True)
+instantiate_device_type_tests(TestUtils, globals(), except_for="cpu", allow_xpu=True)
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
<!-- PR title: [Test] Tag instantiate_device_type_tests-based FSDP test classes with hw_classification and open up their device whitelist -->

## Summary

Add `hw_classification = HardwareClassification.ACCELERATOR` to the four
`TestCase` subclasses in `test/distributed/fsdp/test_utils.py`,
`test_fsdp_traversal.py`, `test_fsdp_uneven.py`, and
`test_hsdp_dtensor_state_dict.py` that are already instantiated via
`instantiate_device_type_tests`, and replace each file's hardcoded
`only_for=("cuda", "hpu", "xpu")` with `except_for="cpu"`.

## Motivation

Each of these four classes is already parameterized with
`instantiate_device_type_tests(..., globals())` at the bottom of its
file, matching the documented `ACCELERATOR` semantics in
`HardwareClassification`'s docstring (single-process, must hold across
every accelerator). No other classes in these four files needed
tagging.

Separately, all four files restrict device-type instantiation to a
hardcoded `only_for=("cuda", "hpu", "xpu")` tuple. This excludes any
runtime-registered out-of-tree `PrivateUse1` accelerator (e.g. Ascend
NPU) from ever having its test class generated at all, unless the
caller separately sets `PYTORCH_TESTING_DEVICE_FOR_CUSTOM` (the
documented escape hatch in `get_desired_device_type_test_bases`).
Switching to `except_for="cpu"` keeps CPU excluded (multi-rank tests
don't make sense there) while including CUDA/HPU/XPU and any registered
`PrivateUse1` backend by default, without requiring the environment
variable workaround. `MPS` stays excluded as before (`allow_mps` is not
set), since these are multi-rank tests and typical MPS hosts only
expose a single device.

## Changes

- `test_utils.py`: `TestUtils` -> `ACCELERATOR`; `only_for=devices` ->
  `except_for="cpu"`.
- `test_fsdp_traversal.py`: `TestTraversal` -> `ACCELERATOR`; same
  `only_for` -> `except_for` change.
- `test_fsdp_uneven.py`: `TestUnevenParamShard` -> `ACCELERATOR`; same
  `only_for` -> `except_for` change.
- `test_hsdp_dtensor_state_dict.py`: `TestHSDPWithDeviceMeshAndDTensor`
  -> `ACCELERATOR`; same `only_for` -> `except_for` change.

The `hw_classification` addition is metadata-only. The `except_for`
change is behavior-preserving for CPU/CUDA/HPU/XPU (identical set of
generated test classes) and additionally makes registered `PrivateUse1`
backends discoverable without the `PYTORCH_TESTING_DEVICE_FOR_CUSTOM`
workaround.

## Test Plan

NPU/HCCL (with the device-detection fixes from #187650 applied), prior
to the `only_for` -> `except_for` change, using
`PYTORCH_TESTING_DEVICE_FOR_CUSTOM=privateuse1` to work around the
hardcoded whitelist:

- `test_utils.py`: 6 tests passed
- `test_fsdp_traversal.py`: 1 test passed (2 ranks)
- `test_fsdp_uneven.py`: 1 test passed (4 ranks)
- `test_hsdp_dtensor_state_dict.py`: 8 tests passed (4 ranks)

The `except_for="cpu"` change was made after this verification pass and
has not yet been independently re-run; per
`get_desired_device_type_test_bases`, it should produce the identical
set of generated test classes for a `PrivateUse1` backend as the
`PYTORCH_TESTING_DEVICE_FOR_CUSTOM` workaround did, so no behavior
change is expected, but a fresh confirmation run is planned before
merge.

CPU/CUDA: not independently re-run for this PR; the change adds a class
attribute only and does not affect test discovery or execution when
`--hw-classification` is not passed.

## Related

Related to #185590.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian
