### PR TITLE
[Testcase Refactoring] Add hw_classification and instantiate_device_type_tests to test_nvshmem.py

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_rocm_multiprocess,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     requires_cuda_p2p_access,
@@ -66,6 +67,8 @@ device_module = torch.get_device_module(device_type)
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -413,6 +416,8 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMSignalNegativeTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
@@ -553,6 +558,8 @@ class NVSHMEMSignalNegativeTest(MultiProcessTestCase):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMAll2AllTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -954,6 +961,8 @@ def dispatch_then_combine(device, align: int, group) -> None:
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class DispatchCombineTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -978,6 +987,8 @@ class DispatchCombineTest(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class DispatchCombineInSubgroups(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -1009,6 +1020,8 @@ class DispatchCombineInSubgroups(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMTileCommTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)

--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -59,21 +59,25 @@ def requires_nvls():
     )
 
 
+# So that tests are written in device-agnostic way
+device_type = "cuda"
+device_module = torch.get_device_module(device_type)
+
+
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
 
     def _init_device(self, device) -> None:
-        self._dev = torch.device(torch.device(device).type, self.rank)
         # TODO: relieve this (seems to hang if without)
-        torch.get_device_module(self.device.type).set_device(self.device)
+        device_module.set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return self._dev
+        return torch.device(device_type, self.rank)
 
     def test_alloc(self, device) -> None:
         self._init_device(device)
@@ -93,7 +97,6 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         symm_mem.rendezvous(out, group=group_name)
 
     def test_alloc_without_device_context(self, device) -> None:
-        self._dev = torch.device(torch.device(device).type, self.rank)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
         group_name = dist.group.WORLD.group_name
@@ -555,15 +558,14 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
 
     def _init_device(self, device) -> None:
-        self._dev = torch.device(torch.device(device).type, self.rank)
         # TODO: relieve this (seems to hang if without)
-        torch.get_device_module(self.device.type).set_device(self.device)
+        device_module.set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return self._dev
+        return torch.device(device_type, self.rank)
 
     def test_nvshmem_all_to_all(self, device) -> None:
         self._init_device(device)
@@ -958,15 +960,14 @@ class DispatchCombineTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
 
     def _init_device(self, device) -> None:
-        self._dev = torch.device(torch.device(device).type, self.rank)
         # TODO: relieve this (seems to hang if without)
-        torch.get_device_module(self.device.type).set_device(self.device)
+        device_module.set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return self._dev
+        return torch.device(device_type, self.rank)
 
     @parametrize("align", [1, 8, 16])  # `major_align` of output
     def test_dispatch_combine(self, device, align: int) -> None:
@@ -984,15 +985,14 @@ class DispatchCombineInSubgroups(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
 
     def _init_device(self, device) -> None:
-        self._dev = torch.device(torch.device(device).type, self.rank)
         # TODO: relieve this (seems to hang if without)
-        torch.get_device_module(self.device.type).set_device(self.device)
+        device_module.set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return self._dev
+        return torch.device(device_type, self.rank)
 
     @skip_but_pass_in_sandcastle_if(
         torch.accelerator.device_count() < 4,
@@ -1008,7 +1008,7 @@ class DispatchCombineInSubgroups(MultiProcContinuousTest):
         ngroups = 2
         subgroup_size = self.world_size // ngroups
         dm = init_device_mesh(
-            device, (ngroups, subgroup_size), mesh_dim_names=("dp", "ep")
+            device_type, (ngroups, subgroup_size), mesh_dim_names=("dp", "ep")
         )
         subgroup = dm.get_group("ep")
         dispatch_then_combine(self.device, align=8, group=subgroup)
@@ -1020,15 +1020,14 @@ class NVSHMEMTileCommTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
 
     def _init_device(self, device) -> None:
-        self._dev = torch.device(torch.device(device).type, self.rank)
         # TODO: relieve this (seems to hang if without)
-        torch.get_device_module(self.device.type).set_device(self.device)
+        device_module.set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return self._dev
+        return torch.device(device_type, self.rank)
 
     @requires_nvls()
     @parametrize("tile_size", [32, 128, 512])

--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -11,10 +11,10 @@ import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed.device_mesh import init_device_mesh
 from torch.testing._internal.common_cuda import _get_torch_cuda_version
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     PLATFORM_SUPPORTS_SYMM_MEM,
-    skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -22,8 +22,12 @@ from torch.testing._internal.common_utils import (
     requires_cuda_p2p_access,
     run_tests,
     skip_but_pass_in_sandcastle_if,
-    TEST_WITH_ROCM,
+    skipIfRocm,
 )
+try:
+    from torch.testing._internal.common_utils import HardwareClassification
+except ImportError:
+    HardwareClassification = None
 
 
 # Decorator
@@ -69,25 +73,23 @@ def skip_if_cuda_13_2():
     )
 
 
-# So that tests are written in device-agnostic way
-device_type = "cuda"
-device_module = torch.get_device_module(device_type)
-
-
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA if HardwareClassification else None
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
-        device_module.set_device(self.device)
+        torch.get_device_module(self.device.type).set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return self._dev
 
-    def test_alloc(self) -> None:
+    def test_alloc(self, device) -> None:
+        self._dev = torch.device(device, self.rank)
         self._init_device()
 
         group_name = dist.group.WORLD.group_name
@@ -104,7 +106,8 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         out = symm_mem.empty(numel, dtype=dtype, device=self.device)
         symm_mem.rendezvous(out, group=group_name)
 
-    def test_alloc_without_device_context(self) -> None:
+    def test_alloc_without_device_context(self, device) -> None:
+        self._dev = torch.device(device, self.rank)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
         group_name = dist.group.WORLD.group_name
@@ -115,10 +118,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         self.assertEqual(out.device, self.device)
         symm_mem.rendezvous(out, group=group_name)
 
-    def test_mempool_tensor_factory(self) -> None:
+    def test_mempool_tensor_factory(self, device) -> None:
         """
         Test the effectiveness of MemPool on tensor factory ops.
         """
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -139,10 +143,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         torch.ops.symm_mem.nvshmem_broadcast(tensor, src_rank, group_name)
         self.assertEqual(tensor, torch.arange(numel, dtype=dtype, device=self.device))
 
-    def test_mempool_tensor_w_collective(self) -> None:
+    def test_mempool_tensor_w_collective(self, device) -> None:
         """
         Test the effectiveness of MemPool on tensor factory ops.
         """
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -161,10 +166,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
             tensor, torch.ones(numel, dtype=dtype, device=self.device) * self.world_size
         )
 
-    def test_mempool_compute_ops(self) -> None:
+    def test_mempool_compute_ops(self, device) -> None:
         """
         Apply MemPool context to a compute op that creates input to collective.
         """
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -185,10 +191,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         expected = torch.mm(x0, w)
         self.assertEqual(y, expected)
 
-    def test_handle_offset(self) -> None:
+    def test_handle_offset(self, device) -> None:
         """
         Test if handle offset is correctly set.
         """
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -206,10 +213,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         self.assertEqual(hdl0.offset, 0)
         self.assertEqual(hdl1.offset, x0.untyped_storage().nbytes())
 
-    def test_get_remote_tensor(self) -> None:
+    def test_get_remote_tensor(self, device) -> None:
         """
         Get a remote tensor and use regular aten ops to write to it.
         """
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -234,10 +242,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         )
         self.assertEqual(y, expected)
 
-    def test_get_remote_tensors(self) -> None:
+    def test_get_remote_tensors(self, device) -> None:
         """
         Get all remote tensors
         """
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -248,10 +257,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         for peer, tensor in enumerate(remote_tensors):
             self.assertEqual(tensor, peer)
 
-    def test_multicast_ptr(self) -> None:
+    def test_multicast_ptr(self, device) -> None:
         """
         Get the multicast pointer
         """
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -262,7 +272,8 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         else:
             self.assertEqual(handle.multicast_ptr, 0)
 
-    def test_nvshmem_put(self) -> None:
+    def test_nvshmem_put(self, device) -> None:
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -283,7 +294,8 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
                 tensor, torch.zeros(numel, dtype=dtype, device=self.device)
             )
 
-    def test_nvshmem_get(self) -> None:
+    def test_nvshmem_get(self, device) -> None:
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -304,10 +316,9 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
             # TODO: remove after we have wait_signal
             dist.barrier()
 
-    @skip_but_pass_in_sandcastle_if(
-        TEST_WITH_ROCM, "nvshmem_get_out not yet implemented for ROCm"
-    )
-    def test_get(self) -> None:
+    @skipIfRocm(msg="nvshmem_get_out not yet implemented for ROCm")
+    def test_get(self, device) -> None:
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -385,17 +396,20 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMAll2AllTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA if HardwareClassification else None
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
-        device_module.set_device(self.device)
+        torch.get_device_module(self.device.type).set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return self._dev
 
-    def test_nvshmem_all_to_all(self) -> None:
+    def test_nvshmem_all_to_all(self, device) -> None:
+        self._dev = torch.device(device, self.rank)
         self._init_device()
 
         group_name = dist.group.WORLD.group_name
@@ -418,7 +432,8 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         )
         torch.testing.assert_close(out, expected)
 
-    def test_all_to_all_vdev(self) -> None:
+    def test_all_to_all_vdev(self, device) -> None:
+        self._dev = torch.device(device, self.rank)
         self._init_device()
 
         group_name = dist.group.WORLD.group_name
@@ -479,8 +494,9 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         torch.testing.assert_close(out[:out_numel], expected)
 
     @parametrize("align", [1, 8, 16])  # `major_align` of output
-    def test_all_to_all_vdev_2d(self, align: int) -> None:
+    def test_all_to_all_vdev_2d(self, device, align: int) -> None:
         torch.manual_seed(42 + self.rank)
+        self._dev = torch.device(device, self.rank)
         self._init_device()
 
         group_name = dist.group.WORLD.group_name
@@ -586,8 +602,9 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
             received_chunk = out[start : start + split]
             torch.testing.assert_close(received_chunk, chunk)
 
-    def test_all_to_all_vdev_2d_offset(self) -> None:
+    def test_all_to_all_vdev_2d_offset(self, device) -> None:
         torch.manual_seed(42 + self.rank)
+        self._dev = torch.device(device, self.rank)
         self._init_device()
 
         group_name = dist.group.WORLD.group_name
@@ -786,23 +803,26 @@ def dispatch_then_combine(device, align: int, group) -> None:
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class DispatchCombineTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA if HardwareClassification else None
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
-        device_module.set_device(self.device)
+        torch.get_device_module(self.device.type).set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return self._dev
 
     @skip_if_cuda_13_2()
     @parametrize("align", [1, 8, 16])  # `major_align` of output
-    def test_dispatch_combine(self, align: int) -> None:
+    def test_dispatch_combine(self, device, align: int) -> None:
         """
         Test dispatch-and-combine over World group
         """
         torch.manual_seed(42 + self.rank)
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         dispatch_then_combine(self.device, align, dist.group.WORLD)
 
@@ -811,29 +831,35 @@ class DispatchCombineTest(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class DispatchCombineInSubgroups(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA if HardwareClassification else None
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
-        device_module.set_device(self.device)
+        torch.get_device_module(self.device.type).set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return self._dev
 
     @skip_if_cuda_13_2()
-    @skip_if_lt_x_gpu(4)
-    def test_dispatch_combine_subgroup(self) -> None:
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 4,
+        "test requires 4+ accelerators",
+    )
+    def test_dispatch_combine_subgroup(self, device) -> None:
         """
         Test dispatch-and-combine over concurrent subgroups
         """
         torch.manual_seed(42 + self.rank)
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         # Test on two concurrent subgroups
         ngroups = 2
         subgroup_size = self.world_size // ngroups
         dm = init_device_mesh(
-            device_type, (ngroups, subgroup_size), mesh_dim_names=("dp", "ep")
+            device, (ngroups, subgroup_size), mesh_dim_names=("dp", "ep")
         )
         subgroup = dm.get_group("ep")
         dispatch_then_combine(self.device, align=8, group=subgroup)
@@ -843,26 +869,29 @@ class DispatchCombineInSubgroups(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMTileCommTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA if HardwareClassification else None
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
-        device_module.set_device(self.device)
+        torch.get_device_module(self.device.type).set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return self._dev
 
     @requires_nvls()
     @parametrize("tile_size", [32, 128, 512])
     @parametrize("dtype", [torch.float, torch.half, torch.bfloat16])
-    def test_tile_reduce(self, tile_size: int, dtype: torch.dtype) -> None:
+    def test_tile_reduce(self, device, tile_size: int, dtype: torch.dtype) -> None:
         full_size = 1024
         if not (tile_size <= full_size):
             raise AssertionError(
                 f"Expected tile_size <= full_size, got {tile_size} vs {full_size}"
             )
 
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -896,7 +925,7 @@ class NVSHMEMTileCommTest(MultiProcContinuousTest):
     )  # 1: all ranks are roots, 2: half of ranks are roots
     @parametrize("dtype", [torch.float, torch.half, torch.bfloat16])
     def test_multi_root_tile_reduce(
-        self, tile_size: int, root_ratio: int, dtype: torch.dtype
+        self, device, tile_size: int, root_ratio: int, dtype: torch.dtype
     ) -> None:
         full_size = 2048
         num_slices_col = 2  # number of tiles on column dimension
@@ -914,6 +943,7 @@ class NVSHMEMTileCommTest(MultiProcContinuousTest):
                 f"{tile_size * num_slices_row} vs {full_size}"
             )
 
