### PR TITLE
[xpu] Fix the typo in test_xpu.py

### DIFF
--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -3274,13 +3274,12 @@ class TestXpuOptims(TestCase):
         [
             optim
             for optim in optim_db
-            if "foreach" in optim.supported_impls and "cuda" in optim.supports_fused_on
+            if "foreach" in optim.supported_impls and "xpu" in optim.supports_fused_on
         ],
         dtypes=[torch.float32],
     )
     def test_graph_grad_scaling(self, dtype, optim_info, foreach, fused):
-        device = "xpu"
-        torch.cuda.empty_cache()
+        torch.xpu.empty_cache()
 
         scaler = torch.amp.GradScaler(device="xpu", init_scale=4.0)
         g = torch.xpu.XPUGraph()
@@ -3288,7 +3287,6 @@ class TestXpuOptims(TestCase):
         weight = torch.ones((100,), device="xpu", requires_grad=True)
         opt = optim_info.optim_cls([weight], lr=0.1, foreach=foreach, fused=fused)
         static_input = torch.ones_like(weight)
-        static_grad = torch.ones_like(weight)
 
         # warmup
         s = torch.xpu.Stream()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192173

# Motivation
As title.
