### PR TITLE
[CI] Advisor: pass github_token to skip the OIDC app-token exchange

### DIFF
--- a/.github/workflows/claude-autorevert-advisor.yml
+++ b/.github/workflows/claude-autorevert-advisor.yml
@@ -26,6 +26,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      # Needed by the advisor's `gh pr view` investigation step, since the
+      # scoped GITHUB_TOKEN below replaces the action's own app token.
+      pull-requests: read
 
     steps:
       - name: Checkout pytorch/pytorch trunk
@@ -48,6 +51,11 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
         with:
+          # Providing the workflow token stops the action from minting its own
+          # app token, bypassing Anthropic's OIDC app-token exchange -- the
+          # source of the observed intermittent "Workflow validation failed"
+          # 401s, which require the workflow to match the default branch.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: "pytorch-auto-revert[bot],pytorch-bot[bot]"
           use_bedrock: "true"
           claude_args: |


### PR DESCRIPTION
## Summary

The Claude CI Advisor is the **only** Claude workflow in `pytorch/pytorch` that does not pass `github_token:` to `anthropics/claude-code-action`. That omission — not the pinned version — is what makes it the only one hitting the intermittent `Workflow validation failed …` 401.

At the currently pinned ref (`6e2bd528`, v1.0.89), `src/github/token.ts` reads:

```ts
export async function setupGitHubToken(): Promise<string> {
  const providedToken = process.env.OVERRIDE_GITHUB_TOKEN;   // = inputs.github_token
  if (providedToken) { return providedToken; }               // <- returns BEFORE the exchange
  const oidcToken = await retryWithBackoff(() => getOidcToken());
  const appToken  = await retryWithBackoff(() => exchangeForAppToken(oidcToken, permissions), {...});
}
```

`exchangeForAppToken()` POSTs `api.anthropic.com/api/github/github-app-token-exchange` and is the only call site that can return the 401 carrying that message. Passing `github_token` never reaches it.

## Why this instead of bumping the pin

The alternative under discussion was bumping past upstream [anthropics/claude-code-action#1417](https://github.com/anthropics/claude-code-action/pull/1417), which converts that 401 into a graceful warn+skip. But a skipped run still produces **no verdict** — it trades a visible red for a silent green-empty run, and it's a ~90-version jump on a workflow that uses `allowed_bots`, `use_bedrock`, `--json-schema`, `settings`, and both the `structured_output` and `execution_file` outputs. This change removes the failure class at the current pin with no version-jump risk.

Version currency is a separate question and can be decided on its own merits.

## Why `pull-requests: read` ships in the same patch

With an explicit `permissions:` block present, unlisted scopes are `none`. The action's app token carried pull-request read implicitly; the scoped `GITHUB_TOKEN` does not, and the advisor's investigation prompt runs:

```
gh pr view ${{ inputs.pr_number }} --repo pytorch/pytorch --json title,body,files
```

Without the added scope that call would start failing on a private-metadata read, so the two lines belong together.

## Prior art

`claude-issue-triage-run.yml`, `claude-distributed-triage.yml`, and the gha-infra sibling `claude-infra-investigations.yml` all already pass `github_token`. The gha-infra one carries a comment naming this exact mechanism: *"it makes the action skip its OIDC app-token exchange, which requires the workflow to match the default branch."*

## Context

- gha-infra issue: https://github.com/meta-pytorch/pytorch-gha-infra/issues/1320 (closed 2026-07-26; the error string recurred 4× on 2026-07-29/30 with no new issue filed)
- Note the 401 is only part of the current failure mix — the other half is `--json-schema was provided but Claude did not return structured_output`, which neither this change nor a version bump addresses. Base rate overall is ~0.73% (162 / 22,274 runs).
