### PR TITLE
Disable multithreaded autograd by default

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -102,7 +102,7 @@ dtensor_dispatch_collectives,instruction_count,32510000,0.1
 
 
 
-dtensor_dispatch_add_backward,instruction_count,648100,0.1
+dtensor_dispatch_add_backward,instruction_count,723000,0.2
 
 
 

--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -102,7 +102,7 @@ dtensor_dispatch_collectives,instruction_count,32510000,0.1
 
 
 
-dtensor_dispatch_add_backward,instruction_count,371900,0.1
+dtensor_dispatch_add_backward,instruction_count,792900,0.1
 
 
 

--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -102,7 +102,7 @@ dtensor_dispatch_collectives,instruction_count,32510000,0.1
 
 
 
-dtensor_dispatch_add_backward,instruction_count,792900,0.1
+dtensor_dispatch_add_backward,instruction_count,648100,0.1
 
 
 

--- a/c10/core/AutogradState.cpp
+++ b/c10/core/AutogradState.cpp
@@ -5,13 +5,13 @@
 namespace c10 {
 
 namespace {
-// By default, grad mode and multithreading are enabled, inference mode is
+// By default, grad mode is enabled, inference mode and multithreading are
 // disabled,
 thread_local AutogradState autograd_state_tls = AutogradState(
     /* grad_mode */ true,
     /* inference_mode */ false,
     /* fw_grad_mode */ true,
-    /* multithreading_enabled */ true);
+    /* multithreading_enabled */ false);
 } // namespace
 
 AutogradState& AutogradState::get_tls_state() {

--- a/c10/core/AutogradState.h
+++ b/c10/core/AutogradState.h
@@ -83,7 +83,7 @@ struct C10_API AutogradState {
   bool grad_mode_ : 1 = true;
   bool inference_mode_ : 1 = false;
   bool fw_grad_mode_ : 1 = true;
-  bool multithreading_enabled_ : 1 = true;
+  bool multithreading_enabled_ : 1 = false;
   bool view_replay_enabled_ : 1 = false;
   bool grad_layout_enforcement_enabled_ : 1 = true;
 };

--- a/c10/core/InferenceMode.h
+++ b/c10/core/InferenceMode.h
@@ -60,7 +60,7 @@ struct C10_API InferenceMode {
         /* grad_mode */ !enabled,
         /* inference_mode */ enabled,
         /* fw_grad_mode */ !enabled,
-        /* multithreading_enabled*/ !enabled));
+        /* multithreading_enabled*/ false));
     DispatchKeySet included = enabled
         ? prev_keyset.included_.remove(c10::DispatchKey::ADInplaceOrView)
         : prev_keyset.included_.add(c10::DispatchKey::ADInplaceOrView);

--- a/c10/core/InferenceMode.h
+++ b/c10/core/InferenceMode.h
@@ -60,7 +60,7 @@ struct C10_API InferenceMode {
         /* grad_mode */ !enabled,
         /* inference_mode */ enabled,
         /* fw_grad_mode */ !enabled,
-        /* multithreading_enabled*/ false));
+        /* multithreading_enabled*/ prev_mode.get_multithreading_enabled()));
     DispatchKeySet included = enabled
         ? prev_keyset.included_.remove(c10::DispatchKey::ADInplaceOrView)
         : prev_keyset.included_.add(c10::DispatchKey::ADInplaceOrView);

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -13021,6 +13021,10 @@ class DynamicCondModel(torch.nn.Module):
     "CUDA 12.4 or greater is required for CUDA Graphs with conditional nodes",
 )
 class TestControlFlowNN(TestCase):
+    # Multithreaded autograd keeps backward off the capturing thread, which
+    # still has dynamo's eval frame callback installed; compiling there during
+    # CUDA graph capture is an error.
+    @torch.autograd.set_multithreading_enabled(True)
     def test_cond_in_NN(self):
         model = DynamicCondModel().cuda()
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5307,14 +5307,15 @@ SinBackward0, MulBackward0, torch::autograd::AccumulateGrad
         ):
             torch._C._current_graph_task_execution_order()
 
-        # Errors when context manager not enabled
+        # Errors when multithreading is enabled
         t = torch.tensor(1.0, requires_grad=True).clone().sin().exp()
         all_hooks.append(t.register_hook(hook))
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "expects the current backward to be executed with multithreading disabled",
-        ):
-            t.backward()
+        with torch.autograd.set_multithreading_enabled(True):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "expects the current backward to be executed with multithreading disabled",
+            ):
+                t.backward()
 
         # Avoid leaking memory
         for h in all_hooks:
@@ -13698,9 +13699,11 @@ class TestAutogradDeviceType(TestCase):
         t6 = ReentrantFunc.apply(t3)
         t7 = t6 * t6
 
-        # Parent graph will error out first, while child graph will continue executing.
-        with self.assertRaisesRegex(Exception, "Simulate error"):
-            torch.autograd.backward([t5.sum(), t7.sum()])
+        # Parent graph will error out first, while child graph will continue
+        # executing. This interleaving requires multithreaded autograd.
+        with torch.autograd.set_multithreading_enabled(True):
+            with self.assertRaisesRegex(Exception, "Simulate error"):
+                torch.autograd.backward([t5.sum(), t7.sum()])
 
         # No grads should be accumulated since child graph will stop execution
         # after parent receives error.
@@ -16086,25 +16089,29 @@ class TestMultithreadAutograd(TestCase):
         torch.autograd.gradcheck(fn2, [inp_c, inp_r], check_forward_ad=True)
 
     def test_set_multithreading_enabled_as_context_manager_and_function(self):
-        # Test as a context manager
-        with torch.autograd.set_multithreading_enabled(False):
-            self.assertFalse(torch.autograd.is_multithreading_enabled())
-        self.assertTrue(torch.autograd.is_multithreading_enabled())
-
-        with torch.autograd.set_multithreading_enabled(True):
-            self.assertTrue(torch.autograd.is_multithreading_enabled())
-        self.assertTrue(torch.autograd.is_multithreading_enabled())
-
-        with torch.autograd.set_multithreading_enabled(False):
-            torch.autograd.set_multithreading_enabled(True)
-            self.assertTrue(torch.autograd.is_multithreading_enabled())
-        self.assertTrue(torch.autograd.is_multithreading_enabled())
-
-        torch.autograd.set_multithreading_enabled(False)
+        # Multithreaded backward is disabled by default
         self.assertFalse(torch.autograd.is_multithreading_enabled())
 
-        torch.autograd.set_multithreading_enabled(True)
-        self.assertTrue(torch.autograd.is_multithreading_enabled())
+        # Test as a context manager
+        with torch.autograd.set_multithreading_enabled(True):
+            self.assertTrue(torch.autograd.is_multithreading_enabled())
+        self.assertFalse(torch.autograd.is_multithreading_enabled())
+
+        with torch.autograd.set_multithreading_enabled(False):
+            self.assertFalse(torch.autograd.is_multithreading_enabled())
+        self.assertFalse(torch.autograd.is_multithreading_enabled())
+
+        with torch.autograd.set_multithreading_enabled(True):
+            torch.autograd.set_multithreading_enabled(False)
+            self.assertFalse(torch.autograd.is_multithreading_enabled())
+        self.assertFalse(torch.autograd.is_multithreading_enabled())
+
+        try:
+            torch.autograd.set_multithreading_enabled(True)
+            self.assertTrue(torch.autograd.is_multithreading_enabled())
+        finally:
+            torch.autograd.set_multithreading_enabled(False)
+        self.assertFalse(torch.autograd.is_multithreading_enabled())
 
     @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
     def test_custom_function_propagates_errors_from_device_thread(self):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2177,7 +2177,13 @@ class TestCompositeCompliance(TestCase):
                         output_grads_copy.append(output_grad.detach().clone())
                         output_grads.append(torch._lazy_clone(output_grad))
 
-                    torch.autograd.grad(
+                    # COW non-materialization is an eager autograd property.
+                    # Under a dynamo-compiled test harness, backward runs on
+                    # the calling thread with the eval frame callback active,
+                    # so python kernels invoked by the engine (e.g. native op
+                    # override routers) would get compiled and materialize the
+                    # COW grads.
+                    torch._dynamo.disable(torch.autograd.grad)(
                         results,
                         leaf_tensors,
                         output_grads,

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -314,20 +314,21 @@ def _exit_inference_mode(mode):
 class set_multithreading_enabled(_DecoratorContextManager):
     r"""Context-manager that enables or disables multithreaded backward.
 
-    Ordinarily, when :ref:`accelerator<accelerators>` devices are in use,
-    the backward pass runs on device-specific worker threads. The engine
-    creates these threads based on the number of available devices and
-    reuses them across iterations.
+    When ``mode=True`` and :ref:`accelerator<accelerators>` devices are in
+    use, the backward pass runs on device-specific worker threads. The
+    engine creates these threads based on the number of available devices
+    and reuses them across iterations.
 
-    When ``mode=False``, the backward pass runs on the calling thread
-    instead. ``mode=True`` restores the default behavior.
+    When ``mode=False`` (the default), the backward pass runs on the
+    calling thread instead. Multithreaded backward mainly benefits
+    workloads spanning multiple accelerator devices in one process.
 
     This can be used as a context-manager or as a function. It is
     thread-local and will not affect computation in other threads.
 
     Args:
-        mode (bool): Whether to enable multithreaded backward (``True``,
-                    default) or disable (``False``).
+        mode (bool): Whether to enable multithreaded backward (``True``)
+                    or disable (``False``, default).
 
     .. note::
         This API does not apply to :ref:`forward-mode AD <forward-mode-ad>`,

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -261,6 +261,29 @@ size_t ReadyQueue::size() const {
   return heap_.size();
 }
 
+void ReadyQueue::drain_completed() {
+  std::vector<NodeTask> live;
+  std::vector<NodeTask> dropped;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    live.reserve(heap_.size());
+    while (!heap_.empty()) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      auto task = std::move(const_cast<NodeTask&>(heap_.top()));
+      heap_.pop();
+      auto graph_task = task.base_.lock();
+      bool completed = !task.isShutdownTask_ &&
+          (!graph_task || graph_task->future_result_->completed());
+      (completed ? dropped : live).push_back(std::move(task));
+    }
+    for (auto& task : live) {
+      heap_.push(std::move(task));
+    }
+  }
+  // `dropped` destructs here, releasing InputBuffer grad tensors outside the
+  // lock.
+}
+
 auto ReadyQueue::pop() -> NodeTask {
   // Lock mutex for accesses to heap_
   std::unique_lock<std::mutex> lock(mutex_);
@@ -1507,6 +1530,10 @@ c10::intrusive_ptr<at::ivalue::Future> Engine::execute_with_graph_task(
     lock.unlock();
     thread_main(graph_task);
     TORCH_INTERNAL_ASSERT(graph_task->future_result_->completed());
+    // If the graph_task errored out, tasks that were queued but never popped
+    // would otherwise keep their grad tensors alive until the next backward
+    // call on this thread pops them.
+    local_ready_queue->drain_completed();
     // reset the worker_device after the completion of the graph_task, this is
     // so that the initial state of the engine remains the same across every
     // backward() or grad() call, we don't need to reset local_ready_queue as we

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -123,6 +123,11 @@ struct ReadyQueue {
   NodeTask pop();
   bool empty() const;
   size_t size() const;
+  // Drop tasks whose GraphTask has already completed (e.g. due to an error),
+  // releasing the grad tensors held by their InputBuffers. Used when a thread
+  // that drives the engine exits thread_main, since no one else will pop its
+  // local ready queue until the next backward call.
+  void drain_completed();
 };
 
 // A single instance of this struct should be created through the whole process

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1376,6 +1376,14 @@ def _clear_cublas_workspaces() -> None:
     if not is_initialized():
         return
 
+    # If this thread is already executing a backward pass (e.g. cudagraph
+    # trees clearing workspaces during backward warmup), the reentrant
+    # synthetic backward below would interleave the outer graph task's
+    # remaining nodes onto this thread and can deadlock. The direct clear
+    # above already covered this thread, so skip the worker-side clear.
+    if torch._C._current_graph_task_id() != -1:
+        return
+
     global _ClearCublasWorkspaces
     if _ClearCublasWorkspaces is None:
         from torch.autograd import Function


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192082
* #192081

Flip the default of multithreading_enabled from true to false in
AutogradState, so backward runs on the calling thread unless a user opts
in via torch.autograd.set_multithreading_enabled(True). Multithreaded
backward mainly benefits workloads spanning multiple accelerator devices
in one process, which is rare, while the extra threads add overhead and
surprising behavior for the common single-device case.

The change touches the TLS default (AutogradState.cpp), the in-class bit
default (AutogradState.h), and InferenceMode, which no longer derives
multithreading from the inference flag. Tests that relied on the old
default now opt in explicitly, and the set_multithreading_enabled docs
describe False as the default.

Test Plan:

```
python test/test_autograd.py -k multithreading
python test/test_autograd.py TestMultithreadAutograd
```

Authored with assistance from an AI coding assistant.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98