### PR TITLE
[Testcase Refactoring] Add hw_classification and instantiate_device_type_tests to test_nccl.py

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_WINDOWS,
     load_tests,
@@ -57,6 +58,8 @@ broadcast_dtypes = (
 
 
 class TestNCCL(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     def test_unique_id(self, device):
         uid = nccl.unique_id()
@@ -1192,6 +1195,24 @@ class NCCLSymmetricMemoryNcclLazyTest(NCCLSymmetricMemoryNccl2Test):
 
 
 instantiate_device_type_tests(TestNCCL, globals(), only_for="cuda")
+
+instantiate_device_type_tests(
+    NCCLSymmetricMemoryTest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    NCCLSymmetricMemoryNccl2Test,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    NCCLSymmetricMemoryNcclLazyTest,
+    globals(),
+    only_for=("cuda",),
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -243,9 +243,12 @@ class TestNCCL(TestCase):
 @requires_cuda_p2p_access()
 class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
+    def _set_device(self, device: str) -> None:
+        self._dev = torch.device(torch.device(device).type, self.rank)
+
     @property
     def device(self) -> torch.device:
-        return torch.device("cuda", self.rank)
+        return self._dev
 
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file):
@@ -274,6 +277,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nccl_symmem_alloc(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
         # test will hang.  TODO: investigate how NCCLSymmetricMemory can
         # initialize NCCL communicator.
@@ -299,6 +303,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nccl_symmem_rendezvous_many_allocations(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
 
@@ -327,6 +332,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_if_lt_x_gpu(2)
     def test_nccl_symmem_rendezvous_world(self, device):
+        self._set_device(device)
         symm_mem.set_backend("NCCL")
         group_name = c10d.group.WORLD.group_name
 
@@ -350,6 +356,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nccl_symmem_barrier(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
 
@@ -376,6 +383,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nccl_symmem_barrier_channel_out_of_bounds(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
 
@@ -398,6 +406,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nccl_symmem_signal_rank_out_of_bounds(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
 
@@ -414,6 +423,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_if_lt_x_gpu(2)
     def test_nccl_symmem_rendezvous_subgroup(self, device):
+        self._set_device(device)
         symm_mem.set_backend("NCCL")
 
         subgroup = c10d.new_group(list(range(self.world_size)))
@@ -440,6 +450,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nccl_symmem_collective(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
         # test will hang.  TODO: investigate how NCCLSymmetricMemory can
         # initialize NCCL communicator.
@@ -471,6 +482,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nccl_symmem_collective_cuda_graph(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
         # test will hang.  TODO: investigate how NCCLSymmetricMemory can
         # initialize NCCL communicator.
@@ -520,6 +532,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nccl_symmem_tensor_creation_and_collective_cuda_graph(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
 
@@ -583,6 +596,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nccl_symmem_put(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
         # test will hang.  TODO: investigate how NCCLSymmetricMemory can
         # initialize NCCL communicator.
@@ -624,6 +638,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nccl_symmem_handle_signal(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         # need this all_reduce to initialize NCCL communicator. Otherwise, the
         # test will hang.  TODO: investigate how NCCLSymmetricMemory can
         # initialize NCCL communicator.
@@ -663,6 +678,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nccl_symmem_get(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
         # test will hang.  TODO: investigate how NCCLSymmetricMemory can
         # initialize NCCL communicator.
@@ -697,6 +713,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_get(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
 
@@ -783,6 +800,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         Grouped GEMM buffer is left unmodified."""
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
 
@@ -860,6 +878,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         of different sizes, verifying that out[j] shapes differ across j."""
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
 
@@ -939,6 +958,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         scatter_dim, gather_dim = scatter_gather
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
 
@@ -1025,6 +1045,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_put_wait_signal(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         # Use this barrier to make sure all ranks are initialized.
         c10d.barrier()
         group_name = c10d.group.WORLD.group_name
@@ -1053,6 +1074,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_mempool_tensor_factory(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
         # test will hang.  TODO: investigate how NCCLSymmetricMemory can
         # initialize NCCL communicator.
@@ -1081,6 +1103,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     def test_mempool_compute_ops(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
         # test will hang.  TODO: investigate how NCCLSymmetricMemory can
         # initialize NCCL communicator.
@@ -1116,6 +1139,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         # still works on the recycled region.
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
         mempool = symm_mem.get_mem_pool(self.device)
@@ -1159,6 +1183,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
 
@@ -1184,9 +1209,12 @@ class NCCLSymmetricMemoryNccl2Test(MultiProcContinuousTest):
 
     backend_name = "nccl2"
 
+    def _set_device(self, device: str) -> None:
+        self._dev = torch.device(torch.device(device).type, self.rank)
+
     @property
     def device(self) -> torch.device:
-        return torch.device("cuda", self.rank)
+        return self._dev
 
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file):
@@ -1215,6 +1243,7 @@ class NCCLSymmetricMemoryNccl2Test(MultiProcContinuousTest):
     def test_nccl_symmem_rendezvous(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
+        self._set_device(device)
         # Confirm the intended path: a torchcomms PG + the NCCL symm-mem backend.
         self.assertEqual(c10d.get_backend(c10d.group.WORLD), self.backend_name)
         self.assertEqual(symm_mem.get_backend(self.device), "NCCL")

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -240,11 +240,9 @@ class TestNCCL(TestCase):
             self.assertEqual(outputs[i], expected[i])
 
 
-@instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
-
     @property
     def device(self) -> torch.device:
         return torch.device("cuda", self.rank)
@@ -273,7 +271,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_alloc(self):
+    def test_nccl_symmem_alloc(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
@@ -298,7 +296,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_rendezvous_many_allocations(self):
+    def test_nccl_symmem_rendezvous_many_allocations(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         c10d.all_reduce(torch.ones(1, device=self.device))
@@ -328,7 +326,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_rendezvous_world(self):
+    def test_nccl_symmem_rendezvous_world(self, device):
         symm_mem.set_backend("NCCL")
         group_name = c10d.group.WORLD.group_name
 
@@ -349,7 +347,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_barrier(self):
+    def test_nccl_symmem_barrier(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         c10d.all_reduce(torch.ones(1, device=self.device))
@@ -375,7 +373,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
     )
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_barrier_channel_out_of_bounds(self):
+    def test_nccl_symmem_barrier_channel_out_of_bounds(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         c10d.all_reduce(torch.ones(1, device=self.device))
@@ -397,7 +395,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @requires_nccl_version((2, 29), "NCCL one-sided host API support from nccl 2.29")
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_signal_rank_out_of_bounds(self):
+    def test_nccl_symmem_signal_rank_out_of_bounds(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         c10d.all_reduce(torch.ones(1, device=self.device))
@@ -415,7 +413,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_rendezvous_subgroup(self):
+    def test_nccl_symmem_rendezvous_subgroup(self, device):
         symm_mem.set_backend("NCCL")
 
         subgroup = c10d.new_group(list(range(self.world_size)))
@@ -439,7 +437,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
     )
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_collective(self):
+    def test_nccl_symmem_collective(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
@@ -470,7 +468,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
     )
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_collective_cuda_graph(self):
+    def test_nccl_symmem_collective_cuda_graph(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
@@ -519,7 +517,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
     )
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_tensor_creation_and_collective_cuda_graph(self):
+    def test_nccl_symmem_tensor_creation_and_collective_cuda_graph(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         c10d.all_reduce(torch.ones(1, device=self.device))
@@ -582,7 +580,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
     )
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_put(self):
+    def test_nccl_symmem_put(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
@@ -623,7 +621,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @requires_nccl_version((2, 29), "NCCL one-sided host API support from nccl 2.29")
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_handle_signal(self):
+    def test_nccl_symmem_handle_signal(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         # need this all_reduce to initialize NCCL communicator. Otherwise, the
@@ -662,7 +660,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_get(self):
+    def test_nccl_symmem_get(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
@@ -696,7 +694,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         (2, 28), "NCCL Symmetric Memory device API support from nccl 2.28"
     )
     @skip_if_lt_x_gpu(2)
-    def test_get(self):
+    def test_get(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         c10d.all_reduce(torch.ones(1, device=self.device))
@@ -779,7 +777,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_if_lt_x_gpu(2)
     @parametrize("experts_per_rank", [1, 2])
     @parametrize("dim", [0, 1])
-    def test_reduce_scatter_offset(self, experts_per_rank: int, dim: int):
+    def test_reduce_scatter_offset(self, device, experts_per_rank: int, dim: int):
         """reduce_scatter_offset: each expert gradient is reduced to its
         destination rank and written to a separate contiguous tensor; the source
         Grouped GEMM buffer is left unmodified."""
@@ -857,7 +855,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(2)
     @parametrize("dim", [0, 1])
-    def test_reduce_scatter_offset_uneven(self, dim: int):
+    def test_reduce_scatter_offset_uneven(self, device, dim: int):
         """reduce_scatter_offset with uneven block sizes: j=0 and j=1 own blocks
         of different sizes, verifying that out[j] shapes differ across j."""
         symm_mem.set_backend("NCCL")
@@ -936,7 +934,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
             ((0, 1), True, True),
         ],
     )
-    def test_all_to_all_nd(self, scatter_gather, out_2d, input_3d):
+    def test_all_to_all_nd(self, device, scatter_gather, out_2d, input_3d):
         """all_to_all_nd: (1,0)/(0,1); 3-D input [rows,G,loc] or [G,loc,cols] where supported."""
         scatter_dim, gather_dim = scatter_gather
         symm_mem.set_backend("NCCL")
@@ -1024,7 +1022,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @requires_nccl_version((2, 29), "NCCL one-sided host API support from nccl 2.29")
     @skip_if_lt_x_gpu(2)
-    def test_put_wait_signal(self):
+    def test_put_wait_signal(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         # Use this barrier to make sure all ranks are initialized.
@@ -1052,7 +1050,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_if_lt_x_gpu(2)
-    def test_mempool_tensor_factory(self):
+    def test_mempool_tensor_factory(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
@@ -1080,7 +1078,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_if_lt_x_gpu(2)
-    def test_mempool_compute_ops(self):
+    def test_mempool_compute_ops(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         # Need this all_reduce to initialize NCCL communicator. Otherwise, the
@@ -1108,7 +1106,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
     @skip_if_lt_x_gpu(2)
-    def test_mempool_recycled_barrier(self):
+    def test_mempool_recycled_barrier(self, device):
         # Regression test for the signal-pad pollution bug: ncclMemAlloc does
         # not zero memory, so a MemPool-recycled NCCL symmetric allocation could
         # start the CAS-based barrier() protocol from a non-zero signal pad and
@@ -1152,7 +1150,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @requires_nccl_version(
         (2, 29), "NCCL Symmetric Memory multicast support from nccl 2.29"
     )
-    def test_multicast_ptr(self) -> None:
+    def test_multicast_ptr(self, device) -> None:
         """
         Get the multicast pointer
         """
@@ -1175,7 +1173,6 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 @requires_cuda_p2p_access()
 class NCCLSymmetricMemoryNccl2Test(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
-
     """NCCL symmetric memory over an nccl2-backed process group.
 
     Same flow as NCCLSymmetricMemoryTest, but the process group uses the in-tree
@@ -1215,7 +1212,7 @@ class NCCLSymmetricMemoryNccl2Test(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
     @skip_if_lt_x_gpu(2)
-    def test_nccl_symmem_rendezvous(self):
+    def test_nccl_symmem_rendezvous(self, device):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
         # Confirm the intended path: a torchcomms PG + the NCCL symm-mem backend.
@@ -1243,6 +1240,24 @@ class NCCLSymmetricMemoryNcclLazyTest(NCCLSymmetricMemoryNccl2Test):
 
 
 instantiate_device_type_tests(TestNCCL, globals(), only_for="cuda")
+
+instantiate_device_type_tests(
+    NCCLSymmetricMemoryTest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    NCCLSymmetricMemoryNccl2Test,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    NCCLSymmetricMemoryNcclLazyTest,
+    globals(),
+    only_for=("cuda",),
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_WINDOWS,
     load_tests,
@@ -57,6 +58,8 @@ broadcast_dtypes = (
 
 
 class TestNCCL(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     def test_unique_id(self, device):
         uid = nccl.unique_id()
@@ -240,6 +243,8 @@ class TestNCCL(TestCase):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device("cuda", self.rank)
@@ -1169,6 +1174,8 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
 @requires_cuda_p2p_access()
 class NCCLSymmetricMemoryNccl2Test(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     """NCCL symmetric memory over an nccl2-backed process group.
 
     Same flow as NCCLSymmetricMemoryTest, but the process group uses the in-tree
@@ -1231,6 +1238,7 @@ class NCCLSymmetricMemoryNccl2Test(MultiProcContinuousTest):
 
 
 class NCCLSymmetricMemoryNcclLazyTest(NCCLSymmetricMemoryNccl2Test):
+    hw_classification = HardwareClassification.CUDA
     backend_name = "nccl-lazy"
 
 

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -1197,7 +1197,6 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
 @requires_cuda_p2p_access()
 class NCCLSymmetricMemoryNccl2Test(MultiProcContinuousTest):
-    hw_classification = HardwareClassification.CUDA
     """NCCL symmetric memory over an nccl2-backed process group.
 
     Same flow as NCCLSymmetricMemoryTest, but the process group uses the in-tree
@@ -1207,6 +1206,7 @@ class NCCLSymmetricMemoryNccl2Test(MultiProcContinuousTest):
     on an nccl2 group raised "NCCL host communicator for group ... not found".
     """
 
+    hw_classification = HardwareClassification.CUDA
     backend_name = "nccl2"
 
     def _set_device(self, device: str) -> None:
@@ -1266,6 +1266,9 @@ class NCCLSymmetricMemoryNccl2Test(MultiProcContinuousTest):
 class NCCLSymmetricMemoryNcclLazyTest(NCCLSymmetricMemoryNccl2Test):
     hw_classification = HardwareClassification.CUDA
     backend_name = "nccl-lazy"
+    # Re-bind the inherited test because instantiate_device_type_tests collects
+    # tests from __dict__ only.
+    test_nccl_symmem_rendezvous = NCCLSymmetricMemoryNccl2Test.test_nccl_symmem_rendezvous
 
 
 instantiate_device_type_tests(TestNCCL, globals(), only_for="cuda")


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.CUDA` to the
`TestNCCL` class and register the three multi-process symmetric-memory
test classes via `instantiate_device_type_tests(only_for=("cuda",))`.
These tests are NVIDIA NCCL-specific and should only run on CUDA
variants.

## Changes

- **Import `HardwareClassification`** from `common_utils`.
- **Add `hw_classification = HardwareClassification.CUDA`** to
  `TestNCCL`.
- **Add `instantiate_device_type_tests(only_for=("cuda",))`** for
  `NCCLSymmetricMemoryTest`, `NCCLSymmetricMemoryNccl2Test`, and
  `NCCLSymmetricMemoryNcclLazyTest`.  The existing `TestNCCL`
  instantiation with `only_for="cuda"` is unchanged.

## Not changed

- No test logic, decorators, or assertions are modified.  The existing
  `skip_if_lt_x_gpu`, `TEST_WITH_ROCM` skips, and NCCL version checks
  remain in place as before.

## Test plan

- `python test/distributed/test_nccl.py` — TODO: run on a CUDA build
  with 2+ GPUs and confirm all generated `*CUDA` test variants pass.