### PR TITLE
[c10d][nccl] Never issue collective NCCL calls from the caching-allocator trace hook

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -30,6 +30,7 @@ import torch.distributed.distributed_c10d as c10d
 import torch.nn.functional as F
 import torch.testing._internal.common_utils as common
 from torch import nn
+from torch._C._distributed_c10d import Backend as C10DBackend
 from torch.nn.parallel import DistributedDataParallel
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
@@ -2580,6 +2581,80 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
 
 
 instantiate_parametrized_tests(CommonDistributedDataParallelTest)
+
+
+class SplitGroupOptionsTest(TestCase):
+    class _SplittingBackend(C10DBackend):
+        def __init__(self, rank, size, name):
+            super().__init__(rank, size)
+            self._name = name
+            self._options = C10DBackend.Options(name, timeout=timedelta(seconds=111))
+            self.split_opts = None
+
+        @property
+        def supports_splitting(self):
+            return True
+
+        @property
+        def options(self):
+            return self._options
+
+        def getBackendName(self):
+            return self._name
+
+        def split(self, store, ranks, opts):
+            self.split_opts = opts
+            return SplitGroupOptionsTest._SplittingBackend(
+                ranks.index(self.rank()), len(ranks), f"{self._name}-child"
+            )
+
+    def _make_group(self):
+        # Shaped like a "cpu:gloo,cuda:nccl" group: two distinct backends, the
+        # accelerator one being the group's default. The backend type tags are
+        # just map keys here, the backends themselves are Python ones.
+        cpu_backend = self._SplittingBackend(0, 1, "cpu-backend")
+        default_backend = self._SplittingBackend(0, 1, "default-backend")
+        pg = dist.ProcessGroup(dist.HashStore(), 0, 1)
+        pg._register_backend(
+            torch.device("cpu"), dist.ProcessGroup.BackendType.GLOO, cpu_backend
+        )
+        pg._register_backend(
+            torch.device("cuda"), dist.ProcessGroup.BackendType.NCCL, default_backend
+        )
+        pg._set_default_backend(dist.ProcessGroup.BackendType.NCCL)
+        pg._set_group_name("split-options-test")
+        return pg, cpu_backend, default_backend
+
+    def test_split_group_clones_parent_options(self):
+        # getBackendOptions() returns the backend's live options_, and split()
+        # implementations write into what they are given, so splitGroup used to
+        # rewrite the parent's group_name/timeout and hand the child an object
+        # aliasing the parent's.
+        pg, cpu_backend, default_backend = self._make_group()
+        pg.split_group([0], timeout=timedelta(seconds=222), group_name="child")
+
+        for backend in (cpu_backend, default_backend):
+            self.assertIsNot(backend.split_opts, backend.options)
+            self.assertEqual(backend.options.group_name, "")
+            self.assertEqual(backend.options._timeout, timedelta(seconds=111))
+            self.assertEqual(backend.split_opts.group_name, "child")
+            self.assertEqual(backend.split_opts._timeout, timedelta(seconds=222))
+
+    def test_split_group_opts_apply_to_default_backend_only(self):
+        # An explicit `opts` describes the group's default backend, the same way
+        # pg_options does for init_process_group. Handing it to every device's
+        # backend made the others reject it (and silently fall back to their
+        # defaults, losing the caller's timeout).
+        pg, cpu_backend, default_backend = self._make_group()
+        opts = C10DBackend.Options("caller-supplied", timeout=timedelta(seconds=5))
+        pg.split_group([0], opts=opts, timeout=timedelta(seconds=222))
+
+        self.assertEqual(default_backend.split_opts.backend, "caller-supplied")
+        self.assertEqual(cpu_backend.split_opts.backend, "cpu-backend")
+        # The caller's object is not mutated either.
+        self.assertIsNot(default_backend.split_opts, opts)
+        self.assertEqual(opts.group_name, "")
+        self.assertEqual(opts._timeout, timedelta(seconds=5))
 
 
 class ProcessGroupWithDispatchedCollectivesTests(MultiProcessTestCase):

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -3480,6 +3480,77 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
     def test_bool_tensors(self):
         self._test_bool_tensors(backend="gloo")
 
+    @requires_gloo()
+    def test_split_group_does_not_alias_parent_options(self):
+        # Regression test: ProcessGroup::splitGroup used to hand the parent
+        # backend's live Options object to the child, so a split rewrote the
+        # parent's group_name/timeout and ProcessGroupGloo::split overwrote the
+        # parent's global_ranks_in_group with the child's ranks. The parent's
+        # next split then indexed that subgroup-sized vector out of bounds.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        c10d.init_process_group(
+            backend="gloo",
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+            timeout=timedelta(seconds=111),
+        )
+        pg = c10d.distributed_c10d._get_default_group()
+        cpu = torch.device("cpu")
+        parent_options = pg._get_backend(cpu).options
+        parent_group_name = parent_options.group_name
+
+        half = self.world_size // 2
+        halves = (
+            list(range(half))
+            if self.rank < half
+            else list(range(half, self.world_size))
+        )
+        child = pg.split_group(
+            halves, timeout=timedelta(seconds=222), group_name=f"halves{halves}"
+        )
+        child_options = child._get_backend(cpu).options
+        self.assertIsNot(child_options, parent_options)
+        self.assertEqual(parent_options.group_name, parent_group_name)
+        self.assertEqual(parent_options._timeout, timedelta(seconds=111))
+        self.assertEqual(parent_options.global_ranks_in_group, [])
+        self.assertEqual(child_options._timeout, timedelta(seconds=222))
+        self.assertEqual(child_options.global_ranks_in_group, halves)
+
+        # A second split of the same parent must still see the world's ranks.
+        parity = [r for r in range(self.world_size) if r % 2 == self.rank % 2]
+        second = pg.split_group(
+            parity, timeout=timedelta(seconds=333), group_name=f"parity{parity}"
+        )
+        self.assertEqual(second._get_backend(cpu).options.global_ranks_in_group, parity)
+
+        c10d.destroy_process_group()
+
+    @skip_if_lt_x_gpu(1)
+    @requires_gloo()
+    def test_split_group_keeps_gloo_options(self):
+        # dist.split_group used to substitute a deep copy of the accelerator
+        # backend's options for every device. On a gloo world that raised
+        # "cannot pickle _Options" (ProcessGroupGloo._Options has no
+        # __deepcopy__), and on a "cpu:gloo,cuda:nccl" world the gloo leg
+        # rejected the nccl options and fell back to Options::create_default(),
+        # dropping the caller's timeout and group_name.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        c10d.init_process_group(
+            backend="gloo",
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+            device_id=torch.device("cuda", self.rank % torch.cuda.device_count()),
+        )
+        ranks = list(range(self.world_size))
+        child = c10d.split_group(split_ranks=[ranks], timeout=timedelta(seconds=222))
+        options = child._get_backend(torch.device("cpu")).options
+        self.assertEqual(options._timeout, timedelta(seconds=222))
+        self.assertEqual(options.group_name, child.group_name)
+        self.assertEqual(options.global_ranks_in_group, ranks)
+        c10d.destroy_process_group()
+
 
 class GlooProcessGroupWithDispatchedCollectivesTests(
     test_c10d_common.ProcessGroupWithDispatchedCollectivesTests

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -297,6 +297,43 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             fut.wait()
 
     @requires_gloo()
+    def test_split_world_pg_created_after_another_gloo_pg(self):
+        # Regression test: ProcessGroupGloo::groupRanks() used to derive the
+        # identity rank mapping only when local_id_ == 0. local_id_ is a
+        # process-global counter over every ProcessGroupGloo constructed in the
+        # process, so a world-sized pg built after any other gloo pg (e.g. a
+        # stateless pg, or one inherited across fork) fell through to its empty
+        # global_ranks_in_group, and split() then indexed that empty vector and
+        # segfaulted on a null data pointer.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        # (1) burn local_id_ == 0 on an unrelated gloo pg.
+        self._create_process_group_gloo(
+            c10d.PrefixStore("prior", store),
+            self.rank,
+            self.world_size,
+            self.opts(group_name="prior"),
+        )
+        # (2) a world-sized pg: default options -> global_ranks_in_group empty.
+        pg = self._create_process_group_gloo(
+            c10d.PrefixStore("world", store),
+            self.rank,
+            self.world_size,
+            self.opts(group_name="world"),
+        )
+
+        ranks = list(range(self.world_size))
+        split = pg.split(
+            c10d.PrefixStore("split", store), ranks, self.opts(group_name="split")
+        )
+        self.assertIsNotNone(split)
+        self.assertEqual(split.options.global_ranks_in_group, ranks)
+
+        tensor = torch.full((4,), float(self.rank + 1))
+        split.allreduce([tensor]).wait()
+        expected = float(sum(r + 1 for r in ranks))
+        self.assertEqual(tensor, torch.full_like(tensor, expected))
+
+    @requires_gloo()
     def test_empty_tensors(self):
         store = c10d.FileStore(self.file_name, self.world_size)
         pg = self._create_process_group_gloo(

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
 import copy
+import glob
 import json
 import logging
 import os
@@ -374,10 +375,13 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
     def tearDown(self):
         super().tearDown()
-        try:
-            os.remove(self.file_name)
-        except OSError:
-            pass
+        # self.file_name plus anything a test derived from it, e.g. the flight
+        # recorder dumps of test_global_rank_of_pg_created_after_another_nccl_pg
+        for path in glob.glob(f"{self.file_name}*"):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
 
     @property
     def world_size(self):
@@ -1267,6 +1271,43 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         self.assertEqual(tensor, torch.full((1,), 0))
 
         dist.destroy_process_group()
+
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_global_rank_of_pg_created_after_another_nccl_pg(self):
+        # Regression test: ProcessGroupNCCL::globalRank() used to be a
+        # function-local static, so it was seeded by whichever pg was
+        # constructed first in the process (the constructor calls it while
+        # logging) and never updated. A stateless subgroup built before the
+        # default pg therefore froze its own group-local rank as "the global
+        # rank" for every pg in the process. Checked here through the flight
+        # recorder dump, which is named after globalRank(); the same value also
+        # names broadcastSignal(kStoreDumpKey) and picks the device in
+        # guessDeviceId(), which split() relies on.
+        trace_prefix = f"{self.file_name}_trace_"
+        os.environ["TORCH_NCCL_ENABLE_MONITORING"] = "0"
+        os.environ["TORCH_NCCL_EXTRA_DUMP_ON_EXEC"] = "1"
+        os.environ["TORCH_FR_DUMP_TEMP_FILE"] = trace_prefix
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        # (1) a single-rank stateless pg, constructed before the default pg.
+        prior = c10d.ProcessGroupNCCL(c10d.PrefixStore("prior", store), 0, 1)
+        # (2) the real default pg, whose rank is the global one.
+        c10d.init_process_group(
+            "nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=c10d.PrefixStore("world", store),
+            pg_options=self.opts(),
+            device_id=device,
+        )
+        pg = c10d.distributed_c10d._get_default_group()
+        dist.all_reduce(torch.ones(1, device=device))
+
+        # abort() dumps the flight recorder to <prefix><globalRank()>.
+        pg._get_backend(device).abort()
+        self.assertTrue(os.path.exists(f"{trace_prefix}{self.rank}"))
+        del prior
 
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1226,6 +1226,50 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_comm_split_world_pg_created_after_another_nccl_pg(self):
+        # Regression test: ProcessGroupNCCL::groupRanks() used to derive the
+        # identity rank mapping only when local_id_ == 0. local_id_ is a
+        # process-global counter over every ProcessGroupNCCL constructed in the
+        # process, so a default pg built after any other nccl pg (e.g. a
+        # stateless pg, one inherited across fork, or an earlier
+        # init_process_group that was destroyed) fell through to its empty
+        # global_ranks_in_group, and split() then indexed that empty vector and
+        # segfaulted on a null data pointer.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        # (1) burn local_id_ == 0 on an unrelated nccl pg.
+        c10d.init_process_group(
+            "nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=c10d.PrefixStore("prior", store),
+        )
+        dist.destroy_process_group()
+        # (2) the real default pg -> global_ranks_in_group empty.
+        c10d.init_process_group(
+            "nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=c10d.PrefixStore("world", store),
+            pg_options=self.opts(),
+            device_id=device,
+        )
+        pg = c10d.distributed_c10d._get_default_group()
+
+        ranks = list(range(self.world_size))
+        ng = c10d.split_group(pg, [ranks])
+        self.assertIsNotNone(ng)
+        self.assertEqual(dist.get_process_group_ranks(ng), ranks)
+        self.assertEqual(ng._get_backend(device).options.global_ranks_in_group, ranks)
+
+        tensor = torch.full((1,), self.rank).cuda(device)
+        dist.broadcast(tensor, 0, group=ng)
+        self.assertEqual(tensor, torch.full((1,), 0))
+
+        dist.destroy_process_group()
+
+    @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_comm_split_group_mixed_backend(self):
         # Test `ncclCommSplit` for smaller subgroups of the world when
         # we've passed a specific device_id to init_process_group.

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -623,6 +623,45 @@ class ProcessGroupNCCL2ObservabilityTest(MultiProcContinuousTest):
             for group in groups:
                 dist.destroy_process_group(group)
 
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_split_group_child_global_ranks(self) -> None:
+        # nccl2's split() copied everything into the child's options except the
+        # parent-global rank map, which FlightRecorderHook then falls back to
+        # identity ranks for -- so a child's recorded membership claimed world
+        # ranks instead of its own.
+        pg = dist.distributed_c10d._get_default_group()
+        # Bring the parent communicator up before splitting it.
+        dist.all_reduce(torch.ones(4, device=self.device))
+        half = self.world_size // 2
+        halves = (
+            list(range(half))
+            if self.rank < half
+            else list(range(half, self.world_size))
+        )
+        child = pg.split_group(halves, group_name=f"halves{halves}")
+        child_options = child._get_backend(self.device).options
+        self.assertEqual(child_options.global_ranks_in_group, halves)
+        if hasattr(child_options.config, "comm_name"):
+            # split() points config.commName at the group_name string for the
+            # ncclCommSplit call; storing that pointer left the child holding
+            # one that outlives its string.
+            self.assertIsNone(child_options.config.comm_name)
+
+        # Splitting the child again must map its ranks through the parent's map
+        # rather than treating them as world ranks.
+        mine = [halves.index(self.rank)]
+        grandchild = child.split_group(mine, group_name=f"single{self.rank}")
+        self.assertEqual(
+            grandchild._get_backend(self.device).options.global_ranks_in_group,
+            [self.rank],
+        )
+
+        t = torch.full((4,), float(self.rank), device=self.device)
+        dist.all_reduce(t, group=child)
+        expected = float(sum(halves))
+        self.assertEqual(t, torch.full_like(t, expected))
+
 
 _UNINITIALIZED_CUDA_SCRIPT = """\
 import torch

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -300,6 +300,96 @@ class ProcessGroupNCCL2ExpandableSegmentsTest(MultiProcContinuousTest):
             self.assertEqual(chunk, torch.full_like(chunk, rank))
 
 
+class ProcessGroupNCCL2MemPoolTest(MultiProcContinuousTest):
+    """register_mem_pool / deregister_mem_pool: the NCCL user-buffer path that
+    Megatron's nccl_allocator drives (megatron/core/nccl_allocator.py)."""
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    def _backend(self):
+        # nccl2 bootstraps its communicator on the first collective, and
+        # register_mem_pool needs it up (as it does on the stock backend, whose
+        # test eagerly inits via init_process_group(device_id=...) instead).
+        dist.all_reduce(torch.zeros(1, device=self.device))
+        torch.cuda.synchronize()
+        return dist.get_backend_impl(device=self.device)
+
+    @property
+    def _all_reduced(self) -> float:
+        return float(sum(range(self.world_size)))
+
+    def _pool_tensor(self, pool, numel: int = 1024 * 1024) -> torch.Tensor:
+        with torch.cuda.use_mem_pool(pool):
+            return torch.full((numel,), float(self.rank), device=self.device)
+
+    def _check_all_reduce_over_pool(self, symm: bool) -> None:
+        backend = self._backend()
+        pool = torch.cuda.MemPool(backend.mem_allocator)
+        tensor = self._pool_tensor(pool)
+        backend.register_mem_pool(pool, symm=symm)
+        try:
+            dist.all_reduce(tensor)
+            torch.cuda.synchronize()
+            self.assertEqual(tensor, torch.full_like(tensor, self._all_reduced))
+        finally:
+            backend.deregister_mem_pool(pool)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_register_mem_pool(self) -> None:
+        self._check_all_reduce_over_pool(symm=False)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_register_mem_pool_symmetric(self) -> None:
+        self._check_all_reduce_over_pool(symm=True)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_register_mem_pool_round_trip(self) -> None:
+        # Megatron re-enters its allocator context once per bucket: deregister,
+        # grow the pool, register again. Neither leg may trip over a segment
+        # the caching-allocator hook already registered, and the second
+        # register has to pick up segments the hook never saw (reused ones).
+        backend = self._backend()
+        pool = torch.cuda.MemPool(backend.mem_allocator)
+        first = self._pool_tensor(pool)
+        backend.register_mem_pool(pool, symm=True)
+        backend.deregister_mem_pool(pool)
+        second = self._pool_tensor(pool)
+        backend.register_mem_pool(pool, symm=True)
+        try:
+            for tensor in (first, second):
+                dist.all_reduce(tensor)
+            torch.cuda.synchronize()
+            for tensor in (first, second):
+                self.assertEqual(tensor, torch.full_like(tensor, self._all_reduced))
+        finally:
+            backend.deregister_mem_pool(pool)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_deregister_unregistered_mem_pool_raises(self) -> None:
+        backend = self._backend()
+        pool = torch.cuda.MemPool(backend.mem_allocator)
+        with self.assertRaisesRegex(RuntimeError, "not previously registered"):
+            backend.deregister_mem_pool(pool)
+
+
 class ProcessGroupNCCLLazyTest(ProcessGroupNCCL2Test):
     @classmethod
     def backend_str(cls) -> str:

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -5,10 +5,12 @@
 import ctypes
 import os
 import time
+from datetime import timedelta
+from unittest import mock
 
 import torch
 import torch.distributed as dist
-from torch._C._distributed_c10d import ReconfigureOptions
+from torch._C._distributed_c10d import ErrorType, ReconfigureOptions
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_nccl,
@@ -142,6 +144,110 @@ class ProcessGroupNCCLLegacyNonblockingTest(ProcessGroupNCCL2NonblockingTest):
     @classmethod
     def backend_str(cls) -> str:
         return "nccl-legacy"
+
+
+class _ProcessGroupNCCL2SubgroupTest(MultiProcContinuousTest):
+    """Base for tests that tear a group down.
+
+    They run on a throwaway subgroup so the class-wide default group survives;
+    a collective on that default group afterwards is what proves the process is
+    still alive and healthy.
+    """
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    def _new_subgroup(self, timeout=timedelta(seconds=60)):
+        return dist.new_group(
+            backend="nccl2",
+            use_local_synchronization=True,
+            timeout=timeout,
+        )
+
+    def _check_all_reduce(self, group=None) -> None:
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t, group=group)
+        self.assertEqual(t, torch.full_like(t, self.world_size))
+
+
+class ProcessGroupNCCL2AbortTest(_ProcessGroupNCCL2SubgroupTest):
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_backend_abort_on_healthy_group(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        backend = pg._get_backend(self.device)
+        # Must return instead of ::abort()ing the process, like stock NCCL.
+        backend.abort()
+        self.assertEqual(backend.get_error(), ErrorType.COMM_ERROR)
+
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_abort_process_group_on_healthy_group(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        dist.distributed_c10d._abort_process_group(pg)
+        self._check_all_reduce()
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_destroy_process_group_returns(self) -> None:
+        pg = self._new_subgroup()
+        self._check_all_reduce(pg)
+
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
+
+
+class ProcessGroupNCCL2WatchdogNoTearDownTest(_ProcessGroupNCCL2SubgroupTest):
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_timeout_without_process_abort(self) -> None:
+        # NoHandling is how a stock NCCL user opts out of the process being
+        # taken down by the watchdog; nccl2 reads the same variable, when the
+        # backend is constructed.
+        env = {"TORCH_NCCL_ASYNC_ERROR_HANDLING": "0"}
+        with mock.patch.dict(os.environ, env):
+            pg = self._new_subgroup(timeout=timedelta(seconds=5))
+        backend = pg._get_backend(self.device)
+        self._check_all_reduce(pg)
+
+        if self.rank == 0:
+            # Nobody else joins, so this can never complete and the watchdog
+            # trips. Without the tear-down the process must survive and the
+            # timeout must become readable through get_error().
+            dist.all_reduce(torch.ones(1024, device=self.device), group=pg)
+            deadline = time.time() + 60
+            while time.time() < deadline and backend.get_error() == ErrorType.SUCCESS:
+                time.sleep(0.5)
+            self.assertEqual(backend.get_error(), ErrorType.TIMEOUT)
+            # The next collective on the timed-out group raises rather than
+            # silently proceeding on a dead communicator.
+            with self.assertRaises(RuntimeError):
+                dist.all_reduce(torch.ones(4, device=self.device), group=pg)
+        else:
+            time.sleep(30)
+
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
 
 
 class ProcessGroupNCCL2ExpandableSegmentsTest(MultiProcContinuousTest):

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -2,6 +2,8 @@
 #
 # Tests specific to the in-tree torchcomms NCCL backends.
 
+import ctypes
+import os
 import time
 
 import torch
@@ -240,6 +242,94 @@ class ProcessGroupNCCLLazyNonblockingTest(ProcessGroupNCCL2NonblockingTest):
     @classmethod
     def backend_str(cls) -> str:
         return "nccl-lazy"
+
+
+def _live_env(name: str) -> str | None:
+    # os.environ is a snapshot taken at interpreter startup and does NOT observe
+    # values set later by C++ via setenv (which is how the nccl2 backend forces
+    # NCCL_ALGO under deterministic mode), so read the live environ via libc.
+    libc = ctypes.CDLL(None)
+    libc.getenv.restype = ctypes.c_char_p
+    val = libc.getenv(name.encode())
+    return val.decode() if val is not None else None
+
+
+class _DeterministicNVLSTest(MultiProcContinuousTest):
+    """Base for the nccl2 deterministic-mode NVLS-disable hook.
+
+    Under torch deterministic mode, if the user has not set NCCL_ALGO the nccl2
+    backend forces NCCL_ALGO=^NVLS (NVLS can give non-deterministic reductions),
+    mirroring the stock ProcessGroupNCCL. The hook runs during PG init and the
+    env var persists once set, so each scenario is its own subclass: every class
+    gets a freshly spawned process pool (clean deterministic flag / NCCL_ALGO)
+    and configures the env in _init_pg before the PG (and thus the hook) runs.
+    """
+
+    deterministic: bool = False
+    preset_nccl_algo: str | None = None
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file) -> None:
+        if cls.preset_nccl_algo is not None:
+            os.environ["NCCL_ALGO"] = cls.preset_nccl_algo
+        else:
+            os.environ.pop("NCCL_ALGO", None)
+        if cls.deterministic:
+            torch.use_deterministic_algorithms(True)
+        super()._init_pg(rank, world_size, rdvz_file)
+
+    def _all_reduce_and_read_algo(self) -> str | None:
+        # Force the (possibly lazy) nccl2 comm to initialize so the hook runs,
+        # and confirm the reduction is numerically correct under the chosen algo.
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t)
+        torch.cuda.synchronize()
+        self.assertEqual(t, torch.full_like(t, self.world_size))
+        return _live_env("NCCL_ALGO")
+
+
+class ProcessGroupNCCL2DeterministicNVLSDisabledTest(_DeterministicNVLSTest):
+    deterministic = True
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_deterministic_disables_nvls(self) -> None:
+        self.assertEqual(self._all_reduce_and_read_algo(), "^NVLS")
+
+
+class ProcessGroupNCCL2DeterministicNVLSPresetTest(_DeterministicNVLSTest):
+    deterministic = True
+    preset_nccl_algo = "Ring"
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_deterministic_respects_user_nccl_algo(self) -> None:
+        self.assertEqual(self._all_reduce_and_read_algo(), "Ring")
+
+
+class ProcessGroupNCCL2NonDeterministicNVLSTest(_DeterministicNVLSTest):
+    deterministic = False
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_non_deterministic_does_not_force_nccl_algo(self) -> None:
+        self.assertIsNone(self._all_reduce_and_read_algo())
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -3,9 +3,11 @@
 # Tests specific to the in-tree torchcomms NCCL backends.
 
 import ctypes
+import json
 import os
 import subprocess
 import sys
+import tempfile
 import time
 import unittest
 from datetime import timedelta
@@ -535,6 +537,91 @@ class ProcessGroupNCCL2NonDeterministicNVLSTest(_DeterministicNVLSTest):
     @skip_if_lt_x_gpu(2)
     def test_non_deterministic_does_not_force_nccl_algo(self) -> None:
         self.assertIsNone(self._all_reduce_and_read_algo())
+
+
+class ProcessGroupNCCL2ObservabilityTest(MultiProcContinuousTest):
+    """What nccl2 reports about a collective to profilers and flight recorders."""
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_profiler_sequence_number_is_per_group(self) -> None:
+        # TracingGuard used to record a process-global counter of its own
+        # instead of the issuing group's sequence_number_, so a rank's
+        # numbering depended on how it interleaved its other groups'
+        # collectives -- and profilers pair collectives across ranks by
+        # (process group, sequence number).
+        groups = [
+            dist.new_group(
+                backend=self.backend_str(),
+                use_local_synchronization=True,
+                timeout=timedelta(seconds=60),
+            )
+            for _ in range(2)
+        ]
+        t = torch.ones(4, device=self.device)
+        try:
+            # Bootstrap both communicators outside the profiled region.
+            for group in groups:
+                dist.all_reduce(t, group=group)
+            torch.cuda.synchronize()
+            # Three collectives on the first group, one on the second: a
+            # process-global counter would number the second group's collective
+            # after all of the first group's.
+            counts = [3, 1]
+            base = [group._get_sequence_number_for_group() for group in groups]
+
+            with torch.profiler.profile(
+                activities=[
+                    torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA,
+                ],
+                record_shapes=True,
+            ) as prof:
+                for group, count in zip(groups, counts):
+                    for _ in range(count):
+                        dist.all_reduce(t, group=group)
+                torch.cuda.synchronize()
+
+            with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+                trace_path = f.name
+            try:
+                prof.export_chrome_trace(trace_path)
+                with open(trace_path) as f:
+                    trace = json.load(f)
+            finally:
+                os.unlink(trace_path)
+
+            recorded: dict[str, set[int]] = {}
+            for ev in trace.get("traceEvents", []):
+                args = ev.get("args", {})
+                if "Process Group Name" in args and "Seq" in args:
+                    recorded.setdefault(args["Process Group Name"], set()).add(
+                        args["Seq"]
+                    )
+            for group, count, first in zip(groups, counts, base):
+                self.assertEqual(
+                    sorted(recorded.get(group.group_name, set())),
+                    [first + i + 1 for i in range(count)],
+                )
+        finally:
+            for group in groups:
+                dist.destroy_process_group(group)
 
 
 _UNINITIALIZED_CUDA_SCRIPT = """\

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -4,7 +4,10 @@
 
 import ctypes
 import os
+import subprocess
+import sys
 import time
+import unittest
 from datetime import timedelta
 from unittest import mock
 
@@ -16,7 +19,13 @@ from torch.testing._internal.common_distributed import (
     requires_nccl,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_CUDA
+from torch.testing._internal.common_utils import (
+    IS_FBCODE,
+    IS_SANDCASTLE,
+    run_tests,
+    TEST_CUDA,
+    TestCase,
+)
 
 
 class ProcessGroupNCCL2Test(MultiProcContinuousTest):
@@ -436,6 +445,66 @@ class ProcessGroupNCCL2NonDeterministicNVLSTest(_DeterministicNVLSTest):
     @skip_if_lt_x_gpu(2)
     def test_non_deterministic_does_not_force_nccl_algo(self) -> None:
         self.assertIsNone(self._all_reduce_and_read_algo())
+
+
+_UNINITIALIZED_CUDA_SCRIPT = """\
+import torch
+import torch.distributed as dist
+
+# Nothing above this point may touch torch.cuda: the caching allocator is
+# brought up lazily by the Python torch.cuda layer, and neither CUDAGuard nor
+# stream/event creation does it.
+dist.init_process_group(
+    "cpu:gloo,cuda:nccl2",
+    rank=0,
+    world_size=1,
+    store=dist.HashStore(),
+    device_id=torch.device("cuda:0"),
+)
+assert not torch.cuda.is_initialized(), "creating a process group initialized CUDA"
+{extra}
+dist.destroy_process_group()
+"""
+
+
+class ProcessGroupNCCL2UninitializedCudaTest(TestCase):
+    """Constructing a process group must not need the CUDA caching allocator up.
+
+    Eager init (`init_process_group(device_id=...)`) allocated the barrier
+    buffer from the caching allocator, so a process that had made no torch.cuda
+    call died inside init_process_group with "Allocator not initialized for
+    device 0". Any external launcher or library that builds the PG before
+    touching CUDA hits this. Runs in a subprocess because the harness (and
+    every other test here) calls torch.cuda.set_device in setUp, which hides it.
+    """
+
+    def _run_child(self, extra: str = "") -> None:
+        try:
+            subprocess.check_output(
+                [sys.executable, "-c", _UNINITIALIZED_CUDA_SCRIPT.format(extra=extra)],
+                stderr=subprocess.STDOUT,
+                cwd=os.path.dirname(os.path.realpath(__file__)),
+                timeout=300,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("child process timed out")
+        except subprocess.CalledProcessError as e:
+            self.fail(f"child process failed with:\n{e.output.decode()}")
+
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "subprocess test fails in fbcode")
+    @requires_nccl()
+    @skip_if_lt_x_gpu(1)
+    def test_eager_init(self) -> None:
+        self._run_child()
+
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "subprocess test fails in fbcode")
+    @requires_nccl()
+    @skip_if_lt_x_gpu(1)
+    def test_barrier_after_init(self) -> None:
+        # The allocation is merely deferred, so barrier() is the second entrance
+        # into the same allocator: without lazyInitDevice() it hits the identical
+        # assert one call later.
+        self._run_child("dist.barrier()")
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -777,6 +777,50 @@ class TestFakePG(TestCase):
 
     @skipIfHpu
     @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
+    def test_split_group_backend_filter(self):
+        # A fake world's backend string is the bare name "fake", which
+        # BackendConfig expands to every device fake supports. split_group's
+        # filter validation used to re-expand it through
+        # Backend.default_device_backend_map -- where fake is only the default
+        # for hpu -- so every device-qualified filter was rejected as "not
+        # present in the parent" and the bare "fake" filter selected hpu alone.
+        store = FakeStore()
+        dist.init_process_group(
+            backend="fake",
+            rank=0,
+            world_size=2,
+            store=store,
+            device_id=torch.device(device_type, 0),
+        )
+        parent_pg = dist.distributed_c10d._get_default_group()
+        parent_devices = {d.type for d in parent_pg._device_types}
+        self.assertIn(device_type, parent_devices)
+
+        # A bare filter naming the parent's backend keeps every parent device.
+        full = dist.split_group(split_ranks=[[0, 1]], backend="fake")
+        self.assertEqual({d.type for d in full._device_types}, parent_devices)
+
+        # A device-qualified filter keeps exactly the named devices. The C++
+        # split additionally requires the filter to keep the parent's default
+        # backend device, which for an all-fake parent is cpu.
+        cpu_only = dist.split_group(split_ranks=[[0, 1]], backend="cpu:fake")
+        self.assertEqual({d.type for d in cpu_only._device_types}, {"cpu"})
+
+        pair = dist.split_group(
+            split_ranks=[[0, 1]], backend=f"cpu:fake,{device_type}:fake"
+        )
+        self.assertEqual({d.type for d in pair._device_types}, {"cpu", device_type})
+
+        # Filters that genuinely do not match the parent are still rejected.
+        with self.assertRaisesRegex(ValueError, "is not present in the parent"):
+            dist.split_group(split_ranks=[[0, 1]], backend="mps:fake")
+        with self.assertRaisesRegex(ValueError, "Backend mismatch"):
+            dist.split_group(split_ranks=[[0, 1]], backend="cpu:gloo")
+        with self.assertRaisesRegex(ValueError, "is not present in the parent"):
+            dist.split_group(split_ranks=[[0, 1]], backend="gloo")
+
+    @skipIfHpu
+    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
     def test_split_group_non_member(self):
         store = FakeStore()
         dist.init_process_group(

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -11,6 +11,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from sys import platform
+from unittest import mock
 
 import torch
 import torch.distributed as dist
@@ -934,6 +935,40 @@ class RendezvousTCPTest(TestCase):
         gen0 = dist.rendezvous(url + "&rank=0&use_libuv=1")
         store0, _, _ = next(gen0)
         self.assertTrue(store0.libuvBackend)
+
+    def test_agent_store_ignored_for_other_address(self):
+        # torchrun's elastic agent exports TORCHELASTIC_USE_AGENT_STORE into
+        # every worker, meaning "the agent serves a store at
+        # MASTER_ADDR:MASTER_PORT". _create_c10d_store used to honor it for any
+        # address it was handed, so a private store on a caller-chosen port
+        # became client-only on every rank, nobody ever started a server and
+        # every rank blocked in connect-retry until the store timeout.
+        url = self.create_tcp_url()
+        env = {
+            "TORCHELASTIC_USE_AGENT_STORE": "True",
+            "MASTER_ADDR": DEFAULT_HOSTNAME,
+            "MASTER_PORT": str(common.find_free_port()),
+        }
+        with mock.patch.dict(os.environ, env):
+            gen0 = dist.rendezvous(url + "&rank=0", timeout=timedelta(seconds=10))
+            store0, _, _ = next(gen0)
+        store0.set("key0", "value0")
+        self.assertEqual(b"value0", store0.get("key0"))
+
+    def test_agent_store_honored_for_master_address(self):
+        # The flip side: at MASTER_ADDR:MASTER_PORT the agent is the server, so
+        # every rank must stay a client. Point at a port nothing listens on and
+        # check we fail to connect rather than silently starting a server.
+        port = common.find_free_port()
+        url = f"tcp://{DEFAULT_HOSTNAME}:{port:d}?world_size=1&rank=0"
+        env = {
+            "TORCHELASTIC_USE_AGENT_STORE": "True",
+            "MASTER_ADDR": DEFAULT_HOSTNAME,
+            "MASTER_PORT": str(port),
+        }
+        with mock.patch.dict(os.environ, env):
+            with self.assertRaises(DistNetworkError):
+                next(dist.rendezvous(url, timeout=timedelta(seconds=1)))
 
 
 class DummyStore(dist.Store):

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -94,6 +94,18 @@ class TORCH_API Backend : public torch::CustomClassHolder {
     ~Options() override = default;
     Options(const Options&) = default;
 
+    // Returns an independent copy, preserving the concrete type.
+    // ProcessGroup::splitGroup()/mergeRemoteGroup() clone the options they
+    // hand to a child backend: getBackendOptions() returns the parent's live
+    // options_, and split()/merge() implementations mutate what they are given
+    // (group_name, timeout, global_ranks_in_group, split_color, ...), so
+    // sharing one object corrupts the parent. A subclass that adds fields must
+    // override this or it would be sliced; ProcessGroup detects a sliced clone
+    // and falls back to sharing rather than handing a backend the wrong type.
+    virtual c10::intrusive_ptr<Options> clone() const {
+      return c10::make_intrusive<Options>(*this);
+    }
+
     std::chrono::milliseconds timeout;
 
     // backend name

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -29,6 +29,10 @@ class FakeProcessGroup : public Backend {
   struct Options : Backend::Options {
     explicit Options() : Backend::Options("fake") {}
 
+    c10::intrusive_ptr<Backend::Options> clone() const override {
+      return c10::make_intrusive<Options>(*this);
+    }
+
     int fake_option = 0;
     bool error_on_collective = false;
   };

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -519,7 +519,7 @@ ncclResult_t NCCLComm::registerSegment(
   return ncclSuccess;
 }
 
-ncclResult_t NCCLComm::deregisterSegment(void* ptr, bool window /*false*/) {
+ncclResult_t NCCLComm::deregisterSegment(void* ptr) {
   LockType lock(mutex_);
   TORCH_CHECK(
       registeredSegmentHandles_.count(ptr) == 1,
@@ -532,7 +532,10 @@ ncclResult_t NCCLComm::deregisterSegment(void* ptr, bool window /*false*/) {
   // Use getNcclComm to make sure comm is ready before calling nccl APIs
   auto comm = getNcclComm();
 #ifdef NCCL_HAS_COMM_WINDOW_REGISTER
-  if (window) {
+  // Pick the API from how the segment was actually registered: a caller's view
+  // of a pool ("symmetric") can disagree with an individual segment, and
+  // passing a ncclReg* to the window API (or vice versa) is a type confusion.
+  if (registeredSegmentHandles_[ptr].second) {
     C10D_NCCL_CHECK(
         ncclCommWindowDeregister(comm, (ncclWindow_t)handle),
         c10::str(

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -334,7 +334,8 @@ class NCCLComm {
       bool errorOnRereg = true,
       bool window = false);
 
-  ncclResult_t deregisterSegment(void* ptr, bool window = false);
+  // Uses the window vs local API recorded when the segment was registered.
+  ncclResult_t deregisterSegment(void* ptr);
 
   std::string repr() const;
 

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -6,11 +6,35 @@
 #include <fmt/ranges.h>
 
 #include <algorithm>
+#include <typeinfo>
 #include <unordered_set>
 
 #include <torch/csrc/distributed/c10d/PrefixStore.hpp>
 
 namespace c10d {
+
+namespace {
+
+// Options handed to a child backend must never alias the parent's (or the
+// caller's) object: Backend::getBackendOptions() returns the backend's live
+// options_, and split()/merge() implementations write into what they are given
+// (ProcessGroupGloo::split overwrites global_ranks_in_group,
+// ProcessGroupNCCL::split also sets split_from/split_color). Sharing one object
+// leaves the parent describing its child's ranks, which the parent's next split
+// then indexes out of bounds.
+c10::intrusive_ptr<Backend::Options> cloneOptions(
+    const c10::intrusive_ptr<Backend::Options>& opts) {
+  auto copy = opts->clone();
+  if (copy == nullptr || typeid(*copy) != typeid(*opts)) {
+    // An out-of-tree Options subclass that does not override clone() would be
+    // sliced. Keep the legacy aliasing behavior for it rather than handing its
+    // backend an object of the wrong type.
+    return opts;
+  }
+  return copy;
+}
+
+} // namespace
 
 std::string opTypeToString(OpType opType) {
   switch (opType) {
@@ -202,6 +226,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
   std::string groupDesc = desc.has_value()
       ? desc.value()
       : c10::str(getGroupDesc(), ":split:", incrementSplitCount());
+  std::unordered_map<BackendType, c10::intrusive_ptr<Backend>> splitBackends;
   for (const auto& pair : deviceTypeToBackendType_) {
     c10::DeviceType deviceType = pair.first;
     BackendType backendType = pair.second;
@@ -210,9 +235,27 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
       continue;
     }
 
+    // One backend instance can serve several device types -- a gloo world maps
+    // both cpu and cuda to the same ProcessGroupGloo, and setBackend() reuses
+    // whatever is already registered for a backend type. Split it once: the
+    // second child would be thrown away by setBackend() below, but only after
+    // rendezvousing on the same store prefix as the real child, which races
+    // with it and hangs.
+    auto splitIt = splitBackends.find(backendType);
+    if (splitIt != splitBackends.end()) {
+      newGroup->setBackend(deviceType, backendType, splitIt->second);
+      continue;
+    }
+
     auto parentBackend = getBackend(deviceType);
-    auto backendOpts =
-        opts.has_value() ? opts.value() : parentBackend->getBackendOptions();
+    // `opts` describes the group's default backend, mirroring what
+    // `pg_options` means for init_process_group; a backend of another type
+    // would reject it (or worse, silently fall back to defaults and drop the
+    // caller's timeout), so those inherit the parent's own options instead.
+    auto backendOpts = cloneOptions(
+        opts.has_value() && backendType == backendType_
+            ? opts.value()
+            : parentBackend->getBackendOptions());
     backendOpts->group_name = groupName;
     backendOpts->timeout =
         timeout.has_value() ? timeout.value() : backendOpts->timeout;
@@ -228,6 +271,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
       newGroup->setDefaultBackend(backendType_);
     }
     newGroup->setBackend(deviceType, backendType, splitBackend);
+    splitBackends.emplace(backendType, splitBackend);
   }
 
   if (!newGroup) {
@@ -252,11 +296,18 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::mergeRemoteGroup(
   std::string groupDesc = opts.group_desc.has_value()
       ? opts.group_desc.value()
       : c10::str(getGroupDesc(), ":merge");
+  std::unordered_map<BackendType, c10::intrusive_ptr<Backend>> mergedBackends;
   for (const auto& pair : deviceTypeToBackendType_) {
     c10::DeviceType deviceType = pair.first;
     BackendType backendType = pair.second;
+    // Merge each backend instance once; see the same guard in splitGroup().
+    auto mergedIt = mergedBackends.find(backendType);
+    if (mergedIt != mergedBackends.end()) {
+      newGroup->setBackend(deviceType, backendType, mergedIt->second);
+      continue;
+    }
     auto parentBackend = getBackend(deviceType);
-    auto backendOpts = parentBackend->getBackendOptions();
+    auto backendOpts = cloneOptions(parentBackend->getBackendOptions());
     backendOpts->group_name = groupName;
     backendOpts->timeout = opts.timeout;
     auto mergedBackend = parentBackend->merge(store, backendOpts, rank, size);
@@ -270,6 +321,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::mergeRemoteGroup(
       newGroup->setDefaultBackend(backendType_);
     }
     newGroup->setBackend(deviceType, backendType, mergedBackend);
+    mergedBackends.emplace(backendType, mergedBackend);
   }
 
   if (!newGroup) {

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -753,7 +753,20 @@ void ProcessGroupGloo::runLoop(int workerIndex) {
 }
 
 const std::vector<uint64_t>& ProcessGroupGloo::groupRanks() const {
-  if (options_->global_ranks_in_group.empty() && local_id_ == 0) {
+  // An empty global_ranks_in_group means "this group spans the whole world, in
+  // rank order": _new_process_group_helper() only fills the vector in for
+  // subgroups, and a directly-constructed (stateless) ProcessGroupGloo leaves
+  // it at its default. Deriving the identity mapping is therefore the right
+  // answer whenever it is empty.
+  //
+  // This must NOT be gated on local_id_ == 0. local_id_ is a process-global
+  // counter over every ProcessGroupGloo ever constructed in this process, so
+  // the default group only gets 0 when it happens to be the first gloo backend
+  // built. If any gloo pg was created earlier -- a stateless pg, or one
+  // inherited across fork() -- the default group fell through to the empty
+  // global_ranks_in_group below and split() then indexed an empty vector,
+  // segfaulting on a null data pointer.
+  if (options_->global_ranks_in_group.empty()) {
     if (defaultRanks_.size() != static_cast<size_t>(size_)) {
       defaultRanks_.resize(size_);
       std::iota(defaultRanks_.begin(), defaultRanks_.end(), 0);

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -259,6 +259,10 @@ class TORCH_API ProcessGroupGloo : public Backend {
     static c10::intrusive_ptr<Options> create_default(
         std::chrono::milliseconds timeout = kBackendDefaultTimeout);
 
+    c10::intrusive_ptr<Backend::Options> clone() const override {
+      return c10::make_intrusive<Options>(*this);
+    }
+
     std::vector<std::shared_ptr<::gloo::transport::Device>> devices;
     int threads{2};
   };

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -957,6 +957,17 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     std::iota(defaultRanks_.begin(), defaultRanks_.end(), 0);
   }
 
+  // groupRanks() maps this group's ranks onto world ranks, so
+  // groupRanks()[rank_] is this process's global rank. Compute it here, before
+  // the watchdog and heartbeat monitor threads that read it are started, so
+  // globalRank() is a pure read of state published by thread creation. A merged
+  // group inherits its parent's (shorter) global_ranks_in_group, so fall back
+  // to rank_ instead of reading out of bounds.
+  const auto& ranks = groupRanks();
+  globalRank_ = rank_ < static_cast<int>(ranks.size())
+      ? static_cast<int>(ranks[rank_])
+      : rank_;
+
   // getNcclVersion needs to get called before launching threads which can
   // potentially call getenv. getNcclVersion internally calls setenv to set some
   // environment variables from config file, which can race with getenv from
@@ -2667,8 +2678,14 @@ const std::string& ProcessGroupNCCL::logPrefix() const {
 }
 
 const int& ProcessGroupNCCL::globalRank() const {
-  static int globalRank = rank_;
-  return globalRank;
+  // This must NOT be a function-local static. A static is seeded by whichever
+  // ProcessGroupNCCL is constructed first in the process -- the constructor
+  // calls globalRank() while logging -- and never updated, so if that first
+  // group is a subgroup whose group-local rank differs from the world rank,
+  // every later group reports the wrong global rank: flight recorder dumps
+  // land in another rank's file, broadcastSignal(kStoreDumpKey) names the wrong
+  // rank, and guessDeviceId() (used by split()) picks the wrong CUDA device.
+  return globalRank_;
 }
 
 const c10::intrusive_ptr<Store>& ProcessGroupNCCL::globalStore() const {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -949,6 +949,14 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       "ProcessGroupNCCL does not support enable_reconfigure "
       "(reconfigure-based fault tolerance).");
 
+  // An empty global_ranks_in_group means "this group spans the whole world, in
+  // rank order"; see groupRanks(). Materialize that mapping here rather than
+  // lazily, so groupRanks() is a pure read and needs no synchronization.
+  if (options_->global_ranks_in_group.empty()) {
+    defaultRanks_.resize(size_);
+    std::iota(defaultRanks_.begin(), defaultRanks_.end(), 0);
+  }
+
   // getNcclVersion needs to get called before launching threads which can
   // potentially call getenv. getNcclVersion internally calls setenv to set some
   // environment variables from config file, which can race with getenv from
@@ -2668,10 +2676,22 @@ const c10::intrusive_ptr<Store>& ProcessGroupNCCL::globalStore() const {
 }
 
 const std::vector<uint64_t>& ProcessGroupNCCL::groupRanks() const {
-  if (options_->global_ranks_in_group.empty() && local_id_ == 0) {
-    static std::vector<uint64_t> globalRanks(size_);
-    std::iota(globalRanks.begin(), globalRanks.end(), 0);
-    return globalRanks;
+  // An empty global_ranks_in_group means "this group spans the whole world, in
+  // rank order": _new_process_group_helper() only fills the vector in for
+  // subgroups, and a directly-constructed (stateless) ProcessGroupNCCL leaves
+  // it at its default. defaultRanks_ (built in the constructor) is therefore
+  // the right answer whenever it is empty.
+  //
+  // This must NOT be gated on local_id_ == 0. local_id_ is a process-global
+  // counter over every ProcessGroupNCCL ever constructed in this process, so
+  // the default group only gets 0 when it happens to be the first NCCL backend
+  // built. If any NCCL pg was created earlier -- a stateless pg, one inherited
+  // across fork(), or simply a previous init_process_group() that has since
+  // been destroyed -- the default group fell through to the empty
+  // global_ranks_in_group below and split() then indexed an empty vector,
+  // segfaulting on a null data pointer.
+  if (options_->global_ranks_in_group.empty()) {
+    return defaultRanks_;
   }
   return options_->global_ranks_in_group;
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -320,6 +320,52 @@ static std::mutex ncclCommMemPoolMapMutex;
 
 std::atomic<bool> ProcessGroupNCCL::shouldDump_(false);
 
+// NOTE [NCCL calls from the caching allocator trace hooks]
+// The hooks below run on whichever thread allocated or freed the segment, with
+// the caching allocator's mutex held, so only NCCL calls that are local to this
+// rank are safe here. ncclCommWindowRegister is not one of them: it runs a
+// bootstrap allgather and barrier across the whole communicator (and
+// ncclCommWindowDeregister is collective too on NCCL builds that barrier before
+// tearing a window down). Issuing one from a hook deadlocks the job inside an
+// innocent-looking `torch.empty()` as soon as one rank allocates or frees a
+// segment that the others do not -- and the allocator mutex it holds stalls
+// every other thread of this process meanwhile. Symmetric windows are therefore
+// only created by registerMemPool(), which the user calls collectively.
+//
+// Returns the communicators interested in this segment, paired with whether
+// their pool was registered as symmetric. Caller must hold
+// ncclCommMemPoolMapMutex, and must keep holding it while acting on the result:
+// that is what keeps abortComms() from retiring a communicator underneath us.
+static std::vector<std::pair<std::shared_ptr<NCCLComm>, bool>>
+commsInterestedInSegment(const c10::CachingDeviceAllocator::TraceEntry& te) {
+  std::vector<std::pair<std::shared_ptr<NCCLComm>, bool>> comms;
+  for (auto& [ncclComm, memPools] : ncclCommMemPoolMap) {
+    if (te.device_ != ncclComm->getDeviceIndex()) {
+      continue;
+    }
+    bool symm = false;
+    bool should_register = shouldAllCommunicatorsRegisterAllTensors();
+    auto it =
+        std::find_if(memPools.begin(), memPools.end(), [&](const auto& tup) {
+          return std::get<0>(tup) == te.mempool_;
+        });
+    if (it != memPools.end()) {
+      should_register = true;
+      symm = std::get<1>(*it);
+    }
+    if (should_register) {
+      comms.emplace_back(ncclComm, symm);
+    }
+  }
+  // ncclCommMemPoolMap is keyed by pointer, so its iteration order differs
+  // between ranks; sort by a key every rank agrees on so that any NCCL call
+  // that does wait on peers is at least issued in the same order everywhere.
+  std::sort(comms.begin(), comms.end(), [](const auto& a, const auto& b) {
+    return a.first->getUniqueHash() < b.first->getUniqueHash();
+  });
+  return comms;
+}
+
 static void cacheAllocatorRegisterHook(
     const c10::CachingDeviceAllocator::TraceEntry& te) {
   // Register after SEGMENT_ALLOC
@@ -329,27 +375,22 @@ static void cacheAllocatorRegisterHook(
   }
 
   std::lock_guard<std::mutex> lock(ncclCommMemPoolMapMutex);
-  for (auto& [ncclComm, memPools] : ncclCommMemPoolMap) {
-    if (te.device_ == ncclComm->getDeviceIndex()) {
-      bool symm = false;
-      bool should_register = shouldAllCommunicatorsRegisterAllTensors();
-      auto it =
-          std::find_if(memPools.begin(), memPools.end(), [&](const auto& tup) {
-            return std::get<0>(tup) == te.mempool_;
-          });
-      if (it != memPools.end()) {
-        should_register = true;
-        symm = std::get<1>(*it);
-      }
-      if (should_register) {
-        // NOLINTNEXTLINE(performance-no-int-to-ptr)
-        ncclComm->registerSegment(
-            reinterpret_cast<void*>(te.addr_),
-            te.size_,
-            /*errorOnRereg*/ false,
-            /*window*/ symm);
-      }
+  for (const auto& [ncclComm, symm] : commsInterestedInSegment(te)) {
+    if (symm) {
+      TORCH_WARN_ONCE(
+          "A segment was allocated in a MemPool that is registered with "
+          "symm=True. It is registered with NCCL, but not as a symmetric "
+          "window, because window registration is collective and cannot be "
+          "issued from the allocator hook. Call deregister_mem_pool() and "
+          "register_mem_pool() again, from every rank, to window-register the "
+          "new segments.");
     }
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    ncclComm->registerSegment(
+        reinterpret_cast<void*>(te.addr_),
+        te.size_,
+        /*errorOnRereg*/ false,
+        /*window*/ false);
   }
 }
 
@@ -362,23 +403,24 @@ static void cacheAllocatorDeregisterHook(
   }
 
   std::lock_guard<std::mutex> lock(ncclCommMemPoolMapMutex);
-  for (auto& [ncclComm, memPools] : ncclCommMemPoolMap) {
-    if (te.device_ == ncclComm->getDeviceIndex()) {
-      bool symm = false;
-      bool should_register = shouldAllCommunicatorsRegisterAllTensors();
-      auto it =
-          std::find_if(memPools.begin(), memPools.end(), [&](const auto& tup) {
-            return std::get<0>(tup) == te.mempool_;
-          });
-      if (it != memPools.end()) {
-        should_register = true;
-        symm = std::get<1>(*it);
-      }
-      if (should_register) {
-        // NOLINTNEXTLINE(performance-no-int-to-ptr)
-        ncclComm->deregisterSegment(reinterpret_cast<void*>(te.addr_), symm);
-      }
+  for (const auto& [ncclComm, symm] : commsInterestedInSegment(te)) {
+    // Leaving the window behind would be worse than tearing it down here: the
+    // allocator is about to hand this address range back, and a later
+    // allocation reusing it would silently resolve to the stale window.
+    if (symm) {
+      TORCH_WARN_ONCE(
+          "Freeing a segment of a MemPool that is registered with symm=True "
+          "without calling deregister_mem_pool() first. The NCCL window has to "
+          "be torn down from the allocator hook, which hangs on NCCL builds "
+          "where that is a collective unless every rank frees the same segment "
+          "in the same order. Call deregister_mem_pool() from every rank before "
+          "freeing.");
     }
+    // deregisterSegment picks the window vs local API from what was recorded at
+    // registration time, not from `symm`: a symm=True pool can also hold
+    // segments that were registered locally by the hook above.
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    ncclComm->deregisterSegment(reinterpret_cast<void*>(te.addr_));
   }
 }
 
@@ -1226,7 +1268,6 @@ void ProcessGroupNCCL::deregisterMemPool(at::cuda::MemPool* pool) {
         DistBackendError,
         "NCCL communicator has not been initialized before mem pool creation. You can pass `device_id` to init_process_group -- one way of eager initialization -- to work around this issue");
   }
-  bool symm;
   {
     std::lock_guard<std::mutex> lock(ncclCommMemPoolMapMutex);
     auto iter = ncclCommMemPoolMap.find(ncclComm);
@@ -1237,7 +1278,6 @@ void ProcessGroupNCCL::deregisterMemPool(at::cuda::MemPool* pool) {
     TORCH_CHECK(
         mempool_it != iter->second.end(),
         "Trying to unregister not previously registered pool");
-    symm = std::get<1>(*mempool_it);
     iter->second.erase(mempool_it);
   }
   auto snapshot = c10::cuda::CUDACachingAllocator::snapshot(pool->id());
@@ -1246,8 +1286,7 @@ void ProcessGroupNCCL::deregisterMemPool(at::cuda::MemPool* pool) {
         segmentInfo.device == pool->device(),
         "Mismatch between CUDA memory segment device and pool's device");
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    ncclComm->deregisterSegment(
-        reinterpret_cast<void*>(segmentInfo.address), symm);
+    ncclComm->deregisterSegment(reinterpret_cast<void*>(segmentInfo.address));
   }
 }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1257,10 +1257,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Returns the unique prefix created in createLogPrefix
   const std::string& logPrefix() const;
 
-  // Returns the global rank of the device. This function assumes that users
-  // always create a default global process group(PG) which includes all
-  // devices. It is called in the constructor of ProcessGroupNCCL, so it always
-  // return the rank_ of the very first PG created, aka, default global PG.
+  // Returns this process's rank in the world, i.e. this group's rank_ mapped
+  // through groupRanks(). Computed per instance in the constructor.
   const int& globalRank() const;
 
   const c10::intrusive_ptr<Store>& globalStore() const;
@@ -1511,6 +1509,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Identity rank mapping [0, size_), used by groupRanks() when
   // options_->global_ranks_in_group is empty. Filled in the constructor.
   std::vector<uint64_t> defaultRanks_;
+
+  // This process's rank in the world, i.e. groupRanks()[rank_]. Filled in the
+  // constructor; see globalRank().
+  int globalRank_{};
 
   std::string logPrefix_;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -11,10 +11,13 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
+#include <cstring>
 #include <deque>
 #include <future>
 #include <iostream>
 #include <list>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <thread>
@@ -525,6 +528,24 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       return c10::make_intrusive<Options>(is_high_priority_stream);
     }
 
+    c10::intrusive_ptr<Backend::Options> clone() const override {
+      auto copy = c10::make_intrusive<Options>(*this);
+      if (config.netName != nullptr) {
+        // ncclConfig_t::netName is a strdup'ed const char* (see the NCCLConfig
+        // pybind setter) and ncclConfig_t records no owner, so a plain copy
+        // would leave two Options sharing one allocation. Give the clone its
+        // own and tie the allocation to it: copies of this Options share it and
+        // free it once, when the last of them goes away. A netName from
+        // anywhere else -- the pybind setter, a config also handed to NCCL --
+        // is untracked and untouched.
+        copy->owned_net_name_ = std::shared_ptr<const char>(
+            strdup(config.netName),
+            [](const char* p) { std::free(const_cast<char*>(p)); });
+        copy->config.netName = copy->owned_net_name_.get();
+      }
+      return copy;
+    }
+
     // Schedule NCCL operations on high priority CUDA streams
     bool is_high_priority_stream;
 
@@ -546,6 +567,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // raise a RuntimeError saying type is incompatible. See also
     // `_process_group_color` in `distributed_c10d.py`.
     int split_color{NCCL_SPLIT_NOCOLOR - 1};
+
+   private:
+    // Keeps clone()'s strdup'ed config.netName alive; see clone().
+    std::shared_ptr<const char> owned_net_name_;
   };
 
   // Helper class related to TORCH_NCCL_DESYNC_DEBUG

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1483,6 +1483,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // The number of ProcessGroupNCCL created on the current rank.
   size_t local_id_;
 
+  // Identity rank mapping [0, size_), used by groupRanks() when
+  // options_->global_ranks_in_group is empty. Filled in the constructor.
+  std::vector<uint64_t> defaultRanks_;
+
   std::string logPrefix_;
 
   c10::intrusive_ptr<intra_node_comm::IntraNodeComm> intraNodeComm_;

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -4171,6 +4171,14 @@ Returns:
               "get_error",
               &::c10d::nccl2::ProcessGroupNCCL::getError,
               py::call_guard<py::gil_scoped_release>())
+          .def(
+              "register_mem_pool",
+              &::c10d::nccl2::ProcessGroupNCCL::registerMemPool,
+              py::arg("pool"),
+              py::arg("symm") = false)
+          .def(
+              "deregister_mem_pool",
+              &::c10d::nccl2::ProcessGroupNCCL::deregisterMemPool)
           .def_property_readonly(
               "options",
               &::c10d::nccl2::ProcessGroupNCCL::getBackendOptions,

--- a/torch/csrc/distributed/c10d/nccl2/NCCLCachingAllocatorHook.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/NCCLCachingAllocatorHook.cpp
@@ -4,6 +4,9 @@
 
 #include <torch/csrc/distributed/c10d/nccl2/NCCLCachingAllocatorHook.hpp>
 
+#include <algorithm>
+#include <vector>
+
 #include <ATen/Context.h>
 #include <c10/core/AllocatorConfig.h>
 #include <torch/csrc/distributed/c10d/nccl2/Logging.hpp>
@@ -15,6 +18,25 @@ namespace {
 void ncclCachingAllocatorHookFn(
     const c10::cuda::CUDACachingAllocator::TraceEntry& te) {
   NCCLCachingAllocatorHook::getInstance().regDeregMem(te);
+}
+
+// registeredComms_ is ordered by pointer, which differs between ranks. Any NCCL
+// call these hooks make that waits on peers (deregister_address tearing down a
+// symmetric window does so on NCCL builds that barrier there) must be issued in
+// the same order everywhere, so order by the group name instead.
+std::vector<ProcessGroupNCCL*> commsForDevice(
+    const std::set<ProcessGroupNCCL*>& comms,
+    c10::DeviceIndex device) {
+  std::vector<ProcessGroupNCCL*> out;
+  for (auto* comm : comms) {
+    if (device == comm->getDevice().index()) {
+      out.push_back(comm);
+    }
+  }
+  std::stable_sort(out.begin(), out.end(), [](auto* a, auto* b) {
+    return a->getCommName() < b->getCommName();
+  });
+  return out;
 }
 } // namespace
 
@@ -73,10 +95,8 @@ void NCCLCachingAllocatorHook::regDeregMem(
     TORCH_CHECK(
         !registeredMemMap_.count(addr), "Memory already registered with NCCL");
     registeredMemMap_.emplace(addr, MemInfo{len, te.device_});
-    for (auto* comm : registeredComms_) {
-      if (te.device_ == comm->getDevice().index()) {
-        comm->register_address(addr, len);
-      }
+    for (auto* comm : commsForDevice(registeredComms_, te.device_)) {
+      comm->register_address(addr, len);
     }
   } else if (
       te.action_ ==
@@ -86,10 +106,8 @@ void NCCLCachingAllocatorHook::regDeregMem(
     TORCH_CHECK(
         registeredMemMap_.count(addr), "Memory not registered with NCCL");
     registeredMemMap_.erase(addr);
-    for (auto* comm : registeredComms_) {
-      if (te.device_ == comm->getDevice().index()) {
-        comm->deregister_address(addr);
-      }
+    for (auto* comm : commsForDevice(registeredComms_, te.device_)) {
+      comm->deregister_address(addr, /*from_allocator_hook=*/true);
     }
   }
 }

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -186,7 +186,7 @@ void ProcessGroupNCCL::init(at::Device device) {
   initNcclResources();
 
   init_state_ = InitializationState::INITIALIZED;
-  TracingGuard tracingGuard(name_, comm_size_, "init", rank_);
+  TracingGuard tracingGuard(name_, comm_size_, "init", rank_, sequence_number_);
 
   TC_LOG(INFO, this) << "ProcessGroupNCCL initialized for rank: " << rank_;
 }
@@ -236,7 +236,7 @@ void ProcessGroupNCCL::initFromSplitComm(
   nccl_comm_ = comm;
   initNcclResources();
   init_state_ = InitializationState::INITIALIZED;
-  TracingGuard tracingGuard(name_, comm_size_, "init", rank_);
+  TracingGuard tracingGuard(name_, comm_size_, "init", rank_, sequence_number_);
   TC_LOG(INFO, this) << "ProcessGroupNCCL initialized from split for rank: "
                      << rank_;
 }
@@ -564,7 +564,8 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::sendImpl(
   ensureTensorContiguous(tensor);
   checkTensorDevice(tensor);
 
-  TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
+  TracingGuard tracingGuard(
+      name_, comm_size_, "send", dst, sequence_number_, tensor, tensor);
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -622,7 +623,8 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::recvImpl(
   ensureTensorContiguous(tensor);
   checkTensorDevice(tensor);
 
-  TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
+  TracingGuard tracingGuard(
+      name_, comm_size_, "recv", src, sequence_number_, tensor, tensor);
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -700,6 +702,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::batch_op_issue(
       comm_size_,
       "batch_op_issue",
       rank_,
+      sequence_number_,
       input_tensors,
       output_tensors);
 
@@ -772,7 +775,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::broadcastImpl(
   checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(
-      name_, comm_size_, "broadcast", root, tensor, tensor);
+      name_, comm_size_, "broadcast", root, sequence_number_, tensor, tensor);
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -814,7 +817,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::all_reduce(
   checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(
-      name_, comm_size_, "all_reduce", rank_, tensor, tensor);
+      name_, comm_size_, "all_reduce", rank_, sequence_number_, tensor, tensor);
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -857,7 +860,8 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::reduceImpl(
   ensureTensorContiguous(tensor);
   checkTensorDevice(tensor);
 
-  TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
+  TracingGuard tracingGuard(
+      name_, comm_size_, "reduce", root, sequence_number_, tensor, tensor);
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -934,7 +938,13 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::all_gather(
   }
 
   TracingGuard tracingGuard(
-      name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
+      name_,
+      comm_size_,
+      "all_gather",
+      rank_,
+      sequence_number_,
+      tensor_list,
+      {tensor});
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -1014,7 +1024,13 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::allGatherSingleImpl(
   }
 
   TracingGuard tracingGuard(
-      name_, comm_size_, "allGatherSingleImpl", rank_, input, output);
+      name_,
+      comm_size_,
+      "allGatherSingleImpl",
+      rank_,
+      sequence_number_,
+      input,
+      output);
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -1070,7 +1086,13 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::reduce_scatter(
   checkSameDtype(output, input_list);
 
   TracingGuard tracingGuard(
-      name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
+      name_,
+      comm_size_,
+      "reduce_scatter",
+      rank_,
+      sequence_number_,
+      input_list,
+      {output});
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -1153,7 +1175,13 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::reduceScatterSingleImpl(
   }
 
   TracingGuard tracingGuard(
-      name_, comm_size_, "reduceScatterSingleImpl", rank_, input, output);
+      name_,
+      comm_size_,
+      "reduceScatterSingleImpl",
+      rank_,
+      sequence_number_,
+      input,
+      output);
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -1209,7 +1237,13 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::allToAllSingleImpl(
   }
 
   TracingGuard tracingGuard(
-      name_, comm_size_, "allToAllSingleImpl", rank_, input, output);
+      name_,
+      comm_size_,
+      "allToAllSingleImpl",
+      rank_,
+      sequence_number_,
+      input,
+      output);
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -1320,7 +1354,13 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::all_to_all_v_single(
   }
 
   TracingGuard tracingGuard(
-      name_, comm_size_, "all_to_all_v_single", rank_, input, output);
+      name_,
+      comm_size_,
+      "all_to_all_v_single",
+      rank_,
+      sequence_number_,
+      input,
+      output);
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -1433,6 +1473,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::all_to_all(
       comm_size_,
       "all_to_all",
       rank_,
+      sequence_number_,
       input_tensor_list,
       output_tensor_list);
 
@@ -1511,7 +1552,8 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::barrierImpl(
         c10::cuda::CUDACachingAllocator::get()->allocate(sizeof(float));
   }
 
-  TracingGuard tracingGuard(name_, comm_size_, "barrier", rank_);
+  TracingGuard tracingGuard(
+      name_, comm_size_, "barrier", rank_, sequence_number_);
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
   auto work = createWork(stream, timeout);
@@ -1575,7 +1617,13 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::scatterImpl(
   }
 
   TracingGuard tracingGuard(
-      name_, comm_size_, "scatter", root, input_tensor_list, {output_tensor});
+      name_,
+      comm_size_,
+      "scatter",
+      root,
+      sequence_number_,
+      input_tensor_list,
+      {output_tensor});
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);
@@ -1690,7 +1738,13 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::gatherImpl(
   }
 
   TracingGuard tracingGuard(
-      name_, comm_size_, "gather", root, {input_tensor}, output_tensor_list);
+      name_,
+      comm_size_,
+      "gather",
+      root,
+      sequence_number_,
+      {input_tensor},
+      output_tensor_list);
 
   c10::cuda::CUDAGuard device_guard(device_);
   cudaStream_t stream = getOperationStream(async_op);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -13,9 +13,11 @@
 #include <thread>
 #include <unordered_set>
 
+#include <ATen/Context.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/util/env.h>
 #include <fmt/core.h>
 #include <nccl.h>
 #include <torch/csrc/cuda/CUDAPluggableAllocator.h>
@@ -165,6 +167,21 @@ void ProcessGroupNCCL::init(at::Device device) {
 
   if (!nccl_api_) {
     nccl_api_ = std::make_unique<DefaultNcclApi>();
+  }
+
+  // If deterministic mode is enabled, disable the NVLS algorithm in NCCL
+  // (which can lead to non-deterministic reductions). Mirrors the stock
+  // ProcessGroupNCCL. NCCL reads NCCL_ALGO when the communicator is created,
+  // so this must run before createNcclComm below. If the user already set
+  // NCCL_ALGO, leave it untouched.
+  // TODO: remove this once NVLS supports deterministic mode.
+  if (at::globalContext().deterministicAlgorithms()) {
+    if (!c10::utils::get_env("NCCL_ALGO").has_value()) {
+      LOG(INFO)
+          << "torch deterministic mode is enabled, "
+          << "disabling NVLS algorithm in NCCL which can lead to non-deterministic reduction.";
+      c10::utils::set_env("NCCL_ALGO", "^NVLS");
+    }
   }
 
   if (device_.index() == -1 || nccl_comm_ == nullptr) {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -205,11 +205,6 @@ void ProcessGroupNCCL::initNcclResources() {
     dependency_event_.emplace(cudaEventDisableTiming);
   }
 
-  if (!barrier_buffer_) {
-    barrier_buffer_ =
-        c10::cuda::CUDACachingAllocator::get()->allocate(sizeof(float));
-  }
-
   max_event_pool_size_ = kDefaultMaxEventPoolSize;
 
   NCCL_CHECK(
@@ -1501,6 +1496,20 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::barrierImpl(
     std::chrono::milliseconds timeout) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
+
+  // Allocated here rather than in initNcclResources() so that merely creating a
+  // process group never touches the CUDA caching allocator. Eager init runs
+  // before anything has initialized CUDA (init_process_group(device_id=...) on
+  // a process that has made no torch.cuda call), and the allocator is brought
+  // up lazily, so allocating there tripped "Allocator not initialized for
+  // device N". lazyInitDevice() is what ATen's own allocating paths call, and
+  // is a no-op once CUDA is up.
+  if (!barrier_buffer_) {
+    at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
+    c10::cuda::CUDAGuard gpuGuard(device_);
+    barrier_buffer_ =
+        c10::cuda::CUDACachingAllocator::get()->allocate(sizeof(float));
+  }
 
   TracingGuard tracingGuard(name_, comm_size_, "barrier", rank_);
   c10::cuda::CUDAGuard device_guard(device_);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -103,31 +103,14 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
         << " was not finalized before destruction. "
         << "This may indicate a resource leak. Please call finalize() explicitly.";
 
-    // Signal shutdown to timeout watchdog thread to prevent it from accessing
-    // this object after destruction
-    shutdown_ = true;
+    // Stop the watchdog so it cannot access this object after destruction. It
+    // may be the caller (garbageCollect can pop a work item whose destruction
+    // releases the last reference to this comm), which stopWatchdog handles.
+    stopWatchdog();
 
-    // Wake up the timeout watchdog thread
-    {
-      std::lock_guard<std::mutex> lock(timeout_mutex_);
-      timeout_cv_.notify_all();
-    }
-
-    // Wait for timeout thread to finish. If we're being called from within
-    // the timeout thread itself (e.g., garbageCollect popped a work item whose
-    // destruction released the last shared_ptr to this comm), we must detach
-    // instead of join to avoid a deadlock.
-    if (timeout_thread_.joinable()) {
-      if (std::this_thread::get_id() != timeout_thread_.get_id()) {
-        timeout_thread_.join();
-      } else {
-        timeout_thread_.detach(); // NOLINT(facebook-hte-BadCall-detach)
-      }
-    }
-
-    // Abort the NCCL communicator since we can't do a clean finalization
-    // Note: We don't call the full abortNcclComm() to avoid potential abort()
-    // calls from abort_process_on_timeout_or_error_
+    // Abort the NCCL communicator since we can't do a clean finalization.
+    // Open-coded rather than abortNcclComm() so a failure cannot throw out of
+    // the destructor (abortNcclComm() throws on a failed or timed-out abort).
     if (nccl_comm_) {
       // Drop our symmetric-memory registration while nccl_comm_ is still valid
       // (it is nulled below, before detachMemoryHook runs).
@@ -349,10 +332,24 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::split(
 }
 
 void ProcessGroupNCCL::abort() {
-  comm_state_ = CommState::ERROR;
+  // User-initiated (backend.abort() / _abort_process_group()): tear the
+  // communicator down and return. Never terminates the process, whatever
+  // TORCH_NCCL_ASYNC_ERROR_HANDLING says -- that gate only covers failures the
+  // watchdog detects on its own.
+  TC_LOG(INFO, this) << "abort() requested on rank " << rank_
+                     << "; aborting the NCCL communicator";
   if (options_c10d_->enable_reconfigure) {
+    comm_state_ = CommState::ERROR;
     revokeNcclComm();
   } else {
+    // Stop the watchdog before publishing the error: this failure is one the
+    // caller asked for, so it must not trigger a process abort, and there is no
+    // communicator left to watch either. Not done in reconfigurable mode, where
+    // the comm is revoked rather than destroyed and the watchdog is needed again
+    // after reconfigure(). The error is still published before the teardown, so
+    // work in flight reports it instead of completing.
+    stopWatchdog();
+    comm_state_ = CommState::ERROR;
     abortNcclComm();
   }
 }
@@ -416,19 +413,10 @@ void ProcessGroupNCCL::finalize() {
   }
   init_state_ = InitializationState::FINALIZED;
 
-  // Signal shutdown to timeout watchdog
-  shutdown_ = true;
-
-  // Wake up the timeout watchdog thread
-  {
-    std::lock_guard<std::mutex> lock(timeout_mutex_);
-    timeout_cv_.notify_all();
-  }
-
-  // Wait for timeout thread to finish
-  if (timeout_thread_.joinable()) {
-    timeout_thread_.join();
-  }
+  // Stop the watchdog first: draining the work queue below may surface a
+  // timeout, which is a teardown result to report to the caller, not a reason
+  // to terminate the process.
+  stopWatchdog();
 
   // Wait for all pending work objects to complete and get final status
   auto work_status = workq_.finalize();
@@ -446,6 +434,10 @@ void ProcessGroupNCCL::finalize() {
     throw std::runtime_error("Work timed out during finalize");
   } else if (work_status == WorkNCCL::WorkStatus::ERROR) {
     comm_state_ = CommState::ERROR;
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCL communicator was aborted after a previous error");
+    }
     ncclResult_t asyncErr{};
     NCCL_CHECK(
         nccl_api_,
@@ -500,14 +492,36 @@ void ProcessGroupNCCL::abortNcclComm() {
         "NCCL Abort failed");
     nccl_comm_ = nullptr;
   }
-  // Never abort the process in reconfigurable mode: callers fall back to
-  // revoke + throw so the failure can be handled by reconfiguring.
-  if (abort_process_on_timeout_or_error_ &&
-      !options_c10d_->enable_reconfigure) {
-    TC_LOG(ERROR, this) << "Aborting process due to timeout";
-    runAbortHooks();
-    ::abort();
+}
+
+void ProcessGroupNCCL::stopWatchdog() {
+  shutdown_ = true;
+  {
+    std::lock_guard<std::mutex> lock(timeout_mutex_);
+    timeout_cv_.notify_all();
   }
+  if (timeout_thread_.joinable()) {
+    // Joining from within the watchdog thread (the async-error path calls
+    // abort()) would deadlock.
+    if (std::this_thread::get_id() != timeout_thread_.get_id()) {
+      timeout_thread_.join();
+    } else {
+      timeout_thread_.detach(); // NOLINT(facebook-hte-BadCall-detach)
+    }
+  }
+}
+
+void ProcessGroupNCCL::abortProcess(const std::string& reason) {
+  // Never terminate the process in reconfigurable mode: callers fall back to
+  // revoke + throw so the failure can be handled by reconfiguring.
+  if (!abort_process_on_timeout_or_error_ ||
+      options_c10d_->enable_reconfigure) {
+    return;
+  }
+  TC_LOG(ERROR, this) << "Aborting process on rank " << rank_ << " due to "
+                      << reason;
+  runAbortHooks();
+  ::abort();
 }
 
 void ProcessGroupNCCL::revokeNcclComm() {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -317,8 +317,33 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::split(
   auto childOpts = Options::create(ncclOpts->is_high_priority_stream);
   childOpts->timeout = ncclOpts->timeout;
   childOpts->config = config;
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
+  // commName above borrows `name`, which belongs to the Options handed to
+  // split() -- a clone that dies with the caller's frame. Every consumer of a
+  // stored config assigns commName from a live string before passing it to
+  // NCCL (createNcclComm, reconfigure(), this function), so store no pointer
+  // rather than one that outlives its string.
+  childOpts->config.commName = nullptr;
+#endif
   childOpts->group_name = ncclOpts->group_name;
   childOpts->group_desc = ncclOpts->group_desc;
+
+  // The child's membership in world-rank terms, as stock's split() records it.
+  // nccl2 never reads this itself; its one consumer is FlightRecorderHook,
+  // which otherwise falls back to identity ranks. Map through this group's own
+  // map, not the passed-in Options': an empty map means "spans the world in
+  // rank order", and a merged group inherits its parent's shorter map, so
+  // treat anything too short the same way instead of indexing out of bounds.
+  const auto& parentRanks = options_c10d_->global_ranks_in_group;
+  const bool parentSpansWorld =
+      parentRanks.size() < static_cast<size_t>(getSize());
+  std::vector<uint64_t> childRanks;
+  childRanks.reserve(ranks.size());
+  for (int r : ranks) {
+    childRanks.push_back(
+        parentSpansWorld ? static_cast<uint64_t>(r) : parentRanks[r]);
+  }
+  childOpts->global_ranks_in_group = std::move(childRanks);
 
   auto child = c10::make_intrusive<ProcessGroupNCCL>(
       store, newRank, static_cast<int>(ranks.size()), childOpts);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <optional>
 #include <queue>
+#include <set>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -278,6 +279,16 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   }
   c10::intrusive_ptr<::c10d::Window> new_window(
       const std::optional<at::Tensor>& tensor = std::nullopt) override;
+
+  // MemPool registration (::c10d::ProcessGroupNCCL::registerMemPool parity).
+  // Unlike the stock backend, plain ncclCommRegister of every private-pool
+  // segment already happens unconditionally through NCCLCachingAllocatorHook,
+  // so this only has to cover the segments the hook could not reach and -- for
+  // symm -- perform the collective NCCL_WIN_COLL_SYMMETRIC upgrade that the
+  // hook must not do from an allocator thread. Collective when symm is set:
+  // every rank must call it with the same pool contents, in the same order.
+  void registerMemPool(at::cuda::MemPool* pool, bool symm = false);
+  void deregisterMemPool(at::cuda::MemPool* pool);
 
   // Caching-allocator segment registration (called by
   // NCCLCachingAllocatorHook, potentially from allocator threads).
@@ -603,9 +614,18 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
     size_t len{0};
   };
   std::map<void*, RegistrationHandle, std::less<>> memoryRegistrationHandles_;
-  // Guards memoryRegistrationHandles_: register/deregister_address run on
-  // allocator threads while window ops look segments up on the main thread.
+  // Guards memoryRegistrationHandles_ and registeredMemPools_:
+  // register/deregister_address run on allocator threads while window ops look
+  // segments up on the main thread.
   std::mutex memory_registration_mutex_;
+  // MemPools passed to registerMemPool, so deregisterMemPool can reject a pool
+  // that was never registered (stock does the same via its global
+  // ncclCommMemPoolMap). The symm mode is not tracked: a segment carries its
+  // own window handle, so teardown does not need to be told which mode to use.
+  std::set<c10::cuda::MempoolId_t> registeredMemPools_;
+  // Caller must hold memory_registration_mutex_ and have checked that `addr`
+  // is not already registered.
+  void registerAddressLocked(void* addr, size_t len);
 
   // Abort hooks (c10d::Backend API; storage was in torchcomms' TorchCommBackend
   // base, folded in here).

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -328,7 +328,19 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
       ncclResult_t status,
       std::chrono::milliseconds timeout,
       std::string_view operation);
+  // Tears the NCCL communicator down. This NEVER terminates the process --
+  // a user-initiated abort()/shutdown() must be survivable, matching
+  // ::c10d::ProcessGroupNCCL::abort(). Callers that are handling a
+  // watchdog-detected timeout or async error follow it with abortProcess().
   void abortNcclComm();
+  // Terminates the process (after running the abort hooks) if
+  // TORCH_NCCL_ASYNC_ERROR_HANDLING asks for a tear-down and we are not in
+  // reconfigurable mode. `reason` is logged after "Aborting process on rank N
+  // due to ", so it must describe the actual trigger.
+  void abortProcess(const std::string& reason);
+  // Signals the watchdog thread to exit and reaps it. Detaches instead of
+  // joining when called from the watchdog thread itself.
+  void stopWatchdog();
   void revokeNcclComm();
 
   enum class CommState {
@@ -567,8 +579,13 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   std::mutex timeout_mutex_;
 
   bool is_high_priority_stream_{false};
-  bool abort_process_on_timeout_or_error_{true};
   std::string name_;
+
+  // Whether a watchdog-detected timeout or async error takes the process down,
+  // read from TORCH_NCCL_ASYNC_ERROR_HANDLING so both NCCL backends fail the
+  // same way. Only the tear-down half of the mode applies here: our watchdog
+  // deliberately leaves the communicator for the next collective to abort.
+  const bool abort_process_on_timeout_or_error_;
 
   c10::intrusive_ptr<Options> options_c10d_;
 

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -293,7 +293,9 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // Caching-allocator segment registration (called by
   // NCCLCachingAllocatorHook, potentially from allocator threads).
   void register_address(void* addr, size_t len);
-  void deregister_address(void* addr);
+  // from_allocator_hook only controls diagnostics: tearing a symmetric window
+  // down from the hook is the uncollective path worth warning about.
+  void deregister_address(void* addr, bool from_allocator_hook = false);
   // Returns {window handle, byte offset of ptr within the segment}, or
   // {nullptr, 0} if ptr is not inside a window-registered segment.
   std::pair<ncclWindow_t, size_t> lookupSegmentWindow(const void* ptr);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -88,6 +88,10 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     : Backend(rank, size),
       device_(at::kCUDA),
       store_(std::move(store)),
+      abort_process_on_timeout_or_error_(
+          SHOULD_TEAR_DOWN(static_cast<::c10d::ErrorHandlingMode>(getCvarInt(
+              ::c10d::TORCH_NCCL_ASYNC_ERROR_HANDLING,
+              ::c10d::SkipCleanUp)))),
       options_c10d_(options ? std::move(options) : Options::create()) {
   name_ = options_c10d_->group_name.empty() ? std::string(kBackendName)
                                             : options_c10d_->group_name;

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -8,9 +8,11 @@
 #include <nccl.h>
 #include <torch/csrc/distributed/c10d/nccl2/Logging.hpp>
 #include <torch/csrc/distributed/c10d/nccl2/NCCLCachingAllocatorHook.hpp>
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <variant>
+#include <vector>
 
 namespace c10d::nccl2 {
 
@@ -543,14 +545,7 @@ void ProcessGroupNCCL::detachMemoryHook() {
   NCCLCachingAllocatorHook::getInstance().deregisterComm(this);
 }
 
-void ProcessGroupNCCL::register_address(void* addr, size_t len) {
-  if (nccl_comm_ == nullptr) {
-    return;
-  }
-  std::lock_guard<std::mutex> lock(memory_registration_mutex_);
-  TORCH_CHECK(
-      !memoryRegistrationHandles_.count(addr),
-      "Memory already registered with NCCL");
+void ProcessGroupNCCL::registerAddressLocked(void* addr, size_t len) {
   void* handle = nullptr;
   NCCL_CHECK(
       nccl_api_,
@@ -562,6 +557,17 @@ void ProcessGroupNCCL::register_address(void* addr, size_t len) {
   // happens lazily in ensureSegmentWindow(), keyed by the base recorded here.
   memoryRegistrationHandles_.emplace(
       addr, RegistrationHandle{handle, nullptr, len});
+}
+
+void ProcessGroupNCCL::register_address(void* addr, size_t len) {
+  if (nccl_comm_ == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+  TORCH_CHECK(
+      !memoryRegistrationHandles_.count(addr),
+      "Memory already registered with NCCL");
+  registerAddressLocked(addr, len);
 }
 
 void ProcessGroupNCCL::deregister_address(void* addr) {
@@ -638,6 +644,108 @@ ncclResult_t ProcessGroupNCCL::ensureSegmentWindow(const void* ptr) {
   }
   it->second.winHandle = win;
   return ncclSuccess;
+}
+
+namespace {
+
+// Segments currently backing `id`, in allocation order. Symmetric window
+// registration is collective, so every rank has to walk them in the same
+// order; registration_counter is the only cross-rank-stable ordering the
+// snapshot offers (this is what the stock backend sorts on too).
+std::vector<c10::cuda::CUDACachingAllocator::SegmentInfo> poolSegments(
+    const c10::cuda::MempoolId_t& id) {
+  auto snapshot = c10::cuda::CUDACachingAllocator::snapshot(id);
+  std::sort(
+      snapshot.segments.begin(),
+      snapshot.segments.end(),
+      [](const auto& a, const auto& b) {
+        return a.registration_counter < b.registration_counter;
+      });
+  return std::move(snapshot.segments);
+}
+
+constexpr const char* kUninitializedCommError =
+    "NCCL communicator has not been initialized before mem pool creation. You can pass `device_id` to init_process_group -- one way of eager initialization -- to work around this issue";
+
+} // namespace
+
+void ProcessGroupNCCL::registerMemPool(at::cuda::MemPool* pool, bool symm) {
+  if (nccl_comm_ == nullptr) {
+    C10_THROW_ERROR(DistBackendError, kUninitializedCommError);
+  }
+  TORCH_CHECK(
+      pool->device() == device_.index(),
+      "MemPool is on device ",
+      static_cast<int>(pool->device()),
+      " but this process group is bound to ",
+      device_);
+  TC_LOG(INFO, this) << "Registering MemPool " << pool->id().first << ":"
+                     << pool->id().second << " (symm=" << symm << ") on "
+                     << device_;
+  {
+    std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+    registeredMemPools_.insert(pool->id());
+  }
+  bool symmUnsupported = false;
+  for (const auto& segment : poolSegments(pool->id())) {
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    void* addr = reinterpret_cast<void*>(segment.address);
+    {
+      std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+      // The allocator hook normally registered this segment already; only the
+      // ones it could not reach (allocated while the comm was down, or
+      // deregistered by an earlier deregisterMemPool) are left to do here.
+      if (!memoryRegistrationHandles_.count(addr)) {
+        registerAddressLocked(addr, segment.total_size);
+      }
+    }
+    if (!symm) {
+      continue;
+    }
+    // Only segments that exist now can be upgraded: the window call is
+    // collective, so a segment another thread allocates concurrently must be
+    // left to the next registerMemPool.
+    auto rc = ensureSegmentWindow(addr);
+    if (rc == ncclInvalidUsage) {
+      // No symmetric-memory-capable transport (or NCCL predates
+      // ncclCommWindowRegister). The stock backend keeps the plain
+      // registration and reports success here; do the same, but say so.
+      symmUnsupported = true;
+      continue;
+    }
+    TORCH_CHECK(
+        rc == ncclSuccess,
+        "Failed to register segment ",
+        addr,
+        " as an NCCL symmetric window: ",
+        nccl_api_->getErrorString(rc));
+  }
+  if (symmUnsupported) {
+    TC_LOG(WARNING, this)
+        << "Symmetric (NVLS) registration unavailable for MemPool "
+        << pool->id().first << ":" << pool->id().second
+        << "; its buffers stay registered as plain NCCL user buffers.";
+  }
+}
+
+void ProcessGroupNCCL::deregisterMemPool(at::cuda::MemPool* pool) {
+  if (nccl_comm_ == nullptr) {
+    C10_THROW_ERROR(DistBackendError, kUninitializedCommError);
+  }
+  {
+    std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+    TORCH_CHECK(
+        registeredMemPools_.erase(pool->id()) == 1,
+        "Trying to unregister not previously registered pool");
+  }
+  TC_LOG(INFO, this) << "Deregistering MemPool " << pool->id().first << ":"
+                     << pool->id().second << " on " << device_;
+  for (const auto& segment : poolSegments(pool->id())) {
+    // deregister_address tears the symmetric window down before the plain
+    // registration and tolerates a segment that is not registered.
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    deregister_address(reinterpret_cast<void*>(segment.address));
+  }
 }
 
 } // namespace c10d::nccl2

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -265,22 +265,15 @@ void ProcessGroupNCCL::timeoutWatchdog() noexcept {
       if (shutdown_) {
         break;
       }
-      if (comm_state_ != CommState::NORMAL &&
-          abort_process_on_timeout_or_error_ &&
-          !options_c10d_->enable_reconfigure) {
-        if (comm_state_ == CommState::TIMEOUT) {
-          TC_LOG(ERROR, this)
-              << "Aborting process due to timeout on rank " << rank_
-              << " - timeout watchdog detected operation timeout";
-        } else if (comm_state_ == CommState::ERROR) {
-          TC_LOG(ERROR, this)
-              << "Aborting process due to error on rank " << rank_
-              << " - timeout watchdog detected operation error. ";
-        }
-
-        runAbortHooks();
-
-        ::abort();
+      // With abort_process_on_timeout_or_error disabled this is a no-op and
+      // the loop keeps running: comm_state_ stays TIMEOUT/ERROR so getError()
+      // reports it, and the next collective throws from
+      // checkAndAbortIfTimedOutOrError().
+      if (comm_state_ != CommState::NORMAL) {
+        abortProcess(
+            comm_state_ == CommState::TIMEOUT
+                ? "timeout - timeout watchdog detected operation timeout"
+                : "error - timeout watchdog detected operation error");
       }
 
       // Detect a communicator-level async error while the comm is still
@@ -295,13 +288,14 @@ void ProcessGroupNCCL::timeoutWatchdog() noexcept {
         if (asyncErr != ncclSuccess && asyncErr != ncclInProgress) {
           comm_state_ = CommState::ERROR;
           if (!options_c10d_->enable_reconfigure) {
-            TC_LOG(ERROR, this)
-                << "Aborting process due to error on rank " << rank_
-                << " - nccl hit async error: " << ncclGetErrorString(asyncErr);
-
-            runAbortHooks();
-
+            TC_LOG(ERROR, this) << "nccl hit async error on rank " << rank_
+                                << ": " << ncclGetErrorString(asyncErr);
+            // abort() only tears the communicator down; abortProcess() runs
+            // the abort hooks and terminates if the mode allows it.
             abort();
+            abortProcess(
+                std::string("error - nccl hit async error: ") +
+                ncclGetErrorString(asyncErr));
           } else {
             // Revoked below by the reconfigurable-mode handler.
             TC_LOG(ERROR, this)
@@ -360,15 +354,17 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
       throw std::runtime_error("NCCL operation timed out");
     } else {
       abortNcclComm();
-      if (abort_process_on_timeout_or_error_) {
-        TC_LOG(ERROR, this) << "Aborting process due to timeout";
-        runAbortHooks();
-        ::abort();
-      } else {
-        throw std::runtime_error("NCCL operation timed out");
-      }
+      abortProcess("timeout - collective operation timed out");
+      throw std::runtime_error("NCCL operation timed out");
     }
   } else if (comm_state_ == CommState::ERROR) {
+    // With abort_process_on_timeout_or_error disabled the watchdog aborts the
+    // communicator on an async error and lets the process live, so a later
+    // collective can reach here with no communicator left to query.
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCL communicator was aborted after a previous error");
+    }
     ncclResult_t asyncErr{};
     NCCL_CHECK(
         nccl_api_,
@@ -384,14 +380,8 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
       throw std::move(ncclException);
     }
     abortNcclComm();
-    if (abort_process_on_timeout_or_error_) {
-      TC_LOG(ERROR, this) << "Aborting process due to error: "
-                          << ncclException.what();
-      runAbortHooks();
-      ::abort();
-    } else {
-      throw std::move(ncclException);
-    }
+    abortProcess(std::string("error - ") + ncclException.what());
+    throw std::move(ncclException);
   }
 }
 

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -570,7 +570,7 @@ void ProcessGroupNCCL::register_address(void* addr, size_t len) {
   registerAddressLocked(addr, len);
 }
 
-void ProcessGroupNCCL::deregister_address(void* addr) {
+void ProcessGroupNCCL::deregister_address(void* addr, bool from_allocator_hook) {
   if (nccl_comm_ == nullptr) {
     return;
   }
@@ -580,6 +580,19 @@ void ProcessGroupNCCL::deregister_address(void* addr) {
     return;
   }
   if (it->second.winHandle != nullptr) {
+    // Tearing the window down is still the least bad option -- the allocator is
+    // about to hand this address range back, and a later allocation reusing it
+    // would silently resolve to the stale window -- but say so loudly: on NCCL
+    // builds where ncclCommWindowDeregister barriers, a rank-divergent free
+    // hangs here, on an allocator thread, holding the allocator's mutex.
+    if (from_allocator_hook) {
+      TORCH_WARN_ONCE(
+          "A symmetric-window segment was freed without deregister_mem_pool() "
+          "being called first, so its NCCL window is being torn down from the "
+          "CUDA allocator hook. That is only safe if every rank frees the same "
+          "segment in the same order; call deregister_mem_pool() from every "
+          "rank before freeing.");
+    }
     NCCL_CHECK_IGNORE(
         nccl_api_,
         nccl_api_->commWindowDeregister(nccl_comm_, it->second.winHandle),

--- a/torch/csrc/distributed/c10d/nccl2/TracingGuard.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/TracingGuard.cpp
@@ -66,6 +66,7 @@ void TracingGuard::initializeTracingCommon(
     int comm_size,
     std::string_view collective_name,
     int collective_rank,
+    uint64_t sequence_number,
     const std::vector<at::Tensor>& input_tensor_list,
     const std::vector<at::Tensor>& output_tensor_list) {
   std::vector<int64_t> in_split_sizes;
@@ -77,23 +78,28 @@ void TracingGuard::initializeTracingCommon(
     out_split_sizes.push_back(output_tensor_list[r].numel());
   }
 
+  auto debug_info = getDebugInfo(
+      comm_name,
+      comm_id,
+      comm_size,
+      collective_name,
+      collective_rank,
+      input_tensor_list,
+      output_tensor_list,
+      in_split_sizes,
+      out_split_sizes);
+  // Where the profiler reads the sequence number from to build its cross-rank
+  // "Comms Id" (torch/csrc/profiler/util.cpp); it stays at -1 unless set here.
+  // isP2P is false throughout: nccl2 counts p2p and collectives in the one
+  // per-PG sequence_number_, so there is no separate p2p sequence space.
+  debug_info->setSequenceInfo(static_cast<int64_t>(sequence_number), false);
   debug_info_guard_ = std::make_unique<c10::DebugInfoGuard>(
-      c10::DebugInfoKind::PARAM_COMMS_INFO,
-      getDebugInfo(
-          comm_name,
-          comm_id,
-          comm_size,
-          collective_name,
-          collective_rank,
-          input_tensor_list,
-          output_tensor_list,
-          in_split_sizes,
-          out_split_sizes));
+      c10::DebugInfoKind::PARAM_COMMS_INFO, std::move(debug_info));
 
   if (record_function_guard_->needsInputs()) {
     std::initializer_list<const c10::IValue> paramList = {
         c10::IValue(input_tensor_list),
-        std::make_tuple(++sequence_number_, false),
+        std::make_tuple(static_cast<int64_t>(sequence_number), false),
         std::make_tuple(std::string(comm_name), std::string(comm_id)),
         collective_rank,
         std::string(collective_name),
@@ -119,6 +125,7 @@ TracingGuard::TracingGuard(
     int comm_size,
     std::string_view collective_name,
     int collective_rank,
+    uint64_t sequence_number,
     const at::Tensor& input_tensor,
     const at::Tensor& output_tensor) {
   record_function_guard_.emplace(at::RecordScope::FUNCTION);
@@ -131,6 +138,7 @@ TracingGuard::TracingGuard(
       comm_size,
       collective_name,
       collective_rank,
+      sequence_number,
       {input_tensor},
       {output_tensor});
 }
@@ -140,6 +148,7 @@ TracingGuard::TracingGuard(
     int comm_size,
     std::string_view collective_name,
     int collective_rank,
+    uint64_t sequence_number,
     const std::vector<at::Tensor>& input_tensor_list,
     const std::vector<at::Tensor>& output_tensor_list) {
   record_function_guard_.emplace(at::RecordScope::FUNCTION);
@@ -152,6 +161,7 @@ TracingGuard::TracingGuard(
       comm_size,
       collective_name,
       collective_rank,
+      sequence_number,
       input_tensor_list,
       output_tensor_list);
 }
@@ -159,6 +169,7 @@ TracingGuard::TracingGuard(
 TracingGuard::TracingGuard(
     const TracingGuardInfo& info,
     std::string_view collective_name,
+    uint64_t sequence_number,
     const std::vector<at::Tensor>& input_tensor_list,
     const std::vector<at::Tensor>& output_tensor_list) {
   record_function_guard_.emplace(at::RecordScope::FUNCTION);
@@ -171,6 +182,7 @@ TracingGuard::TracingGuard(
       info.commSize,
       collective_name,
       info.rank,
+      sequence_number,
       input_tensor_list,
       output_tensor_list);
 }
@@ -178,6 +190,7 @@ TracingGuard::TracingGuard(
 TracingGuard::TracingGuard(
     const TracingGuardInfo& info,
     std::string_view collective_name,
+    uint64_t sequence_number,
     const at::Tensor& input_tensor,
     const at::Tensor& output_tensor) {
   record_function_guard_.emplace(at::RecordScope::FUNCTION);
@@ -190,6 +203,7 @@ TracingGuard::TracingGuard(
       info.commSize,
       collective_name,
       info.rank,
+      sequence_number,
       {input_tensor},
       {output_tensor});
 }

--- a/torch/csrc/distributed/c10d/nccl2/TracingGuard.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/TracingGuard.hpp
@@ -5,6 +5,7 @@
 #ifdef USE_C10D_NCCL
 
 #include <ATen/core/ivalue.h>
+#include <cstdint>
 #include <string_view>
 #include <vector>
 
@@ -25,11 +26,17 @@ struct TracingGuardInfo {
 
 class TracingGuard {
  public:
+  // `sequence_number` is the issuing process group's own collective counter
+  // (ProcessGroupNCCL::sequence_number_, the value the work handle also
+  // carries). Profilers pair collectives across ranks by (process group,
+  // sequence number), so it has to be per-PG: a process-wide counter makes a
+  // rank's numbering depend on how it interleaved its other groups' work.
   TracingGuard(
       std::string_view comm_name,
       int comm_size,
       std::string_view collective_name,
       int collective_rank,
+      uint64_t sequence_number,
       const std::vector<at::Tensor>& input_tensor_list = {},
       const std::vector<at::Tensor>& output_tensor_list = {});
 
@@ -38,18 +45,21 @@ class TracingGuard {
       int comm_size,
       std::string_view collective_name,
       int collective_rank,
+      uint64_t sequence_number,
       const at::Tensor& input_tensor,
       const at::Tensor& output_tensor);
 
   TracingGuard(
       const TracingGuardInfo& info,
       std::string_view collective_name,
+      uint64_t sequence_number,
       const std::vector<at::Tensor>& input_tensor_list = {},
       const std::vector<at::Tensor>& output_tensor_list = {});
 
   TracingGuard(
       const TracingGuardInfo& info,
       std::string_view collective_name,
+      uint64_t sequence_number,
       const at::Tensor& input_tensor,
       const at::Tensor& output_tensor);
 
@@ -59,6 +69,7 @@ class TracingGuard {
       int comm_size,
       std::string_view collective_name,
       int collective_rank,
+      uint64_t sequence_number,
       const std::vector<at::Tensor>& input_tensor_list,
       const std::vector<at::Tensor>& output_tensor_list);
 
@@ -76,8 +87,6 @@ class TracingGuard {
  private:
   std::unique_ptr<c10::DebugInfoGuard> debug_info_guard_;
   std::optional<at::RecordFunction> record_function_guard_;
-
-  inline static int sequence_number_ = 0;
 };
 
 } // namespace c10d::nccl2

--- a/torch/csrc/distributed/c10d/nccl2/WorkNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/WorkNCCL.cpp
@@ -210,7 +210,8 @@ void WorkNCCL::synchronizeInternal() {
       std::string(comm_->getCommName()),
       comm_->getSize(),
       "wait",
-      comm_->getRank());
+      comm_->getRank(),
+      seq_);
 
   // Make the current stream wait for the end event recorded on the work's
   // stream, ordering subsequent current-stream ops after this collective.

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -6659,13 +6659,38 @@ def split_group(
     # loop honors this filter so unwanted backends are never split.
     device_types_filter: list[torch.device] | None = None
     if backend is not None:
+        # The parent's per-device backends are what BackendConfig expanded its
+        # backend string to when the group was built (see
+        # _new_process_group_helper), restricted to what actually got
+        # registered. Re-deriving them from Backend.default_device_backend_map
+        # answers a different question -- "which devices default to this
+        # backend" -- and gets a bare parent string wrong: a "gloo" parent runs
+        # gloo on cuda too, and "fake" is no device's default at all.
         parent_devices = {d.type for d in parent_pg._device_types}
-        parent_device_backends = _parse_backend_string(
-            parent_backend_str, available_devices=parent_devices
-        )
-        requested_device_backends = _parse_backend_string(
-            str(backend), available_devices=parent_devices
-        )
+        parent_device_backends = {
+            device_type: str(be)
+            for device_type, be in backend_config.get_device_backend_map().items()
+            if device_type in parent_devices
+        }
+        requested_backend_str = str(backend).lower()
+        if ":" in requested_backend_str:
+            requested_device_backends = _parse_backend_string(
+                requested_backend_str, available_devices=parent_devices
+            )
+        else:
+            # A bare backend name selects every parent device running it.
+            Backend._ensure_backend_registered(requested_backend_str)
+            requested_device_backends = {
+                device_type: be
+                for device_type, be in parent_device_backends.items()
+                if be == requested_backend_str
+            }
+            if not requested_device_backends:
+                raise ValueError(
+                    f"Requested backend '{requested_backend_str}' is not present "
+                    f"in the parent process group (parent backends: "
+                    f"{parent_device_backends})"
+                )
         for device_type, requested_be in requested_device_backends.items():
             if device_type not in parent_device_backends:
                 raise ValueError(
@@ -6736,17 +6761,19 @@ def split_group(
     global_ranks_in_my_group = [parent_group_to_global_ranks[rank] for rank in my_group]
     split_pg.bound_device_id = device_id  # type: ignore[union-attr]
 
-    if torch.accelerator.is_available():
-        split_backend_class = split_pg._get_backend(
-            torch.accelerator.current_accelerator()  # pyrefly: ignore[bad-argument-type]
-        )
-    elif _use_torchcomms_enabled():
-        # torchcomms supports CPU/gloo splitting; no accelerator is required.
-        split_backend_class = split_pg._get_backend(torch.device("cpu"))
+    # `backend` may have filtered the accelerator's leg out of the child, so
+    # look the child's backend up on a device the child actually has.
+    accelerator = torch.accelerator.current_accelerator()
+    split_devices = {d.type for d in split_pg._device_types}
+    if accelerator is not None and accelerator.type in split_devices:
+        split_backend_device = accelerator
+    elif "cpu" in split_devices:
+        split_backend_device = torch.device("cpu")
     else:
         raise RuntimeError(
             "No backend for the parent process group or its backend does not support splitting"
         )
+    split_backend_class = split_pg._get_backend(split_backend_device)
 
     if split_pg.group_name != group_name:
         raise AssertionError(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -4,7 +4,6 @@
 import builtins
 import collections.abc
 import contextlib
-import copy
 import ctypes
 import hashlib
 import io
@@ -6687,11 +6686,12 @@ def split_group(
         pg_backend = Backend(str(backend))
         backend_config = BackendConfig(pg_backend)
 
-    if pg_options is None and not _use_torchcomms_enabled():
-        # default pg_options same as the parent process group
-        # A deep copy is needed because if the option will be modified inside split
-        # and if we split parent pg multiple times, we will run into device out of bound error.
-        pg_options = copy.deepcopy(parent_backend.options)
+    # pg_options is left as-is when the caller did not pass any: ProcessGroup::
+    # splitGroup gives each device's backend a copy of *that backend's* options,
+    # which is what the child needs. Substituting the default (accelerator)
+    # backend's options here would hand e.g. ProcessGroupNCCL::Options to the
+    # gloo leg of a "cpu:gloo,cuda:nccl" group, which rejects them and silently
+    # falls back to defaults, dropping the caller's timeout and group_name.
 
     # this timeout defaulting/validation is used for all the new_groups/new_subgroups variants,
     # which may just pass their timeout value (or None)

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -159,6 +159,22 @@ def _torchelastic_use_agent_store() -> bool:
     return os.environ.get("TORCHELASTIC_USE_AGENT_STORE", None) == str(True)
 
 
+def _agent_store_serves(hostname, port) -> bool:
+    """Whether the elastic agent is the one serving a store at ``hostname:port``.
+
+    ``TORCHELASTIC_USE_AGENT_STORE`` only promises a server at the agent's own
+    ``MASTER_ADDR:MASTER_PORT``, which the agent exports alongside it. Honoring
+    the flag for any other endpoint makes every rank a client of a store nobody
+    hosts. ``TCPStore``'s C++ constructor applies the same address check before
+    it forgives a failed server bind.
+    """
+    return (
+        _torchelastic_use_agent_store()
+        and os.environ.get("MASTER_ADDR") == hostname
+        and os.environ.get("MASTER_PORT") == str(port)
+    )
+
+
 def _create_c10d_store(
     hostname, port, rank, world_size, timeout, use_libuv=True
 ) -> Store:
@@ -171,21 +187,21 @@ def _create_c10d_store(
     By default, the TCPStore server uses the asynchronous implementation
     ``LibUVStoreDaemon`` which utilizes libuv.
 
-    If ``torchelastic_use_agent_store()`` is ``True``, then it is assumed that
-    the agent leader (node rank 0) hosts the TCPStore server (for which the
-    endpoint is specified by the given ``hostname:port``). Hence
+    If ``torchelastic_use_agent_store()`` is ``True`` *and* ``hostname:port`` is
+    the agent's own ``MASTER_ADDR:MASTER_PORT``, then it is assumed that the
+    agent leader (node rank 0) hosts the TCPStore server there. Hence
     ALL ranks will create and return a TCPStore client (e.g. ``start_daemon=False``).
 
-    If ``torchelastic_use_agent_store()`` is ``False``, then rank 0 will host
-    the TCPStore (with multi-tenancy) and it is assumed that rank 0's hostname
-    and port are correctly passed via ``hostname`` and ``port``. All
-    non-zero ranks will create and return a TCPStore client.
+    Otherwise rank 0 will host the TCPStore (with multi-tenancy) and it is
+    assumed that rank 0's hostname and port are correctly passed via
+    ``hostname`` and ``port``. All non-zero ranks will create and return a
+    TCPStore client.
     """
     # check if port is uint16_t
     if not 0 <= port < 2**16:
         raise ValueError(f"port must have value from 0 to 65535 but was {port}.")
 
-    if _torchelastic_use_agent_store():
+    if _agent_store_serves(hostname, port):
         # We create a new TCPStore for every retry so no need to add prefix for each attempt.
         return TCPStore(
             host_name=hostname,


### PR DESCRIPTION

Summary:
cacheAllocatorRegisterHook ran NCCLComm::registerSegment(window=true) for any
segment allocated into a pool that had been registered with symm=True, and on
NCCL 2.29.7 ncclCommWindowRegister is unconditionally collective:
src/dev_runtime.cc enqueues a group task that runs
bootstrapIntraNodeAllGather to exchange memory handles,
bootstrapIntraNodeBarrier to make sure everyone imported them,
bootstrapIntraNodeBroadcast for the multicast handle, and a final
bootstrapBarrier for the symmetric window. Every rank of the communicator must
call it, the same number of times, in the same order, and none of those
bootstrap sockets has a timeout.

The hook is the wrong place for that. It is called from record_trace, which
CUDACachingAllocator invokes from alloc_block and release_block with the device
allocator's recursive_mutex held, immediately under the comment "Callbacks
should not include any Pytorch call". So the NCCL rendezvous blocks every other
thread in the process that wants to allocate. It also runs on whatever thread
happens to allocate or free -- the main thread, an autograd worker, or for
SEGMENT_FREE the GC pass that drops the last MemPool reference. And
SEGMENT_ALLOC / SEGMENT_FREE are purely local allocator decisions: a
rank-specific tensor, or fragmentation-driven release_available_cached_blocks
firing out of the OOM retry on whichever rank happens to be tight, is enough to
make one rank call and the others not.

Reproduced as a hard hang on stock nccl, 2 ranks, no torchcomms in the process:
all ranks register a symm pool, rank 0 alone allocates one more tensor into it,
and rank 0's next plain torch.zeros() never returns. py-spy --native:

    accept (libc.so.6)
    ncclSocketAccept -> socketAccept (bootstrap.cc:1057)
    bootstrapIntraNodeAllGather (bootstrap.cc:1226)
    symMemoryMapLsaTeam -> symMemoryObtain -> ncclDevrWindowRegisterInGroup
    pncclCommWindowRegister (dev_runtime.cc:1102)
    c10d::NCCLComm::registerSegment
    c10d::cacheAllocatorRegisterHook
    ...::record_trace -> alloc_block -> NativeCachingAllocator::malloc
    at::detail::empty_cuda ... THPVariable_zeros

There is no recovery from that state. ProcessGroupNCCL::abortComms() takes
ncclCommMemPoolMapMutex before aborting the comms, and the parked hook is
holding that mutex for the whole duration of the NCCL call, so the watchdog
blocks behind it. Re-run with a 20 s PG timeout and a 130 s budget, both ranks
still had to be killed.

How it was found: by inspection while implementing nccl2's register_mem_pool
(earlier in this stack). Writing down *why* nccl2 defers window registration out
of the allocator hook forced the question of whether stock's version of the same
hook was safe, and reading NCCL 2.29.7's dev_runtime.cc answered it. No
downstream run failed: Megatron's nccl_allocator always deregisters its pool
collectively before allocating into it again, which is why the tp2_dp2_nvls
bit-exact cell was clean. The purpose-built 2-rank harness is what turned the
analysis into the reproducible hang above. The NVLS work raised the
reachability -- more segments carry windows -- but did not create the bug.

Working around this downstream is not possible in general. The hang happens
inside an ordinary torch.zeros() with the allocator mutex held, so the only
downstream mitigation is to guarantee that no rank ever allocates into (or frees
from) a symm-registered pool without every peer doing the same, in the same
order -- unachievable when the divergence source is an OOM-driven
release_available_cached_blocks on whichever rank happens to be tight. The
alternative mitigation is "never call register_mem_pool(symm=True)", i.e. give
up NVLS. And once wedged there is no escape hatch at any layer: NCCL's bootstrap
sockets have no timeout, and c10d's own watchdog blocks behind the hook's mutex.
The invariant has to be enforced where the hook is installed.

The rule this change enforces is that the trace hook may only make NCCL calls
that are local to this rank. cacheAllocatorRegisterHook now always registers
with window=false and TORCH_WARN_ONCEs when it sees a symm pool, pointing at
deregister_mem_pool() + register_mem_pool() as the collective way to get new
segments windowed. Symmetric windows are created exclusively by
registerMemPool(), which the user calls collectively. The rule is written down
as NOTE [NCCL calls from the caching allocator trace hooks] next to the hooks,
because the next person to add a call here needs the reason, not just the
current shape.

This is a deliberate behaviour change: segments allocated into a symm pool
*after* register_mem_pool(symm=True) are no longer auto-upgraded to symmetric
windows. They stay registered as plain NCCL user buffers, so collectives over
them take the non-symmetric algorithm -- the same decision on every rank, so no
mismatch. That auto-upgrade is exactly what hangs, and the hook has no way to
know whether the peers are making the same allocation. The cheaper-looking
alternative -- keep the upgrade but only when the allocation "looks symmetric"
-- does not exist: the hook sees one rank's allocator, and any predicate it
could evaluate is exactly the local decision that diverges. Losing NVLS on late
segments is a performance regression for a workload that grows its pool after
registering it; hanging is not a performance regression, so the trade is not
close. Callers that want the windows back have a supported, collective way to
get them, and the warning names it.

Two smaller hazards on the same path are fixed with it. ncclCommMemPoolMap is
keyed by shared_ptr<NCCLComm> and hashed by pointer, so its iteration order is
heap-address order and differs between ranks; with two communicators sharing a
symm pool, rank A could issue windowRegister(commX) then windowRegister(commY)
while rank B did the reverse -- two blocking rendezvous in opposite orders, a
deadlock even under perfectly symmetric allocation. The new
commsInterestedInSegment() returns the interested comms sorted by
NCCLComm::getUniqueHash() -- the hex of the ncclUniqueId plus ":<splitCounter>"
for split children, the one key every rank agrees on; device index or pointer
order would not do. The map mutex is still held across the calls on purpose:
that is what keeps abortComms() from retiring a comm underneath the hook.

NCCLUtils' deregisterSegment(void* ptr) loses its `window` parameter and uses
the flag recorded at registration time instead. That is required by the above: a
symm pool can now hold both windowed segments (from registerMemPool) and locally
registered ones (from the hook), and handing a ncclReg* to
ncclCommWindowDeregister, or the reverse, is a handle type confusion. Deriving
the API from the registration record rather than from the caller's view of the
pool makes that unrepresentable, which is why the parameter is removed rather
than merely fixed at the two call sites.

One correction to the record while here. ncclCommWindowDeregister is *not*
collective on upstream NCCL 2.29.7: symWindowDestroy -> symMemoryDropRef +
ncclCommDeregister contains no bootstrap call, and the divergent-free case was
verified not to hang here. It is collective under NCCLX with rmaAlgo != orig,
where it goes through ctran::ctranWinFree -> CtranWin::free and takes a
windowBarrier. So the deregister half is build-dependent rather than
unconditionally broken. The teardown is kept regardless -- dropping it would
leave a stale window over an address range the allocator is about to hand out
again, so a later allocation reusing that range would silently resolve to the
stale window, which is memory corruption rather than a hang, and strictly worse
-- but the hook now warns once that this is the uncollective path. In other
words the risky half is kept knowingly, because the safe-looking alternative is
unsafe.

The nccl2 backend shares the two secondary hazards and is hardened the same way
earlier in this stack, in "[c10d][nccl2] Never issue collective NCCL calls from
the caching-allocator trace hook"; its register half was already correct.

Test Plan:
A 2-rank harness on the four interesting shapes, on GPUs 2,3, each cell under a
200 s cap. Every cell uses backend="nccl" with no torchcomms in the process, so
it exercises the code changed here:

    CUDA_VISIBLE_DEVICES=2,3 timeout 200 python \
      triage/bug6_alloc_hook_collective.py <mode>

  - div_alloc (divergent allocation into a symm pool) -- the direct regression
    check -- went from a hang the watchdog could not break (exitcodes [1, 1]) to
    both ranks printing DONE (exitcodes [0, 0])
  - sym_alloc (symmetric allocation):          exitcodes [0, 0], stayed green
  - div_free (divergent free):                 exitcodes [0, 0], stayed green
  - div_alloc_local (divergence, symm=False):  exitcodes [0, 0], stayed green

The existing registration tests, including the one most likely to notice the
behaviour change above:

    python -m pytest test/distributed/test_c10d_nccl.py \
      -k "window_registration or user_buffer_registration" -v
    NcclUserBufferRegistrationTest::test_nccl_user_buffer_registration PASSED
    NcclUserBufferRegistrationTest::test_nccl_window_registration      PASSED
    2 passed, 282 deselected

No CI regression test is added: the pre-fix failure mode is a hang, so such a
test can only fail by timing out.

Two things this does not establish. The NCCLX collective-deregister path is
inferred from source, not measured -- everything ran against upstream NCCL
2.29.7. And all runs were single-node, 2 or 4 ranks, so the getUniqueHash()
ordering fix and the multi-communicator iteration-order deadlock it closes
remain argued rather than reproduced.

Authored with the assistance of an AI coding agent.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/192101).
* __->__ #192101
* #191988
* #191996
* #191990
* #191989
* #191987
* #191986
* #191985
* #191952
* #191951
* #191950
* #191949
* #191948
* #191782