### PR TITLE
[DTensor] Support non-overlapping last-dimension sharding for convolution op

### DIFF
--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -16,11 +16,8 @@ from torch.distributed.tensor import (
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.nn import functional as F
 from torch.testing._internal.common_cuda import with_tf32_off
-from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
-    parametrize,
-    run_tests,
-)
+from torch.testing._internal.common_distributed import run_subtests
+from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -333,8 +330,14 @@ class DistConvolutionOpsTest(DTensorTestBase):
 
     @with_tf32_off
     @with_comms
-    @parametrize("conv_dim", [1, 2, 3], name_fn=lambda conv_dim: f"conv{conv_dim}d")
-    def test_convolution_last_dim_shard(self, conv_dim):
+    def test_convolution_last_dim_shard(self):
+        run_subtests(
+            self,
+            {"conv_dim": [1, 2, 3]},
+            self._test_convolution_last_dim_shard,
+        )
+
+    def _test_convolution_last_dim_shard(self, conv_dim):
         device_mesh = self.build_device_mesh()
         conv_cls = (nn.Conv1d, nn.Conv2d, nn.Conv3d)[conv_dim - 1]
         spatial_shape = (8,) * (conv_dim - 1) + (16,)
@@ -467,7 +470,6 @@ class DistConvolutionOpsTest(DTensorTestBase):
         self.assertEqual(x_dt.grad.full_tensor(), x_ref.grad)
 
 
-instantiate_parametrized_tests(DistConvolutionOpsTest)
 DistConvolutionOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistConvolutionOpsTest,
     # Send / recv ops are not supported

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -16,7 +16,11 @@ from torch.distributed.tensor import (
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.nn import functional as F
 from torch.testing._internal.common_cuda import with_tf32_off
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -327,6 +331,45 @@ class DistConvolutionOpsTest(DTensorTestBase):
         out_ref.backward(grad)
         self.assertEqual(x_dt.grad.full_tensor(), x_ref.grad)
 
+    @with_tf32_off
+    @with_comms
+    @parametrize("conv_dim", [1, 2, 3], name_fn=lambda conv_dim: f"conv{conv_dim}d")
+    def test_convolution_last_dim_shard(self, conv_dim):
+        device_mesh = self.build_device_mesh()
+        conv_cls = (nn.Conv1d, nn.Conv2d, nn.Conv3d)[conv_dim - 1]
+        spatial_shape = (8,) * (conv_dim - 1) + (16,)
+        kernel_size = (3,) * (conv_dim - 1) + (4,)
+        stride = (1,) * (conv_dim - 1) + (4,)
+        padding = (1,) * (conv_dim - 1) + (0,)
+
+        model = conv_cls(
+            3, 8, kernel_size=kernel_size, stride=stride, padding=padding
+        ).to(self.device_type)
+        model_ref = copy.deepcopy(model).to(self.device_type)
+        model = distribute_module(model, device_mesh, _conv_fn)
+
+        x = torch.randn(
+            4, 3, *spatial_shape, device=self.device_type, requires_grad=True
+        )
+        placements = (Shard(x.ndim - 1),)
+        x_ref = x.detach().clone().requires_grad_(True)
+        x_dt = distribute_tensor(x, device_mesh, placements)
+
+        out_dt = model(x_dt)
+        out_ref = model_ref(x_ref)
+        self.assertEqual(out_dt.placements, placements)
+        self.assertEqual(out_dt.shape, out_ref.shape)
+        self.assertEqual(out_dt.full_tensor(), out_ref)
+
+        grad = torch.randn_like(out_ref)
+        grad_dt = distribute_tensor(grad, device_mesh, placements)
+        out_dt.backward(grad_dt)
+        out_ref.backward(grad)
+
+        self.assertEqual(x_dt.grad.placements, placements)
+        self.assertEqual(x_dt.grad.shape, x_ref.grad.shape)
+        self.assertEqual(x_dt.grad.full_tensor(), x_ref.grad)
+
     @with_comms
     def test_conv2d_module_no_bias(self):
         """Test nn.Conv2d module with bias=False (Issue #167091)
@@ -424,6 +467,7 @@ class DistConvolutionOpsTest(DTensorTestBase):
         self.assertEqual(x_dt.grad.full_tensor(), x_ref.grad)
 
 
+instantiate_parametrized_tests(DistConvolutionOpsTest)
 DistConvolutionOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistConvolutionOpsTest,
     # Send / recv ops are not supported

--- a/torch/distributed/tensor/_ops/_conv_ops.py
+++ b/torch/distributed/tensor/_ops/_conv_ops.py
@@ -4,6 +4,7 @@
 from typing import Any
 
 import torch
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor._op_schema import (
     OpSchema,
@@ -15,7 +16,14 @@ from torch.distributed.tensor._ops.single_dim_strategy import (
     register_single_dim_strategy,
 )
 from torch.distributed.tensor._ops.utils import register_prop_rule
-from torch.distributed.tensor.placement_types import Partial, Placement, Replicate
+from torch.distributed.tensor.placement_types import (
+    _StridedShard,
+    Partial,
+    Placement,
+    Replicate,
+    Shard,
+)
+from torch.fx.experimental.symbolic_shapes import guard_or_false
 
 
 aten = torch.ops.aten
@@ -157,16 +165,86 @@ def convolution_backward_rules(op_schema: OpSchema) -> OutputSharding:
 # _tp_conv.py continue to handle runtime dispatch.
 
 
+def _supports_last_dim_sharding(
+    input_meta: TensorMeta,
+    weight_meta: TensorMeta,
+    stride: list[Any],
+    padding: list[Any],
+    dilation: list[Any],
+    transposed: bool,
+) -> bool:
+    ndim = len(input_meta.shape)
+    return (
+        ndim == len(weight_meta.shape)
+        and ndim in (3, 4, 5)
+        and not transposed
+        and guard_or_false(padding[-1] == 0)
+        and guard_or_false(dilation[-1] == 1)
+        and guard_or_false(stride[-1] == weight_meta.shape[-1])
+    )
+
+
+def _convolution_full_mesh_strategy_filter(
+    mesh: DeviceMesh,
+    op_schema: OpSchema,
+    input_specs: list[DTensorSpec],
+    _output_specs: DTensorSpec | tuple[DTensorSpec | None, ...],
+) -> bool:
+    if op_schema.op == aten.convolution.default:
+        input_idx, stride_idx = 0, 3
+    elif op_schema.op == aten.convolution_backward.default:
+        input_idx, stride_idx = 1, 4
+    else:
+        raise AssertionError(f"Unexpected op {op_schema.op}")
+
+    input_spec = input_specs[input_idx]
+    last_dim = len(input_spec.shape) - 1
+    last_dim_mesh_dims = [
+        mesh_dim
+        for mesh_dim, placement in enumerate(input_spec.placements)
+        if placement.is_shard(last_dim)
+    ]
+    if not last_dim_mesh_dims:
+        return True
+    # _tp_conv converts placements to dim_map, which cannot represent one tensor
+    # dimension sharded over multiple mesh dimensions.
+    if len(last_dim_mesh_dims) != 1:
+        return False
+
+    last_dim_mesh_dim = last_dim_mesh_dims[0]
+    last_dim_placement = input_spec.placements[last_dim_mesh_dim]
+    if not isinstance(last_dim_placement, Shard) or isinstance(
+        last_dim_placement, _StridedShard
+    ):
+        return False
+
+    stride = op_schema.args_schema[stride_idx]
+    if not isinstance(stride, list):
+        raise AssertionError(f"Expected stride list, got {type(stride)}")
+    return guard_or_false(
+        input_spec.shape[last_dim] % (stride[-1] * mesh.size(last_dim_mesh_dim)) == 0
+    )
+
+
 @register_single_dim_strategy(
     [aten.convolution.default],
     schema_info=RuntimeSchemaInfo(2),
+    full_mesh_strategy_filter=_convolution_full_mesh_strategy_filter,
 )
 def convolution_single_dim_strategy(
     op: torch._ops.OpOverload,
     args_schema: tuple[Any, ...],
     kwargs_schema: dict[str, Any],
 ) -> list[list[Placement | _ShardingPlaceholder]]:
+    input_meta = args_schema[0]
+    if not isinstance(input_meta, TensorMeta):
+        raise AssertionError(f"Expected TensorMeta, got {type(input_meta)}")
+    weight_meta = args_schema[1]
+    if not isinstance(weight_meta, TensorMeta):
+        raise AssertionError(f"Expected TensorMeta, got {type(weight_meta)}")
     bias_meta = args_schema[2]
+    stride, padding, dilation = args_schema[3:6]
+    transposed = args_schema[6]
     # [output, input, weight, (bias)]
     rule: list[Placement | _ShardingPlaceholder] = [
         _ShardingPlaceholder(0),  # output
@@ -175,19 +253,43 @@ def convolution_single_dim_strategy(
     ]
     if bias_meta is not None:
         rule.append(Replicate())  # bias
-    return [rule]
+    strategies = [rule]
+
+    if _supports_last_dim_sharding(
+        input_meta, weight_meta, stride, padding, dilation, transposed
+    ):
+        last_dim = len(input_meta.shape) - 1
+        last_dim_rule: list[Placement | _ShardingPlaceholder] = [
+            Shard(last_dim),  # output
+            Shard(last_dim),  # input
+            Replicate(),  # weight
+        ]
+        if bias_meta is not None:
+            last_dim_rule.append(Replicate())  # bias
+        strategies.append(last_dim_rule)
+
+    return strategies
 
 
 @register_single_dim_strategy(
     [aten.convolution_backward.default],
     schema_info=RuntimeSchemaInfo(3),
+    full_mesh_strategy_filter=_convolution_full_mesh_strategy_filter,
 )
 def convolution_backward_single_dim_strategy(
     op: torch._ops.OpOverload,
     args_schema: tuple[Any, ...],
     kwargs_schema: dict[str, Any],
 ) -> list[list[Placement | _ShardingPlaceholder | None]]:
+    input_meta = args_schema[1]
+    if not isinstance(input_meta, TensorMeta):
+        raise AssertionError(f"Expected TensorMeta, got {type(input_meta)}")
+    weight_meta = args_schema[2]
+    if not isinstance(weight_meta, TensorMeta):
+        raise AssertionError(f"Expected TensorMeta, got {type(weight_meta)}")
     bias_sizes = args_schema[3]
+    stride, padding, dilation = args_schema[4:7]
+    transposed = args_schema[7]
     has_bias = bias_sizes is not None
     # outputs: [grad_input, grad_weight, grad_bias]
     # inputs: [grad_output, input, weight]
@@ -199,4 +301,21 @@ def convolution_backward_single_dim_strategy(
         _ShardingPlaceholder(0),  # input
         Replicate(),  # weight
     ]
-    return [rule]
+    strategies = [rule]
+
+    if _supports_last_dim_sharding(
+        input_meta, weight_meta, stride, padding, dilation, transposed
+    ):
+        last_dim = len(input_meta.shape) - 1
+        strategies.append(
+            [
+                Shard(last_dim),  # grad_input
+                Partial("sum"),  # grad_weight
+                Partial("sum") if has_bias else None,  # grad_bias
+                Shard(last_dim),  # grad_output
+                Shard(last_dim),  # input
+                Replicate(),  # weight
+            ]
+        )
+
+    return strategies


### PR DESCRIPTION
**Summary:**  Solves https://github.com/pytorch/pytorch/issues/191926. This change adds DTensor convolution strategies that preserve sharding along the final spatial dimension through both forward and backward operations. Support is limited to aligned, non-overlapping convolution windows, and a full-mesh filter excludes layouts that the existing _tp_conv dim_map representation cannot handle. Regression coverage verifies forward and backward correctness for Conv1d, Conv2d, and Conv3d.

**Test Cases**
1. pytest test/distributed/tensor/test_convolution_ops.py -k test_convolution_last_dim_shard

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #192147

