### PR TITLE
Restore MemoryTracker op_index on load so summary works for saved traces

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 import os
+import pickle
 import unittest
 
 import torch
@@ -62,6 +63,52 @@ class TestMemoryTracker(TestCase):
         self.assertTrue(len(tracker._markers) == 2)
         self.assertTrue(tracker._cur_module_name != "")
         self.assertTrue(hasattr(tracker, "_num_alloc_retries"))
+
+    @unittest.skipIf(not torch.accelerator.is_available(), "no accelerator")
+    def test_load_restores_op_index_in_fresh_tracker(self):
+        """
+        Regression test for https://github.com/pytorch/pytorch/issues/191397:
+        load() must restore _op_index so summary() works when stats are loaded
+        into a fresh tracker (e.g. in a notebook), not only when reusing the
+        tracker that recorded them.
+        """
+        device = torch.accelerator.current_accelerator()
+        torch.manual_seed(0)
+        model = nn.Sequential(nn.Linear(64, 8), nn.ReLU(), nn.Linear(8, 2)).to(device)
+
+        tracker = MemoryTracker()
+        tracker.start_monitor(model)
+        model(torch.randn(4, 64, device=device)).sum().backward()
+        tracker.stop()
+
+        expected_op_index = tracker._op_index
+        self.assertGreater(expected_op_index, 0)
+
+        path = "memory_op_index.trace"
+        try:
+            tracker.save_stats(path)
+
+            # Loading into a fresh tracker must restore _op_index.
+            fresh = MemoryTracker()
+            fresh.load(path)
+            self.assertEqual(fresh._op_index, expected_op_index)
+            self.assertEqual(len(fresh.memories_allocated), fresh._op_index)
+            fresh.summary()
+
+            # Backward compatibility: stats saved before this fix lack the
+            # "op_index" key, so load() must reconstruct it from the traces.
+            with open(path, "rb") as f:
+                legacy_stats = pickle.load(f)
+            del legacy_stats["op_index"]
+            with open(path, "wb") as f:
+                pickle.dump(legacy_stats, f, pickle.HIGHEST_PROTOCOL)
+
+            legacy = MemoryTracker()
+            legacy.load(path)
+            self.assertEqual(legacy._op_index, expected_op_index)
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -212,6 +212,7 @@ class MemoryTracker:
             "memories_reserved": self.memories_reserved,
             "markers": self._markers,
             "num_alloc_retries": self._num_alloc_retries,
+            "op_index": self._op_index,
         }
 
         with open(path, "wb") as f:
@@ -227,6 +228,9 @@ class MemoryTracker:
         self.memories_reserved = stats["memories_reserved"]
         self._markers = stats["markers"]
         self._num_alloc_retries = stats["num_alloc_retries"]
+        # Stats saved before op_index was persisted lack the key; reconstruct it
+        # from the traces, whose indices are contiguous starting at zero.
+        self._op_index = stats.get("op_index", len(self.memories_allocated))
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """Prefix operator name with current module and 'forward', and insert 'fw_start' marker at forward pass start."""


### PR DESCRIPTION
Fixes #191397

## What
`MemoryTracker.summary()` iterates `range(1, self._op_index)`, but `save_stats`
never persisted `_op_index` and `load` never restored it. Loading a saved trace
into a fresh tracker (the intended notebook/offline use) left `_op_index` at 0,
so `summary()` produced empty output despite the traces being present. The
existing test missed this because it reloaded into the same tracker, which still
held `_op_index` from the recording run.

## Fix
Persist `op_index` in `save_stats` and restore it in `load`. For files written
before this change (no `op_index` key), reconstruct it from the number of
recorded traces -- `memories_*` are keyed by contiguous indices from zero, so
their length equals the original `_op_index`. Persisting plus reconstructing
keeps new files explicit while old files still load correctly.

## Test
Added `test_load_restores_op_index_in_fresh_tracker`: records a short run, saves,
loads into a fresh `MemoryTracker`, and asserts `_op_index` is restored and
`summary()` runs. Fails before this change. It also strips the `op_index` key to
emulate a pre-fix file and verifies reconstruction.

    python test/distributed/_tools/test_memory_tracker.py -k test_load_restores_op_index_in_fresh_tracker

> Authored with the assistance of an AI coding assistant (Claude Code) and
> reviewed by me before submission.