### PR TITLE
Add `fbsource-caffe2-lintrunner` Claude skill for running PyTorch lintrunner locally (#192145)

### DIFF
--- a/.claude/skills/fbsource-caffe2-lintrunner/SKILL.md
+++ b/.claude/skills/fbsource-caffe2-lintrunner/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: fbsource-caffe2-lintrunner
+description: Run PyTorch (caffe2) lintrunner linters locally in fbsource to reproduce the OSS PR lint jobs (e.g. Lint / lintrunner-noclang-partial). Use when lintrunner is not installed, when `uv`-based linters fail to download CPython, or when running CLANGFORMAT, RUFF, PYFMT, FLAKE8, CODESPELL, or PYREFLY on changed caffe2 files from a devserver.
+---
+
+# Run caffe2 lintrunner linters locally in fbsource
+
+Reproduce the PyTorch OSS PR lint jobs (e.g. `Lint / lintrunner-noclang-partial`) against
+local changes in `fbcode/caffe2` (and the `xplat/caffe2` mirror) from an fbsource
+devserver, where `lintrunner` is not preinstalled and network egress is restricted.
+
+## When to use this skill
+
+Use this skill when:
+- Asked to run the linters from a PyTorch PR / a specific lint CI job locally.
+- `lintrunner` is not on `PATH` and there is no `.venv`.
+- A `uv`-based linter fails with `Failed to download ... cpython ... github.com` (blocked egress).
+- Running `CLANGFORMAT`, `RUFF`, `PYFMT`, `FLAKE8`, `CODESPELL`, or `PYREFLY` on changed
+  `caffe2` files.
+- User mentions "lintrunner", "lintrunner-noclang", "noclang-partial", "docstring linter",
+  or "reproduce the lint job".
+
+## Key facts
+
+- Run all `lintrunner` commands from `fbcode/caffe2` (that is where `.lintrunner.toml`,
+  `pyproject.toml`, and `pyrefly.toml` live). `-I/-X` and config paths are relative to CWD.
+- fbsource is Sapling/EdenFS, not git. `lintrunner` still works when you pass explicit
+  file paths; the `fatal: not a git repository` messages from some adapters are non-fatal.
+- Network: AWS S3 (`oss-clang-format.s3.us-east-2.amazonaws.com`) is reachable, so
+  `clang-format` / `clang-tidy` / `actionlint` download fine. `github.com` direct downloads
+  are blocked, so `uv run --python 3.10 ...` (used by the Python linters) fails. Work around
+  it by running each Python linter's adapter script directly with the venv Python and
+  installing the adapter's pinned deps from the internal PyPI mirror (plain `pip` works).
+- `xplat/caffe2` is a byte-identical mirror of `fbcode/caffe2`; `.lintrunner.toml` only lives
+  under `fbcode/caffe2`. Lint the fbcode copy (maps to OSS paths) and mirror any fix into xplat.
+- An adapter prints LintMessage JSON per finding; no JSON output == clean.
+
+## Step 1: Environment setup
+
+```bash
+# venv (system python3 is 3.12; matches pyrefly.toml python-version = "3.12")
+python3 -m venv /tmp/lr_venv
+/tmp/lr_venv/bin/python -m pip install --upgrade pip lintrunner
+
+# Download the S3-hosted binaries into fbcode/caffe2/.lintbin
+# (full `lintrunner init` also works; its uv-based init steps fail harmlessly)
+cd /data/users/adelesun/fbsource/fbcode/caffe2
+python3 tools/linter/adapters/s3_init.py \
+    --config-json=tools/linter/adapters/s3_init_config.json \
+    --linter=clang-format --dry-run=0 --output-dir=.lintbin --output-name=clang-format
+
+# Put lintrunner on PATH so the LINTRUNNER_VERSION adapter (calls bare `lintrunner -V`) passes
+export PATH="/tmp/lr_venv/bin:$PATH"
+```
+
+Cleanup when done: `rm -rf /tmp/lr_venv` and `fbcode/caffe2/.lintbin`.
+
+## Step 2: Offline linters via lintrunner (no uv, no build)
+
+Run from `fbcode/caffe2` with explicit file paths. Each linter applies its own
+include/exclude patterns, so a mixed C++/py/md file list is fine.
+
+Faithful "noclang" run = everything except the clang linters (need a build) and the
+uv-based linters (run separately in Step 3):
+
+```bash
+cd /data/users/adelesun/fbsource/fbcode/caffe2
+export PATH="/tmp/lr_venv/bin:$PATH"
+
+SKIP="CLANGFORMAT,CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,\
+FLAKE8,PYREFLY,NATIVEFUNCTIONS,GHA,CMAKE,SHELLCHECK,TEST_HAS_MAIN,\
+WORKFLOWSYNC,NO_WORKFLOWS_ON_FORK,CODESPELL,PYFMT,PYPROJECT,\
+CMAKE_MINIMUM_REQUIRED,RUFF"
+
+lintrunner --skip "$SKIP" <files...>
+
+# CLANGFORMAT is offline too (uses .lintbin/clang-format); run it explicitly
+lintrunner --take CLANGFORMAT <cpp/h files...>
+```
+
+This covers `NEWLINE`, `TABS`, `SPACES`, `INCLUDE`, `TYPEIGNORE`, `NOQA`, `RAWTHROW`,
+`COPYRIGHT`, `C10_UNUSED`, `C10_NODISCARD`, `RAWCUDA`, `RAWCUDADEVICE`, `CALL_ONCE`,
+`ONCE_FLAG`, `ATEN_CPU_GPU_AGNOSTIC`, `PYBIND11_INCLUDE`, `PYBIND11_SPECIALIZATION`,
+`ERROR_PRONE_ISINSTANCE`, `SET_LINTER`, `IMPORT_LINTER`, `DOCSTRING_LINTER`,
+`META_NO_CREATE_UNBACKED`, `SYMPY_MINMAX`, and other offline grep/pattern linters.
+
+Notes:
+- `DOCSTRING_LINTER`: fails on an undocumented `class` >100 lines or `def` >80 lines that is
+  not listed in `tools/linter/adapters/docstring_linter-grandfather.json`. Fix by adding a
+  docstring (a documented block is exempt regardless of size).
+- Filter noise in output with:
+  `2>&1 | grep -vE 'INFO lintrunner|not a git repo|Stopping at filesystem|hint:|sl root|sl help'`
+
+## Step 3: Python linters via their adapter scripts (uv bypassed)
+
+Run each adapter `.py` directly with the venv Python and install its pinned deps (from the
+adapter's PEP-723 `# dependencies` block) from the internal mirror.
+
+```bash
+cd /data/users/adelesun/fbsource/fbcode/caffe2
+PY=/tmp/lr_venv/bin/python
+PYFILES="<changed .py files...>"
+ALLFILES="<all changed files incl C++/md...>"
+
+# RUFF (pinned 0.14.4)
+/tmp/lr_venv/bin/pip install 'ruff==0.14.4'
+$PY tools/linter/adapters/ruff_linter.py --config=pyproject.toml --show-disable -- $PYFILES
+
+# PYFMT (ruff-format + usort + isort); ruff==0.14.4 already installed
+/tmp/lr_venv/bin/pip install 'usort==1.1.3' 'isort==6.0.1'
+$PY tools/linter/adapters/pyfmt_linter.py $PYFILES
+
+# FLAKE8 (7.3.0 + plugins). flake8-logging-format imports pkg_resources, removed in
+# setuptools>=81, so pin setuptools<81.
+/tmp/lr_venv/bin/pip install \
+  'flake8==7.3.0' 'flake8-bugbear==24.12.12' 'flake8-comprehensions==3.16.0' \
+  'flake8-executable==2.1.3' 'flake8-logging-format==2024.24.12' 'flake8-pyi==25.5.0' \
+  'flake8-simplify==0.30.0' 'mccabe==0.7.0' 'pycodestyle==2.14.0' 'pyflakes==3.4.0' \
+  'setuptools<81'
+$PY tools/linter/adapters/flake8_linter.py $PYFILES
+
+# CODESPELL (2.4.1) - runs on all file types
+/tmp/lr_venv/bin/pip install 'codespell[toml]==2.4.1'
+$PY tools/linter/adapters/codespell_linter.py $ALLFILES
+```
+
+Always pin to the adapter's PEP-723 `# dependencies` block; a version mismatch (e.g. a newer
+ruff) can change results.
+
+### Auto-fixing offline (offline equivalent of `lintrunner -a`)
+
+`uv`-based `lintrunner -a` is blocked, but the pinned tools auto-fix in place. From
+`fbcode/caffe2`:
+
+```bash
+/tmp/lr_venv/bin/ruff check --config=pyproject.toml --fix $PYFILES   # RUFF safe fixes (e.g. F401)
+/tmp/lr_venv/bin/usort format $PYFILES                               # import ordering (PYFMT step 1)
+/tmp/lr_venv/bin/ruff format --config=pyproject.toml $PYFILES        # formatting (PYFMT step 2)
+```
+
+Together these reproduce the RUFF + PYFMT autofixes that `lintrunner -a` would apply. `arc f`
+(which runs automatically on `sl amend` / `sl commit`) is ruff-compatible for caffe2, so a file
+that is clean under these stays clean after amend/commit.
+
+### Common findings and fixes
+
+- `RUFF S101` ("use of `assert`"): `S101` is enabled repo-wide in `pyproject.toml`'s ruff
+  `select` with no test-directory exemption, so a bare `assert` is flagged even in test files
+  (e.g. under `torch/_inductor/tests/`). For a deliberate invariant assert, append
+  `# noqa: S101` (a short assert plus the noqa still fits under the B950 line limit).
+
+## Step 4: PYREFLY (type checker)
+
+```bash
+cd /data/users/adelesun/fbsource/fbcode/caffe2
+/tmp/lr_venv/bin/pip install \
+  'pyrefly==0.58.0' 'numpy==2.1.0' 'expecttest==0.3.0' 'sympy==1.13.3' \
+  'types-requests==2.27.25' 'types-pyyaml==6.0.2' 'types-tabulate==0.8.8' \
+  'types-protobuf==5.29.1.20250403' 'types-setuptools==79.0.0.20250422' \
+  'types-jinja2==2.11.9' 'types-colorama==0.4.6' 'filelock==3.18.0' \
+  'junitparser==2.1.1' 'rich==14.1.0'
+# Optional: 'spmd_types==0.2.1' (pulls in a PyPI torch + CUDA wheels as deps)
+
+/tmp/lr_venv/bin/pyrefly check --config pyrefly.toml --output-format=json <changed .py files...>
+```
+
+Caveat: without a built PyTorch, the local `torch` source lacks generated `_C` stubs
+(`_VariableFunctions.pyi`, etc.), so pyrefly reports many baseline `missing-attribute` errors
+on `torch.*` builtins (e.g. `torch.rand`, `torch._scaled_mm`). These are environment noise,
+not code defects. To isolate your change, attribute errors to the lines your commit added
+(parse the added-line ranges from `sl diff -c <rev> -g <file>` hunks and intersect with each
+error's line number). A clean-baseline CI-fidelity run requires a built torch so the
+generated stubs exist.
+
+## Linters that can NOT run locally
+
+- `CLANGTIDY`, `CLANGTIDY_EXECUTORCH_COMPATIBILITY`: need `compile_commands.json` from a
+  CUDA/ROCm build (`--build_dir=./build`). Not available in a plain checkout.
+- `PYREFLY` at CI fidelity: needs a built torch (generated `.pyi` stubs) for a clean baseline.
+- uv-based non-`.py` linters (`GHA`, `ACTIONLINT`, `CMAKE`, `SHELLCHECK`, `NATIVEFUNCTIONS`,
+  `WORKFLOWSYNC`, `PYPROJECT`, `CMAKE_MINIMUM_REQUIRED`): uv is blocked, and they do not apply
+  to C++/py/md source changes anyway, so they are no-ops for typical caffe2 diffs.
+
+## Meta-native alternatives (do apply here)
+
+```bash
+arc f <files...>          # format
+arc lint -a <files...>    # lint + autofix (BLACK, import sort, autodeps). Run before amend.
+```

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -816,9 +816,18 @@ void bgemm_internal<at::BFloat16, float>(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(at:
   }
 }
 
+// Returns true iff dispatched via TunableOp (concrete hit, wildcard hit, or
+// tuning ran via FindFastest). Returns false on a tuned-entry miss with
+// tuning disabled, leaving the caller to fall back to bgemm_internal --
+// the same path bgemm() takes when TunableOp is disabled. We never let the
+// dispatch fall through to ResultEntry::Default(), since the Default
+// kernel can fault on MI300X for some shapes.
 template <typename Dtype, typename C_Dtype = Dtype>
-inline void bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
+inline bool bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
   tunable::GemmStridedBatchedParams<Dtype> params;
+  // Stamp per-call dynamic-dims mask before invoking the TunableOp; see
+  // launchTunableGemmAndBias in Blas.cpp for the rationale.
+  params.dynamic_dims_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
   params.transa = transa;
   params.transb = transb;
   params.m = m;
@@ -840,21 +849,44 @@ inline void bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
   bool transa_ = ((transa != 'n') && (transa != 'N'));
   bool transb_ = ((transb != 'n') && (transb != 'N'));
 
+  auto try_dispatch = [&](auto& bgemm_op) -> bool {
+    auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+    auto& mgr = tuning_ctx->GetTuningResultsManager();
+    auto op_sig = bgemm_op.Signature();
+    auto concrete_sig = params.Signature();
+    auto result = mgr.Lookup(op_sig, concrete_sig);
+    if (result == at::cuda::tunable::ResultEntry::Null()
+        && !tuning_ctx->IsTuningEnabled()) {
+      // Concrete miss + tuning disabled: match persisted wildcard entries by
+      // token pattern (same as the addmm path). AOTI's cpp_wrapper emits no
+      // TunableDynamicDimsGuard, so the mask may be empty even when wildcards
+      // were persisted at compile-time tuning.
+      result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()) {
+        return false;
+      }
+    }
+    // Pass the already-computed concrete_sig so operator() does not recompute
+    // params.Signature() on the dispatch fast path.
+    bgemm_op(&params, concrete_sig);
+    return true;
+  };
+
   if (transa_ && transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::T, tunable::BlasOp::T> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else if (transa_ && !transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::T, tunable::BlasOp::N> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else if (!transa_ && transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::N, tunable::BlasOp::T> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else if (!transa_ && !transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::N, tunable::BlasOp::N> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else {
     TORCH_CHECK(false, "unreachable");
@@ -864,67 +896,61 @@ inline void bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
 template <>
 void bgemm<double>(CUDABLAS_BGEMM_ARGTYPES(double)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<double>(CUDABLAS_BGEMM_ARGS(double));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<double>(CUDABLAS_BGEMM_ARGS(double))) {
+    return;
   }
-  else {
-    bgemm_internal<double>(CUDABLAS_BGEMM_ARGS(double));
-  }
+  bgemm_internal<double>(CUDABLAS_BGEMM_ARGS(double));
 }
 
 template <>
 void bgemm<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<float>(CUDABLAS_BGEMM_ARGS(float));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<float>(CUDABLAS_BGEMM_ARGS(float))) {
+    return;
   }
-  else {
-    bgemm_internal<float>(CUDABLAS_BGEMM_ARGS(float));
-  }
+  bgemm_internal<float>(CUDABLAS_BGEMM_ARGS(float));
 }
 
 template <>
 void bgemm<c10::complex<double>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<double>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>))) {
+    return;
   }
-  else {
-    bgemm_internal<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>));
-  }
+  bgemm_internal<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>));
 }
 
 template <>
 void bgemm<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<float>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>))) {
+    return;
   }
-  else {
-    bgemm_internal<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>));
-  }
+  bgemm_internal<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>));
 }
 
 template <>
 void bgemm<at::Half>(CUDABLAS_BGEMM_ARGTYPES(at::Half)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half))) {
+    return;
   }
-  else {
-    bgemm_internal<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half));
-  }
+  bgemm_internal<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half));
 }
 
 template <>
 void bgemm<at::BFloat16>(CUDABLAS_BGEMM_ARGTYPES(at::BFloat16)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16))) {
+    return;
   }
-  else {
-    bgemm_internal<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16));
-  }
+  bgemm_internal<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16));
 }
 
 template <>
@@ -1365,9 +1391,17 @@ void gemm_internal<at::BFloat16, float>(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(at::B
   }
 }
 
+// Returns true iff dispatched via TunableOp. Returns false on a
+// tuned-entry miss with tuning disabled, leaving the caller to fall back
+// to gemm_internal -- the same path gemm() takes when TunableOp is
+// disabled. We never let the dispatch fall through to ResultEntry::Default()
+// since the Default kernel can fault on MI300X for some shapes.
 template <typename DType, typename C_Dtype>
-inline void gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
+inline bool gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
   tunable::GemmParams<DType> params;
+  // Stamp per-call dynamic-dims mask before invoking the TunableOp; see
+  // launchTunableGemmAndBias in Blas.cpp for the rationale.
+  params.dynamic_dims_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
   params.transa = transa;
   params.transb = transb;
   params.m = m;
@@ -1385,21 +1419,44 @@ inline void gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
   bool transa_ = ((transa != 'n') && (transa != 'N'));
   bool transb_ = ((transb != 'n') && (transb != 'N'));
 
+  auto try_dispatch = [&](auto& gemm_op) -> bool {
+    auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+    auto& mgr = tuning_ctx->GetTuningResultsManager();
+    auto op_sig = gemm_op.Signature();
+    auto concrete_sig = params.Signature();
+    auto result = mgr.Lookup(op_sig, concrete_sig);
+    if (result == at::cuda::tunable::ResultEntry::Null()
+        && !tuning_ctx->IsTuningEnabled()) {
+      // Concrete miss + tuning disabled: match persisted wildcard entries by
+      // token pattern (same as the addmm path). AOTI's cpp_wrapper emits no
+      // TunableDynamicDimsGuard, so the mask may be empty even when wildcards
+      // were persisted at compile-time tuning.
+      result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()) {
+        return false;
+      }
+    }
+    // Pass the already-computed concrete_sig so operator() does not recompute
+    // params.Signature() on the dispatch fast path.
+    gemm_op(&params, concrete_sig);
+    return true;
+  };
+
   if (transa_ && transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::T, tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (transa_ && !transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::T, tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::N, tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && !transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::N, tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else {
     TORCH_CHECK(false, "unreachable");
@@ -1409,67 +1466,61 @@ inline void gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
 template <>
 void gemm<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<double>(CUDABLAS_GEMM_ARGS(double));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<double>(CUDABLAS_GEMM_ARGS(double))) {
+    return;
   }
-  else {
-    gemm_internal<double>(CUDABLAS_GEMM_ARGS(double));
-  }
+  gemm_internal<double>(CUDABLAS_GEMM_ARGS(double));
 }
 
 template <>
 void gemm<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<float>(CUDABLAS_GEMM_ARGS(float));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<float>(CUDABLAS_GEMM_ARGS(float))) {
+    return;
   }
-  else {
-    gemm_internal<float>(CUDABLAS_GEMM_ARGS(float));
-  }
+  gemm_internal<float>(CUDABLAS_GEMM_ARGS(float));
 }
 
 template <>
 void gemm<c10::complex<double>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<double>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>))) {
+    return;
   }
-  else {
-    gemm_internal<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>));
-  }
+  gemm_internal<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>));
 }
 
 template <>
 void gemm<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<float>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>))) {
+    return;
   }
-  else {
-    gemm_internal<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>));
-  }
+  gemm_internal<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>));
 }
 
 template <>
 void gemm<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<at::Half>(CUDABLAS_GEMM_ARGS(at::Half))) {
+    return;
   }
-  else {
-    gemm_internal<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
-  }
+  gemm_internal<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
 }
 
 template <>
 void gemm<at::BFloat16>(CUDABLAS_GEMM_ARGTYPES(at::BFloat16)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16))) {
+    return;
   }
-  else {
-    gemm_internal<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16));
-  }
+  gemm_internal<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16));
 }
 
 template <>

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -816,9 +816,18 @@ void bgemm_internal<at::BFloat16, float>(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(at:
   }
 }
 
+// Returns true iff dispatched via TunableOp (concrete hit, wildcard hit, or
+// tuning ran via FindFastest). Returns false on a tuned-entry miss with
+// tuning disabled, leaving the caller to fall back to bgemm_internal --
+// the same path bgemm() takes when TunableOp is disabled. We never let the
+// dispatch fall through to ResultEntry::Default(), since the Default
+// kernel can fault on MI300X for some shapes.
 template <typename Dtype, typename C_Dtype = Dtype>
-inline void bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
+inline bool bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
   tunable::GemmStridedBatchedParams<Dtype> params;
+  // Stamp per-call dynamic-dims mask before invoking the TunableOp; see
+  // launchTunableGemmAndBias in Blas.cpp for the rationale.
+  params.dynamic_dims_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
   params.transa = transa;
   params.transb = transb;
   params.m = m;
@@ -840,21 +849,47 @@ inline void bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
   bool transa_ = ((transa != 'n') && (transa != 'N'));
   bool transb_ = ((transb != 'n') && (transb != 'N'));
 
+  auto try_dispatch = [&](auto& bgemm_op) -> bool {
+    auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+    auto& mgr = tuning_ctx->GetTuningResultsManager();
+    auto op_sig = bgemm_op.Signature();
+    auto concrete_sig = params.Signature();
+    auto result = mgr.Lookup(op_sig, concrete_sig);
+    if (result == at::cuda::tunable::ResultEntry::Null()
+        && !tuning_ctx->IsTuningEnabled()) {
+      // Concrete miss + tuning disabled. Scan persisted wildcard entries via
+      // token-pattern matching against the concrete signature, matching the
+      // addmm path (launchTunableGemmAndBias). Do not rely on a caller-set
+      // dynamic mask: the AOTI cpp_wrapper does not emit a
+      // TunableDynamicDimsGuard, so GetCurrentDynamicDimsMask() (and thus
+      // DynamicSignature()) is empty here even when wildcard entries were
+      // persisted at compile-time tuning.
+      result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()) {
+        return false;
+      }
+    }
+    // Pass the already-computed concrete_sig so operator() does not recompute
+    // params.Signature() on the dispatch fast path.
+    bgemm_op(&params, concrete_sig);
+    return true;
+  };
+
   if (transa_ && transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::T, tunable::BlasOp::T> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else if (transa_ && !transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::T, tunable::BlasOp::N> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else if (!transa_ && transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::N, tunable::BlasOp::T> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else if (!transa_ && !transb_) {
     static tunable::GemmStridedBatchedTunableOp<Dtype, tunable::BlasOp::N, tunable::BlasOp::N> bgemm{};
-    bgemm(&params);
+    return try_dispatch(bgemm);
   }
   else {
     TORCH_CHECK(false, "unreachable");
@@ -864,67 +899,61 @@ inline void bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
 template <>
 void bgemm<double>(CUDABLAS_BGEMM_ARGTYPES(double)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<double>(CUDABLAS_BGEMM_ARGS(double));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<double>(CUDABLAS_BGEMM_ARGS(double))) {
+    return;
   }
-  else {
-    bgemm_internal<double>(CUDABLAS_BGEMM_ARGS(double));
-  }
+  bgemm_internal<double>(CUDABLAS_BGEMM_ARGS(double));
 }
 
 template <>
 void bgemm<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<float>(CUDABLAS_BGEMM_ARGS(float));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<float>(CUDABLAS_BGEMM_ARGS(float))) {
+    return;
   }
-  else {
-    bgemm_internal<float>(CUDABLAS_BGEMM_ARGS(float));
-  }
+  bgemm_internal<float>(CUDABLAS_BGEMM_ARGS(float));
 }
 
 template <>
 void bgemm<c10::complex<double>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<double>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>))) {
+    return;
   }
-  else {
-    bgemm_internal<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>));
-  }
+  bgemm_internal<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>));
 }
 
 template <>
 void bgemm<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<float>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>))) {
+    return;
   }
-  else {
-    bgemm_internal<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>));
-  }
+  bgemm_internal<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>));
 }
 
 template <>
 void bgemm<at::Half>(CUDABLAS_BGEMM_ARGTYPES(at::Half)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half))) {
+    return;
   }
-  else {
-    bgemm_internal<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half));
-  }
+  bgemm_internal<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half));
 }
 
 template <>
 void bgemm<at::BFloat16>(CUDABLAS_BGEMM_ARGTYPES(at::BFloat16)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    bgemm_tunable<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && bgemm_tunable<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16))) {
+    return;
   }
-  else {
-    bgemm_internal<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16));
-  }
+  bgemm_internal<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16));
 }
 
 template <>
@@ -1365,9 +1394,17 @@ void gemm_internal<at::BFloat16, float>(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(at::B
   }
 }
 
+// Returns true iff dispatched via TunableOp. Returns false on a
+// tuned-entry miss with tuning disabled, leaving the caller to fall back
+// to gemm_internal -- the same path gemm() takes when TunableOp is
+// disabled. We never let the dispatch fall through to ResultEntry::Default()
+// since the Default kernel can fault on MI300X for some shapes.
 template <typename DType, typename C_Dtype>
-inline void gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
+inline bool gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
   tunable::GemmParams<DType> params;
+  // Stamp per-call dynamic-dims mask before invoking the TunableOp; see
+  // launchTunableGemmAndBias in Blas.cpp for the rationale.
+  params.dynamic_dims_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
   params.transa = transa;
   params.transb = transb;
   params.m = m;
@@ -1385,21 +1422,47 @@ inline void gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
   bool transa_ = ((transa != 'n') && (transa != 'N'));
   bool transb_ = ((transb != 'n') && (transb != 'N'));
 
+  auto try_dispatch = [&](auto& gemm_op) -> bool {
+    auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+    auto& mgr = tuning_ctx->GetTuningResultsManager();
+    auto op_sig = gemm_op.Signature();
+    auto concrete_sig = params.Signature();
+    auto result = mgr.Lookup(op_sig, concrete_sig);
+    if (result == at::cuda::tunable::ResultEntry::Null()
+        && !tuning_ctx->IsTuningEnabled()) {
+      // Concrete miss + tuning disabled. Scan persisted wildcard entries via
+      // token-pattern matching against the concrete signature, matching the
+      // addmm path (launchTunableGemmAndBias). Do not rely on a caller-set
+      // dynamic mask: the AOTI cpp_wrapper does not emit a
+      // TunableDynamicDimsGuard, so GetCurrentDynamicDimsMask() (and thus
+      // DynamicSignature()) is empty here even when wildcard entries were
+      // persisted at compile-time tuning.
+      result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()) {
+        return false;
+      }
+    }
+    // Pass the already-computed concrete_sig so operator() does not recompute
+    // params.Signature() on the dispatch fast path.
+    gemm_op(&params, concrete_sig);
+    return true;
+  };
+
   if (transa_ && transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::T, tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (transa_ && !transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::T, tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::N, tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && !transb_) {
     static tunable::GemmTunableOp<DType, tunable::BlasOp::N, tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else {
     TORCH_CHECK(false, "unreachable");
@@ -1409,67 +1472,61 @@ inline void gemm_tunable(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(DType, C_Dtype)) {
 template <>
 void gemm<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<double>(CUDABLAS_GEMM_ARGS(double));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<double>(CUDABLAS_GEMM_ARGS(double))) {
+    return;
   }
-  else {
-    gemm_internal<double>(CUDABLAS_GEMM_ARGS(double));
-  }
+  gemm_internal<double>(CUDABLAS_GEMM_ARGS(double));
 }
 
 template <>
 void gemm<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<float>(CUDABLAS_GEMM_ARGS(float));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<float>(CUDABLAS_GEMM_ARGS(float))) {
+    return;
   }
-  else {
-    gemm_internal<float>(CUDABLAS_GEMM_ARGS(float));
-  }
+  gemm_internal<float>(CUDABLAS_GEMM_ARGS(float));
 }
 
 template <>
 void gemm<c10::complex<double>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<double>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>))) {
+    return;
   }
-  else {
-    gemm_internal<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>));
-  }
+  gemm_internal<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>));
 }
 
 template <>
 void gemm<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<float>)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>))) {
+    return;
   }
-  else {
-    gemm_internal<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>));
-  }
+  gemm_internal<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>));
 }
 
 template <>
 void gemm<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<at::Half>(CUDABLAS_GEMM_ARGS(at::Half))) {
+    return;
   }
-  else {
-    gemm_internal<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
-  }
+  gemm_internal<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
 }
 
 template <>
 void gemm<at::BFloat16>(CUDABLAS_GEMM_ARGTYPES(at::BFloat16)) {
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
-  if (tuning_ctx->IsTunableOpEnabled()) {
-    gemm_tunable<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16));
+  if (tuning_ctx->IsTunableOpEnabled()
+      && gemm_tunable<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16))) {
+    return;
   }
-  else {
-    gemm_internal<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16));
-  }
+  gemm_internal<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16));
 }
 
 template <>

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -26,6 +26,7 @@
 #include <ATen/ops/from_blob.h>
 #endif
 #include <ATen/OpMathType.h>
+#include <fmt/core.h>
 #include <fmt/printf.h>
 
 namespace at::cuda::tunable {
@@ -102,6 +103,44 @@ inline const char* BLASTypeName(c10::complex<double> v) {
 template <>
 inline const char* BLASTypeName(c10::complex<float> v) {
   return "f32_r";
+}
+
+inline std::string MaybeWildcardInt(int64_t value, bool wildcard) {
+  return wildcard ? "*" : c10::str(value);
+}
+
+inline bool UsesMForLda(char transa) {
+  // lda is the leading dim of A. For non-transposed A (transa == 'N'), A is
+  // laid out with lda >= m, so lda tracks M; for transposed A (transa == 'T'),
+  // lda >= k, so lda tracks K. This mirrors GetSizeA's stride computation.
+  return transa == 'N' || transa == 'n';
+}
+
+inline bool UsesKForLdb(char transb) {
+  return transb == 'N' || transb == 'n';
+}
+
+// A leading dim is "tight" (equals its logical extent, no independent padding)
+// only when lda==m/k, ldb==k/n, ldc==m. Wildcard a leading dim only when it is
+// tight AND tracks a dynamic logical dim. A padded leading dim is not a
+// function of m/n/k, so replacing it with '*' would let the entry match shapes
+// with different padding/alignment -- exactly the input that decides hipBLASLt
+// algo validity and workspace size. See the sub-matrix check in
+// torch/cuda/tunable.py and ROCm/TheRock#5553.
+inline bool ShouldWildcardLda(char transa, bool dynamic_m, bool dynamic_k,
+                              int64_t lda, int64_t m, int64_t k) {
+  return UsesMForLda(transa) ? (dynamic_m && lda == m)
+                             : (dynamic_k && lda == k);
+}
+
+inline bool ShouldWildcardLdb(char transb, bool dynamic_n, bool dynamic_k,
+                              int64_t ldb, int64_t n, int64_t k) {
+  return UsesKForLdb(transb) ? (dynamic_k && ldb == k)
+                             : (dynamic_n && ldb == n);
+}
+
+inline bool ShouldWildcardLdc(bool dynamic_m, int64_t ldc, int64_t m) {
+  return dynamic_m && ldc == m;
 }
 
 inline std::string ScalarTypeToBLASType(c10::ScalarType scalar_type) {
@@ -291,7 +330,34 @@ struct GemmParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld", transa, transb, m, n, k, lda, ldb, ldc);
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        lda,
+        ldb,
+        ldc);
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        MaybeWildcardInt(m, dynamic_m),
+        MaybeWildcardInt(n, dynamic_n),
+        MaybeWildcardInt(k, dynamic_k),
+        MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k, lda, m, k)),
+        MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k, ldb, n, k)),
+        MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m, ldc, m)));
+    return signature;
   }
 
   size_t GetSizeA() const {
@@ -393,7 +459,34 @@ struct GemmAndBiasParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld", transa, transb, m, n, k, lda, ldb, ldc);
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        lda,
+        ldb,
+        ldc);
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        MaybeWildcardInt(m, dynamic_m),
+        MaybeWildcardInt(n, dynamic_n),
+        MaybeWildcardInt(k, dynamic_k),
+        MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k, lda, m, k)),
+        MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k, ldb, n, k)),
+        MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m, ldc, m)));
+    return signature;
   }
 
   size_t GetSizeA() const {
@@ -496,7 +589,37 @@ struct GemmStridedBatchedParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_B_%ld_ld_%ld_%ld_%ld", transa, transb, m, n, k, batch, lda, ldb, ldc);
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_B_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        batch,
+        lda,
+        ldb,
+        ldc);
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    const bool dynamic_batch = this->IsDynamicBatch();
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_B_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        MaybeWildcardInt(m, dynamic_m),
+        MaybeWildcardInt(n, dynamic_n),
+        MaybeWildcardInt(k, dynamic_k),
+        MaybeWildcardInt(batch, dynamic_batch),
+        MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k, lda, m, k)),
+        MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k, ldb, n, k)),
+        MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m, ldc, m)));
+    return signature;
   }
 
   size_t GetSizeA() const {
@@ -618,10 +741,42 @@ struct ScaledGemmParams : OpParams {
     // params.bias_dtype = bias ? bias->scalar_type() : isFloat8Type(out_dtype_) ? at::ScalarType::Half : out_dtype_;
     //
     // In TunableOp, we must distinguish in param signature these two cases: with and without a bias vector.
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld_rw_%d_bias_%s",
-      transa, transb, m, n, k, lda, ldb, ldc,
+    auto signature = fmt::format(
+      // {:d} renders the RowWise flag as 0/1. Plain {} would print true/false,
+      // which would not match ScaledGemm entries in tuning-result files persisted
+      // before the fmt::sprintf("%d") -> fmt::format migration.
+      "{}{}_{}_{}_{}_ld_{}_{}_{}_rw_{:d}_bias_{}",
+      transa,
+      transb,
+      m,
+      n,
+      k,
+      lda,
+      ldb,
+      ldc,
       a_scaling_type == ScalingType::RowWise && b_scaling_type == ScalingType::RowWise,
       bias_ptr == nullptr ? "None" : at::toString(bias_dtype));
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    auto signature = fmt::format(
+      // {:d} keeps the RowWise flag as 0/1, consistent with Signature() above.
+      "{}{}_{}_{}_{}_ld_{}_{}_{}_rw_{:d}_bias_{}",
+      transa,
+      transb,
+      MaybeWildcardInt(m, dynamic_m),
+      MaybeWildcardInt(n, dynamic_n),
+      MaybeWildcardInt(k, dynamic_k),
+      MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k, lda, m, k)),
+      MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k, ldb, n, k)),
+      MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m, ldc, m)),
+      a_scaling_type == ScalingType::RowWise && b_scaling_type == ScalingType::RowWise,
+      bias_ptr == nullptr ? "None" : at::toString(bias_dtype));
+    return signature;
   }
 
   size_t GetSizeA() const {

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -26,6 +26,7 @@
 #include <ATen/ops/from_blob.h>
 #endif
 #include <ATen/OpMathType.h>
+#include <fmt/core.h>
 #include <fmt/printf.h>
 
 namespace at::cuda::tunable {
@@ -102,6 +103,33 @@ inline const char* BLASTypeName(c10::complex<double> v) {
 template <>
 inline const char* BLASTypeName(c10::complex<float> v) {
   return "f32_r";
+}
+
+inline std::string MaybeWildcardInt(int64_t value, bool wildcard) {
+  return wildcard ? "*" : c10::str(value);
+}
+
+inline bool UsesMForLda(char transa) {
+  // lda is the leading dim of A. For non-transposed A (transa == 'N'), A is
+  // laid out with lda >= m, so lda tracks M; for transposed A (transa == 'T'),
+  // lda >= k, so lda tracks K. This mirrors GetSizeA's stride computation.
+  return transa == 'N' || transa == 'n';
+}
+
+inline bool UsesKForLdb(char transb) {
+  return transb == 'N' || transb == 'n';
+}
+
+inline bool ShouldWildcardLda(char transa, bool dynamic_m, bool dynamic_k) {
+  return UsesMForLda(transa) ? dynamic_m : dynamic_k;
+}
+
+inline bool ShouldWildcardLdb(char transb, bool dynamic_n, bool dynamic_k) {
+  return UsesKForLdb(transb) ? dynamic_k : dynamic_n;
+}
+
+inline bool ShouldWildcardLdc(bool dynamic_m) {
+  return dynamic_m;
 }
 
 inline std::string ScalarTypeToBLASType(c10::ScalarType scalar_type) {
@@ -291,7 +319,36 @@ struct GemmParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld", transa, transb, m, n, k, lda, ldb, ldc);
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        lda,
+        ldb,
+        ldc);
+    TUNABLE_LOG3("GemmParams concrete_signature=", signature);
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        MaybeWildcardInt(m, dynamic_m),
+        MaybeWildcardInt(n, dynamic_n),
+        MaybeWildcardInt(k, dynamic_k),
+        MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k)),
+        MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k)),
+        MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m)));
+    TUNABLE_LOG3("GemmParams dynamic_signature=", signature, " dyn=", this->dynamic_dims_mask.ToString());
+    return signature;
   }
 
   size_t GetSizeA() const {
@@ -393,7 +450,36 @@ struct GemmAndBiasParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld", transa, transb, m, n, k, lda, ldb, ldc);
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        lda,
+        ldb,
+        ldc);
+    TUNABLE_LOG3("GemmAndBiasParams concrete_signature=", signature);
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        MaybeWildcardInt(m, dynamic_m),
+        MaybeWildcardInt(n, dynamic_n),
+        MaybeWildcardInt(k, dynamic_k),
+        MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k)),
+        MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k)),
+        MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m)));
+    TUNABLE_LOG3("GemmAndBiasParams dynamic_signature=", signature, " dyn=", this->dynamic_dims_mask.ToString());
+    return signature;
   }
 
   size_t GetSizeA() const {
@@ -496,7 +582,39 @@ struct GemmStridedBatchedParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_B_%ld_ld_%ld_%ld_%ld", transa, transb, m, n, k, batch, lda, ldb, ldc);
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_B_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        batch,
+        lda,
+        ldb,
+        ldc);
+    TUNABLE_LOG3("GemmStridedBatchedParams concrete_signature=", signature);
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    const bool dynamic_batch = this->IsDynamicBatch();
+    auto signature = fmt::format(
+        "{}{}_{}_{}_{}_B_{}_ld_{}_{}_{}",
+        transa,
+        transb,
+        MaybeWildcardInt(m, dynamic_m),
+        MaybeWildcardInt(n, dynamic_n),
+        MaybeWildcardInt(k, dynamic_k),
+        MaybeWildcardInt(batch, dynamic_batch),
+        MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k)),
+        MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k)),
+        MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m)));
+    TUNABLE_LOG3("GemmStridedBatchedParams dynamic_signature=", signature, " dyn=", this->dynamic_dims_mask.ToString());
+    return signature;
   }
 
   size_t GetSizeA() const {
@@ -618,10 +736,44 @@ struct ScaledGemmParams : OpParams {
     // params.bias_dtype = bias ? bias->scalar_type() : isFloat8Type(out_dtype_) ? at::ScalarType::Half : out_dtype_;
     //
     // In TunableOp, we must distinguish in param signature these two cases: with and without a bias vector.
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld_rw_%d_bias_%s",
-      transa, transb, m, n, k, lda, ldb, ldc,
+    auto signature = fmt::format(
+      // {:d} renders the RowWise flag as 0/1. Plain {} would print true/false,
+      // which would not match ScaledGemm entries in tuning-result files persisted
+      // before the fmt::sprintf("%d") -> fmt::format migration.
+      "{}{}_{}_{}_{}_ld_{}_{}_{}_rw_{:d}_bias_{}",
+      transa,
+      transb,
+      m,
+      n,
+      k,
+      lda,
+      ldb,
+      ldc,
       a_scaling_type == ScalingType::RowWise && b_scaling_type == ScalingType::RowWise,
       bias_ptr == nullptr ? "None" : at::toString(bias_dtype));
+    TUNABLE_LOG3("ScaledGemmParams concrete_signature=", signature);
+    return signature;
+  }
+
+  std::string DynamicSignature() const override {
+    const bool dynamic_m = this->IsDynamicM();
+    const bool dynamic_n = this->IsDynamicN();
+    const bool dynamic_k = this->IsDynamicK();
+    auto signature = fmt::format(
+      // {:d} keeps the RowWise flag as 0/1, consistent with Signature() above.
+      "{}{}_{}_{}_{}_ld_{}_{}_{}_rw_{:d}_bias_{}",
+      transa,
+      transb,
+      MaybeWildcardInt(m, dynamic_m),
+      MaybeWildcardInt(n, dynamic_n),
+      MaybeWildcardInt(k, dynamic_k),
+      MaybeWildcardInt(lda, ShouldWildcardLda(transa, dynamic_m, dynamic_k)),
+      MaybeWildcardInt(ldb, ShouldWildcardLdb(transb, dynamic_n, dynamic_k)),
+      MaybeWildcardInt(ldc, ShouldWildcardLdc(dynamic_m)),
+      a_scaling_type == ScalingType::RowWise && b_scaling_type == ScalingType::RowWise,
+      bias_ptr == nullptr ? "None" : at::toString(bias_dtype));
+    TUNABLE_LOG3("ScaledGemmParams dynamic_signature=", signature, " dyn=", this->dynamic_dims_mask.ToString());
+    return signature;
   }
 
   size_t GetSizeA() const {

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -46,6 +47,44 @@
 #endif
 
 namespace at::cuda::tunable {
+
+namespace {
+
+// Matches a tunableop params signature against a wildcard pattern. Both
+// strings are split on '_' and compared token-by-token; '*' in the pattern
+// matches any single token. Returns true iff every pattern token equals
+// the corresponding concrete token (or is '*').
+bool matches_wildcard_pattern(
+    const std::string& pattern,
+    const std::string& concrete) {
+  if (pattern.find('*') == std::string::npos) {
+    // Pattern has no wildcard token -> only exact match counts.
+    return pattern == concrete;
+  }
+  size_t p_i = 0, c_i = 0;
+  while (p_i < pattern.size() && c_i < concrete.size()) {
+    // Find next token boundary in each string.
+    size_t p_end = pattern.find('_', p_i);
+    if (p_end == std::string::npos) {
+      p_end = pattern.size();
+    }
+    size_t c_end = concrete.find('_', c_i);
+    if (c_end == std::string::npos) {
+      c_end = concrete.size();
+    }
+    const auto p_tok = std::string_view(pattern).substr(p_i, p_end - p_i);
+    const auto c_tok = std::string_view(concrete).substr(c_i, c_end - c_i);
+    if (p_tok != "*" && p_tok != c_tok) {
+      return false;
+    }
+    p_i = (p_end == pattern.size()) ? pattern.size() : p_end + 1;
+    c_i = (c_end == concrete.size()) ? concrete.size() : c_end + 1;
+  }
+  // Both must be fully consumed (same token count).
+  return p_i >= pattern.size() && c_i >= concrete.size();
+}
+
+} // namespace
 
 TuningContext* getTuningContext() {
   static TuningContext tuning_context;
@@ -83,12 +122,55 @@ ResultEntry TuningResultsManager::Lookup(const std::string& op_signature, const 
 
   const auto& km = kernel_map_it->second;
   auto it = km.find(params_signature);
-  if (it == km.cend()) {
-    TUNABLE_LOG3("missing params_signature, returning null ResultEntry for ", op_signature, ",", params_signature);
+  if (it != km.cend()) {
+    TUNABLE_LOG3(
+        "ResultEntry found for ",
+        op_signature,
+        ",",
+        params_signature);
+    return it->second;
+  }
+  // Exact-match-only Lookup. Callers that want to look up a wildcard key
+  // (e.g. operator() in TunableOp.h, or try_dispatch in Blas.cpp) must pass
+  // the already-formed wildcard signature; this Lookup will neither expand
+  // wildcards in the request nor match a wildcard request against concrete
+  // candidates. The previous "fuzzy fallback" scan was removed because it
+  // conflicted with the case-4 "is the wildcard KEY persisted?" check
+  // performed by operator() (the scan would spuriously return a concrete
+  // result for a wildcard request).
+  TUNABLE_LOG3(
+      "missing params_signature, returning null ResultEntry for ",
+      op_signature,
+      ",",
+      params_signature);
+  return ResultEntry::Null();
+}
+
+ResultEntry TuningResultsManager::LookupWildcardFallback(
+    const std::string& op_signature,
+    const std::string& concrete_params_signature) {
+  std::scoped_lock l{lock_};
+  auto kernel_map_it = results_.find(op_signature);
+  if (kernel_map_it == results_.cend()) {
     return ResultEntry::Null();
   }
-  TUNABLE_LOG3("ResultEntry found for ", op_signature, ",", params_signature);
-  return it->second;
+  const auto& km = kernel_map_it->second;
+  for (const auto& [key, entry] : km) {
+    if (key.find('*') == std::string::npos) {
+      continue; // skip concrete entries
+    }
+    if (matches_wildcard_pattern(key, concrete_params_signature)) {
+      TUNABLE_LOG3(
+          "wildcard fallback hit for ",
+          op_signature,
+          ",",
+          concrete_params_signature,
+          " via wildcard ",
+          key);
+      return entry;
+    }
+  }
+  return ResultEntry::Null();
 }
 
 void TuningResultsManager::AddImpl(const std::string& op_signature,
@@ -934,6 +1016,55 @@ bool TuningContext::GetLogOkay() const {
 std::ostream& TuningContext::GetLog() const {
   static auto streamptr = get_stream(GetLogFilename());
   return *streamptr;
+}
+
+namespace {
+
+// Per-thread stack of dynamic-dims masks. Producers in Blas.cpp /
+// CUDABlas.cpp / ScaledBlas.cpp read the top via GetCurrentDynamicDimsMask()
+// and stamp it onto the constructed Gemm*Params before calling the
+// TunableOp. The stack semantics let nested wrappers compose naturally:
+// e.g. an outer torch.cuda.tunable.dynamic_dims_mask(...) ctx-mgr around a
+// benchmark loop, with inner per-choice or per-call wrappers; each
+// TunableDynamicDimsGuard pushes on construction and pops on destruction.
+std::vector<DynamicDimsMask>& dynamic_dims_stack() {
+  // Function-local TLS: avoids a static-init dependency on std::vector's
+  // ctor running before any TunableDynamicDimsGuard is constructed.
+  thread_local std::vector<DynamicDimsMask> stack;
+  return stack;
+}
+
+} // namespace
+
+DynamicDimsMask GetCurrentDynamicDimsMask() {
+  const auto& stack = dynamic_dims_stack();
+  if (stack.empty()) {
+    return DynamicDimsMask{};
+  }
+  return stack.back();
+}
+
+TunableDynamicDimsGuard::TunableDynamicDimsGuard(DynamicDimsMask mask)
+    : owner_thread_(std::this_thread::get_id()) {
+  dynamic_dims_stack().push_back(mask);
+}
+
+TunableDynamicDimsGuard::~TunableDynamicDimsGuard() {
+  // The stack is thread-local, so a guard may only pop on the thread that
+  // pushed it. Destroying it elsewhere (e.g. a Python capsule released by the
+  // GC on another thread) would corrupt an unrelated thread's stack, so warn
+  // and leave both stacks untouched instead.
+  if (std::this_thread::get_id() != owner_thread_) {
+    TORCH_WARN_ONCE(
+        "TunableDynamicDimsGuard destroyed on a different thread than it was "
+        "created on; skipping pop. Prefer torch.cuda.tunable.dynamic_dims_mask "
+        "over raw push_/pop_dynamic_dims_mask.");
+    return;
+  }
+  auto& stack = dynamic_dims_stack();
+  if (!stack.empty()) {
+    stack.pop_back();
+  }
 }
 
 } // namespace at::cuda::tunable

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -46,6 +47,44 @@
 #endif
 
 namespace at::cuda::tunable {
+
+namespace {
+
+// Matches a tunableop params signature against a wildcard pattern. Both
+// strings are split on '_' and compared token-by-token; '*' in the pattern
+// matches any single token. Returns true iff every pattern token equals
+// the corresponding concrete token (or is '*').
+bool matches_wildcard_pattern(
+    const std::string& pattern,
+    const std::string& concrete) {
+  if (pattern.find('*') == std::string::npos) {
+    // Pattern has no wildcard token -> only exact match counts.
+    return pattern == concrete;
+  }
+  size_t p_i = 0, c_i = 0;
+  while (p_i < pattern.size() && c_i < concrete.size()) {
+    // Find next token boundary in each string.
+    size_t p_end = pattern.find('_', p_i);
+    if (p_end == std::string::npos) {
+      p_end = pattern.size();
+    }
+    size_t c_end = concrete.find('_', c_i);
+    if (c_end == std::string::npos) {
+      c_end = concrete.size();
+    }
+    const auto p_tok = std::string_view(pattern).substr(p_i, p_end - p_i);
+    const auto c_tok = std::string_view(concrete).substr(c_i, c_end - c_i);
+    if (p_tok != "*" && p_tok != c_tok) {
+      return false;
+    }
+    p_i = (p_end == pattern.size()) ? pattern.size() : p_end + 1;
+    c_i = (c_end == concrete.size()) ? concrete.size() : c_end + 1;
+  }
+  // Both must be fully consumed (same token count).
+  return p_i >= pattern.size() && c_i >= concrete.size();
+}
+
+} // namespace
 
 TuningContext* getTuningContext() {
   static TuningContext tuning_context;
@@ -83,12 +122,52 @@ ResultEntry TuningResultsManager::Lookup(const std::string& op_signature, const 
 
   const auto& km = kernel_map_it->second;
   auto it = km.find(params_signature);
-  if (it == km.cend()) {
-    TUNABLE_LOG3("missing params_signature, returning null ResultEntry for ", op_signature, ",", params_signature);
+  if (it != km.cend()) {
+    TUNABLE_LOG3(
+        "ResultEntry found for ",
+        op_signature,
+        ",",
+        params_signature);
+    return it->second;
+  }
+  // Exact-match-only Lookup: callers that want a wildcard key (e.g. operator()
+  // in TunableOp.h, or try_dispatch in Blas.cpp) must pass the already-formed
+  // wildcard signature. This neither expands wildcards in the request nor
+  // matches a wildcard request against concrete candidates; wildcard fallback
+  // lives in LookupWildcardFallback below.
+  TUNABLE_LOG3(
+      "missing params_signature, returning null ResultEntry for ",
+      op_signature,
+      ",",
+      params_signature);
+  return ResultEntry::Null();
+}
+
+ResultEntry TuningResultsManager::LookupWildcardFallback(
+    const std::string& op_signature,
+    const std::string& concrete_params_signature) {
+  std::scoped_lock l{lock_};
+  auto kernel_map_it = results_.find(op_signature);
+  if (kernel_map_it == results_.cend()) {
     return ResultEntry::Null();
   }
-  TUNABLE_LOG3("ResultEntry found for ", op_signature, ",", params_signature);
-  return it->second;
+  const auto& km = kernel_map_it->second;
+  for (const auto& [key, entry] : km) {
+    if (key.find('*') == std::string::npos) {
+      continue; // skip concrete entries
+    }
+    if (matches_wildcard_pattern(key, concrete_params_signature)) {
+      TUNABLE_LOG3(
+          "wildcard fallback hit for ",
+          op_signature,
+          ",",
+          concrete_params_signature,
+          " via wildcard ",
+          key);
+      return entry;
+    }
+  }
+  return ResultEntry::Null();
 }
 
 void TuningResultsManager::AddImpl(const std::string& op_signature,
@@ -934,6 +1013,55 @@ bool TuningContext::GetLogOkay() const {
 std::ostream& TuningContext::GetLog() const {
   static auto streamptr = get_stream(GetLogFilename());
   return *streamptr;
+}
+
+namespace {
+
+// Per-thread stack of dynamic-dims masks. Producers in Blas.cpp /
+// CUDABlas.cpp / ScaledBlas.cpp read the top via GetCurrentDynamicDimsMask()
+// and stamp it onto the constructed Gemm*Params before calling the
+// TunableOp. The stack semantics let nested wrappers compose naturally:
+// e.g. an outer torch.cuda.tunable.dynamic_dims_mask(...) ctx-mgr around a
+// benchmark loop, with inner per-choice or per-call wrappers; each
+// TunableDynamicDimsGuard pushes on construction and pops on destruction.
+std::vector<DynamicDimsMask>& dynamic_dims_stack() {
+  // Function-local TLS: avoids a static-init dependency on std::vector's
+  // ctor running before any TunableDynamicDimsGuard is constructed.
+  thread_local std::vector<DynamicDimsMask> stack;
+  return stack;
+}
+
+} // namespace
+
+DynamicDimsMask GetCurrentDynamicDimsMask() {
+  const auto& stack = dynamic_dims_stack();
+  if (stack.empty()) {
+    return DynamicDimsMask{};
+  }
+  return stack.back();
+}
+
+TunableDynamicDimsGuard::TunableDynamicDimsGuard(DynamicDimsMask mask)
+    : owner_thread_(std::this_thread::get_id()) {
+  dynamic_dims_stack().push_back(mask);
+}
+
+TunableDynamicDimsGuard::~TunableDynamicDimsGuard() {
+  // The stack is thread-local, so a guard may only pop on the thread that
+  // pushed it. Destroying it elsewhere (e.g. a Python capsule released by the
+  // GC on another thread) would corrupt an unrelated thread's stack, so warn
+  // and leave both stacks untouched instead.
+  if (std::this_thread::get_id() != owner_thread_) {
+    TORCH_WARN_ONCE(
+        "TunableDynamicDimsGuard destroyed on a different thread than it was "
+        "created on; skipping pop. Prefer torch.cuda.tunable.dynamic_dims_mask "
+        "over raw push_/pop_dynamic_dims_mask.");
+    return;
+  }
+  auto& stack = dynamic_dims_stack();
+  if (!stack.empty()) {
+    stack.pop_back();
+  }
 }
 
 } // namespace at::cuda::tunable

--- a/aten/src/ATen/cuda/tunable/Tunable.h
+++ b/aten/src/ATen/cuda/tunable/Tunable.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -76,6 +77,16 @@ class TORCH_CUDA_CPP_API TuningResultsManager {
     KernelMap Lookup(const std::string& op_signature);
 
     ResultEntry Lookup(const std::string& op_signature, const std::string& params_signature);
+
+    // Scans persisted wildcard entries (keys containing '*') under
+    // `op_signature` and returns the first whose token-by-token pattern
+    // matches `concrete_params_signature`. Used as a runtime fallback
+    // when a concrete miss happens without an active TunableDynamicDimsGuard
+    // (e.g., AOTI cpp_wrapper that wasn't compiled with guard emission).
+    // Returns ResultEntry::Null() if no wildcard matches.
+    ResultEntry LookupWildcardFallback(
+        const std::string& op_signature,
+        const std::string& concrete_params_signature);
 
     void AddImpl(const std::string& op_signature,
         const std::string& params_signature,
@@ -158,6 +169,57 @@ struct NumericalCheckConfig {
   NumericalCheckConfig(bool e, double a, double r) : enabled(e), atol(a), rtol(r) {}
 };
 
+// Per-call dynamic-dims mask. POD, trivially copyable so it composes with
+// the existing OpParams DeepCopy(*this) paths without any custom copy logic.
+// The four bits select which logical GEMM dim (M/N/K/BATCH) is wildcarded
+// when computing DynamicSignature() for that specific op invocation.
+struct TORCH_CUDA_CPP_API DynamicDimsMask {
+  static constexpr uint8_t M_BIT = 1u << 0;
+  static constexpr uint8_t N_BIT = 1u << 1;
+  static constexpr uint8_t K_BIT = 1u << 2;
+  static constexpr uint8_t BATCH_BIT = 1u << 3;
+
+  uint8_t bits{0};
+
+  constexpr DynamicDimsMask() = default;
+  constexpr DynamicDimsMask(bool m, bool n, bool k, bool batch)
+      : bits(
+            static_cast<uint8_t>(
+                (m ? M_BIT : 0) | (n ? N_BIT : 0) | (k ? K_BIT : 0) |
+                (batch ? BATCH_BIT : 0))) {}
+  explicit constexpr DynamicDimsMask(uint8_t b) : bits(b) {}
+
+  constexpr bool m() const { return (bits & M_BIT) != 0; }
+  constexpr bool n() const { return (bits & N_BIT) != 0; }
+  constexpr bool k() const { return (bits & K_BIT) != 0; }
+  constexpr bool batch() const { return (bits & BATCH_BIT) != 0; }
+  constexpr bool any() const { return bits != 0; }
+  constexpr bool empty() const { return bits == 0; }
+
+  // Human-readable form, e.g. "M|N" or "" when empty.
+  std::string ToString() const {
+    std::string s;
+    auto add = [&s](const char* tok) {
+      if (!s.empty()) {
+        s.push_back('|');
+      }
+      s.append(tok);
+    };
+    if (m()) {
+      add("M");
+    }
+    if (n()) {
+      add("N");
+    }
+    if (k()) {
+      add("K");
+    }
+    if (batch()) {
+      add("B");
+    }
+    return s;
+  }
+};
 
 class TORCH_CUDA_CPP_API TuningContext {
   public:
@@ -254,6 +316,52 @@ class TORCH_CUDA_CPP_API TuningContext {
 };
 
 TORCH_CUDA_CPP_API TuningContext* getTuningContext();
+
+// Returns the current top-of-stack DynamicDimsMask for this thread, or an
+// all-zero mask when no TunableDynamicDimsGuard is active. Producers in
+// Blas.cpp / CUDABlas.cpp / ScaledBlas.cpp call this once per Gemm*Params
+// construction and stamp the result onto the params before invoking the
+// TunableOp, so DynamicSignature() can read the mask off *this rather than
+// from a global TuningContext setting.
+//
+// Frame note (canonical): the mask is pushed in inductor frame
+// (M = mat1.size(0), N = mat2.size(1), K = mat1.size(1)). When BLAS dispatch
+// swaps (M, N) -> (n, m) to keep cuBLAS column-major (cublasCommonArgs::
+// swapped_mn, or a transposed batched result), producers must remap the bits
+// (swap m()<->n()) before stamping; otherwise DynamicSignature() places '*'
+// in the wrong slot and LookupWildcardFallback never matches at runtime.
+TORCH_CUDA_CPP_API DynamicDimsMask GetCurrentDynamicDimsMask();
+
+// RAII guard that pushes a DynamicDimsMask onto the thread-local stack on
+// construction and pops on destruction. Use to wrap a single GEMM call (or a
+// scope containing GEMM calls) with the mask that applies to that op.
+//
+// Lives in at::cuda::tunable so it is reachable from both ATen Blas.cpp
+// callers (eager mode) and the AOTI cpp_wrapper-emitted code in compiled .so
+// shared libraries (which include this header).
+//
+// Thread affinity: the guard must be destroyed on the thread that constructed
+// it, because it pops the constructing thread's thread-local stack. The
+// destructor records the owning thread and TORCH_WARNs (without popping) on a
+// cross-thread destruction rather than corrupting another thread's stack. The
+// raw push_/pop_dynamic_dims_mask Python API can violate this if a capsule is
+// released by the GC on another thread; prefer the dynamic_dims_mask context
+// manager, which keeps push and pop on the same thread.
+class TORCH_CUDA_CPP_API TunableDynamicDimsGuard {
+ public:
+  explicit TunableDynamicDimsGuard(DynamicDimsMask mask);
+  TunableDynamicDimsGuard(bool dyn_m, bool dyn_n, bool dyn_k, bool dyn_batch)
+      : TunableDynamicDimsGuard(DynamicDimsMask(dyn_m, dyn_n, dyn_k, dyn_batch)) {}
+  ~TunableDynamicDimsGuard();
+
+  TunableDynamicDimsGuard(const TunableDynamicDimsGuard&) = delete;
+  TunableDynamicDimsGuard& operator=(const TunableDynamicDimsGuard&) = delete;
+  TunableDynamicDimsGuard(TunableDynamicDimsGuard&&) = delete;
+  TunableDynamicDimsGuard& operator=(TunableDynamicDimsGuard&&) = delete;
+
+ private:
+  std::thread::id owner_thread_;
+};
 
 class ITimer {
   public:

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -49,38 +49,95 @@ class TunableOp {
     virtual ~TunableOp() = default;
 
     TuningStatus operator()(const ParamsT* params) {
+      return (*this)(params, params->Signature());
+    }
+
+    // Overload for callers that already computed the concrete params signature
+    // (the BLAS try_dispatch pre-check in Blas.cpp / ScaledBlas.cpp), avoiding
+    // a second params->Signature() fmt::format on the dispatch fast path.
+    TuningStatus operator()(
+        const ParamsT* params,
+        const std::string& concrete_params_sig) {
+      // Dispatch matrix. has_dynamic_dim (a GEMM dim is symbolic) is set only
+      // during compile-time autotune; the AOTI runtime .so never carries it.
+      //   tuning on, concrete miss -> tune; persist concrete (+ wildcard if dynamic)
+      //   tuning on, concrete hit  -> persist wildcard if dynamic and not yet stored
+      //   runtime,   concrete hit          -> dispatch via concrete
+      //   runtime,   miss + wildcard match -> dispatch via wildcard
+      //   runtime,   miss + no wildcard    -> Null; callers fall back to aten
       ResultEntry result = ResultEntry::Null();
       TuningContext* ctx = getTuningContext();
       if (ctx->IsTunableOpEnabled()) {
         auto& mgr = ctx->GetTuningResultsManager();
         auto op_sig = Signature();
-        auto params_sig = params->Signature();
-        auto blas_sig = params->BLASSignature();
-        result = mgr.Lookup(op_sig, params_sig);
-        // If there is not previous tuning result been found, we do the tuning iff tuning is enabled
-        if (result == ResultEntry::Null()) {
-          bool should_record_untuned = !ctx->IsTuningEnabled();
-          if (ctx->IsTuningEnabled()) {
+        // Only this any() bit-check is on the cache-hit fast path;
+        // DynamicSignature() (a fmt::format with allocations) is computed
+        // lazily in the miss / case-4 branches. At runtime the mask is always
+        // empty (no TunableDynamicDimsGuard from AOTI cpp_wrapper), so this
+        // stays false on the hot path.
+        const bool has_dynamic_dim = params->dynamic_dims_mask.any();
+
+        result = mgr.Lookup(op_sig, concrete_params_sig);
+        const bool concrete_hit = (result != ResultEntry::Null());
+
+        if (ctx->IsTuningEnabled()) {
+          if (!concrete_hit) {
+            // Cases 1 & 2: concrete miss with tuning -> tune + persist.
+            bool can_tune = true;
 #ifndef USE_ROCM
-            bool is_capturing =
-                c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
+            can_tune =
+                c10::cuda::currentStreamCaptureStatusMayInitCtx() ==
                 c10::cuda::CaptureStatus::None;
-            if (!is_capturing) {
+            if (can_tune) {
               RegisterOpCandidates(params);
-              result = FindFastest(params);
-              mgr.Add(op_sig, params_sig, result);
-            } else {
-              should_record_untuned = true;
             }
-#else
-            result = FindFastest(params);
-            mgr.Add(op_sig, params_sig, result);
 #endif
+            if (can_tune) {
+              result = FindFastest(params);
+              mgr.Add(op_sig, concrete_params_sig, result);
+              if (has_dynamic_dim) {
+                // Case 2: also seed wildcard key with the same tuned kernel.
+                // mgr.Add is a no-op when the key already exists, so the
+                // first-tuned-wins semantics required by the dynamic-dims
+                // contract are preserved.
+                mgr.Add(op_sig, params->DynamicSignature(), result);
+              }
+            } else if (ctx->IsRecordUntunedEnabled()) {
+              mgr.RecordUntuned(
+                  ctx->GetUntunedFile(),
+                  op_sig,
+                  concrete_params_sig,
+                  params->BLASSignature());
+            }
           }
-          if (should_record_untuned && ctx->IsRecordUntunedEnabled()) {
-            // or record the gemm into file
-            mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, params_sig, blas_sig);
+          else if (has_dynamic_dim) {
+            // Case 4: concrete hit + dynamic -> ensure wildcard is persisted
+            // so subsequent shapes that differ only in the dynamic dims can
+            // reuse this kernel without re-tuning.
+            auto dynamic_params_sig = params->DynamicSignature();
+            if (mgr.Lookup(op_sig, dynamic_params_sig) == ResultEntry::Null()) {
+              mgr.Add(op_sig, dynamic_params_sig, result);
+            }
           }
+          // Case 3: concrete hit + no dynamic -> nothing to do.
+        }
+        else {
+          // Tuning disabled (runtime). We cannot rely on any caller-set
+          // dynamic mask here -- AOTI cpp_wrapper does not emit a
+          // TunableDynamicDimsGuard so GetCurrentDynamicDimsMask() is
+          // empty. On concrete miss, scan all persisted wildcard
+          // entries and return any whose token-pattern matches the
+          // concrete signature. If none match, result stays Null and
+          // the caller (e.g. launchTunableGemmAndBias) falls back to
+          // the non-tunable aten path.
+          if (!concrete_hit) {
+            result = mgr.LookupWildcardFallback(op_sig, concrete_params_sig);
+            if (result == ResultEntry::Null() && ctx->IsRecordUntunedEnabled()) {
+              auto blas_sig = params->BLASSignature();
+              mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, concrete_params_sig, blas_sig);
+            }
+          }
+          // Case 1: concrete hit -> use it.
         }
       }
       else {
@@ -432,7 +489,27 @@ struct OpParams {
   OpParams(const OpParams&) = default;
   virtual ~OpParams() = default;
   virtual std::string Signature() const = 0;
+  virtual std::string DynamicSignature() const {
+    return Signature();
+  }
   virtual std::string BLASSignature() const = 0;
+
+  // Per-instance mask describing which logical GEMM dims are dynamic for
+  // this particular op invocation. The producer (Blas.cpp / CUDABlas.cpp /
+  // ScaledBlas.cpp) reads at::cuda::tunable::GetCurrentDynamicDimsMask()
+  // once and stamps the result here before calling the TunableOp; the
+  // Gemm*Params subclasses' DynamicSignature() implementations then read
+  // this field instead of the previously-global TuningContext setting.
+  //
+  // Default-constructed (all-zero) means "no dim is dynamic", which yields
+  // a DynamicSignature() byte-identical to Signature() and preserves the
+  // legacy concrete-only behavior for callers that don't push a guard.
+  DynamicDimsMask dynamic_dims_mask{};
+
+  bool IsDynamicM() const { return dynamic_dims_mask.m(); }
+  bool IsDynamicN() const { return dynamic_dims_mask.n(); }
+  bool IsDynamicK() const { return dynamic_dims_mask.k(); }
+  bool IsDynamicBatch() const { return dynamic_dims_mask.batch(); }
 };
 
 } // namespace at::cuda::tunable

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -49,38 +49,99 @@ class TunableOp {
     virtual ~TunableOp() = default;
 
     TuningStatus operator()(const ParamsT* params) {
+      return (*this)(params, params->Signature());
+    }
+
+    // Overload for callers that already computed the concrete params signature
+    // (the BLAS try_dispatch pre-check in Blas.cpp / ScaledBlas.cpp), avoiding
+    // a second params->Signature() fmt::format on the dispatch fast path.
+    TuningStatus operator()(
+        const ParamsT* params,
+        const std::string& concrete_params_sig) {
+      // Dynamic TunableOp dispatch matrix (has_dynamic_dim = a GEMM dim is
+      // symbolic; set only during compile-time autotune, since the AOTI
+      // cpp_wrapper does not propagate dynamic-ness into the runtime .so):
+      //   tuning on,  concrete miss -> tune; persist concrete (+ wildcard if dynamic)
+      //   tuning on,  concrete hit  -> if dynamic and wildcard not yet persisted, persist wildcard
+      //   runtime,    concrete hit          -> dispatch via concrete
+      //   runtime,    miss + wildcard match -> dispatch via wildcard (LookupWildcardFallback)
+      //   runtime,    miss + no wildcard    -> Null; BLAS callers fall back to the aten path
       ResultEntry result = ResultEntry::Null();
       TuningContext* ctx = getTuningContext();
       if (ctx->IsTunableOpEnabled()) {
         auto& mgr = ctx->GetTuningResultsManager();
         auto op_sig = Signature();
-        auto params_sig = params->Signature();
-        auto blas_sig = params->BLASSignature();
-        result = mgr.Lookup(op_sig, params_sig);
-        // If there is not previous tuning result been found, we do the tuning iff tuning is enabled
-        if (result == ResultEntry::Null()) {
-          bool should_record_untuned = !ctx->IsTuningEnabled();
-          if (ctx->IsTuningEnabled()) {
+        // Only this `any()` bit-check is on the cache-hit fast path. The
+        // full DynamicSignature() (which performs a fmt::format with
+        // several string allocations) is computed lazily, only inside the
+        // miss / case-4 branches that actually need it. At runtime
+        // dynamic_dims_mask is always empty (no TunableDynamicDimsGuard
+        // emitted by AOTI cpp_wrapper) so this stays false on the
+        // hot path; only compile-time tuning (when Python pushes a mask
+        // via torch.cuda.tunable.dynamic_dims_mask) sets it.
+        const bool has_dynamic_dim = params->dynamic_dims_mask.any();
+
+        result = mgr.Lookup(op_sig, concrete_params_sig);
+        const bool concrete_hit = (result != ResultEntry::Null());
+
+        if (ctx->IsTuningEnabled()) {
+          if (!concrete_hit) {
+            // Cases 1 & 2: concrete miss with tuning -> tune + persist.
+            bool can_tune = true;
 #ifndef USE_ROCM
-            bool is_capturing =
-                c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
+            can_tune =
+                c10::cuda::currentStreamCaptureStatusMayInitCtx() ==
                 c10::cuda::CaptureStatus::None;
-            if (!is_capturing) {
+            if (can_tune) {
               RegisterOpCandidates(params);
-              result = FindFastest(params);
-              mgr.Add(op_sig, params_sig, result);
-            } else {
-              should_record_untuned = true;
             }
-#else
-            result = FindFastest(params);
-            mgr.Add(op_sig, params_sig, result);
 #endif
+            if (can_tune) {
+              result = FindFastest(params);
+              mgr.Add(op_sig, concrete_params_sig, result);
+              if (has_dynamic_dim) {
+                // Case 2: also seed wildcard key with the same tuned kernel.
+                // mgr.Add is a no-op when the key already exists, so the
+                // first-tuned-wins semantics required by the dynamic-dims
+                // contract are preserved.
+                mgr.Add(op_sig, params->DynamicSignature(), result);
+              }
+            } else if (ctx->IsRecordUntunedEnabled()) {
+              mgr.RecordUntuned(
+                  ctx->GetUntunedFile(),
+                  op_sig,
+                  concrete_params_sig,
+                  params->BLASSignature());
+            }
           }
-          if (should_record_untuned && ctx->IsRecordUntunedEnabled()) {
-            // or record the gemm into file
-            mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, params_sig, blas_sig);
+          else if (has_dynamic_dim) {
+            // Case 4: concrete hit + dynamic -> ensure wildcard is persisted
+            // so subsequent shapes that differ only in the dynamic dims can
+            // reuse this kernel without re-tuning.
+            auto dynamic_params_sig = params->DynamicSignature();
+            if (mgr.Lookup(op_sig, dynamic_params_sig) == ResultEntry::Null()) {
+              mgr.Add(op_sig, dynamic_params_sig, result);
+            }
           }
+          // Case 3: concrete hit + no dynamic -> nothing to do.
+        }
+        else {
+          // Tuning disabled (runtime). We cannot rely on any caller-set
+          // dynamic mask here -- AOTI cpp_wrapper does not emit a
+          // TunableDynamicDimsGuard so GetCurrentDynamicDimsMask() is
+          // empty. On concrete miss, scan all persisted wildcard
+          // entries and return any whose token-pattern matches the
+          // concrete signature. If none match, result stays Null and
+          // the caller (e.g. launchTunableGemmAndBias) falls back to
+          // the non-tunable aten path.
+          if (!concrete_hit) {
+            result = mgr.LookupWildcardFallback(op_sig, concrete_params_sig);
+            if (result == ResultEntry::Null() && ctx->IsRecordUntunedEnabled()) {
+              auto blas_sig = params->BLASSignature();
+              mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, concrete_params_sig, blas_sig);
+            }
+          }
+          // Case 1: concrete hit -> use it.
         }
       }
       else {
@@ -432,7 +493,27 @@ struct OpParams {
   OpParams(const OpParams&) = default;
   virtual ~OpParams() = default;
   virtual std::string Signature() const = 0;
+  virtual std::string DynamicSignature() const {
+    return Signature();
+  }
   virtual std::string BLASSignature() const = 0;
+
+  // Per-instance mask describing which logical GEMM dims are dynamic for
+  // this particular op invocation. The producer (Blas.cpp / CUDABlas.cpp /
+  // ScaledBlas.cpp) reads at::cuda::tunable::GetCurrentDynamicDimsMask()
+  // once and stamps the result here before calling the TunableOp; the
+  // Gemm*Params subclasses' DynamicSignature() implementations then read
+  // this field instead of the previously-global TuningContext setting.
+  //
+  // Default-constructed (all-zero) means "no dim is dynamic", which yields
+  // a DynamicSignature() byte-identical to Signature() and preserves the
+  // legacy concrete-only behavior for callers that don't push a guard.
+  DynamicDimsMask dynamic_dims_mask{};
+
+  bool IsDynamicM() const { return dynamic_dims_mask.m(); }
+  bool IsDynamicN() const { return dynamic_dims_mask.n(); }
+  bool IsDynamicK() const { return dynamic_dims_mask.k(); }
+  bool IsDynamicBatch() const { return dynamic_dims_mask.batch(); }
 };
 
 } // namespace at::cuda::tunable

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -298,11 +298,65 @@ static bool canUseAddmmCudaLtWithDistinctCAndD(
 #endif
 }
 
+// Direct call into at::cuda::blas::gemm_and_bias -- the same code path
+// taken when TunableOp is disabled. Extracted into a free function so both
+// the "TunableOp disabled" branch and the "TunableOp enabled but tunable
+// lookup missed" branch in launchGemmAndBiasCublasLt can call it without
+// having to flip the global TunableOp enable flag (which would be a data
+// race in multithreaded benchmark configs).
+template <typename scalar_t, typename res_scalar_t = scalar_t>
+bool launchGemmAndBiasNonTunable(
+    cublasCommonArgs& args,
+    const scalar_t* self_ptr,
+    const Scalar& alpha,
+    Activation activation) {
+  return at::cuda::blas::gemm_and_bias<scalar_t, res_scalar_t>(
+    args.transa == 't',
+    args.transb == 't',
+    args.m,
+    args.n,
+    args.k,
+    alpha.to<at::opmath_type<scalar_t>>(),
+    args.mata->const_data_ptr<scalar_t>(),
+    args.lda,
+    args.matb->const_data_ptr<scalar_t>(),
+    args.ldb,
+    self_ptr,
+    args.result->data_ptr<res_scalar_t>(),
+    args.result_ld,
+    activation_to_gemm_and_blas_arg(activation));
+}
+
+// Returns true iff the call was dispatched via TunableOp (either an
+// already-tuned entry was found, or tuning ran via FindFastest and produced
+// a result). Returns false when TunableOp is enabled but has no tuned entry
+// for this shape AND tuning is disabled -- in that case the caller must
+// fall back to the regular at::cuda::blas::gemm_and_bias path. We
+// intentionally do NOT let the dispatch fall through to ResultEntry::Default
+// here, because the GemmAndBias Default kernel can hit a GPU memory-access
+// fault on MI300X for large-K shapes, and the safest behavior on miss is
+// the same as the pre-TunableOp behavior (i.e. raw cuBLAS-Lt).
 template <typename scalar_t>
-void launchTunableGemmAndBias(cublasCommonArgs &args, const Scalar& alpha, const scalar_t* bias, cuda::blas::GEMMAndBiasActivationEpilogue activation) {
+bool launchTunableGemmAndBias(cublasCommonArgs &args, const Scalar& alpha, const scalar_t* bias, cuda::blas::GEMMAndBiasActivationEpilogue activation) {
   bool transa_ = ((args.transa != 'n') && (args.transa != 'N'));
   bool transb_ = ((args.transb != 'n') && (args.transb != 'N'));
   at::cuda::tunable::GemmAndBiasParams<scalar_t> params;
+  // Stamp the per-call dynamic-dims mask onto the params, remapping to BLAS
+  // frame when the dispatch swapped (M, N) -> (n, m). See
+  // GetCurrentDynamicDimsMask() in ATen/cuda/tunable/Tunable.h for the frame
+  // and remap rationale.
+  {
+    auto raw_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+    if (args.swapped_mn) {
+      params.dynamic_dims_mask = at::cuda::tunable::DynamicDimsMask(
+          /*M=*/raw_mask.n(),
+          /*N=*/raw_mask.m(),
+          /*K=*/raw_mask.k(),
+          /*BATCH=*/raw_mask.batch());
+    } else {
+      params.dynamic_dims_mask = raw_mask;
+    }
+  }
   params.transa = args.transa;
   params.transb = args.transb;
   params.m = args.m;
@@ -317,21 +371,49 @@ void launchTunableGemmAndBias(cublasCommonArgs &args, const Scalar& alpha, const
   params.ldc = args.result_ld;
   params.bias = bias;
   params.activation = activation;
+
+  // Returns true if `gemm` handled `params` -- a tuned concrete/wildcard entry
+  // was dispatched, or tuning is enabled and operator() will tune. Returns
+  // false only on a pure miss with tuning disabled, so the caller falls back
+  // to the non-tunable path.
+  auto try_dispatch = [&](auto& gemm) -> bool {
+    auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+    auto& mgr = tuning_ctx->GetTuningResultsManager();
+    auto op_sig = gemm.Signature();
+    auto concrete_sig = params.Signature();
+    auto result = mgr.Lookup(op_sig, concrete_sig);
+    if (result == at::cuda::tunable::ResultEntry::Null()
+        && !tuning_ctx->IsTuningEnabled()) {
+      // Concrete miss + tuning disabled: match persisted wildcard entries by
+      // token pattern. AOTI's cpp_wrapper emits no TunableDynamicDimsGuard, so
+      // params.dynamic_dims_mask may be empty even when wildcards were
+      // persisted at compile-time tuning.
+      result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()) {
+        return false;  // total miss: caller re-dispatches the non-tunable path
+      }
+    }
+    // Pass the already-computed concrete_sig so operator() does not recompute
+    // params.Signature() on the dispatch fast path.
+    gemm(&params, concrete_sig);
+    return true;
+  };
+
   if (transa_ && transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::T, at::cuda::tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (transa_ && !transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::T, at::cuda::tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::N, at::cuda::tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && !transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::N, at::cuda::tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else {
     TORCH_CHECK(false, "unreachable");
@@ -355,29 +437,24 @@ bool launchGemmAndBiasCublasLt(
 
   const auto tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
-    // TODO: maybe also return some success state?
-    launchTunableGemmAndBias<scalar_t>(
-      args, alpha, self_ptr, activation_to_gemm_and_blas_arg(activation)
-    );
-    return true;
+    if (launchTunableGemmAndBias<scalar_t>(
+            args, alpha, self_ptr, activation_to_gemm_and_blas_arg(activation))) {
+      return true;
+    }
+    // launchTunableGemmAndBias returned false: TunableOp is enabled but
+    // there is no tuned entry for this shape and tuning is disabled.
+    // Re-dispatch through launchGemmAndBiasNonTunable -- the exact same
+    // code path taken when TunableOp is disabled at the call site. We do
+    // NOT toggle the global TunableOp enable flag for this fallback,
+    // because that flag is non-atomic global state and would race with
+    // concurrent dispatches on other CPU threads (mts_gpu_benchmark uses
+    // num_threads > 1 in some configs).
+    return launchGemmAndBiasNonTunable<scalar_t, res_scalar_t>(
+        args, self_ptr, alpha, activation);
   }
 
-  return at::cuda::blas::gemm_and_bias<scalar_t, res_scalar_t>(
-    args.transa == 't',
-    args.transb == 't',
-    args.m,
-    args.n,
-    args.k,
-    alpha.to<at::opmath_type<scalar_t>>(),
-    args.mata->const_data_ptr<scalar_t>(),
-    args.lda,
-    args.matb->const_data_ptr<scalar_t>(),
-    args.ldb,
-    self_ptr,
-    args.result->data_ptr<res_scalar_t>(),
-    args.result_ld,
-    activation_to_gemm_and_blas_arg(activation)
-  );
+  return launchGemmAndBiasNonTunable<scalar_t, res_scalar_t>(
+      args, self_ptr, alpha, activation);
 }
 
 template <typename scalar_t, typename res_scalar_t = scalar_t>
@@ -387,6 +464,19 @@ bool launchGemmCublas(
     const Scalar& alpha,
     const Scalar& beta
 ) {
+  // Re-push the mask remapped to BLAS frame so gemm_tunable (CUDABlas.cpp)
+  // stamps it, since at::cuda::blas::gemm's ABI does not carry swapped_mn.
+  // Only when a dynamic mask is active AND the dispatch swapped, so the common
+  // path is untouched. See GetCurrentDynamicDimsMask() in Tunable.h.
+  const auto raw_dyn_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+  std::optional<at::cuda::tunable::TunableDynamicDimsGuard> dyn_guard;
+  if (raw_dyn_mask.any() && args.swapped_mn) {
+    dyn_guard.emplace(at::cuda::tunable::DynamicDimsMask(
+        /*M=*/raw_dyn_mask.n(),
+        /*N=*/raw_dyn_mask.m(),
+        /*K=*/raw_dyn_mask.k(),
+        /*BATCH=*/raw_dyn_mask.batch()));
+  }
   at::cuda::blas::gemm<scalar_t, res_scalar_t>(
     args.transa,
     args.transb,
@@ -694,6 +784,20 @@ const Tensor& baddbmm_out_cuda_impl(const Tensor& result, const Tensor& self, co
 
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!result_->is_conj());
   bool is_float_output_with_half_input = (batch1.scalar_type() == at::ScalarType::Half || batch1.scalar_type() == at::ScalarType::BFloat16) && result.scalar_type() == at::ScalarType::Float;
+
+  // Re-push the mask remapped to BLAS frame so (b)gemm_tunable stamps it; the
+  // batched dispatch transposes the result (M<->N) and carries no swapped_mn
+  // flag. Only when a dynamic mask is active AND the result is transposed, so
+  // the common path is untouched. See GetCurrentDynamicDimsMask() in Tunable.h.
+  const auto raw_dyn_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+  std::optional<at::cuda::tunable::TunableDynamicDimsGuard> baddbmm_dyn_guard;
+  if (raw_dyn_mask.any() && transpose_result) {
+    baddbmm_dyn_guard.emplace(at::cuda::tunable::DynamicDimsMask(
+        /*M=*/raw_dyn_mask.n(),
+        /*N=*/raw_dyn_mask.m(),
+        /*K=*/raw_dyn_mask.k(),
+        /*BATCH=*/raw_dyn_mask.batch()));
+  }
 
   if (is_float_output_with_half_input) {
     AT_DISPATCH_REDUCED_FLOATING_TYPES(batch1.scalar_type(), "baddbmm_cuda", [&] {

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -229,11 +229,65 @@ static bool isInputCompliesAddmmCudaLt(
   );
 }
 
+// Direct call into at::cuda::blas::gemm_and_bias -- the same code path
+// taken when TunableOp is disabled. Extracted into a free function so both
+// the "TunableOp disabled" branch and the "TunableOp enabled but tunable
+// lookup missed" branch in launchGemmAndBiasCublasLt can call it without
+// having to flip the global TunableOp enable flag (which would be a data
+// race in multithreaded benchmark configs).
+template <typename scalar_t, typename res_scalar_t = scalar_t>
+bool launchGemmAndBiasNonTunable(
+    cublasCommonArgs& args,
+    const scalar_t* self_ptr,
+    const Scalar& alpha,
+    Activation activation) {
+  return at::cuda::blas::gemm_and_bias<scalar_t, res_scalar_t>(
+    args.transa == 't',
+    args.transb == 't',
+    args.m,
+    args.n,
+    args.k,
+    alpha.to<at::opmath_type<scalar_t>>(),
+    args.mata->const_data_ptr<scalar_t>(),
+    args.lda,
+    args.matb->const_data_ptr<scalar_t>(),
+    args.ldb,
+    self_ptr,
+    args.result->data_ptr<res_scalar_t>(),
+    args.result_ld,
+    activation_to_gemm_and_blas_arg(activation));
+}
+
+// Returns true iff the call was dispatched via TunableOp (either an
+// already-tuned entry was found, or tuning ran via FindFastest and produced
+// a result). Returns false when TunableOp is enabled but has no tuned entry
+// for this shape AND tuning is disabled -- in that case the caller must
+// fall back to the regular at::cuda::blas::gemm_and_bias path. We
+// intentionally do NOT let the dispatch fall through to ResultEntry::Default
+// here, because the GemmAndBias Default kernel can hit a GPU memory-access
+// fault on MI300X for large-K shapes, and the safest behavior on miss is
+// the same as the pre-TunableOp behavior (i.e. raw cuBLAS-Lt).
 template <typename scalar_t>
-void launchTunableGemmAndBias(cublasCommonArgs &args, const Scalar& alpha, const scalar_t* bias, cuda::blas::GEMMAndBiasActivationEpilogue activation) {
+bool launchTunableGemmAndBias(cublasCommonArgs &args, const Scalar& alpha, const scalar_t* bias, cuda::blas::GEMMAndBiasActivationEpilogue activation) {
   bool transa_ = ((args.transa != 'n') && (args.transa != 'N'));
   bool transb_ = ((args.transb != 'n') && (args.transb != 'N'));
   at::cuda::tunable::GemmAndBiasParams<scalar_t> params;
+  // Stamp the per-call dynamic-dims mask onto the params, remapping to BLAS
+  // frame when the dispatch swapped (M, N) -> (n, m). See
+  // GetCurrentDynamicDimsMask() in ATen/cuda/tunable/Tunable.h for the frame
+  // and remap rationale.
+  {
+    auto raw_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+    if (args.swapped_mn) {
+      params.dynamic_dims_mask = at::cuda::tunable::DynamicDimsMask(
+          /*M=*/raw_mask.n(),
+          /*N=*/raw_mask.m(),
+          /*K=*/raw_mask.k(),
+          /*BATCH=*/raw_mask.batch());
+    } else {
+      params.dynamic_dims_mask = raw_mask;
+    }
+  }
   params.transa = args.transa;
   params.transb = args.transb;
   params.m = args.m;
@@ -248,21 +302,58 @@ void launchTunableGemmAndBias(cublasCommonArgs &args, const Scalar& alpha, const
   params.ldc = args.result_ld;
   params.bias = bias;
   params.activation = activation;
+
+  // Helper: returns true if `gemm` has a usable tuned entry (concrete or
+  // wildcard) for `params` and dispatched it; returns false on a pure miss
+  // when tuning is disabled, leaving the caller to fall back.
+  auto try_dispatch = [&](auto& gemm) -> bool {
+    auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+    auto& mgr = tuning_ctx->GetTuningResultsManager();
+    auto op_sig = gemm.Signature();
+    auto concrete_sig = params.Signature();
+    auto result = mgr.Lookup(op_sig, concrete_sig);
+    if (result == at::cuda::tunable::ResultEntry::Null()
+        && !tuning_ctx->IsTuningEnabled()) {
+      // Concrete miss + tuning disabled. Scan persisted wildcard
+      // entries via token-pattern matching against the concrete
+      // signature. This avoids relying on any caller-set dynamic
+      // mask -- the AOTI cpp_wrapper does not emit a
+      // TunableDynamicDimsGuard so `params.dynamic_dims_mask` may be
+      // empty here even when wildcard entries were persisted at
+      // compile-time tuning.
+      result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()) {
+        // Both concrete and wildcard missed -- skip the TunableOp dispatch
+        // entirely so we do not invoke the (potentially crashing) Default
+        // kernel. Caller (launchGemmAndBiasCublasLt) re-dispatches via
+        // launchGemmAndBiasNonTunable.
+        return false;
+      }
+    }
+    // Either we have a tuned entry (concrete or wildcard), or tuning is
+    // enabled and the standard operator() will run FindFastest and store a
+    // result. In all cases operator() dispatches to a real (tuned) kernel,
+    // never Default. Pass the already-computed concrete_sig so operator()
+    // does not recompute params.Signature().
+    gemm(&params, concrete_sig);
+    return true;
+  };
+
   if (transa_ && transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::T, at::cuda::tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (transa_ && !transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::T, at::cuda::tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::N, at::cuda::tunable::BlasOp::T> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else if (!transa_ && !transb_) {
     static at::cuda::tunable::GemmAndBiasTunableOp<scalar_t, at::cuda::tunable::BlasOp::N, at::cuda::tunable::BlasOp::N> gemm{};
-    gemm(&params);
+    return try_dispatch(gemm);
   }
   else {
     TORCH_CHECK(false, "unreachable");
@@ -286,29 +377,24 @@ bool launchGemmAndBiasCublasLt(
 
   const auto tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
-    // TODO: maybe also return some success state?
-    launchTunableGemmAndBias<scalar_t>(
-      args, alpha, self_ptr, activation_to_gemm_and_blas_arg(activation)
-    );
-    return true;
+    if (launchTunableGemmAndBias<scalar_t>(
+            args, alpha, self_ptr, activation_to_gemm_and_blas_arg(activation))) {
+      return true;
+    }
+    // launchTunableGemmAndBias returned false: TunableOp is enabled but
+    // there is no tuned entry for this shape and tuning is disabled.
+    // Re-dispatch through launchGemmAndBiasNonTunable -- the exact same
+    // code path taken when TunableOp is disabled at the call site. We do
+    // NOT toggle the global TunableOp enable flag for this fallback,
+    // because that flag is non-atomic global state and would race with
+    // concurrent dispatches on other CPU threads (mts_gpu_benchmark uses
+    // num_threads > 1 in some configs).
+    return launchGemmAndBiasNonTunable<scalar_t, res_scalar_t>(
+        args, self_ptr, alpha, activation);
   }
 
-  return at::cuda::blas::gemm_and_bias<scalar_t, res_scalar_t>(
-    args.transa == 't',
-    args.transb == 't',
-    args.m,
-    args.n,
-    args.k,
-    alpha.to<at::opmath_type<scalar_t>>(),
-    args.mata->const_data_ptr<scalar_t>(),
-    args.lda,
-    args.matb->const_data_ptr<scalar_t>(),
-    args.ldb,
-    self_ptr,
-    args.result->data_ptr<res_scalar_t>(),
-    args.result_ld,
-    activation_to_gemm_and_blas_arg(activation)
-  );
+  return launchGemmAndBiasNonTunable<scalar_t, res_scalar_t>(
+      args, self_ptr, alpha, activation);
 }
 
 template <typename scalar_t, typename res_scalar_t = scalar_t>
@@ -318,6 +404,19 @@ bool launchGemmCublas(
     const Scalar& alpha,
     const Scalar& beta
 ) {
+  // Re-push the mask remapped to BLAS frame so gemm_tunable (CUDABlas.cpp)
+  // stamps it, since at::cuda::blas::gemm's ABI does not carry swapped_mn.
+  // Only when a dynamic mask is active AND the dispatch swapped, so the common
+  // path is untouched. See GetCurrentDynamicDimsMask() in Tunable.h.
+  const auto raw_dyn_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+  std::optional<at::cuda::tunable::TunableDynamicDimsGuard> dyn_guard;
+  if (raw_dyn_mask.any() && args.swapped_mn) {
+    dyn_guard.emplace(at::cuda::tunable::DynamicDimsMask(
+        /*M=*/raw_dyn_mask.n(),
+        /*N=*/raw_dyn_mask.m(),
+        /*K=*/raw_dyn_mask.k(),
+        /*BATCH=*/raw_dyn_mask.batch()));
+  }
   at::cuda::blas::gemm<scalar_t, res_scalar_t>(
     args.transa,
     args.transb,
@@ -554,6 +653,20 @@ const Tensor& baddbmm_out_cuda_impl(const Tensor& result, const Tensor& self, co
 
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!result_->is_conj());
   bool is_float_output_with_half_input = (batch1.scalar_type() == at::ScalarType::Half || batch1.scalar_type() == at::ScalarType::BFloat16) && result.scalar_type() == at::ScalarType::Float;
+
+  // Re-push the mask remapped to BLAS frame so (b)gemm_tunable stamps it; the
+  // batched dispatch transposes the result (M<->N) and carries no swapped_mn
+  // flag. Only when a dynamic mask is active AND the result is transposed, so
+  // the common path is untouched. See GetCurrentDynamicDimsMask() in Tunable.h.
+  const auto raw_dyn_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+  std::optional<at::cuda::tunable::TunableDynamicDimsGuard> baddbmm_dyn_guard;
+  if (raw_dyn_mask.any() && transpose_result) {
+    baddbmm_dyn_guard.emplace(at::cuda::tunable::DynamicDimsMask(
+        /*M=*/raw_dyn_mask.n(),
+        /*N=*/raw_dyn_mask.m(),
+        /*K=*/raw_dyn_mask.k(),
+        /*BATCH=*/raw_dyn_mask.batch()));
+  }
 
   if (is_float_output_with_half_input) {
     AT_DISPATCH_REDUCED_FLOATING_TYPES(batch1.scalar_type(), "baddbmm_cuda", [&] {

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -254,7 +254,7 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
   );
 }
 
-Tensor&
+bool
 _tunable_scaled_gemm_rocm(
           cublasCommonArgs& args,
           const Tensor& mat1, const Tensor& mat2,
@@ -265,19 +265,20 @@ _tunable_scaled_gemm_rocm(
           const at::ScalarType out_dtype,
           Tensor& out) {
 #ifdef USE_ROCM
+  bool dispatched = false;
 #define TUNABLE_DISPATCH(BLASOP_A, BLASOP_B)                            \
       if (mat1.scalar_type() == ScalarType::Float8_e4m3fnuz) {        \
         if (mat2.scalar_type() == ScalarType::Float8_e4m3fnuz) {      \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fnuz, at::Float8_e4m3fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2fnuz) { \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fnuz, at::Float8_e5m2fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }                                                               \
       else if (mat1.scalar_type() == ScalarType::Float8_e5m2fnuz) {   \
@@ -285,13 +286,13 @@ _tunable_scaled_gemm_rocm(
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2fnuz, at::Float8_e4m3fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2fnuz) { \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2fnuz, at::Float8_e5m2fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }                                                               \
       else if (mat1.scalar_type() == ScalarType::Float8_e4m3fn) {     \
@@ -299,13 +300,13 @@ _tunable_scaled_gemm_rocm(
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fn, at::Float8_e4m3fn, scalar_t,         \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2) {     \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fn, at::Float8_e5m2, scalar_t,           \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }                                                               \
       else if (mat1.scalar_type() == ScalarType::Float8_e5m2) {       \
@@ -313,19 +314,35 @@ _tunable_scaled_gemm_rocm(
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2, at::Float8_e4m3fn, scalar_t,           \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2) {     \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2, at::Float8_e5m2, scalar_t,             \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }
   AT_DISPATCH_V2(out_dtype, "_tunable_scaled_gemm", AT_WRAP([&] {
     bool transa_ = ((args.transa != 'n') && (args.transa != 'N'));
     bool transb_ = ((args.transb != 'n') && (args.transb != 'N'));
     at::cuda::tunable::ScaledGemmParams<scalar_t> params;
+    // Stamp per-call dynamic-dims mask before invoking the TunableOp,
+    // remapping to BLAS frame on swapped_mn (same logic as
+    // launchTunableGemmAndBias in Blas.cpp). See GetCurrentDynamicDimsMask()
+    // in ATen/cuda/tunable/Tunable.h for the frame and remap rationale.
+    {
+      auto raw_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+      if (args.swapped_mn) {
+        params.dynamic_dims_mask = at::cuda::tunable::DynamicDimsMask(
+            /*M=*/raw_mask.n(),
+            /*N=*/raw_mask.m(),
+            /*K=*/raw_mask.k(),
+            /*BATCH=*/raw_mask.batch());
+      } else {
+        params.dynamic_dims_mask = raw_mask;
+      }
+    }
     params.transa = args.transa;
     params.transb = args.transb;
     params.m = args.m;
@@ -352,6 +369,29 @@ _tunable_scaled_gemm_rocm(
     params.ldc = args.result_ld;
     params.c_dtype = out_dtype;
     params.use_fast_accum = use_fast_accum;
+    // Gate dispatch to match the addmm path (launchTunableGemmAndBias): on a
+    // concrete miss with tuning disabled, scan persisted wildcard entries;
+    // on a total miss return false so the caller (_scaled_gemm) re-dispatches
+    // the non-tunable at::cuda::blas::scaled_gemm instead of the (potentially
+    // crashing) Default kernel.
+    auto try_scaled_dispatch = [&](auto& scaledgemm) -> bool {
+      auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+      auto& mgr = tuning_ctx->GetTuningResultsManager();
+      auto op_sig = scaledgemm.Signature();
+      auto concrete_sig = params.Signature();
+      auto result = mgr.Lookup(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()
+          && !tuning_ctx->IsTuningEnabled()) {
+        result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+        if (result == at::cuda::tunable::ResultEntry::Null()) {
+          return false;
+        }
+      }
+      // Pass the already-computed concrete_sig so operator() does not
+      // recompute params.Signature() on the dispatch fast path.
+      scaledgemm(&params, concrete_sig);
+      return true;
+    };
     if (transa_ && transb_) {
       TUNABLE_DISPATCH(at::cuda::tunable::BlasOp::T, at::cuda::tunable::BlasOp::T)
     }
@@ -370,7 +410,7 @@ _tunable_scaled_gemm_rocm(
   }),
   kHalf, kBFloat16, AT_EXPAND(AT_FLOAT8_TYPES), AT_EXPAND(AT_FLOATING_TYPES));
 #undef TUNABLE_DISPATCH
-  return out;
+  return dispatched;
 #else
   TORCH_CHECK_NOT_IMPLEMENTED(false, "_scaled_gemm_rocm only callable on ROCM devices");
 #endif
@@ -409,18 +449,23 @@ _scaled_gemm(
   bool tunable_op_enabled = false;
 #endif
   if (tunable_op_enabled) {
-      // Only available on ROCM
-      return _tunable_scaled_gemm_rocm(
-          args,
-          mat1, mat2,
-          scale_a, scale_b,
-          scaling_choice_a, scaling_choice_b,
-          bias,
-          use_fast_accum,
-          out_dtype_,
-          out);
+      // Only available on ROCM. Returns false when TunableOp is enabled but
+      // there is no tuned entry (concrete or wildcard) and tuning is disabled;
+      // in that case fall through to the non-tunable scaled_gemm below rather
+      // than invoking the Default kernel. Matches the addmm fallback in
+      // launchGemmAndBiasCublasLt.
+      if (_tunable_scaled_gemm_rocm(
+              args,
+              mat1, mat2,
+              scale_a, scale_b,
+              scaling_choice_a, scaling_choice_b,
+              bias,
+              use_fast_accum,
+              out_dtype_,
+              out)) {
+        return out;
+      }
   }
-  else
   {
       at::cuda::blas::scaled_gemm(
           args.transa,

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -230,7 +230,7 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
   );
 }
 
-Tensor&
+bool
 _tunable_scaled_gemm_rocm(
           cublasCommonArgs& args,
           const Tensor& mat1, const Tensor& mat2,
@@ -241,19 +241,20 @@ _tunable_scaled_gemm_rocm(
           const at::ScalarType out_dtype,
           Tensor& out) {
 #ifdef USE_ROCM
+  bool dispatched = false;
 #define TUNABLE_DISPATCH(BLASOP_A, BLASOP_B)                            \
       if (mat1.scalar_type() == ScalarType::Float8_e4m3fnuz) {        \
         if (mat2.scalar_type() == ScalarType::Float8_e4m3fnuz) {      \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fnuz, at::Float8_e4m3fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2fnuz) { \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fnuz, at::Float8_e5m2fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }                                                               \
       else if (mat1.scalar_type() == ScalarType::Float8_e5m2fnuz) {   \
@@ -261,13 +262,13 @@ _tunable_scaled_gemm_rocm(
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2fnuz, at::Float8_e4m3fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2fnuz) { \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2fnuz, at::Float8_e5m2fnuz, scalar_t,     \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }                                                               \
       else if (mat1.scalar_type() == ScalarType::Float8_e4m3fn) {     \
@@ -275,13 +276,13 @@ _tunable_scaled_gemm_rocm(
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fn, at::Float8_e4m3fn, scalar_t,         \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2) {     \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e4m3fn, at::Float8_e5m2, scalar_t,           \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }                                                               \
       else if (mat1.scalar_type() == ScalarType::Float8_e5m2) {       \
@@ -289,19 +290,35 @@ _tunable_scaled_gemm_rocm(
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2, at::Float8_e4m3fn, scalar_t,           \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
         else if (mat2.scalar_type() == ScalarType::Float8_e5m2) {     \
           static at::cuda::tunable::ScaledGemmTunableOp<              \
               at::Float8_e5m2, at::Float8_e5m2, scalar_t,             \
               BLASOP_A, BLASOP_B> scaledgemm{};                       \
-          scaledgemm(&params);                                        \
+          dispatched = try_scaled_dispatch(scaledgemm);                                        \
         }                                                             \
       }
   AT_DISPATCH_V2(out_dtype, "_tunable_scaled_gemm", AT_WRAP([&] {
     bool transa_ = ((args.transa != 'n') && (args.transa != 'N'));
     bool transb_ = ((args.transb != 'n') && (args.transb != 'N'));
     at::cuda::tunable::ScaledGemmParams<scalar_t> params;
+    // Stamp per-call dynamic-dims mask before invoking the TunableOp,
+    // remapping to BLAS frame on swapped_mn (same logic as
+    // launchTunableGemmAndBias in Blas.cpp). See GetCurrentDynamicDimsMask()
+    // in ATen/cuda/tunable/Tunable.h for the frame and remap rationale.
+    {
+      auto raw_mask = at::cuda::tunable::GetCurrentDynamicDimsMask();
+      if (args.swapped_mn) {
+        params.dynamic_dims_mask = at::cuda::tunable::DynamicDimsMask(
+            /*M=*/raw_mask.n(),
+            /*N=*/raw_mask.m(),
+            /*K=*/raw_mask.k(),
+            /*BATCH=*/raw_mask.batch());
+      } else {
+        params.dynamic_dims_mask = raw_mask;
+      }
+    }
     params.transa = args.transa;
     params.transb = args.transb;
     params.m = args.m;
@@ -328,6 +345,29 @@ _tunable_scaled_gemm_rocm(
     params.ldc = args.result_ld;
     params.c_dtype = out_dtype;
     params.use_fast_accum = use_fast_accum;
+    // Gate dispatch to match the addmm path (launchTunableGemmAndBias): on a
+    // concrete miss with tuning disabled, scan persisted wildcard entries;
+    // on a total miss return false so the caller (_scaled_gemm) re-dispatches
+    // the non-tunable at::cuda::blas::scaled_gemm instead of the (potentially
+    // crashing) Default kernel.
+    auto try_scaled_dispatch = [&](auto& scaledgemm) -> bool {
+      auto* tuning_ctx = at::cuda::tunable::getTuningContext();
+      auto& mgr = tuning_ctx->GetTuningResultsManager();
+      auto op_sig = scaledgemm.Signature();
+      auto concrete_sig = params.Signature();
+      auto result = mgr.Lookup(op_sig, concrete_sig);
+      if (result == at::cuda::tunable::ResultEntry::Null()
+          && !tuning_ctx->IsTuningEnabled()) {
+        result = mgr.LookupWildcardFallback(op_sig, concrete_sig);
+        if (result == at::cuda::tunable::ResultEntry::Null()) {
+          return false;
+        }
+      }
+      // Pass the already-computed concrete_sig so operator() does not
+      // recompute params.Signature() on the dispatch fast path.
+      scaledgemm(&params, concrete_sig);
+      return true;
+    };
     if (transa_ && transb_) {
       TUNABLE_DISPATCH(at::cuda::tunable::BlasOp::T, at::cuda::tunable::BlasOp::T)
     }
@@ -346,7 +386,7 @@ _tunable_scaled_gemm_rocm(
   }),
   kHalf, kBFloat16, AT_EXPAND(AT_FLOAT8_TYPES), AT_EXPAND(AT_FLOATING_TYPES));
 #undef TUNABLE_DISPATCH
-  return out;
+  return dispatched;
 #else
   TORCH_CHECK_NOT_IMPLEMENTED(false, "_scaled_gemm_rocm only callable on ROCM devices");
 #endif
@@ -385,18 +425,23 @@ _scaled_gemm(
   bool tunable_op_enabled = false;
 #endif
   if (tunable_op_enabled) {
-      // Only available on ROCM
-      return _tunable_scaled_gemm_rocm(
-          args,
-          mat1, mat2,
-          scale_a, scale_b,
-          scaling_choice_a, scaling_choice_b,
-          bias,
-          use_fast_accum,
-          out_dtype_,
-          out);
+      // Only available on ROCM. Returns false when TunableOp is enabled but
+      // there is no tuned entry (concrete or wildcard) and tuning is disabled;
+      // in that case fall through to the non-tunable scaled_gemm below rather
+      // than invoking the Default kernel. Matches the addmm fallback in
+      // launchGemmAndBiasCublasLt.
+      if (_tunable_scaled_gemm_rocm(
+              args,
+              mat1, mat2,
+              scale_a, scale_b,
+              scaling_choice_a, scaling_choice_b,
+              bias,
+              use_fast_accum,
+              out_dtype_,
+              out)) {
+        return out;
+      }
   }
-  else
   {
       at::cuda::blas::scaled_gemm(
           args.transa,

--- a/aten/src/ATen/native/cuda/cuBlasCommonArgs.h
+++ b/aten/src/ATen/native/cuda/cuBlasCommonArgs.h
@@ -142,6 +142,13 @@ struct cublasCommonArgs {
     transa = transpose_a ? mata->is_conj() ? 'c' : 't' : 'n';
     transb = transpose_b ? matb->is_conj() ? 'c' : 't' : 'n';
 
+    // Record whether PyTorch's BLAS dispatch swapped inductor's
+    // (M, N) -> (n, m) when computing C^T = B^T @ A^T in column-major
+    // cuBLAS. Consumers that need to translate an inductor-frame
+    // dynamic-dims mask (e.g. TunableOp wildcard signatures) into the
+    // BLAS frame read this flag and swap the M and N bits when set.
+    swapped_mn = transpose_result;
+
     // cuBLAS expects unpacked values of `k`, `lda` and `ldb`, adjust for 4x2 packing
     // if the gemm operands are in packed float4
     if (mat1.dtype() == at::kFloat4_e2m1fn_x2 && mat2.dtype() == at::kFloat4_e2m1fn_x2) {
@@ -156,6 +163,11 @@ struct cublasCommonArgs {
   int64_t m, n, k;
   int64_t lda, ldb, result_ld;
   c10::MaybeOwned<Tensor> mata, matb, result;
+  // True iff PyTorch's BLAS dispatch swapped inductor's (M, N) into
+  // BLAS's (n, m). Used by TunableOp consumers to translate a dynamic
+  // -dims mask captured in inductor frame into the BLAS frame stamped
+  // onto `params.dynamic_dims_mask`.
+  bool swapped_mn = false;
 
   // Scale members
   void* scale_mata_ptr = nullptr;

--- a/docs/source/cuda.tunable.md
+++ b/docs/source/cuda.tunable.md
@@ -99,3 +99,15 @@
 ```{eval-rst}
 .. autofunction:: set_numerical_check_tolerances
 ```
+
+```{eval-rst}
+.. autofunction:: push_dynamic_dims_mask
+```
+
+```{eval-rst}
+.. autofunction:: pop_dynamic_dims_mask
+```
+
+```{eval-rst}
+.. autofunction:: dynamic_dims_mask
+```

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import logging
 import typing
 from typing import Any, TYPE_CHECKING
 
@@ -32,6 +33,9 @@ from .scheduler import BaseSchedulerNode, Scheduler, WhyNoFuse
 from .select_algorithm import ExternKernelChoice
 from .utils import _use_autotune_backend
 from .virtualized import V
+
+
+log = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
@@ -392,7 +396,18 @@ class InductorChoices:
                 if hasattr(ktc, "_choice"):
                     del ktc._choice
         # Third pass: Convert to ChoiceCaller objects
-        return [ktc.choice for ktc in adjusted_choices if ktc.choice is not None]
+        callers = [ktc.choice for ktc in adjusted_choices if ktc.choice is not None]
+
+        # Only ExternKernelCaller (aten) reads this mask to drive TunableOp
+        # wildcard persistence; Triton/CUTLASS callers ignore it.
+        from torch._inductor.select_algorithm import ExternKernelCaller
+
+        mask = kernel_inputs.dynamic_dim_mask(op_name)
+        for caller in callers:
+            if isinstance(caller, ExternKernelCaller):
+                caller.tunable_dyn_dims_mask = mask
+
+        return callers
 
     def triton_kernel_kwargs(
         self,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2712,9 +2712,17 @@ class xpu(cutlass):
 
 
 class rocm:
+    """Configuration for Inductor's ROCm (AMD GPU) backend."""
+
     # Offload arch list for device code compilation, e.g. ["gfx90a", "gfx942"].
     # If empty, the `native` arch is used
     arch: list[str] = []
+
+    # When True, inductor autotune pushes a per-op dynamic-dims mask for
+    # symbolic GEMM dims so TunableOp persists wildcard kernel-map entries that
+    # runtime concrete-miss lookups can reuse. False stops producing new
+    # wildcard entries; existing rows in a loaded file still satisfy lookups.
+    autotune_tunableop_dynamic_dims_wildcard: bool = False
 
     # Enable the CK backend for CDNA2 and CDNA3 only (for now)
     # Processor name reference: https://llvm.org/docs/AMDGPUUsage.html#processors

--- a/torch/_inductor/kernel_inputs.py
+++ b/torch/_inductor/kernel_inputs.py
@@ -5,7 +5,8 @@ from typing import Any, TYPE_CHECKING
 
 import torch
 import torch._inductor.config
-from torch._inductor import ir
+from torch._inductor import config as inductor_config, ir
+from torch._inductor.utils import has_free_symbols
 from torch._inductor.virtualized import V
 
 from .ir import FixedLayout, FlexibleLayout, Layout
@@ -115,6 +116,96 @@ class KernelInputs(ABC):
             A tuple of shape tuples for each input node
         """
         return tuple(node.get_size() for node in self._input_nodes)
+
+    def _mnk_operand_shapes(
+        self,
+    ) -> tuple[tuple[Any, ...], tuple[Any, ...]] | None:
+        """
+        Return the (mat1_shape, mat2_shape) used for GEMM dim-dynamism
+        analysis in `dynamic_dim_mask`.
+
+        The base implementation assumes the GEMM operands are the trailing
+        two inputs. Subclasses that track explicit operand positions (see
+        MMKernelInputs.mat1_idx / mat2_idx) override this so the mask is
+        derived from the real operands -- which matters for scaled GEMM,
+        where the trailing inputs are scale/bias tensors.
+
+        Returns None when there are fewer than two inputs.
+        """
+        shapes = self.shapes_symbolic()
+        if len(shapes) < 2:
+            return None
+        return shapes[-2], shapes[-1]
+
+    def dynamic_dim_mask(self, op_name: str) -> tuple[bool, bool, bool, bool]:
+        """
+        Derive a per-call (dyn_m, dyn_n, dyn_k, dyn_batch) mask describing
+        which logical GEMM dims are dynamic (SymInt) for this op invocation.
+
+        The autotune path pushes this mask so TunableOp persists wildcard keys
+        that runtime lookup can reuse.
+
+        Operands are selected via `_mnk_operand_shapes()` so subclasses that
+        track explicit operand positions (see MMKernelInputs) read the true
+        mat1/mat2 shapes rather than the trailing two inputs.
+
+        Mask derivation rules:
+        - mm / addmm / scaled_mm:
+            (M, K) = mat1.shape, (K, N) = mat2.shape
+            dyn_m = is_symbolic(M); dyn_k = is_symbolic(K); dyn_n = is_symbolic(N);
+            dyn_batch = False
+        - bmm / baddbmm:
+            (B, M, K) = mat1.shape, (B, K, N) = mat2.shape
+            dyn_batch = is_symbolic(B); others as above
+
+        For unrecognized op_names we return all-zero (no wildcarding) so the
+        caller falls back to the legacy concrete-only behavior.
+        """
+        # Feature disabled: persist concrete signatures for new tuning entries.
+        if not inductor_config.rocm.autotune_tunableop_dynamic_dims_wildcard:
+            return (False, False, False, False)
+
+        # IR dimensions may be symbolic sympy expressions.
+        def _dyn(d: Any) -> bool:
+            return has_free_symbols((d,))
+
+        # Operands come from the subclass-aware selector so that kernels
+        # whose GEMM operands are not the trailing two inputs (e.g. scaled
+        # GEMM, where the trailing inputs are scale/bias tensors) still read
+        # the true mat1/mat2 shapes.
+        operand_shapes = self._mnk_operand_shapes()
+        if operand_shapes is None:
+            return (False, False, False, False)
+        mat1_shape, mat2_shape = operand_shapes
+
+        # bmm / baddbmm: both operands carry a leading batch dim.
+        if (
+            op_name in ("bmm", "baddbmm")
+            and len(mat1_shape) >= 3
+            and len(mat2_shape) >= 3
+        ):
+            b1, m, k1 = mat1_shape[-3], mat1_shape[-2], mat1_shape[-1]
+            b2, k2, n = mat2_shape[-3], mat2_shape[-2], mat2_shape[-1]
+            dyn_batch = _dyn(b1) or _dyn(b2)
+            dyn_m = _dyn(m)
+            dyn_k = _dyn(k1) or _dyn(k2)
+            dyn_n = _dyn(n)
+            return (dyn_m, dyn_n, dyn_k, dyn_batch)
+
+        # mm / addmm / scaled_mm: 2D matmul, no batch axis.
+        if (
+            op_name in ("mm", "addmm", "scaled_mm")
+            and len(mat1_shape) >= 2
+            and len(mat2_shape) >= 2
+        ):
+            m, k1 = mat1_shape[-2], mat1_shape[-1]
+            k2, n = mat2_shape[-2], mat2_shape[-1]
+            dyn_m = _dyn(m)
+            dyn_k = _dyn(k1) or _dyn(k2)
+            dyn_n = _dyn(n)
+            return (dyn_m, dyn_n, dyn_k, False)
+
+        return (False, False, False, False)
 
     def shapes_hinted(self) -> tuple[tuple[int, ...], ...]:
         """
@@ -312,6 +403,22 @@ class MMKernelInputs(KernelInputs):
         """
         nodes = self.nodes()
         return nodes[self._mat1_idx], nodes[self._mat2_idx]
+
+    def _mnk_operand_shapes(
+        self,
+    ) -> tuple[tuple[Any, ...], tuple[Any, ...]] | None:
+        """
+        Select the GEMM operand shapes using the explicit mat1_idx / mat2_idx
+        positions instead of the trailing two inputs.
+
+        This is required for callsites where the operands are not the last two
+        inputs -- e.g. scaled GEMM, whose inputs are
+        [mat_a, mat_b, scale_a, scale_b, (bias)] with mat1_idx=0, mat2_idx=1.
+        Reading the trailing inputs there would derive the mask from the
+        scale/bias tensors rather than the true M/N/K operands.
+        """
+        shapes = self.shapes_symbolic()
+        return shapes[self._mat1_idx], shapes[self._mat2_idx]
 
     def mnk_hinted(self) -> tuple[int, int, int]:
         """

--- a/torch/_inductor/kernel_inputs.py
+++ b/torch/_inductor/kernel_inputs.py
@@ -5,7 +5,8 @@ from typing import Any, TYPE_CHECKING
 
 import torch
 import torch._inductor.config
-from torch._inductor import ir
+from torch._inductor import config as inductor_config, ir
+from torch._inductor.utils import has_free_symbols
 from torch._inductor.virtualized import V
 
 from .ir import FixedLayout, FlexibleLayout, Layout
@@ -23,6 +24,12 @@ class KernelInputs(ABC):
     This class takes in a tuple of input nodes and provides methods to access
     information about these nodes, such as their device type and device.
     """
+
+    # GEMM operand positions within input_nodes, used by dynamic_dim_mask.
+    # Defaults select the trailing two inputs; MMKernelInputs overrides them
+    # (scaled GEMM trails scale/bias tensors, so operands are not the last two).
+    _mat1_idx: int = -2
+    _mat2_idx: int = -1
 
     def __init__(
         self,
@@ -115,6 +122,58 @@ class KernelInputs(ABC):
             A tuple of shape tuples for each input node
         """
         return tuple(node.get_size() for node in self._input_nodes)
+
+    def dynamic_dim_mask(self, op_name: str) -> tuple[bool, bool, bool, bool]:
+        """
+        Derive a per-call (dyn_m, dyn_n, dyn_k, dyn_batch) mask marking which
+        GEMM dims are symbolic (SymInt) for this op. The autotune path pushes
+        this mask so TunableOp persists wildcard keys that runtime lookup reuses.
+        Unrecognized ops (or non-symbolic shapes) yield all-False, i.e. the
+        legacy concrete-only behavior.
+        """
+        # Feature disabled: persist concrete signatures for new tuning entries.
+        if not inductor_config.rocm.autotune_tunableop_dynamic_dims_wildcard:
+            return (False, False, False, False)
+
+        # IR dimensions may be symbolic sympy expressions.
+        def _dyn(d: Any) -> bool:
+            return has_free_symbols((d,))
+
+        # mat1/mat2 live at explicit operand positions, not necessarily the
+        # trailing two inputs (scaled GEMM trails scale/bias tensors).
+        shapes = self.shapes_symbolic()
+        if len(shapes) < 2:
+            return (False, False, False, False)
+        mat1_shape, mat2_shape = shapes[self._mat1_idx], shapes[self._mat2_idx]
+
+        # bmm / baddbmm: both operands carry a leading batch dim.
+        if (
+            op_name in ("bmm", "baddbmm")
+            and len(mat1_shape) >= 3
+            and len(mat2_shape) >= 3
+        ):
+            b1, m, k1 = mat1_shape[-3], mat1_shape[-2], mat1_shape[-1]
+            b2, k2, n = mat2_shape[-3], mat2_shape[-2], mat2_shape[-1]
+            dyn_batch = _dyn(b1) or _dyn(b2)
+            dyn_m = _dyn(m)
+            dyn_k = _dyn(k1) or _dyn(k2)
+            dyn_n = _dyn(n)
+            return (dyn_m, dyn_n, dyn_k, dyn_batch)
+
+        # mm / addmm / scaled_mm: 2D matmul, no batch axis.
+        if (
+            op_name in ("mm", "addmm", "scaled_mm")
+            and len(mat1_shape) >= 2
+            and len(mat2_shape) >= 2
+        ):
+            m, k1 = mat1_shape[-2], mat1_shape[-1]
+            k2, n = mat2_shape[-2], mat2_shape[-1]
+            dyn_m = _dyn(m)
+            dyn_k = _dyn(k1) or _dyn(k2)
+            dyn_n = _dyn(n)
+            return (dyn_m, dyn_n, dyn_k, False)
+
+        return (False, False, False, False)
 
     def shapes_hinted(self) -> tuple[tuple[int, ...], ...]:
         """

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3473,6 +3473,9 @@ class ExternKernelCaller(ChoiceCaller):
         self.has_out_variant = has_out_variant
         self.gm = choice.gm
         self.bmreq: BenchmarkRequest | None = None
+        # Per-op dynamic-dims mask stamped by choices.py to drive TunableOp
+        # wildcard persistence during autotune; only extern (aten) callers use it.
+        self.tunable_dyn_dims_mask: tuple[bool, bool, bool, bool] | None = None
 
         from torch._inductor.autotune_process import (
             ExternKernelBenchmarkRequest,
@@ -3528,6 +3531,14 @@ class ExternKernelCaller(ChoiceCaller):
             raise AssertionError("self.bmreq must not be None")
         # pyrefly: ignore[missing-attribute]
         self.bmreq.benchmark_with_cudagraphs = self._benchmark_with_cudagraphs
+        mask = self.tunable_dyn_dims_mask
+        # TunableOp only exists in CUDA/ROCm builds; gate on the output device
+        # so a non-empty mask on a CPU op does not hit a missing _C binding.
+        if mask is not None and any(mask) and out.is_cuda:
+            with torch.cuda.tunable.dynamic_dims_mask(
+                M=mask[0], N=mask[1], K=mask[2], BATCH=mask[3]
+            ):
+                return self.bmreq.benchmark(*args, out=out)
         return self.bmreq.benchmark(*args, out=out)
 
     def benchmark_collective(self, *args, out):

--- a/torch/_inductor/tests/test_dynamic_tunable_ops.py
+++ b/torch/_inductor/tests/test_dynamic_tunable_ops.py
@@ -78,8 +78,12 @@ import tempfile
 import unittest
 from typing import cast, TypeAlias
 
+import sympy
+
 import torch
 import torch.cuda.tunable
+from torch._inductor import config as inductor_config
+from torch._inductor.kernel_inputs import MMKernelInputs
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -891,6 +895,904 @@ class DynamicTunableOpsTest(TestCase):
             rtol=1e-2,
             msg="baddbmm both-miss fallback output should match reference",
         )
+
+
+# ─── Layout coverage: verify swap remap across NN/NT/TN/TT ────────────
+# PyTorch's BLAS dispatch picks `transa, transb` and the
+# `transpose_result` decision based on operand layouts. The
+# `cublasCommonArgs::swapped_mn` flag tracks `transpose_result` so the
+# `launchTunableGemmAndBias` mask remap fires whenever the dispatch
+# swaps inductor (M, N) -> BLAS (n, m). These tests force each
+# (transa, transb) combination by transposing input tensors and
+# verify the wildcard-tune -> wildcard-fallback round trip works
+# correctly for every layout.
+
+
+class LayoutCoverageWildcardTest(TestCase):
+    """Exercise the dynamic-mask + wildcard-fallback contract for each
+    of the four (transa, transb) layout combinations, with each of the
+    M/N/K dims taken dynamic in turn. Each test tunes at one shape, then
+    queries at a shape that differs only in the dynamic dim with no
+    runtime mask, and asserts: a wildcard entry was persisted, its
+    leading-dim wildcarding is self-consistent with the transpose flags
+    (white-box), no concrete entry is added at runtime, and output
+    matches a tunable-disabled reference.
+
+    The K-dynamic cases are what give lda coverage: for torch.mm the
+    row-major dispatch swaps inductor (M, N) into BLAS (n, m), so an
+    M-dynamic call lands the dynamic bit on BLAS-n (never lda). K is not
+    swapped, so a K-dynamic call keeps k dynamic in the BLAS frame and
+    forces lda to be wildcarded exactly when transa == 'T'."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("cuda not available")
+        cls._tmpdir = tempfile.mkdtemp(prefix="layout_coverage_test_")
+        cls._tmp_results_path = os.path.join(cls._tmpdir, "tunable_results.csv")
+        torch.cuda.tunable.set_filename(cls._tmp_results_path, False)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls._tmpdir:
+            import shutil
+
+            shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def setUp(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def tearDown(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    @staticmethod
+    def _make_layout(
+        m: int, k: int, n: int, transa: bool, transb: bool, seed: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build (mat1, mat2) for `mm(mat1, mat2)` so the BLAS dispatch
+        picks the requested (transa, transb) layout. We synthesize the
+        layout by allocating the underlying storage in the transposed
+        shape and then transposing the view; this is the canonical way
+        to make a tensor "non-contiguous" along a particular axis without
+        triggering a contiguous() copy."""
+        torch.manual_seed(seed)
+        if not transa:
+            mat1 = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+        else:
+            mat1 = torch.randn(k, m, dtype=DTYPE, device=DEVICE).t()
+        if not transb:
+            mat2 = torch.randn(k, n, dtype=DTYPE, device=DEVICE)
+        else:
+            mat2 = torch.randn(n, k, dtype=DTYPE, device=DEVICE).t()
+        return mat1, mat2
+
+    def _round_trip_for_layout(
+        self, transa: bool, transb: bool, seed_offset: int, dynamic: str = "M"
+    ) -> None:
+        """Run the tune-then-fallback round trip for one layout, taking the
+        `dynamic` dim (one of "M"/"N"/"K") as symbolic. Tuning and runtime
+        shapes differ only in that dim."""
+        base_m, n, k = 41 + seed_offset, 257, 251
+        delta = 12
+        tuned = {"m": base_m, "n": n, "k": k}
+        test = {"m": base_m, "n": n, "k": k}
+        test[dynamic.lower()] += delta
+
+        mat1_t, mat2_t = self._make_layout(
+            tuned["m"], tuned["k"], tuned["n"], transa, transb, seed=100 + seed_offset
+        )
+        mat1_x, mat2_x = self._make_layout(
+            test["m"], test["k"], test["n"], transa, transb, seed=200 + seed_offset
+        )
+
+        # Reference (tunable disabled).
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.mm(mat1_x, mat2_x)
+
+        # Phase A: tune at the tuned shape with the chosen dim dynamic ->
+        # wildcard persisted.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(**{dynamic: True}):
+            torch.mm(mat1_t, mat2_t)
+        # Op-wide `_has_wildcard_entry` (not the shape-specific
+        # `_has_wildcard_with_dims` used elsewhere) is deliberate here: every
+        # layout variant in this class shares the same (n, k), so a
+        # shape-specific check could not tell them apart. The per-entry
+        # `_assert_ld_wildcarding_consistent` below is the real gate.
+        self.assertTrue(
+            _has_wildcard_entry("GemmTunableOp"),
+            f"expected GemmTunableOp wildcard entry after tuning "
+            f"layout (transa={transa}, transb={transb}, dynamic={dynamic})",
+        )
+        # White-box: the persisted wildcard must wildcard the correct
+        # leading dims for its transpose flags. This is what catches an
+        # inverted lda/ldb/ldc -> dim mapping (e.g. a broken UsesMForLda),
+        # which _has_wildcard_entry alone silently tolerates because a
+        # mis-wildcarded key still contains a '*'.
+        _assert_ld_wildcarding_consistent(self, "GemmTunableOp")
+
+        # Phase C: runtime, no mask, shape differs only in the dynamic dim
+        # -> expected to dispatch via the wildcard fallback. Gated on the
+        # observable proxies (no new concrete entry, output matches the
+        # tunable-disabled reference); the persistence-side white-box check
+        # above is the real gate on the wildcarding logic.
+        before = len(_get_tunable_results())
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.mm(mat1_x, mat2_x)
+        after = len(_get_tunable_results())
+        self.assertEqual(
+            before,
+            after,
+            f"layout (transa={transa}, transb={transb}, dynamic={dynamic}): "
+            f"runtime dispatch with tuning disabled must not add a new entry",
+        )
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg=f"layout (transa={transa}, transb={transb}, dynamic={dynamic}): "
+            f"wildcard-fallback dispatch output must match tunable-disabled "
+            f"reference",
+        )
+
+    def test_layout_NN(self) -> None:
+        """No transpose on either operand."""
+        self._round_trip_for_layout(transa=False, transb=False, seed_offset=0)
+
+    def test_layout_NT(self) -> None:
+        """mat1 contiguous, mat2 transposed."""
+        self._round_trip_for_layout(transa=False, transb=True, seed_offset=4)
+
+    def test_layout_TN(self) -> None:
+        """mat1 transposed, mat2 contiguous."""
+        self._round_trip_for_layout(transa=True, transb=False, seed_offset=8)
+
+    def test_layout_TT(self) -> None:
+        """Both operands transposed."""
+        self._round_trip_for_layout(transa=True, transb=True, seed_offset=12)
+
+    def test_layout_NN_dynamic_k(self) -> None:
+        """K dynamic (not swapped by the mm remap) exercises lda/ldb."""
+        self._round_trip_for_layout(
+            transa=False, transb=False, seed_offset=16, dynamic="K"
+        )
+
+    def test_layout_NT_dynamic_k(self) -> None:
+        self._round_trip_for_layout(
+            transa=False, transb=True, seed_offset=20, dynamic="K"
+        )
+
+    def test_layout_TN_dynamic_k(self) -> None:
+        """transa == 'T' + K dynamic forces lda to be wildcarded; the
+        inverted UsesMForLda leaves it concrete and this test fails."""
+        self._round_trip_for_layout(
+            transa=True, transb=False, seed_offset=24, dynamic="K"
+        )
+
+    def test_layout_TT_dynamic_k(self) -> None:
+        self._round_trip_for_layout(
+            transa=True, transb=True, seed_offset=28, dynamic="K"
+        )
+
+    def test_layout_NN_dynamic_n(self) -> None:
+        """N dynamic. For torch.mm the row-major dispatch swaps inductor
+        (M, N) into BLAS (n, m), so an N-dynamic call lands the dynamic bit
+        on BLAS-m and forces ldc (and lda for transa == 'N') to wildcard."""
+        self._round_trip_for_layout(
+            transa=False, transb=False, seed_offset=32, dynamic="N"
+        )
+
+    def test_layout_NT_dynamic_n(self) -> None:
+        self._round_trip_for_layout(
+            transa=False, transb=True, seed_offset=36, dynamic="N"
+        )
+
+    def test_layout_TN_dynamic_n(self) -> None:
+        self._round_trip_for_layout(
+            transa=True, transb=False, seed_offset=40, dynamic="N"
+        )
+
+    def test_layout_TT_dynamic_n(self) -> None:
+        self._round_trip_for_layout(
+            transa=True, transb=True, seed_offset=44, dynamic="N"
+        )
+
+
+# --- Layout coverage for the batched path (bmm / baddbmm) ---
+# Why mm layout coverage is not duplicated for every op:
+#   - addmm: torch.mm and torch.addmm both route through
+#     addmm_out_cuda_impl (mm calls it with beta=0, alpha=1), so the mm
+#     layout tests above already exercise addmm's transpose-flag derivation
+#     (cublasCommonArgs), the swapped_mn mask remap (launchTunableGemmAndBias
+#     / launchGemmCublas) and the ShouldWildcardLda/Ldb/Ldc logic verbatim.
+#     No separate addmm layout tests are needed.
+#   - _scaled_mm: reuses the SAME cublasCommonArgs transpose/swapped_mn
+#     derivation and the SAME ShouldWildcardLd* logic (ScaledGemmParams).
+#     Only the mask-remap stamping is a distinct function
+#     (_tunable_scaled_gemm_rocm, ROCm-only) that reads the same swapped_mn
+#     flag, and it is already exercised by the M-dynamic round trip in
+#     ScaledGemmTunableOpFP8Test. No separate scaled layout matrix is added.
+#   - bmm / baddbmm: DIFFERENT code path. baddbmm_out_cuda_impl does NOT
+#     build a cublasCommonArgs; it derives transa/transb from its own
+#     prepare_batch_matrix_for_cublas plus a local transpose_result, and
+#     performs the M<->N mask remap itself via a TunableDynamicDimsGuard
+#     (not the shared swapped_mn field). Only the leading-dim wildcarding is
+#     shared (GemmStridedBatchedParams -> ShouldWildcardLd*). The mm layout
+#     tests never touch this batched transpose/remap code, so it gets its own
+#     coverage below. bmm and baddbmm share baddbmm_out_cuda_impl, so this bmm
+#     coverage also covers baddbmm's layout path (baddbmm's bias handling is
+#     covered by the round-trip tests in DynamicTunableOpsTest).
+
+
+class BmmLayoutCoverageWildcardTest(TestCase):
+    """Batched analog of LayoutCoverageWildcardTest for torch.bmm, whose
+    transpose-flag derivation and M<->N mask remap live in
+    baddbmm_out_cuda_impl -- a separate code path from the mm/addmm
+    launchers. Tunes each (transa, transb) layout with one dim dynamic, then
+    queries at a shape differing only in that dim with no runtime mask, and
+    asserts: a wildcard was persisted, its leading-dim wildcarding is
+    self-consistent with the transpose flags (white-box), no concrete entry
+    is added at runtime, and the output matches a tunable-disabled
+    reference."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("cuda not available")
+        cls._tmpdir = tempfile.mkdtemp(prefix="bmm_layout_coverage_test_")
+        cls._tmp_results_path = os.path.join(cls._tmpdir, "tunable_results.csv")
+        torch.cuda.tunable.set_filename(cls._tmp_results_path, False)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls._tmpdir:
+            import shutil
+
+            shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def setUp(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def tearDown(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    @staticmethod
+    def _make_layout(
+        b: int, m: int, k: int, n: int, transa: bool, transb: bool, seed: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build (batch1, batch2) for `bmm(batch1, batch2)` so the batched
+        BLAS dispatch picks the requested (transa, transb) layout. As in the
+        mm helper, a transposed operand is allocated in the swapped shape and
+        then transposed on its last two dims so it is non-contiguous without a
+        contiguous() copy."""
+        torch.manual_seed(seed)
+        if not transa:
+            batch1 = torch.randn(b, m, k, dtype=DTYPE, device=DEVICE)
+        else:
+            batch1 = torch.randn(b, k, m, dtype=DTYPE, device=DEVICE).transpose(-2, -1)
+        if not transb:
+            batch2 = torch.randn(b, k, n, dtype=DTYPE, device=DEVICE)
+        else:
+            batch2 = torch.randn(b, n, k, dtype=DTYPE, device=DEVICE).transpose(-2, -1)
+        return batch1, batch2
+
+    def _round_trip_for_layout(
+        self, transa: bool, transb: bool, seed_offset: int, dynamic: str = "M"
+    ) -> None:
+        """Tune-then-fallback round trip for one batched layout, taking the
+        `dynamic` dim (one of "M"/"N"/"K") symbolic. Tuning and runtime shapes
+        differ only in that dim. Shapes are kept disjoint from the mm layout
+        tests via a distinct op (GemmStridedBatchedTunableOp) and seed range;
+        see the module-level isolation note (the in-memory results table is
+        process-global)."""
+        b = 8
+        base_m, n, k = 41 + seed_offset, 257, 251
+        delta = 12
+        tuned = {"m": base_m, "n": n, "k": k}
+        test = {"m": base_m, "n": n, "k": k}
+        test[dynamic.lower()] += delta
+
+        b1_t, b2_t = self._make_layout(
+            b,
+            tuned["m"],
+            tuned["k"],
+            tuned["n"],
+            transa,
+            transb,
+            seed=300 + seed_offset,
+        )
+        b1_x, b2_x = self._make_layout(
+            b, test["m"], test["k"], test["n"], transa, transb, seed=400 + seed_offset
+        )
+
+        # Reference (tunable disabled).
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.bmm(b1_x, b2_x)
+
+        # Phase A: tune at the tuned shape with the chosen dim dynamic ->
+        # wildcard persisted.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(**{dynamic: True}):
+            torch.bmm(b1_t, b2_t)
+        # Op-wide `_has_wildcard_entry` (not the shape-specific
+        # `_has_wildcard_with_dims`) is deliberate here: every layout variant in
+        # this class shares the same (n, k), so a shape-specific check could not
+        # tell them apart. `_assert_ld_wildcarding_consistent` below is the real
+        # per-entry gate.
+        self.assertTrue(
+            _has_wildcard_entry("GemmStridedBatchedTunableOp"),
+            f"expected GemmStridedBatchedTunableOp wildcard entry after tuning "
+            f"layout (transa={transa}, transb={transb}, dynamic={dynamic})",
+        )
+        # White-box: the batched path shares ShouldWildcardLda/Ldb/Ldc via
+        # GemmStridedBatchedParams, so a broken ld->dim mapping surfaces here
+        # just as it does for mm.
+        _assert_ld_wildcarding_consistent(self, "GemmStridedBatchedTunableOp")
+
+        # Phase C: runtime, no mask, shape differs only in the dynamic dim.
+        # Gated on the observable proxies (no new concrete entry, output
+        # matches reference); the white-box check above is the real gate on
+        # the wildcarding logic.
+        before = len(_get_tunable_results())
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.bmm(b1_x, b2_x)
+        after = len(_get_tunable_results())
+        self.assertEqual(
+            before,
+            after,
+            f"layout (transa={transa}, transb={transb}, dynamic={dynamic}): "
+            f"runtime dispatch with tuning disabled must not add a new entry",
+        )
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg=f"layout (transa={transa}, transb={transb}, dynamic={dynamic}): "
+            f"wildcard-fallback dispatch output must match tunable-disabled "
+            f"reference",
+        )
+
+    def test_bmm_layout_NN(self) -> None:
+        """No transpose on either operand."""
+        self._round_trip_for_layout(transa=False, transb=False, seed_offset=0)
+
+    def test_bmm_layout_NT(self) -> None:
+        """batch1 contiguous, batch2 transposed."""
+        self._round_trip_for_layout(transa=False, transb=True, seed_offset=4)
+
+    def test_bmm_layout_TN(self) -> None:
+        """batch1 transposed, batch2 contiguous."""
+        self._round_trip_for_layout(transa=True, transb=False, seed_offset=8)
+
+    def test_bmm_layout_TT(self) -> None:
+        """Both operands transposed."""
+        self._round_trip_for_layout(transa=True, transb=True, seed_offset=12)
+
+    def test_bmm_layout_NN_dynamic_k(self) -> None:
+        """K dynamic exercises lda/ldb on the batched path."""
+        self._round_trip_for_layout(
+            transa=False, transb=False, seed_offset=16, dynamic="K"
+        )
+
+    def test_bmm_layout_NT_dynamic_k(self) -> None:
+        self._round_trip_for_layout(
+            transa=False, transb=True, seed_offset=20, dynamic="K"
+        )
+
+    def test_bmm_layout_TN_dynamic_k(self) -> None:
+        """transa == 'T' + K dynamic forces lda to be wildcarded on the
+        batched path too."""
+        self._round_trip_for_layout(
+            transa=True, transb=False, seed_offset=24, dynamic="K"
+        )
+
+    def test_bmm_layout_TT_dynamic_k(self) -> None:
+        self._round_trip_for_layout(
+            transa=True, transb=True, seed_offset=28, dynamic="K"
+        )
+
+    def test_bmm_layout_NN_dynamic_n(self) -> None:
+        """N dynamic exercises the batched M<->N remap independent of the
+        shared swapped_mn field."""
+        self._round_trip_for_layout(
+            transa=False, transb=False, seed_offset=32, dynamic="N"
+        )
+
+    def test_bmm_layout_NT_dynamic_n(self) -> None:
+        self._round_trip_for_layout(
+            transa=False, transb=True, seed_offset=36, dynamic="N"
+        )
+
+    def test_bmm_layout_TN_dynamic_n(self) -> None:
+        self._round_trip_for_layout(
+            transa=True, transb=False, seed_offset=40, dynamic="N"
+        )
+
+    def test_bmm_layout_TT_dynamic_n(self) -> None:
+        self._round_trip_for_layout(
+            transa=True, transb=True, seed_offset=44, dynamic="N"
+        )
+
+
+# ─── ScaledGemmTunableOp coverage (FP8 _scaled_mm) ────────────────────
+# Mirrors the inductor_lowering_context node_replacement_dict
+# `{'torch.nn.Linear':{'(10000+,1000+)': 'fp8_float_model_dynamic_quantization_tensorwise'}}`
+# which rewrites large Linear layers into FP8 + per-tensor (tensorwise)
+# scaling. The lowered op is `torch._scaled_mm(a_fp8, b_fp8, scale_a,
+# scale_b, ...)` which ultimately dispatches to
+# `launchTunableScaledGemm` -> `ScaledGemmTunableOp::operator()`.
+#
+# This test verifies the same wildcard round-trip for that op:
+#   Phase A: tune at m_tuned with M dynamic -> wildcard persisted.
+#   Phase C: runtime concrete miss at m_test, no runtime mask
+#            -> LookupWildcardFallback hits the wildcard.
+
+
+class ScaledGemmTunableOpFP8Test(TestCase):
+    """Verify the dynamic-mask + wildcard-fallback contract for
+    `torch._scaled_mm` with tensorwise FP8 scaling, matching the
+    `node_replacement_dict` setup that triggers
+    `ScaledGemmTunableOp` for large Linear layers."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("cuda not available")
+        # FP8 e4m3fn requires a recent enough device; skip on older
+        # hardware that doesn't expose the dtype.
+        if not hasattr(torch, "float8_e4m3fn"):
+            raise unittest.SkipTest("torch.float8_e4m3fn not available")
+        cls._tmpdir = tempfile.mkdtemp(prefix="scaled_gemm_test_")
+        cls._tmp_results_path = os.path.join(cls._tmpdir, "tunable_results.csv")
+        torch.cuda.tunable.set_filename(cls._tmp_results_path, False)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls._tmpdir:
+            import shutil
+
+            shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def setUp(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def tearDown(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    @staticmethod
+    def _scaled_mm_inputs(
+        m: int, n: int, k: int, seed: int = 0
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Build (a_fp8, b_fp8, scale_a, scale_b) for a tensorwise-
+        scaled `_scaled_mm(a, b, scale_a, scale_b)` of shape (m, n, k).
+
+        a is M×K row-major, b is K×N -> b must be col-major for the
+        cuBLAS scaled-mm path (the typical inductor pattern after the
+        `fp8_float_model_dynamic_quantization_tensorwise` rewrite).
+        """
+        torch.manual_seed(seed)
+        # Random BF16 then quantize to FP8 e4m3fn with a tensorwise scale.
+        a_bf16 = torch.randn(m, k, dtype=torch.bfloat16, device=DEVICE)
+        b_bf16 = torch.randn(n, k, dtype=torch.bfloat16, device=DEVICE)
+        # Per-tensor (tensorwise) absmax scale -> single-element fp32
+        # tensor.
+        a_amax = a_bf16.abs().max().to(torch.float32)
+        b_amax = b_bf16.abs().max().to(torch.float32)
+        # FP8 e4m3fn dynamic range max value.
+        fp8_max = torch.finfo(torch.float8_e4m3fn).max
+        scale_a = (a_amax / fp8_max).reciprocal().clamp(min=1e-12)
+        scale_b = (b_amax / fp8_max).reciprocal().clamp(min=1e-12)
+        a_fp8 = (
+            (a_bf16.to(torch.float32) * scale_a)
+            .clamp(min=-fp8_max, max=fp8_max)
+            .to(torch.float8_e4m3fn)
+        )
+        b_fp8 = (
+            (b_bf16.to(torch.float32) * scale_b)
+            .clamp(min=-fp8_max, max=fp8_max)
+            .to(torch.float8_e4m3fn)
+        )
+        # `_scaled_mm` requires `b` to be column-major (matches the
+        # inductor lowering for the fp8 quantization rewrite).
+        b_fp8_colmajor = b_fp8.t().contiguous().t()
+        # Scale tensors are reciprocals of the quantization scales.
+        scale_a_inv = scale_a.reciprocal()
+        scale_b_inv = scale_b.reciprocal()
+        return a_fp8, b_fp8_colmajor, scale_a_inv, scale_b_inv
+
+    def _run_scaled_mm(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+    ) -> torch.Tensor:
+        # `_scaled_mm` with a column-major `b` produces an M×N bf16 out.
+        return torch._scaled_mm(a, b, scale_a, scale_b, out_dtype=torch.bfloat16)
+
+    def test_scaled_gemm_tunable_op_wildcard_round_trip(self) -> None:
+        """Tune `_scaled_mm` at m_tuned with M dynamic; query at
+        m_test with no runtime mask. Wildcard fallback must hit (or
+        the dispatch must safely fall through to a non-tunable path
+        with correct output)."""
+        # Use shapes that match the
+        # `node_replacement_dict`-style trigger: a "large Linear" with
+        # K and N >= 1000 (the prod rule says 10000+, 1000+; we use a
+        # smaller-but-representative shape so the test runs quickly).
+        m_tuned, n, k = 1024, 1024, 1024
+        m_test = 2048
+
+        # Reference: tunable disabled.
+        a_t, b_t, sa_t, sb_t = self._scaled_mm_inputs(m_tuned, n, k, seed=30)
+        a_x, b_x, sa_x, sb_x = self._scaled_mm_inputs(m_test, n, k, seed=31)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        try:
+            ref = self._run_scaled_mm(a_x, b_x, sa_x, sb_x)
+        except RuntimeError as e:
+            # _scaled_mm may not be supported on this device/dtype combo
+            # (e.g. unsupported gfx arch). Skip rather than fail.
+            raise unittest.SkipTest(
+                f"_scaled_mm not supported in this configuration: {e}"
+            ) from e
+
+        # Phase A: tune at m_tuned with M dynamic.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            self._run_scaled_mm(a_t, b_t, sa_t, sb_t)
+
+        # We don't strictly require a wildcard entry to exist -- some
+        # FP8 paths may take a non-tunable shortcut. But if any
+        # ScaledGemmTunableOp entry is present it should be the one we
+        # tuned. Check for "any" Scaled entry as a sanity gate.
+        scaled_entries = [
+            e for e in _get_tunable_results() if "ScaledGemmTunableOp" in e[0]
+        ]
+        if not scaled_entries:
+            raise unittest.SkipTest(
+                "no ScaledGemmTunableOp entries persisted; "
+                "_scaled_mm may have skipped the tunable path on this "
+                "configuration"
+            )
+        wildcard_present = any("*" in e[1] for e in scaled_entries)
+        self.assertTrue(
+            wildcard_present,
+            f"expected ScaledGemmTunableOp wildcard entry after tuning "
+            f"with M dynamic; got entries: {scaled_entries}",
+        )
+
+        # Phase C: runtime, no mask, different M -> wildcard fallback
+        # (or aten fallback) must produce correct output.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = self._run_scaled_mm(a_x, b_x, sa_x, sb_x)
+
+        self.assertEqual(
+            out,
+            ref,
+            atol=5e-2,
+            rtol=5e-2,
+            msg="ScaledGemmTunableOp dispatch output should match "
+            "tunable-disabled reference (either via wildcard fallback "
+            "or via non-tunable aten fallback)",
+        )
+
+    def test_scaled_gemm_both_miss_falls_back_safely(self) -> None:
+        """_scaled_mm both-miss: tunable enabled, tuning disabled, with no
+        concrete and no wildcard entry primed -> must fall back to the
+        non-tunable at::cuda::blas::scaled_gemm (NOT ResultEntry::Default())
+        and produce correct output without crashing. Regression gate for the
+        scaled path's safe-aten fallback: before the try_scaled_dispatch gate
+        in _tunable_scaled_gemm_rocm, a total miss reached the Default kernel
+        instead of falling back like the addmm path does."""
+        m, n, k = 4096, 1024, 1024
+        a, b, sa, sb = self._scaled_mm_inputs(m, n, k, seed=32)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        try:
+            ref = self._run_scaled_mm(a, b, sa, sb)
+        except RuntimeError as e:
+            raise unittest.SkipTest(
+                f"_scaled_mm not supported in this configuration: {e}"
+            ) from e
+
+        # No entries primed for this shape. Tunable enabled, tuning disabled:
+        # concrete miss + wildcard miss must fall back safely.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = self._run_scaled_mm(a, b, sa, sb)  # must NOT crash / Default
+
+        self.assertEqual(
+            out,
+            ref,
+            atol=5e-2,
+            rtol=5e-2,
+            msg="scaled both-miss fallback output should match "
+            "tunable-disabled reference",
+        )
+
+
+# ─── Legacy "non-dynamic" behavior (BEFORE the wildcard feature) ─────
+# These tests assert what TunableOp does when no `dynamic_dims_mask`
+# is ever pushed (the pre-feature world): only concrete-key entries
+# get persisted at compile-time tuning, and runtime concrete-miss
+# queries fall through to the non-tunable aten path. These are the
+# canonical "before" behavior gates -- they document and lock in what
+# the system reverts to when `rocm.autotune_tunableop_dynamic_dims_
+# wildcard=False` (the kill-switch for the dynamic-tunable-ops
+# feature).
+
+
+class LegacyConcreteOnlyTunableOpsTest(TestCase):
+    """Verify that without a dynamic-dims mask (the pre-feature
+    behavior), TunableOp only persists concrete entries and runtime
+    concrete-misses safely fall through. These tests do NOT push any
+    `dynamic_dims_mask` -- they emulate the world where the feature
+    flag `rocm.autotune_tunableop_dynamic_dims_wildcard=False`."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("cuda not available")
+        cls._tmpdir = tempfile.mkdtemp(prefix="legacy_concrete_only_test_")
+        cls._tmp_results_path = os.path.join(cls._tmpdir, "tunable_results.csv")
+        torch.cuda.tunable.set_filename(cls._tmp_results_path, False)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls._tmpdir:
+            import shutil
+
+            shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def setUp(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def tearDown(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def _entries_for_op(self, op_substr: str) -> list[_TunableResultEntry]:
+        return [e for e in _get_tunable_results() if op_substr in e[0]]
+
+    def test_addmm_tuning_no_mask_persists_concrete_only(self) -> None:
+        """Tuning enabled, NO `dynamic_dims_mask` context.
+        addmm produces a single concrete entry; no wildcard."""
+        m, n, k = 89, 1031, 257
+        bias, mat1, mat2 = _addmm(m, n, k, seed=40)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.addmm(bias, mat1, mat2)  # NO mask context
+
+        entries = self._entries_for_op("GemmAndBiasTunableOp")
+        # The persisted entries must NOT contain a wildcard.
+        for op_sig, params_sig, _, _ in entries:
+            self.assertNotIn(
+                "*",
+                params_sig,
+                f"legacy mode (no mask) must not persist wildcards; "
+                f"got {op_sig},{params_sig}",
+            )
+        # At least one concrete entry must exist for our shape.
+        concrete_match = [
+            e for e in entries if all(f"_{d}_" in ("_" + e[1] + "_") for d in (m, n, k))
+        ]
+        self.assertGreaterEqual(
+            len(concrete_match),
+            1,
+            f"expected concrete entry covering ({m},{n},{k}) after tuning",
+        )
+
+    def test_mm_tuning_no_mask_persists_concrete_only(self) -> None:
+        """torch.mm tuning without mask: only GemmTunableOp concrete."""
+        m, n, k = 91, 1033, 263
+        mat1, mat2 = _mm(m, n, k, seed=41)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.mm(mat1, mat2)  # NO mask
+
+        for op_sig, params_sig, _, _ in self._entries_for_op("GemmTunableOp"):
+            self.assertNotIn(
+                "*",
+                params_sig,
+                f"legacy mode (no mask) must not persist wildcards; "
+                f"got {op_sig},{params_sig}",
+            )
+
+    def test_bmm_tuning_no_mask_persists_concrete_only(self) -> None:
+        """torch.bmm tuning without mask: only StridedBatched concrete."""
+        b, m, n, k = 16, 47, 257, 251
+        b1, b2 = _bmm(b, m, n, k, seed=42)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.bmm(b1, b2)  # NO mask
+
+        for op_sig, params_sig, _, _ in self._entries_for_op(
+            "GemmStridedBatchedTunableOp"
+        ):
+            self.assertNotIn(
+                "*",
+                params_sig,
+                f"legacy mode (no mask) must not persist wildcards; "
+                f"got {op_sig},{params_sig}",
+            )
+
+    def test_runtime_concrete_miss_no_mask_falls_back_to_aten(self) -> None:
+        """Runtime: tunable enabled, tuning OFF, NO mask, no
+        wildcards exist -> concrete miss must fall back to non-
+        tunable aten (output correct, no entries added, no Default
+        crash)."""
+        # Use a fresh shape that no other test seeded.
+        m, n, k = 73, 1039, 269
+        bias, mat1, mat2 = _addmm(m, n, k, seed=43)
+
+        # Reference.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias, mat1, mat2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        before = len(_get_tunable_results())
+        out = torch.addmm(bias, mat1, mat2)  # NO mask, NO concrete entry
+        after = len(_get_tunable_results())
+
+        self.assertEqual(
+            before,
+            after,
+            "concrete-miss + tuning-disabled must not add any entries",
+        )
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="fallback dispatch result should match tunable-disabled reference",
+        )
+
+    def test_runtime_concrete_hit_no_mask_dispatches_via_concrete(
+        self,
+    ) -> None:
+        """After tuning a concrete entry (no mask), runtime queries
+        for the same shape must hit that concrete entry. No wildcard
+        scan needed."""
+        m, n, k = 79, 1049, 271
+        bias, mat1, mat2 = _addmm(m, n, k, seed=44)
+
+        # Reference.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias, mat1, mat2)
+
+        # Tune the concrete shape (no mask).
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.addmm(bias, mat1, mat2)
+        before = len(_get_tunable_results())
+
+        # Runtime: same shape -> concrete hit, no new entry, output
+        # matches.
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.addmm(bias, mat1, mat2)
+        after = len(_get_tunable_results())
+
+        self.assertEqual(
+            before,
+            after,
+            "concrete-hit dispatch must not add any new entry",
+        )
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="concrete-hit dispatch result should match reference",
+        )
+
+
+class _SizeOnlyNode:
+    """Minimal input-node stub exposing only get_size(), which is all that
+    shapes_symbolic / dynamic_dim_mask consult. Lets us drive
+    dynamic_dim_mask with symbolic (sympy) dims on CPU, no GPU needed."""
+
+    def __init__(self, size: tuple[object, ...]) -> None:
+        self._size = size
+
+    def get_size(self) -> tuple[object, ...]:
+        return self._size
+
+
+@inductor_config.patch({"rocm.autotune_tunableop_dynamic_dims_wildcard": True})
+class DynamicDimMaskOperandSelectionTest(TestCase):
+    """CPU unit tests pinning down two properties of
+    ``MMKernelInputs.dynamic_dim_mask`` that matter for scaled GEMM:
+
+      1. Operands are read from the explicit mat1_idx / mat2_idx, not the
+         trailing two inputs. Scaled GEMM lays out inputs as
+         ``[mat_a, mat_b, scale_a, scale_b, (bias)]`` with mat1_idx=0,
+         mat2_idx=1, so reading the trailing inputs would derive the mask
+         from the scale/bias tensors instead of the real M/N/K operands.
+      2. The ``"scaled_mm"`` op name (used by the inductor scaled-mm
+         lowering) is recognized as a 2D matmul.
+    """
+
+    def _scaled_mm_inputs(self, with_bias: bool) -> MMKernelInputs:
+        """Scaled-mm-style inputs where the real operands (indices 0, 1)
+        have a dynamic M only, while the trailing scale/bias tensors carry a
+        *different* dynamic dim -- so a (buggy) trailing-input mask would be
+        distinguishable from the correct operand-based mask."""
+        s_m = sympy.Symbol("s_m", positive=True, integer=True)
+        s_bad = sympy.Symbol("s_bad", positive=True, integer=True)
+        mat_a = _SizeOnlyNode((s_m, 512))  # (M_dyn, K)
+        mat_b = _SizeOnlyNode((512, 256))  # (K, N)  static
+        scale_a = _SizeOnlyNode((1, 1))
+        scale_b = _SizeOnlyNode((s_bad, 999))  # dynamic dim in trailing input
+        nodes: list[object] = [mat_a, mat_b, scale_a, scale_b]
+        if with_bias:
+            nodes.append(_SizeOnlyNode((256,)))
+        return MMKernelInputs(nodes, mat1_idx=0, mat2_idx=1)
+
+    def test_scaled_mm_reads_operands_not_trailing_scales(self) -> None:
+        ki = self._scaled_mm_inputs(with_bias=False)
+        # Correct mask is derived from mat_a/mat_b -> only M dynamic. If the
+        # trailing scale tensors were read, s_bad would surface as dyn_k.
+        self.assertEqual(ki.dynamic_dim_mask("scaled_mm"), (True, False, False, False))
+
+    def test_scaled_mm_with_bias_reads_operands(self) -> None:
+        ki = self._scaled_mm_inputs(with_bias=True)
+        self.assertEqual(ki.dynamic_dim_mask("scaled_mm"), (True, False, False, False))
+
+    def test_scaled_mm_op_name_recognized(self) -> None:
+        # A dynamic operand dim must yield a non-all-False mask, proving the
+        # "scaled_mm" name is recognized as a 2D matmul.
+        ki = self._scaled_mm_inputs(with_bias=False)
+        self.assertNotEqual(
+            ki.dynamic_dim_mask("scaled_mm"), (False, False, False, False)
+        )
+
+    def test_unrecognized_op_name_returns_all_false(self) -> None:
+        ki = self._scaled_mm_inputs(with_bias=False)
+        self.assertEqual(
+            ki.dynamic_dim_mask("not_a_gemm"), (False, False, False, False)
+        )
+
+    def test_default_indices_mm_reads_trailing_operands(self) -> None:
+        # Plain mm: [mat1, mat2], default indices, dynamic N only.
+        s_n = sympy.Symbol("s_n", positive=True, integer=True)
+        mat1 = _SizeOnlyNode((128, 512))  # (M, K)
+        mat2 = _SizeOnlyNode((512, s_n))  # (K, N_dyn)
+        ki = MMKernelInputs([mat1, mat2])
+        self.assertEqual(ki.dynamic_dim_mask("mm"), (False, True, False, False))
+
+    def test_feature_flag_off_returns_all_false(self) -> None:
+        with inductor_config.patch(
+            {"rocm.autotune_tunableop_dynamic_dims_wildcard": False}
+        ):
+            ki = self._scaled_mm_inputs(with_bias=False)
+            self.assertEqual(
+                ki.dynamic_dim_mask("scaled_mm"), (False, False, False, False)
+            )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/tests/test_dynamic_tunable_ops.py
+++ b/torch/_inductor/tests/test_dynamic_tunable_ops.py
@@ -1,0 +1,897 @@
+"""Test suite for the dynamic TunableOp dispatch matrix.
+
+Exercises every branch of the design:
+
+Tuning enabled (compile-time autotune)
+  1. no dynamic dim + concrete key miss  -> tune; persist concrete key only
+  2. has dynamic dim + concrete key miss -> tune; persist concrete + wildcard
+  3. no dynamic dim + concrete key hit   -> nothing new persisted
+  4. has dynamic dim + concrete key hit  -> persist wildcard if missing
+
+Tuning disabled (runtime)
+  Runtime callers (notably the AOTI cpp_wrapper) cannot know which
+  dim is dynamic: no `TunableDynamicDimsGuard` is emitted, so
+  `GetCurrentDynamicDimsMask()` is always empty.
+
+  1. concrete key hit                       -> dispatch via concrete
+  2. concrete miss + wildcard match         -> dispatch via wildcard
+                                               (TuningResultsManager::
+                                               LookupWildcardFallback scans
+                                               persisted wildcard entries
+                                               token-by-token against the
+                                               concrete signature)
+  3. concrete miss + no wildcard match      -> result stays Null;
+                                               caller (e.g.
+                                               launchTunableGemmAndBias)
+                                               falls back to the
+                                               non-tunable aten path
+                                               (no Default kernel invoked,
+                                               no entries added)
+
+Observability caveat (applies to every "wildcard fallback" runtime test
+below): there is NO Python- or C++-visible counter for how many times a
+tuned kernel or the wildcard fallback was actually dispatched -- the
+fallback only emits a TUNABLE_LOG3 debug line, not a queryable stat. A
+successful wildcard-fallback dispatch and a safe fall-through to the
+non-tunable aten path produce the SAME numerical result (that is the point
+of the safe fallback) and both add no concrete entry. So the runtime tests
+here gate on the two observable proxies -- output matches the
+tunable-disabled reference AND no new concrete entry is persisted -- which
+are necessary but NOT sufficient to prove the fallback fired. The real
+gate on the wildcard machinery is the persistence side: the wildcard entry
+is present with the expected concrete dims, and (for the layout tests) its
+leading-dim wildcarding is self-consistent with the transpose flags
+(`_assert_ld_wildcarding_consistent`). Tightening the runtime tests into
+hard gates requires a dispatch hit counter that does not yet exist.
+
+Covered (every variant is verified for all three runtime dispatch outcomes --
+concrete hit, concrete miss + wildcard fallback, and concrete miss + no
+wildcard -> safe non-tunable aten fallback -- matching the addmm reference
+launchTunableGemmAndBias):
+  - GemmAndBiasTunableOp via torch.addmm
+  - GemmTunableOp via torch.mm
+  - GemmStridedBatchedTunableOp via torch.bmm and torch.baddbmm
+  - ScaledGemmTunableOp via torch._scaled_mm (incl. the safe-aten fallback on
+    a total miss -- the ResultEntry::Default() kernel is never invoked)
+  - several mm layout combinations: NN/NT/TN/TT (exercising the swapped_mn
+    M<->N mask remap)
+
+All non-scaled entry points (mm/bmm/baddbmm) route through gemm_tunable /
+bgemm_tunable in CUDABlas.cpp, which now (a) resolve a concrete miss via
+TuningResultsManager::LookupWildcardFallback and (b) receive the inductor-frame
+mask already remapped into BLAS frame (by launchGemmCublas /
+baddbmm_out_cuda_impl in Blas.cpp) when the dispatch swaps M<->N -- exactly as
+launchTunableGemmAndBias does for addmm. The scaled path (_tunable_scaled_gemm_
+rocm in ScaledBlas.cpp) applies the same remap and now gates dispatch so a
+total miss falls back to at::cuda::blas::scaled_gemm.
+
+Not fully covered:
+  - addbmm or other higher-level batched add variants, if routed differently
+  - scaled GEMM variants beyond the FP8 tensorwise _scaled_mm shape
+"""
+
+# pyre-strict
+
+import logging
+import os
+import tempfile
+import unittest
+from typing import cast, TypeAlias
+
+import torch
+import torch.cuda.tunable
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+DEVICE: str = "cuda"
+DTYPE: torch.dtype = torch.bfloat16
+_TunableResultEntry: TypeAlias = tuple[str, str, str, float]
+
+
+def _get_tunable_results() -> list[_TunableResultEntry]:
+    return cast(list[_TunableResultEntry], torch.cuda.tunable.get_results())
+
+
+def _addmm(
+    m: int, n: int, k: int, seed: int = 0
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build (bias, mat1, mat2) for an addmm of shape (m, n, k)."""
+    torch.manual_seed(seed)
+    bias = torch.randn(n, dtype=DTYPE, device=DEVICE)
+    mat1 = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+    mat2 = torch.randn(k, n, dtype=DTYPE, device=DEVICE)
+    return bias, mat1, mat2
+
+
+def _mm(m: int, n: int, k: int, seed: int = 0) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build (mat1, mat2) for a plain mm of shape (m, n, k)."""
+    torch.manual_seed(seed)
+    mat1 = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+    mat2 = torch.randn(k, n, dtype=DTYPE, device=DEVICE)
+    return mat1, mat2
+
+
+def _bmm(
+    b: int, m: int, n: int, k: int, seed: int = 0
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build (batch1, batch2) for a bmm of shape (b, m, n, k)."""
+    torch.manual_seed(seed)
+    batch1 = torch.randn(b, m, k, dtype=DTYPE, device=DEVICE)
+    batch2 = torch.randn(b, k, n, dtype=DTYPE, device=DEVICE)
+    return batch1, batch2
+
+
+def _baddbmm(
+    b: int, m: int, n: int, k: int, seed: int = 0
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build (bias, batch1, batch2) for a baddbmm of shape (b, m, n, k)."""
+    torch.manual_seed(seed)
+    bias = torch.randn(b, m, n, dtype=DTYPE, device=DEVICE)
+    batch1 = torch.randn(b, m, k, dtype=DTYPE, device=DEVICE)
+    batch2 = torch.randn(b, k, n, dtype=DTYPE, device=DEVICE)
+    return bias, batch1, batch2
+
+
+def _entries_for(
+    op_substr: str, *required_dim_tokens: str
+) -> list[_TunableResultEntry]:
+    """Filter `_get_tunable_results()` to entries whose
+    op-signature contains `op_substr` AND whose params-signature contains
+    every requested `_<token>_` substring.
+
+    The dim tokens are matched as `_<token>_` against `_<params_sig>_`, so
+    callers do not have to know the cuBLAS-vs-PyTorch column-major /
+    row-major dim ordering -- they just supply the integer dims that must
+    appear somewhere in the params signature."""
+    out: list[_TunableResultEntry] = []
+    for entry in _get_tunable_results():
+        # Each entry is a 4-tuple: (op_signature, params_signature, key, time).
+        op_sig, params_sig, _, _ = entry
+        if op_substr not in op_sig:
+            continue
+        padded = "_" + params_sig + "_"
+        if all(f"_{tok}_" in padded for tok in required_dim_tokens):
+            out.append(entry)
+    return out
+
+
+def _has_concrete_entry(op_substr: str, m: int, n: int, k: int) -> bool:
+    """True if get_results() has an entry whose params_sig contains every
+    one of (m, n, k) as `_N_` substrings AND no `*` wildcard token."""
+    for entry in _entries_for(op_substr, str(m), str(n), str(k)):
+        if "*" not in entry[1]:
+            return True
+    return False
+
+
+def _has_wildcard_entry(op_substr: str) -> bool:
+    """True if get_results() has any wildcard (asterisk-bearing) entry for
+    the given op."""
+    for entry in _get_tunable_results():
+        op_sig, params_sig, _, _ = entry
+        if op_substr in op_sig and "*" in params_sig:
+            return True
+    return False
+
+
+def _has_wildcard_with_dims(op_substr: str, *dims: int) -> bool:
+    """True if get_results() has a wildcard entry whose m/n/k tokens include
+    every one of `dims`.
+
+    Matching is restricted to the three m/n/k position tokens (parsed via
+    `_parse_gemm_params_sig`) rather than a raw substring scan of the whole
+    signature, so a coincidental lda/ldb/ldc (or batch) token that happens to
+    equal a requested dim cannot produce a false positive."""
+    for entry in _get_tunable_results():
+        op_sig, params_sig, _, _ = entry
+        if op_substr not in op_sig or "*" not in params_sig:
+            continue
+        _, _, m_tok, n_tok, k_tok, _, _, _ = _parse_gemm_params_sig(params_sig)
+        mnk = (m_tok, n_tok, k_tok)
+        if all(str(d) in mnk for d in dims):
+            return True
+    return False
+
+
+# Positions of (lda, ldb, ldc) tokens right after the "_ld_" marker.
+_LD_MARKER = "_ld_"
+
+
+def _parse_gemm_params_sig(
+    params_sig: str,
+) -> tuple[str, str, str, str, str, str, str, str]:
+    """Split a Gemm*Params signature into its component tokens.
+
+    Handles all variants -- GemmParams / GemmAndBiasParams
+    (``{ta}{tb}_{m}_{n}_{k}_ld_{lda}_{ldb}_{ldc}``), GemmStridedBatched
+    (extra ``_B_{batch}`` before ``_ld_``) and ScaledGemm (extra
+    ``_rw_..._bias_...`` after the ld triple) -- because m/n/k are always the
+    first three tokens after the leading ``{ta}{tb}`` token and lda/ldb/ldc
+    are always the first three tokens after ``_ld_``.
+
+    Returns ``(transa, transb, m, n, k, lda, ldb, ldc)`` as raw string tokens
+    (each is either a decimal integer or ``"*"``)."""
+    transa, transb = params_sig[0], params_sig[1]
+    ld_idx = params_sig.find(_LD_MARKER)
+    assert ld_idx != -1, f"no '{_LD_MARKER}' marker in signature: {params_sig}"  # noqa: S101
+    prefix_toks = params_sig[:ld_idx].split("_")
+    m_tok, n_tok, k_tok = prefix_toks[1], prefix_toks[2], prefix_toks[3]
+    ld_toks = params_sig[ld_idx + len(_LD_MARKER) :].split("_")
+    lda_tok, ldb_tok, ldc_tok = ld_toks[0], ld_toks[1], ld_toks[2]
+    return transa, transb, m_tok, n_tok, k_tok, lda_tok, ldb_tok, ldc_tok
+
+
+def _assert_ld_wildcarding_consistent(test: TestCase, op_substr: str) -> None:
+    """White-box check that the leading-dim wildcarding of every persisted
+    wildcard entry matches the actual lda/ldb/ldc dependency encoded by the
+    transpose flags in that same signature.
+
+    This is the invariant that ``ShouldWildcardLda/Ldb/Ldc`` in GemmCommon.h
+    must satisfy, derived from ``GetSizeA/B/C`` in that file:
+
+      * lda >= m for non-transposed A (transa == 'N'), lda >= k for
+        transposed A (transa == 'T'), so lda tracks M or K accordingly.
+      * ldb >= k for non-transposed B (transb == 'N'), ldb >= n for
+        transposed B (transb == 'T'), so ldb tracks K or N accordingly.
+      * ldc >= m always, so ldc tracks M.
+
+    Reading transa/transb and which of m/n/k are ``*`` from the persisted
+    signature makes the check independent of the row-major addmm/mm M<->N
+    remap: whatever frame the signature ends up in, its ld wildcarding must
+    be self-consistent. The pre-fix inverted ``UsesMForLda`` wildcards lda on
+    the wrong dim whenever exactly one of {m, k} is dynamic, which this check
+    flags."""
+    checked = 0
+    for op_sig, params_sig, _, _ in _get_tunable_results():
+        if op_substr not in op_sig or "*" not in params_sig:
+            continue
+        transa, transb, m_tok, n_tok, k_tok, lda_tok, ldb_tok, ldc_tok = (
+            _parse_gemm_params_sig(params_sig)
+        )
+        dyn_m, dyn_n, dyn_k = m_tok == "*", n_tok == "*", k_tok == "*"
+        exp_lda = dyn_m if transa in "Nn" else dyn_k
+        exp_ldb = dyn_k if transb in "Nn" else dyn_n
+        exp_ldc = dyn_m
+        test.assertEqual(
+            lda_tok == "*",
+            exp_lda,
+            f"lda wildcarding wrong for {params_sig!r}: transa={transa}, "
+            f"dyn_m={dyn_m}, dyn_k={dyn_k}; lda tracks "
+            f"{'M' if transa in 'Nn' else 'K'}",
+        )
+        test.assertEqual(
+            ldb_tok == "*",
+            exp_ldb,
+            f"ldb wildcarding wrong for {params_sig!r}: transb={transb}, "
+            f"dyn_n={dyn_n}, dyn_k={dyn_k}; ldb tracks "
+            f"{'K' if transb in 'Nn' else 'N'}",
+        )
+        test.assertEqual(
+            ldc_tok == "*",
+            exp_ldc,
+            f"ldc wildcarding wrong for {params_sig!r}: dyn_m={dyn_m}; "
+            f"ldc always tracks M",
+        )
+        checked += 1
+    test.assertGreaterEqual(
+        checked,
+        1,
+        f"expected at least one {op_substr} wildcard entry to validate",
+    )
+
+
+class DynamicTunableOpsTest(TestCase):
+    """Verification of the full tuning enable/disable x dynamic-dim matrix.
+
+    Note: there is NO API to clear the in-memory TuningResultsManager, and
+    `set_filename` does not reset it (see setUpClass). The in-memory results
+    table therefore accumulates for the whole process, across every test AND
+    every test class. Isolation relies entirely on each test picking
+    (m, n, k) shapes that are disjoint from all other tests in the module, so
+    one test's entries never satisfy another's concrete/wildcard lookups. The
+    enabled/tuning flags are always restored to False in tearDown.
+    """
+
+    _tmpdir: str = ""
+    _tmp_results_path: str = ""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("cuda not available")
+        # Redirect TunableOp persistence to a fresh per-process tempfile so
+        # this run never appends to (or lazily loads) the shared default
+        # "tunableop_results.csv".
+        #
+        # Caveat (verified against Tunable.cpp): set_filename ONLY changes the
+        # read/write path. It does NOT clear the in-memory results table, and
+        # it does NOT re-arm the one-time lazy file load (guarded by a
+        # c10::once_flag). So the "read our empty tempfile" effect only applies
+        # to the very first class in the process to touch the manager; later
+        # classes inherit whatever is already in memory. There is no API to
+        # clear the in-memory table, which is why cross-test isolation relies
+        # on globally-disjoint shapes rather than on this tempfile.
+        cls._tmpdir = tempfile.mkdtemp(prefix="dynamic_tunable_ops_test_")
+        cls._tmp_results_path = os.path.join(cls._tmpdir, "tunable_results.csv")
+        torch.cuda.tunable.set_filename(cls._tmp_results_path, False)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls._tmpdir:
+            import shutil
+
+            shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def setUp(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    def tearDown(self) -> None:
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+
+    # -- Tuning enabled --------------------------------------------------
+
+    def test_tuning_enabled_no_dynamic_concrete_miss_persists_concrete_only(
+        self,
+    ) -> None:
+        """Tuning enabled + no dynamic dim + concrete miss
+        -> tune; persist concrete; do NOT persist wildcard."""
+        # Choose a fresh shape that is unlikely to clash with anything else
+        # (small to keep tuning latency low).
+        # Unusual primes -> guaranteed not in any prod-style CSV.
+        m, n, k = 17, 2053, 257
+        bias, mat1, mat2 = _addmm(m, n, k, seed=1)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        out = torch.addmm(bias, mat1, mat2)
+        self.assertEqual(out.shape, (m, n))
+
+        matched = _entries_for("GemmAndBiasTunableOp", str(m), str(n), str(k))
+        # Should have exactly one concrete entry, no wildcard entry.
+        self.assertGreaterEqual(
+            len(matched), 1, f"expected >=1 entry for ({m},{n},{k}), got {matched}"
+        )
+        for entry in matched:
+            self.assertNotIn(
+                "*",
+                entry[1],
+                f"unexpected wildcard entry for non-dynamic call: {entry}",
+            )
+
+    def test_tuning_enabled_dynamic_concrete_miss_persists_concrete_and_wildcard(
+        self,
+    ) -> None:
+        """Tuning enabled + has dynamic dim (M dynamic) + concrete miss
+        -> tune; persist concrete AND wildcard."""
+        m, n, k = 23, 2053, 269
+        bias, mat1, mat2 = _addmm(m, n, k, seed=2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            out = torch.addmm(bias, mat1, mat2)
+        self.assertEqual(out.shape, (m, n))
+
+        concrete_matched = [
+            e
+            for e in _entries_for("GemmAndBiasTunableOp", str(m), str(n), str(k))
+            if "*" not in e[1]
+        ]
+        wildcard_matched = [
+            e for e in _entries_for("GemmAndBiasTunableOp") if "*" in e[1]
+        ]
+        self.assertGreaterEqual(
+            len(concrete_matched),
+            1,
+            f"expected concrete entry for ({m},{n},{k}); got {concrete_matched}",
+        )
+        self.assertGreaterEqual(
+            len(wildcard_matched),
+            1,
+            f"expected at least one wildcard entry; got {wildcard_matched}",
+        )
+
+    def test_tuning_enabled_no_dynamic_concrete_hit_no_new_entries(self) -> None:
+        """Tuning enabled + no dynamic dim + concrete hit
+        -> no new entries are added on the second call."""
+        m, n, k = 29, 2053, 271
+        bias, mat1, mat2 = _addmm(m, n, k, seed=3)
+
+        # Prime: tune once.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.addmm(bias, mat1, mat2)
+        before = len(_get_tunable_results())
+
+        # Run again with same shape, no dynamic mask.
+        torch.addmm(bias, mat1, mat2)
+        after = len(_get_tunable_results())
+        self.assertEqual(
+            before,
+            after,
+            "concrete-hit + no-dynamic case should not add entries",
+        )
+
+    def test_tuning_enabled_dynamic_concrete_hit_persists_wildcard_if_missing(
+        self,
+    ) -> None:
+        """Tuning enabled + has dynamic dim + concrete hit (wildcard not
+        yet persisted) -> persist wildcard now.
+
+        Note on the BLAS-frame remap: PyTorch's row-major addmm dispatch
+        swaps inductor's (M, N) into BLAS's (n, m) so cuBLAS can stay
+        column-major. `cublasCommonArgs::swapped_mn` flags this and
+        `launchTunableGemmAndBias` remaps the inductor-frame mask sent
+        by the test (`dynamic_dims_mask(M=True)`) into a BLAS-frame
+        (N=True) before stamping `params.dynamic_dims_mask`. The
+        persisted wildcard signature therefore has `*` in the BLAS-n
+        slot (which is the original inductor-M, the actually dynamic
+        dim). The wildcard's BLAS-m slot is concrete and equals
+        inductor-N, and BLAS-k stays inductor-K."""
+        # Use a (m, k) pair that no other test in this class touches so the
+        # wildcard signature is unique and we can check for its specific
+        # presence rather than relying on a fragile count delta.
+        m, n, k = 41, 2053, 1009
+        bias, mat1, mat2 = _addmm(m, n, k, seed=4)
+
+        # Phase A: tune the concrete shape WITHOUT any dynamic mask, so only
+        # the concrete key gets persisted.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.addmm(bias, mat1, mat2)
+
+        # Sanity: concrete entry should exist, but no wildcard for it yet.
+        self.assertTrue(
+            _has_concrete_entry("GemmAndBiasTunableOp", m, n, k),
+            f"expected concrete entry for ({m},{n},{k}) after phase A",
+        )
+        # The "concrete-as-checked" tokens here are inductor-frame; the
+        # actual BLAS-frame signature swaps M↔N. `_has_wildcard_with_dims`
+        # below checks BLAS-frame tokens to match what's persisted.
+        self.assertFalse(
+            _has_wildcard_with_dims("GemmAndBiasTunableOp", n, k),
+            f"unexpected wildcard for BLAS-frame ({n},*,{k}) before phase B",
+        )
+
+        # Phase B: same concrete shape, but now declare M dynamic. operator()
+        # should hit the concrete entry and persist the wildcard.
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.addmm(bias, mat1, mat2)
+
+        # The persisted wildcard is in BLAS frame: tokens `_<n>_` (BLAS m
+        # = inductor N) and `_<k>_` (BLAS k = inductor K) are concrete;
+        # the BLAS-n slot holds `*` (the swapped inductor-M).
+        self.assertTrue(
+            _has_wildcard_with_dims("GemmAndBiasTunableOp", n, k),
+            f"expected BLAS-frame wildcard containing ({n},*,{k}) after "
+            "phase B (case 4: concrete hit + dynamic must persist wildcard "
+            "if missing). With cublasCommonArgs::swapped_mn the inductor-M "
+            "dynamic bit lands in BLAS-n.",
+        )
+
+    # -- Tuning disabled -------------------------------------------------
+
+    def test_tuning_disabled_concrete_hit_dispatches_via_concrete(self) -> None:
+        """Tuning disabled + concrete hit -> dispatch via concrete entry,
+        result matches tunable-disabled reference."""
+        m, n, k = 43, 2053, 1013
+        bias, mat1, mat2 = _addmm(m, n, k, seed=5)
+
+        # Prime concrete entry.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.addmm(bias, mat1, mat2)
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias, mat1, mat2)
+
+        # Test: tunable enabled, tuning disabled. Concrete hit.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        before = len(_get_tunable_results())
+        out = torch.addmm(bias, mat1, mat2)
+        after = len(_get_tunable_results())
+
+        self.assertEqual(before, after, "tuning disabled should not add entries")
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="tunable-enabled output should match tunable-disabled reference",
+        )
+
+    def test_tuning_disabled_concrete_miss_wildcard_hit_dispatches_via_wildcard(
+        self,
+    ) -> None:
+        """Tuning disabled + concrete miss + wildcard match
+        -> dispatch via wildcard entry, result matches tunable-disabled
+        reference. The runtime cannot push a dynamic-dims mask (AOTI
+        cpp_wrapper does not emit a TunableDynamicDimsGuard), so this
+        test deliberately runs Phase B WITHOUT a `dynamic_dims_mask`
+        context to mirror real runtime behavior. The wildcard match
+        comes from `LookupWildcardFallback`'s token-by-token scan over
+        persisted wildcard entries."""
+        m_tuned, n, k = 47, 2053, 1019
+        m_test = 53  # different M, same wildcard pattern
+        bias_t, mat1_t, mat2_t = _addmm(m_tuned, n, k, seed=6)
+        bias_x, mat1_x, mat2_x = _addmm(m_test, n, k, seed=7)
+
+        # Phase A (compile-time analog): tune at m_tuned with M dynamic
+        # so the wildcard `tn_*_n_k_…` is seeded into the manager.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.addmm(bias_t, mat1_t, mat2_t)
+
+        # Shape-specific: the BLAS-frame wildcard keeps n and k concrete (M is
+        # the wildcarded dim), so match on this test's own (n, k) rather than
+        # any wildcard for the op -- otherwise a wildcard seeded by another
+        # test would satisfy this assertion.
+        self.assertTrue(
+            _has_wildcard_with_dims("GemmAndBiasTunableOp", n, k),
+            "expected wildcard entry with concrete (n, k) after phase A tuning",
+        )
+        # m_test has no concrete entry yet.
+        self.assertFalse(
+            _has_concrete_entry("GemmAndBiasTunableOp", m_test, n, k),
+            "should have no concrete entry for the new M before phase B",
+        )
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias_x, mat1_x, mat2_x)
+
+        # Phase B (runtime analog): tunable enabled, tuning disabled,
+        # NO `dynamic_dims_mask` context -- the AOTI runtime cannot push
+        # one. Concrete miss for m_test -> LookupWildcardFallback finds
+        # the wildcard seeded in Phase A and dispatches via it.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.addmm(bias_x, mat1_x, mat2_x)
+
+        self.assertFalse(
+            _has_concrete_entry("GemmAndBiasTunableOp", m_test, n, k),
+            "tuning-disabled wildcard-fallback dispatch must not add a concrete entry",
+        )
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="wildcard-fallback dispatched output should match "
+            "tunable-disabled reference",
+        )
+
+    def test_tuning_disabled_both_miss_falls_back_to_non_tunable_aten(self) -> None:
+        """Tuning disabled + concrete miss + no wildcard match
+        -> dispatch falls back to the non-tunable aten path; no Default
+        kernel invoked, no entries added, output matches tunable-disabled
+        reference. Uses a large-K shape that historically crashed via the
+        Default kernel on MI300X to confirm the safe path is taken."""
+        # One of the prod shapes that crashed in tunable_mi300x_fresh_v2.txt
+        # when TunableOp was enabled with no tuned entries.
+        m, n, k = 2048, 2048, 11088
+        bias, mat1, mat2 = _addmm(m, n, k, seed=8)
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.addmm(bias, mat1, mat2)
+
+        # Test: tunable enabled, tuning disabled, no entries primed (no
+        # concrete or wildcard for this shape exists in the manager).
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        before_results = len(_get_tunable_results())
+        out = torch.addmm(bias, mat1, mat2)  # must NOT crash
+        after_results = len(_get_tunable_results())
+
+        self.assertEqual(
+            before_results,
+            after_results,
+            "both-miss + tuning disabled must not add any entries",
+        )
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="fallback dispatch result should match tunable-disabled reference",
+        )
+
+    # -- Tuning disabled: mm / bmm runtime wildcard fallback -------------
+    # Regression coverage for making GemmTunableOp (torch.mm) and
+    # GemmStridedBatchedTunableOp (torch.bmm) consume persisted wildcard
+    # entries at runtime via LookupWildcardFallback, matching the addmm
+    # path (launchTunableGemmAndBias). Before the fix, gemm_tunable /
+    # bgemm_tunable in CUDABlas.cpp did an exact-match Lookup on
+    # DynamicSignature(); at runtime the mask is empty (no
+    # TunableDynamicDimsGuard), so dynamic_sig == concrete_sig and the
+    # lookup never fired -- every concrete miss silently fell back to the
+    # non-tunable aten path instead of the persisted wildcard-tuned kernel.
+
+    def test_tuning_disabled_mm_concrete_miss_wildcard_hit(self) -> None:
+        """torch.mm: tuning disabled + concrete miss + wildcard match.
+        Phase A tunes at m_tuned with M dynamic (seeds a GemmTunableOp
+        wildcard); Phase B queries a different M at runtime with no mask.
+        The concrete miss is expected to resolve via LookupWildcardFallback.
+        Gated on the observable proxies only (no concrete entry added, output
+        matches the tunable-disabled reference); see the module-level
+        observability caveat -- the fallback firing itself is not directly
+        observable."""
+        m_tuned, n, k = 61, 2063, 1021
+        m_test = 79
+        mat1_t, mat2_t = _mm(m_tuned, n, k, seed=50)
+        mat1_x, mat2_x = _mm(m_test, n, k, seed=51)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.mm(mat1_t, mat2_t)
+        self.assertTrue(
+            _has_wildcard_with_dims("GemmTunableOp", n, k),
+            "expected GemmTunableOp wildcard entry with concrete (n, k) after "
+            "phase A tuning",
+        )
+        self.assertFalse(
+            _has_concrete_entry("GemmTunableOp", m_test, n, k),
+            "should have no concrete entry for the new M before phase B",
+        )
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.mm(mat1_x, mat2_x)
+
+        # Runtime: tunable enabled, tuning disabled, no mask.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.mm(mat1_x, mat2_x)
+
+        self.assertFalse(
+            _has_concrete_entry("GemmTunableOp", m_test, n, k),
+            "mm wildcard-fallback dispatch must not add a concrete entry",
+        )
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="mm wildcard-fallback output should match tunable-disabled reference",
+        )
+
+    def test_tuning_disabled_bmm_concrete_miss_wildcard_hit(self) -> None:
+        """torch.bmm: tuning disabled + concrete miss + wildcard match.
+        bmm is not subject to the cuBLAS M<->N swap, so the inductor-frame
+        M-dynamic mask lands directly on the BLAS m slot; the persisted
+        wildcard therefore matches a different-M concrete signature via
+        LookupWildcardFallback's token scan. No concrete entry is added and
+        the output matches the tunable-disabled reference."""
+        b = 8
+        m_tuned, n, k = 37, 263, 277
+        m_test = 43
+        b1_t, b2_t = _bmm(b, m_tuned, n, k, seed=52)
+        b1_x, b2_x = _bmm(b, m_test, n, k, seed=53)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.bmm(b1_t, b2_t)
+        self.assertTrue(
+            _has_wildcard_with_dims("GemmStridedBatchedTunableOp", n, k),
+            "expected GemmStridedBatchedTunableOp wildcard entry with concrete "
+            "(n, k) after phase A",
+        )
+        self.assertFalse(
+            _has_concrete_entry("GemmStridedBatchedTunableOp", m_test, n, k),
+            "should have no concrete entry for the new M before phase B",
+        )
+
+        # Reference: tunable disabled.
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.bmm(b1_x, b2_x)
+
+        # Runtime: tunable enabled, tuning disabled, no mask.
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.bmm(b1_x, b2_x)
+
+        self.assertFalse(
+            _has_concrete_entry("GemmStridedBatchedTunableOp", m_test, n, k),
+            "bmm wildcard-fallback dispatch must not add a concrete entry",
+        )
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="bmm wildcard-fallback output should match tunable-disabled reference",
+        )
+
+    # -- Cache-behavior parity: concrete hit + safe aten fallback --------
+    # Mirror the three addmm runtime scenarios (concrete hit, wildcard
+    # fallback, both-miss safe fallback) for mm/bmm/baddbmm so every
+    # non-scaled variant is verified to behave identically to
+    # launchTunableGemmAndBias.
+
+    def test_tuning_disabled_mm_concrete_hit(self) -> None:
+        """torch.mm concrete hit: after tuning a concrete entry, a runtime
+        query for the same shape dispatches via it -- no new entry, output
+        matches the tunable-disabled reference."""
+        m, n, k = 83, 2039, 1033
+        mat1, mat2 = _mm(m, n, k, seed=54)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.mm(mat1, mat2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.mm(mat1, mat2)
+        before = len(_get_tunable_results())
+
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.mm(mat1, mat2)
+        after = len(_get_tunable_results())
+
+        self.assertEqual(before, after, "mm concrete-hit must not add an entry")
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="mm concrete-hit output should match reference",
+        )
+
+    def test_tuning_disabled_mm_both_miss_falls_back_safely(self) -> None:
+        """torch.mm both-miss: tunable enabled, tuning disabled, no concrete
+        entry and no matching wildcard -> safe non-tunable aten fallback (no
+        crash, no entry added, output matches reference)."""
+        m, n, k = 97, 1493, 1499
+        mat1, mat2 = _mm(m, n, k, seed=55)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.mm(mat1, mat2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        before = len(_get_tunable_results())
+        out = torch.mm(mat1, mat2)  # must NOT crash
+        after = len(_get_tunable_results())
+
+        self.assertEqual(before, after, "mm both-miss must not add an entry")
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="mm both-miss fallback output should match reference",
+        )
+
+    def test_tuning_disabled_bmm_concrete_hit(self) -> None:
+        """torch.bmm concrete hit -> dispatch via concrete entry, no new
+        entry added, output matches reference."""
+        b, m, n, k = 8, 31, 269, 281
+        b1, b2 = _bmm(b, m, n, k, seed=56)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.bmm(b1, b2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.bmm(b1, b2)
+        before = len(_get_tunable_results())
+
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.bmm(b1, b2)
+        after = len(_get_tunable_results())
+
+        self.assertEqual(before, after, "bmm concrete-hit must not add an entry")
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="bmm concrete-hit output should match reference",
+        )
+
+    def test_tuning_disabled_bmm_both_miss_falls_back_safely(self) -> None:
+        """torch.bmm both-miss -> safe non-tunable aten fallback (no crash,
+        no entry added, output matches reference)."""
+        b, m, n, k = 8, 101, 1451, 1453
+        b1, b2 = _bmm(b, m, n, k, seed=57)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.bmm(b1, b2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        before = len(_get_tunable_results())
+        out = torch.bmm(b1, b2)  # must NOT crash
+        after = len(_get_tunable_results())
+
+        self.assertEqual(before, after, "bmm both-miss must not add an entry")
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="bmm both-miss fallback output should match reference",
+        )
+
+    def test_tuning_disabled_baddbmm_concrete_miss_wildcard_hit(self) -> None:
+        """torch.baddbmm: tune at m_tuned with M dynamic -> wildcard; runtime
+        query at a different M with no mask -> wildcard fallback, output
+        matches reference. baddbmm shares bgemm_tunable with bmm; the bias is
+        applied around the same GemmStridedBatchedTunableOp dispatch."""
+        b = 8
+        m_tuned, n, k = 29, 277, 287
+        m_test = 41
+        bias_t, b1_t, b2_t = _baddbmm(b, m_tuned, n, k, seed=58)
+        bias_x, b1_x, b2_x = _baddbmm(b, m_test, n, k, seed=59)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(True)
+        with torch.cuda.tunable.dynamic_dims_mask(M=True):
+            torch.baddbmm(bias_t, b1_t, b2_t)
+        self.assertTrue(
+            _has_wildcard_with_dims("GemmStridedBatchedTunableOp", n, k),
+            "expected GemmStridedBatchedTunableOp wildcard entry with concrete "
+            "(n, k) after baddbmm phase A",
+        )
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.baddbmm(bias_x, b1_x, b2_x)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.baddbmm(bias_x, b1_x, b2_x)
+
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="baddbmm wildcard-fallback output should match reference",
+        )
+
+    def test_tuning_disabled_baddbmm_both_miss_falls_back_safely(self) -> None:
+        """torch.baddbmm both-miss -> safe non-tunable aten fallback (no
+        crash, output matches reference)."""
+        b = 8
+        m, n, k = 103, 1481, 1483
+        bias, b1, b2 = _baddbmm(b, m, n, k, seed=60)
+
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(False)
+        ref = torch.baddbmm(bias, b1, b2)
+
+        torch.cuda.tunable.enable(True)
+        torch.cuda.tunable.tuning_enable(False)
+        out = torch.baddbmm(bias, b1, b2)  # must NOT crash
+
+        self.assertEqual(
+            out,
+            ref,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="baddbmm both-miss fallback output should match reference",
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1936,6 +1936,85 @@ PyObject* THCPModule_cuda_tunableop_get_cublaslt_requested_algo_count(
   END_HANDLE_TH_ERRORS
 }
 
+namespace {
+
+constexpr const char* kTunableDynamicDimsGuardCapsuleName =
+    "at::cuda::tunable::TunableDynamicDimsGuard";
+
+void THCPModule_cuda_tunableop_dynamic_dims_mask_capsule_destructor(
+    PyObject* capsule) {
+  if (!PyCapsule_IsValid(capsule, kTunableDynamicDimsGuardCapsuleName)) {
+    return;
+  }
+  auto* guard = static_cast<at::cuda::tunable::TunableDynamicDimsGuard*>(
+      PyCapsule_GetPointer(capsule, kTunableDynamicDimsGuardCapsuleName));
+  delete guard;
+}
+
+} // namespace
+
+PyObject* THCPModule_cuda_tunableop_push_dynamic_dims_mask(
+    PyObject* _unused,
+    PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      THPUtils_checkLong(arg),
+      "cuda_tunableop_push_dynamic_dims_mask expects an int, but got ",
+      THPUtils_typename(arg));
+  // Pack the four dim flags (M/N/K/BATCH) into the low 4 bits on the Python
+  // side, push as a single mask value here. See torch.cuda.tunable
+  // .dynamic_dims_mask context manager for the high-level wrapper.
+  const auto raw_bits = THPUtils_unpackLong(arg);
+  TORCH_CHECK(
+      raw_bits >= 0 && raw_bits <= 0xF,
+      "cuda_tunableop_push_dynamic_dims_mask expects a mask in [0, 0xF] "
+      "(low 4 bits = M|N|K|BATCH), but got ",
+      raw_bits);
+  auto bits = static_cast<uint8_t>(raw_bits);
+  at::cuda::tunable::TunableDynamicDimsGuard* guard =
+      new at::cuda::tunable::TunableDynamicDimsGuard(
+          at::cuda::tunable::DynamicDimsMask{bits});
+  // Returning the heap-owned guard pointer as a PyCapsule so the Python side
+  // owns its lifetime; pop_dynamic_dims_mask takes the same capsule and
+  // deletes it, which runs the dtor and pops the TLS stack.
+  PyObject* capsule = PyCapsule_New(
+      static_cast<void*>(guard),
+      kTunableDynamicDimsGuardCapsuleName,
+      THCPModule_cuda_tunableop_dynamic_dims_mask_capsule_destructor);
+  if (capsule == nullptr) {
+    delete guard;
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(
+          PyExc_RuntimeError,
+          "Failed to create TunableDynamicDimsGuard capsule.");
+    }
+  }
+  return capsule;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THCPModule_cuda_tunableop_pop_dynamic_dims_mask(
+    PyObject* _unused,
+    PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      PyCapsule_IsValid(arg, kTunableDynamicDimsGuardCapsuleName),
+      "cuda_tunableop_pop_dynamic_dims_mask expects a valid, unconsumed "
+      "TunableDynamicDimsGuard capsule");
+  auto* guard = static_cast<at::cuda::tunable::TunableDynamicDimsGuard*>(
+      PyCapsule_GetPointer(arg, kTunableDynamicDimsGuardCapsuleName));
+  delete guard;
+  PyCapsule_SetDestructor(arg, nullptr);
+  // Mark the capsule as consumed by renaming it. PyCapsule_SetPointer
+  // rejects nullptr (it raises a ValueError), so we instead change the
+  // capsule's name to a sentinel that subsequent PyCapsule_GetPointer
+  // calls will not match -- giving us double-pop detection without
+  // tripping the CPython null-pointer guard.
+  PyCapsule_SetName(arg, "at::cuda::tunable::TunableDynamicDimsGuard[popped]");
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject* THCPModule_cuda_tunableop_set_filename(
     PyObject* _unused,
     PyObject* args) {
@@ -2447,6 +2526,14 @@ static struct PyMethodDef _THCPModule_methods[] = {
     {"_cuda_tunableop_set_filename",
      THCPModule_cuda_tunableop_set_filename,
      METH_VARARGS,
+     nullptr},
+    {"_cuda_tunableop_push_dynamic_dims_mask",
+     THCPModule_cuda_tunableop_push_dynamic_dims_mask,
+     METH_O,
+     nullptr},
+    {"_cuda_tunableop_pop_dynamic_dims_mask",
+     THCPModule_cuda_tunableop_pop_dynamic_dims_mask,
+     METH_O,
      nullptr},
     {"_cuda_tunableop_get_filename",
      THCPModule_cuda_tunableop_get_filename,

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -189,13 +189,21 @@ Use the C++ or Python APIs instead.
 
 """
 
+import contextlib
 import glob
 import multiprocessing as mp
 import os
 import shutil
 import warnings
+from collections.abc import Iterator
 
 import torch
+
+
+_DYN_M_BIT = 1 << 0
+_DYN_N_BIT = 1 << 1
+_DYN_K_BIT = 1 << 2
+_DYN_BATCH_BIT = 1 << 3
 
 
 __all__ = [
@@ -211,6 +219,9 @@ __all__ = [
     "get_max_tuning_iterations",
     "set_cublaslt_requested_algo_count",
     "get_cublaslt_requested_algo_count",
+    "push_dynamic_dims_mask",
+    "pop_dynamic_dims_mask",
+    "dynamic_dims_mask",
     "set_filename",
     "get_filename",
     "get_results",
@@ -303,6 +314,79 @@ def get_cublaslt_requested_algo_count() -> int:
         torch._C._cuda_tunableop_get_cublaslt_requested_algo_count  # type: ignore[attr-defined]
     )
     return get_count()
+
+
+def _pack_dynamic_dims_mask(
+    M: bool = False,
+    N: bool = False,
+    K: bool = False,
+    BATCH: bool = False,
+) -> int:
+    r"""Pack four per-dim flags into the single byte mask used by C++."""
+    bits = 0
+    if M:
+        bits |= _DYN_M_BIT
+    if N:
+        bits |= _DYN_N_BIT
+    if K:
+        bits |= _DYN_K_BIT
+    if BATCH:
+        bits |= _DYN_BATCH_BIT
+    return bits
+
+
+def push_dynamic_dims_mask(
+    M: bool = False,
+    N: bool = False,
+    K: bool = False,
+    BATCH: bool = False,
+) -> object:
+    r"""Push a per-call dynamic-dims mask onto the thread-local TunableOp stack.
+
+    Returns an opaque handle (PyCapsule) that must be passed to
+    :func:`pop_dynamic_dims_mask`. Handles must be popped in reverse push order,
+    and on the same thread that pushed them: the stack is thread-local, so a
+    handle released on another thread (e.g. by the garbage collector) will warn
+    and skip its pop. Prefer the :func:`dynamic_dims_mask` context manager,
+    which keeps push and pop on the same thread, unless you need raw push/pop
+    semantics.
+
+    The mask wildcards the named GEMM dims when computing the TunableOp
+    DynamicSignature; tuned entries seeded under the wildcard key will be
+    reused by subsequent shapes that differ only in the dynamic dim(s).
+    """
+    bits = _pack_dynamic_dims_mask(M=M, N=N, K=K, BATCH=BATCH)
+    return torch._C._cuda_tunableop_push_dynamic_dims_mask(bits)  # type: ignore[attr-defined]
+
+
+def pop_dynamic_dims_mask(handle: object) -> None:
+    r"""Pop the most recently pushed dynamic-dims mask.
+
+    Pass the handle returned by the latest unmatched
+    :func:`push_dynamic_dims_mask` call. Handles must be popped in LIFO order,
+    on the same thread that pushed them (the mask stack is thread-local).
+    """
+    torch._C._cuda_tunableop_pop_dynamic_dims_mask(handle)  # type: ignore[attr-defined]
+
+
+@contextlib.contextmanager
+def dynamic_dims_mask(
+    M: bool = False,
+    N: bool = False,
+    K: bool = False,
+    BATCH: bool = False,
+) -> Iterator[None]:
+    r"""Context manager that wraps a scope with a per-call dynamic-dims mask.
+
+    Each TunableOp GEMM call inside the scope uses the given mask when
+    computing its wildcard signature; outside the scope the legacy
+    concrete-only behavior applies.
+    """
+    handle = push_dynamic_dims_mask(M=M, N=N, K=K, BATCH=BATCH)
+    try:
+        yield
+    finally:
+        pop_dynamic_dims_mask(handle)
 
 
 def set_filename(filename: str, insert_device_ordinal: bool = False) -> None:


### PR DESCRIPTION
Summary:

Adds a Claude skill at `fbcode/caffe2/.claude/skills/fbsource-caffe2-lintrunner/`
documenting how to reproduce the PyTorch OSS PR lint jobs (e.g.
`Lint / lintrunner-noclang-partial`) against local `caffe2` changes from an
fbsource devserver.

This is non-trivial in fbsource because `lintrunner` is not preinstalled and
network egress is restricted: AWS S3 is reachable (so `clang-format` downloads),
but `github.com` is blocked, so the `uv run --python 3.10` invocation the Python
linters use cannot fetch a standalone CPython. The skill captures the working
setup:

- a `/tmp` venv plus `pip install lintrunner`, and `s3_init.py` to populate
  `.lintbin`;
- the offline linters (incl. `CLANGFORMAT`, `NEWLINE`, `DOCSTRING_LINTER`, ...)
  via a single `lintrunner --skip` pass;
- the `uv`-gated Python linters (`RUFF`, `PYFMT`, `FLAKE8`, `CODESPELL`,
  `PYREFLY`) run via their adapter scripts directly, with pinned deps from the
  internal PyPI mirror (including the `setuptools<81` and missing-torch-stub
  caveats);
- what cannot run locally (`CLANGTIDY`, CI-fidelity `PYREFLY`) and the
  `arc f` / `arc lint -a` alternatives.

The skill follows the `name`/`description` frontmatter format of the existing
skills under `fbcode/caffe2/.claude/skills/`.

Test Plan:
Doc-only change (a single `SKILL.md`); no build or runtime impact. The commands
documented were exercised in-session against changed `caffe2` files: the
`lintrunner --skip` noclang pass plus `RUFF`, `PYFMT`, `FLAKE8`, `CODESPELL`, and
`PYREFLY` adapters all ran and reported results as described.

Reviewed By: ZhitongGuo, Ruishenl

Differential Revision: D114789051


