### PR TITLE
[Inductor] Fix KeyError: 'complex64' by adding complex dtypes to _type_of

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -569,6 +569,20 @@ def helper(x):
                 sig, expected_sig, lambda msg: f"{msg}\nwrong signature for {dtype}"
             )
 
+    def test_signature_of_complex_dtypes(self):
+        """complex dtypes should produce correct Triton pointer signatures via _type_of."""
+        expected = {
+            torch.complex32: "*c32",
+            torch.complex64: "*c64",
+            torch.complex128: "*c128",
+        }
+        for dtype, expected_sig in expected.items():
+            arg = TensorArg(name="x", buffer="buf0", dtype=dtype)
+            sig = triton_utils.signature_of(arg, size_dtype=None)
+            self.assertEqual(
+                sig, expected_sig, lambda msg: f"{msg}\nwrong signature for {dtype}"
+            )
+
     @unittest.skipUnless(has_triton_package(), "requires Triton package")
     def test_fp8_dtype_support_matrix(self):
         self.assertFalse(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -601,6 +601,9 @@ def _type_of(key: torch.dtype | None) -> str:
         "uint16": "u16",
         "uint32": "u32",
         "uint64": "u64",
+        "complex32": "c32",
+        "complex64": "c64",
+        "complex128": "c128",
     }
     # reinterpret can create triton type
     tys.update({v: v for v in list(tys.values())})


### PR DESCRIPTION
### Description
Fixes #191330.

In `torch/_inductor/utils.py`, `_type_of` maps PyTorch dtypes to Triton type strings (e.g., `float32` -> `fp32`). When `_type_of` or `signature_of` were called on complex tensor dtypes (`complex32`, `complex64`, `complex128`), `_type_of` raised `KeyError: 'complex64'` because complex dtypes were omitted from the `tys` mapping table.

This PR adds `"complex32": "c32"`, `"complex64": "c64"`, and `"complex128": "c128"` to `_type_of` in `torch/_inductor/utils.py` and adds a regression test in `test/inductor/test_codegen_triton.py`.

### Testing
- Added `test_signature_of_complex_dtypes` in `test/inductor/test_codegen_triton.py`.
- Verified locally that `_type_of` and `signature_of` produce `*c32`, `*c64`, `*c128` for complex dtypes without error.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo