### PR TITLE
[cuda][graphs] Global lifecycle hooks for capture start/end and replay, plus a per-graph capture-start hook

### DIFF
--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -120,9 +120,9 @@
 Register callbacks that fire at each point in any CUDA graph's lifecycle -- capture
 start, capture end, instantiate, each replay, and destroy -- for example, a profiler
 observing graph lifecycle without the graph code carrying any consumer knowledge, and
-including graphs the consumer did not build. Registering a hook is the opt-in; with none
-registered they are no-ops. Each has a per-graph counterpart on
-{class}`torch.cuda.CUDAGraph`. Live in `torch.cuda.graphs`.
+including graphs the consumer did not build. Registering a hook is the opt-in and the whole
+API -- the graph fires them; with none registered they are no-ops. Each has a per-graph
+counterpart on {class}`torch.cuda.CUDAGraph`. Live in `torch.cuda.graphs`.
 
 ```{eval-rst}
 .. currentmodule:: torch.cuda.graphs
@@ -131,18 +131,11 @@ registered they are no-ops. Each has a per-graph counterpart on
     :nosignatures:
 
     register_graph_capture_start_hook
-    run_graph_capture_start_hooks
     register_graph_capture_end_hook
-    run_graph_capture_end_hooks
     register_graph_instantiate_hook
-    run_graph_instantiate_hooks
     register_graph_replay_start_hook
-    run_graph_replay_start_hooks
     register_graph_replay_end_hook
-    run_graph_replay_end_hooks
     register_graph_destroy_hook
-    run_graph_destroy_hooks
-    graph_destroy_hooks_active
 
 .. currentmodule:: torch.cuda
 ```

--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -117,10 +117,12 @@
 
 ### CUDA graph lifecycle hooks
 
-Register callbacks that fire when any CUDA graph is instantiated or destroyed --
-for example, a profiler observing graph lifecycle without the graph code carrying
-any consumer knowledge. Registering a hook is the opt-in; with none registered
-both are no-ops. Live in `torch.cuda.graphs`.
+Register callbacks that fire at each point in any CUDA graph's lifecycle -- capture
+start, capture end, instantiate, each replay, and destroy -- for example, a profiler
+observing graph lifecycle without the graph code carrying any consumer knowledge, and
+including graphs the consumer did not build. Registering a hook is the opt-in; with none
+registered they are no-ops. Each has a per-graph counterpart on
+{class}`torch.cuda.CUDAGraph`. Live in `torch.cuda.graphs`.
 
 ```{eval-rst}
 .. currentmodule:: torch.cuda.graphs
@@ -128,8 +130,16 @@ both are no-ops. Live in `torch.cuda.graphs`.
     :toctree: generated
     :nosignatures:
 
+    register_graph_capture_start_hook
+    run_graph_capture_start_hooks
+    register_graph_capture_end_hook
+    run_graph_capture_end_hooks
     register_graph_instantiate_hook
     run_graph_instantiate_hooks
+    register_graph_replay_start_hook
+    run_graph_replay_start_hooks
+    register_graph_replay_end_hook
+    run_graph_replay_end_hooks
     register_graph_destroy_hook
     run_graph_destroy_hooks
     graph_destroy_hooks_active

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -977,8 +977,8 @@ class TestIsAvailable(TestCase):
 
 
 # Host-side test of the graph-instantiate hook registry: consumers register hooks that a
-# CUDAGraph fans out to via run_graph_instantiate_hooks at the end of instantiate(). The
-# registry just passes the graph through, so a sentinel stands in for it. No CUDA needed.
+# CUDAGraph fans out to at the end of instantiate(). The registry just passes the graph
+# through, so a sentinel stands in for it. No CUDA needed.
 class TestGraphInstantiateHooks(TestCase):
     def tearDown(self):
         import torch.cuda.graphs as cg
@@ -986,16 +986,22 @@ class TestGraphInstantiateHooks(TestCase):
         cg._global_instantiate_hooks.clear()
         super().tearDown()
 
+    @staticmethod
+    def _run(graph):
+        import torch.cuda.graphs as cg
+
+        cg._run_global_hooks(cg._global_instantiate_hooks, graph)
+
     def test_register_run_unregister(self):
         import torch.cuda.graphs as cg
 
         seen = []
         graph = object()
         handle = cg.register_graph_instantiate_hook(lambda g: seen.append(g))
-        cg.run_graph_instantiate_hooks(graph)
+        self._run(graph)
         self.assertEqual(seen, [graph])
         handle.remove()
-        cg.run_graph_instantiate_hooks(graph)  # unregistered: not called again
+        self._run(graph)  # unregistered: not called again
         self.assertEqual(seen, [graph])
 
     def test_multiple_hooks_all_run(self):
@@ -1005,7 +1011,7 @@ class TestGraphInstantiateHooks(TestCase):
         cg.register_graph_instantiate_hook(lambda g: seen_a.append(g))
         cg.register_graph_instantiate_hook(lambda g: seen_b.append(g))
         graph = object()
-        cg.run_graph_instantiate_hooks(graph)
+        self._run(graph)
         self.assertEqual((seen_a, seen_b), ([graph], [graph]))
 
     def test_run_swallows_hook_errors(self):
@@ -1019,7 +1025,7 @@ class TestGraphInstantiateHooks(TestCase):
         cg.register_graph_instantiate_hook(boom)
         cg.register_graph_instantiate_hook(lambda g: seen.append(g))
         graph = object()
-        cg.run_graph_instantiate_hooks(graph)  # first raises, second still runs
+        self._run(graph)  # first raises, second still runs
         self.assertEqual(seen, [graph])
 
     @requires_cuda
@@ -1046,8 +1052,8 @@ class TestGraphInstantiateHooks(TestCase):
 
 
 # Host-side test of the graph-destroy hook registry: consumers register per-resolver
-# cleanup hooks that a CUDAGraph invokes (gated on graph_destroy_hooks_active) via
-# run_graph_destroy_hooks when a CUDA graph is destroyed. No CUDA needed.
+# cleanup hooks that a CUDAGraph invokes (gated on _graph_destroy_hooks_active) via
+# _run_graph_destroy_hooks when a CUDA graph is destroyed. No CUDA needed.
 class TestGraphDestroyHooks(TestCase):
     def tearDown(self):
         import torch.cuda.graphs as cg
@@ -1059,14 +1065,14 @@ class TestGraphDestroyHooks(TestCase):
         import torch.cuda.graphs as cg
 
         seen = []
-        self.assertFalse(cg.graph_destroy_hooks_active())
+        self.assertFalse(cg._graph_destroy_hooks_active())
         handle = cg.register_graph_destroy_hook(lambda ids: seen.append(set(ids)))
-        self.assertTrue(cg.graph_destroy_hooks_active())
-        cg.run_graph_destroy_hooks({7})
+        self.assertTrue(cg._graph_destroy_hooks_active())
+        cg._run_graph_destroy_hooks({7})
         self.assertEqual(seen, [{7}])
         handle.remove()
-        self.assertFalse(cg.graph_destroy_hooks_active())
-        cg.run_graph_destroy_hooks({8})  # unregistered: not called again
+        self.assertFalse(cg._graph_destroy_hooks_active())
+        cg._run_graph_destroy_hooks({8})  # unregistered: not called again
         self.assertEqual(seen, [{7}])
 
     def test_multiple_hooks_all_run(self):
@@ -1075,7 +1081,7 @@ class TestGraphDestroyHooks(TestCase):
         seen_a, seen_b = [], []
         cg.register_graph_destroy_hook(lambda ids: seen_a.append(set(ids)))
         cg.register_graph_destroy_hook(lambda ids: seen_b.append(set(ids)))
-        cg.run_graph_destroy_hooks({5})
+        cg._run_graph_destroy_hooks({5})
         self.assertEqual((seen_a, seen_b), ([{5}], [{5}]))
 
     def test_run_swallows_hook_errors(self):
@@ -1088,7 +1094,7 @@ class TestGraphDestroyHooks(TestCase):
 
         cg.register_graph_destroy_hook(boom)
         cg.register_graph_destroy_hook(lambda ids: seen.append(set(ids)))
-        cg.run_graph_destroy_hooks({1})  # first raises, second still runs
+        cg._run_graph_destroy_hooks({1})  # first raises, second still runs
         self.assertEqual(seen, [{1}])
 
     @requires_cuda
@@ -1232,11 +1238,14 @@ class TestGraphGlobalLifecycleHooks(TestCase):
 
     @staticmethod
     def _api(name):
+        # The fan-out is private -- only CUDAGraph calls it -- so drive it the way the graph
+        # does, with the registry the register_* function writes to.
         import torch.cuda.graphs as cg
 
+        registry = getattr(cg, f"_global_{name}_hooks")
         return (
             getattr(cg, f"register_graph_{name}_hook"),
-            getattr(cg, f"run_graph_{name}_hooks"),
+            lambda graph: cg._run_global_hooks(registry, graph),
         )
 
     @parametrize("name", GLOBAL_HOOK_REGISTRIES)
@@ -1266,11 +1275,11 @@ class TestGraphGlobalLifecycleHooks(TestCase):
         self.assertEqual(seen, [graph])
 
     @parametrize("name", GLOBAL_HOOK_REGISTRIES)
-    def test_exported(self, name):
+    def test_only_registration_is_public(self, name):
         import torch.cuda.graphs as cg
 
         self.assertIn(f"register_graph_{name}_hook", cg.__all__)
-        self.assertIn(f"run_graph_{name}_hooks", cg.__all__)
+        self.assertFalse(hasattr(cg, f"run_graph_{name}_hooks"))
 
     @requires_cuda
     def test_fire_points_over_a_real_graph(self):

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -1208,5 +1208,161 @@ class TestAnnotateTrace(TestCase):
         self.assertNotIn("annotation", args)
 
 
+# Every global lifecycle registry behaves the same way -- register / fan out / remove, with
+# per-hook errors swallowed so one consumer cannot break the step for another -- so the
+# contract is checked once per registry. The instantiate and destroy registries have their own
+# classes above; these are the four that pair with a per-graph hook.
+GLOBAL_HOOK_REGISTRIES = [
+    "capture_start",
+    "capture_end",
+    "instantiate",
+    "replay_start",
+    "replay_end",
+]
+
+
+@instantiate_parametrized_tests
+class TestGraphGlobalLifecycleHooks(TestCase):
+    def tearDown(self):
+        import torch.cuda.graphs as cg
+
+        for name in GLOBAL_HOOK_REGISTRIES:
+            getattr(cg, f"_global_{name}_hooks").clear()
+        super().tearDown()
+
+    @staticmethod
+    def _api(name):
+        import torch.cuda.graphs as cg
+
+        return (
+            getattr(cg, f"register_graph_{name}_hook"),
+            getattr(cg, f"run_graph_{name}_hooks"),
+        )
+
+    @parametrize("name", GLOBAL_HOOK_REGISTRIES)
+    def test_register_run_unregister(self, name):
+        register, run = self._api(name)
+        seen = []
+        graph = object()  # the registry passes the graph through untouched
+        handle = register(seen.append)
+        run(graph)
+        self.assertEqual(seen, [graph])
+        handle.remove()
+        run(graph)  # unregistered: not called again
+        self.assertEqual(seen, [graph])
+
+    @parametrize("name", GLOBAL_HOOK_REGISTRIES)
+    def test_run_swallows_hook_errors(self, name):
+        register, run = self._api(name)
+        seen = []
+
+        def boom(g):
+            raise RuntimeError("boom")
+
+        register(boom)
+        register(seen.append)
+        graph = object()
+        run(graph)  # first raises, second still runs
+        self.assertEqual(seen, [graph])
+
+    @parametrize("name", GLOBAL_HOOK_REGISTRIES)
+    def test_exported(self, name):
+        import torch.cuda.graphs as cg
+
+        self.assertIn(f"register_graph_{name}_hook", cg.__all__)
+        self.assertIn(f"run_graph_{name}_hooks", cg.__all__)
+
+    @requires_cuda
+    def test_fire_points_over_a_real_graph(self):
+        # Each registry fires at its own point in one graph's life, for a graph the consumer
+        # never built: capture start once, capture end once, instantiate once, and the replay
+        # pair once per replay.
+        import torch.cuda.graphs as cg
+
+        seen = []
+        for name in GLOBAL_HOOK_REGISTRIES:
+            handle = getattr(cg, f"register_graph_{name}_hook")(
+                lambda g, name=name: seen.append(name)
+            )
+            self.addCleanup(handle.remove)
+
+        x = torch.zeros(4, device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            _ = x + 1
+        # keep_graph=False instantiates from capture_end, so instantiate lands after it.
+        self.assertEqual(seen, ["capture_start", "capture_end", "instantiate"])
+        for _ in range(2):
+            g.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(
+            seen[3:],
+            ["replay_start", "replay_end", "replay_start", "replay_end"],
+        )
+        g.reset()
+
+    @requires_cuda
+    def test_global_hooks_run_before_per_graph_hooks(self):
+        # Ordering matches instantiate(): the global fan-out runs first, then the graph's own
+        # hooks. A consumer registering both sees them in that order.
+        import torch.cuda.graphs as cg
+
+        order = []
+        handle = cg.register_graph_capture_start_hook(lambda g: order.append("global"))
+        self.addCleanup(handle.remove)
+
+        x = torch.zeros(4, device="cuda")
+        g = torch.cuda.CUDAGraph()
+        g.register_capture_start_hook(lambda gr: order.append("per-graph"))
+        with torch.cuda.graph(g):
+            _ = x + 1
+        self.assertEqual(order, ["global", "per-graph"])
+        g.reset()
+
+    @requires_cuda
+    def test_capture_start_hook_sees_live_capture(self):
+        # The hook fires with capture already under way -- that is what lets it read capture
+        # state, and why its docs forbid issuing CUDA work.
+        import torch.cuda.graphs as cg
+
+        capturing = []
+        handle = cg.register_graph_capture_start_hook(
+            lambda g: capturing.append(torch.cuda.is_current_stream_capturing())
+        )
+        self.addCleanup(handle.remove)
+
+        x = torch.zeros(4, device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            _ = x + 1
+        self.assertEqual(capturing, [True])
+        g.reset()
+
+    @requires_cuda
+    def test_replay_end_hook_fires_when_launch_raises(self):
+        # The end hook is in a finally, so a start hook is always balanced by an end even if
+        # the launch itself fails; the launch error still propagates.
+        import torch.cuda.graphs as cg
+
+        seen = []
+        for name in ("replay_start", "replay_end"):
+            handle = getattr(cg, f"register_graph_{name}_hook")(
+                lambda g, name=name: seen.append(name)
+            )
+            self.addCleanup(handle.remove)
+
+        x = torch.zeros(4, device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            _ = x + 1
+        with unittest.mock.patch.object(
+            torch._C._CUDAGraph, "replay", side_effect=RuntimeError("boom")
+        ):
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                g.replay()
+        self.assertEqual(seen, ["replay_start", "replay_end"])
+        g.reset()
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -46,8 +46,16 @@ __all__ = [
     "make_graphed_callables",
     "export_dot",
     "export_graph_data",
+    "register_graph_capture_start_hook",
+    "run_graph_capture_start_hooks",
+    "register_graph_capture_end_hook",
+    "run_graph_capture_end_hooks",
     "register_graph_instantiate_hook",
     "run_graph_instantiate_hooks",
+    "register_graph_replay_start_hook",
+    "run_graph_replay_start_hooks",
+    "register_graph_replay_end_hook",
+    "run_graph_replay_end_hooks",
     "register_graph_destroy_hook",
     "run_graph_destroy_hooks",
     "graph_destroy_hooks_active",
@@ -162,11 +170,77 @@ class _RetainedCallbacks:
 
 
 # Global CUDA-graph lifecycle hooks (the module-level counterpart of the per-graph
-# _post_instantiate_hooks). A consumer (e.g. a profiler observer) registers a hook that fires
-# for every graph, so the graph code stays free of consumer knowledge; registering a hook is
-# the opt-in. Keyed by RemovableHandle id. Instantiate hooks run at the end of instantiate()
-# with the freshly instantiated graph.
+# _capture_start_hooks / _capture_end_hooks / _post_instantiate_hooks / _replay_*_hooks). A
+# consumer (e.g. a profiler observer) registers a hook that fires for every graph, so the graph
+# code stays free of consumer knowledge and a consumer sees captures of graphs it did not build
+# (an inductor or NCCL capture); registering a hook is the opt-in. Keyed by RemovableHandle id.
+# Every global runner swallows per-hook errors so one consumer cannot break a graph lifecycle
+# step for another -- unlike the per-graph hooks, whose errors propagate to the graph's owner.
+_global_capture_start_hooks: OrderedDict[int, Callable[[CUDAGraph], None]] = (
+    OrderedDict()
+)
+_global_capture_end_hooks: OrderedDict[int, Callable[[CUDAGraph], None]] = OrderedDict()
 _global_instantiate_hooks: OrderedDict[int, Callable[[CUDAGraph], None]] = OrderedDict()
+_global_replay_start_hooks: OrderedDict[int, Callable[[CUDAGraph], None]] = (
+    OrderedDict()
+)
+_global_replay_end_hooks: OrderedDict[int, Callable[[CUDAGraph], None]] = OrderedDict()
+
+
+def _register_global_hook(
+    registry: OrderedDict[int, Callable[[CUDAGraph], None]],
+    fn: Callable[[CUDAGraph], None],
+) -> RemovableHandle:
+    from torch.utils.hooks import RemovableHandle
+
+    handle = RemovableHandle(registry)
+    registry[handle.id] = fn
+    return handle
+
+
+def _run_global_hooks(
+    registry: OrderedDict[int, Callable[[CUDAGraph], None]],
+    torch_cuda_graph: CUDAGraph,
+) -> None:
+    for fn in list(registry.values()):
+        try:
+            fn(torch_cuda_graph)
+        except Exception:
+            pass
+
+
+def register_graph_capture_start_hook(
+    fn: Callable[[CUDAGraph], None],
+) -> RemovableHandle:
+    """Register a hook run with each CUDA graph as its capture begins. Returns a
+    RemovableHandle; call ``.remove()`` to unregister.
+
+    .. warning::
+        The hook runs with capture already live on the current stream, so it must not issue
+        CUDA work: anything it launches is captured into the graph, and under the default
+        ``"global"`` capture error mode an unsafe call (e.g. an allocation) raises. Querying
+        capture state is fine. Do preparation that needs CUDA before the capture instead.
+    """
+    return _register_global_hook(_global_capture_start_hooks, fn)
+
+
+def run_graph_capture_start_hooks(torch_cuda_graph: CUDAGraph) -> None:
+    """Run every registered capture-start hook with the graph."""
+    _run_global_hooks(_global_capture_start_hooks, torch_cuda_graph)
+
+
+def register_graph_capture_end_hook(
+    fn: Callable[[CUDAGraph], None],
+) -> RemovableHandle:
+    """Register a hook run with each CUDA graph when its capture ends, while the captured
+    ``cudaGraph_t`` is still live (see :meth:`CUDAGraph.register_capture_end_hook`). Returns a
+    RemovableHandle; call ``.remove()`` to unregister."""
+    return _register_global_hook(_global_capture_end_hooks, fn)
+
+
+def run_graph_capture_end_hooks(torch_cuda_graph: CUDAGraph) -> None:
+    """Run every registered capture-end hook with the graph."""
+    _run_global_hooks(_global_capture_end_hooks, torch_cuda_graph)
 
 
 def register_graph_instantiate_hook(
@@ -174,21 +248,47 @@ def register_graph_instantiate_hook(
 ) -> RemovableHandle:
     """Register a hook run with each CUDA graph right after it is instantiated. Returns a
     RemovableHandle; call ``.remove()`` to unregister."""
-    from torch.utils.hooks import RemovableHandle
-
-    handle = RemovableHandle(_global_instantiate_hooks)
-    _global_instantiate_hooks[handle.id] = fn
-    return handle
+    return _register_global_hook(_global_instantiate_hooks, fn)
 
 
 def run_graph_instantiate_hooks(torch_cuda_graph: CUDAGraph) -> None:
     """Run every registered instantiate hook with the graph. Errors are swallowed so one
     consumer cannot break instantiate() for another."""
-    for fn in list(_global_instantiate_hooks.values()):
-        try:
-            fn(torch_cuda_graph)
-        except Exception:
-            pass
+    _run_global_hooks(_global_instantiate_hooks, torch_cuda_graph)
+
+
+def register_graph_replay_start_hook(
+    fn: Callable[[CUDAGraph], None],
+) -> RemovableHandle:
+    """Register a hook run with each CUDA graph at the start of every replay, just before it
+    is launched. Returns a RemovableHandle; call ``.remove()`` to unregister.
+
+    .. note::
+        Replay is the hot path and this fires for EVERY graph on EVERY replay -- keep it
+        cheap. With nothing registered the cost is a single dict emptiness check.
+    """
+    return _register_global_hook(_global_replay_start_hooks, fn)
+
+
+def run_graph_replay_start_hooks(torch_cuda_graph: CUDAGraph) -> None:
+    """Run every registered replay-start hook with the graph."""
+    _run_global_hooks(_global_replay_start_hooks, torch_cuda_graph)
+
+
+def register_graph_replay_end_hook(
+    fn: Callable[[CUDAGraph], None],
+) -> RemovableHandle:
+    """Register a hook run with each CUDA graph at the end of every replay, once the replay is
+    *enqueued* (the launch is asynchronous, so the GPU work has not completed). Fires even if
+    the launch raised, so a start hook is always balanced by an end. Returns a RemovableHandle;
+    call ``.remove()`` to unregister. See the hot-path note on
+    :func:`register_graph_replay_start_hook`."""
+    return _register_global_hook(_global_replay_end_hooks, fn)
+
+
+def run_graph_replay_end_hooks(torch_cuda_graph: CUDAGraph) -> None:
+    """Run every registered replay-end hook with the graph."""
+    _run_global_hooks(_global_replay_end_hooks, torch_cuda_graph)
 
 
 # Graph-destroy hooks, each handed the destroyed graph's exec ids (tools_id >> 32) so a
@@ -268,7 +368,8 @@ class CUDAGraph(_CUDAGraph):
     # can purge that state and their maps do not grow across the run.
     _recorded_exec_ids: set[int]
     _keep_graph: bool
-    # User hooks fired by capture_end / instantiate (see register_*_hook).
+    # User hooks fired by capture_begin / capture_end / instantiate (see register_*_hook).
+    _capture_start_hooks: dict[int, Callable[[CUDAGraph], None]]
     _capture_end_hooks: dict[int, Callable[[CUDAGraph], None]]
     _post_instantiate_hooks: dict[int, Callable[[CUDAGraph], None]]
     # Transient get_graph_data() cache shared across a single instantiate()'s
@@ -296,6 +397,7 @@ class CUDAGraph(_CUDAGraph):
         instance._recorded_exec_ids = set()
         instance._keep_graph = keep_graph
         # OrderedDict (not dict): RemovableHandle weak-references the mapping.
+        instance._capture_start_hooks = OrderedDict()
         instance._capture_end_hooks = OrderedDict()
         instance._post_instantiate_hooks = OrderedDict()
         instance._caching_graph_data = False
@@ -324,6 +426,24 @@ class CUDAGraph(_CUDAGraph):
         if graph_destroy_hooks_active():
             exec_ids = self._recorded_exec_ids
             self.register_destroy_callback(lambda: run_graph_destroy_hooks(exec_ids))
+
+    def register_capture_start_hook(
+        self, hook: Callable[[CUDAGraph], None]
+    ) -> RemovableHandle:
+        r"""Register ``hook(graph)`` to run when capture begins on this graph, right
+        after capture is under way on the current stream. Hooks fire in registration
+        order. Returns a handle whose ``remove()`` deregisters the hook.
+
+        .. warning::
+            The hook runs inside the capture: any CUDA work it issues is captured into
+            the graph, and under the default ``"global"`` capture error mode an unsafe
+            call raises. See :func:`torch.cuda.register_graph_capture_start_hook`.
+        """
+        from torch.utils.hooks import RemovableHandle
+
+        handle = RemovableHandle(self._capture_start_hooks)
+        self._capture_start_hooks[handle.id] = hook
+        return handle
 
     def register_capture_end_hook(
         self, hook: Callable[[CUDAGraph], None]
@@ -527,6 +647,12 @@ class CUDAGraph(_CUDAGraph):
 
             self._tracker = _CUDAGraphInputLivenessTracker()
             self._tracker.start()
+        # Capture is live from here, so a hook must not issue CUDA work (see
+        # register_capture_start_hook). Global hooks run before the per-graph ones,
+        # matching instantiate().
+        run_graph_capture_start_hooks(self)
+        for hook in list(self._capture_start_hooks.values()):
+            hook(self)
 
     def capture_end_pre(self) -> None:
         r"""End capture but do not finalize: leaves the captured ``cudaGraph_t``
@@ -560,6 +686,7 @@ class CUDAGraph(_CUDAGraph):
         from torch.cuda._graph_annotations import maybe_stamp_capture_graph_id
 
         maybe_stamp_capture_graph_id(self)
+        run_graph_capture_end_hooks(self)
         for hook in list(self._capture_end_hooks.values()):
             hook(self)
         if not self._keep_graph:
@@ -604,12 +731,16 @@ class CUDAGraph(_CUDAGraph):
         # annotation remap rides on instantiate(), so it is handled by that call.
         if not self._has_graph_exec:
             self.instantiate()
+        if _global_replay_start_hooks:
+            run_graph_replay_start_hooks(self)
         if self._replay_start_hooks:
             for hook in list(self._replay_start_hooks.values()):
                 hook(self)
         try:
             super().replay()
         finally:
+            if _global_replay_end_hooks:
+                run_graph_replay_end_hooks(self)
             if self._replay_end_hooks:
                 for hook in list(self._replay_end_hooks.values()):
                     hook(self)

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -47,18 +47,11 @@ __all__ = [
     "export_dot",
     "export_graph_data",
     "register_graph_capture_start_hook",
-    "run_graph_capture_start_hooks",
     "register_graph_capture_end_hook",
-    "run_graph_capture_end_hooks",
     "register_graph_instantiate_hook",
-    "run_graph_instantiate_hooks",
     "register_graph_replay_start_hook",
-    "run_graph_replay_start_hooks",
     "register_graph_replay_end_hook",
-    "run_graph_replay_end_hooks",
     "register_graph_destroy_hook",
-    "run_graph_destroy_hooks",
-    "graph_destroy_hooks_active",
 ]
 
 
@@ -174,8 +167,8 @@ class _RetainedCallbacks:
 # consumer (e.g. a profiler observer) registers a hook that fires for every graph, so the graph
 # code stays free of consumer knowledge and a consumer sees captures of graphs it did not build
 # (an inductor or NCCL capture); registering a hook is the opt-in. Keyed by RemovableHandle id.
-# Every global runner swallows per-hook errors so one consumer cannot break a graph lifecycle
-# step for another -- unlike the per-graph hooks, whose errors propagate to the graph's owner.
+# The fan-out (_run_global_hooks) swallows per-hook errors so one consumer cannot break a graph
+# lifecycle step for another -- unlike the per-graph hooks, whose errors propagate to the owner.
 _global_capture_start_hooks: OrderedDict[int, Callable[[CUDAGraph], None]] = (
     OrderedDict()
 )
@@ -224,11 +217,6 @@ def register_graph_capture_start_hook(
     return _register_global_hook(_global_capture_start_hooks, fn)
 
 
-def run_graph_capture_start_hooks(torch_cuda_graph: CUDAGraph) -> None:
-    """Run every registered capture-start hook with the graph."""
-    _run_global_hooks(_global_capture_start_hooks, torch_cuda_graph)
-
-
 def register_graph_capture_end_hook(
     fn: Callable[[CUDAGraph], None],
 ) -> RemovableHandle:
@@ -238,23 +226,12 @@ def register_graph_capture_end_hook(
     return _register_global_hook(_global_capture_end_hooks, fn)
 
 
-def run_graph_capture_end_hooks(torch_cuda_graph: CUDAGraph) -> None:
-    """Run every registered capture-end hook with the graph."""
-    _run_global_hooks(_global_capture_end_hooks, torch_cuda_graph)
-
-
 def register_graph_instantiate_hook(
     fn: Callable[[CUDAGraph], None],
 ) -> RemovableHandle:
     """Register a hook run with each CUDA graph right after it is instantiated. Returns a
     RemovableHandle; call ``.remove()`` to unregister."""
     return _register_global_hook(_global_instantiate_hooks, fn)
-
-
-def run_graph_instantiate_hooks(torch_cuda_graph: CUDAGraph) -> None:
-    """Run every registered instantiate hook with the graph. Errors are swallowed so one
-    consumer cannot break instantiate() for another."""
-    _run_global_hooks(_global_instantiate_hooks, torch_cuda_graph)
 
 
 def register_graph_replay_start_hook(
@@ -270,11 +247,6 @@ def register_graph_replay_start_hook(
     return _register_global_hook(_global_replay_start_hooks, fn)
 
 
-def run_graph_replay_start_hooks(torch_cuda_graph: CUDAGraph) -> None:
-    """Run every registered replay-start hook with the graph."""
-    _run_global_hooks(_global_replay_start_hooks, torch_cuda_graph)
-
-
 def register_graph_replay_end_hook(
     fn: Callable[[CUDAGraph], None],
 ) -> RemovableHandle:
@@ -286,14 +258,9 @@ def register_graph_replay_end_hook(
     return _register_global_hook(_global_replay_end_hooks, fn)
 
 
-def run_graph_replay_end_hooks(torch_cuda_graph: CUDAGraph) -> None:
-    """Run every registered replay-end hook with the graph."""
-    _run_global_hooks(_global_replay_end_hooks, torch_cuda_graph)
-
-
 # Graph-destroy hooks, each handed the destroyed graph's exec ids (tools_id >> 32) so a
 # consumer can purge its per-graph state. A CUDAGraph arms a single destroy callback (only
-# while a hook is registered, see graph_destroy_hooks_active) that fans out here.
+# while a hook is registered, see _graph_destroy_hooks_active) that fans out here.
 _global_destroy_hooks: OrderedDict[int, Callable[[set[int]], None]] = OrderedDict()
 
 
@@ -307,13 +274,13 @@ def register_graph_destroy_hook(fn: Callable[[set[int]], None]) -> RemovableHand
     return handle
 
 
-def graph_destroy_hooks_active() -> bool:
+def _graph_destroy_hooks_active() -> bool:
     """True when any graph-destroy hook is registered -- the gate a CUDAGraph checks before
     arming its destroy callback."""
     return bool(_global_destroy_hooks)
 
 
-def run_graph_destroy_hooks(exec_graph_ids: set[int]) -> None:
+def _run_graph_destroy_hooks(exec_graph_ids: set[int]) -> None:
     """Invoke every registered hook with the destroyed exec graph ids, swallowing per-hook
     errors so one failure does not abort the rest (matching the destroy-callback fire
     semantics). The single entry point a graph's destroy callback calls."""
@@ -423,9 +390,9 @@ class CUDAGraph(_CUDAGraph):
         # a hook: a closure reachable to the graph would pin it past collection so it
         # never fires. reset() re-arms a fresh holder, so this re-registers per cycle;
         # a graph that records nothing just fires on an empty set (a no-op).
-        if graph_destroy_hooks_active():
+        if _graph_destroy_hooks_active():
             exec_ids = self._recorded_exec_ids
-            self.register_destroy_callback(lambda: run_graph_destroy_hooks(exec_ids))
+            self.register_destroy_callback(lambda: _run_graph_destroy_hooks(exec_ids))
 
     def register_capture_start_hook(
         self, hook: Callable[[CUDAGraph], None]
@@ -437,7 +404,7 @@ class CUDAGraph(_CUDAGraph):
         .. warning::
             The hook runs inside the capture: any CUDA work it issues is captured into
             the graph, and under the default ``"global"`` capture error mode an unsafe
-            call raises. See :func:`torch.cuda.register_graph_capture_start_hook`.
+            call raises. See :func:`torch.cuda.graphs.register_graph_capture_start_hook`.
         """
         from torch.utils.hooks import RemovableHandle
 
@@ -650,7 +617,8 @@ class CUDAGraph(_CUDAGraph):
         # Capture is live from here, so a hook must not issue CUDA work (see
         # register_capture_start_hook). Global hooks run before the per-graph ones,
         # matching instantiate().
-        run_graph_capture_start_hooks(self)
+        if _global_capture_start_hooks:
+            _run_global_hooks(_global_capture_start_hooks, self)
         for hook in list(self._capture_start_hooks.values()):
             hook(self)
 
@@ -686,7 +654,8 @@ class CUDAGraph(_CUDAGraph):
         from torch.cuda._graph_annotations import maybe_stamp_capture_graph_id
 
         maybe_stamp_capture_graph_id(self)
-        run_graph_capture_end_hooks(self)
+        if _global_capture_end_hooks:
+            _run_global_hooks(_global_capture_end_hooks, self)
         for hook in list(self._capture_end_hooks.values()):
             hook(self)
         if not self._keep_graph:
@@ -710,7 +679,8 @@ class CUDAGraph(_CUDAGraph):
         # one query; the cache is dropped afterwards so nothing is retained for the graph.
         self._caching_graph_data = True
         try:
-            run_graph_instantiate_hooks(self)
+            if _global_instantiate_hooks:
+                _run_global_hooks(_global_instantiate_hooks, self)
             for hook in list(self._post_instantiate_hooks.values()):
                 hook(self)
         finally:
@@ -732,7 +702,7 @@ class CUDAGraph(_CUDAGraph):
         if not self._has_graph_exec:
             self.instantiate()
         if _global_replay_start_hooks:
-            run_graph_replay_start_hooks(self)
+            _run_global_hooks(_global_replay_start_hooks, self)
         if self._replay_start_hooks:
             for hook in list(self._replay_start_hooks.values()):
                 hook(self)
@@ -740,7 +710,7 @@ class CUDAGraph(_CUDAGraph):
             super().replay()
         finally:
             if _global_replay_end_hooks:
-                run_graph_replay_end_hooks(self)
+                _run_global_hooks(_global_replay_end_hooks, self)
             if self._replay_end_hooks:
                 for hook in list(self._replay_end_hooks.values()):
                     hook(self)

--- a/torch/profiler/_cupti/observers/base.py
+++ b/torch/profiler/_cupti/observers/base.py
@@ -229,7 +229,7 @@ class CuptiMonitorObserver:
         acceptable on the infrequent destroy path and what bounds cache growth over a
         long run). Hooks capture only the cache wrapper + purge fn (never self, so they
         cannot pin this observer -- the dependency purge closes over the map dict, not the
-        observer); run_graph_destroy_hooks also swallows any error they raise
+        observer); the destroy fan-out also swallows any error they raise
         (finalizer-safe, since a destroy may fire from a GC/finalizer thread). The lane
         resolver is externally backed (nothing to purge), so its hook only clears the
         cache."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #192162

CUDA graphs expose per-graph lifecycle hooks (capture end, post-instantiate, replay
start/end, destroy), but only instantiate and destroy have a module-level counterpart that
fires for EVERY graph. The global form is the one a consumer that does not construct the
graph can use -- a profiler observing an inductor or NCCL capture -- so this fills in the
missing ones and adds capture start, which had neither form:

  capture start   register_graph_capture_start_hook   + CUDAGraph.register_capture_start_hook
  capture end     register_graph_capture_end_hook     (per-graph hook already existed)
  replay start    register_graph_replay_start_hook    (per-graph hook already existed)
  replay end      register_graph_replay_end_hook      (per-graph hook already existed)

Test Plan:

```
python test/test_cuda_graph_utils.py TestGraphGlobalLifecycleHooks
python test/test_cuda.py -k graph_replay_hooks
```

cc @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng