### PR TITLE
[Inductor][CUDA] Do not pad if using pointwise lowering

### DIFF
--- a/test/inductor/test_mmdecomp.py
+++ b/test/inductor/test_mmdecomp.py
@@ -163,6 +163,27 @@ class TestDecomp(NNTestCase):
         self.assertEqual(counters["inductor"]["decompose_mm_pointwise"], 1)
 
     @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @config.patch(shape_padding=True)
+    def test_small_mm_pointwise_skips_padding(self, device):
+        if device == "cpu":
+            self.skipTest("small-dim mm pointwise is GPU-only")
+        from unittest import mock
+
+        from torch._dynamo.utils import counters
+
+        counters.clear()
+        torch._dynamo.reset()
+        a = torch.ones(64, 3, device=device)
+        b = torch.ones(3, 3, device=device)
+        with mock.patch(
+            "torch._inductor.fx_passes.pad_mm._should_pad", return_value=True
+        ) as should_pad:
+            with fresh_cache():
+                run_comp_nocomp(torch_mm, a, b)
+        self.assertEqual(should_pad.call_count, 0)
+        self.assertEqual(counters["inductor"]["decompose_mm_pointwise"], 1)
+
+    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
     @parametrize(
         "dtype",
         [torch.float, torch.float16, torch.bfloat16]

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -530,6 +530,15 @@ def _should_pad(
         if torch._inductor.config.force_shape_pad:
             return True
 
+        # Small-K/N mm is lowered to a fused pointwise kernel in tuned_mm.
+        # Leave these shapes unpadded and let the pointwise lowering handle them.
+        from ..kernel.mm_common import _use_small_mm_pointwise
+
+        if op is torch.ops.aten.mm and _use_small_mm_pointwise(
+            m, k, n, mat1.device.type, statically_known_true=statically_known_true
+        ):
+            return False
+
         # Resolve symbolic dims to concrete hints for heuristic checks below.
         # These are performance decisions, not correctness — optimization_hint is safe.
         m_concrete, k_concrete, n_concrete = hint_symbols((m, k, n))

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -478,10 +478,27 @@ def should_pad(
     op: torch._ops.OpOverloadPacket,
     input: Tensor | None = None,
 ) -> bool:
-    _can_pad = can_pad(mat1, mat2, op, input)
+    if not can_pad(mat1, mat2, op, input):
+        return False
+
+    # Force padding when explicitly requested - performance override
+    if torch._inductor.config.force_shape_pad:
+        return True
+
+    # Small-K/N mm is lowered to a fused pointwise kernel in tuned_mm.
+    # Leave those shapes unpadded and let the pointwise lowering handle them.
+    if op is torch.ops.aten.mm:
+        from ..kernel.mm_common import _use_small_mm_pointwise
+
+        m, k, n = hint_symbols((mat1.shape[0], mat1.shape[1], mat2.shape[1]))
+        if _use_small_mm_pointwise(
+            m, k, n, mat1.device.type, statically_known_true=statically_known_true
+        ):
+            return False
+
     # Note that if you're tempted to insert a dynamo_timed call here, this function can
     # be called enough that the dynamo_timed overhead is not negligible.
-    return _can_pad and _should_pad(match, mat1, mat2, op, input)
+    return _should_pad(match, mat1, mat2, op, input)
 
 
 def get_do_bench() -> Callable[[Callable[[], Any]], float]:
@@ -524,19 +541,6 @@ def _should_pad(
             m_padded_length = get_padded_length(m, get_alignment_size(mat1))
             n_padded_length = get_padded_length(n, get_alignment_size(mat2))
         else:
-            return False
-
-        # Force padding when explicitly requested - performance override
-        if torch._inductor.config.force_shape_pad:
-            return True
-
-        # Small-K/N mm is lowered to a fused pointwise kernel in tuned_mm.
-        # Leave these shapes unpadded and let the pointwise lowering handle them.
-        from ..kernel.mm_common import _use_small_mm_pointwise
-
-        if op is torch.ops.aten.mm and _use_small_mm_pointwise(
-            m, k, n, mat1.device.type, statically_known_true=statically_known_true
-        ):
             return False
 
         # Resolve symbolic dims to concrete hints for heuristic checks below.

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -490,7 +490,7 @@ def should_pad(
     if op is torch.ops.aten.mm:
         from ..kernel.mm_common import _use_small_mm_pointwise
 
-        m, k, n = hint_symbols((mat1.shape[0], mat1.shape[1], mat2.shape[1]))
+        m, k, n = mat1.shape[0], mat1.shape[1], mat2.shape[1]
         if _use_small_mm_pointwise(
             m, k, n, mat1.device.type, statically_known_true=statically_known_true
         ):

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -391,7 +391,7 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
         mat1, mat2, layout=layout, out_dtype=out_dtype
     )
 
-    if out_dtype is None and _use_small_mm_pointwise(m, k, n, layout):
+    if out_dtype is None and _use_small_mm_pointwise(m, k, n, layout.device.type):
         counters["inductor"]["decompose_mm_pointwise"] += 1
         mat1 = L.unsqueeze(mat1, -1)
         mat2 = L.unsqueeze(mat2, 0)

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -194,7 +194,9 @@ def use_native_matmul(mat1, mat2):
     return True
 
 
-def _use_small_mm_pointwise(m, k, n, layout) -> bool:
+def _use_small_mm_pointwise(
+    m, k, n, device_type: str, statically_known_true=None
+) -> bool:
     """Check if mm should be lowered to pointwise ops for small K and N.
 
     For very small inner dimensions (K < 5 and N < 5) with M >= 64,
@@ -205,12 +207,16 @@ def _use_small_mm_pointwise(m, k, n, layout) -> bool:
     at large M due to reduction-dimension alignment).  Disabled under
     max_autotune to preserve template selection.
     See https://github.com/pytorch/pytorch/issues/186348
+
+    ``statically_known_true`` lets callers that run before the inductor
+    ``GraphLowering`` is active (e.g. the pad_mm joint-graph pass, where
+    ``V.graph`` is unavailable) supply their own predicate.
     """
     if config.max_autotune or config.max_autotune_gemm:
         return False
-    if layout.device.type in ("cpu", "mps"):
+    if device_type in ("cpu", "mps"):
         return False
-    skt = V.graph.sizevars.statically_known_true
+    skt = statically_known_true or V.graph.sizevars.statically_known_true
     return skt(m >= 64) and skt(k < 5) and skt(n < 5)
 
 


### PR DESCRIPTION
Cases of `test_small_mm_pointwise` are failing flakily in `test/inductor/test_mmdecomp.py` on GB200 because the lowering pathway runs autotuning to determine whether to pad or not- this generally favors the pointwise lowering but GPU timing noise can cause occasional padding, which cause the test to fail because the inductor counter for "decompose_mm_pointwise" is 0 instead of 1.
```
======================================================================
FAIL: test_small_mm_pointwise_transposed_bfloat16_m_256_k_2_n_3_transpose_lhs_cuda_bfloat16 (__main__.TestDecompCUDA.test_small_mm_pointwise_transposed_bfloat16_m_256_k_2_n_3_transpose_lhs_cuda_bfloat16)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3794, in wrapper
    method(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3794, in wrapper
    method(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 627, in instantiated_test
    result = test(self, **param_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/inductor/test_mmdecomp.py", line 209, in test_small_mm_pointwise_transposed
    self.assertEqual(counters["inductor"]["decompose_mm_pointwise"], 1)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 4844, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
AssertionError: Scalars are not equal!

Expected 1 but got 0.
Absolute difference: 1
Relative difference: 1.0

To execute this test, run the following from the base repo dir:
    python test/inductor/test_mmdecomp.py TestDecompCUDA.test_small_mm_pointwise_transposed_bfloat16_m_256_k_2_n_3_transpose_lhs_cuda_bfloat16

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
```
This PR adds a `_use_small_mm_pointwise` check to `_should_pad` so that padding autotuning never runs in cases that should use the pointwise lowering. 

Authored with assistance from Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy