### PR TITLE
[inductor] Test that ORDERED effectful op inputs are still freed

### DIFF
--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -1,10 +1,13 @@
 # Owner(s): ["module: inductor"]
+import contextlib
+import re
 import unittest
 from unittest import mock
 
 import torch
 from torch._C import FileCheck
 from torch._dynamo.utils import same
+from torch._higher_order_ops.effects import _EffectType
 from torch._inductor import config, memory
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_triton_code
@@ -553,6 +556,177 @@ class TestOperatorReorderForPeakMemory(TestCase):
                     f"because different ranks may execute collectives in different orders."
                 ),
             )
+
+
+# Every knob here decides whether a free is emitted for an intermediate buffer,
+# or how that free is spelled, so pin them instead of inheriting whatever the
+# shard happens to run with.
+@config.patch(
+    {
+        # cpp_wrapper spells a free "buf.reset();" rather than "del buf", and CI
+        # has TORCHINDUCTOR_CPP_WRAPPER=1 shards.
+        "cpp_wrapper": False,
+        # A reused buffer is freed as part of its reuse line ("buf1 = buf0; del
+        # buf0"); with reuse off every free is its own "del buf" line.
+        "allow_buffer_reuse": False,
+        # Pooled allocation frees several buffers on a single "del a, b" line.
+        "memory_planning": False,
+        "memory_pool": "none",
+        # Reordering rewrites the very schedule whose frees are asserted below.
+        "reorder_for_peak_memory": False,
+    }
+)
+class TestEffectfulOpMemory(TestCase):
+    """
+    An ORDERED effectful op does not extend the lifetime of its tensor inputs, so
+    those buffers must still be freed once the op has run. Adding them to
+    ``never_reuse_buffers`` makes ``codegen_free`` skip the free entirely -- it
+    early-returns for any buffer ``can_reuse`` rejects -- and peak memory then
+    grows with the number of effectful ops in the graph.
+    """
+
+    # Enough steps that a leak is unambiguous: with the frees dropped, the graph
+    # holds this many intermediates at once instead of one.
+    NUM_EFFECTFUL_OPS = 8
+
+    # 8M elements, i.e. 32 MiB at the float32 the tests use, so that one leaked
+    # intermediate is far larger than any allocator noise in the peak-memory test
+    # below. The bound there is computed from the dtype, not from this constant.
+    INPUT_NUMEL = 1024 * 1024 * 8
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _observe_op():
+        """An ORDERED effectful op that ignores its input."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define("mylib::observe", "(Tensor x) -> ()", lib=lib)
+            lib.impl("observe", lambda x: None, "CompositeExplicitAutograd")
+            torch.library._register_effectful_op(
+                "mylib::observe", _EffectType.ORDERED, lib=lib
+            )
+            yield
+
+    @staticmethod
+    def _make_fn(num_effectful_ops):
+        def fn(x):
+            # Seed the chain with a reduction rather than a constant: `x + 0` is
+            # folded away, which would hand the first op the graph input itself
+            # instead of an intermediate.
+            total = x.mean()
+            for _ in range(num_effectful_ops):
+                # Each step depends on a reduction over the previous one, so only
+                # one of them can be live at a time. Independent steps would be
+                # fused into a single multi-output kernel and be co-resident
+                # regardless of how they are freed.
+                step = x + total
+                torch.ops.mylib.observe(step)
+                total = total + step.mean()
+            return total
+
+        return fn
+
+    def _compile_serial_chain(self, x):
+        """
+        Compile and run the chain on ``x``, returning ``(compiled, code,
+        observed_buffers)`` where ``observed_buffers`` are the intermediate
+        buffers the effectful op is called on, in program order.
+
+        Also asserts the shape the callers' assertions depend on: one effectful op
+        per step, each called on its own intermediate buffer. An op handed a graph
+        input exercises nothing -- ``codegen_free`` writes an unconditional
+        ``FreeLine`` for an ``InputBuffer`` and returns before it ever consults
+        ``never_reuse_buffers`` -- so without this the callers could be asserting
+        against a graph that no longer reproduces the regression at all. It is
+        not a fusion detector: a multi-output fusion would still emit one
+        distinct buffer per step and satisfy all three checks.
+        """
+        torch._dynamo.reset()
+        compiled = torch.compile(self._make_fn(self.NUM_EFFECTFUL_OPS), fullgraph=True)
+        code = run_and_get_triton_code(compiled, x)
+
+        observed = re.findall(r"observe\.default\((\w+)\)", code)
+        self.assertEqual(
+            len(observed),
+            self.NUM_EFFECTFUL_OPS,
+            f"expected one effectful op per step, got {observed}\n\n{code}",
+        )
+        # Each op must be called on an intermediate buffer. A graph input would
+        # not exercise the regression at all: codegen_free writes an
+        # unconditional FreeLine for an InputBuffer and returns before it ever
+        # consults never_reuse_buffers.
+        self.assertEqual(
+            [b for b in observed if not re.fullmatch(r"buf\d+", b)],
+            [],
+            f"effectful op called on something other than an intermediate "
+            f"buffer: {observed}\n\n{code}",
+        )
+        self.assertEqual(
+            len(set(observed)),
+            self.NUM_EFFECTFUL_OPS,
+            f"the steps did not stay separate buffers: {observed}\n\n{code}",
+        )
+        return compiled, code, observed
+
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_effectful_op_inputs_are_freed(self):
+        # Assert the free directly in the generated wrapper. That is the property
+        # which regressed, and unlike a memory measurement it cannot be perturbed
+        # by anything else running in the process.
+        with self._observe_op():
+            x = torch.ones(self.INPUT_NUMEL, device=GPU_TYPE)
+            _, code, observed = self._compile_serial_chain(x)
+
+        for buf in observed:
+            # Match the trailing newline so that "del buf1" is not satisfied by a
+            # "del buf12" line.
+            FileCheck().check(f"observe.default({buf})").check(f"del {buf}\n").run(code)
+
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    @serialTest()
+    # This test does not read the generated code for frees, so unlike the codegen
+    # test it does not need them spelled any particular way -- what it needs is
+    # the schedule production actually runs. So restore every class pin that sits
+    # off its default and the measurement is taken at stock config; the two that
+    # remain (cpp_wrapper, memory_planning) already are the defaults and are
+    # pinned only so a shard cannot move them from the environment. cudagraphs is
+    # pinned for the same reason but is specific to this test: cudagraph trees
+    # allocate from a private pool, which perturbs the measurement rather than
+    # the codegen.
+    @config.patch(
+        {
+            "allow_buffer_reuse": True,
+            "reorder_for_peak_memory": True,
+            "memory_pool": "intermediates",
+            "triton.cudagraphs": False,
+        }
+    )
+    def test_effectful_op_peak_memory_does_not_scale(self):
+        # The user-visible symptom of the missing frees (the regression showed up
+        # as training OOMs), asserted end to end.
+        with self._observe_op():
+            x = torch.ones(self.INPUT_NUMEL, device=GPU_TYPE)
+            compiled, _, _ = self._compile_serial_chain(x)
+
+            device_module = torch.get_device_module(GPU_TYPE)
+            device_module.synchronize()
+            device_module.reset_peak_memory_stats()
+            allocated_before = device_module.memory_allocated()
+            compiled(x)
+            device_module.synchronize()
+            peak_mem = device_module.max_memory_allocated() - allocated_before
+
+        # Only one `x + total` is live at a time and everything else in the graph
+        # is a scalar, so the call holds one intermediate however many effectful
+        # ops there are. Allow two for slack; a dropped free costs
+        # NUM_EFFECTFUL_OPS of them.
+        intermediate = self.INPUT_NUMEL * x.dtype.itemsize
+        self.assertLess(
+            peak_mem,
+            2 * intermediate,
+            f"peak memory scaled with the effectful op count: {peak_mem} bytes "
+            f"for {self.NUM_EFFECTFUL_OPS} ops, expected roughly one "
+            f"{intermediate}-byte intermediate",
+        )
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -5,6 +5,7 @@ from unittest import mock
 import torch
 from torch._C import FileCheck
 from torch._dynamo.utils import same
+from torch._higher_order_ops.effects import _EffectType
 from torch._inductor import config, memory
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_triton_code
@@ -552,6 +553,62 @@ class TestOperatorReorderForPeakMemory(TestCase):
                     f"This can cause NCCL hangs when torch.cond contains collective operations "
                     f"because different ranks may execute collectives in different orders."
                 ),
+            )
+
+
+class TestEffectfulOpMemory(TestCase):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    @serialTest()
+    def test_effectful_op_inputs_are_freed(self):
+        # An ORDERED effectful op does not extend the lifetime of its input, so
+        # the input buffer must still be freed once the op has run. Adding those
+        # buffers to never_reuse_buffers makes codegen_free skip the free, and
+        # peak memory then grows with the number of effectful ops in the graph.
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define("mylib::observe", "(Tensor x) -> ()", lib=lib)
+            lib.impl("observe", lambda x: None, "CompositeExplicitAutograd")
+            lib.impl("observe", lambda x: None, "Meta")
+            torch.library._register_effectful_op(
+                "mylib::observe", _EffectType.ORDERED, lib=lib
+            )
+
+            def make_fn(num_effectful_ops):
+                def fn(x):
+                    total = torch.zeros((), dtype=x.dtype, device=x.device)
+                    for _ in range(num_effectful_ops):
+                        # Each step depends on a reduction over the previous one,
+                        # so only one of them can be live at a time. Independent
+                        # steps would be fused into a single multi-output kernel
+                        # and be co-resident regardless of how they are freed.
+                        step = x + total
+                        torch.ops.mylib.observe(step)
+                        total = total + step.mean()
+                    return total
+
+                return fn
+
+            device_module = torch.get_device_module(GPU_TYPE)
+            peak_mems = []
+            for num_effectful_ops in (2, 8):
+                torch._dynamo.reset()
+                x = torch.ones(1024 * 1024 * 8, device=GPU_TYPE)
+                compiled = torch.compile(make_fn(num_effectful_ops), fullgraph=True)
+                compiled(x)  # compile before measuring
+                device_module.synchronize()
+                device_module.reset_peak_memory_stats()
+                allocated_before = device_module.memory_allocated()
+                compiled(x)
+                device_module.synchronize()
+                peak_mems.append(
+                    device_module.max_memory_allocated() - allocated_before
+                )
+                del x
+                device_module.empty_cache()
+
+            self.assertLess(
+                peak_mems[-1],
+                peak_mems[0] * 1.5,
+                f"peak memory grew with the effectful op count: {peak_mems}",
             )
 
 


### PR DESCRIPTION
Summary:
D114390609 added every tensor input of every ORDERED effectful op to
`V.graph.never_reuse_buffers`. `codegen_free()` returns early for buffers it
cannot reuse, so those inputs were never freed and stayed live for the whole
compiled call, making peak GPU memory scale with the number of effectful ops in
the graph. That caused training OOMs and it was reverted in D114674671, which
recorded no repro. This adds the missing repro as a regression test.

What regressed is a codegen property, so the primary assertion is a codegen one:
compile a serial chain of effectful ops and FileCheck that the wrapper emits
`del bufN` after each `observe.default(bufN)`. A second test keeps the
user-visible symptom (peak memory) end to end, with a bound derived from the
tensor size rather than a tuned ratio.

Three choices are deliberate:

- The graph is a serial chain, each step depending on a reduction over the
  previous one, so only one intermediate is ever live. Independent steps get
  fused into one multi-output kernel and are co-resident whether or not they are
  freed. Separately, `_compile_serial_chain` asserts the shape the assertions
  depend on -- one op per step, each called on its own intermediate buffer -- so
  they cannot run against a graph that stopped reproducing the regression. That
  check earns its keep: it is what caught an earlier version of this test seeding
  the chain with a constant, which folds `x + 0` away and hands the first
  `observe` the graph input.
- The chain is seeded with `x.mean()` rather than a constant. With a constant the
  first `x + 0` folds away and the first op is handed the graph input, which
  exercises nothing: `codegen_free` writes an unconditional `FreeLine` for an
  `InputBuffer` and returns before it ever consults `never_reuse_buffers`.
- The class pins the inductor configs that decide whether a free is emitted at
  all or how it is spelled, instead of inheriting whatever the shard runs with.
  CI has `TORCHINDUCTOR_CPP_WRAPPER=1` shards, where a free is `buf.reset();` and
  not `del buf`. Only the codegen test needs those pins, so the peak-memory test
  restores every one of them that sits off its default and takes its measurement
  at stock config, and additionally pins cudagraphs off, since cudagraph trees
  allocate from a private pool that would perturb the number.

It goes in `test_memory.py` rather than beside the D114390609 tests in
`test_with_effects.py` because what regressed is inductor peak memory, and unlike
`test/higher_order_ops/` this file has an fbcode GPU target so the test also runs
internally.

This change was authored with AI assistance (Claude Code).

Test Plan:
On 2x A100-80GB at `59c157666c7b`:

```
buck2 run @//mode/opt fbcode//caffe2/test/inductor:memory -- \
    caffe2.test.inductor.test_memory.TestEffectfulOpMemory
```

Both tests pass on trunk. Re-applying the D114390609 pin to `lowering.py` on top
of trunk makes both fail, so they catch what they guard against:

|                                                | trunk | pin re-applied |
|------------------------------------------------|-------|----------------|
| `test_effectful_op_inputs_are_freed`           | pass  | `RuntimeError: Expected to find "del buf2\n" but did not find it` |
| `test_effectful_op_peak_memory_does_not_scale` | pass  | `AssertionError: 268439552 not less than 67108864` |
| measured peak                                  | 33,558,528 B | 268,439,552 B |

One intermediate is `8388608 * 4` = 33,554,432 B. Trunk holds exactly one of them
(plus 4 KiB of scalars) no matter how many effectful ops there are; the pinned
build holds exactly eight, one per op, none of them freed. The bound is two
intermediates, so it has 2x headroom on trunk and is exceeded 4x on the
regression.

The rest of the file is unaffected -- the whole module is `Ran 11 tests ... OK`.

Differential Revision: D114741442


