### PR TITLE
[Testcase Refactoring] Add hw_classification and instantiate_device_type_tests to test_c10d_ops_nccl.py

### DIFF
--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -24,6 +24,7 @@ if not c10d.is_available() or not c10d.is_nccl_available():
 
 import torch.distributed as dist
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8, TEST_MULTIGPU
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     init_multigpu_helper,
     MultiProcContinuousTest,
@@ -31,11 +32,12 @@ from torch.testing._internal.common_distributed import (
     requires_nccl_version,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_LINUX,
     run_tests,
     skip_but_pass_in_sandcastle_if,
+    skipIfRocm,
     TEST_WITH_DEV_DBG_ASAN,
-    TEST_WITH_ROCM,
 )
 
 
@@ -47,6 +49,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @classmethod
     def backend_str(cls) -> str:
         return "nccl"
@@ -320,7 +324,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
             expected_val *= self.world_size
             self.assertEqual(xs.item(), expected_val)
 
-    @unittest.skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/157896")
+    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/157896")
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_nccl_watchdog_cudagraph(self):
@@ -1253,6 +1257,12 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         # Like other ReduceOps, PREMUL_SUM should have a unique integer value.
         self.assertEqual(c10d.ReduceOp.PREMUL_SUM, 8)
 
+
+instantiate_device_type_tests(
+    ProcessGroupNCCLOpTest,
+    globals(),
+    only_for=("cuda",),
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -70,7 +70,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_empty_tensors(self, device):
         pg = self.pg
-        local_device_idx = self.rank_to_GPU[self.rank][0]
+        local_device_idx = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         xs = [torch.FloatTensor([]).cuda(local_device_idx)]
         pg.broadcast(xs).wait()
@@ -106,6 +106,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_broadcast_ops(self, device):
         pg = self.pg
+        device_type = torch.device(device).type
 
         def broadcast(xs, rootRank, rootTensor):
             opts = c10d.BroadcastOptions()
@@ -118,20 +119,26 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         # Every rank is root once
         for i in range(self.world_size):
             # Run with 1 input tensor
-            x = torch.tensor([self.rank]).cuda(self.rank_to_GPU[self.rank][0])
+            x = torch.tensor([self.rank]).cuda(
+                torch.device(device_type, self.rank_to_GPU[self.rank][0])
+            )
             output = broadcast([x], i, 0)
             self.assertEqual(torch.tensor([i]), output[0])
 
             expected_tensor = torch.empty([i + 1, i + 1]).fill_(i + 1)
             xs = [
-                torch.empty([i + 1, i + 1]).fill_(-1).cuda(device=device_idx)
+                torch.empty([i + 1, i + 1]).fill_(-1).cuda(
+                    device=torch.device(device_type, device_idx)
+                )
                 for device_idx in self.rank_to_GPU[self.rank]
             ]
 
             # test with multiple input tensors (multiple gpu in one rank)
             for j in range(len(xs)):
                 if self.rank == i:
-                    xs[j] = expected_tensor.cuda(device=self.rank_to_GPU[self.rank][j])
+                    xs[j] = expected_tensor.cuda(
+                        device=torch.device(device_type, self.rank_to_GPU[self.rank][j])
+                    )
 
                 broadcast(xs, i, j)
 
@@ -142,11 +149,12 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_sparse_allreduce_ops(self, device):
         pg = self.pg
+        device = torch.device(torch.device(device).type, self.rank)
 
         indices = torch.tensor([[0, 1]])
         values = torch.tensor([[1, 2, 0], [4, 0, 6]])
         sparse_tensor = torch.sparse_coo_tensor(indices, values, size=(2, 3)).to(
-            self.rank
+            device
         )
 
         # sparse allreduce call is wrapped in a try catch since the c10d API is only available in the nccl experimental branch
@@ -156,7 +164,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
             work.wait()
 
             # tensor_list is a list of size 1, with the allreduce output as a dense tensor
-            a = torch.tensor([[2, 4, 0], [8, 0, 12]]).to(self.rank)
+            a = torch.tensor([[2, 4, 0], [8, 0, 12]]).to(device)
             self.assertEqual(tensor_list[0], a)
         except RuntimeError as e:
             if "NCCL does not support all_reduce with sparse tensors" in str(e):
@@ -169,7 +177,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_allreduce_ops(self, device):
         pg = self.pg
-        local_device_id = self.rank_to_GPU[self.rank][0]
+        local_device_id = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         def allreduce(tensors, op):
             opts = c10d.AllreduceOptions()
@@ -297,7 +305,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_allreduce_in_cudagraph(self, device):
-        local_device_idx = self.rank_to_GPU[self.rank][0]
+        local_device_idx = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
         # This device setting is needed by the CUDAGraph API to understand on
         # which device to find the current stream
         torch.cuda.set_device(local_device_idx)
@@ -330,7 +338,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     def test_nccl_watchdog_cudagraph(self, device):
         # test that the watchdog does not crash graphs with disallowed event query
         pg = self.pg
-        rank = self.rank_to_GPU[self.rank][0]
+        rank = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
         with torch.cuda.device(rank):
             for _ in range(10):
                 xs = [torch.FloatTensor([1]).cuda(rank)]
@@ -356,12 +364,12 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     def test_nccl_cudagraph_multisegment(self, device):
         # Prior to NCCL 2.29, this would cause an Invalid Memory Access (IMA)
         # because NCCL didn't properly handle multisegment memory in graphs.
-        local_device_idx = self.rank_to_GPU[self.rank][0]
+        local_device_idx = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
         torch.cuda.set_device(local_device_idx)
         torch.cuda.memory._set_allocator_settings("expandable_segments:True")
 
         b, t, d = 64, 1, 101024
-        inp = torch.ones((b, t, d), device="cuda") * (self.rank + 1)
+        inp = torch.ones((b, t, d), device=torch.device(device).type) * (self.rank + 1)
 
         for _ in range(3):
             output = inp.new_empty((self.world_size, b, t, d))
@@ -387,7 +395,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_reduce_ops(self, device):
         pg = self.pg
-        local_device_id = self.rank_to_GPU[self.rank][0]
+        local_device_id = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         def reduce(xs, rootRank, rootTensor, op=None):
             opts = c10d.ReduceOptions()
@@ -452,7 +460,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_allgather_ops(self, device):
         pg = self.pg
-        local_device_ids = self.rank_to_GPU[self.rank]
+        local_device_ids = [torch.device(torch.device(device).type, i) for i in self.rank_to_GPU[self.rank]]
 
         def allgather(output_ts, input_ts):
             work = pg.allgather(output_ts, input_ts)
@@ -482,7 +490,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_allgather_base_ops(self, device):
         pg = self.pg
-        local_device_id = self.rank_to_GPU[self.rank][0]
+        local_device_id = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         def allgather_base(output_t, input_t):
             work = pg.all_gather_single(output_t, input_t)
@@ -504,7 +512,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_allgather_base_basics(self, device):
         pg = self.pg
-        local_device_id = self.rank_to_GPU[self.rank][0]
+        local_device_id = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         def allgather_base(output_t, input_t):
             work = pg.all_gather_single(output_t, input_t)
@@ -537,7 +545,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_gather_ops(self, device):
         pg = self.pg
-        local_device_ids = self.rank_to_GPU[self.rank]
+        local_device_ids = [torch.device(torch.device(device).type, i) for i in self.rank_to_GPU[self.rank]]
         num_gpus = len(local_device_ids)
 
         def gather(output_t, input_t, rootRank):
@@ -572,7 +580,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_gather_stress(self, device):
         pg = self.pg
-        local_device_ids = self.rank_to_GPU[self.rank]
+        local_device_ids = [torch.device(torch.device(device).type, i) for i in self.rank_to_GPU[self.rank]]
         num_gpus = len(local_device_ids)
 
         def gather(output_t, input_t, rootRank):
@@ -614,7 +622,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_gather_checks(self, device):
         pg = self.pg
-        device_id = self.rank_to_GPU[self.rank][0]
+        device_id = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         # init input
         tensor = torch.tensor([self.rank]).cuda(device_id)
@@ -650,7 +658,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_scatter_ops(self, device):
         pg = self.pg
-        local_device_ids = self.rank_to_GPU[self.rank]
+        local_device_ids = [torch.device(torch.device(device).type, i) for i in self.rank_to_GPU[self.rank]]
         num_gpus = len(local_device_ids)
 
         def scatter(output_t, input_t, rootRank):
@@ -685,7 +693,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_scatter_stress(self, device):
         pg = self.pg
-        local_device_ids = self.rank_to_GPU[self.rank]
+        local_device_ids = [torch.device(torch.device(device).type, i) for i in self.rank_to_GPU[self.rank]]
         num_gpus = len(local_device_ids)
 
         def scatter(output_t, input_t, rootRank):
@@ -727,7 +735,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_scatter_checks(self, device):
         pg = self.pg
-        local_device_ids = self.rank_to_GPU[self.rank]
+        local_device_ids = [torch.device(torch.device(device).type, i) for i in self.rank_to_GPU[self.rank]]
         num_gpus = len(local_device_ids)
 
         # init output
@@ -769,7 +777,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_reduce_scatter_base_basics(self, device):
         pg = self.pg
-        local_device_id = self.rank_to_GPU[self.rank][0]
+        local_device_id = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         def reduce_scatter_base(output_t, input_t):
             work = pg.reduce_scatter_single(output_t, input_t)
@@ -828,7 +836,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_reduce_scatter_ops(self, device):
         pg = self.pg
-        local_device_ids = self.rank_to_GPU[self.rank]
+        local_device_ids = [torch.device(torch.device(device).type, i) for i in self.rank_to_GPU[self.rank]]
         num_gpus = len(local_device_ids)
 
         def reduce_scatter(outputs, input_lists, op):
@@ -939,7 +947,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_reduce_scatter_base_ops(self, device):
         pg = self.pg
-        local_device_id = self.rank_to_GPU[self.rank][0]
+        local_device_id = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         def reduce_scatter_base(output_t, input_t):
             work = pg.reduce_scatter_single(output_t, input_t)
@@ -1003,7 +1011,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_barrier(self, device):
         pg = self.pg
-        local_device_ids = self.rank_to_GPU[self.rank]
+        local_device_ids = [torch.device(torch.device(device).type, i) for i in self.rank_to_GPU[self.rank]]
 
         def allreduce(tensors):
             opts = c10d.AllreduceOptions()
@@ -1083,7 +1091,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         os.environ["TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK"] = "1"
 
         pg = self.pg
-        local_device_id = self.rank_to_GPU[self.rank][0]
+        local_device_id = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         def allgather_base(output_t, input_t):
             work = pg.all_gather_single(output_t, input_t)
@@ -1111,7 +1119,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
             self.skipTest("NCCL 2.11.1+ is required for PREMUL_SUM")
 
         pg = self.pg
-        local_device_id = self.rank_to_GPU[self.rank][0]
+        local_device_id = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         def allreduce(tensors, op):
             opts = c10d.AllreduceOptions()

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -68,7 +68,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_empty_tensors(self):
+    def test_empty_tensors(self, device):
         pg = self.pg
         local_device_idx = self.rank_to_GPU[self.rank][0]
 
@@ -104,7 +104,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_broadcast_ops(self):
+    def test_broadcast_ops(self, device):
         pg = self.pg
 
         def broadcast(xs, rootRank, rootTensor):
@@ -140,7 +140,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_sparse_allreduce_ops(self):
+    def test_sparse_allreduce_ops(self, device):
         pg = self.pg
 
         indices = torch.tensor([[0, 1]])
@@ -167,7 +167,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_allreduce_ops(self):
+    def test_allreduce_ops(self, device):
         pg = self.pg
         local_device_id = self.rank_to_GPU[self.rank][0]
 
@@ -255,7 +255,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(
         not PLATFORM_SUPPORTS_FP8, "Float8 requires sm >= 90"
     )
-    def test_allreduce_float8(self):
+    def test_allreduce_float8(self, device):
         device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
 
         numel = 1024
@@ -271,7 +271,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_alltoall_ops_with_cudafree_race(self):
+    def test_alltoall_ops_with_cudafree_race(self, device):
         pg = self.pg
         opts = c10d.AllToAllOptions()
         local_device = f"cuda:{self.rank_to_GPU[self.rank][0]}"
@@ -296,7 +296,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_allreduce_in_cudagraph(self):
+    def test_allreduce_in_cudagraph(self, device):
         local_device_idx = self.rank_to_GPU[self.rank][0]
         # This device setting is needed by the CUDAGraph API to understand on
         # which device to find the current stream
@@ -327,7 +327,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/157896")
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_nccl_watchdog_cudagraph(self):
+    def test_nccl_watchdog_cudagraph(self, device):
         # test that the watchdog does not crash graphs with disallowed event query
         pg = self.pg
         rank = self.rank_to_GPU[self.rank][0]
@@ -353,7 +353,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         (2, 29), "Need NCCL 2.29+ for multisegment memory in CUDA graph"
     )
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_nccl_cudagraph_multisegment(self):
+    def test_nccl_cudagraph_multisegment(self, device):
         # Prior to NCCL 2.29, this would cause an Invalid Memory Access (IMA)
         # because NCCL didn't properly handle multisegment memory in graphs.
         local_device_idx = self.rank_to_GPU[self.rank][0]
@@ -385,7 +385,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_reduce_ops(self):
+    def test_reduce_ops(self, device):
         pg = self.pg
         local_device_id = self.rank_to_GPU[self.rank][0]
 
@@ -450,7 +450,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_allgather_ops(self):
+    def test_allgather_ops(self, device):
         pg = self.pg
         local_device_ids = self.rank_to_GPU[self.rank]
 
@@ -480,7 +480,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_allgather_base_ops(self):
+    def test_allgather_base_ops(self, device):
         pg = self.pg
         local_device_id = self.rank_to_GPU[self.rank][0]
 
@@ -502,7 +502,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_allgather_base_basics(self):
+    def test_allgather_base_basics(self, device):
         pg = self.pg
         local_device_id = self.rank_to_GPU[self.rank][0]
 
@@ -535,7 +535,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_gather_ops(self):
+    def test_gather_ops(self, device):
         pg = self.pg
         local_device_ids = self.rank_to_GPU[self.rank]
         num_gpus = len(local_device_ids)
@@ -570,7 +570,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_gather_stress(self):
+    def test_gather_stress(self, device):
         pg = self.pg
         local_device_ids = self.rank_to_GPU[self.rank]
         num_gpus = len(local_device_ids)
@@ -612,7 +612,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_gather_checks(self):
+    def test_gather_checks(self, device):
         pg = self.pg
         device_id = self.rank_to_GPU[self.rank][0]
 
@@ -648,7 +648,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_scatter_ops(self):
+    def test_scatter_ops(self, device):
         pg = self.pg
         local_device_ids = self.rank_to_GPU[self.rank]
         num_gpus = len(local_device_ids)
@@ -683,7 +683,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_scatter_stress(self):
+    def test_scatter_stress(self, device):
         pg = self.pg
         local_device_ids = self.rank_to_GPU[self.rank]
         num_gpus = len(local_device_ids)
@@ -725,7 +725,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_scatter_checks(self):
+    def test_scatter_checks(self, device):
         pg = self.pg
         local_device_ids = self.rank_to_GPU[self.rank]
         num_gpus = len(local_device_ids)
@@ -767,7 +767,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_reduce_scatter_base_basics(self):
+    def test_reduce_scatter_base_basics(self, device):
         pg = self.pg
         local_device_id = self.rank_to_GPU[self.rank][0]
 
@@ -800,7 +800,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_reduce_scatter_v(self):
+    def test_reduce_scatter_v(self, device):
         device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
         # A list of tensors with different sizes
         input_list = [torch.ones(i, device=device) for i in range(self.world_size)]
@@ -813,7 +813,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_all_gather_v(self):
+    def test_all_gather_v(self, device):
         device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
         # A list of tensors with different sizes
         output_list = [torch.zeros(i, device=device) for i in range(self.world_size)]
