### PR TITLE
Fix input race in test_synchronize_event_threads_all_prior_sync_data

### DIFF
--- a/test/inductor/test_user_streams.py
+++ b/test/inductor/test_user_streams.py
@@ -1910,6 +1910,8 @@ class GraphModule(torch.nn.Module):
             s = torch.cuda.Stream()
             e0 = torch.cuda.Event()
             e1 = torch.cuda.Event()
+            # Order the side stream after the default-stream producers of the inputs.
+            s.wait_stream(torch.cuda.current_stream())
             with torch.cuda.stream(s):
                 a = x @ w1
                 e0.record()

--- a/test/inductor/test_user_streams.py
+++ b/test/inductor/test_user_streams.py
@@ -1872,6 +1872,9 @@ class GraphModule(torch.nn.Module):
         x = torch.randn(32, 32, device="cuda")
         w1 = torch.randn(32, 32, device="cuda")
         w2 = torch.randn(32, 32, device="cuda")
+        # fn reads these on a side stream that is not ordered after the default
+        # stream, so they have to be materialized before it is called.
+        torch.cuda.synchronize()
         expected = fn(x, w1, w2)
         result, _, fw_graphs, _ = extract_graph(fn, x, w1, w2)
         self.assertEqual(result, expected)
@@ -1910,8 +1913,6 @@ class GraphModule(torch.nn.Module):
             s = torch.cuda.Stream()
             e0 = torch.cuda.Event()
             e1 = torch.cuda.Event()
-            # Order the side stream after the default-stream producers of the inputs.
-            s.wait_stream(torch.cuda.current_stream())
             with torch.cuda.stream(s):
                 a = x @ w1
                 e0.record()
@@ -1923,6 +1924,9 @@ class GraphModule(torch.nn.Module):
         x = torch.randn(32, 32, device="cuda")
         w1 = torch.randn(32, 32, device="cuda")
         w2 = torch.randn(32, 32, device="cuda")
+        # fn reads these on a side stream that is not ordered after the default
+        # stream, so they have to be materialized before it is called.
+        torch.cuda.synchronize()
         expected = fn(x, w1, w2)
         result, _, fw_graphs, _ = extract_graph(fn, x, w1, w2)
         self.assertEqual(result, expected)


### PR DESCRIPTION
Fixes #191746

`fn` enters `with torch.cuda.stream(s)` and does `x @ w1` without ever ordering `s`
behind the default stream, but `x`, `w1` and `w2` are filled by `torch.randn` on the
default stream immediately before the call. When the default stream is still busy,
the side-stream matmul reads those buffers before the `randn` kernels have run, so
the eager `expected` value is garbage while the compiled `result` (computed later,
against inputs that are by then materialized) is correct. That matches the reported
failure, `Expected 5.372708352718838e-36 but got -211.53076171875`: the denormal is
the eager side.

Adds `s.wait_stream(torch.cuda.current_stream())` before the stream context. Same
one-line fix, in the same file, that closed #181368 and #181369 in 4921945628e.

Verified on 8x A40 (sm_86), CUDA 12.6, against a source build at af3c9b4, the commit
that introduced the barrier semantics this test asserts on. `test_user_streams.py` is
byte-identical between that commit and current main.

- Running the test's `fn` in a loop with the default stream kept busy: 49/50 eager
  runs returned wrong values without the `wait_stream`, 0/50 with it.
- A copy of this test with default-stream contention inserted before the inputs are
  allocated fails 3/3 with the same `Scalars are not close` signature as CI, and
  passes 3/3 with the fix. Passing covers the `control_deps` / `synchronize_event`
  graph assertions too, so the extra `wait_stream` in the traced region does not
  disturb them.
- Whole file: 2 pre-existing AOTI C++ wrapper errors in my environment (local gcc
  too old), identical before and after. `lintrunner` clean.

Not verified: I could not get the test to fail on an idle box, so the failing
direction is only shown under artificial contention, and only CI can confirm the
flake is actually gone. I also did not build current main, only af3c9b4.

Note for whoever picks this up: `test_synchronize_threads_all_prior_sync_data` a few
lines above has the identical missing `wait_stream` and is the same latent flake. It
is not covered by this issue so I left it alone, but it will likely be the next
disable.

Thanks to the flaky-test bot report for the clean repro signature.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo