### PR TITLE
[CUDA][SDPA] Fix remap extents, causal key bound, and 32-bit dropout offsets in mem-efficient attention

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -84,6 +84,7 @@
 #ifdef USE_MEM_EFF_ATTENTION
 #ifndef USE_ROCM
 // MemoryEfficient Attention Specific Imports for CUDA
+#include <ATen/native/transformers/cuda/mem_eff_attention/gemm_kernel_utils.h>
 #include <ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h>
 #include <ATen/native/transformers/cuda/mem_eff_attention/kernels/cutlassF.h>
 #include <ATen/native/transformers/cuda/mem_eff_attention/pytorch_utils.h>
@@ -2027,8 +2028,9 @@ __global__ void rand_uniform_kernel(
 
   const auto [seed, offset] = at::cuda::philox::unpack(rng_engine_inputs);
 
-  const int dropout_seq_start = batch_id * (n_heads * n_queries * n_keys) +
-      head_id * (n_queries * n_keys);
+  // See NOTE [Mem-efficient attention dropout RNG offset]
+  const int64_t dropout_seq_start = gemm_kernel_utils::dropout_rng_offset(
+      batch_id, head_id, n_heads, n_queries, n_keys);
   const int64_t query_start_idx = query_idx * n_keys;
 
   curandStatePhilox4_32_10_t curand_state;
@@ -2038,7 +2040,7 @@ __global__ void rand_uniform_kernel(
       offset + dropout_seq_start + query_start_idx,
       &curand_state);
 
-  for (int key_start_idx = 0; key_start_idx < n_keys; key_start_idx += 4) {
+  for (int64_t key_start_idx = 0; key_start_idx < n_keys; key_start_idx += 4) {
     float4 rand_quad = curand_uniform4(&curand_state);
 
 #pragma unroll

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/gemm_kernel_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/gemm_kernel_utils.h
@@ -96,6 +96,21 @@ constexpr CUTLASS_HOST_DEVICE integer align_up(integer n, integer m) {
   return ((n + m - 1) / m) * m;
 }
 
+// NOTE [Mem-efficient attention dropout RNG offset]
+// The forward kernel, the backward kernel and the rand_uniform_kernel helper
+// that reconstructs the mask for tests must partition the Philox sequence
+// identically, otherwise the passes disagree about which elements were
+// dropped. Taking every extent as int64_t also keeps num_queries * num_keys
+// from wrapping at 2^32.
+constexpr CUTLASS_HOST_DEVICE int64_t dropout_rng_offset(
+    int64_t batch_id,
+    int64_t head_id,
+    int64_t num_heads,
+    int64_t num_queries,
+    int64_t num_keys) {
+  return (batch_id * num_heads + head_id) * num_queries * num_keys;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Determine the type of GEMM we do (TensorCores or not, Shapes ...)
 // TODO: Maybe we could rely on Cutlass's DefaultGemm templates

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
@@ -765,9 +765,9 @@ struct AttentionBackwardKernel {
       // Advance pointers that depend on the total concatenated
       // number of queries, as `num_queries` is modified in the block
       // below
-      dropout_batch_head_rng_offset =
-          batch_id * (num_heads * num_queries * num_keys) +
-          head_id * (num_queries * num_keys);
+      // See NOTE [Mem-efficient attention dropout RNG offset]
+      dropout_batch_head_rng_offset = gemm_kernel_utils::dropout_rng_offset(
+          batch_id, head_id, num_heads, num_queries, num_keys);
       logsumexp_ptr += batch_id * lse_strideB + head_id * lse_strideH;
 
       if (cu_seqlens_q_ptr != nullptr) {

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
@@ -205,9 +205,9 @@ struct AttentionKernel {
       auto lse_dim = ceil_div((int32_t)num_queries, kAlignLSE) * kAlignLSE;
 
       if (kSupportsDropout) {
-        dropout_batch_head_rng_offset =
-            batch_id * num_heads * num_queries * num_keys +
-            head_id * num_queries * num_keys;
+        // See NOTE [Mem-efficient attention dropout RNG offset]
+        dropout_batch_head_rng_offset = gemm_kernel_utils::dropout_rng_offset(
+            batch_id, head_id, num_heads, num_queries, num_keys);
       }
 
       int64_t q_start = 0, k_start = 0;
@@ -239,10 +239,10 @@ struct AttentionKernel {
         query_ptr += batch_id * q_strideB;
         key_ptr += batch_id * k_strideB;
         value_ptr += batch_id * v_strideB;
-        output_ptr += int64_t(batch_id * num_queries) * o_strideM;
+        output_ptr += int64_t(batch_id) * num_queries * o_strideM;
         if (output_accum_ptr != nullptr) {
           output_accum_ptr +=
-              int64_t(batch_id * num_queries) * (head_dim_value * num_heads);
+              int64_t(batch_id) * num_queries * head_dim_value * num_heads;
         }
         q_start = 0;
         k_start = 0;
@@ -261,7 +261,7 @@ struct AttentionKernel {
       }
       if (output_accum_ptr != nullptr) {
         output_accum_ptr +=
-            int64_t(q_start + query_start) * (head_dim_value * num_heads) +
+            int64_t(q_start + query_start) * head_dim_value * num_heads +
             head_id * head_dim_value;
       } else {
         // Accumulate directly in the destination buffer (eg for f32)
@@ -270,8 +270,8 @@ struct AttentionKernel {
 
       if (logsumexp_ptr != nullptr) {
         // lse[batch_id, head_id, query_start]
-        logsumexp_ptr +=
-            batch_id * lse_dim * num_heads + head_id * lse_dim + query_start;
+        logsumexp_ptr += (int64_t(batch_id) * num_heads + head_id) * lse_dim +
+            query_start;
       }
 
       // Custom masking
@@ -283,12 +283,12 @@ struct AttentionKernel {
       num_keys_absolute = num_keys;
       if (custom_mask_type == CausalFromTopLeft ||
           custom_mask_type == CausalFromBottomRight) {
-        // the bottom row of the current block is query_start + kQueriesPerBlock
-        // the last active key is then query_start + causal_diagonal_offset +
-        // kQueriesPerBlock so num_keys is the min between actual num_keys and
-        // this to avoid extra computations
+        // Exact rather than block-granular: the remap below drops causal
+        // masking, so slack keys here would be attended unmasked.
+        int32_t rows_this_block = cutlass::fast_min(
+            int32_t(kQueriesPerBlock), num_queries - int32_t(query_start));
         num_keys = cutlass::fast_min(
-            int32_t(query_start + causal_diagonal_offset + kQueriesPerBlock),
+            int32_t(query_start + causal_diagonal_offset + rows_this_block),
             num_keys);
       }
 
@@ -299,14 +299,18 @@ struct AttentionKernel {
       // 15/16th of tensor core compute In that case :
       //  - we only launch kernels for head_id % kQueriesPerBlock == 0
       //  - we iterate over heads instead of queries (strideM = strideH)
+      // Excluded under dropout: rows become heads here, but the per-row RNG
+      // offset still indexes them as queries.
       if (num_queries == 1 && k_strideH == 0 && v_strideH == 0 &&
-          logsumexp_ptr == nullptr && window_size == 0) {
+          logsumexp_ptr == nullptr && window_size == 0 &&
+          !(kSupportsDropout && use_dropout)) {
         if (head_id % kQueriesPerBlock != 0) {
           return false;
         }
         q_strideM = q_strideH;
         bias_strideM = bias_strideH;
-        num_queries = num_heads;
+        // Pointers are anchored at head_id, so only later heads are rows.
+        num_queries = num_heads - int32_t(head_id);
         num_heads = 1; // unused but here for intent
         // remove causal since n_query = 1
         // otherwise, offset would change with head !

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -4159,6 +4159,64 @@ class TestSDPACudaOnly(NNTestCase):
         max_diff = (out - out_contig).abs().mean()
         self.assertTrue(max_diff.item() < 1e-7)
 
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
+    @unittest.skipIf(not SM80OrLater, "bfloat16 requires SM80 or later")
+    @parametrize("kv_len,num_heads,is_causal", [(289, 40, False), (400, 16, True)])
+    def test_mem_eff_attention_single_query_tail(self, device, kv_len, num_heads, is_causal):
+        # head_dim > 128 gives 32 queries per block, so 289 queries leave a single-query
+        # tail block, which iterates over heads instead of queries: 40 heads reach a
+        # second head block, and the causal case must still bound keys at the tail
+        # row's own diagonal.
+        q_len, head_dim = 289, 512
+        make_tensor = partial(torch.randn, device=device, dtype=torch.bfloat16)
+        query = make_tensor(1, q_len, num_heads, head_dim).transpose(1, 2)
+        key = make_tensor(kv_len, head_dim).expand(1, num_heads, -1, -1)
+        value = make_tensor(kv_len, head_dim).expand(1, num_heads, -1, -1)
+
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            expected = F.scaled_dot_product_attention(query, key, value, is_causal=is_causal, scale=1.0)
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            actual = F.scaled_dot_product_attention(query, key, value, is_causal=is_causal, scale=1.0)
+
+        self.assertEqual(actual, expected, atol=2e-2, rtol=2e-2)
+
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
+    @unittest.skipIf(not SM80OrLater, "bfloat16 requires SM80 or later")
+    def test_mem_eff_attention_dropout_rng_offset_no_wraparound(self, device):
+        # num_queries * num_keys == 2^32, which wraps a 32-bit offset so that head 1
+        # replays head 0's mask. Inputs are identical per head, so a shared mask shows
+        # up as identical outputs.
+        seq_len, num_heads, head_dim = 1 << 16, 2, 64
+        base = torch.randn(1, 1, seq_len, head_dim, device=device, dtype=torch.bfloat16)
+        query, key, value = (base.expand(1, num_heads, -1, -1).contiguous().requires_grad_() for _ in range(3))
+
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            out = F.scaled_dot_product_attention(query, key, value, dropout_p=0.5, scale=1.0)
+
+        self.assertFalse(torch.equal(out[0, 0], out[0, 1]))
+
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
+    @unittest.skipIf(not SM80OrLater, "bfloat16 requires SM80 or later")
+    def test_mem_eff_attention_dropout_single_query_tail(self, device):
+        # The tail remap makes rows heads while the RNG offset still treats them as
+        # queries, so head h's tail row would replay head 1's row h - 1. kv_len == 1
+        # makes each output element either zero or v/(1 - p), exposing the mask.
+        q_len, kv_len, num_heads, head_dim = 65, 1, 32, 64
+        make_tensor = partial(torch.randn, device=device, dtype=torch.bfloat16)
+        query = make_tensor(1, num_heads, q_len, head_dim)
+        key = make_tensor(kv_len, head_dim).expand(1, num_heads, -1, -1)
+        value = make_tensor(kv_len, head_dim).expand(1, num_heads, -1, -1)
+
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            out = F.scaled_dot_product_attention(query, key, value, dropout_p=0.5, scale=1.0)
+
+        tail_row = out[0, 1:, q_len - 1, 0]
+        head_one_rows = out[0, 1, : num_heads - 1, 0]
+        self.assertFalse(torch.equal(tail_row, head_one_rows))
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
     def test_mem_eff_attention_save_on_cpu_unaligned_bias_stride(self, device):
         dtype = torch.float16


### PR DESCRIPTION
## Human Note
I toook claudes feedback  on the effiecnt attention edge cases went thorugh verified each one that was real and 
added fixes

## Agent Report
# Mem-efficient attention: stride and index fixes found by auditing PR #191984

PR #191984 fixed bias indexing in the single-query head-remap path of the CUTLASS
mem-efficient attention forward kernel. A bot audit on that PR listed four more
suspects; all four were real, and a review pass found a fifth. Each was taken
through the same loop: minimal reproducer, confirm it fails, smallest fix,
confirm it passes, add regression coverage where a CI-sized test is possible.

## Changes

`kernel_forward.h`

1. The remap set `num_queries = num_heads`, but pointers are already anchored at
   `head_id`, so only `num_heads - head_id` rows remain addressable. Head blocks
   above 0 read past the end of query and bias.
2. The causal `num_keys` clamp used `kQueriesPerBlock` rather than the block's
   row count. That slack is normally removed by the in-loop causal mask, but the
   remap sets `NoCustomMask`, so a `CausalFromTopLeft` tail row with more keys
   than queries attended past its diagonal. The bound is now exact.
3. `dropout_batch_head_rng_offset` wrapped in 32-bit.
4. `int64_t(batch_id * num_queries)` widened after the multiply instead of
   before, as did the logsumexp offset.
5. The remap turns rows into heads while the per-row dropout `skipahead` still
   indexes them as queries, so heads replayed each other's mask. The remap is
   now skipped under dropout.

`kernel_backward.h` and `attention.cu` share the dropout offset via one
`dropout_rng_offset` helper in `gemm_kernel_utils.h`, under a named note, since
all three sites must agree. `rand_uniform_kernel` (behind the test-only
`_fill_mem_eff_dropout_mask_`) also assigned an int64 expression to
`const int`, making the mask write index negative past 2^31 elements.

`test/test_transformers.py`: four regression cases.

## Evidence

Built from `main` at `aa8abcb98c3` on a GB200; reproducers in
`pytorch/agent_space/`.

| # | Reproducer | Before | After |
| --- | --- | --- | --- |
| 1 | `repro_head_remap_oob.py` (`seq_len=289, heads=40, head_dim=512`, broadcast KV) | memcheck: 99 invalid reads, then `unspecified launch failure` | 0 errors |
| 2 | `repro_causal_remap.py` (`q_len=289, kv_len=400`, causal) | row 288 wrong, max abs diff 4.375 vs math | 0.0156 |
| 3 | `repro_dropout_offset.py` (`seq_len=2^16`, 2 heads) | heads 0 and 1 bitwise identical | heads differ |
| 3 | `repro_dropout_mask_helper.py` (2^32-element mask) | illegal memory access | mask fully written |
| 4 | `repro_batch_offset.py` (`batch=65535, q_len=65600`, 128 GB) | batches from 65473 wrong, 95.2% mismatched | 0.0020 |
| 5 | `repro_dropout_remap_collision.py` (`q_len=65, kv_len=1, heads=32`) | head h's tail row replays head 1's row h-1, every seed | no collision |

Two controls make the clean runs trustworthy: the #191984 reproducer fails on
this build (max abs diff 5.0), confirming the binary matches unpatched source,
and a deliberate out-of-bounds kernel is caught by memcheck here.

## Validation

- `pytest test/test_transformers.py -k "mem_eff or efficient or dropout or sdpa"`
  on the final build: 12266 passed, 3554 skipped, 1 xfailed.
- Whole file, run before the last two fixes: 12415 passed, 1 failed. The failure,
  `TestTransformersCPU::test_transformer_encoder_layer_fwd_fake_cpu`, is a CPU
  Inductor `CppCompileError` from conflicting aarch64 `-march` flags in this
  environment, unrelated to these CUDA-only changes.
- New tests under `compute-sanitizer --tool memcheck`: 4 passed, 0 errors.
- Sweeps over head dim, head count, sequence lengths, causal, and broadcast KV:
  no mismatches beyond bf16 rounding, no memory errors.
- `lintrunner` on the changed files: clean.

## Decisions and remaining uncertainty

- **Stacking**: this checkout does not contain PR #191984, so the bias anchoring
  bug is still present here. This work is independent but should land after it.
- **Skipping the remap under dropout** gives up its decode throughput win for
  dropout without grad. Preserving it would mean threading the original query
  extent into the RNG indexing.
- **Forward/backward dropout agreement** rests on the shared helper, not a test:
  observing divergence needs a reference mask above 2^32 floats.
- **Defect 1's test is a numeric assert**, but the bug is an out-of-bounds read
  that does not change results, so it only fails reliably under memcheck.
- **Not fixed**: `bias_strideM = bias_strideH` narrows a 64-bit stride; needs a
  bias row stride above INT32_MAX, a different defect.
- **Defensive only**: the query-offset sibling of fix 4 was widened for
  uniformity. It needs a 264 GiB accumulator to overflow, and the CUTLASS
  iterator takes that row stride as `int32_t` regardless.
- Defects 1 and 2 share a root cause: the tail block misstates its own extent.
  One explicit remap layout computation would subsume both, worth doing
  separately.
- All testing was on sm100, using the sm50-sm80 CUTLASS variants. No other
  architecture was exercised.

## Human review needed

Written by an AI assistant. Per the repository AI policy it must be read and
understood by a human before it goes up, as a draft if not yet reviewed.


<details>
<summary>Agent Worklog</summary>

# Worklog: mem-efficient attention stride/index audit (follow-up to PR #191984)

See `report.md` for the summary. This file keeps only what is not obvious from
the diff: how to reach the buggy paths, and the traps hit along the way.

Environment: GB200 (sm100), local build of `2.14.0a0+gitaa8abcb` (main, without
#191984). Reproducers in `pytorch/agent_space/`.

## Reaching the remap path

The single-query head remap needs all of: `num_queries == 1` *at the block*,
`k_strideH == v_strideH == 0` (broadcast KV), `logsumexp_ptr == nullptr` (no
input requires grad), and `window_size == 0`.

Two facts controlled every reproducer:

- `kQueriesPerBlock` is 64 for bf16 `head_dim <= 128` (`64x128_rf`) and 32 for
  `head_dim > 128` (`32x128_gmem`). Bugs gated on `num_heads > kQueriesPerBlock`
  therefore need `head_dim > 128`.
- A `seq_len == 1` input does **not** reproduce. The failing configuration is the
  single-query *tail block* of a longer sequence, e.g. `seq_len = 289`.

## Traps hit

- Spent the first round on a `seq_len=1, head_dim=128` shape that never entered
  the remap, and read the clean memcheck as evidence of no bug. Fixed by adding
  two controls: the #191984 repro fails on this build (max abs diff 5.0), and a
  deliberate OOB kernel is caught by memcheck (exit 99). Run both before
  trusting a clean sanitizer result.
- For defect 5 the first oracle was wrong: the collided stream belongs to head 1,
  not head 0. Comparing against head 0's rows showed no collision. The kernel
  draws from position `query_start + h`, which is head 1's row `h - 1`.
- Defect 1 is an OOB *read*; each query row is independent so results are
  unaffected and the plain run passes. Only memcheck distinguishes it.
- Defect 4 was called cosmetic by the audit. It is reachable: head dim must be a
  multiple of 8 and batch is capped at 65535, so the smallest repro is ~128 GB,
  which this box can allocate. 95.2% of the tail slice was wrong.

## Review round

Six parallel sol subagents: three reviews (correctness, kernel domain, tests) and
three simplifier passes. Findings folded in: defect 5, the logsumexp truncation,
missing `SM80OrLater` on the bf16 tests, a 32-bit product inside the output
accumulator offset, the shared `dropout_rng_offset` helper, and parametrizing
the two tail tests. The test-coverage child died with a provider error, so that
angle is thinner than the other two.

Claims checked and rejected: the audit's fwd/bwd asymmetry in `skipahead` does
not hold, since backward's `query_start` is already `int64_t`.

## Rebuild loop

`bash ~/.ptq_workspace/scripts/rebuild.sh <worktree>` takes about 21 minutes,
since `kernel_forward.h` fans out to every cutlassF/cutlassB TU. Batch source
edits before rebuilding; comment-only edits still trigger a full recompile.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*