### PR TITLE
Avoid symbolic storage recomputation on FakeTensor cache hits

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4538,8 +4538,8 @@ def forward(self, arg0_1: "i64[2][1]cpu", arg1_1: "Sym(u2)", arg2_1: "Sym(u3)", 
         _assert_scalar_6 = torch.ops.aten._assert_scalar.default(eq, "Runtime assertion failed for expression Eq(u2*u3, u0*u1) on node 'eq'");  eq = _assert_scalar_6 = None
         clone: "f32[u2, u3][Max(1, u3), 1]cpu" = torch.ops.aten.clone.default(arg3_1, memory_format = torch.contiguous_format);  arg3_1 = None
         view: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.view.default(clone, [_local_scalar_dense, _local_scalar_dense_1]);  clone = _local_scalar_dense = _local_scalar_dense_1 = None
-        mul_21: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
-        return (mul_21,)""",
+        mul_19: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
+        return (mul_19,)""",
             ignore_comments=True,
             ignore_empty_lines=True,
         )

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4597,8 +4597,8 @@ def forward(self, arg0_1: "i64[2][1]cpu", arg1_1: "Sym(u2)", arg2_1: "Sym(u3)", 
         _assert_scalar_6 = torch.ops.aten._assert_scalar.default(eq, "Runtime assertion failed for expression Eq(u2*u3, u0*u1) on node 'eq'");  eq = _assert_scalar_6 = None
         clone: "f32[u2, u3][Max(1, u3), 1]cpu" = torch.ops.aten.clone.default(arg3_1, memory_format = torch.contiguous_format);  arg3_1 = None
         view: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.view.default(clone, [_local_scalar_dense, _local_scalar_dense_1]);  clone = _local_scalar_dense = _local_scalar_dense_1 = None
-        mul_17: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
-        return (mul_17,)""",
+        mul_15: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
+        return (mul_15,)""",
             ignore_comments=True,
             ignore_empty_lines=True,
         )

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3824,7 +3824,6 @@ class FakeTensorDispatchCache(TestCase):
 
     def test_cache_view_output_preserves_resized_storage(self):
         fake_mode = FakeTensorMode()
-        fake_mode.cache_crosscheck_enabled = False
 
         with fake_mode:
             x = torch.randn(4, 8)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3711,7 +3711,6 @@ class FakeTensorDispatchCache(TestCase):
     def _symbolic_cache_input(self, *, dtype=torch.float32, requires_grad=False):
         shape_env = ShapeEnv()
         fake_mode = FakeTensorMode(shape_env=shape_env)
-        fake_mode.cache_crosscheck_enabled = False
         x = fake_mode.from_tensor(
             torch.randn(4, 8, dtype=dtype, requires_grad=requires_grad),
             source=LocalSource("x", is_input=True),
@@ -3733,6 +3732,7 @@ class FakeTensorDispatchCache(TestCase):
 
     def test_cache_symbolic_contiguous_output_avoids_empty_strided(self):
         fake_mode, x = self._symbolic_cache_input()
+        fake_mode.cache_crosscheck_enabled = False
 
         with fake_mode:
             FakeTensorMode.cache_clear()
@@ -3782,6 +3782,7 @@ class FakeTensorDispatchCache(TestCase):
 
     def test_cache_symbolic_noncontiguous_output_preserves_strides(self):
         fake_mode, x = self._symbolic_cache_input()
+        fake_mode.cache_crosscheck_enabled = False
 
         with fake_mode:
             x = aten.transpose.int(x, 0, 1)
@@ -3799,6 +3800,7 @@ class FakeTensorDispatchCache(TestCase):
 
     def test_cache_symbolic_view_output_preserves_strides_and_storage_offset(self):
         fake_mode, x = self._symbolic_cache_input()
+        fake_mode.cache_crosscheck_enabled = False
 
         with fake_mode:
             x = aten.transpose.int(x, 0, 1)
@@ -3900,6 +3902,7 @@ class FakeTensorDispatchCache(TestCase):
 
     def test_cache_symbolic_dtype_changing_view_preserves_dtype(self):
         fake_mode, x = self._symbolic_cache_input(dtype=torch.complex64)
+        fake_mode.cache_crosscheck_enabled = False
 
         with fake_mode:
             x = aten.slice.Tensor(x, 0, 1, 4)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3899,6 +3899,48 @@ class FakeTensorDispatchCache(TestCase):
                 before_downstream_hit.misses,
             )
 
+    def test_cache_symbolic_contiguous_output_preserves_storage_bytes(self):
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        x = fake_mode.from_tensor(
+            torch.randn(4, 8),
+            source=LocalSource("x", is_input=True),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.DYNAMIC],
+                constraint_sizes=[None, None],
+            ),
+        )
+
+        with fake_mode:
+            FakeTensorMode.cache_clear()
+            expected = aten.mul.Tensor(x, 2)
+            before_hit = FakeTensorMode.cache_info()
+            actual = aten.mul.Tensor(x, 2)
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
+
+            expected_storage_bytes = expected.untyped_storage().nbytes()
+            actual_storage_bytes = actual.untyped_storage().nbytes()
+            self.assertIsInstance(expected_storage_bytes, torch.SymInt)
+            self.assertIsInstance(actual_storage_bytes, torch.SymInt)
+            self.assertEqual(
+                actual_storage_bytes.node.expr,
+                expected_storage_bytes.node.expr,
+            )
+
+            FakeTensorMode.cache_clear()
+            aten.sin.default(expected)
+            before_downstream_hit = FakeTensorMode.cache_info()
+            aten.sin.default(actual)
+            after_downstream_hit = FakeTensorMode.cache_info()
+            self.assertEqual(
+                after_downstream_hit.hits,
+                before_downstream_hit.hits + 1,
+            )
+            self.assertEqual(
+                after_downstream_hit.misses,
+                before_downstream_hit.misses,
+            )
+
     def test_cache_symbolic_dtype_changing_view_preserves_dtype(self):
         fake_mode, x = self._symbolic_cache_input(dtype=torch.complex64)
         fake_mode.cache_crosscheck_enabled = False

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3838,27 +3838,30 @@ class FakeTensorDispatchCache(TestCase):
             self.assertEqual(actual.untyped_storage().nbytes(), 0)
             self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
-    def test_cache_symbolic_view_output_restores_view_bits(self):
-        cases = (
+    @parametrize(
+        "func,set_flag,flag_name,dtype",
+        (
             (aten._conj.default, torch._C._set_conj, "is_conj", torch.complex64),
             (aten._neg_view.default, torch._C._set_neg, "is_neg", torch.float32),
-        )
-        for func, set_flag, flag_name, dtype in cases:
-            with self.subTest(func=func):
-                fake_mode, x = self._symbolic_cache_input(dtype=dtype)
+        ),
+    )
+    def test_cache_symbolic_view_output_restores_view_bits(
+        self, func, set_flag, flag_name, dtype
+    ):
+        fake_mode, x = self._symbolic_cache_input(dtype=dtype)
 
-                with fake_mode:
-                    set_flag(x, True)
-                    FakeTensorMode.cache_clear()
-                    expected = func(x)
-                    before_hit = FakeTensorMode.cache_info()
-                    actual = func(x)
+        with fake_mode:
+            set_flag(x, True)
+            FakeTensorMode.cache_clear()
+            expected = func(x)
+            before_hit = FakeTensorMode.cache_info()
+            actual = func(x)
 
-                    self.assertEqual(
-                        getattr(actual, flag_name)(),
-                        getattr(expected, flag_name)(),
-                    )
-                    self._assert_symbolic_cache_hit(before_hit, actual, expected)
+            self.assertEqual(
+                getattr(actual, flag_name)(),
+                getattr(expected, flag_name)(),
+            )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_symbolic_contiguous_output_preserves_stride_backrefs(self):
         shape_env = ShapeEnv()
@@ -4534,6 +4537,9 @@ class FakeTensorDispatchCache(TestCase):
         FakeTensorMode.cache_clear()
         ep.run_decompositions({})
         self.assertBypasses("unrepresented symbol in output", 2)
+
+
+instantiate_parametrized_tests(FakeTensorDispatchCache)
 
 
 class FakeTensorPreferDeviceType(TestCase):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3676,6 +3676,109 @@ class FakeTensorDispatchCache(TestCase):
                 extract_tensor_metadata(res2),
             )
 
