### PR TITLE
[Inductor] Keep padded tail divisors non-zero in vectorized integer remainder

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3845,6 +3845,36 @@ class CPUReproTests(TestCase):
             self.common(torch.remainder, _args)
             check_metrics_vec_kernel_count(1)
 
+    @requires_vectorization
+    def test_vec_remainder_tail(self):
+        # 131 leaves a masked tail for every integer dtype width on every
+        # supported ISA, and the tail load zero-fills the padded lanes. A
+        # padded zero divisor must not trip the divide-by-zero check; only a
+        # real one may.
+        def fn(a, b):
+            return a % b
+
+        for dtype in [torch.uint8, torch.int8, torch.int32, torch.int64]:
+            a = torch.arange(131, dtype=dtype) + 1
+            b = torch.full((131,), 16, dtype=dtype)
+            torch._dynamo.reset()
+            metrics.reset()
+            self.common(fn, (a, b))
+            check_metrics_vec_kernel_count(1)
+
+        # The reported repro shape: odd inner size, broadcast divisor. Whether
+        # it vectorizes is ISA-dependent, so pin correctness only.
+        a = torch.arange(6, dtype=torch.int64).reshape(2, 3) + 1
+        b = torch.full((3,), 16, dtype=torch.int64)
+        torch._dynamo.reset()
+        self.common(fn, (a, b))
+
+        a = torch.arange(6, dtype=torch.int64).reshape(2, 3)
+        b = torch.tensor([16, 0, 16], dtype=torch.int64)
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(RuntimeError, "ZeroDivisionError"):
+            torch.compile(fn, fullgraph=True)(a, b)
+
     def test_skip_cpp_codegen(self):
         with config.patch({"disable_cpp_codegen": True}):
             inps = torch.ones([20]), torch.rand([20])

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3675,6 +3675,27 @@ class CPUReproTests(TestCase):
             self.common(torch.remainder, _args)
             check_metrics_vec_kernel_count(1)
 
+    @requires_vectorization
+    def test_vec_remainder_tail(self):
+        # Odd inner sizes leave padded lanes in the masked tail load, and those
+        # lanes are zero-filled. A padded zero divisor must not trip the
+        # divide-by-zero check; only a real one may.
+        def fn(a, b):
+            return a % b
+
+        for dtype in [torch.uint8, torch.int8, torch.int32, torch.int64]:
+            for length in [3, 5, 7]:
+                a = torch.arange(2 * length, dtype=dtype).reshape(2, length) + 1
+                b = torch.full((length,), 16, dtype=dtype)
+                torch._dynamo.reset()
+                self.common(fn, (a, b))
+
+        a = torch.arange(6, dtype=torch.int64).reshape(2, 3)
+        b = torch.tensor([16, 0, 16], dtype=torch.int64)
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(RuntimeError, "ZeroDivisionError"):
+            torch.compile(fn, fullgraph=True)(a, b)
+
     def test_skip_cpp_codegen(self):
         with config.patch({"disable_cpp_codegen": True}):
             inps = torch.ones([20]), torch.rand([20])

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1548,10 +1548,11 @@ class CppVecOverrides(CppOverrides):
                 "remainder vec implementation expect the same inputs' dtype."
             )
         if is_integer_dtype(a.dtype):
-            # Doing blend to set the remaining bits of b to non-zero
+            # Padded divisor lanes must stay non-zero: masked tail loads
+            # zero-fill the unused lanes, and a zero there trips the
+            # divide-by-zero check even though the lane is never stored.
             _t = f"decltype({a})"
-            if V.kernel._get_raw_num_vectors(b.dtype) < 1:
-                b = f"{_t}::blend<{(1 << V.kernel.tiling_factor) - 1}>({_t}(1), {b})"
+            b = f"{_t}::set({_t}(1), {b}, {cexpr_index(V.kernel.num_elems)})"
             return f"remainder_integral({a}, {b})"
         return f"{a} - ({CppVecOverrides.floordiv(a, b)}) * {b}"
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1548,10 +1548,11 @@ class CppVecOverrides(CppOverrides):
                 "remainder vec implementation expect the same inputs' dtype."
             )
         if is_integer_dtype(a.dtype):
-            # Doing blend to set the remaining bits of b to non-zero
-            _t = f"decltype({a})"
-            if V.kernel._get_raw_num_vectors(b.dtype) < 1:
-                b = f"{_t}::blend<{(1 << V.kernel.tiling_factor) - 1}>({_t}(1), {b})"
+            # Padded divisor lanes must stay non-zero: masked tail loads
+            # zero-fill the unused lanes, and a zero there trips the
+            # divide-by-zero check even though the lane is never stored.
+            _t = f"decltype({b})"
+            b = f"{_t}::set({_t}(1), {b}, {cexpr_index(V.kernel.num_elems)})"
             return f"remainder_integral({a}, {b})"
         return f"{a} - ({CppVecOverrides.floordiv(a, b)}) * {b}"
 
@@ -2906,11 +2907,6 @@ class CppVecKernel(CppKernel):
         if num_vectors < 1:
             raise AssertionError("expected num_vectors >= 1")
         return num_vectors
-
-    def _get_raw_num_vectors(self, dtype: torch.dtype) -> float:
-        # This utility function is used to check if the vector lanes has been
-        # fully utilized. For example, uint8 will only use 1/4 of the vector lanes.
-        return self.tiling_factor * dtype.itemsize * 8 / self.vec_isa.bit_width()
 
     def _get_vec_type(self, dtype: torch.dtype) -> str:
         num_vectors = self._get_num_vectors(dtype)


### PR DESCRIPTION
Fixes #191968.

An integer remainder with an inner size that does not fill the vector raises a spurious `ZeroDivisionError` on the CPU Inductor backend, while eager and TorchScript answer the same inputs fine. Reproduces on the first compiled call:

```python
def mod(indices, ns):
    return indices % ns

indices = torch.arange(6, dtype=torch.int64).reshape(2, 3)
ns = torch.tensor([16, 16, 16], dtype=torch.int64)
torch.compile(mod, fullgraph=True)(indices, ns)  # ZeroDivisionError
```

The generated kernel processes the tail with a masked `loadu(ptr, 3)`, which zero-fills the unused lanes. `remainder_integral` then evaluates the divide-by-zero check from #179923 on every lane, so the padded zero reads as a real zero divisor and trips `inductor_cpu_throw_if_integer_div_error`, even though that lane is never stored. This is what made odd inner sizes (3, 5, 7) fail while even ones pass.

Vectorized `floordiv` already handles the same hazard with `VectorizedN::set(one, b, num_elems)`, which fills padded divisor lanes with 1. This PR gives `remainder` the same guard and drops the narrower sub-vector-only blend it subsumes.

## Test plan

New `test_vec_remainder_tail` covers tail lengths 3/5/7 across the four integer dtypes and confirms a genuine zero divisor still raises `ZeroDivisionError`. Verified against a 2.13.0 arm64 wheel with the patched codegen: full tail matrix green, values match eager, real zero divisors still raise, and the same matrix fails with the pre-fix codegen. Relying on CI for the repo suite since there is no local build tree here.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo