### PR TITLE
Fix LayerNorm backward returning a wrongly-shaped dgamma for multi-dim normalized_shape

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1023,25 +1023,31 @@ void LaunchGammaBetaBackwardCUDAKernel(
     Tensor dbeta_blocks;
     T * dgamma_blocks_ptr = nullptr;
     T * dbeta_blocks_ptr = nullptr;
+    // The partial-sum buffers are indexed by the kernel at stride N (the full
+    // prod(normalized_shape)), so they must be N wide. Using dgamma->size(-1)
+    // here only happens to work for a 1-D normalized_shape; for a multi-dim one
+    // it under-allocates and the kernel writes out of bounds.
     if (dgamma->defined()) {
       auto options = dgamma->options();
-      dgamma_blocks = at::empty({blocks.y * threads.y, dgamma->size(-1)}, options);
+      dgamma_blocks = at::empty({blocks.y * threads.y, N}, options);
       dgamma_blocks_ptr = dgamma_blocks.data_ptr<T>();
     }
     if (dbeta->defined() && !rms_norm) {
       auto options = dbeta->options();
-      dbeta_blocks = at::empty({blocks.y * threads.y, dgamma->size(-1)}, options);
+      dbeta_blocks = at::empty({blocks.y * threads.y, N}, options);
       dbeta_blocks_ptr = dbeta_blocks.data_ptr<T>();
     }
     LaunchAndCheckGammaBetaBackwardKernel<T, T_ACC, block_dim_x, block_dim_y, rows_per_block_y, /*skip_block_reduction=*/true, rms_norm>(
       aligned_grid, blocks, threads, 0, cuda_stream, dY_data, X_data, mean_data, rstd_data, M, N, dgamma_blocks_ptr, dbeta_blocks_ptr);
 
+    // sum(0) reduces to a flat [N]; restore normalized_shape so the returned
+    // gradient matches the parameter autograd expects.
     if (dgamma_blocks.defined()) {
-      *dgamma = dgamma_blocks.sum(0);
+      *dgamma = dgamma_blocks.sum(0).view_as(*dgamma);
     }
     if constexpr (!rms_norm){
       if (dbeta_blocks.defined()) {
-        *dbeta = dbeta_blocks.sum(0);
+        *dbeta = dbeta_blocks.sum(0).view_as(*dbeta);
       }
     }
   } else {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6665,6 +6665,49 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                     self.assertEqual(ln.bias.grad, ln_cuda.bias.grad, lambda msg: f"{msg}\nbias grad failed: {m=} {n=}", rtol=rtol, atol=atol)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_layer_norm_backwards_multidim_normalized_shape(self):
+        # Regression: with a multi-dim normalized_shape, the two-pass dgamma
+        # kernel (selected when M > 64 * 1024) sized its partial-sum buffer with
+        # normalized_shape[-1] instead of prod(normalized_shape), then rebound
+        # dgamma to the flat sum(0). That both wrote out of bounds and returned
+        # a gradient shaped [normalized_shape[-1]] instead of normalized_shape.
+        # normalized_shape is kept tiny so N // 32 < sm_count // 2 holds on every
+        # device, which is the second condition for selecting that kernel.
+        dtype = torch.float
+        normalized_shape = (2, 8)
+        for m in (64 * 1024, 64 * 1024 + 1, 66000):
+            x = torch.randn((m, *normalized_shape), dtype=dtype, requires_grad=True)
+            grad_output = torch.rand_like(x)
+            x_cuda = x.clone().detach().to("cuda").requires_grad_()
+            grad_output_cuda = grad_output.clone().detach().to("cuda")
+
+            ln = nn.LayerNorm(normalized_shape, dtype=dtype)
+            ln_cuda = nn.LayerNorm(normalized_shape, device="cuda", dtype=dtype)
+            with torch.no_grad():
+                ln_cuda.weight.copy_(ln.weight)
+                ln_cuda.bias.copy_(ln.bias)
+
+            ln(x).backward(grad_output)
+            ln_cuda(x_cuda).backward(grad_output_cuda)
+
+            self.assertEqual(ln_cuda.weight.grad.shape, normalized_shape)
+            self.assertEqual(ln_cuda.bias.grad.shape, normalized_shape)
+            atol, rtol = (1e-3, 1e-3) if m > 64 * 1024 else (1e-4, 1e-5)
+            self.assertEqual(ln.weight.grad, ln_cuda.weight.grad, lambda msg: f"{msg}\nweight grad failed: {m=}", rtol=rtol, atol=atol)
+            self.assertEqual(ln.bias.grad, ln_cuda.bias.grad, lambda msg: f"{msg}\nbias grad failed: {m=}", rtol=rtol, atol=atol)
+            self.assertEqual(x.grad, x_cuda.grad, lambda msg: f"{msg}\ninput grad failed: {m=}", rtol=rtol, atol=atol)
+
+        # dbeta requested without dgamma: the buffer for dbeta used to be sized
+        # from the (undefined) dgamma tensor.
+        m = 66000
+        x_cuda = torch.randn((m, *normalized_shape), dtype=dtype, device="cuda")
+        ln_cuda = nn.LayerNorm(normalized_shape, device="cuda", dtype=dtype)
+        ln_cuda.weight.requires_grad_(False)
+        ln_cuda(x_cuda).backward(torch.rand_like(x_cuda))
+        self.assertIsNone(ln_cuda.weight.grad)
+        self.assertEqual(ln_cuda.bias.grad.shape, normalized_shape)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     @largeTensorTest("40GB", device="cuda")
     def test_layer_norm_large_tensor(self):
         # test for https://github.com/pytorch/pytorch/issues/136291

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6671,10 +6671,17 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         # normalized_shape[-1] instead of prod(normalized_shape), then rebound
         # dgamma to the flat sum(0). That both wrote out of bounds and returned
         # a gradient shaped [normalized_shape[-1]] instead of normalized_shape.
-        # normalized_shape is kept tiny so N // 32 < sm_count // 2 holds on every
-        # device, which is the second condition for selecting that kernel.
         dtype = torch.float
         normalized_shape = (2, 8)
+        # The second condition for selecting that kernel is N // warp_size <
+        # sm_count // 2. Skip rather than silently pass if the device can't meet it.
+        props = torch.cuda.get_device_properties(torch.cuda.current_device())
+        n = math.prod(normalized_shape)
+        if not n // props.warp_size < props.multi_processor_count // 2:
+            self.skipTest(
+                f"two-pass dgamma kernel not selected on this device: "
+                f"{n=} {props.warp_size=} {props.multi_processor_count=}"
+            )
         for m in (64 * 1024, 64 * 1024 + 1, 66000):
             x = torch.randn((m, *normalized_shape), dtype=dtype, requires_grad=True)
             grad_output = torch.rand_like(x)


### PR DESCRIPTION
`nn.LayerNorm` with a multi-dimensional `normalized_shape` (e.g. `nn.LayerNorm([6, 129])`) produces a wrongly-shaped weight/bias gradient on CUDA once the row count `M` exceeds 65536, so the backward pass fails with:

```
RuntimeError: Function NativeLayerNormBackward0 returned an invalid gradient at index 1 - got [129] but expected shape compatible with [6, 129]
```

The same path also performs an out-of-bounds device write, so this is a memory-safety issue and not only a shape mismatch.

## Root cause

`LaunchGammaBetaBackwardCUDAKernel` selects a two-pass partial-sum kernel when `M > 64 * 1024 && N / block_dim_x < sm_count / 2`, where `N == prod(normalized_shape)`. That path used `dgamma->size(-1)` -- the *last dimension* of `normalized_shape` -- where the full `N` was meant, in two places:

1. The scratch buffer was allocated as
   `at::empty({blocks.y * threads.y, dgamma->size(-1)})`, but the kernel indexes it  as `dg[thread_y * N + thread_x]`. For `normalized_shape = [6, 129]` the row stride is 129 while the kernel writes at stride 774, a ~6x out-of-bounds write.
2. The reduction was assigned with `*dgamma = dgamma_blocks.sum(0)`, which rebinds  `dgamma` to a flat `[N]` tensor rather than writing into the correctly-shaped output allocated by `layer_norm_backward_cuda`. Autograd then rejects the `[129]`
   gradient for a `[6, 129]` parameter.

For a 1-D `normalized_shape`, `size(-1) == N`, so both defects are invisible. The other three gamma/beta kernels are unaffected: they take a raw `T*` and write in place, never rebinding the tensor.

A related latent bug: the `dbeta` buffer was also sized from `dgamma`, so requesting a bias gradient without a weight gradient dereferenced an undefined tensor.

## Fix

Size both partial-sum buffers with `N`, and restore `normalized_shape` on the reduced result. `view_as` is safe here: `sum(0)` returns a contiguous `[N]` tensor and `view_as` only reads the target's sizes, so it never depends on `dgamma`'s strides.

## Repro

```python
import torch

norm = torch.nn.LayerNorm([6, 129], device="cuda")
x = torch.randn(70000, 6, 129, device="cuda", requires_grad=True)
norm(x).sum().backward()        # RuntimeError before this patch
print(norm.weight.grad.shape)   # torch.Size([6, 129])
```

`M = 65536` passes and `M = 65537` fails, matching the `M > 64 * 1024` guard.

## Why existing tests missed it

`test_layer_norm_backwards_eps` already covers large `M` (including `(128 * 1024, 32)`) and is even aware of the 65536 boundary, but every case uses a **1-D** `normalized_shape`. The multi-dim x large-`M` cell was uncovered.

Note also the second selection condition, `N / warp_size < sm_count / 2`: the bug only reproduces on a GPU with enough SMs. It fires on a full H100 (132 SMs) but is dormant on a small MIG slice, which makes it easy to miss in CI. The new test therefore keeps
`normalized_shape` small and, rather than assuming that suffices, queries `warp_size` / `multi_processor_count` and skips with an explicit message when the device cannot select the affected kernel -- so it can never silently pass without covering the bug.

## Test plan

```
python test/test_nn.py -k test_layer_norm_backwards_multidim_normalized_shape
python test/test_nn.py -k test_layer_norm_backwards_eps
```

`test_layer_norm_backwards_multidim_normalized_shape` covers `M` at 65536 / 65537 / 66000 with a 2-D `normalized_shape`, checking gradient shape and comparing `dgamma`/`dbeta`/`dx` against CPU, plus the dbeta-without-dgamma case. It fails on the parent commit with the error above and passes with the fix. Verified on an H100.

(This fix and commit message was done with the help of AI coding agent.)