+    def _symbolic_cache_input(self, *, requires_grad=False):
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        fake_mode.cache_crosscheck_enabled = False
+        x = fake_mode.from_tensor(
+            torch.randn(4, 8, requires_grad=requires_grad),
+            source=LocalSource("x", is_input=True),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.STATIC],
+                constraint_sizes=[None, None],
+            ),
+        )
+        return fake_mode, x
+
+    def test_cache_symbolic_contiguous_output_avoids_empty_strided(self):
+        fake_mode, x = self._symbolic_cache_input()
+
+        with fake_mode:
+            FakeTensorMode.cache_clear()
+            expected = aten.clone.default(x)
+            before_hit = FakeTensorMode.cache_info()
+
+            with patch.object(
+                torch, "empty_strided", wraps=torch.empty_strided
+            ) as empty_strided:
+                actual = aten.clone.default(x)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            empty_strided.assert_not_called()
+            self.assertEqual(
+                extract_tensor_metadata(actual),
+                extract_tensor_metadata(expected),
+            )
+
+    def test_cache_symbolic_noncontiguous_output_preserves_strides(self):
+        fake_mode, x = self._symbolic_cache_input()
+
+        with fake_mode:
+            x = aten.transpose.int(x, 0, 1)
+            FakeTensorMode.cache_clear()
+            expected = aten.clone.default(x, memory_format=torch.preserve_format)
+            before_hit = FakeTensorMode.cache_info()
+
+            with patch.object(
+                torch, "empty_strided", wraps=torch.empty_strided
+            ) as empty_strided:
+                actual = aten.clone.default(x, memory_format=torch.preserve_format)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            empty_strided.assert_called_once()
+            self.assertEqual(
+                extract_tensor_metadata(actual),
+                extract_tensor_metadata(expected),
+            )
+
+    def test_cache_symbolic_view_output_uses_as_strided(self):
+        fake_mode, x = self._symbolic_cache_input()
+
+        with fake_mode:
+            FakeTensorMode.cache_clear()
+            expected = aten.transpose.int(x, 0, 1)
+            before_hit = FakeTensorMode.cache_info()
+
+            with patch.object(
+                torch, "as_strided", wraps=torch.as_strided
+            ) as as_strided:
+                actual = aten.transpose.int(x, 0, 1)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            as_strided.assert_called_once()
+            self.assertEqual(
+                extract_tensor_metadata(actual),
+                extract_tensor_metadata(expected),
+            )
+            self.assertEqual(
+                actual.untyped_storage()._cdata,
+                x.untyped_storage()._cdata,
+            )
+
+    def test_cache_symbolic_detach_output_clears_requires_grad(self):
+        fake_mode, x = self._symbolic_cache_input(requires_grad=True)
+
+        with fake_mode:
+            FakeTensorMode.cache_clear()
+            expected = aten.detach.default(x)
+            before_hit = FakeTensorMode.cache_info()
+            actual = aten.detach.default(x)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            self.assertFalse(actual.requires_grad)
+            self.assertEqual(
+                extract_tensor_metadata(actual),
+                extract_tensor_metadata(expected),
+            )
+
     def test_cache_bypass_prims_as_strided(self):
         x = torch.empty(0, 8)
         y = torch.empty(0, 8)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3676,12 +3676,12 @@ class FakeTensorDispatchCache(TestCase):
                 extract_tensor_metadata(res2),
             )
 
-    def _symbolic_cache_input(self, *, requires_grad=False):
+    def _symbolic_cache_input(self, *, dtype=torch.float32, requires_grad=False):
         shape_env = ShapeEnv()
         fake_mode = FakeTensorMode(shape_env=shape_env)
         fake_mode.cache_crosscheck_enabled = False
         x = fake_mode.from_tensor(
-            torch.randn(4, 8, requires_grad=requires_grad),
+            torch.randn(4, 8, dtype=dtype, requires_grad=requires_grad),
             source=LocalSource("x", is_input=True),
             symbolic_context=StatelessSymbolicContext(
                 dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.STATIC],
@@ -3752,6 +3752,33 @@ class FakeTensorDispatchCache(TestCase):
             self.assertEqual(after_hit.hits, before_hit.hits + 1)
             self.assertEqual(after_hit.misses, before_hit.misses)
             as_strided.assert_called_once()
+            self.assertEqual(
+                extract_tensor_metadata(actual),
+                extract_tensor_metadata(expected),
+            )
+            self.assertEqual(
+                actual.untyped_storage()._cdata,
+                x.untyped_storage()._cdata,
+            )
+
+    def test_cache_symbolic_dtype_changing_view_preserves_dtype(self):
+        fake_mode, x = self._symbolic_cache_input(dtype=torch.complex64)
+
+        with fake_mode:
+            FakeTensorMode.cache_clear()
+            expected = aten.view_as_real.default(x)
+            before_hit = FakeTensorMode.cache_info()
+
+            with patch.object(
+                torch, "as_strided", wraps=torch.as_strided
+            ) as as_strided:
+                actual = aten.view_as_real.default(x)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            as_strided.assert_not_called()
+            self.assertEqual(actual.dtype, torch.float32)
             self.assertEqual(
                 extract_tensor_metadata(actual),
                 extract_tensor_metadata(expected),

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3690,6 +3690,15 @@ class FakeTensorDispatchCache(TestCase):
         )
         return fake_mode, x
 
+    def _assert_symbolic_cache_hit(self, before_hit, actual, expected):
+        after_hit = FakeTensorMode.cache_info()
+        self.assertEqual(after_hit.hits, before_hit.hits + 1)
+        self.assertEqual(after_hit.misses, before_hit.misses)
+        self.assertEqual(
+            extract_tensor_metadata(actual),
+            extract_tensor_metadata(expected),
+        )
+
     def test_cache_symbolic_contiguous_output_avoids_empty_strided(self):
         fake_mode, x = self._symbolic_cache_input()
 
@@ -3703,14 +3712,8 @@ class FakeTensorDispatchCache(TestCase):
             ) as empty_strided:
                 actual = aten.clone.default(x)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             empty_strided.assert_not_called()
-            self.assertEqual(
-                extract_tensor_metadata(actual),
-                extract_tensor_metadata(expected),
-            )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_symbolic_noncontiguous_output_preserves_strides(self):
         fake_mode, x = self._symbolic_cache_input()
@@ -3726,40 +3729,31 @@ class FakeTensorDispatchCache(TestCase):
             ) as empty_strided:
                 actual = aten.clone.default(x, memory_format=torch.preserve_format)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             empty_strided.assert_called_once()
-            self.assertEqual(
-                extract_tensor_metadata(actual),
-                extract_tensor_metadata(expected),
-            )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
-    def test_cache_symbolic_view_output_uses_as_strided(self):
+    def test_cache_symbolic_view_output_preserves_strides_and_storage_offset(self):
         fake_mode, x = self._symbolic_cache_input()
 
         with fake_mode:
+            x = aten.transpose.int(x, 0, 1)
             FakeTensorMode.cache_clear()
-            expected = aten.transpose.int(x, 0, 1)
+            expected = aten.slice.Tensor(x, 0, 1, 8)
             before_hit = FakeTensorMode.cache_info()
 
             with patch.object(
                 torch, "as_strided", wraps=torch.as_strided
             ) as as_strided:
-                actual = aten.transpose.int(x, 0, 1)
+                actual = aten.slice.Tensor(x, 0, 1, 8)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             as_strided.assert_called_once()
-            self.assertEqual(
-                extract_tensor_metadata(actual),
-                extract_tensor_metadata(expected),
-            )
+            self.assertNotEqual(expected.storage_offset(), 0)
+            self.assertFalse(expected.is_contiguous())
             self.assertEqual(
                 actual.untyped_storage()._cdata,
                 x.untyped_storage()._cdata,
             )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_symbolic_view_output_restores_view_bits(self):
         cases = (
@@ -3777,17 +3771,11 @@ class FakeTensorDispatchCache(TestCase):
                     before_hit = FakeTensorMode.cache_info()
                     actual = func(x)
 
-                    after_hit = FakeTensorMode.cache_info()
-                    self.assertEqual(after_hit.hits, before_hit.hits + 1)
-                    self.assertEqual(after_hit.misses, before_hit.misses)
                     self.assertEqual(
                         getattr(actual, flag_name)(),
                         getattr(expected, flag_name)(),
                     )
-                    self.assertEqual(
-                        extract_tensor_metadata(actual),
-                        extract_tensor_metadata(expected),
-                    )
+                    self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_symbolic_contiguous_output_preserves_stride_backrefs(self):
         shape_env = ShapeEnv()
@@ -3811,10 +3799,8 @@ class FakeTensorDispatchCache(TestCase):
             ) as empty_strided:
                 actual = aten.clone.default(x, memory_format=torch.preserve_format)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             empty_strided.assert_called_once()
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
             FakeTensorMode.cache_clear()
             aten.sin.default(expected)
@@ -3834,6 +3820,7 @@ class FakeTensorDispatchCache(TestCase):
         fake_mode, x = self._symbolic_cache_input(dtype=torch.complex64)
 
         with fake_mode:
+            x = aten.slice.Tensor(x, 0, 1, 4)
             FakeTensorMode.cache_clear()
             expected = aten.view_as_real.default(x)
             before_hit = FakeTensorMode.cache_info()
@@ -3843,19 +3830,14 @@ class FakeTensorDispatchCache(TestCase):
             ) as as_strided:
                 actual = aten.view_as_real.default(x)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             as_strided.assert_not_called()
             self.assertEqual(actual.dtype, torch.float32)
-            self.assertEqual(
-                extract_tensor_metadata(actual),
-                extract_tensor_metadata(expected),
-            )
+            self.assertNotEqual(expected.storage_offset(), 0)
             self.assertEqual(
                 actual.untyped_storage()._cdata,
                 x.untyped_storage()._cdata,
             )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_symbolic_detach_output_clears_requires_grad(self):
         fake_mode, x = self._symbolic_cache_input(requires_grad=True)
@@ -3866,14 +3848,8 @@ class FakeTensorDispatchCache(TestCase):
             before_hit = FakeTensorMode.cache_info()
             actual = aten.detach.default(x)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             self.assertFalse(actual.requires_grad)
-            self.assertEqual(
-                extract_tensor_metadata(actual),
-                extract_tensor_metadata(expected),
-            )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_bypass_prims_as_strided(self):
         x = torch.empty(0, 8)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3761,6 +3761,75 @@ class FakeTensorDispatchCache(TestCase):
                 x.untyped_storage()._cdata,
             )
 
+    def test_cache_symbolic_view_output_restores_view_bits(self):
+        cases = (
+            (aten._conj.default, torch._C._set_conj, "is_conj", torch.complex64),
+            (aten._neg_view.default, torch._C._set_neg, "is_neg", torch.float32),
+        )
+        for func, set_flag, flag_name, dtype in cases:
+            with self.subTest(func=func):
+                fake_mode, x = self._symbolic_cache_input(dtype=dtype)
+
+                with fake_mode:
+                    set_flag(x, True)
+                    FakeTensorMode.cache_clear()
+                    expected = func(x)
+                    before_hit = FakeTensorMode.cache_info()
+                    actual = func(x)
+
+                    after_hit = FakeTensorMode.cache_info()
+                    self.assertEqual(after_hit.hits, before_hit.hits + 1)
+                    self.assertEqual(after_hit.misses, before_hit.misses)
+                    self.assertEqual(
+                        getattr(actual, flag_name)(),
+                        getattr(expected, flag_name)(),
+                    )
+                    self.assertEqual(
+                        extract_tensor_metadata(actual),
+                        extract_tensor_metadata(expected),
+                    )
+
+    def test_cache_symbolic_contiguous_output_preserves_stride_backrefs(self):
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        fake_mode.cache_crosscheck_enabled = False
+        x = fake_mode.from_tensor(
+            torch.randn(4, 8),
+            source=LocalSource("x", is_input=True),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.DYNAMIC],
+                dynamic_strides=[DimDynamic.DYNAMIC, DimDynamic.DYNAMIC],
+            ),
+        )
+
+        with fake_mode:
+            FakeTensorMode.cache_clear()
+            expected = aten.clone.default(x, memory_format=torch.preserve_format)
+            before_hit = FakeTensorMode.cache_info()
+            with patch.object(
+                torch, "empty_strided", wraps=torch.empty_strided
+            ) as empty_strided:
+                actual = aten.clone.default(x, memory_format=torch.preserve_format)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            empty_strided.assert_called_once()
+
+            FakeTensorMode.cache_clear()
+            aten.sin.default(expected)
+            before_downstream_hit = FakeTensorMode.cache_info()
+            aten.sin.default(actual)
+            after_downstream_hit = FakeTensorMode.cache_info()
+            self.assertEqual(
+                after_downstream_hit.hits,
+                before_downstream_hit.hits + 1,
+            )
+            self.assertEqual(
+                after_downstream_hit.misses,
+                before_downstream_hit.misses,
+            )
+
     def test_cache_symbolic_dtype_changing_view_preserves_dtype(self):
         fake_mode, x = self._symbolic_cache_input(dtype=torch.complex64)
 

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3747,6 +3747,39 @@ class FakeTensorDispatchCache(TestCase):
             empty_strided.assert_not_called()
             self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
+    def test_cache_contiguous_output_preserves_stride_expressions(self):
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        fake_mode.cache_crosscheck_enabled = False
+
+        with fake_mode:
+            u0 = shape_env.create_unbacked_symint()
+            u1 = shape_env.create_unbacked_symint()
+            torch._check(u0 >= 1)
+            torch._check(u1 >= 1)
+            x = torch.empty_strided((u0, u1), (u1, 1))
+            FakeTensorMode.cache_clear()
+            expected = aten.stack.default([x, x], 0)
+            before_hit = FakeTensorMode.cache_info()
+
+            with patch.object(
+                torch, "empty_strided", wraps=torch.empty_strided
+            ) as empty_strided:
+                actual = aten.stack.default([x, x], 0)
+
+            empty_strided.assert_called_once()
+            self.assertEqual(
+                tuple(
+                    s.node.expr if isinstance(s, torch.SymInt) else s
+                    for s in actual.stride()
+                ),
+                tuple(
+                    s.node.expr if isinstance(s, torch.SymInt) else s
+                    for s in expected.stride()
+                ),
+            )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
+
     def test_cache_symbolic_noncontiguous_output_preserves_strides(self):
         fake_mode, x = self._symbolic_cache_input()
 
@@ -3785,6 +3818,23 @@ class FakeTensorDispatchCache(TestCase):
                 actual.untyped_storage()._cdata,
                 x.untyped_storage()._cdata,
             )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
+
+    def test_cache_view_output_preserves_resized_storage(self):
+        fake_mode = FakeTensorMode()
+        fake_mode.cache_crosscheck_enabled = False
+
+        with fake_mode:
+            x = torch.randn(4, 8)
+            torch.ops.inductor.resize_storage_bytes_(x, 0)
+            FakeTensorMode.cache_clear()
+            expected = aten.slice.Tensor(x, 0, 1, 3)
+            before_hit = FakeTensorMode.cache_info()
+            actual = aten.slice.Tensor(x, 0, 1, 3)
+
+            self.assertEqual(x.untyped_storage().nbytes(), 0)
+            self.assertEqual(expected.untyped_storage().nbytes(), 0)
+            self.assertEqual(actual.untyped_storage().nbytes(), 0)
             self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_symbolic_view_output_restores_view_bits(self):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3708,12 +3708,12 @@ class FakeTensorDispatchCache(TestCase):
                 extract_tensor_metadata(res2),
             )
 
-    def _symbolic_cache_input(self, *, requires_grad=False):
+    def _symbolic_cache_input(self, *, dtype=torch.float32, requires_grad=False):
         shape_env = ShapeEnv()
         fake_mode = FakeTensorMode(shape_env=shape_env)
         fake_mode.cache_crosscheck_enabled = False
         x = fake_mode.from_tensor(
-            torch.randn(4, 8, requires_grad=requires_grad),
+            torch.randn(4, 8, dtype=dtype, requires_grad=requires_grad),
             source=LocalSource("x", is_input=True),
             symbolic_context=StatelessSymbolicContext(
                 dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.STATIC],
@@ -3784,6 +3784,33 @@ class FakeTensorDispatchCache(TestCase):
             self.assertEqual(after_hit.hits, before_hit.hits + 1)
             self.assertEqual(after_hit.misses, before_hit.misses)
             as_strided.assert_called_once()
+            self.assertEqual(
+                extract_tensor_metadata(actual),
+                extract_tensor_metadata(expected),
+            )
+            self.assertEqual(
+                actual.untyped_storage()._cdata,
+                x.untyped_storage()._cdata,
+            )
+
+    def test_cache_symbolic_dtype_changing_view_preserves_dtype(self):
+        fake_mode, x = self._symbolic_cache_input(dtype=torch.complex64)
+
+        with fake_mode:
+            FakeTensorMode.cache_clear()
+            expected = aten.view_as_real.default(x)
+            before_hit = FakeTensorMode.cache_info()
+
+            with patch.object(
+                torch, "as_strided", wraps=torch.as_strided
+            ) as as_strided:
+                actual = aten.view_as_real.default(x)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            as_strided.assert_not_called()
+            self.assertEqual(actual.dtype, torch.float32)
             self.assertEqual(
                 extract_tensor_metadata(actual),
                 extract_tensor_metadata(expected),

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3793,6 +3793,75 @@ class FakeTensorDispatchCache(TestCase):
                 x.untyped_storage()._cdata,
             )
 
+    def test_cache_symbolic_view_output_restores_view_bits(self):
+        cases = (
+            (aten._conj.default, torch._C._set_conj, "is_conj", torch.complex64),
+            (aten._neg_view.default, torch._C._set_neg, "is_neg", torch.float32),
+        )
+        for func, set_flag, flag_name, dtype in cases:
+            with self.subTest(func=func):
+                fake_mode, x = self._symbolic_cache_input(dtype=dtype)
+
+                with fake_mode:
+                    set_flag(x, True)
+                    FakeTensorMode.cache_clear()
+                    expected = func(x)
+                    before_hit = FakeTensorMode.cache_info()
+                    actual = func(x)
+
+                    after_hit = FakeTensorMode.cache_info()
+                    self.assertEqual(after_hit.hits, before_hit.hits + 1)
+                    self.assertEqual(after_hit.misses, before_hit.misses)
+                    self.assertEqual(
+                        getattr(actual, flag_name)(),
+                        getattr(expected, flag_name)(),
+                    )
+                    self.assertEqual(
+                        extract_tensor_metadata(actual),
+                        extract_tensor_metadata(expected),
+                    )
+
+    def test_cache_symbolic_contiguous_output_preserves_stride_backrefs(self):
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        fake_mode.cache_crosscheck_enabled = False
+        x = fake_mode.from_tensor(
+            torch.randn(4, 8),
+            source=LocalSource("x", is_input=True),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.DYNAMIC],
+                dynamic_strides=[DimDynamic.DYNAMIC, DimDynamic.DYNAMIC],
+            ),
+        )
+
+        with fake_mode:
+            FakeTensorMode.cache_clear()
+            expected = aten.clone.default(x, memory_format=torch.preserve_format)
+            before_hit = FakeTensorMode.cache_info()
+            with patch.object(
+                torch, "empty_strided", wraps=torch.empty_strided
+            ) as empty_strided:
+                actual = aten.clone.default(x, memory_format=torch.preserve_format)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            empty_strided.assert_called_once()
+
+            FakeTensorMode.cache_clear()
+            aten.sin.default(expected)
+            before_downstream_hit = FakeTensorMode.cache_info()
+            aten.sin.default(actual)
+            after_downstream_hit = FakeTensorMode.cache_info()
+            self.assertEqual(
+                after_downstream_hit.hits,
+                before_downstream_hit.hits + 1,
+            )
+            self.assertEqual(
+                after_downstream_hit.misses,
+                before_downstream_hit.misses,
+            )
+
     def test_cache_symbolic_dtype_changing_view_preserves_dtype(self):
         fake_mode, x = self._symbolic_cache_input(dtype=torch.complex64)
 

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3722,6 +3722,15 @@ class FakeTensorDispatchCache(TestCase):
         )
         return fake_mode, x
 
+    def _assert_symbolic_cache_hit(self, before_hit, actual, expected):
+        after_hit = FakeTensorMode.cache_info()
+        self.assertEqual(after_hit.hits, before_hit.hits + 1)
+        self.assertEqual(after_hit.misses, before_hit.misses)
+        self.assertEqual(
+            extract_tensor_metadata(actual),
+            extract_tensor_metadata(expected),
+        )
+
     def test_cache_symbolic_contiguous_output_avoids_empty_strided(self):
         fake_mode, x = self._symbolic_cache_input()
 
@@ -3735,14 +3744,8 @@ class FakeTensorDispatchCache(TestCase):
             ) as empty_strided:
                 actual = aten.clone.default(x)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             empty_strided.assert_not_called()
-            self.assertEqual(
-                extract_tensor_metadata(actual),
-                extract_tensor_metadata(expected),
-            )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_symbolic_noncontiguous_output_preserves_strides(self):
         fake_mode, x = self._symbolic_cache_input()
@@ -3758,40 +3761,31 @@ class FakeTensorDispatchCache(TestCase):
             ) as empty_strided:
                 actual = aten.clone.default(x, memory_format=torch.preserve_format)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             empty_strided.assert_called_once()
-            self.assertEqual(
-                extract_tensor_metadata(actual),
-                extract_tensor_metadata(expected),
-            )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
-    def test_cache_symbolic_view_output_uses_as_strided(self):
+    def test_cache_symbolic_view_output_preserves_strides_and_storage_offset(self):
         fake_mode, x = self._symbolic_cache_input()
 
         with fake_mode:
+            x = aten.transpose.int(x, 0, 1)
             FakeTensorMode.cache_clear()
-            expected = aten.transpose.int(x, 0, 1)
+            expected = aten.slice.Tensor(x, 0, 1, 8)
             before_hit = FakeTensorMode.cache_info()
 
             with patch.object(
                 torch, "as_strided", wraps=torch.as_strided
             ) as as_strided:
-                actual = aten.transpose.int(x, 0, 1)
+                actual = aten.slice.Tensor(x, 0, 1, 8)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             as_strided.assert_called_once()
-            self.assertEqual(
-                extract_tensor_metadata(actual),
-                extract_tensor_metadata(expected),
-            )
+            self.assertNotEqual(expected.storage_offset(), 0)
+            self.assertFalse(expected.is_contiguous())
             self.assertEqual(
                 actual.untyped_storage()._cdata,
                 x.untyped_storage()._cdata,
             )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_symbolic_view_output_restores_view_bits(self):
         cases = (
@@ -3809,17 +3803,11 @@ class FakeTensorDispatchCache(TestCase):
                     before_hit = FakeTensorMode.cache_info()
                     actual = func(x)
 
-                    after_hit = FakeTensorMode.cache_info()
-                    self.assertEqual(after_hit.hits, before_hit.hits + 1)
-                    self.assertEqual(after_hit.misses, before_hit.misses)
                     self.assertEqual(
                         getattr(actual, flag_name)(),
                         getattr(expected, flag_name)(),
                     )
-                    self.assertEqual(
-                        extract_tensor_metadata(actual),
-                        extract_tensor_metadata(expected),
-                    )
+                    self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_symbolic_contiguous_output_preserves_stride_backrefs(self):
         shape_env = ShapeEnv()
@@ -3843,10 +3831,8 @@ class FakeTensorDispatchCache(TestCase):
             ) as empty_strided:
                 actual = aten.clone.default(x, memory_format=torch.preserve_format)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             empty_strided.assert_called_once()
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
             FakeTensorMode.cache_clear()
             aten.sin.default(expected)
@@ -3866,6 +3852,7 @@ class FakeTensorDispatchCache(TestCase):
         fake_mode, x = self._symbolic_cache_input(dtype=torch.complex64)
 
         with fake_mode:
+            x = aten.slice.Tensor(x, 0, 1, 4)
             FakeTensorMode.cache_clear()
             expected = aten.view_as_real.default(x)
             before_hit = FakeTensorMode.cache_info()
@@ -3875,19 +3862,14 @@ class FakeTensorDispatchCache(TestCase):
             ) as as_strided:
                 actual = aten.view_as_real.default(x)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             as_strided.assert_not_called()
             self.assertEqual(actual.dtype, torch.float32)
-            self.assertEqual(
-                extract_tensor_metadata(actual),
-                extract_tensor_metadata(expected),
-            )
+            self.assertNotEqual(expected.storage_offset(), 0)
             self.assertEqual(
                 actual.untyped_storage()._cdata,
                 x.untyped_storage()._cdata,
             )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_symbolic_detach_output_clears_requires_grad(self):
         fake_mode, x = self._symbolic_cache_input(requires_grad=True)
@@ -3898,14 +3880,8 @@ class FakeTensorDispatchCache(TestCase):
             before_hit = FakeTensorMode.cache_info()
             actual = aten.detach.default(x)
 
-            after_hit = FakeTensorMode.cache_info()
-            self.assertEqual(after_hit.hits, before_hit.hits + 1)
-            self.assertEqual(after_hit.misses, before_hit.misses)
             self.assertFalse(actual.requires_grad)
-            self.assertEqual(
-                extract_tensor_metadata(actual),
-                extract_tensor_metadata(expected),
-            )
+            self._assert_symbolic_cache_hit(before_hit, actual, expected)
 
     def test_cache_bypass_prims_as_strided(self):
         x = torch.empty(0, 8)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3708,6 +3708,109 @@ class FakeTensorDispatchCache(TestCase):
                 extract_tensor_metadata(res2),
             )
 
+    def _symbolic_cache_input(self, *, requires_grad=False):
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        fake_mode.cache_crosscheck_enabled = False
+        x = fake_mode.from_tensor(
+            torch.randn(4, 8, requires_grad=requires_grad),
+            source=LocalSource("x", is_input=True),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.STATIC],
+                constraint_sizes=[None, None],
+            ),
+        )
+        return fake_mode, x
+
+    def test_cache_symbolic_contiguous_output_avoids_empty_strided(self):
+        fake_mode, x = self._symbolic_cache_input()
+
+        with fake_mode:
+            FakeTensorMode.cache_clear()
+            expected = aten.clone.default(x)
+            before_hit = FakeTensorMode.cache_info()
+
+            with patch.object(
+                torch, "empty_strided", wraps=torch.empty_strided
+            ) as empty_strided:
+                actual = aten.clone.default(x)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            empty_strided.assert_not_called()
+            self.assertEqual(
+                extract_tensor_metadata(actual),
+                extract_tensor_metadata(expected),
+            )
+
+    def test_cache_symbolic_noncontiguous_output_preserves_strides(self):
+        fake_mode, x = self._symbolic_cache_input()
+
+        with fake_mode:
+            x = aten.transpose.int(x, 0, 1)
+            FakeTensorMode.cache_clear()
+            expected = aten.clone.default(x, memory_format=torch.preserve_format)
+            before_hit = FakeTensorMode.cache_info()
+
+            with patch.object(
+                torch, "empty_strided", wraps=torch.empty_strided
+            ) as empty_strided:
+                actual = aten.clone.default(x, memory_format=torch.preserve_format)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            empty_strided.assert_called_once()
+            self.assertEqual(
+                extract_tensor_metadata(actual),
+                extract_tensor_metadata(expected),
+            )
+
+    def test_cache_symbolic_view_output_uses_as_strided(self):
+        fake_mode, x = self._symbolic_cache_input()
+
+        with fake_mode:
+            FakeTensorMode.cache_clear()
+            expected = aten.transpose.int(x, 0, 1)
+            before_hit = FakeTensorMode.cache_info()
+
+            with patch.object(
+                torch, "as_strided", wraps=torch.as_strided
+            ) as as_strided:
+                actual = aten.transpose.int(x, 0, 1)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            as_strided.assert_called_once()
+            self.assertEqual(
+                extract_tensor_metadata(actual),
+                extract_tensor_metadata(expected),
+            )
+            self.assertEqual(
+                actual.untyped_storage()._cdata,
+                x.untyped_storage()._cdata,
+            )
+
+    def test_cache_symbolic_detach_output_clears_requires_grad(self):
+        fake_mode, x = self._symbolic_cache_input(requires_grad=True)
+
+        with fake_mode:
+            FakeTensorMode.cache_clear()
+            expected = aten.detach.default(x)
+            before_hit = FakeTensorMode.cache_info()
+            actual = aten.detach.default(x)
+
+            after_hit = FakeTensorMode.cache_info()
+            self.assertEqual(after_hit.hits, before_hit.hits + 1)
+            self.assertEqual(after_hit.misses, before_hit.misses)
+            self.assertFalse(actual.requires_grad)
+            self.assertEqual(
+                extract_tensor_metadata(actual),
+                extract_tensor_metadata(expected),
+            )
+
     def test_cache_bypass_prims_as_strided(self):
         x = torch.empty(0, 8)
         y = torch.empty(0, 8)

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8978,7 +8978,7 @@ COMPILE_BACKWARD_SKIPS_AND_XFAILS = [
     # mean(): weird bug
     XFailRule(
         error_type=torch._dynamo.exc.BackendCompilerFailed,
-        error_msg="'NestedIntNode' object has no attribute 'sub'",
+        error_msg="'NestedIntNode' object has no attribute 'sym_float'",
         op_match_fn=lambda device, op: (op.full_name == "mean"),
         sample_match_fn=lambda device, sample: (
             "full reduction" not in sample.name

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2174,7 +2174,7 @@ class FakeTensorMode(TorchDispatchMode):
             and metadata.layout == torch.strided
             and statically_known_true(metadata.storage_offset == 0)
             and all(
-                _same_int_expr(actual, expected)
+                _same_int_expr(cast(IntLikeType, actual), expected)
                 for actual, expected in zip(
                     metadata.stride,
                     make_contiguous_strides_for(output.shape),

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2171,7 +2171,7 @@ class FakeTensorMode(TorchDispatchMode):
             view_idx = idxs[0]
 
         metadata = extract_tensor_metadata(output)
-        shape = metadata.shape
+        shape = output.shape
         stride = metadata.stride
         storage_offset = metadata.storage_offset
         metadata.shape = tuple(state.convert_output(v) for v in shape)

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1373,13 +1373,17 @@ class TensorMetadata:
                 result.append(value)
 
 
-def _same_int_expr(a: IntLikeType, b: IntLikeType) -> bool:
-    if isinstance(a, SymInt) or isinstance(b, SymInt):
-        return (
-            isinstance(a, SymInt)
-            and isinstance(b, SymInt)
-            and a.node.expr == b.node.expr
-        )
+def _same_int_expr(a: _MetadataIntLike, b: _MetadataIntLike) -> bool:
+    if isinstance(a, _SymIntOutputStub):
+        if not isinstance(b, _SymIntOutputStub):
+            return False
+        if isinstance(a.value, int):
+            return isinstance(b.value, int) and a.value == b.value
+        return not isinstance(b.value, int) and a.value._expr == b.value._expr
+    if isinstance(a, SymInt):
+        return isinstance(b, SymInt) and a.node.expr == b.node.expr
+    if isinstance(b, (_SymIntOutputStub, SymInt)):
+        return False
     return a == b
 
 
@@ -2167,34 +2171,38 @@ class FakeTensorMode(TorchDispatchMode):
             view_idx = idxs[0]
 
         metadata = extract_tensor_metadata(output)
-        from torch.fx.experimental.symbolic_shapes import statically_known_true
-
-        is_canonical_contiguous = (
-            view_idx is None
-            and metadata.layout == torch.strided
-            and statically_known_true(metadata.storage_offset == 0)
-            and all(
-                _same_int_expr(cast(IntLikeType, actual), expected)
-                for actual, expected in zip(
-                    metadata.stride,
-                    make_contiguous_strides_for(output.shape),
-                    strict=True,
-                )
-            )
-        )
-        metadata.shape = tuple(state.convert_output(v) for v in metadata.shape)
-        metadata.stride = tuple(state.convert_output(v) for v in metadata.stride)
-        metadata.storage_offset = state.convert_output(metadata.storage_offset)
-        # An int payload is a backreference to an input SymNode. torch.empty
-        # would recompute the stride or offset and lose that node identity.
-        is_canonical_contiguous = is_canonical_contiguous and not any(
-            isinstance(value, _SymIntOutputStub) and isinstance(value.value, int)
-            for value in (*metadata.stride, metadata.storage_offset)
-        )
+        shape = metadata.shape
+        stride = metadata.stride
+        storage_offset = metadata.storage_offset
+        metadata.shape = tuple(state.convert_output(v) for v in shape)
+        metadata.stride = tuple(state.convert_output(v) for v in stride)
+        metadata.storage_offset = state.convert_output(storage_offset)
         metadata.storage_bytes = (
             None
             if metadata.storage_bytes is None
             else state.convert_output(metadata.storage_bytes)
+        )
+        from torch.fx.experimental.symbolic_shapes import statically_known_true
+
+        # An int output-stub payload identifies an input SymNode. torch.empty
+        # would recompute the stride or offset and lose that node identity.
+        has_input_symnode_backref = any(
+            isinstance(value, _SymIntOutputStub) and isinstance(value.value, int)
+            for value in (*metadata.stride, metadata.storage_offset)
+        )
+        is_canonical_contiguous = (
+            view_idx is None
+            and metadata.layout == torch.strided
+            and statically_known_true(storage_offset == 0)
+            and not has_input_symnode_backref
+            and all(
+                _same_int_expr(actual, state.convert_output(expected))
+                for actual, expected in zip(
+                    metadata.stride,
+                    make_contiguous_strides_for(shape),
+                    strict=True,
+                )
+            )
         )
 
         entry = _DispatchCacheEntryOutputInfo(

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2405,22 +2405,24 @@ class FakeTensorMode(TorchDispatchMode):
         if self.shape_env is not None:
             maybe_suppress = self.shape_env.suppress_guards
 
-        is_view = entry.view_idx is not None
-        view_arg = None
-        if is_view:
-            view_arg = args[cast(int, entry.view_idx)]
-            if not isinstance(view_arg, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
+        view_idx = entry.view_idx
+        view_arg: FakeTensor | None = None
+        if view_idx is not None:
+            arg = args[view_idx]
+            if not isinstance(arg, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
                 raise AssertionError("view_arg must be a FakeTensor")
-        view_dtype_matches = (
+            view_arg = arg
+
+        # Rebuild same-dtype views that should not require gradients directly
+        # with as_strided. Detach a grad-requiring base to match the metadata.
+        if (
             view_arg is not None
             and metadata.dtype == view_arg.dtype
             and not metadata.requires_grad
-        )
-
-        with in_kernel_invocation_manager(self), maybe_suppress():
-            if view_dtype_matches:
-                view_base: Tensor = cast(FakeTensor, view_arg)
-                if view_base.requires_grad and not metadata.requires_grad:
+        ):
+            with in_kernel_invocation_manager(self), maybe_suppress():
+                view_base: Tensor = view_arg
+                if view_base.requires_grad:
                     view_base = view_base.detach()
                 empty = torch.as_strided(
                     view_base,
@@ -2428,7 +2430,13 @@ class FakeTensorMode(TorchDispatchMode):
                     stride,
                     storage_offset,
                 )
-            elif entry.is_canonical_contiguous:
+            torch._C._set_conj(empty, metadata.is_conj)
+            torch._C._set_neg(empty, metadata.is_neg)
+            return FakeTensor(self, empty, metadata.device)
+
+        is_view = view_arg is not None
+        with in_kernel_invocation_manager(self), maybe_suppress():
+            if entry.is_canonical_contiguous:
                 empty = torch.empty(
                     shape,
                     dtype=metadata.dtype,
@@ -2448,19 +2456,14 @@ class FakeTensorMode(TorchDispatchMode):
                     requires_grad=metadata.requires_grad,
                 )
 
-        if view_dtype_matches:
-            torch._C._set_conj(empty, metadata.is_conj)
-            torch._C._set_neg(empty, metadata.is_neg)
-        else:
-            if metadata.is_conj:
-                torch._C._set_conj(empty, True)
-            if metadata.is_neg:
-                torch._C._set_neg(empty, True)
+        if metadata.is_conj:
+            torch._C._set_conj(empty, True)
+        if metadata.is_neg:
+            torch._C._set_neg(empty, True)
 
-        if is_view and not view_dtype_matches:
+        if view_arg is not None:
             # For view ops, the storage should be the same as the tensor input.
-            view_base = cast(FakeTensor, view_arg)
-            storage = view_base.untyped_storage()
+            storage = view_arg.untyped_storage()
             with in_kernel_invocation_manager(self), maybe_suppress():
                 empty.set_(storage, storage_offset, shape, stride)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2168,6 +2168,10 @@ class FakeTensorMode(TorchDispatchMode):
         metadata.shape = tuple(state.convert_output(v) for v in metadata.shape)
         metadata.stride = tuple(state.convert_output(v) for v in metadata.stride)
         metadata.storage_offset = state.convert_output(metadata.storage_offset)
+        is_canonical_contiguous = is_canonical_contiguous and not any(
+            isinstance(value, _SymIntOutputStub) and isinstance(value.value, int)
+            for value in (*metadata.stride, metadata.storage_offset)
+        )
         metadata.storage_bytes = (
             None
             if metadata.storage_bytes is None
@@ -2378,7 +2382,6 @@ class FakeTensorMode(TorchDispatchMode):
         is_view = isinstance(func, torch._ops.OpOverload) and func.is_view
         view_arg = None
         if is_view:
-            # For view ops, the storage should be the same as the tensor input.
             view_arg = args[cast(int, entry.view_idx)]
             if not isinstance(view_arg, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
                 raise AssertionError("view_arg must be a FakeTensor")
@@ -2413,12 +2416,17 @@ class FakeTensorMode(TorchDispatchMode):
                     requires_grad=metadata.requires_grad,
                 )
 
-        if metadata.is_conj:
-            torch._C._set_conj(empty, True)
-        if metadata.is_neg:
-            torch._C._set_neg(empty, True)
+        if view_dtype_matches:
+            torch._C._set_conj(empty, metadata.is_conj)
+            torch._C._set_neg(empty, metadata.is_neg)
+        else:
+            if metadata.is_conj:
+                torch._C._set_conj(empty, True)
+            if metadata.is_neg:
+                torch._C._set_neg(empty, True)
 
         if is_view and not view_dtype_matches:
+            # For view ops, the storage should be the same as the tensor input.
             view_base = cast(FakeTensor, view_arg)
             storage = view_base.untyped_storage()
             with in_kernel_invocation_manager(self), maybe_suppress():

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -26,7 +26,7 @@ from torch._custom_class_base import CustomClassBase
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.fake_profile import MissingOpProfile
 from torch._logging import dtrace_structured
-from torch._prims_common import suggest_memory_format
+from torch._prims_common import make_contiguous_strides_for, suggest_memory_format
 from torch._subclasses.meta_utils import (
     assert_eq,
     assert_metadata_eq,
@@ -1463,6 +1463,7 @@ class _DispatchCacheEntryOutputInfo:
     inplace_idx: int | None
     metadata: TensorMetadata | None
     view_idx: int | None
+    is_canonical_contiguous: bool = False
     constant_value: Any | None = SingletonConstant
 
 
@@ -2149,6 +2150,21 @@ class FakeTensorMode(TorchDispatchMode):
             view_idx = idxs[0]
 
         metadata = extract_tensor_metadata(output)
+        from torch.fx.experimental.symbolic_shapes import statically_known_true
+
+        is_canonical_contiguous = (
+            view_idx is None
+            and metadata.layout == torch.strided
+            and statically_known_true(metadata.storage_offset == 0)
+            and all(
+                statically_known_true(actual == expected)
+                for actual, expected in zip(
+                    metadata.stride,
+                    make_contiguous_strides_for(output.shape),
+                    strict=True,
+                )
+            )
+        )
         metadata.shape = tuple(state.convert_output(v) for v in metadata.shape)
         metadata.stride = tuple(state.convert_output(v) for v in metadata.stride)
         metadata.storage_offset = state.convert_output(metadata.storage_offset)
@@ -2162,6 +2178,7 @@ class FakeTensorMode(TorchDispatchMode):
             inplace_idx=None,
             metadata=metadata,
             view_idx=view_idx,
+            is_canonical_contiguous=is_canonical_contiguous,
         )
 
         # N.B.: Some checks for bypassing the cache would be performed on the
@@ -2358,29 +2375,47 @@ class FakeTensorMode(TorchDispatchMode):
         if self.shape_env is not None:
             maybe_suppress = self.shape_env.suppress_guards
 
+        is_view = isinstance(func, torch._ops.OpOverload) and func.is_view
+        view_arg = None
+        if is_view:
+            # For view ops, the storage should be the same as the tensor input.
+            view_arg = args[cast(int, entry.view_idx)]
+            if not isinstance(view_arg, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
+                raise AssertionError("view_arg must be a FakeTensor")
+
         with in_kernel_invocation_manager(self), maybe_suppress():
-            empty = torch.empty_strided(
-                shape,
-                stride,
-                dtype=metadata.dtype,
-                layout=metadata.layout,
-                device="meta",
-                requires_grad=metadata.requires_grad,
-            )
+            if is_view:
+                view_base: Tensor = cast(FakeTensor, view_arg)
+                if view_base.requires_grad and not metadata.requires_grad:
+                    view_base = view_base.detach()
+                empty = torch.as_strided(
+                    view_base,
+                    shape,
+                    stride,
+                    storage_offset,
+                )
+            elif entry.is_canonical_contiguous:
+                empty = torch.empty(
+                    shape,
+                    dtype=metadata.dtype,
+                    layout=metadata.layout,
+                    device="meta",
+                    requires_grad=metadata.requires_grad,
+                )
+            else:
+                empty = torch.empty_strided(
+                    shape,
+                    stride,
+                    dtype=metadata.dtype,
+                    layout=metadata.layout,
+                    device="meta",
+                    requires_grad=metadata.requires_grad,
+                )
 
         if metadata.is_conj:
             torch._C._set_conj(empty, True)
         if metadata.is_neg:
             torch._C._set_neg(empty, True)
-
-        if isinstance(func, torch._ops.OpOverload) and func.is_view:
-            # For view ops, the storage should be the same as the tensor input.
-            view_arg = args[cast(int, entry.view_idx)]
-            if not isinstance(view_arg, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
-                raise AssertionError("view_arg must be a FakeTensor")
-            storage = view_arg.untyped_storage()
-            with in_kernel_invocation_manager(self), maybe_suppress():
-                empty.set_(storage, storage_offset, shape, stride)
 
         return FakeTensor(self, empty, metadata.device)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2382,9 +2382,10 @@ class FakeTensorMode(TorchDispatchMode):
             view_arg = args[cast(int, entry.view_idx)]
             if not isinstance(view_arg, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
                 raise AssertionError("view_arg must be a FakeTensor")
+        view_dtype_matches = view_arg is not None and metadata.dtype == view_arg.dtype
 
         with in_kernel_invocation_manager(self), maybe_suppress():
-            if is_view:
+            if view_dtype_matches:
                 view_base: Tensor = cast(FakeTensor, view_arg)
                 if view_base.requires_grad and not metadata.requires_grad:
                     view_base = view_base.detach()
@@ -2416,6 +2417,12 @@ class FakeTensorMode(TorchDispatchMode):
             torch._C._set_conj(empty, True)
         if metadata.is_neg:
             torch._C._set_neg(empty, True)
+
+        if is_view and not view_dtype_matches:
+            view_base = cast(FakeTensor, view_arg)
+            storage = view_base.untyped_storage()
+            with in_kernel_invocation_manager(self), maybe_suppress():
+                empty.set_(storage, storage_offset, shape, stride)
 
         return FakeTensor(self, empty, metadata.device)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -26,7 +26,7 @@ from torch._custom_class_base import CustomClassBase
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.fake_profile import MissingOpProfile
 from torch._logging import dtrace_structured
-from torch._prims_common import suggest_memory_format
+from torch._prims_common import make_contiguous_strides_for, suggest_memory_format
 from torch._subclasses.meta_utils import (
     assert_eq,
     assert_metadata_eq,
@@ -1465,6 +1465,7 @@ class _DispatchCacheEntryOutputInfo:
     inplace_idx: int | None
     metadata: TensorMetadata | None
     view_idx: int | None
+    is_canonical_contiguous: bool = False
     constant_value: Any | None = SingletonConstant
 
 
@@ -2156,6 +2157,21 @@ class FakeTensorMode(TorchDispatchMode):
             view_idx = idxs[0]
 
         metadata = extract_tensor_metadata(output)
+        from torch.fx.experimental.symbolic_shapes import statically_known_true
+
+        is_canonical_contiguous = (
+            view_idx is None
+            and metadata.layout == torch.strided
+            and statically_known_true(metadata.storage_offset == 0)
+            and all(
+                statically_known_true(actual == expected)
+                for actual, expected in zip(
+                    metadata.stride,
+                    make_contiguous_strides_for(output.shape),
+                    strict=True,
+                )
+            )
+        )
         metadata.shape = tuple(state.convert_output(v) for v in metadata.shape)
         metadata.stride = tuple(state.convert_output(v) for v in metadata.stride)
         metadata.storage_offset = state.convert_output(metadata.storage_offset)
@@ -2169,6 +2185,7 @@ class FakeTensorMode(TorchDispatchMode):
             inplace_idx=None,
             metadata=metadata,
             view_idx=view_idx,
+            is_canonical_contiguous=is_canonical_contiguous,
         )
 
         # N.B.: Some checks for bypassing the cache would be performed on the
@@ -2364,34 +2381,47 @@ class FakeTensorMode(TorchDispatchMode):
         if self.shape_env is not None:
             maybe_suppress = self.shape_env.suppress_guards
 
-        # The set_ below replaces the size, stride and storage of the tensor
-        # created here, so for a view op don't pay to derive them twice. On
-        # symbolic shapes that derivation is the bulk of the cost of both calls.
         is_view = entry.view_idx is not None
-
-        with in_kernel_invocation_manager(self), maybe_suppress():
-            empty = torch.empty_strided(
-                () if is_view else shape,
-                () if is_view else stride,
-                dtype=metadata.dtype,
-                layout=metadata.layout,
-                device="meta",
-                requires_grad=metadata.requires_grad,
-            )
-
-        if metadata.is_conj:
-            torch._C._set_conj(empty, True)
-        if metadata.is_neg:
-            torch._C._set_neg(empty, True)
-
+        view_arg = None
         if is_view:
             # For view ops, the storage should be the same as the tensor input.
             view_arg = args[cast(int, entry.view_idx)]
             if not isinstance(view_arg, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
                 raise AssertionError("view_arg must be a FakeTensor")
-            storage = view_arg.untyped_storage()
-            with in_kernel_invocation_manager(self), maybe_suppress():
-                empty.set_(storage, storage_offset, shape, stride)
+
+        with in_kernel_invocation_manager(self), maybe_suppress():
+            if is_view:
+                view_base: Tensor = cast(FakeTensor, view_arg)
+                if view_base.requires_grad and not metadata.requires_grad:
+                    view_base = view_base.detach()
+                empty = torch.as_strided(
+                    view_base,
+                    shape,
+                    stride,
+                    storage_offset,
+                )
+            elif entry.is_canonical_contiguous:
+                empty = torch.empty(
+                    shape,
+                    dtype=metadata.dtype,
+                    layout=metadata.layout,
+                    device="meta",
+                    requires_grad=metadata.requires_grad,
+                )
+            else:
+                empty = torch.empty_strided(
+                    shape,
+                    stride,
+                    dtype=metadata.dtype,
+                    layout=metadata.layout,
+                    device="meta",
+                    requires_grad=metadata.requires_grad,
+                )
+
+        if metadata.is_conj:
+            torch._C._set_conj(empty, True)
+        if metadata.is_neg:
+            torch._C._set_neg(empty, True)
 
         return FakeTensor(self, empty, metadata.device)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2388,9 +2388,10 @@ class FakeTensorMode(TorchDispatchMode):
             view_arg = args[cast(int, entry.view_idx)]
             if not isinstance(view_arg, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
                 raise AssertionError("view_arg must be a FakeTensor")
+        view_dtype_matches = view_arg is not None and metadata.dtype == view_arg.dtype
 
         with in_kernel_invocation_manager(self), maybe_suppress():
-            if is_view:
+            if view_dtype_matches:
                 view_base: Tensor = cast(FakeTensor, view_arg)
                 if view_base.requires_grad and not metadata.requires_grad:
                     view_base = view_base.detach()
@@ -2409,9 +2410,11 @@ class FakeTensorMode(TorchDispatchMode):
                     requires_grad=metadata.requires_grad,
                 )
             else:
+                # The set_ below replaces these fields for view outputs, so do
+                # not derive their symbolic metadata twice on the fallback path.
                 empty = torch.empty_strided(
-                    shape,
-                    stride,
+                    () if is_view else shape,
+                    () if is_view else stride,
                     dtype=metadata.dtype,
                     layout=metadata.layout,
                     device="meta",
@@ -2422,6 +2425,12 @@ class FakeTensorMode(TorchDispatchMode):
             torch._C._set_conj(empty, True)
         if metadata.is_neg:
             torch._C._set_neg(empty, True)
+
+        if is_view and not view_dtype_matches:
+            view_base = cast(FakeTensor, view_arg)
+            storage = view_base.untyped_storage()
+            with in_kernel_invocation_manager(self), maybe_suppress():
+                empty.set_(storage, storage_offset, shape, stride)
 
         return FakeTensor(self, empty, metadata.device)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1373,6 +1373,16 @@ class TensorMetadata:
                 result.append(value)
 
 
+def _same_int_expr(a: IntLikeType, b: IntLikeType) -> bool:
+    if isinstance(a, SymInt) or isinstance(b, SymInt):
+        return (
+            isinstance(a, SymInt)
+            and isinstance(b, SymInt)
+            and a.node.expr == b.node.expr
+        )
+    return a == b
+
+
 def extract_tensor_metadata(t: Tensor) -> TensorMetadata:
     """
     Extract the TensorMetadata of a tensor.
@@ -2164,7 +2174,7 @@ class FakeTensorMode(TorchDispatchMode):
             and metadata.layout == torch.strided
             and statically_known_true(metadata.storage_offset == 0)
             and all(
-                statically_known_true(actual == expected)
+                _same_int_expr(actual, expected)
                 for actual, expected in zip(
                     metadata.stride,
                     make_contiguous_strides_for(output.shape),
@@ -2175,6 +2185,8 @@ class FakeTensorMode(TorchDispatchMode):
         metadata.shape = tuple(state.convert_output(v) for v in metadata.shape)
         metadata.stride = tuple(state.convert_output(v) for v in metadata.stride)
         metadata.storage_offset = state.convert_output(metadata.storage_offset)
+        # An int payload is a backreference to an input SymNode. torch.empty
+        # would recompute the stride or offset and lose that node identity.
         is_canonical_contiguous = is_canonical_contiguous and not any(
             isinstance(value, _SymIntOutputStub) and isinstance(value.value, int)
             for value in (*metadata.stride, metadata.storage_offset)
@@ -2391,7 +2403,11 @@ class FakeTensorMode(TorchDispatchMode):
             view_arg = args[cast(int, entry.view_idx)]
             if not isinstance(view_arg, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
                 raise AssertionError("view_arg must be a FakeTensor")
-        view_dtype_matches = view_arg is not None and metadata.dtype == view_arg.dtype
+        view_dtype_matches = (
+            view_arg is not None
+            and metadata.dtype == view_arg.dtype
+            and not metadata.requires_grad
+        )
 
         with in_kernel_invocation_manager(self), maybe_suppress():
             if view_dtype_matches:

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2175,6 +2175,10 @@ class FakeTensorMode(TorchDispatchMode):
         metadata.shape = tuple(state.convert_output(v) for v in metadata.shape)
         metadata.stride = tuple(state.convert_output(v) for v in metadata.stride)
         metadata.storage_offset = state.convert_output(metadata.storage_offset)
+        is_canonical_contiguous = is_canonical_contiguous and not any(
+            isinstance(value, _SymIntOutputStub) and isinstance(value.value, int)
+            for value in (*metadata.stride, metadata.storage_offset)
+        )
         metadata.storage_bytes = (
             None
             if metadata.storage_bytes is None
@@ -2384,7 +2388,6 @@ class FakeTensorMode(TorchDispatchMode):
         is_view = entry.view_idx is not None
         view_arg = None
         if is_view:
-            # For view ops, the storage should be the same as the tensor input.
             view_arg = args[cast(int, entry.view_idx)]
             if not isinstance(view_arg, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
                 raise AssertionError("view_arg must be a FakeTensor")
@@ -2421,12 +2424,17 @@ class FakeTensorMode(TorchDispatchMode):
                     requires_grad=metadata.requires_grad,
                 )
 
-        if metadata.is_conj:
-            torch._C._set_conj(empty, True)
-        if metadata.is_neg:
-            torch._C._set_neg(empty, True)
+        if view_dtype_matches:
+            torch._C._set_conj(empty, metadata.is_conj)
+            torch._C._set_neg(empty, metadata.is_neg)
+        else:
+            if metadata.is_conj:
+                torch._C._set_conj(empty, True)
+            if metadata.is_neg:
+                torch._C._set_neg(empty, True)
 
         if is_view and not view_dtype_matches:
+            # For view ops, the storage should be the same as the tensor input.
             view_base = cast(FakeTensor, view_arg)
             storage = view_base.untyped_storage()
             with in_kernel_invocation_manager(self), maybe_suppress():


### PR DESCRIPTION
Relates to pytorch/pytorch#191500

## Problem

FakeTensor's dispatch cache stores a recipe for rebuilding an output, not the output itself. On every cache hit, the old code rebuilt all strided outputs with `empty_strided`; views then rebound that placeholder to the current input with `set_`. For dynamic shapes, both general operations repeatedly calculate symbolic storage bounds.

## Change

This PR uses simpler, equivalent reconstruction for the two common cases:

| Cached output | Before | After |
|---|---|---|
| Fresh, canonical-contiguous output | `empty_strided(shape, stride)` | `empty(shape)` |
| Cached same-dtype view of an input | `empty_strided(...)` then `set_(input storage, ...)` | `as_strided(input, ...)` |
| Anything else | existing fallback | unchanged |

For example, cached `clone(x)` with symbolic shape `(s, 8)` changes from `empty_strided((s, 8), (8, 1))` to `empty((s, 8))`. Cached `x.transpose(0, 1)` changes from allocating and rebinding a placeholder to `as_strided(x, (8, s), (1, 8), 0)`, directly constructing a view of the current input.

Dtype-changing views such as `view_as_real` retain the typed-placeholder plus `set_` path because `as_strided` cannot change dtype. Fresh noncontiguous outputs also retain `empty_strided`.

The direct `as_strided` path also deliberately changes one edge case: if a FakeTensor input's storage was resized to zero, a cached view now keeps that zero-sized storage. The old placeholder plus `set_` reconstruction grew the storage to cover the view, while an uncached FakeTensor view keeps it at zero. Matching the uncached result is important because AOTAutograd uses zero-sized FakeTensor storage to represent resized storage. I reflected this as [a regression test](https://github.com/pytorch/pytorch/pull/192047/changes#diff-3bc0cf540b694f4ec0a3749f78b047456657a53a5657e495ffb68e5970c5fdaaR3822).

Canonical-contiguous detection requires structurally identical symbolic stride expressions, rather than expressions that are only provably value-equal. This preserves input SymNode identity in cache entries. Views that require gradients continue to use the existing placeholder path.

## Performance

Measured with [`qwen3_compile_repro.py`](https://gist.github.com/zou3519/63fa2e77d7fcefe21c73d44e4e9190d6/3f1b7df41dbcd53c390f657d480aec048520d70a) on `Qwen/Qwen3-8B`, an NVIDIA H100 (Hopper, `sm_90`), and CUDA 13.4. Three interleaved fresh processes per arm used separate Inductor caches.

| Metric | Base median | Patch median | Change |
|---|---:|---:|---:|
| Static first call | 38.876 s | 38.786 s | -0.2% |
| Dynamic first call | 56.872 s | 49.673 s | -12.7% |
| Dynamic `aot_collect_metadata` | 5.244 s | 3.561 s | -32.1% |

After each timed first call, an untimed second shape reused the same compiled graph.

## Tests

- `python test/test_fake_tensor.py -k FakeTensorDispatchCache` (42 passed)
- `python test/test_dynamic_shapes.py -k test_unbacked_reshape2` (1 passed)
- Dynamic `torch.compile` integration check: eager parity, zero graph breaks, and one graph reused across two shapes
