### PR TITLE
[Testcase Refactoring] Add hw_classification to test_processgroup_jit

### DIFF
--- a/test/distributed/test_processgroup_jit.py
+++ b/test/distributed/test_processgroup_jit.py
@@ -5,6 +5,7 @@ import unittest
 import torch
 import torch.distributed as dist
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     scoped_load_inline,
     skipIfTorchDynamo,
@@ -25,6 +26,8 @@ class DummyProcessGroup(dist.ProcessGroup):
 @unittest.skipIf(not dist.is_available(), "requires distributed")
 @skipIfTorchDynamo("JIT/C++ extension test")
 class TestProcessGroupCapsule(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @scoped_load_inline
     def test_processgroup_capsule_discrimination(self, load_inline):
         """Test C++ can distinguish string vs ProcessGroup vs other capsule types."""


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to `TestProcessGroupCapsule` in `test_processgroup_jit.py`, following the convention that every `TestCase` subclass carries a hardware classification label.

## Changes

- **`test/distributed/test_processgroup_jit.py`**:
  - Imported `HardwareClassification` from `torch.testing._internal.common_utils`.
  - Labeled `TestProcessGroupCapsule` with `hw_classification = HardwareClassification.GENERIC`.

## Motivation

`TestProcessGroupCapsule` exercises C++ extension / IValue type discrimination logic (`scoped_load_inline` + `dynamic_cast<c10d::ProcessGroup*>`) against a `DummyProcessGroup` — a fake process group that never touches a real device. The test asserts IValue type tags (string/capsule/int/tensor) and ProcessGroup rank/size extraction, which is pure framework mechanics with no device dependency. It classifies as `GENERIC` (device-agnostic), not `ACCELERATOR` or `CUDA`. An unclassified class is silently dropped when `--hw-classification GENERIC ACCELERATOR` is passed, so labeling it ensures it is correctly selected under hardware-classification filtering.

## Test Plan

- Verified on an accelerator backend (8 devices) that the test still passes after adding the label:

  ```bash
  python test/distributed/test_processgroup_jit.py -v
  ```

  Output: `Ran 1 test in 22.305s / OK`. The C++ extension (`test_pg_capsule`) compiles and links successfully; all 7 IValue type discrimination assertions pass. The test does not touch the accelerator (fake PG, no device tensors), consistent with the `GENERIC` classification.

## Notes

- This is part of the test case refactoring initiative tracked in #185590.
