### PR TITLE
[MPS] Use atomic counters for histc

### DIFF
--- a/aten/src/ATen/native/mps/kernels/HistogramKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/HistogramKernel.metal
@@ -26,6 +26,16 @@ U upper_bound(constant T* arr, U first, U len, T val) {
   return first;
 }
 
+template <typename T>
+inline long linear_bin(
+    T element,
+    long num_bins,
+    T leftmost_edge,
+    T rightmost_edge) {
+  return static_cast<long>(
+      (element - leftmost_edge) * num_bins / (rightmost_edge - leftmost_edge));
+}
+
 // The implementation here is mostly taken from the CPU's implementation with
 // some modifications. Please see `aten/src/ATen/native/cpu/HistogramKernel.cpp`
 // for more details.
@@ -70,9 +80,11 @@ kernel void histogramdd(
         algorithm == BIN_SELECTION_ALGORITHM::LINEAR_INTERPOLATION ||
         algorithm ==
             BIN_SELECTION_ALGORITHM::LINEAR_INTERPOLATION_WITH_LOCAL_SEARCH) {
-      pos = static_cast<int64_t>(
-          (element - leftmost_edge[dim]) * (num_bin_edges[dim] - 1) /
-          (rightmost_edge[dim] - leftmost_edge[dim]));
+      pos = linear_bin(
+          element,
+          num_bin_edges[dim] - 1,
+          leftmost_edge[dim],
+          rightmost_edge[dim]);
       if (algorithm == LINEAR_INTERPOLATION_WITH_LOCAL_SEARCH) {
         int64_t pos_min = max(static_cast<int64_t>(0), pos - 1);
         int64_t pos_max = min(pos + 2, num_bin_edges[dim]);
@@ -128,14 +140,11 @@ inline long histc_bin(
     long num_bins,
     T leftmost_edge,
     T rightmost_edge) {
-  constexpr auto eps = T(4e-6);
-  if (!(element >= (leftmost_edge - eps) &&
-        element <= (rightmost_edge + eps))) {
+  if (!(element >= leftmost_edge && element <= rightmost_edge)) {
     return -1;
   }
-  long pos = static_cast<long>(
-      (element - leftmost_edge) * num_bins / (rightmost_edge - leftmost_edge));
-  return pos == num_bins ? pos - 1 : pos;
+  long pos = linear_bin(element, num_bins, leftmost_edge, rightmost_edge);
+  return metal::clamp(pos, 0L, num_bins - 1);
 }
 
 template <typename T, bool dense>

--- a/aten/src/ATen/native/mps/kernels/HistogramKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/HistogramKernel.metal
@@ -1,5 +1,7 @@
+#include <c10/metal/atomic.h>
 #include <metal_stdlib>
 using namespace metal;
+using namespace c10::metal;
 
 enum BIN_SELECTION_ALGORITHM {
   LINEAR_INTERPOLATION,
@@ -119,6 +121,134 @@ REGISTER_HISTOGRAMDD_OP(long);
 REGISTER_HISTOGRAMDD_OP(short);
 REGISTER_HISTOGRAMDD_OP(char);
 REGISTER_HISTOGRAMDD_OP(uchar);
+
+template <typename T>
+inline long histc_bin(
+    T element,
+    long num_bins,
+    T leftmost_edge,
+    T rightmost_edge) {
+  constexpr auto eps = T(4e-6);
+  if (!(element >= (leftmost_edge - eps) &&
+        element <= (rightmost_edge + eps))) {
+    return -1;
+  }
+  long pos = static_cast<long>(
+      (element - leftmost_edge) * num_bins / (rightmost_edge - leftmost_edge));
+  return pos == num_bins ? pos - 1 : pos;
+}
+
+template <typename T, bool dense>
+kernel void histc_atomic_global(
+    constant T* input [[buffer(0)]],
+    device AtomicType_t<long>* counts [[buffer(1)]],
+    constant uint* offsets [[buffer(2)]],
+    constant uint& num_elements [[buffer(3)]],
+    constant long& num_bins [[buffer(4)]],
+    constant T* bin_edges [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]) {
+  if (tid >= num_elements) {
+    return;
+  }
+  T element = input[dense ? tid : offsets[tid]];
+  long bin = histc_bin(element, num_bins, bin_edges[0], bin_edges[num_bins]);
+  if (bin >= 0) {
+    AtomicType<long>::atomic_add(counts, bin, 1);
+  }
+}
+
+template <typename T, bool dense>
+kernel void histc_atomic_threadgroup(
+    constant T* input [[buffer(0)]],
+    device AtomicType_t<long>* counts [[buffer(1)]],
+    constant uint* offsets [[buffer(2)]],
+    constant uint& num_elements [[buffer(3)]],
+    constant long& num_bins [[buffer(4)]],
+    constant T* bin_edges [[buffer(5)]],
+    constant uint& total_threads [[buffer(6)]],
+    threadgroup atomic_uint* local_counts [[threadgroup(0)]],
+    uint tid [[thread_position_in_grid]],
+    uint local_tid [[thread_index_in_threadgroup]],
+    uint threads_per_threadgroup [[threads_per_threadgroup]]) {
+  for (uint bin = local_tid; bin < num_bins; bin += threads_per_threadgroup) {
+    atomic_store_explicit(&local_counts[bin], 0, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // The host limits num_elements to UINT32_MAX, so a local bin count fits in
+  // uint.
+  for (uint index = tid; index < num_elements; index += total_threads) {
+    T element = input[dense ? index : offsets[index]];
+    long bin = histc_bin(element, num_bins, bin_edges[0], bin_edges[num_bins]);
+    if (bin >= 0) {
+      atomic_fetch_add_explicit(&local_counts[bin], 1, memory_order_relaxed);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint bin = local_tid; bin < num_bins; bin += threads_per_threadgroup) {
+    uint value = atomic_load_explicit(&local_counts[bin], memory_order_relaxed);
+    if (value != 0) {
+      AtomicType<long>::atomic_add(counts, bin, static_cast<long>(value));
+    }
+  }
+}
+
+#define REGISTER_HISTC_ATOMIC_OP(DTYPE)                                        \
+  template [[host_name("histc_atomic_global_dense_" #DTYPE)]] kernel void      \
+  histc_atomic_global<DTYPE, true>(                                            \
+      constant DTYPE*,                                                         \
+      device AtomicType_t<long>*,                                              \
+      constant uint*,                                                          \
+      constant uint&,                                                          \
+      constant long&,                                                          \
+      constant DTYPE*,                                                         \
+      uint);                                                                   \
+  template [[host_name("histc_atomic_global_strided_" #DTYPE)]] kernel void    \
+  histc_atomic_global<DTYPE, false>(                                           \
+      constant DTYPE*,                                                         \
+      device AtomicType_t<long>*,                                              \
+      constant uint*,                                                          \
+      constant uint&,                                                          \
+      constant long&,                                                          \
+      constant DTYPE*,                                                         \
+      uint);                                                                   \
+  template [[host_name("histc_atomic_threadgroup_dense_" #DTYPE)]] kernel void \
+  histc_atomic_threadgroup<DTYPE, true>(                                       \
+      constant DTYPE*,                                                         \
+      device AtomicType_t<long>*,                                              \
+      constant uint*,                                                          \
+      constant uint&,                                                          \
+      constant long&,                                                          \
+      constant DTYPE*,                                                         \
+      constant uint&,                                                          \
+      threadgroup atomic_uint*,                                                \
+      uint,                                                                    \
+      uint,                                                                    \
+      uint);                                                                   \
+  template                                                                     \
+      [[host_name("histc_atomic_threadgroup_strided_" #DTYPE)]] kernel void    \
+      histc_atomic_threadgroup<DTYPE, false>(                                  \
+          constant DTYPE*,                                                     \
+          device AtomicType_t<long>*,                                          \
+          constant uint*,                                                      \
+          constant uint&,                                                      \
+          constant long&,                                                      \
+          constant DTYPE*,                                                     \
+          constant uint&,                                                      \
+          threadgroup atomic_uint*,                                            \
+          uint,                                                                \
+          uint,                                                                \
+          uint)
+
+REGISTER_HISTC_ATOMIC_OP(float);
+REGISTER_HISTC_ATOMIC_OP(half);
+REGISTER_HISTC_ATOMIC_OP(bfloat);
+REGISTER_HISTC_ATOMIC_OP(int);
+REGISTER_HISTC_ATOMIC_OP(long);
+REGISTER_HISTC_ATOMIC_OP(short);
+REGISTER_HISTC_ATOMIC_OP(char);
+REGISTER_HISTC_ATOMIC_OP(uchar);
 
 kernel void kernel_index_offset(
     constant uint* strides [[buffer(0)]],

--- a/aten/src/ATen/native/mps/operations/HistogramKernel.mm
+++ b/aten/src/ATen/native/mps/operations/HistogramKernel.mm
@@ -175,9 +175,10 @@ void histc_atomic_kernel_impl(Tensor& hist_output, const TensorList& bin_edges, 
         const uint32_t nDim = input.dim();
         const IntArrayRef& inputShape = input.sizes();
         std::vector<uint32_t> inputShapeData(inputShape.size());
-        std::vector<uint32_t> strides(input.strides().begin(), input.strides().end());
+        std::vector<uint32_t> strides(inputShape.size());
         for (const auto i : c10::irange(inputShape.size())) {
-          inputShapeData[i] = static_cast<uint32_t>(inputShape[i]);
+          inputShapeData[i] = c10::checked_convert<uint32_t>(inputShape[i], "uint32_t");
+          strides[i] = c10::checked_convert<uint32_t>(input.stride(i), "uint32_t");
         }
         stridedIndicesBuffer = [[device newBufferWithLength:num_elements * sizeof(uint) options:0] autorelease];
         id<MTLComputePipelineState> stridedIndicesPSO = lib.getPipelineStateForFunc("kernel_index_offset");

--- a/aten/src/ATen/native/mps/operations/HistogramKernel.mm
+++ b/aten/src/ATen/native/mps/operations/HistogramKernel.mm
@@ -23,8 +23,14 @@ enum BIN_SELECTION_ALGORITHM {
 };
 
 constexpr NSUInteger kHistcThreadsPerThreadgroup = 256;
-// Bounds the number of local histograms merged into global memory.
+// Keep threadgroup memory below 8 KiB so at least four local histograms can
+// reside within the 32 KiB available on supported Apple GPUs.
+constexpr NSUInteger kHistcMaxThreadgroupMemoryLength = 8 * 1024;
+// M1 sweeps over 8, 32, 64, 128, and 256 threadgroups showed a broad
+// performance plateau from 32 through 256. Use the midpoint to bound the
+// number of local histograms merged into global memory.
 constexpr NSUInteger kHistcMaxThreadgroups = 128;
+constexpr NSUInteger kMetalThreadgroupMemoryAlignment = 16;
 
 #ifndef PYTORCH_JIT_COMPILE_SHADERS
 static auto& lib = MetalShaderLibrary::getBundledLibrary();
@@ -154,7 +160,6 @@ void histc_atomic_kernel_impl(Tensor& hist_output, const TensorList& bin_edges, 
   TORCH_INTERNAL_ASSERT(hist_output.numel() + 1 == bin_edges[0].numel());
 
   const int64_t num_bins = hist_output.numel();
-  TORCH_CHECK(input.numel() * input.element_size() <= UINT32_MAX, "histc(): Tensor is larger than 4Gb");
   const auto num_elements = c10::checked_convert<uint32_t>(input.numel(), "uint32_t");
   Tensor counts = at::zeros({num_bins}, hist_output.options().dtype(kLong));
   if (num_elements == 0) {
@@ -172,6 +177,8 @@ void histc_atomic_kernel_impl(Tensor& hist_output, const TensorList& bin_edges, 
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
       id<MTLBuffer> stridedIndicesBuffer = nil;
       if (!dense) {
+        TORCH_CHECK(num_elements <= [device maxBufferLength] / sizeof(uint),
+                    "histc(): non-contiguous input is too large");
         const uint32_t nDim = input.dim();
         const IntArrayRef& inputShape = input.sizes();
         std::vector<uint32_t> inputShapeData(inputShape.size());
@@ -187,7 +194,10 @@ void histc_atomic_kernel_impl(Tensor& hist_output, const TensorList& bin_edges, 
         mtl_dispatch1DJob(computeEncoder, stridedIndicesPSO, num_elements);
       }
 
-      const bool use_threadgroup = num_bins <= [device maxThreadgroupMemoryLength] / sizeof(uint);
+      const NSUInteger max_threadgroup_memory_length =
+          std::min<NSUInteger>(kHistcMaxThreadgroupMemoryLength, [device maxThreadgroupMemoryLength]);
+      const bool use_threadgroup =
+          num_bins <= c10::checked_convert<int64_t>(max_threadgroup_memory_length / sizeof(uint), "int64_t");
       const std::string kernel = fmt::format("histc_atomic_{}_{}_{}",
                                              use_threadgroup ? "threadgroup" : "global",
                                              dense ? "dense" : "strided",
@@ -195,22 +205,20 @@ void histc_atomic_kernel_impl(Tensor& hist_output, const TensorList& bin_edges, 
       id<MTLComputePipelineState> histogramPSO = lib.getPipelineStateForFunc(kernel);
       getMPSProfiler().beginProfileKernel(histogramPSO, "histc", {input, counts});
       [computeEncoder setComputePipelineState:histogramPSO];
-      mtl_setArgs(computeEncoder,
-                  input,
-                  counts,
-                  dense ? getMTLBufferStorage(counts) : stridedIndicesBuffer,
-                  num_elements,
-                  num_bins,
-                  bin_edges[0]);
+      mtl_setArgs(computeEncoder, input, counts, stridedIndicesBuffer, num_elements, num_bins, bin_edges[0]);
 
       if (use_threadgroup) {
+        const NSUInteger threadgroup_memory_length =
+            (c10::checked_convert<NSUInteger>(num_bins, "NSUInteger") * sizeof(uint) +
+             kMetalThreadgroupMemoryAlignment - 1) &
+            ~(kMetalThreadgroupMemoryAlignment - 1);
         const NSUInteger threadgroup_size =
             std::min<NSUInteger>(kHistcThreadsPerThreadgroup, [histogramPSO maxTotalThreadsPerThreadgroup]);
         const NSUInteger threadgroups =
             std::min<NSUInteger>((num_elements + threadgroup_size - 1) / threadgroup_size, kHistcMaxThreadgroups);
         const uint32_t total_threads = threadgroups * threadgroup_size;
         mtl_setArgs<6>(computeEncoder, total_threads);
-        [computeEncoder setThreadgroupMemoryLength:num_bins * sizeof(uint) atIndex:0];
+        [computeEncoder setThreadgroupMemoryLength:threadgroup_memory_length atIndex:0];
         [computeEncoder dispatchThreadgroups:MTLSizeMake(threadgroups, 1, 1)
                        threadsPerThreadgroup:MTLSizeMake(threadgroup_size, 1, 1)];
       } else {
@@ -295,7 +303,6 @@ static void histogramdd_linear_kernel(const Tensor& self,
         self, weight, density, hist, bin_edges);
   } else {
     // histc codepath: bin_edges are not returned to the caller
-    TORCH_CHECK(self.device() == hist.device(), "histc: expected self and out to be on the same device");
     TORCH_INTERNAL_ASSERT(!weight.has_value() && !density);
     AT_DISPATCH_V2(self.scalar_type(),
                    "histc_mps",

--- a/aten/src/ATen/native/mps/operations/HistogramKernel.mm
+++ b/aten/src/ATen/native/mps/operations/HistogramKernel.mm
@@ -22,6 +22,10 @@ enum BIN_SELECTION_ALGORITHM {
   BINARY_SEARCH,
 };
 
+constexpr NSUInteger kHistcThreadsPerThreadgroup = 256;
+// Bounds the number of local histograms merged into global memory.
+constexpr NSUInteger kHistcMaxThreadgroups = 128;
+
 #ifndef PYTORCH_JIT_COMPILE_SHADERS
 static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #else
@@ -143,6 +147,80 @@ void histogramdd_kernel_impl(Tensor& hist_output,
   at::sum_out(hist_output, thread_histograms, /*dim=*/{0});
 }
 
+template <typename input_t>
+void histc_atomic_kernel_impl(Tensor& hist_output, const TensorList& bin_edges, const Tensor& input) {
+  TORCH_INTERNAL_ASSERT(input.dim() == 2 && input.size(1) == 1);
+  TORCH_INTERNAL_ASSERT(bin_edges.size() == 1);
+  TORCH_INTERNAL_ASSERT(hist_output.numel() + 1 == bin_edges[0].numel());
+
+  const int64_t num_bins = hist_output.numel();
+  TORCH_CHECK(input.numel() * input.element_size() <= UINT32_MAX, "histc(): Tensor is larger than 4Gb");
+  const auto num_elements = c10::checked_convert<uint32_t>(input.numel(), "uint32_t");
+  Tensor counts = at::zeros({num_bins}, hist_output.options().dtype(kLong));
+  if (num_elements == 0) {
+    hist_output.copy_(counts);
+    return;
+  }
+
+  const bool dense = input.is_contiguous();
+
+  id<MTLDevice> device = MPSDevice::getInstance()->device();
+  MPSStream* mpsStream = getCurrentMPSStream();
+
+  dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+      id<MTLBuffer> stridedIndicesBuffer = nil;
+      if (!dense) {
+        const uint32_t nDim = input.dim();
+        const IntArrayRef& inputShape = input.sizes();
+        std::vector<uint32_t> inputShapeData(inputShape.size());
+        std::vector<uint32_t> strides(input.strides().begin(), input.strides().end());
+        for (const auto i : c10::irange(inputShape.size())) {
+          inputShapeData[i] = static_cast<uint32_t>(inputShape[i]);
+        }
+        stridedIndicesBuffer = [[device newBufferWithLength:num_elements * sizeof(uint) options:0] autorelease];
+        id<MTLComputePipelineState> stridedIndicesPSO = lib.getPipelineStateForFunc("kernel_index_offset");
+        [computeEncoder setComputePipelineState:stridedIndicesPSO];
+        mtl_setArgs(computeEncoder, strides, stridedIndicesBuffer, inputShapeData, nDim);
+        mtl_dispatch1DJob(computeEncoder, stridedIndicesPSO, num_elements);
+      }
+
+      const bool use_threadgroup = num_bins <= [device maxThreadgroupMemoryLength] / sizeof(uint);
+      const std::string kernel = fmt::format("histc_atomic_{}_{}_{}",
+                                             use_threadgroup ? "threadgroup" : "global",
+                                             dense ? "dense" : "strided",
+                                             scalarToMetalTypeString(input));
+      id<MTLComputePipelineState> histogramPSO = lib.getPipelineStateForFunc(kernel);
+      getMPSProfiler().beginProfileKernel(histogramPSO, "histc", {input, counts});
+      [computeEncoder setComputePipelineState:histogramPSO];
+      mtl_setArgs(computeEncoder,
+                  input,
+                  counts,
+                  dense ? getMTLBufferStorage(counts) : stridedIndicesBuffer,
+                  num_elements,
+                  num_bins,
+                  bin_edges[0]);
+
+      if (use_threadgroup) {
+        const NSUInteger threadgroup_size =
+            std::min<NSUInteger>(kHistcThreadsPerThreadgroup, [histogramPSO maxTotalThreadsPerThreadgroup]);
+        const NSUInteger threadgroups =
+            std::min<NSUInteger>((num_elements + threadgroup_size - 1) / threadgroup_size, kHistcMaxThreadgroups);
+        const uint32_t total_threads = threadgroups * threadgroup_size;
+        mtl_setArgs<6>(computeEncoder, total_threads);
+        [computeEncoder setThreadgroupMemoryLength:num_bins * sizeof(uint) atIndex:0];
+        [computeEncoder dispatchThreadgroups:MTLSizeMake(threadgroups, 1, 1)
+                       threadsPerThreadgroup:MTLSizeMake(threadgroup_size, 1, 1)];
+      } else {
+        mtl_dispatch1DJob(computeEncoder, histogramPSO, num_elements);
+      }
+      getMPSProfiler().endProfileKernel(histogramPSO);
+    }
+  });
+  hist_output.copy_(counts);
+}
+
 template <BIN_SELECTION_ALGORITHM bin_algorithm>
 static void histogramdd_out_mps_template(const Tensor& self,
                                          const std::optional<Tensor>& weight,
@@ -216,7 +294,15 @@ static void histogramdd_linear_kernel(const Tensor& self,
         self, weight, density, hist, bin_edges);
   } else {
     // histc codepath: bin_edges are not returned to the caller
-    mps::histogramdd_out_mps_template<mps::LINEAR_INTERPOLATION>(self, weight, density, hist, bin_edges);
+    TORCH_CHECK(self.device() == hist.device(), "histc: expected self and out to be on the same device");
+    TORCH_INTERNAL_ASSERT(!weight.has_value() && !density);
+    AT_DISPATCH_V2(self.scalar_type(),
+                   "histc_mps",
+                   AT_WRAP([&]() { mps::histc_atomic_kernel_impl<scalar_t>(hist, bin_edges, self); }),
+                   AT_EXPAND(AT_ALL_TYPES),
+                   kBFloat16,
+                   kHalf,
+                   AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES));
   }
 }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -920,20 +920,6 @@ class TestMPS(TestCaseMPS):
         kl_div = F.kl_div(q.log(), p, reduction='sum').item()
         self.assertLess(kl_div, 0.03)
 
-    def test_histc_atomic_paths(self):
-        for dtype in (torch.float16, torch.bfloat16, torch.float32):
-            cpu_base = (torch.arange(64, dtype=torch.float32) * 0.0137 + 0.031).to(dtype)
-            mps_base = cpu_base.to("mps")
-
-            for cpu_input, mps_input in ((cpu_base, mps_base), (cpu_base[::2], mps_base[::2])):
-                for bins in (256, 8193):
-                    with self.subTest(dtype=dtype, bins=bins, contiguous=cpu_input.is_contiguous()):
-                        expected = torch.histc(cpu_input, bins=bins, min=0.0, max=1.0)
-                        out_base = torch.empty(2 * bins, dtype=dtype, device="mps")
-                        actual = out_base[::2]
-                        torch.histc(mps_input, bins=bins, min=0.0, max=1.0, out=actual)
-                        self.assertEqual(actual.cpu(), expected)
-
     def test_stream_base(self):
         s1 = torch._C._MPSStreamBase()
         s2 = torch._C._MPSStreamBase()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -920,6 +920,20 @@ class TestMPS(TestCaseMPS):
         kl_div = F.kl_div(q.log(), p, reduction='sum').item()
         self.assertLess(kl_div, 0.03)
 
+    def test_histc_atomic_paths(self):
+        for dtype in (torch.float16, torch.bfloat16, torch.float32):
+            cpu_base = (torch.arange(64, dtype=torch.float32) * 0.0137 + 0.031).to(dtype)
+            mps_base = cpu_base.to("mps")
+
+            for cpu_input, mps_input in ((cpu_base, mps_base), (cpu_base[::2], mps_base[::2])):
+                for bins in (256, 8193):
+                    with self.subTest(dtype=dtype, bins=bins, contiguous=cpu_input.is_contiguous()):
+                        expected = torch.histc(cpu_input, bins=bins, min=0.0, max=1.0)
+                        out_base = torch.empty(2 * bins, dtype=dtype, device="mps")
+                        actual = out_base[::2]
+                        torch.histc(mps_input, bins=bins, min=0.0, max=1.0, out=actual)
+                        self.assertEqual(actual.cpu(), expected)
+
     def test_stream_base(self):
         s1 = torch._C._MPSStreamBase()
         s2 = torch._C._MPSStreamBase()

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3269,6 +3269,19 @@ def sample_inputs_histc(op_info, device, dtype, requires_grad, **kwargs):
         for bins in [1, 3, 10]:
             yield SampleInput(make_arg(size), bins=bins, min=min, max=max)
 
+    # Exercises implementations that switch algorithms for large bin counts.
+    yield SampleInput(make_arg((S,)), bins=8193, min=0, max=10)
+
+    if dtype.is_floating_point:
+        # Values just outside a narrow range must not produce an invalid bin.
+        narrow_range = torch.tensor(
+            [0.0, 5e-6, 1e-5, 1.2e-5],
+            device=device,
+            dtype=dtype,
+            requires_grad=requires_grad,
+        )
+        yield SampleInput(narrow_range, bins=1000, min=0.0, max=1e-5)
+
 def sample_inputs_bincount(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, dtype=dtype, device=device, requires_grad=requires_grad)
 


### PR DESCRIPTION
## Summary

Replace the per-element temporary used by MPS `histc` with an atomic Metal
histogram. The new implementation uses threadgroup counters for histograms that
fit within an 8 KiB local-memory budget and global counters for larger bin
counts.

The current path materializes a tensor with shape `[input.numel(), bins]`. For
one million float32 elements and 256 bins, this is a 1 GiB temporary. The new
path uses a 2 KiB global count tensor and 1 KiB of threadgroup memory per active
threadgroup.

Counts are accumulated as int64 using the existing
`c10::metal::AtomicType<long>` helper, then copied to the requested output
dtype. Since `histc` is unweighted and each update adds the exact integer value
one, atomic update order does not affect the result.

## Performance

Apple M1, float32, 256 bins:

| Elements | Current MPS | This change | Speedup |
|---:|---:|---:|---:|
| 1,024 | 50.017 ms | 0.0664 ms | 752.7x |
| 65,536 | 49.905 ms | 0.0714 ms | 698.6x |
| 1,048,576 | 82.225 ms | 0.1996 ms | 412.0x |

These numbers are specific to the tested M1 and workload.

## Testing

```text
python test/test_ops.py TestCommonMPS -k histc
python test/test_ops.py TestCommonCPU -k histc
```

The common OpInfo samples cover floating-point and integer dtypes, empty input,
single-bin histograms, large-bin global counters, and narrow ranges. Additional
checks covered contiguous and non-contiguous inputs, non-contiguous `out=`, and
the threadgroup/global boundary. The changed files also pass lintrunner.
