### PR TITLE
[Testcase Refactoring] Add hw_classification to test_store

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -35,6 +35,7 @@ from torch.testing._internal.common_distributed import (
 from torch.testing._internal.common_utils import (
     ADDRESS_IN_USE,
     CONNECT_TIMEOUT,
+    HardwareClassification,
     load_tests,
     retry_on_connect_failures,
     run_tests,
@@ -76,6 +77,8 @@ device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else 
 
 
 class StoreTestBase:
+    hw_classification = HardwareClassification.GENERIC
+
     def _create_store(self, i):
         raise RuntimeError("not implemented")
 
@@ -280,6 +283,8 @@ class StoreTestBase:
 
 
 class FileStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -330,6 +335,8 @@ class FileStoreTest(TestCase, StoreTestBase):
 
 @skip_if_win32()
 class HashStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _create_store(self):
         store = dist.HashStore()
         store.set_timeout(timedelta(seconds=300))
@@ -337,6 +344,8 @@ class HashStoreTest(TestCase, StoreTestBase):
 
 
 class PrefixStoreTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # delete is false as FileStore will automatically clean up the file
@@ -360,6 +369,8 @@ class PrefixStoreTest(TestCase):
 
 
 class PrefixFileStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -377,6 +388,8 @@ class PrefixFileStoreTest(TestCase, StoreTestBase):
 
 
 class TCPStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     _use_libuv = False
 
     def _create_store(self):
@@ -693,6 +706,8 @@ class TCPStoreTest(TestCase, StoreTestBase):
 
 
 class LibUvTCPStoreTest(TCPStoreTest):
+    hw_classification = HardwareClassification.GENERIC
+
     _use_libuv = True
 
     def _create_store(self):
@@ -707,6 +722,8 @@ class LibUvTCPStoreTest(TCPStoreTest):
 
 
 class PrefixTCPStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.tcpstore = create_tcp_store()
@@ -771,6 +788,8 @@ class MyPythonStore(dist.Store):
 
 
 class PythonStoreTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_set_get(self):
         # If we were to inherit from StoreTestBase and try to use
         # its test_set_get function, we would exercise the Python
@@ -783,6 +802,8 @@ class PythonStoreTest(TestCase):
 
 
 class RendezvousTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_unknown_handler(self):
         with self.assertRaisesRegex(RuntimeError, "^No rendezvous handler"):
             dist.rendezvous("invalid://")
@@ -793,6 +814,8 @@ class RendezvousTest(TestCase):
 
 
 class RendezvousEnvTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @retry_on_connect_failures
     def test_nominal(self):
         os.environ["WORLD_SIZE"] = "1"
@@ -813,6 +836,8 @@ class RendezvousEnvTest(TestCase):
 
 
 class RendezvousFileTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_common_errors(self):
         with self.assertRaisesRegex(ValueError, "path missing"):
             gen = dist.rendezvous("file://?rank=0&world_size=1")
@@ -847,6 +872,8 @@ class RendezvousFileTest(TestCase):
 
 @skip_if_win32()
 class RendezvousTCPTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def create_tcp_url(self):
         addr = DEFAULT_HOSTNAME
         port = common.find_free_port()
@@ -994,6 +1021,8 @@ class DummyStore(dist.Store):
 
 
 class TestPythonStore(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_optional_methods_fail(self):
         class TestStore(dist.Store):
             pass
@@ -1063,6 +1092,8 @@ class TestPythonStore(TestCase):
 
 
 class TestMultiThreadedWait(MultiThreadedTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     file_store = dist.FileStore(tempfile.NamedTemporaryFile(delete=False).name, 1)  # noqa: SIM115
     hash_store = dist.HashStore()
 
@@ -1124,6 +1155,8 @@ instantiate_parametrized_tests(TestMultiThreadedWait)
 
 @skip_if_win32()
 class TimeoutTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def tearDown(self):
         import signal
 
@@ -1194,6 +1227,8 @@ class InitPgWithNonUvStore(TestCase):
     the default backend.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     def tearDown(self):
         super().tearDown()
         os.environ.pop("USE_LIBUV", None)
@@ -1231,6 +1266,8 @@ class InitPgWithNonUvStore(TestCase):
 
 
 class TestClientProtocol(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_client_connect(self) -> None:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.bind(("localhost", 0))

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_distributed import (
 from torch.testing._internal.common_utils import (
     ADDRESS_IN_USE,
     CONNECT_TIMEOUT,
+    HardwareClassification,
     load_tests,
     retry_on_connect_failures,
     run_tests,
@@ -75,6 +76,8 @@ device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else 
 
 
 class StoreTestBase:
+    hw_classification = HardwareClassification.GENERIC
+
     def _create_store(self, i):
         raise RuntimeError("not implemented")
 
@@ -279,6 +282,8 @@ class StoreTestBase:
 
 
 class FileStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -329,6 +334,8 @@ class FileStoreTest(TestCase, StoreTestBase):
 
 @skip_if_win32()
 class HashStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _create_store(self):
         store = dist.HashStore()
         store.set_timeout(timedelta(seconds=300))
@@ -336,6 +343,8 @@ class HashStoreTest(TestCase, StoreTestBase):
 
 
 class PrefixStoreTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # delete is false as FileStore will automatically clean up the file
@@ -359,6 +368,8 @@ class PrefixStoreTest(TestCase):
 
 
 class PrefixFileStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -376,6 +387,8 @@ class PrefixFileStoreTest(TestCase, StoreTestBase):
 
 
 class TCPStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     _use_libuv = False
 
     def _create_store(self):
@@ -692,6 +705,8 @@ class TCPStoreTest(TestCase, StoreTestBase):
 
 
 class LibUvTCPStoreTest(TCPStoreTest):
+    hw_classification = HardwareClassification.GENERIC
+
     _use_libuv = True
 
     def _create_store(self):
@@ -706,6 +721,8 @@ class LibUvTCPStoreTest(TCPStoreTest):
 
 
 class PrefixTCPStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.tcpstore = create_tcp_store()
@@ -770,6 +787,8 @@ class MyPythonStore(dist.Store):
 
 
 class PythonStoreTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_set_get(self):
         # If we were to inherit from StoreTestBase and try to use
         # its test_set_get function, we would exercise the Python
@@ -782,6 +801,8 @@ class PythonStoreTest(TestCase):
 
 
 class RendezvousTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_unknown_handler(self):
         with self.assertRaisesRegex(RuntimeError, "^No rendezvous handler"):
             dist.rendezvous("invalid://")
@@ -792,6 +813,8 @@ class RendezvousTest(TestCase):
 
 
 class RendezvousEnvTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @retry_on_connect_failures
     def test_nominal(self):
         os.environ["WORLD_SIZE"] = "1"
@@ -812,6 +835,8 @@ class RendezvousEnvTest(TestCase):
 
 
 class RendezvousFileTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_common_errors(self):
         with self.assertRaisesRegex(ValueError, "path missing"):
             gen = dist.rendezvous("file://?rank=0&world_size=1")
@@ -846,6 +871,8 @@ class RendezvousFileTest(TestCase):
 
 @skip_if_win32()
 class RendezvousTCPTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def create_tcp_url(self):
         addr = DEFAULT_HOSTNAME
         port = common.find_free_port()
@@ -959,6 +986,8 @@ class DummyStore(dist.Store):
 
 
 class TestPythonStore(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_optional_methods_fail(self):
         class TestStore(dist.Store):
             pass
@@ -1028,6 +1057,8 @@ class TestPythonStore(TestCase):
 
 
 class TestMultiThreadedWait(MultiThreadedTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     file_store = dist.FileStore(tempfile.NamedTemporaryFile(delete=False).name, 1)  # noqa: SIM115
     hash_store = dist.HashStore()
 
@@ -1089,6 +1120,8 @@ instantiate_parametrized_tests(TestMultiThreadedWait)
 
 @skip_if_win32()
 class TimeoutTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def tearDown(self):
         import signal
 
@@ -1159,6 +1192,8 @@ class InitPgWithNonUvStore(TestCase):
     the default backend.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     def tearDown(self):
         super().tearDown()
         os.environ.pop("USE_LIBUV", None)
@@ -1196,6 +1231,8 @@ class InitPgWithNonUvStore(TestCase):
 
 
 class TestClientProtocol(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_client_connect(self) -> None:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.bind(("localhost", 0))


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to all 17 `TestCase` subclasses in `test_store.py`, following the convention that every `TestCase` subclass carries a hardware classification label.

## Changes

- **`test/distributed/test_store.py`**:
  - Imported `HardwareClassification` from `torch.testing._internal.common_utils`.
  - Labeled all 17 `TestCase` subclasses with `hw_classification = HardwareClassification.GENERIC`: `FileStoreTest`, `HashStoreTest`, `PrefixStoreTest`, `PrefixFileStoreTest`, `TCPStoreTest`, `LibUvTCPStoreTest`, `PrefixTCPStoreTest`, `PythonStoreTest`, `RendezvousTest`, `RendezvousEnvTest`, `RendezvousFileTest`, `RendezvousTCPTest`, `TestPythonStore`, `TestMultiThreadedWait`, `TimeoutTest`, `InitPgWithNonUvStore`, `TestClientProtocol`.
  - Three non-`TestCase` classes (`StoreTestBase` mixin, `MyPythonStore`, `DummyStore`, all subclassing `dist.Store`) are not labeled.

## Motivation

These classes exercise Store and Rendezvous protocols (FileStore, HashStore, TCPStore, PrefixStore, PythonStore, `dist.rendezvous` over file/tcp/env) — set/get/wait/append/queue/multi_set/multi_get/barrier/timeout on the host/CPU side, with no accelerator dependency. They classify as `GENERIC` (device-agnostic). An unclassified class is silently dropped when `--hw-classification GENERIC ACCELERATOR` is passed, so labeling them ensures they are correctly selected under hardware-classification filtering.

## Test Plan

- Verified on an accelerator backend (8 devices) that the labels do not change runtime behavior — results are identical to the unmodified baseline:

  ```bash
  python test/distributed/test_store.py -v
  ```

  Output: `Ran 138 tests / FAILED (errors=3, skipped=12)`. 135 tests pass. The 12 skips are `Store does not support queues` (runtime capability probe in `StoreTestBase._create_store_or_skip_if_no_queues` — `FileStore`/`PrefixFileStore`/`TCPStore` do not implement the queue API; this is expected and orthogonal to classification). The 3 errors are `rpc.init_rpc` failures from the verify host's backend being registered first in `BackendType` with a `construct_rpc_backend_options_handler` signature incompatible with the standard call convention — this is a verify-host RPC backend defect, not a Store test issue, and is unchanged by the labels.

## Notes

- This is part of the test case refactoring initiative tracked in #185590.
