### PR TITLE
[TEST] Refactor test_dtensor_dispatch_overhead.py with hw_classification

### DIFF
--- a/test/distributed/tensor/test_dtensor_dispatch_overhead.py
+++ b/test/distributed/tensor/test_dtensor_dispatch_overhead.py
@@ -10,8 +10,9 @@ from collections import namedtuple
 import torch
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Shard
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -62,6 +63,8 @@ class TimeCaptureMode(TorchDispatchMode):
 
 
 class DistOpDispatchOverHead(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 4
@@ -69,19 +72,14 @@ class DistOpDispatchOverHead(DTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @with_comms
     def test_dtensor_add_op_dispatch_overhead(self):
-        if torch.cuda.is_available():
-            device_props = torch.cuda.get_device_name(0)
-            gpu_name = device_props
-            logger.info("running on %s", gpu_name)
-            # TODO: adjust `expected_propagate_time` and `expected_dispatch_time` to target different hardware
-        else:
-            self.skipTest("CUDA not available")
+        # TODO: adjust `expected_propagate_time` and `expected_dispatch_time` to target different hardware
+        logger.info("running on %s", self.device_type)
         expected_propagate_time = 880  # noqa: F841
         expected_dispatch_time = 90  # noqa: F841
         diff_percent_threshold = 0.20  # noqa: F841
         propagator = DTensor._op_dispatcher.sharding_propagator
-        device_mesh = init_device_mesh("cuda", (self.world_size,))
-        input_data = torch.rand(512, 512, device="cuda")
+        device_mesh = init_device_mesh(self.device_type, (self.world_size,))
+        input_data = torch.rand(512, 512, device=self.device_type)
         a = distribute_tensor(input_data, device_mesh, [Shard(0)])
         # warm up
         with TimeCaptureMode() as tcm:
@@ -134,6 +132,8 @@ class DistOpDispatchOverHead(DTensorTestBase):
         #     ),
         # )
 
+
+instantiate_device_type_tests(DistOpDispatchOverHead, globals())
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
Apply hardware classification following #186918 guidelines.

Changes:
- `DistOpDispatchOverHead`: `ACCELERATOR`
- Replace hardcoded `"cuda"` with `self.device_type`
- Add `instantiate_device_type_tests(DistOpDispatchOverHead, globals())`

## Test Plan
**lintrunner -a test/distributed/tensor/test_dtensor_dispatch_overhead.py**
```
ok No lint issues.
```

**python test/distributed/tensor/test_dtensor_dispatch_overhead.py -v**
```
Ran 2 tests in 19.800s -- OK
```

Authored with an AI assistant.
