### PR TITLE
[BE] factor gemv launch setup into helpers (2/N)

### DIFF
--- a/aten/src/ATen/native/mps/operations/GemmHeuristics.cpp
+++ b/aten/src/ATen/native/mps/operations/GemmHeuristics.cpp
@@ -19,27 +19,12 @@ GemvConfig t2d(int nsimd, int kq) {
   return cfg;
 }
 
-// gemv_t is bandwidth bound, so the pick just has to keep enough simdgroups
-// issuing loads to hide memory latency on every device size: the output gives
-// ceil(outlen / (32 * vec)) blocks of them, splitting K gives nsimd per block.
-// These few numbers are all that change per dtype.
-struct GemvTuning {
-  int vec; // load width in elements
-  int nsimd_min; // smallest built nsimd for this dtype
-  int nsimd_max; // largest built nsimd
-  int min_k_per_simd; // fewest K elements worth one simdgroup
-  int waves; // target simdgroups per core, sets the occupancy knees
-  int small_outlen; // at or below this, use t2d
-  int t2d_kq; // t2d k-sublane count
-  int scalar_cols_k; // K at or above this uses scalar columns, 0 to disable
-};
+} // namespace
 
 // One profile for all GPU generations: sweep-fitted on M5 Pro and biased
 // toward oversubscription, since on unmeasured hardware extra simdgroups only
 // add reduction overhead while missing ones leave memory latency exposed.
-// nsimd_min and nsimd_max must match the built MB_GEMV_* kernels, since the
-// snap assumes contiguous powers of two.
-GemvTuning gemv_tuning_t(c10::ScalarType dt) {
+GemvTuning gemv_tuning(c10::ScalarType dt) {
   GemvTuning t{
       .vec = 2,
       .nsimd_min = 16,
@@ -48,7 +33,10 @@ GemvTuning gemv_tuning_t(c10::ScalarType dt) {
       .waves = 896,
       .small_outlen = 1024,
       .t2d_kq = 8,
-      .scalar_cols_k = 0};
+      .scalar_cols_k = 0,
+      .nt_nsimd_lo = 4,
+      .nt_nsimd_hi = 8,
+      .nt_vec = 8};
   if (dt == at::kFloat) {
     // fp32 moves twice the bytes per element, so it saturates the bus with
     // far fewer waves and rewards backing off the K-split on wide outputs.
@@ -56,11 +44,11 @@ GemvTuning gemv_tuning_t(c10::ScalarType dt) {
     t.waves = 56;
     t.t2d_kq = 4;
     t.scalar_cols_k = 16384; // long fp32 reductions prefer scalar columns
+    t.nt_nsimd_hi = 16;
+    t.nt_vec = 4;
   }
   return t;
 }
-
-} // namespace
 
 GemvPolicy::GemvPolicy(uint32_t cores) : cores_(cores) {}
 
@@ -70,7 +58,7 @@ GemvPolicy GemvPolicy::current() {
 }
 
 GemvConfig GemvPolicy::pick_t(c10::ScalarType dt, int64_t outlen, int64_t K, int64_t align) const {
-  const GemvTuning t = gemv_tuning_t(dt);
+  const GemvTuning t = gemv_tuning(dt);
 
   // Small matrices sit in cache, so let t2d stream them.
   if (outlen <= t.small_outlen) {
@@ -110,10 +98,11 @@ GemvConfig GemvPolicy::pick_t(c10::ScalarType dt, int64_t outlen, int64_t K, int
 // simdgroups no matter what nsimd is; nsimd only sets threadgroup granularity
 // and vec the K-loop load width.
 GemvConfig GemvPolicy::pick_nt(c10::ScalarType dt, int64_t outlen, int64_t /*K*/, int64_t align) const {
+  const GemvTuning t = gemv_tuning(dt);
   if (dt == at::kFloat) {
-    return clamp_vec({outlen >= 2048 ? 4 : 16, 4}, align);
+    return clamp_vec({outlen >= 2048 ? t.nt_nsimd_lo : t.nt_nsimd_hi, t.nt_vec}, align);
   }
-  return clamp_vec({outlen >= 8192 ? 8 : 4, 8}, align);
+  return clamp_vec({outlen >= 8192 ? t.nt_nsimd_hi : t.nt_nsimd_lo, t.nt_vec}, align);
 }
 
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/GemmHeuristics.cpp
+++ b/aten/src/ATen/native/mps/operations/GemmHeuristics.cpp
@@ -24,6 +24,8 @@ GemvConfig t2d(int nsimd, int kq) {
 // One profile for all GPU generations: sweep-fitted on M5 Pro and biased
 // toward oversubscription, since on unmeasured hardware extra simdgroups only
 // add reduction overhead while missing ones leave memory latency exposed.
+// nsimd_min and nsimd_max must match the built MB_GEMV_* kernels, since the
+// snap assumes contiguous powers of two.
 GemvTuning gemv_tuning(c10::ScalarType dt) {
   GemvTuning t{
       .vec = 2,

--- a/aten/src/ATen/native/mps/operations/GemmHeuristics.h
+++ b/aten/src/ATen/native/mps/operations/GemmHeuristics.h
@@ -30,9 +30,9 @@ struct GemvTuning {
   int small_outlen; // at or below this, use t2d
   int t2d_kq; // t2d k-sublane count
   int scalar_cols_k; // K at or above this uses scalar columns, 0 to disable
-  int nt_nsimd_lo; // the two built gemv_nt nsimd variants
+  int nt_nsimd_lo;
   int nt_nsimd_hi;
-  int nt_vec; // largest built gemv_nt vec
+  int nt_vec;
 };
 
 GemvTuning gemv_tuning(c10::ScalarType dt);

--- a/aten/src/ATen/native/mps/operations/GemmHeuristics.h
+++ b/aten/src/ATen/native/mps/operations/GemmHeuristics.h
@@ -35,9 +35,6 @@ struct GemvTuning {
   int nt_vec; // largest built gemv_nt vec
 };
 
-// Single source of truth for the built MB_GEMV_* kernel matrix in
-// LinearAlgebra.metal; the heuristic picks derive from it. nsimd ranges
-// assume contiguous powers of two.
 GemvTuning gemv_tuning(c10::ScalarType dt);
 
 // One shape-based launch heuristic shared by every GPU generation; only the

--- a/aten/src/ATen/native/mps/operations/GemmHeuristics.h
+++ b/aten/src/ATen/native/mps/operations/GemmHeuristics.h
@@ -17,6 +17,29 @@ struct GemvConfig {
   GemvKernel kernel = GemvKernel::Standard;
 };
 
+// gemv_t is bandwidth bound, so the pick just has to keep enough simdgroups
+// issuing loads to hide memory latency on every device size: the output gives
+// ceil(outlen / (32 * vec)) blocks of them, splitting K gives nsimd per block.
+// These few numbers are all that change per dtype.
+struct GemvTuning {
+  int vec; // load width in elements
+  int nsimd_min; // smallest built nsimd for this dtype
+  int nsimd_max; // largest built nsimd
+  int min_k_per_simd; // fewest K elements worth one simdgroup
+  int waves; // target simdgroups per core, sets the occupancy knees
+  int small_outlen; // at or below this, use t2d
+  int t2d_kq; // t2d k-sublane count
+  int scalar_cols_k; // K at or above this uses scalar columns, 0 to disable
+  int nt_nsimd_lo; // the two built gemv_nt nsimd variants
+  int nt_nsimd_hi;
+  int nt_vec; // largest built gemv_nt vec
+};
+
+// Single source of truth for the built MB_GEMV_* kernel matrix in
+// LinearAlgebra.metal; the heuristic picks derive from it. nsimd ranges
+// assume contiguous powers of two.
+GemvTuning gemv_tuning(c10::ScalarType dt);
+
 // One shape-based launch heuristic shared by every GPU generation; only the
 // device core count scales the occupancy targets. Per-device peak is deferred
 // to an opt-in autotuner (follow-up).

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -138,7 +138,7 @@ std::optional<GemvConfig> normalize_gemv_config(GemvConfig config,
   return GemvPolicy::clamp_vec(config, align);
 }
 
-std::string gemv_kernel_name(const std::string& dt_str,
+std::string gemv_kernel_name(c10::ScalarType dt,
                              GemvConfig config,
                              GemmEpilogue epi,
                              bool use_t,
@@ -146,6 +146,7 @@ std::string gemv_kernel_name(const std::string& dt_str,
                              bool idx64,
                              int64_t vec_xs,
                              int64_t vec_offset) {
+  const auto dt_str = scalarToMetalTypeString(dt);
   const bool use_t2d = use_t && config.kernel == GemvKernel::T2D;
   // Vectorized x loads need x unit-stride and VEC-aligned (nt only).
   const bool xc = !use_t && config.vec > 1 && vec_xs == 1 && (vec_offset % config.vec) == 0;
@@ -162,8 +163,7 @@ std::string gemv_kernel_name(const std::string& dt_str,
       "gemv_nt_{}_{}_{}_{}_{}{}{}", dt_str, config.nsimd, config.vec, epi_str, xc ? "xc" : "xs", matrix_str, idx_str);
 }
 
-GemvLaunch prepare_gemv_launch(const std::string& dt_str,
-                               c10::ScalarType dt,
+GemvLaunch prepare_gemv_launch(c10::ScalarType dt,
                                GemvConfig config,
                                GemmEpilogue epi,
                                bool use_t,
@@ -173,7 +173,7 @@ GemvLaunch prepare_gemv_launch(const std::string& dt_str,
                                int64_t vec_xs,
                                int64_t vec_offset) {
   const bool use_t2d = use_t && config.kernel == GemvKernel::T2D;
-  auto kernel = gemv_kernel_name(dt_str, config, epi, use_t, matrix_contiguous, idx64, vec_xs, vec_offset);
+  auto kernel = gemv_kernel_name(dt, config, epi, use_t, matrix_contiguous, idx64, vec_xs, vec_offset);
   const int t2d_vec = static_cast<int>(16 / c10::elementSize(dt));
   const int64_t rows_per_tg = use_t2d ? (c10::metal::simdgroup_size / config.kq) * t2d_vec
       : use_t                         ? c10::metal::simdgroup_size * config.vec
@@ -217,7 +217,6 @@ void dispatch_gemv(const Tensor& A,
                    int64_t outlen,
                    bool idx64) {
   const auto dt = out.scalar_type();
-  const std::string dt_str = scalarToMetalTypeString(out);
   constexpr int64_t r = 0, c = 1;
   const auto K = A.size(1);
 
@@ -269,7 +268,7 @@ void dispatch_gemv(const Tensor& A,
 
   auto stream = getCurrentMPSStream();
   const auto launch =
-      prepare_gemv_launch(dt_str, dt, config, epi, gemv_use_t, matrix_contiguous, idx64, outlen, vec_xs, vec_offset);
+      prepare_gemv_launch(dt, config, epi, gemv_use_t, matrix_contiguous, idx64, outlen, vec_xs, vec_offset);
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       encode_gemv_launch(stream, launch, matrix.tensor, vvec, out, dims, expanded_bias, alpha_beta);

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -61,6 +61,7 @@
 #include <c10/util/env.h>
 #include <algorithm>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 
 namespace at::native {
@@ -146,6 +147,8 @@ std::string gemv_kernel_name(c10::ScalarType dt,
                              bool idx64,
                              int64_t vec_xs,
                              int64_t vec_offset) {
+  using namespace std::string_view_literals;
+
   const auto dt_str = scalarToMetalTypeString(dt);
   const bool use_t2d = use_t && config.kernel == GemvKernel::T2D;
   // Vectorized x loads need x unit-stride and VEC-aligned (nt only).
@@ -153,6 +156,7 @@ std::string gemv_kernel_name(c10::ScalarType dt,
   const auto epi_str = epi == GemmEpilogue::Bias ? "ab" : "none";
   const auto matrix_str = matrix_contiguous ? "" : "_strided";
   const auto idx_str = idx64 ? "_i64" : "";
+  const auto x_str = xc ? "xc"sv : "xs"sv;
   if (use_t2d) {
     return fmt::format("gemv_t2d_{}_{}_{}_{}", dt_str, config.nsimd, config.kq, epi_str);
   }
@@ -160,7 +164,7 @@ std::string gemv_kernel_name(c10::ScalarType dt,
     return fmt::format("gemv_t_{}_{}_{}_{}{}{}", dt_str, config.nsimd, config.vec, epi_str, matrix_str, idx_str);
   }
   return fmt::format(
-      "gemv_nt_{}_{}_{}_{}_{}{}{}", dt_str, config.nsimd, config.vec, epi_str, xc ? "xc" : "xs", matrix_str, idx_str);
+      "gemv_nt_{}_{}_{}_{}_{}{}{}", dt_str, config.nsimd, config.vec, epi_str, x_str, matrix_str, idx_str);
 }
 
 GemvLaunch prepare_gemv_launch(c10::ScalarType dt,

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -251,17 +251,18 @@ void dispatch_gemv(const Tensor& A,
 
   GemvConfig config;
   if (idx64) {
-    // These operands are DRAM-bound, so use the fixed _i64 configurations.
+    // Offsets overflow int32: such operands are DRAM-bound, so skip the
+    // policy and use the fixed configs the _i64 variants are built at.
     config = gemv_use_t ? GemvConfig{16, 2} : GemvConfig{8, dt == at::kFloat ? 4 : 8};
   } else {
     config = gemv_use_t ? policy.pick_t(dt, outlen, K, align) : policy.pick_nt(dt, outlen, K, align);
   }
+  // T2D loads a full 16 bytes per lane; misaligned matrices fall back to the
+  // scalar-column standard kernel.
   auto normalized = normalize_gemv_config(config, dt, gemv_use_t, matrix_contiguous, align);
   if (normalized.has_value()) {
     config = *normalized;
   } else {
-    // T2D requires 16-byte loads from a contiguous matrix; misaligned or
-    // strided matrices use the standard kernel.
     config.kernel = GemvKernel::Standard;
     config.vec = matrix_contiguous ? 1 : 2;
   }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -116,6 +116,92 @@ ResolvedMatrix resolve_matrix(const Tensor& matrix) {
   return {matrix, row_stride, col_stride, false};
 }
 
+struct GemvLaunch {
+  std::string kernel;
+  MTLComputePipelineState_t pso;
+  NSUInteger threads_per_tg;
+  int64_t num_groups;
+};
+
+std::optional<GemvConfig> normalize_gemv_config(GemvConfig config,
+                                                c10::ScalarType dt,
+                                                bool use_t,
+                                                bool matrix_contiguous,
+                                                int64_t align) {
+  if (config.kernel == GemvKernel::T2D) {
+    const int t2d_vec = static_cast<int>(16 / c10::elementSize(dt));
+    if (!use_t || !matrix_contiguous || (align & (t2d_vec - 1))) {
+      return std::nullopt;
+    }
+    return config;
+  }
+  return GemvPolicy::clamp_vec(config, align);
+}
+
+std::string gemv_kernel_name(const std::string& dt_str,
+                             GemvConfig config,
+                             GemmEpilogue epi,
+                             bool use_t,
+                             bool matrix_contiguous,
+                             bool idx64,
+                             int64_t vec_xs,
+                             int64_t vec_offset) {
+  const bool use_t2d = use_t && config.kernel == GemvKernel::T2D;
+  // Vectorized x loads need x unit-stride and VEC-aligned (nt only).
+  const bool xc = !use_t && config.vec > 1 && vec_xs == 1 && (vec_offset % config.vec) == 0;
+  const auto epi_str = epi == GemmEpilogue::Bias ? "ab" : "none";
+  const auto matrix_str = matrix_contiguous ? "" : "_strided";
+  const auto idx_str = idx64 ? "_i64" : "";
+  if (use_t2d) {
+    return fmt::format("gemv_t2d_{}_{}_{}_{}", dt_str, config.nsimd, config.kq, epi_str);
+  }
+  if (use_t) {
+    return fmt::format("gemv_t_{}_{}_{}_{}{}{}", dt_str, config.nsimd, config.vec, epi_str, matrix_str, idx_str);
+  }
+  return fmt::format(
+      "gemv_nt_{}_{}_{}_{}_{}{}{}", dt_str, config.nsimd, config.vec, epi_str, xc ? "xc" : "xs", matrix_str, idx_str);
+}
+
+GemvLaunch prepare_gemv_launch(const std::string& dt_str,
+                               c10::ScalarType dt,
+                               GemvConfig config,
+                               GemmEpilogue epi,
+                               bool use_t,
+                               bool matrix_contiguous,
+                               bool idx64,
+                               int64_t outlen,
+                               int64_t vec_xs,
+                               int64_t vec_offset) {
+  const bool use_t2d = use_t && config.kernel == GemvKernel::T2D;
+  auto kernel = gemv_kernel_name(dt_str, config, epi, use_t, matrix_contiguous, idx64, vec_xs, vec_offset);
+  const int t2d_vec = static_cast<int>(16 / c10::elementSize(dt));
+  const int64_t rows_per_tg = use_t2d ? (c10::metal::simdgroup_size / config.kq) * t2d_vec
+      : use_t                         ? c10::metal::simdgroup_size * config.vec
+                                      : config.nsimd;
+  auto pso = lib.getPipelineStateForFunc(kernel);
+  return {std::move(kernel),
+          pso,
+          static_cast<NSUInteger>(config.nsimd * c10::metal::simdgroup_size),
+          at::ceil_div(outlen, rows_per_tg)};
+}
+
+void encode_gemv_launch(at::mps::MPSStream* stream,
+                        const GemvLaunch& launch,
+                        const Tensor& mat,
+                        const Tensor& vec,
+                        const Tensor& out,
+                        const GemvDims& dims,
+                        const Tensor& bias,
+                        const std::array<float, 2>& alpha_beta) {
+  getMPSProfiler().beginProfileKernel(launch.pso, "gemm_gemv/" + launch.kernel, {mat, vec});
+  auto enc = stream->commandEncoder();
+  [enc setComputePipelineState:launch.pso];
+  mtl_setArgs(enc, mat, vec, out, dims, bias, alpha_beta);
+  [enc dispatchThreadgroups:MTLSizeMake(launch.num_groups, 1, 1)
+      threadsPerThreadgroup:MTLSizeMake(launch.threads_per_tg, 1, 1)];
+  getMPSProfiler().endProfileKernel(launch.pso);
+}
+
 // Rank-1 GEMV launch. Matrix orientation selects gemv_t vs gemv_nt; one
 // GemvDims packing handles all four mat/vec layouts.
 void dispatch_gemv(const Tensor& A,
@@ -139,29 +225,9 @@ void dispatch_gemv(const Tensor& A,
   const bool gemv_use_t = m_is_one ? !matrix.transposed : matrix.transposed;
   const bool matrix_contiguous = matrix.stride == 1;
   const int64_t align = matrix_contiguous ? matrix.ld | matrix.tensor.storage_offset() : 0;
-  GemvConfig cfg;
-  if (idx64) {
-    // Offsets overflow int32: such operands are DRAM-bound, so skip the
-    // policy and use the fixed configs the _i64 variants are built at.
-    cfg = gemv_use_t ? GemvConfig{16, 2} : GemvConfig{8, dt == at::kFloat ? 4 : 8};
-    cfg = GemvPolicy::clamp_vec(cfg, align);
-  } else {
-    cfg = gemv_use_t ? policy.pick_t(dt, outlen, K, align) : policy.pick_nt(dt, outlen, K, align);
-  }
-  // T2D loads a full 16 bytes per lane; misaligned matrices fall back to the
-  // scalar-column standard kernel.
-  const int t2d_vec = static_cast<int>(16 / c10::elementSize(dt));
-  if (cfg.kernel == GemvKernel::T2D && (!matrix_contiguous || (align & (t2d_vec - 1)))) {
-    cfg.kernel = GemvKernel::Standard;
-    cfg.vec = matrix_contiguous ? 1 : 2;
-  }
-  const GemvConfig launch_cfg = cfg;
-  const bool gemv_t2d = gemv_use_t && launch_cfg.kernel == GemvKernel::T2D;
-
   const auto vvec = m_is_one ? A : B;
   const auto vec_xs = m_is_one ? A.stride(c) : B.stride(r);
-  // Vectorized x loads need x unit-stride and VEC-aligned (nt only).
-  const bool xc = !gemv_use_t && launch_cfg.vec > 1 && vec_xs == 1 && (vvec.storage_offset() % launch_cfg.vec) == 0;
+  const auto vec_offset = vvec.storage_offset();
 
   Tensor expanded_bias;
   int64_t out_stride = 0;
@@ -182,43 +248,31 @@ void dispatch_gemv(const Tensor& A,
   dims.xs = vec_xs;
   dims.bias_r = gemv_use_t ? 0 : out_stride;
   dims.bias_c = gemv_use_t ? out_stride : 0;
+  const std::array<float, 2> alpha_beta = {static_cast<float>(alpha.toDouble()), static_cast<float>(beta.toDouble())};
 
-  const auto epi_str = epi == GemmEpilogue::Bias ? "ab" : "none";
-  const auto matrix_str = matrix_contiguous ? "" : "_strided";
-  const auto idx_str = idx64 ? "_i64" : "";
-  std::string fname;
-  if (gemv_t2d) {
-    fname = fmt::format("gemv_t2d_{}_{}_{}_{}", dt_str, launch_cfg.nsimd, launch_cfg.kq, epi_str);
-  } else if (gemv_use_t) {
-    fname =
-        fmt::format("gemv_t_{}_{}_{}_{}{}{}", dt_str, launch_cfg.nsimd, launch_cfg.vec, epi_str, matrix_str, idx_str);
+  GemvConfig config;
+  if (idx64) {
+    // These operands are DRAM-bound, so use the fixed _i64 configurations.
+    config = gemv_use_t ? GemvConfig{16, 2} : GemvConfig{8, dt == at::kFloat ? 4 : 8};
   } else {
-    fname = fmt::format("gemv_nt_{}_{}_{}_{}_{}{}{}",
-                        dt_str,
-                        launch_cfg.nsimd,
-                        launch_cfg.vec,
-                        epi_str,
-                        xc ? "xc" : "xs",
-                        matrix_str,
-                        idx_str);
+    config = gemv_use_t ? policy.pick_t(dt, outlen, K, align) : policy.pick_nt(dt, outlen, K, align);
   }
-  auto pso = lib.getPipelineStateForFunc(fname);
-  const NSUInteger threads_per_tg = static_cast<NSUInteger>(launch_cfg.nsimd * c10::metal::simdgroup_size);
-  const int64_t rows_per_tg = gemv_t2d ? (c10::metal::simdgroup_size / launch_cfg.kq) * t2d_vec
-      : gemv_use_t                     ? c10::metal::simdgroup_size * launch_cfg.vec
-                                       : launch_cfg.nsimd;
-  const int64_t num_groups = (outlen + rows_per_tg - 1) / rows_per_tg;
-  const std::array<float, 2> ab = {static_cast<float>(alpha.toDouble()), static_cast<float>(beta.toDouble())};
+  auto normalized = normalize_gemv_config(config, dt, gemv_use_t, matrix_contiguous, align);
+  if (normalized.has_value()) {
+    config = *normalized;
+  } else {
+    // T2D requires 16-byte loads from a contiguous matrix; misaligned or
+    // strided matrices use the standard kernel.
+    config.kernel = GemvKernel::Standard;
+    config.vec = matrix_contiguous ? 1 : 2;
+  }
 
   auto stream = getCurrentMPSStream();
+  const auto launch =
+      prepare_gemv_launch(dt_str, dt, config, epi, gemv_use_t, matrix_contiguous, idx64, outlen, vec_xs, vec_offset);
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
-      getMPSProfiler().beginProfileKernel(pso, "gemm_gemv", {matrix.tensor, vvec});
-      auto enc = stream->commandEncoder();
-      [enc setComputePipelineState:pso];
-      mtl_setArgs(enc, matrix.tensor, vvec, out, dims, expanded_bias, ab);
-      [enc dispatchThreadgroups:MTLSizeMake(num_groups, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_tg, 1, 1)];
-      getMPSProfiler().endProfileKernel(pso);
+      encode_gemv_launch(stream, launch, matrix.tensor, vvec, out, dims, expanded_bias, alpha_beta);
     }
   });
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #192059
* __->__ #192054
* #192053

Refactor: split `dispatch_gemv` into config and launch helpers, move `GemvTuning` into the header. No behavior change, profiler label now includes the kernel name.
