### PR TITLE
[Test][XPU] Enable nn and profiler tests for XPU

### DIFF
--- a/test/nn/test_load_state_dict.py
+++ b/test/nn/test_load_state_dict.py
@@ -25,8 +25,6 @@ if TEST_NUMPY:
 
 
 class TestLoadStateDict(NNTestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
@@ -442,14 +440,7 @@ class TestLoadStateDict(NNTestCase):
         with torch.device("meta"):
             m = torch.nn.Linear(3, 5)
         state_dict = m.state_dict()
-        runtime_device = (
-            torch.device("xpu")
-            if hasattr(torch, "xpu") and torch.xpu.is_available()
-            else torch.device("cpu")
-        )
-        state_dict["weight"] = torch.empty_like(
-            state_dict["weight"], device=runtime_device
-        )
+        state_dict["weight"] = torch.empty_like(state_dict["weight"], device="cpu")
         with self.assertWarnsRegex(
             UserWarning,
             "for weight: copying from a non-meta parameter in the checkpoint to a meta",
@@ -604,8 +595,6 @@ class MyWrapperLoadTensor(MyLoadTensor):
 
 
 class TestLoadStateDictSwap(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     @skipIfCrossRef
     @skipIfTorchDynamo("Can't swap with dynamo as dynamo installs weakrefs")
     @swap([True])

--- a/test/nn/test_load_state_dict.py
+++ b/test/nn/test_load_state_dict.py
@@ -25,6 +25,8 @@ if TEST_NUMPY:
 
 
 class TestLoadStateDict(NNTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
@@ -440,7 +442,14 @@ class TestLoadStateDict(NNTestCase):
         with torch.device("meta"):
             m = torch.nn.Linear(3, 5)
         state_dict = m.state_dict()
-        state_dict["weight"] = torch.empty_like(state_dict["weight"], device="cpu")
+        runtime_device = (
+            torch.device("xpu")
+            if hasattr(torch, "xpu") and torch.xpu.is_available()
+            else torch.device("cpu")
+        )
+        state_dict["weight"] = torch.empty_like(
+            state_dict["weight"], device=runtime_device
+        )
         with self.assertWarnsRegex(
             UserWarning,
             "for weight: copying from a non-meta parameter in the checkpoint to a meta",
@@ -595,6 +604,8 @@ class MyWrapperLoadTensor(MyLoadTensor):
 
 
 class TestLoadStateDictSwap(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @skipIfCrossRef
     @skipIfTorchDynamo("Can't swap with dynamo as dynamo installs weakrefs")
     @swap([True])

--- a/test/profiler/test_torch_tidy.py
+++ b/test/profiler/test_torch_tidy.py
@@ -62,6 +62,8 @@ class SimpleNet(nn.Module):
 
 
 class TestTorchTidyProfiler(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _get_tensor_fields(self, node, index):
         self.assertIsNotNone(node)
         self.assertIsInstance(
@@ -578,6 +580,7 @@ class TestTorchTidyProfiler(TestCase):
     def test_tensor_properties(self):
         x = torch.ones(10, 10).as_strided([4, 4], [12, 3])
         y = torch.ones(4, 1, requires_grad=True)
+        expected_device = x.device
 
         with profile(with_stack=True, profile_memory=True, record_shapes=True) as p:
             _ = x + y
@@ -601,7 +604,7 @@ class TestTorchTidyProfiler(TestCase):
         )
         self.assertEqual(
             getattr_inputs("device", None),
-            [torch.device("cpu"), torch.device("cpu"), None],
+            [expected_device, expected_device, None],
         )
         self.assertEqual(
             getattr_inputs("dtype", None), [torch.float32, torch.float32, None]
@@ -618,6 +621,7 @@ class TestTorchTidyProfiler(TestCase):
         i = [[0, 1, 1], [2, 0, 2]]
         v = [3, 4, 5]
         s = torch.sparse_coo_tensor(i, v, (2, 3))
+        expected_device = s.device
 
         with profile(with_stack=True, profile_memory=True, record_shapes=True) as p:
             _ = s + s
@@ -640,7 +644,7 @@ class TestTorchTidyProfiler(TestCase):
         )
         self.assertEqual(
             getattr_inputs("device", None),
-            [torch.device("cpu"), torch.device("cpu"), None],
+            [expected_device, expected_device, None],
         )
 
     @unittest.skipIf(
@@ -648,6 +652,8 @@ class TestTorchTidyProfiler(TestCase):
     )
     def test_mkldnn_tensors(self):
         x = torch.ones(4, 3).to_mkldnn()
+        # MKLDNN tensors are CPU-only; keep this test tied to CPU behavior.
+        self.assertEqual(x.device, torch.device("cpu"))
 
         with profile(with_stack=True, profile_memory=True, record_shapes=True) as p:
             _ = x + x
@@ -670,7 +676,7 @@ class TestTorchTidyProfiler(TestCase):
         )
         self.assertEqual(
             getattr_inputs("device", None),
-            [torch.device("cpu"), torch.device("cpu"), None],
+            [x.device, x.device, None],
         )
 
     def test_scalar_ins(self):
@@ -859,6 +865,7 @@ class TestTorchTidyProfiler(TestCase):
         gc.collect()
         with profile(profile_memory=True) as p:
             x = torch.empty((3, 4))
+        expected_device = x.device
 
         nodes = p.profiler.kineto_results.experimental_event_tree()
         node = find_node_with_name(nodes, "[memory]")
@@ -868,7 +875,7 @@ class TestTorchTidyProfiler(TestCase):
         ptr = node.extra_fields.ptr
         self.assertGreater(ptr, 0)
         self.assertEqual(node.extra_fields.alloc_size, alloc_size)
-        self.assertEqual(node.extra_fields.device, torch.device("cpu"))
+        self.assertEqual(node.extra_fields.device, expected_device)
         total_allocated = node.extra_fields.total_allocated
 
         # total_reserved is only for CUDACachingAllocator
@@ -884,7 +891,7 @@ class TestTorchTidyProfiler(TestCase):
 
         self.assertEqual(node.extra_fields.ptr, ptr)
         self.assertEqual(node.extra_fields.alloc_size, -alloc_size)
-        self.assertEqual(node.extra_fields.device, torch.device("cpu"))
+        self.assertEqual(node.extra_fields.device, expected_device)
         self.assertEqual(
             node.extra_fields.total_allocated, total_allocated - alloc_size
         )

--- a/test/profiler/test_torch_tidy.py
+++ b/test/profiler/test_torch_tidy.py
@@ -14,6 +14,7 @@ import torch.utils.data
 from torch._C._profiler import _ExtraFields_PyCall, _TensorMetadata
 from torch.profiler import _utils, profile
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_LINUX,
     IS_MACOS,
     IS_WINDOWS,


### PR DESCRIPTION
This PR enables nn and profiler tests to be able to run on XPU without any adjustments by removing hardcoded references to specific devices.