### PR TITLE
Log multi-device backward passes via C10_LOG_API_USAGE_ONCE

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1305,6 +1305,11 @@ auto Engine::compute_dependencies(
   // Computes the number of dependencies for each function which requires grad
   std::vector<Node*> queue{root};
   bool will_use_accelerator = false;
+  // Log (once per process) backward passes that span multiple non-CPU
+  // devices, to assess reliance on multithreaded autograd before changing
+  // its default. CPU + a single accelerator does not count.
+  static std::atomic<bool> multidevice_logged{false};
+  std::optional<at::Device> first_noncpu_device;
 
   // Queue contains all nodes that will start propagating gradients.
   // We no longer have to expand functions that don't require grad.
@@ -1317,6 +1322,17 @@ auto Engine::compute_dependencies(
     }
     if (!will_use_accelerator) {
       will_use_accelerator = fn->stream().has_value();
+    }
+    if (!multidevice_logged.load(std::memory_order_relaxed)) {
+      auto device = fn->device();
+      if (!should_run_in_cpu_ready_queue(device.type())) {
+        if (!first_noncpu_device.has_value()) {
+          first_noncpu_device = device;
+        } else if (first_noncpu_device.value() != device) {
+          multidevice_logged.store(true, std::memory_order_relaxed);
+          C10_LOG_API_USAGE_ONCE("torch.autograd.multidevice_backward");
+        }
+      }
     }
     for (const auto& edge : fn->next_edges()) {
       if (auto next_ptr = edge.function.get()) {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1305,11 +1305,20 @@ auto Engine::compute_dependencies(
   // Computes the number of dependencies for each function which requires grad
   std::vector<Node*> queue{root};
   bool will_use_accelerator = false;
-  // Log (once per process) backward passes that span multiple non-CPU
-  // devices, to assess reliance on multithreaded autograd before changing
-  // its default. CPU + a single accelerator does not count.
+  // Log (once per process each) backward passes by the devices they span, to
+  // assess reliance on multithreaded autograd before changing its default.
+  // The two cases are independent and may both fire for the same pass: one
+  // for a second distinct non-CPU device (multi-device), one for a non-CPU
+  // device alongside CPU nodes (GPU + CPU).
   static std::atomic<bool> multidevice_logged{false};
+  static std::atomic<bool> gpu_cpu_logged{false};
+  // Skip the per-node device inspection entirely once both cases have already
+  // been logged for this process; the logs fire at most once anyway.
+  const bool inspect_devices =
+      !multidevice_logged.load(std::memory_order_relaxed) ||
+      !gpu_cpu_logged.load(std::memory_order_relaxed);
   std::optional<at::Device> first_noncpu_device;
+  bool saw_cpu = false;
 
   // Queue contains all nodes that will start propagating gradients.
   // We no longer have to expand functions that don't require grad.
@@ -1323,15 +1332,20 @@ auto Engine::compute_dependencies(
     if (!will_use_accelerator) {
       will_use_accelerator = fn->stream().has_value();
     }
-    if (!multidevice_logged.load(std::memory_order_relaxed)) {
+    if (inspect_devices) {
       auto device = fn->device();
-      if (!should_run_in_cpu_ready_queue(device.type())) {
-        if (!first_noncpu_device.has_value()) {
-          first_noncpu_device = device;
-        } else if (first_noncpu_device.value() != device) {
-          multidevice_logged.store(true, std::memory_order_relaxed);
-          C10_LOG_API_USAGE_ONCE("torch.autograd.multidevice_backward");
-        }
+      if (should_run_in_cpu_ready_queue(device.type())) {
+        saw_cpu = true;
+      } else if (!first_noncpu_device.has_value()) {
+        first_noncpu_device = device;
+      } else if (
+          first_noncpu_device.value() != device &&
+          !multidevice_logged.exchange(true, std::memory_order_relaxed)) {
+        C10_LOG_API_USAGE_ONCE("torch.autograd.multidevice_backward");
+      }
+      if (saw_cpu && first_noncpu_device.has_value() &&
+          !gpu_cpu_logged.exchange(true, std::memory_order_relaxed)) {
+        C10_LOG_API_USAGE_ONCE("torch.autograd.gpu_cpu_backward");
       }
     }
     for (const auto& edge : fn->next_edges()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192081

Add once-per-process API usage logs for backward passes, split by the set
of devices they span, so we can assess how much real workloads rely on
multithreaded autograd before changing its default. The check walks the
graph roots in compute_dependencies and emits two independent signals that
may both fire for the same pass:

- torch.autograd.multidevice_backward when two distinct non-CPU devices
  are observed.
- torch.autograd.gpu_cpu_backward when a single non-CPU device runs
  alongside CPU nodes.

Multi-device (multiple accelerators in one backward) is the case that
genuinely benefits from multithreaded autograd and is expected to be rare;
the GPU + CPU case is expected to be common. Each log fires at most once
per process, and the per-node device inspection is skipped entirely once
both have fired.

Test Plan: Built, then ran each case in a fresh process with
PYTORCH_API_USAGE_STDERR=1 and grepped the emitted events:

```
a = torch.randn(4, requires_grad=True, device="cuda")
b = torch.randn(4, requires_grad=True, device="cpu")
(a.sum() + b.sum()).backward()

a = torch.randn(4, requires_grad=True, device="cuda")
(a * 2).sum().backward()

a = torch.randn(4, requires_grad=True, device="cpu")
(a * 2).sum().backward()
```

The GPU + CPU, single-accelerator, and CPU-only cases behaved as
described. The multi-device path was not exercised at runtime (the test
host has a single GPU); its logic mirrors the GPU + CPU path and was
verified by inspection.

Authored with assistance from an AI coding assistant.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>