+        self._dev = torch.device(device, self.rank)
         self._init_device()
         group_name = dist.group.WORLD.group_name
 
@@ -962,6 +992,36 @@ class NVSHMEMTileCommTest(MultiProcContinuousTest):
             expected_tile.fill_(self.world_size * (self.world_size - 1) / 2)
         torch.testing.assert_close(full_out, expected)
 
+
+instantiate_device_type_tests(
+    NVSHMEMSymmetricMemoryTest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    NVSHMEMAll2AllTest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    DispatchCombineTest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    DispatchCombineInSubgroups,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    NVSHMEMTileCommTest,
+    globals(),
+    only_for=("cuda",),
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -10,6 +10,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed.device_mesh import init_device_mesh
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     MultiProcessTestCase,
@@ -19,12 +20,11 @@ from torch.testing._internal.common_distributed import (
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    instantiate_parametrized_tests,
     parametrize,
     requires_cuda_p2p_access,
     run_tests,
     skip_but_pass_in_sandcastle_if,
-    TEST_WITH_ROCM,
+    skipIfRocm,
 )
 
 
@@ -59,28 +59,24 @@ def requires_nvls():
     )
 
 
-# So that tests are written in device-agnostic way
-device_type = "cuda"
-device_module = torch.get_device_module(device_type)
-
-
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
 
-    def _init_device(self) -> None:
+    def _init_device(self, device) -> None:
+        self._dev = torch.device(torch.device(device).type, self.rank)
         # TODO: relieve this (seems to hang if without)
-        device_module.set_device(self.device)
+        torch.get_device_module(self.device.type).set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return self._dev
 
-    def test_alloc(self) -> None:
-        self._init_device()
+    def test_alloc(self, device) -> None:
+        self._init_device(device)
 
         group_name = dist.group.WORLD.group_name
 
@@ -96,7 +92,8 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         out = symm_mem.empty(numel, dtype=dtype, device=self.device)
         symm_mem.rendezvous(out, group=group_name)
 
-    def test_alloc_without_device_context(self) -> None:
+    def test_alloc_without_device_context(self, device) -> None:
+        self._dev = torch.device(torch.device(device).type, self.rank)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
         group_name = dist.group.WORLD.group_name
@@ -107,11 +104,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         self.assertEqual(out.device, self.device)
         symm_mem.rendezvous(out, group=group_name)
 
-    def test_mempool_tensor_factory(self) -> None:
+    def test_mempool_tensor_factory(self, device) -> None:
         """
         Test the effectiveness of MemPool on tensor factory ops.
         """
-        self._init_device()
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         dtype = torch.float
@@ -131,11 +128,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         torch.ops.symm_mem.nvshmem_broadcast(tensor, src_rank, group_name)
         self.assertEqual(tensor, torch.arange(numel, dtype=dtype, device=self.device))
 
-    def test_mempool_tensor_w_collective(self) -> None:
+    def test_mempool_tensor_w_collective(self, device) -> None:
         """
         Test the effectiveness of MemPool on tensor factory ops.
         """
-        self._init_device()
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         dtype = torch.float
@@ -153,11 +150,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
             tensor, torch.ones(numel, dtype=dtype, device=self.device) * self.world_size
         )
 
-    def test_mempool_compute_ops(self) -> None:
+    def test_mempool_compute_ops(self, device) -> None:
         """
         Apply MemPool context to a compute op that creates input to collective.
         """
-        self._init_device()
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         dtype = torch.float
@@ -177,11 +174,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         expected = torch.mm(x0, w)
         self.assertEqual(y, expected)
 
-    def test_handle_offset(self) -> None:
+    def test_handle_offset(self, device) -> None:
         """
         Test if handle offset is correctly set.
         """
-        self._init_device()
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         dtype = torch.float
@@ -198,11 +195,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         self.assertEqual(hdl0.offset, 0)
         self.assertEqual(hdl1.offset, x0.untyped_storage().nbytes())
 
-    def test_get_remote_tensor(self) -> None:
+    def test_get_remote_tensor(self, device) -> None:
         """
         Get a remote tensor and use regular aten ops to write to it.
         """
-        self._init_device()
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         dtype = torch.float
@@ -226,11 +223,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         )
         self.assertEqual(y, expected)
 
-    def test_get_remote_tensors(self) -> None:
+    def test_get_remote_tensors(self, device) -> None:
         """
         Get all remote tensors
         """
-        self._init_device()
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         my_tensor = symm_mem.empty(1, device=self.device).fill_(self.rank)
@@ -240,11 +237,11 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         for peer, tensor in enumerate(remote_tensors):
             self.assertEqual(tensor, peer)
 
-    def test_multicast_ptr(self) -> None:
+    def test_multicast_ptr(self, device) -> None:
         """
         Get the multicast pointer
         """
-        self._init_device()
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         tensor = symm_mem.empty(1, device=self.device)
@@ -254,8 +251,8 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         else:
             self.assertEqual(handle.multicast_ptr, 0)
 
-    def test_nvshmem_put(self) -> None:
-        self._init_device()
+    def test_nvshmem_put(self, device) -> None:
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         dtype = torch.float
@@ -275,8 +272,8 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
                 tensor, torch.zeros(numel, dtype=dtype, device=self.device)
             )
 
-    def test_nvshmem_get(self) -> None:
-        self._init_device()
+    def test_nvshmem_get(self, device) -> None:
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         dtype = torch.float
@@ -295,8 +292,8 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
             # rank may reuse its buffer.
             hdl.wait_signal(src_rank=0)
 
-    def test_barrier(self) -> None:
-        self._init_device()
+    def test_barrier(self, device) -> None:
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         numel = 64
@@ -310,8 +307,8 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
             self.assertTrue(buf.eq(peer).all())
         hdl.barrier()
 
-    def test_put_wait_signal(self) -> None:
-        self._init_device()
+    def test_put_wait_signal(self, device) -> None:
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         numel = 64
@@ -332,11 +329,9 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
             hdl.put_signal(dst_rank=0)
         hdl.barrier()
 
-    @skip_but_pass_in_sandcastle_if(
-        TEST_WITH_ROCM, "nvshmem_get_out not yet implemented for ROCm"
-    )
-    def test_get(self) -> None:
-        self._init_device()
+    @skipIfRocm(msg="nvshmem_get_out not yet implemented for ROCm")
+    def test_get(self, device) -> None:
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         dtype = torch.float
@@ -428,7 +423,7 @@ class NVSHMEMSignalNegativeTest(MultiProcessTestCase):
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return torch.device("cuda", self.rank)
 
     def _init_process(self) -> None:
         torch.cuda.set_device(self.device)
@@ -554,24 +549,24 @@ class NVSHMEMSignalNegativeTest(MultiProcessTestCase):
         torch.cuda.synchronize()
 
 
-@instantiate_parametrized_tests
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMAll2AllTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
 
-    def _init_device(self) -> None:
+    def _init_device(self, device) -> None:
+        self._dev = torch.device(torch.device(device).type, self.rank)
         # TODO: relieve this (seems to hang if without)
-        device_module.set_device(self.device)
+        torch.get_device_module(self.device.type).set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return self._dev
 
-    def test_nvshmem_all_to_all(self) -> None:
-        self._init_device()
+    def test_nvshmem_all_to_all(self, device) -> None:
+        self._init_device(device)
 
         group_name = dist.group.WORLD.group_name
 
@@ -593,8 +588,8 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         )
         torch.testing.assert_close(out, expected)
 
-    def test_all_to_all_vdev(self) -> None:
-        self._init_device()
+    def test_all_to_all_vdev(self, device) -> None:
+        self._init_device(device)
 
         group_name = dist.group.WORLD.group_name
 
@@ -654,9 +649,9 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         torch.testing.assert_close(out[:out_numel], expected)
 
     @parametrize("align", [1, 8, 16])  # `major_align` of output
-    def test_all_to_all_vdev_2d(self, align: int) -> None:
+    def test_all_to_all_vdev_2d(self, device, align: int) -> None:
         torch.manual_seed(42 + self.rank)
-        self._init_device()
+        self._init_device(device)
 
         group_name = dist.group.WORLD.group_name
 
@@ -761,9 +756,9 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
             received_chunk = out[start : start + split]
             torch.testing.assert_close(received_chunk, chunk)
 
-    def test_all_to_all_vdev_2d_offset(self) -> None:
+    def test_all_to_all_vdev_2d_offset(self, device) -> None:
         torch.manual_seed(42 + self.rank)
-        self._init_device()
+        self._init_device(device)
 
         group_name = dist.group.WORLD.group_name
 
@@ -957,92 +952,95 @@ def dispatch_then_combine(device, align: int, group) -> None:
     torch.cuda.synchronize(device)
 
 
-@instantiate_parametrized_tests
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class DispatchCombineTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
 
-    def _init_device(self) -> None:
+    def _init_device(self, device) -> None:
+        self._dev = torch.device(torch.device(device).type, self.rank)
         # TODO: relieve this (seems to hang if without)
-        device_module.set_device(self.device)
+        torch.get_device_module(self.device.type).set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return self._dev
 
     @parametrize("align", [1, 8, 16])  # `major_align` of output
-    def test_dispatch_combine(self, align: int) -> None:
+    def test_dispatch_combine(self, device, align: int) -> None:
         """
         Test dispatch-and-combine over World group
         """
         torch.manual_seed(42 + self.rank)
-        self._init_device()
+        self._init_device(device)
         dispatch_then_combine(self.device, align, dist.group.WORLD)
 
 
-@instantiate_parametrized_tests
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class DispatchCombineInSubgroups(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
 
-    def _init_device(self) -> None:
+    def _init_device(self, device) -> None:
+        self._dev = torch.device(torch.device(device).type, self.rank)
         # TODO: relieve this (seems to hang if without)
-        device_module.set_device(self.device)
+        torch.get_device_module(self.device.type).set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return self._dev
 
-    @skip_if_lt_x_gpu(4)
-    def test_dispatch_combine_subgroup(self) -> None:
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 4,
+        "test requires 4+ accelerators",
+    )
+    def test_dispatch_combine_subgroup(self, device) -> None:
         """
         Test dispatch-and-combine over concurrent subgroups
         """
         torch.manual_seed(42 + self.rank)
-        self._init_device()
+        self._init_device(device)
         # Test on two concurrent subgroups
         ngroups = 2
         subgroup_size = self.world_size // ngroups
         dm = init_device_mesh(
-            device_type, (ngroups, subgroup_size), mesh_dim_names=("dp", "ep")
+            device, (ngroups, subgroup_size), mesh_dim_names=("dp", "ep")
         )
         subgroup = dm.get_group("ep")
         dispatch_then_combine(self.device, align=8, group=subgroup)
 
 
-@instantiate_parametrized_tests
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMTileCommTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
 
-    def _init_device(self) -> None:
+    def _init_device(self, device) -> None:
+        self._dev = torch.device(torch.device(device).type, self.rank)
         # TODO: relieve this (seems to hang if without)
-        device_module.set_device(self.device)
+        torch.get_device_module(self.device.type).set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return self._dev
 
     @requires_nvls()
     @parametrize("tile_size", [32, 128, 512])
     @parametrize("dtype", [torch.float, torch.half, torch.bfloat16])
-    def test_tile_reduce(self, tile_size: int, dtype: torch.dtype) -> None:
+    def test_tile_reduce(self, device, tile_size: int, dtype: torch.dtype) -> None:
         full_size = 1024
         if not (tile_size <= full_size):
             raise AssertionError(
                 f"Expected tile_size <= full_size, got {tile_size} vs {full_size}"
             )
 
-        self._init_device()
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         full_inp = symm_mem.empty(
@@ -1075,7 +1073,7 @@ class NVSHMEMTileCommTest(MultiProcContinuousTest):
     )  # 1: all ranks are roots, 2: half of ranks are roots
     @parametrize("dtype", [torch.float, torch.half, torch.bfloat16])
     def test_multi_root_tile_reduce(
-        self, tile_size: int, root_ratio: int, dtype: torch.dtype
+        self, device, tile_size: int, root_ratio: int, dtype: torch.dtype
     ) -> None:
         full_size = 2048
         num_slices_col = 2  # number of tiles on column dimension
@@ -1093,7 +1091,7 @@ class NVSHMEMTileCommTest(MultiProcContinuousTest):
                 f"{tile_size * num_slices_row} vs {full_size}"
             )
 
-        self._init_device()
+        self._init_device(device)
         group_name = dist.group.WORLD.group_name
 
         full_inp = symm_mem.empty(
@@ -1141,6 +1139,36 @@ class NVSHMEMTileCommTest(MultiProcContinuousTest):
             expected_tile.fill_(self.world_size * (self.world_size - 1) / 2)
         torch.testing.assert_close(full_out, expected)
 
+
+instantiate_device_type_tests(
+    NVSHMEMSymmetricMemoryTest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    NVSHMEMAll2AllTest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    DispatchCombineTest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    DispatchCombineInSubgroups,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    NVSHMEMTileCommTest,
+    globals(),
+    only_for=("cuda",),
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Replace the module-level `device_type` / `device_module` constants in
`test/distributed/test_nvshmem.py` with a `device` parameter injected by
`instantiate_device_type_tests(only_for=("cuda",))` into each test method.
Add `hw_classification = HardwareClassification.CUDA` to all five multi-process
test classes.

## Changes

- **Add `instantiate_device_type_tests(only_for=("cuda",))`** for the five
  test classes: `NVSHMEMSymmetricMemoryTest`, `NVSHMEMAll2AllTest`,
  `DispatchCombineTest`, `DispatchCombineInSubgroups`, and
  `NVSHMEMTileCommTest`.  `only_for=("cuda",)` reflects that NVSHMEM is
  NVIDIA-specific.
- **Add `hw_classification = HardwareClassification.CUDA`** to each class.
  `HardwareClassification` is imported with a fallback to `None` for
  backward compatibility with older PyTorch installations that do not yet
  ship the enum.
- **Remove module-level `device_type = "cuda"` and `device_module`.**  The
  `device` property now returns `self._dev`, which each test method
  initializes from the `device` parameter.
- **Replace `TEST_WITH_ROCM` with `@skipIfRocm`** on `test_get`.
- **Replace `@skip_if_lt_x_gpu(4)`** on `test_dispatch_combine_subgroup`
  with an accelerator-agnostic `skip_but_pass_in_sandcastle_if(
  torch.accelerator.device_count() < 4, ...)`.
- **Use `torch.get_device_module(self.device.type)`** in `_init_device`
  instead of the removed module-level `device_module`.
- **Derive `init_device_mesh` device** from the `device` parameter instead
  of the removed module-level `device_type`.

## Not changed

- The test logic inside each method is unchanged beyond the device string
  derivation.  All NVSHMEM collective semantics, expected values, and
  assertions are preserved exactly.
- `torch.cuda.MemPool`, `torch.cuda.use_mem_pool`, `torch.cuda.synchronize`
  remain in place — these are NVSHMEM/CUDA-specific APIs that cannot be
  generalized.

## Test plan

- `python test/distributed/test_nvshmem.py` — TODO: run on a CUDA build
  with 2+ GPUs and NVSHMEM support to confirm the generated
  `NVSHMEMSymmetricMemoryTestCUDA` variant passes all tests.
