### PR TITLE
[BE] Fix B007 unused loop control variables in benchmarks/

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -711,7 +711,7 @@ def timed(
 
     time_total = 0
     # Dont collect outputs to correctly measure timing
-    for i in range(times):
+    for _ in range(times):
         # If batch_size is 1, it too often collides with other non batch size
         # dimensions resulting in errors.
         if batch_size and batch_size > 1:
@@ -1296,7 +1296,7 @@ def baselines(models, model_iter_fn, example_inputs, args):
     timings = np.zeros((args.repeat, len(models)), np.float64)
     timings.fill(1.0e10)
     for rep in range(args.repeat):
-        for idx, (name, model) in enumerate(models):
+        for idx, (_name, model) in enumerate(models):
             if model is not None:
                 try:
                     timings[rep, idx] = timed(model, model_iter_fn, example_inputs)
@@ -1308,7 +1308,7 @@ def baselines(models, model_iter_fn, example_inputs, args):
     ]
     median = np.median(timings, axis=0)
     speedup = median[0] / median[1:]
-    for idx, (name, model) in enumerate(models[1:]):
+    for idx, (_name, model) in enumerate(models[1:]):
         if model is None:
             speedup[idx] = 0.0
     result = " ".join(

--- a/benchmarks/dynamo/distributed.py
+++ b/benchmarks/dynamo/distributed.py
@@ -34,7 +34,7 @@ def torchviz_model(args, model, inputs, rank):
 
 def profile_model(args, model, inputs, rank):
     with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
-        for i in range(args.repeat):
+        for _ in range(args.repeat):
             with record_function("Forward"):
                 outputs = model(*inputs)
                 loss = reduce_to_scalar_loss(outputs)

--- a/benchmarks/dynamo/microbenchmarks/analyze_templates.py
+++ b/benchmarks/dynamo/microbenchmarks/analyze_templates.py
@@ -150,7 +150,7 @@ def optimize_templates(N, occurrence_count, benchmark_logs, verbose=False):
         )
 
         # Ensure Triton templates can only be selected if they are included in the N allowed templates
-        for triton_time, template in triton_options:
+        for _triton_time, template in triton_options:
             prob += selection_vars[(shape, template)] <= template_vars[template]
 
     # Print the constraints

--- a/benchmarks/dynamo/microbenchmarks/fx_microbenchmarks.py
+++ b/benchmarks/dynamo/microbenchmarks/fx_microbenchmarks.py
@@ -20,7 +20,7 @@ def main():
     g = huge_graph()
 
     def fn():
-        for n in g.graph.nodes:
+        for _ in g.graph.nodes:
             pass
 
     t = min(timeit.repeat(fn, number=K, repeat=3))

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/mm_loop.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/mm_loop.py
@@ -41,7 +41,7 @@ class Benchmark(BenchmarkBase):
         )
         def f(a, b):
             z = torch.mm(a, b)
-            for i in range(200):
+            for _ in range(200):
                 z = torch.mm(z, b)
             return z
 

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/nested_module.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/nested_module.py
@@ -18,10 +18,10 @@ class NestedModule(nn.Module):
 
         sub_mods = []
         if depth > 0:
-            for i in range(width):
+            for _ in range(width):
                 sub_mods.append(NestedModule(depth - 1, width))
         else:
-            for i in range(width):
+            for _ in range(width):
                 sub_mods.append(nn.ReLU())
         self.sub_mods = nn.Sequential(*sub_mods)
         self.a = 2

--- a/benchmarks/dynamo/summarize_perf.py
+++ b/benchmarks/dynamo/summarize_perf.py
@@ -29,7 +29,7 @@ def find_csv_files(path, perf_compare):
             return f.endswith("_performance.csv")
 
     csv_files = []
-    for root, dirs, files in os.walk(path):
+    for root, _dirs, files in os.walk(path):
         for file in files:
             if is_csv(file):
                 csv_files.append(os.path.join(root, file))

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -41,7 +41,7 @@ def _reassign_parameters(model):
     # https://github.com/pyg-team/pytorch_geometric/blob/master/torch_geometric/nn/dense/linear.py#L158-L168
     # Since it is unusual thing to do, we just reassign them to parameters
     def state_dict_hook(module, destination, prefix, local_metadata):
-        for name, param in module.named_parameters():
+        for name, _param in module.named_parameters():
             if isinstance(destination[name], torch.Tensor) and not isinstance(
                 destination[name], torch.nn.Parameter
             ):

--- a/benchmarks/dynamo/training_loss.py
+++ b/benchmarks/dynamo/training_loss.py
@@ -64,7 +64,7 @@ def model_training_evaluation(
     else:
         # Support backends: eager, aot_eager, aot_nvfuser and inductor
         opt_training_iter_fn = torch._dynamo.optimize(backend)(training_iter_fn)
-    for epoch in range(num_epochs):
+    for _ in range(num_epochs):
         running_loss = 0.0
         for i, batch in enumerate(train_dataloader, 0):
             batch = {k: v.to(device) for k, v in batch.items()}

--- a/benchmarks/fastrnns/factory.py
+++ b/benchmarks/fastrnns/factory.py
@@ -339,7 +339,7 @@ def layernorm_pytorch_lstm_creator(**kwargs):
         # Layernorm cudnn LSTM in the forward pass
         seq_len = len(input.unbind(0))
         hy, cy = new_hidden
-        for i in range(seq_len):
+        for _ in range(seq_len):
             ln_i(ln_input1)
             ln_h(ln_input1)
             cy = ln_c(cy)

--- a/benchmarks/fastrnns/scratch.py
+++ b/benchmarks/fastrnns/scratch.py
@@ -9,7 +9,7 @@ def fn(x, scale, shift):
 @torch.jit.script
 def recurrent(x, scale, shift):
     y = x
-    for i in range(100):
+    for _ in range(100):
         y = fn(y, scale, shift)
     return y
 
@@ -30,7 +30,7 @@ import torch
 @torch.jit.script
 def recurrent_scaleshift(x, scale, shift):
     y = x
-    for i in range(64):
+    for _ in range(64):
         y = scale * y + shift
     return y
 

--- a/benchmarks/framework_overhead_benchmark/SimpleAddModule.py
+++ b/benchmarks/framework_overhead_benchmark/SimpleAddModule.py
@@ -5,7 +5,7 @@ import torch
 
 def add_tensors_loop(x, y):
     z = torch.add(x, y)
-    for i in range(NUM_LOOP_ITERS):
+    for _ in range(NUM_LOOP_ITERS):
         z = torch.add(z, x)
     return z
 

--- a/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
+++ b/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
@@ -250,7 +250,7 @@ def run_model(
     run_once_fn(model, inp, task, v, maybe_check_consistency=True)
 
     elapsed = []
-    for it in range(args.num_iters):
+    for _ in range(args.num_iters):
         do_sync()
         start = time.time()
         run_once_fn(model, inp, task, v)

--- a/benchmarks/functional_autograd_benchmark/utils.py
+++ b/benchmarks/functional_autograd_benchmark/utils.py
@@ -56,7 +56,7 @@ def extract_weights(mod: nn.Module) -> tuple[tuple[Tensor, ...], list[str]]:
     orig_params = tuple(mod.parameters())
     # Remove all the parameters in the model
     names = []
-    for name, p in list(mod.named_parameters()):
+    for name, _p in list(mod.named_parameters()):
         _del_nested_attr(mod, name.split("."))
         names.append(name)
 

--- a/benchmarks/functional_autograd_benchmark/vision_models.py
+++ b/benchmarks/functional_autograd_benchmark/vision_models.py
@@ -111,7 +111,7 @@ def get_detr(device: torch.device) -> GetterReturnType:
 
     inputs = torch.rand(N, 3, 800, 1200, device=device)
     labels = []
-    for idx in range(N):
+    for _ in range(N):
         targets = {}
         n_targets: int = int(torch.randint(5, 10, size=()).item())
         label = torch.randint(5, 10, size=(n_targets,), device=device)

--- a/benchmarks/gpt_fast/generate.py
+++ b/benchmarks/gpt_fast/generate.py
@@ -105,7 +105,7 @@ def decode_n_tokens(
     **sampling_kwargs,
 ):
     new_tokens, new_probs = [], []
-    for i in range(num_new_tokens):
+    for _ in range(num_new_tokens):
         with torch.nn.attention.sdpa_kernel(
             torch.nn.attention.SDPBackend.MATH
         ):  # Actually better for Inductor to codegen attention here
@@ -172,7 +172,7 @@ def _load_model(x: GPTModelConfig, device="cuda", precision=torch.bfloat16):
 # Only count activated parameters and buffers.
 def _get_model_size(model):
     model_size = 0
-    for name, child in model.named_children():
+    for _name, child in model.named_children():
         if not isinstance(child, torch.nn.Embedding):
             model_size += sum(
                 p.numel() * p.dtype.itemsize

--- a/benchmarks/gpt_fast/mixtral_moe_model.py
+++ b/benchmarks/gpt_fast/mixtral_moe_model.py
@@ -141,7 +141,7 @@ class Transformer(nn.Module):
         freqs_cis = self.freqs_cis[input_pos]
         x = self.tok_embeddings(idx)
 
-        for i, layer in enumerate(self.layers):
+        for layer in self.layers:
             x = layer(x, input_pos, freqs_cis, mask)
         x = self.norm(x)
         logits = self.output(x)

--- a/benchmarks/gpt_fast/model.py
+++ b/benchmarks/gpt_fast/model.py
@@ -160,7 +160,7 @@ class Transformer(nn.Module):
         freqs_cis = self.freqs_cis[input_pos]
         x = self.tok_embeddings(idx)
 
-        for i, layer in enumerate(self.layers):
+        for layer in self.layers:
             x = layer(x, input_pos, freqs_cis, mask)
         x = self.norm(x)
         logits = self.output(x)

--- a/benchmarks/inference/server.py
+++ b/benchmarks/inference/server.py
@@ -50,7 +50,7 @@ class FrontendWorker(mp.Process):
         warmup_response_time = None
         response_times = []
 
-        for i in range(self.num_iters + 1):
+        for _ in range(self.num_iters + 1):
             response, request_time = self.response_queue.get()
             if warmup_response_time is None:
                 self.warmup_event.set()

--- a/benchmarks/instruction_counts/execution/runner.py
+++ b/benchmarks/instruction_counts/execution/runner.py
@@ -181,7 +181,7 @@ class Runner:
 
     def _enqueue_new_jobs(self) -> None:
         work_queue: list[WorkOrder] = []
-        for i, work_order in enumerate(self._work_queue):
+        for work_order in self._work_queue:
             self._currently_processed = work_order
             cpu_list = self._core_pool.reserve(work_order.timer_args.num_threads)
 

--- a/benchmarks/nested/nested_bmm_bench.py
+++ b/benchmarks/nested/nested_bmm_bench.py
@@ -12,7 +12,7 @@ def bench(nt_a, nt_b, niter):
     start_event = torch.cuda.Event(enable_timing=True)
     end_event = torch.cuda.Event(enable_timing=True)
     start_event.record()
-    for iter in range(niter):
+    for _ in range(niter):
         nt_a.bmm(nt_b)
     end_event.record()
     torch.cuda.synchronize()

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -289,7 +289,7 @@ def random_sample_configs(**configs):
 
     configs_attrs_list = []
     randomsample = RandomSample(configs)
-    for i in range(configs["total_samples"]):
+    for _ in range(configs["total_samples"]):
         tmp_attr_list = randomsample.get_one_set_of_inputs()
         tmp_attr_list.append({"tags": "_".join(configs["tags"])})
         configs_attrs_list.append(tmp_attr_list)

--- a/benchmarks/operator_benchmark/pt/cat_test.py
+++ b/benchmarks/operator_benchmark/pt/cat_test.py
@@ -128,7 +128,7 @@ class CatBenchmark(op_bench.TorchBenchmarkBase):
         if type(sizes) is list and N == -1:
             gen_sizes = sizes
         else:
-            for i in range(N):
+            for _ in range(N):
                 gen_sizes.append(
                     [
                         old_size() if callable(old_size) else old_size

--- a/benchmarks/operator_benchmark/pt/stack_test.py
+++ b/benchmarks/operator_benchmark/pt/stack_test.py
@@ -64,7 +64,7 @@ class StackBenchmark(op_bench.TorchBenchmarkBase):
         if type(sizes) is list and N == -1:
             gen_sizes = sizes
         else:
-            for i in range(N):
+            for _ in range(N):
                 gen_sizes.append(
                     [
                         old_size() if callable(old_size) else old_size

--- a/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
+++ b/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
@@ -10,7 +10,7 @@ class TestConsumeOp(unittest.TestCase):
         iters = 6
 
         def foo(x):
-            for i in range(iters):
+            for _ in range(iters):
                 result = torch.ops.operator_benchmark._consume(torch.sum(x))
             return result
 
@@ -28,7 +28,7 @@ class TestConsumeOp(unittest.TestCase):
         iters = 6
 
         def foo(x):
-            for i in range(iters):
+            for _ in range(iters):
                 result = torch.ops.operator_benchmark._consume(torch.chunk(x, 2))
             return result
 

--- a/benchmarks/profiler_benchmark/profiler_bench.py
+++ b/benchmarks/profiler_benchmark/profiler_bench.py
@@ -11,19 +11,19 @@ INTERNAL_ITER = None
 
 
 def loop_workload(x):
-    for i in range(INTERNAL_ITER):
+    for _ in range(INTERNAL_ITER):
         x = torch.mm(x, x)
     return x
 
 
 def parallel_workload(x):
     def parallel_task(x):
-        for i in range(int(INTERNAL_ITER / PARALLEL_TASKS_NUM)):
+        for _ in range(int(INTERNAL_ITER / PARALLEL_TASKS_NUM)):
             x = torch.mm(x, x)
         return x
 
     futs = []
-    for i in range(PARALLEL_TASKS_NUM):
+    for _ in range(PARALLEL_TASKS_NUM):
         futs.append(torch.jit._fork(parallel_task, x))
     for i in range(PARALLEL_TASKS_NUM):
         torch.jit._wait(futs[i])

--- a/benchmarks/sparse/triton_ops.py
+++ b/benchmarks/sparse/triton_ops.py
@@ -382,7 +382,7 @@ if __name__ == "__main__":
                 )
                 time_ms_lst = []
                 performance_tflops_lst = []
-                for r in range(args.repeat):
+                for _ in range(args.repeat):
                     try:
                         time_ms, performance_tflops = test_func(x, y, **meta)
                     except triton.compiler.OutOfResources:

--- a/benchmarks/sparse/utils.py
+++ b/benchmarks/sparse/utils.py
@@ -39,7 +39,7 @@ def gen_sparse_coo(shape, nnz):
     dense = np.random.randn(*shape)
     values = []
     indices = [[], []]
-    for n in range(nnz):
+    for _ in range(nnz):
         row = random.randint(0, shape[0] - 1)
         col = random.randint(0, shape[1] - 1)
         indices[0].append(row)

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -291,7 +291,7 @@ class DynamicShape:
     # pre-compute inputs so the creations of random tensors
     # do not add to the compute time
     def load_inputs(self):
-        for i in range(self.SAMPLE_SIZE - 1):
+        for _ in range(self.SAMPLE_SIZE - 1):
             self.instantiate_input()
 
     # returns a randomized shape

--- a/benchmarks/tensorexpr/microbenchmarks.py
+++ b/benchmarks/tensorexpr/microbenchmarks.py
@@ -255,7 +255,7 @@ def run_benchmarks(benchmarks, sizes):
                     for _ in range(10):
                         cg.call([tA, tB, tX])
                     start = time.time()
-                    for it in range(iters):
+                    for _ in range(iters):
                         cg.call([tA, tB, tX])
                     time1 = time.time() - start
 
@@ -264,7 +264,7 @@ def run_benchmarks(benchmarks, sizes):
                     for _ in range(10):
                         tR = fn()
                     start = time.time()
-                    for it in range(iters):
+                    for _ in range(iters):
                         tR = fn()
                     time2 = time.time() - start
 
@@ -297,7 +297,7 @@ def dump_plot(df, sizes):
     keys = []
     vals = []
     indexed = df[df["N"] == df["M"]]
-    for index, row in indexed.iterrows():
+    for _index, row in indexed.iterrows():
         keys.append(row["name"])
         vals.append(row["ratio"])
 


### PR DESCRIPTION
### Summary

Part of #106571. The **benchmarks/** slice of the B007 (unused loop control variable) cleanup: 30 files, every unused loop variable renamed with a leading underscore. No behavior changes.

This is split out of #189319, which did the whole tree in one PR and turned out to be too wide to get reviewed — 106 files across inductor, dynamo, distributed, quantization and test, which auto-assigned 11 reviewers and then sat for four weeks. Splitting by directory so each piece has a clear owner, following what is working for B017/B018 (#191649, #191831).

B007 stays in the `pyproject.toml` ignore list until the final slice lands and can flip it on, so this PR is a no-op for CI today.

### Test plan

Verified with the ruff version the lint job pins (0.14.4) plus the RUFF `exclude_patterns` from `.lintrunner.toml`:

```
uvx ruff@0.14.4 check benchmarks/ --config=pyproject.toml --select B007 --config "lint.ignore=[]"
# -> All checks passed!   (no B007 left under benchmarks/)
uvx ruff@0.14.4 check <changed files> --config=pyproject.toml     # All checks passed!
uvx ruff@0.14.4 format --check <changed files> --config=pyproject.toml   # 30 files already formatted
python -m py_compile <changed files>
```

Renaming an unused binding cannot change behavior, and ruff's F821 pass over the touched files confirms no rename broke an existing reference.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Skylion007 (author of #106571)

> Authored with the assistance of an AI coding assistant (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
