### PR TITLE
[inductor] Fix symm-mem alloc_id collision from globally-seeded random

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -2183,6 +2183,36 @@ class LoweringTest(MultiProcContinuousTest):
         # Verify that exactly one symm_mem allocation call is generated
         FileCheck().check_count("empty_strided_p2p(", 1, exactly=True).run(code)
 
+    @skip_if_rocm_multiprocess
+    @skip_if_lt_x_gpu(2)
+    @fresh_inductor_cache()
+    def test_symm_mem_alloc_id_no_collision_after_reseed(self):
+        """Regression test for issue #192087.
+
+        The persistent symm_mem alloc_id must stay unique across graphs even
+        when the global random module is reseeded between compilations, as
+        TestCase.setUp does via random.seed(). Otherwise different-sized
+        allocations collide in the process-global persistent allocation map and
+        fail with an allocation-size-mismatch error.
+        """
+        self._init_process()
+
+        def alloc_id(n):
+            def func(x):
+                return torch.ops.symm_mem.one_shot_all_reduce(x + 1, "sum", "0")
+
+            x = torch.rand(n, n, device=self.device)
+            code = run_and_get_triton_code(torch.compile(func, fullgraph=True), x)
+            match = re.search(r"alloc_id=(\d+)", code)
+            self.assertIsNotNone(match, "expected a symm_mem allocation in the code")
+            return match.group(1)
+
+        random.seed(1234)
+        id_small = alloc_id(4)
+        random.seed(1234)
+        id_large = alloc_id(8)
+        self.assertNotEqual(id_small, id_large)
+
 
 class SymmMemSingleProcTest(TestCase):
     @requires_cuda

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1069,6 +1069,12 @@ class AllocateLine(MemoryPlanningLine):
                 f"{dtype}, "
                 f'torch.device("cuda:{device.index}"), '
                 f'group_name="{group_name}", '
+                # alloc_id keys a process-global persistent-allocation map
+                # (SymmetricMemory.cpp) that outlives the graph and rejects
+                # same-id allocations of differing size. Draw from secrets, not
+                # the global random module, which is frequently reseeded (e.g.
+                # TestCase.setUp calls random.seed()) and would yield colliding
+                # ids across graphs.
                 f"alloc_id={secrets.randbits(64)})"
             )
         else:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -10,8 +10,8 @@ import inspect
 import logging
 import operator
 import os
-import random
 import re
+import secrets
 import tempfile
 from collections.abc import Callable
 from itertools import chain, count
@@ -1069,7 +1069,7 @@ class AllocateLine(MemoryPlanningLine):
                 f"{dtype}, "
                 f'torch.device("cuda:{device.index}"), '
                 f'group_name="{group_name}", '
-                f"alloc_id={random.randint(0, 2**64 - 1)})"
+                f"alloc_id={secrets.randbits(64)})"
             )
         else:
             raise NotImplementedError(


### PR DESCRIPTION
Inductor generates the persistent symmetric-memory `alloc_id` for comm buffers via `random.randint(0, 2**64 - 1)` at codegen time. That draw comes from the process-global random module, which routinely gets reseeded and notably PyTorch's `TestCase.setUp` calls `random.seed(1234)` before every test, so the first `randint` after setup is deterministically `14354624986284130233` for every test.

The `alloc_id` is used as a key into a process-global map (`alloc_id_to_dev_ptr` in SymmetricMemory.cpp) that persists for the lifetime of the process and enforces that all allocations sharing an `alloc_id` have the same size. When two different graphs draw the same `alloc_id` but allocate different sizes, the second allocation fails with `requested allocation size (X) is different from the size of a previous allocation with the same alloc_id Y`.

This surfaces as `test_custom_op_symm_mem_realization` failing only when the full file (or the whole LoweringTest class) runs: LoweringTest is a MultiProcContinuousTest whose workers live across the class, so `test_comm_buffer_inplace_prevention` (256B) registers the id first and `test_custom_op_symm_mem_realization` (64B) then collides on it. Run in isolation the test passes because nothing else claims the id.

The id only needs to be unique within the process and is baked into the generated code as a constant, so an entropy-based draw is both sufficient and immune to `random.seed()`. Switch to `secrets.randbits(64)`. This also fixes the latent collision for user code that calls `random.seed()` before `torch.compile()` on symm-mem collectives.

Fixes #192087

Test Plan:
Full file, which previously failed with errors=1:
```
python test/distributed/test_symmetric_memory.py
# Ran 133 tests ... OK (skipped=57)
```
LoweringTest class, the minimal reproducer:
```
python test/distributed/test_symmetric_memory.py LoweringTest
# Ran 9 tests ... OK (skipped=2)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo