### PR TITLE
[inductor][ROCm] Flush the LLC, not just L2, when autotuning

### DIFF
--- a/test/inductor/test_benchmarking.py
+++ b/test/inductor/test_benchmarking.py
@@ -571,6 +571,65 @@ class TestBenchmarker(TestCase):
         "hip_value, expected_buffer_size_bytes",
         ((None, 1024), ("mock-hip", 256 * 1024 * 1024)),
     )
+    def test_inductor_benchmarker_flushes_triton_cache_size_on_hip(
+        self, hip_value, expected_buffer_size_bytes, device=GPU_TYPE
+    ):
+        benchmarker = InductorBenchmarker()
+        benchmarker.__dict__["L2_cache_size"] = 1024
+        _, _callable = self.make_params(device, size=16)
+
+        captured_buffer_lengths = []
+        original_empty = torch.empty
+
+        def empty_spy(*args, **kwargs):
+            captured_buffer_lengths.append(args[0])
+            return original_empty(*args, **kwargs)
+
+        with patch.object(torch.version, "hip", hip_value):
+            with patch(
+                "torch._inductor.runtime.benchmarking.torch.empty",
+                side_effect=empty_spy,
+            ):
+                timing = benchmarker.benchmark_gpu(
+                    _callable,
+                    estimation_iters=1,
+                    memory_warmup_iters=0,
+                    benchmark_iters=1,
+                    is_vetted_benchmarking=True,
+                )
+
+        self.assertGreater(timing, 0)
+        self.assertEqual(len(captured_buffer_lengths), 1)
+        self.assertEqual(captured_buffer_lengths[0], expected_buffer_size_bytes // 4)
+
+    @parametrize("hip_value", (None, "mock-hip"))
+    def test_inductor_benchmarker_unknown_device_cache_size(self, hip_value):
+        """A device reporting no cache size is assumed to be flush-sized."""
+        from torch._inductor.runtime import benchmarking as _bench
+
+        class FakeDeviceInterface:
+            def current_device(self):
+                return 0
+
+            def get_device_properties(self, device):
+                return object()  # exposes neither cache-size attribute
+
+        benchmarker = InductorBenchmarker()
+        with (
+            patch.object(
+                _bench, "get_interface_for_device", return_value=FakeDeviceInterface()
+            ),
+            patch.object(torch.version, "hip", hip_value),
+        ):
+            flush_size = benchmarker.get_cache_flush_size("cuda")
+            self.assertIsNone(benchmarker.get_device_cache_size("cuda"))
+            self.assertEqual(flush_size, 256 * 1024 * 1024)
+
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    @parametrize(
+        "hip_value, expected_buffer_size_bytes",
+        ((None, 1024), ("mock-hip", 256 * 1024 * 1024)),
+    )
     def test_torch_profiler_benchmarker_reuses_inductor_helpers(
         self, hip_value, expected_buffer_size_bytes, device=GPU_TYPE
     ):

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -24,6 +24,8 @@ _CALLABLE_PROFILE_EVENT_NAME = "_CALLABLE"
 
 
 MILLISECONDS_PER_SECOND = 1000
+# Buffer size triton.testing.do_bench zeroes between iterations to evict inputs.
+_TRITON_CACHE_FLUSH_SIZE = 256 * 1024 * 1024
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -564,14 +566,18 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
         self._in_cudagraph_benchmark = False
 
     @cached_property
-    def L2_cache_size(self: Self) -> int:
+    def L2_cache_size(self: Self) -> int | None:
         """Get the L2 cache size, in bytes, of the current device."""
         return self.get_device_cache_size()
 
     def get_device_cache_size(
         self: Self, device_type: str | torch.device | None = None
-    ) -> int:
-        """Get the L2/global cache size, in bytes, of the current device."""
+    ) -> int | None:
+        """Get the L2/global cache size, in bytes, of the current device.
+
+        None if the device reports no cache size, so that callers can tell
+        "unknown" apart from a real size.
+        """
         if "L2_cache_size" in self.__dict__:
             return self.__dict__["L2_cache_size"]
 
