### PR TITLE
Fix out-of-bounds write in multilabel_margin_loss CUDA kernels

### DIFF
--- a/aten/src/ATen/native/cuda/MultiLabelMarginCriterion.cu
+++ b/aten/src/ATen/native/cuda/MultiLabelMarginCriterion.cu
@@ -81,7 +81,8 @@ __global__ void multilabel_margin_loss_forward_kernel(
   // mark targets in is_target
   if (threadIdx.x == 0) {
     for (int dt = 0; dt < dim; dt++) {
-      int target_idx = target_k[dt];
+      int64_t target_idx = target_k[dt];
+      CUDA_KERNEL_ASSERT(target_idx >= -1 && target_idx < dim && "target index is out of bounds");
       if (target_idx < 0) {
         break;
       }
@@ -94,7 +95,8 @@ __global__ void multilabel_margin_loss_forward_kernel(
   accscalar_t sum = 0;
   for (int dt = 0; dt < dim; dt++) {
     // next target:
-    int target_idx = target_k[dt];
+    int64_t target_idx = target_k[dt];
+    CUDA_KERNEL_ASSERT(target_idx >= -1 && target_idx < dim && "target index is out of bounds");
     if (target_idx < 0) {
       break;
     }
@@ -164,7 +166,8 @@ __global__ void multilabel_margin_loss_backward_kernel(
   // iterate over targets
   for (int dt = 0; dt < dim; dt++) {
     // next target:
-    int target_idx = static_cast<int>(target_k[dt]);
+    int64_t target_idx = target_k[dt];
+    CUDA_KERNEL_ASSERT(target_idx >= -1 && target_idx < dim && "target index is out of bounds");
     if (target_idx < 0) {
       break;
     }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12348,6 +12348,37 @@ if __name__ == '__main__':
 
 
 
+    @onlyCUDA
+    @parametrize_test("target_value", [-1_000_000_000_000, 4])
+    def test_multilabel_margin_loss_out_of_bounds_target(self, device, target_value):
+        # Test for issue #191567
+        # Run in a different process to prevent the device-side assert from affecting other tests
+        stderr = TestCase.runWithPytorchAPIUsageStderr(f"""\
+#!/usr/bin/env python3
+
+import torch
+import torch.nn.functional as F
+from torch.testing._internal.common_utils import (run_tests, TestCase)
+
+class TestThatContainsCUDAAssert(TestCase):
+    def test_multilabel_margin_loss_out_of_bounds_target(self):
+        device = '{str(device)}'
+        input = torch.zeros(4, device=device)
+        target = torch.tensor([{target_value}, -1, -1, -1], device=device)
+        F.multilabel_margin_loss(input, target, reduction="none")
+        torch.cuda.synchronize()
+
+
+if __name__ == '__main__':
+    run_tests()
+        """)
+        # CUDA says "device-side assert triggered"
+        # ROCm says "unspecified launch failure", or HSA_STATUS_ERROR_EXCEPTION
+        has_cuda_assert = 'CUDA error: device-side assert triggered' in stderr
+        has_hip_assert = 'launch failure' in stderr or 'HSA_STATUS_ERROR_EXCEPTION' in stderr
+        self.assertTrue(has_cuda_assert or has_hip_assert,
+                        lambda msg: f"{msg}\nExpected device assert error in stderr, got: {stderr}")
+
     def test_cross_entropy_loss_prob_target_all_reductions(self, device):
         # Test with k-dimensional loss.
         for k in range(5):


### PR DESCRIPTION
Fixes #191567

`multilabel_margin_loss_forward_kernel` and `multilabel_margin_loss_backward_kernel` read the int64 target into a 32-bit `int`, so a target like `-1_000_000_000_000` truncates to `+727379968`, the `target_idx < 0` terminator check does not fire, and the kernel writes `is_target_k[727379968]` past the end of the allocation. The kernel also never compared the target against `dim`, so a positive but too-large target was an out-of-bounds write too; the CPU path rejects both host-side with the `target.min() >= -1` / `target.max() < dim` checks in `LossMultiLabelMargin.cpp`.

This reads the target as `int64_t` and bounds-checks it with `CUDA_KERNEL_ASSERT`, the same way `MultiMarginLoss.cu` already does. CUDA now rejects exactly the targets CPU rejects instead of writing out of bounds.

Note for reviewers: a CUDA caller passing a target below `-1` previously got a silent result and now gets a device-side assert. CPU has always errored on that input, so this makes the two agree.

Verified on 1x A40 (sm_86), CUDA 12.6, built from source. The new test in `test_nn.py` fails on the unpatched kernel (illegal memory access for the negative target; no assert at all for the too-large target, whose out-of-bounds write lands inside the allocator block at that size) and passes with the fix. Also ran `test_ops.py -k multilabel_margin_loss`, `test_ops_gradients.py -k multilabel_margin`, `test_nn.py -k MultiLabelMargin`, and a CPU/CUDA forward and backward parity check over 1-D and 2-D inputs with `-1` padding and all three reductions.

Not verified: ROCm (no AMD hardware here). The test accepts the HIP assert signatures the neighbouring `test_cross_entropy_loss_2d_out_of_bounds_class_index` accepts, minus `illegal memory access`, which is the pre-fix symptom. Only sm_86 and float32 were exercised.

Thanks to @kokol16 for the report and the minimal reproducer.