### PR TITLE
[Test] Disable shape padding for flaky tests in `test_provenance_tracing.py`

### DIFF
--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -1188,6 +1188,7 @@ class ProvenanceTracingKernelContextTemplate:
             torch.compile(model)(*example_inputs)
 
     @unittest.skipIf(sys.platform == "darwin", "Different kernel names on MacOS")
+    @config.patch(shape_padding=False)
     def test_aoti_python_stack_traces(self):
         class Model(torch.nn.Module):
             def __init__(self):

--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -293,6 +293,7 @@ class TestProvenanceTracingArtifact(TestCase):
                     shutil.rmtree(filepath)
 
     @requires_gpu_and_triton
+    @config.patch("shape_padding", False)
     def test_triton_kernel_to_post_grad_tracing_cuda(self):
         self._test_triton_kernel_to_post_grad_tracing(device=GPU_TYPE)
 
@@ -300,6 +301,7 @@ class TestProvenanceTracingArtifact(TestCase):
         self._test_triton_kernel_to_post_grad_tracing(device="cpu")
 
     @requires_gpu_and_triton
+    @config.patch("shape_padding", False)
     def test_triton_kernel_to_post_grad_tracing_extern_kernel(self):
         M = 8
         N = 6
@@ -643,6 +645,7 @@ class TestProvenanceTracingStackTraces(TestCase):
 
     @torch._inductor.config.patch({"trace.provenance_tracking_level": 2})
     @requires_gpu_and_triton
+    @config.patch("shape_padding", False)
     def test_tlparse_kernel_stack_traces(self):
         device = GPU_TYPE
         model = Model4().to(device)
@@ -741,6 +744,7 @@ class TestProvenanceTracingStackTraces(TestCase):
 
     @requires_gpu_and_triton
     @torch._inductor.config.patch("trace.provenance_tracking_level", 1)
+    @config.patch("shape_padding", False)
     def test_kernel_information_generation(self):
         """Test basic kernel information generation in AOTI packages."""
 
@@ -1188,7 +1192,7 @@ class ProvenanceTracingKernelContextTemplate:
             torch.compile(model)(*example_inputs)
 
     @unittest.skipIf(sys.platform == "darwin", "Different kernel names on MacOS")
-    @config.patch(shape_padding=False)
+    @config.patch("shape_padding", False)
     def test_aoti_python_stack_traces(self):
         class Model(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
`test_aoti_python_stack_traces_cuda`, `test_kernel_information_generation`, `test_tlparse_kernel_stack_traces`, `test_triton_kernel_to_post_grad_tracing_extern_kernel`, and `test_triton_kernel_to_post_grad_tracing_cuda`  all fail flakily on GB200 because autotuning sometimes inserts padding, changing the indices of operations from their expected values.
```
ERROR: test_aoti_python_stack_traces_cuda (__main__.TestProvenanceTracingKernelContextGpu.test_aoti_python_stack_traces_cuda)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3794, in wrapper
    method(*args, **kwargs)
  File "/opt/pytorch/pytorch/test/inductor/test_torchinductor.py", line 19393, in new_test
    return value(self)
           ^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/inductor/test_provenance_tracing.py", line 1282, in test_aoti_python_stack_traces
    ).check("call_triton_poi_fused_addmm_gelu_2(").run(code)
                                                   ^^^^^^^^^
RuntimeError: Expected to find " KernelContextGuard _ctx(\"triton_poi_fused_addmm_gelu_2\", R\"(" but did not find it
Searched string:
)");
    RAIIAtenRecordFunctionHandle record_aoti_torch_cuda_mm_out_("aoti_torch_cuda_mm_out", nullptr);
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_cuda_mm_out(buf5, buf3, buf4));
    }
    buf3.reset();
    buf4.reset();
    if (_check_aoti_runtime_check_inputs_env()) { assert_size_stride(arg5_1, {30L, }, {1L, }, "input"); }
    static constexpr int64_t int_array_10[] = {10L, 30L};
    static constexpr int64_t int_array_11[] = {30L, 1L};
    AtenTensorHandle buf6_handle;
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_empty_strided(2, int_array_10, int_array_11, cached_torch_dtype_float32, cached_torch_device_type_cuda, this->device_idx_, &buf6_handle));
    RAIIAtenTensorHandle buf6(buf6_handle);
    // Topologically Sorted Source Nodes: [, gelu_default], Original ATen: [aten.addmm, aten.gelu]
    // [Provenance debug handles] triton_poi_fused_addmm_gelu_4:7
    {
    KernelContextGuard _ctx("triton_poi_fused_addmm_gelu_4", R"(
File "/opt/pytorch/pytorch/test/inductor/test_provenance_tracing.py", line 1205, in forward
    z = torch.nn.functional.gelu(y)

File "/opt/pytorch/pytorch/test/inductor/test_provenance_tracing.py", line 1204, in forward
    y = torch.addmm(c, d, b)
)");
    call_triton_poi_fused_addmm_gelu_4(arg5_1, buf5, buf6, 300L, this->device_idx_, stream, kernels, this->cubin_dir_);
    }
    arg5_1.reset();
    buf5.reset();
    output_handles[0] = buf1.release();
    output_handles[1] = buf6.release();
} // AOTInductorModel::run_impl
} // namespace torch::aot_inductor

```
This PR just decorates the tests with a config patch to disable shape padding.

Authored with assistance from Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy 