### PR TITLE
[Inductor] Fix invalid attn_mask + is_causal combo in qwen2 SDPA repro test

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -3126,10 +3126,6 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
 
         self.assertEqual(eager_out, compile_out)
 
-    @skipIfXpu(
-        msg="_scaled_dot_product_efficient_attention returns log_sumexp in the query "
-        "dtype instead of float32, tripping Inductor's fake kernel metadata check"
-    )
     def test_qwen2_7b_sdpa_input_alignment_requires_recompile(self):
         # SDPA constraints ensures inputs have alignment (8).
         device = device_type

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -3126,6 +3126,10 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
 
         self.assertEqual(eager_out, compile_out)
 
+    @skipIfXpu(
+        msg="_scaled_dot_product_efficient_attention returns log_sumexp in the query "
+        "dtype instead of float32, tripping Inductor's fake kernel metadata check"
+    )
     def test_qwen2_7b_sdpa_input_alignment_requires_recompile(self):
         # SDPA constraints ensures inputs have alignment (8).
         device = device_type

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -3126,10 +3126,6 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
 
         self.assertEqual(eager_out, compile_out)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/163689")
-    @skipIfXpu(
-        msg="Explicit attn_mask should not be set when is_causal=True - torch-xpu-ops: 2802"
-    )
     def test_qwen2_7b_sdpa_input_alignment_requires_recompile(self):
         # SDPA constraints ensures inputs have alignment (8).
         device = device_type
@@ -3174,7 +3170,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
                     v,
                     attn_bias,
                     dropout_p=0.0,
-                    is_causal=True,
+                    is_causal=False,
                     scale=scale,
                     compute_log_sumexp=True,
                 )


### PR DESCRIPTION
Drops the `attn_mask` + `is_causal=True` combination from `test_qwen2_7b_sdpa_input_alignment_requires_recompile` and removes the `@skipIfRocm` decorator it forced. The `@skipIfXpu` decorator stays: the change fixes the XPU error that motivated it, but XPU then trips an unrelated bug, so the skip is kept with an accurate reason (see below).

## What the test checks

The test guards the fix from #163083: after compiling with a sequence length divisible by 8 (no padding needed), running the same compiled function with a length that is *not* divisible by 8 must recompile instead of reusing the first graph. Reusing it produced:

```
RuntimeError: attn_bias is not correctly aligned (strideM). attn_bias.stride(2) = 6102, and should be a multiple of 4.
```

That is why the test runs the compiled function twice, at `S=6144` and then `S=6102`. The comparison itself is incidental: `grad_out` is built from `torch.zeros(...)`, so every gradient is mathematically zero regardless of the mask. What the test really asserts is that the unaligned shape triggers a recompile rather than blowing up.

## Why the combination is invalid

The forward call passes both an explicit `attn_bias` and `is_causal=True`. PyTorch rejects that combination everywhere it is reachable through a public API — `scaled_dot_product_attention` in `aten/src/ATen/native/transformers/attention.cpp` raises `"_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True"`, and the math fallback repeats the check. The test only reaches it by calling the private `aten` op directly.

It is also self-inconsistent: the backward call a few lines below passes no `is_causal` at all, so it defaults to `False` while the forward asks for a causal mask. The original Qwen2-7B traceback in #163083 shows the same thing — the backward is invoked as `..., 0.0, [True, True, True, False], scale=0.08838834764831845)`, with no `is_causal` argument. So `is_causal=True` in the forward looks like a transcription slip rather than something the test means to exercise.

## Why it passes only on CUDA

The CUTLASS mem-efficient kernel happens to tolerate it. In `aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h` the bias is added into the logits (`accum[idx] += bias_tensor_ref.at({accum_m, accum_n})`) and out-of-causal entries are then overwritten with `-inf`, so causal masking simply wins over the bias and the result is well defined.

The other two backends do not tolerate it:

- **ROCm / AOTriton** has no kernel variant taking a bias together with a causal mask, and returns without launching one.

  Because nothing writes the outputs, the op returns its freshly allocated tensors unmodified, so the result depends on what the caching allocator previously held — zeros, stale values or NaN. That is what the ROCm failure was: `Mismatched elements: 6283648 / 44040192 (14.3%)` with `nan` at index `(0, 0, 0, 0)`, and the exact count varies run to run. Tracked as #163689.

- **XPU** raises outright with the same message the public API uses, `RuntimeError: _scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True`. Tracked as intel/torch-xpu-ops#2802.

## Why drop `is_causal` and not the bias

The alignment constraint that motivated the test is on `attn_bias.stride(2)`, so the bias has to stay — removing it would delete the test's entire purpose. `is_causal` is irrelevant to that constraint, so dropping it keeps the test intact, makes it agree with its own backward call, and makes it valid on every backend.

The recompilation being guarded is unaffected: the second, unaligned shape still produces a new graph (`torch._dynamo.utils.counters["stats"]["unique_graphs"]` goes 1 → 2 across the two runs).

## XPU stays skipped, for a different reason

The first CI run confirmed the `is_causal` part: XPU no longer raises intel/torch-xpu-ops#2802's error, and the eager call succeeds. The compiled call then fails instead:

```
File "test/inductor/test_cuda_repro.py", line 3219, in test_qwen2_7b_sdpa_input_alignment_requires_recompile
    actual = compiled(*example_inputs)
...
File "torch/_inductor/runtime/runtime_utils.py", line 106, in assert_tensor_metadata
RuntimeError: expected dtype torch.float32 but got torch.bfloat16
Error in op: torch.ops.aten._scaled_dot_product_efficient_attention.default
```

That is an independent XPU bug rather than anything specific to this test. `meta__scaled_dot_product_efficient_attention` in `torch/_meta_registrations.py` allocates `log_sumexp` as `torch.float` for every backend, and the CUDA and ROCm kernels agree (`query.options().dtype(at::ScalarType::Float)`). The XPU fallback, `_scaled_dot_product_efficient_attention_xpu` in `torch-xpu-ops` `src/ATen/native/transformers/Attention.cpp`, allocates it with `attention.options()` instead and so inherits the query dtype, `bfloat16` here. The shapes match; only the dtype differs.

It surfaces solely under `torch.compile` because Inductor emits `assert_tensor_metadata` against the fake kernel's promise for fallback op outputs. Nothing verifies it in eager, and the XPU backward discards the tensor (`(void)logsumexp;`), so the mismatch has been harmless and invisible until this test reached the compiled call.

Fixing that belongs in `torch-xpu-ops`, so the second commit restores `@skipIfXpu` with the real reason. cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @daisyden @guangyey

## Verification

- **ROCm**: passes. `inductor/test_cuda_repro` ran in `linux-jammy-rocm-py3.10-mi350 / test (default, 1, 8)` and reported success; also `ok (12.174s)` locally on MI350X (gfx950), ROCm 7.2.53211. Before the change, with the skip removed and `is_causal=True` kept: `FAIL`, `Mismatched elements: 6283648 / 44040192 (14.3%)`, `Greatest absolute difference: nan at index (0, 0, 0, 0)`. Note that the file is not part of the ROCm `inductor` config, whose include list in `.ci/pytorch/test.sh` covers `test_torchinductor`, `test_torchinductor_opinfo`, `test_aot_inductor` and `test_cpu_select_algorithm`.
- **XPU**: skipped again, as described above.
