### PR TITLE
[Testcase Refactoring] Tag test_format_utils.py with hw_classification

### DIFF
--- a/test/distributed/checkpoint/test_format_utils.py
+++ b/test/distributed/checkpoint/test_format_utils.py
@@ -116,6 +116,8 @@ class TestFormatUtils(DTensorTestBase):
         self.assertEqual(sd["model"], model.state_dict())
 
 
-instantiate_device_type_tests(TestFormatUtils, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestFormatUtils, globals(), except_for="cpu", allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_format_utils.py
+++ b/test/distributed/checkpoint/test_format_utils.py
@@ -118,8 +118,6 @@ class TestFormatUtils(DTensorTestBase):
         self.assertEqual(sd["model"], model.state_dict())
 
 
-instantiate_device_type_tests(
-    TestFormatUtils, globals(), except_for="cpu", allow_xpu=True
-)
+instantiate_device_type_tests(TestFormatUtils, globals(), except_for="cpu")
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_format_utils.py
+++ b/test/distributed/checkpoint/test_format_utils.py
@@ -13,8 +13,13 @@ from torch.distributed.checkpoint.format_utils import (
 )
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -47,6 +52,8 @@ class SimpleModelUneven(nn.Module):
 
 
 class TestFormatUtils(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_temp_dir
     def test_dcp_to_torch_save(self) -> None:
         model = SimpleModelUneven()
@@ -75,7 +82,12 @@ class TestFormatUtils(DTensorTestBase):
     @with_comms
     @with_temp_dir
     @skip_if_lt_x_gpu(2)
-    def test_online_torch_save_to_dcp(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.dtensor,
+        Capability.distributed.fsdp,
+    )
+    def test_online_torch_save_to_dcp(self, device) -> None:
         """Tests loading a model saved by torch.save directly into a sharded model
         using dcp.load
         """
@@ -106,5 +118,8 @@ class TestFormatUtils(DTensorTestBase):
         self.assertEqual(sd["model"], model.state_dict())
 
 
+instantiate_device_type_tests(
+    TestFormatUtils, globals(), except_for="cpu", allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_format_utils.py
+++ b/test/distributed/checkpoint/test_format_utils.py
@@ -44,9 +44,6 @@ class SimpleModelUneven(nn.Module):
         x = self.net4(x)
         return x
 
-    def get_input(self):
-        return torch.rand(4, 5, device=self.net1.weight.device)
-
 
 class TestFormatUtilsNoDist(TestCase):
     # These two tests drive the dcp <-> torch.save conversion on the no-dist

--- a/test/distributed/checkpoint/test_format_utils.py
+++ b/test/distributed/checkpoint/test_format_utils.py
@@ -15,15 +15,16 @@ from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import HardwareClassification, run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
 )
 from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
-
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
 class SimpleModelUneven(nn.Module):
@@ -44,14 +45,19 @@ class SimpleModelUneven(nn.Module):
         return x
 
     def get_input(self):
-        return torch.rand(4, 5, device=device_type)
+        return torch.rand(4, 5, device=self.net1.weight.device)
 
 
-class TestFormatUtils(DTensorTestBase):
-    hw_classification = HardwareClassification.ACCELERATOR
+class TestFormatUtilsNoDist(TestCase):
+    # These two tests drive the dcp <-> torch.save conversion on the no-dist
+    # path: no process group, and no device is referenced anywhere, so they
+    # are GENERIC and stay un-instantiated. Keeping them in the ACCELERATOR
+    # class below would stop them from being generated (and run) on CPU-only
+    # hosts once ``except_for="cpu"`` filters that class out.
+    hw_classification = HardwareClassification.GENERIC
 
     @with_temp_dir
-    def test_dcp_to_torch_save(self, device) -> None:
+    def test_dcp_to_torch_save(self) -> None:
         model = SimpleModelUneven()
         dcp.save({"model": model}, checkpoint_id=self.temp_dir)
 
@@ -62,7 +68,7 @@ class TestFormatUtils(DTensorTestBase):
         self.assertEqual(loaded_sd, {"model": model.state_dict()})
 
     @with_temp_dir
-    def test_torch_save_to_dcp(self, device) -> None:
+    def test_torch_save_to_dcp(self) -> None:
         model = SimpleModelUneven()
         sd = {"model": model.state_dict()}
         torch_path = self.temp_dir + "/model.pt"
@@ -74,6 +80,10 @@ class TestFormatUtils(DTensorTestBase):
         dcp.load({"model": model}, checkpoint_id=self.temp_dir)
 
         self.assertEqual({"model": model.state_dict()}, sd)
+
+
+class TestFormatUtils(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @with_comms
     @with_temp_dir

--- a/test/distributed/checkpoint/test_format_utils.py
+++ b/test/distributed/checkpoint/test_format_utils.py
@@ -55,7 +55,7 @@ class TestFormatUtils(DTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @with_temp_dir
-    def test_dcp_to_torch_save(self) -> None:
+    def test_dcp_to_torch_save(self, device) -> None:
         model = SimpleModelUneven()
         dcp.save({"model": model}, checkpoint_id=self.temp_dir)
 
@@ -66,7 +66,7 @@ class TestFormatUtils(DTensorTestBase):
         self.assertEqual(loaded_sd, {"model": model.state_dict()})
 
     @with_temp_dir
-    def test_torch_save_to_dcp(self) -> None:
+    def test_torch_save_to_dcp(self, device) -> None:
         model = SimpleModelUneven()
         sd = {"model": model.state_dict()}
         torch_path = self.temp_dir + "/model.pt"

--- a/test/distributed/checkpoint/test_format_utils.py
+++ b/test/distributed/checkpoint/test_format_utils.py
@@ -13,11 +13,7 @@ from torch.distributed.checkpoint.format_utils import (
 )
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -82,11 +78,6 @@ class TestFormatUtils(DTensorTestBase):
     @with_comms
     @with_temp_dir
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.dtensor,
-        Capability.distributed.fsdp,
-    )
     def test_online_torch_save_to_dcp(self, device) -> None:
         """Tests loading a model saved by torch.save directly into a sharded model
         using dcp.load


### PR DESCRIPTION
## Summary

Tags the distributed format test as `HardwareClassification.ACCELERATOR`,
instantiates it by device type, and keeps the two no-dist conversion tests in a
separate `HardwareClassification.GENERIC` `TestCase`.

## Changes

- `TestFormatUtils` is tagged `ACCELERATOR` and instantiated with
  `except_for=cpu`;
- the two conversion-only tests move to `TestFormatUtilsNoDist`, since they do
  not initialize a process group or reference a device;
- the existing `skip_if_lt_x_gpu(2)` gate remains unchanged;
- the module-level `current_accelerator()`/global `device_type` lookup is
  removed; `SimpleModelUneven.get_input()` follows the model parameter device.

No capability declaration is added because this file had no matching
capability-specific decorator before the refactor.

## Test Plan

The previous head passed the accelerator run with 3 tests. The latest review
follow-up will be revalidated on NPU and CPU before requesting re-review.

## Related

Part of #185590. The device-count helper used by the unchanged world-size gate
was generalized by the landed #185184.