### PR TITLE
Fix UnboundLocalError masking socket errors in etcd find_free_port

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -6,12 +6,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+import socket
 import sys
 import unittest
+from unittest import mock
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
 if os.getenv("CIRCLECI"):
@@ -58,3 +60,41 @@ class EtcdServerTest(unittest.TestCase):
             self.assertEqual(1, rdzv_info.world_size)
         finally:
             server.stop()
+
+
+class FindFreePortTest(unittest.TestCase):
+    @staticmethod
+    def _addr():
+        return (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0))
+
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.etcd_server.socket.getaddrinfo"
+    )
+    @mock.patch("torch.distributed.elastic.rendezvous.etcd_server.socket.socket")
+    def test_find_free_port_falls_back_to_next_addr(
+        self, socket_mock, getaddrinfo_mock
+    ) -> None:
+        # Creating a socket for the first address fails; find_free_port must
+        # move on to the next address instead of raising UnboundLocalError from
+        # closing a socket that was never created.
+        getaddrinfo_mock.return_value = [self._addr(), self._addr()]
+        good_socket = mock.MagicMock()
+        socket_mock.side_effect = [OSError("first attempt failed"), good_socket]
+
+        self.assertIs(find_free_port(), good_socket)
+        good_socket.bind.assert_called_once()
+        good_socket.listen.assert_called_once()
+
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.etcd_server.socket.getaddrinfo"
+    )
+    @mock.patch("torch.distributed.elastic.rendezvous.etcd_server.socket.socket")
+    def test_find_free_port_raises_with_cause_when_all_fail(
+        self, socket_mock, getaddrinfo_mock
+    ) -> None:
+        getaddrinfo_mock.return_value = [self._addr()]
+        socket_mock.side_effect = OSError("no socket for you")
+
+        with self.assertRaises(RuntimeError) as cm:
+            find_free_port()
+        self.assertIsInstance(cm.exception.__cause__, OSError)

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -51,17 +51,22 @@ def find_free_port():
         host="localhost", port=None, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
     )
 
+    last_exc: OSError | None = None
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
-            print(f"Socket creation attempt failed: {e}")
-    raise RuntimeError("Failed to create a socket")
+            # socket() may fail before s is bound, so only close what we created.
+            if s is not None:
+                s.close()
+            last_exc = e
+            logger.warning("Socket creation attempt failed: %s", e)
+    raise RuntimeError("Failed to create a socket") from last_exc
 
 
 def stop_etcd(subprocess, data_dir: str | None = None):


### PR DESCRIPTION
Fixes #191395

## What
`find_free_port` closes `s` in its `except OSError` handler, but if
`socket.socket()` itself raises on the first candidate address, `s` was never
assigned and `s.close()` raises `UnboundLocalError`. That masks the real socket
error and aborts the loop, so the intended fallback to the remaining addresses
never runs. The final `RuntimeError` also dropped the underlying cause.

## Fix
Initialize `s = None` each iteration and only close a socket that was actually
created, so the loop continues to the next address. Track the last `OSError` and
`raise RuntimeError(...) from last_exc` to preserve the diagnostic. The raw
`print` is replaced with `logger.warning` to match the rest of the module.

## Test
Added `FindFreePortTest` (mocked sockets, no etcd binary needed):
- `test_find_free_port_falls_back_to_next_addr` — first `socket()` raises; the
  next address is used. Fails before the change with `UnboundLocalError`.
- `test_find_free_port_raises_with_cause_when_all_fail` — all attempts raise; a
  `RuntimeError` with `__cause__` set to the `OSError` is raised.

    python test/distributed/elastic/rendezvous/etcd_server_test.py -k FindFreePort

> Authored with the assistance of an AI coding assistant (Claude Code) and
> reviewed by me before submission.