### PR TITLE
[Test] Refactored test_ops.py to include hw_classification

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -44,6 +44,8 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    instantiate_parametrized_tests,
     is_iterable_of_tensors,
     noncontiguous_like,
     parametrize,
@@ -441,6 +443,8 @@ complex_ordered_op_db = tuple(
 @unittest.skipIf(TEST_WITH_ASAN, "tests time out with asan, are probably redundant")
 @unMarkDynamoStrictTest
 class TestOperators(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
     @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
     @skipOps(
@@ -2427,30 +2431,6 @@ class TestOperators(TestCase):
             for loop_out, batched_out in generator:
                 self.assertEqual(loop_out, batched_out)
 
-    def test_vmapvmapjvp_linalg_solve(self):
-        ops = [op for op in op_db if op.name == "linalg.solve"]
-        if len(ops) == 0:
-            raise AssertionError("Expected at least one linalg.solve op")
-
-        # this specializes a lot of code from the get_fallback_and_vmap_exhaustive test. If we need this more
-        # generally, this could go for a refactor
-
-        B0 = 2
-        B1 = 3
-
-        # we want to check the case where A will be seen as contiguous by jvp but during the vmap calls will become
-        # non-contiguous because vmap will expand. This will happen during both levels of vmap
-        A = torch.randn(4, 4)
-        k = torch.randn(4, 5, B1, B0)
-        fn, args = get_jvp_variant_primals_tangents(
-            torch.linalg.solve, SampleInput(A, args=(k,))
-        )
-
-        in_dims_all = (None, -1, None, -1)
-        batched_out = vmap(vmap(fn, in_dims=in_dims_all), in_dims=in_dims_all)(*args)
-        loop_out = loop2(fn, in_dims_all, in_dims_all, 0, 0, B0, B1, *args)
-        self.assertEqual(loop_out, batched_out)
-
     @ops(
         filter(lambda op: op.name in aliasing_ops, op_db + additional_op_db),
         allowed_dtypes=(torch.float,),
@@ -2518,44 +2498,6 @@ class TestOperators(TestCase):
                 else:
                     if grad_op != "vjp":
                         raise AssertionError(f"Expected 'vjp', got {grad_op!r}")
-                    vjp(f, torch.randn_like(without_grad))
-
-    @parametrize("grad_op", ["jvp", "vjp"])
-    def test_view_then_inplace_special(self, grad_op):
-        # some things in __getitem__ use at::index, which doesn't alias, so this tests a subset of them that do alias
-        ops = [
-            lambda x: x[0],
-            lambda x: x[0, 0, 0],
-            lambda x: x[:1],
-            lambda x: x[:, :1],
-            lambda x: x[:, :1, :],
-        ]
-
-        for op in ops:
-
-            def f(x):
-                op(captured).copy_(x)
-                return x
-
-            captured = torch.randn(4, 3, 3)
-            without_grad = op(captured)
-            if grad_op == "jvp":
-                with self.assertRaisesRegex(
-                    RuntimeError,
-                    "During a grad .* attempted to call in-place operation",
-                ):
-                    jvp(
-                        f,
-                        (torch.randn_like(without_grad),),
-                        (torch.randn_like(without_grad),),
-                    )
-            else:
-                if grad_op != "vjp":
-                    raise AssertionError(f"Expected 'vjp', got {grad_op!r}")
-                with self.assertRaisesRegex(
-                    RuntimeError,
-                    "During a grad .* attempted to call in-place operation",
-                ):
                     vjp(f, torch.randn_like(without_grad))
 
     @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
@@ -2938,6 +2880,74 @@ class TestOperators(TestCase):
                 **sample_input.kwargs,
             )
 
+
+class TestOperatorsGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_vmapvmapjvp_linalg_solve(self):
+        ops = [op for op in op_db if op.name == "linalg.solve"]
+        if len(ops) == 0:
+            raise AssertionError("Expected at least one linalg.solve op")
+
+        # this specializes a lot of code from the get_fallback_and_vmap_exhaustive test. If we need this more
+        # generally, this could go for a refactor
+
+        B0 = 2
+        B1 = 3
+
+        # we want to check the case where A will be seen as contiguous by jvp but during the vmap calls will become
+        # non-contiguous because vmap will expand. This will happen during both levels of vmap
+        A = torch.randn(4, 4)
+        k = torch.randn(4, 5, B1, B0)
+        fn, args = get_jvp_variant_primals_tangents(
+            torch.linalg.solve, SampleInput(A, args=(k,))
+        )
+
+        in_dims_all = (None, -1, None, -1)
+        batched_out = vmap(vmap(fn, in_dims=in_dims_all), in_dims=in_dims_all)(*args)
+        loop_out = loop2(fn, in_dims_all, in_dims_all, 0, 0, B0, B1, *args)
+        self.assertEqual(loop_out, batched_out)
+
+    @parametrize("grad_op", ["jvp", "vjp"])
+    def test_view_then_inplace_special(self, grad_op):
+        # some things in __getitem__ use at::index, which doesn't alias, so this tests a subset of them that do alias
+        ops = [
+            lambda x: x[0],
+            lambda x: x[0, 0, 0],
+            lambda x: x[:1],
+            lambda x: x[:, :1],
+            lambda x: x[:, :1, :],
+        ]
+
+        for op in ops:
+
+            def f(x):
+                op(captured).copy_(x)
+                return x
+
+            captured = torch.randn(4, 3, 3)
+            without_grad = op(captured)
+            if grad_op == "jvp":
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "During a grad .* attempted to call in-place operation",
+                ):
+                    jvp(
+                        f,
+                        (torch.randn_like(without_grad),),
+                        (torch.randn_like(without_grad),),
+                    )
+            else:
+                if grad_op != "vjp":
+                    raise AssertionError(f"Expected 'vjp', got {grad_op!r}")
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "During a grad .* attempted to call in-place operation",
+                ):
+                    vjp(f, torch.randn_like(without_grad))
+
+
+instantiate_parametrized_tests(TestOperatorsGeneric)
 
 only_for = ("cpu", "cuda")
 instantiate_device_type_tests(TestOperators, globals(), only_for=only_for)

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -2881,6 +2881,8 @@ class TestOperators(TestCase):
             )
 
 
+@unittest.skipIf(TEST_WITH_ASAN, "tests time out with asan, are probably redundant")
+@unMarkDynamoStrictTest
 class TestOperatorsGeneric(TestCase):
     hw_classification = HardwareClassification.GENERIC
 


### PR DESCRIPTION
## Summary
Apply hardware classification structure following #186918 guidelines.

Changes:
- Add hw_classification = ACCELERATOR to TestOperators — 35 device-parametrized op tests
- Split TestOperatorsGeneric (hw_classification = GENERIC) — 2 CPU-only transform tests  
(test_vmapvmapjvp_linalg_solve, test_view_then_inplace_special)
- Add instantiate_parametrized_tests for TestOperatorsGeneric
- Restore class decorators (@unittest.skipIf ASAN, @unMarkDynamoStrictTest) on TestOperatorsGeneric

**Note on moved tests**: test_vmapvmapjvp_linalg_solve and test_view_then_inplace_special were moved from TestOperators to TestOperatorsGeneric. As a result, they drop from two device instantiations (CPU + CUDA) to one and get new test IDs. For example:

Old: TestOperatorsCPU.test_view_then_inplace_special_grad_op_jvp_cpu
New: TestOperatorsGeneric.test_view_then_inplace_special_grad_op_jvp
No in-tree references (slow_tests.json, dynamo_skips/, dynamo_expected_failures/) point to the old IDs, so there is no breakage.

## Test Plan

```bash
python -m pytest test/functorch/test_ops.py -v
# 15207 passed, 4658 skipped, 743 xfailed in 6729.88s (1:52:09)

python -m pytest test/functorch/test_ops.py --collect-only -q --hw-classification GENERIC
# 3 tests selected (20608 collected)

python -m pytest test/functorch/test_ops.py --collect-only -q --hw-classification ACCELERATOR
# 20605 tests selected (20608 collected)

# GENERIC: 3, ACCELERATOR: 20605, total: 20608, unclassified: 0
```

CC: @vishalgoyal316 @RiyaP2508 @mansiag05