### PR TITLE
[MPSInductor] Add uint-types support to Inductor Metal codegen

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -204,6 +204,15 @@ class MPSBasicTests(TestCase):
 
         self.common(fn, (torch.eye(64),), check_lowp=False)
 
+    def test_eye_uint16_index(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/191942
+        def fn(x):
+            return torch.eye(x.shape[-1], dtype=x.dtype, device=x.device)
+
+        x = torch.zeros(10, 256, device=self.device)
+        compiled = torch.compile(fn)
+        self.assertEqual(compiled(x), fn(x))
+
     def test_reduced_max(self):
         # inductor test do not validate that max of say 16K half elements can be computed
         self.common(torch.max, (torch.rand(16384, dtype=torch.half),), check_lowp=False)

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -204,13 +204,18 @@ class MPSBasicTests(TestCase):
 
         self.common(fn, (torch.eye(64),), check_lowp=False)
 
-    def test_eye_uint16_index(self):
-        # Regression test for https://github.com/pytorch/pytorch/issues/191942
-        def fn(x):
-            return torch.eye(x.shape[-1], dtype=x.dtype, device=x.device)
-
-        self.common(fn, (torch.zeros(10, 256),))
-
+>>> torch.eye(10, device="mps", dtype=torch.uint16)
+Traceback (most recent call last):
+  File "<python-input-4>", line 1, in <module>
+    torch.eye(10, device="mps", dtype=torch.uint16)
+    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+RuntimeError: Failed to create function state object for: eye_ushort
+>>> torch.eye(10, device="cpu", dtype=torch.uint16)
+Traceback (most recent call last):
+  File "<python-input-5>", line 1, in <module>
+    torch.eye(10, device="cpu", dtype=torch.uint16)
+    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+NotImplementedError: "eye" not implemented for 'UInt16'
     def test_reduced_max(self):
         # inductor test do not validate that max of say 16K half elements can be computed
         self.common(torch.max, (torch.rand(16384, dtype=torch.half),), check_lowp=False)

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -204,13 +204,6 @@ class MPSBasicTests(TestCase):
 
         self.common(fn, (torch.eye(64),), check_lowp=False)
 
-    def test_eye_uint16_index(self):
-        # Inductor uses uint16 indices for this size; the output remains float32.
-        def fn(x):
-            return torch.eye(x.shape[-1], device=x.device)
-
-        self.common(fn, (torch.zeros(10, 256),))
-
     def test_reduced_max(self):
         # inductor test do not validate that max of say 16K half elements can be computed
         self.common(torch.max, (torch.rand(16384, dtype=torch.half),), check_lowp=False)

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -204,18 +204,13 @@ class MPSBasicTests(TestCase):
 
         self.common(fn, (torch.eye(64),), check_lowp=False)
 
->>> torch.eye(10, device="mps", dtype=torch.uint16)
-Traceback (most recent call last):
-  File "<python-input-4>", line 1, in <module>
-    torch.eye(10, device="mps", dtype=torch.uint16)
-    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-RuntimeError: Failed to create function state object for: eye_ushort
->>> torch.eye(10, device="cpu", dtype=torch.uint16)
-Traceback (most recent call last):
-  File "<python-input-5>", line 1, in <module>
-    torch.eye(10, device="cpu", dtype=torch.uint16)
-    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-NotImplementedError: "eye" not implemented for 'UInt16'
+    def test_eye_uint16_index(self):
+        # Inductor uses uint16 indices for this size; the output remains float32.
+        def fn(x):
+            return torch.eye(x.shape[-1], device=x.device)
+
+        self.common(fn, (torch.zeros(10, 256),))
+
     def test_reduced_max(self):
         # inductor test do not validate that max of say 16K half elements can be computed
         self.common(torch.max, (torch.rand(16384, dtype=torch.half),), check_lowp=False)

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -209,9 +209,7 @@ class MPSBasicTests(TestCase):
         def fn(x):
             return torch.eye(x.shape[-1], dtype=x.dtype, device=x.device)
 
-        x = torch.zeros(10, 256, device=self.device)
-        compiled = torch.compile(fn)
-        self.assertEqual(compiled(x), fn(x))
+        self.common(fn, (torch.zeros(10, 256),))
 
     def test_reduced_max(self):
         # inductor test do not validate that max of say 16K half elements can be computed

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19369,6 +19369,13 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         for _ in range(4):
             self.assertEqual(compiled(x, a, b), fn(x, a, b))
 
+    def test_eye_uint16_index(self):
+        # Inductor uses uint16 indices for this size; the output remains float32.
+        def fn(x):
+            return torch.eye(x.shape[-1], device=x.device)
+
+        self.common(fn, (torch.zeros(10, 256, device=self.device),))
+
     # end of class CommonTemplate - add new tests here
 
 

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -47,6 +47,8 @@ DTYPE_TO_METAL = {
     torch.int64: "long",
     torch.uint8: "uchar",
     torch.uint16: "ushort",
+    torch.uint32: "uint",
+    torch.uint64: "ulong",
     torch.float: "float",
     torch.half: "half",
     torch.bfloat16: "bfloat",

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -46,6 +46,7 @@ DTYPE_TO_METAL = {
     torch.int32: "int",
     torch.int64: "long",
     torch.uint8: "uchar",
+    torch.uint16: "ushort",
     torch.float: "float",
     torch.half: "half",
     torch.bfloat16: "bfloat",


### PR DESCRIPTION
## Summary

`torch.eye(256)` can produce `torch.uint16` index expressions in Inductor. Metal code generation failed because `DTYPE_TO_METAL` did not contain that dtype and `MetalOverrides.to_dtype` raised a `KeyError`.

This maps `torch.uint16` to `ushort`, `torch.uint32` to `uint` and `torch.uint64` to `ulong`.

Fixes #191942

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo