### PR TITLE
[ROCm] Remove obsolete skipIfRocm from nested tensor SDPA tests (test_sdpa_autocast, test_compile_preserves_metadata_cache)

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -7359,8 +7359,6 @@ torch.cuda.synchronize()
     )
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     @onlyCUDA
-    # flash_attention_forward meta kernel shape mismatch on CDNA - see issue #171568
-    @skipIfRocm
     @skipIfTorchDynamo()
     def test_sdpa_autocast(self, device):
         def fn_nt(values32, values16, offsets):
@@ -7847,8 +7845,6 @@ torch.cuda.synchronize()
 
     @dtypes(torch.float32)
     @skipIfTorchDynamo("Test compiles internally")
-    # efficient_attention_forward meta kernel shape mismatch on CDNA - see issue #171568
-    @skipIfRocm
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     def test_compile_preserves_metadata_cache(self, device, dtype):
         # shape (B, *, D)


### PR DESCRIPTION
FIXES https://github.com/pytorch/pytorch/issues/168789
FIXES https://github.com/pytorch/pytorch/issues/168792

### Investigation summary

On a machine with an MI300X / gfx942 GPU, Torch `2.14.0a0+git59e389b` and HIP `7.2.53211`. All tests verified on main @ 59e389b.

### Root cause

Both skips were added for #171568 (fused-attention meta-kernel shape mismatch on CDNA). That issue was closed without a landed fix, but the underlying LSE shape mismatches have since been fixed on main:

- `test_sdpa_autocast` (flash attention, varlen path): the AOTriton 0.12b bump #184288 switched the ROCm varlen logsumexp to the compact `(num_heads, total_q)` shape the meta kernel expects; the CK varlen path was similarly fixed by #178322.
- `test_compile_preserves_metadata_cache` (efficient attention): #190723 added a `torch.version.hip` branch to `meta__efficient_attention_forward` matching the ROCm kernel's unpadded LSE. That fix is the base commit (59e389b) used for verification here.

These are the only two references to #171568 in the file (`grep -n 171568 test/test_nestedtensor.py`).

### Proposed changes

Removes two obsolete @skipIfRocm decorators in test/test_nestedtensor.py:
- `TestNestedTensorSubclass::test_sdpa_autocast`
- `TestNestedTensorSubclass::test_compile_preserves_metadata_cache`

### Verification 

After removing their respective @skipIfRocm, the tests show:

```
PYTORCH_TEST_WITH_ROCM=1 python -m pytest test/test_nestedtensor.py -k "test_sdpa_autocast" -v
test/test_nestedtensor.py::TestNestedTensorSubclassCUDA::test_sdpa_autocast_cuda PASSED [4.2950s]
```

```
PYTORCH_TEST_WITH_ROCM=1 python -m pytest test/test_nestedtensor.py -k "test_compile_preserves_metadata_cache" -v
test/test_nestedtensor.py::TestNestedTensorSubclassCUDA::test_compile_preserves_metadata_cache_cuda_float32 PASSED
```

Also tried setting `--flake-finder --flake-runs=50` for both test commands above, they passed for each iteration.

*(Root cause section updated by @jeffdaily, drafted with an AI assistant.)*

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
