### PR TITLE
[Test] Refcatored test_parsing.py to include hw_classification

### DIFF
--- a/test/functorch/test_parsing.py
+++ b/test/functorch/test_parsing.py
@@ -35,7 +35,11 @@ from functorch.einops._parsing import (
     ParsedExpression,
     validate_rearrange_expressions,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def mock_anonymous_axis_eq(self: AnonymousAxis, other: object) -> bool:
@@ -43,6 +47,8 @@ def mock_anonymous_axis_eq(self: AnonymousAxis, other: object) -> bool:
 
 
 class TestAnonymousAxis(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_anonymous_axes(self) -> None:
         a, b = AnonymousAxis("2"), AnonymousAxis("2")
         self.assertNotEqual(a, b)
@@ -57,6 +63,8 @@ class TestAnonymousAxis(TestCase):
 
 
 class TestParsedExpression(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_elementary_axis_name(self) -> None:
         for name in [
             "a",
@@ -205,6 +213,8 @@ class TestParsedExpression(TestCase):
 
 
 class TestParsingUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_parse_pattern_number_of_arrows(self) -> None:
         axes_lengths: dict[str, int] = {}
 
@@ -253,6 +263,8 @@ class MaliciousRepr:
 
 
 class TestValidateRearrangeExpressions(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_validate_axes_lengths_are_integers(self) -> None:
         axes_lengths: dict[str, Any] = {"a": 1, "b": 2, "c": 3}
         pattern = "a b c -> c b a"


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add hw_classification = GENERIC to TestAnonymousAxis — 1 CPU-only parsing test
- Add hw_classification = GENERIC to TestParsedExpression — 3 CPU-only expression parsing tests
- Add hw_classification = GENERIC to TestParsingUtils — 4 CPU-only pattern parsing tests
- Add hw_classification = GENERIC to TestValidateRearrangeExpressions — 4 CPU-only validation tests

## Test Plan

```bash
python -m pytest test/functorch/test_parsing.py -v
12 passed in 1.00s

python -m pytest test/functorch/test_parsing.py -v --hw-classification GENERIC
12 passed in 1.01s
```

CC: @mansiag05 @RiyaP2508 @vishalgoyal316 