### PR TITLE
[dynamo] Type guards.py lambda-guard closures and predicates as object

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -39,7 +39,7 @@ import weakref
 from contextlib import contextmanager
 from copy import deepcopy
 from inspect import currentframe
-from typing import Any, NamedTuple, NoReturn, TYPE_CHECKING
+from typing import Any, cast, NamedTuple, NoReturn, TYPE_CHECKING
 from typing_extensions import LiteralString, TypeAliasType, TypeVar
 from weakref import ReferenceType
 
@@ -215,13 +215,14 @@ except ModuleNotFoundError:
 
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, KeysView, Sequence
+    from collections.abc import Generator, KeysView, Sequence, Sized
 
     from sympy import Symbol
 
     from torch._C import DispatchKeySet
     from torch._dynamo.output_graph import OutputGraphCommon, OutputGraphGuardsState
     from torch._dynamo.package import SerializedCode
+    from torch.utils._python_dispatch import TraceableWrapperSubclass
 
 T = TypeVar("T")
 log = logging.getLogger(__name__)
@@ -233,18 +234,18 @@ recompiles_verbose_log = torch._logging.getArtifactLogger(
 verbose_guards_log = torch._logging.getArtifactLogger(__name__, "verbose_guards")
 
 
-def _sequence_length(value: Any) -> int:
+def _sequence_length(value: object) -> int:
     if isinstance(value, set):
         return set.__len__(value)
     if isinstance(value, frozenset):
         return frozenset.__len__(value)
-    return len(value)
+    return len(cast("Sized", value))
 
 
 _COW_TENSOR_UNSUPPORTED = object()
 
 
-def _try_is_cow_tensor(value: Any) -> bool | object:
+def _try_is_cow_tensor(value: object) -> bool | object:
     if not isinstance(value, torch.Tensor):
         return _COW_TENSOR_UNSUPPORTED
     if torch._C._dispatch_keys(value).has(torch._C.DispatchKey.Python):
@@ -252,7 +253,7 @@ def _try_is_cow_tensor(value: Any) -> bool | object:
     return torch._C._is_cow_tensor(value)  # pyrefly: ignore[missing-attribute]
 
 
-def _cow_tensor_matches(value: Any, expected: Any) -> bool:
+def _cow_tensor_matches(value: object, expected: object) -> bool:
     if not isinstance(expected, bool):
         return False
     actual = _try_is_cow_tensor(value)
@@ -979,7 +980,7 @@ def get_tensor_guard_code_part(
     return guard_str
 
 
-def get_key_index(dct: dict[Any, Any], key: Any) -> int:
+def get_key_index(dct: dict[Any, Any], key: object) -> int:
     # Ensure that we call dict.keys and not value.keys (which can call
     # overridden keys method). In the C++ guards, we relied on PyDict_Next
     # to traverse the dictionary, which uses the internal data structure and
@@ -991,7 +992,7 @@ def get_key_index_source(source: Any, index: Any) -> str:
     return f"list(dict.keys({source}))[{index}]"
 
 
-def raise_local_type_error(obj: Any) -> NoReturn:
+def raise_local_type_error(obj: object) -> NoReturn:
     raise TypeError(
         f"Type {type(obj)} for object {obj} cannot be saved "
         + "into torch.compile() package since it's defined in local scope. "
@@ -999,7 +1000,7 @@ def raise_local_type_error(obj: Any) -> NoReturn:
     )
 
 
-def should_optimize_getattr_on_nn_module(value: Any) -> bool:
+def should_optimize_getattr_on_nn_module(value: object) -> bool:
     return isinstance(value, torch.nn.Module)
 
 
@@ -1166,11 +1167,14 @@ def _validate_default_subclass_metadata_guard(metadata: Any, cls: type[Any]) -> 
     )
 
 
-# Used by TENSOR_SUBCLASS_METADATA_MATCH guard check spec
-def extract_subclass_metadata(guard: Any, value: Any) -> tuple[Any, ...]:
+# Used by TENSOR_SUBCLASS_METADATA_MATCH guard check spec.
+# Unlike check_dtensor_spec below, this pair is only reached at trace time:
+# TENSOR_SUBCLASS_METADATA_MATCH has its own inlined metadata_checker closure
+# for the C++ path, so narrowing with a typing.cast is free here.
+def extract_subclass_metadata(guard: Any, value: object) -> tuple[Any, ...]:
     cls = type(value)
     has_custom_guard = hasattr(value, "__metadata_guard__")
-    metadata = value.__tensor_flatten__()[1]
+    metadata = cast("TraceableWrapperSubclass", value).__tensor_flatten__()[1]
     if not has_custom_guard:
         _validate_default_subclass_metadata_guard(metadata, cls)
     metadata = deepcopy(metadata)
@@ -1178,25 +1182,30 @@ def extract_subclass_metadata(guard: Any, value: Any) -> tuple[Any, ...]:
 
 
 # Used by TENSOR_SUBCLASS_METADATA_MATCH guard check spec
-def check_subclass_metadata(value: Any, metadata: tuple[Any, ...]) -> bool:
+def check_subclass_metadata(value: object, metadata: tuple[Any, ...]) -> bool:
     saved_metadata, cls, has_custom_guard = metadata
+    subclass_metadata = cast("TraceableWrapperSubclass", value).__tensor_flatten__()[1]
     if has_custom_guard:
-        return cls.__metadata_guard__(saved_metadata, value.__tensor_flatten__()[1])
-    return value.__tensor_flatten__()[1] == saved_metadata
+        return cls.__metadata_guard__(saved_metadata, subclass_metadata)
+    return subclass_metadata == saved_metadata
 
 
 # Used by DTENSOR_SPEC_MATCH guard check spec
-def extract_dtensor_spec(guard: Any, value: Any) -> Any:
+def extract_dtensor_spec(guard: Any, value: object) -> Any:
     return deepcopy(value)
 
 
 # Used by DTENSOR_SPEC_MATCH guard check spec
-def check_dtensor_spec(value: Any, metadata: Any) -> bool:
+def check_dtensor_spec(value: object, metadata: Any) -> bool:
+    # DTENSOR_SPEC_MATCH's lambda guard calls this on every guard evaluation,
+    # so narrow with a suppression rather than a typing.cast, which would be a
+    # real call on the check path.
+    # pyrefly: ignore[missing-attribute]
     return value._check_equals(metadata, skip_shapes=True)
 
 
 # Used by OPAQUE_OBJ_GUARD_FN_MATCH guard check spec
-def extract_opaque_obj(guard: Any, value: Any) -> Any:
+def extract_opaque_obj(guard: Any, value: object) -> Any:
     opaque_info = get_opaque_obj_info(type(value))
     if not opaque_info or not opaque_info.guard_fn:
         return None
@@ -1204,7 +1213,7 @@ def extract_opaque_obj(guard: Any, value: Any) -> Any:
 
 
 # Used by OPAQUE_OBJ_GUARD_FN_MATCH guard check spec
-def check_opaque_obj(value: Any, metadata: Any) -> bool:
+def check_opaque_obj(value: object, metadata: Any) -> bool:
     if metadata is None:
         return True
     opaque_info = get_opaque_obj_info(type(value))
@@ -1214,20 +1223,20 @@ def check_opaque_obj(value: Any, metadata: Any) -> bool:
 
 
 # Used by CLOSURE_MATCH guard check spec
-def extract_closure(guard: Any, value: Any) -> Any:
+def extract_closure(guard: Any, value: object) -> Any:
     if type(value) is types.FunctionType and hasattr(value, "__code__"):
         return value.__code__
     return id(value)
 
 
 # Used by CLOSURE_MATCH guard check spec
-def check_closure(value: Any, metadata: Any) -> bool:
+def check_closure(value: object, metadata: Any) -> bool:
     if type(value) is types.FunctionType and hasattr(value, "__code__"):
         return value.__code__ is metadata
     return id(value) == metadata
 
 
-def _constant_subclass_base_value(value: Any) -> Any:
+def _constant_subclass_base_value(value: object) -> Any:
     """Extract the base constant value from a constant subclass instance."""
     from .variables.user_defined import _CONSTANT_BASE_TYPES
 
@@ -2466,7 +2475,7 @@ class GuardBuilder(GuardBuilderBase):
         get_metadata_fn=lambda guard, value: _guard_create_fn_keyword(guard, "key"),
         eval_fn=lambda value, metadata: metadata in value,
     )
-    def SET_CONTAINS(self, guard: Guard, key: Any) -> None:
+    def SET_CONTAINS(self, guard: Guard, key: object) -> None:
         set_ref = self.arg_ref(guard)
         item = key
 
@@ -2488,7 +2497,7 @@ class GuardBuilder(GuardBuilderBase):
         get_metadata_fn=lambda guard, value: _guard_create_fn_keyword(guard, "key"),
         eval_fn=lambda value, metadata: metadata not in value,
     )
-    def SET_NOT_CONTAINS(self, guard: Guard, key: Any) -> None:
+    def SET_NOT_CONTAINS(self, guard: Guard, key: object) -> None:
         set_ref = self.arg_ref(guard)
         item = key
 
@@ -2537,7 +2546,7 @@ class GuardBuilder(GuardBuilderBase):
         if not isinstance(expected, bool):
             raise AssertionError("COW_TENSOR_MATCH requires a plain Tensor")
 
-        def guard_fn(x: Any) -> bool:
+        def guard_fn(x: object) -> bool:
             return _cow_tensor_matches(x, expected)
 
         code = f"___cow_tensor_matches({self.arg_ref(guard)}, {expected!r})"
@@ -2616,7 +2625,7 @@ class GuardBuilder(GuardBuilderBase):
         get_metadata_fn=lambda guard, value: None,
         eval_fn=lambda value, metadata: value is not None,
     )
-    def NOT_NONE_MATCH(self, guard: Guard, value: Any | None = None) -> None:
+    def NOT_NONE_MATCH(self, guard: Guard, value: object | None = None) -> None:
         ref = self.arg_ref(guard)
         val = self.get(guard)
         if not isinstance(val, torch.Tensor):
@@ -2676,7 +2685,7 @@ class GuardBuilder(GuardBuilderBase):
         # TODO(anijain2305) - Consider this moving this guard to C++
         compare_fn = torch._functorch.pyfunctorch.compare_functorch_state
 
-        def fn(x: Any) -> bool:
+        def fn(x: object) -> bool:
             return compare_fn(states)
 
         self.guard_manager.root.add_lambda_guard(
@@ -2706,7 +2715,7 @@ class GuardBuilder(GuardBuilderBase):
         ]
         self._set_guard_export_info(guard, code)
 
-        def fn(x: Any) -> bool:
+        def fn(x: object) -> bool:
             return guard_hooks_ids == hooks_ids_fn(get_hooks())
 
         self.guard_manager.root.add_lambda_guard(
@@ -2740,16 +2749,21 @@ class GuardBuilder(GuardBuilderBase):
         original_metadata = deepcopy(
             pytree.tree_map_only(torch.SymInt, lambda _: _AnyCompare(), metadata)
         )
+        # Either arm runs on every guard evaluation, so they narrow the opaque
+        # guarded value with a suppression rather than a typing.cast, which
+        # would be a real call on the check path.
         if has_custom_guard:
 
-            def metadata_checker(x: Any) -> bool:
+            def metadata_checker(x: object) -> bool:
                 return cls.__metadata_guard__(
-                    original_metadata, x.__tensor_flatten__()[1]
+                    original_metadata,
+                    x.__tensor_flatten__()[1],  # pyrefly: ignore[missing-attribute]
                 )
 
         else:
 
-            def metadata_checker(x: Any) -> bool:
+            def metadata_checker(x: object) -> bool:
+                # pyrefly: ignore[missing-attribute]
                 return x.__tensor_flatten__()[1] == original_metadata
 
         global_name = f"___check_metadata_{id(metadata_checker)}_c{CompileContext.current_compile_id()}"
@@ -2768,7 +2782,7 @@ class GuardBuilder(GuardBuilderBase):
         # TODO - Consider moving this to C++ if stable
         expected = extract_dtensor_spec(guard, self.get(guard))
 
-        def guard_fn(x: Any) -> bool:
+        def guard_fn(x: object) -> bool:
             return check_dtensor_spec(x, expected)
 
         code = f"__dtensor_spec_{id(guard_fn)}"
@@ -2789,7 +2803,7 @@ class GuardBuilder(GuardBuilderBase):
         if original_values is None:
             return
 
-        def opaque_guard_checker(x: Any) -> bool:
+        def opaque_guard_checker(x: object) -> bool:
             return check_opaque_obj(x, original_values)
 
         global_name = f"___check_opaque_guard_fn_{id(opaque_guard_checker)}_c{CompileContext.current_compile_id()}"
@@ -2959,8 +2973,11 @@ class GuardBuilder(GuardBuilderBase):
         base_value = base_type(val)
         code = [f"{base_type.__name__}({ref}) == {base_value!r}"]
 
-        def check_fn(x: Any) -> bool:
-            return base_type(x) == base_value
+        def check_fn(x: object) -> bool:
+            # Mirrors _constant_subclass_base_value: base_type is a union of
+            # int/float/str, none of which typecheck against an opaque arg,
+            # but x is an instance of base_type by construction.
+            return base_type(x) == base_value  # pyrefly: ignore[bad-argument-type]
 
         self.get_guard_manager(guard).add_lambda_guard(
             check_fn,
@@ -3160,7 +3177,7 @@ class GuardBuilder(GuardBuilderBase):
         count_type = type(value)
         normalized_count_iter = normalize_count_iter(value)
 
-        def guard_fn(x: Any) -> bool:
+        def guard_fn(x: object) -> bool:
             return (
                 type(x) is count_type
                 and normalize_count_iter(x) == normalized_count_iter
@@ -3857,7 +3874,7 @@ class GuardBuilder(GuardBuilderBase):
         self,
         guard: Guard,
         code_list: list[str],
-        provided_guarded_object: Any | None = None,
+        provided_guarded_object: object | None = None,
         provided_func_name: str | None = None,
     ) -> None:
         # WARNING: It is important that cur_frame/caller do NOT stay in


### PR DESCRIPTION
The value flowing into a lambda guard is opaque at the guard boundary: the
C++ guard manager hands the closure whatever object currently lives at the
guarded source, which is precisely why several of these closures start by
checking `type(x)` before touching it. Annotating that parameter as `Any`
says the opposite -- that anything may be assumed about it -- and disables
checking inside the closure body. The same is true of the small
module-level guard helpers that only hash, `isinstance`, or `repr` their
argument. Widen all of them to `object`, which still accepts every value
but forces the body to narrow before use.

Closures handed to `add_lambda_guard` (the pyi param is
`Callable[..., Any]`, so any signature is accepted): FUNCTORCH_STACK_MATCH
and AUTOGRAD_SAVED_TENSORS_HOOKS (both ignore the argument entirely),
DTENSOR_SPEC_MATCH and OPAQUE_OBJ_GUARD_FN_MATCH (pass straight through to
`check_dtensor_spec` / `check_opaque_obj`), CONSTANT_SUBCLASS_MATCH,
TENSOR_SUBCLASS_METADATA_MATCH, COUNT_ITERATOR_MATCH and
COW_TENSOR_MATCH. Guard-builder params: SET_CONTAINS/SET_NOT_CONTAINS
`key`, NOT_NONE_MATCH `value` (unused), and `_set_guard_export_info`'s
`provided_guarded_object`, which only calls
`type()`/`getattr`/`weakref.ref` on it. Module-level:
`_sequence_length`, `get_key_index`'s `key`, `raise_local_type_error`,
`should_optimize_getattr_on_nn_module`, `_constant_subclass_base_value`,
and the `isinstance`-first pair `_try_is_cow_tensor`/`_cow_tensor_matches`.

TENSOR_MATCH's `value` stays `Any | None` on purpose. It is not an opaque
guarded value: the body calls `torch._C._dispatch_keys(value)` before it
asserts `isinstance(value, torch.Tensor)`, so the real contract is
`torch.Tensor | TensorWeakRef | None`, which is strictly more informative
than `object`. Spelling that out is a different change, not a widening.

Each of those guards also has a second, equivalent evaluation arm -- the
`extract_*`/`check_*` pair registered through `@register_guard_check_spec`
and used by the serialized-guard and invoke_subgraph paths -- so those are
typed the same way rather than leaving the two arms inconsistent:
`extract_subclass_metadata`/`check_subclass_metadata`,
`extract_dtensor_spec`/`check_dtensor_spec`,
`extract_opaque_obj`/`check_opaque_obj`, and CLOSURE_MATCH's
`extract_closure`/`check_closure`, which has the same shape and narrows
through `type(value) is types.FunctionType`. Widening `guard_fn(x)` alone
would have been cosmetic, since the callee re-widened to `Any` one frame
down.

Two mechanisms narrow the opaque value, split by whether the code is
reachable from a lambda guard. `typing.cast` where it is not: `Sized` in
`_sequence_length` and the canonical `TraceableWrapperSubclass` protocol
before `__tensor_flatten__` (`torch.Tensor` itself does not declare that
method) in the TENSOR_SUBCLASS_METADATA_MATCH spec pair, both of which are
only reached at trace time or through `eval_fn`. A `pyrefly: ignore`
comment where it is -- the two `metadata_checker` arms and
`check_dtensor_spec`, which the C++ `LAMBDA_GUARD` invokes on every guard
evaluation -- because `typing.cast` is a real Python call on the check
path. CONSTANT_SUBCLASS_MATCH would have needed a suppression regardless:
`base_type` is a `type[int] | type[float] | type[str]` union that no
single cast satisfies, mirroring the identical suppression already in
`_constant_subclass_base_value`. The casts all take a string type
argument, so the `TYPE_CHECKING`-only import stays out of the runtime
import graph.

Two spots need no narrowing at all: COUNT_ITERATOR_MATCH's closure, where
`count_type` is a `type[Any]` so `type(x) is count_type` re-widens `x`
back to `Any` before `normalize_count_iter` sees it (the checker accepts
it for that reason, not because the guard proved anything), and
`check_opaque_obj`, which goes through `get_opaque_obj_info(type(value))`.

The two parameters that default to `None` -- NOT_NONE_MATCH's unused
`value` and `_set_guard_export_info`'s `provided_guarded_object`, whose
body branches on the sentinel -- are spelled `object | None` rather than
bare `object` so the default stays legible at the signature, even though
`object` already admits `None`.

Two things are deliberately left for a follow-up. `reducer_override`
further down the file is a similar opportunity but needs several more
suppressions. And the `GuardCheckGetMetadataFn`/`GuardCheckEvalFn` aliases
still erase the widened parameter back to `Any` at the registration
boundary; widening them is not free, since the ~25 inline lambdas
registered through the same decorator infer their parameter types from the
alias and would each need a suppression. The win here is that the bodies
of the named spec functions are now checked. Also left alone:
DICT_CONTAINS/DICT_NOT_CONTAINS still take `key: str` where their set
siblings now take `object`, an asymmetry that predates this PR, and
`from_numpy`, whose `else a` branch already contradicts its
`-> torch.Tensor` return type; widening its parameter would surface that
as a new error, and fixing a wrong return type is a different change.

Test Plan:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 \
  torch/_dynamo/guards.py
```

```
uvx pyrefly@0.58.0 check --config pyrefly.toml \
  torch/_dynamo/guards.py
```

pyrefly reports 0 errors on the file both before and after. Its tally of
suppressed *errors* (not of suppression comments) goes 24 -> 29: four new
comments covering five errors, since the `base_type(x)` line carries two
overload errors. The other three are one `__tensor_flatten__` access in
each arm of TENSOR_SUBCLASS_METADATA_MATCH plus the `_check_equals`
access in `check_dtensor_spec`. A whole-project pyrefly run stays at the
same 92 pre-existing errors, none of them in this file.

No runtime behavior changes. The only executable additions are three
`typing.cast` calls, none of them reachable from a lambda guard, which
return their argument unchanged.

This PR was authored with the assistance of an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98