### PR TITLE
[Testcase Refactoring]Add hw_classification to non-DDP test classes in test_c10d_ucc.py

### DIFF
--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -117,7 +117,7 @@ def simple_reduce_tests(rank, world_size):
 
 
 class RendezvousEnvTest(TestCase):
-    hw_classification = HardwareClassification.CPU
+    hw_classification = HardwareClassification.GENERIC
 
     @requires_ucc()
     @retry_on_connect_failures
@@ -140,7 +140,7 @@ class RendezvousEnvTest(TestCase):
 
 
 class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
-    hw_classification = HardwareClassification.CPU
+    hw_classification = HardwareClassification.GENERIC
 
     @requires_ucc()
     @retry_on_connect_failures
@@ -149,7 +149,7 @@ class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
 
 
 class ProcessGroupUCCTest(MultiProcContinuousTest):
-    hw_classification = HardwareClassification.CPU
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @classmethod
     def backend_str(cls) -> str:
@@ -1237,13 +1237,13 @@ instantiate_device_type_tests(
 instantiate_device_type_tests(
     CommTest,
     globals(),
-    only_for=("cuda",),
+    except_for=("cpu",),
 )
 
 instantiate_device_type_tests(
     UccProcessGroupWithDispatchedCollectivesTests,
     globals(),
-    only_for=("cuda",),
+    except_for=("cpu",),
 )
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -375,11 +375,7 @@ class _DistributedDataParallelTestBase(
         return "ucc"
 
     def _get_process_group(self):
-        store = c10d.FileStore(self.rdvz_file, self.world_size)
-        c10d.init_process_group(
-            "ucc", store=store, rank=self.rank, world_size=self.world_size
-        )
-        return c10d.distributed_c10d._get_default_group()
+        return self.pg
 
     def _test_ucc_backend(
         self, devices, device_ids, multi_device=False, gradient_as_bucket_view=False
@@ -686,7 +682,7 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
     )
     def test_ucc_backend_1gpu_module_device_ids_integer_list(self, device):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device(torch.device(device).type, i) for i in int_devices]
+        devices = [torch.device(self.device_type, i) for i in int_devices]
         self._test_ucc_backend(devices, int_devices)
 
     @requires_ucc()
@@ -696,7 +692,7 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
     )
     def test_ucc_backend_1gpu_module_device_ids_torch_device_list(self, device):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device(torch.device(device).type, i) for i in int_devices]
+        devices = [torch.device(self.device_type, i) for i in int_devices]
         self._test_ucc_backend(devices, devices)
 
     @skip_but_pass_in_sandcastle(
@@ -709,7 +705,7 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
     )
     def test_ucc_backend_2gpu_module(self, device):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
-        devices = [torch.device(torch.device(device).type, i) for i in int_devices]
+        devices = [torch.device(self.device_type, i) for i in int_devices]
         self._test_ucc_backend(devices, None, multi_device=True)
 
     @skip_but_pass_in_sandcastle(
@@ -722,7 +718,7 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
     )
     def test_ucc_backend_4gpu_module(self, device):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
-        devices = [torch.device(torch.device(device).type, i) for i in int_devices]
+        devices = [torch.device(self.device_type, i) for i in int_devices]
         self._test_ucc_backend(devices, None, multi_device=True)
 
     @skip_but_pass_in_sandcastle("times out")
@@ -819,13 +815,6 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
         "test requires 2+ accelerators",
     )
     def test_save_load_checkpoint(self, device):
-        dist.init_process_group(
-            "ucc",
-            init_method=f"file://{self.rdvz_file}",
-            world_size=self.world_size,
-            rank=self.rank,
-        )
-
         class TestModel(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -847,7 +836,7 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
                 optimizer.step()
 
         device_id = gpus_for_rank(self.world_size)[self.rank][0]
-        dev = torch.device(torch.device(device).type, device_id)
+        dev = torch.device(self.device_type, device_id)
 
         model_withload = TestModel().float().to(dev)
         model_withoutload = TestModel().float().to(dev)
@@ -895,8 +884,7 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
             torch.save(ddp_withload.state_dict(), checkpoint_path)
 
         dist.barrier()
-        device_type = torch.device(device).type
-        map_location = {f"{device_type}:0": f"{device_type}:{device_id}"}
+        map_location = {f"{self.device_type}:0": f"{self.device_type}:{device_id}"}
         ddp_state_dict = torch.load(checkpoint_path, map_location=map_location)
 
         for model in [ddp_withload, model_withload]:
@@ -1063,55 +1051,50 @@ class DistributedDataParallelUccCommHookValidationTest(MultiProcessTestCase):
             model.register_comm_hook(None, dummy_hook)
 
 
-class CommTest(test_c10d_common.AbstractCommTest, MultiProcContinuousTest):
-    hw_classification = HardwareClassification.ACCELERATOR
-
-    @classmethod
-    def backend_str(cls) -> str:
-        return "ucc"
+class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
+    hw_classification = HardwareClassification.CPU
 
     @property
-    def device(self) -> str:
+    def device(self):
         return "cpu"
 
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self):
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
     @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
-    def test_sequence_num_set_default_pg_ucc(self, device):
+    @skip_if_lt_x_gpu(2)
+    def test_sequence_num_set_default_pg_ucc(self):
         self._test_sequence_num_set_default_pg(backend="ucc")
 
     @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
-    def test_sequence_num_set_ucc_new_group(self, device):
+    @skip_if_lt_x_gpu(2)
+    def test_sequence_num_set_ucc_new_group(self):
         self._test_sequence_num_set_new_group(backend="ucc")
 
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
+    @skip_if_lt_x_gpu(2)
     @requires_ucc()
-    def test_sequence_num_incremented_ucc_default(self, device):
+    def test_sequence_num_incremented_ucc_default(self):
         self._test_sequence_num_incremented_default_group("ucc")
 
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 4,
-        "test requires 4+ accelerators",
-    )
+    @skip_if_lt_x_gpu(4)
     @requires_ucc()
-    def test_sequence_num_incremented_ucc_subgroup(self, device):
+    def test_sequence_num_incremented_ucc_subgroup(self):
         if self.world_size < 4:
             return skip_but_pass_in_sandcastle("Test requires world_size of at least 4")
         self._test_sequence_num_incremented_subgroup("ucc")
 
     @skip_but_pass_in_sandcastle("Fails on M60")
     @requires_ucc()
-    def test_ucc_barrier_device_ids(self, device):
-        store = c10d.FileStore(self.rdvz_file, self.world_size)
+    def test_ucc_barrier_device_ids(self):
+        store = c10d.FileStore(self.file_name, self.world_size)
         c10d.init_process_group(
             backend="ucc", rank=self.rank, world_size=self.world_size, store=store
         )
@@ -1120,36 +1103,24 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcContinuousTest):
             c10d.barrier(device_ids=[self.rank])
 
     @skip_but_pass_in_sandcastle("Fails on M60")
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
+    @skip_if_lt_x_gpu(2)
     @requires_ucc()
-    def test_ucc_warn_not_in_group(self, device):
+    def test_ucc_warn_not_in_group(self):
         self._test_warn_not_in_group(backend="ucc")
 
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
+    @skip_if_lt_x_gpu(2)
     @requires_ucc()
-    def test_ucc_rank_membership(self, device):
+    def test_ucc_rank_membership(self):
         self._test_rank_membership(backend="ucc")
 
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
+    @skip_if_lt_x_gpu(2)
     @requires_ucc()
-    def test_tensor_dtype_mismatch(self, device):
+    def test_tensor_dtype_mismatch(self):
         self._test_tensor_dtype_mismatch(backend="ucc")
 
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
+    @skip_if_lt_x_gpu(2)
     @requires_ucc()
-    def test_tensor_dtype_complex(self, device):
+    def test_tensor_dtype_complex(self):
         self._test_tensor_dtype_complex(backend="ucc")
 
 
@@ -1189,16 +1160,5 @@ instantiate_device_type_tests(
     only_for=("cuda",),
 )
 
-instantiate_device_type_tests(
-    CommTest,
-    globals(),
-    except_for=("cpu",),
-)
-
 if __name__ == "__main__":
-    if torch.cuda._initialized:
-        raise AssertionError(
-            "test_distributed must not have initialized CUDA context on main process"
-        )
-
     run_tests()

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -35,6 +35,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_distributed import (
     DEFAULT_WORLD_SIZE,
     MultiProcContinuousTest,
+    MultiProcessTestCase,
     requires_ucc,
     skip_if_lt_x_gpu,
     verify_ddp_error_logged,
@@ -150,17 +151,23 @@ class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
         self._test_default_store_timeout("ucc")
 
 
-class ProcessGroupUCCTest(MultiProcContinuousTest):
+class ProcessGroupUCCTest(MultiProcessTestCase):
     hw_classification = HardwareClassification.CPU
-    world_size = DEFAULT_WORLD_SIZE
-
-    @classmethod
-    def backend_str(cls) -> str:
-        return "ucc"
 
     def _create_process_group_ucc(self):
-        store = c10d.FileStore(self.rdvz_file, self.world_size)
+        store = c10d.FileStore(self.file_name, self.world_size)
         return c10d.ProcessGroupUCC(store, self.rank, self.world_size)
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self):
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
 
     @requires_ucc()
     def test_empty_tensors(self):
@@ -938,16 +945,22 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
 
 
 
-class DistributedDataParallelUccCommHookValidationTest(MultiProcContinuousTest):
+class DistributedDataParallelUccCommHookValidationTest(MultiProcessTestCase):
     hw_classification = HardwareClassification.CPU
-    world_size = DEFAULT_WORLD_SIZE
 
-    @classmethod
-    def backend_str(cls) -> str:
-        return "ucc"
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self):
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
 
     def _get_process_group(self):
-        store = c10d.FileStore(self.rdvz_file, self.world_size)
+        store = c10d.FileStore(self.file_name, self.world_size)
         c10d.init_process_group(
             "ucc", store=store, rank=self.rank, world_size=self.world_size
         )

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -31,13 +31,13 @@ import torch.nn.functional as F
 import torch.testing._internal.common_utils as common
 from torch import nn
 from torch.nn.parallel import DistributedDataParallel
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
-    MultiProcessTestCase,
+    MultiProcContinuousTest,
     requires_ucc,
-    skip_if_lt_x_gpu,
-    verify_ddp_error_logged,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     retry_on_connect_failures,
     run_tests,
     skip_but_pass_in_sandcastle,
@@ -115,6 +115,8 @@ def simple_reduce_tests(rank, world_size):
 
 
 class RendezvousEnvTest(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     @requires_ucc()
     @retry_on_connect_failures
     def test_logging_init(self):
@@ -136,30 +138,32 @@ class RendezvousEnvTest(TestCase):
 
 
 class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
+    hw_classification = HardwareClassification.CPU
+
     @requires_ucc()
     @retry_on_connect_failures
     def test_default_store_timeout_ucc(self):
         self._test_default_store_timeout("ucc")
 
 
-class ProcessGroupUCCTest(MultiProcessTestCase):
+class ProcessGroupUCCTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CPU
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "ucc"
+
+    @property
+    def device(self) -> torch.device:
+        return self._dev
+
     def _create_process_group_ucc(self):
-        store = c10d.FileStore(self.file_name, self.world_size)
+        store = c10d.FileStore(self.rdvz_file, self.world_size)
         return c10d.ProcessGroupUCC(store, self.rank, self.world_size)
 
-    def setUp(self):
-        super().setUp()
-        self._spawn_processes()
-
-    def tearDown(self):
-        super().tearDown()
-        try:
-            os.remove(self.file_name)
-        except OSError:
-            pass
-
     @requires_ucc()
-    def test_empty_tensors(self):
+    def test_empty_tensors(self, device):
+        self._dev = torch.device(device, self.rank)
         pg = self._create_process_group_ucc()
 
         xs = [torch.FloatTensor([])]
@@ -199,7 +203,8 @@ class ProcessGroupUCCTest(MultiProcessTestCase):
         self.assertEqual(torch.tensor([1.0]), result[0])
 
     @requires_ucc()
-    def test_broadcast_basics(self):
+    def test_broadcast_basics(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_broadcast_basics(lambda t: t.clone())
 
     # TODO: test_broadcast_basics_cuda times out locally
@@ -231,7 +236,8 @@ class ProcessGroupUCCTest(MultiProcessTestCase):
         )
 
     @requires_ucc()
-    def test_allreduce_basics(self):
+    def test_allreduce_basics(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_allreduce_basics(lambda t: t.clone())
 
     # TODO: test_allreduce_basics_cuda times out locally
@@ -257,7 +263,8 @@ class ProcessGroupUCCTest(MultiProcessTestCase):
                 result = [result]
             self.assertEqual(expected_output, result)
 
-    def test_allgather_basics(self):
+    def test_allgather_basics(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_allgather_basics(lambda t: t.clone())
 
     def _test_reduce_basics(self, fn):
@@ -275,13 +282,15 @@ class ProcessGroupUCCTest(MultiProcessTestCase):
                     self.assertEqual(output, result[0], exact_dtype=False)
 
     @requires_ucc()
-    def test_reduce_basics(self):
+    def test_reduce_basics(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_reduce_basics(lambda t: t.clone())
 
     # TODO: test_reduce_basics_cuda times out locally
 
     @requires_ucc()
-    def test_send_recv_all_to_all(self):
+    def test_send_recv_all_to_all(self, device):
+        self._dev = torch.device(device, self.rank)
         pg = self._create_process_group_ucc()
 
         # Preallocate tensors for input/output
@@ -321,7 +330,8 @@ class ProcessGroupUCCTest(MultiProcessTestCase):
     # TODO: test_barrier_implies_wait fails with numerical mismatch, will investigate later
     @skip_but_pass_in_sandcastle("fails with numerical mismatch, skip for now")
     @requires_ucc()
-    def test_barrier_implies_wait(self):
+    def test_barrier_implies_wait(self, device):
+        self._dev = torch.device(device, self.rank)
         pg = self._create_process_group_ucc()
 
         # Kick off allreduce operations
@@ -350,19 +360,26 @@ class ProcessGroupUCCTest(MultiProcessTestCase):
         result = fut.value()
         self.assertEqual(result[0], expected_output)
 
-    def test_reduce_scatter_base_basics(self):
+    def test_reduce_scatter_base_basics(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_reduce_scatter_base_basics(lambda t: t.clone())
 
 
 class DistributedDataParallelTest(
-    test_c10d_common.CommonDistributedDataParallelTest, MultiProcessTestCase
+    test_c10d_common.CommonDistributedDataParallelTest, MultiProcContinuousTest
 ):
-    def setUp(self):
-        super().setUp()
-        self._spawn_processes()
+    hw_classification = HardwareClassification.CUDA
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "ucc"
+
+    @property
+    def device(self) -> torch.device:
+        return self._dev
 
     def _get_process_group(self):
-        store = self._get_store()
+        store = c10d.FileStore(self.rdvz_file, self.world_size)
         c10d.init_process_group(
             "ucc", store=store, rank=self.rank, world_size=self.world_size
         )
@@ -377,27 +394,37 @@ class DistributedDataParallelTest(
         )
 
     @requires_ucc()
-    def test_ucc_backend_cpu_module(self):
+    def test_ucc_backend_cpu_module(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_ucc_backend([torch.device("cpu")], None)
 
     @requires_ucc()
-    def test_ucc_backend_cpu_module_grad_is_view(self):
+    def test_ucc_backend_cpu_module_grad_is_view(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_ucc_backend(
             [torch.device("cpu")], None, gradient_as_bucket_view=True
         )
 
     @requires_ucc()
-    @skip_if_lt_x_gpu(2)
-    def test_ucc_backend_1gpu_module_device_ids_integer_list(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_ucc_backend_1gpu_module_device_ids_integer_list(self, device):
+        self._dev = torch.device(device, self.rank)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
+        devices = [torch.device(device, i) for i in int_devices]
         self._test_ucc_backend(devices, int_devices)
 
     @requires_ucc()
-    @skip_if_lt_x_gpu(2)
-    def test_ucc_backend_1gpu_module_device_ids_torch_device_list(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_ucc_backend_1gpu_module_device_ids_torch_device_list(self, device):
+        self._dev = torch.device(device, self.rank)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
+        devices = [torch.device(device, i) for i in int_devices]
         self._test_ucc_backend(devices, devices)
 
     # TODO: test_ucc_backend_2gpu_module and test_ucc_backend_4gpu_module
@@ -406,20 +433,28 @@ class DistributedDataParallelTest(
         "requires broadcast coalesced, which is not supported by ucc currently"
     )
     @requires_ucc()
-    @skip_if_lt_x_gpu(4)
-    def test_ucc_backend_2gpu_module(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 4,
+        "test requires 4+ accelerators",
+    )
+    def test_ucc_backend_2gpu_module(self, device):
+        self._dev = torch.device(device, self.rank)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
+        devices = [torch.device(device, i) for i in int_devices]
         self._test_ucc_backend(devices, None, multi_device=True)
 
     @skip_but_pass_in_sandcastle(
         "requires broadcast coalesced, which is not supported by ucc currently"
     )
     @requires_ucc()
-    @skip_if_lt_x_gpu(8)
-    def test_ucc_backend_4gpu_module(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 8,
+        "test requires 8+ accelerators",
+    )
+    def test_ucc_backend_4gpu_module(self, device):
+        self._dev = torch.device(device, self.rank)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
+        devices = [torch.device(device, i) for i in int_devices]
         self._test_ucc_backend(devices, None, multi_device=True)
 
     def _test_global_local_unused_params_grad(
@@ -477,8 +512,9 @@ class DistributedDataParallelTest(
 
         # Test on GPU
         device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        dev = torch.device(self.device_type, device_id)
         gpu_model = DistributedDataParallel(
-            GlobalLocalUnusedParamModule().to(device_id),
+            GlobalLocalUnusedParamModule().to(dev),
             device_ids=[device_id],
             process_group=process_group,
             find_unused_parameters=True,
@@ -490,29 +526,44 @@ class DistributedDataParallelTest(
     # TODO: times out
     @skip_but_pass_in_sandcastle("times out")
     @requires_ucc()
-    @skip_if_lt_x_gpu(2)
-    def test_global_local_unused_params_grad(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_global_local_unused_params_grad(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_global_local_unused_params_grad()
 
     # TODO: times out
     @skip_but_pass_in_sandcastle("times out")
     @requires_ucc()
-    @skip_if_lt_x_gpu(2)
-    def test_global_local_unused_params_grad_with_grad_is_view(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_global_local_unused_params_grad_with_grad_is_view(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_global_local_unused_params_grad(gradient_as_bucket_view=True)
 
     # TODO: times out
     @skip_but_pass_in_sandcastle("times out")
     @requires_ucc()
-    @skip_if_lt_x_gpu(2)
-    def test_global_local_unused_params_grad_with_static_graph(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_global_local_unused_params_grad_with_static_graph(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_global_local_unused_params_grad(static_graph=True)
 
     # TODO: times out
     @skip_but_pass_in_sandcastle("times out")
     @requires_ucc()
-    @skip_if_lt_x_gpu(2)
-    def test_find_unused_parameters_when_unused_parameters_empty(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_find_unused_parameters_when_unused_parameters_empty(self, device):
         """
         An empty unused_parameters array does not imply find_unused_parameters =
         false. This test makes sure that DDP allreduces unused parameters
@@ -520,6 +571,7 @@ class DistributedDataParallelTest(
         This unit test creates a module that uses all parameters in rank = 0, and
         has unused parameters in other ranks.
         """
+        self._dev = torch.device(device, self.rank)
 
         class FindUnusedParamModule(nn.Module):
             def __init__(self) -> None:
@@ -558,8 +610,9 @@ class DistributedDataParallelTest(
 
         # Test on GPU
         device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        dev = torch.device(self.device_type, device_id)
         gpu_model = DistributedDataParallel(
-            FindUnusedParamModule().to(device_id),
+            FindUnusedParamModule().to(dev),
             device_ids=[device_id],
             process_group=process_group,
             find_unused_parameters=True,
@@ -567,11 +620,12 @@ class DistributedDataParallelTest(
         run_and_verify_grad(gpu_model)
 
     @requires_ucc()
-    def test_ignored_output(self):
+    def test_ignored_output(self, device):
         """
         Test that the output of a model can be ignored and that there is no
         implicit requirement that `backward` gets called.
         """
+        self._dev = torch.device(device, self.rank)
         process_group = self._get_process_group()
 
         class IgnoredOutput(nn.Module):
@@ -608,12 +662,13 @@ class DistributedDataParallelTest(
             loss.backward()
 
     @requires_ucc()
-    def test_ignored_output_with_unused_parameters(self):
+    def test_ignored_output_with_unused_parameters(self, device):
         """
         Test that the output of a model can be ignored and that there is no
         implicit requirement that `backward` gets called, if not all model
         parameters participated in computing the model output.
         """
+        self._dev = torch.device(device, self.rank)
         process_group = self._get_process_group()
 
         class IgnoredOutputWithUnusedParameters(nn.Module):
@@ -674,11 +729,15 @@ class DistributedDataParallelTest(
         )
 
     @requires_ucc()
-    @skip_if_lt_x_gpu(2)
-    def test_save_load_checkpoint(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_save_load_checkpoint(self, device):
+        self._dev = torch.device(device, self.rank)
         dist.init_process_group(
             "ucc",
-            init_method=f"file://{self.file_name}",
+            init_method=f"file://{self.rdvz_file}",
             world_size=self.world_size,
             rank=self.rank,
         )
@@ -704,9 +763,10 @@ class DistributedDataParallelTest(
                 optimizer.step()
 
         device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        dev = torch.device(device, device_id)
 
-        model_withload = TestModel().float().to(device_id)
-        model_withoutload = TestModel().float().to(device_id)
+        model_withload = TestModel().float().to(dev)
+        model_withoutload = TestModel().float().to(dev)
 
         ddp_withload = DistributedDataParallel(
             model_withload,
@@ -737,9 +797,9 @@ class DistributedDataParallelTest(
         )
         optimizer_withoutload = torch.optim.SGD(ddp_withoutload.parameters(), lr=0.001)
 
-        input = torch.rand([batch_size, 2], dtype=torch.float).to(device_id)
+        input = torch.rand([batch_size, 2], dtype=torch.float).to(dev)
         target = torch.LongTensor([random.randrange(4) for _ in range(batch_size)]).to(
-            device_id
+            dev
         )
 
         # run the model for 6 iterations, with a checkpoint in the middle
@@ -751,7 +811,7 @@ class DistributedDataParallelTest(
             torch.save(ddp_withload.state_dict(), checkpoint_path)
 
         dist.barrier()
-        map_location = {"cuda:0": f"cuda:{self.rank:d}"}
+        map_location = {f"{device}:0": f"{device}:{device_id}"}
         ddp_state_dict = torch.load(checkpoint_path, map_location=map_location)
 
         for model in [ddp_withload, model_withload]:
@@ -797,21 +857,24 @@ class DistributedDataParallelTest(
     # TODO: backward pass: input tensor has to be dense
     @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
     @requires_ucc()
-    def test_sparse_gradients(self):
+    def test_sparse_gradients(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_sparse_gradients()
 
     # TODO: backward pass: input tensor has to be dense
     @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
     @requires_ucc()
-    def test_sparse_gradients_grad_is_view(self):
+    def test_sparse_gradients_grad_is_view(self, device):
+        self._dev = torch.device(device, self.rank)
         self._test_sparse_gradients(gradient_as_bucket_view=True)
 
     @requires_ucc()
-    def test_ddp_comm_hook_future_passing_cpu(self):
+    def test_ddp_comm_hook_future_passing_cpu(self, device):
         """
         This unit test verifies whether the Future object is passed properly.
         The callback function creates a Future object and sets a value to it.
         """
+        self._dev = torch.device(device, self.rank)
         process_group = self._get_process_group()
 
         # Test on CPU
@@ -830,8 +893,9 @@ class DistributedDataParallelTest(
         self, process_group, hook=None, gradient_as_bucket_view=False, state=None
     ):
         device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        dev = torch.device(self.device_type, device_id)
         gpu_model = DistributedDataParallel(
-            ModuleForDdpCommHook().to(device_id),
+            ModuleForDdpCommHook().to(dev),
             device_ids=[device_id],
             process_group=process_group,
             gradient_as_bucket_view=gradient_as_bucket_view,
@@ -844,12 +908,16 @@ class DistributedDataParallelTest(
         return gpu_model
 
     @requires_ucc()
-    @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_future_passing_gpu_ucc(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_ddp_comm_hook_future_passing_gpu_ucc(self, device):
         """
         This unit test verifies whether the Future object is passed properly using ucc backend.
         The hook callback function creates a Future object and sets a value to it.
         """
+        self._dev = torch.device(device, self.rank)
         process_group = self._get_process_group()
 
         # Get GPU model with simple_hook registered.
@@ -860,12 +928,13 @@ class DistributedDataParallelTest(
         self._run_and_verify_hook(gpu_model, 8, 2 * torch.ones(2, 2))
 
     @requires_ucc()
-    def test_ddp_invalid_comm_hook_init(self):
+    def test_ddp_invalid_comm_hook_init(self, device):
         """
         This unit test makes sure that register_comm_hook properly checks the format
         of hook defined by user. The Python hook must be callable. This test also
         checks whether bucket annotation checked properly if defined.
         """
+        self._dev = torch.device(device, self.rank)
         process_group = self._get_process_group()
 
         model = DistributedDataParallel(
@@ -887,12 +956,13 @@ class DistributedDataParallelTest(
             model.register_comm_hook(state=None, hook=comm_hook)
 
     @requires_ucc()
-    def test_ddp_invalid_comm_hook_return_type(self):
+    def test_ddp_invalid_comm_hook_return_type(self, device):
         """
         This test checks whether return annotation checked properly if defined. It also
         checks whether an internal error is thrown if return type is incorrect and user
         hasn't specified any return type annotation.
         """
+        self._dev = torch.device(device, self.rank)
         process_group = self._get_process_group()
 
         model = DistributedDataParallel(
@@ -931,11 +1001,12 @@ class DistributedDataParallelTest(
             output.mean().backward()
 
     @requires_ucc()
-    def test_ddp_comm_hook_register_just_once(self):
+    def test_ddp_comm_hook_register_just_once(self, device):
         """
         DDP communication hook can only be registered once. This test validates whether
         the error is thrown properly when register_comm_hook is called more than once.
         """
+        self._dev = torch.device(device, self.rank)
         process_group = self._get_process_group()
 
         model = DistributedDataParallel(
@@ -958,11 +1029,12 @@ class DistributedDataParallelTest(
     # TODO: backward pass: input tensor must be dense
     @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
     @requires_ucc()
-    def test_ddp_comm_hook_sparse_gradients(self):
+    def test_ddp_comm_hook_sparse_gradients(self, device):
         """
         Runs "test_sparse_gradients" unit test with DDP communication hook. We define a
         simple hook that does allreduce and works with ucc backend for this test.
         """
+        self._dev = torch.device(device, self.rank)
         process_group = self._get_process_group()
 
         # Ensure initialized weights and inputs are identical across processes
@@ -990,48 +1062,63 @@ class DistributedDataParallelTest(
         self._run_and_verify_sparse_gradients(vanilla_model, ddp_model)
 
 
-class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
+class CommTest(test_c10d_common.AbstractCommTest, MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "ucc"
+
     @property
-    def device(self):
+    def device(self) -> None:
         return "cpu"
 
-    def setUp(self):
-        super().setUp()
-        self._spawn_processes()
+    @property
+    def _dev(self) -> torch.device:
+        return torch.device("cpu")
 
-    def tearDown(self):
-        super().tearDown()
-        try:
-            os.remove(self.file_name)
-        except OSError:
-            pass
+    @_dev.setter
+    def _dev(self, value):
+        pass
 
     @requires_ucc()
-    @skip_if_lt_x_gpu(2)
-    def test_sequence_num_set_default_pg_ucc(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_sequence_num_set_default_pg_ucc(self, device):
         self._test_sequence_num_set_default_pg(backend="ucc")
 
     @requires_ucc()
-    @skip_if_lt_x_gpu(2)
-    def test_sequence_num_set_ucc_new_group(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_sequence_num_set_ucc_new_group(self, device):
         self._test_sequence_num_set_new_group(backend="ucc")
 
-    @skip_if_lt_x_gpu(2)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
     @requires_ucc()
-    def test_sequence_num_incremented_ucc_default(self):
+    def test_sequence_num_incremented_ucc_default(self, device):
         self._test_sequence_num_incremented_default_group("ucc")
 
-    @skip_if_lt_x_gpu(4)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 4,
+        "test requires 4+ accelerators",
+    )
     @requires_ucc()
-    def test_sequence_num_incremented_ucc_subgroup(self):
+    def test_sequence_num_incremented_ucc_subgroup(self, device):
         if self.world_size < 4:
             return skip_but_pass_in_sandcastle("Test requires world_size of at least 4")
         self._test_sequence_num_incremented_subgroup("ucc")
 
     @skip_but_pass_in_sandcastle("Fails on M60")
     @requires_ucc()
-    def test_ucc_barrier_device_ids(self):
-        store = c10d.FileStore(self.file_name, self.world_size)
+    def test_ucc_barrier_device_ids(self, device):
+        store = c10d.FileStore(self.rdvz_file, self.world_size)
         c10d.init_process_group(
             backend="ucc", rank=self.rank, world_size=self.world_size, store=store
         )
@@ -1040,54 +1127,97 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
             c10d.barrier(device_ids=[self.rank])
 
     @skip_but_pass_in_sandcastle("Fails on M60")
-    @skip_if_lt_x_gpu(2)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
     @requires_ucc()
-    def test_ucc_warn_not_in_group(self):
+    def test_ucc_warn_not_in_group(self, device):
         self._test_warn_not_in_group(backend="ucc")
 
-    @skip_if_lt_x_gpu(2)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
     @requires_ucc()
-    def test_ucc_rank_membership(self):
+    def test_ucc_rank_membership(self, device):
         self._test_rank_membership(backend="ucc")
 
-    @skip_if_lt_x_gpu(2)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
     @requires_ucc()
-    def test_tensor_dtype_mismatch(self):
+    def test_tensor_dtype_mismatch(self, device):
         self._test_tensor_dtype_mismatch(backend="ucc")
 
-    @skip_if_lt_x_gpu(2)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
     @requires_ucc()
-    def test_tensor_dtype_complex(self):
+    def test_tensor_dtype_complex(self, device):
         self._test_tensor_dtype_complex(backend="ucc")
 
 
 class UccProcessGroupWithDispatchedCollectivesTests(
     test_c10d_common.ProcessGroupWithDispatchedCollectivesTests
 ):
+    hw_classification = HardwareClassification.CUDA
+
     @skip_but_pass_in_sandcastle("Fails on M60")
     @requires_ucc()
-    @skip_if_lt_x_gpu(1)
-    def test_collectives(self):
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 1,
+        "test requires 1+ accelerators",
+    )
+    def test_collectives(self, device):
         # includes reduce, broadcast, all_reduce, all_gather, reduce_scatter, barrier, all_to_all, scatter
         self._test_collectives(backend="ucc")
 
     @skip_but_pass_in_sandcastle("Fails on M60")
     @requires_ucc()
-    @skip_if_lt_x_gpu(1)
-    def test_allgather_base(self):
-        store = dist.FileStore(self.file_name, self.world_size)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 1,
+        "test requires 1+ accelerators",
+    )
+    def test_allgather_base(self, device):
+        store = dist.FileStore(self.rdvz_file, self.world_size)
         dist.init_process_group(
             "ucc",
             world_size=self.world_size,
             rank=self.rank,
             store=store,
         )
-        device = "cuda"
         tensor = torch.ones(10, 10, device=torch.device(device))
         output_tensor = torch.zeros(10, 10, device=torch.device(device))
         dist.all_gather_single(output_tensor, tensor)
         self.assertEqual(output_tensor, tensor)
 
+
+instantiate_device_type_tests(
+    ProcessGroupUCCTest,
+    globals(),
+    only_for=("cpu",),
+)
+
+instantiate_device_type_tests(
+    DistributedDataParallelTest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    CommTest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    UccProcessGroupWithDispatchedCollectivesTests,
+    globals(),
+    only_for=("cuda",),
+)
 
 if __name__ == "__main__":
     if torch.cuda._initialized:

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -272,6 +272,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
                 result = [result]
             self.assertEqual(expected_output, result)
 
+    @requires_ucc()
     def test_allgather_basics(self, device):
         self._set_device(device)
         self._test_allgather_basics(lambda t: t.clone())
@@ -377,7 +378,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
 class DistributedDataParallelTest(
     test_c10d_common.CommonDistributedDataParallelTest, MultiProcContinuousTest
 ):
-    hw_classification = HardwareClassification.CUDA
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @classmethod
     def backend_str(cls) -> str:
@@ -936,14 +937,67 @@ class DistributedDataParallelTest(
         # without the comm_hook, result would be 0.25 * torch.ones(2, 2).
         self._run_and_verify_hook(gpu_model, 8, 2 * torch.ones(2, 2))
 
+    # TODO: backward pass: input tensor must be dense
+    @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
     @requires_ucc()
-    def test_ddp_invalid_comm_hook_init(self, device):
+    def test_ddp_comm_hook_sparse_gradients(self, device):
+        """
+        Runs "test_sparse_gradients" unit test with DDP communication hook. We define a
+        simple hook that does allreduce and works with ucc backend for this test.
+        """
+        self._dev = torch.device(device)
+        process_group = self._get_process_group()
+
+        # Ensure initialized weights and inputs are identical across processes
+        torch.manual_seed(1337)
+
+        vanilla_model = SparseGradientModule()
+        ddp_model = DistributedDataParallel(
+            copy.deepcopy(vanilla_model),
+            process_group=process_group,
+        )
+
+        def allreduce_hook_ucc(
+            state: object, bucket: dist.GradBucket
+        ) -> torch.futures.Future[torch.Tensor]:
+            def div_by_world_size(fut):
+                # Divide the result by 2 * world_size.
+                return fut.wait()[0] / self.world_size
+
+            # Prepare allreduced grad bucket tensors by running an async work.
+            fut = process_group.allreduce([bucket.buffer()]).get_future()
+            return fut.then(div_by_world_size)
+
+        ddp_model.register_comm_hook(None, allreduce_hook_ucc)
+
+        self._run_and_verify_sparse_gradients(vanilla_model, ddp_model)
+
+
+class DistributedDataParallelUccCommHookValidationTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CPU
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return "ucc"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cpu")
+
+    def _get_process_group(self):
+        store = c10d.FileStore(self.rdvz_file, self.world_size)
+        c10d.init_process_group(
+            "ucc", store=store, rank=self.rank, world_size=self.world_size
+        )
+        return c10d.distributed_c10d._get_default_group()
+
+    @requires_ucc()
+    def test_ddp_invalid_comm_hook_init(self):
         """
         This unit test makes sure that register_comm_hook properly checks the format
         of hook defined by user. The Python hook must be callable. This test also
         checks whether bucket annotation checked properly if defined.
         """
-        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         model = DistributedDataParallel(
@@ -965,13 +1019,12 @@ class DistributedDataParallelTest(
             model.register_comm_hook(state=None, hook=comm_hook)
 
     @requires_ucc()
-    def test_ddp_invalid_comm_hook_return_type(self, device):
+    def test_ddp_invalid_comm_hook_return_type(self):
         """
         This test checks whether return annotation checked properly if defined. It also
         checks whether an internal error is thrown if return type is incorrect and user
         hasn't specified any return type annotation.
         """
-        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         model = DistributedDataParallel(
@@ -1010,12 +1063,11 @@ class DistributedDataParallelTest(
             output.mean().backward()
 
     @requires_ucc()
-    def test_ddp_comm_hook_register_just_once(self, device):
+    def test_ddp_comm_hook_register_just_once(self):
         """
         DDP communication hook can only be registered once. This test validates whether
         the error is thrown properly when register_comm_hook is called more than once.
         """
-        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         model = DistributedDataParallel(
@@ -1035,44 +1087,9 @@ class DistributedDataParallelTest(
         ):
             model.register_comm_hook(None, dummy_hook)
 
-    # TODO: backward pass: input tensor must be dense
-    @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
-    @requires_ucc()
-    def test_ddp_comm_hook_sparse_gradients(self, device):
-        """
-        Runs "test_sparse_gradients" unit test with DDP communication hook. We define a
-        simple hook that does allreduce and works with ucc backend for this test.
-        """
-        self._dev = torch.device(device)
-        process_group = self._get_process_group()
-
-        # Ensure initialized weights and inputs are identical across processes
-        torch.manual_seed(1337)
-
-        vanilla_model = SparseGradientModule()
-        ddp_model = DistributedDataParallel(
-            copy.deepcopy(vanilla_model),
-            process_group=process_group,
-        )
-
-        def allreduce_hook_ucc(
-            state: object, bucket: dist.GradBucket
-        ) -> torch.futures.Future[torch.Tensor]:
-            def div_by_world_size(fut):
-                # Divide the result by 2 * world_size.
-                return fut.wait()[0] / self.world_size
-
-            # Prepare allreduced grad bucket tensors by running an async work.
-            fut = process_group.allreduce([bucket.buffer()]).get_future()
-            return fut.then(div_by_world_size)
-
-        ddp_model.register_comm_hook(None, allreduce_hook_ucc)
-
-        self._run_and_verify_sparse_gradients(vanilla_model, ddp_model)
-
 
 class CommTest(test_c10d_common.AbstractCommTest, MultiProcContinuousTest):
-    hw_classification = HardwareClassification.CUDA
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @classmethod
     def backend_str(cls) -> str:
@@ -1172,7 +1189,7 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcContinuousTest):
 class UccProcessGroupWithDispatchedCollectivesTests(
     test_c10d_common.ProcessGroupWithDispatchedCollectivesTests
 ):
-    hw_classification = HardwareClassification.CUDA
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @skip_but_pass_in_sandcastle("Fails on M60")
     @requires_ucc()
@@ -1180,7 +1197,7 @@ class UccProcessGroupWithDispatchedCollectivesTests(
         torch.accelerator.device_count() < 1,
         "test requires 1+ accelerators",
     )
-    def test_collectives(self):
+    def test_collectives(self, device):
         # includes reduce, broadcast, all_reduce, all_gather, reduce_scatter, barrier, all_to_all, scatter
         self._test_collectives(backend="ucc")
 
@@ -1190,7 +1207,7 @@ class UccProcessGroupWithDispatchedCollectivesTests(
         torch.accelerator.device_count() < 1,
         "test requires 1+ accelerators",
     )
-    def test_allgather_base(self):
+    def test_allgather_base(self, device):
         store = dist.FileStore(self.file_name, self.world_size)
         dist.init_process_group(
             "ucc",
@@ -1198,8 +1215,9 @@ class UccProcessGroupWithDispatchedCollectivesTests(
             rank=self.rank,
             store=store,
         )
-        tensor = torch.ones(10, 10, device=torch.device("cuda"))
-        output_tensor = torch.zeros(10, 10, device=torch.device("cuda"))
+        dev = torch.device(device)
+        tensor = torch.ones(10, 10, device=dev)
+        output_tensor = torch.zeros(10, 10, device=dev)
         dist.all_gather_single(output_tensor, tensor)
         self.assertEqual(output_tensor, tensor)
 
@@ -1207,17 +1225,21 @@ class UccProcessGroupWithDispatchedCollectivesTests(
 instantiate_device_type_tests(
     ProcessGroupUCCTest,
     globals(),
-    only_for=("cpu",),
 )
 
 instantiate_device_type_tests(
     DistributedDataParallelTest,
     globals(),
-    only_for=("cuda",),
 )
 
 instantiate_device_type_tests(
     CommTest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    UccProcessGroupWithDispatchedCollectivesTests,
     globals(),
     only_for=("cuda",),
 )

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -168,7 +168,9 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
         return c10d.ProcessGroupUCC(store, self.rank, self.world_size)
 
     def _set_device(self, device: str) -> None:
-        self._dev = torch.device(device, self.rank) if device != "cpu" else torch.device("cpu")
+        self._dev = (
+            torch.device(device, self.rank) if device != "cpu" else torch.device("cpu")
+        )
 
     @requires_ucc()
     def test_empty_tensors(self, device):

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -35,12 +35,14 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_ucc,
+    verify_ddp_error_logged,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     retry_on_connect_failures,
     run_tests,
     skip_but_pass_in_sandcastle,
+    skip_but_pass_in_sandcastle_if,
     TestCase,
 )
 
@@ -154,6 +156,10 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
         return "ucc"
 
     @property
+    def world_size(self):
+        return 4
+
+    @property
     def device(self) -> torch.device:
         return self._dev
 
@@ -161,9 +167,12 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
         store = c10d.FileStore(self.rdvz_file, self.world_size)
         return c10d.ProcessGroupUCC(store, self.rank, self.world_size)
 
+    def _set_device(self, device: str) -> None:
+        self._dev = torch.device(device, self.rank) if device != "cpu" else torch.device("cpu")
+
     @requires_ucc()
     def test_empty_tensors(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._set_device(device)
         pg = self._create_process_group_ucc()
 
         xs = [torch.FloatTensor([])]
@@ -204,7 +213,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
 
     @requires_ucc()
     def test_broadcast_basics(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._set_device(device)
         self._test_broadcast_basics(lambda t: t.clone())
 
     # TODO: test_broadcast_basics_cuda times out locally
@@ -237,7 +246,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
 
     @requires_ucc()
     def test_allreduce_basics(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._set_device(device)
         self._test_allreduce_basics(lambda t: t.clone())
 
     # TODO: test_allreduce_basics_cuda times out locally
@@ -264,7 +273,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
             self.assertEqual(expected_output, result)
 
     def test_allgather_basics(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._set_device(device)
         self._test_allgather_basics(lambda t: t.clone())
 
     def _test_reduce_basics(self, fn):
@@ -283,14 +292,14 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
 
     @requires_ucc()
     def test_reduce_basics(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._set_device(device)
         self._test_reduce_basics(lambda t: t.clone())
 
     # TODO: test_reduce_basics_cuda times out locally
 
     @requires_ucc()
     def test_send_recv_all_to_all(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._set_device(device)
         pg = self._create_process_group_ucc()
 
         # Preallocate tensors for input/output
@@ -331,7 +340,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle("fails with numerical mismatch, skip for now")
     @requires_ucc()
     def test_barrier_implies_wait(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._set_device(device)
         pg = self._create_process_group_ucc()
 
         # Kick off allreduce operations
@@ -361,7 +370,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
         self.assertEqual(result[0], expected_output)
 
     def test_reduce_scatter_base_basics(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._set_device(device)
         self._test_reduce_scatter_base_basics(lambda t: t.clone())
 
 
@@ -395,12 +404,12 @@ class DistributedDataParallelTest(
 
     @requires_ucc()
     def test_ucc_backend_cpu_module(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         self._test_ucc_backend([torch.device("cpu")], None)
 
     @requires_ucc()
     def test_ucc_backend_cpu_module_grad_is_view(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         self._test_ucc_backend(
             [torch.device("cpu")], None, gradient_as_bucket_view=True
         )
@@ -411,7 +420,7 @@ class DistributedDataParallelTest(
         "test requires 2+ accelerators",
     )
     def test_ucc_backend_1gpu_module_device_ids_integer_list(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
         devices = [torch.device(device, i) for i in int_devices]
         self._test_ucc_backend(devices, int_devices)
@@ -422,7 +431,7 @@ class DistributedDataParallelTest(
         "test requires 2+ accelerators",
     )
     def test_ucc_backend_1gpu_module_device_ids_torch_device_list(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
         devices = [torch.device(device, i) for i in int_devices]
         self._test_ucc_backend(devices, devices)
@@ -438,7 +447,7 @@ class DistributedDataParallelTest(
         "test requires 4+ accelerators",
     )
     def test_ucc_backend_2gpu_module(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
         devices = [torch.device(device, i) for i in int_devices]
         self._test_ucc_backend(devices, None, multi_device=True)
@@ -452,7 +461,7 @@ class DistributedDataParallelTest(
         "test requires 8+ accelerators",
     )
     def test_ucc_backend_4gpu_module(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
         devices = [torch.device(device, i) for i in int_devices]
         self._test_ucc_backend(devices, None, multi_device=True)
@@ -531,7 +540,7 @@ class DistributedDataParallelTest(
         "test requires 2+ accelerators",
     )
     def test_global_local_unused_params_grad(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         self._test_global_local_unused_params_grad()
 
     # TODO: times out
@@ -542,7 +551,7 @@ class DistributedDataParallelTest(
         "test requires 2+ accelerators",
     )
     def test_global_local_unused_params_grad_with_grad_is_view(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         self._test_global_local_unused_params_grad(gradient_as_bucket_view=True)
 
     # TODO: times out
@@ -553,7 +562,7 @@ class DistributedDataParallelTest(
         "test requires 2+ accelerators",
     )
     def test_global_local_unused_params_grad_with_static_graph(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         self._test_global_local_unused_params_grad(static_graph=True)
 
     # TODO: times out
@@ -571,7 +580,7 @@ class DistributedDataParallelTest(
         This unit test creates a module that uses all parameters in rank = 0, and
         has unused parameters in other ranks.
         """
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
 
         class FindUnusedParamModule(nn.Module):
             def __init__(self) -> None:
@@ -625,7 +634,7 @@ class DistributedDataParallelTest(
         Test that the output of a model can be ignored and that there is no
         implicit requirement that `backward` gets called.
         """
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         class IgnoredOutput(nn.Module):
@@ -668,7 +677,7 @@ class DistributedDataParallelTest(
         implicit requirement that `backward` gets called, if not all model
         parameters participated in computing the model output.
         """
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         class IgnoredOutputWithUnusedParameters(nn.Module):
@@ -734,7 +743,7 @@ class DistributedDataParallelTest(
         "test requires 2+ accelerators",
     )
     def test_save_load_checkpoint(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         dist.init_process_group(
             "ucc",
             init_method=f"file://{self.rdvz_file}",
@@ -858,14 +867,14 @@ class DistributedDataParallelTest(
     @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
     @requires_ucc()
     def test_sparse_gradients(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         self._test_sparse_gradients()
 
     # TODO: backward pass: input tensor has to be dense
     @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
     @requires_ucc()
     def test_sparse_gradients_grad_is_view(self, device):
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         self._test_sparse_gradients(gradient_as_bucket_view=True)
 
     @requires_ucc()
@@ -874,7 +883,7 @@ class DistributedDataParallelTest(
         This unit test verifies whether the Future object is passed properly.
         The callback function creates a Future object and sets a value to it.
         """
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         # Test on CPU
@@ -917,7 +926,7 @@ class DistributedDataParallelTest(
         This unit test verifies whether the Future object is passed properly using ucc backend.
         The hook callback function creates a Future object and sets a value to it.
         """
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         # Get GPU model with simple_hook registered.
@@ -934,7 +943,7 @@ class DistributedDataParallelTest(
         of hook defined by user. The Python hook must be callable. This test also
         checks whether bucket annotation checked properly if defined.
         """
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         model = DistributedDataParallel(
@@ -962,7 +971,7 @@ class DistributedDataParallelTest(
         checks whether an internal error is thrown if return type is incorrect and user
         hasn't specified any return type annotation.
         """
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         model = DistributedDataParallel(
@@ -1006,7 +1015,7 @@ class DistributedDataParallelTest(
         DDP communication hook can only be registered once. This test validates whether
         the error is thrown properly when register_comm_hook is called more than once.
         """
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         model = DistributedDataParallel(
@@ -1034,7 +1043,7 @@ class DistributedDataParallelTest(
         Runs "test_sparse_gradients" unit test with DDP communication hook. We define a
         simple hook that does allreduce and works with ucc backend for this test.
         """
-        self._dev = torch.device(device, self.rank)
+        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         # Ensure initialized weights and inputs are identical across processes
@@ -1171,7 +1180,7 @@ class UccProcessGroupWithDispatchedCollectivesTests(
         torch.accelerator.device_count() < 1,
         "test requires 1+ accelerators",
     )
-    def test_collectives(self, device):
+    def test_collectives(self):
         # includes reduce, broadcast, all_reduce, all_gather, reduce_scatter, barrier, all_to_all, scatter
         self._test_collectives(backend="ucc")
 
@@ -1181,16 +1190,16 @@ class UccProcessGroupWithDispatchedCollectivesTests(
         torch.accelerator.device_count() < 1,
         "test requires 1+ accelerators",
     )
-    def test_allgather_base(self, device):
-        store = dist.FileStore(self.rdvz_file, self.world_size)
+    def test_allgather_base(self):
+        store = dist.FileStore(self.file_name, self.world_size)
         dist.init_process_group(
             "ucc",
             world_size=self.world_size,
             rank=self.rank,
             store=store,
         )
-        tensor = torch.ones(10, 10, device=torch.device(device))
-        output_tensor = torch.zeros(10, 10, device=torch.device(device))
+        tensor = torch.ones(10, 10, device=torch.device("cuda"))
+        output_tensor = torch.zeros(10, 10, device=torch.device("cuda"))
         dist.all_gather_single(output_tensor, tensor)
         self.assertEqual(output_tensor, tensor)
 
@@ -1209,12 +1218,6 @@ instantiate_device_type_tests(
 
 instantiate_device_type_tests(
     CommTest,
-    globals(),
-    only_for=("cuda",),
-)
-
-instantiate_device_type_tests(
-    UccProcessGroupWithDispatchedCollectivesTests,
     globals(),
     only_for=("cuda",),
 )

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -33,6 +33,7 @@ from torch import nn
 from torch.nn.parallel import DistributedDataParallel
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
+    DEFAULT_WORLD_SIZE,
     MultiProcContinuousTest,
     requires_ucc,
     skip_if_lt_x_gpu,
@@ -118,7 +119,7 @@ def simple_reduce_tests(rank, world_size):
 
 
 class RendezvousEnvTest(TestCase):
-    hw_classification = HardwareClassification.CPU
+    hw_classification = HardwareClassification.GENERIC
 
     @requires_ucc()
     @retry_on_connect_failures
@@ -141,7 +142,7 @@ class RendezvousEnvTest(TestCase):
 
 
 class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
-    hw_classification = HardwareClassification.CPU
+    hw_classification = HardwareClassification.GENERIC
 
     @requires_ucc()
     @retry_on_connect_failures
@@ -151,6 +152,7 @@ class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
 
 class ProcessGroupUCCTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CPU
+    world_size = DEFAULT_WORLD_SIZE
 
     @classmethod
     def backend_str(cls) -> str:
@@ -161,7 +163,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
         return c10d.ProcessGroupUCC(store, self.rank, self.world_size)
 
     @requires_ucc()
-    def test_empty_tensors(self, device):
+    def test_empty_tensors(self):
         pg = self._create_process_group_ucc()
 
         xs = [torch.FloatTensor([])]
@@ -201,7 +203,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
         self.assertEqual(torch.tensor([1.0]), result[0])
 
     @requires_ucc()
-    def test_broadcast_basics(self, device):
+    def test_broadcast_basics(self):
         self._test_broadcast_basics(lambda t: t.clone())
 
     # TODO: test_broadcast_basics_cuda times out locally
@@ -233,7 +235,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
         )
 
     @requires_ucc()
-    def test_allreduce_basics(self, device):
+    def test_allreduce_basics(self):
         self._test_allreduce_basics(lambda t: t.clone())
 
     # TODO: test_allreduce_basics_cuda times out locally
@@ -260,7 +262,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
             self.assertEqual(expected_output, result)
 
     @requires_ucc()
-    def test_allgather_basics(self, device):
+    def test_allgather_basics(self):
         self._test_allgather_basics(lambda t: t.clone())
 
     def _test_reduce_basics(self, fn):
@@ -278,13 +280,13 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
                     self.assertEqual(output, result[0], exact_dtype=False)
 
     @requires_ucc()
-    def test_reduce_basics(self, device):
+    def test_reduce_basics(self):
         self._test_reduce_basics(lambda t: t.clone())
 
     # TODO: test_reduce_basics_cuda times out locally
 
     @requires_ucc()
-    def test_send_recv_all_to_all(self, device):
+    def test_send_recv_all_to_all(self):
         pg = self._create_process_group_ucc()
 
         # Preallocate tensors for input/output
@@ -324,7 +326,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
     # TODO: test_barrier_implies_wait fails with numerical mismatch, will investigate later
     @skip_but_pass_in_sandcastle("fails with numerical mismatch, skip for now")
     @requires_ucc()
-    def test_barrier_implies_wait(self, device):
+    def test_barrier_implies_wait(self):
         pg = self._create_process_group_ucc()
 
         # Kick off allreduce operations
@@ -353,7 +355,7 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
         result = fut.value()
         self.assertEqual(result[0], expected_output)
 
-    def test_reduce_scatter_base_basics(self, device):
+    def test_reduce_scatter_base_basics(self):
         self._test_reduce_scatter_base_basics(lambda t: t.clone())
 
 
@@ -364,10 +366,6 @@ class _DistributedDataParallelTestBase(
     @classmethod
     def backend_str(cls) -> str:
         return "ucc"
-
-    @property
-    def device(self) -> torch.device:
-        return self._dev
 
     def _get_process_group(self):
         store = c10d.FileStore(self.rdvz_file, self.world_size)
@@ -509,26 +507,24 @@ class _DistributedDataParallelTestBase(
 
 class DistributedDataParallelTest(_DistributedDataParallelTestBase):
     hw_classification = HardwareClassification.CPU
+    world_size = DEFAULT_WORLD_SIZE
 
     @requires_ucc()
-    def test_ucc_backend_cpu_module(self, device):
-        self._dev = torch.device(device)
+    def test_ucc_backend_cpu_module(self):
         self._test_ucc_backend([torch.device("cpu")], None)
 
     @requires_ucc()
-    def test_ucc_backend_cpu_module_grad_is_view(self, device):
-        self._dev = torch.device(device)
+    def test_ucc_backend_cpu_module_grad_is_view(self):
         self._test_ucc_backend(
             [torch.device("cpu")], None, gradient_as_bucket_view=True
         )
 
     @requires_ucc()
-    def test_ignored_output(self, device):
+    def test_ignored_output(self):
         """
         Test that the output of a model can be ignored and that there is no
         implicit requirement that `backward` gets called.
         """
-        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         class IgnoredOutput(nn.Module):
@@ -565,13 +561,12 @@ class DistributedDataParallelTest(_DistributedDataParallelTestBase):
             loss.backward()
 
     @requires_ucc()
-    def test_ignored_output_with_unused_parameters(self, device):
+    def test_ignored_output_with_unused_parameters(self):
         """
         Test that the output of a model can be ignored and that there is no
         implicit requirement that `backward` gets called, if not all model
         parameters participated in computing the model output.
         """
-        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         class IgnoredOutputWithUnusedParameters(nn.Module):
@@ -611,23 +606,20 @@ class DistributedDataParallelTest(_DistributedDataParallelTestBase):
 
     @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
     @requires_ucc()
-    def test_sparse_gradients(self, device):
-        self._dev = torch.device(device)
+    def test_sparse_gradients(self):
         self._test_sparse_gradients()
 
     @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
     @requires_ucc()
-    def test_sparse_gradients_grad_is_view(self, device):
-        self._dev = torch.device(device)
+    def test_sparse_gradients_grad_is_view(self):
         self._test_sparse_gradients(gradient_as_bucket_view=True)
 
     @requires_ucc()
-    def test_ddp_comm_hook_future_passing_cpu(self, device):
+    def test_ddp_comm_hook_future_passing_cpu(self):
         """
         This unit test verifies whether the Future object is passed properly.
         The callback function creates a Future object and sets a value to it.
         """
-        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         # Test on CPU
@@ -644,12 +636,11 @@ class DistributedDataParallelTest(_DistributedDataParallelTestBase):
 
     @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
     @requires_ucc()
-    def test_ddp_comm_hook_sparse_gradients(self, device):
+    def test_ddp_comm_hook_sparse_gradients(self):
         """
         Runs "test_sparse_gradients" unit test with DDP communication hook. We define a
         simple hook that does allreduce and works with ucc backend for this test.
         """
-        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         # Ensure initialized weights and inputs are identical across processes
@@ -687,7 +678,6 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
         "test requires 2+ accelerators",
     )
     def test_ucc_backend_1gpu_module_device_ids_integer_list(self, device):
-        self._dev = torch.device(device)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
         devices = [torch.device(torch.device(device).type, i) for i in int_devices]
         self._test_ucc_backend(devices, int_devices)
@@ -698,7 +688,6 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
         "test requires 2+ accelerators",
     )
     def test_ucc_backend_1gpu_module_device_ids_torch_device_list(self, device):
-        self._dev = torch.device(device)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
         devices = [torch.device(torch.device(device).type, i) for i in int_devices]
         self._test_ucc_backend(devices, devices)
@@ -712,7 +701,6 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
         "test requires 4+ accelerators",
     )
     def test_ucc_backend_2gpu_module(self, device):
-        self._dev = torch.device(device)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
         devices = [torch.device(torch.device(device).type, i) for i in int_devices]
         self._test_ucc_backend(devices, None, multi_device=True)
@@ -726,7 +714,6 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
         "test requires 8+ accelerators",
     )
     def test_ucc_backend_4gpu_module(self, device):
-        self._dev = torch.device(device)
         int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
         devices = [torch.device(torch.device(device).type, i) for i in int_devices]
         self._test_ucc_backend(devices, None, multi_device=True)
@@ -738,7 +725,6 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
         "test requires 2+ accelerators",
     )
     def test_global_local_unused_params_grad(self, device):
-        self._dev = torch.device(device)
         self._test_global_local_unused_params_grad()
 
     @skip_but_pass_in_sandcastle("times out")
@@ -748,7 +734,6 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
         "test requires 2+ accelerators",
     )
     def test_global_local_unused_params_grad_with_grad_is_view(self, device):
-        self._dev = torch.device(device)
         self._test_global_local_unused_params_grad(gradient_as_bucket_view=True)
 
     @skip_but_pass_in_sandcastle("times out")
@@ -758,7 +743,6 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
         "test requires 2+ accelerators",
     )
     def test_global_local_unused_params_grad_with_static_graph(self, device):
-        self._dev = torch.device(device)
         self._test_global_local_unused_params_grad(static_graph=True)
 
     @skip_but_pass_in_sandcastle("times out")
@@ -775,7 +759,6 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
         This unit test creates a module that uses all parameters in rank = 0, and
         has unused parameters in other ranks.
         """
-        self._dev = torch.device(device)
 
         class FindUnusedParamModule(nn.Module):
             def __init__(self) -> None:
@@ -829,7 +812,6 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
         "test requires 2+ accelerators",
     )
     def test_save_load_checkpoint(self, device):
-        self._dev = torch.device(device)
         dist.init_process_group(
             "ucc",
             init_method=f"file://{self.rdvz_file}",
@@ -945,7 +927,6 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
         This unit test verifies whether the Future object is passed properly using ucc backend.
         The hook callback function creates a Future object and sets a value to it.
         """
-        self._dev = torch.device(device)
         process_group = self._get_process_group()
 
         # Get GPU model with simple_hook registered.
@@ -959,14 +940,11 @@ class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
 
 class DistributedDataParallelUccCommHookValidationTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CPU
+    world_size = DEFAULT_WORLD_SIZE
 
     @classmethod
     def backend_str(cls) -> str:
         return "ucc"
-
-    @property
-    def device(self) -> torch.device:
-        return torch.device("cpu")
 
     def _get_process_group(self):
         store = c10d.FileStore(self.rdvz_file, self.world_size)
@@ -976,7 +954,7 @@ class DistributedDataParallelUccCommHookValidationTest(MultiProcContinuousTest):
         return c10d.distributed_c10d._get_default_group()
 
     @requires_ucc()
-    def test_ddp_invalid_comm_hook_init(self, device):
+    def test_ddp_invalid_comm_hook_init(self):
         """
         This unit test makes sure that register_comm_hook properly checks the format
         of hook defined by user. The Python hook must be callable. This test also
@@ -1003,7 +981,7 @@ class DistributedDataParallelUccCommHookValidationTest(MultiProcContinuousTest):
             model.register_comm_hook(state=None, hook=comm_hook)
 
     @requires_ucc()
-    def test_ddp_invalid_comm_hook_return_type(self, device):
+    def test_ddp_invalid_comm_hook_return_type(self):
         """
         This test checks whether return annotation checked properly if defined. It also
         checks whether an internal error is thrown if return type is incorrect and user
@@ -1047,7 +1025,7 @@ class DistributedDataParallelUccCommHookValidationTest(MultiProcContinuousTest):
             output.mean().backward()
 
     @requires_ucc()
-    def test_ddp_comm_hook_register_just_once(self, device):
+    def test_ddp_comm_hook_register_just_once(self):
         """
         DDP communication hook can only be registered once. This test validates whether
         the error is thrown properly when register_comm_hook is called more than once.
@@ -1193,27 +1171,9 @@ class UccProcessGroupWithDispatchedCollectivesTests(
 
 
 instantiate_device_type_tests(
-    ProcessGroupUCCTest,
-    globals(),
-    only_for=("cpu",),
-)
-
-instantiate_device_type_tests(
-    DistributedDataParallelTest,
-    globals(),
-    only_for=("cpu",),
-)
-
-instantiate_device_type_tests(
     DistributedDataParallelCUDATest,
     globals(),
     only_for=("cuda",),
-)
-
-instantiate_device_type_tests(
-    DistributedDataParallelUccCommHookValidationTest,
-    globals(),
-    only_for=("cpu",),
 )
 
 instantiate_device_type_tests(

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -156,10 +156,6 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
     def backend_str(cls) -> str:
         return "ucc"
 
-    @property
-    def world_size(self):
-        return 4
-
     def _create_process_group_ucc(self):
         store = c10d.FileStore(self.rdvz_file, self.world_size)
         return c10d.ProcessGroupUCC(store, self.rank, self.world_size)

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -35,6 +35,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_ucc,
+    skip_if_lt_x_gpu,
     verify_ddp_error_logged,
 )
 from torch.testing._internal.common_utils import (
@@ -117,7 +118,7 @@ def simple_reduce_tests(rank, world_size):
 
 
 class RendezvousEnvTest(TestCase):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.CPU
 
     @requires_ucc()
     @retry_on_connect_failures
@@ -140,7 +141,7 @@ class RendezvousEnvTest(TestCase):
 
 
 class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.CPU
 
     @requires_ucc()
     @retry_on_connect_failures
@@ -149,7 +150,7 @@ class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
 
 
 class ProcessGroupUCCTest(MultiProcContinuousTest):
-    hw_classification = HardwareClassification.ACCELERATOR
+    hw_classification = HardwareClassification.CPU
 
     @classmethod
     def backend_str(cls) -> str:
@@ -159,22 +160,12 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
     def world_size(self):
         return 4
 
-    @property
-    def device(self) -> torch.device:
-        return self._dev
-
     def _create_process_group_ucc(self):
         store = c10d.FileStore(self.rdvz_file, self.world_size)
         return c10d.ProcessGroupUCC(store, self.rank, self.world_size)
 
-    def _set_device(self, device: str) -> None:
-        self._dev = (
-            torch.device(device, self.rank) if device != "cpu" else torch.device("cpu")
-        )
-
     @requires_ucc()
     def test_empty_tensors(self, device):
-        self._set_device(device)
         pg = self._create_process_group_ucc()
 
         xs = [torch.FloatTensor([])]
@@ -215,7 +206,6 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
 
     @requires_ucc()
     def test_broadcast_basics(self, device):
-        self._set_device(device)
         self._test_broadcast_basics(lambda t: t.clone())
 
     # TODO: test_broadcast_basics_cuda times out locally
@@ -248,7 +238,6 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
 
     @requires_ucc()
     def test_allreduce_basics(self, device):
-        self._set_device(device)
         self._test_allreduce_basics(lambda t: t.clone())
 
     # TODO: test_allreduce_basics_cuda times out locally
@@ -276,7 +265,6 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
 
     @requires_ucc()
     def test_allgather_basics(self, device):
-        self._set_device(device)
         self._test_allgather_basics(lambda t: t.clone())
 
     def _test_reduce_basics(self, fn):
@@ -295,14 +283,12 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
 
     @requires_ucc()
     def test_reduce_basics(self, device):
-        self._set_device(device)
         self._test_reduce_basics(lambda t: t.clone())
 
     # TODO: test_reduce_basics_cuda times out locally
 
     @requires_ucc()
     def test_send_recv_all_to_all(self, device):
-        self._set_device(device)
         pg = self._create_process_group_ucc()
 
         # Preallocate tensors for input/output
@@ -343,7 +329,6 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle("fails with numerical mismatch, skip for now")
     @requires_ucc()
     def test_barrier_implies_wait(self, device):
-        self._set_device(device)
         pg = self._create_process_group_ucc()
 
         # Kick off allreduce operations
@@ -373,14 +358,12 @@ class ProcessGroupUCCTest(MultiProcContinuousTest):
         self.assertEqual(result[0], expected_output)
 
     def test_reduce_scatter_base_basics(self, device):
-        self._set_device(device)
         self._test_reduce_scatter_base_basics(lambda t: t.clone())
 
 
-class DistributedDataParallelTest(
+class _DistributedDataParallelTestBase(
     test_c10d_common.CommonDistributedDataParallelTest, MultiProcContinuousTest
 ):
-    hw_classification = HardwareClassification.ACCELERATOR
 
     @classmethod
     def backend_str(cls) -> str:
@@ -404,70 +387,6 @@ class DistributedDataParallelTest(
         self._test_ddp_with_process_group(
             process_group, devices, device_ids, multi_device, gradient_as_bucket_view
         )
-
-    @requires_ucc()
-    def test_ucc_backend_cpu_module(self, device):
-        self._dev = torch.device(device)
-        self._test_ucc_backend([torch.device("cpu")], None)
-
-    @requires_ucc()
-    def test_ucc_backend_cpu_module_grad_is_view(self, device):
-        self._dev = torch.device(device)
-        self._test_ucc_backend(
-            [torch.device("cpu")], None, gradient_as_bucket_view=True
-        )
-
-    @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
-    def test_ucc_backend_1gpu_module_device_ids_integer_list(self, device):
-        self._dev = torch.device(device)
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device(device, i) for i in int_devices]
-        self._test_ucc_backend(devices, int_devices)
-
-    @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
-    def test_ucc_backend_1gpu_module_device_ids_torch_device_list(self, device):
-        self._dev = torch.device(device)
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device(device, i) for i in int_devices]
-        self._test_ucc_backend(devices, devices)
-
-    # TODO: test_ucc_backend_2gpu_module and test_ucc_backend_4gpu_module
-    # require broadcast_coalesced which is not supported by ucc currently
-    @skip_but_pass_in_sandcastle(
-        "requires broadcast coalesced, which is not supported by ucc currently"
-    )
-    @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 4,
-        "test requires 4+ accelerators",
-    )
-    def test_ucc_backend_2gpu_module(self, device):
-        self._dev = torch.device(device)
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
-        devices = [torch.device(device, i) for i in int_devices]
-        self._test_ucc_backend(devices, None, multi_device=True)
-
-    @skip_but_pass_in_sandcastle(
-        "requires broadcast coalesced, which is not supported by ucc currently"
-    )
-    @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 8,
-        "test requires 8+ accelerators",
-    )
-    def test_ucc_backend_4gpu_module(self, device):
-        self._dev = torch.device(device)
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
-        devices = [torch.device(device, i) for i in int_devices]
-        self._test_ucc_backend(devices, None, multi_device=True)
 
     def _test_global_local_unused_params_grad(
         self, gradient_as_bucket_view=False, static_graph=False
@@ -535,101 +454,77 @@ class DistributedDataParallelTest(
         )
         run_and_verify_grad(gpu_model)
 
-    # TODO: times out
-    @skip_but_pass_in_sandcastle("times out")
-    @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
-    def test_global_local_unused_params_grad(self, device):
-        self._dev = torch.device(device)
-        self._test_global_local_unused_params_grad()
+    def _run_and_verify_sparse_gradients(self, vanilla_model, ddp_model):
+        mult = 2
+        batch_size = mult * self.world_size
+        criterion = nn.CrossEntropyLoss()
+        input = torch.randint(0, 10, [batch_size, 2])
+        target = torch.randint(0, 10, [batch_size])
 
-    # TODO: times out
-    @skip_but_pass_in_sandcastle("times out")
-    @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
-    def test_global_local_unused_params_grad_with_grad_is_view(self, device):
-        self._dev = torch.device(device)
-        self._test_global_local_unused_params_grad(gradient_as_bucket_view=True)
+        # Run with entire batch against single process version
+        criterion(vanilla_model(input), target).backward()
 
-    # TODO: times out
-    @skip_but_pass_in_sandcastle("times out")
-    @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
-    def test_global_local_unused_params_grad_with_static_graph(self, device):
-        self._dev = torch.device(device)
-        self._test_global_local_unused_params_grad(static_graph=True)
+        # Run with partial batch against multi process version
+        partial_input = input.split(mult)[self.rank]
+        partial_target = target.split(mult)[self.rank]
+        criterion(ddp_model(partial_input), partial_target).backward()
 
-    # TODO: times out
-    @skip_but_pass_in_sandcastle("times out")
-    @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
-    def test_find_unused_parameters_when_unused_parameters_empty(self, device):
-        """
-        An empty unused_parameters array does not imply find_unused_parameters =
-        false. This test makes sure that DDP allreduces unused parameters
-        accordingly where the forward pass in some process uses all parameters.
-        This unit test creates a module that uses all parameters in rank = 0, and
-        has unused parameters in other ranks.
-        """
-        self._dev = torch.device(device)
+        # Check that the gradients are sparse and identical
+        vanilla_parameter = next(vanilla_model.parameters())
+        ddp_parameter = next(ddp_model.parameters())
+        self.assertEqual(
+            vanilla_parameter.grad.coalesce(), ddp_parameter.grad.coalesce()
+        )
 
-        class FindUnusedParamModule(nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.t0 = Task()
-                self.t1 = Task()
-
-            def task_parameters(self):
-                return (self.t0.p, self.t1.p)
-
-            def forward(self, x, rank):
-                return self.t1(self.t0(x)) if rank == 0 else self.t1(x)
-
-        def run_and_verify_grad(model):
-            # Run forward
-            output = model(8, self.rank)
-
-            # The grads of all parameters should be None at this point.
-            [self.assertIsNone(t_p.grad) for t_p in model.module.task_parameters()]
-
-            # Run backward
-            output.mean().backward()
-
-            # Now locally unused parameter should have grad updated on all ranks.
-            [self.assertIsNotNone(t_p.grad) for t_p in model.module.task_parameters()]
-
+    def _test_sparse_gradients(self, gradient_as_bucket_view=False):
         process_group = self._get_process_group()
 
-        # Test on CPU
-        cpu_model = DistributedDataParallel(
-            FindUnusedParamModule().cpu(),
-            process_group=process_group,
-            find_unused_parameters=True,
-        )
-        run_and_verify_grad(cpu_model)
+        # Ensure initialized weights and inputs are identical across processes
+        torch.manual_seed(1337)
 
-        # Test on GPU
+        vanilla_model = SparseGradientModule()
+        ddp_model = DistributedDataParallel(
+            copy.deepcopy(vanilla_model),
+            process_group=process_group,
+            gradient_as_bucket_view=gradient_as_bucket_view,
+        )
+
+        self._run_and_verify_sparse_gradients(vanilla_model, ddp_model)
+
+    def _gpu_model_with_ddp_comm_hook(
+        self, process_group, hook=None, gradient_as_bucket_view=False, state=None
+    ):
         device_id = gpus_for_rank(self.world_size)[self.rank][0]
         dev = torch.device(self.device_type, device_id)
         gpu_model = DistributedDataParallel(
-            FindUnusedParamModule().to(dev),
+            ModuleForDdpCommHook().to(dev),
             device_ids=[device_id],
             process_group=process_group,
-            find_unused_parameters=True,
+            gradient_as_bucket_view=gradient_as_bucket_view,
         )
-        run_and_verify_grad(gpu_model)
+
+        # Register a DDP communication hook if any.
+        if hook is not None:
+            gpu_model.register_comm_hook(state, hook)
+
+        return gpu_model
+
+
+
+class DistributedDataParallelTest(_DistributedDataParallelTestBase):
+    hw_classification = HardwareClassification.CPU
+
+    @requires_ucc()
+    def test_ucc_backend_cpu_module(self, device):
+        self._dev = torch.device(device)
+        self._test_ucc_backend([torch.device("cpu")], None)
+
+    @requires_ucc()
+    def test_ucc_backend_cpu_module_grad_is_view(self, device):
+        self._dev = torch.device(device)
+        self._test_ucc_backend(
+            [torch.device("cpu")], None, gradient_as_bucket_view=True
+        )
 
     @requires_ucc()
     def test_ignored_output(self, device):
@@ -718,27 +613,219 @@ class DistributedDataParallelTest(
             loss = criterion(output, target)
             loss.backward()
 
-    def _run_and_verify_sparse_gradients(self, vanilla_model, ddp_model):
-        mult = 2
-        batch_size = mult * self.world_size
-        criterion = nn.CrossEntropyLoss()
-        input = torch.randint(0, 10, [batch_size, 2])
-        target = torch.randint(0, 10, [batch_size])
+    @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
+    @requires_ucc()
+    def test_sparse_gradients(self, device):
+        self._dev = torch.device(device)
+        self._test_sparse_gradients()
 
-        # Run with entire batch against single process version
-        criterion(vanilla_model(input), target).backward()
+    @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
+    @requires_ucc()
+    def test_sparse_gradients_grad_is_view(self, device):
+        self._dev = torch.device(device)
+        self._test_sparse_gradients(gradient_as_bucket_view=True)
 
-        # Run with partial batch against multi process version
-        partial_input = input.split(mult)[self.rank]
-        partial_target = target.split(mult)[self.rank]
-        criterion(ddp_model(partial_input), partial_target).backward()
+    @requires_ucc()
+    def test_ddp_comm_hook_future_passing_cpu(self, device):
+        """
+        This unit test verifies whether the Future object is passed properly.
+        The callback function creates a Future object and sets a value to it.
+        """
+        self._dev = torch.device(device)
+        process_group = self._get_process_group()
 
-        # Check that the gradients are sparse and identical
-        vanilla_parameter = next(vanilla_model.parameters())
-        ddp_parameter = next(ddp_model.parameters())
-        self.assertEqual(
-            vanilla_parameter.grad.coalesce(), ddp_parameter.grad.coalesce()
+        # Test on CPU
+        cpu_model = DistributedDataParallel(
+            ModuleForDdpCommHook().cpu(), process_group=process_group
         )
+
+        # Register DDP Communication Hook
+        cpu_model.register_comm_hook(None, self._simple_hook)
+
+        # check whether the grads are equal to what then callback returns.
+        # without the comm_hook, result would be 0.25 * torch.ones(2, 2).
+        self._run_and_verify_hook(cpu_model, 8, 2 * torch.ones(2, 2))
+
+    @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
+    @requires_ucc()
+    def test_ddp_comm_hook_sparse_gradients(self, device):
+        """
+        Runs "test_sparse_gradients" unit test with DDP communication hook. We define a
+        simple hook that does allreduce and works with ucc backend for this test.
+        """
+        self._dev = torch.device(device)
+        process_group = self._get_process_group()
+
+        # Ensure initialized weights and inputs are identical across processes
+        torch.manual_seed(1337)
+
+        vanilla_model = SparseGradientModule()
+        ddp_model = DistributedDataParallel(
+            copy.deepcopy(vanilla_model),
+            process_group=process_group,
+        )
+
+        def allreduce_hook_ucc(
+            state: object, bucket: dist.GradBucket
+        ) -> torch.futures.Future[torch.Tensor]:
+            def div_by_world_size(fut):
+                # Divide the result by 2 * world_size.
+                return fut.wait()[0] / self.world_size
+
+            # Prepare allreduced grad bucket tensors by running an async work.
+            fut = process_group.allreduce([bucket.buffer()]).get_future()
+            return fut.then(div_by_world_size)
+
+        ddp_model.register_comm_hook(None, allreduce_hook_ucc)
+
+        self._run_and_verify_sparse_gradients(vanilla_model, ddp_model)
+
+
+
+class DistributedDataParallelCUDATest(_DistributedDataParallelTestBase):
+    hw_classification = HardwareClassification.CUDA
+
+    @requires_ucc()
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_ucc_backend_1gpu_module_device_ids_integer_list(self, device):
+        self._dev = torch.device(device)
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
+        devices = [torch.device(torch.device(device).type, i) for i in int_devices]
+        self._test_ucc_backend(devices, int_devices)
+
+    @requires_ucc()
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_ucc_backend_1gpu_module_device_ids_torch_device_list(self, device):
+        self._dev = torch.device(device)
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
+        devices = [torch.device(torch.device(device).type, i) for i in int_devices]
+        self._test_ucc_backend(devices, devices)
+
+    @skip_but_pass_in_sandcastle(
+        "requires broadcast coalesced, which is not supported by ucc currently"
+    )
+    @requires_ucc()
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 4,
+        "test requires 4+ accelerators",
+    )
+    def test_ucc_backend_2gpu_module(self, device):
+        self._dev = torch.device(device)
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
+        devices = [torch.device(torch.device(device).type, i) for i in int_devices]
+        self._test_ucc_backend(devices, None, multi_device=True)
+
+    @skip_but_pass_in_sandcastle(
+        "requires broadcast coalesced, which is not supported by ucc currently"
+    )
+    @requires_ucc()
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 8,
+        "test requires 8+ accelerators",
+    )
+    def test_ucc_backend_4gpu_module(self, device):
+        self._dev = torch.device(device)
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
+        devices = [torch.device(torch.device(device).type, i) for i in int_devices]
+        self._test_ucc_backend(devices, None, multi_device=True)
+
+    @skip_but_pass_in_sandcastle("times out")
+    @requires_ucc()
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_global_local_unused_params_grad(self, device):
+        self._dev = torch.device(device)
+        self._test_global_local_unused_params_grad()
+
+    @skip_but_pass_in_sandcastle("times out")
+    @requires_ucc()
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_global_local_unused_params_grad_with_grad_is_view(self, device):
+        self._dev = torch.device(device)
+        self._test_global_local_unused_params_grad(gradient_as_bucket_view=True)
+
+    @skip_but_pass_in_sandcastle("times out")
+    @requires_ucc()
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_global_local_unused_params_grad_with_static_graph(self, device):
+        self._dev = torch.device(device)
+        self._test_global_local_unused_params_grad(static_graph=True)
+
+    @skip_but_pass_in_sandcastle("times out")
+    @requires_ucc()
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
+    def test_find_unused_parameters_when_unused_parameters_empty(self, device):
+        """
+        An empty unused_parameters array does not imply find_unused_parameters =
+        false. This test makes sure that DDP allreduces unused parameters
+        accordingly where the forward pass in some process uses all parameters.
+        This unit test creates a module that uses all parameters in rank = 0, and
+        has unused parameters in other ranks.
+        """
+        self._dev = torch.device(device)
+
+        class FindUnusedParamModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.t0 = Task()
+                self.t1 = Task()
+
+            def task_parameters(self):
+                return (self.t0.p, self.t1.p)
+
+            def forward(self, x, rank):
+                return self.t1(self.t0(x)) if rank == 0 else self.t1(x)
+
+        def run_and_verify_grad(model):
+            # Run forward
+            output = model(8, self.rank)
+
+            # The grads of all parameters should be None at this point.
+            [self.assertIsNone(t_p.grad) for t_p in model.module.task_parameters()]
+
+            # Run backward
+            output.mean().backward()
+
+            # Now locally unused parameter should have grad updated on all ranks.
+            [self.assertIsNotNone(t_p.grad) for t_p in model.module.task_parameters()]
+
+        process_group = self._get_process_group()
+
+        # Test on CPU
+        cpu_model = DistributedDataParallel(
+            FindUnusedParamModule().cpu(),
+            process_group=process_group,
+            find_unused_parameters=True,
+        )
+        run_and_verify_grad(cpu_model)
+
+        # Test on GPU
+        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        dev = torch.device(self.device_type, device_id)
+        gpu_model = DistributedDataParallel(
+            FindUnusedParamModule().to(dev),
+            device_ids=[device_id],
+            process_group=process_group,
+            find_unused_parameters=True,
+        )
+        run_and_verify_grad(gpu_model)
 
     @requires_ucc()
     @skip_but_pass_in_sandcastle_if(
@@ -775,7 +862,7 @@ class DistributedDataParallelTest(
                 optimizer.step()
 
         device_id = gpus_for_rank(self.world_size)[self.rank][0]
-        dev = torch.device(device, device_id)
+        dev = torch.device(torch.device(device).type, device_id)
 
         model_withload = TestModel().float().to(dev)
         model_withoutload = TestModel().float().to(dev)
@@ -823,7 +910,8 @@ class DistributedDataParallelTest(
             torch.save(ddp_withload.state_dict(), checkpoint_path)
 
         dist.barrier()
-        map_location = {f"{device}:0": f"{device}:{device_id}"}
+        device_type = torch.device(device).type
+        map_location = {f"{device_type}:0": f"{device_type}:{device_id}"}
         ddp_state_dict = torch.load(checkpoint_path, map_location=map_location)
 
         for model in [ddp_withload, model_withload]:
@@ -851,74 +939,6 @@ class DistributedDataParallelTest(
             self.assertEqual(p_withload, p_withoutload)
             self.assertEqual(p_non_ddp_withload, p_withoutload)
 
-    def _test_sparse_gradients(self, gradient_as_bucket_view=False):
-        process_group = self._get_process_group()
-
-        # Ensure initialized weights and inputs are identical across processes
-        torch.manual_seed(1337)
-
-        vanilla_model = SparseGradientModule()
-        ddp_model = DistributedDataParallel(
-            copy.deepcopy(vanilla_model),
-            process_group=process_group,
-            gradient_as_bucket_view=gradient_as_bucket_view,
-        )
-
-        self._run_and_verify_sparse_gradients(vanilla_model, ddp_model)
-
-    # TODO: backward pass: input tensor has to be dense
-    @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
-    @requires_ucc()
-    def test_sparse_gradients(self, device):
-        self._dev = torch.device(device)
-        self._test_sparse_gradients()
-
-    # TODO: backward pass: input tensor has to be dense
-    @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
-    @requires_ucc()
-    def test_sparse_gradients_grad_is_view(self, device):
-        self._dev = torch.device(device)
-        self._test_sparse_gradients(gradient_as_bucket_view=True)
-
-    @requires_ucc()
-    def test_ddp_comm_hook_future_passing_cpu(self, device):
-        """
-        This unit test verifies whether the Future object is passed properly.
-        The callback function creates a Future object and sets a value to it.
-        """
-        self._dev = torch.device(device)
-        process_group = self._get_process_group()
-
-        # Test on CPU
-        cpu_model = DistributedDataParallel(
-            ModuleForDdpCommHook().cpu(), process_group=process_group
-        )
-
-        # Register DDP Communication Hook
-        cpu_model.register_comm_hook(None, self._simple_hook)
-
-        # check whether the grads are equal to what then callback returns.
-        # without the comm_hook, result would be 0.25 * torch.ones(2, 2).
-        self._run_and_verify_hook(cpu_model, 8, 2 * torch.ones(2, 2))
-
-    def _gpu_model_with_ddp_comm_hook(
-        self, process_group, hook=None, gradient_as_bucket_view=False, state=None
-    ):
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
-        dev = torch.device(self.device_type, device_id)
-        gpu_model = DistributedDataParallel(
-            ModuleForDdpCommHook().to(dev),
-            device_ids=[device_id],
-            process_group=process_group,
-            gradient_as_bucket_view=gradient_as_bucket_view,
-        )
-
-        # Register a DDP communication hook if any.
-        if hook is not None:
-            gpu_model.register_comm_hook(state, hook)
-
-        return gpu_model
-
     @requires_ucc()
     @skip_but_pass_in_sandcastle_if(
         torch.accelerator.device_count() < 2,
@@ -939,40 +959,6 @@ class DistributedDataParallelTest(
         # without the comm_hook, result would be 0.25 * torch.ones(2, 2).
         self._run_and_verify_hook(gpu_model, 8, 2 * torch.ones(2, 2))
 
-    # TODO: backward pass: input tensor must be dense
-    @skip_but_pass_in_sandcastle("backward pass: input tensor has to be dense")
-    @requires_ucc()
-    def test_ddp_comm_hook_sparse_gradients(self, device):
-        """
-        Runs "test_sparse_gradients" unit test with DDP communication hook. We define a
-        simple hook that does allreduce and works with ucc backend for this test.
-        """
-        self._dev = torch.device(device)
-        process_group = self._get_process_group()
-
-        # Ensure initialized weights and inputs are identical across processes
-        torch.manual_seed(1337)
-
-        vanilla_model = SparseGradientModule()
-        ddp_model = DistributedDataParallel(
-            copy.deepcopy(vanilla_model),
-            process_group=process_group,
-        )
-
-        def allreduce_hook_ucc(
-            state: object, bucket: dist.GradBucket
-        ) -> torch.futures.Future[torch.Tensor]:
-            def div_by_world_size(fut):
-                # Divide the result by 2 * world_size.
-                return fut.wait()[0] / self.world_size
-
-            # Prepare allreduced grad bucket tensors by running an async work.
-            fut = process_group.allreduce([bucket.buffer()]).get_future()
-            return fut.then(div_by_world_size)
-
-        ddp_model.register_comm_hook(None, allreduce_hook_ucc)
-
-        self._run_and_verify_sparse_gradients(vanilla_model, ddp_model)
 
 
 class DistributedDataParallelUccCommHookValidationTest(MultiProcContinuousTest):
@@ -994,7 +980,7 @@ class DistributedDataParallelUccCommHookValidationTest(MultiProcContinuousTest):
         return c10d.distributed_c10d._get_default_group()
 
     @requires_ucc()
-    def test_ddp_invalid_comm_hook_init(self):
+    def test_ddp_invalid_comm_hook_init(self, device):
         """
         This unit test makes sure that register_comm_hook properly checks the format
         of hook defined by user. The Python hook must be callable. This test also
@@ -1021,7 +1007,7 @@ class DistributedDataParallelUccCommHookValidationTest(MultiProcContinuousTest):
             model.register_comm_hook(state=None, hook=comm_hook)
 
     @requires_ucc()
-    def test_ddp_invalid_comm_hook_return_type(self):
+    def test_ddp_invalid_comm_hook_return_type(self, device):
         """
         This test checks whether return annotation checked properly if defined. It also
         checks whether an internal error is thrown if return type is incorrect and user
@@ -1065,7 +1051,7 @@ class DistributedDataParallelUccCommHookValidationTest(MultiProcContinuousTest):
             output.mean().backward()
 
     @requires_ucc()
-    def test_ddp_comm_hook_register_just_once(self):
+    def test_ddp_comm_hook_register_just_once(self, device):
         """
         DDP communication hook can only be registered once. This test validates whether
         the error is thrown properly when register_comm_hook is called more than once.
@@ -1098,16 +1084,8 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcContinuousTest):
         return "ucc"
 
     @property
-    def device(self) -> None:
+    def device(self) -> str:
         return "cpu"
-
-    @property
-    def _dev(self) -> torch.device:
-        return torch.device("cpu")
-
-    @_dev.setter
-    def _dev(self, value):
-        pass
 
     @requires_ucc()
     @skip_but_pass_in_sandcastle_if(
@@ -1191,25 +1169,19 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcContinuousTest):
 class UccProcessGroupWithDispatchedCollectivesTests(
     test_c10d_common.ProcessGroupWithDispatchedCollectivesTests
 ):
-    hw_classification = HardwareClassification.ACCELERATOR
+    hw_classification = HardwareClassification.CPU
 
     @skip_but_pass_in_sandcastle("Fails on M60")
     @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 1,
-        "test requires 1+ accelerators",
-    )
-    def test_collectives(self, device):
+    @skip_if_lt_x_gpu(1)
+    def test_collectives(self):
         # includes reduce, broadcast, all_reduce, all_gather, reduce_scatter, barrier, all_to_all, scatter
         self._test_collectives(backend="ucc")
 
     @skip_but_pass_in_sandcastle("Fails on M60")
     @requires_ucc()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 1,
-        "test requires 1+ accelerators",
-    )
-    def test_allgather_base(self, device):
+    @skip_if_lt_x_gpu(1)
+    def test_allgather_base(self):
         store = dist.FileStore(self.file_name, self.world_size)
         dist.init_process_group(
             "ucc",
@@ -1217,9 +1189,9 @@ class UccProcessGroupWithDispatchedCollectivesTests(
             rank=self.rank,
             store=store,
         )
-        dev = torch.device(device)
-        tensor = torch.ones(10, 10, device=dev)
-        output_tensor = torch.zeros(10, 10, device=dev)
+        device = "cpu"
+        tensor = torch.ones(10, 10, device=torch.device(device))
+        output_tensor = torch.zeros(10, 10, device=torch.device(device))
         dist.all_gather_single(output_tensor, tensor)
         self.assertEqual(output_tensor, tensor)
 
@@ -1227,21 +1199,29 @@ class UccProcessGroupWithDispatchedCollectivesTests(
 instantiate_device_type_tests(
     ProcessGroupUCCTest,
     globals(),
+    only_for=("cpu",),
 )
 
 instantiate_device_type_tests(
     DistributedDataParallelTest,
     globals(),
+    only_for=("cpu",),
+)
+
+instantiate_device_type_tests(
+    DistributedDataParallelCUDATest,
+    globals(),
+    only_for=("cuda",),
+)
+
+instantiate_device_type_tests(
+    DistributedDataParallelUccCommHookValidationTest,
+    globals(),
+    only_for=("cpu",),
 )
 
 instantiate_device_type_tests(
     CommTest,
-    globals(),
-    except_for=("cpu",),
-)
-
-instantiate_device_type_tests(
-    UccProcessGroupWithDispatchedCollectivesTests,
     globals(),
     except_for=("cpu",),
 )


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to the five
device-independent test classes in
`test/distributed/test_c10d_ucc.py`, per review feedback: these classes are
not instantiated and their test methods take no device parameter, so a CPU
label would violate the hw_classification structural contract.

## Changes

- `RendezvousEnvTest` / `TimeoutTest` / `ProcessGroupUCCTest` / `CommTest` /
  `UccProcessGroupWithDispatchedCollectivesTests` → GENERIC
- Gate `ProcessGroupUCCTest.test_allgather_basics` with `@requires_ucc()`
- Switch `test_allgather_base` to a CPU tensor so the class stays device-free

## Not changed

- The `DistributedDataParallelTest` restructuring is split into two follow-up
  PRs (parts 2 and 3) to keep each PR reviewable.

## Test plan

- `python test/distributed/test_c10d_ucc.py` (requires a UCC-enabled build)