### PR TITLE
[BE] Fix B007 unused loop control variables in tools/, torchgen/ and functorch/

### DIFF
--- a/.ci/libtorch/extract_libtorch_from_wheel.py
+++ b/.ci/libtorch/extract_libtorch_from_wheel.py
@@ -293,7 +293,7 @@ def create_libtorch_zip(
 ) -> Path:
     zip_path = output_dir / f"{zip_prefix}-{version}.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for root, dirs, files in os.walk(libtorch_dir):
+        for root, _dirs, files in os.walk(libtorch_dir):
             for f in files:
                 filepath = Path(root) / f
                 arcname = filepath.relative_to(libtorch_dir.parent)

--- a/.github/scripts/check_doc_redirects.py
+++ b/.github/scripts/check_doc_redirects.py
@@ -119,7 +119,7 @@ def find_missing_redirects(
         List of (old_key, new_url) tuples. new_url is None for deletions.
     """
     missing = []
-    for status, old_path, new_path in changes:
+    for _status, old_path, new_path in changes:
         old_key = path_to_key(old_path)
         if old_key not in existing:
             new_url = path_to_url(new_path) if new_path else None

--- a/.github/scripts/test_gitutils.py
+++ b/.github/scripts/test_gitutils.py
@@ -29,7 +29,7 @@ class TestPeekableIterator(TestCase):
 
     def test_peek(self, input_: str = "abcdef") -> None:
         iter_ = PeekableIterator(input_)
-        for idx, c in enumerate(iter_):
+        for idx, _c in enumerate(iter_):
             if idx + 1 < len(input_):
                 self.assertEqual(iter_.peek(), input_[idx + 1])
             else:

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2329,7 +2329,7 @@ def get_ghstack_dependent_prs(
     if skip_len > 0:
         rev_list = rev_list[:-skip_len]
     rc: list[tuple[str, GitHubPR]] = []
-    for pr_, sha in _revlist_to_prs(repo, pr, rev_list):
+    for pr_, _sha in _revlist_to_prs(repo, pr, rev_list):
         if not pr_.is_closed():
             if not only_closed:
                 rc.append(("", pr_))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2345,7 +2345,7 @@ def coverage_post_process(app, exception):
     if "torch" not in modules:
         missing.add("torch")
 
-    for _, modname, ispkg in pkgutil.walk_packages(
+    for _, modname, _ in pkgutil.walk_packages(
         path=torch.__path__, prefix=torch.__name__ + "."
     ):
         if is_not_internal(modname):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2345,7 +2345,7 @@ def coverage_post_process(app, exception):
     if "torch" not in modules:
         missing.add("torch")
 
-    for _, modname, ispkg in pkgutil.walk_packages(
+    for _, modname, _ispkg in pkgutil.walk_packages(
         path=torch.__path__, prefix=torch.__name__ + "."
     ):
         if is_not_internal(modname):

--- a/functorch/dim/__init__.py
+++ b/functorch/dim/__init__.py
@@ -1325,7 +1325,7 @@ def split(tensor: Any, split_size_or_sections: Any, dim: Any = None) -> tuple:
     result = []
     new_levels = list(self_info.levels)
 
-    for i, (result_tensor, size_dim) in enumerate(zip(result_tensors, sizes)):
+    for result_tensor, size_dim in zip(result_tensors, sizes):
         new_levels[idx] = DimEntry(size_dim)
         result.append(
             Tensor.from_positional(

--- a/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
@@ -201,7 +201,7 @@ def test(db, net, device, epoch, log):
     qry_losses = []
     qry_accs = []
 
-    for batch_idx in range(n_test_iter):
+    for _ in range(n_test_iter):
         x_spt, y_spt, x_qry, y_qry = db.next("test")
         task_num, setsz, c_, h, w = x_spt.size()
 

--- a/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
@@ -199,7 +199,7 @@ def test(db, net, device, epoch, log):
     qry_losses = []
     qry_accs = []
 
-    for batch_idx in range(n_test_iter):
+    for _ in range(n_test_iter):
         x_spt, y_spt, x_qry, y_qry = db.next("test")
         task_num, setsz, c_, h, w = x_spt.size()
 

--- a/functorch/examples/maml_omniglot/support/omniglot_loaders.py
+++ b/functorch/examples/maml_omniglot/support/omniglot_loaders.py
@@ -120,7 +120,7 @@ class Omniglot(data.Dataset):
 
 def find_classes(root_dir):
     retour = []
-    for root, dirs, files in os.walk(root_dir):
+    for root, _dirs, files in os.walk(root_dir):
         for f in files:
             if f.endswith("png"):
                 r = root.split("/")
@@ -177,10 +177,8 @@ class OmniglotNShot:
                     temp[label] = [img]
 
             self.x = []
-            for (
-                label,
-                imgs,
-            ) in temp.items():  # labels info deserted , each label contains 20imgs
+            # labels info deserted , each label contains 20imgs
+            for imgs in temp.values():
                 self.x.append(np.array(imgs))
 
             # as different class may have different number of imgs
@@ -260,9 +258,9 @@ class OmniglotNShot:
         data_cache = []
 
         # print('preload next 50 caches of batchsz of batch.')
-        for sample in range(10):  # num of episodes
+        for _ in range(10):  # num of episodes
             x_spts, y_spts, x_qrys, y_qrys = [], [], [], []
-            for i in range(self.batchsz):  # one batch means one set
+            for _ in range(self.batchsz):  # one batch means one set
                 x_spt, y_spt, x_qry, y_qry = [], [], [], []
                 selected_cls = np.random.choice(data_pack.shape[0], self.n_way, False)
 

--- a/functorch/examples/maml_regression/evjang.py
+++ b/functorch/examples/maml_regression/evjang.py
@@ -109,7 +109,7 @@ t_y = t_A * torch.sin(t_x + t_b)
 opt.zero_grad()
 
 t_params = params
-for k in range(5):
+for _ in range(5):
     t_f = net(t_x, t_params)
     t_loss = F.l1_loss(t_f, t_y)
 

--- a/functorch/examples/maml_regression/evjang_transforms.py
+++ b/functorch/examples/maml_regression/evjang_transforms.py
@@ -113,7 +113,7 @@ t_y = t_A * torch.sin(t_x + t_b)
 opt.zero_grad()
 
 t_params = params
-for k in range(5):
+for _ in range(5):
     t_f = net(t_params, t_x)
     t_loss = F.l1_loss(t_f, t_y)
 

--- a/functorch/examples/maml_regression/evjang_transforms_module.py
+++ b/functorch/examples/maml_regression/evjang_transforms_module.py
@@ -109,7 +109,7 @@ t_y = t_A * torch.sin(t_x + t_b)
 opt.zero_grad()
 
 t_params = params
-for k in range(5):
+for _ in range(5):
     t_f = net(t_params, t_x)
     t_loss = F.l1_loss(t_f, t_y)
 

--- a/tools/code_analyzer/gen_operators_yaml.py
+++ b/tools/code_analyzer/gen_operators_yaml.py
@@ -477,7 +477,7 @@ def fill_output(output: dict[str, object], options: Namespace) -> None:
     # to True, since it indicates that this operator list came from something
     # other than a traced operator list.
     include_all_non_op_selectives = False
-    for op_name, op_info in operators.items():
+    for op_info in operators.values():
         include_all_non_op_selectives = (
             include_all_non_op_selectives or op_info.include_all_overloads
         )

--- a/tools/experimental/torchfuzz/codegen.py
+++ b/tools/experimental/torchfuzz/codegen.py
@@ -215,7 +215,7 @@ class FuzzTemplate:
         )
 
         if arg_operations:
-            for i, (node_id, spec) in enumerate(arg_operations):
+            for i, (_node_id, spec) in enumerate(arg_operations):
                 arg_name = f"arg_{i}"
 
                 if isinstance(spec, ScalarSpec):

--- a/tools/experimental/torchfuzz/cuda/_codegen.py
+++ b/tools/experimental/torchfuzz/cuda/_codegen.py
@@ -187,7 +187,7 @@ class DTensorFuzzTemplate(FuzzTemplate):
         )
 
         if arg_operations:
-            for i, (node_id, spec) in enumerate(arg_operations):
+            for i, (_node_id, spec) in enumerate(arg_operations):
                 arg_name = f"arg_{i}"
 
                 if isinstance(spec, ScalarSpec):
@@ -379,7 +379,7 @@ class StreamFuzzTemplate(DefaultFuzzTemplate):
         """
         code_lines = super().args_codegen(arg_operations, constant_operations)
         if arg_operations:
-            for i, (node_id, spec) in enumerate(arg_operations):
+            for i, (_node_id, spec) in enumerate(arg_operations):
                 if isinstance(spec, TensorSpec) and spec.dtype in [
                     torch.float32,
                     torch.float64,
@@ -610,7 +610,7 @@ class DTensorFuzzPlacementsTemplate(DTensorFuzzTemplate):
 
         # Args with random placements using dist_tensor API
         if arg_operations:
-            for i, (node_id, spec) in enumerate(arg_operations):
+            for i, (_node_id, spec) in enumerate(arg_operations):
                 if isinstance(spec, TensorSpec):
                     size_str = str(spec.size)
                     dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")
@@ -636,7 +636,7 @@ class DTensorFuzzPlacementsTemplate(DTensorFuzzTemplate):
 
         # Constants (if any) - use same dist_tensor approach
         if constant_operations:
-            for node_id, var_name, spec in constant_operations:
+            for _node_id, var_name, spec in constant_operations:
                 if isinstance(spec, TensorSpec):
                     size_str = str(spec.size)
                     dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")

--- a/tools/experimental/torchfuzz/multi_process_fuzzer.py
+++ b/tools/experimental/torchfuzz/multi_process_fuzzer.py
@@ -586,7 +586,7 @@ def run_until_failure(
                     pbar = None
 
                 # Collect results as they complete
-                for seed, future in future_results:
+                for _seed, future in future_results:
                     result: FuzzerResult = future.get()
 
                     if result.ignored_pattern_idx != -1:

--- a/tools/linter/adapters/gb_registry_linter.py
+++ b/tools/linter/adapters/gb_registry_linter.py
@@ -165,7 +165,7 @@ def _update_registry_with_changes(
     # Collect new entries separately to insert them all at once
     new_entries: list[tuple[str, list[dict[str, Any]]]] = []
 
-    for gb_type, (call, file_path) in calls.items():
+    for gb_type, (call, _file_path) in calls.items():
         if gb_type in latest_entry:
             existing_entry = latest_entry[gb_type]
 
@@ -244,7 +244,7 @@ def check_registry_sync(dynamo_dir: Path, registry_path: Path) -> list[LintMessa
     for gb_type, call_list in all_calls.items():
         if len(call_list) > 1:
             first_call = call_list[0][0]
-            for call, file_path in call_list[1:]:
+            for call, _file_path in call_list[1:]:
                 if (
                     call["context"] != first_call["context"]
                     or call["explanation"] != first_call["explanation"]
@@ -321,7 +321,7 @@ def check_registry_sync(dynamo_dir: Path, registry_path: Path) -> list[LintMessa
     renames: dict[str, str] = {}
     remaining_calls = dict(calls)
 
-    for gb_type, (call, file_path) in calls.items():
+    for gb_type, (call, _file_path) in calls.items():
         if gb_type not in latest_entry:
             for existing_gb_type, existing_entry in latest_entry.items():
                 if (
@@ -335,7 +335,7 @@ def check_registry_sync(dynamo_dir: Path, registry_path: Path) -> list[LintMessa
 
     needs_update = bool(renames)
 
-    for gb_type, (call, file_path) in remaining_calls.items():
+    for gb_type, (call, _file_path) in remaining_calls.items():
         if gb_type in latest_entry:
             existing_entry = latest_entry[gb_type]
 

--- a/tools/stats/check_disabled_tests.py
+++ b/tools/stats/check_disabled_tests.py
@@ -209,7 +209,7 @@ def save_results(
 
     # Log the results
     print(f"The following {len(should_be_enabled_tests)} tests should be re-enabled:")
-    for test_id, stats in should_be_enabled_tests.items():
+    for test_id in should_be_enabled_tests:
         disabled_test_name, name, classname, filename = get_disabled_test_name(test_id)
         print(f"  {disabled_test_name} from {filename}")
 

--- a/torchgen/_autoheuristic/pad_mm/collect_known_mm_shapes.py
+++ b/torchgen/_autoheuristic/pad_mm/collect_known_mm_shapes.py
@@ -202,7 +202,7 @@ def main(output_file="mm_shapes.csv"):
 
     # Convert to desired format and filter dtypes
     csv_rows = []
-    for m, k, n, dtype1, dtype2 in shapes:
+    for m, k, n, dtype1, _dtype2 in shapes:
         # Use the first dtype and convert to string
         if dtype1 in dtype_map:
             dtype_str = dtype_map[dtype1]

--- a/torchgen/_autoheuristic/train_decision.py
+++ b/torchgen/_autoheuristic/train_decision.py
@@ -473,7 +473,7 @@ class AHTrainDecisionTree(AHTrain):
         def add_near_best_configs(df):
             new_rows = []
 
-            for index, row in df.iterrows():
+            for _index, row in df.iterrows():
                 dictionary = json.loads(row["choice2time"])
                 min_value = min(dictionary.values())
 

--- a/torchgen/api/autograd.py
+++ b/torchgen/api/autograd.py
@@ -410,18 +410,18 @@ def gen_foreach_derivativeinfo(
         return ref_diff_info, False
 
     map_refarg2foreacharg, map_name2arg = {}, {}
-    for i, (arg, ref_arg) in enumerate(
-        zip(
-            foreach_function.func.arguments.flat_non_out,
-            function_schema.arguments.flat_non_out,
-        )
+    for arg, ref_arg in zip(
+        foreach_function.func.arguments.flat_non_out,
+        function_schema.arguments.flat_non_out,
     ):
         map_refarg2foreacharg[ref_arg.name] = arg.name
         map_name2arg[arg.name] = arg
 
     all_saved_inputs, all_saved_outputs, all_var_names = [], [], []
     modified_derivative_formulas = []
-    for i, derivative in enumerate(ref_diff_info.derivatives):
+    for derivative in ref_diff_info.derivatives:
+        # The "[i]" here is the foreach loop index in the generated C++, not a
+        # Python binding.
         modified_formula = derivative.formula.replace("grad", "grads[i]").replace(
             "result", "result[i]"
         )

--- a/torchgen/api/autograd.py
+++ b/torchgen/api/autograd.py
@@ -410,18 +410,16 @@ def gen_foreach_derivativeinfo(
         return ref_diff_info, False
 
     map_refarg2foreacharg, map_name2arg = {}, {}
-    for i, (arg, ref_arg) in enumerate(
-        zip(
-            foreach_function.func.arguments.flat_non_out,
-            function_schema.arguments.flat_non_out,
-        )
+    for arg, ref_arg in zip(
+        foreach_function.func.arguments.flat_non_out,
+        function_schema.arguments.flat_non_out,
     ):
         map_refarg2foreacharg[ref_arg.name] = arg.name
         map_name2arg[arg.name] = arg
 
     all_saved_inputs, all_saved_outputs, all_var_names = [], [], []
     modified_derivative_formulas = []
-    for i, derivative in enumerate(ref_diff_info.derivatives):
+    for derivative in ref_diff_info.derivatives:
         modified_formula = derivative.formula.replace("grad", "grads[i]").replace(
             "result", "result[i]"
         )

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2024,7 +2024,7 @@ def gen_per_operator_headers(
         dispatch_namespace = dispatch_key.lower()
         dispatch_names = []
 
-        for name, functions in functions_by_root_name.items():
+        for name in functions_by_root_name:
             grouped_functions = grouped_functions_by_root_name.get(name, [])
             declarations = list(
                 concatMap(

--- a/torchgen/yaml_utils.py
+++ b/torchgen/yaml_utils.py
@@ -16,7 +16,7 @@ YamlDumper = Dumper
 class YamlLoader(Loader):
     def construct_mapping(self, node, deep=False):  # type: ignore[no-untyped-def]
         mapping = []
-        for key_node, value_node in node.value:
+        for key_node, _value_node in node.value:
             key = self.construct_object(key_node, deep=deep)  # type: ignore[no-untyped-call]
             if key in mapping:
                 raise AssertionError(


### PR DESCRIPTION
### Summary

Part of #106571. The **tools/ + torchgen/ + functorch/ + .github/ + .ci/** slice of the B007 (unused loop control variable) cleanup: 23 files.

Most hunks are ruff's own fix — rename the unused loop variable with a leading underscore. Three dict iterations that only use one half of the pair are rewritten as `for v in d.values()` / `for k in d`, since prefixing the unused target there would just trade B007 for `PERF102`/`SIM118`.

In `omniglot_loaders.py` the rewrite also collapses a three-line `for (label, imgs,) in temp.items():` into one line; its trailing comment moves to its own line above the loop so the result stays under the formatter's column limit (a single-line version with the comment attached fails PYFMT).

### Deliberately deferred

Two sites in `tools/autograd` are left for the final slice, because the loop variable is used outside the loop body:

| file | why |
|---|---|
| `gen_variable_type.py` | `edge_off` is a for/else index search, read after the `else` clause |
| `load_derivatives.py` | `defn` is captured by the nested `set_up_derivatives` closure — renaming it produces F821 |

Both need `# noqa: B007`, which `RUF100` rejects while B007 is still in the ignore list, so they have to land in the same PR that turns the code on.

Split out of #189319 (whole tree at once, too wide to review). B007 stays in the `pyproject.toml` ignore list until the final slice, so this is a no-op for CI today.

### Test plan

```
uvx ruff@0.14.4 check tools/ torchgen/ functorch/ .github/ .ci/ docs/ \
    --config=pyproject.toml --select B007 --config "lint.ignore=[]"
# -> only the 2 deferred tools/autograd sites remain
uvx ruff@0.14.4 check <changed files> --config=pyproject.toml            # All checks passed!
uvx ruff@0.14.4 format --check <changed files> --config=pyproject.toml   # 23 files already formatted
python -m py_compile <changed files>
```

cc @Skylion007 (author of #106571)

> Authored with the assistance of an AI coding assistant (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
