### PR TITLE
Generate the clang-tidy compilation database in build_lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,6 +250,7 @@ build/
 build_host_protoc
 build_android
 build_ios
+build_lint
 .build_debug/*
 .build_release/*
 .build_profile/*

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -286,7 +286,7 @@ command = [
     'python3',
     'tools/linter/adapters/clangtidy_linter.py',
     '--binary=.lintbin/clang-tidy',
-    '--build_dir=./build',
+    '--build_dir=./build_lint',
     '--',
     '@{{PATHSFILE}}'
 ]
@@ -338,7 +338,7 @@ command = [
     'python3',
     'tools/linter/adapters/clangtidy_linter.py',
     '--binary=.lintbin/clang-tidy',
-    '--build_dir=./build',
+    '--build_dir=./build_lint',
     '--std=c++17',
     '--',
     '@{{PATHSFILE}}'

--- a/tools/linter/clang_tidy/generate_build_files.py
+++ b/tools/linter/clang_tidy/generate_build_files.py
@@ -26,8 +26,17 @@ def update_submodules() -> None:
     run_cmd(["git", "submodule", "update", "--init", "--recursive"])
 
 
+# Deliberately not the `build` directory used by `pip install -e .` (see
+# `build-dir` in pyproject.toml): CMake takes CC/CXX and the USE_* cache
+# variables below from the environment only when it creates the cache, so
+# reusing the developer's build directory would silently keep their compiler
+# and overwrite their cache variables. Must match the `--build_dir` passed to
+# the CLANGTIDY linters in .lintrunner.toml.
+BUILD_DIR = "build_lint"
+
+
 def gen_compile_commands() -> None:
-    """Configure cmake to produce build/compile_commands.json for clang-tidy.
+    """Configure cmake to produce compile_commands.json for clang-tidy.
 
     Configure-only invocation; does not run the build step. The repo-level
     cmake/EnvVarForwarding.cmake forwards BUILD_*/USE_* environment
@@ -38,7 +47,7 @@ def gen_compile_commands() -> None:
     os.environ["USE_PRECOMPILED_HEADERS"] = "1"
     os.environ["CC"] = "clang"
     os.environ["CXX"] = "clang++"
-    run_cmd(["cmake", "-S", ".", "-B", "build", "-G", "Ninja"])
+    run_cmd(["cmake", "-S", ".", "-B", BUILD_DIR, "-G", "Ninja"])
 
 
 def run_autogen() -> None:
@@ -50,7 +59,7 @@ def run_autogen() -> None:
             "-s",
             "aten/src/ATen",
             "-d",
-            "build/aten/src/ATen",
+            f"{BUILD_DIR}/aten/src/ATen",
             "--per-operator-headers",
         ]
     )

--- a/tools/test/test_generate_build_files.py
+++ b/tools/test/test_generate_build_files.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest import mock
+
+from tools.linter.clang_tidy import generate_build_files
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[import-not-found, no-redef]
+
+
+REPO_ROOT = Path(__file__).absolute().parents[2]
+
+
+def _run_capturing_cmds(func: Callable[[], None]) -> list[list[str]]:
+    cmds: list[list[str]] = []
+    with (
+        mock.patch.object(generate_build_files, "run_cmd", cmds.append),
+        mock.patch.dict(os.environ),
+    ):
+        func()
+    return cmds
+
+
+class TestClangTidyBuildDir(unittest.TestCase):
+    def setUp(self) -> None:
+        (cmd,) = _run_capturing_cmds(generate_build_files.gen_compile_commands)
+        self.build_dir = cmd[cmd.index("-B") + 1]
+
+    def test_isolated_from_the_pip_build_dir(self) -> None:
+        with (REPO_ROOT / "pyproject.toml").open("rb") as f:
+            pyproject = tomllib.load(f)
+        pip_build_dir = pyproject["tool"]["scikit-build"]["build-dir"]
+        self.assertNotEqual(self.build_dir, pip_build_dir)
+
+    def test_generated_aten_headers_land_in_the_same_build_dir(self) -> None:
+        cmds = _run_capturing_cmds(generate_build_files.run_autogen)
+        torchgen = next(cmd for cmd in cmds if "torchgen.gen" in cmd)
+        out_dir = Path(torchgen[torchgen.index("-d") + 1])
+        self.assertEqual(out_dir.parts[0], self.build_dir)
+
+    def test_linters_point_at_the_regenerated_build_dir(self) -> None:
+        with (REPO_ROOT / ".lintrunner.toml").open("rb") as f:
+            config = tomllib.load(f)
+        build_dirs = {
+            arg.partition("=")[2]
+            for linter in config["linter"]
+            if linter["code"].startswith("CLANGTIDY")
+            for arg in linter["command"]
+            if arg.startswith("--build_dir=")
+        }
+        self.assertEqual(build_dirs, {f"./{self.build_dir}"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #191252

`gen_compile_commands()` sets `CC=clang`/`CXX=clang++` and then configures into `build`, which
is the same directory `pip install -e .` uses (`build-dir = "build"` in `pyproject.toml`). CMake
only reads `CC`/`CXX` when it creates a cache, so on a machine that has already built PyTorch
the Clang request is silently dropped and clang-tidy gets a GCC compilation database, with GCC
PCH arguments. That is where the bogus redefinition and parser errors come from. The same
configure also FORCE-writes `USE_NCCL=0` and `USE_PRECOMPILED_HEADERS=1` into the developer's
live build cache via `cmake/EnvVarForwarding.cmake`.

Changes:

- `generate_build_files.py` configures into `build_lint` and writes the generated ATen headers
  there too.
- Both CLANGTIDY linters in `.lintrunner.toml` read `--build_dir=./build_lint`.
- `build_lint` added to `.gitignore`.

Behaviour change worth a look: a developer without `clang` on PATH now gets a hard CMake error
from `spin regenerate-clangtidy-files` instead of a silently wrong GCC database. In CI nothing
changes, `build/` does not pre-exist there.

This is the isolation half of the issue only. It does not make `spin lint` regenerate the
database automatically and it does not ship a pinned Clang toolchain.

Verified on Linux x86-64, no GPU involved. Added `tools/test/test_generate_build_files.py`,
which intercepts `run_cmd` and asserts on the arguments actually passed to cmake and torchgen:
it fails with `AssertionError: 'build' == 'build'` before the change and passes after. The full
`pytest tools/test -o "python_files=test*.py"` job passes (229 passed, 1 xfailed), minus four
boto3-dependent modules that would not install here. `lintrunner` is clean on the changed files.

Not verified: I have no Clang compiler and no built PyTorch on this machine, so I never ran
`spin regenerate-clangtidy-files` or a real clang-tidy pass end to end. I reproduced the
compiler-pinning and cache-clobbering mechanism with a minimal CMake project that includes the
repo's own `cmake/EnvVarForwarding.cmake`. Someone with a working Clang should confirm that a
full-tree `spin lint -- --take CLANGTIDY --all-files` against `build_lint` matches CI.

Reported by @albanD.