### PR TITLE
Retry the working-tree diff in STABLE_SHIM_VERSION linter

### DIFF
--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import re
 import sys
 from pathlib import Path
@@ -45,8 +44,6 @@ def get_added_lines(filename: str) -> set[int]:
     Returns:
         Set of line numbers (1-indexed) that are new additions.
     """
-    import subprocess
-
     added_lines = set()
 
     def parse_diff(diff_output: str) -> set[int]:
@@ -70,16 +67,8 @@ def get_added_lines(filename: str) -> set[int]:
 
     try:
         # Check uncommitted changes (working directory vs HEAD)
-        result = subprocess.run(
-            ["git", "diff", "HEAD", filename],
-            cwd=REPO_ROOT,
-            env={**os.environ, "GIT_NO_LAZY_FETCH": "1"},
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode == 0:
-            added_lines.update(parse_diff(result.stdout))
+        result = run_git_object_command(["diff", "HEAD", "--", filename])
+        added_lines.update(parse_diff(result.stdout))
 
         # Get merge-base with origin/main to check all PR commits
         merge_base = merge_base_with_main()

--- a/tools/test/test_stable_shim_version_linter.py
+++ b/tools/test/test_stable_shim_version_linter.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -98,6 +99,23 @@ index 365c954dbe7..c5fcf7a09cf 100644
             self.assertEqual(
                 result, {18, 19, 20, 21, 22, 23, 24, 49, 50, 51, 52, 53, 54}
             )
+
+    def test_get_added_lines_retries_when_git_diff_times_out(self):
+        """A `git diff` slower than the short local timeout must be retried, not fatal."""
+        simulated_diff = """@@ -15,6 +15,7 @@
++AOTI_TORCH_EXPORT int new_function();
+"""
+
+        def fake_run(cmd, **kwargs):
+            # Only the short, no-lazy-fetch attempt times out.
+            if cmd[:2] == ["git", "diff"] and kwargs["timeout"] == 5:
+                raise subprocess.TimeoutExpired(cmd, 5)
+            return MagicMock(returncode=0, stdout=simulated_diff)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = get_added_lines("torch/csrc/stable/c/shim.h")
+
+        self.assertEqual(result, {15})
 
     def test_get_current_version(self):
         """Test that we can get the current version from version.txt."""


### PR DESCRIPTION
Fixes #191282

`get_added_lines()` runs two git diffs. The merge-base one already goes through
`run_git_object_command()`, which retries with a 120s timeout if the 5s local-only
attempt times out. The working-tree diff was left as a bare
`subprocess.run(..., timeout=5)` with no fallback, so a slow `git diff HEAD` raises
`TimeoutExpired` and fails the whole lint job.

This routes it through the same helper. Dropped the now-unused `import os` and the
function-local `import subprocess`.

One behavior change: a non-zero exit from `git diff HEAD` used to be silently ignored,
now it raises after the retries are exhausted. That matches what the merge-base diff
already does.

Verified on Linux, x86. Reproduction was a `git` wrapper earlier on `PATH` that sleeps
8s before any `git diff`. Before: the linter dies in 5s with
`RuntimeError: Failed to get git diff information ... timed out after 5 seconds`.
After: it takes 26s (5s timeout plus 8s retry, once per diff) and exits 0. The new unit
test simulates the same thing by making only the 5s attempt raise; it fails without the
patch and passes with it. `tools/test/test_stable_shim_{version_linter,utils,usage_linter}.py`
and `test_generated_shims_version_linter.py` all pass (27 tests).

Not verified: the traceback in the issue names `git diff <merge-base>..HEAD` without
`--`, which is an older revision of this file, so I reproduced the same failure mode on
the remaining unprotected call site rather than the literal command from that log. I
also did not measure real CI git latency, so I cannot say the 120s fallback is enough
headroom, only that the fallback is now reached.

Thanks to @malfet for the report.