### PR TITLE
[Test] Make test_complex_tensor.py device-agnostic for OOT backends

### DIFF
--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -32,7 +32,11 @@ from torch.testing._internal.common_device_type import (
     OpDTypes,
     ops,
 )
-from torch.testing._internal.common_utils import run_tests, unMarkDynamoStrictTest
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    unMarkDynamoStrictTest,
+)
 
 
 if TYPE_CHECKING:
@@ -128,6 +132,7 @@ EXTRA_KWARGS = {
 
 
 class TestComplexTensor(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
     _default_dtype_check_enabled = True
 
     @ops(
@@ -141,6 +146,11 @@ class TestComplexTensor(TestCase):
     @ops(force_test_op_db, allowed_dtypes=list(COMPLEX_DTYPES))
     def test_maybe_error(self, device, dtype, op: OpInfo):
         self.check_consistency(device, dtype, op, Variant.Op)
+
+
+class TestComplexTensorGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+    _default_dtype_check_enabled = True
 
     def test_get_set_components(self):
         from torch._subclasses.complex_tensor import ComplexTensor
@@ -182,6 +192,7 @@ class TestComplexTensor(TestCase):
 
 @unMarkDynamoStrictTest
 class TestComplexBwdGradients(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
     _default_dtype_check_enabled = True
 
     @ops(
@@ -202,6 +213,8 @@ if dist.is_available():
 
     @unMarkDynamoStrictTest
     class TestComplexDistributed(TestCase, MultiProcessTestCase):
+        hw_classification = HardwareClassification.ACCELERATOR
+
         @ops(implemented_op_db, allowed_dtypes=list(COMPLEX_DTYPES))
         def test_distributed(self, device, dtype, op: OpInfo):
             self.check_consistency(device, dtype, op, Variant.Distributed)


### PR DESCRIPTION
### Summary

Make `test/complex_tensor/test_complex_tensor.py` device-agnostic for OOT (out-of-tree) backends.

The file already used the modern `instantiate_device_type_tests` pattern: all four `@ops`-driven
tests (`test_consistency`, `test_maybe_error`, `test_fn_grad`, `test_distributed`) take
`(self, device, dtype, op)` and delegate to device-generic helpers. The one remaining
device-decoupling issue was three CPU-only tests that lived inside the device-parametrized
`TestComplexTensor` class and were re-running identical CPU work on every device variant:

- Extract `test_get_set_components`, `test_mul_inplace_complex`, and `test_ne_real_operand`
  (which create plain `torch.tensor(...)` CPU tensors and exercise the `ComplexTensor`
  subclass, with no `device` usage) from `TestComplexTensor` into a new plain-`TestCase`
  class `TestComplexTensorOnCPU`.

Also tag every test class with the `hw_classification` member so OOT backends can filter on
it explicitly:

- `TestComplexTensor` -> `HardwareClassification.ACCELERATOR`
- `TestComplexTensorOnCPU` -> `HardwareClassification.GENERIC`
- `TestComplexBwdGradients` -> `HardwareClassification.ACCELERATOR`
- `TestComplexDistributed` -> `HardwareClassification.ACCELERATOR`

No classes were renamed: `TestComplexBwdGradients` is referenced by an external ASAN-skip
`DecorateInfo` in `torch/testing/_internal/common_methods_invocations.py`, which uses exact
`cls_name` matching.

---

*Generated with the assistance of my agent.*
