### PR TITLE
[Test] Generalize `export/test_torchbind.py` tests and enable on XPU

### DIFF
--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -769,6 +769,11 @@ TORCH_LIBRARY_IMPL(_TorchScriptTesting, CUDA, m) {
   m.impl("queue_pop", queue_pop);
 }
 
+TORCH_LIBRARY_IMPL(_TorchScriptTesting, XPU, m) {
+  m.impl("queue_push", queue_push);
+  m.impl("queue_pop", queue_pop);
+}
+
 TORCH_LIBRARY_IMPL(_TorchScriptTesting, Meta, m) {
   m.impl("takes_foo", &takes_foo);
   m.impl("takes_foo_list_return", takes_foo_list_return);

--- a/test/export/test_torchbind.py
+++ b/test/export/test_torchbind.py
@@ -1694,7 +1694,7 @@ class TestRegisterFakeClass(TestCase):
 
 instantiate_parametrized_tests(TestExportTorchbind)
 instantiate_parametrized_tests(TestCompileTorchbind)
-instantiate_device_type_tests(TestCompileTorchbindDevice, globals())
+instantiate_device_type_tests(TestCompileTorchbindDevice, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/export/test_torchbind.py
+++ b/test/export/test_torchbind.py
@@ -12,6 +12,7 @@ from torch._higher_order_ops.wrap import wrap
 from torch._library.fake_class_registry import FakeScriptObject
 from torch.export._trace import _export
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -20,11 +21,11 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TestCase,
 )
+from torch.testing._internal.inductor_utils import requires_triton
 from torch.testing._internal.torchbind_impls import (
     _empty_tensor_queue,
     init_torchbind_implementations,
 )
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
 
 def _assertEqualSkipScriptObject(test_case, exp, actual):
@@ -1568,8 +1569,34 @@ def forward(self, token, obj, x):
             self, f(_empty_tensor_queue(), x), opt_f(_empty_tensor_queue(), x)
         )
 
-    @requires_cuda_and_triton
-    @parametrize("device", ["cpu", "cuda"])
+
+class TestCompileTorchbindDevice(TestCase):
+    def setUp(self):
+        super().setUp()
+        init_torchbind_implementations()
+
+        @torch._library.register_fake_class("_TorchScriptTesting::_TensorQueue")
+        class FakeTensorQueue:
+            def __init__(self, queue):
+                self.queue = queue
+
+            @classmethod
+            def __obj_unflatten__(cls, flattened_ctx):
+                return cls(**dict(flattened_ctx))
+
+            def push(self, x):
+                self.queue.append(x)
+
+            def pop(self):
+                return self.queue.pop(0)
+
+            def size(self):
+                return len(self.queue)
+
+    def tearDown(self):
+        torch._dynamo.reset()
+
+    @requires_triton()
     @parametrize("backend", ["eager", "aot_eager", "inductor"])
     def test_compile_obj_torchbind_op_with_autocast(self, backend, device):
         def f(tq, x):
@@ -1586,8 +1613,6 @@ def forward(self, token, obj, x):
             self, f(_empty_tensor_queue(), x), opt_f(_empty_tensor_queue(), x)
         )
 
-    @requires_cuda_and_triton
-    @parametrize("device", ["cpu", "cuda"])
     def test_export_obj_torchbind_op_with_autocast(self, device):
         class Mod(torch.nn.Module):
             def forward(self, x, tq):
@@ -1660,6 +1685,7 @@ class TestRegisterFakeClass(TestCase):
 
 instantiate_parametrized_tests(TestExportTorchbind)
 instantiate_parametrized_tests(TestCompileTorchbind)
+instantiate_device_type_tests(TestCompileTorchbindDevice, globals())
 
 if __name__ == "__main__":
     run_tests()

--- a/test/export/test_torchbind.py
+++ b/test/export/test_torchbind.py
@@ -14,6 +14,7 @@ from torch.export._trace import _export
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -59,6 +60,8 @@ def _assertEqualScriptObject(
 
 @skipIfTorchDynamo("torchbind not supported with dynamo yet")
 class TestExportTorchbind(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         init_torchbind_implementations()
@@ -1123,6 +1126,8 @@ graph():
 
 
 class TestCompileTorchbind(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         init_torchbind_implementations()
@@ -1571,6 +1576,8 @@ def forward(self, token, obj, x):
 
 
 class TestCompileTorchbindDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         init_torchbind_implementations()
@@ -1634,6 +1641,8 @@ class TestCompileTorchbindDevice(TestCase):
 
 @skipIfTorchDynamo("torchbind not supported with dynamo yet")
 class TestRegisterFakeClass(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         init_torchbind_implementations()

--- a/torch/testing/_internal/torchbind_impls.py
+++ b/torch/testing/_internal/torchbind_impls.py
@@ -51,12 +51,18 @@ def register_fake_operators():
     torch.library.register_autocast(
         "_TorchScriptTesting::queue_push", "cuda", torch.float32
     )
+    torch.library.register_autocast(
+        "_TorchScriptTesting::queue_push", "xpu", torch.float32
+    )
 
     torch.library.register_autocast(
         "_TorchScriptTesting::queue_pop", "cpu", torch.float32
     )
     torch.library.register_autocast(
         "_TorchScriptTesting::queue_pop", "cuda", torch.float32
+    )
+    torch.library.register_autocast(
+        "_TorchScriptTesting::queue_pop", "xpu", torch.float32
     )
 
     @torch.library.register_fake("_TorchScriptTesting::queue_size")


### PR DESCRIPTION
This PR refactors and generalizes the `export/test_torchbind.py` tests to support multiple accelerator devices (CUDA, XPU, etc.) instead of being hard-coded to CUDA. The changes extract device-dependent tests into a separate class and parameterize them to run on all supported devices.

Changes/commits:
1. Separate device-unrelated and device-agnostic parts of the TestCompileTorchbind class.
2. Add `HardwareClassification`s to test classes.
3. Enable TestCompileTorchbindGeneric tests on XPU.