### PR TITLE
Set OpOverloadPacket.qualname instead of leaking the pybind11 one

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2507,6 +2507,17 @@ class TestSelfKwarg(TestCase):
         torch.ops.aten.min.default(self=torch.rand(100))
 
 
+class TestOpOverloadPacket(TestCase):
+    def test_qualname(self):
+        # https://github.com/pytorch/pytorch/issues/186140
+        # __qualname__ used to leak the pybind11 function-record qualname of
+        # the underlying C++ op through OpOverloadPacket.__getattr__.
+        packet = torch.ops.aten.sin
+        self.assertEqual(packet.__qualname__, "sin")
+        self.assertEqual(packet.__name__, "sin")
+        self.assertEqual(packet.default.__qualname__, "aten::sin")
+
+
 @unMarkDynamoStrictTest
 class TestRefsOpsInfo(TestCase):
     hw_classification = HardwareClassification.GENERIC

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2542,6 +2542,17 @@ class TestSelfKwarg(TestCase):
         torch.ops.aten.min.default(self=torch.rand(100))
 
 
+class TestOpOverloadPacket(TestCase):
+    def test_qualname(self):
+        # https://github.com/pytorch/pytorch/issues/186140
+        # __qualname__ used to leak the pybind11 function-record qualname of
+        # the underlying C++ op through OpOverloadPacket.__getattr__.
+        packet = torch.ops.aten.sin
+        self.assertEqual(packet.__qualname__, "sin")
+        self.assertEqual(packet.__name__, "sin")
+        self.assertEqual(packet.default.__qualname__, "aten::sin")
+
+
 @unMarkDynamoStrictTest
 class TestRefsOpsInfo(TestCase):
     hw_classification = HardwareClassification.GENERIC

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -1248,6 +1248,9 @@ class OpOverloadPacket(Generic[_P, _T]):
         # defined below but are immutable
         self._qualified_op_name = qualified_op_name
         self.__name__ = op_name
+        # Without this, __getattr__ would forward __qualname__ to the pybind11
+        # function self._op, which has an unreadable internal qualname.
+        self.__qualname__ = op_name
         self._op = op
         self._overload_names = overload_names
         self._dir: list[str] = []


### PR DESCRIPTION
Fixes #186140

torch.ops.aten.sin.__qualname__ used to print pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1.sin. OpOverloadPacket never sets __qualname__, and its __getattr__ forwards dunder attributes to the underlying pybind11-bound function, so the pybind internal name leaked through. Now __init__ sets __qualname__ to the op name, same as __name__, so it reads as sin with __module__ still torch._ops.aten. Went with the plain op name rather than aten::sin because that string is already the qualname of the default overload and is used as a registry key (torch.library._defs, torch._library.simple_registry), so reusing it for the packet could conflate the two.

Added a small regression test in test/test_ops.py.