### PR TITLE
[Testcase Refactoring] Refactor test_stage with instantiate_device_type_tests and hw-classification

### DIFF
--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -128,42 +128,30 @@ def get_flatten_hook():
 
 
 class PipelineStageTestBase(MultiProcContinuousTest):
-    # instantiate_device_type_tests copies non-test members using getattr(). A
-    # classmethod defined on generic_test_class is copied already bound to that
-    # class and cannot see the generated class's device_type. Defining backend_str
-    # on this base leaves it inherited, so cls refers to the generated
-    # device-specific test class when called.
-    @classmethod
-    def _resolved_device_type(cls) -> str:
-        # MultiProcContinuousTest subprocesses run tests without calling
-        # PrivateUse1TestBase.setUpClass, so cls.device_type stays the generic
-        # "privateuse1" token; resolve it to the registered backend name.
-        dt = cls.device_type
-        if dt == "privateuse1":
-            dt = torch._C._get_privateuse1_backend_name()
-        return dt
-
     @classmethod
     def backend_str(cls) -> str:
-        return dist.get_default_backend_for_device(cls._resolved_device_type())
+        return backend
+
+    def _rank_device(self, device: str) -> torch.device:
+        # `device` is the framework-injected primary device ("{type}:0",
+        # rank-0); resolve to this worker's per-rank device for self.rank.
+        device_type = torch.device(device).type
+        return torch.device(device_type, self.rank)
 
 
 class StageTest(PipelineStageTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @property
-    def device(self) -> torch.device:
-        return torch.device(self._resolved_device_type(), self.rank)
-
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
     @parametrize("ModelClass", [ExampleCode, MultiMLP])
-    def test_tracer(self, ModelClass):
+    def test_tracer(self, device, ModelClass):
+        rank_device = self._rank_device(device)
         mod = ModelClass(d_hid, self.world_size)
-        mod.to(self.device)
+        mod.to(rank_device)
 
-        x = torch.randn(batch_size, d_hid, device=self.device)
+        x = torch.randn(batch_size, d_hid, device=rank_device)
         x_mb = x.chunk(chunks)[0]
 
         split_spec = mod.split_spec if hasattr(mod, "split_spec") else None
@@ -175,7 +163,7 @@ class StageTest(PipelineStageTestBase):
 
         stage = pipe.build_stage(
             self.rank,
-            self.device,
+            rank_device,
         )
 
         # Attach to a schedule
@@ -207,12 +195,13 @@ class StageTest(PipelineStageTestBase):
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
     @parametrize("ModelClass", [ModelWithKwargs])
-    def test_tracer_kwargs(self, ModelClass):
+    def test_tracer_kwargs(self, device, ModelClass):
+        rank_device = self._rank_device(device)
         mod = ModelClass(d_hid, self.world_size)
-        mod.to(self.device)
+        mod.to(rank_device)
 
-        x = torch.randn(batch_size, d_hid, device=self.device)
-        y = torch.randn(batch_size, d_hid, device=self.device)
+        x = torch.randn(batch_size, d_hid, device=rank_device)
+        y = torch.randn(batch_size, d_hid, device=rank_device)
 
         x_mb = x.chunk(chunks)[0]
         y_mb = y.chunk(chunks)[0]
@@ -230,7 +219,7 @@ class StageTest(PipelineStageTestBase):
             stage_mod,
             self.rank,
             pipe.info(),
-            self.device,
+            rank_device,
         )
 
         # Attach to a schedule
@@ -259,18 +248,19 @@ class StageTest(PipelineStageTestBase):
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
-    def test_manual(self):
+    def test_manual(self, device):
+        rank_device = self._rank_device(device)
         full_mod = MultiMLP(d_hid, n_layers=self.world_size)
-        full_mod.to(self.device)
+        full_mod.to(rank_device)
         stage_mod = full_mod.get_submodule(f"layers.{self.rank}")
 
-        x = torch.randn(batch_size, d_hid, device=self.device)
+        x = torch.randn(batch_size, d_hid, device=rank_device)
 
         stage = PipelineStage(
             stage_mod,
             self.rank,
             self.world_size,
-            self.device,
+            rank_device,
         )
 
         # Attach to a schedule
@@ -292,14 +282,15 @@ class StageTest(PipelineStageTestBase):
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
-    def test_custom_dw_with_fb_schedule(self):
+    def test_custom_dw_with_fb_schedule(self, device):
         """Tests that separate weight grad function 'dw_runner' gets run under a schedule that's only aware of F/B."""
+        rank_device = self._rank_device(device)
         full_mod = MultiMLP(d_hid, n_layers=self.world_size)
-        full_mod.to(self.device)
+        full_mod.to(rank_device)
         stage_mod = full_mod.get_submodule(f"layers.{self.rank}")
 
-        x = torch.randn(batch_size, d_hid, device=self.device)
-        target = torch.randn(batch_size, d_hid, device=self.device)
+        x = torch.randn(batch_size, d_hid, device=rank_device)
+        target = torch.randn(batch_size, d_hid, device=rank_device)
 
         class CustomState:
             def __init__(self) -> None:
@@ -323,7 +314,7 @@ class StageTest(PipelineStageTestBase):
             stage_mod,
             self.rank,
             self.world_size,
-            self.device,
+            rank_device,
             dw_builder=cs.dw_builder,
         )
 
@@ -353,18 +344,19 @@ class StageTest(PipelineStageTestBase):
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
-    def test_output_chunks_memory_usage(self):
+    def test_output_chunks_memory_usage(self, device):
         """Test that output_chunks doesn't store memory for non-first stages."""
+        rank_device = self._rank_device(device)
         full_mod = MultiMLP(d_hid, n_layers=self.world_size)
-        full_mod.to(self.device)
+        full_mod.to(rank_device)
         stage_mod = full_mod.get_submodule(f"layers.{self.rank}")
-        x = torch.randn(batch_size, d_hid, device=self.device)
-        target = torch.randn(batch_size, d_hid, device=self.device)
+        x = torch.randn(batch_size, d_hid, device=rank_device)
+        target = torch.randn(batch_size, d_hid, device=rank_device)
         stage = PipelineStage(
             stage_mod,
             self.rank,
             self.world_size,
-            self.device,
+            rank_device,
         )
         self.assertEqual(
             len(stage.output_chunks), 0, "output_chunks should be empty initially"
@@ -416,26 +408,23 @@ instantiate_device_type_tests(StageTest, globals(), except_for=["cpu"], allow_xp
 class StageNegativeTest(PipelineStageTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @property
-    def device(self) -> torch.device:
-        return torch.device(self._resolved_device_type(), self.rank)
-
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
-    def test_shape_prop_mismatch(self):
+    def test_shape_prop_mismatch(self, device):
         """Tests shape prop errors are raised"""
+        rank_device = self._rank_device(device)
         full_mod = MultiMLP(d_hid, n_layers=self.world_size)
-        full_mod.to(self.device)
+        full_mod.to(rank_device)
         stage_mod = full_mod.get_submodule(f"layers.{self.rank}")
 
-        x = torch.randn(batch_size, d_hid, device=self.device)
+        x = torch.randn(batch_size, d_hid, device=rank_device)
 
         stage = PipelineStage(
             stage_mod,
             self.rank,
             self.world_size,
-            self.device,
+            rank_device,
         )
         stage._runtime_validate = True
 
@@ -453,7 +442,7 @@ class StageNegativeTest(PipelineStageTestBase):
 
         if self.rank == 0:
             with self.assertRaisesRegex(PipeliningMetadataError, "shape mismatch"):
-                _run_step(torch.randn(batch_size + 1, d_hid, device=self.device))
+                _run_step(torch.randn(batch_size + 1, d_hid, device=rank_device))
 
             with self.assertRaisesRegex(PipeliningMetadataError, "dtype mismatch"):
                 _run_step(x.to(torch.int32))
@@ -471,17 +460,18 @@ class StageNegativeTest(PipelineStageTestBase):
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
-    def test_custom_dw_errors(self):
+    def test_custom_dw_errors(self, device):
         """Tests expected errors are raised"""
+        rank_device = self._rank_device(device)
         full_mod = MultiMLP(d_hid, n_layers=self.world_size)
-        full_mod.to(self.device)
+        full_mod.to(rank_device)
         stage_mod = full_mod.get_submodule(f"layers.{self.rank}")
 
         stage_with_dw_builder = PipelineStage(
             stage_mod,
             self.rank,
             self.world_size,
-            self.device,
+            rank_device,
             dw_builder=lambda: None,
         )
         stage_with_dw_builder._has_backward = True

--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -15,12 +15,10 @@ from torch.distributed.pipelining import (
     ScheduleGPipe,
 )
 from torch.distributed.pipelining._utils import PipeliningMetadataError
-from torch.testing._internal.common_distributed import (
-    MultiProcContinuousTest,
-    requires_accelerator_dist_backend,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_distributed import MultiProcContinuousTest
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
     skip_but_pass_in_sandcastle_if,
@@ -41,6 +39,8 @@ torch.manual_seed(0)
 
 
 class PipelineStageMetadataInferenceTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_dynamic_metadata_inference_restores_module_buffers(self):
         class BufferMutatingModule(torch.nn.Module):
             def __init__(self) -> None:
@@ -127,21 +127,34 @@ def get_flatten_hook():
     return flatten_hook
 
 
-class StageTest(MultiProcContinuousTest):
+class PipelineStageTestBase(MultiProcContinuousTest):
+    # instantiate_device_type_tests copies non-test members using getattr(). A
+    # classmethod defined on generic_test_class is copied already bound to that
+    # class and cannot see the generated class's device_type. Defining backend_str
+    # on this base leaves it inherited, so cls refers to the generated
+    # device-specific test class when called.
     @classmethod
-    def backend_str(cls) -> str:
-        # Testing with NCCL backend
-        return backend
+    def _resolved_device_type(cls) -> str:
+        # MultiProcContinuousTest subprocesses run tests without calling
+        # PrivateUse1TestBase.setUpClass, so cls.device_type stays the generic
+        # "privateuse1" token; resolve it to the registered backend name.
+        dt = cls.device_type
+        if dt == "privateuse1":
+            dt = torch._C._get_privateuse1_backend_name()
+        return dt
 
     @classmethod
-    def device_type(cls) -> str:
-        return device_type
+    def backend_str(cls) -> str:
+        return dist.get_default_backend_for_device(cls._resolved_device_type())
+
+
+class StageTest(PipelineStageTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return torch.device(self._resolved_device_type(), self.rank)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
@@ -190,7 +203,6 @@ class StageTest(MultiProcContinuousTest):
                 f"Some keys not found in old_keys: {[k for k in submod_keys if k not in old_keys]}"
             )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
@@ -244,7 +256,6 @@ class StageTest(MultiProcContinuousTest):
                 f"Some keys not found in old_keys: {[k for k in submod_keys if k not in old_keys]}"
             )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
@@ -278,7 +289,6 @@ class StageTest(MultiProcContinuousTest):
             ref_out = full_mod(x)
             torch.testing.assert_close(out, ref_out)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
@@ -340,7 +350,6 @@ class StageTest(MultiProcContinuousTest):
             ref_out = full_mod(x)
             torch.testing.assert_close(out, ref_out)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
@@ -401,23 +410,16 @@ class StageTest(MultiProcContinuousTest):
             )
 
 
-instantiate_parametrized_tests(StageTest)
+instantiate_device_type_tests(StageTest, globals(), except_for=["cpu"], allow_xpu=True)
 
 
-class StageNegativeTest(MultiProcContinuousTest):
-    @classmethod
-    def backend_str(cls) -> str:
-        return backend
-
-    @classmethod
-    def device_type(cls) -> str:
-        return device_type
+class StageNegativeTest(PipelineStageTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return torch.device(self._resolved_device_type(), self.rank)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
@@ -466,7 +468,6 @@ class StageNegativeTest(MultiProcContinuousTest):
             with self.assertRaisesRegex(PipeliningMetadataError, "dtype mismatch"):
                 _run_step(x)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
@@ -487,6 +488,13 @@ class StageNegativeTest(MultiProcContinuousTest):
         with self.assertRaisesRegex(AssertionError, "backward_one_chunk"):
             stage_with_dw_builder.backward_weight_one_chunk(bwd_chunk_id=0)
 
+
+instantiate_device_type_tests(
+    StageNegativeTest,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -32,9 +32,6 @@ d_hid = 512
 batch_size = 256
 chunks = 8
 
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-backend = dist.get_default_backend_for_device(device_type)
-
 torch.manual_seed(0)
 
 
@@ -130,7 +127,7 @@ def get_flatten_hook():
 class PipelineStageTestBase(MultiProcContinuousTest):
     @classmethod
     def backend_str(cls) -> str:
-        return backend
+        return dist.get_default_backend_for_device(cls.device_type)
 
     def _rank_device(self, device: str) -> torch.device:
         # `device` is the framework-injected primary device ("{type}:0",
@@ -143,7 +140,7 @@ class StageTest(PipelineStageTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Test requires 2+ accelerators"
     )
     @parametrize("ModelClass", [ExampleCode, MultiMLP])
     def test_tracer(self, device, ModelClass):
@@ -192,7 +189,7 @@ class StageTest(PipelineStageTestBase):
             )
 
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Test requires 2+ accelerators"
     )
     @parametrize("ModelClass", [ModelWithKwargs])
     def test_tracer_kwargs(self, device, ModelClass):
@@ -246,7 +243,7 @@ class StageTest(PipelineStageTestBase):
             )
 
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Test requires 2+ accelerators"
     )
     def test_manual(self, device):
         rank_device = self._rank_device(device)
@@ -280,7 +277,7 @@ class StageTest(PipelineStageTestBase):
             torch.testing.assert_close(out, ref_out)
 
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Test requires 2+ accelerators"
     )
     def test_custom_dw_with_fb_schedule(self, device):
         """Tests that separate weight grad function 'dw_runner' gets run under a schedule that's only aware of F/B."""
@@ -342,7 +339,7 @@ class StageTest(PipelineStageTestBase):
             torch.testing.assert_close(out, ref_out)
 
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Test requires 2+ accelerators"
     )
     def test_output_chunks_memory_usage(self, device):
         """Test that output_chunks doesn't store memory for non-first stages."""
@@ -409,7 +406,7 @@ class StageNegativeTest(PipelineStageTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Test requires 2+ accelerators"
     )
     def test_shape_prop_mismatch(self, device):
         """Tests shape prop errors are raised"""
@@ -458,7 +455,7 @@ class StageNegativeTest(PipelineStageTestBase):
                 _run_step(x)
 
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Test requires 2+ accelerators"
     )
     def test_custom_dw_errors(self, device):
         """Tests expected errors are raised"""


### PR DESCRIPTION
## Summary
Enable `test_stage.py`'s multi-process stage tests on out-of-tree PrivateUse1 accelerators by switching `StageTest`/`StageNegativeTest` to `instantiate_device_type_tests` with hardware-classification labels. The backend-availability check this relies on is split into #192186 (lands first); this PR rebases on top.

## Changes
- `test/distributed/pipelining/test_stage.py`:
  - Switched `StageTest`/`StageNegativeTest` (real multi-process pipeline-parallel tests that spawn ranks and use a real collective backend) to `instantiate_device_type_tests(only_for=["cuda", "xpu", "privateuse1"], allow_xpu=True)`. The framework auto-discovers the registered PrivateUse1 backend and generates a per-device variant, so the PrivateUse1 variant runs on out-of-tree accelerators. Previously these classes were plain `MultiProcContinuousTest` subclasses with module-level device/backend globals and `instantiate_parametrized_tests`, which never produced a PrivateUse1 variant.
  - Removed all seven `@requires_accelerator_dist_backend(["nccl", "xccl"])` decorators. The backend availability check now lives in `MultiProcContinuousTest._ensure_processes_spawned` via `is_backend_available` (#192186), so the decorator's gate is redundant; the explicit list also excluded PrivateUse1's backend.
  - Added a `PipelineStageTestBase(MultiProcContinuousTest)` intermediate base holding `backend_str`. It is defined on the base (not on `StageTest`) so `instantiate_device_type_tests` inherits it rather than ports it — a ported classmethod is bound to the generic class and cannot see the generated variant's `device_type`. `backend_str` delegates to a `_resolved_device_type()` helper that resolves the generic `"privateuse1"` token to the registered backend name, needed because `MultiProcContinuousTest` subprocesses run tests directly without calling `setUpClass` (where `PrivateUse1TestBase` would otherwise resolve `device_type`).
  - Classified `PipelineStageMetadataInferenceTest` (single-rank, CPU + gloo, pure metadata-inference logic) as `HardwareClassification.GENERIC`, and `StageTest`/`StageNegativeTest` (real multi-process comm) as `HardwareClassification.ACCELERATOR`. The classification is metadata: it only filters tests when `--hw-classification` is passed; normal discovery/execution is unchanged.

## Motivation
Part of the test-case refactoring initiative (#185590) to decouple tests from hardcoded CUDA/NCCL assumptions so out-of-tree PrivateUse1 accelerators can run the suite. The framework change (spawn-time backend check) lives in #192186; this PR switches `test_stage.py` to `instantiate_device_type_tests` (per-device variants) and classifies the classes so the suite can filter them by hardware category.

## Notes
This is part of the test case refactoring initiative tracked in #185590. Depends on #192186 (the `is_backend_available` framework change); rebases onto main after #192186 merges.