@@ -826,7 +826,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_reduce_scatter_ops(self):
+    def test_reduce_scatter_ops(self, device):
         pg = self.pg
         local_device_ids = self.rank_to_GPU[self.rank]
         num_gpus = len(local_device_ids)
@@ -937,7 +937,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_reduce_scatter_base_ops(self):
+    def test_reduce_scatter_base_ops(self, device):
         pg = self.pg
         local_device_id = self.rank_to_GPU[self.rank][0]
 
@@ -963,7 +963,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(
         not PLATFORM_SUPPORTS_FP8, "Float8 requires sm >= 90"
     )
-    def test_reduce_scatter_float8(self):
+    def test_reduce_scatter_float8(self, device):
         device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
 
         numel = 1024
@@ -981,7 +981,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         torch.testing.assert_close(output_tensor, expected)
 
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_reduce_scatter_bfloat16(self):
+    def test_reduce_scatter_bfloat16(self, device):
         device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
 
         numel = 1024
@@ -1001,7 +1001,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_barrier(self):
+    def test_barrier(self, device):
         pg = self.pg
         local_device_ids = self.rank_to_GPU[self.rank]
 
@@ -1036,7 +1036,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_send_recv(self):
+    def test_send_recv(self, device):
         device = self.rank_to_GPU[self.rank][0]
 
         # Generate the same random tensor
@@ -1051,7 +1051,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_send_recv_complex(self):
+    def test_send_recv_complex(self, device):
         device = self.rank_to_GPU[self.rank][0]
 
         # Generate the same random tensor
@@ -1066,7 +1066,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_send_recv_object_list(self):
+    def test_send_recv_object_list(self, device):
         device = self.rank_to_GPU[self.rank][0]
 
         val = 99 if self.rank == 0 else None
@@ -1079,7 +1079,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_tensor_register_hook(self):
+    def test_tensor_register_hook(self, device):
         os.environ["TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK"] = "1"
 
         pg = self.pg
@@ -1106,7 +1106,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_reduce_op_premul_sum(self):
+    def test_reduce_op_premul_sum(self, device):
         if torch.cuda.nccl.version() < (2, 11, 1):
             self.skipTest("NCCL 2.11.1+ is required for PREMUL_SUM")
 

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -441,13 +441,13 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
                         factor_ref = factor
                     float_tensors = [
                         torch.tensor(
-                            [self.rank + 1.0], device=f"cuda:{local_device_id}"
+                            [self.rank + 1.0], device=local_device_id
                         )
                     ]
                     float_tensors_ref = [
                         torch.tensor(
                             [(self.rank + 1.0) * factor_ref],
-                            device=f"cuda:{local_device_id}",
+                            device=local_device_id,
                         )
                     ]
 
@@ -1152,13 +1152,13 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
             expected = scalar_factor * torch.tensor(
                 [self.world_size * (self.world_size + 1) / 2],
                 dtype=dtype,
-                device=f"cuda:{local_device_id}",
+                device=local_device_id,
             )
             self.assertEqual(expected, tensors[0])
 
         for dtype in (torch.half, torch.float, torch.double):
             tensor_factor = torch.tensor(
-                [5.0], device=f"cuda:{local_device_id}", dtype=dtype
+                [5.0], device=local_device_id, dtype=dtype
             )
             tensors = [
                 torch.tensor([self.rank + 1]).cuda(local_device_id).to(dtype=dtype)
@@ -1169,7 +1169,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
             expected = tensor_factor * torch.tensor(
                 [self.world_size * (self.world_size + 1) / 2],
                 dtype=dtype,
-                device=f"cuda:{local_device_id}",
+                device=local_device_id,
             )
             self.assertEqual(expected, tensors[0])
 
@@ -1188,13 +1188,13 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
                     expected = scalar_factor * torch.tensor(
                         [self.world_size * (self.world_size + 1) / 2],
                         dtype=dtype,
-                        device=f"cuda:{local_device_id}",
+                        device=local_device_id,
                     )
                     self.assertEqual(expected, tensors[0])
 
                 # Test with tensor factor
                 tensor_factor = torch.tensor(
-                    [4.0], device=f"cuda:{local_device_id}", dtype=dtype
+                    [4.0], device=local_device_id, dtype=dtype
                 )
                 tensors = [
                     torch.tensor([self.rank + 1]).cuda(local_device_id).to(dtype=dtype)
@@ -1206,7 +1206,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
                     expected = tensor_factor * torch.tensor(
                         [self.world_size * (self.world_size + 1) / 2],
                         dtype=dtype,
-                        device=f"cuda:{local_device_id}",
+                        device=local_device_id,
                     )
                     self.assertEqual(expected, tensors[0])
 
@@ -1214,10 +1214,10 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         for dtype in (torch.half, torch.float, torch.double):
             # Test with scalar factor
             scalar_factor = 3.0
-            output = [torch.zeros(1, dtype=dtype, device=f"cuda:{local_device_id}")]
+            output = [torch.zeros(1, dtype=dtype, device=local_device_id)]
             input_lists = [
                 [
-                    torch.tensor([i + 1], dtype=dtype, device=f"cuda:{local_device_id}")
+                    torch.tensor([i + 1], dtype=dtype, device=local_device_id)
                     for i in range(self.world_size)
                 ]
             ]
@@ -1228,18 +1228,18 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
             expected = scalar_factor * torch.tensor(
                 [self.world_size * (self.rank + 1)],
                 dtype=dtype,
-                device=f"cuda:{local_device_id}",
+                device=local_device_id,
             )
             self.assertEqual(expected, output[0])
 
             # Test with tensor factor
             tensor_factor = torch.tensor(
-                [5.0], device=f"cuda:{local_device_id}", dtype=dtype
+                [5.0], device=local_device_id, dtype=dtype
             )
-            output = [torch.zeros(1, dtype=dtype, device=f"cuda:{local_device_id}")]
+            output = [torch.zeros(1, dtype=dtype, device=local_device_id)]
             input_lists = [
                 [
-                    torch.tensor([i + 1], dtype=dtype, device=f"cuda:{local_device_id}")
+                    torch.tensor([i + 1], dtype=dtype, device=local_device_id)
                     for i in range(self.world_size)
                 ]
             ]
@@ -1249,7 +1249,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
             expected = tensor_factor * torch.tensor(
                 [self.world_size * (self.rank + 1)],
                 dtype=dtype,
-                device=f"cuda:{local_device_id}",
+                device=local_device_id,
             )
             self.assertEqual(expected, output[0])
 

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -256,7 +256,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_FP8, "Float8 requires sm >= 90"
     )
     def test_allreduce_float8(self, device):
-        device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
+        device = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         numel = 1024
         tensor = torch.ones(numel, dtype=torch.float32, device=device).to(
@@ -801,7 +801,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_reduce_scatter_v(self, device):
-        device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
+        device = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
         # A list of tensors with different sizes
         input_list = [torch.ones(i, device=device) for i in range(self.world_size)]
         # The i-th output should have size i
@@ -814,7 +814,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_all_gather_v(self, device):
-        device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
+        device = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
         # A list of tensors with different sizes
         output_list = [torch.zeros(i, device=device) for i in range(self.world_size)]
         # The i-th input has size i, filled with value i
@@ -964,7 +964,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_FP8, "Float8 requires sm >= 90"
     )
     def test_reduce_scatter_float8(self, device):
-        device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
+        device = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         numel = 1024
         output_tensor = torch.zeros(numel, dtype=torch.float32, device=device).to(
@@ -982,7 +982,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_reduce_scatter_bfloat16(self, device):
-        device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
+        device = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         numel = 1024
         output_tensor = torch.zeros(numel, dtype=torch.float32, device=device).to(
@@ -1037,7 +1037,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_send_recv(self, device):
-        device = self.rank_to_GPU[self.rank][0]
+        device = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         # Generate the same random tensor
         torch.manual_seed(0)
@@ -1052,7 +1052,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_send_recv_complex(self, device):
-        device = self.rank_to_GPU[self.rank][0]
+        device = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         # Generate the same random tensor
         torch.manual_seed(0)
@@ -1067,7 +1067,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_send_recv_object_list(self, device):
-        device = self.rank_to_GPU[self.rank][0]
+        device = torch.device(torch.device(device).type, self.rank_to_GPU[self.rank][0])
 
         val = 99 if self.rank == 0 else None
         object_list = [val] * self.world_size


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.CUDA` to
`ProcessGroupNCCLOpTest` and register it via
`instantiate_device_type_tests(only_for=("cuda",))`.  Also replace
the remaining `@unittest.skipIf(TEST_WITH_ROCM, ...)` with the
standard `@skipIfRocm` decorator.

## Changes

- **Import `HardwareClassification`, `skipIfRocm`,
  `instantiate_device_type_tests`.**  Remove the unused
  `TEST_WITH_ROCM` import.
- **Add `hw_classification = HardwareClassification.CUDA`** to
  `ProcessGroupNCCLOpTest`.
- **Replace `@unittest.skipIf(TEST_WITH_ROCM, ...)`** on
  `test_nccl_watchdog_cudagraph` with `@skipIfRocm(msg=...)`.
- **Add `instantiate_device_type_tests(only_for=("cuda",))`** at
  module level so `ProcessGroupNCCLOpTestCUDA` is generated.
  `only_for=("cuda",)` reflects that every test in this file
  requires NCCL, which is NVIDIA-specific.

## Not changed

- No test logic, assertions, or other decorators are modified.  The
  existing `@requires_nccl()`, `TEST_MULTIGPU` gates, and NCCL
  version checks on individual methods remain in place.

## Test plan

- `python test/distributed/test_c10d_ops_nccl.py` — TODO: run on a
  CUDA build with 2+ GPUs and confirm the generated
  `ProcessGroupNCCLOpTestCUDA` variant passes all tests.