@@ -583,7 +589,23 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
             cache_size = getattr(props, attr, None)
             if cache_size:
                 return cache_size
-        return 256 * 1024 * 1024
+        return None
+
+    def get_cache_flush_size(
+        self: Self, device_type: str | torch.device | None = None
+    ) -> int:
+        """Get the size, in bytes, of the buffer zeroed between timed iterations.
+
+        The device cache size, except on ROCm: hipDeviceProp reports only the
+        per-XCD L2 (4 MB on gfx942), not the last-level cache behind it (256 MB
+        on MI300X/MI350X), so an L2-sized flush leaves the input cached and
+        autotuning ranks configs by their cache-warm times. Use Triton's flush
+        size there, but never shrink below what the device does report.
+        """
+        cache_size = self.get_device_cache_size(device_type)
+        if torch.version.hip:
+            return max(_TRITON_CACHE_FLUSH_SIZE, cache_size or 0)
+        return _TRITON_CACHE_FLUSH_SIZE if cache_size is None else cache_size
 
     def get_event_pairs(
         self: Self, iters: int, device_type: str | torch.device | None = None
@@ -653,8 +675,9 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
         Keyword Arguments:
         - estimation_iters: Optionally, the number of iterations to run `_callable`
         during runtime estimation.
-        - memory_warmup_iters: Optionally, the number of iterations to flush the L2
-        cache before starting benchmarking.
+        - memory_warmup_iters: Optionally, the number of times to zero the cache
+        flush buffer, to bring the cache to a steady state, before starting
+        benchmarking.
         - benchmark_iters: Optionally, the number of iterations to run `_callable`
         during the benchmarking.
         - max_benchmark_duration: Optionally, the maximum duration of the benchmarking,
@@ -714,7 +737,7 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
 
         # see https://github.com/triton-lang/triton/pull/840 for why `dtype=torch.int`
         buffer = torch.empty(
-            self.get_device_cache_size(device_type) // 4,
+            self.get_cache_flush_size(device_type) // 4,
             dtype=torch.int,
             device=device_type,
         )
@@ -835,16 +858,9 @@ class TorchProfilerBenchmarker(InductorBenchmarker):  # noqa: docstring_linter
         _callable()
         device_interface.synchronize()
 
-        # Keep Triton's 256 MB cache flush on ROCm. On other backends, reuse
-        # the shared L2-sized flush from InductorBenchmarker.
         # see https://github.com/triton-lang/triton/pull/840 for why `dtype=torch.int`
-        if torch.version.hip:
-            buffer_size_bytes = 256 * 1024 * 1024
-        else:
-            buffer_size_bytes = self.get_device_cache_size(device_type)
-        buffer = torch.empty(
-            buffer_size_bytes // 4, dtype=torch.int, device=device_type
-        )
+        flush_size = self.get_cache_flush_size(device_type)
+        buffer = torch.empty(flush_size // 4, dtype=torch.int, device=device_type)
         buffer.zero_()
 
         # Estimation phase with separate event pairs — also serves as warmup.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #192159

Autotuning times each candidate with a cache flush between iterations:
`benchmark_gpu` zeroes a buffer sized by `get_device_cache_size()` so the input
is evicted and every iteration measures a cold kernel. Sizing that buffer to the
device's exact reported cache rather than Triton's flat 256 MB was deliberate
(https://github.com/pytorch/pytorch/pull/133058) and is the right principle, but
it assumes the reported size is the last-level cache. On MI300X it is not: the
hierarchy is a 4 MB L2 per XCD, then a 256 MB last-level cache in front of HBM,
and hipDeviceProp exposes only the per-XCD L2. So the flush comes out 64x too
small, zeroing 4 MB evicts nothing from a 256 MB cache, and every candidate is
timed reading out of cache instead of HBM -- exactly the regime where
memory-bound configs are indistinguishable.

So autotune ranks by noise. For layer_norm fwd fp32 M=4096 N=4096, configs
(XBLOCK=1, R0_BLOCK=4096, warps=4), (1, 2048, 2) and (1, 2048, 8) score
50.7 / 51.7 / 51.1 us against true times of 90.9 / 54.7 / 64.5 us: a 1.64x
spread collapses to 2.6% and the worst config ranks first.

The fix is to flush 256 MB on ROCm instead of the 4 MB the device reports. New
`get_cache_flush_size()` owns that rule -- on ROCm the larger of Triton's 256 MB
and whatever the device reports, elsewhere exactly the device cache size -- and
both `benchmark_gpu` implementations call it, replacing the inline ROCm case
`TorchProfilerBenchmarker` already carried
(https://github.com/pytorch/pytorch/pull/175097). `get_device_cache_size()` is
no longer overloaded to mean "flush size" and returns None when the device
reports no cache. Non-ROCm is unchanged by construction. The gate is arch-wide
because no arch exposes a queryable LLC size and Triton's AMD backend flushes
256 MB on every one, so matching it keeps all three benchmarkers ranking alike.

This costs ROCm compile time: one `zero_()` goes 4.2 -> 55.7 us and
`benchmark_gpu` zeroes 110-210 times per candidate. Five bf16 matmuls under
max-autotune-no-cudagraphs, 6 interleaved separate-process rounds per arm:
6.89 s base against 7.77 s, +12.8% over 74 benchmarked configs, disjoint
distributions.

tritonbench on a perf_determinism-locked MI300X, median of interleaved
separate-process rounds per arm with a fresh inductor cache each. layer_norm fwd
fp32 M=4096, 30 shapes, 5 rounds per arm:

    N       base us   new us   ratio
    1536       80.8     26.0    3.11
    2048       83.8     28.0    2.99
    2560       83.6     36.7    2.28
    3072       83.6     39.3    2.13
    3584       90.7     43.7    2.07
    4608      100.1     64.8    1.54

Geomean 1.221 over all 30, and 1.006 over the 19 at N>=6656 where the input no
longer fits the LLC. Selection also stops being bimodal: base spreads >10%
run-to-run on 9 of 30 shapes against 3 here. Counters put traffic within 6%
across configs whose latency spans 3.1x, so the lever is achieved bandwidth, not
bytes moved. Scope checks: rms_norm +1.6% geomean over 6 shapes (H=4096 +16.5%,
H=8192 +13.5%), softmax fp16 neutral at 1.003 over 98.

Regressions, each deterministic per shape:

    op          shape      delta   cause
    rms_norm    H=1024    -11.9%   selection swing between configs 15% apart
    rms_norm    H=2048     -5.5%   genuinely slower selected config
    layer_norm  N=5120     -3.6%   base bimodal, this arm deterministic at 74.3
    softmax     scattered   +-8%   no direction, coordinate-descent search paths

Both rms_norm shapes are sub-20 us kernels whose 16 MB footprint sits far inside
the LLC, the regime where an LLC-sized flush most changes what "cold" means. All
ratios are raw; the eager control itself moves up to 5% at the smallest shapes,
so sub-1% readings are not worth interpreting.

Follow-up: `return_mode="min"` scores by the fastest of ~100 timed iterations,
which under this flush is a first-iteration transient. The 100 warmup passes do
not remove that transient -- they make it reach every candidate, which is what
keeps the comparison fair; cutting them to 10 denied it to whichever candidate
runs first and mis-ranked. Scoring with the median would be position-independent
by construction, allow a much shorter warmup, recover most of the +12.8%, and
align with `TritonBenchmarker`, which already uses median. It changes semantics
for every backend including CUDA, so it needs separate validation.

Authored with the assistance of an AI coding agent.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben