### PR TITLE
Preserve strides for custom Function inputs returned as-is

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -522,6 +522,29 @@ TEST(CustomAutogradTest, FunctionReturnsInput) {
   ASSERT_VARIABLE_EQ(x.grad(), torch::full(1, 2.));
 }
 
+TEST(CustomAutogradTest, FunctionReturnsInputPreservesStrides) {
+  struct MyFunction : public Function<MyFunction> {
+    static Variable forward(AutogradContext*, Variable input) {
+      return input;
+    }
+
+    static variable_list backward(
+        AutogradContext*, variable_list grad_outputs) {
+      return {grad_outputs[0] * 2};
+    }
+  };
+
+  auto input = torch::zeros({3, 1}).permute({1, 0});
+  auto output = MyFunction::apply(input);
+  EXPECT_EQ(output.strides(), input.strides());
+
+  input.requires_grad_();
+  output = MyFunction::apply(input);
+  EXPECT_EQ(output.strides(), input.strides());
+  output.sum().backward();
+  ASSERT_VARIABLE_EQ(input.grad(), torch::full_like(input, 2.));
+}
+
 TEST(CustomAutogradTest, FunctionReturnsUndefined) {
   struct MyFunction : public Function<MyFunction> {
     static Variable forward(AutogradContext* ctx, Variable var) {

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -342,6 +342,16 @@ class TestAutograd(TestCase):
             MyFunction.apply(v.clone()).backward()
             self.assertEqual(v.grad, torch.full(shape, 2.0))
 
+        v = torch.zeros((3, 1)).permute(1, 0)
+        result = MyFunction.apply(v)
+        self.assertEqual(result.stride(), v.stride())
+
+        v.requires_grad_()
+        result = MyFunction.apply(v)
+        self.assertEqual(result.stride(), v.stride())
+        result.sum().backward()
+        self.assertEqual(v.grad, torch.full_like(v, 2.0))
+
     def test_function_returns_undefined_tensor(self):
         class MyFunction(Function):
             @staticmethod
@@ -10568,9 +10578,8 @@ for shape in [(1,), ()]:
         )
 
         return_lambdas = {
-            # If we return an input as-is in forward, that is treated
-            # as if self.view_as(self) is performed. If jvp returns x.view_as(x),
-            # this is OK.
+            # Returning an input as-is attaches an alias/view to the forward
+            # output. Returning x.view_as(x) from jvp preserves that relation.
             "view_as": lambda x: x.view_as(x),
             # Expect this to raise an error
             "self": lambda x: x,

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -276,18 +276,17 @@ static at::Tensor _view_as_self_with_no_grad(
   //
   // (2) Though it is not necessary for the purposes of attaching grad_fn, we
   // also call this function when an output is non-differentiable (and does not
-  // require grad). to help custom forward AD UX more consistent. We'd like to
-  // uniformly say that returning an input as-is is treated as if
-  // `self.view_as(self)` were returned for that output.
+  // require grad), to make custom forward AD UX more consistent. Returning an
+  // input as-is is treated as an alias so it can receive distinct autograd
+  // metadata without changing the input's tensor metadata.
   //
   // Alternatively, we could have not disabled forward grad while performing
   // this view, but it would mean that the user defined jvp may be silently
   // ignored.
   at::AutoFwGradMode fw_grad_mode(false);
   AutoGradMode grad_mode(false);
-  // We thread through this view_as_self_fn lambda so that in the case we are a
-  // Python custom function (rather than a cpp one), we can properly call the
-  // view_as from python so that torch function logic can still trigger.
+  // We thread through this view_as_self_fn lambda so Python custom functions can
+  // retain the Python view_as path when torch function logic must trigger.
   return view_as_self_fn(self);
 }
 

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <ATen/ops/alias.h>
 #include <c10/core/SymInt.h>
 #include <c10/util/flat_hash_map.h>
 #include <c10/util/irange.h>
@@ -531,7 +532,7 @@ auto Function<T>::apply(Args&&... args)
   };
 
   auto view_as_self_fn = [](const at::Tensor& x) -> at::Tensor {
-    return x.view_as(x);
+    return at::alias(x);
   };
 
   c10::intrusive_ptr<Node> attached_node;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -4,12 +4,14 @@
 
 #include <ATen/ATen.h>
 #include <ATen/SequenceNumber.h>
+#include <ATen/ops/alias.h>
 #include <c10/util/SmallVector.h>
 #include <c10/util/irange.h>
 #include <pybind11/pybind11.h>
 #include <structmember.h>
 #include <torch/csrc/PyInterpreter.h>
 #include <torch/csrc/python_headers.h>
+#include <torch/csrc/utils/disable_torch_function.h>
 #include <torch/csrc/utils/pybind.h>
 
 #include <ATen/FuncTorchTLS.h>
@@ -793,6 +795,11 @@ static void _wrap_outputs(
   auto view_as_self_fn = [](const at::Tensor& x) -> at::Tensor {
     pybind11::gil_scoped_acquire gil;
     THPObjectPtr py_x(THPVariable_Wrap(x));
+    if (!py_x)
+      throw_python_error();
+    if (!torch::has_torch_function(py_x.get())) {
+      return at::alias(x);
+    }
     THPObjectPtr py_view_as_method(PyObject_GetAttrString(py_x, "view_as"));
     if (!py_view_as_method)
       throw_python_error();


### PR DESCRIPTION
Summary:
- Preserve tensor metadata when a custom autograd Function returns an input as-is.
- Use `aten.alias` instead of `view_as` for regular Tensor wrapping, while keeping the Python `view_as` path for `__torch_function__` inputs.
- Add Python and C++ coverage for non-contiguous returned inputs.

Testing:
- `git diff --cached --check`
- Manual repro on an existing torch 2.13.0 install: a custom Function returning a `(1, 1)` stride input produced `(3, 1)`, while `torch.ops.aten.alias.default` preserved `(1, 1)`.
- Not run: `python test/test_autograd.py TestAutograd.test_function_returns_input` because the local checkout is sparse/unbuilt and could not import source `torch`.
