### PR TITLE
[BE] Fix B007 unused loop control variables in test/

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
@@ -364,7 +364,7 @@ class TestMemoryLeaks(TestCase):
         size = 50 * 1024 * 1024 // 4
         iterations = 50
 
-        for i in range(iterations):
+        for _i in range(iterations):
             x = torch.empty(size, device="openreg")
             del x
             gc.collect()
@@ -382,11 +382,11 @@ class TestMemoryLeaks(TestCase):
         num_cycles = 10
         allocations_per_cycle = 100
 
-        for cycle in range(num_cycles):
+        for _cycle in range(num_cycles):
             tensors = []
 
             # Allocate many tensors
-            for i in range(allocations_per_cycle):
+            for _i in range(allocations_per_cycle):
                 t = torch.empty(1000, device="openreg")
                 tensors.append(t)
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
@@ -364,7 +364,7 @@ class TestMemoryLeaks(TestCase):
         size = 50 * 1024 * 1024 // 4
         iterations = 50
 
-        for _i in range(iterations):
+        for _ in range(iterations):
             x = torch.empty(size, device="openreg")
             del x
             gc.collect()
@@ -382,11 +382,11 @@ class TestMemoryLeaks(TestCase):
         num_cycles = 10
         allocations_per_cycle = 100
 
-        for _cycle in range(num_cycles):
+        for _ in range(num_cycles):
             tensors = []
 
             # Allocate many tensors
-            for _i in range(allocations_per_cycle):
+            for _ in range(allocations_per_cycle):
                 t = torch.empty(1000, device="openreg")
                 tensors.append(t)
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -217,7 +217,7 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
         with context:
             model(inp).sum()
             state_dict = model.state_dict()
-            for name, dtensor in state_dict.items():
+            for dtensor in state_dict.values():
                 self.assertEqual(dtensor.device.type, "cpu")
 
     @skip_if_lt_x_gpu(2)

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2216,7 +2216,7 @@ class TestFullyShardNDTraining(FSDPTest):
         fully_shard(
             model, mesh=dp_mesh, reshard_after_forward=reshard_non_layer_modules
         )
-        for (name, param), (_, ref_param) in zip(
+        for (_name, param), (_, ref_param) in zip(
             model.named_parameters(), ref_model.named_parameters()
         ):
             full_param = param.full_tensor()

--- a/test/distributed/elastic/test_control_plane.py
+++ b/test/distributed/elastic/test_control_plane.py
@@ -242,7 +242,7 @@ class WorkerServerTest(TestCase):
 
             # Use the counter multiple times to generate metrics
             # Note: Using minimal/no sleep to avoid timing issues
-            for i in range(3):
+            for _i in range(3):
                 with counter.guard():
                     pass  # Minimal work
 

--- a/test/distributed/elastic/test_control_plane.py
+++ b/test/distributed/elastic/test_control_plane.py
@@ -242,7 +242,7 @@ class WorkerServerTest(TestCase):
 
             # Use the counter multiple times to generate metrics
             # Note: Using minimal/no sleep to avoid timing issues
-            for _i in range(3):
+            for _ in range(3):
                 with counter.guard():
                     pass  # Minimal work
 

--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -263,7 +263,7 @@ class DistMatrixOpsTest(DTensorTestBase):
 
         # Find strategies where output is Partial (contracting dim case)
         # Strategy format: [output, bias, mat1, mat2]
-        for strategies, bias_shape in [
+        for strategies, _bias_shape in [
             (strategies_1d, bias_shape_1d),
             (strategies_2d, bias_shape_2d),
         ]:

--- a/test/distributed/tensor/test_strategy_validation.py
+++ b/test/distributed/tensor/test_strategy_validation.py
@@ -752,7 +752,7 @@ class TestCreatePartialInput(TestCase):
         tensor = torch.tensor([-10.0, -1.0, 5.0, 8.0])
         value_range = (tensor.max() - tensor.min()).item()  # 18.0
 
-        for reduce_op, sign in [("min", 1), ("max", -1)]:
+        for reduce_op, _sign in [("min", 1), ("max", -1)]:
             local = _create_partial_input(tensor, Partial(reduce_op), world_size=2)
             r0, r1 = local._local_tensors[0], local._local_tensors[1]
             # The actual offset applied should exceed value_range

--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -1399,7 +1399,7 @@ class Test_StridedShard_Optimizer(DTensorTestBase):
             optim.step()
 
             # Verify parameters still have correct placement after optimizer step
-            for name, param in model.named_parameters():
+            for _name, param in model.named_parameters():
                 self.assertIsInstance(param, DTensor)
                 self.assertEqual(len(param.placements), 2)
 
@@ -1846,7 +1846,7 @@ class TestStridedShardAlltoAll(TestStridedShardCollectiveOpUtils, LocalTensorTes
             mesh_shape,
             tensor_shape,
             src_p,
-            src_tensor_dim,
+            _src_tensor_dim,
             tgt_p,
             tgt_tensor_dim,
             operate_mesh_dim,

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -154,7 +154,7 @@ class TestWithNCCL(DistributedTestBase):
             "avg",
             "default",
         )
-        for i, (output, input) in enumerate(zip(outputs, inputs)):
+        for i, (output, _input) in enumerate(zip(outputs, inputs)):
             if output.completed:
                 raise AssertionError("Expected output.completed to be False")
             expected = sum(self.ranks) / self.world_size * i

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -3027,7 +3027,7 @@ class ReducerTest(TestCase):
         reducer_bat = self._create_reducer(model_bat, batched_grad_copy=True)
         loss_fn = nn.CrossEntropyLoss()
 
-        for _i in range(3):
+        for _ in range(3):
             input = torch.rand([10, 2], dtype=torch.double)
             target = torch.LongTensor([random.randrange(4) for _ in range(10)])
 
@@ -3073,7 +3073,7 @@ class ReducerTest(TestCase):
         )
         loss_fn = nn.CrossEntropyLoss()
 
-        for _i in range(3):
+        for _ in range(3):
             input = torch.rand([10, 2], dtype=torch.double)
             target = torch.LongTensor([random.randrange(4) for _ in range(10)])
 

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -3027,7 +3027,7 @@ class ReducerTest(TestCase):
         reducer_bat = self._create_reducer(model_bat, batched_grad_copy=True)
         loss_fn = nn.CrossEntropyLoss()
 
-        for i in range(3):
+        for _i in range(3):
             input = torch.rand([10, 2], dtype=torch.double)
             target = torch.LongTensor([random.randrange(4) for _ in range(10)])
 
@@ -3073,7 +3073,7 @@ class ReducerTest(TestCase):
         )
         loss_fn = nn.CrossEntropyLoss()
 
-        for i in range(3):
+        for _i in range(3):
             input = torch.rand([10, 2], dtype=torch.double)
             target = torch.LongTensor([random.randrange(4) for _ in range(10)])
 
@@ -3132,7 +3132,7 @@ class ReducerTest(TestCase):
         self.assertIsNone(model_bat.fc3.weight.grad)
 
         # Used parameters should have identical grads
-        for (name_ref, p_ref), (name_bat, p_bat) in zip(
+        for (name_ref, p_ref), (_name_bat, p_bat) in zip(
             model_ref.named_parameters(), model_bat.named_parameters()
         ):
             if p_ref.grad is not None:

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -555,7 +555,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         for idx in range(num_gpus):
             gpu_idx = local_device_ids[idx]
             output_ts.append([])
-            for rank in range(self.world_size):
+            for _rank in range(self.world_size):
                 output_ts[idx].append(torch.tensor([-1]).cuda(gpu_idx))
 
         expected = [[torch.tensor([rank]) for rank in range(self.world_size)]]

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -555,7 +555,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         for idx in range(num_gpus):
             gpu_idx = local_device_ids[idx]
             output_ts.append([])
-            for _rank in range(self.world_size):
+            for _ in range(self.world_size):
                 output_ts[idx].append(torch.tensor([-1]).cuda(gpu_idx))
 
         expected = [[torch.tensor([rank]) for rank in range(self.world_size)]]

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -594,7 +594,7 @@ class TestDataParallel(TestCase):
             opt_single.step()
             opt_dp.step()
 
-            for (n1, p1), (n2, p2) in zip(
+            for (n1, p1), (_n2, p2) in zip(
                 model_single.named_parameters(), model_dp_base.named_parameters()
             ):
                 self.assertEqual(p1.grad.shape, p2.grad.shape)
@@ -604,7 +604,7 @@ class TestDataParallel(TestCase):
                     lambda msg: f"{msg}\nEpoch {epoch}: gradients differ for {n1}",
                 )
 
-            for (n1, p1), (n2, p2) in zip(
+            for (n1, p1), (_n2, p2) in zip(
                 model_single.named_parameters(), model_dp_base.named_parameters()
             ):
                 self.assertTrue(
@@ -671,7 +671,7 @@ class TestDataParallel(TestCase):
             opt_single.step()
             opt_dp.step()
 
-            for (n1, p1), (n2, p2) in zip(
+            for (n1, p1), (_n2, p2) in zip(
                 model_single.named_parameters(), model_dp_base.named_parameters()
             ):
                 self.assertEqual(p1.grad.shape, p2.grad.shape)
@@ -681,7 +681,7 @@ class TestDataParallel(TestCase):
                     lambda msg: f"{msg}\nEpoch {epoch}: gradients differ for {n1}",
                 )
 
-            for (n1, p1), (n2, p2) in zip(
+            for (n1, p1), (_n2, p2) in zip(
                 model_single.named_parameters(), model_dp_base.named_parameters()
             ):
                 self.assertTrue(

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -2647,7 +2647,7 @@ class TestBitsetAncestors(TestCase):
 
         g = fx.Graph()
         nodes = [g.placeholder("x")]
-        for i in range(99):
+        for _i in range(99):
             nodes.append(g.call_function(torch.relu, (nodes[-1],)))
         g.output(nodes[-1])
 

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -2647,7 +2647,7 @@ class TestBitsetAncestors(TestCase):
 
         g = fx.Graph()
         nodes = [g.placeholder("x")]
-        for _i in range(99):
+        for _ in range(99):
             nodes.append(g.call_function(torch.relu, (nodes[-1],)))
         g.output(nodes[-1])
 

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1446,7 +1446,7 @@ class SymmMemCollectiveTest(MultiProcContinuousTest):
         self._init_process()
         group_name = dist.group.WORLD.group_name
 
-        for dtype, size_bytes, align_bytes, copy, offset in itertools.product(
+        for dtype, size_bytes, _align_bytes, copy, offset in itertools.product(
             [torch.float, torch.bfloat16],
             [4, 8192, 8196],
             [

--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -1569,13 +1569,13 @@ from user code:
             """
             torch.manual_seed(seed)
             getattr(torch, GPU_TYPE).manual_seed(seed)
-            for name, param in module.named_parameters():
+            for _name, param in module.named_parameters():
                 if param.requires_grad:
                     local_param = (
                         param.to_local() if isinstance(param, DTensor) else param
                     )
                     local_param.data.normal_(mean=0.0, std=0.02)
-            for name, buf in module.named_buffers():
+            for _name, buf in module.named_buffers():
                 local_buf = buf.to_local() if isinstance(buf, DTensor) else buf
                 local_buf.data.normal_(mean=0.0, std=0.02)
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1308,7 +1308,7 @@ from user code:
     def test_graph_break_in_loop(self, records):
         @torch.compile(backend="eager")
         def fn(x):
-            for i in range(2):
+            for _i in range(2):
                 torch._dynamo.graph_break()
             return x + 1
 
@@ -1350,7 +1350,7 @@ User code traceback:
 
         @torch.compile(backend="eager")
         def gn(x):
-            for i in range(2):
+            for _i in range(2):
                 if x.sum() > 0:
                     x = x + 1
                 else:
@@ -1403,7 +1403,7 @@ User code traceback:
     @make_logging_test(graph_breaks=True)
     def test_skip_frame_in_loop_message(self, records):
         def fn(x):
-            for i in range(2):
+            for _i in range(2):
                 with GenericCtxMgr():
                     if x.sum() > 0:
                         x = x + 1
@@ -2590,7 +2590,7 @@ User code traceback:
         global f1, f2, f3
 
         def f1(x):
-            for i in range(2):
+            for _i in range(2):
                 with GenericCtxMgr():
                     if x.sum() > 0:
                         x = x + 1
@@ -2884,7 +2884,7 @@ NOTE: the most recent `torch.compile` tracing attempt might not be where you app
     def test_stack_variable_source_attribution(self, records):
         @torch.compile(backend="eager")
         def fn(x):
-            for i in range(2):
+            for _i in range(2):
                 torch._dynamo.graph_break()
             return x + 1
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1308,7 +1308,7 @@ from user code:
     def test_graph_break_in_loop(self, records):
         @torch.compile(backend="eager")
         def fn(x):
-            for _i in range(2):
+            for _ in range(2):
                 torch._dynamo.graph_break()
             return x + 1
 
@@ -1350,7 +1350,7 @@ User code traceback:
 
         @torch.compile(backend="eager")
         def gn(x):
-            for _i in range(2):
+            for _ in range(2):
                 if x.sum() > 0:
                     x = x + 1
                 else:
@@ -1403,7 +1403,7 @@ User code traceback:
     @make_logging_test(graph_breaks=True)
     def test_skip_frame_in_loop_message(self, records):
         def fn(x):
-            for _i in range(2):
+            for _ in range(2):
                 with GenericCtxMgr():
                     if x.sum() > 0:
                         x = x + 1
@@ -2590,7 +2590,7 @@ User code traceback:
         global f1, f2, f3
 
         def f1(x):
-            for _i in range(2):
+            for _ in range(2):
                 with GenericCtxMgr():
                     if x.sum() > 0:
                         x = x + 1
@@ -2884,7 +2884,7 @@ NOTE: the most recent `torch.compile` tracing attempt might not be where you app
     def test_stack_variable_source_attribution(self, records):
         @torch.compile(backend="eager")
         def fn(x):
-            for _i in range(2):
+            for _ in range(2):
                 torch._dynamo.graph_break()
             return x + 1
 
@@ -2922,7 +2922,7 @@ graph break in loop
 Stack variable source attribution:
   RangeIteratorVariable() originated from:
   File "test_error_messages.py", line N
-                for i in range(2):
+                for _ in range(2):
                          ~~~~~^^^
 
 User code traceback:

--- a/test/dynamo/test_generator.py
+++ b/test/dynamo/test_generator.py
@@ -681,7 +681,7 @@ class GraphModule(torch.nn.Module):
 
         def fn(t):
             s = 0
-            for b, p in itertools.product(whoo(t), itertools.permutations((4, 5))):
+            for b, _p in itertools.product(whoo(t), itertools.permutations((4, 5))):
                 s += b
             return s
 

--- a/test/dynamo/test_polyfills.py
+++ b/test/dynamo/test_polyfills.py
@@ -203,7 +203,7 @@ class TestGroupTensorsByDeviceAndDtype(TestCase):
             # Perform some tensor computation to ensure the frame is not skipped
             # Sum up results for each dtype group
             total = torch.tensor(0.0)
-            for grouped_tensors, indices in grouped.values():
+            for grouped_tensors, _indices in grouped.values():
                 tensor_list, grad_list = grouped_tensors
                 for t, g in zip(tensor_list, grad_list):
                     if t is not None and g is not None:

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -77,7 +77,7 @@ def _check_compile_cudagraph_backend(test_case, fn, args):
     # 3 and beyond) do graph replay
     # So we need to get to iteration 3 to test all ways of running.
     outputs = []
-    for i in range(3):
+    for _i in range(3):
         with check_cudagraphs_not_skipped(test_case):
             torch.compiler.cudagraph_mark_step_begin()
             outputs.append(

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -77,7 +77,7 @@ def _check_compile_cudagraph_backend(test_case, fn, args):
     # 3 and beyond) do graph replay
     # So we need to get to iteration 3 to test all ways of running.
     outputs = []
-    for _i in range(3):
+    for _ in range(3):
         with check_cudagraphs_not_skipped(test_case):
             torch.compiler.cudagraph_mark_step_begin()
             outputs.append(

--- a/test/functorch/test_control_flow_cuda_initialization.py
+++ b/test/functorch/test_control_flow_cuda_initialization.py
@@ -34,8 +34,8 @@ class TestControlFlowInCUDAGraphInitialization(TestCase):
 
         outputs = []
 
-        for p in [pred, torch.logical_not(pred)]:
-            for i in range(3):
+        for _p in [pred, torch.logical_not(pred)]:
+            for _i in range(3):
                 torch.compiler.cudagraph_mark_step_begin()
                 outputs.append(f_compiled(pred, *other_args).clone())
 

--- a/test/functorch/test_control_flow_cuda_initialization.py
+++ b/test/functorch/test_control_flow_cuda_initialization.py
@@ -34,8 +34,8 @@ class TestControlFlowInCUDAGraphInitialization(TestCase):
 
         outputs = []
 
-        for _p in [pred, torch.logical_not(pred)]:
-            for _i in range(3):
+        for _ in [pred, torch.logical_not(pred)]:
+            for _ in range(3):
                 torch.compiler.cudagraph_mark_step_begin()
                 outputs.append(f_compiled(pred, *other_args).clone())
 

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1397,7 +1397,7 @@ class TestOperators(TestCase):
                 is_batch_norm_and_training = is_batch_norm_training(
                     op.name, kwarg_values
                 )
-                for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                for _loop_out, _batched_out in get_fallback_and_vmap_exhaustive(
                     fn,
                     args,
                     {},
@@ -1515,7 +1515,7 @@ class TestOperators(TestCase):
                 is_batch_norm_and_training = is_batch_norm_training(
                     op.name, sample.kwargs
                 )
-                for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                for _loop_out, _batched_out in get_fallback_and_vmap_exhaustive(
                     fn,
                     args,
                     {},
@@ -1527,7 +1527,7 @@ class TestOperators(TestCase):
                     fn, args = get_vjp_fn_and_args_with_cotangents(
                         a_op, sample, cotangents
                     )
-                    for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                    for _loop_out, _batched_out in get_fallback_and_vmap_exhaustive(
                         fn,
                         args,
                         {},
@@ -2112,7 +2112,7 @@ class TestOperators(TestCase):
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
             target_options = self._make_extremal_inputs(shape, device)
-            for input, target, kwargs in self._arg_and_kwarg_options(
+            for input, target, _kwargs in self._arg_and_kwarg_options(
                 (input_options, target_options), kwargs_options
             ):
                 result = torch.nn.functional.l1_loss(input, target)
@@ -2128,7 +2128,7 @@ class TestOperators(TestCase):
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
             target_options = self._make_extremal_inputs(shape, device)
-            for input, target, kwargs in self._arg_and_kwarg_options(
+            for input, target, _kwargs in self._arg_and_kwarg_options(
                 (input_options, target_options), kwargs_options
             ):
                 result = torch.nn.functional.mse_loss(input, target)
@@ -2143,7 +2143,7 @@ class TestOperators(TestCase):
         kwargs_options = ({"dim": 1}, {})
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
-            for input, kwargs in self._arg_and_kwarg_options(
+            for input, _kwargs in self._arg_and_kwarg_options(
                 (input_options,), kwargs_options
             ):
                 result = torch.nn.functional.softmax(input)
@@ -2158,7 +2158,7 @@ class TestOperators(TestCase):
         kwargs_options = ({"dim": 1}, {})
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
-            for input, kwargs in self._arg_and_kwarg_options(
+            for input, _kwargs in self._arg_and_kwarg_options(
                 (input_options,), kwargs_options
             ):
                 result = torch.nn.functional.log_softmax(input)

--- a/test/inductor/test_auto_functionalize.py
+++ b/test/inductor/test_auto_functionalize.py
@@ -1947,7 +1947,7 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
             data = torch.randn((10, 10), dtype=torch.float32)
             result_eager = f_dtype_view(cache.clone(), data)
 
-            for mode_name, mode_ctx in [
+            for _mode_name, mode_ctx in [
                 ("inference", torch.inference_mode()),
                 ("no_grad", torch.no_grad()),
             ]:

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2769,7 +2769,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
                 ("compiled", out_compiled, "compiled mode"),
             ]
 
-            for mode_name, output, description in test_cases:
+            for _mode_name, output, description in test_cases:
                 loss = output.sum()
                 grads = torch.autograd.grad(loss, (query, key, value))
 

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -454,7 +454,7 @@ class TestGpuWrapper(InductorTestCase):
                 "graph_partition": False,
             }
         )(test_fn)
-        for i in range(3):
+        for _i in range(3):
             res = comp(x, s)
             self.assertEqual(res, expected)
 

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -454,7 +454,7 @@ class TestGpuWrapper(InductorTestCase):
                 "graph_partition": False,
             }
         )(test_fn)
-        for _i in range(3):
+        for _ in range(3):
             res = comp(x, s)
             self.assertEqual(res, expected)
 

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -513,7 +513,7 @@ class TestOperatorReorderForPeakMemory(TestCase):
             # Look for patterns like "cond" or "cond_1" in the generated code
             # along with their buffer sizes
             lines = code.split("\n")
-            for i, line in enumerate(lines):
+            for _i, line in enumerate(lines):
                 # Match true_graph buffer allocations which indicate cond execution
                 match = re.search(r"true_graph_(\d+)_buf0\s*=.*\((\d+),", line)
                 if match:

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -900,7 +900,7 @@ class TestDumpLaunchTensors(TestCase):
             kernel_bases = {}
             verified_tensor_load = False
 
-            for root, dirs, files in os.walk(cache_dir()):
+            for root, dirs, _files in os.walk(cache_dir()):
                 for d in dirs:
                     if "_run_" in d:
                         full_path = os.path.join(root, d)

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -70,14 +70,14 @@ class TestUtils(TestCase):
         schema = result._opoverload._schema
         g = torch.tensor([11, 2])
         found = False
-        for arg, val in torch._library.utils.zip_schema(schema, [], {"x": g}):
+        for arg, _val in torch._library.utils.zip_schema(schema, [], {"x": g}):
             if arg.name == "x":
                 found = True
 
         self.assertTrue(found)
 
         found = False
-        for arg, val in torch._library.utils.zip_schema(schema, [g], {}):
+        for arg, _val in torch._library.utils.zip_schema(schema, [g], {}):
             if arg.name == "x":
                 found = True
         self.assertTrue(found)

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -2488,7 +2488,7 @@ class TestFrozenOptimizations(JitTestCase):
         use_tracing = [True, False]
         bn_running_stats = [True, False]
 
-        for modules, tracing, track_stats in product(
+        for modules, tracing, _track_stats in product(
             module_pairs, use_tracing, bn_running_stats
         ):
 

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -561,7 +561,7 @@ class TestConvolutionNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_thnn_conv_strided_padded_dilated(self):
-        for convfn, dims, transposed in (
+        for convfn, dims, _transposed in (
             (torch.nn.functional.conv2d, 2, False),
             (torch.nn.functional.conv_transpose2d, 2, True),
             (torch.nn.functional.conv3d, 3, False),
@@ -1273,7 +1273,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @onlyAccelerator
     @skipMPS
     def test_thnn_conv_strided_padded_dilated(self, device):
-        for convfn, dims, transposed in (
+        for convfn, dims, _transposed in (
             (torch.nn.functional.conv2d, 2, False),
             (torch.nn.functional.conv_transpose2d, 2, True),
             (torch.nn.functional.conv3d, 3, False),

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12518,7 +12518,7 @@ get_out().sum().backward()
             barrier.wait()
             return weakref.ref(tensor.grad)
 
-        for i in range(NUM_ITERS):
+        for _i in range(NUM_ITERS):
             tensor = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
             (tensor**2).sum().backward()
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12518,7 +12518,7 @@ get_out().sum().backward()
             barrier.wait()
             return weakref.ref(tensor.grad)
 
-        for _i in range(NUM_ITERS):
+        for _ in range(NUM_ITERS):
             tensor = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
             (tensor**2).sum().backward()
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -9119,7 +9119,7 @@ class TestMemPool(TestCase):
         # Generate trace entries
         with torch.cuda.use_mem_pool(pool):
             tensors = []
-            for i in range(1000):
+            for _i in range(1000):
                 tensors.append(torch.randn(1024, device="cuda"))
             del tensors
 
@@ -9371,7 +9371,7 @@ class TestMemPool(TestCase):
         tensor_sizes = [24 * 1024 * 1024, 32 * 1024 * 1024]
         alloc_cases = []
         case_no = 0
-        for idx in range(3):
+        for _idx in range(3):
             for stream_idx, stream in enumerate([first_stream, second_stream]):
                 # for second stream in reverse order
                 reverse_order = stream_idx % 2 == 1

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -9119,7 +9119,7 @@ class TestMemPool(TestCase):
         # Generate trace entries
         with torch.cuda.use_mem_pool(pool):
             tensors = []
-            for _i in range(1000):
+            for _ in range(1000):
                 tensors.append(torch.randn(1024, device="cuda"))
             del tensors
 
@@ -9371,7 +9371,7 @@ class TestMemPool(TestCase):
         tensor_sizes = [24 * 1024 * 1024, 32 * 1024 * 1024]
         alloc_cases = []
         case_no = 0
-        for _idx in range(3):
+        for _ in range(3):
             for stream_idx, stream in enumerate([first_stream, second_stream]):
                 # for second stream in reverse order
                 reverse_order = stream_idx % 2 == 1

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4817,7 +4817,7 @@ with warnings.catch_warnings(record=True) as w:
         calls = ["decorator", "function"]
         device_types_options = [("cpu", "cuda"), "cpu", None]
 
-        for mode, call, device_types in itertools.product(
+        for mode, call, _device_types in itertools.product(
             modes, calls, device_types_options
         ):
             with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -255,7 +255,7 @@ class TestFlopCounter(TestCase):
         weight = torch.randn(1, 1, 1, 1, requires_grad=True)
         assert_equivalence(lambda: F.conv2d(x, weight).sum().backward(), 8)
 
-        for in_channels, out_channels, groups in [
+        for in_channels, out_channels, _groups in [
             (1, 1, 1),
             (1, 3, 1),
             (3, 1, 1),

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2543,7 +2543,7 @@ class TestOptimRenewed(TestCase):
             # Simulate bf16 storage: after each ref step, quantize states to
             # bf16 and back so the reference matches the mixed-precision kernel.
             tracker = TensorTracker()
-            for i in range(7):
+            for _i in range(7):
                 ref_optim.step()
                 bf16_optim.step()
                 for p in params:
@@ -2561,7 +2561,7 @@ class TestOptimRenewed(TestCase):
                         tracker.add(max_exp_avg_sq_bf16)
                         d["max_exp_avg_sq"] = max_exp_avg_sq_bf16.to(torch.float32)
 
-                for e, pc in enumerate(params_c):
+                for _e, pc in enumerate(params_c):
                     tracker.pop_check_set(pc, self)
                     tracker.pop_check_set(pc.grad, self)
 

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2543,7 +2543,7 @@ class TestOptimRenewed(TestCase):
             # Simulate bf16 storage: after each ref step, quantize states to
             # bf16 and back so the reference matches the mixed-precision kernel.
             tracker = TensorTracker()
-            for _i in range(7):
+            for _ in range(7):
                 ref_optim.step()
                 bf16_optim.step()
                 for p in params:


### PR DESCRIPTION
### Summary

Part of #106571. The **test/** slice of the B007 (unused loop control variable) cleanup: 33 files.

Most hunks are ruff's own fix — rename the unused loop variable with a leading underscore. One dict iteration that only uses the value is rewritten as `for dtensor in state_dict.values()`, since prefixing the unused key would just trade B007 for `PERF102`.

### Deliberately deferred

Five files are left for the final slice, for two different reasons:

| file | why |
|---|---|
| `test/dynamo/test_recompiles.py` | `key` is read after the loop, so it needs `# noqa: B007` — which `RUF100` rejects while B007 is still ignored |
| `test/test_mps.py` | same, and the loop there has a latent indentation bug worth its own fix (only the last `itertools.product` combination is exercised) |
| `test/test_datapipe.py`, `test/test_sparse_csr.py`, `test/quantization/fx/test_quantize_fx.py` | pre-existing formatting that `ruff format` wants to rewrite; touching them would drag an unrelated reformat into this PR, so they get a `per-file-ignores` entry when B007 is turned on |

Split out of #189319 (whole tree at once, too wide to review). B007 stays in the `pyproject.toml` ignore list until the final slice, so this is a no-op for CI today.

### Test plan

```
uvx ruff@0.14.4 check <changed files> --config=pyproject.toml            # All checks passed!
uvx ruff@0.14.4 format --check <changed files> --config=pyproject.toml   # 33 files already formatted
python -m py_compile <changed files>
```

Renaming an unused binding cannot change behavior, and ruff's F821 pass over the touched files confirms no rename broke an existing reference.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @Skylion007 (author of #106571)

> Authored with the assistance of an AI coding assistant (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
