### PR TITLE
Fix F.normalize producing NaN for zero-norm float16 inputs

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8440,6 +8440,33 @@ class TestNNDeviceType(NNTestCase):
 
         self.assertEqual(Y_ref, Y)
 
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float16, torch.bfloat16, torch.float32, torch.float64)
+    @dtypesIfMPS(torch.float16, torch.bfloat16, torch.float32)
+    def test_normalize_zero_norm_default_eps(self, device, dtype):
+        # The previous default eps of 1e-12 rounds to 0.0 in float16, so clamp_min
+        # could not stop a zero-norm vector from evaluating 0/0.
+        x = torch.zeros(2, 4, device=device, dtype=dtype, requires_grad=True)
+        out = F.normalize(x, dim=1)
+        self.assertEqual(out, torch.zeros_like(out))
+
+        out.sum().backward()
+        self.assertTrue(torch.isfinite(x.grad).all())
+
+        out_kwarg = torch.empty_like(x)
+        F.normalize(x.detach(), dim=1, out=out_kwarg)
+        self.assertEqual(out_kwarg, torch.zeros_like(out_kwarg))
+
+    @onlyNativeDeviceTypes
+    @dtypes(torch.bfloat16, torch.float32, torch.float64)
+    @dtypesIfMPS(torch.bfloat16, torch.float32)
+    def test_normalize_default_eps_unchanged_off_half(self, device, dtype):
+        # Only float16 gains a new default; every other dtype stays bit-identical.
+        x = torch.randn(16, 8, device=device).to(dtype)
+        self.assertEqual(
+            F.normalize(x, dim=1), F.normalize(x, dim=1, eps=1e-12), atol=0, rtol=0
+        )
+
     @onlyCPU
     def test_glu_bfloat16(self, device):
         def test_dtype(fn, input, dtype):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6097,7 +6097,7 @@ def normalize(
     input: Tensor,
     p: float = 2.0,
     dim: int = 1,
-    eps: float = 1e-12,
+    eps: float | None = None,
     out: Tensor | None = None,
 ) -> Tensor:
     r"""Perform :math:`L_p` normalization of inputs over specified dimension.
@@ -6114,7 +6114,10 @@ def normalize(
         input: input tensor of any shape
         p (float): the exponent value in the norm formulation. Default: 2
         dim (int or tuple of ints): the dimension to reduce. Default: 1
-        eps (float): small value to avoid division by zero. Default: 1e-12
+        eps (float, optional): small value to avoid division by zero. Default: ``1e-12``,
+            except when the norm is computed in ``float16``, which uses
+            ``torch.finfo(torch.float16).tiny`` because ``1e-12`` is not representable
+            in that dtype.
         out (Tensor, optional): the output tensor. If :attr:`out` is used, this
                                 operation won't be differentiable.
     """
@@ -6122,12 +6125,15 @@ def normalize(
         return handle_torch_function(
             normalize, (input, out), input, p=p, dim=dim, eps=eps, out=out
         )
+    denom = input.norm(p, dim, keepdim=True)
+    if eps is None:
+        # float16 rounds 1e-12 to 0.0, which silently disables the clamp below.
+        # Literal is torch.finfo(torch.float16).tiny; torch.finfo is not scriptable.
+        eps = 6.103515625e-05 if denom.dtype == torch.float16 else 1e-12
     if out is None:
-        denom = input.norm(p, dim, keepdim=True).clamp_min(eps).expand_as(input)
-        return input / denom
+        return input / denom.clamp_min(eps).expand_as(input)
     else:
-        denom = input.norm(p, dim, keepdim=True).clamp_min_(eps).expand_as(input)
-        return torch.div(input, denom, out=out)
+        return torch.div(input, denom.clamp_min_(eps).expand_as(input), out=out)
 
 
 def assert_int_or_pair(arg: list[int], arg_name: str, message: str) -> None:

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -978,7 +978,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.nn.functional.nll_loss: (
             lambda input, target, weight=None, size_average=None, ignore_index=-100, reduce=None, reduction="mean": -1
         ),
-        torch.nn.functional.normalize: lambda input, p=2, dim=1, eps=1e-12, out=None: -1,
+        torch.nn.functional.normalize: lambda input, p=2, dim=1, eps=None, out=None: -1,
         torch.nn.functional.one_hot: lambda tensor, num_classes=-1: -1,
         torch.nn.functional.pad: lambda input, pad, mode="constant", value=0: -1,
         torch.nn.functional.pairwise_distance: lambda x1, x2, p=2.0, eps=1e-06, keepdim=False: -1,


### PR DESCRIPTION
Fixes #32137

### Problem

`F.normalize` returns `NaN` for any zero-norm vector in `float16`, in both the forward and the backward pass. Other floating dtypes return zeros correctly.

```python
>>> F.normalize(torch.zeros(2, 4, dtype=torch.float16), dim=1)
tensor([[nan, nan, nan, nan],
        [nan, nan, nan, nan]], dtype=torch.float16)
>>> F.normalize(torch.zeros(2, 4, dtype=torch.float32), dim=1)   # fine
tensor([[0., 0., 0., 0.],
        [0., 0., 0., 0.]])
```

Reproduces on CPU and CUDA, and under `torch.export`.

### Root cause

`normalize` divides by `input.norm(p, dim, keepdim=True).clamp_min(eps)` with a hardcoded `eps=1e-12`. The norm tensor inherits the input dtype, and `float16` cannot represent `1e-12` at all -- its smallest positive subnormal is `5.96e-8`, so the constant rounds to exactly `0.0`. `clamp_min(0.0)` is a no-op, and the division evaluates `0/0`.

The clamp exists solely to prevent that division, and it is inert in precisely the dtype that needs it.

`bfloat16` is unaffected despite also being 16-bit, because its 8 exponent bits represent `1e-12` fine. The defect is one of range, not precision.

### Fix

`eps` becomes `Optional[float]`, mirroring `F.rms_norm`, defaulting to `torch.finfo(torch.float16).tiny` when the norm is computed in `float16`.

Two implementation notes that are not obvious:

- The constant is a literal because **`torch.finfo` is not scriptable** -- there is no `aten::finfo`, even for a literal dtype -- while `F.normalize` is scriptable today. Calling `finfo` here would be a TorchScript BC break.
- The dtype is read off the *norm*, not the input, because `eps` guards the division. For a `complex32` input the norm is `float16`, so `input.dtype` would miss it.

### On the choice of constant

`torch.finfo(dtype).eps`, per the umbrella rules in #151110, also fixes the NaN. I did not use it because `bfloat16` has no defect yet would take the largest change: `finfo(bfloat16).eps` is `7.8e-3`, so a `bfloat16` vector of norm `1e-3` would go from unit length to `0.128`. `float32` would also move for no defect.

`tiny` leaves every dtype except `float16` bit-identical, clamps *exactly* the `float16` subnormals, and keeps `1/eps = 16384` representable.

A smaller constant is not a safe middle ground -- `1e-6` gives a zero-norm `float16` gradient of `1e6`, which overflows to `inf` rather than fixing anything:

| eps (float16) | zero-norm gradient |
|---|---|
| `1e-12` (current) | `nan` |
| `1e-6` | `inf` |
| `finfo.tiny` = `6.1e-5` (this PR) | `16384` |
| `finfo.eps` = `9.8e-4` (#151110 rule) | `1024` |

**Happy to switch to the uniform `finfo(dtype).eps` rule if preferred** -- it is a one-line change to the conditional. I kept this PR minimal because the `bfloat16` change seemed like it should be a deliberate decision rather than a side effect.

### Backward compatibility

`float32`, `float64` and `bfloat16` are bit-identical to the old default; this is asserted in the tests with `atol=0, rtol=0`. Explicitly passed `eps` values are untouched.

The one behaviour change is `float16` vectors whose norm is subnormal (`< 6.1e-5`). Some of those previously produced a correct result -- e.g. norm `2e-5` gave `0.5` and now gives `0.164`. That is the cost of making the zero-norm gradient representable, and it is strictly narrower than what the #151110 rule would do.

### Tests

`test_normalize_zero_norm_default_eps` covers the zero-norm forward, the gradient, and the separate `out=` code path across four dtypes and both native device types. It fails before this change on `float16` only, with `Greatest absolute difference: nan at index (0, 0)`.

`test_normalize_default_eps_unchanged_off_half` never fails today by design -- it pins the backward-compatibility claim that only `float16` moves, so a future switch to a uniform epsilon rule has to be an explicit, reviewed decision rather than a silent numerics change.

```
python -m pytest test/test_nn.py -k "normalize_zero_norm_default_eps or normalize_default_eps_unchanged_off_half" -v
python -m pytest test/test_nn.py -k "normalize"
python -m pytest test/test_ops.py -k "normalize and not batch_norm and not layer_norm and not group_norm and not rms_norm and not weight_norm"
python -m pytest test/test_overrides.py
spin quicklint
```

7 passed; 8 passed / 4 skipped; 41 passed / 8 skipped; 7462 passed / 155 skipped; no lint issues.

Also verified by hand: `torch.jit.script` still compiles `F.normalize`; `torch.compile` (eager, aot_eager) and `torch.export` no longer produce NaN, and the exported graph carries the new constant with correct dtype guards.

### Performance

One Python-level dtype comparison per call, before any kernel launch. No extra kernels.

### Known limitations

CUDA was not exercised against the patched source (my local build is CPU-only), though the pre-existing bug was confirmed to behave identically on CUDA. inductor was not exercised as it needs a C++ compiler I do not have locally. MPS was not exercised for lack of hardware; the tests carry `@dtypesIfMPS` mirroring the neighbouring `test_rmsnorm_epsilon`.

---

> AI assistance disclosure: I used Claude Code to help inspect the relevant code paths and draft portions of the patch and tests. I reviewed every change, reproduced the issue independently, ran the reported validation, and can explain the implementation. The final technical decisions and this submission are my responsibility.
