### PR TITLE
Reuse inner storage size for FunctionalTensor wrappers

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -2720,7 +2720,8 @@ class FakeTensorConverterTest(TestCase):
         self.assertEqual(y_refake.storage_offset(), y.storage_offset())
         self.assertEqual(y_refake.real_tensor, y)
 
-    def test_functional_tensor_reuses_symbolic_storage_size(self):
+    @parametrize("use_view", (False, True))
+    def test_functional_tensor_reuses_symbolic_storage_size(self, use_view):
         from torch._subclasses.functional_tensor import (
             FunctionalTensor,
             FunctionalTensorMode,
@@ -2736,6 +2737,10 @@ class FakeTensorConverterTest(TestCase):
                 constraint_sizes=[None, None],
             ),
         )
+
+        if use_view:
+            with fake_mode:
+                x = aten.slice.Tensor(x, 1, 2, 6)
 
         with FunctionalTensorMode():
             functional = FunctionalTensor.to_functional(x)
@@ -2891,6 +2896,7 @@ class FakeTensorConverterTest(TestCase):
         self.assertEqual(g_eager.dtype, g_traced.dtype)
 
 
+instantiate_parametrized_tests(FakeTensorConverterTest)
 make_propagate_real_tensors_cls(FakeTensorConverterTest)
 
 

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -2720,6 +2720,31 @@ class FakeTensorConverterTest(TestCase):
         self.assertEqual(y_refake.storage_offset(), y.storage_offset())
         self.assertEqual(y_refake.real_tensor, y)
 
+    def test_functional_tensor_reuses_symbolic_storage_size(self):
+        from torch._subclasses.functional_tensor import (
+            FunctionalTensor,
+            FunctionalTensorMode,
+        )
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        x = fake_mode.from_tensor(
+            torch.randn(4, 8),
+            source=LocalSource("x", is_input=True),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.STATIC],
+                constraint_sizes=[None, None],
+            ),
+        )
+
+        with FunctionalTensorMode():
+            functional = FunctionalTensor.to_functional(x)
+
+        outer_storage_size = functional.untyped_storage().nbytes()
+        inner_storage_size = functional.elem.untyped_storage().nbytes()
+        self.assertEqual(outer_storage_size, inner_storage_size)
+        self.assertIs(outer_storage_size.node, inner_storage_size.node)
+
     def test_refake_unbacked_storage_static_shapes(self):
         with torch._functorch.config.patch(fake_tensor_propagate_real_tensors=False):
             shape_env = ShapeEnv()

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -216,6 +216,7 @@ class FunctionalTensor(torch.Tensor):
             False,  # dispatch_device
             False,  # dispatch_layout
             extra_dispatch_keys,  # _extra_dispatch_keys
+            None if is_sparse_any(elem) else elem.untyped_storage().nbytes(),
         )
         torch._C._set_throw_on_mutable_data_ptr(out)
         out.elem = elem

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -551,6 +551,10 @@ def _nary_sym_min(*args: Any) -> Any:
     return functools.reduce(torch.sym_min, args)
 
 
+def _nary_sym_mul(*args: Any) -> Any:
+    return functools.reduce(operator.mul, args)
+
+
 @functools.cache
 def _sympy_handlers() -> dict[type[sympy.Expr], Callable[..., Any]]:
     """
@@ -583,10 +587,12 @@ def _sympy_handlers() -> dict[type[sympy.Expr], Callable[..., Any]]:
         elif v == "pow_by_natural":
             handlers[k] = operator.pow
 
-    # sympy.Add is n-ary (e.g. Add(a, b, c)) but operator.add is binary.
+    # sympy.Add and sympy.Mul are n-ary (e.g. Add(a, b, c)) but the
+    # corresponding operator functions are binary.
     # torch.sym_sum handles n-ary integer addition and accepts both
     # sym_sum([a, b, c]) and sym_sum(a, b, c).
     handlers[sympy.Add] = torch.sym_sum
+    handlers[sympy.Mul] = _nary_sym_mul
     return handlers
 
 


### PR DESCRIPTION
Relates to #191500

## Summary

Reuse the inner tensor's existing storage size when constructing dense/strided `FunctionalTensor` wrappers, instead of recomputing it from symbolic metadata. This preserves the backing storage size for views and its exact SymNode. Only sparse tensors keep the existing behavior.

## Performance

With `qwen3_compile_repro.py`, `Qwen/Qwen3-8B`, NVIDIA H100, and CUDA 13.4, dynamic first-call time decreased from 56.872 s to 53.581 s (-5.8%). Static first-call time was unchanged (+0.2%).

## Test plan

- Symbolic base and partial-view storage-size regression coverage
- All `FakeTensorConverterTest` cases
- Sparse COO/CSR construction