### PR TITLE
[Testcase Refactoring] Make test_utils.py device-agnostic and tag TestUtils

### DIFF
--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -207,6 +207,6 @@ class TestUtils(TestCase):
         )
 
 
-instantiate_device_type_tests(TestUtils, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(TestUtils, globals(), except_for="cpu")
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -207,6 +207,6 @@ class TestUtils(TestCase):
         )
 
 
-instantiate_device_type_tests(TestUtils, globals(), except_for="cpu")
+instantiate_device_type_tests(TestUtils, globals(), except_for="cpu", allow_xpu=True)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -15,6 +15,7 @@ from torch.distributed.utils import _apply_to_tensors, _replace_by_prefix
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     parametrize,
     run_tests,
     subtest,
@@ -41,10 +42,13 @@ if TEST_HPU:
 elif TEST_XPU:
     list_device = "xpu"
 else:
-    list_device = "cuda"
+    _acc = torch.accelerator.current_accelerator(check_available=True)
+    list_device = _acc.type if _acc is not None else "cuda"
 
 
 class TestUtils(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @parametrize(
         "device_list",
         [
@@ -203,7 +207,6 @@ class TestUtils(TestCase):
         )
 
 
-devices = ("cuda", "hpu", "xpu")
-instantiate_device_type_tests(TestUtils, globals(), only_for=devices, allow_xpu=True)
+instantiate_device_type_tests(TestUtils, globals(), except_for="cpu", allow_xpu=True)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -33,6 +33,7 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
+
 class TestUtils(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -13,15 +13,11 @@ from torch import distributed as dist
 from torch.distributed.fsdp._common_utils import _get_param_to_fqns
 from torch.distributed.utils import _apply_to_tensors, _replace_by_prefix
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     parametrize,
     run_tests,
-    subtest,
-    TEST_HPU,
     TEST_WITH_DEV_DBG_ASAN,
-    TEST_XPU,
     TestCase,
 )
 
@@ -37,28 +33,20 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
-if TEST_HPU:
-    list_device = "hpu"
-elif TEST_XPU:
-    list_device = "xpu"
-else:
-    _acc = torch.accelerator.current_accelerator(check_available=True)
-    list_device = _acc.type if _acc is not None else "cuda"
-
-
 class TestUtils(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @parametrize(
-        "device_list",
-        [
-            ["cpu"],
-            [list_device],
-            subtest(["cpu", list_device], name=f"cpu_{list_device}"),
-        ],
+        "device_list_mode",
+        ["cpu", "acc", "mixed"],
     )
-    @skip_if_lt_x_gpu(1)
-    def test_apply_to_tensors(self, device_list):
+    def test_apply_to_tensors(self, device, device_list_mode):
+        device_lists = {
+            "cpu": ["cpu"],
+            "acc": [device],
+            "mixed": ["cpu", device],
+        }
+        device_list = device_lists[device_list_mode]
         expected = 0
 
         def get_a_tensor():
@@ -107,7 +95,10 @@ class TestUtils(TestCase):
         for i, v in enumerate(data):
             self.assertEqual(type(new_data[i]), type(v))
 
-    @skip_if_lt_x_gpu(1)
+
+class TestUtilsGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_replace_by_prefix(self):
         state_dict = {
             "layer.a": torch.tensor(1),
@@ -132,7 +123,6 @@ class TestUtils(TestCase):
                 f"Expected keys {set(original_state_dict.keys())}, got {set(state_dict.keys())}"
             )
 
-    @skip_if_lt_x_gpu(1)
     def test_packed_sequence(self):
         """Test to ensure RNN packed sequences are modified correctly."""
         rnn = nn.RNN(5, 5)


### PR DESCRIPTION
## Summary

Make `test/distributed/fsdp/test_utils.py` device-agnostic and classify tests according to their actual hardware requirements.

## Changes

- Keep `test_apply_to_tensors` in an `ACCELERATOR` class, instantiated with `except_for="cpu", allow_xpu=True`.
- Replace the module-level device list and explicit accelerator selection with `cpu`, `acc`, and `mixed` parameterization modes. Resolve each mode inside the test using the framework-injected `device`.
- Move `test_replace_by_prefix`, `test_packed_sequence`, and `test_get_param_to_fqns_scales_linearly` into a separate `GENERIC` class without device instantiation.
- Remove the redundant `skip_if_lt_x_gpu(1)` decorators and unused imports.

No capability declarations are added. These utility tests do not require a distributed process group or FSDP test-base changes.

## Validation

Targeted validation of the split-class implementation:
- Accelerator environment: 6 tests passed, with no skips.
- CPU-only environment: 3 GENERIC tests passed, with no skips.

See the Checks tab for CI results.

## Dependencies

No dependency on an unmerged PR.

Part of #185590.