### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_cse_pass.py

### DIFF
--- a/test/fx/test_cse_pass.py
+++ b/test/fx/test_cse_pass.py
@@ -6,7 +6,11 @@ import torch
 from torch.fx import symbolic_trace
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.passes.dialect.common.cse_pass import CSEPass, get_CSE_banned_ops
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 banned_ops = get_CSE_banned_ops()
@@ -94,6 +98,8 @@ def check(self, f, t, delta, check_val=True, graph_input=False, P=None):
 
 
 class TestCSEPass(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_nochange(self):
         def f(x):
             a = x + 1


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC attribute to TestCSEPass class, enabling hardware-based test classification and filtering.

## Changes
test/fx/test_cse_pass.py : import HardwareClassification and add hw_classification to TestCSEPass class。

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/fx/test_cse_pass.py

## Notes
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

