### PR TITLE
[inductor] Realize select_scatter src before broadcasting it

### DIFF
--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -33,6 +33,7 @@ from torch.testing._internal.common_device_type import (
     skipCUDAIf,
 )
 from torch.testing._internal.common_utils import (
+    DeterministicGuard,
     parametrize,
     run_tests,
     TestCase,
@@ -989,27 +990,46 @@ class TestScheduler(TestCase):
 
     @xfailIfNoAcceleratorTriton
     @onlyCUDA
-    def test_select_scatter_realizes_expensive_src(self):
-        def fn(base, a, b, c, d, e):
-            p = a[..., 1] * b[..., 0] + c[..., 1] * d[..., 0] + e[..., 2]
-            return torch.select_scatter(base, p, dim=2, index=1)
+    @parametrize("op", ["select_scatter", "index_put"])
+    # Both settings are pinned so the test can only pass via graph_fanout:
+    # deterministic mode makes expand realize src on its own, and the read
+    # threshold decides whether src counts as expensive at all.
+    @inductor_config.patch(deterministic=False, realize_reads_threshold=4)
+    def test_scatter_realizes_expensive_src(self, op):
+        def src(a, b, c, d, e):
+            return a[..., 1] * b[..., 0] + c[..., 1] * d[..., 0] + e[..., 2]
+
+        if op == "select_scatter":
+
+            def fn(base, *args):
+                return torch.select_scatter(base, src(*args), dim=2, index=1)
+        else:
+
+            def fn(base, *args):
+                index = torch.arange(base.shape[0], device=base.device)
+                base.index_put_((index,), src(*args))
+                return base
 
         device = "cuda"
         torch.manual_seed(0)
+        base_size = (32, 32, 26) if op == "select_scatter" else (26, 32, 32)
+        base = torch.rand(base_size, dtype=torch.float32, device=device)
         args = [
             torch.rand((32, 32, 26), dtype=torch.float32, device=device)
-            for _ in range(6)
+            for _ in range(5)
         ]
-        expected = fn(*args)
+        expected = fn(base.clone(), *args)
 
         torch._dynamo.reset()
         metrics.reset()
-        with fresh_inductor_cache():
-            actual = torch.compile(fn, backend="inductor", fullgraph=True)(*args)
+        with DeterministicGuard(False), fresh_inductor_cache():
+            compiled = torch.compile(fn, backend="inductor", fullgraph=True)
+            actual = compiled(base.clone(), *args)
 
         self.assertEqual(expected, actual)
-        # src must not be inlined into the 3D scatter loop, which would recompute
-        # it once per element of the scattered dim.
+        # src must not be inlined into the scatter loop, which would recompute it
+        # once per element of the broadcast dim.
+        self.assertEqual(metrics.ir_nodes_pre_fusion, 2)
         self.assertEqual(metrics.generated_kernel_count, 2)
 
 

--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -987,6 +987,31 @@ class TestScheduler(TestCase):
         with inductor_config.patch(deterministic=True):
             check_realizes()
 
+    @xfailIfNoAcceleratorTriton
+    @onlyCUDA
+    def test_select_scatter_realizes_expensive_src(self):
+        def fn(base, a, b, c, d, e):
+            p = a[..., 1] * b[..., 0] + c[..., 1] * d[..., 0] + e[..., 2]
+            return torch.select_scatter(base, p, dim=2, index=1)
+
+        device = "cuda"
+        torch.manual_seed(0)
+        args = [
+            torch.rand((32, 32, 26), dtype=torch.float32, device=device)
+            for _ in range(6)
+        ]
+        expected = fn(*args)
+
+        torch._dynamo.reset()
+        metrics.reset()
+        with fresh_inductor_cache():
+            actual = torch.compile(fn, backend="inductor", fullgraph=True)(*args)
+
+        self.assertEqual(expected, actual)
+        # src must not be inlined into the 3D scatter loop, which would recompute
+        # it once per element of the scattered dim.
+        self.assertEqual(metrics.generated_kernel_count, 2)
+
 
 class TestScoreFusionMemory(TestCase):
     """

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1444,9 +1444,10 @@ def expand(x, sizes, *, implicit=False, graph_fanout=False):
         if x_size_product > 0 and not free_unbacked_symbols(sizes):
             # Broadcast loop reuse is not graph fanout; keep the graph-fanout
             # read-count heuristic from materializing cheap expanded producers.
-            # Callers that go on to read the result once per position of the
-            # broadcast dims pass graph_fanout=True, since for them the reuse is
-            # recompute rather than a hoistable load.
+            # graph_fanout=True is for consumers that cannot hoist the broadcast
+            # load out of their loop: a reduction over the broadcast dim can, but
+            # a pointwise or scatter loop over the expanded size folds that dim
+            # into its own index space and so reloads x at every position.
             # In deterministic modes, preserve the old materialization boundary
             # since fusing through expanded inputs can change reduction numerics.
             x.mark_reuse(
@@ -4095,8 +4096,7 @@ def select_scatter(x, src, dim: int, index: int):
 
     V.graph.sizevars.check_leq(0, index)  # type: ignore[arg-type]
     V.graph.sizevars.check_lt(index, x.get_size()[dim])  # type: ignore[arg-type]
-    # src is evaluated at every position of `dim` below even though only
-    # `index` keeps the value, so the broadcast is real fanout.
+    # inner_fn below loads src at every position of `dim`; see expand()
     src = expand(unsqueeze(src, dim), x.get_size(), graph_fanout=True)
     src_loader = src.make_loader()
 
@@ -5013,8 +5013,8 @@ def index_put_impl_(self, indices, values, accumulate, check, may_realize=False)
         None,
         check=check,
     )
-    # the Scatter below reads values once per position of expected_vals_size,
-    # so the broadcast is real fanout.
+    # the Scatter below loads values at every position of expected_vals_size;
+    # see expand()
     values = expand(values, expected_vals_size, graph_fanout=True)
     # all guards are set above during broadcast_tensors and expand
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1417,7 +1417,7 @@ def trunc(x):
 
 
 @register_lowering(aten.expand, type_promotion_kind=None)
-def expand(x, sizes, *, implicit=False):
+def expand(x, sizes, *, implicit=False, graph_fanout=False):
     # `implicit` is autograd-internal metadata (see aten::expand schema); it
     # does not affect the produced tensor, so the lowering ignores it. Without
     # this kwarg the lowering rejects graphs produced by dynamo autograd where
@@ -1444,12 +1444,16 @@ def expand(x, sizes, *, implicit=False):
         if x_size_product > 0 and not free_unbacked_symbols(sizes):
             # Broadcast loop reuse is not graph fanout; keep the graph-fanout
             # read-count heuristic from materializing cheap expanded producers.
+            # Callers that go on to read the result once per position of the
+            # broadcast dims pass graph_fanout=True, since for them the reuse is
+            # recompute rather than a hoistable load.
             # In deterministic modes, preserve the old materialization boundary
             # since fusing through expanded inputs can change reduction numerics.
             x.mark_reuse(
                 V.graph.sizevars.guarding_hint_or_throw(sympy_product(sizes))
                 // x_size_product,
-                graph_reuse=config.deterministic
+                graph_reuse=graph_fanout
+                or config.deterministic
                 or torch.are_deterministic_algorithms_enabled(),
             )
     return TensorBox(ExpandView.create(x.data, tuple(sizes)))
@@ -4092,10 +4096,8 @@ def select_scatter(x, src, dim: int, index: int):
     V.graph.sizevars.check_leq(0, index)  # type: ignore[arg-type]
     V.graph.sizevars.check_lt(index, x.get_size()[dim])  # type: ignore[arg-type]
     # src is evaluated at every position of `dim` below even though only
-    # `index` keeps the value, so this is real fanout rather than the free loop
-    # reuse that the expand lowering assumes for its own mark_reuse.
-    src.mark_reuse(V.graph.sizevars.optimization_hint(x.get_size()[dim]))
-    src = expand(unsqueeze(src, dim), x.get_size())
+    # `index` keeps the value, so the broadcast is real fanout.
+    src = expand(unsqueeze(src, dim), x.get_size(), graph_fanout=True)
     src_loader = src.make_loader()
 
     def inner_fn(idx):
@@ -5011,7 +5013,9 @@ def index_put_impl_(self, indices, values, accumulate, check, may_realize=False)
         None,
         check=check,
     )
-    values = expand(values, expected_vals_size)
+    # the Scatter below reads values once per position of expected_vals_size,
+    # so the broadcast is real fanout.
+    values = expand(values, expected_vals_size, graph_fanout=True)
     # all guards are set above during broadcast_tensors and expand
 
     device = self.get_device()

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -4091,6 +4091,10 @@ def select_scatter(x, src, dim: int, index: int):
 
     V.graph.sizevars.check_leq(0, index)  # type: ignore[arg-type]
     V.graph.sizevars.check_lt(index, x.get_size()[dim])  # type: ignore[arg-type]
+    # src is evaluated at every position of `dim` below even though only
+    # `index` keeps the value, so this is real fanout rather than the free loop
+    # reuse that the expand lowering assumes for its own mark_reuse.
+    src.mark_reuse(V.graph.sizevars.optimization_hint(x.get_size()[dim]))
     src = expand(unsqueeze(src, dim), x.get_size())
     src_loader = src.make_loader()
 


### PR DESCRIPTION
Fixes #191469

The `select_scatter` lowering broadcasts `src` over the scattered dim via
`expand`, and relied on `expand`'s own `mark_reuse` to realize an expensive
`src` first. #184182 made `expand` pass `graph_reuse=False`, which turns off the
`num_reads() > realize_reads_threshold` branch of `should_realize_on_reuse`, so
`src` is now always inlined into the full-size scatter loop and recomputed once
per element of that dim.

Fix is in `select_scatter`, which is the caller that knows the reuse is not
free: mark the reuse explicitly before the expand. `expand` is unchanged, so the
reduction case #184182 fixed is untouched. Reverting #184182 instead is not an
option, it breaks `test_expand_reuse_does_not_realize_before_reduction`.

`optimization_hint` rather than `guarding_hint_or_throw` because the reuse count
is only a heuristic input and the scattered dim can be unbacked.

Verified on an A40 (sm_86, CUDA 12.6):

- The reporter's repro goes from one 1,040,000-element kernel back to a
  40,000-element producer plus the 1,040,000-element scatter, about 11% faster
  on those shapes.
- New test `test_select_scatter_realizes_expensive_src` fails before the change
  and passes after. It uses a 5-read producer so it trips the default
  `realize_reads_threshold` with no config patching.
- Both #184182 tests still pass. `test_inductor_scheduler.py` and
  `test_unbacked_symints.py` show no new failures.
- Ad-hoc sweep over dtypes, dims, negative index, dynamic shapes, a size-1
  scattered dim, and an unbacked base dim, all matching eager.

Not verified: `pyhpc_turbulent_kinetic_energy` end to end (no torchbench on the
machine I used), and the CPU path (CPU inductor could not compile there), so the
new test is `onlyCUDA` like its neighbours.

Thanks to the reporter for the bisect to #184182 and the minimal repro, both of
which this change is built on.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo