### PR TITLE
[inductor] Drop the dead frame walk in _find_names

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -50,6 +50,7 @@ from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
     _check_max_grid_x,
     _enforce_reduction_config_block_minimums,
+    _find_names,
     _num_warps,
     _persistent_reduction_configs,
     _reduction_configs,
@@ -65,6 +66,12 @@ from torch._inductor.runtime.triton_heuristics import (
 )
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_cache
+
+
+class _FindNamesProbe:
+    # A gc-tracked stand-in for a CachingAutotuner; object() is untracked, so a
+    # dict holding one can itself stay untracked and escape gc.get_referrers.
+    pass
 
 
 @triton.jit
@@ -94,6 +101,41 @@ def get_autotuned_amd_sqr_kernel():
 @instantiate_parametrized_tests
 class TestTritonHeuristics(TestCase):
     device_type = GPU_TYPE
+
+    def test_find_names_ignores_frame_locals(self):
+        """
+        A kernel held only by frame locals has no name, so DebugAutotuner can
+        fall back to inductor_meta["kernel_name"]. The stack walk used to leak
+        _find_names' own `obj` and the caller's `self` into the result.
+        """
+        probe = _FindNamesProbe()
+        self.assertEqual(_find_names(probe), [])
+
+    def test_find_names_finds_namespace_binding(self):
+        probe = _FindNamesProbe()
+        namespace = {"triton_poi_fused_add_0": probe}
+        try:
+            self.assertIn("triton_poi_fused_add_0", _find_names(probe))
+        finally:
+            del namespace
+
+    def test_unbound_kernel_falls_back_to_inductor_meta_name(self):
+        """
+        The label DebugAutotuner.run derives for an unbound kernel. The stack
+        walk made _find_names return ['obj', 'self'], so max(..., key=len)
+        picked "self" instead of reaching the inductor_meta fallback.
+        """
+
+        class FakeAutotuner:
+            inductor_meta = {"kernel_name": "triton_poi_fused_add_0"}
+
+            def kernel_name(self):
+                possible_names = _find_names(self)
+                if possible_names:
+                    return f"{max(possible_names, key=len)}"
+                return self.inductor_meta["kernel_name"]
+
+        self.assertEqual(FakeAutotuner().kernel_name(), "triton_poi_fused_add_0")
 
     def test_triton_config(self):
         """

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3327,16 +3327,13 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
 
 def _find_names(obj):
     import gc
-    import inspect
 
-    frame = inspect.currentframe()
-    while frame is not None:
-        # On CPython <= 3.12 this access materializes the frame's locals
-        # dict so gc.get_referrers below can find obj inside it. On 3.13+
-        # f_locals is a fresh write-through proxy (PEP 667) and this loop
-        # is a no-op, so function-local names are not discoverable there.
-        _ = frame.f_locals
-        frame = frame.f_back
+    # Only namespace dicts are searched. Wrapper codegen binds kernels in the
+    # generated module's globals, so that is where the real name comes from.
+    # Walking the stack to expose frame locals as well only adds incidental
+    # binding names (`obj` here, `self` in the caller), never the codegen name,
+    # and it kept an unbound kernel from falling back to
+    # inductor_meta["kernel_name"].
     obj_names = []
     for referrer in gc.get_referrers(obj):
         if isinstance(referrer, dict):

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3363,16 +3363,13 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
 
 def _find_names(obj):
     import gc
-    import inspect
 
-    frame = inspect.currentframe()
-    while frame is not None:
-        # On CPython <= 3.12 this access materializes the frame's locals
-        # dict so gc.get_referrers below can find obj inside it. On 3.13+
-        # f_locals is a fresh write-through proxy (PEP 667) and this loop
-        # is a no-op, so function-local names are not discoverable there.
-        _ = frame.f_locals
-        frame = frame.f_back
+    # Only namespace dicts are searched. Wrapper codegen binds kernels in the
+    # generated module's globals, so that is where the real name comes from.
+    # Walking the stack to expose frame locals as well only adds incidental
+    # binding names (`obj` here, `self` in the caller), never the codegen name,
+    # and it kept an unbound kernel from falling back to
+    # inductor_meta["kernel_name"].
     obj_names = []
     for referrer in gc.get_referrers(obj):
         if isinstance(referrer, dict):


### PR DESCRIPTION
### Background

While addressing your review feedback on #191866, your review bot pointed out that a comment I had added to `_find_names` describes behavior that stopped being true in CPython 3.13 (PEP 667). That was correct — and checking it showed the *code* under the comment has a bug of its own. #191866 only corrected the wording; this fixes the function.

### The bug

`_find_names()` resolves the name a `CachingAutotuner` is bound to, so `DebugAutotuner` can label kernels in bandwidth-profiling output. It walked the stack reading `frame.f_locals` **purely for the side effect** of materializing each frame's locals dict, so that the `gc.get_referrers()` scan below would also see frame locals:

```python
frame = inspect.currentframe()
while frame is not None:
    frame.f_locals          # side effect: materialize + cache a real dict
    frame = frame.f_back
```

That walk only ever contributed noise. The frames it exposes are `_find_names`' own frame, which binds the kernel to `obj`, and `DebugAutotuner.run`'s frame, which binds it to `self`. The real name comes from inductor's wrapper codegen binding kernels in a module namespace, and `gc.get_referrers()` finds that on its own.

The damage is in exactly the case the walk was supposed to help. When a kernel is held only by frame locals, `possible_names` came back as `['obj', 'self']` rather than empty, so the fallback below it — and the comment explaining that the AOTI lazy-compile path has no module-level name — was **unreachable**, and `max(possible_names, key=len)` labelled the kernel `"self"`.

CPython 3.13 already removed the walk's effect: under [PEP 667](https://peps.python.org/pep-0667/), `f_locals` on an optimized frame returns a fresh write-through `FrameLocalsProxy` that caches nothing and is not a `dict`, so it is skipped by the `isinstance(referrer, dict)` filter. Nothing regressed when that happened, and the unbound case started falling back correctly on 3.13+. This PR deletes the walk so every supported interpreter behaves the way 3.13 and 3.14 already do.

### Test plan

Added `test_find_names_ignores_frame_locals` and `test_find_names_finds_namespace_binding` to `test/inductor/test_triton_heuristics.py`. The first fails on the current implementation on CPython <= 3.12 (returns `['obj', 'self']` rather than `[]`) and passes on 3.13+; the second pins the namespace lookup the fix must preserve. Both are CPU-only.

The probe is a user-defined class rather than `object()`: `object()` is untracked by gc, so a dict holding one can itself stay untracked and escape `gc.get_referrers` — that made the naive version of this test pass on 3.14 but not on 3.12/3.13.

My environment cannot build torch, so I also ran the current and patched implementations against a faithful copy of the call shape (a method calling `_find_names(self)`, with the object either bound in a namespace or unbound) under three interpreters:

```
python 3.12.9
  before: namespace-bound -> picks 'triton_poi_fused_add_0';  unbound -> picks 'self'
  after : namespace-bound -> picks 'triton_poi_fused_add_0';  unbound -> falls back
python 3.13.14 / 3.14.6
  before: namespace-bound -> picks 'triton_poi_fused_add_0';  unbound -> falls back
  after : namespace-bound -> picks 'triton_poi_fused_add_0';  unbound -> falls back
```

Lint with the CI-pinned ruff 0.14.4 (`ruff check` and `ruff format --check`) passes on both files.

A larger cleanup is possible — dropping `_find_names` entirely and always using `inductor_meta["kernel_name"]` — but that changes kernel labels for every profiled run, so I kept this diff to the defect. Happy to do it as a follow-up if you'd prefer.

@jansel — follow-up to the finding your bot raised on #191866.

> Authored with the assistance of an AI coding assistant (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo