### PR TITLE
[XPU][Refactor] Refactor test decoupling and device-agnostic in test_serialization.py and test_after_aot.py

### DIFF
--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -23,8 +23,11 @@ from torch._dynamo.repro.after_aot import (
 )
 from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import IS_FBCODE, TEST_CUDA
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
+from torch.testing._internal.common_utils import HardwareClassification, IS_FBCODE
 from torch.utils._traceback import report_compile_source_on_error
 from torch.utils._triton import has_triton
 
@@ -329,44 +332,6 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
 
             self.assertIn("import triton.language.extra.libdevice as libdevice", repro)
 
-    @unittest.skipIf(not TEST_CUDA or not has_triton(), "requires CUDA and Triton")
-    def test_after_aot_minifier_emits_extra_triton_imports_integration(self):
-        extra_import_kernel = self.import_triton_extra_import_kernel()
-        from torch._dynamo.debug_utils import minifier_dir
-        from torch._inductor.codegen.simd import SIMDScheduling
-
-        @torch.compile  # noqa: UNSPECIFIED_BACKEND
-        def fn(x):
-            extra_import_kernel.triton_kernel_with_extra_import[(1,)](x, BLOCK=16)
-            return x + 1
-
-        def fail_codegen_node(*args, **kwargs):
-            raise RuntimeError("intentional triton codegen failure")
-
-        with tempfile.TemporaryDirectory() as d:
-            repro_path = None
-            with (
-                torch._dynamo.config.patch(
-                    repro_after="aot",
-                    repro_level=2,
-                    debug_dir_root=d,
-                ),
-                patch.object(
-                    SIMDScheduling,
-                    "codegen_node",
-                    side_effect=fail_codegen_node,
-                ),
-            ):
-                with self.assertRaises(RuntimeError):
-                    fn(torch.randn(16, device="cuda"))
-                repro_path = os.path.join(minifier_dir(), "minifier_launcher.py")
-
-            self.assertIsNotNone(repro_path)
-            with open(repro_path) as f:
-                repro = f.read()
-
-        self.assertIn("import triton.language.extra.libdevice as libdevice", repro)
-
     def test_repro_run_accuracy_does_not_reuse_compiled_graph(self):
         class Repro(torch.nn.Module):
             def forward(self, arg0, arg1, arg2):
@@ -384,41 +349,6 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
             accuracy="accuracy", save_dir=None, tracing_mode="real"
         )
         repro_run(options, Repro(), load_args)
-
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
-    def test_dump_generator(self):
-        gen = torch.cuda.default_generators[0].clone_state()
-        writer = InputWriter(None)
-        writer.generator("fwd_rng_state_0", gen)
-        self.assertExpectedInline(
-            "\n".join(writer._lines),
-            """reader.generator('cuda', 0)  # fwd_rng_state_0""",
-        )
-        reader = InputReader(None)
-        env = {"reader": reader, "torch": torch}
-        exec("\n".join(writer._lines), env)
-        self.assertIsInstance(reader.args[0], torch._C.Generator)
-        self.assertEqual(reader.args[0].device, torch.device("cuda", 0))
-
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
-    def test_graphsafe_rng_repro(self):
-        """save_graph_repro should emit reader.generator() for Generator args."""
-        gen = torch.cuda.default_generators[0].clone_state()
-
-        def f(x):
-            return (x * x,)
-
-        args = [torch.randn(4, device="cuda"), gen]
-        gm = make_fx(f)(args[0])
-        with gm.graph.inserting_before(next(iter(gm.graph.nodes))):
-            gm.graph.placeholder("fwd_rng_state_0")
-        gm.recompile()
-
-        buf = io.StringIO()
-        save_graph_repro(buf, gm, args, "inductor_accuracy")
-        r = buf.getvalue()
-        self.assertIn("reader.generator('cuda', 0)", r)
-        self.assertNotIn("reader.unsupported(", r)
 
     @unittest.skipIf(not torch.distributed.is_available(), "requires distributed")
     def test_extract_distributed_info_skips_non_string_group_name(self):
@@ -661,6 +591,86 @@ class TupleOut(torch.nn.Module):
         return (x,)
 
 
+class TestAfterAotAccelerator(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    @unittest.skipIf(not has_triton(), "requires Triton")
+    def test_after_aot_minifier_emits_extra_triton_imports_integration(self, device):
+        extra_import_kernel = TestAfterAot.import_triton_extra_import_kernel(self)
+        from torch._dynamo.debug_utils import minifier_dir
+        from torch._inductor.codegen.simd import SIMDScheduling
+
+        @torch.compile  # noqa: UNSPECIFIED_BACKEND
+        def fn(x):
+            extra_import_kernel.triton_kernel_with_extra_import[(1,)](x, BLOCK=16)
+            return x + 1
+
+        def fail_codegen_node(*args, **kwargs):
+            raise RuntimeError("intentional triton codegen failure")
+
+        with tempfile.TemporaryDirectory() as d:
+            repro_path = None
+            with (
+                torch._dynamo.config.patch(
+                    repro_after="aot",
+                    repro_level=2,
+                    debug_dir_root=d,
+                ),
+                patch.object(
+                    SIMDScheduling,
+                    "codegen_node",
+                    side_effect=fail_codegen_node,
+                ),
+            ):
+                with self.assertRaises(RuntimeError):
+                    fn(torch.randn(16, device=device))
+                repro_path = os.path.join(minifier_dir(), "minifier_launcher.py")
+
+            self.assertIsNotNone(repro_path)
+            with open(repro_path) as f:
+                repro = f.read()
+
+        self.assertIn("import triton.language.extra.libdevice as libdevice", repro)
+
+    @onlyAccelerator
+    def test_dump_generator(self, device):
+        device_type = torch.device(device).type
+        gen = torch.get_device_module(device_type).default_generators[0].clone_state()
+        writer = InputWriter(None)
+        writer.generator("fwd_rng_state_0", gen)
+        self.assertExpectedInline(
+            "\n".join(writer._lines),
+            f"reader.generator('{device_type}', 0)  # fwd_rng_state_0",
+        )
+        reader = InputReader(None)
+        env = {"reader": reader, "torch": torch}
+        exec("\n".join(writer._lines), env)
+        self.assertIsInstance(reader.args[0], torch._C.Generator)
+        self.assertEqual(reader.args[0].device, torch.device(device_type, 0))
+
+    @onlyAccelerator
+    def test_graphsafe_rng_repro(self, device):
+        """save_graph_repro should emit reader.generator() for Generator args."""
+        device_type = torch.device(device).type
+        gen = torch.get_device_module(device_type).default_generators[0].clone_state()
+
+        def f(x):
+            return (x * x,)
+
+        args = [torch.randn(4, device=device), gen]
+        gm = make_fx(f)(args[0])
+        with gm.graph.inserting_before(next(iter(gm.graph.nodes))):
+            gm.graph.placeholder("fwd_rng_state_0")
+        gm.recompile()
+
+        buf = io.StringIO()
+        save_graph_repro(buf, gm, args, "inductor_accuracy")
+        r = buf.getvalue()
+        self.assertIn(f"reader.generator('{device_type}', 0)", r)
+        self.assertNotIn("reader.unsupported(", r)
+
+
 class TestWrapCompilerDebugSync(torch._dynamo.test_case.TestCase):
     def test_synchronize_called_for_accelerator_tensor(self, device):
         if torch.device(device).type == "cpu":
@@ -750,6 +760,9 @@ class TestWrapCompilerDebugSync(torch._dynamo.test_case.TestCase):
 
 
 instantiate_device_type_tests(TestWrapCompilerDebugSync, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestAfterAotAccelerator, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -49,6 +49,7 @@ from torch.testing._internal.common_utils import (
     AlwaysWarnTypedStorageRemoval,
     BytesIOContext,
     download_file,
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_CI,
     IS_FBCODE,
@@ -4844,7 +4845,9 @@ class TestSerialization(TestCase, SerializationMixin):
             return super().run(*args, **kwargs)
 
 
-class TestSerializationDeviceType(TestCase):
+class TestSerializationAccelerator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @onlyAccelerator
     def test_serialization_map_location(self, device):
         test_file_path = download_file('https://download.pytorch.org/test_data/gpu_tensors.pt')
@@ -5054,6 +5057,24 @@ class TestSerializationDeviceType(TestCase):
             ):
                 with skip_data(), BytesIOContext() as f:
                     torch.save(ft, f)
+
+    @onlyAccelerator
+    def test_tensor_subclass_map_location(self, device):
+        t = TwoTensor(torch.randn(2, 3), torch.randn(2, 3))
+        sd = {'t': t}
+
+        with TemporaryFileName() as f:
+            torch.save(sd, f)
+            with safe_globals([TwoTensor]):
+                sd_loaded = torch.load(f, map_location=torch.device(device))
+                self.assertTrue(sd_loaded['t'].device == torch.device(device))
+                self.assertTrue(sd_loaded['t'].a.device == torch.device(device))
+                self.assertTrue(sd_loaded['t'].b.device == torch.device(device))
+                # make sure map_location is not propagated over multiple torch.load calls
+                sd_loaded = torch.load(f)
+                self.assertTrue(sd_loaded['t'].device == torch.device('cpu'))
+                self.assertTrue(sd_loaded['t'].a.device == torch.device('cpu'))
+                self.assertTrue(sd_loaded['t'].b.device == torch.device('cpu'))
 
     @onlyAccelerator
     @skipMPSIf(True, "pin memory allocator is not registered on MPS")
@@ -5293,24 +5314,6 @@ class TestSubclassSerialization(TestCase):
             l_s = torch.load(f, weights_only=True)
             self.assertEqual(l_s, s)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "map_location loads to cuda")
-    def test_tensor_subclass_map_location(self):
-        t = TwoTensor(torch.randn(2, 3), torch.randn(2, 3))
-        sd = {'t': t}
-
-        with TemporaryFileName() as f:
-            torch.save(sd, f)
-            with safe_globals([TwoTensor]):
-                sd_loaded = torch.load(f, map_location=torch.device('cuda:0'))
-                self.assertTrue(sd_loaded['t'].device == torch.device('cuda:0'))
-                self.assertTrue(sd_loaded['t'].a.device == torch.device('cuda:0'))
-                self.assertTrue(sd_loaded['t'].b.device == torch.device('cuda:0'))
-                # make sure map_location is not propagated over multiple torch.load calls
-                sd_loaded = torch.load(f)
-                self.assertTrue(sd_loaded['t'].device == torch.device('cpu'))
-                self.assertTrue(sd_loaded['t'].a.device == torch.device('cpu'))
-                self.assertTrue(sd_loaded['t'].b.device == torch.device('cpu'))
-
     @parametrize("opcode,opcode_name", [
         (b's', "SETITEM"),
         (b'u', "SETITEMS"),
@@ -5460,8 +5463,8 @@ class TestSubclassSerialization(TestCase):
             torch.load(modified_buffer, weights_only=True)
 
 
-instantiate_device_type_tests(TestBothSerialization, globals())
-instantiate_device_type_tests(TestSerializationDeviceType, globals())
+instantiate_device_type_tests(TestBothSerialization, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestSerializationAccelerator, globals(), allow_xpu=True)
 instantiate_parametrized_tests(TestSubclassSerialization)
 instantiate_parametrized_tests(TestOldSerialization)
 instantiate_parametrized_tests(TestSerialization)


### PR DESCRIPTION
Refactor test/test_serialization.py test/dynamo/test_after_aot.py to be device-agnostic

- move GPU-only tests to class `TestAfterAotAccelerator` in test/dynamo/test_after_aot.py
- move `test_tensor_subclass_map_location` to GPU-only class
- enable XPU for `TestAfterAotAccelerator`, `TestBothSerialization`, `TestSerializationAccelerator`
- add hardware classification

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98